### PR TITLE
refactor(design-system): replace inline buttons with ActionButton in transport-health (PR-CS1)

### DIFF
--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -15,6 +15,7 @@ import { createManagedAsyncResource } from '../lib/async-state'
 import { TextInput } from './common/input'
 import { StatusDot } from './common/status-dot'
 import { CopyIdButton } from './common/copy-id-button'
+import { ActionButton } from './common/button'
 
 type StatusTone = 'ok' | 'warn' | 'bad'
 
@@ -392,7 +393,7 @@ export function TransportHealthPanel() {
 
   if (!data) return null
   if (!data.summary || !data.agent_health) {
-    return html`<div class="p-6 text-center text-text-muted text-sm">트랜스포트 데이터 불완전. <button class="underline" onClick=${() => void refreshTransportHealth()}>재시도</button></div>`
+    return html`<div class="p-6 text-center text-text-muted text-sm">트랜스포트 데이터 불완전. <${ActionButton} variant="subtle" size="sm" class="underline" onClick=${() => void refreshTransportHealth()}>재시도<//></div>`
   }
 
   const sseStatus = sseTone(data)
@@ -430,10 +431,12 @@ export function TransportHealthPanel() {
             ? html`<div class="mt-1 text-2xs text-text-muted">${truthLine}</div>`
             : null}
         </div>
-        <button
-          class="text-3xs text-text-muted hover:text-text-body transition-colors"
+        <${ActionButton}
+          variant="subtle"
+          size="sm"
+          class="text-3xs"
           onClick=${() => void refreshTransportHealth()}
-        >새로고침</button>
+        >새로고침<//>
       </div>
 
       <details class="group rounded border border-card-border/50 bg-card/18 overflow-hidden" open=${hasAnyBadTransport}>


### PR DESCRIPTION
## Summary

**첫 component-level swap PoC** — PR-M 시리즈(token 문자열 치환)와 다른 차원의 마이그레이션. 실제 인라인 `<button>` 구현을 canonical `ActionButton` 컴포넌트로 교체.

## 발견 — palette divergence

Production dashboard와 design-system은 **다른 색조 시스템**을 사용:

| | Production (`variables.css`) | Design-system (`tokens.css`) |
|--|------------------------------|------------------------------|
| primary | `#eaf1ff` (cool blue) | `#f0e9dc` (warm cream) |
| muted | `#a8bfdf` (cool) | `#7a7065` (warm tan) |
| 의미 | dark blue gothic | dark brass aesthetic |

`--text-muted` → `--color-fg-muted` 같은 sed 치환은 **시각 회귀 발생**. SPEC §6.2 escape hatch 후보로 별도 정리 필요.

대신 본 PR은 **추상화 레벨 교체** — 인라인 `<button>` → 캡슐화된 `ActionButton` 컴포넌트로 갈음. 색상 팔레트는 ActionButton 내부에서 production token(`--text-muted`, `--accent-30`)을 그대로 사용하므로 시각 회귀 0.

## 변경

`dashboard/src/components/transport-health.ts`:

| 위치 | 이전 | 이후 |
|------|------|------|
| 재시도 (불완전 데이터) | `<button class="underline">` | `<${ActionButton} variant="subtle" size="sm" class="underline">` |
| 새로고침 (panel header) | `<button class="text-3xs text-text-muted hover:text-text-body">` | `<${ActionButton} variant="subtle" size="sm" class="text-3xs">` |

ActionButton (`common/button.ts`)이 자동 부여:
- focus-visible:ring (`--accent-45`) → a11y 자동 향상
- active:scale-[0.97] active:opacity-90 → 인터랙션 일관성
- aria-label / title / testId props 표준화

## 안전성

- **시각 회귀 ≈ 0**: ActionButton subtle variant가 동일한 token 사용 (`--text-muted`, `--text-body`)
- **테스트 영향 0**: transport-health.test.ts는 "릴레이 재시도" (MetricRow label)만 검증, 본 PR의 button label 미검증

## Out of scope

- 다른 7개 컴포넌트 (autoresearch, tool-picker 등)의 inline `<button>` swap — 후속 PR
- production ↔ design-system palette 통합 — SPEC 차원 결정 필요

## Test plan

- [ ] CI green (typecheck, lint, vitest)
- [ ] transport-health 페이지에서 재시도/새로고침 버튼 시각 회귀 0
- [ ] 키보드 focus 시 ring 표시 (a11y 향상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
