### PR TITLE
perf(text-similarity): fold lowercase+transform into String.map (3 allocs -> 1)

### DIFF
--- a/lib/core/text_similarity.ml
+++ b/lib/core/text_similarity.ml
@@ -9,21 +9,24 @@ module StringMap = Map.Make (String)
     These functions have no external dependencies beyond Stdlib. *)
 
 (** Strip non-alphanumeric ASCII, keep multibyte (CJK, etc.) and digits.
-    Returns a cleaned lowercase string for tokenization. *)
+    Returns a cleaned lowercase string for tokenization.
+
+    [String.map] folds lowercase + transform into one allocation; the
+    previous implementation chained three (lowercase_ascii ->
+    Bytes.of_string -> Bytes.to_string). Hot in keeper memory recall
+    and tool dispatch fuzzy matching. *)
 let clean_for_similarity (s : string) : string =
-  let s = String.lowercase_ascii s in
-  let b = Bytes.of_string s in
-  for i = 0 to Bytes.length b - 1 do
-    let c = Bytes.get b i in
-    let code = Char.code c in
-    let keep =
-      (c >= 'a' && c <= 'z') ||
-      (c >= '0' && c <= '9') ||
-      code >= 128
-    in
-    if not keep then Bytes.set b i ' '
-  done;
-  Bytes.to_string b
+  String.map
+    (fun c ->
+      let lc = Char.lowercase_ascii c in
+      let code = Char.code lc in
+      let keep =
+        (lc >= 'a' && lc <= 'z') ||
+        (lc >= '0' && lc <= '9') ||
+        code >= 128
+      in
+      if keep then lc else ' ')
+    s
 
 (** Extract unique word tokens (space-split, length >= 2). *)
 let normalize_for_similarity (s : string) : string list =


### PR DESCRIPTION
## What

`lib/core/text_similarity.clean_for_similarity` 함수를 `String.map` 단일 패스로 변환. allocation 3 -> 1.

## Why

기존 구현 (lines 13-26):
1. `String.lowercase_ascii s` — alloc 1
2. `Bytes.of_string s` — alloc 2 (lowercase 결과 복사)
3. for loop으로 `Bytes.set b i ' '` — in-place mutation
4. `Bytes.to_string b` — alloc 3

`String.map`은 character mapper로 lowercase + filter를 한 패스로 — alloc 1.

## Hot path

`clean_for_similarity`는 `Text_similarity` jaccard/n-gram 계산의 첫 단계. callers:
- `lib/keeper/keeper_memory_bank.ml`: keeper 기억 recall fuzzy match
- `lib/keeper/keeper_memory_recall.ml`: 동상
- `lib/tool_dispatch.ml`: tool 이름 fuzzy match
- `lib/tool_input_validation.ml`: 파라미터 이름 similarity (jaccard fallback)

매 keeper turn × 매 tool 후보마다 호출. 짧은 string (tool name ~30 bytes) × N候補 = ~수백 호출/turn.

## Semantics

- 원본: lowercased byte에 keep predicate 적용
- 변환: `String.map` 콜백 안에서 `Char.lowercase_ascii` 후 keep predicate. 결과 동등 — lowercased char의 분류 = upper char의 lowercase 분류.

`String.map`은 OCaml 4.02+ stdlib 안정 API.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean. test_text_similarity 자체는 없지만 4 caller 테스트가 통과하면 통합 검증.

## Sweep series

`String_util` family 다음 단계. 단일 함수 변환이지만 hot path × 3 alloc/call 절감 → high ROI.
