### PR TITLE
feat(dashboard): localize 30 keeper-detail field titles (round-43)

### DIFF
--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -1151,41 +1151,41 @@ export function RawDataDebug({ keeper }: { keeper: Keeper }) {
   const filter = fieldSearch.value.toLowerCase()
 
   const fields: { title: string; key: string; value: string }[] = [
-    { title: 'Name', key: 'name', value: keeper.name },
-    { title: 'Emoji', key: 'emoji', value: keeper.emoji ?? '-' },
-    { title: 'Korean', key: 'koreanName', value: keeper.koreanName ?? '-' },
-    { title: 'Model', key: 'model', value: keeper.model ?? '-' },
-    { title: 'Status', key: 'status', value: keeper.status },
-    { title: 'Primary', key: 'primaryValue', value: keeper.primaryValue ?? '-' },
-    { title: 'Gen', key: 'generation', value: String(keeper.generation ?? '-') },
-    { title: 'Turns', key: 'turn_count', value: String(keeper.turn_count ?? '-') },
-    { title: 'Context', key: 'context_ratio', value: formatPct(keeper.context_ratio) },
-    { title: 'Heartbeat', key: 'last_heartbeat', value: keeper.last_heartbeat ?? '-' },
-    { title: 'Traits', key: 'traits', value: keeper.traits?.join(', ') || '-' },
-    { title: 'Interests', key: 'interests', value: keeper.interests?.join(', ') || '-' },
+    { title: '이름', key: 'name', value: keeper.name },
+    { title: '이모지', key: 'emoji', value: keeper.emoji ?? '-' },
+    { title: '한글명', key: 'koreanName', value: keeper.koreanName ?? '-' },
+    { title: '모델', key: 'model', value: keeper.model ?? '-' },
+    { title: '상태', key: 'status', value: keeper.status },
+    { title: '주력', key: 'primaryValue', value: keeper.primaryValue ?? '-' },
+    { title: '세대', key: 'generation', value: String(keeper.generation ?? '-') },
+    { title: '턴', key: 'turn_count', value: String(keeper.turn_count ?? '-') },
+    { title: '컨텍스트', key: 'context_ratio', value: formatPct(keeper.context_ratio) },
+    { title: '하트비트', key: 'last_heartbeat', value: keeper.last_heartbeat ?? '-' },
+    { title: '특성', key: 'traits', value: keeper.traits?.join(', ') || '-' },
+    { title: '관심사', key: 'interests', value: keeper.interests?.join(', ') || '-' },
   ]
 
   // Extra fields from keeper object
   const extras: { title: string; value: string; mono?: boolean }[] = []
-  if (keeper.trace_id) extras.push({ title: 'Trace ID', value: keeper.trace_id, mono: true })
-  if (keeper.agent_name) extras.push({ title: 'Agent', value: keeper.agent_name })
-  if (keeper.primary_model) extras.push({ title: 'Primary Model', value: keeper.primary_model, mono: true })
-  if (keeper.active_model) extras.push({ title: 'Active Model', value: keeper.active_model, mono: true })
-  if (keeper.next_model_hint) extras.push({ title: 'Next Model Hint', value: keeper.next_model_hint, mono: true })
-  if (keeper.skill_primary) extras.push({ title: 'Skill (Primary)', value: keeper.skill_primary })
-  if (keeper.skill_secondary?.length) extras.push({ title: 'Skill (Secondary)', value: keeper.skill_secondary.join(', ') })
-  if (keeper.skill_reason) extras.push({ title: 'Skill Reason', value: keeper.skill_reason })
-  if (keeper.context_source) extras.push({ title: 'Context Source', value: keeper.context_source })
-  if (keeper.context_tokens != null) extras.push({ title: 'Context Tokens', value: formatTokens(keeper.context_tokens) })
-  if (keeper.context_max != null) extras.push({ title: 'Context Max', value: formatTokens(keeper.context_max) })
-  if (keeper.memory_recent_note) extras.push({ title: 'Memory Note', value: keeper.memory_recent_note })
-  if (keeper.k2k_count != null) extras.push({ title: 'K2K Count', value: String(keeper.k2k_count) })
-  if (keeper.conversation_tail_count != null) extras.push({ title: 'Conv Tail', value: String(keeper.conversation_tail_count) })
-  if (keeper.handoff_count_total != null) extras.push({ title: 'Total Handoffs', value: String(keeper.handoff_count_total) })
-  if (keeper.compaction_count != null) extras.push({ title: 'Compactions', value: String(keeper.compaction_count) })
-  if (keeper.last_compaction_saved_tokens != null) extras.push({ title: 'Last Compact Saved', value: formatTokens(keeper.last_compaction_saved_tokens) })
-  if (keeper.context?.message_count != null) extras.push({ title: 'Message Count', value: String(keeper.context.message_count) })
-  if (keeper.context?.has_checkpoint != null) extras.push({ title: 'Has Checkpoint', value: keeper.context.has_checkpoint ? 'Yes' : 'No' })
+  if (keeper.trace_id) extras.push({ title: '추적 ID', value: keeper.trace_id, mono: true })
+  if (keeper.agent_name) extras.push({ title: '에이전트', value: keeper.agent_name })
+  if (keeper.primary_model) extras.push({ title: '주력 모델', value: keeper.primary_model, mono: true })
+  if (keeper.active_model) extras.push({ title: '활성 모델', value: keeper.active_model, mono: true })
+  if (keeper.next_model_hint) extras.push({ title: '다음 모델 힌트', value: keeper.next_model_hint, mono: true })
+  if (keeper.skill_primary) extras.push({ title: '스킬 (주)', value: keeper.skill_primary })
+  if (keeper.skill_secondary?.length) extras.push({ title: '스킬 (보조)', value: keeper.skill_secondary.join(', ') })
+  if (keeper.skill_reason) extras.push({ title: '스킬 사유', value: keeper.skill_reason })
+  if (keeper.context_source) extras.push({ title: '컨텍스트 소스', value: keeper.context_source })
+  if (keeper.context_tokens != null) extras.push({ title: '컨텍스트 토큰', value: formatTokens(keeper.context_tokens) })
+  if (keeper.context_max != null) extras.push({ title: '컨텍스트 최대', value: formatTokens(keeper.context_max) })
+  if (keeper.memory_recent_note) extras.push({ title: '메모리 노트', value: keeper.memory_recent_note })
+  if (keeper.k2k_count != null) extras.push({ title: 'K2K 카운트', value: String(keeper.k2k_count) })
+  if (keeper.conversation_tail_count != null) extras.push({ title: '대화 tail', value: String(keeper.conversation_tail_count) })
+  if (keeper.handoff_count_total != null) extras.push({ title: '핸드오프 총합', value: String(keeper.handoff_count_total) })
+  if (keeper.compaction_count != null) extras.push({ title: '압축 횟수', value: String(keeper.compaction_count) })
+  if (keeper.last_compaction_saved_tokens != null) extras.push({ title: '마지막 압축 절약', value: formatTokens(keeper.last_compaction_saved_tokens) })
+  if (keeper.context?.message_count != null) extras.push({ title: '메시지 수', value: String(keeper.context.message_count) })
+  if (keeper.context?.has_checkpoint != null) extras.push({ title: '체크포인트 보유', value: keeper.context.has_checkpoint ? '예' : '아니오' })
 
   const filtered = filter
     ? fields.filter(f => f.title.toLowerCase().includes(filter) || f.key.includes(filter) || f.value.toLowerCase().includes(filter))


### PR DESCRIPTION
## Summary

대시보드 라운드 43 — \`RawDataDebug\` 의 30 field title 한국어화. 직전 라운드들에서 deferred 했던 batch (filter 매핑 우려 해소 후 진행).

## Field title 매핑

### Base fields (12)

| Before | After |
|---|---|
| Name | 이름 |
| Emoji | 이모지 |
| Korean | 한글명 |
| Model | 모델 |
| Status | 상태 |
| Primary | 주력 |
| Gen | 세대 |
| Turns | 턴 |
| Context | 컨텍스트 |
| Heartbeat | 하트비트 |
| Traits | 특성 |
| Interests | 관심사 |

### Extra fields (18, conditional)

| Before | After |
|---|---|
| Trace ID | 추적 ID |
| Agent | 에이전트 |
| Primary Model | 주력 모델 |
| Active Model | 활성 모델 |
| Next Model Hint | 다음 모델 힌트 |
| Skill (Primary) | 스킬 (주) |
| Skill (Secondary) | 스킬 (보조) |
| Skill Reason | 스킬 사유 |
| Context Source | 컨텍스트 소스 |
| Context Tokens | 컨텍스트 토큰 |
| Context Max | 컨텍스트 최대 |
| Memory Note | 메모리 노트 |
| K2K Count | K2K 카운트 |
| Conv Tail | 대화 tail |
| Total Handoffs | 핸드오프 총합 |
| Compactions | 압축 횟수 |
| Last Compact Saved | 마지막 압축 절약 |
| Message Count | 메시지 수 |
| Has Checkpoint (Yes/No) | 체크포인트 보유 (예/아니오) |

## Filter 매핑 검증 (이중 언어 검색 지원)

\`RawDataDebug\` 의 filter 로직:
\`\`\`typescript
fields.filter(f =>
  f.title.toLowerCase().includes(filter) ||  // Korean search via title
  f.key.includes(filter) ||                   // English search via key
  f.value.toLowerCase().includes(filter))     // data search
\`\`\`

→ \`title\` 한국어화 후에도 \`key\` (영문 identifier) 가 그대로 → **사용자가 영문/한국어 둘 다로 검색 가능**.

| 검색어 | matches via |
|---|---|
| 'heartbeat' (영문) | \`f.key === 'last_heartbeat'\` ✓ |
| '하트비트' (한국어) | \`f.title === '하트비트'\` ✓ |
| 'context' (영문) | 다수 keys ✓ |
| '컨텍스트' (한국어) | 다수 titles ✓ |

직전 라운드들에서 \"검색 매핑 우려\" 로 deferred 했던 issue — \`f.key\` 가 영문 identifier 로 유지되어 자동 해결.

## Test fixture coupling 검증

\`keeper-detail-panels.test.ts\` 는 \`filterCtxCompositionEntries\` 함수만 테스트 (lines 219-298). \`RawDataDebug\` field titles 에 대한 assertion 없음. 0 충돌.

## 보존

| 단어 | 이유 |
|---|---|
| K2K | 약어 (Keeper-to-Keeper, 도메인 식별어) |
| tail | git 명령 / 로그 tail (technical 인용) |
| ID | 표준 약어 (Trace ID) |

## 라운드 누적 (23-43)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-41 | -- | MERGED | 82 |
| 42 | #10727 | Draft | 16 |
| 43 | this | Draft | **30** |

누적 chips ≈ **185**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)