### PR TITLE
refactor(design-system): swap connector-quick-bind keeper select to Select canonical (CS11)

### DIFF
--- a/dashboard/src/components/connector-quick-bind.ts
+++ b/dashboard/src/components/connector-quick-bind.ts
@@ -12,6 +12,7 @@ import { signal } from '@preact/signals'
 import type { GateKeeperInfo } from '../api/gate'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
+import { Select } from './common/select'
 import { bindConnector } from './connector-status'
 
 interface FormEntry {
@@ -128,18 +129,14 @@ export function QuickBindForm({ connectorId, keepers }: {
         <label class="mb-1 block text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]" for=${`qb-keeper-${connectorId}`}>
           Keeper
         </label>
-        <select
+        <${Select}
           id=${`qb-keeper-${connectorId}`}
-          class="w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-2xs text-[var(--color-fg-primary)] focus:border-[var(--accent-1)] focus:outline-none"
-          onChange=${(ev: Event) => {
-            const target = ev.currentTarget as HTMLSelectElement
-            setEntry(connectorId, { keeperName: target.value })
-          }}
-        >
-          ${keepers.map(k => html`
-            <option value=${k.name} selected=${k.name === entry.keeperName}>${k.name}</option>
-          `)}
-        </select>
+          class="px-2 py-1 font-mono text-2xs"
+          ariaLabel="키퍼 선택"
+          value=${entry.keeperName}
+          options=${keepers.map(k => k.name)}
+          onInput=${(v: string) => { setEntry(connectorId, { keeperName: v }) }}
+        />
       </div>
       <${ActionButton}
         variant="primary"


### PR DESCRIPTION
## Summary

CS series select sweep #2. keeper picker `<select>` → Select canonical.

## 변경

`dashboard/src/components/connector-quick-bind.ts`:

**Before**:
```tsx
<select
  id=${`qb-keeper-${connectorId}`}
  class="w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-2xs text-[var(--color-fg-primary)] focus:border-[var(--accent-1)] focus:outline-none"
  onChange=${(ev: Event) => {
    const target = ev.currentTarget as HTMLSelectElement
    setEntry(connectorId, { keeperName: target.value })
  }}
>
  ${keepers.map(k => html`
    <option value=${k.name} selected=${k.name === entry.keeperName}>${k.name}</option>
  `)}
</select>
```

**After**:
```tsx
<${Select}
  id=${`qb-keeper-${connectorId}`}
  class="px-2 py-1 font-mono text-2xs"
  ariaLabel="키퍼 선택"
  value=${entry.keeperName}
  options=${keepers.map(k => k.name)}
  onInput=${(v: string) => { setEntry(connectorId, { keeperName: v }) }}
/>
```

## 핵심 발견

**per-option `selected={...}` → 단일 `value` prop**: 원본은 each option이 자기 selected 판정. Select canonical은 native `<select>` value 패턴으로 단일 source of truth. 동작 동치 + 코드 -3 lines.

**string[] options shorthand**: `keepers.map(k => k.name)` 으로 `Array<string>` 전달. Select가 `string | {value, label}` union 처리.

palette 100% 호환 (양쪽 design-system 토큰).

## 이점

- focus-visible:ring-2 (a11y, 원본 focus:outline-none이었음 → 향상)
- ariaLabel "키퍼 선택" 명시 (label `for=` 외 추가 명시)
- testId 가능 (E2E i18n decoupling)

## 검증

- pnpm typecheck: green
- pnpm test src/components/connector-quick-bind: 11/11 pass

## CS series progress

| PR | 카테고리 | 상태 |
|----|---------|------|
| CS1~9 | 30 inline buttons | MERGED |
| CS10 #10715 | governance-monitor select+button | OPEN |
| CS11 (this) | connector-quick-bind keeper select | OPEN |

## Test plan

- [ ] CI green
- [ ] Connector quick-bind 폼에서 keeper 변경 정상
- [ ] focus ring (accent-45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
