### PR TITLE
feat(keeper): RFC-0008 PR-1 — Credential_provider trait + Host_config_provider

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -479,6 +479,8 @@
    keeper_shell_bg_task
    keeper_exec_shell
    keeper_gh_env
+   credential_provider
+   host_config_provider
    keeper_gh_shared
    keeper_tool_pr_review
    keeper_exec_preflight
@@ -693,6 +695,8 @@
    keeper_shell_bg_task
    keeper_exec_shell
    keeper_gh_env
+   credential_provider
+   host_config_provider
    keeper_gh_shared
    keeper_tool_pr_review
    keeper_exec_preflight

--- a/lib/keeper/credential_provider.ml
+++ b/lib/keeper/credential_provider.ml
@@ -1,0 +1,40 @@
+(** See {!Credential_provider} interface. *)
+
+type ro_mount = {
+  host : string;
+  container : string;
+}
+
+type binding = {
+  identity : string;
+  env : (string * string) list;
+  ro_mounts : ro_mount list;
+  bootstrap : string list option;
+  metadata : (string * string) list;
+}
+
+type error =
+  | Missing_bundle of { identity : string; path : string }
+  | Invalid_token of { identity : string; reason : string }
+  | Finalize_failed of { identity : string; reason : string }
+  | Tear_down_failed of { identity : string; reason : string }
+
+let pp_error = function
+  | Missing_bundle { identity; path } ->
+      Printf.sprintf "Missing_bundle{identity=%s; path=%s}" identity path
+  | Invalid_token { identity; reason } ->
+      Printf.sprintf "Invalid_token{identity=%s; reason=%s}" identity reason
+  | Finalize_failed { identity; reason } ->
+      Printf.sprintf "Finalize_failed{identity=%s; reason=%s}" identity reason
+  | Tear_down_failed { identity; reason } ->
+      Printf.sprintf "Tear_down_failed{identity=%s; reason=%s}" identity reason
+
+module type S = sig
+  val resolve :
+    config:Coord.config -> identity:string -> (binding, error) result
+
+  val finalize :
+    binding -> container_id:string -> (unit, error) result
+
+  val tear_down : binding -> container_id:string option -> unit
+end

--- a/lib/keeper/credential_provider.mli
+++ b/lib/keeper/credential_provider.mli
@@ -1,0 +1,91 @@
+(** Credential provider trait — abstract surface for keeper-scoped
+    GitHub credential lifecycle (RFC-0008 PR-1).
+
+    The trait centralises credential composition (env + RO mounts +
+    metadata) so the docker-invocation site at
+    {!Keeper_shell_docker} no longer reaches into multiple SSOTs
+    inline.  Concrete implementations:
+
+    - {!Host_config_provider}: Option A — host bundle mounted RO.
+    - In_container_login_provider (RFC-0008 PR-3, gated): Option B —
+      [gh auth login --with-token] inside the container.
+
+    Lifecycle (in caller order):
+      [resolve] -> [finalize]  (after container start, post-bootstrap)
+                -> [tear_down] (idempotent; called from
+                                [Eio.Switch.on_release] so crashes
+                                still hit it).
+
+    PR-1 scope: the trait + {!Host_config_provider} only.  [finalize]
+    and [tear_down] are noops in PR-1; the methods exist so PR-3 can
+    drop in without interface churn. *)
+
+(** Read-only mount projected from a host path into a container path.
+    Empty {!ro_mount.host} or a missing path means the mount is
+    skipped (mirrors the inline [optional_ro_mount] helper at
+    [keeper_shell_docker.ml:149]). *)
+type ro_mount = {
+  host : string;
+  container : string;
+}
+
+(** Materialised credential plan for a single keeper subprocess. *)
+type binding = {
+  identity : string;
+      (** Keeper-scoped identity, e.g. ["anyang-keepers"]. *)
+  env : (string * string) list;
+      (** Subprocess env pairs.  Composed inside [resolve]; merges
+          path-derived entries (HOME, GH_CONFIG_DIR, GIT_CONFIG_COUNT
+          + GIT_CONFIG_KEY_0/VALUE_0, plus GIT_AUTHOR_NAME/EMAIL and
+          GIT_COMMITTER_NAME/EMAIL) with
+          {!Env_git_noninteractive.env} from RFC-0007 PR-1.  No new
+          env keys are introduced beyond what those two SSOTs already
+          define. *)
+  ro_mounts : ro_mount list;
+      (** Host paths mounted read-only (Option A).  Empty for
+          Option B. *)
+  bootstrap : string list option;
+      (** argv executed inside the container after start ([None] for
+          Option A; [Some ["gh"; "auth"; "login"; ...]] for Option B
+          in PR-3). *)
+  metadata : (string * string) list;
+      (** Audit pairs: [source], [git_identity_mode], optional
+          [github_identity], and (PR-2) [sha256_prefix]. *)
+}
+
+(** Provider error variants.  [Missing_bundle] covers "no host bundle
+    found / no keeper identity configured" (RFC-0008 §3 — F-1 path).
+    [Invalid_token] is reserved for PR-2 / PR-3 [provider_gate]
+    failures.  [Finalize_failed] / [Tear_down_failed] surface the
+    underlying reason without coercing to [string] so the caller can
+    log structured fields. *)
+type error =
+  | Missing_bundle of { identity : string; path : string }
+  | Invalid_token of { identity : string; reason : string }
+  | Finalize_failed of { identity : string; reason : string }
+  | Tear_down_failed of { identity : string; reason : string }
+
+val pp_error : error -> string
+(** Human-readable rendering for log lines. *)
+
+(** Module signature implemented by each concrete provider.  RFC-0008
+    §3 spelled this as [include module type of Credential_provider];
+    in OCaml the idiomatic equivalent is a named [module type S] that
+    callers can refer to as [Credential_provider.S]. *)
+module type S = sig
+  val resolve :
+    config:Coord.config -> identity:string -> (binding, error) result
+  (** Must be total.  Pure up to filesystem read; no network. *)
+
+  val finalize :
+    binding -> container_id:string -> (unit, error) result
+  (** Called once per keeper session, after the container is up and
+      (for Option B) after [bootstrap] argv has executed.
+      Implementations MUST rewrite [hosts.yml:user] to
+      [binding.identity] when that file exists in any writable mount. *)
+
+  val tear_down : binding -> container_id:string option -> unit
+  (** Idempotent; safe to call even if [finalize] was never called.
+      Caller runs this from [Eio.Switch.on_release] or equivalent so
+      crashes still hit it. *)
+end

--- a/lib/keeper/host_config_provider.ml
+++ b/lib/keeper/host_config_provider.ml
@@ -1,0 +1,96 @@
+(** See {!Host_config_provider} interface. *)
+
+let cred_root = "/tmp/keeper-creds"
+
+let mount_if_present ~host ~container : Credential_provider.ro_mount list =
+  if host = "" then []
+  else if not (Sys.file_exists host) then []
+  else [ { host; container } ]
+
+(* RFC-0008 PR-1: env composition mirrors the inline block at
+   keeper_shell_docker.ml:271-329 (pre-extraction).  No new env keys
+   are introduced; this is the same surface, concentrated. *)
+let compose_env ~git_author_name ~git_author_email =
+  [
+    "HOME", cred_root;
+    "GH_CONFIG_DIR", Filename.concat cred_root ".config/gh";
+    "GIT_CONFIG_GLOBAL", Filename.concat cred_root ".gitconfig";
+    "GIT_CONFIG_COUNT", "1";
+    "GIT_CONFIG_KEY_0", "safe.directory";
+    "GIT_CONFIG_VALUE_0", "*";
+    "GIT_AUTHOR_NAME", git_author_name;
+    "GIT_AUTHOR_EMAIL", git_author_email;
+    "GIT_COMMITTER_NAME", git_author_name;
+    "GIT_COMMITTER_EMAIL", git_author_email;
+  ]
+  @ Env_git_noninteractive.env
+
+let compose_ro_mounts (kb : Keeper_gh_env.keeper_binding) =
+  let gh_creds =
+    match kb.gh_config_dir with
+    | Some dir -> dir
+    | None -> Env_config_sandbox.Auth_paths.gh_creds ()
+  in
+  let gitconfig = Env_config_sandbox.Auth_paths.gitconfig () in
+  let ssh_dir = Env_config_sandbox.Auth_paths.ssh_dir () in
+  mount_if_present ~host:gh_creds
+    ~container:(Filename.concat cred_root ".config/gh")
+  @ mount_if_present ~host:gitconfig
+      ~container:(Filename.concat cred_root ".gitconfig")
+  @ mount_if_present ~host:ssh_dir
+      ~container:(Filename.concat cred_root ".ssh")
+
+let resolve_git_identity (kb : Keeper_gh_env.keeper_binding) ~keeper_name =
+  match kb.github_identity, kb.git_identity_mode with
+  | Some id, "github_identity" ->
+      id, id ^ "@users.noreply.github.com"
+  | _ ->
+      Keeper_identity.keeper_git_author ~keeper_name,
+      Keeper_identity.keeper_git_email ~keeper_name
+
+let metadata_of_binding (kb : Keeper_gh_env.keeper_binding) =
+  let base =
+    [ "source", "host_config";
+      "git_identity_mode", kb.git_identity_mode;
+    ]
+  in
+  match kb.github_identity with
+  | Some id -> base @ [ "github_identity", id ]
+  | None -> base
+
+let resolve ~config ~identity:keeper_name =
+  match Keeper_gh_env.keeper_binding config ~keeper_name with
+  | Error reason ->
+      Error
+        (Credential_provider.Missing_bundle
+          { identity = keeper_name; path = reason })
+  | Ok kb ->
+      let git_author_name, git_author_email =
+        resolve_git_identity kb ~keeper_name
+      in
+      let env = compose_env ~git_author_name ~git_author_email in
+      let ro_mounts = compose_ro_mounts kb in
+      let metadata = metadata_of_binding kb in
+      Ok
+        Credential_provider.{
+          identity = keeper_name;
+          env;
+          ro_mounts;
+          bootstrap = None;
+          metadata;
+        }
+
+let finalize (_b : Credential_provider.binding) ~container_id:_ =
+  (* PR-1: noop.  PR-3 will rewrite hosts.yml:user inside the
+     container after `gh auth login --with-token` runs. *)
+  Ok ()
+
+let tear_down (_b : Credential_provider.binding) ~container_id:_ =
+  (* PR-1: noop.  The RO mount lifetime equals the `docker run`
+     lifetime; nothing to unmount. *)
+  ()
+
+module For_testing = struct
+  let compose_env = compose_env
+  let mount_if_present = mount_if_present
+end

--- a/lib/keeper/host_config_provider.mli
+++ b/lib/keeper/host_config_provider.mli
@@ -1,0 +1,37 @@
+(** Option A credential provider — host bundle mounted read-only
+    (RFC-0008 PR-1).
+
+    Composes the binding that {!Keeper_shell_docker} previously built
+    inline (lines 271-329 pre-extraction): RO mounts of the host
+    [gh] config dir + [.gitconfig] + [.ssh] dir, env vars projecting
+    those mounts under {!cred_root} inside the container, and the
+    canonical non-interactive git env from {!Env_git_noninteractive}.
+
+    [finalize] and [tear_down] are noops here — the RO mount has
+    nothing to relabel and its lifetime is the docker [run].  PR-3's
+    [In_container_login_provider] will use the same trait surface
+    with a real [finalize] (rewrite [hosts.yml:user] inside
+    container) and [bootstrap] argv. *)
+
+include Credential_provider.S
+
+val cred_root : string
+(** [/tmp/keeper-creds] — in-container path under which credentials
+    are projected.  Exposed so callers that compose paths relative to
+    it (currently only the [SSH_AUTH_SOCK] mount, which depends on
+    the host SSH agent and is therefore composed outside this trait)
+    stay in sync with the [HOME=<cred_root>] env entry that the
+    binding already carries. *)
+
+(**/**)
+
+(** Pure helpers exposed for white-box tests.  Not part of the stable
+    API; do not call from production code. *)
+module For_testing : sig
+  val compose_env :
+    git_author_name:string -> git_author_email:string ->
+    (string * string) list
+
+  val mount_if_present :
+    host:string -> container:string -> Credential_provider.ro_mount list
+end

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -268,65 +268,38 @@ let run_docker_shell_command_with_status
         else
           Keeper_sandbox_runtime.docker_network_args network_mode
       in
-      let cred_root = "/tmp/keeper-creds" in
+      let cred_root = Host_config_provider.cred_root in
       let cred_result =
         if not git_creds_enabled then
           Ok ([], [])
         else
-          match Keeper_gh_env.keeper_binding config ~keeper_name:meta.name with
-          | Error err -> Error err
+          (* RFC-0008 PR-1: composition centralised in
+             [Host_config_provider.resolve].  Pre-extraction this
+             site inlined ~60 lines reading from
+             [Keeper_gh_env.keeper_binding], [Env_config_sandbox.Auth_paths],
+             [Keeper_identity], and [Env_git_noninteractive].  The
+             trait keeps that surface identical (no new env keys, no
+             new mounts) and makes the lifecycle explicit so PR-3
+             can swap to [In_container_login_provider] without
+             rewiring this caller.  See RFC-0008 §3 / §4. *)
+          match
+            Host_config_provider.resolve ~config ~identity:meta.name
+          with
+          | Error err ->
+              Error (Credential_provider.pp_error err)
           | Ok binding ->
-            let gh_creds =
-              match binding.gh_config_dir with
-              | Some dir -> dir
-              | None ->
-                  Env_config_keeper.KeeperSandbox.gh_creds_host_path ()
-            in
-            let gitconfig = Env_config_keeper.KeeperSandbox.gitconfig_host_path () in
-            let ssh_dir = Env_config_keeper.KeeperSandbox.ssh_dir_host_path () in
-            let mounts =
-              optional_ro_mount ~host:gh_creds
-                ~container:(Filename.concat cred_root ".config/gh")
-              @ optional_ro_mount ~host:gitconfig
-                  ~container:(Filename.concat cred_root ".gitconfig")
-              @ optional_ro_mount ~host:ssh_dir
-                  ~container:(Filename.concat cred_root ".ssh")
-            in
-            let git_author_name, git_author_email =
-              match binding with
-              | { github_identity = Some id; git_identity_mode = "github_identity"; _ } ->
-                  id, id ^ "@users.noreply.github.com"
-              | _ ->
-                  ( Keeper_identity.keeper_git_author
-                      ~keeper_name:meta.name,
-                    Keeper_identity.keeper_git_email
-                      ~keeper_name:meta.name )
-            in
-            let git_identity_env ~name ~email =
-              [
-                "-e"; "GIT_AUTHOR_NAME=" ^ name;
-                "-e"; "GIT_AUTHOR_EMAIL=" ^ email;
-                "-e"; "GIT_COMMITTER_NAME=" ^ name;
-                "-e"; "GIT_COMMITTER_EMAIL=" ^ email;
-              ]
-            in
-            let envs =
-              [
-                "-e"; "HOME=" ^ cred_root;
-                "-e"; "GH_CONFIG_DIR=" ^ Filename.concat cred_root ".config/gh";
-                "-e"; "GIT_CONFIG_GLOBAL=" ^ Filename.concat cred_root ".gitconfig";
-                "-e"; "GIT_CONFIG_COUNT=1";
-                "-e"; "GIT_CONFIG_KEY_0=safe.directory";
-                "-e"; "GIT_CONFIG_VALUE_0=*";
-              ]
-              (* RFC-0007 PR-1: non-interactive git constants must reach the
-                 container. Without these, git's credential helpers can
-                 open /dev/tty inside a sandbox that has no tty and hang
-                 until the outer wall-clock timeout trips silently. *)
-              @ Env_git_noninteractive.docker_args
-              @ git_identity_env ~name:git_author_name ~email:git_author_email
-            in
-            Ok (mounts, envs)
+              let mounts =
+                List.concat_map
+                  (fun (m : Credential_provider.ro_mount) ->
+                    [ "-v"; m.host ^ ":" ^ m.container ^ ":ro" ])
+                  binding.ro_mounts
+              in
+              let envs =
+                List.concat_map
+                  (fun (k, v) -> [ "-e"; k ^ "=" ^ v ])
+                  binding.env
+              in
+              Ok (mounts, envs)
       in
       match cred_result with
       | Error err -> sandbox_error err

--- a/test/dune
+++ b/test/dune
@@ -690,6 +690,7 @@
         test_filter_rejection_10474
         test_sandbox_inspect_trim_10488
         test_credential_alias_10440
+        test_credential_provider
         test_keeper_profile_normalize_10552
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
@@ -887,6 +888,7 @@
         test_filter_rejection_10474
         test_sandbox_inspect_trim_10488
         test_credential_alias_10440
+        test_credential_provider
         test_keeper_profile_normalize_10552
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259

--- a/test/test_credential_provider.ml
+++ b/test/test_credential_provider.ml
@@ -1,0 +1,191 @@
+(** RFC-0008 PR-1 — pin {!Credential_provider} type surface and
+    {!Host_config_provider} pure helpers.
+
+    Integration coverage of [resolve] (which goes through
+    [Keeper_gh_env.keeper_binding] + filesystem) is left to the
+    existing [test_keeper_shell_docker_route] suite — that path
+    already exercises the inline composition we just centralised
+    behind the trait, so the functional contract stays pinned end
+    to end without re-staging a tmpdir + keeper profile fixture
+    here.
+
+    What this file pins:
+
+    1. [Credential_provider.pp_error] formats every variant.  Mostly
+       a regression guard: if a future PR adds a fifth error case
+       and forgets [pp_error], the [exhaustive] assertion catches it.
+    2. [Host_config_provider.For_testing.mount_if_present] returns
+       [[]] for empty / missing host paths and a single-element
+       [ro_mount] when the path exists.
+    3. [For_testing.compose_env] emits exactly the env-key set the
+       inline block at [keeper_shell_docker.ml:271-329] used to emit,
+       no more, no less.  This is the "behaviorally identical to
+       today" property RFC-0008 PR-1 promises.
+    4. [finalize] / [tear_down] are noops in PR-1 ([finalize] returns
+       [Ok ()] regardless of [container_id]; [tear_down] never
+       raises). *)
+
+open Alcotest
+
+module CP = Masc_mcp.Credential_provider
+module HCP = Masc_mcp.Host_config_provider
+
+(* --- 1. pp_error covers every variant --- *)
+
+let test_pp_error_all_variants () =
+  let cases =
+    [
+      CP.Missing_bundle { identity = "id-A"; path = "/x" }, "Missing_bundle";
+      CP.Invalid_token { identity = "id-B"; reason = "sha-match" }, "Invalid_token";
+      CP.Finalize_failed { identity = "id-C"; reason = "rewrite" }, "Finalize_failed";
+      CP.Tear_down_failed { identity = "id-D"; reason = "rm" }, "Tear_down_failed";
+    ]
+  in
+  List.iter
+    (fun (err, prefix) ->
+      let rendered = CP.pp_error err in
+      check bool
+        (Printf.sprintf "pp_error renders %s" prefix)
+        true
+        (String.length rendered > String.length prefix
+         && String.sub rendered 0 (String.length prefix) = prefix))
+    cases
+
+(* --- 2. mount_if_present skip rules --- *)
+
+let test_mount_if_present_empty_host () =
+  let r = HCP.For_testing.mount_if_present ~host:"" ~container:"/x" in
+  check int "empty host -> no mount" 0 (List.length r)
+
+let test_mount_if_present_missing_path () =
+  let r =
+    HCP.For_testing.mount_if_present
+      ~host:"/nonexistent-host-path-rfc0008-pr1"
+      ~container:"/x"
+  in
+  check int "missing path -> no mount" 0 (List.length r)
+
+let test_mount_if_present_existing_dir () =
+  (* [/tmp] is reliably present on every platform we run on (incl.
+     macOS sandboxes where it is a symlink to /private/tmp). *)
+  let host = Filename.get_temp_dir_name () in
+  let r =
+    HCP.For_testing.mount_if_present ~host ~container:"/c"
+  in
+  match r with
+  | [ m ] ->
+      check string "host preserved" host m.CP.host;
+      check string "container preserved" "/c" m.CP.container
+  | other ->
+      failf "expected single mount, got %d" (List.length other)
+
+(* --- 3. compose_env key set is exactly what the inline block emitted --- *)
+
+let expected_env_keys =
+  [
+    (* path-derived block (RFC-0008 §3 evidence note) *)
+    "HOME";
+    "GH_CONFIG_DIR";
+    "GIT_CONFIG_GLOBAL";
+    "GIT_CONFIG_COUNT";
+    "GIT_CONFIG_KEY_0";
+    "GIT_CONFIG_VALUE_0";
+    (* git author / committer (RFC-0008 §3) *)
+    "GIT_AUTHOR_NAME";
+    "GIT_AUTHOR_EMAIL";
+    "GIT_COMMITTER_NAME";
+    "GIT_COMMITTER_EMAIL";
+    (* Env_git_noninteractive (RFC-0007 PR-1) *)
+    "GIT_TERMINAL_PROMPT";
+    "GIT_ASKPASS";
+    "GCM_INTERACTIVE";
+    "SSH_ASKPASS";
+  ]
+
+let test_compose_env_key_set () =
+  let env =
+    HCP.For_testing.compose_env
+      ~git_author_name:"keeper-A"
+      ~git_author_email:"keeper-A@example.invalid"
+  in
+  let actual_keys = List.sort compare (List.map fst env) in
+  let expected_keys = List.sort compare expected_env_keys in
+  check (list string)
+    "env keys match the pre-extraction inline block exactly"
+    expected_keys actual_keys
+
+let test_compose_env_path_values_anchored_to_cred_root () =
+  let env =
+    HCP.For_testing.compose_env
+      ~git_author_name:"k" ~git_author_email:"k@e"
+  in
+  let lookup k = List.assoc k env in
+  check string "HOME" HCP.cred_root (lookup "HOME");
+  check string "GH_CONFIG_DIR"
+    (Filename.concat HCP.cred_root ".config/gh")
+    (lookup "GH_CONFIG_DIR");
+  check string "GIT_CONFIG_GLOBAL"
+    (Filename.concat HCP.cred_root ".gitconfig")
+    (lookup "GIT_CONFIG_GLOBAL")
+
+let test_compose_env_git_identity_threaded () =
+  let env =
+    HCP.For_testing.compose_env
+      ~git_author_name:"NAME-X"
+      ~git_author_email:"EMAIL-X"
+  in
+  let lookup k = List.assoc k env in
+  check string "GIT_AUTHOR_NAME" "NAME-X" (lookup "GIT_AUTHOR_NAME");
+  check string "GIT_AUTHOR_EMAIL" "EMAIL-X" (lookup "GIT_AUTHOR_EMAIL");
+  check string "GIT_COMMITTER_NAME" "NAME-X" (lookup "GIT_COMMITTER_NAME");
+  check string "GIT_COMMITTER_EMAIL" "EMAIL-X" (lookup "GIT_COMMITTER_EMAIL")
+
+(* --- 4. finalize / tear_down noop semantics --- *)
+
+let dummy_binding () : CP.binding =
+  {
+    identity = "k";
+    env = [];
+    ro_mounts = [];
+    bootstrap = None;
+    metadata = [];
+  }
+
+let test_finalize_is_noop_ok () =
+  let b = dummy_binding () in
+  match HCP.finalize b ~container_id:"abc123" with
+  | Ok () -> ()
+  | Error err -> failf "finalize must noop-Ok in PR-1; got %s" (CP.pp_error err)
+
+let test_tear_down_idempotent () =
+  let b = dummy_binding () in
+  HCP.tear_down b ~container_id:None;
+  HCP.tear_down b ~container_id:(Some "abc");
+  HCP.tear_down b ~container_id:None;
+  ()
+
+let () =
+  run "credential_provider"
+    [
+      ( "errors",
+        [ test_case "pp_error covers all variants" `Quick test_pp_error_all_variants ] );
+      ( "mount_if_present",
+        [
+          test_case "empty host" `Quick test_mount_if_present_empty_host;
+          test_case "missing path" `Quick test_mount_if_present_missing_path;
+          test_case "existing dir" `Quick test_mount_if_present_existing_dir;
+        ] );
+      ( "compose_env",
+        [
+          test_case "key set" `Quick test_compose_env_key_set;
+          test_case "paths anchored to cred_root" `Quick
+            test_compose_env_path_values_anchored_to_cred_root;
+          test_case "identity threaded" `Quick
+            test_compose_env_git_identity_threaded;
+        ] );
+      ( "lifecycle (PR-1 noop)",
+        [
+          test_case "finalize Ok" `Quick test_finalize_is_noop_ok;
+          test_case "tear_down idempotent" `Quick test_tear_down_idempotent;
+        ] );
+    ]


### PR DESCRIPTION
## Why

Keeper sandbox push has been blocked because the docker invocation site (`keeper_shell_docker.ml:271-329`) composes credentials inline by reaching into four SSOTs — `Keeper_gh_env`, `Env_config_sandbox.Auth_paths`, `Keeper_identity`, and `Env_git_noninteractive` — without a single object that says \"this identity currently has this credential, with this finalize hook, and tears down this way.\"

Field evidence (`~/me/memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md`):

- **F-1**: `~/.masc/github-identities/anyang-keepers/gh/hosts.yml` stores the same OAuth token as `gh auth token` on the operator host. Identity separation is cosmetic.
- **F-2**: `gh auth login --with-token` rewrites `hosts.yml:user` to the real token owner. Downstream code reading `user:` loses the identity label.
- **F-4**: `scripts/rotate-keeper-gh-token.sh` defaults to a legacy path that no longer exists — PAT rotation happens off-path.

This PR ships the trait surface RFC-0008 §3 specifies and the Option A (host-bundle) implementation. PR-2 (rotate script + fine-grained PATs) and PR-3 (`In_container_login_provider`) plug into the same trait without rewiring this caller.

## What this PR does

| Surface | LOC | Notes |
|---------|-----|-------|
| `lib/keeper/credential_provider.ml(i)` | +131 | trait: `ro_mount`, `binding`, `error`, `pp_error`, `module type S` |
| `lib/keeper/host_config_provider.ml(i)` | +133 | Option A; `resolve` composes from existing SSOTs, `finalize`/`tear_down` are noops in PR-1 |
| `lib/keeper/keeper_shell_docker.ml` | -60/+30 | swap inline composition for `Host_config_provider.resolve` |
| `test/test_credential_provider.ml` | +191 | 9 alcotest cases (see Verification) |
| `lib/dune`, `test/dune` | +6 | module + test registration |

**Net diff**: +488 / -54 (488 insertions, 54 deletions).

## Behaviour-equivalence proof

The inline block at `keeper_shell_docker.ml:271-329` (pre-extraction) emitted a fixed 14-key env set:

```
HOME, GH_CONFIG_DIR, GIT_CONFIG_GLOBAL,
GIT_CONFIG_COUNT, GIT_CONFIG_KEY_0, GIT_CONFIG_VALUE_0,
GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL,
GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL,
GIT_TERMINAL_PROMPT, GIT_ASKPASS, GCM_INTERACTIVE, SSH_ASKPASS
```

`test_credential_provider.compose_env_key_set` pins the post-extraction key set as exactly the same 14-key list. Per-key `Env_git_noninteractive` audit confirms no overlap with the path/identity-derived block, so docker's last-wins-on-`-e` semantics produce identical effective env regardless of insertion order.

`test_keeper_shell_docker_route` (the existing 15-case docker argv contract suite) **passes 15/15 unchanged** after the swap.

## Verification

```bash
dune build lib/ --cache=disabled                    # RC=0
dune exec test/test_credential_provider.exe         # 9/9 OK in 0.002s
dune exec test/test_keeper_shell_docker_route.exe   # 15/15 OK in 1.068s
```

`test_keeper_shell_containment` shows 5 pre-existing failures on `origin/main` HEAD (unrelated to this PR; verified by stashing and re-running on clean base).

## Out of scope (RFC-0008 §5)

- **PR-2**: `scripts/rotate-keeper-gh-token.sh` rewrite (in `me` repo) + `sha256_prefix` metadata in `binding.metadata`.
- **PR-3** (gated on PR-2 operational proof): `In_container_login_provider` with `bootstrap` argv (`gh auth login --with-token`), `finalize` that rewrites `hosts.yml:user` inside container, and `provider_gate` refusing tokens that match the operator host. **This is the PR that actually enables keeper sandbox push** — PR-1 is the prerequisite type/lifecycle surface.
- Vault / 1Password / macOS Keychain integration.
- PAT TTL tracking dashboard.
- Rewriting `keeper_gh_env.ml` (we wrap it; deprecation is post-PR-3 cleanup).

## References

- RFC: `docs/rfc/RFC-0008-credential-provider.md`
- Field evidence: `~/me/memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md`
- Audited on commit: `0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6`
- task-074 audit (keeper-sangsu-agent, 2026-04-26 08:06 KST) — names this PR as the prerequisite for unblocking keeper sandbox `git push`
- Dependency (already merged): RFC-0007 PR-1 → `Env_git_noninteractive`