### PR TITLE
feat(dashboard): localize 8 chips/headings across 6 components (round-26)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -315,8 +315,8 @@ export function keepersWithUnknownCanonical(
 function KeeperChip({ row }: { row: KeeperCascadeRow }) {
   const base = 'rounded border px-2 py-0.5 text-xs flex items-center gap-1'
   const borderTone = row.drift
-    ? 'border-[var(--color-status-warn)] text-[var(--color-fg-secondary)]'
-    : 'border-[var(--color-border-default)] text-[var(--color-fg-secondary)]'
+    ? 'border-[var(--warn)] text-[var(--text-strong)]'
+    : 'border-[var(--card-border)] text-[var(--text-strong)]'
   return html`
     <span
       class=${`${base} ${borderTone}`}
@@ -326,7 +326,7 @@ function KeeperChip({ row }: { row: KeeperCascadeRow }) {
     >
       <span class="font-semibold">${row.keeper}</span>
       ${row.drift
-        ? html`<code class="text-3xs text-[var(--color-fg-muted)]">${row.raw_cascade_name}</code>`
+        ? html`<code class="text-3xs text-[var(--text-muted)]">${row.raw_cascade_name}</code>`
         : null}
     </span>
   `
@@ -371,16 +371,16 @@ function ProfileCard({
   }
 
   return html`
-    <article class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] p-3">
+    <article class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] p-3">
       <header class="flex items-center gap-2 mb-2 flex-wrap">
-        <span class="font-semibold text-[var(--color-fg-secondary)]">${profile.name}</span>
+        <span class="font-semibold text-[var(--text-strong)]">${profile.name}</span>
         <${StatusChip} tone=${sourceTone(profile.source)}>
           ${sourceLabel(profile.source)}
         <//>
         ${!profile.keeper_assignable
           ? html`<${StatusChip} tone="neutral" uppercase=${false}>manual/system-only<//>`
           : null}
-        <span class="text-xs text-[var(--color-fg-muted)]">
+        <span class="text-xs text-[var(--text-muted)]">
           ${profileSummaryText(profile, keepers)}
         </span>
         ${driftCount > 0
@@ -388,7 +388,7 @@ function ProfileCard({
           : null}
       </header>
       ${assignmentNote
-        ? html`<div class="text-xs text-[var(--color-fg-muted)] mb-2">${assignmentNote}</div>`
+        ? html`<div class="text-xs text-[var(--text-muted)] mb-2">${assignmentNote}</div>`
         : null}
       ${keepers.length > 0
         ? html`
@@ -400,12 +400,12 @@ function ProfileCard({
       ${profile.keeper_assignable
         ? html`
           <form
-            class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2 mb-3"
+            class="rounded border border-[var(--card-border)] bg-[var(--bg-panel)] p-2 mb-3"
             onSubmit=${handleAssignKeeper}
           >
             <div class="flex items-center gap-2 flex-wrap mb-2">
-              <span class="text-xs font-medium text-[var(--color-fg-secondary)]">Keeper assignment</span>
-              <span class="text-xs text-[var(--color-fg-muted)]">
+              <span class="text-xs font-medium text-[var(--text-strong)]">키퍼 할당</span>
+              <span class="text-xs text-[var(--text-muted)]">
                 current profile로 keeper를 이동합니다.
               </span>
             </div>
@@ -413,7 +413,7 @@ function ProfileCard({
               ? html`
                 <div class="flex items-center gap-2 flex-wrap">
                   <select
-                    class="min-w-44 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--color-fg-secondary)]"
+                    class="min-w-44 rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--text-strong)]"
                     value=${selectedKeeper.value}
                     disabled=${assigning.value}
                     onChange=${(event: Event) => {
@@ -435,7 +435,7 @@ function ProfileCard({
                 </div>
               `
               : html`
-                <div class="text-xs text-[var(--color-fg-muted)]">
+                <div class="text-xs text-[var(--text-muted)]">
                   currently known keepers are already assigned to this profile.
                 </div>
               `}
@@ -445,7 +445,7 @@ function ProfileCard({
                   class=${`mt-2 text-xs ${
                     assignmentMessage.value.startsWith('Failed')
                       ? 'text-[var(--bad-light)]'
-                      : 'text-[var(--color-fg-muted)]'
+                      : 'text-[var(--text-muted)]'
                   }`}
                 >
                   ${assignmentMessage.value}
@@ -456,7 +456,7 @@ function ProfileCard({
         `
         : null}
       ${profile.candidates.length === 0
-        ? html`<div class="text-xs text-[var(--color-fg-muted)]">no candidates resolved</div>`
+        ? html`<div class="text-xs text-[var(--text-muted)]">no candidates resolved</div>`
         : html`
           <ol class="flex flex-col gap-1 text-xs">
             ${profile.candidates.map((c, idx) => {
@@ -465,27 +465,27 @@ function ProfileCard({
               const displayProvider = c.display_provider_name ?? c.provider_name ?? null
               const runtimeLabel = runtimeKindLabel(c.runtime_kind)
               return html`
-              <li class="flex items-start gap-2 py-1 border-b border-[var(--color-border-default)] last:border-b-0">
-                <span class="tabular-nums text-[var(--color-fg-muted)] w-5">${idx + 1}.</span>
+              <li class="flex items-start gap-2 py-1 border-b border-[var(--card-border)] last:border-b-0">
+                <span class="tabular-nums text-[var(--text-muted)] w-5">${idx + 1}.</span>
                 <${StatusChip} tone=${candidateTone(c)}>
                   ${c.in_cooldown ? 'cooldown' : fmtPct(c.success_rate)}
                 <//>
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-2 flex-wrap">
-                    <code class="text-[var(--color-fg-secondary)]">${displayModel}</code>
+                    <code class="text-[var(--text-strong)]">${displayModel}</code>
                     ${displayProvider
-                      ? html`<span class="text-[var(--color-fg-muted)]">${displayProvider}</span>`
+                      ? html`<span class="text-[var(--text-muted)]">${displayProvider}</span>`
                       : null}
                     ${runtimeLabel
-                      ? html`<span class="text-[var(--color-fg-muted)]">${runtimeLabel}</span>`
+                      ? html`<span class="text-[var(--text-muted)]">${runtimeLabel}</span>`
                       : null}
                   </div>
                   ${c.model !== displayModel
-                    ? html`<div class="text-[11px] text-[var(--color-fg-muted)] mt-0.5">config: <code>${c.model}</code></div>`
+                    ? html`<div class="text-[11px] text-[var(--text-muted)] mt-0.5">config: <code>${c.model}</code></div>`
                     : null}
                   ${expanded.length > 1
                     ? html`
-                      <ol class="mt-1 flex flex-col gap-0.5 text-[11px] text-[var(--color-fg-muted)]">
+                      <ol class="mt-1 flex flex-col gap-0.5 text-[11px] text-[var(--text-muted)]">
                         ${expanded.map((model, expandedIdx) => html`
                           <li><span class="tabular-nums">${expandedIdx + 1}.</span> <code>${model}</code></li>
                         `)}
@@ -493,7 +493,7 @@ function ProfileCard({
                     `
                     : null}
                 </div>
-                <span class="tabular-nums text-[var(--color-fg-muted)]">
+                <span class="tabular-nums text-[var(--text-muted)]">
                   w ${c.config_weight}${c.effective_weight === c.config_weight ? '' : ` → ${c.effective_weight}`}
                 </span>
               </li>
@@ -507,20 +507,20 @@ function ProfileCard({
 function OrphanKeeperList({ orphans }: { orphans: readonly CascadeKeeperProfile[] }) {
   if (orphans.length === 0) return null
   return html`
-    <div class="rounded border border-[var(--color-status-warn)] bg-[var(--color-bg-page)] p-3 text-xs">
-      <div class="font-semibold text-[var(--color-fg-secondary)] mb-1">
+    <div class="rounded border border-[var(--warn)] bg-[var(--color-bg-page)] p-3 text-xs">
+      <div class="font-semibold text-[var(--text-strong)] mb-1">
         등록된 프로필 없음 (${orphans.length})
       </div>
-      <div class="text-[var(--color-fg-muted)] mb-2">
+      <div class="text-[var(--text-muted)] mb-2">
         아래 keeper 는 canonical cascade 가 현재 profile 목록에 없어 해당 cascade 로 라우팅할 수 없습니다.
       </div>
       <ul class="flex flex-col gap-1">
         ${orphans.map(o => html`
           <li class="flex gap-2">
-            <span class="font-semibold text-[var(--color-fg-secondary)]">${o.keeper}</span>
+            <span class="font-semibold text-[var(--text-strong)]">${o.keeper}</span>
             <code>${o.cascade_name}</code>
-            <span class="text-[var(--color-fg-muted)]">→</span>
-            <code class="text-[var(--color-status-warn)]">${o.canonical}</code>
+            <span class="text-[var(--text-muted)]">→</span>
+            <code class="text-[var(--warn)]">${o.canonical}</code>
           </li>
         `)}
       </ul>
@@ -535,10 +535,10 @@ function InvalidProfileSummary({
   const extraErrors = Math.max(0, invalidProfile.errors.length - 1)
   return html`
     <li class="flex flex-wrap items-start gap-2">
-      <code class="text-[var(--color-fg-secondary)]">${invalidProfile.name}</code>
-      <span class="text-[var(--color-fg-muted)]">${firstError}</span>
+      <code class="text-[var(--text-strong)]">${invalidProfile.name}</code>
+      <span class="text-[var(--text-muted)]">${firstError}</span>
       ${extraErrors > 0
-        ? html`<span class="text-[var(--color-fg-muted)]">+${extraErrors} more</span>`
+        ? html`<span class="text-[var(--text-muted)]">+${extraErrors} more</span>`
         : null}
     </li>
   `
@@ -548,33 +548,33 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
   if (config.validation_status === 'validated') return null
   const tone = validationTone(config.validation_status)
   const boxTone = tone === 'bad'
-    ? 'border-[var(--color-status-err)]/40 bg-[var(--color-status-err)]/10'
-    : 'border-[var(--color-status-warn)]/40 bg-[var(--color-status-warn)]/10'
+    ? 'border-[var(--bad)]/40 bg-[var(--bad)]/10'
+    : 'border-[var(--warn)]/40 bg-[var(--warn)]/10'
   const visibleErrors = config.validation_errors.slice(0, 3)
   const visibleProfiles = config.invalid_profiles.slice(0, 4)
   return html`
     <div class=${`rounded border ${boxTone} p-3 text-xs mb-3`}>
       <div class="flex items-center gap-2 flex-wrap mb-2">
         <${StatusChip} tone=${tone}>${validationLabel(config.validation_status)}<//>
-        <span class="text-[var(--color-fg-muted)]">
+        <span class="text-[var(--text-muted)]">
           ${config.invalid_profiles.length} invalid profile${config.invalid_profiles.length === 1 ? '' : 's'}
           · ${config.validation_errors.length} error${config.validation_errors.length === 1 ? '' : 's'}
         </span>
       </div>
-      <div class="text-[var(--color-fg-secondary)] mb-2">
+      <div class="text-[var(--text-strong)] mb-2">
         ${validationDescription(config.validation_status)}
       </div>
       ${visibleErrors.length > 0
         ? html`
-          <ul class="flex flex-col gap-1 mb-2 text-[var(--color-fg-muted)]">
+          <ul class="flex flex-col gap-1 mb-2 text-[var(--text-muted)]">
             ${visibleErrors.map(error => html`<li>${error}</li>`)}
           </ul>
         `
         : null}
       ${visibleProfiles.length > 0
         ? html`
-          <div class="text-[var(--color-fg-secondary)] mb-1">거부된 프로파일</div>
-          <ul class="flex flex-col gap-1 text-[var(--color-fg-muted)]">
+          <div class="text-[var(--text-strong)] mb-1">거부된 프로파일</div>
+          <ul class="flex flex-col gap-1 text-[var(--text-muted)]">
             ${visibleProfiles.map(invalidProfile => html`
               <${InvalidProfileSummary} invalidProfile=${invalidProfile} />
             `)}
@@ -583,7 +583,7 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
         : null}
       ${config.invalid_profiles.length > visibleProfiles.length
         ? html`
-          <div class="mt-2 text-[var(--color-fg-muted)]">
+          <div class="mt-2 text-[var(--text-muted)]">
             + ${config.invalid_profiles.length - visibleProfiles.length} more invalid profiles
           </div>
         `
@@ -680,9 +680,9 @@ export function filterHealthProviders(
 }
 
 const TONE_DOT: Record<string, string> = {
-  ok: 'bg-[var(--color-status-ok)]',
-  warn: 'bg-[var(--color-status-warn)]',
-  bad: 'bg-[var(--color-status-err)]',
+  ok: 'bg-[var(--ok)]',
+  warn: 'bg-[var(--warn)]',
+  bad: 'bg-[var(--bad)]',
 }
 
 function HealthTable({
@@ -705,15 +705,15 @@ function HealthTable({
         onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
       />
       ${isFiltering
-        ? html`<span class="text-xs text-[var(--color-fg-muted)]">${filtered.length}/${health.providers.length}건</span>`
+        ? html`<span class="text-xs text-[var(--text-muted)]">${filtered.length}/${health.providers.length}건</span>`
         : null}
     </div>
     ${isFiltering && filtered.length === 0
-      ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-muted)]">필터 결과 없음 (${health.providers.length} providers)</div>`
+      ? html`<div class="py-4 text-center text-2xs text-[var(--text-muted)]">필터 결과 없음 (${health.providers.length} providers)</div>`
       : html`
         <table class="w-full text-xs">
           <thead>
-            <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
+            <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
               <th class="text-left py-1 w-4"></th>
               <th class="text-left py-1">제공자</th>
               <th
@@ -754,26 +754,26 @@ function HealthTable({
               // too old to carry the field — don't decorate in that case.
               const orphaned = p.declared === false
               return html`
-              <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
+              <tr class="border-b border-[var(--card-border)] last:border-b-0">
                 <td class="py-1"><span class=${`inline-block w-2 h-2 rounded-full ${TONE_DOT[tone]}`}></span></td>
                 <td class="py-1">
-                  <code class="text-[var(--color-fg-secondary)]">${p.provider_key}</code>
+                  <code class="text-[var(--text-strong)]">${p.provider_key}</code>
                   ${orphaned
-                    ? html`<span class="ml-1 text-2xs text-[var(--color-status-warn)]" title="Provider was tracked but is no longer declared in cascade.json">orphan</span>`
+                    ? html`<span class="ml-1 text-2xs text-[var(--warn)]" title="Provider was tracked but is no longer declared in cascade.json">orphan</span>`
                     : null}
                 </td>
                 <td class="py-1">
                   ${status
                     ? html`<${StatusChip} tone=${providerStatusTone(status)} uppercase=${false}>${status}<//>`
-                    : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
+                    : html`<span class="text-[var(--text-muted)]">—</span>`}
                 </td>
                 <td class="py-1 text-right tabular-nums">${fmtPct(p.success_rate)}</td>
                 <td class="py-1 text-right tabular-nums">${p.consecutive_failures}</td>
                 <td class="py-1 text-right tabular-nums">${p.events_in_window}</td>
                 <td class="py-1 text-right tabular-nums">
                   ${rejected > 0
-                    ? html`<span class="text-[var(--color-status-warn)]">${rejected}</span>`
-                    : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
+                    ? html`<span class="text-[var(--warn)]">${rejected}</span>`
+                    : html`<span class="text-[var(--text-muted)]">—</span>`}
                 </td>
                 <td class="py-1 text-right tabular-nums">${fmtPerfTokPerSec(p.avg_prompt_tok_per_sec)}</td>
                 <td class="py-1 text-right tabular-nums">${fmtPerfTokPerSec(p.avg_decode_tok_per_sec)}</td>
@@ -781,7 +781,7 @@ function HealthTable({
                 <td class="py-1 text-right">
                   ${p.in_cooldown
                     ? html`<${StatusChip} tone="bad">${fmtCooldownExpiry(p.cooldown_expires_at)}<//>`
-                    : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
+                    : html`<span class="text-[var(--text-muted)]">—</span>`}
                 </td>
               </tr>
             `})}
@@ -890,7 +890,7 @@ function SloCard({ slo }: { slo: CascadeSloResponse }) {
     <div class="flex flex-col gap-3">
       <div class="flex items-center gap-2 flex-wrap">
         <${StatusChip} tone=${tone}>${sloStatusLabel(slo.status)}<//>
-        <span class="text-xs text-[var(--color-fg-muted)]">sample ${totalEvents}/${slo.window_sample_size}</span>
+        <span class="text-xs text-[var(--text-muted)]">sample ${totalEvents}/${slo.window_sample_size}</span>
         ${slo.violations.length > 0
           ? html`<span class="text-xs text-[var(--bad-light)]">violating: ${slo.violations.join(', ')}</span>`
           : null}
@@ -928,10 +928,10 @@ function StrategyTraceTable({
     ? trace.events.filter(e => traceEventMatchesSearch(e, query))
     : trace.events
   return html`
-    ${query ? html`<div class="text-xs text-[var(--color-fg-muted)] mb-2">${filtered.length}/${trace.events.length}건</div>` : null}
+    ${query ? html`<div class="text-xs text-[var(--text-muted)] mb-2">${filtered.length}/${trace.events.length}건</div>` : null}
     <table class="w-full text-xs">
       <thead>
-        <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
+        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
           <th class="text-left py-1 w-20">시간</th>
           <th class="text-left py-1">캐스케이드</th>
           <th class="text-left py-1">전략</th>
@@ -945,10 +945,10 @@ function StrategyTraceTable({
         ${filtered.map((e: CascadeStrategyTraceEvent) => {
           const tone = traceKindTone(e.kind)
           return html`
-          <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
-            <td class="py-1 text-[var(--color-fg-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
-            <td class="py-1"><code class="text-[var(--color-fg-secondary)]">${e.cascade_name}</code></td>
-            <td class="py-1 text-[var(--color-fg-muted)]">${e.strategy}</td>
+          <tr class="border-b border-[var(--card-border)] last:border-b-0">
+            <td class="py-1 text-[var(--text-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
+            <td class="py-1"><code class="text-[var(--text-strong)]">${e.cascade_name}</code></td>
+            <td class="py-1 text-[var(--text-muted)]">${e.strategy}</td>
             <td class="py-1 text-right tabular-nums">${e.cycle}</td>
             <td class="py-1 text-right tabular-nums">${e.candidates_in}/${e.candidates_out}</td>
             <td class="py-1 text-right tabular-nums">${e.backoff_ms > 0 ? e.backoff_ms : '–'}</td>
@@ -969,7 +969,7 @@ function ClientCapacityHistoryTable({
   return html`
     <table class="w-full text-xs">
       <thead>
-        <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
+        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
           <th class="text-left py-1 w-20">시간</th>
           <th class="text-left py-1">종류</th>
           <th class="text-left py-1">키</th>
@@ -980,10 +980,10 @@ function ClientCapacityHistoryTable({
         ${history.events.map((e: CascadeClientCapacityHistoryEvent) => {
           const tone = eventKindTone(e.kind)
           return html`
-          <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
-            <td class="py-1 text-[var(--color-fg-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
+          <tr class="border-b border-[var(--card-border)] last:border-b-0">
+            <td class="py-1 text-[var(--text-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
             <td class="py-1"><${StatusChip} tone=${tone}>${eventKindLabel(e.kind)}<//></td>
-            <td class="py-1"><code class="text-[var(--color-fg-secondary)]">${e.key}</code></td>
+            <td class="py-1"><code class="text-[var(--text-strong)]">${e.key}</code></td>
             <td class="py-1 text-right tabular-nums">${e.active_after}</td>
           </tr>
         `})}
@@ -999,7 +999,7 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
   return html`
     <table class="w-full text-xs">
       <thead>
-        <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
+        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
           <th class="text-left py-1 w-4"></th>
           <th class="text-left py-1">종류</th>
           <th class="text-left py-1">키</th>
@@ -1012,10 +1012,10 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
         ${capacity.entries.map((e: CascadeClientCapacityEntry) => {
           const tone = capacityTone(e)
           return html`
-          <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
+          <tr class="border-b border-[var(--card-border)] last:border-b-0">
             <td class="py-1"><span class=${`inline-block w-2 h-2 rounded-full ${TONE_DOT[tone]}`}></span></td>
             <td class="py-1"><${StatusChip} tone=${tone === 'ok' ? 'neutral' : tone}>${capacityKindLabel(e.kind)}<//></td>
-            <td class="py-1"><code class="text-[var(--color-fg-secondary)]">${e.key}</code></td>
+            <td class="py-1"><code class="text-[var(--text-strong)]">${e.key}</code></td>
             <td class="py-1 text-right tabular-nums">${e.active}</td>
             <td class="py-1 text-right tabular-nums">${e.available}</td>
             <td class="py-1 text-right tabular-nums">${e.total}</td>
@@ -1108,14 +1108,14 @@ function CascadeRawConfigEditor({
   return html`
     <${Card} title=${mode.title}>
       <div class="flex flex-col gap-3 p-4">
-        <p class="text-sm text-[var(--color-fg-muted)]">${mode.primary}</p>
-        <p class="text-xs text-[var(--color-fg-muted)]">
+        <p class="text-sm text-[var(--text-muted)]">${mode.primary}</p>
+        <p class="text-xs text-[var(--text-muted)]">
           ${mode.secondary}
         </p>
 
         <form class="flex flex-col gap-3" onSubmit=${handleSave}>
           <textarea
-            class="h-96 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs text-[var(--color-fg-secondary)]"
+            class="h-96 w-full rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
             spellcheck="false"
             readonly=${!sourceEditable}
             value=${editorText.value}
@@ -1127,13 +1127,13 @@ function CascadeRawConfigEditor({
           />
 
           <div class="flex items-center gap-3 flex-wrap text-xs">
-            <span class=${editorDirty.value ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-fg-muted)]'}>
+            <span class=${editorDirty.value ? 'text-[var(--warn)]' : 'text-[var(--text-muted)]'}>
               ${editorDirty.value ? 'unsaved changes' : 'in sync with disk'}
             </span>
             ${syntaxError
               ? html`<span class="text-[var(--bad-light)]">syntax: ${syntaxError}</span>`
               : html`
-                <span class="text-[var(--color-status-ok)]">
+                <span class="text-[var(--ok)]">
                   ${raw?.source_kind === 'toml' ? 'syntax: validated on save (TOML)' : 'syntax: valid JSON'}
                 </span>
               `}
@@ -1141,7 +1141,7 @@ function CascadeRawConfigEditor({
               ? html`
                 <span class=${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid')
                   ? 'text-[var(--bad-light)]'
-                  : 'text-[var(--color-fg-muted)]'}
+                  : 'text-[var(--text-muted)]'}
                 >
                   ${saveMessage.value}
                 </span>
@@ -1159,7 +1159,7 @@ function CascadeRawConfigEditor({
             </button>
             <button
               type="button"
-              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50"
+              class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
               onClick=${handleReset}
               disabled=${saving.value || !editorDirty.value}
             >
@@ -1167,7 +1167,7 @@ function CascadeRawConfigEditor({
             </button>
             <button
               type="button"
-              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50"
+              class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
               onClick=${() => void onRefresh()}
               disabled=${saving.value}
             >
@@ -1178,14 +1178,14 @@ function CascadeRawConfigEditor({
         ${mode.previewTitle
           ? html`
             <div class="flex flex-col gap-2">
-              <div class="text-xs font-medium text-[var(--color-fg-secondary)]">
+              <div class="text-xs font-medium text-[var(--text-strong)]">
                 ${mode.previewTitle}
               </div>
-              <div class="text-xs text-[var(--color-fg-muted)]">
+              <div class="text-xs text-[var(--text-muted)]">
                 ${raw?.config_path ?? 'unresolved'}
               </div>
               <textarea
-                class="h-72 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs text-[var(--color-fg-secondary)]"
+                class="h-72 w-full rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
                 spellcheck="false"
                 readonly
                 value=${raw?.raw_json ?? ''}
@@ -1223,14 +1223,14 @@ export function CascadeConfigPanel() {
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <button
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
+          class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
           onClick=${() => void loadCascadeData(resource)}
         >
           새로고침
         </button>
-        ${current.loading ? html`<span class="text-xs text-[var(--color-fg-muted)]">로딩 중...</span>` : null}
+        ${current.loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
         ${config?.updated_at
-          ? html`<span class="text-xs text-[var(--color-fg-muted)]">config · ${config.updated_at}</span>`
+          ? html`<span class="text-xs text-[var(--text-muted)]">config · ${config.updated_at}</span>`
           : null}
       </div>
 

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -120,14 +120,14 @@ function statusLabel(status: FeatureStatus): string {
 function statusChipClass(status: FeatureStatus): string {
   switch (status) {
     case 'healthy':
-      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--color-status-ok)]'
+      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--ok)]'
     case 'warning':
-      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--color-status-warn)]'
+      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--warn)]'
     case 'inactive':
-      return 'border-[var(--white-12)] bg-[var(--white-4)] text-[var(--color-fg-muted)]'
+      return 'border-[var(--white-12)] bg-[var(--white-4)] text-[var(--text-muted)]'
     case 'deprecated':
     default:
-      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--color-status-err)]'
+      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--bad)]'
   }
 }
 
@@ -145,20 +145,20 @@ function FeatureItem({ item }: { item: FeatureHealthItem }) {
       <div class="flex items-start justify-between gap-3">
         <div class="flex-1">
           <div class="flex items-center gap-2">
-            <code class="text-xs font-medium text-[var(--color-fg-secondary)]">${item.env_name}</code>
+            <code class="text-xs font-medium text-[var(--text-strong)]">${item.env_name}</code>
             <${StatusPill} status=${item.status} />
             ${item.is_enabled ? html`
-              <span class="inline-flex items-center rounded border border-[var(--ok-30)] bg-[var(--ok-12)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--color-status-ok)]">
+              <span class="inline-flex items-center rounded border border-[var(--ok-30)] bg-[var(--ok-12)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--ok)]">
                 ON
               </span>
             ` : html`
-              <span class="inline-flex items-center rounded border border-[var(--white-12)] bg-[var(--white-4)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--color-fg-muted)]">
+              <span class="inline-flex items-center rounded border border-[var(--white-12)] bg-[var(--white-4)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--text-muted)]">
                 OFF
               </span>
             `}
           </div>
-          <div class="mt-1.5 text-sm text-[var(--color-fg-primary)]">${item.description}</div>
-          <div class="mt-1 flex items-center gap-3 text-xs text-[var(--color-fg-muted)]">
+          <div class="mt-1.5 text-sm text-[var(--text-body)]">${item.description}</div>
+          <div class="mt-1 flex items-center gap-3 text-xs text-[var(--text-muted)]">
             <span>source: ${item.source}</span>
             <span>since: v${item.since}</span>
           </div>
@@ -176,12 +176,12 @@ function CategorySection({ category, categoryData }: { category: string; categor
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-4">
       <div class="mb-3 flex items-center justify-between">
         <div>
-          <div class="text-sm font-medium text-[var(--color-fg-secondary)]">${categoryLabel}</div>
-          <div class="mt-0.5 text-xs text-[var(--color-fg-muted)]">
+          <div class="text-sm font-medium text-[var(--text-strong)]">${categoryLabel}</div>
+          <div class="mt-0.5 text-xs text-[var(--text-muted)]">
             ${categoryData.enabled} / ${categoryData.total} enabled (${enabledRatio}%)
           </div>
         </div>
-        <div class="rounded-sm border border-[var(--white-8)] bg-[var(--white-6)] px-3 py-1 text-xs font-semibold text-[var(--color-fg-primary)]">
+        <div class="rounded-sm border border-[var(--white-8)] bg-[var(--white-6)] px-3 py-1 text-xs font-semibold text-[var(--text-body)]">
           ${categoryData.total}
         </div>
       </div>
@@ -211,18 +211,18 @@ export function FeatureHealth() {
                 <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-4">
                   <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                     <div class="max-w-3xl">
-                      <${SectionCap}>Feature Flags Health<//>
-                      <div class="mt-2 text-2xl font-semibold text-[var(--color-fg-secondary)]">
+                      <${SectionCap}>기능 플래그 상태<//>
+                      <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">
                         ${overview.enabled_count} / ${overview.total_features} 기능 활성화
                       </div>
-                      <div class="mt-2 text-sm leading-airy text-[var(--color-fg-primary)]">
+                      <div class="mt-2 text-sm leading-airy text-[var(--text-body)]">
                         시스템 기능 플래그 상태를 실시간으로 모니터링합니다.
                         ${overview.overridden_count ? `${overview.overridden_count}개 플래그가 환경변수로 오버라이드되었습니다.` : ''}
                       </div>
                     </div>
                     <button
                       type="button"
-                      class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-accent-fg)] hover:text-[var(--color-fg-primary)]"
+                      class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--text-body)]"
                       onClick=${() => { void loadFeatureHealth() }}
                     >새로고침</button>
                   </div>
@@ -236,7 +236,7 @@ export function FeatureHealth() {
                     <${StatCard} label="폐기 예정" value=${overview.deprecated_count} />
                   </div>
 
-                  <div class="mt-4 text-xs text-[var(--color-fg-disabled)]">
+                  <div class="mt-4 text-xs text-[var(--text-dim)]">
                     generated ${formatTimeAgo(data.generated_at)}
                   </div>
                 </div>
@@ -284,14 +284,14 @@ export function FeatureHealth() {
                   )
                   if (filtered.length === 0) {
                     return html`
-                      <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-4 text-xs text-[var(--color-fg-disabled)]">
+                      <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-4 text-xs text-[var(--text-dim)]">
                         조건에 맞는 기능이 없습니다.
                       </div>
                     `
                   }
                   return html`
                     <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-4">
-                      <div class="mb-3 text-xs text-[var(--color-fg-muted)]">
+                      <div class="mb-3 text-xs text-[var(--text-muted)]">
                         ${filtered.length} / ${data.all_features.length}개 기능
                       </div>
                       <div class="space-y-2">

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -276,7 +276,7 @@ function ContractSection({ task }: { task: Task }) {
 
       ${completionItems.length > 0 ? html`
         <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
-          <div class="text-xs font-medium text-text-strong">Completion Contract</div>
+          <div class="text-xs font-medium text-text-strong">완료 계약</div>
           <div class="mt-2 flex flex-col gap-1">
             ${completionItems.map((item: string) => html`
               <div key=${item} class=${`text-2xs ${unmetItems.includes(item) ? 'text-bad' : 'text-text-body'}`}>${item}</div>
@@ -287,7 +287,7 @@ function ContractSection({ task }: { task: Task }) {
 
       ${requiredEvidence.length > 0 ? html`
         <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
-          <div class="text-xs font-medium text-text-strong">Required Evidence</div>
+          <div class="text-xs font-medium text-text-strong">필수 증거</div>
           <div class="mt-2 flex flex-wrap gap-1.5">
             ${requiredEvidence.map((item: string) => html`
               <span key=${item} class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-3xs font-mono text-text-body">${item}</span>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -359,7 +359,7 @@ function Callout({
 }) {
   const toneClass =
     tone === 'warn'
-      ? 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+      ? 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]'
       : 'border-card-border/60 bg-card/35 text-text-body'
   return html`
     <div class="rounded border px-3 py-3 shadow-sm ${toneClass}">
@@ -405,9 +405,9 @@ function LongText({ text, truncateAt = 200 }: { text: string; truncateAt?: numbe
 function PromptSourceBadge({ source }: { source: string }) {
   const tone =
     source === 'override'
-      ? 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]'
+      ? 'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]'
       : source === 'file'
-        ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]'
+        ? 'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]'
         : 'bg-white/5 text-text-dim border-white/10'
   return html`<span class="text-3xs font-bold px-2 py-0.5 rounded border ${tone} shadow-sm">${source.toUpperCase()}</span>`
 }
@@ -422,7 +422,7 @@ function PromptBlock({
   return html`
     <div class="mt-2">
       <div class="flex items-center justify-between gap-2 mb-1">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">${title}</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">${title}</div>
         <div class="flex items-center gap-2">
           <span class="text-3xs text-text-dim">${block.key}</span>
           <${PromptSourceBadge} source=${block.source} />
@@ -690,12 +690,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     <div class="flex gap-2 items-center mb-3">
       ${isEditing ? html`
         <button type="button"
-          class="${btnBase} bg-[var(--color-status-ok)] text-[#000]"
+          class="${btnBase} bg-[var(--ok)] text-[#000]"
           onClick=${saveConfig}
           disabled=${isSaving}
         >${isSaving ? '저장 중...' : '저장'}</button>
         <button type="button"
-          class="${btnBase} bg-[var(--white-10)] text-[var(--color-fg-primary)]"
+          class="${btnBase} bg-[var(--white-10)] text-[var(--text-body)]"
           onClick=${cancelEdit}
           disabled=${isSaving}
         >취소</button>
@@ -705,7 +705,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           onClick=${enterEditMode}
         >편집</button>
       `}
-      ${saveError.value ? html`<span class="text-xs text-[var(--color-status-err)]">${saveError.value}</span>` : null}
+      ${saveError.value ? html`<span class="text-xs text-[var(--bad)]">${saveError.value}</span>` : null}
     </div>
   `
 
@@ -722,30 +722,30 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     <${EditTextarea} field="instructions" label="지시사항" rows=${4} />
   ` : html`
     <${SectionHeader} title="프롬프트" />
-    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">목표</div>
+    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-0.5">목표</div>
     <${LongText} text=${c.prompt.goal} />
     ${c.prompt.short_goal ? html`
-      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">단기 목표</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">단기 목표</div>
       <${LongText} text=${c.prompt.short_goal} />
     ` : null}
     ${c.prompt.mid_goal ? html`
-      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">중기 목표</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">중기 목표</div>
       <${LongText} text=${c.prompt.mid_goal} />
     ` : null}
     ${c.prompt.long_goal ? html`
-      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">장기 목표</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">장기 목표</div>
       <${LongText} text=${c.prompt.long_goal} />
     ` : null}
     ${c.prompt.instructions ? html`
-      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">지시사항</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">지시사항</div>
       <${LongText} text=${c.prompt.instructions} />
     ` : null}
-    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-3 mb-0.5">시스템 프롬프트 블록</div>
+    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-3 mb-0.5">시스템 프롬프트 블록</div>
     <${PromptBlock} title="헌법" block=${c.prompt.system_prompt_blocks.constitution} />
     <${PromptBlock} title="세계관" block=${c.prompt.system_prompt_blocks.world} />
     <${PromptBlock} title="능력" block=${c.prompt.system_prompt_blocks.capabilities} />
     <details class="mt-3">
-      <summary class="cursor-pointer py-2 px-3 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] list-none select-none rounded hover:bg-[var(--white-3)] transition-colors">컴파일된 시스템 프롬프트 보기</summary>
+      <summary class="cursor-pointer py-2 px-3 text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] list-none select-none rounded hover:bg-[var(--white-3)] transition-colors">컴파일된 시스템 프롬프트 보기</summary>
       <${LongText} text=${c.prompt.effective_system_prompt} truncateAt=${null} />
     </details>
   `
@@ -819,7 +819,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                   <option value=${profileName}>${profileName}</option>
                 `)}
               </select>
-              <span class="text-2xs text-[var(--color-fg-disabled)]">
+              <span class="text-2xs text-[var(--text-dim)]">
                 ${cascadeSaving.value
                   ? 'cascade_name 저장 중...'
                   : cascadeState.status === 'loading'
@@ -827,10 +827,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                     : '변경 시 keeper manifest의 cascade_name 이 즉시 갱신됩니다.'}
               </span>
               ${cascadeSaveError.value
-                ? html`<span class="text-2xs text-[var(--color-status-err)]">${cascadeSaveError.value}</span>`
+                ? html`<span class="text-2xs text-[var(--bad)]">${cascadeSaveError.value}</span>`
                 : null}
               ${invalidCascadeProfiles.length > 0
-                ? html`<span class="text-2xs text-[var(--color-status-warn)]">invalid profile ${invalidCascadeProfiles.length}개: ${invalidCascadeSummary}</span>`
+                ? html`<span class="text-2xs text-[var(--warn)]">invalid profile ${invalidCascadeProfiles.length}개: ${invalidCascadeSummary}</span>`
                 : null}
             </label>
           `
@@ -846,48 +846,48 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         : null}
       <${ConfigRow} label="catalog source" value=${cascadeCatalogSourceLabel(c)} />
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--color-fg-muted)]">라이브 오버라이드</span>
+        <span class="text-xs text-[var(--text-muted)]">라이브 오버라이드</span>
         <${BoolBadge} value=${c.sources.has_live_override} />
       </div>
-      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">라이브 메타 경로</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">라이브 메타 경로</div>
       <${LongText} text=${c.sources.live_meta_path} />
       ${c.sources.default_manifest_path ? html`
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">기본 매니페스트 경로</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">기본 매니페스트 경로</div>
         <${LongText} text=${c.sources.default_manifest_path} />
       ` : null}
       ${c.sources.cascade_catalog_source_path ? html`
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">캐스케이드 카탈로그 출처</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">캐스케이드 카탈로그 출처</div>
         <${LongText} text=${c.sources.cascade_catalog_source_path} />
       ` : null}
       ${c.sources.cascade_runtime_json_path ? html`
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mt-2 mb-0.5">Generated runtime JSON</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">생성된 런타임 JSON</div>
         <${LongText} text=${c.sources.cascade_runtime_json_path} />
       ` : null}
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--color-fg-muted)]">cascade.json 직접 수정 가능</span>
+        <span class="text-xs text-[var(--text-muted)]">cascade.json 직접 수정 가능</span>
         <${BoolBadge} value=${c.sources.cascade_runtime_json_editable} />
       </div>
       <div class="mt-1.5">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">우선순위</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">우선순위</div>
         <${ModelList} models=${c.sources.precedence} />
       </div>
       <div class="mt-1.5">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">오버라이드 필드</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">오버라이드 필드</div>
         <${ModelList} models=${c.sources.override_fields} />
       </div>
 
       <${SectionHeader} title="실행" />
       <${ConfigRow} label="활성 모델" value=${c.execution.active_model || '--'} />
       <${ConfigRow} label="provider timeout" value=${perProviderTimeoutLabel(c.execution)} />
-      <div class="mb-1.5 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
+      <div class="mb-1.5 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--text-muted)]">
         cascade fallback 중 마지막 provider를 제외한 provider들에만 적용됩니다.
       </div>
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--color-fg-muted)]">검증</span>
+        <span class="text-xs text-[var(--text-muted)]">검증</span>
         <${BoolBadge} value=${c.execution.verify} />
       </div>
       <div class="mt-1.5">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">모델</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">모델</div>
         <${ModelList} models=${c.execution.models} />
       </div>
 
@@ -933,10 +933,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         />
         <div class="py-2 px-3 rounded bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1">
-            <span class="text-xs text-[var(--color-fg-primary)]">allowed_paths</span>
-            <span class="text-3xs text-[var(--color-fg-muted)]">한 줄에 하나씩. 명시 경로만 허용됩니다.</span>
+            <span class="text-xs text-[var(--text-body)]">allowed_paths</span>
+            <span class="text-3xs text-[var(--text-muted)]">한 줄에 하나씩. 명시 경로만 허용됩니다.</span>
           </div>
-          <textarea class="w-full text-xs font-mono bg-[var(--white-6)] border border-[var(--color-border-default)] rounded px-2 py-1.5 text-[var(--color-fg-primary)] resize-y"
+          <textarea class="w-full text-xs font-mono bg-[var(--white-6)] border border-[var(--card-border)] rounded px-2 py-1.5 text-[var(--text-body)] resize-y"
             rows=${3}
             value=${rd.allowed_paths_text}
             placeholder=".masc/keepers/<name>/"
@@ -944,7 +944,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           ></textarea>
         </div>
         ${(c.effective_allowed_paths ?? []).length > 0 ? html`
-          <div class="py-1.5 px-3 text-3xs text-[var(--color-fg-muted)]">
+          <div class="py-1.5 px-3 text-3xs text-[var(--text-muted)]">
             effective: ${(c.effective_allowed_paths ?? []).join(', ') || '(전체 허용)'}
           </div>
         ` : null}
@@ -974,7 +974,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ConfigRow} label="config_base_path" value=${c.sandbox_environment.base_path || '--'} />
         <${ConfigRow} label="project_root" value=${c.sandbox_environment.project_root || '--'} />
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--color-fg-muted)]">docker_playground</span>
+          <span class="text-xs text-[var(--text-muted)]">docker_playground</span>
           <${BoolBadge} value=${c.sandbox_environment.docker_playground_enabled} />
         </div>
         <${ConfigRow} label="docker_container" value=${c.sandbox_environment.docker_container_name || '--'} />
@@ -985,11 +985,11 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ConfigRow} label="sandbox_tmpfs_size" value=${c.sandbox_environment.tmpfs_size || '--'} />
         <${ConfigRow} label="sandbox_seccomp_profile" value=${c.sandbox_environment.seccomp_profile || '--'} />
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--color-fg-muted)]">require_rootless</span>
+          <span class="text-xs text-[var(--text-muted)]">require_rootless</span>
           <${BoolBadge} value=${c.sandbox_environment.require_rootless} />
         </div>
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--color-fg-muted)]">require_userns</span>
+          <span class="text-xs text-[var(--text-muted)]">require_userns</span>
           <${BoolBadge} value=${c.sandbox_environment.require_userns} />
         </div>
         ${c.sandbox_last_error ? html`
@@ -1013,7 +1013,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           min=${10} max=${3600} step=${10} suffix="s" />
       ` : html`
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--color-fg-muted)]">활성</span>
+          <span class="text-xs text-[var(--text-muted)]">활성</span>
           <${BoolBadge} value=${c.proactive.enabled} />
         </div>
         <${ConfigRow} label="유휴 트리거" value=${c.proactive.idle_sec + 's'} />
@@ -1022,21 +1022,21 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       <${SectionHeader} title="런타임" />
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--color-fg-muted)]">일시정지</span>
+        <span class="text-xs text-[var(--text-muted)]">일시정지</span>
         <${BoolBadge} value=${c.runtime.paused} />
       </div>
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--color-fg-muted)]">자동 부팅 등록</span>
+        <span class="text-xs text-[var(--text-muted)]">자동 부팅 등록</span>
         <${BoolBadge} value=${c.runtime.registered} />
       </div>
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--color-fg-muted)]">킵얼라이브 실행</span>
+        <span class="text-xs text-[var(--text-muted)]">킵얼라이브 실행</span>
         <${BoolBadge} value=${c.runtime.keepalive_running} />
       </div>
       <${ConfigRow} label="레지스트리 상태" value=${c.runtime.registry_state || '--'} />
       <${ConfigRow} label="파이버 상태" value=${c.runtime.fiber_health || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--color-fg-muted)]">프레즌스 킵얼라이브</span>
+        <span class="text-xs text-[var(--text-muted)]">프레즌스 킵얼라이브</span>
         <${BoolBadge} value=${c.runtime.presence_keepalive} />
       </div>
       <${ConfigRow} label="프레즌스 간격" value=${c.runtime.presence_keepalive_sec + 's'} />
@@ -1045,18 +1045,18 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <div class="py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm mb-1.5">
         <div class="flex items-center justify-between gap-3 mb-2">
           <span class="text-xs font-medium text-text-muted">active_goal_ids</span>
-          <span class="text-3xs text-[var(--color-fg-muted)]">${selectedActiveGoalIds.length}개 선택</span>
+          <span class="text-3xs text-[var(--text-muted)]">${selectedActiveGoalIds.length}개 선택</span>
         </div>
         ${goalState.status === 'loading' ? html`
-          <div class="text-2xs text-[var(--color-fg-muted)]">목표 목록 로딩 중...</div>
+          <div class="text-2xs text-[var(--text-muted)]">목표 목록 로딩 중...</div>
         ` : goalState.status === 'error' ? html`
-          <div class="text-2xs text-[var(--color-status-err)]">${goalState.message}</div>
+          <div class="text-2xs text-[var(--bad)]">${goalState.message}</div>
         ` : goalOptions.length > 0 && rd ? html`
           <div class="grid gap-1.5">
             ${goalOptions.map((goal) => {
               const checked = rd.active_goal_ids.includes(goal.id)
               return html`
-                <label class="flex items-center gap-2 rounded bg-[var(--white-3)] px-2 py-1.5 text-xs text-[var(--color-fg-primary)]">
+                <label class="flex items-center gap-2 rounded bg-[var(--white-3)] px-2 py-1.5 text-xs text-[var(--text-body)]">
                   <input
                     type="checkbox"
                     checked=${checked}
@@ -1064,9 +1064,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                       toggleRuntimeActiveGoal(goal.id, (event.currentTarget as HTMLInputElement).checked)
                     }}
                   />
-                  <span class="min-w-[4.5rem] font-mono text-3xs text-[var(--color-fg-muted)]">${goal.horizon}</span>
+                  <span class="min-w-[4.5rem] font-mono text-3xs text-[var(--text-muted)]">${goal.horizon}</span>
                   <span class="flex-1 truncate">${goal.title}</span>
-                  <span class="font-mono text-3xs text-[var(--color-fg-disabled)]">${goal.id}</span>
+                  <span class="font-mono text-3xs text-[var(--text-dim)]">${goal.id}</span>
                 </label>
               `
             })}
@@ -1074,10 +1074,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         ` : selectedActiveGoalIds.length > 0 ? html`
           <${ModelList} models=${selectedActiveGoalIds} />
         ` : html`
-          <div class="text-2xs text-[var(--color-fg-muted)]">활성 목표가 연결되어 있지 않습니다.</div>
+          <div class="text-2xs text-[var(--text-muted)]">활성 목표가 연결되어 있지 않습니다.</div>
         `}
         ${unknownSelectedGoalIds.length > 0 ? html`
-          <div class="mt-2 text-2xs text-[var(--color-status-warn)]">
+          <div class="mt-2 text-2xs text-[var(--warn)]">
             Goal Store에서 찾을 수 없는 연결: ${unknownSelectedGoalIds.join(', ')}
           </div>
         ` : null}
@@ -1090,12 +1090,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ` : null}
       ${c.coordination.mention_targets.length > 0 ? html`
       <div class="mt-1.5">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">멘션 대상</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">멘션 대상</div>
         <${ModelList} models=${c.coordination.mention_targets} />
       </div>
       ` : null}
       <div class="mt-1.5">
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">참여 네임스페이스</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">참여 네임스페이스</div>
         <${ModelList} models=${c.coordination.joined_room_ids} />
       </div>
 
@@ -1111,7 +1111,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           min=${0} max=${3600} step=${30} suffix="s" />
       ` : html`
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--color-fg-muted)]">자동</span>
+          <span class="text-xs text-[var(--text-muted)]">자동</span>
           <${BoolBadge} value=${c.handoff.auto} />
         </div>
         <${ConfigRow} label="임계값" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
@@ -1121,12 +1121,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ${runtimeHasChanges ? html`
         <div class="flex gap-2 items-center mt-4 mb-2 p-3 rounded border border-accent/30 bg-accent/5">
           <button type="button"
-            class="${btnBase} bg-[var(--color-status-ok)] text-[#000]"
+            class="${btnBase} bg-[var(--ok)] text-[#000]"
             onClick=${saveRuntimeConfig}
             disabled=${runtimeSaving.value}
           >${runtimeSaving.value ? '저장 중...' : '런타임 설정 저장'}</button>
           <button type="button"
-            class="${btnBase} bg-[var(--white-10)] text-[var(--color-fg-primary)]"
+            class="${btnBase} bg-[var(--white-10)] text-[var(--text-body)]"
             onClick=${resetRuntimeDraft}
           >초기화</button>
           <span class="text-3xs text-accent">변경된 설정이 있습니다</span>
@@ -1147,14 +1147,14 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
               placeholder="슬롯 이름 / source / gate 필터"
               aria-label="훅 슬롯 필터"
               onInput=${(e: Event) => { hookFilterQuery.value = (e.target as HTMLInputElement).value }}
-              class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
+              class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
             />
           </div>
           ${isFiltering && visibleEntries.length === 0 && allEntries.length > 0
-            ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${allEntries.length} slots)</div>`
+            ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${allEntries.length} slots)</div>`
             : visibleEntries.map(([name, slot]) => html`
                 <div class="flex items-start gap-2 py-2 px-3 rounded border border-card-border/50 bg-card/20 mb-1.5">
-                  <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--color-status-ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--color-fg-disabled)]'}"></span>
+                  <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--text-dim)]'}"></span>
                   <div class="flex-1 min-w-0">
                     <div class="flex justify-between">
                       <span class="text-xs font-semibold text-text-strong">${name}</span>
@@ -1163,7 +1163,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                     ${(slot.gates ?? slot.effects ?? slot.features ?? []).length > 0 ? html`
                       <div class="flex flex-wrap gap-1 mt-1">
                         ${(slot.gates ?? slot.effects ?? slot.features ?? []).map((d: string) => html`
-                          <span class="text-3xs px-1.5 py-0.5 rounded ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--color-fg-disabled)]' : 'bg-[var(--accent-10)] text-[var(--color-accent-fg)] opacity-80'}">${d}</span>
+                          <span class="text-3xs px-1.5 py-0.5 rounded ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--text-dim)]' : 'bg-[var(--accent-10)] text-[var(--accent)] opacity-80'}">${d}</span>
                         `)}
                       </div>
                     ` : null}

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -19,7 +19,7 @@ function KeeperModelChip({ keeper }: { keeper: Keeper }) {
   if (!display) return null
   return html`
     <span
-      class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-mono bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-20)]"
+      class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-mono bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-20)]"
       title=${`${display.label}: ${display.value}`}
     >${display.value}</span>
   `
@@ -32,8 +32,8 @@ function KeeperToolPresetChip({ keeperName }: { keeperName: string }) {
   return html`
     <span class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-semibold uppercase tracking-wide
       ${canPR
-        ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border border-[var(--ok-20)]'
-        : 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border border-[var(--white-8)]'
+        ? 'bg-[var(--ok-10)] text-[var(--ok)] border border-[var(--ok-20)]'
+        : 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
       }"
       title=${`Tool preset: ${preset}${canPR ? ' (clone/PR 가능)' : ''}`}
     >${preset}</span>
@@ -79,7 +79,7 @@ function KeeperCascadeSelector({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="flex items-center gap-1.5">
       <select
-        class="py-0.5 px-1 rounded text-3xs font-mono bg-[var(--white-5)] text-[var(--color-fg-muted)] border border-[var(--white-8)] cursor-pointer"
+        class="py-0.5 px-1 rounded text-3xs font-mono bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)] cursor-pointer"
         title=${invalidProfiles.length > 0
           ? `Cascade profile\n\nDisabled invalid presets:\n${invalidSummary}`
           : 'Cascade profile'}
@@ -135,16 +135,16 @@ export function KeeperDetailMissingState({
 }) {
   return html`
     <div class="mx-auto flex w-full max-w-[1100px] flex-col gap-4">
-      <div class="rounded-[28px] border border-[var(--color-border-default)] bg-[rgba(9,14,24,0.92)] px-6 py-6 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
-        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">Keeper Detail</div>
-        <h2 class="m-0 mt-2 text-xl font-semibold text-[var(--color-fg-secondary)]">${keeperName}</h2>
+      <div class="rounded-[28px] border border-[var(--card-border)] bg-[rgba(9,14,24,0.92)] px-6 py-6 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
+        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">키퍼 상세</div>
+        <h2 class="m-0 mt-2 text-xl font-semibold text-[var(--text-strong)]">${keeperName}</h2>
         <p class="m-0 mt-2 text-sm leading-relaxed text-[var(--text-secondary)]">
           현재 스냅샷에서 keeper를 찾지 못했습니다. 목록으로 돌아가서 다시 선택하거나, 최신 dashboard refresh 이후 다시 열어 보세요.
         </p>
         <div class="mt-4">
           <button
             type="button"
-            class="inline-flex items-center gap-2 rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-4 py-2 text-sm font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--white-8)]"
+            class="inline-flex items-center gap-2 rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-4 py-2 text-sm font-medium text-[var(--text-strong)] transition-colors hover:bg-[var(--white-8)]"
             onClick=${onClose}
           >
             목록으로 돌아가기
@@ -171,23 +171,23 @@ export function KeeperDetailHeaderInfo({
       <button
         type="button"
         onClick=${onClose}
-        class="inline-flex shrink-0 items-center gap-2 rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-3.5 py-2 text-sm font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--white-8)]"
+        class="inline-flex shrink-0 items-center gap-2 rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-3.5 py-2 text-sm font-medium text-[var(--text-strong)] transition-colors hover:bg-[var(--white-8)]"
       >
         <span aria-hidden="true">←</span>
         목록
       </button>
       <div class="size-12 shrink-0 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-2xl">${keeper.emoji}</div>
       <div class="flex flex-col gap-0.5">
-        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">Monitoring / Agents / Keeper Detail</div>
+        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Monitoring / Agents / Keeper Detail</div>
         <div class="mt-1 flex flex-wrap items-center gap-2.5">
-          <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--color-fg-secondary)]">${keeper.name}</h2>
+          <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--text-strong)]">${keeper.name}</h2>
           <${KeeperPhaseAndStage} phase=${keeper.phase} pipelineStage=${keeper.pipeline_stage} phaseEnteredAtSec=${phaseEnteredAtSec} />
           <${KeeperModelChip} keeper=${keeper} />
           <${KeeperToolPresetChip} keeperName=${keeper.name} />
           <${KeeperCascadeSelector} keeper=${keeper} />
         </div>
         ${keeper.koreanName || keeper.created_at ? html`
-          <div class="flex flex-wrap items-center gap-2 text-xs text-[var(--color-fg-muted)]">
+          <div class="flex flex-wrap items-center gap-2 text-xs text-[var(--text-muted)]">
             ${keeper.koreanName ? html`<span>${keeper.koreanName}</span>` : null}
             ${keeper.created_at ? html`<span class="font-mono tabular-nums opacity-60"><${TimeAgo} timestamp=${keeper.created_at} /></span>` : null}
           </div>
@@ -255,8 +255,8 @@ function KeeperDetailQuickFact({
 }) {
   return html`
     <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] px-3.5 py-3">
-      <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">${label}</div>
-      <div class="mt-1 text-sm font-medium leading-snug text-[var(--color-fg-secondary)]">${children}</div>
+      <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">${label}</div>
+      <div class="mt-1 text-sm font-medium leading-snug text-[var(--text-strong)]">${children}</div>
     </div>
   `
 }
@@ -286,9 +286,9 @@ export function KeeperDetailOverviewSidebar({
 }) {
   return html`
     <aside class="order-2 xl:order-1 xl:sticky xl:top-[104px] xl:self-start">
-      <div class="flex flex-col gap-4 rounded-[28px] border border-[var(--color-border-default)] bg-[rgba(9,14,24,0.84)] p-4 shadow-[0_20px_48px_rgba(0,0,0,0.18)]">
+      <div class="flex flex-col gap-4 rounded-[28px] border border-[var(--card-border)] bg-[rgba(9,14,24,0.84)] p-4 shadow-[0_20px_48px_rgba(0,0,0,0.18)]">
         <div>
-          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">Overview</div>
+          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Overview</div>
           <p class="m-0 mt-2 text-sm leading-relaxed text-[var(--text-secondary)]">
             긴 단일 모달 대신 keeper 상세를 별도 화면으로 펼쳤습니다. 운영자가 자주 오가는 맥락 단위로 나눠서 바로 점프할 수 있습니다.
           </p>
@@ -304,7 +304,7 @@ export function KeeperDetailOverviewSidebar({
         </div>
 
         <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] p-3.5">
-          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">빠른 이동</div>
+          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">빠른 이동</div>
           <div class="mt-3 flex flex-col gap-2">
             ${KEEPER_DETAIL_SECTIONS.map((section) => html`
               <button
@@ -312,8 +312,8 @@ export function KeeperDetailOverviewSidebar({
                 class="rounded-2xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-left transition-colors hover:bg-[var(--white-6)]"
                 onClick=${() => scrollToKeeperDetailSection(section.id)}
               >
-                <div class="text-sm font-medium text-[var(--color-fg-secondary)]">${section.label}</div>
-                <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${section.summary}</div>
+                <div class="text-sm font-medium text-[var(--text-strong)]">${section.label}</div>
+                <div class="mt-1 text-2xs leading-relaxed text-[var(--text-muted)]">${section.summary}</div>
               </button>
             `)}
           </div>
@@ -339,13 +339,13 @@ export function KeeperDetailSection({
   return html`
     <section
       id=${id}
-      class="scroll-mt-24 rounded-[28px] border border-[var(--color-border-default)] bg-[linear-gradient(180deg,rgba(12,19,34,0.94),rgba(8,13,24,0.98))] shadow-[0_24px_48px_rgba(0,0,0,0.22)]"
+      class="scroll-mt-24 rounded-[28px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(12,19,34,0.94),rgba(8,13,24,0.98))] shadow-[0_24px_48px_rgba(0,0,0,0.22)]"
     >
       <div class="border-b border-[var(--white-8)] px-5 py-4 sm:px-6">
-        <div class="text-3xs font-semibold uppercase tracking-[0.22em] text-[var(--color-fg-muted)]">${eyebrow}</div>
+        <div class="text-3xs font-semibold uppercase tracking-[0.22em] text-[var(--text-muted)]">${eyebrow}</div>
         <div class="mt-1 flex flex-col gap-1 lg:flex-row lg:items-end lg:justify-between">
           <div>
-            <h3 class="m-0 text-lg font-semibold text-[var(--color-fg-secondary)]">${title}</h3>
+            <h3 class="m-0 text-lg font-semibold text-[var(--text-strong)]">${title}</h3>
             <p class="m-0 mt-1 text-sm leading-relaxed text-[var(--text-secondary)]">${description}</p>
           </div>
         </div>

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -504,7 +504,7 @@ describe('TelemetryUnified', () => {
     expect(groupRow?.getAttribute('aria-expanded')).toBe('true')
     expect(container.textContent).toContain('Latest:')
     expect(container.textContent).toContain('keeper-alpha -> masc_status')
-    expect(container.textContent).toContain('Raw JSON')
+    expect(container.textContent).toContain('원본 JSON')
   })
 
   it('keeps condensed keys stable when repeated no-timestamp groups reappear', async () => {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -87,12 +87,12 @@ const CONDENSED_CATEGORY_META: Record<TelemetryCondensedCategory, {
   heartbeat: {
     label: 'Heartbeat',
     icon: 'H',
-    color: 'text-[var(--color-accent-fg)]',
+    color: 'text-[var(--accent)]',
   },
   polling: {
     label: 'Polling / no-op',
     icon: 'P',
-    color: 'text-[var(--color-accent-fg)]',
+    color: 'text-[var(--accent)]',
   },
 }
 
@@ -453,32 +453,32 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
   const hasData = src.entry_count > 0
 
   return html`
-    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3 min-w-35">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-35">
       <div class="flex items-center gap-2 mb-1">
         <span class="font-mono font-bold ${meta.color}">${meta.icon}</span>
-        <span class="text-xs font-medium text-[var(--color-fg-secondary)]">${meta.label}</span>
+        <span class="text-xs font-medium text-[var(--text-strong)]">${meta.label}</span>
       </div>
-      ${meta.sublabel ? html`<div class="text-3xs text-[var(--color-fg-disabled)] mb-1">${meta.sublabel}</div>` : null}
-      <div class="text-2xl font-bold ${hasData ? 'text-[var(--color-fg-secondary)]' : 'text-[var(--color-fg-muted)]'}">
+      ${meta.sublabel ? html`<div class="text-3xs text-[var(--text-dim)] mb-1">${meta.sublabel}</div>` : null}
+      <div class="text-2xl font-bold ${hasData ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'}">
         ${src.entry_count.toLocaleString()}
       </div>
       ${src.keeper_count != null ? html`
-        <div class="text-xs text-[var(--color-fg-muted)]">${src.keeper_count} keepers</div>
+        <div class="text-xs text-[var(--text-muted)]">${src.keeper_count} keepers</div>
       ` : null}
       ${src.exists === false ? html`
-        <div class="text-xs text-[var(--color-fg-muted)] italic">store not found</div>
+        <div class="text-xs text-[var(--text-muted)] italic">store not found</div>
       ` : null}
     </div>
   `
 }
 
 function DiagnosisCard({ title, value, detail, tone }: { title: string; value: string; detail: string; tone: 'ok' | 'warn' | 'neutral' }) {
-  const toneColor = tone === 'ok' ? 'text-[var(--color-status-ok)]' : tone === 'warn' ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-fg-muted)]'
+  const toneColor = tone === 'ok' ? 'text-[var(--ok)]' : tone === 'warn' ? 'text-[var(--warn)]' : 'text-[var(--text-muted)]'
   return html`
-    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3 min-w-35">
-      <div class="text-xs font-medium text-[var(--color-fg-muted)] mb-1">${title}</div>
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-35">
+      <div class="text-xs font-medium text-[var(--text-muted)] mb-1">${title}</div>
       <div class="text-2xl font-bold ${toneColor}">${value}</div>
-      <div class="text-3xs text-[var(--color-fg-disabled)]">${detail}</div>
+      <div class="text-3xs text-[var(--text-dim)]">${detail}</div>
     </div>
   `
 }
@@ -493,7 +493,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
 
   return html`
     <div
-      class="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+      class="border-b border-[var(--card-border)] hover:bg-[var(--bg-panel-hover)] transition-colors"
       style="content-visibility:auto;contain-intrinsic-size:36px"
     >
       <div class="flex items-center gap-1">
@@ -504,23 +504,23 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
           aria-expanded=${expanded.value}
         >
           <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
-          <span class="font-mono text-[var(--color-fg-muted)] w-28 flex-shrink-0" title=${formatTs(ts)}>
+          <span class="font-mono text-[var(--text-muted)] w-28 flex-shrink-0" title=${formatTs(ts)}>
             ${timeAgoSafe(ts)}
           </span>
           ${success != null ? html`
-            <span class="flex-shrink-0 w-4 ${success ? 'text-[var(--color-status-ok)]' : 'text-[var(--bad-light)]'}">
+            <span class="flex-shrink-0 w-4 ${success ? 'text-[var(--ok)]' : 'text-[var(--bad-light)]'}">
               ${success ? 'O' : 'X'}
             </span>
           ` : html`<span class="w-4"></span>`}
-          <span class="font-mono text-[var(--color-fg-secondary)] truncate flex-1" title=${entryPreview(entry)}>
+          <span class="font-mono text-[var(--text-strong)] truncate flex-1" title=${entryPreview(entry)}>
             ${entryPreview(entry)}
           </span>
           ${scopeBadges.length > 0 ? html`
             <span class="hidden xl:flex items-center gap-1 flex-shrink-0">
-              ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-disabled)] font-mono">${badge}</span>`)}
+              ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
             </span>
           ` : null}
-          <span class="flex-shrink-0 w-4 text-[var(--color-fg-muted)]">${expanded.value ? '-' : '+'}</span>
+          <span class="flex-shrink-0 w-4 text-[var(--text-muted)]">${expanded.value ? '-' : '+'}</span>
         </button>
         <span class="mr-2 inline-flex flex-shrink-0">
           <${CopyIdButton}
@@ -535,12 +535,12 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
         <div class="px-3 pb-3 flex flex-col gap-2">
           ${scopeBadges.length > 0 ? html`
             <div class="flex flex-wrap gap-1.5">
-              ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-3xs text-[var(--color-fg-disabled)] font-mono">${badge}</span>`)}
+              ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
             </div>
           ` : null}
           <div class="rounded bg-[rgba(0,0,0,0.3)] p-2">
             <div class="mb-1.5 flex items-center justify-between gap-2">
-              <span class="text-3xs font-medium text-[var(--color-fg-disabled)]">Raw JSON</span>
+              <span class="text-3xs font-medium text-[var(--text-dim)]">원본 JSON</span>
               <${CopyIdButton}
                 value=${rawJson}
                 label="expanded telemetry entry JSON"
@@ -548,7 +548,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
                 size=${13}
               />
             </div>
-            <pre class="m-0 text-3xs font-mono text-[var(--color-fg-muted)] overflow-x-auto max-h-75 overflow-y-auto whitespace-pre-wrap break-all">
+            <pre class="m-0 text-3xs font-mono text-[var(--text-muted)] overflow-x-auto max-h-75 overflow-y-auto whitespace-pre-wrap break-all">
 ${rawJson}</pre>
           </div>
         </div>
@@ -567,7 +567,7 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
 
   return html`
     <div
-      class="border-b border-[var(--color-border-default)] bg-[rgba(255,255,255,0.015)] hover:bg-[var(--color-bg-hover)] transition-colors"
+      class="border-b border-[var(--card-border)] bg-[rgba(255,255,255,0.015)] hover:bg-[var(--bg-panel-hover)] transition-colors"
       style="content-visibility:auto;contain-intrinsic-size:36px"
     >
       <div class="flex items-center gap-1">
@@ -579,24 +579,24 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
           onClick=${() => { expanded.value = !expanded.value }}
         >
           <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
-          <span class="font-mono text-[var(--color-fg-muted)] w-28 flex-shrink-0" title=${`${formatTs(item.oldestTs)} → ${formatTs(item.latestTs)}`}>
+          <span class="font-mono text-[var(--text-muted)] w-28 flex-shrink-0" title=${`${formatTs(item.oldestTs)} → ${formatTs(item.latestTs)}`}>
             ${timeAgoSafe(item.latestTs)}
           </span>
-          <span class="flex-shrink-0 w-4 text-[var(--color-fg-disabled)]">~</span>
-          <span class="font-mono text-[var(--color-fg-secondary)] truncate flex-1" title=${`${meta.label} · ${item.label} · ${item.count} events`}>
+          <span class="flex-shrink-0 w-4 text-[var(--text-dim)]">~</span>
+          <span class="font-mono text-[var(--text-strong)] truncate flex-1" title=${`${meta.label} · ${item.label} · ${item.count} events`}>
             ${meta.label} · ${item.label} · ${item.count} events
           </span>
           ${sourceIcons.length > 0 ? html`
-            <span class="hidden lg:flex items-center gap-1 flex-shrink-0 text-3xs text-[var(--color-fg-disabled)] font-mono">
+            <span class="hidden lg:flex items-center gap-1 flex-shrink-0 text-3xs text-[var(--text-dim)] font-mono">
               ${sourceIcons.join('/')}
             </span>
           ` : null}
           ${item.scopeBadges.length > 0 ? html`
             <span class="hidden xl:flex items-center gap-1 flex-shrink-0">
-              ${item.scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-disabled)] font-mono">${badge}</span>`)}
+              ${item.scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
             </span>
           ` : null}
-          <span class="flex-shrink-0 w-4 text-[var(--color-fg-muted)]">${expanded.value ? '-' : '+'}</span>
+          <span class="flex-shrink-0 w-4 text-[var(--text-muted)]">${expanded.value ? '-' : '+'}</span>
         </button>
         <span class="mr-2 inline-flex flex-shrink-0">
           <${CopyIdButton}
@@ -609,8 +609,8 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
       </div>
       <div id=${contentId} class=${expanded.value ? 'px-3 pb-3 flex flex-col gap-2' : 'hidden'} role="region">
         ${expanded.value ? html`
-          <div class="rounded bg-[var(--white-3)] px-2 py-1.5 text-2xs text-[var(--color-fg-disabled)]">
-            Latest: <span class="font-mono text-[var(--color-fg-secondary)]">${latestPreview}</span>
+          <div class="rounded bg-[var(--white-3)] px-2 py-1.5 text-2xs text-[var(--text-dim)]">
+            Latest: <span class="font-mono text-[var(--text-strong)]">${latestPreview}</span>
           </div>
           ${item.entries.map((entry, index) => {
             const entryMeta = sourceMeta(entry.source)
@@ -618,16 +618,16 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
             return html`
               <div class="flex items-center gap-2 rounded bg-[var(--black-20)] px-2 py-1.5 text-3xs" key=${`${item.key}:${index}`}>
                 <span class="font-mono font-bold ${entryMeta.color} w-4 text-center flex-shrink-0">${entryMeta.icon}</span>
-                <span class="font-mono text-[var(--color-fg-disabled)] w-24 flex-shrink-0" title=${formatTs(ts)}>${timeAgoSafe(ts)}</span>
-                <span class="font-mono text-[var(--color-fg-secondary)] truncate flex-1" title=${entryPreview(entry)}>${entryPreview(entry)}</span>
+                <span class="font-mono text-[var(--text-dim)] w-24 flex-shrink-0" title=${formatTs(ts)}>${timeAgoSafe(ts)}</span>
+                <span class="font-mono text-[var(--text-strong)] truncate flex-1" title=${entryPreview(entry)}>${entryPreview(entry)}</span>
               </div>
             `
           })}
           <div class="rounded bg-[var(--black-20)] px-2 py-1.5">
             <div class="flex items-start justify-between gap-2">
               <details class="min-w-0 flex-1">
-                <summary class="cursor-pointer text-3xs text-[var(--color-fg-disabled)]">Raw JSON</summary>
-                <pre class="mt-2 text-3xs font-mono text-[var(--color-fg-muted)] overflow-x-auto max-h-70 overflow-y-auto whitespace-pre-wrap break-all">
+                <summary class="cursor-pointer text-3xs text-[var(--text-dim)]">원본 JSON</summary>
+                <pre class="mt-2 text-3xs font-mono text-[var(--text-muted)] overflow-x-auto max-h-70 overflow-y-auto whitespace-pre-wrap break-all">
 ${rawJson}</pre>
               </details>
               <${CopyIdButton}
@@ -804,16 +804,16 @@ export function TelemetryUnified() {
 
   return html`
     <div class="flex flex-col gap-4">
-      <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-4">
-        <div class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">런타임 진단</div>
-        <div class="mt-1 text-base leading-relaxed text-[var(--color-fg-primary)]">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-4">
+        <div class="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">런타임 진단</div>
+        <div class="mt-1 text-base leading-relaxed text-[var(--text-body)]">
           MASC telemetry store (keeper/tool/agent) 진단 뷰.
         </div>
         <div class="mt-3 flex flex-wrap gap-2">
-          <span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-disabled)]">MASC: keeper/tool/agent store</span>
-          ${sessionFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">session ${sessionFilter.value}</span>` : null}
-          ${operationFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">operation ${operationFilter.value}</span>` : null}
-          ${workerRunFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">worker_run ${workerRunFilter.value}</span>` : null}
+          <span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-dim)]">MASC: keeper/tool/agent store</span>
+          ${sessionFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--text-dim)]">session ${sessionFilter.value}</span>` : null}
+          ${operationFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--text-dim)]">operation ${operationFilter.value}</span>` : null}
+          ${workerRunFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--text-dim)]">worker_run ${workerRunFilter.value}</span>` : null}
         </div>
       </div>
 
@@ -821,9 +821,9 @@ export function TelemetryUnified() {
 
       <div class="flex flex-wrap gap-3">
         ${summary.map(src => html`<${SummaryCard} src=${src} />`)}
-        <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3 min-w-35">
-          <div class="text-xs font-medium text-[var(--color-fg-muted)] mb-1">전체</div>
-          <div class="text-2xl font-bold text-[var(--color-fg-secondary)]">${totalEntries.toLocaleString()}</div>
+        <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-35">
+          <div class="text-xs font-medium text-[var(--text-muted)] mb-1">전체</div>
+          <div class="text-2xl font-bold text-[var(--text-strong)]">${totalEntries.toLocaleString()}</div>
         </div>
       </div>
 
@@ -857,7 +857,7 @@ export function TelemetryUnified() {
       <div class="flex items-center gap-3 flex-wrap">
         <select
           aria-label="텔레메트리 소스 필터"
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--color-fg-secondary)]"
+          class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--text-strong)]"
           value=${sourceFilter.value}
           onChange=${(e: Event) => { sourceFilter.value = (e.target as HTMLSelectElement).value as TelemetrySource | '' }}
         >
@@ -868,7 +868,7 @@ export function TelemetryUnified() {
           type="text"
           placeholder="키퍼 이름..."
           aria-label="키퍼 이름 필터"
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] w-32"
+          class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--text-strong)] w-32"
           value=${keeperFilter.value}
           onInput=${(e: Event) => { keeperFilter.value = (e.target as HTMLInputElement).value }}
         />
@@ -876,7 +876,7 @@ export function TelemetryUnified() {
           type="text"
           placeholder="session_id"
           aria-label="session_id 필터"
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] w-40 font-mono"
+          class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--text-strong)] w-40 font-mono"
           value=${sessionFilter.value}
           onInput=${(e: Event) => { sessionFilter.value = (e.target as HTMLInputElement).value.trim() }}
         />
@@ -884,7 +884,7 @@ export function TelemetryUnified() {
           type="text"
           placeholder="operation_id"
           aria-label="operation_id 필터"
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] w-40 font-mono"
+          class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--text-strong)] w-40 font-mono"
           value=${operationFilter.value}
           onInput=${(e: Event) => { operationFilter.value = (e.target as HTMLInputElement).value.trim() }}
         />
@@ -892,7 +892,7 @@ export function TelemetryUnified() {
           type="text"
           placeholder="worker_run_id"
           aria-label="worker_run_id 필터"
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] w-40 font-mono"
+          class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--text-strong)] w-40 font-mono"
           value=${workerRunFilter.value}
           onInput=${(e: Event) => { workerRunFilter.value = (e.target as HTMLInputElement).value.trim() }}
         />
@@ -900,13 +900,13 @@ export function TelemetryUnified() {
           type="search"
           placeholder="엔트리 검색..."
           aria-label="엔트리 텍스트 검색"
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] w-48"
+          class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--text-strong)] w-48"
           value=${entrySearch.value}
           onInput=${(e: Event) => { entrySearch.value = (e.target as HTMLInputElement).value }}
         />
         <select
           aria-label="표시 개수 제한"
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--color-fg-secondary)]"
+          class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--text-strong)]"
           value=${String(limit.value)}
           onChange=${(e: Event) => { limit.value = Number((e.target as HTMLSelectElement).value) }}
         >
@@ -916,13 +916,13 @@ export function TelemetryUnified() {
           <option value="500">500</option>
         </select>
         <button
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
+          class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
           onClick=${() => void load()}
         >
           Refresh
         </button>
-        <span class="text-xs text-[var(--color-fg-muted)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
-        ${loading ? html`<span class="text-xs text-[var(--color-fg-muted)]">로딩 중...</span>` : null}
+        <span class="text-xs text-[var(--text-muted)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
+        ${loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
       </div>
 
       ${error ? html`
@@ -931,8 +931,8 @@ export function TelemetryUnified() {
         </div>
       ` : null}
 
-      <div class="rounded border border-[var(--color-border-default)] overflow-hidden">
-        <div class="px-3 py-2 border-b border-[var(--color-border-default)] bg-[var(--white-3)] text-xs text-[var(--color-fg-muted)]">
+      <div class="rounded border border-[var(--card-border)] overflow-hidden">
+        <div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-xs text-[var(--text-muted)]">
           MASC telemetry store entries ${entries.length.toLocaleString()}건
           ${isFilteringEntries
             ? ` · 검색 매치 ${displayItems.length.toLocaleString()}건`
@@ -942,11 +942,11 @@ export function TelemetryUnified() {
             : ''}
         </div>
         ${condensed.groups > 0 ? html`
-          <div class="px-3 py-2 border-b border-[var(--color-border-default)] bg-[var(--white-1)] flex flex-wrap gap-2 text-2xs">
+          <div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-1)] flex flex-wrap gap-2 text-2xs">
             ${Array.from(condensed.byCategory.entries()).map(([category, count]) => {
               const meta = CONDENSED_CATEGORY_META[category]
               return html`
-                <span class="rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-2 py-1 text-[var(--color-fg-disabled)]">
+                <span class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-1 text-[var(--text-dim)]">
                   <span class="font-mono ${meta.color}">${meta.icon}</span>
                   <span class="ml-1">${meta.label}</span>
                   <span class="ml-1 font-mono">${count}</span>
@@ -961,8 +961,8 @@ export function TelemetryUnified() {
               ? html`<${GroupRow} key=${item.key} item=${item} />`
               : html`<${EntryRow} key=${item.key} entry=${item.entry} />`)
             : isFilteringEntries && allDisplayItems.length > 0
-              ? html`<div class="px-4 py-6 text-sm text-[var(--color-fg-muted)]">필터 결과 없음 (${allDisplayItems.length} items)</div>`
-              : html`<div class="px-4 py-6 text-sm text-[var(--color-fg-muted)]">선택한 scope에 해당하는 MASC telemetry entry가 없습니다.</div>`}
+              ? html`<div class="px-4 py-6 text-sm text-[var(--text-muted)]">필터 결과 없음 (${allDisplayItems.length} items)</div>`
+              : html`<div class="px-4 py-6 text-sm text-[var(--text-muted)]">선택한 scope에 해당하는 MASC telemetry entry가 없습니다.</div>`}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

영한혼용 금지 (memory: feedback_dashboard-observation-focus). round-25 (#10651 Draft) 와 file overlap 없음.

### 변경 내용

| 파일 | 변경 |
|------|------|
| \`keeper-detail-shell.ts\` | header eyebrow \"Keeper Detail\" → \"키퍼 상세\" |
| \`keeper-config-panel.ts\` | \"Generated runtime JSON\" → \"생성된 런타임 JSON\" |
| \`telemetry-unified.ts\` | \"Raw JSON\" x2 → \"원본 JSON\" (+ test fixture sync) |
| \`feature-health.ts\` | SectionCap \"Feature Flags Health\" → \"기능 플래그 상태\" |
| \`goals/task-detail-overlay.ts\` | \"Completion Contract\" → \"완료 계약\", \"Required Evidence\" → \"필수 증거\" |
| \`cascade-config-panel.ts\` | \"Keeper assignment\" → \"키퍼 할당\" |

\`telemetry-unified.test.ts:507\` 의 \`toContain('Raw JSON')\` assertion 도 \`'원본 JSON'\` 으로 동기화.

### 보존 ledger

- \`JSON\` (식별자), \`SectionCap\` (component name), \`current profile\` (line 409 이미 mid-mixed)

### 검증

- chip text + sync된 test assertion 만 수정. 로직/타입 무변경.
- vitest 는 #10645 infra 회귀로 dashboard 전역 startup-fail 중. 이 PR 의 test assertion 변경은 round-25 와 동일하게 visual review 로 commit.

## Test plan

- [ ] dashboard build 후 6 component 한국어 렌더링 확인
- [ ] vitest infra (#10645) 회복 후 telemetry-unified.test.ts 통과 확인