### PR TITLE
refactor(keeper): delegate to_prompt_form to normalize_self_model_text SSOT

### DIFF
--- a/lib/keeper/keeper_personality_io.ml
+++ b/lib/keeper/keeper_personality_io.ml
@@ -134,11 +134,12 @@ let compare_normalized (current : coerced_personality)
   match diffs with [] -> `Equal | _ :: _ -> `Drift diffs
 
 let to_prompt_form ~max_bytes (p : raw_personality) : raw_personality =
-  let render s =
-    let trimmed = String.trim s in
-    if trimmed = "" then ""
-    else Keeper_config.utf8_safe_prefix_bytes trimmed ~max_bytes
-  in
+  (* Delegate to the SSOT helper so render layer auto-inherits any future
+     normalization fixes (e.g. PR #10557 idempotency hardening on
+     [normalize_self_model_text]).  Behaviour today is identical to the
+     prior inline [trim → utf8_safe_prefix_bytes] sequence; the value is
+     in not having two copies of the trim/cap recipe drift apart. *)
+  let render s = Keeper_config.normalize_self_model_text ~max_bytes s in
   {
     will = render p.will;
     needs = render p.needs;


### PR DESCRIPTION
## Summary

`Keeper_personality_io.to_prompt_form` (added in #10538 Layer 2 PR-B) inlines the same `trim → utf8_safe_prefix_bytes` sequence that already lives in `Keeper_config.normalize_self_model_text`. Two copies of the same recipe drift independently. This PR collapses them so the render layer always tracks the SSOT.

## Why now

PR #10557 fixes the idempotency violation in `normalize_self_model_text` (`trim → cap → trim`). Without this delegation, after #10557 lands the helper is idempotent but `to_prompt_form`'s inline copy still violates `f(f(x)) = f(x)` — would need a separate follow-up. With this delegation, the render layer auto-inherits the fix.

## Scope

| File | Change |
|------|--------|
| `lib/keeper/keeper_personality_io.ml` | `to_prompt_form` calls `Keeper_config.normalize_self_model_text` instead of inlining `String.trim → utf8_safe_prefix_bytes` |

Behaviour today is identical (both sequences produce the same bytes given the current helper).

## Verification

- `dune build @check`: clean
- 5 personality_io test suites: **38/38 PASS**
  - `test_keeper_personality_io_parse.exe` — 8 tests
  - `test_keeper_personality_io_coerce.exe` — 6 tests
  - `test_keeper_personality_io_validate.exe` — 7 tests
  - `test_keeper_personality_io_compare.exe` — 10 tests
  - `test_keeper_personality_io_render.exe` — 7 tests (includes per-field parity check that pins `to_prompt_form` against `normalize_self_model_text`)

## Disk-of-record

Pure refactor. No persisted data shape change.

## Non-goals

- Idempotency fix itself (that's PR #10557 on `normalize_self_model_text`).
- Removing `to_prompt_form` API. The `~max_bytes` parameter still gives callers control over render cap.

## Why Draft + do-not-merge

Cycle 9 self-audit identified this as cosmetic-only follow-up (see `feedback_ssot-inline-copy-bypasses-root-fix.md` cycle 8 caveat — `to_prompt_form` is render-layer only, not in the reconcile drift loop path). Operator decides whether to merge before or after #10557 lands; ordering does not affect correctness.
