### PR TITLE
feat(dashboard): localize 9 chips/labels across 5 components (round-31)

### DIFF
--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -93,7 +93,7 @@ export function ConnectorPathsStrip({ connectors }: { connectors: GateConnectorI
         aria-controls="connector-paths-body"
       >
         <span>
-          <span class="mr-2 text-3xs uppercase tracking-4">Paths</span>
+          <span class="mr-2 text-3xs uppercase tracking-4">경로</span>
           <span class="font-mono">${paths.connectorsDir ?? paths.sidecarsDir}</span>
           <span class="ml-2 text-[var(--color-fg-disabled)]">${paths.connectorsDir ? '' : '(런타임 미관찰 · sidecar 경로만 표시)'}</span>
         </span>

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -1035,7 +1035,7 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
 
         ${'' /* reasoning tokens */}
         <div class="p-3 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">Reasoning</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">추론</span>
           <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${totalReasoning > 0 ? totalReasoning.toLocaleString() : '-'}</span>
           <span class="text-3xs text-[var(--color-fg-disabled)]">total tokens</span>
         </div>

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -642,10 +642,10 @@ export function MemorySubsystems() {
                         <table class="w-full text-left">
                           <thead>
                             <tr class="border-b border-[var(--white-10)] text-xs text-[var(--color-fg-muted)]0">
-                              <th class="py-1.5 px-2">From</th>
+                              <th class="py-1.5 px-2">출처</th>
                               <th class="py-1.5 px-2"></th>
-                              <th class="py-1.5 px-2">To</th>
-                              <th class="py-1.5 px-2 text-right">Weight</th>
+                              <th class="py-1.5 px-2">대상</th>
+                              <th class="py-1.5 px-2 text-right">가중치</th>
                               <th class="py-1.5 px-2 text-center">성공</th>
                               <th class="py-1.5 px-2 text-center">실패</th>
                               <th class="py-1.5 px-2">마지막</th>

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -163,7 +163,7 @@ function CoordinationHealthPanel() {
         </div>
       ` : null}
       ${violations.length === 0 ? html`
-        <div class="mt-2 text-xs text-text-muted">Aligned</div>
+        <div class="mt-2 text-xs text-text-muted">정합</div>
       ` : html`
         <ul class="mt-2 grid gap-2">
           ${topViolations.map((violation, index) => html`
@@ -173,7 +173,7 @@ function CoordinationHealthPanel() {
       `}
       ${topEvidence.length > 0 ? html`
         <div class="mt-3">
-          <div class="mb-1 text-3xs font-semibold uppercase text-text-muted">Evidence</div>
+          <div class="mb-1 text-3xs font-semibold uppercase text-text-muted">근거</div>
           <ul class="grid gap-1 md:grid-cols-2">
             ${topEvidence.map((item, index) => html`
               <${CoordinationEvidenceRow} key=${`${item.source ?? 'evidence'}-${item.kind ?? 'kind'}-${item.id ?? index}`} evidence=${item} />

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -135,11 +135,11 @@ function ServerMeta() {
   return html`
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
-        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">Version</div>
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">버전</div>
         <div class="text-sm font-mono text-[var(--text-primary)]">${server.version}</div>
       </div>
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
-        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">Uptime</div>
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">가동시간</div>
         <div class="text-sm font-mono text-[var(--text-primary)]">${formatUptime(server.uptime_seconds)}</div>
       </div>
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">


### PR DESCRIPTION
## Summary

대시보드 라운드 31 — 5 components 9 chips 한국어화.

| File | Chip | Before | After |
|---|---|---|---|
| server-config.ts:138 | metric label | Version | 버전 |
| server-config.ts:142 | metric label | Uptime | 가동시간 |
| memory-subsystems.ts:645 | table header | From | 출처 |
| memory-subsystems.ts:647 | table header | To | 대상 |
| memory-subsystems.ts:648 | table header | Weight | 가중치 |
| planning-panel.ts:166 | status chip | Aligned | 정합 |
| planning-panel.ts:176 | section heading | Evidence | 근거 |
| keeper-detail-panels.ts:1038 | metric label | Reasoning | 추론 |
| connector-paths-strip.ts:96 | section heading | Paths | 경로 |

## Test fixture coupling 검증

각 단어가 test 파일에 등장하는지 사전 sweep — coupling 없음 확인:

| 단어 | Test 등장 위치 | 충돌 여부 |
|---|---|---|
| Paths | `connector-paths-strip.test.ts` 의 `deriveMascPaths` 식별자 | ❌ no (identifier vs visible string) |
| Evidence | `monitoring-runtime.test.ts` 의 `summarizeMonitoringEvidence` 식별자 | ❌ no |
| Overview | `connector-overview-skeleton.test.ts` 의 `ConnectorOverviewSkeleton` 컴포넌트명 | ❌ no (이번 PR 범위 밖) |
| Uptime | `heartbeat-history.test.ts` 의 `formatUptime` 등 식별자 | ❌ no |
| From | api 테스트의 헬퍼 식별자 | ❌ no |

→ assertion fixture 와 무관한 가시 텍스트만 변경.

## 보존 (영문 유지)

| 위치 | 단어 | 이유 |
|---|---|---|
| `server-config.ts:146` | OCaml | 언어/런타임명 |
| `server-config.ts:150` | PID | 표준 약어 |
| `memory-subsystems.ts:649-651` | 성공/실패/마지막 | 이미 한국어 (drift 없음) |

## Test plan

- [ ] dashboard `pnpm dev` — 5 컴포넌트 시각 확인
- [ ] 영한혼용 잔여 검사 (`>[A-Z][a-z]+<` regex sweep)

## Round 누적 (23-31)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23 | #10635 | MERGED | 11 |
| 24 | #10644 | MERGED | 13 |
| 25 | #10651 | MERGED | 9 |
| 26 | #10653 | MERGED | 8 |
| 27 | #10655 | MERGED | 8 |
| 28 | #10666 | MERGED | -- |
| 29 | #10671 | MERGED | 3 |
| 30 | #10674 | MERGED | 5 |
| 31 | this | Draft | **9** |

누적 chips ≈ **66**.

## Why Draft

Vitest infra 미해결 case (#10645) 가 dashboard test suite startup fail 유발 가능 → visual review 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)