### PR TITLE
diag(prometheus): capture EDEADLK backtrace on metrics_mutex (#10682)

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -53,11 +53,36 @@ type metric = {
 let metrics : (string, metric) Hashtbl.t = Hashtbl.create 64
 let metrics_mutex = Stdlib.Mutex.create ()
 
+(* #10682 diagnostic: when EDEADLK fires (PTHREAD_MUTEX_ERRORCHECK
+   detects same-thread re-entry on OCaml 5), lock raises Sys_error with
+   message "Mutex.lock: Resource deadlock avoided". Without a backtrace,
+   the actual re-entrant call site is invisible because [with_lock] is
+   used by ~12 sites in this module and is reachable from every read
+   tool dispatch. We capture the raw backtrace at the point of failure
+   and stash it on a side-channel for the next render so the offending
+   site self-documents. The non-failing path is unchanged. *)
+let last_deadlock_backtrace : string option Atomic.t = Atomic.make None
+
 let with_lock f =
-  Stdlib.Mutex.lock metrics_mutex;
+  let bt0 = Printexc.get_callstack 64 in
+  (try Stdlib.Mutex.lock metrics_mutex
+   with Sys_error msg as exn ->
+     let trace = Printexc.raw_backtrace_to_string bt0 in
+     let dump =
+       Printf.sprintf "Prometheus.with_lock: %s\nCaller stack:\n%s"
+         msg trace
+     in
+     Atomic.set last_deadlock_backtrace (Some dump);
+     Printf.eprintf "[ERROR] [Prometheus] %s\n%!" dump;
+     raise exn);
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock metrics_mutex)
     f
+
+(** Read-only accessor for the most recent EDEADLK backtrace captured
+    by [with_lock]. Used by diagnostic dumps and tests. *)
+let last_deadlock_backtrace_for_test () =
+  Atomic.get last_deadlock_backtrace
 
 (** {1 Metric Registration} *)
 

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -399,3 +399,11 @@ val update_uptime : unit -> unit
     Called automatically at module load via [let () = init ()].
     Idempotent — safe to call again. *)
 val init : unit -> unit
+
+(** {1 Diagnostics — issue #10682}
+
+    The most recent EDEADLK backtrace captured by [with_lock]. [None]
+    until the first re-entrant lock failure. Set side-effectfully when
+    [Stdlib.Mutex.lock metrics_mutex] raises [Sys_error]. The backtrace
+    pinpoints the offending re-entrant caller without requiring repro. *)
+val last_deadlock_backtrace_for_test : unit -> string option


### PR DESCRIPTION
## 무엇

Issue #10682 추적용 진단 hook. `Prometheus.with_lock`가 EDEADLK로 실패할 때 caller backtrace를 capture해 stderr 로그 + Atomic 측면 channel에 저장. **non-failing 경로는 변경 없음**.

## 왜

오늘 64+건의 `Sys_error("Mutex.lock: Resource deadlock avoided")`가 7개 read-only 도구에서 발생. hit 분포는 호출 빈도 비례 → 단일 mutex(`metrics_mutex`) 가설 일관. 그러나 `with_lock`의 12 callsite + ~12 caller 모듈 어디가 재진입을 일으키는지 단순 grep으로는 미확정.

cycle 5 분석에서 `Stdlib.Mutex` 정당화 주장(코멘트 line 46-51)이 일부 무효화됨:
- "init runs before Eio scheduler" — `init()` 자체가 `with_lock`를 우회. 무효.
- "must hold across OCaml 5 domains (Executor_pool workers)" — `rg "Domain.spawn" lib --type ml` 0 hit. 무효.

그러나 blind한 `Eio.Mutex` 마이그레이션은 EDEADLK를 영구 fiber deadlock으로 바꿀 수 있음 (Eio.Mutex는 raise 대신 block). 따라서 **1단계: 재진입 경로 식별 → 2단계: 마이그레이션** 순서가 안전.

## 변경

- `lib/prometheus.ml`: `with_lock`에 `Printexc.get_callstack 64`를 lock 시도 직전에 스냅샷. `Stdlib.Mutex.lock`가 raise하면 backtrace를 포맷해 `Atomic.set` + `Printf.eprintf` (stderr).
- `lib/prometheus.mli`: `last_deadlock_backtrace_for_test : unit -> string option` 노출.

## 영향

- 정상 경로: `Printexc.get_callstack 64`는 OCaml 런타임의 thin C 호출, 할당 없는 raw_backtrace. 무시할 수준.
- 실패 경로: 단발성 stderr 한 줄 + Atomic.set. 다음 EDEADLK가 자기 callstack 기록.
- 외부 surface: 신규 `last_deadlock_backtrace_for_test` 1개 함수만 추가. 기존 호출자 영향 없음.

## 다음 작업

- 운영에서 EDEADLK 1회 더 발생 시 stderr 로그(또는 system_log)에서 backtrace 확인.
- 재진입 callsite 확정 후 마이그레이션 또는 callsite 수정.
- 본 PR은 진단 목적이라 머지 후 backtrace가 잡히면 별도 fix PR이 본 hook을 제거 또는 Eio.Mutex로 전환.
