### PR TITLE
refactor(design-system): replace inline buttons with ActionButton across 3 components (PR-CS3)

### DIFF
--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { ActionButton } from './common/button'
 import { useEffect, useRef } from 'preact/hooks'
 import { Network } from 'vis-network'
 import 'vis-network/styles/vis-network.css'
@@ -267,7 +268,7 @@ export function GraphView({ data }: GraphViewProps) {
           <strong class="text-lg text-[var(--text-near-white)]">${selectedNode.label}</strong>
           <span class="py-0.5 px-2 bg-[var(--slate-gray-15)] text-2xs text-[var(--text-slate)] rounded">${kindLabel(selectedNode.kind)}</span>
           <span class="py-0.5 px-2 rounded text-2xs ${selectedNode.status === 'active' || selectedNode.status === 'done' ? 'text-[var(--color-status-ok)] bg-[var(--ok-10)]' : selectedNode.status === 'offline' || selectedNode.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--text-slate-light)] bg-[var(--slate-gray-10)]'}">${statusLabel(selectedNode.status)}</span>
-          <button type="button" class="ml-auto text-[var(--color-fg-muted)] hover:text-[var(--text-slate-light)] text-sm cursor-pointer bg-transparent border-none" onClick=${() => { selectedNodeId.value = null }}>닫기</button>
+          <${ActionButton} variant="subtle" size="sm" class="ml-auto" onClick=${() => { selectedNodeId.value = null }} ariaLabel="패널 닫기">닫기<//>
         </div>
         <div class="grid grid-cols-3 gap-3 mb-3">
           <div class="text-center">

--- a/dashboard/src/components/common/error-panel.ts
+++ b/dashboard/src/components/common/error-panel.ts
@@ -9,6 +9,7 @@ import {
 } from './error-notification-state'
 import type { ErrorCode, ErrorSeverity } from '../../types/error'
 import { formatElapsedCompact } from '../../lib/format-time'
+import { ActionButton } from './button'
 
 const CODE_LABELS: Record<ErrorCode, string> = {
   validation_error: '입력',
@@ -64,10 +65,12 @@ export function ErrorPanel({ onClose }: ErrorPanelProps) {
       <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--white-5)] shrink-0">
         <span class="text-xs font-medium text-[var(--color-fg-muted)]">미확인 에러 <span class="text-[var(--color-status-err)]">${items.length}</span>건</span>
         <div class="flex items-center gap-1">
-          <button type="button"
-            class="text-2xs px-2 py-0.5 rounded border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-muted)] hover:bg-[var(--white-10)] cursor-pointer transition-colors"
+          <${ActionButton}
+            variant="ghost"
+            size="sm"
+            class="text-2xs"
             onClick=${() => { clearAllErrors(); onClose() }}
-          >모두 확인</button>
+          >모두 확인<//>
           <button type="button" class="text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer p-0.5" onClick=${onClose}>
             <${X} size=${14} />
           </button>

--- a/dashboard/src/components/tool-executor/tool-result-display.ts
+++ b/dashboard/src/components/tool-executor/tool-result-display.ts
@@ -75,10 +75,10 @@ function StoredBlobView({
         </div>
         <div class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] overflow-hidden">
           <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--color-border-default)]">
-            <button type="button" class="text-3xs text-[var(--color-fg-muted)] cursor-pointer hover:text-[var(--color-fg-primary)]"
+            <${ActionButton} variant="subtle" size="sm" class="text-3xs"
               onClick=${() => { expanded.value = false }}>
               접기 (${marker.bytes.toLocaleString()}B)
-            </button>
+            <//>
             <${ActionButton} variant="subtle" size="sm"
               onClick=${() => void navigator.clipboard.writeText(fullText.value ?? '')}>복사<//>
           </div>
@@ -154,10 +154,10 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
       </div>
       <div class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] overflow-hidden">
         <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--color-border-default)]">
-          <button type="button" class="text-3xs text-[var(--color-fg-muted)] cursor-pointer hover:text-[var(--color-fg-primary)]"
+          <${ActionButton} variant="subtle" size="sm" class="text-3xs"
             onClick=${() => { expanded.value = !expanded.value }}>
             ${expanded.value ? '접기' : '펼치기'} (${lines}줄)
-          </button>
+          <//>
           <${ActionButton} variant="subtle" size="sm" onClick=${() => void navigator.clipboard.writeText(text)}>복사<//>
         </div>
         ${expanded.value ? html`


### PR DESCRIPTION
## Summary

CS1(transport-health), CS2(autoresearch) 패턴 확장. 3 production 컴포넌트의 인라인 `<button>`을 canonical `ActionButton`으로 교체.

## 변경

| 파일 | 변경 | Variant |
|------|------|---------|
| `activity-graph-view.ts` | "닫기" 패널 close button | `subtle` + ariaLabel |
| `common/error-panel.ts` | "모두 확인" bulk acknowledge | `ghost` |
| `tool-executor/tool-result-display.ts` | "접기" / "펼치기" toggle 2건 | `subtle` |

## 의도적 보존 (ActionButton 부적합)

| 파일 | 사유 |
|------|------|
| `tool-picker.ts` | Tab-like selection state (`isSelected` 분기). ActionButton에 `aria-pressed`-like prop 부재 |
| `agent-profile.ts` | List item navigation pattern (selection-like) |
| `memory-post-detail.ts` | Author link semantic (text-inline link as button) |
| `error-panel.ts` X icon close + ack check | Icon-only with `opacity-0→hover:1` 커스텀 패턴 |

## 이점

- **a11y**: focus-visible:ring (`--accent-45`) 자동 적용
- **명시적 ariaLabel**: "패널 닫기"가 스크린리더에 announce
- **인터랙션 일관성**: active:scale + opacity 통일
- **유지보수**: variant 정책 변경 시 한 곳에서 일괄 변경

## 안전성

- **시각 회귀 미세**: subtle/ghost variant이 기존 inline 스타일과 거의 동등
- **테스트 영향 0**: 텍스트 매칭 기반, 영향 없음

## Test plan

- [ ] CI green
- [ ] activity graph 닫기, error panel 모두 확인, tool result 접기/펼치기 동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)
