### PR TITLE
fix(dashboard-test): align test expectations with semantic aliases

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -152,9 +152,9 @@ describe('successClass', () => {
     expect(successClass(50)).toContain('var(--bad-light)')
   })
 
-  it('returns dim for null/non-finite', () => {
-    expect(successClass(null)).toContain('dim')
-    expect(successClass(NaN)).toContain('dim')
+  it('returns disabled for null/non-finite', () => {
+    expect(successClass(null)).toContain('color-fg-disabled')
+    expect(successClass(NaN)).toContain('color-fg-disabled')
   })
 })
 

--- a/dashboard/src/components/harness-health-sections.test.ts
+++ b/dashboard/src/components/harness-health-sections.test.ts
@@ -108,15 +108,15 @@ describe('statusChipClass', () => {
   })
 
   it('returns muted class for stale', () => {
-    expect(statusChipClass('stale')).toContain('text-muted')
+    expect(statusChipClass('stale')).toContain('color-fg-muted')
   })
 
-  it('returns dim class for idle', () => {
-    expect(statusChipClass('idle')).toContain('text-dim')
+  it('returns disabled class for idle', () => {
+    expect(statusChipClass('idle')).toContain('color-fg-disabled')
   })
 
-  it('returns dim class for unknown', () => {
-    expect(statusChipClass('unknown' as any)).toContain('text-dim')
+  it('returns disabled class for unknown', () => {
+    expect(statusChipClass('unknown' as any)).toContain('color-fg-disabled')
   })
 })
 


### PR DESCRIPTION
## Summary
- Update `successClass` and `statusChipClass` test assertions to match the semantic alias tokens introduced in #10638
- Tests were expecting old token fragments (`dim`, `text-muted`, `text-dim`) while source code now uses semantic aliases (`color-fg-disabled`, `color-fg-muted`)

## Test plan
- [ ] CI Dashboard test passes
- [ ] CI Gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)