### PR TITLE
refactor(design-system): bulk SPEC §3 alignment across all prod surfaces (Stage 3-7+)

### DIFF
--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -14,11 +14,11 @@ const hoveredNodeId = signal<string | null>(null)
 function nodeColor(kind: string, status: string): string {
   if (status === 'offline' || status === 'retired') return 'var(--slate-500)'
   switch (kind) {
-    case 'keeper': return 'var(--ok)'
+    case 'keeper': return 'var(--color-status-ok)'
     case 'agent': return 'var(--cyan)'
-    case 'task': return 'var(--warn)'
+    case 'task': return 'var(--color-status-warn)'
     case 'decision': return 'var(--purple)'
-    case 'operation': return 'var(--ok)'
+    case 'operation': return 'var(--color-status-ok)'
     case 'debate': return '#fb923c'
     case 'post': return '#f472b6'
     default: return 'var(--slate-400)'
@@ -102,7 +102,7 @@ export function GraphView({ data }: GraphViewProps) {
           border: (n.status === 'offline' || n.status === 'retired') ? 'var(--slate-600)' : color,
           highlight: {
             background: color,
-            border: 'var(--warn)'
+            border: 'var(--color-status-warn)'
           },
           hover: {
             background: color,
@@ -242,19 +242,19 @@ export function GraphView({ data }: GraphViewProps) {
   }
 
   return html`
-    <div class="relative w-full my-3 rounded border border-[var(--card-border)] bg-[#0f1117]">
+    <div class="relative w-full my-3 rounded border border-[var(--color-border-default)] bg-[#0f1117]">
       <div ref=${containerRef} class="w-full h-90" role="img" aria-label="에이전트 활동 네트워크 그래프"></div>
     </div>
     <div class="flex flex-wrap gap-x-4 gap-y-1 mt-1 px-1">
       ${[
-        { label: '키퍼', color: 'var(--ok)' },
+        { label: '키퍼', color: 'var(--color-status-ok)' },
         { label: '에이전트', color: 'var(--cyan)' },
-        { label: '작업', color: 'var(--warn)' },
+        { label: '작업', color: 'var(--color-status-warn)' },
         { label: '결정', color: 'var(--purple)' },
-        { label: '작전', color: 'var(--ok)' },
+        { label: '작전', color: 'var(--color-status-ok)' },
         { label: '게시글', color: '#f472b6' },
       ].map(({ label, color }) => html`
-        <div class="flex items-center gap-1.5 text-2xs text-[var(--text-muted)]" key=${label}>
+        <div class="flex items-center gap-1.5 text-2xs text-[var(--color-fg-muted)]" key=${label}>
           <span class="w-2.5 h-2.5 rounded-full inline-block" style="background:${color}"></span>
           ${label}
         </div>
@@ -262,36 +262,36 @@ export function GraphView({ data }: GraphViewProps) {
     </div>
 
     ${selectedNode ? html`
-      <div class="rounded border border-[var(--card-border)] bg-[var(--card)] p-4 mt-2">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--card)] p-4 mt-2">
         <div class="flex items-center gap-3 mb-3">
           <strong class="text-lg text-[var(--text-near-white)]">${selectedNode.label}</strong>
           <span class="py-0.5 px-2 bg-[var(--slate-gray-15)] text-2xs text-[var(--text-slate)] rounded">${kindLabel(selectedNode.kind)}</span>
-          <span class="py-0.5 px-2 rounded text-2xs ${selectedNode.status === 'active' || selectedNode.status === 'done' ? 'text-[var(--ok)] bg-[var(--ok-10)]' : selectedNode.status === 'offline' || selectedNode.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--text-slate-light)] bg-[var(--slate-gray-10)]'}">${statusLabel(selectedNode.status)}</span>
-          <button type="button" class="ml-auto text-[var(--text-muted)] hover:text-[var(--text-slate-light)] text-sm cursor-pointer bg-transparent border-none" onClick=${() => { selectedNodeId.value = null }}>닫기</button>
+          <span class="py-0.5 px-2 rounded text-2xs ${selectedNode.status === 'active' || selectedNode.status === 'done' ? 'text-[var(--color-status-ok)] bg-[var(--ok-10)]' : selectedNode.status === 'offline' || selectedNode.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--text-slate-light)] bg-[var(--slate-gray-10)]'}">${statusLabel(selectedNode.status)}</span>
+          <button type="button" class="ml-auto text-[var(--color-fg-muted)] hover:text-[var(--text-slate-light)] text-sm cursor-pointer bg-transparent border-none" onClick=${() => { selectedNodeId.value = null }}>닫기</button>
         </div>
         <div class="grid grid-cols-3 gap-3 mb-3">
           <div class="text-center">
-            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-1">중요도</div>
+            <div class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-1">중요도</div>
             <div class="text-xl font-bold text-[var(--text-near-white)] tabular-nums">${(selectedNode.semantic_weight ?? selectedNode.weight).toFixed(1)}</div>
           </div>
           <div class="text-center">
-            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-1">빈도</div>
+            <div class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-1">빈도</div>
             <div class="text-xl font-bold text-[var(--text-slate-light)] tabular-nums">${selectedNode.weight}</div>
           </div>
           <div class="text-center">
-            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-1">연결</div>
+            <div class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-1">연결</div>
             <div class="text-xl font-bold text-[var(--text-slate-light)] tabular-nums">${connectedEdges.length}</div>
           </div>
         </div>
         ${connectedEdges.length > 0 ? html`
           <div class="border-t border-[var(--slate-gray-10)] pt-3">
-            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-1 mb-2">연결된 관계</div>
+            <div class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-1 mb-2">연결된 관계</div>
             <div class="flex flex-col gap-1.5 max-h-40 overflow-y-auto">
               ${connectedEdges.slice(0, 20).map(({ edge, otherLabel }) => html`
                 <div class="flex items-center gap-2 text-sm py-1 px-2 rounded bg-[rgba(15,23,42,0.4)]" key=${edge.id ?? `${edge.source}-${edge.kind}-${edge.target}`}>
                   <span class="text-[var(--text-slate-light)]">${otherLabel}</span>
-                  <span class="text-2xs text-[var(--text-muted)]">${edgeKindLabel(edge.kind)}</span>
-                  ${edge.active ? html`<span class="w-1.5 h-1.5 rounded-full bg-[var(--ok)]"></span>` : null}
+                  <span class="text-2xs text-[var(--color-fg-muted)]">${edgeKindLabel(edge.kind)}</span>
+                  ${edge.active ? html`<span class="w-1.5 h-1.5 rounded-full bg-[var(--color-status-ok)]"></span>` : null}
                 </div>
               `)}
             </div>

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -94,9 +94,9 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
 
   function statCard(label: string, value: number, series: number[], color: string, highlight = false) {
     return html`
-      <div class="rounded border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
-        <div class="text-3xs text-[var(--text-muted)] tracking-1 uppercase font-medium">${label}</div>
-        <div class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums ${highlight ? 'text-[var(--ok)]' : ''}">${value}</div>
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--card)] py-[15px] px-3.5">
+        <div class="text-3xs text-[var(--color-fg-muted)] tracking-1 uppercase font-medium">${label}</div>
+        <div class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums ${highlight ? 'text-[var(--color-status-ok)]' : ''}">${value}</div>
         ${series.length >= 2 ? html`<div class="mt-2"><${Sparkline} values=${series} color=${color} /></div>` : null}
       </div>
     `
@@ -106,8 +106,8 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
     <div class="stats-grid grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-3 mb-4">
       ${statCard('노드', s.node_count ?? 0, [], 'var(--slate-400)')}
       ${statCard('엣지', s.edge_count ?? 0, [], 'var(--slate-500)')}
-      ${statCard('활성 에이전트', s.active_agents ?? 0, agSeries, 'var(--ok)', true)}
-      ${statCard('작업', s.task_count ?? 0, tdSeries, 'var(--warn)')}
+      ${statCard('활성 에이전트', s.active_agents ?? 0, agSeries, 'var(--color-status-ok)', true)}
+      ${statCard('작업', s.task_count ?? 0, tdSeries, 'var(--color-status-warn)')}
       ${statCard('이벤트', s.event_count ?? 0, evSeries, 'var(--purple)')}
     </div>
   `
@@ -116,19 +116,19 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
 function actionCategoryClass(group: ActionTimelineGroup): string {
   switch (group.category) {
     case 'task':
-      return 'border-[var(--warn)]/35 bg-[var(--warn)]/10 text-[var(--warn)]'
+      return 'border-[var(--color-status-warn)]/35 bg-[var(--color-status-warn)]/10 text-[var(--color-status-warn)]'
     case 'session':
-      return 'border-[var(--ok)]/35 bg-[var(--ok)]/10 text-[var(--ok-20)]'
+      return 'border-[var(--color-status-ok)]/35 bg-[var(--color-status-ok)]/10 text-[var(--ok-20)]'
     case 'message':
       return 'border-[var(--cyan)]/35 bg-[var(--cyan)]/10 text-[var(--cyan)]'
     case 'board':
       return 'border-[#c084fc]/35 bg-[#c084fc]/10 text-[var(--purple)]'
     case 'governance':
-      return 'border-[var(--rose-light)]/35 bg-[var(--bad)]/10 text-[var(--bad-light)]'
+      return 'border-[var(--rose-light)]/35 bg-[var(--color-status-err)]/10 text-[var(--bad-light)]'
     case 'lifecycle':
-      return 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)]'
+      return 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)]'
     default:
-      return 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-muted)]'
+      return 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-muted)]'
   }
 }
 
@@ -172,10 +172,10 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="flex flex-col gap-3 rounded border border-[var(--card-border)] bg-[var(--card)]/50 p-4">
+      <div class="flex flex-col gap-3 rounded border border-[var(--color-border-default)] bg-[var(--card)]/50 p-4">
         <div class="flex flex-col gap-1">
-          <div class="text-base font-semibold text-[var(--text-strong)]">원본 실행 이벤트를 최근 액션 단위로 묶어 보여줍니다.</div>
-          <div class="text-xs text-[var(--text-muted)]">
+          <div class="text-base font-semibold text-[var(--color-fg-secondary)]">원본 실행 이벤트를 최근 액션 단위로 묶어 보여줍니다.</div>
+          <div class="text-xs text-[var(--color-fg-muted)]">
             액션 ${isFiltering ? `${filteredGroups.length}/${categoryFilteredGroups.length}` : filteredGroups.length}개 · 원본 타임라인 ${data.timeline.length}건 · 분석 범위 ${data.stats.event_count ?? data.timeline.length}건
             ${lifecycleHiddenCount > 0 ? ` · 생명주기 ${lifecycleHiddenCount}건 숨김` : ''}
           </div>
@@ -188,13 +188,13 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
             placeholder="액션 필터 (title, actor, subject...)"
             aria-label="액션 타임라인 필터"
             onInput=${(e: Event) => { actionQuery.value = (e.target as HTMLInputElement).value }}
-            class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
           />
           <button
             type="button"
             class="inline-flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-2xs transition-all duration-150 ${showLifecycle.value
-              ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--text-strong)]'
-              : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)]'}"
+              ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--color-fg-secondary)]'
+              : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)]'}"
             onClick=${() => { showLifecycle.value = !showLifecycle.value }}
           >
             생명주기 ${showLifecycle.value ? '표시 중' : '숨김'}
@@ -205,48 +205,48 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
 
       ${filteredGroups.length === 0
         ? (isFiltering && categoryFilteredGroups.length > 0
-          ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${categoryFilteredGroups.length} items)</div>`
+          ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${categoryFilteredGroups.length} items)</div>`
           : html`<${EmptyState} message="선택한 필터에 맞는 액션 그룹이 없습니다." compact />`)
         : filteredGroups.map(group => {
             const expanded = expandedActionGroups.value.has(group.id)
             return html`
-              <div class="rounded border border-[var(--card-border)] bg-[var(--card)]/55 p-4 shadow-sm shadow-black/8" key=${group.id}>
+              <div class="rounded border border-[var(--color-border-default)] bg-[var(--card)]/55 p-4 shadow-sm shadow-black/8" key=${group.id}>
                 <div class="flex flex-wrap items-start justify-between gap-3">
                   <div class="min-w-0 flex-1">
                     <div class="flex flex-wrap items-center gap-2">
                       <span class="inline-flex items-center rounded-sm border px-2 py-0.5 text-3xs font-semibold uppercase tracking-1 ${actionCategoryClass(group)}">
                         ${categoryLabel(group.category)}
                       </span>
-                      ${group.actor ? html`<span class="text-2xs font-medium text-[var(--text-body)]">${group.actor}</span>` : null}
-                      ${group.subjectId ? html`<span class="text-2xs text-[var(--text-muted)] font-mono">${group.subjectId}</span>` : null}
+                      ${group.actor ? html`<span class="text-2xs font-medium text-[var(--color-fg-primary)]">${group.actor}</span>` : null}
+                      ${group.subjectId ? html`<span class="text-2xs text-[var(--color-fg-muted)] font-mono">${group.subjectId}</span>` : null}
                     </div>
-                    <div class="mt-2 text-md font-semibold text-[var(--text-strong)]">${group.title}</div>
-                    <div class="mt-1 text-sm leading-loose text-[var(--text-body)]">${group.summary}</div>
+                    <div class="mt-2 text-md font-semibold text-[var(--color-fg-secondary)]">${group.title}</div>
+                    <div class="mt-1 text-sm leading-loose text-[var(--color-fg-primary)]">${group.summary}</div>
                   </div>
-                  <div class="flex shrink-0 flex-col items-end gap-2 text-2xs text-[var(--text-muted)]">
+                  <div class="flex shrink-0 flex-col items-end gap-2 text-2xs text-[var(--color-fg-muted)]">
                     <span>${group.rawCount}건</span>
                     <${TimeAgo} timestamp=${group.latestTs} />
                   </div>
                 </div>
                 <div class="mt-3 flex flex-wrap gap-1.5">
                   ${group.kinds.slice(0, 4).map(kind => html`
-                    <span class="inline-flex items-center rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-muted)]" key=${kind}>
+                    <span class="inline-flex items-center rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]" key=${kind}>
                       ${activityEventKindLabel(kind)}
                     </span>
                   `)}
                 </div>
                 <div class="mt-3 flex items-center justify-between gap-3 border-t border-[var(--white-6)] pt-3">
-                  <span class="text-2xs text-[var(--text-muted)]">원본 이벤트를 펼쳐서 순서를 확인할 수 있습니다.</span>
+                  <span class="text-2xs text-[var(--color-fg-muted)]">원본 이벤트를 펼쳐서 순서를 확인할 수 있습니다.</span>
                   <div class="flex items-center gap-2">
                     ${group.actor ? html`
                       <a
-                        class="rounded border border-[var(--accent-20)] bg-[var(--accent-soft)] px-3 py-1.5 text-2xs text-[var(--accent)] no-underline transition-all duration-150 hover:bg-[var(--accent-10)]"
+                        class="rounded border border-[var(--accent-20)] bg-[var(--accent-soft)] px-3 py-1.5 text-2xs text-[var(--color-accent-fg)] no-underline transition-all duration-150 hover:bg-[var(--accent-10)]"
                         href=${hashForRoute('monitoring', { section: 'observatory', keeper: group.actor, range: activityRange() })}
                       >이 keeper로 보기</a>
                     ` : null}
                     <button
                       type="button"
-                      class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-3 py-1.5 text-2xs text-[var(--text-body)] transition-all duration-150 hover:bg-[var(--white-8)]"
+                      class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-3 py-1.5 text-2xs text-[var(--color-fg-primary)] transition-all duration-150 hover:bg-[var(--white-8)]"
                       onClick=${() => toggleExpandedGroup(group.id)}
                     >
                       ${expanded ? '원본 접기' : '원본 보기'}
@@ -257,16 +257,16 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
                   <div class="mt-3 flex flex-col gap-2 rounded border border-[var(--white-8)] bg-[rgba(15,23,42,0.42)] p-3">
                     ${group.rawEvents.map(event => html`
                       <div class="flex items-start gap-3 rounded border border-[var(--white-6)] bg-[var(--white-3)] px-3 py-2" key=${event.seq}>
-                        <span class="inline-flex min-w-18 items-center rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">
+                        <span class="inline-flex min-w-18 items-center rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">
                           ${activityEventKindLabel(event.kind)}
                         </span>
                         <div class="min-w-0 flex-1">
-                          <div class="text-xs text-[var(--text-body)]">${eventDetail(event, 160)}</div>
+                          <div class="text-xs text-[var(--color-fg-primary)]">${eventDetail(event, 160)}</div>
                            ${(() => { const ns = visibleNamespaceLabel(event.room_id); return ns
-                             ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">namespace: ${ns}</div>`
+                             ? html`<div class="mt-1 text-2xs text-[var(--color-fg-muted)]">namespace: ${ns}</div>`
                              : null; })()}
                         </div>
-                        <span class="shrink-0 text-2xs text-[var(--text-muted)]">
+                        <span class="shrink-0 text-2xs text-[var(--color-fg-muted)]">
                           <${TimeAgo} timestamp=${event.ts_iso} />
                         </span>
                       </div>
@@ -307,14 +307,14 @@ function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
             <div class="flex-1 flex flex-col gap-1 min-w-0">
               <div class="flex items-center gap-2">
                 <span class="text-base font-semibold text-[var(--text-near-white)] whitespace-nowrap overflow-hidden text-ellipsis">${node.label}</span>
-                <span class="text-2xs text-[var(--text-muted)]">${node.weight}회</span>
+                <span class="text-2xs text-[var(--color-fg-muted)]">${node.weight}회</span>
               </div>
               <div class="h-1 rounded-sm bg-[var(--slate-gray-10)] overflow-hidden">
                 <div class="h-full rounded-sm bg-[var(--cyan)] transition-[width] duration-300 ease-in-out" style="width:${pct}%"></div>
               </div>
             </div>
             <span class="text-sm font-semibold text-text-slate-light min-w-8 text-right">${score.toFixed(1)}</span>
-            <span class="text-2xs py-0.5 px-[7px] rounded ${node.status === 'offline' || node.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--ok)] bg-[var(--ok-10)]'}">${node.status}</span>
+            <span class="text-2xs py-0.5 px-[7px] rounded ${node.status === 'offline' || node.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--color-status-ok)] bg-[var(--ok-10)]'}">${node.status}</span>
           </div>
         `
       })}
@@ -385,7 +385,7 @@ function DerivedActivityPanels({ data }: { data: ActivityGraphResponse }) {
         <${Suspense} fallback=${lazyPanelFallback('관계 그래프')}>
           <${LazyGraphView} data=${data} />
         <//>
-        <div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--text-muted)] text-sm">
+        <div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--color-fg-muted)] text-sm">
           <span>생성 시각: ${data.generated_at}</span>
           <span>데이터 범위: 최근 ${data.window.limit}건 이벤트</span>
           <span>필터: ${timeRangeLabel(activityRange())}</span>
@@ -433,7 +433,7 @@ export function ObservatoryActivityPanels() {
             : html`
                 <${CollapsibleSection}
                   title="활동 분석"
-                  badge=${html`<span class="ml-1 text-3xs font-normal text-[var(--text-dim)]">액션 ${actionCount}</span>`}
+                  badge=${html`<span class="ml-1 text-3xs font-normal text-[var(--color-fg-disabled)]">액션 ${actionCount}</span>`}
                   mountWhenOpen
                 >
                   <${ActivityTimelinePanel} data=${data} />

--- a/dashboard/src/components/activity-heatmap.ts
+++ b/dashboard/src/components/activity-heatmap.ts
@@ -255,7 +255,7 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
   return html`
     <${Card} title="활동 히트맵" testId="activity_heatmap">
       <div class="mb-2">
-        <p class="text-sm text-[var(--text-muted)]">필터링된 전체 이벤트를 기준으로 요일별, 시간대별 활동 밀도를 보여줍니다.</p>
+        <p class="text-sm text-[var(--color-fg-muted)]">필터링된 전체 이벤트를 기준으로 요일별, 시간대별 활동 밀도를 보여줍니다.</p>
       </div>
       <div ref=${containerRef} class="relative overflow-x-auto bg-[#0f1117] rounded p-3">
         <canvas ref=${canvasRef} class="block" role="img" aria-label="요일별 시간대별 활동 밀도 히트맵" />

--- a/dashboard/src/components/activity-swimlane.test.ts
+++ b/dashboard/src/components/activity-swimlane.test.ts
@@ -51,12 +51,12 @@ describe('truncateLabel', () => {
 describe('spanStyle', () => {
   it('returns task style', () => {
     const style = spanStyle('task')
-    expect(style).toEqual({ bg: 'var(--warn)', text: 'var(--panel-dark)' })
+    expect(style).toEqual({ bg: 'var(--color-status-warn)', text: 'var(--panel-dark)' })
   })
 
   it('returns operation style', () => {
     const style = spanStyle('operation')
-    expect(style).toEqual({ bg: 'var(--ok)', text: 'var(--panel-dark)' })
+    expect(style).toEqual({ bg: 'var(--color-status-ok)', text: 'var(--panel-dark)' })
   })
 
   it('returns autonomy style', () => {

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -78,8 +78,8 @@ function syncTimelineSelection(
 }
 
 const SPAN_STYLES: Record<string, { bg: string; text: string }> = {
-  task:      { bg: 'var(--warn)', text: 'var(--panel-dark)' },
-  operation: { bg: 'var(--ok)', text: 'var(--panel-dark)' },
+  task:      { bg: 'var(--color-status-warn)', text: 'var(--panel-dark)' },
+  operation: { bg: 'var(--color-status-ok)', text: 'var(--panel-dark)' },
   autonomy:  { bg: 'var(--cyan)', text: 'var(--panel-dark)' },
   presence:  { bg: 'rgba(148, 163, 184, 0.25)', text: 'var(--frost-100)' },
 }
@@ -240,14 +240,14 @@ export function ActivitySwimlane({ since }: { since?: string }) {
   return html`
     <${Card} title="활동 타임라인" testId="activity_swimlane">
       <div class="mb-2">
-        <p class="text-sm text-[var(--text-muted)]">에이전트별 활동 구간을 시간축으로 보여줍니다. 마우스 휠로 줌인/아웃, 드래그로 이동이 가능합니다.</p>
+        <p class="text-sm text-[var(--color-fg-muted)]">에이전트별 활동 구간을 시간축으로 보여줍니다. 마우스 휠로 줌인/아웃, 드래그로 이동이 가능합니다.</p>
       </div>
-      <div class="w-full bg-[#0f1117] rounded border border-[var(--card-border)] overflow-hidden swimlane-vis-container">
+      <div class="w-full bg-[#0f1117] rounded border border-[var(--color-border-default)] overflow-hidden swimlane-vis-container">
         <div ref=${containerRef} class="w-full" role="img" aria-label="에이전트별 활동 타임라인"></div>
       </div>
-      <div class="flex flex-wrap gap-3 mt-3 text-2xs text-[var(--text-muted)]">
-        <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[var(--warn)] inline-block"></span>작업</span>
-        <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[var(--ok)] inline-block"></span>운영</span>
+      <div class="flex flex-wrap gap-3 mt-3 text-2xs text-[var(--color-fg-muted)]">
+        <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[var(--color-status-warn)] inline-block"></span>작업</span>
+        <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[var(--color-status-ok)] inline-block"></span>운영</span>
         <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[var(--cyan)] inline-block"></span>자율</span>
         <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[rgba(148,163,184,0.5)] inline-block"></span>접속</span>
       </div>

--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -89,7 +89,7 @@ export function AgentDetailMemory({ agentName }: Props) {
   const { loading, error, data } = state.value
   if (loading) return html`<${LoadingState} label="메모리 컨텍스트 로드 중..." />`
   if (error)
-    return html`<div class="text-sm text-[var(--warn)]">메모리 로드 실패: ${error}</div>`
+    return html`<div class="text-sm text-[var(--color-status-warn)]">메모리 로드 실패: ${error}</div>`
   if (!data) return null
 
   // Filter hebbian synapses where this keeper is either endpoint
@@ -118,12 +118,12 @@ export function AgentDetailMemory({ agentName }: Props) {
       <div class="space-y-4">
         <!-- Hebbian collaboration -->
         <div>
-          <div class="text-xs text-[var(--text-dim)] uppercase tracking-wide mb-2">
+          <div class="text-xs text-[var(--color-fg-disabled)] uppercase tracking-wide mb-2">
             협업 시냅스 (나에게 연결된 ${myEdges.length}개)
           </div>
           ${
             myEdges.length === 0
-              ? html`<div class="text-sm text-[var(--text-dim)]">
+              ? html`<div class="text-sm text-[var(--color-fg-disabled)]">
                   아직 협업 데이터가 없습니다. task 완료 시 자동 학습됩니다.
                 </div>`
               : html`
@@ -131,7 +131,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                     ${outgoing.length > 0
                       ? html`
                           <div>
-                            <div class="text-2xs text-[var(--text-muted)] mb-1">
+                            <div class="text-2xs text-[var(--color-fg-muted)] mb-1">
                               내가 강화한 파트너 (out, ${outgoing.length})
                             </div>
                             <div class="space-y-1">
@@ -145,7 +145,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                                         style="width:${Math.round(s.weight * 100)}%"
                                       ></div>
                                     </div>
-                                    <span class="text-[var(--text-muted)] w-10 text-right">${Math.round(s.weight * 100)}%</span>
+                                    <span class="text-[var(--color-fg-muted)] w-10 text-right">${Math.round(s.weight * 100)}%</span>
                                   </div>
                                 `,
                               )}
@@ -156,7 +156,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                     ${incoming.length > 0
                       ? html`
                           <div>
-                            <div class="text-2xs text-[var(--text-muted)] mb-1">
+                            <div class="text-2xs text-[var(--color-fg-muted)] mb-1">
                               나를 강화한 파트너 (in, ${incoming.length})
                             </div>
                             <div class="space-y-1">
@@ -170,7 +170,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                                         style="width:${Math.round(s.weight * 100)}%"
                                       ></div>
                                     </div>
-                                    <span class="text-[var(--text-muted)] w-10 text-right">${Math.round(s.weight * 100)}%</span>
+                                    <span class="text-[var(--color-fg-muted)] w-10 text-right">${Math.round(s.weight * 100)}%</span>
                                   </div>
                                 `,
                               )}
@@ -186,7 +186,7 @@ export function AgentDetailMemory({ agentName }: Props) {
         <!-- Recent episodes for this keeper -->
         <div>
           <div class="mb-2 flex items-center justify-between gap-2">
-            <div class="text-xs text-[var(--text-dim)] uppercase tracking-wide">
+            <div class="text-xs text-[var(--color-fg-disabled)] uppercase tracking-wide">
               최근 에피소드 (${
                 isFilteringEpisodes
                   ? `${visibleEpisodes.length}/${episodes.length}`
@@ -202,17 +202,17 @@ export function AgentDetailMemory({ agentName }: Props) {
                   onInput=${(e: Event) => {
                     episodeQuery.value = (e.target as HTMLInputElement).value
                   }}
-                  class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                  class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
                 />`
               : null}
           </div>
           ${
             episodes.length === 0
-              ? html`<div class="text-sm text-[var(--text-dim)]">
+              ? html`<div class="text-sm text-[var(--color-fg-disabled)]">
                   이 키퍼의 에피소드 기록이 없습니다.
                 </div>`
               : visibleEpisodes.length === 0
-                ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">
+                ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">
                     필터 결과 없음 (${episodes.length}개 중 0)
                   </div>`
                 : html`
@@ -229,21 +229,21 @@ export function AgentDetailMemory({ agentName }: Props) {
                               : '○'
                         const outcomeColor =
                           ep.outcome === 'success'
-                            ? 'text-[var(--ok)]'
+                            ? 'text-[var(--color-status-ok)]'
                             : ep.outcome === 'partial'
-                              ? 'text-[var(--warn)]'
+                              ? 'text-[var(--color-status-warn)]'
                               : 'text-[var(--bad-light)]'
                         return html`
                           <div class="border border-[var(--white-10)] rounded px-2 py-1.5 text-xs">
                             <div class="flex items-center justify-between gap-2">
                               <div class="flex items-center gap-2 min-w-0">
                                 <span class="${outcomeColor}">${outcomeIcon}</span>
-                                <span class="truncate text-[var(--text-muted)]">${highlightMatch(ep.summary, episodeQuery.value)}</span>
+                                <span class="truncate text-[var(--color-fg-muted)]">${highlightMatch(ep.summary, episodeQuery.value)}</span>
                               </div>
-                              <span class="text-3xs text-[var(--text-muted)]0 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
+                              <span class="text-3xs text-[var(--color-fg-muted)]0 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
                             </div>
                             ${ep.learnings.length > 0
-                              ? html`<div class="mt-1 text-2xs text-[var(--text-muted)] pl-3 border-l border-[var(--white-10)]">${highlightMatch(ep.learnings[0]!, episodeQuery.value)}</div>`
+                              ? html`<div class="mt-1 text-2xs text-[var(--color-fg-muted)] pl-3 border-l border-[var(--white-10)]">${highlightMatch(ep.learnings[0]!, episodeQuery.value)}</div>`
                               : null}
                           </div>
                         `

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -102,23 +102,23 @@ function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }
           ${cat.icon}
         </div>
         <span class="text-xs font-mono font-medium ${cat.color} truncate max-w-50" title=${toolName}>${toolName}</span>
-        <span class="text-3xs px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)]">${cat.label}</span>
+        <span class="text-3xs px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--color-fg-disabled)]">${cat.label}</span>
         ${durationMs != null
           ? html`<span class="text-2xs font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span>`
           : null}
         ${success
-          ? html`<span class="text-3xs px-1 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--ok)]">ok</span>`
-          : html`<span class="text-3xs px-1 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">err</span>`}
+          ? html`<span class="text-3xs px-1 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--color-status-ok)]">ok</span>`
+          : html`<span class="text-3xs px-1 py-0.5 rounded bg-[var(--bad-10)] text-[var(--color-status-err)]">err</span>`}
         <span class="flex-1"></span>
         ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
       </div>
       ${args ? html`
-        <div class="ml-8 mt-0.5 text-3xs text-[var(--text-dim)] font-mono truncate">
+        <div class="ml-8 mt-0.5 text-3xs text-[var(--color-fg-disabled)] font-mono truncate">
           ${typeof args === 'string' ? trimText(args, 60) : formatArgs(args)}
         </div>
       ` : null}
       ${errorMsg ? html`
-        <div class="ml-8 mt-0.5 text-3xs text-[var(--bad)] font-mono truncate" title=${errorMsg}>
+        <div class="ml-8 mt-0.5 text-3xs text-[var(--color-status-err)] font-mono truncate" title=${errorMsg}>
           ${trimText(errorMsg, 60)}
         </div>
       ` : null}
@@ -142,11 +142,11 @@ export function AgentTimelineSection() {
     <${Card} title="활동 타임라인 (${summary?.total_events ?? 0}건)">
       ${summary ? html`
         <div class="flex gap-1.5 flex-wrap mb-2">
-          ${summary.tasks_completed > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">완료 ${summary.tasks_completed}</span>` : null}
-          ${summary.tasks_claimed > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">수임 ${summary.tasks_claimed}</span>` : null}
-          ${summary.messages_sent > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">메시지 ${summary.messages_sent}</span>` : null}
-          ${(summary.tool_calls ?? 0) > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">도구 ${summary.tool_calls}</span>` : null}
-          ${summary.active_duration_minutes > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
+          ${summary.tasks_completed > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--color-accent-fg)] whitespace-nowrap rounded-sm">완료 ${summary.tasks_completed}</span>` : null}
+          ${summary.tasks_claimed > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--color-accent-fg)] whitespace-nowrap rounded-sm">수임 ${summary.tasks_claimed}</span>` : null}
+          ${summary.messages_sent > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--color-accent-fg)] whitespace-nowrap rounded-sm">메시지 ${summary.messages_sent}</span>` : null}
+          ${(summary.tool_calls ?? 0) > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--color-accent-fg)] whitespace-nowrap rounded-sm">도구 ${summary.tool_calls}</span>` : null}
+          ${summary.active_duration_minutes > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--color-accent-fg)] whitespace-nowrap rounded-sm">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
         </div>
       ` : null}
       ${events.length === 0
@@ -176,7 +176,7 @@ export function AgentTimelineSection() {
                 onInput=${(e: Event) => { timelineSearchQuery.value = (e.target as HTMLInputElement).value }}
               />
               ${filterActive
-                ? html`<span class="text-3xs text-[var(--text-dim)] tabular-nums">${filtered.length} / ${events.length}</span>`
+                ? html`<span class="text-3xs text-[var(--color-fg-disabled)] tabular-nums">${filtered.length} / ${events.length}</span>`
                 : null}
             </div>
             ${filtered.length === 0

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -16,33 +16,33 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
     <${Card} title="워커 상태">
       <div class="flex flex-col gap-1.5">
         <div class="flex items-baseline gap-2 text-sm">
-          <span class="text-2xs text-[var(--text-muted)] min-w-15 shrink-0">상태</span>
+          <span class="text-2xs text-[var(--color-fg-muted)] min-w-15 shrink-0">상태</span>
           <${StatusBadge} status=${worker.state} />
         </div>
         ${worker.focus ? html`
           <div class="flex items-baseline gap-2 text-sm">
-            <span class="text-2xs text-[var(--text-muted)] min-w-15 shrink-0">포커스</span>
+            <span class="text-2xs text-[var(--color-fg-muted)] min-w-15 shrink-0">포커스</span>
             <span>${worker.focus}</span>
           </div>
         ` : null}
         ${worker.recent_output_preview ? html`
           <div class="flex items-baseline gap-2 text-sm">
-            <span class="text-2xs text-[var(--text-muted)] min-w-15 shrink-0">출력</span>
+            <span class="text-2xs text-[var(--color-fg-muted)] min-w-15 shrink-0">출력</span>
             <span class="agent-worker-brief__preview">${trimText(worker.recent_output_preview, 200)}</span>
           </div>
         ` : null}
         ${worker.related_session_id ? html`
           <div class="flex items-baseline gap-2 text-sm">
-            <span class="text-2xs text-[var(--text-muted)] min-w-15 shrink-0">세션</span>
+            <span class="text-2xs text-[var(--color-fg-muted)] min-w-15 shrink-0">세션</span>
             <span class="font-mono truncate" style="font-size: 11px" title=${worker.related_session_id}>${worker.related_session_id}</span>
             <${CopyIdButton} value=${worker.related_session_id} label="session_id" size=${10} />
           </div>
         ` : null}
         ${worker.last_signal_at ? html`
           <div class="flex items-baseline gap-2 text-sm">
-            <span class="text-2xs text-[var(--text-muted)] min-w-15 shrink-0">시그널</span>
+            <span class="text-2xs text-[var(--color-fg-muted)] min-w-15 shrink-0">시그널</span>
             <${TimeAgo} timestamp=${worker.last_signal_at} />
-            ${worker.signal_truth ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${worker.signal_truth}</span>` : null}
+            ${worker.signal_truth ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--color-accent-fg)] whitespace-nowrap rounded-sm">${worker.signal_truth}</span>` : null}
           </div>
         ` : null}
       </div>

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -146,7 +146,7 @@ function renderOwnedTasks(
     return html`<div class="h-full min-h-30"><${EmptyState} message="할당된 작업이 없습니다" compact /></div>`
   }
   if (isFiltering && visibleTasks.length === 0) {
-    return html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${allTasks.length} tasks)</div>`
+    return html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${allTasks.length} tasks)</div>`
   }
   return html`<div class="flex flex-col gap-3">${visibleTasks.map(t => html`<${TaskSummary} key=${t.id} task=${t} />`)}</div>`
 }
@@ -160,7 +160,7 @@ function renderTaskHistories(
     return html`<${EmptyState} message="작업 이력이 없습니다" compact />`
   }
   if (isFiltering && visibleRows.length === 0) {
-    return html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${allRows.length} rows)</div>`
+    return html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${allRows.length} rows)</div>`
   }
   return html`<div class="flex flex-col gap-3">${visibleRows.map(row => html`<${TaskHistoryPanel} key=${row.taskId} row=${row} />`)}</div>`
 }
@@ -331,12 +331,12 @@ export function AgentDetailOverlay() {
 
         <${AgentSessionReport} agentName=${agentName} />
 
-        <${CollapsibleSection} title="활동 추적" badge=${html`<span class="text-3xs text-[var(--text-dim)] font-normal ml-1">통합 타임라인</span>`}>
+        <${CollapsibleSection} title="활동 추적" badge=${html`<span class="text-3xs text-[var(--color-fg-disabled)] font-normal ml-1">통합 타임라인</span>`}>
           <${SessionTraceView} agentName=${agentName} isKeeper=${!!keeper} />
         <//>
 
         <div class="flex items-center justify-between gap-2">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">
             작업 필터
             ${isFilteringTasks
               ? html`<span class="ml-2 normal-case tracking-normal text-text-muted">할당 ${visibleOwnedTasks.length}/${ownedTasks.length} · 이력 ${visibleHistories.length}/${historyRows.length}</span>`
@@ -348,7 +348,7 @@ export function AgentDetailOverlay() {
             placeholder="id / title / status 필터"
             aria-label="작업 필터"
             onInput=${(e: Event) => { taskQuery.value = (e.target as HTMLInputElement).value }}
-            class="min-w-40 max-w-70 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-70 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
           />
         </div>
 
@@ -380,7 +380,7 @@ export function AgentDetailOverlay() {
                 ].map(([label, val]) => html`
                   <div class="rounded border border-card-border/50 bg-card/30 p-3 text-center">
                     <div class="text-3xs font-semibold uppercase tracking-wider text-text-muted mb-1">${label}</div>
-                    <div class="text-lg font-bold ${(val as number) >= 0.7 ? 'text-ok' : (val as number) >= 0.4 ? 'text-[var(--warn)]' : 'text-bad'}">${val != null ? ((val as number) * 100).toFixed(0) + '%' : '-'}</div>
+                    <div class="text-lg font-bold ${(val as number) >= 0.7 ? 'text-ok' : (val as number) >= 0.4 ? 'text-[var(--color-status-warn)]' : 'text-bad'}">${val != null ? ((val as number) * 100).toFixed(0) + '%' : '-'}</div>
                   </div>
                 `)}
               </div>

--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -151,12 +151,12 @@ export function AgentLiveTimeline({ name }: { name: string }) {
       <div class="flex items-center justify-between gap-2 flex-wrap">
         <${FilterChips} chips=${FILTER_CHIPS} active=${activeFilter} />
         <div class="flex items-center gap-2 text-2xs">
-          <span class="px-2 py-0.5 rounded bg-[var(--white-4)] border border-[var(--white-8)] text-[var(--text-muted)] text-3xs">${eventsPerMin}/min</span>
-          <span class="text-[var(--text-muted)]">${filtered.length} events</span>
+          <span class="px-2 py-0.5 rounded bg-[var(--white-4)] border border-[var(--white-8)] text-[var(--color-fg-muted)] text-3xs">${eventsPerMin}/min</span>
+          <span class="text-[var(--color-fg-muted)]">${filtered.length} events</span>
           <button type="button"
             class="px-2 py-0.5 rounded text-3xs border cursor-pointer transition-all duration-150 ${autoScroll.value
-              ? 'border-[rgba(34,197,94,0.4)] text-[var(--ok)] bg-[var(--white-4)]'
-              : 'border-[var(--white-10)] text-[var(--text-dim)] bg-[var(--white-4)]'}"
+              ? 'border-[rgba(34,197,94,0.4)] text-[var(--color-status-ok)] bg-[var(--white-4)]'
+              : 'border-[var(--white-10)] text-[var(--color-fg-disabled)] bg-[var(--white-4)]'}"
             onClick=${() => { autoScroll.value = !autoScroll.value }}
             title=${autoScroll.value ? 'Auto-scroll ON' : 'Auto-scroll OFF'}
           >
@@ -173,9 +173,9 @@ export function AgentLiveTimeline({ name }: { name: string }) {
                 <span class="agent-event-badge ${eventKindBadgeClass(entry)}">
                   ${eventKindLabel(entry.eventType)}
                 </span>
-                <span class="flex-1 text-[var(--text-body)] truncate">${compactText(entry.text)}</span>
+                <span class="flex-1 text-[var(--color-fg-primary)] truncate">${compactText(entry.text)}</span>
                 ${entry.timestamp ? html`
-                  <span class="text-[var(--text-dim)] text-2xs whitespace-nowrap"><${TimeAgo} timestamp=${entry.timestamp} /></span>
+                  <span class="text-[var(--color-fg-disabled)] text-2xs whitespace-nowrap"><${TimeAgo} timestamp=${entry.timestamp} /></span>
                 ` : null}
               </div>
             `)}

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -38,35 +38,35 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
 
       ${ctxPct != null ? html`
         <div class="flex items-center gap-1.5 text-sm">
-          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">CTX</span>
+          <span class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-wider">CTX</span>
           <div class="w-16 h-1.5 bg-[#1a1a2e] rounded-sm overflow-hidden">
             <div
               class="agent-runtime-ctx-fill rounded-sm ${ctxBarClass(ctxRatio)}"
               style=${{ width: `${ctxPct}%` }}
             ></div>
           </div>
-          <span class="text-sm text-[var(--text-body)] tabular-nums">${ctxPct}%</span>
+          <span class="text-sm text-[var(--color-fg-primary)] tabular-nums">${ctxPct}%</span>
         </div>
       ` : null}
 
       ${generation != null ? html`
         <div class="flex items-center gap-1.5 text-sm">
-          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">GEN</span>
-          <span class="text-sm text-[var(--text-body)] tabular-nums">${generation}</span>
+          <span class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-wider">GEN</span>
+          <span class="text-sm text-[var(--color-fg-primary)] tabular-nums">${generation}</span>
         </div>
       ` : null}
 
       ${model ? html`
         <div class="flex items-center gap-1.5 text-sm">
-          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">${model.label}</span>
-          <span class="text-sm text-[var(--text-body)] font-mono truncate max-w-50">${model.value}</span>
+          <span class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-wider">${model.label}</span>
+          <span class="text-sm text-[var(--color-fg-primary)] font-mono truncate max-w-50">${model.value}</span>
         </div>
       ` : null}
 
       ${activity.ageSeconds != null ? html`
         <div class="flex items-center gap-1.5 text-sm">
-          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">ACTIVITY</span>
-          <span class="text-sm text-[var(--text-body)] tabular-nums">${activity.label} ${formatDuration(activity.ageSeconds)} 전</span>
+          <span class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-wider">ACTIVITY</span>
+          <span class="text-sm text-[var(--color-fg-primary)] tabular-nums">${activity.label} ${formatDuration(activity.ageSeconds)} 전</span>
         </div>
       ` : null}
     </div>

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -257,39 +257,39 @@ function CharacterPlate({ name }: { name: string }) {
             ${agentEmoji ? html`<span class="text-[1.4em]">${agentEmoji}</span>` : ''}
             ${displayName}
           </h2>
-          ${koreanName ? html`<span class="text-base text-[var(--text-muted)]">(${koreanName})</span>` : ''}
-          ${generation != null ? html`<span class="text-sm font-bold text-[var(--accent)] bg-[var(--accent-10)] border border-[var(--accent-30)] px-1.5 py-px tabular-nums rounded" title="세대 번호 — 핸드오프마다 증가 (레벨/등급 아님)">Gen.${generation}</span>` : null}
+          ${koreanName ? html`<span class="text-base text-[var(--color-fg-muted)]">(${koreanName})</span>` : ''}
+          ${generation != null ? html`<span class="text-sm font-bold text-[var(--color-accent-fg)] bg-[var(--accent-10)] border border-[var(--accent-30)] px-1.5 py-px tabular-nums rounded" title="세대 번호 — 핸드오프마다 증가 (레벨/등급 아님)">Gen.${generation}</span>` : null}
         </div>
 
         <div class="flex items-center gap-1.5 flex-wrap">
           <${StatusBadge} status=${headerStatus} />
-          ${model ? html`<span class="font-[family-name:'IBM_Plex_Mono',monospace] text-2xs text-[var(--text-muted)] bg-[var(--accent-8)] border border-[var(--accent-10)] px-[5px] py-px rounded">${model}</span>` : null}
+          ${model ? html`<span class="font-[family-name:'IBM_Plex_Mono',monospace] text-2xs text-[var(--color-fg-muted)] bg-[var(--accent-8)] border border-[var(--accent-10)] px-[5px] py-px rounded">${model}</span>` : null}
         </div>
 
         ${ctxPct != null ? html`
           <div class="flex items-center gap-2 mt-0.5">
             <span class="text-2xs font-bold text-[var(--ff-gold)] tracking-[1px] w-7">CTX</span>
             <div class="h-1.5 mt-1.5 rounded-sm overflow-hidden bg-[var(--white-10)]" style="flex:1">
-              <div class="h-full rounded-sm transition-[width] duration-[250ms] ease-[ease] motion-reduce:transition-none ${ctxBarClass(ctxRatio) === 'warn' ? 'bg-linear-to-r from-[var(--warn)] to-[var(--warn-bright)]' : ctxBarClass(ctxRatio) === 'bad' ? 'bg-linear-to-r from-[var(--bad)] to-[var(--warn-bright)]' : 'bg-linear-to-r from-[var(--accent)] to-[var(--ok)]'}" style=${{ width: `${ctxPct}%` }}></div>
+              <div class="h-full rounded-sm transition-[width] duration-[250ms] ease-[ease] motion-reduce:transition-none ${ctxBarClass(ctxRatio) === 'warn' ? 'bg-linear-to-r from-[var(--color-status-warn)] to-[var(--warn-bright)]' : ctxBarClass(ctxRatio) === 'bad' ? 'bg-linear-to-r from-[var(--color-status-err)] to-[var(--warn-bright)]' : 'bg-linear-to-r from-[var(--color-accent-fg)] to-[var(--color-status-ok)]'}" style=${{ width: `${ctxPct}%` }}></div>
             </div>
-            <span class="text-sm tabular-nums text-[var(--text-strong)] min-w-9 text-right">${ctxPct}%</span>
+            <span class="text-sm tabular-nums text-[var(--color-fg-secondary)] min-w-9 text-right">${ctxPct}%</span>
             ${keeper?.context_tokens != null && keeper?.context_max != null
-              ? html`<span class="text-2xs tabular-nums text-[var(--text-muted)] font-mono ml-1">${formatTokens(keeper.context_tokens)} / ${formatTokens(keeper.context_max)}</span>`
+              ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)] font-mono ml-1">${formatTokens(keeper.context_tokens)} / ${formatTokens(keeper.context_max)}</span>`
               : null}
           </div>
         ` : null}
 
         <div class="flex gap-2 items-center flex-wrap">
           ${currentWork
-            ? html`<span class="text-base text-[var(--text-body)]">${currentWork}</span>`
-            : html`<span class="text-base text-[var(--text-dim)] italic">대기 중</span>`
+            ? html`<span class="text-base text-[var(--color-fg-primary)]">${currentWork}</span>`
+            : html`<span class="text-base text-[var(--color-fg-disabled)] italic">대기 중</span>`
           }
-          ${workerState ? html`<span class="text-2xs text-[var(--accent)] bg-[var(--accent-8)] px-[5px] py-px rounded-xs">${workerState}</span>` : null}
-          ${workerFocus ? html`<span class="text-2xs text-[var(--text-muted)]">${workerFocus}</span>` : null}
+          ${workerState ? html`<span class="text-2xs text-[var(--color-accent-fg)] bg-[var(--accent-8)] px-[5px] py-px rounded-xs">${workerState}</span>` : null}
+          ${workerFocus ? html`<span class="text-2xs text-[var(--color-fg-muted)]">${workerFocus}</span>` : null}
         </div>
 
         ${lastSeenAt || lastActivity != null ? html`
-          <div class="flex gap-3 flex-wrap text-sm text-[var(--text-muted)]">
+          <div class="flex gap-3 flex-wrap text-sm text-[var(--color-fg-muted)]">
             ${lastSeenAt ? html`<span>${activityLabel}: <${TimeAgo} timestamp=${lastSeenAt} /></span>` : null}
             ${lastActivity != null && (!keeperActivity || !lastSeenAt)
               ? html`<span>${activityLabel} ${formatDuration(lastActivity)} 전</span>`
@@ -298,7 +298,7 @@ function CharacterPlate({ name }: { name: string }) {
         ` : null}
 
         ${keeperIdent || continuitySummary || brief?.related_session_id ? html`
-          <div class="flex gap-3 flex-wrap text-sm text-[var(--text-muted)]">
+          <div class="flex gap-3 flex-wrap text-sm text-[var(--color-fg-muted)]">
             ${keeperIdent ? html`<span>${keeperIdent}</span>` : null}
             ${brief?.related_session_id ? html`<span>세션 ${brief.related_session_id}</span>` : null}
             ${continuitySummary ? html`<span>${continuitySummary}</span>` : null}
@@ -371,9 +371,9 @@ export function AgentProfile({ name }: { name: string }) {
           ${owned.length === 0
             ? html`<${EmptyState} message="할당된 태스크 없음" compact />`
             : html`<div class="flex flex-col gap-2">${owned.map(t => html`
-                <div class="flex items-center gap-2 border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 rounded" key=${t.id}>
-                  <span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${t.id}</span>
-                  <span class="flex-1 text-[var(--text-strong)]">${t.title}</span>
+                <div class="flex items-center gap-2 border border-[var(--color-border-default)] bg-[var(--white-3)] px-2.5 py-2 rounded" key=${t.id}>
+                  <span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--color-accent-fg)] whitespace-nowrap rounded-sm">${t.id}</span>
+                  <span class="flex-1 text-[var(--color-fg-secondary)]">${t.title}</span>
                   <${StatusBadge} status=${t.status} />
                 </div>
               `)}</div>`}
@@ -424,7 +424,7 @@ export function AgentProfile({ name }: { name: string }) {
                 return html`
                   <div class="agent-timeline-event flex items-baseline gap-1.5 py-1 px-2 text-sm transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
                     <span class="text-2xs font-semibold text-[var(--ff-gold)] min-w-8">${timelineEventLabel(evt.type)}</span>
-                    ${title ? html`<span class="flex-1 text-sm text-[var(--text-body)]">${trimText(title, 80)}</span>` : null}
+                    ${title ? html`<span class="flex-1 text-sm text-[var(--color-fg-primary)]">${trimText(title, 80)}</span>` : null}
                     ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
                   </div>
                 `
@@ -449,12 +449,12 @@ export function AgentProfile({ name }: { name: string }) {
                       placeholder="활동 필터 (메시지 본문)"
                       aria-label="프로젝트 활동 필터"
                       onInput=${(e: Event) => { activityQuery.value = (e.target as HTMLInputElement).value }}
-                      class="w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                      class="w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
                     />
                     ${isFiltering && visible.length === 0
-                      ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${lines.length} items)</div>`
+                      ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${lines.length} items)</div>`
                       : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${visible.map((line: string, idx: number) =>
-                          html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-sm text-[var(--text-body)] leading-[1.4] rounded">${line}</div>`)}</div>`}
+                          html`<div key=${idx} class="border border-[var(--color-border-default)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-sm text-[var(--color-fg-primary)] leading-[1.4] rounded">${line}</div>`)}</div>`}
                   </div>
                 `
               })()}
@@ -463,9 +463,9 @@ export function AgentProfile({ name }: { name: string }) {
         ${(profileData?.taskHistories ?? []).length > 0 ? html`
           <${Card} title="태스크 이력" class="ff-card rounded col-span-full">
             <div class="agent-history-list">${(profileData?.taskHistories ?? []).map((row: TaskHistoryRow) => html`
-              <div class="border border-[var(--card-border)] rounded-[10px] bg-[var(--white-2)] p-2.5" key=${row.taskId}>
-                <div class="mb-2"><span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${row.taskId}</span></div>
-                <pre class="m-0 whitespace-pre-wrap text-sm leading-normal text-[var(--text-strong)] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || '이력 없음'}</pre>
+              <div class="border border-[var(--color-border-default)] rounded-[10px] bg-[var(--white-2)] p-2.5" key=${row.taskId}>
+                <div class="mb-2"><span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--color-accent-fg)] whitespace-nowrap rounded-sm">${row.taskId}</span></div>
+                <pre class="m-0 whitespace-pre-wrap text-sm leading-normal text-[var(--color-fg-secondary)] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || '이력 없음'}</pre>
               </div>
             `)}</div>
           <//>

--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -46,11 +46,11 @@ async function flushUi(): Promise<void> {
 
 describe('runtimeBadgeClass', () => {
   it('returns green classes for active', () => {
-    expect(runtimeBadgeClass('active')).toContain('text-[var(--ok)]')
+    expect(runtimeBadgeClass('active')).toContain('text-[var(--color-status-ok)]')
   })
 
   it('returns yellow classes for attention', () => {
-    expect(runtimeBadgeClass('attention')).toContain('text-[var(--warn)]')
+    expect(runtimeBadgeClass('attention')).toContain('text-[var(--color-status-warn)]')
   })
 
   it('returns purple classes for paused', () => {
@@ -58,21 +58,21 @@ describe('runtimeBadgeClass', () => {
   })
 
   it('returns dim classes for unknown band', () => {
-    expect(runtimeBadgeClass('offline')).toContain('text-[var(--text-dim)]')
+    expect(runtimeBadgeClass('offline')).toContain('text-[var(--color-fg-disabled)]')
   })
 })
 
 describe('stageBadgeClass', () => {
   it('returns accent classes for tool_use', () => {
-    expect(stageBadgeClass('tool_use')).toContain('text-[var(--accent)]')
+    expect(stageBadgeClass('tool_use')).toContain('text-[var(--color-accent-fg)]')
   })
 
   it('returns ok classes for thinking', () => {
-    expect(stageBadgeClass('thinking')).toContain('text-[var(--ok)]')
+    expect(stageBadgeClass('thinking')).toContain('text-[var(--color-status-ok)]')
   })
 
   it('returns ok classes for scheduled_autonomous', () => {
-    expect(stageBadgeClass('scheduled_autonomous')).toContain('text-[var(--ok)]')
+    expect(stageBadgeClass('scheduled_autonomous')).toContain('text-[var(--color-status-ok)]')
   })
 
   it('returns purple classes for handoff', () => {
@@ -84,11 +84,11 @@ describe('stageBadgeClass', () => {
   })
 
   it('returns bad classes for failing', () => {
-    expect(stageBadgeClass('failing')).toContain('text-[var(--bad)]')
+    expect(stageBadgeClass('failing')).toContain('text-[var(--color-status-err)]')
   })
 
   it('returns bad classes for crashed', () => {
-    expect(stageBadgeClass('crashed')).toContain('text-[var(--bad)]')
+    expect(stageBadgeClass('crashed')).toContain('text-[var(--color-status-err)]')
   })
 
   it('returns purple classes for paused stage', () => {
@@ -96,7 +96,7 @@ describe('stageBadgeClass', () => {
   })
 
   it('returns muted classes for unknown stage', () => {
-    expect(stageBadgeClass('idle')).toContain('text-[var(--text-muted)]')
+    expect(stageBadgeClass('idle')).toContain('text-[var(--color-fg-muted)]')
   })
 })
 

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -52,19 +52,19 @@ import {
 type StatusFilter = 'all' | RuntimeBand
 
 export function runtimeBadgeClass(band: RuntimeBand): string {
-  if (band === 'active') return 'border-[rgba(52,211,153,0.2)] bg-[rgba(52,211,153,0.12)] text-[var(--ok)]'
-  if (band === 'attention') return 'border-[var(--warn-20)] bg-[rgba(251,191,36,0.12)] text-[var(--warn)]'
+  if (band === 'active') return 'border-[rgba(52,211,153,0.2)] bg-[rgba(52,211,153,0.12)] text-[var(--color-status-ok)]'
+  if (band === 'attention') return 'border-[var(--warn-20)] bg-[rgba(251,191,36,0.12)] text-[var(--color-status-warn)]'
   if (band === 'paused') return 'border-[rgba(167,139,250,0.2)] bg-[var(--purple-12)] text-[var(--purple)]'
-  return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--text-dim)]'
+  return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--color-fg-disabled)]'
 }
 
 export function stageBadgeClass(stageKey: string): string {
-  if (stageKey === 'tool_use') return 'border-[rgba(71,184,255,0.24)] bg-[var(--accent-12)] text-[var(--accent)]'
-  if (stageKey === 'scheduled_autonomous' || stageKey === 'thinking') return 'border-[rgba(52,211,153,0.22)] bg-[rgba(52,211,153,0.1)] text-[var(--ok)]'
+  if (stageKey === 'tool_use') return 'border-[rgba(71,184,255,0.24)] bg-[var(--accent-12)] text-[var(--color-accent-fg)]'
+  if (stageKey === 'scheduled_autonomous' || stageKey === 'thinking') return 'border-[rgba(52,211,153,0.22)] bg-[rgba(52,211,153,0.1)] text-[var(--color-status-ok)]'
   if (stageKey === 'handoff' || stageKey === 'compacting') return 'border-[var(--purple-24)] bg-[var(--purple-12)] text-[#c4b5fd]'
-  if (stageKey === 'failing' || stageKey === 'crashed') return 'border-[rgba(239,68,68,0.24)] bg-[var(--bad-12)] text-[var(--bad)]'
+  if (stageKey === 'failing' || stageKey === 'crashed') return 'border-[rgba(239,68,68,0.24)] bg-[var(--bad-12)] text-[var(--color-status-err)]'
   if (stageKey === 'paused') return 'border-[var(--purple-24)] bg-[var(--purple-12)] text-[var(--purple)]'
-  return 'border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]'
+  return 'border-[var(--white-8)] bg-[var(--white-3)] text-[var(--color-fg-muted)]'
 }
 
 export function compactModelLabel(model: string | null | undefined): string | null {
@@ -575,16 +575,16 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
             <div class="flex min-w-0 flex-col gap-2">
               <div class="flex flex-wrap items-center gap-3">
-                <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">디렉터리 필터</span>
-                <span class="inline-flex items-center rounded-sm border border-[var(--border-slate-22)] bg-[var(--accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--text-strong)]">${resultCountLabel}</span>
+                <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">디렉터리 필터</span>
+                <span class="inline-flex items-center rounded-sm border border-[var(--border-slate-22)] bg-[var(--accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]">${resultCountLabel}</span>
               </div>
-              <p class="m-0 max-w-180 text-sm leading-loose text-[var(--text-body)]">${pageDescription}</p>
+              <p class="m-0 max-w-180 text-sm leading-loose text-[var(--color-fg-primary)]">${pageDescription}</p>
             </div>
 
-            <label class="flex w-full flex-col gap-2 text-2xs font-semibold tracking-1 text-[var(--text-muted)] uppercase">
+            <label class="flex w-full flex-col gap-2 text-2xs font-semibold tracking-1 text-[var(--color-fg-muted)] uppercase">
               <span>이름 / model / 작업</span>
               <${TextInput}
-                class="rounded bg-[var(--white-3)] px-4 py-3 text-base text-[var(--text-body)] shadow-[inset_0_1px_0_var(--white-3)] focus:border-[var(--accent)] focus:shadow-[0_0_0_2px_var(--accent-soft)]"
+                class="rounded bg-[var(--white-3)] px-4 py-3 text-base text-[var(--color-fg-primary)] shadow-[inset_0_1px_0_var(--white-3)] focus:border-[var(--color-accent-fg)] focus:shadow-[0_0_0_2px_var(--accent-soft)]"
                 name="agent_search"
                 ariaLabel="에이전트 이름 · 모델 · 작업 검색"
                 autoComplete="off"
@@ -598,8 +598,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           <div class="monitor-muted-panel p-3.5 md:p-4">
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div class="flex flex-col gap-1">
-                <div class="text-2xs font-semibold tracking-1 text-[var(--text-strong)] uppercase">운영 상태</div>
-                <p class="m-0 text-xs leading-normal text-[var(--text-muted)]">live runtime 신호로 먼저 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.</p>
+                <div class="text-2xs font-semibold tracking-1 text-[var(--color-fg-secondary)] uppercase">운영 상태</div>
+                <p class="m-0 text-xs leading-normal text-[var(--color-fg-muted)]">live runtime 신호로 먼저 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.</p>
               </div>
               <${FilterChips}
                 chips=${statusChips}
@@ -616,11 +616,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 <div class="rounded border ${executionError.value ? 'border-[rgba(251,191,36,0.28)] bg-[var(--warn-10)]' : 'border-[var(--accent-20)] bg-[var(--accent-10)]'} px-4 py-3 shadow-[0_10px_28px_rgba(0,0,0,0.12)]">
                   <div class="flex flex-col gap-2">
                     <div class="flex flex-wrap items-center gap-2">
-                      <strong class="text-xs font-semibold text-[var(--text-strong)]">${fallbackStateTitle}</strong>
-                      <span class="inline-flex items-center rounded-sm border border-[var(--white-10)] bg-[var(--white-6)] px-2 py-0.5 text-3xs font-medium text-[var(--text-muted)]">${countSourceLabel}</span>
+                      <strong class="text-xs font-semibold text-[var(--color-fg-secondary)]">${fallbackStateTitle}</strong>
+                      <span class="inline-flex items-center rounded-sm border border-[var(--white-10)] bg-[var(--white-6)] px-2 py-0.5 text-3xs font-medium text-[var(--color-fg-muted)]">${countSourceLabel}</span>
                     </div>
-                    <p class="m-0 text-xs leading-paragraph text-[var(--text-body)]">${fallbackStateMessage}</p>
-                    <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--text-muted)]">
+                    <p class="m-0 text-xs leading-paragraph text-[var(--color-fg-primary)]">${fallbackStateMessage}</p>
+                    <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
                       <span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">scope ${namespaceName}</span>
                       ${configuredKeeperHint ? html`<span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">${configuredKeeperHint}</span>` : null}
                     </div>
@@ -725,9 +725,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
                   <div class="min-w-0 flex-1 py-0.5">
                     <div class="flex flex-wrap items-center gap-2">
-                      <strong class="min-w-0 overflow-hidden text-[17px] font-semibold leading-[1.3] text-[var(--text-strong)] transition-colors group-hover:text-[var(--accent)] [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [overflow-wrap:anywhere]">${displayName}</strong>
+                      <strong class="min-w-0 overflow-hidden text-[17px] font-semibold leading-[1.3] text-[var(--color-fg-secondary)] transition-colors group-hover:text-[var(--color-accent-fg)] [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [overflow-wrap:anywhere]">${displayName}</strong>
                       ${agent.synthetic ? html`
-                        <span class="inline-flex items-center rounded-sm border border-dashed border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-3xs italic text-[var(--text-muted)]" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">
+                        <span class="inline-flex items-center rounded-sm border border-dashed border-[var(--color-border-default)] bg-[var(--white-6)] px-2 py-0.5 text-3xs italic text-[var(--color-fg-muted)]" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">
                           파생
                         </span>
                       ` : null}
@@ -740,19 +740,19 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 </div>
               </div>
 
-              <p class="m-0 text-sm leading-paragraph text-[var(--text-body)] break-words line-clamp-2" title=${summaryText}>${summaryText}</p>
+              <p class="m-0 text-sm leading-paragraph text-[var(--color-fg-primary)] break-words line-clamp-2" title=${summaryText}>${summaryText}</p>
 
               ${stateNote ? html`
-                <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--text-muted)]">
-                  <span class="inline-flex items-center rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5 text-3xs font-semibold text-[var(--warn)]">
+                <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
+                  <span class="inline-flex items-center rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-status-warn)]">
                     ${stateNote.label}
                   </span>
                   ${lastActivityAt
-                    ? html`<span class="text-3xs text-[var(--text-muted)]">최근 신호 · ${lastActivityLabel} <${TimeAgo} timestamp=${lastActivityAt} /></span>`
+                    ? html`<span class="text-3xs text-[var(--color-fg-muted)]">최근 신호 · ${lastActivityLabel} <${TimeAgo} timestamp=${lastActivityAt} /></span>`
                     : lastActivityAge != null
-                      ? html`<span class="text-3xs text-[var(--text-muted)]">최근 신호 · ${lastActivityLabel} ${formatDuration(lastActivityAge)} 전</span>`
+                      ? html`<span class="text-3xs text-[var(--color-fg-muted)]">최근 신호 · ${lastActivityLabel} ${formatDuration(lastActivityAge)} 전</span>`
                     : null}
-                  <span class="min-w-0 flex-1 text-xs leading-relaxed text-[var(--text-body)] break-words line-clamp-2" title=${stateNote.text}>
+                  <span class="min-w-0 flex-1 text-xs leading-relaxed text-[var(--color-fg-primary)] break-words line-clamp-2" title=${stateNote.text}>
                     ${stateNote.text}
                   </span>
                 </div>
@@ -773,10 +773,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 </div>
               ` : null}
 
-              <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--text-muted)]">
+              <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
                 <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
                   ${lastActivityLabel}
-                  <span class="ml-1 text-[var(--text-body)]">
+                  <span class="ml-1 text-[var(--color-fg-primary)]">
                     ${lastActivityAt
                       ? html`<${TimeAgo} timestamp=${lastActivityAt} />`
                       : lastActivityAge != null
@@ -787,28 +787,28 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 ${isKeeper && contextMeta ? html`
                   <span class="inline-flex items-center gap-1.5 rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
                     <span>CTX</span>
-                    <span class="font-mono font-medium ${contextMeta.pct > 85 ? 'text-[var(--bad)]' : contextMeta.pct > 60 ? 'text-[var(--warn)]' : 'text-[var(--text-strong)]'}">${contextMeta.pct}%</span>
+                    <span class="font-mono font-medium ${contextMeta.pct > 85 ? 'text-[var(--color-status-err)]' : contextMeta.pct > 60 ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-fg-secondary)]'}">${contextMeta.pct}%</span>
                     ${contextMeta.detail ? html`
-                      <span class="font-mono text-3xs text-[var(--text-muted)]">${contextMeta.detail}</span>
+                      <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${contextMeta.detail}</span>
                     ` : null}
                     <span class="inline-block h-1.5 w-12 overflow-hidden rounded-sm bg-[var(--white-6)]">
-                      <span class="block h-full rounded-sm ${contextMeta.pct > 85 ? 'bg-[var(--bad)]' : contextMeta.pct > 60 ? 'bg-[var(--warn)]' : 'bg-[var(--ok)]'}" style="width:${contextMeta.pct}%"></span>
+                      <span class="block h-full rounded-sm ${contextMeta.pct > 85 ? 'bg-[var(--color-status-err)]' : contextMeta.pct > 60 ? 'bg-[var(--color-status-warn)]' : 'bg-[var(--color-status-ok)]'}" style="width:${contextMeta.pct}%"></span>
                     </span>
                   </span>
                 ` : null}
                 ${modelMeta && modelDisplay ? html`
                   <span class="inline-flex items-center gap-1.5 rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
                     <span>${modelMeta.label}</span>
-                    <span class="max-w-[18rem] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-3xs text-[var(--text-body)]" translate="no" title=${modelMeta.value}>${modelDisplay}</span>
+                    <span class="max-w-[18rem] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-3xs text-[var(--color-fg-primary)]" translate="no" title=${modelMeta.value}>${modelDisplay}</span>
                   </span>
                 ` : null}
               </div>
 
               ${(primaryTool || toolCallCount != null || toolAuditAt) ? html`
-                <div class="flex flex-wrap items-center gap-1.5 text-2xs text-[var(--text-muted)]">
+                <div class="flex flex-wrap items-center gap-1.5 text-2xs text-[var(--color-fg-muted)]">
                   <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5">최근 도구</span>
                   ${primaryTool ? html`
-                    <span class="inline-flex items-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 font-mono text-3xs text-[var(--text-body)]" translate="no">
+                    <span class="inline-flex items-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 font-mono text-3xs text-[var(--color-fg-primary)]" translate="no">
                       ${primaryTool}
                     </span>
                   ` : null}

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -92,13 +92,13 @@ export function AgentsUnified() {
       />
 
       ${currentView !== 'fsm' ? html`
-        <div class="monitor-muted-panel flex flex-wrap items-center gap-2 px-4 py-3 text-xs text-[var(--text-muted)]">
-          <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">이 화면 밖</span>
+        <div class="monitor-muted-panel flex flex-wrap items-center gap-2 px-4 py-3 text-xs text-[var(--color-fg-muted)]">
+          <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">이 화면 밖</span>
           <span>cached 조율 스냅샷, 이벤트 로그, 도구 품질, 거버넌스</span>
           <${RouteLink}
             tab="monitoring"
             params=${{ section: 'fleet-health' }}
-            class="inline-flex shrink-0 items-center justify-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-1.5 text-xs font-medium text-[var(--text-strong)] transition-colors hover:bg-[var(--accent-20)]"
+            class="inline-flex shrink-0 items-center justify-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-1.5 text-xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--accent-20)]"
           >
             플릿 텔레메트리 열기
           <//>

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -47,17 +47,17 @@ function outcomeLabel(a: Attribution): string {
 
 function outcomeToneClass(kind: Attribution['outcome']['kind']): string {
   switch (kind) {
-    case 'passed': return 'text-[var(--ok)]'
+    case 'passed': return 'text-[var(--color-status-ok)]'
     case 'policy_failed': return 'text-[var(--bad-light)]'
     case 'transition_blocked': return 'text-[var(--bad-light)]'
-    case 'partial_pass': return 'text-[var(--warn)]'
+    case 'partial_pass': return 'text-[var(--color-status-warn)]'
   }
 }
 
 function originBadgeClass(origin: Attribution['origin']): string {
   return origin === 'det'
-    ? 'bg-[var(--accent-10)]0/20 text-[var(--accent)] border border-[var(--accent-20)]0/40'
-    : 'bg-[var(--accent-10)]0/20 text-[var(--accent)] border border-[var(--accent-20)]0/40'
+    ? 'bg-[var(--accent-10)]0/20 text-[var(--color-accent-fg)] border border-[var(--accent-20)]0/40'
+    : 'bg-[var(--accent-10)]0/20 text-[var(--color-accent-fg)] border border-[var(--accent-20)]0/40'
 }
 
 function formatTs(recordedAt: number): string {
@@ -140,11 +140,11 @@ function GateCard({
         <div class="flex flex-col gap-2">
           <div class="flex items-baseline justify-between">
             <span class="text-xs font-semibold tracking-tight">${gate}</span>
-            <span class="text-3xs text-[var(--text-muted)]">${total}건</span>
+            <span class="text-3xs text-[var(--color-fg-muted)]">${total}건</span>
           </div>
           <div class="grid grid-cols-2 gap-1 text-2xs">
-            <span class="text-[var(--ok)]">✓ ${passed}</span>
-            <span class="text-[var(--warn)]">◐ ${partial}</span>
+            <span class="text-[var(--color-status-ok)]">✓ ${passed}</span>
+            <span class="text-[var(--color-status-warn)]">◐ ${partial}</span>
             <span class="text-[var(--bad-light)]">✗ ${policyFailed}</span>
             <span class="text-[var(--bad-light)]">⊘ ${blocked}</span>
           </div>
@@ -170,10 +170,10 @@ function EventRow({
   return html`
     <button
       type="button"
-      class="w-full text-left px-3 py-2 border-b border-[var(--card-border)] flex items-center gap-3 text-xs ${rowBg}"
+      class="w-full text-left px-3 py-2 border-b border-[var(--color-border-default)] flex items-center gap-3 text-xs ${rowBg}"
       onClick=${onSelect}
     >
-      <span class="text-2xs font-mono text-[var(--text-muted)] w-20 shrink-0">
+      <span class="text-2xs font-mono text-[var(--color-fg-muted)] w-20 shrink-0">
         ${formatTs(event.recorded_at)}
       </span>
       <span class="text-3xs px-1.5 py-0.5 rounded ${originBadgeClass(a.origin)} shrink-0">
@@ -183,7 +183,7 @@ function EventRow({
       <span class="${outcomeToneClass(a.outcome.kind)} shrink-0 w-20">
         ${outcomeLabel(a)}
       </span>
-      <span class="text-[var(--text-muted)] truncate grow min-w-0">
+      <span class="text-[var(--color-fg-muted)] truncate grow min-w-0">
         ${reasonText ? highlightMatch(reasonText, query) : '—'}
       </span>
     </button>
@@ -204,7 +204,7 @@ function EvidenceDetail({ event }: { event: AttributionEvent | null }) {
     <${SurfaceCard} variant="compact">
       <div class="flex flex-col gap-3">
         <div class="flex items-baseline gap-3 flex-wrap">
-          <span class="text-2xs text-[var(--text-muted)]">${formatTs(event.recorded_at)}</span>
+          <span class="text-2xs text-[var(--color-fg-muted)]">${formatTs(event.recorded_at)}</span>
           <span class="font-mono text-sm font-semibold">${a.gate}</span>
           <span class="text-3xs px-1.5 py-0.5 rounded ${originBadgeClass(a.origin)}">
             ${a.origin}
@@ -214,7 +214,7 @@ function EvidenceDetail({ event }: { event: AttributionEvent | null }) {
           </span>
         </div>
         ${reasonOf(a)
-          ? html`<div class="text-xs text-[var(--text-muted)]">${reasonOf(a)}</div>`
+          ? html`<div class="text-xs text-[var(--color-fg-muted)]">${reasonOf(a)}</div>`
           : null}
         <pre class="text-2xs font-mono bg-[var(--white-5)]/30 rounded p-3 overflow-x-auto max-h-64 whitespace-pre-wrap">${evidenceJson}</pre>
       </div>
@@ -294,10 +294,10 @@ export function AttributionPanel() {
   return html`
     <div class="flex flex-col gap-4">
       <div class="flex flex-col gap-1">
-        <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+        <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
           Attribution — gate chain 관찰
         </div>
-        <p class="m-0 text-xs leading-paragraph text-[var(--text-muted)]">
+        <p class="m-0 text-xs leading-paragraph text-[var(--color-fg-muted)]">
           각 gate의 결과 카운트 + 최근 ${RECENT_LIMIT}건 이벤트. 5초마다 자동 갱신.
         </p>
       </div>
@@ -318,7 +318,7 @@ export function AttributionPanel() {
       <div class="flex items-center justify-between gap-2 flex-wrap">
         ${filterGate.value
           ? html`
-            <div class="text-2xs text-[var(--text-muted)]">
+            <div class="text-2xs text-[var(--color-fg-muted)]">
               필터: <span class="font-mono text-[var(--text-primary)]">${filterGate.value}</span>
               <button
                 class="ml-2 underline"
@@ -337,14 +337,14 @@ export function AttributionPanel() {
             query.value = (e.target as HTMLInputElement).value
             selectedEventIdx.value = null
           }}
-          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--card-border)] bg-[var(--white-5)]/20 px-2 py-1 text-2xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50"
+          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--color-border-default)] bg-[var(--white-5)]/20 px-2 py-1 text-2xs text-[var(--text-primary)] placeholder:text-[var(--color-fg-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50"
         />
       </div>
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <${SurfaceCard} variant="light">
           <div class="flex flex-col">
-            <div class="px-3 py-2 border-b border-[var(--card-border)] text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+            <div class="px-3 py-2 border-b border-[var(--color-border-default)] text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
               최근 이벤트 (${isFiltering
                 ? `${visibleEvents.length}/${gateFiltered.length}`
                 : gateFiltered.length})

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -44,24 +44,24 @@ function authBadgeSummary(): {
 
   if (validated) {
     return {
-      dotColor: 'bg-[var(--ok)] shadow-[0_0_6px_rgba(74,222,128,0.6)]',
+      dotColor: 'bg-[var(--color-status-ok)] shadow-[0_0_6px_rgba(74,222,128,0.6)]',
       label: `검증됨 @${actor} · ${role}`,
     }
   }
   if (hasError) {
     return {
-      dotColor: 'bg-[var(--bad)] shadow-[0_0_6px_rgba(244,63,94,0.45)]',
+      dotColor: 'bg-[var(--color-status-err)] shadow-[0_0_6px_rgba(244,63,94,0.45)]',
       label: '인증 오류',
     }
   }
   if (remote) {
     return {
-      dotColor: 'bg-[var(--bad)]',
+      dotColor: 'bg-[var(--color-status-err)]',
       label: '미인증',
     }
   }
   return {
-    dotColor: 'bg-[var(--warn)]',
+    dotColor: 'bg-[var(--color-status-warn)]',
     label: '로컬',
   }
 }
@@ -131,8 +131,8 @@ function openPopover(): void {
 function AuthRow({ label, value }: { label: string; value: string }) {
   return html`
     <div class="contents">
-      <div class="text-[var(--text-muted)]">${label}</div>
-      <div class="text-[var(--text-body)] break-all">${value}</div>
+      <div class="text-[var(--color-fg-muted)]">${label}</div>
+      <div class="text-[var(--color-fg-primary)] break-all">${value}</div>
     </div>
   `
 }
@@ -143,7 +143,7 @@ export function AuthStatus() {
   return html`
     <div class="relative">
       <button type="button"
-        class="flex items-center gap-1.5 text-2xs py-1 px-2 rounded border border-solid border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[var(--white-8)] text-[var(--text-muted)]"
+        class="flex items-center gap-1.5 text-2xs py-1 px-2 rounded border border-solid border-[var(--color-border-default)] bg-[var(--white-4)] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[var(--white-8)] text-[var(--color-fg-muted)]"
         onClick=${() => { popoverOpen.value ? (popoverOpen.value = false) : openPopover() }}
         title="인증 상태"
       >
@@ -168,7 +168,7 @@ function AuthPopover() {
   const actorOverrideLocked = authenticated
 
   return html`
-    <div class="absolute right-0 top-full mt-1.5 w-80 rounded border border-[var(--card-border)] bg-[rgba(10,18,34,0.97)] shadow-sm backdrop-blur-sm p-3 z-50">
+    <div class="absolute right-0 top-full mt-1.5 w-80 rounded border border-[var(--color-border-default)] bg-[rgba(10,18,34,0.97)] shadow-sm backdrop-blur-sm p-3 z-50">
       <div class="flex flex-col gap-3">
         <div class="grid grid-cols-[auto,1fr] gap-x-2 gap-y-1 text-2xs">
           <${AuthRow} label="stored actor" value=${storedActor ? `@${storedActor}` : '-'} />
@@ -180,9 +180,9 @@ function AuthPopover() {
         </div>
 
         <div class="flex flex-col gap-2">
-          <div class="text-2xs text-[var(--text-muted)]">행위자 재정의</div>
+          <div class="text-2xs text-[var(--color-fg-muted)]">행위자 재정의</div>
           ${actorOverrideLocked ? html`
-            <div class="text-2xs text-[var(--text-muted)]">
+            <div class="text-2xs text-[var(--color-fg-muted)]">
               검증된 세션은 token owner를 단일 actor로 사용합니다. 로컬 actor override는 저장되더라도 요청 actor로 쓰이지 않습니다.
             </div>
           ` : null}
@@ -191,7 +191,7 @@ function AuthPopover() {
               type="text"
               placeholder="dashboard actor"
               aria-label="Dashboard actor"
-              class="min-w-0 flex-1 py-1.5 px-2 rounded text-2xs border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] placeholder-[var(--text-muted)] outline-none focus:border-[rgba(71,184,255,0.5)]"
+              class="min-w-0 flex-1 py-1.5 px-2 rounded text-2xs border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)] placeholder-[var(--color-fg-muted)] outline-none focus:border-[rgba(71,184,255,0.5)]"
               value=${actorInput.value}
               disabled=${actorOverrideLocked}
               onInput=${(e: Event) => { actorInput.value = (e.target as HTMLInputElement).value }}
@@ -200,7 +200,7 @@ function AuthPopover() {
               }}
             />
             <button type="button"
-              class="shrink-0 py-1.5 px-3 rounded text-2xs border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              class="shrink-0 py-1.5 px-3 rounded text-2xs border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               disabled=${actorOverrideLocked}
               onClick=${() => { void handleApplyActor() }}
             >적용</button>
@@ -208,7 +208,7 @@ function AuthPopover() {
         </div>
 
         <div class="flex flex-col gap-2">
-          <div class="text-2xs text-[var(--text-muted)]">
+          <div class="text-2xs text-[var(--color-fg-muted)]">
             ${authenticated
               ? 'Bearer token이 서버에서 검증되었습니다.'
               : 'Bearer token을 입력하면 원격 환경에서 mutation 작업을 검증할 수 있습니다.'}
@@ -224,13 +224,13 @@ function AuthPopover() {
                 type="password"
                 placeholder="Bearer token"
                 aria-label="Bearer token"
-                class="w-full py-1.5 px-2 rounded text-2xs border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] placeholder-[var(--text-muted)] outline-none focus:border-[rgba(71,184,255,0.5)]"
+                class="w-full py-1.5 px-2 rounded text-2xs border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)] placeholder-[var(--color-fg-muted)] outline-none focus:border-[rgba(71,184,255,0.5)]"
                 value=${tokenInput.value}
                 onInput=${(e: Event) => { tokenInput.value = (e.target as HTMLInputElement).value }}
                 onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') void handleSetToken() }}
               />
               <button type="button"
-                class="w-full py-1.5 px-3 rounded text-2xs border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
+                class="w-full py-1.5 px-3 rounded text-2xs border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
                 onClick=${() => { void handleSetToken() }}
               >토큰 설정</button>
             </div>
@@ -253,15 +253,15 @@ export function RemoteWarningBanner() {
         : '원격 접속이 감지되었습니다. Mutation 작업을 위해 검증된 Bearer token을 설정하세요.'
 
   return html`
-    <div class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[var(--warn-10)] border-b border-[var(--warn-20)] text-xs text-[var(--warn)]">
+    <div class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[var(--warn-10)] border-b border-[var(--warn-20)] text-xs text-[var(--color-status-warn)]">
       <span>${message}</span>
       <div class="flex items-center gap-2 shrink-0">
         <button type="button"
-          class="px-2 py-0.5 rounded text-2xs border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
+          class="px-2 py-0.5 rounded text-2xs border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
           onClick=${openPopover}
         >인증 열기</button>
         <button type="button"
-          class="text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer text-2xs transition-colors"
+          class="text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer text-2xs transition-colors"
           onClick=${() => { bannerDismissed.value = true }}
         >\u2715</button>
       </div>

--- a/dashboard/src/components/autoresearch-form.ts
+++ b/dashboard/src/components/autoresearch-form.ts
@@ -124,13 +124,13 @@ export function StartAutoresearchForm() {
       overlayClass="fixed inset-0 z-50 flex items-center justify-center bg-[var(--white-5)]/60 backdrop-blur-sm"
       panelClass="w-full max-w-lg mx-4 rounded border border-card-border bg-[var(--card-bg)] shadow-sm p-6"
     >
-      <h2 id="start-autoresearch-title" class="text-sm font-semibold text-[var(--text-strong)] mb-4">
+      <h2 id="start-autoresearch-title" class="text-sm font-semibold text-[var(--color-fg-secondary)] mb-4">
         새 오토리서치 루프
       </h2>
 
       <div class="flex flex-col gap-3">
         <label class="flex flex-col gap-1">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">목표 *</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] font-medium">목표 *</span>
           <${TextArea}
             value=${formGoal.value}
             placeholder="최적화 목표 (예: Reduce inference latency by optimizing hot path)"
@@ -141,7 +141,7 @@ export function StartAutoresearchForm() {
         </label>
 
         <label class="flex flex-col gap-1">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">메트릭 명령어 *</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] font-medium">메트릭 명령어 *</span>
           <${TextInput}
             value=${formMetricFn.value}
             placeholder="마지막 줄에 float를 출력하는 명령어 (예: python eval.py --metric accuracy)"
@@ -151,7 +151,7 @@ export function StartAutoresearchForm() {
         </label>
 
         <label class="flex flex-col gap-1">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">대상 파일 *</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] font-medium">대상 파일 *</span>
           <${TextInput}
             value=${formTargetFile.value}
             placeholder="수정할 파일 경로 (예: lib/optimizer.ml)"
@@ -161,7 +161,7 @@ export function StartAutoresearchForm() {
         </label>
 
         <button type="button"
-          class="self-start text-2xs text-[var(--text-muted)] hover:text-[var(--text-body)] transition-colors"
+          class="self-start text-2xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] transition-colors"
           onClick=${() => { formShowAdvanced.value = !formShowAdvanced.value }}
         >
           ${formShowAdvanced.value ? '고급 설정 접기 \u25B2' : '고급 설정 \u25BC'}
@@ -170,7 +170,7 @@ export function StartAutoresearchForm() {
         ${formShowAdvanced.value ? html`
           <div class="grid grid-cols-2 gap-3 border-t border-card-border pt-3">
             <label class="flex flex-col gap-1">
-              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">작업 디렉토리</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">작업 디렉토리</span>
               <${TextInput}
                 value=${formWorkdir.value}
                 placeholder="기본: 프로젝트 루트"
@@ -178,7 +178,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="flex flex-col gap-1">
-              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">모델</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">모델</span>
               <${TextInput}
                 value=${formModelModel.value}
                 placeholder="glm"
@@ -186,7 +186,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="flex flex-col gap-1">
-              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">최대 사이클</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">최대 사이클</span>
               <${TextInput}
                 type="number"
                 value=${formMaxCycles.value}
@@ -195,7 +195,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="flex flex-col gap-1">
-              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">사이클 타임아웃 (초)</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">사이클 타임아웃 (초)</span>
               <${TextInput}
                 type="number"
                 value=${formCycleTimeoutS.value}
@@ -204,7 +204,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="flex flex-col gap-1">
-              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">기준선 (baseline)</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">기준선 (baseline)</span>
               <${TextInput}
                 type="number"
                 value=${formBaseline.value}
@@ -213,7 +213,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="flex flex-col gap-1">
-              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">인내 (patience)</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">인내 (patience)</span>
               <${TextInput}
                 type="number"
                 value=${formPatience.value}
@@ -222,7 +222,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="col-span-2 flex flex-col gap-1">
-              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">빌드 검증 명령어</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">빌드 검증 명령어</span>
               <${TextInput}
                 value=${formBuildVerifyFn.value}
                 placeholder="선택 (예: dune build)"
@@ -233,14 +233,14 @@ export function StartAutoresearchForm() {
         ` : null}
 
         ${startFormError.value ? html`
-          <div class="px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--bad)] text-xs">
+          <div class="px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--color-status-err)] text-xs">
             ${startFormError.value}
           </div>
         ` : null}
 
         <div class="flex items-center justify-end gap-2 mt-2">
           <button type="button"
-            class="px-3 py-1.5 rounded text-xs font-medium border border-card-border text-[var(--text-muted)] hover:text-[var(--text-body)] transition-colors"
+            class="px-3 py-1.5 rounded text-xs font-medium border border-card-border text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] transition-colors"
             onClick=${closeStartForm}
             disabled=${startFormBusy.value}
           >
@@ -250,7 +250,7 @@ export function StartAutoresearchForm() {
             class="px-4 py-1.5 rounded text-xs font-semibold border transition-colors ${
               canSubmit.value
                 ? 'border-accent/60 bg-accent/15 text-accent hover:bg-accent/25'
-                : 'border-card-border bg-card/60 text-[var(--text-muted)] cursor-not-allowed opacity-50'
+                : 'border-card-border bg-card/60 text-[var(--color-fg-muted)] cursor-not-allowed opacity-50'
             }"
             disabled=${!canSubmit.value}
             onClick=${() => { void handleStartSubmit() }}

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -57,11 +57,11 @@ export function resetAutoresearchState(): void {
 
 function statusColor(status: string): string {
   switch (status) {
-    case 'running': return 'text-[var(--ok)]'
-    case 'completed': return 'text-[var(--accent)]'
-    case 'stopped': return 'text-[var(--warn)]'
-    case 'error': return 'text-[var(--bad)]'
-    default: return 'text-[var(--text-muted)]'
+    case 'running': return 'text-[var(--color-status-ok)]'
+    case 'completed': return 'text-[var(--color-accent-fg)]'
+    case 'stopped': return 'text-[var(--color-status-warn)]'
+    case 'error': return 'text-[var(--color-status-err)]'
+    default: return 'text-[var(--color-fg-muted)]'
   }
 }
 
@@ -111,9 +111,9 @@ function LoopSelector() {
   return html`
     <div class="flex flex-col gap-3">
       <div class="flex items-center gap-2">
-        <label class="text-2xs text-[var(--text-muted)] font-medium">실행자 필터</label>
+        <label class="text-2xs text-[var(--color-fg-muted)] font-medium">실행자 필터</label>
         <select
-          class="bg-card border border-card-border text-[var(--text-body)] text-xs rounded px-2 py-1 outline-none focus:border-accent"
+          class="bg-card border border-card-border text-[var(--color-fg-primary)] text-xs rounded px-2 py-1 outline-none focus:border-accent"
           value=${authorFilter.value}
           onChange=${(e: Event) => {
             const target = e.target as HTMLSelectElement
@@ -129,8 +129,8 @@ function LoopSelector() {
         ${loops.map(loop => {
           const isSelected = loop.loop_id === selectedLoopId.value
           const cls = isSelected
-            ? 'px-3 py-1.5 rounded text-xs font-medium border border-accent/60 bg-[var(--accent-10)] text-[var(--text-strong)] cursor-pointer'
-            : 'px-3 py-1.5 rounded text-xs font-medium border border-card-border bg-card/60 text-[var(--text-muted)] cursor-pointer hover:border-accent/30 transition-colors'
+            ? 'px-3 py-1.5 rounded text-xs font-medium border border-accent/60 bg-[var(--accent-10)] text-[var(--color-fg-secondary)] cursor-pointer'
+            : 'px-3 py-1.5 rounded text-xs font-medium border border-card-border bg-card/60 text-[var(--color-fg-muted)] cursor-pointer hover:border-accent/30 transition-colors'
           return html`
             <button type="button" key=${loop.loop_id} class=${cls} onClick=${() => selectLoop(loop.loop_id)}>
               <span class="${statusColor(loop.status)} mr-1">\u25CF</span>
@@ -140,7 +140,7 @@ function LoopSelector() {
             </button>
           `
         })}
-        ${loops.length === 0 ? html`<div class="text-[var(--text-muted)] text-xs py-1.5">선택된 실행자의 루프가 없습니다.</div>` : null}
+        ${loops.length === 0 ? html`<div class="text-[var(--color-fg-muted)] text-xs py-1.5">선택된 실행자의 루프가 없습니다.</div>` : null}
         ${hasMoreLoops.value ? html`
           <button type="button" 
             class="px-3 py-1.5 rounded text-xs font-medium border border-card-border bg-card/60 text-accent cursor-pointer hover:bg-[var(--accent-10)] hover:border-accent/40 transition-colors flex items-center gap-1" 
@@ -161,37 +161,37 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div class="flex flex-col gap-3">
         <div>
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-1">목표</div>
-          <div class="text-[var(--text-body)] text-sm leading-relaxed">${loop.goal}</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">목표</div>
+          <div class="text-[var(--color-fg-primary)] text-sm leading-relaxed">${loop.goal}</div>
         </div>
         <div class="grid grid-cols-2 gap-3">
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">상태</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">상태</div>
             <div class="text-sm font-medium ${statusColor(loop.status)}">${statusLabel(loop.status)}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">사이클</div>
-            <div class="text-[var(--text-strong)] text-sm font-mono">${loop.current_cycle} / ${loop.max_cycles}</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">사이클</div>
+            <div class="text-[var(--color-fg-secondary)] text-sm font-mono">${loop.current_cycle} / ${loop.max_cycles}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">경과 시간</div>
-            <div class="text-[var(--text-body)] text-sm font-mono">${formatElapsedCompact(loop.elapsed_s)}</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">경과 시간</div>
+            <div class="text-[var(--color-fg-primary)] text-sm font-mono">${formatElapsedCompact(loop.elapsed_s)}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">실행자</div>
-            <div class="text-[var(--text-body)] text-sm font-mono">${loop.author ?? '알 수 없음'}</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">실행자</div>
+            <div class="text-[var(--color-fg-primary)] text-sm font-mono">${loop.author ?? '알 수 없음'}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">모델</div>
-            <div class="text-[var(--text-body)] text-sm font-mono">${loop.model_model}</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">모델</div>
+            <div class="text-[var(--color-fg-primary)] text-sm font-mono">${loop.model_model}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">소스</div>
-            <div class="text-[var(--text-body)] text-sm">${liveLabel(loop)}</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">소스</div>
+            <div class="text-[var(--color-fg-primary)] text-sm">${liveLabel(loop)}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">최근 갱신</div>
-            <div class="text-[var(--text-body)] text-sm font-mono">${loop.updated_at != null ? formatTimestampKo(loop.updated_at) : '알 수 없음'}</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">최근 갱신</div>
+            <div class="text-[var(--color-fg-primary)] text-sm font-mono">${loop.updated_at != null ? formatTimestampKo(loop.updated_at) : '알 수 없음'}</div>
           </div>
         </div>
       </div>
@@ -199,21 +199,21 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
       <div class="flex flex-col gap-3">
         <div class="grid grid-cols-2 gap-3">
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">기준선</div>
-            <div class="text-[var(--text-body)] text-sm font-mono">${loop.baseline.toFixed(4)}</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">기준선</div>
+            <div class="text-[var(--color-fg-primary)] text-sm font-mono">${loop.baseline.toFixed(4)}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">최고 점수</div>
-            <div class="text-[var(--ok)] text-sm font-mono font-semibold">${loop.best_score.toFixed(4)}</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">최고 점수</div>
+            <div class="text-[var(--color-status-ok)] text-sm font-mono font-semibold">${loop.best_score.toFixed(4)}</div>
           </div>
         </div>
         <div>
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-1">유지 / 삭제</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">유지 / 삭제</div>
           <div class="flex items-center gap-2">
-            <span class="text-[var(--ok)] text-sm font-mono font-semibold">${loop.total_keeps}</span>
-            <span class="text-[var(--text-muted)] text-xs">/</span>
-            <span class="text-[var(--bad)] text-sm font-mono font-semibold">${loop.total_discards}</span>
-            <span class="text-[var(--text-muted)] text-xs ml-1">(${keepPct}% keep)</span>
+            <span class="text-[var(--color-status-ok)] text-sm font-mono font-semibold">${loop.total_keeps}</span>
+            <span class="text-[var(--color-fg-muted)] text-xs">/</span>
+            <span class="text-[var(--color-status-err)] text-sm font-mono font-semibold">${loop.total_discards}</span>
+            <span class="text-[var(--color-fg-muted)] text-xs ml-1">(${keepPct}% keep)</span>
           </div>
           ${totalCycles > 0 ? html`
             <div class="mt-1.5 h-2 rounded-sm bg-[var(--white-6)] overflow-hidden flex">
@@ -229,18 +229,18 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
           ` : null}
         </div>
         <div>
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">대상 파일</div>
-          <div class="text-[var(--text-body)] text-xs font-mono truncate" title=${loop.target_file}>${loop.target_file}</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">대상 파일</div>
+          <div class="text-[var(--color-fg-primary)] text-xs font-mono truncate" title=${loop.target_file}>${loop.target_file}</div>
         </div>
         <div>
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">메트릭</div>
-          <div class="text-[var(--text-body)] text-xs font-mono truncate" title=${loop.metric_fn}>${loop.metric_fn}</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">메트릭</div>
+          <div class="text-[var(--color-fg-primary)] text-xs font-mono truncate" title=${loop.metric_fn}>${loop.metric_fn}</div>
         </div>
       </div>
     </div>
 
     ${loop.error ? html`
-      <div class="mt-3 px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--bad)] text-xs">
+      <div class="mt-3 px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--color-status-err)] text-xs">
         ${loop.error}
       </div>
     ` : null}
@@ -268,16 +268,16 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
           placeholder="가설 / 판정 / # 필터"
           aria-label="사이클 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && visibleCycles.length === 0
-        ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${cycles.length} cycles)</div>`
+        ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${cycles.length} cycles)</div>`
         : html`
           <div class="overflow-x-auto overflow-y-auto max-h-100 custom-scrollbar rounded border border-[var(--white-6)] bg-[rgba(0,0,0,0.1)]">
             <table class="w-full text-xs">
               <thead>
-                <tr class="text-[var(--text-muted)] text-3xs uppercase tracking-wider border-b border-[var(--white-10)]">
+                <tr class="text-[var(--color-fg-muted)] text-3xs uppercase tracking-wider border-b border-[var(--white-10)]">
                   <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-left py-2.5 px-3 font-medium">#</th>
                   <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-left py-2.5 px-3 font-medium">가설</th>
                   <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-right py-2.5 px-3 font-medium">이전</th>
@@ -290,19 +290,19 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
               <tbody>
                 ${visibleCycles.map(c => html`
                   <tr key=${c.cycle} class="border-b border-[var(--white-5)] hover:bg-[var(--white-4)] transition-colors duration-150">
-                    <td class="py-2 px-3 font-mono text-[var(--text-muted)]">${c.cycle}</td>
-                    <td class="py-2 px-3 text-[var(--text-body)] max-w-50 truncate" title=${c.hypothesis}>${c.hypothesis}</td>
-                    <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_before.toFixed(4)}</td>
-                    <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_after.toFixed(4)}</td>
-                    <td class="py-2 px-3 text-right font-mono ${c.delta >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">${formatDelta(c.delta)}</td>
+                    <td class="py-2 px-3 font-mono text-[var(--color-fg-muted)]">${c.cycle}</td>
+                    <td class="py-2 px-3 text-[var(--color-fg-primary)] max-w-50 truncate" title=${c.hypothesis}>${c.hypothesis}</td>
+                    <td class="py-2 px-3 text-right font-mono text-[var(--color-fg-primary)]">${c.score_before.toFixed(4)}</td>
+                    <td class="py-2 px-3 text-right font-mono text-[var(--color-fg-primary)]">${c.score_after.toFixed(4)}</td>
+                    <td class="py-2 px-3 text-right font-mono ${c.delta >= 0 ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-err)]'}">${formatDelta(c.delta)}</td>
                     <td class="py-2 px-3 text-center">
                       <span class="px-1.5 py-0.5 rounded text-3xs font-semibold ${
                         c.decision === 'keep'
-                          ? 'bg-[var(--ok-soft)] text-[var(--ok)] border border-[var(--ok-20)]'
-                          : 'bg-[var(--bad-soft)] text-[var(--bad)] border border-[var(--bad-20)]'
+                          ? 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border border-[var(--ok-20)]'
+                          : 'bg-[var(--bad-soft)] text-[var(--color-status-err)] border border-[var(--bad-20)]'
                       }">${decisionLabel(c.decision)}</span>
                     </td>
-                    <td class="py-2 px-3 text-right text-[var(--text-muted)] font-mono">${formatTimestampKo(c.timestamp)}</td>
+                    <td class="py-2 px-3 text-right text-[var(--color-fg-muted)] font-mono">${formatTimestampKo(c.timestamp)}</td>
                   </tr>
                 `)}
               </tbody>
@@ -321,8 +321,8 @@ function InsightsList({ insights }: { insights: string[] }) {
   return html`
     <ul class="flex flex-col gap-1.5">
       ${insights.map((insight, i) => html`
-        <li key=${i} class="flex items-start gap-2 text-xs text-[var(--text-body)]">
-          <span class="text-[var(--text-muted)] mt-0.5 shrink-0">${i + 1}.</span>
+        <li key=${i} class="flex items-start gap-2 text-xs text-[var(--color-fg-primary)]">
+          <span class="text-[var(--color-fg-muted)] mt-0.5 shrink-0">${i + 1}.</span>
           <span class="leading-relaxed">${insight}</span>
         </li>
       `)}
@@ -336,7 +336,7 @@ function WarningsList({ warnings }: { warnings: string[] }) {
   return html`
     <div class="flex flex-col gap-1.5">
       ${warnings.map((w, i) => html`
-        <div key=${i} class="px-3 py-1.5 rounded bg-[var(--warn-10)] border border-[var(--warn-20)] text-[var(--warn)] text-xs">
+        <div key=${i} class="px-3 py-1.5 rounded bg-[var(--warn-10)] border border-[var(--warn-20)] text-[var(--color-status-warn)] text-xs">
           ${w}
         </div>
       `)}
@@ -351,44 +351,44 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
     <${SurfaceCard} variant="compact">
       <div class="flex flex-col gap-3">
         <div>
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-1 font-medium">연구 브리프</div>
-          <div class="text-sm leading-paragraph text-[var(--text-body)]">
-            이 루프는 <span class="font-semibold text-[var(--text-strong)]">${loop.goal}</span> 를 목표로
-            <span class="font-mono text-[var(--text-strong)]"> ${loop.target_file} </span>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-1 font-medium">연구 브리프</div>
+          <div class="text-sm leading-paragraph text-[var(--color-fg-primary)]">
+            이 루프는 <span class="font-semibold text-[var(--color-fg-secondary)]">${loop.goal}</span> 를 목표로
+            <span class="font-mono text-[var(--color-fg-secondary)]"> ${loop.target_file} </span>
             변경을 시도하고,
-            <span class="font-mono text-[var(--text-strong)]"> ${loop.metric_fn} </span>
+            <span class="font-mono text-[var(--color-fg-secondary)]"> ${loop.metric_fn} </span>
             결과로 keep/discard를 반복합니다.
           </div>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">무엇을 연구하나</div>
-            <div class="leading-relaxed text-[var(--text-body)]">${loop.goal}</div>
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">무엇을 연구하나</div>
+            <div class="leading-relaxed text-[var(--color-fg-primary)]">${loop.goal}</div>
           </div>
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">무엇으로 성공을 보나</div>
-            <div class="font-mono text-[var(--text-body)]">${loop.metric_fn}</div>
-            <div class="mt-1 text-[var(--text-dim)]">baseline ${loop.baseline.toFixed(4)} -> best ${loop.best_score.toFixed(4)}</div>
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">무엇으로 성공을 보나</div>
+            <div class="font-mono text-[var(--color-fg-primary)]">${loop.metric_fn}</div>
+            <div class="mt-1 text-[var(--color-fg-disabled)]">baseline ${loop.baseline.toFixed(4)} -> best ${loop.best_score.toFixed(4)}</div>
           </div>
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">연결된 실행 컨텍스트</div>
-            <div class="flex flex-col gap-1 text-[var(--text-body)]">
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">연결된 실행 컨텍스트</div>
+            <div class="flex flex-col gap-1 text-[var(--color-fg-primary)]">
               <span>session ${loop.session_id ?? '없음'}</span>
               <span>operation ${loop.operation_id ?? '없음'}</span>
               <span>linked ${linkedAt}</span>
             </div>
           </div>
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">현재 가설 / 메모</div>
-            <div class="flex flex-col gap-1 text-[var(--text-body)] leading-relaxed">
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">현재 가설 / 메모</div>
+            <div class="flex flex-col gap-1 text-[var(--color-fg-primary)] leading-relaxed">
               <span>${loop.queued_hypothesis ?? '대기 가설 없음'}</span>
-              <span class="text-[var(--text-dim)]">${loop.program_note ?? 'program note 없음'}</span>
+              <span class="text-[var(--color-fg-disabled)]">${loop.program_note ?? 'program note 없음'}</span>
             </div>
           </div>
         </div>
 
-        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-xs leading-normal text-[var(--text-muted)]">
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-xs leading-normal text-[var(--color-fg-muted)]">
           이 화면은 generator loop 자체를 설명합니다. Safety Harness는 evaluator와 장기 실행 safety rail을 보여주며,
           각 cycle의 keep/discard 판정을 직접 대체하지 않습니다.
         </div>
@@ -402,22 +402,22 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
     <${SurfaceCard} variant="compact">
       <div class="grid grid-cols-1 gap-3 md:grid-cols-[1.3fr_1fr]">
         <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">실험 결과</div>
-          <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">이 화면은 keep/discard 루프를 봅니다.</div>
-          <div class="mt-2 text-sm leading-loose text-[var(--text-body)]">
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">실험 결과</div>
+          <div class="mt-1 text-sm font-medium text-[var(--color-fg-secondary)]">이 화면은 keep/discard 루프를 봅니다.</div>
+          <div class="mt-2 text-sm leading-loose text-[var(--color-fg-primary)]">
             어떤 파일을 바꾸고 어떤 metric을 밀어 올리려는지, 그리고 현재 ${loopCount}개 루프가 어떤 cycle에 있는지 직접 봅니다.
           </div>
         </div>
 
         <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-3">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">안전 하네스</div>
-          <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">심판 기계의 건강도는 별도로 봅니다.</div>
-          <div class="mt-2 text-sm leading-loose text-[var(--text-body)]">
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">안전 하네스</div>
+          <div class="mt-1 text-sm font-medium text-[var(--color-fg-secondary)]">심판 기계의 건강도는 별도로 봅니다.</div>
+          <div class="mt-2 text-sm leading-loose text-[var(--color-fg-primary)]">
             평가 모델, 압축 전 상태, 세대 교체 rail 상태는 하네스에서 봅니다.
           </div>
           <button
             type="button"
-            class="mt-3 rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
+            class="mt-3 rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--color-fg-primary)]"
             onClick=${() => navigate('lab', { section: 'harness' })}
           >하네스 열기</button>
         </div>
@@ -442,7 +442,7 @@ function LoopDetailView() {
 
   if (detailError.value) {
     return html`
-      <div class="px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--bad)] text-xs">
+      <div class="px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--color-status-err)] text-xs">
         ${detailError.value}
       </div>
     `
@@ -459,12 +459,12 @@ function LoopDetailView() {
 
       <${SurfaceCard} variant="compact">
         <div class="flex items-start justify-between gap-3 mb-3">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">루프 개요</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] font-medium">루프 개요</div>
           ${canRepairErrorLoop ? html`
             <div class="flex items-center gap-2">
               <button
                 type="button"
-                class="px-2.5 py-1 rounded text-2xs text-[var(--text-body)] border border-card-border hover:border-accent/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                class="px-2.5 py-1 rounded text-2xs text-[var(--color-fg-primary)] border border-card-border hover:border-accent/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled=${loopActionBusy.value}
                 onClick=${() => { void retrySelectedLoop() }}
               >
@@ -472,7 +472,7 @@ function LoopDetailView() {
               </button>
               <button
                 type="button"
-                class="px-2.5 py-1 rounded text-2xs text-[var(--bad)] border border-[var(--bad-30)] hover:border-[var(--bad)] opacity-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                class="px-2.5 py-1 rounded text-2xs text-[var(--color-status-err)] border border-[var(--bad-30)] hover:border-[var(--color-status-err)] opacity-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled=${loopActionBusy.value}
                 onClick=${() => { void deleteSelectedLoop() }}
               >
@@ -483,7 +483,7 @@ function LoopDetailView() {
         </div>
         <${LoopOverview} loop=${loop} />
         ${loopActionError.value ? html`
-          <div class="mt-3 px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--bad)] text-xs">
+          <div class="mt-3 px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--color-status-err)] text-xs">
             ${loopActionError.value}
           </div>
         ` : null}
@@ -491,14 +491,14 @@ function LoopDetailView() {
 
       ${warnings.length > 0 ? html`
         <${SurfaceCard} variant="compact">
-          <div class="text-3xs uppercase tracking-wider text-[var(--warn)]/80 mb-3 font-medium">경고</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-status-warn)]/80 mb-3 font-medium">경고</div>
           <${WarningsList} warnings=${warnings} />
         <//>
       ` : null}
 
       <${SurfaceCard} variant="compact">
         <div class="flex items-center justify-between mb-3">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] font-medium">
             사이클 이력 ${detail ? `(${detail.history_count}건)` : ''}
           </div>
         </div>
@@ -506,7 +506,7 @@ function LoopDetailView() {
       <//>
 
       <${SurfaceCard} variant="compact">
-        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-3 font-medium">인사이트</div>
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-3 font-medium">인사이트</div>
         <${InsightsList} insights=${insights} />
       <//>
     </div>
@@ -530,11 +530,11 @@ export function Autoresearch() {
   if (state.status === 'error') {
     return html`
       <div class="flex flex-col gap-4">
-        <div class="px-4 py-3 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--bad)] text-sm">
+        <div class="px-4 py-3 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--color-status-err)] text-sm">
           ${state.message}
         </div>
         <button type="button"
-          class="self-start px-3 py-1.5 rounded text-xs font-medium border border-card-border text-[var(--text-muted)] hover:text-[var(--text-body)] hover:border-accent/40 transition-colors"
+          class="self-start px-3 py-1.5 rounded text-xs font-medium border border-card-border text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] hover:border-accent/40 transition-colors"
           onClick=${() => loadLoops()}
         >
           다시 시도
@@ -563,7 +563,7 @@ export function Autoresearch() {
       <${OutcomeVsHarnessCallout} loopCount=${loops.length} />
 
       <div class="flex items-center justify-between">
-        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] font-medium">
           전체 ${loops.length}개 루프
         </div>
         <div class="flex items-center gap-2">
@@ -571,12 +571,12 @@ export function Autoresearch() {
             class="px-2.5 py-1 rounded text-2xs text-accent border border-accent/40 hover:bg-[var(--accent-10)] transition-colors"
           />
           <a href="/api/v1/autoresearch/loops/csv" download="autoresearch_loops.csv"
-            class="px-2.5 py-1 rounded text-2xs text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors no-underline"
+            class="px-2.5 py-1 rounded text-2xs text-[var(--color-fg-muted)] border border-card-border hover:text-[var(--color-fg-primary)] hover:border-accent/40 transition-colors no-underline"
           >
             CSV 다운로드
           </a>
           <button type="button"
-            class="px-2.5 py-1 rounded text-2xs text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors"
+            class="px-2.5 py-1 rounded text-2xs text-[var(--color-fg-muted)] border border-card-border hover:text-[var(--color-fg-primary)] hover:border-accent/40 transition-colors"
             onClick=${() => { void refreshAutoresearchSurface() }}
           >
             새로고침

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -315,8 +315,8 @@ export function keepersWithUnknownCanonical(
 function KeeperChip({ row }: { row: KeeperCascadeRow }) {
   const base = 'rounded border px-2 py-0.5 text-xs flex items-center gap-1'
   const borderTone = row.drift
-    ? 'border-[var(--warn)] text-[var(--text-strong)]'
-    : 'border-[var(--card-border)] text-[var(--text-strong)]'
+    ? 'border-[var(--color-status-warn)] text-[var(--color-fg-secondary)]'
+    : 'border-[var(--color-border-default)] text-[var(--color-fg-secondary)]'
   return html`
     <span
       class=${`${base} ${borderTone}`}
@@ -326,7 +326,7 @@ function KeeperChip({ row }: { row: KeeperCascadeRow }) {
     >
       <span class="font-semibold">${row.keeper}</span>
       ${row.drift
-        ? html`<code class="text-3xs text-[var(--text-muted)]">${row.raw_cascade_name}</code>`
+        ? html`<code class="text-3xs text-[var(--color-fg-muted)]">${row.raw_cascade_name}</code>`
         : null}
     </span>
   `
@@ -371,16 +371,16 @@ function ProfileCard({
   }
 
   return html`
-    <article class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] p-3">
+    <article class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] p-3">
       <header class="flex items-center gap-2 mb-2 flex-wrap">
-        <span class="font-semibold text-[var(--text-strong)]">${profile.name}</span>
+        <span class="font-semibold text-[var(--color-fg-secondary)]">${profile.name}</span>
         <${StatusChip} tone=${sourceTone(profile.source)}>
           ${sourceLabel(profile.source)}
         <//>
         ${!profile.keeper_assignable
           ? html`<${StatusChip} tone="neutral" uppercase=${false}>manual/system-only<//>`
           : null}
-        <span class="text-xs text-[var(--text-muted)]">
+        <span class="text-xs text-[var(--color-fg-muted)]">
           ${profileSummaryText(profile, keepers)}
         </span>
         ${driftCount > 0
@@ -388,7 +388,7 @@ function ProfileCard({
           : null}
       </header>
       ${assignmentNote
-        ? html`<div class="text-xs text-[var(--text-muted)] mb-2">${assignmentNote}</div>`
+        ? html`<div class="text-xs text-[var(--color-fg-muted)] mb-2">${assignmentNote}</div>`
         : null}
       ${keepers.length > 0
         ? html`
@@ -400,12 +400,12 @@ function ProfileCard({
       ${profile.keeper_assignable
         ? html`
           <form
-            class="rounded border border-[var(--card-border)] bg-[var(--bg-panel)] p-2 mb-3"
+            class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2 mb-3"
             onSubmit=${handleAssignKeeper}
           >
             <div class="flex items-center gap-2 flex-wrap mb-2">
-              <span class="text-xs font-medium text-[var(--text-strong)]">Keeper assignment</span>
-              <span class="text-xs text-[var(--text-muted)]">
+              <span class="text-xs font-medium text-[var(--color-fg-secondary)]">Keeper assignment</span>
+              <span class="text-xs text-[var(--color-fg-muted)]">
                 current profile로 keeper를 이동합니다.
               </span>
             </div>
@@ -413,7 +413,7 @@ function ProfileCard({
               ? html`
                 <div class="flex items-center gap-2 flex-wrap">
                   <select
-                    class="min-w-44 rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
+                    class="min-w-44 rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)]"
                     value=${selectedKeeper.value}
                     disabled=${assigning.value}
                     onChange=${(event: Event) => {
@@ -435,7 +435,7 @@ function ProfileCard({
                 </div>
               `
               : html`
-                <div class="text-xs text-[var(--text-muted)]">
+                <div class="text-xs text-[var(--color-fg-muted)]">
                   currently known keepers are already assigned to this profile.
                 </div>
               `}
@@ -445,7 +445,7 @@ function ProfileCard({
                   class=${`mt-2 text-xs ${
                     assignmentMessage.value.startsWith('Failed')
                       ? 'text-[var(--bad-light)]'
-                      : 'text-[var(--text-muted)]'
+                      : 'text-[var(--color-fg-muted)]'
                   }`}
                 >
                   ${assignmentMessage.value}
@@ -456,7 +456,7 @@ function ProfileCard({
         `
         : null}
       ${profile.candidates.length === 0
-        ? html`<div class="text-xs text-[var(--text-muted)]">no candidates resolved</div>`
+        ? html`<div class="text-xs text-[var(--color-fg-muted)]">no candidates resolved</div>`
         : html`
           <ol class="flex flex-col gap-1 text-xs">
             ${profile.candidates.map((c, idx) => {
@@ -465,27 +465,27 @@ function ProfileCard({
               const displayProvider = c.display_provider_name ?? c.provider_name ?? null
               const runtimeLabel = runtimeKindLabel(c.runtime_kind)
               return html`
-              <li class="flex items-start gap-2 py-1 border-b border-[var(--card-border)] last:border-b-0">
-                <span class="tabular-nums text-[var(--text-muted)] w-5">${idx + 1}.</span>
+              <li class="flex items-start gap-2 py-1 border-b border-[var(--color-border-default)] last:border-b-0">
+                <span class="tabular-nums text-[var(--color-fg-muted)] w-5">${idx + 1}.</span>
                 <${StatusChip} tone=${candidateTone(c)}>
                   ${c.in_cooldown ? 'cooldown' : fmtPct(c.success_rate)}
                 <//>
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-2 flex-wrap">
-                    <code class="text-[var(--text-strong)]">${displayModel}</code>
+                    <code class="text-[var(--color-fg-secondary)]">${displayModel}</code>
                     ${displayProvider
-                      ? html`<span class="text-[var(--text-muted)]">${displayProvider}</span>`
+                      ? html`<span class="text-[var(--color-fg-muted)]">${displayProvider}</span>`
                       : null}
                     ${runtimeLabel
-                      ? html`<span class="text-[var(--text-muted)]">${runtimeLabel}</span>`
+                      ? html`<span class="text-[var(--color-fg-muted)]">${runtimeLabel}</span>`
                       : null}
                   </div>
                   ${c.model !== displayModel
-                    ? html`<div class="text-[11px] text-[var(--text-muted)] mt-0.5">config: <code>${c.model}</code></div>`
+                    ? html`<div class="text-[11px] text-[var(--color-fg-muted)] mt-0.5">config: <code>${c.model}</code></div>`
                     : null}
                   ${expanded.length > 1
                     ? html`
-                      <ol class="mt-1 flex flex-col gap-0.5 text-[11px] text-[var(--text-muted)]">
+                      <ol class="mt-1 flex flex-col gap-0.5 text-[11px] text-[var(--color-fg-muted)]">
                         ${expanded.map((model, expandedIdx) => html`
                           <li><span class="tabular-nums">${expandedIdx + 1}.</span> <code>${model}</code></li>
                         `)}
@@ -493,7 +493,7 @@ function ProfileCard({
                     `
                     : null}
                 </div>
-                <span class="tabular-nums text-[var(--text-muted)]">
+                <span class="tabular-nums text-[var(--color-fg-muted)]">
                   w ${c.config_weight}${c.effective_weight === c.config_weight ? '' : ` → ${c.effective_weight}`}
                 </span>
               </li>
@@ -507,20 +507,20 @@ function ProfileCard({
 function OrphanKeeperList({ orphans }: { orphans: readonly CascadeKeeperProfile[] }) {
   if (orphans.length === 0) return null
   return html`
-    <div class="rounded border border-[var(--warn)] bg-[var(--bg-0)] p-3 text-xs">
-      <div class="font-semibold text-[var(--text-strong)] mb-1">
+    <div class="rounded border border-[var(--color-status-warn)] bg-[var(--bg-0)] p-3 text-xs">
+      <div class="font-semibold text-[var(--color-fg-secondary)] mb-1">
         등록된 프로필 없음 (${orphans.length})
       </div>
-      <div class="text-[var(--text-muted)] mb-2">
+      <div class="text-[var(--color-fg-muted)] mb-2">
         아래 keeper 는 canonical cascade 가 현재 profile 목록에 없어 해당 cascade 로 라우팅할 수 없습니다.
       </div>
       <ul class="flex flex-col gap-1">
         ${orphans.map(o => html`
           <li class="flex gap-2">
-            <span class="font-semibold text-[var(--text-strong)]">${o.keeper}</span>
+            <span class="font-semibold text-[var(--color-fg-secondary)]">${o.keeper}</span>
             <code>${o.cascade_name}</code>
-            <span class="text-[var(--text-muted)]">→</span>
-            <code class="text-[var(--warn)]">${o.canonical}</code>
+            <span class="text-[var(--color-fg-muted)]">→</span>
+            <code class="text-[var(--color-status-warn)]">${o.canonical}</code>
           </li>
         `)}
       </ul>
@@ -535,10 +535,10 @@ function InvalidProfileSummary({
   const extraErrors = Math.max(0, invalidProfile.errors.length - 1)
   return html`
     <li class="flex flex-wrap items-start gap-2">
-      <code class="text-[var(--text-strong)]">${invalidProfile.name}</code>
-      <span class="text-[var(--text-muted)]">${firstError}</span>
+      <code class="text-[var(--color-fg-secondary)]">${invalidProfile.name}</code>
+      <span class="text-[var(--color-fg-muted)]">${firstError}</span>
       ${extraErrors > 0
-        ? html`<span class="text-[var(--text-muted)]">+${extraErrors} more</span>`
+        ? html`<span class="text-[var(--color-fg-muted)]">+${extraErrors} more</span>`
         : null}
     </li>
   `
@@ -548,33 +548,33 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
   if (config.validation_status === 'validated') return null
   const tone = validationTone(config.validation_status)
   const boxTone = tone === 'bad'
-    ? 'border-[var(--bad)]/40 bg-[var(--bad)]/10'
-    : 'border-[var(--warn)]/40 bg-[var(--warn)]/10'
+    ? 'border-[var(--color-status-err)]/40 bg-[var(--color-status-err)]/10'
+    : 'border-[var(--color-status-warn)]/40 bg-[var(--color-status-warn)]/10'
   const visibleErrors = config.validation_errors.slice(0, 3)
   const visibleProfiles = config.invalid_profiles.slice(0, 4)
   return html`
     <div class=${`rounded border ${boxTone} p-3 text-xs mb-3`}>
       <div class="flex items-center gap-2 flex-wrap mb-2">
         <${StatusChip} tone=${tone}>${validationLabel(config.validation_status)}<//>
-        <span class="text-[var(--text-muted)]">
+        <span class="text-[var(--color-fg-muted)]">
           ${config.invalid_profiles.length} invalid profile${config.invalid_profiles.length === 1 ? '' : 's'}
           · ${config.validation_errors.length} error${config.validation_errors.length === 1 ? '' : 's'}
         </span>
       </div>
-      <div class="text-[var(--text-strong)] mb-2">
+      <div class="text-[var(--color-fg-secondary)] mb-2">
         ${validationDescription(config.validation_status)}
       </div>
       ${visibleErrors.length > 0
         ? html`
-          <ul class="flex flex-col gap-1 mb-2 text-[var(--text-muted)]">
+          <ul class="flex flex-col gap-1 mb-2 text-[var(--color-fg-muted)]">
             ${visibleErrors.map(error => html`<li>${error}</li>`)}
           </ul>
         `
         : null}
       ${visibleProfiles.length > 0
         ? html`
-          <div class="text-[var(--text-strong)] mb-1">거부된 프로파일</div>
-          <ul class="flex flex-col gap-1 text-[var(--text-muted)]">
+          <div class="text-[var(--color-fg-secondary)] mb-1">거부된 프로파일</div>
+          <ul class="flex flex-col gap-1 text-[var(--color-fg-muted)]">
             ${visibleProfiles.map(invalidProfile => html`
               <${InvalidProfileSummary} invalidProfile=${invalidProfile} />
             `)}
@@ -583,7 +583,7 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
         : null}
       ${config.invalid_profiles.length > visibleProfiles.length
         ? html`
-          <div class="mt-2 text-[var(--text-muted)]">
+          <div class="mt-2 text-[var(--color-fg-muted)]">
             + ${config.invalid_profiles.length - visibleProfiles.length} more invalid profiles
           </div>
         `
@@ -680,9 +680,9 @@ export function filterHealthProviders(
 }
 
 const TONE_DOT: Record<string, string> = {
-  ok: 'bg-[var(--ok)]',
-  warn: 'bg-[var(--warn)]',
-  bad: 'bg-[var(--bad)]',
+  ok: 'bg-[var(--color-status-ok)]',
+  warn: 'bg-[var(--color-status-warn)]',
+  bad: 'bg-[var(--color-status-err)]',
 }
 
 function HealthTable({
@@ -705,15 +705,15 @@ function HealthTable({
         onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
       />
       ${isFiltering
-        ? html`<span class="text-xs text-[var(--text-muted)]">${filtered.length}/${health.providers.length}건</span>`
+        ? html`<span class="text-xs text-[var(--color-fg-muted)]">${filtered.length}/${health.providers.length}건</span>`
         : null}
     </div>
     ${isFiltering && filtered.length === 0
-      ? html`<div class="py-4 text-center text-2xs text-[var(--text-muted)]">필터 결과 없음 (${health.providers.length} providers)</div>`
+      ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-muted)]">필터 결과 없음 (${health.providers.length} providers)</div>`
       : html`
         <table class="w-full text-xs">
           <thead>
-            <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+            <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
               <th class="text-left py-1 w-4"></th>
               <th class="text-left py-1">제공자</th>
               <th
@@ -754,26 +754,26 @@ function HealthTable({
               // too old to carry the field — don't decorate in that case.
               const orphaned = p.declared === false
               return html`
-              <tr class="border-b border-[var(--card-border)] last:border-b-0">
+              <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
                 <td class="py-1"><span class=${`inline-block w-2 h-2 rounded-full ${TONE_DOT[tone]}`}></span></td>
                 <td class="py-1">
-                  <code class="text-[var(--text-strong)]">${p.provider_key}</code>
+                  <code class="text-[var(--color-fg-secondary)]">${p.provider_key}</code>
                   ${orphaned
-                    ? html`<span class="ml-1 text-2xs text-[var(--warn)]" title="Provider was tracked but is no longer declared in cascade.json">orphan</span>`
+                    ? html`<span class="ml-1 text-2xs text-[var(--color-status-warn)]" title="Provider was tracked but is no longer declared in cascade.json">orphan</span>`
                     : null}
                 </td>
                 <td class="py-1">
                   ${status
                     ? html`<${StatusChip} tone=${providerStatusTone(status)} uppercase=${false}>${status}<//>`
-                    : html`<span class="text-[var(--text-muted)]">—</span>`}
+                    : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
                 </td>
                 <td class="py-1 text-right tabular-nums">${fmtPct(p.success_rate)}</td>
                 <td class="py-1 text-right tabular-nums">${p.consecutive_failures}</td>
                 <td class="py-1 text-right tabular-nums">${p.events_in_window}</td>
                 <td class="py-1 text-right tabular-nums">
                   ${rejected > 0
-                    ? html`<span class="text-[var(--warn)]">${rejected}</span>`
-                    : html`<span class="text-[var(--text-muted)]">—</span>`}
+                    ? html`<span class="text-[var(--color-status-warn)]">${rejected}</span>`
+                    : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
                 </td>
                 <td class="py-1 text-right tabular-nums">${fmtPerfTokPerSec(p.avg_prompt_tok_per_sec)}</td>
                 <td class="py-1 text-right tabular-nums">${fmtPerfTokPerSec(p.avg_decode_tok_per_sec)}</td>
@@ -781,7 +781,7 @@ function HealthTable({
                 <td class="py-1 text-right">
                   ${p.in_cooldown
                     ? html`<${StatusChip} tone="bad">${fmtCooldownExpiry(p.cooldown_expires_at)}<//>`
-                    : html`<span class="text-[var(--text-muted)]">—</span>`}
+                    : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
                 </td>
               </tr>
             `})}
@@ -890,7 +890,7 @@ function SloCard({ slo }: { slo: CascadeSloResponse }) {
     <div class="flex flex-col gap-3">
       <div class="flex items-center gap-2 flex-wrap">
         <${StatusChip} tone=${tone}>${sloStatusLabel(slo.status)}<//>
-        <span class="text-xs text-[var(--text-muted)]">sample ${totalEvents}/${slo.window_sample_size}</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">sample ${totalEvents}/${slo.window_sample_size}</span>
         ${slo.violations.length > 0
           ? html`<span class="text-xs text-[var(--bad-light)]">violating: ${slo.violations.join(', ')}</span>`
           : null}
@@ -928,10 +928,10 @@ function StrategyTraceTable({
     ? trace.events.filter(e => traceEventMatchesSearch(e, query))
     : trace.events
   return html`
-    ${query ? html`<div class="text-xs text-[var(--text-muted)] mb-2">${filtered.length}/${trace.events.length}건</div>` : null}
+    ${query ? html`<div class="text-xs text-[var(--color-fg-muted)] mb-2">${filtered.length}/${trace.events.length}건</div>` : null}
     <table class="w-full text-xs">
       <thead>
-        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+        <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
           <th class="text-left py-1 w-20">시간</th>
           <th class="text-left py-1">캐스케이드</th>
           <th class="text-left py-1">전략</th>
@@ -945,10 +945,10 @@ function StrategyTraceTable({
         ${filtered.map((e: CascadeStrategyTraceEvent) => {
           const tone = traceKindTone(e.kind)
           return html`
-          <tr class="border-b border-[var(--card-border)] last:border-b-0">
-            <td class="py-1 text-[var(--text-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
-            <td class="py-1"><code class="text-[var(--text-strong)]">${e.cascade_name}</code></td>
-            <td class="py-1 text-[var(--text-muted)]">${e.strategy}</td>
+          <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
+            <td class="py-1 text-[var(--color-fg-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
+            <td class="py-1"><code class="text-[var(--color-fg-secondary)]">${e.cascade_name}</code></td>
+            <td class="py-1 text-[var(--color-fg-muted)]">${e.strategy}</td>
             <td class="py-1 text-right tabular-nums">${e.cycle}</td>
             <td class="py-1 text-right tabular-nums">${e.candidates_in}/${e.candidates_out}</td>
             <td class="py-1 text-right tabular-nums">${e.backoff_ms > 0 ? e.backoff_ms : '–'}</td>
@@ -969,7 +969,7 @@ function ClientCapacityHistoryTable({
   return html`
     <table class="w-full text-xs">
       <thead>
-        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+        <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
           <th class="text-left py-1 w-20">시간</th>
           <th class="text-left py-1">종류</th>
           <th class="text-left py-1">키</th>
@@ -980,10 +980,10 @@ function ClientCapacityHistoryTable({
         ${history.events.map((e: CascadeClientCapacityHistoryEvent) => {
           const tone = eventKindTone(e.kind)
           return html`
-          <tr class="border-b border-[var(--card-border)] last:border-b-0">
-            <td class="py-1 text-[var(--text-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
+          <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
+            <td class="py-1 text-[var(--color-fg-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
             <td class="py-1"><${StatusChip} tone=${tone}>${eventKindLabel(e.kind)}<//></td>
-            <td class="py-1"><code class="text-[var(--text-strong)]">${e.key}</code></td>
+            <td class="py-1"><code class="text-[var(--color-fg-secondary)]">${e.key}</code></td>
             <td class="py-1 text-right tabular-nums">${e.active_after}</td>
           </tr>
         `})}
@@ -999,7 +999,7 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
   return html`
     <table class="w-full text-xs">
       <thead>
-        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+        <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
           <th class="text-left py-1 w-4"></th>
           <th class="text-left py-1">종류</th>
           <th class="text-left py-1">키</th>
@@ -1012,10 +1012,10 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
         ${capacity.entries.map((e: CascadeClientCapacityEntry) => {
           const tone = capacityTone(e)
           return html`
-          <tr class="border-b border-[var(--card-border)] last:border-b-0">
+          <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
             <td class="py-1"><span class=${`inline-block w-2 h-2 rounded-full ${TONE_DOT[tone]}`}></span></td>
             <td class="py-1"><${StatusChip} tone=${tone === 'ok' ? 'neutral' : tone}>${capacityKindLabel(e.kind)}<//></td>
-            <td class="py-1"><code class="text-[var(--text-strong)]">${e.key}</code></td>
+            <td class="py-1"><code class="text-[var(--color-fg-secondary)]">${e.key}</code></td>
             <td class="py-1 text-right tabular-nums">${e.active}</td>
             <td class="py-1 text-right tabular-nums">${e.available}</td>
             <td class="py-1 text-right tabular-nums">${e.total}</td>
@@ -1108,14 +1108,14 @@ function CascadeRawConfigEditor({
   return html`
     <${Card} title=${mode.title}>
       <div class="flex flex-col gap-3 p-4">
-        <p class="text-sm text-[var(--text-muted)]">${mode.primary}</p>
-        <p class="text-xs text-[var(--text-muted)]">
+        <p class="text-sm text-[var(--color-fg-muted)]">${mode.primary}</p>
+        <p class="text-xs text-[var(--color-fg-muted)]">
           ${mode.secondary}
         </p>
 
         <form class="flex flex-col gap-3" onSubmit=${handleSave}>
           <textarea
-            class="h-96 w-full rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
+            class="h-96 w-full rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-2 font-mono text-xs text-[var(--color-fg-secondary)]"
             spellcheck="false"
             readonly=${!sourceEditable}
             value=${editorText.value}
@@ -1127,13 +1127,13 @@ function CascadeRawConfigEditor({
           />
 
           <div class="flex items-center gap-3 flex-wrap text-xs">
-            <span class=${editorDirty.value ? 'text-[var(--warn)]' : 'text-[var(--text-muted)]'}>
+            <span class=${editorDirty.value ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-fg-muted)]'}>
               ${editorDirty.value ? 'unsaved changes' : 'in sync with disk'}
             </span>
             ${syntaxError
               ? html`<span class="text-[var(--bad-light)]">syntax: ${syntaxError}</span>`
               : html`
-                <span class="text-[var(--ok)]">
+                <span class="text-[var(--color-status-ok)]">
                   ${raw?.source_kind === 'toml' ? 'syntax: validated on save (TOML)' : 'syntax: valid JSON'}
                 </span>
               `}
@@ -1141,7 +1141,7 @@ function CascadeRawConfigEditor({
               ? html`
                 <span class=${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid')
                   ? 'text-[var(--bad-light)]'
-                  : 'text-[var(--text-muted)]'}
+                  : 'text-[var(--color-fg-muted)]'}
                 >
                   ${saveMessage.value}
                 </span>
@@ -1159,7 +1159,7 @@ function CascadeRawConfigEditor({
             </button>
             <button
               type="button"
-              class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
+              class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50"
               onClick=${handleReset}
               disabled=${saving.value || !editorDirty.value}
             >
@@ -1167,7 +1167,7 @@ function CascadeRawConfigEditor({
             </button>
             <button
               type="button"
-              class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
+              class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50"
               onClick=${() => void onRefresh()}
               disabled=${saving.value}
             >
@@ -1178,14 +1178,14 @@ function CascadeRawConfigEditor({
         ${mode.previewTitle
           ? html`
             <div class="flex flex-col gap-2">
-              <div class="text-xs font-medium text-[var(--text-strong)]">
+              <div class="text-xs font-medium text-[var(--color-fg-secondary)]">
                 ${mode.previewTitle}
               </div>
-              <div class="text-xs text-[var(--text-muted)]">
+              <div class="text-xs text-[var(--color-fg-muted)]">
                 ${raw?.config_path ?? 'unresolved'}
               </div>
               <textarea
-                class="h-72 w-full rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
+                class="h-72 w-full rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-2 font-mono text-xs text-[var(--color-fg-secondary)]"
                 spellcheck="false"
                 readonly
                 value=${raw?.raw_json ?? ''}
@@ -1223,14 +1223,14 @@ export function CascadeConfigPanel() {
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <button
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
           onClick=${() => void loadCascadeData(resource)}
         >
           새로고침
         </button>
-        ${current.loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
+        ${current.loading ? html`<span class="text-xs text-[var(--color-fg-muted)]">로딩 중...</span>` : null}
         ${config?.updated_at
-          ? html`<span class="text-xs text-[var(--text-muted)]">config · ${config.updated_at}</span>`
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">config · ${config.updated_at}</span>`
           : null}
       </div>
 

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -148,16 +148,16 @@ function ChatMessageBubble({
             ${isMessenger
               ? html`
                   <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span class="truncate text-xs font-semibold text-[var(--text-strong)]">
+                    <span class="truncate text-xs font-semibold text-[var(--color-fg-secondary)]">
                       ${avatarLabel(entry)}
                     </span>
                     ${timestamp
-                      ? html`<span class="text-2xs tabular-nums text-[var(--text-muted)]">${timestamp}</span>`
+                      ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]">${timestamp}</span>`
                       : null}
                     ${showDeliveryBadge(entry, variant)
                       ? html`
                           <span
-                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-0.5 text-3xs font-medium uppercase tracking-1 text-[var(--text-muted)]"
+                            class="inline-flex items-center rounded-sm border border-[var(--color-border-default)] bg-[var(--white-3)] px-2 py-0.5 text-3xs font-medium uppercase tracking-1 text-[var(--color-fg-muted)]"
                             data-chat-delivery=${delivery}
                           >
                             ${delivery}
@@ -176,7 +176,7 @@ function ChatMessageBubble({
                     ${showDeliveryBadge(entry, variant)
                       ? html`
                           <span
-                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-1 text-3xs font-medium uppercase tracking-2 text-[var(--text-muted)]"
+                            class="inline-flex items-center rounded-sm border border-[var(--color-border-default)] bg-[var(--white-3)] px-2.5 py-1 text-3xs font-medium uppercase tracking-2 text-[var(--color-fg-muted)]"
                             data-chat-delivery=${delivery}
                           >
                             ${delivery}
@@ -185,13 +185,13 @@ function ChatMessageBubble({
                       : null}
                     ${timestamp
                       ? html`
-                          <span class="inline-flex items-center rounded-sm border border-[var(--slate-gray-16)] bg-[var(--slate-gray-8)] px-2.5 py-1 text-3xs font-medium tabular-nums text-[var(--text-muted)]">
+                          <span class="inline-flex items-center rounded-sm border border-[var(--slate-gray-16)] bg-[var(--slate-gray-8)] px-2.5 py-1 text-3xs font-medium tabular-nums text-[var(--color-fg-muted)]">
                             ${timestamp}
                           </span>
                         `
                       : null}
                   </div>
-                  <div class="mt-2 truncate text-sm font-semibold text-[var(--text-strong)]">
+                  <div class="mt-2 truncate text-sm font-semibold text-[var(--color-fg-secondary)]">
                     ${avatarLabel(entry)}
                   </div>
                 `}
@@ -201,7 +201,7 @@ function ChatMessageBubble({
           ? html`
               <button
                 type="button"
-                class=${`border border-[var(--card-border)] bg-[var(--white-3)] text-2xs font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)] ${
+                class=${`border border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs font-medium text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--color-fg-primary)] ${
                   isMessenger ? 'rounded px-2.5 py-1' : 'rounded-sm px-3 py-1'
                 }`}
                 onClick=${() => { setExpandedRaw(!expandedRaw) }}
@@ -215,14 +215,14 @@ function ChatMessageBubble({
       ${showMetadata && detailItems.length > 0
         ? html`<div class=${`flex flex-wrap gap-1.5 ${isMessenger ? 'pt-0.5' : ''}`}>
             ${detailItems.map(item => html`
-              <span class="inline-flex items-center rounded-sm border border-[var(--accent-soft)] bg-[var(--accent-10)] px-2.5 py-1 text-3xs font-medium text-[var(--text-strong)]">
+              <span class="inline-flex items-center rounded-sm border border-[var(--accent-soft)] bg-[var(--accent-10)] px-2.5 py-1 text-3xs font-medium text-[var(--color-fg-secondary)]">
                 ${item}
               </span>
             `)}
           </div>`
         : null}
 
-      <div class="whitespace-pre-wrap break-words text-base leading-airy text-[var(--text-body)]">
+      <div class="whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)]">
         ${entry.text || (entry.delivery === 'streaming' ? '' : '(empty reply)')}
       </div>
       ${entry.error
@@ -241,8 +241,8 @@ function ChatMessageBubble({
                     <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                       ${overview.map(item => html`
                         <div class="rounded border border-[var(--slate-gray-12)] bg-[var(--white-3)] px-3 py-2.5">
-                          <div class="text-3xs font-semibold uppercase tracking-3 text-[var(--text-muted)]">${item.label}</div>
-                          <div class="mt-1 text-sm font-semibold text-[var(--text-strong)]">${item.value}</div>
+                          <div class="text-3xs font-semibold uppercase tracking-3 text-[var(--color-fg-muted)]">${item.label}</div>
+                          <div class="mt-1 text-sm font-semibold text-[var(--color-fg-secondary)]">${item.value}</div>
                         </div>
                       `)}
                     </div>
@@ -262,12 +262,12 @@ function ChatMessageBubble({
               ${state.length > 0
                 ? html`
                     <div class="flex flex-col gap-2">
-                      <div class="text-3xs font-semibold uppercase tracking-3 text-[var(--text-muted)]">상태 스냅샷</div>
+                      <div class="text-3xs font-semibold uppercase tracking-3 text-[var(--color-fg-muted)]">상태 스냅샷</div>
                       <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                         ${state.map(item => html`
                           <div class="rounded border border-[var(--accent-soft)] bg-[rgba(71,184,255,0.06)] px-3 py-2.5">
-                            <div class="text-3xs font-semibold uppercase tracking-2 text-[var(--accent)]">${item.label}</div>
-                            <div class="mt-1 text-xs leading-paragraph text-[var(--text-body)]">${item.value}</div>
+                            <div class="text-3xs font-semibold uppercase tracking-2 text-[var(--color-accent-fg)]">${item.label}</div>
+                            <div class="mt-1 text-xs leading-paragraph text-[var(--color-fg-primary)]">${item.value}</div>
                           </div>
                         `)}
                       </div>
@@ -279,7 +279,7 @@ function ChatMessageBubble({
                     <div class="flex flex-col gap-2">
                       <button
                         type="button"
-                        class="self-start rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1 text-2xs font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)]"
+                        class="self-start rounded-sm border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-1 text-2xs font-medium text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--color-fg-primary)]"
                         onClick=${() => { setRawExpandedRaw(!rawExpandedRaw) }}
                       >
                         ${rawExpanded ? '원본 숨기기' : '원본 보기'}
@@ -333,7 +333,7 @@ export function ChatTranscript({
       ${entries.length === 0
         ? html`
             <div class="flex min-h-55 flex-col items-center justify-center rounded-card border border-dashed border-[rgba(148,163,184,0.18)] bg-[var(--white-3)] px-6 text-center">
-              <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">직접 메시지 없음</div>
+              <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--color-fg-muted)]">직접 메시지 없음</div>
               <div class="mt-3 max-w-[34rem] text-sm leading-airy text-[var(--text-secondary)]">${emptyText}</div>
             </div>
           `
@@ -382,8 +382,8 @@ export function ChatComposer({
   return html`
     <div class="chat-composer flex flex-col gap-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--text-muted)]">메시지</div>
-        <div class="text-2xs text-[var(--text-muted)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
+        <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">메시지</div>
+        <div class="text-2xs text-[var(--color-fg-muted)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
       </div>
       <textarea
         class="control-textarea min-h-24 rounded-card border border-[var(--slate-gray-16)] bg-[var(--white-3)] px-3 py-3 text-base leading-loose"
@@ -401,7 +401,7 @@ export function ChatComposer({
         disabled=${disabled}
       ></textarea>
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="text-2xs leading-paragraph text-[var(--text-muted)]">
+        <div class="text-2xs leading-paragraph text-[var(--color-fg-muted)]">
           ${streaming
             ? '키퍼 응답 스트림이 활성 상태입니다. 멈춘 것 같으면 중지할 수 있습니다.'
             : '직접 메시지만 이 레인에 표시됩니다. 내부 키퍼 프롬프트는 숨겨집니다.'}

--- a/dashboard/src/components/common/badge.ts
+++ b/dashboard/src/components/common/badge.ts
@@ -7,11 +7,11 @@ import type { ComponentChildren } from 'preact'
 type BadgeTone = 'default' | 'warn' | 'ok' | 'bad' | 'accent'
 
 const TONE_CLASSES: Record<BadgeTone, string> = {
-  default: 'bg-[var(--white-8)] text-[var(--text-muted)]',
-  warn: 'bg-[var(--warn-12)] text-[var(--warn)]',
+  default: 'bg-[var(--white-8)] text-[var(--color-fg-muted)]',
+  warn: 'bg-[var(--warn-12)] text-[var(--color-status-warn)]',
   ok: 'bg-[var(--ok-10)] text-[var(--ok-20)]',
   bad: 'bg-[var(--bad-10)] text-[var(--bad-light)]',
-  accent: 'bg-[var(--accent-12)] text-[var(--accent)]',
+  accent: 'bg-[var(--accent-12)] text-[var(--color-accent-fg)]',
 }
 
 const BASE = 'inline-flex items-center text-3xs px-1.5 py-px rounded tabular-nums font-medium'

--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -23,10 +23,10 @@ const SIZE_CLASSES: Record<ButtonSize, string> = {
 }
 
 const VARIANT_CLASSES: Record<ButtonVariant, string> = {
-  primary: 'border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--text-strong)] hover:bg-[var(--accent-20)]',
-  ghost: 'border border-solid border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] hover:bg-[var(--white-8)]',
+  primary: 'border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--color-fg-secondary)] hover:bg-[var(--accent-20)]',
+  ghost: 'border border-solid border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)] hover:bg-[var(--white-8)]',
   danger: 'border border-solid border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-20)]',
-  subtle: 'border-none bg-transparent text-[var(--text-muted)] hover:text-[var(--text-body)] hover:bg-[var(--white-6)]',
+  subtle: 'border-none bg-transparent text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] hover:bg-[var(--white-6)]',
 }
 
 const BASE = 'rounded cursor-pointer transition-all duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] active:scale-[0.97] active:opacity-90'

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -1,5 +1,5 @@
 // SurfaceCard — reusable card container with Tailwind variants
-// Replaces 40+ inline `p-4 rounded border border-[var(--card-border)]` patterns
+// Replaces 40+ inline `p-4 rounded border border-[var(--color-border-default)]` patterns
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'

--- a/dashboard/src/components/common/checkbox.test.ts
+++ b/dashboard/src/components/common/checkbox.test.ts
@@ -109,6 +109,6 @@ describe('Checkbox', () => {
     const cn = container.querySelector('input')!.className
     // Accent + rounded are part of CHECKBOX_BASE; regression would strip them.
     expect(cn).toContain('rounded')
-    expect(cn).toContain('accent-[var(--accent)]')
+    expect(cn).toContain('accent-[var(--color-accent-fg)]')
   })
 })

--- a/dashboard/src/components/common/checkbox.ts
+++ b/dashboard/src/components/common/checkbox.ts
@@ -12,7 +12,7 @@
 
 import { html } from 'htm/preact'
 
-const CHECKBOX_BASE = 'w-4 h-4 rounded border border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer transition-colors hover:bg-[var(--white-8)] hover:border-[var(--white-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] accent-[var(--accent)]'
+const CHECKBOX_BASE = 'w-4 h-4 rounded border border-[var(--color-border-default)] bg-[var(--white-4)] cursor-pointer transition-colors hover:bg-[var(--white-8)] hover:border-[var(--white-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] accent-[var(--color-accent-fg)]'
 
 interface CheckboxProps {
   checked?: boolean

--- a/dashboard/src/components/common/collapsible.ts
+++ b/dashboard/src/components/common/collapsible.ts
@@ -1,5 +1,5 @@
 // CollapsibleSection — consistent expandable section
-// Replaces 5+ inline `<details class="rounded border border-[var(--card-border)] overflow-hidden">` patterns
+// Replaces 5+ inline `<details class="rounded border border-[var(--color-border-default)] overflow-hidden">` patterns
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
@@ -37,12 +37,12 @@ export function CollapsibleSection({
     <details
       open=${open}
       id=${id}
-      class="rounded border border-[var(--card-border)] overflow-hidden ${cx ?? ''}"
+      class="rounded border border-[var(--color-border-default)] overflow-hidden ${cx ?? ''}"
       onToggle=${(event: Event) => {
         if ((event.currentTarget as HTMLDetailsElement).open) setHasOpened(true)
       }}
     >
-      <summary class="flex items-center gap-2 px-4 py-3 cursor-pointer text-sm font-medium text-[var(--text-strong)] select-none hover:bg-[var(--white-3)] transition-colors list-none">
+      <summary class="flex items-center gap-2 px-4 py-3 cursor-pointer text-sm font-medium text-[var(--color-fg-secondary)] select-none hover:bg-[var(--white-3)] transition-colors list-none">
         ${title}
         ${badge ?? null}
       </summary>

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -168,16 +168,16 @@ export function CommandPalette() {
       placeholder="명령어 또는 에이전트/세션 검색... (⌘/Ctrl+K)"
       hideBreadcrumbs
       style="
-        --ninja-modal-background: var(--bg-panel);
+        --ninja-modal-background: var(--color-bg-surface);
         --ninja-modal-shadow: 0 24px 64px rgba(0,0,0,0.6);
-        --ninja-text-color: var(--text-body);
+        --ninja-text-color: var(--color-fg-primary);
         --ninja-secondary-background-color: var(--white-5);
-        --ninja-secondary-text-color: var(--text-muted);
+        --ninja-secondary-text-color: var(--color-fg-muted);
         --ninja-selected-background: var(--white-10);
-        --ninja-icon-color: var(--text-muted);
+        --ninja-icon-color: var(--color-fg-muted);
         --ninja-key-background: var(--white-10);
-        --ninja-key-text-color: var(--text-strong);
-        --ninja-border-bottom: 1px solid var(--border-base);
+        --ninja-key-text-color: var(--color-fg-secondary);
+        --ninja-border-bottom: 1px solid var(--color-border-default);
       "
     ></ninja-keys>
   `

--- a/dashboard/src/components/common/confirm-dialog.ts
+++ b/dashboard/src/components/common/confirm-dialog.ts
@@ -70,24 +70,24 @@ export function ConfirmDialogOverlay() {
 
   let iconColor = 'text-warn'
   let iconBg = 'bg-warn/10 border-warn/20'
-  let confirmBtnClass = 'bg-[var(--warn)] text-[var(--bg-0)] hover:bg-[var(--warn)]/90'
+  let confirmBtnClass = 'bg-[var(--color-status-warn)] text-[var(--bg-0)] hover:bg-[var(--color-status-warn)]/90'
   let IconComponent = AlertTriangle
 
   if (state.tone === 'danger') {
     iconColor = 'text-bad'
     iconBg = 'bg-bad/10 border-bad/20'
-    confirmBtnClass = 'bg-[var(--bad)] text-white hover:bg-[var(--bad)]/90'
+    confirmBtnClass = 'bg-[var(--color-status-err)] text-white hover:bg-[var(--color-status-err)]/90'
     IconComponent = AlertCircle
   } else if (state.tone === 'info') {
     iconColor = 'text-accent'
     iconBg = 'bg-[var(--accent-10)] border-accent/20'
-    confirmBtnClass = 'bg-[var(--accent)] text-[var(--bg-0)] hover:bg-[var(--accent)]/90'
+    confirmBtnClass = 'bg-[var(--color-accent-fg)] text-[var(--bg-0)] hover:bg-[var(--color-accent-fg)]/90'
     IconComponent = Info
   }
 
   return html`
     <div class="fixed inset-0 z-[100] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-4 animate-in fade-in duration-200" onClick=${handleClose}>
-      <div class="w-full max-w-100 bg-[rgba(13,21,38,0.98)] rounded-md border border-[var(--card-border)] shadow-[0_24px_64px_rgba(0,0,0,0.6)] overflow-hidden" onClick=${stopPropagation} role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
+      <div class="w-full max-w-100 bg-[rgba(13,21,38,0.98)] rounded-md border border-[var(--color-border-default)] shadow-[0_24px_64px_rgba(0,0,0,0.6)] overflow-hidden" onClick=${stopPropagation} role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
         <div class="p-5">
           <div class="flex items-start gap-4">
             <div class="shrink-0 size-10 rounded-sm border flex items-center justify-center ${iconBg} ${iconColor}">
@@ -100,7 +100,7 @@ export function ConfirmDialogOverlay() {
           </div>
           <div class="mt-6 flex items-center justify-end gap-2">
             <button type="button"
-              class="px-4 py-2 rounded text-sm font-medium border border-[var(--card-border)] bg-[var(--white-4)] text-text-body hover:bg-[var(--white-8)] transition-colors cursor-pointer"
+              class="px-4 py-2 rounded text-sm font-medium border border-[var(--color-border-default)] bg-[var(--white-4)] text-text-body hover:bg-[var(--white-8)] transition-colors cursor-pointer"
               onClick=${state.onCancel}
             >${state.cancelText}</button>
             <button type="button"

--- a/dashboard/src/components/common/copy-id-button.ts
+++ b/dashboard/src/components/common/copy-id-button.ts
@@ -33,7 +33,7 @@ export function CopyIdButton({ value, label, ariaLabel, size = 12 }: CopyIdButto
   return html`
     <button
       type="button"
-      class="inline-flex shrink-0 cursor-pointer items-center justify-center rounded p-0.5 text-[var(--text-dim)] opacity-60 transition-all hover:bg-[var(--white-8)] hover:text-[var(--text-body)] hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent-30)]"
+      class="inline-flex shrink-0 cursor-pointer items-center justify-center rounded p-0.5 text-[var(--color-fg-disabled)] opacity-60 transition-all hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)] hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent-30)]"
       aria-label=${ariaLabel || (label ? `Copy ${label}` : 'Copy')}
       title=${ariaLabel || (label ? `Copy ${label}` : 'Copy')}
       onClick=${onCopy}

--- a/dashboard/src/components/common/copyable-code.test.ts
+++ b/dashboard/src/components/common/copyable-code.test.ts
@@ -148,7 +148,7 @@ describe('CopyableCode', () => {
     expect(wrap.className).toContain('border-[var(--accent-30)]')
     expect(wrap.className).toContain('bg-[var(--accent-12)]')
     const label = wrap.querySelector('span')!
-    expect(label.className).toContain('text-[var(--accent)]')
+    expect(label.className).toContain('text-[var(--color-accent-fg)]')
     expect(label.className).toContain('font-semibold')
   })
 
@@ -185,13 +185,13 @@ describe('copyableWrapperClasses (pure)', () => {
 describe('copyableLabelClasses (pure)', () => {
   it('primary label uses accent color + font-semibold', () => {
     const cls = copyableLabelClasses('primary')
-    expect(cls).toContain('text-[var(--accent)]')
+    expect(cls).toContain('text-[var(--color-accent-fg)]')
     expect(cls).toContain('font-semibold')
   })
 
   it('secondary label uses muted text-dim + no bold', () => {
     const cls = copyableLabelClasses('secondary')
-    expect(cls).toContain('text-[var(--text-dim)]')
+    expect(cls).toContain('text-[var(--color-fg-disabled)]')
     expect(cls).not.toContain('font-semibold')
   })
 })

--- a/dashboard/src/components/common/copyable-code.ts
+++ b/dashboard/src/components/common/copyable-code.ts
@@ -69,8 +69,8 @@ export function copyableWrapperClasses(variant: CopyableVariant): string {
     at the left edge and starts leading the reader's eye into the command. */
 export function copyableLabelClasses(variant: CopyableVariant): string {
   return variant === 'primary'
-    ? 'shrink-0 text-3xs font-semibold uppercase tracking-4 text-[var(--accent)]'
-    : 'shrink-0 text-3xs uppercase tracking-4 text-[var(--text-dim)]'
+    ? 'shrink-0 text-3xs font-semibold uppercase tracking-4 text-[var(--color-accent-fg)]'
+    : 'shrink-0 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]'
 }
 
 export function CopyableCode({
@@ -108,13 +108,13 @@ export function CopyableCode({
       ${label
         ? html`<span class=${labelTone}>${label}</span>`
         : null}
-      <code class="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-2xs text-[var(--text-body)]">${command}</code>
+      <code class="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-2xs text-[var(--color-fg-primary)]">${command}</code>
       ${justCopied
-        ? html`<span class="shrink-0 text-3xs font-semibold text-[var(--ok)]" data-copied-badge aria-live="polite">✓ Copied</span>`
+        ? html`<span class="shrink-0 text-3xs font-semibold text-[var(--color-status-ok)]" data-copied-badge aria-live="polite">✓ Copied</span>`
         : null}
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded border border-transparent p-1 text-[var(--text-dim)] opacity-60 transition-opacity hover:bg-[var(--white-8)] hover:text-[var(--text-body)] focus-visible:opacity-100 group-hover:opacity-100"
+        class="shrink-0 cursor-pointer rounded border border-transparent p-1 text-[var(--color-fg-disabled)] opacity-60 transition-opacity hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)] focus-visible:opacity-100 group-hover:opacity-100"
         aria-label=${ariaLabel || (label ? `Copy ${label}` : 'Copy command')}
         data-copy-button
         onClick=${onCopy}

--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -34,18 +34,18 @@ const NODE_COLORS: Record<FsmNode['type'], { bg: string; border: string; text: s
   state:    { bg: 'var(--slate-800)', border: 'var(--slate-600)', text: 'var(--frost-100)' },
   active:   { bg: '#065f46', border: 'var(--emerald)', text: 'var(--white-pure)' },
   buffer:   { bg: '#78350f', border: 'var(--amber-bright)', text: 'var(--white-pure)' },
-  terminal: { bg: '#7f1d1d', border: 'var(--bad)', text: 'var(--white-pure)' },
+  terminal: { bg: '#7f1d1d', border: 'var(--color-status-err)', text: 'var(--white-pure)' },
   start:    { bg: 'var(--slate-800)', border: '#6366f1', text: '#c7d2fe' },
   end:      { bg: 'var(--slate-800)', border: '#6b7280', text: '#9ca3af' },
   ok:       { bg: '#065f46', border: 'var(--emerald)', text: 'var(--white-pure)' },
   warn:     { bg: '#78350f', border: 'var(--amber-bright)', text: 'var(--white-pure)' },
-  err:      { bg: '#7f1d1d', border: 'var(--bad)', text: 'var(--white-pure)' },
+  err:      { bg: '#7f1d1d', border: 'var(--color-status-err)', text: 'var(--white-pure)' },
   dim:      { bg: 'var(--slate-800)', border: '#374151', text: '#6b7280' },
 }
 
 const EDGE_COLORS: Record<string, string> = {
   normal: 'var(--slate-500)',
-  error: 'var(--bad)',
+  error: 'var(--color-status-err)',
   recovery: 'var(--emerald)',
   cascade: 'var(--amber-bright)',
 }
@@ -283,13 +283,13 @@ export function CytoscapeFsm({ spec, height = '280px', class: className = '' }: 
   }, [spec, loading])
 
   if (error) {
-    return html`<div class="text-2xs text-[var(--text-dim)]">${error}</div>`
+    return html`<div class="text-2xs text-[var(--color-fg-disabled)]">${error}</div>`
   }
 
   return html`
     <div class=${`relative rounded border border-[var(--white-8)] bg-[rgba(9,12,20,0.7)] overflow-hidden ${className}`.trim()}>
       ${loading ? html`
-        <div class="absolute inset-0 flex items-center justify-center text-2xs text-[var(--text-dim)]">
+        <div class="absolute inset-0 flex items-center justify-center text-2xs text-[var(--color-fg-disabled)]">
           <${InlineSpinner} class="mr-2" />
           그래프 로딩중
         </div>

--- a/dashboard/src/components/common/dashed-notice.test.ts
+++ b/dashboard/src/components/common/dashed-notice.test.ts
@@ -16,7 +16,7 @@ describe('dashedNoticeClasses (pure)', () => {
     const cls = dashedNoticeClasses()
     expect(cls).toContain('border-dashed')
     expect(cls).toContain('text-center')
-    expect(cls).toContain('text-[var(--text-dim)]')
+    expect(cls).toContain('text-[var(--color-fg-disabled)]')
   })
 
   it('sm size: 10px text + rounded + tight padding (matches fsm-hub timeline panels)', () => {
@@ -36,7 +36,7 @@ describe('dashedNoticeClasses (pure)', () => {
   })
 
   it('card border tone uses --card-border', () => {
-    expect(dashedNoticeClasses('sm', 'card')).toContain('border-[var(--card-border)]')
+    expect(dashedNoticeClasses('sm', 'card')).toContain('border-[var(--color-border-default)]')
   })
 
   it('subtle border tone uses --white-8 (dimmer)', () => {

--- a/dashboard/src/components/common/dashed-notice.ts
+++ b/dashboard/src/components/common/dashed-notice.ts
@@ -29,12 +29,12 @@ export function dashedNoticeClasses(
 ): string {
   const borderClass = border === 'subtle'
     ? 'border-[var(--white-8)]'
-    : 'border-[var(--card-border)]'
+    : 'border-[var(--color-border-default)]'
   const sized = size === 'md'
     ? 'rounded px-4 py-6 text-xs'
     : 'rounded px-4 py-2 text-3xs'
   const parts = [
-    'border border-dashed text-center text-[var(--text-dim)]',
+    'border border-dashed text-center text-[var(--color-fg-disabled)]',
     sized,
     borderClass,
   ]

--- a/dashboard/src/components/common/distribution-bars.test.ts
+++ b/dashboard/src/components/common/distribution-bars.test.ts
@@ -4,36 +4,36 @@ import { paletteFor } from './distribution-bars'
 describe('paletteFor', () => {
   it('returns accent palette by default', () => {
     const p = paletteFor(undefined)
-    expect(p.fill).toBe('var(--accent)')
-    expect(p.text).toBe('var(--accent)')
+    expect(p.fill).toBe('var(--color-accent-fg)')
+    expect(p.text).toBe('var(--color-accent-fg)')
   })
 
   it('returns ok palette', () => {
     const p = paletteFor('ok')
-    expect(p.fill).toBe('var(--ok)')
-    expect(p.text).toBe('var(--ok)')
+    expect(p.fill).toBe('var(--color-status-ok)')
+    expect(p.text).toBe('var(--color-status-ok)')
   })
 
   it('returns warn palette', () => {
     const p = paletteFor('warn')
-    expect(p.fill).toBe('var(--warn)')
+    expect(p.fill).toBe('var(--color-status-warn)')
     expect(p.chipBg).toContain('250,204,21')
   })
 
   it('returns bad palette', () => {
     const p = paletteFor('bad')
-    expect(p.fill).toBe('var(--bad)')
+    expect(p.fill).toBe('var(--color-status-err)')
     expect(p.chipBg).toContain('248,113,113')
   })
 
   it('returns muted palette', () => {
     const p = paletteFor('muted')
-    expect(p.text).toBe('var(--text-muted)')
+    expect(p.text).toBe('var(--color-fg-muted)')
   })
 
   it('returns accent palette for explicit accent', () => {
     const p = paletteFor('accent')
-    expect(p.fill).toBe('var(--accent)')
+    expect(p.fill).toBe('var(--color-accent-fg)')
     expect(p.chipBg).toContain('--accent-')
   })
 })

--- a/dashboard/src/components/common/distribution-bars.ts
+++ b/dashboard/src/components/common/distribution-bars.ts
@@ -18,32 +18,32 @@ interface TonePalette {
 
 const TONE_PALETTES: Record<DistributionTone, TonePalette> = {
   accent: {
-    fill: 'var(--accent)',
-    text: 'var(--accent)',
+    fill: 'var(--color-accent-fg)',
+    text: 'var(--color-accent-fg)',
     chipBg: 'var(--accent-12)',
     chipBorder: 'rgba(71,184,255,0.24)',
   },
   ok: {
-    fill: 'var(--ok)',
-    text: 'var(--ok)',
+    fill: 'var(--color-status-ok)',
+    text: 'var(--color-status-ok)',
     chipBg: 'var(--emerald-12)',
     chipBorder: 'rgba(34,197,94,0.24)',
   },
   warn: {
-    fill: 'var(--warn)',
-    text: 'var(--warn)',
+    fill: 'var(--color-status-warn)',
+    text: 'var(--color-status-warn)',
     chipBg: 'rgba(250,204,21,0.12)',
     chipBorder: 'rgba(250,204,21,0.24)',
   },
   bad: {
-    fill: 'var(--bad)',
-    text: 'var(--bad)',
+    fill: 'var(--color-status-err)',
+    text: 'var(--color-status-err)',
     chipBg: 'rgba(248,113,113,0.12)',
     chipBorder: 'rgba(248,113,113,0.24)',
   },
   muted: {
     fill: 'rgba(148,163,184,0.85)',
-    text: 'var(--text-muted)',
+    text: 'var(--color-fg-muted)',
     chipBg: 'var(--slate-gray-12)',
     chipBorder: 'rgba(148,163,184,0.24)',
   },
@@ -77,12 +77,12 @@ export function DistributionBars({
     <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3">
       ${title
         ? html`
-            <div class="text-3xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">${title}</div>
-            ${subtitle ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">${subtitle}</div>` : null}
+            <div class="text-3xs font-semibold uppercase tracking-5 text-[var(--color-fg-muted)]">${title}</div>
+            ${subtitle ? html`<div class="mt-1 text-2xs text-[var(--color-fg-muted)]">${subtitle}</div>` : null}
           `
         : null}
       ${visibleItems.length === 0
-        ? html`<div class="${title ? 'mt-3 ' : ''}text-2xs italic text-[var(--text-muted)]">${emptyLabel}</div>`
+        ? html`<div class="${title ? 'mt-3 ' : ''}text-2xs italic text-[var(--color-fg-muted)]">${emptyLabel}</div>`
         : html`
             <div class="${title ? 'mt-3 ' : ''}flex flex-col gap-2.5">
               ${visibleItems.map(item => {
@@ -92,8 +92,8 @@ export function DistributionBars({
                   <div class="flex flex-col gap-1">
                     <div class="flex items-center justify-between gap-2">
                       <div class="min-w-0">
-                        <div class="truncate text-xs font-semibold text-[var(--text-strong)]">${item.label}</div>
-                        ${item.detail ? html`<div class="truncate text-3xs text-[var(--text-muted)]">${item.detail}</div>` : null}
+                        <div class="truncate text-xs font-semibold text-[var(--color-fg-secondary)]">${item.label}</div>
+                        ${item.detail ? html`<div class="truncate text-3xs text-[var(--color-fg-muted)]">${item.detail}</div>` : null}
                       </div>
                       <span
                         class="shrink-0 rounded-sm border px-2 py-0.5 text-3xs font-semibold"
@@ -135,12 +135,12 @@ export function SegmentedBar({
     <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3">
       ${title
         ? html`
-            <div class="text-3xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">${title}</div>
-            ${subtitle ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">${subtitle}</div>` : null}
+            <div class="text-3xs font-semibold uppercase tracking-5 text-[var(--color-fg-muted)]">${title}</div>
+            ${subtitle ? html`<div class="mt-1 text-2xs text-[var(--color-fg-muted)]">${subtitle}</div>` : null}
           `
         : null}
       ${total === 0
-        ? html`<div class="${title ? 'mt-3 ' : ''}text-2xs italic text-[var(--text-muted)]">표시할 데이터가 없습니다.</div>`
+        ? html`<div class="${title ? 'mt-3 ' : ''}text-2xs italic text-[var(--color-fg-muted)]">표시할 데이터가 없습니다.</div>`
         : html`
             <div class="${title ? 'mt-3 ' : ''}flex flex-col gap-2.5">
               <div class="flex h-3 overflow-hidden rounded-sm bg-[var(--white-5)]">

--- a/dashboard/src/components/common/error-boundary.test.ts
+++ b/dashboard/src/components/common/error-boundary.test.ts
@@ -38,7 +38,7 @@ describe('ErrorBoundary', () => {
 
     const button = container.querySelector('button')
     expect(button).not.toBeNull()
-    expect(button?.className).toContain('border-[var(--card-border)]')
+    expect(button?.className).toContain('border-[var(--color-border-default)]')
     expect(button?.className).not.toContain('card rounded-border')
   })
 

--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -39,15 +39,15 @@ export class ErrorBoundary extends Component<Props, State> {
         return this.props.fallback(this.state.error, this.reset)
       }
       return html`
-        <div class="error-card rounded my-3 border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-5 flex gap-4 items-start shadow-sm">
-          <div class="shrink-0 text-[var(--bad)] mt-0.5">
+        <div class="error-card rounded my-3 border border-[var(--color-status-err)]/30 bg-[rgba(10,22,40,0.92)] p-5 flex gap-4 items-start shadow-sm">
+          <div class="shrink-0 text-[var(--color-status-err)] mt-0.5">
             <${AlertOctagon} size=${24} />
           </div>
           <div class="flex-1 min-w-0">
-            <h3 class="text-base font-semibold text-[var(--bad)] tracking-tight mb-1">${this.props.label ?? 'Component'} 렌더링 오류</h3>
-            <pre class="text-sm whitespace-pre-wrap opacity-80 text-[var(--text-body)] overflow-x-auto bg-[var(--black-20)] p-2 rounded">${this.state.error.message}</pre>
+            <h3 class="text-base font-semibold text-[var(--color-status-err)] tracking-tight mb-1">${this.props.label ?? 'Component'} 렌더링 오류</h3>
+            <pre class="text-sm whitespace-pre-wrap opacity-80 text-[var(--color-fg-primary)] overflow-x-auto bg-[var(--black-20)] p-2 rounded">${this.state.error.message}</pre>
             <button type="button"
-              class="mt-3 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 cursor-pointer rounded border border-[var(--card-border)] bg-[var(--white-5)] text-[var(--text-strong)] text-sm hover:bg-[var(--white-10)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bad)]"
+              class="mt-3 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 cursor-pointer rounded border border-[var(--color-border-default)] bg-[var(--white-5)] text-[var(--color-fg-secondary)] text-sm hover:bg-[var(--white-10)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-status-err)]"
               onClick=${this.reset}
             >
               <${RefreshCcw} size=${14} />

--- a/dashboard/src/components/common/error-panel.ts
+++ b/dashboard/src/components/common/error-panel.ts
@@ -25,14 +25,14 @@ const CODE_LABELS: Record<ErrorCode, string> = {
 }
 
 const SEVERITY_ICON_COLOR: Record<ErrorSeverity, string> = {
-  critical: 'text-[var(--bad)]',
-  warning: 'text-[var(--warn)]',
+  critical: 'text-[var(--color-status-err)]',
+  warning: 'text-[var(--color-status-warn)]',
   info: 'text-[var(--accent-45)]',
 }
 
 const CODE_BADGE_BG: Record<ErrorSeverity, string> = {
-  critical: 'bg-[var(--bad)]/15 text-[var(--bad)]',
-  warning: 'bg-[var(--warn)]/15 text-[var(--warn)]',
+  critical: 'bg-[var(--color-status-err)]/15 text-[var(--color-status-err)]',
+  warning: 'bg-[var(--color-status-warn)]/15 text-[var(--color-status-warn)]',
   info: 'bg-[var(--accent-45)]/15 text-[var(--accent-45)]',
 }
 
@@ -45,14 +45,14 @@ export function ErrorPanel({ onClose }: ErrorPanelProps) {
 
   if (items.length === 0) {
     return html`
-      <div class="absolute right-0 top-full mt-1.5 z-[var(--z-overlay-dropdown,3050)] w-96 max-h-80 overflow-hidden rounded-lg border border-[var(--card-border)] bg-[rgba(10,18,34,0.98)] shadow-xl backdrop-blur-xl">
+      <div class="absolute right-0 top-full mt-1.5 z-[var(--z-overlay-dropdown,3050)] w-96 max-h-80 overflow-hidden rounded-lg border border-[var(--color-border-default)] bg-[rgba(10,18,34,0.98)] shadow-xl backdrop-blur-xl">
         <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--white-5)]">
-          <span class="text-xs font-medium text-[var(--text-muted)]">에러 없음</span>
-          <button type="button" class="text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer p-0.5" onClick=${onClose}>
+          <span class="text-xs font-medium text-[var(--color-fg-muted)]">에러 없음</span>
+          <button type="button" class="text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer p-0.5" onClick=${onClose}>
             <${X} size=${14} />
           </button>
         </div>
-        <div class="flex items-center justify-center py-6 text-xs text-[var(--text-muted)]">
+        <div class="flex items-center justify-center py-6 text-xs text-[var(--color-fg-muted)]">
           모든 에러를 확인했습니다.
         </div>
       </div>
@@ -60,15 +60,15 @@ export function ErrorPanel({ onClose }: ErrorPanelProps) {
   }
 
   return html`
-    <div class="absolute right-0 top-full mt-1.5 z-[var(--z-overlay-dropdown,3050)] w-96 max-h-80 overflow-hidden rounded-lg border border-[var(--card-border)] bg-[rgba(10,18,34,0.98)] shadow-xl backdrop-blur-xl flex flex-col">
+    <div class="absolute right-0 top-full mt-1.5 z-[var(--z-overlay-dropdown,3050)] w-96 max-h-80 overflow-hidden rounded-lg border border-[var(--color-border-default)] bg-[rgba(10,18,34,0.98)] shadow-xl backdrop-blur-xl flex flex-col">
       <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--white-5)] shrink-0">
-        <span class="text-xs font-medium text-[var(--text-muted)]">미확인 에러 <span class="text-[var(--bad)]">${items.length}</span>건</span>
+        <span class="text-xs font-medium text-[var(--color-fg-muted)]">미확인 에러 <span class="text-[var(--color-status-err)]">${items.length}</span>건</span>
         <div class="flex items-center gap-1">
           <button type="button"
-            class="text-2xs px-2 py-0.5 rounded border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-muted)] hover:bg-[var(--white-10)] cursor-pointer transition-colors"
+            class="text-2xs px-2 py-0.5 rounded border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-muted)] hover:bg-[var(--white-10)] cursor-pointer transition-colors"
             onClick=${() => { clearAllErrors(); onClose() }}
           >모두 확인</button>
-          <button type="button" class="text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer p-0.5" onClick=${onClose}>
+          <button type="button" class="text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer p-0.5" onClick=${onClose}>
             <${X} size=${14} />
           </button>
         </div>
@@ -87,16 +87,16 @@ export function ErrorPanel({ onClose }: ErrorPanelProps) {
             </span>
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-1.5 text-xs">
-                <span class="font-medium text-[var(--text-strong)] truncate">${e.agentName}</span>
+                <span class="font-medium text-[var(--color-fg-secondary)] truncate">${e.agentName}</span>
                 <span class="shrink-0 text-2xs px-1 py-px rounded ${badgeBg}">${label}</span>
-                ${e.taskId ? html`<span class="text-[var(--text-muted)] truncate max-w-20">${e.taskId}</span>` : null}
-                ${e.count > 1 ? html`<span class="shrink-0 text-2xs text-[var(--warn)]">×${e.count}</span>` : null}
+                ${e.taskId ? html`<span class="text-[var(--color-fg-muted)] truncate max-w-20">${e.taskId}</span>` : null}
+                ${e.count > 1 ? html`<span class="shrink-0 text-2xs text-[var(--color-status-warn)]">×${e.count}</span>` : null}
               </div>
-              <p class="mt-0.5 text-xs text-[var(--text-body)] leading-[1.4] line-clamp-2">${e.message}</p>
-              <span class="mt-0.5 block text-2xs text-[var(--text-muted)]">${formatElapsedCompact((Date.now() - e.timestamp) / 1000)} 전</span>
+              <p class="mt-0.5 text-xs text-[var(--color-fg-primary)] leading-[1.4] line-clamp-2">${e.message}</p>
+              <span class="mt-0.5 block text-2xs text-[var(--color-fg-muted)]">${formatElapsedCompact((Date.now() - e.timestamp) / 1000)} 전</span>
             </div>
             <button type="button"
-              class="shrink-0 mt-0.5 p-1 rounded opacity-0 group-hover:opacity-100 text-[var(--text-muted)] hover:text-[var(--ok)] hover:bg-[var(--white-8)] cursor-pointer transition-all"
+              class="shrink-0 mt-0.5 p-1 rounded opacity-0 group-hover:opacity-100 text-[var(--color-fg-muted)] hover:text-[var(--color-status-ok)] hover:bg-[var(--white-8)] cursor-pointer transition-all"
               title="확인"
               onClick=${() => acknowledgeError(e.id)}
             ><${Check} size=${14} /></button>

--- a/dashboard/src/components/common/feedback-state.ts
+++ b/dashboard/src/components/common/feedback-state.ts
@@ -24,7 +24,7 @@ export function EmptyState({
   const content = children ?? message
 
   return html`
-    <div class="flex flex-col items-center justify-center gap-2 text-center ${compact ? 'py-4' : 'py-8'} text-sm text-[var(--text-muted)] ${cx ?? ''}" role="status">
+    <div class="flex flex-col items-center justify-center gap-2 text-center ${compact ? 'py-4' : 'py-8'} text-sm text-[var(--color-fg-muted)] ${cx ?? ''}" role="status">
       ${icon ? html`<span class="text-2xl opacity-40" aria-hidden="true">${icon}</span>` : null}
       ${content ? html`<span class="leading-relaxed">${content}</span>` : null}
       ${action ?? null}

--- a/dashboard/src/components/common/filter-chips.ts
+++ b/dashboard/src/components/common/filter-chips.ts
@@ -36,11 +36,11 @@ export function FilterChips<T extends string>({
     ? 'inline-flex min-h-9 items-center gap-1.5 rounded border px-3 py-2 text-2xs font-medium'
     : 'inline-flex items-center gap-1.5 rounded border px-2 py-1 text-[length:var(--fs-xs)]'
   const activeToneClass = tone === 'accent'
-    ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--text-strong)]'
+    ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--color-fg-secondary)]'
     : 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn-bright)]'
   const idleToneClass = tone === 'accent'
-    ? 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[var(--border-slate-22)] hover:text-[var(--text-body)]'
-    : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[rgba(200,168,78,0.4)]'
+    ? 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:border-[var(--border-slate-22)] hover:text-[var(--color-fg-primary)]'
+    : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:border-[rgba(200,168,78,0.4)]'
 
   return html`
     <div class="flex flex-wrap gap-1.5 ${cx ?? ''}" role="tablist">

--- a/dashboard/src/components/common/heartbeat-streak-chip.test.ts
+++ b/dashboard/src/components/common/heartbeat-streak-chip.test.ts
@@ -102,7 +102,7 @@ describe('HeartbeatStreakChip component', () => {
   it('tone class reflects state — ok for up, bad for down, muted for unknown', () => {
     render(html`<${HeartbeatStreakChip} history=${['up', 'up']} />`, container)
     let el = container.querySelector('[data-heartbeat-streak-chip]')!
-    expect(el.className).toContain('var(--ok)')
+    expect(el.className).toContain('var(--color-status-ok)')
     render(null, container)
 
     render(html`<${HeartbeatStreakChip} history=${['down']} />`, container)
@@ -112,7 +112,7 @@ describe('HeartbeatStreakChip component', () => {
 
     render(html`<${HeartbeatStreakChip} history=${['unknown']} />`, container)
     el = container.querySelector('[data-heartbeat-streak-chip]')!
-    expect(el.className).toContain('text-[var(--text-dim)]')
+    expect(el.className).toContain('text-[var(--color-fg-disabled)]')
   })
 
   it('data attrs pin state + samples for E2E selectors', () => {

--- a/dashboard/src/components/common/heartbeat-streak-chip.ts
+++ b/dashboard/src/components/common/heartbeat-streak-chip.ts
@@ -28,9 +28,9 @@ const STATE_LABEL: Record<HeartbeatState, string> = {
 }
 
 const STATE_TONE: Record<HeartbeatState, string> = {
-  up: 'text-[var(--ok)] border-[var(--ok-20)] bg-[var(--ok-10)]',
+  up: 'text-[var(--color-status-ok)] border-[var(--ok-20)] bg-[var(--ok-10)]',
   down: 'text-[var(--bad-light)] border-[var(--bad-20)] bg-[var(--bad-10)]',
-  unknown: 'text-[var(--text-dim)] border-[var(--white-8)] bg-[var(--white-2)]',
+  unknown: 'text-[var(--color-fg-disabled)] border-[var(--white-8)] bg-[var(--white-2)]',
 }
 
 /** Pure: render a streak as narrator-friendly text. Exposed so the
@@ -73,7 +73,7 @@ export function HeartbeatStreakChip({
   >
     <span aria-hidden="true">${STATE_GLYPH[streak.state]}</span>
     <span>${STATE_LABEL[streak.state]}</span>
-    <span class="text-[var(--text-dim)]">×</span>
+    <span class="text-[var(--color-fg-disabled)]">×</span>
     <span>${streak.samples}</span>
   </span>`
 }

--- a/dashboard/src/components/common/heartbeat-uptime-chip.test.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.test.ts
@@ -97,7 +97,7 @@ describe('HeartbeatUptimeChip component', () => {
     const el = container.querySelector('[data-heartbeat-uptime-chip]') as HTMLElement
     expect(el).toBeTruthy()
     expect(el.textContent).toContain('100%')
-    expect(el.className).toContain('var(--ok)')
+    expect(el.className).toContain('var(--color-status-ok)')
     expect(el.getAttribute('data-heartbeat-uptime-tone')).toBe('operational')
     expect(el.getAttribute('data-heartbeat-uptime-pct')).toBe('100')
   })
@@ -109,7 +109,7 @@ describe('HeartbeatUptimeChip component', () => {
       container,
     )
     const el = container.querySelector('[data-heartbeat-uptime-chip]')!
-    expect(el.className).toContain('var(--warn)')
+    expect(el.className).toContain('var(--color-status-warn)')
     expect(el.getAttribute('data-heartbeat-uptime-tone')).toBe('degraded')
   })
 

--- a/dashboard/src/components/common/heartbeat-uptime-chip.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.ts
@@ -38,8 +38,8 @@ export function formatUptimeChip(summary: HeartbeatSummary): UptimeChipView | nu
 }
 
 const TONE_CLASS: Record<UptimeTone, string> = {
-  operational: 'text-[var(--ok)] border-[var(--ok-20)] bg-[var(--ok-10)]',
-  degraded: 'text-[var(--warn)] border-[var(--warn-20)] bg-[var(--warn-10)]',
+  operational: 'text-[var(--color-status-ok)] border-[var(--ok-20)] bg-[var(--ok-10)]',
+  degraded: 'text-[var(--color-status-warn)] border-[var(--warn-20)] bg-[var(--warn-10)]',
   unhealthy: 'text-[var(--bad-light)] border-[var(--bad-20)] bg-[var(--bad-10)]',
 }
 

--- a/dashboard/src/components/common/inline-spinner.test.ts
+++ b/dashboard/src/components/common/inline-spinner.test.ts
@@ -25,12 +25,12 @@ describe('inlineSpinnerSizeClass (pure)', () => {
 
 describe('inlineSpinnerToneClass (pure)', () => {
   it('accent tone uses the --accent CSS var (the dashboard brand hue)', () => {
-    expect(inlineSpinnerToneClass('accent')).toContain('var(--accent)')
+    expect(inlineSpinnerToneClass('accent')).toContain('var(--color-accent-fg)')
     expect(inlineSpinnerToneClass('accent')).toContain('border-t-transparent')
   })
 
   it('muted tone uses --text-dim for background-sync contexts', () => {
-    expect(inlineSpinnerToneClass('muted')).toContain('var(--text-dim)')
+    expect(inlineSpinnerToneClass('muted')).toContain('var(--color-fg-disabled)')
     expect(inlineSpinnerToneClass('muted')).toContain('border-t-transparent')
   })
 })

--- a/dashboard/src/components/common/inline-spinner.ts
+++ b/dashboard/src/components/common/inline-spinner.ts
@@ -11,7 +11,7 @@
 // Pre-change the dashboard had 5+ call sites with near-identical
 // Tailwind strings:
 //   inline-block h-3 w-3 rounded-full border-2
-//     border-[var(--accent)] border-t-transparent animate-spin
+//     border-[var(--color-accent-fg)] border-t-transparent animate-spin
 // This primitive pins the canonical 3 sizes + 2 tones.
 
 import { html } from 'htm/preact'
@@ -35,8 +35,8 @@ export function inlineSpinnerSizeClass(size: InlineSpinnerSize = 'sm'): string {
     variant for when the spinner is secondary to the row it lives in. */
 export function inlineSpinnerToneClass(tone: InlineSpinnerTone = 'accent'): string {
   return tone === 'accent'
-    ? 'border-[var(--accent)] border-t-transparent'
-    : 'border-[var(--text-dim)] border-t-transparent'
+    ? 'border-[var(--color-accent-fg)] border-t-transparent'
+    : 'border-[var(--color-fg-disabled)] border-t-transparent'
 }
 
 const BASE = 'inline-block rounded-full animate-spin shrink-0'

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -10,7 +10,7 @@
 
 import { html } from 'htm/preact'
 
-const INPUT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
+const INPUT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
 
 interface TextInputProps {
   id?: string

--- a/dashboard/src/components/common/json-viewer.ts
+++ b/dashboard/src/components/common/json-viewer.ts
@@ -21,8 +21,8 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
   if (isObject && ancestors.includes(data as object)) {
     return html`
       <div class="font-mono text-sm leading-relaxed flex items-start gap-1.5 py-0.5 min-w-0 max-w-full">
-        ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
-        <span class="text-[var(--text-muted)] italic">[Circular]</span>
+        ${label ? html`<span class="text-[var(--color-fg-primary)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
+        <span class="text-[var(--color-fg-muted)] italic">[Circular]</span>
       </div>
     `
   }
@@ -30,20 +30,20 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
   if (!isObject) {
     let valueNode
     if (typeof data === 'string') {
-      valueNode = html`<span class="text-[var(--ok)] whitespace-pre-wrap break-words">"${data}"</span>`
+      valueNode = html`<span class="text-[var(--color-status-ok)] whitespace-pre-wrap break-words">"${data}"</span>`
     } else if (typeof data === 'number') {
-      valueNode = html`<span class="text-[var(--warn)]">${data}</span>`
+      valueNode = html`<span class="text-[var(--color-status-warn)]">${data}</span>`
     } else if (typeof data === 'boolean') {
       valueNode = html`<span class="text-[#e27e8d]">${data ? 'true' : 'false'}</span>`
     } else if (data === null) {
-      valueNode = html`<span class="text-[var(--text-muted)] italic">null</span>`
+      valueNode = html`<span class="text-[var(--color-fg-muted)] italic">null</span>`
     } else {
-      valueNode = html`<span class="text-[var(--text-muted)]">${String(data)}</span>`
+      valueNode = html`<span class="text-[var(--color-fg-muted)]">${String(data)}</span>`
     }
 
     return html`
       <div class="font-mono text-sm leading-relaxed flex items-start gap-1.5 py-0.5 min-w-0 max-w-full">
-        ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
+        ${label ? html`<span class="text-[var(--color-fg-primary)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
         <div class="min-w-0 break-words">${valueNode}</div>
       </div>
     `
@@ -57,8 +57,8 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
   if (isEmpty) {
     return html`
       <div class="font-mono text-sm leading-relaxed flex items-start gap-1.5 py-0.5">
-        ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
-        <span class="text-[var(--text-muted)]">${isArray ? '[]' : '{}'}</span>
+        ${label ? html`<span class="text-[var(--color-fg-primary)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
+        <span class="text-[var(--color-fg-muted)]">${isArray ? '[]' : '{}'}</span>
       </div>
     `
   }
@@ -72,9 +72,9 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
         aria-expanded=${!collapsed}
         aria-label=${`${collapsed ? 'Expand' : 'Collapse'} ${toggleLabel}`}
       >
-        <span aria-hidden="true" class="text-[var(--text-muted)] shrink-0 w-4 inline-flex justify-center transition-transform duration-150 ${collapsed ? '-rotate-90' : ''}">▼</span>
-        ${label ? html`<span class="text-[var(--text-body)] font-medium truncate">${label}</span>` : null}
-        <span class="text-[var(--text-muted)] text-2xs ml-1 shrink-0">
+        <span aria-hidden="true" class="text-[var(--color-fg-muted)] shrink-0 w-4 inline-flex justify-center transition-transform duration-150 ${collapsed ? '-rotate-90' : ''}">▼</span>
+        ${label ? html`<span class="text-[var(--color-fg-primary)] font-medium truncate">${label}</span>` : null}
+        <span class="text-[var(--color-fg-muted)] text-2xs ml-1 shrink-0">
           ${isArray ? `[${(data as unknown[]).length}]` : `{${entries.length}}`}
         </span>
       </button>
@@ -93,8 +93,8 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
 
 export function JsonViewerCard({ data, title }: { data: unknown; title?: string }) {
   return html`
-    <div class="bg-[var(--bg-0)] border border-[var(--card-border)] rounded overflow-hidden flex flex-col max-h-100" data-testid="json-viewer-card" data-title=${title ?? ''}>
-      ${title ? html`<div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-2xs uppercase tracking-wider font-semibold text-[var(--text-muted)]">${title}</div>` : null}
+    <div class="bg-[var(--bg-0)] border border-[var(--color-border-default)] rounded overflow-hidden flex flex-col max-h-100" data-testid="json-viewer-card" data-title=${title ?? ''}>
+      ${title ? html`<div class="px-3 py-2 border-b border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs uppercase tracking-wider font-semibold text-[var(--color-fg-muted)]">${title}</div>` : null}
       <div class="p-3 overflow-y-auto min-h-0 w-full">
         <${JsonViewer} data=${data} />
       </div>

--- a/dashboard/src/components/common/kbd.test.ts
+++ b/dashboard/src/components/common/kbd.test.ts
@@ -13,14 +13,14 @@ describe('kbdClasses (pure)', () => {
     const cls = kbdClasses('md')
     expect(cls).toContain('text-3xs')
     expect(cls).toContain('px-1.5')
-    expect(cls).toContain('text-[var(--text-body)]')
+    expect(cls).toContain('text-[var(--color-fg-primary)]')
   })
 
   it('sm variant: 10px text + tight padding (px-1 py-0) + dimmed color', () => {
     const cls = kbdClasses('sm')
     expect(cls).toContain('text-3xs')
     expect(cls).toContain('px-1')
-    expect(cls).toContain('text-[var(--text-dim)]')
+    expect(cls).toContain('text-[var(--color-fg-disabled)]')
   })
 
   it('extra class is appended (caller composition)', () => {

--- a/dashboard/src/components/common/kbd.ts
+++ b/dashboard/src/components/common/kbd.ts
@@ -29,8 +29,8 @@ const BASE = 'inline-flex items-center justify-center rounded border font-mono t
 export function kbdClasses(size: KbdSize = 'md', extra?: string): string {
   const sized =
     size === 'sm'
-      ? 'text-3xs px-1 py-0 border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)]'
-      : 'text-3xs px-1.5 py-px border-[var(--white-10)] bg-[var(--bg-0)] text-[var(--text-body)]'
+      ? 'text-3xs px-1 py-0 border-[var(--white-10)] bg-[var(--white-3)] text-[var(--color-fg-disabled)]'
+      : 'text-3xs px-1.5 py-px border-[var(--white-10)] bg-[var(--bg-0)] text-[var(--color-fg-primary)]'
   return extra === undefined || extra === ''
     ? `${BASE} ${sized}`
     : `${BASE} ${sized} ${extra}`

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -40,7 +40,7 @@ function loadingClasses(className?: string): string {
     'inline-flex',
     'items-center',
     'text-2xs',
-    'text-[var(--text-dim)]',
+    'text-[var(--color-fg-disabled)]',
     className,
   ].filter(Boolean).join(' ')
 }

--- a/dashboard/src/components/common/mermaid-graph.ts
+++ b/dashboard/src/components/common/mermaid-graph.ts
@@ -121,7 +121,7 @@ export function MermaidGraph({
         <div class="space-y-2">
           <${EmptyState} message=${error} compact />
           ${fallbackText ? html`
-            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm leading-loose text-[var(--text-dim)]">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm leading-loose text-[var(--color-fg-disabled)]">
               ${fallbackText}
             </div>
           ` : null}

--- a/dashboard/src/components/common/number-input.ts
+++ b/dashboard/src/components/common/number-input.ts
@@ -10,7 +10,7 @@
 
 import { html } from 'htm/preact'
 
-const INPUT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
+const INPUT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
 
 interface NumberInputProps {
   value?: number | string

--- a/dashboard/src/components/common/progress-bar.test.ts
+++ b/dashboard/src/components/common/progress-bar.test.ts
@@ -56,10 +56,10 @@ describe('progressBarTrackToneClass (pure)', () => {
 
 describe('progressBarToneClass (pure)', () => {
   it('semantic tokens route to the dashboard CSS vars', () => {
-    expect(progressBarToneClass('accent')).toBe('bg-[var(--accent)]')
-    expect(progressBarToneClass('ok')).toBe('bg-[var(--ok)]')
-    expect(progressBarToneClass('warn')).toBe('bg-[var(--warn)]')
-    expect(progressBarToneClass('bad')).toBe('bg-[var(--bad)]')
+    expect(progressBarToneClass('accent')).toBe('bg-[var(--color-accent-fg)]')
+    expect(progressBarToneClass('ok')).toBe('bg-[var(--color-status-ok)]')
+    expect(progressBarToneClass('warn')).toBe('bg-[var(--color-status-warn)]')
+    expect(progressBarToneClass('bad')).toBe('bg-[var(--color-status-err)]')
   })
 
   it('raw Tailwind tones route to their bg-500 class', () => {
@@ -118,7 +118,7 @@ describe('ProgressBar component', () => {
   it('tone prop maps to the fill bg class', () => {
     render(html`<${ProgressBar} pct=${50} tone="ok" />`, container)
     const fill = container.querySelector('[data-progress-bar] > div') as HTMLElement
-    expect(fill.className).toContain('bg-[var(--ok)]')
+    expect(fill.className).toContain('bg-[var(--color-status-ok)]')
   })
 
   it('class prop overrides tone (threshold-varying colors)', () => {
@@ -129,7 +129,7 @@ describe('ProgressBar component', () => {
     const fill = container.querySelector('[data-progress-bar] > div') as HTMLElement
     expect(fill.className).toContain('bg-[var(--sky-400)]')
     // Tone fallback must NOT also be present when class is given.
-    expect(fill.className).not.toContain('bg-[var(--accent)]')
+    expect(fill.className).not.toContain('bg-[var(--color-accent-fg)]')
   })
 
   it('title attribute propagates to the track', () => {

--- a/dashboard/src/components/common/progress-bar.ts
+++ b/dashboard/src/components/common/progress-bar.ts
@@ -42,10 +42,10 @@ export function progressBarHeightClass(size: ProgressBarSize = 'sm'): string {
     bespoke brand color pass `class` instead. */
 export function progressBarToneClass(tone: ProgressBarTone): string {
   switch (tone) {
-    case 'accent': return 'bg-[var(--accent)]'
-    case 'ok': return 'bg-[var(--ok)]'
-    case 'warn': return 'bg-[var(--warn)]'
-    case 'bad': return 'bg-[var(--bad)]'
+    case 'accent': return 'bg-[var(--color-accent-fg)]'
+    case 'ok': return 'bg-[var(--color-status-ok)]'
+    case 'warn': return 'bg-[var(--color-status-warn)]'
+    case 'bad': return 'bg-[var(--color-status-err)]'
     case 'emerald': return 'bg-[var(--ok-10)]'
     case 'amber': return 'bg-[var(--warn-10)]'
     case 'rose': return 'bg-[var(--bad-10)]'

--- a/dashboard/src/components/common/rich-composer.ts
+++ b/dashboard/src/components/common/rich-composer.ts
@@ -25,8 +25,8 @@ export function RichComposer({
   const [mode, setMode] = useState<ComposerMode>('write')
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[rgba(8,13,22,0.88)]">
-      <div class="flex items-center justify-between gap-3 border-b border-[var(--card-border)] px-3 py-2">
+    <div class="rounded border border-[var(--color-border-default)] bg-[rgba(8,13,22,0.88)]">
+      <div class="flex items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-3 py-2">
         <div class="flex items-center gap-1.5">
           ${(['write', 'preview'] as ComposerMode[]).map(tab => html`
             <button
@@ -34,8 +34,8 @@ export function RichComposer({
               type="button"
               class=${`rounded border px-2.5 py-1 text-2xs font-medium transition-colors ${
                 mode === tab
-                  ? 'border-[rgba(71,184,255,0.35)] bg-[var(--accent-12)] text-[var(--accent)]'
-                  : 'border-transparent bg-transparent text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]'
+                  ? 'border-[rgba(71,184,255,0.35)] bg-[var(--accent-12)] text-[var(--color-accent-fg)]'
+                  : 'border-transparent bg-transparent text-[var(--color-fg-muted)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)]'
               }`}
               onClick=${() => setMode(tab)}
               disabled=${disabled}
@@ -44,7 +44,7 @@ export function RichComposer({
             </button>
           `)}
         </div>
-        <div class="text-3xs text-[var(--text-muted)]">
+        <div class="text-3xs text-[var(--color-fg-muted)]">
           Markdown, code fence, URL, image link
         </div>
       </div>
@@ -63,17 +63,17 @@ export function RichComposer({
             `
           : value.trim()
             ? html`
-                <div class="max-h-80 overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] p-3 custom-scrollbar">
+                <div class="max-h-80 overflow-auto rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] p-3 custom-scrollbar">
                   <${RichContent} text=${value} previewLimit=${previewLimit} />
                 </div>
               `
             : html`
-                <div class="rounded border border-dashed border-[var(--card-border)] bg-[var(--white-3)] px-3 py-6 text-center text-xs text-[var(--text-muted)]">
+                <div class="rounded border border-dashed border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-6 text-center text-xs text-[var(--color-fg-muted)]">
                   미리볼 내용이 아직 없습니다.
                 </div>
               `}
         ${helpText
-          ? html`<div class="mt-2 text-2xs leading-relaxed text-[var(--text-muted)]">${helpText}</div>`
+          ? html`<div class="mt-2 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${helpText}</div>`
           : null}
       </div>
     </div>

--- a/dashboard/src/components/common/rich-content.ts
+++ b/dashboard/src/components/common/rich-content.ts
@@ -24,7 +24,7 @@ function previewCard(preview: LinkPreview) {
       href=${href}
       target="_blank"
       rel="noreferrer"
-      class="group flex overflow-hidden rounded border border-[var(--card-border)] bg-[var(--white-3)] text-inherit no-underline transition-colors hover:border-[var(--accent-20)] hover:bg-[var(--white-5)]"
+      class="group flex overflow-hidden rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-inherit no-underline transition-colors hover:border-[var(--accent-20)] hover:bg-[var(--white-5)]"
     >
       ${imageUrl
         ? html`
@@ -34,15 +34,15 @@ function previewCard(preview: LinkPreview) {
           `
         : null}
       <div class="min-w-0 flex-1 px-3 py-2.5">
-        <div class="flex items-center gap-2 text-2xs text-[var(--text-muted)]">
+        <div class="flex items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
           ${faviconUrl ? html`<img src=${faviconUrl} alt="" class="h-3.5 w-3.5 rounded-sm" loading="lazy" />` : null}
           <span class="truncate">${preview.site_name || hostLabel}</span>
         </div>
-        <div class="mt-1 text-xs font-semibold leading-snug text-[var(--text-strong)] group-hover:text-[var(--accent)]">
+        <div class="mt-1 text-xs font-semibold leading-snug text-[var(--color-fg-secondary)] group-hover:text-[var(--color-accent-fg)]">
           ${title}
         </div>
         ${description
-          ? html`<div class="mt-1 line-clamp-3 text-2xs leading-relaxed text-[var(--text-muted)]">${description}</div>`
+          ? html`<div class="mt-1 line-clamp-3 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${description}</div>`
           : null}
       </div>
     </a>

--- a/dashboard/src/components/common/scroll-to-top.ts
+++ b/dashboard/src/components/common/scroll-to-top.ts
@@ -70,7 +70,7 @@ export function ScrollToTopButton({
 
   return html`<button
     type="button"
-    class=${`fixed bottom-6 right-6 z-[var(--z-overlay-toast,3070)] flex h-10 w-10 items-center justify-center rounded-sm border border-[var(--white-10)] bg-[var(--bg-1)]/90 text-[var(--text-body)] shadow-[0_6px_18px_rgba(0,0,0,0.32)] backdrop-blur transition-all duration-150 hover:border-[var(--accent-30)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)] cursor-pointer ${cx ?? ''}`}
+    class=${`fixed bottom-6 right-6 z-[var(--z-overlay-toast,3070)] flex h-10 w-10 items-center justify-center rounded-sm border border-[var(--white-10)] bg-[var(--bg-1)]/90 text-[var(--color-fg-primary)] shadow-[0_6px_18px_rgba(0,0,0,0.32)] backdrop-blur transition-all duration-150 hover:border-[var(--accent-30)] hover:text-[var(--color-accent-fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)] cursor-pointer ${cx ?? ''}`}
     aria-label="맨 위로"
     title="맨 위로 (Home)"
     data-scroll-to-top

--- a/dashboard/src/components/common/section-cap.ts
+++ b/dashboard/src/components/common/section-cap.ts
@@ -20,9 +20,9 @@
 // Tone tokens resolve through the Tailwind v4 `@theme` (tokens.css):
 //   text-text-muted → var(--color-text-muted)
 //   text-text-dim   → var(--color-text-dim)
-// Using the generated utility instead of `text-[var(--text-muted)]`
+// Using the generated utility instead of `text-[var(--color-fg-muted)]`
 // keeps purge predictable, autocomplete honest, and fixes the
-// `text-text-muted` / `text-[var(--text-muted)]` / `text-[var(--text-muted)]`
+// `text-text-muted` / `text-[var(--color-fg-muted)]` / `text-[var(--color-fg-muted)]`
 // trident drift the audit surfaced.
 //
 // NOT a replacement for:

--- a/dashboard/src/components/common/section-header.ts
+++ b/dashboard/src/components/common/section-header.ts
@@ -1,5 +1,5 @@
 // SectionHeader — consistent section labels across dashboard
-// Replaces 34+ inline patterns: `text-3xs uppercase tracking-1 text-[var(--text-muted)] font-medium`
+// Replaces 34+ inline patterns: `text-3xs uppercase tracking-1 text-[var(--color-fg-muted)] font-medium`
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
@@ -29,7 +29,7 @@ export function SectionHeader({
 }: SectionHeaderProps) {
   return html`
     <div class="flex items-center justify-between gap-2 ${cx ?? ''}">
-      <h4 class="m-0 ${SIZE_CLASSES[size]} uppercase tracking-[0.06em] text-[var(--text-muted)] font-medium">${children}</h4>
+      <h4 class="m-0 ${SIZE_CLASSES[size]} uppercase tracking-[0.06em] text-[var(--color-fg-muted)] font-medium">${children}</h4>
       ${right ?? null}
     </div>
   `

--- a/dashboard/src/components/common/select.ts
+++ b/dashboard/src/components/common/select.ts
@@ -11,7 +11,7 @@
 
 import { html } from 'htm/preact'
 
-const SELECT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] appearance-none cursor-pointer'
+const SELECT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] appearance-none cursor-pointer'
 
 interface SelectOption { value: string; label: string }
 

--- a/dashboard/src/components/common/stat-card.ts
+++ b/dashboard/src/components/common/stat-card.ts
@@ -5,9 +5,9 @@ import { html } from 'htm/preact'
 export function StatCard({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3 text-center">
-      <div class="text-2xl font-bold text-[var(--accent)]">${value}</div>
-      <div class="mt-1 text-xs text-[var(--text-muted)]">${label}</div>
-      ${sub ? html`<div class="mt-0.5 text-xs text-[var(--text-dim)]">${sub}</div>` : null}
+      <div class="text-2xl font-bold text-[var(--color-accent-fg)]">${value}</div>
+      <div class="mt-1 text-xs text-[var(--color-fg-muted)]">${label}</div>
+      ${sub ? html`<div class="mt-0.5 text-xs text-[var(--color-fg-disabled)]">${sub}</div>` : null}
     </div>
   `
 }

--- a/dashboard/src/components/common/stat-cell.ts
+++ b/dashboard/src/components/common/stat-cell.ts
@@ -27,9 +27,9 @@ const VALUE_SIZE = {
 export function StatCell({ label, value, detail, tone, size = 'md', bg = 'white-4', class: className }: StatCellProps) {
   return html`
     <div class="p-4 rounded ${BG[bg]} border border-[var(--white-6)] grid gap-1.5 ${tone ?? ''} ${className ?? ''}" role="group" aria-label="${label}: ${value}${detail != null ? ` (${detail})` : ''}">
-      <span class="text-3xs text-[var(--text-muted)] tracking-wider uppercase font-medium">${label}</span>
-      <strong class="text-[var(--text-strong)] ${VALUE_SIZE[size]} leading-tight tabular-nums">${value}</strong>
-      ${detail != null ? html`<small class="text-[var(--text-muted)] text-3xs leading-relaxed">${detail}</small>` : null}
+      <span class="text-3xs text-[var(--color-fg-muted)] tracking-wider uppercase font-medium">${label}</span>
+      <strong class="text-[var(--color-fg-secondary)] ${VALUE_SIZE[size]} leading-tight tabular-nums">${value}</strong>
+      ${detail != null ? html`<small class="text-[var(--color-fg-muted)] text-3xs leading-relaxed">${detail}</small>` : null}
     </div>
   `
 }

--- a/dashboard/src/components/common/stat-row.ts
+++ b/dashboard/src/components/common/stat-row.ts
@@ -14,10 +14,10 @@ interface KpiCardProps {
 
 export function KpiCard({ label, value, hint, tone, class: cx }: KpiCardProps) {
   return html`
-    <div class="flex flex-col gap-1 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] ${cx ?? ''}">
-      <span class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.06em] font-medium">${label}</span>
-      <span class="text-2xl font-semibold tabular-nums leading-none ${tone ?? 'text-[var(--text-strong)]'}">${value}</span>
-      ${hint ? html`<span class="text-2xs text-[var(--text-dim)] mt-0.5">${hint}</span>` : null}
+    <div class="flex flex-col gap-1 p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] ${cx ?? ''}">
+      <span class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-[0.06em] font-medium">${label}</span>
+      <span class="text-2xl font-semibold tabular-nums leading-none ${tone ?? 'text-[var(--color-fg-secondary)]'}">${value}</span>
+      ${hint ? html`<span class="text-2xs text-[var(--color-fg-disabled)] mt-0.5">${hint}</span>` : null}
     </div>
   `
 }

--- a/dashboard/src/components/common/stat-tile.ts
+++ b/dashboard/src/components/common/stat-tile.ts
@@ -11,17 +11,17 @@ interface StatTileProps {
 }
 
 const VARIANT_STYLES = {
-  default: 'bg-[var(--white-4)] border-[var(--card-border)] text-[var(--text-strong)]',
-  gold: 'bg-[rgba(200,168,78,0.05)] border-[var(--ff-gold-10)] text-[var(--text-strong)]',
-  accent: 'bg-[var(--accent-soft)] border-[var(--accent-20)] text-[var(--text-strong)]',
-  warn: 'bg-[rgba(230,167,0,0.06)] border-[rgba(230,167,0,0.2)] text-[var(--warn)]',
+  default: 'bg-[var(--white-4)] border-[var(--color-border-default)] text-[var(--color-fg-secondary)]',
+  gold: 'bg-[rgba(200,168,78,0.05)] border-[var(--ff-gold-10)] text-[var(--color-fg-secondary)]',
+  accent: 'bg-[var(--accent-soft)] border-[var(--accent-20)] text-[var(--color-fg-secondary)]',
+  warn: 'bg-[rgba(230,167,0,0.06)] border-[rgba(230,167,0,0.2)] text-[var(--color-status-warn)]',
 } as const
 
 const LABEL_STYLES = {
-  default: 'text-[var(--text-muted)]',
+  default: 'text-[var(--color-fg-muted)]',
   gold: 'text-[var(--ff-gold)]',
-  accent: 'text-[var(--accent)]',
-  warn: 'text-[var(--warn)]',
+  accent: 'text-[var(--color-accent-fg)]',
+  warn: 'text-[var(--color-status-warn)]',
 } as const
 
 function StatTile({ label, value, hint, variant = 'default' }: StatTileProps) {
@@ -29,7 +29,7 @@ function StatTile({ label, value, hint, variant = 'default' }: StatTileProps) {
     <div class="flex flex-col items-center gap-0.5 rounded border px-4 py-3 ${VARIANT_STYLES[variant]}">
       <span class="text-base font-bold tabular-nums leading-tight">${value}</span>
       <span class="text-[length:var(--fs-2xs)] tracking-wider uppercase ${LABEL_STYLES[variant]}">${label}</span>
-      ${hint ? html`<span class="text-[length:var(--fs-2xs)] text-[var(--text-dim)] mt-0.5">${hint}</span>` : null}
+      ${hint ? html`<span class="text-[length:var(--fs-2xs)] text-[var(--color-fg-disabled)] mt-0.5">${hint}</span>` : null}
     </div>
   `
 }

--- a/dashboard/src/components/common/status-badge.test.ts
+++ b/dashboard/src/components/common/status-badge.test.ts
@@ -3,23 +3,23 @@ import { statusDotColor } from './status-badge'
 
 describe('statusDotColor', () => {
   it('returns warn for in_progress', () => {
-    expect(statusDotColor('in_progress')).toBe('bg-[var(--warn)]')
+    expect(statusDotColor('in_progress')).toBe('bg-[var(--color-status-warn)]')
   })
 
   it('returns warn for running', () => {
-    expect(statusDotColor('running')).toBe('bg-[var(--warn)]')
+    expect(statusDotColor('running')).toBe('bg-[var(--color-status-warn)]')
   })
 
   it('returns accent for awaiting_verification', () => {
-    expect(statusDotColor('awaiting_verification')).toBe('bg-[var(--accent)]')
+    expect(statusDotColor('awaiting_verification')).toBe('bg-[var(--color-accent-fg)]')
   })
 
   it('returns accent for interrupted', () => {
-    expect(statusDotColor('interrupted')).toBe('bg-[var(--accent)]')
+    expect(statusDotColor('interrupted')).toBe('bg-[var(--color-accent-fg)]')
   })
 
   it('returns accent for listening', () => {
-    expect(statusDotColor('listening')).toBe('bg-[var(--accent)]')
+    expect(statusDotColor('listening')).toBe('bg-[var(--color-accent-fg)]')
   })
 
   it('returns slate for inactive', () => {
@@ -31,7 +31,7 @@ describe('statusDotColor', () => {
   })
 
   it('returns ok for active', () => {
-    expect(statusDotColor('active')).toBe('bg-[var(--ok)]')
+    expect(statusDotColor('active')).toBe('bg-[var(--color-status-ok)]')
   })
 
   it('returns text-slate for busy', () => {
@@ -43,11 +43,11 @@ describe('statusDotColor', () => {
   })
 
   it('returns bad for error', () => {
-    expect(statusDotColor('error')).toBe('bg-[var(--bad)]')
+    expect(statusDotColor('error')).toBe('bg-[var(--color-status-err)]')
   })
 
   it('returns muted for unknown status', () => {
-    expect(statusDotColor('unknown')).toBe('bg-[var(--text-muted)]')
-    expect(statusDotColor('')).toBe('bg-[var(--text-muted)]')
+    expect(statusDotColor('unknown')).toBe('bg-[var(--color-fg-muted)]')
+    expect(statusDotColor('')).toBe('bg-[var(--color-fg-muted)]')
   })
 })

--- a/dashboard/src/components/common/status-badge.ts
+++ b/dashboard/src/components/common/status-badge.ts
@@ -12,30 +12,30 @@ export function statusDotColor(status: string): string {
   switch (status) {
     case 'in_progress':
     case 'running':
-      return 'bg-[var(--warn)]'
+      return 'bg-[var(--color-status-warn)]'
     case 'awaiting_verification':
-      return 'bg-[var(--accent)]'
+      return 'bg-[var(--color-accent-fg)]'
     case 'interrupted':
     case 'listening':
-      return 'bg-[var(--accent)]'
+      return 'bg-[var(--color-accent-fg)]'
     case 'inactive':
     case 'offline':
       return 'bg-[#5f7199]'
     case 'active':
-      return 'bg-[var(--ok)]'
+      return 'bg-[var(--color-status-ok)]'
     case 'busy':
     case 'stopped':
       return 'bg-[var(--text-slate)]'
     case 'error':
-      return 'bg-[var(--bad)]'
+      return 'bg-[var(--color-status-err)]'
     default:
-      return 'bg-[var(--text-muted)]'
+      return 'bg-[var(--color-fg-muted)]'
   }
 }
 
 export function StatusBadge({ status, label }: StatusBadgeProps) {
   return html`
-    <span class="border border-solid border-[var(--card-border)] ${status} ${status === 'offline' ? 'text-[var(--text-dim)]' : ''}">
+    <span class="border border-solid border-[var(--color-border-default)] ${status} ${status === 'offline' ? 'text-[var(--color-fg-disabled)]' : ''}">
       <span class="size-1.5 rounded-sm inline-block ${statusDotColor(status)}"></span>
       ${label ?? statusLabel(status)}
     </span>

--- a/dashboard/src/components/common/status-chip.test.ts
+++ b/dashboard/src/components/common/status-chip.test.ts
@@ -12,7 +12,7 @@ describe('isSemanticTone (pure)', () => {
   })
 
   it('rejects raw Tailwind class strings (they pass through as extras)', () => {
-    expect(isSemanticTone('bg-[var(--ok)]')).toBe(false)
+    expect(isSemanticTone('bg-[var(--color-status-ok)]')).toBe(false)
     expect(isSemanticTone('text-accent')).toBe(false)
   })
 })
@@ -64,12 +64,12 @@ describe('statusChipClasses (pure)', () => {
     expect(cls).toContain('uppercase')
     expect(cls).toContain('tracking-wider')
     // neutral fallback
-    expect(cls).toContain('text-[var(--text-muted)]')
+    expect(cls).toContain('text-[var(--color-fg-muted)]')
   })
 
   it("semantic 'ok' maps to ok CSS-var palette", () => {
     const cls = statusChipClasses('ok')
-    expect(cls).toContain('text-[var(--ok)]')
+    expect(cls).toContain('text-[var(--color-status-ok)]')
     expect(cls).toContain('bg-[var(--ok-10)]')
   })
 
@@ -79,10 +79,10 @@ describe('statusChipClasses (pure)', () => {
   })
 
   it('raw Tailwind class string passes through verbatim', () => {
-    const cls = statusChipClasses('bg-[var(--ok)]')
+    const cls = statusChipClasses('bg-[var(--color-status-ok)]')
     // Raw tone gets appended; no semantic-palette leakage.
-    expect(cls).toContain('bg-[var(--ok)]')
-    expect(cls).not.toContain('text-[var(--ok)]') // not expanded
+    expect(cls).toContain('bg-[var(--color-status-ok)]')
+    expect(cls).not.toContain('text-[var(--color-status-ok)]') // not expanded
   })
 
   it('extra class appended (caller composition)', () => {
@@ -95,7 +95,7 @@ describe('statusChipClasses (pure)', () => {
   })
 
   it('base shape tokens present for every tone (regression guard, uppercase=true default)', () => {
-    for (const tone of ['ok', 'warn', 'bad', 'info', 'neutral', '', 'bg-[var(--ok)]']) {
+    for (const tone of ['ok', 'warn', 'bad', 'info', 'neutral', '', 'bg-[var(--color-status-ok)]']) {
       const cls = statusChipClasses(tone)
       for (const token of ['rounded-sm', 'text-3xs', 'uppercase', 'tracking-wider']) {
         expect(cls).toContain(token)
@@ -112,7 +112,7 @@ describe('statusChipClasses uppercase flag', () => {
     // shape + tone still present
     expect(cls).toContain('rounded-sm')
     expect(cls).toContain('text-3xs')
-    expect(cls).toContain('text-[var(--text-muted)]')
+    expect(cls).toContain('text-[var(--color-fg-muted)]')
   })
 
   it('uppercase=true (explicit) matches the default', () => {

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -11,12 +11,12 @@
 // with `rg cmd-chip`: zero hits outside this file). The tone param
 // was a bare string passed straight into `class=`, which meant
 // calls like `<StatusChip tone="warn">` rendered with no styling
-// at all, while calls like `<StatusChip tone="bg-[var(--ok)]">`
+// at all, while calls like `<StatusChip tone="bg-[var(--color-status-ok)]">`
 // (verdictTone helper) rendered correctly. This rewrite closes the
 // gap without breaking either caller shape:
 //   - Semantic tones ('ok'|'warn'|'bad'|'info'|'neutral'|'') map
 //     to Tailwind classes inside the primitive.
-//   - Raw Tailwind class strings (e.g. "bg-[var(--ok)]") pass
+//   - Raw Tailwind class strings (e.g. "bg-[var(--color-status-ok)]") pass
 //     through unchanged as extra classes.
 // Caller helpers continue to work without audit.
 //
@@ -54,14 +54,14 @@ const BASE_SHAPE =
 const UPPERCASE_CLASS = 'uppercase tracking-wider'
 
 const SEMANTIC_TONE: Record<StatusChipTone, string> = {
-  ok: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]',
-  warn: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]',
+  ok: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]',
+  warn: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]',
   bad: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]',
-  info: 'border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--accent)]',
-  neutral: 'border-[var(--white-10)] bg-[var(--white-5)] text-[var(--text-muted)]',
+  info: 'border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]',
+  neutral: 'border-[var(--white-10)] bg-[var(--white-5)] text-[var(--color-fg-muted)]',
   paused: 'border-[var(--paused-20)] bg-[var(--paused-10)] text-[var(--paused)]',
   select: 'border-[var(--select-20)] bg-[var(--select-10)] text-[var(--select)]',
-  '': 'border-[var(--white-10)] bg-[var(--white-5)] text-[var(--text-muted)]',
+  '': 'border-[var(--white-10)] bg-[var(--white-5)] text-[var(--color-fg-muted)]',
 }
 
 /** Keeper lifecycle state → StatusChip tone.
@@ -124,7 +124,7 @@ export function keeperStateTone(state: string): StatusChipTone {
 }
 
 /** Pure: true when `tone` is one of the semantic enum members. Raw
-    Tailwind class strings (`bg-[var(--ok)]`) fall through and are
+    Tailwind class strings (`bg-[var(--color-status-ok)]`) fall through and are
     composed as-is. Exposed so higher-level helpers can branch. */
 export function isSemanticTone(tone: string): tone is StatusChipTone {
   return tone in SEMANTIC_TONE

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -40,15 +40,15 @@ function enqueueToast(toast: Toast) {
 }
 
 const BORDER_COLOR: Record<ToastType, string> = {
-  success: 'border-l-[var(--ok)]',
-  warning: 'border-l-[var(--warn)]',
-  error: 'border-l-[var(--bad)]'
+  success: 'border-l-[var(--color-status-ok)]',
+  warning: 'border-l-[var(--color-status-warn)]',
+  error: 'border-l-[var(--color-status-err)]'
 }
 
 const ICON_COLOR: Record<ToastType, string> = {
-  success: 'text-[var(--ok)]',
-  warning: 'text-[var(--warn)]',
-  error: 'text-[var(--bad)]'
+  success: 'text-[var(--color-status-ok)]',
+  warning: 'text-[var(--color-status-warn)]',
+  error: 'text-[var(--color-status-err)]'
 }
 
 const ICON: Record<ToastType, () => ComponentChildren> = {
@@ -173,7 +173,7 @@ export function ToastContainer() {
         <div
           key=${t.id}
           role=${t.type === 'error' ? 'alert' : 'status'}
-          class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-55 max-w-90 rounded border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-sm animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
+          class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-55 max-w-90 rounded border-l-[3px] border-l-solid border border-solid border-[var(--color-border-default)] bg-[rgba(10,18,34,0.96)] shadow-sm animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
           onMouseEnter=${() => pauseToastTimer(t.id)}
           onMouseLeave=${() => resumeToastTimer(t.id)}
           onFocusIn=${() => pauseToastTimer(t.id)}
@@ -181,11 +181,11 @@ export function ToastContainer() {
           data-toast-id=${t.id}
         >
           <span class="shrink-0 flex items-center ${ICON_COLOR[t.type]}">${ICON[t.type]()}</span>
-          <span class="flex-1 text-sm text-[var(--text-body)] leading-[1.4]">${t.message}</span>
+          <span class="flex-1 text-sm text-[var(--color-fg-primary)] leading-[1.4]">${t.message}</span>
           ${t.action ? html`
             <button
               type="button"
-              class="shrink-0 text-2xs px-2 py-1 rounded border border-[var(--card-border)] bg-[var(--white-5)] text-[var(--accent)] hover:bg-[var(--white-10)] cursor-pointer transition-colors duration-150"
+              class="shrink-0 text-2xs px-2 py-1 rounded border border-[var(--color-border-default)] bg-[var(--white-5)] text-[var(--color-accent-fg)] hover:bg-[var(--white-10)] cursor-pointer transition-colors duration-150"
               onClick=${(e: Event) => {
                 e.stopPropagation()
                 t.action!.onClick()
@@ -197,7 +197,7 @@ export function ToastContainer() {
           ` : null}
           <button
             type="button"
-            class="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer p-1 rounded hover:bg-[var(--white-5)] transition-colors duration-150 flex items-center justify-center"
+            class="shrink-0 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer p-1 rounded hover:bg-[var(--white-5)] transition-colors duration-150 flex items-center justify-center"
             aria-label="닫기"
             title="닫기"
             onClick=${(e: Event) => {

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -140,12 +140,12 @@ export function CompositeFsmFlowchart(props: CompositeFsmFlowchartProps = {}) {
       class="rounded border border-[var(--white-10)] bg-[var(--white-5)] ${props.class ?? ''}"
     >
       <header class="border-b border-[var(--white-10)] p-3">
-        <h2 class="text-sm font-semibold text-[var(--text-muted)]">
+        <h2 class="text-sm font-semibold text-[var(--color-fg-muted)]">
           Composite FSM flowchart (TLA+ spec)
         </h2>
-        <p class="mt-1 text-xs text-[var(--text-muted)]">
+        <p class="mt-1 text-xs text-[var(--color-fg-muted)]">
           6 orthogonal axes rendered as Harel parallel regions. Source:
-          <code class="text-[var(--text-muted)]">specs/keeper-state-machine/*.tla</code>.
+          <code class="text-[var(--color-fg-muted)]">specs/keeper-state-machine/*.tla</code>.
           Transitions here are the common-case edges; the TLA+
           model-checker owns the exhaustive enumeration.
         </p>

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -316,7 +316,7 @@ export function ConnectorConfigToggle({ connectorId }: { connectorId: string }) 
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)]"
       aria-expanded=${entry.open}
       aria-controls=${`connector-config-${connectorId}`}
       onClick=${onClick}
@@ -342,12 +342,12 @@ function FieldWidget({ id, field, value, revealed }: {
     setEntry(id, { reveal: { ...getEntry(id).reveal, [field.name]: !revealed } })
   }
 
-  const baseInput = 'w-full rounded border border-[var(--white-8)] bg-[var(--bg-0)] px-2 py-1 font-mono text-2xs text-[var(--text-body)] focus:border-[var(--accent-1)] focus:outline-none'
+  const baseInput = 'w-full rounded border border-[var(--white-8)] bg-[var(--bg-0)] px-2 py-1 font-mono text-2xs text-[var(--color-fg-primary)] focus:border-[var(--accent-1)] focus:outline-none'
 
   switch (field.type) {
     case 'boolean':
       return html`
-        <label class="flex items-center gap-2 text-2xs text-[var(--text-body)]">
+        <label class="flex items-center gap-2 text-2xs text-[var(--color-fg-primary)]">
           <input
             type="checkbox"
             checked=${value === 'true'}
@@ -382,7 +382,7 @@ function FieldWidget({ id, field, value, revealed }: {
             />
             <button
               type="button"
-              class="shrink-0 cursor-pointer rounded border border-[var(--white-8)] p-1 text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+              class="shrink-0 cursor-pointer rounded border border-[var(--white-8)] p-1 text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)]"
               aria-label=${revealed ? 'Hide value' : 'Reveal value'}
               onClick=${toggleReveal}
             >
@@ -402,7 +402,7 @@ function FieldWidget({ id, field, value, revealed }: {
       `
     default:
       return html`
-        <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-3xs text-[var(--warn)]">
+        <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-3xs text-[var(--color-status-warn)]">
           unsupported type — refactor BotConfig?
         </div>
       `
@@ -443,7 +443,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
 
   if (entry.fields.length === 0) {
     return html`
-      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--white-8)] bg-[var(--bg-1)] p-3 text-2xs text-[var(--text-dim)]">
+      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--white-8)] bg-[var(--bg-1)] p-3 text-2xs text-[var(--color-fg-disabled)]">
         schema가 비어있습니다. backend가 sidecar venv를 못 찾았을 수 있어요.
       </div>
     `
@@ -454,14 +454,14 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
   return html`
     <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--white-8)] bg-[var(--bg-1)] p-3">
       <div class="mb-2 flex items-center justify-between">
-        <div class="text-3xs uppercase tracking-4 text-[var(--text-dim)]">
+        <div class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">
           ${entry.fields.length} fields · ${entry.fields.filter(f => f.required).length} required
           ${entry.lastSavedAt
             ? html`
-                <span class="ml-2 text-[var(--ok)]">· 저장됨 ${new Date(entry.lastSavedAt).toLocaleTimeString()}</span>
+                <span class="ml-2 text-[var(--color-status-ok)]">· 저장됨 ${new Date(entry.lastSavedAt).toLocaleTimeString()}</span>
                 <button
                   type="button"
-                  class="ml-2 cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs text-[var(--ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-50"
+                  class="ml-2 cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-50"
                   disabled=${entry.restarting}
                   title="POST /sidecar/stop → 800ms → POST /sidecar/start"
                   onClick=${() => { void restartSidecar(connectorId) }}
@@ -473,7 +473,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
         </div>
         <div class="flex items-center gap-2">
           <label
-            class="flex cursor-pointer items-center gap-1 text-3xs uppercase tracking-4 text-[var(--text-dim)] hover:text-[var(--text-body)]"
+            class="flex cursor-pointer items-center gap-1 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)]"
             title="저장 직후 자동으로 sidecar 재시작 (stop → 800ms → start)"
           >
             <input
@@ -512,10 +512,10 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
       <div class="space-y-2.5">
         ${entry.fields.map(field => html`
           <div class="flex flex-col gap-1">
-            <label class="flex items-center gap-1.5 text-2xs font-medium text-[var(--text-body)]" for=${`field-${connectorId}-${field.name}`}>
+            <label class="flex items-center gap-1.5 text-2xs font-medium text-[var(--color-fg-primary)]" for=${`field-${connectorId}-${field.name}`}>
               <span>${field.name}</span>
               ${field.required ? html`<span class="text-[var(--bad-light)]" aria-label="required">*</span>` : null}
-              <span class="text-3xs uppercase tracking-4 text-[var(--text-dim)]">${field.type}</span>
+              <span class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">${field.type}</span>
             </label>
             <${FieldWidget}
               id=${connectorId}
@@ -524,13 +524,13 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
               revealed=${entry.reveal[field.name] === true}
             />
             ${field.description
-              ? html`<div class="text-3xs text-[var(--text-dim)]">${field.description}</div>`
+              ? html`<div class="text-3xs text-[var(--color-fg-disabled)]">${field.description}</div>`
               : null}
             ${(() => {
               const hint = getFieldHint(field.name)
               if (hint === null) return null
               return html`
-                <div class="rounded border border-[var(--accent-20)] bg-[var(--accent-10)]0/5 px-2 py-1 text-3xs text-[var(--accent)]" data-field-hint=${field.name}>
+                <div class="rounded border border-[var(--accent-20)] bg-[var(--accent-10)]0/5 px-2 py-1 text-3xs text-[var(--color-accent-fg)]" data-field-hint=${field.name}>
                   <span class="mr-1" aria-hidden="true">📍</span>
                   <span>${hint.where}</span>
                   ${hint.url
@@ -539,7 +539,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
                           href=${hint.url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          class="ml-1 underline hover:text-[var(--accent)]"
+                          class="ml-1 underline hover:text-[var(--color-accent-fg)]"
                         >열기 ↗</a>
                       `
                     : null}
@@ -551,11 +551,11 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
       </div>
 
       <div class="mt-3 border-t border-[var(--white-8)] pt-2.5">
-        <div class="mb-1 text-3xs uppercase tracking-4 text-[var(--text-dim)]">
+        <div class="mb-1 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">
           .env 블록 (현재 입력값)
         </div>
         ${envBlock === ''
-          ? html`<div class="text-3xs text-[var(--text-dim)]">(필수 필드를 채우면 여기에 표시됩니다)</div>`
+          ? html`<div class="text-3xs text-[var(--color-fg-disabled)]">(필수 필드를 채우면 여기에 표시됩니다)</div>`
           : html`<${CopyableCode} command=${envBlock} ariaLabel=${`Copy ${connectorId} .env block`} />`}
       </div>
     </div>

--- a/dashboard/src/components/connector-keeper-matrix.test.ts
+++ b/dashboard/src/components/connector-keeper-matrix.test.ts
@@ -196,7 +196,7 @@ describe('ConnectorKeeperMatrix', () => {
     const cells = container.querySelectorAll('[data-matrix-column-total-bound]')
     const discordCell = cells[0] as HTMLElement
     expect(discordCell.getAttribute('data-matrix-column-total-unknown')).toBe('1')
-    expect(discordCell.className).toContain('text-[var(--warn)]')
+    expect(discordCell.className).toContain('text-[var(--color-status-warn)]')
   })
 
   it('column totals footer dashes empty columns (no bound, no unbound, no unknown)', () => {

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -150,10 +150,10 @@ export function deriveMatrix(
 }
 
 const CELL_TONE: Record<MatrixCellState, { dot: string; text: string; bg: string }> = {
-  bound:   { dot: 'bg-[var(--ok-10)]',     text: 'text-[var(--ok)]',        bg: 'bg-[var(--ok-10)]' },
-  unbound: { dot: 'bg-[var(--white-8)]', text: 'text-[var(--text-dim)]', bg: 'bg-transparent'    },
-  na:      { dot: 'bg-[var(--white-4)]', text: 'text-[var(--text-dim)]', bg: 'bg-transparent'    },
-  unknown: { dot: 'bg-[var(--warn-10)]',       text: 'text-[var(--warn)]',          bg: 'bg-[var(--warn-10)]'   },
+  bound:   { dot: 'bg-[var(--ok-10)]',     text: 'text-[var(--color-status-ok)]',        bg: 'bg-[var(--ok-10)]' },
+  unbound: { dot: 'bg-[var(--white-8)]', text: 'text-[var(--color-fg-disabled)]', bg: 'bg-transparent'    },
+  na:      { dot: 'bg-[var(--white-4)]', text: 'text-[var(--color-fg-disabled)]', bg: 'bg-transparent'    },
+  unknown: { dot: 'bg-[var(--warn-10)]',       text: 'text-[var(--color-status-warn)]',          bg: 'bg-[var(--warn-10)]'   },
 }
 
 const CELL_GLYPH: Record<MatrixCellState, string> = {
@@ -226,22 +226,22 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
   const gridCols = `grid-template-columns: minmax(160px, 1fr) repeat(${matrix.columns.length}, minmax(80px, 1fr)) minmax(90px, auto);`
 
   return html`
-    <section class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-1)] p-3" data-panel="connector-keeper-matrix">
+    <section class="mb-4 rounded border border-[var(--color-border-default)] bg-[var(--bg-1)] p-3" data-panel="connector-keeper-matrix">
       <header class="mb-2 flex items-baseline justify-between gap-3">
         <div>
-          <h4 class="text-xs font-semibold uppercase tracking-4 text-[var(--text-body)]">
+          <h4 class="text-xs font-semibold uppercase tracking-4 text-[var(--color-fg-primary)]">
             Keeper × Connector Matrix
           </h4>
-          <p class="mt-0.5 text-3xs text-[var(--text-dim)]">
+          <p class="mt-0.5 text-3xs text-[var(--color-fg-disabled)]">
             ${matrix.totals.knownKeepers} keeper${matrix.totals.knownKeepers === 1 ? '' : 's'}
             · ${matrix.totals.liveConnectors}/${matrix.columns.length} connector
             · ${matrix.totals.totalBindings} binding${matrix.totals.totalBindings === 1 ? '' : 's'}
             ${matrix.totals.unknownKeepers > 0
-              ? html`· <span class="text-[var(--warn)]">${matrix.totals.unknownKeepers} unknown</span>`
+              ? html`· <span class="text-[var(--color-status-warn)]">${matrix.totals.unknownKeepers} unknown</span>`
               : null}
           </p>
         </div>
-        <div class="text-3xs text-[var(--text-dim)]">
+        <div class="text-3xs text-[var(--color-fg-disabled)]">
           <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--ok-10)]"></span>bound</span>
           <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--white-8)]"></span>unbound</span>
           <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--white-4)]"></span>n/a</span>
@@ -251,18 +251,18 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
 
       ${!hasKeepers
         ? html`
-            <div class="rounded border border-dashed border-[var(--card-border)] px-3 py-4 text-center text-2xs text-[var(--text-dim)]">
+            <div class="rounded border border-dashed border-[var(--color-border-default)] px-3 py-4 text-center text-2xs text-[var(--color-fg-disabled)]">
               No keepers yet — add one under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart.
             </div>
           `
         : html`
             <div class="overflow-x-auto">
               <div class="grid gap-1 text-2xs" style=${gridCols} data-matrix-grid>
-                <div class="px-1 py-1 text-3xs uppercase tracking-4 text-[var(--text-dim)]">Keeper ↓ / Connector →</div>
+                <div class="px-1 py-1 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">Keeper ↓ / Connector →</div>
                 ${matrix.columns.map(colId => html`
                   <button
                     type="button"
-                    class="flex cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-3xs uppercase tracking-3 text-[var(--text-dim)] hover:text-[var(--text-body)]"
+                    class="flex cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-3xs uppercase tracking-3 text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)]"
                     onClick=${() => scrollToConnectorRow(colId)}
                     title=${`${CONNECTOR_DISPLAY_NAMES[colId] ?? colId} — 행으로 이동`}
                   >
@@ -271,7 +271,7 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
                   </button>
                 `)}
                 <div
-                  class="px-1 py-1 text-center text-3xs uppercase tracking-4 text-[var(--text-dim)]"
+                  class="px-1 py-1 text-center text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]"
                   title="Per-keeper coverage totals (bound / unbound / n·a)"
                   data-matrix-coverage-header
                 >커버리지</div>
@@ -299,19 +299,19 @@ function MatrixColumnTotalsRow({ matrix }: { matrix: MatrixData }) {
   )
   return html`
     <div
-      class="col-span-full mt-1 border-t border-[var(--card-border)]"
+      class="col-span-full mt-1 border-t border-[var(--color-border-default)]"
       aria-hidden="true"
       data-matrix-column-totals-divider
     ></div>
     <div
-      class="flex items-center gap-1 px-2 py-1 text-3xs uppercase tracking-4 text-[var(--text-dim)]"
+      class="flex items-center gap-1 px-2 py-1 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]"
       data-matrix-column-totals-label
     >Totals →</div>
     ${matrix.columns.map((_, idx) => html`
       <${ColumnTotalsCell} counts=${summarizeMatrixColumn(matrix, idx)} />
     `)}
     <div
-      class=${`flex items-center justify-end gap-1 px-1 py-1 text-3xs tabular-nums ${totalBound > 0 ? 'text-[var(--ok)]' : 'text-[var(--text-dim)]'}`}
+      class=${`flex items-center justify-end gap-1 px-1 py-1 text-3xs tabular-nums ${totalBound > 0 ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-fg-disabled)]'}`}
       title=${`Grand total: ${totalBound} bound cells across all keepers × connectors`}
       data-matrix-grand-total
       data-matrix-grand-total-bound=${totalBound}
@@ -328,9 +328,9 @@ function ColumnTotalsCell({ counts }: { counts: MatrixStateCounts }) {
   // when any unknowns exist. Empty column (0 bound, 0 unbound) → dash.
   const hasAny = bound + unbound + unknown > 0
   const tone =
-    unknown > 0 ? 'text-[var(--warn)]' :
-    bound > 0 ? 'text-[var(--ok)]' :
-    'text-[var(--text-dim)]'
+    unknown > 0 ? 'text-[var(--color-status-warn)]' :
+    bound > 0 ? 'text-[var(--color-status-ok)]' :
+    'text-[var(--color-fg-disabled)]'
   const label = hasAny ? `${bound}` : '—'
   const title = `${bound} bound · ${unbound} unbound · ${unknown} unknown · ${counts.na} n/a`
   return html`
@@ -351,11 +351,11 @@ function MatrixRowRender({ row }: { row: MatrixRow }) {
   return html`
     <button
       type="button"
-      class=${`flex cursor-pointer items-center gap-2 truncate rounded px-2 py-1 text-left text-xs hover:bg-[var(--white-4)] ${row.known ? 'text-[var(--text-body)]' : 'text-[var(--warn)]'}`}
+      class=${`flex cursor-pointer items-center gap-2 truncate rounded px-2 py-1 text-left text-xs hover:bg-[var(--white-4)] ${row.known ? 'text-[var(--color-fg-primary)]' : 'text-[var(--color-status-warn)]'}`}
       onClick=${() => scrollToKeeper(row.keeperName)}
       title=${row.known ? row.keeperName : `${row.keeperName} — directory 밖 keeper`}
     >
-      ${row.known ? null : html`<span class="text-[var(--warn)]" aria-hidden="true">⚠</span>`}
+      ${row.known ? null : html`<span class="text-[var(--color-status-warn)]" aria-hidden="true">⚠</span>`}
       <span class="truncate">${row.keeperName}</span>
     </button>
     ${row.cells.map(cell => html`<${MatrixCellButton} cell=${cell} />`)}
@@ -377,9 +377,9 @@ function RowCoverageChip({
   // Tone follows the dominant state: if anything is unknown → amber,
   // else if all live cells are bound → emerald, else muted.
   const tone =
-    unknown > 0 ? 'text-[var(--warn)]' :
-    (bound > 0 && unbound === 0) ? 'text-[var(--ok)]' :
-    'text-[var(--text-dim)]'
+    unknown > 0 ? 'text-[var(--color-status-warn)]' :
+    (bound > 0 && unbound === 0) ? 'text-[var(--color-status-ok)]' :
+    'text-[var(--color-fg-disabled)]'
   return html`
     <div
       class=${`flex items-center justify-end gap-1 px-1 py-1 text-3xs tabular-nums ${tone}`}

--- a/dashboard/src/components/connector-onboarding.ts
+++ b/dashboard/src/components/connector-onboarding.ts
@@ -48,18 +48,18 @@ function OnboardingCard({ connectorId }: { connectorId: KnownConnectorId }) {
       <div class="mb-2 flex items-center justify-between gap-2">
         <div class="flex items-center gap-2">
           <span class="text-base leading-none" aria-hidden="true">${channelIcon(connectorId)}</span>
-          <span class="text-sm font-semibold text-[var(--text-body)]">${CONNECTOR_DISPLAY_NAMES[connectorId]}</span>
+          <span class="text-sm font-semibold text-[var(--color-fg-primary)]">${CONNECTOR_DISPLAY_NAMES[connectorId]}</span>
         </div>
         <button
           type="button"
-          class=${`rounded cursor-pointer transition-all duration-200 font-medium border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--text-strong)] hover:bg-[var(--accent-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] py-1 px-2 text-3xs ${starting ? 'opacity-50 pointer-events-none' : 'active:scale-[0.97]'}`}
+          class=${`rounded cursor-pointer transition-all duration-200 font-medium border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--color-fg-secondary)] hover:bg-[var(--accent-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] py-1 px-2 text-3xs ${starting ? 'opacity-50 pointer-events-none' : 'active:scale-[0.97]'}`}
           disabled=${starting}
           aria-busy=${starting ? 'true' : 'false'}
           data-onboarding-start=${connectorId}
           onClick=${() => { void onStart() }}
         >${onboardingStartLabel(starting)}</button>
       </div>
-      <div class="text-2xs text-[var(--text-dim)]">
+      <div class="text-2xs text-[var(--color-fg-disabled)]">
         <strong>Start</strong>를 누르면 backend가 sidecar를 spawn합니다. 또는 명령을 복사해 새 터미널에서 직접 실행하세요.
       </div>
       <div class="mt-2 grid grid-cols-1 gap-1.5">
@@ -75,8 +75,8 @@ export function ConnectorOnboardingGrid() {
   return html`
     <div>
       <div class="mb-3">
-        <h3 class="text-sm font-semibold text-[var(--text-body)]">아직 연결된 sidecar가 없습니다</h3>
-        <div class="mt-1 text-2xs text-[var(--text-dim)]">
+        <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">아직 연결된 sidecar가 없습니다</h3>
+        <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">
           4개의 채널 sidecar를 켤 수 있습니다. 카드의 시작 명령을 복사해 새 터미널에서 실행하거나, 아래
           <strong>Start All</strong>로 한 번에 spawn하세요. spawn 후 이 화면이 라이브 상태로 갱신됩니다.
         </div>

--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -413,7 +413,7 @@ describe('TilePrimaryAction component (rendered inside ConnectorOverviewStrip)',
     expect(btn).toBeTruthy()
     expect(btn.getAttribute('data-tile-primary-action-tone')).toBe('start')
     expect(btn.textContent?.trim()).toBe('▶ Start')
-    expect(btn.className).toContain('var(--ok)')
+    expect(btn.className).toContain('var(--color-status-ok)')
   })
 
   it('renders a Stop button (bad) for an up sidecar', () => {
@@ -767,7 +767,7 @@ describe('TileErrorNotice component (rendered inside ConnectorOverviewStrip)', (
     )
     const notice = container.querySelector('[data-tile-notice="stale"]') as HTMLElement
     expect(notice.textContent).toContain('Stale')
-    expect(notice.className).toContain('var(--warn)')
+    expect(notice.className).toContain('var(--color-status-warn)')
   })
 
   it('renders nothing when connector is clean (no ribbon clutter)', () => {

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -156,7 +156,7 @@ export function summarizeOverviewTile(
   if (connector === null || connector.available !== true) {
     return {
       badge: '설정 필요',
-      badgeClass: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]',
+      badgeClass: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]',
       detail: keeperCount > 0
         ? '아직 시작되지 않음 · 시작 후 keeper를 바인딩하세요'
         : '아직 시작되지 않음 · 먼저 Config와 Start가 필요합니다',
@@ -180,7 +180,7 @@ export function summarizeOverviewTile(
   if (bindingCount === 0) {
     return {
       badge: '바인딩 필요',
-      badgeClass: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]',
+      badgeClass: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]',
       detail: keeperCount > 0
         ? '실행 중 · 아직 channel binding이 없습니다'
         : '실행 중 · keeper 디렉토리가 비어 있습니다',
@@ -189,7 +189,7 @@ export function summarizeOverviewTile(
 
   return {
     badge: '정상',
-    badgeClass: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]',
+    badgeClass: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]',
     detail: `실행 중 · ${bindingCount} ${bindingCount === 1 ? 'binding' : 'bindings'} active`,
   }
 }
@@ -235,7 +235,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
     <div
       class=${`flex min-w-0 flex-col gap-3 rounded border bg-[var(--bg-1)] p-3 transition-colors ${
         selected
-          ? 'border-[var(--accent)] shadow-[0_0_0_1px_var(--accent-18)]'
+          ? 'border-[var(--color-accent-fg)] shadow-[0_0_0_1px_var(--accent-18)]'
           : 'border-[var(--white-8)] hover:border-[var(--white-10)]'
       }`}
       data-overview-tile=${id}
@@ -254,24 +254,24 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
         >${channelIcon(id)}</span>
         <span class="min-w-0 flex-1">
           <span class="flex items-center gap-2">
-            <span class="block truncate text-sm font-semibold text-[var(--text-body)]">${displayName}</span>
+            <span class="block truncate text-sm font-semibold text-[var(--color-fg-primary)]">${displayName}</span>
             <span class=${`rounded-sm border px-2 py-0.5 text-3xs font-medium ${summary.badgeClass}`}>${summary.badge}</span>
             ${uptimeLabel !== null
               ? html`
                   <span
-                    class="rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-px text-3xs font-normal text-[var(--ok)]/80"
+                    class="rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-px text-3xs font-normal text-[var(--color-status-ok)]/80"
                     data-uptime-chip
                     title="last_ready_at 기준 경과 시간"
                   >${uptimeLabel}</span>
                 `
               : null}
           </span>
-          <span class="mt-1 block text-2xs leading-5 text-[var(--text-dim)]" data-overview-summary>${summary.detail}</span>
+          <span class="mt-1 block text-2xs leading-5 text-[var(--color-fg-disabled)]" data-overview-summary>${summary.detail}</span>
           ${(() => {
             const identity = formatTileIdentityLine(connector)
             return identity !== null
               ? html`<span
-                  class="mt-1 block truncate text-3xs text-[var(--text-dim)]"
+                  class="mt-1 block truncate text-3xs text-[var(--color-fg-disabled)]"
                   data-tile-identity=${id}
                   title=${identity}
                 >${identity}</span>`
@@ -280,7 +280,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
         </span>
       </button>
       <${ConnectorReadinessRail} pills=${pills} />
-      <span class=${`text-3xs uppercase tracking-4 ${selected ? 'text-[var(--accent-1)]' : 'text-[var(--text-dim)]'}`}>
+      <span class=${`text-3xs uppercase tracking-4 ${selected ? 'text-[var(--accent-1)]' : 'text-[var(--color-fg-disabled)]'}`}>
         ${selected ? 'Selected' : 'View Details'}
       </span>
       <${TilePrimaryAction} id=${id} sidecarUp=${sidecarUp} />
@@ -344,7 +344,7 @@ const TILE_ACTION_TONE_CLASS: Record<'start' | 'stop', string> = {
   // across per-tile + bulk controls. The per-tile button is deliberately
   // block-width and text-xs so it reads as the primary action of the
   // tile, distinct from the smaller pill row above.
-  start: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)] hover:bg-[var(--ok-10)]',
+  start: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)] hover:bg-[var(--ok-10)]',
   stop: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-10)]',
 }
 
@@ -416,7 +416,7 @@ const TILE_NOTICE_TONE_CLASS: Record<'error' | 'stale', string> = {
   // amber for stale (data hasn't refreshed but no explicit error).
   // Matches Sentry \"issue\" rose + Vercel \"warning\" amber convention.
   error: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]',
-  stale: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]',
+  stale: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]',
 }
 
 const TILE_NOTICE_GLYPH: Record<'error' | 'stale', string> = {
@@ -505,7 +505,7 @@ function deriveTrendColor(series: readonly number[]): string {
   // Tailwind emerald-400 / amber-400 / rose-400 hex codes — matches
   // the border-*-400 tones used on HeartbeatUptimeChip.
   if (last >= 99) return '#34d399'
-  if (last >= 95) return 'var(--warn)'
+  if (last >= 95) return 'var(--color-status-warn)'
   return 'var(--rose-light)'
 }
 
@@ -522,10 +522,10 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
   const startBusy = bulkInflight.value.start
   const stopBusy = bulkInflight.value.stop
   return html`
-    <div class="flex items-center gap-2 text-2xs text-[var(--text-dim)]">
+    <div class="flex items-center gap-2 text-2xs text-[var(--color-fg-disabled)]">
       <button
         type="button"
-        class="cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-2 py-1 text-2xs text-[var(--ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-40"
+        class="cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-2 py-1 text-2xs text-[var(--color-status-ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-40"
         disabled=${startBusy || downCount === 0}
         title=${downCount === 0 ? '모두 이미 실행 중' : `${downCount} 개 sidecar 시작`}
         onClick=${() => { void runBulk('start', c => c?.available !== true, connectors) }}
@@ -635,7 +635,7 @@ function StatusSummaryLine({ summary, connectors }: { summary: ConnectorStripSum
   const offlineLabel = formatOfflineConnectorLabel(offlineConnectorNames(connectors))
   return html`
     <div
-      class="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-2xs text-[var(--text-dim)]"
+      class="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-2xs text-[var(--color-fg-disabled)]"
       data-strip-summary
     >
       <${LivePulseDot}
@@ -645,7 +645,7 @@ function StatusSummaryLine({ summary, connectors }: { summary: ConnectorStripSum
         testId="overview-strip-live"
       />
       <span>
-        <span class="font-semibold text-[var(--text-body)]" data-strip-summary-running>${summary.runningCount}/${summary.connectorTotal}</span>
+        <span class="font-semibold text-[var(--color-fg-primary)]" data-strip-summary-running>${summary.runningCount}/${summary.connectorTotal}</span>
         <span> running</span>
         ${offlineLabel !== null
           ? html`<span
@@ -657,12 +657,12 @@ function StatusSummaryLine({ summary, connectors }: { summary: ConnectorStripSum
       </span>
       <span aria-hidden="true" class="text-[var(--white-10)]">·</span>
       <span>
-        <span class="font-semibold text-[var(--text-body)]" data-strip-summary-healthy>${summary.healthyCount}/${summary.connectorTotal}</span>
+        <span class="font-semibold text-[var(--color-fg-primary)]" data-strip-summary-healthy>${summary.healthyCount}/${summary.connectorTotal}</span>
         <span> healthy</span>
       </span>
       <span aria-hidden="true" class="text-[var(--white-10)]">·</span>
       <span>
-        <span class="font-semibold text-[var(--text-body)]" data-strip-summary-bindings>${summary.bindingCount}</span>
+        <span class="font-semibold text-[var(--color-fg-primary)]" data-strip-summary-bindings>${summary.bindingCount}</span>
         <span> ${summary.bindingCount === 1 ? 'binding' : 'bindings'}</span>
       </span>
     </div>
@@ -718,7 +718,7 @@ export function ConnectorOverviewStrip({
   const summary = summarizeConnectorStrip(connectors, keeperCount)
   return html`
     <div
-      class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-1)] p-3"
+      class="mb-4 rounded border border-[var(--color-border-default)] bg-[var(--bg-1)] p-3"
       data-overview-strip-root
     >
       <${IncidentBanner} droppedIds=${droppedIds} />

--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -67,7 +67,7 @@ function PathRow({ label, value, hint }: { label: string; value: string; hint: s
   return html`
     <div class="flex items-center gap-2" data-paths-row=${label}>
       <span
-        class="w-25 shrink-0 text-3xs uppercase tracking-4 text-[var(--text-dim)]"
+        class="w-25 shrink-0 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]"
         title=${hint}
       >${label}</span>
       <div class="min-w-0 flex-1">
@@ -82,12 +82,12 @@ export function ConnectorPathsStrip({ connectors }: { connectors: GateConnectorI
   const open = pathsExpanded.value
   return html`
     <div
-      class="mb-3 rounded border border-[var(--card-border)] bg-[var(--bg-1)]"
+      class="mb-3 rounded border border-[var(--color-border-default)] bg-[var(--bg-1)]"
       data-panel="connector-paths-strip"
     >
       <button
         type="button"
-        class="flex w-full cursor-pointer items-center justify-between gap-3 px-3 py-2 text-left text-2xs text-[var(--text-dim)] hover:text-[var(--text-body)]"
+        class="flex w-full cursor-pointer items-center justify-between gap-3 px-3 py-2 text-left text-2xs text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)]"
         onClick=${() => { pathsExpanded.value = !open }}
         aria-expanded=${open}
         aria-controls="connector-paths-body"
@@ -95,13 +95,13 @@ export function ConnectorPathsStrip({ connectors }: { connectors: GateConnectorI
         <span>
           <span class="mr-2 text-3xs uppercase tracking-4">Paths</span>
           <span class="font-mono">${paths.connectorsDir ?? paths.sidecarsDir}</span>
-          <span class="ml-2 text-[var(--text-dim)]">${paths.connectorsDir ? '' : '(런타임 미관찰 · sidecar 경로만 표시)'}</span>
+          <span class="ml-2 text-[var(--color-fg-disabled)]">${paths.connectorsDir ? '' : '(런타임 미관찰 · sidecar 경로만 표시)'}</span>
         </span>
         <span>${open ? '▴' : '▾'}</span>
       </button>
       ${open
         ? html`
-            <div id="connector-paths-body" class="space-y-1.5 border-t border-[var(--card-border)] px-3 py-2">
+            <div id="connector-paths-body" class="space-y-1.5 border-t border-[var(--color-border-default)] px-3 py-2">
               ${paths.connectorsDir
                 ? html`<${PathRow} label="Connectors" value=${paths.connectorsDir} hint="sidecar names.json / status.json 위치" />`
                 : null}

--- a/dashboard/src/components/connector-quick-bind.ts
+++ b/dashboard/src/components/connector-quick-bind.ts
@@ -99,11 +99,11 @@ export function QuickBindForm({ connectorId, keepers }: {
 
   return html`
     <div
-      class="mt-3 flex flex-wrap items-end gap-2 rounded border border-dashed border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2.5"
+      class="mt-3 flex flex-wrap items-end gap-2 rounded border border-dashed border-[var(--color-border-default)] bg-[var(--white-2)] px-3 py-2.5"
       data-quick-bind=${connectorId}
     >
       <div class="min-w-0 flex-1 basis-[160px]">
-        <label class="mb-1 block text-3xs uppercase tracking-4 text-[var(--text-dim)]" for=${`qb-channel-${connectorId}`}>
+        <label class="mb-1 block text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]" for=${`qb-channel-${connectorId}`}>
           채널 ID
         </label>
         <${TextInput}
@@ -125,12 +125,12 @@ export function QuickBindForm({ connectorId, keepers }: {
         />
       </div>
       <div class="min-w-0 basis-[140px]">
-        <label class="mb-1 block text-3xs uppercase tracking-4 text-[var(--text-dim)]" for=${`qb-keeper-${connectorId}`}>
+        <label class="mb-1 block text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]" for=${`qb-keeper-${connectorId}`}>
           Keeper
         </label>
         <select
           id=${`qb-keeper-${connectorId}`}
-          class="w-full rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 font-mono text-2xs text-[var(--text-body)] focus:border-[var(--accent-1)] focus:outline-none"
+          class="w-full rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 font-mono text-2xs text-[var(--color-fg-primary)] focus:border-[var(--accent-1)] focus:outline-none"
           onChange=${(ev: Event) => {
             const target = ev.currentTarget as HTMLSelectElement
             setEntry(connectorId, { keeperName: target.value })

--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -71,7 +71,7 @@ const TONE: Record<RailState, { bg: string; border: string; text: string; dot: s
   ok: {
     bg: 'bg-[var(--ok-10)]',
     border: 'border-[var(--ok-20)]',
-    text: 'text-[var(--ok)]',
+    text: 'text-[var(--color-status-ok)]',
     dot: 'bg-[var(--ok-10)]',
     icon: '✓',
     // Grafana Stat panel "Background Gradient" mode — subtle vertical
@@ -82,7 +82,7 @@ const TONE: Record<RailState, { bg: string; border: string; text: string; dot: s
   warn: {
     bg: 'bg-[var(--warn-10)]',
     border: 'border-[var(--warn-20)]',
-    text: 'text-[var(--warn)]',
+    text: 'text-[var(--color-status-warn)]',
     dot: 'bg-[var(--warn-10)]',
     icon: '!',
     gradient: 'bg-gradient-to-b from-amber-500/15 to-amber-500/0',
@@ -98,7 +98,7 @@ const TONE: Record<RailState, { bg: string; border: string; text: string; dot: s
   idle: {
     bg: 'bg-[var(--white-3)]',
     border: 'border-[var(--white-8)]',
-    text: 'text-[var(--text-dim)]',
+    text: 'text-[var(--color-fg-disabled)]',
     dot: 'bg-[var(--white-10)]',
     icon: '·',
     gradient: 'bg-gradient-to-b from-[var(--white-4)] to-[var(--white-2)]',

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -285,11 +285,11 @@ export function headerSuccessTone(successPct: number | null | undefined): Header
 /** Pure: map header tone to a Tailwind text-color utility. */
 export function headerStatToneClass(tone: HeaderStatTone): string {
   switch (tone) {
-    case 'ok':      return 'text-[var(--ok)]'
-    case 'partial': return 'text-[var(--warn)]'
+    case 'ok':      return 'text-[var(--color-status-ok)]'
+    case 'partial': return 'text-[var(--color-status-warn)]'
     case 'bad':     return 'text-[var(--bad-light)]'
     case 'default':
-    default:        return 'text-[var(--text-body)]'
+    default:        return 'text-[var(--color-fg-primary)]'
   }
 }
 
@@ -320,7 +320,7 @@ export function HeaderMiniStat({
       data-testid=${testId}
     >
       <span class=${`text-sm font-semibold tabular-nums leading-tight ${valueTone}`}>${value}</span>
-      <span class="mt-0.5 text-3xs uppercase tracking-5 text-[var(--text-dim)]">${label}</span>
+      <span class="mt-0.5 text-3xs uppercase tracking-5 text-[var(--color-fg-disabled)]">${label}</span>
     </div>
   `
 }
@@ -331,13 +331,13 @@ function healthTone(health: string): { dot: string; badge: string; label: string
     case 'healthy':
       return {
         dot: 'var(--green)',
-        badge: 'border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]',
+        badge: 'border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]',
         label: 'healthy',
       }
     case 'degraded':
       return {
         dot: 'var(--yellow)',
-        badge: 'border border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]',
+        badge: 'border border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]',
         label: 'degraded',
       }
     case 'failing':
@@ -348,8 +348,8 @@ function healthTone(health: string): { dot: string; badge: string; label: string
       }
     default:
       return {
-        dot: 'var(--text-dim)',
-        badge: 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-dim)]',
+        dot: 'var(--color-fg-disabled)',
+        badge: 'border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-disabled)]',
         label: health || 'idle',
       }
   }
@@ -401,7 +401,7 @@ function dotClass(state: LivenessState): string {
     case 'down':
       return 'bg-[var(--bad-10)]'
     default:
-      return 'bg-[var(--text-dim)]'
+      return 'bg-[var(--color-fg-disabled)]'
   }
 }
 
@@ -414,7 +414,7 @@ function dotClassForLabel(label: string): string {
     case 'disconnected':
       return 'bg-[var(--bad-10)]'
     default:
-      return 'bg-[var(--text-dim)]'
+      return 'bg-[var(--color-fg-disabled)]'
   }
 }
 
@@ -477,12 +477,12 @@ export function connectorCardBorderClass(label: string): string {
 function connectorStateTone(connector: GateConnectorInfo | null): string {
   const label = connectorStateLabel(connector)
   if (label === 'connected') {
-    return 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]'
+    return 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]'
   }
   if (label === 'disconnected') {
     return 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]'
   }
-  return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]'
+  return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
 }
 
 function findKnownConnector(connectors: GateConnectorInfo[], connectorId: KnownConnectorId): GateConnectorInfo | null {
@@ -826,24 +826,24 @@ function ConnectorLivePanel({
   const headerIcon = channelIcon(connector?.channel ?? connectorId)
 
   return html`
-    <div id=${`connector-card-${connectorId}`} class=${`mb-4 scroll-mt-4 rounded border border-[var(--card-border)] ${connectorCardBorderClass(directLabel)} p-4`} data-connector-card-state=${directLabel} style=${connectorAccentStyle(connectorId)}>
+    <div id=${`connector-card-${connectorId}`} class=${`mb-4 scroll-mt-4 rounded border border-[var(--color-border-default)] ${connectorCardBorderClass(directLabel)} p-4`} data-connector-card-state=${directLabel} style=${connectorAccentStyle(connectorId)}>
       <div class="flex flex-wrap items-center gap-2 text-xs">
         <span class="text-base leading-none" aria-hidden="true">${headerIcon}</span>
-        <span class="text-sm font-semibold text-[var(--text-body)]">${connectorName}</span>
+        <span class="text-sm font-semibold text-[var(--color-fg-primary)]">${connectorName}</span>
         ${connector?.bot_user_name
-          ? html`<span class="text-[var(--text-dim)]">· ${connector.bot_user_name}</span>`
+          ? html`<span class="text-[var(--color-fg-disabled)]">· ${connector.bot_user_name}</span>`
           : null}
-        <span class="text-[var(--text-dim)]">·</span>
+        <span class="text-[var(--color-fg-disabled)]">·</span>
         <span class=${`inline-flex items-center gap-1.5 rounded-sm border px-2 py-0.5 text-3xs uppercase tracking-4 ${directTone}`}>
           <span class=${`inline-block h-2 w-2 rounded-full ${dotClassForLabel(directLabel)}`}></span>
           <span>${directLabel}</span>
         </span>
-        <span class="text-[var(--text-dim)]">· hb ${timeAgo(connector?.updated_at ?? '')}</span>
+        <span class="text-[var(--color-fg-disabled)]">· hb ${timeAgo(connector?.updated_at ?? '')}</span>
         ${connector?.reply_mode
-          ? html`<span class="text-[var(--text-dim)]">· reply ${connector.reply_mode}</span>`
+          ? html`<span class="text-[var(--color-fg-disabled)]">· reply ${connector.reply_mode}</span>`
           : null}
         ${connector?.self_chat_guid
-          ? html`<span class="text-[var(--text-dim)]">· self-chat ${truncateMiddle(connector.self_chat_guid, 28)}</span>`
+          ? html`<span class="text-[var(--color-fg-disabled)]">· self-chat ${truncateMiddle(connector.self_chat_guid, 28)}</span>`
           : null}
         <span class="ml-auto flex items-center gap-2">
           ${connector?.available
@@ -860,11 +860,11 @@ function ConnectorLivePanel({
           <${SidecarLogToggle} connectorId=${connectorId} />
           <${ConnectorConfigToggle} connectorId=${connectorId} />
           ${sidecarLogPath
-            ? html`<span class="cursor-help text-3xs text-[var(--text-dim)]" title=${sidecarLogPath}>↗</span>`
+            ? html`<span class="cursor-help text-3xs text-[var(--color-fg-disabled)]" title=${sidecarLogPath}>↗</span>`
             : null}
           <button
             type="button"
-            class="cursor-pointer rounded border border-[var(--card-border)] px-1.5 text-2xs text-[var(--text-dim)] hover:text-[var(--text-body)]"
+            class="cursor-pointer rounded border border-[var(--color-border-default)] px-1.5 text-2xs text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)]"
             aria-label="toggle header details"
             onClick=${() => { patchConnectorUiState(connectorId, { headerExpanded: !ui.headerExpanded }) }}
           >${ui.headerExpanded ? '▴' : '▾'}</button>
@@ -905,20 +905,20 @@ function ConnectorLivePanel({
 
       ${ui.headerExpanded
         ? html`
-            <div class="mt-2 rounded border border-[var(--card-border)] bg-[var(--white-4)] p-3 text-2xs">
+            <div class="mt-2 rounded border border-[var(--color-border-default)] bg-[var(--white-4)] p-3 text-2xs">
               <div class="space-y-1.5">
                 ${livenessDots.map(dot => html`
                   <div class="flex min-w-0 flex-wrap items-center gap-2">
                     <span class=${`inline-block h-2 w-2 rounded-full ${dotClass(dot.state)}`}></span>
                     <span class="font-medium">${dot.label}</span>
-                    <span class="text-[var(--text-dim)]">${dot.detail}</span>
+                    <span class="text-[var(--color-fg-disabled)]">${dot.detail}</span>
                     ${dot.hint && (dot.state === 'down' || dot.state === 'warn')
-                      ? html`<span class="italic text-[var(--text-dim)]">— ${dot.hint}</span>`
+                      ? html`<span class="italic text-[var(--color-fg-disabled)]">— ${dot.hint}</span>`
                       : null}
                   </div>
                 `)}
               </div>
-              <div class="mt-3 flex flex-wrap gap-3 text-3xs text-[var(--text-dim)]">
+              <div class="mt-3 flex flex-wrap gap-3 text-3xs text-[var(--color-fg-disabled)]">
                 <span>guilds ${connector?.guild_count ?? 0}</span>
                 <span>gate ${gateHealthLabel}</span>
                 <span>source ${connector?.binding_source || 'unknown'}</span>
@@ -934,8 +934,8 @@ function ConnectorLivePanel({
 
       ${connectorError || connector?.error
         ? html`
-            <div class="mt-3 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]" data-connector-warning-panel>
-              <div class="font-semibold text-[var(--text-body)]">
+            <div class="mt-3 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--color-status-warn)]" data-connector-warning-panel>
+              <div class="font-semibold text-[var(--color-fg-primary)]">
                 ${connectorError ? 'Connector API unavailable' : 'Sidecar status warning'}
               </div>
               <div class="mt-1">
@@ -957,18 +957,18 @@ function ConnectorLivePanel({
       ${keeperDirectoryError && keepers.length === 0
         ? html`
             <div
-              class="mt-3 rounded border border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]"
+              class="mt-3 rounded border border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--color-status-warn)]"
               data-keeper-directory-error-panel
             >
               <span
-                class="mr-2 inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--warn)]"
+                class="mr-2 inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-status-warn)]"
                 aria-label="Keeper directory status: unavailable"
               >
                 <span aria-hidden="true">⚠</span>
                 <span>디렉토리 오류</span>
               </span>
               ${connector?.gate_health_checked_at
-                ? html`<span class="text-3xs text-[var(--text-dim)]">checked ${timeAgo(connector.gate_health_checked_at)}</span>`
+                ? html`<span class="text-3xs text-[var(--color-fg-disabled)]">checked ${timeAgo(connector.gate_health_checked_at)}</span>`
                 : null}
               <div class="mt-1">
                 <span class="font-medium">Cause: </span> keeper directory unavailable, manual entry only.
@@ -988,16 +988,16 @@ function ConnectorLivePanel({
             >
               <div class="mb-1 flex items-center gap-2">
                 <span
-                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--warn)]"
+                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-status-warn)]"
                   aria-label="Keeper configuration status: none configured"
                   data-no-keepers-status-chip
                 >
                   <span aria-hidden="true">⊘</span>
                   <span>설정 필요</span>
                 </span>
-                <span class="font-medium text-[var(--text-body)]">설정된 키퍼 없음</span>
+                <span class="font-medium text-[var(--color-fg-primary)]">설정된 키퍼 없음</span>
               </div>
-              <div class="text-3xs text-[var(--warn)]/80">
+              <div class="text-3xs text-[var(--color-status-warn)]/80">
                 Add keeper config files under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart the server.
               </div>
             </div>
@@ -1029,16 +1029,16 @@ function ConnectorLivePanel({
                 <div class="mb-1 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                   <div class="flex flex-wrap items-center gap-2">
                     <span
-                      class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--warn)]"
+                      class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-status-warn)]"
                       aria-label="Sidecar process status: not running"
                       data-sidecar-status-chip
                     >
                       <span aria-hidden="true">⊘</span>
                       <span>실행 중 아님</span>
                     </span>
-                    <span class="font-medium text-[var(--text-body)]">사이드카 미시작</span>
+                    <span class="font-medium text-[var(--color-fg-primary)]">사이드카 미시작</span>
                     ${connector?.updated_at
-                      ? html`<span class="text-3xs text-[var(--text-dim)]">last seen ${timeAgo(connector.updated_at)}</span>`
+                      ? html`<span class="text-3xs text-[var(--color-fg-disabled)]">last seen ${timeAgo(connector.updated_at)}</span>`
                       : null}
                   </div>
                   <div class="flex flex-wrap items-center gap-2 sm:justify-end">
@@ -1048,10 +1048,10 @@ function ConnectorLivePanel({
                       disabled=${isActionLoading}
                       onClick=${() => { void startSidecar(connectorId) }}
                     >${isActionLoading ? '...' : 'Start'}<//>
-                    <span class="text-3xs uppercase tracking-4 text-[var(--text-dim)]">${connectorName}</span>
+                    <span class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">${connectorName}</span>
                   </div>
                 </div>
-                <div class="text-2xs text-[var(--warn)]/80">
+                <div class="text-2xs text-[var(--color-status-warn)]/80">
                   <div>
                     <span class="font-medium">Cause: </span> no sidecar status file has been observed at <code class="rounded bg-[var(--white-4)] px-1">${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}</code>.
                   </div>
@@ -1068,7 +1068,7 @@ function ConnectorLivePanel({
                   />
                 </div>
                 <div class="mt-2">
-                  <div class="mb-1 text-3xs uppercase tracking-4 text-[var(--text-dim)]">
+                  <div class="mb-1 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">
                     Or for diagnostics
                   </div>
                   <div class="grid grid-cols-1 gap-1.5" data-sidecar-secondary-cmds>
@@ -1109,11 +1109,11 @@ function ConnectorLivePanel({
                   aria-label="Keeper 필터"
                   data-testid=${`keeper-filter-${connectorId}`}
                   onInput=${(e: Event) => { patchConnectorUiState(connectorId, { keeperGroupQuery: (e.target as HTMLInputElement).value }) }}
-                  class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                  class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
                 />
               </div>
               ${isFilteringKeepers && visibleKnownGroups.length === 0
-                ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${knownGroups.length} keepers)</div>`
+                ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${knownGroups.length} keepers)</div>`
                 : null}
               ${visibleKnownGroups.map(group => {
                 const keeper = group.keeper
@@ -1129,12 +1129,12 @@ function ConnectorLivePanel({
                   }
                 }
                 return html`
-                  <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-2" data-keeper=${group.name}>
+                  <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-4)] px-3 py-2" data-keeper=${group.name}>
                     <div class="flex flex-wrap items-baseline gap-3">
-                      <div class="text-sm font-medium text-[var(--text-body)]">${group.name}</div>
+                      <div class="text-sm font-medium text-[var(--color-fg-primary)]">${group.name}</div>
                       ${keeper
                         ? html`
-                            <div class="text-3xs text-[var(--text-dim)]">
+                            <div class="text-3xs text-[var(--color-fg-disabled)]">
                               status ${keeper.status || 'unknown'}
                               ${modelLabelForKeeper(keeper) ? ` · model ${modelLabelForKeeper(keeper)}` : ''}
                               ${runtimeLabelForKeeper(keeper) ? ` · runtime ${runtimeLabelForKeeper(keeper)}` : ''}
@@ -1144,19 +1144,19 @@ function ConnectorLivePanel({
                     </div>
 
                     ${group.bindings.length === 0
-                      ? html`<div class="mt-1 text-2xs text-[var(--text-dim)]">(no channels)</div>`
+                      ? html`<div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">(no channels)</div>`
                       : html`
                           <div class="mt-2 space-y-1">
                             ${group.bindings.map(binding => {
                               const humanized = humanizeChannel(names, binding.channel_id)
                               return html`
                                 <div class="flex items-center justify-between gap-3 text-xs" data-channel-id=${binding.channel_id}>
-                                  <div class="min-w-0 text-[var(--text-body)]">
-                                    <span class="mr-1 text-[var(--text-dim)]">·</span>
+                                  <div class="min-w-0 text-[var(--color-fg-primary)]">
+                                    <span class="mr-1 text-[var(--color-fg-disabled)]">·</span>
                                     ${humanized
                                       ? html`<span>${humanized}</span>`
-                                      : html`<span class="text-[var(--text-dim)]" title="sidecar has not sent names yet">names pending</span>`}
-                                    <span class="ml-2 text-3xs text-[var(--text-dim)]">(${truncateMiddle(binding.channel_id, 14)})</span>
+                                      : html`<span class="text-[var(--color-fg-disabled)]" title="sidecar has not sent names yet">names pending</span>`}
+                                    <span class="ml-2 text-3xs text-[var(--color-fg-disabled)]">(${truncateMiddle(binding.channel_id, 14)})</span>
                                   </div>
                                   ${bindingActionsEnabled
                                     ? html`
@@ -1180,14 +1180,14 @@ function ConnectorLivePanel({
                           <div class="mt-2">
                             <button
                               type="button"
-                              class="cursor-pointer text-2xs text-[var(--text-dim)] hover:text-[var(--text-body)]"
+                              class="cursor-pointer text-2xs text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)]"
                               aria-label=${`add channel to ${group.name}`}
                               onClick=${toggleExpand}
                             >${expanded ? '− close' : '+ add channel'}</button>
                           </div>
                           ${expanded
                             ? html`
-                                <div class="mt-2 rounded border border-dashed border-[var(--card-border)] bg-[var(--white-3)] p-2">
+                                <div class="mt-2 rounded border border-dashed border-[var(--color-border-default)] bg-[var(--white-3)] p-2">
                                   <${TextInput}
                                     value=${ui.channelDraft}
                                     placeholder=${`Paste ${connectorName} channel ID — right-click a channel → Copy ID`}
@@ -1195,7 +1195,7 @@ function ConnectorLivePanel({
                                     onInput=${(e: Event) => { patchConnectorUiState(connectorId, { channelDraft: (e.target as HTMLInputElement).value }) }}
                                   />
                                   ${ui.channelDraft.trim() && humanizeChannel(names, ui.channelDraft.trim())
-                                    ? html`<div class="mt-1 text-3xs text-[var(--text-dim)]">resolves to ${humanizeChannel(names, ui.channelDraft.trim())}</div>`
+                                    ? html`<div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">resolves to ${humanizeChannel(names, ui.channelDraft.trim())}</div>`
                                     : null}
                                   ${observedRooms.length > 0
                                     ? html`
@@ -1205,11 +1205,11 @@ function ConnectorLivePanel({
                                             return html`
                                               <button
                                                 type="button"
-                                                class="cursor-pointer rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-body)] hover:bg-[var(--white-8)]"
+                                                class="cursor-pointer rounded-sm border border-[var(--color-border-default)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--color-fg-primary)] hover:bg-[var(--white-8)]"
                                                 title=${roomId}
                                                 onClick=${() => { patchConnectorUiState(connectorId, { channelDraft: roomId }) }}
                                               >${humanized
-                                                ? html`<span>${humanized}</span><span class="ml-1 text-[var(--text-dim)]">· ${truncateMiddle(roomId, 10)}</span>`
+                                                ? html`<span>${humanized}</span><span class="ml-1 text-[var(--color-fg-disabled)]">· ${truncateMiddle(roomId, 10)}</span>`
                                                 : truncateMiddle(roomId, 22)}</button>
                                             `
                                           })}
@@ -1242,10 +1242,10 @@ function ConnectorLivePanel({
               ${unknownGroups.map(group => html`
                 <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2" data-keeper=${group.name}>
                   <div class="flex items-baseline gap-2">
-                    <span class="text-[var(--warn)]">⚠</span>
+                    <span class="text-[var(--color-status-warn)]">⚠</span>
                     <div class="min-w-0">
-                      <div class="text-sm font-medium text-[var(--text-body)]">${group.name}</div>
-                      <div class="text-3xs text-[var(--warn)]/90">binding references undefined keeper</div>
+                      <div class="text-sm font-medium text-[var(--color-fg-primary)]">${group.name}</div>
+                      <div class="text-3xs text-[var(--color-status-warn)]/90">binding references undefined keeper</div>
                     </div>
                   </div>
                   <div class="mt-2 space-y-1">
@@ -1253,12 +1253,12 @@ function ConnectorLivePanel({
                       const humanized = humanizeChannel(names, binding.channel_id)
                       return html`
                         <div class="flex items-center justify-between gap-3 text-xs" data-channel-id=${binding.channel_id}>
-                          <div class="min-w-0 text-[var(--text-body)]">
-                            <span class="mr-1 text-[var(--text-dim)]">·</span>
+                          <div class="min-w-0 text-[var(--color-fg-primary)]">
+                            <span class="mr-1 text-[var(--color-fg-disabled)]">·</span>
                             ${humanized
                               ? html`<span>${humanized}</span>`
-                              : html`<span class="text-[var(--text-dim)]">names pending</span>`}
-                            <span class="ml-2 text-3xs text-[var(--text-dim)]">(${truncateMiddle(binding.channel_id, 14)})</span>
+                              : html`<span class="text-[var(--color-fg-disabled)]">names pending</span>`}
+                            <span class="ml-2 text-3xs text-[var(--color-fg-disabled)]">(${truncateMiddle(binding.channel_id, 14)})</span>
                           </div>
                           ${bindingActionsEnabled
                             ? html`
@@ -1283,7 +1283,7 @@ function ConnectorLivePanel({
 
       ${connector
         ? html`
-            <div class="mt-4 flex flex-wrap gap-3 text-3xs text-[var(--text-dim)]">
+            <div class="mt-4 flex flex-wrap gap-3 text-3xs text-[var(--color-fg-disabled)]">
               ${connector.status_path
                 ? html`<span title=${connector.status_path}>runtime ${truncateMiddle(connector.status_path, 50)}</span>`
                 : null}
@@ -1302,13 +1302,13 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
   const lastError = shortText(ch.last_error)
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] p-3">
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-4)] p-3">
       <div class="mb-3 flex items-start justify-between gap-3">
         <div class="flex items-center gap-2">
           <span class="text-lg">${channelIcon(ch.channel)}</span>
           <div>
-            <div class="text-sm font-medium text-[var(--text-body)]">${ch.channel}</div>
-            <div class="text-3xs uppercase tracking-[0.18em] text-[var(--text-dim)]">
+            <div class="text-sm font-medium text-[var(--color-fg-primary)]">${ch.channel}</div>
+            <div class="text-3xs uppercase tracking-[0.18em] text-[var(--color-fg-disabled)]">
               ${ch.last_keeper ? `keeper ${ch.last_keeper}` : 'no keeper yet'}
             </div>
           </div>
@@ -1323,47 +1323,47 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
 
       <div class="grid grid-cols-3 gap-2 text-xs">
         <div>
-          <div class="text-[var(--text-dim)]">messages</div>
-          <div class="font-mono text-[var(--text-body)]">${ch.message_count}</div>
+          <div class="text-[var(--color-fg-disabled)]">messages</div>
+          <div class="font-mono text-[var(--color-fg-primary)]">${ch.message_count}</div>
         </div>
         <div>
-          <div class="text-[var(--text-dim)]">success</div>
-          <div class="font-mono text-[var(--text-body)]">${ch.success_rate_pct}%</div>
+          <div class="text-[var(--color-fg-disabled)]">success</div>
+          <div class="font-mono text-[var(--color-fg-primary)]">${ch.success_rate_pct}%</div>
         </div>
         <div>
-          <div class="text-[var(--text-dim)]">errors</div>
-          <div class="font-mono text-[var(--text-body)]">${ch.error_count}</div>
+          <div class="text-[var(--color-fg-disabled)]">errors</div>
+          <div class="font-mono text-[var(--color-fg-primary)]">${ch.error_count}</div>
         </div>
         <div>
-          <div class="text-[var(--text-dim)]">duplicates</div>
-          <div class="font-mono text-[var(--text-body)]">${ch.duplicate_count}</div>
+          <div class="text-[var(--color-fg-disabled)]">duplicates</div>
+          <div class="font-mono text-[var(--color-fg-primary)]">${ch.duplicate_count}</div>
         </div>
         <div>
-          <div class="text-[var(--text-dim)]">namespaces</div>
-          <div class="font-mono text-[var(--text-body)]">${ch.room_count}</div>
+          <div class="text-[var(--color-fg-disabled)]">namespaces</div>
+          <div class="font-mono text-[var(--color-fg-primary)]">${ch.room_count}</div>
         </div>
         <div>
-          <div class="text-[var(--text-dim)]">last active</div>
-          <div class="font-mono text-[var(--text-body)]">${timeAgo(ch.last_activity)}</div>
+          <div class="text-[var(--color-fg-disabled)]">last active</div>
+          <div class="font-mono text-[var(--color-fg-primary)]">${timeAgo(ch.last_activity)}</div>
         </div>
       </div>
 
-      <div class="mt-3 grid grid-cols-2 gap-2 text-2xs text-[var(--text-dim)]">
+      <div class="mt-3 grid grid-cols-2 gap-2 text-2xs text-[var(--color-fg-disabled)]">
         <div>
           avg ${(ch.avg_duration_ms / 1000).toFixed(1)}s
-          <span class="text-[var(--text-dim)]"> / max ${(ch.max_duration_ms / 1000).toFixed(1)}s</span>
+          <span class="text-[var(--color-fg-disabled)]"> / max ${(ch.max_duration_ms / 1000).toFixed(1)}s</span>
         </div>
         <div>
           slow ${ch.slow_count}
-          <span class="text-[var(--text-dim)]"> (${ch.slow_rate_pct}%)</span>
+          <span class="text-[var(--color-fg-disabled)]"> (${ch.slow_rate_pct}%)</span>
         </div>
         <div>
           last outcome
-          <span class="font-mono text-[var(--text-body)]"> ${ch.last_outcome}</span>
+          <span class="font-mono text-[var(--color-fg-primary)]"> ${ch.last_outcome}</span>
         </div>
         <div>
           last namespace
-          <span class="font-mono text-[var(--text-body)]"> ${ch.last_room_id || '-'}</span>
+          <span class="font-mono text-[var(--color-fg-primary)]"> ${ch.last_room_id || '-'}</span>
         </div>
       </div>
 
@@ -1386,13 +1386,13 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
   const lastError = shortText(binding.last_error, 72)
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-2">
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-4)] px-3 py-2">
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
-          <div class="text-xs font-medium text-[var(--text-body)]">
+          <div class="text-xs font-medium text-[var(--color-fg-primary)]">
             ${binding.channel} · room ${truncateMiddle(binding.room_id)}
           </div>
-          <div class="text-3xs uppercase tracking-5 text-[var(--text-dim)]">
+          <div class="text-3xs uppercase tracking-5 text-[var(--color-fg-disabled)]">
             ${binding.keeper ? `keeper ${binding.keeper}` : 'keeper pending'}
           </div>
         </div>
@@ -1400,19 +1400,19 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
           ${tone.label}
         </span>
       </div>
-      <div class="mt-2 grid grid-cols-3 gap-2 text-2xs text-[var(--text-dim)]">
+      <div class="mt-2 grid grid-cols-3 gap-2 text-2xs text-[var(--color-fg-disabled)]">
         <div>
-          msgs <span class="font-mono text-[var(--text-body)]">${binding.message_count}</span>
+          msgs <span class="font-mono text-[var(--color-fg-primary)]">${binding.message_count}</span>
         </div>
         <div>
-          success <span class="font-mono text-[var(--text-body)]">${binding.success_rate_pct}%</span>
+          success <span class="font-mono text-[var(--color-fg-primary)]">${binding.success_rate_pct}%</span>
         </div>
         <div>
-          last <span class="font-mono text-[var(--text-body)]">${binding.last_outcome}</span>
+          last <span class="font-mono text-[var(--color-fg-primary)]">${binding.last_outcome}</span>
         </div>
       </div>
-      <div class="mt-1 text-2xs text-[var(--text-dim)]">
-        recent activity <span class="font-mono text-[var(--text-body)]">${timeAgo(binding.last_activity)}</span>
+      <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">
+        recent activity <span class="font-mono text-[var(--color-fg-primary)]">${timeAgo(binding.last_activity)}</span>
       </div>
       ${lastError
         ? html`
@@ -1429,13 +1429,13 @@ function EventRow({ event }: { event: GateEventInfo }) {
   const isError = Boolean(event.error)
   const badgeClass = isError
     ? 'border border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]'
-    : 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-dim)]'
+    : 'border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-disabled)]'
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-2">
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-4)] px-3 py-2">
       <div class="flex items-start justify-between gap-3">
-        <div class="min-w-0 text-2xs text-[var(--text-dim)]">
-          <div class="font-medium text-[var(--text-body)]">
+        <div class="min-w-0 text-2xs text-[var(--color-fg-disabled)]">
+          <div class="font-medium text-[var(--color-fg-primary)]">
             ${event.channel} · ${event.keeper || 'unassigned'} · room ${truncateMiddle(event.room_id)}
           </div>
           <div class="mt-1">
@@ -1472,17 +1472,17 @@ function DisclosurePanel({
   testId: string
 }) {
   return html`
-    <details class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-1)]" data-testid=${testId}>
+    <details class="mb-4 rounded border border-[var(--color-border-default)] bg-[var(--bg-1)]" data-testid=${testId}>
       <summary class="cursor-pointer list-none px-3 py-2.5">
         <div class="flex items-center justify-between gap-3">
           <div>
-            <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--text-body)]">${title}</div>
-            <div class="mt-1 text-2xs text-[var(--text-dim)]">${subtitle}</div>
+            <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--color-fg-primary)]">${title}</div>
+            <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">${subtitle}</div>
           </div>
-          <span class="text-2xs text-[var(--text-dim)]">펴기</span>
+          <span class="text-2xs text-[var(--color-fg-disabled)]">펴기</span>
         </div>
       </summary>
-      <div class="border-t border-[var(--card-border)] px-3 py-3">
+      <div class="border-t border-[var(--color-border-default)] px-3 py-3">
         ${children}
       </div>
     </details>
@@ -1511,7 +1511,7 @@ function GateAnalyticsSection({
     >
       ${gate === null
         ? html`
-            <div class="rounded border border-dashed border-[var(--card-border)] px-3 py-4 text-xs text-[var(--text-dim)]">
+            <div class="rounded border border-dashed border-[var(--color-border-default)] px-3 py-4 text-xs text-[var(--color-fg-disabled)]">
               게이트가 광고하는 connector runtime 은 보이지만, 게이트가 관찰한 트래픽 은 아직 없습니다.
             </div>
           `
@@ -1524,24 +1524,24 @@ function GateAnalyticsSection({
                 <${StatCard} label="중복 제거 키" value=${gate.dedup_table_size} />
               </div>
 
-              <div class="mb-4 grid grid-cols-2 gap-2 text-2xs text-[var(--text-dim)] max-[720px]:grid-cols-1">
-                <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-2">
+              <div class="mb-4 grid grid-cols-2 gap-2 text-2xs text-[var(--color-fg-disabled)] max-[720px]:grid-cols-1">
+                <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-4)] px-3 py-2">
                   duplicate suppressions
-                  <span class="ml-2 font-mono text-[var(--text-body)]">${gate.total_duplicates}</span>
+                  <span class="ml-2 font-mono text-[var(--color-fg-primary)]">${gate.total_duplicates}</span>
                 </div>
-                <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-2">
+                <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-4)] px-3 py-2">
                   active connectors
-                  <span class="ml-2 font-mono text-[var(--text-body)]">${gate.channels.length}</span>
+                  <span class="ml-2 font-mono text-[var(--color-fg-primary)]">${gate.channels.length}</span>
                 </div>
               </div>
 
               <div class="mb-4 grid grid-cols-2 gap-3 max-[900px]:grid-cols-1">
                 <div>
-                  <div class="mb-2 text-3xs uppercase tracking-5 text-[var(--text-dim)]">
+                  <div class="mb-2 text-3xs uppercase tracking-5 text-[var(--color-fg-disabled)]">
                     Observed room bindings
                   </div>
                   ${gate.bindings.length === 0
-                    ? html`<div class="rounded border border-dashed border-[var(--card-border)] px-3 py-4 text-xs text-[var(--text-dim)]">관찰된 room 바인딩 없음</div>`
+                    ? html`<div class="rounded border border-dashed border-[var(--color-border-default)] px-3 py-4 text-xs text-[var(--color-fg-disabled)]">관찰된 room 바인딩 없음</div>`
                     : html`
                         <div class="space-y-2">
                           ${gate.bindings.slice(0, 6).map(binding => html`<${BindingRow} binding=${binding} />`)}
@@ -1550,11 +1550,11 @@ function GateAnalyticsSection({
                 </div>
 
                 <div>
-                  <div class="mb-2 text-3xs uppercase tracking-5 text-[var(--text-dim)]">
+                  <div class="mb-2 text-3xs uppercase tracking-5 text-[var(--color-fg-disabled)]">
                     Recent gate events
                   </div>
                   ${gate.recent_events.length === 0
-                    ? html`<div class="rounded border border-dashed border-[var(--card-border)] px-3 py-4 text-xs text-[var(--text-dim)]">커넥터 이벤트 기록 없음</div>`
+                    ? html`<div class="rounded border border-dashed border-[var(--color-border-default)] px-3 py-4 text-xs text-[var(--color-fg-disabled)]">커넥터 이벤트 기록 없음</div>`
                     : html`
                         <div class="space-y-2">
                           ${gate.recent_events.slice(0, 8).map(event => html`<${EventRow} event=${event} />`)}
@@ -1564,7 +1564,7 @@ function GateAnalyticsSection({
               </div>
 
               ${gate.channels.length === 0
-                ? html`<div class="py-4 text-center text-xs text-[var(--text-dim)]">활성 커넥터 없음</div>`
+                ? html`<div class="py-4 text-center text-xs text-[var(--color-fg-disabled)]">활성 커넥터 없음</div>`
                 : html`
                     <div class="grid grid-cols-2 gap-2 max-[900px]:grid-cols-1">
                       ${gate.channels.map(ch => html`<${ChannelCard} ch=${ch} />`)}
@@ -1619,7 +1619,7 @@ export function ConnectorStatusPanel() {
 
   if (filterId && allConnectors.length > 0 && visibleConnectors.length === 0) {
     return html`
-      <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-6 text-center text-xs text-[var(--text-dim)]">
+      <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-6 text-center text-xs text-[var(--color-fg-disabled)]">
         ${filterId} sidecar가 아직 Gate에 등록되지 않았습니다. 시작 후 다시 확인하세요.
       </div>
     `
@@ -1644,8 +1644,8 @@ export function ConnectorStatusPanel() {
     <div>
       <div class="mb-3 flex items-start justify-between gap-3">
         <div>
-          <h3 class="text-sm font-semibold text-[var(--text-body)]">${filterId ? CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? '커넥터' : '커넥터'}</h3>
-          <div class="mt-1 text-2xs text-[var(--text-dim)]">
+          <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">${filterId ? CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? '커넥터' : '커넥터'}</h3>
+          <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">
             ${filterId
               ? `${CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? filterId} sidecar의 라이브 상태와 keeper 바인딩.`
               : '4종 채널 sidecar overview 카드에서 커넥터를 고르면 아래 상세 패널이 교체됩니다.'}
@@ -1653,7 +1653,7 @@ export function ConnectorStatusPanel() {
         </div>
         ${filterId
           ? html`
-              <div class="text-right text-3xs uppercase tracking-5 text-[var(--text-dim)]">
+              <div class="text-right text-3xs uppercase tracking-5 text-[var(--color-fg-disabled)]">
                 <div>${d ? `success ${d.success_rate_pct}%` : `${visibleConnectors.length} connector${visibleConnectors.length !== 1 ? 's' : ''}`}</div>
                 <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : 'gate metrics unavailable'}</div>
               </div>
@@ -1677,15 +1677,15 @@ export function ConnectorStatusPanel() {
         ? html`
             <div
               id="connector-detail-panel"
-              class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-0)]/40 p-3"
+              class="mb-4 rounded border border-[var(--color-border-default)] bg-[var(--bg-0)]/40 p-3"
               data-testid="connector-detail-panel"
             >
               <div class="mb-3 flex items-center justify-between gap-3 text-2xs">
                 <div>
-                  <span class="font-semibold text-[var(--text-body)]">${CONNECTOR_DISPLAY_NAMES[focusedConnectorId]}</span>
-                  <span class="ml-2 text-[var(--text-dim)]">선택한 커넥터의 상세와 액션만 보여줍니다.</span>
+                  <span class="font-semibold text-[var(--color-fg-primary)]">${CONNECTOR_DISPLAY_NAMES[focusedConnectorId]}</span>
+                  <span class="ml-2 text-[var(--color-fg-disabled)]">선택한 커넥터의 상세와 액션만 보여줍니다.</span>
                 </div>
-                <span class="text-[var(--text-dim)]">overview 카드에서 전환</span>
+                <span class="text-[var(--color-fg-disabled)]">overview 카드에서 전환</span>
               </div>
               <${ConnectorLivePanel}
                 connector=${focusedConnector}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -105,12 +105,12 @@ export function ConnectionStatus() {
       class="flex items-center gap-1.5 whitespace-nowrap text-xs ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}"
       title=${titleAttr || undefined}
     >
-      <span class="inline-block size-[8px] rounded-sm ${isConnected ? 'bg-[var(--ok)] shadow-[0_0_7px_rgba(74,222,128,0.75)]' : 'bg-[var(--bad)]'}"></span>
+      <span class="inline-block size-[8px] rounded-sm ${isConnected ? 'bg-[var(--color-status-ok)] shadow-[0_0_7px_rgba(74,222,128,0.75)]' : 'bg-[var(--color-status-err)]'}"></span>
       <span class="status-text">${statusLabel}</span>
       ${attentionCount > 0 ? html`
         <${RouteLink}
           tab="overview"
-          class="inline-flex items-center justify-center rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 tabular-nums attention-badge"
+          class="inline-flex items-center justify-center rounded-sm border border-[var(--color-border-default)] bg-[var(--white-4)] px-2 py-0.5 tabular-nums attention-badge"
         >주의 ${attentionCount}건<//>
       ` : null}
     </div>
@@ -127,7 +127,7 @@ export function ErrorCounterBadge() {
     <div class="relative" role="status">
       <button
         type="button"
-        class="flex items-center gap-1.5 cursor-pointer rounded px-1 py-0.5 transition-colors hover:bg-[var(--white-5)] ${count > 0 ? 'text-[var(--bad)]' : 'text-[var(--text-muted)]'}"
+        class="flex items-center gap-1.5 cursor-pointer rounded px-1 py-0.5 transition-colors hover:bg-[var(--white-5)] ${count > 0 ? 'text-[var(--color-status-err)]' : 'text-[var(--color-fg-muted)]'}"
         title=${count > 0 ? `미확인 에러 ${count}건` : '에러 없음'}
         onClick=${() => { errorPanelOpen.value = !errorPanelOpen.value }}
         aria-expanded=${open}
@@ -135,7 +135,7 @@ export function ErrorCounterBadge() {
       >
         <${Bell} size=${14} />
         ${count > 0 ? html`
-          <span class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-[var(--bad)] text-2xs font-semibold text-white tabular-nums">${count > 99 ? '99+' : count}</span>
+          <span class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-[var(--color-status-err)] text-2xs font-semibold text-white tabular-nums">${count > 99 ? '99+' : count}</span>
         ` : null}
       </button>
       ${open ? html`<${ErrorPanel} onClose=${() => { errorPanelOpen.value = false }} />` : null}
@@ -226,7 +226,7 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button type="button"
-        class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+        class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs text-[var(--color-fg-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--color-fg-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
         aria-expanded=${buildIdentityOpen.value}
         aria-label=${`서버 빌드 정보 ${label}`}
         title=${hoverTitle}
@@ -238,12 +238,12 @@ export function BuildIdentityBadge() {
       </button>
       ${buildIdentityOpen.value
         ? html`
-            <div class="absolute top-[calc(100%+8px)] right-0 min-w-70 rounded border border-solid border-[var(--card-border)] bg-[var(--bg-panel)] px-3 py-2.5 shadow-[0_10px_24px_rgba(0,0,0,0.22)] grid gap-1.5">
-              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
+            <div class="absolute top-[calc(100%+8px)] right-0 min-w-70 rounded border border-solid border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2.5 shadow-[0_10px_24px_rgba(0,0,0,0.22)] grid gap-1.5">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--color-fg-muted)]">
                 <span>릴리즈</span>
-                <strong class="text-[color:var(--text-strong)] text-right">${build?.release_version ?? status?.version ?? 'unknown'}</strong>
+                <strong class="text-[color:var(--color-fg-secondary)] text-right">${build?.release_version ?? status?.version ?? 'unknown'}</strong>
               </div>
-              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--color-fg-muted)]">
                 <span>커밋</span>
                 ${(() => {
                   const url = githubCommitUrl(build?.commit)
@@ -253,27 +253,27 @@ export function BuildIdentityBadge() {
                         href=${url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="text-right font-bold text-[color:var(--text-strong)] underline decoration-dotted underline-offset-2 decoration-[color:var(--text-dim)] hover:decoration-[color:var(--accent)] hover:text-[color:var(--accent)]"
+                        class="text-right font-bold text-[color:var(--color-fg-secondary)] underline decoration-dotted underline-offset-2 decoration-[color:var(--color-fg-disabled)] hover:decoration-[color:var(--color-accent-fg)] hover:text-[color:var(--color-accent-fg)]"
                         data-build-commit-link
                         title="GitHub에서 이 커밋 보기"
                       >${text} ↗</a>`
-                    : html`<strong class="text-[color:var(--text-strong)] text-right">${text}</strong>`
+                    : html`<strong class="text-[color:var(--color-fg-secondary)] text-right">${text}</strong>`
                 })()}
               </div>
-              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--color-fg-muted)]">
                 <span>서버 시작</span>
-                <strong class="text-[color:var(--text-strong)] text-right">${build?.started_at ? html`<${TimeAgo} timestamp=${build.started_at} />` : '알 수 없음'}</strong>
+                <strong class="text-[color:var(--color-fg-secondary)] text-right">${build?.started_at ? html`<${TimeAgo} timestamp=${build.started_at} />` : '알 수 없음'}</strong>
               </div>
-              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--color-fg-muted)]">
                 <span>업타임</span>
                 <strong
-                  class="text-[color:var(--text-strong)] text-right tabular-nums"
+                  class="text-[color:var(--color-fg-secondary)] text-right tabular-nums"
                   title=${typeof build?.uptime_seconds === 'number' ? `${build.uptime_seconds}s raw` : undefined}
                 >${formatUptimeSecondsHuman(build?.uptime_seconds)}</strong>
               </div>
-              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--color-fg-muted)]">
                 <span>쉘 스냅샷</span>
-                <strong class="text-[color:var(--text-strong)] text-right">${status?.generated_at ? html`<${TimeAgo} timestamp=${status.generated_at} />` : '알 수 없음'}</strong>
+                <strong class="text-[color:var(--color-fg-secondary)] text-right">${status?.generated_at ? html`<${TimeAgo} timestamp=${status.generated_at} />` : '알 수 없음'}</strong>
               </div>
             </div>
           `
@@ -339,17 +339,17 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   let label: string
 
   if (!live) {
-    dotClass = 'bg-[var(--bad)]'
+    dotClass = 'bg-[var(--color-status-err)]'
     label = '신호 없음'
   } else if (!snap) {
-    dotClass = 'bg-[var(--text-muted)]'
+    dotClass = 'bg-[var(--color-fg-muted)]'
     label = missionLoading.value ? '로딩 중' : '대기 중'
   } else if (blockers > 0 || attentionCount > 0) {
-    dotClass = 'bg-[var(--warn)]'
+    dotClass = 'bg-[var(--color-status-warn)]'
     const total = blockers + attentionCount
     label = `주의 ${total}건`
   } else {
-    dotClass = 'bg-[var(--ok)]'
+    dotClass = 'bg-[var(--color-status-ok)]'
     label = '정상'
   }
 
@@ -365,7 +365,7 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   return html`
     <div class="flex items-center gap-2 px-1" role="status" aria-label=${label} title=${titleText}>
       ${dot}
-      <span class="text-2xs text-[var(--text-muted)] truncate">${label}</span>
+      <span class="text-2xs text-[var(--color-fg-muted)] truncate">${label}</span>
     </div>
   `
 }
@@ -380,12 +380,12 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
       <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-2 pt-2 pb-1">
         ${!collapsed ? html`
           <div class="px-1">
-            <div class="text-3xs font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">내비게이션</div>
-            <div class="mt-0.5 text-sm font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Core</div>
+            <div class="text-3xs font-bold uppercase tracking-[0.2em] text-[var(--color-fg-muted)]">내비게이션</div>
+            <div class="mt-0.5 text-sm font-semibold tracking-[-0.02em] text-[var(--color-fg-secondary)]">MASC Core</div>
           </div>
         ` : null}
         <button type="button"
-          class="flex size-7 items-center justify-center rounded text-[var(--text-muted)] cursor-pointer transition-colors duration-200 hover:bg-[var(--white-10)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
+          class="flex size-7 items-center justify-center rounded text-[var(--color-fg-muted)] cursor-pointer transition-colors duration-200 hover:bg-[var(--white-10)] hover:text-[var(--color-fg-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
           aria-label=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
           onClick=${onToggle}
           title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
@@ -405,7 +405,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex items-center justify-center w-full rounded border p-2 cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive ? 'bg-[var(--accent-soft)] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)]'}"
+                  class="flex items-center justify-center w-full rounded border p-2 cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive ? 'bg-[var(--accent-soft)] text-[var(--color-fg-secondary)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'border-transparent text-[var(--color-fg-muted)] hover:bg-[var(--white-5)]'}"
                   title=${surface.label}
                   aria-label=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
@@ -420,19 +420,19 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex items-center gap-2 w-full rounded border px-2 py-1.5 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.14),rgba(71,184,255,0.04))] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'bg-transparent border-transparent text-[var(--text-strong)] hover:bg-[var(--white-5)]'}"
+                  class="flex items-center gap-2 w-full rounded border px-2 py-1.5 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.14),rgba(71,184,255,0.04))] text-[var(--color-fg-secondary)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'bg-transparent border-transparent text-[var(--color-fg-secondary)] hover:bg-[var(--white-5)]'}"
                   ariaCurrent=${isSurfaceActive && sections.length === 0 ? 'page' : undefined}
                 >
                   <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-3)] text-base" aria-hidden="true">
                     ${surface.icon}
                   </span>
                   <div class="flex-1 min-w-0">
-                    <div class="text-base font-medium truncate leading-none ${isSurfaceActive ? 'text-[var(--accent)]' : ''}">${surface.label}</div>
+                    <div class="text-base font-medium truncate leading-none ${isSurfaceActive ? 'text-[var(--color-accent-fg)]' : ''}">${surface.label}</div>
                   </div>
                 <//>
 
                 ${sections.length > 0 ? html`
-                  <div class="ml-7 flex flex-col gap-0.5 border-l border-[var(--border-subtle)] pl-3" role="list">
+                  <div class="ml-7 flex flex-col gap-0.5 border-l border-[var(--color-border-divider)] pl-3" role="list">
                     ${sections.map(item => {
                       const isSectionActive = isSurfaceActive && currentSection?.id === item.id
                       return html`
@@ -440,7 +440,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                           role="listitem"
                           tab=${surface.id}
                           params=${item.params}
-                          class="w-full rounded border px-2 py-1 text-left cursor-pointer text-sm transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[var(--accent-soft)] text-[var(--accent)] font-medium shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-soft)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)] hover:text-[var(--text-body)]'}"
+                          class="w-full rounded border px-2 py-1 text-left cursor-pointer text-sm transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[var(--accent-soft)] text-[var(--color-accent-fg)] font-medium shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-soft)]' : 'border-transparent text-[var(--color-fg-muted)] hover:bg-[var(--white-5)] hover:text-[var(--color-fg-primary)]'}"
                           ariaCurrent=${isSectionActive ? 'page' : undefined}
                         >
                           <div class="truncate">${item.label}</div>
@@ -614,7 +614,7 @@ function SurfaceLead() {
     <div class="mb-3 flex flex-col gap-1.5">
       ${trail.length > 0
         ? html`<nav
-            class="flex items-center gap-1 text-2xs text-[var(--text-dim)]"
+            class="flex items-center gap-1 text-2xs text-[var(--color-fg-disabled)]"
             aria-label="페이지 경로"
             data-surface-breadcrumb
           >
@@ -626,10 +626,10 @@ function SurfaceLead() {
               const crumbEl = crumb.navigableTab !== null && !isLast
                 ? html`<${RouteLink}
                     tab=${crumb.navigableTab}
-                    class="cursor-pointer rounded px-1 py-0.5 hover:bg-[var(--white-5)] hover:text-[var(--text-body)]"
+                    class="cursor-pointer rounded px-1 py-0.5 hover:bg-[var(--white-5)] hover:text-[var(--color-fg-primary)]"
                   >${crumb.label}<//>`
                 : html`<span
-                    class="px-1 py-0.5 ${isLast ? 'text-[var(--text-body)]' : ''}"
+                    class="px-1 py-0.5 ${isLast ? 'text-[var(--color-fg-primary)]' : ''}"
                     aria-current=${isLast ? 'page' : undefined}
                   >${crumb.label}</span>`
               return html`${sep}${crumbEl}`
@@ -637,7 +637,7 @@ function SurfaceLead() {
           </nav>`
         : null}
       <div class="flex items-center gap-2">
-        <h2 class="text-[22px] font-bold tracking-tight text-[var(--text-strong)]">
+        <h2 class="text-[22px] font-bold tracking-tight text-[var(--color-fg-secondary)]">
           ${title}
         </h2>
         ${shareUrl !== ''
@@ -649,7 +649,7 @@ function SurfaceLead() {
             />`
           : null}
       </div>
-      ${description ? html`<p class="m-0 text-sm leading-normal text-[var(--text-dim)]">${description}</p>` : null}
+      ${description ? html`<p class="m-0 text-sm leading-normal text-[var(--color-fg-disabled)]">${description}</p>` : null}
     </div>
   `
 }

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -63,11 +63,11 @@ export function severityLabel(code: number): string {
 export function severityChipClass(code: number): string {
   switch (severityForExitCode(code)) {
     case 'ok':
-      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--ok)]'
+      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--color-status-ok)]'
     case 'warn':
-      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--warn)]'
+      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--color-status-warn)]'
     case 'error':
-      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--bad)]'
+      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--color-status-err)]'
   }
 }
 
@@ -184,7 +184,7 @@ function chipClassForSidecarSeverity(severity: string): string {
 
 function SidecarChecksList({ checks }: { checks: SidecarCheckView[] }) {
   if (checks.length === 0) {
-    return html`<div class="text-xs text-[var(--text-muted)]">세부 검사 없음.</div>`
+    return html`<div class="text-xs text-[var(--color-fg-muted)]">세부 검사 없음.</div>`
   }
   return html`
     <ul class="mt-3 space-y-2">
@@ -193,12 +193,12 @@ function SidecarChecksList({ checks }: { checks: SidecarCheckView[] }) {
         return html`
           <li class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-2">
             <div class="flex items-baseline justify-between gap-2">
-              <div class="text-xs font-medium text-[var(--text-strong)]">${c.name}</div>
+              <div class="text-xs font-medium text-[var(--color-fg-secondary)]">${c.name}</div>
               <div class="flex items-center gap-1">
                 ${c.autofix_available
                   ? html`
                       <span
-                        class="rounded-full border border-[var(--accent)]/40 bg-[var(--accent)]/10 px-1.5 py-0.5 text-[10px] text-[var(--accent)]"
+                        class="rounded-full border border-[var(--color-accent-fg)]/40 bg-[var(--color-accent-fg)]/10 px-1.5 py-0.5 text-[10px] text-[var(--color-accent-fg)]"
                         title=${c.autofix_description
                           ? `자동 치유 시도: ${c.autofix_description} (CLI: masc-mcp doctor --fix)`
                           : '자동 치유 가능 (CLI: masc-mcp doctor --fix)'}
@@ -212,11 +212,11 @@ function SidecarChecksList({ checks }: { checks: SidecarCheckView[] }) {
                 </span>
               </div>
             </div>
-            ${c.detail ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">${c.detail}</div>` : ''}
-            ${c.message ? html`<div class="mt-1 text-[11px] text-[var(--text-body)]">↳ ${c.message}</div>` : ''}
-            ${c.hint ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">hint: ${c.hint}</div>` : ''}
+            ${c.detail ? html`<div class="mt-1 text-[11px] text-[var(--color-fg-muted)]">${c.detail}</div>` : ''}
+            ${c.message ? html`<div class="mt-1 text-[11px] text-[var(--color-fg-primary)]">↳ ${c.message}</div>` : ''}
+            ${c.hint ? html`<div class="mt-1 text-[11px] text-[var(--color-fg-muted)]">hint: ${c.hint}</div>` : ''}
             ${c.autofix_available && c.autofix_description
-              ? html`<div class="mt-1 text-[11px] text-[var(--accent)]">fix: ${c.autofix_description}</div>`
+              ? html`<div class="mt-1 text-[11px] text-[var(--color-accent-fg)]">fix: ${c.autofix_description}</div>`
               : ''}
           </li>
         `
@@ -228,15 +228,15 @@ function SidecarChecksList({ checks }: { checks: SidecarCheckView[] }) {
 function ConfigNotesList({ notes }: { notes: ConfigNotesView }) {
   const { warnings, next_actions } = notes
   if (warnings.length === 0 && next_actions.length === 0) {
-    return html`<div class="text-xs text-[var(--text-muted)]">추가 메모 없음.</div>`
+    return html`<div class="text-xs text-[var(--color-fg-muted)]">추가 메모 없음.</div>`
   }
   return html`
     <div class="mt-3 space-y-3">
       ${warnings.length > 0
         ? html`
             <div>
-              <div class="text-[11px] uppercase tracking-wider text-[var(--text-muted)]">경고</div>
-              <ul class="mt-1 list-disc space-y-1 pl-5 text-[11px] text-[var(--text-body)]">
+              <div class="text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">경고</div>
+              <ul class="mt-1 list-disc space-y-1 pl-5 text-[11px] text-[var(--color-fg-primary)]">
                 ${warnings.map((w) => html`<li>${w}</li>`)}
               </ul>
             </div>
@@ -245,8 +245,8 @@ function ConfigNotesList({ notes }: { notes: ConfigNotesView }) {
       ${next_actions.length > 0
         ? html`
             <div>
-              <div class="text-[11px] uppercase tracking-wider text-[var(--text-muted)]">다음 조치</div>
-              <ul class="mt-1 list-disc space-y-1 pl-5 text-[11px] text-[var(--text-body)]">
+              <div class="text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">다음 조치</div>
+              <ul class="mt-1 list-disc space-y-1 pl-5 text-[11px] text-[var(--color-fg-primary)]">
                 ${next_actions.map((a) => html`<li>${a}</li>`)}
               </ul>
             </div>
@@ -269,15 +269,15 @@ function DoctorEntryCard({ entry }: { entry: DoctorEntry }) {
         aria-expanded=${expanded.value}
         onClick=${onToggle}
       >
-        <div class="text-sm font-semibold text-[var(--text-strong)]">
+        <div class="text-sm font-semibold text-[var(--color-fg-secondary)]">
           ${doctorHeading(entry)}
-          <span class="ml-2 text-[10px] text-[var(--text-muted)]">${expanded.value ? '▾' : '▸'}</span>
+          <span class="ml-2 text-[10px] text-[var(--color-fg-muted)]">${expanded.value ? '▾' : '▸'}</span>
         </div>
         <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider ${chip}">
           ${label}
         </span>
       </button>
-      <div class="mt-1 text-xs text-[var(--text-muted)]">
+      <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
         ${entry.kind === 'config' ? 'Config Doctor' : `${entry.name} sidecar`} · exit ${entry.exit_code}
       </div>
       ${expanded.value
@@ -307,16 +307,16 @@ export function DoctorPanel() {
                 <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                   <div>
                     <${SectionCap}>시스템 전반 Doctor<//>
-                    <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">
+                    <div class="mt-2 text-2xl font-semibold text-[var(--color-fg-secondary)]">
                       ${summaryLine(data.summary)}
                     </div>
-                    <div class="mt-2 text-sm leading-airy text-[var(--text-body)]">
-                      ${data.title} · <code class="text-[var(--text-muted)]">masc-mcp doctor all</code> 과 동일 결과.
+                    <div class="mt-2 text-sm leading-airy text-[var(--color-fg-primary)]">
+                      ${data.title} · <code class="text-[var(--color-fg-muted)]">masc-mcp doctor all</code> 과 동일 결과.
                     </div>
                   </div>
                   <button
                     type="button"
-                    class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--text-body)]"
+                    class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-accent-fg)] hover:text-[var(--color-fg-primary)]"
                     onClick=${() => { void refreshDoctor() }}
                   >새로고침</button>
                 </div>

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -71,7 +71,7 @@ export function ExcusePatterns() {
   return html`
     <${Card} title="Anti-Rationalization Excuse Patterns">
       <div class="p-4">
-        <p class="text-sm text-[var(--text-muted)] mb-4">
+        <p class="text-sm text-[var(--color-fg-muted)] mb-4">
           These patterns are matched against agent completion notes. If matched, the task is rejected.
           Changes here are saved to <code>config/excuse_patterns.json</code> and applied immediately without restarting.
           The format must be a JSON array of arrays, each containing two strings: <code>["pattern", "reason"]</code>.
@@ -80,7 +80,7 @@ export function ExcusePatterns() {
         <form onSubmit=${handleSave}>
           <textarea
             name="patterns"
-            class="w-full h-96 p-3 bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded font-mono text-sm mb-4 text-[var(--text-primary)]"
+            class="w-full h-96 p-3 bg-[var(--bg-card)] border border-[var(--color-border-divider)] rounded font-mono text-sm mb-4 text-[var(--text-primary)]"
             spellcheck="false"
           >${jsonStr}</textarea>
           
@@ -93,7 +93,7 @@ export function ExcusePatterns() {
               ${saving.value ? 'Saving...' : 'Save Patterns'}
             </button>
             ${saveMessage.value ? html`
-              <span class="text-sm ${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid') ? 'text-[var(--bad-light)]' : 'text-[var(--ok)]'}">
+              <span class="text-sm ${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid') ? 'text-[var(--bad-light)]' : 'text-[var(--color-status-ok)]'}">
                 ${saveMessage.value}
               </span>
             ` : null}

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -120,14 +120,14 @@ function statusLabel(status: FeatureStatus): string {
 function statusChipClass(status: FeatureStatus): string {
   switch (status) {
     case 'healthy':
-      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--ok)]'
+      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--color-status-ok)]'
     case 'warning':
-      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--warn)]'
+      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--color-status-warn)]'
     case 'inactive':
-      return 'border-[var(--white-12)] bg-[var(--white-4)] text-[var(--text-muted)]'
+      return 'border-[var(--white-12)] bg-[var(--white-4)] text-[var(--color-fg-muted)]'
     case 'deprecated':
     default:
-      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--bad)]'
+      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--color-status-err)]'
   }
 }
 
@@ -145,20 +145,20 @@ function FeatureItem({ item }: { item: FeatureHealthItem }) {
       <div class="flex items-start justify-between gap-3">
         <div class="flex-1">
           <div class="flex items-center gap-2">
-            <code class="text-xs font-medium text-[var(--text-strong)]">${item.env_name}</code>
+            <code class="text-xs font-medium text-[var(--color-fg-secondary)]">${item.env_name}</code>
             <${StatusPill} status=${item.status} />
             ${item.is_enabled ? html`
-              <span class="inline-flex items-center rounded border border-[var(--ok-30)] bg-[var(--ok-12)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--ok)]">
+              <span class="inline-flex items-center rounded border border-[var(--ok-30)] bg-[var(--ok-12)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--color-status-ok)]">
                 ON
               </span>
             ` : html`
-              <span class="inline-flex items-center rounded border border-[var(--white-12)] bg-[var(--white-4)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--text-muted)]">
+              <span class="inline-flex items-center rounded border border-[var(--white-12)] bg-[var(--white-4)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--color-fg-muted)]">
                 OFF
               </span>
             `}
           </div>
-          <div class="mt-1.5 text-sm text-[var(--text-body)]">${item.description}</div>
-          <div class="mt-1 flex items-center gap-3 text-xs text-[var(--text-muted)]">
+          <div class="mt-1.5 text-sm text-[var(--color-fg-primary)]">${item.description}</div>
+          <div class="mt-1 flex items-center gap-3 text-xs text-[var(--color-fg-muted)]">
             <span>source: ${item.source}</span>
             <span>since: v${item.since}</span>
           </div>
@@ -176,12 +176,12 @@ function CategorySection({ category, categoryData }: { category: string; categor
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-4">
       <div class="mb-3 flex items-center justify-between">
         <div>
-          <div class="text-sm font-medium text-[var(--text-strong)]">${categoryLabel}</div>
-          <div class="mt-0.5 text-xs text-[var(--text-muted)]">
+          <div class="text-sm font-medium text-[var(--color-fg-secondary)]">${categoryLabel}</div>
+          <div class="mt-0.5 text-xs text-[var(--color-fg-muted)]">
             ${categoryData.enabled} / ${categoryData.total} enabled (${enabledRatio}%)
           </div>
         </div>
-        <div class="rounded-sm border border-[var(--white-8)] bg-[var(--white-6)] px-3 py-1 text-xs font-semibold text-[var(--text-body)]">
+        <div class="rounded-sm border border-[var(--white-8)] bg-[var(--white-6)] px-3 py-1 text-xs font-semibold text-[var(--color-fg-primary)]">
           ${categoryData.total}
         </div>
       </div>
@@ -212,17 +212,17 @@ export function FeatureHealth() {
                   <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                     <div class="max-w-3xl">
                       <${SectionCap}>Feature Flags Health<//>
-                      <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">
+                      <div class="mt-2 text-2xl font-semibold text-[var(--color-fg-secondary)]">
                         ${overview.enabled_count} / ${overview.total_features} 기능 활성화
                       </div>
-                      <div class="mt-2 text-sm leading-airy text-[var(--text-body)]">
+                      <div class="mt-2 text-sm leading-airy text-[var(--color-fg-primary)]">
                         시스템 기능 플래그 상태를 실시간으로 모니터링합니다.
                         ${overview.overridden_count ? `${overview.overridden_count}개 플래그가 환경변수로 오버라이드되었습니다.` : ''}
                       </div>
                     </div>
                     <button
                       type="button"
-                      class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--text-body)]"
+                      class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-accent-fg)] hover:text-[var(--color-fg-primary)]"
                       onClick=${() => { void loadFeatureHealth() }}
                     >새로고침</button>
                   </div>
@@ -236,7 +236,7 @@ export function FeatureHealth() {
                     <${StatCard} label="폐기 예정" value=${overview.deprecated_count} />
                   </div>
 
-                  <div class="mt-4 text-xs text-[var(--text-dim)]">
+                  <div class="mt-4 text-xs text-[var(--color-fg-disabled)]">
                     generated ${formatTimeAgo(data.generated_at)}
                   </div>
                 </div>
@@ -284,14 +284,14 @@ export function FeatureHealth() {
                   )
                   if (filtered.length === 0) {
                     return html`
-                      <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-4 text-xs text-[var(--text-dim)]">
+                      <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-4 text-xs text-[var(--color-fg-disabled)]">
                         조건에 맞는 기능이 없습니다.
                       </div>
                     `
                   }
                   return html`
                     <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-4">
-                      <div class="mb-3 text-xs text-[var(--text-muted)]">
+                      <div class="mb-3 text-xs text-[var(--color-fg-muted)]">
                         ${filtered.length} / ${data.all_features.length}개 기능
                       </div>
                       <div class="space-y-2">

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -75,48 +75,48 @@ const INVARIANT_KEYS = Object.keys(INVARIANT_LABELS) as Array<
 // recommendation: stable=gray, in-motion=amber/blue, terminal=red.
 const CHIP_CLASS_BY_STATE: Record<string, string> = {
   // KSM
-  Running:      'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]',
+  Running:      'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]',
   Failing:      'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]',
-  Overflowed:   'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]',
-  Compacting:   'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]',
-  HandingOff:   'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
-  Draining:     'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
-  Paused:       'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
-  Stopped:      'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
+  Overflowed:   'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]',
+  Compacting:   'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]',
+  HandingOff:   'bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]',
+  Draining:     'bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]',
+  Paused:       'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--white-10)]',
+  Stopped:      'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--white-10)]',
   Crashed:      'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]',
-  Restarting:   'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
+  Restarting:   'bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]',
   Dead:         'bg-[var(--white-5)] text-[var(--bad-light)] border-[var(--bad-20)]',
-  Offline:      'bg-[var(--white-5)] text-[var(--text-muted)]0 border-[var(--white-10)]',
+  Offline:      'bg-[var(--white-5)] text-[var(--color-fg-muted)]0 border-[var(--white-10)]',
   // KTC
-  idle:         'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
-  prompting:    'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
-  executing:    'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]',
-  compacting:   'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]',
-  finalizing:   'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
+  idle:         'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--white-10)]',
+  prompting:    'bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]',
+  executing:    'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]',
+  compacting:   'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]',
+  finalizing:   'bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]',
   // KDP
-  undecided:          'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
-  guard_ok:           'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]',
+  undecided:          'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--white-10)]',
+  guard_ok:           'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]',
   gate_rejected:      'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]',
-  tool_policy_selected: 'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
+  tool_policy_selected: 'bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]',
   // KCL
-  selecting:    'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
-  trying:       'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]',
-  done:         'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]',
+  selecting:    'bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]',
+  trying:       'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]',
+  done:         'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]',
   exhausted:    'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]',
   // KMC
-  accumulating: 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
+  accumulating: 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--white-10)]',
   // KCB (LT-16-KCB Phase 3). Clean = baseline grey same as any other
   // "nothing happening" state; warning = amber (partial failure
   // streak); cooling = blue (at least one past trip, currently
   // recovered). "tripped" is unobservable at snapshot time and has no
   // chip colour by design — the mutator resets the count before any
   // observer can see it.
-  clean:   'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
-  warning: 'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]',
-  cooling: 'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
+  clean:   'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--white-10)]',
+  warning: 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]',
+  cooling: 'bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]',
 }
 
-const DEFAULT_CHIP = 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]'
+const DEFAULT_CHIP = 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--white-10)]'
 
 export function chipClassFor(value: string): string {
   return CHIP_CLASS_BY_STATE[value] ?? DEFAULT_CHIP
@@ -172,9 +172,9 @@ export type FleetRuntimeAssistHandler =
   (request: FleetRuntimeAssistRequest) => Promise<void> | void
 
 const RUNTIME_ATTENTION_CLASS: Record<FleetRuntimeAttentionLevel, string> = {
-  ok: 'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]',
-  stale: 'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]',
-  idle: 'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]',
+  ok: 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]',
+  stale: 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]',
+  idle: 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]',
   blocked: 'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]',
 }
 
@@ -708,7 +708,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
     return html`
       <div
         data-testid="fleet-fsm-matrix"
-        class="rounded border border-[var(--white-10)] bg-[var(--white-5)] p-4 text-sm text-[var(--text-muted)]"
+        class="rounded border border-[var(--white-10)] bg-[var(--white-5)] p-4 text-sm text-[var(--color-fg-muted)]"
       >
         Loading fleet composite snapshot…
       </div>
@@ -730,7 +730,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
     return html`
       <div
         data-testid="fleet-fsm-matrix"
-        class="rounded border border-[var(--white-10)] bg-[var(--white-5)] p-4 text-sm text-[var(--text-muted)]"
+        class="rounded border border-[var(--white-10)] bg-[var(--white-5)] p-4 text-sm text-[var(--color-fg-muted)]"
       >
         No keepers registered.
       </div>
@@ -743,8 +743,8 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
       class="rounded border border-[var(--white-10)] bg-[var(--white-5)]"
     >
       <header class="flex flex-wrap items-baseline gap-3 border-b border-[var(--white-10)] p-3">
-        <h2 class="text-sm font-semibold text-[var(--text-muted)]">Fleet composite (KSM × KTC × KDP × KCL × KMC × KCB)</h2>
-        <span class="text-xs text-[var(--text-muted)]0">
+        <h2 class="text-sm font-semibold text-[var(--color-fg-muted)]">Fleet composite (KSM × KTC × KDP × KCL × KMC × KCB)</h2>
+        <span class="text-xs text-[var(--color-fg-muted)]0">
           ${data.count} keepers · updated ${new Date(data.generated_at * 1000).toLocaleTimeString()}
         </span>
         <input
@@ -754,7 +754,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
           aria-label="Keeper 필터"
           data-testid="fleet-fsm-matrix-filter"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-40 max-w-65 rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-xs text-[var(--text-muted)] placeholder:text-[var(--text-muted)]0 focus:border-[var(--white-10)]0 focus:outline-none"
+          class="min-w-40 max-w-65 rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-xs text-[var(--color-fg-muted)] placeholder:text-[var(--color-fg-muted)]0 focus:border-[var(--white-10)]0 focus:outline-none"
         />
         ${runtimeTallies
           ? html`
@@ -789,7 +789,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                 ${INVARIANT_KEYS.map(k => {
                   const count = tallies[k]
                   const tone = count === 0
-                    ? 'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]'
+                    ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]'
                     : 'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]'
                   return html`
                     <span
@@ -809,7 +809,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
         ? html`
             <div
               data-testid="fleet-fsm-matrix-empty"
-              class="p-4 text-center text-xs text-[var(--text-muted)]0"
+              class="p-4 text-center text-xs text-[var(--color-fg-muted)]0"
             >
               필터 결과 없음 (${data.snapshots.length} keepers)
             </div>
@@ -817,13 +817,13 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
         : null}
       <div class="overflow-x-auto">
         <table class="min-w-full text-xs">
-          <thead class="bg-[var(--white-5)] text-[var(--text-muted)]">
+          <thead class="bg-[var(--white-5)] text-[var(--color-fg-muted)]">
             <tr>
               <th class="px-3 py-2 text-left font-semibold">Keeper</th>
               <th class="px-3 py-2 text-left font-semibold">Runtime</th>
               ${AXES.map(a => html`
                 <th class="px-3 py-2 text-left font-semibold" title=${a.label}>
-                  ${a.acronym} <span class="text-[var(--text-muted)]0">${a.label}</span>
+                  ${a.acronym} <span class="text-[var(--color-fg-muted)]0">${a.label}</span>
                 </th>
               `)}
             </tr>
@@ -846,7 +846,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                   class="border-t border-[var(--white-10)] hover:bg-[var(--white-5)] ${rowTone}"
                   onClick=${props.onSelectKeeper ? () => props.onSelectKeeper?.(name) : undefined}
                 >
-                  <td class="px-3 py-2 font-mono text-[var(--text-muted)]">${name}</td>
+                  <td class="px-3 py-2 font-mono text-[var(--color-fg-muted)]">${name}</td>
                   <td class="px-3 py-2 align-top">
                     <div class="flex max-w-72 flex-col gap-1">
                       <span
@@ -858,14 +858,14 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                       <span
                         data-runtime-evidence
                         data-runtime-cause
-                        class="text-3xs leading-snug text-[var(--text-muted)]0"
+                        class="text-3xs leading-snug text-[var(--color-fg-muted)]0"
                         title=${attention.title}
                       >
                         원인: ${attention.cause}
                       </span>
                       <span
                         data-runtime-next
-                        class="text-3xs leading-snug text-[var(--text-muted)]0"
+                        class="text-3xs leading-snug text-[var(--color-fg-muted)]0"
                         title=${attention.title}
                       >
                         다음: ${attention.nextStep}
@@ -875,7 +875,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                             <button
                               type="button"
                               data-runtime-assist
-                              class="self-start rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-3xs font-semibold text-[var(--accent)] hover:bg-[var(--white-10)] disabled:cursor-not-allowed disabled:opacity-50"
+                              class="self-start rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-accent-fg)] hover:bg-[var(--white-10)] disabled:cursor-not-allowed disabled:opacity-50"
                               title="현재 원인/증거를 keeper LLM에 보내 감독형 진단을 요청합니다"
                               disabled=${assisting}
                               onClick=${(event: MouseEvent) => {

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -63,8 +63,8 @@ export function FleetHealthPanel() {
   return html`
     <div class="flex flex-col gap-4">
         <div class="flex flex-col gap-1">
-          <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">운영 신호 묶음</div>
-          <p class="m-0 text-xs leading-paragraph text-[var(--text-muted)]">
+          <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">운영 신호 묶음</div>
+          <p class="m-0 text-xs leading-paragraph text-[var(--color-fg-muted)]">
             이 화면은 roster가 아니라 이벤트, 비교, 도구 품질, 거버넌스 같은 플릿 신호를 보는 곳입니다.
           </p>
         </div>

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -90,9 +90,9 @@ function trendArrow(direction: TrendDirection): string {
 }
 
 function trendColorClass(direction: TrendDirection, metric: MetricKey): string {
-  if (direction === 'flat') return 'text-[var(--text-dim)]'
+  if (direction === 'flat') return 'text-[var(--color-fg-disabled)]'
   const bad = (direction === 'up' && isUpBad(metric)) || (direction === 'down' && !isUpBad(metric))
-  return bad ? 'text-[var(--bad-light)]' : 'text-[var(--ok)]'
+  return bad ? 'text-[var(--bad-light)]' : 'text-[var(--color-status-ok)]'
 }
 
 function sparklineColor(metric: MetricKey, direction: TrendDirection): string {
@@ -102,11 +102,11 @@ function sparklineColor(metric: MetricKey, direction: TrendDirection): string {
 }
 
 function auditFreshnessClass(isoTimestamp: string | null): string {
-  if (!isoTimestamp) return 'text-[var(--text-dim)]'
+  if (!isoTimestamp) return 'text-[var(--color-fg-disabled)]'
   const ageMs = Date.now() - new Date(isoTimestamp).getTime()
   if (ageMs < 5 * 60 * 1000) return 'text-[var(--text)]'
-  if (ageMs < 15 * 60 * 1000) return 'text-[var(--text-dim)]'
-  return 'text-[var(--warn)]'
+  if (ageMs < 15 * 60 * 1000) return 'text-[var(--color-fg-disabled)]'
+  return 'text-[var(--color-status-warn)]'
 }
 
 function SummaryCard({
@@ -125,13 +125,13 @@ function SummaryCard({
       ? 'border-[var(--ok-20)] bg-[var(--ok-10)]'
       : tone === 'warn'
         ? 'border-[var(--warn-20)] bg-[var(--warn-10)]'
-        : 'border-[var(--card-border)] bg-[var(--white-1)]'
+        : 'border-[var(--color-border-default)] bg-[var(--white-1)]'
 
   return html`
     <div class="rounded border ${toneClass} p-3">
-      <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">${title}</div>
+      <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">${title}</div>
       <div class="mt-1 text-xl font-semibold text-[var(--text)]">${value}</div>
-      <div class="mt-1 text-2xs leading-relaxed text-[var(--text-dim)]">${detail}</div>
+      <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-disabled)]">${detail}</div>
     </div>
   `
 }
@@ -139,8 +139,8 @@ function SummaryCard({
 function WarningBanner({ warnings }: { warnings: string[] }) {
   if (warnings.length === 0) return null
   return html`
-    <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]">
-      <div class="font-medium text-[var(--warn)]">부분 텔레메트리</div>
+    <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--color-status-warn)]">
+      <div class="font-medium text-[var(--color-status-warn)]">부분 텔레메트리</div>
       <div class="mt-1 flex flex-col gap-1">
         ${warnings.map(warning => html`<div>${warning}</div>`)}
       </div>
@@ -155,21 +155,21 @@ function readinessTone(status: string | null | undefined): 'neutral' | 'ok' | 'w
 }
 
 function readinessStatusClass(status: string | null | undefined): string {
-  if (status === 'ok') return 'text-[var(--ok)]'
-  if (status === 'warn') return 'text-[var(--warn)]'
+  if (status === 'ok') return 'text-[var(--color-status-ok)]'
+  if (status === 'warn') return 'text-[var(--color-status-warn)]'
   if (status === 'bad') return 'text-[var(--bad-light)]'
-  return 'text-[var(--text-dim)]'
+  return 'text-[var(--color-fg-disabled)]'
 }
 
 function attentionSeverityClass(severity: string | null | undefined): string {
   if (severity === 'bad') return 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]'
-  if (severity === 'warn') return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]'
-  return 'border-[var(--card-border)] bg-[var(--white-1)] text-[var(--text-dim)]'
+  if (severity === 'warn') return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+  return 'border-[var(--color-border-default)] bg-[var(--white-1)] text-[var(--color-fg-disabled)]'
 }
 
 function ReadinessPillarCard({ pillar }: { pillar: DashboardReadinessPillar }) {
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3">
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3">
       <div class="flex items-center justify-between gap-3">
         <div class="text-2xs font-medium text-[var(--text)]">${pillar.label}</div>
         <div class="font-mono text-2xs ${readinessStatusClass(pillar.status)}">
@@ -179,7 +179,7 @@ function ReadinessPillarCard({ pillar }: { pillar: DashboardReadinessPillar }) {
       <div class="mt-1 text-3xs ${readinessStatusClass(pillar.status)}">${pillar.summary}</div>
       ${pillar.blocking_reasons.length > 0
         ? html`
-          <div class="mt-2 flex flex-col gap-1 text-3xs text-[var(--text-dim)]">
+          <div class="mt-2 flex flex-col gap-1 text-3xs text-[var(--color-fg-disabled)]">
             ${pillar.blocking_reasons.slice(0, 2).map(reason => html`<div>${reason}</div>`)}
           </div>
         `
@@ -191,7 +191,7 @@ function ReadinessPillarCard({ pillar }: { pillar: DashboardReadinessPillar }) {
 function AttentionEventList({ events }: { events: DashboardAttentionEvent[] }) {
   if (events.length === 0) {
     return html`
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 text-2xs text-[var(--text-dim)]">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3 text-2xs text-[var(--color-fg-disabled)]">
         No decision-needed or blocker events are active.
       </div>
     `
@@ -213,7 +213,7 @@ function AttentionEventList({ events }: { events: DashboardAttentionEvent[] }) {
               : null}
           </div>
           ${event.recommended_action
-            ? html`<div class="mt-1 text-3xs text-[var(--text-dim)]">Next: ${event.recommended_action}</div>`
+            ? html`<div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">Next: ${event.recommended_action}</div>`
             : null}
         </div>
       `)}
@@ -231,7 +231,7 @@ function ControlRoomPanel({ state }: { state: FleetTelemetryState }) {
 
   if (!truth || !readiness) {
     return html`
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 text-2xs text-[var(--text-dim)]">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3 text-2xs text-[var(--color-fg-disabled)]">
         Control room readiness is unavailable for this refresh.
       </div>
     `
@@ -268,13 +268,13 @@ function ControlRoomPanel({ state }: { state: FleetTelemetryState }) {
 
       <div class="grid grid-cols-1 gap-3 xl:grid-cols-[minmax(0,2fr)_minmax(0,1.3fr)]">
         <div>
-          <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">준비 상태 항목</div>
+          <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">준비 상태 항목</div>
           <div class="grid grid-cols-1 gap-2 md:grid-cols-2">
             ${readiness.pillars.map(pillar => html`<${ReadinessPillarCard} pillar=${pillar} />`)}
           </div>
         </div>
         <div>
-          <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">주의 대기열</div>
+          <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">주의 대기열</div>
           <${AttentionEventList} events=${attentionEvents} />
         </div>
       </div>
@@ -295,19 +295,19 @@ function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
 
   if (watchlist.length === 0) {
     return html`
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 text-2xs text-[var(--text-dim)]">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3 text-2xs text-[var(--color-fg-disabled)]">
         No keepers are near context pressure or stale activity thresholds.
       </div>
     `
   }
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)]">
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)]">
       ${watchlist.map(row => html`
-        <div class="flex items-center justify-between gap-3 border-b border-[var(--card-border)] px-3 py-2 text-2xs last:border-b-0">
+        <div class="flex items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-3 py-2 text-2xs last:border-b-0">
           <div class="min-w-0">
             <div class="font-mono text-[var(--text)]">${row.name}</div>
-            <div class="text-[var(--text-dim)]">
+            <div class="text-[var(--color-fg-disabled)]">
               ${row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC
                 ? `stale ${formatActivitySignal(row)}`
                 : `ctx ${formatPercent(row.context_ratio * 100, 1)}`}
@@ -315,7 +315,7 @@ function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
           </div>
           <div class="text-right">
             <div class="font-mono ${pressureClass(row.context_ratio)}">${formatPercent(row.context_ratio * 100, 1)}</div>
-            <div class="text-[var(--text-dim)]">${formatActivitySignal(row)}</div>
+            <div class="text-[var(--color-fg-disabled)]">${formatActivitySignal(row)}</div>
           </div>
         </div>
       `)}
@@ -349,14 +349,14 @@ function TrendCell({ name, metric, value, valueClass }: {
 
 function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (name: string) => void }) {
   if (rows.length === 0) {
-    return html`<div class="text-2xs text-[var(--text-dim)]">Keeper 데이터 없음.</div>`
+    return html`<div class="text-2xs text-[var(--color-fg-disabled)]">Keeper 데이터 없음.</div>`
   }
 
   return html`
     <div class="overflow-x-auto">
       <table class="w-full text-2xs">
         <thead>
-          <tr class="border-b border-[var(--card-border)] text-[var(--text-dim)]">
+          <tr class="border-b border-[var(--color-border-default)] text-[var(--color-fg-disabled)]">
             <th class="py-1 text-left font-normal">Keeper</th>
             <th class="py-1 text-right font-normal">Status</th>
             <th class="py-1 text-right font-normal">Activity</th>
@@ -386,9 +386,9 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
             const rowHintClass =
               diagnosticState === 'offline' || diagnosticState === 'dead'
                 ? 'text-[var(--bad-light)]'
-                : 'text-[var(--warn)]'
+                : 'text-[var(--color-status-warn)]'
             return html`
-            <tr class="border-b border-[var(--card-border)] border-opacity-30 align-top">
+            <tr class="border-b border-[var(--color-border-default)] border-opacity-30 align-top">
               <td class="py-1.5">
                 <div class="font-mono text-[var(--text)]">${row.name}</div>
                 ${rowHint
@@ -398,14 +398,14 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                     </div>
                   `
                   : null}
-                <div class="max-w-60 truncate text-3xs text-[var(--text-dim)]" title=${toolInfo.title}>
+                <div class="max-w-60 truncate text-3xs text-[var(--color-fg-disabled)]" title=${toolInfo.title}>
                   ${toolInfo.label}
                 </div>
                 <div class="mt-1 flex max-w-60 flex-wrap gap-1">
                   <span
                     class=${row.goal_linked
-                      ? 'rounded bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs text-[var(--ok)]'
-                      : 'rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--warn)]'}
+                      ? 'rounded bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-ok)]'
+                      : 'rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-warn)]'}
                     title=${row.goal_label ?? '이 키퍼에 연결된 활성 목표가 없습니다.'}
                   >
                     ${row.goal_label
@@ -414,8 +414,8 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                   </span>
                   <span
                     class=${row.sandbox_profile
-                      ? 'rounded bg-[var(--white-8)] px-1.5 py-0.5 text-3xs text-[var(--text-dim)]'
-                      : 'rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--warn)]'}
+                      ? 'rounded bg-[var(--white-8)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-disabled)]'
+                      : 'rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-warn)]'}
                     title=${row.effective_sandbox_image ?? row.sandbox_profile ?? '샌드박스 프로필 정보 없음.'}
                   >
                     ${row.sandbox_profile ? `sandbox ${row.sandbox_profile}` : 'sandbox unknown'}
@@ -425,7 +425,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                     : null}
                 </div>
                 ${row.goal_label
-                  ? html`<div class="max-w-60 truncate text-3xs text-[var(--text-dim)]" title=${row.goal_label}>${row.goal_label}</div>`
+                  ? html`<div class="max-w-60 truncate text-3xs text-[var(--color-fg-disabled)]" title=${row.goal_label}>${row.goal_label}</div>`
                   : null}
                 ${row.sandbox_last_error
                   ? html`
@@ -436,7 +436,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                   : null}
               </td>
               <td class="py-1.5 text-right font-mono ${statusClass(row)}">${row.status}</td>
-              <td class="py-1.5 text-right text-[var(--text-dim)]">${formatActivitySignal(row)}</td>
+              <td class="py-1.5 text-right text-[var(--color-fg-disabled)]">${formatActivitySignal(row)}</td>
               <td class="py-1.5 text-right text-3xs ${auditFreshnessClass(row.tool_audit_at)}" title=${row.tool_audit_at ?? ''}>
                 ${row.tool_audit_at ? formatTimeAgo(row.tool_audit_at) : '-'}
               </td>
@@ -458,19 +458,19 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
               <${TrendCell}
                 name=${row.name} metric="last_latency_ms"
                 value=${formatLatency(row.last_latency_ms)}
-                valueClass="text-[var(--text-dim)]"
+                valueClass="text-[var(--color-fg-disabled)]"
               />
-              <td class="py-1.5 text-right text-3xs text-[var(--text-dim)]">${row.model}</td>
+              <td class="py-1.5 text-right text-3xs text-[var(--color-fg-disabled)]">${row.model}</td>
               <td class="py-1.5 text-center">
                 ${row.budget_source === 'override_invalid'
                   ? html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--bad-light)]" title="TOML override가 범위를 벗어남">ERR</span>`
                   : row.budget_source === 'override'
-                    ? html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--warn)]" title="TOML override 적용됨">OVR</span>`
-                    : html`<span class="text-3xs text-[var(--text-dim)]">\u2014</span>`}
+                    ? html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--color-status-warn)]" title="TOML override 적용됨">OVR</span>`
+                    : html`<span class="text-3xs text-[var(--color-fg-disabled)]">\u2014</span>`}
               </td>
               <td class="py-1.5 text-center">
                 <button
-                  class="rounded p-0.5 text-[var(--text-dim)] hover:text-[var(--bad-light)] hover:bg-[var(--bad-10)] transition-colors"
+                  class="rounded p-0.5 text-[var(--color-fg-disabled)] hover:text-[var(--bad-light)] hover:bg-[var(--bad-10)] transition-colors"
                   onClick=${() => onReset(row.name)}
                   title="초기화"
                   aria-label=${`${row.name} 초기화`}
@@ -488,21 +488,21 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
 
 function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] }) {
   if (sources.length === 0) {
-    return html`<div class="text-2xs text-[var(--text-dim)]">Telemetry store summary is unavailable.</div>`
+    return html`<div class="text-2xs text-[var(--color-fg-disabled)]">Telemetry store summary is unavailable.</div>`
   }
 
   const sorted = [...sources].sort((a, b) => b.entry_count - a.entry_count)
   return html`
     <div class="grid grid-cols-1 gap-2 md:grid-cols-2">
       ${sorted.map(source => html`
-        <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3">
+        <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3">
           <div class="flex items-center justify-between gap-3">
             <div class="text-2xs font-medium text-[var(--text)]">${sourceLabel(source.source)}</div>
             <div class="font-mono text-2xs ${sourceCountClass(source)}">
               ${source.entry_count.toLocaleString()}
             </div>
           </div>
-          <div class="mt-1 text-3xs text-[var(--text-dim)]">${sourceDetail(source)}</div>
+          <div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">${sourceDetail(source)}</div>
         </div>
       `)}
     </div>
@@ -511,7 +511,7 @@ function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] 
 
 function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityResponse }) {
   if (toolQuality.failure_categories.length === 0) {
-    return html`<div class="text-2xs text-[var(--text-dim)]">최근 실패 카테고리 없음.</div>`
+    return html`<div class="text-2xs text-[var(--color-fg-disabled)]">최근 실패 카테고리 없음.</div>`
   }
 
   const top = toolQuality.failure_categories.slice(0, 8)
@@ -528,7 +528,7 @@ function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityRespons
             ></div>
             <span class="truncate font-mono text-[var(--bad-light)]" title=${category.category}>${category.category}</span>
           </div>
-          <span class="text-[var(--text-dim)]">${category.count}</span>
+          <span class="text-[var(--color-fg-disabled)]">${category.count}</span>
         </div>
       `)}
     </div>
@@ -689,22 +689,22 @@ export function FleetTelemetryPanel() {
         <div class="flex items-center gap-3">
           <h2 class="text-sm font-medium">Keeper 텔레메트리</h2>
           <div class="flex items-center gap-2 text-3xs">
-            ${activeCount > 0 ? html`<span class="rounded-sm bg-[var(--ok-10)] px-1.5 py-0.5 text-[var(--ok)]">${activeCount} 가동</span>` : null}
-            ${attentionCount > 0 ? html`<span class="rounded-sm bg-[var(--warn-10)] px-1.5 py-0.5 text-[var(--warn)]">${attentionCount} 주의</span>` : null}
-            ${offlineCount > 0 ? html`<span class="rounded-sm bg-[var(--white-8)] px-1.5 py-0.5 text-[var(--text-dim)]">${offlineCount} 오프라인</span>` : null}
-            ${budgetOverrideCount > 0 ? html`<span class="rounded-sm bg-[var(--warn-10)] px-1.5 py-0.5 text-[var(--warn)]">${budgetOverrideCount} 예산 재정의</span>` : null}
+            ${activeCount > 0 ? html`<span class="rounded-sm bg-[var(--ok-10)] px-1.5 py-0.5 text-[var(--color-status-ok)]">${activeCount} 가동</span>` : null}
+            ${attentionCount > 0 ? html`<span class="rounded-sm bg-[var(--warn-10)] px-1.5 py-0.5 text-[var(--color-status-warn)]">${attentionCount} 주의</span>` : null}
+            ${offlineCount > 0 ? html`<span class="rounded-sm bg-[var(--white-8)] px-1.5 py-0.5 text-[var(--color-fg-disabled)]">${offlineCount} 오프라인</span>` : null}
+            ${budgetOverrideCount > 0 ? html`<span class="rounded-sm bg-[var(--warn-10)] px-1.5 py-0.5 text-[var(--color-status-warn)]">${budgetOverrideCount} 예산 재정의</span>` : null}
           </div>
         </div>
         <div class="flex items-center gap-2">
-          <span class="text-3xs text-[var(--text-dim)]">
+          <span class="text-3xs text-[var(--color-fg-disabled)]">
             ${value.updated_at ? `${formatTimeAgo(value.updated_at)} 갱신` : ''}
           </span>
           <button
-            class="rounded bg-[var(--bg-subtle)] px-2 py-0.5 text-3xs text-[var(--text-dim)] hover:text-[var(--text)]"
+            class="rounded bg-[var(--bg-subtle)] px-2 py-0.5 text-3xs text-[var(--color-fg-disabled)] hover:text-[var(--text)]"
             onClick=${() => { void loadFleetTelemetry() }}
             aria-label="Keeper 텔레메트리 새로고침"
           >새로고침</button>
-          <span class="text-3xs text-[var(--text-dim)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
         </div>
       </div>
 
@@ -742,39 +742,39 @@ export function FleetTelemetryPanel() {
       </div>
 
       <div>
-        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">함대 통제실</div>
+        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">함대 통제실</div>
         <${ControlRoomPanel} state=${value} />
       </div>
 
       <div>
-        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">압박 감시 목록</div>
+        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">압박 감시 목록</div>
         <${PressureWatchlist} rows=${value.rows} />
       </div>
 
       <div>
         <div class="mb-1 flex items-center justify-between gap-2">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">Keeper 비교</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">Keeper 비교</div>
           <input
             type="search"
             value=${query.value}
             placeholder="name / model / blocker 필터"
             aria-label="Keeper 필터"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
           />
         </div>
         ${isFiltering && visibleRows.length === 0 && value.rows.length > 0
-          ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${value.rows.length} keepers)</div>`
+          ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${value.rows.length} keepers)</div>`
           : html`<${FleetComparisonTable} rows=${visibleRows} onReset=${handleReset} />`}
       </div>
 
       <div>
-        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">텔레메트리 출처</div>
+        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">텔레메트리 출처</div>
         <${TelemetrySourcesPanel} sources=${value.telemetry_sources} />
       </div>
 
       <div>
-        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">실패 분류</div>
+        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">실패 분류</div>
         <${FailureCategoryPanel} toolQuality=${value.tool_quality} />
       </div>
     </div>

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -138,13 +138,13 @@ describe('uniqueStrings', () => {
 
 describe('successClass', () => {
   it('returns ok for >=97', () => {
-    expect(successClass(97)).toContain('var(--ok)')
-    expect(successClass(100)).toContain('var(--ok)')
+    expect(successClass(97)).toContain('var(--color-status-ok)')
+    expect(successClass(100)).toContain('var(--color-status-ok)')
   })
 
   it('returns warn for 90-96', () => {
-    expect(successClass(90)).toContain('var(--warn)')
-    expect(successClass(96)).toContain('var(--warn)')
+    expect(successClass(90)).toContain('var(--color-status-warn)')
+    expect(successClass(96)).toContain('var(--color-status-warn)')
   })
 
   it('returns bad-light for <90', () => {
@@ -253,11 +253,11 @@ describe('pressureClass', () => {
   })
 
   it('returns warn for warn ratio', () => {
-    expect(pressureClass(PRESSURE_WARN_RATIO)).toContain('var(--warn)')
+    expect(pressureClass(PRESSURE_WARN_RATIO)).toContain('var(--color-status-warn)')
   })
 
   it('returns ok for low ratio', () => {
-    expect(pressureClass(0.1)).toContain('var(--ok)')
+    expect(pressureClass(0.1)).toContain('var(--color-status-ok)')
   })
 })
 
@@ -268,11 +268,11 @@ describe('statusClass', () => {
   })
 
   it('returns warn for runtime blocker', () => {
-    expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toContain('var(--warn)')
+    expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toContain('var(--color-status-warn)')
   })
 
   it('returns warn for stale diagnostic health state', () => {
-    expect(statusClass(makeRow({ status: 'inactive', diagnostic_health_state: 'stale' }))).toContain('var(--warn)')
+    expect(statusClass(makeRow({ status: 'inactive', diagnostic_health_state: 'stale' }))).toContain('var(--color-status-warn)')
   })
 
   it('returns bad-light for offline diagnostic health state', () => {
@@ -280,7 +280,7 @@ describe('statusClass', () => {
   })
 
   it('returns ok for healthy', () => {
-    expect(statusClass(makeRow())).toContain('var(--ok)')
+    expect(statusClass(makeRow())).toContain('var(--color-status-ok)')
   })
 })
 

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -147,9 +147,9 @@ function keeperLastLatencyMs(keeper: Keeper): number {
 }
 
 export function successClass(rate: number | null): string {
-  if (rate == null || !Number.isFinite(rate)) return 'text-[var(--text-dim)]'
-  if (rate >= 97) return 'text-[var(--ok)]'
-  if (rate >= 90) return 'text-[var(--warn)]'
+  if (rate == null || !Number.isFinite(rate)) return 'text-[var(--color-fg-disabled)]'
+  if (rate >= 97) return 'text-[var(--color-status-ok)]'
+  if (rate >= 90) return 'text-[var(--color-status-warn)]'
   return 'text-[var(--bad-light)]'
 }
 
@@ -415,8 +415,8 @@ export function toneForPressure(hot: number, warn: number): 'neutral' | 'ok' | '
 
 export function pressureClass(ratio: number): string {
   if (ratio >= PRESSURE_HOT_RATIO) return 'text-[var(--bad-light)]'
-  if (ratio >= PRESSURE_WARN_RATIO) return 'text-[var(--warn)]'
-  return 'text-[var(--ok)]'
+  if (ratio >= PRESSURE_WARN_RATIO) return 'text-[var(--color-status-warn)]'
+  return 'text-[var(--color-status-ok)]'
 }
 
 export function statusClass(row: FleetRow): string {
@@ -438,10 +438,10 @@ export function statusClass(row: FleetRow): string {
     || normalizedStatus === 'inactive'
     || row.runtime_blocker_class != null
   ) {
-    return 'text-[var(--warn)]'
+    return 'text-[var(--color-status-warn)]'
   }
-  if (row.context_ratio >= PRESSURE_HOT_RATIO) return 'text-[var(--warn)]'
-  return 'text-[var(--ok)]'
+  if (row.context_ratio >= PRESSURE_HOT_RATIO) return 'text-[var(--color-status-warn)]'
+  return 'text-[var(--color-status-ok)]'
 }
 
 export function formatPercent(value: number | null, digits = 0): string {
@@ -483,15 +483,15 @@ export function sourceCountClass(source: TelemetrySourceSummary): string {
       return 'text-[var(--bad-light)]'
     case 'stale':
     case 'coverage_gap':
-      return 'text-[var(--warn)]'
+      return 'text-[var(--color-status-warn)]'
     case 'ok':
-      return 'text-[var(--ok)]'
+      return 'text-[var(--color-status-ok)]'
   }
   if (source.exists === false) return 'text-[var(--bad-light)]'
-  if (source.entry_count <= 0) return 'text-[var(--text-dim)]'
+  if (source.entry_count <= 0) return 'text-[var(--color-fg-disabled)]'
   const age = numericAge(source.latest_age_s)
-  if (age != null && age >= TELEMETRY_SOURCE_STALE_SEC) return 'text-[var(--warn)]'
-  return 'text-[var(--ok)]'
+  if (age != null && age >= TELEMETRY_SOURCE_STALE_SEC) return 'text-[var(--color-status-warn)]'
+  return 'text-[var(--color-status-ok)]'
 }
 
 export function sourceDetail(source: TelemetrySourceSummary): string {

--- a/dashboard/src/components/flow-control/flow-control-panel.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.ts
@@ -36,11 +36,11 @@ export function FlowControlPanel() {
   return html`
     <${SurfaceCard} variant="compact" class="mb-4">
       <div class="flex items-center gap-3 mb-3">
-        <h3 class="text-sm text-[var(--text-strong)] font-medium">흐름 제어</h3>
+        <h3 class="text-sm text-[var(--color-fg-secondary)] font-medium">흐름 제어</h3>
         <${CountBadge} tone=${stateTone(state)}>${stateLabel(state)}<//>
       </div>
       ${mutationAccess.allowed ? null : html`
-        <p class="mb-3 text-2xs text-[var(--warn)]">
+        <p class="mb-3 text-2xs text-[var(--color-status-warn)]">
           제어 차단: ${mutationAccess.reason ?? 'worker 권한이 필요합니다.'}
         </p>
       `}
@@ -55,7 +55,7 @@ export function FlowControlPanel() {
     ${'' /* ── Maintenance ── */}
     <${SurfaceCard} variant="compact">
       <details>
-        <summary class="cursor-pointer text-sm text-[var(--text-strong)] font-medium select-none py-1">유지보수</summary>
+        <summary class="cursor-pointer text-sm text-[var(--color-fg-secondary)] font-medium select-none py-1">유지보수</summary>
         <div class="mt-3 flex flex-wrap gap-2">
           <${ActionButton} variant="ghost" size="md" disabled=${maintenanceLoading.value || !mutationAccess.allowed}
             onClick=${async () => {

--- a/dashboard/src/components/fsm-hub-health-panels.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.ts
@@ -35,11 +35,11 @@ export function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapsho
   const m = snapshot.measurement
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
-      <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)] mb-2">
+      <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)] mb-2">
         Measurement
       </div>
       ${m.captured && m.auto_rules ? html`
-        <div class="flex flex-col gap-1.5 text-2xs text-[var(--text-body)]">
+        <div class="flex flex-col gap-1.5 text-2xs text-[var(--color-fg-primary)]">
           <div class="flex flex-wrap gap-1.5 font-mono">
             <${Flag} label="reflect" on=${m.auto_rules.reflect} />
             <${Flag} label="plan" on=${m.auto_rules.plan} />
@@ -49,7 +49,7 @@ export function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapsho
           <div class="flex items-center gap-2 font-mono">
             <${Flag} label="guardrail" on=${m.auto_rules.guardrail_stop} tone="warn" />
             <span
-              class="text-3xs text-[var(--text-dim)] cursor-help"
+              class="text-3xs text-[var(--color-fg-disabled)] cursor-help"
               title="Goal drift: 0 = keeper is on-target; higher = keeper output is diverging from its declared goal. Values above ~0.5 typically trigger the guardrail."
             >drift ${m.auto_rules.goal_drift.toFixed(2)}</span>
           </div>
@@ -58,7 +58,7 @@ export function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapsho
           ` : null}
         </div>
       ` : html`
-        <div class="text-3xs text-[var(--text-dim)]">키퍼가 첫 턴을 완료하면 auto-rules가 여기 표시됩니다</div>
+        <div class="text-3xs text-[var(--color-fg-disabled)]">키퍼가 첫 턴을 완료하면 auto-rules가 여기 표시됩니다</div>
       `}
     </div>
   `
@@ -71,7 +71,7 @@ export function flagTooltip(label: string, on: boolean): string {
 }
 
 function Flag({ label, on, tone = 'ok' }: { label: string; on: boolean; tone?: 'ok' | 'warn' }) {
-  const offCls = 'text-[var(--text-dim)] border-[var(--white-8)]'
+  const offCls = 'text-[var(--color-fg-disabled)] border-[var(--white-8)]'
   const onCls =
     tone === 'warn'
       ? 'text-[var(--amber-bright)] border-[rgba(251,191,36,0.3)] bg-[var(--warn-8)]'
@@ -119,14 +119,14 @@ export function InvariantsPanel({
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
       <div class="flex items-center justify-between mb-2">
-        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
           Safety
         </div>
         <span
           class=${`rounded-sm border px-2 py-0.5 text-3xs font-mono tabular-nums ${
             allOk
               ? 'text-[var(--emerald)] border-[var(--emerald-30)] bg-[var(--emerald-8)]'
-              : 'text-[var(--bad)] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]'
+              : 'text-[var(--color-status-err)] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]'
           }`}
           title=${allOk
             ? `All ${total} keeper composite invariants hold.`
@@ -145,10 +145,10 @@ export function InvariantsPanel({
           const tooltip = `${entry.label} — ${entry.ok ? 'holds' : 'BROKEN'}\n${desc}${rate ? `\n누적: ${rate}` : ''}`
           return html`
             <li class="flex gap-2 text-3xs cursor-help" title=${tooltip}>
-              <span class=${`mt-[5px] h-1.5 w-1.5 rounded-full shrink-0 ${entry.ok ? 'bg-[var(--emerald)]' : 'bg-[var(--bad)]'}`}></span>
+              <span class=${`mt-[5px] h-1.5 w-1.5 rounded-full shrink-0 ${entry.ok ? 'bg-[var(--emerald)]' : 'bg-[var(--color-status-err)]'}`}></span>
               <div class="min-w-0 flex-1">
                 <div class="flex items-center gap-1.5">
-                  <span class=${entry.ok ? 'text-[var(--text-body)]' : 'text-[var(--bad-light)] font-semibold'}>
+                  <span class=${entry.ok ? 'text-[var(--color-fg-primary)]' : 'text-[var(--bad-light)] font-semibold'}>
                     ${entry.label}
                   </span>
                   ${vCount > 0 ? html`
@@ -157,7 +157,7 @@ export function InvariantsPanel({
                     </span>
                   ` : null}
                 </div>
-                <div class="text-4xs leading-relaxed text-[var(--text-dim)]">
+                <div class="text-4xs leading-relaxed text-[var(--color-fg-disabled)]">
                   ${entry.detail}
                 </div>
               </div>

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -49,9 +49,9 @@ export function filterObservedLanes(
 
 const INSIGHT_BADGE_CLS: Record<InsightTone, string> = {
   ok: 'text-[var(--emerald)] border-[var(--emerald-30)] bg-[var(--emerald-8)]',
-  info: 'text-[var(--accent)] border-[var(--accent-30)] bg-[var(--accent-10)]',
+  info: 'text-[var(--color-accent-fg)] border-[var(--accent-30)] bg-[var(--accent-10)]',
   warn: 'text-[var(--amber-bright)] border-[rgba(245,158,11,0.3)] bg-[rgba(245,158,11,0.08)]',
-  error: 'text-[var(--bad)] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]',
+  error: 'text-[var(--color-status-err)] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]',
 }
 
 /** Panel-level accent -- border + subtle tinted overlay -- so that the
@@ -93,29 +93,29 @@ export function OperationalMeaningPanel({
     >
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div class="min-w-0">
-          <div class="text-3xs font-semibold uppercase tracking-2 text-[var(--text-muted)]">오퍼레이터 의미</div>
-          <div class="mt-1 text-xl font-semibold text-[var(--text-strong)]">${insight.headline}</div>
-          <div class="mt-1 text-2xs text-[var(--text-dim)] leading-relaxed">${insight.detail}</div>
+          <div class="text-3xs font-semibold uppercase tracking-2 text-[var(--color-fg-muted)]">오퍼레이터 의미</div>
+          <div class="mt-1 text-xl font-semibold text-[var(--color-fg-secondary)]">${insight.headline}</div>
+          <div class="mt-1 text-2xs text-[var(--color-fg-disabled)] leading-relaxed">${insight.detail}</div>
         </div>
         <span class=${`rounded-sm border px-2.5 py-0.5 text-3xs font-mono ${INSIGHT_BADGE_CLS[insight.tone]}`}>
           ${insight.tone}
         </span>
       </div>
 
-      <div class="mt-2 text-3xs text-[var(--text-body)]">
-        <span class="font-semibold text-[var(--text-muted)]">Next:</span> ${insight.nextStep}
+      <div class="mt-2 text-3xs text-[var(--color-fg-primary)]">
+        <span class="font-semibold text-[var(--color-fg-muted)]">Next:</span> ${insight.nextStep}
       </div>
 
       <div class="mt-2 flex flex-wrap gap-1.5">
         ${insight.evidence.map(item => html`
-          <span class="rounded-sm border border-[var(--white-8)] px-2 py-0.5 text-3xs font-mono text-[var(--text-dim)]">
+          <span class="rounded-sm border border-[var(--white-8)] px-2 py-0.5 text-3xs font-mono text-[var(--color-fg-disabled)]">
             ${item}
           </span>
         `)}
       </div>
 
       <div class="mt-4 flex items-center justify-between gap-2">
-        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
           관찰 레인
         </div>
         <input
@@ -124,26 +124,26 @@ export function OperationalMeaningPanel({
           placeholder="field / label / state / meaning 필터"
           aria-label="관찰 레인 필터"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
 
       ${isFiltering && visibleLanes.length === 0 && lanes.length > 0
-        ? html`<div class="mt-2 py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${lanes.length} lanes)</div>`
+        ? html`<div class="mt-2 py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${lanes.length} lanes)</div>`
         : html`
           <div class="mt-2 grid gap-2 md:grid-cols-2 xl:grid-cols-5">
             ${visibleLanes.map(lane => html`
               <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
                 <div class="flex items-center justify-between gap-2">
-                  <span class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">${lane.field}</span>
+                  <span class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">${lane.field}</span>
                   <span class=${`rounded-sm border px-1.5 py-0.5 text-4xs font-mono ${INSIGHT_BADGE_CLS[lane.tone]}`}>
                     ${fmtDuration(lane.observedForSec)}
                   </span>
                 </div>
-                <div class="mt-1 font-mono text-sm font-semibold text-[var(--text-strong)]">${lane.value}</div>
-                <div class="mt-0.5 text-3xs text-[var(--text-dim)]">${lane.label}</div>
-                <div class="mt-1.5 text-3xs leading-relaxed text-[var(--text-body)]">${lane.meaning}</div>
-                <div class="mt-1 text-4xs font-mono text-[var(--text-dim)]">
+                <div class="mt-1 font-mono text-sm font-semibold text-[var(--color-fg-secondary)]">${lane.value}</div>
+                <div class="mt-0.5 text-3xs text-[var(--color-fg-disabled)]">${lane.label}</div>
+                <div class="mt-1.5 text-3xs leading-relaxed text-[var(--color-fg-primary)]">${lane.meaning}</div>
+                <div class="mt-1 text-4xs font-mono text-[var(--color-fg-disabled)]">
                   ${lane.transitionCount} observed edge${lane.transitionCount === 1 ? '' : 's'}
                 </div>
               </div>
@@ -159,8 +159,8 @@ const PHASE_BAR_FILL: Record<string, string> = {
   Overflowed: 'var(--amber-bright)',
   Compacting: 'var(--amber-bright)',
   HandingOff: 'var(--purple)',
-  Failing: 'var(--bad)',
-  Draining: 'var(--warn)',
+  Failing: 'var(--color-status-err)',
+  Draining: 'var(--color-status-warn)',
   Stable: '#71717a',
 }
 
@@ -187,7 +187,7 @@ function PhaseSparkline({
   const bars = segments.map((seg, i) => {
     const dur = Math.max(0, seg.to - seg.from)
     const w = Math.max(1, (dur / totalDuration) * (W - (segments.length - 1) * gap))
-    const fill = PHASE_BAR_FILL[seg.value] ?? 'var(--accent)'
+    const fill = PHASE_BAR_FILL[seg.value] ?? 'var(--color-accent-fg)'
     const barX = x
     x += w + gap
     const isLast = i === segments.length - 1
@@ -196,7 +196,7 @@ function PhaseSparkline({
 
   return html`
     <div class="mt-2 flex items-center gap-2">
-      <span class="text-4xs text-[var(--text-dim)]">phase</span>
+      <span class="text-4xs text-[var(--color-fg-disabled)]">phase</span>
       <svg
         width=${W} height=${H}
         viewBox=${`0 0 ${W} ${H}`}
@@ -286,14 +286,14 @@ export function HeroPhase({
   }, [snapshot.phase])
 
   const phaseColor: Record<string, string> = {
-    Running: 'text-[var(--ok)]',
-    Overflowed: 'text-[var(--warn)]',
-    Compacting: 'text-[var(--warn)]',
-    HandingOff: 'text-[var(--accent)]',
+    Running: 'text-[var(--color-status-ok)]',
+    Overflowed: 'text-[var(--color-status-warn)]',
+    Compacting: 'text-[var(--color-status-warn)]',
+    HandingOff: 'text-[var(--color-accent-fg)]',
     Failing: 'text-[var(--bad-light)]',
-    Stable: 'text-[var(--text-dim)]',
+    Stable: 'text-[var(--color-fg-disabled)]',
   }
-  const color = phaseColor[snapshot.phase] ?? 'text-[var(--accent)]'
+  const color = phaseColor[snapshot.phase] ?? 'text-[var(--color-accent-fg)]'
   const heldFor = phaseSince != null ? fmtDuration(Math.max(0, now - phaseSince)) : null
   const collapsedSource = snapshot.phase === 'Stable' ? snapshot.collapsed_from : null
   const collapsedSourceLabel = collapsedSource
@@ -309,29 +309,29 @@ export function HeroPhase({
   ].filter(Boolean).join(', ')
 
   return html`
-    <div class=${`rounded border p-5 transition-all duration-700 ${flash ? 'border-[var(--accent)] bg-[rgba(71,184,255,0.06)] shadow-[0_0_16px_var(--accent-20)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}
+    <div class=${`rounded border p-5 transition-all duration-700 ${flash ? 'border-[var(--color-accent-fg)] bg-[rgba(71,184,255,0.06)] shadow-[0_0_16px_var(--accent-20)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}
       role="status" aria-live="polite" aria-label=${ariaLabel}
       title=${title}
     >
       <div class="flex items-baseline justify-between">
         <div>
-          <div class="text-3xs font-semibold tracking-[0.06em] text-[var(--text-muted)]" id="ksm-label">Keeper 생명주기 <span class="font-mono text-4xs text-[var(--text-dim)]">KSM</span></div>
+          <div class="text-3xs font-semibold tracking-[0.06em] text-[var(--color-fg-muted)]" id="ksm-label">Keeper 생명주기 <span class="font-mono text-4xs text-[var(--color-fg-disabled)]">KSM</span></div>
           <div class=${`mt-1 font-mono text-[32px] font-bold tracking-tight ${color}`} aria-labelledby="ksm-label">
             ${displayState(snapshot.phase)}
           </div>
-          <div class="mt-0.5 text-3xs font-mono text-[var(--text-dim)]">${snapshot.phase}</div>
+          <div class="mt-0.5 text-3xs font-mono text-[var(--color-fg-disabled)]">${snapshot.phase}</div>
           ${collapsedSourceLabel ? html`
-            <div class="mt-1 text-3xs font-mono text-[var(--text-dim)]">
-              collapsed from <span class="text-[var(--text-body)]">${collapsedSourceLabel}</span>
+            <div class="mt-1 text-3xs font-mono text-[var(--color-fg-disabled)]">
+              collapsed from <span class="text-[var(--color-fg-primary)]">${collapsedSourceLabel}</span>
             </div>
           ` : null}
           ${heldFor ? html`
-            <div class="mt-1 text-3xs font-mono text-[var(--text-dim)]" aria-hidden="true">
-              유지 <span class="text-[var(--text-body)]">${heldFor}</span>
+            <div class="mt-1 text-3xs font-mono text-[var(--color-fg-disabled)]" aria-hidden="true">
+              유지 <span class="text-[var(--color-fg-primary)]">${heldFor}</span>
             </div>
           ` : null}
         </div>
-        ${flash ? html`<span class="text-3xs text-[var(--accent)] animate-pulse font-mono" aria-live="assertive">상태 변경</span>` : null}
+        ${flash ? html`<span class="text-3xs text-[var(--color-accent-fg)] animate-pulse font-mono" aria-live="assertive">상태 변경</span>` : null}
       </div>
       <${PhaseSparkline} observations=${observations} now=${now} />
     </div>
@@ -371,7 +371,7 @@ export function PipelineStep({
 
   const isActive = value !== 'idle' && value !== 'undecided' && value !== 'accumulating'
   const borderCls = flash
-    ? 'border-[var(--accent)] shadow-[0_0_8px_rgba(71,184,255,0.35)]'
+    ? 'border-[var(--color-accent-fg)] shadow-[0_0_8px_rgba(71,184,255,0.35)]'
     : isActive
       ? 'border-[var(--indigo-50)] shadow-[0_0_6px_rgba(129,140,248,0.15)]'
       : 'border-[var(--white-8)]'
@@ -386,12 +386,12 @@ export function PipelineStep({
 
   const heldFor = sinceTs != null ? fmtDuration(Math.max(0, now - sinceTs)) : null
   const stalenessCls = (() => {
-    if (!heldFor || sinceTs == null) return 'text-[var(--text-dim)]'
+    if (!heldFor || sinceTs == null) return 'text-[var(--color-fg-disabled)]'
     const ageSec = now - sinceTs
     if (!isActive) {
       // idle 상태에서도 장기 대기를 시각적으로 구분
-      if (ageSec > 600) return 'text-[var(--text-muted)]'
-      return 'text-[var(--text-dim)]'
+      if (ageSec > 600) return 'text-[var(--color-fg-muted)]'
+      return 'text-[var(--color-fg-disabled)]'
     }
     if (ageSec > 60) return 'text-[var(--amber-bright)]'
     if (ageSec > 20) return 'text-[var(--yellow-bright)]'
@@ -406,17 +406,17 @@ export function PipelineStep({
         <div class="flex items-center justify-between gap-1.5">
           <div class="flex items-center gap-1.5 min-w-0">
             ${isActive ? html`<span class="h-1.5 w-1.5 rounded-full bg-[var(--indigo)] ${activePulse} shrink-0"></span>` : null}
-            <span class="text-3xs font-semibold tracking-[0.04em] text-[var(--text-muted)]">${label}</span>
-            ${limited ? html`<span class="text-[7px] font-mono text-[var(--text-dim)] border border-[var(--white-10)] rounded px-1" title="Event_bus 구독 미구현으로 일부 상태만 관찰 가능">제한</span>` : null}
+            <span class="text-3xs font-semibold tracking-[0.04em] text-[var(--color-fg-muted)]">${label}</span>
+            ${limited ? html`<span class="text-[7px] font-mono text-[var(--color-fg-disabled)] border border-[var(--white-10)] rounded px-1" title="Event_bus 구독 미구현으로 일부 상태만 관찰 가능">제한</span>` : null}
           </div>
           ${heldFor ? html`
             <span class=${`text-3xs font-mono tabular-nums ${stalenessCls}`} aria-hidden="true">${heldFor}</span>
           ` : null}
         </div>
-        <div class=${`mt-0.5 font-mono text-sm font-semibold ${isActive ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'} ${flash ? 'animate-pulse' : ''}`}>
+        <div class=${`mt-0.5 font-mono text-sm font-semibold ${isActive ? 'text-[var(--color-fg-secondary)]' : 'text-[var(--color-fg-muted)]'} ${flash ? 'animate-pulse' : ''}`}>
           ${displayState(value)}
         </div>
-        <div class="text-4xs font-mono text-[var(--text-dim)] mt-0.5">${shortLabel} · ${value}</div>
+        <div class="text-4xs font-mono text-[var(--color-fg-disabled)] mt-0.5">${shortLabel} · ${value}</div>
       </div>
       ${!isLast ? html`<div class=${`hidden md:block w-5 shrink-0 ${connectorCls}`}></div>` : null}
     </div>
@@ -434,7 +434,7 @@ export function TurnPipelineStrip({
 }) {
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
-      <div class="mb-2 text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+      <div class="mb-2 text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
         턴 파이프라인
       </div>
       <div class="flex flex-col gap-1 md:flex-row md:gap-0 md:items-stretch" role="list" aria-label="턴 파이프라인 단계">

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -20,7 +20,7 @@ import {
 } from './fsm-hub-derivations'
 
 const FIELD_COLOR: Record<string, string> = {
-  KSM: 'text-[var(--accent)]',
+  KSM: 'text-[var(--color-accent-fg)]',
   KTC: 'text-[var(--indigo)]',
   KDP: 'text-[var(--indigo)]',
   KCL: 'text-[var(--indigo)]',
@@ -163,7 +163,7 @@ export function SwimlaneTimeline({
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3" data-fsm-swimlane-root="true">
       <div class="mb-2 flex items-baseline justify-between gap-3 flex-wrap">
-        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
           상태 타임라인
         </div>
         <div class="flex items-center gap-1 flex-wrap">
@@ -174,22 +174,22 @@ export function SwimlaneTimeline({
               <span
                 class=${`rounded-sm border px-1.5 py-0.5 text-3xs font-mono tabular-nums ${
                   count === 0
-                    ? 'text-[var(--text-dim)] border-[var(--white-8)]'
+                    ? 'text-[var(--color-fg-disabled)] border-[var(--white-8)]'
                     : isBusiest
                       ? 'text-[var(--indigo)] border-[var(--indigo-40)] bg-[rgba(129,140,248,0.08)]'
-                      : 'text-[var(--text-body)] border-[var(--white-10)]'
+                      : 'text-[var(--color-fg-primary)] border-[var(--white-10)]'
                 }`}
                 title=${`${lane.label} · ${count} transition${count === 1 ? '' : 's'} in this window`}
               >${lane.short} ${count}</span>
             `
           })}
         </div>
-        <div class="text-3xs font-mono text-[var(--text-dim)]">
+        <div class="text-3xs font-mono text-[var(--color-fg-disabled)]">
           <span>${fmtAbs(spanStart)}</span>
-          <span class="mx-1 text-[var(--text-muted)]">→</span>
+          <span class="mx-1 text-[var(--color-fg-muted)]">→</span>
           <span>${fmtAbs(spanEnd)}</span>
-          · window <span class="text-[var(--text-body)]">${windowDuration}</span>
-          · <span class="text-[var(--text-body)]">${observations.length}</span> obs
+          · window <span class="text-[var(--color-fg-primary)]">${windowDuration}</span>
+          · <span class="text-[var(--color-fg-primary)]">${observations.length}</span> obs
         </div>
       </div>
       <div class="flex flex-col gap-1.5">
@@ -197,7 +197,7 @@ export function SwimlaneTimeline({
           const segments = deriveSwimlaneSegments(observations, lane.key, spanEnd)
           return html`
             <div class="flex items-center gap-2">
-              <div class="w-11 shrink-0 text-3xs font-mono font-semibold text-[var(--text-muted)]">
+              <div class="w-11 shrink-0 text-3xs font-mono font-semibold text-[var(--color-fg-muted)]">
                 ${lane.short}
               </div>
               <div class="flex h-4 flex-1 overflow-hidden rounded border border-[var(--white-8)]" role="group" aria-label=${`${lane.label} swimlane with ${segments.length} segments`}>
@@ -218,7 +218,7 @@ export function SwimlaneTimeline({
                       data-lane-key=${lane.key}
                       data-lane-index=${laneIndex}
                       data-seg-index=${segIndex}
-                      class=${`${swimlaneSegmentColor(seg.value)} h-full transition-all duration-200 border-r border-[rgba(0,0,0,0.25)] last:border-r-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-inset ${isHovered ? 'ring-1 ring-[var(--accent)] brightness-125' : ''} ${dimmed ? 'opacity-40' : ''}`}
+                      class=${`${swimlaneSegmentColor(seg.value)} h-full transition-all duration-200 border-r border-[rgba(0,0,0,0.25)] last:border-r-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-fg)] focus-visible:ring-inset ${isHovered ? 'ring-1 ring-[var(--color-accent-fg)] brightness-125' : ''} ${dimmed ? 'opacity-40' : ''}`}
                       style=${`width: ${pct.toFixed(2)}%`}
                       title=${`${lane.label} (${lane.short}) · ${displayState(seg.value)} (${seg.value})\n${fmtAbs(seg.from)} → ${fmtAbs(seg.to)} · ${holdFor}`}
                       aria-label=${ariaLabel}
@@ -243,7 +243,7 @@ export function SwimlaneTimeline({
               const leftPct = ((tick.ts - spanStart) / spanWidth) * 100
               return html`
                 <div
-                  class="absolute top-0 flex flex-col items-center text-[var(--text-dim)]"
+                  class="absolute top-0 flex flex-col items-center text-[var(--color-fg-disabled)]"
                   style=${`left: ${leftPct.toFixed(2)}%; transform: translateX(-50%)`}
                 >
                   <div class="h-1 w-px bg-[var(--white-10)]"></div>
@@ -256,7 +256,7 @@ export function SwimlaneTimeline({
       ` : null}
       ${observations.length > 1 ? html`
         <div class="mt-0.5 flex items-center gap-2" aria-hidden="true">
-          <div class="w-11 shrink-0 text-4xs text-[var(--text-dim)] text-right">obs</div>
+          <div class="w-11 shrink-0 text-4xs text-[var(--color-fg-disabled)] text-right">obs</div>
           <div class="relative flex-1 h-2.5">
             ${observations.map((obs, obsIndex) => {
               const leftPct = ((obs.ts - spanStart) / spanWidth) * 100
@@ -290,7 +290,7 @@ export function SwimlaneTimeline({
           </div>
         </div>
       ` : null}
-      <div class="mt-2 flex flex-wrap items-center gap-2 text-3xs text-[var(--text-dim)]">
+      <div class="mt-2 flex flex-wrap items-center gap-2 text-3xs text-[var(--color-fg-disabled)]">
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[var(--indigo-45)]"></span>active</span>
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[var(--amber-bright-45)]"></span>compact</span>
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[var(--purple-50)]"></span>handoff</span>
@@ -386,7 +386,7 @@ export function TransitionTrail({
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
       <div class="mb-1.5 flex items-center justify-between gap-2">
-        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
           Transition History (${isFiltering ? `${visibleHistory.length}/${history.length}` : history.length})
         </div>
         <input
@@ -395,16 +395,16 @@ export function TransitionTrail({
           placeholder="field / from / to 필터"
           aria-label="전이 이력 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-30 max-w-50 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-30 max-w-50 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && visibleHistory.length === 0
-        ? html`<div class="py-3 text-center text-3xs text-[var(--text-dim)]">필터 결과 없음 (${history.length} items)</div>`
+        ? html`<div class="py-3 text-center text-3xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${history.length} items)</div>`
         : html`
       <div ref=${scrollRef} class="flex flex-col gap-0.5 max-h-30 overflow-y-auto">
         ${visibleHistory.map((entry, trailIndex) => {
           const ago = fmtDuration(Math.max(0, now - entry.ts))
-          const color = FIELD_COLOR[entry.field] ?? 'text-[var(--text-body)]'
+          const color = FIELD_COLOR[entry.field] ?? 'text-[var(--color-fg-primary)]'
           const inSegment = isTransitionInSegment(entry, hoveredSegment)
           const dimmed = hoveredSegment != null && !inSegment
           const rowCls = inSegment
@@ -420,12 +420,12 @@ export function TransitionTrail({
               title=${tooltip}
               class=${`flex items-center gap-2 text-3xs font-mono leading-tight transition-opacity duration-150 cursor-help ${dimmed ? 'opacity-40' : ''} ${rowCls}`}
             >
-              <span class="w-[52px] shrink-0 text-right text-[var(--text-dim)]">${ago} ago</span>
+              <span class="w-[52px] shrink-0 text-right text-[var(--color-fg-disabled)]">${ago} ago</span>
               <span class=${`w-[28px] shrink-0 font-semibold ${color}`}>${entry.field}</span>
-              <span class="text-[var(--text-dim)]">${entry.from}</span>
-              <span class="text-[var(--text-muted)]">→</span>
-              <span class="text-[var(--text-strong)]">${entry.to}</span>
-              ${reason ? html`<span class="ml-1 text-4xs text-[var(--text-dim)] opacity-50">ⓘ</span>` : null}
+              <span class="text-[var(--color-fg-disabled)]">${entry.from}</span>
+              <span class="text-[var(--color-fg-muted)]">→</span>
+              <span class="text-[var(--color-fg-secondary)]">${entry.to}</span>
+              ${reason ? html`<span class="ml-1 text-4xs text-[var(--color-fg-disabled)] opacity-50">ⓘ</span>` : null}
             </div>
           `
         })}
@@ -458,12 +458,12 @@ export function TopTransitionsPanel({
 
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
         Top Transitions (${transitions.length})
       </div>
       <div class="flex flex-col gap-0.5">
         ${transitions.map((entry) => {
-          const color = FIELD_COLOR[entry.field] ?? 'text-[var(--text-body)]'
+          const color = FIELD_COLOR[entry.field] ?? 'text-[var(--color-fg-primary)]'
           const matchesHover =
             hoveredSegment != null && hoveredSegment.field === entry.field
           const dimmed = hoveredSegment != null && !matchesHover
@@ -477,17 +477,17 @@ export function TopTransitionsPanel({
               title=${`${entry.field}: ${entry.from} → ${entry.to} (관측 ${entry.count}회)`}
             >
               <span class=${`w-[28px] shrink-0 font-semibold ${color}`}>${entry.field}</span>
-              <span class="text-[var(--text-dim)]">${displayState(entry.from)}</span>
-              <span class="text-[var(--text-muted)]">→</span>
-              <span class="text-[var(--text-strong)]">${displayState(entry.to)}</span>
+              <span class="text-[var(--color-fg-disabled)]">${displayState(entry.from)}</span>
+              <span class="text-[var(--color-fg-muted)]">→</span>
+              <span class="text-[var(--color-fg-secondary)]">${displayState(entry.to)}</span>
               <span class="ml-auto flex items-center gap-1.5 shrink-0">
                 <span class="h-1 w-12 rounded-sm bg-[var(--white-8)] overflow-hidden">
                   <span
-                    class="block h-full bg-[var(--accent)]"
+                    class="block h-full bg-[var(--color-accent-fg)]"
                     style=${`width: ${widthPct}%`}
                   ></span>
                 </span>
-                <span class="w-[18px] text-right text-[var(--text-dim)]">${entry.count}</span>
+                <span class="w-[18px] text-right text-[var(--color-fg-disabled)]">${entry.count}</span>
               </span>
             </div>
           `
@@ -498,7 +498,7 @@ export function TopTransitionsPanel({
 }
 
 const BAR_COLOR: Record<string, string> = {
-  KSM: 'bg-[var(--accent)]',
+  KSM: 'bg-[var(--color-accent-fg)]',
   KTC: 'bg-[var(--indigo)]',
   KDP: 'bg-[var(--indigo)]',
   KCL: 'bg-[var(--indigo)]',
@@ -522,20 +522,20 @@ export function DwellHistogramPanel({
 
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
         State Dwell Time
       </div>
       <div class="flex flex-col gap-2">
         ${histograms.map((lane) => {
           const matchesHover = hoveredSegment != null && hoveredSegment.field === lane.field
           const dimmed = hoveredSegment != null && !matchesHover
-          const color = FIELD_COLOR[lane.field] ?? 'text-[var(--text-body)]'
-          const barColor = BAR_COLOR[lane.field] ?? 'bg-[var(--accent)]'
+          const color = FIELD_COLOR[lane.field] ?? 'text-[var(--color-fg-primary)]'
+          const barColor = BAR_COLOR[lane.field] ?? 'bg-[var(--color-accent-fg)]'
           return html`
             <div class=${`transition-opacity duration-150 ${dimmed ? 'opacity-40' : ''}`}>
               <div class="flex items-center gap-1.5 mb-0.5">
                 <span class=${`text-3xs font-semibold ${color}`}>${lane.field}</span>
-                <span class="text-3xs text-[var(--text-dim)]">${fmtDuration(lane.totalSeconds)}</span>
+                <span class="text-3xs text-[var(--color-fg-disabled)]">${fmtDuration(lane.totalSeconds)}</span>
               </div>
               <div class="flex flex-col gap-px">
                 ${lane.entries.map((entry) => {
@@ -550,14 +550,14 @@ export function DwellHistogramPanel({
                       class=${`flex items-center gap-1.5 text-3xs font-mono leading-tight ${rowCls}`}
                       title=${`${displayState(entry.value)}: ${fmtDuration(entry.seconds)} (${entry.pct.toFixed(1)}%)`}
                     >
-                      <span class="w-15 shrink-0 text-[var(--text-body)] truncate">${displayState(entry.value)}</span>
+                      <span class="w-15 shrink-0 text-[var(--color-fg-primary)] truncate">${displayState(entry.value)}</span>
                       <span class="flex-1 h-1.5 rounded-sm bg-[var(--white-8)] overflow-hidden">
                         <span
                           class=${`block h-full ${barColor}`}
                           style=${`width: ${Math.max(2, entry.pct)}%`}
                         ></span>
                       </span>
-                      <span class="w-9 shrink-0 text-right text-3xs text-[var(--text-dim)]">${entry.pct.toFixed(0)}%</span>
+                      <span class="w-9 shrink-0 text-right text-3xs text-[var(--color-fg-disabled)]">${entry.pct.toFixed(0)}%</span>
                     </div>
                   `
                 })}

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -162,13 +162,13 @@ function executionReceiptTitle(execution: KeeperCompositeExecution | undefined):
 function executionReceiptClass(execution: KeeperCompositeExecution | undefined): string {
   switch (executionReceiptTone(execution)) {
     case 'ok':
-      return 'border-[var(--ok-20)] text-[var(--ok)] bg-[var(--ok-10)]'
+      return 'border-[var(--ok-20)] text-[var(--color-status-ok)] bg-[var(--ok-10)]'
     case 'bad':
       return 'border-[rgba(248,113,113,0.36)] text-[var(--bad-light)] bg-[rgba(248,113,113,0.08)]'
     case 'warn':
-      return 'border-[var(--warn-20)] text-[var(--warn)] bg-[var(--warn-10)]'
+      return 'border-[var(--warn-20)] text-[var(--color-status-warn)] bg-[var(--warn-10)]'
     case 'muted':
-      return 'border-[var(--white-8)] text-[var(--text-dim)] bg-[var(--white-3)]'
+      return 'border-[var(--white-8)] text-[var(--color-fg-disabled)] bg-[var(--white-3)]'
   }
 }
 
@@ -592,7 +592,7 @@ export function FsmHub(props: FsmHubProps = {}) {
           open=${graphOpen}
           onToggle=${(e: Event) => setGraphOpen((e.target as HTMLDetailsElement).open)}
         >
-          <summary class="cursor-pointer select-none px-4 py-2.5 text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)] hover:text-[var(--text-body)]">
+          <summary class="cursor-pointer select-none px-4 py-2.5 text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)]">
             Compound Graph — 5 sub-FSMs (Cytoscape)
           </summary>
           <div class="px-3 pb-3">
@@ -636,11 +636,11 @@ function ShortcutsOverlay({
         onClick=${(e: MouseEvent) => e.stopPropagation()}
       >
         <div class="flex items-center justify-between mb-3">
-          <div class="text-2xs font-semibold uppercase tracking-2 text-[var(--text-muted)]">
+          <div class="text-2xs font-semibold uppercase tracking-2 text-[var(--color-fg-muted)]">
             키보드 단축키
           </div>
           <button
-            class="text-3xs text-[var(--text-dim)] hover:text-[var(--text-body)] cursor-pointer"
+            class="text-3xs text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)] cursor-pointer"
             onClick=${onClose}
             aria-label="닫기"
           >Esc</button>
@@ -648,10 +648,10 @@ function ShortcutsOverlay({
         <div class="flex flex-col gap-1.5">
           ${rows.map(r => html`
             <div class="flex items-center gap-3 text-2xs">
-              <kbd class="font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-body)] min-w-16 text-center">
+              <kbd class="font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--color-fg-primary)] min-w-16 text-center">
                 ${r.keys}
               </kbd>
-              <span class="text-[var(--text-body)]">${r.desc}</span>
+              <span class="text-[var(--color-fg-primary)]">${r.desc}</span>
             </div>
           `)}
         </div>
@@ -709,8 +709,8 @@ function StatusBar({
     && (now - (snapshot.last_outcome?.ended_at ?? snapshot.ts)) > 300
   const liveBadge = snapshot
     ? snapshot.is_live
-      ? html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono text-[var(--ok)] border-[var(--ok-20)] bg-[var(--ok-10)] animate-pulse">● 실행 중</span>`
-      : html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono ${idleIsLong ? 'text-[var(--text-muted)] border-[var(--warn-20)]' : 'text-[var(--text-dim)] border-white/10'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-4xs opacity-70">· 턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
+      ? html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono text-[var(--color-status-ok)] border-[var(--ok-20)] bg-[var(--ok-10)] animate-pulse">● 실행 중</span>`
+      : html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono ${idleIsLong ? 'text-[var(--color-fg-muted)] border-[var(--warn-20)]' : 'text-[var(--color-fg-disabled)] border-white/10'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-4xs opacity-70">· 턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
     : null
   const receiptLabel = snapshot ? executionReceiptLabel(snapshot.execution) : null
 
@@ -733,13 +733,13 @@ function StatusBar({
     <div class=${`sticky top-0 z-20 rounded border border-[var(--white-8)] bg-[var(--panel-dark-60)] backdrop-blur-sm shadow-[0_4px_12px_rgba(0,0,0,0.25)] ${containerPadding}`}>
       <div class="flex items-center justify-between gap-3 flex-wrap">
         <div class="flex items-center gap-3">
-          <span class="text-3xs font-semibold uppercase tracking-3 text-[var(--text-muted)]">FSM Hub</span>
+          <span class="text-3xs font-semibold uppercase tracking-3 text-[var(--color-fg-muted)]">FSM Hub</span>
           <${Kbd} size="sm" class="hidden md:inline-flex" title="단축키 목록 (?)">?<//>
           <button
             class=${`text-3xs font-mono px-1.5 py-0.5 rounded border cursor-pointer transition-all ${
               refreshFlash
-                ? 'border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)]'
-                : 'border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)] hover:text-[var(--text-body)] hover:border-[var(--accent-30)]'
+                ? 'border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]'
+                : 'border-[var(--white-10)] bg-[var(--white-3)] text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)] hover:border-[var(--accent-30)]'
             }`}
             onClick=${onRefresh}
             aria-label="강제 새로고침"
@@ -748,7 +748,7 @@ function StatusBar({
             ${refreshFlash ? '✓' : '↻'}
           </button>
           <button
-            class="text-3xs font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)] hover:text-[var(--text-body)] hover:border-[var(--accent-30)] cursor-pointer"
+            class="text-3xs font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)] hover:border-[var(--accent-30)] cursor-pointer"
             onClick=${onDensityToggle}
             title=${`현재 밀도: ${density === 'compact' ? '조밀' : '여유'} (단축키 d)`}
             aria-label=${`밀도 토글: 현재 ${density === 'compact' ? '조밀' : '여유'}`}
@@ -767,7 +767,7 @@ function StatusBar({
           ${loading ? html`<${InlineSpinner} size="xs" />` : null}
           ${paused ? html`
             <span
-              class="px-1.5 py-0.5 rounded border text-3xs font-mono text-[var(--text-muted)] border-[var(--white-10)] bg-[var(--white-3)]"
+              class="px-1.5 py-0.5 rounded border text-3xs font-mono text-[var(--color-fg-muted)] border-[var(--white-10)] bg-[var(--white-3)]"
               title="탭이 백그라운드 상태 — 폴링 중지됨. 탭으로 돌아오면 즉시 갱신됩니다."
             >
               ⏸ 일시 중지
@@ -778,7 +778,7 @@ function StatusBar({
               ${fmtDuration(staleSec)} 전 갱신
             </span>
           ` : staleSec > 60 ? html`
-            <span class="text-3xs font-mono text-[var(--warn)]" title="마지막 관측이 1분 이상 경과">
+            <span class="text-3xs font-mono text-[var(--color-status-warn)]" title="마지막 관측이 1분 이상 경과">
               ${fmtDuration(staleSec)} 전 갱신
             </span>
           ` : null}
@@ -791,24 +791,24 @@ function StatusBar({
               placeholder="keeper 이름 필터"
               aria-label="Keeper 이름 필터"
               onInput=${(e: Event) => onKeeperFilterChange((e.target as HTMLInputElement).value)}
-              class="min-w-30 max-w-45 rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-0.5 text-3xs font-mono text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent-30)]"
+              class="min-w-30 max-w-45 rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-0.5 text-3xs font-mono text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--accent-30)]"
             />
           ` : null}
           ${keeperFilterHasNoMatch ? html`
-            <span class="text-3xs font-mono text-[var(--text-dim)]">
+            <span class="text-3xs font-mono text-[var(--color-fg-disabled)]">
               필터 결과 없음 (${keeperNames.length} keepers)
             </span>
           ` : visibleKeeperNames.map((name, i) => {
             const active = name === selected
             const cls = active
-              ? 'bg-[var(--accent-10)] border-[var(--accent-30)] text-[var(--accent)]'
-              : 'bg-[var(--white-3)] border-[var(--white-8)] text-[var(--text-dim)] hover:text-[var(--text-body)] hover:border-[var(--accent-30)]'
+              ? 'bg-[var(--accent-10)] border-[var(--accent-30)] text-[var(--color-accent-fg)]'
+              : 'bg-[var(--white-3)] border-[var(--white-8)] text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)] hover:border-[var(--accent-30)]'
             return html`
               <button
                 role="tab"
                 aria-selected=${active}
                 tabindex=${active ? 0 : -1}
-                class=${`rounded-sm border px-2.5 py-0.5 text-3xs font-mono transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--bg-0)] ${cls}`}
+                class=${`rounded-sm border px-2.5 py-0.5 text-3xs font-mono transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-fg)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--bg-0)] ${cls}`}
                 onClick=${() => onSelect(name)}
                 title=${i < 9 ? `${name} — 단축키 ${i + 1}` : name}
                 onKeyDown=${(e: KeyboardEvent) => {
@@ -838,17 +838,17 @@ function StatusBar({
       ${snapshot ? html`
         <div class="mt-1.5 flex items-center gap-2 text-3xs font-mono flex-wrap">
           ${/* KPI micro-metrics */ ''}
-          <span class="px-1.5 py-0.5 rounded border border-[var(--white-8)] text-[var(--text-body)]">
+          <span class="px-1.5 py-0.5 rounded border border-[var(--white-8)] text-[var(--color-fg-primary)]">
             턴 ${snapshot.last_outcome ? `#${snapshot.last_outcome.turn_id}` : '—'}
           </span>
-          <span class=${`px-1.5 py-0.5 rounded border ${transitionCount > 0 ? 'border-[rgba(129,140,248,0.3)] text-[var(--indigo)]' : 'border-[var(--white-8)] text-[var(--text-dim)]'}`}>
+          <span class=${`px-1.5 py-0.5 rounded border ${transitionCount > 0 ? 'border-[rgba(129,140,248,0.3)] text-[var(--indigo)]' : 'border-[var(--white-8)] text-[var(--color-fg-disabled)]'}`}>
             ${transitionCount} 전환
           </span>
           <span
             class=${`relative px-1.5 py-0.5 rounded border overflow-hidden ${
               observationCount >= MAX_OBSERVATIONS
                 ? 'border-[rgba(245,158,11,0.4)] text-[var(--amber-bright)]'
-                : 'border-[var(--white-8)] text-[var(--text-dim)]'
+                : 'border-[var(--white-8)] text-[var(--color-fg-disabled)]'
             }`}
             title=${`관측 버퍼 ${observationCount}/${MAX_OBSERVATIONS} — 가득 차면 오래된 관측부터 순환 교체됩니다`}
           >
@@ -863,8 +863,8 @@ function StatusBar({
             <span class="relative">${observationCount}/${MAX_OBSERVATIONS} 관측</span>
           </span>
           ${/* Meta IDs */ ''}
-          <span class="text-[var(--text-dim)] opacity-60">corr ${snapshot.correlation_id?.slice(-8) ?? '?'}</span>
-          <span class="text-[var(--text-dim)] opacity-60">run ${snapshot.run_id?.slice(-8) ?? '?'}</span>
+          <span class="text-[var(--color-fg-disabled)] opacity-60">corr ${snapshot.correlation_id?.slice(-8) ?? '?'}</span>
+          <span class="text-[var(--color-fg-disabled)] opacity-60">run ${snapshot.run_id?.slice(-8) ?? '?'}</span>
         </div>
       ` : null}
     </div>
@@ -1002,8 +1002,8 @@ function CollapsibleZone({
         aria-expanded=${!collapsed}
         aria-controls=${`zone-${id}`}
       >
-        <span class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">${zoneTitle}</span>
-        <span class=${`text-3xs text-[var(--text-dim)] transition-transform duration-200 ${collapsed ? '' : 'rotate-180'}`}>▾</span>
+        <span class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">${zoneTitle}</span>
+        <span class=${`text-3xs text-[var(--color-fg-disabled)] transition-transform duration-200 ${collapsed ? '' : 'rotate-180'}`}>▾</span>
       </button>
       ${!collapsed ? html`<div id=${`zone-${id}`} class="px-4 pb-3">${children}</div>` : null}
     </div>

--- a/dashboard/src/components/goals/goal-helpers.test.ts
+++ b/dashboard/src/components/goals/goal-helpers.test.ts
@@ -70,7 +70,7 @@ describe('horizonLabel', () => {
 
 describe('horizonColor', () => {
   it('returns green for short', () => {
-    expect(horizonColor('short')).toBe('var(--ok)')
+    expect(horizonColor('short')).toBe('var(--color-status-ok)')
   })
 
   it('returns amber for mid', () => {

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -102,7 +102,7 @@ export function horizonLabel(h: string): string {
 
 export function horizonColor(h: string): string {
   switch (h) {
-    case 'short': return 'var(--ok)'
+    case 'short': return 'var(--color-status-ok)'
     case 'mid': return 'var(--amber-bright)'
     case 'long': return 'var(--indigo)'
     default: return '#888'

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -321,10 +321,10 @@ async function refreshGoalDetail(goalId: string) {
 function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' }) {
   const clamped = Math.max(0, Math.min(100, pct))
   const barColor =
-    clamped >= 80 ? 'var(--ok)'
+    clamped >= 80 ? 'var(--color-status-ok)'
     : clamped >= 50 ? 'var(--amber-bright)'
     : clamped >= 20 ? '#fb923c'
-    : 'var(--bad)'
+    : 'var(--color-status-err)'
 
   const h = size === 'sm' ? 'h-1.5' : 'h-2.5'
   return html`

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -41,8 +41,8 @@ export function resetTaskBacklogState() {
 
 function priorityToneClass(priority: number): string {
   switch (priority) {
-    case 1: return 'border-l-[var(--rose-light)] bg-[var(--bad)]/10 text-[#fecdd3]'
-    case 2: return 'border-l-[var(--warn)] bg-[var(--warn)]/10 text-[var(--yellow-100)]'
+    case 1: return 'border-l-[var(--rose-light)] bg-[var(--color-status-err)]/10 text-[#fecdd3]'
+    case 2: return 'border-l-[var(--color-status-warn)] bg-[var(--color-status-warn)]/10 text-[var(--yellow-100)]'
     case 3: return 'border-l-[var(--blue-400)] bg-[var(--blue-400)]/10 text-[#bfdbfe]'
     default: return 'border-l-[rgba(148,163,184,0.45)] bg-white/5 text-text-muted'
   }

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -163,7 +163,7 @@ export function TaskActivityList({
             type="button"
             class="px-2 py-1 rounded text-2xs font-medium border cursor-pointer transition-colors ${
               filter === chip.key
-                ? 'border-accent/40 bg-accent/12 text-[var(--accent)]'
+                ? 'border-accent/40 bg-accent/12 text-[var(--color-accent-fg)]'
                 : 'border-[var(--white-10)] bg-[var(--white-4)] text-text-muted hover:bg-[var(--white-8)]'
             }"
             onClick=${() => { activeFilter.value = chip.key }}

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -81,7 +81,7 @@ function TaskEventsSection() {
           onInput=${(e: Event) => { taskEventsSearchQuery.value = (e.target as HTMLInputElement).value }}
           class="min-w-45 flex-1 !py-1 !text-2xs"
         />
-        <span class="text-3xs text-[var(--text-muted)] tabular-nums">
+        <span class="text-3xs text-[var(--color-fg-muted)] tabular-nums">
           ${trimmed
             ? `${visible.length} / ${events.length}`
             : `${events.length}개`}
@@ -369,9 +369,9 @@ function GoalRelationSection({ goalIds }: { goalIds: string[] }) {
             placeholder="목표 검색 (title/status/metric)"
             aria-label="목표 검색"
             onInput=${(e: Event) => { goalRelationSearchQuery.value = (e.target as HTMLInputElement).value }}
-            class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
           />
-          <span class="text-3xs text-[var(--text-muted)] tabular-nums">
+          <span class="text-3xs text-[var(--color-fg-muted)] tabular-nums">
             ${isFiltering
               ? `${visibleIds.length} / ${goalIds.length}`
               : `${goalIds.length}개`}
@@ -379,7 +379,7 @@ function GoalRelationSection({ goalIds }: { goalIds: string[] }) {
         ` : null}
       </div>
       ${isFiltering && visibleIds.length === 0
-        ? html`<div class="py-3 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${goalIds.length} goals)</div>`
+        ? html`<div class="py-3 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${goalIds.length} goals)</div>`
         : html`
       <div class="flex flex-col gap-1">
         ${visibleIds.map(id => {
@@ -416,10 +416,10 @@ export function TaskDetailOverlay() {
       onClose=${closeTaskDetail}
       initialFocusRef=${closeButtonRef}
       overlayClass="fixed inset-0 z-[60] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-200"
-      panelClass="w-full max-w-[900px] max-h-[90vh] overflow-y-auto bg-[#0d1526] rounded border border-[var(--card-border)] shadow-[0_24px_64px_var(--black-50)]"
+      panelClass="w-full max-w-[900px] max-h-[90vh] overflow-y-auto bg-[#0d1526] rounded border border-[var(--color-border-default)] shadow-[0_24px_64px_var(--black-50)]"
     >
       ${'' /* Sticky Header */}
-      <div class="sticky top-0 z-10 flex items-center justify-between gap-4 px-6 py-4 border-b border-[var(--card-border)] bg-[rgba(13,21,38,0.97)] backdrop-blur-sm rounded-t-2xl">
+      <div class="sticky top-0 z-10 flex items-center justify-between gap-4 px-6 py-4 border-b border-[var(--color-border-default)] bg-[rgba(13,21,38,0.97)] backdrop-blur-sm rounded-t-2xl">
         <div class="flex-1 min-w-0">
           <h2 id=${titleId} class="text-lg font-semibold text-text-strong break-words">${task.title}</h2>
           <div class="mt-1.5 flex flex-wrap items-center gap-2">
@@ -446,7 +446,7 @@ export function TaskDetailOverlay() {
               type="button"
               class="px-3 py-1.5 rounded text-xs font-medium border cursor-pointer transition-colors ${
                 activeTab.value === tab
-                  ? 'border-accent/40 bg-accent/12 text-[var(--accent)]'
+                  ? 'border-accent/40 bg-accent/12 text-[var(--color-accent-fg)]'
                   : 'border-transparent text-text-muted hover:bg-[var(--white-8)]'
               }"
               onClick=${() => tab === 'activity' ? switchToActivityTab(task) : (activeTab.value = 'overview')}
@@ -483,7 +483,7 @@ export function TaskDetailOverlay() {
           </div>
 
           ${'' /* Metadata */}
-          <div class="flex flex-wrap items-center gap-3 text-2xs text-text-dim border-t border-[var(--card-border)] pt-4">
+          <div class="flex flex-wrap items-center gap-3 text-2xs text-text-dim border-t border-[var(--color-border-default)] pt-4">
             ${task.created_at ? html`<span>생성: <${TimeAgo} timestamp=${task.created_at} /></span>` : null}
             <span class="font-mono">${task.id}</span>
           </div>

--- a/dashboard/src/components/governance-monitor.ts
+++ b/dashboard/src/components/governance-monitor.ts
@@ -133,7 +133,7 @@ export function GovernanceMonitor() {
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <select
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)]"
           value=${String(windowMinutes.value)}
           onChange=${(e: Event) => { windowMinutes.value = Number((e.target as HTMLSelectElement).value) }}
         >
@@ -143,11 +143,11 @@ export function GovernanceMonitor() {
           <option value="720">12h</option>
         </select>
         <button
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
           onClick=${() => void load()}
         >새로고침</button>
-        <span class="text-xs text-[var(--text-muted)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
-        ${current.loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
+        <span class="text-xs text-[var(--color-fg-muted)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
+        ${current.loading ? html`<span class="text-xs text-[var(--color-fg-muted)]">로딩 중...</span>` : null}
       </div>
 
       ${current.error ? html`<${ErrorState} message=${current.error} />` : null}
@@ -193,17 +193,17 @@ export function GovernanceMonitor() {
             placeholder="tool / reason 필터"
             aria-label="Tool rejection 필터"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-40 max-w-60 rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-60 rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] placeholder:text-[var(--color-fg-muted)] focus:outline-none focus:border-[var(--color-accent-fg)]"
           />
           ${allRejections.length === 0
             ? html`<${EmptyState} message="선택한 시간 범위에 tool rejection이 없습니다." compact />`
             : isFiltering && visibleRejections.length === 0
-              ? html`<div class="py-4 text-center text-2xs text-[var(--text-muted)]">필터 결과 없음 (${allRejections.length} items)</div>`
+              ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-muted)]">필터 결과 없음 (${allRejections.length} items)</div>`
               : html`
                 <div class="overflow-x-auto">
                   <table class="w-full text-xs">
                     <thead>
-                      <tr class="text-left text-[var(--text-muted)] border-b border-[var(--card-border)]">
+                      <tr class="text-left text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
                         <th class="py-1.5 pr-4 font-medium">도구</th>
                         <th class="py-1.5 pr-4 font-medium">사유</th>
                         <th class="py-1.5 font-medium text-right">횟수</th>
@@ -211,12 +211,12 @@ export function GovernanceMonitor() {
                     </thead>
                     <tbody>
                       ${visibleRejections.map(r => html`
-                        <tr class="border-b border-[var(--card-border)]/30 text-[var(--text-body)]">
+                        <tr class="border-b border-[var(--color-border-default)]/30 text-[var(--color-fg-primary)]">
                           <td class="py-1.5 pr-4 font-mono text-2xs">${r.tool}</td>
                           <td class="py-1.5 pr-4">
-                            <span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs bg-[var(--bg-panel-hover)]">${r.reason}</span>
+                            <span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs bg-[var(--color-bg-hover)]">${r.reason}</span>
                           </td>
-                          <td class="py-1.5 text-right font-medium text-[var(--text-strong)]">${r.count}</td>
+                          <td class="py-1.5 text-right font-medium text-[var(--color-fg-secondary)]">${r.count}</td>
                         </tr>
                       `)}
                     </tbody>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -216,7 +216,7 @@ function JudgmentsSection() {
     const meta = [judge?.keeper_name, judge?.model_used].filter((value): value is string => typeof value === 'string' && value.length > 0).join(' · ')
     const chipClass = tone === 'warn'
       ? 'border-warn/30 bg-warn/10 text-warn'
-      : 'border-[var(--card-border)] bg-[var(--white-3)] text-text-muted'
+      : 'border-[var(--color-border-default)] bg-[var(--white-3)] text-text-muted'
     return html`
       <div data-testid="live-judge-empty">
         <${Card} title=${title} class="section mb-5" variant="compact">
@@ -498,7 +498,7 @@ function KeeperApprovalQueueSection() {
             aria-label="Keeper HITL 승인 필터"
             data-testid="keeper-hitl-approval-filter"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-40 max-w-70 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-70 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
           />
         </div>
       ` : null}
@@ -506,7 +506,7 @@ function KeeperApprovalQueueSection() {
         ? html`<${KeeperApprovalEmptyState} />`
         : isFiltering && visibleItems.length === 0
           ? html`
-              <div class="py-4 text-center text-2xs text-[var(--text-dim)]" data-testid="keeper-hitl-approval-empty-filter">
+              <div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]" data-testid="keeper-hitl-approval-empty-filter">
                 필터 결과 없음 (${items.length} items)
               </div>
             `

--- a/dashboard/src/components/harness-health-sections.test.ts
+++ b/dashboard/src/components/harness-health-sections.test.ts
@@ -326,19 +326,19 @@ describe('emptyReasonText', () => {
 
 describe('verdictTone', () => {
   it('returns ok for approve', () => {
-    expect(verdictTone('approve')).toBe('bg-[var(--ok)]')
+    expect(verdictTone('approve')).toBe('bg-[var(--color-status-ok)]')
   })
 
   it('returns ok for approve:conditional', () => {
-    expect(verdictTone('approve:conditional')).toBe('bg-[var(--ok)]')
+    expect(verdictTone('approve:conditional')).toBe('bg-[var(--color-status-ok)]')
   })
 
   it('returns bad for reject', () => {
-    expect(verdictTone('reject')).toBe('bg-[var(--bad)]')
+    expect(verdictTone('reject')).toBe('bg-[var(--color-status-err)]')
   })
 
   it('returns bad for reject:vague notes', () => {
-    expect(verdictTone('reject:vague notes')).toBe('bg-[var(--bad)]')
+    expect(verdictTone('reject:vague notes')).toBe('bg-[var(--color-status-err)]')
   })
 })
 

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -114,14 +114,14 @@ export function railStatusLabel(status: RailStatus): string {
 export function statusChipClass(status: RailStatus): string {
   switch (status) {
     case 'healthy':
-      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--ok)]'
+      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--color-status-ok)]'
     case 'warning':
-      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--warn)]'
+      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--color-status-warn)]'
     case 'stale':
-      return 'border-[var(--white-12)] bg-[var(--white-4)] text-[var(--text-muted)]'
+      return 'border-[var(--white-12)] bg-[var(--white-4)] text-[var(--color-fg-muted)]'
     case 'idle':
     default:
-      return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--text-dim)]'
+      return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--color-fg-disabled)]'
   }
 }
 
@@ -160,8 +160,8 @@ export function emptyReasonText(reason?: string | null): string {
 
 export function verdictTone(verdict: string): string {
   return verdict.startsWith('approve')
-    ? 'bg-[var(--ok)]'
-    : 'bg-[var(--bad)]'
+    ? 'bg-[var(--color-status-ok)]'
+    : 'bg-[var(--color-status-err)]'
 }
 
 export function verdictSummary(verdict: string): string {
@@ -235,7 +235,7 @@ export { StatCard } from './common/stat-card'
 
 export function EmptySignal({ text }: { text: string }) {
   return html`
-    <div class="rounded border border-dashed border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm text-[var(--text-dim)]">
+    <div class="rounded border border-dashed border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm text-[var(--color-fg-disabled)]">
       ${text}
     </div>
   `
@@ -251,14 +251,14 @@ export function GateChart({ distribution }: { distribution: GateDistribution }) 
     <div class="space-y-2">
       ${entries.map(([gate, count]) => html`
         <div class="flex items-center gap-2">
-          <span class="w-20 text-right font-mono text-xs text-[var(--text-muted)]">${gate}</span>
+          <span class="w-20 text-right font-mono text-xs text-[var(--color-fg-muted)]">${gate}</span>
           <div class="h-4 flex-1 overflow-hidden rounded bg-[var(--white-6)]">
             <div
               class="h-full rounded opacity-80 transition-all"
-              style=${{ width: `${(count / max) * 100}%`, background: 'var(--accent)' }}
+              style=${{ width: `${(count / max) * 100}%`, background: 'var(--color-accent-fg)' }}
             />
           </div>
-          <span class="w-8 text-right text-xs text-[var(--text-body)]">${count}</span>
+          <span class="w-8 text-right text-xs text-[var(--color-fg-primary)]">${count}</span>
         </div>
       `)}
     </div>
@@ -279,11 +279,11 @@ export function HeroRailCard({
   return html`
     <div class=${`rounded border p-3 ${statusCardClass(status)}`}>
       <div class="flex items-start justify-between gap-3">
-        <div class="text-sm font-medium text-[var(--text-strong)]">${label}</div>
+        <div class="text-sm font-medium text-[var(--color-fg-secondary)]">${label}</div>
         <${StatusPill} status=${status} />
       </div>
-      <div class="mt-3 text-lg font-semibold text-[var(--text-body)]">${detail}</div>
-      <div class="mt-1 text-xs text-[var(--text-dim)]">최근 신호 ${freshness}</div>
+      <div class="mt-3 text-lg font-semibold text-[var(--color-fg-primary)]">${detail}</div>
+      <div class="mt-1 text-xs text-[var(--color-fg-disabled)]">최근 신호 ${freshness}</div>
     </div>
   `
 }
@@ -296,15 +296,15 @@ export function ScopePairing() {
           <div class="flex items-center justify-between gap-3">
             <div>
               <${SectionCap}>실험 루프<//>
-              <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">오토리서치가 답하는 것</div>
+              <div class="mt-1 text-sm font-medium text-[var(--color-fg-secondary)]">오토리서치가 답하는 것</div>
             </div>
             <button
               type="button"
-              class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
+              class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--color-fg-primary)]"
               onClick=${() => navigate('lab', { section: 'autoresearch' })}
             >오토리서치 열기</button>
           </div>
-          <div class="text-sm leading-loose text-[var(--text-body)]">
+          <div class="text-sm leading-loose text-[var(--color-fg-primary)]">
             어떤 파일을 어떻게 바꿔 어떤 metric을 밀어 올리려는지, 그리고 cycle별 keep/discard가 어땠는지 봅니다.
           </div>
         </div>
@@ -313,8 +313,8 @@ export function ScopePairing() {
       <${SurfaceCard} variant="compact">
         <div class="flex flex-col gap-2">
           <${SectionCap}>안전 감시<//>
-          <div class="text-sm font-medium text-[var(--text-strong)]">하네스가 답하는 것</div>
-          <div class="text-sm leading-loose text-[var(--text-body)]">
+          <div class="text-sm font-medium text-[var(--color-fg-secondary)]">하네스가 답하는 것</div>
+          <div class="text-sm leading-loose text-[var(--color-fg-primary)]">
             평가 모델이 건강한지, 장기 실행 중 압축이 정상인지, 세대 교체가 안전한지 봅니다.
           </div>
         </div>
@@ -338,12 +338,12 @@ export function RailHeader({
     <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
       <div>
         <div class="flex items-center gap-2">
-          <div class="text-sm font-medium text-[var(--text-strong)]">${title}</div>
+          <div class="text-sm font-medium text-[var(--color-fg-secondary)]">${title}</div>
           <${StatusPill} status=${status} />
         </div>
-        <div class="mt-1 text-sm leading-loose text-[var(--text-muted)]">${description}</div>
+        <div class="mt-1 text-sm leading-loose text-[var(--color-fg-muted)]">${description}</div>
       </div>
-      <div class="text-xs text-[var(--text-dim)]">최근 신호 ${freshnessLabel(lastEventAt)}</div>
+      <div class="text-xs text-[var(--color-fg-disabled)]">최근 신호 ${freshnessLabel(lastEventAt)}</div>
     </div>
   `
 }
@@ -371,25 +371,25 @@ export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
           placeholder="task / agent / gate / cascade 필터"
           aria-label="판정 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0
-        ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${items.length} items)</div>`
+        ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${items.length} items)</div>`
         : visibleItems.map(item => html`
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
             <div class="flex items-start justify-between gap-3">
               <div>
-                <div class="text-sm font-medium text-[var(--text-strong)]">${item.task_title || item.task_id}</div>
-                <div class="mt-1 text-xs text-[var(--text-muted)]">
+                <div class="text-sm font-medium text-[var(--color-fg-secondary)]">${item.task_title || item.task_id}</div>
+                <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
                   ${item.agent_name || 'agent'} · ${item.gate || 'gate'} · ${item.evaluator_cascade || 'cascade'} · ${formatTimestamp(item.timestamp)}
                 </div>
               </div>
               <${StatusDot} size="md" class=${verdictTone(item.verdict)} />
             </div>
-            <div class="mt-2 text-sm text-[var(--text-body)]">${verdictSummary(item.verdict)}</div>
+            <div class="mt-2 text-sm text-[var(--color-fg-primary)]">${verdictSummary(item.verdict)}</div>
             ${item.fallback_reason ? html`
-              <div class="mt-2 break-all text-xs text-[var(--warn)]">${item.fallback_reason}</div>
+              <div class="mt-2 break-all text-xs text-[var(--color-status-warn)]">${item.fallback_reason}</div>
             ` : null}
           </div>
         `)}
@@ -418,28 +418,28 @@ export function PreCompactList({ section }: { section: HarnessSignalSection<PreC
           placeholder="keeper / trigger / model / strategy 필터"
           aria-label="압축 이벤트 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0
-        ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
+        ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
         : visibleItems.map(item => html`
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
             <div class="flex items-start justify-between gap-3">
-              <div class="text-sm font-medium text-[var(--text-strong)]">${item.keeper_name}</div>
-              <div class="text-xs text-[var(--text-muted)]">${formatTimestamp(item.timestamp)}</div>
+              <div class="text-sm font-medium text-[var(--color-fg-secondary)]">${item.keeper_name}</div>
+              <div class="text-xs text-[var(--color-fg-muted)]">${formatTimestamp(item.timestamp)}</div>
             </div>
-            <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--text-body)]">
+            <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--color-fg-primary)]">
               <span>컨텍스트 ${Math.round(item.context_ratio * 100)}%</span>
               <span>메시지 ${item.message_count}건</span>
               <span>토큰 ${item.token_count.toLocaleString()}</span>
               <span>${item.model_family || '모델 미확인'}</span>
             </div>
-            <div class="mt-2 text-xs text-[var(--text-muted)]">${item.trigger}</div>
+            <div class="mt-2 text-xs text-[var(--color-fg-muted)]">${item.trigger}</div>
             ${item.strategies.length > 0 ? html`
               <div class="mt-2 flex flex-wrap gap-1">
                 ${item.strategies.map(strategy => html`
-                  <span class="rounded-sm border border-[var(--white-8)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">${strategy}</span>
+                  <span class="rounded-sm border border-[var(--white-8)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">${strategy}</span>
                 `)}
               </div>
             ` : null}
@@ -470,18 +470,18 @@ export function HandoffList({ section }: { section: HarnessSignalSection<Handoff
           placeholder="keeper / model / trace_id 필터"
           aria-label="세대 교체 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0
-        ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
+        ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
         : visibleItems.map(item => html`
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
             <div class="flex items-start justify-between gap-3">
-              <div class="text-sm font-medium text-[var(--text-strong)]">${item.keeper_name}</div>
-              <div class="text-xs text-[var(--text-muted)]">${formatTimestamp(item.timestamp)}</div>
+              <div class="text-sm font-medium text-[var(--color-fg-secondary)]">${item.keeper_name}</div>
+              <div class="text-xs text-[var(--color-fg-muted)]">${formatTimestamp(item.timestamp)}</div>
             </div>
-            <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--text-body)]">
+            <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--color-fg-primary)]">
               <span>${item.generation}세대</span>
               <span>다음 ${item.next_generation ?? '-'}세대</span>
               <span class="inline-flex items-center gap-1">
@@ -491,7 +491,7 @@ export function HandoffList({ section }: { section: HarnessSignalSection<Handoff
               <span>${item.to_model ?? '모델 미확인'}</span>
             </div>
             ${item.prev_trace_id ? html`
-              <div class="mt-2 text-xs text-[var(--text-muted)]">이전 ${item.prev_trace_id.slice(0, 8)} → 새 ${item.new_trace_id?.slice(0, 8) ?? '-'}</div>
+              <div class="mt-2 text-xs text-[var(--color-fg-muted)]">이전 ${item.prev_trace_id.slice(0, 8)} → 새 ${item.new_trace_id?.slice(0, 8) ?? '-'}</div>
             ` : null}
           </div>
         `)}

--- a/dashboard/src/components/harness-health.test.ts
+++ b/dashboard/src/components/harness-health.test.ts
@@ -254,7 +254,7 @@ describe('HarnessHealth', () => {
     expect(mermaidSource(container)).toContain('debounced reload')
 
     const markup = container.innerHTML
-    expect(markup).toContain('text-[var(--accent)]')
+    expect(markup).toContain('text-[var(--color-accent-fg)]')
     expect(markup).toContain('bg-[var(--ok-12)]')
     expect(markup).not.toContain('bg-slate-800')
     expect(markup).not.toContain('bg-slate-700')

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -137,8 +137,8 @@ export function buildHarnessFlowMermaid(data: HarnessHealthData): string {
     'flowchart LR',
     '  classDef source fill:var(--panel-dark),stroke:var(--slate-600),color:#cbd5e1;',
     '  classDef hub fill:#111827,stroke:var(--sky-400),color:#e0f2fe;',
-    '  classDef healthyRail fill:#082f1d,stroke:var(--ok),color:#dcfce7;',
-    '  classDef warningRail fill:#3b2a07,stroke:var(--warn),color:var(--yellow-100);',
+    '  classDef healthyRail fill:#082f1d,stroke:var(--color-status-ok),color:#dcfce7;',
+    '  classDef warningRail fill:#3b2a07,stroke:var(--color-status-warn),color:var(--yellow-100);',
     '  classDef staleRail fill:#1f2937,stroke:var(--slate-400),color:var(--frost-100),stroke-dasharray: 5 3;',
     '  classDef idleRail fill:#111827,stroke:var(--slate-600),color:var(--slate-400),stroke-dasharray: 3 4;',
     '  classDef activeRail stroke:#7dd3fc,stroke-width:3px;',
@@ -179,20 +179,20 @@ function HarnessFlowCard({ data }: { data: HarnessHealthData }) {
     <div class="space-y-3">
       <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
         <div>
-          <div class="text-sm font-medium text-[var(--text-strong)]">실시간 상태 그래프</div>
-          <div class="mt-1 text-sm leading-loose text-[var(--text-muted)]">
+          <div class="text-sm font-medium text-[var(--color-fg-secondary)]">실시간 상태 그래프</div>
+          <div class="mt-1 text-sm leading-loose text-[var(--color-fg-muted)]">
             작업 완료, 컨텍스트 압축, 세대 교체 신호가 하네스로 모이는 구조입니다.
           </div>
         </div>
-        <div class="text-xs text-[var(--text-dim)]">
+        <div class="text-xs text-[var(--color-fg-disabled)]">
           가장 최근 채널: ${active ? railTitle(active) : '없음'}
         </div>
       </div>
 
-      <div class="flex flex-wrap gap-2 text-2xs text-[var(--text-dim)]">
+      <div class="flex flex-wrap gap-2 text-2xs text-[var(--color-fg-disabled)]">
         <span class="rounded-sm border border-[var(--white-8)] px-2 py-1">실선: 실시간 신호</span>
         <span class="rounded-sm border border-[var(--white-8)] px-2 py-1">점선: 스냅샷 갱신</span>
-        <span class="rounded-sm border border-[var(--accent)] px-2 py-1 text-[var(--text-body)]">강조: 가장 최근 채널</span>
+        <span class="rounded-sm border border-[var(--color-accent-fg)] px-2 py-1 text-[var(--color-fg-primary)]">강조: 가장 최근 채널</span>
       </div>
 
       <${MermaidGraph}
@@ -236,9 +236,9 @@ export function HarnessHealth() {
   let overviewContent = html`<${EmptySignal} text="안전 감시 데이터가 없습니다." />`
 
   if (isLoading) {
-    overviewContent = html`<div class="text-sm text-[var(--text-dim)]">로딩 중...</div>`
+    overviewContent = html`<div class="text-sm text-[var(--color-fg-disabled)]">로딩 중...</div>`
   } else if (isError) {
-    overviewContent = html`<div class="text-sm text-[var(--bad)]">${s.message}</div>`
+    overviewContent = html`<div class="text-sm text-[var(--color-status-err)]">${s.message}</div>`
   } else if (data) {
     overviewContent = html`
       <div class="space-y-4">
@@ -246,18 +246,18 @@ export function HarnessHealth() {
           <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
             <div class="max-w-3xl">
               <${SectionCap}>keeper 장기 실행 중 평가/압축/교체가 정상인지 감시합니다<//>
-              <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">${heroTitle(data)}</div>
-              <div class="mt-2 text-sm leading-airy text-[var(--text-body)]">${heroBody(data)}</div>
+              <div class="mt-2 text-2xl font-semibold text-[var(--color-fg-secondary)]">${heroTitle(data)}</div>
+              <div class="mt-2 text-sm leading-airy text-[var(--color-fg-primary)]">${heroBody(data)}</div>
             </div>
             <div class="flex items-center gap-2">
               <button
                 type="button"
-                class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--text-body)]"
+                class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-accent-fg)] hover:text-[var(--color-fg-primary)]"
                 onClick=${() => { void loadHarnessHealth() }}
               >새로고침</button>
               <button
                 type="button"
-                class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
+                class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--color-fg-primary)]"
                 onClick=${() => navigate('lab', { section: 'autoresearch' })}
               >오토리서치 보기</button>
             </div>
@@ -284,12 +284,12 @@ export function HarnessHealth() {
             />
           </div>
 
-          <div class="mt-4 text-xs text-[var(--text-dim)]">
+          <div class="mt-4 text-xs text-[var(--color-fg-disabled)]">
             generated ${formatTimestamp(data.generated_at)} · 마지막 안전 신호 ${freshnessLabel(data.overview.last_signal_at)}
           </div>
         </div>
 
-        <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] px-4 py-3 text-sm leading-airy text-[var(--text-body)]">
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] px-4 py-3 text-sm leading-airy text-[var(--color-fg-primary)]">
           ${data.scope_note}
         </div>
 
@@ -326,17 +326,17 @@ export function HarnessHealth() {
 
             ${fallbackPct > 80 ? html`
               <div class="rounded border border-[var(--warn-30)] bg-[var(--warn-12)] px-4 py-3">
-                <div class="mb-1 text-sm font-medium text-[var(--warn)]">평가 모델 미연결</div>
-                <div class="text-xs text-[var(--warn)]">
+                <div class="mb-1 text-sm font-medium text-[var(--color-status-warn)]">평가 모델 미연결</div>
+                <div class="text-xs text-[var(--color-status-warn)]">
                   전체 ${cal.total_verdicts}건 중 ${fallbackCount}건이 대체 처리됐습니다.
                   지금은 평가 모델보다 기본 규칙이 더 많이 작동합니다.
                 </div>
                 ${fallbackReasons.length > 0 ? html`
                   <details class="mt-2">
-                    <summary class="cursor-pointer text-xs text-[var(--warn)] opacity-70">최근 에러 (${fallbackReasons.length}건)</summary>
+                    <summary class="cursor-pointer text-xs text-[var(--color-status-warn)] opacity-70">최근 에러 (${fallbackReasons.length}건)</summary>
                     <div class="mt-1 space-y-1">
                       ${fallbackReasons.map(reason => html`
-                        <div class="break-all font-mono text-xs text-[var(--warn)] opacity-70">${reason}</div>
+                        <div class="break-all font-mono text-xs text-[var(--color-status-warn)] opacity-70">${reason}</div>
                       `)}
                     </div>
                   </details>
@@ -355,17 +355,17 @@ export function HarnessHealth() {
               />
             </div>
 
-            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-3 text-xs leading-loose text-[var(--text-muted)]">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-3 text-xs leading-loose text-[var(--color-fg-muted)]">
               인간 라벨 ${cal.labeled_count}건이 calibration ground truth입니다. 값이 0이면 runtime health는 볼 수 있어도 evaluator accuracy는 아직 검증되지 않았습니다.
             </div>
 
             <div>
-              <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">게이트 분포</div>
+              <div class="mb-2 text-xs uppercase tracking-wider text-[var(--color-fg-disabled)]">게이트 분포</div>
               <${GateChart} distribution=${cal.gate_distribution} />
             </div>
 
             <div>
-              <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">최근 판정</div>
+              <div class="mb-2 text-xs uppercase tracking-wider text-[var(--color-fg-disabled)]">최근 판정</div>
               <${RecentVerdictsList} items=${data.recent_verdicts} />
             </div>
           </div>

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -452,8 +452,8 @@ function MetricChip({
 }) {
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
-      <div class="text-3xs uppercase tracking-3 text-[var(--text-dim)]">${label}</div>
-      <div class="mt-1 flex items-center gap-2 text-sm font-semibold text-[var(--text-strong)]">
+      <div class="text-3xs uppercase tracking-3 text-[var(--color-fg-disabled)]">${label}</div>
+      <div class="mt-1 flex items-center gap-2 text-sm font-semibold text-[var(--color-fg-secondary)]">
         <${StatusChip} tone=${tone} uppercase=${false}>${value}<//>
       </div>
     </div>
@@ -468,9 +468,9 @@ function JourneyTile({
   children: preact.ComponentChildren
 }) {
   return html`
-    <section class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-4 flex flex-col gap-3 min-h-[150px]">
-      <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-dim)]">${label}</div>
-      <div class="flex flex-col gap-2 text-sm text-[var(--text-body)]">
+    <section class="rounded-xl border border-[var(--color-border-default)] bg-[var(--white-3)] p-4 flex flex-col gap-3 min-h-[150px]">
+      <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-disabled)]">${label}</div>
+      <div class="flex flex-col gap-2 text-sm text-[var(--color-fg-primary)]">
         ${children}
       </div>
     </section>
@@ -478,7 +478,7 @@ function JourneyTile({
 }
 
 function TileHint({ text }: { text: string }) {
-  return html`<div class="text-xs leading-relaxed text-[var(--text-muted)]">${text}</div>`
+  return html`<div class="text-xs leading-relaxed text-[var(--color-fg-muted)]">${text}</div>`
 }
 
 function JourneyCard({ record }: { record: JourneyRecord }) {
@@ -501,7 +501,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
       <div class="flex flex-wrap items-start justify-between gap-4">
         <div class="min-w-0 flex-1">
           <div class="flex flex-wrap items-center gap-2">
-            <h3 class="m-0 text-xl font-semibold text-[var(--text-strong)]">${record.title}</h3>
+            <h3 class="m-0 text-xl font-semibold text-[var(--color-fg-secondary)]">${record.title}</h3>
             ${task?.status
               ? html`<${StatusBadge} status=${task.status} />`
               : keeper?.status
@@ -512,7 +512,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
             <//>
           </div>
           ${record.subtitle
-            ? html`<div class="mt-1 text-sm leading-relaxed text-[var(--text-muted)]">${record.subtitle}</div>`
+            ? html`<div class="mt-1 text-sm leading-relaxed text-[var(--color-fg-muted)]">${record.subtitle}</div>`
             : null}
         </div>
 
@@ -520,7 +520,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
           <${RouteLink}
             tab="workspace"
             params=${{ section: 'planning' }}
-            class="inline-flex items-center rounded-full border border-[var(--white-10)] bg-[var(--white-5)] px-3 py-1.5 text-xs text-[var(--text-body)] hover:bg-[var(--white-8)]"
+            class="inline-flex items-center rounded-full border border-[var(--white-10)] bg-[var(--white-5)] px-3 py-1.5 text-xs text-[var(--color-fg-primary)] hover:bg-[var(--white-8)]"
           >
             작업 보기
           <//>
@@ -534,7 +534,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                     ...(record.sessionId ? { session_id: record.sessionId } : {}),
                     ...(record.operationId ? { operation_id: record.operationId } : {}),
                   }}
-                  class="inline-flex items-center rounded-full border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-1.5 text-xs text-[var(--accent)] hover:bg-[var(--accent-20)]"
+                  class="inline-flex items-center rounded-full border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-1.5 text-xs text-[var(--color-accent-fg)] hover:bg-[var(--accent-20)]"
                 >
                   실행 로그
                 <//>
@@ -545,7 +545,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                 <${RouteLink}
                   tab="monitoring"
                   params=${{ section: 'agents', agent: searchKeeperName }}
-                  class="inline-flex items-center rounded-full border border-[var(--ok-20)] bg-[var(--ok-10)] px-3 py-1.5 text-xs text-[var(--ok)] hover:bg-[var(--ok-20)]"
+                  class="inline-flex items-center rounded-full border border-[var(--ok-20)] bg-[var(--ok-10)] px-3 py-1.5 text-xs text-[var(--color-status-ok)] hover:bg-[var(--ok-20)]"
                 >
                   키퍼 보기
                 <//>
@@ -559,12 +559,12 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
           <${JourneyTile} label="작업">
             ${task
               ? html`
-                  <div class="font-mono text-xs text-[var(--text-strong)]">${task.id}</div>
+                  <div class="font-mono text-xs text-[var(--color-fg-secondary)]">${task.id}</div>
                   ${task.assignee
-                    ? html`<div>담당: <strong class="text-[var(--text-strong)]">${task.assignee}</strong></div>`
+                    ? html`<div>담당: <strong class="text-[var(--color-fg-secondary)]">${task.assignee}</strong></div>`
                     : html`<${TileHint} text="아직 assignee가 없습니다." />`}
                   ${task.updated_at
-                    ? html`<div class="text-xs text-[var(--text-muted)]">최근 갱신 <${TimeAgo} timestamp=${task.updated_at} /></div>`
+                    ? html`<div class="text-xs text-[var(--color-fg-muted)]">최근 갱신 <${TimeAgo} timestamp=${task.updated_at} /></div>`
                     : null}
                 `
               : html`<${TileHint} text="현재 연결된 task 없이 keeper 연속성만 추적 중입니다." />`}
@@ -572,16 +572,16 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
 
           <${JourneyTile} label="실행">
             ${record.sessionId
-              ? html`<div><span class="text-[var(--text-dim)]">session</span><div class="mt-1 font-mono text-xs text-[var(--text-strong)]">${truncate(record.sessionId, 24)}</div></div>`
+              ? html`<div><span class="text-[var(--color-fg-disabled)]">session</span><div class="mt-1 font-mono text-xs text-[var(--color-fg-secondary)]">${truncate(record.sessionId, 24)}</div></div>`
               : html`<${TileHint} text="아직 session_id가 연결되지 않았습니다." />`}
             ${record.operationId
-              ? html`<div><span class="text-[var(--text-dim)]">operation</span><div class="mt-1 font-mono text-xs text-[var(--text-strong)]">${truncate(record.operationId, 24)}</div></div>`
+              ? html`<div><span class="text-[var(--color-fg-disabled)]">operation</span><div class="mt-1 font-mono text-xs text-[var(--color-fg-secondary)]">${truncate(record.operationId, 24)}</div></div>`
               : null}
             ${record.workerRunId
-              ? html`<div><span class="text-[var(--text-dim)]">worker run</span><div class="mt-1 font-mono text-xs text-[var(--text-strong)]">${truncate(record.workerRunId, 24)}</div></div>`
+              ? html`<div><span class="text-[var(--color-fg-disabled)]">worker run</span><div class="mt-1 font-mono text-xs text-[var(--color-fg-secondary)]">${truncate(record.workerRunId, 24)}</div></div>`
               : null}
             ${trimText(record.executionSession?.goal ?? record.missionSession?.goal, 90)
-              ? html`<div class="text-xs leading-relaxed text-[var(--text-muted)]">${trimText(record.executionSession?.goal ?? record.missionSession?.goal, 90)}</div>`
+              ? html`<div class="text-xs leading-relaxed text-[var(--color-fg-muted)]">${trimText(record.executionSession?.goal ?? record.missionSession?.goal, 90)}</div>`
               : null}
           <//>
 
@@ -602,7 +602,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                     <${MetricChip} label="evidence" value=${requiredEvidence.length} />
                   </div>
                   ${unmetItems.length > 0
-                    ? html`<div class="text-xs leading-relaxed text-[var(--warn)]">${unmetItems.slice(0, 2).join(' · ')}</div>`
+                    ? html`<div class="text-xs leading-relaxed text-[var(--color-status-warn)]">${unmetItems.slice(0, 2).join(' · ')}</div>`
                     : null}
                 `
               : keeper?.runtime_blocker_class === 'completion_contract_violation'
@@ -614,17 +614,17 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
             ${keeper
               ? html`
                   <div class="flex flex-wrap items-center gap-2">
-                    <div class="font-semibold text-[var(--text-strong)]">${keeper.name}</div>
+                    <div class="font-semibold text-[var(--color-fg-secondary)]">${keeper.name}</div>
                     ${keeper.phase ? html`<${StatusChip} tone=${keeperStateTone(keeper.phase)}>${keeper.phase}<//>` : null}
                     <${StatusChip} tone=${keeperStateTone(keeper.status)}>${keeper.status}<//>
                   </div>
-                  <div class="flex flex-wrap gap-3 text-xs text-[var(--text-muted)]">
+                  <div class="flex flex-wrap gap-3 text-xs text-[var(--color-fg-muted)]">
                     <span>ctx ${formatPct(keeper.context_ratio)}</span>
                     ${contextSummary ? html`<span>${contextSummary}</span>` : null}
                     ${keeperActivity?.ageSeconds != null ? html`<span>${keeperActivity.label} ${formatAgeSeconds(keeperActivity.ageSeconds)}</span>` : null}
                   </div>
                   ${trimText(record.continuity?.continuity_summary ?? record.continuity?.note, 100)
-                    ? html`<div class="text-xs leading-relaxed text-[var(--text-muted)]">${trimText(record.continuity?.continuity_summary ?? record.continuity?.note, 100)}</div>`
+                    ? html`<div class="text-xs leading-relaxed text-[var(--color-fg-muted)]">${trimText(record.continuity?.continuity_summary ?? record.continuity?.note, 100)}</div>`
                     : null}
                 `
               : html`<${TileHint} text="현재 task에 연결된 keeper가 없습니다." />`}
@@ -633,12 +633,12 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
 
         <div class="flex items-center gap-3 border-t border-[var(--white-8)] pt-3">
           <button
-            class="inline-flex items-center rounded px-3 py-1.5 text-xs font-medium text-[var(--text-muted)] transition hover:text-[var(--text-body)] hover:bg-[var(--white-5)]"
+            class="inline-flex items-center rounded px-3 py-1.5 text-xs font-medium text-[var(--color-fg-muted)] transition hover:text-[var(--color-fg-primary)] hover:bg-[var(--white-5)]"
             onClick=${() => { showExtended.value = !showExtended.value }}
           >
             ${showExtended.value ? '▼' : '▶'} 추가 정보
           </button>
-          <div class="text-2xs text-[var(--text-dim)]">
+          <div class="text-2xs text-[var(--color-fg-disabled)]">
             thinking, memory, turn, lifecycle, cascade
           </div>
         </div>
@@ -651,16 +651,16 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                     ? html`<${StatusChip} tone=${pipelineTone(keeper.pipeline_stage)}>${keeper.pipeline_stage}<//>`
                     : html`<${TileHint} text="thinking stage가 아직 보고되지 않았습니다." />`}
                   ${keeper?.skill_primary
-                    ? html`<div><span class="text-[var(--text-dim)]">skill</span><div class="mt-1 font-semibold text-[var(--text-strong)]">${keeper.skill_primary}</div></div>`
+                    ? html`<div><span class="text-[var(--color-fg-disabled)]">skill</span><div class="mt-1 font-semibold text-[var(--color-fg-secondary)]">${keeper.skill_primary}</div></div>`
                     : null}
                   ${trimText(keeper?.skill_reason ?? keeper?.recent_input_preview ?? record.worker?.focus, 100)
-                    ? html`<div class="text-xs leading-relaxed text-[var(--text-muted)]">${trimText(keeper?.skill_reason ?? keeper?.recent_input_preview ?? record.worker?.focus, 100)}</div>`
+                    ? html`<div class="text-xs leading-relaxed text-[var(--color-fg-muted)]">${trimText(keeper?.skill_reason ?? keeper?.recent_input_preview ?? record.worker?.focus, 100)}</div>`
                     : null}
                 <//>
 
                 <${JourneyTile} label="기억">
                   ${trimText(keeper?.memory_recent_note, 100)
-                    ? html`<div class="text-xs leading-relaxed text-[var(--text-body)]">${trimText(keeper?.memory_recent_note, 100)}</div>`
+                    ? html`<div class="text-xs leading-relaxed text-[var(--color-fg-primary)]">${trimText(keeper?.memory_recent_note, 100)}</div>`
                     : html`<${TileHint} text="최근 memory note가 아직 없습니다." />`}
                   ${keeper?.metrics_window
                     ? html`
@@ -682,7 +682,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                           <${MetricChip} label="auto" value=${keeper.autonomous_turn_count ?? 0} />
                         </div>
                         ${keeper.runtime_blocker_summary
-                          ? html`<div class="text-xs leading-relaxed text-[var(--warn)]">${trimText(keeper.runtime_blocker_summary, 100)}</div>`
+                          ? html`<div class="text-xs leading-relaxed text-[var(--color-status-warn)]">${trimText(keeper.runtime_blocker_summary, 100)}</div>`
                           : null}
                       `
                     : html`<${TileHint} text="연결된 keeper turn 정보가 없습니다." />`}
@@ -697,9 +697,9 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                               <${StatusChip} tone=${entry.source === 'journal' ? 'info' : entry.source === 'handoff' ? 'warn' : 'neutral'} uppercase=${false}>
                                 ${entry.source}
                               <//>
-                              ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} class="text-2xs text-[var(--text-dim)]" />` : null}
+                              ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} class="text-2xs text-[var(--color-fg-disabled)]" />` : null}
                             </div>
-                            <div class="mt-2 text-xs leading-relaxed text-[var(--text-body)]">${entry.text}</div>
+                            <div class="mt-2 text-xs leading-relaxed text-[var(--color-fg-primary)]">${entry.text}</div>
                           </div>
                         `)}
                       `
@@ -713,14 +713,14 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                           ${keeper.cascade_name ? html`<${StatusChip} tone="info">${keeper.cascade_name}<//>` : null}
                           ${keeperModel ? html`<${StatusChip} tone="neutral" uppercase=${false}>${keeperModel.value}<//>` : null}
                         </div>
-                        <div class="text-xs text-[var(--text-muted)]">
+                        <div class="text-xs text-[var(--color-fg-muted)]">
                           ${keeperModel ? html`${keeperModel.label} ${keeperModel.value}` : 'model 기록 없음'}
                         </div>
                         ${keeper.next_model_hint
-                          ? html`<div class="text-xs text-[var(--text-muted)]">next ${keeper.next_model_hint}</div>`
+                          ? html`<div class="text-xs text-[var(--color-fg-muted)]">next ${keeper.next_model_hint}</div>`
                           : null}
                         ${keeper.metrics_window?.fallback_rate != null
-                          ? html`<div class="text-xs text-[var(--text-muted)]">fallback ${formatPct(keeper.metrics_window.fallback_rate)}</div>`
+                          ? html`<div class="text-xs text-[var(--color-fg-muted)]">fallback ${formatPct(keeper.metrics_window.fallback_rate)}</div>`
                           : null}
                       `
                     : html`<${TileHint} text="cascade 선택 정보는 keeper runtime에서만 노출됩니다." />`}
@@ -765,10 +765,10 @@ export function JourneyPanel() {
       <${Card} class="flex flex-col gap-4">
         <div class="flex flex-col gap-2">
           <div class="flex flex-wrap items-center gap-2">
-            <h2 class="m-0 text-2xl font-semibold text-[var(--text-strong)]">작업 → 실행 → 계약 → 키퍼 → 사고 → 기억 → 턴 → 생애 → 캐스케이드</h2>
+            <h2 class="m-0 text-2xl font-semibold text-[var(--color-fg-secondary)]">작업 → 실행 → 계약 → 키퍼 → 사고 → 기억 → 턴 → 생애 → 캐스케이드</h2>
             <${StatusChip} tone="info">journey beta<//>
           </div>
-          <div class="text-sm leading-relaxed text-[var(--text-muted)]">
+          <div class="text-sm leading-relaxed text-[var(--color-fg-muted)]">
             task 중심 흐름과 task에 안 묶인 keeper 연속성을 같은 카드 문법으로 읽습니다. 실행 링크, contract gate, keeper stage, memory note, recent life signal, cascade 선택을 한 번에 붙여 봅니다.
           </div>
         </div>
@@ -792,7 +792,7 @@ export function JourneyPanel() {
               query.value = (event.target as HTMLInputElement).value
             }}
           />
-          <div class="text-xs text-[var(--text-muted)]">
+          <div class="text-xs text-[var(--color-fg-muted)]">
             ${query.value.trim() !== '' ? `${visible.length} / ${records.length}개 표시` : `${records.length}개 흐름`}
           </div>
         </div>
@@ -804,7 +804,7 @@ export function JourneyPanel() {
             ${taskRecords.length > 0
               ? html`
                   <div class="flex flex-col gap-3">
-                    <div class="text-2xs font-semibold uppercase tracking-3 text-[var(--text-muted)]">작업 여정</div>
+                    <div class="text-2xs font-semibold uppercase tracking-3 text-[var(--color-fg-muted)]">작업 여정</div>
                     ${taskRecords.map((record) => html`<${JourneyCard} key=${record.key} record=${record} />`)}
                   </div>
                 `
@@ -813,7 +813,7 @@ export function JourneyPanel() {
             ${keeperRecords.length > 0
               ? html`
                   <div class="flex flex-col gap-3">
-                    <div class="text-2xs font-semibold uppercase tracking-3 text-[var(--text-muted)]">독립 키퍼 여정</div>
+                    <div class="text-2xs font-semibold uppercase tracking-3 text-[var(--color-fg-muted)]">독립 키퍼 여정</div>
                     ${keeperRecords.map((record) => html`<${JourneyCard} key=${record.key} record=${record} />`)}
                   </div>
                 `

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -194,11 +194,11 @@ export function KeeperChatPanel({ name }: { name: string }) {
       : entries
 
   return html`
-    <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(11,18,34,0.95),rgba(6,11,22,0.92))] shadow-[0_24px_56px_rgba(0,0,0,0.24)]">
+    <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--color-border-default)] bg-[linear-gradient(180deg,rgba(11,18,34,0.95),rgba(6,11,22,0.92))] shadow-[0_24px_56px_rgba(0,0,0,0.24)]">
       <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--slate-gray-12)] px-4 py-4">
         <div class="min-w-55 flex-1">
-          <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">직접 대화</div>
-          <div class="mt-2 text-md font-semibold text-[var(--text-strong)]">@${name}</div>
+          <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--color-fg-muted)]">직접 대화</div>
+          <div class="mt-2 text-md font-semibold text-[var(--color-fg-secondary)]">@${name}</div>
           <div class="mt-1 text-sm leading-loose text-[var(--text-secondary)]">
             이 키퍼와의 실시간 직접 대화입니다. 스트리밍 응답은 동일한 대화 레인에 표시됩니다.
           </div>
@@ -213,7 +213,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
             value=${query}
             onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
           />
-          <span class="inline-flex items-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2.5 py-1 text-2xs font-medium text-[var(--text-strong)]">
+          <span class="inline-flex items-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]">
             ${hasQuery ? `${filteredMessages.length} / ${messages.length}개 메시지` : `${messages.length}개 메시지`}
           </span>
         </div>

--- a/dashboard/src/components/keeper-conditions-divergent.ts
+++ b/dashboard/src/components/keeper-conditions-divergent.ts
@@ -116,22 +116,22 @@ export function KeeperConditionsDivergent({ keeper }: { keeper: Keeper }) {
   return html`
     <section class="rounded border border-[var(--warn-24)] bg-[rgba(251,191,36,0.05)] p-3 mb-3">
       <header class="mb-2 flex items-baseline justify-between gap-2">
-        <h3 class="text-2xs font-semibold tracking-1 uppercase text-[var(--warn)]">
+        <h3 class="text-2xs font-semibold tracking-1 uppercase text-[var(--color-status-warn)]">
           ⚠️ 조건-Phase 불일치
         </h3>
-        <span class="text-3xs text-[var(--text-dim)]">phase가 아직 반응하지 않은 관측 신호</span>
+        <span class="text-3xs text-[var(--color-fg-disabled)]">phase가 아직 반응하지 않은 관측 신호</span>
       </header>
       <div class="flex flex-wrap gap-1.5">
         ${divs.map(d => html`
           <span
-            class="px-2 py-0.5 rounded-sm border border-[rgba(251,191,36,0.3)] bg-[var(--warn-8)] text-[var(--warn)] text-2xs font-mono tabular-nums"
+            class="px-2 py-0.5 rounded-sm border border-[rgba(251,191,36,0.3)] bg-[var(--warn-8)] text-[var(--color-status-warn)] text-2xs font-mono tabular-nums"
             title=${d.reason}
           >
             ${d.field}=${String(d.value)}
           </span>
         `)}
       </div>
-      <div class="mt-2 text-3xs text-[var(--text-dim)] leading-snug">
+      <div class="mt-2 text-3xs text-[var(--color-fg-disabled)] leading-snug">
         ${first.reason}${rest.length > 0 ? ` (외 ${rest.length}건, 칩 hover로 확인)` : ''}
       </div>
     </section>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -359,7 +359,7 @@ function Callout({
 }) {
   const toneClass =
     tone === 'warn'
-      ? 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]'
+      ? 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
       : 'border-card-border/60 bg-card/35 text-text-body'
   return html`
     <div class="rounded border px-3 py-3 shadow-sm ${toneClass}">
@@ -405,9 +405,9 @@ function LongText({ text, truncateAt = 200 }: { text: string; truncateAt?: numbe
 function PromptSourceBadge({ source }: { source: string }) {
   const tone =
     source === 'override'
-      ? 'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]'
+      ? 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]'
       : source === 'file'
-        ? 'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]'
+        ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]'
         : 'bg-white/5 text-text-dim border-white/10'
   return html`<span class="text-3xs font-bold px-2 py-0.5 rounded border ${tone} shadow-sm">${source.toUpperCase()}</span>`
 }
@@ -422,7 +422,7 @@ function PromptBlock({
   return html`
     <div class="mt-2">
       <div class="flex items-center justify-between gap-2 mb-1">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">${title}</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">${title}</div>
         <div class="flex items-center gap-2">
           <span class="text-3xs text-text-dim">${block.key}</span>
           <${PromptSourceBadge} source=${block.source} />
@@ -690,12 +690,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     <div class="flex gap-2 items-center mb-3">
       ${isEditing ? html`
         <button type="button"
-          class="${btnBase} bg-[var(--ok)] text-[#000]"
+          class="${btnBase} bg-[var(--color-status-ok)] text-[#000]"
           onClick=${saveConfig}
           disabled=${isSaving}
         >${isSaving ? '저장 중...' : '저장'}</button>
         <button type="button"
-          class="${btnBase} bg-[var(--white-10)] text-[var(--text-body)]"
+          class="${btnBase} bg-[var(--white-10)] text-[var(--color-fg-primary)]"
           onClick=${cancelEdit}
           disabled=${isSaving}
         >취소</button>
@@ -705,7 +705,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           onClick=${enterEditMode}
         >편집</button>
       `}
-      ${saveError.value ? html`<span class="text-xs text-[var(--bad)]">${saveError.value}</span>` : null}
+      ${saveError.value ? html`<span class="text-xs text-[var(--color-status-err)]">${saveError.value}</span>` : null}
     </div>
   `
 
@@ -722,30 +722,30 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     <${EditTextarea} field="instructions" label="지시사항" rows=${4} />
   ` : html`
     <${SectionHeader} title="프롬프트" />
-    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-0.5">목표</div>
+    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">목표</div>
     <${LongText} text=${c.prompt.goal} />
     ${c.prompt.short_goal ? html`
-      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">단기 목표</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">단기 목표</div>
       <${LongText} text=${c.prompt.short_goal} />
     ` : null}
     ${c.prompt.mid_goal ? html`
-      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">중기 목표</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">중기 목표</div>
       <${LongText} text=${c.prompt.mid_goal} />
     ` : null}
     ${c.prompt.long_goal ? html`
-      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">장기 목표</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">장기 목표</div>
       <${LongText} text=${c.prompt.long_goal} />
     ` : null}
     ${c.prompt.instructions ? html`
-      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">지시사항</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">지시사항</div>
       <${LongText} text=${c.prompt.instructions} />
     ` : null}
-    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-3 mb-0.5">시스템 프롬프트 블록</div>
+    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-3 mb-0.5">시스템 프롬프트 블록</div>
     <${PromptBlock} title="헌법" block=${c.prompt.system_prompt_blocks.constitution} />
     <${PromptBlock} title="세계관" block=${c.prompt.system_prompt_blocks.world} />
     <${PromptBlock} title="능력" block=${c.prompt.system_prompt_blocks.capabilities} />
     <details class="mt-3">
-      <summary class="cursor-pointer py-2 px-3 text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] list-none select-none rounded hover:bg-[var(--white-3)] transition-colors">컴파일된 시스템 프롬프트 보기</summary>
+      <summary class="cursor-pointer py-2 px-3 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] list-none select-none rounded hover:bg-[var(--white-3)] transition-colors">컴파일된 시스템 프롬프트 보기</summary>
       <${LongText} text=${c.prompt.effective_system_prompt} truncateAt=${null} />
     </details>
   `
@@ -819,7 +819,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                   <option value=${profileName}>${profileName}</option>
                 `)}
               </select>
-              <span class="text-2xs text-[var(--text-dim)]">
+              <span class="text-2xs text-[var(--color-fg-disabled)]">
                 ${cascadeSaving.value
                   ? 'cascade_name 저장 중...'
                   : cascadeState.status === 'loading'
@@ -827,10 +827,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                     : '변경 시 keeper manifest의 cascade_name 이 즉시 갱신됩니다.'}
               </span>
               ${cascadeSaveError.value
-                ? html`<span class="text-2xs text-[var(--bad)]">${cascadeSaveError.value}</span>`
+                ? html`<span class="text-2xs text-[var(--color-status-err)]">${cascadeSaveError.value}</span>`
                 : null}
               ${invalidCascadeProfiles.length > 0
-                ? html`<span class="text-2xs text-[var(--warn)]">invalid profile ${invalidCascadeProfiles.length}개: ${invalidCascadeSummary}</span>`
+                ? html`<span class="text-2xs text-[var(--color-status-warn)]">invalid profile ${invalidCascadeProfiles.length}개: ${invalidCascadeSummary}</span>`
                 : null}
             </label>
           `
@@ -846,48 +846,48 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         : null}
       <${ConfigRow} label="catalog source" value=${cascadeCatalogSourceLabel(c)} />
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">라이브 오버라이드</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">라이브 오버라이드</span>
         <${BoolBadge} value=${c.sources.has_live_override} />
       </div>
-      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">라이브 메타 경로</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">라이브 메타 경로</div>
       <${LongText} text=${c.sources.live_meta_path} />
       ${c.sources.default_manifest_path ? html`
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">기본 매니페스트 경로</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">기본 매니페스트 경로</div>
         <${LongText} text=${c.sources.default_manifest_path} />
       ` : null}
       ${c.sources.cascade_catalog_source_path ? html`
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">캐스케이드 카탈로그 출처</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">캐스케이드 카탈로그 출처</div>
         <${LongText} text=${c.sources.cascade_catalog_source_path} />
       ` : null}
       ${c.sources.cascade_runtime_json_path ? html`
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Generated runtime JSON</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">Generated runtime JSON</div>
         <${LongText} text=${c.sources.cascade_runtime_json_path} />
       ` : null}
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">cascade.json 직접 수정 가능</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">cascade.json 직접 수정 가능</span>
         <${BoolBadge} value=${c.sources.cascade_runtime_json_editable} />
       </div>
       <div class="mt-1.5">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">우선순위</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">우선순위</div>
         <${ModelList} models=${c.sources.precedence} />
       </div>
       <div class="mt-1.5">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">오버라이드 필드</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">오버라이드 필드</div>
         <${ModelList} models=${c.sources.override_fields} />
       </div>
 
       <${SectionHeader} title="실행" />
       <${ConfigRow} label="활성 모델" value=${c.execution.active_model || '--'} />
       <${ConfigRow} label="provider timeout" value=${perProviderTimeoutLabel(c.execution)} />
-      <div class="mb-1.5 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--text-muted)]">
+      <div class="mb-1.5 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
         cascade fallback 중 마지막 provider를 제외한 provider들에만 적용됩니다.
       </div>
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">검증</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">검증</span>
         <${BoolBadge} value=${c.execution.verify} />
       </div>
       <div class="mt-1.5">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">모델</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">모델</div>
         <${ModelList} models=${c.execution.models} />
       </div>
 
@@ -933,10 +933,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         />
         <div class="py-2 px-3 rounded bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1">
-            <span class="text-xs text-[var(--text-body)]">allowed_paths</span>
-            <span class="text-3xs text-[var(--text-muted)]">한 줄에 하나씩. 명시 경로만 허용됩니다.</span>
+            <span class="text-xs text-[var(--color-fg-primary)]">allowed_paths</span>
+            <span class="text-3xs text-[var(--color-fg-muted)]">한 줄에 하나씩. 명시 경로만 허용됩니다.</span>
           </div>
-          <textarea class="w-full text-xs font-mono bg-[var(--white-6)] border border-[var(--card-border)] rounded px-2 py-1.5 text-[var(--text-body)] resize-y"
+          <textarea class="w-full text-xs font-mono bg-[var(--white-6)] border border-[var(--color-border-default)] rounded px-2 py-1.5 text-[var(--color-fg-primary)] resize-y"
             rows=${3}
             value=${rd.allowed_paths_text}
             placeholder=".masc/keepers/<name>/"
@@ -944,7 +944,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           ></textarea>
         </div>
         ${(c.effective_allowed_paths ?? []).length > 0 ? html`
-          <div class="py-1.5 px-3 text-3xs text-[var(--text-muted)]">
+          <div class="py-1.5 px-3 text-3xs text-[var(--color-fg-muted)]">
             effective: ${(c.effective_allowed_paths ?? []).join(', ') || '(전체 허용)'}
           </div>
         ` : null}
@@ -974,7 +974,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ConfigRow} label="config_base_path" value=${c.sandbox_environment.base_path || '--'} />
         <${ConfigRow} label="project_root" value=${c.sandbox_environment.project_root || '--'} />
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--text-muted)]">docker_playground</span>
+          <span class="text-xs text-[var(--color-fg-muted)]">docker_playground</span>
           <${BoolBadge} value=${c.sandbox_environment.docker_playground_enabled} />
         </div>
         <${ConfigRow} label="docker_container" value=${c.sandbox_environment.docker_container_name || '--'} />
@@ -985,11 +985,11 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ConfigRow} label="sandbox_tmpfs_size" value=${c.sandbox_environment.tmpfs_size || '--'} />
         <${ConfigRow} label="sandbox_seccomp_profile" value=${c.sandbox_environment.seccomp_profile || '--'} />
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--text-muted)]">require_rootless</span>
+          <span class="text-xs text-[var(--color-fg-muted)]">require_rootless</span>
           <${BoolBadge} value=${c.sandbox_environment.require_rootless} />
         </div>
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--text-muted)]">require_userns</span>
+          <span class="text-xs text-[var(--color-fg-muted)]">require_userns</span>
           <${BoolBadge} value=${c.sandbox_environment.require_userns} />
         </div>
         ${c.sandbox_last_error ? html`
@@ -1013,7 +1013,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           min=${10} max=${3600} step=${10} suffix="s" />
       ` : html`
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--text-muted)]">활성</span>
+          <span class="text-xs text-[var(--color-fg-muted)]">활성</span>
           <${BoolBadge} value=${c.proactive.enabled} />
         </div>
         <${ConfigRow} label="유휴 트리거" value=${c.proactive.idle_sec + 's'} />
@@ -1022,21 +1022,21 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       <${SectionHeader} title="런타임" />
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">일시정지</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">일시정지</span>
         <${BoolBadge} value=${c.runtime.paused} />
       </div>
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">자동 부팅 등록</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">자동 부팅 등록</span>
         <${BoolBadge} value=${c.runtime.registered} />
       </div>
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">킵얼라이브 실행</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">킵얼라이브 실행</span>
         <${BoolBadge} value=${c.runtime.keepalive_running} />
       </div>
       <${ConfigRow} label="레지스트리 상태" value=${c.runtime.registry_state || '--'} />
       <${ConfigRow} label="파이버 상태" value=${c.runtime.fiber_health || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">프레즌스 킵얼라이브</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">프레즌스 킵얼라이브</span>
         <${BoolBadge} value=${c.runtime.presence_keepalive} />
       </div>
       <${ConfigRow} label="프레즌스 간격" value=${c.runtime.presence_keepalive_sec + 's'} />
@@ -1045,18 +1045,18 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <div class="py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm mb-1.5">
         <div class="flex items-center justify-between gap-3 mb-2">
           <span class="text-xs font-medium text-text-muted">active_goal_ids</span>
-          <span class="text-3xs text-[var(--text-muted)]">${selectedActiveGoalIds.length}개 선택</span>
+          <span class="text-3xs text-[var(--color-fg-muted)]">${selectedActiveGoalIds.length}개 선택</span>
         </div>
         ${goalState.status === 'loading' ? html`
-          <div class="text-2xs text-[var(--text-muted)]">목표 목록 로딩 중...</div>
+          <div class="text-2xs text-[var(--color-fg-muted)]">목표 목록 로딩 중...</div>
         ` : goalState.status === 'error' ? html`
-          <div class="text-2xs text-[var(--bad)]">${goalState.message}</div>
+          <div class="text-2xs text-[var(--color-status-err)]">${goalState.message}</div>
         ` : goalOptions.length > 0 && rd ? html`
           <div class="grid gap-1.5">
             ${goalOptions.map((goal) => {
               const checked = rd.active_goal_ids.includes(goal.id)
               return html`
-                <label class="flex items-center gap-2 rounded bg-[var(--white-3)] px-2 py-1.5 text-xs text-[var(--text-body)]">
+                <label class="flex items-center gap-2 rounded bg-[var(--white-3)] px-2 py-1.5 text-xs text-[var(--color-fg-primary)]">
                   <input
                     type="checkbox"
                     checked=${checked}
@@ -1064,9 +1064,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                       toggleRuntimeActiveGoal(goal.id, (event.currentTarget as HTMLInputElement).checked)
                     }}
                   />
-                  <span class="min-w-[4.5rem] font-mono text-3xs text-[var(--text-muted)]">${goal.horizon}</span>
+                  <span class="min-w-[4.5rem] font-mono text-3xs text-[var(--color-fg-muted)]">${goal.horizon}</span>
                   <span class="flex-1 truncate">${goal.title}</span>
-                  <span class="font-mono text-3xs text-[var(--text-dim)]">${goal.id}</span>
+                  <span class="font-mono text-3xs text-[var(--color-fg-disabled)]">${goal.id}</span>
                 </label>
               `
             })}
@@ -1074,10 +1074,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         ` : selectedActiveGoalIds.length > 0 ? html`
           <${ModelList} models=${selectedActiveGoalIds} />
         ` : html`
-          <div class="text-2xs text-[var(--text-muted)]">활성 목표가 연결되어 있지 않습니다.</div>
+          <div class="text-2xs text-[var(--color-fg-muted)]">활성 목표가 연결되어 있지 않습니다.</div>
         `}
         ${unknownSelectedGoalIds.length > 0 ? html`
-          <div class="mt-2 text-2xs text-[var(--warn)]">
+          <div class="mt-2 text-2xs text-[var(--color-status-warn)]">
             Goal Store에서 찾을 수 없는 연결: ${unknownSelectedGoalIds.join(', ')}
           </div>
         ` : null}
@@ -1090,12 +1090,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ` : null}
       ${c.coordination.mention_targets.length > 0 ? html`
       <div class="mt-1.5">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">멘션 대상</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">멘션 대상</div>
         <${ModelList} models=${c.coordination.mention_targets} />
       </div>
       ` : null}
       <div class="mt-1.5">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">참여 네임스페이스</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">참여 네임스페이스</div>
         <${ModelList} models=${c.coordination.joined_room_ids} />
       </div>
 
@@ -1111,7 +1111,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           min=${0} max=${3600} step=${30} suffix="s" />
       ` : html`
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--text-muted)]">자동</span>
+          <span class="text-xs text-[var(--color-fg-muted)]">자동</span>
           <${BoolBadge} value=${c.handoff.auto} />
         </div>
         <${ConfigRow} label="임계값" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
@@ -1121,12 +1121,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ${runtimeHasChanges ? html`
         <div class="flex gap-2 items-center mt-4 mb-2 p-3 rounded border border-accent/30 bg-accent/5">
           <button type="button"
-            class="${btnBase} bg-[var(--ok)] text-[#000]"
+            class="${btnBase} bg-[var(--color-status-ok)] text-[#000]"
             onClick=${saveRuntimeConfig}
             disabled=${runtimeSaving.value}
           >${runtimeSaving.value ? '저장 중...' : '런타임 설정 저장'}</button>
           <button type="button"
-            class="${btnBase} bg-[var(--white-10)] text-[var(--text-body)]"
+            class="${btnBase} bg-[var(--white-10)] text-[var(--color-fg-primary)]"
             onClick=${resetRuntimeDraft}
           >초기화</button>
           <span class="text-3xs text-accent">변경된 설정이 있습니다</span>
@@ -1147,14 +1147,14 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
               placeholder="슬롯 이름 / source / gate 필터"
               aria-label="훅 슬롯 필터"
               onInput=${(e: Event) => { hookFilterQuery.value = (e.target as HTMLInputElement).value }}
-              class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+              class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
             />
           </div>
           ${isFiltering && visibleEntries.length === 0 && allEntries.length > 0
-            ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${allEntries.length} slots)</div>`
+            ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${allEntries.length} slots)</div>`
             : visibleEntries.map(([name, slot]) => html`
                 <div class="flex items-start gap-2 py-2 px-3 rounded border border-card-border/50 bg-card/20 mb-1.5">
-                  <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--text-dim)]'}"></span>
+                  <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--color-status-ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--color-fg-disabled)]'}"></span>
                   <div class="flex-1 min-w-0">
                     <div class="flex justify-between">
                       <span class="text-xs font-semibold text-text-strong">${name}</span>
@@ -1163,7 +1163,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                     ${(slot.gates ?? slot.effects ?? slot.features ?? []).length > 0 ? html`
                       <div class="flex flex-wrap gap-1 mt-1">
                         ${(slot.gates ?? slot.effects ?? slot.features ?? []).map((d: string) => html`
-                          <span class="text-3xs px-1.5 py-0.5 rounded ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--text-dim)]' : 'bg-[var(--accent-10)] text-[var(--accent)] opacity-80'}">${d}</span>
+                          <span class="text-3xs px-1.5 py-0.5 rounded ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--color-fg-disabled)]' : 'bg-[var(--accent-10)] text-[var(--color-accent-fg)] opacity-80'}">${d}</span>
                         `)}
                       </div>
                     ` : null}

--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -57,35 +57,35 @@ function CheckpointSummaryCard({
 }) {
   if (!summary) {
     return html`
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-xs text-[var(--text-muted)]">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-2)] px-3 py-3 text-xs text-[var(--color-fg-muted)]">
         ${title}: 저장된 checkpoint 없음
       </div>
     `
   }
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3">
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-2)] px-3 py-3">
       <div class="flex flex-wrap items-center gap-2">
-        <span class="text-xs font-semibold text-[var(--text-strong)]">${title}</span>
-        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-18)]">
+        <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">${title}</span>
+        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-18)]">
           gen ${summary.generation}
         </span>
-        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]">
+        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--color-fg-muted)]">
           ${summary.message_count} msgs
         </span>
         ${summary.system_prompt_present
-          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]">system kept</span>`
+          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]">system kept</span>`
           : null}
       </div>
-      <div class="mt-2 text-2xs text-[var(--text-muted)]">
+      <div class="mt-2 text-2xs text-[var(--color-fg-muted)]">
         ${formatCheckpointTime(summary.created_at)}
       </div>
       ${summary.latest_preview
-        ? html`<div class="mt-2 text-xs leading-relaxed text-[var(--text-body)]">${summary.latest_preview}</div>`
+        ? html`<div class="mt-2 text-xs leading-relaxed text-[var(--color-fg-primary)]">${summary.latest_preview}</div>`
         : null}
       ${summary.continuity_summary
-        ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--text-muted)]">${summary.continuity_summary}</pre>`
-        : html`<div class="mt-2 text-2xs text-[var(--text-dim)]">continuity snapshot 없음</div>`}
+        ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${summary.continuity_summary}</pre>`
+        : html`<div class="mt-2 text-2xs text-[var(--color-fg-disabled)]">continuity snapshot 없음</div>`}
     </div>
   `
 }
@@ -169,7 +169,7 @@ export function KeeperCheckpointPanel({
 
   if (loading) {
     return html`
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-xs text-[var(--text-muted)]">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-2)] px-3 py-3 text-xs text-[var(--color-fg-muted)]">
         checkpoint inventory 로딩 중...
       </div>
     `
@@ -181,7 +181,7 @@ export function KeeperCheckpointPanel({
         ${error}
         <button
           type="button"
-          class="ml-2 rounded border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] hover:bg-[var(--white-8)] cursor-pointer"
+          class="ml-2 rounded border border-[var(--color-border-default)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] hover:bg-[var(--white-8)] cursor-pointer"
           onClick=${loadInventory}
         >다시 로드</button>
       </div>
@@ -191,16 +191,16 @@ export function KeeperCheckpointPanel({
   return html`
     <div class="flex flex-col gap-3">
       <div class="flex items-center justify-between gap-3">
-        <div class="text-2xs text-[var(--text-muted)]">
+        <div class="text-2xs text-[var(--color-fg-muted)]">
           current OAS checkpoint와 OAS snapshot history만 노출합니다.
           ${inventory && inventory.legacy_shadow_count > 0
-            ? html`<span class="block mt-1 text-[var(--warn)]">legacy shadow ${inventory.legacy_shadow_count}개는 picker에서 제외됩니다.</span>`
+            ? html`<span class="block mt-1 text-[var(--color-status-warn)]">legacy shadow ${inventory.legacy_shadow_count}개는 picker에서 제외됩니다.</span>`
             : null}
         </div>
         <div class="flex items-center gap-2">
           <button
             type="button"
-            class="rounded border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-1.5 text-2xs font-semibold text-[var(--text-body)] hover:bg-[var(--white-8)] cursor-pointer"
+            class="rounded border border-[var(--color-border-default)] bg-[var(--white-4)] px-3 py-1.5 text-2xs font-semibold text-[var(--color-fg-primary)] hover:bg-[var(--white-8)] cursor-pointer"
             onClick=${loadInventory}
           >새로고침</button>
           <button
@@ -217,12 +217,12 @@ export function KeeperCheckpointPanel({
         summary=${inventory?.current ?? null}
       />
 
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--card-border)] px-3 py-2">
-          <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-2)]">
+        <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--color-border-default)] px-3 py-2">
+          <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
             OAS Snapshot History
             ${inventory && inventory.history.length > 0 && historyQuery.trim() !== ''
-              ? html`<span class="ml-2 text-3xs font-normal normal-case tracking-normal text-[var(--text-dim)]">${filterCheckpointHistory(inventory.history, historyQuery).length}/${inventory.history.length}</span>`
+              ? html`<span class="ml-2 text-3xs font-normal normal-case tracking-normal text-[var(--color-fg-disabled)]">${filterCheckpointHistory(inventory.history, historyQuery).length}/${inventory.history.length}</span>`
               : null}
           </div>
           <input
@@ -231,21 +231,21 @@ export function KeeperCheckpointPanel({
             placeholder="snapshot id / preview / 요약 필터"
             aria-label="OAS snapshot history 필터"
             onInput=${(e: Event) => { setHistoryQuery((e.target as HTMLInputElement).value) }}
-            class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
           />
         </div>
         ${!inventory || inventory.history.length === 0
-          ? html`<div class="px-3 py-3 text-xs text-[var(--text-muted)]">저장된 OAS history snapshot이 아직 없습니다.</div>`
+          ? html`<div class="px-3 py-3 text-xs text-[var(--color-fg-muted)]">저장된 OAS history snapshot이 아직 없습니다.</div>`
           : (() => {
               const visibleHistory = filterCheckpointHistory(inventory.history, historyQuery)
               const isFiltering = historyQuery.trim() !== ''
               if (isFiltering && visibleHistory.length === 0) {
-                return html`<div class="px-3 py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${inventory.history.length} items)</div>`
+                return html`<div class="px-3 py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${inventory.history.length} items)</div>`
               }
               return html`
                 <div class="flex flex-col">
                   ${visibleHistory.map(item => html`
-                    <label class="flex gap-3 border-b border-[var(--card-border)] px-3 py-3 text-xs last:border-b-0">
+                    <label class="flex gap-3 border-b border-[var(--color-border-default)] px-3 py-3 text-xs last:border-b-0">
                       <input
                         type="checkbox"
                         class="mt-1"
@@ -254,27 +254,27 @@ export function KeeperCheckpointPanel({
                       />
                       <div class="min-w-0 flex-1">
                         <div class="flex flex-wrap items-center gap-2">
-                          <span class="font-mono text-[var(--text-strong)]">${item.snapshot_id}</span>
-                          <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-18)]">
+                          <span class="font-mono text-[var(--color-fg-secondary)]">${item.snapshot_id}</span>
+                          <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-18)]">
                             gen ${item.generation}
                           </span>
-                          <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]">
+                          <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--color-fg-muted)]">
                             ${item.message_count} msgs
                           </span>
                           ${item.system_prompt_present
-                            ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]">system kept</span>`
+                            ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]">system kept</span>`
                             : null}
                         </div>
-                        <div class="mt-1 text-2xs text-[var(--text-muted)]">
+                        <div class="mt-1 text-2xs text-[var(--color-fg-muted)]">
                           ${formatCheckpointTime(item.created_at)}
                           ${item.file_stat?.size_bytes ? html` · ${(item.file_stat.size_bytes / 1024).toFixed(1)} KB` : null}
                         </div>
                         ${item.latest_preview
-                          ? html`<div class="mt-2 text-xs leading-relaxed text-[var(--text-body)]">${item.latest_preview}</div>`
+                          ? html`<div class="mt-2 text-xs leading-relaxed text-[var(--color-fg-primary)]">${item.latest_preview}</div>`
                           : null}
                         ${item.continuity_summary
-                          ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--text-muted)]">${item.continuity_summary}</pre>`
-                          : html`<div class="mt-2 text-2xs text-[var(--text-dim)]">continuity snapshot 없음</div>`}
+                          ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${item.continuity_summary}</pre>`
+                          : html`<div class="mt-2 text-2xs text-[var(--color-fg-disabled)]">continuity snapshot 없음</div>`}
                       </div>
                     </label>
                   `)}
@@ -416,13 +416,13 @@ export function lineageTransitionLabel(parentGeneration: number | null | undefin
 function verdictBadgeClass(verdict: string | undefined): string {
   switch (verdict) {
     case 'verified':
-      return 'bg-[var(--ok-10)] text-[var(--ok)] border border-[var(--ok-20)]'
+      return 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border border-[var(--ok-20)]'
     case 'drift_detected':
-      return 'bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]'
+      return 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border border-[var(--warn-20)]'
     case 'unavailable':
-      return 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
+      return 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border border-[var(--white-8)]'
     default:
-      return 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
+      return 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border border-[var(--white-8)]'
   }
 }
 
@@ -453,7 +453,7 @@ export function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
   return html`
     <div class="md:col-span-2">
       <${KeeperDetailSectionCard} title="생성 계보">
-        <div class="text-2xs text-[var(--text-muted)] mb-3">
+        <div class="text-2xs text-[var(--color-fg-muted)] mb-3">
           Track keeper state transfer across successful handoffs. Lineage telemetry is append-only, shows the latest rollover first, and helps explain whether the same keeper identity carried into the new trace.
         </div>
 
@@ -461,21 +461,21 @@ export function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
           ? html`
             <div class="rounded border border-[var(--accent-20)] bg-[var(--accent-8)] p-3 mb-3">
               <div class="flex flex-wrap items-center gap-2 mb-1">
-                <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--accent)]">최신 핸드오프</span>
-                <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">
+                <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-accent-fg)]">최신 핸드오프</span>
+                <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-15)]">
                   ${lineageTransitionLabel(latestEntry.parent_generation, latestEntry.generation)}
                 </span>
                 <span class="text-3xs px-1.5 py-0.5 rounded ${verdictBadgeClass(latestEntry.continuity_verdict)}">
                   ${latestEntryMeta?.badgeLabel}
                 </span>
                 ${latestEntry.created_at
-                  ? html`<span class="text-3xs text-[var(--text-dim)]">recorded <${TimeAgo} timestamp=${latestEntry.created_at} /></span>`
+                  ? html`<span class="text-3xs text-[var(--color-fg-disabled)]">recorded <${TimeAgo} timestamp=${latestEntry.created_at} /></span>`
                   : null}
               </div>
-              <div class="text-2xs text-[var(--text-body)]">
+              <div class="text-2xs text-[var(--color-fg-primary)]">
                 ${latestEntry.trigger_reason ? `trigger ${latestEntry.trigger_reason} · ` : ''}context ratio ${formatLineageRatio(latestEntry.context_ratio)}
               </div>
-              <div class="mt-1 text-2xs text-[var(--text-dim)]">
+              <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">
                 ${latestEntryMeta?.detail}
               </div>
             </div>
@@ -484,19 +484,19 @@ export function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
 
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 mb-3">
           <div class="px-3 py-2 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">현재 세대</div>
-            <div class="mt-1 text-lg font-semibold text-[var(--text-strong)]">${currentGeneration ?? '-'}</div>
-            ${generationId ? html`<div class="text-3xs text-[var(--text-dim)] font-mono truncate" title=${generationId}>${generationId}</div>` : null}
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">현재 세대</div>
+            <div class="mt-1 text-lg font-semibold text-[var(--color-fg-secondary)]">${currentGeneration ?? '-'}</div>
+            ${generationId ? html`<div class="text-3xs text-[var(--color-fg-disabled)] font-mono truncate" title=${generationId}>${generationId}</div>` : null}
           </div>
           <div class="px-3 py-2 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">추적 계보</div>
-            <div class="mt-1 text-lg font-semibold text-[var(--text-strong)]">${traceHistoryCount}</div>
-            <div class="text-3xs text-[var(--text-dim)]">historical traces retained in meta.trace_history</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">추적 계보</div>
+            <div class="mt-1 text-lg font-semibold text-[var(--color-fg-secondary)]">${traceHistoryCount}</div>
+            <div class="text-3xs text-[var(--color-fg-disabled)]">historical traces retained in meta.trace_history</div>
           </div>
           <div class="px-3 py-2 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">현재 추적</div>
-            <div class="mt-1 text-sm font-mono text-[var(--text-strong)] truncate" title=${currentTraceId ?? ''}>${currentTraceId ? compactTraceId(currentTraceId) : '-'}</div>
-            <div class="text-3xs text-[var(--text-dim)]">artifact appears after the first successful handoff</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">현재 추적</div>
+            <div class="mt-1 text-sm font-mono text-[var(--color-fg-secondary)] truncate" title=${currentTraceId ?? ''}>${currentTraceId ? compactTraceId(currentTraceId) : '-'}</div>
+            <div class="text-3xs text-[var(--color-fg-disabled)]">artifact appears after the first successful handoff</div>
           </div>
         </div>
 
@@ -504,64 +504,64 @@ export function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
           ? html`
             <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3 mb-3">
               <div class="flex flex-wrap items-center gap-2 mb-2">
-                <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">현재 매니페스트</span>
-                <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">gen ${manifest.generation}</span>
+                <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">현재 매니페스트</span>
+                <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-15)]">gen ${manifest.generation}</span>
                 ${continuity?.verdict
                   ? html`<span class="text-3xs px-1.5 py-0.5 rounded ${verdictBadgeClass(continuity.verdict)}">${continuityMeta.badgeLabel}</span>`
                   : null}
                 ${manifest.created_at
-                  ? html`<span class="text-3xs text-[var(--text-dim)]">created <${TimeAgo} timestamp=${manifest.created_at} /></span>`
+                  ? html`<span class="text-3xs text-[var(--color-fg-disabled)]">created <${TimeAgo} timestamp=${manifest.created_at} /></span>`
                   : null}
               </div>
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 text-2xs">
                 <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-                  <div class="text-3xs text-[var(--text-muted)] uppercase tracking-wider mb-1">부모</div>
-                  <div class="text-[var(--text-strong)]">${manifest.parent_generation != null ? `gen ${manifest.parent_generation}` : 'root generation'}</div>
+                  <div class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-wider mb-1">부모</div>
+                  <div class="text-[var(--color-fg-secondary)]">${manifest.parent_generation != null ? `gen ${manifest.parent_generation}` : 'root generation'}</div>
                   ${manifest.parent_trace_id
-                    ? html`<div class="font-mono text-[var(--text-dim)] truncate" title=${manifest.parent_trace_id}>${compactTraceId(manifest.parent_trace_id)}</div>`
+                    ? html`<div class="font-mono text-[var(--color-fg-disabled)] truncate" title=${manifest.parent_trace_id}>${compactTraceId(manifest.parent_trace_id)}</div>`
                     : null}
                 </div>
                 <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-                  <div class="text-3xs text-[var(--text-muted)] uppercase tracking-wider mb-1">트리거</div>
-                  <div class="text-[var(--text-strong)]">${manifest.trigger_reason ?? '-'}</div>
-                  <div class="text-[var(--text-dim)]">context ratio ${formatLineageRatio(manifest.context_ratio)}</div>
+                  <div class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-wider mb-1">트리거</div>
+                  <div class="text-[var(--color-fg-secondary)]">${manifest.trigger_reason ?? '-'}</div>
+                  <div class="text-[var(--color-fg-disabled)]">context ratio ${formatLineageRatio(manifest.context_ratio)}</div>
                 </div>
               </div>
               <div class="mt-3 flex flex-wrap gap-2">
                 ${delta
                   ? html`
-                    <span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">
+                    <span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--color-fg-muted)]">
                       inherited ${delta.inherited_fields.length}
                     </span>
-                    <span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">
+                    <span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--color-fg-muted)]">
                       changed ${delta.changed_fields.length}
                     </span>
-                    <span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">
+                    <span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--color-fg-muted)]">
                       dropped ${delta.dropped_fields.length}
                     </span>
                   `
                   : null}
                 ${continuity?.similarity != null
-                  ? html`<span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">similarity ${(continuity.similarity * 100).toFixed(1)}%</span>`
+                  ? html`<span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--color-fg-muted)]">similarity ${(continuity.similarity * 100).toFixed(1)}%</span>`
                   : null}
               </div>
               ${continuity?.verdict
-                ? html`<div class="mt-2 text-2xs text-[var(--text-dim)]">${continuityMeta.detail}</div>`
+                ? html`<div class="mt-2 text-2xs text-[var(--color-fg-disabled)]">${continuityMeta.detail}</div>`
                 : null}
               ${delta && delta.changed_fields.length === 0 && delta.dropped_fields.length === 0
-                ? html`<div class="mt-2 text-2xs text-[var(--text-dim)]">identity-only inheritance stayed intact across the rollover.</div>`
+                ? html`<div class="mt-2 text-2xs text-[var(--color-fg-disabled)]">identity-only inheritance stayed intact across the rollover.</div>`
                 : null}
             </div>
           `
           : html`
-            <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3 mb-3 text-2xs text-[var(--text-muted)]">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3 mb-3 text-2xs text-[var(--color-fg-muted)]">
               아직 handoff lineage manifest가 없습니다. generation 0에서는 현재 trace만 유지되고, 첫 successful handoff 이후부터 manifest/index가 생깁니다.
             </div>
           `}
 
         <div>
-          <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">최근 핸드오프</div>
-          <div class="text-2xs text-[var(--text-dim)] mb-2">Latest recorded rollover appears first so operators can compare the current trace against recent history.</div>
+          <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">최근 핸드오프</div>
+          <div class="text-2xs text-[var(--color-fg-disabled)] mb-2">Latest recorded rollover appears first so operators can compare the current trace against recent history.</div>
           ${recent.length > 0
             ? html`
               <div class="flex flex-col gap-2">
@@ -571,31 +571,31 @@ export function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
                   return html`
                     <div class=${`px-3 py-2 rounded border ${isLatest ? 'border-[var(--accent-22)] bg-[var(--accent-8)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}>
                       <div class="flex flex-wrap items-center gap-2">
-                        <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">gen ${entry.generation}</span>
+                        <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-15)]">gen ${entry.generation}</span>
                         ${isLatest
-                          ? html`<span class="text-3xs px-1.5 py-0.5 rounded border border-[var(--accent-18)] bg-[var(--accent-12)] text-[var(--accent)]">latest</span>`
+                          ? html`<span class="text-3xs px-1.5 py-0.5 rounded border border-[var(--accent-18)] bg-[var(--accent-12)] text-[var(--color-accent-fg)]">latest</span>`
                           : null}
                         ${entry.continuity_verdict
                           ? html`<span class="text-3xs px-1.5 py-0.5 rounded ${verdictBadgeClass(entry.continuity_verdict)}">${entryMeta.badgeLabel}</span>`
                           : null}
                         ${entry.created_at
-                          ? html`<span class="text-3xs text-[var(--text-dim)]"><${TimeAgo} timestamp=${entry.created_at} /></span>`
+                          ? html`<span class="text-3xs text-[var(--color-fg-disabled)]"><${TimeAgo} timestamp=${entry.created_at} /></span>`
                           : null}
                       </div>
-                      <div class="mt-1 text-2xs text-[var(--text-body)]">
+                      <div class="mt-1 text-2xs text-[var(--color-fg-primary)]">
                         ${lineageTransitionLabel(entry.parent_generation, entry.generation)}
                         ${entry.trigger_reason ? ` · ${entry.trigger_reason}` : ''}
                         ${entry.context_ratio != null ? ` · ratio ${formatLineageRatio(entry.context_ratio)}` : ''}
                       </div>
-                      <div class="mt-1 text-3xs font-mono text-[var(--text-dim)] truncate" title=${entry.trace_id}>
+                      <div class="mt-1 text-3xs font-mono text-[var(--color-fg-disabled)] truncate" title=${entry.trace_id}>
                         ${compactTraceId(entry.trace_id)}
                       </div>
                       ${entry.continuity_verdict
-                        ? html`<div class="mt-1 text-3xs text-[var(--text-dim)]">${entryMeta.detail}</div>`
+                        ? html`<div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">${entryMeta.detail}</div>`
                         : null}
                       ${(entry.identity_changed_fields?.length ?? 0) > 0 || (entry.identity_dropped_fields?.length ?? 0) > 0
                         ? html`
-                          <div class="mt-1 text-3xs text-[var(--text-dim)]">
+                          <div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">
                             ${entry.identity_changed_fields && entry.identity_changed_fields.length > 0 ? `changed: ${entry.identity_changed_fields.join(', ')}` : ''}
                             ${entry.identity_changed_fields && entry.identity_changed_fields.length > 0 && entry.identity_dropped_fields && entry.identity_dropped_fields.length > 0 ? ' · ' : ''}
                             ${entry.identity_dropped_fields && entry.identity_dropped_fields.length > 0 ? `dropped: ${entry.identity_dropped_fields.join(', ')}` : ''}
@@ -607,12 +607,12 @@ export function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
                 })}
               </div>
             `
-            : html`<div class="text-2xs text-[var(--text-muted)]">No recorded handoff entries yet.</div>`}
+            : html`<div class="text-2xs text-[var(--color-fg-muted)]">No recorded handoff entries yet.</div>`}
         </div>
 
         ${manifestPath || indexPath
           ? html`
-            <div class="mt-3 flex flex-col gap-1 text-3xs text-[var(--text-dim)]">
+            <div class="mt-3 flex flex-col gap-1 text-3xs text-[var(--color-fg-disabled)]">
               ${manifestPath ? html`<div class="font-mono truncate" title=${manifestPath}>manifest ${manifestPath}</div>` : null}
               ${indexPath ? html`<div class="font-mono truncate" title=${indexPath}>index ${indexPath}</div>` : null}
             </div>

--- a/dashboard/src/components/keeper-detail-panels.test.ts
+++ b/dashboard/src/components/keeper-detail-panels.test.ts
@@ -34,8 +34,8 @@ describe('ctxColor', () => {
   })
 
   it('returns critical color above 85', () => {
-    expect(ctxColor(86)).toBe('var(--bad)')
-    expect(ctxColor(100)).toBe('var(--bad)')
+    expect(ctxColor(86)).toBe('var(--color-status-err)')
+    expect(ctxColor(100)).toBe('var(--color-status-err)')
   })
 
   it('boundary at exactly 70', () => {

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -13,7 +13,7 @@ import type { Keeper, KeeperMetricPoint, PromptSegmentTelemetry } from '../types
 // ── Context pressure thresholds (shared across KPIs, charts) ─
 const CTX_CRITICAL_PCT = 85
 const CTX_WARN_PCT = 70
-const CTX_COLOR_CRITICAL = 'var(--bad)'
+const CTX_COLOR_CRITICAL = 'var(--color-status-err)'
 const CTX_COLOR_WARN = 'var(--amber-bright)'
 const CTX_COLOR_OK = 'var(--emerald)'
 
@@ -94,17 +94,17 @@ export function filterCtxCompositionEntries(
 type KpiTone = 'default' | 'ok' | 'warn' | 'bad'
 
 const KPI_TONE: Record<KpiTone, string> = {
-  default: 'border-[var(--card-border)] bg-[var(--white-3)]',
+  default: 'border-[var(--color-border-default)] bg-[var(--white-3)]',
   ok: 'border-[var(--ok-20)] bg-[var(--ok-6)]',
   warn: 'border-[var(--warn-20)] bg-[var(--warn-8)]',
   bad: 'border-[var(--bad-20)] bg-[var(--bad-6)]',
 }
 
 const KPI_VALUE_TONE: Record<KpiTone, string> = {
-  default: 'text-[var(--text-strong)]',
-  ok: 'text-[var(--ok)]',
-  warn: 'text-[var(--warn)]',
-  bad: 'text-[var(--bad)]',
+  default: 'text-[var(--color-fg-secondary)]',
+  ok: 'text-[var(--color-status-ok)]',
+  warn: 'text-[var(--color-status-warn)]',
+  bad: 'text-[var(--color-status-err)]',
 }
 
 const KPI_ICON: Record<string, string> = {
@@ -130,7 +130,7 @@ function KpiCard({ label, value, hint, tone = 'default', progress }: {
   return html`
     <div class="p-3.5 rounded border ${KPI_TONE[tone]} flex flex-col gap-1.5 transition-colors">
       <div class="flex items-center justify-between">
-        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">${label}</span>
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">${label}</span>
         ${icon ? html`<span class="text-2xs opacity-60">${icon}</span>` : null}
       </div>
       <div class="text-2xl font-bold ${KPI_VALUE_TONE[tone]} tabular-nums leading-none">${value}</div>
@@ -139,7 +139,7 @@ function KpiCard({ label, value, hint, tone = 'default', progress }: {
           <div class="h-full rounded-sm transition-all duration-500" style="width:${Math.min(progress, 100)}%;background:${ctxColor(progress)}"></div>
         </div>
       ` : null}
-      ${hint ? html`<div class="text-3xs text-[var(--text-dim)] leading-snug">${hint}</div>` : null}
+      ${hint ? html`<div class="text-3xs text-[var(--color-fg-disabled)] leading-snug">${hint}</div>` : null}
     </div>
   `
 }
@@ -164,32 +164,32 @@ function OperationalHealth({ keeper }: { keeper: Keeper }) {
   if (!hasAny) return null
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] p-3">
-      <div class="mb-2 text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)]">운영 건강도</div>
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-2)] p-3">
+      <div class="mb-2 text-3xs font-semibold tracking-1 uppercase text-[var(--color-fg-muted)]">운영 건강도</div>
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
         ${hb ? html`
           <div class="p-2 rounded border ${KPI_TONE[hbTone]} flex flex-col gap-0.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">하트비트</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">하트비트</span>
             <span class="text-xs font-mono ${KPI_VALUE_TONE[hbTone]}">${hb.replace('T', ' ').slice(0, 19)}</span>
           </div>
         ` : null}
         ${compSavedRatio != null ? html`
           <div class="p-2 rounded border ${KPI_TONE[compTone]} flex flex-col gap-0.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">압축 절감률</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">압축 절감률</span>
             <span class="text-sm font-mono tabular-nums ${KPI_VALUE_TONE[compTone]}">${(compSavedRatio * 100).toFixed(1)}%</span>
-            ${avgSaved != null ? html`<span class="text-3xs text-[var(--text-dim)]">avg ${formatTokens(avgSaved)} saved</span>` : null}
+            ${avgSaved != null ? html`<span class="text-3xs text-[var(--color-fg-disabled)]">avg ${formatTokens(avgSaved)} saved</span>` : null}
           </div>
         ` : null}
         ${dropRatio != null ? html`
           <div class="p-2 rounded border ${KPI_TONE[dropTone]} flex flex-col gap-0.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">메모리 손실률</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">메모리 손실률</span>
             <span class="text-sm font-mono tabular-nums ${KPI_VALUE_TONE[dropTone]}">${(dropRatio * 100).toFixed(1)}%</span>
           </div>
         ` : null}
         ${lastCompAgo != null ? html`
           <div class="p-2 rounded border ${KPI_TONE['default']} flex flex-col gap-0.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">마지막 압축</span>
-            <span class="text-xs font-mono text-[var(--text-strong)]">${formatDuration(lastCompAgo)} 전</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">마지막 압축</span>
+            <span class="text-xs font-mono text-[var(--color-fg-secondary)]">${formatDuration(lastCompAgo)} 전</span>
           </div>
         ` : null}
       </div>
@@ -235,44 +235,44 @@ function OutcomesLedger({ keeper, outcomes }: {
   const verdictTotal = verdicts.pass + verdicts.fail + verdicts.unknown
   const passRatePct = verdictTotal > 0 ? Math.round((verdicts.pass / verdictTotal) * 100) : null
   const passBarColor =
-    passRatePct == null ? 'var(--text-dim)'
-    : passRatePct >= 90 ? 'var(--ok)'
-    : passRatePct >= 70 ? 'var(--warn)'
-    : 'var(--bad)'
+    passRatePct == null ? 'var(--color-fg-disabled)'
+    : passRatePct >= 90 ? 'var(--color-status-ok)'
+    : passRatePct >= 70 ? 'var(--color-status-warn)'
+    : 'var(--color-status-err)'
 
   return html`
     <div class="flex flex-col gap-3">
       ${'' /* Row 1 — Success / Failure Ledger */}
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-2">
         <div class="flex items-baseline justify-between gap-2 mb-1.5">
-          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">성공/실패 (최근 ${observed_turns}턴)</span>
-          <span class="text-3xs text-[var(--text-dim)]">${ledgerTotal > 0 ? `합계 ${ledgerTotal}` : '관측 없음'}</span>
+          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">성공/실패 (최근 ${observed_turns}턴)</span>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">${ledgerTotal > 0 ? `합계 ${ledgerTotal}` : '관측 없음'}</span>
         </div>
         <div class="flex items-center gap-3 text-xs">
-          <span class="tabular-nums"><span class="text-[var(--ok)]">✅</span> ${successes.substantive_turns} 성공</span>
-          <span class="tabular-nums"><span class="text-[var(--warn)]">⚠️</span> ${failures.turn_failed} 실패</span>
-          <span class="tabular-nums"><span class="text-[var(--bad)]">🚫</span> ${failures.gate_rejected} 거절</span>
+          <span class="tabular-nums"><span class="text-[var(--color-status-ok)]">✅</span> ${successes.substantive_turns} 성공</span>
+          <span class="tabular-nums"><span class="text-[var(--color-status-warn)]">⚠️</span> ${failures.turn_failed} 실패</span>
+          <span class="tabular-nums"><span class="text-[var(--color-status-err)]">🚫</span> ${failures.gate_rejected} 거절</span>
         </div>
         <div class="mt-2 w-full h-1.5 bg-[var(--white-6)] rounded-sm overflow-hidden flex" aria-label="성공/실패 비율 바">
-          <div class="h-full bg-[var(--ok)]" style="width:${pctSuccess}%" title=${`성공 ${pctSuccess.toFixed(0)}%`}></div>
-          <div class="h-full bg-[var(--warn)]" style="width:${pctFail}%" title=${`실패 ${pctFail.toFixed(0)}%`}></div>
-          <div class="h-full bg-[var(--bad)]" style="width:${pctReject}%" title=${`거절 ${pctReject.toFixed(0)}%`}></div>
+          <div class="h-full bg-[var(--color-status-ok)]" style="width:${pctSuccess}%" title=${`성공 ${pctSuccess.toFixed(0)}%`}></div>
+          <div class="h-full bg-[var(--color-status-warn)]" style="width:${pctFail}%" title=${`실패 ${pctFail.toFixed(0)}%`}></div>
+          <div class="h-full bg-[var(--color-status-err)]" style="width:${pctReject}%" title=${`거절 ${pctReject.toFixed(0)}%`}></div>
         </div>
         ${(successes.compactions_ok > 0 || successes.handoffs_ok > 0 || failures.compaction_failed > 0 || failures.handoff_failed > 0) ? html`
           <div class="mt-2 flex flex-wrap gap-1.5 text-3xs">
-            ${successes.compactions_ok > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-6)] text-[var(--ok)]">압축 ${successes.compactions_ok}</span>` : null}
-            ${failures.compaction_failed > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--bad-20)] bg-[var(--bad-6)] text-[var(--bad)]">압축 실패 ${failures.compaction_failed}</span>` : null}
-            ${successes.handoffs_ok > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-6)] text-[var(--ok)]">인계 ${successes.handoffs_ok}</span>` : null}
-            ${failures.handoff_failed > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--bad-20)] bg-[var(--bad-6)] text-[var(--bad)]">인계 실패 ${failures.handoff_failed}</span>` : null}
+            ${successes.compactions_ok > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-6)] text-[var(--color-status-ok)]">압축 ${successes.compactions_ok}</span>` : null}
+            ${failures.compaction_failed > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--bad-20)] bg-[var(--bad-6)] text-[var(--color-status-err)]">압축 실패 ${failures.compaction_failed}</span>` : null}
+            ${successes.handoffs_ok > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-6)] text-[var(--color-status-ok)]">인계 ${successes.handoffs_ok}</span>` : null}
+            ${failures.handoff_failed > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--bad-20)] bg-[var(--bad-6)] text-[var(--color-status-err)]">인계 실패 ${failures.handoff_failed}</span>` : null}
           </div>
         ` : null}
       </div>
 
       ${'' /* Row 2 — Validator Pass Rate */}
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-2">
         <div class="flex items-baseline justify-between gap-2 mb-1.5">
-          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">검증자 (OAS verdict)</span>
-          <span class="text-3xs text-[var(--text-dim)]">
+          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">검증자 (OAS verdict)</span>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">
             ${verdictTotal > 0 ? `${verdicts.pass}/${verdictTotal} pass` : 'verdict 없음'}
           </span>
         </div>
@@ -285,40 +285,40 @@ function OutcomesLedger({ keeper, outcomes }: {
           </div>
           ${verdicts.top_failure_reasons.length > 0 ? html`
             <div class="mt-2 flex flex-wrap gap-1.5 text-3xs">
-              <span class="text-[var(--text-dim)]">주요 실패 원인:</span>
+              <span class="text-[var(--color-fg-disabled)]">주요 실패 원인:</span>
               ${verdicts.top_failure_reasons.map(reason => html`
-                <span class="px-2 py-0.5 rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] font-mono text-[var(--text-body)]">${reason}</span>
+                <span class="px-2 py-0.5 rounded-sm border border-[var(--color-border-default)] bg-[var(--white-4)] font-mono text-[var(--color-fg-primary)]">${reason}</span>
               `)}
             </div>
           ` : null}
           ${validation.cdal_gate ? html`
-            <div class="mt-2 flex flex-wrap gap-3 text-2xs text-[var(--text-body)]">
-              <span class="tabular-nums">CDAL pass <span class="font-semibold text-[var(--ok)]">${validation.cdal_gate.pass}</span></span>
-              <span class="tabular-nums">reject <span class="font-semibold text-[var(--bad)]">${validation.cdal_gate.reject}</span></span>
+            <div class="mt-2 flex flex-wrap gap-3 text-2xs text-[var(--color-fg-primary)]">
+              <span class="tabular-nums">CDAL pass <span class="font-semibold text-[var(--color-status-ok)]">${validation.cdal_gate.pass}</span></span>
+              <span class="tabular-nums">reject <span class="font-semibold text-[var(--color-status-err)]">${validation.cdal_gate.reject}</span></span>
               ${validation.cdal_gate.pending_verification > 0 ? html`
-                <span class="tabular-nums">검증 대기 <span class="font-semibold text-[var(--warn)]">${validation.cdal_gate.pending_verification}</span></span>
+                <span class="tabular-nums">검증 대기 <span class="font-semibold text-[var(--color-status-warn)]">${validation.cdal_gate.pending_verification}</span></span>
               ` : null}
             </div>
           ` : null}
         ` : html`
-          <div class="text-2xs text-[var(--text-dim)] leading-snug">
+          <div class="text-2xs text-[var(--color-fg-disabled)] leading-snug">
             이 키퍼에 대해 기록된 OAS verdict가 아직 없습니다.
           </div>
         `}
       </div>
 
       ${'' /* Row 3 — Resilience Profile */}
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-2">
         <div class="flex items-baseline justify-between gap-2 mb-1.5">
-          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">회복력</span>
-          <span class="text-3xs text-[var(--text-dim)]">supervisor 이력</span>
+          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">회복력</span>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">supervisor 이력</span>
         </div>
         <div class="flex flex-wrap gap-1.5 text-2xs">
-          <span class="px-2 py-0.5 rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] tabular-nums">세대 ${keeper.generation ?? '-'}</span>
-          <span class=${`px-2 py-0.5 rounded-sm tabular-nums ${failures.crashes > 0 ? 'border border-[var(--bad-20)] bg-[var(--bad-6)] text-[var(--bad)]' : 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)]'}`}>크래시 ${failures.crashes}회</span>
-          <span class=${`px-2 py-0.5 rounded-sm tabular-nums ${failures.restarts > 0 ? 'border border-[var(--warn-20)] bg-[var(--warn-8)] text-[var(--warn)]' : 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)]'}`}>재시작 ${failures.restarts}회</span>
+          <span class="px-2 py-0.5 rounded-sm border border-[var(--color-border-default)] bg-[var(--white-4)] tabular-nums">세대 ${keeper.generation ?? '-'}</span>
+          <span class=${`px-2 py-0.5 rounded-sm tabular-nums ${failures.crashes > 0 ? 'border border-[var(--bad-20)] bg-[var(--bad-6)] text-[var(--color-status-err)]' : 'border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)]'}`}>크래시 ${failures.crashes}회</span>
+          <span class=${`px-2 py-0.5 rounded-sm tabular-nums ${failures.restarts > 0 ? 'border border-[var(--warn-20)] bg-[var(--warn-8)] text-[var(--color-status-warn)]' : 'border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)]'}`}>재시작 ${failures.restarts}회</span>
           ${failures.consecutive_fail_current > 0 ? html`
-            <span class="px-2 py-0.5 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-8)] text-[var(--warn)] tabular-nums">연속 실패 ${failures.consecutive_fail_current}</span>
+            <span class="px-2 py-0.5 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-8)] text-[var(--color-status-warn)] tabular-nums">연속 실패 ${failures.consecutive_fail_current}</span>
           ` : null}
         </div>
       </div>
@@ -346,10 +346,10 @@ function KpiSection({ title, question, children }: {
   children: unknown
 }) {
   return html`
-    <section class="rounded border border-[var(--card-border)] bg-[var(--white-2)] p-3">
+    <section class="rounded border border-[var(--color-border-default)] bg-[var(--white-2)] p-3">
       <header class="mb-2 flex items-baseline justify-between gap-2">
-        <h3 class="text-2xs font-semibold tracking-1 uppercase text-[var(--text-muted)]">${title}</h3>
-        <span class="text-3xs text-[var(--text-dim)] truncate">${question}</span>
+        <h3 class="text-2xs font-semibold tracking-1 uppercase text-[var(--color-fg-muted)]">${title}</h3>
+        <span class="text-3xs text-[var(--color-fg-disabled)] truncate">${question}</span>
       </header>
       ${children}
     </section>
@@ -428,14 +428,14 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
           </div>
           <${OperationalHealth} keeper=${keeper} />
           ${totalCalls > 0 ? html`
-            <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] p-3">
-              <div class="mb-2 text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)]">모델 호출 분포</div>
+            <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] p-3">
+              <div class="mb-2 text-3xs font-semibold tracking-1 uppercase text-[var(--color-fg-muted)]">모델 호출 분포</div>
               <div class="flex flex-col gap-1.5">
                 ${modelEntries.slice(0, 4).map(([model, count]) => {
                   const pct = Math.round((count / totalCalls) * 100)
                   return html`
                     <div class="flex items-center gap-2 text-xs">
-                      <span class="shrink-0 w-35 truncate font-mono text-2xs text-[var(--accent)]" title=${model}>${model}</span>
+                      <span class="shrink-0 w-35 truncate font-mono text-2xs text-[var(--color-accent-fg)]" title=${model}>${model}</span>
                       <${ProgressBar}
                         pct=${pct}
                         size="sm"
@@ -443,13 +443,13 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
                         trackTone="dim"
                         trackClass="flex-1"
                       />
-                      <span class="shrink-0 w-10 text-right text-[var(--text-muted)]">${count}회</span>
+                      <span class="shrink-0 w-10 text-right text-[var(--color-fg-muted)]">${count}회</span>
                     </div>
                   `
                 })}
               </div>
               ${modelEntries.length > 4 ? html`
-                <div class="mt-1 text-3xs text-[var(--text-muted)]">외 ${modelEntries.length - 4}개 모델</div>
+                <div class="mt-1 text-3xs text-[var(--color-fg-muted)]">외 ${modelEntries.length - 4}개 모델</div>
               ` : null}
             </div>
           ` : null}
@@ -485,7 +485,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
 
       <${KpiSection} title="결과" question="무엇을 해냈고 실패했고 검증을 통과했나?">
         ${outcomes ? html`<${OutcomesLedger} keeper=${keeper} outcomes=${outcomes} />` : html`
-          <div class="text-2xs text-[var(--text-dim)] leading-snug">
+          <div class="text-2xs text-[var(--color-fg-disabled)] leading-snug">
             outcomes 집계를 불러오는 중이거나, 이 키퍼는 아직 관찰된 전이가 없습니다.
           </div>
         `}
@@ -508,11 +508,11 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
     const pct = ((keeper.context_ratio ?? keeper.context?.context_ratio ?? 0) * 100)
     const color = ctxColor(pct)
     return html`
-      <div class="flex items-center gap-3 mb-5 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+      <div class="flex items-center gap-3 mb-5 p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
         <div class="flex-1 h-2 bg-[var(--white-6)] rounded-sm overflow-hidden">
           <div class="h-full rounded-sm transition-all duration-300" style="width:${pct.toFixed(1)}%;background:${color}"></div>
         </div>
-        <span class="text-sm font-semibold tabular-nums text-[var(--text-strong)]">${pct.toFixed(1)}%</span>
+        <span class="text-sm font-semibold tabular-nums text-[var(--color-fg-secondary)]">${pct.toFixed(1)}%</span>
       </div>`
   }
 
@@ -528,13 +528,13 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
   const lineColor = ctxColor(lastRatio)
 
   return html`
-    <div class="flex items-center gap-3 mb-5 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+    <div class="flex items-center gap-3 mb-5 p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded" style="background:var(--bg-deepest);">
         <line x1="${pad}" y1="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
         <line x1="${pad}" y1="${(H - pad - (CTX_WARN_PCT / 100) * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - (CTX_WARN_PCT / 100) * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
         <line x1="${pad}" y1="${(H - pad - (CTX_CRITICAL_PCT / 100) * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - (CTX_CRITICAL_PCT / 100) * (H - 2 * pad)).toFixed(1)}" stroke="${CTX_COLOR_WARN}" stroke-dasharray="3,3" stroke-width="0.5"/>
         ${pts.filter(({ p }) => p.is_handoff).map(({ x }) => html`
-          <line x1="${x.toFixed(1)}" y1="${pad}" x2="${x.toFixed(1)}" y2="${H - pad}" stroke="var(--bad)" stroke-width="1.5" opacity="0.7"/>
+          <line x1="${x.toFixed(1)}" y1="${pad}" x2="${x.toFixed(1)}" y2="${H - pad}" stroke="var(--color-status-err)" stroke-width="1.5" opacity="0.7"/>
         `)}
         <polyline points="${polyline}" fill="none" stroke="${lineColor}" stroke-width="1.5"/>
         ${pts.filter(({ p }) => p.is_compaction).map(({ x, y, p }) => {
@@ -548,7 +548,7 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
           `
         })}
       </svg>
-      <span class="text-sm font-semibold tabular-nums text-[var(--text-strong)]">${lastRatio.toFixed(1)}%</span>
+      <span class="text-sm font-semibold tabular-nums text-[var(--color-fg-secondary)]">${lastRatio.toFixed(1)}%</span>
     </div>`
 }
 
@@ -595,33 +595,33 @@ export function TokenTrendChart({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="mb-5">
       <div class="flex items-center gap-2 mb-2">
-        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">턴 토큰 추세</span>
-        <span class="text-3xs text-[var(--text-dim)]">${points.length} turns</span>
+        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">턴 토큰 추세</span>
+        <span class="text-3xs text-[var(--color-fg-disabled)]">${points.length} turns</span>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
         ${'' /* Dual-line chart: input (cyan) + output (green) */}
-        <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
           <div class="flex items-center gap-4 mb-1.5">
-            <span class="flex items-center gap-1 text-3xs text-[var(--text-muted)]">
+            <span class="flex items-center gap-1 text-3xs text-[var(--color-fg-muted)]">
               <span class="inline-block w-2.5 h-0.5 rounded bg-[#67e8f9]"></span> input
               <span class="font-mono text-[var(--cyan)]">${formatTokens(lastInput)}</span>
             </span>
-            <span class="flex items-center gap-1 text-3xs text-[var(--text-muted)]">
-              <span class="inline-block w-2.5 h-0.5 rounded bg-[var(--ok)]"></span> output
+            <span class="flex items-center gap-1 text-3xs text-[var(--color-fg-muted)]">
+              <span class="inline-block w-2.5 h-0.5 rounded bg-[var(--color-status-ok)]"></span> output
               <span class="font-mono text-[var(--good)]">${formatTokens(lastOutput)}</span>
             </span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
             ${inputLine ? html`<polyline points="${inputLine}" fill="none" stroke="#67e8f9" stroke-width="1.5" opacity="0.8"/>` : null}
-            ${outputLine ? html`<polyline points="${outputLine}" fill="none" stroke="var(--ok)" stroke-width="1.5" opacity="0.8"/>` : null}
+            ${outputLine ? html`<polyline points="${outputLine}" fill="none" stroke="var(--color-status-ok)" stroke-width="1.5" opacity="0.8"/>` : null}
           </svg>
         </div>
 
         ${'' /* Input/Output ratio */}
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">In/Out 비율</span>
-          <span class="text-lg font-mono tabular-nums text-[var(--accent)]">${avgRatio.toFixed(1)}x</span>
-          <span class="text-3xs text-[var(--text-dim)]">${avgRatio > 10 ? '프롬프트 비대 주의' : avgRatio > 5 ? '프롬프트 무거움' : '정상 범위'}</span>
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">In/Out 비율</span>
+          <span class="text-lg font-mono tabular-nums text-[var(--color-accent-fg)]">${avgRatio.toFixed(1)}x</span>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">${avgRatio > 10 ? '프롬프트 비대 주의' : avgRatio > 5 ? '프롬프트 무거움' : '정상 범위'}</span>
         </div>
       </div>
     </div>
@@ -676,25 +676,25 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="mb-5">
       <div class="flex items-center gap-2 mb-2">
-        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">프롬프트 핑거프린트</span>
-        <span class="text-3xs text-[var(--text-dim)]">${promptPoints.length}개 스냅샷</span>
+        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">프롬프트 핑거프린트</span>
+        <span class="text-3xs text-[var(--color-fg-disabled)]">${promptPoints.length}개 스냅샷</span>
         ${latest?.prompt_fingerprint
           ? html`<span class="inline-flex items-center gap-1">
-              <span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono" title=${latest.prompt_fingerprint}>${formatFingerprint(latest.prompt_fingerprint)}</span>
+              <span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--color-fg-disabled)] font-mono" title=${latest.prompt_fingerprint}>${formatFingerprint(latest.prompt_fingerprint)}</span>
               <${CopyIdButton} value=${latest.prompt_fingerprint} label="fingerprint" size=${10} />
             </span>`
           : null}
       </div>
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
-        <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">estimated prompt tokens</span>
-            <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">estimated prompt tokens</span>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
             ${totalLine ? html`<polyline points="${totalLine}" fill="none" stroke="var(--amber-bright)" stroke-width="1.5"/>` : null}
           </svg>
-          <div class="mt-1 flex flex-wrap gap-2 text-3xs text-[var(--text-dim)]">
+          <div class="mt-1 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-disabled)]">
             <span>latest ${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
             <span>cacheable ${latestCacheable != null ? formatTokens(latestCacheable) : '-'}</span>
             ${cacheableRatio != null ? html`<span>${Math.round(cacheableRatio * 100)}% cacheable</span>` : null}
@@ -713,41 +713,41 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
           </div>
         </div>
 
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">fingerprint revisions</span>
-          <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${fingerprintTransitions}</span>
-          <span class="text-3xs text-[var(--text-dim)]">${uniqueFingerprintCount} unique</span>
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">fingerprint revisions</span>
+          <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${fingerprintTransitions}</span>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">${uniqueFingerprintCount} unique</span>
         </div>
 
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">latest fingerprint</span>
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">latest fingerprint</span>
           <div class="flex items-center gap-1.5">
-            <span class="text-sm font-mono break-all text-[var(--text-strong)]" title=${latest?.prompt_fingerprint ?? ''}>${latest?.prompt_fingerprint ? formatFingerprint(latest.prompt_fingerprint) : '-'}</span>
+            <span class="text-sm font-mono break-all text-[var(--color-fg-secondary)]" title=${latest?.prompt_fingerprint ?? ''}>${latest?.prompt_fingerprint ? formatFingerprint(latest.prompt_fingerprint) : '-'}</span>
             ${latest?.prompt_fingerprint ? html`<${CopyIdButton} value=${latest.prompt_fingerprint} label="fingerprint" size=${12} />` : null}
           </div>
-          <span class="text-3xs text-[var(--text-dim)]">${latestSegments.length} segments</span>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">${latestSegments.length} segments</span>
         </div>
       </div>
 
       ${latestSegments.length > 0 ? html`
         <div class="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
           ${latestSegments.map(([segmentKey, segment]) => html`
-            <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+            <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
               <div class="flex items-center justify-between gap-2 mb-2">
-                <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">${formatSegmentLabel(segmentKey)}</span>
+                <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">${formatSegmentLabel(segmentKey)}</span>
                 <span class="inline-flex items-center gap-1">
-                  <span class="text-3xs font-mono text-[var(--text-dim)]" title=${segment.fingerprint ?? ''}>${formatFingerprint(segment.fingerprint)}</span>
+                  <span class="text-3xs font-mono text-[var(--color-fg-disabled)]" title=${segment.fingerprint ?? ''}>${formatFingerprint(segment.fingerprint)}</span>
                   ${segment.fingerprint ? html`<${CopyIdButton} value=${segment.fingerprint} label="segment fingerprint" size=${10} />` : null}
                 </span>
               </div>
               <div class="grid grid-cols-2 gap-2 text-xs">
                 <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-2">
-                  <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">tokens</div>
-                  <div class="mt-1 font-mono tabular-nums text-[var(--accent)]">${formatTokens(segment.estimated_tokens)}</div>
+                  <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">tokens</div>
+                  <div class="mt-1 font-mono tabular-nums text-[var(--color-accent-fg)]">${formatTokens(segment.estimated_tokens)}</div>
                 </div>
                 <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-2">
-                  <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">bytes</div>
-                  <div class="mt-1 font-mono tabular-nums text-[var(--text-strong)]">${segment.bytes.toLocaleString()}</div>
+                  <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">bytes</div>
+                  <div class="mt-1 font-mono tabular-nums text-[var(--color-fg-secondary)]">${segment.bytes.toLocaleString()}</div>
                 </div>
               </div>
             </div>
@@ -804,14 +804,14 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="mb-5">
       <div class="flex items-center gap-2 mb-2">
-        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">CTX Composition</span>
-        <span class="text-3xs text-[var(--text-dim)]">${points.length} snapshots</span>
+        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">CTX Composition</span>
+        <span class="text-3xs text-[var(--color-fg-disabled)]">${points.length} snapshots</span>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
-        <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-2 gap-3">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">latest turn input</span>
-            <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${formatTokens(latestTotal)}</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">latest turn input</span>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${formatTokens(latestTotal)}</span>
           </div>
           <div class="h-3 rounded-sm overflow-hidden border border-[var(--white-8)] bg-[var(--white-2)] flex">
             ${latestEntries.map(([key, segment]) => {
@@ -822,7 +822,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
               ></div>`
             })}
           </div>
-          <div class="mt-2 flex flex-wrap gap-2 text-3xs text-[var(--text-dim)]">
+          <div class="mt-2 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-disabled)]">
             ${latestActual != null ? html`<span>actual ${formatTokens(latestActual)}</span>` : null}
             <span>known ${formatTokens(latestKnown)}</span>
             <span>${Math.round(knownRatio * 100)}% attributed</span>
@@ -830,26 +830,26 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           </div>
         </div>
 
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">largest bucket</span>
-          <span class="text-sm font-medium text-[var(--text-strong)]">${ctxSegmentLabel(latestEntries[0]?.[0] ?? 'unknown')}</span>
-          <span class="text-3xs font-mono text-[var(--text-dim)]">
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">largest bucket</span>
+          <span class="text-sm font-medium text-[var(--color-fg-secondary)]">${ctxSegmentLabel(latestEntries[0]?.[0] ?? 'unknown')}</span>
+          <span class="text-3xs font-mono text-[var(--color-fg-disabled)]">
             ${latestEntries[0] ? `${formatTokens(latestEntries[0][1].estimated_tokens)} · ${((latestEntries[0][1].estimated_tokens / latestTotal) * 100).toFixed(1)}%` : '-'}
           </span>
         </div>
 
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">residual</span>
-          <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${formatTokens(unattributedTokens)}</span>
-          <span class="text-3xs text-[var(--text-dim)]">tool schema / provider overhead / estimator gap</span>
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">residual</span>
+          <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${formatTokens(unattributedTokens)}</span>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">tool schema / provider overhead / estimator gap</span>
         </div>
       </div>
 
       <div class="mt-3 grid grid-cols-1 md:grid-cols-3 gap-3">
-        <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">stacked history</span>
-            <span class="text-3xs text-[var(--text-dim)]">${points.length} turns</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">stacked history</span>
+            <span class="text-3xs text-[var(--color-fg-disabled)]">${points.length} turns</span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
             ${points.map((point: KeeperMetricPoint, index: number) => {
@@ -875,10 +875,10 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           </svg>
         </div>
 
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between gap-2 mb-2">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">latest breakdown</span>
-            <span class="text-3xs font-mono text-[var(--text-dim)]">${visibleCtxEntries.length}/${latestEntries.length}</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">latest breakdown</span>
+            <span class="text-3xs font-mono text-[var(--color-fg-disabled)]">${visibleCtxEntries.length}/${latestEntries.length}</span>
           </div>
           <input
             type="search"
@@ -886,10 +886,10 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
             placeholder="세그먼트 필터 (예: history, memory)"
             aria-label="context composition 세그먼트 필터"
             onInput=${(e: Event) => { ctxCompositionSearch.value = (e.target as HTMLInputElement).value }}
-            class="mb-2 w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="mb-2 w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
           />
           ${visibleCtxEntries.length === 0 ? html`
-            <div class="py-4 text-center text-2xs text-[var(--text-dim)]">
+            <div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">
               필터 결과 없음 (${latestEntries.length} items)
             </div>
           ` : null}
@@ -900,9 +900,9 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
                 <div class="flex items-center justify-between gap-2 text-2xs">
                   <span class="inline-flex items-center gap-2 min-w-0">
                     <span class="inline-block w-2.5 h-2.5 rounded-full shrink-0" style=${`background:${ctxSegmentColor(key)};`}></span>
-                    <span class="truncate text-[var(--text-body)]">${ctxSegmentLabel(key)}</span>
+                    <span class="truncate text-[var(--color-fg-primary)]">${ctxSegmentLabel(key)}</span>
                   </span>
-                  <span class="font-mono tabular-nums text-[var(--text-dim)] whitespace-nowrap">
+                  <span class="font-mono tabular-nums text-[var(--color-fg-disabled)] whitespace-nowrap">
                     ${pct.toFixed(1)}% · ${formatTokens(segment.estimated_tokens)}
                   </span>
                 </div>
@@ -984,42 +984,42 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="mb-5">
       <div class="flex items-center gap-2 mb-2">
-        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">추론 텔레메트리</span>
-        <span class="text-3xs text-[var(--text-dim)]">${telemetryPoints.length}개 지점</span>
-        ${lastFp ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono">${lastFp}</span>` : null}
+        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">추론 텔레메트리</span>
+        <span class="text-3xs text-[var(--color-fg-disabled)]">${telemetryPoints.length}개 지점</span>
+        ${lastFp ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--color-fg-disabled)] font-mono">${lastFp}</span>` : null}
       </div>
       <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
         ${wallTokPerSec.length > 0 ? html`
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">wall tok/s</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">wall tok/s</span>
             <span class="text-xs font-mono tabular-nums text-[var(--good)]">${lastWallTps.toFixed(1)}</span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
-            ${wallTpsLine ? html`<polyline points="${wallTpsLine}" fill="none" stroke="var(--ok)" stroke-width="1.5"/>` : null}
+            ${wallTpsLine ? html`<polyline points="${wallTpsLine}" fill="none" stroke="var(--color-status-ok)" stroke-width="1.5"/>` : null}
           </svg>
-          <div class="text-3xs text-[var(--text-dim)] mt-1">avg ${avgWallTps.toFixed(1)}</div>
+          <div class="text-3xs text-[var(--color-fg-disabled)] mt-1">avg ${avgWallTps.toFixed(1)}</div>
         </div>
         ` : null}
 
         ${hwTokPerSec.length > 0 ? html`
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">hw tok/s</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">hw tok/s</span>
             <span class="text-xs font-mono tabular-nums text-[var(--good)]">${lastHwTps.toFixed(1)}</span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
-            ${hwTpsLine ? html`<polyline points="${hwTpsLine}" fill="none" stroke="var(--ok)" stroke-width="1.5"/>` : null}
+            ${hwTpsLine ? html`<polyline points="${hwTpsLine}" fill="none" stroke="var(--color-status-ok)" stroke-width="1.5"/>` : null}
           </svg>
-          <div class="text-3xs text-[var(--text-dim)] mt-1">avg ${avgHwTps.toFixed(1)} · decode-only</div>
+          <div class="text-3xs text-[var(--color-fg-disabled)] mt-1">avg ${avgHwTps.toFixed(1)} · decode-only</div>
         </div>
         ` : null}
 
         ${'' /* request latency */}
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">API latency</span>
-            <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">API latency</span>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
             ${latencyLine ? html`<polyline points="${latencyLine}" fill="none" stroke="#9ad9ff" stroke-width="1.5"/>` : null}
@@ -1027,17 +1027,17 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
         </div>
 
         ${'' /* cache hits */}
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">KV Cache</span>
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">KV Cache</span>
           <span class="text-lg font-mono tabular-nums text-[var(--purple)]">${totalCacheN > 0 ? totalCacheN.toLocaleString() : '-'}</span>
-          <span class="text-3xs text-[var(--text-dim)]">cumulative tokens</span>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">cumulative tokens</span>
         </div>
 
         ${'' /* reasoning tokens */}
-        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Reasoning</span>
-          <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${totalReasoning > 0 ? totalReasoning.toLocaleString() : '-'}</span>
-          <span class="text-3xs text-[var(--text-dim)]">total tokens</span>
+        <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">Reasoning</span>
+          <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${totalReasoning > 0 ? totalReasoning.toLocaleString() : '-'}</span>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">total tokens</span>
         </div>
       </div>
     </div>
@@ -1075,27 +1075,27 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-5">
       ${'' /* Latency + fallback markers */}
-      <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+      <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
         <div class="flex items-center justify-between mb-1.5">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">지연 시간</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">지연 시간</span>
           <span class="flex items-center gap-2">
-            ${fallbackCount > 0 ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--bad-soft)] text-[var(--bad)] font-mono">FB ${fallbackCount}</span>` : null}
-            <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
+            ${fallbackCount > 0 ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--bad-soft)] text-[var(--color-status-err)] font-mono">FB ${fallbackCount}</span>` : null}
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
           </span>
         </div>
         <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
           ${fallbackIndices.map((idx: number) => {
             const x = SPARKLINE_PAD + (idx / Math.max(n - 1, 1)) * (W - 2 * SPARKLINE_PAD)
-            return html`<line x1="${x.toFixed(1)}" y1="${SPARKLINE_PAD}" x2="${x.toFixed(1)}" y2="${H - SPARKLINE_PAD}" stroke="var(--bad)" stroke-width="1.5" opacity="0.6"/>`
+            return html`<line x1="${x.toFixed(1)}" y1="${SPARKLINE_PAD}" x2="${x.toFixed(1)}" y2="${H - SPARKLINE_PAD}" stroke="var(--color-status-err)" stroke-width="1.5" opacity="0.6"/>`
           })}
           ${latencyLine ? html`<polyline points="${latencyLine}" fill="none" stroke="#9ad9ff" stroke-width="1.5"/>` : null}
         </svg>
       </div>
 
       ${'' /* Cost */}
-      <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+      <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
         <div class="flex items-center justify-between mb-1.5">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">비용</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">비용</span>
           <span class="text-xs font-mono tabular-nums text-[var(--purple)]">$${totalCost.toFixed(4)}</span>
         </div>
         <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
@@ -1105,14 +1105,14 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
 
       ${'' /* Model timeline */}
       ${modelSwitches.length > 0 ? html`
-        <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">모델 전환</span>
-            <span class="text-3xs text-[var(--text-dim)]">${modelSwitches.length}회</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">모델 전환</span>
+            <span class="text-3xs text-[var(--color-fg-disabled)]">${modelSwitches.length}회</span>
           </div>
           <div class="flex flex-wrap gap-1.5">
             ${modelSwitches.map(s => html`
-              <span class="text-3xs px-2 py-0.5 rounded-sm bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)] font-mono">
+              <span class="text-3xs px-2 py-0.5 rounded-sm bg-[var(--warn-10)] text-[var(--color-status-warn)] border border-[var(--warn-20)] font-mono">
                 T${s.index} -> ${s.model.length > MODEL_NAME_MAX_LEN ? s.model.slice(0, MODEL_NAME_MAX_LEN) + '...' : s.model}
               </span>
             `)}
@@ -1124,12 +1124,12 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
       ${fallbackCount > 0 ? html`
         <div class="md:col-span-2 p-3 rounded border border-[var(--bad-20)] bg-[var(--bad-6)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">캐스케이드 폴백</span>
-            <span class="text-3xs text-[var(--bad)]">${fallbackCount}회</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">캐스케이드 폴백</span>
+            <span class="text-3xs text-[var(--color-status-err)]">${fallbackCount}회</span>
           </div>
           <div class="flex flex-wrap gap-1.5">
             ${series.filter((p: KeeperMetricPoint) => p.fallback_applied).slice(-10).map((p: KeeperMetricPoint) => html`
-              <span class="text-3xs px-2 py-0.5 rounded-sm bg-[var(--bad-10)] text-[var(--bad)] border border-[var(--bad-20)] font-mono">
+              <span class="text-3xs px-2 py-0.5 rounded-sm bg-[var(--bad-10)] text-[var(--color-status-err)] border border-[var(--bad-20)] font-mono">
                 ${p.fallback_from ?? '?'} -> ${p.fallback_to ?? p.model_used}${p.fallback_reason ? ` (${p.fallback_reason.length > 20 ? p.fallback_reason.slice(0, 20) + '...' : p.fallback_reason})` : ''}
               </span>
             `)}
@@ -1201,15 +1201,15 @@ export function RawDataDebug({ keeper }: { keeper: Keeper }) {
       <div class="flex flex-col">
         ${filtered.map((f, i) => html`
           <div class="grid grid-cols-[100px_80px_1fr] gap-2 py-2 px-2 text-xs rounded ${i % 2 === 0 ? 'bg-[var(--white-2)]' : ''}">
-            <span class="font-semibold text-[var(--text-body)] truncate">${f.title}</span>
+            <span class="font-semibold text-[var(--color-fg-primary)] truncate">${f.title}</span>
             <span class="font-mono text-[var(--cyan)] text-2xs truncate">${f.key}</span>
-            <span class="text-right text-[var(--text-body)] truncate">${f.value}</span>
+            <span class="text-right text-[var(--color-fg-primary)] truncate">${f.value}</span>
           </div>
         `)}
         ${extras.map((f, i) => html`
           <div class="grid grid-cols-[100px_1fr] gap-2 py-2 px-2 text-xs rounded ${(filtered.length + i) % 2 === 0 ? 'bg-[var(--white-2)]' : ''}">
-            <span class="font-semibold text-[var(--text-body)] truncate">${f.title}</span>
-            <span class="text-right text-[var(--text-body)] truncate ${f.mono ? 'font-mono' : ''}">${f.value}</span>
+            <span class="font-semibold text-[var(--color-fg-primary)] truncate">${f.title}</span>
+            <span class="text-right text-[var(--color-fg-primary)] truncate ${f.mono ? 'font-mono' : ''}">${f.value}</span>
           </div>
         `)}
       </div>
@@ -1220,13 +1220,13 @@ export function RawDataDebug({ keeper }: { keeper: Keeper }) {
 // ── Equipment, Relationships, Traits ───────────────
 
 export function EquipmentList({ items }: { items: string[] }) {
-  if (items.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">장비 없음</div>`
+  if (items.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--color-fg-muted)] italic">장비 없음</div>`
 
   return html`
     <div class="flex flex-col gap-1.5">
       ${items.map((item, i) => html`
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--text-body)]">${item}</span>
+          <span class="text-xs text-[var(--color-fg-primary)]">${item}</span>
           <span class="text-3xs text-[var(--cyan)] font-mono">#${i + 1}</span>
         </div>
       `)}
@@ -1236,14 +1236,14 @@ export function EquipmentList({ items }: { items: string[] }) {
 
 export function RelationshipList({ rels }: { rels: Record<string, string> }) {
   const entries = Object.entries(rels)
-  if (entries.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">관계 없음</div>`
+  if (entries.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--color-fg-muted)] italic">관계 없음</div>`
 
   return html`
     <div class="max-h-55 overflow-y-auto flex flex-col gap-1.5">
       ${entries.map(([name, relation]) => html`
         <div class="flex items-center gap-2 py-2 px-3 bg-[var(--white-3)] rounded">
-          <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-2xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${name}</span>
-          <span class="text-2xs text-[var(--text-muted)] font-mono">${relation}</span>
+          <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-2xs font-medium bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-30)]">${name}</span>
+          <span class="text-2xs text-[var(--color-fg-muted)] font-mono">${relation}</span>
         </div>
       `)}
     </div>
@@ -1255,9 +1255,9 @@ export function TraitsList({ traits, label }: { traits: string[]; label: string 
 
   return html`
     <div class="mb-3">
-      <div class="text-3xs text-[var(--text-muted)] uppercase tracking-wider font-semibold mb-2">${label}</div>
+      <div class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-wider font-semibold mb-2">${label}</div>
       <div class="flex flex-wrap gap-1.5">
-        ${traits.map(t => html`<span class="inline-flex items-center py-0.5 px-2.5 rounded-sm text-2xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${t}</span>`)}
+        ${traits.map(t => html`<span class="inline-flex items-center py-0.5 px-2.5 rounded-sm text-2xs font-medium bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-30)]">${t}</span>`)}
       </div>
     </div>
   `

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -55,8 +55,8 @@ export function resolveKeeperCurrentTaskLabel(
 function SignalRow({ label, value }: { label: string; value: string | number }) {
   return html`
     <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-      <span class="text-xs text-[var(--text-muted)]">${label}</span>
-      <span class="text-xs font-medium text-[var(--text-strong)]">${value}</span>
+      <span class="text-xs text-[var(--color-fg-muted)]">${label}</span>
+      <span class="text-xs font-medium text-[var(--color-fg-secondary)]">${value}</span>
     </div>
   `
 }
@@ -67,7 +67,7 @@ function ToolChip({ name }: { name: string }) {
   const cat = toolCategory(name)
   return html`
     <button type="button"
-      class="inline-flex items-center gap-1 py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)] hover:bg-[var(--accent-20)] cursor-pointer transition-colors"
+      class="inline-flex items-center gap-1 py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-30)] hover:bg-[var(--accent-20)] cursor-pointer transition-colors"
       title=${`${cat.label}: ${name}`}
       onClick=${() => openToolsInventory(name)}
     >
@@ -107,7 +107,7 @@ export function AllowlistPreview({
   }, [tools.length, firstTool, lastTool, previewLimit])
 
   if (tools.length === 0) {
-    return html`<span class="text-2xs text-[var(--text-muted)] italic">${emptyLabel}</span>`
+    return html`<span class="text-2xs text-[var(--color-fg-muted)] italic">${emptyLabel}</span>`
   }
 
   const { visibleTools, hiddenCount } = expanded
@@ -120,7 +120,7 @@ export function AllowlistPreview({
         ${visibleTools.map(tool => html`<${ToolChip} name=${tool} />`)}
         ${!expanded && hiddenCount > 0
           ? html`
-              <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium border border-dashed border-[var(--card-border)] text-[var(--text-muted)]">
+              <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium border border-dashed border-[var(--color-border-default)] text-[var(--color-fg-muted)]">
                 +${hiddenCount}
               </span>
             `
@@ -129,7 +129,7 @@ export function AllowlistPreview({
       ${tools.length > previewLimit
         ? html`
             <button type="button"
-              class="self-start text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+              class="self-start text-3xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer transition-colors"
               aria-expanded=${expanded}
               aria-label=${expanded ? '허용된 도구 접기' : `허용된 도구 나머지 ${hiddenCount}개 보기`}
               onClick=${() => setExpanded(value => !value)}
@@ -147,12 +147,12 @@ export function AllowlistPreview({
 function ToolSection({ title, description, tools, fallback }: { title: string; description?: string; tools: string[]; fallback: string }) {
   return html`
     <div class="flex flex-col gap-1.5 mt-3">
-      <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">${title}</span>
-      ${description ? html`<span class="text-2xs text-[var(--text-muted)] leading-snug">${description}</span>` : null}
+      <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">${title}</span>
+      ${description ? html`<span class="text-2xs text-[var(--color-fg-muted)] leading-snug">${description}</span>` : null}
       <div class="flex flex-wrap gap-1.5">
         ${tools.length > 0
           ? tools.map(tool => html`<${ToolChip} name=${tool} />`)
-          : html`<span class="text-2xs text-[var(--text-muted)] italic">${fallback}</span>`}
+          : html`<span class="text-2xs text-[var(--color-fg-muted)] italic">${fallback}</span>`}
       </div>
     </div>
   `
@@ -222,19 +222,19 @@ function BudgetRow({ label, slot, manifest, clamp }: {
     valueClass = 'text-[var(--bad-light)] underline decoration-wavy decoration-red-400 underline-offset-4 cursor-help'
     pill = html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid</span>`
   } else if (isOverride) {
-    valueClass = 'text-[var(--text-strong)] underline decoration-dotted decoration-amber-300/60 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
+    valueClass = 'text-[var(--color-fg-secondary)] underline decoration-dotted decoration-amber-300/60 underline-offset-4 cursor-help'
+    pill = html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--color-status-warn)]">override</span>`
   } else {
-    valueClass = 'text-[var(--text-muted)] cursor-help'
-    pill = html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`
+    valueClass = 'text-[var(--color-fg-muted)] cursor-help'
+    pill = html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wider text-[var(--color-fg-muted)]">env</span>`
   }
 
   return html`
     <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-      <span class="text-xs text-[var(--text-muted)]">${label}</span>
+      <span class="text-xs text-[var(--color-fg-muted)]">${label}</span>
       <div class="flex items-center gap-2">
         ${isOverride && deltaText
-          ? html`<span class="text-3xs text-[var(--text-muted)] tabular-nums">${deltaText}</span>`
+          ? html`<span class="text-3xs text-[var(--color-fg-muted)] tabular-nums">${deltaText}</span>`
           : null}
         <span
           class="text-xs font-medium tabular-nums ${valueClass}"
@@ -250,7 +250,7 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
   const budget = keeper.turn_budget
   if (!budget) {
     return html`
-      <div class="text-2xs text-[var(--text-muted)] italic">
+      <div class="text-2xs text-[var(--color-fg-muted)] italic">
         턴 예산 정보를 아직 수신하지 못했습니다. 서버 재시작 후 확인해주세요.
       </div>
     `
@@ -267,14 +267,14 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="flex flex-col gap-1.5">
       <div class="flex items-center gap-2 mb-1">
-        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">
           턴 예산 (OAS 호출당)
         </span>
         ${hasInvalid
           ? html`<span class="rounded-sm bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid override</span>`
           : hasOverride
-            ? html`<span class="rounded-sm bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
-            : html`<span class="rounded-sm bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wider text-[var(--ok)]">inherited</span>`}
+            ? html`<span class="rounded-sm bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--color-status-warn)]">override</span>`
+            : html`<span class="rounded-sm bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wider text-[var(--color-status-ok)]">inherited</span>`}
       </div>
       <${BudgetRow}
         label="반응형"
@@ -288,7 +288,7 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
         manifest=${budget.manifest_path}
         clamp=${clamp}
       />
-      <span class="text-2xs text-[var(--text-muted)] leading-snug mt-1">
+      <span class="text-2xs text-[var(--color-fg-muted)] leading-snug mt-1">
         반응형 = 보드/멘션 반응 턴 예산, 예약 자율 = 자율 주기 턴 예산.
         값에 마우스를 올리면 설정 출처와 기본값 비교를 확인할 수 있습니다.
       </span>
@@ -303,7 +303,7 @@ export function TurnBudgetSection({ keeper }: { keeper: Keeper }) {
       <summary class="cursor-pointer text-2xs font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full ${diverges ? 'bg-[var(--warn-10)]' : 'bg-accent/50'}"></span>
         턴 예산
-        ${diverges ? html`<span class="text-3xs text-[var(--warn)] font-normal normal-case tracking-normal">(재정의됨)</span>` : null}
+        ${diverges ? html`<span class="text-3xs text-[var(--color-status-warn)] font-normal normal-case tracking-normal">(재정의됨)</span>` : null}
       </summary>
       <div class="mt-3">
         <${TurnBudgetPanel} keeper=${keeper} />
@@ -453,7 +453,7 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
             <div class="flex items-center gap-2">
               <input
                 type="search"
-                class="flex-1 min-w-0 py-1.5 px-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-30)]"
+                class="flex-1 min-w-0 py-1.5 px-2 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)] focus:outline-none focus:border-[var(--accent-30)]"
                 placeholder="신호 지표 필터 (예: 폴백, 메모리, 컴팩션)"
                 aria-label="런타임 신호 지표 필터"
                 value=${signalQuery}
@@ -463,21 +463,21 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
                 }}
               />
               ${isFiltering
-                ? html`<span class="text-3xs text-[var(--text-muted)] tabular-nums whitespace-nowrap">${matchedRows}/${totalRows}</span>`
+                ? html`<span class="text-3xs text-[var(--color-fg-muted)] tabular-nums whitespace-nowrap">${matchedRows}/${totalRows}</span>`
                 : null}
             </div>
           `
         : null}
       ${showEmptyState
         ? html`
-            <div class="py-3 px-3 rounded border border-dashed border-[var(--card-border)] text-2xs text-[var(--text-muted)] italic">
+            <div class="py-3 px-3 rounded border border-dashed border-[var(--color-border-default)] text-2xs text-[var(--color-fg-muted)] italic">
               필터 결과 없음 (${totalRows} items)
             </div>
           `
         : null}
       ${filteredGroups.map(g => html`
         <div class="flex flex-col gap-1">
-          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] px-1">${g.title}</span>
+          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] px-1">${g.title}</span>
           <div class="flex flex-col gap-1">
             ${g.rows.map(r => html`<${SignalRow} label=${r.label} value=${r.value} />`)}
           </div>
@@ -606,7 +606,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
 
       <div class="flex justify-end mt-1">
         <button type="button"
-          class="py-1.5 px-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-default"
+          class="py-1.5 px-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs text-[var(--color-fg-muted)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-default"
           disabled=${!openToolsQuery}
           onClick=${() => { openToolsInventory(openToolsQuery) }}
         >
@@ -615,9 +615,9 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
       </div>
 
       <div class="flex items-center justify-between mt-3">
-        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">허용된 도구</span>
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">허용된 도구</span>
         <button type="button"
-          class="text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-default"
+          class="text-3xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-default"
           disabled=${!policyEditable}
           onClick=${() => {
             showAllowlistEditor.value = !showAllowlistEditor.value
@@ -642,7 +642,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
             }}
           />`
         : html`
-          <span class="text-2xs text-[var(--text-muted)] leading-snug">
+          <span class="text-2xs text-[var(--color-fg-muted)] leading-snug">
             ${policyLoading
               ? '정적 도구 정책을 불러오는 중입니다.'
               : policyEditable
@@ -666,8 +666,8 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
 
       <${SignalRow} label="도구 호출" value=${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback} />
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">감사</span>
-        <span class="text-xs font-medium text-[var(--text-strong)]">${auditSource ?? metadataFallback}${auditAt ? html` · <${TimeAgo} timestamp=${auditAt} />` : ''}</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">감사</span>
+        <span class="text-xs font-medium text-[var(--color-fg-secondary)]">${auditSource ?? metadataFallback}${auditAt ? html` · <${TimeAgo} timestamp=${auditAt} />` : ''}</span>
       </div>
 
     </div>

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -19,7 +19,7 @@ function KeeperModelChip({ keeper }: { keeper: Keeper }) {
   if (!display) return null
   return html`
     <span
-      class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-mono bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-20)]"
+      class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-mono bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-20)]"
       title=${`${display.label}: ${display.value}`}
     >${display.value}</span>
   `
@@ -32,8 +32,8 @@ function KeeperToolPresetChip({ keeperName }: { keeperName: string }) {
   return html`
     <span class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-semibold uppercase tracking-wide
       ${canPR
-        ? 'bg-[var(--ok-10)] text-[var(--ok)] border border-[var(--ok-20)]'
-        : 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
+        ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border border-[var(--ok-20)]'
+        : 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border border-[var(--white-8)]'
       }"
       title=${`Tool preset: ${preset}${canPR ? ' (clone/PR 가능)' : ''}`}
     >${preset}</span>
@@ -79,7 +79,7 @@ function KeeperCascadeSelector({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="flex items-center gap-1.5">
       <select
-        class="py-0.5 px-1 rounded text-3xs font-mono bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)] cursor-pointer"
+        class="py-0.5 px-1 rounded text-3xs font-mono bg-[var(--white-5)] text-[var(--color-fg-muted)] border border-[var(--white-8)] cursor-pointer"
         title=${invalidProfiles.length > 0
           ? `Cascade profile\n\nDisabled invalid presets:\n${invalidSummary}`
           : 'Cascade profile'}
@@ -135,16 +135,16 @@ export function KeeperDetailMissingState({
 }) {
   return html`
     <div class="mx-auto flex w-full max-w-[1100px] flex-col gap-4">
-      <div class="rounded-[28px] border border-[var(--card-border)] bg-[rgba(9,14,24,0.92)] px-6 py-6 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
-        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Keeper Detail</div>
-        <h2 class="m-0 mt-2 text-xl font-semibold text-[var(--text-strong)]">${keeperName}</h2>
+      <div class="rounded-[28px] border border-[var(--color-border-default)] bg-[rgba(9,14,24,0.92)] px-6 py-6 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
+        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">Keeper Detail</div>
+        <h2 class="m-0 mt-2 text-xl font-semibold text-[var(--color-fg-secondary)]">${keeperName}</h2>
         <p class="m-0 mt-2 text-sm leading-relaxed text-[var(--text-secondary)]">
           현재 스냅샷에서 keeper를 찾지 못했습니다. 목록으로 돌아가서 다시 선택하거나, 최신 dashboard refresh 이후 다시 열어 보세요.
         </p>
         <div class="mt-4">
           <button
             type="button"
-            class="inline-flex items-center gap-2 rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-4 py-2 text-sm font-medium text-[var(--text-strong)] transition-colors hover:bg-[var(--white-8)]"
+            class="inline-flex items-center gap-2 rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-4 py-2 text-sm font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--white-8)]"
             onClick=${onClose}
           >
             목록으로 돌아가기
@@ -171,23 +171,23 @@ export function KeeperDetailHeaderInfo({
       <button
         type="button"
         onClick=${onClose}
-        class="inline-flex shrink-0 items-center gap-2 rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-3.5 py-2 text-sm font-medium text-[var(--text-strong)] transition-colors hover:bg-[var(--white-8)]"
+        class="inline-flex shrink-0 items-center gap-2 rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-3.5 py-2 text-sm font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--white-8)]"
       >
         <span aria-hidden="true">←</span>
         목록
       </button>
       <div class="size-12 shrink-0 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-2xl">${keeper.emoji}</div>
       <div class="flex flex-col gap-0.5">
-        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Monitoring / Agents / Keeper Detail</div>
+        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">Monitoring / Agents / Keeper Detail</div>
         <div class="mt-1 flex flex-wrap items-center gap-2.5">
-          <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--text-strong)]">${keeper.name}</h2>
+          <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--color-fg-secondary)]">${keeper.name}</h2>
           <${KeeperPhaseAndStage} phase=${keeper.phase} pipelineStage=${keeper.pipeline_stage} phaseEnteredAtSec=${phaseEnteredAtSec} />
           <${KeeperModelChip} keeper=${keeper} />
           <${KeeperToolPresetChip} keeperName=${keeper.name} />
           <${KeeperCascadeSelector} keeper=${keeper} />
         </div>
         ${keeper.koreanName || keeper.created_at ? html`
-          <div class="flex flex-wrap items-center gap-2 text-xs text-[var(--text-muted)]">
+          <div class="flex flex-wrap items-center gap-2 text-xs text-[var(--color-fg-muted)]">
             ${keeper.koreanName ? html`<span>${keeper.koreanName}</span>` : null}
             ${keeper.created_at ? html`<span class="font-mono tabular-nums opacity-60"><${TimeAgo} timestamp=${keeper.created_at} /></span>` : null}
           </div>
@@ -255,8 +255,8 @@ function KeeperDetailQuickFact({
 }) {
   return html`
     <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] px-3.5 py-3">
-      <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">${label}</div>
-      <div class="mt-1 text-sm font-medium leading-snug text-[var(--text-strong)]">${children}</div>
+      <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">${label}</div>
+      <div class="mt-1 text-sm font-medium leading-snug text-[var(--color-fg-secondary)]">${children}</div>
     </div>
   `
 }
@@ -286,9 +286,9 @@ export function KeeperDetailOverviewSidebar({
 }) {
   return html`
     <aside class="order-2 xl:order-1 xl:sticky xl:top-[104px] xl:self-start">
-      <div class="flex flex-col gap-4 rounded-[28px] border border-[var(--card-border)] bg-[rgba(9,14,24,0.84)] p-4 shadow-[0_20px_48px_rgba(0,0,0,0.18)]">
+      <div class="flex flex-col gap-4 rounded-[28px] border border-[var(--color-border-default)] bg-[rgba(9,14,24,0.84)] p-4 shadow-[0_20px_48px_rgba(0,0,0,0.18)]">
         <div>
-          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Overview</div>
+          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">Overview</div>
           <p class="m-0 mt-2 text-sm leading-relaxed text-[var(--text-secondary)]">
             긴 단일 모달 대신 keeper 상세를 별도 화면으로 펼쳤습니다. 운영자가 자주 오가는 맥락 단위로 나눠서 바로 점프할 수 있습니다.
           </p>
@@ -304,7 +304,7 @@ export function KeeperDetailOverviewSidebar({
         </div>
 
         <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] p-3.5">
-          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">빠른 이동</div>
+          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">빠른 이동</div>
           <div class="mt-3 flex flex-col gap-2">
             ${KEEPER_DETAIL_SECTIONS.map((section) => html`
               <button
@@ -312,8 +312,8 @@ export function KeeperDetailOverviewSidebar({
                 class="rounded-2xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-left transition-colors hover:bg-[var(--white-6)]"
                 onClick=${() => scrollToKeeperDetailSection(section.id)}
               >
-                <div class="text-sm font-medium text-[var(--text-strong)]">${section.label}</div>
-                <div class="mt-1 text-2xs leading-relaxed text-[var(--text-muted)]">${section.summary}</div>
+                <div class="text-sm font-medium text-[var(--color-fg-secondary)]">${section.label}</div>
+                <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${section.summary}</div>
               </button>
             `)}
           </div>
@@ -339,13 +339,13 @@ export function KeeperDetailSection({
   return html`
     <section
       id=${id}
-      class="scroll-mt-24 rounded-[28px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(12,19,34,0.94),rgba(8,13,24,0.98))] shadow-[0_24px_48px_rgba(0,0,0,0.22)]"
+      class="scroll-mt-24 rounded-[28px] border border-[var(--color-border-default)] bg-[linear-gradient(180deg,rgba(12,19,34,0.94),rgba(8,13,24,0.98))] shadow-[0_24px_48px_rgba(0,0,0,0.22)]"
     >
       <div class="border-b border-[var(--white-8)] px-5 py-4 sm:px-6">
-        <div class="text-3xs font-semibold uppercase tracking-[0.22em] text-[var(--text-muted)]">${eyebrow}</div>
+        <div class="text-3xs font-semibold uppercase tracking-[0.22em] text-[var(--color-fg-muted)]">${eyebrow}</div>
         <div class="mt-1 flex flex-col gap-1 lg:flex-row lg:items-end lg:justify-between">
           <div>
-            <h3 class="m-0 text-lg font-semibold text-[var(--text-strong)]">${title}</h3>
+            <h3 class="m-0 text-lg font-semibold text-[var(--color-fg-secondary)]">${title}</h3>
             <p class="m-0 mt-1 text-sm leading-relaxed text-[var(--text-secondary)]">${description}</p>
           </div>
         </div>

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -254,7 +254,7 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
 
   const toneClass = keeper.paused || socialFallbackActive || runtimeBlocker || blocker || hbStale
     ? 'border-[var(--warn-24)] bg-[var(--warn-8)]'
-    : 'border-[var(--card-border)] bg-[var(--white-3)]'
+    : 'border-[var(--color-border-default)] bg-[var(--white-3)]'
   const runtimeBlockerLabel = runtimeBlockerClass
     ? {
         ambiguous_post_commit_timeout: '커밋 후 응답 없음',
@@ -270,12 +270,12 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
     : null
   const trustToneClass =
     trustDisposition === 'Alert'
-      ? 'bg-[var(--bad-soft)] text-[var(--bad)]'
+      ? 'bg-[var(--bad-soft)] text-[var(--color-status-err)]'
       : trustDisposition === 'Pause' || keeper.trust?.needs_attention
-        ? 'bg-[var(--warn-14)] text-[var(--warn)]'
+        ? 'bg-[var(--warn-14)] text-[var(--color-status-warn)]'
         : trustDisposition === 'Pass'
-          ? 'bg-[var(--ok-10)] text-[var(--ok)]'
-          : 'bg-[var(--white-6)] text-[var(--text-strong)]'
+          ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
+          : 'bg-[var(--white-6)] text-[var(--color-fg-secondary)]'
   const trustDispositionLabel = trustDisposition
     ? ({ Alert: '경보', Pause: '정지', Pass: '통과' } as Record<string, string>)[
         trustDisposition
@@ -284,23 +284,23 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="px-6 pt-4">
-      <div class="rounded border ${toneClass} px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-[var(--text-body)]">
+      <div class="rounded border ${toneClass} px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-[var(--color-fg-primary)]">
         ${keeper.paused
-          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">일시정지</span>
-            ${hasActivitySignal ? html`<span class="text-[var(--text-muted)]">${renderActivitySignal()}</span>` : null}
+          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--color-status-warn)]">일시정지</span>
+            ${hasActivitySignal ? html`<span class="text-[var(--color-fg-muted)]">${renderActivitySignal()}</span>` : null}
             <button
-              class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
+              class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--color-fg-secondary)] transition-colors disabled:opacity-50"
               disabled=${directiveLoading.value}
               onClick=${() => handleDirective('resume')}
             >재개</button>`
           : html`<button
-              class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
+              class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--color-fg-secondary)] transition-colors disabled:opacity-50"
               disabled=${directiveLoading.value}
               onClick=${() => handleDirective('pause')}
             >일시정지</button>
             ${(hbStale || runtimeBlockerClass === 'oas_timeout_budget' || runtimeBlockerClass === 'cascade_exhausted' || runtimeBlockerClass === 'turn_timeout')
               ? html`<button
-                  class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--warn-14)] hover:bg-[var(--warn-24)] text-[var(--warn)] transition-colors disabled:opacity-50"
+                  class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--warn-14)] hover:bg-[var(--warn-24)] text-[var(--color-status-warn)] transition-colors disabled:opacity-50"
                   disabled=${directiveLoading.value}
                   onClick=${() => handleDirective('wakeup')}
                   title="자고 있는 keeper의 sleep을 깨워 다음 turn을 시도합니다. fiber가 살아 있을 때만 효과가 있습니다."
@@ -312,45 +312,45 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
             ? html`<span>하트비트는 유지되지만 자율 행동은 멈춰 있습니다.</span>`
           : null}
         ${hbStale
-          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--bad-soft)] text-[var(--bad)]">하트비트 끊김</span>
+          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--bad-soft)] text-[var(--color-status-err)]">하트비트 끊김</span>
             <span>마지막 하트비트: <${TimeAgo} timestamp=${keeper.last_heartbeat} /></span>`
           : null}
         ${continueGate
           ? html`
-              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">
+              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--color-status-warn)]">
                 계속 진행 승인 대기
               </span>
-              ${hasActivitySignal ? html`<span class="text-[var(--text-muted)]">${renderActivitySignal()}</span>` : null}
+              ${hasActivitySignal ? html`<span class="text-[var(--color-fg-muted)]">${renderActivitySignal()}</span>` : null}
             `
           : socialFallbackActive
           ? html`
-              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">
+              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--color-status-warn)]">
                 소셜 폴백
               </span>
-              ${hasActivitySignal ? html`<span class="text-[var(--text-muted)]">${renderActivitySignal()}</span>` : null}
+              ${hasActivitySignal ? html`<span class="text-[var(--color-fg-muted)]">${renderActivitySignal()}</span>` : null}
             `
           : runtimeBlockerClass
           ? html`
-              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--bad-soft)] text-[var(--bad)]">
+              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--bad-soft)] text-[var(--color-status-err)]">
                 ${runtimeBlockerLabel ?? '런타임 차단'}
               </span>
-              ${hasActivitySignal ? html`<span class="text-[var(--text-muted)]">${renderActivitySignal()}</span>` : null}
+              ${hasActivitySignal ? html`<span class="text-[var(--color-fg-muted)]">${renderActivitySignal()}</span>` : null}
             `
           : null}
         ${runtimeBlocker
-          ? html`<span><strong class="text-[var(--text-strong)]">런타임 차단</strong> · ${runtimeBlocker}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">런타임 차단</strong> · ${runtimeBlocker}</span>`
           : null}
         ${blocker
-          ? html`<span><strong class="text-[var(--text-strong)]">차단 요인</strong> · ${blocker}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">차단 요인</strong> · ${blocker}</span>`
           : null}
         ${keeper.last_need
-          ? html`<span><strong class="text-[var(--text-strong)]">최근 필요</strong> · ${keeper.last_need}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">최근 필요</strong> · ${keeper.last_need}</span>`
           : null}
         ${attentionReason
-          ? html`<span><strong class="text-[var(--text-strong)]">주의 사유</strong> · ${attentionReason}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">주의 사유</strong> · ${attentionReason}</span>`
           : null}
         ${nextHumanAction
-          ? html`<span><strong class="text-[var(--text-strong)]">다음 액션</strong> · ${nextHumanAction}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">다음 액션</strong> · ${nextHumanAction}</span>`
           : null}
         ${trustDisposition
           ? html`
@@ -360,24 +360,24 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
             `
           : null}
         ${trustSummary
-          ? html`<span><strong class="text-[var(--text-strong)]">검증</strong> · ${trustSummary}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">검증</strong> · ${trustSummary}</span>`
           : null}
         ${runtimeProofStatus
-          ? html`<span><strong class="text-[var(--text-strong)]">증명</strong> · ${runtimeProofStatus}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">증명</strong> · ${runtimeProofStatus}</span>`
           : null}
         ${requiredTools.length > 0
-          ? html`<span><strong class="text-[var(--text-strong)]">필요 도구</strong> · ${requiredTools.join(', ')}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">필요 도구</strong> · ${requiredTools.join(', ')}</span>`
           : null}
         ${usedTools.length > 0
-          ? html`<span><strong class="text-[var(--text-strong)]">사용 도구</strong> · ${usedTools.join(', ')}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">사용 도구</strong> · ${usedTools.join(', ')}</span>`
           : null}
         ${missingRequiredTools.length > 0
-          ? html`<span class="text-[var(--bad)]"><strong>누락</strong> · ${missingRequiredTools.join(', ')}</span>`
+          ? html`<span class="text-[var(--color-status-err)]"><strong>누락</strong> · ${missingRequiredTools.join(', ')}</span>`
           : null}
         ${providerSelectedModel || cascadeOutcome || typeof providerAttempts === 'number'
           ? html`
               <span>
-                <strong class="text-[var(--text-strong)]">프로바이더</strong>
+                <strong class="text-[var(--color-fg-secondary)]">프로바이더</strong>
                 · ${providerSelectedModel ?? cascadeOutcome ?? 'observed'}
                 ${typeof providerAttempts === 'number' ? ` · ${providerAttempts}회 시도` : ''}
                 ${providerFallback === true ? ' · 폴백' : ''}
@@ -387,26 +387,26 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${trustLatestEvent
           ? html`
               <span>
-                <strong class="text-[var(--text-strong)]">최근 검증 이벤트</strong>
+                <strong class="text-[var(--color-fg-secondary)]">최근 검증 이벤트</strong>
                 · ${trustLatestEvent.title}
                 · <${TimeAgo} timestamp=${trustLatestEvent.ts} />
               </span>
             `
           : null}
         ${sandboxTarget
-          ? html`<span><strong class="text-[var(--text-strong)]">샌드박스</strong> · ${sandboxTarget}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">샌드박스</strong> · ${sandboxTarget}</span>`
           : null}
         ${typeof persistedPolicyCount === 'number'
-          ? html`<span><strong class="text-[var(--text-strong)]">상시 규칙</strong> · ${persistedPolicyCount}건</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">상시 규칙</strong> · ${persistedPolicyCount}건</span>`
           : null}
         ${typeof goalLinkedTasks === 'number'
-          ? html`<span><strong class="text-[var(--text-strong)]">목표 작업</strong> · ${goalLinkedTasks}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">목표 작업</strong> · ${goalLinkedTasks}</span>`
           : null}
         ${typeof goalConvergence === 'number'
-          ? html`<span><strong class="text-[var(--text-strong)]">목표 진행률</strong> · ${Math.round(goalConvergence * 100)}%</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">목표 진행률</strong> · ${Math.round(goalConvergence * 100)}%</span>`
           : null}
         ${hasActivitySignal
-          ? html`<span><strong class="text-[var(--text-strong)]">최근 신호</strong> · ${renderActivitySignal()}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">최근 신호</strong> · ${renderActivitySignal()}</span>`
           : null}
       </div>
     </div>
@@ -421,7 +421,7 @@ function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Keeper; e
 
   if (isOffline) return html`
     <button type="button"
-      class="py-1 px-3 rounded text-2xs font-semibold cursor-pointer border border-[rgba(34,197,94,0.4)] bg-[var(--emerald-8)] text-[var(--ok)] hover:bg-[rgba(34,197,94,0.15)] transition-colors"
+      class="py-1 px-3 rounded text-2xs font-semibold cursor-pointer border border-[rgba(34,197,94,0.4)] bg-[var(--emerald-8)] text-[var(--color-status-ok)] hover:bg-[rgba(34,197,94,0.15)] transition-colors"
       onClick=${() => {
         void (async () => {
           try {
@@ -506,17 +506,17 @@ function KeeperClearContextDialog({
     >
       <div class="p-5 flex flex-col gap-4">
         <div class="flex flex-col gap-1">
-          <h3 id=${titleId} class="m-0 text-[17px] font-semibold text-[var(--text-strong)]">키퍼 컨텍스트 비우기</h3>
-          <p id=${descId} class="m-0 text-sm leading-relaxed text-[var(--text-muted)]">
+          <h3 id=${titleId} class="m-0 text-[17px] font-semibold text-[var(--color-fg-secondary)]">키퍼 컨텍스트 비우기</h3>
+          <p id=${descId} class="m-0 text-sm leading-relaxed text-[var(--color-fg-muted)]">
             ${keeperName}의 checkpoint 대화와 continuity summary를 비웁니다. 사유는 감사 로그에 남습니다.
           </p>
         </div>
 
         <label class="flex flex-col gap-2">
-          <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">사유</span>
+          <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">사유</span>
           <textarea
             ref=${reasonRef}
-            class="min-h-[112px] resize-y rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2 text-sm leading-paragraph text-[var(--text-body)] outline-none focus:border-[var(--accent-45)] focus:ring-2 focus:ring-[var(--accent-18)]"
+            class="min-h-[112px] resize-y rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-2 text-sm leading-paragraph text-[var(--color-fg-primary)] outline-none focus:border-[var(--accent-45)] focus:ring-2 focus:ring-[var(--accent-18)]"
             placeholder="예: stale continuity replay 제거"
             disabled=${pending}
             value=${reason}
@@ -524,7 +524,7 @@ function KeeperClearContextDialog({
           ></textarea>
         </label>
 
-        <label class="flex items-start gap-3 rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-xs text-[var(--text-body)]">
+        <label class="flex items-start gap-3 rounded border border-[var(--color-border-default)] bg-[var(--white-2)] px-3 py-3 text-xs text-[var(--color-fg-primary)]">
           <input
             type="checkbox"
             class="mt-0.5"
@@ -534,24 +534,24 @@ function KeeperClearContextDialog({
           />
           <span>
             system prompt는 보존하고 나머지 메시지만 비웁니다.
-            <span class="block mt-1 text-[var(--text-muted)]">끄면 system prompt까지 같이 제거합니다.</span>
+            <span class="block mt-1 text-[var(--color-fg-muted)]">끄면 system prompt까지 같이 제거합니다.</span>
           </span>
         </label>
 
-        <div class="rounded border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-2xs leading-relaxed text-[var(--text-muted)]">
+        <div class="rounded border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
           마지막 수단용 액션입니다. 잘못된 continuity가 재주입될 때만 쓰고, 실행 후 즉시 상태를 다시 확인하세요.
         </div>
 
         <div class="flex items-center justify-end gap-2">
           <button
             type="button"
-            class="px-4 py-2 rounded text-sm font-medium border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] hover:bg-[var(--white-8)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            class="px-4 py-2 rounded text-sm font-medium border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)] hover:bg-[var(--white-8)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
             disabled=${pending}
             onClick=${onClose}
           >취소</button>
           <button
             type="button"
-            class="px-4 py-2 rounded text-sm font-medium border border-transparent bg-[var(--bad)] text-white hover:bg-[rgba(239,68,68,0.88)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            class="px-4 py-2 rounded text-sm font-medium border border-transparent bg-[var(--color-status-err)] text-white hover:bg-[rgba(239,68,68,0.88)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
             disabled=${pending || reason.trim() === ''}
             onClick=${onSubmit}
           >${pending ? '비우는 중...' : '비우기'}</button>
@@ -568,10 +568,10 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="border-t border-[var(--border-slate-12)] pt-5">
-      <h3 class="m-0 mb-3 text-sm font-semibold text-[var(--text-strong)] uppercase tracking-[0.06em]">직접 통신</h3>
+      <h3 class="m-0 mb-3 text-sm font-semibold text-[var(--color-fg-secondary)] uppercase tracking-[0.06em]">직접 통신</h3>
 
       ${isOffline ? html`
-        <div class="px-4 py-3 rounded border border-[var(--card-border)] bg-[rgba(90,100,120,0.08)] text-sm text-[var(--text-muted)]">
+        <div class="px-4 py-3 rounded border border-[var(--color-border-default)] bg-[rgba(90,100,120,0.08)] text-sm text-[var(--color-fg-muted)]">
           이 키퍼는 현재 비활동 상태입니다. 기동 후 메시지를 보낼 수 있습니다.
         </div>
       ` : html`
@@ -590,7 +590,7 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
 
 function ProfileField({ label, value, color }: { label: string; value: string; color: string }) {
   return html`
-    <div class="flex items-start gap-2 text-xs text-[var(--text-muted)]">
+    <div class="flex items-start gap-2 text-xs text-[var(--color-fg-muted)]">
       <span class="flex-shrink-0">${label}:</span>
       <span class="font-medium leading-relaxed" style="color: ${color}">${value}</span>
     </div>
@@ -661,19 +661,19 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
       <div class="flex flex-col gap-3">
         ${repos.length > 0 ? html`
           <div>
-            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">Repos (${repos.length})</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1.5">Repos (${repos.length})</div>
             <div class="flex flex-col gap-1.5">
               ${repos.map(r => html`
                 <div class="flex items-center gap-3 px-3 py-2 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2">
-                      <span class="text-xs font-medium text-[var(--text-strong)] truncate">${r.name}</span>
-                      <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">${r.branch}</span>
-                      ${r.shallow ? html`<span class="text-3xs px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]">shallow</span>` : null}
+                      <span class="text-xs font-medium text-[var(--color-fg-secondary)] truncate">${r.name}</span>
+                      <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-15)]">${r.branch}</span>
+                      ${r.shallow ? html`<span class="text-3xs px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--color-status-warn)] border border-[var(--warn-20)]">shallow</span>` : null}
                     </div>
-                    <div class="text-3xs text-[var(--text-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
+                    <div class="text-3xs text-[var(--color-fg-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
                   </div>
-                  <span class="text-3xs text-[var(--text-dim)] flex-shrink-0">${r.last_action}</span>
+                  <span class="text-3xs text-[var(--color-fg-disabled)] flex-shrink-0">${r.last_action}</span>
                 </div>
               `)}
             </div>
@@ -682,14 +682,14 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
 
         ${prs.length > 0 ? html`
           <div>
-            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">PRs (${prs.length})</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1.5">PRs (${prs.length})</div>
             <div class="flex flex-col gap-1.5">
               ${prs.map(pr => html`
                 <div class="flex items-center gap-2 px-3 py-1.5 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-                  <span class="text-xs text-[var(--text-strong)] truncate flex-1">${pr.title}</span>
-                  <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">${pr.branch}</span>
-                  ${pr.draft ? html`<span class="text-3xs px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]">draft</span>` : null}
-                  <a href=${pr.pr_url} target="_blank" rel="noopener" class="text-3xs text-[var(--accent)] hover:underline flex-shrink-0">PR</a>
+                  <span class="text-xs text-[var(--color-fg-secondary)] truncate flex-1">${pr.title}</span>
+                  <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-15)]">${pr.branch}</span>
+                  ${pr.draft ? html`<span class="text-3xs px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--color-status-warn)] border border-[var(--warn-20)]">draft</span>` : null}
+                  <a href=${pr.pr_url} target="_blank" rel="noopener" class="text-3xs text-[var(--color-accent-fg)] hover:underline flex-shrink-0">PR</a>
                 </div>
               `)}
             </div>
@@ -698,10 +698,10 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
 
         ${worktrees.length > 0 ? html`
           <div>
-            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">Worktrees (${worktrees.length})</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1.5">Worktrees (${worktrees.length})</div>
             <div class="flex flex-wrap gap-1.5">
               ${worktrees.map(w => html`
-                <span class="text-3xs font-mono px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]" title=${w.path}>${w.name}</span>
+                <span class="text-3xs font-mono px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--color-fg-muted)]" title=${w.path}>${w.name}</span>
               `)}
             </div>
           </div>
@@ -844,8 +844,8 @@ export function KeeperDetailPage() {
 
   return html`
     <div class="mx-auto flex w-full max-w-[1600px] flex-col gap-5 pb-8">
-      <div class="sticky top-0 z-20 overflow-hidden rounded-[28px] border border-[var(--card-border)] bg-[rgba(13,21,38,0.96)] shadow-[0_24px_64px_rgba(0,0,0,0.22)] backdrop-blur-xl">
-        <div class="flex items-center justify-between gap-4 border-b border-[var(--card-border)] px-5 py-4 sm:px-6">
+      <div class="sticky top-0 z-20 overflow-hidden rounded-[28px] border border-[var(--color-border-default)] bg-[rgba(13,21,38,0.96)] shadow-[0_24px_64px_rgba(0,0,0,0.22)] backdrop-blur-xl">
+        <div class="flex items-center justify-between gap-4 border-b border-[var(--color-border-default)] px-5 py-4 sm:px-6">
           <${KeeperDetailHeaderInfo}
             keeper=${keeper}
             titleId=${titleId}
@@ -868,7 +868,7 @@ export function KeeperDetailPage() {
             <button
               type="button"
               onClick=${() => closeKeeperDetail()}
-              class="flex items-center justify-center size-8 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:text-[var(--text-strong)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1526]"
+              class="flex items-center justify-center size-8 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-secondary)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1526]"
               aria-label="키퍼 상세 종료"
             >
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg>
@@ -897,7 +897,7 @@ export function KeeperDetailPage() {
           >
         <${PipelineStageBar} stage=${keeper.pipeline_stage} />
         <details class="rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-          <summary class="cursor-pointer py-2 px-4 text-3xs font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
+          <summary class="cursor-pointer py-2 px-4 text-3xs font-semibold uppercase tracking-widest text-[var(--color-fg-muted)] list-none select-none flex items-center gap-2">
             <span class="w-1.5 h-1.5 rounded-full bg-[rgba(71,184,255,0.5)]"></span>
             Phase State Machine
           </summary>
@@ -907,7 +907,7 @@ export function KeeperDetailPage() {
         </details>
 
         <details class="rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-          <summary class="cursor-pointer py-2 px-4 text-3xs font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
+          <summary class="cursor-pointer py-2 px-4 text-3xs font-semibold uppercase tracking-widest text-[var(--color-fg-muted)] list-none select-none flex items-center gap-2">
             <span class="w-1.5 h-1.5 rounded-full bg-[rgba(99,102,241,0.5)]"></span>
             Memory Tier & Compaction
           </summary>
@@ -933,40 +933,40 @@ export function KeeperDetailPage() {
           ? html`
             <div class="flex flex-wrap items-start gap-3 px-1">
               ${keeper.last_heartbeat
-                ? html`<span class="inline-flex items-center gap-1.5 text-2xs text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
+                ? html`<span class="inline-flex items-center gap-1.5 text-2xs text-[var(--color-fg-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
                     하트비트 <${TimeAgo} timestamp=${keeper.last_heartbeat} />
                   </span>`
                 : null}
               ${keeper.last_speech_act
-                ? html`<span class="inline-flex items-center gap-1.5 text-2xs text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-                    최근 <span class="font-mono text-[var(--text-body)]">${keeper.last_speech_act}</span>
+                ? html`<span class="inline-flex items-center gap-1.5 text-2xs text-[var(--color-fg-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
+                    최근 <span class="font-mono text-[var(--color-fg-primary)]">${keeper.last_speech_act}</span>
                   </span>`
                 : null}
               ${keeper.social_model_recognized === false
-                ? html`<span class="inline-flex items-center gap-1.5 text-2xs text-[var(--warn)] px-2.5 py-1 rounded border border-[var(--warn-24)] bg-[var(--warn-8)]">
+                ? html`<span class="inline-flex items-center gap-1.5 text-2xs text-[var(--color-status-warn)] px-2.5 py-1 rounded border border-[var(--warn-24)] bg-[var(--warn-8)]">
                     소셜 모델
                     ${keeper.configured_social_model
-                      ? html`<span class="font-mono text-[var(--text-body)]">${keeper.configured_social_model}</span>`
+                      ? html`<span class="font-mono text-[var(--color-fg-primary)]">${keeper.configured_social_model}</span>`
                       : null}
                     ${keeper.configured_social_model && keeper.social_model_fallback
                       ? html`<span>→</span>`
                       : null}
                     ${keeper.social_model_fallback
-                      ? html`<span class="font-mono text-[var(--text-body)]">${keeper.social_model_fallback}</span>`
+                      ? html`<span class="font-mono text-[var(--color-fg-primary)]">${keeper.social_model_fallback}</span>`
                       : null}
                   </span>`
                 : null}
               ${(keeper.k2k_count ?? 0) > 0
-                ? html`<span class="inline-flex items-center gap-1 text-2xs px-2.5 py-1 rounded bg-[rgba(167,139,250,0.08)] border border-[rgba(167,139,250,0.15)] text-[var(--text-muted)]">
+                ? html`<span class="inline-flex items-center gap-1 text-2xs px-2.5 py-1 rounded bg-[rgba(167,139,250,0.08)] border border-[rgba(167,139,250,0.15)] text-[var(--color-fg-muted)]">
                     K2K <span class="font-mono font-medium text-[var(--purple)]">${keeper.k2k_count}</span>
                   </span>`
                 : null}
               ${keeper.memory_recent_note
-                ? html`<span class="text-2xs text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] truncate max-w-90" title=${keeper.memory_recent_note}>${keeper.memory_recent_note}</span>`
+                ? html`<span class="text-2xs text-[var(--color-fg-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] truncate max-w-90" title=${keeper.memory_recent_note}>${keeper.memory_recent_note}</span>`
                 : null}
             </div>
             ${keeper.recent_output_preview
-              ? html`<div class="py-2 px-3 rounded bg-[rgba(71,184,255,0.06)] border border-[var(--accent-12)] text-xs text-[var(--text-body)] leading-relaxed">
+              ? html`<div class="py-2 px-3 rounded bg-[rgba(71,184,255,0.06)] border border-[var(--accent-12)] text-xs text-[var(--color-fg-primary)] leading-relaxed">
                   <div class="line-clamp-2">${keeper.recent_output_preview}</div>
                 </div>`
               : null}
@@ -994,7 +994,7 @@ export function KeeperDetailPage() {
           >
             <${KeeperCommsPanel} keeper=${keeper} />
             <${SectionCard} title="세션 활동 로그">
-              <div class="text-2xs text-[var(--text-muted)] mb-3">현재 세션의 도구 호출, 태스크 완료, 메시지 등 이벤트 기록</div>
+              <div class="text-2xs text-[var(--color-fg-muted)] mb-3">현재 세션의 도구 호출, 태스크 완료, 메시지 등 이벤트 기록</div>
               <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
             <//>
           </${KeeperDetailSection}>
@@ -1025,7 +1025,7 @@ export function KeeperDetailPage() {
               onSocialSweep=${() => { void runSocialSweep() }}
             />
             <div class="pt-3 border-t border-[var(--border-slate-12)]">
-              <h4 class="m-0 mb-3 text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">호출 검사기</h4>
+              <h4 class="m-0 mb-3 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">호출 검사기</h4>
               ${diagOpen ? html`<${KeeperToolCallInspector} keeperName=${keeper.name} />` : null}
             </div>
           </div>
@@ -1035,7 +1035,7 @@ export function KeeperDetailPage() {
                 <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
                 품질 시그널 (고급 지표)
               </summary>
-              <div class="mt-3 text-2xs text-[var(--text-muted)] mb-3">폴백 비율, 정렬 품질, 자율 행동 비율 등 metrics_window 기반 런타임 품질 지표</div>
+              <div class="mt-3 text-2xs text-[var(--color-fg-muted)] mb-3">폴백 비율, 정렬 품질, 자율 행동 비율 등 metrics_window 기반 런타임 품질 지표</div>
               <${RuntimeSignals} keeper=${keeper} />
             </details>
           </${KeeperDetailSection}>
@@ -1051,19 +1051,19 @@ export function KeeperDetailPage() {
             <${TraitsList} traits=${keeper.traits ?? []} label="특성" />
             <${TraitsList} traits=${keeper.interests ?? []} label="관심사" />
             ${keeper.primaryValue
-              ? html`<div class="flex items-center gap-2 mt-3 text-xs text-[var(--text-muted)]">
-                  <span class="text-[var(--text-muted)]">핵심 가치:</span>
-                  <span class="font-medium text-[var(--ok)]">${keeper.primaryValue}</span>
+              ? html`<div class="flex items-center gap-2 mt-3 text-xs text-[var(--color-fg-muted)]">
+                  <span class="text-[var(--color-fg-muted)]">핵심 가치:</span>
+                  <span class="font-medium text-[var(--color-status-ok)]">${keeper.primaryValue}</span>
                 </div>`
               : null}
             ${keeper.skill_primary
-              ? html`<div class="flex items-center gap-2 mt-2 text-xs text-[var(--text-muted)]">
+              ? html`<div class="flex items-center gap-2 mt-2 text-xs text-[var(--color-fg-muted)]">
                   <span>스킬 경로:</span>
                   <span class="font-medium text-[var(--cyan)]">${keeper.skill_primary}</span>
                 </div>`
               : null}
             ${keeper.skill_reason
-              ? html`<div class="text-2xs text-[var(--text-muted)] mt-1 leading-relaxed">${keeper.skill_reason}</div>`
+              ? html`<div class="text-2xs text-[var(--color-fg-muted)] mt-1 leading-relaxed">${keeper.skill_reason}</div>`
               : null}
 
             ${'' /* ── Identity: will / needs / desires ── */}
@@ -1071,7 +1071,7 @@ export function KeeperDetailPage() {
               ? html`
                 <div class="mt-3 flex flex-col gap-1.5">
                   ${keeper.will ? html`<${ProfileField} label="의지" value=${keeper.will} color="var(--cyan)" />` : null}
-                  ${keeper.needs ? html`<${ProfileField} label="필요" value=${keeper.needs} color="var(--warn)" />` : null}
+                  ${keeper.needs ? html`<${ProfileField} label="필요" value=${keeper.needs} color="var(--color-status-warn)" />` : null}
                   ${keeper.desires ? html`<${ProfileField} label="열망" value=${keeper.desires} color="var(--purple)" />` : null}
                 </div>
               `
@@ -1146,17 +1146,17 @@ export function KeeperDetailPage() {
             description="운영 중에는 덜 자주 보지만, 문제를 깊게 파고들 때 필요한 raw surface를 마지막에 모았습니다."
           >
             <details class="mt-0">
-          <summary class="cursor-pointer py-3 px-4 text-2xs font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none rounded border border-[var(--card-border)] bg-[var(--white-3)] hover:bg-[var(--white-6)] transition-colors flex items-center gap-2">
-            <span class="w-1.5 h-1.5 rounded-full bg-[var(--text-dim)]"></span>
+          <summary class="cursor-pointer py-3 px-4 text-2xs font-semibold uppercase tracking-widest text-[var(--color-fg-muted)] list-none select-none rounded border border-[var(--color-border-default)] bg-[var(--white-3)] hover:bg-[var(--white-6)] transition-colors flex items-center gap-2">
+            <span class="w-1.5 h-1.5 rounded-full bg-[var(--color-fg-disabled)]"></span>
             디버그
           </summary>
           <div class="mt-2 flex flex-col gap-4">
             <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm">
-              <h4 class="m-0 mb-3 text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">저널</h4>
+              <h4 class="m-0 mb-3 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">저널</h4>
               <${AgentJournalStream} agentName=${keeper.name} />
             </div>
             <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm">
-              <h4 class="m-0 mb-3 text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">원시 데이터</h4>
+              <h4 class="m-0 mb-3 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">원시 데이터</h4>
               <${RawDataDebug} keeper=${keeper} />
             </div>
           </div>

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -51,9 +51,9 @@ async function loadEvalData(name: string): Promise<void> {
 // ── Coverage bar ────────────────────────────────────────
 
 function coverageColor(coverage: number): string {
-  if (coverage >= 0.9) return 'var(--ok)'
-  if (coverage >= 0.6) return 'var(--warn)'
-  return 'var(--bad)'
+  if (coverage >= 0.9) return 'var(--color-status-ok)'
+  if (coverage >= 0.6) return 'var(--color-status-warn)'
+  return 'var(--color-status-err)'
 }
 
 function coverageTone(coverage: number): string {
@@ -66,13 +66,13 @@ function baselineLabel(status: string | null): { text: string; cls: string } | n
   if (!status) return null
   switch (status) {
     case 'Improved':
-      return { text: 'Improved', cls: 'text-[var(--ok)]' }
+      return { text: 'Improved', cls: 'text-[var(--color-status-ok)]' }
     case 'Regressed':
-      return { text: 'Regressed', cls: 'text-[var(--bad)]' }
+      return { text: 'Regressed', cls: 'text-[var(--color-status-err)]' }
     case 'Unchanged':
-      return { text: 'Unchanged', cls: 'text-[var(--text-muted)]' }
+      return { text: 'Unchanged', cls: 'text-[var(--color-fg-muted)]' }
     default:
-      return { text: status, cls: 'text-[var(--text-muted)]' }
+      return { text: status, cls: 'text-[var(--color-fg-muted)]' }
   }
 }
 
@@ -81,17 +81,17 @@ function baselineLabel(status: string | null): { text: string; cls: string } | n
 function LayerResultRow({ layer }: { layer: EvalLayerResult }) {
   const icon = layer.passed ? '\u2713' : '\u2717'
   const iconCls = layer.passed
-    ? 'text-[var(--ok)]'
-    : 'text-[var(--bad)]'
+    ? 'text-[var(--color-status-ok)]'
+    : 'text-[var(--color-status-err)]'
   const scoreText = layer.score != null ? layer.score.toFixed(2) : '-'
   const detail = layer.detail ?? layer.evidence[0] ?? ''
 
   return html`
     <div class="flex items-center gap-3 py-1.5 px-2 rounded hover:bg-[var(--white-3)] transition-colors">
       <span class="flex-shrink-0 w-4 text-center font-bold text-sm ${iconCls}">${icon}</span>
-      <span class="flex-shrink-0 w-30 text-2xs font-mono text-[var(--accent)] truncate" title=${layer.layer_name}>${layer.layer_name}</span>
-      <span class="flex-shrink-0 w-10 text-right text-2xs font-mono tabular-nums text-[var(--text-strong)]">${scoreText}</span>
-      <span class="flex-1 text-3xs text-[var(--text-muted)] truncate" title=${detail}>${detail}</span>
+      <span class="flex-shrink-0 w-30 text-2xs font-mono text-[var(--color-accent-fg)] truncate" title=${layer.layer_name}>${layer.layer_name}</span>
+      <span class="flex-shrink-0 w-10 text-right text-2xs font-mono tabular-nums text-[var(--color-fg-secondary)]">${scoreText}</span>
+      <span class="flex-1 text-3xs text-[var(--color-fg-muted)] truncate" title=${detail}>${detail}</span>
     </div>
   `
 }
@@ -133,27 +133,27 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
 
   if (loading && !data) {
     return html`
-      <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)] mb-2">평가 품질</div>
-        <div class="text-2xs text-[var(--text-dim)] animate-pulse">데이터 로딩 중...</div>
+      <div class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-2)]">
+        <div class="text-3xs font-semibold tracking-1 uppercase text-[var(--color-fg-muted)] mb-2">평가 품질</div>
+        <div class="text-2xs text-[var(--color-fg-disabled)] animate-pulse">데이터 로딩 중...</div>
       </div>
     `
   }
 
   if (error && !data) {
     return html`
-      <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)] mb-2">평가 품질</div>
-        <div class="text-2xs text-[var(--text-dim)]">eval 데이터 없음</div>
+      <div class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-2)]">
+        <div class="text-3xs font-semibold tracking-1 uppercase text-[var(--color-fg-muted)] mb-2">평가 품질</div>
+        <div class="text-2xs text-[var(--color-fg-disabled)]">eval 데이터 없음</div>
       </div>
     `
   }
 
   if (!data || data.count === 0) {
     return html`
-      <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)] mb-2">평가 품질</div>
-        <div class="text-2xs text-[var(--text-dim)]">eval 결과 없음. OAS harness가 verdict를 생성하면 여기에 표시됩니다.</div>
+      <div class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-2)]">
+        <div class="text-3xs font-semibold tracking-1 uppercase text-[var(--color-fg-muted)] mb-2">평가 품질</div>
+        <div class="text-2xs text-[var(--color-fg-disabled)]">eval 결과 없음. OAS harness가 verdict를 생성하면 여기에 표시됩니다.</div>
       </div>
     `
   }
@@ -173,16 +173,16 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ${'' /* Header */}
       <div class="flex items-center justify-between mb-3">
         <div class="flex items-center gap-2">
-          <span class="text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)]">평가 품질</span>
+          <span class="text-3xs font-semibold tracking-1 uppercase text-[var(--color-fg-muted)]">평가 품질</span>
           ${allPassed
-            ? html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[rgba(74,222,128,0.12)] text-[var(--ok)]">ALL PASS</span>`
-            : html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[var(--bad-12)] text-[var(--bad)]">FAIL</span>`
+            ? html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[rgba(74,222,128,0.12)] text-[var(--color-status-ok)]">ALL PASS</span>`
+            : html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[var(--bad-12)] text-[var(--color-status-err)]">FAIL</span>`
           }
           ${baseline ? html`<span class="text-3xs font-medium ${baseline.cls}">${baseline.text}</span>` : null}
         </div>
         <button
           type="button"
-          class="text-3xs text-[var(--text-dim)] hover:text-[var(--text-muted)] cursor-pointer bg-transparent border-0 p-0"
+          class="text-3xs text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-muted)] cursor-pointer bg-transparent border-0 p-0"
           onClick=${() => void loadEvalData(keeperName)}
           title="새로고침"
         >${loading ? '...' : '\u21bb'}</button>
@@ -190,7 +190,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* Coverage bar */}
       <div class="flex items-center gap-3 mb-3">
-        <span class="text-3xs text-[var(--text-muted)] flex-shrink-0 w-16">Coverage</span>
+        <span class="text-3xs text-[var(--color-fg-muted)] flex-shrink-0 w-16">Coverage</span>
         <div class="flex-1 h-2 bg-[var(--white-6)] rounded-sm overflow-hidden">
           <div
             class="h-full rounded-sm transition-all duration-500"
@@ -203,7 +203,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ${'' /* Layer Results */}
       ${layers.length > 0 ? html`
         <div class="mb-3">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)] mb-1.5">레이어 결과</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)] mb-1.5">레이어 결과</div>
           <div class="flex flex-col gap-0.5">
             ${layers.map((layer: EvalLayerResult) => html`<${LayerResultRow} layer=${layer} />`)}
           </div>
@@ -213,18 +213,18 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ${'' /* 24h Trend */}
       ${trend ? html`
         <div class="flex items-center gap-2 pt-2 border-t border-[var(--white-8)]">
-          <span class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">Trend (24h)</span>
-          <span class="text-2xs font-mono tabular-nums text-[var(--text-muted)]">
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">Trend (24h)</span>
+          <span class="text-2xs font-mono tabular-nums text-[var(--color-fg-muted)]">
             ${trend.oldCoverage.toFixed(2)} \u2192 ${trend.newCoverage.toFixed(2)}
           </span>
-          <span class="text-2xs font-mono tabular-nums font-semibold ${trend.deltaPercent >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">
+          <span class="text-2xs font-mono tabular-nums font-semibold ${trend.deltaPercent >= 0 ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-err)]'}">
             (${trend.deltaPercent >= 0 ? '+' : ''}${trend.deltaPercent.toFixed(1)}%)
           </span>
         </div>
       ` : null}
 
       ${'' /* Snapshot count */}
-      <div class="mt-2 text-3xs text-[var(--text-dim)]">${data.count} eval snapshot${data.count !== 1 ? 's' : ''}</div>
+      <div class="mt-2 text-3xs text-[var(--color-fg-disabled)]">${data.count} eval snapshot${data.count !== 1 ? 's' : ''}</div>
     </div>
   `
 }

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -115,7 +115,7 @@ export function KeeperMemoryTierPanel({
 
   if (loading) {
     return html`
-      <div class="flex items-center justify-center gap-2 py-6 text-2xs text-[var(--text-dim)]">
+      <div class="flex items-center justify-center gap-2 py-6 text-2xs text-[var(--color-fg-disabled)]">
         <${InlineSpinner} />
         메모리 티어 로딩중
       </div>
@@ -143,7 +143,7 @@ export function KeeperMemoryTierPanel({
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="flex flex-wrap items-center gap-2 text-3xs text-[var(--text-dim)]">
+      <div class="flex flex-wrap items-center gap-2 text-3xs text-[var(--color-fg-disabled)]">
         <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">
           total ${totalUsed} / ${totalCap}
         </span>
@@ -167,7 +167,7 @@ export function KeeperMemoryTierPanel({
           placeholder="kind 필터"
           aria-label="memory kind 필터"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-30 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-30 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
         <${FilterChips}
           chips=${[
@@ -180,7 +180,7 @@ export function KeeperMemoryTierPanel({
       </div>
 
       ${visible.length === 0 ? html`
-        <div class="py-4 text-center text-2xs text-[var(--text-dim)]">
+        <div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">
           필터 결과 없음
         </div>
       ` : null}
@@ -196,16 +196,16 @@ export function KeeperMemoryTierPanel({
               : 'bg-[rgba(99,102,241,0.6)]'
           return html`
             <div class="flex items-center gap-2 text-2xs">
-              <div class="w-24 truncate text-[var(--text-body)] font-mono" title=${row.kind}>
+              <div class="w-24 truncate text-[var(--color-fg-primary)] font-mono" title=${row.kind}>
                 ${row.kind}
               </div>
               <div class="relative flex-1 h-4 rounded-sm bg-[var(--white-4)] border border-[var(--white-8)] overflow-hidden">
                 <div class=${`absolute inset-y-0 left-0 ${barColor}`} style=${`width: ${pct}%`}></div>
               </div>
-              <div class="w-16 text-right text-[var(--text-muted)] tabular-nums">
+              <div class="w-16 text-right text-[var(--color-fg-muted)] tabular-nums">
                 ${row.used}/${row.cap}
               </div>
-              <div class="w-10 text-right text-3xs text-[var(--text-dim)] tabular-nums">
+              <div class="w-10 text-right text-3xs text-[var(--color-fg-disabled)] tabular-nums">
                 p${row.priority}
               </div>
             </div>
@@ -214,7 +214,7 @@ export function KeeperMemoryTierPanel({
       </div>
 
       <div class="mt-2">
-        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)] mb-2">
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)] mb-2">
           Compaction sub-FSM (KeeperCompactionLifecycle.tla)
         </div>
         <${CytoscapeFsm} spec=${compactionSpec} height="200px" />

--- a/dashboard/src/components/keeper-phase-indicator.test.ts
+++ b/dashboard/src/components/keeper-phase-indicator.test.ts
@@ -75,7 +75,7 @@ describe('getPhaseStyle', () => {
   it('returns correct style for Running (ok group)', () => {
     const s = getPhaseStyle('Running')
     expect(s.label).toBe('실행중')
-    expect(s.color).toBe('var(--ok)')
+    expect(s.color).toBe('var(--color-status-ok)')
     expect(s.bg).toBe('var(--ok-10)')
   })
 
@@ -97,7 +97,7 @@ describe('getPhaseStyle', () => {
       (p) => getPhaseStyle(p).color,
     )
     expect(new Set(tones).size).toBe(1)
-    expect(tones[0]).toBe('var(--accent)')
+    expect(tones[0]).toBe('var(--color-accent-fg)')
   })
 
   it('returns Offline for unknown phase string', () => {

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -46,17 +46,17 @@ const SOFT_GLOW = '0 0 8px color-mix(in srgb, currentColor 25%, transparent)'
 const STRONG_GLOW = '0 0 10px color-mix(in srgb, currentColor 32%, transparent)'
 
 const PHASE_STYLES: Record<KeeperPhase, PhaseStyle> = {
-  Offline:    { label: '오프라인',     color: 'var(--text-muted)', bg: 'var(--white-5)',   border: 'var(--white-10)',   glow: 'none',        icon: '○' },
-  Running:    { label: '실행중',       color: 'var(--ok)',         bg: 'var(--ok-10)',     border: 'var(--ok-20)',      glow: SOFT_GLOW,     icon: '●' },
-  Failing:    { label: '오류중',       color: 'var(--warn)',       bg: 'var(--warn-10)',   border: 'var(--warn-20)',    glow: SOFT_GLOW,     icon: '▲' },
-  Overflowed: { label: '컨텍스트초과', color: 'var(--warn)',       bg: 'var(--warn-10)',   border: 'var(--warn-20)',    glow: SOFT_GLOW,     icon: '⚠' },
-  Compacting: { label: '압축중',       color: 'var(--accent)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '◆' },
-  HandingOff: { label: '승계중',       color: 'var(--accent)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '⟳' },
-  Draining:   { label: '종료중',       color: 'var(--accent)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '▽' },
+  Offline:    { label: '오프라인',     color: 'var(--color-fg-muted)', bg: 'var(--white-5)',   border: 'var(--white-10)',   glow: 'none',        icon: '○' },
+  Running:    { label: '실행중',       color: 'var(--color-status-ok)',         bg: 'var(--ok-10)',     border: 'var(--ok-20)',      glow: SOFT_GLOW,     icon: '●' },
+  Failing:    { label: '오류중',       color: 'var(--color-status-warn)',       bg: 'var(--warn-10)',   border: 'var(--warn-20)',    glow: SOFT_GLOW,     icon: '▲' },
+  Overflowed: { label: '컨텍스트초과', color: 'var(--color-status-warn)',       bg: 'var(--warn-10)',   border: 'var(--warn-20)',    glow: SOFT_GLOW,     icon: '⚠' },
+  Compacting: { label: '압축중',       color: 'var(--color-accent-fg)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '◆' },
+  HandingOff: { label: '승계중',       color: 'var(--color-accent-fg)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '⟳' },
+  Draining:   { label: '종료중',       color: 'var(--color-accent-fg)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '▽' },
   Paused:     { label: '일시정지',     color: 'var(--paused)',     bg: 'var(--paused-10)', border: 'var(--paused-20)',  glow: 'none',        icon: '⏸' },
-  Stopped:    { label: '정지',         color: 'var(--text-muted)', bg: 'var(--white-5)',   border: 'var(--white-10)',   glow: 'none',        icon: '■' },
+  Stopped:    { label: '정지',         color: 'var(--color-fg-muted)', bg: 'var(--white-5)',   border: 'var(--white-10)',   glow: 'none',        icon: '■' },
   Crashed:    { label: '비정상종료',   color: 'var(--bad-light)',  bg: 'var(--bad-10)',    border: 'var(--bad-20)',     glow: STRONG_GLOW,   icon: '✕' },
-  Restarting: { label: '재시작중',     color: 'var(--accent)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '↺' },
+  Restarting: { label: '재시작중',     color: 'var(--color-accent-fg)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '↺' },
   Dead:       { label: '종료',         color: 'var(--bad-light)',  bg: 'var(--bad-10)',    border: 'var(--bad-20)',     glow: 'none',        icon: '✦' },
 }
 
@@ -117,10 +117,10 @@ export function KeeperPhaseAndStage({
     <div class="flex items-center gap-2">
       <${KeeperPhaseBadge} phase=${phase} />
       ${dwellText ? html`
-        <span class="text-3xs text-[var(--text-muted)] font-mono tracking-tight" title="현재 phase에 머문 시간">· ${dwellText}</span>
+        <span class="text-3xs text-[var(--color-fg-muted)] font-mono tracking-tight" title="현재 phase에 머문 시간">· ${dwellText}</span>
       ` : null}
       ${stageLabel ? html`
-        <span class="text-3xs text-[var(--text-dim)] font-mono tracking-tight opacity-80">${stageLabel}</span>
+        <span class="text-3xs text-[var(--color-fg-disabled)] font-mono tracking-tight opacity-80">${stageLabel}</span>
       ` : null}
     </div>
   `

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -30,8 +30,8 @@ function phaseInlineStyle(phase: string): string {
 
 function signalColor(t: KeeperTransition): string {
   const severity = t.operator_signal?.severity
-  if (severity === 'bad') return 'var(--bad)'
-  if (severity === 'warn') return 'var(--warn)'
+  if (severity === 'bad') return 'var(--color-status-err)'
+  if (severity === 'warn') return 'var(--color-status-warn)'
   return phaseColor(t.new_phase)
 }
 
@@ -74,18 +74,18 @@ function TransitionDot({ t, idx }: { t: KeeperTransition; idx: number }) {
         style="border-color: ${color}; background: ${color}33"
       />
       <div class="absolute bottom-full mb-2 hidden group-hover:flex flex-col items-center z-10">
-        <div class="rounded border border-[var(--card-border)] bg-[var(--card)] px-3 py-2 shadow-sm text-2xs whitespace-nowrap">
+        <div class="rounded border border-[var(--color-border-default)] bg-[var(--card)] px-3 py-2 shadow-sm text-2xs whitespace-nowrap">
           <div class="font-semibold">${t.prev_phase} → ${t.new_phase}</div>
-          <div class="text-[var(--text-muted)] mt-0.5">${t.event_type ?? eventLabel(t.selected_event)}</div>
+          <div class="text-[var(--color-fg-muted)] mt-0.5">${t.event_type ?? eventLabel(t.selected_event)}</div>
           ${signal ? html`
-            <div class="mt-1 text-[var(--text-body)]">${signal.summary}</div>
+            <div class="mt-1 text-[var(--color-fg-primary)]">${signal.summary}</div>
             ${signal.requires_operator_decision ? html`
-              <div class="mt-1 font-semibold text-[var(--warn)]">
+              <div class="mt-1 font-semibold text-[var(--color-status-warn)]">
                 decision required${signal.next_human_action ? ` · ${signal.next_human_action}` : ''}
               </div>
             ` : null}
           ` : null}
-          <div class="text-[var(--text-muted)]"><${TimeAgo} timestamp=${t.wall_clock_at_decision * 1000} /></div>
+          <div class="text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${t.wall_clock_at_decision * 1000} /></div>
         </div>
       </div>
     </div>
@@ -99,7 +99,7 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
   return html`
     <div class="flex items-center gap-3 py-2 px-3 rounded border border-[var(--white-6)] bg-[var(--white-3)]" role="listitem" aria-label="${name}: ${getPhaseStyle(toPascalPhase(phase)).label}, 전환 ${transitions.length}건">
       <div class="w-24 shrink-0">
-        <div class="text-sm font-semibold text-[var(--text-strong)] truncate">${name}</div>
+        <div class="text-sm font-semibold text-[var(--color-fg-secondary)] truncate">${name}</div>
         <div
           class="inline-flex items-center rounded px-2 py-0.5 text-3xs font-semibold tracking-wide mt-1"
           style="${phaseInlineStyle(phase)}"
@@ -110,14 +110,14 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
       </div>
       <div class="flex-1 flex items-center gap-1.5 overflow-x-auto min-h-6">
         ${transitions.length === 0
-          ? html`<span class="text-2xs text-[var(--text-muted)]">전환 없음</span>`
+          ? html`<span class="text-2xs text-[var(--color-fg-muted)]">전환 없음</span>`
           : transitions.map((t, i) => html`
               <${TransitionDot} t=${t} idx=${i} />
               ${i < transitions.length - 1 ? html`<div class="w-3 h-px bg-[var(--white-10)]" />` : null}
             `)
         }
       </div>
-      <div class="shrink-0 text-2xs text-[var(--text-muted)] tabular-nums">
+      <div class="shrink-0 text-2xs text-[var(--color-fg-muted)] tabular-nums">
         ${transitions.length}건
       </div>
     </div>
@@ -136,16 +136,16 @@ export function KeeperPhaseTimeline() {
   }
 
   if (keeperList.length === 0) {
-    return html`<div class="text-xs text-[var(--text-muted)] py-4 text-center">등록된 키퍼 없음</div>`
+    return html`<div class="text-xs text-[var(--color-fg-muted)] py-4 text-center">등록된 키퍼 없음</div>`
   }
 
   return html`
     <div class="flex flex-col gap-2" role="list" aria-label="키퍼 페이즈 전환 타임라인">
       <div class="flex items-center justify-between mb-1">
-        <div class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">페이즈 전환 (최근 30건)</div>
+        <div class="text-2xs text-[var(--color-fg-muted)] uppercase tracking-wider font-medium">페이즈 전환 (최근 30건)</div>
         <button
           type="button"
-          class="text-2xs text-[var(--text-dim)] hover:text-[var(--text-body)] transition-colors"
+          class="text-2xs text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)] transition-colors"
           onClick=${() => { void loadAll() }}
         >새로고침</button>
       </div>
@@ -155,8 +155,8 @@ export function KeeperPhaseTimeline() {
           ? html`<${KeeperStrip} name=${k.name} data=${d} key=${k.name} />`
           : html`
             <div class="flex items-center gap-3 py-2 px-3 rounded border border-[var(--white-6)] bg-[var(--white-3)]" key=${k.name}>
-              <div class="w-24 text-sm font-semibold text-[var(--text-strong)] truncate">${k.name}</div>
-              <span class="text-2xs text-[var(--text-muted)]">데이터 없음</span>
+              <div class="w-24 text-sm font-semibold text-[var(--color-fg-secondary)] truncate">${k.name}</div>
+              <span class="text-2xs text-[var(--color-fg-muted)]">데이터 없음</span>
             </div>
           `
       })}

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -136,9 +136,9 @@ function conversationStateClass(sending: boolean, hydrating: boolean): string {
     return 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok-20)]'
   }
   if (hydrating) {
-    return 'border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--text-strong)]'
+    return 'border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--color-fg-secondary)]'
   }
-  return 'border-[rgba(148,163,184,0.18)] bg-[var(--slate-gray-8)] text-[var(--text-body)]'
+  return 'border-[rgba(148,163,184,0.18)] bg-[var(--slate-gray-8)] text-[var(--color-fg-primary)]'
 }
 
 function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnostic | null {
@@ -151,7 +151,7 @@ function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnosti
 
 function DiagChip({ label }: { label: string }) {
   return html`
-    <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${label}</span>
+    <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-30)]">${label}</span>
   `
 }
 
@@ -165,7 +165,7 @@ export function KeeperDiagnosticSummary({
   showRawStatus?: boolean
 }) {
   if (!keeper) {
-    return html`<div class="text-xs text-[var(--text-muted)] leading-relaxed py-2">키퍼를 선택하여 직접 응답 상태를 확인하세요.</div>`
+    return html`<div class="text-xs text-[var(--color-fg-muted)] leading-relaxed py-2">키퍼를 선택하여 직접 응답 상태를 확인하세요.</div>`
   }
 
   const detail = keeperStatusDetails.value[keeper.name]
@@ -181,12 +181,12 @@ export function KeeperDiagnosticSummary({
   }
 
   return html`
-    <div class="py-3 px-4 rounded border border-[var(--card-border)] bg-[rgba(5,14,31,0.55)]">
+    <div class="py-3 px-4 rounded border border-[var(--color-border-default)] bg-[rgba(5,14,31,0.55)]">
       <div class="mb-3 flex items-center justify-between gap-3">
-        <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--text-muted)]">명시적 상태 조회</div>
+        <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">명시적 상태 조회</div>
         <button
           type="button"
-          class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)]"
           disabled=${busy}
           onClick=${() => { void refreshStatus() }}
         >
@@ -208,12 +208,12 @@ export function KeeperDiagnosticSummary({
           : null}
         ${busy ? html`<${DiagChip} label="refreshing" />` : null}
       </div>
-      <div class="text-xs text-[var(--text-body)] leading-relaxed">
+      <div class="text-xs text-[var(--color-fg-primary)] leading-relaxed">
         ${diagnostic?.continuity_summary
           ?? diagnostic?.summary
           ?? '자동 판단 필드는 기본으로 채우지 않습니다. 필요할 때만 상태를 불러오세요.'}
       </div>
-      <div class="text-xs text-[var(--text-body)] leading-relaxed mt-1">
+      <div class="text-xs text-[var(--color-fg-primary)] leading-relaxed mt-1">
         응답: ${diagnostic?.last_reply_status ?? '미조회'}
         ${diagnostic?.last_reply_at ? html` -- ${formatTime(diagnostic.last_reply_at)}` : null}
         ${diagnostic?.next_eligible_at_s ? html` -- 다음 응답 가능 ${formatEligible(diagnostic.next_eligible_at_s)}` : null}
@@ -222,7 +222,7 @@ export function KeeperDiagnosticSummary({
         ? html`<div class="text-xs text-[var(--bad-light)] leading-relaxed mt-1">${diagnostic.last_error}</div>`
         : null}
       ${showRawStatus
-        ? html`<div class="mt-3 max-h-60 overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```text\n' + (detail?.rawText ?? '키퍼 상태를 아직 불러오지 않았습니다.') + '\n```'} /></div>`
+        ? html`<div class="mt-3 max-h-60 overflow-auto rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```text\n' + (detail?.rawText ?? '키퍼 상태를 아직 불러오지 않았습니다.') + '\n```'} /></div>`
         : null}
     </div>
   `
@@ -290,12 +290,12 @@ export function KeeperConversationPanel({
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,15,28,0.96),rgba(5,10,20,0.94))] shadow-[0_24px_56px_rgba(0,0,0,0.28)]">
+      <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--color-border-default)] bg-[linear-gradient(180deg,rgba(9,15,28,0.96),rgba(5,10,20,0.94))] shadow-[0_24px_56px_rgba(0,0,0,0.28)]">
         <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--slate-gray-12)] px-4 py-4">
           <div class="min-w-55 flex-1">
-            <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">직접 대화</div>
+            <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--color-fg-muted)]">직접 대화</div>
             <div class="mt-2 flex flex-wrap items-center gap-2">
-              <div class="text-md font-semibold text-[var(--text-strong)]">@${keeperName}</div>
+              <div class="text-md font-semibold text-[var(--color-fg-secondary)]">@${keeperName}</div>
               <span class=${`inline-flex items-center rounded-sm border px-2.5 py-1 text-3xs font-medium uppercase tracking-2 ${conversationStateClass(sending, hydrating)}`}>
                 ${conversationStateLabel(sending, hydrating)}
               </span>
@@ -307,14 +307,14 @@ export function KeeperConversationPanel({
           <div class="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+              class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)]"
               onClick=${toggleMetadata}
             >
               ${showMetadata ? '메타데이터 숨김' : '메타데이터 표시'}
             </button>
             <button
               type="button"
-              class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)] ${showInternal ? 'border-[rgba(167,139,250,0.3)] text-[var(--purple)]' : ''}"
+              class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] ${showInternal ? 'border-[rgba(167,139,250,0.3)] text-[var(--purple)]' : ''}"
               onClick=${toggleInternal}
             >
               ${showInternal ? '내부 메시지 숨김' : '내부 메시지 표시'}
@@ -323,7 +323,7 @@ export function KeeperConversationPanel({
               ? html`
                   <button
                     type="button"
-                    class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+                    class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)]"
                     disabled=${hydrating}
                     onClick=${() => { void expandHistory() }}
                   >
@@ -400,10 +400,10 @@ export function KeeperRuntimeActions({
   const canRecover = diagnostic?.recoverable === true
 
   const btnBase = 'py-1.5 px-4 rounded text-xs font-medium cursor-pointer transition-colors border'
-  const ghostBtn = `${btnBase} border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]`
-  const activeGhostBtn = `${btnBase} border-[rgba(71,184,255,0.4)] bg-[var(--accent-12)] text-[var(--accent)] hover:bg-[var(--accent-20)]`
-  const secondaryBtn = `${btnBase} border-[rgba(251,191,36,0.3)] bg-[var(--warn-10)] text-[var(--warn)] hover:bg-[var(--warn-soft)]`
-  const activeSecondaryBtn = `${btnBase} border-[rgba(251,191,36,0.5)] bg-[var(--warn-soft)] text-[var(--warn)] hover:bg-[var(--warn-20)]`
+  const ghostBtn = `${btnBase} border-[var(--color-border-default)] bg-[var(--white-3)] text-[var(--color-fg-muted)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)]`
+  const activeGhostBtn = `${btnBase} border-[rgba(71,184,255,0.4)] bg-[var(--accent-12)] text-[var(--color-accent-fg)] hover:bg-[var(--accent-20)]`
+  const secondaryBtn = `${btnBase} border-[rgba(251,191,36,0.3)] bg-[var(--warn-10)] text-[var(--color-status-warn)] hover:bg-[var(--warn-soft)]`
+  const activeSecondaryBtn = `${btnBase} border-[rgba(251,191,36,0.5)] bg-[var(--warn-soft)] text-[var(--color-status-warn)] hover:bg-[var(--warn-20)]`
 
   return html`
     <div class="flex flex-wrap gap-2">

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
@@ -15,9 +15,9 @@ export function KeeperSpawnPanel() {
     </div>`
   }
   return html`
-    <div class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-1)] p-4">
+    <div class="mb-4 rounded border border-[var(--color-border-default)] bg-[var(--bg-1)] p-4">
       <div class="flex items-center justify-between mb-3">
-        <h3 class="text-sm text-[var(--text-strong)] font-medium">키퍼 생성</h3>
+        <h3 class="text-sm text-[var(--color-fg-secondary)] font-medium">키퍼 생성</h3>
         <${ActionButton} variant="subtle" size="sm" onClick=${() => { showSpawnPanel.value = false }}>닫기<//>
       </div>
       <div class="flex gap-2 mb-3">
@@ -32,7 +32,7 @@ export function KeeperSpawnPanel() {
         ? html`<${PersonaBrowser} />`
         : spawnMode.value === 'generate'
           ? html`<${PersonaGenerator} />`
-        : html`<p class="text-xs text-[var(--text-muted)]">직접 생성은 도구 실행기에서 <code class="text-[var(--accent)]">masc_keeper_up</code>을 사용하세요.</p>`}
+        : html`<p class="text-xs text-[var(--color-fg-muted)]">직접 생성은 도구 실행기에서 <code class="text-[var(--color-accent-fg)]">masc_keeper_up</code>을 사용하세요.</p>`}
     </div>
   `
 }

--- a/dashboard/src/components/keeper-spawn/persona-browser.ts
+++ b/dashboard/src/components/keeper-spawn/persona-browser.ts
@@ -41,15 +41,15 @@ function PersonaCard({ persona }: { persona: PersonaSummary }) {
   const spawnAccess = dashboardAuthAccess(shellAuthSummary.value, 'worker')
   const title = persona.displayName ?? persona.name
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] p-4 flex flex-col gap-2 min-w-45">
-      <div class="text-base text-[var(--text-strong)] font-medium">${title}</div>
-      ${persona.role ? html`<div class="text-2xs text-[var(--text-muted)]">${persona.role}</div>` : null}
-      ${persona.mode ? html`<div class="text-3xs text-[var(--text-muted)]">모드: ${persona.mode}</div>` : null}
-      ${persona.description ? html`<div class="text-2xs text-[var(--text-body)] mt-1 line-clamp-2">${persona.description}</div>` : null}
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-4)] p-4 flex flex-col gap-2 min-w-45">
+      <div class="text-base text-[var(--color-fg-secondary)] font-medium">${title}</div>
+      ${persona.role ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${persona.role}</div>` : null}
+      ${persona.mode ? html`<div class="text-3xs text-[var(--color-fg-muted)]">모드: ${persona.mode}</div>` : null}
+      ${persona.description ? html`<div class="text-2xs text-[var(--color-fg-primary)] mt-1 line-clamp-2">${persona.description}</div>` : null}
       <div class="mt-auto pt-2">
         ${isConfirming ? html`
           <div class="flex flex-col gap-1.5">
-            <p class="text-3xs text-[var(--warn)]">키퍼를 시작합니까?</p>
+            <p class="text-3xs text-[var(--color-status-warn)]">키퍼를 시작합니까?</p>
             <div class="flex gap-1.5">
               <${ActionButton} variant="primary" size="sm" disabled=${isSpawning || !spawnAccess.allowed}
                 title=${spawnAccess.allowed ? undefined : spawnAccess.reason ?? undefined}
@@ -76,18 +76,18 @@ function PersonaCard({ persona }: { persona: PersonaSummary }) {
 export function PersonaBrowser() {
   useEffect(() => { if (personas.value.length === 0 && !personasLoading.value) void loadPersonas() }, [])
   const spawnAccess = dashboardAuthAccess(shellAuthSummary.value, 'worker')
-  if (personasLoading.value) return html`<p class="text-xs text-[var(--text-muted)] py-4">페르소나 로딩 중...</p>`
+  if (personasLoading.value) return html`<p class="text-xs text-[var(--color-fg-muted)] py-4">페르소나 로딩 중...</p>`
   if (personasError.value) return html`
     <div class="py-4">
-      <p class="text-xs text-[var(--bad)] mb-2">${personasError.value}</p>
+      <p class="text-xs text-[var(--color-status-err)] mb-2">${personasError.value}</p>
       <${ActionButton} variant="ghost" size="sm" onClick=${() => void loadPersonas()}>재시도<//>
     </div>`
-  if (personas.value.length === 0) return html`<p class="text-xs text-[var(--text-muted)] py-4">등록된 페르소나가 없습니다.</p>`
+  if (personas.value.length === 0) return html`<p class="text-xs text-[var(--color-fg-muted)] py-4">등록된 페르소나가 없습니다.</p>`
   const visible = filterPersonas(personas.value, searchQuery.value)
   return html`
     <div>
       ${spawnAccess.allowed ? null : html`
-        <p class="mb-3 text-2xs text-[var(--warn)]">
+        <p class="mb-3 text-2xs text-[var(--color-status-warn)]">
           키퍼 생성 차단: ${spawnAccess.reason ?? 'worker 권한이 필요합니다.'}
         </p>
       `}
@@ -98,16 +98,16 @@ export function PersonaBrowser() {
           placeholder="페르소나 검색 (이름/역할/모드/설명)"
           aria-label="페르소나 검색"
           onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
-          class="min-w-45 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-45 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
-        <span class="text-3xs text-[var(--text-muted)] tabular-nums">
+        <span class="text-3xs text-[var(--color-fg-muted)] tabular-nums">
           ${searchQuery.value.trim()
             ? `${visible.length} / ${personas.value.length}`
             : `${personas.value.length}개`}
         </span>
       </div>
       ${visible.length === 0
-        ? html`<p class="text-xs text-[var(--text-muted)] py-4">검색 조건에 맞는 페르소나가 없습니다.</p>`
+        ? html`<p class="text-xs text-[var(--color-fg-muted)] py-4">검색 조건에 맞는 페르소나가 없습니다.</p>`
         : html`
           <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-3">
             ${visible.map(p => html`<${PersonaCard} key=${p.name} persona=${p} />`)}
@@ -116,7 +116,7 @@ export function PersonaBrowser() {
       ${spawnResult.value ? html`
         <${SurfaceCard} class="mt-3" variant="compact">
           <pre class="text-2xs font-mono overflow-x-auto max-h-50 overflow-y-auto
-            ${spawnResult.value.success ? 'text-[var(--text-body)]' : 'text-[var(--bad)]'}">${spawnResult.value.message}</pre>
+            ${spawnResult.value.success ? 'text-[var(--color-fg-primary)]' : 'text-[var(--color-status-err)]'}">${spawnResult.value.message}</pre>
         <//>` : null}
     </div>
   `

--- a/dashboard/src/components/keeper-spawn/persona-generator.ts
+++ b/dashboard/src/components/keeper-spawn/persona-generator.ts
@@ -93,14 +93,14 @@ export function PersonaGenerator() {
     <div class="grid gap-4 lg:grid-cols-[minmax(260px,0.9fr)_minmax(360px,1.2fr)]">
       <div class="space-y-3">
         <div class="grid gap-2">
-          <label class="text-3xs text-[var(--text-muted)]" for="persona-concept">컨셉</label>
+          <label class="text-3xs text-[var(--color-fg-muted)]" for="persona-concept">컨셉</label>
           <textarea
             id="persona-concept"
             rows=${5}
             value=${concept.value}
             placeholder="good evil chaos research keeper"
             onInput=${(e: Event) => { concept.value = (e.target as HTMLTextAreaElement).value }}
-            class="w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-2 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-2 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
           />
         </div>
 
@@ -119,35 +119,35 @@ export function PersonaGenerator() {
         ` : null}
 
         <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          <label class="grid gap-1 text-3xs text-[var(--text-muted)]">
+          <label class="grid gap-1 text-3xs text-[var(--color-fg-muted)]">
             handle
             <input
               value=${handle.value}
               placeholder="auto"
               onInput=${(e: Event) => { handle.value = (e.target as HTMLInputElement).value }}
-              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--text-body)] focus:outline-none focus:border-[var(--accent)]"
+              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--color-fg-primary)] focus:outline-none focus:border-[var(--color-accent-fg)]"
             />
           </label>
-          <label class="grid gap-1 text-3xs text-[var(--text-muted)]">
+          <label class="grid gap-1 text-3xs text-[var(--color-fg-muted)]">
             display
             <input
               value=${displayName.value}
               placeholder="auto"
               onInput=${(e: Event) => { displayName.value = (e.target as HTMLInputElement).value }}
-              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--text-body)] focus:outline-none focus:border-[var(--accent)]"
+              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--color-fg-primary)] focus:outline-none focus:border-[var(--color-accent-fg)]"
             />
           </label>
-          <label class="grid gap-1 text-3xs text-[var(--text-muted)]">
+          <label class="grid gap-1 text-3xs text-[var(--color-fg-muted)]">
             preset
             <select
               value=${toolPreset.value}
               onChange=${(e: Event) => { toolPreset.value = (e.target as HTMLSelectElement).value }}
-              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--text-body)] focus:outline-none focus:border-[var(--accent)]"
+              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--color-fg-primary)] focus:outline-none focus:border-[var(--color-accent-fg)]"
             >
               ${presetChoices.map(choice => html`<option key=${choice} value=${choice}>${choice}</option>`)}
             </select>
           </label>
-          <label class="flex items-center gap-2 pt-5 text-2xs text-[var(--text-body)]">
+          <label class="flex items-center gap-2 pt-5 text-2xs text-[var(--color-fg-primary)]">
             <input
               type="checkbox"
               checked=${proactiveEnabled.value}
@@ -178,7 +178,7 @@ export function PersonaGenerator() {
             ariaBusy=${personaSaving.value}
             onClick=${() => void saveDraft(false)}
           >${personaSaving.value ? '저장 중...' : '저장'}<//>
-          <label class="flex items-center gap-1.5 text-3xs text-[var(--text-muted)]">
+          <label class="flex items-center gap-1.5 text-3xs text-[var(--color-fg-muted)]">
             <input
               type="checkbox"
               checked=${overwrite.value}
@@ -190,7 +190,7 @@ export function PersonaGenerator() {
 
         ${schema ? html`
           <div class="rounded border border-[var(--white-10)] bg-[var(--white-4)]">
-            <div class="border-b border-[var(--white-10)] px-2 py-1.5 text-3xs text-[var(--text-muted)]">
+            <div class="border-b border-[var(--white-10)] px-2 py-1.5 text-3xs text-[var(--color-fg-muted)]">
               ${schema.personasRoot ?? ''} · ${schema.handleRules ?? ''}
             </div>
             <div class="max-h-56 overflow-auto">
@@ -198,9 +198,9 @@ export function PersonaGenerator() {
                 <tbody>
                   ${schema.fieldCatalog.map(field => html`
                     <tr key=${field.path} class="border-b border-[var(--white-6)] align-top">
-                      <td class="px-2 py-1.5 font-mono text-[var(--accent)] whitespace-nowrap">${field.path}</td>
-                      <td class="px-2 py-1.5 text-[var(--text-muted)]">${field.type ?? ''}${field.required ? ' *' : ''}</td>
-                      <td class="px-2 py-1.5 text-[var(--text-body)]">${field.effect ?? ''}</td>
+                      <td class="px-2 py-1.5 font-mono text-[var(--color-accent-fg)] whitespace-nowrap">${field.path}</td>
+                      <td class="px-2 py-1.5 text-[var(--color-fg-muted)]">${field.type ?? ''}${field.required ? ' *' : ''}</td>
+                      <td class="px-2 py-1.5 text-[var(--color-fg-primary)]">${field.effect ?? ''}</td>
                     </tr>
                   `)}
                 </tbody>
@@ -213,8 +213,8 @@ export function PersonaGenerator() {
       <div class="space-y-3">
         <div class="grid gap-2">
           <div class="flex items-center justify-between">
-            <label class="text-3xs text-[var(--text-muted)]" for="persona-profile-json">profile.json</label>
-            ${draft ? html`<span class="text-3xs text-[var(--text-muted)]">${draft.handle}</span>` : null}
+            <label class="text-3xs text-[var(--color-fg-muted)]" for="persona-profile-json">profile.json</label>
+            ${draft ? html`<span class="text-3xs text-[var(--color-fg-muted)]">${draft.handle}</span>` : null}
           </div>
           <textarea
             id="persona-profile-json"
@@ -222,7 +222,7 @@ export function PersonaGenerator() {
             value=${profileText.value}
             placeholder="초안을 생성하면 profile.json이 표시됩니다"
             onInput=${(e: Event) => { profileText.value = (e.target as HTMLTextAreaElement).value }}
-            class="w-full rounded border border-[var(--white-10)] bg-[var(--bg-0)] px-2 py-2 font-mono text-3xs leading-5 text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="w-full rounded border border-[var(--white-10)] bg-[var(--bg-0)] px-2 py-2 font-mono text-3xs leading-5 text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
           />
         </div>
 
@@ -230,8 +230,8 @@ export function PersonaGenerator() {
           <div class="rounded border border-[var(--white-10)] bg-[var(--white-4)]">
             ${draft.fieldExplanations.map(item => html`
               <div key=${item.path} class="grid grid-cols-[minmax(120px,0.35fr)_1fr] gap-2 border-b border-[var(--white-6)] px-2 py-1.5 text-3xs">
-                <span class="font-mono text-[var(--accent)]">${item.path}</span>
-                <span class="text-[var(--text-body)]">${item.effect ?? prettyValue(item.value)}</span>
+                <span class="font-mono text-[var(--color-accent-fg)]">${item.path}</span>
+                <span class="text-[var(--color-fg-primary)]">${item.effect ?? prettyValue(item.value)}</span>
               </div>
             `)}
           </div>
@@ -251,12 +251,12 @@ export function PersonaGenerator() {
             onClick=${() => draft && void spawnKeeperFromPersona(draft.handle)}
           >키퍼 시작<//>
           ${saveResult?.profilePath ? html`
-            <span class="self-center text-3xs text-[var(--text-muted)]">${saveResult.profilePath}</span>
+            <span class="self-center text-3xs text-[var(--color-fg-muted)]">${saveResult.profilePath}</span>
           ` : null}
         </div>
 
         ${personaAuthoringResult.value ? html`
-          <pre class="max-h-48 overflow-auto rounded border border-[var(--white-10)] bg-[var(--white-4)] p-2 text-3xs ${personaAuthoringResult.value.success ? 'text-[var(--text-body)]' : 'text-[var(--bad)]'}">${personaAuthoringResult.value.message}</pre>
+          <pre class="max-h-48 overflow-auto rounded border border-[var(--white-10)] bg-[var(--white-4)] p-2 text-3xs ${personaAuthoringResult.value.success ? 'text-[var(--color-fg-primary)]' : 'text-[var(--color-status-err)]'}">${personaAuthoringResult.value.message}</pre>
         ` : null}
       </div>
     </div>

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -75,25 +75,25 @@ function signalTone(severity: string | null | undefined): string {
   // here explicitly before it is allowed to show as healthy.
   switch (severity) {
     case 'bad':
-      return 'border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad)]'
+      return 'border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--color-status-err)]'
     case 'warn':
-      return 'border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--warn)]'
+      return 'border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--color-status-warn)]'
     case 'ok':
-      return 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--ok)]'
+      return 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--color-status-ok)]'
     default:
       // Client-side observability: record unexpected severities so future
       // backend additions are noticed before they regress to silent-OK.
       if (typeof console !== 'undefined' && severity != null && severity !== '') {
         console.warn('[signalTone] unknown severity; rendering as warn', { severity })
       }
-      return 'border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--warn)]'
+      return 'border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--color-status-warn)]'
   }
 }
 
 function badgeTone(ok: boolean): string {
   return ok
-    ? 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--ok)]'
-    : 'border-[rgba(239,68,68,0.24)] bg-[var(--bad-10)] text-[var(--bad)]'
+    ? 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--color-status-ok)]'
+    : 'border-[rgba(239,68,68,0.24)] bg-[var(--bad-10)] text-[var(--color-status-err)]'
 }
 
 export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStateDiagramProps) {
@@ -157,7 +157,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
 
   if (loading) {
     return html`
-      <div class="flex items-center justify-center gap-2 py-6 text-2xs text-[var(--text-dim)]">
+      <div class="flex items-center justify-center gap-2 py-6 text-2xs text-[var(--color-fg-disabled)]">
         <${InlineSpinner} />
         composite lifecycle 로딩중
       </div>
@@ -170,8 +170,8 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="flex flex-wrap items-center gap-2 text-3xs text-[var(--text-dim)]">
-        <span class="inline-flex items-center rounded-sm border border-[var(--accent-30)] bg-[var(--accent-10)] px-2 py-0.5 text-[var(--accent)]">
+      <div class="flex flex-wrap items-center gap-2 text-3xs text-[var(--color-fg-disabled)]">
+        <span class="inline-flex items-center rounded-sm border border-[var(--accent-30)] bg-[var(--accent-10)] px-2 py-0.5 text-[var(--color-accent-fg)]">
           composite ${snapshot.phase}
         </span>
         ${keeperPhase ? html`
@@ -199,13 +199,13 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
       </div>
 
       ${phaseMismatch ? html`
-        <div class="rounded border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-2xs leading-normal text-[var(--text-body)]">
+        <div class="rounded border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-2xs leading-normal text-[var(--color-fg-primary)]">
           keeper row phase와 composite snapshot phase가 다릅니다. composite snapshot을 authoritative runtime-truth로 사용합니다.
         </div>
       ` : null}
 
       <div>
-        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)] mb-2">Composite Lifecycle (KSM · KTC · KDP · KCL · KMC)</div>
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)] mb-2">Composite Lifecycle (KSM · KTC · KDP · KCL · KMC)</div>
         <${CytoscapeFsm} spec=${compositeSpec} height="320px" />
       </div>
 
@@ -223,14 +223,14 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
 
       ${transitions.length > 0 ? html`
         <div class="grid gap-2">
-          <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">관측된 전이</div>
+          <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">관측된 전이</div>
           ${transitions.map(transition => html`
-            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-normal text-[var(--text-body)]">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-normal text-[var(--color-fg-primary)]">
               <div class="flex flex-wrap items-center gap-2">
-                <span class="font-mono text-[var(--text-strong)]">${normalizePhase(transition.prev_phase) ?? transition.prev_phase}</span>
-                <span class="text-[var(--text-dim)]">→</span>
-                <span class="font-mono text-[var(--accent)]">${normalizePhase(transition.new_phase) ?? transition.new_phase}</span>
-                <span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">
+                <span class="font-mono text-[var(--color-fg-secondary)]">${normalizePhase(transition.prev_phase) ?? transition.prev_phase}</span>
+                <span class="text-[var(--color-fg-disabled)]">→</span>
+                <span class="font-mono text-[var(--color-accent-fg)]">${normalizePhase(transition.new_phase) ?? transition.new_phase}</span>
+                <span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">
                   ${transition.event_type ?? transitionType(transition.selected_event)}
                 </span>
                 ${transition.operator_signal ? html`
@@ -240,10 +240,10 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
                 ` : null}
               </div>
               ${transition.operator_signal ? html`
-                <div class="mt-1 text-[var(--text-muted)]">
+                <div class="mt-1 text-[var(--color-fg-muted)]">
                   ${transition.operator_signal.summary}
                   ${transition.operator_signal.next_human_action
-                    ? html`<span class="text-[var(--warn)]"> · ${transition.operator_signal.next_human_action}</span>`
+                    ? html`<span class="text-[var(--color-status-warn)]"> · ${transition.operator_signal.next_human_action}</span>`
                     : null}
                 </div>
               ` : null}

--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -37,10 +37,10 @@ function SectionCard({ title, children }: { title: string; children: preact.Comp
 function registryStateBadge(state: string | null) {
   if (!state) return null
   const colors: Record<string, { bg: string; text: string }> = {
-    Running: { bg: 'bg-[var(--emerald-12)]', text: 'text-[var(--ok)]' },
-    Crashed: { bg: 'bg-[var(--bad-soft)]', text: 'text-[var(--bad)]' },
+    Running: { bg: 'bg-[var(--emerald-12)]', text: 'text-[var(--color-status-ok)]' },
+    Crashed: { bg: 'bg-[var(--bad-soft)]', text: 'text-[var(--color-status-err)]' },
     Dead: { bg: 'bg-[rgba(100,116,139,0.15)]', text: 'text-[var(--slate-400)]' },
-    Stopped: { bg: 'bg-[rgba(234,179,8,0.12)]', text: 'text-[var(--warn)]' },
+    Stopped: { bg: 'bg-[rgba(234,179,8,0.12)]', text: 'text-[var(--color-status-warn)]' },
     Paused: { bg: 'bg-[var(--white-10)]', text: 'text-[var(--purple)]' },
   }
   const c = colors[state] ?? { bg: 'bg-[rgba(138,163,211,0.1)]', text: 'text-[#86a0cf]' }
@@ -49,7 +49,7 @@ function registryStateBadge(state: string | null) {
 
 const COHORT_COLORS: Record<CrashCategory, string> = {
   heartbeat: 'var(--amber-bright)',
-  turn: 'var(--bad)',
+  turn: 'var(--color-status-err)',
   fiber: '#8b5cf6',
   exception: '#ec4899',
   other: '#6b7280',
@@ -64,7 +64,7 @@ function CrashCohortBar({ crash_log }: { crash_log: KeeperSupervisorCrashLogEntr
     .filter(([, count]) => count > 0)
   return html`
     <div>
-      <div class="text-3xs font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">장애 유형 분포</div>
+      <div class="text-3xs font-semibold uppercase tracking-widest text-[var(--color-fg-muted)] mb-2">장애 유형 분포</div>
       <div class="flex w-full h-3 rounded-sm overflow-hidden bg-[var(--white-5)]">
         ${entries.map(([key, count]) => html`
           <div style="width: ${(count / total * 100).toFixed(1)}%; background: ${COHORT_COLORS[key]}"
@@ -74,7 +74,7 @@ function CrashCohortBar({ crash_log }: { crash_log: KeeperSupervisorCrashLogEntr
       </div>
       <div class="flex flex-wrap gap-x-3 gap-y-1 mt-1.5">
         ${entries.map(([key, count]) => html`
-          <span class="text-3xs text-[var(--text-muted)] flex items-center gap-1">
+          <span class="text-3xs text-[var(--color-fg-muted)] flex items-center gap-1">
             <span class="inline-block w-2 h-2 rounded-full" style="background: ${COHORT_COLORS[key]}"></span>
             ${key} ${count}
           </span>
@@ -96,11 +96,11 @@ function SpEventsPanel({ sp_events }: { sp_events?: unknown[] }) {
   const entries = sp_events.slice(0, 10) as SpEventLike[]
   return html`
     <div>
-      <div class="text-3xs font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">자기 보호 발동 이력</div>
+      <div class="text-3xs font-semibold uppercase tracking-widest text-[var(--color-fg-muted)] mb-2">자기 보호 발동 이력</div>
       <div class="space-y-1 max-h-28 overflow-y-auto">
         ${entries.map((e) => html`
           <div class="flex items-center justify-between py-1 px-2 rounded text-2xs bg-[rgba(139,92,246,0.06)]">
-            <span class="font-mono text-[var(--text-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
+            <span class="font-mono text-[var(--color-fg-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
             <span class="text-[#8b5cf6]">${e.suppressed_count ?? 0}/${e.total ?? 0} 억제 (${e.dominant_cohort ?? '--'})</span>
           </div>
         `)}
@@ -125,24 +125,24 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
     dead_eta_sec,
   } = diag
   const budgetPct = max_restarts > 0 ? Math.min(100, (restart_count / max_restarts) * 100) : 0
-  const budgetColor = budgetPct >= 80 ? 'var(--bad)' : budgetPct >= 50 ? 'var(--amber-bright)' : 'var(--ok)'
+  const budgetColor = budgetPct >= 80 ? 'var(--color-status-err)' : budgetPct >= 50 ? 'var(--amber-bright)' : 'var(--color-status-ok)'
   const hs = typeof health_score === 'number' ? health_score : 100
-  const hsColor = hs >= 80 ? 'var(--ok)' : hs >= 50 ? 'var(--amber-bright)' : 'var(--bad)'
+  const hsColor = hs >= 80 ? 'var(--color-status-ok)' : hs >= 50 ? 'var(--amber-bright)' : 'var(--color-status-err)'
   return html`
     <${SectionCard} title="감독 진단">
       <div class="space-y-3">
         <div class="flex items-center justify-between">
-          <span class="text-xs text-[var(--text-muted)]">건강도</span>
+          <span class="text-xs text-[var(--color-fg-muted)]">건강도</span>
           <span class="text-sm font-bold font-mono" style="color: ${hsColor}">${hs}</span>
         </div>
         <div class="flex items-center justify-between">
-          <span class="text-xs text-[var(--text-muted)]">실행 상태</span>
+          <span class="text-xs text-[var(--color-fg-muted)]">실행 상태</span>
           ${registryStateBadge(keeper.registry_state ?? null)}
         </div>
         <div>
           <div class="flex items-center justify-between mb-1">
-            <span class="text-xs text-[var(--text-muted)]">재시작 예산</span>
-            <span class="text-xs font-mono text-[var(--text-body)]">${restart_count}/${max_restarts}</span>
+            <span class="text-xs text-[var(--color-fg-muted)]">재시작 예산</span>
+            <span class="text-xs font-mono text-[var(--color-fg-primary)]">${restart_count}/${max_restarts}</span>
           </div>
           <div class="w-full h-1.5 rounded-sm bg-[var(--white-5)] overflow-hidden">
             <div class="h-full rounded-sm transition-all duration-300" style="width: ${budgetPct}%; background: ${budgetColor}"></div>
@@ -150,13 +150,13 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
         </div>
         ${typeof dead_eta_sec === 'number' && dead_eta_sec > 0 && dead_since == null ? html`
           <div class="flex items-center justify-between">
-            <span class="text-xs text-[var(--text-muted)]">종료 예상</span>
-            <span class="text-2xs font-mono" style="color: ${budgetPct >= 50 ? 'var(--amber-bright)' : 'var(--text-body)'}">${dead_eta_sec >= 3600 ? (dead_eta_sec / 3600).toFixed(1) + 'h' : (dead_eta_sec / 60).toFixed(0) + 'm'} 후</span>
+            <span class="text-xs text-[var(--color-fg-muted)]">종료 예상</span>
+            <span class="text-2xs font-mono" style="color: ${budgetPct >= 50 ? 'var(--amber-bright)' : 'var(--color-fg-primary)'}">${dead_eta_sec >= 3600 ? (dead_eta_sec / 3600).toFixed(1) + 'h' : (dead_eta_sec / 60).toFixed(0) + 'm'} 후</span>
           </div>
         ` : null}
         ${last_failure_reason ? html`
           <div class="flex items-center justify-between">
-            <span class="text-xs text-[var(--text-muted)]">마지막 실패 원인</span>
+            <span class="text-xs text-[var(--color-fg-muted)]">마지막 실패 원인</span>
             <span class="text-2xs font-mono text-[var(--rose-light)]">${last_failure_reason}</span>
           </div>
         ` : null}
@@ -179,10 +179,10 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
           return html`
             <div>
               <div class="flex items-center justify-between mb-2">
-                <div class="text-3xs font-semibold uppercase tracking-widest text-[var(--text-muted)]">장애 이력</div>
+                <div class="text-3xs font-semibold uppercase tracking-widest text-[var(--color-fg-muted)]">장애 이력</div>
                 ${filtered.length > 10 ? html`
                   <button type="button"
-                    class="text-3xs font-medium px-2 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)] transition-colors"
+                    class="text-3xs font-medium px-2 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)] transition-colors"
                     onClick=${() => { crashShowAll.value = !crashShowAll.value }}
                     aria-pressed=${crashShowAll.value}>
                     ${crashShowAll.value ? `최근 10건 보기` : `전체 ${filtered.length}건 보기`}
@@ -200,10 +200,10 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
               ` : null}
               <div class="space-y-1 ${crashShowAll.value ? 'max-h-64' : 'max-h-32'} overflow-y-auto">
                 ${visible.length === 0 ? html`
-                  <div class="py-2 px-2 text-2xs text-[var(--text-muted)] italic">선택된 카테고리에 해당하는 장애가 없습니다.</div>
+                  <div class="py-2 px-2 text-2xs text-[var(--color-fg-muted)] italic">선택된 카테고리에 해당하는 장애가 없습니다.</div>
                 ` : visible.map((e) => html`
                   <div class="flex items-center justify-between py-1 px-2 rounded text-2xs bg-[var(--white-3)]">
-                    <span class="font-mono text-[var(--text-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
+                    <span class="font-mono text-[var(--color-fg-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
                     <span class="text-[var(--rose-light)]">${e.reason ?? 'unknown'}</span>
                   </div>
                 `)}

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -20,15 +20,15 @@ const formatTimestamp = formatTimeHms
 function sourceHealthClass(health?: string | null): string {
   switch ((health ?? '').toLowerCase()) {
     case 'ok':
-      return 'text-[var(--ok)]'
+      return 'text-[var(--color-status-ok)]'
     case 'stale':
     case 'coverage_gap':
     case 'empty':
-      return 'text-[var(--warn)]'
+      return 'text-[var(--color-status-warn)]'
     case 'missing':
       return 'text-[var(--bad-light)]'
     default:
-      return 'text-[var(--text-dim)]'
+      return 'text-[var(--color-fg-disabled)]'
   }
 }
 
@@ -42,7 +42,7 @@ function freshnessText(d: TelemetryFreshnessMetadata): string {
 
 function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
   return html`
-    <div class="text-3xs text-[var(--text-dim)]">
+    <div class="text-3xs text-[var(--color-fg-disabled)]">
       <span class="font-mono">${data.source ?? 'tool_call_io'}</span>
       <span class="mx-1">·</span>
       <span class="font-mono ${sourceHealthClass(data.health)}">${data.health ?? 'unknown'}</span>
@@ -122,7 +122,7 @@ function CopyableToolCallBlock({
           size=${12}
         />
       </div>
-      <pre class=${`text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto ${maxHeightClass} whitespace-pre-wrap text-[var(--text-strong)]`}>${value}</pre>
+      <pre class=${`text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto ${maxHeightClass} whitespace-pre-wrap text-[var(--color-fg-secondary)]`}>${value}</pre>
     </div>
   `
 }
@@ -135,7 +135,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
 
   return html`
     <div
-      class="border-b border-[var(--card-border)] hover:bg-[var(--bg-panel-hover)] transition-colors"
+      class="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
     >
       <button
         type="button"
@@ -144,15 +144,15 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
         onClick=${() => { expanded.value = !expanded.value }}
       >
         <span class="font-mono ${cat.color} w-4 text-center flex-shrink-0">${cat.icon}</span>
-        <span class="font-mono text-[var(--text-strong)] flex-shrink-0 w-16">${formatTimestamp(entry.ts)}</span>
-        <span class="font-mono font-medium text-[var(--text-strong)] truncate flex-1" title=${entry.tool}>${entry.tool}</span>
+        <span class="font-mono text-[var(--color-fg-secondary)] flex-shrink-0 w-16">${formatTimestamp(entry.ts)}</span>
+        <span class="font-mono font-medium text-[var(--color-fg-secondary)] truncate flex-1" title=${entry.tool}>${entry.tool}</span>
         <span class=${`font-mono flex-shrink-0 w-16 text-right ${durationColor(entry.duration_ms)}`}>
           ${formatDuration(entry.duration_ms)}
         </span>
-        <span class=${`flex-shrink-0 w-5 text-center ${entry.success ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}`}>
+        <span class=${`flex-shrink-0 w-5 text-center ${entry.success ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-err)]'}`}>
           ${entry.success ? 'O' : 'X'}
         </span>
-        <span class="flex-shrink-0 w-4 text-[var(--text-muted)] text-center">
+        <span class="flex-shrink-0 w-4 text-[var(--color-fg-muted)] text-center">
           ${expanded.value ? '-' : '+'}
         </span>
       </button>
@@ -160,7 +160,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
       ${expanded.value ? html`
         <div class="px-3 pb-3 space-y-2">
           ${entry.model ? html`
-            <div class="text-3xs text-[var(--text-muted)]">model: <span class="text-[var(--text-strong)] font-mono">${entry.model}</span></div>
+            <div class="text-3xs text-[var(--color-fg-muted)]">model: <span class="text-[var(--color-fg-secondary)] font-mono">${entry.model}</span></div>
           ` : null}
           <${CopyableToolCallBlock}
             title="Input"
@@ -210,7 +210,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   }
 
   if (resource.state.value.error) {
-    return html`<div class="text-xs text-[var(--bad)] p-4">${resource.state.value.error}</div>`
+    return html`<div class="text-xs text-[var(--color-status-err)] p-4">${resource.state.value.error}</div>`
   }
 
   const entries = allEntries
@@ -218,7 +218,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   if (entries.length === 0) {
     return html`
       <div class="p-4">
-        <div class="text-xs text-[var(--text-muted)]">도구 호출 데이터 없음</div>
+        <div class="text-xs text-[var(--color-fg-muted)]">도구 호출 데이터 없음</div>
         <${FreshnessLine} data=${response ?? { source: 'tool_call_io' }} />
       </div>
     `
@@ -234,23 +234,23 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   return html`
     <div class="space-y-3">
       <div class="flex items-center justify-between gap-3 flex-wrap">
-        <div class="flex gap-4 text-xs text-[var(--text-muted)]">
+        <div class="flex gap-4 text-xs text-[var(--color-fg-muted)]">
           <span>${totalCalls} calls</span>
           <span>${uniqueTools} tools</span>
-          <span class=${successRate < 80 ? 'text-[var(--warn)]' : ''}>${successRate}% ok</span>
+          <span class=${successRate < 80 ? 'text-[var(--color-status-warn)]' : ''}>${successRate}% ok</span>
         </div>
         <${FreshnessLine} data=${response ?? { source: 'tool_call_io' }} />
         <input
           type="text"
           placeholder="Filter tool..."
-          class="text-xs font-mono bg-[var(--bg-deep)] border border-[var(--card-border)] rounded px-2 py-1 w-40 text-[var(--text-strong)]"
+          class="text-xs font-mono bg-[var(--bg-deep)] border border-[var(--color-border-default)] rounded px-2 py-1 w-40 text-[var(--color-fg-secondary)]"
           value=${filterTool.value}
           onInput=${(e: Event) => { filterTool.value = (e.target as HTMLInputElement).value }}
         />
       </div>
 
-      <div class="border border-[var(--card-border)] rounded overflow-hidden max-h-[500px] overflow-y-auto">
-        <${SectionCap} class="flex items-center gap-2 px-3 py-1.5 bg-[var(--bg-deep)] border-b border-[var(--card-border)]">
+      <div class="border border-[var(--color-border-default)] rounded overflow-hidden max-h-[500px] overflow-y-auto">
+        <${SectionCap} class="flex items-center gap-2 px-3 py-1.5 bg-[var(--bg-deep)] border-b border-[var(--color-border-default)]">
           <span class="w-4"></span>
           <span class="w-16">시간</span>
           <span class="flex-1">도구</span>

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -23,15 +23,15 @@ interface TelemetryState extends TelemetryFreshnessMetadata {
 function sourceHealthClass(health?: string | null): string {
   switch ((health ?? '').toLowerCase()) {
     case 'ok':
-      return 'text-[var(--ok)]'
+      return 'text-[var(--color-status-ok)]'
     case 'stale':
     case 'coverage_gap':
     case 'empty':
-      return 'text-[var(--warn)]'
+      return 'text-[var(--color-status-warn)]'
     case 'missing':
       return 'text-[var(--bad-light)]'
     default:
-      return 'text-[var(--text-dim)]'
+      return 'text-[var(--color-fg-disabled)]'
   }
 }
 
@@ -45,7 +45,7 @@ function freshnessText(d: TelemetryFreshnessMetadata): string {
 
 function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
   return html`
-    <div class="text-3xs text-[var(--text-dim)]">
+    <div class="text-3xs text-[var(--color-fg-disabled)]">
       <span class="font-mono">${data.source ?? 'trajectory_tool_call'}</span>
       <span class="mx-1">·</span>
       <span class="font-mono ${sourceHealthClass(data.health)}">${data.health ?? 'unknown'}</span>
@@ -101,10 +101,10 @@ function Sparkline({ buckets, height = 32 }: { buckets: HourlyBucket[]; height?:
     return html`
       <g key=${i}>
         <rect x=${x} y=${y} width=${barW} height=${barH} rx="1.5"
-          fill="var(--accent)" opacity="0.5" />
+          fill="var(--color-accent-fg)" opacity="0.5" />
         ${errH > 0 ? html`
           <rect x=${x} y=${height - errH} width=${barW} height=${errH} rx="1.5"
-            fill="var(--bad)" opacity="0.7" />
+            fill="var(--color-status-err)" opacity="0.7" />
         ` : null}
       </g>
     `
@@ -120,7 +120,7 @@ function Sparkline({ buckets, height = 32 }: { buckets: HourlyBucket[]; height?:
     const x = i * (barW + gap) + barW / 2
     return html`
       <text key=${'lbl' + i} x=${x} y=${height + 10} text-anchor="middle"
-        fill="var(--text-dim)" font-size="8" font-family="monospace">
+        fill="var(--color-fg-disabled)" font-size="8" font-family="monospace">
         ${label}
       </text>
     `
@@ -138,11 +138,11 @@ function Sparkline({ buckets, height = 32 }: { buckets: HourlyBucket[]; height?:
 
 function SuccessRateBar({ stat }: { stat: ToolStat }) {
   const successPct = stat.call_count > 0 ? (stat.success_count / stat.call_count) * 100 : 100
-  let barColor = 'var(--bad)'
+  let barColor = 'var(--color-status-err)'
   if (successPct >= 95) {
-    barColor = 'var(--ok)'
+    barColor = 'var(--color-status-ok)'
   } else if (successPct >= 80) {
-    barColor = 'var(--warn)'
+    barColor = 'var(--color-status-warn)'
   }
 
   return html`
@@ -211,13 +211,13 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
   // operators can distinguish no calls from a broken trajectory lane.
   if (asyncState.loading) return null
   if (asyncState.error) {
-    return html`<div class="text-xs text-[var(--bad)] py-2 px-3">텔레메트리 로드 실패: ${asyncState.error}</div>`
+    return html`<div class="text-xs text-[var(--color-status-err)] py-2 px-3">텔레메트리 로드 실패: ${asyncState.error}</div>`
   }
 
   if (s.tools.length === 0) {
     return html`
-      <div class="p-4 rounded border border-[var(--card-border)] bg-card/30">
-        <div class="text-xs text-[var(--text-muted)]">도구 텔레메트리 데이터 없음</div>
+      <div class="p-4 rounded border border-[var(--color-border-default)] bg-card/30">
+        <div class="text-xs text-[var(--color-fg-muted)]">도구 텔레메트리 데이터 없음</div>
         <${FreshnessLine} data=${s} />
       </div>
     `
@@ -244,18 +244,18 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
 
       ${'' /* Summary row */}
       <div class="flex gap-3 flex-wrap text-2xs">
-        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">
-          <span class="font-mono font-medium text-[var(--text-strong)]">${s.tools.length}</span> 도구
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--color-fg-muted)]">
+          <span class="font-mono font-medium text-[var(--color-fg-secondary)]">${s.tools.length}</span> 도구
         </span>
-        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">
-          <span class="font-mono font-medium text-[var(--text-strong)]">${s.totalEntries}</span> 호출
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--color-fg-muted)]">
+          <span class="font-mono font-medium text-[var(--color-fg-secondary)]">${s.totalEntries}</span> 호출
         </span>
         ${totalCost > 0 ? html`
-          <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--accent-12)] border border-[var(--accent-15)] text-[var(--text-muted)]">
-            <span class="font-mono font-medium text-[var(--accent)]">$${totalCost.toFixed(3)}</span>
+          <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--accent-12)] border border-[var(--accent-15)] text-[var(--color-fg-muted)]">
+            <span class="font-mono font-medium text-[var(--color-accent-fg)]">$${totalCost.toFixed(3)}</span>
           </span>
         ` : null}
-        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-dim)]">
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--color-fg-disabled)]">
           ${s.windowHours}h 기간
         </span>
       </div>
@@ -282,9 +282,9 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
               placeholder="도구 검색 (이름/카테고리)"
               aria-label="도구 텔레메트리 검색"
               onInput=${(e: Event) => { setQuery((e.target as HTMLInputElement).value) }}
-              class="min-w-40 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+              class="min-w-40 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
             />
-            <span class="text-3xs text-[var(--text-muted)] tabular-nums">
+            <span class="text-3xs text-[var(--color-fg-muted)] tabular-nums">
               ${trimmedQuery
                 ? `${visibleTools.length} / ${s.tools.length}`
                 : `${s.tools.length}개`}
@@ -292,7 +292,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
           </div>
         </div>
         ${visibleTools.length === 0 ? html`
-          <div class="text-2xs text-[var(--text-muted)] py-2 px-2">
+          <div class="text-2xs text-[var(--color-fg-muted)] py-2 px-2">
             필터 결과 없음 (${s.tools.length} items)
           </div>
         ` : visibleTools.slice(0, 15).map(stat => {
@@ -303,15 +303,15 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
               <div class="size-5 rounded flex-shrink-0 bg-[var(--white-5)] flex items-center justify-center text-3xs font-mono font-bold ${cat.color}">
                 ${cat.icon}
               </div>
-              <div class="w-28 flex-shrink-0 text-2xs font-mono text-[var(--text-muted)] truncate" title=${stat.name}>
+              <div class="w-28 flex-shrink-0 text-2xs font-mono text-[var(--color-fg-muted)] truncate" title=${stat.name}>
                 ${stat.name.replace(/^(keeper_|masc_)/, '')}
               </div>
               <div class="flex-1 h-3 rounded bg-[var(--white-5)] overflow-hidden">
                 <div class="h-full rounded transition-all duration-300"
-                  style="width: ${barWidth}%; background: ${stat.failure_count > 0 ? 'var(--warn)' : 'var(--accent)'}; opacity: 0.7">
+                  style="width: ${barWidth}%; background: ${stat.failure_count > 0 ? 'var(--color-status-warn)' : 'var(--color-accent-fg)'}; opacity: 0.7">
                 </div>
               </div>
-              <span class="w-8 text-right text-2xs font-mono text-[var(--text-muted)]">${stat.call_count}</span>
+              <span class="w-8 text-right text-2xs font-mono text-[var(--color-fg-muted)]">${stat.call_count}</span>
               <span class="w-14 text-right text-3xs font-mono ${durationColor(stat.avg_duration_ms)}">
                 ${formatDuration(stat.avg_duration_ms)}
               </span>
@@ -326,11 +326,11 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
           <${SectionCap} tone="dim" weight="semibold" class="mb-1">성공률<//>
           ${s.tools.filter(st => st.failure_count > 0).map(stat => html`
             <div class="flex items-center gap-2">
-              <span class="w-28 flex-shrink-0 text-2xs font-mono text-[var(--text-muted)] truncate">
+              <span class="w-28 flex-shrink-0 text-2xs font-mono text-[var(--color-fg-muted)] truncate">
                 ${stat.name.replace(/^(keeper_|masc_)/, '')}
               </span>
               <${SuccessRateBar} stat=${stat} />
-              <span class="text-3xs text-[var(--bad)] w-10 text-right">${stat.failure_count}err</span>
+              <span class="text-3xs text-[var(--color-status-err)] w-10 text-right">${stat.failure_count}err</span>
             </div>
           `)}
         </div>
@@ -342,9 +342,9 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
           <${SectionCap} tone="dim" weight="semibold" class="mb-1">P95 지연 시간<//>
           ${slowest.map(stat => html`
             <div class="flex items-center justify-between py-1 px-2 rounded bg-[var(--white-3)]">
-              <span class="text-2xs font-mono text-[var(--text-muted)]">${stat.name.replace(/^(keeper_|masc_)/, '')}</span>
+              <span class="text-2xs font-mono text-[var(--color-fg-muted)]">${stat.name.replace(/^(keeper_|masc_)/, '')}</span>
               <div class="flex items-center gap-3">
-                <span class="text-3xs text-[var(--text-dim)]">avg ${formatDuration(stat.avg_duration_ms)}</span>
+                <span class="text-3xs text-[var(--color-fg-disabled)]">avg ${formatDuration(stat.avg_duration_ms)}</span>
                 <span class="text-2xs font-mono font-medium ${durationColor(stat.p95_duration_ms)}">p95 ${formatDuration(stat.p95_duration_ms)}</span>
               </div>
             </div>

--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -64,8 +64,8 @@ function InspectorTabButton({
       class=${[
         'rounded-sm border px-3 py-1.5 text-2xs font-semibold transition-colors',
         active
-          ? 'border-accent/30 bg-[var(--accent-10)] text-[var(--accent)]'
-          : 'border-card-border bg-[var(--white-3)] text-[var(--text-muted)] hover:text-[var(--text-body)] hover:bg-[var(--white-6)]',
+          ? 'border-accent/30 bg-[var(--accent-10)] text-[var(--color-accent-fg)]'
+          : 'border-card-border bg-[var(--white-3)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] hover:bg-[var(--white-6)]',
       ].join(' ')}
       onClick=${() => {
         inspectorSection.value = id
@@ -81,18 +81,18 @@ function InspectorOverview() {
     <div class="grid gap-4">
       <${Card} title="대시보드 포커스" class="section">
         <div class="grid gap-3">
-          <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3 text-sm leading-airy text-[var(--text-body)]">
-            이제 대시보드는 <strong class="text-[var(--text-strong)]">핵심 운영 화면</strong>에 더 집중합니다.
+          <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3 text-sm leading-airy text-[var(--color-fg-primary)]">
+            이제 대시보드는 <strong class="text-[var(--color-fg-secondary)]">핵심 운영 화면</strong>에 더 집중합니다.
             낮은 활용도의 화면은 줄이고, 진짜 자주 보는 상태/개입/근거 화면으로 빠르게 이동할 수 있게 정리했습니다.
           </div>
           <div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
             ${FOCUS_SURFACES.map(surface => html`
               <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3">
-                <div class="text-xs font-semibold text-[var(--text-strong)]">${surface.title}</div>
-                <div class="mt-2 text-2xs leading-loose text-[var(--text-muted)]">${surface.description}</div>
+                <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">${surface.title}</div>
+                <div class="mt-2 text-2xs leading-loose text-[var(--color-fg-muted)]">${surface.description}</div>
                 <button
                   type="button"
-                  class="mt-3 rounded border border-accent/25 bg-[var(--accent-10)] px-2.5 py-1.5 text-2xs font-semibold text-[var(--accent)] transition-colors hover:bg-[var(--accent-20)]"
+                  class="mt-3 rounded border border-accent/25 bg-[var(--accent-10)] px-2.5 py-1.5 text-2xs font-semibold text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--accent-20)]"
                   onClick=${() => navigate(surface.tab, surface.params)}
                 >
                   ${surface.action}
@@ -113,7 +113,7 @@ export function LabInspector() {
     <div class="flex flex-col gap-4">
       <${Card} title="운영 인스펙터" class="section">
         <div class="flex flex-col gap-3">
-          <div class="text-sm leading-airy text-[var(--text-body)]">
+          <div class="text-sm leading-airy text-[var(--color-fg-primary)]">
             피처 플래그와 서버 설정을 한 곳에서 보고, 대시보드에서 실제 자주 쓰는 운영 화면으로 빠르게 이동합니다.
           </div>
           <div class="flex flex-wrap gap-2">

--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -21,8 +21,8 @@ export function Live({ variant = 'full' }: LiveProps) {
         <section class="monitor-surface-card monitor-surface-card-strong px-5 py-4">
           <div class="flex flex-col gap-2">
             <div class="flex flex-col gap-2">
-              <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--text-strong)]">라이브 모니터</h2>
-              <p class="m-0 text-sm leading-paragraph text-[var(--text-body)]">실시간 이벤트 흐름과 활성 에이전트 상태를 한 화면에서 봅니다.</p>
+              <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--color-fg-secondary)]">라이브 모니터</h2>
+              <p class="m-0 text-sm leading-paragraph text-[var(--color-fg-primary)]">실시간 이벤트 흐름과 활성 에이전트 상태를 한 화면에서 봅니다.</p>
             </div>
           </div>
         </section>

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -29,8 +29,8 @@ function FilterBar() {
         <button type="button"
           key=${opt.kind}
           class="px-3 py-1.5 text-2xs rounded-sm border cursor-pointer transition-all duration-150 ${active.has(opt.kind)
-            ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--text-strong)]'
-            : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[var(--border-slate-22)] hover:text-[var(--text-body)]'}"
+            ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--color-fg-secondary)]'
+            : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:border-[var(--border-slate-22)] hover:text-[var(--color-fg-primary)]'}"
           onClick=${() => toggleLiveFilter(opt.kind)}
         >
           ${opt.label}
@@ -46,8 +46,8 @@ export function ActivityStream() {
   return html`
     <div class="grid gap-3 grid-rows-[auto_auto_1fr] min-h-0">
       <div class="activity-stream-head flex items-center justify-between gap-3 border-b border-[var(--border-slate-12)] pb-3">
-        <h3 class="m-0 text-[0.95rem] font-semibold text-[var(--text-strong)]">활동 스트림</h3>
-        <span class="text-xs text-[var(--text-muted)]">${totalEvents.value} 수신 · ${entries.length} 표시</span>
+        <h3 class="m-0 text-[0.95rem] font-semibold text-[var(--color-fg-secondary)]">활동 스트림</h3>
+        <span class="text-xs text-[var(--color-fg-muted)]">${totalEvents.value} 수신 · ${entries.length} 표시</span>
       </div>
       <${FilterBar} />
       <div class="activity-stream-list grid max-h-[52vh] min-h-0 content-start gap-2 overflow-y-auto pr-1">
@@ -64,10 +64,10 @@ export function ActivityStream() {
             >
               <div class="activity-item-head flex items-center gap-2">
                 <span class="activity-kind-chip rounded px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.04em] ${eventKindColor(entry)}">${eventKindLabel(entry)}</span>
-                <span class="text-[0.75rem] text-[var(--text-body)] font-medium">${entry.agent}</span>
-                <span class="text-[0.7rem] text-[var(--text-muted)] ml-auto">${formatTimeAgo(entry.timestamp)}</span>
+                <span class="text-[0.75rem] text-[var(--color-fg-primary)] font-medium">${entry.agent}</span>
+                <span class="text-[0.7rem] text-[var(--color-fg-muted)] ml-auto">${formatTimeAgo(entry.timestamp)}</span>
               </div>
-              <div class="text-sm text-[var(--text-body)] leading-normal break-words">${entry.text}</div>
+              <div class="text-sm text-[var(--color-fg-primary)] leading-normal break-words">${entry.text}</div>
             </div>
           `)}
       </div>

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -35,13 +35,13 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
         ? null
         : html`
             <div class="focus-sidebar-head flex items-center justify-between gap-3 border-b border-[var(--border-slate-12)] pb-3">
-              <h3 class="m-0 text-[0.95rem] font-semibold text-[var(--text-strong)]">에이전트</h3>
-              <span class="text-xs text-[var(--text-muted)]">${list.length}명 활성</span>
+              <h3 class="m-0 text-[0.95rem] font-semibold text-[var(--color-fg-secondary)]">에이전트</h3>
+              <span class="text-xs text-[var(--color-fg-muted)]">${list.length}명 활성</span>
             </div>
           `}
       <div class="grid content-start gap-1.5 overflow-y-auto pr-1 ${compact ? 'max-h-[32vh]' : 'max-h-140'}">
         ${list.length === 0
-          ? html`<div class="py-6 text-center text-[var(--text-muted)] text-sm">활성 에이전트 없음. masc_join으로 접속하면 여기에 표시됩니다.</div>`
+          ? html`<div class="py-6 text-center text-[var(--color-fg-muted)] text-sm">활성 에이전트 없음. masc_join으로 접속하면 여기에 표시됩니다.</div>`
           : list.map(agent => html`
             <button
               type="button"
@@ -50,7 +50,7 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
               onClick=${() => openAgentDetail(agent.name)}
             >
               <div class="focus-agent-header">
-                <span class="text-[0.85rem] font-medium text-[var(--text-strong)] flex items-center gap-1">
+                <span class="text-[0.85rem] font-medium text-[var(--color-fg-secondary)] flex items-center gap-1">
                   ${agent.emoji ? html`<span class="text-[0.95rem]">${agent.emoji}</span>` : null}
                   ${agent.koreanName ?? agent.name}
                 </span>
@@ -60,12 +60,12 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
                 </span>
               </div>
               ${agent.currentTask
-                ? html`<div class="text-[0.75rem] text-[var(--text-body)] py-[3px] px-2 bg-[var(--white-2)] border border-[var(--border-slate-12)] whitespace-nowrap overflow-hidden text-ellipsis rounded">${agent.currentTask}</div>`
+                ? html`<div class="text-[0.75rem] text-[var(--color-fg-primary)] py-[3px] px-2 bg-[var(--white-2)] border border-[var(--border-slate-12)] whitespace-nowrap overflow-hidden text-ellipsis rounded">${agent.currentTask}</div>`
                 : null}
               <div class="flex items-center gap-2 mt-1">
                 ${agent.lastActivityText
-                  ? html`<span class="text-2xs text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0">${agent.lastActivityText}</span>`
-                  : html`<span class="text-2xs text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0 italic">최근 활동 없음</span>`}
+                  ? html`<span class="text-2xs text-[var(--color-fg-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0">${agent.lastActivityText}</span>`
+                  : html`<span class="text-2xs text-[var(--color-fg-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0 italic">최근 활동 없음</span>`}
                 ${agent.lastActivityAt
                   ? html`<${TimeAgo} timestamp=${agent.lastActivityAt} />`
                   : null}

--- a/dashboard/src/components/live/keeper-health-strip.ts
+++ b/dashboard/src/components/live/keeper-health-strip.ts
@@ -5,10 +5,10 @@ import { keeperHealthSummary, type KeeperPressure } from '../../live-store'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from '../../config/constants'
 
 function pressureColor(ratio: number): string {
-  if (ratio > CONTEXT_RATIO_CRITICAL) return 'bg-[var(--bad)]'
-  if (ratio > CONTEXT_RATIO_WARN) return 'bg-[var(--warn)]'
-  if (ratio > CONTEXT_RATIO_COMPACTING) return 'bg-[var(--warn)]'
-  return 'bg-[var(--ok)]'
+  if (ratio > CONTEXT_RATIO_CRITICAL) return 'bg-[var(--color-status-err)]'
+  if (ratio > CONTEXT_RATIO_WARN) return 'bg-[var(--color-status-warn)]'
+  if (ratio > CONTEXT_RATIO_COMPACTING) return 'bg-[var(--color-status-warn)]'
+  return 'bg-[var(--color-status-ok)]'
 }
 
 function stageIndicator(stage: string): string {
@@ -36,12 +36,12 @@ export function KeeperHealthStrip() {
   return html`
     <div class="flex items-center gap-4 rounded border border-[var(--border-slate-12)] bg-[var(--white-3)] px-4 py-2.5">
       <div class="flex items-center gap-2 min-w-0">
-        <span class="text-sm font-medium text-[var(--text-strong)] whitespace-nowrap">
+        <span class="text-sm font-medium text-[var(--color-fg-secondary)] whitespace-nowrap">
           Keeper
         </span>
-        <span class="text-sm text-[var(--text-body)] whitespace-nowrap">
+        <span class="text-sm text-[var(--color-fg-primary)] whitespace-nowrap">
           ${summary.activeCount} 활성
-          <span class="text-[var(--text-muted)]">/ ${summary.totalCount}</span>
+          <span class="text-[var(--color-fg-muted)]">/ ${summary.totalCount}</span>
         </span>
       </div>
 
@@ -53,11 +53,11 @@ export function KeeperHealthStrip() {
 
       <div class="flex items-center gap-2 ml-auto whitespace-nowrap">
         ${alertCount > 0
-          ? html`<span class="text-xs font-medium text-[var(--warn)]">${alertCount} 주의</span>`
-          : html`<span class="text-xs text-[var(--text-muted)]">정상</span>`
+          ? html`<span class="text-xs font-medium text-[var(--color-status-warn)]">${alertCount} 주의</span>`
+          : html`<span class="text-xs text-[var(--color-fg-muted)]">정상</span>`
         }
         ${summary.criticalCount > 0 && html`
-          <span class="text-xs font-medium text-[var(--bad)]">${summary.criticalCount} 위험</span>
+          <span class="text-xs font-medium text-[var(--color-status-err)]">${summary.criticalCount} 위험</span>
         `}
       </div>
     </div>

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -19,7 +19,7 @@ export function PulseStrip() {
   if (pulses.length === 0) {
     return html`
       <div class="pulse-strip rounded">
-        <span class="text-[var(--text-dim)] text-sm">연결된 에이전트 없음. masc_join으로 에이전트가 접속하면 여기에 표시됩니다.</span>
+        <span class="text-[var(--color-fg-disabled)] text-sm">연결된 에이전트 없음. masc_join으로 에이전트가 접속하면 여기에 표시됩니다.</span>
       </div>
     `
   }
@@ -34,7 +34,7 @@ export function PulseStrip() {
           title="${p.koreanName ? `${p.name} (${p.koreanName})` : p.name}${p.currentTask ? ` — ${p.currentTask}` : ''}"
         >
           <span class="text-[1.15rem] leading-none">${p.emoji || p.name.charAt(0).toUpperCase()}</span>
-          <span class="text-[0.65rem] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis max-w-16">${p.koreanName ?? p.name}</span>
+          <span class="text-[0.65rem] text-[var(--color-fg-muted)] whitespace-nowrap overflow-hidden text-ellipsis max-w-16">${p.koreanName ?? p.name}</span>
         </button>
       `)}
     </div>

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -28,8 +28,8 @@ let moduleDebounceTimer: ReturnType<typeof setTimeout> | null = null
 let latestRequestId = 0
 
 const LEVEL_COLORS: Record<string, string> = {
-  DEBUG: 'var(--text-muted)',
-  INFO: 'var(--text-body)',
+  DEBUG: 'var(--color-fg-muted)',
+  INFO: 'var(--color-fg-primary)',
   WARN: '#e6a700',
   ERROR: '#e05050',
 }
@@ -178,7 +178,7 @@ function sourceTone(source: string): string {
     case 'legacy_traceln':
       return 'text-[#ffd88a] bg-[rgba(230,167,0,0.12)] border-[rgba(230,167,0,0.18)]'
     default:
-      return 'text-[var(--text-muted)] bg-[var(--white-3)] border-[var(--white-10)]'
+      return 'text-[var(--color-fg-muted)] bg-[var(--white-3)] border-[var(--white-10)]'
   }
 }
 
@@ -247,13 +247,13 @@ function renderLogRow(entry: LogEntry) {
       key=${entry.seq}
       class="logs-row grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 rounded-card border border-[rgba(255,255,255,0.05)] px-3 py-3 ${backgroundClass}"
     >
-      <div class="font-mono text-2xs whitespace-nowrap text-[color:var(--text-muted)]">
+      <div class="font-mono text-2xs whitespace-nowrap text-[color:var(--color-fg-muted)]">
         ${entry.ts.replace('T', ' ').replace('Z', '')}
       </div>
       <div class="font-mono text-2xs font-semibold whitespace-nowrap" style="color: ${LEVEL_COLORS[level] ?? 'inherit'}">
         ${level}
       </div>
-      <div class="min-w-0 font-mono text-2xs text-[color:var(--accent)] truncate" title=${entry.module || '(root)'}>
+      <div class="min-w-0 font-mono text-2xs text-[color:var(--color-accent-fg)] truncate" title=${entry.module || '(root)'}>
         ${entry.module || '(root)'}
       </div>
       <div class="flex flex-wrap items-start gap-1">
@@ -261,41 +261,41 @@ function renderLogRow(entry: LogEntry) {
           ${sourceLabel(source)}
         </span>
         ${entry.legacy_classified
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">classified</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">classified</span>`
           : null}
         ${rawLevelChanged
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">${entry.raw_level}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">${entry.raw_level}</span>`
           : null}
         ${clientName
           ? html`<span class="rounded-sm border border-[var(--accent-soft)] px-2 py-0.5 text-3xs text-[#dff3ff]">${clientName}</span>`
           : null}
         ${toolName
-          ? html`<span class="inline-flex items-center gap-1 rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span class="text-[var(--text-muted)]">${toolName}</span></span>`
+          ? html`<span class="inline-flex items-center gap-1 rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span class="text-[var(--color-fg-muted)]">${toolName}</span></span>`
           : null}
         ${fixes
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">fixes ${fixes}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">fixes ${fixes}</span>`
           : null}
         ${phase
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">${phase}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">${phase}</span>`
           : null}
         ${requestId
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">req ${requestId}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">req ${requestId}</span>`
           : null}
         ${sessionId
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">session ${sessionId}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">session ${sessionId}</span>`
           : null}
         ${failure
           ? html`<span class="rounded-sm border border-[rgba(224,80,80,0.24)] bg-[var(--brick-soft)] px-2 py-0.5 text-3xs text-[var(--bad-light)]">${failure.cause_code}</span>`
           : null}
         ${failure
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">${failure.recoverability}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">${failure.recoverability}</span>`
           : null}
         ${failure?.operator_action
           ? html`<span class="rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-3xs text-[#dff3ff]">next ${failure.operator_action}</span>`
           : null}
       </div>
       <div
-        class="text-xs leading-relaxed text-[var(--text-body)]"
+        class="text-xs leading-relaxed text-[var(--color-fg-primary)]"
         title=${failure ? `${renderedMessage}\n${failure.summary}` : renderedMessage}
         style=${{
           display: '-webkit-box',
@@ -368,7 +368,7 @@ export function LogViewer() {
             <select
               name="log-level"
               aria-label="로그 레벨"
-              class="logs-select rounded border border-[var(--white-10)] bg-[var(--white-3)] px-3 py-2 text-xs text-[var(--text-body)]"
+              class="logs-select rounded border border-[var(--white-10)] bg-[var(--white-3)] px-3 py-2 text-xs text-[var(--color-fg-primary)]"
               value=${levelFilter.value}
               onChange=${(e: Event) => {
                 levelFilter.value = (e.target as HTMLSelectElement).value
@@ -405,7 +405,7 @@ export function LogViewer() {
             <select
               name="log-limit"
               aria-label="로그 개수"
-              class="logs-select rounded border border-[var(--white-10)] bg-[var(--white-3)] px-3 py-2 text-xs text-[var(--text-body)]"
+              class="logs-select rounded border border-[var(--white-10)] bg-[var(--white-3)] px-3 py-2 text-xs text-[var(--color-fg-primary)]"
               value=${String(logLimit.value)}
               onChange=${(e: Event) => {
                 logLimit.value = parseInt((e.target as HTMLSelectElement).value, 10)
@@ -419,7 +419,7 @@ export function LogViewer() {
             </select>
           </div>
 
-          <div class="logs-actions flex flex-wrap gap-3 items-center text-2xs text-[color:var(--text-muted)]">
+          <div class="logs-actions flex flex-wrap gap-3 items-center text-2xs text-[color:var(--color-fg-muted)]">
             <span class="rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-1 tabular-nums">${logEntries.length.toLocaleString()} / ${logTotal.toLocaleString()}</span>
             <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
               <input
@@ -451,7 +451,7 @@ export function LogViewer() {
         ` : null}
 
         <div class="px-3 pt-3">
-          <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)]">
+          <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">
             <div>timestamp</div>
             <div>level</div>
             <div>module</div>
@@ -462,7 +462,7 @@ export function LogViewer() {
 
         ${logEntries.length === 0
           ? html`
-              <div class="flex flex-1 items-center justify-center px-6 text-sm text-[var(--text-muted)]">
+              <div class="flex flex-1 items-center justify-center px-6 text-sm text-[var(--color-fg-muted)]">
                 ${logLoading ? '로그를 불러오는 중...' : '조건에 맞는 로그가 없습니다.'}
               </div>
             `

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -42,7 +42,7 @@ function expiryChip(post: BoardPost) {
   const expiresAtMs = Date.parse(post.expires_at)
   if (!Number.isFinite(expiresAtMs)) return null
   if (expiresAtMs <= Date.now()) return html`<span class="inline-flex items-center px-2 py-0.5 rounded-sm text-3xs tracking-wide uppercase bg-[var(--bad-15)] text-[var(--bad-light)] border border-[var(--bad-30)]">만료됨</span>`
-  return html`<span class="inline-flex items-center px-2 py-0.5 rounded-sm text-3xs tracking-wide uppercase bg-[var(--warn-15)] text-[var(--warn)] border border-[var(--warn-30)]">만료까지 <${TimeAgo} timestamp=${post.expires_at} /></span>`
+  return html`<span class="inline-flex items-center px-2 py-0.5 rounded-sm text-3xs tracking-wide uppercase bg-[var(--warn-15)] text-[var(--color-status-warn)] border border-[var(--warn-30)]">만료까지 <${TimeAgo} timestamp=${post.expires_at} /></span>`
 }
 
 // ── Comment tree building ──────────────────────────────────────────
@@ -143,17 +143,17 @@ function CommentItem({
       <div class="board-comment rounded p-3 bg-[var(--white-3)] border border-[var(--border-slate-12)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
         <div class="flex items-center gap-2 mb-1.5">
           <span class="text-xs">${authorAvatar(authorAvatarKey)}</span>
-          <button type="button" class="text-xs font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" title=${authorTitle} onClick=${() => navigateToAuthor(comment.author, undefined, comment.author_identity)}>${authorLabel}</button>
-          <span class="text-2xs text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
+          <button type="button" class="text-xs font-medium text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] transition-colors cursor-pointer bg-transparent border-none p-0" title=${authorTitle} onClick=${() => navigateToAuthor(comment.author, undefined, comment.author_identity)}>${authorLabel}</button>
+          <span class="text-2xs text-[var(--color-fg-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
           <button type="button"
-            class="text-2xs text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 ml-auto"
+            class="text-2xs text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] cursor-pointer bg-transparent border-0 ml-auto"
             onClick=${() => { replyingTo.value = isReplying ? null : comment.id; commentText.value = '' }}
           >${isReplying ? '취소' : '답글'}</button>
         </div>
-        <div class="text-sm text-[var(--text-body)] leading-paragraph"><${RichContent} text=${displayText} previewLimit=${1} /></div>
+        <div class="text-sm text-[var(--color-fg-primary)] leading-paragraph"><${RichContent} text=${displayText} previewLimit=${1} /></div>
         ${needsTruncation ? html`
           <button type="button"
-            class="mt-1 text-2xs text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0"
+            class="mt-1 text-2xs text-[var(--color-accent-fg)] hover:underline cursor-pointer bg-transparent border-0"
             onClick=${() => setExpanded(!expanded)}
           >${expanded ? '접기' : '더 보기...'}</button>
         ` : null}
@@ -172,8 +172,8 @@ function CommentItem({
               <button type="button"
                 class="py-1.5 px-3 rounded text-xs font-medium font-[inherit] cursor-pointer transition-all duration-150 border
                   ${commentSubmitting.value || commentText.value.trim() === ''
-                    ? 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
-                    : 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
+                    ? 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
+                    : 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
                   }"
                 onClick=${() => submitComment(postId, comment.id)}
                 disabled=${commentSubmitting.value || commentText.value.trim() === ''}
@@ -216,14 +216,14 @@ export function CommentThread({ comments, postId }: { comments: BoardComment[]; 
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-2 mb-1">
-        <div class="text-2xs text-[var(--text-muted)]">댓글 ${comments.length}개${isFiltering ? ` · 일치 ${filteredRoots.length}` : ''}</div>
+        <div class="text-2xs text-[var(--color-fg-muted)]">댓글 ${comments.length}개${isFiltering ? ` · 일치 ${filteredRoots.length}` : ''}</div>
         <input
           type="search"
           value=${query.value}
           placeholder="댓글 내용 검색"
           aria-label="댓글 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="ml-auto min-w-35 max-w-55 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="ml-auto min-w-35 max-w-55 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && filteredRoots.length === 0 ? html`
@@ -231,14 +231,14 @@ export function CommentThread({ comments, postId }: { comments: BoardComment[]; 
       ` : null}
       ${!expanded && hiddenCount > 0 ? html`
         <button type="button"
-          class="text-xs text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0 text-left py-1"
+          class="text-xs text-[var(--color-accent-fg)] hover:underline cursor-pointer bg-transparent border-0 text-left py-1"
           onClick=${() => setExpanded(true)}
         >이전 댓글 ${hiddenCount}개 더 보기</button>
       ` : null}
       ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} childrenMap=${filteredChildrenMap} />`)}
       ${expanded && hiddenCount > 0 ? html`
         <button type="button"
-          class="text-xs text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 text-left py-1"
+          class="text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] cursor-pointer bg-transparent border-0 text-left py-1"
           onClick=${() => setExpanded(false)}
         >접기</button>
       ` : null}
@@ -263,8 +263,8 @@ function CommentForm({ postId }: { postId: string }) {
         <button type="button"
           class="py-2 px-4 rounded text-sm font-medium font-[inherit] cursor-pointer transition-all duration-150 border
             ${commentSubmitting.value || commentText.value.trim() === ''
-              ? 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
-              : 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
+              ? 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
+              : 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
             }"
           onClick=${() => submitComment(postId)}
           disabled=${commentSubmitting.value || commentText.value.trim() === ''}
@@ -300,26 +300,26 @@ export function PostDetail({ post }: { post: BoardPost }) {
   return html`
     <div>
       <button type="button"
-        class="mb-4 px-3 py-1.5 rounded text-xs font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
+        class="mb-4 px-3 py-1.5 rounded text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] transition-all cursor-pointer"
         onClick=${() => navigate('workspace', { section: 'board' })}
       >← 게시판으로 돌아가기</button>
 
       <${Card}>
         <div class="flex flex-col gap-4">
           <div>
-            <h1 class="m-0 text-2xl font-semibold leading-tight text-[var(--text-strong)]">${post.title}</h1>
+            <h1 class="m-0 text-2xl font-semibold leading-tight text-[var(--color-fg-secondary)]">${post.title}</h1>
           </div>
 
-          <div class="text-sm text-[var(--text-body)] leading-loose">
+          <div class="text-sm text-[var(--color-fg-primary)] leading-loose">
             <${RichContent} text=${stripStateBlocks(post.body)} previewLimit=${4} />
           </div>
 
           <!-- Author and meta -->
           <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
             <span class="text-sm">${authorAvatar(authorAvatarKey)}</span>
-            <button type="button" class="text-xs text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" title=${authorTitle} onClick=${() => navigateToAuthor(post.author, undefined, post.author_identity)}>${authorLabel}</button>
-            <span class="text-2xs text-[var(--text-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
-            <span class="text-2xs text-[var(--text-muted)]">${post.votes ?? 0} votes</span>
+            <button type="button" class="text-xs text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] transition-colors cursor-pointer bg-transparent border-none p-0" title=${authorTitle} onClick=${() => navigateToAuthor(post.author, undefined, post.author_identity)}>${authorLabel}</button>
+            <span class="text-2xs text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
+            <span class="text-2xs text-[var(--color-fg-muted)]">${post.votes ?? 0} votes</span>
           </div>
 
           <!-- Badges -->
@@ -333,7 +333,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
                     ${expiryChip(post)}
                   </div>
                   ${post.classification_reason
-                    ? html`<div class="text-2xs text-[var(--text-muted)]">분류 근거: ${post.classification_reason}</div>`
+                    ? html`<div class="text-2xs text-[var(--color-fg-muted)]">분류 근거: ${post.classification_reason}</div>`
                     : null}
                 </div>
               `
@@ -343,11 +343,11 @@ export function PostDetail({ post }: { post: BoardPost }) {
           ${post.meta
             ? html`
                 <details class="mt-1">
-                  <summary class="cursor-pointer text-xs text-[var(--text-muted)] py-1.5 hover:text-[var(--text-body)] transition-colors">운영 메타</summary>
+                  <summary class="cursor-pointer text-xs text-[var(--color-fg-muted)] py-1.5 hover:text-[var(--color-fg-primary)] transition-colors">운영 메타</summary>
                   <div class="mt-2 p-3 rounded bg-[var(--white-3)] border border-[var(--border-slate-12)]">
-                    ${post.meta.source ? html`<div class="text-xs text-[var(--text-body)]"><span class="text-[var(--text-muted)]">출처:</span> ${post.meta.source}</div>` : null}
+                    ${post.meta.source ? html`<div class="text-xs text-[var(--color-fg-primary)]"><span class="text-[var(--color-fg-muted)]">출처:</span> ${post.meta.source}</div>` : null}
                     ${post.meta.state_block
-                      ? html`<pre class="whitespace-pre-wrap mt-2 text-2xs text-[var(--text-muted)] leading-relaxed">${post.meta.state_block}</pre>`
+                      ? html`<pre class="whitespace-pre-wrap mt-2 text-2xs text-[var(--color-fg-muted)] leading-relaxed">${post.meta.state_block}</pre>`
                       : null}
                   </div>
                 </details>
@@ -357,11 +357,11 @@ export function PostDetail({ post }: { post: BoardPost }) {
           <!-- Vote buttons -->
           <div class="flex gap-2">
             <button type="button"
-              class="vote-btn upvote px-3 py-1.5 rounded text-xs font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--text-muted)] hover:text-[var(--warn-bright)] hover:border-[var(--warn-30)] hover:bg-[var(--warn-10)] transition-all cursor-pointer"
+              class="vote-btn upvote px-3 py-1.5 rounded text-xs font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--color-fg-muted)] hover:text-[var(--warn-bright)] hover:border-[var(--warn-30)] hover:bg-[var(--warn-10)] transition-all cursor-pointer"
               onClick=${() => handleVote('up')}
             >▲ 추천</button>
             <button type="button"
-              class="vote-btn downvote px-3 py-1.5 rounded text-xs font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--text-muted)] hover:text-[var(--accent)] hover:border-[var(--accent-30)] hover:bg-[var(--accent-10)] transition-all cursor-pointer"
+              class="vote-btn downvote px-3 py-1.5 rounded text-xs font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] hover:border-[var(--accent-30)] hover:bg-[var(--accent-10)] transition-all cursor-pointer"
               onClick=${() => handleVote('down')}
             >▼ 비추천</button>
           </div>

--- a/dashboard/src/components/memory-state.ts
+++ b/dashboard/src/components/memory-state.ts
@@ -152,11 +152,11 @@ export function categoryLabel(cat: ContentCategory): string {
 
 export function categoryBadgeColor(cat: ContentCategory): string {
   switch (cat) {
-    case 'article': return 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)]'
+    case 'article': return 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)]'
     case 'review': return 'bg-[var(--purple-10)] text-[var(--purple)] border-[var(--purple-20)]'
     case 'notice': return 'bg-[var(--warn-10)] text-[var(--warn-bright)] border-[var(--warn-20)]'
     case 'system': return 'bg-[var(--slate-gray-15)] text-[var(--text-slate)] border-[var(--border-slate-22)]'
-    default: return 'bg-[var(--white-8)] text-[var(--text-muted)] border-[var(--border-slate-16)]'
+    default: return 'bg-[var(--white-8)] text-[var(--color-fg-muted)] border-[var(--border-slate-16)]'
   }
 }
 
@@ -252,10 +252,10 @@ export function kindLabel(kind: string): string {
 
 export function kindBadgeColor(kind: string): string {
   switch (kind) {
-    case 'direct': return 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)]'
-    case 'automation': return 'bg-[var(--cyan-16)] text-[var(--accent)] border-[var(--cyan-16)]'
+    case 'direct': return 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--border-slate-12)]'
+    case 'automation': return 'bg-[var(--cyan-16)] text-[var(--color-accent-fg)] border-[var(--cyan-16)]'
     case 'system': return 'bg-[var(--slate-gray-15)] text-[var(--text-slate)] border-[var(--border-slate-22)]'
-    default: return 'bg-[var(--white-8)] text-[var(--text-muted)] border-[var(--border-slate-16)]'
+    default: return 'bg-[var(--white-8)] text-[var(--color-fg-muted)] border-[var(--border-slate-16)]'
   }
 }
 
@@ -271,7 +271,7 @@ export function visibilityLabel(vis: string): string | null {
 
 export function visibilityBadgeColor(vis: string): string {
   if (vis === 'internal') return 'bg-[var(--white-10)] text-[var(--purple)] border-[var(--white-20)]'
-  return 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-16)]'
+  return 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--border-slate-16)]'
 }
 
 // ── Data operations ────────────────────────────────────────────────

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -250,7 +250,7 @@ function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
                   stroke=${active ? '#f1f5f9' : isDiag ? 'var(--slate-500)' : 'var(--panel-dark)'}
                   stroke-dasharray=${isDiag ? '2 2' : ''}
                   stroke-width=${active ? '1.5' : '0.5'}
-                  class="cursor-pointer hover:stroke-[var(--text-muted)]"
+                  class="cursor-pointer hover:stroke-[var(--color-fg-muted)]"
                   role="button"
                   aria-label=${`${from} to ${to}: ${pct}% — filter episodes for this pair`}
                   aria-pressed=${active ? 'true' : 'false'}
@@ -286,7 +286,7 @@ function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
           )}
         </g>
       </svg>
-      <div class="mt-2 text-xs text-[var(--text-muted)]0 text-center">
+      <div class="mt-2 text-xs text-[var(--color-fg-muted)]0 text-center">
         행 = from · 열 = to · 셀 = 시냅스 가중치 · 정렬 = 활동량 내림차순
       </div>
     </div>
@@ -297,7 +297,7 @@ function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
 // the backend; reverse for chronological left-to-right rendering.
 function WeightSparkline({ history }: { history?: Array<[number, number]> }) {
   if (!history || history.length < 2) {
-    return html`<span class="text-[var(--text-muted)] text-3xs w-20 text-center">—</span>`
+    return html`<span class="text-[var(--color-fg-muted)] text-3xs w-20 text-center">—</span>`
   }
   const chronological = [...history].reverse()
   const { width: sw, height: sh, strokeWidth } = SPARKLINE
@@ -332,7 +332,7 @@ function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) 
   const top = [...synapses].sort((a, b) => b.weight - a.weight).slice(0, TOP_LINK_COUNT)
   return html`
     <div class="bg-[var(--white-5)] rounded p-3 mt-3">
-      <div class="text-xs text-[var(--text-muted)]0 mb-2">강한 연결 Top ${TOP_LINK_COUNT} · sparkline = 학습 궤적</div>
+      <div class="text-xs text-[var(--color-fg-muted)]0 mb-2">강한 연결 Top ${TOP_LINK_COUNT} · sparkline = 학습 궤적</div>
       <div class="space-y-1.5">
         ${top.map(s => {
           const pct = Math.round(s.weight * 100)
@@ -341,27 +341,27 @@ function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) 
             <div class="flex items-center gap-2 text-xs font-mono px-1 py-0.5 rounded ${active ? 'ring-1 ring-[var(--white-10)] bg-[var(--white-5)]' : 'hover:bg-[var(--white-5)]'}">
               <button
                 type="button"
-                class="text-[var(--text-muted)] hover:text-[var(--accent)] truncate w-32 text-right focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+                class="text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] truncate w-32 text-right focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
                 onClick=${() => openAgentDetail(s.from_agent)}
               >${shortAgentLabel(s.from_agent)}</button>
               <button
                 type="button"
                 aria-pressed=${active ? 'true' : 'false'}
                 title="이 쌍의 에피소드만 필터"
-                class="text-[var(--text-muted)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent ${active ? 'text-[var(--accent)]' : ''}"
+                class="text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent ${active ? 'text-[var(--color-accent-fg)]' : ''}"
                 onClick=${() => toggleSynapsePairFilter(s.from_agent, s.to_agent)}
               >→</button>
               <button
                 type="button"
-                class="text-[var(--text-muted)] hover:text-[var(--accent)] truncate w-32 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+                class="text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] truncate w-32 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
                 onClick=${() => openAgentDetail(s.to_agent)}
               >${shortAgentLabel(s.to_agent)}</button>
               <div class="flex-1 bg-[var(--white-5)] rounded h-1.5 min-w-15">
                 <div class="${weightBarClass(s.weight)} rounded h-1.5" style="width:${pct}%"></div>
               </div>
-              <span class="text-[var(--text-muted)] w-10 text-right">${pct}%</span>
+              <span class="text-[var(--color-fg-muted)] w-10 text-right">${pct}%</span>
               <${WeightSparkline} history=${s.weight_history} />
-              <span class="text-[var(--ok)] w-8 text-right">${s.success_count}</span>
+              <span class="text-[var(--color-status-ok)] w-8 text-right">${s.success_count}</span>
               <span class="text-[var(--bad-light)] w-8 text-right">${s.failure_count}</span>
             </div>
           `
@@ -377,14 +377,14 @@ function SynapseRow({ s }: { s: MemorySubsystemsSynapse }) {
     <tr class="border-b border-[var(--white-10)]">
       <td class="py-1.5 px-2 text-sm font-mono">
         <button
-          class="hover:text-[var(--accent)] hover:underline focus:outline-none focus:text-[var(--accent)]"
+          class="hover:text-[var(--color-accent-fg)] hover:underline focus:outline-none focus:text-[var(--color-accent-fg)]"
           onClick=${() => openAgentDetail(s.from_agent)}
         >${s.from_agent}</button>
       </td>
-      <td class="py-1.5 px-2 text-sm text-[var(--text-muted)] text-center">→</td>
+      <td class="py-1.5 px-2 text-sm text-[var(--color-fg-muted)] text-center">→</td>
       <td class="py-1.5 px-2 text-sm font-mono">
         <button
-          class="hover:text-[var(--accent)] hover:underline focus:outline-none focus:text-[var(--accent)]"
+          class="hover:text-[var(--color-accent-fg)] hover:underline focus:outline-none focus:text-[var(--color-accent-fg)]"
           onClick=${() => openAgentDetail(s.to_agent)}
         >${s.to_agent}</button>
       </td>
@@ -393,12 +393,12 @@ function SynapseRow({ s }: { s: MemorySubsystemsSynapse }) {
           <div class="w-16 bg-[var(--white-5)] rounded h-1.5">
             <div class="${weightBarClass(s.weight)} rounded h-1.5" style="width:${pct}%"></div>
           </div>
-          <span class="text-[var(--text-muted)] w-10 text-right">${pct}%</span>
+          <span class="text-[var(--color-fg-muted)] w-10 text-right">${pct}%</span>
         </div>
       </td>
-      <td class="py-1.5 px-2 text-sm text-[var(--ok)] text-center">${s.success_count}</td>
+      <td class="py-1.5 px-2 text-sm text-[var(--color-status-ok)] text-center">${s.success_count}</td>
       <td class="py-1.5 px-2 text-sm text-[var(--bad-light)] text-center">${s.failure_count}</td>
-      <td class="py-1.5 px-2 text-xs text-[var(--text-muted)]0">${formatTimeAgo(s.last_updated * 1000)}</td>
+      <td class="py-1.5 px-2 text-xs text-[var(--color-fg-muted)]0">${formatTimeAgo(s.last_updated * 1000)}</td>
     </tr>
   `
 }
@@ -406,9 +406,9 @@ function SynapseRow({ s }: { s: MemorySubsystemsSynapse }) {
 function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
   const outcomeColor =
     ep.outcome === 'success'
-      ? 'text-[var(--ok)]'
+      ? 'text-[var(--color-status-ok)]'
       : ep.outcome === 'partial'
-        ? 'text-[var(--warn)]'
+        ? 'text-[var(--color-status-warn)]'
         : 'text-[var(--bad-light)]'
   const outcomeIcon =
     ep.outcome === 'success' ? '●' : ep.outcome === 'partial' ? '◐' : '○'
@@ -417,16 +417,16 @@ function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
       <div class="flex items-start justify-between gap-2 mb-1">
         <div class="flex items-center gap-2 min-w-0">
           <span class="${outcomeColor} text-xs">${outcomeIcon}</span>
-          <span class="text-sm font-medium text-[var(--text-muted)] truncate">${ep.summary}</span>
+          <span class="text-sm font-medium text-[var(--color-fg-muted)] truncate">${ep.summary}</span>
         </div>
-        <span class="text-xs text-[var(--text-muted)]0 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
+        <span class="text-xs text-[var(--color-fg-muted)]0 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
       </div>
-      <div class="flex items-center gap-2 text-xs text-[var(--text-muted)]0 mb-1 flex-wrap">
+      <div class="flex items-center gap-2 text-xs text-[var(--color-fg-muted)]0 mb-1 flex-wrap">
         <span class="bg-[var(--white-5)] px-1.5 py-0.5 rounded">${ep.event_type}</span>
         ${ep.participants.map(
           (p: string) => html`<span class="font-mono">${p}</span>`,
         )}
-        <span class="text-[var(--text-muted)] font-mono text-3xs">${ep.id}</span>
+        <span class="text-[var(--color-fg-muted)] font-mono text-3xs">${ep.id}</span>
       </div>
       ${
         ep.learnings.length > 0
@@ -434,7 +434,7 @@ function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
               <div class="mt-1.5 space-y-0.5">
                 ${ep.learnings.map(
                   (l: string) =>
-                    html`<div class="text-xs text-[var(--text-muted)] pl-3 border-l border-[var(--white-10)]">${l}</div>`,
+                    html`<div class="text-xs text-[var(--color-fg-muted)] pl-3 border-l border-[var(--white-10)]">${l}</div>`,
                 )}
               </div>
             `
@@ -446,7 +446,7 @@ function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
               <div class="mt-1 flex gap-2 flex-wrap">
                 ${Object.entries(ep.context).map(
                   ([k, v]) =>
-                    html`<span class="text-xs bg-[var(--white-5)] px-1.5 py-0.5 rounded text-[var(--text-muted)]0"
+                    html`<span class="text-xs bg-[var(--white-5)] px-1.5 py-0.5 rounded text-[var(--color-fg-muted)]0"
                       >${k}: ${v}</span
                     >`,
                 )}
@@ -554,8 +554,8 @@ export function MemorySubsystems() {
 
   return html`
     <div class="space-y-6">
-      <div class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-3 py-2 text-xs text-[var(--text-muted)]">
-        이 화면은 <span class="text-[var(--text-muted)] font-medium">global memory surface</span>만 보여줍니다.
+      <div class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-3 py-2 text-xs text-[var(--color-fg-muted)]">
+        이 화면은 <span class="text-[var(--color-fg-muted)] font-medium">global memory surface</span>만 보여줍니다.
         institution episodes와 Hebbian graph는 여기서 보고,
         keeper checkpoint/history/memory bank는 Keeper Detail에서 확인합니다.
       </div>
@@ -566,11 +566,11 @@ export function MemorySubsystems() {
           onClick=${() => (showArch.value = !showArch.value)}
           class="w-full flex items-center justify-between p-2 bg-[var(--white-5)] rounded hover:bg-[var(--white-5)] transition-colors"
         >
-          <span class="text-sm font-semibold text-[var(--text-muted)] flex items-center gap-2">
+          <span class="text-sm font-semibold text-[var(--color-fg-muted)] flex items-center gap-2">
             <span class="text-xs">${showArch.value ? '▼' : '▶'}</span>
             아키텍처 — 데이터 흐름도
           </span>
-          <span class="text-xs text-[var(--text-muted)]0">
+          <span class="text-xs text-[var(--color-fg-muted)]0">
             Keeper turn → episodes / task_done → Hebbian. Keeper memory bank와 checkpoint는 다른 패널에서 본다.
           </span>
         </button>
@@ -592,8 +592,8 @@ export function MemorySubsystems() {
       <!-- Hebbian Synapses -->
       <section>
         <div class="flex items-center justify-between mb-3">
-          <h3 class="text-base font-semibold text-[var(--text-muted)]">Hebbian 시냅스 그래프</h3>
-          <div class="flex items-center gap-3 text-xs text-[var(--text-muted)]0">
+          <h3 class="text-base font-semibold text-[var(--color-fg-muted)]">Hebbian 시냅스 그래프</h3>
+          <div class="flex items-center gap-3 text-xs text-[var(--color-fg-muted)]0">
             <span>${synapses.length}개 시냅스</span>
             ${
               lastConsolidation > 0
@@ -612,7 +612,7 @@ export function MemorySubsystems() {
         }
         ${
           synapses.length === 0
-            ? html`<div class="text-sm text-[var(--text-muted)]0 bg-[var(--white-5)] rounded p-4 text-center">
+            ? html`<div class="text-sm text-[var(--color-fg-muted)]0 bg-[var(--white-5)] rounded p-4 text-center">
                 시냅스 데이터 없음. keeper task 완료 시 자동 생성됩니다.
               </div>`
             : html`
@@ -625,23 +625,23 @@ export function MemorySubsystems() {
                     onInput=${(e: Event) => {
                       synapseQuery.value = (e.target as HTMLInputElement).value
                     }}
-                    class="flex-1 min-w-50 bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] placeholder:text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
+                    class="flex-1 min-w-50 bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--color-fg-muted)] placeholder:text-[var(--color-fg-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
                   />
                   ${
                     isSynapseFiltering
-                      ? html`<span class="text-xs text-[var(--text-muted)]0">${visibleSynapses.length}/${synapses.length}</span>`
+                      ? html`<span class="text-xs text-[var(--color-fg-muted)]0">${visibleSynapses.length}/${synapses.length}</span>`
                       : null
                   }
                 </div>
                 ${
                   isSynapseFiltering && visibleSynapses.length === 0
-                    ? html`<div class="text-sm text-[var(--text-muted)]0 bg-[var(--white-5)] rounded p-4 text-center">
+                    ? html`<div class="text-sm text-[var(--color-fg-muted)]0 bg-[var(--white-5)] rounded p-4 text-center">
                         필터 결과 없음 (${synapses.length} items)
                       </div>`
                     : html`<div class="overflow-x-auto">
                         <table class="w-full text-left">
                           <thead>
-                            <tr class="border-b border-[var(--white-10)] text-xs text-[var(--text-muted)]0">
+                            <tr class="border-b border-[var(--white-10)] text-xs text-[var(--color-fg-muted)]0">
                               <th class="py-1.5 px-2">From</th>
                               <th class="py-1.5 px-2"></th>
                               <th class="py-1.5 px-2">To</th>
@@ -666,8 +666,8 @@ export function MemorySubsystems() {
       <!-- Episodes -->
       <section>
         <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
-          <h3 class="text-base font-semibold text-[var(--text-muted)]">에피소드 기록</h3>
-          <span class="text-xs text-[var(--text-muted)]0">
+          <h3 class="text-base font-semibold text-[var(--color-fg-muted)]">에피소드 기록</h3>
+          <span class="text-xs text-[var(--color-fg-muted)]0">
             총 ${totalEpisodes}개 · 필터 ${filteredTotal}개 · 표시 ${visibleEpisodes.length}개
           </span>
         </div>
@@ -675,10 +675,10 @@ export function MemorySubsystems() {
         ${
           pairFilter
             ? html`<div class="flex items-center gap-2 mb-2 px-2 py-1 bg-[var(--white-5)] border border-[var(--white-10)] rounded text-xs">
-                <span class="text-[var(--text-muted)]0">시냅스 쌍 필터</span>
-                <span class="text-[var(--text-muted)] font-mono">${shortAgentLabel(pairFilter.from)} → ${shortAgentLabel(pairFilter.to)}</span>
+                <span class="text-[var(--color-fg-muted)]0">시냅스 쌍 필터</span>
+                <span class="text-[var(--color-fg-muted)] font-mono">${shortAgentLabel(pairFilter.from)} → ${shortAgentLabel(pairFilter.to)}</span>
                 <button
-                  class="ml-auto text-[var(--text-muted)] hover:text-[var(--text-muted)]"
+                  class="ml-auto text-[var(--color-fg-muted)] hover:text-[var(--color-fg-muted)]"
                   onClick=${() => setSynapsePairFilter(null)}
                   aria-label="시냅스 쌍 필터 해제"
                 >✕</button>
@@ -693,12 +693,12 @@ export function MemorySubsystems() {
             placeholder="검색 (summary, learnings, event_type...)"
             value=${searchQuery.value}
             onInput=${onSearchInput}
-            class="flex-1 min-w-50 bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] placeholder:text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
+            class="flex-1 min-w-50 bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--color-fg-muted)] placeholder:text-[var(--color-fg-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
           />
           <select
             value=${keeperFilter.value}
             onChange=${(e: Event) => (keeperFilter.value = (e.target as HTMLSelectElement).value)}
-            class="bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
+            class="bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--color-fg-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
           >
             <option value="">모든 키퍼</option>
             ${knownKeepers.map(
@@ -708,7 +708,7 @@ export function MemorySubsystems() {
           <select
             value=${outcomeFilter.value}
             onChange=${(e: Event) => (outcomeFilter.value = (e.target as HTMLSelectElement).value)}
-            class="bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
+            class="bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--color-fg-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
           >
             <option value="">모든 결과</option>
             ${knownOutcomes.map(
@@ -719,7 +719,7 @@ export function MemorySubsystems() {
             hasFilter
               ? html`<button
                   onClick=${clearFilters}
-                  class="text-xs text-[var(--text-muted)] hover:text-[var(--text-muted)] px-2 py-1 border border-[var(--white-10)] rounded hover:border-[var(--white-10)]0"
+                  class="text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-muted)] px-2 py-1 border border-[var(--white-10)] rounded hover:border-[var(--white-10)]0"
                 >
                   필터 해제
                 </button>`
@@ -729,7 +729,7 @@ export function MemorySubsystems() {
 
         ${
           visibleEpisodes.length === 0
-            ? html`<div class="text-sm text-[var(--text-muted)]0 bg-[var(--white-5)] rounded p-4 text-center">
+            ? html`<div class="text-sm text-[var(--color-fg-muted)]0 bg-[var(--white-5)] rounded p-4 text-center">
                 ${hasFilter
                   ? '필터 조건에 맞는 에피소드가 없습니다.'
                   : '에피소드 없음. keeper [STATE] 출력 시 자동 기록됩니다.'}
@@ -750,7 +750,7 @@ export function MemorySubsystems() {
 
       ${
         error
-          ? html`<div class="text-xs text-[var(--warn)] mt-2">refresh error: ${error}</div>`
+          ? html`<div class="text-xs text-[var(--color-status-warn)] mt-2">refresh error: ${error}</div>`
           : null
       }
     </div>

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -154,7 +154,7 @@ function renderCategorySection(
   if (posts.length === 0 && hidden === 0) return null
   if (posts.length === 0 && hidden > 0) {
     return html`
-      <div class="mb-3 px-3 py-2 rounded border border-dashed border-[var(--border-slate-16)] text-xs text-[var(--text-muted)]">
+      <div class="mb-3 px-3 py-2 rounded border border-dashed border-[var(--border-slate-16)] text-xs text-[var(--color-fg-muted)]">
         ${label} — ${hidden}건 숨김
       </div>
     `
@@ -172,7 +172,7 @@ function renderCategorySection(
         }} />
         <div class="text-center py-3">
           <button type="button"
-            class="px-4 py-2 rounded text-xs font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer disabled:opacity-50"
+            class="px-4 py-2 rounded text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] transition-all cursor-pointer disabled:opacity-50"
             disabled=${loadingMore}
             onClick=${() => {
               expandCategory(category, limits, limit, posts.length)
@@ -195,14 +195,14 @@ function NewPostForm() {
   if (!showNewPostForm.value) {
     return html`
       <button type="button"
-        class="w-full py-2.5 rounded border border-dashed border-[var(--card-border)] text-sm text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-4)] hover:text-[var(--text-body)] transition-colors bg-transparent"
+        class="w-full py-2.5 rounded border border-dashed border-[var(--color-border-default)] text-sm text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--white-4)] hover:text-[var(--color-fg-primary)] transition-colors bg-transparent"
         onClick=${() => { showNewPostForm.value = true }}
       >+ 새 글 작성</button>
     `
   }
 
   return html`
-    <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] grid gap-3">
+    <div class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] grid gap-3">
       <${TextInput}
         name="board_post_title"
         ariaLabel="새 글 제목"
@@ -221,11 +221,11 @@ function NewPostForm() {
       />
       <div class="flex gap-2 justify-end">
         <button type="button"
-          class="px-3 py-1.5 rounded text-sm border border-[var(--card-border)] bg-transparent text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]"
+          class="px-3 py-1.5 rounded text-sm border border-[var(--color-border-default)] bg-transparent text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--white-6)]"
           onClick=${() => { showNewPostForm.value = false; newPostTitle.value = ''; newPostContent.value = '' }}
         >취소</button>
         <button type="button"
-          class="px-4 py-1.5 rounded text-sm font-medium border border-[rgba(71,184,255,0.4)] bg-[var(--accent-soft)] text-[var(--accent)] cursor-pointer hover:bg-[var(--accent-20)] disabled:opacity-50"
+          class="px-4 py-1.5 rounded text-sm font-medium border border-[rgba(71,184,255,0.4)] bg-[var(--accent-soft)] text-[var(--color-accent-fg)] cursor-pointer hover:bg-[var(--accent-20)] disabled:opacity-50"
           disabled=${newPostSubmitting.value || !newPostTitle.value.trim() || !newPostContent.value.trim()}
           onClick=${() => { void submitNewPost() }}
         >${newPostSubmitting.value ? '등록 중...' : '등록'}</button>
@@ -239,14 +239,14 @@ function SortBar() {
   const current = boardSortMode.value
   const grouped = splitVisiblePosts(boardPosts.value)
   return html`
-    <div class="flex flex-col gap-3 mb-4 p-3 rounded border border-[var(--card-border)] bg-[var(--card)]">
+    <div class="flex flex-col gap-3 mb-4 p-3 rounded border border-[var(--color-border-default)] bg-[var(--card)]">
       <div class="flex items-center gap-1.5 flex-wrap">
         ${SORT_MODES.map(mode => html`
           <button type="button"
             class="px-3 py-1.5 rounded text-xs font-medium transition-all duration-150 border cursor-pointer
               ${current === mode.id
-                ? 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)]'
-                : 'bg-transparent text-[var(--text-muted)] border-transparent hover:bg-[var(--white-8)] hover:text-[var(--text-body)]'
+                ? 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)]'
+                : 'bg-transparent text-[var(--color-fg-muted)] border-transparent hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)]'
               }"
             onClick=${() => {
               boardSortMode.value = mode.id
@@ -268,8 +268,8 @@ function SortBar() {
             <button type="button"
               class="px-2.5 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer
                 ${isHidden
-                  ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)] line-through opacity-60'
-                  : 'bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
+                  ? 'bg-[var(--accent-12)] text-[var(--color-accent-fg)] border-[var(--accent-18)] line-through opacity-60'
+                  : 'bg-transparent text-[var(--color-fg-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
                 }"
               onClick=${() => {
                 const next = new Set(boardHiddenCategories.value)
@@ -287,7 +287,7 @@ function SortBar() {
           placeholder="작성자"
           aria-label="작성자 필터"
           value=${boardAuthorFilter.value}
-          class="px-2.5 py-1 rounded text-2xs font-medium border bg-transparent text-[var(--text)] border-[var(--border-slate-16)] placeholder:text-[var(--text-muted)] w-28 focus:outline-none focus:border-[var(--accent)]"
+          class="px-2.5 py-1 rounded text-2xs font-medium border bg-transparent text-[var(--text)] border-[var(--border-slate-16)] placeholder:text-[var(--color-fg-muted)] w-28 focus:outline-none focus:border-[var(--color-accent-fg)]"
           onKeyDown=${(e: KeyboardEvent) => {
             if (e.key === 'Enter') {
               boardAuthorFilter.value = (e.target as HTMLInputElement).value.trim()
@@ -312,12 +312,12 @@ function SortBar() {
               ${bulkDeleting.value ? '삭제 중...' : `선택 삭제 (${selectedPostIds.value.size})`}
             </button>
             <button type="button"
-              class="px-2 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]"
+              class="px-2 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]"
               onClick=${() => { selectedPostIds.value = new Set() }}
             >선택 해제</button>
           ` : null}
           <button type="button"
-            class="px-3 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] disabled:opacity-50 disabled:cursor-not-allowed"
+            class="px-3 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] disabled:opacity-50 disabled:cursor-not-allowed"
             onClick=${refreshBoard}
             disabled=${boardLoading.value}
           >
@@ -334,13 +334,13 @@ function MemorySummary() {
   const grouped = splitVisiblePosts(boardPosts.value)
   const visibleCount = grouped.groups.reduce((sum, g) => sum + g.posts.length, 0)
   return html`
-    <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded border border-[var(--card-border)] bg-[var(--card)] text-xs text-[var(--text-muted)]">
-      <span class="font-semibold text-[var(--text-strong)] tabular-nums text-md">${visibleCount}</span>
+    <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded border border-[var(--color-border-default)] bg-[var(--card)] text-xs text-[var(--color-fg-muted)]">
+      <span class="font-semibold text-[var(--color-fg-secondary)] tabular-nums text-md">${visibleCount}</span>
       <span>개 표시 중</span>
       ${grouped.groups.map(g => {
         const meta = CONTENT_CATEGORIES.find(c => c.id === g.category)
         return html`
-          <span class="text-[var(--text-muted)]">·</span>
+          <span class="text-[var(--color-fg-muted)]">·</span>
           <span>${meta?.icon ?? ''} ${g.posts.length}</span>
         `
       })}
@@ -396,14 +396,14 @@ function PostCard({ post }: { post: BoardPost }) {
   return html`
     <button
       type="button"
-      class="board-post group w-full flex gap-3 rounded p-4 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+      class="board-post group w-full flex gap-3 rounded p-4 border border-[var(--color-border-default)] bg-[var(--card)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
       onClick=${() => navigateToPost(post.id)}
     >
       <!-- Select checkbox -->
       <div class="flex items-start pt-1">
         <input type="checkbox"
           aria-label=${`게시글 선택: ${post.id}`}
-          class="w-3.5 h-3.5 rounded cursor-pointer accent-[var(--accent)]"
+          class="w-3.5 h-3.5 rounded cursor-pointer accent-[var(--color-accent-fg)]"
           checked=${selectedPostIds.value.has(post.id)}
           onClick=${(e: Event) => togglePostSelection(post.id, e)}
         />
@@ -412,12 +412,12 @@ function PostCard({ post }: { post: BoardPost }) {
       <!-- Vote column -->
       <div class="flex flex-col items-center gap-0.5 pt-0.5 min-w-9">
         <button type="button"
-          class="vote-btn upvote w-7 h-5 flex items-center justify-center rounded text-2xs text-[var(--text-muted)] hover:text-[var(--warn-bright)] hover:bg-[var(--warn-10)] transition-colors cursor-pointer border-0 bg-transparent"
+          class="vote-btn upvote w-7 h-5 flex items-center justify-center rounded text-2xs text-[var(--color-fg-muted)] hover:text-[var(--warn-bright)] hover:bg-[var(--warn-10)] transition-colors cursor-pointer border-0 bg-transparent"
           onClick=${(event: Event) => handleVote('up', event)}
         >▲</button>
-        <span class="text-sm font-semibold tabular-nums text-[var(--text-strong)]">${post.votes ?? 0}</span>
+        <span class="text-sm font-semibold tabular-nums text-[var(--color-fg-secondary)]">${post.votes ?? 0}</span>
         <button type="button"
-          class="vote-btn downvote w-7 h-5 flex items-center justify-center rounded text-2xs text-[var(--text-muted)] hover:text-[var(--accent)] hover:bg-[var(--accent-10)] transition-colors cursor-pointer border-0 bg-transparent"
+          class="vote-btn downvote w-7 h-5 flex items-center justify-center rounded text-2xs text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] hover:bg-[var(--accent-10)] transition-colors cursor-pointer border-0 bg-transparent"
           onClick=${(event: Event) => handleVote('down', event)}
         >▼</button>
       </div>
@@ -425,10 +425,10 @@ function PostCard({ post }: { post: BoardPost }) {
       <!-- Post body -->
       <div class="flex-1 min-w-0">
         <!-- Title -->
-        <div class="text-md font-semibold text-[var(--text-strong)] leading-snug mb-1.5 group-hover:text-[var(--accent)] transition-colors">${stripInlineMarkdown(post.title)}</div>
+        <div class="text-md font-semibold text-[var(--color-fg-secondary)] leading-snug mb-1.5 group-hover:text-[var(--color-accent-fg)] transition-colors">${stripInlineMarkdown(post.title)}</div>
 
         <!-- Content preview: rendered markdown, height-capped -->
-        <div class="board-post-preview text-sm text-[var(--text-body)] leading-paragraph mb-2.5 overflow-hidden relative ${richPreview ? 'max-h-[12rem]' : 'max-h-[4.8em]'}">
+        <div class="board-post-preview text-sm text-[var(--color-fg-primary)] leading-paragraph mb-2.5 overflow-hidden relative ${richPreview ? 'max-h-[12rem]' : 'max-h-[4.8em]'}">
           <${RichContent} text=${previewBody} class="board-post-preview__content" previewLimit=${1} />
           <div class="absolute bottom-0 left-0 right-0 ${richPreview ? 'h-10' : 'h-6'} bg-gradient-to-t from-[var(--card)] to-transparent pointer-events-none" />
         </div>
@@ -436,20 +436,20 @@ function PostCard({ post }: { post: BoardPost }) {
         <!-- Footer: author + meta + badges -->
         <div class="flex items-center gap-2 flex-wrap">
           <!-- Author line -->
-          <span class="text-xs text-[var(--text-muted)]">${authorAvatar(authorAvatarKey)}</span>
+          <span class="text-xs text-[var(--color-fg-muted)]">${authorAvatar(authorAvatarKey)}</span>
           <a
-            class="text-xs text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors cursor-pointer"
+            class="text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] transition-colors cursor-pointer"
             title=${authorTitle}
             onClick=${(e: Event) => navigateToAuthor(post.author, e, post.author_identity)}
           >${authorLabel}</a>
-          <span class="text-2xs text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${post.created_at} /></span>
-          ${isUpdated(post) ? html`<span class="text-3xs text-[var(--text-muted)] opacity-50">(수정됨)</span>` : null}
+          <span class="text-2xs text-[var(--color-fg-muted)] opacity-60"><${TimeAgo} timestamp=${post.created_at} /></span>
+          ${isUpdated(post) ? html`<span class="text-3xs text-[var(--color-fg-muted)] opacity-50">(수정됨)</span>` : null}
 
           <!-- Separator -->
-          <span class="text-[var(--text-muted)] opacity-30">|</span>
+          <span class="text-[var(--color-fg-muted)] opacity-30">|</span>
 
           <!-- Counts -->
-          <span class="text-2xs text-[var(--text-muted)]">댓글 ${post.comment_count}</span>
+          <span class="text-2xs text-[var(--color-fg-muted)]">댓글 ${post.comment_count}</span>
 
           <!-- Category badges -->
           <span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs font-medium border ${categoryBadgeColor(cat)}">${categoryLabel(cat)}</span>
@@ -502,7 +502,7 @@ export function Memory() {
           <div>
             <${MemorySummary} />
             <button type="button"
-              class="mb-4 px-3 py-1.5 rounded text-xs font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
+              class="mb-4 px-3 py-1.5 rounded text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] transition-all cursor-pointer"
               onClick=${() => navigate('workspace', { section: 'board' })}
             >← 게시판으로 돌아가기</button>
             ${detailLoading.value
@@ -517,7 +517,7 @@ export function Memory() {
       <${MemorySummary} />
       <${SortBar} />
       ${hint ? html`
-        <div class="mb-4 px-3 py-2 rounded border border-[var(--border-slate-16)] bg-[var(--white-3)] text-xs text-[var(--text-muted)]">
+        <div class="mb-4 px-3 py-2 rounded border border-[var(--border-slate-16)] bg-[var(--white-3)] text-xs text-[var(--color-fg-muted)]">
           ${hint}
         </div>
       ` : null}
@@ -531,17 +531,17 @@ export function Memory() {
           placeholder="제목/본문에서 검색"
           aria-label="게시글 본문 필터"
           onInput=${(e: Event) => setContentQuery((e.target as HTMLInputElement).value)}
-          class="min-w-45 max-w-80 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-45 max-w-80 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && posts.length === 0 && rawPosts.length > 0
-        ? html`<div class="py-4 text-center text-xs text-[var(--text-dim)]">필터 결과 없음 (${rawPosts.length} items)</div>`
+        ? html`<div class="py-4 text-center text-xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${rawPosts.length} items)</div>`
         : posts.length === 0 && boardLoading.value
           ? html`<${LoadingState}>메모리 피드 불러오는 중...<//>`
           : posts.length === 0
             ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
             : html`
-                ${boardLoading.value ? html`<div class="mb-2 text-2xs text-[var(--text-muted)] animate-pulse">업데이트 중...</div>` : null}
+                ${boardLoading.value ? html`<div class="mb-2 text-2xs text-[var(--color-fg-muted)] animate-pulse">업데이트 중...</div>` : null}
                 ${grouped.groups.map(g => html`
                   <${CategorySection} key=${g.category} group=${g} />
                 `)}

--- a/dashboard/src/components/mission-utils.test.ts
+++ b/dashboard/src/components/mission-utils.test.ts
@@ -160,7 +160,7 @@ describe('liveStateClass', () => {
 
 describe('dotStateBg', () => {
   it('returns warn bg for idle state', () => {
-    expect(dotStateBg('mission-state-idle')).toBe('bg-[var(--warn)]')
+    expect(dotStateBg('mission-state-idle')).toBe('bg-[var(--color-status-warn)]')
   })
 
   it('returns gray bg for offline state', () => {

--- a/dashboard/src/components/mission-utils.ts
+++ b/dashboard/src/components/mission-utils.ts
@@ -51,7 +51,7 @@ export function liveStateClass(status?: string | null, health?: string | null): 
 
 /** Tailwind bg override for the status dot based on live state */
 export function dotStateBg(stateClass: string): string {
-  if (stateClass === 'mission-state-idle') return 'bg-[var(--warn)]'
+  if (stateClass === 'mission-state-idle') return 'bg-[var(--color-status-warn)]'
   if (stateClass === 'mission-state-offline') return 'bg-[#555]'
   return ''
 }

--- a/dashboard/src/components/oas-health-chip.ts
+++ b/dashboard/src/components/oas-health-chip.ts
@@ -132,7 +132,7 @@ export function OasHealthChip() {
           label="에러"
           value=${summary.value.totalErrors}
           detail=${sampleWindow ? `${errorDetail} · ${sampleWindow}` : errorDetail}
-          tone=${summary.value.totalErrors > 0 ? 'text-[var(--bad)]' : undefined}
+          tone=${summary.value.totalErrors > 0 ? 'text-[var(--color-status-err)]' : undefined}
         />
         <${StatCell}
           label="에이전트 이벤트"
@@ -148,25 +148,25 @@ export function OasHealthChip() {
           label="최근 tick"
           value=${formatLastTick(summary.value.lastKeeperTick)}
           detail=${isStale.value ? '신호 끊김' : '수신 중'}
-          tone=${isStale.value ? 'text-[var(--warn)]' : 'text-[var(--ok)]'}
+          tone=${isStale.value ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-status-ok)]'}
         />
       </div>
       ${recentEvents.value.length > 0 || recentKeepers.value.length > 0 ? html`
         <div class="mt-3 pt-3 border-t border-[var(--white-6)] grid md:grid-cols-2 gap-4">
           ${recentEvents.value.length > 0 ? html`
             <div>
-              <div class="text-3xs text-[var(--text-muted)] tracking-wider uppercase font-medium mb-2">
+              <div class="text-3xs text-[var(--color-fg-muted)] tracking-wider uppercase font-medium mb-2">
                 최근 자율성 이벤트
               </div>
               <ul class="space-y-1">
                 ${recentEvents.value.map(evt => html`
                   <li class="flex items-baseline justify-between gap-2 text-2xs">
-                    <span class="text-[var(--text-body)] truncate">
-                      <span class="font-mono text-[var(--text-dim)]">${evt.agent_name}</span>
-                      <span class="text-[var(--text-muted)]"> · </span>
+                    <span class="text-[var(--color-fg-primary)] truncate">
+                      <span class="font-mono text-[var(--color-fg-disabled)]">${evt.agent_name}</span>
+                      <span class="text-[var(--color-fg-muted)]"> · </span>
                       ${describeAgentEvent(evt)}
                     </span>
-                    <span class="text-[var(--text-muted)] tabular-nums shrink-0">
+                    <span class="text-[var(--color-fg-muted)] tabular-nums shrink-0">
                       ${formatLastTick(evt.timestamp * 1000)}
                     </span>
                   </li>
@@ -176,17 +176,17 @@ export function OasHealthChip() {
           ` : null}
           ${recentKeepers.value.length > 0 ? html`
             <div>
-              <div class="text-3xs text-[var(--text-muted)] tracking-wider uppercase font-medium mb-2">
+              <div class="text-3xs text-[var(--color-fg-muted)] tracking-wider uppercase font-medium mb-2">
                 활성 Keeper
               </div>
               <ul class="space-y-1">
                 ${recentKeepers.value.map(snap => html`
                   <li class="flex items-baseline justify-between gap-2 text-2xs">
-                    <span class="text-[var(--text-body)] truncate">
-                      <span class="font-mono text-[var(--text-dim)]">${snap.keeper_name}</span>
-                      <span class="text-[var(--text-muted)]"> · gen ${snap.generation} · ${Math.round(snap.context_ratio * 100)}%</span>
+                    <span class="text-[var(--color-fg-primary)] truncate">
+                      <span class="font-mono text-[var(--color-fg-disabled)]">${snap.keeper_name}</span>
+                      <span class="text-[var(--color-fg-muted)]"> · gen ${snap.generation} · ${Math.round(snap.context_ratio * 100)}%</span>
                     </span>
-                    <span class="text-[var(--text-muted)] tabular-nums shrink-0">
+                    <span class="text-[var(--color-fg-muted)] tabular-nums shrink-0">
                       ${formatLastTick(snap.timestamp * 1000)}
                     </span>
                   </li>

--- a/dashboard/src/components/observatory/cross-signal-readout.ts
+++ b/dashboard/src/components/observatory/cross-signal-readout.ts
@@ -54,8 +54,8 @@ function Row({
   tone?: 'neutral' | 'ok' | 'warn' | 'bad'
 }) {
   const toneClass =
-    tone === 'ok' ? 'text-[var(--ok)]'
-      : tone === 'warn' ? 'text-[var(--warn)]'
+    tone === 'ok' ? 'text-[var(--color-status-ok)]'
+      : tone === 'warn' ? 'text-[var(--color-status-warn)]'
       : tone === 'bad' ? 'text-[var(--bad-light)]'
       : 'text-text-strong'
   return html`

--- a/dashboard/src/components/observatory/detail-pane.ts
+++ b/dashboard/src/components/observatory/detail-pane.ts
@@ -29,7 +29,7 @@ function outcomeTag(entry: TelemetryEntry): { label: string; tone: 'ok' | 'bad' 
 }
 
 function toneClass(tone: 'ok' | 'bad' | 'neutral'): string {
-  if (tone === 'ok') return 'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]'
+  if (tone === 'ok') return 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]'
   if (tone === 'bad') return 'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]'
   return 'bg-white/5 text-text-dim border-card-border'
 }

--- a/dashboard/src/components/observatory/metric-track.ts
+++ b/dashboard/src/components/observatory/metric-track.ts
@@ -46,7 +46,7 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
   const lastRate = windowed[windowed.length - 1]?.point.success_rate ?? null
   const lastRateColor =
     lastRate == null ? 'text-text-dim'
-      : lastRate >= 97 ? 'text-[var(--ok)]'
+      : lastRate >= 97 ? 'text-[var(--color-status-ok)]'
       : lastRate >= 90 ? 'text-text-strong'
       : 'text-[var(--bad-light)]'
 
@@ -97,8 +97,8 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
                 </rect>
               `
             })}
-            <line x1="0" y1="${viewBoxHeight * 0.03}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.03}" stroke="currentColor" stroke-dasharray="2 4" class="text-[var(--ok)]/30" stroke-width="0.5" />
-            <line x1="0" y1="${viewBoxHeight * 0.1}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.1}" stroke="currentColor" stroke-dasharray="2 4" class="text-[var(--warn)]/30" stroke-width="0.5" />
+            <line x1="0" y1="${viewBoxHeight * 0.03}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.03}" stroke="currentColor" stroke-dasharray="2 4" class="text-[var(--color-status-ok)]/30" stroke-width="0.5" />
+            <line x1="0" y1="${viewBoxHeight * 0.1}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.1}" stroke="currentColor" stroke-dasharray="2 4" class="text-[var(--color-status-warn)]/30" stroke-width="0.5" />
             <polyline
               points=${polyline}
               fill="none"
@@ -116,7 +116,7 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
                   cy="${y.toFixed(1)}"
                   r=${r.isAnomaly ? '3' : '1.5'}
                   fill="currentColor"
-                  class=${r.isAnomaly ? (r.zScore < 0 ? 'text-[var(--bad-light)]' : 'text-[var(--warn)]') : 'text-accent'}
+                  class=${r.isAnomaly ? (r.zScore < 0 ? 'text-[var(--bad-light)]' : 'text-[var(--color-status-warn)]') : 'text-accent'}
                   stroke=${r.isAnomaly ? 'currentColor' : 'none'}
                   stroke-width=${r.isAnomaly ? '0.5' : '0'}
                 >

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -293,7 +293,7 @@ export function Observatory() {
               type="button"
               class="inline-flex items-center gap-1.5 rounded border px-2.5 py-1 text-2xs font-medium transition-colors ${
                 liveMode.value
-                  ? 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]'
+                  ? 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]'
                   : 'border-card-border text-text-muted hover:text-text-strong hover:bg-white/5'
               }"
               onClick=${() => {
@@ -315,7 +315,7 @@ export function Observatory() {
       </div>
 
       ${activeView.value === 'timeline' && data.error ? html`
-        <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]">
+        <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--color-status-warn)]">
           일부 데이터 불러오기 실패: ${data.error}
         </div>
       ` : null}

--- a/dashboard/src/components/observatory/tool-call-track.ts
+++ b/dashboard/src/components/observatory/tool-call-track.ts
@@ -94,7 +94,7 @@ export function ToolCallTrack({ events, windowStart, windowEnd }: Props) {
       <div class="w-24 shrink-0">
         <div class="text-2xs font-semibold text-text-muted">도구 호출</div>
         <div class="text-3xs text-text-dim">
-          <span class="text-[var(--ok)]">${successCount}</span>
+          <span class="text-[var(--color-status-ok)]">${successCount}</span>
           <span class="text-text-dim/60 mx-0.5">·</span>
           <span class="text-[var(--bad-light)]">${failureCount}</span>
         </div>

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -166,15 +166,15 @@ function renderActivityTimeline() {
           key=${entry.key}
           data-testid="ops-activity-item"
           data-activity-kind=${entry.kind}
-          class="rounded border border-[var(--card-border)] bg-[var(--white-3)] p-3"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] p-3"
         >
-          <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--text-muted)]">
+          <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
             <${CountBadge} tone=${entry.tone}>${entry.label}<//>
             <span>${entry.target}</span>
             <span>${entry.actor}</span>
             <span><${TimeAgo} timestamp=${entry.at} /></span>
           </div>
-          <div class="mt-2 text-sm leading-paragraph text-[var(--text-body)]">${entry.detail}</div>
+          <div class="mt-2 text-sm leading-paragraph text-[var(--color-fg-primary)]">${entry.detail}</div>
         </article>
       `)}
     </div>
@@ -210,19 +210,19 @@ export function Ops() {
 
   return html`
     <section class="flex flex-col gap-4">
-      ${operatorError.value ? html`<section class="ops-banner rounded py-3 px-3.5 border border-[var(--card-border)] error">${operatorError.value}</section>` : null}
-      ${operatorDigestError.value ? html`<section class="ops-banner rounded py-3 px-3.5 border border-[var(--card-border)] error">${operatorDigestError.value}</section>` : null}
+      ${operatorError.value ? html`<section class="ops-banner rounded py-3 px-3.5 border border-[var(--color-border-default)] error">${operatorError.value}</section>` : null}
+      ${operatorDigestError.value ? html`<section class="ops-banner rounded py-3 px-3.5 border border-[var(--color-border-default)] error">${operatorDigestError.value}</section>` : null}
 
       ${workflowContext ? html`
-        <section class="ops-banner rounded py-3 px-3.5 border border-[var(--card-border)] ${workflowReady ? 'info' : 'warn'} grid gap-2">
-          <div class="flex gap-2 flex-wrap items-center text-[var(--text-body)]">
+        <section class="ops-banner rounded py-3 px-3.5 border border-[var(--color-border-default)] ${workflowReady ? 'info' : 'warn'} grid gap-2">
+          <div class="flex gap-2 flex-wrap items-center text-[var(--color-fg-primary)]">
             <strong class="font-semibold">${workflowContext.source_label}</strong>
             <span>${workflowActionLabel(workflowContext.action_type)}</span>
             <span>${workflowTargetLabel(workflowContext)}</span>
           </div>
-          <div class="text-[var(--text-strong)] leading-relaxed">${workflowContext.summary}</div>
+          <div class="text-[var(--color-fg-secondary)] leading-relaxed">${workflowContext.summary}</div>
           ${workflowContext.payload_preview ? html`<div class="mt-1 p-2 rounded bg-[var(--white-3)] text-xs font-mono">${workflowContext.payload_preview}</div>` : null}
-          <div class="text-[var(--text-muted)] text-xs">
+          <div class="text-[var(--color-fg-muted)] text-xs">
             ${workflowReady
               ? '추천 액션 기준으로 대상 선택과 입력값을 미리 맞춰 두었습니다.'
               : '대상이 현재 snapshot에 없습니다. 일반 개입 화면으로 열렸고, 실제 대상 선택은 수동으로 해야 합니다.'}
@@ -239,8 +239,8 @@ export function Ops() {
 
         <section class="${CARD_STANDARD} grid gap-3 order-2 max-[1200px]:order-1">
           <div>
-            <h2 class="text-sm font-semibold text-[var(--text-strong)]">최근 운영 활동</h2>
-            <p class="mt-1 text-xs text-[var(--text-muted)]">최근 처리와 직접 개입을 시간순으로 함께 보여줍니다. 검토 큐와 Live Judge 판단은 거버넌스 페이지에서 처리합니다.</p>
+            <h2 class="text-sm font-semibold text-[var(--color-fg-secondary)]">최근 운영 활동</h2>
+            <p class="mt-1 text-xs text-[var(--color-fg-muted)]">최근 처리와 직접 개입을 시간순으로 함께 보여줍니다. 검토 큐와 Live Judge 판단은 거버넌스 페이지에서 처리합니다.</p>
           </div>
           <${renderActivityTimeline} />
         </section>

--- a/dashboard/src/components/ops/keeper-utilities.ts
+++ b/dashboard/src/components/ops/keeper-utilities.ts
@@ -75,13 +75,13 @@ export function KeeperUtilitiesPanel() {
     <section class="${CARD_STANDARD} flex flex-col gap-3" data-testid="keeper-utilities-panel">
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
-          <h3 class="text-sm font-semibold text-[var(--text-strong)]">키퍼 유틸리티</h3>
-          <p class="mt-1 text-xs leading-[1.45] text-[var(--text-muted)]">
+          <h3 class="text-sm font-semibold text-[var(--color-fg-secondary)]">키퍼 유틸리티</h3>
+          <p class="mt-1 text-xs leading-[1.45] text-[var(--color-fg-muted)]">
             서버 available_actions catalog 기준으로 노출합니다.
           </p>
         </div>
         <select
-          class="shrink-0 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-xs text-[var(--text-body)] transition-colors cursor-pointer min-w-36 focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]"
+          class="shrink-0 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-xs text-[var(--color-fg-primary)] transition-colors cursor-pointer min-w-36 focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]"
           aria-label="키퍼 유틸리티 대상"
           value=${selectedName}
           disabled=${busy || onlineKeepers.length === 0}
@@ -107,8 +107,8 @@ export function KeeperUtilitiesPanel() {
             >
               <div class="flex items-start justify-between gap-3">
                 <div class="min-w-0">
-                  <div class="text-xs font-semibold text-[var(--text-strong)]">${actionTypeLabel(action.action_type)}</div>
-                  <div class="mt-1 text-2xs leading-[1.45] text-[var(--text-muted)]">${actionDescription(action)}</div>
+                  <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">${actionTypeLabel(action.action_type)}</div>
+                  <div class="mt-1 text-2xs leading-[1.45] text-[var(--color-fg-muted)]">${actionDescription(action)}</div>
                   ${adapted
                     ? null
                     : html`<div class="mt-1 text-2xs font-medium text-warn">UI adapter pending</div>`}

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -53,8 +53,8 @@ export function QuickIntervene() {
     <section class="${CARD_STANDARD} flex flex-col gap-3">
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
-          <h3 class="text-sm font-semibold text-[var(--text-strong)]">빠른 개입</h3>
-          <p class="mt-1 text-xs leading-[1.45] text-[var(--text-muted)]">메시지나 메모를 방 또는 키퍼에 바로 보냅니다.</p>
+          <h3 class="text-sm font-semibold text-[var(--color-fg-secondary)]">빠른 개입</h3>
+          <p class="mt-1 text-xs leading-[1.45] text-[var(--color-fg-muted)]">메시지나 메모를 방 또는 키퍼에 바로 보냅니다.</p>
         </div>
         <${ActionButton}
           variant="subtle"
@@ -68,7 +68,7 @@ export function QuickIntervene() {
 
       <div class="flex gap-2 items-stretch flex-wrap">
         <select
-          class="shrink-0 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm text-[var(--text-body)] transition-colors cursor-pointer min-w-30 focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]"
+          class="shrink-0 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm text-[var(--color-fg-primary)] transition-colors cursor-pointer min-w-30 focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]"
           value=${quickTarget.value}
           aria-label="개입 대상"
           onChange=${(e: Event) => { quickTarget.value = (e.target as HTMLSelectElement).value }}
@@ -100,10 +100,10 @@ export function QuickIntervene() {
       ${showAdvanced
         ? html`
             <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
-              <label class="block text-2xs font-medium uppercase tracking-1 text-[var(--text-muted)]" for="quick-intervene-actor">
+              <label class="block text-2xs font-medium uppercase tracking-1 text-[var(--color-fg-muted)]" for="quick-intervene-actor">
                 기록 주체
               </label>
-              <p class="mt-1 text-xs leading-[1.45] text-[var(--text-muted)]">개입과 승인 요청은 이 이름으로 기록됩니다.</p>
+              <p class="mt-1 text-xs leading-[1.45] text-[var(--color-fg-muted)]">개입과 승인 요청은 이 이름으로 기록됩니다.</p>
               <${TextInput}
                 class="mt-3 max-w-65 border-[var(--white-8)] bg-[var(--white-3)]"
                 value=${actorName.value.trim() || 'dashboard'}

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -223,14 +223,14 @@ describe('pickActiveKeepers', () => {
 
 describe('severityToneClass', () => {
   it.each<[string | null | undefined, string]>([
-    ['critical', 'text-[var(--bad)]'],
-    ['HIGH', 'text-[var(--bad)]'],
-    ['warn', 'text-[var(--warn)]'],
-    ['medium', 'text-[var(--warn)]'],
-    ['info', 'text-[var(--text-muted)]'],
-    ['', 'text-[var(--text-muted)]'],
-    [null, 'text-[var(--text-muted)]'],
-    [undefined, 'text-[var(--text-muted)]'],
+    ['critical', 'text-[var(--color-status-err)]'],
+    ['HIGH', 'text-[var(--color-status-err)]'],
+    ['warn', 'text-[var(--color-status-warn)]'],
+    ['medium', 'text-[var(--color-status-warn)]'],
+    ['info', 'text-[var(--color-fg-muted)]'],
+    ['', 'text-[var(--color-fg-muted)]'],
+    [null, 'text-[var(--color-fg-muted)]'],
+    [undefined, 'text-[var(--color-fg-muted)]'],
   ])('maps severity %s to expected tone', (input, expected) => {
     expect(severityToneClass(input)).toBe(expected)
   })

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -152,11 +152,11 @@ function fmtValue(value: number, type: string, name: string): string {
 
 function typeBadge(type: string): ReturnType<typeof html> {
   const colors: Record<string, string> = {
-    counter: 'bg-[var(--accent-10)] text-[var(--accent)]',
-    gauge: 'bg-[var(--ok-10)] text-[var(--ok)]',
-    summary: 'bg-[var(--warn-10)] text-[var(--warn)]',
+    counter: 'bg-[var(--accent-10)] text-[var(--color-accent-fg)]',
+    gauge: 'bg-[var(--ok-10)] text-[var(--color-status-ok)]',
+    summary: 'bg-[var(--warn-10)] text-[var(--color-status-warn)]',
   }
-  return html`<span class="inline-block rounded px-1.5 py-0.5 text-3xs font-mono ${colors[type] ?? 'bg-[var(--white-5)] text-[var(--text-muted)]'}">${type}</span>`
+  return html`<span class="inline-block rounded px-1.5 py-0.5 text-3xs font-mono ${colors[type] ?? 'bg-[var(--white-5)] text-[var(--color-fg-muted)]'}">${type}</span>`
 }
 
 function labelPills(labels: Record<string, string>): ReturnType<typeof html> | null {
@@ -165,7 +165,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
   return html`<span class="ml-2 inline-flex gap-1 flex-wrap">${entries.map(([k, v]) => {
     if (k === 'keeper') {
       return html`<button
-        class="rounded bg-[var(--accent-10)] px-1 py-0.5 text-3xs text-[var(--accent)] font-mono hover:bg-[var(--accent-10)] hover:text-[var(--accent)] transition-colors cursor-pointer"
+        class="rounded bg-[var(--accent-10)] px-1 py-0.5 text-3xs text-[var(--color-accent-fg)] font-mono hover:bg-[var(--accent-10)] hover:text-[var(--color-accent-fg)] transition-colors cursor-pointer"
         title="View keeper detail"
         onClick=${(e: Event) => {
           e.stopPropagation()
@@ -175,7 +175,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
     }
     if (k === 'tool_name' || k === 'tool') {
       return html`<button
-        class="rounded bg-[var(--warn-10)] px-1 py-0.5 text-3xs text-[var(--warn)] font-mono hover:bg-[var(--warn-10)] hover:text-[var(--warn)] transition-colors cursor-pointer"
+        class="rounded bg-[var(--warn-10)] px-1 py-0.5 text-3xs text-[var(--color-status-warn)] font-mono hover:bg-[var(--warn-10)] hover:text-[var(--color-status-warn)] transition-colors cursor-pointer"
         title="View tool quality"
         onClick=${(e: Event) => {
           e.stopPropagation()
@@ -183,7 +183,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
         }}
       >${k}=${v}</button>`
     }
-    return html`<span class="rounded bg-[var(--white-5)] px-1 py-0.5 text-3xs text-[var(--text-muted)] font-mono">${k}=${v}</span>`
+    return html`<span class="rounded bg-[var(--white-5)] px-1 py-0.5 text-3xs text-[var(--color-fg-muted)] font-mono">${k}=${v}</span>`
   })}</span>`
 }
 
@@ -292,14 +292,14 @@ export function PrometheusMetrics() {
       <div class="flex items-center justify-between">
         <div>
           <h2 class="text-lg font-semibold text-[var(--text-heading)]">Prometheus 메트릭</h2>
-          <p class="text-xs text-[var(--text-muted)]">
+          <p class="text-xs text-[var(--color-fg-muted)]">
             /metrics endpoint (${totalMetrics}개 메트릭, ${totalSamples}개 샘플, ${nonZeroSamples}개 활성)
           </p>
         </div>
         <div class="flex items-center gap-3">
-          ${lastUpdated.value && html`<span class="text-xs text-[var(--text-muted)]">${lastUpdated.value}</span>`}
+          ${lastUpdated.value && html`<span class="text-xs text-[var(--color-fg-muted)]">${lastUpdated.value}</span>`}
           <button
-            class="rounded border border-[var(--card-border)] bg-[var(--bg-1)] px-3 py-1.5 text-xs text-[var(--text-body)] hover:bg-[var(--bg-2)] transition-colors"
+            class="rounded border border-[var(--color-border-default)] bg-[var(--bg-1)] px-3 py-1.5 text-xs text-[var(--color-fg-primary)] hover:bg-[var(--bg-2)] transition-colors"
             onClick=${refresh}
             disabled=${loading.value}
           >
@@ -323,7 +323,7 @@ export function PrometheusMetrics() {
       />
 
       ${query && html`
-        <span class="text-xs text-[var(--text-muted)]">
+        <span class="text-xs text-[var(--color-fg-muted)]">
           ${totalMetrics} / ${metrics.value.length} 메트릭 일치
         </span>
       `}
@@ -348,16 +348,16 @@ export function PrometheusMetrics() {
               onClick=${() => toggleCategory(cat)}
             >
               <div class="flex items-center gap-2">
-                <span class="text-xs font-mono ${expanded ? 'text-[var(--text-body)]' : 'text-[var(--text-muted)]'}">${expanded ? '▼' : '▶'}</span>
+                <span class="text-xs font-mono ${expanded ? 'text-[var(--color-fg-primary)]' : 'text-[var(--color-fg-muted)]'}">${expanded ? '▼' : '▶'}</span>
                 <span class="font-medium text-[var(--text-heading)]">${meta.label}</span>
-                <span class="text-xs text-[var(--text-muted)]">${meta.description}</span>
+                <span class="text-xs text-[var(--color-fg-muted)]">${meta.description}</span>
               </div>
               <div class="flex items-center gap-2">
-                <span class="rounded-sm bg-[var(--bg-2)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">
+                <span class="rounded-sm bg-[var(--bg-2)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">
                   ${catMetrics.length}개 메트릭
                 </span>
                 ${activeSamples > 0 && html`
-                  <span class="rounded-sm bg-[var(--ok-10)] px-2 py-0.5 text-3xs text-[var(--ok)]">
+                  <span class="rounded-sm bg-[var(--ok-10)] px-2 py-0.5 text-3xs text-[var(--color-status-ok)]">
                     ${activeSamples}개 활성
                   </span>
                 `}
@@ -368,7 +368,7 @@ export function PrometheusMetrics() {
               <div class="mt-3 overflow-x-auto">
                 <table class="w-full text-xs">
                   <thead>
-                    <tr class="border-b border-[var(--card-border)] text-[var(--text-muted)]">
+                    <tr class="border-b border-[var(--color-border-default)] text-[var(--color-fg-muted)]">
                       <th class="pb-2 text-left font-normal">메트릭</th>
                       <th class="pb-2 text-left font-normal w-16">유형</th>
                       <th class="pb-2 text-right font-normal w-24">값</th>
@@ -378,23 +378,23 @@ export function PrometheusMetrics() {
                     ${catMetrics.flatMap(m =>
                       m.samples.length === 0
                         ? [html`
-                            <tr key="${m.name}" class="border-b border-[var(--card-border)]/30 hover:bg-[var(--bg-1)]">
-                              <td class="py-1.5 font-mono text-[var(--text-body)]">
+                            <tr key="${m.name}" class="border-b border-[var(--color-border-default)]/30 hover:bg-[var(--bg-1)]">
+                              <td class="py-1.5 font-mono text-[var(--color-fg-primary)]">
                                 ${m.name}
-                                <div class="text-3xs text-[var(--text-muted)] font-sans">${m.help}</div>
+                                <div class="text-3xs text-[var(--color-fg-muted)] font-sans">${m.help}</div>
                               </td>
                               <td class="py-1.5">${typeBadge(m.type)}</td>
-                              <td class="py-1.5 text-right text-[var(--text-muted)]">--</td>
+                              <td class="py-1.5 text-right text-[var(--color-fg-muted)]">--</td>
                             </tr>
                           `]
                         : m.samples.map((s, i) => html`
-                            <tr key="${s.name}-${i}" class="border-b border-[var(--card-border)]/30 hover:bg-[var(--bg-1)]">
-                              <td class="py-1.5 font-mono ${s.value !== 0 ? 'text-[var(--text-body)]' : 'text-[var(--text-muted)]'}">
+                            <tr key="${s.name}-${i}" class="border-b border-[var(--color-border-default)]/30 hover:bg-[var(--bg-1)]">
+                              <td class="py-1.5 font-mono ${s.value !== 0 ? 'text-[var(--color-fg-primary)]' : 'text-[var(--color-fg-muted)]'}">
                                 ${s.name}${labelPills(s.labels)}
-                                ${i === 0 && html`<div class="text-3xs text-[var(--text-muted)] font-sans">${m.help}</div>`}
+                                ${i === 0 && html`<div class="text-3xs text-[var(--color-fg-muted)] font-sans">${m.help}</div>`}
                               </td>
                               <td class="py-1.5">${i === 0 ? typeBadge(m.type) : null}</td>
-                              <td class="py-1.5 text-right font-mono tabular-nums ${s.value !== 0 ? 'text-[var(--ok)]' : 'text-[var(--text-muted)]'}">
+                              <td class="py-1.5 text-right font-mono tabular-nums ${s.value !== 0 ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-fg-muted)]'}">
                                 ${fmtValue(s.value, m.type, s.name)}
                               </td>
                             </tr>

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -354,7 +354,7 @@ export function RuntimeMonitor() {
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <select
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)]"
           value=${String(windowMinutes.value)}
           onChange=${(e: Event) => { windowMinutes.value = Number((e.target as HTMLSelectElement).value) }}
         >
@@ -364,12 +364,12 @@ export function RuntimeMonitor() {
           <option value="180">180분</option>
         </select>
         <button
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
           onClick=${() => void load()}
         >
           새로고침
         </button>
-        ${current.loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
+        ${current.loading ? html`<span class="text-xs text-[var(--color-fg-muted)]">로딩 중...</span>` : null}
       </div>
 
       ${current.error
@@ -457,7 +457,7 @@ export function RuntimeMonitor() {
           />
         </div>
         ${(metrics?.models ?? []).length > 0 && filterModelMetrics(metrics?.models ?? [], modelSearch.value).length === 0
-          ? html`<div class="text-2xs text-[var(--text-muted)] mb-2">검색 결과 없음 (${metrics?.models.length ?? 0}개 중)</div>`
+          ? html`<div class="text-2xs text-[var(--color-fg-muted)] mb-2">검색 결과 없음 (${metrics?.models.length ?? 0}개 중)</div>`
           : null}
         <div class="flex flex-col gap-3">
           ${(metrics?.models ?? []).length > 0
@@ -488,7 +488,7 @@ export function RuntimeMonitor() {
                       <strong class="text-sm text-text-strong">${metric.model_id}</strong>
                       <span class="text-xs text-text-muted">entries ${fmtNumber(metric.entry_count)} · fallback ${fmtNumber(metric.fallback_count)}</span>
                       ${metricCoverageText(metric)
-                        ? html`<span class="text-2xs ${hasCoverageGap ? 'text-[var(--status-warn)]' : 'text-[var(--text-muted)]'}">${metricCoverageText(metric)}</span>`
+                        ? html`<span class="text-2xs ${hasCoverageGap ? 'text-[var(--status-warn)]' : 'text-[var(--color-fg-muted)]'}">${metricCoverageText(metric)}</span>`
                         : null}
                     </div>
                     <div class="flex gap-2 items-center">
@@ -550,7 +550,7 @@ export function RuntimeMonitor() {
                       .map(b => b.error_rate)
                       .filter((value): value is number => typeof value === 'number' && !Number.isNaN(value))
                     if (latencySeries.length < 2 || errorSeries.length < 2) return null
-                    return html`<div class="flex items-center gap-4 mt-1 text-2xs text-[var(--text-muted)]">
+                    return html`<div class="flex items-center gap-4 mt-1 text-2xs text-[var(--color-fg-muted)]">
                         <span>p95 latency</span>
                         <span dangerouslySetInnerHTML=${{ __html: sparklineSvg(latencySeries, 'var(--status-warn)', 80, 18) }}></span>
                         <span>error rate</span>
@@ -571,7 +571,7 @@ export function RuntimeMonitor() {
                       hasCacheNumbers
                         ? cacheRead + inputTokens
                         : null
-                    return html`<div class="text-2xs text-[var(--text-muted)] mt-1">
+                    return html`<div class="text-2xs text-[var(--color-fg-muted)] mt-1">
                       cost ${fmtCoverageAwareCost(metric, metric.total_cost_usd)} · cache savings ${fmtPct(cacheRatio)} (${fmtCoverageAwareNumber(metric, cacheRead)} / ${fmtCoverageAwareNumber(metric, totalIn)} tokens)
                     </div>`
                   })()}
@@ -581,8 +581,8 @@ export function RuntimeMonitor() {
                   ${(metric.top_tools ?? []).length > 0
                     ? html`<div class="flex flex-wrap gap-1 mt-1">
                         ${metric.top_tools?.slice(0, 5).map(t => html`
-                          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs bg-[var(--bg-panel-hover)] text-[var(--text-muted)]">
-                            ${t.tool} <span class="ml-0.5 text-[var(--text-strong)]">${t.count}</span>
+                          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs bg-[var(--color-bg-hover)] text-[var(--color-fg-muted)]">
+                            ${t.tool} <span class="ml-0.5 text-[var(--color-fg-secondary)]">${t.count}</span>
                           </span>
                         `)}
                       </div>`
@@ -590,21 +590,21 @@ export function RuntimeMonitor() {
                   ${(metric.recent_entries ?? []).length > 0
                     ? html`
                       <button
-                        class="text-2xs text-[var(--text-muted)] hover:text-[var(--text-strong)] mt-1 text-left"
+                        class="text-2xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-secondary)] mt-1 text-left"
                         onClick=${() => { expandedModel.value = expandedModel.value === metric.model_id ? null : metric.model_id }}
                       >
                         ${expandedModel.value === metric.model_id ? '▾' : '▸'} recent ${metric.recent_entries?.length ?? 0} turns
                       </button>
                       ${expandedModel.value === metric.model_id
                         ? html`<div class="mt-1 border-t border-card-border/50 pt-2">
-                            <div class="grid grid-cols-7 gap-1 text-3xs text-[var(--text-muted)] font-medium mb-1">
+                            <div class="grid grid-cols-7 gap-1 text-3xs text-[var(--color-fg-muted)] font-medium mb-1">
                               <div>time</div><div>in tok</div><div>out tok</div><div>latency</div><div>prefill tok/s</div><div>cost</div><div>tools</div>
                             </div>
                             ${metric.recent_entries?.map(re => {
                               const detail = recentEntryDetail(re)
                               return html`
                                 <div class="mb-1">
-                                  <div class="grid grid-cols-7 gap-1 text-2xs text-[var(--text-body)]">
+                                  <div class="grid grid-cols-7 gap-1 text-2xs text-[var(--color-fg-primary)]">
                                     <div>${fmtTime(re.ts_unix)}</div>
                                     <div>${fmtRecentEntryNumber(re, re.input_tokens)}</div>
                                     <div>${fmtRecentEntryNumber(re, re.output_tokens)}</div>
@@ -614,7 +614,7 @@ export function RuntimeMonitor() {
                                     <div>${re.tools_count}</div>
                                   </div>
                                   ${detail
-                                    ? html`<div class="text-3xs text-[var(--text-muted)]">${detail}</div>`
+                                    ? html`<div class="text-3xs text-[var(--color-fg-muted)]">${detail}</div>`
                                     : null}
                                 </div>
                               `

--- a/dashboard/src/components/safe-autonomy.ts
+++ b/dashboard/src/components/safe-autonomy.ts
@@ -90,12 +90,12 @@ const safeAutonomy: AsyncResource<SafeAutonomyData> = createAsyncResource()
 function statusTone(status: DomainStatus): string {
   switch (status) {
     case 'pass':
-      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--ok)]'
+      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--color-status-ok)]'
     case 'warn':
-      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--warn)]'
+      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--color-status-warn)]'
     case 'fail':
     default:
-      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--bad)]'
+      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--color-status-err)]'
   }
 }
 
@@ -214,14 +214,14 @@ function DomainCard({ item }: { item: ScorecardItem }) {
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
           <div class="flex items-center gap-2">
-            <div class="text-sm font-semibold text-[var(--text-strong)]">${item.label}</div>
+            <div class="text-sm font-semibold text-[var(--color-fg-secondary)]">${item.label}</div>
             <${StatusPill} status=${item.status} />
           </div>
-          <div class="mt-1 text-xs text-[var(--text-muted)]">${item.summary}</div>
+          <div class="mt-1 text-xs text-[var(--color-fg-muted)]">${item.summary}</div>
         </div>
         <div class="text-right">
-          <div class="text-lg font-semibold text-[var(--text-strong)]">${item.score.toFixed(1)}</div>
-          <div class="text-3xs uppercase tracking-wide text-[var(--text-muted)]">
+          <div class="text-lg font-semibold text-[var(--color-fg-secondary)]">${item.score.toFixed(1)}</div>
+          <div class="text-3xs uppercase tracking-wide text-[var(--color-fg-muted)]">
             weight ${item.weight ?? 0}
           </div>
         </div>
@@ -236,21 +236,21 @@ function KeeperCard({ item }: { item: KeeperItem }) {
       <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div class="min-w-0">
           <div class="flex items-center gap-2">
-            <div class="text-sm font-semibold text-[var(--text-strong)]">${item.name}</div>
+            <div class="text-sm font-semibold text-[var(--color-fg-secondary)]">${item.name}</div>
             <${StatusPill} status=${item.status} />
           </div>
-          <div class="mt-1 text-xs text-[var(--text-muted)]">
+          <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
             ${item.agent_name} · ${item.sandbox_profile}/${item.sandbox_backend} · ${item.network_mode}
           </div>
-          <div class="mt-2 text-sm text-[var(--text-body)]">${item.goal || 'goal 없음'}</div>
-          <div class="mt-2 flex flex-wrap gap-2 text-3xs text-[var(--text-muted)]">
+          <div class="mt-2 text-sm text-[var(--color-fg-primary)]">${item.goal || 'goal 없음'}</div>
+          <div class="mt-2 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-muted)]">
             ${item.active_goal_ids.map(goalId => html`
               <span class="rounded border border-[var(--white-10)] bg-[var(--white-6)] px-2 py-0.5">${goalId}</span>
             `)}
           </div>
           ${item.last_blocker
             ? html`
-              <div class="mt-3 rounded border border-[var(--warn-30)] bg-[var(--warn-12)] px-3 py-2 text-xs text-[var(--warn)]">
+              <div class="mt-3 rounded border border-[var(--warn-30)] bg-[var(--warn-12)] px-3 py-2 text-xs text-[var(--color-status-warn)]">
                 blocker: ${item.last_blocker}
               </div>
             `
@@ -280,16 +280,16 @@ function FindingsList({ findings }: { findings: FindingItem[] }) {
           <div class="flex items-start justify-between gap-3">
             <div class="min-w-0">
               <div class="flex flex-wrap items-center gap-2">
-                <code class="text-3xs text-[var(--text-muted)]">${item.reason_code}</code>
+                <code class="text-3xs text-[var(--color-fg-muted)]">${item.reason_code}</code>
                 <${StatusPill} status=${item.severity} />
-                ${item.keeper_name ? html`<span class="text-3xs text-[var(--text-muted)]">${item.keeper_name}</span>` : null}
+                ${item.keeper_name ? html`<span class="text-3xs text-[var(--color-fg-muted)]">${item.keeper_name}</span>` : null}
               </div>
-              <div class="mt-1 text-sm text-[var(--text-strong)]">${item.summary}</div>
-              <div class="mt-1 text-xs text-[var(--text-muted)]">${item.suggested_next_action}</div>
+              <div class="mt-1 text-sm text-[var(--color-fg-secondary)]">${item.summary}</div>
+              <div class="mt-1 text-xs text-[var(--color-fg-muted)]">${item.suggested_next_action}</div>
             </div>
             ${item.human_action_required
               ? html`
-                <span class="rounded border border-[var(--bad-30)] bg-[var(--bad-12)] px-2 py-1 text-3xs font-semibold uppercase tracking-wide text-[var(--bad)]">
+                <span class="rounded border border-[var(--bad-30)] bg-[var(--bad-12)] px-2 py-1 text-3xs font-semibold uppercase tracking-wide text-[var(--color-status-err)]">
                   human
                 </span>
               `
@@ -311,12 +311,12 @@ function TimelineList({ timeline }: { timeline: TimelineItem[] }) {
         <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
           <div class="flex items-start justify-between gap-3">
             <div class="min-w-0">
-              <div class="text-xs text-[var(--text-strong)]">${item.summary}</div>
-              <div class="mt-1 text-3xs text-[var(--text-muted)]">
+              <div class="text-xs text-[var(--color-fg-secondary)]">${item.summary}</div>
+              <div class="mt-1 text-3xs text-[var(--color-fg-muted)]">
                 ${item.kind}${item.keeper_name ? ` · ${item.keeper_name}` : ''}
               </div>
             </div>
-            <div class="shrink-0 text-3xs text-[var(--text-muted)]">
+            <div class="shrink-0 text-3xs text-[var(--color-fg-muted)]">
               ${item.ts_iso ? formatTimeAgo(item.ts_iso) : '정보 없음'}
             </div>
           </div>
@@ -342,20 +342,20 @@ export function SafeAutonomyPanel() {
               <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-4">
                 <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                   <div class="max-w-3xl">
-                    <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+                    <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
                       Advisory Truth Layer
                     </div>
                     <div class="mt-2 flex items-center gap-2">
-                      <div class="text-2xl font-semibold text-[var(--text-strong)]">
+                      <div class="text-2xl font-semibold text-[var(--color-fg-secondary)]">
                         ${data.summary.global_score.toFixed(1)}
                       </div>
                       <${StatusPill} status=${data.summary.status} />
                     </div>
-                    <div class="mt-2 text-sm leading-paragraph text-[var(--text-body)]">
+                    <div class="mt-2 text-sm leading-paragraph text-[var(--color-fg-primary)]">
                       Tool correctness, sandbox truth, approval gates, cascade/FSM gracefulness,
                       audit trail completeness를 keeper별로 한 번에 보여줍니다.
                     </div>
-                    <div class="mt-2 text-3xs text-[var(--text-muted)]">
+                    <div class="mt-2 text-3xs text-[var(--color-fg-muted)]">
                       generated ${data.generated_at ? formatTimeAgo(data.generated_at) : '정보 없음'}
                     </div>
                   </div>

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -53,13 +53,13 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
   const isEnv = entry.source === 'env'
   const isDefault = entry.source !== 'env'
   const valueClass = entry.sensitive
-    ? 'text-[var(--text-muted)] italic'
+    ? 'text-[var(--color-fg-muted)] italic'
     : isDefault
-      ? 'text-[var(--text-muted)]'
+      ? 'text-[var(--color-fg-muted)]'
       : 'text-[var(--accent-primary)] font-medium'
 
   return html`
-    <div class="flex items-start gap-3 py-2 px-3 rounded hover:bg-[var(--bg-panel-hover)] transition-colors">
+    <div class="flex items-start gap-3 py-2 px-3 rounded hover:bg-[var(--color-bg-hover)] transition-colors">
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
           <code class="text-xs font-mono text-[var(--text-primary)]">${entry.env}</code>
@@ -67,15 +67,15 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
             <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
           ` : null}
           ${!isEnv && entry.source !== 'default' ? html`
-            <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--bg-panel-hover)] text-[var(--text-muted)]">${entry.source}</span>
+            <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--color-bg-hover)] text-[var(--color-fg-muted)]">${entry.source}</span>
           ` : null}
           ${entry.sensitive ? html`
-            <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)]">sensitive</span>
+            <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--warn-10)] text-[var(--color-status-warn)]">sensitive</span>
           ` : null}
         </div>
-        <div class="text-xs text-[var(--text-muted)] mt-0.5">${entry.description}</div>
+        <div class="text-xs text-[var(--color-fg-muted)] mt-0.5">${entry.description}</div>
         ${entry.source_detail ? html`
-          <div class="text-3xs text-[var(--text-muted)] mt-0.5">source: ${entry.source_detail}</div>
+          <div class="text-3xs text-[var(--color-fg-muted)] mt-0.5">source: ${entry.source_detail}</div>
         ` : null}
       </div>
       <div class="text-right shrink-0">
@@ -83,7 +83,7 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
           ${entry.value ?? entry.default}
         </div>
         ${isEnv && entry.default ? html`
-          <div class="text-3xs text-[var(--text-muted)] mt-0.5">
+          <div class="text-3xs text-[var(--color-fg-muted)] mt-0.5">
             default: ${entry.default}
           </div>
         ` : null}
@@ -101,15 +101,15 @@ function CategoryPanel({ name, entries }: { name: string; entries: ConfigEntry[]
   if (filtered.length === 0) return null
 
   return html`
-    <div class="border border-[var(--border-subtle)] rounded overflow-hidden mb-3">
+    <div class="border border-[var(--color-border-divider)] rounded overflow-hidden mb-3">
       <button
-        class="w-full flex items-center justify-between px-4 py-2.5 bg-[var(--bg-surface)] hover:bg-[var(--bg-panel-hover)] transition-colors text-left"
+        class="w-full flex items-center justify-between px-4 py-2.5 bg-[var(--bg-surface)] hover:bg-[var(--color-bg-hover)] transition-colors text-left"
         onClick=${() => toggleCategory(name)}
       >
         <div class="flex items-center gap-2">
-          <span class="text-xs text-[var(--text-muted)]">${isExpanded ? '\u25BC' : '\u25B6'}</span>
+          <span class="text-xs text-[var(--color-fg-muted)]">${isExpanded ? '\u25BC' : '\u25B6'}</span>
           <span class="text-sm font-medium text-[var(--text-primary)] capitalize">${name}</span>
-          <span class="text-xs text-[var(--text-muted)]">(${filtered.length})</span>
+          <span class="text-xs text-[var(--color-fg-muted)]">(${filtered.length})</span>
         </div>
         ${customCount > 0 ? html`
           <span class="text-3xs px-2 py-0.5 rounded-sm bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">
@@ -118,7 +118,7 @@ function CategoryPanel({ name, entries }: { name: string; entries: ConfigEntry[]
         ` : null}
       </button>
       ${isExpanded ? html`
-        <div class="divide-y divide-[var(--border-subtle)]">
+        <div class="divide-y divide-[var(--color-border-divider)]">
           ${filtered.map(entry => html`<${EntryRow} entry=${entry} />`)}
         </div>
       ` : null}
@@ -134,20 +134,20 @@ function ServerMeta() {
 
   return html`
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
-      <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
-        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Version</div>
+      <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">Version</div>
         <div class="text-sm font-mono text-[var(--text-primary)]">${server.version}</div>
       </div>
-      <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
-        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Uptime</div>
+      <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">Uptime</div>
         <div class="text-sm font-mono text-[var(--text-primary)]">${formatUptime(server.uptime_seconds)}</div>
       </div>
-      <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
-        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">OCaml</div>
+      <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">OCaml</div>
         <div class="text-sm font-mono text-[var(--text-primary)]">${server.ocaml_version}</div>
       </div>
-      <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
-        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">PID</div>
+      <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">PID</div>
         <div class="text-sm font-mono text-[var(--text-primary)]">${server.pid}</div>
       </div>
     </div>
@@ -176,7 +176,7 @@ export function ServerConfig() {
           onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
         />
         <button
-          class="px-3 py-1.5 text-xs rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel-hover)] transition-colors"
+          class="px-3 py-1.5 text-xs rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)] text-[var(--color-fg-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
           onClick=${() => void refreshServerConfig()}
           disabled=${loading}
         >
@@ -185,7 +185,7 @@ export function ServerConfig() {
       </div>
 
       ${error ? html`
-        <div class="text-sm text-[var(--bad)] mb-3">${error}</div>
+        <div class="text-sm text-[var(--color-status-err)] mb-3">${error}</div>
       ` : null}
 
       ${loading && !data ? html`

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -51,7 +51,7 @@ function HighlightedText({ text, query }: { text: string; query: string }) {
   return html`
     <span>${segments.map(seg =>
       seg.match
-        ? html`<mark class="bg-[rgba(99,102,241,0.25)] text-[var(--text-strong)] px-0.5 rounded">${seg.text}</mark>`
+        ? html`<mark class="bg-[rgba(99,102,241,0.25)] text-[var(--color-fg-secondary)] px-0.5 rounded">${seg.text}</mark>`
         : seg.text
     )}</span>
   `
@@ -69,10 +69,10 @@ interface KindStyle {
 
 const KIND_STYLES: Record<TraceEventKind, KindStyle> = {
   broadcast:  { icon: 'M', color: 'text-[var(--blue-400)]', label: '브로드캐스트' },
-  task:       { icon: 'T', color: 'text-[var(--accent)]', label: '태스크' },
-  tool_call:  { icon: '>', color: 'text-[var(--ok)]', label: '도구 호출' },
+  task:       { icon: 'T', color: 'text-[var(--color-accent-fg)]', label: '태스크' },
+  tool_call:  { icon: '>', color: 'text-[var(--color-status-ok)]', label: '도구 호출' },
   heartbeat:  { icon: 'H', color: 'text-[var(--slate-400)]', label: '하트비트' },
-  lifecycle:  { icon: 'L', color: 'text-[var(--warn)]', label: '생명주기' },
+  lifecycle:  { icon: 'L', color: 'text-[var(--color-status-warn)]', label: '생명주기' },
   thinking:   { icon: '\u{1F4AD}', color: 'text-[#c084fc]', label: '내부 사고' },
   oas_tool:   { icon: 'O', color: 'text-[var(--amber-bright)]', label: 'OAS 도구' },
   oas_turn:   { icon: 'R', color: 'text-[var(--rose-light)]', label: 'OAS 턴' },
@@ -91,12 +91,12 @@ function durableStyle(kind: unknown): { icon: string; color: string } | null {
   switch (kind) {
     case 'llm_request':      return { icon: '>', color: 'text-[var(--sky-400)]' }
     case 'llm_response':     return { icon: '<', color: 'text-[var(--cyan)]' }
-    case 'error_occurred':   return { icon: '!', color: 'text-[var(--bad)]' }
-    case 'tool_called':      return { icon: 't', color: 'text-[var(--ok)]' }
-    case 'tool_completed':   return { icon: 'x', color: 'text-[var(--ok)]' }
-    case 'state_transition': return { icon: '>', color: 'text-[var(--accent)]' }
+    case 'error_occurred':   return { icon: '!', color: 'text-[var(--color-status-err)]' }
+    case 'tool_called':      return { icon: 't', color: 'text-[var(--color-status-ok)]' }
+    case 'tool_completed':   return { icon: 'x', color: 'text-[var(--color-status-ok)]' }
+    case 'state_transition': return { icon: '>', color: 'text-[var(--color-accent-fg)]' }
     case 'checkpoint_saved': return { icon: '*', color: 'text-[var(--slate-400)]' }
-    case 'turn_started':     return { icon: 'r', color: 'text-[var(--warn)]' }
+    case 'turn_started':     return { icon: 'r', color: 'text-[var(--color-status-warn)]' }
     default: return null
   }
 }
@@ -122,9 +122,9 @@ function taskIcon(type: string): string {
 
 function taskColor(type: string): string {
   switch (type) {
-    case 'task_completed':  return 'text-[var(--ok)]'
-    case 'task_cancelled':  return 'text-[var(--bad)]'
-    default: return 'text-[var(--accent)]'
+    case 'task_completed':  return 'text-[var(--color-status-ok)]'
+    case 'task_cancelled':  return 'text-[var(--color-status-err)]'
+    default: return 'text-[var(--color-accent-fg)]'
   }
 }
 
@@ -167,14 +167,14 @@ function DiffBlock({ text }: { text: string }) {
     <div class="font-mono text-2xs leading-loose overflow-x-auto">
       ${lines.map((line: string) => {
         const cls =
-          line.startsWith('+') && !line.startsWith('+++') ? 'text-[var(--ok)] bg-[var(--ok-6)]'
-          : line.startsWith('-') && !line.startsWith('---') ? 'text-[var(--bad)] bg-[var(--bad-6)]'
-          : line.startsWith('@@') ? 'text-[var(--accent)] font-semibold'
-          : 'text-[var(--text-body)]'
+          line.startsWith('+') && !line.startsWith('+++') ? 'text-[var(--color-status-ok)] bg-[var(--ok-6)]'
+          : line.startsWith('-') && !line.startsWith('---') ? 'text-[var(--color-status-err)] bg-[var(--bad-6)]'
+          : line.startsWith('@@') ? 'text-[var(--color-accent-fg)] font-semibold'
+          : 'text-[var(--color-fg-primary)]'
         return html`<div class="${cls} px-2 min-h-[1.6em]">${line || ' '}</div>`
       })}
       ${truncatedCount > 0 ? html`
-        <div class="px-2 py-2 text-[var(--text-muted)] italic text-center border-t border-[var(--white-6)]">
+        <div class="px-2 py-2 text-[var(--color-fg-muted)] italic text-center border-t border-[var(--white-6)]">
           ... ${truncatedCount} lines truncated for performance ...
         </div>
       ` : null}
@@ -190,7 +190,7 @@ function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: Cont
   const shouldCollapse = needsCollapse && !expanded.value
 
   const titleLabel = isErr ? 'Error' : 'Result'
-  const titleColor = isErr ? 'text-[var(--bad)]' : 'text-[var(--text-muted)]'
+  const titleColor = isErr ? 'text-[var(--color-status-err)]' : 'text-[var(--color-fg-muted)]'
   const borderColor = isErr ? 'border-[var(--bad-20)]' : 'border-[var(--white-8)]'
   const bgColor = isErr ? 'bg-[var(--bad-6)]' : 'bg-[var(--white-3)]'
 
@@ -203,7 +203,7 @@ function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: Cont
       <div class="flex items-center justify-between mb-1">
         <span class="text-3xs font-semibold uppercase tracking-wider ${titleColor}">${titleLabel}</span>
         ${hint !== 'plain' ? html`
-          <span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] uppercase">${hint}</span>
+          <span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--color-fg-disabled)] uppercase">${hint}</span>
         ` : null}
       </div>
       <div class="rounded border ${borderColor} ${bgColor} overflow-hidden">
@@ -211,7 +211,7 @@ function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: Cont
              style=${shouldCollapse ? `max-height: ${RESULT_COLLAPSED_MAX_HEIGHT}px` : ''}>
           ${hint === 'diff' ? html`<${DiffBlock} text=${text} />`
             : hint === 'json' ? html`<${JsonViewerCard} title=${titleLabel} data=${parseJsonLikeData(text)} />`
-            : html`<pre class="m-0 text-2xs font-mono ${isErr ? 'text-[var(--bad)]' : 'text-[var(--text-body)]'} p-3 overflow-x-auto whitespace-pre-wrap break-all leading-relaxed">${displayText}</pre>`}
+            : html`<pre class="m-0 text-2xs font-mono ${isErr ? 'text-[var(--color-status-err)]' : 'text-[var(--color-fg-primary)]'} p-3 overflow-x-auto whitespace-pre-wrap break-all leading-relaxed">${displayText}</pre>`}
           ${shouldCollapse ? html`
             <div class="absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t ${isErr ? 'from-[rgba(239,68,68,0.08)]' : 'from-[var(--white-3)]'} to-transparent pointer-events-none"></div>
           ` : null}
@@ -219,7 +219,7 @@ function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: Cont
         ${needsCollapse ? html`
           <button
             type="button"
-            class="w-full py-1.5 text-3xs font-medium text-[var(--accent)] hover:text-[var(--text-strong)] hover:bg-[var(--white-5)] transition-colors cursor-pointer border-t border-[var(--white-6)] bg-transparent"
+            class="w-full py-1.5 text-3xs font-medium text-[var(--color-accent-fg)] hover:text-[var(--color-fg-secondary)] hover:bg-[var(--white-5)] transition-colors cursor-pointer border-t border-[var(--white-6)] bg-transparent"
             onClick=${() => { expanded.value = !expanded.value }}
           >
             ${expanded.value ? '접기' : `전체 보기 (${text.split('\n').length}줄)`}
@@ -241,7 +241,7 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
     <div class="mt-2 space-y-2">
       ${event.toolArgs ? html`
         <div>
-          <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Args</div>
+          <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">Args</div>
           <${JsonViewerCard} title="Args" data=${parseJsonLikeData(event.toolArgs)} />
         </div>
       ` : null}
@@ -249,19 +249,19 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
         <${ResultViewer} text=${resultText} hint=${hint} isError=${Boolean(event.error)} />
       ` : null}
       ${gateRejected ? html`
-        <div class="text-3xs px-2 py-1 rounded bg-[var(--bad-10)] text-[var(--bad)] inline-block">
+        <div class="text-3xs px-2 py-1 rounded bg-[var(--bad-10)] text-[var(--color-status-err)] inline-block">
           거부: ${event.gate?.reason ?? ''}
         </div>
       ` : null}
       ${!event.toolArgs && !resultText && !gateRejected ? html`
-        <div class="text-3xs text-[var(--text-dim)] italic px-2 py-1">
+        <div class="text-3xs text-[var(--color-fg-disabled)] italic px-2 py-1">
           세부 정보가 기록되지 않았습니다.
         </div>
       ` : null}
       ${'' /* Metadata row */}
       ${event.cost_usd != null && event.cost_usd > 0 ? html`
-        <div class="flex gap-3 text-3xs text-[var(--text-dim)]">
-          <span>비용: <span class="font-mono text-[var(--accent)]">$${event.cost_usd.toFixed(4)}</span></span>
+        <div class="flex gap-3 text-3xs text-[var(--color-fg-disabled)]">
+          <span>비용: <span class="font-mono text-[var(--color-accent-fg)]">$${event.cost_usd.toFixed(4)}</span></span>
           ${event.duration_ms != null ? html`<span>소요: <span class="font-mono ${durationColor(event.duration_ms)}">${formatDuration(event.duration_ms)}</span></span>` : null}
         </div>
       ` : null}
@@ -285,10 +285,10 @@ function TaskDetail({ event }: { event: UnifiedTraceEvent }) {
   const title = typeof d.title === 'string' ? d.title : null
   const notes = typeof d.completion_notes === 'string' ? d.completion_notes : null
   return html`
-    <div class="mt-2 text-xs text-[var(--text-body)] space-y-1 px-3 py-2 bg-[var(--white-3)] rounded">
-      ${taskId ? html`<div><span class="text-[var(--text-dim)]">ID:</span> <span class="font-mono">${taskId}</span></div>` : null}
-      ${title ? html`<div><span class="text-[var(--text-dim)]">제목:</span> ${title}</div>` : null}
-      ${notes ? html`<div><span class="text-[var(--text-dim)]">노트:</span> ${notes}</div>` : null}
+    <div class="mt-2 text-xs text-[var(--color-fg-primary)] space-y-1 px-3 py-2 bg-[var(--white-3)] rounded">
+      ${taskId ? html`<div><span class="text-[var(--color-fg-disabled)]">ID:</span> <span class="font-mono">${taskId}</span></div>` : null}
+      ${title ? html`<div><span class="text-[var(--color-fg-disabled)]">제목:</span> ${title}</div>` : null}
+      ${notes ? html`<div><span class="text-[var(--color-fg-disabled)]">노트:</span> ${notes}</div>` : null}
     </div>
   `
 }
@@ -305,7 +305,7 @@ function ThinkingDetail({ event }: { event: UnifiedTraceEvent }) {
   if (!content) return null
   return html`
     <div class="mt-2 px-3 py-2 rounded bg-[rgba(192,132,252,0.04)] border border-[rgba(192,132,252,0.12)]">
-      <div class="text-sm leading-relaxed text-[var(--text-body)]">
+      <div class="text-sm leading-relaxed text-[var(--color-fg-primary)]">
         <${Markdown} text=${content} />
       </div>
     </div>
@@ -320,16 +320,16 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const phase = typeof d.phase === 'string' ? d.phase : ''
     const toolName = typeof d.tool_name === 'string' ? d.tool_name : 'unknown'
     const phaseLabel = phase === 'called' ? '호출' : phase === 'completed' ? '완료' : phase
-    const phaseColor = phase === 'called' ? 'text-[var(--accent)]' : 'text-[var(--ok)]'
+    const phaseColor = phase === 'called' ? 'text-[var(--color-accent-fg)]' : 'text-[var(--color-status-ok)]'
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--white-6)] space-y-1">
         <div class="flex items-center gap-2 text-xs">
-          <span class="text-[var(--text-dim)]">단계:</span>
+          <span class="text-[var(--color-fg-disabled)]">단계:</span>
           <span class="font-mono font-semibold ${phaseColor}">${phaseLabel}</span>
         </div>
         <div class="flex items-center gap-2 text-xs">
-          <span class="text-[var(--text-dim)]">도구:</span>
-          <span class="font-mono text-[var(--text-body)]">${toolName}</span>
+          <span class="text-[var(--color-fg-disabled)]">도구:</span>
+          <span class="font-mono text-[var(--color-fg-primary)]">${toolName}</span>
         </div>
       </div>
     `
@@ -343,8 +343,8 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--white-6)]">
         <div class="flex items-center gap-2 text-xs">
-          <span class="text-[var(--text-dim)]">턴 ${turn != null ? String(turn) : '-'}:</span>
-          <span class="font-mono font-semibold text-[var(--text-body)]">${phaseLabel}</span>
+          <span class="text-[var(--color-fg-disabled)]">턴 ${turn != null ? String(turn) : '-'}:</span>
+          <span class="font-mono font-semibold text-[var(--color-fg-primary)]">${phaseLabel}</span>
         </div>
       </div>
     `
@@ -360,9 +360,9 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[var(--sky-4)] border border-[rgba(56,189,248,0.15)] space-y-2">
         <div class="flex items-center gap-3 text-xs">
-          ${before != null ? html`<span><span class="text-[var(--text-dim)]">Before:</span> <span class="font-mono">${before.toLocaleString()}</span></span>` : null}
-          <span class="text-[var(--text-dim)]">→</span>
-          ${after != null ? html`<span><span class="text-[var(--text-dim)]">After:</span> <span class="font-mono">${after.toLocaleString()}</span></span>` : null}
+          ${before != null ? html`<span><span class="text-[var(--color-fg-disabled)]">Before:</span> <span class="font-mono">${before.toLocaleString()}</span></span>` : null}
+          <span class="text-[var(--color-fg-disabled)]">→</span>
+          ${after != null ? html`<span><span class="text-[var(--color-fg-disabled)]">After:</span> <span class="font-mono">${after.toLocaleString()}</span></span>` : null}
         </div>
         ${saved != null && saved > 0 ? html`
           <div class="flex items-center gap-2">
@@ -376,7 +376,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
             <span class="text-3xs font-mono text-[var(--sky-400)]">-${saved.toLocaleString()}tok (${(ratio ?? 0).toFixed(0)}%)</span>
           </div>
         ` : null}
-        ${compactPhase ? html`<div class="text-3xs text-[var(--text-dim)]">단계: ${compactPhase}</div>` : null}
+        ${compactPhase ? html`<div class="text-3xs text-[var(--color-fg-disabled)]">단계: ${compactPhase}</div>` : null}
       </div>
     `
   }
@@ -391,9 +391,9 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[var(--sky-4)] border border-[rgba(56,189,248,0.12)] space-y-1">
         <div class="flex items-center gap-3 text-xs">
-          <span><span class="text-[var(--text-dim)]">모델:</span> <span class="font-mono">${model}</span></span>
-          <span><span class="text-[var(--text-dim)]">입력:</span> <span class="font-mono">${inputTokens.toLocaleString()}tok</span></span>
-          ${turn != null ? html`<span><span class="text-[var(--text-dim)]">턴:</span> <span class="font-mono">${String(turn)}</span></span>` : null}
+          <span><span class="text-[var(--color-fg-disabled)]">모델:</span> <span class="font-mono">${model}</span></span>
+          <span><span class="text-[var(--color-fg-disabled)]">입력:</span> <span class="font-mono">${inputTokens.toLocaleString()}tok</span></span>
+          ${turn != null ? html`<span><span class="text-[var(--color-fg-disabled)]">턴:</span> <span class="font-mono">${String(turn)}</span></span>` : null}
         </div>
       </div>
     `
@@ -405,19 +405,19 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const durationMs = typeof d.duration_ms === 'number' ? d.duration_ms : null
     const turn = d.turn
     const responseText = typeof d.response_text === 'string' ? d.response_text : ''
-    const stopColor = stopReason === 'end_turn' || stopReason === 'stop' ? 'text-[var(--ok)]' : 'text-[var(--warn)]'
+    const stopColor = stopReason === 'end_turn' || stopReason === 'stop' ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-warn)]'
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[rgba(34,211,238,0.04)] border border-[var(--cyan-12)] space-y-1">
         <div class="flex items-center gap-3 text-xs flex-wrap">
-          <span><span class="text-[var(--text-dim)]">출력:</span> <span class="font-mono">${outputTokens.toLocaleString()}tok</span></span>
-          <span><span class="text-[var(--text-dim)]">종료:</span> <span class="font-mono ${stopColor}">${stopReason}</span></span>
-          ${durationMs != null ? html`<span><span class="text-[var(--text-dim)]">소요:</span> <span class="font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span></span>` : null}
-          ${turn != null ? html`<span><span class="text-[var(--text-dim)]">턴:</span> <span class="font-mono">${String(turn)}</span></span>` : null}
+          <span><span class="text-[var(--color-fg-disabled)]">출력:</span> <span class="font-mono">${outputTokens.toLocaleString()}tok</span></span>
+          <span><span class="text-[var(--color-fg-disabled)]">종료:</span> <span class="font-mono ${stopColor}">${stopReason}</span></span>
+          ${durationMs != null ? html`<span><span class="text-[var(--color-fg-disabled)]">소요:</span> <span class="font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span></span>` : null}
+          ${turn != null ? html`<span><span class="text-[var(--color-fg-disabled)]">턴:</span> <span class="font-mono">${String(turn)}</span></span>` : null}
         </div>
         ${responseText ? html`
           <details class="mt-1">
-            <summary class="text-3xs text-[var(--text-dim)] cursor-pointer hover:text-[var(--text-body)]">응답 텍스트</summary>
-            <pre class="mt-1 p-2 rounded bg-[var(--white-3)] text-2xs font-mono text-[var(--text-body)] whitespace-pre-wrap break-all max-h-75 overflow-auto">${responseText}</pre>
+            <summary class="text-3xs text-[var(--color-fg-disabled)] cursor-pointer hover:text-[var(--color-fg-primary)]">응답 텍스트</summary>
+            <pre class="mt-1 p-2 rounded bg-[var(--white-3)] text-2xs font-mono text-[var(--color-fg-primary)] whitespace-pre-wrap break-all max-h-75 overflow-auto">${responseText}</pre>
           </details>
         ` : null}
       </div>
@@ -429,8 +429,8 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const errorDetail = typeof d.detail === 'string' ? d.detail : ''
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[var(--bad-6)] border border-[var(--bad-soft)] space-y-1">
-        <div class="text-xs"><span class="text-[var(--text-dim)]">도메인:</span> <span class="font-mono text-[var(--bad)]">${domain}</span></div>
-        ${errorDetail ? html`<div class="text-2xs font-mono text-[var(--text-body)] break-all">${errorDetail}</div>` : null}
+        <div class="text-xs"><span class="text-[var(--color-fg-disabled)]">도메인:</span> <span class="font-mono text-[var(--color-status-err)]">${domain}</span></div>
+        ${errorDetail ? html`<div class="text-2xs font-mono text-[var(--color-fg-primary)] break-all">${errorDetail}</div>` : null}
       </div>
     `
   }
@@ -444,8 +444,8 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     <div class="mt-2 grid gap-1.5 px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--white-6)]">
       ${detailRows.map(row => html`
         <div class="flex items-start gap-2 text-xs leading-relaxed">
-          <span class="min-w-[92px] text-[var(--text-dim)] font-mono">${row.label}</span>
-          <span class="text-[var(--text-body)] font-mono break-all">${row.value}</span>
+          <span class="min-w-[92px] text-[var(--color-fg-disabled)] font-mono">${row.label}</span>
+          <span class="text-[var(--color-fg-primary)] font-mono break-all">${row.value}</span>
         </div>
       `)}
     </div>
@@ -497,31 +497,31 @@ export function SessionTraceEntry({ event, searchQuery }: { event: UnifiedTraceE
           ${event.kind === 'tool_call' && event.toolName
             ? html`<span class="text-xs font-mono font-medium ${style.color}">${event.toolName}</span>`
             : html`<span class="text-3xs font-medium uppercase tracking-wider ${kindStyle.color}">${kindStyle.label}</span>`}
-          <span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] uppercase tracking-wider">
+          <span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--color-fg-disabled)] uppercase tracking-wider">
             ${event.sourceLane === 'oas' ? 'OAS' : 'MASC'}
           </span>
           ${event.turn != null ? html`
-            <span class="text-3xs text-[var(--text-dim)]">
+            <span class="text-3xs text-[var(--color-fg-disabled)]">
               T${event.turn}${event.round != null ? `R${event.round}` : ''}
             </span>
           ` : null}
-          ${event.sessionId ? html`<span class="text-3xs text-[var(--text-dim)] font-mono">S ${event.sessionId}</span>` : null}
-          ${event.operationId ? html`<span class="text-3xs text-[var(--text-dim)] font-mono">OP ${event.operationId}</span>` : null}
-          ${event.workerRunId ? html`<span class="text-3xs text-[var(--text-dim)] font-mono">WR ${event.workerRunId}</span>` : null}
+          ${event.sessionId ? html`<span class="text-3xs text-[var(--color-fg-disabled)] font-mono">S ${event.sessionId}</span>` : null}
+          ${event.operationId ? html`<span class="text-3xs text-[var(--color-fg-disabled)] font-mono">OP ${event.operationId}</span>` : null}
+          ${event.workerRunId ? html`<span class="text-3xs text-[var(--color-fg-disabled)] font-mono">WR ${event.workerRunId}</span>` : null}
           ${event.kind === 'task' ? html`
             <span class="text-3xs font-bold uppercase tracking-wider ${taskColor(String(event.detail.type))} bg-[var(--white-5)] px-1.5 py-0.5 rounded">
               ${taskIcon(String(event.detail.type))}
             </span>
           ` : null}
           ${event.error
-            ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">오류</span>`
+            ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--color-status-err)]">오류</span>`
             : gateRejected
-              ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">거부</span>`
+              ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--color-status-err)]">거부</span>`
               : event.kind === 'tool_call'
-                ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--ok)]">완료</span>`
+                ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--color-status-ok)]">완료</span>`
                 : null}
         </div>
-        <div class="mt-0.5 text-2xs text-[var(--text-muted)] font-mono truncate max-w-full" title=${event.summary}>
+        <div class="mt-0.5 text-2xs text-[var(--color-fg-muted)] font-mono truncate max-w-full" title=${event.summary}>
           <${HighlightedText} text=${summaryText} query=${searchQuery ?? ''} />
         </div>
       </div>
@@ -531,7 +531,7 @@ export function SessionTraceEntry({ event, searchQuery }: { event: UnifiedTraceE
         ${event.duration_ms != null ? html`
           <span class="text-2xs font-mono ${durationColor(event.duration_ms)}">${formatDuration(event.duration_ms)}</span>
         ` : null}
-        <${TimeAgo} timestamp=${event.ts_iso} class="text-3xs text-[var(--text-dim)]" />
+        <${TimeAgo} timestamp=${event.ts_iso} class="text-3xs text-[var(--color-fg-disabled)]" />
       </div>
     </div>
   `
@@ -543,7 +543,7 @@ export function SessionTraceEntry({ event, searchQuery }: { event: UnifiedTraceE
       <summary class="list-none cursor-pointer relative pr-8">
         ${row}
         <div class="absolute right-3 top-1/2 -translate-y-1/2 opacity-40 group-hover:opacity-100 transition-opacity">
-          <svg class="w-4 h-4 text-[var(--text-muted)] group-open:rotate-90 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4 text-[var(--color-fg-muted)] group-open:rotate-90 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
           </svg>
         </div>

--- a/dashboard/src/components/session-trace/session-trace-filter.ts
+++ b/dashboard/src/components/session-trace/session-trace-filter.ts
@@ -66,12 +66,12 @@ export function SessionTraceFilter({ agentName }: { agentName: string }) {
             const v = (e.target as HTMLInputElement).value
             setTraceSearchQuery(agentName, v)
           }}
-          class="w-full px-3 py-1.5 text-xs rounded bg-[var(--white-3)] border border-[var(--white-6)] text-[var(--text-body)] placeholder:text-[var(--text-dim)] outline-none focus:border-[var(--accent)]"
+          class="w-full px-3 py-1.5 text-xs rounded bg-[var(--white-3)] border border-[var(--white-6)] text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] outline-none focus:border-[var(--color-accent-fg)]"
         />
         ${searchQuery ? html`
           <button
             onClick=${() => setTraceSearchQuery(agentName, '')}
-            class="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-dim)] hover:text-[var(--text-body)] text-base leading-none"
+            class="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)] text-base leading-none"
           >\u00d7</button>
         ` : null}
       </div>
@@ -88,7 +88,7 @@ export function SessionTraceFilter({ agentName }: { agentName: string }) {
       <!-- Status chips -->
       ${statusCounts.all > 0 ? html`
         <div>
-          <div class="text-3xs text-[var(--text-dim)] mb-1">상태</div>
+          <div class="text-3xs text-[var(--color-fg-disabled)] mb-1">상태</div>
           <${FilterChips}
             chips=${statusChips}
             value=${currentStatus}

--- a/dashboard/src/components/session-trace/session-trace-view.ts
+++ b/dashboard/src/components/session-trace/session-trace-view.ts
@@ -54,7 +54,7 @@ function TraceSummaryBar({ summary }: { summary: TraceSummary }) {
   if (s.total_cost_usd > 0) items.push(`$${s.total_cost_usd.toFixed(3)}`)
 
   return html`
-    <div class="flex flex-wrap gap-2 text-3xs text-[var(--text-muted)]">
+    <div class="flex flex-wrap gap-2 text-3xs text-[var(--color-fg-muted)]">
       ${items.map(item => html`
         <span class="inline-flex items-center bg-[var(--white-4)] border border-[var(--white-6)] px-2 py-1 rounded font-medium">
           ${item}
@@ -75,10 +75,10 @@ function LiveIndicator({ events }: { events: readonly { ts: number }[] }) {
   if (!isRecent) return null
 
   return html`
-    <div class="flex items-center gap-2 px-3 py-2 text-2xs text-[var(--text-muted)]">
+    <div class="flex items-center gap-2 px-3 py-2 text-2xs text-[var(--color-fg-muted)]">
       <span class="relative flex size-2">
-        <span class="animate-ping absolute inline-flex h-full w-full rounded-sm bg-[var(--ok)] opacity-75"></span>
-        <span class="relative inline-flex size-2 rounded-sm bg-[var(--ok)]"></span>
+        <span class="animate-ping absolute inline-flex h-full w-full rounded-sm bg-[var(--color-status-ok)] opacity-75"></span>
+        <span class="relative inline-flex size-2 rounded-sm bg-[var(--color-status-ok)]"></span>
       </span>
       에이전트 작업 중...
     </div>
@@ -183,14 +183,14 @@ export function SessionTraceView({ agentName, isKeeper, keeperStatus, keeperGene
       ${'' /* Event list */}
       <div
         ref=${listRef}
-        class="flex flex-col gap-0.5 max-h-[500px] overflow-y-auto rounded border border-[var(--card-border)] bg-[var(--white-2)]"
+        class="flex flex-col gap-0.5 max-h-[500px] overflow-y-auto rounded border border-[var(--color-border-default)] bg-[var(--white-2)]"
       >
         ${events.map(evt => html`<${SessionTraceEntry} key=${evt.id} event=${evt} searchQuery=${searchQuery} />`)}
         <${LiveIndicator} events=${events} />
       </div>
 
       ${'' /* Footer: event count */}
-      <div class="text-3xs text-[var(--text-dim)] text-right">
+      <div class="text-3xs text-[var(--color-fg-disabled)] text-right">
         ${events.length}건 표시
       </div>
     </div>

--- a/dashboard/src/components/setup-guide-card.test.ts
+++ b/dashboard/src/components/setup-guide-card.test.ts
@@ -139,7 +139,7 @@ describe('SetupGuideCard', () => {
     expect(wrapper.getAttribute('data-setup-guide-tone')).toBe('in-progress')
     // Count chip carries an accent tone (not text-dim muted)
     const progress = container.querySelector('[data-setup-progress="discord"]')!
-    expect(progress.className).toContain('text-[var(--accent)]')
+    expect(progress.className).toContain('text-[var(--color-accent-fg)]')
   })
 
   it('renders numbered step circles (Plane step-wizard pattern)', async () => {

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -75,7 +75,7 @@ function ExternalLinkChip({ href, label }: { href: string; label: string }) {
       href=${href}
       target="_blank"
       rel="noopener noreferrer"
-      class="inline-flex items-center gap-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] px-1.5 py-0.5 text-3xs text-[var(--text-body)] transition-colors hover:bg-[var(--white-8)]"
+      class="inline-flex items-center gap-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--white-8)]"
     >
       ${label}
       <${ExternalLink} size=${10} />
@@ -100,12 +100,12 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
   // count chip in accent color so scanning a list of cards shows which
   // ones are halfway; idle stays muted.
   const countToneClass =
-    tone === 'complete' ? 'text-[var(--ok)]' :
-    tone === 'in-progress' ? 'text-[var(--accent)]' :
-    'text-[var(--text-dim)]'
+    tone === 'complete' ? 'text-[var(--color-status-ok)]' :
+    tone === 'in-progress' ? 'text-[var(--color-accent-fg)]' :
+    'text-[var(--color-fg-disabled)]'
   const progressBarToneClass =
     tone === 'complete' ? 'bg-[var(--ok-10)]' :
-    tone === 'in-progress' ? 'bg-[var(--accent)]' :
+    tone === 'in-progress' ? 'bg-[var(--color-accent-fg)]' :
     'bg-[var(--white-10)]'
 
   return html`
@@ -115,7 +115,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
     >
       <button
         type="button"
-        class="flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left text-xs text-[var(--text-body)] hover:bg-[var(--white-4)]"
+        class="flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left text-xs text-[var(--color-fg-primary)] hover:bg-[var(--white-4)]"
         aria-expanded=${isOpen}
         aria-controls=${`setup-guide-${connectorId}`}
         onClick=${toggle}
@@ -128,7 +128,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
           ${tone === 'complete'
             ? html`
                 <span
-                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--ok)]"
+                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-status-ok)]"
                   aria-label="Setup guide complete"
                   data-setup-complete-badge
                 >
@@ -166,8 +166,8 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
 
       ${isOpen
         ? html`
-            <div id=${`setup-guide-${connectorId}`} class="border-t border-[var(--white-8)] px-3 py-2.5 text-2xs text-[var(--text-body)]">
-              <p class="mb-2 text-[var(--text-dim)]">${guide.intro}</p>
+            <div id=${`setup-guide-${connectorId}`} class="border-t border-[var(--white-8)] px-3 py-2.5 text-2xs text-[var(--color-fg-primary)]">
+              <p class="mb-2 text-[var(--color-fg-disabled)]">${guide.intro}</p>
               <ol class="list-none space-y-2" data-setup-step-list>
                 ${guide.steps.map((step, idx) => {
                   const done = completedMap?.[idx] === true
@@ -177,8 +177,8 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
                   // even before checkboxes are ticked. Circle turns
                   // emerald-filled when the step is complete.
                   const circleToneClass = done
-                    ? 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]'
-                    : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)]'
+                    ? 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]'
+                    : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)]'
                   return html`
                     <li class="flex items-start gap-2.5" data-setup-step-item=${idx}>
                       <span
@@ -200,7 +200,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
                       />
                       <label
                         for=${`setup-step-${connectorId}-${idx}`}
-                        class=${`min-w-0 flex-1 cursor-pointer ${done ? 'text-[var(--text-dim)] line-through decoration-[var(--white-10)]' : ''}`}
+                        class=${`min-w-0 flex-1 cursor-pointer ${done ? 'text-[var(--color-fg-disabled)] line-through decoration-[var(--white-10)]' : ''}`}
                       >
                         <span>${step.text}</span>
                         ${step.link
@@ -214,7 +214,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
               ${guide.references.length > 0
                 ? html`
                     <div class="mt-3 flex flex-wrap items-center gap-1.5 border-t border-[var(--white-8)] pt-2">
-                      <span class="text-3xs uppercase tracking-4 text-[var(--text-dim)]">refs</span>
+                      <span class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">refs</span>
                       ${guide.references.map(ref => html`<${ExternalLinkChip} href=${ref.href} label=${ref.label} />`)}
                     </div>
                   `

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -124,7 +124,7 @@ export function SidecarLogToggle({ connectorId }: { connectorId: string }) {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)]"
       aria-expanded=${entry.open}
       aria-controls=${`sidecar-log-${connectorId}`}
       onClick=${onClick}
@@ -147,8 +147,8 @@ function LevelPills({ connectorId, active }: { connectorId: string; active: LogL
       ${LEVELS.map(level => {
         const isActive = level === active
         const base = 'cursor-pointer rounded border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4'
-        const activeCls = 'border-[var(--accent-1)] bg-[var(--accent-1)]/15 text-[var(--text-body)]'
-        const idleCls = 'border-[var(--white-8)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]'
+        const activeCls = 'border-[var(--accent-1)] bg-[var(--accent-1)]/15 text-[var(--color-fg-primary)]'
+        const idleCls = 'border-[var(--white-8)] text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)]'
         return html`
           <button
             type="button"
@@ -191,11 +191,11 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
       class="mt-3 rounded border border-[var(--white-8)] bg-[var(--bg-1)] p-2"
     >
       <div class="mb-2 flex items-center justify-between gap-2">
-        <div class="min-w-0 truncate text-3xs uppercase tracking-4 text-[var(--text-dim)]" title=${entry.logPath}>
+        <div class="min-w-0 truncate text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]" title=${entry.logPath}>
           ${entry.logPath || '(log path unknown)'}
         </div>
         <div class="flex items-center gap-2">
-          <span class="text-3xs uppercase tracking-4 text-[var(--text-dim)]" data-log-count>
+          <span class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]" data-log-count>
             ${entry.available
               ? hasFilter
                 ? `${filtered.length} / ${entry.lines.length} lines`
@@ -218,7 +218,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
                 type="search"
                 value=${entry.keyword}
                 placeholder="keyword 필터 (case-insensitive)"
-                class="min-w-0 flex-1 rounded border border-[var(--white-8)] bg-[var(--bg-0)] px-2 py-0.5 text-2xs text-[var(--text-body)] focus:border-[var(--accent-1)] focus:outline-none"
+                class="min-w-0 flex-1 rounded border border-[var(--white-8)] bg-[var(--bg-0)] px-2 py-0.5 text-2xs text-[var(--color-fg-primary)] focus:border-[var(--accent-1)] focus:outline-none"
                 data-log-keyword
                 onInput=${(ev: Event) => {
                   const v = (ev.target as HTMLInputElement).value
@@ -229,7 +229,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
                 ? html`
                     <button
                       type="button"
-                      class="cursor-pointer rounded border border-[var(--white-8)] px-1.5 py-0.5 text-3xs uppercase tracking-4 text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+                      class="cursor-pointer rounded border border-[var(--white-8)] px-1.5 py-0.5 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)]"
                       data-log-filter-clear
                       onClick=${() => setEntry(connectorId, { level: 'all', keyword: '' })}
                     >clear</button>
@@ -249,7 +249,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
           : entry.available
             ? filtered.length === 0 && hasFilter
               ? html`
-                  <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-2xs text-[var(--text-dim)]">
+                  <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-2xs text-[var(--color-fg-disabled)]">
                     필터 조건에 맞는 라인이 없습니다.
                     ${entry.lines.length > MAX_FILTER_WINDOW
                       ? ` (최근 ${MAX_FILTER_WINDOW}줄만 검색)`
@@ -257,10 +257,10 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
                   </div>
                 `
               : html`
-                  <pre class="max-h-[40vh] overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--bg-0)] p-2 font-mono text-3xs leading-[1.4] text-[var(--text-body)]">${filtered.join('\n')}</pre>
+                  <pre class="max-h-[40vh] overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--bg-0)] p-2 font-mono text-3xs leading-[1.4] text-[var(--color-fg-primary)]">${filtered.join('\n')}</pre>
                 `
             : html`
-                <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-2xs text-[var(--text-dim)]">
+                <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-2xs text-[var(--color-fg-disabled)]">
                   오늘 날짜 로그 파일이 아직 없습니다. sidecar를 시작하면 자동 생성됩니다.
                 </div>
               `}

--- a/dashboard/src/components/sidecar-startup-watch.ts
+++ b/dashboard/src/components/sidecar-startup-watch.ts
@@ -95,7 +95,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
 
   return html`
     <div
-      class="mt-2 flex items-center gap-2 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]"
+      class="mt-2 flex items-center gap-2 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--color-status-warn)]"
       data-startup-warning=${connectorId}
     >
       <span class="text-base leading-none" aria-hidden="true">⚠</span>
@@ -108,7 +108,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
       </div>
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-3xs uppercase tracking-4 text-[var(--warn)] hover:bg-[var(--warn-10)]"
+        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-3xs uppercase tracking-4 text-[var(--color-status-warn)] hover:bg-[var(--warn-10)]"
         onClick=${() => {
           openSidecarLogs(connectorId)
           // Don't clear startAt yet — operator might toggle logs back closed
@@ -118,7 +118,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
       >📋 로그 열기</button>
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] px-1.5 py-0.5 text-base leading-none text-[var(--warn)]/70 hover:text-[var(--warn)]"
+        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] px-1.5 py-0.5 text-base leading-none text-[var(--color-status-warn)]/70 hover:text-[var(--color-status-warn)]"
         aria-label="dismiss startup warning"
         onClick=${() => clearStartAttempt(connectorId)}
       >×</button>

--- a/dashboard/src/components/task-manage/task-create-form.ts
+++ b/dashboard/src/components/task-manage/task-create-form.ts
@@ -70,7 +70,7 @@ export function TaskCreateForm(props: { goalId?: string | null; goalTitle?: stri
 
         <div class="flex flex-col gap-1.5">
           <label class="text-2xs font-medium text-text-muted">
-            제목<span class="ml-0.5 text-[var(--bad)]">*</span>
+            제목<span class="ml-0.5 text-[var(--color-status-err)]">*</span>
           </label>
           <${TextInput}
             value=${title.value}

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -87,12 +87,12 @@ const CONDENSED_CATEGORY_META: Record<TelemetryCondensedCategory, {
   heartbeat: {
     label: 'Heartbeat',
     icon: 'H',
-    color: 'text-[var(--accent)]',
+    color: 'text-[var(--color-accent-fg)]',
   },
   polling: {
     label: 'Polling / no-op',
     icon: 'P',
-    color: 'text-[var(--accent)]',
+    color: 'text-[var(--color-accent-fg)]',
   },
 }
 
@@ -453,32 +453,32 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
   const hasData = src.entry_count > 0
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-35">
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3 min-w-35">
       <div class="flex items-center gap-2 mb-1">
         <span class="font-mono font-bold ${meta.color}">${meta.icon}</span>
-        <span class="text-xs font-medium text-[var(--text-strong)]">${meta.label}</span>
+        <span class="text-xs font-medium text-[var(--color-fg-secondary)]">${meta.label}</span>
       </div>
-      ${meta.sublabel ? html`<div class="text-3xs text-[var(--text-dim)] mb-1">${meta.sublabel}</div>` : null}
-      <div class="text-2xl font-bold ${hasData ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'}">
+      ${meta.sublabel ? html`<div class="text-3xs text-[var(--color-fg-disabled)] mb-1">${meta.sublabel}</div>` : null}
+      <div class="text-2xl font-bold ${hasData ? 'text-[var(--color-fg-secondary)]' : 'text-[var(--color-fg-muted)]'}">
         ${src.entry_count.toLocaleString()}
       </div>
       ${src.keeper_count != null ? html`
-        <div class="text-xs text-[var(--text-muted)]">${src.keeper_count} keepers</div>
+        <div class="text-xs text-[var(--color-fg-muted)]">${src.keeper_count} keepers</div>
       ` : null}
       ${src.exists === false ? html`
-        <div class="text-xs text-[var(--text-muted)] italic">store not found</div>
+        <div class="text-xs text-[var(--color-fg-muted)] italic">store not found</div>
       ` : null}
     </div>
   `
 }
 
 function DiagnosisCard({ title, value, detail, tone }: { title: string; value: string; detail: string; tone: 'ok' | 'warn' | 'neutral' }) {
-  const toneColor = tone === 'ok' ? 'text-[var(--ok)]' : tone === 'warn' ? 'text-[var(--warn)]' : 'text-[var(--text-muted)]'
+  const toneColor = tone === 'ok' ? 'text-[var(--color-status-ok)]' : tone === 'warn' ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-fg-muted)]'
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-35">
-      <div class="text-xs font-medium text-[var(--text-muted)] mb-1">${title}</div>
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3 min-w-35">
+      <div class="text-xs font-medium text-[var(--color-fg-muted)] mb-1">${title}</div>
       <div class="text-2xl font-bold ${toneColor}">${value}</div>
-      <div class="text-3xs text-[var(--text-dim)]">${detail}</div>
+      <div class="text-3xs text-[var(--color-fg-disabled)]">${detail}</div>
     </div>
   `
 }
@@ -493,7 +493,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
 
   return html`
     <div
-      class="border-b border-[var(--card-border)] hover:bg-[var(--bg-panel-hover)] transition-colors"
+      class="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
       style="content-visibility:auto;contain-intrinsic-size:36px"
     >
       <div class="flex items-center gap-1">
@@ -504,23 +504,23 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
           aria-expanded=${expanded.value}
         >
           <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
-          <span class="font-mono text-[var(--text-muted)] w-28 flex-shrink-0" title=${formatTs(ts)}>
+          <span class="font-mono text-[var(--color-fg-muted)] w-28 flex-shrink-0" title=${formatTs(ts)}>
             ${timeAgoSafe(ts)}
           </span>
           ${success != null ? html`
-            <span class="flex-shrink-0 w-4 ${success ? 'text-[var(--ok)]' : 'text-[var(--bad-light)]'}">
+            <span class="flex-shrink-0 w-4 ${success ? 'text-[var(--color-status-ok)]' : 'text-[var(--bad-light)]'}">
               ${success ? 'O' : 'X'}
             </span>
           ` : html`<span class="w-4"></span>`}
-          <span class="font-mono text-[var(--text-strong)] truncate flex-1" title=${entryPreview(entry)}>
+          <span class="font-mono text-[var(--color-fg-secondary)] truncate flex-1" title=${entryPreview(entry)}>
             ${entryPreview(entry)}
           </span>
           ${scopeBadges.length > 0 ? html`
             <span class="hidden xl:flex items-center gap-1 flex-shrink-0">
-              ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
+              ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-disabled)] font-mono">${badge}</span>`)}
             </span>
           ` : null}
-          <span class="flex-shrink-0 w-4 text-[var(--text-muted)]">${expanded.value ? '-' : '+'}</span>
+          <span class="flex-shrink-0 w-4 text-[var(--color-fg-muted)]">${expanded.value ? '-' : '+'}</span>
         </button>
         <span class="mr-2 inline-flex flex-shrink-0">
           <${CopyIdButton}
@@ -535,12 +535,12 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
         <div class="px-3 pb-3 flex flex-col gap-2">
           ${scopeBadges.length > 0 ? html`
             <div class="flex flex-wrap gap-1.5">
-              ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
+              ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-3xs text-[var(--color-fg-disabled)] font-mono">${badge}</span>`)}
             </div>
           ` : null}
           <div class="rounded bg-[rgba(0,0,0,0.3)] p-2">
             <div class="mb-1.5 flex items-center justify-between gap-2">
-              <span class="text-3xs font-medium text-[var(--text-dim)]">Raw JSON</span>
+              <span class="text-3xs font-medium text-[var(--color-fg-disabled)]">Raw JSON</span>
               <${CopyIdButton}
                 value=${rawJson}
                 label="expanded telemetry entry JSON"
@@ -548,7 +548,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
                 size=${13}
               />
             </div>
-            <pre class="m-0 text-3xs font-mono text-[var(--text-muted)] overflow-x-auto max-h-75 overflow-y-auto whitespace-pre-wrap break-all">
+            <pre class="m-0 text-3xs font-mono text-[var(--color-fg-muted)] overflow-x-auto max-h-75 overflow-y-auto whitespace-pre-wrap break-all">
 ${rawJson}</pre>
           </div>
         </div>
@@ -567,7 +567,7 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
 
   return html`
     <div
-      class="border-b border-[var(--card-border)] bg-[rgba(255,255,255,0.015)] hover:bg-[var(--bg-panel-hover)] transition-colors"
+      class="border-b border-[var(--color-border-default)] bg-[rgba(255,255,255,0.015)] hover:bg-[var(--color-bg-hover)] transition-colors"
       style="content-visibility:auto;contain-intrinsic-size:36px"
     >
       <div class="flex items-center gap-1">
@@ -579,24 +579,24 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
           onClick=${() => { expanded.value = !expanded.value }}
         >
           <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
-          <span class="font-mono text-[var(--text-muted)] w-28 flex-shrink-0" title=${`${formatTs(item.oldestTs)} → ${formatTs(item.latestTs)}`}>
+          <span class="font-mono text-[var(--color-fg-muted)] w-28 flex-shrink-0" title=${`${formatTs(item.oldestTs)} → ${formatTs(item.latestTs)}`}>
             ${timeAgoSafe(item.latestTs)}
           </span>
-          <span class="flex-shrink-0 w-4 text-[var(--text-dim)]">~</span>
-          <span class="font-mono text-[var(--text-strong)] truncate flex-1" title=${`${meta.label} · ${item.label} · ${item.count} events`}>
+          <span class="flex-shrink-0 w-4 text-[var(--color-fg-disabled)]">~</span>
+          <span class="font-mono text-[var(--color-fg-secondary)] truncate flex-1" title=${`${meta.label} · ${item.label} · ${item.count} events`}>
             ${meta.label} · ${item.label} · ${item.count} events
           </span>
           ${sourceIcons.length > 0 ? html`
-            <span class="hidden lg:flex items-center gap-1 flex-shrink-0 text-3xs text-[var(--text-dim)] font-mono">
+            <span class="hidden lg:flex items-center gap-1 flex-shrink-0 text-3xs text-[var(--color-fg-disabled)] font-mono">
               ${sourceIcons.join('/')}
             </span>
           ` : null}
           ${item.scopeBadges.length > 0 ? html`
             <span class="hidden xl:flex items-center gap-1 flex-shrink-0">
-              ${item.scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
+              ${item.scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-disabled)] font-mono">${badge}</span>`)}
             </span>
           ` : null}
-          <span class="flex-shrink-0 w-4 text-[var(--text-muted)]">${expanded.value ? '-' : '+'}</span>
+          <span class="flex-shrink-0 w-4 text-[var(--color-fg-muted)]">${expanded.value ? '-' : '+'}</span>
         </button>
         <span class="mr-2 inline-flex flex-shrink-0">
           <${CopyIdButton}
@@ -609,8 +609,8 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
       </div>
       <div id=${contentId} class=${expanded.value ? 'px-3 pb-3 flex flex-col gap-2' : 'hidden'} role="region">
         ${expanded.value ? html`
-          <div class="rounded bg-[var(--white-3)] px-2 py-1.5 text-2xs text-[var(--text-dim)]">
-            Latest: <span class="font-mono text-[var(--text-strong)]">${latestPreview}</span>
+          <div class="rounded bg-[var(--white-3)] px-2 py-1.5 text-2xs text-[var(--color-fg-disabled)]">
+            Latest: <span class="font-mono text-[var(--color-fg-secondary)]">${latestPreview}</span>
           </div>
           ${item.entries.map((entry, index) => {
             const entryMeta = sourceMeta(entry.source)
@@ -618,16 +618,16 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
             return html`
               <div class="flex items-center gap-2 rounded bg-[var(--black-20)] px-2 py-1.5 text-3xs" key=${`${item.key}:${index}`}>
                 <span class="font-mono font-bold ${entryMeta.color} w-4 text-center flex-shrink-0">${entryMeta.icon}</span>
-                <span class="font-mono text-[var(--text-dim)] w-24 flex-shrink-0" title=${formatTs(ts)}>${timeAgoSafe(ts)}</span>
-                <span class="font-mono text-[var(--text-strong)] truncate flex-1" title=${entryPreview(entry)}>${entryPreview(entry)}</span>
+                <span class="font-mono text-[var(--color-fg-disabled)] w-24 flex-shrink-0" title=${formatTs(ts)}>${timeAgoSafe(ts)}</span>
+                <span class="font-mono text-[var(--color-fg-secondary)] truncate flex-1" title=${entryPreview(entry)}>${entryPreview(entry)}</span>
               </div>
             `
           })}
           <div class="rounded bg-[var(--black-20)] px-2 py-1.5">
             <div class="flex items-start justify-between gap-2">
               <details class="min-w-0 flex-1">
-                <summary class="cursor-pointer text-3xs text-[var(--text-dim)]">Raw JSON</summary>
-                <pre class="mt-2 text-3xs font-mono text-[var(--text-muted)] overflow-x-auto max-h-70 overflow-y-auto whitespace-pre-wrap break-all">
+                <summary class="cursor-pointer text-3xs text-[var(--color-fg-disabled)]">Raw JSON</summary>
+                <pre class="mt-2 text-3xs font-mono text-[var(--color-fg-muted)] overflow-x-auto max-h-70 overflow-y-auto whitespace-pre-wrap break-all">
 ${rawJson}</pre>
               </details>
               <${CopyIdButton}
@@ -804,16 +804,16 @@ export function TelemetryUnified() {
 
   return html`
     <div class="flex flex-col gap-4">
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-4">
-        <div class="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">런타임 진단</div>
-        <div class="mt-1 text-base leading-relaxed text-[var(--text-body)]">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-4">
+        <div class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">런타임 진단</div>
+        <div class="mt-1 text-base leading-relaxed text-[var(--color-fg-primary)]">
           MASC telemetry store (keeper/tool/agent) 진단 뷰.
         </div>
         <div class="mt-3 flex flex-wrap gap-2">
-          <span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-dim)]">MASC: keeper/tool/agent store</span>
-          ${sessionFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--text-dim)]">session ${sessionFilter.value}</span>` : null}
-          ${operationFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--text-dim)]">operation ${operationFilter.value}</span>` : null}
-          ${workerRunFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--text-dim)]">worker_run ${workerRunFilter.value}</span>` : null}
+          <span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-disabled)]">MASC: keeper/tool/agent store</span>
+          ${sessionFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">session ${sessionFilter.value}</span>` : null}
+          ${operationFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">operation ${operationFilter.value}</span>` : null}
+          ${workerRunFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">worker_run ${workerRunFilter.value}</span>` : null}
         </div>
       </div>
 
@@ -821,9 +821,9 @@ export function TelemetryUnified() {
 
       <div class="flex flex-wrap gap-3">
         ${summary.map(src => html`<${SummaryCard} src=${src} />`)}
-        <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-35">
-          <div class="text-xs font-medium text-[var(--text-muted)] mb-1">전체</div>
-          <div class="text-2xl font-bold text-[var(--text-strong)]">${totalEntries.toLocaleString()}</div>
+        <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3 min-w-35">
+          <div class="text-xs font-medium text-[var(--color-fg-muted)] mb-1">전체</div>
+          <div class="text-2xl font-bold text-[var(--color-fg-secondary)]">${totalEntries.toLocaleString()}</div>
         </div>
       </div>
 
@@ -857,7 +857,7 @@ export function TelemetryUnified() {
       <div class="flex items-center gap-3 flex-wrap">
         <select
           aria-label="텔레메트리 소스 필터"
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)]"
           value=${sourceFilter.value}
           onChange=${(e: Event) => { sourceFilter.value = (e.target as HTMLSelectElement).value as TelemetrySource | '' }}
         >
@@ -868,7 +868,7 @@ export function TelemetryUnified() {
           type="text"
           placeholder="키퍼 이름..."
           aria-label="키퍼 이름 필터"
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-32"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] w-32"
           value=${keeperFilter.value}
           onInput=${(e: Event) => { keeperFilter.value = (e.target as HTMLInputElement).value }}
         />
@@ -876,7 +876,7 @@ export function TelemetryUnified() {
           type="text"
           placeholder="session_id"
           aria-label="session_id 필터"
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-40 font-mono"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] w-40 font-mono"
           value=${sessionFilter.value}
           onInput=${(e: Event) => { sessionFilter.value = (e.target as HTMLInputElement).value.trim() }}
         />
@@ -884,7 +884,7 @@ export function TelemetryUnified() {
           type="text"
           placeholder="operation_id"
           aria-label="operation_id 필터"
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-40 font-mono"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] w-40 font-mono"
           value=${operationFilter.value}
           onInput=${(e: Event) => { operationFilter.value = (e.target as HTMLInputElement).value.trim() }}
         />
@@ -892,7 +892,7 @@ export function TelemetryUnified() {
           type="text"
           placeholder="worker_run_id"
           aria-label="worker_run_id 필터"
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-40 font-mono"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] w-40 font-mono"
           value=${workerRunFilter.value}
           onInput=${(e: Event) => { workerRunFilter.value = (e.target as HTMLInputElement).value.trim() }}
         />
@@ -900,13 +900,13 @@ export function TelemetryUnified() {
           type="search"
           placeholder="엔트리 검색..."
           aria-label="엔트리 텍스트 검색"
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-48"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] w-48"
           value=${entrySearch.value}
           onInput=${(e: Event) => { entrySearch.value = (e.target as HTMLInputElement).value }}
         />
         <select
           aria-label="표시 개수 제한"
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)]"
           value=${String(limit.value)}
           onChange=${(e: Event) => { limit.value = Number((e.target as HTMLSelectElement).value) }}
         >
@@ -916,13 +916,13 @@ export function TelemetryUnified() {
           <option value="500">500</option>
         </select>
         <button
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
           onClick=${() => void load()}
         >
           Refresh
         </button>
-        <span class="text-xs text-[var(--text-muted)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
-        ${loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
+        <span class="text-xs text-[var(--color-fg-muted)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
+        ${loading ? html`<span class="text-xs text-[var(--color-fg-muted)]">로딩 중...</span>` : null}
       </div>
 
       ${error ? html`
@@ -931,8 +931,8 @@ export function TelemetryUnified() {
         </div>
       ` : null}
 
-      <div class="rounded border border-[var(--card-border)] overflow-hidden">
-        <div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-xs text-[var(--text-muted)]">
+      <div class="rounded border border-[var(--color-border-default)] overflow-hidden">
+        <div class="px-3 py-2 border-b border-[var(--color-border-default)] bg-[var(--white-3)] text-xs text-[var(--color-fg-muted)]">
           MASC telemetry store entries ${entries.length.toLocaleString()}건
           ${isFilteringEntries
             ? ` · 검색 매치 ${displayItems.length.toLocaleString()}건`
@@ -942,11 +942,11 @@ export function TelemetryUnified() {
             : ''}
         </div>
         ${condensed.groups > 0 ? html`
-          <div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-1)] flex flex-wrap gap-2 text-2xs">
+          <div class="px-3 py-2 border-b border-[var(--color-border-default)] bg-[var(--white-1)] flex flex-wrap gap-2 text-2xs">
             ${Array.from(condensed.byCategory.entries()).map(([category, count]) => {
               const meta = CONDENSED_CATEGORY_META[category]
               return html`
-                <span class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-1 text-[var(--text-dim)]">
+                <span class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-2 py-1 text-[var(--color-fg-disabled)]">
                   <span class="font-mono ${meta.color}">${meta.icon}</span>
                   <span class="ml-1">${meta.label}</span>
                   <span class="ml-1 font-mono">${count}</span>
@@ -961,8 +961,8 @@ export function TelemetryUnified() {
               ? html`<${GroupRow} key=${item.key} item=${item} />`
               : html`<${EntryRow} key=${item.key} entry=${item.entry} />`)
             : isFilteringEntries && allDisplayItems.length > 0
-              ? html`<div class="px-4 py-6 text-sm text-[var(--text-muted)]">필터 결과 없음 (${allDisplayItems.length} items)</div>`
-              : html`<div class="px-4 py-6 text-sm text-[var(--text-muted)]">선택한 scope에 해당하는 MASC telemetry entry가 없습니다.</div>`}
+              ? html`<div class="px-4 py-6 text-sm text-[var(--color-fg-muted)]">필터 결과 없음 (${allDisplayItems.length} items)</div>`
+              : html`<div class="px-4 py-6 text-sm text-[var(--color-fg-muted)]">선택한 scope에 해당하는 MASC telemetry entry가 없습니다.</div>`}
         </div>
       </div>
     </div>

--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -56,7 +56,7 @@ export function ThemeSwitch() {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs font-mono uppercase tracking-4 text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs font-mono uppercase tracking-4 text-[var(--color-fg-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--color-fg-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
       aria-label=${TITLE[key]}
       title=${TITLE[key]}
       onClick=${toggleTheme}

--- a/dashboard/src/components/tool-call-shared.test.ts
+++ b/dashboard/src/components/tool-call-shared.test.ts
@@ -145,27 +145,27 @@ describe('summarizeEntries', () => {
 
 describe('durationColor', () => {
   it('returns ok for fast (< 500ms)', () => {
-    expect(durationColor(100)).toBe('text-[var(--ok)]')
+    expect(durationColor(100)).toBe('text-[var(--color-status-ok)]')
   })
 
   it('returns ok for just under threshold', () => {
-    expect(durationColor(499)).toBe('text-[var(--ok)]')
+    expect(durationColor(499)).toBe('text-[var(--color-status-ok)]')
   })
 
   it('returns warn for medium (500-1999ms)', () => {
-    expect(durationColor(500)).toBe('text-[var(--warn)]')
+    expect(durationColor(500)).toBe('text-[var(--color-status-warn)]')
   })
 
   it('returns warn for just under slow threshold', () => {
-    expect(durationColor(1999)).toBe('text-[var(--warn)]')
+    expect(durationColor(1999)).toBe('text-[var(--color-status-warn)]')
   })
 
   it('returns bad for slow (>= 2000ms)', () => {
-    expect(durationColor(2000)).toBe('text-[var(--bad)]')
+    expect(durationColor(2000)).toBe('text-[var(--color-status-err)]')
   })
 
   it('returns bad for very slow', () => {
-    expect(durationColor(10000)).toBe('text-[var(--bad)]')
+    expect(durationColor(10000)).toBe('text-[var(--color-status-err)]')
   })
 })
 

--- a/dashboard/src/components/tool-call-shared.ts
+++ b/dashboard/src/components/tool-call-shared.ts
@@ -25,13 +25,13 @@ type ToolCategoryEntry = {
 const TOOL_CATEGORIES: ToolCategoryEntry[] = [
   // Shell / Bash — execution tools
   { match: n => n.includes('bash') || n.includes('shell'),
-    icon: '>', color: 'text-[var(--ok)]', label: 'shell' },
+    icon: '>', color: 'text-[var(--color-status-ok)]', label: 'shell' },
   // Git / GitHub / Worktree — version control
   { match: n => n.includes('github') || n.includes('git') || n.includes('worktree'),
-    icon: 'G', color: 'text-[var(--accent)]', label: 'git' },
+    icon: 'G', color: 'text-[var(--color-accent-fg)]', label: 'git' },
   // File write / edit — mutations
   { match: n => n.includes('edit') || n.includes('write') || n.includes('delete'),
-    icon: 'E', color: 'text-[var(--warn)]', label: 'edit' },
+    icon: 'E', color: 'text-[var(--color-status-warn)]', label: 'edit' },
   // File read / filesystem
   { match: n => n.includes('fs_read') || n.includes('code_read'),
     icon: 'F', color: 'text-[var(--purple)]', label: 'file' },
@@ -49,7 +49,7 @@ const TOOL_CATEGORIES: ToolCategoryEntry[] = [
     icon: 'W', color: 'text-[var(--sky-400)]', label: 'web' },
   // Coordination — tasks, transitions, heartbeat
   { match: n => n.includes('task') || n.includes('transition') || n.includes('claim') || n.includes('heartbeat') || n.includes('broadcast'),
-    icon: 'C', color: 'text-[var(--warn)]', label: 'coord' },
+    icon: 'C', color: 'text-[var(--color-status-warn)]', label: 'coord' },
   // Memory — recall, context, memory search
   { match: n => n.includes('memory') || n.includes('recall') || n.includes('context'),
     icon: 'M', color: 'text-[#34d399]', label: 'memory' },
@@ -98,9 +98,9 @@ export function summarizeEntries(entries: Array<{ duration_ms?: number; error?: 
 }
 
 export function durationColor(ms: number): string {
-  if (ms < DURATION_FAST_MS) return 'text-[var(--ok)]'
-  if (ms < DURATION_SLOW_MS) return 'text-[var(--warn)]'
-  return 'text-[var(--bad)]'
+  if (ms < DURATION_FAST_MS) return 'text-[var(--color-status-ok)]'
+  if (ms < DURATION_SLOW_MS) return 'text-[var(--color-status-warn)]'
+  return 'text-[var(--color-status-err)]'
 }
 
 export function formatArgs(args: Record<string, unknown> | string): string {

--- a/dashboard/src/components/tool-executor/schema-field.ts
+++ b/dashboard/src/components/tool-executor/schema-field.ts
@@ -17,17 +17,17 @@ interface SchemaFieldProps {
 
 export function SchemaField({ name, schema, value, required, onChange }: SchemaFieldProps) {
   const requiredMark = required
-    ? html`<span class="text-[var(--bad)] ml-0.5">*</span>`
+    ? html`<span class="text-[var(--color-status-err)] ml-0.5">*</span>`
     : null
 
   const hint = schema.description
-    ? html`<span class="text-3xs text-[var(--text-muted)] mt-0.5">${schema.description}</span>`
+    ? html`<span class="text-3xs text-[var(--color-fg-muted)] mt-0.5">${schema.description}</span>`
     : null
 
   if (schema.type === 'string' && schema.enum) {
     return html`
       <div class="flex flex-col gap-1">
-        <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
+        <label class="text-2xs text-[var(--color-fg-muted)] font-medium">${name}${requiredMark}</label>
         ${hint}
         <${Select} value=${(value as string) ?? ''} options=${schema.enum} placeholder="-- 선택 --"
           onInput=${(v: string) => onChange(name, v)} />
@@ -40,7 +40,7 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
     if (isLong) {
       return html`
         <div class="flex flex-col gap-1">
-          <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
+          <label class="text-2xs text-[var(--color-fg-muted)] font-medium">${name}${requiredMark}</label>
           ${hint}
           <${TextArea} value=${(value as string) ?? (schema.default as string) ?? ''} placeholder=${name} rows=${3}
             onInput=${(e: Event) => onChange(name, (e.target as HTMLTextAreaElement).value)} />
@@ -49,7 +49,7 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
     }
     return html`
       <div class="flex flex-col gap-1">
-        <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
+        <label class="text-2xs text-[var(--color-fg-muted)] font-medium">${name}${requiredMark}</label>
         ${hint}
         <${TextInput} value=${(value as string) ?? (schema.default as string) ?? ''} placeholder=${name}
           onInput=${(e: Event) => onChange(name, (e.target as HTMLInputElement).value)} />
@@ -60,7 +60,7 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
   if (schema.type === 'integer' || schema.type === 'number') {
     return html`
       <div class="flex flex-col gap-1">
-        <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
+        <label class="text-2xs text-[var(--color-fg-muted)] font-medium">${name}${requiredMark}</label>
         ${hint}
         <${NumberInput} value=${(value as number) ?? (schema.default as number) ?? ''} placeholder=${name}
           step=${schema.type === 'integer' ? 1 : 'any'} onInput=${(v: number | undefined) => onChange(name, v)} />
@@ -73,8 +73,8 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
       <div class="flex items-center gap-2 py-1">
         <${Checkbox} checked=${(value as boolean) ?? (schema.default as boolean) ?? false}
           onChange=${(v: boolean) => onChange(name, v)} />
-        <label class="text-xs text-[var(--text-body)]">${name}${requiredMark}</label>
-        ${schema.description ? html`<span class="text-3xs text-[var(--text-muted)]">- ${schema.description}</span>` : null}
+        <label class="text-xs text-[var(--color-fg-primary)]">${name}${requiredMark}</label>
+        ${schema.description ? html`<span class="text-3xs text-[var(--color-fg-muted)]">- ${schema.description}</span>` : null}
       </div>
     `
   }
@@ -83,7 +83,7 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
     const strValue = Array.isArray(value) ? (value as string[]).join('\n') : ''
     return html`
       <div class="flex flex-col gap-1">
-        <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}
+        <label class="text-2xs text-[var(--color-fg-muted)] font-medium">${name}${requiredMark}
           <span class="font-normal"> (줄바꿈으로 구분)</span></label>
         ${hint}
         <${TextArea} value=${strValue} placeholder=${name} rows=${3}
@@ -99,7 +99,7 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
     : typeof value === 'string' ? value : JSON.stringify(value, null, 2)
   return html`
     <div class="flex flex-col gap-1">
-      <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}
+      <label class="text-2xs text-[var(--color-fg-muted)] font-medium">${name}${requiredMark}
         <span class="font-normal"> (JSON)</span></label>
       ${hint}
       <${TextArea} value=${rawValue} placeholder=${'{ ... }'} rows=${4} class="font-mono text-xs"

--- a/dashboard/src/components/tool-executor/schema-form.ts
+++ b/dashboard/src/components/tool-executor/schema-form.ts
@@ -10,7 +10,7 @@ interface SchemaFormProps {
 
 export function SchemaForm({ schema, values, onChange }: SchemaFormProps) {
   if (!schema.properties || Object.keys(schema.properties).length === 0) {
-    return html`<p class="text-[var(--text-muted)] text-xs py-2">이 도구는 파라미터가 없습니다.</p>`
+    return html`<p class="text-[var(--color-fg-muted)] text-xs py-2">이 도구는 파라미터가 없습니다.</p>`
   }
 
   const required = new Set(schema.required ?? [])

--- a/dashboard/src/components/tool-executor/tool-executor.ts
+++ b/dashboard/src/components/tool-executor/tool-executor.ts
@@ -26,7 +26,7 @@ function ConfirmDialog({ toolName, onConfirm, onCancel }: { toolName: string; on
 function ToolDetail() {
   const showConfirm = useSignal(false)
   const tool = selectedTool.value
-  if (!tool) return html`<div class="flex items-center justify-center h-full text-[var(--text-muted)] text-sm">좌측에서 도구를 선택하세요.</div>`
+  if (!tool) return html`<div class="flex items-center justify-center h-full text-[var(--color-fg-muted)] text-sm">좌측에서 도구를 선택하세요.</div>`
 
   const isDestructive = tool.annotations?.destructiveHint === true
   const missing = validationErrors.value
@@ -37,20 +37,20 @@ function ToolDetail() {
   return html`
     <div class="flex flex-col gap-3 h-full overflow-y-auto">
       <div>
-        <h3 class="text-base text-[var(--text-strong)] font-mono font-medium">${tool.name}</h3>
-        <p class="text-xs text-[var(--text-muted)] mt-1">${tool.description}</p>
-        ${tool.annotations?.readOnlyHint === true ? html`<span class="text-3xs text-[var(--ok)] mt-1">읽기 전용</span>` : null}
-        ${isDestructive ? html`<span class="text-3xs text-[var(--bad)] mt-1 ml-2">파괴적</span>` : null}
+        <h3 class="text-base text-[var(--color-fg-secondary)] font-mono font-medium">${tool.name}</h3>
+        <p class="text-xs text-[var(--color-fg-muted)] mt-1">${tool.description}</p>
+        ${tool.annotations?.readOnlyHint === true ? html`<span class="text-3xs text-[var(--color-status-ok)] mt-1">읽기 전용</span>` : null}
+        ${isDestructive ? html`<span class="text-3xs text-[var(--color-status-err)] mt-1 ml-2">파괴적</span>` : null}
       </div>
-      <div class="border-t border-[var(--card-border)] pt-3">
+      <div class="border-t border-[var(--color-border-default)] pt-3">
         <${SchemaForm} schema=${tool.inputSchema} values=${formValues.value} onChange=${updateFormValues} />
       </div>
       ${toolAccess.allowed ? null : html`
-        <p class="text-2xs text-[var(--warn)]">
+        <p class="text-2xs text-[var(--color-status-warn)]">
           실행 차단: ${toolAccess.reason ?? `${toolAccess.required_role} 권한이 필요합니다.`}
         </p>
       `}
-      ${missing.length > 0 ? html`<p class="text-2xs text-[var(--bad)]">필수 필드 누락: ${missing.join(', ')}</p>` : null}
+      ${missing.length > 0 ? html`<p class="text-2xs text-[var(--color-status-err)]">필수 필드 누락: ${missing.join(', ')}</p>` : null}
       ${showConfirm.value
         ? html`<${ConfirmDialog} toolName=${tool.name} onConfirm=${handleConfirmedExecute} onCancel=${() => { showConfirm.value = false }} />`
         : html`
@@ -67,18 +67,18 @@ function ToolDetail() {
 export function ToolExecutor() {
   useEffect(() => { void loadToolSchemas() }, [])
   if (schemasLoading.value && !selectedTool.value) {
-    return html`<${SurfaceCard}><p class="text-xs text-[var(--text-muted)] py-8 text-center">도구 스키마 로딩 중...</p><//>`
+    return html`<${SurfaceCard}><p class="text-xs text-[var(--color-fg-muted)] py-8 text-center">도구 스키마 로딩 중...</p><//>`
   }
   if (schemasError.value) {
     return html`<${SurfaceCard}><div class="py-4 text-center">
-      <p class="text-xs text-[var(--bad)] mb-2">${schemasError.value}</p>
+      <p class="text-xs text-[var(--color-status-err)] mb-2">${schemasError.value}</p>
       <${ActionButton} variant="ghost" size="sm" onClick=${() => void loadToolSchemas(true)}>재시도<//>
     </div><//>`
   }
   return html`
     <${SurfaceCard} class="h-[calc(100vh-240px)] min-h-100">
       <div class="flex gap-4 h-full">
-        <div class="w-70 flex-shrink-0 border-r border-[var(--card-border)] pr-4"><${ToolPicker} /></div>
+        <div class="w-70 flex-shrink-0 border-r border-[var(--color-border-default)] pr-4"><${ToolPicker} /></div>
         <div class="flex-1 min-w-0"><${ToolDetail} /></div>
       </div>
     <//>

--- a/dashboard/src/components/tool-executor/tool-picker.ts
+++ b/dashboard/src/components/tool-executor/tool-picker.ts
@@ -20,11 +20,11 @@ function ToolRow({ tool, isSelected }: { tool: McpToolSchema; isSelected: boolea
       ${isSelected ? 'bg-[var(--accent-12)] border border-[var(--accent-30)]' : 'hover:bg-[var(--white-6)] border border-transparent'}
       ${isDeprecated ? 'opacity-50' : ''}" onClick=${() => selectTool(tool)}>
       <div class="flex items-center gap-1.5">
-        <span class="text-xs text-[var(--text-strong)] font-mono truncate flex-1">${tool.name}</span>
+        <span class="text-xs text-[var(--color-fg-secondary)] font-mono truncate flex-1">${tool.name}</span>
         ${isDestructive ? html`<${CountBadge} tone="bad">D<//>` : null}
         ${isReadOnly ? html`<${CountBadge} tone="ok">R<//>` : null}
       </div>
-      <div class="text-3xs text-[var(--text-muted)] mt-0.5 line-clamp-1">${tool.description}</div>
+      <div class="text-3xs text-[var(--color-fg-muted)] mt-0.5 line-clamp-1">${tool.description}</div>
     </button>
   `
 }
@@ -40,15 +40,15 @@ export function ToolPicker() {
         ${TIER_OPTIONS.map(opt => html`
           <button type="button" class="text-3xs px-2 py-0.5 rounded transition-colors cursor-pointer
             ${tierFilter.value === opt.value
-              ? 'bg-[var(--accent-12)] text-[var(--text-strong)] border border-[var(--accent-30)]'
-              : 'text-[var(--text-muted)] hover:text-[var(--text-body)] border border-transparent hover:bg-[var(--white-6)]'}"
+              ? 'bg-[var(--accent-12)] text-[var(--color-fg-secondary)] border border-[var(--accent-30)]'
+              : 'text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] border border-transparent hover:bg-[var(--white-6)]'}"
             onClick=${() => { tierFilter.value = opt.value }}>${opt.label}</button>
         `)}
-        <span class="text-3xs text-[var(--text-muted)] ml-auto self-center">${tools.length}개</span>
+        <span class="text-3xs text-[var(--color-fg-muted)] ml-auto self-center">${tools.length}개</span>
       </div>
       <div class="flex flex-col gap-0.5 overflow-y-auto flex-1 min-h-0 pr-1">
         ${tools.length === 0
-          ? html`<p class="text-xs text-[var(--text-muted)] py-4 text-center">결과 없음</p>`
+          ? html`<p class="text-xs text-[var(--color-fg-muted)] py-4 text-center">결과 없음</p>`
           : tools.map(tool => html`<${ToolRow} key=${tool.name} tool=${tool} isSelected=${selected?.name === tool.name} />`)}
       </div>
     </div>

--- a/dashboard/src/components/tool-executor/tool-result-display.ts
+++ b/dashboard/src/components/tool-executor/tool-result-display.ts
@@ -70,12 +70,12 @@ function StoredBlobView({
       <div class="flex flex-col gap-2 mt-3">
         <div class="flex items-center gap-2">
           <${CountBadge} tone=${success ? 'ok' : 'bad'}>${success ? 'OK' : 'ERR'}<//>
-          <span class="text-2xs text-[var(--text-muted)]">${toolName}</span>
-          <span class="text-3xs text-[var(--text-muted)] ml-auto">${timeStr}</span>
+          <span class="text-2xs text-[var(--color-fg-muted)]">${toolName}</span>
+          <span class="text-3xs text-[var(--color-fg-muted)] ml-auto">${timeStr}</span>
         </div>
-        <div class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] overflow-hidden">
-          <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--card-border)]">
-            <button type="button" class="text-3xs text-[var(--text-muted)] cursor-pointer hover:text-[var(--text-body)]"
+        <div class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] overflow-hidden">
+          <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--color-border-default)]">
+            <button type="button" class="text-3xs text-[var(--color-fg-muted)] cursor-pointer hover:text-[var(--color-fg-primary)]"
               onClick=${() => { expanded.value = false }}>
               접기 (${marker.bytes.toLocaleString()}B)
             </button>
@@ -87,7 +87,7 @@ function StoredBlobView({
               const { isJson, parsed } = tryParseJson(fullText.value ?? '')
               return isJson
                 ? html`<${JsonViewer} data=${parsed} />`
-                : html`<pre class="text-xs font-mono ${success ? 'text-[var(--text-body)]' : 'text-[var(--bad-light)]'}">${fullText.value}</pre>`
+                : html`<pre class="text-xs font-mono ${success ? 'text-[var(--color-fg-primary)]' : 'text-[var(--bad-light)]'}">${fullText.value}</pre>`
             })()}
           </div>
         </div>
@@ -100,12 +100,12 @@ function StoredBlobView({
     <div class="flex flex-col gap-2 mt-3" data-testid="tool-blob-marker">
       <div class="flex items-center gap-2">
         <${CountBadge} tone=${success ? 'ok' : 'bad'}>${success ? 'OK' : 'ERR'}<//>
-        <span class="text-2xs text-[var(--text-muted)]">${toolName}</span>
-        <span class="text-3xs text-[var(--text-muted)] ml-auto">${timeStr}</span>
+        <span class="text-2xs text-[var(--color-fg-muted)]">${toolName}</span>
+        <span class="text-3xs text-[var(--color-fg-muted)] ml-auto">${timeStr}</span>
       </div>
-      <div class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] overflow-hidden">
-        <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--card-border)]">
-          <span class="text-3xs text-[var(--text-muted)]">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] overflow-hidden">
+        <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--color-border-default)]">
+          <span class="text-3xs text-[var(--color-fg-muted)]">
             저장된 출력 · ${marker.bytes.toLocaleString()}B · sha ${marker.sha256.slice(0, 12)}\u2026
           </span>
           <${ActionButton}
@@ -116,10 +116,10 @@ function StoredBlobView({
           <//>
         </div>
         <div class="px-3 py-2 overflow-x-auto max-h-50 overflow-y-auto">
-          <pre class="text-xs font-mono text-[var(--text-muted)] whitespace-pre-wrap">${marker.preview}</pre>
+          <pre class="text-xs font-mono text-[var(--color-fg-muted)] whitespace-pre-wrap">${marker.preview}</pre>
         </div>
         ${error.value ? html`
-          <div class="px-3 py-1.5 border-t border-[var(--card-border)] text-2xs text-[var(--bad-light)]">
+          <div class="px-3 py-1.5 border-t border-[var(--color-border-default)] text-2xs text-[var(--bad-light)]">
             ${error.value}
           </div>
         ` : null}
@@ -149,12 +149,12 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
     <div class="flex flex-col gap-2 mt-3">
       <div class="flex items-center gap-2">
         <${CountBadge} tone=${success ? 'ok' : 'bad'}>${success ? 'OK' : 'ERR'}<//>
-        <span class="text-2xs text-[var(--text-muted)]">${toolName}</span>
-        <span class="text-3xs text-[var(--text-muted)] ml-auto">${timeStr}</span>
+        <span class="text-2xs text-[var(--color-fg-muted)]">${toolName}</span>
+        <span class="text-3xs text-[var(--color-fg-muted)] ml-auto">${timeStr}</span>
       </div>
-      <div class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] overflow-hidden">
-        <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--card-border)]">
-          <button type="button" class="text-3xs text-[var(--text-muted)] cursor-pointer hover:text-[var(--text-body)]"
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] overflow-hidden">
+        <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--color-border-default)]">
+          <button type="button" class="text-3xs text-[var(--color-fg-muted)] cursor-pointer hover:text-[var(--color-fg-primary)]"
             onClick=${() => { expanded.value = !expanded.value }}>
             ${expanded.value ? '접기' : '펼치기'} (${lines}줄)
           </button>
@@ -164,7 +164,7 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
           <div class="px-3 py-2 overflow-x-auto max-h-100 overflow-y-auto">
             ${isJson
               ? html`<${JsonViewer} data=${parsed} />`
-              : html`<pre class="text-xs font-mono ${success ? 'text-[var(--text-body)]' : 'text-[var(--bad-light)]'}">${text}</pre>`
+              : html`<pre class="text-xs font-mono ${success ? 'text-[var(--color-fg-primary)]' : 'text-[var(--bad-light)]'}">${text}</pre>`
             }
           </div>
         ` : null}

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -55,7 +55,7 @@ function loadMetrics() {
 /** Map category color CSS class (text-[...]) to a usable bar background color. */
 function categoryBarColor(colorClass: string): string {
   const match = colorClass.match(/text-\[(.*)\]/)
-  if (!match) return 'var(--accent)'
+  if (!match) return 'var(--color-accent-fg)'
   const val = match[1]!
   // CSS variable references
   if (val.startsWith('var(')) return val
@@ -75,13 +75,13 @@ function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount:
           <div class="tool-bar-row" key=${item.name}>
             <div class="flex items-center gap-1.5 overflow-hidden">
               <span class="flex-shrink-0 size-4 rounded text-3xs font-mono font-bold flex items-center justify-center bg-[var(--white-5)] ${cat.color}">${cat.icon}</span>
-              <span class="text-[var(--text-body)] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-2xs" title=${item.name}>${item.name}</span>
+              <span class="text-[var(--color-fg-primary)] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-2xs" title=${item.name}>${item.name}</span>
             </div>
-            <span class="px-1.5 py-px rounded-xs text-3xs font-medium text-center text-[var(--text-dim)] bg-[var(--white-4)]">${cat.label}</span>
+            <span class="px-1.5 py-px rounded-xs text-3xs font-medium text-center text-[var(--color-fg-disabled)] bg-[var(--white-4)]">${cat.label}</span>
             <div class="h-3.5 rounded-xs bg-[var(--white-6)] overflow-hidden">
               <div class="h-full rounded-xs min-w-0.5 transition-[width] duration-300 ease-in-out" style=${{ width: `${pct}%`, backgroundColor: barBg }} />
             </div>
-            <span class="text-[var(--text-muted)] text-2xs text-right font-mono">${item.call_count}</span>
+            <span class="text-[var(--color-fg-muted)] text-2xs text-right font-mono">${item.call_count}</span>
           </div>
         `
       })}
@@ -90,7 +90,7 @@ function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount:
 }
 
 function ToolDistribution({ dist }: { dist: { total: number; public: number; visible: number; hidden: number } | null | undefined }) {
-  if (!dist) return html`<div class="text-2xs text-[var(--text-muted)] italic">도구 분포 데이터가 없습니다.</div>`
+  if (!dist) return html`<div class="text-2xs text-[var(--color-fg-muted)] italic">도구 분포 데이터가 없습니다.</div>`
   // Mutually exclusive segments: public ⊂ visible, hidden = total - visible
   const visibleExclusive = Math.max(0, dist.visible - dist.public)
   const pct = (n: number) => dist.total > 0 ? ((n / dist.total) * 100).toFixed(1) : '0'
@@ -98,20 +98,20 @@ function ToolDistribution({ dist }: { dist: { total: number; public: number; vis
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-3">
         <span class="inline-block min-w-18 px-2 py-0.5 text-2xs font-semibold text-center rounded badge-essential">공개 MCP</span>
-        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.public}</span>
-        <span class="text-[var(--text-muted)] text-sm min-w-12 text-right">${pct(dist.public)}%</span>
+        <span class="text-[var(--color-fg-secondary)] text-sm font-semibold min-w-9 text-right">${dist.public}</span>
+        <span class="text-[var(--color-fg-muted)] text-sm min-w-12 text-right">${pct(dist.public)}%</span>
       </div>
       <div class="flex items-center gap-3">
         <span class="inline-block min-w-18 px-2 py-0.5 text-2xs font-semibold text-center rounded badge-standard">내부 전용</span>
-        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${visibleExclusive}</span>
-        <span class="text-[var(--text-muted)] text-sm min-w-12 text-right">${pct(visibleExclusive)}%</span>
+        <span class="text-[var(--color-fg-secondary)] text-sm font-semibold min-w-9 text-right">${visibleExclusive}</span>
+        <span class="text-[var(--color-fg-muted)] text-sm min-w-12 text-right">${pct(visibleExclusive)}%</span>
       </div>
       <div class="flex items-center gap-3">
         <span class="inline-block min-w-18 px-2 py-0.5 text-2xs font-semibold text-center rounded badge-full">숨김</span>
-        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.hidden}</span>
-        <span class="text-[var(--text-muted)] text-sm min-w-12 text-right">${pct(dist.hidden)}%</span>
+        <span class="text-[var(--color-fg-secondary)] text-sm font-semibold min-w-9 text-right">${dist.hidden}</span>
+        <span class="text-[var(--color-fg-muted)] text-sm min-w-12 text-right">${pct(dist.hidden)}%</span>
       </div>
-      <div class="text-3xs text-[var(--text-dim)] mt-1">전체 ${dist.total}개 (공개 ${dist.public} + 내부 ${visibleExclusive} + 숨김 ${dist.hidden})</div>
+      <div class="text-3xs text-[var(--color-fg-disabled)] mt-1">전체 ${dist.total}개 (공개 ${dist.public} + 내부 ${visibleExclusive} + 숨김 ${dist.hidden})</div>
     </div>
   `
 }
@@ -131,7 +131,7 @@ export function ToolMetrics() {
   return html`
     <div class="flex flex-col gap-4">
       <div class="flex justify-between items-center">
-        <h3 class="text-[var(--text-strong)] text-lg font-semibold m-0">도구 사용 현황</h3>
+        <h3 class="text-[var(--color-fg-secondary)] text-lg font-semibold m-0">도구 사용 현황</h3>
         <${ActionButton}
           variant="ghost"
           onClick=${() => void loadMetrics()}
@@ -144,39 +144,39 @@ export function ToolMetrics() {
       ${error ? html`<${ErrorState} message=${error} />` : null}
 
       ${data ? html`
-        <div class="text-2xs text-[var(--text-muted)] mb-3">
+        <div class="text-2xs text-[var(--color-fg-muted)] mb-3">
           서버 시작 이후 메모리 기반 집계. 재시작 시 초기화됩니다.
         </div>
         <div class="grid grid-cols-[repeat(5,minmax(0,1fr))] gap-3 max-[880px]:grid-cols-[repeat(2,minmax(0,1fr))]">
-          <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
-            <span class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${data.total_calls}</span>
-            <span class="text-2xs text-[var(--text-muted)] font-medium">총 호출 수</span>
+          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--card)] p-3">
+            <span class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${data.total_calls}</span>
+            <span class="text-2xs text-[var(--color-fg-muted)] font-medium">총 호출 수</span>
           </div>
-          <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
-            <span class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${data.distinct_tools_called}</span>
-            <span class="text-2xs text-[var(--text-muted)] font-medium">사용된 도구</span>
+          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--card)] p-3">
+            <span class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${data.distinct_tools_called}</span>
+            <span class="text-2xs text-[var(--color-fg-muted)] font-medium">사용된 도구</span>
           </div>
-          <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
-            <span class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${data.never_called_count}</span>
-            <span class="text-2xs text-[var(--text-muted)] font-medium">미사용 도구</span>
+          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--card)] p-3">
+            <span class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${data.never_called_count}</span>
+            <span class="text-2xs text-[var(--color-fg-muted)] font-medium">미사용 도구</span>
           </div>
-          <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
-            <span class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${data.registered_count}</span>
-            <span class="text-2xs text-[var(--text-muted)] font-medium">등록됨 (v2)</span>
+          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--card)] p-3">
+            <span class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${data.registered_count}</span>
+            <span class="text-2xs text-[var(--color-fg-muted)] font-medium">등록됨 (v2)</span>
           </div>
-          <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
-            <span class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${data.dispatch_v2_enabled ? 'ON' : 'OFF'}</span>
-            <span class="text-2xs text-[var(--text-muted)] font-medium">Dispatch v2</span>
+          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--card)] p-3">
+            <span class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${data.dispatch_v2_enabled ? 'ON' : 'OFF'}</span>
+            <span class="text-2xs text-[var(--color-fg-muted)] font-medium">Dispatch v2</span>
           </div>
         </div>
 
         <div class="tool-metrics-sections">
           <div>
-            <h4 class="text-[var(--text-muted)] text-2xs uppercase tracking-[0.05em] mb-2.5 mt-0">도구 분포</h4>
+            <h4 class="text-[var(--color-fg-muted)] text-2xs uppercase tracking-[0.05em] mb-2.5 mt-0">도구 분포</h4>
             <${ToolDistribution} dist=${data.tool_distribution} />
           </div>
           <div>
-            <h4 class="text-[var(--text-muted)] text-2xs uppercase tracking-[0.05em] mb-2.5 mt-0">상위 20 도구</h4>
+            <h4 class="text-[var(--color-fg-muted)] text-2xs uppercase tracking-[0.05em] mb-2.5 mt-0">상위 20 도구</h4>
             ${(() => {
               // Build category chips from labels actually present in top_20.
               const labelCounts = new Map<string, number>()
@@ -211,7 +211,7 @@ export function ToolMetrics() {
                   />
                 </div>
                 ${(categoryFilter.value !== 'all' || searchQuery.value.trim() !== '') ? html`
-                  <div class="mb-2 text-2xs text-[var(--text-muted)]">
+                  <div class="mb-2 text-2xs text-[var(--color-fg-muted)]">
                     ${filtered.length} / ${data.top_20.length}개 도구
                   </div>
                 ` : null}

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -95,23 +95,23 @@ function handleRefreshToolQualityClick() {
 
 const successColor = computed(() => {
   const rate = data.value?.success_rate ?? 0
-  if (rate >= 95) return 'text-[var(--ok)]'
-  if (rate >= 90) return 'text-[var(--warn)]'
+  if (rate >= 95) return 'text-[var(--color-status-ok)]'
+  if (rate >= 90) return 'text-[var(--color-status-warn)]'
   return 'text-[var(--bad-light)]'
 })
 
 function sourceHealthClass(health?: string | null): string {
   switch ((health ?? '').toLowerCase()) {
     case 'ok':
-      return 'text-[var(--ok)]'
+      return 'text-[var(--color-status-ok)]'
     case 'stale':
     case 'coverage_gap':
     case 'empty':
-      return 'text-[var(--warn)]'
+      return 'text-[var(--color-status-warn)]'
     case 'missing':
       return 'text-[var(--bad-light)]'
     default:
-      return 'text-[var(--text-dim)]'
+      return 'text-[var(--color-fg-disabled)]'
   }
 }
 
@@ -143,12 +143,12 @@ function RateGauge({ rate, label }: { rate: number; label: string }) {
   const color = rate >= 95 ? 'bg-[var(--ok-10)]' : rate >= 90 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'
   return html`
     <div class="flex flex-col gap-1">
-      <div class="text-3xs text-[var(--text-dim)] uppercase tracking-wider">${label}</div>
+      <div class="text-3xs text-[var(--color-fg-disabled)] uppercase tracking-wider">${label}</div>
       <div class="flex items-center gap-2">
         <div class="flex-1 h-1.5 bg-[var(--bg-subtle)] rounded-sm overflow-hidden">
           <div class="${color} h-full rounded-sm transition-all" style="width: ${Math.min(rate, 100)}%" />
         </div>
-        <span class="text-xs font-mono ${rate >= 95 ? 'text-[var(--ok)]' : rate >= 90 ? 'text-[var(--warn)]' : 'text-[var(--bad-light)]'}">${rate.toFixed(1)}%</span>
+        <span class="text-xs font-mono ${rate >= 95 ? 'text-[var(--color-status-ok)]' : rate >= 90 ? 'text-[var(--color-status-warn)]' : 'text-[var(--bad-light)]'}">${rate.toFixed(1)}%</span>
       </div>
     </div>
   `
@@ -173,14 +173,14 @@ function ToolTable({
   const hasQuery = query.trim() !== ''
   if (hasQuery && filtered.length === 0) {
     return html`
-      <div class="text-2xs text-[var(--text-dim)] py-2">조건에 맞는 도구가 없습니다.</div>
+      <div class="text-2xs text-[var(--color-fg-disabled)] py-2">조건에 맞는 도구가 없습니다.</div>
     `
   }
   return html`
     <div class="overflow-x-auto">
       <table class="w-full text-2xs">
         <thead>
-          <tr class="text-[var(--text-dim)] border-b border-[var(--card-border)]">
+          <tr class="text-[var(--color-fg-disabled)] border-b border-[var(--color-border-default)]">
             <th class="text-left py-1 font-normal">Tool</th>
             <th class="text-right py-1 font-normal">Calls</th>
             <th class="text-right py-1 font-normal">Success</th>
@@ -190,19 +190,19 @@ function ToolTable({
         </thead>
         <tbody>
           ${displayed.map(t => {
-            const color = t.success_pct >= 95 ? 'text-[var(--ok)]'
-              : t.success_pct >= 80 ? 'text-[var(--warn)]' : 'text-[var(--bad-light)]'
+            const color = t.success_pct >= 95 ? 'text-[var(--color-status-ok)]'
+              : t.success_pct >= 80 ? 'text-[var(--color-status-warn)]' : 'text-[var(--bad-light)]'
             const isHighlighted = highlightTool && t.name === highlightTool
             const rowClass = isHighlighted
               ? 'border-b border-[var(--warn-20)] bg-[var(--warn-10)] ring-1 ring-[var(--warn-20)]0/40'
-              : 'border-b border-[var(--card-border)] border-opacity-30'
+              : 'border-b border-[var(--color-border-default)] border-opacity-30'
             return html`
               <tr class=${rowClass} ref=${isHighlighted ? ((el: HTMLElement | null) => el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })) : undefined}>
-                <td class="py-0.5 font-mono">${t.name.replace('keeper_', '').replace('masc_', 'm:')}${isHighlighted ? html`<span class="ml-1 text-3xs text-[var(--warn)]">◀ selected</span>` : null}</td>
-                <td class="text-right py-0.5 text-[var(--text-dim)]">${t.calls}</td>
+                <td class="py-0.5 font-mono">${t.name.replace('keeper_', '').replace('masc_', 'm:')}${isHighlighted ? html`<span class="ml-1 text-3xs text-[var(--color-status-warn)]">◀ selected</span>` : null}</td>
+                <td class="text-right py-0.5 text-[var(--color-fg-disabled)]">${t.calls}</td>
                 <td class="text-right py-0.5 font-mono ${color}">${t.success_pct.toFixed(0)}%</td>
-                <td class="text-right py-0.5 text-[var(--text-dim)]">${t.avg_ms.toFixed(0)}</td>
-                <td class="text-right py-0.5 font-mono ${t.output_truncated_count > 0 ? 'text-[var(--warn)]' : 'text-[var(--text-dim)]'}">${
+                <td class="text-right py-0.5 text-[var(--color-fg-disabled)]">${t.avg_ms.toFixed(0)}</td>
+                <td class="text-right py-0.5 font-mono ${t.output_truncated_count > 0 ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-fg-disabled)]'}">${
                   t.output_truncated_count > 0
                     ? `${(t.avg_output_chars / 1000).toFixed(1)}k ✂${t.output_truncated_count}`
                     : `${(t.avg_output_chars / 1000).toFixed(1)}k`
@@ -238,12 +238,12 @@ function TrendSparkline({ points }: { points: HourlyPoint[] }) {
   })
 
   const lastRate = points[points.length - 1]?.success_rate ?? 0
-  const lineColor = lastRate >= 95 ? 'var(--ok)' : lastRate >= 90 ? 'var(--warn)' : 'var(--bad)'
+  const lineColor = lastRate >= 95 ? 'var(--color-status-ok)' : lastRate >= 90 ? 'var(--color-status-warn)' : 'var(--color-status-err)'
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] p-3">
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] p-3">
       <div class="flex items-center justify-between mb-1.5">
-        <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">성공률 추이</span>
+        <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">성공률 추이</span>
         <span class="text-xs font-mono" style="color:${lineColor}">${lastRate.toFixed(1)}%</span>
       </div>
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
@@ -252,7 +252,7 @@ function TrendSparkline({ points }: { points: HourlyPoint[] }) {
         `)}
         <polyline points="${rateLine}" fill="none" stroke="${lineColor}" stroke-width="1.5"/>
       </svg>
-      <div class="flex justify-between mt-1 text-4xs text-[var(--text-dim)] font-mono">
+      <div class="flex justify-between mt-1 text-4xs text-[var(--color-fg-disabled)] font-mono">
         <span>${points[0]?.hour?.slice(5) ?? ''}</span>
         <span>${points[points.length - 1]?.hour?.slice(5) ?? ''}</span>
       </div>
@@ -266,15 +266,15 @@ function KeeperRateBars({ keepers }: { keepers: KeeperStat[] }) {
     <div class="flex flex-col gap-1.5">
       ${keepers.map(k => {
         const color = k.success_pct >= 95 ? 'bg-[var(--ok-10)]' : k.success_pct >= 90 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'
-        const textColor = k.success_pct >= 95 ? 'text-[var(--ok)]' : k.success_pct >= 90 ? 'text-[var(--warn)]' : 'text-[var(--bad-light)]'
+        const textColor = k.success_pct >= 95 ? 'text-[var(--color-status-ok)]' : k.success_pct >= 90 ? 'text-[var(--color-status-warn)]' : 'text-[var(--bad-light)]'
         return html`
           <div class="flex items-center gap-2 text-2xs">
-            <span class="w-24 truncate text-[var(--text-dim)] font-mono" title=${k.name}>${k.name}</span>
+            <span class="w-24 truncate text-[var(--color-fg-disabled)] font-mono" title=${k.name}>${k.name}</span>
             <div class="flex-1 h-1.5 bg-[var(--bg-subtle)] rounded-sm overflow-hidden">
               <div class="${color} h-full rounded-sm transition-all" style="width:${Math.min(k.success_pct, 100)}%" />
             </div>
             <span class="w-12 text-right font-mono ${textColor}">${k.success_pct.toFixed(1)}%</span>
-            <span class="w-10 text-right text-[var(--text-dim)]">${k.calls}</span>
+            <span class="w-10 text-right text-[var(--color-fg-disabled)]">${k.calls}</span>
           </div>
         `
       })}
@@ -284,13 +284,13 @@ function KeeperRateBars({ keepers }: { keepers: KeeperStat[] }) {
 
 function FailureList({ categories }: { categories: FailureCategory[] }) {
   const top = categories.slice(0, 8)
-  if (top.length === 0) return html`<div class="text-2xs text-[var(--text-dim)]">실패 없음</div>`
+  if (top.length === 0) return html`<div class="text-2xs text-[var(--color-fg-disabled)]">실패 없음</div>`
   return html`
     <div class="flex flex-col gap-1">
       ${top.map(c => html`
         <div class="flex items-center justify-between text-2xs">
           <span class="font-mono text-[var(--bad-light)]/80 truncate flex-1 mr-2">${c.category}</span>
-          <span class="text-[var(--text-dim)] shrink-0">${c.count}x</span>
+          <span class="text-[var(--color-fg-disabled)] shrink-0">${c.count}x</span>
         </div>
       `)}
     </div>
@@ -322,19 +322,19 @@ export function ToolQualityPanel() {
   const d = data.value
   if (loading.value && !d) return html`<${LoadingState}>도구 품질 불러오는 중...<//>`
   if (error.value) return html`<${ErrorState} message=${error.value} class="m-4" />`
-  if (!d || d.total === 0) return html`<div class="p-4 text-2xs text-[var(--text-dim)]">도구 호출 데이터 없음</div>`
+  if (!d || d.total === 0) return html`<div class="p-4 text-2xs text-[var(--color-fg-disabled)]">도구 호출 데이터 없음</div>`
 
   return html`
     <div class="flex flex-col gap-4 p-4">
       <div class="flex items-center justify-between">
         <div>
           <h2 class="text-sm font-medium">도구 호출 품질</h2>
-          <div class="text-3xs text-[var(--text-dim)]">
+          <div class="text-3xs text-[var(--color-fg-disabled)]">
             ${d.sampling_mode === 'recent_n'
               ? `최근 ${d.sample_limit.toLocaleString()}건 기준 집계`
               : `최근 ${(d.window_hours ?? TOOL_QUALITY_WINDOW_HOURS).toLocaleString()}시간 기준 집계`}
           </div>
-          <div class="mt-0.5 text-3xs text-[var(--text-dim)]">
+          <div class="mt-0.5 text-3xs text-[var(--color-fg-disabled)]">
             <span class="font-mono">${d.source ?? 'tool_call_io'}</span>
             <span class="mx-1">·</span>
             <span class="font-mono ${sourceHealthClass(d.health)}">${d.health ?? 'unknown'}</span>
@@ -345,27 +345,27 @@ export function ToolQualityPanel() {
           </div>
         </div>
         <button
-          class="text-3xs px-2 py-0.5 rounded bg-[var(--bg-subtle)] text-[var(--text-dim)] hover:text-[var(--text)]"
+          class="text-3xs px-2 py-0.5 rounded bg-[var(--bg-subtle)] text-[var(--color-fg-disabled)] hover:text-[var(--text)]"
           onClick=${handleRefreshToolQualityClick}
           aria-label="도구 품질 새로고침"
         >새로고침</button>
-        <span class="text-3xs text-[var(--text-dim)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
+        <span class="text-3xs text-[var(--color-fg-disabled)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <div class="text-center">
           <div class="text-lg font-mono ${successColor.value}">${d.success_rate.toFixed(1)}%</div>
-          <div class="text-3xs text-[var(--text-dim)] uppercase">성공률</div>
+          <div class="text-3xs text-[var(--color-fg-disabled)] uppercase">성공률</div>
         </div>
         <div class="text-center">
           <div class="text-lg font-mono text-[var(--text)]">${d.total.toLocaleString()}</div>
-          <div class="text-3xs text-[var(--text-dim)] uppercase">
+          <div class="text-3xs text-[var(--color-fg-disabled)] uppercase">
             ${d.sampling_mode === 'recent_n' ? 'Sampled Calls' : 'Window Calls'}
           </div>
         </div>
         <div class="text-center">
           <div class="text-lg font-mono text-[var(--bad-light)]/80">${d.failure}</div>
-          <div class="text-3xs text-[var(--text-dim)] uppercase">Failures</div>
+          <div class="text-3xs text-[var(--color-fg-disabled)] uppercase">Failures</div>
         </div>
       </div>
 
@@ -376,13 +376,13 @@ export function ToolQualityPanel() {
       ` : null}
 
       <div>
-        <div class="text-3xs text-[var(--text-dim)] uppercase tracking-wider mb-1">키퍼별</div>
+        <div class="text-3xs text-[var(--color-fg-disabled)] uppercase tracking-wider mb-1">키퍼별</div>
         <${KeeperRateBars} keepers=${d.by_keeper} />
       </div>
 
       <div>
         <div class="flex items-center justify-between mb-1 gap-2">
-          <div class="text-3xs text-[var(--text-dim)] uppercase tracking-wider">도구별 성공률</div>
+          <div class="text-3xs text-[var(--color-fg-disabled)] uppercase tracking-wider">도구별 성공률</div>
           <${TextInput}
             class="max-w-45"
             name="tool_quality_search"
@@ -401,7 +401,7 @@ export function ToolQualityPanel() {
       </div>
 
       <div>
-        <div class="text-3xs text-[var(--text-dim)] uppercase tracking-wider mb-1">실패 분류</div>
+        <div class="text-3xs text-[var(--color-fg-disabled)] uppercase tracking-wider mb-1">실패 분류</div>
         <${FailureList} categories=${d.failure_categories} />
       </div>
     </div>

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -62,7 +62,7 @@ function toneClass(status: string): string {
     case 'invalid_env':
       return 'border-[var(--rose-28)] bg-[var(--rose-10)] text-[#fecdd3]'
     default:
-      return 'border-[var(--card-border)] bg-[var(--white-6)] text-[var(--text-muted)]'
+      return 'border-[var(--color-border-default)] bg-[var(--white-6)] text-[var(--color-fg-muted)]'
   }
 }
 
@@ -157,9 +157,9 @@ function ConfigRow({
   const showSourceBadge = !isRoot && (rootSource === '' || item.source !== rootSource)
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3" title=${item.path}>
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-3" title=${item.path}>
       <div class="mb-2 flex flex-wrap items-center gap-2">
-        <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">${label}</div>
+        <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">${label}</div>
         <${StatusChip} tone=${toneClass(item.exists ? 'ready' : item.source === 'invalid_env' ? 'invalid_env' : 'warn')}>${item.exists ? 'present' : 'missing'}<//>
         ${showSourceBadge
           ? html`
@@ -173,14 +173,14 @@ function ConfigRow({
           : null}
       </div>
       <div class="flex items-start gap-1.5">
-        <div class="min-w-0 flex-1 break-all font-mono text-xs leading-relaxed text-[var(--text-body)]">${pathInfo.primary}</div>
+        <div class="min-w-0 flex-1 break-all font-mono text-xs leading-relaxed text-[var(--color-fg-primary)]">${pathInfo.primary}</div>
         ${item.path
           ? html`<${CopyIdButton} value=${copyablePath(item)} label=${label} ariaLabel=${`${label} 경로 복사`} />`
           : null}
       </div>
       ${pathInfo.context
         ? html`
-            <div class="mt-2 text-2xs text-[var(--text-muted)]">${pathInfo.context}</div>
+            <div class="mt-2 text-2xs text-[var(--color-fg-muted)]">${pathInfo.context}</div>
           `
         : null}
     </div>
@@ -201,7 +201,7 @@ function WarningBlock({
       <div class="mb-2 text-2xs uppercase tracking-1 text-[var(--yellow-100)]">${title}</div>
       <div class="flex flex-col gap-2">
         ${warnings.map(warning => html`
-          <div class="text-xs leading-relaxed text-[var(--text-body)]">${warning}</div>
+          <div class="text-xs leading-relaxed text-[var(--color-fg-primary)]">${warning}</div>
         `)}
       </div>
     </div>
@@ -216,16 +216,16 @@ function RuntimeMetaRow({
   value: string
 }) {
   return html`
-    <div class="flex items-center justify-between gap-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2">
-      <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">${label}</div>
-      <div class="break-all text-right font-mono text-xs text-[var(--text-body)]">${value}</div>
+    <div class="flex items-center justify-between gap-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-2">
+      <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">${label}</div>
+      <div class="break-all text-right font-mono text-xs text-[var(--color-fg-primary)]">${value}</div>
     </div>
   `
 }
 
 function DiagnosticRow({ item }: { item: DashboardRuntimeDiagnostic }) {
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3">
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-3">
       <div class="mb-1 flex flex-wrap items-center gap-2">
         <${StatusChip} tone="neutral">${item.kind}<//>
         ${item.signal
@@ -233,9 +233,9 @@ function DiagnosticRow({ item }: { item: DashboardRuntimeDiagnostic }) {
               <${StatusChip} tone="warn">${item.signal}<//>
             `
           : null}
-        <span class="text-2xs text-[var(--text-muted)]">${item.ts}</span>
+        <span class="text-2xs text-[var(--color-fg-muted)]">${item.ts}</span>
       </div>
-      <div class="text-xs leading-relaxed text-[var(--text-body)]">${item.message}</div>
+      <div class="text-xs leading-relaxed text-[var(--color-fg-primary)]">${item.message}</div>
     </div>
   `
 }
@@ -262,9 +262,9 @@ function probeTone(signal: string | null | undefined, probeOk: boolean | null | 
     case 'possible_reuse':
       return 'border-[var(--yellow-bright-28)] bg-[var(--yellow-bright-10)] text-[var(--yellow-100)]'
     case 'no_visible_reuse':
-      return 'border-[var(--card-border)] bg-[var(--white-6)] text-[var(--text-muted)]'
+      return 'border-[var(--color-border-default)] bg-[var(--white-6)] text-[var(--color-fg-muted)]'
     default:
-      return 'border-[var(--card-border)] bg-[var(--white-6)] text-[var(--text-muted)]'
+      return 'border-[var(--color-border-default)] bg-[var(--white-6)] text-[var(--color-fg-muted)]'
   }
 }
 
@@ -305,7 +305,7 @@ function sourceTone(source: string): string {
     case 'env': return 'border-[var(--accent-primary)]/30 bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]'
     case 'toml': return 'border-[var(--emerald-28)] bg-[var(--emerald-10)] text-[#bbf7d0]'
     case 'derived': return 'border-[var(--yellow-bright-28)] bg-[var(--yellow-bright-10)] text-[var(--yellow-100)]'
-    default: return 'border-[var(--card-border)] bg-[var(--white-6)] text-[var(--text-muted)]'
+    default: return 'border-[var(--color-border-default)] bg-[var(--white-6)] text-[var(--color-fg-muted)]'
   }
 }
 
@@ -324,9 +324,9 @@ function KeeperRuntimePanel({ runtime }: { runtime: KeeperRuntimeResolved | null
   const envCount = KEEPER_RUNTIME_ROWS.filter(r => runtime[r.key]?.source === 'env').length
 
   return html`
-    <div class="mt-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-4 py-4">
+    <div class="mt-4 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-4 py-4">
       <div class="mb-3 flex flex-wrap items-center gap-2">
-        <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">keeper runtime limits</div>
+        <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">keeper runtime limits</div>
         ${tomlCount > 0 ? html`
           <${StatusChip} tone=${sourceTone('toml')}>${tomlCount} TOML<//>
         ` : null}
@@ -334,7 +334,7 @@ function KeeperRuntimePanel({ runtime }: { runtime: KeeperRuntimeResolved | null
           <${StatusChip} tone=${sourceTone('env')}>${envCount} env<//>
         ` : null}
       </div>
-      <div class="mb-3 text-xs text-[var(--text-muted)]">
+      <div class="mb-3 text-xs text-[var(--color-fg-muted)]">
         Per-keeper runtime caps and timeouts. These values are not the live keeper count.
       </div>
       <div class="grid gap-2 md:grid-cols-2">
@@ -342,10 +342,10 @@ function KeeperRuntimePanel({ runtime }: { runtime: KeeperRuntimeResolved | null
           const field: KeeperRuntimeField<number | null> | undefined = runtime[row.key]
           if (!field) return null
           return html`
-            <div class="flex items-center justify-between gap-3 rounded border border-[var(--card-border)] bg-[var(--white-6)] px-3 py-2">
-              <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">${row.label}</div>
+            <div class="flex items-center justify-between gap-3 rounded border border-[var(--color-border-default)] bg-[var(--white-6)] px-3 py-2">
+              <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">${row.label}</div>
               <div class="flex items-center gap-2">
-                <span class="font-mono text-xs text-[var(--text-body)]">${fmtKeeperValue(field.value, row.fmt)}</span>
+                <span class="font-mono text-xs text-[var(--color-fg-primary)]">${fmtKeeperValue(field.value, row.fmt)}</span>
                 <span class="text-3xs px-1.5 py-0.5 rounded ${sourceTone(field.source)}">${field.source}</span>
               </div>
             </div>
@@ -391,9 +391,9 @@ function RuntimeProbePanel() {
   const signal = assessment?.signal ?? null
 
   return html`
-    <div class="mt-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-4 py-4">
+    <div class="mt-4 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-4 py-4">
       <div class="mb-3 flex flex-wrap items-center gap-2">
-        <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">ollama warm / kv probe</div>
+        <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">ollama warm / kv probe</div>
         <${StatusChip} tone=${probeTone(signal, probe?.probe_ok)}>${probeSignalLabel(signal)}<//>
         ${state.value.data?.cache_hit !== undefined
           ? html`
@@ -401,7 +401,7 @@ function RuntimeProbePanel() {
             `
           : null}
         <button
-          class="ml-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-2xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="ml-auto rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-1 text-2xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
           onClick=${() => void load(true)}
         >
           ${state.value.loading ? 'probing...' : 'refresh probe'}
@@ -418,7 +418,7 @@ function RuntimeProbePanel() {
 
       ${!state.value.error && !probe
         ? html`
-            <div class="text-xs text-[var(--text-muted)]">
+            <div class="text-xs text-[var(--color-fg-muted)]">
               ${state.value.loading ? 'runtime probe를 불러오는 중입니다.' : 'probe result가 아직 없습니다.'}
             </div>
           `
@@ -456,7 +456,7 @@ function RuntimeProbePanel() {
 
             ${assessment?.note
               ? html`
-                  <div class="mt-3 text-xs leading-relaxed text-[var(--text-muted)]">
+                  <div class="mt-3 text-xs leading-relaxed text-[var(--color-fg-muted)]">
                     ${assessment.note}
                   </div>
                 `
@@ -466,7 +466,7 @@ function RuntimeProbePanel() {
               ? html`
                   <div class="mt-3 flex flex-col gap-2">
                     ${probe.observations?.map(item => html`
-                      <div class="rounded border border-[var(--card-border)] bg-[var(--white-6)] px-3 py-2 text-xs text-[var(--text-body)]">
+                      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-6)] px-3 py-2 text-xs text-[var(--color-fg-primary)]">
                         ${item}
                       </div>
                     `)}
@@ -513,7 +513,7 @@ export function ConfigResolutionPanel({
 
   return html`
     <${Card} title="설정 경로" class="section mb-4">
-      <div class="mb-4 text-xs leading-relaxed text-[var(--text-muted)]">
+      <div class="mb-4 text-xs leading-relaxed text-[var(--color-fg-muted)]">
         서버가 실제로 해석한 config root와 runtime/data root를 함께 보여줍니다. cascade는 human-authored cascade.toml과 runtime cascade.json을 분리해 보여주며, 현재 실행이 바라보는 경로와 체크인된 seed config는 다를 수 있습니다.
       </div>
 
@@ -523,7 +523,7 @@ export function ConfigResolutionPanel({
               <div class="mb-3 flex flex-wrap items-center gap-2">
                 <${StatusChip} tone=${toneClass(resolution.status)}>${resolution.status}<//>
                 <${StatusChip} tone="neutral" uppercase=${false}>${sourceLabel(resolution.config_root.source)}<//>
-                <span class="text-xs text-[var(--text-muted)]">resolved config root</span>
+                <span class="text-xs text-[var(--color-fg-muted)]">resolved config root</span>
               </div>
 
               <div class="mb-4">
@@ -578,7 +578,7 @@ export function ConfigResolutionPanel({
             <div>
               <div class="mb-3 flex flex-wrap items-center gap-2">
                 <${StatusChip} tone=${toneClass(runtimeResolution.status)}>${runtimeResolution.status}<//>
-                <span class="text-xs text-[var(--text-muted)]">runtime path resolution</span>
+                <span class="text-xs text-[var(--color-fg-muted)]">runtime path resolution</span>
                 ${runtimeResolution.source_mismatch
                   ? html`
                       <${StatusChip} tone="bad">source mismatch<//>
@@ -607,7 +607,7 @@ export function ConfigResolutionPanel({
 
               <div class="mt-4">
                 <div class="mb-2 flex items-center justify-between gap-2">
-                  <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">
+                  <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">
                     recent diagnostics
                   </div>
                   ${runtimeResolution.diagnostics.length > 0
@@ -618,7 +618,7 @@ export function ConfigResolutionPanel({
                           placeholder="kind / signal / message 필터"
                           aria-label="Diagnostics 필터"
                           onInput=${(e: Event) => { diagnosticsQuery.value = (e.target as HTMLInputElement).value }}
-                          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
                         />
                       `
                     : null}
@@ -626,13 +626,13 @@ export function ConfigResolutionPanel({
                 <div class="flex flex-col gap-3">
                   ${runtimeResolution.diagnostics.length === 0
                     ? html`
-                        <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3 text-xs text-[var(--text-muted)]">
+                        <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-3 text-xs text-[var(--color-fg-muted)]">
                           최근 runtime warning이 없습니다.
                         </div>
                       `
                     : isFilteringDiagnostics && visibleDiagnostics.length === 0
                       ? html`
-                          <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3 text-center text-xs text-[var(--text-muted)]">
+                          <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-3 text-center text-xs text-[var(--color-fg-muted)]">
                             필터 결과 없음 (${runtimeResolution.diagnostics.length} diagnostics)
                           </div>
                         `

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -31,13 +31,13 @@ const SOURCE_LABELS: Record<PromptSourceFilter, string> = {
 function sourceBadgeClass(source: PromptSource): string {
   switch (source) {
     case 'override':
-      return 'text-[var(--warn)] bg-[rgba(250,204,21,0.12)] border-[var(--yellow-bright-28)]'
+      return 'text-[var(--color-status-warn)] bg-[rgba(250,204,21,0.12)] border-[var(--yellow-bright-28)]'
     case 'file':
       return 'text-[var(--ok-20)] bg-[var(--emerald-12)] border-[var(--emerald-28)]'
     case 'missing':
       return 'text-[var(--bad-light)] bg-[rgba(244,63,94,0.12)] border-[var(--rose-28)]'
     default:
-      return 'text-[var(--text-muted)] bg-[var(--white-6)] border-[var(--card-border)]'
+      return 'text-[var(--color-fg-muted)] bg-[var(--white-6)] border-[var(--color-border-default)]'
   }
 }
 
@@ -166,7 +166,7 @@ export function PromptRegistryPanel() {
 
   return html`
     <${Card} title="프롬프트 레지스트리" class="section mb-4">
-      <div class="mb-4 text-xs text-[var(--text-muted)] leading-relaxed">
+      <div class="mb-4 text-xs text-[var(--color-fg-muted)] leading-relaxed">
         <div>기준 원문은 resolved config root의 <code>prompts/*.md</code>입니다. 경로는 설정 경로 상세 패널에서 확인할 수 있습니다.</div>
         <div>이 화면에서는 현재 effective 값 확인과 runtime override 적용/해제만 합니다.</div>
       </div>
@@ -175,12 +175,12 @@ export function PromptRegistryPanel() {
       ${status ? html`<div class="mb-4 rounded border border-[var(--sky-28)] bg-[var(--sky-8)] px-3 py-2 text-xs text-[#bae6fd]">${status}</div>` : null}
 
       <div class="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
-        <div class="min-h-65 rounded border border-[var(--card-border)] bg-[var(--white-3)] p-2">
+        <div class="min-h-65 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] p-2">
           <div class="mb-2 flex items-center justify-between gap-2 px-2">
-            <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">
+            <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">
               등록된 프롬프트
               ${sourceFilter.value !== 'all' || searchQuery.value
-                ? html`<span class="ml-1 normal-case tracking-normal text-[var(--text-muted)]">${visiblePrompts.length} / ${prompts.length}</span>`
+                ? html`<span class="ml-1 normal-case tracking-normal text-[var(--color-fg-muted)]">${visiblePrompts.length} / ${prompts.length}</span>`
                 : null}
             </div>
             <${ActionButton} variant="ghost" size="sm" disabled=${loading || saving} onClick=${() => { void loadPrompts(selectedPrompt?.key ?? null) }}>
@@ -207,7 +207,7 @@ export function PromptRegistryPanel() {
           </div>
           <div class="flex max-h-130 flex-col gap-2 overflow-y-auto pr-1">
             ${visiblePrompts.length === 0 ? html`
-              <div class="rounded border border-dashed border-[var(--card-border)] px-3 py-6 text-center text-2xs text-[var(--text-muted)]">
+              <div class="rounded border border-dashed border-[var(--color-border-default)] px-3 py-6 text-center text-2xs text-[var(--color-fg-muted)]">
                 조건에 맞는 프롬프트가 없습니다.
               </div>
             ` : null}
@@ -216,7 +216,7 @@ export function PromptRegistryPanel() {
                 type="button"
                 class="rounded border px-3 py-2 text-left transition-colors ${selectedPrompt?.key === prompt.key
                   ? 'border-[var(--accent-30)] bg-[var(--accent-10)]'
-                  : 'border-[var(--card-border)] bg-[var(--white-2)] hover:bg-[var(--white-4)]'}"
+                  : 'border-[var(--color-border-default)] bg-[var(--white-2)] hover:bg-[var(--white-4)]'}"
                 onClick=${() => {
                   setSelectedKey(prompt.key)
                   setDraft(normalizeDraft(prompt))
@@ -224,20 +224,20 @@ export function PromptRegistryPanel() {
                 }}
               >
                 <div class="mb-1 flex items-start justify-between gap-2">
-                  <div class="font-mono text-xs text-[var(--text-strong)]">${prompt.key}</div>
+                  <div class="font-mono text-xs text-[var(--color-fg-secondary)]">${prompt.key}</div>
                   <${StatusChip} tone=${sourceBadgeClass(prompt.source)}>${prompt.source}<//>
                 </div>
-                <div class="mb-1 text-2xs text-[var(--text-muted)]">${prompt.category}</div>
-                <div class="text-xs text-[var(--text-body)] leading-relaxed">${prompt.description}</div>
+                <div class="mb-1 text-2xs text-[var(--color-fg-muted)]">${prompt.category}</div>
+                <div class="text-xs text-[var(--color-fg-primary)] leading-relaxed">${prompt.description}</div>
               </button>
             `)}
           </div>
         </div>
 
-        <div class="min-w-0 rounded border border-[var(--card-border)] bg-[var(--white-3)] p-4">
+        <div class="min-w-0 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] p-4">
           ${selectedPrompt ? html`
             <div class="mb-4 flex flex-wrap items-center gap-2">
-              <div class="font-mono text-sm text-[var(--text-strong)]">${selectedPrompt.key}</div>
+              <div class="font-mono text-sm text-[var(--color-fg-secondary)]">${selectedPrompt.key}</div>
               <${StatusChip} tone=${sourceBadgeClass(selectedPrompt.source)}>${selectedPrompt.source}<//>
               ${selectedPrompt.has_override
                 ? html`<${StatusChip} tone="warn">오버라이드 활성<//>`
@@ -245,35 +245,35 @@ export function PromptRegistryPanel() {
             </div>
 
             <div class="mb-4 grid gap-3 md:grid-cols-2">
-              <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">마크다운 파일</div>
-                <div class="mt-1 break-all font-mono text-xs text-[var(--text-body)]">${selectedPrompt.file_path ?? '미설정'}</div>
+              <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-2)] px-3 py-2">
+                <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">마크다운 파일</div>
+                <div class="mt-1 break-all font-mono text-xs text-[var(--color-fg-primary)]">${selectedPrompt.file_path ?? '미설정'}</div>
               </div>
-              <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">문자 수</div>
-                <div class="mt-1 font-mono text-xs text-[var(--text-body)]">${selectedPrompt.char_count}</div>
+              <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-2)] px-3 py-2">
+                <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">문자 수</div>
+                <div class="mt-1 font-mono text-xs text-[var(--color-fg-primary)]">${selectedPrompt.char_count}</div>
               </div>
             </div>
 
             ${selectedPrompt.template_variables.length > 0 ? html`
-              <div class="mb-4 rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">허용된 플레이스홀더</div>
+              <div class="mb-4 rounded border border-[var(--color-border-default)] bg-[var(--white-2)] px-3 py-2">
+                <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">허용된 플레이스홀더</div>
                 <div class="mt-2 flex flex-wrap gap-2">
                   ${selectedPrompt.template_variables.map(variable => html`
-                    <span class="rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 font-mono text-2xs text-[var(--text-body)]">${`{{${variable}}}`}</span>
+                    <span class="rounded-sm border border-[var(--color-border-default)] bg-[var(--white-4)] px-2 py-0.5 font-mono text-2xs text-[var(--color-fg-primary)]">${`{{${variable}}}`}</span>
                   `)}
                 </div>
               </div>
             ` : null}
 
             <div class="mb-4">
-              <div class="mb-2 text-2xs uppercase tracking-1 text-[var(--text-muted)]">파일 기준값</div>
-              <div class="max-h-55 overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```markdown\n' + (selectedPrompt.file_value ?? '없음') + '\n```'} /></div>
+              <div class="mb-2 text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">파일 기준값</div>
+              <div class="max-h-55 overflow-auto rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```markdown\n' + (selectedPrompt.file_value ?? '없음') + '\n```'} /></div>
             </div>
 
             <div class="mb-2 flex items-center justify-between gap-2">
-              <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">런타임 오버라이드</div>
-              <div class="text-2xs text-[var(--text-muted)]">저장 후 effective 미리보기가 오버라이드를 반영합니다</div>
+              <div class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">런타임 오버라이드</div>
+              <div class="text-2xs text-[var(--color-fg-muted)]">저장 후 effective 미리보기가 오버라이드를 반영합니다</div>
             </div>
             <${TextArea}
               rows=${18}
@@ -300,7 +300,7 @@ export function PromptRegistryPanel() {
               <//>
             </div>
           ` : html`
-            <div class="rounded border border-dashed border-[var(--card-border)] px-4 py-10 text-center text-xs text-[var(--text-muted)]">
+            <div class="rounded border border-dashed border-[var(--color-border-default)] px-4 py-10 text-center text-xs text-[var(--color-fg-muted)]">
               ${loading ? '프롬프트 목록을 불러오는 중입니다.' : '표시할 프롬프트가 없습니다.'}
             </div>
           `}

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -116,10 +116,10 @@ function removeFromList(listSig: typeof alsoAllowItems, name: string) {
 
 function RemovableChip({ name, onRemove }: { name: string; onRemove: () => void }) {
   return html`
-    <span class="inline-flex items-center gap-0.5 py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">
+    <span class="inline-flex items-center gap-0.5 py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-30)]">
       ${name}
       <button type="button"
-        class="text-[var(--accent)]/50 hover:text-[#ff6b6b] cursor-pointer text-2xs leading-none transition-colors"
+        class="text-[var(--color-accent-fg)]/50 hover:text-[#ff6b6b] cursor-pointer text-2xs leading-none transition-colors"
         onClick=${onRemove}
         title="제거"
       >\u00d7</button>
@@ -129,7 +129,7 @@ function RemovableChip({ name, onRemove }: { name: string; onRemove: () => void 
 
 function ReadOnlyChip({ name }: { name: string }) {
   return html`
-    <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">
+    <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-30)]">
       ${name}
     </span>
   `
@@ -206,8 +206,8 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
   if (tools.length === 0) {
     return html`
       <div class="flex flex-col gap-1">
-        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">resolved allowlist (0)</span>
-        <span class="text-2xs text-[var(--text-muted)] italic">resolved allowlist 없음</span>
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">resolved allowlist (0)</span>
+        <span class="text-2xs text-[var(--color-fg-muted)] italic">resolved allowlist 없음</span>
       </div>
     `
   }
@@ -221,7 +221,7 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
   return html`
     <div class="flex flex-col gap-1">
       <div class="flex items-center justify-between gap-2">
-        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">
           resolved allowlist (${tools.length}개, ${groups.length} 카테고리)
         </span>
         <input
@@ -230,11 +230,11 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
           placeholder="도구/카테고리 필터"
           aria-label="resolved allowlist 필터"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-35 max-w-55 flex-1 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-35 max-w-55 flex-1 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && visibleTools.length === 0
-        ? html`<div class="py-3 text-center text-2xs text-[var(--text-muted)]">필터 결과 없음 (${tools.length}개 도구)</div>`
+        ? html`<div class="py-3 text-center text-2xs text-[var(--color-fg-muted)]">필터 결과 없음 (${tools.length}개 도구)</div>`
         : html`
           <div class="flex flex-col gap-2">
             ${visibleGroups.map(group => {
@@ -242,12 +242,12 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
               const hiddenToolCount = Math.max(0, group.names.length - visibleNames.length)
               return html`
               <div class="flex flex-col gap-1">
-                <span class="text-3xs font-bold uppercase tracking-widest text-[var(--text-muted)]">${group.category} (${group.names.length})</span>
+                <span class="text-3xs font-bold uppercase tracking-widest text-[var(--color-fg-muted)]">${group.category} (${group.names.length})</span>
                 <div class="flex flex-wrap gap-1">
                   ${visibleNames.map(name => html`<${ReadOnlyChip} name=${name} />`)}
                   ${!expanded && hiddenToolCount > 0
                     ? html`
-                        <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium border border-dashed border-[var(--card-border)] text-[var(--text-muted)]">
+                        <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium border border-dashed border-[var(--color-border-default)] text-[var(--color-fg-muted)]">
                           +${hiddenToolCount}
                         </span>
                       `
@@ -260,7 +260,7 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
           ${hasHiddenContent
             ? html`
                 <button type="button"
-                  class="self-start text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+                  class="self-start text-3xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer transition-colors"
                   aria-expanded=${expanded}
                   aria-label=${expanded ? 'resolved allowlist 접기' : `resolved allowlist 전체 ${tools.length}개 보기`}
                   onClick=${() => setExpanded(value => !value)}
@@ -361,19 +361,19 @@ function ToolSearchPicker({
         <input
           ...${getInputProps({
             placeholder,
-            class: 'w-full px-3 py-1.5 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]',
+            class: 'w-full px-3 py-1.5 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)]',
           })}
         />
 
         <ul ...${getMenuProps({
           class: showMenu && filtered.length > 0
-            ? 'absolute z-10 top-full left-0 right-0 mt-1 max-h-55 overflow-y-auto rounded border border-[var(--card-border)] bg-[var(--backdrop-modal)] shadow-sm backdrop-blur-sm list-none m-0 p-0'
+            ? 'absolute z-10 top-full left-0 right-0 mt-1 max-h-55 overflow-y-auto rounded border border-[var(--color-border-default)] bg-[var(--backdrop-modal)] shadow-sm backdrop-blur-sm list-none m-0 p-0'
             : 'hidden',
         })}>
           ${showMenu && filtered.length > 0
             ? Array.from(groupedFiltered.entries()).map(([cat, names]) => html`
               ${groupedFiltered.size > 1
-                ? html`<li class="px-3 pt-2 pb-0.5 text-3xs font-bold uppercase tracking-widest text-[var(--text-muted)] select-none" aria-hidden="true">${cat}</li>`
+                ? html`<li class="px-3 pt-2 pb-0.5 text-3xs font-bold uppercase tracking-widest text-[var(--color-fg-muted)] select-none" aria-hidden="true">${cat}</li>`
                 : null}
               ${names.map(name => {
                 const idx = filtered.indexOf(name)
@@ -383,14 +383,14 @@ function ToolSearchPicker({
                     ...${getItemProps({ item: name, index: idx })}
                     class=${`w-full flex items-start gap-2 text-left px-3 py-1.5 cursor-pointer transition-colors ${
                       highlightedIndex === idx
-                        ? 'bg-[var(--accent-soft)] text-[var(--accent)]'
+                        ? 'bg-[var(--accent-soft)] text-[var(--color-accent-fg)]'
                         : 'hover:bg-[var(--accent-10)]'
                     }`}
                   >
-                    <span class="text-2xs text-[var(--text-body)] font-medium shrink-0">${name}</span>
-                    ${usage ? html`<span class="text-3xs text-[var(--text-muted)] shrink-0 tabular-nums">${usage}x</span>` : null}
+                    <span class="text-2xs text-[var(--color-fg-primary)] font-medium shrink-0">${name}</span>
+                    ${usage ? html`<span class="text-3xs text-[var(--color-fg-muted)] shrink-0 tabular-nums">${usage}x</span>` : null}
                     ${descMap.has(name)
-                      ? html`<span class="text-3xs text-[var(--text-muted)] truncate">${descMap.get(name)}</span>`
+                      ? html`<span class="text-3xs text-[var(--color-fg-muted)] truncate">${descMap.get(name)}</span>`
                       : null}
                   </li>
                 `
@@ -400,7 +400,7 @@ function ToolSearchPicker({
         </ul>
         ${showMenu && filtered.length === 0
           ? html`
-            <div class="absolute z-10 top-full left-0 right-0 mt-1 px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--backdrop-modal)] text-2xs text-[var(--text-muted)]">
+            <div class="absolute z-10 top-full left-0 right-0 mt-1 px-3 py-2 rounded border border-[var(--color-border-default)] bg-[var(--backdrop-modal)] text-2xs text-[var(--color-fg-muted)]">
               ${allNames.length === 0
                 ? '도구 목록 로딩 중... Enter로 직접 추가 가능'
                 : '일치하는 도구 없음. Enter로 직접 추가 가능'}
@@ -424,7 +424,7 @@ function TextModeToggle({
   if (!isText) {
     return html`
       <button type="button"
-        class="text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+        class="text-3xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer transition-colors"
         onClick=${() => {
           textInputBuffer.value = listSig.value.join(', ')
           textInputSection.value = section
@@ -436,14 +436,14 @@ function TextModeToggle({
   return html`
     <div class="flex gap-2">
       <button type="button"
-        class="text-3xs text-[var(--ok)] hover:text-[var(--ok)] cursor-pointer transition-colors"
+        class="text-3xs text-[var(--color-status-ok)] hover:text-[var(--color-status-ok)] cursor-pointer transition-colors"
         onClick=${() => {
           listSig.value = parseToolList(textInputBuffer.value)
           textInputSection.value = null
         }}
       >적용</button>
       <button type="button"
-        class="text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+        class="text-3xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer transition-colors"
         onClick=${() => { textInputSection.value = null }}
       >취소</button>
     </div>
@@ -463,8 +463,8 @@ function SectionHeader({
 }) {
   return html`
     <div class="flex items-center justify-between">
-      <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-        ${label}${listSig.value.length > 0 ? html` <span class="text-[var(--text-body)]">(${listSig.value.length})</span>` : ''}
+      <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">
+        ${label}${listSig.value.length > 0 ? html` <span class="text-[var(--color-fg-primary)]">(${listSig.value.length})</span>` : ''}
       </span>
       <${TextModeToggle} section=${section} listSig=${listSig} />
     </div>
@@ -538,11 +538,11 @@ export function ToolAllowlistEditor({
   }
 
   return html`
-    <div class="flex flex-col gap-3 mt-2 p-3 rounded border border-[var(--card-border)] bg-[var(--panel-dark-60)]">
+    <div class="flex flex-col gap-3 mt-2 p-3 rounded border border-[var(--color-border-default)] bg-[var(--panel-dark-60)]">
       <div class="flex items-center justify-between">
-        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">도구 정책 편집</span>
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">도구 정책 편집</span>
         <button type="button"
-          class="text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer"
+          class="text-3xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer"
           onClick=${() => resetEditorState({
             mode: currentMode,
             preset: currentPreset,
@@ -559,8 +559,8 @@ export function ToolAllowlistEditor({
           <button type="button"
             class=${`py-1 px-3 rounded text-3xs font-medium border transition-colors cursor-pointer ${
               policyMode.value === mode
-                ? 'border-[var(--accent-30)] bg-[var(--accent-soft)] text-[var(--accent)]'
-                : 'border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)]'
+                ? 'border-[var(--accent-30)] bg-[var(--accent-soft)] text-[var(--color-accent-fg)]'
+                : 'border-[var(--color-border-default)] bg-[var(--white-3)] text-[var(--color-fg-muted)]'
             }`}
             onClick=${() => { policyMode.value = mode; textInputSection.value = null }}
           >${mode}</button>
@@ -571,9 +571,9 @@ export function ToolAllowlistEditor({
       ${policyMode.value === 'preset'
         ? html`
           <label class="flex flex-col gap-1">
-            <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">preset</span>
+            <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">preset</span>
             <select
-              class="w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)]"
+              class="w-full px-3 py-2 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs text-[var(--color-fg-primary)]"
               value=${preset.value}
               onChange=${(e: Event) => { preset.value = (e.target as HTMLSelectElement).value as typeof preset.value }}
             >
@@ -588,7 +588,7 @@ export function ToolAllowlistEditor({
             ${textInputSection.value === 'also_allow'
               ? html`
                 <textarea
-                  class="min-h-18 w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
+                  class="min-h-18 w-full px-3 py-2 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)]"
                   placeholder="쉼표 또는 줄바꿈으로 구분"
                   value=${textInputBuffer.value}
                   onInput=${(e: Event) => { textInputBuffer.value = (e.target as HTMLTextAreaElement).value }}
@@ -612,15 +612,15 @@ export function ToolAllowlistEditor({
               ? html`
                 <div class="flex flex-col gap-2 px-3 py-2 rounded bg-[var(--bad-12)] border border-[var(--bad-30)]">
                   <div class="flex items-start gap-2">
-                    <span class="text-[var(--bad)] text-sm shrink-0 font-bold">0</span>
-                    <span class="text-2xs text-[var(--bad)] leading-snug">
+                    <span class="text-[var(--color-status-err)] text-sm shrink-0 font-bold">0</span>
+                    <span class="text-2xs text-[var(--color-status-err)] leading-snug">
                       allowlist가 비어 있으면 이 키퍼는 <strong>도구를 하나도 사용할 수 없습니다</strong>.
                     </span>
                   </div>
                   ${resolvedAllowlist.length > 0
                     ? html`
                       <button type="button"
-                        class="self-start py-1 px-3 rounded text-3xs font-medium border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-22)] cursor-pointer transition-colors"
+                        class="self-start py-1 px-3 rounded text-3xs font-medium border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)] hover:bg-[var(--accent-22)] cursor-pointer transition-colors"
                         onClick=${() => { customAllowItems.value = [...resolvedAllowlist] }}
                       >현재 resolved list에서 복사 (${resolvedAllowlist.length}개)</button>
                     `
@@ -631,7 +631,7 @@ export function ToolAllowlistEditor({
             ${textInputSection.value === 'custom'
               ? html`
                 <textarea
-                  class="min-h-[88px] w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
+                  class="min-h-[88px] w-full px-3 py-2 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)]"
                   placeholder="쉼표 또는 줄바꿈으로 구분"
                   value=${textInputBuffer.value}
                   onInput=${(e: Event) => { textInputBuffer.value = (e.target as HTMLTextAreaElement).value }}
@@ -654,7 +654,7 @@ export function ToolAllowlistEditor({
         ${textInputSection.value === 'deny'
           ? html`
             <textarea
-              class="min-h-18 w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
+              class="min-h-18 w-full px-3 py-2 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)]"
               placeholder="쉼표 또는 줄바꿈으로 구분"
               value=${textInputBuffer.value}
               onInput=${(e: Event) => { textInputBuffer.value = (e.target as HTMLTextAreaElement).value }}
@@ -677,8 +677,8 @@ export function ToolAllowlistEditor({
         <button type="button"
           class=${`py-1.5 px-4 rounded text-3xs font-medium transition-colors cursor-pointer disabled:opacity-50 ${
             isCustomEmpty
-              ? 'bg-[var(--bad-light)] text-white hover:bg-[var(--bad)]'
-              : 'bg-[var(--ok)] text-[#000] hover:bg-[var(--emerald)]'
+              ? 'bg-[var(--bad-light)] text-white hover:bg-[var(--color-status-err)]'
+              : 'bg-[var(--color-status-ok)] text-[#000] hover:bg-[var(--emerald)]'
           }`}
           onClick=${applyChanges}
           disabled=${saving.value}
@@ -689,7 +689,7 @@ export function ToolAllowlistEditor({
               ? '도구 0개로 적용'
               : '정책 적용'}
         </button>
-        <span class="text-3xs text-[var(--text-muted)]">
+        <span class="text-3xs text-[var(--color-fg-muted)]">
           ${policyMode.value === 'custom'
             ? `${customAllowItems.value.length}개 허용${denyItems.value.length > 0 ? `, ${denyItems.value.length}개 차단` : ''}`
             : `preset: ${preset.value}${alsoAllowItems.value.length > 0 ? ` + ${alsoAllowItems.value.length}개 추가` : ''}${denyItems.value.length > 0 ? `, ${denyItems.value.length}개 차단` : ''}`}
@@ -697,10 +697,10 @@ export function ToolAllowlistEditor({
       </div>
 
       ${lastError.value
-        ? html`<span class="text-3xs text-[var(--bad)]">${lastError.value}</span>`
+        ? html`<span class="text-3xs text-[var(--color-status-err)]">${lastError.value}</span>`
         : null}
       ${lastSuccess.value
-        ? html`<span class="text-3xs text-[var(--ok)]">${lastSuccess.value}</span>`
+        ? html`<span class="text-3xs text-[var(--color-status-ok)]">${lastSuccess.value}</span>`
         : null}
     </div>
   `

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -82,46 +82,46 @@ export function FullInventoryView({
   const directCallCount = inventory.filter(item => item.direct_call_allowed).length
 
   return html`
-    <div class="sticky top-[var(--header-h)] z-[var(--z-tab-sticky)] bg-[var(--backdrop-modal)] backdrop-blur-[8px] py-3 border-b border-[var(--card-border)]">
+    <div class="sticky top-[var(--header-h)] z-[var(--z-tab-sticky)] bg-[var(--backdrop-modal)] backdrop-blur-[8px] py-3 border-b border-[var(--color-border-default)]">
       <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-4">
-        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${totalCount}</span>
-          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">전체 도구</span>
+        <div class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${totalCount}</span>
+          <span class="text-2xs text-[var(--color-fg-muted)] uppercase tracking-wider font-medium">전체 도구</span>
         </div>
-        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${publicCount}</span>
-          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">MCP 공개</span>
+        <div class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${publicCount}</span>
+          <span class="text-2xs text-[var(--color-fg-muted)] uppercase tracking-wider font-medium">MCP 공개</span>
         </div>
-        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${hiddenCount}</span>
-          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">숨김</span>
+        <div class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${hiddenCount}</span>
+          <span class="text-2xs text-[var(--color-fg-muted)] uppercase tracking-wider font-medium">숨김</span>
         </div>
-        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${deprecatedCount}</span>
-          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">지원 중단</span>
+        <div class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${deprecatedCount}</span>
+          <span class="text-2xs text-[var(--color-fg-muted)] uppercase tracking-wider font-medium">지원 중단</span>
         </div>
-        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${directCallCount}</span>
-          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">직접 호출</span>
+        <div class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${directCallCount}</span>
+          <span class="text-2xs text-[var(--color-fg-muted)] uppercase tracking-wider font-medium">직접 호출</span>
         </div>
-        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${filtered.length}</span>
-          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">필터 결과</span>
+        <div class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${filtered.length}</span>
+          <span class="text-2xs text-[var(--color-fg-muted)] uppercase tracking-wider font-medium">필터 결과</span>
         </div>
       </div>
 
-      <div class="text-xs text-[var(--text-muted)] mb-4">
+      <div class="text-xs text-[var(--color-fg-muted)] mb-4">
         카드 숫자는 서로 다른 축이다. MCP 공개는 surface, 숨김은 visibility, 직접 호출은 hidden direct-call policy 기준이다.
       </div>
 
       <div class="flex flex-wrap gap-2 mb-4">
         ${(Object.keys(SURFACE_LABELS) as SurfaceFilter[]).map(key => html`
           <button type="button"
-            class=${`px-3 py-1.5 rounded text-sm font-medium border transition-colors cursor-pointer ${surfaceFilter.value === key ? 'border-[var(--accent)]/40 text-[var(--accent)] bg-[var(--accent-8)]' : 'border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] text-[var(--text-body)]'}`}
+            class=${`px-3 py-1.5 rounded text-sm font-medium border transition-colors cursor-pointer ${surfaceFilter.value === key ? 'border-[var(--color-accent-fg)]/40 text-[var(--color-accent-fg)] bg-[var(--accent-8)]' : 'border-[var(--color-border-default)] bg-[var(--white-4)] hover:bg-[var(--white-8)] text-[var(--color-fg-primary)]'}`}
             onClick=${() => { surfaceFilter.value = key }}
           >
             ${SURFACE_LABELS[key]}
-            <span class="inline-flex items-center justify-center min-w-5 h-[18px] px-[5px] text-3xs font-semibold bg-[var(--white-8)] text-[var(--text-muted)] rounded-sm ml-1">${surfaceCountForFilter(inventory, key)}</span>
+            <span class="inline-flex items-center justify-center min-w-5 h-[18px] px-[5px] text-3xs font-semibold bg-[var(--white-8)] text-[var(--color-fg-muted)] rounded-sm ml-1">${surfaceCountForFilter(inventory, key)}</span>
           </button>
         `)}
       </div>
@@ -139,7 +139,7 @@ export function FullInventoryView({
           }}
         />
         <select
-          class="px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-sm focus:border-[var(--accent)]/50 outline-none"
+          class="px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] text-sm focus:border-[var(--color-accent-fg)]/50 outline-none"
           name="tool_inventory_category"
           aria-label="도구 카테고리 필터"
           value=${categoryFilter.value}
@@ -152,7 +152,7 @@ export function FullInventoryView({
             <option value=${category}>${category === 'uncategorized' ? '미분류' : category}</option>
           `)}
         </select>
-        <label class="inline-flex items-center gap-2 text-xs text-[var(--text-body)]">
+        <label class="inline-flex items-center gap-2 text-xs text-[var(--color-fg-primary)]">
           <input
             type="checkbox"
             checked=${directOnly.value}
@@ -162,7 +162,7 @@ export function FullInventoryView({
           />
           <span>직접 호출만</span>
         </label>
-        <label class="inline-flex items-center gap-2 text-xs text-[var(--text-body)]">
+        <label class="inline-flex items-center gap-2 text-xs text-[var(--color-fg-primary)]">
           <input
             type="checkbox"
             checked=${showHidden.value}
@@ -172,7 +172,7 @@ export function FullInventoryView({
           />
           <span>숨김 표시</span>
         </label>
-        <label class="inline-flex items-center gap-2 text-xs text-[var(--text-body)]">
+        <label class="inline-flex items-center gap-2 text-xs text-[var(--color-fg-primary)]">
           <input
             type="checkbox"
             checked=${showDeprecated.value}
@@ -183,7 +183,7 @@ export function FullInventoryView({
           <span>지원 중단 표시</span>
         </label>
         <button type="button"
-          class="px-3 py-1.5 rounded text-sm font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
+          class="px-3 py-1.5 rounded text-sm font-medium border border-[var(--color-border-default)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--color-fg-primary)]"
           onClick=${() => { void loadTools() }}
           disabled=${loading}
         >

--- a/dashboard/src/components/tools/tool-inventory-row.ts
+++ b/dashboard/src/components/tools/tool-inventory-row.ts
@@ -9,11 +9,11 @@ export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
   const categoryHint = item.category === 'uncategorized' ? ' (서버 미지정)' : ''
 
   return html`
-    <article class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+    <article class="p-4 rounded border border-[var(--color-border-default)] bg-[var(--white-3)]">
       <div class="flex justify-between gap-3 items-start">
         <div>
-          <div class="text-md font-bold text-[var(--text-strong)]">${item.name}</div>
-          <div class="tool-inventory-desc text-xs text-[var(--text-muted)] mt-0.5">${item.description}</div>
+          <div class="text-md font-bold text-[var(--color-fg-secondary)]">${item.name}</div>
+          <div class="tool-inventory-desc text-xs text-[var(--color-fg-muted)] mt-0.5">${item.description}</div>
         </div>
         <div class="flex flex-wrap gap-1.5 justify-end">
           ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
@@ -22,18 +22,18 @@ export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
           ${toolBadge(item.implementationStatus)}
         </div>
       </div>
-      <div class="flex flex-wrap gap-3 text-xs text-[var(--text-muted)] mt-2">
-        <span>카테고리: <strong class="text-[var(--text-body)]">${categoryLabel}${categoryHint}</strong></span>
-        <span>직접 호출: <strong class="text-[var(--text-body)]">${item.direct_call_allowed ? '허용' : '차단'}</strong></span>
-        <span>권한: <strong class="text-[var(--text-body)]">${item.required_permission ?? '없음'}</strong></span>
+      <div class="flex flex-wrap gap-3 text-xs text-[var(--color-fg-muted)] mt-2">
+        <span>카테고리: <strong class="text-[var(--color-fg-primary)]">${categoryLabel}${categoryHint}</strong></span>
+        <span>직접 호출: <strong class="text-[var(--color-fg-primary)]">${item.direct_call_allowed ? '허용' : '차단'}</strong></span>
+        <span>권한: <strong class="text-[var(--color-fg-primary)]">${item.required_permission ?? '없음'}</strong></span>
       </div>
       ${item.reason
-        ? html`<div class="tool-inventory-reason text-xs text-[var(--text-muted)] mt-1.5">${item.reason}</div>`
+        ? html`<div class="tool-inventory-reason text-xs text-[var(--color-fg-muted)] mt-1.5">${item.reason}</div>`
         : null}
-      <div class="flex flex-wrap gap-3 text-xs text-[var(--text-muted)] mt-1.5">
-        ${item.canonicalName ? html`<span>정식 이름: <strong class="text-[var(--text-body)]">${item.canonicalName}</strong></span>` : null}
-        ${item.replacement ? html`<span>대체 도구: <strong class="text-[var(--text-body)]">${item.replacement}</strong></span>` : null}
-        ${item.doc_refs.length > 0 ? html`<span>문서: <strong class="text-[var(--text-body)]">${item.doc_refs.join(', ')}</strong></span>` : null}
+      <div class="flex flex-wrap gap-3 text-xs text-[var(--color-fg-muted)] mt-1.5">
+        ${item.canonicalName ? html`<span>정식 이름: <strong class="text-[var(--color-fg-primary)]">${item.canonicalName}</strong></span>` : null}
+        ${item.replacement ? html`<span>대체 도구: <strong class="text-[var(--color-fg-primary)]">${item.replacement}</strong></span>` : null}
+        ${item.doc_refs.length > 0 ? html`<span>문서: <strong class="text-[var(--color-fg-primary)]">${item.doc_refs.join(', ')}</strong></span>` : null}
       </div>
     </article>
   `

--- a/dashboard/src/components/tools/tool-state.ts
+++ b/dashboard/src/components/tools/tool-state.ts
@@ -72,9 +72,9 @@ export function toolMatchesQuery(item: DashboardToolInventoryItem, rawQuery: str
 export function toolBadge(label: string, tone: 'default' | 'ok' | 'warn' | 'surface' = 'default') {
   const toneClass =
     tone === 'ok' ? 'text-[#7dd3fc] bg-[rgba(14,165,233,0.18)]'
-      : tone === 'warn' ? 'text-[var(--warn)] bg-[var(--warn-12)]'
+      : tone === 'warn' ? 'text-[var(--color-status-warn)] bg-[var(--warn-12)]'
       : tone === 'surface' ? 'text-[#c4b5fd] bg-[rgba(139,92,246,0.18)]'
-      : 'text-[var(--text-muted)] bg-[var(--white-8)]'
+      : 'text-[var(--color-fg-muted)] bg-[var(--white-8)]'
   return html`
     <span class="text-2xs rounded-sm px-2 py-0.5 ${toneClass}">
       ${label}

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -24,15 +24,15 @@ const activeView = signal<ToolsView>('inventory')
 function sourceHealthClass(health?: string | null): string {
   switch ((health ?? '').toLowerCase()) {
     case 'ok':
-      return 'text-[var(--ok)]'
+      return 'text-[var(--color-status-ok)]'
     case 'stale':
     case 'coverage_gap':
     case 'empty':
-      return 'text-[var(--warn)]'
+      return 'text-[var(--color-status-warn)]'
     case 'missing':
       return 'text-[var(--bad-light)]'
     default:
-      return 'text-[var(--text-muted)]'
+      return 'text-[var(--color-fg-muted)]'
   }
 }
 
@@ -81,10 +81,10 @@ export function Tools() {
       <${Card} title="도구 사용 현황" class="section mb-4">
         ${usage
           ? html`
-              <div class="text-xs text-[var(--text-muted)] mb-2">
+              <div class="text-xs text-[var(--color-fg-muted)] mb-2">
                 등록됨 ${usage.registered_count} (모든 MCP 서버 합산) · 사용된 ${usage.distinct_tools_called} · 미사용 ${usage.never_called_count}
               </div>
-              <div class="text-3xs text-[var(--text-muted)] mb-2">
+              <div class="text-3xs text-[var(--color-fg-muted)] mb-2">
                 <span class="font-mono">${usage.source ?? 'tool_usage'}</span>
                 <span class="mx-1">·</span>
                 <span class="font-mono ${sourceHealthClass(usage.health)}">${usage.health ?? 'unknown'}</span>
@@ -98,7 +98,7 @@ export function Tools() {
         <${ToolMetrics} />
       <//>
       ${data?.generated_at
-        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--text-muted)] text-xs">
+        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--color-fg-muted)] text-xs">
             <span>생성 시각: ${data.generated_at}</span>
             <span>metrics 기준: 최근 1시간</span>
           </div>`

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -182,15 +182,15 @@ export function formatAvgBufferedBytes(sum: number, count: number): string {
 }
 
 function statusDot(status: StatusTone): string {
-  if (status === 'ok') return 'bg-[var(--ok)]'
-  if (status === 'warn') return 'bg-[var(--warn)]'
-  return 'bg-[var(--bad)]'
+  if (status === 'ok') return 'bg-[var(--color-status-ok)]'
+  if (status === 'warn') return 'bg-[var(--color-status-warn)]'
+  return 'bg-[var(--color-status-err)]'
 }
 
 function toneClass(status: StatusTone): string {
-  if (status === 'ok') return 'text-[var(--ok)]'
-  if (status === 'warn') return 'text-[var(--warn)]'
-  return 'text-[var(--bad)]'
+  if (status === 'ok') return 'text-[var(--color-status-ok)]'
+  if (status === 'warn') return 'text-[var(--color-status-warn)]'
+  return 'text-[var(--color-status-err)]'
 }
 
 function queuePressureTone(pressure: string): StatusTone {
@@ -351,7 +351,7 @@ function CaseCard({ item, data }: { item: PracticalCase; data: TransportHealthDa
       </div>
       <div class="text-2xs text-text-muted mb-2 font-mono break-all">${item.endpoint(data)}</div>
       <div class="text-xs text-text-body leading-relaxed">${item.description}</div>
-      <div class="mt-3 text-2xs text-[var(--accent)]">${item.live(data)}</div>
+      <div class="mt-3 text-2xs text-[var(--color-accent-fg)]">${item.live(data)}</div>
     </div>
   `
 }
@@ -387,7 +387,7 @@ export function TransportHealthPanel() {
   }
 
   if (error && !data) {
-    return html`<div class="p-6 text-center text-[var(--bad)] text-sm">${error}</div>`
+    return html`<div class="p-6 text-center text-[var(--color-status-err)] text-sm">${error}</div>`
   }
 
   if (!data) return null

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -221,10 +221,10 @@ async function submitResolve(
 // ── Row actions (approve/reject UI) ───────────────────
 
 const BTN_PRIMARY =
-  'rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
+  'rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
 
 const BTN_SECONDARY =
-  'rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--text-body)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
+  'rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
 
 function RowActions({
   row,
@@ -239,7 +239,7 @@ function RowActions({
 
   if (state.kind === 'pending') {
     return html`
-      <span class="text-2xs text-[var(--text-muted)]">
+      <span class="text-2xs text-[var(--color-fg-muted)]">
         ${state.decision === 'approve' ? '승인 중…' : '반려 중…'}
       </span>
     `
@@ -248,7 +248,7 @@ function RowActions({
   if (state.kind === 'confirm-approve') {
     return html`
       <div class="flex items-center gap-1 flex-wrap">
-        <span class="text-2xs text-[var(--text-strong)]">승인 확정?</span>
+        <span class="text-2xs text-[var(--color-fg-secondary)]">승인 확정?</span>
         <button
           class=${BTN_PRIMARY}
           onClick=${() => void submitResolve(row, 'approve', '', refresh)}
@@ -268,7 +268,7 @@ function RowActions({
       <div class="flex items-center gap-1 flex-wrap">
         <input
           type="text"
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--text-body)] w-50"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] w-50"
           placeholder="반려 사유 (필수)"
           value=${reason}
           autofocus
@@ -338,29 +338,29 @@ function VerificationRow({
   const actionState = rowActions.value.get(row.request_id) ?? { kind: 'idle' as const }
 
   return html`
-    <tr class="border-b border-[var(--card-border)] last:border-b-0 align-top">
+    <tr class="border-b border-[var(--color-border-default)] last:border-b-0 align-top">
       <td class="py-2 pr-2">
         <${StatusChip} tone=${statusToneForRow(row)}>
           ${statusLabel(row)}
         <//>
       </td>
       <td class="py-2 pr-2">
-        <code class="text-[var(--text-strong)]" title=${row.request_id}>
+        <code class="text-[var(--color-fg-secondary)]" title=${row.request_id}>
           ${truncate(row.request_id, 14)}
         </code>
       </td>
       <td class="py-2 pr-2">
-        <code class="text-[var(--text-body)]" title=${row.task_id}>
+        <code class="text-[var(--color-fg-primary)]" title=${row.task_id}>
           ${truncate(row.task_id, 20)}
         </code>
       </td>
-      <td class="py-2 pr-2 text-[var(--text-body)]">${row.submitted_by}</td>
+      <td class="py-2 pr-2 text-[var(--color-fg-primary)]">${row.submitted_by}</td>
       <td class="py-2 pr-2">
         ${row.approved_by
-          ? html`<span class="text-[var(--text-body)]">${row.approved_by}</span>`
-          : html`<span class="text-[var(--text-muted)]">—</span>`}
+          ? html`<span class="text-[var(--color-fg-primary)]">${row.approved_by}</span>`
+          : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
       </td>
-      <td class="py-2 pr-2 text-[var(--text-muted)] tabular-nums whitespace-nowrap"
+      <td class="py-2 pr-2 text-[var(--color-fg-muted)] tabular-nums whitespace-nowrap"
           title=${row.created_at}>
         ${relativeTime(row.created_at)}
       </td>
@@ -369,7 +369,7 @@ function VerificationRow({
           ? html`<${StatusChip} tone=${verdictTone(row.verdict)}>
               ${VERDICT_LABEL[row.verdict]}
             <//>`
-          : html`<span class="text-[var(--text-muted)]">—</span>`}
+          : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
       </td>
       <td class="py-2 pr-2">
         ${row.status === 'pending'
@@ -383,53 +383,53 @@ function VerificationRow({
                 : null}
               <${RowActions} row=${row} state=${actionState} refresh=${refresh} />
             `
-          : html`<span class="text-[var(--text-muted)]">—</span>`}
+          : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
       </td>
       <td class="py-2">
         ${hasDetails
           ? html`
               <details class="text-2xs">
-                <summary class="cursor-pointer text-[var(--text-muted)] hover:text-[var(--text-body)]">
+                <summary class="cursor-pointer text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)]">
                   자세히
                 </summary>
-                <div class="flex flex-col gap-2 mt-2 p-2 rounded border border-[var(--card-border)] bg-[var(--bg-0)]">
+                <div class="flex flex-col gap-2 mt-2 p-2 rounded border border-[var(--color-border-default)] bg-[var(--bg-0)]">
                   ${hasTaskTitle
                     ? html`
                         <div>
-                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)] mb-1">
                             Task Title
                           </div>
-                          <div class="text-[var(--text-body)]">${row.task_title}</div>
+                          <div class="text-[var(--color-fg-primary)]">${row.task_title}</div>
                         </div>
                       `
                     : null}
                   ${hasRequestSummary
                     ? html`
                         <div>
-                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)] mb-1">
                             Verification Summary
                           </div>
-                          <div class="text-[var(--text-body)]">${row.request_summary}</div>
+                          <div class="text-[var(--color-fg-primary)]">${row.request_summary}</div>
                         </div>
                       `
                     : null}
                   ${hasNextAction
                     ? html`
                         <div>
-                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)] mb-1">
                             Next Action
                           </div>
-                          <div class="text-[var(--text-body)]">${row.next_action}</div>
+                          <div class="text-[var(--color-fg-primary)]">${row.next_action}</div>
                         </div>
                       `
                     : null}
                   ${hasContract
                     ? html`
                         <div>
-                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)] mb-1">
                             Completion Contract
                           </div>
-                          <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--text-body)]">
+                          <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--color-fg-primary)]">
                             ${row.completion_contract.map((c) => html`<li>${c}</li>`)}
                           </ul>
                         </div>
@@ -438,10 +438,10 @@ function VerificationRow({
                   ${hasEvidence
                     ? html`
                         <div>
-                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)] mb-1">
                             Required Evidence
                           </div>
-                          <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--text-body)]">
+                          <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--color-fg-primary)]">
                             ${row.required_evidence.map((e) => html`<li><code>${e}</code></li>`)}
                           </ul>
                         </div>
@@ -450,17 +450,17 @@ function VerificationRow({
                   ${row.verdict_reason !== ''
                     ? html`
                         <div>
-                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)] mb-1">
                             Verdict Reason
                           </div>
-                          <div class="text-[var(--text-body)]">${row.verdict_reason}</div>
+                          <div class="text-[var(--color-fg-primary)]">${row.verdict_reason}</div>
                         </div>
                       `
                     : null}
                 </div>
               </details>
             `
-          : html`<span class="text-[var(--text-muted)]">—</span>`}
+          : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
       </td>
     </tr>
   `
@@ -496,7 +496,7 @@ function RequestsTable({
     <div class="overflow-x-auto">
       <table class="w-full text-xs">
         <thead>
-          <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+          <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
             <th class="text-left py-1 pr-2">상태</th>
             <th class="text-left py-1 pr-2">요청</th>
             <th class="text-left py-1 pr-2">작업</th>
@@ -570,21 +570,21 @@ export function VerificationRequestsPanel() {
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <button
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
           onClick=${() => void loadData(resource)}
         >
           새로고침
         </button>
         ${current.loading
-          ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>`
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">로딩 중...</span>`
           : null}
         ${data?.updated_at
-          ? html`<span class="text-xs text-[var(--text-muted)]">
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">
               updated · ${relativeTime(data.updated_at)}
             </span>`
           : null}
         ${data
-          ? html`<span class="text-xs text-[var(--text-muted)]">
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">
               ${statusFilter.value === 'all' && !searchQuery.value
                 ? `총 ${data.total}건`
                 : `${filtered.length} / ${data.total}건`}
@@ -624,10 +624,10 @@ export function VerificationRequestsPanel() {
         ? html`
             <div
               role="note"
-              class="rounded border border-[var(--card-border)] bg-[var(--bg-panel)] px-3 py-2 text-2xs text-[var(--text-muted)]"
+              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-2xs text-[var(--color-fg-muted)]"
             >
               검증 대기(pending) 요청이 없어 액션 컬럼이 비어 있습니다. 승인/반려 버튼은
-              <code class="text-[var(--text-strong)]">pending</code> 상태에서만 표시됩니다.
+              <code class="text-[var(--color-fg-secondary)]">pending</code> 상태에서만 표시됩니다.
             </div>
           `
         : null}

--- a/dashboard/src/components/verification-specs-panel.ts
+++ b/dashboard/src/components/verification-specs-panel.ts
@@ -140,17 +140,17 @@ export function VerificationSpecsPanel() {
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <button
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
           onClick=${() => void loadSpecs(resource)}
         >
           새로고침
         </button>
-        ${current.loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
+        ${current.loading ? html`<span class="text-xs text-[var(--color-fg-muted)]">로딩 중...</span>` : null}
         ${data?.updated_at
-          ? html`<span class="text-xs text-[var(--text-muted)]">specs · ${data.updated_at}</span>`
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">specs · ${data.updated_at}</span>`
           : null}
         ${data
-          ? html`<span class="text-xs text-[var(--text-muted)]">
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">
               ${categoryFilter.value === 'all' && !searchQuery.value
                 ? `총 ${data.count}건`
                 : `${filtered.length} / ${data.count}건`}

--- a/dashboard_bonsai/src/archive_runs_view.ml
+++ b/dashboard_bonsai/src/archive_runs_view.ml
@@ -16,11 +16,11 @@ stylesheet
   .quiet {
     padding: 40px 20px;
     text-align: center;
-    border: 1px dashed var(--border-main);
+    border: 1px dashed var(--color-border-default);
     font-family: 'EB Garamond', serif;
     font-style: italic;
     font-size: 14px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .loop_list {
@@ -34,14 +34,14 @@ stylesheet
     grid-template-columns: 90px 1fr 120px 140px 90px;
     gap: 14px;
     padding: 12px 16px;
-    border: 1px solid var(--border-main);
-    background: linear-gradient(180deg, color-mix(in oklab, var(--bg-panel) 70%, transparent), color-mix(in oklab, var(--bg-deep) 85%, transparent));
+    border: 1px solid var(--color-border-default);
+    background: linear-gradient(180deg, color-mix(in oklab, var(--color-bg-surface) 70%, transparent), color-mix(in oklab, var(--color-bg-page) 85%, transparent));
     align-items: center;
     transition: border-color 120ms ease, background 120ms ease;
   }
   .loop:hover {
-    border-color: var(--border-highlight);
-    background: linear-gradient(180deg, color-mix(in oklab, var(--bg-card) 80%, transparent), color-mix(in oklab, var(--bg-deep) 90%, transparent));
+    border-color: var(--color-border-strong);
+    background: linear-gradient(180deg, color-mix(in oklab, var(--color-bg-elevated) 80%, transparent), color-mix(in oklab, var(--color-bg-page) 90%, transparent));
   }
 
   .pill {
@@ -51,18 +51,18 @@ stylesheet
     text-transform: uppercase;
     padding: 4px 8px;
     text-align: center;
-    border: 1px solid var(--border-main);
+    border: 1px solid var(--color-border-default);
     font-variant-numeric: tabular-nums;
   }
   .pill_running {
-    color: var(--status-ok);
-    border-color: var(--status-ok);
-    background: color-mix(in oklab, var(--status-ok) 12%, transparent);
+    color: var(--color-status-ok);
+    border-color: var(--color-status-ok);
+    background: color-mix(in oklab, var(--color-status-ok) 12%, transparent);
   }
   .pill_completed {
-    color: var(--accent-brass);
-    border-color: var(--accent-brass);
-    background: color-mix(in oklab, var(--accent-brass) 12%, transparent);
+    color: var(--color-accent-fg);
+    border-color: var(--color-accent-fg);
+    background: color-mix(in oklab, var(--color-accent-fg) 12%, transparent);
   }
   .pill_failed {
     color: var(--accent-blood);
@@ -70,23 +70,23 @@ stylesheet
     background: color-mix(in oklab, var(--accent-blood) 14%, transparent);
   }
   .pill_stopped {
-    color: var(--text-dim);
-    border-color: var(--border-main);
+    color: var(--color-fg-muted);
+    border-color: var(--color-border-default);
   }
   .pill_paused {
-    color: var(--status-warn);
-    border-color: var(--status-warn);
-    background: color-mix(in oklab, var(--accent-brass) 10%, transparent);
+    color: var(--color-status-warn);
+    border-color: var(--color-status-warn);
+    background: color-mix(in oklab, var(--color-accent-fg) 10%, transparent);
   }
   .pill_unknown {
-    color: var(--text-dim);
-    border-color: var(--border-main);
+    color: var(--color-fg-muted);
+    border-color: var(--color-border-default);
   }
 
   .goal {
     font-family: 'EB Garamond', serif;
     font-size: 14px;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -95,7 +95,7 @@ stylesheet
   .goal_id {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     letter-spacing: 0.06em;
     margin-right: 10px;
   }
@@ -114,24 +114,24 @@ stylesheet
     font-variant-numeric: tabular-nums;
     text-align: right;
   }
-  .cycle_dim { color: var(--text-dim); font-size: 11px; }
+  .cycle_dim { color: var(--color-fg-muted); font-size: 11px; }
 
   .kd {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
     font-variant-numeric: tabular-nums;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     text-align: right;
   }
-  .kd_keep { color: var(--status-ok); }
-  .kd_slash { color: var(--text-dim); margin: 0 4px; }
+  .kd_keep { color: var(--color-status-ok); }
+  .kd_slash { color: var(--color-fg-muted); margin: 0 4px; }
   .kd_disc { color: var(--accent-viscera); }
 
   .elapsed {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
     font-variant-numeric: tabular-nums;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     text-align: right;
   }
 

--- a/dashboard_bonsai/src/ctx_chart.ml
+++ b/dashboard_bonsai/src/ctx_chart.ml
@@ -26,7 +26,7 @@ stylesheet
   {|
   .chart { display: grid; grid-template-columns: 140px 1fr; }
   .meta {
-    border-right: 1px solid var(--border-main);
+    border-right: 1px solid var(--color-border-default);
     padding: 10px 14px;
     display: flex;
     flex-direction: column;
@@ -36,14 +36,14 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
   .meta_v {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
     letter-spacing: 0.08em;
     text-transform: none;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
   }
   .track {
     position: relative;
@@ -60,11 +60,11 @@ stylesheet
     right: 8px;
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     pointer-events: none;
   }
-  .lbl_warn { top: 22px; color: color-mix(in oklab, var(--accent-brass) 80%, var(--text-dim)); }
-  .lbl_dang { top: 6px;  color: color-mix(in oklab, var(--accent-blood) 80%, var(--text-dim)); }
+  .lbl_warn { top: 22px; color: color-mix(in oklab, var(--color-accent-fg) 80%, var(--color-fg-muted)); }
+  .lbl_dang { top: 6px;  color: color-mix(in oklab, var(--accent-blood) 80%, var(--color-fg-muted)); }
 
   @media (prefers-contrast: more) {
     .meta { border-right-width: 2px; border-right-color: var(--text-bright); color: var(--text-bright); }
@@ -126,7 +126,7 @@ let hairline ~x =
       ; svg_a "y1" "0"
       ; svg_a "x2" (Printf.sprintf "%d" x)
       ; svg_a "y2" "100"
-      ; svg_a "stroke" "var(--border-main)"
+      ; svg_a "stroke" "var(--color-border-default)"
       ; svg_a "stroke-width" "1"
       ; svg_a "opacity" "0.5"
       ; svg_a "vector-effect" "non-scaling-stroke"
@@ -208,7 +208,7 @@ let meta_lines_of (ks : Keepers_types.keeper list) : string list =
 let view ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
   let hairlines = List.init 7 ~f:(fun i -> hairline ~x:(i * 100)) in
   let guides =
-    [ guide ~y:25 ~stroke_var:"var(--accent-brass-dim)" (* 75% warn  *)
+    [ guide ~y:25 ~stroke_var:"var(--color-accent-fg-dim)" (* 75% warn  *)
     ; guide ~y:10 ~stroke_var:"var(--accent-blood)"     (* 90% danger *)
     ]
   in

--- a/dashboard_bonsai/src/dead_keepers_view.ml
+++ b/dashboard_bonsai/src/dead_keepers_view.ml
@@ -23,11 +23,11 @@ stylesheet
   .quiet {
     padding: 40px 20px;
     text-align: center;
-    border: 1px dashed var(--border-main);
+    border: 1px dashed var(--color-border-default);
     font-family: 'EB Garamond', serif;
     font-style: italic;
     font-size: 14px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   @media (prefers-contrast: more) {

--- a/dashboard_bonsai/src/flame.ml
+++ b/dashboard_bonsai/src/flame.ml
@@ -30,13 +30,13 @@ stylesheet
   .flame_bar {
     display: flex;
     height: 14px;
-    border: 1px solid var(--border-main);
-    background: var(--bg-deep);
+    border: 1px solid var(--color-border-default);
+    background: var(--color-bg-page);
     overflow: hidden;
   }
   .flame_seg {
     height: 100%;
-    border-right: 1px solid color-mix(in oklab, var(--bg-deep) 35%, transparent);
+    border-right: 1px solid color-mix(in oklab, var(--color-bg-page) 35%, transparent);
   }
   .flame_seg:last-child { border-right: 0; }
   .flame_seg_llm   { background: var(--t-llm); }
@@ -51,7 +51,7 @@ stylesheet
     margin-top: 10px;
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     letter-spacing: 0.04em;
   }
   .flame_item { display: inline-flex; align-items: center; gap: 6px; }
@@ -59,9 +59,9 @@ stylesheet
     width: 10px;
     height: 10px;
     display: inline-block;
-    border: 1px solid color-mix(in oklab, var(--bg-deep) 45%, transparent);
+    border: 1px solid color-mix(in oklab, var(--color-bg-page) 45%, transparent);
   }
-  .flame_lbl { color: var(--text-primary); }
+  .flame_lbl { color: var(--color-fg-primary); }
   .flame_pct {
     color: var(--text-bright);
     font-variant-numeric: tabular-nums;

--- a/dashboard_bonsai/src/goals_view.ml
+++ b/dashboard_bonsai/src/goals_view.ml
@@ -17,11 +17,11 @@ stylesheet
   .quiet {
     padding: 40px 20px;
     text-align: center;
-    border: 1px dashed var(--border-main);
+    border: 1px dashed var(--color-border-default);
     font-family: 'EB Garamond', serif;
     font-style: italic;
     font-size: 14px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .tree {
@@ -31,14 +31,14 @@ stylesheet
   }
 
   .goal {
-    border: 1px solid var(--border-main);
-    background: linear-gradient(180deg, color-mix(in oklab, var(--bg-panel) 70%, transparent), color-mix(in oklab, var(--bg-deep) 85%, transparent));
+    border: 1px solid var(--color-border-default);
+    background: linear-gradient(180deg, color-mix(in oklab, var(--color-bg-surface) 70%, transparent), color-mix(in oklab, var(--color-bg-page) 85%, transparent));
     padding: 14px 16px;
     display: flex;
     flex-direction: column;
     gap: 10px;
   }
-  .goal_indent { margin-left: 24px; border-left: 1px dashed var(--border-main); padding-left: 16px; }
+  .goal_indent { margin-left: 24px; border-left: 1px dashed var(--color-border-default); padding-left: 16px; }
 
   .goal_head {
     display: grid;
@@ -63,7 +63,7 @@ stylesheet
   .goal_horizon {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     letter-spacing: 0.14em;
     text-transform: uppercase;
   }
@@ -74,22 +74,22 @@ stylesheet
     gap: 18px;
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
   .goal_meta_v { color: var(--text-bright); font-variant-numeric: tabular-nums; }
-  .goal_meta_v_ok { color: var(--status-ok); font-variant-numeric: tabular-nums; }
+  .goal_meta_v_ok { color: var(--color-status-ok); font-variant-numeric: tabular-nums; }
 
   .conv_bar_wrap {
     text-align: right;
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-variant-numeric: tabular-nums;
   }
   .conv_bar {
     margin-top: 4px;
     height: 4px;
-    background: color-mix(in oklab, var(--status-ok) 12%, transparent);
+    background: color-mix(in oklab, var(--color-status-ok) 12%, transparent);
     position: relative;
   }
   .conv_bar_fill {
@@ -97,14 +97,14 @@ stylesheet
     left: 0;
     top: 0;
     bottom: 0;
-    background: var(--status-ok);
+    background: var(--color-status-ok);
   }
 
 
   .tasks {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
@@ -114,14 +114,14 @@ stylesheet
     align-items: baseline;
     gap: 6px;
   }
-  .task_dot { color: var(--text-dim); }
-  .task_dot_done { color: var(--status-ok); }
-  .task_dot_run { color: var(--status-warn); }
-  .task_title { color: var(--text-primary); }
+  .task_dot { color: var(--color-fg-muted); }
+  .task_dot_done { color: var(--color-status-ok); }
+  .task_dot_run { color: var(--color-status-warn); }
+  .task_title { color: var(--color-fg-primary); }
 
   .blocker {
-    border: 1px solid color-mix(in oklab, var(--accent-brass) 28%, transparent);
-    background: color-mix(in oklab, var(--accent-brass) 8%, transparent);
+    border: 1px solid color-mix(in oklab, var(--color-accent-fg) 28%, transparent);
+    background: color-mix(in oklab, var(--color-accent-fg) 8%, transparent);
     padding: 8px 10px;
     display: flex;
     flex-direction: column;
@@ -133,20 +133,20 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.16em;
     text-transform: uppercase;
-    color: var(--status-warn);
+    color: var(--color-status-warn);
   }
 
   .blocker_v {
     font-family: 'Noto Sans KR', sans-serif;
     font-size: 12px;
     line-height: 1.45;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
   }
 
   .blocker_meta {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   @media (max-width: 760px) {

--- a/dashboard_bonsai/src/hello_view.ml
+++ b/dashboard_bonsai/src/hello_view.ml
@@ -13,8 +13,8 @@ stylesheet
   {|
   .root {
     min-height: 100vh;
-    background: var(--bg-deep);
-    color: var(--text-primary);
+    background: var(--color-bg-page);
+    color: var(--color-fg-primary);
     font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
     padding: 3rem 4rem;
     display: flex;
@@ -32,9 +32,9 @@ stylesheet
     font-family: 'Noto Sans KR', sans-serif;
     font-size: 13px;
     padding: 8px 16px;
-    background: var(--bg-panel);
-    color: var(--accent-brass);
-    border: 2px solid var(--accent-brass);
+    background: var(--color-bg-surface);
+    color: var(--color-accent-fg);
+    border: 2px solid var(--color-accent-fg);
     text-decoration: none;
   }
   .skip_nav:focus {
@@ -50,7 +50,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.3em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     margin: 0;
   }
 
@@ -68,7 +68,7 @@ stylesheet
   .sub {
     font-family: 'EB Garamond', Georgia, serif;
     font-size: 1rem;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     margin: 0;
     max-width: 38rem;
     line-height: 1.55;
@@ -76,7 +76,7 @@ stylesheet
 
   .divider {
     border: 0;
-    border-top: 1px solid var(--border-main);
+    border-top: 1px solid var(--color-border-default);
     margin: 1rem 0;
   }
 
@@ -84,7 +84,7 @@ stylesheet
     font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
     font-variant-numeric: tabular-nums;
     font-size: 0.75rem;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   @media (prefers-contrast: more) {

--- a/dashboard_bonsai/src/keepers_directory.ml
+++ b/dashboard_bonsai/src/keepers_directory.ml
@@ -39,8 +39,8 @@ module Style =
 stylesheet
   {|
   .directory {
-    border: 1px solid var(--border-main);
-    background: color-mix(in oklab, var(--bg-deep) 48%, transparent);
+    border: 1px solid var(--color-border-default);
+    background: color-mix(in oklab, var(--color-bg-page) 48%, transparent);
     box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--text-bright) 3%, transparent);
     overflow-x: auto;
   }
@@ -51,13 +51,13 @@ stylesheet
     gap: 14px;
     align-items: center;
     padding: 10px 16px;
-    border-bottom: 1px solid color-mix(in oklab, var(--border-highlight) 16%, transparent);
-    background: linear-gradient(180deg, color-mix(in oklab, var(--bg-panel) 80%, var(--bg-deep)), var(--bg-deep));
+    border-bottom: 1px solid color-mix(in oklab, var(--color-border-strong) 16%, transparent);
+    background: linear-gradient(180deg, color-mix(in oklab, var(--color-bg-surface) 80%, var(--color-bg-page)), var(--color-bg-page));
     font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
     font-size: 11px;
     letter-spacing: 0.28em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .row {
@@ -67,7 +67,7 @@ stylesheet
     gap: 14px;
     align-items: center;
     padding: 12px 16px;
-    border-bottom: 1px solid color-mix(in oklab, var(--border-highlight) 12%, transparent);
+    border-bottom: 1px solid color-mix(in oklab, var(--color-border-strong) 12%, transparent);
     cursor: pointer;
     transition: background 120ms ease;
   }
@@ -76,16 +76,16 @@ stylesheet
 
   .row:hover,
   .row:focus-visible {
-    background: color-mix(in oklab, var(--accent-brass) 4%, transparent);
+    background: color-mix(in oklab, var(--color-accent-fg) 4%, transparent);
   }
 
   .row:focus-visible {
-    outline: 1px solid var(--accent-brass);
+    outline: 1px solid var(--color-accent-fg);
     outline-offset: -1px;
   }
 
   .row_selected {
-    background: linear-gradient(90deg, color-mix(in oklab, var(--accent-brass) 8%, transparent), transparent 72%);
+    background: linear-gradient(90deg, color-mix(in oklab, var(--color-accent-fg) 8%, transparent), transparent 72%);
   }
 
   .row_selected::before {
@@ -95,17 +95,17 @@ stylesheet
     top: 0;
     bottom: 0;
     width: 2px;
-    background: var(--accent-brass);
-    box-shadow: 0 0 12px var(--accent-brass);
+    background: var(--color-accent-fg);
+    box-shadow: 0 0 12px var(--color-accent-fg);
   }
 
   .sigil {
     width: 40px;
     height: 40px;
-    border: 1px solid var(--accent-brass-dim);
+    border: 1px solid var(--color-accent-fg-dim);
     background:
       radial-gradient(circle at 35% 30%, color-mix(in oklab, var(--text-bright) 16%, transparent), transparent 58%),
-      var(--bg-panel-alt, #1b140f);
+      var(--color-bg-panel-alt, #1b140f);
     display: grid;
     place-items: center;
     font-family: var(--font-display, 'Cinzel', serif);
@@ -138,7 +138,7 @@ stylesheet
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
     line-height: 1.35;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     overflow: hidden;
@@ -150,13 +150,13 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .summary_v {
     font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
     font-size: 12px;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -187,14 +187,14 @@ stylesheet
     font-variant-numeric: tabular-nums;
   }
 
-  .metric_v_warn { color: var(--accent-brass); }
+  .metric_v_warn { color: var(--color-accent-fg); }
   .metric_v_bad { color: var(--accent-blood); }
 
   .metric_sub {
     margin-top: 3px;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     overflow: hidden;
@@ -202,8 +202,8 @@ stylesheet
   }
 
   .vial_fill_warn {
-    background: linear-gradient(90deg, var(--accent-brass-dim), var(--accent-brass));
-    box-shadow: 0 0 6px color-mix(in oklab, var(--accent-brass) 35%, transparent);
+    background: linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg));
+    box-shadow: 0 0 6px color-mix(in oklab, var(--color-accent-fg) 35%, transparent);
   }
 
   .vial_fill_bad {
@@ -216,8 +216,8 @@ stylesheet
   }
 
   .note_box {
-    border: 1px solid var(--border-main);
-    background: color-mix(in oklab, var(--bg-deep) 40%, transparent);
+    border: 1px solid var(--color-border-default);
+    background: color-mix(in oklab, var(--color-bg-page) 40%, transparent);
     padding: 12px 14px;
     display: flex;
     flex-direction: column;
@@ -229,14 +229,14 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .note_v {
     font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
     font-size: 12px;
     line-height: 1.55;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
   }
 
   .list {
@@ -257,7 +257,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .list_v {
@@ -271,11 +271,11 @@ stylesheet
 
   .quiet {
     padding: 24px 18px;
-    border: 1px dashed var(--border-main);
+    border: 1px dashed var(--color-border-default);
     font-family: var(--font-body, 'EB Garamond', serif);
     font-size: 15px;
     font-style: italic;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     text-align: center;
   }
 

--- a/dashboard_bonsai/src/keepers_view.ml
+++ b/dashboard_bonsai/src/keepers_view.ml
@@ -20,10 +20,10 @@ stylesheet
   .quiet {
     padding: 28px 20px;
     text-align: center;
-    border: 1px dashed var(--border-main);
+    border: 1px dashed var(--color-border-default);
     font-family: 'EB Garamond', serif;
     font-style: italic;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   @media (prefers-contrast: more) {

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -10,7 +10,7 @@
     Tokens are inlined as literals because ppx_css has no access to the
     design system's [:root] variables yet. When [colors_and_type.css] is
     served from [assets/dashboard_bonsai/], the inline values become
-    [var(--bg-deep)] etc. *)
+    [var(--color-bg-page)] etc. *)
 
 open! Core
 open! Bonsai_web
@@ -25,10 +25,10 @@ stylesheet
     position: relative;
     min-height: 100vh;
     background:
-      radial-gradient(circle at 88% 14%, color-mix(in oklab, var(--accent-brass) 10%, transparent), transparent 22%),
+      radial-gradient(circle at 88% 14%, color-mix(in oklab, var(--color-accent-fg) 10%, transparent), transparent 22%),
       radial-gradient(circle at 8% 88%, color-mix(in oklab, var(--accent-blood) 5%, transparent), transparent 28%),
-      var(--bg-deep);
-    color: var(--text-primary);
+      var(--color-bg-page);
+    color: var(--color-fg-primary);
     font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
     font-size: 15px;
     padding: 1.5rem calc(340px + 24px) 4rem 244px;
@@ -48,9 +48,9 @@ stylesheet
     font-family: 'Noto Sans KR', sans-serif;
     font-size: 13px;
     padding: 8px 16px;
-    background: var(--bg-panel);
-    color: var(--accent-brass);
-    border: 2px solid var(--accent-brass);
+    background: var(--color-bg-surface);
+    color: var(--color-accent-fg);
+    border: 2px solid var(--color-accent-fg);
     text-decoration: none;
   }
   .skip_nav:focus {
@@ -86,16 +86,16 @@ stylesheet
     align-items: center;
     gap: 14px;
     padding-bottom: 1rem;
-    border-bottom: 1px solid var(--border-main);
+    border-bottom: 1px solid var(--color-border-default);
   }
 
   .rune {
     width: 22px;
     height: 22px;
-    border: 1px solid var(--accent-brass);
+    border: 1px solid var(--color-accent-fg);
     display: grid;
     place-items: center;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     font-family: 'Cinzel', serif;
     font-size: 11px;
     transform: rotate(45deg);
@@ -109,7 +109,7 @@ stylesheet
     font-family: 'Cinzel', serif;
     font-size: 13px;
     letter-spacing: 0.22em;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     text-transform: uppercase;
   }
 
@@ -118,17 +118,17 @@ stylesheet
     display: flex;
     align-items: center;
     gap: 10px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-family: 'Noto Sans KR', -apple-system, sans-serif;
     font-size: 11px;
     letter-spacing: 0.12em;
     text-transform: uppercase;
   }
 
-  .crumbs_sep { color: var(--border-highlight); }
+  .crumbs_sep { color: var(--color-border-strong); }
   .crumbs_cur { color: var(--text-bright); letter-spacing: 0.14em; }
   .crumbs_room {
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     letter-spacing: 0.14em;
     font-variant-numeric: tabular-nums;
   }
@@ -139,8 +139,8 @@ stylesheet
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--accent-brass);
-    box-shadow: 0 0 8px color-mix(in oklab, var(--accent-brass) 55%, transparent);
+    background: var(--color-accent-fg);
+    box-shadow: 0 0 8px color-mix(in oklab, var(--color-accent-fg) 55%, transparent);
     animation: pulse-beat 2.4s ease-in-out infinite;
   }
 
@@ -154,7 +154,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.25em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .heartbeat {
@@ -163,10 +163,10 @@ stylesheet
     gap: 6px;
     padding: 10px 14px 12px;
     background:
-      linear-gradient(180deg, var(--bg-panel) 0%, var(--bg-deep) 100%);
-    border: 1px solid var(--border-main);
+      linear-gradient(180deg, var(--color-bg-surface) 0%, var(--color-bg-page) 100%);
+    border: 1px solid var(--color-border-default);
     border-radius: 2px;
-    box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent-brass) 4%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--color-accent-fg) 4%, transparent);
   }
 
   .heartbeat_head {
@@ -180,14 +180,14 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.25em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .heartbeat_scale {
     font-family: 'JetBrains Mono', ui-monospace, Menlo, monospace;
     font-size: 11px;
     letter-spacing: 0.12em;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .heartbeat_track {
@@ -198,7 +198,7 @@ stylesheet
     height: 36px;
     align-items: end;
     padding: 0 1px;
-    border-bottom: 1px solid var(--border-main);
+    border-bottom: 1px solid var(--color-border-default);
   }
 
   .heartbeat_bar {
@@ -208,9 +208,9 @@ stylesheet
     opacity: 0.82;
   }
 
-  .heartbeat_bar_warn  { background: linear-gradient(180deg, var(--status-warn) 0%, color-mix(in oklab, var(--status-warn) 40%, var(--bg-deep)) 100%); }
+  .heartbeat_bar_warn  { background: linear-gradient(180deg, var(--color-status-warn) 0%, color-mix(in oklab, var(--color-status-warn) 40%, var(--color-bg-page)) 100%); }
   .heartbeat_bar_error { background: linear-gradient(180deg, var(--accent-blood) 0%, var(--accent-blood-dim) 100%); box-shadow: 0 0 6px color-mix(in oklab, var(--accent-blood) 45%, transparent); }
-  .heartbeat_bar_idle  { background: var(--border-main); opacity: 0.6; }
+  .heartbeat_bar_idle  { background: var(--color-border-default); opacity: 0.6; }
 
   /* hud CSS → Hud 모듈로 이관 (shell 추출 Phase 2.A) */
 
@@ -224,24 +224,24 @@ stylesheet
     padding: 8px 14px;
     background:
       linear-gradient(90deg,
-        color-mix(in oklab, var(--accent-brass) 10%, transparent) 0%,
+        color-mix(in oklab, var(--color-accent-fg) 10%, transparent) 0%,
         transparent 45%,
         color-mix(in oklab, var(--accent-blood) 6%, transparent) 100%),
-      var(--bg-deep);
-    border: 1px solid var(--border-main);
+      var(--color-bg-page);
+    border: 1px solid var(--color-border-default);
     border-radius: 2px;
     font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
     font-variant: small-caps;
     letter-spacing: 0.08em;
     font-size: 12px;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
   }
 
   .moon_glyph {
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    background: radial-gradient(circle at 28% 28%, var(--text-bright) 0%, var(--accent-brass) 55%, var(--border-highlight) 100%);
+    background: radial-gradient(circle at 28% 28%, var(--text-bright) 0%, var(--color-accent-fg) 55%, var(--color-border-strong) 100%);
     box-shadow:
       0 0 10px color-mix(in oklab, var(--text-bright) 22%, transparent),
       inset 0 0 0 1px color-mix(in oklab, var(--text-bright) 12%, transparent);
@@ -258,7 +258,7 @@ stylesheet
   }
 
   .moon_sep {
-    color: var(--border-highlight);
+    color: var(--color-border-strong);
     font-variant: normal;
   }
 
@@ -267,12 +267,12 @@ stylesheet
     font-size: 11px;
     font-variant: normal;
     letter-spacing: 0.04em;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
   }
 
   .moon_tail {
     margin-left: auto;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-variant: normal;
     font-size: 11px;
     letter-spacing: 0.2em;
@@ -284,8 +284,8 @@ stylesheet
     align-items: center;
     gap: 12px;
     padding: 8px 12px;
-    background: var(--bg-panel);
-    border: 1px solid var(--border-main);
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
     border-radius: 2px;
     flex-wrap: wrap;
   }
@@ -294,9 +294,9 @@ stylesheet
     display: inline-flex;
     gap: 4px;
     padding: 2px;
-    border: 1px solid var(--border-main);
+    border: 1px solid var(--color-border-default);
     border-radius: 999px;
-    background: var(--bg-deep);
+    background: var(--color-bg-page);
   }
 
   .chip {
@@ -306,17 +306,17 @@ stylesheet
     text-transform: uppercase;
     padding: 7px 12px;
     border-radius: 999px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     cursor: pointer;
     transition: background 0.18s, color 0.18s;
   }
 
-  .chip:hover { color: var(--text-primary); }
-  .chip:focus-visible { outline: 2px solid var(--accent-brass); outline-offset: 1px; }
+  .chip:hover { color: var(--color-fg-primary); }
+  .chip:focus-visible { outline: 2px solid var(--color-accent-fg); outline-offset: 1px; }
   .chip_active {
     color: var(--text-bright);
-    background: color-mix(in oklab, var(--accent-brass) 14%, transparent);
-    box-shadow: inset 0 0 0 1px var(--accent-brass);
+    background: color-mix(in oklab, var(--color-accent-fg) 14%, transparent);
+    box-shadow: inset 0 0 0 1px var(--color-accent-fg);
   }
 
   /* Declarative active state for filter chips — theme chip 패턴과 동일.
@@ -328,8 +328,8 @@ stylesheet
   html[data-log-level="error"] .chip[data-filter-level="error"],
   html:not([data-log-level])   .chip[data-filter-level="info"] {
     color: var(--text-bright);
-    background: color-mix(in oklab, var(--accent-brass) 14%, transparent);
-    box-shadow: inset 0 0 0 1px var(--accent-brass);
+    background: color-mix(in oklab, var(--color-accent-fg) 14%, transparent);
+    box-shadow: inset 0 0 0 1px var(--color-accent-fg);
   }
 
   .input_shell {
@@ -337,16 +337,16 @@ stylesheet
     align-items: center;
     gap: 6px;
     padding: 4px 10px;
-    border: 1px solid var(--border-main);
+    border: 1px solid var(--color-border-default);
     border-radius: 2px;
-    background: var(--bg-deep);
+    background: var(--color-bg-page);
     font-family: 'Noto Sans KR', -apple-system, sans-serif;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
-  .input_shell_label { letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-dim); font-size: 11px; }
-  .input_shell_value { font-family: 'JetBrains Mono', ui-monospace, Menlo, monospace; font-size: 11px; color: var(--text-primary); }
+  .input_shell_label { letter-spacing: 0.2em; text-transform: uppercase; color: var(--color-fg-muted); font-size: 11px; }
+  .input_shell_value { font-family: 'JetBrains Mono', ui-monospace, Menlo, monospace; font-size: 11px; color: var(--color-fg-primary); }
 
   .toolbar_spacer { flex: 1; }
 
@@ -356,21 +356,21 @@ stylesheet
     letter-spacing: 0.2em;
     text-transform: uppercase;
     padding: 7px 12px;
-    border: 1px solid var(--border-main);
+    border: 1px solid var(--color-border-default);
     border-radius: 2px;
     background: transparent;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     cursor: pointer;
     transition: color 0.18s, border-color 0.18s;
   }
-  .btn_ghost:hover { color: var(--accent-brass); border-color: var(--border-highlight); }
-  .btn_ghost:focus-visible { outline: 2px solid var(--accent-brass); outline-offset: -2px; }
+  .btn_ghost:hover { color: var(--color-accent-fg); border-color: var(--color-border-strong); }
+  .btn_ghost:focus-visible { outline: 2px solid var(--color-accent-fg); outline-offset: -2px; }
 
   .header {
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
-    border-bottom: 1px solid var(--border-main);
+    border-bottom: 1px solid var(--color-border-default);
     padding-bottom: 0.75rem;
     gap: 1rem;
   }
@@ -382,7 +382,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.25em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     margin: 0 0 0.25rem 0;
   }
 
@@ -406,11 +406,11 @@ stylesheet
     font-weight: 600;
     letter-spacing: 0;
     text-transform: uppercase;
-    background: linear-gradient(180deg, var(--text-bright) 0%, var(--accent-brass) 55%, var(--border-highlight) 100%);
+    background: linear-gradient(180deg, var(--text-bright) 0%, var(--color-accent-fg) 55%, var(--color-border-strong) 100%);
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
-    text-shadow: 0 0 18px color-mix(in oklab, var(--accent-brass) 28%, transparent);
+    text-shadow: 0 0 18px color-mix(in oklab, var(--color-accent-fg) 28%, transparent);
     margin-right: 4px;
     align-self: flex-start;
     padding-top: 6px;
@@ -421,14 +421,14 @@ stylesheet
     font-weight: 400;
     font-size: 1rem;
     letter-spacing: 0.3em;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     text-transform: uppercase;
   }
 
   .title_rule {
     flex: 1;
     height: 1px;
-    background: linear-gradient(90deg, var(--border-highlight) 0%, transparent 100%);
+    background: linear-gradient(90deg, var(--color-border-strong) 0%, transparent 100%);
     margin-left: 10px;
     margin-right: 10px;
     align-self: center;
@@ -439,7 +439,7 @@ stylesheet
     font-variant-numeric: tabular-nums;
     font-size: 11px;
     letter-spacing: 0.08em;
-    color: var(--border-highlight);
+    color: var(--color-border-strong);
     text-transform: none;
   }
 
@@ -448,7 +448,7 @@ stylesheet
     font-variant-numeric: tabular-nums;
     font-size: 11px;
     letter-spacing: 0.1em;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
   }
 
   .tape {
@@ -470,8 +470,8 @@ stylesheet
     width: 1px;
     background: linear-gradient(180deg,
       transparent 0%,
-      var(--border-highlight) 6%,
-      var(--border-main) 92%,
+      var(--color-border-strong) 6%,
+      var(--color-border-default) 92%,
       transparent 100%);
     pointer-events: none;
     z-index: 0;
@@ -485,7 +485,7 @@ stylesheet
     right: 0;
     top: 0;
     height: 28px;
-    background: linear-gradient(180deg, var(--bg-deep) 0%, transparent 100%);
+    background: linear-gradient(180deg, var(--color-bg-page) 0%, transparent 100%);
     pointer-events: none;
     z-index: 2;
   }
@@ -496,7 +496,7 @@ stylesheet
   .tape_end {
     position: relative;
     height: 32px;
-    background: linear-gradient(180deg, transparent 0%, var(--bg-deep) 100%);
+    background: linear-gradient(180deg, transparent 0%, var(--color-bg-page) 100%);
     margin-top: -8px;
     pointer-events: none;
   }
@@ -506,8 +506,8 @@ stylesheet
     grid-template-columns: 1.75rem 10rem 5rem 9rem 7.5rem minmax(0, 1fr);
     gap: 1rem;
     padding: 0.625rem 0.75rem;
-    border-bottom: 1px dashed var(--border-main);
-    border-left: 2px solid var(--border-main);
+    border-bottom: 1px dashed var(--color-border-default);
+    border-left: 2px solid var(--color-border-default);
     align-items: baseline;
     transition: background 0.18s ease, box-shadow 0.18s ease, border-left-color 0.18s ease;
   }
@@ -516,25 +516,25 @@ stylesheet
     width: 22px;
     height: 22px;
     border-radius: 50%;
-    border: 1px solid var(--accent-brass);
+    border: 1px solid var(--color-accent-fg);
     background:
       radial-gradient(circle at 35% 30%, color-mix(in oklab, var(--text-bright) 18%, transparent), transparent 55%),
-      var(--bg-panel);
+      var(--color-bg-surface);
     display: grid;
     place-items: center;
     font-family: 'Cinzel', serif;
     font-size: 11px;
     letter-spacing: 0;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     text-transform: uppercase;
     box-shadow:
       inset 0 0 0 1px color-mix(in oklab, var(--text-bright) 6%, transparent),
-      0 0 6px color-mix(in oklab, var(--accent-brass) 18%, transparent);
+      0 0 6px color-mix(in oklab, var(--color-accent-fg) 18%, transparent);
     align-self: center;
   }
 
-  .sigil_warn  { color: var(--status-warn); border-color: var(--status-warn); box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--text-bright) 6%, transparent), 0 0 8px color-mix(in oklab, var(--accent-brass) 35%, transparent); }
-  .sigil_error { color: var(--text-bright); border-color: var(--accent-blood); background: radial-gradient(circle at 35% 30%, color-mix(in oklab, var(--text-bright) 28%, transparent), transparent 55%), color-mix(in oklab, var(--accent-blood) 25%, var(--bg-deep)); box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--text-bright) 8%, transparent), 0 0 10px color-mix(in oklab, var(--accent-blood) 45%, transparent); }
+  .sigil_warn  { color: var(--color-status-warn); border-color: var(--color-status-warn); box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--text-bright) 6%, transparent), 0 0 8px color-mix(in oklab, var(--color-accent-fg) 35%, transparent); }
+  .sigil_error { color: var(--text-bright); border-color: var(--accent-blood); background: radial-gradient(circle at 35% 30%, color-mix(in oklab, var(--text-bright) 28%, transparent), transparent 55%), color-mix(in oklab, var(--accent-blood) 25%, var(--color-bg-page)); box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--text-bright) 8%, transparent), 0 0 10px color-mix(in oklab, var(--accent-blood) 45%, transparent); }
 
   .message_lead::first-letter {
     font-family: 'Cinzel', 'EB Garamond', serif;
@@ -544,20 +544,20 @@ stylesheet
     float: left;
     padding: 2px 8px 0 0;
     margin-top: 2px;
-    background: linear-gradient(180deg, var(--text-bright) 0%, var(--accent-brass) 55%, var(--border-highlight) 100%);
+    background: linear-gradient(180deg, var(--text-bright) 0%, var(--color-accent-fg) 55%, var(--color-border-strong) 100%);
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
-    text-shadow: 0 0 14px color-mix(in oklab, var(--accent-brass) 25%, transparent);
+    text-shadow: 0 0 14px color-mix(in oklab, var(--color-accent-fg) 25%, transparent);
   }
 
-  .row_debug { border-left-color: var(--status-idle); }
+  .row_debug { border-left-color: var(--color-status-idle); }
   .row_info  { border-left-color: var(--accent-mold); }
 
   .row:hover {
-    background: linear-gradient(90deg, color-mix(in oklab, var(--accent-brass) 8%, transparent), transparent 70%);
-    box-shadow: inset 1px 0 0 0 color-mix(in oklab, var(--accent-brass) 35%, transparent);
-    border-left-color: var(--accent-brass);
+    background: linear-gradient(90deg, color-mix(in oklab, var(--color-accent-fg) 8%, transparent), transparent 70%);
+    box-shadow: inset 1px 0 0 0 color-mix(in oklab, var(--color-accent-fg) 35%, transparent);
+    border-left-color: var(--color-accent-fg);
   }
 
   .row_error {
@@ -572,13 +572,13 @@ stylesheet
   }
 
   .row_warn {
-    background: linear-gradient(90deg, color-mix(in oklab, var(--accent-brass) 6%, transparent) 0%, transparent 60%);
-    border-left-color: var(--status-warn);
+    background: linear-gradient(90deg, color-mix(in oklab, var(--color-accent-fg) 6%, transparent) 0%, transparent 60%);
+    border-left-color: var(--color-status-warn);
   }
 
   .row_warn:hover {
-    background: linear-gradient(90deg, color-mix(in oklab, var(--accent-brass) 15%, transparent) 0%, transparent 65%);
-    box-shadow: inset 1px 0 0 0 color-mix(in oklab, var(--accent-brass) 50%, transparent);
+    background: linear-gradient(90deg, color-mix(in oklab, var(--color-accent-fg) 15%, transparent) 0%, transparent 65%);
+    box-shadow: inset 1px 0 0 0 color-mix(in oklab, var(--color-accent-fg) 50%, transparent);
     border-left-color: var(--accent-ember);
   }
 
@@ -589,7 +589,7 @@ stylesheet
     font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
     font-variant-numeric: tabular-nums;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .ts_rel {
@@ -597,7 +597,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .level {
@@ -608,15 +608,15 @@ stylesheet
     font-weight: 500;
   }
 
-  .level_debug { color: var(--text-dim); }
-  .level_info  { color: var(--text-primary); }
-  .level_warn  { color: var(--status-warn); }
+  .level_debug { color: var(--color-fg-muted); }
+  .level_info  { color: var(--color-fg-primary); }
+  .level_warn  { color: var(--color-status-warn); }
   .level_error { color: var(--accent-blood); text-shadow: 0 0 12px color-mix(in oklab, var(--accent-blood) 32%, transparent); }
 
   .mod_col {
     font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .source_badge {
@@ -628,10 +628,10 @@ stylesheet
     letter-spacing: 0.2em;
     text-transform: uppercase;
     padding: 3px 8px;
-    border: 1px solid var(--border-main);
+    border: 1px solid var(--color-border-default);
     border-radius: 999px;
-    background: var(--bg-panel-alt);
-    color: var(--text-dim);
+    background: var(--color-bg-panel-alt);
+    color: var(--color-fg-muted);
     width: fit-content;
     height: fit-content;
   }
@@ -640,16 +640,16 @@ stylesheet
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--text-dim);
+    background: var(--color-fg-muted);
     display: inline-block;
   }
 
-  .dot_ok    { background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); }
-  .dot_warn  { background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
+  .dot_ok    { background: var(--color-status-ok); box-shadow: 0 0 6px var(--color-status-ok); }
+  .dot_warn  { background: var(--color-status-warn); box-shadow: 0 0 6px var(--color-status-warn); }
   .dot_bad   { background: var(--accent-blood); box-shadow: 0 0 6px var(--accent-blood); }
 
   .message {
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
     font-size: 14px;
     line-height: 1.5;
@@ -657,7 +657,7 @@ stylesheet
   }
 
   .details {
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
     font-size: 11px;
     line-height: 1.45;
@@ -666,7 +666,7 @@ stylesheet
   }
 
   .empty {
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-family: 'EB Garamond', Georgia, serif;
     font-style: italic;
     padding: 3rem 0 4rem;
@@ -683,7 +683,7 @@ stylesheet
     text-transform: uppercase;
     font-family: 'Noto Sans KR', -apple-system, sans-serif;
     font-style: normal;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   /* Wrapper kept for backward compatibility with the existing render
@@ -702,14 +702,14 @@ stylesheet
     width: 56px;
     height: 56px;
     border-radius: 50%;
-    background: radial-gradient(circle at 32% 28%, var(--accent-viscera) 0%, var(--accent-blood) 40%, color-mix(in oklab, var(--accent-blood) 50%, var(--bg-deep)) 80%, color-mix(in oklab, var(--accent-blood) 20%, var(--bg-deep)) 100%);
-    border: 2px solid var(--accent-brass);
+    background: radial-gradient(circle at 32% 28%, var(--accent-viscera) 0%, var(--accent-blood) 40%, color-mix(in oklab, var(--accent-blood) 50%, var(--color-bg-page)) 80%, color-mix(in oklab, var(--accent-blood) 20%, var(--color-bg-page)) 100%);
+    border: 2px solid var(--color-accent-fg);
     box-shadow:
       inset 0 0 0 1px color-mix(in oklab, var(--text-bright) 18%, transparent),
-      inset -6px -8px 14px color-mix(in oklab, var(--bg-deep) 55%, transparent),
+      inset -6px -8px 14px color-mix(in oklab, var(--color-bg-page) 55%, transparent),
       inset 5px 4px 10px color-mix(in oklab, var(--text-bright) 15%, transparent),
       0 6px 14px color-mix(in oklab, var(--accent-blood) 35%, transparent),
-      0 0 22px color-mix(in oklab, var(--accent-brass) 22%, transparent);
+      0 0 22px color-mix(in oklab, var(--color-accent-fg) 22%, transparent);
     transform: rotate(-14deg);
     z-index: 4;
     pointer-events: none;
@@ -720,7 +720,7 @@ stylesheet
     color: var(--text-bright);
     font-size: 22px;
     letter-spacing: 0.04em;
-    text-shadow: 0 1px 0 color-mix(in oklab, var(--bg-deep) 60%, transparent), 0 0 8px color-mix(in oklab, var(--text-bright) 35%, transparent);
+    text-shadow: 0 1px 0 color-mix(in oklab, var(--color-bg-page) 60%, transparent), 0 0 8px color-mix(in oklab, var(--text-bright) 35%, transparent);
   }
 
   .signet::before {
@@ -742,7 +742,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.3em;
     text-transform: uppercase;
-    color: var(--border-highlight);
+    color: var(--color-border-strong);
     white-space: nowrap;
   }
 
@@ -756,9 +756,9 @@ stylesheet
     width: 220px;
     height: 100vh;
     padding: 18px 0 24px;
-    background: linear-gradient(180deg, var(--bg-panel) 0%, var(--bg-deep) 100%);
-    border-right: 1px solid var(--border-main);
-    box-shadow: inset -1px 0 0 color-mix(in oklab, var(--accent-brass) 8%, transparent);
+    background: linear-gradient(180deg, var(--color-bg-surface) 0%, var(--color-bg-page) 100%);
+    border-right: 1px solid var(--color-border-default);
+    box-shadow: inset -1px 0 0 color-mix(in oklab, var(--color-accent-fg) 8%, transparent);
     display: flex;
     flex-direction: column;
     overflow-y: auto;
@@ -770,14 +770,14 @@ stylesheet
     align-items: center;
     gap: 10px;
     padding: 4px 18px 18px;
-    border-bottom: 1px solid var(--border-main);
+    border-bottom: 1px solid var(--color-border-default);
     margin-bottom: 12px;
   }
   .nav_brand_rune {
     width: 18px;
     height: 18px;
-    border: 1px solid var(--accent-brass);
-    color: var(--accent-brass);
+    border: 1px solid var(--color-accent-fg);
+    color: var(--color-accent-fg);
     display: grid;
     place-items: center;
     font-family: 'Cinzel', serif;
@@ -800,7 +800,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.25em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     display: flex;
     align-items: center;
     gap: 10px;
@@ -809,7 +809,7 @@ stylesheet
     content: "";
     flex: 1;
     height: 1px;
-    background: linear-gradient(90deg, var(--border-highlight), transparent);
+    background: linear-gradient(90deg, var(--color-border-strong), transparent);
   }
 
   .nav_link {
@@ -817,7 +817,7 @@ stylesheet
     align-items: center;
     gap: 11px;
     padding: 14px 18px;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     font-family: 'Noto Sans KR', sans-serif;
     font-size: 11px;
     letter-spacing: 0.1em;
@@ -827,31 +827,31 @@ stylesheet
     user-select: none;
   }
   .nav_link:hover {
-    color: var(--accent-brass);
-    background: color-mix(in oklab, var(--accent-brass) 5%, transparent);
+    color: var(--color-accent-fg);
+    background: color-mix(in oklab, var(--color-accent-fg) 5%, transparent);
   }
   .nav_link:focus-visible {
-    outline: 2px solid var(--accent-brass);
+    outline: 2px solid var(--color-accent-fg);
     outline-offset: -2px;
   }
   .nav_link_active {
-    color: var(--accent-brass);
-    border-left-color: var(--accent-brass);
-    background: linear-gradient(90deg, color-mix(in oklab, var(--accent-brass) 10%, transparent), transparent 70%);
+    color: var(--color-accent-fg);
+    border-left-color: var(--color-accent-fg);
+    background: linear-gradient(90deg, color-mix(in oklab, var(--color-accent-fg) 10%, transparent), transparent 70%);
   }
   .nav_link_glyph {
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--border-highlight);
+    background: var(--color-border-strong);
     flex-shrink: 0;
   }
   .nav_link_active .nav_link_glyph {
-    background: var(--accent-brass);
-    box-shadow: 0 0 6px var(--accent-brass);
+    background: var(--color-accent-fg);
+    box-shadow: 0 0 6px var(--color-accent-fg);
   }
   .nav_link_soon {
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-style: italic;
   }
   .nav_link_tail {
@@ -865,14 +865,14 @@ stylesheet
   .nav_foot {
     margin-top: auto;
     padding: 14px 18px 0;
-    border-top: 1px solid var(--border-main);
+    border-top: 1px solid var(--color-border-default);
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
     letter-spacing: 0.16em;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     text-transform: uppercase;
   }
-  .nav_foot_v { color: var(--text-dim); }
+  .nav_foot_v { color: var(--color-fg-muted); }
 
   /* ─── theme chips ───
      클릭 시 location.hash 를 바꾸면 bin/main.ml 의 hashchange listener가
@@ -892,23 +892,23 @@ stylesheet
     letter-spacing: 0.22em;
     text-transform: uppercase;
     padding: 7px 8px;
-    background: var(--bg-panel);
-    border: 1px solid var(--border-main);
-    color: var(--text-dim);
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    color: var(--color-fg-muted);
     cursor: pointer;
     user-select: none;
     border-radius: 1px;
   }
   .theme_chip:hover {
-    border-color: var(--accent-brass-dim);
-    color: var(--accent-brass);
+    border-color: var(--color-accent-fg-dim);
+    color: var(--color-accent-fg);
   }
-  .theme_chip:focus-visible { outline: 2px solid var(--accent-brass); outline-offset: 1px; }
+  .theme_chip:focus-visible { outline: 2px solid var(--color-accent-fg); outline-offset: 1px; }
   .theme_chip_active {
-    border-color: var(--accent-brass);
-    color: var(--accent-brass);
-    background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
-    box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent-brass) 25%, transparent) inset;
+    border-color: var(--color-accent-fg);
+    color: var(--color-accent-fg);
+    background: linear-gradient(180deg, var(--color-bg-surface), var(--color-bg-page));
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--color-accent-fg) 25%, transparent) inset;
   }
 
   /* active chip via declarative CSS only — listener가 <html data-theme>
@@ -919,10 +919,10 @@ stylesheet
   html[data-theme="terminal"]     .theme_chip[data-chip-theme="term"],
   html[data-theme="parchment"]    .theme_chip[data-chip-theme="parchment"],
   html[data-theme="paper"]        .theme_chip[data-chip-theme="paper"] {
-    border-color: var(--accent-brass);
-    color: var(--accent-brass);
-    background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
-    box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent-brass) 25%, transparent) inset;
+    border-color: var(--color-accent-fg);
+    color: var(--color-accent-fg);
+    background: linear-gradient(180deg, var(--color-bg-surface), var(--color-bg-page));
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--color-accent-fg) 25%, transparent) inset;
   }
 
   /* ─── right aside (340px, fixed) ───
@@ -935,9 +935,9 @@ stylesheet
     width: 340px;
     height: 100vh;
     padding: 22px 18px 28px;
-    background: linear-gradient(180deg, var(--bg-panel) 0%, var(--bg-deep) 100%);
-    border-left: 1px solid var(--border-main);
-    box-shadow: inset 1px 0 0 color-mix(in oklab, var(--accent-brass) 6%, transparent);
+    background: linear-gradient(180deg, var(--color-bg-surface) 0%, var(--color-bg-page) 100%);
+    border-left: 1px solid var(--color-border-default);
+    box-shadow: inset 1px 0 0 color-mix(in oklab, var(--color-accent-fg) 6%, transparent);
     display: flex;
     flex-direction: column;
     gap: 22px;
@@ -949,7 +949,7 @@ stylesheet
     font-family: 'Cinzel', serif;
     font-size: 11px;
     letter-spacing: 0.28em;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     text-transform: uppercase;
     margin: 0 0 10px;
     display: flex;
@@ -960,12 +960,12 @@ stylesheet
     content: "";
     flex: 1;
     height: 1px;
-    background: linear-gradient(90deg, var(--border-highlight), transparent);
+    background: linear-gradient(90deg, var(--color-border-strong), transparent);
   }
   .aside_h_tail {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     margin-left: auto;
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.04em;
@@ -976,14 +976,14 @@ stylesheet
   .focus {
     position: relative;
     padding: 16px 16px 14px;
-    background: linear-gradient(180deg, var(--bg-panel-alt) 0%, var(--bg-panel) 100%);
-    border: 1px solid var(--accent-brass-dim);
+    background: linear-gradient(180deg, var(--color-bg-panel-alt) 0%, var(--color-bg-surface) 100%);
+    border: 1px solid var(--color-accent-fg-dim);
   }
   .focus::before {
     content: "";
     position: absolute;
     inset: 3px;
-    border: 1px solid var(--border-highlight);
+    border: 1px solid var(--color-border-strong);
     pointer-events: none;
   }
   .focus_who {
@@ -995,20 +995,20 @@ stylesheet
   .focus_portrait {
     width: 46px;
     height: 46px;
-    border: 1px solid var(--accent-brass);
-    background: linear-gradient(135deg, var(--bg-panel-alt), var(--bg-deep));
+    border: 1px solid var(--color-accent-fg);
+    background: linear-gradient(135deg, var(--color-bg-panel-alt), var(--color-bg-page));
     display: grid;
     place-items: center;
     font-family: 'Cinzel', serif;
     font-size: 18px;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     flex-shrink: 0;
   }
   .focus_name_col { flex: 1; }
   .focus_name {
     font-family: 'Cinzel', serif;
     font-size: 16px;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     letter-spacing: 0.16em;
     text-transform: uppercase;
   }
@@ -1016,7 +1016,7 @@ stylesheet
     font-family: 'EB Garamond', Georgia, serif;
     font-style: italic;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     margin-top: 2px;
   }
 
@@ -1026,15 +1026,15 @@ stylesheet
     justify-content: space-between;
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     margin-bottom: 4px;
     font-variant-numeric: tabular-nums;
   }
   .ctx_lbl_v { color: var(--text-bright); }
   .vial {
     height: 8px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-main);
+    background: var(--color-bg-page);
+    border: 1px solid var(--color-border-default);
     position: relative;
     overflow: hidden;
   }
@@ -1042,14 +1042,14 @@ stylesheet
     display: block;
     height: 100%;
     width: 64%;
-    background: linear-gradient(90deg, var(--accent-brass-dim), var(--accent-brass));
-    box-shadow: 0 0 6px color-mix(in oklab, var(--accent-brass) 45%, transparent);
+    background: linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg));
+    box-shadow: 0 0 6px color-mix(in oklab, var(--color-accent-fg) 45%, transparent);
   }
   .vial::after {
     content: "";
     position: absolute;
     inset: 0;
-    background-image: repeating-linear-gradient(90deg, transparent 0 19px, color-mix(in oklab, var(--bg-deep) 50%, transparent) 19px 20px);
+    background-image: repeating-linear-gradient(90deg, transparent 0 19px, color-mix(in oklab, var(--color-bg-page) 50%, transparent) 19px 20px);
     pointer-events: none;
   }
 
@@ -1064,7 +1064,7 @@ stylesheet
     font-family: 'Noto Sans KR', sans-serif;
     font-size: 11px;
     letter-spacing: 0.18em;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     text-transform: uppercase;
   }
   .focus_stat_v {
@@ -1082,14 +1082,14 @@ stylesheet
     grid-template-columns: 52px 12px 1fr;
     gap: 10px;
     padding: 8px 0;
-    border-bottom: 1px dashed var(--border-main);
+    border-bottom: 1px dashed var(--color-border-default);
     align-items: baseline;
   }
   .evrow:last-child { border-bottom: 0; }
   .evrow_t {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-variant-numeric: tabular-nums;
   }
   .evrow_mk {
@@ -1098,25 +1098,25 @@ stylesheet
     border-radius: 50%;
     align-self: center;
     justify-self: center;
-    background: var(--accent-brass-dim);
+    background: var(--color-accent-fg-dim);
   }
-  .evrow_ok  .evrow_mk { background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); }
-  .evrow_warn .evrow_mk { background: var(--accent-brass); box-shadow: 0 0 6px var(--accent-brass); }
+  .evrow_ok  .evrow_mk { background: var(--color-status-ok); box-shadow: 0 0 6px var(--color-status-ok); }
+  .evrow_warn .evrow_mk { background: var(--color-accent-fg); box-shadow: 0 0 6px var(--color-accent-fg); }
   .evrow_bad  .evrow_mk { background: var(--accent-blood); box-shadow: 0 0 6px var(--accent-blood); }
   .evrow_b {
     font-family: 'EB Garamond', Georgia, serif;
     font-size: 12px;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     line-height: 1.45;
   }
   .evrow_b_em { color: var(--text-bright); font-style: italic; }
   .evrow_b_code {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--accent-brass);
-    background: color-mix(in oklab, var(--accent-brass) 8%, transparent);
+    color: var(--color-accent-fg);
+    background: color-mix(in oklab, var(--color-accent-fg) 8%, transparent);
     padding: 0 5px;
-    border: 1px solid var(--border-main);
+    border: 1px solid var(--color-border-default);
   }
   .evrow_bad .evrow_b_code {
     color: var(--accent-blood);
@@ -1145,7 +1145,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.3em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     display: flex;
     align-items: center;
     gap: 10px;
@@ -1154,7 +1154,7 @@ stylesheet
     content: "";
     flex: 0 0 40px;
     height: 1px;
-    background: var(--border-highlight);
+    background: var(--color-border-strong);
   }
   .page_h1 {
     font-family: 'Cinzel', 'Noto Sans KR', serif;
@@ -1170,17 +1170,17 @@ stylesheet
     text-shadow: 0 0 18px color-mix(in oklab, var(--accent-blood) 32%, transparent);
   }
   .page_h1_brass {
-    color: var(--accent-brass);
-    text-shadow: 0 0 18px color-mix(in oklab, var(--accent-brass) 32%, transparent);
+    color: var(--color-accent-fg);
+    text-shadow: 0 0 18px color-mix(in oklab, var(--color-accent-fg) 32%, transparent);
   }
   .page_h1_bright {
     color: var(--text-bright);
-    text-shadow: 0 0 18px color-mix(in oklab, var(--text-primary) 24%, transparent);
+    text-shadow: 0 0 18px color-mix(in oklab, var(--color-fg-primary) 24%, transparent);
   }
   .page_sub {
     font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
     font-style: italic;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     margin-top: 6px;
     font-size: 14px;
     max-width: 540px;
@@ -1197,9 +1197,9 @@ stylesheet
     letter-spacing: 0.24em;
     text-transform: uppercase;
     padding: 7px 12px;
-    background: linear-gradient(180deg, var(--bg-panel-alt) 0%, var(--bg-panel) 100%);
-    border: 1px solid var(--accent-brass-dim);
-    color: var(--text-primary);
+    background: linear-gradient(180deg, var(--color-bg-panel-alt) 0%, var(--color-bg-surface) 100%);
+    border: 1px solid var(--color-accent-fg-dim);
+    color: var(--color-fg-primary);
     cursor: default;
     user-select: none;
     display: inline-flex;
@@ -1207,17 +1207,17 @@ stylesheet
     gap: 6px;
   }
   .pbtn:hover {
-    border-color: var(--accent-brass);
-    color: var(--accent-brass);
+    border-color: var(--color-accent-fg);
+    color: var(--color-accent-fg);
   }
-  .pbtn:focus-visible { outline: 2px solid var(--accent-brass); outline-offset: -2px; }
+  .pbtn:focus-visible { outline: 2px solid var(--color-accent-fg); outline-offset: -2px; }
   .pbtn_primary {
-    background: linear-gradient(180deg, color-mix(in oklab, var(--accent-brass) 20%, var(--bg-panel)) 0%, color-mix(in oklab, var(--accent-brass) 10%, var(--bg-deep)) 100%);
-    border-color: var(--accent-brass);
-    color: var(--accent-brass);
+    background: linear-gradient(180deg, color-mix(in oklab, var(--color-accent-fg) 20%, var(--color-bg-surface)) 0%, color-mix(in oklab, var(--color-accent-fg) 10%, var(--color-bg-page)) 100%);
+    border-color: var(--color-accent-fg);
+    color: var(--color-accent-fg);
   }
   .pbtn_primary:hover {
-    background: color-mix(in oklab, var(--accent-brass) 12%, transparent);
+    background: color-mix(in oklab, var(--color-accent-fg) 12%, transparent);
     color: var(--text-bright);
   }
   .pbtn_glyph {
@@ -1242,22 +1242,22 @@ stylesheet
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--accent-brass);
-    box-shadow: 0 0 6px color-mix(in oklab, var(--accent-brass) 35%, transparent);
+    background: var(--color-accent-fg);
+    box-shadow: 0 0 6px color-mix(in oklab, var(--color-accent-fg) 35%, transparent);
     align-self: center;
   }
   .sec_h {
     font-family: 'Cinzel', serif;
     font-size: 12px;
     letter-spacing: 0.26em;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     text-transform: uppercase;
     margin: 0;
   }
   .sec_sub {
     font-family: 'EB Garamond', Georgia, serif;
     font-style: italic;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-size: 12px;
   }
   .sec_hr {
@@ -1265,15 +1265,15 @@ stylesheet
     height: 1px;
     background: linear-gradient(
       90deg,
-      var(--border-highlight) 0%,
-      var(--border-main) 60%,
+      var(--color-border-strong) 0%,
+      var(--color-border-default) 60%,
       transparent 100%
     );
   }
   .sec_r {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.04em;
   }
@@ -1301,21 +1301,21 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.16em;
     text-transform: uppercase;
-    color: var(--text-dim);
-    border: 1px solid var(--border-main);
-    background: var(--bg-panel-alt);
+    color: var(--color-fg-muted);
+    border: 1px solid var(--color-border-default);
+    background: var(--color-bg-panel-alt);
   }
   .tomb_active {
-    color: var(--accent-brass);
-    border-color: var(--accent-brass);
-    background: linear-gradient(180deg, var(--bg-panel-alt), var(--bg-panel));
+    color: var(--color-accent-fg);
+    border-color: var(--color-accent-fg);
+    background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-surface));
   }
   .tomb_danger {
     color: var(--accent-blood);
     border-color: color-mix(in oklab, var(--accent-blood) 50%, transparent);
   }
   .tomb_dead {
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     text-decoration: line-through;
     text-decoration-color: var(--accent-blood);
   }
@@ -1340,10 +1340,10 @@ stylesheet
   }
 
   @media (prefers-contrast: more) {
-    .row { border-bottom-width: 1px; border-bottom-color: var(--text-dim); }
+    .row { border-bottom-width: 1px; border-bottom-color: var(--color-fg-muted); }
     .level, .source_badge { border-width: 2px; }
     .level_error { border-color: var(--accent-blood); }
-    .level_warn  { border-color: var(--status-warn); }
+    .level_warn  { border-color: var(--color-status-warn); }
     .filter_bar { border-width: 2px; border-color: var(--text-bright); }
     .search_input { border-width: 2px; border-color: var(--text-bright); }
     .chip, .btn_ghost { border-width: 2px; border-color: var(--text-bright); }

--- a/dashboard_bonsai/src/meta.ml
+++ b/dashboard_bonsai/src/meta.ml
@@ -20,15 +20,15 @@ stylesheet
     flex-wrap: wrap;
     gap: 24px;
     padding: 12px 16px;
-    border: 1px solid var(--border-main, #3a2e20);
+    border: 1px solid var(--color-border-default, #3a2e20);
     background: linear-gradient(
       180deg,
-      color-mix(in oklab, var(--bg-card) 35%, transparent),
-      color-mix(in oklab, var(--bg-deep) 65%, transparent)
+      color-mix(in oklab, var(--color-bg-elevated) 35%, transparent),
+      color-mix(in oklab, var(--color-bg-page) 65%, transparent)
     );
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim, #9a846e);
+    color: var(--color-fg-muted, #9a846e);
   }
 
   .item { display: flex; align-items: baseline; gap: 8px; }
@@ -38,7 +38,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: var(--text-dim, #9a846e);
+    color: var(--color-fg-muted, #9a846e);
   }
 
   .v {
@@ -46,8 +46,8 @@ stylesheet
     color: var(--text-bright, #e8d9b0);
   }
 
-  .v_ok    { color: var(--status-ok, #6a9a4a); font-variant-numeric: tabular-nums; }
-  .v_brass { color: var(--accent-brass, #968228); font-variant-numeric: tabular-nums; }
+  .v_ok    { color: var(--color-status-ok, #6a9a4a); font-variant-numeric: tabular-nums; }
+  .v_brass { color: var(--color-accent-fg, #968228); font-variant-numeric: tabular-nums; }
   .v_blood { color: var(--accent-blood, #e85050); font-variant-numeric: tabular-nums; }
 
   @media (prefers-contrast: more) {

--- a/dashboard_bonsai/src/pill.ml
+++ b/dashboard_bonsai/src/pill.ml
@@ -33,9 +33,9 @@ stylesheet
     text-transform: uppercase;
     padding: 4px 8px;
     text-align: center;
-    border: 1px solid var(--border-main, #3a2e20);
+    border: 1px solid var(--color-border-default, #3a2e20);
     font-variant-numeric: tabular-nums;
-    color: var(--text-dim, #9a846e);
+    color: var(--color-fg-muted, #9a846e);
   }
 
   .pill_sm {
@@ -44,29 +44,29 @@ stylesheet
     letter-spacing: 0.16em;
     text-transform: uppercase;
     padding: 2px 6px;
-    border: 1px solid var(--border-main, #3a2e20);
+    border: 1px solid var(--color-border-default, #3a2e20);
     text-align: center;
-    color: var(--text-dim, #9a846e);
+    color: var(--color-fg-muted, #9a846e);
   }
 
-  .c_ok      { color: var(--status-ok, #6a9a4a); border-color: var(--status-ok, #6a9a4a); }
-  .c_warn    { color: var(--status-warn, #b87828); border-color: var(--status-warn, #b87828); }
+  .c_ok      { color: var(--color-status-ok, #6a9a4a); border-color: var(--color-status-ok, #6a9a4a); }
+  .c_warn    { color: var(--color-status-warn, #b87828); border-color: var(--color-status-warn, #b87828); }
   .c_bad     { color: var(--accent-blood, #e85050); border-color: var(--accent-blood, #e85050); }
-  .c_brass   { color: var(--accent-brass, #968228); border-color: var(--accent-brass, #968228); }
-  .c_paused  { color: var(--text-dim, #9a846e); border-color: var(--border-main, #3a2e20); }
-  .c_neutral { color: var(--text-dim, #9a846e); border-color: var(--border-main, #3a2e20); }
+  .c_brass   { color: var(--color-accent-fg, #968228); border-color: var(--color-accent-fg, #968228); }
+  .c_paused  { color: var(--color-fg-muted, #9a846e); border-color: var(--color-border-default, #3a2e20); }
+  .c_neutral { color: var(--color-fg-muted, #9a846e); border-color: var(--color-border-default, #3a2e20); }
 
   @media (prefers-contrast: more) {
     .pill_md, .pill_sm {
       border-width: 2px;
       border-color: var(--text-bright);
     }
-    .c_ok      { border-color: var(--status-ok); }
-    .c_warn    { border-color: var(--status-warn); }
+    .c_ok      { border-color: var(--color-status-ok); }
+    .c_warn    { border-color: var(--color-status-warn); }
     .c_bad     { border-color: var(--accent-blood); }
-    .c_brass   { border-color: var(--accent-brass); }
-    .c_paused  { border-color: var(--text-dim); }
-    .c_neutral { border-color: var(--text-dim); }
+    .c_brass   { border-color: var(--color-accent-fg); }
+    .c_paused  { border-color: var(--color-fg-muted); }
+    .c_neutral { border-color: var(--color-fg-muted); }
   }
 
   @media (forced-colors: active) {

--- a/dashboard_bonsai/src/placeholder_view.ml
+++ b/dashboard_bonsai/src/placeholder_view.ml
@@ -21,9 +21,9 @@ stylesheet
 
   .panel {
     min-height: 148px;
-    border: 1px solid var(--border-main);
+    border: 1px solid var(--color-border-default);
     background:
-      linear-gradient(180deg, color-mix(in oklab, var(--bg-panel) 68%, transparent), color-mix(in oklab, var(--bg-deep) 86%, transparent));
+      linear-gradient(180deg, color-mix(in oklab, var(--color-bg-surface) 68%, transparent), color-mix(in oklab, var(--color-bg-page) 86%, transparent));
     padding: 15px 16px;
     display: flex;
     flex-direction: column;
@@ -35,7 +35,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.28em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     margin: 0;
   }
 
@@ -43,7 +43,7 @@ stylesheet
     font-family: var(--font-body, 'EB Garamond', serif);
     font-size: 15px;
     line-height: 1.55;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     margin: 0;
   }
 
@@ -52,7 +52,7 @@ stylesheet
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
     line-height: 1.45;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     overflow-wrap: anywhere;
   }
 
@@ -62,9 +62,9 @@ stylesheet
     gap: 8px;
     align-items: center;
     padding: 14px 16px;
-    border: 1px solid var(--border-highlight);
+    border: 1px solid var(--color-border-strong);
     background:
-      linear-gradient(180deg, color-mix(in oklab, var(--bg-card) 40%, transparent), color-mix(in oklab, var(--bg-deep) 70%, transparent));
+      linear-gradient(180deg, color-mix(in oklab, var(--color-bg-elevated) 40%, transparent), color-mix(in oklab, var(--color-bg-page) 70%, transparent));
   }
 
   .btn {
@@ -73,9 +73,9 @@ stylesheet
     gap: 6px;
     min-height: 30px;
     padding: 7px 12px;
-    border: 1px solid var(--accent-brass-dim);
-    background: linear-gradient(180deg, color-mix(in oklab, var(--bg-panel) 80%, var(--bg-deep)), var(--bg-deep));
-    color: var(--text-primary);
+    border: 1px solid var(--color-accent-fg-dim);
+    background: linear-gradient(180deg, color-mix(in oklab, var(--color-bg-surface) 80%, var(--color-bg-page)), var(--color-bg-page));
+    color: var(--color-fg-primary);
     font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
     font-size: 11px;
     letter-spacing: 0.24em;
@@ -84,22 +84,22 @@ stylesheet
   }
 
   .btn:hover {
-    color: var(--accent-brass);
-    border-color: var(--accent-brass);
+    color: var(--color-accent-fg);
+    border-color: var(--color-accent-fg);
   }
-  .btn:focus-visible { outline: 2px solid var(--accent-brass); outline-offset: -2px; }
+  .btn:focus-visible { outline: 2px solid var(--color-accent-fg); outline-offset: -2px; }
 
   .btn_primary {
-    color: var(--accent-brass);
-    border-color: var(--accent-brass);
-    background: linear-gradient(180deg, color-mix(in oklab, var(--accent-brass) 20%, var(--bg-panel)), var(--bg-deep));
+    color: var(--color-accent-fg);
+    border-color: var(--color-accent-fg);
+    background: linear-gradient(180deg, color-mix(in oklab, var(--color-accent-fg) 20%, var(--color-bg-surface)), var(--color-bg-page));
   }
 
   .cta_note {
     margin-left: auto;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-variant-numeric: tabular-nums;
   }
 

--- a/dashboard_bonsai/src/roster.ml
+++ b/dashboard_bonsai/src/roster.ml
@@ -44,17 +44,17 @@ stylesheet
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: 1px;
-    background: var(--border-main);
-    border: 1px solid var(--border-main);
+    background: var(--color-border-default);
+    border: 1px solid var(--color-border-default);
     border-radius: 2px;
     box-shadow:
-      inset 0 0 0 1px color-mix(in oklab, var(--accent-brass) 6%, transparent),
-      0 -8px 24px -12px color-mix(in oklab, var(--bg-deep) 85%, transparent);
+      inset 0 0 0 1px color-mix(in oklab, var(--color-accent-fg) 6%, transparent),
+      0 -8px 24px -12px color-mix(in oklab, var(--color-bg-page) 85%, transparent);
     backdrop-filter: blur(2px);
   }
 
   .slot {
-    background: var(--bg-panel);
+    background: var(--color-bg-surface);
     padding: 10px 14px;
     display: flex;
     align-items: center;
@@ -65,15 +65,15 @@ stylesheet
     width: 26px;
     height: 26px;
     border-radius: 50%;
-    border: 1px solid var(--accent-brass);
-    background: radial-gradient(circle at 35% 30%, color-mix(in oklab, var(--text-bright) 22%, transparent), transparent 55%), var(--bg-panel);
+    border: 1px solid var(--color-accent-fg);
+    background: radial-gradient(circle at 35% 30%, color-mix(in oklab, var(--text-bright) 22%, transparent), transparent 55%), var(--color-bg-surface);
     display: grid;
     place-items: center;
     font-family: 'Cinzel', serif;
     font-size: 11px;
     color: var(--text-bright);
     text-transform: uppercase;
-    box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--text-bright) 8%, transparent), 0 0 8px color-mix(in oklab, var(--accent-brass) 22%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--text-bright) 8%, transparent), 0 0 8px color-mix(in oklab, var(--color-accent-fg) 22%, transparent);
     flex-shrink: 0;
   }
 
@@ -103,19 +103,19 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .dot {
     width: 5px;
     height: 5px;
     border-radius: 50%;
-    background: var(--text-dim);
+    background: var(--color-fg-muted);
   }
 
-  .dot_live     { background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); animation: roster_pulse 1.8s ease-in-out infinite; }
-  .dot_thinking { background: var(--accent-brass); box-shadow: 0 0 6px var(--accent-brass); animation: roster_pulse 1.2s ease-in-out infinite; }
-  .dot_idle     { background: var(--text-dim); }
+  .dot_live     { background: var(--color-status-ok); box-shadow: 0 0 6px var(--color-status-ok); animation: roster_pulse 1.8s ease-in-out infinite; }
+  .dot_thinking { background: var(--color-accent-fg); box-shadow: 0 0 6px var(--color-accent-fg); animation: roster_pulse 1.2s ease-in-out infinite; }
+  .dot_idle     { background: var(--color-fg-muted); }
   .dot_failed   { background: var(--accent-blood); box-shadow: 0 0 8px var(--accent-blood); }
 
   .when_ {
@@ -123,7 +123,7 @@ stylesheet
     font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
     font-variant-numeric: tabular-nums;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     flex-shrink: 0;
   }
 

--- a/dashboard_bonsai/src/sec.ml
+++ b/dashboard_bonsai/src/sec.ml
@@ -26,7 +26,7 @@ stylesheet
     font-family: var(--font-display, 'Cinzel', serif);
     font-size: 13px;
     letter-spacing: 0.26em;
-    color: var(--accent-brass, #968228);
+    color: var(--color-accent-fg, #968228);
     text-transform: uppercase;
     margin: 0;
     flex-shrink: 0;
@@ -34,7 +34,7 @@ stylesheet
   .sec_sub {
     font-family: var(--font-body, 'EB Garamond', serif);
     font-style: italic;
-    color: var(--text-dim, #9a846e);
+    color: var(--color-fg-muted, #9a846e);
     font-size: 13px;
     flex-shrink: 0;
   }
@@ -43,15 +43,15 @@ stylesheet
     height: 1px;
     background: linear-gradient(
       90deg,
-      var(--border-highlight, #5a3028) 0%,
-      var(--border-main, #2a1a14) 60%,
+      var(--color-border-strong, #5a3028) 0%,
+      var(--color-border-default, #2a1a14) 60%,
       transparent 100%
     );
   }
   .sec_right {
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
-    color: var(--text-dim, #9a846e);
+    color: var(--color-fg-muted, #9a846e);
     font-variant-numeric: tabular-nums;
     flex-shrink: 0;
   }

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -19,11 +19,11 @@ stylesheet
     grid-template-columns: 220px minmax(0, 1fr) 340px;
     grid-template-rows: 52px 1fr;
     min-height: 100vh;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     background:
-      radial-gradient(ellipse 60% 40% at 12% 8%, color-mix(in oklab, var(--accent-brass) 6%, transparent), transparent 55%),
+      radial-gradient(ellipse 60% 40% at 12% 8%, color-mix(in oklab, var(--color-accent-fg) 6%, transparent), transparent 55%),
       radial-gradient(ellipse 40% 50% at 92% 95%, color-mix(in oklab, var(--accent-blood) 8%, transparent), transparent 60%),
-      linear-gradient(170deg, var(--bg-deep) 0%, color-mix(in oklab, var(--bg-panel) 50%, var(--bg-deep)) 60%, var(--bg-deep) 100%);
+      linear-gradient(170deg, var(--color-bg-page) 0%, color-mix(in oklab, var(--color-bg-surface) 50%, var(--color-bg-page)) 60%, var(--color-bg-page) 100%);
     font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
   }
 
@@ -33,9 +33,9 @@ stylesheet
     align-items: center;
     gap: 18px;
     padding: 0 22px;
-    background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
-    border-bottom: 1px solid var(--border-highlight);
-    box-shadow: 0 2px 0 color-mix(in oklab, var(--bg-deep) 40%, transparent), inset 0 -1px 0 color-mix(in oklab, var(--accent-brass) 12%, transparent);
+    background: linear-gradient(180deg, var(--color-bg-surface), var(--color-bg-page));
+    border-bottom: 1px solid var(--color-border-strong);
+    box-shadow: 0 2px 0 color-mix(in oklab, var(--color-bg-page) 40%, transparent), inset 0 -1px 0 color-mix(in oklab, var(--color-accent-fg) 12%, transparent);
   }
 
   .brand {
@@ -48,8 +48,8 @@ stylesheet
   .brand_mark {
     width: 22px;
     height: 22px;
-    border: 1px solid var(--accent-brass-dim);
-    color: var(--accent-brass);
+    border: 1px solid var(--color-accent-fg-dim);
+    color: var(--color-accent-fg);
     display: grid;
     place-items: center;
     font-family: var(--font-display, 'Cinzel', serif);
@@ -78,7 +78,7 @@ stylesheet
     display: flex;
     align-items: center;
     gap: 10px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
     font-size: 11px;
     letter-spacing: 0.22em;
@@ -88,10 +88,10 @@ stylesheet
   }
 
   .crumbs_current {
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
   }
 
-  .sep { color: var(--border-highlight); }
+  .sep { color: var(--color-border-strong); }
 
   .top_right {
     margin-left: auto;
@@ -104,7 +104,7 @@ stylesheet
   .clock {
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 12px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.08em;
   }
@@ -123,20 +123,20 @@ stylesheet
     letter-spacing: 0.2em;
     text-transform: uppercase;
     padding: 4px 8px;
-    border: 1px solid var(--border-main);
-    color: var(--text-primary);
-    background: var(--bg-panel);
+    border: 1px solid var(--color-border-default);
+    color: var(--color-fg-primary);
+    background: var(--color-bg-surface);
     white-space: nowrap;
   }
 
   .pill_ok {
-    color: var(--status-ok);
-    border-color: color-mix(in oklab, var(--status-ok) 40%, transparent);
+    color: var(--color-status-ok);
+    border-color: color-mix(in oklab, var(--color-status-ok) 40%, transparent);
   }
 
   .pill_warn {
-    color: var(--accent-brass);
-    border-color: color-mix(in oklab, var(--accent-brass) 40%, transparent);
+    color: var(--color-accent-fg);
+    border-color: color-mix(in oklab, var(--color-accent-fg) 40%, transparent);
   }
 
   .pill_bad {
@@ -153,8 +153,8 @@ stylesheet
   }
 
   .nav {
-    background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
-    border-right: 1px solid var(--border-main);
+    background: linear-gradient(180deg, var(--color-bg-surface), var(--color-bg-page));
+    border-right: 1px solid var(--color-border-default);
     padding: 16px 0;
     display: flex;
     flex-direction: column;
@@ -167,7 +167,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.25em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     display: flex;
     align-items: center;
     gap: 10px;
@@ -177,7 +177,7 @@ stylesheet
     content: "";
     flex: 1;
     height: 1px;
-    background: linear-gradient(90deg, var(--border-highlight), transparent);
+    background: linear-gradient(90deg, var(--color-border-strong), transparent);
   }
 
   .nav_link {
@@ -185,7 +185,7 @@ stylesheet
     align-items: center;
     gap: 11px;
     padding: 14px 18px;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
     font-size: 11px;
     text-decoration: none;
@@ -196,20 +196,20 @@ stylesheet
   }
 
   .nav_link:hover {
-    color: var(--accent-brass);
-    background: color-mix(in oklab, var(--accent-brass) 5%, transparent);
+    color: var(--color-accent-fg);
+    background: color-mix(in oklab, var(--color-accent-fg) 5%, transparent);
   }
 
   .nav_link:focus-visible {
-    outline: 2px solid var(--accent-brass);
+    outline: 2px solid var(--color-accent-fg);
     outline-offset: -2px;
-    background: color-mix(in oklab, var(--accent-brass) 8%, transparent);
+    background: color-mix(in oklab, var(--color-accent-fg) 8%, transparent);
   }
 
   .nav_link_active {
-    color: var(--accent-brass);
-    border-left-color: var(--accent-brass);
-    background: linear-gradient(90deg, color-mix(in oklab, var(--accent-brass) 10%, transparent), transparent 70%);
+    color: var(--color-accent-fg);
+    border-left-color: var(--color-accent-fg);
+    background: linear-gradient(90deg, color-mix(in oklab, var(--color-accent-fg) 10%, transparent), transparent 70%);
   }
 
   .nav_link_active::after {
@@ -220,13 +220,13 @@ stylesheet
     width: 4px;
     height: 4px;
     border-radius: 50%;
-    background: var(--accent-brass);
-    box-shadow: 0 0 8px var(--accent-brass);
+    background: var(--color-accent-fg);
+    box-shadow: 0 0 8px var(--color-accent-fg);
     transform: translateY(-50%);
   }
 
   .nav_link_soon {
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-style: italic;
   }
 
@@ -241,7 +241,7 @@ stylesheet
 
   .nav_link_active .nav_glyph {
     opacity: 1;
-    box-shadow: 0 0 8px var(--accent-glow);
+    box-shadow: 0 0 8px var(--color-accent-glow);
   }
 
   .tail {
@@ -259,13 +259,13 @@ stylesheet
   .hud {
     display: grid;
     grid-template-columns: repeat(6, minmax(0, 1fr));
-    background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
-    border-bottom: 1px solid var(--border-highlight);
+    background: linear-gradient(180deg, var(--color-bg-surface), var(--color-bg-page));
+    border-bottom: 1px solid var(--color-border-strong);
   }
 
   .hud_cell {
     padding: 10px 14px;
-    border-right: 1px solid var(--border-main);
+    border-right: 1px solid var(--color-border-default);
     position: relative;
     min-width: 0;
   }
@@ -277,7 +277,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .hud_v {
@@ -293,8 +293,8 @@ stylesheet
     white-space: nowrap;
   }
 
-  .hud_ok { color: var(--status-ok); }
-  .hud_warn { color: var(--accent-brass); }
+  .hud_ok { color: var(--color-status-ok); }
+  .hud_warn { color: var(--color-accent-fg); }
   .hud_bad { color: var(--accent-blood); }
 
   .page {
@@ -305,8 +305,8 @@ stylesheet
   }
 
   .aside {
-    background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
-    border-left: 1px solid var(--border-main);
+    background: linear-gradient(180deg, var(--color-bg-surface), var(--color-bg-page));
+    border-left: 1px solid var(--color-border-default);
     padding: 18px 18px 30px;
     overflow: auto;
     display: flex;
@@ -318,7 +318,7 @@ stylesheet
     font-family: var(--font-display, 'Cinzel', serif);
     font-size: 11px;
     letter-spacing: 0.28em;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     text-transform: uppercase;
     margin: 0 0 10px;
     display: flex;
@@ -330,13 +330,13 @@ stylesheet
     content: "";
     flex: 1;
     height: 1px;
-    background: linear-gradient(90deg, var(--border-highlight), transparent);
+    background: linear-gradient(90deg, var(--color-border-strong), transparent);
   }
 
   .aside_title .r {
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     margin-left: auto;
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.04em;
@@ -346,11 +346,11 @@ stylesheet
   .focus {
     position: relative;
     padding: 16px 16px 14px;
-    background: linear-gradient(180deg, var(--bg-panel-alt), var(--bg-panel));
+    background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-surface));
     content: "";
     position: absolute;
     inset: 3px;
-    border: 1px solid var(--border-highlight);
+    border: 1px solid var(--color-border-strong);
     pointer-events: none;
   }
 
@@ -371,21 +371,21 @@ stylesheet
   .portrait {
     width: 46px;
     height: 46px;
-    border: 1px solid var(--accent-brass);
+    border: 1px solid var(--color-accent-fg);
     display: grid;
     place-items: center;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     font-family: var(--font-display, 'Cinzel', serif);
     font-size: 20px;
     background:
-      radial-gradient(circle at 35% 25%, color-mix(in oklab, var(--accent-brass) 16%, transparent), transparent 38%),
-      linear-gradient(180deg, var(--bg-panel-alt), var(--bg-deep));
+      radial-gradient(circle at 35% 25%, color-mix(in oklab, var(--color-accent-fg) 16%, transparent), transparent 38%),
+      linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-page));
   }
 
   .focus_name {
     font-family: var(--font-display, 'Cinzel', serif);
     font-size: 16px;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     letter-spacing: 0.16em;
     text-transform: uppercase;
   }
@@ -394,7 +394,7 @@ stylesheet
     font-family: var(--font-body, 'EB Garamond', serif);
     font-style: italic;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     margin-top: 2px;
   }
 
@@ -403,7 +403,7 @@ stylesheet
     justify-content: space-between;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     margin-bottom: 4px;
     font-variant-numeric: tabular-nums;
   }
@@ -415,8 +415,8 @@ stylesheet
 
   .vial {
     height: 8px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-main);
+    background: var(--color-bg-page);
+    border: 1px solid var(--color-border-default);
     position: relative;
     overflow: hidden;
   }
@@ -425,15 +425,15 @@ stylesheet
     display: block;
     height: 100%;
     width: 62%;
-    background: linear-gradient(90deg, color-mix(in oklab, var(--status-ok) 60%, var(--bg-deep)), var(--status-ok));
-    box-shadow: 0 0 6px color-mix(in oklab, var(--status-ok) 35%, transparent);
+    background: linear-gradient(90deg, color-mix(in oklab, var(--color-status-ok) 60%, var(--color-bg-page)), var(--color-status-ok));
+    box-shadow: 0 0 6px color-mix(in oklab, var(--color-status-ok) 35%, transparent);
   }
 
   .vial::after {
     content: "";
     position: absolute;
     inset: 0;
-    background-image: repeating-linear-gradient(90deg, transparent 0 19px, color-mix(in oklab, var(--bg-deep) 50%, transparent) 19px 20px);
+    background-image: repeating-linear-gradient(90deg, transparent 0 19px, color-mix(in oklab, var(--color-bg-page) 50%, transparent) 19px 20px);
     pointer-events: none;
   }
 
@@ -447,7 +447,7 @@ stylesheet
     font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
     font-size: 11px;
     letter-spacing: 0.18em;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     text-transform: uppercase;
   }
 
@@ -463,8 +463,8 @@ stylesheet
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
     color: var(--text-bright);
-    border: 1px solid color-mix(in oklab, var(--border-highlight) 14%, transparent);
-    background: var(--bg-deep);
+    border: 1px solid color-mix(in oklab, var(--color-border-strong) 14%, transparent);
+    background: var(--color-bg-page);
     padding: 1px;
   }
 
@@ -490,7 +490,7 @@ stylesheet
 
   .flame_plan { background: #2a3a2a; color: #c4dcb0; }
   .flame_exec { background: #3a2a2a; color: #e4b8b0; }
-  .flame_wait { background: #1a1410; color: var(--text-dim); }
+  .flame_wait { background: #1a1410; color: var(--color-fg-muted); }
   .flame_err { background: #3a1010; color: #e0b8a8; }
 
   .events {
@@ -503,7 +503,7 @@ stylesheet
     grid-template-columns: 56px 14px 1fr;
     gap: 10px;
     padding: 8px 0;
-    border-bottom: 1px dashed var(--border-main);
+    border-bottom: 1px dashed var(--color-border-default);
     align-items: baseline;
   }
 
@@ -512,34 +512,34 @@ stylesheet
   .event_time {
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     font-variant-numeric: tabular-nums;
   }
 
   .event_mark {
     width: 10px;
     height: 10px;
-    border: 1px solid var(--accent-brass-dim);
+    border: 1px solid var(--color-accent-fg-dim);
     transform: rotate(45deg);
   }
 
   .event_bad { border-color: var(--accent-blood); box-shadow: 0 0 5px var(--accent-blood-glow); }
-  .event_ok { border-color: var(--status-ok); }
+  .event_ok { border-color: var(--color-status-ok); }
 
   .event_body {
     font-family: var(--font-body, 'EB Garamond', serif);
     font-size: 12px;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     line-height: 1.45;
   }
 
   .event_body code {
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
-    color: var(--accent-brass);
-    background: color-mix(in oklab, var(--accent-brass) 8%, transparent);
+    color: var(--color-accent-fg);
+    background: color-mix(in oklab, var(--color-accent-fg) 8%, transparent);
     padding: 0 5px;
-    border: 1px solid var(--border-main);
+    border: 1px solid var(--color-border-default);
   }
 
   @media (max-width: 1180px) {
@@ -566,7 +566,7 @@ stylesheet
       flex-direction: row;
       overflow-x: auto;
       border-right: 0;
-      border-bottom: 1px solid var(--border-main);
+      border-bottom: 1px solid var(--color-border-default);
       padding: 6px 0;
     }
     .nav_section {
@@ -579,7 +579,7 @@ stylesheet
       padding: 8px 12px;
     }
     .nav_link_active {
-      border-bottom-color: var(--accent-brass);
+      border-bottom-color: var(--color-accent-fg);
     }
     .nav_link_active::after {
       display: none;
@@ -606,9 +606,9 @@ stylesheet
     font-family: 'Noto Sans KR', sans-serif;
     font-size: 13px;
     padding: 8px 16px;
-    background: var(--bg-panel);
-    color: var(--accent-brass);
-    border: 2px solid var(--accent-brass);
+    background: var(--color-bg-surface);
+    color: var(--color-accent-fg);
+    border: 2px solid var(--color-accent-fg);
     text-decoration: none;
   }
   .skip_nav:focus {
@@ -629,7 +629,7 @@ stylesheet
     .aside { border-left-width: 2px; border-left-color: var(--text-bright); }
     .pill { border-width: 2px; border-color: var(--text-bright); }
     .vial { border-width: 2px; border-color: var(--text-bright); }
-    .event { border-bottom-width: 2px; border-bottom-color: var(--text-dim); }
+    .event { border-bottom-width: 2px; border-bottom-color: var(--color-fg-muted); }
     .event_body code { border-width: 2px; border-color: var(--text-bright); }
     .focus { border-width: 2px; border-color: var(--text-bright); }
   }

--- a/dashboard_bonsai/src/swim.ml
+++ b/dashboard_bonsai/src/swim.ml
@@ -33,36 +33,36 @@ module Style =
 stylesheet
   {|
   .swim {
-    border: 1px solid var(--border-main);
-    background: color-mix(in oklab, var(--bg-deep) 40%, transparent);
+    border: 1px solid var(--color-border-default);
+    background: color-mix(in oklab, var(--color-bg-page) 40%, transparent);
     margin-top: 6px;
   }
   .axis {
     display: grid;
     grid-template-columns: 140px 1fr;
-    border-bottom: 1px solid var(--border-main);
+    border-bottom: 1px solid var(--color-border-default);
   }
   .axis_sp {
-    border-right: 1px solid var(--border-main);
+    border-right: 1px solid var(--color-border-default);
     padding: 6px 14px;
     font-family: 'Noto Sans KR', sans-serif;
     font-size: 11px;
     letter-spacing: 0.24em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
   .axis_ax {
     position: relative;
     height: 24px;
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
   .tick {
     position: absolute;
     top: 0;
     bottom: 0;
-    border-left: 1px solid var(--border-main);
+    border-left: 1px solid var(--color-border-default);
   }
   .tick_lbl {
     position: absolute;
@@ -74,11 +74,11 @@ stylesheet
   .lane {
     display: grid;
     grid-template-columns: 140px 1fr;
-    border-bottom: 1px solid var(--border-main);
+    border-bottom: 1px solid var(--color-border-default);
   }
   .lane:last-child { border-bottom: 0; }
   .lane_meta {
-    border-right: 1px solid var(--border-main);
+    border-right: 1px solid var(--color-border-default);
     padding: 8px 14px;
     display: flex;
     align-items: center;
@@ -88,11 +88,11 @@ stylesheet
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--status-ok);
+    background: var(--color-status-ok);
     flex-shrink: 0;
-    box-shadow: 0 0 6px var(--status-ok);
+    box-shadow: 0 0 6px var(--color-status-ok);
   }
-  .dot_warn { background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
+  .dot_warn { background: var(--color-status-warn); box-shadow: 0 0 6px var(--color-status-warn); }
   .dot_bad { background: var(--accent-blood); box-shadow: 0 0 6px var(--accent-blood); }
   .nm {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
@@ -102,7 +102,7 @@ stylesheet
     flex: 1;
   }
   .nm_dead {
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     text-decoration: line-through;
     text-decoration-color: var(--accent-blood);
   }
@@ -110,13 +110,13 @@ stylesheet
     font-family: 'Noto Sans KR', sans-serif;
     font-size: 11px;
     letter-spacing: 0.18em;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     text-transform: uppercase;
   }
   .track {
     position: relative;
     height: 32px;
-    background: repeating-linear-gradient(to right, transparent 0 99px, color-mix(in oklab, var(--border-highlight) 5%, transparent) 99px 100px);
+    background: repeating-linear-gradient(to right, transparent 0 99px, color-mix(in oklab, var(--color-border-strong) 5%, transparent) 99px 100px);
   }
   .frame {
     position: absolute;
@@ -124,7 +124,7 @@ stylesheet
     height: 14px;
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--bg-deep);
+    color: var(--color-bg-page);
     padding: 0 4px;
     line-height: 14px;
     overflow: hidden;
@@ -138,8 +138,8 @@ stylesheet
   .frame_llm  { background: var(--t-llm); }
   .frame_tool { background: var(--t-tool); }
   .frame_err  { background: var(--t-err); color: var(--text-bright); }
-  .frame_wait { background: var(--t-wait); color: var(--text-dim); }
-  .frame_think { background: var(--t-think); color: var(--text-primary); }
+  .frame_wait { background: var(--t-wait); color: var(--color-fg-muted); }
+  .frame_think { background: var(--t-think); color: var(--color-fg-primary); }
 
   @media (prefers-contrast: more) {
     .track { outline: 1px solid var(--text-bright); }


### PR DESCRIPTION
## Summary

**Stage 3-7+ bulk migration** — combines audit §6의 모든 잔여 stage를 한 PR로. SPEC v0.1 §3.1-3.5 Semantic vocabulary를 양쪽 prod의 모든 잔여 파일에 일괄 적용.

Diff: **204 files, +3217/-3217** (sed 같은 줄 수 refactor). Visual diff = zero (alias forward to same raw value, Stage 2와 동일 패턴).

## Method

재사용 sed driver: `.tmp/spec-alignment-sed.sh`

```bash
# Bonsai 16 raw → semantic 매핑
bash .tmp/spec-alignment-sed.sh bonsai dashboard_bonsai/src/*.ml

# Preact 15 raw → semantic 매핑 (component + test)
bash .tmp/spec-alignment-sed.sh preact dashboard/src/components/**/*.ts
```

각 매핑은 단일 형태(`var(--ok)`)와 fallback 형태(`var(--ok, #hex)`) 양쪽 모두 처리. `--text-bright` + `--accent-blood`는 SPEC §3.2/§3.4 bonsai-only로 명시되어 raw 유지.

## Per-prod 통계

| Surface | 파일 수 | 변경 라인 (sed) |
|---------|--------|-----------------|
| Bonsai | 16 | 458 +/- |
| Preact components | 162 | ~2,500 +/- |
| Preact tests | 26 | ~250 +/- |

## Validation

### Raw 잔존 0 (양쪽 prod)

```
Bonsai 잔존 (text-primary/dim, border-main/highlight, accent-brass, status-*, bg-*):
  (empty)

Preact 잔존 (text-muted/strong/body/dim, card-border, border-*, accent, warn/ok/bad, bg-*):
  (empty)
```

### Semantic 도입 (top)

**Preact**:
- `--color-fg-muted` 942
- `--color-fg-disabled` 456
- `--color-fg-primary` 378
- `--color-border-default` 302
- `--color-fg-secondary` 255
- `--color-status-warn` 216
- `--color-accent-fg` 205
- `--color-status-ok` 180
- `--color-status-err` 130

**Bonsai**:
- `--color-accent-fg` 148
- `--color-fg-muted` 105
- `--color-border-default` 69
- `--color-bg-page` 59
- `--color-fg-primary` 35
- `--color-bg-surface` 32
- `--color-border-strong` 30
- `--color-status-ok` 29
- `--color-status-warn` 21
- `--color-accent-fg-dim` 11

## Test files swept

테스트가 raw vocabulary로 assertion했기 때문에 (`text-[var(--ok)]` 등) component vocabulary 변경 시 매치되도록 같은 sed 적용. component ↔ test 항상 동기화.

## Visual diff = zero

Stage 1 PR #10611의 alias가 raw 값을 forward reference. CSS cascade로 동일 computed value에 도달. 7개 테마 (dashboard dark/light + bonsai 5: dark-fantasy/cyberpunk/terminal/parchment/paper) 모두 시각 변화 zero 예상.

## 시리즈 완성

- [x] Stage 0 audit ([#10606](https://github.com/jeong-sik/masc-mcp/pull/10606) merged)
- [x] Stage 1 SPEC aliases ([#10611](https://github.com/jeong-sik/masc-mcp/pull/10611) merged)
- [x] Stage 2 Overview ([#10634](https://github.com/jeong-sik/masc-mcp/pull/10634) merged)
- [x] **Stage 3-7+ bulk (this PR)** — 잔여 모든 prod surface
- [ ] Stage 1.5 `.flame_*` raw hex (별도 PR, 색 매핑 분석 후)

본 PR 머지 후 양쪽 prod의 모든 신규 화면이 SPEC vocabulary를 default로 사용. raw tier는 alias가 가리키는 raw value provider로만 존재. `.flame_*` 4 라인만 raw로 남음 (의도적, 색 매핑 분석 별도).

Refs: SPEC.md, audit #10606, alias #10611, overview #10634

🤖 Generated with [Claude Code](https://claude.com/claude-code)
