### PR TITLE
feat(operator-control): add recommended actions for stalled states

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -32,6 +32,7 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.turn_phase).toBe('idle')
     expect(result.is_live).toBe(true)
     expect(result.last_outcome).toBeNull()
+    expect(result.recommended_actions).toEqual([])
   })
 
   it('parses explicit keeper identity when emitted by the backend', () => {
@@ -127,6 +128,34 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.execution?.terminal_reason_code).toBe('config_error')
     expect(result.execution?.cascade?.fallback_reason).toBe('turn_timeout')
     expect(result.execution?.error?.message_preview).toContain('fallback_cascade')
+  })
+
+  it('parses backend-recommended runtime actions', () => {
+    const result = parseKeeperCompositeSnapshot({
+      ...VALID_SNAPSHOT,
+      recommended_actions: [
+        {
+          action_type: 'keeper_recover',
+          target_type: 'keeper',
+          target_id: 'analyst',
+          severity: 'bad',
+          reason: 'Controlled keeper recovery for runtime stall: api_error',
+          confirm_required: true,
+          suggested_payload: {
+            source: 'fleet_fsm',
+            keeper: 'analyst',
+          },
+          preview: {
+            actor: 'fleet_fsm',
+            action_type: 'keeper_recover',
+          },
+        },
+      ],
+    })
+
+    expect(result.recommended_actions).toHaveLength(1)
+    expect(result.recommended_actions[0]!.action_type).toBe('keeper_recover')
+    expect(result.recommended_actions[0]!.confirm_required).toBe(true)
   })
 
   it('parses snapshot with measurement auto_rules', () => {

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -21,6 +21,7 @@
 import {
   array,
   boolean,
+  fallback,
   nullable,
   number,
   object,
@@ -124,6 +125,17 @@ const KeeperCompositeExecutionSchema = object({
   ),
 })
 
+const OperatorRecommendedActionSchema = object({
+  action_type: string(),
+  target_type: string(),
+  target_id: optional(nullable(string())),
+  severity: fallback(string(), 'unknown'),
+  reason: string(),
+  confirm_required: optional(boolean()),
+  suggested_payload: optional(unknown()),
+  preview: optional(unknown()),
+})
+
 export const KeeperCompositeSnapshotSchema = object({
   // Explicit registry identity from new backends. Optional so pinned older
   // backends keep rendering; UI falls back to canonical correlation_id parsing.
@@ -152,6 +164,7 @@ export const KeeperCompositeSnapshotSchema = object({
   is_live: boolean(),
   last_outcome: nullable(KeeperLastOutcomeSchema),
   execution: optional(KeeperCompositeExecutionSchema),
+  recommended_actions: fallback(array(OperatorRecommendedActionSchema), []),
   /** @deprecated kept only for old backend experiments; new payloads use `execution`. */
   latest_receipt: optional(unknown()),
 })

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -1,13 +1,23 @@
 import { html } from 'htm/preact'
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import { afterEach, describe, it, expect, vi } from 'vitest'
 
-const { fetchKeepersCompositeMock } = vi.hoisted(() => ({
+const { fetchKeepersCompositeMock, dispatchOperatorActionMock, showToastMock } = vi.hoisted(() => ({
   fetchKeepersCompositeMock: vi.fn(),
+  dispatchOperatorActionMock: vi.fn(),
+  showToastMock: vi.fn(),
 }))
 
 vi.mock('../api/keeper', () => ({
   fetchKeepersComposite: fetchKeepersCompositeMock,
+}))
+
+vi.mock('../operator-store', () => ({
+  dispatchOperatorAction: dispatchOperatorActionMock,
+}))
+
+vi.mock('./common/toast', () => ({
+  showToast: showToastMock,
 }))
 
 import {
@@ -62,6 +72,7 @@ function snapshot(
     },
     is_live: false,
     last_outcome: null,
+    recommended_actions: [],
   }
   return { ...base, ...overrides }
 }
@@ -101,6 +112,8 @@ afterEach(() => {
   cleanup()
   vi.useRealTimers()
   fetchKeepersCompositeMock.mockReset()
+  dispatchOperatorActionMock.mockReset()
+  showToastMock.mockReset()
   fleetCompositeSnapshot.value = null
 })
 
@@ -593,6 +606,115 @@ describe('FleetFsmMatrix streaming fallback', () => {
         }),
         message: expect.stringContaining('resolve 후보'),
       }),
+    )
+  })
+
+  it('runs backend-recommended probe actions through the operator action path', async () => {
+    dispatchOperatorActionMock.mockResolvedValue({
+      status: 'ok',
+      confirm_required: false,
+    })
+    fetchKeepersCompositeMock.mockResolvedValue(
+      fleetSnapshot([
+        snapshot({
+          name: 'blocked',
+          phase: 'Running',
+          is_live: false,
+          execution: execution({
+            outcome: 'error',
+            terminal_reason_code: 'api_error',
+            operator_disposition: 'pause_human',
+            operator_disposition_reason: 'tool_required_unsatisfied',
+          }),
+          recommended_actions: [
+            {
+              action_type: 'keeper_probe',
+              target_type: 'keeper',
+              target_id: 'blocked',
+              severity: 'warn',
+              reason: 'Inspect tool-contract blocker: tool_required_unsatisfied',
+              confirm_required: false,
+              suggested_payload: {
+                source: 'fleet_fsm',
+                keeper: 'blocked',
+              },
+            },
+          ],
+        }),
+      ]),
+    )
+
+    render(html`<${FleetFsmMatrix} pollIntervalMs=${1000} />`)
+
+    const button = await screen.findByRole('button', { name: '상태 확인' })
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    await waitFor(() => {
+      expect(dispatchOperatorActionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action_type: 'keeper_probe',
+          target_type: 'keeper',
+          target_id: 'blocked',
+          payload: expect.objectContaining({
+            source: 'fleet_fsm',
+            keeper: 'blocked',
+          }),
+        }),
+      )
+    })
+    expect(fetchKeepersCompositeMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces recover as a supervised preview instead of auto-confirming it', async () => {
+    dispatchOperatorActionMock.mockResolvedValue({
+      status: 'ok',
+      confirm_required: true,
+      confirm_token: 'confirm-1',
+    })
+    fetchKeepersCompositeMock.mockResolvedValue(
+      fleetSnapshot([
+        snapshot({
+          name: 'blocked',
+          phase: 'Running',
+          is_live: false,
+          execution: execution({
+            outcome: 'error',
+            terminal_reason_code: 'api_error',
+            operator_disposition: 'unknown',
+          }),
+          recommended_actions: [
+            {
+              action_type: 'keeper_recover',
+              target_type: 'keeper',
+              target_id: 'blocked',
+              severity: 'bad',
+              reason: 'Controlled keeper recovery for runtime stall: api_error',
+              confirm_required: true,
+              suggested_payload: {
+                source: 'fleet_fsm',
+                keeper: 'blocked',
+              },
+            },
+          ],
+        }),
+      ]),
+    )
+
+    render(html`<${FleetFsmMatrix} pollIntervalMs=${1000} />`)
+
+    const button = await screen.findByRole('button', { name: '복구 요청' })
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    await waitFor(() => {
+      expect(dispatchOperatorActionMock).toHaveBeenCalledTimes(1)
+    })
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.stringContaining('승인 대기 중'),
+      'success',
     )
   })
 })

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -171,12 +171,20 @@ export type FleetRuntimeAssistRequest = {
 export type FleetRuntimeAssistHandler =
   (request: FleetRuntimeAssistRequest) => Promise<void> | void
 
+type FleetRuntimeAction = KeeperCompositeSnapshot['recommended_actions'][number]
+
 const RUNTIME_ATTENTION_CLASS: Record<FleetRuntimeAttentionLevel, string> = {
   ok: 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]',
   stale: 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]',
   idle: 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]',
   blocked: 'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]',
 }
+
+const RUNTIME_ACTION_TYPES = new Set([
+  'keeper_probe',
+  'keeper_recover',
+  'keeper_message',
+])
 
 export type FleetCellPresentation = {
   label: string
@@ -397,6 +405,58 @@ async function requestRuntimeAssistViaOperator(
   showToast(`${request.keeperName} AI 진단 요청을 보냈습니다`, 'success')
 }
 
+function runtimeActionPayload(action: FleetRuntimeAction): Record<string, unknown> {
+  const payload = action.suggested_payload
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    return payload as Record<string, unknown>
+  }
+  return {}
+}
+
+function runtimeActionLabel(action: FleetRuntimeAction): string {
+  switch (action.action_type) {
+    case 'keeper_probe':
+      return '상태 확인'
+    case 'keeper_recover':
+      return '복구 요청'
+    case 'keeper_message':
+      return 'AI 진단'
+    default:
+      return action.action_type
+  }
+}
+
+function runtimeActionBusyLabel(action: FleetRuntimeAction): string {
+  switch (action.action_type) {
+    case 'keeper_probe':
+      return '확인 중'
+    case 'keeper_recover':
+      return '요청 중'
+    case 'keeper_message':
+      return '진단 중'
+    default:
+      return '실행 중'
+  }
+}
+
+function runtimeActionTone(action: FleetRuntimeAction): string {
+  if (action.action_type === 'keeper_recover') {
+    return 'text-[var(--warn)]'
+  }
+  return 'text-[var(--accent)]'
+}
+
+function runtimeActionsForSnapshot(
+  snapshot: KeeperCompositeSnapshot,
+  attention: FleetRuntimeAttention,
+): FleetRuntimeAction[] {
+  if (attention.level === 'ok') return []
+  return (snapshot.recommended_actions ?? [])
+    .filter(action => RUNTIME_ACTION_TYPES.has(action.action_type))
+    .filter(action => action.target_type === 'keeper')
+    .slice(0, 3)
+}
+
 export function runtimeAttentionForSnapshot(
   snapshot: KeeperCompositeSnapshot,
   generatedAt: number,
@@ -593,6 +653,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   const [loading, setLoading] = useState<boolean>(true)
   const [query, setQuery] = useState<string>('')
   const [assistBusy, setAssistBusy] = useState<Set<string>>(() => new Set())
+  const [actionBusy, setActionBusy] = useState<Set<string>>(() => new Set())
   const lastStreamedAtRef = useRef<number | null>(null)
   // Observation ring. Ref rather than state because pushObservation
   // returns a fresh record per tick and we pair it with a setData call
@@ -631,6 +692,43 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
       })
     }
   }, [props.onRequestRuntimeAssist])
+
+  const refreshFleetComposite = useCallback(async () => {
+    const snap = await fetcher()
+    applySnapshot(snap)
+  }, [applySnapshot, fetcher])
+
+  const runRuntimeAction = useCallback(async (
+    keeperName: string,
+    action: FleetRuntimeAction,
+  ) => {
+    const key = `${keeperName}:${action.action_type}`
+    setActionBusy(prev => new Set(prev).add(key))
+    try {
+      const result = await dispatchOperatorAction({
+        actor: currentDashboardActor(),
+        action_type: action.action_type,
+        target_type: action.target_type || 'keeper',
+        target_id: action.target_id ?? keeperName,
+        payload: runtimeActionPayload(action),
+      })
+      if (result.confirm_required) {
+        showToast(`${keeperName} ${runtimeActionLabel(action)} 승인 대기 중`, 'success')
+      } else {
+        showToast(`${keeperName} ${runtimeActionLabel(action)} 실행 완료`, 'success')
+      }
+      await refreshFleetComposite()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : `${runtimeActionLabel(action)} 실패`
+      showToast(message, 'error')
+    } finally {
+      setActionBusy(prev => {
+        const next = new Set(prev)
+        next.delete(key)
+        return next
+      })
+    }
+  }, [refreshFleetComposite])
 
   useEffect(() => {
     if (!allowStreamedData) return
@@ -840,6 +938,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
               }
               const name = inferKeeperNameFrom(snap)
               const assisting = assistBusy.has(name)
+              const runtimeActions = runtimeActionsForSnapshot(snap, attention)
               return html`
                 <tr
                   data-keeper=${name}
@@ -870,7 +969,34 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                       >
                         다음: ${attention.nextStep}
                       </span>
-                      ${attention.level !== 'ok'
+                      ${runtimeActions.length > 0
+                        ? html`
+                            <div class="flex flex-wrap gap-1" data-runtime-actions>
+                              ${runtimeActions.map(action => {
+                                const key = `${name}:${action.action_type}`
+                                const busy = actionBusy.has(key)
+                                return html`
+                                  <button
+                                    type="button"
+                                    key=${key}
+                                    data-runtime-action
+                                    data-runtime-action-type=${action.action_type}
+                                    class="self-start rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-3xs font-semibold ${runtimeActionTone(action)} hover:bg-[var(--white-10)] disabled:cursor-not-allowed disabled:opacity-50"
+                                    title=${action.reason}
+                                    disabled=${busy}
+                                    onClick=${(event: MouseEvent) => {
+                                      event.stopPropagation()
+                                      void runRuntimeAction(name, action)
+                                    }}
+                                  >
+                                    ${busy ? runtimeActionBusyLabel(action) : runtimeActionLabel(action)}
+                                  </button>
+                                `
+                              })}
+                            </div>
+                          `
+                        : null}
+                      ${attention.level !== 'ok' && runtimeActions.length === 0
                         ? html`
                             <button
                               type="button"

--- a/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
@@ -22,6 +22,7 @@ function makeSnapshot(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperC
     },
     is_live: true,
     last_outcome: null,
+    recommended_actions: [],
     ...overrides,
   }
 }

--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -34,6 +34,7 @@ function snapshot(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperCompo
     },
     is_live: false,
     last_outcome: null,
+    recommended_actions: [],
     ...overrides,
   }
 }

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -62,6 +62,7 @@ const REAL_COMPOSITE_SHAPE: KeeperCompositeSnapshot = {
     cascade_state: 'done',
     selected_model: 'glm-4.5',
   },
+  recommended_actions: [],
 }
 
 /** Real-world payload observed from `keeper_composite_observer.ml`

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -58,6 +58,7 @@ function snapshot(
     },
     is_live: false,
     last_outcome: null,
+    recommended_actions: [],
   }
 
   return {

--- a/lib/operator_approval.ml
+++ b/lib/operator_approval.ml
@@ -7,7 +7,8 @@
 
 let high_risk_actions =
   [ "namespace_pause"; "room_pause"; "team_stop"; "team_task_inject";
-    "team_worker_spawn_batch"; "keeper_github_identity_login_prepare" ]
+    "team_worker_spawn_batch"; "keeper_recover";
+    "keeper_github_identity_login_prepare" ]
 
 let allowed_actions =
   [ "broadcast"; "namespace_pause"; "room_pause"; "namespace_resume"; "room_resume"; "social_sweep";

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -512,6 +512,12 @@ let compact_receipt_tool_surface_json receipt =
         ]
   | _ -> `Null
 
+let json_number key json =
+  match json_member key json with
+  | `Float value -> Some value
+  | `Int value -> Some (float_of_int value)
+  | _ -> None
+
 let composite_execution_receipt_json ~(config : Coord.config) ~keeper_name =
   match Keeper_execution_receipt.latest_json config keeper_name with
   | None ->
@@ -562,21 +568,224 @@ let composite_execution_receipt_json ~(config : Coord.config) ~keeper_name =
           ("tool_surface", compact_receipt_tool_surface_json receipt);
         ]
 
+let lower_string_opt = Option.map (fun value -> String.lowercase_ascii (String.trim value))
+
+let string_opt_is_any value candidates =
+  match lower_string_opt value with
+  | Some value -> List.mem value candidates
+  | None -> false
+
+let string_opt_present value =
+  match Option.map String.trim value with
+  | Some value -> value <> ""
+  | None -> false
+
+let json_string_eq key json expected =
+  match json_string key json with
+  | Some value -> String.equal value expected
+  | None -> false
+
+let composite_latest_activity_epoch snapshot execution =
+  let last_outcome_epoch =
+    match json_member "last_outcome" snapshot with
+    | `Assoc _ as last_outcome -> json_number "ended_at" last_outcome
+    | _ -> None
+  in
+  let receipt_epoch =
+    match json_string "recorded_at" execution with
+    | Some raw -> Types.parse_iso8601_opt raw
+    | None -> None
+  in
+  match last_outcome_epoch, receipt_epoch with
+  | Some a, Some b -> Some (max a b)
+  | Some value, None | None, Some value -> Some value
+  | None, None -> None
+
+let composite_snapshot_is_idle snapshot =
+  let decision = json_member "decision" snapshot in
+  let cascade = json_member "cascade" snapshot in
+  let compaction = json_member "compaction" snapshot in
+  let breaker_state =
+    match json_member "circuit_breaker" snapshot with
+    | `Assoc _ as breaker -> json_string "state" breaker
+    | _ -> Some "clean"
+  in
+  json_string_eq "turn_phase" snapshot "idle"
+  && json_string_eq "stage" decision "undecided"
+  && json_string_eq "state" cascade "idle"
+  && json_string_eq "stage" compaction "accumulating"
+  && Option.value ~default:"clean" breaker_state = "clean"
+
+let composite_execution_tool_required execution =
+  string_opt_is_any
+    (json_string "tool_contract_result" execution)
+    [
+      "violated";
+      "unknown";
+      "needs_execution_progress";
+      "missing_required_tool_use";
+      "passive_only";
+      "claim_only_after_owned_task";
+      "tool_surface_mismatch";
+      "no_tool_capable_provider";
+    ]
+  || string_opt_is_any
+       (json_string "operator_disposition_reason" execution)
+       [ "tool_required_unsatisfied" ]
+
+let composite_execution_config_blocked execution =
+  string_opt_is_any
+    (json_string "operator_disposition_reason" execution)
+    [ "preflight_config_error" ]
+
+let composite_execution_saturated execution =
+  string_opt_is_any
+    (json_string "terminal_reason_code" execution)
+    [ "ollama_saturated" ]
+  || string_opt_is_any
+       (json_string "operator_disposition_reason" execution)
+       [ "ollama_saturated" ]
+
+let composite_execution_blocked execution =
+  composite_execution_tool_required execution
+  || string_opt_is_any (json_string "operator_disposition" execution) [ "pause_human" ]
+  || (match lower_string_opt (json_string "terminal_reason_code" execution) with
+      | Some terminal -> terminal <> "" && terminal <> "completed"
+      | None -> false)
+  || (match json_member "error" execution with
+      | `Assoc _ as error -> string_opt_present (json_string "kind" error)
+      | _ -> false)
+
+let fleet_fsm_action_payload ~keeper_name ~kind ~reason ~snapshot ~execution =
+  `Assoc
+    [
+      ("source", `String "fleet_fsm");
+      ("kind", `String kind);
+      ("keeper", `String keeper_name);
+      ("reason", `String reason);
+      ("phase", Json_util.string_opt_to_json (json_string "phase" snapshot));
+      ("turn_phase", Json_util.string_opt_to_json (json_string "turn_phase" snapshot));
+      ("execution", execution);
+    ]
+
+let fleet_fsm_message_payload ~keeper_name ~reason ~snapshot ~execution =
+  let message =
+    Printf.sprintf
+      "Fleet FSM supervised resolve request for %s.\nReason: %s.\nInspect the latest runtime evidence, distinguish configuration/tool-contract blockers from restartable runtime stalls, and reply with the safest next operator action. Do not self-restart."
+      keeper_name reason
+  in
+  match fleet_fsm_action_payload ~keeper_name ~kind:"diagnose" ~reason ~snapshot ~execution with
+  | `Assoc fields ->
+      `Assoc
+        (fields
+         @ [
+             ("direct_reply", `Bool true);
+             ("message", `String message);
+           ])
+  | other -> other
+
+let composite_recommended_actions_json ~keeper_name ~snapshot ~execution =
+  let is_live = Option.value ~default:false (json_bool "is_live" snapshot) in
+  let latest = composite_latest_activity_epoch snapshot execution in
+  let now = Unix.gettimeofday () in
+  let stale_long_enough =
+    match latest with
+    | Some ts -> now -. ts >= 600.0
+    | None -> not is_live
+  in
+  let idle_attention =
+    is_live && composite_snapshot_is_idle snapshot && stale_long_enough
+  in
+  let blocked = composite_execution_blocked execution in
+  let needs_attention = blocked || (not is_live) || idle_attention in
+  let reason =
+    match json_string "operator_disposition_reason" execution with
+    | Some value when String.trim value <> "" -> value
+    | _ -> (
+        match json_string "terminal_reason_code" execution with
+        | Some value when String.trim value <> "" -> value
+        | _ when idle_attention -> "idle_composite"
+        | _ when not is_live -> "not_live"
+        | _ -> "runtime_attention" )
+  in
+  let make action_type severity reason suggested_payload =
+    let action : Operator_digest_types.recommended_action =
+      {
+        action_type;
+        target_type = "keeper";
+        target_id = Some keeper_name;
+        severity;
+        reason;
+        suggested_payload;
+      }
+    in
+    action
+  in
+  let probe action_reason =
+    make "keeper_probe" Operator_digest_types.Sev_warn action_reason
+      (fleet_fsm_action_payload ~keeper_name ~kind:"probe" ~reason ~snapshot ~execution)
+  in
+  let message action_reason =
+    make "keeper_message" Operator_digest_types.Sev_warn action_reason
+      (fleet_fsm_message_payload ~keeper_name ~reason:action_reason ~snapshot ~execution)
+  in
+  let recover action_reason =
+    make "keeper_recover" Operator_digest_types.Sev_bad action_reason
+      (fleet_fsm_action_payload ~keeper_name ~kind:"recover" ~reason:action_reason
+         ~snapshot ~execution)
+  in
+  let actions =
+    if not needs_attention then []
+    else if composite_execution_tool_required execution then
+      [
+        probe ("Inspect tool-contract blocker: " ^ reason);
+        message ("Resolve tool-contract blocker: " ^ reason);
+      ]
+    else if composite_execution_config_blocked execution then
+      [
+        probe ("Inspect configuration/auth blocker: " ^ reason);
+        message ("Resolve configuration/auth blocker: " ^ reason);
+      ]
+    else if composite_execution_saturated execution && not stale_long_enough then
+      [ probe ("Inspect local runtime saturation: " ^ reason) ]
+    else if idle_attention then
+      [
+        probe ("Inspect idle composite: " ^ reason);
+        message ("Diagnose idle composite trigger gap: " ^ reason);
+      ]
+    else
+      [
+        probe ("Refresh stale runtime evidence: " ^ reason);
+        recover ("Controlled keeper recovery for runtime stall: " ^ reason);
+      ]
+  in
+  `List
+    (actions
+     |> Operator_digest_types.dedup_recommendations
+     |> List.map (Operator_digest_types.recommended_action_to_yojson ~actor:"fleet_fsm"))
+
 let enrich_composite_snapshot_json ~(config : Coord.config) ~keeper_name json =
   match json with
   | `Assoc fields ->
       let fields =
         List.filter
           (fun (name, _) ->
-            not (String.equal name "keeper" || String.equal name "execution"))
+            not
+              (String.equal name "keeper"
+               || String.equal name "execution"
+               || String.equal name "recommended_actions"))
           fields
+      in
+      let execution = composite_execution_receipt_json ~config ~keeper_name in
+      let recommended_actions =
+        composite_recommended_actions_json ~keeper_name ~snapshot:json ~execution
       in
       `Assoc
         (fields
          @ [
              ("keeper", `String keeper_name);
-             ( "execution",
-               composite_execution_receipt_json ~config ~keeper_name );
+             ("execution", execution);
+             ("recommended_actions", recommended_actions);
            ])
   | other -> other
 

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -585,7 +585,8 @@ let seed_agent_file ?(agent_type = "worker") ?(capabilities = []) config agent_n
   Masc_mcp.Coord.write_json config agent_file (Types.agent_to_yojson agent)
 ;;
 
-let append_execution_receipt config ~keeper_name =
+let append_execution_receipt ?(tool_contract_result = "satisfied")
+    ?(tools_used = [ "keeper_fs_read" ]) config ~keeper_name =
   let meta =
     match Masc_mcp.Keeper_types.read_meta config keeper_name with
     | Ok (Some meta) -> meta
@@ -612,8 +613,8 @@ let append_execution_receipt config ~keeper_name =
       observed_tools = [ "keeper_fs_read" ];
       canonical_tools = [ "keeper_fs_read" ];
       unexpected_tools = [ "WebSearch" ];
-      tools_used = [ "keeper_fs_read" ];
-      tool_contract_result = "satisfied";
+      tools_used;
+      tool_contract_result;
       tool_surface =
         {
           turn_lane = "tool";
@@ -1263,6 +1264,40 @@ let test_composite_routes_surface_latest_execution_receipt () =
     (fleet_execution |> member "cascade" |> member "selected_model" |> to_string)
 ;;
 
+let test_composite_routes_surface_runtime_recommended_actions () =
+  with_seeded_server
+  @@ fun ~port ~config ~admin_token ~keeper_name ->
+  let boot_path = Printf.sprintf "/api/v1/keepers/%s/boot" keeper_name in
+  let boot_result =
+    run_curl_post ~body:"{}" ~token:admin_token ~port ~path:boot_path ()
+  in
+  require_status "boot route registers keeper before composite read" 200 boot_result;
+  append_execution_receipt ~tool_contract_result:"missing_required_tool_use"
+    ~tools_used:[] config ~keeper_name;
+  let path = Printf.sprintf "/api/v1/keepers/%s/composite" keeper_name in
+  let result = run_curl_get ~port ~path () in
+  require_status "per-keeper composite GET returns 200" 200 result;
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string result.body in
+  let actions = json |> member "recommended_actions" |> to_list in
+  check bool "composite recommends keeper_probe" true
+    (List.exists
+       (fun row ->
+         row |> member "action_type" |> to_string = "keeper_probe"
+         && row |> member "target_id" |> to_string = keeper_name)
+       actions);
+  check bool "composite recommends keeper_message" true
+    (List.exists
+       (fun row ->
+         row |> member "action_type" |> to_string = "keeper_message"
+         && row |> member "target_id" |> to_string = keeper_name)
+       actions);
+  check bool "tool-contract blocker does not recommend restart" false
+    (List.exists
+       (fun row -> row |> member "action_type" |> to_string = "keeper_recover")
+       actions)
+;;
+
 let test_tool_calls_route_surfaces_coverage_gap_health () =
   with_seeded_server
   @@ fun ~port ~config ~admin_token:_ ~keeper_name ->
@@ -1480,6 +1515,10 @@ let () =
             "composite routes surface latest execution receipt"
             `Slow
             test_composite_routes_surface_latest_execution_receipt
+        ; test_case
+            "composite routes surface runtime recommended actions"
+            `Slow
+            test_composite_routes_surface_runtime_recommended_actions
         ; test_case
             "tool calls route surfaces coverage gap health"
             `Slow

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -485,7 +485,7 @@ let test_snapshot_exposes_keeper_and_social_actions () =
           in
           Alcotest.(check string) "keeper_recover target_type" "keeper"
             Yojson.Safe.Util.(keeper_recover |> member "target_type" |> to_string);
-          Alcotest.(check bool) "keeper_recover confirm false" false
+          Alcotest.(check bool) "keeper_recover confirm true" true
             Yojson.Safe.Util.(keeper_recover |> member "confirm_required" |> to_bool);
           let keeper_identity_login_prepare =
             match find_action "keeper_github_identity_login_prepare" with
@@ -1481,9 +1481,27 @@ let test_operator_keeper_recover_accepts_agent_name_alias () =
         | Ok json -> json
         | Error err -> Alcotest.fail err
       in
+      Alcotest.(check bool) "recover requires confirmation" true
+        Yojson.Safe.Util.(action_json |> member "confirm_required" |> to_bool);
       Alcotest.(check string) "recover delegates to keeper recover"
         "masc_keeper_recover"
         Yojson.Safe.Util.(action_json |> member "tool_name" |> to_string);
+      let confirm_token =
+        Yojson.Safe.Util.(action_json |> member "confirm_token" |> to_string)
+      in
+      let action_json =
+        match
+          Operator_control.confirm_json ctx
+            (`Assoc
+              [
+                ("actor", `String "operator");
+                ("confirm_token", `String confirm_token);
+                ("decision", `String "confirm");
+              ])
+        with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
       let delegated_result =
         Yojson.Safe.Util.(action_json |> member "result" |> member "result")
       in

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -356,6 +356,12 @@ let test_snapshot_pending_confirm_summary_tracks_actor_scope () =
                row |> member "action_type" |> to_string)
              = "keeper_github_identity_login_prepare")
            confirm_required_actions);
+      Alcotest.(check bool) "keeper recover listed" true
+        (List.exists
+           (fun row ->
+             Yojson.Safe.Util.(row |> member "action_type" |> to_string)
+             = "keeper_recover")
+           confirm_required_actions);
       Alcotest.(check bool) "team stop removed from confirm surface" false
         (List.exists
            (fun row ->


### PR DESCRIPTION
## Summary\n- Add recommended_actions to fleet FSM composite snapshots so stalled/idle states can suggest keeper_probe, keeper_message, or keeper_recover.\n- Route tool_contract/config/auth/ollama saturation conditions through probe/message instead of blind recover.\n- Promote keeper_recover to high-risk requiring preview + confirm flow (no auto-approve).\n- Wire Dashboard FSM action button execution to backend recommended actions and mark recover as approval-required.\n\n## Validation\n- scripts/dune-local.sh build bin/main_eio.exe test/test_operator_control.exe test/test_dashboard_keeper_routes.exe\n- ./_build/default/test/test_operator_control.exe test --color=never --bail operator 8,24,39\n- ./_build/default/test/test_dashboard_keeper_routes.exe test --color=never --bail dashboard_keeper_routes 9,10\n- pnpm --dir dashboard exec vitest run ... --no-file-parallelism --maxWorkers=1\n- pnpm --dir dashboard exec tsc --noEmit --pretty false\n- git diff --check