### PR TITLE
refactor(design-system): swap quick-intervene target select to canonical Select (CS13)

### DIFF
--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -7,6 +7,7 @@ import { useState } from 'preact/hooks'
 import { CARD_STANDARD } from '../common/card'
 import { ActionButton } from '../common/button'
 import { TextInput } from '../common/input'
+import { Select } from '../common/select'
 import {
   operatorActionBusy,
   operatorSnapshot,
@@ -67,20 +68,17 @@ export function QuickIntervene() {
       </div>
 
       <div class="flex gap-2 items-stretch flex-wrap">
-        <select
-          class="shrink-0 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm text-[var(--color-fg-primary)] transition-colors cursor-pointer min-w-30 focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]"
+        <${Select}
+          class="shrink-0 px-3 py-2 text-sm min-w-30"
           value=${quickTarget.value}
-          aria-label="개입 대상"
-          onChange=${(e: Event) => { quickTarget.value = (e.target as HTMLSelectElement).value }}
+          ariaLabel="개입 대상"
+          options=${[
+            { value: 'namespace', label: '전체' },
+            ...onlineKeepers.map(k => ({ value: `keeper:${k.name}`, label: k.name })),
+          ]}
+          onInput=${(v: string) => { quickTarget.value = v }}
           disabled=${busy}
-        >
-          <option value="namespace">전체</option>
-          ${onlineKeepers.map(k => html`
-            <option key=${k.name} value=${`keeper:${k.name}`}>
-              ${k.name}
-            </option>
-          `)}
-        </select>
+        />
         <${TextInput}
           class="min-w-50 flex-1 border-[var(--white-8)] bg-[var(--white-3)]"
           placeholder="메시지"


### PR DESCRIPTION
## Summary

CS series select sweep #4 — quick-intervene target picker.

## 변경

`dashboard/src/components/ops/quick-intervene.ts`:
- inline `<select>` (개입 대상) → `<${Select}>`
- options spread: `[{namespace}, ...onlineKeepers.map(k => ({value, label}))]`

palette: `--white-8` / `--white-3` / `--color-fg-primary` — design-system, 호환.

## 검증

- pnpm typecheck: green
- pnpm test src/components/common/select: 14/14 pass
- `quick-intervene.test.ts`는 baseline(main)에서도 timeout (flaky pre-existing, scope 외)

## CS series progress

| PR | 카테고리 | 상태 |
|----|---------|------|
| CS1~9 | 30 inline buttons | MERGED |
| CS10 #10715 | governance-monitor | MERGED |
| CS11 #10717 | connector-quick-bind | OPEN |
| CS12 #10722 | runtime-monitor | OPEN |
| CS13 (this) | quick-intervene | OPEN |

## Test plan

- [ ] CI green
- [ ] Quick intervene 폼: 대상 선택 (namespace / keeper:X) 정상
- [ ] focus ring (accent-45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
