### PR TITLE
fix(oas-bridge): add ProviderTerminal arm at 3 partial-match sites

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1350,6 +1350,13 @@ let run_named
         | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
             Keeper_types.Other_detail
               (Printf.sprintf "%s provider requires a CLI transport" kind)
+        | Some (Llm_provider.Http_client.ProviderTerminal
+            { kind = Llm_provider.Http_client.Max_turns _; _ }) ->
+            Keeper_types.Max_turns_exceeded
+        | Some (Llm_provider.Http_client.ProviderTerminal
+            { kind = Llm_provider.Http_client.Other subtype; message }) ->
+            Keeper_types.Other_detail
+              (Printf.sprintf "provider terminal %s: %s" subtype message)
         | None -> Keeper_types.No_providers_available
       in
       let observation =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -21,6 +21,13 @@ let error_message_of_http_error = function
   | Llm_provider.Http_client.AcceptRejected { reason } -> reason
   | Llm_provider.Http_client.CliTransportRequired { kind } ->
       Printf.sprintf "%s provider requires a CLI transport" kind
+  | Llm_provider.Http_client.ProviderTerminal
+      { kind = Llm_provider.Http_client.Max_turns { turns; limit }; message } ->
+      Printf.sprintf "provider terminal: max turns exceeded (%d/%d): %s"
+        turns limit message
+  | Llm_provider.Http_client.ProviderTerminal
+      { kind = Llm_provider.Http_client.Other subtype; message } ->
+      Printf.sprintf "provider terminal: %s: %s" subtype message
   | Llm_provider.Http_client.HttpError { code; body } -> (
       try
         let json = Yojson.Safe.from_string body in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -123,6 +123,13 @@ let error_message_of_http_error = function
   | Llm_provider.Http_client.AcceptRejected { reason } -> reason
   | Llm_provider.Http_client.CliTransportRequired { kind } ->
       Printf.sprintf "%s provider requires a CLI transport" kind
+  | Llm_provider.Http_client.ProviderTerminal
+      { kind = Llm_provider.Http_client.Max_turns { turns; limit }; message } ->
+      Printf.sprintf "provider terminal: max turns exceeded (%d/%d): %s"
+        turns limit message
+  | Llm_provider.Http_client.ProviderTerminal
+      { kind = Llm_provider.Http_client.Other subtype; message } ->
+      Printf.sprintf "provider terminal: %s: %s" subtype message
   | Llm_provider.Http_client.HttpError { code; body } -> (
       try
         let json = Yojson.Safe.from_string body in


### PR DESCRIPTION
fix(oas-bridge): add ProviderTerminal arm at 3 partial-match sites

OAS #1204 (162940fd, merged via masc-mcp #10667) added a new variant
ProviderTerminal { kind: provider_terminal_kind; message: string } to
Llm_provider.Http_client.<error_type>. The downstream sweep was
incomplete, leaving 3 main-blocking partial-match warnings (warning 8,
treated as error via -warn-error +8):

- lib/tool_local_runtime_bench.ml:19
- lib/tool_local_runtime_verify.ml:121
- lib/oas_worker_named.ml:1329

All three currently pattern-match on Http_client error variants without
covering ProviderTerminal. memory feedback_variant-add-partial-match-cascade
documents this exact pattern.

This fix-forward (per the memory's prescription — never revert when the
upstream feature is wanted) adds explicit arms so:

- bench/verify error_message_of_http_error: ProviderTerminal stringifies
  to "provider terminal: max turns exceeded (T/L): MSG" or "provider
  terminal: SUBTYPE: MSG". Unique prefix avoids collision with
  CliTransportRequired or HttpError formatting.
- oas_worker_named cascade reason mapping:
  - ProviderTerminal { Max_turns _ } → Keeper_types.Max_turns_exceeded
    (matches the existing CLI-message-pattern→Max_turns_exceeded heuristic
    that this variant supersedes).
  - ProviderTerminal { Other subtype; message } → Other_detail
    "provider terminal SUBTYPE: MSG" so dashboards can distinguish.

Determinism: structural variant addition; pattern compilation is
deterministic. No behavioural change for non-ProviderTerminal paths.

Unblocks: #10707 (diag/prometheus-deadlock-hook), #10709 (chore/oas-pin
1201) — both inherit this main breakage.
