### PR TITLE
refactor(design-system): swap tool-allowlist-editor preset select to Select canonical (CS17)

### DIFF
--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -3,6 +3,7 @@ import { signal, computed } from '@preact/signals'
 import { useEffect, useState, useMemo } from 'preact/hooks'
 import { useCombobox } from 'downshift'
 import { editKeeperTools, type ToolEditResponse } from '../../api/keeper'
+import { Select } from '../common/select'
 import { toolsData } from './tool-state'
 
 // ── State signals ────────────────────────────
@@ -572,15 +573,16 @@ export function ToolAllowlistEditor({
         ? html`
           <label class="flex flex-col gap-1">
             <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">preset</span>
-            <select
-              class="w-full px-3 py-2 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs text-[var(--color-fg-primary)]"
+            <${Select}
+              class="px-3 py-2 text-2xs"
+              ariaLabel="preset"
               value=${preset.value}
-              onChange=${(e: Event) => { preset.value = (e.target as HTMLSelectElement).value as typeof preset.value }}
-            >
-              ${Object.entries(PRESET_DESCRIPTIONS).map(([key, desc]) => html`
-                <option value=${key}>${key} \u2014 ${desc}</option>
-              `)}
-            </select>
+              options=${Object.entries(PRESET_DESCRIPTIONS).map(([key, desc]) => ({
+                value: key,
+                label: `${key} \u2014 ${desc}`,
+              }))}
+              onInput=${(v: string) => { preset.value = v as typeof preset.value }}
+            />
           </label>
 
           <div class="flex flex-col gap-1">


### PR DESCRIPTION
## Summary

CS series select sweep #8 — tool-allowlist-editor preset picker.

## 변경

`dashboard/src/components/tools/tool-allowlist-editor.ts`:
- inline `<select>` (8 preset options) → `<${Select}>`
- options: `Object.entries(PRESET_DESCRIPTIONS).map(...)` → `{value, label: 'key — desc'}`
- string union typecast `as typeof preset.value` 는 onInput callback 안으로 이동

palette: design-system 토큰 호환.

## 검증

- pnpm typecheck: green
- pnpm test src/components/tools/tool-allowlist-editor: 11/11 pass

## CS series progress (post-#10734 unblock)

| PR | 카테고리 | 상태 |
|----|---------|------|
| CS1~9 | 30 inline buttons | MERGED |
| CS10 #10715 | governance-monitor | MERGED |
| CS11 #10717 | connector-quick-bind | MERGED |
| CS12 #10722 | runtime-monitor | OPEN |
| CS13 #10724 | quick-intervene | OPEN |
| CS14 #10725 | tool-full-inventory | OPEN |
| CS15 #10726 | keeper-utilities | OPEN |
| CS16 #10728 | persona-generator | OPEN |
| CS17 (this) | tool-allowlist-editor | OPEN |
| **드리프트 fix #10734** | connector-* test/source 동기화 | OPEN — 큐 unblock |

## Test plan

- [ ] CI green (drift fix #10734 머지 후)
- [ ] tool-allowlist-editor preset 변경 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)
