### PR TITLE
perf(cdal-judge): delegate contains_sub/contains_ci to String_util SSOT

### DIFF
--- a/lib/cdal_judge.ml
+++ b/lib/cdal_judge.ml
@@ -243,20 +243,17 @@ let marker_to_string = function
 
 (* --- low-level text helpers (no re lib; keep deps thin) --- *)
 
+(* Delegates to [String_util] SSOT (byte-wise scan, no per-step
+   allocation). The SSOT [contains_substring] returns [true] for an
+   empty needle natively, matching the original local helper.
+   [contains_substring_ci] returns [false] for empty needle, so guard
+   explicitly to preserve the legacy convention. *)
 let contains_sub s sub =
-  let ls = String.length s and lsub = String.length sub in
-  if lsub = 0 then true
-  else if lsub > ls then false
-  else
-    let rec loop i =
-      if i + lsub > ls then false
-      else if String.sub s i lsub = sub then true
-      else loop (i + 1)
-    in
-    loop 0
+  String_util.contains_substring s sub
 
 let contains_ci s sub =
-  contains_sub (String.lowercase_ascii s) (String.lowercase_ascii sub)
+  if sub = "" then true
+  else String_util.contains_substring_ci s sub
 
 (* Counts occurrences of a fixed substring. *)
 let count_sub s sub =


### PR DESCRIPTION
## What

`lib/cdal_judge.ml`의 두 substring helper를 `String_util` SSOT delegate으로 교체:
- `contains_sub` (case-sensitive) → `String_util.contains_substring`
- `contains_ci` → `String_util.contains_substring_ci` (empty-needle guard 유지)

`#10460/#10468/#10478/#10630` SSOT 통합 series에서 누락된 fork. memory entry `feedback_audit-bucket-cascade-pattern.md`의 "1차 sweep 누락 fork" 패턴.

## Why

기존 `contains_sub` (lines 246-256):
1. inner loop 매 i 마다 `String.sub s i lsub` — N alloc per scan
2. `contains_ci`는 그 위에 lowercase 2 alloc 추가

`String_util` SSOT는 byte-wise scan으로 0 alloc.

`cdal_judge`는 build/test output 분류 hot path:
- `contains_sub out "dune build"` (line 277)
- `contains_sub out "dune runtest"` (line 282)
- `contains_sub out "Compiling "` (line 287)
- 등 매 cdal eval cycle마다 다수 호출

## Semantics

`contains_sub`: SSOT 자체가 empty needle → true (legacy와 일치). 추가 가드 불필요.
`contains_ci`: SSOT는 empty needle → false. legacy는 true. `if sub = "" then true` 가드 추가.

caller (line 277+)는 모두 non-empty literal이라 실제 영향 없음.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean.

## Sweep series

- 1차 (#10460/#10468/#10478): server_dashboard_http, mcp_server_eio_call_tool, server_routes_http_keeper_stream, gh_exit_class, autoresearch_knowledge
- #10630: gate_diff_types fork (1차 누락분)
- 본 PR: cdal_judge fork (1차 누락분)
- `count_sub` (lines 262+)는 SSOT에 변형 없음 — 별도 검토 보류

## Verify

`grep -rn "let contains_sub\b\|let contains_ci\b" lib --include "*.ml"` → 0 (sweep 완료).
