### PR TITLE
feat(dashboard): localize 9 chips/labels across 5 components (round-25)

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -376,7 +376,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
   const visibleSurfaces = DASHBOARD_SURFACES.filter(surface => surface.hidden !== true)
 
   return html`
-    <nav class="flex flex-col h-full" aria-label="Dashboard navigation">
+    <nav class="flex flex-col h-full" aria-label="대시보드 내비게이션">
       <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-2 pt-2 pb-1">
         ${!collapsed ? html`
           <div class="px-1">

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -202,7 +202,7 @@ function PhaseSparkline({
         viewBox=${`0 0 ${W} ${H}`}
         class="shrink-0"
         role="img"
-        aria-label="Phase duration sparkline"
+        aria-label="단계 지속시간 스파크라인"
       >
         ${bars.map((b) => html`
           <rect

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -657,7 +657,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
   if (repos.length === 0 && prs.length === 0 && worktrees.length === 0) return null
 
   return html`
-    <${SectionCard} title="Playground">
+    <${SectionCard} title="플레이그라운드">
       <div class="flex flex-col gap-3">
         ${repos.length > 0 ? html`
           <div>

--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -76,11 +76,11 @@ describe('KeeperToolCallInspector render', () => {
     })
     await flushUi()
 
-    const inputCopy = container.querySelector('[aria-label="Copy tool call input"]') as HTMLButtonElement | null
-    const outputCopy = container.querySelector('[aria-label="Copy tool call output"]') as HTMLButtonElement | null
+    const inputCopy = container.querySelector('[aria-label="도구 호출 입력 복사"]') as HTMLButtonElement | null
+    const outputCopy = container.querySelector('[aria-label="도구 호출 출력 복사"]') as HTMLButtonElement | null
     expect(inputCopy).not.toBeNull()
     expect(outputCopy).not.toBeNull()
-    expect(inputCopy?.getAttribute('title')).toBe('Copy tool call input')
-    expect(outputCopy?.getAttribute('title')).toBe('Copy tool call output')
+    expect(inputCopy?.getAttribute('title')).toBe('도구 호출 입력 복사')
+    expect(outputCopy?.getAttribute('title')).toBe('도구 호출 출력 복사')
   })
 })

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -163,16 +163,16 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
             <div class="text-3xs text-[var(--color-fg-muted)]">model: <span class="text-[var(--color-fg-secondary)] font-mono">${entry.model}</span></div>
           ` : null}
           <${CopyableToolCallBlock}
-            title="Input"
+            title="입력"
             value=${formattedInput}
             maxHeightClass="max-h-48"
-            ariaLabel="Copy tool call input"
+            ariaLabel="도구 호출 입력 복사"
           />
           <${CopyableToolCallBlock}
-            title="Output"
+            title="출력"
             value=${formattedOutput}
             maxHeightClass="max-h-64"
-            ariaLabel="Copy tool call output"
+            ariaLabel="도구 호출 출력 복사"
           />
         </div>
       ` : null}
@@ -242,7 +242,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
         <${FreshnessLine} data=${response ?? { source: 'tool_call_io' }} />
         <input
           type="text"
-          placeholder="Filter tool..."
+          placeholder="도구 필터..."
           class="text-xs font-mono bg-[var(--bg-deep)] border border-[var(--color-border-default)] rounded px-2 py-1 w-40 text-[var(--color-fg-secondary)]"
           value=${filterTool.value}
           onInput=${(e: Event) => { filterTool.value = (e.target as HTMLInputElement).value }}

--- a/dashboard/src/components/safe-autonomy.ts
+++ b/dashboard/src/components/safe-autonomy.ts
@@ -383,15 +383,15 @@ export function SafeAutonomyPanel() {
               <//>
 
               <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-                <${Card} title="Findings" class="section">
+                <${Card} title="발견" class="section">
                   <${FindingsList} findings=${data.findings} />
                 <//>
-                <${Card} title="Timeline" class="section">
+                <${Card} title="타임라인" class="section">
                   <${TimelineList} timeline=${data.timeline} />
                 <//>
               </div>
 
-              <${JsonViewerCard} title="Artifacts" data=${data.artifacts} />
+              <${JsonViewerCard} title="아티팩트" data=${data.artifacts} />
             </div>
           `}
         />


### PR DESCRIPTION
## Summary

영한혼용 금지 (memory: feedback_dashboard-observation-focus) 후속 작업. round-24 (#10644 Draft) 와 file overlap 없음.

### 변경 내용

| 파일 | chip / label |
|------|--------------|
| \`keeper-tool-call-inspector.ts\` | CopyableToolCallBlock title Input/Output → 입력/출력, ariaLabel "Copy tool call input/output" → "도구 호출 입력/출력 복사", placeholder "Filter tool..." → "도구 필터..." |
| \`keeper-detail.ts\` | SectionCard "Playground" → "플레이그라운드" |
| \`safe-autonomy.ts\` | Card titles "Findings"/"Timeline"/"Artifacts" → "발견"/"타임라인"/"아티팩트" |
| \`dashboard-shell.ts\` | nav aria-label "Dashboard navigation" → "대시보드 내비게이션" |
| \`fsm-hub-pipeline-panels.ts\` | svg aria-label "Phase duration sparkline" → "단계 지속시간 스파크라인" |

### 보존 ledger (이번 라운드 의도적 미변경)

- \`MASC Core\` (제품명, dashboard-shell.ts:384)
- \`OAS\`, \`HITL\`, \`Anti-Rationalization\`, \`WebSocket\`, \`WebRTC\`, \`GitHub\`, \`Composite observer is_live count\` (제품명/프로토콜/도메인 식별자/diagnostic technical name)

### 검증

- Test fixture 에 위 string reference 없음 (rg 확인).
- vitest 는 dashboard 전역에서 #10645 의 \`AArrowDown\` infra 회귀로 95 file fail 중 — 별도 issue, 이 PR 무관.
- chip text 만 수정, 로직/타입 무변경.

## Test plan

- [ ] dashboard build 후 5 component 한국어 렌더링 확인
- [ ] vitest infra (#10645) 회복 후 5 component test 회귀 없음 확인