### PR TITLE
fix(tla): clear OperatorPauseBroadcast deadlock blocking PR queue

### DIFF
--- a/specs/keeper-state-machine/OperatorPauseBroadcast.tla
+++ b/specs/keeper-state-machine/OperatorPauseBroadcast.tla
@@ -73,10 +73,24 @@ Resolve(k) ==
   /\ phase' = [phase EXCEPT ![k] = "Resolved"]
   /\ UNCHANGED emitted
 
+\* After resolution, the keeper returns to the work pool to accept the
+\* next turn. Without this transition every behavior in which all
+\* keepers reach "Resolved" deadlocks (no action is enabled), which TLC
+\* reports as a spec error rather than a property failure (exit 11).
+\* The runtime models exactly this recycle: keeper_supervisor flips a
+\* keeper back to Idle after the operator broadcast is acknowledged.
+\* emitted is reset to FALSE so the leads-to property is meaningful for
+\* subsequent turns of the same keeper rather than trivially carrying
+\* over a stale TRUE.
+Recycle(k) ==
+  /\ phase[k] = "Resolved"
+  /\ phase' = [phase EXCEPT ![k] = "Idle"]
+  /\ emitted' = [emitted EXCEPT ![k] = FALSE]
+
 Next ==
   \E k \in Keepers : StartTurn(k) \/ EnterPauseHuman(k)
                      \/ EnterStaleRunning(k) \/ WatchdogEmit(k)
-                     \/ Resolve(k)
+                     \/ Resolve(k) \/ Recycle(k)
 
 Spec ==
   /\ Init


### PR DESCRIPTION
## Summary

`specs/keeper-state-machine/OperatorPauseBroadcast.tla`에 `Recycle(k)` action 추가. `phase[k]="Resolved"` → `"Idle"`, `emitted[k] := FALSE` 전이로 terminal deadlock 제거.

**Spec 변경: 1 액션 추가 (+15 lines).** Spec 의도 보존, runtime semantic과 정합.

## Why

#10599가 `ticks` 변수 제거로 OOM은 풀었지만 의도치 않게 hard terminal 만들었음:
- 모든 keeper가 `Resolved` 상태에 도달하면 어떤 Next disjunct도 enabled 안 됨
- TLC: `Error: Deadlock reached.` exit 11
- `make check-clean` 실패 → CI Gate fail → **모든 PR 차단** (#10657, #10658, ... 다수)

증거 (local TLC 1.8.0, CI와 동일 jar):
```
$ java ... tlc2.TLC -workers auto -cleanup \
    -config keeper-state-machine/OperatorPauseBroadcast.cfg \
    keeper-state-machine/OperatorPauseBroadcast.tla
Error: Deadlock reached.
State 7: <Resolve(k2) ...>
  emitted = (k1 :> TRUE @@ k2 :> TRUE)
  phase = (k1 :> "Resolved" @@ k2 :> "Resolved")   ← terminal
73 states, 36 distinct, depth 7, exit 11
```

## Fix

`Recycle(k)` action 추가:
```tla
Recycle(k) ==
  /\ phase[k] = "Resolved"
  /\ phase' = [phase EXCEPT ![k] = "Idle"]
  /\ emitted' = [emitted EXCEPT ![k] = FALSE]
```

`Next` disjunction에 포함.

`emitted := FALSE` 의도: 다음 turn에서 `PauseLeadsToBroadcast` (`(phase \in {PauseHuman, StaleRunning}) ~> emitted`)가 의미 있으려면 prior turn의 stale TRUE를 carry over하지 말아야 함.

## Runtime mapping

`lib/keeper/keeper_supervisor.ml`이 operator broadcast acknowledged 후 keeper를 work pool로 돌려보냄. 본 spec change는 그 transition을 모델에 추가한 것 — 실제 동작과 정합.

## Verification

```
$ java ... tlc2.TLC ... -config OperatorPauseBroadcast.cfg OperatorPauseBroadcast.tla
Model checking completed. No error has been found.
85 states generated, 36 distinct, depth 7, 03s
```

Pre-fix: 36 distinct + deadlock at depth 7.
Post-fix: 36 distinct + recycle loop, finite via fairness, no error.

## Buggy spec note

`OperatorPauseBroadcast-buggy.cfg`는 fix 전에도 exit 11(deadlock)이었고 fix 후에도 동일. `make check-buggy` 스크립트가 exit 12/13만 expected violation으로 인식하고 11은 WARN으로 분류 (non-blocking). 따라서 본 PR은 buggy의 동작 변경 없음.

향후 spec 강화 PR로 buggy의 진짜 liveness violation을 surface할 수 있음 — 본 PR scope에서는 PR 큐 unblock에 집중.

## Affected PRs

이 fix가 머지되면 TLA+ Model Checking이 main에서 green 회복. CI Gate 의존 PR 모두 자동 unblock:
- #10658 (cycle-break prep) — 본인 이전 PR
- #10657 (WS-only cutover)
- 기타 다수 open PR

## Risk

- **Spec semantic 변화**: keeper lifecycle을 cyclic으로 모델링. 기존 모델은 unicyclic (Idle → ... → Resolved). 운영 reality는 cyclic이므로 더 정확한 모델.
- **`emitted` reset 부작용**: `EmittedBeforeResolved` invariant (phase=Resolved => emitted)는 Recycle 직전 만족되고 Recycle 직후 phase != Resolved이므로 무관. 안전.
- **State space 증가**: 36 → 36 distinct (Recycle이 새 state를 만들지 않고 기존 Idle 상태로 회귀). 0% 증가.
- **Author trail**: #10599도 Co-Authored-By: Claude Opus 4.7 (1M context). 본 PR도 같은 동일성 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)