### PR TITLE
refactor(design-system): swap agent-profile collab list to ActionButton (PR-CS9 — final)

### DIFF
--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -392,13 +392,18 @@ export function AgentProfile({ name }: { name: string }) {
               ${collabs.length > 0 ? html`
                 <div class="flex flex-col gap-1">
                   ${collabs.map(c => html`
-                    <button type="button" class="w-full flex items-center gap-2 px-2 py-1.5 transition-colors duration-150 hover:bg-[var(--gold-8)] rounded text-left cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent" key=${c.name}
-                      onClick=${() => navigate('monitoring', { section: 'agents', agent: c.name })}
-                    >
+                    <${ActionButton}
+                      key=${c.name}
+                      block
+                      variant="subtle"
+                      size="sm"
+                      class="text-left px-2 py-1.5 hover:bg-[var(--gold-8)]"
+                      ariaLabel=${`${c.name} 에이전트 프로필 열기`}
+                      onClick=${() => navigate('monitoring', { section: 'agents', agent: c.name })}>
                       <span class="text-[var(--ff-gold)] font-semibold text-base flex-1">${c.name}</span>
                       <span class="text-[var(--white-50)] text-sm tabular-nums">${c.collaborations}회</span>
                       ${c.last_collab ? html`<span class="ff-relation-time"><${TimeAgo} timestamp=${c.last_collab} /></span>` : null}
-                    </button>
+                    <//>
                   `)}
                 </div>
               ` : null}


### PR DESCRIPTION
## Summary

CS series 마무리. dashboard/src/components/ 마지막 inline `<button>` swap.

## 변경

`dashboard/src/components/agent-profile.ts` 협력 에이전트 list item:

**Before** (FF gold theme list):
```tsx
<button type="button" class="w-full flex items-center gap-2 px-2 py-1.5 transition-colors duration-150 hover:bg-[var(--gold-8)] rounded text-left cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent" key=${c.name}
  onClick=${() => navigate('monitoring', { section: 'agents', agent: c.name })}
>
  <span class="text-[var(--ff-gold)] font-semibold text-base flex-1">${c.name}</span>
  ...
</button>
```

**After**:
```tsx
<${ActionButton}
  key=${c.name}
  block
  variant="subtle"
  size="sm"
  class="text-left px-2 py-1.5 hover:bg-[var(--gold-8)]"
  ariaLabel=${`${c.name} 에이전트 프로필 열기`}
  onClick=${() => navigate('monitoring', { section: 'agents', agent: c.name })}>
  <span class="text-[var(--ff-gold)] font-semibold text-base flex-1">${c.name}</span>
  ...
<//>
```

## 매핑

| 원본 | ActionButton |
|------|--------------|
| `w-full` | `block=true` |
| `text-left` | `class="text-left"` |
| `px-2 py-1.5` | `class="px-2 py-1.5"` (size=sm 위에 override) |
| `hover:bg-[var(--gold-8)]` (FF gold theme) | `class="hover:bg-[var(--gold-8)]"` (subtle 기본 `hover:bg-white-6` over-ride) |
| `focus-visible:ring-1 focus-visible:ring-accent` | ActionButton BASE의 `focus-visible:ring-2 ring-[var(--accent-45)]` (a11y 향상) |

## 핵심 발견

**Custom theme (FF gold) hover 보존도 class override만으로 처리**. variant 추가 없이 design system 외부 어휘 호환.

## 누적 CS series 완료

| PR | 파일 | Buttons | 상태 |
|----|------|---------|------|
| CS1 #10646 | transport-health | 2 | MERGED |
| CS2 #10656 | autoresearch (action) | 6 | MERGED |
| CS3 #10673 | activity-graph + error-panel + tool-result-display | 4 | MERGED |
| CS4 #10679 | ActionButton.pressed prop + tool-picker filter | 1 + ✅API | MERGED |
| CS5 #10683 | autoresearch loop selector | 1 | MERGED |
| CS6 #10687 | error-panel icon-only | 3 | MERGED |
| CS7 #10694 | tool-picker ToolRow | 1 | MERGED |
| CS8 #10702 | memory-post-detail | 11 | OPEN |
| CS9 (this) | agent-profile collab list | 1 | OPEN |
| **합계** | **10 컴포넌트** | **30 buttons** | — |

## Sweep 검증

CS8 + CS9 모두 머지되면 `rg '<button[^>]*class=' dashboard/src/` → **0 results**.

## Test plan

- [ ] CI green
- [ ] Agent profile 페이지에서 collab list 클릭 → 다른 에이전트 프로필 이동 정상
- [ ] hover 시 gold-8 배경 정상
- [ ] 키보드 focus ring 표시 (accent-45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
