### PR TITLE
fix(watchdog): add grace period and extract hardcoded thresholds

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -147,6 +147,39 @@ module KeeperSupervisor = struct
     Float.max 300.0 (get_float ~default:Masc_time_constants.day "MASC_KEEPER_PAUSED_CLEANUP_TTL_SEC")
 end
 
+(** {1 Keeper Watchdog Configuration}
+
+    Thresholds for the stale-turn watchdog fiber
+    ({!Keeper_stale_watchdog}). Previously hardcoded; extracted so
+    operators can tune per deployment without a rebuild.
+
+    Precedence: process env > hardcoded default below. *)
+
+module KeeperWatchdog = struct
+  (** Seconds since last turn before a Running keeper is considered idle-stale.
+      Must be >= 60. Default: 300 (5 minutes). *)
+  let stale_threshold_sec =
+    Float.max 60.0 (get_float ~default:300.0 "MASC_KEEPER_WATCHDOG_STALE_SEC")
+
+  (** Watchdog poll interval in seconds. Must be >= 5.
+      Default: 30. *)
+  let poll_sec =
+    Float.max 5.0 (get_float ~default:30.0 "MASC_KEEPER_WATCHDOG_POLL_SEC")
+
+  (** Consecutive noop turns before considering the keeper stuck in a
+      failure loop. Must be >= 2. Default: 3. *)
+  let noop_threshold =
+    max 2 (get_int ~default:3 "MASC_KEEPER_WATCHDOG_NOOP_THRESHOLD")
+
+  (** Grace period after fiber start before idle-stale detection activates.
+      Prevents false positives on server restart when [last_turn_ts] is
+      carried over from a previous server lifecycle.
+      Must be >= 0. Default: 360 (6 minutes — covers proactive warmup
+      up to 255 s plus one heartbeat cycle). *)
+  let grace_period_sec =
+    Float.max 0.0 (get_float ~default:360.0 "MASC_KEEPER_WATCHDOG_GRACE_SEC")
+end
+
 (** {1 Keeper Runtime Configuration} *)
 
 module KeeperRuntime = struct

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -2249,6 +2249,16 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
       | None -> m
     in
     let synced = ensure_keeper_room_presence ctx.config m in
+    (* Reset stale timestamp from previous server lifecycle.
+       Without this, the stale watchdog reads the old last_turn_ts
+       and immediately terminates the fiber on server restart. *)
+    let synced =
+      { synced with
+        runtime = { synced.runtime with
+          usage = { synced.runtime.usage with last_turn_ts = 0.0 };
+        };
+      }
+    in
     (match write_meta ~force:true ctx.config synced with
      | Ok () -> ()
      | Error e ->

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -20,9 +20,18 @@ open Keeper_types
 let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
     (reg : Keeper_registry.registry_entry) =
   let base_path = ctx.config.base_path in
-  let stale_threshold_sec = 300.0 in
-  let watchdog_poll_sec = 30.0 in
-  let noop_threshold = 3 in
+  let stale_threshold_sec () =
+    Env_config_keeper.KeeperWatchdog.stale_threshold_sec
+  in
+  let watchdog_poll_sec () =
+    Env_config_keeper.KeeperWatchdog.poll_sec
+  in
+  let noop_threshold () =
+    Env_config_keeper.KeeperWatchdog.noop_threshold
+  in
+  let grace_period_sec () =
+    Env_config_keeper.KeeperWatchdog.grace_period_sec
+  in
   let last_broadcast_ts = ref 0.0 in
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     let rec watchdog_loop () =
@@ -30,25 +39,31 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
       else begin
         Eio.Fiber.yield ();
         let now = Time_compat.now () in
+        let threshold = stale_threshold_sec () in
         (try
            match Keeper_registry.get ~base_path meta.name with
            | Some entry
              when entry.phase = Keeper_state_machine.Running ->
              let last_turn = entry.meta.runtime.usage.last_turn_ts in
+             let fiber_age = now -. entry.started_at in
+             let grace_remaining = grace_period_sec () -. fiber_age in
              let idle_stale =
-               last_turn > 0.0 && now -. last_turn > stale_threshold_sec
+               last_turn > 0.0
+               && now -. last_turn > threshold
+               && fiber_age >= grace_period_sec ()
              in
              let noop_count =
                entry.meta.runtime.proactive_rt.consecutive_noop_count
              in
-             let failure_loop = noop_count >= noop_threshold in
+             let failure_loop = noop_count >= noop_threshold () in
              let stale = idle_stale || failure_loop in
              Log.Keeper.info
-               "%s: watchdog tick noop=%d idle_stale=%b failure_loop=%b stale=%b last_turn=%.0f"
-               meta.name noop_count idle_stale failure_loop stale last_turn;
+               "%s: watchdog tick noop=%d idle_stale=%b failure_loop=%b stale=%b last_turn=%.0f fiber_age=%.0f grace_rem=%.0f"
+               meta.name noop_count idle_stale failure_loop stale last_turn
+               fiber_age grace_remaining;
              let cooldown_ok =
                !last_broadcast_ts = 0.0
-               || now -. !last_broadcast_ts > stale_threshold_sec
+               || now -. !last_broadcast_ts > threshold
              in
              if stale && cooldown_ok then begin
                let reason_desc =
@@ -95,7 +110,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
            Log.Keeper.warn
              "%s: stale watchdog tick failed (suppressed): %s"
              meta.name (Printexc.to_string exn));
-        (try Eio.Time.sleep ctx.clock watchdog_poll_sec with
+        (try Eio.Time.sleep ctx.clock (watchdog_poll_sec ()) with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | _ -> ());
         watchdog_loop ()

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -339,6 +339,8 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
+  | Oas.Event_bus.TurnReady _ ->
+      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256


### PR DESCRIPTION
## Summary

- **Grace period**: Watchdog now skips idle_stale detection for the first 360s after fiber start, preventing false positives on server restart when `last_turn_ts` is carried over from a previous lifecycle
- **Extract thresholds**: Hardcoded `300.0`/`30.0`/`3` moved to `Env_config_keeper.KeeperWatchdog` module (stale_threshold_sec, poll_sec, noop_threshold, grace_period_sec)
- **Bootstrap reset**: `bootstrap_live_keeper_meta` resets `last_turn_ts` to `0.0` so the watchdog's `last_turn > 0.0` gate prevents idle_stale even without grace period (defense in depth)

## Problem

On server restart, all keepers crash within seconds. The stale watchdog reads `last_turn_ts` from the previous server, immediately detects idle_stale (>300s), terminates the fiber. After 5 crash-restart cycles (backoff: 10→20→40→80→160s), the keeper enters Dead (terminal). Keeper performs zero turns.

## Files changed

| File | Change |
|------|--------|
| `lib/config/env_config_keeper.ml` | `KeeperWatchdog` module (4 config values) |
| `lib/keeper/keeper_stale_watchdog.ml` | Env_config thresholds, grace period logic, enriched log |
| `lib/keeper/keeper_keepalive.ml` | Reset `last_turn_ts = 0.0` in bootstrap |

## Test plan

- [x] `dune build @install` passes
- [x] `dune runtest test/test_keeper_supervisor.ml` — 19/19 tests pass
- [ ] Server restart: all keepers reach Running and stay Running (no Crashed/Dead within 5 minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)