### PR TITLE
feat(dashboard): localize 3 chips across 2 components (round-29)

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -819,8 +819,8 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
         <table class="min-w-full text-xs">
           <thead class="bg-[var(--white-5)] text-[var(--color-fg-muted)]">
             <tr>
-              <th class="px-3 py-2 text-left font-semibold">Keeper</th>
-              <th class="px-3 py-2 text-left font-semibold">Runtime</th>
+              <th class="px-3 py-2 text-left font-semibold">키퍼</th>
+              <th class="px-3 py-2 text-left font-semibold">런타임</th>
               ${AXES.map(a => html`
                 <th class="px-3 py-2 text-left font-semibold" title=${a.label}>
                   ${a.acronym} <span class="text-[var(--color-fg-muted)]0">${a.label}</span>

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -203,7 +203,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
               : 'no log yet'}
           </span>
           ${showMore
-            ? html`<${ActionButton} variant="ghost" size="sm" disabled=${entry.loading} onClick=${onShowMore}>Show 1000<//>`
+            ? html`<${ActionButton} variant="ghost" size="sm" disabled=${entry.loading} onClick=${onShowMore}>1000개 더 보기<//>`
             : null}
           <${ActionButton} variant="ghost" size="sm" disabled=${entry.loading} onClick=${onRefresh}>
             ${entry.loading ? '...' : 'Refresh'}


### PR DESCRIPTION
## Summary

영한혼용 금지 (memory: feedback_dashboard-observation-focus). round-28 (#10666 Draft) 후속.

### 변경 내용

| 파일 | 변경 |
|------|------|
| \`sidecar-log-viewer.ts\` | ActionButton \"Show 1000\" → \"1000개 더 보기\" |
| \`fleet-fsm-matrix.ts\` | th \"Keeper\" / \"Runtime\" → \"키퍼\" / \"런타임\" |

### Scope minimal 이유

connector-status.ts 의 \"Cause: ... Next: ...\" 헬퍼 텍스트 (line 1054-1059) 도 후보였으나 5+ test fixture chain (\`connector-status.test.ts:415, 451, 452, 662, 663\`) 과 동일 패턴의 다른 메시지들이 cross-coupled — 별도 라운드가 안전.

### 보존 ledger

- \`AXES.acronym\` (FSM축 약어, 식별자)
- \`onboardingStartLabel\` 의 \"Start\"/\"Starting…\" (별도 라운드 — function 시그니처 변경 + test 5+ refs)

### File overlap

| 파일 | 다른 PR | overlap? |
|------|---------|----------|
| \`sidecar-log-viewer.ts\` | (없음) | ✓ clean |
| \`fleet-fsm-matrix.ts\` | (없음) | ✓ clean |

→ round-25/26/27/28 와 file overlap 0. round-27 (#10655) 의 conflict 와 무관.

### 검증

- chip text 만 수정. 로직/타입 무변경. test fixture reference 0 (rg 확인).
- vitest 는 #10645 infra 회귀로 dashboard 전역 startup-fail. visual review 로 commit.

## Test plan

- [ ] dashboard sidecar log viewer / fleet fsm matrix 한국어 렌더링 확인
- [ ] vitest infra (#10645) 회복 후 회귀 없음 확인