### PR TITLE
fix(build): unbreak main — For_testing module + redundant TurnReady arm

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -357,4 +357,19 @@ let prune t ~days =
     !deleted
   end
 
+(* Test hooks declared in the .mli — implementation lives in this
+   module so tests can verify mutex-registry sharing without
+   widening the public API surface. *)
+module For_testing = struct
+  let mutex (t : t) = Atomic.get t.mutex
+
+  let mutex_for_base_dir base_dir =
+    let cell = mutex_for_base_dir ~base_dir ~injected:None in
+    Atomic.get cell
+
+  let registry_size () =
+    Stdlib.Mutex.protect mutex_registry_mu (fun () ->
+      Hashtbl.length mutex_registry)
+end
+
 (* Duplicate count_entries removed — canonical definition at line 225 *)

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -341,8 +341,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
-  | Oas.Event_bus.TurnReady _ ->
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256


### PR DESCRIPTION
## P0 — main 빌드 깨짐 (현재)

```
File \"lib/dated_jsonl/dated_jsonl.ml\", line 1:
Error: The implementation lib/dated_jsonl/dated_jsonl.ml
       does not match the interface lib/dated_jsonl/dated_jsonl.mli:
       The module For_testing is required but not provided

File \"lib/oas_event_bridge.ml\", line 344, characters 4-29:
344 |   | Oas.Event_bus.TurnReady _ ->
Error (warning 11 [redundant-case]): this match case is unused.
```

두 개의 독립된 break:

### 1. dated_jsonl: .mli 와 .ml 불일치

`#10739` (`fix: make dated_jsonl shared append mutex recoverable`) 에서 `dated_jsonl.mli` 에 `module For_testing` 을 선언했으나 `.ml` 본문이 함께 들어가지 않음.

```ocaml
(* mli 라인 51-62 *)
module For_testing : sig
  val mutex : t -> Eio.Mutex.t
  val mutex_for_base_dir : string -> Eio.Mutex.t
  val registry_size : unit -> int
end
```

### 2. oas_event_bridge: 중복 arm

`#10709` (OAS pin TurnReady event) cascade 에서 같은 match 블록에 `TurnReady _` arm 이 두 번 들어감:
- line 211: `| Oas.Event_bus.TurnReady _ -> None`  ← 도달 가능
- line 344: `| Oas.Event_bus.TurnReady _ -> None`  ← unreachable, warning 11 fatal

## 변경

| 파일 | 변경 |
|------|------|
| `lib/dated_jsonl/dated_jsonl.ml` | `.mli` 가 요구하는 `For_testing` 서브모듈 추가 (registry_size, mutex_for_base_dir, mutex). 기존 module-private helper 위임 — 새 로직 없음. |
| `lib/oas_event_bridge.ml` | line 344-345 의 unreachable `TurnReady` arm 제거. line 211 의 첫 arm 이 case 처리. |

## 테스트

`dune build @check` EXIT=0.

## 영향

- 모든 open PR 이 main rebase 시 즉시 build green 회복.
- runtime semantics 변경 없음 — `.mli` 가 이미 약속한 surface 만 채움 + dead arm 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)