### PR TITLE
fix(watchdog): extract to standalone module, cover autoboot path

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -560,6 +560,7 @@
    keeper_invariant_check
    keeper_trace_emit
    keeper_supervisor
+   keeper_stale_watchdog
    keeper_runtime
    keeper_turn_setup
    keeper_turn_up_args

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -122,6 +122,7 @@ type snapshot = {
   fiber_wakeup_flag : bool;
   consecutive_noop_count : int;
   idle_seconds : int;
+  last_turn_ts : float;
 }
 
 let ksm_phase_to_string = function
@@ -470,6 +471,7 @@ let observe
       (let last = entry.meta.runtime.proactive_rt.last_ts in
        if last <= 0.0 then 0
        else int_of_float (max 0.0 (Time_compat.now () -. last)));
+    last_turn_ts = entry.meta.runtime.usage.last_turn_ts;
   }
 
 (* Fleet fold — observe every currently-registered keeper under
@@ -558,4 +560,5 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
     "fiber_wakeup_flag", `Bool s.fiber_wakeup_flag;
     "consecutive_noop_count", `Int s.consecutive_noop_count;
     "idle_seconds", `Int s.idle_seconds;
+    "last_turn_ts", `Float s.last_turn_ts;
   ]

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -184,6 +184,11 @@ type snapshot = {
       (** Wall-clock seconds since the keeper last did something the
           metrics layer treated as substantive. Compared against
           [proactive.idle_sec] to gate scheduled-autonomous turns. *)
+  last_turn_ts : float;
+      (** Raw [runtime.usage.last_turn_ts] from the registry entry.
+          Exposed for watchdog staleness diagnosis — the stale watchdog
+          in [Keeper_supervisor] reads this exact field. A value of [0.0]
+          means the registry never recorded a completed turn. *)
 }
 
 (** Derive a composite snapshot from a live registry entry.

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -2402,6 +2402,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
        behavioral_stats no longer consumed by build_prompt. *)
     dispatch_fiber_started ~base_path:ctx.config.base_path live_meta.name;
     publish_keeper_started ~live_meta;
+    Keeper_stale_watchdog.fork_stale_watchdog ctx live_meta reg;
     Eio.Fiber.fork ~sw:ctx.sw (fun () ->
       let record_crash failure_reason =
         record_keeper_crashed

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -1,0 +1,105 @@
+(** Stale-turn watchdog — standalone fiber for keeper liveness detection.
+
+    Extracted from [Keeper_supervisor] to avoid circular dependency with
+    [Keeper_keepalive]. Both modules call [fork_stale_watchdog] through
+    this shared implementation.
+
+    Two stall detection modes:
+    1. Idle stall: [last_turn_ts] older than 300s while [Running].
+    2. Failure loop: [consecutive_noop_count >= 3] — catches keepers in
+       LLM timeout loops where [last_turn_ts] stays fresh because each
+       failed turn updates it.
+
+    On detection, sets [fiber_stop] and emits a stale broadcast so the
+    supervisor's [sweep_and_recover] can restart the keeper.
+
+    @since PR #10670 — extracted from Keeper_supervisor. *)
+
+open Keeper_types
+
+let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
+    (reg : Keeper_registry.registry_entry) =
+  let base_path = ctx.config.base_path in
+  let stale_threshold_sec = 300.0 in
+  let watchdog_poll_sec = 30.0 in
+  let noop_threshold = 3 in
+  let last_broadcast_ts = ref 0.0 in
+  Eio.Fiber.fork ~sw:ctx.sw (fun () ->
+    let rec watchdog_loop () =
+      if Atomic.get reg.fiber_stop then ()
+      else begin
+        Eio.Fiber.yield ();
+        let now = Time_compat.now () in
+        (try
+           match Keeper_registry.get ~base_path meta.name with
+           | Some entry
+             when entry.phase = Keeper_state_machine.Running ->
+             let last_turn = entry.meta.runtime.usage.last_turn_ts in
+             let idle_stale =
+               last_turn > 0.0 && now -. last_turn > stale_threshold_sec
+             in
+             let noop_count =
+               entry.meta.runtime.proactive_rt.consecutive_noop_count
+             in
+             let failure_loop = noop_count >= noop_threshold in
+             let stale = idle_stale || failure_loop in
+             Log.Keeper.info
+               "%s: watchdog tick noop=%d idle_stale=%b failure_loop=%b stale=%b last_turn=%.0f"
+               meta.name noop_count idle_stale failure_loop stale last_turn;
+             let cooldown_ok =
+               !last_broadcast_ts = 0.0
+               || now -. !last_broadcast_ts > stale_threshold_sec
+             in
+             if stale && cooldown_ok then begin
+               let reason_desc =
+                 if idle_stale
+                 then Printf.sprintf "idle %.0fs" (now -. last_turn)
+                 else Printf.sprintf "failure-loop noop=%d" noop_count
+               in
+               Keeper_registry.set_failure_reason ~base_path meta.name
+                 (Some (Keeper_registry.Stale_turn_timeout
+                          (now -. last_turn)));
+               Atomic.set reg.fiber_stop true;
+               Log.Keeper.error
+                 "%s: stale watchdog terminating fiber (%s)"
+                 meta.name reason_desc;
+               (try
+                  Keeper_execution_receipt.emit_stale_keeper_broadcast
+                    ctx.config
+                    ~keeper_name:meta.name
+                    ~agent_name:meta.agent_name
+                    ~trace_id:
+                      (Keeper_id.Trace_id.to_string
+                         entry.meta.runtime.trace_id)
+                    ~generation:entry.meta.runtime.generation
+                    ~stale_seconds:(now -. last_turn)
+                    ~last_turn_ts:last_turn;
+                  last_broadcast_ts := now
+                with
+                | Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
+                  Log.Keeper.warn
+                    "%s: stale broadcast emit failed (restart still triggered): %s"
+                    meta.name (Printexc.to_string exn))
+             end
+           | None ->
+             Log.Keeper.warn "%s: watchdog: registry entry NOT FOUND" meta.name
+           | Some entry ->
+             Log.Keeper.info
+               "%s: watchdog: phase=%s (not Running, skipping)"
+               meta.name
+               (Keeper_state_machine.phase_to_string entry.phase)
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Keeper.warn
+             "%s: stale watchdog tick failed (suppressed): %s"
+             meta.name (Printexc.to_string exn));
+        (try Eio.Time.sleep ctx.clock watchdog_poll_sec with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | _ -> ());
+        watchdog_loop ()
+      end
+    in
+    try watchdog_loop ()
+    with Eio.Cancel.Cancelled _ -> ())

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -1,0 +1,18 @@
+(** Stale-turn watchdog — standalone fiber for keeper liveness detection.
+
+    @since PR #10670 — extracted from Keeper_supervisor. *)
+
+open Keeper_types
+
+val fork_stale_watchdog :
+  'a context -> keeper_meta -> Keeper_registry.registry_entry -> unit
+(** Fork a stale-turn watchdog fiber for the given keeper.
+
+    Two detection modes:
+    - Idle stall: [last_turn_ts] older than 300s while [Running].
+    - Failure loop: [consecutive_noop_count >= 3] — catches keepers in
+      LLM timeout loops where [last_turn_ts] stays fresh.
+
+    On detection, sets [fiber_stop] and emits a stale broadcast. The
+    supervisor's [sweep_and_recover] picks up the stopped fiber and
+    restarts with exponential backoff. *)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -133,9 +133,16 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
      not produced a turn for longer than stale_threshold_sec, the watchdog
      signals fiber stop so the supervisor restarts the keeper automatically.
      This closes the "KSM=Running but no live turn" gap where the previous
-     implementation only emitted a broadcast without triggering recovery. *)
+     implementation only emitted a broadcast without triggering recovery.
+
+     Two stall detection modes:
+     1. Idle stall: no turn executed for > stale_threshold_sec
+     2. Failure loop: turns keep running but all fail (consecutive_noop_count
+        >= 3) — the turn timeout loop keeps last_turn_ts fresh so the idle
+        check alone never fires. *)
   let stale_threshold_sec = 300.0 in
   let watchdog_poll_sec = 30.0 in
+  let noop_threshold = 3 in
   let last_broadcast_ts = ref 0.0 in
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     let rec watchdog_loop () =
@@ -148,29 +155,31 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
            | Some entry
              when entry.phase = Keeper_state_machine.Running ->
              let last_turn = entry.meta.runtime.usage.last_turn_ts in
-             let stale =
+             let idle_stale =
                last_turn > 0.0 && now -. last_turn > stale_threshold_sec
              in
+             let noop_count =
+               entry.meta.runtime.proactive_rt.consecutive_noop_count
+             in
+             let failure_loop = noop_count >= noop_threshold in
+             let stale = idle_stale || failure_loop in
              let cooldown_ok =
                !last_broadcast_ts = 0.0
                || now -. !last_broadcast_ts > stale_threshold_sec
              in
              if stale && cooldown_ok then begin
-               (* Fail-closed ordering: signal fiber stop + failure reason
-                  FIRST so sweep_and_recover restarts unconditionally. The
-                  broadcast is best-effort; if it throws, the keeper still
-                  gets restarted instead of being silently stuck. *)
+               let reason_desc =
+                 if idle_stale
+                 then Printf.sprintf "idle %.0fs" (now -. last_turn)
+                 else Printf.sprintf "failure-loop noop=%d" noop_count
+               in
                Keeper_registry.set_failure_reason ~base_path meta.name
                  (Some (Keeper_registry.Stale_turn_timeout
                           (now -. last_turn)));
                Atomic.set reg.fiber_stop true;
                Log.Keeper.error
-                 "%s: stale watchdog terminating fiber (%.0fs since last turn)"
-                 meta.name (now -. last_turn);
-               (* Broadcast wrapped separately. last_broadcast_ts is only
-                  advanced on successful emit so a failed broadcast retries
-                  on the next tick instead of being suppressed for
-                  stale_threshold_sec. *)
+                 "%s: stale watchdog terminating fiber (%s)"
+                 meta.name reason_desc;
                (try
                   Keeper_execution_receipt.emit_stale_keeper_broadcast
                     ctx.config

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -113,6 +113,10 @@ let publish_phase_lifecycle ~phase keeper_name detail () =
   publish_lifecycle ~event:(Keeper_lifecycle_events.Phase_event phase)
     keeper_name detail ()
 
+(* ── Stale-turn watchdog (delegated to Keeper_stale_watchdog) ── *)
+
+let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog
+
 (* ── Supervised fiber launch ─────────────────────────────── *)
 
 let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
@@ -127,93 +131,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
          "%s: Fiber_started rejected during supervised launch: %s"
          meta.name
          (Keeper_state_machine.transition_error_to_string err));
-  (* Stale-turn watchdog (#fleet-stall 2026-04-26 Step 3 → Step 4).
-     Runs in its own Eio fiber so it stays responsive even if the heartbeat
-     fiber is blocked on a long synchronous call. When a Running keeper has
-     not produced a turn for longer than stale_threshold_sec, the watchdog
-     signals fiber stop so the supervisor restarts the keeper automatically.
-     This closes the "KSM=Running but no live turn" gap where the previous
-     implementation only emitted a broadcast without triggering recovery.
-
-     Two stall detection modes:
-     1. Idle stall: no turn executed for > stale_threshold_sec
-     2. Failure loop: turns keep running but all fail (consecutive_noop_count
-        >= 3) — the turn timeout loop keeps last_turn_ts fresh so the idle
-        check alone never fires. *)
-  let stale_threshold_sec = 300.0 in
-  let watchdog_poll_sec = 30.0 in
-  let noop_threshold = 3 in
-  let last_broadcast_ts = ref 0.0 in
-  Eio.Fiber.fork ~sw:ctx.sw (fun () ->
-    let rec watchdog_loop () =
-      if Atomic.get reg.fiber_stop then ()
-      else begin
-        Eio.Fiber.yield ();
-        let now = Time_compat.now () in
-        (try
-           match Keeper_registry.get ~base_path meta.name with
-           | Some entry
-             when entry.phase = Keeper_state_machine.Running ->
-             let last_turn = entry.meta.runtime.usage.last_turn_ts in
-             let idle_stale =
-               last_turn > 0.0 && now -. last_turn > stale_threshold_sec
-             in
-             let noop_count =
-               entry.meta.runtime.proactive_rt.consecutive_noop_count
-             in
-             let failure_loop = noop_count >= noop_threshold in
-             let stale = idle_stale || failure_loop in
-             let cooldown_ok =
-               !last_broadcast_ts = 0.0
-               || now -. !last_broadcast_ts > stale_threshold_sec
-             in
-             if stale && cooldown_ok then begin
-               let reason_desc =
-                 if idle_stale
-                 then Printf.sprintf "idle %.0fs" (now -. last_turn)
-                 else Printf.sprintf "failure-loop noop=%d" noop_count
-               in
-               Keeper_registry.set_failure_reason ~base_path meta.name
-                 (Some (Keeper_registry.Stale_turn_timeout
-                          (now -. last_turn)));
-               Atomic.set reg.fiber_stop true;
-               Log.Keeper.error
-                 "%s: stale watchdog terminating fiber (%s)"
-                 meta.name reason_desc;
-               (try
-                  Keeper_execution_receipt.emit_stale_keeper_broadcast
-                    ctx.config
-                    ~keeper_name:meta.name
-                    ~agent_name:meta.agent_name
-                    ~trace_id:
-                      (Keeper_id.Trace_id.to_string
-                         entry.meta.runtime.trace_id)
-                    ~generation:entry.meta.runtime.generation
-                    ~stale_seconds:(now -. last_turn)
-                    ~last_turn_ts:last_turn;
-                  last_broadcast_ts := now
-                with
-                | Eio.Cancel.Cancelled _ as e -> raise e
-                | exn ->
-                  Log.Keeper.warn
-                    "%s: stale broadcast emit failed (restart still triggered): %s"
-                    meta.name (Printexc.to_string exn))
-             end
-           | _ -> ()
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-           Log.Keeper.warn
-             "%s: stale watchdog tick failed (suppressed): %s"
-             meta.name (Printexc.to_string exn));
-        (try Eio.Time.sleep ctx.clock watchdog_poll_sec with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | _ -> ());
-        watchdog_loop ()
-      end
-    in
-    try watchdog_loop ()
-    with Eio.Cancel.Cancelled _ -> ());
+  fork_stale_watchdog ctx meta reg;
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     let resolved = ref false in
     let resolve_done value =

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -20,6 +20,21 @@ val supervise_keepalive :
     On fiber termination, resolves the Promise and publishes
     keeper-lifecycle events via Event_bus. *)
 
+(** {1 Watchdog} *)
+
+val fork_stale_watchdog :
+  'a context -> keeper_meta -> Keeper_registry.registry_entry -> unit
+(** Fork a stale-turn watchdog fiber for the given keeper.
+
+    Two detection modes:
+    - Idle stall: [last_turn_ts] older than 300s while [Running].
+    - Failure loop: [consecutive_noop_count >= 3] — catches keepers in
+      LLM timeout loops where [last_turn_ts] stays fresh.
+
+    On detection, sets [fiber_stop] and emits a stale broadcast. The
+    supervisor's [sweep_and_recover] picks up the stopped fiber and
+    restarts with exponential backoff. *)
+
 (** {1 Sweep and Recovery} *)
 
 val sweep_and_recover : 'a context -> unit


### PR DESCRIPTION
## Summary

- **Root cause**: `Keeper_keepalive.start_keepalive` (autoboot path) never forked the stale-turn watchdog. Only `Keeper_supervisor.launch_supervised_fiber` had it, but autoboot doesn't go through supervisor. Result: every keeper started via autoboot had **zero watchdog coverage**.
- Extract `fork_stale_watchdog` into standalone `Keeper_stale_watchdog` module to break the `Keeper_keepalive ↔ Keeper_supervisor` circular dependency.
- Add `Keeper_stale_watchdog.fork_stale_watchdog` call in `start_keepalive` so autoboot-launched keepers get watchdog coverage.
- Supervisor delegates to same module — single implementation, two call sites.
- Two detection modes: idle stall (300s no turn) + failure loop (consecutive_noop_count ≥ 3, catches LLM timeout loops where `last_turn_ts` stays fresh).

## Test plan
- [x] `dune build` passes
- [ ] Deploy and verify watchdog tick logs appear for autoboot-launched keepers
- [ ] Verify stuck keepers in failure loops get detected and restarted

Depends on #10663 (merged — `last_turn_ts` diagnostic field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)