### PR TITLE
diag(observer): expose last_turn_ts for watchdog staleness diagnosis

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -122,6 +122,7 @@ type snapshot = {
   fiber_wakeup_flag : bool;
   consecutive_noop_count : int;
   idle_seconds : int;
+  last_turn_ts : float;
 }
 
 let ksm_phase_to_string = function
@@ -470,6 +471,7 @@ let observe
       (let last = entry.meta.runtime.proactive_rt.last_ts in
        if last <= 0.0 then 0
        else int_of_float (max 0.0 (Time_compat.now () -. last)));
+    last_turn_ts = entry.meta.runtime.usage.last_turn_ts;
   }
 
 (* Fleet fold — observe every currently-registered keeper under
@@ -558,4 +560,5 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
     "fiber_wakeup_flag", `Bool s.fiber_wakeup_flag;
     "consecutive_noop_count", `Int s.consecutive_noop_count;
     "idle_seconds", `Int s.idle_seconds;
+    "last_turn_ts", `Float s.last_turn_ts;
   ]

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -184,6 +184,11 @@ type snapshot = {
       (** Wall-clock seconds since the keeper last did something the
           metrics layer treated as substantive. Compared against
           [proactive.idle_sec] to gate scheduled-autonomous turns. *)
+  last_turn_ts : float;
+      (** Raw [runtime.usage.last_turn_ts] from the registry entry.
+          Exposed for watchdog staleness diagnosis — the stale watchdog
+          in [Keeper_supervisor] reads this exact field. A value of [0.0]
+          means the registry never recorded a completed turn. *)
 }
 
 (** Derive a composite snapshot from a live registry entry.


### PR DESCRIPTION
## Summary
- Expose `runtime.usage.last_turn_ts` from registry entry in composite snapshot JSON
- The stale watchdog (#10540) reads this exact field but its value was not observable via any API endpoint
- Purpose: determine why the watchdog isn't triggering for stuck keepers (ollama-local, ramarama, janitor)

## Context
Watchdog condition: `last_turn > 0.0 && now - last_turn > 300.0`. Despite disk `last_turn_ts` being 1000+ seconds old, watchdog never fires. Hypothesis: registry's `last_turn_ts` may be 0.0 or different from disk value.

## Test plan
- [ ] Rebuild + restart with this binary
- [ ] `curl localhost:8935/api/v1/keepers/ollama-local/composite | jq .last_turn_ts`
- [ ] Verify value matches expectation (0.0 = registry never updated, or timestamp = same as disk)
- [ ] Use finding to implement the actual fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)