### PR TITLE
perf(auth): collapse mem_assoc+assoc raise pair to single List.assoc_opt walk

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -328,16 +328,19 @@ let load_credential config agent_name : agent_credential option =
     try
       let content = read_text_file file in
       let json = Yojson.Safe.from_string content in
-      (* Redirect stub: { "redirect_to": "<uuid>.json" } *)
+      (* Redirect stub: { "redirect_to": "<uuid>.json" } — single
+         [List.assoc_opt] walk replaces the [mem_assoc + assoc] pair
+         (two passes, second raises [Not_found]). *)
       match json with
-      | `Assoc fields when List.mem_assoc "redirect_to" fields -> (
-          match List.assoc "redirect_to" fields with
-          | `String target -> (
+      | `Assoc fields -> (
+          match List.assoc_opt "redirect_to" fields with
+          | Some (`String target) -> (
               match redirect_target_file config target with
               | Some redirect_path ->
                   load_credential_from_path_raw config agent_name redirect_path
               | None -> None)
-          | _ -> None)
+          | Some _ -> None
+          | None -> load_credential_from_path_raw config agent_name file)
       | _ -> load_credential_from_path_raw config agent_name file
     with Sys_error _ | Yojson.Json_error _ -> None
 


### PR DESCRIPTION
## What

`lib/auth.ml:333-341` `load_credential_from_path_raw`의 redirect-stub 분기에서 `List.mem_assoc + List.assoc` 두 walk를 단일 `List.assoc_opt`로 통합.

## Why

기존 패턴:
```ocaml
| `Assoc fields when List.mem_assoc "redirect_to" fields -> (
    match List.assoc "redirect_to" fields with
    | `String target -> ...
    | _ -> None)
| _ -> load_credential_from_path_raw ...
```

두 가지 cost:
1. `List.mem_assoc` walk (O(n))
2. `List.assoc` 또 walk (O(n)) + 없으면 `Not_found` raise

또한 `mem_assoc=true && assoc returns _ -> None` 분기가 `redirect_to`가 non-string인 경우 fall-through 안 함 — `load_credential_from_path_raw` 호출이 누락. 변환 후:

```ocaml
| `Assoc fields -> (
    match List.assoc_opt "redirect_to" fields with
    | Some (`String target) -> ...
    | Some _ -> None
    | None -> load_credential_from_path_raw config agent_name file)
| _ -> load_credential_from_path_raw config agent_name file
```

단일 walk + None일 때 정상 fall-through. 이전엔 `Some _` (non-string) 일 때만 None 반환 — semantic 미세 변화: 전엔 mem_assoc=false면 fall-through, 이젠 None일 때 fall-through. 대부분의 credential JSON에 redirect_to가 없으므로 동등 + 누락된 fall-through 케이스(`Some _`)는 명시적으로 None.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean. credential file 매 keeper auth마다 호출 — perf hot path.

## Note

`tool_autoresearch.ml:523` `List.assoc key required`도 raise 가능. 별도 PR — caller가 require validation 했다는 가정 검증 필요.
