### PR TITLE
feat(dashboard): localize 7 chips/labels across 3 components (round-36)

### DIFF
--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -171,7 +171,7 @@ async function submitMention(target: string): Promise<void> {
     showToast(`${target}에게 전송`, 'success')
     void loadProfile(target)
   } catch (err) {
-    showToast(err instanceof Error ? err.message : 'Failed', 'error')
+    showToast(err instanceof Error ? err.message : '실패', 'error')
   } finally {
     sendingMention.value = false
   }

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -130,11 +130,11 @@ const VERDICT_LINEAGE_LABELS = new Set([
 function verdictStageLabel(label: string): string {
   switch (label) {
     case 'submit_for_verification':
-    case 'awaiting_verification': return 'Submit'
+    case 'awaiting_verification': return '제출'
     case 'approve':
-    case 'approved': return 'Approve'
+    case 'approved': return '승인'
     case 'reject':
-    case 'rejected': return 'Reject'
+    case 'rejected': return '반려'
     default: return label
   }
 }

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -15,9 +15,9 @@ function pressureClass(pressure: 'calm' | 'normal' | 'hot'): string {
 
 function pressureLabel(pressure: 'calm' | 'normal' | 'hot'): string {
   switch (pressure) {
-    case 'hot': return 'High'
-    case 'normal': return 'Active'
-    default: return 'Calm'
+    case 'hot': return '높음'
+    case 'normal': return '활동중'
+    default: return '평온'
   }
 }
 


### PR DESCRIPTION
## Summary

대시보드 라운드 36 — pressure / verdict stage 라벨 + error fallback 한국어화.

| File | Function | Before | After |
|---|---|---|---|
| live/focus-sidebar.ts:18 | pressureLabel('hot') | High | 높음 |
| live/focus-sidebar.ts:19 | pressureLabel('normal') | Active | 활동중 |
| live/focus-sidebar.ts:20 | pressureLabel('calm') | Calm | 평온 |
| goals/task-detail-overlay.ts:133 | verdictStageLabel('awaiting_verification') | Submit | 제출 |
| goals/task-detail-overlay.ts:135 | verdictStageLabel('approved') | Approve | 승인 |
| goals/task-detail-overlay.ts:137 | verdictStageLabel('rejected') | Reject | 반려 |
| agent-profile.ts:174 | error toast fallback | Failed | 실패 |

## Test fixture coupling 검증

| 단어 | Test 등장 | 분석 | 충돌 |
|---|---|---|---|
| High | \`governance-risk.test.ts:31\` \`approvalRiskToneClass('High')\` | API risk_level data 함수 인자, focus-sidebar 의 pressureLabel 출력과 무관 | ❌ |
| Active / Calm | -- | -- | ❌ |
| Submit / Approve / Reject | -- | verdictStageLabel 출력에 대한 test assertion 없음 | ❌ |
| Failed | -- | toast fallback path test couple 없음 | ❌ |

## 회피 (vitest infra 의존)

| 위치 | 단어 | 이유 |
|---|---|---|
| \`session-trace-entry.ts:192\` | 'Error' / 'Result' | \`session-trace-entry.test.ts:88\` 직접 assertion + \`task-activity-list.test.ts:120\` data-title 'Result' attribute selector. atomic test sync 필요 → #10645 (vitest infra) 복구 후 단일 PR 처리 |
| \`keeper-detail-panels.ts:1155-1192\` | 30+ field titles | filter 로직이 \`f.title.toLowerCase().includes(filter)\` 사용. 한국어화 시 영문 검색어 호환성 영향 — 별도 라운드에서 검색 매핑과 함께 처리 |

## Test plan

- [ ] \`pnpm dev\` — focus sidebar pressure pill (calm/normal/hot) + task verdict stage chip 시각 확인
- [ ] agent-profile 멘션 전송 실패 시 toast 메시지 한국어 확인 (drop-in: 네트워크 차단 후 retry)

## 라운드 누적 (23-36)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31 | #10685 | MERGED | 9 |
| 32 | #10689 | MERGED | 5 |
| 33 | #10690 | MERGED | 7 |
| 34 | #10695 | MERGED | 6 |
| 35 | #10697 | OPEN, Mergeable | 5 |
| 36 | this | Draft | **7** |

누적 chips ≈ **96**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)