### PR TITLE
fix(deploy): build dashboard SPA in Dockerfile multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,11 @@ logs
 .masc
 .env
 .env.*
+# Tracked Vite mode-specific env files (not secrets).  Required by the
+# dashboard-builder stage in the Dockerfile so `vite build` picks up
+# VITE_DASHBOARD_WS_ONLY (and any future tracked defaults).
+!dashboard/.env.development
+!dashboard/.env.production
 *.exe
 masc-mcp-linux-x64
 .github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,32 @@
 # MASC MCP Server - Production Dockerfile
-# Runtime image for the CI-built Linux Eio binary.
-# NOTE: Dashboard SPA (assets/dashboard/) is not included.
-# To add it, use a multi-stage build with Node.js or COPY from CI artifact.
+# Two stages:
+#   1. dashboard-builder: Vite SPA build (Node 20).  Produces /build/assets/dashboard.
+#   2. runtime: Ubuntu 24.04 with the OCaml binary + the SPA copied in.
 
+# ---- Stage 1: dashboard SPA -------------------------------------------------
+FROM node:20-slim AS dashboard-builder
+
+# corepack ships with Node 20+ but is opt-in.  Pin pnpm to the version
+# package.json declares (10.31.0) so build-time pnpm matches dev/CI.
+RUN corepack enable && corepack prepare pnpm@10.31.0 --activate
+
+WORKDIR /build/dashboard
+
+# Copy lockfile + manifest first so `pnpm install` cache layer survives
+# unrelated source edits.
+COPY dashboard/package.json dashboard/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --prefer-offline
+
+# Copy the rest of the dashboard sources (env files, src, vite.config, etc.).
+# .dockerignore must whitelist dashboard/.env.production for `vite build`
+# (mode=production) to pick up VITE_DASHBOARD_WS_ONLY=true.
+COPY dashboard/ ./
+
+# vite.config.ts sets outDir='../assets/dashboard' → output lands at
+# /build/assets/dashboard relative to the Vite working directory.
+RUN pnpm run build
+
+# ---- Stage 2: runtime -------------------------------------------------------
 FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -34,6 +58,12 @@ RUN mkdir -p /app/.masc && chown -R appuser:appgroup /app/.masc
 
 # Copy all config files. CI may generate additional JSON alongside tracked files.
 COPY config/ /app/config/
+
+# Copy the built dashboard SPA from the build stage.  lib/web_dashboard.ml
+# resolves the index at $MASC_BASE_PATH/assets/dashboard/index.html, which
+# is /app/assets/dashboard/index.html under the env settings below.
+COPY --from=dashboard-builder /build/assets/dashboard /app/assets/dashboard
+RUN chown -R appuser:appgroup /app/assets
 
 ENV PORT=8080
 ENV MASC_BASE_PATH=/app

--- a/docs/sse-ws-cutover.md
+++ b/docs/sse-ws-cutover.md
@@ -38,14 +38,12 @@ The flag is build-time: `vite build` reads `.env.production` (and `.env`,
 A rebuild is required to flip the tracked default; for a single browser
 tab without a rebuild, use the runtime injection below.
 
-> Dashboard production deployment caveat: as of this PR, the dashboard
-> SPA is built locally by an operator (`make build` triggers
-> `scripts/build-dashboard-if-needed.sh` → `vite build`).  Neither
-> `release.yml` nor `deploy-railway.yml` rebuilds the SPA, and the
-> Dockerfile does not COPY `assets/dashboard/`.  The cutover flag
-> therefore only takes effect on builds an operator produces locally
-> before deploying.  Wiring a real production dashboard build into CI
-> is tracked separately.
+The Dockerfile rebuilds the SPA in a Node 20 stage every Railway deploy,
+so the cutover flag in `dashboard/.env.production` is applied to every
+production image automatically.  See `Dockerfile` (`dashboard-builder`
+stage) and `.dockerignore` (whitelist for `dashboard/.env.production`).
+Operators who run `make build` locally still get the same default
+because both paths read the same env file.
 
 ## Reading the beacon
 


### PR DESCRIPTION
Closes #10670.

## Why

Production users hit `"Dashboard build not found. Run: cd dashboard && pnpm run build"` when opening the dashboard.  Root cause: `assets/dashboard/` is git-ignored, neither `release.yml` nor `deploy-railway.yml` invoked `make build`, the Dockerfile did not COPY the SPA, and `.dockerignore` excluded `.env.*` (which would have blocked Vite even if a build stage existed).

This blocks the SSE → WS cutover series (#10657, #10669) from taking effect for any deployed instance: the production cutover flag in `dashboard/.env.production` is moot if the SPA is never built or shipped.

## What

Multi-stage Dockerfile:

- **Stage 1 `dashboard-builder`** (`node:20-slim`): pin pnpm to the package.json-declared 10.31.0 via corepack, `pnpm install --frozen-lockfile`, `pnpm run build`.  Vite outputs to `/build/assets/dashboard` per the existing `outDir: '../assets/dashboard'` in `vite.config.ts`.
- **Stage 2 runtime** (existing Ubuntu 24.04): `COPY --from=dashboard-builder /build/assets/dashboard /app/assets/dashboard`, `chown` to the non-root `appuser`.

`.dockerignore` whitelists `dashboard/.env.production` and `dashboard/.env.development` so Vite picks up `VITE_DASHBOARD_WS_ONLY=true` in the build stage.

`lib/web_dashboard.ml` resolves the index at `$MASC_BASE_PATH/assets/dashboard/index.html` → `/app/assets/dashboard/index.html` under the existing `ENV MASC_BASE_PATH=/app`, so no OCaml-side change.

## Verification

```sh
docker build --target dashboard-builder -t masc-dashboard-build-smoke .
# vite build succeeds in 43.56s, output lands at /build/assets/dashboard

docker run --rm masc-dashboard-build-smoke ls /build/assets/dashboard/
# → assets/  index.html

docker run --rm masc-dashboard-build-smoke sh -c \
  'grep -oE ".{40}__MASC_DASHBOARD_WS_ONLY__.{120}" /build/assets/dashboard/assets/index-*.js | head -1'
# → ...function ps(e=window){const t=e.__MASC_DASHBOARD_WS_ONLY__;return t===!0?!0:t===!1?!1:"true"==="true"}...
```

The compiled gate ends with the inlined literal `"true"==="true"` — identical to the local-build verification done in #10669.  Confirms `dashboard/.env.production` is reachable inside the Docker context and Vite substitutes the env variable as expected.

Full runtime stage build was not exercised locally (requires the OCaml binary).  `deploy-railway.yml`'s existing smoke step (`docker build -t masc-mcp-railway-smoke . && docker run ... healthcheck`) covers it end-to-end on every workflow_dispatch.

## Build time impact

The dashboard-builder stage adds ~50s to `docker build` (one-time per Railway deploy).  BuildKit can schedule it in parallel with the OCaml binary preparation, so wall-clock impact on `deploy-railway.yml` is closer to the SPA build alone than additive.

## Out of scope

- Bundle size: cytoscape (442 KB), wardley (492 KB), activity-swimlane (494 KB), mermaid.core (577 KB) chunks exceed Vite's 500 KB warning.  Dynamic-import code-split is a separate PR.
- pnpm store cache via `RUN --mount=type=cache,target=/root/.local/share/pnpm/store`: would shave install time on warm builders but adds Docker BuildKit version requirements.  Defer until first measurement shows it matters.
- `release.yml` does not produce a docker image, so this PR does not affect tag releases — `deploy-railway.yml` is the only deploy path.

## Test plan

- [x] `docker build --target dashboard-builder` succeeds and produces `/build/assets/dashboard/index.html`
- [x] Compiled bundle contains the inlined `"true"==="true"` cutover gate
- [ ] After merge, `deploy-railway.yml` smoke step succeeds end-to-end (`docker build` + `docker run` + healthcheck)
- [ ] Railway deploy: confirm `curl https://<railway-host>/dashboard/` returns the real SPA `index.html`, not the "Build not found" stub
- [ ] Confirm in browser DevTools: 0 connections to `/sse`, 1 connection to `/ws`, transport beacon green
