### PR TITLE
refactor(design-system): swap memory-subsystems 2 selects to Select canonical (CS19)

### DIFF
--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -3,6 +3,7 @@ import { signal, useSignal } from '@preact/signals'
 import { useEffect, useMemo } from 'preact/hooks'
 import { LoadingState } from './common/feedback-state'
 import { MermaidGraph } from './common/mermaid-graph'
+import { Select } from './common/select'
 import {
   fetchMemorySubsystems,
   type MemorySubsystemsResponse,
@@ -695,26 +696,26 @@ export function MemorySubsystems() {
             onInput=${onSearchInput}
             class="flex-1 min-w-50 bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--color-fg-muted)] placeholder:text-[var(--color-fg-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
           />
-          <select
+          <${Select}
+            class="px-2 py-1 text-sm"
+            ariaLabel="키퍼 필터"
             value=${keeperFilter.value}
-            onChange=${(e: Event) => (keeperFilter.value = (e.target as HTMLSelectElement).value)}
-            class="bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--color-fg-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
-          >
-            <option value="">모든 키퍼</option>
-            ${knownKeepers.map(
-              (k: string) => html`<option value=${k}>${k}</option>`,
-            )}
-          </select>
-          <select
+            options=${[
+              { value: '', label: '모든 키퍼' },
+              ...knownKeepers.map((k: string) => ({ value: k, label: k })),
+            ]}
+            onInput=${(v: string) => { keeperFilter.value = v }}
+          />
+          <${Select}
+            class="px-2 py-1 text-sm"
+            ariaLabel="결과 필터"
             value=${outcomeFilter.value}
-            onChange=${(e: Event) => (outcomeFilter.value = (e.target as HTMLSelectElement).value)}
-            class="bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--color-fg-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
-          >
-            <option value="">모든 결과</option>
-            ${knownOutcomes.map(
-              (o: string) => html`<option value=${o}>${o}</option>`,
-            )}
-          </select>
+            options=${[
+              { value: '', label: '모든 결과' },
+              ...knownOutcomes.map((o: string) => ({ value: o, label: o })),
+            ]}
+            onInput=${(v: string) => { outcomeFilter.value = v }}
+          />
           ${
             hasFilter
               ? html`<button


### PR DESCRIPTION
## Summary

CS series select sweep #10 — memory-subsystems 2 selects.

## 변경

`dashboard/src/components/memory-subsystems.ts`:
1. 키퍼 필터 select (모든 키퍼 + knownKeepers) → `<${Select}>`
2. 결과 필터 select (모든 결과 + knownOutcomes) → `<${Select}>`

palette: design-system 토큰 호환.
원본 typo `focus:border-[var(--white-10)]0` 자동 제거 (canonical focus styling 적용).

## 검증

- pnpm typecheck: green
- pnpm test src/components/memory-subsystems: 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
