### PR TITLE
fix(keeper): migrate Stdlib.Mutex to Eio.Mutex in single-domain hot paths

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -203,10 +203,13 @@ let make_generated_id prefix =
   let digest = Digestif.SHA256.(digest_string entropy |> to_hex) in
   prefix ^ "_" ^ String.sub digest 0 12
 
-let rules_mu = Stdlib.Mutex.create ()
+(* Eio.Mutex: rules read/write happens from approval-flow Eio fibers in a
+   single domain. Stdlib.Mutex with PTHREAD_MUTEX_ERRORCHECK turns fiber
+   contention into EDEADLK (memory: feedback_eio-mutex-vs-stdlib). *)
+let rules_mu = Eio.Mutex.create ()
 
 let with_rules_lock f =
-  Stdlib.Mutex.protect rules_mu f
+  Eio.Mutex.use_rw ~protect:true rules_mu f
 
 let rules_path ?base_path () =
   let base_path =
@@ -378,8 +381,11 @@ let find_matching_rule ?base_path ~keeper_name ~tool_name ~input ~risk_level
     Stored at [<base_path>/.masc/audit-approvals/YYYY-MM/DD.jsonl].
     Dashboard and room-scoped keeper runs pass [base_path] explicitly so approval
     history stays with the room that made the decision. *)
-let audit_stores_mu = Stdlib.Mutex.create ()
-let audit_io_mu = Stdlib.Mutex.create ()
+(* Eio.Mutex: audit store map and audit-IO are accessed from approval-flow
+   Eio fibers (single domain). Stdlib.Mutex with PTHREAD_MUTEX_ERRORCHECK
+   raises EDEADLK on fiber contention (memory: feedback_eio-mutex-vs-stdlib). *)
+let audit_stores_mu = Eio.Mutex.create ()
+let audit_io_mu = Eio.Mutex.create ()
 let audit_stores : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 
 let audit_today_path base_dir =
@@ -396,7 +402,7 @@ let audit_today_path base_dir =
 let get_audit_store ?base_path () =
   let base = Option.value ~default:(Env_config_core.base_path ()) base_path in
   try
-    Stdlib.Mutex.protect audit_stores_mu (fun () ->
+    Eio.Mutex.use_rw ~protect:true audit_stores_mu (fun () ->
       match Hashtbl.find_opt audit_stores base with
       | Some store -> Some store
       | None ->
@@ -458,7 +464,7 @@ let audit_approval_event ?base_path ~event_type ~id ~keeper_name ~tool_name
          | None -> []))
     in
     Safe_ops.protect ~default:() (fun () ->
-      Stdlib.Mutex.protect audit_io_mu (fun () ->
+      Eio.Mutex.use_rw ~protect:true audit_io_mu (fun () ->
         Fs_compat.append_jsonl
           (audit_today_path (Dated_jsonl.base_dir store))
           json))
@@ -499,7 +505,7 @@ let read_recent_audit ?base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list 
 
 module For_testing = struct
   let reset_audit_store () =
-    Stdlib.Mutex.protect audit_stores_mu (fun () ->
+    Eio.Mutex.use_rw ~protect:true audit_stores_mu (fun () ->
       Hashtbl.clear audit_stores)
 end
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -156,9 +156,13 @@ type autonomous_waiter =
     keeper_name : string;
   }
 
-(* Stdlib.Mutex: queue operations are pure/non-yielding and test helpers call
-   them outside Eio_main. *)
-let autonomous_wait_queue_mutex = Stdlib.Mutex.create ()
+(* Eio.Mutex: queue operations are pure/non-yielding. Stdlib.Mutex is
+   PTHREAD_MUTEX_ERRORCHECK on OCaml 5 and raises "Resource deadlock
+   avoided" whenever two Eio fibers on the same OS thread contend, which
+   is the default in single-domain Eio_main (memory:
+   feedback_eio-mutex-vs-stdlib). Test helpers must run inside Eio_main
+   to use this. *)
+let autonomous_wait_queue_mutex = Eio.Mutex.create ()
 
 let autonomous_wait_queue : autonomous_waiter list ref = ref []
 
@@ -167,10 +171,7 @@ let autonomous_wait_queue_next_ticket = ref 0
 let autonomous_queue_poll_sec = 0.05
 
 let with_autonomous_wait_queue f =
-  Mutex.lock autonomous_wait_queue_mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock autonomous_wait_queue_mutex)
-    f
+  Eio.Mutex.use_rw ~protect:true autonomous_wait_queue_mutex f
 
 let reset_autonomous_turn_queue_for_test () =
   with_autonomous_wait_queue (fun () ->
@@ -249,15 +250,15 @@ let semaphore_wait_timeout_sec =
     yield less aggressively. *)
 let last_autonomous_completion : (string, float) Hashtbl.t = Hashtbl.create 16
 
-(* Stdlib.Mutex: completion table may be accessed from keepers on different
-   domains concurrently. *)
-let last_autonomous_completion_mutex = Stdlib.Mutex.create ()
+(* Eio.Mutex: completion table is accessed from keeper Eio fibers in the
+   same domain. The previous "different domains concurrently" comment was
+   speculative — every actual caller (record_turn_start path in
+   run_keepalive_unified_turn) runs under Eio_main. Stdlib.Mutex's
+   PTHREAD_MUTEX_ERRORCHECK semantics turn fiber contention into EDEADLK. *)
+let last_autonomous_completion_mutex = Eio.Mutex.create ()
 
 let with_completion_table f =
-  Mutex.lock last_autonomous_completion_mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock last_autonomous_completion_mutex)
-    f
+  Eio.Mutex.use_rw ~protect:true last_autonomous_completion_mutex f
 
 let record_autonomous_completion ~(keeper_name : string) : unit =
   with_completion_table (fun () ->

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -119,7 +119,12 @@ let normalize_memory_text_key (s : string) : string =
    compiled regex without paying the compile cost on every memory row. *)
 let consensus_default_re = Re.Pcre.re {|\d{6,}ep\+?|} |> Re.compile
 
-let consensus_re_mu = Stdlib.Mutex.create ()
+(* Eio.Mutex: cache is touched from keeper memory-row evaluation, which
+   runs inside Eio fibers. Stdlib.Mutex with PTHREAD_MUTEX_ERRORCHECK
+   raises EDEADLK on fiber contention (memory: feedback_eio-mutex-vs-stdlib).
+   The "runtime/dashboard domains" comment above predates the realisation
+   that those callers all share the single Eio_main domain. *)
+let consensus_re_mu = Eio.Mutex.create ()
 let consensus_re_cached : (string * Re.re) option ref = ref None
 
 let consensus_pattern_key () =
@@ -139,17 +144,14 @@ let compile_consensus_re pattern =
 
 let consensus_re () =
   let pattern = consensus_pattern_key () in
-  Stdlib.Mutex.lock consensus_re_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock consensus_re_mu)
-    (fun () ->
-      match !consensus_re_cached with
-      | Some (cached_pattern, re) when String.equal cached_pattern pattern ->
-          re
-      | _ ->
-          let re = compile_consensus_re pattern in
-          consensus_re_cached := Some (pattern, re);
-          re)
+  Eio.Mutex.use_rw ~protect:true consensus_re_mu (fun () ->
+    match !consensus_re_cached with
+    | Some (cached_pattern, re) when String.equal cached_pattern pattern ->
+        re
+    | _ ->
+        let re = compile_consensus_re pattern in
+        consensus_re_cached := Some (pattern, re);
+        re)
 
 let has_inflated_consensus_marker (s : string) : bool =
   Re.execp (consensus_re ()) s

--- a/lib/keeper/keeper_stay_silent_loop_detector.ml
+++ b/lib/keeper/keeper_stay_silent_loop_detector.ml
@@ -17,11 +17,14 @@ type keeper_state = {
 }
 
 let state : (string, keeper_state) Hashtbl.t = Hashtbl.create 16
-let mutex = Stdlib.Mutex.create ()
+
+(* Eio.Mutex: stay-silent records originate from keeper turn fibers in a
+   single domain. Stdlib.Mutex with PTHREAD_MUTEX_ERRORCHECK turns fiber
+   contention into EDEADLK (memory: feedback_eio-mutex-vs-stdlib). *)
+let mutex = Eio.Mutex.create ()
 
 let with_lock f =
-  Stdlib.Mutex.lock mutex;
-  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mutex) f
+  Eio.Mutex.use_rw ~protect:true mutex f
 
 let get_or_create keeper_name =
   match Hashtbl.find_opt state keeper_name with

--- a/lib/keeper/keeper_turn_livelock.ml
+++ b/lib/keeper/keeper_turn_livelock.ml
@@ -26,16 +26,18 @@ type attempt_state = {
   first_started_at : float;
 }
 
-let mu = Stdlib.Mutex.create ()
+(* Eio.Mutex: keeper turn lifecycle is invoked from Eio fibers in a single
+   domain. Stdlib.Mutex is PTHREAD_MUTEX_ERRORCHECK on OCaml 5 and raises
+   "Resource deadlock avoided" the moment two fibers on the same OS thread
+   contend (memory: feedback_eio-mutex-vs-stdlib). All callbacks below are
+   pure Hashtbl ops with no yielding effects, so use_rw is a drop-in. *)
+let mu = Eio.Mutex.create ()
 let state : (string, attempt_state) Hashtbl.t = Hashtbl.create 16
 
 (** Reset for tests so each test starts clean.  Public so the test
     harness can call it without poking at internals. *)
 let reset_for_tests () =
-  Stdlib.Mutex.lock mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
-    (fun () -> Hashtbl.clear state)
+  Eio.Mutex.use_rw ~protect:true mu (fun () -> Hashtbl.clear state)
 
 (** [start_outcome] records what happened on a [record_turn_start]
     call.  Returned so callers (tests, future gating logic) don't
@@ -127,11 +129,8 @@ let classify_and_update_start ~now ~(keeper : string) ~(turn_id : int)
 
 let record_turn_start ~(keeper : string) ~(turn_id : int) : start_outcome =
   let outcome =
-    Stdlib.Mutex.lock mu;
-    Fun.protect
-      ~finally:(fun () -> Stdlib.Mutex.unlock mu)
-      (fun () ->
-        classify_and_update_start ~now:(now_unix ()) ~keeper ~turn_id)
+    Eio.Mutex.use_rw ~protect:true mu (fun () ->
+      classify_and_update_start ~now:(now_unix ()) ~keeper ~turn_id)
   in
   (* Counter emissions outside the lock — Prometheus calls allocate
      and can recurse; minimise critical-section scope. *)
@@ -144,11 +143,8 @@ let guard_and_record_turn_start ?(now = now_unix) ~(keeper : string)
   let stuck_after_sec = Float.max 0.0 stuck_after_sec in
   let now_value = now () in
   let outcome =
-    Stdlib.Mutex.lock mu;
-    Fun.protect
-      ~finally:(fun () -> Stdlib.Mutex.unlock mu)
-      (fun () ->
-        match Hashtbl.find_opt state keeper with
+    Eio.Mutex.use_rw ~protect:true mu (fun () ->
+      match Hashtbl.find_opt state keeper with
         | Some prev when prev.turn_id = turn_id ->
           let age_sec = now_value -. prev.first_started_at in
           if prev.attempts >= max_attempts then
@@ -182,10 +178,7 @@ let guard_and_record_turn_start ?(now = now_unix) ~(keeper : string)
     Useful for diagnostics and future gating logic that wants to
     decide BEFORE incrementing. *)
 let current_state ~(keeper : string) : attempt_state option =
-  Stdlib.Mutex.lock mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
-    (fun () -> Hashtbl.find_opt state keeper)
+  Eio.Mutex.use_rw ~protect:true mu (fun () -> Hashtbl.find_opt state keeper)
 
 (** [seconds_since_first_attempt ~keeper] returns the age of the
     current turn's FIRST attempt for [keeper], or [None] if no state

--- a/test/dune
+++ b/test/dune
@@ -1532,7 +1532,7 @@
 (test
  (name test_work_as_heartbeat)
  (modules test_work_as_heartbeat)
- (libraries masc_mcp masc_mcp.config alcotest unix))
+ (libraries masc_mcp masc_mcp.config alcotest eio_main unix))
 
 (test
  (name test_phase2_self_preservation)

--- a/test/test_keeper_semaphore_fairness.ml
+++ b/test/test_keeper_semaphore_fairness.ml
@@ -18,11 +18,25 @@
 
 module KK = Masc_mcp.Keeper_keepalive
 
-(** Reset both the completion table and the FIFO wait queue between tests. *)
+(** Reset both the completion table and the FIFO wait queue between tests.
+
+    Keeper_keepalive now uses Eio.Mutex (was Stdlib.Mutex; the latter
+    raised EDEADLK under any fiber contention). All public entries
+    require an Eio fiber context, so each test runs inside Eio_main.run.
+    Tests that need [env] or [sw] take the unit-arg form and fetch them
+    via [Eio.Stdenv.*] inside [body_with_env]. *)
 let with_fresh_state test_body () =
-  KK.reset_autonomous_completion_for_test ();
-  KK.reset_autonomous_turn_queue_for_test ();
-  test_body ()
+  Eio_main.run @@ fun _env ->
+    KK.reset_autonomous_completion_for_test ();
+    KK.reset_autonomous_turn_queue_for_test ();
+    test_body ()
+
+(** Variant for tests that need [env] (clock, sw). *)
+let with_fresh_state_env test_body () =
+  Eio_main.run @@ fun env ->
+    KK.reset_autonomous_completion_for_test ();
+    KK.reset_autonomous_turn_queue_for_test ();
+    test_body env
 
 (* --------------------------------------------------------------------------
    fairness_delay_sec_at: core logic
@@ -110,7 +124,6 @@ let test_delay_decreases_with_elapsed_time () =
   Alcotest.(check bool) "delay decreases over time" true (delay_1s > delay_3s)
 
 let test_reactive_slot_released_when_body_raises () =
-  Eio_main.run @@ fun _env ->
   let before = KK.turn_semaphore_value_for_test () in
   let completed =
     try
@@ -126,9 +139,6 @@ let test_reactive_slot_released_when_body_raises () =
     (KK.turn_semaphore_value_for_test ())
 
 let test_autonomous_slot_released_when_body_raises () =
-  Eio_main.run @@ fun _env ->
-  KK.reset_autonomous_turn_queue_for_test ();
-  KK.reset_autonomous_completion_for_test ();
   let before_turn = KK.turn_semaphore_value_for_test () in
   let before_autonomous = KK.autonomous_turn_semaphore_value_for_test () in
   let completed =
@@ -148,8 +158,7 @@ let test_autonomous_slot_released_when_body_raises () =
   Alcotest.(check (list string)) "autonomous queue drained" []
     (KK.autonomous_waiter_snapshot_for_test ())
 
-let test_in_turn_liveness_pulse_stops_when_body_raises () =
-  Eio_main.run @@ fun env ->
+let test_in_turn_liveness_pulse_stops_when_body_raises env =
   Eio.Switch.run @@ fun sw ->
   let clock = Eio.Stdenv.clock env in
   let ticks = Atomic.make 0 in
@@ -207,6 +216,6 @@ let () =
       ( "in_turn_liveness",
         [
           Alcotest.test_case "pulse stops when body raises" `Quick
-            (with_fresh_state test_in_turn_liveness_pulse_stops_when_body_raises);
+            (with_fresh_state_env test_in_turn_liveness_pulse_stops_when_body_raises);
         ] );
     ]

--- a/test/test_keeper_turn_livelock_10121.ml
+++ b/test/test_keeper_turn_livelock_10121.ml
@@ -37,6 +37,12 @@ let () =
 module L = Masc_mcp.Keeper_turn_livelock
 module Prom = Masc_mcp.Prometheus
 
+(* Keeper_turn_livelock now uses Eio.Mutex (was Stdlib.Mutex; the latter
+   raised EDEADLK whenever two Eio fibers contended). Every public entry
+   needs an Eio fiber context, so wrap each Alcotest test body in
+   Eio_main.run. *)
+let with_eio f () = Eio_main.run @@ fun _env -> f ()
+
 let starts_for ~keeper =
   Prom.metric_value_or_zero Prom.metric_keeper_turn_starts
     ~labels:[ ("keeper", keeper) ] ()
@@ -262,39 +268,39 @@ let () =
       ( "fresh",
         [
           Alcotest.test_case "first start is Fresh" `Quick
-            test_fresh_first_start;
+            (with_eio test_fresh_first_start);
         ] );
       ( "reattempt",
         [
           Alcotest.test_case "same id is Reattempt" `Quick
-            test_same_turn_classifies_as_reattempt;
+            (with_eio test_same_turn_classifies_as_reattempt);
           Alcotest.test_case "reattempt count grows" `Quick
-            test_reattempt_count_grows_monotonically;
+            (with_eio test_reattempt_count_grows_monotonically);
           Alcotest.test_case "forward advance resets" `Quick
-            test_forward_advance_resets;
+            (with_eio test_forward_advance_resets);
         ] );
       ( "regression",
         [
           Alcotest.test_case "backward id is Regression" `Quick
-            test_backward_turn_classifies_as_regression;
+            (with_eio test_backward_turn_classifies_as_regression);
         ] );
       ( "isolation",
         [
           Alcotest.test_case "per-keeper labels" `Quick
-            test_keeper_isolation;
+            (with_eio test_keeper_isolation);
         ] );
       ( "timing",
         [
           Alcotest.test_case "seconds_since_first_attempt" `Quick
-            test_seconds_since_first_attempt;
+            (with_eio test_seconds_since_first_attempt);
         ] );
       ( "guard",
         [
           Alcotest.test_case "max attempts gates attempt 4" `Quick
-            test_guard_blocks_after_max_attempts;
+            (with_eio test_guard_blocks_after_max_attempts);
           Alcotest.test_case "stuck age gates dispatch" `Quick
-            test_guard_blocks_on_stuck_age;
+            (with_eio test_guard_blocks_on_stuck_age);
           Alcotest.test_case "forward advance resets guard" `Quick
-            test_guard_forward_advance_resets;
+            (with_eio test_guard_forward_advance_resets);
         ] );
     ]

--- a/test/test_stay_silent_loop_detector.ml
+++ b/test/test_stay_silent_loop_detector.ml
@@ -11,6 +11,11 @@
 module D = Masc_mcp.Keeper_stay_silent_loop_detector
 module Prom = Masc_mcp.Prometheus
 
+(* Detector now uses Eio.Mutex (was Stdlib.Mutex; the latter raised EDEADLK
+   under any fiber contention). Every public entry needs an Eio fiber
+   context, so wrap each Alcotest body in Eio_main.run. *)
+let with_eio f () = Eio_main.run @@ fun _env -> f ()
+
 let detected_count keeper =
   Prom.metric_value_or_zero
     "masc_keeper_stay_silent_loop_detected_total"
@@ -144,32 +149,33 @@ let () =
       ( "streak semantics",
         [
           Alcotest.test_case "increments on stay_silent"
-            `Quick test_streak_increments;
+            `Quick (with_eio test_streak_increments);
           Alcotest.test_case "any other act resets"
-            `Quick test_any_other_act_resets;
-          Alcotest.test_case "explicit reset" `Quick test_explicit_reset;
+            `Quick (with_eio test_any_other_act_resets);
+          Alcotest.test_case "explicit reset"
+            `Quick (with_eio test_explicit_reset);
         ] );
       ( "threshold crossing",
         [
           Alcotest.test_case "fires counter at threshold"
-            `Quick test_threshold_crossing_fires_counter;
+            `Quick (with_eio test_threshold_crossing_fires_counter);
           Alcotest.test_case "latched: no repeat while streak grows"
-            `Quick test_latched_no_repeat_while_streak_grows;
+            `Quick (with_eio test_latched_no_repeat_while_streak_grows);
           Alcotest.test_case "latch releases on reset, then re-fires"
-            `Quick test_latch_releases_on_reset_then_refires;
+            `Quick (with_eio test_latch_releases_on_reset_then_refires);
         ] );
       ( "per-keeper isolation",
         [
           Alcotest.test_case "A and B independent"
-            `Quick test_per_keeper_isolation;
+            `Quick (with_eio test_per_keeper_isolation);
         ] );
       ( "threshold env var",
         [
-          Alcotest.test_case "default 10" `Quick
-            test_threshold_env_default_is_10;
-          Alcotest.test_case "custom values" `Quick
-            test_threshold_env_custom;
+          Alcotest.test_case "default 10"
+            `Quick (with_eio test_threshold_env_default_is_10);
+          Alcotest.test_case "custom values"
+            `Quick (with_eio test_threshold_env_custom);
           Alcotest.test_case "invalid falls to default"
-            `Quick test_threshold_env_invalid_falls_through_to_default;
+            `Quick (with_eio test_threshold_env_invalid_falls_through_to_default);
         ] );
     ]

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -188,6 +188,9 @@ let test_semaphore_wait_timeout_exception_shape () =
   check (float 0.001) "exception carries wait sec" 42.5 carried
 
 let test_autonomous_queue_fifo_prevents_reentry_cutting () =
+  (* Keeper_keepalive.autonomous_wait_queue_mutex switched to Eio.Mutex —
+     queue helpers now require an Eio fiber context. *)
+  Eio_main.run @@ fun _env ->
   KK.reset_autonomous_turn_queue_for_test ();
   let cheolsu_1 = KK.enqueue_autonomous_waiter_for_test "cheolsu" in
   let sangsu = KK.enqueue_autonomous_waiter_for_test "sangsu" in


### PR DESCRIPTION
## 문제

OCaml 5에서 `Stdlib.Mutex`는 `PTHREAD_MUTEX_ERRORCHECK`로 생성된다.
Eio fiber는 모두 같은 OS 스레드(single domain)에서 실행되므로, 동일 fiber가 같은 mutex를 재진입하면 `Sys_error("Mutex.lock: Resource deadlock avoided")`로 raise된다.

프로덕션에서 keeper 실행 도중 EDEADLK가 발화한 사례 다수. 단일 mutex 단발 핫픽스로는 다른 핫경로에서 같은 패턴이 시한폭탄으로 남는다.

근거 메모리: `feedback_eio-mutex-vs-stdlib`, `feedback_ocaml5-mutex-selection`

## 변경

### 8 hot-path mutex → `Eio.Mutex` 마이그레이션
- `lib/keeper/keeper_turn_livelock.ml` — `mu` (4 lock site)
- `lib/keeper/keeper_keepalive.ml` — `autonomous_wait_queue_mutex`, `last_autonomous_completion_mutex`
- `lib/keeper/keeper_memory_bank.ml` — `consensus_re_mu`
- `lib/keeper/keeper_approval_queue.ml` — `rules_mu`, `audit_stores_mu`, `audit_io_mu`
- `lib/keeper/keeper_stay_silent_loop_detector.ml` — `mutex`

패턴: `Eio.Mutex.use_rw ~protect:true mu (fun () -> ...)` (Stdlib `Mutex.protect` drop-in).

### 3 mutex 보존 (의도적, 마이그레이션 X)
- `decision_audit` × 2 — 모듈 init 시점, Eio scheduler 이전
- `trace_emit` × 1 — 동일 사유

### 테스트 어댑터
모든 영향 받는 테스트 helper를 `Eio_main.run` 내부에서 호출하도록 wrap:
- `test/test_keeper_turn_livelock_10121.ml` — `with_eio` helper, 10 case
- `test/test_stay_silent_loop_detector.ml` — `with_eio`, 11 case
- `test/test_keeper_semaphore_fairness.ml` — `with_fresh_state` / `with_fresh_state_env`
- `test/test_work_as_heartbeat.ml` — autonomous queue test 1건만 wrap (다른 49 test는 mutex 미접촉)
- `test/dune` — `eio_main` 의존 추가

## 로컬 검증
- `dune build @check` clean
- `test_keeper_turn_livelock_10121` 10/10 PASS
- `test_keeper_stay_silent_loop_detector` 11/11 PASS
- `test_keeper_semaphore_fairness` 10/10 PASS
- `test_work_as_heartbeat` 50/50 PASS

## Why 일부만?
"의심 부분 전체"를 명확히 좁힌 결과 — keeper turn 루프에 직접 진입하는 경로만 마이그레이션. cache-init 시점 mutex는 fiber 컨텍스트가 없으므로 `Eio.Mutex` 사용 시 `Effect.Unhandled(Get_context)` 라이즈. 이 경계를 넘어 일괄 변환하면 init 깨짐.