### PR TITLE
feat(dashboard): localize 16 enum-style labels (round-42)

### DIFF
--- a/dashboard/src/components/activity-graph-groups.ts
+++ b/dashboard/src/components/activity-graph-groups.ts
@@ -49,13 +49,13 @@ export function categoryForActivityKind(kind: string): ActivityCategory {
 
 export function categoryLabel(category: ActivityCategory): string {
   switch (category) {
-    case 'task': return 'Task'
-    case 'session': return 'Session'
-    case 'message': return 'Message'
-    case 'board': return 'Board'
-    case 'governance': return 'Governance'
-    case 'lifecycle': return 'Lifecycle'
-    default: return 'Other'
+    case 'task': return '태스크'
+    case 'session': return '세션'
+    case 'message': return '메시지'
+    case 'board': return '보드'
+    case 'governance': return '거버넌스'
+    case 'lifecycle': return '라이프사이클'
+    default: return '기타'
   }
 }
 

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -139,11 +139,11 @@ function flattenGoalTree(nodes: readonly GoalTreeNode[]): GoalTreeNode[] {
 function badgeLabel(badge: string): string {
   switch (badge) {
     case 'awaiting_approval': return '승인 대기'
-    case 'sandbox': return 'Sandbox'
+    case 'sandbox': return '샌드박스'
     case 'cascade': return 'Cascade'
     case 'task_verification_pending': return 'Task 검증 대기'
-    case 'stalled': return 'Stalled'
-    case 'linkage_warning': return 'Linkage'
+    case 'stalled': return '정체'
+    case 'linkage_warning': return '연결 경고'
     default: return badge
   }
 }
@@ -195,13 +195,13 @@ function healthClass(health: GoalTreeNode['health']): string {
 
 function blockerSourceLabel(source: GoalTreeNode['blocking_source']): string {
   switch (source) {
-    case 'goal_phase': return 'Goal phase'
-    case 'child_goal': return 'Child goal'
-    case 'approval': return 'Approval'
-    case 'keeper_runtime': return 'Keeper runtime'
+    case 'goal_phase': return 'Goal 단계'
+    case 'child_goal': return '하위 Goal'
+    case 'approval': return '승인'
+    case 'keeper_runtime': return '키퍼 런타임'
     case 'task_fsm': return 'Task FSM'
-    case 'goal_linkage': return 'Goal linkage'
-    case 'stalled': return 'Stalled'
+    case 'goal_linkage': return 'Goal 연결'
+    case 'stalled': return '정체'
     default: return source
   }
 }


### PR DESCRIPTION
## Summary

대시보드 라운드 42 — switch/case 매핑 함수 3종에서 enum→가시 라벨 16개 한국어화.

## goal-tree badgeLabel (3/6)

| case | Before | After |
|---|---|---|
| 'sandbox' | Sandbox | 샌드박스 |
| 'stalled' | Stalled | 정체 |
| 'linkage_warning' | Linkage | 연결 경고 |
| ~~'cascade'~~ | Cascade | (보존 — MASC 도메인 용어) |
| 'awaiting_approval' / 'task_verification_pending' | (이미 한국어) | -- |

## goal-tree blockerSourceLabel (6/7)

| case | Before | After |
|---|---|---|
| 'goal_phase' | Goal phase | Goal 단계 |
| 'child_goal' | Child goal | 하위 Goal |
| 'approval' | Approval | 승인 |
| 'keeper_runtime' | Keeper runtime | 키퍼 런타임 |
| 'goal_linkage' | Goal linkage | Goal 연결 |
| 'stalled' | Stalled | 정체 |
| ~~'task_fsm'~~ | Task FSM | (보존 — FSM acronym) |

## activity-graph-groups categoryLabel (7/7)

| case | Before | After |
|---|---|---|
| 'task' | Task | 태스크 |
| 'session' | Session | 세션 |
| 'message' | Message | 메시지 |
| 'board' | Board | 보드 |
| 'governance' | Governance | 거버넌스 |
| 'lifecycle' | Lifecycle | 라이프사이클 |
| default | Other | 기타 |

## 보존 (도메인 용어)

| 단어 | 이유 |
|---|---|
| Cascade | MASC 도메인 — \`cascade.json\`, cascade rotation, cascade_exhausted (cross-system 식별어) |
| Goal | OKR/Goal-tree 도메인 (한국어 \"목표\" 와 의미 분리) |
| Task / FSM | 표준 약어 / acronym ledger |

## Test fixture coupling 검증

| Test 위치 | 영향 분석 | 충돌 |
|---|---|---|
| \`runtime-panel.test.ts:145\` \`chips[1]?.textContent === 'Cascade'\` | runtime-panel.ts:45 의 별개 chip 배열 (\`{ key: 'cascade', label: 'Cascade' }\`) — goal-tree.ts 의 badgeLabel 과 무관 | ❌ 실제 충돌 없음 (Cascade 보존 결정으로 0 risk) |
| \`activity-graph-groups.test.ts\` | 같은 모듈 import 하지만 \`categoryLabel\` 또는 변경 string 참조 없음 | ❌ |
| \`memory-state.test.ts:107-116\` / \`verification-specs-panel.test.ts:22\` | 각 자체 \`categoryLabel\` 함수 (다른 export). 같은 이름, 다른 함수. | ❌ |

## 라운드 누적 (23-42)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-40 | -- | MERGED | 75 |
| 41 | #10723 | Draft | 7 |
| 42 | this | Draft | **16** |

누적 chips ≈ **155**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)