### PR TITLE
feat(dashboard): WS-only cutover production build default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ specs/**/TraceData.tla
 # defaults).  Use .env.<mode>.local for local secret overrides; those
 # remain ignored by the .env.* rule above.
 !dashboard/.env.development
+!dashboard/.env.production
 
 # Infrastructure secrets (launchd plist contains env vars with tokens)
 infrastructure/launchd/*.plist

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -22,7 +22,9 @@ MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:8935
 # EventSource entirely and consumes broadcast traffic only over /ws.
 # Default is false (parallel mode) to keep existing deployments on the
 # safety net until the operator has validated WS in their environment.
-# Dev defaults to true via .env.development; staging/prod must opt in
-# explicitly.  Hot rollback in the browser:
+# Dev defaults to true via .env.development.  Production builds default
+# to true via .env.production (loaded by `vite build`).  For a one-off
+# build with the flag off, copy .env.production to .env.production.local
+# and comment out the assignment.  Hot rollback in the browser:
 #   window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()
 # VITE_DASHBOARD_WS_ONLY=true

--- a/dashboard/.env.production
+++ b/dashboard/.env.production
@@ -1,0 +1,12 @@
+# Loaded automatically by `vite build` (i.e., `pnpm --filter masc-dashboard build`,
+# which is what `make build` runs via scripts/build-dashboard-if-needed.sh).
+# Dev (`vite serve`) ignores this file — see .env.development.
+
+# WS-only cutover for production builds.  Any operator who runs `make build`
+# (or pnpm build directly) will produce a SPA that consumes broadcast traffic
+# only over /ws and skips the parallel /sse EventSource.
+#
+# Rollback: comment this line, rerun `make build`, redeploy.
+# Hot rollback in a single browser tab (no rebuild):
+#   window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()
+VITE_DASHBOARD_WS_ONLY=true

--- a/docs/sse-ws-cutover.md
+++ b/docs/sse-ws-cutover.md
@@ -29,11 +29,23 @@ SSE plumbing.
 | Environment | Mechanism |
 |-------------|-----------|
 | Dev (`pnpm --filter masc-dashboard dev`) | `dashboard/.env.development` ships with `VITE_DASHBOARD_WS_ONLY=true` |
-| Staging | Set `VITE_DASHBOARD_WS_ONLY=true` in the staging build pipeline |
-| Production | Set `VITE_DASHBOARD_WS_ONLY=true` in the prod build pipeline (last) |
+| Production (`make build` / `pnpm --filter masc-dashboard build`) | `dashboard/.env.production` ships with `VITE_DASHBOARD_WS_ONLY=true` |
+| Staging | Same as production unless `--mode staging` is invoked with a custom `dashboard/.env.staging` |
+| One-off opt-out | Create `dashboard/.env.production.local` with `VITE_DASHBOARD_WS_ONLY=` (or `=false`); `.local` overrides the tracked file and is git-ignored |
 
-The flag is build-time.  A redeploy is required to flip it server-side.
-For ad-hoc browser overrides, use the runtime injection below.
+The flag is build-time: `vite build` reads `.env.production` (and `.env`,
+`.env.local`) automatically; `vite serve` reads `.env.development`.
+A rebuild is required to flip the tracked default; for a single browser
+tab without a rebuild, use the runtime injection below.
+
+> Dashboard production deployment caveat: as of this PR, the dashboard
+> SPA is built locally by an operator (`make build` triggers
+> `scripts/build-dashboard-if-needed.sh` → `vite build`).  Neither
+> `release.yml` nor `deploy-railway.yml` rebuilds the SPA, and the
+> Dockerfile does not COPY `assets/dashboard/`.  The cutover flag
+> therefore only takes effect on builds an operator produces locally
+> before deploying.  Wiring a real production dashboard build into CI
+> is tracked separately.
 
 ## Reading the beacon
 


### PR DESCRIPTION
## Summary

PR-2 of the SSE → WebSocket cutover series.  Stacked on #10657 (PR-1: dev cutover + transport beacon).

Adds `dashboard/.env.production` with `VITE_DASHBOARD_WS_ONLY=true` so any production build (`make build` or `pnpm --filter masc-dashboard build`) skips the parallel `/sse` EventSource and consumes broadcast traffic only over `/ws`.

Vite auto-loads `.env.production` for `vite build`; `.env.development` (PR-1) covers `vite serve`.  No code change — the existing `dashboardWsOnlyEnabled()` helper already reads `import.meta.env`.

## Verification

- Built locally with the new env file: `pnpm --filter masc-dashboard build` → built bundle contains the inlined gate `t===!0?!0:t===!1?!1:"true"==="true"`, confirming Vite substituted the env variable into a `true` literal.  Runtime injection precedence (`window.__MASC_DASHBOARD_WS_ONLY__`) is preserved by the compiled three-branch gate.
- `.gitignore` whitelist extended to track `dashboard/.env.production` (mirrors `.env.development` from PR-1).

## Reversibility

| Path | Mechanism |
|------|-----------|
| Per-tab hot rollback | `window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()` in browser console |
| Build-time opt-out | `dashboard/.env.production.local` with `VITE_DASHBOARD_WS_ONLY=` (or `=false`); `.local` overrides the tracked file and is git-ignored |
| Wholesale revert | revert this commit, rerun `make build`, redeploy |

## Caveat (documented in `docs/sse-ws-cutover.md`)

Dashboard SPA is currently rebuilt locally by an operator before deployment.  `release.yml` and `deploy-railway.yml` do not invoke `make build`, and `Dockerfile` does not COPY `assets/dashboard/`.  This PR makes the cutover the **default** for any production build that does happen, but wiring a CI-driven dashboard build is a separate follow-up — tracking as a discovered issue, not in this PR's scope.

## Stack

- PR-1: #10657 — dev `.env.development` + transport beacon (this PR's base)
- **PR-2 (this)** — production `.env.production` SSOT
- PR-3: server-side SSE infra deletion (after parallel-mode soak)
- PR-4: `Oas_sse_bridge` → `Oas_event_bridge` rename
- PR-5: A2A `/sse/portal`, `/sse/subscriptions` external endpoint migration

## Test plan

- [x] `pnpm --filter masc-dashboard build` succeeds and inlines the cutover flag as `true`
- [ ] After PR-1 merges, rebase PR-2 onto main and verify base flips to `main`
- [ ] Manual dev sanity: build SPA → serve via OCaml binary → confirm beacon green + DevTools shows 0 SSE connections, 1 WS upgrade
