### PR TITLE
feat(dashboard): localize 6 chips/sentences across 2 components (round-34)

### DIFF
--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -103,13 +103,13 @@ export function ConnectorPathsStrip({ connectors }: { connectors: GateConnectorI
         ? html`
             <div id="connector-paths-body" class="space-y-1.5 border-t border-[var(--color-border-default)] px-3 py-2">
               ${paths.connectorsDir
-                ? html`<${PathRow} label="Connectors" value=${paths.connectorsDir} hint="sidecar names.json / status.json 위치" />`
+                ? html`<${PathRow} label="커넥터" value=${paths.connectorsDir} hint="sidecar names.json / status.json 위치" />`
                 : null}
               ${paths.logsDir
-                ? html`<${PathRow} label="Logs" value=${paths.logsDir} hint="sidecar 로그 디렉토리" />`
+                ? html`<${PathRow} label="로그" value=${paths.logsDir} hint="sidecar 로그 디렉토리" />`
                 : null}
-              <${PathRow} label="Keepers" value=${paths.keepersDir} hint="keeper TOML 설정 파일" />
-              <${PathRow} label="Sidecars" value=${paths.sidecarsDir} hint="sidecar 스크립트 (run.sh) 위치" />
+              <${PathRow} label="키퍼" value=${paths.keepersDir} hint="keeper TOML 설정 파일" />
+              <${PathRow} label="사이드카" value=${paths.sidecarsDir} hint="sidecar 스크립트 (run.sh) 위치" />
             </div>
           `
         : null}

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1053,10 +1053,10 @@ function ConnectorLivePanel({
                 </div>
                 <div class="text-2xs text-[var(--color-status-warn)]/80">
                   <div>
-                    <span class="font-medium">Cause: </span> no sidecar status file has been observed at <code class="rounded bg-[var(--white-4)] px-1">${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}</code>.
+                    <span class="font-medium">원인: </span> sidecar status 파일이 <code class="rounded bg-[var(--white-4)] px-1">${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}</code> 에서 관찰되지 않았습니다.
                   </div>
                   <div class="mt-1">
-                    <span class="font-medium">Next: </span> click <strong>Start</strong> to spawn via the backend, or copy the command below to run it from a terminal. Use <strong>status</strong> and <strong>tail logs</strong> if it stays offline.
+                    <span class="font-medium">다음: </span> <strong>Start</strong> 버튼으로 backend 를 통해 spawn 하거나, 아래 명령을 복사해 터미널에서 실행하세요. 오프라인이 지속되면 <strong>status</strong> 와 <strong>tail logs</strong> 를 사용하세요.
                   </div>
                 </div>
                 <div class="mt-2 grid grid-cols-1 gap-1.5">


### PR DESCRIPTION
## Summary

대시보드 라운드 34 — connector 영역 path label 4종 + 영문 안내 문장 한국어화.

| File | Element | Before | After |
|---|---|---|---|
| connector-paths-strip.ts:106 | PathRow label | Connectors | 커넥터 |
| connector-paths-strip.ts:109 | PathRow label | Logs | 로그 |
| connector-paths-strip.ts:111 | PathRow label | Keepers | 키퍼 |
| connector-paths-strip.ts:112 | PathRow label | Sidecars | 사이드카 |
| connector-status.ts:1056 | offline reason | Cause: no sidecar status file ... | 원인: sidecar status 파일이 ... 관찰되지 않았습니다 |
| connector-status.ts:1059 | offline next-step | Next: click Start to spawn ... | 다음: Start 버튼으로 backend 를 통해 spawn ... |

## Test fixture coupling 검증

| 단어 | Test 등장 | 충돌 |
|---|---|---|
| Connectors | \`control.test.ts:62\` \`not.toContain('Connectors')\` 단언 | ❌ — mock body 단언, paths-strip label 변경과 독립 (assertion 은 더 통과하기 쉬워짐) |
| Logs / Keepers / Sidecars | -- | ❌ |

## 보존 (영문 유지)

| 위치 | 단어 | 이유 |
|---|---|---|
| connector-status.ts:1059 | Start, status, tail logs | 실제 버튼 라벨 + CLI 명령 (한국어 문장 내 인용) |
| connector-onboarding.ts:63,81 | Start / Start All | 동일 — 버튼 라벨 인용 |
| lab-inspector.ts:123 / doctor-panel.ts:299 | Doctor | 진단 도구 명, 다음 라운드 검토 |

## Test plan

- [ ] \`pnpm dev\` — connector path strip 펼침 + offline connector 의 안내 텍스트 시각 확인
- [ ] \`rg '>[A-Z][a-z]+<' dashboard/src/components --type ts -g '!*.test.ts'\` 잔여 chip sweep

## 라운드 누적 (23-34)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31 | #10685 | MERGED | 9 |
| 32 | #10689 | MERGED | 5 |
| 33 | #10690 | MERGED | 7 |
| 34 | this | Draft | **6** |

누적 chips ≈ **84**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)