### PR TITLE
feat(dashboard): localize transport-health eyebrow strings (round-28)

### DIFF
--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -186,7 +186,7 @@ describe('TransportHealthPanel', () => {
     expect(container.textContent).toContain('WebRTC')
     expect(container.textContent).toContain('시그널링')
     expect(container.textContent).toContain('shared_http')
-    expect(container.innerHTML).toContain('signaling down')
+    expect(container.innerHTML).toContain('시그널링 중단')
     expect(container.innerHTML).not.toContain('2 ICE')
     expect(container.textContent).toContain('namespace default')
   })

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -304,15 +304,15 @@ function MetricRow({ label, value, sub }: { label: string; value: string | numbe
 }
 
 function transportEyebrow(configured: boolean, listening: boolean, port: number): string {
-  if (!configured) return 'disabled'
-  return listening ? `:${port} live` : `:${port} down`
+  if (!configured) return '비활성'
+  return listening ? `:${port} 활성` : `:${port} 중단`
 }
 
 function webrtcEyebrow(data: TransportHealthData): string {
-  if (!data.webrtc.configured) return 'disabled'
+  if (!data.webrtc.configured) return '비활성'
   return data.webrtc.signaling_available
-    ? `${data.webrtc.ice_server_count} ICE · signaling ready`
-    : 'signaling down'
+    ? `${data.webrtc.ice_server_count} ICE · 시그널링 준비`
+    : '시그널링 중단'
 }
 
 function SectionCard({
@@ -449,7 +449,7 @@ export function TransportHealthPanel() {
         </summary>
         <div class="p-4">
           <div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
-            <${SectionCard} title="SSE" status=${sseStatus} eyebrow=${`${data.sse.sessions_total} live`}>
+            <${SectionCard} title="SSE" status=${sseStatus} eyebrow=${`${data.sse.sessions_total} 활성`}>
               <${MetricRow} label="옵저버" value=${data.sse.sessions_observer} />
               <${MetricRow} label="코디네이터" value=${data.sse.sessions_coordinator} />
               <${MetricRow} label="외부 팬아웃" value=${data.sse.external_subscribers} />


### PR DESCRIPTION
## Summary

영한혼용 금지 (memory: feedback_dashboard-observation-focus). 처음으로 **eyebrow helper 함수** 안의 status string 까지 sweep.

### 변경 내용

\`transport-health.ts\`:

| 함수 / 위치 | 변경 |
|-------------|------|
| \`transportEyebrow\` (line 306-309) | disabled → 비활성 / \`:port live\` → \`:port 활성\` / \`:port down\` → \`:port 중단\` |
| \`webrtcEyebrow\` (line 311-316) | disabled → 비활성 / signaling ready → 시그널링 준비 / signaling down → 시그널링 중단 |
| SSE SectionCard (line 452) | \`${data.sse.sessions_total} live\` → \`${data.sse.sessions_total} 활성\` |

→ gRPC, WebSocket, WebRTC, SSE 4 transport 카드의 eyebrow status indicator 한국어화.

### Test fixture sync

\`transport-health.test.ts:189\`: \`'signaling down'\` → \`'시그널링 중단'\`

### 보존 ledger

- \`SSE\`, \`gRPC\`, \`HTTP\`, \`WebSocket\`, \`WebRTC\` (프로토콜 식별자, SectionCard title 그대로)
- \`ICE\` (count prefix, 식별자)
- \`shared_http\`, port number (data identifier)

### 검증

- helper function 의 string return 만 수정. 함수 시그니처/타입 무변경.
- vitest 는 #10645 infra 회귀로 dashboard 전역 startup-fail. visual review 로 commit.

## Test plan

- [ ] dashboard transport-health 카드 4 개 한국어 status indicator 확인
- [ ] vitest infra (#10645) 회복 후 transport-health.test.ts 통과 확인