### PR TITLE
feat(dashboard): localize 5 chips/labels across 4 components (round-32)

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -864,7 +864,7 @@ function GoalDetailPanel({
 
         ${selectedNode.badges.length > 0 ? html`
           <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
-            <div class="mb-2 text-2xs font-semibold uppercase tracking-widest text-text-muted">Badges</div>
+            <div class="mb-2 text-2xs font-semibold uppercase tracking-widest text-text-muted">배지</div>
             <${GoalBadges} badges=${selectedNode.badges} />
           </div>
         ` : null}

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -288,7 +288,7 @@ export function KeeperDetailOverviewSidebar({
     <aside class="order-2 xl:order-1 xl:sticky xl:top-[104px] xl:self-start">
       <div class="flex flex-col gap-4 rounded-[28px] border border-[var(--card-border)] bg-[rgba(9,14,24,0.84)] p-4 shadow-[0_20px_48px_rgba(0,0,0,0.18)]">
         <div>
-          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Overview</div>
+          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">개요</div>
           <p class="m-0 mt-2 text-sm leading-relaxed text-[var(--text-secondary)]">
             긴 단일 모달 대신 keeper 상세를 별도 화면으로 펼쳤습니다. 운영자가 자주 오가는 맥락 단위로 나눠서 바로 점프할 수 있습니다.
           </p>

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -190,7 +190,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* Coverage bar */}
       <div class="flex items-center gap-3 mb-3">
-        <span class="text-3xs text-[var(--color-fg-muted)] flex-shrink-0 w-16">Coverage</span>
+        <span class="text-3xs text-[var(--color-fg-muted)] flex-shrink-0 w-16">커버리지</span>
         <div class="flex-1 h-2 bg-[var(--white-6)] rounded-sm overflow-hidden">
           <div
             class="h-full rounded-sm transition-all duration-500"

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -365,11 +365,11 @@ export function ToolQualityPanel() {
         </div>
         <div class="text-center">
           <div class="text-lg font-mono text-[var(--bad-light)]/80">${d.failure}</div>
-          <div class="text-3xs text-[var(--color-fg-disabled)] uppercase">Failures</div>
+          <div class="text-3xs text-[var(--color-fg-disabled)] uppercase">실패</div>
         </div>
       </div>
 
-      <${RateGauge} rate=${d.success_rate} label="Overall" />
+      <${RateGauge} rate=${d.success_rate} label="전체" />
 
       ${d.hourly_trend && d.hourly_trend.length >= 2 ? html`
         <${TrendSparkline} points=${d.hourly_trend} />


### PR DESCRIPTION
## Summary

대시보드 라운드 32 — 4 components 5 chips 한국어화.

| File | Chip | Before | After |
|---|---|---|---|
| keeper-detail-shell.ts:291 | section heading | Overview | 개요 |
| tool-quality-panel.ts:368 | metric label | Failures | 실패 |
| tool-quality-panel.ts:372 | RateGauge label | Overall | 전체 |
| keeper-eval-quality.ts:193 | metric label | Coverage | 커버리지 |
| goals/goal-tree.ts:867 | section heading | Badges | 배지 |

## Test fixture coupling 검증

후보 단어별 사전 sweep — coupling 없음 확인 (Args 만 제외):

| 단어 | Test 등장 | 충돌 |
|---|---|---|
| Overview | 식별자 (`ConnectorOverviewSkeleton`) | ❌ |
| Failures | -- | ❌ |
| Overall | -- | ❌ |
| Coverage | -- | ❌ |
| Badges | -- | ❌ |
| ~~Args~~ | **`data-title` attribute assertion (2 tests)** | **✅ 회피** |

## 보존 (영문 유지)

| 위치 | 단어 | 이유 |
|---|---|---|
| `goal-tree.ts:875` | Goal-Scoped Task | 다음 라운드 후보 (이번 PR scope 외) |
| `tool-quality-panel.ts:363` | Sampled Calls / Window Calls | 한 번에 통합 라운드에서 처리 권장 |
| `session-trace-entry.ts:244` | Args (×2) | 테스트 attribute assertion 충돌 — vitest infra (#10645) unblock 후 동기 변경 필요 |

## Test plan

- [ ] `pnpm dev` — 4 컴포넌트 시각 확인
- [ ] `rg '>[A-Z][a-z]+<' dashboard/src/components --type ts -g '!*.test.ts'` 잔여 chip sweep

## 라운드 누적 (23-32)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31 | #10685 | Draft | 9 |
| 32 | this | Draft | **5** |

누적 chips ≈ **71**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)