### PR TITLE
refactor(design-system): swap persona-browser search input to TextInput canonical (CS20)

### DIFF
--- a/dashboard/src/components/keeper-spawn/persona-browser.ts
+++ b/dashboard/src/components/keeper-spawn/persona-browser.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { SurfaceCard } from '../common/card'
 import { ActionButton } from '../common/button'
+import { TextInput } from '../common/input'
 import { shellAuthSummary } from '../../store'
 import { dashboardAuthAccess } from '../../lib/dashboard-auth-access'
 import { personas, personasLoading, personasError, loadPersonas, spawnKeeperFromPersona, spawning, spawnResult, type PersonaSummary } from './keeper-spawn-state'
@@ -92,13 +93,13 @@ export function PersonaBrowser() {
         </p>
       `}
       <div class="flex flex-wrap items-center gap-2 mb-3">
-        <input
+        <${TextInput}
           type="search"
+          class="min-w-45 flex-1 !px-2 !py-1 !text-2xs"
           value=${searchQuery.value}
           placeholder="페르소나 검색 (이름/역할/모드/설명)"
-          aria-label="페르소나 검색"
+          ariaLabel="페르소나 검색"
           onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
-          class="min-w-45 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
         <span class="text-3xs text-[var(--color-fg-muted)] tabular-nums">
           ${searchQuery.value.trim()


### PR DESCRIPTION
## Summary

CS series **input sweep #1** — persona-browser 검색 input.

## 변경

`dashboard/src/components/keeper-spawn/persona-browser.ts`:
- inline `<input type="search">` (페르소나 검색) → `<${TextInput} type="search">`
- class override `!px-2 !py-1 !text-2xs` (dense layout 보존)

palette:
- 원본 `--white-10` border / `--white-4` bg / `--color-fg-primary` text / `--color-fg-disabled` placeholder
- TextInput INPUT_BASE: `--color-border-default` / `--white-4` / `--color-fg-primary` / `--color-fg-muted`
- 양쪽 모두 design-system, 호환. placeholder는 muted(밝음) → a11y 향상.

## 검증

- pnpm typecheck: green
- pnpm test src/components/keeper-spawn/persona-browser: 11/11 pass

## 진행 상황

select sweep 10개 완료, 첫 input swap PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
