### PR TITLE
refactor(oas-compat): route ProviderTerminal through boundary adapter (followup #10713)

### DIFF
--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -61,6 +61,7 @@ let format_exhausted_error last_err =
     | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
       Printf.sprintf "%s provider requires a CLI transport" kind
     | Some (Llm_provider.Http_client.NetworkError { message; _ }) -> message
+    | Some (Llm_provider.Http_client.ProviderTerminal { message; _ }) -> message
     | None -> "No providers available"
   in
   let network_error_kind =

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -25,6 +25,7 @@ type cascade_failure_class =
   | Accept_rejected_terminal
   | Cli_transport_required
   | Network_error
+  | Provider_terminal
 
 let classify_failure err = Oas_compat.Http_client.classify err
 

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -11,6 +11,7 @@ module Http_client = struct
     | Accept_rejected_terminal
     | Cli_transport_required
     | Network_error
+    | Provider_terminal
 
   (* Case-insensitive substring check, mirroring [cascade_health_filter]. *)
   let contains_ci ?(max_scan = 512) ~haystack ~needle () =
@@ -93,12 +94,14 @@ module Http_client = struct
       | Llm_provider.Http_client.CliTransportRequired _ ->
           Cli_transport_required
       | Llm_provider.Http_client.NetworkError _ -> Network_error
+      | Llm_provider.Http_client.ProviderTerminal _ -> Provider_terminal
 
   let should_cascade (err : Llm_provider.Http_client.http_error) : bool =
     match classify err with
     | Local_resource_exhaustion
     | Terminal_http _
-    | Accept_rejected_terminal ->
+    | Accept_rejected_terminal
+    | Provider_terminal ->
         false
     | Context_overflow
     | Provider_parse_error

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -31,6 +31,10 @@ module Http_client : sig
     | Accept_rejected_terminal
     | Cli_transport_required
     | Network_error
+    | Provider_terminal
+        (** Provider returned a structured terminal signal (e.g. max_turns
+            exhausted). The next provider would hit the same conceptual
+            limit, so cascading is not useful. *)
 
   val classify : Llm_provider.Http_client.http_error -> cascade_failure_class
   (** Classify an OAS HTTP/client failure into MASC's typed cascade boundary.

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1350,6 +1350,12 @@ let run_named
         | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
             Keeper_types.Other_detail
               (Printf.sprintf "%s provider requires a CLI transport" kind)
+        | Some (Llm_provider.Http_client.ProviderTerminal { kind; message }) -> (
+            match kind with
+            | Llm_provider.Http_client.Max_turns _ ->
+                Keeper_types.Max_turns_exceeded
+            | Llm_provider.Http_client.Other _ ->
+                Keeper_types.Other_detail message)
         | None -> Keeper_types.No_providers_available
       in
       let observation =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -21,6 +21,7 @@ let error_message_of_http_error = function
   | Llm_provider.Http_client.AcceptRejected { reason } -> reason
   | Llm_provider.Http_client.CliTransportRequired { kind } ->
       Printf.sprintf "%s provider requires a CLI transport" kind
+  | Llm_provider.Http_client.ProviderTerminal { message; _ } -> message
   | Llm_provider.Http_client.HttpError { code; body } -> (
       try
         let json = Yojson.Safe.from_string body in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -123,6 +123,7 @@ let error_message_of_http_error = function
   | Llm_provider.Http_client.AcceptRejected { reason } -> reason
   | Llm_provider.Http_client.CliTransportRequired { kind } ->
       Printf.sprintf "%s provider requires a CLI transport" kind
+  | Llm_provider.Http_client.ProviderTerminal { message; _ } -> message
   | Llm_provider.Http_client.HttpError { code; body } -> (
       try
         let json = Yojson.Safe.from_string body in


### PR DESCRIPTION
## Context

PR #10713 (already MERGED) fixed the **3 partial-match build break sites** that blocked v0.18.0 release:
- `lib/oas_worker_named.ml`, `lib/tool_local_runtime_bench.ml`, `lib/tool_local_runtime_verify.ml`

This PR is the **architectural follow-up**: route `ProviderTerminal` through the `Oas_compat.Http_client` boundary adapter and add the missing arm at one more call site that #10713 did not touch.

## What this adds (4 files, 10 lines)

| File | Change |
|------|--------|
| `lib/oas_compat/oas_compat.{ml,mli}` | Add new `Provider_terminal` to `cascade_failure_class`. `should_cascade=false` (max_turns reached → next provider hits same conceptual limit). |
| `lib/cascade/cascade_health_filter.ml` | Extend re-export of `cascade_failure_class`. |
| `lib/cascade/cascade_fsm.ml` | `format_exhausted_error`: add `ProviderTerminal { message; _ }` arm |

## Why a separate PR

This complements #10713 rather than competing with it:
- #10713 did the immediate P0 surface fixes (3 sites)
- This adds the typed cascade classification (`Provider_terminal`) that downstream cascade health logic and the `cascade_fsm.format_exhausted_error` consumer can branch on

`lib/cascade/cascade_fsm.ml` was a remaining partial-match site that #10713 did not include — without it `format_exhausted_error` is non-exhaustive when it ever reaches `ProviderTerminal`.

## Verification

- Local opam pin `162940fd60552156c45431544efa3cec5d61f1ca`
- `dune build --root .` exits 0

## Decision: cascade or stop?

`should_cascade Provider_terminal = false`. Rationale: `Max_turns` and `Other` provider-terminal signals indicate the provider returned a structured terminal status (vs. transport failure). Cascading to the next provider would hit the same conceptual limit (turn budget exhausted, max-tokens, etc.) without informing the user that the underlying call structurally failed. Local supervisor / keeper layers can take a higher-level decision (resume, increase budget, escalate) rather than blindly retrying.

## Test plan

- [x] Build clean with new pin
- [ ] CI green
- [ ] No regression in cascade health classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)