### PR TITLE
chore(oas-pin): bump SHA to 97b8a603 (OAS #1201 TurnReady event)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.177.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="162940fd60552156c45431544efa3cec5d61f1ca"
+readonly OAS_AGENT_SDK_SHA="97b8a603f1917298ff1fd7814c46a7c108e986df"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.177.0"


### PR DESCRIPTION
chore(oas-pin): bump SHA to 97b8a603 (OAS #1201 TurnReady event)

OAS #1201 (feat(event_bus): add TurnReady event with effective tool
list) merged at 11:45 UTC. This bump pulls in the new event so
downstream MASC consumers can observe per-turn tool availability
deltas without polling.

Version unchanged (0.177.0); cap range >=0.177.0 & <0.178.0 still
satisfied.

Verified upstream commit exists (git cat-file -t commit) and pinned
SHA's dune-project version still 0.177.0 (raw URL fetch).
