### PR TITLE
fix(dashboard-test): align telemetry/overview tests with current source

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -223,14 +223,14 @@ describe('pickActiveKeepers', () => {
 
 describe('severityToneClass', () => {
   it.each<[string | null | undefined, string]>([
-    ['critical', 'text-[var(--bad)]'],
-    ['HIGH', 'text-[var(--bad)]'],
-    ['warn', 'text-[var(--warn)]'],
-    ['medium', 'text-[var(--warn)]'],
-    ['info', 'text-[var(--text-muted)]'],
-    ['', 'text-[var(--text-muted)]'],
-    [null, 'text-[var(--text-muted)]'],
-    [undefined, 'text-[var(--text-muted)]'],
+    ['critical', 'text-[var(--color-status-err)]'],
+    ['HIGH', 'text-[var(--color-status-err)]'],
+    ['warn', 'text-[var(--color-status-warn)]'],
+    ['medium', 'text-[var(--color-status-warn)]'],
+    ['info', 'text-[var(--color-fg-muted)]'],
+    ['', 'text-[var(--color-fg-muted)]'],
+    [null, 'text-[var(--color-fg-muted)]'],
+    [undefined, 'text-[var(--color-fg-muted)]'],
   ])('maps severity %s to expected tone', (input, expected) => {
     expect(severityToneClass(input)).toBe(expected)
   })

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -199,7 +199,7 @@ describe('TelemetryUnified', () => {
     })
     await flushUi()
 
-    expect(container.textContent).toContain('Runtime Diagnosis')
+    expect(container.textContent).toContain('런타임 진단')
     expect(container.textContent).toContain('MASC telemetry store')
     expect(container.textContent).toContain('Refresh')
     expect(container.textContent).toContain('30초 자동 갱신')


### PR DESCRIPTION
main에서 발견된 test 실패 fix. 다른 design-system PR들 unblock.

## 변경

### telemetry-unified.test.ts:202
`Runtime Diagnosis` → `런타임 진단` — 소스(line 808)는 Korean label로 변경됐으나 test 미업데이트.

### overview.test.ts:226-233
Legacy production tokens(`--bad`/`--warn`/`--text-muted`) → semantic aliases(`--color-status-err`/`-warn`/`--color-fg-muted`) — overview.ts(line 134-139)는 이미 semantic alias 사용 중.

## Blocked PRs

- #10638 (PR-M29: dashboard/src/ token migration)
- #10646 (PR-CS1: ActionButton swap PoC)

## Test plan

- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
