### PR TITLE
diag(keeper-tools-oas): capture backtrace on EDEADLK (#10682)

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -335,11 +335,29 @@ let make_keeper_tool_handler
           (true, truncated_result)
         end
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+        (* #10682: capture backtrace BEFORE any other operation that might
+           raise/handle exceptions and clobber the raw_backtrace.  Used
+           below to attach a stack to mutex EDEADLK ("Resource deadlock
+           avoided") errors so the exact Stdlib.Mutex site can be
+           identified — without this, the issue body for #10682 had to
+           speculate across 5 candidate sites because no caller wrote
+           the backtrace anywhere. *)
+        let raw_bt = Printexc.get_raw_backtrace () in
         let ts = Time_compat.now () in
         let duration_ms =
           int_of_float ((ts -. t0) *. 1000.0) in
         let count = prior_fails + 1 in
         let error_text = Printexc.to_string exn in
+        let edeadlk_backtrace =
+          (* Mutex EDEADLK signature on macOS / Linux pthread errorcheck
+             mutexes is exactly this Sys_error message; targeting it
+             keeps backtrace dump narrow (rare event) instead of
+             spamming every routine tool error. *)
+          if String_util.contains_substring error_text
+               "Resource deadlock avoided"
+          then Some (Printexc.raw_backtrace_to_string raw_bt)
+          else None
+        in
         Hashtbl.replace failure_counts key count;
         Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
         !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:false ~duration_ms;
@@ -359,6 +377,11 @@ let make_keeper_tool_handler
           name count max_consecutive_failures
           (Printexc.to_string exn) in
         Log.Keeper.error "%s" msg;
+        (match edeadlk_backtrace with
+         | Some bt ->
+             Log.Keeper.error
+               "tool %s EDEADLK backtrace (#10682):\n%s" name bt
+         | None -> ());
         let normalized_exn = normalize_tool_result ~success:false msg in
         (try
           Keeper_types_support.append_jsonl_line


### PR DESCRIPTION
## 문제 (#10682)

`#10649` mutex 마이그레이션 후에도 `masc_tasks` 도구 호출에서 `Sys_error("Mutex.lock: Resource deadlock avoided")` 재발. 5개 candidate Stdlib.Mutex 사이트(mention, coord_utils_backend_setup, coord_verification_store, heuristic_metrics, relay) 중 어느 것이 trigger인지 판정 불가 — 어디에서도 stack trace를 기록하지 않음.

이슈 본문 자체가 "다음 단계 후보 1: EDEADLK 발생 시 stack trace를 capture해 정확한 mutex 사이트를 결정"으로 시작.

## 변경 (진단 우선)

`lib/keeper/keeper_tools_oas.ml:337` `with exn ->` 핸들러에서:

1. `Printexc.get_raw_backtrace ()` 를 핸들러 첫 줄에서 호출 — 다른 어떤 코드보다 먼저 실행해 backtrace clobber 방지
2. error_text가 `"Resource deadlock avoided"` 포함 시에만 `Printexc.raw_backtrace_to_string` 으로 포맷 + `Log.Keeper.error \"... EDEADLK backtrace (#10682):\n%s\"` 로 기록
3. EDEADLK 외 일반 tool error는 backtrace 미출력 (log noise 회피)

## 비용

- 정상 경로: 영향 없음 (raw_backtrace 캡처는 ~free, 포맷 string은 EDEADLK 시에만)
- EDEADLK 경로: 1회 발생당 1줄 추가 (drama-free, 다음 fix PR을 위한 결정적 신호)

## 후속 PR (별도)

이 PR 머지 후 production에서 1회 EDEADLK 발생하면 stack 의 mutex 식별. 해당 사이트를:
- (A) Eio.Mutex로 마이그레이션 (same-domain re-entry safe), 또는
- (B) held-across-yield 패턴 제거 (mutex unlock 후 yielding op 호출)

`worktree_live_context.ml:165` 의 per-repo `gate` Stdlib.Mutex가 `current_status_lines_uncached → run_git_capture_lines` (Eio yield) 가로질러 잡혀있는 건 이미 발견 — 다만 masc_tasks call path 와 직접 연결 증거 없어 별도 PR로 처리 예정 (관련 이슈 발행 가능).

## 테스트

- `dune build @check` EXIT=0
- `dune build @runtest` EXIT=0 (regression 없음)
- 단순 substring match + Printexc API 사용 — 별도 unit test 없이 integration validation으로 충분

Refs #10682

🤖 Generated with [Claude Code](https://claude.com/claude-code)