### PR TITLE
fix(dune): exclude misplaced worktrees/ (no-dot) from dune scan

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
-(dirs (:standard \ .worktrees _build_codex_trpg archive dashboard_bonsai))
+(dirs (:standard \ .worktrees worktrees _build_codex_trpg archive dashboard_bonsai))
 
 (env
  (dev


### PR DESCRIPTION
## Summary

Root `dune` 파일의 `(dirs ... \ ...)` 옵트아웃 리스트에 `worktrees`(no dot) 추가.

```diff
-(dirs (:standard \ .worktrees _build_codex_trpg archive dashboard_bonsai))
+(dirs (:standard \ .worktrees worktrees _build_codex_trpg archive dashboard_bonsai))
```

**1 line, single 단어 추가.** Behavior change: `worktrees/`(non-dot) 디렉토리가 dune scan에서 제외됨.

## Why

오늘 (2026-04-26 20:09 KST) 로컬 `dune build` 실패 reproduce:

```
$ dune build
Error: The package "masc_mcp" is defined more than once:
- worktrees/task-105-yojson/dune-project:23
- dune-project:23
```

Root cause: 누군가 (자동화 스크립트 또는 수동 `git worktree add`) worktree를 표준 `.worktrees/`(dot, hidden) 대신 `worktrees/`(no-dot, visible)에 만듦. dune은 hidden dir만 자동 무시하고 `worktrees/`는 scan하면서 같은 `dune-project`를 두 번 발견 → duplicate package error.

기존 옵트아웃 리스트는 `.worktrees`만 명시 (불필요했지만 명시적으로 하드닝). `worktrees`는 빠져 있어 misplacement에 무방비.

## Fix scope

| 파일 | 변경 |
|------|------|
| `dune` (root) | `\ .worktrees` 옆에 `worktrees` 추가 |

총 **1 file, +1/-1 단어**. 다른 영향 0.

## Verification

격리 테스트 (이 PR worktree에서):
```bash
mkdir -p worktrees/test-dummy
cat > worktrees/test-dummy/dune-project <<'EOF'
(lang dune 3.22)
(name masc_mcp)
EOF
dune build @check --cache=disabled
# Expected: green (worktrees/ ignored)
# Pre-fix: Error "defined more than once"
```

Pre-fix와 post-fix 동일 dummy package 심어서 차이 검증.

## Why both `.worktrees` AND `worktrees`?

| dir | dune 기본 동작 | 옵트아웃 필요? |
|-----|--------------|--------------|
| `.worktrees/` | 이미 무시 (`.` prefix = hidden) | 명시 안 해도 작동 — 그러나 자기 문서화 차원에서 유지 |
| `worktrees/` | scan함 | **필수** — 이 PR이 추가 |

`.`만 빠진 typo 또는 잘못된 자동화로 다시 발생하지 않도록 영구 가드.

## Related

- 즉시 fix는 `git worktree move worktrees/task-105-yojson .worktrees/task-105-yojson-3`로 해소됨 (memory `masc-mcp-nested-worktree-containers`와 별개 케이스 — nested 아니라 misplaced)
- 본 PR은 systemic 가드 (재발 방지)
- memory `masc-mcp-nested-worktree-containers`는 `.worktrees/feature/`, `.worktrees/fix/` 같은 subtree container 보호용 — 이번 케이스와 다른 root cause

## Risk

- 미래에 누군가 의도적으로 `worktrees/` 하위에 OCaml 빌드 대상을 만들 가능성 → 그땐 PR로 옵트아웃 제거 + 명시적 마이그레이션 필요. 현재로썬 `worktrees/` 사용처 0건.
- `dashboard_bonsai`, `archive`, `_build_codex_trpg`처럼 기존 패턴과 동일한 단순 옵트아웃 — 정밀도 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)