### PR TITLE
feat(audit): wire credential audits into Meta Guards + fix integrity I1/I2 blind spots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,7 @@ jobs:
           bash scripts/ci/check-telemetry-coverage.sh
           bash scripts/ci/check-determinism-contract.sh
           bash scripts/audit-hardcoding-truth.sh --fail-on-confirmed
+          bash scripts/ci/check-credential-audits.sh
 
   health:
     name: Health

--- a/docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md
+++ b/docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md
@@ -3,7 +3,7 @@ status: runbook
 last_verified: 2026-04-17
 code_refs:
   - lib/oas_events.ml
-  - lib/oas_sse_bridge.ml
+  - lib/oas_event_bridge.ml
   - lib/telemetry_unified.ml
 ---
 
@@ -22,13 +22,13 @@ This audit records the producer -> bridge -> durable store -> dashboard consumer
 
 ### 2. Bridge
 
-- `lib/oas_sse_bridge.ml` subscribes to the OAS event bus with `accept_all`.
+- `lib/oas_event_bridge.ml` subscribes to the OAS event bus with `accept_all`.
 - Native events are serialized with an `oas:` prefix.
 - Envelope fields `correlation_id`, `run_id`, and `ts_unix` are emitted for every relayed event.
 
 ### 3. Durable Store
 
-- `lib/oas_sse_bridge.ml` appends every relayed OAS event to `.masc/oas-events/` through `Dated_jsonl.append`.
+- `lib/oas_event_bridge.ml` appends every relayed OAS event to `.masc/oas-events/` through `Dated_jsonl.append`.
 - This durable JSONL store is the replay source for dashboard recovery and telemetry inspection.
 
 ### 4. Server Read Path

--- a/scripts/audit-keeper-credential-uuid-integrity.sh
+++ b/scripts/audit-keeper-credential-uuid-integrity.sh
@@ -132,13 +132,26 @@ TOTAL_UUID=$(wc -l < "$UUID_FILES_FILE" | tr -d ' ')
 TOTAL_REDIRECTS=$(wc -l < "$REDIRECTS_FILE" | tr -d ' ')
 
 # I1. Dangling redirects: redirect_to target not in UUID inventory.
-awk -F'\t' 'NR==FNR { uuids[$1]=1; next } !($4 in uuids) { print $1 "\t" $4 }' \
-  "$UUID_FILES_FILE" "$REDIRECTS_FILE" > "$DANGLING_FILE"
+# Note: when UUID_FILES_FILE is empty, awk's `NR==FNR` trick mis-treats
+# REDIRECTS_FILE as the first file and never runs the dangling check.
+# Guard with -s so an empty UUID inventory still flags every redirect.
+if [ -s "$UUID_FILES_FILE" ]; then
+  awk -F'\t' 'NR==FNR { uuids[$1]=1; next } !($4 in uuids) { print $1 "\t" $4 }' \
+    "$UUID_FILES_FILE" "$REDIRECTS_FILE" > "$DANGLING_FILE"
+else
+  awk -F'\t' '{ print $1 "\t" $4 }' "$REDIRECTS_FILE" > "$DANGLING_FILE"
+fi
 DANGLING=$(wc -l < "$DANGLING_FILE" | tr -d ' ')
 
 # I2. Orphan UUID files: UUID never appears as a redirect target.
-awk -F'\t' 'NR==FNR { targets[$4]=1; next } !($1 in targets) { print $1 "\t" $2 }' \
-  "$REDIRECTS_FILE" "$UUID_FILES_FILE" > "$ORPHAN_FILE"
+# Same NR==FNR + empty-first-file caveat: when REDIRECTS_FILE is empty,
+# every UUID file is by definition orphan.
+if [ -s "$REDIRECTS_FILE" ]; then
+  awk -F'\t' 'NR==FNR { targets[$4]=1; next } !($1 in targets) { print $1 "\t" $2 }' \
+    "$REDIRECTS_FILE" "$UUID_FILES_FILE" > "$ORPHAN_FILE"
+else
+  awk -F'\t' '{ print $1 "\t" $2 }' "$UUID_FILES_FILE" > "$ORPHAN_FILE"
+fi
 ORPHAN=$(wc -l < "$ORPHAN_FILE" | tr -d ' ')
 
 # I3. Agent_name mismatch: UUID file's agent_name does not match the

--- a/scripts/ci/check-credential-audits.sh
+++ b/scripts/ci/check-credential-audits.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# CI gate: keeper credential audit scripts self-test.
+#
+# Verifies that the two read-only audit scripts merged in #10706 and
+# #10718 still detect the violations they document. This guards
+# against silent regressions in the audit logic itself — a refactor
+# of either script that breaks detection would otherwise go unnoticed
+# until production drift accumulates again.
+#
+# Tests (each fixture is a synthetic .masc/auth/agents/ tree):
+#   1. clean       — bare+canonical stubs both redirect to the same
+#                    well-formed UUID file.
+#                    drift     → exit 0 (converged)
+#                    integrity → exit 0 (no violations)
+#
+#   2. split-brain — bare stub redirects to UUID-A, canonical stub
+#                    redirects to UUID-B. Two real UUID files.
+#                    drift     → exit 1 (split-brain detected)
+#
+#   3. dangling    — bare stub redirects to a UUID file that does
+#                    not exist on disk.
+#                    integrity → exit 1 (dangling redirect detected)
+#
+#   4. orphan      — a UUID file with no inbound redirect stub.
+#                    integrity → exit 1 (orphan UUID detected)
+#
+# All fixtures are built inline; nothing under repo control is
+# modified or read.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+DRIFT="scripts/audit-keeper-credential-drift.sh"
+INTEG="scripts/audit-keeper-credential-uuid-integrity.sh"
+
+if [[ ! -x "$DRIFT" || ! -x "$INTEG" ]]; then
+  chmod +x "$DRIFT" "$INTEG"
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+write_uuid_file() {
+  # write_uuid_file <agents_dir> <uuid> <agent_name>
+  local dir="$1" uuid="$2" name="$3"
+  cat > "${dir}/${uuid}.json" <<EOF
+{
+  "id": "${uuid}",
+  "agent_name": "${name}",
+  "token": "test-token-${uuid:0:8}",
+  "role": "worker",
+  "admin": false,
+  "created_at": "2026-04-26T00:00:00Z"
+}
+EOF
+}
+
+write_stub() {
+  # write_stub <agents_dir> <stem> <target_uuid>
+  local dir="$1" stem="$2" target="$3"
+  printf '{ "redirect_to": "%s.json" }\n' "$target" > "${dir}/${stem}.json"
+}
+
+build_clean() {
+  local base="$1"
+  local agents="${base}/.masc/auth/agents"
+  mkdir -p "$agents"
+  local uuid="11111111-1111-4111-8111-111111111111"
+  write_uuid_file "$agents" "$uuid" "keeper-alpha-agent"
+  write_stub "$agents" "alpha" "$uuid"
+  write_stub "$agents" "keeper-alpha-agent" "$uuid"
+}
+
+build_split_brain() {
+  local base="$1"
+  local agents="${base}/.masc/auth/agents"
+  mkdir -p "$agents"
+  local uuid_a="22222222-2222-4222-8222-222222222222"
+  local uuid_b="33333333-3333-4333-8333-333333333333"
+  write_uuid_file "$agents" "$uuid_a" "keeper-beta-agent"
+  write_uuid_file "$agents" "$uuid_b" "keeper-beta-agent"
+  write_stub "$agents" "beta" "$uuid_a"
+  write_stub "$agents" "keeper-beta-agent" "$uuid_b"
+}
+
+build_dangling() {
+  local base="$1"
+  local agents="${base}/.masc/auth/agents"
+  mkdir -p "$agents"
+  write_stub "$agents" "gamma" "44444444-4444-4444-8444-444444444444"
+}
+
+build_orphan() {
+  local base="$1"
+  local agents="${base}/.masc/auth/agents"
+  mkdir -p "$agents"
+  local uuid="55555555-5555-4555-8555-555555555555"
+  write_uuid_file "$agents" "$uuid" "keeper-delta-agent"
+}
+
+run_with_expect() {
+  # run_with_expect <label> <expected_exit> <script> <base>
+  local label="$1" expected="$2" script="$3" base="$4"
+  local actual
+  set +e
+  bash "$script" --base-path "$base" --json >/dev/null 2>&1
+  actual=$?
+  set -e
+  if [[ "$actual" -ne "$expected" ]]; then
+    printf '  FAIL  %s: expected exit %d, got %d\n' "$label" "$expected" "$actual" >&2
+    return 1
+  fi
+  printf '  ok    %s (exit %d)\n' "$label" "$actual"
+  return 0
+}
+
+echo "=== Credential audit self-test ==="
+
+clean="${tmpdir}/clean"
+split="${tmpdir}/split-brain"
+dangling="${tmpdir}/dangling"
+orphan="${tmpdir}/orphan"
+build_clean "$clean"
+build_split_brain "$split"
+build_dangling "$dangling"
+build_orphan "$orphan"
+
+failed=0
+run_with_expect "drift on clean"               0 "$DRIFT" "$clean"    || failed=1
+run_with_expect "drift on split-brain"         1 "$DRIFT" "$split"    || failed=1
+run_with_expect "integrity on clean"           0 "$INTEG" "$clean"    || failed=1
+run_with_expect "integrity on dangling"        1 "$INTEG" "$dangling" || failed=1
+run_with_expect "integrity on orphan"          1 "$INTEG" "$orphan"   || failed=1
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "credential audit self-test: FAILED" >&2
+  exit 1
+fi
+
+echo "credential audit self-test: ok"


### PR DESCRIPTION
## Summary

`scripts/ci/check-credential-audits.sh`를 Meta Guards에 추가해 두 audit script(#10706 drift, #10718 integrity)의 detection contract를 회귀 방어. 작성 과정에서 integrity script의 I1/I2 awk 빈 파일 blind spot 2건을 수정.

## Why

`audit-bucket-cascade-pattern` 메모리: detection 만 있고 lint gate가 없으면 audit 로직 자체의 회귀가 silent. 누가 두 script를 refactor 하면 production drift가 다시 쌓일 때까지 detection 이 작동하지 않는 줄 모름.

## I1/I2 bug (CI gate 작성 중 발견)

```bash
# Before — empty UUID_FILES_FILE 일 때 awk가 REDIRECTS_FILE 을 첫 파일로 오인
awk -F'\t' 'NR==FNR { uuids[$1]=1; next } !($4 in uuids) { print $1 "\t" $4 }' \
  "$UUID_FILES_FILE" "$REDIRECTS_FILE"
```

`NR==FNR` 트릭은 첫 파일이 비어 있으면 두 번째 파일을 첫 파일로 취급, 두 번째 액션(dangling 검출)이 영원히 실행 안 됨. I2 (orphan)도 동일 패턴.

```bash
# After — empty 가드
if [ -s "$UUID_FILES_FILE" ]; then
  awk -F'\t' 'NR==FNR { uuids[$1]=1; next } !($4 in uuids) { print $1 "\t" $4 }' \
    "$UUID_FILES_FILE" "$REDIRECTS_FILE" > "$DANGLING_FILE"
else
  awk -F'\t' '{ print $1 "\t" $4 }' "$REDIRECTS_FILE" > "$DANGLING_FILE"
fi
```

## Self-test fixtures (inline, repo state 비건드림)

| # | 픽스처 | drift 기대 | integrity 기대 |
|---|--------|-----------|---------------|
| 1 | clean (bare+canonical → same UUID) | exit 0 | exit 0 |
| 2 | split-brain (bare→A, canonical→B) | exit 1 | — |
| 3 | dangling (stub → missing UUID) | — | exit 1 |
| 4 | orphan (UUID file, no inbound stub) | — | exit 1 |

5개 case 모두 로컬 통과:
```
=== Credential audit self-test ===
  ok    drift on clean (exit 0)
  ok    drift on split-brain (exit 1)
  ok    integrity on clean (exit 0)
  ok    integrity on dangling (exit 1)
  ok    integrity on orphan (exit 1)
credential audit self-test: ok
```

## Production 회귀 확인 (ME_ROOT)

I1/I2 수정 후 14 UUID files / 28 redirect stubs / 5 invariants 모두 0 violations 유지.

```json
[
  {"key": "dangling_redirects", "count": 0},
  {"key": "orphan_uuids", "count": 0},
  {"key": "name_mismatches", "count": 0},
  {"key": "shared_uuids", "count": 0},
  {"key": "missing_token", "count": 0}
]
```

## Fix scope

| 파일 | 변경 |
|------|------|
| `scripts/audit-keeper-credential-uuid-integrity.sh` | I1+I2에 `[ -s ]` 가드 + 폴스루 awk (+21/-4 lines, comment 포함) |
| `scripts/ci/check-credential-audits.sh` | 신규 self-test (141 lines, 5 fixture cases) |
| `.github/workflows/ci.yml` | Meta Guards "bug-class gates" 단계에 1 line 추가 |

## Risk

- Meta Guards 항상 실행되므로 self-test가 깨지면 모든 PR 차단. 로컬에서 5/5 통과 + ME_ROOT 회귀 0건 확인. bash 3.2 호환은 fixture 작성 시 `set -euo pipefail` 안전 사용 (audit script의 bash 3.2 caveat은 mktemp/awk 패턴 때문이며 self-test는 직접 array 사용 없음).
- 첫 파일 empty 시 두 번째 파일 print 패턴은 표준 awk 관용구 — POSIX 호환.

## Out of scope

- I3 (name_mismatch), I4 (shared_uuid), I5 (missing_token) 검출은 production 데이터로 0건 유효 확인됨. 이번 PR은 I1/I2 빈 파일 edge case 만.
- drift script (#10706)는 `NR==FNR` 패턴 미사용, 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)