### PR TITLE
fix(coord): resolve git_clone policy at canonical .masc/config/ path (task-102)

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -79,11 +79,31 @@ let policy_string_array_of_line ~key line =
       in
       Some items
 
+(* SSOT path resolution: canonical config root is [<base_path>/.masc/config/]
+   (same primitive Config_dir_resolver.path_from_local_masc uses via
+   Common.masc_dir_from_base_path). The legacy [<base_path>/config/] form is
+   retained as a secondary lookup for older deployments. Reading order:
+   canonical first, legacy fallback only when canonical is absent. *)
 let load_git_clone_policy ~base_path =
-  let path = Filename.concat (Filename.concat base_path "config") "tool_policy.toml" in
-  match Safe_ops.read_file_safe path with
-  | Error _ -> [], []
-  | Ok content ->
+  let canonical =
+    Filename.concat
+      (Common.masc_dir_from_base_path ~base_path |> fun d -> Filename.concat d "config")
+      "tool_policy.toml"
+  in
+  let legacy = Filename.concat (Filename.concat base_path "config") "tool_policy.toml" in
+  let read_or_empty p =
+    match Safe_ops.read_file_safe p with
+    | Error _ -> None
+    | Ok content -> Some content
+  in
+  let content_opt =
+    match read_or_empty canonical with
+    | Some c -> Some c
+    | None -> read_or_empty legacy
+  in
+  match content_opt with
+  | None -> [], []
+  | Some content ->
       let rec loop in_git_clone allowed denied = function
         | [] -> allowed, denied
         | raw_line :: rest ->

--- a/test/dune
+++ b/test/dune
@@ -108,6 +108,7 @@
         test_keeper_toml
         test_keeper_runtime_toml
         test_keeper_tool_policy_config
+        test_coord_worktree_policy_path
         test_keeper_toml_config_validation
         test_keeper_id
         test_exec_core
@@ -262,6 +263,7 @@
           test_keeper_toml
           test_keeper_runtime_toml
           test_keeper_tool_policy_config
+          test_coord_worktree_policy_path
           test_keeper_toml_config_validation
           test_keeper_id
           test_exec_core

--- a/test/test_coord_worktree_policy_path.ml
+++ b/test/test_coord_worktree_policy_path.ml
@@ -1,0 +1,95 @@
+(** Regression test for [Coord_worktree.load_git_clone_policy] path resolution.
+
+    Bug: prior to this fix, the loader read [<base_path>/config/tool_policy.toml]
+    only, but the canonical config root is [<base_path>/.masc/config/]. Result
+    was empty [allowed_orgs] for keepers whose lookup goes through this loader,
+    surfacing as [No allowed orgs configured for git clone] in clone attempts.
+
+    These tests pin the new behaviour: canonical path takes precedence, legacy
+    path is honoured as a fallback, and absence of both is a clean empty
+    return.
+*)
+
+open Alcotest
+
+module CW = Coord_worktree
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let rec rm_rf path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+      end else Sys.remove path
+  in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let policy_with_orgs orgs =
+  let arr = orgs |> List.map (Printf.sprintf "%S") |> String.concat ", " in
+  Printf.sprintf "[git_clone]\nallowed_orgs = [%s]\n" arr
+
+let test_canonical_masc_config () =
+  with_temp_dir "coord-worktree-policy-canon" @@ fun base ->
+  let dir = Filename.concat (Filename.concat base ".masc") "config" in
+  mkdir_p dir;
+  write_file (Filename.concat dir "tool_policy.toml")
+    (policy_with_orgs [ "jeong-sik"; "kidsnote" ]);
+  let allowed, _denied = CW.load_git_clone_policy ~base_path:base in
+  check (list string) "canonical .masc/config/ resolves orgs"
+    [ "jeong-sik"; "kidsnote" ] allowed
+
+let test_legacy_config_dir () =
+  with_temp_dir "coord-worktree-policy-legacy" @@ fun base ->
+  let dir = Filename.concat base "config" in
+  mkdir_p dir;
+  write_file (Filename.concat dir "tool_policy.toml")
+    (policy_with_orgs [ "legacy-org" ]);
+  let allowed, _denied = CW.load_git_clone_policy ~base_path:base in
+  check (list string) "legacy <base>/config/ honoured when canonical missing"
+    [ "legacy-org" ] allowed
+
+let test_canonical_takes_priority () =
+  with_temp_dir "coord-worktree-policy-priority" @@ fun base ->
+  let canon = Filename.concat (Filename.concat base ".masc") "config" in
+  mkdir_p canon;
+  write_file (Filename.concat canon "tool_policy.toml")
+    (policy_with_orgs [ "canonical" ]);
+  let legacy = Filename.concat base "config" in
+  mkdir_p legacy;
+  write_file (Filename.concat legacy "tool_policy.toml")
+    (policy_with_orgs [ "legacy" ]);
+  let allowed, _denied = CW.load_git_clone_policy ~base_path:base in
+  check (list string) "canonical wins over legacy when both exist"
+    [ "canonical" ] allowed
+
+let test_neither_present () =
+  with_temp_dir "coord-worktree-policy-none" @@ fun base ->
+  let allowed, denied = CW.load_git_clone_policy ~base_path:base in
+  check (list string) "no policy file → empty allowed" [] allowed;
+  check (list string) "no policy file → empty denied" [] denied
+
+let () =
+  Alcotest.run "coord_worktree policy path"
+    [
+      ( "load_git_clone_policy",
+        [
+          test_case "canonical .masc/config/" `Quick test_canonical_masc_config;
+          test_case "legacy <base>/config/" `Quick test_legacy_config_dir;
+          test_case "canonical takes priority" `Quick test_canonical_takes_priority;
+          test_case "neither path present" `Quick test_neither_present;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

`Coord_worktree.load_git_clone_policy` resolved `<base_path>/config/tool_policy.toml` only, ignoring the canonical `<base_path>/.masc/config/tool_policy.toml` that the rest of the codebase uses. Result: empty `allowed_orgs` for keepers routed through this loader, surfacing as `auto_provision_clone_failed: ... No allowed orgs configured for git clone (git_clone.allowed_orgs in tool_pol...)` (visible repeatedly for `nick0cave`, `qa-king` in `~/me/.masc/logs/system_log_2026-04-26.jsonl`).

The fix uses the same SSOT primitive (`Common.masc_dir_from_base_path`) that `Config_dir_resolver.path_from_local_masc` uses, then falls back to the legacy `<base>/config/` location for older layouts. No behaviour change for deployments that only had the legacy path; new behaviour for any deployment that has `.masc/config/`.

## Why this matters (root cause for task-102)

User report (2026-04-26): "오케이 아직도 docker 생긴 다음 아무도 거기서 작업 하지 않음." Catch-22: keepers cannot land a fix for docker because docker keeps rejecting `git_clone`. Three independent lookup paths exist:

| Lookup | Module | Path source | Status |
|---|---|---|---|
| `Keeper_tool_policy.git_clone_allowed_orgs ()` | `Keeper_tool_policy` | global cached | ok |
| `Keeper_tool_policy_config.git_clone_allowed_orgs cfg` | `Keeper_tool_policy_config` | `Config_dir_resolver` | ok |
| `Coord_worktree.load_git_clone_policy ~base_path` | `Coord_worktree` | direct concat (this file) | **buggy** |

Only the third path was missing the `.masc/` segment. After this PR, all three resolve to the same canonical file.

## Changes

- `lib/coord/coord_worktree.ml`: add canonical-first / legacy-fallback ladder via `Common.masc_dir_from_base_path`. SSOT comment references `Config_dir_resolver.path_from_local_masc`.
- `test/test_coord_worktree_policy_path.ml` (new): regression covering canonical-only, legacy-only, both-present (canonical wins), and neither-present.
- `test/dune`: wire the new test in both `tests` and `tests` mirror lists.

## Test plan

- [x] `dune build` (`lib/coord/`) on top of `origin/main` clean
- [x] `dune exec test/test_coord_worktree_policy_path.exe` — 4/4 OK
- [ ] After merge + server restart: tail `~/me/.masc/logs/system_log_$(date +%Y-%m-%d).jsonl` and confirm `grep -c "No allowed orgs configured" $LOG` == 0 for fresh attempts; `auto_provision_clone_failed` events stop for `nick0cave` / `qa-king`.

## Out of scope (sibling defects, separate tasks)

- task-103: sandbox worktree pre-setup automation (`fatal: not a git repository: .../keeper-sangsu-agent-task-100`).
- task-104: git_clone owner parser — derive owner from URL, never infer from local context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)