### PR TITLE
feat(dashboard): localize 7 button loading states + Doctor config kind (round-41)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -430,7 +430,7 @@ function ProfileCard({
                     class="rounded border border-[var(--accent-primary)] bg-[var(--accent-primary)] px-3 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
                     disabled=${assigning.value || selectedKeeper.value === ''}
                   >
-                    ${assigning.value ? 'Assigning...' : 'Assign keeper'}
+                    ${assigning.value ? '할당 중...' : '키퍼 할당'}
                   </button>
                 </div>
               `
@@ -1155,7 +1155,7 @@ function CascadeRawConfigEditor({
               class="rounded border border-[var(--accent-primary)] bg-[var(--accent-primary)] px-3 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
               disabled=${saveDisabled}
             >
-              ${saving.value ? 'Saving...' : mode.saveLabel}
+              ${saving.value ? '저장 중...' : mode.saveLabel}
             </button>
             <button
               type="button"

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1222,7 +1222,7 @@ function ConnectorLivePanel({
                                       size="sm"
                                       disabled=${isActionLoading || ui.channelDraft.trim().length === 0}
                                       onClick=${() => { void bindConnector(connectorId, group.name, ui.channelDraft.trim()) }}
-                                    >${isActionLoading ? 'Applying...' : 'bind'}<//>
+                                    >${isActionLoading ? '적용 중...' : '연결'}<//>
                                   </div>
                                 </div>
                               `

--- a/dashboard/src/components/doctor-panel.test.ts
+++ b/dashboard/src/components/doctor-panel.test.ts
@@ -56,14 +56,14 @@ describe('severityChipClass', () => {
 })
 
 describe('doctorHeading', () => {
-  it('returns Config for config entries', () => {
+  it('returns 설정 for config entries', () => {
     const entry: DoctorEntry = {
       name: 'config',
       kind: 'config',
       exit_code: 0,
       payload: {},
     }
-    expect(doctorHeading(entry)).toBe('Config')
+    expect(doctorHeading(entry)).toBe('설정')
   })
   it('capitalises sidecar names', () => {
     const entry: DoctorEntry = {

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -72,9 +72,9 @@ export function severityChipClass(code: number): string {
 }
 
 // Human-readable heading for a doctor entry — sidecar names get capitalised
-// for display; config stays as "Config".
+// for display; config kind renders as "설정".
 export function doctorHeading(entry: DoctorEntry): string {
-  if (entry.kind === 'config') return 'Config'
+  if (entry.kind === 'config') return '설정'
   return entry.name.charAt(0).toUpperCase() + entry.name.slice(1)
 }
 

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -90,7 +90,7 @@ export function ExcusePatterns() {
               class="px-4 py-2 bg-[var(--accent-primary)] text-white rounded hover:opacity-90 disabled:opacity-50 text-sm font-medium"
               disabled=${saving.value}
             >
-              ${saving.value ? 'Saving...' : 'Save Patterns'}
+              ${saving.value ? '저장 중...' : '패턴 저장'}
             </button>
             ${saveMessage.value ? html`
               <span class="text-sm ${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid') ? 'text-[var(--bad-light)]' : 'text-[var(--color-status-ok)]'}">

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -417,7 +417,7 @@ export function KeeperRuntimeActions({
         }}
         disabled=${probing || !actor.trim()}
       >
-        ${probing ? 'Probing...' : 'Probe'}
+        ${probing ? '점검 중...' : '점검'}
       </button>
       <button type="button"
         class=${recommended === 'recover' ? activeSecondaryBtn : secondaryBtn}
@@ -429,7 +429,7 @@ export function KeeperRuntimeActions({
         }}
         disabled=${recovering || !canRecover || !actor.trim()}
       >
-        ${recovering ? 'Recovering...' : 'Recover'}
+        ${recovering ? '복구 중...' : '복구'}
       </button>
       <button type="button"
         class=${recommended === 'manual_social_sweep' ? activeGhostBtn : ghostBtn}


### PR DESCRIPTION
## Summary

대시보드 라운드 41 — 버튼 loading state 페어 6 + Doctor config kind 1 한국어화.

| File | Element | Before | After |
|---|---|---|---|
| excuse-patterns.ts:93 | submit button | Saving... / Save Patterns | 저장 중... / 패턴 저장 |
| cascade-config-panel.ts:433 | assign button | Assigning... / Assign keeper | 할당 중... / 키퍼 할당 |
| cascade-config-panel.ts:1158 | save button (loading only) | Saving... | 저장 중... |
| keeper-shared.ts:420 | probe button | Probing... / Probe | 점검 중... / 점검 |
| keeper-shared.ts:432 | recover button | Recovering... / Recover | 복구 중... / 복구 |
| connector-status.ts:1225 | bind button | Applying... / bind | 적용 중... / 연결 |
| doctor-panel.ts:77 | doctorHeading('config' kind) | Config | 설정 |

## Test sync (atomic)

\`doctor-panel.test.ts:59-66\` 의 1 assertion + describe 라벨 동기 변경:

\`\`\`diff
-  it('returns Config for config entries', () => {
+  it('returns 설정 for config entries', () => {
     ...
-    expect(doctorHeading(entry)).toBe('Config')
+    expect(doctorHeading(entry)).toBe('설정')
\`\`\`

sidecar name capitalisation tests (Discord, Cli) 는 보존 — \`name.charAt(0).toUpperCase()\` 동작이 변경되지 않음.

## 보존 (영문/computed 유지)

| 위치 | 단어/계산 | 이유 |
|---|---|---|
| cascade-config-panel.ts:1158 | \`mode.saveLabel\` | computed 라벨 (mode 별 다른 텍스트). loading state 만 변경 |
| doctor-panel.ts:77 | name capitalisation logic | sidecar name 그대로 사용 |
| connector-status.ts | Start, status, tail logs (round-34) | 버튼 라벨 / CLI 명령 인용 |

## 일관성 (round-35 와 정합)

\`'Config Doctor' → '설정 진단'\` (round-35) 와 동일 매핑:
- \`'Config'\` → \`'설정'\` ✓
- doctorHeading 의 다른 분기 (sidecar name) 영향 없음.

## Test fixture coupling 검증

| 단어 | Test 등장 | 처리 |
|---|---|---|
| Config | \`doctor-panel.test.ts:66\` | ✅ atomic test sync (이번 PR) |
| Saving / Probing / Recovering / Assigning / Applying / Save Patterns / Probe / Recover / Assign keeper / bind | -- | ❌ no couple |

## 라운드 누적 (23-41)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-39 | -- | MERGED | 63 |
| 40 | #10714 | MERGED | 12 |
| 41 | this | Draft | **7 (loading pairs + Config)** |

누적 chips ≈ **139**.

## Why Draft

#10645 (vitest infra) 미해결. test sync 가 PR 에 포함되어 vitest 복구 즉시 검증 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)