### PR TITLE
refactor(design-system): swap memory-post-detail 11 inline buttons to ActionButton (PR-CS8)

### DIFF
--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
+import { ActionButton } from './common/button'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
@@ -143,19 +144,23 @@ function CommentItem({
       <div class="board-comment rounded p-3 bg-[var(--white-3)] border border-[var(--border-slate-12)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
         <div class="flex items-center gap-2 mb-1.5">
           <span class="text-xs">${authorAvatar(authorAvatarKey)}</span>
-          <button type="button" class="text-xs font-medium text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] transition-colors cursor-pointer bg-transparent border-none p-0" title=${authorTitle} onClick=${() => navigateToAuthor(comment.author, undefined, comment.author_identity)}>${authorLabel}</button>
+          <${ActionButton} variant="subtle" size="sm" class="text-xs font-medium text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] bg-transparent border-none p-0" title=${authorTitle} ariaLabel=${`작성자 ${authorLabel} 프로필로 이동`} onClick=${() => navigateToAuthor(comment.author, undefined, comment.author_identity)}>${authorLabel}<//>
           <span class="text-2xs text-[var(--color-fg-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
-          <button type="button"
-            class="text-2xs text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] cursor-pointer bg-transparent border-0 ml-auto"
+          <${ActionButton}
+            variant="subtle"
+            size="sm"
+            class="text-2xs hover:text-[var(--color-accent-fg)] bg-transparent border-0 ml-auto"
             onClick=${() => { replyingTo.value = isReplying ? null : comment.id; commentText.value = '' }}
-          >${isReplying ? '취소' : '답글'}</button>
+          >${isReplying ? '취소' : '답글'}<//>
         </div>
         <div class="text-sm text-[var(--color-fg-primary)] leading-paragraph"><${RichContent} text=${displayText} previewLimit=${1} /></div>
         ${needsTruncation ? html`
-          <button type="button"
-            class="mt-1 text-2xs text-[var(--color-accent-fg)] hover:underline cursor-pointer bg-transparent border-0"
+          <${ActionButton}
+            variant="subtle"
+            size="sm"
+            class="mt-1 text-2xs text-[var(--color-accent-fg)] hover:underline bg-transparent border-0"
             onClick=${() => setExpanded(!expanded)}
-          >${expanded ? '접기' : '더 보기...'}</button>
+          >${expanded ? '접기' : '더 보기...'}<//>
         ` : null}
         ${isReplying ? html`
           <div class="mt-2">
@@ -169,17 +174,16 @@ function CommentItem({
               previewLimit=${1}
             />
             <div class="mt-2 flex justify-end">
-              <button type="button"
-                class="py-1.5 px-3 rounded text-xs font-medium font-[inherit] cursor-pointer transition-all duration-150 border
-                  ${commentSubmitting.value || commentText.value.trim() === ''
-                    ? 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
-                    : 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
-                  }"
-                onClick=${() => submitComment(postId, comment.id)}
+              <${ActionButton}
+                variant="ghost"
+                size="md"
+                class="text-xs bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]"
                 disabled=${commentSubmitting.value || commentText.value.trim() === ''}
+                ariaBusy=${commentSubmitting.value}
+                onClick=${() => submitComment(postId, comment.id)}
               >
                 ${commentSubmitting.value ? '...' : '등록'}
-              </button>
+              <//>
             </div>
           </div>
         ` : null}
@@ -230,17 +234,21 @@ export function CommentThread({ comments, postId }: { comments: BoardComment[]; 
         <${EmptyState} message=${`"${query.value.trim()}" 일치하는 댓글 없음`} compact />
       ` : null}
       ${!expanded && hiddenCount > 0 ? html`
-        <button type="button"
-          class="text-xs text-[var(--color-accent-fg)] hover:underline cursor-pointer bg-transparent border-0 text-left py-1"
+        <${ActionButton}
+          variant="subtle"
+          size="sm"
+          class="text-xs text-[var(--color-accent-fg)] hover:underline bg-transparent border-0 text-left py-1"
           onClick=${() => setExpanded(true)}
-        >이전 댓글 ${hiddenCount}개 더 보기</button>
+        >이전 댓글 ${hiddenCount}개 더 보기<//>
       ` : null}
       ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} childrenMap=${filteredChildrenMap} />`)}
       ${expanded && hiddenCount > 0 ? html`
-        <button type="button"
-          class="text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] cursor-pointer bg-transparent border-0 text-left py-1"
+        <${ActionButton}
+          variant="subtle"
+          size="sm"
+          class="text-xs hover:text-[var(--color-accent-fg)] bg-transparent border-0 text-left py-1"
           onClick=${() => setExpanded(false)}
-        >접기</button>
+        >접기<//>
       ` : null}
     </div>
   `
@@ -260,17 +268,16 @@ function CommentForm({ postId }: { postId: string }) {
         previewLimit=${1}
       />
       <div class="mt-2 flex justify-end">
-        <button type="button"
-          class="py-2 px-4 rounded text-sm font-medium font-[inherit] cursor-pointer transition-all duration-150 border
-            ${commentSubmitting.value || commentText.value.trim() === ''
-              ? 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
-              : 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
-            }"
-          onClick=${() => submitComment(postId)}
+        <${ActionButton}
+          variant="ghost"
+          size="lg"
+          class="text-sm bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]"
           disabled=${commentSubmitting.value || commentText.value.trim() === ''}
+          ariaBusy=${commentSubmitting.value}
+          onClick=${() => submitComment(postId)}
         >
           ${commentSubmitting.value ? '...' : '등록'}
-        </button>
+        <//>
       </div>
     </div>
   `
@@ -299,10 +306,12 @@ export function PostDetail({ post }: { post: BoardPost }) {
 
   return html`
     <div>
-      <button type="button"
-        class="mb-4 px-3 py-1.5 rounded text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] transition-all cursor-pointer"
+      <${ActionButton}
+        variant="ghost"
+        size="sm"
+        class="mb-4 text-xs"
         onClick=${() => navigate('workspace', { section: 'board' })}
-      >← 게시판으로 돌아가기</button>
+      >← 게시판으로 돌아가기<//>
 
       <${Card}>
         <div class="flex flex-col gap-4">
@@ -317,7 +326,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
           <!-- Author and meta -->
           <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
             <span class="text-sm">${authorAvatar(authorAvatarKey)}</span>
-            <button type="button" class="text-xs text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] transition-colors cursor-pointer bg-transparent border-none p-0" title=${authorTitle} onClick=${() => navigateToAuthor(post.author, undefined, post.author_identity)}>${authorLabel}</button>
+            <${ActionButton} variant="subtle" size="sm" class="text-xs text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] bg-transparent border-none p-0" title=${authorTitle} ariaLabel=${`작성자 ${authorLabel} 프로필로 이동`} onClick=${() => navigateToAuthor(post.author, undefined, post.author_identity)}>${authorLabel}<//>
             <span class="text-2xs text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
             <span class="text-2xs text-[var(--color-fg-muted)]">${post.votes ?? 0} votes</span>
           </div>
@@ -356,14 +365,18 @@ export function PostDetail({ post }: { post: BoardPost }) {
 
           <!-- Vote buttons -->
           <div class="flex gap-2">
-            <button type="button"
-              class="vote-btn upvote px-3 py-1.5 rounded text-xs font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--color-fg-muted)] hover:text-[var(--warn-bright)] hover:border-[var(--warn-30)] hover:bg-[var(--warn-10)] transition-all cursor-pointer"
+            <${ActionButton}
+              variant="ghost"
+              size="sm"
+              class="vote-btn upvote text-xs hover:text-[var(--warn-bright)] hover:border-[var(--warn-30)] hover:bg-[var(--warn-10)]"
               onClick=${() => handleVote('up')}
-            >▲ 추천</button>
-            <button type="button"
-              class="vote-btn downvote px-3 py-1.5 rounded text-xs font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] hover:border-[var(--accent-30)] hover:bg-[var(--accent-10)] transition-all cursor-pointer"
+            >▲ 추천<//>
+            <${ActionButton}
+              variant="ghost"
+              size="sm"
+              class="vote-btn downvote text-xs hover:text-[var(--color-accent-fg)] hover:border-[var(--accent-30)] hover:bg-[var(--accent-10)]"
               onClick=${() => handleVote('down')}
-            >▼ 비추천</button>
+            >▼ 비추천<//>
           </div>
         </div>
       <//>


### PR DESCRIPTION
## Summary

CS series 마지막. memory-post-detail 11 inline `<button>` → ActionButton 일괄 교체. 단일 PR 중 최대 button swap.

## 변경

`dashboard/src/components/memory-post-detail.ts`:

| # | 위치 | 텍스트 | Variant |
|---|------|--------|---------|
| 1 | CommentItem.author | (avatar 옆 작성자 이름) | subtle + ariaLabel="작성자 X 프로필로 이동" |
| 2 | CommentItem.actions | "취소"/"답글" toggle | subtle |
| 3 | CommentItem.body | "접기"/"더 보기..." truncate | subtle |
| 4 | CommentItem.replyForm | "등록" comment submit | ghost + ariaBusy |
| 5 | CommentThread | "이전 댓글 N개 더 보기" | subtle |
| 6 | CommentThread | "접기" (expanded view) | subtle |
| 7 | CommentForm | "등록" comment submit (top-level) | ghost + ariaBusy + size=lg |
| 8 | PostDetail.author | (avatar 옆 작성자 이름) | subtle + ariaLabel |
| 9 | PostDetail.back | "← 게시판으로 돌아가기" | ghost |
| 10 | PostDetail.vote | "▲ 추천" upvote | ghost + warn-bright hover |
| 11 | PostDetail.vote | "▼ 비추천" downvote | ghost + accent-fg hover |

## 이점

- **a11y**: 11개 모두 focus-visible:ring 자동 + ariaLabel 명시 (작성자 link 2건은 스크린리더 announce 향상)
- **ariaBusy**: 댓글 "등록" 중 AT announce
- **인터랙션 일관성**: active:scale-[0.97] + opacity:0.9 통일
- **커스텀 hover 보존**: vote button의 `--warn-bright` / `--accent-fg` 호버 색상은 `class` override로 보존

## 핵심 발견

**ghost variant + class override 조합으로 ok-soft palette button (등록 submit) 재현**:
```tsx
<${ActionButton}
  variant="ghost"
  class="bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]"
  ariaBusy=${commentSubmitting.value}
>
```
ghost variant의 base styles (border-solid, rounded, hover bg) 위에 색상만 override. 별도 `success` variant 신설 불필요.

## 통계

| 메트릭 | 값 |
|--------|-----|
| 변경 라인 | 91 (52 insertions, 39 deletions) |
| 인라인 `<button class=` | **11 → 0** |
| ActionButton 호출 | **11** |

## 누적 CS series

| PR | 파일 | Buttons | 상태 |
|----|------|---------|------|
| CS1 #10646 | transport-health | 2 | MERGED |
| CS2 #10656 | autoresearch (action) | 6 | MERGED |
| CS3 #10673 | activity-graph + error-panel "모두 확인" + tool-result-display | 4 | MERGED |
| CS4 #10679 | ActionButton.pressed prop + tool-picker filter | 1 + ✅API | MERGED |
| CS5 #10683 | autoresearch loop selector | 1 | MERGED |
| CS6 #10687 | error-panel icon-only | 3 | MERGED |
| CS7 #10694 | tool-picker ToolRow | 1 | MERGED |
| CS8 (this) | memory-post-detail | 11 | OPEN |
| **합계** | **9 컴포넌트** | **29 buttons** | — |

## 잔존 (out-of-scope)

- `agent-profile.ts`: 1 list item with `--gold-8` 커스텀 palette → 별도 PR 검토

## Test plan

- [ ] CI green
- [ ] 게시글 상세 페이지: 작성자 클릭 / 추천/비추천 / 댓글 등록 / 답글 / 접기·더보기 시각 정상
- [ ] 키보드 focus ring 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)
