### PR TITLE
refactor(design-system): swap error-panel icon-only buttons to ActionButton (PR-CS6)

### DIFF
--- a/dashboard/src/components/common/error-panel.ts
+++ b/dashboard/src/components/common/error-panel.ts
@@ -49,9 +49,9 @@ export function ErrorPanel({ onClose }: ErrorPanelProps) {
       <div class="absolute right-0 top-full mt-1.5 z-[var(--z-overlay-dropdown,3050)] w-96 max-h-80 overflow-hidden rounded-lg border border-[var(--color-border-default)] bg-[rgba(10,18,34,0.98)] shadow-xl backdrop-blur-xl">
         <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--white-5)]">
           <span class="text-xs font-medium text-[var(--color-fg-muted)]">에러 없음</span>
-          <button type="button" class="text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer p-0.5" onClick=${onClose}>
+          <${ActionButton} variant="subtle" size="sm" class="p-0.5" ariaLabel="에러 패널 닫기" onClick=${onClose}>
             <${X} size=${14} />
-          </button>
+          <//>
         </div>
         <div class="flex items-center justify-center py-6 text-xs text-[var(--color-fg-muted)]">
           모든 에러를 확인했습니다.
@@ -71,9 +71,9 @@ export function ErrorPanel({ onClose }: ErrorPanelProps) {
             class="text-2xs"
             onClick=${() => { clearAllErrors(); onClose() }}
           >모두 확인<//>
-          <button type="button" class="text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer p-0.5" onClick=${onClose}>
+          <${ActionButton} variant="subtle" size="sm" class="p-0.5" ariaLabel="에러 패널 닫기" onClick=${onClose}>
             <${X} size=${14} />
-          </button>
+          <//>
         </div>
       </div>
 
@@ -98,11 +98,14 @@ export function ErrorPanel({ onClose }: ErrorPanelProps) {
               <p class="mt-0.5 text-xs text-[var(--color-fg-primary)] leading-[1.4] line-clamp-2">${e.message}</p>
               <span class="mt-0.5 block text-2xs text-[var(--color-fg-muted)]">${formatElapsedCompact((Date.now() - e.timestamp) / 1000)} 전</span>
             </div>
-            <button type="button"
-              class="shrink-0 mt-0.5 p-1 rounded opacity-0 group-hover:opacity-100 text-[var(--color-fg-muted)] hover:text-[var(--color-status-ok)] hover:bg-[var(--white-8)] cursor-pointer transition-all"
+            <${ActionButton}
+              variant="subtle"
+              size="sm"
+              class="shrink-0 mt-0.5 p-1 opacity-0 group-hover:opacity-100 hover:text-[var(--color-status-ok)] hover:bg-[var(--white-8)]"
               title="확인"
+              ariaLabel="에러 확인"
               onClick=${() => acknowledgeError(e.id)}
-            ><${Check} size=${14} /></button>
+            ><${Check} size=${14} /><//>
           </div>
         `})}
       </div>


### PR DESCRIPTION
## Summary

CS3 (#10673)에서 "icon-only with opacity-0→hover:1 (custom pattern)"으로 의도적 보존했던 error-panel 3 icon-only buttons를 swap.

CS3 시점에 보존한 이유는 ActionButton subtle variant + class override만으로 동일 효과 가능한지 검증되지 않았음. CS6에서 검증 완료.

## 변경 (`dashboard/src/components/common/error-panel.ts`)

| 위치 | 이전 | 이후 |
|------|------|------|
| line 52 (panel close, items=0) | `<button class="text-fg-muted hover:text-fg-primary p-0.5">` | `<${ActionButton} variant="subtle" size="sm" class="p-0.5" ariaLabel="에러 패널 닫기">` |
| line 74 (panel close, items>0) | 동일 | 동일 (`replace_all=true` 적용) |
| line 101 (per-error ack check) | `<button class="opacity-0 group-hover:opacity-100 hover:text-status-ok hover:bg-white-8 ...">` | `<${ActionButton} variant="subtle" size="sm" class="opacity-0 group-hover:opacity-100 hover:text-status-ok hover:bg-white-8 ...">` |

## 핵심 발견

ActionButton subtle variant + class override 조합으로 icon-only 패턴 충분 처리 가능:
- `class="p-0.5"` 또는 `class="p-1"` → 컴팩트 padding
- `class="opacity-0 group-hover:opacity-100"` → 호버 reveal
- `class="hover:bg-[var(--white-8)]"` → variant default hover 위에 override
- 별도 IconButton 컴포넌트 불필요

## 이점

- **a11y**: focus-visible:ring 자동 (icon-only도 키보드 접근성)
- **ariaLabel**: "에러 패널 닫기" / "에러 확인" 스크린리더 announce
- **인터랙션**: active:scale-[0.97] 적용
- **유지보수**: 모든 button surface가 ActionButton 단일 진입점

## 누적 swap (error-panel.ts)

| PR | Buttons | 상태 |
|----|---------|------|
| CS3 #10673 | 1 ("모두 확인" ghost) | MERGED |
| CS6 (this) | 3 (icon-only subtle) | OPEN |
| **합계** | **4 / 4** | inline `<button>` 0건 ✅ |

## Test plan

- [ ] CI green
- [ ] error panel 열고 X 닫기 동작
- [ ] error item 호버 시 check icon opacity-0→100 정상
- [ ] check 클릭 시 acknowledge 동작 + 키보드 focus ring 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)
