### PR TITLE
fix(dashboard): sync connector test expectations to localized labels (unblock CI)

### DIFF
--- a/dashboard/src/components/connector-paths-strip.test.ts
+++ b/dashboard/src/components/connector-paths-strip.test.ts
@@ -87,7 +87,7 @@ describe('ConnectorPathsStrip', () => {
     }
     const rows = container.querySelectorAll('[data-paths-row]')
     const labels = Array.from(rows).map(r => r.getAttribute('data-paths-row'))
-    expect(labels).toEqual(['Keepers', 'Sidecars'])
+    expect(labels).toEqual(['키퍼', '사이드카'])
   })
 
   it('surfaces Connectors + Logs rows once a connector reports a names_path', async () => {
@@ -103,7 +103,7 @@ describe('ConnectorPathsStrip', () => {
     }
     const rows = container.querySelectorAll('[data-paths-row]')
     const labels = Array.from(rows).map(r => r.getAttribute('data-paths-row'))
-    expect(labels).toEqual(['Connectors', 'Logs', 'Keepers', 'Sidecars'])
+    expect(labels).toEqual(['커넥터', '로그', '키퍼', '사이드카'])
   })
 
   it('header shows runtime hint when no connector has names_path', () => {

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -426,7 +426,7 @@ describe('ConnectorStatusPanel', () => {
     expect(dirPanel!.className).toContain('border-l-amber-500')
     // Named chip: "Directory error" is what AT hears.
     const dirChip = dirPanel!.querySelector('[aria-label]')
-    expect(dirChip?.getAttribute('aria-label')).toContain('unavailable')
+    expect(dirChip?.getAttribute('aria-label')).toContain('사용 불가')
   })
 
   it('pairs connector API failures with a browser/server next action', async () => {
@@ -659,9 +659,13 @@ describe('ConnectorStatusPanel', () => {
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(text).toContain('사이드카 미시작')
     expect(text).toContain('cd sidecars/discord-bot && ./run.sh')
-    expect(text).toContain('Cause: no sidecar status file has been observed at /tmp/discord_status.json')
-    expect(text).toContain('Next: click Start to spawn via the backend')
-    expect(text).toContain('Use status and tail logs if it stays offline')
+    expect(text).toContain('원인: sidecar status 파일이')
+    expect(text).toContain('/tmp/discord_status.json')
+    expect(text).toContain('관찰되지 않았습니다')
+    expect(text).toContain('다음:')
+    expect(text).toContain('Start')
+    expect(text).toContain('status')
+    expect(text).toContain('tail logs')
 
     // Regression guard for the screenshot bug: when a connector card's
     // brand accent is green (iMessage), the outer card renders a green
@@ -677,7 +681,7 @@ describe('ConnectorStatusPanel', () => {
     // And the explicit "Not running" status chip is the one AT users hear.
     const chip = panel!.querySelector('[data-sidecar-status-chip]')
     expect(chip).toBeTruthy()
-    expect(chip!.getAttribute('aria-label')).toContain('not running')
+    expect(chip!.getAttribute('aria-label')).toContain('실행 중 아님')
     expect(chip!.textContent).toContain('실행 중 아님')
 
     const copyLabels = Array.from(panel!.querySelectorAll<HTMLButtonElement>('[data-copy-button]'))
@@ -725,7 +729,7 @@ describe('ConnectorStatusPanel', () => {
     expect(emptyPanel!.className).toContain('border-l-amber-500')
     const chip = emptyPanel!.querySelector('[data-no-keepers-status-chip]')
     expect(chip).toBeTruthy()
-    expect(chip!.getAttribute('aria-label')).toContain('none configured')
+    expect(chip!.getAttribute('aria-label')).toContain('설정된 키퍼 없음')
     expect(chip!.textContent).toContain('설정 필요')
   })
 


### PR DESCRIPTION
## Summary

main의 connector-* 컴포넌트가 한글 라벨로 i18n 되었으나 테스트 expectation이 영문 그대로 남아 **모든 PR에서 Dashboard CI fail**. 본 PR이 큐 unblock.

## 변경

### `connector-paths-strip.test.ts`
- `['Keepers', 'Sidecars']` → `['키퍼', '사이드카']`
- `['Connectors', 'Logs', 'Keepers', 'Sidecars']` → `['커넥터', '로그', '키퍼', '사이드카']`

### `connector-status.test.ts`
- aria-label `'unavailable'` → `'사용 불가'`
- aria-label `'none configured'` → `'설정된 키퍼 없음'`
- aria-label `'not running'` → `'실행 중 아님'`
- 사이드카 미시작 cause/next 메시지: 영문 → 한글 (원인:/다음:/Start/status/tail logs)

## 검증

- `pnpm test src/components/connector-paths-strip src/components/connector-status`: **34/34 pass**

## 영향

- CS12 #10722 / CS13 #10724 / CS14 #10725 / CS15 #10726 / CS16 #10728 (5 PR) BLOCKED 해제 예상
- round-41 #10723 / round-42 #10727 도 동일

## Test plan

- [ ] CI green
- [ ] 다음 PR queue가 Dashboard CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
