### PR TITLE
fix(keeper): use container path for default_cwd in masc_keeper_status (#10650)

### DIFF
--- a/lib/keeper/keeper_sandbox.ml
+++ b/lib/keeper/keeper_sandbox.ml
@@ -106,6 +106,11 @@ let allowed_path_roots ~(name : string) : string list =
 let allowed_path_roots_of_meta ~(meta : Keeper_types.keeper_meta) : string list =
   [ allowed_root_rel_of_meta ~meta ]
 
+let keeper_visible_root_abs (t : t) : string =
+  match t.container_root with
+  | Some container -> container
+  | None -> t.host_root_abs
+
 let storage_lifetime = "persistent_backend_task_overlay"
 
 let context_status_fields (t : t) : (string * Yojson.Safe.t) list =

--- a/lib/keeper/keeper_sandbox.mli
+++ b/lib/keeper/keeper_sandbox.mli
@@ -89,6 +89,15 @@ val allowed_root_rel_of_meta :
   meta:Keeper_types.keeper_meta ->
   string
 
+(** [keeper_visible_root_abs t] is the absolute path the keeper LLM
+    should treat as its working root.  For Docker keepers this is the
+    in-container path ({!container_root}); for Local keepers this is
+    {!host_root_abs}.  Surfacing the host path to a Docker keeper makes
+    the LLM emit [cd /Users/.../.masc/playground/...] inside the
+    container, which fails because that path does not exist there
+    (#10650). *)
+val keeper_visible_root_abs : t -> string
+
 (** {1 Dashboard / status output} *)
 
 (** Key-value fields describing the sandbox shape (id, backend,

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1243,6 +1243,13 @@ let handle_keeper_status ctx args : tool_result =
            (let sandbox = Keeper_sandbox.of_meta ~config:ctx.config ~meta:m in
            let playground_rel = sandbox.host_root_rel in
            let playground_abs = sandbox.host_root_abs in
+           (* #10650: default_cwd / private_workspace_root must be a path
+              that resolves *inside* the keeper's runtime.  For Docker
+              keepers the host abs path does not exist inside the
+              container, so the LLM emitted [cd <host_abs>] which fails
+              ~890/day.  keeper_visible_root_abs picks container_root for
+              Docker, host_root_abs for Local. *)
+           let keeper_visible_abs = Keeper_sandbox.keeper_visible_root_abs sandbox in
            "execution_context", `Assoc [
              ("sandbox_id", `String sandbox.sandbox_id);
              ("sandbox_backend", `String (Keeper_sandbox.backend_to_string sandbox.backend));
@@ -1252,8 +1259,8 @@ let handle_keeper_status ctx args : tool_result =
              ("sandbox_host_root", `String sandbox.host_root_abs);
              ("sandbox_container_root", Json_util.string_opt_to_json sandbox.container_root);
              ("playground_path", `String playground_rel);
-             ("default_cwd", `String playground_abs);
-             ("private_workspace_root", `String playground_abs);
+             ("default_cwd", `String keeper_visible_abs);
+             ("private_workspace_root", `String keeper_visible_abs);
              ("sandbox_profile", `String (sandbox_profile_to_string m.sandbox_profile));
              ("network_mode", `String (network_mode_to_string m.network_mode));
              ("shared_memory_scope",

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2140,9 +2140,23 @@ let test_keeper_config_uses_backend_scoped_private_workspace_root () =
       Alcotest.(check string) "status playground path"
         docker_rel
         (execution_context |> member "playground_path" |> to_string);
+      (* #10650: for a Docker keeper, private_workspace_root in the
+         keeper-LLM-facing status response is the in-container path
+         ([/home/keeper/playground/<sanitized>]), NOT the host abs path.
+         The host path is inaccessible inside the container; surfacing
+         it caused ~890/day [cd: No such file or directory] errors. *)
+      let docker_container_root =
+        Masc_mcp.Keeper_sandbox.container_root keeper_name
+      in
       Alcotest.(check string) "status private workspace root"
+        docker_container_root
+        (execution_context |> member "private_workspace_root" |> to_string);
+      Alcotest.(check string) "status default cwd"
+        docker_container_root
+        (execution_context |> member "default_cwd" |> to_string);
+      Alcotest.(check string) "status sandbox host root preserved"
         docker_abs
-        (execution_context |> member "private_workspace_root" |> to_string))
+        (execution_context |> member "sandbox_host_root" |> to_string))
 
 let test_snapshot_keeper_tool_audit_fallback () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## 문제 (#10650)

Docker 키퍼의 `masc_keeper_status` 응답에서 `execution_context.default_cwd`와 `private_workspace_root`가 HOST abs path (`/Users/.../.masc/playground/docker/<keeper>/`)를 노출.

키퍼 LLM이 이를 docker bash sandbox 안에서 `cd <host_abs>` 타깃으로 사용 → 컨테이너 안에 그 경로가 없으므로 `No such file or directory`.

Fleet 영향: 5000-line system_log 샘플 기준 37/40 sandbox docker exec failed events (≈ **890/day**).

`config/prompts/keeper.world.md:34-38`이 host abs path 사용을 명시적으로 금지하지만, JSON 데이터에 host abs가 들어있으면 LLM은 docs 보다 데이터를 따른다.

## 변경

### `Keeper_sandbox.keeper_visible_root_abs : t -> string` 신설

- Docker → `container_root` (`/home/keeper/playground/<sanitized>`)
- Local → `host_root_abs` (호스트 fs 그대로 키퍼 sh에 유효)

### `keeper_status_detail.execution_context`

| 필드 | 기존 | 변경 후 |
|------|------|---------|
| `default_cwd` | `host_root_abs` | `keeper_visible_root_abs` |
| `private_workspace_root` | `host_root_abs` | `keeper_visible_root_abs` |
| `sandbox_host_root` | `host_root_abs` | (유지) operator dashboard 용 |
| `sandbox_container_root` | `container_root option` | (유지) |

### server-side fs reads는 변경 없음

`playground_repos` cache (`.playground_state.json`), `pr_history` (`.playground_pr_history.jsonl`)는 server-side host filesystem read이므로 `host_root_abs` 그대로 유지.

### `dashboard_http_keeper.keeper_config_json` 변경 없음

operator-facing endpoint는 host abs path가 정당. operator는 호스트 fs를 직접 다루기 때문.

## 테스트

`test_keeper_config_uses_backend_scoped_private_workspace_root` 확장:
- Docker 키퍼: `default_cwd` / `private_workspace_root` == `container_root`
- Docker 키퍼: `sandbox_host_root` == `docker_abs` (operator 용 보존)

`dune build @runtest` EXIT=0.

## Issue 후보 A 채택

`#10650` Issue Body의 Option A "Hide host_root_abs from keeper_context_status — return container path for docker-profile keepers" 경로. Option B (separate field)는 backward compat 위해 `sandbox_host_root` 보존으로 충분, 새 필드 도입 불필요.

## 관련 PR

- #10647 (defense-in-depth `/workspace` negative anchor) — 1/40 cluster 처리
- #10624 (sandbox auto-chdir for single-repo case) — wrapper-side complementary fix
- 이번 PR — 37/40 dominant cluster 처리 (root)

Closes #10650

🤖 Generated with [Claude Code](https://claude.com/claude-code)