### PR TITLE
feat(dashboard): localize 4 telemetry copy ariaLabels (round-38)

### DIFF
--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -227,9 +227,9 @@ describe('TelemetryUnified', () => {
     })
     await flushUi()
 
-    const copyButton = container.querySelector('[aria-label="Copy telemetry entry JSON"]') as HTMLButtonElement | null
+    const copyButton = container.querySelector('[aria-label="텔레메트리 항목 JSON 복사"]') as HTMLButtonElement | null
     expect(copyButton).not.toBeNull()
-    expect(copyButton?.getAttribute('title')).toBe('Copy telemetry entry JSON')
+    expect(copyButton?.getAttribute('title')).toBe('텔레메트리 항목 JSON 복사')
   })
 
   it('surfaces a raw JSON copy action inside an expanded telemetry entry', async () => {
@@ -251,9 +251,9 @@ describe('TelemetryUnified', () => {
     })
     await flushUi()
 
-    const expandedCopyButton = container.querySelector('[aria-label="Copy expanded telemetry entry JSON"]') as HTMLButtonElement | null
+    const expandedCopyButton = container.querySelector('[aria-label="펼친 텔레메트리 항목 JSON 복사"]') as HTMLButtonElement | null
     expect(expandedCopyButton).not.toBeNull()
-    expect(expandedCopyButton?.getAttribute('title')).toBe('Copy expanded telemetry entry JSON')
+    expect(expandedCopyButton?.getAttribute('title')).toBe('펼친 텔레메트리 항목 JSON 복사')
   })
 
   it('condenses consecutive noisy telemetry into grouped categories', async () => {
@@ -333,9 +333,9 @@ describe('TelemetryUnified', () => {
     })
     await flushUi()
 
-    const expandedCopyButton = container.querySelector('[aria-label="Copy expanded telemetry group JSON"]') as HTMLButtonElement | null
+    const expandedCopyButton = container.querySelector('[aria-label="펼친 텔레메트리 그룹 JSON 복사"]') as HTMLButtonElement | null
     expect(expandedCopyButton).not.toBeNull()
-    expect(expandedCopyButton?.getAttribute('title')).toBe('Copy expanded telemetry group JSON')
+    expect(expandedCopyButton?.getAttribute('title')).toBe('펼친 텔레메트리 그룹 JSON 복사')
   })
 
   it('groups heartbeat keeper metrics into a heartbeat category', async () => {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -525,8 +525,8 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
         <span class="mr-2 inline-flex flex-shrink-0">
           <${CopyIdButton}
             value=${rawJson}
-            label="telemetry entry JSON"
-            ariaLabel="Copy telemetry entry JSON"
+            label="텔레메트리 항목 JSON"
+            ariaLabel="텔레메트리 항목 JSON 복사"
             size=${13}
           />
         </span>
@@ -543,8 +543,8 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
               <span class="text-3xs font-medium text-[var(--text-dim)]">원본 JSON</span>
               <${CopyIdButton}
                 value=${rawJson}
-                label="expanded telemetry entry JSON"
-                ariaLabel="Copy expanded telemetry entry JSON"
+                label="펼친 텔레메트리 항목 JSON"
+                ariaLabel="펼친 텔레메트리 항목 JSON 복사"
                 size=${13}
               />
             </div>
@@ -601,8 +601,8 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
         <span class="mr-2 inline-flex flex-shrink-0">
           <${CopyIdButton}
             value=${rawJson}
-            label="telemetry group JSON"
-            ariaLabel="Copy telemetry group JSON"
+            label="텔레메트리 그룹 JSON"
+            ariaLabel="텔레메트리 그룹 JSON 복사"
             size=${13}
           />
         </span>
@@ -632,8 +632,8 @@ ${rawJson}</pre>
               </details>
               <${CopyIdButton}
                 value=${rawJson}
-                label="expanded telemetry group JSON"
-                ariaLabel="Copy expanded telemetry group JSON"
+                label="펼친 텔레메트리 그룹 JSON"
+                ariaLabel="펼친 텔레메트리 그룹 JSON 복사"
                 size=${13}
               />
             </div>


### PR DESCRIPTION
## Summary

대시보드 라운드 38 — telemetry-unified.ts 의 caller-provided ariaLabel 4종 한국어화. round-37 (#10703) 의 fallback ariaLabel 한국어화 와 짝을 이뤄, copy ariaLabel 전체 surface 를 한국어로 통일.

| File | Line | Element | Before | After |
|---|---|---|---|---|
| telemetry-unified.ts | 528-529 | CopyIdButton label/ariaLabel | telemetry entry JSON / Copy telemetry entry JSON | 텔레메트리 항목 JSON / 텔레메트리 항목 JSON 복사 |
| telemetry-unified.ts | 546-547 | CopyIdButton label/ariaLabel | expanded telemetry entry JSON / Copy expanded telemetry entry JSON | 펼친 텔레메트리 항목 JSON / 펼친 텔레메트리 항목 JSON 복사 |
| telemetry-unified.ts | 604-605 | CopyIdButton label/ariaLabel | telemetry group JSON / Copy telemetry group JSON | 텔레메트리 그룹 JSON / 텔레메트리 그룹 JSON 복사 |
| telemetry-unified.ts | 635-636 | CopyIdButton label/ariaLabel | expanded telemetry group JSON / Copy expanded telemetry group JSON | 펼친 텔레메트리 그룹 JSON / 펼친 텔레메트리 그룹 JSON 복사 |

## Test sync (atomic)

\`telemetry-unified.test.ts\` 6 assertion 동기 변경:

| Line | Before | After |
|---|---|---|
| 230 | \`querySelector('[aria-label=\"Copy telemetry entry JSON\"]')\` | \`...텔레메트리 항목 JSON 복사...\` |
| 232 | \`title === 'Copy telemetry entry JSON'\` | \`title === '텔레메트리 항목 JSON 복사'\` |
| 254 | \`querySelector('[aria-label=\"Copy expanded telemetry entry JSON\"]')\` | \`...펼친 텔레메트리 항목 JSON 복사...\` |
| 256 | \`title === 'Copy expanded telemetry entry JSON'\` | \`title === '펼친 텔레메트리 항목 JSON 복사'\` |
| 336 | \`querySelector('[aria-label=\"Copy expanded telemetry group JSON\"]')\` | \`...펼친 텔레메트리 그룹 JSON 복사...\` |
| 338 | \`title === 'Copy expanded telemetry group JSON'\` | \`title === '펼친 텔레메트리 그룹 JSON 복사'\` |

→ aria-label querySelector 3개 + title attribute 3개 = 6 assertion 모두 동기.

## Round-37 / Round-38 layered localization

| 단계 | 변경 위치 | 변경 대상 |
|---|---|---|
| Round-37 (#10703) | \`copyable-code.ts\` / \`copy-id-button.ts\` | **fallback** ariaLabel (\"Copy command\", \"Copy ${label}\", \"Copy\") |
| Round-38 (this) | \`telemetry-unified.ts\` | **caller-provided** ariaLabel (\"Copy telemetry entry JSON\" 등) |

\`telemetry-unified\` 만 caller-provided ariaLabel 을 사용 (rg 결과 1 file). 다른 모든 caller 는 round-37 fallback 으로 자동 localization.

## 보존 (영문 유지)

| 단어 | 이유 |
|---|---|
| JSON | 영문 약어 ledger (round 23-37 일관) |

## Test plan

- [ ] vitest 복구 후 \`pnpm test telemetry-unified\` — 6 assertion 통과 확인 (#10645 dependency)
- [ ] \`pnpm dev\` — telemetry-unified 패널의 4 copy 버튼 hover 시 한국어 tooltip 표시 확인

## 라운드 누적 (23-38)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-36 | -- | MERGED | 39 |
| 37 | #10703 | Draft | 9 |
| 38 | this | Draft | **8** |

누적 chips ≈ **113**.

## Why Draft

#10645 (vitest infra) 미해결. test sync 가 PR 에 포함되어 vitest 복구 즉시 검증 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)