### PR TITLE
fix(provider): add Gemini_cli to normalize_cli_provider_caps

### DIFF
--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -18,7 +18,8 @@ let normalize_cli_provider_caps
         supports_runtime_mcp_tools = true;
         supports_runtime_tool_events = true;
       }
-  | Llm_provider.Provider_config.Kimi_cli ->
+  | Llm_provider.Provider_config.Kimi_cli
+  | Llm_provider.Provider_config.Gemini_cli ->
       {
         caps with
         supports_tools = false;


### PR DESCRIPTION
## Summary
- Gemini_cli was missing from `normalize_cli_provider_caps`, causing all keepers using gemini_cli providers to fail with `no_tool_capable_provider`
- The function forces `supports_tools=false` (CLI subprocesses can't do inline tool calling) but must set `supports_runtime_mcp_tools=true` so the runtime MCP lane is available
- Without this fix, the two-stage provider filter removed all gemini_cli candidates from cascades, leaving zero callable models

## Root Cause
`normalize_cli_provider_caps` had match arms for `Claude_code` and `Kimi_cli` but not `Gemini_cli`. When a Gemini_cli provider was selected:
1. Stage 1 (`apply_required_tool_use_filter`): `supports_required_tool_use` returned false because `supports_inline_tool_choice=false` AND `supports_runtime_mcp_tools=false`
2. Stage 2 (`filter_candidate_providers_for_tool_support`): Same result
3. All providers filtered → `no callable models available`

## Fix
Added `Gemini_cli` to the existing `Kimi_cli` match arm in `normalize_cli_provider_caps`.

## Verification
- 14/14 keepers autoboot successfully after fix
- `no_tool_capable_provider` and `tool-use gate removed all providers` errors eliminated from logs
- Gemini_cli stderr visible in server output (actual execution happening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)