### PR TITLE
feat(dashboard): localize 9 copy/feature-health strings across 3 components (round-37)

### DIFF
--- a/dashboard/src/components/common/copy-id-button.ts
+++ b/dashboard/src/components/common/copy-id-button.ts
@@ -23,10 +23,10 @@ export function CopyIdButton({ value, label, ariaLabel, size = 12 }: CopyIdButto
     const ok = await copyToClipboard(value)
     if (ok) {
       setJustCopied(true)
-      showToast(label ? `Copied: ${label}` : 'Copied', 'success', 1400)
+      showToast(label ? `복사됨: ${label}` : '복사됨', 'success', 1400)
       setTimeout(() => setJustCopied(false), 1200)
     } else {
-      showToast('Copy failed', 'error')
+      showToast('복사 실패', 'error')
     }
   }
 
@@ -34,8 +34,8 @@ export function CopyIdButton({ value, label, ariaLabel, size = 12 }: CopyIdButto
     <button
       type="button"
       class="inline-flex shrink-0 cursor-pointer items-center justify-center rounded p-0.5 text-[var(--color-fg-disabled)] opacity-60 transition-all hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)] hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent-30)]"
-      aria-label=${ariaLabel || (label ? `Copy ${label}` : 'Copy')}
-      title=${ariaLabel || (label ? `Copy ${label}` : 'Copy')}
+      aria-label=${ariaLabel || (label ? `${label} 복사` : '복사')}
+      title=${ariaLabel || (label ? `${label} 복사` : '복사')}
       onClick=${onCopy}
     >
       ${justCopied ? html`<${Check} size=${size} />` : html`<${Copy} size=${size} />`}

--- a/dashboard/src/components/common/copyable-code.test.ts
+++ b/dashboard/src/components/common/copyable-code.test.ts
@@ -36,14 +36,14 @@ describe('CopyableCode', () => {
     expect(container.textContent).toContain('test cmd')
   })
 
-  it('default aria-label is "Copy command"; customized when label or ariaLabel provided', () => {
+  it('default aria-label is "명령 복사"; customized when label or ariaLabel provided', () => {
     render(html`<${CopyableCode} command="x" />`, container)
-    expect(container.querySelector('[data-copy-button]')!.getAttribute('aria-label')).toBe('Copy command')
+    expect(container.querySelector('[data-copy-button]')!.getAttribute('aria-label')).toBe('명령 복사')
   })
 
-  it('aria-label uses "Copy <label>" when label set but ariaLabel missing', () => {
+  it('aria-label uses "<label> 복사" when label set but ariaLabel missing', () => {
     render(html`<${CopyableCode} command="x" label="start" />`, container)
-    expect(container.querySelector('[data-copy-button]')!.getAttribute('aria-label')).toBe('Copy start')
+    expect(container.querySelector('[data-copy-button]')!.getAttribute('aria-label')).toBe('start 복사')
   })
 
   it('explicit ariaLabel overrides the default computation', () => {

--- a/dashboard/src/components/common/copyable-code.ts
+++ b/dashboard/src/components/common/copyable-code.ts
@@ -84,10 +84,10 @@ export function CopyableCode({
     const ok = await copyToClipboard(command)
     if (ok) {
       setJustCopied(true)
-      showToast(label ? `Copied: ${label}` : 'Copied to clipboard', 'success', 1800)
+      showToast(label ? `복사됨: ${label}` : '클립보드에 복사됨', 'success', 1800)
       setTimeout(() => setJustCopied(false), 1400)
     } else {
-      showToast('Copy failed — select the text manually', 'error')
+      showToast('복사 실패 — 텍스트를 직접 선택하세요', 'error')
     }
   }
 
@@ -115,7 +115,7 @@ export function CopyableCode({
       <button
         type="button"
         class="shrink-0 cursor-pointer rounded border border-transparent p-1 text-[var(--color-fg-disabled)] opacity-60 transition-opacity hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)] focus-visible:opacity-100 group-hover:opacity-100"
-        aria-label=${ariaLabel || (label ? `Copy ${label}` : 'Copy command')}
+        aria-label=${ariaLabel || (label ? `${label} 복사` : '명령 복사')}
         data-copy-button
         onClick=${onCopy}
       >

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -202,8 +202,8 @@ export function FeatureHealth() {
       <${Card} title="기능 상태" class="section">
         <${AsyncContainer}
           state=${featureHealth.state}
-          loadingMessage="Feature health 데이터를 불러오는 중..."
-          emptyMessage="Feature health 데이터가 없습니다."
+          loadingMessage="기능 상태 데이터를 불러오는 중..."
+          emptyMessage="기능 상태 데이터가 없습니다."
           render=${(data: FeatureHealthData) => {
             const overview = data.overview
             return html`


### PR DESCRIPTION
## Summary

대시보드 라운드 37 — copy 가족 toast/aria-label + feature-health AsyncContainer messages 한국어화.

| File | Element | Before | After |
|---|---|---|---|
| feature-health.ts:205 | AsyncContainer loadingMessage | Feature health 데이터를 ... | 기능 상태 데이터를 ... |
| feature-health.ts:206 | AsyncContainer emptyMessage | Feature health 데이터가 없습니다. | 기능 상태 데이터가 없습니다. |
| common/copyable-code.ts:87 | toast (success, with label) | Copied: ${label} | 복사됨: ${label} |
| common/copyable-code.ts:87 | toast (success, no label) | Copied to clipboard | 클립보드에 복사됨 |
| common/copyable-code.ts:90 | toast (error) | Copy failed — select the text manually | 복사 실패 — 텍스트를 직접 선택하세요 |
| common/copyable-code.ts:118 | aria-label fallback | Copy command / Copy ${label} | 명령 복사 / ${label} 복사 |
| common/copy-id-button.ts:26 | toast (success, with label) | Copied: ${label} | 복사됨: ${label} |
| common/copy-id-button.ts:26 | toast (success, no label) | Copied | 복사됨 |
| common/copy-id-button.ts:29 | toast (error) | Copy failed | 복사 실패 |
| common/copy-id-button.ts:37-38 | aria-label/title fallback | Copy / Copy ${label} | 복사 / ${label} 복사 |

## Test sync (atomic)

\`copyable-code.test.ts:39-46\` 의 2 assertion 이 aria-label fallback string 직접 매칭. 동일 PR 에서 sync:

\`\`\`diff
-    expect(...getAttribute('aria-label')).toBe('Copy command')
+    expect(...getAttribute('aria-label')).toBe('명령 복사')

-    expect(...getAttribute('aria-label')).toBe('Copy start')
+    expect(...getAttribute('aria-label')).toBe('start 복사')
\`\`\`

## 보존 (caller-provided ariaLabel)

| 위치 | ariaLabel | 이유 |
|---|---|---|
| \`telemetry-unified.ts\` | \"Copy telemetry entry JSON\" | caller 가 명시적으로 영문 ariaLabel 지정. 본 PR 은 **fallback** 만 변경. |
| \`telemetry-unified.ts\` | \"Copy expanded telemetry entry JSON\" | 동일 |
| \`telemetry-unified.ts\` | \"Copy expanded telemetry group JSON\" | 동일 |

→ telemetry-unified.test.ts:230,254,336 의 assertion 은 caller string 그대로 통과.
→ telemetry-unified 의 영문 ariaLabel 자체는 별도 라운드 후보 (caller side localization).

## Test fixture coupling 검증

| 단어 | Test 등장 | 처리 |
|---|---|---|
| Feature health | -- | ❌ no couple |
| Copy failed / Copied / Copy: | -- | ❌ no couple |
| Copy command / Copy <label> | \`copyable-code.test.ts:41,46\` | ✅ atomic test sync (이번 PR 포함) |
| Copy telemetry entry JSON 등 | telemetry-unified.test.ts | ❌ caller string, 본 PR 미관여 |

## 라운드 누적 (23-37)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-35 | -- | MERGED | 32 |
| 36 | #10700 | Draft | 7 |
| 37 | this | Draft | **9** |

누적 chips ≈ **105**.

## Why Draft

#10645 (vitest infra) 미해결. test sync 가 PR 에 포함되어 vitest 복구 즉시 검증 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)