### PR TITLE
feat(dashboard): localize 5 chips/labels across 2 components (round-30)

### DIFF
--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -189,8 +189,8 @@ function AuthPopover() {
           <div class="flex gap-2">
             <input
               type="text"
-              placeholder="dashboard actor"
-              aria-label="Dashboard actor"
+              placeholder="대시보드 행위자"
+              aria-label="대시보드 행위자"
               class="min-w-0 flex-1 py-1.5 px-2 rounded text-2xs border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)] placeholder-[var(--color-fg-muted)] outline-none focus:border-[rgba(71,184,255,0.5)]"
               value=${actorInput.value}
               disabled=${actorOverrideLocked}

--- a/dashboard/src/components/setup-guide-card.test.ts
+++ b/dashboard/src/components/setup-guide-card.test.ts
@@ -175,7 +175,7 @@ describe('SetupGuideCard', () => {
     }
     const badge = container.querySelector('[data-setup-complete-badge]')
     expect(badge).toBeTruthy()
-    expect(badge!.getAttribute('aria-label')).toBe('Setup guide complete')
+    expect(badge!.getAttribute('aria-label')).toBe('설정 가이드 완료')
     const wrapper = container.querySelector('[data-setup-guide-tone]')!
     expect(wrapper.getAttribute('data-setup-guide-tone')).toBe('complete')
     const bar = container.querySelector('[role="progressbar"]')!

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -129,11 +129,11 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
             ? html`
                 <span
                   class="inline-flex items-center gap-1 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-status-ok)]"
-                  aria-label="Setup guide complete"
+                  aria-label="설정 가이드 완료"
                   data-setup-complete-badge
                 >
                   <span aria-hidden="true">✓</span>
-                  <span>Complete</span>
+                  <span>완료</span>
                 </span>
               `
             : null}
@@ -154,7 +154,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
         aria-valuenow=${pct}
         aria-valuemin=${0}
         aria-valuemax=${100}
-        aria-label="Setup guide progress"
+        aria-label="설정 가이드 진행률"
         data-setup-progress-bar
       >
         <div


### PR DESCRIPTION
## Summary

영한혼용 금지 (memory: feedback_dashboard-observation-focus). round-28 (#10666) merge 후 main 위에서 시작 — round-23/24/28 까지 적용된 컬러 토큰 + 한국어화 모두 포함.

### 변경 내용

| 파일 | 변경 |
|------|------|
| \`auth-status.ts\` | input placeholder + aria-label \"Dashboard actor\" → \"대시보드 행위자\" |
| \`setup-guide-card.ts\` | Complete 뱃지 텍스트 \"Complete\" → \"완료\", aria-label \"Setup guide complete\" → \"설정 가이드 완료\", aria-label \"Setup guide progress\" → \"설정 가이드 진행률\" |

### Test fixture sync

\`setup-guide-card.test.ts:178\`: \`'Setup guide complete'\` → \`'설정 가이드 완료'\`

### File overlap with prior rounds

| 파일 | 다른 PR / 변경 라인 | 본 PR / 변경 라인 |
|------|---------------------|--------------------|
| \`auth-status.ts\` | round-23 (line 183) | line 192-193 |
| \`setup-guide-card.ts\` | (없음) | line 132/136/157 |

→ line-level conflict 없음.

### 보존 ledger

- \`Bearer token\` (auth-status:225, OAuth domain term — round-30 보존, 별도 라운드도 안 만들 예정)

### 검증

- chip text + sync된 test assertion 만 수정. 로직/타입 무변경.
- vitest 는 #10645 infra 회귀로 dashboard 전역 startup-fail. visual review 로 commit.

## Test plan

- [ ] dashboard auth-status / setup-guide-card 한국어 렌더링 확인
- [ ] vitest infra (#10645) 회복 후 setup-guide-card.test.ts 통과 확인