### PR TITLE
fix(cascade): order judge profiles gemini-first to skip codex 30s timeout cycle

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -17,18 +17,18 @@
   ],
   "big_three_temperature": 0.2,
   "big_three_max_tokens": 16384,
-  "_comment_governance_judge": "System-only dashboard governance judge profile. Explicitly defined so background judge loops do not inherit fallback providers such as Claude CLI.",
+  "_comment_governance_judge": "System-only dashboard governance judge profile. Explicitly defined so background judge loops do not inherit fallback providers such as Claude CLI. Gemini listed first because [codex_cli:auto] internally rotates 5 models (30s timeout each = 150s wasted wall-clock when codex auth is broken); Gemini-first attempts the cheap success path first while codex remains a fallback that auto-rejoins on recovery (#10554 disabled codex_cli for 4 seed cascades; this profile keeps codex as fallback rather than removing it).",
   "governance_judge_models": [
-    { "model": "codex_cli:auto", "weight": 1 },
-    { "model": "gemini_cli:auto", "weight": 1 }
+    { "model": "gemini_cli:auto", "weight": 1 },
+    { "model": "codex_cli:auto", "weight": 1 }
   ],
   "governance_judge_temperature": 0.2,
   "governance_judge_max_tokens": 16384,
   "governance_judge_keeper_assignable": false,
-  "_comment_operator_judge": "System-only dashboard operator judge profile. Mirrors governance_judge so background control loops stay off Claude CLI by default.",
+  "_comment_operator_judge": "System-only dashboard operator judge profile. Mirrors governance_judge so background control loops stay off Claude CLI by default. Gemini-first ordering: see governance_judge for rationale.",
   "operator_judge_models": [
-    { "model": "codex_cli:auto", "weight": 1 },
-    { "model": "gemini_cli:auto", "weight": 1 }
+    { "model": "gemini_cli:auto", "weight": 1 },
+    { "model": "codex_cli:auto", "weight": 1 }
   ],
   "operator_judge_temperature": 0.2,
   "operator_judge_max_tokens": 16384,

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -22,20 +22,20 @@ temperature = 0.2
 max_tokens = 16384
 
 [governance_judge]
-comment = "System-only dashboard governance judge profile. Explicitly defined so background judge loops do not inherit fallback providers such as Claude CLI."
+comment = "System-only dashboard governance judge profile. Explicitly defined so background judge loops do not inherit fallback providers such as Claude CLI. Gemini listed first because [codex_cli:auto] internally rotates 5 models (30s timeout each = 150s wasted wall-clock when codex auth is broken); Gemini-first attempts the cheap success path first while codex remains a fallback that auto-rejoins on recovery (#10554 disabled codex_cli for 4 seed cascades; this profile keeps codex as fallback rather than removing it)."
 models = [
-  { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
+  { model = "codex_cli:auto", weight = 1 },
 ]
 temperature = 0.2
 max_tokens = 16384
 keeper_assignable = false
 
 [operator_judge]
-comment = "System-only dashboard operator judge profile. Mirrors governance_judge so background control loops stay off Claude CLI by default."
+comment = "System-only dashboard operator judge profile. Mirrors governance_judge so background control loops stay off Claude CLI by default. Gemini-first ordering: see governance_judge for rationale."
 models = [
-  { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
+  { model = "codex_cli:auto", weight = 1 },
 ]
 temperature = 0.2
 max_tokens = 16384

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -115,8 +115,8 @@ let test_repo_seed_excludes_claude_from_automatic_profiles () =
     [ "codex_cli:auto"; "gemini_cli:auto"; "codex_cli:gpt-5.3-codex-spark" ];
   expect_profile_models "big_three"
     [ "codex_cli:auto"; "gemini_cli:auto"; "codex_cli:gpt-5.3-codex-spark" ];
-  expect_profile_models "governance_judge" [ "codex_cli:auto"; "gemini_cli:auto" ];
-  expect_profile_models "operator_judge" [ "codex_cli:auto"; "gemini_cli:auto" ];
+  expect_profile_models "governance_judge" [ "gemini_cli:auto"; "codex_cli:auto" ];
+  expect_profile_models "operator_judge" [ "gemini_cli:auto"; "codex_cli:auto" ];
   check bool "governance_judge is system-only" false
     (rendered |> member "governance_judge_keeper_assignable" |> to_bool);
   check bool "operator_judge is system-only" false


### PR DESCRIPTION
## Why

Live ops log (2026-04-26 16:30 KST onward) shows `governance_judge` cascade refresh hitting 180s timeout every cycle:

```
[16:30:42] [Misc] [cascade-fallback] cascade governance_judge: gpt-5.3-codex-spark failed (Network error: codex exited with code 1: ...)
[16:30:48] [Misc] masc_oas_bridge: OAS execution timed out after 180.0s (caller=governance_judge)
[16:30:48] [Governance] refresh_once: compute_judgments failed: Timeout
```

codex CLI session is in an `AuthRequired` state (stderr: `worker quit with fatal: Transport channel closed, when AuthRequired`). Every cascade slot for `codex_cli:auto` triggers the internal 5-model rotation (gpt-5.3-codex-spark / 5.4-mini / 5.4 / 5.5 / 5.2) — each fails after 30s on the broken auth — totalling **~150s before gemini_cli is even attempted**. This consumes the entire `governance_judge` 180s budget on a clearly-broken provider.

## Scope

#10554 already disabled `codex_cli` for the 4 seed cascades (`big_three`, `default`, ...).  Judge cascades (`governance_judge`, `operator_judge`) were not in that scope:

```toml
# Before
[governance_judge]
models = [
  { model = "codex_cli:auto", weight = 1 },   # tried first → 150s wasted on broken auth
  { model = "gemini_cli:auto", weight = 1 },
]
```

This PR reorders (without changing weights or removing `codex_cli`) so the cheap-success path runs first:

```toml
# After
[governance_judge]
models = [
  { model = "gemini_cli:auto", weight = 1 },  # tried first → succeeds while codex auth is broken
  { model = "codex_cli:auto", weight = 1 },   # remains as fallback; auto-rejoins on codex recovery
]
```

`operator_judge` mirrors `governance_judge`.

## Why order swap and not weight=0

- **No permanent demotion**: codex_cli stays in the cascade, so when operator runs `codex login` and the session recovers, codex is automatically re-tried as fallback without a config edit.
- **No quality cliff**: when both providers work, behaviour is preserved (still a 2-provider judge ensemble). Order matters only when the first provider fails fast or hangs.
- **Minimal blast radius**: 12 LOC across 3 files (TOML + committed JSON + pinned test). All other cascade profiles untouched.

## Files

| File | Change |
|------|--------|
| `config/cascade.toml` | Swap model order in `[governance_judge]` and `[operator_judge]`; expand `comment` to explain the rationale so future PRs don't silently swap back |
| `config/cascade.json` | Mirror the swap (committed render kept in sync via `test_repo_toml_renders_to_committed_json`) |
| `test/test_cascade_toml_materialization.ml` | Update `expect_profile_models` to the new order |

## Verification

```bash
MASC_CASCADE_TOML_PATH=./config/cascade.toml \
MASC_CASCADE_JSON_PATH=./config/cascade.json \
dune exec test/test_cascade_toml_materialization.exe
# -> Test Successful in 0.009s. 13 tests run.

dune build lib/ --cache=disabled  # RC=0
```

Tests covered:
- `repo_sync` 0: TOML ↔ committed JSON drift check (catches if either side is updated without the other)
- `validation` 0–7: include `expect_profile_models "governance_judge"`/`operator_judge` order pin

## Out of scope

- **Root cause** (codex CLI session corruption) is operator-side: `codex login` re-issue. Not solved by config changes.
- **Permanent codex_cli removal** from judge cascades: deferred. If operators decide judge ensembles should never call codex, follow-up PR can apply `weight = 0` (now accepted via #10610 / #10571 materializer).
- **Health-checked cascades** (skip provider if last N attempts failed): tracked separately as a behaviour-changing improvement; needs Plan.

## References

- #10554 — fix(config): remove codex_cli from 4 seed cascades (precedent; same class)
- #10571 / #10610 — cascade materializer accepts `weight=0` (enables future hard-disable if needed)
- memory: `feedback_codex_cli_disable_eliminated_70_percent_failures.md` (#10554 result data)
- memory: `feedback_codex_cli_internal_5model_rotation.md` (`codex_cli:auto` = 5 internal models per slot)