### PR TITLE
fix(keeper-proactive): exclude Claim_context from noop cycle (unblocks 8x cooldown trap, live evidence)

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -298,10 +298,17 @@ let has_substantive_tool_calls (tools_used : string list) : bool =
   List.exists Keeper_tool_disclosure.is_execution_progress_tool_name tools_used
 
 (** A cycle is noop when it produced no text AND all tools used (if any)
-    are observation-only.  Productive cycles reset consecutive_noop_count. *)
+    are passive-status only (e.g. board_list, context_status).  A turn whose
+    only tool is a [Claim_context] action such as [keeper_task_claim] is NOT
+    a noop: claiming a task mutates server-side assignment state and is the
+    documented first step of the multi-turn task lifecycle (claim -> act ->
+    done) per the prompt.  The noop-backoff was originally introduced in
+    #7168 to penalise the [board_list]-only pattern; sweeping
+    [Claim_context] into noop was an unintended side-effect that pinned
+    real keepers at the 8x cooldown cap. *)
 let is_noop_cycle ~has_text ~(tools_used : string list) : bool =
   not has_text
-  && List.for_all is_observation_only_tool_name tools_used
+  && List.for_all Keeper_tool_disclosure.is_passive_status_tool_name tools_used
 
 let visible_run_validation (result : Keeper_agent_run.run_result) :
     Oas.Raw_trace.run_validation option =


### PR DESCRIPTION
## Summary

Root cause of the **"proactive turns terminating early"** symptom in the operator's diagnostic prompt. Live evidence: 2 keepers (`ollama-local`, `qa-king`) currently pinned at the 8x cooldown cap, 3 more (`ramarama`, `janitor`, `sangsu`) in 2x–4x range, captured from `~/.masc/keepers/*.json` runtime snapshots.

## Root cause chain

1. `lib/keeper/keeper_world_observation.ml:823-826` — `effective_scheduled_autonomous_cooldown` multiplies the base proactive cooldown by `2^min(consecutive_noop_count, 3)`, capping at 8x.
2. `lib/keeper/keeper_unified_metrics.ml:1091-1096` — `consecutive_noop_count` increments by 1 each scheduled-autonomous cycle classified as noop, resets to 0 otherwise.
3. `lib/keeper/keeper_unified_metrics.ml:300-304` — `is_noop_cycle` returns `true` when no text was emitted AND `List.for_all is_observation_only_tool_name tools_used`.
4. `lib/keeper/keeper_unified_metrics.ml:294-295` — `is_observation_only_tool_name = not is_execution_progress_tool_name`.
5. `lib/keeper/keeper_tool_disclosure.ml:266-269` — `is_execution_progress_tool_name` returns `true` only for `Execution | Completion`. **`Claim_context` returns false** → counted as observation-only → counted as noop.
6. `lib/keeper/keeper_tool_disclosure.ml:177-180` — `Claim_context` includes `keeper_task_claim`, `masc_claim_task`, `masc_claim_next`.

So a keeper that proactively claims a task but defers the work to the next turn (per the documented `claim → act → done` multi-turn lifecycle in `keeper_prompt.ml:140`) is recorded as noop, and after 3 such cycles its proactive cooldown becomes 8x. The keeper appears to "stop firing".

## Why this is unintended (not by-design)

PR #7168 introduced the noop-backoff. Its evidence section names only the `board_list`-only pattern as the target — `keeper_task_claim` is not mentioned. The keeper prompt itself contradicts the classifier:
- `keeper_prompt.ml:134-138` lists `keeper_task_claim` as a satisfying mutating tool for the strict tool-use contract.
- `keeper_prompt.ml:140` (TASK LIFECYCLE) explicitly normalises claim-now/act-later across separate turns.

`Claim_context` being swept into noop appears to be an unintended side-effect of how `is_execution_progress_tool_name` was defined, not a deliberate decision.

## Surgical fix

Change `is_noop_cycle` to use `is_passive_status_tool_name` (`Passive_status` only) instead of `is_observation_only_tool_name` (`Passive_status | Claim_context`). One function-body change in `lib/keeper/keeper_unified_metrics.ml`.

Other callers of `is_observation_only_tool_name` (`substantive_tool_call_count` at line 973) are unaffected — the broader observation-only definition is still correct for counting "substantive" actions.

## Determinism boundary

This is a **deterministic scheduler-classifier bug**, not a provider/model/verified/approve issue. The exponential backoff formula was correct; the noop predicate was over-broad. The fix is one symbol swap that aligns the classifier with the documented lifecycle.

## Test plan

- [x] `dune build lib/keeper/` passes.
- [ ] After merge: monitor `consecutive_noop_count` in `~/.masc/keepers/{ollama-local,qa-king}.json` — should drop to 0 within one proactive turn after a successful claim.
- [ ] Monitor proactive turn fire rate per keeper in fleet log — should rise back to baseline.

## Why no dedicated unit test in this PR

No existing test covers `is_noop_cycle`. Adding a new test file expands scope to `test/dune` modifications. The change is minimal (1 function body), the evidence is live (5 real keeper snapshots), and the direction is strictly more permissive (cannot regress productive cycles into noop). I propose a follow-up test PR if reviewer requests it.

## Related

- PR #10663 (`diag(observer): expose last_turn_ts in composite snapshot for watchdog diagnosis`) just merged — provides the observability needed to validate this fix's effect.
- Companion to PR #10647 (`/workspace negative anchor`, merged) which addressed sandbox docker hallucination — different symptom, same investigation thread.
