### PR TITLE
refactor(design-system): swap autoresearch loop selector to ActionButton with pressed prop (PR-CS5)

### DIFF
--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -129,16 +129,19 @@ function LoopSelector() {
       <div class="flex flex-wrap gap-2">
         ${loops.map(loop => {
           const isSelected = loop.loop_id === selectedLoopId.value
-          const cls = isSelected
-            ? 'px-3 py-1.5 rounded text-xs font-medium border border-accent/60 bg-[var(--accent-10)] text-[var(--text-strong)] cursor-pointer'
-            : 'px-3 py-1.5 rounded text-xs font-medium border border-card-border bg-card/60 text-[var(--text-muted)] cursor-pointer hover:border-accent/30 transition-colors'
           return html`
-            <button type="button" key=${loop.loop_id} class=${cls} onClick=${() => selectLoop(loop.loop_id)}>
+            <${ActionButton}
+              key=${loop.loop_id}
+              variant=${isSelected ? 'ghost' : 'subtle'}
+              size="md"
+              pressed=${isSelected}
+              class="text-xs"
+              onClick=${() => selectLoop(loop.loop_id)}>
               <span class="${statusColor(loop.status)} mr-1">\u25CF</span>
               ${loop.loop_id.slice(0, 8)}
               <span class="ml-1 opacity-60">${statusLabel(loop.status)}</span>
               <span class="ml-1 opacity-60">${liveLabel(loop)}</span>
-            </button>
+            <//>
           `
         })}
         ${loops.length === 0 ? html`<div class="text-[var(--text-muted)] text-xs py-1.5">선택된 실행자의 루프가 없습니다.</div>` : null}


### PR DESCRIPTION
## Summary

CS4 (#10679)의 ActionButton.pressed prop 첫 자율 활용. CS2에서 의도적으로 raw `<button>`으로 보존했던 autoresearch loop selector를 swap.

## 변경

`dashboard/src/components/autoresearch.ts` line 130 (LoopSelector map):

**Before**:
```tsx
const cls = isSelected
  ? 'px-3 py-1.5 rounded text-xs font-medium border border-accent/60 bg-[var(--accent-10)] text-[var(--text-strong)] cursor-pointer'
  : 'px-3 py-1.5 rounded text-xs font-medium border border-card-border bg-card/60 text-[var(--text-muted)] cursor-pointer hover:border-accent/30 transition-colors'
return html`<button type="button" key=${loop.loop_id} class=${cls} ...>...</button>`
```

**After**:
```tsx
return html`
  <${ActionButton}
    key=${loop.loop_id}
    variant=${isSelected ? 'ghost' : 'subtle'}
    size="md"
    pressed=${isSelected}
    class="text-xs"
    onClick=${() => selectLoop(loop.loop_id)}>
    ...
  <//>
`
```

## 이점

- **a11y**: aria-pressed 자동 ("이 버튼은 toggle group 멤버이며 현재 active") + focus-visible:ring (`--accent-45`)
- **인터랙션**: active:scale-[0.97] + opacity-90 (CS1+ 일관)
- **selected look**: ghost+pressed → `--accent-12` bg + `--accent-30` border (기존 inline의 `--accent-10` 와 거의 동등 — accent palette intermediate step)
- **inactive look**: subtle variant (가벼운 배경)

## 누적 swap (autoresearch.ts)

| PR | Buttons | 상태 |
|----|---------|------|
| CS2 #10656 | 6 (action) | MERGED |
| CS5 (this) | 1 (selection) | OPEN |
| **합계** | **7 / 7** | inline `<button>` 0건 ✅ |

## 안전성

- **시각 회귀 미세**: `--accent-12` ≈ `--accent-10` (alpha 1단계 차이)
- **테스트 영향**: autoresearch.test.ts 18 tests 모두 텍스트 매칭 기반

## Test plan

- [ ] CI green
- [ ] autoresearch loop selector 클릭 시 selected/unselected 시각 토글 확인
- [ ] 스크린리더로 aria-pressed announce 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)
