### PR TITLE
feat(dashboard): localize Doctor → 진단 across 2 components (round-35)

### DIFF
--- a/dashboard/src/components/doctor-panel.test.ts
+++ b/dashboard/src/components/doctor-panel.test.ts
@@ -89,13 +89,13 @@ describe('summaryLine', () => {
   it('formats aggregate with Korean middot separators', () => {
     const summary: DoctorSummary = { total: 6, ok: 3, warn: 2, error: 1 }
     expect(summaryLine(summary)).toBe(
-      '6 Doctor · 정상 3 · 경고 2 · 오류 1',
+      '6건 진단 · 정상 3 · 경고 2 · 오류 1',
     )
   })
   it('all-ok summary shows zeros', () => {
     const summary: DoctorSummary = { total: 6, ok: 6, warn: 0, error: 0 }
     expect(summaryLine(summary)).toBe(
-      '6 Doctor · 정상 6 · 경고 0 · 오류 0',
+      '6건 진단 · 정상 6 · 경고 0 · 오류 0',
     )
   })
 })

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -78,11 +78,11 @@ export function doctorHeading(entry: DoctorEntry): string {
   return entry.name.charAt(0).toUpperCase() + entry.name.slice(1)
 }
 
-// Aggregate breakdown string, e.g. "6 Doctor · 정상 3 · 경고 2 · 오류 1".
+// Aggregate breakdown string, e.g. "6건 진단 · 정상 3 · 경고 2 · 오류 1".
 // Korean separator (` · `) matches the CLI footer in `doctor all`.
 export function summaryLine(summary: DoctorSummary): string {
   return (
-    `${summary.total} Doctor · ` +
+    `${summary.total}건 진단 · ` +
     `정상 ${summary.ok} · 경고 ${summary.warn} · 오류 ${summary.error}`
   )
 }
@@ -278,7 +278,7 @@ function DoctorEntryCard({ entry }: { entry: DoctorEntry }) {
         </span>
       </button>
       <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
-        ${entry.kind === 'config' ? 'Config Doctor' : `${entry.name} sidecar`} · exit ${entry.exit_code}
+        ${entry.kind === 'config' ? '설정 진단' : `${entry.name} sidecar`} · exit ${entry.exit_code}
       </div>
       ${expanded.value
         ? entry.kind === 'sidecar'
@@ -296,11 +296,11 @@ export function DoctorPanel() {
 
   return html`
     <div class="space-y-4">
-      <${Card} title="Doctor" class="section">
+      <${Card} title="진단" class="section">
         <${AsyncContainer}
           state=${doctorEnvelope.state}
-          loadingMessage="Doctor 데이터를 불러오는 중..."
-          emptyMessage="Doctor 데이터가 없습니다."
+          loadingMessage="진단 데이터를 불러오는 중..."
+          emptyMessage="진단 데이터가 없습니다."
           render=${(data: DoctorEnvelope) => html`
             <div class="space-y-4">
               <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-4">

--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -120,7 +120,7 @@ export function LabInspector() {
             <${InspectorTabButton} id="overview" label="개요" />
             <${InspectorTabButton} id="features" label="피처 플래그" />
             <${InspectorTabButton} id="config" label="서버 설정" />
-            <${InspectorTabButton} id="doctor" label="Doctor" />
+            <${InspectorTabButton} id="doctor" label="진단" />
           </div>
         </div>
       <//>


### PR DESCRIPTION
## Summary

대시보드 라운드 35 — \`Doctor\` 진단 패널 사용자 노출 문자열 한국어화. 코드 식별자/타입/API 엔드포인트는 모두 보존.

| File | Element | Before | After |
|---|---|---|---|
| lab-inspector.ts:123 | InspectorTabButton label | Doctor | 진단 |
| doctor-panel.ts:299 | Card title | Doctor | 진단 |
| doctor-panel.ts:302 | AsyncContainer loadingMessage | Doctor 데이터를 불러오는 중... | 진단 데이터를 불러오는 중... |
| doctor-panel.ts:303 | AsyncContainer emptyMessage | Doctor 데이터가 없습니다. | 진단 데이터가 없습니다. |
| doctor-panel.ts:281 | Config card subtitle | Config Doctor | 설정 진단 |
| doctor-panel.ts:85 | summaryLine 출력 형식 | \`6 Doctor · 정상 3 ...\` | \`6건 진단 · 정상 3 ...\` |

## Test 동기 변경

\`doctor-panel.test.ts:91-99\` 의 2 assertion 이 \`summaryLine\` 출력 문자열을 정확히 매칭 (\`'6 Doctor · ...'\`). 동일 PR 에서 sync:

\`\`\`diff
-      '6 Doctor · 정상 3 · 경고 2 · 오류 1',
+      '6건 진단 · 정상 3 · 경고 2 · 오류 1',
\`\`\`

## 보존 (영문/식별자 유지)

| 위치 | 식별자 | 종류 | 이유 |
|---|---|---|---|
| 전체 | \`DoctorEntry\` / \`DoctorKind\` / \`DoctorSummary\` / \`DoctorEnvelope\` / \`DoctorSeverity\` | TypeScript 타입 | 코드 identifier — 변경 불가 |
| 전체 | \`DoctorPanel\` / \`DoctorEntryCard\` | Preact 컴포넌트명 | 코드 identifier |
| 전체 | \`loadDoctor\` / \`refreshDoctor\` / \`doctorEnvelope\` / \`doctorHeading\` | 함수명 | 코드 identifier |
| backend | \`/api/v1/dashboard/doctor\` | API 엔드포인트 | URL 경로 |
| OCaml | \`Doctor_dispatch\` | 백엔드 모듈명 | cross-language 식별자 (주석에서 참조) |
| connector-status.ts:1059 (round-34) | \`Start\`, \`status\`, \`tail logs\` | UI 버튼/CLI 명령 | 실제 라벨 인용 |

## Test plan

- [ ] \`pnpm dev\` — Lab Inspector 진단 탭 + 진단 카드 시각 확인
- [ ] \`pnpm test doctor-panel\` — summaryLine 2 assertion 통과 확인 (vitest infra 복구 후)

## 라운드 누적 (23-35)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31 | #10685 | MERGED | 9 |
| 32 | #10689 | MERGED | 5 |
| 33 | #10690 | MERGED | 7 |
| 34 | #10695 | MERGED | 6 |
| 35 | this | Draft | **5** (Doctor) |

누적 chips ≈ **89**.

## Why Draft

#10645 (vitest infra) 미해결. summaryLine assertion sync 가 동일 PR 에 포함되어 vitest 복구 즉시 검증 가능. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)