### PR TITLE
refactor(design-system): swap tool-picker ToolRow to ActionButton block + pressed (PR-CS7)

### DIFF
--- a/dashboard/src/components/tool-executor/tool-picker.ts
+++ b/dashboard/src/components/tool-executor/tool-picker.ts
@@ -17,16 +17,20 @@ function ToolRow({ tool, isSelected }: { tool: McpToolSchema; isSelected: boolea
   const isReadOnly = tool.annotations?.readOnlyHint === true
   const isDeprecated = tool.annotations?.deprecated === true
   return html`
-    <button type="button" class="w-full text-left px-3 py-2 rounded transition-colors cursor-pointer
-      ${isSelected ? 'bg-[var(--accent-12)] border border-[var(--accent-30)]' : 'hover:bg-[var(--white-6)] border border-transparent'}
-      ${isDeprecated ? 'opacity-50' : ''}" onClick=${() => selectTool(tool)}>
+    <${ActionButton}
+      block
+      variant=${isSelected ? 'ghost' : 'subtle'}
+      size="md"
+      pressed=${isSelected}
+      class=${`text-left px-3 py-2 ${isDeprecated ? 'opacity-50' : ''}`}
+      onClick=${() => selectTool(tool)}>
       <div class="flex items-center gap-1.5">
         <span class="text-xs text-[var(--color-fg-secondary)] font-mono truncate flex-1">${tool.name}</span>
         ${isDestructive ? html`<${CountBadge} tone="bad">D<//>` : null}
         ${isReadOnly ? html`<${CountBadge} tone="ok">R<//>` : null}
       </div>
       <div class="text-3xs text-[var(--color-fg-muted)] mt-0.5 line-clamp-1">${tool.description}</div>
-    </button>
+    <//>
   `
 }
 


### PR DESCRIPTION
## Summary

CS3 (#10673)에서 의도적으로 raw `<button>`으로 보존했던 tool-picker `ToolRow`를 swap. CS4 (#10679)의 `ActionButton.pressed` prop + `block` prop 조합으로 list-item-as-button 패턴 처리.

## 변경

`dashboard/src/components/tool-executor/tool-picker.ts` `ToolRow`:

**Before** (선택 가능 list item):
```tsx
<button type="button" class="w-full text-left px-3 py-2 rounded transition-colors cursor-pointer
  ${isSelected ? 'bg-[var(--accent-12)] border border-[var(--accent-30)]' : 'hover:bg-[var(--white-6)] border border-transparent'}
  ${isDeprecated ? 'opacity-50' : ''}" onClick=${() => selectTool(tool)}>
  <div class="flex items-center gap-1.5">...</div>
  <div class="text-3xs ...">${tool.description}</div>
</button>
```

**After**:
```tsx
<${ActionButton}
  block
  variant=${isSelected ? 'ghost' : 'subtle'}
  size="md"
  pressed=${isSelected}
  class=${`text-left px-3 py-2 ${isDeprecated ? 'opacity-50' : ''}`}
  onClick=${() => selectTool(tool)}>
  <div class="flex items-center gap-1.5">...</div>
  <div class="text-3xs ...">${tool.description}</div>
<//>
```

## 매핑

| 원본 동작 | ActionButton 매핑 |
|----------|-------------------|
| `w-full` | `block=true` |
| `text-left` | `class="text-left"` (BASE는 정렬 미지정) |
| `px-3 py-2` | `class="px-3 py-2"` (size=md 기본 위에 override) |
| selected: `bg-accent-12 + border-accent-30` | variant=ghost + pressed=true |
| unselected: `hover:bg-white-6 + border-transparent` | variant=subtle |
| `opacity-50` (deprecated) | dynamic class |

## 이점

- **a11y**: aria-pressed 자동 (toggle group semantic) + focus-visible:ring
- **인터랙션**: active:scale-[0.97] 적용
- **유지보수**: 모든 button surface 단일 진입점

## 누적 swap (tool-picker.ts)

| PR | Buttons | 상태 |
|----|---------|------|
| CS4 #10679 | 1 (tier filter) | MERGED |
| CS7 (this) | 1 (ToolRow list item) | OPEN |
| **합계** | **2 / 2** | inline `<button>` 0건 ✅ |

## Test plan

- [ ] CI green
- [ ] tool-picker 도구 선택 시 selected look (bg + border) 정상
- [ ] deprecated 도구 opacity-50 정상
- [ ] 키보드 focus ring 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)
