### PR TITLE
feat(dashboard): localize 7 chips/headings across 6 components (round-39)

### DIFF
--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -258,7 +258,7 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
         : html`
             <div class="overflow-x-auto">
               <div class="grid gap-1 text-2xs" style=${gridCols} data-matrix-grid>
-                <div class="px-1 py-1 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">Keeper ↓ / Connector →</div>
+                <div class="px-1 py-1 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">키퍼 ↓ / 커넥터 →</div>
                 ${matrix.columns.map(colId => html`
                   <button
                     type="button"

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -872,7 +872,7 @@ function GoalDetailPanel({
         <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
           <div class="mb-3 flex items-center justify-between gap-3">
             <div>
-              <div class="text-2xs font-semibold uppercase tracking-widest text-text-muted">Goal-Scoped Task</div>
+              <div class="text-2xs font-semibold uppercase tracking-widest text-text-muted">Goal 범위 태스크</div>
               <div class="mt-1 text-sm text-text-body">이 goal에 직접 연결되는 새 태스크를 backlog에 넣습니다.</div>
             </div>
           </div>

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -178,7 +178,7 @@ export function KeeperDetailHeaderInfo({
       </button>
       <div class="size-12 shrink-0 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-2xl">${keeper.emoji}</div>
       <div class="flex flex-col gap-0.5">
-        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Monitoring / Agents / Keeper Detail</div>
+        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">모니터링 / 에이전트 / 키퍼 상세</div>
         <div class="mt-1 flex flex-wrap items-center gap-2.5">
           <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--text-strong)]">${keeper.name}</h2>
           <${KeeperPhaseAndStage} phase=${keeper.phase} pipelineStage=${keeper.pipeline_stage} phaseEnteredAtSec=${phaseEnteredAtSec} />

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -661,7 +661,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
       <div class="flex flex-col gap-3">
         ${repos.length > 0 ? html`
           <div>
-            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1.5">Repos (${repos.length})</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1.5">저장소 (${repos.length})</div>
             <div class="flex flex-col gap-1.5">
               ${repos.map(r => html`
                 <div class="flex items-center gap-3 px-3 py-2 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
@@ -698,7 +698,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
 
         ${worktrees.length > 0 ? html`
           <div>
-            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1.5">Worktrees (${worktrees.length})</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1.5">워크트리 (${worktrees.length})</div>
             <div class="flex flex-wrap gap-1.5">
               ${worktrees.map(w => html`
                 <span class="text-3xs font-mono px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--color-fg-muted)]" title=${w.path}>${w.name}</span>

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -213,7 +213,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ${'' /* 24h Trend */}
       ${trend ? html`
         <div class="flex items-center gap-2 pt-2 border-t border-[var(--white-8)]">
-          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">Trend (24h)</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">추세 (24h)</span>
           <span class="text-2xs font-mono tabular-nums text-[var(--color-fg-muted)]">
             ${trend.oldCoverage.toFixed(2)} \u2192 ${trend.newCoverage.toFixed(2)}
           </span>

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -205,7 +205,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
       ` : null}
 
       <div>
-        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)] mb-2">Composite Lifecycle (KSM · KTC · KDP · KCL · KMC)</div>
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)] mb-2">통합 라이프사이클 (KSM · KTC · KDP · KCL · KMC)</div>
         <${CytoscapeFsm} spec=${compositeSpec} height="320px" />
       </div>
 


### PR DESCRIPTION
## Summary

대시보드 라운드 39 — breadcrumb / 다이어그램 헤딩 / 매트릭스 축 / 카운트 헤더 한국어화.

| File | Element | Before | After |
|---|---|---|---|
| keeper-detail-shell:181 | breadcrumb | Monitoring / Agents / Keeper Detail | 모니터링 / 에이전트 / 키퍼 상세 |
| keeper-state-diagram:208 | section heading | Composite Lifecycle (KSM · KTC · KDP · KCL · KMC) | 통합 라이프사이클 (KSM · KTC · KDP · KCL · KMC) |
| keeper-eval-quality:216 | trend label | Trend (24h) | 추세 (24h) |
| goals/goal-tree:875 | section heading | Goal-Scoped Task | Goal 범위 태스크 |
| connector-keeper-matrix:261 | axis label | Keeper ↓ / Connector → | 키퍼 ↓ / 커넥터 → |
| keeper-detail:664 | count header | Repos (${n}) | 저장소 (${n}) |
| keeper-detail:701 | count header | Worktrees (${n}) | 워크트리 (${n}) |

## 보존 (영문/식별자 유지)

| 위치 | 단어 | 이유 |
|---|---|---|
| keeper-state-diagram:208 | KSM / KTC / KDP / KCL / KMC | FSM lifecycle 약어 (4-letter codes) |
| goal-tree:875 | Goal | Goal/OKR 도메인 용어 (한국어 \"목표\" 와 의미 분리) |
| keeper-detail:685 | PRs | GitHub 표준 약어 |
| keeper-detail:672, 691 | shallow / draft | git/GitHub 표준 상태 |

## Test fixture coupling 검증

| 단어 | Test 등장 | 충돌 |
|---|---|---|
| Monitoring / Composite Lifecycle / Trend / Goal-Scoped / Repos / Worktrees / Keeper ↓ | -- | ❌ 0 |

## Test plan

- [ ] \`pnpm dev\` — 6 컴포넌트 시각 확인:
  - keeper detail breadcrumb (모니터링 / 에이전트 / 키퍼 상세)
  - state diagram section header (통합 라이프사이클)
  - eval-quality trend label (추세 (24h))
  - goal tree task creation card heading (Goal 범위 태스크)
  - connector-keeper matrix axis label
  - keeper-detail playground 저장소/워크트리 count headers

## 라운드 누적 (23-39)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-37 | -- | MERGED | 48 |
| 38 | #10708 | MERGED | 8 |
| 39 | this | Draft | **7** |

누적 chips ≈ **120**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)