### PR TITLE
refactor(common): hoist auth_dir/agents_dir helpers to break P2 cycle

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -21,9 +21,8 @@ let sha256_hash input =
 (* Auth directory management                    *)
 (* ============================================ *)
 
-let auth_dir config =
-  Filename.concat (Common.masc_dir_from_base_path ~base_path:config) "auth"
-let agents_dir config = Filename.concat (auth_dir config) "agents"
+let auth_dir config = Common.auth_dir_from_base_path ~base_path:config
+let agents_dir config = Common.agents_dir_from_base_path ~base_path:config
 let room_secret_file config = Filename.concat (auth_dir config) "room_secret.hash"
 let auth_config_file config = Filename.concat (auth_dir config) "config.json"
 let initial_admin_file config = Filename.concat (auth_dir config) "initial_admin"

--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -39,6 +39,12 @@ let masc_dirname = ".masc"
 let masc_dir_from_base_path ~base_path =
   Filename.concat base_path masc_dirname
 
+let auth_dir_from_base_path ~base_path =
+  Filename.concat (masc_dir_from_base_path ~base_path) "auth"
+
+let agents_dir_from_base_path ~base_path =
+  Filename.concat (auth_dir_from_base_path ~base_path) "agents"
+
 (** Maximum output bytes for tool responses. SSOT for the 64KB cap. *)
 let max_tool_output_bytes = 65_536
 

--- a/lib/core/common.mli
+++ b/lib/core/common.mli
@@ -45,6 +45,16 @@ val masc_dir_from_base_path : base_path:string -> string
     [Filename.concat base_path masc_dirname]. Canonical way to spell
     [<base_path>/.masc]. *)
 
+val auth_dir_from_base_path : base_path:string -> string
+(** [<base_path>/.masc/auth]. SSOT path so {!Auth} and
+    {!Keeper_identity} can both compute it without depending on each
+    other (RFC P2 cycle-break prep). *)
+
+val agents_dir_from_base_path : base_path:string -> string
+(** [<base_path>/.masc/auth/agents]. Same SSOT motivation as
+    {!auth_dir_from_base_path}; this is where keeper credential JSON
+    files live ([<agent_name>.json]). *)
+
 val max_tool_output_bytes : int
 (** SSOT 64KB cap for MCP tool response bodies. *)
 

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -241,7 +241,9 @@ let normalize_all_names ~input_agent_name ?(base_path = "")
           if not check_credential then Ok ()
           else
             let path =
-              Filename.concat (Auth.agents_dir base_path) (credential_stem ^ ".json")
+              Filename.concat
+                (Common.agents_dir_from_base_path ~base_path)
+                (credential_stem ^ ".json")
             in
             if Sys.file_exists path then Ok ()
             else


### PR DESCRIPTION
## Summary

`Common`에 `auth_dir_from_base_path` / `agents_dir_from_base_path` 두 helper 추가. `Keeper_identity.normalize_all_names`가 `Auth.agents_dir` 대신 `Common.agents_dir_from_base_path` 사용하도록 전환. `Auth.auth_dir` / `Auth.agents_dir`도 동일 helper에 위임 (호출부 변경 0).

**Behavior change: 0**. Path 계산 동일.

## Why (RFC P2 cycle-break prep)

RFC P-series 다음 단계(Path X — `Auth.verify_token_owner_alias`가 `Keeper_identity.normalize_all_names` 사용)를 막는 module-level dep cycle을 깨기 위함.

현재 의존 그래프:
```
Keeper_identity → Auth (Auth.agents_dir at keeper_identity.ml:244)
```

만약 `Auth → Keeper_identity` 추가 시:
```
Auth → Keeper_identity → Auth   (cycle, dune reject)
```

P2-a 본문이 §2.2 deviation 사유로 명시한 cycle. caller-side normalize로 우회했지만 호출자가 늘어날 때마다 normalize boilerplate 중복 — 정작 필요한 곳(verify_token_owner_alias)에 적용도 막힘.

본 PR 후:
```
Keeper_identity → Common (cycle 없음)
Auth → Keeper_identity (안전하게 가능)
```

## Scope

| 파일 | 변경 |
|------|------|
| `lib/core/common.ml` | +6 lines: `auth_dir_from_base_path`, `agents_dir_from_base_path` 정의 |
| `lib/core/common.mli` | +10 lines: signature + doc |
| `lib/keeper/keeper_identity.ml` | -1/+3 lines: `Auth.agents_dir base_path` → `Common.agents_dir_from_base_path ~base_path` |
| `lib/auth.ml` | -2/+2 lines: 기존 `auth_dir` / `agents_dir`를 Common helper에 위임 |

총 **4 파일, +21/-4 lines**. 신규 module 0, behavior change 0, test 추가 0 (기존 path 계산 테스트가 이미 cover).

## Behavior preservation

수동 검증 (path 계산 동일):

| 항목 | Before | After |
|------|--------|-------|
| `Auth.auth_dir base` | `<base>/.masc/auth` | `<base>/.masc/auth` |
| `Auth.agents_dir base` | `<base>/.masc/auth/agents` | `<base>/.masc/auth/agents` |
| `Keeper_identity` cred path | `<base>/.masc/auth/agents/<stem>.json` | `<base>/.masc/auth/agents/<stem>.json` |

`masc_dirname` SSOT 위배 0 — 신규 literal 없음, 모두 `masc_dir_from_base_path` 위임.

## Cycle verification

```
$ rg "Auth\." lib/keeper/keeper_identity.ml
# (no matches)
```

`Keeper_identity` 더 이상 `Auth` 참조 0건 → cycle 없음.

## Test plan

- [x] `dune build @check` (격리 worktree, `_build_p2prep` cache, `--cache=disabled`) → exit 0 확인
- [ ] CI green (Build/Test/Lint/Health/Meta Guards)
- [ ] 기존 `test_masc_dirname_ssot` baseline 통과 (신규 `.masc` literal 없으므로 변화 없음)

## Series / Follow-up

- 본 PR (P2 cycle-break prep): `Common` helper 추가 + `Keeper_identity` Auth dep 제거
- **다음 PR** (Path X — `Auth.verify_token_owner_alias` 강화): 본 PR 머지 후, `verify_token_owner_alias`가 `Keeper_identity.normalize_all_names`로 dual-identity 119 burst 차단

## Risk

- **순수 path refactor**: equivalent computation, 외부 caller 영향 0.
- **`auth_dir`/`agents_dir` API 보존**: 기존 호출자(`test_auth_doctor.ml:93`, `test_server_runtime_bootstrap.ml:1716` 등) 그대로 작동.
- **Common 모듈 부풀림 우려**: 두 1-line wrapper 추가 — `masc_dir_from_base_path` 옆에 배치, 같은 SSOT 의도 doc.

## References

- P2-a (#10491) `lib/auth.mli` deviation note (Auth → Keeper_identity → Auth cycle 사유)
- 본 PR이 깨는 cycle: `lib/keeper/keeper_identity.ml:244` `Auth.agents_dir`
- RFC: `~/me/planning/2026-04-25-keeper-identity-canonicalization-rfc.md` §2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)