### PR TITLE
feat(dashboard): localize 12 chips/tooltips/aria-labels across 6 components (round-40)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -729,15 +729,15 @@ function HealthTable({
               >거부</th>
               <th
                 class="text-right py-1"
-                title="Prompt prefill throughput (entry-weighted mean across this provider's models)"
+                title="프롬프트 prefill 처리량 (이 provider 의 모델 entry-가중 평균)"
               >Prefill tok/s</th>
               <th
                 class="text-right py-1"
-                title="Decode throughput (predicted tokens / second, entry-weighted)"
+                title="Decode 처리량 (예측 토큰 / 초, entry-가중)"
               >Decode tok/s</th>
               <th
                 class="text-right py-1"
-                title="Latency p50 / p95 in milliseconds (approximation: weighted mean of per-model percentiles)"
+                title="Latency p50 / p95 (밀리초, 모델별 퍼센타일의 가중 평균 근사)"
               >Latency p50/p95</th>
               <th class="text-right py-1">쿨다운</th>
             </tr>
@@ -759,7 +759,7 @@ function HealthTable({
                 <td class="py-1">
                   <code class="text-[var(--text-strong)]">${p.provider_key}</code>
                   ${orphaned
-                    ? html`<span class="ml-1 text-2xs text-[var(--warn)]" title="Provider was tracked but is no longer declared in cascade.json">orphan</span>`
+                    ? html`<span class="ml-1 text-2xs text-[var(--warn)]" title="Provider 가 추적되었지만 cascade.json 에 더 이상 선언되어 있지 않음">orphan</span>`
                     : null}
                 </td>
                 <td class="py-1">

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -155,7 +155,7 @@ export function CompositeFsmFlowchart(props: CompositeFsmFlowchartProps = {}) {
           source=${MERMAID_COMPOSITE}
           prefix="composite-fsm"
           minHeightClass="min-h-80"
-          fallbackText="Flowchart render failed — see browser console."
+          fallbackText="플로우차트 렌더 실패 — 브라우저 콘솔을 확인하세요."
         />
       </div>
     </section>

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -962,7 +962,7 @@ function ConnectorLivePanel({
             >
               <span
                 class="mr-2 inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-status-warn)]"
-                aria-label="Keeper directory status: unavailable"
+                aria-label="키퍼 디렉토리 상태: 사용 불가"
               >
                 <span aria-hidden="true">⚠</span>
                 <span>디렉토리 오류</span>
@@ -989,7 +989,7 @@ function ConnectorLivePanel({
               <div class="mb-1 flex items-center gap-2">
                 <span
                   class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-status-warn)]"
-                  aria-label="Keeper configuration status: none configured"
+                  aria-label="키퍼 설정 상태: 설정된 키퍼 없음"
                   data-no-keepers-status-chip
                 >
                   <span aria-hidden="true">⊘</span>
@@ -1030,7 +1030,7 @@ function ConnectorLivePanel({
                   <div class="flex flex-wrap items-center gap-2">
                     <span
                       class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-status-warn)]"
-                      aria-label="Sidecar process status: not running"
+                      aria-label="사이드카 프로세스 상태: 실행 중 아님"
                       data-sidecar-status-chip
                     >
                       <span aria-hidden="true">⊘</span>

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -762,23 +762,23 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                 <span
                   data-runtime-truth="live"
                   class="rounded border px-2 py-0.5 text-xs ${runtimeTallies.live === runtimeTallies.total ? RUNTIME_ATTENTION_CLASS.ok : RUNTIME_ATTENTION_CLASS.stale}"
-                  title="Composite observer is_live count"
+                  title="통합 observer 의 is_live 카운트"
                 >
-                  Runtime live: ${runtimeTallies.live}/${runtimeTallies.total}
+                  런타임 활성: ${runtimeTallies.live}/${runtimeTallies.total}
                 </span>
                 <span
                   data-runtime-truth="blocked"
                   class="rounded border px-2 py-0.5 text-xs ${runtimeTallies.blocked === 0 ? RUNTIME_ATTENTION_CLASS.ok : RUNTIME_ATTENTION_CLASS.blocked}"
-                  title="Rows with operator disposition, terminal error, or failed tool contract evidence"
+                  title="운영자 disposition, 터미널 에러, 또는 tool contract 위반 evidence 가 있는 row"
                 >
-                  Evidence blocked: ${runtimeTallies.blocked}
+                  근거 차단: ${runtimeTallies.blocked}
                 </span>
                 <span
                   data-runtime-truth="stale"
                   class="rounded border px-2 py-0.5 text-xs ${runtimeTallies.stale + runtimeTallies.idle === 0 ? RUNTIME_ATTENTION_CLASS.ok : RUNTIME_ATTENTION_CLASS.stale}"
-                  title="Rows that are not live or stayed in the idle composite longer than the operator threshold"
+                  title="활성 상태가 아니거나 운영자 임계값보다 오래 idle 통합 상태를 유지한 row"
                 >
-                  Idle/stale: ${runtimeTallies.stale + runtimeTallies.idle}
+                  유휴/지연: ${runtimeTallies.stale + runtimeTallies.idle}
                 </span>
               </div>
             `

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -881,7 +881,7 @@ function SkeletonBar({ w, h = 'h-3' }: { w: string; h?: string }) {
 
 function SkeletonLayout() {
   return html`
-    <div class="flex flex-col gap-3" aria-hidden="true" aria-label="Loading composite snapshot">
+    <div class="flex flex-col gap-3" aria-hidden="true" aria-label="통합 스냅샷 로딩 중">
       ${/* Operator Meaning skeleton */ ''}
       <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-4">
         <${SkeletonBar} w="w-24" h="h-2" />

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -246,7 +246,7 @@ export function PrometheusMetrics() {
   }
 
   if (metrics.value.length === 0) {
-    return html`<${EmptyState} message="No metrics available" />`
+    return html`<${EmptyState} message="사용 가능한 메트릭이 없습니다" />`
   }
 
   // Group by category (filtered if search active)


### PR DESCRIPTION
## Summary

대시보드 라운드 40 — tooltip / aria-label / runtime-truth chip 12종 한국어화. 첫 라운드의 \"chip\" 위주가 sentence-level tooltip 으로 전환된 단계.

| File | Element | Before | After |
|---|---|---|---|
| fsm-hub.ts:884 | aria-label | Loading composite snapshot | 통합 스냅샷 로딩 중 |
| composite-fsm-flowchart.ts:158 | fallbackText | Flowchart render failed — see browser console. | 플로우차트 렌더 실패 — 브라우저 콘솔을 확인하세요. |
| cascade-config-panel.ts:732 | tooltip | Prompt prefill throughput (entry-weighted mean ...) | 프롬프트 prefill 처리량 (이 provider 의 모델 entry-가중 평균) |
| cascade-config-panel.ts:736 | tooltip | Decode throughput (predicted tokens / second, ...) | Decode 처리량 (예측 토큰 / 초, entry-가중) |
| cascade-config-panel.ts:740 | tooltip | Latency p50 / p95 in milliseconds (approximation: ...) | Latency p50 / p95 (밀리초, 모델별 퍼센타일의 가중 평균 근사) |
| cascade-config-panel.ts:762 | orphan tooltip | Provider was tracked but is no longer declared in cascade.json | Provider 가 추적되었지만 cascade.json 에 더 이상 선언되어 있지 않음 |
| prometheus-metrics.ts:249 | EmptyState message | No metrics available | 사용 가능한 메트릭이 없습니다 |
| fleet-fsm-matrix.ts:765 | tooltip + chip | Composite observer is_live count / Runtime live: N/M | 통합 observer 의 is_live 카운트 / 런타임 활성: N/M |
| fleet-fsm-matrix.ts:772 | tooltip + chip | Rows with operator disposition ... / Evidence blocked: N | 운영자 disposition ... / 근거 차단: N |
| fleet-fsm-matrix.ts:779 | tooltip + chip | Rows that are not live ... / Idle/stale: N | 활성 상태가 아니거나 ... / 유휴/지연: N |
| connector-status.ts:965 | aria-label | Keeper directory status: unavailable | 키퍼 디렉토리 상태: 사용 불가 |
| connector-status.ts:992 | aria-label | Keeper configuration status: none configured | 키퍼 설정 상태: 설정된 키퍼 없음 |
| connector-status.ts:1033 | aria-label | Sidecar process status: not running | 사이드카 프로세스 상태: 실행 중 아님 |

## 보존 (영문/도메인 용어 유지)

| 위치 | 단어 | 이유 |
|---|---|---|
| cascade-config-panel | tok/s, Prefill, Decode, Latency, p50/p95 | LLM 운영 약어 / metric jargon |
| cascade-config-panel | orphan | git/cascade 표준 상태 |
| 전반 | Provider | 도메인 entity (이 PR 일부 tooltip 에 한국어로 풀어 쓰기 시도) |
| fleet-fsm-matrix | is_live, idle, row | 데이터 필드/스키마 용어 |

## Test fixture coupling 검증

| 단어 | Test 등장 | 충돌 |
|---|---|---|
| Loading composite snapshot / Flowchart render failed | -- | ❌ 0 |
| Prompt prefill throughput / Decode throughput / Latency p50 | -- | ❌ 0 |
| No metrics available | -- | ❌ 0 |
| Composite observer / Rows with operator / Rows that are not live | -- | ❌ 0 |
| Keeper directory / Keeper configuration / Sidecar process | -- | ❌ 0 |

## 라운드 누적 (23-40)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-38 | -- | MERGED | 56 |
| 39 | #10712 | Draft | 7 |
| 40 | this | Draft | **12** |

누적 chips ≈ **132**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)