### PR TITLE
fix(obs): prepend [max_turns]/[hard_quota] class label on cascade-fallback log (#10629)

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1521,11 +1521,25 @@ let run_named
                  from hard failures.  The exec layer's per-tier
                  "agent errored" log was also demoted to DEBUG in the
                  same change, so this INFO is the canonical per-tier
-                 signal. *)
-              Log.Misc.info "[cascade-fallback] cascade %s: %s failed (%s), trying next" cascade_name provider_cfg.model_id (Oas.Error.to_string sdk_err);
+                 signal.
+
+                 #10629: prepend a classification label so
+                 [cli_wrapped_max_turns] and [hard_quota] inside
+                 NetworkError messages stay legible at the dashboard /
+                 log-grep layer.  Pre-fix the log read "Network error:
+                 claude exited with code 1: {...subtype error_max_turns...}"
+                 which masked that this was a graceful turn-budget exit
+                 (33/day claude_code, 2.5x growth). *)
+              let class_label =
+                if sdk_error_is_hard_quota sdk_err then "[hard_quota] "
+                else if sdk_error_is_max_turns_exceeded sdk_err
+                then "[max_turns] "
+                else ""
+              in
+              Log.Misc.info "[cascade-fallback] cascade %s: %s failed (%s%s), trying next" cascade_name provider_cfg.model_id class_label (Oas.Error.to_string sdk_err);
               Oas_worker_cascade.record_fallback_event capture ~candidate_cfgs
                 ~from_model:provider_cfg.model_id ~to_model:"next"
-                ~reason:(Oas.Error.to_string sdk_err);
+                ~reason:(class_label ^ Oas.Error.to_string sdk_err);
               try_cascade ?resume_checkpoint:next_resume rest new_err
             | Cascade_fsm.Exhausted _ ->
               let observation =


### PR DESCRIPTION
## 요약

cascade-fallback INFO 로그가 \`Oas.Error.to_string sdk_err\` raw text를 그대로 emit → claude_code의 \`subtype:error_max_turns\`가 \"Network error: claude exited with code 1\" 로 표면화. 33 events/day claude_code (2.5x growth)가 잘못된 카테고리로 보임.

## 변경

\`lib/oas_worker_named.ml:1517-1528\` cascade-fallback Try_next 분기에 class label prepend:

**Before:**
\`\`\`
[cascade-fallback] cascade tool_use_strict: auto failed (Network error: claude exited with code 1: {...})
\`\`\`

**After:**
\`\`\`
[cascade-fallback] cascade tool_use_strict: auto failed ([max_turns] Network error: claude exited with code 1: {...})
\`\`\`

기존 \`sdk_error_is_hard_quota\` + \`sdk_error_is_max_turns_exceeded\` helper를 그대로 사용해 분류. Behavior unchanged at classification layer.

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
\`\`\`

## 영향

- 33 events/day가 즉시 [max_turns]로 식별 가능 → cascade fallback이 graceful exit인지 진짜 transport failure인지 dashboard/grep으로 분간
- \`record_fallback_event\`의 \`reason\`도 동일 prefix → metrics에서 분류별 카운트 가능

## 비목표

- claude_code transport에서 \`MaxTurnsExceeded\` proper variant로 변환: 외부 패키지 (agent_sdk) 작업
- 다른 cascade-fallback 사이트의 reason classification: 별도 sweep PR

## Defensive guards

Draft + \`do-not-merge\`.

## 관련

- Issue: \`#10629\`
- Pattern: \`feedback_no-collapse-richer-enum-at-sdk-boundary\`
- Cross: \`#10528\` (cascade error inline context — 같은 family)