### PR TITLE
refactor(design-system): swap tool-full-inventory category select to Select canonical (CS14)

### DIFF
--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -6,6 +6,7 @@ import { VirtualList } from '../common/virtual-list'
 import { EmptyState } from '../common/empty-state'
 import { ErrorState } from '../common/feedback-state'
 import { TextInput } from '../common/input'
+import { Select } from '../common/select'
 import { route } from '../../router'
 import type { DashboardToolInventoryItem } from '../../api'
 import { InventoryRow } from './tool-inventory-row'
@@ -138,20 +139,20 @@ export function FullInventoryView({
             searchQuery.value = (e.target as HTMLInputElement).value
           }}
         />
-        <select
-          class="px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] text-sm focus:border-[var(--color-accent-fg)]/50 outline-none"
+        <${Select}
+          class="px-3 py-2 text-sm"
           name="tool_inventory_category"
-          aria-label="도구 카테고리 필터"
+          ariaLabel="도구 카테고리 필터"
           value=${categoryFilter.value}
-          onChange=${(e: Event) => {
-            categoryFilter.value = (e.target as HTMLSelectElement).value
-          }}
-        >
-          <option value="all">전체 카테고리</option>
-          ${categories.map(category => html`
-            <option value=${category}>${category === 'uncategorized' ? '미분류' : category}</option>
-          `)}
-        </select>
+          options=${[
+            { value: 'all', label: '전체 카테고리' },
+            ...categories.map(category => ({
+              value: category,
+              label: category === 'uncategorized' ? '미분류' : category,
+            })),
+          ]}
+          onInput=${(v: string) => { categoryFilter.value = v }}
+        />
         <label class="inline-flex items-center gap-2 text-xs text-[var(--color-fg-primary)]">
           <input
             type="checkbox"


### PR DESCRIPTION
## Summary

CS series select sweep #5 — tool-full-inventory category filter.

## 변경

`dashboard/src/components/tools/tool-full-inventory.ts`:
- inline `<select>` (도구 카테고리 필터) → `<${Select}>`
- options: `[{all}, ...categories.map(c => ({value, label}))]`
- `uncategorized` → "미분류" 라벨 변환 유지

palette: design-system 토큰 호환.

## 검증

- pnpm typecheck: green
- 컴포넌트 테스트 없음

## CS series progress

| PR | 카테고리 | 상태 |
|----|---------|------|
| CS1~9 | 30 inline buttons | MERGED |
| CS10 #10715 | governance-monitor | MERGED |
| CS11 #10717 | connector-quick-bind | MERGED |
| CS12 #10722 | runtime-monitor | OPEN |
| CS13 #10724 | quick-intervene | OPEN |
| CS14 (this) | tool-full-inventory | OPEN |

## Test plan

- [ ] CI green
- [ ] Tool inventory 페이지: 카테고리 변경 → 필터 적용
- [ ] focus ring (accent-45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
