### PR TITLE
fix(oas-boundary): close ProviderTerminal partial-match in Oas_compat (CI red)

### DIFF
--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -61,6 +61,13 @@ let format_exhausted_error last_err =
     | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
       Printf.sprintf "%s provider requires a CLI transport" kind
     | Some (Llm_provider.Http_client.NetworkError { message; _ }) -> message
+    | Some (Llm_provider.Http_client.ProviderTerminal _ as err) ->
+      (* Mirror the rendering shape used elsewhere on main HEAD
+         (tool_local_runtime_bench / verify): "provider terminal:
+         <kind>: <message>". The boundary adapter
+         [Oas_compat.Http_client.error_message] supplies that exact
+         format, so future variant additions only break the adapter. *)
+      Oas_compat.Http_client.error_message err
     | None -> "No providers available"
   in
   let network_error_kind =

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -25,6 +25,7 @@ type cascade_failure_class =
   | Accept_rejected_terminal
   | Cli_transport_required
   | Network_error
+  | Provider_terminal
 
 let classify_failure err = Oas_compat.Http_client.classify err
 

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -11,6 +11,14 @@ module Http_client = struct
     | Accept_rejected_terminal
     | Cli_transport_required
     | Network_error
+    | Provider_terminal
+        (** OAS [ProviderTerminal] — provider has signalled a terminal
+            condition (e.g. claude_cli [error_max_turns]). Treat as
+            cascade-stopping; the next provider would face the same
+            agent-level limit. Sub-kind ([Max_turns]/[Other]) is
+            collapsed here because [should_cascade] only needs the
+            terminality bit; consumers wanting the message extract it
+            via the original [ProviderTerminal] match. *)
 
   (* Case-insensitive substring check, mirroring [cascade_health_filter]. *)
   let contains_ci ?(max_scan = 512) ~haystack ~needle () =
@@ -93,12 +101,14 @@ module Http_client = struct
       | Llm_provider.Http_client.CliTransportRequired _ ->
           Cli_transport_required
       | Llm_provider.Http_client.NetworkError _ -> Network_error
+      | Llm_provider.Http_client.ProviderTerminal _ -> Provider_terminal
 
   let should_cascade (err : Llm_provider.Http_client.http_error) : bool =
     match classify err with
     | Local_resource_exhaustion
     | Terminal_http _
-    | Accept_rejected_terminal ->
+    | Accept_rejected_terminal
+    | Provider_terminal ->
         false
     | Context_overflow
     | Provider_parse_error
@@ -107,6 +117,30 @@ module Http_client = struct
     | Cli_transport_required
     | Network_error ->
         true
+
+  let error_message (err : Llm_provider.Http_client.http_error) : string =
+    match err with
+    | Llm_provider.Http_client.NetworkError { message; _ } -> message
+    | Llm_provider.Http_client.AcceptRejected { reason } -> reason
+    | Llm_provider.Http_client.CliTransportRequired { kind } ->
+        Printf.sprintf "%s provider requires a CLI transport" kind
+    | Llm_provider.Http_client.ProviderTerminal
+        { kind = Llm_provider.Http_client.Max_turns { turns; limit }; message } ->
+        Printf.sprintf "provider terminal: max turns exceeded (%d/%d): %s"
+          turns limit message
+    | Llm_provider.Http_client.ProviderTerminal
+        { kind = Llm_provider.Http_client.Other subtype; message } ->
+        Printf.sprintf "provider terminal: %s: %s" subtype message
+    | Llm_provider.Http_client.HttpError { code; body } -> (
+        try
+          let json = Yojson.Safe.from_string body in
+          match Yojson.Safe.Util.member "error" json with
+          | `Assoc fields -> (
+              match List.assoc_opt "message" fields with
+              | Some (`String msg) -> msg
+              | _ -> Printf.sprintf "HTTP %d" code)
+          | _ -> Printf.sprintf "HTTP %d" code
+        with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
 end
 
 module Metrics = struct

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -31,6 +31,7 @@ module Http_client : sig
     | Accept_rejected_terminal
     | Cli_transport_required
     | Network_error
+    | Provider_terminal
 
   val classify : Llm_provider.Http_client.http_error -> cascade_failure_class
   (** Classify an OAS HTTP/client failure into MASC's typed cascade boundary.
@@ -62,6 +63,21 @@ module Http_client : sig
       All of these are per-provider, not cascade-wide; a fallback provider
       may succeed where the current one rejected. See masc-mcp #9932
       (kimi fallback), #9850 (codex_cli runtime_mcp_auth). *)
+
+  val error_message : Llm_provider.Http_client.http_error -> string
+  (** Extract a human-readable message from an OAS HTTP error.
+
+      Centralises the "render error for log/observation" logic so callers
+      stop pattern-matching the OAS variant directly. When OAS adds a new
+      [http_error] variant, only this adapter (and its [classify] /
+      [should_cascade]) need to be updated — without this helper, every
+      consumer carries its own copy of the match and a new variant breaks
+      [warn-error +8] across the codebase (see #oas-providerterminal-sweep
+      2026-04-26 cascade where 5 sites repeated the same match).
+
+      For [HttpError] the body is parsed as JSON to surface the
+      provider-supplied [error.message] when present; otherwise the HTTP
+      status code is rendered. *)
 end
 
 module Metrics : sig

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -80,6 +80,70 @@ let test_http_429_cascades () =
     true
     (Oas_compat.Http_client.should_cascade err)
 
+(* --- ProviderTerminal: pin classify, should_cascade, and the new
+       error_message helper. The variant arrived in agent_sdk without
+       a sweep, so [warn-error +8] flipped 5 [partial-match] warnings
+       to hard errors on main (#oas-providerterminal-sweep
+       2026-04-26). The new helper [Oas_compat.Http_client.error_message]
+       centralises the per-variant rendering so the next OAS variant
+       addition fails to compile *only* in this adapter. *)
+
+let test_provider_terminal_max_turns () =
+  let err =
+    Http_client.ProviderTerminal
+      { kind = Max_turns { turns = 10; limit = 10 };
+        message = "agent reached max_turns" }
+  in
+  Alcotest.(check bool)
+    "ProviderTerminal Max_turns must NOT cascade — agent-level terminal"
+    false
+    (Oas_compat.Http_client.should_cascade err);
+  (match Oas_compat.Http_client.classify err with
+   | Provider_terminal -> ()
+   | _ -> Alcotest.fail "Max_turns must classify as Provider_terminal");
+  let rendered = Oas_compat.Http_client.error_message err in
+  Alcotest.(check bool)
+    "error_message renders kind + turns/limit + message"
+    true
+    (String.length rendered > 0
+     && Astring.String.is_infix ~affix:"max turns exceeded" rendered
+     && Astring.String.is_infix ~affix:"10/10" rendered)
+
+let test_provider_terminal_other () =
+  let err =
+    Http_client.ProviderTerminal
+      { kind = Other "structured_terminal_subtype";
+        message = "provider signalled terminal condition" }
+  in
+  Alcotest.(check bool)
+    "ProviderTerminal Other must NOT cascade"
+    false
+    (Oas_compat.Http_client.should_cascade err);
+  (match Oas_compat.Http_client.classify err with
+   | Provider_terminal -> ()
+   | _ -> Alcotest.fail "Other must classify as Provider_terminal");
+  let rendered = Oas_compat.Http_client.error_message err in
+  Alcotest.(check bool)
+    "error_message renders subtype + message"
+    true
+    (Astring.String.is_infix ~affix:"structured_terminal_subtype" rendered
+     && Astring.String.is_infix ~affix:"provider signalled" rendered)
+
+let test_error_message_baseline () =
+  (* Smoke check that the new helper preserves existing semantics for
+     the variants that already had inline matches at the call sites. *)
+  let net = Http_client.NetworkError
+              { message = "boom"; kind = Llm_provider.Http_client.Unknown } in
+  Alcotest.(check string) "NetworkError -> message"
+    "boom" (Oas_compat.Http_client.error_message net);
+  let cli = Http_client.CliTransportRequired { kind = "claude" } in
+  Alcotest.(check string) "CliTransportRequired -> humanised"
+    "claude provider requires a CLI transport"
+    (Oas_compat.Http_client.error_message cli);
+  let acc = Http_client.AcceptRejected { reason = "x" } in
+  Alcotest.(check string) "AcceptRejected -> reason"
+    "x" (Oas_compat.Http_client.error_message acc)
+
 let () =
   Alcotest.run "oas_compat_cascade_fallback"
     [
@@ -103,5 +167,17 @@ let () =
       ( "Baseline: HTTP errors unaffected",
         [
           Alcotest.test_case "HTTP 429 cascades" `Quick test_http_429_cascades;
+        ] );
+      ( "ProviderTerminal — agent-level terminal does not cascade",
+        [
+          Alcotest.test_case "Max_turns classify + cascade + message"
+            `Quick test_provider_terminal_max_turns;
+          Alcotest.test_case "Other classify + cascade + message"
+            `Quick test_provider_terminal_other;
+        ] );
+      ( "error_message helper baseline",
+        [
+          Alcotest.test_case "preserves existing variants"
+            `Quick test_error_message_baseline;
         ] );
     ]


### PR DESCRIPTION
## Summary

CI is **red** on the default branch at `lib/oas_compat/oas_compat.ml:75-95` (`partial-match` for `ProviderTerminal _` under `warn-error +8`). User repro:

```
$ dune build
File "lib/oas_compat/oas_compat.ml", lines 75-95, characters 6-64:
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
  Here is an example of a case that is not matched: ProviderTerminal _
```

Other PRs already added arms in `tool_local_runtime_bench`, `tool_local_runtime_verify`, and `oas_worker_named.ml`. The boundary adapter `Oas_compat` itself was missed — that is what this PR fixes.

## Scope (boundary only — 3 files + 1 test)

| File | Change |
|------|--------|
| `lib/oas_compat/oas_compat.ml(.mli)` | New variant `Provider_terminal` in `cascade_failure_class`. Classify arm + cascade decision (terminal, no cascade). New helper `error_message : http_error -> string`. |
| `lib/cascade/cascade_health_filter.ml` | Re-export `Provider_terminal` |
| `lib/cascade/cascade_fsm.ml` | `format_exhausted_error` arm — delegates `ProviderTerminal` rendering to the new helper, keeps existing arms with local semantics. |
| `test/test_oas_compat_cascade_fallback.ml` | +3 regression cases. |

## Structural improvement

The new helper `Oas_compat.Http_client.error_message` centralises per-variant rendering. Previous fragmentation pattern: 5 call sites carrying their own copy of the match → OAS adds a variant → 5 hard errors. After this PR: route through `error_message` → OAS adds a variant → 1 hard error in `Oas_compat`. cascade_fsm already routes the new arm through it; future fragmentation cleanups can route the other surviving callers through the same helper.

## Cascade decision

`ProviderTerminal _` does **not** cascade — agent-level limits like `error_max_turns` are not provider-specific (the next provider would face the same limit). Pinned by `should_cascade=false` in two test cases (Max_turns, Other).

## Tests

- `test_oas_compat_cascade_fallback`: **8/8 pass** (5 existing + 3 new):
  - `ProviderTerminal Max_turns classify + cascade + message`
  - `ProviderTerminal Other classify + cascade + message`
  - `error_message helper baseline` (NetworkError / CliTransportRequired / AcceptRejected preserved)
- `test_cascade_runtime`: **9/9 pass** (regression baseline preserved)
- `dune build @check`: green on this branch

## Risk

The classify mapping collapses `Max_turns` and `Other` into a single `Provider_terminal` class, because `should_cascade` only needs the terminality bit. Consumers wanting the kind details extract them via the original `Llm_provider.Http_client.ProviderTerminal` match (e.g. `oas_worker_named.ml` already does this on the default branch). The new helper preserves the kind-level rendering shape used elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
