### PR TITLE
feat(dashboard): localize 7 chips/labels across 2 components (round-33)

### DIFF
--- a/dashboard/src/components/common/observatory-filter-bar.ts
+++ b/dashboard/src/components/common/observatory-filter-bar.ts
@@ -60,28 +60,28 @@ export function ObservatoryFilterBar() {
       <span class="text-3xs uppercase tracking-wider text-text-dim font-semibold">필터</span>
       ${keeper ? html`
         <${Chip}
-          label="Keeper"
+          label="키퍼"
           value=${keeper}
           onClear=${() => setObservatoryFilter({ keeper: null })}
         />
       ` : null}
       ${namespace ? html`
         <${Chip}
-          label="Namespace"
+          label="네임스페이스"
           value=${namespace}
           onClear=${() => setObservatoryFilter({ namespace: null })}
         />
       ` : null}
       ${operation ? html`
         <${Chip}
-          label="Operation"
+          label="작업"
           value=${operation}
           onClear=${() => setObservatoryFilter({ operation: null })}
         />
       ` : null}
       ${range ? html`
         <${Chip}
-          label="Range"
+          label="기간"
           value=${timeRangeLabel(range)}
           onClear=${() => setObservatoryFilter({ range: null })}
         />

--- a/dashboard/src/components/governance-monitor.ts
+++ b/dashboard/src/components/governance-monitor.ts
@@ -168,16 +168,16 @@ export function GovernanceMonitor() {
               value=${fmtSec(data.approval_queue.p50_wait_sec)}
             />
             <${StatCell}
-              label="p95 Wait"
+              label="p95 대기"
               value=${fmtSec(data.approval_queue.p95_wait_sec)}
             />
             <div class="flex items-center gap-2">
               <${StatCell}
-                label="Oldest"
+                label="최장 대기"
                 value=${fmtSec(data.approval_queue.oldest_pending_sec)}
               />
               <${StatusChip}
-                label=${data.approval_queue.depth === 0 ? 'clear' : `${data.approval_queue.depth} pending`}
+                label=${data.approval_queue.depth === 0 ? '없음' : `${data.approval_queue.depth}건 대기`}
                 tone=${queueTone(data.approval_queue.depth, data.approval_queue.oldest_pending_sec)}
               />
             </div>


### PR DESCRIPTION
## Summary

대시보드 라운드 33 — observatory filter + governance monitor 영문 chip 정리.

| File | Chip | Before | After |
|---|---|---|---|
| observatory-filter-bar.ts:63 | Chip label | Keeper | 키퍼 |
| observatory-filter-bar.ts:70 | Chip label | Namespace | 네임스페이스 |
| observatory-filter-bar.ts:77 | Chip label | Operation | 작업 |
| observatory-filter-bar.ts:84 | Chip label | Range | 기간 |
| governance-monitor.ts:171 | StatCell label | p95 Wait | p95 대기 |
| governance-monitor.ts:176 | StatCell label | Oldest | 최장 대기 |
| governance-monitor.ts:180 | StatusChip label | clear / N pending | 없음 / N건 대기 |

## Test fixture coupling 검증

| 단어 | Test 등장 | 충돌 |
|---|---|---|
| Keeper / Namespace / Operation / Range | -- | ❌ |
| Oldest | -- | ❌ |
| pending | mission-normalizers/keeper-store-normalize tests reference **status field values** (not visible chip label) | ❌ |
| clear | -- | ❌ |

## 보존 (영문 유지)

| 위치 | 단어 | 이유 |
|---|---|---|
| `verification-specs-panel.ts:84` | Cfg | 영문 약어 ledger |
| `fleet-telemetry-panel.ts:366` | Ctx | 영문 약어 ledger |
| `lab-inspector.ts:123`, `doctor-panel.ts:299` | Doctor | 진단 도구 명 (한국어 대응 미정) |
| `connector-onboarding.ts:63,81` | Start / Start All | 버튼 라벨, 한국어 문장 내 인용 |

## 라운드 누적 (23-33)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31 | #10685 | Draft | 9 |
| 32 | #10689 | Draft | 5 |
| 33 | this | Draft | **7** |

누적 chips ≈ **78**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)