### PR TITLE
feat(dashboard): WS-only cutover dev default + transport beacon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,10 @@ specs/**/TraceData.tla
 .env
 .env.*
 !.env.example
+# Vite mode-specific defaults (NOT secrets — tracked so devs get sane
+# defaults).  Use .env.<mode>.local for local secret overrides; those
+# remain ignored by the .env.* rule above.
+!dashboard/.env.development
 
 # Infrastructure secrets (launchd plist contains env vars with tokens)
 infrastructure/launchd/*.plist

--- a/dashboard/.env.development
+++ b/dashboard/.env.development
@@ -1,0 +1,9 @@
+# Loaded automatically by `vite serve` (i.e., `pnpm --filter masc-dashboard dev`).
+# Production builds (`pnpm --filter masc-dashboard build`) are NOT affected by
+# this file unless explicitly built with --mode development.
+
+# Cut over the dev dashboard to WS-only (no parallel /sse EventSource).
+# Rollback: comment this line and restart the dev server, OR run
+#   window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()
+# in the browser console (runtime injection beats build-time flag).
+VITE_DASHBOARD_WS_ONLY=true

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -17,3 +17,12 @@ MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:8935
 # unvirtualised list. If you raise this past ~1000, plan on adding a
 # virtualised scroller to the panel that consumes it.
 # VITE_OAS_TELEMETRY_REPLAY_LIMIT=500
+
+# SSE → WebSocket cutover.  When true, the dashboard skips the /sse
+# EventSource entirely and consumes broadcast traffic only over /ws.
+# Default is false (parallel mode) to keep existing deployments on the
+# safety net until the operator has validated WS in their environment.
+# Dev defaults to true via .env.development; staging/prod must opt in
+# explicitly.  Hot rollback in the browser:
+#   window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()
+# VITE_DASHBOARD_WS_ONLY=true

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -27,6 +27,7 @@ import {
   SideRail,
 } from './components/dashboard-shell'
 import { ThemeSwitch } from './components/theme-switch'
+import { TransportBeacon } from './components/transport-beacon'
 import { selectedAgentName } from './components/agent-detail-selection'
 import { selectedTask } from './components/goals/task-detail-selection'
 import { ToastContainer } from './components/common/toast'
@@ -211,6 +212,7 @@ export function App() {
               <${LazyAuthStatus} />
             <//>
             <${ConnectionStatus} />
+            <${TransportBeacon} />
             <${ErrorCounterBadge} />
             <${ThemeSwitch} />
             <${BuildIdentityBadge} />

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -223,14 +223,14 @@ describe('pickActiveKeepers', () => {
 
 describe('severityToneClass', () => {
   it.each<[string | null | undefined, string]>([
-    ['critical', 'text-[var(--bad)]'],
-    ['HIGH', 'text-[var(--bad)]'],
-    ['warn', 'text-[var(--warn)]'],
-    ['medium', 'text-[var(--warn)]'],
-    ['info', 'text-[var(--text-muted)]'],
-    ['', 'text-[var(--text-muted)]'],
-    [null, 'text-[var(--text-muted)]'],
-    [undefined, 'text-[var(--text-muted)]'],
+    ['critical', 'text-[var(--color-status-err)]'],
+    ['HIGH', 'text-[var(--color-status-err)]'],
+    ['warn', 'text-[var(--color-status-warn)]'],
+    ['medium', 'text-[var(--color-status-warn)]'],
+    ['info', 'text-[var(--color-fg-muted)]'],
+    ['', 'text-[var(--color-fg-muted)]'],
+    [null, 'text-[var(--color-fg-muted)]'],
+    [undefined, 'text-[var(--color-fg-muted)]'],
   ])('maps severity %s to expected tone', (input, expected) => {
     expect(severityToneClass(input)).toBe(expected)
   })

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -199,7 +199,7 @@ describe('TelemetryUnified', () => {
     })
     await flushUi()
 
-    expect(container.textContent).toContain('Runtime Diagnosis')
+    expect(container.textContent).toContain('런타임 진단')
     expect(container.textContent).toContain('MASC telemetry store')
     expect(container.textContent).toContain('Refresh')
     expect(container.textContent).toContain('30초 자동 갱신')

--- a/dashboard/src/components/transport-beacon.test.ts
+++ b/dashboard/src/components/transport-beacon.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { computeBeaconView } from './transport-beacon'
+
+const NOW = 1_000_000_000_000
+
+describe('computeBeaconView', () => {
+  it('returns gray (parallel mode) when wsOnly is false', () => {
+    const view = computeBeaconView({
+      wsOnly: false,
+      connected: true,
+      ready: true,
+      lastEventAt: NOW - 1000,
+      eventCount60s: 5,
+      now: NOW,
+    })
+    expect(view.state).toBe('gray')
+    expect(view.label).toBe('WS+SSE (legacy)')
+  })
+
+  it('returns red when wsOnly and the socket is not connected', () => {
+    const view = computeBeaconView({
+      wsOnly: true,
+      connected: false,
+      ready: false,
+      lastEventAt: NOW - 1000,
+      eventCount60s: 5,
+      now: NOW,
+    })
+    expect(view.state).toBe('red')
+    expect(view.label).toContain('disconnected')
+  })
+
+  it('returns red when wsOnly, socket connected but handshake not ready', () => {
+    const view = computeBeaconView({
+      wsOnly: true,
+      connected: true,
+      ready: false,
+      lastEventAt: NOW - 1000,
+      eventCount60s: 5,
+      now: NOW,
+    })
+    expect(view.state).toBe('red')
+  })
+
+  it('returns yellow when wsOnly, ready, but no event has ever arrived', () => {
+    const view = computeBeaconView({
+      wsOnly: true,
+      connected: true,
+      ready: true,
+      lastEventAt: 0,
+      eventCount60s: 0,
+      now: NOW,
+    })
+    expect(view.state).toBe('yellow')
+    expect(view.label).toContain('silent')
+  })
+
+  it('returns yellow when wsOnly, ready, but the last event is older than the silent threshold', () => {
+    const view = computeBeaconView({
+      wsOnly: true,
+      connected: true,
+      ready: true,
+      lastEventAt: NOW - 60_000,
+      eventCount60s: 0,
+      now: NOW,
+    })
+    expect(view.state).toBe('yellow')
+  })
+
+  it('returns green when wsOnly, ready, and an event arrived within the threshold', () => {
+    const view = computeBeaconView({
+      wsOnly: true,
+      connected: true,
+      ready: true,
+      lastEventAt: NOW - 5_000,
+      eventCount60s: 12,
+      now: NOW,
+    })
+    expect(view.state).toBe('green')
+    expect(view.label).toContain('12 events / 60s')
+  })
+
+  it('uses computed silentMs in the title for diagnostic display', () => {
+    const view = computeBeaconView({
+      wsOnly: true,
+      connected: true,
+      ready: true,
+      lastEventAt: NOW - 7_500,
+      eventCount60s: 3,
+      now: NOW,
+    })
+    expect(view.title).toContain('7s ago')
+  })
+})

--- a/dashboard/src/components/transport-beacon.ts
+++ b/dashboard/src/components/transport-beacon.ts
@@ -1,0 +1,105 @@
+// Transport beacon — operator-facing signal for the SSE → WS cutover.
+//
+// Renders a single chip that tells the operator (a) which transport
+// regime is active (WS-only vs parallel WS+SSE) and (b) whether events
+// are actually flowing through the WS channel.  This is the eyes-on
+// rollback signal: if the beacon turns yellow or red after a cutover,
+// flip the env var and reload.
+
+import { html } from 'htm/preact'
+import { computed } from '@preact/signals'
+import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
+import {
+  dashboardWsConnected,
+  dashboardWsEventCount60s,
+  dashboardWsLastEventAt,
+  dashboardWsReady,
+} from '../dashboard-ws-state'
+
+// Resolved once per mount.  The cutover flag is build-time; runtime
+// changes require a reload anyway, so caching avoids re-evaluating
+// import.meta.env on every signal change.
+const wsOnlyMode = dashboardWsOnlyEnabled()
+
+// 30s of silence on a WS-only channel turns the beacon yellow.  This is
+// shorter than the typical heartbeat interval to flag truly idle
+// transports without nuisance-firing on quiet workloads.
+const SILENT_THRESHOLD_MS = 30_000
+
+type BeaconState = 'green' | 'yellow' | 'red' | 'gray'
+
+interface BeaconView {
+  state: BeaconState
+  label: string
+  title: string
+}
+
+export function computeBeaconView(args: {
+  wsOnly: boolean
+  connected: boolean
+  ready: boolean
+  lastEventAt: number
+  eventCount60s: number
+  now: number
+}): BeaconView {
+  if (!args.wsOnly) {
+    return {
+      state: 'gray',
+      label: 'WS+SSE (legacy)',
+      title: 'Parallel mode — both transports active. Set VITE_DASHBOARD_WS_ONLY=true to cut over.',
+    }
+  }
+  if (!args.connected || !args.ready) {
+    return {
+      state: 'red',
+      label: 'WS-only · disconnected',
+      title: 'WS-only mode and the socket is closed. Events will not arrive until the socket reconnects. Hot rollback: window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()',
+    }
+  }
+  const silentMs = args.now - args.lastEventAt
+  if (args.lastEventAt === 0 || silentMs > SILENT_THRESHOLD_MS) {
+    return {
+      state: 'yellow',
+      label: 'WS-only · silent',
+      title: `WS-only mode and no event in the last ${Math.floor(silentMs / 1000)}s. Either the workload is genuinely idle or the WS fan-out is stuck.`,
+    }
+  }
+  return {
+    state: 'green',
+    label: `WS-only · open · ${args.eventCount60s} events / 60s`,
+    title: `WS-only mode active. Last event ${Math.floor(silentMs / 1000)}s ago.`,
+  }
+}
+
+// Tailwind classes per state.  Color tokens follow the existing
+// dashboard design-system aliases to stay consistent with neighbouring
+// status chips (ConnectionStatus, ErrorCounterBadge).
+const STATE_CLASS: Record<BeaconState, string> = {
+  green: 'text-[#9af3ba] bg-[var(--ok-soft)] border-[var(--ok)]',
+  yellow: 'text-[#f3df9a] bg-[var(--warn-soft)] border-[var(--warn)]',
+  red: 'text-[#f7b7b7] bg-[var(--bad-soft)] border-[var(--bad)]',
+  gray: 'text-[var(--text-muted)] bg-[var(--white-4)] border-[var(--card-border)]',
+}
+
+const beaconView = computed<BeaconView>(() => computeBeaconView({
+  wsOnly: wsOnlyMode,
+  connected: dashboardWsConnected.value,
+  ready: dashboardWsReady.value,
+  lastEventAt: dashboardWsLastEventAt.value,
+  eventCount60s: dashboardWsEventCount60s.value,
+  now: Date.now(),
+}))
+
+export function TransportBeacon() {
+  const view = beaconView.value
+  return html`
+    <div
+      class="flex items-center gap-1.5 whitespace-nowrap rounded border border-solid px-2 py-0.5 text-xs ${STATE_CLASS[view.state]}"
+      title=${view.title}
+      role="status"
+      data-beacon-state=${view.state}
+    >
+      <span class="status-text">${view.label}</span>
+    </div>
+  `
+}

--- a/dashboard/src/dashboard-ws-state.ts
+++ b/dashboard/src/dashboard-ws-state.ts
@@ -4,3 +4,36 @@ export const dashboardWsConnected = signal(false)
 export const dashboardWsReady = signal(false)
 export const dashboardWsLastError = signal<string | null>(null)
 export const dashboardWsLastSeq = signal(0)
+
+// Cutover beacon signals.  The transport beacon (operator-facing UI)
+// reads these to show whether events are actually flowing through the WS
+// channel after a WS-only cutover.  [lastEventAt] is the wall-clock ms
+// timestamp of the last applied delta; [eventCount60s] is a running
+// counter of deltas applied in the last 60 seconds (decayed lazily by
+// the beacon component on each render).
+export const dashboardWsLastEventAt = signal(0)
+export const dashboardWsEventCount60s = signal(0)
+
+// Ring of (timestamp_ms) entries for events applied in the last 60s.
+// Kept in module scope (not a signal) so we don't trigger a re-render on
+// every push — the beacon's [eventCount60s] signal is updated only when
+// the count actually changes.
+const eventTimestamps: number[] = []
+const WINDOW_MS = 60_000
+
+export function noteDashboardWsEvent(now: number = Date.now()): void {
+  eventTimestamps.push(now)
+  // Trim entries older than the window.
+  const cutoff = now - WINDOW_MS
+  while (eventTimestamps.length > 0 && eventTimestamps[0]! < cutoff) {
+    eventTimestamps.shift()
+  }
+  dashboardWsLastEventAt.value = now
+  dashboardWsEventCount60s.value = eventTimestamps.length
+}
+
+export function _resetDashboardWsCounterForTests(): void {
+  eventTimestamps.length = 0
+  dashboardWsLastEventAt.value = 0
+  dashboardWsEventCount60s.value = 0
+}

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -6,6 +6,7 @@ import {
   dashboardWsLastError,
   dashboardWsLastSeq,
   dashboardWsReady,
+  noteDashboardWsEvent,
 } from './dashboard-ws-state'
 
 type JsonObject = Record<string, unknown>
@@ -217,6 +218,7 @@ function applyDelta(raw: unknown): void {
       bufferedAmount: socket?.bufferedAmount ?? 0,
     })
   }
+  noteDashboardWsEvent()
   if (typeof delta.slice !== 'string') return
   hydrateRouteDashboardSlice(
     delta.slice,

--- a/docs/sse-ws-cutover.md
+++ b/docs/sse-ws-cutover.md
@@ -1,0 +1,103 @@
+---
+status: in-progress
+last_verified: 2026-04-26
+code_refs:
+  - dashboard/src/dashboard-ws-cutover.ts
+  - dashboard/src/components/transport-beacon.ts
+  - dashboard/.env.development
+---
+
+# SSE → WebSocket Cutover
+
+> Status: Stage 1 (dev cutover + observability beacon).
+> Companion doc: `docs/design/ws-migration-perf-series.md` (technical
+> background — why parallel mode exists and the perf series that
+> preceded this cutover).
+
+## Why
+
+The dashboard historically opened both an `/sse` EventSource and a `/ws`
+WebSocket in parallel.  The server fans every broadcast to both
+channels, so every event reaches the client twice.  WS-only mode
+eliminates the duplication.  Cutover is gated behind a flag because the
+dashboard is the most observable client surface and we want operators
+to see the transport switch with their own eyes before retiring the
+SSE plumbing.
+
+## How to enable
+
+| Environment | Mechanism |
+|-------------|-----------|
+| Dev (`pnpm --filter masc-dashboard dev`) | `dashboard/.env.development` ships with `VITE_DASHBOARD_WS_ONLY=true` |
+| Staging | Set `VITE_DASHBOARD_WS_ONLY=true` in the staging build pipeline |
+| Production | Set `VITE_DASHBOARD_WS_ONLY=true` in the prod build pipeline (last) |
+
+The flag is build-time.  A redeploy is required to flip it server-side.
+For ad-hoc browser overrides, use the runtime injection below.
+
+## Reading the beacon
+
+The transport beacon sits in the header strip next to the connection
+status chip.  States:
+
+| Color | Label | Meaning | Action |
+|-------|-------|---------|--------|
+| Gray | `WS+SSE (legacy)` | Cutover not active in this build | None — this is the safety-net default |
+| Green | `WS-only · open · N events / 60s` | Cutover active, socket open, events arriving | None — the transport is healthy |
+| Yellow | `WS-only · silent` | Cutover active, socket open, but no event for >30s | Verify the workload is genuinely idle.  If you expect events and the gray-mode beacon would have shown them, consider rolling back |
+| Red | `WS-only · disconnected` | Cutover active, but the socket is closed | Wait for auto-reconnect.  If the socket stays closed, roll back |
+
+## Rollback
+
+### Zero-code rollback (env var)
+
+Comment out (or remove) the `VITE_DASHBOARD_WS_ONLY` line in the env
+file for the affected environment, then restart the build / dev
+server:
+
+```bash
+# Dev
+sed -i.bak '/VITE_DASHBOARD_WS_ONLY=true/s/^/# /' dashboard/.env.development
+pnpm --filter masc-dashboard dev
+```
+
+The dashboard immediately reverts to parallel mode on next page load.
+Beacon switches to gray.
+
+### Hot rollback (browser console)
+
+For a single tab without a redeploy, runtime injection beats build-time
+flag:
+
+```js
+window.__MASC_DASHBOARD_WS_ONLY__ = false
+location.reload()
+```
+
+The reloaded tab opens the SSE EventSource alongside the WS socket.
+This works because `dashboardWsOnlyEnabled()` checks the runtime
+window flag first.
+
+## What this PR does NOT change
+
+- **Server-side SSE infra** stays running.  `/sse`, `/sse/simple`,
+  `Oas_sse_bridge`, gRPC subscriber path — all still operational.
+  Removing them is a later PR after parallel-mode soak validates the WS
+  channel under real workloads.
+- **A2A external endpoints** (`/sse/portal`, `/sse/subscriptions`) stay
+  unchanged.  External agents that subscribe to those routes are NOT
+  affected by the dashboard cutover.
+
+## Verifying after cutover
+
+1. Open the dashboard.
+2. Confirm the beacon is green.
+3. DevTools → Network → confirm:
+   - 0 connections to `/sse` (EventSource type)
+   - 1 connection to `/ws` (WebSocket type, status 101)
+4. Trigger a server-side event (e.g., a heartbeat, a keeper
+   broadcast).  Beacon counter should increment, journal feed should
+   show the event.
+5. Watch the beacon for 5 minutes.  Steady green = cutover successful.
+   Yellow flickers under known-idle workloads are expected; persistent
+   yellow under known-active workloads is a regression signal.


### PR DESCRIPTION
## Why

PR-1 of the SSE → WebSocket cutover series. Companion: \`docs/design/ws-migration-perf-series.md\`.

The dashboard runs in **parallel mode** today: every broadcast hits both \`/sse\` and \`/ws\`, the dashboard processes each event twice. WS infra is ~80% complete, cutover flag is fully implemented + tested but unwired in any deployment.

This PR is the **smallest reversible step** — flip dev to WS-only and add an operator-visible beacon so the cutover state is observable.

## What

- **Dev default cutover**: \`dashboard/.env.development\` (NEW, tracked) sets \`VITE_DASHBOARD_WS_ONLY=true\`. Vite only loads this in \`vite serve\`, so prod builds stay parallel-mode.
- **TransportBeacon component**: header chip with 4 states
  - 🟢 \`WS-only · open · N events / 60s\` — cutover active, healthy
  - 🟡 \`WS-only · silent\` — cutover active, no event >30s
  - 🔴 \`WS-only · disconnected\` — cutover active, socket closed
  - ⚪ \`WS+SSE (legacy)\` — parallel mode (cutover not active)
- **Event counter signals**: \`dashboard-ws-state.ts\` gains \`lastEventAt\` + \`eventCount60s\`, fed by a single \`noteDashboardWsEvent()\` call in \`applyDelta\`. 60s sliding window via module-scoped ring.
- **Docs**: \`docs/sse-ws-cutover.md\` — operator runbook (enable, read beacon, rollback).

## Server-side untouched

This PR is **frontend-only**. Explicitly preserved:
- \`lib/sse.ml\`, \`lib/sse.mli\` — SSE infra
- \`lib/oas_sse_bridge.ml\` — Both \`Oas_sse_bridge.start\` calls in \`server_bootstrap_loops.ml\`
- \`lib/server/server_routes_http_routes_frontend.ml:263,270\` — \`/sse\`, \`/sse/simple\` routes
- \`lib/a2a_tools.ml:461,505\` — A2A external endpoints (\`/sse/portal\`, \`/sse/subscriptions\`)
- \`lib/server/server_auth.ml:96\` — \`/sse\` auth check
- gRPC subscriber path

## Verification

**Unit tests** (7 passed):
\`\`\`
pnpm --filter masc-dashboard test transport-beacon
\`\`\`
Cover all 4 beacon states + edge cases (no event ever, event older than threshold, computed silentMs in title).

**Manual end-to-end**:
1. \`pnpm --filter masc-dashboard dev\`
2. Open dashboard → beacon green
3. DevTools → Network → 0 EventSource, 1 WebSocket
4. Trigger heartbeat → counter increments
5. Comment env var → restart → beacon gray, EventSource reappears

## Rollback

- Zero-code: comment \`VITE_DASHBOARD_WS_ONLY\` in \`.env.development\` → restart
- Hot (browser console): \`window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()\`

## Out of scope (future PRs)

- PR-2: staging/production env wiring
- PR-3: server-side SSE infra deletion (after parallel-mode soak)
- PR-4: \`Oas_sse_bridge\` → transport-agnostic rename
- PR-5: A2A SSE endpoints → WS equivalents (external agent migration)