### PR TITLE
feat(design-system): ActionButton pressed prop + swap tool-picker tier filter (PR-CS4)

### DIFF
--- a/dashboard/src/components/common/button.test.ts
+++ b/dashboard/src/components/common/button.test.ts
@@ -103,4 +103,24 @@ describe('ActionButton', () => {
     render(html`<${ActionButton} class="extra-hook">x<//>`, container)
     expect(container.querySelector('button')!.className).toContain('extra-hook')
   })
+
+  it('pressed=true renders aria-pressed="true" for AT (toggle/tab semantic)', () => {
+    render(html`<${ActionButton} pressed=${true}>Filter<//>`, container)
+    expect(container.querySelector('button')!.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('pressed=false renders aria-pressed="false" (button is in toggle group, currently inactive)', () => {
+    render(html`<${ActionButton} pressed=${false}>Filter<//>`, container)
+    expect(container.querySelector('button')!.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('pressed unset does NOT render aria-pressed (plain action button)', () => {
+    render(html`<${ActionButton}>Save<//>`, container)
+    expect(container.querySelector('button')!.hasAttribute('aria-pressed')).toBe(false)
+  })
+
+  it('pressed=true with ghost variant overrides bg to accent-12 (visual selected state)', () => {
+    render(html`<${ActionButton} variant="ghost" pressed=${true}>Active<//>`, container)
+    expect(container.querySelector('button')!.className).toContain('bg-[var(--accent-12)]')
+  })
 })

--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -29,6 +29,18 @@ const VARIANT_CLASSES: Record<ButtonVariant, string> = {
   subtle: 'border-none bg-transparent text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] hover:bg-[var(--white-6)]',
 }
 
+// Pressed-state overrides per variant. Applied when `pressed=true` so the
+// button visually conveys the "selected" / "active filter" / "active tab"
+// state that aria-pressed announces to assistive tech. Without this the
+// button can be aria-pressed but visually identical to unpressed, which
+// is a confusing mismatch.
+const PRESSED_CLASSES: Record<ButtonVariant, string> = {
+  primary: 'bg-[var(--accent-20)]',
+  ghost: 'bg-[var(--accent-12)] border-[var(--accent-30)] text-[var(--color-fg-secondary)]',
+  danger: 'bg-[var(--bad-20)]',
+  subtle: 'bg-[var(--white-6)] text-[var(--color-fg-primary)]',
+}
+
 const BASE = 'rounded cursor-pointer transition-all duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] active:scale-[0.97] active:opacity-90'
 
 interface ActionButtonProps {
@@ -46,6 +58,12 @@ interface ActionButtonProps {
       the UI; the busy role informs AT, the disabled flag handles
       pointer events. */
   ariaBusy?: boolean
+  /** Tab-like / toggle-like buttons that convey selection state.
+      When true, applies aria-pressed=true plus a variant-specific
+      visual override (see PRESSED_CLASSES). Use for tier filters,
+      view toggles, and similar selection patterns where multiple
+      buttons share a slot and one is "active". */
+  pressed?: boolean
   /** Hover tooltip text (native browser title). */
   title?: string
   /** Rendered as `data-testid` so E2E / unit tests can target this
@@ -65,6 +83,7 @@ export function ActionButton({
   block,
   ariaLabel,
   ariaBusy,
+  pressed,
   title,
   testId,
   onClick,
@@ -74,6 +93,7 @@ export function ActionButton({
     BASE,
     SIZE_CLASSES[size],
     VARIANT_CLASSES[variant],
+    pressed ? PRESSED_CLASSES[variant] : '',
     block ? 'w-full' : '',
     disabled ? 'opacity-50 pointer-events-none' : '',
     cx,
@@ -88,6 +108,7 @@ export function ActionButton({
       disabled=${disabled}
       aria-label=${ariaLabel}
       aria-busy=${ariaBusy === true ? 'true' : undefined}
+      aria-pressed=${pressed === true ? 'true' : pressed === false ? 'false' : undefined}
       title=${title}
       data-testid=${testId}
     >${children}</button>

--- a/dashboard/src/components/tool-executor/tool-picker.ts
+++ b/dashboard/src/components/tool-executor/tool-picker.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { TextInput } from '../common/input'
 import { CountBadge } from '../common/badge'
+import { ActionButton } from '../common/button'
 import { searchQuery, tierFilter, filteredTools, selectedTool, selectTool } from './tool-executor-state'
 import type { McpToolSchema } from '../../types/json-schema'
 
@@ -38,11 +39,12 @@ export function ToolPicker() {
         onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }} />
       <div class="flex gap-1">
         ${TIER_OPTIONS.map(opt => html`
-          <button type="button" class="text-3xs px-2 py-0.5 rounded transition-colors cursor-pointer
-            ${tierFilter.value === opt.value
-              ? 'bg-[var(--accent-12)] text-[var(--color-fg-secondary)] border border-[var(--accent-30)]'
-              : 'text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] border border-transparent hover:bg-[var(--white-6)]'}"
-            onClick=${() => { tierFilter.value = opt.value }}>${opt.label}</button>
+          <${ActionButton}
+            variant=${tierFilter.value === opt.value ? 'ghost' : 'subtle'}
+            size="sm"
+            pressed=${tierFilter.value === opt.value}
+            class="text-3xs"
+            onClick=${() => { tierFilter.value = opt.value }}>${opt.label}<//>
         `)}
         <span class="text-3xs text-[var(--color-fg-muted)] ml-auto self-center">${tools.length}개</span>
       </div>


### PR DESCRIPTION
## Summary

CS3까지의 inline → ActionButton swap이 다루지 못했던 **tab-like / toggle 패턴**을 enable. ActionButton에 `pressed` prop을 추가하고 첫 PoC 적용으로 tool-picker tier filter를 swap.

## ActionButton 확장 (common/button.ts)

**신규 prop**: `pressed?: boolean`

| pressed 값 | aria-pressed | 시각 |
|-----------|--------------|------|
| `true` | `"true"` | variant별 PRESSED_CLASSES override |
| `false` | `"false"` | base variant (toggle group 비활성) |
| unset | 미렌더 | plain action button |

### PRESSED_CLASSES per variant

```ts
{
  primary: 'bg-[var(--accent-20)]',
  ghost: 'bg-[var(--accent-12)] border-[var(--accent-30)] text-[var(--color-fg-secondary)]',
  danger: 'bg-[var(--bad-20)]',
  subtle: 'bg-[var(--white-6)] text-[var(--color-fg-primary)]',
}
```

### 신규 테스트 (4건)

- `pressed=true` → `aria-pressed="true"`
- `pressed=false` → `aria-pressed="false"`
- `pressed` unset → no `aria-pressed`
- `pressed=true` + `ghost` → `bg-[var(--accent-12)]`

## 첫 적용 — tool-picker.ts tier filter

**Before** (inline tab-like):
```tsx
<button class={tierFilter.value === opt.value
  ? 'bg-[var(--accent-12)] text-[var(--color-fg-secondary)] border border-[var(--accent-30)]'
  : 'text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] border border-transparent hover:bg-[var(--white-6)]'}>
```

**After**:
```tsx
<ActionButton
  variant={tierFilter.value === opt.value ? 'ghost' : 'subtle'}
  size="sm"
  pressed={tierFilter.value === opt.value}
  class="text-3xs">
```

ariaPressed 자동 + visual selected state 자동 + a11y focus ring 자동.

## 후속 PR 후보 (이제 가능)

- `autoresearch.ts` loop selector 4 buttons (CS2에서 의도적 보존했던 patterns)
- 기타 dashboard 내 "selection state" 인라인 tab buttons

## 안전성

- **시각 회귀 미세**: ghost+pressed = `--accent-12` + `--accent-30` border = 기존 inline과 동등
- **subtle+pressed = `--white-6` bg**: subtle variant inactive와 활성 상태 구분 명확

## Test plan

- [ ] CI green (button.test.ts +4 cases)
- [ ] tool-picker tier filter 토글 동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)
