### PR TITLE
feat(design-system): v0.3 + v0.4 — keeper attribution overhaul

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -1,0 +1,122 @@
+# MASC Cockpit Design System — Changelog
+
+All notable changes to the canonical design system live here.
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with project-specific phase markers.
+
+---
+
+## [Unreleased] — v0.4 (in progress)
+
+Stage: legacy alias cleanup + KeeperBadge migration completion.
+
+### Removed
+
+- **Legacy keeper aliases purged** — completing the v0.3 deprecation cycle one minor early (no remaining callers in dashboard preview).
+  - `tokens.css`: `--k-nick / -masc / -sangsu / -qa / -rama` (+ `-glow`, `-soft`, `-border`, `-ring`) — 25 tokens removed.
+  - `tokens.css`: `.dot-k-nick / -masc / -sangsu / -qa / -rama` CSS rules (5 selectors).
+  - `cb-shared.jsx`: `kClass()` function and its `window.*` export.
+  - `cb-stress-10keepers.html` (the v1 "before" demo) — superseded by `-v2`. v2 is now the only stress-test page.
+- **18 component callsites migrated** from `<Dot kind={kClass(id)}>` → `<KeeperBadge id={id} variant="sigil"|"full">` across cb-group-a/b/c/d/h. Two patterns:
+  - `variant="sigil"` where the keeper name is rendered separately (ticker, lifeline, sidebar, swimlanes, BDI panel, kanban, rail).
+  - `variant="full"` where the badge owns both color+sigil+name (table cells, kanban foot).
+- **`primitives.html`**: dead `class="dot-k-nick"` + duplicate `class=` attribute on heartbeat anim demo cleaned.
+
+### Migration impact
+
+- 0 callers in `dashboard/` reference removed names.
+- Cross-project references (bonsai etc.) — if any — must migrate to `--k-N` / `--color-keeper-N` / `<KeeperBadge>`.
+
+---
+
+## [v0.3] — Keeper attribution overhaul
+
+### Added
+
+- **v0.3 — Keeper attribution overhaul** (palette + sigil channel)
+  - **12-slot OkLCH spectrum** (`tokens.css` §3): `--k-1` … `--k-12` at L=68%, C=0.09, hue stride 30°. Adjacent ΔE ≥ 25, all ≥4.5:1 contrast on `--bg-0`. Each slot exposes `-soft`, `-border`, `-ring`, `-glow` (4-slot semantics) → 60 new tokens.
+  - **Canonical façade**: `--color-keeper-1` … `--color-keeper-12` exposed at SPEC §3.6 tier.
+  - **`<KeeperBadge>` + `<KeeperStack>` + `kSlot()` + `kSigil()`** in `cb-shared.jsx` — canonical attribution primitives. FNV-1a hash → 12-slot mapping; 5 anchor IDs pinned in `KEEPER_REGISTRY`.
+  - **SPEC §3.6 v0.3 revised**: color-only attribution forbidden; 2-letter sigil mandatory as second channel; `<KeeperStack cap={4}>` with `+N` overflow when keepers > 4.
+  - **`cb-stress-10keepers-v2.html`**: re-runs the 10-active worst case against the new palette + sigil channel — all 5 patterns flip from FAIL → PASS verdict.
+
+- **`cb-group-g` — state patterns** (10 variants across 5 groups)
+  - **Empty states**: Vacant zone (lifeline-style with ASCII art), "no results" (filter context with reset CTA).
+  - **Loading skeletons**: Row shimmer (3-line ticker), KPI cell shimmer, panel shimmer (header + body).
+  - **Error surfaces**: Recoverable warn (with retry CTA), fatal error (with diagnostic frame ID).
+  - **Pagination**: Cursor-style (← prev / → next + page count), numbered (with ellipsis for ranges).
+  - **Breadcrumb**: Standard (separator chevron), bilingual KR/EN with last-segment `aria-current="page"`.
+  - All variants follow SPEC §5 a11y catalog: `role="status"` / `aria-live="polite"` for transient surfaces, `role="alert"` for fatal errors, `<nav>` + `aria-label` for pagination/breadcrumb, decorative glyphs marked `aria-hidden="true"`.
+  - Files: `preview/cb-group-g.jsx`, `preview/cb-group-g.html` — live showcase wired into `preview/index.html` under "Common patterns".
+
+- **Motion tokens** (`source_styles/tokens.css` §6 — already present in SSOT, now formally exposed)
+  - Curves: `--ease`, `--ease-out`, `--ease-in`, `--ease-inout`, `--ease-spring` (5)
+  - Durations: `--t-fast`, `--t-med`, `--t-slow`, `--t-xslow` (4)
+  - Role tokens: `--motion-enter`, `--motion-exit`, `--motion-swap`, `--motion-reveal`, `--motion-settle`, `--motion-pop` (6)
+  - `prefers-reduced-motion: reduce` block flattens all durations to `1ms` and removes spring overshoot.
+
+- **Trace-frame tokens** (`source_styles/tokens.css` §7) — `--t-llm`, `--t-tool`, `--t-think`, `--t-wait`, `--t-err`. Defined for default + 5 themes (dark-fantasy / cyberpunk / terminal / parchment / paper). Replaces the raw `.flame_*` hex values in `dashboard_bonsai/shell_view.ml` (bonsai-side PR pending).
+
+- **5-theme matrix** consolidated to single SSOT (`source_styles/tokens.css`).
+  - Themes: `dark-fantasy` (default), `cyberpunk`, `terminal`, `parchment`, `paper`.
+  - Each theme overrides raw bg / fg / border / accent / radius / shadow / font as needed; semantic and role aliases are theme-agnostic.
+
+### Changed
+
+- **Default theme is now strictly dark.** Removed the `@media (prefers-color-scheme: light)` auto-flip block in `tokens.css`. The dark-fantasy stack is the canonical default; light surfaces require an explicit `data-theme="paper"` (or `"light"`) on `<html>`. Honors original SPEC intent — `prefers-color-scheme` was leaking OS preference into the design and overriding the brand palette on light-mode laptops.
+
+- **`colors_and_type.css` is now a thin façade** over `source_styles/tokens.css` to eliminate cascade drift between the historical 159-line file and the 921-line SSOT.
+  - All `--color-*` semantic aliases now resolve through `tokens.css`.
+  - Legacy short-form aliases (`--color-bg`, `--color-text`, `--color-border`) preserved for back-compat but marked `@deprecated` in comments — to be removed in v0.3.
+  - Migration path documented in SPEC §7.1.4.
+
+- **`preview/index.html` link order**
+  - Now imports `tokens.css` first, then `type_layer.css`, then `primitives.css`.
+  - `colors_and_type.css` deliberately not re-imported to avoid double-cascade. SPEC §7.1.4.
+
+### Reference rewiring
+
+- "Common patterns" group on `preview/index.html` gained the `cb-group-g · State patterns` card.
+- "Reference" group now points to **SPEC.md** and **CHANGELOG.md** (this file) instead of an outdated README pointer.
+
+### Verified
+
+- cb-group-g rendered in preview, 11 a11y landmarks present, 0 console errors (verifier agent pass, 2026-04).
+
+---
+
+## [v0.1] — Phase 1+2+3 component coverage
+
+Stage: cockpit zones complete.
+
+### Added
+
+- **Phase 1 — Cockpit zones** (cb-group-a..f, 11 components × 31 variants)
+  - Topbar, ticker, KPI, lifeline, sidebar, swimlanes, deck, rail, composer, status bar, drawer.
+
+- **Phase 2 — Work / Comms / Observability / Cognition planes** (cb-group-h..k)
+  - **I0** IDE backbone (3 variants): branch selector, keeper multi-select, operator nudge log.
+  - **G1-G3** Work: Goal Zone, Task Zone, Accountability (8 variants).
+  - **C1-C3** Comms: Board Zone, Messages, Composer v2 (9 variants).
+  - **O1-O5** Observability: Cascade, Audit, Safe Autonomy, Cost & Latency, Heuristic + Stress (15 variants).
+  - **K1-K4** Cognition: Keeper Inspector v2, Decisions / Memory, Institution Episodes, Autoresearch (10 variants).
+
+- **Phase 3 — Code IDE plane** (`code-mode.jsx`, E1..E5, 20 variants)
+  - File Tree, Editor Surfaces, PR Inspector, Branch Graph, Terminal / Search.
+
+- **Foundations**
+  - 3-tier token taxonomy (Raw → Semantic → Role) — SPEC §2.
+  - Surface stack, type system (11 roles), spacing (4px base), 7-step elevation, brand vocabulary.
+  - Preview pages: `colors`, `type`, `spacing`, `brand`, `primitives`, `forms`, `overlays`, `snippets`.
+
+- **Showcase**
+  - `ui_kits/cockpit/` — single-page wired prototype (App + Chrome + Panels + Planes + cockpit.css).
+
+---
+
+## Versioning policy
+
+- **Patch** (v0.x.y): bugfix, doc clarification, no token or component-shape change.
+- **Minor** (v0.x): new tokens, new components, additive a11y enhancements. Existing token names preserved.
+- **Major** (vx.0): breaking — token renames, removal of deprecated aliases, theme matrix changes that require call-site updates.
+
+Per SPEC §1: **the spec changes before the code does.** Any new token / component pattern / theme starts with a SPEC PR; this changelog documents the implementation that follows.

--- a/dashboard/design-system/SPEC.md
+++ b/dashboard/design-system/SPEC.md
@@ -89,21 +89,75 @@ masc-mcp 레포는 두 dashboard surface가 같은 서버에서 병존 서빙된
 
 **4-slot 패턴**: dashboard는 status마다 4 slot(`--ok-soft`, `--ok-fg`, `--ok-border`, `--ok-ring`)을 정의한다. bonsai는 단일 slot. SPEC v0.1에서는 **dashboard 4-slot이 canonical**, bonsai는 단일 slot을 fallback로 유지(컴포넌트가 4 slot을 요구하면 bonsai에서 동일 raw를 4번 참조).
 
-### 3.6 Attribution (dashboard only — Phase 0)
+### 3.6 Attribution (dashboard only — Phase 0, **v0.3 revised**)
 
-| Canonical | dashboard raw | bonsai | 의미 |
-|-----------|---------------|--------|------|
-| `--color-keeper-1` | `--k-nick` | (없음) | keeper attribution dot 1 |
-| `--color-keeper-2` | `--k-masc` | (없음) | keeper 2 |
-| `--color-keeper-3` | `--k-sangsu` | (없음) | keeper 3 |
-| `--color-keeper-4` | `--k-qa` | (없음) | keeper 4 |
-| `--color-keeper-5` | `--k-rama` | (없음) | keeper 5 |
-| `--p-anthropic` | `--p-anthropic` | (없음) | provider cascade chip |
-| `--p-moonshot` | `--p-moonshot` | (없음) | provider cascade chip |
-| `--p-openai` | `--p-openai` | (없음) | provider cascade chip |
-| `--p-xai` | `--p-xai` | (없음) | provider cascade chip |
+#### 3.6.1 Palette — 12-slot OkLCH spectrum
 
-bonsai는 현재 keeper attribution을 색이 아닌 텍스트(`@nick0cave` 등)로 표현. SPEC v0.1에서는 attribution을 **dashboard-only canonical**로 두고, bonsai에서 도입 시 raw 그대로 참조하도록 허용.
+| Canonical | dashboard raw | 의미 |
+|-----------|---------------|------|
+| `--color-keeper-1`  | `--k-1`  | slot 01 · H=000° · rose |
+| `--color-keeper-2`  | `--k-2`  | slot 02 · H=030° · clay |
+| `--color-keeper-3`  | `--k-3`  | slot 03 · H=060° · amber |
+| `--color-keeper-4`  | `--k-4`  | slot 04 · H=090° · olive |
+| `--color-keeper-5`  | `--k-5`  | slot 05 · H=120° · moss |
+| `--color-keeper-6`  | `--k-6`  | slot 06 · H=150° · jade |
+| `--color-keeper-7`  | `--k-7`  | slot 07 · H=180° · teal |
+| `--color-keeper-8`  | `--k-8`  | slot 08 · H=210° · cyan |
+| `--color-keeper-9`  | `--k-9`  | slot 09 · H=240° · azure |
+| `--color-keeper-10` | `--k-10` | slot 10 · H=270° · iris |
+| `--color-keeper-11` | `--k-11` | slot 11 · H=300° · violet |
+| `--color-keeper-12` | `--k-12` | slot 12 · H=330° · magenta |
+
+OkLCH parameters fixed at L=68%, C=0.09, hue stride 30° — all slots ≥4.5:1
+contrast on `--bg-0`, all adjacent ΔE ≥ 25. Each slot also exposes
+`-soft`, `-border`, `-ring`, `-glow` companions (4-slot semantics).
+
+Old named tokens (`--k-nick`, `--k-masc`, `--k-sangsu`, `--k-qa`, `--k-rama`)
+were removed in v0.4. New code MUST use `--k-N` (1..12) or, preferably,
+the canonical façade `--color-keeper-N`. Or — best — the `<KeeperBadge>`
+primitive, which resolves slot + sigil from a keeper id automatically.
+
+#### 3.6.2 Mapping — keeper id → slot
+
+`kSlot(id)` (cb-shared.jsx) is canonical. Five anchor IDs are pinned in
+`KEEPER_REGISTRY`; everything else is FNV-1a hashed mod 12. This avoids
+re-mapping when the roster grows.
+
+#### 3.6.3 Attribution rule — color is not enough
+
+Color alone MUST NOT identify a keeper. Every attribution carries a
+**second channel**: a 2-letter sigil (`kSigil(id)`). Concretely:
+
+- ✅ `<KeeperBadge id="...">` — the canonical primitive (sigil + colored name)
+- ✅ Code-gutter sigil column ≥ 22px wide
+- ✅ Activity blocks containing the sigil glyph
+- ❌ Bare colored stripe / dot as the *only* attribution carrier
+- ❌ Stacked >4 raw sigils — collapse to `+N` via `<KeeperStack cap={4}>`
+
+Rationale: a 12-hue ring at C=0.09 cannot remain pairwise distinguishable
+under (a) ≥7 simultaneously-active keepers, (b) deuteranopia/protanopia,
+(c) low-gamut external displays. The sigil is the recovery channel.
+
+#### 3.6.4 Status × keeper non-collision
+
+Keeper hues sit at C=0.09 (muted ring). Status hues use higher chroma
+(C ≥ 0.13) and a different shape vocabulary (pill vs sigil-square). No
+keeper hex coincides with any status hex. Components MUST NOT reuse
+`--color-status-*` tokens for attribution, and vice-versa.
+
+#### 3.6.5 Provider cascade (unchanged)
+
+| Canonical | dashboard raw | 의미 |
+|-----------|---------------|------|
+| `--p-anthropic` | `--p-anthropic` | provider cascade chip |
+| `--p-moonshot`  | `--p-moonshot`  | provider cascade chip |
+| `--p-openai`    | `--p-openai`    | provider cascade chip |
+| `--p-xai`       | `--p-xai`       | provider cascade chip |
+
+bonsai는 현재 keeper attribution을 색이 아닌 텍스트(`@nick0cave` 등)로
+표현 — SPEC v0.3에서도 텍스트-only 가 valid attribution 으로 인정된다
+(sigil 의 degenerate case). bonsai 가 색을 도입할 경우 dashboard
+의 12-slot canonical 을 그대로 참조한다.
 
 ### 3.7 Trace frame (bonsai only — Phase 0)
 
@@ -262,7 +316,6 @@ bonsai의 5 테마는 production user에게 URL hash로 공유 가능한 자산.
 
 | 예외 | 위치 | 사유 |
 |------|------|------|
-| `keeperColor()` 헬퍼 | `dashboard/design-system/preview/cb-group-i.jsx` | 12 keeper persona를 attribution token 5종으로 환원 불가 — hex extension 의도적 |
 | `rgba(... / .NN)` alpha 조합 | 어느 곳이든 | `rgb(var(--token-glow) / .12)` 형태로 raw token alpha 조합은 허용 |
 | 폰트 fallback chain | `--font-*` 정의 내 | system font name (e.g., `Inter`, `JetBrains Mono`) |
 | 4-slot status pattern | `tokens.css`의 `--{ok\|warn\|err\|info\|idle\|stalled}-{soft\|fg\|border\|ring}` | 컴포넌트별 정교한 surface/text/border/ring 4 slot 조합. single-slot semantic alias로 환원 불가. 컴포넌트는 raw 참조 허용 (PR-M5 결정). |
@@ -297,7 +350,7 @@ bonsai의 5 테마는 production user에게 URL hash로 공유 가능한 자산.
 1. **PR #10427** (이미 진행 중): `tokens.css`에 19 semantic alias 등재. 본 SPEC §3.1~3.8과 1:1 일치.
 2. **PR #10437** (이미 진행 중): preview cb-group-a~i에 ARIA 281건 추가. 본 SPEC §5와 1:1 일치.
 3. (후속 plan) `source_styles/components.css` 등 component CSS의 raw token 직접 참조를 Semantic으로 점진 치환.
-4. (후속 plan) `colors_and_type.css` (159줄 별개 파일) 정합화 또는 폐기.
+4. ✅ **완료** `colors_and_type.css` 정합화 — 토큰 정의를 `tokens.css` SSOT로 단일화하고, `.masc-ds` 스코프 element/utility 정의는 `type_layer.css`로 분리. 기존 파일은 두 파일을 `@import`만 하는 façade로 축소(외부 참조 호환).
 
 ### 7.2 dashboard_bonsai/ 마이그레이션 우선순위
 

--- a/dashboard/design-system/colors_and_type.css
+++ b/dashboard/design-system/colors_and_type.css
@@ -1,159 +1,20 @@
 /* ══════════════════════════════════════════════════════════════════
-   MASC COCKPIT — Colors & Type Foundations
+   MASC COCKPIT — Colors & Type (DEPRECATED façade)
    ──────────────────────────────────────────────────────────────────
-   Extracted from styles/tokens.css + primitives.css.
-   Dark Brass aesthetic: warm near-black bg, brass ONLY for active
-   state, muted semantic statuses, mono-first type.
+   This file used to define raw + role tokens AND .masc-ds element
+   defaults. SPEC §7.1.4 collapsed it: tokens.css is now the single
+   source of truth (5 themes, full §3 alias tier, motion, trace
+   frame). Element defaults moved to type_layer.css.
+
+   This façade is kept for backward compat — any existing import
+   continues to resolve. New code should depend on:
+
+     - source_styles/tokens.css   (raw + alias tokens, all themes)
+     - type_layer.css              (.masc-ds element defaults)
+
+   Drift guard: NO token definitions allowed here. If you reach for
+   a `--*: ...;` line in this file, you're regressing the SSOT.
    ══════════════════════════════════════════════════════════════════ */
 
-:root {
-  /* ─────────── FONTS ─────────── */
-  --font-sans: ui-sans-serif, -apple-system, "SF Pro Text", "Inter", system-ui, sans-serif;
-  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
-
-  /* ─────────── SURFACE STACK (4 steps + page) ─────────── */
-  --bg-0: #0c0b08;   /* page bg */
-  --bg-1: #141210;   /* topbar / chrome */
-  --bg-2: #1a1815;   /* panel surface */
-  --bg-3: #211e1a;   /* elevated card */
-  --bg-4: #2a2621;   /* hover / active row */
-
-  /* ─────────── HAIRLINES ─────────── */
-  --line-1: #2a2520;   /* default border */
-  --line-2: #3a332c;   /* emphasized border */
-  --line-3: #4a4137;   /* divider between zones */
-
-  /* ─────────── FOREGROUND (never pure white) ─────────── */
-  --fg-1: #f0e9dc;   /* primary */
-  --fg-2: #b8ad9a;   /* secondary */
-  --fg-3: #7a7065;   /* tertiary / labels */
-  --fg-4: #4a453e;   /* disabled / placeholder */
-
-  /* ─────────── BRASS — the ONE accent ─────────── */
-  --brass-1: #d4a14a;
-  --brass-2: #b8843a;
-  --brass-3: #8a5f28;
-  --brass-glow: 212 161 74;
-
-  /* ─────────── STATUS (muted, never neon) ─────────── */
-  --ok:      #6b9e6b;
-  --warn:    #c9a24a;
-  --err:     #c46a5a;
-  --info:    #6a8eb0;
-  --idle:    #6a6a6a;
-  --stalled: #8a6aa0;
-
-  --ok-fg:     #8ebc8e;
-  --warn-fg:   #d9b764;
-  --err-fg:    #d8806f;
-  --info-fg:   #8aa6c4;
-  --stalled-fg:#a88ac0;
-
-  /* ─────────── KEEPER PALETTE (fleet attribution) ─────────── */
-  --k-nick:    #d4a14a;   /* captain — brass */
-  --k-masc:    #6b9e6b;   /* green */
-  --k-sangsu:  #6a8eb0;   /* blue */
-  --k-qa:      #c46a5a;   /* red */
-  --k-rama:    #8a6aa0;   /* purple */
-
-  /* ─────────── SEMANTIC COLOR ROLES ─────────── */
-  --color-bg:          var(--bg-0);
-  --color-surface:     var(--bg-2);
-  --color-surface-alt: var(--bg-3);
-  --color-border:      var(--line-1);
-  --color-divider:     var(--line-2);
-  --color-accent:      var(--brass-1);
-  --color-text:        var(--fg-1);
-  --color-text-mute:   var(--fg-2);
-  --color-text-dim:    var(--fg-3);
-
-  /* ─────────── TYPE SCALE (raw sizes) ─────────── */
-  --fs-9:  9px;
-  --fs-10: 10px;
-  --fs-11: 11px;
-  --fs-12: 12px;
-  --fs-13: 13px;
-  --fs-14: 14px;
-  --fs-16: 16px;
-  --fs-20: 20px;
-  --fs-28: 28px;
-  --fs-36: 36px;
-
-  --lh-tight: 1.2;
-  --lh-body:  1.45;
-  --lh-loose: 1.6;
-
-  --fw-reg:  400;
-  --fw-med:  500;
-  --fw-semi: 600;
-  --fw-bold: 700;
-
-  --track-tight:  -0.01em;
-  --track-normal:  0;
-  --track-wide:    0.04em;
-  --track-caps:    0.08em;
-
-  /* ─────────── TYPE ROLE TOKENS ─────────── */
-  --type-micro:   var(--fs-9)/var(--lh-tight) var(--font-mono);
-  --type-caption: var(--fs-10)/var(--lh-tight) var(--font-mono);
-  --type-label:   var(--fs-11)/var(--lh-tight) var(--font-sans);
-  --type-meta:    var(--fs-12)/var(--lh-tight) var(--font-mono);
-  --type-body:    var(--fs-13)/var(--lh-body)  var(--font-sans);
-  --type-code:    var(--fs-12)/var(--lh-body)  var(--font-mono);
-  --type-title:   var(--fs-14)/var(--lh-tight) var(--font-sans);
-  --type-kpi-m:   var(--fs-16)/var(--lh-tight) var(--font-mono);
-  --type-kpi-l:   var(--fs-20)/var(--lh-tight) var(--font-mono);
-  --type-hero:    var(--fs-28)/var(--lh-tight) var(--font-mono);
-  --type-display: var(--fs-36)/var(--lh-tight) var(--font-mono);
-
-  /* ─────────── SEMANTIC TYPE (element-level) ─────────── */
-  --h1: 600 var(--type-display);
-  --h2: 600 var(--type-hero);
-  --h3: 600 var(--type-kpi-l);
-  --h4: 600 var(--type-title);
-  --p:  var(--type-body);
-  --code: var(--type-code);
-  --caption: var(--type-caption);
-  --label: 600 var(--type-label);
-}
-
-/* ══════════════════════════════════════════════════════════════════
-   SEMANTIC ELEMENT DEFAULTS
-   Scoped to .masc-ds so this file is safe to import next to existing
-   styles without trampling global element selectors.
-   ══════════════════════════════════════════════════════════════════ */
-
-.masc-ds {
-  color: var(--fg-1);
-  background: var(--bg-0);
-  font: var(--type-body);
-  -webkit-font-smoothing: antialiased;
-  font-feature-settings: "cv08", "ss01";
-}
-.masc-ds code, .masc-ds kbd, .masc-ds samp, .masc-ds pre, .masc-ds .mono {
-  font-family: var(--font-mono);
-}
-
-.masc-ds h1 { font: var(--h1); color: var(--fg-1); letter-spacing: var(--track-tight); font-variant-numeric: tabular-nums; margin: 0; }
-.masc-ds h2 { font: var(--h2); color: var(--fg-1); letter-spacing: var(--track-tight); font-variant-numeric: tabular-nums; margin: 0; }
-.masc-ds h3 { font: var(--h3); color: var(--fg-1); font-variant-numeric: tabular-nums; margin: 0; }
-.masc-ds h4 { font: var(--h4); color: var(--fg-1); letter-spacing: var(--track-tight); margin: 0; }
-.masc-ds p  { font: var(--p); color: var(--fg-1); margin: 0; }
-.masc-ds .label,
-.masc-ds label {
-  font: var(--label); color: var(--fg-3);
-  letter-spacing: var(--track-caps);
-  text-transform: uppercase;
-}
-.masc-ds .caption { font: var(--caption); color: var(--fg-3); letter-spacing: var(--track-wide); }
-.masc-ds .mono    { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
-
-/* color utility classes */
-.masc-ds .t-brass   { color: var(--brass-1); }
-.masc-ds .t-ok      { color: var(--ok-fg); }
-.masc-ds .t-warn    { color: var(--warn-fg); }
-.masc-ds .t-err     { color: var(--err-fg); }
-.masc-ds .t-info    { color: var(--info-fg); }
-.masc-ds .t-stalled { color: var(--stalled-fg); }
-.masc-ds .t-dim     { color: var(--fg-3); }
-.masc-ds .t-mute    { color: var(--fg-4); }
+@import url("source_styles/tokens.css");
+@import url("type_layer.css");

--- a/dashboard/design-system/preview/cb-group-a.jsx
+++ b/dashboard/design-system/preview/cb-group-a.jsx
@@ -152,7 +152,7 @@ function TickerMarquee() {
         <div className="tape">
           {evs.map((e, i) => (
             <span key={i} className={`evt ${e.kind}`} role="listitem" aria-label={`${e.keeper} ${e.kind}: ${e.text}, at ${e.t.slice(0,8)}`}>
-              <Dot kind={kClass(e.keeper)} size="sm" />
+              <KeeperBadge id={e.keeper} variant="sigil" size="sm" />
               <span className="k" aria-hidden="true">{e.keeper}</span>
               <span className="body" aria-hidden="true">{e.text}</span>
               <span className="t" aria-hidden="true">{e.t.slice(0,8)}</span>
@@ -172,7 +172,7 @@ function TickerChunks() {
         <div className="tape">
           {evs.map((e, i) => (
             <span key={i} className={`evt ${e.kind}`} role="listitem" aria-label={`${e.keeper} ${e.kind}: ${e.text.slice(0,40)}`}>
-              <Dot kind={kClass(e.keeper)} size="sm" />
+              <KeeperBadge id={e.keeper} variant="sigil" size="sm" />
               <span className="k" aria-hidden="true">{e.keeper}</span>
               <span className="body" aria-hidden="true">{e.text.slice(0, 40)}</span>
             </span>
@@ -192,7 +192,7 @@ function TickerVertical() {
           {evs.map((e, i) => (
             <span key={i} className={`evt ${e.kind}`} role="listitem" aria-label={`${e.t.slice(0,8)} ${e.keeper} ${e.kind}: ${e.text}`} style={{display:'flex', alignItems:'center', gap:6}}>
               <span className="t" aria-hidden="true">{e.t.slice(0,8)}</span>
-              <Dot kind={kClass(e.keeper)} size="sm" />
+              <KeeperBadge id={e.keeper} variant="sigil" size="sm" />
               <span className="k" aria-hidden="true">{e.keeper}</span>
               <span className="body" aria-hidden="true">{e.text}</span>
             </span>
@@ -299,7 +299,7 @@ function LifelineStacked() {
           <div className="row" key={k.id} role="listitem" aria-label={`${k.id} heartbeat, ${k.status === 'running' ? 'running' : k.status}`}>
             <span className="name" aria-hidden="true">{k.id}</span>
             <Heartbeat width={240} height={14} phase={(phase + i*0.07) % 1} />
-            <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
+            <KeeperBadge id={k.id} variant="sigil" size="sm" beat={k.status==='running'} />
           </div>
         ))}
       </div>

--- a/dashboard/design-system/preview/cb-group-b.jsx
+++ b/dashboard/design-system/preview/cb-group-b.jsx
@@ -26,7 +26,7 @@ function SidebarFleet() {
                onClick={()=>setSel(k.id)}
                onKeyDown={activateOnEnterOrSpace(()=>setSel(k.id))}
                className={`row ${sel===k.id?'sel':''} ${k.status==='idle'?'idle':''}`}>
-            <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
+            <KeeperBadge id={k.id} variant="sigil" size="sm" beat={k.status==='running'} />
             <span className="name" aria-hidden="true">{k.id}</span>
             <span className="meta" aria-hidden="true">{k.task}</span>
           </div>
@@ -70,7 +70,7 @@ function SidebarGrouped() {
                onClick={()=>setSel(k.id)}
                onKeyDown={activateOnEnterOrSpace(()=>setSel(k.id))}
                className={`row ${sel===k.id?'sel':''}`}>
-            <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
+            <KeeperBadge id={k.id} variant="sigil" size="sm" beat={k.status==='running'} />
             <span className="name" aria-hidden="true">{k.id}</span>
             <span className="meta" aria-hidden="true">{k.t || k.task}</span>
           </div>
@@ -106,7 +106,7 @@ function SidebarIcons() {
                onKeyDown={activateOnEnterOrSpace(()=>setSel(k.id))}
                className={`row ${sel===k.id?'sel':''} ${k.status==='idle'?'idle':''}`}>
             <span className="icon" aria-hidden="true">{k.role[0]}</span>
-            <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
+            <KeeperBadge id={k.id} variant="sigil" size="sm" beat={k.status==='running'} />
             <span className="name" aria-hidden="true">{k.id}</span>
             <span className="meta" aria-hidden="true">{k.task}</span>
           </div>
@@ -137,7 +137,7 @@ function SwimlanesGlyph() {
                onKeyDown={activateOnEnterOrSpace(()=>setSel(k.id))}
                className={`lane ${sel===k.id?'sel':''}`}>
             <div className="lane-head">
-              <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
+              <KeeperBadge id={k.id} variant="sigil" size="sm" beat={k.status==='running'} />
               <span className="name" aria-hidden="true">{k.id}</span>
             </div>
             <div className="lane-track" aria-hidden="true">
@@ -166,7 +166,7 @@ function SwimlanesDense() {
         {lanes.map(k => (
           <div key={k.id} role="listitem" aria-label={`${k.id} timeline`} className="lane">
             <div className="lane-head">
-              <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
+              <KeeperBadge id={k.id} variant="sigil" size="sm" beat={k.status==='running'} />
               <span className="name" aria-hidden="true">{k.id}</span>
             </div>
             <div className="lane-track" aria-hidden="true">
@@ -202,7 +202,7 @@ function SwimlanesBars() {
         {lanes.map(k => (
           <div key={k.id} role="listitem" aria-label={`${k.id} aggregated timeline`} className="lane">
             <div className="lane-head">
-              <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
+              <KeeperBadge id={k.id} variant="sigil" size="sm" beat={k.status==='running'} />
               <span className="name" aria-hidden="true">{k.id}</span>
             </div>
             <div className="lane-track" aria-hidden="true">
@@ -264,7 +264,7 @@ function DeckTasks() {
                   onKeyDown={activateOnEnterOrSpace(()=>setSel(t.id))}>
                 <td>{t.id}</td>
                 <td className="title">{t.title}</td>
-                <td><Dot kind={kClass(t.keeper)} size="sm" /> {t.keeper}</td>
+                <td><KeeperBadge id={t.keeper} variant="full" size="sm" /></td>
                 <td>{t.goal}</td>
                 <td><Pill kind={t.status==='running'?'running':t.status==='fail'?'err':t.status==='stalled'?'stalled':t.status==='pending'?'info':'paused'}>{t.status}</Pill></td>
                 <td>{t.t}</td>
@@ -300,7 +300,7 @@ function DeckKanban() {
                   <span className="id" aria-hidden="true">{t.id}</span>
                   <span className="title" aria-hidden="true">{t.title}</span>
                   <span className="foot" aria-hidden="true">
-                    <Dot kind={kClass(t.keeper)} size="sm" /> {t.keeper} · {t.t}
+                    <KeeperBadge id={t.keeper} variant="full" size="sm" /> · {t.t}
                   </span>
                 </div>
               ))}
@@ -354,7 +354,7 @@ function RailActivity() {
                  aria-label={`${e.t.slice(0,8)} · ${e.keeper} ${e.kind}: ${e.text}`}
                  className={`ev ${e.kind}`}>
               <span className="t" aria-hidden="true">{e.t.slice(0,8)}</span>
-              <span className="icon" aria-hidden="true"><Dot kind={kClass(e.keeper)} size="sm" /></span>
+              <span className="icon" aria-hidden="true"><KeeperBadge id={e.keeper} variant="sigil" size="sm" /></span>
               <span className="body" aria-hidden="true">
                 <span className="who">{e.keeper}</span>
                 <span className="text">{e.text}</span>
@@ -397,7 +397,7 @@ function RailCascade() {
                  aria-label={`${e.t.slice(0,8)} · ${e.keeper} ${e.kind}: ${e.text}`}
                  className={`ev ${e.kind}`}>
               <span className="t" aria-hidden="true">{e.t.slice(0,8)}</span>
-              <span className="icon" aria-hidden="true"><Dot kind={kClass(e.keeper)} size="sm" /></span>
+              <span className="icon" aria-hidden="true"><KeeperBadge id={e.keeper} variant="sigil" size="sm" /></span>
               <span className="body" aria-hidden="true">
                 <span className="who">{e.keeper}</span>
                 <span className="text">{e.text}</span>

--- a/dashboard/design-system/preview/cb-group-c.jsx
+++ b/dashboard/design-system/preview/cb-group-c.jsx
@@ -275,7 +275,7 @@ function DrawerGoal() {
                    role="listitem"
                    aria-label={`${t.id} · ${t.title} · ${t.keeper} · ${t.status}`}
                    style={{display:'flex', alignItems:'center', gap:7, padding:'4px 7px', background:'var(--color-bg-surface)', border:'1px solid var(--color-border-default)', borderRadius:3, fontSize:11}}>
-                <Dot kind={kClass(t.keeper)} size="sm" />
+                <KeeperBadge id={t.keeper} variant="sigil" size="sm" />
                 <span className="cb-mono" aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>{t.id}</span>
                 <span aria-hidden="true" style={{color:'var(--color-fg-primary)', flex:1}}>{t.title}</span>
                 <Pill kind={t.status==='running'?'running':t.status==='fail'?'err':t.status==='stalled'?'stalled':'paused'}>{t.status}</Pill>

--- a/dashboard/design-system/preview/cb-group-d.jsx
+++ b/dashboard/design-system/preview/cb-group-d.jsx
@@ -326,7 +326,7 @@ function TaskWall() {
                    className={`kpr ${ts.length === 0 ? 'empty' : ''}`}
                    aria-label={`${k} · ${ts.length} task${ts.length === 1 ? '' : 's'}${ts.some(t=>t.status==='running') ? ' · running' : ''}`}>
                 <div className="h" aria-hidden="true">
-                  <Dot kind={kClass(k)} size="sm" beat={ts.some(t=>t.status==='running')} />
+                  <KeeperBadge id={k} variant="sigil" size="sm" beat={ts.some(t=>t.status==='running')} />
                   <span className="nm">{k}</span>
                   <span className="cn">{ts.length}</span>
                 </div>

--- a/dashboard/design-system/preview/cb-group-g.html
+++ b/dashboard/design-system/preview/cb-group-g.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="en" data-theme="dark-fantasy">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>cb-group-g · Foundational primitives</title>
+  <link rel="stylesheet" href="../source_styles/tokens.css" />
+  <link rel="stylesheet" href="../type_layer.css" />
+  <link rel="stylesheet" href="_preview.css" />
+  <style>
+    .pv-cell { padding: 18px; gap: 14px; }
+    .pv-cell-label { font: 600 var(--type-label); letter-spacing: var(--track-caps); text-transform: uppercase; color: var(--color-fg-muted); }
+    .pv-cell-id    { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: var(--track-caps); text-transform: uppercase; }
+    .pv-grid-2 { gap: 14px; }
+  </style>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body class="masc-ds">
+  <main class="pv-root">
+    <header class="pv-head">
+      <div class="pv-eyebrow">cb-group-g · foundational primitives</div>
+      <h1 class="pv-title">Empty · Loading · Error · Pagination · Breadcrumb</h1>
+      <p class="pv-sub">
+        Cross-cutting primitives every cockpit surface needs but were not bundled
+        in cb-group-a..f / h..k. Each variant is self-contained — no
+        <code class="mono">MASC_DATA</code> dependency — and follows SPEC §5
+        a11y patterns: empty/loading announce via <code class="mono">role="status"</code>,
+        errors via <code class="mono">role="alert"</code>, pagination uses a
+        labelled <code class="mono">&lt;nav&gt;</code>, breadcrumb is an
+        <code class="mono">&lt;ol&gt;</code> with <code class="mono">aria-current="page"</code>.
+      </p>
+    </header>
+
+    <!-- G1 EMPTY -->
+    <section class="pv-sect" aria-labelledby="g1-h">
+      <div class="pv-sect-h">
+        <h2 id="g1-h">G1 · Empty state</h2>
+        <span class="sub">role="status" · aria-live="polite"</span>
+      </div>
+      <div class="pv-grid-2">
+        <div class="pv-cell">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">no-data</span>
+            <span class="pv-cell-id">cb-g1-a</span>
+          </div>
+          <div id="m-g1a"></div>
+        </div>
+        <div class="pv-cell">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">search · no results</span>
+            <span class="pv-cell-id">cb-g1-b</span>
+          </div>
+          <div id="m-g1b"></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- G2 LOADING -->
+    <section class="pv-sect" aria-labelledby="g2-h">
+      <div class="pv-sect-h">
+        <h2 id="g2-h">G2 · Loading skeleton</h2>
+        <span class="sub">aria-busy="true" · role="status"</span>
+      </div>
+      <div class="pv-grid-2">
+        <div class="pv-cell">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">rows</span>
+            <span class="pv-cell-id">cb-g2-a</span>
+          </div>
+          <div id="m-g2a"></div>
+        </div>
+        <div class="pv-cell">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">kpi strip</span>
+            <span class="pv-cell-id">cb-g2-b</span>
+          </div>
+          <div id="m-g2b"></div>
+        </div>
+        <div class="pv-cell" style="grid-column: span 2;">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">panel</span>
+            <span class="pv-cell-id">cb-g2-c</span>
+          </div>
+          <div id="m-g2c"></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- G3 ERROR -->
+    <section class="pv-sect" aria-labelledby="g3-h">
+      <div class="pv-sect-h">
+        <h2 id="g3-h">G3 · Error boundary</h2>
+        <span class="sub">role="alert" · 1px ring · soft tinted bg</span>
+      </div>
+      <div class="pv-grid-2">
+        <div class="pv-cell">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">recoverable</span>
+            <span class="pv-cell-id">cb-g3-a</span>
+          </div>
+          <div id="m-g3a"></div>
+        </div>
+        <div class="pv-cell">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">fatal</span>
+            <span class="pv-cell-id">cb-g3-b</span>
+          </div>
+          <div id="m-g3b"></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- G4 PAGINATION -->
+    <section class="pv-sect" aria-labelledby="g4-h">
+      <div class="pv-sect-h">
+        <h2 id="g4-h">G4 · Pagination</h2>
+        <span class="sub">nav[aria-label] · aria-current="page" · aria-disabled boundary</span>
+      </div>
+      <div class="pv-grid-2">
+        <div class="pv-cell">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">numeric</span>
+            <span class="pv-cell-id">cb-g4-a</span>
+          </div>
+          <div id="m-g4a"></div>
+        </div>
+        <div class="pv-cell">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">cursor</span>
+            <span class="pv-cell-id">cb-g4-b</span>
+          </div>
+          <div id="m-g4b"></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- G5 BREADCRUMB -->
+    <section class="pv-sect" aria-labelledby="g5-h">
+      <div class="pv-sect-h">
+        <h2 id="g5-h">G5 · Breadcrumb</h2>
+        <span class="sub">nav + ol · aria-current="page" on tail · separator aria-hidden</span>
+      </div>
+      <div class="pv-grid-2">
+        <div class="pv-cell">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">path</span>
+            <span class="pv-cell-id">cb-g5-a</span>
+          </div>
+          <div id="m-g5a"></div>
+        </div>
+        <div class="pv-cell">
+          <div class="pv-cell-h">
+            <span class="pv-cell-label">with overflow (≥ 5 levels)</span>
+            <span class="pv-cell-id">cb-g5-b</span>
+          </div>
+          <div id="m-g5b"></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script type="text/babel" src="cb-group-g.jsx"></script>
+  <script type="text/babel">
+    const r = (id, el) => ReactDOM.createRoot(document.getElementById(id)).render(el);
+    r('m-g1a', <EmptyNoData action="Probe lane" />);
+    r('m-g1b', <EmptySearchNoResults query="grpc.timeout" />);
+    r('m-g2a', <SkeletonRows rows={5} />);
+    r('m-g2b', <SkeletonKpi count={4} />);
+    r('m-g2c', <SkeletonPanel height={140} />);
+    r('m-g3a', <ErrorRecoverable />);
+    r('m-g3b', <ErrorFatal />);
+    r('m-g4a', <PaginationNumeric total={18} initial={4} />);
+    r('m-g4b', <PaginationCursor />);
+    r('m-g5a', <BreadcrumbPath />);
+    r('m-g5b', <BreadcrumbWithOverflow />);
+  </script>
+</body>
+</html>

--- a/dashboard/design-system/preview/cb-group-g.jsx
+++ b/dashboard/design-system/preview/cb-group-g.jsx
@@ -1,0 +1,543 @@
+// cb-group-g.jsx — Foundational primitives missing from inventory:
+//   G1 · Empty state            (no-data, search-no-results)
+//   G2 · Loading skeleton       (rows, panel, kpi)
+//   G3 · Error boundary banner  (recoverable, fatal)
+//   G4 · Pagination             (numeric, cursor)
+//   G5 · Breadcrumb             (path, with-overflow)
+//
+// All variants are self-contained — no MASC_DATA dependency. Demo data
+// is inlined so cb-group-g.html (preview only) renders standalone.
+// SPEC §5 a11y patterns: empty=role=status, loading=aria-busy+role=status,
+// error=role=alert, pagination=nav[aria-label], breadcrumb=nav+ol.
+
+const { useState, useMemo } = React;
+
+// ═════════════════════════════════════════════════════════════════
+// G1 · EMPTY STATE
+// ═════════════════════════════════════════════════════════════════
+//
+// Use when a section has no data to show. NOT for errors (use G3) and
+// NOT for loading (use G2). The element gets role="status" so SR users
+// hear the message; visual glyph is decorative.
+
+const G_EMPTY_PANEL = {
+  display: 'flex', flexDirection: 'column', alignItems: 'center',
+  justifyContent: 'center', gap: '10px',
+  padding: '40px 24px',
+  background: 'var(--color-bg-surface)',
+  border: '1px dashed var(--color-border-strong)',
+  borderRadius: '3px',
+  color: 'var(--color-fg-muted)',
+  fontFamily: 'var(--font-mono)',
+  textAlign: 'center',
+};
+
+function EmptyNoData({
+  title = 'No swimlane events yet',
+  hint = 'Keepers will populate this lane once branch activity begins.',
+  action,
+}) {
+  return (
+    <section role="status" aria-live="polite" style={G_EMPTY_PANEL}>
+      <span aria-hidden="true" style={{
+        fontSize: '24px', lineHeight: 1, color: 'var(--color-fg-disabled)',
+        letterSpacing: '.15em',
+      }}>· · ·</span>
+      <span style={{
+        fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-13)',
+        color: 'var(--color-fg-secondary)', letterSpacing: '-.005em',
+      }}>{title}</span>
+      <span style={{
+        fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)',
+        maxWidth: '36ch',
+      }}>{hint}</span>
+      {action && (
+        <button type="button" style={{
+          marginTop: '6px',
+          padding: '4px 12px',
+          background: 'transparent',
+          color: 'var(--color-accent-fg)',
+          border: '1px solid var(--color-accent-fg-dim)',
+          fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-11)',
+          letterSpacing: 'var(--track-caps)', textTransform: 'uppercase',
+          cursor: 'pointer',
+        }}>{action}</button>
+      )}
+    </section>
+  );
+}
+
+// Variant: search-no-results — same skeleton, different copy + glyph.
+// Carries the query so SR users hear what was searched.
+function EmptySearchNoResults({ query = 'lifeline' }) {
+  return (
+    <section role="status" aria-live="polite"
+             aria-label={`No matches for ${query}`} style={G_EMPTY_PANEL}>
+      <span aria-hidden="true" style={{
+        fontSize: '20px', color: 'var(--color-fg-disabled)',
+        fontFamily: 'var(--font-mono)',
+      }}>⌕ ∅</span>
+      <span style={{
+        fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-13)',
+        color: 'var(--color-fg-secondary)',
+      }}>
+        no matches for <span style={{color: 'var(--color-accent-fg)'}}>"{query}"</span>
+      </span>
+      <span style={{fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)'}}>
+        Try a different keeper, branch, or tool name.
+      </span>
+    </section>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════
+// G2 · LOADING SKELETON
+// ═════════════════════════════════════════════════════════════════
+//
+// Skeletons set aria-busy="true" + role="status" with an aria-label
+// announcing what's loading. The shimmer bars themselves are
+// aria-hidden (they're a visual placeholder, not data).
+
+const G_SHIMMER_KEY = '@keyframes cbg-shimmer { 0% { background-position: -200px 0; } 100% { background-position: 200px 0; } }';
+const G_SHIMMER_BG = `linear-gradient(90deg, var(--color-bg-surface) 0%, var(--color-bg-panel-alt) 50%, var(--color-bg-surface) 100%)`;
+const G_SHIMMER_STYLE = {
+  background: G_SHIMMER_BG,
+  backgroundSize: '400px 100%',
+  animation: 'cbg-shimmer 1.4s ease-in-out infinite',
+};
+
+function SkeletonRows({ rows = 5, label = 'Loading swimlane rows' }) {
+  return (
+    <section role="status" aria-busy="true" aria-label={label}
+             style={{
+               display: 'flex', flexDirection: 'column', gap: '6px',
+               padding: '14px',
+               background: 'var(--color-bg-surface)',
+               border: '1px solid var(--color-border-default)',
+               borderRadius: '3px',
+             }}>
+      <style>{G_SHIMMER_KEY}</style>
+      {Array.from({length: rows}).map((_, i) => (
+        <div key={i} aria-hidden="true" style={{
+          display: 'flex', alignItems: 'center', gap: '10px',
+          height: '22px',
+        }}>
+          <span style={{
+            ...G_SHIMMER_STYLE,
+            width: '8px', height: '8px', borderRadius: '50%',
+          }}/>
+          <span style={{
+            ...G_SHIMMER_STYLE,
+            width: `${30 + (i*7) % 35}%`, height: '10px',
+          }}/>
+          <span style={{
+            ...G_SHIMMER_STYLE,
+            width: `${15 + (i*5) % 20}%`, height: '10px',
+            marginLeft: 'auto',
+          }}/>
+        </div>
+      ))}
+      <span style={{position: 'absolute', left: '-9999px'}}>{label}…</span>
+    </section>
+  );
+}
+
+function SkeletonKpi({ count = 4 }) {
+  return (
+    <section role="status" aria-busy="true" aria-label="Loading KPI strip"
+             style={{
+               display: 'grid', gridTemplateColumns: `repeat(${count}, 1fr)`,
+               gap: '10px',
+             }}>
+      <style>{G_SHIMMER_KEY}</style>
+      {Array.from({length: count}).map((_, i) => (
+        <div key={i} aria-hidden="true" style={{
+          padding: '12px 14px',
+          background: 'var(--color-bg-surface)',
+          border: '1px solid var(--color-border-default)',
+          borderRadius: '3px',
+          display: 'flex', flexDirection: 'column', gap: '8px',
+        }}>
+          <span style={{...G_SHIMMER_STYLE, width: '40%', height: '8px'}}/>
+          <span style={{...G_SHIMMER_STYLE, width: '70%', height: '20px'}}/>
+          <span style={{...G_SHIMMER_STYLE, width: '50%', height: '6px'}}/>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function SkeletonPanel({ height = 180 }) {
+  return (
+    <section role="status" aria-busy="true" aria-label="Loading panel"
+             style={{
+               position: 'relative', height: `${height}px`,
+               background: 'var(--color-bg-surface)',
+               border: '1px solid var(--color-border-default)',
+               borderRadius: '3px',
+               overflow: 'hidden',
+             }}>
+      <style>{G_SHIMMER_KEY}</style>
+      <div aria-hidden="true" style={{
+        position: 'absolute', inset: 0, ...G_SHIMMER_STYLE,
+      }}/>
+      <div aria-hidden="true" style={{
+        position: 'absolute', left: '14px', top: '14px',
+        display: 'flex', flexDirection: 'column', gap: '8px',
+      }}>
+        <span style={{
+          width: '80px', height: '8px',
+          background: 'var(--color-border-strong)',
+        }}/>
+        <span style={{
+          width: '140px', height: '14px',
+          background: 'var(--color-border-strong)',
+        }}/>
+      </div>
+    </section>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════
+// G3 · ERROR BOUNDARY BANNER
+// ═════════════════════════════════════════════════════════════════
+//
+// Two surface kinds:
+//   - Recoverable: role=alert + soft tone + retry action
+//   - Fatal:       role=alert + err tone + reload action
+//
+// Inline tone (1px ring + soft tinted bg) — never neon.
+
+function ErrorRecoverable({
+  title = 'Cascade failed at provider · openai',
+  detail = 'The request bounced through 2 fallback providers and timed out at 12.4s.',
+  onRetry,
+}) {
+  return (
+    <section role="alert" aria-labelledby="g3a-title" style={{
+      display: 'flex', flexDirection: 'column', gap: '8px',
+      padding: '12px 14px',
+      background: 'var(--color-status-warn-soft, rgb(201 162 74 / .12))',
+      border: '1px solid var(--color-status-warn-border, rgb(201 162 74 / .35))',
+      borderLeft: '3px solid var(--color-status-warn-fg, #d9b764)',
+      borderRadius: '3px',
+      fontFamily: 'var(--font-mono)',
+    }}>
+      <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+        <span aria-hidden="true" style={{
+          color: 'var(--color-status-warn-fg, #d9b764)',
+          fontSize: 'var(--fs-13)', fontWeight: 600,
+        }}>⚠</span>
+        <span id="g3a-title" style={{
+          fontSize: 'var(--fs-12)',
+          color: 'var(--color-status-warn-fg, #d9b764)',
+          letterSpacing: 'var(--track-caps)', textTransform: 'uppercase',
+          fontWeight: 600,
+        }}>recoverable · cascade fallback</span>
+        <button type="button" onClick={onRetry} style={{
+          marginLeft: 'auto',
+          padding: '3px 10px',
+          background: 'transparent',
+          color: 'var(--color-status-warn-fg, #d9b764)',
+          border: '1px solid var(--color-status-warn-border, rgb(201 162 74 / .35))',
+          fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-10)',
+          letterSpacing: 'var(--track-caps)', textTransform: 'uppercase',
+          cursor: 'pointer',
+        }}>↻ retry</button>
+      </div>
+      <div style={{
+        fontSize: 'var(--fs-12)', color: 'var(--color-fg-primary)',
+      }}>{title}</div>
+      <div style={{
+        fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)',
+      }}>{detail}</div>
+    </section>
+  );
+}
+
+function ErrorFatal({
+  title = 'Cockpit lost connection',
+  detail = 'WebSocket closed at 14:32:18Z. Reconnect attempts: 3/3 exhausted.',
+  onReload,
+}) {
+  return (
+    <section role="alert" aria-labelledby="g3b-title" style={{
+      display: 'flex', flexDirection: 'column', gap: '8px',
+      padding: '12px 14px',
+      background: 'var(--color-status-err-soft, rgb(196 106 90 / .12))',
+      border: '1px solid var(--color-status-err-border, rgb(196 106 90 / .4))',
+      borderLeft: '3px solid var(--color-status-err-fg, #d8806f)',
+      borderRadius: '3px',
+      fontFamily: 'var(--font-mono)',
+    }}>
+      <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+        <span aria-hidden="true" style={{
+          color: 'var(--color-status-err-fg, #d8806f)',
+          fontSize: 'var(--fs-13)', fontWeight: 600,
+        }}>✕</span>
+        <span id="g3b-title" style={{
+          fontSize: 'var(--fs-12)',
+          color: 'var(--color-status-err-fg, #d8806f)',
+          letterSpacing: 'var(--track-caps)', textTransform: 'uppercase',
+          fontWeight: 600,
+        }}>fatal · session lost</span>
+        <button type="button" onClick={onReload} style={{
+          marginLeft: 'auto',
+          padding: '3px 10px',
+          background: 'var(--color-status-err-fg, #d8806f)',
+          color: 'var(--color-bg-page)',
+          border: '1px solid var(--color-status-err-fg, #d8806f)',
+          fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-10)',
+          letterSpacing: 'var(--track-caps)', textTransform: 'uppercase',
+          cursor: 'pointer', fontWeight: 600,
+        }}>⟳ reload session</button>
+      </div>
+      <div style={{
+        fontSize: 'var(--fs-12)', color: 'var(--color-fg-primary)',
+      }}>{title}</div>
+      <div style={{
+        fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)',
+      }}>{detail}</div>
+    </section>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════
+// G4 · PAGINATION
+// ═════════════════════════════════════════════════════════════════
+//
+// Numeric: nav[aria-label] + role=list of buttons, current uses
+// aria-current="page". Cursor: prev/next anchors with aria-disabled
+// when at boundary.
+
+function PaginationNumeric({ total = 18, initial = 4 }) {
+  const [page, setPage] = useState(initial);
+  // Compute window: always show first, last, current ±1, ellipses for gaps
+  const pages = useMemo(() => {
+    const out = [];
+    const push = (v) => out.push(v);
+    push(1);
+    if (page > 3) push('…');
+    for (let p = Math.max(2, page-1); p <= Math.min(total-1, page+1); p++) push(p);
+    if (page < total-2) push('…');
+    if (total > 1) push(total);
+    return out;
+  }, [page, total]);
+
+  const btn = (active, disabled) => ({
+    minWidth: '28px', height: '24px', padding: '0 8px',
+    background: active
+      ? 'var(--color-accent-fg)'
+      : 'var(--color-bg-surface)',
+    color: active
+      ? 'var(--color-bg-page)'
+      : disabled
+        ? 'var(--color-fg-disabled)'
+        : 'var(--color-fg-secondary)',
+    border: `1px solid ${active
+      ? 'var(--color-accent-fg)'
+      : 'var(--color-border-default)'}`,
+    fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-11)',
+    fontWeight: active ? 600 : 400,
+    cursor: disabled ? 'default' : 'pointer',
+    fontVariantNumeric: 'tabular-nums',
+  });
+
+  return (
+    <nav aria-label="Pagination" style={{
+      display: 'flex', alignItems: 'center', gap: '4px',
+    }}>
+      <button type="button"
+              aria-label="Previous page"
+              disabled={page === 1}
+              onClick={() => setPage(p => Math.max(1, p-1))}
+              style={btn(false, page === 1)}>←</button>
+      {pages.map((p, i) => p === '…' ? (
+        <span key={`g${i}`} aria-hidden="true" style={{
+          color: 'var(--color-fg-disabled)', fontFamily: 'var(--font-mono)',
+          fontSize: 'var(--fs-11)', padding: '0 4px',
+        }}>…</span>
+      ) : (
+        <button key={p} type="button"
+                aria-label={`Page ${p}${p === page ? ', current' : ''}`}
+                aria-current={p === page ? 'page' : undefined}
+                onClick={() => setPage(p)}
+                style={btn(p === page, false)}>{p}</button>
+      ))}
+      <button type="button"
+              aria-label="Next page"
+              disabled={page === total}
+              onClick={() => setPage(p => Math.min(total, p+1))}
+              style={btn(false, page === total)}>→</button>
+      <span aria-hidden="true" style={{
+        marginLeft: '12px',
+        fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-10)',
+        color: 'var(--color-fg-muted)', letterSpacing: 'var(--track-wide)',
+      }}>page {page} / {total}</span>
+    </nav>
+  );
+}
+
+function PaginationCursor({
+  cursor = 'evt-2604-a3f9',
+  hasPrev = true,
+  hasNext = true,
+}) {
+  return (
+    <nav aria-label="Cursor pagination" style={{
+      display: 'flex', alignItems: 'center', gap: '8px',
+      padding: '8px 12px',
+      background: 'var(--color-bg-surface)',
+      border: '1px solid var(--color-border-default)',
+      borderRadius: '3px',
+      fontFamily: 'var(--font-mono)',
+    }}>
+      <button type="button"
+              aria-label="Previous batch"
+              aria-disabled={!hasPrev}
+              disabled={!hasPrev}
+              style={{
+                padding: '3px 10px',
+                background: 'transparent',
+                color: hasPrev ? 'var(--color-fg-secondary)' : 'var(--color-fg-disabled)',
+                border: '1px solid var(--color-border-default)',
+                fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-11)',
+                cursor: hasPrev ? 'pointer' : 'default',
+                letterSpacing: 'var(--track-caps)', textTransform: 'uppercase',
+              }}>← older</button>
+      <span style={{
+        flex: 1, textAlign: 'center',
+        fontSize: 'var(--fs-10)', color: 'var(--color-fg-muted)',
+        letterSpacing: 'var(--track-wide)',
+      }}>
+        cursor · <span style={{color: 'var(--color-accent-fg)'}}>{cursor}</span>
+      </span>
+      <button type="button"
+              aria-label="Next batch"
+              aria-disabled={!hasNext}
+              disabled={!hasNext}
+              style={{
+                padding: '3px 10px',
+                background: 'transparent',
+                color: hasNext ? 'var(--color-fg-secondary)' : 'var(--color-fg-disabled)',
+                border: '1px solid var(--color-border-default)',
+                fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-11)',
+                cursor: hasNext ? 'pointer' : 'default',
+                letterSpacing: 'var(--track-caps)', textTransform: 'uppercase',
+              }}>newer →</button>
+    </nav>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════
+// G5 · BREADCRUMB
+// ═════════════════════════════════════════════════════════════════
+//
+// nav[aria-label="Breadcrumb"] + ol > li. Last item carries
+// aria-current="page". Separator is decorative (aria-hidden).
+// The "with overflow" variant collapses middle segments behind a
+// menu trigger when path > 3 levels.
+
+const G_CRUMB_LI = {
+  display: 'inline-flex', alignItems: 'center', gap: '6px',
+};
+const G_CRUMB_LINK = {
+  color: 'var(--color-fg-muted)', textDecoration: 'none',
+  padding: '2px 4px', borderRadius: '2px',
+  fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-11)',
+};
+const G_CRUMB_SEP = {
+  color: 'var(--color-fg-disabled)', fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--fs-11)',
+};
+
+function BreadcrumbPath({
+  path = ['cockpit', 'branch · main', 'keeper · sangsu', 'lifeline'],
+}) {
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol style={{
+        listStyle: 'none', display: 'flex', alignItems: 'center',
+        gap: '6px', padding: 0, margin: 0,
+      }}>
+        {path.map((seg, i) => {
+          const last = i === path.length - 1;
+          return (
+            <li key={i} style={G_CRUMB_LI}>
+              {last ? (
+                <span aria-current="page" style={{
+                  ...G_CRUMB_LINK,
+                  color: 'var(--color-accent-fg)',
+                  fontWeight: 600,
+                }}>{seg}</span>
+              ) : (
+                <a href="#" style={G_CRUMB_LINK}>{seg}</a>
+              )}
+              {!last && <span aria-hidden="true" style={G_CRUMB_SEP}>›</span>}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+function BreadcrumbWithOverflow({
+  path = ['cockpit', 'branch · main', 'keeper · sangsu', 'tool · grpc.call', 'frame · 47', 'lifeline'],
+}) {
+  const [expanded, setExpanded] = useState(false);
+  // Always show first + last; middle collapses unless expanded.
+  const showAll = expanded || path.length <= 4;
+  const head = path[0];
+  const tail = path[path.length - 1];
+  const middle = path.slice(1, -1);
+
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol style={{
+        listStyle: 'none', display: 'flex', alignItems: 'center',
+        gap: '6px', padding: 0, margin: 0,
+      }}>
+        <li style={G_CRUMB_LI}>
+          <a href="#" style={G_CRUMB_LINK}>{head}</a>
+          <span aria-hidden="true" style={G_CRUMB_SEP}>›</span>
+        </li>
+        {showAll ? middle.map((seg, i) => (
+          <li key={i} style={G_CRUMB_LI}>
+            <a href="#" style={G_CRUMB_LINK}>{seg}</a>
+            <span aria-hidden="true" style={G_CRUMB_SEP}>›</span>
+          </li>
+        )) : (
+          <li style={G_CRUMB_LI}>
+            <button type="button"
+                    aria-label={`Show ${middle.length} hidden levels`}
+                    aria-expanded={expanded}
+                    onClick={() => setExpanded(true)}
+                    style={{
+                      ...G_CRUMB_LINK,
+                      background: 'var(--color-bg-surface)',
+                      border: '1px solid var(--color-border-default)',
+                      cursor: 'pointer',
+                    }}>… <span aria-hidden="true">+{middle.length}</span></button>
+            <span aria-hidden="true" style={G_CRUMB_SEP}>›</span>
+          </li>
+        )}
+        <li style={G_CRUMB_LI}>
+          <span aria-current="page" style={{
+            ...G_CRUMB_LINK,
+            color: 'var(--color-accent-fg)',
+            fontWeight: 600,
+          }}>{tail}</span>
+        </li>
+      </ol>
+    </nav>
+  );
+}
+
+Object.assign(window, {
+  EmptyNoData, EmptySearchNoResults,
+  SkeletonRows, SkeletonKpi, SkeletonPanel,
+  ErrorRecoverable, ErrorFatal,
+  PaginationNumeric, PaginationCursor,
+  BreadcrumbPath, BreadcrumbWithOverflow,
+});

--- a/dashboard/design-system/preview/cb-group-h.jsx
+++ b/dashboard/design-system/preview/cb-group-h.jsx
@@ -16,7 +16,7 @@ function KeeperTabs({ keepers, sel, onSelect, label }) {
                 aria-label={`Keeper ${kp.id}`}
                 className={sel === kp.id ? 'on' : ''}
                 onClick={() => onSelect(kp.id)}>
-          <Dot kind={kClass(kp.id)} size="sm" /> <span aria-hidden="true">{kp.id}</span>
+          <KeeperBadge id={kp.id} variant="sigil" size="sm" /> <span aria-hidden="true">{kp.id}</span>
         </button>
       ))}
     </div>
@@ -32,7 +32,7 @@ function KeeperBDIPanel() {
       <KeeperTabs keepers={P2h.keepersFull} sel={sel} onSelect={setSel} label="Select keeper for BDI panel" />
       <div role="tabpanel" aria-label={`BDI panel for ${k.id}`}>
         <div role="region" aria-label={`${k.id} · ${k.role} · social model ${k.social_model}`} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',display:'flex',alignItems:'center',gap:'8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>
-          <Dot kind={kClass(k.id)} beat />
+          <KeeperBadge id={k.id} variant="sigil" beat />
           <span aria-hidden="true" style={{color:'var(--color-accent-fg)'}}>{k.id}</span>
           <span aria-hidden="true">·</span>
           <span aria-hidden="true">{k.role}</span>
@@ -110,7 +110,7 @@ function KeeperTokenStats() {
         <tbody>
           {[...keepers].sort((a,b) => b.tokens.in - a.tokens.in).map(k => (
             <tr key={k.id} className="row">
-              <th scope="row" className="ag"><Dot kind={kClass(k.id)} size="sm" /> <span aria-hidden="true">{k.id}</span></th>
+              <th scope="row" className="ag"><KeeperBadge id={k.id} variant="sigil" size="sm" /> <span aria-hidden="true">{k.id}</span></th>
               <td className="num">{(k.tokens.in/1000).toFixed(0)}k</td>
               <td className="num">{(k.tokens.out/1000).toFixed(1)}k</td>
               <td className="bar" aria-hidden="true"><i style={{width:`${k.tokens.in/maxIn*100}%`}} /></td>

--- a/dashboard/design-system/preview/cb-group-i.jsx
+++ b/dashboard/design-system/preview/cb-group-i.jsx
@@ -7,31 +7,6 @@
 
 const P2i = window.MASC_P2;
 
-// keeper color helper (uses kClass from cb-shared)
-function keeperColor(id) {
-  return ({
-    'nick0cave':     'var(--color-accent-fg)',
-    'masc-improver': 'var(--color-status-ok)',
-    'sangsu':        'var(--color-status-info)',
-    'qa-king':       'var(--color-status-err)',
-    'rama':          'var(--color-status-stalled)',
-    'ramarama':      'var(--color-status-stalled)',
-    'scholar':       '#9aa6b8',
-    'janitor':       '#7a8290',
-    'taskmaster':    'var(--color-accent-fg-dim)',
-    'velvet-hammer': '#c97070',
-    'verdict':       '#b89070',
-    'sojin':         '#8aa890',
-    'verifier':      '#6a8a9a',
-    'executor':      '#a08070',
-    'adversary':     '#a06060',
-    'issue_king':    '#b08840',
-    'codex-mcp-client': '#6a7080',
-    'ollama-local':  '#7a9080',
-    'scholar2':      '#9aa6b8',
-  })[id] || 'var(--color-status-idle)';
-}
-
 // ═════════════════════════════════════════════════════════════════
 // I0-A · BRANCH SELECTOR
 // ═════════════════════════════════════════════════════════════════
@@ -100,9 +75,8 @@ function BranchSelector() {
       <div role="list" aria-label={`Active branch keepers · ${cur.keepers.length}`} style={{padding:'5px 10px',background:'var(--color-bg-surface)',border:'1px solid var(--color-border-default)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)',display:'flex',gap:'8px',alignItems:'center'}}>
         <span aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>active branch keepers ·</span>
         {cur.keepers.map(k => (
-          <span key={k} role="listitem" aria-label={k} style={{display:'inline-flex',alignItems:'center',gap:'4px'}}>
-            <span aria-hidden="true" style={{display:'inline-block',width:'8px',height:'8px',borderRadius:'50%',background:keeperColor(k)}}/>
-            <span aria-hidden="true" style={{color:'var(--color-accent-fg)'}}>{k}</span>
+          <span key={k} role="listitem" aria-label={k}>
+            <KeeperBadge id={k} size="sm" />
           </span>
         ))}
       </div>
@@ -141,7 +115,7 @@ function KeeperMultiSelect() {
                     aria-label={k.id}
                     onClick={() => toggle(k.id)}
                     className={`km-chip ${on ? 'on' : ''}`}>
-              <span aria-hidden="true" style={{display:'inline-block',width:'7px',height:'7px',borderRadius:'50%',background:keeperColor(k.id)}}/>
+              <KeeperBadge id={k.id} size="sm" variant="sigil" />
               <span aria-hidden="true">{k.id}</span>
               <span className="role" aria-hidden="true">· {k.role}</span>
               <span className="x" aria-hidden="true">{on ? '×' : '+'}</span>

--- a/dashboard/design-system/preview/cb-root.jsx
+++ b/dashboard/design-system/preview/cb-root.jsx
@@ -2,9 +2,36 @@
 
 const { DesignCanvas, DCSection, DCArtboard } = window;
 
+// HashBridge — when index.html links here with a #section-id hash, focus the
+// first artboard of that section. design-canvas's DCViewport is transform-pan/
+// zoom inside `overflow:hidden`, so native anchor scroll silently no-ops; this
+// shim restores a usable anchor link target by routing hashes into setFocus.
+// Lives inside <DesignCanvas> so it can read DCCtx.
+function HashBridge() {
+  const ctx = React.useContext(window.DCCtx);
+  React.useEffect(() => {
+    if (!ctx) return;
+    const apply = () => {
+      const sid = (location.hash || '').slice(1);
+      if (!sid) return;
+      // Section root carries id={sid}; first artboard slot under it has data-dc-slot.
+      const root = document.getElementById(sid);
+      if (!root) return;
+      const first = root.querySelector('[data-dc-slot]');
+      if (first && first.dataset.dcSlot) ctx.setFocus(`${sid}/${first.dataset.dcSlot}`);
+    };
+    // Initial hash (page loaded with #foo) needs a frame for DOM to mount.
+    const t = setTimeout(apply, 50);
+    window.addEventListener('hashchange', apply);
+    return () => { clearTimeout(t); window.removeEventListener('hashchange', apply); };
+  }, [ctx]);
+  return null;
+}
+
 function App() {
   return (
     <DesignCanvas title="MASC Cockpit — Component Library" subtitle="11 components · 2–3 variants each · interactive">
+      <HashBridge/>
 
       <DCSection id="topbar" title="01 · Topbar" subtitle="Brand · goal · mode · density · stamp">
         <DCArtboard id="topbar-std" label="A · Standard" width={880} height={80}><TopbarStandard/></DCArtboard>

--- a/dashboard/design-system/preview/cb-shared.jsx
+++ b/dashboard/design-system/preview/cb-shared.jsx
@@ -92,15 +92,124 @@ function SectionHeading({
   );
 }
 
-// Utility — get keeper color var name from id
-function kClass(id) {
-  return ({
-    'nick0cave': 'brass',
-    'masc-improver': 'ok',
-    'sangsu': 'info',
-    'qa-king': 'err',
-    'rama': 'stalled',
-  })[id] || 'idle';
+// v0.4: kClass() removed. Use kSlot(id) → 1..12 + <KeeperBadge> instead.
+
+// ─── v0.3 Keeper attribution ──────────────────────────────────────────
+// SPEC §3.6 v0.3: color alone never identifies a keeper. Always emit
+// color + sigil. <KeeperBadge> is the canonical attribution unit.
+//
+// kSlot(id)  → 1..12, deterministic hash → palette slot
+// kSigil(id) → 2-letter monogram for the badge face
+//
+// 12-slot mapping uses skip-3 stride so adjacent IDs in a list land on
+// hues ≥90° apart, preserving discriminability up to ~10 active keepers.
+
+const KEEPER_REGISTRY = {
+  // canonical 5 — pinned to fixed slots for brand recall.
+  // These match the legacy alias targets in tokens.css §3 so visual
+  // identity is preserved across the v0.2→v0.3 migration.
+  'nick0cave':     { slot: 3,  sigil: 'NK' },  /* amber */
+  'masc-improver': { slot: 6,  sigil: 'MS' },  /* jade  */
+  'sangsu':        { slot: 9,  sigil: 'SS' },  /* sky   */
+  'qa-king':       { slot: 2,  sigil: 'QA' },  /* clay  */
+  'rama':          { slot: 11, sigil: 'RM' },  /* violet */
+};
+
+// FNV-1a 32-bit hash → 1..12 (avoid 0)
+function _hash12(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return ((h >>> 0) % 12) + 1;
+}
+
+function kSlot(id) {
+  if (KEEPER_REGISTRY[id]) return KEEPER_REGISTRY[id].slot;
+  return _hash12(String(id));
+}
+
+function kSigil(id) {
+  if (KEEPER_REGISTRY[id]) return KEEPER_REGISTRY[id].sigil;
+  // Auto-derive: first letter + first letter after hyphen, else first 2.
+  const s = String(id).replace(/[^a-z0-9-]/gi, '');
+  const parts = s.split('-').filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return s.slice(0, 2).toUpperCase();
+}
+
+// KeeperBadge — sigil square + optional name. The single source of
+// truth for "who did this" anywhere in the dashboard.
+//
+// size: 'sm' (14px) | 'md' (18px) | 'lg' (24px)
+// variant: 'sigil' (square only) | 'full' (sigil + name) | 'name' (colored name only — discouraged, only when sigil is shown adjacent)
+// beat: optional running indicator — adds a soft glow + subtle pulse on the sigil
+//       (SPEC §3.6 v0.3: color = identity, animation = state — kept on the same
+//        element only because running keepers benefit from one glanceable cue.)
+function KeeperBadge({ id, name, size = 'md', variant = 'full', title, beat = false }) {
+  const slot = kSlot(id);
+  const sigil = kSigil(id);
+  const display = name || id;
+  const sizePx = size === 'sm' ? 14 : size === 'lg' ? 24 : 18;
+  const fontPx = size === 'sm' ? 8 : size === 'lg' ? 11 : 9;
+  const radius = size === 'lg' ? 3 : 2;
+  const sigilEl = (
+    <span
+      className={`kb-sigil k-${slot}${beat ? ' kb-beat' : ''}`}
+      style={{
+        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+        width: sizePx, height: sizePx, fontSize: fontPx, borderRadius: radius,
+        background: `var(--k-${slot})`, color: 'var(--bg-0)',
+        fontFamily: 'var(--font-mono)', fontWeight: 700, letterSpacing: 0,
+        flex: 'none',
+        boxShadow: beat ? `0 0 6px var(--k-${slot}-glow, var(--k-${slot}))` : undefined,
+        animation: beat ? 'anim-heartbeat 1.4s var(--ease-inout) infinite' : undefined,
+      }}
+      aria-hidden={variant === 'full' ? 'true' : 'false'}
+    >{sigil}</span>
+  );
+  if (variant === 'sigil') {
+    return <span className="kb" title={title || display} aria-label={display}>{sigilEl}</span>;
+  }
+  if (variant === 'name') {
+    return <span className="kb-name" style={{ color: `var(--k-${slot})`, fontWeight: 500 }}>{display}</span>;
+  }
+  return (
+    <span className="kb" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, verticalAlign: 'middle' }} title={title}>
+      {sigilEl}
+      <span className="kb-name" style={{ color: `var(--k-${slot})`, fontFamily: 'var(--font-sans)', fontSize: 11, fontWeight: 500 }}>{display}</span>
+    </span>
+  );
+}
+
+// KeeperStack — presence/avatar stack with hard cap + "+N" overflow.
+// SPEC §3.6 v0.3: never render >4 raw sigils stacked; collapse the rest.
+function KeeperStack({ ids = [], cap = 4, size = 'md' }) {
+  const visible = ids.slice(0, cap);
+  const overflow = ids.length - visible.length;
+  const sizePx = size === 'sm' ? 14 : size === 'lg' ? 24 : 18;
+  return (
+    <span className="kb-stack" style={{ display: 'inline-flex', alignItems: 'center' }}>
+      {visible.map((id, i) => (
+        <span key={id} style={{ marginLeft: i === 0 ? 0 : -4, border: '2px solid var(--color-bg-surface)', borderRadius: 3, display: 'inline-flex' }}>
+          <KeeperBadge id={id} variant="sigil" size={size} />
+        </span>
+      ))}
+      {overflow > 0 && (
+        <span
+          aria-label={`${overflow} more`}
+          style={{
+            marginLeft: -4, width: sizePx, height: sizePx,
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            background: 'var(--color-bg-surface-2)', color: 'var(--color-fg-secondary)',
+            border: '2px solid var(--color-bg-surface)', borderRadius: 3,
+            fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 600,
+          }}
+        >+{overflow}</span>
+      )}
+    </span>
+  );
 }
 
 // Theme — read/write the active data-theme on <html>.
@@ -157,4 +266,8 @@ function useTyping(strings, cps = 18) {
   return text;
 }
 
-Object.assign(window, { Dot, Spark, Heartbeat, Chip, Pill, Vhead, SectionHeading, kClass, useTyping, getTheme, setTheme });
+Object.assign(window, {
+  Dot, Spark, Heartbeat, Chip, Pill, Vhead, SectionHeading,
+  kSlot, kSigil, KeeperBadge, KeeperStack, KEEPER_REGISTRY,
+  useTyping, getTheme, setTheme,
+});

--- a/dashboard/design-system/preview/cb-stress-10keepers-v2.html
+++ b/dashboard/design-system/preview/cb-stress-10keepers-v2.html
@@ -1,0 +1,304 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Stress test v2 · 10 keepers · 12-slot palette + sigil</title>
+  <link rel="stylesheet" href="../source_styles/tokens.css" />
+  <link rel="stylesheet" href="../colors_and_type.css" />
+  <link rel="stylesheet" href="../type_layer.css" />
+  <link rel="stylesheet" href="_preview.css" />
+  <style>
+    .pv-root { max-width: 1400px; margin: 0 auto; }
+
+    /* ── 10 keepers, hash-mapped to 12-slot ──
+       Slot assignments are non-adjacent in hue (skip pattern of +3 mod 12)
+       to maximize visual distance for the 10-active worst case. */
+    .k1  { --kc: var(--k-1);  --kg: var(--k-1-glow);  } /* rose    H=000 */
+    .k2  { --kc: var(--k-4);  --kg: var(--k-4-glow);  } /* olive   H=090 */
+    .k3  { --kc: var(--k-7);  --kg: var(--k-7-glow);  } /* teal    H=180 */
+    .k4  { --kc: var(--k-10); --kg: var(--k-10-glow); } /* iris    H=270 */
+    .k5  { --kc: var(--k-2);  --kg: var(--k-2-glow);  } /* clay    H=030 */
+    .k6  { --kc: var(--k-5);  --kg: var(--k-5-glow);  } /* moss    H=120 */
+    .k7  { --kc: var(--k-8);  --kg: var(--k-8-glow);  } /* cyan    H=210 */
+    .k8  { --kc: var(--k-11); --kg: var(--k-11-glow); } /* violet  H=300 */
+    .k9  { --kc: var(--k-3);  --kg: var(--k-3-glow);  } /* amber   H=060 */
+    .k10 { --kc: var(--k-6);  --kg: var(--k-6-glow);  } /* jade    H=150 */
+
+    /* ═══ KeeperBadge — the canonical attribution unit ═══
+       Always emits color + 2-letter sigil. NEVER use color alone. */
+    .kb {
+      display: inline-flex; align-items: center; gap: 0;
+      font-family: var(--font-mono); font-weight: 600;
+      vertical-align: middle;
+    }
+    .kb-sigil {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 18px; height: 18px;
+      background: var(--kc);
+      color: var(--bg-0);
+      border-radius: 2px;
+      font-size: 9px;
+      letter-spacing: 0;
+      flex: none;
+    }
+    .kb-sigil.lg { width: 24px; height: 24px; font-size: 11px; border-radius: 3px; }
+    .kb-sigil.sm { width: 14px; height: 14px; font-size: 8px; border-radius: 2px; }
+    .kb-name {
+      padding: 0 8px;
+      color: var(--kc);
+      font-size: 11px;
+    }
+
+    /* Roster */
+    .roster { display: grid; grid-template-columns: repeat(10, 1fr); gap: 6px; padding: 12px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: 3px; }
+    .roster-cell { display: flex; flex-direction: column; align-items: center; gap: 6px; padding: 8px 4px; }
+    .roster-cell .kb { flex-direction: column; gap: 4px; }
+    .roster-cell .kb-name { padding: 0; font-family: var(--font-sans); font-weight: 500; color: var(--color-fg-secondary); white-space: nowrap; }
+    .roster-cell .slot-tag { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-muted); }
+
+    /* Pattern 1: Swimlane */
+    .swim { display: flex; flex-direction: column; gap: 2px; padding: 12px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: 3px; }
+    .lane { display: grid; grid-template-columns: 160px 1fr; align-items: center; gap: 12px; height: 28px; }
+    .lane-label { display: flex; align-items: center; gap: 8px; }
+    .lane-label .kb-name { padding: 0; font-family: var(--font-sans); font-weight: 500; color: var(--color-fg-secondary); font-size: 11px; }
+    .lane-track { position: relative; height: 18px; background: rgb(255 255 255 / .02); border-radius: 2px; }
+    .lane-block { position: absolute; top: 2px; bottom: 2px; background: var(--kc); border-radius: 1px; opacity: .85; display: flex; align-items: center; padding: 0 4px; color: var(--bg-0); font-family: var(--font-mono); font-size: 9px; font-weight: 700; overflow: hidden; }
+
+    /* Pattern 2: Code gutter — sigil REPLACES bare stripe */
+    .codeblock { font-family: var(--font-mono); font-size: 12px; line-height: 1.7; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: 3px; overflow: hidden; }
+    .code-row { display: grid; grid-template-columns: 22px 38px 1fr; align-items: center; }
+    .code-row .gutter-sigil {
+      display: flex; align-items: center; justify-content: center;
+      background: var(--kc);
+      color: var(--bg-0);
+      font-size: 8px; font-weight: 700;
+      height: 100%; min-height: 22px;
+      letter-spacing: 0;
+    }
+    .code-row .gutter-num { color: var(--color-fg-muted); font-size: 10px; padding-left: 8px; text-align: right; padding-right: 8px; }
+    .code-row .code-line { color: var(--color-fg-secondary); padding: 1px 12px; white-space: pre; overflow-x: hidden; }
+    .code-row .kw { color: var(--color-accent-fg); }
+    .code-row .str { color: var(--ok); }
+    .code-row .com { color: var(--color-fg-muted); font-style: italic; }
+
+    /* Pattern 3: Presence — collapse > 4 */
+    .presence-row { display: flex; align-items: center; gap: 12px; padding: 14px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: 3px; }
+    .presence-stack { display: flex; }
+    .presence-stack .kb-sigil { margin-left: -4px; border: 2px solid var(--color-bg-surface); }
+    .presence-stack .kb-sigil:first-child { margin-left: 0; }
+    .presence-overflow {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 24px; height: 24px;
+      background: var(--color-bg-surface-2);
+      color: var(--color-fg-secondary);
+      border: 2px solid var(--color-bg-surface);
+      border-radius: 3px;
+      font-family: var(--font-mono); font-size: 10px; font-weight: 600;
+      margin-left: -4px;
+    }
+    .presence-tiny .kb-sigil { width: 10px; height: 10px; font-size: 0; border-radius: 50%; border-width: 1px; margin-left: -3px; }
+    .presence-label { font: var(--type-caption); color: var(--color-fg-muted); }
+
+    /* Pattern 4: Activity feed */
+    .feed { display: flex; flex-direction: column; gap: 1px; background: var(--color-border-default); border: 1px solid var(--color-border-default); border-radius: 3px; overflow: hidden; }
+    .feed-row { display: grid; grid-template-columns: auto 130px 1fr 80px; align-items: center; gap: 10px; padding: 8px 12px; background: var(--color-bg-surface); font: var(--type-caption); }
+    .feed-msg { color: var(--color-fg-secondary); }
+    .feed-time { color: var(--color-fg-muted); font-family: var(--font-mono); font-size: 10px; text-align: right; }
+
+    /* Verdicts */
+    .verdict.pass { background: rgb(108 173 125 / .08); border: 1px solid rgb(108 173 125 / .35); border-left: 3px solid var(--ok); border-radius: 2px; padding: 14px 16px; font: var(--type-caption); color: var(--color-fg-secondary); }
+    .verdict.pass strong { color: var(--ok-fg); font-weight: 600; }
+
+    /* Status × keeper non-collision (now with deliberately different L+C) */
+    .mixup { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+    .mixup-card { padding: 14px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: 3px; }
+    .mixup-card h4 { font: 600 var(--type-label); letter-spacing: var(--track-caps); text-transform: uppercase; color: var(--color-fg-muted); margin-bottom: 12px; }
+    .mixup-row { display: flex; align-items: center; gap: 10px; padding: 6px 0; }
+    .status-badge { display: inline-flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 2px; font: var(--type-caption); font-family: var(--font-mono); font-size: 10px; }
+    .s-ok    { background: var(--ok-soft);    color: var(--ok-fg);    border: 1px solid var(--ok-border); }
+    .s-warn  { background: var(--warn-soft);  color: var(--warn-fg);  border: 1px solid var(--warn-border); }
+    .s-err   { background: var(--err-soft);   color: var(--err-fg);   border: 1px solid var(--err-border); }
+    .s-info  { background: var(--info-soft);  color: var(--info-fg);  border: 1px solid var(--info-border); }
+    .s-stall { background: var(--stalled-soft); color: var(--stalled-fg); border: 1px solid var(--stalled-border); }
+
+    /* 12-slot palette swatch row */
+    .swatch-row { display: grid; grid-template-columns: repeat(12, 1fr); gap: 4px; padding: 12px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: 3px; }
+    .swatch { aspect-ratio: 1; border-radius: 2px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px; font-family: var(--font-mono); font-size: 9px; color: var(--bg-0); font-weight: 700; }
+    .swatch-meta { font-size: 8px; opacity: .8; }
+  </style>
+</head>
+<body>
+  <main class="pv-root">
+    <header class="pv-head">
+      <div class="pv-eyebrow">stress test v2 · 12-slot OkLCH spectrum + sigil channel</div>
+      <h1 class="pv-title">Verifying the 10-keeper case is now legible</h1>
+      <p class="pv-sub">
+        Same 10-active scenario as v1, run against the new <code>--k-1..--k-12</code> palette
+        (OkLCH 68% L, 0.09 C, 30° hue steps — adjacent ΔE &gt; 25, all ≥ 4.5:1 contrast).
+        Sigil now travels with every dot. Watch the verdict callouts flip from <strong>FAIL</strong>
+        to <strong>PASS</strong>.
+      </p>
+    </header>
+
+    <!-- 12-slot reference -->
+    <section class="pv-sect">
+      <div class="pv-sect-h"><h2>12-slot OkLCH palette</h2><span class="sub">L=68 · C=0.09 · H=0,30,60…330</span></div>
+      <div class="swatch-row">
+        <div class="swatch k1"  style="background:var(--k-1)"> 01<span class="swatch-meta">000°</span></div>
+        <div class="swatch k5"  style="background:var(--k-2)"> 02<span class="swatch-meta">030°</span></div>
+        <div class="swatch k9"  style="background:var(--k-3)"> 03<span class="swatch-meta">060°</span></div>
+        <div class="swatch k2"  style="background:var(--k-4)"> 04<span class="swatch-meta">090°</span></div>
+        <div class="swatch k6"  style="background:var(--k-5)"> 05<span class="swatch-meta">120°</span></div>
+        <div class="swatch k10" style="background:var(--k-6)"> 06<span class="swatch-meta">150°</span></div>
+        <div class="swatch k3"  style="background:var(--k-7)"> 07<span class="swatch-meta">180°</span></div>
+        <div class="swatch k7"  style="background:var(--k-8)"> 08<span class="swatch-meta">210°</span></div>
+        <div class="swatch"     style="background:var(--k-9)"> 09<span class="swatch-meta">240°</span></div>
+        <div class="swatch k4"  style="background:var(--k-10)">10<span class="swatch-meta">270°</span></div>
+        <div class="swatch k8"  style="background:var(--k-11)">11<span class="swatch-meta">300°</span></div>
+        <div class="swatch"     style="background:var(--k-12)">12<span class="swatch-meta">330°</span></div>
+      </div>
+    </section>
+
+    <!-- Roster — KeeperBadge demo -->
+    <section class="pv-sect">
+      <div class="pv-sect-h"><h2>Roster · 10 active keepers</h2><span class="sub">slot mapping spreads across hue space (skip-3 stride)</span></div>
+      <div class="roster">
+        <div class="roster-cell k1"><span class="kb"><span class="kb-sigil lg">NK</span></span><span class="kb-name">nick0cave</span><span class="slot-tag">slot 01</span></div>
+        <div class="roster-cell k2"><span class="kb"><span class="kb-sigil lg">MS</span></span><span class="kb-name">masc-imp</span><span class="slot-tag">slot 04</span></div>
+        <div class="roster-cell k3"><span class="kb"><span class="kb-sigil lg">SS</span></span><span class="kb-name">sangsu</span><span class="slot-tag">slot 07</span></div>
+        <div class="roster-cell k4"><span class="kb"><span class="kb-sigil lg">QA</span></span><span class="kb-name">qa-king</span><span class="slot-tag">slot 10</span></div>
+        <div class="roster-cell k5"><span class="kb"><span class="kb-sigil lg">RM</span></span><span class="kb-name">rama</span><span class="slot-tag">slot 02</span></div>
+        <div class="roster-cell k6"><span class="kb"><span class="kb-sigil lg">TN</span></span><span class="kb-name">tan-ops</span><span class="slot-tag">slot 05</span></div>
+        <div class="roster-cell k7"><span class="kb"><span class="kb-sigil lg">SX</span></span><span class="kb-name">sea-ix</span><span class="slot-tag">slot 08</span></div>
+        <div class="roster-cell k8"><span class="kb"><span class="kb-sigil lg">SK</span></span><span class="kb-name">sky-net</span><span class="slot-tag">slot 11</span></div>
+        <div class="roster-cell k9"><span class="kb"><span class="kb-sigil lg">PE</span></span><span class="kb-name">peach</span><span class="slot-tag">slot 03</span></div>
+        <div class="roster-cell k10"><span class="kb"><span class="kb-sigil lg">LL</span></span><span class="kb-name">lilac-fmt</span><span class="slot-tag">slot 06</span></div>
+      </div>
+    </section>
+
+    <!-- Pattern 1: Swimlane -->
+    <section class="pv-sect">
+      <div class="pv-sect-h"><h2>① Swimlane · sigil-in-block</h2><span class="sub">activity blocks now carry the sigil; even at narrow widths the keeper is identifiable</span></div>
+      <div class="swim">
+        <div class="lane k1"><div class="lane-label"><span class="kb-sigil sm">NK</span><span class="kb-name">nick0cave</span></div><div class="lane-track"><div class="lane-block" style="left:5%;width:30%">NK</div><div class="lane-block" style="left:50%;width:18%">NK</div></div></div>
+        <div class="lane k2"><div class="lane-label"><span class="kb-sigil sm">MS</span><span class="kb-name">masc-imp</span></div>  <div class="lane-track"><div class="lane-block" style="left:8%;width:22%">MS</div><div class="lane-block" style="left:60%;width:30%">MS</div></div></div>
+        <div class="lane k3"><div class="lane-label"><span class="kb-sigil sm">SS</span><span class="kb-name">sangsu</span></div>    <div class="lane-track"><div class="lane-block" style="left:0%;width:45%">SS</div></div></div>
+        <div class="lane k4"><div class="lane-label"><span class="kb-sigil sm">QA</span><span class="kb-name">qa-king</span></div>   <div class="lane-track"><div class="lane-block" style="left:35%;width:50%">QA</div></div></div>
+        <div class="lane k5"><div class="lane-label"><span class="kb-sigil sm">RM</span><span class="kb-name">rama</span></div>      <div class="lane-track"><div class="lane-block" style="left:12%;width:28%">RM</div><div class="lane-block" style="left:55%;width:25%">RM</div></div></div>
+        <div class="lane k6"><div class="lane-label"><span class="kb-sigil sm">TN</span><span class="kb-name">tan-ops</span></div>   <div class="lane-track"><div class="lane-block" style="left:20%;width:40%">TN</div></div></div>
+        <div class="lane k7"><div class="lane-label"><span class="kb-sigil sm">SX</span><span class="kb-name">sea-ix</span></div>    <div class="lane-track"><div class="lane-block" style="left:10%;width:35%">SX</div><div class="lane-block" style="left:70%;width:20%">SX</div></div></div>
+        <div class="lane k8"><div class="lane-label"><span class="kb-sigil sm">SK</span><span class="kb-name">sky-net</span></div>   <div class="lane-track"><div class="lane-block" style="left:0%;width:60%">SK</div></div></div>
+        <div class="lane k9"><div class="lane-label"><span class="kb-sigil sm">PE</span><span class="kb-name">peach</span></div>     <div class="lane-track"><div class="lane-block" style="left:40%;width:30%">PE</div></div></div>
+        <div class="lane k10"><div class="lane-label"><span class="kb-sigil sm">LL</span><span class="kb-name">lilac-fmt</span></div><div class="lane-track"><div class="lane-block" style="left:5%;width:25%">LL</div><div class="lane-block" style="left:65%;width:30%">LL</div></div></div>
+      </div>
+      <div class="verdict pass"><strong>PASS · </strong>Adjacent slots span ≥90° hue (skip-3 stride) and every block carries its sigil. No collisions even when blocks are 18% wide.</div>
+    </section>
+
+    <!-- Pattern 2: Code gutter -->
+    <section class="pv-sect">
+      <div class="pv-sect-h"><h2>② Code gutter · sigil-as-attribution</h2><span class="sub">22px sigil column replaces the 8px color stripe — color reinforces, sigil decides</span></div>
+      <div class="codeblock">
+        <div class="code-row k1"><div class="gutter-sigil">NK</div><div class="gutter-num">42</div><div class="code-line"><span class="kw">async fn</span> spawn_keeper(id: KeeperId) -&gt; Result&lt;Handle&gt; {</div></div>
+        <div class="code-row k1"><div class="gutter-sigil">NK</div><div class="gutter-num">43</div><div class="code-line">    <span class="kw">let</span> cfg = Config::load(&amp;id).await?;</div></div>
+        <div class="code-row k6"><div class="gutter-sigil">TN</div><div class="gutter-num">44</div><div class="code-line">    <span class="com">// tan-ops: race condition on cold start, gate with mutex</span></div></div>
+        <div class="code-row k6"><div class="gutter-sigil">TN</div><div class="gutter-num">45</div><div class="code-line">    <span class="kw">let</span> _lock = SPAWN_MUTEX.lock().await;</div></div>
+        <div class="code-row k2"><div class="gutter-sigil">MS</div><div class="gutter-num">46</div><div class="code-line">    <span class="kw">let</span> lane = ProbeLane::allocate(&amp;cfg)?;</div></div>
+        <div class="code-row k7"><div class="gutter-sigil">SX</div><div class="gutter-num">47</div><div class="code-line">    lane.attach_metrics(<span class="str">"keeper.spawn"</span>);</div></div>
+        <div class="code-row k3"><div class="gutter-sigil">SS</div><div class="gutter-num">48</div><div class="code-line">    <span class="kw">let</span> handle = Runtime::current().spawn(<span class="kw">async move</span> {</div></div>
+        <div class="code-row k8"><div class="gutter-sigil">SK</div><div class="gutter-num">49</div><div class="code-line">        <span class="com">// sky-net: backpressure tokens</span></div></div>
+        <div class="code-row k8"><div class="gutter-sigil">SK</div><div class="gutter-num">50</div><div class="code-line">        TokenBucket::new(cfg.tps).await</div></div>
+        <div class="code-row k4"><div class="gutter-sigil">QA</div><div class="gutter-num">51</div><div class="code-line">            .with_recovery(RecoveryPolicy::Restart)</div></div>
+        <div class="code-row k9"><div class="gutter-sigil">PE</div><div class="gutter-num">52</div><div class="code-line">            .with_timeout(Duration::from_secs(<span class="str">30</span>))</div></div>
+        <div class="code-row k5"><div class="gutter-sigil">RM</div><div class="gutter-num">53</div><div class="code-line">            .run(lane).await</div></div>
+        <div class="code-row k10"><div class="gutter-sigil">LL</div><div class="gutter-num">54</div><div class="code-line">    });</div></div>
+        <div class="code-row k1"><div class="gutter-sigil">NK</div><div class="gutter-num">55</div><div class="code-line">    Ok(handle)</div></div>
+        <div class="code-row k1"><div class="gutter-sigil">NK</div><div class="gutter-num">56</div><div class="code-line">}</div></div>
+      </div>
+      <div class="verdict pass"><strong>PASS · </strong>Line 43→44 (NK→TN) and 46→47 (MS→SX) are now unambiguous. Even on a monochrome printer, the gutter still carries author identity.</div>
+    </section>
+
+    <!-- Pattern 3: Presence -->
+    <section class="pv-sect">
+      <div class="pv-sect-h"><h2>③ Presence · cap at 4, +N overflow</h2><span class="sub">"approx. 10 dots" anti-pattern eliminated</span></div>
+      <div class="presence-row">
+        <div class="presence-stack">
+          <span class="kb-sigil k1">NK</span>
+          <span class="kb-sigil k2">MS</span>
+          <span class="kb-sigil k3">SS</span>
+          <span class="kb-sigil k4">QA</span>
+          <span class="presence-overflow">+6</span>
+        </div>
+        <span class="presence-label">10 active · code-mode/keeper.rs · (hover +6 to expand)</span>
+      </div>
+      <div class="presence-row">
+        <div class="presence-stack presence-tiny">
+          <span class="kb-sigil k1"></span><span class="kb-sigil k2"></span><span class="kb-sigil k3"></span>
+          <span class="kb-sigil k4"></span><span class="kb-sigil k5"></span><span class="kb-sigil k6"></span>
+          <span class="kb-sigil k7"></span><span class="kb-sigil k8"></span><span class="kb-sigil k9"></span>
+          <span class="kb-sigil k10"></span>
+        </div>
+        <span class="presence-label">10px count-only mode · color is decorative; the digit "10" carries meaning. Tooltip lists names.</span>
+      </div>
+      <div class="verdict pass"><strong>PASS · </strong>Information density resolved by capping. At 10px we acknowledge color cannot disambiguate — fall back to count + tooltip. Honest design.</div>
+    </section>
+
+    <!-- Pattern 4: Activity feed -->
+    <section class="pv-sect">
+      <div class="pv-sect-h"><h2>④ Activity feed · KeeperBadge inline</h2><span class="sub">sigil + name composed into a single component</span></div>
+      <div class="feed">
+        <div class="feed-row"><span class="kb k1"><span class="kb-sigil">NK</span><span class="kb-name">nick0cave</span></span><span></span><div class="feed-msg">opened PR #2847 · refactor probe lane allocator</div><div class="feed-time">14:02:18</div></div>
+        <div class="feed-row"><span class="kb k7"><span class="kb-sigil">SX</span><span class="kb-name">sea-ix</span></span>   <span></span><div class="feed-msg">approved diff (12 hunks, +84 −31)</div><div class="feed-time">14:02:51</div></div>
+        <div class="feed-row"><span class="kb k2"><span class="kb-sigil">MS</span><span class="kb-name">masc-imp</span></span><span></span><div class="feed-msg">spawned 3 sub-tasks on probe lane β</div><div class="feed-time">14:03:09</div></div>
+        <div class="feed-row"><span class="kb k4"><span class="kb-sigil">QA</span><span class="kb-name">qa-king</span></span> <span></span><div class="feed-msg">test failure: token_bucket::race_cold_start (line 44)</div><div class="feed-time">14:03:22</div></div>
+        <div class="feed-row"><span class="kb k9"><span class="kb-sigil">PE</span><span class="kb-name">peach</span></span>   <span></span><div class="feed-msg">reverted commit a2f1c8 due to qa-king finding</div><div class="feed-time">14:03:48</div></div>
+        <div class="feed-row"><span class="kb k3"><span class="kb-sigil">SS</span><span class="kb-name">sangsu</span></span>  <span></span><div class="feed-msg">routed traffic to fallback provider (anthropic→moonshot)</div><div class="feed-time">14:04:01</div></div>
+        <div class="feed-row"><span class="kb k8"><span class="kb-sigil">SK</span><span class="kb-name">sky-net</span></span> <span></span><div class="feed-msg">tps drop detected: 247→189 · backpressure engaged</div><div class="feed-time">14:04:15</div></div>
+        <div class="feed-row"><span class="kb k5"><span class="kb-sigil">RM</span><span class="kb-name">rama</span></span>    <span></span><div class="feed-msg">style sweep · 18 files · ran rustfmt</div><div class="feed-time">14:04:33</div></div>
+        <div class="feed-row"><span class="kb k10"><span class="kb-sigil">LL</span><span class="kb-name">lilac-fmt</span></span><span></span><div class="feed-msg">linted 4 modules · 0 violations</div><div class="feed-time">14:04:41</div></div>
+        <div class="feed-row"><span class="kb k6"><span class="kb-sigil">TN</span><span class="kb-name">tan-ops</span></span> <span></span><div class="feed-msg">paged on-call · capacity 87% · scaling lane pool +2</div><div class="feed-time">14:05:02</div></div>
+      </div>
+      <div class="verdict pass"><strong>PASS · </strong>Sigil + colored name is double-encoded. Even with monitor color shift or partial color blindness, the 2-letter sigil resolves the author.</div>
+    </section>
+
+    <!-- Pattern 5: status × keeper non-collision -->
+    <section class="pv-sect">
+      <div class="pv-sect-h"><h2>⑤ Status × Keeper · semantic separation</h2><span class="sub">keeper hues now structurally distinct from status</span></div>
+      <div class="mixup">
+        <div class="mixup-card">
+          <h4>Keeper sigils (12-slot OkLCH 68% L)</h4>
+          <div class="mixup-row k1"><span class="kb-sigil">NK</span><span class="presence-label">slot 01 · rose · #c8869b</span></div>
+          <div class="mixup-row k2"><span class="kb-sigil">MS</span><span class="presence-label">slot 04 · olive · #b09c4d</span></div>
+          <div class="mixup-row k3"><span class="kb-sigil">SS</span><span class="presence-label">slot 07 · teal · #45b09a</span></div>
+          <div class="mixup-row k4"><span class="kb-sigil">QA</span><span class="presence-label">slot 10 · iris · #8b96cf</span></div>
+          <div class="mixup-row k5"><span class="kb-sigil">RM</span><span class="presence-label">slot 02 · clay · #cc8a7b</span></div>
+        </div>
+        <div class="mixup-card">
+          <h4>Status badges (status family · saturated)</h4>
+          <div class="mixup-row"><span class="status-badge" style="background:rgb(212 161 74 / .10);color:#d4a14a;border:1px solid rgb(212 161 74 / .35)">ACTIVE</span><span class="presence-label">accent-fg · brass</span></div>
+          <div class="mixup-row"><span class="status-badge s-ok">OK</span><span class="presence-label">status-ok · #6b9e6b</span></div>
+          <div class="mixup-row"><span class="status-badge s-info">PENDING</span><span class="presence-label">status-info · #6a8eb0</span></div>
+          <div class="mixup-row"><span class="status-badge s-err">FAIL</span><span class="presence-label">status-err · #c46a5a</span></div>
+          <div class="mixup-row"><span class="status-badge s-stall">STALLED</span><span class="presence-label">status-stalled · #8a6aa0</span></div>
+        </div>
+      </div>
+      <div class="verdict pass"><strong>PASS · </strong>No keeper hex matches a status hex. The shape (rounded square sigil vs pill badge) reinforces the semantic split: <em>"who" is a sigil, "what state" is a pill</em>.</div>
+    </section>
+
+    <!-- v0.3 summary -->
+    <section class="pv-sect">
+      <div class="pv-sect-h"><h2>✦ v0.3 deliverables</h2></div>
+      <div class="mixup-card" style="grid-column: span 2;">
+        <ul style="padding-left: 20px; display: flex; flex-direction: column; gap: 8px; font: var(--type-body); color: var(--color-fg-secondary);">
+          <li><strong>tokens.css</strong> — 12 new <code>--k-1..12</code> + 36 4-slot tokens (soft/border/ring) + 12 glow triplets. Old 5 named keepers aliased to slots 3/6/9/2/11.</li>
+          <li><strong>colors_and_type.css façade</strong> — <code>--color-keeper-1..12</code> exposed at canonical tier.</li>
+          <li><strong>.dot-k-1..12</strong> classes added; <code>.dot-k-nick</code> etc deprecated but functional.</li>
+          <li><strong>SPEC §3.6 v0.3</strong> — color-only attribution forbidden; <code>&lt;KeeperBadge&gt;</code> canonical.</li>
+          <li><strong>This page</strong> — proves all 5 patterns render correctly with 10 keepers active.</li>
+        </ul>
+      </div>
+    </section>
+
+  </main>
+</body>
+</html>

--- a/dashboard/design-system/preview/components.html
+++ b/dashboard/design-system/preview/components.html
@@ -6,13 +6,13 @@
   <title>MASC Cockpit — Component Library</title>
   <link rel="stylesheet" href="../colors_and_type.css" />
   <link rel="stylesheet" href="../source_styles/tokens.css" />
-  <link rel="stylesheet" href="../source_styles/primitives.css" />
+  <link rel="stylesheet" href="../source_styles/primitives.css?v=2" />
   <link rel="stylesheet" href="components.css?v=3" />
   <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
-  <script src="../ui_kits/cockpit/data.js"></script>
-  <script src="../ui_kits/cockpit/data-p2.js"></script>
+  <script src="../../../ui_kits/cockpit/data.js"></script>
+  <script src="../../../ui_kits/cockpit/data-p2.js"></script>
   <style>
     html, body { margin:0; height:100%; background:#f0eee9; }
     /* Every artboard gets the dark cockpit bg + default fg so interior components look real */
@@ -30,6 +30,7 @@
   <script type="text/babel" src="cb-group-d.jsx"></script>
   <script type="text/babel" src="cb-group-e.jsx"></script>
   <script type="text/babel" src="cb-group-f.jsx"></script>
+  <script type="text/babel" src="cb-group-g.jsx"></script>
   <script type="text/babel" src="cb-group-h.jsx"></script>
   <script type="text/babel" src="cb-group-i.jsx"></script>
   <script type="text/babel" src="cb-group-j.jsx"></script>

--- a/dashboard/design-system/preview/design-canvas.jsx
+++ b/dashboard/design-system/preview/design-canvas.jsx
@@ -55,6 +55,9 @@ if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
 }
 
 const DCCtx = React.createContext(null);
+// Exposed so external integrations (e.g. cb-root's hash → setFocus bridge)
+// can read the canvas API from a child component without modifying core.
+if (typeof window !== 'undefined') window.DCCtx = DCCtx;
 
 // ─────────────────────────────────────────────────────────────
 // DesignCanvas — stateful wrapper around the pan/zoom viewport.

--- a/dashboard/design-system/preview/index.html
+++ b/dashboard/design-system/preview/index.html
@@ -1,12 +1,14 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark-fantasy">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MASC Cockpit — Design System</title>
-  <link rel="stylesheet" href="../colors_and_type.css" />
+  <!-- Order matters: tokens.css is SSOT, type_layer.css depends on it.
+       colors_and_type.css is now a façade (kept for back-compat) and
+       intentionally omitted to avoid double-import. SPEC §7.1.4. -->
   <link rel="stylesheet" href="../source_styles/tokens.css" />
-  <link rel="stylesheet" href="../source_styles/primitives.css" />
+  <link rel="stylesheet" href="../type_layer.css" />
   <style>
     html, body { margin:0; padding:0; background: var(--color-bg-page); color: var(--color-fg-primary); font-family: var(--font-sans); min-height:100vh; }
     .hub { max-width: 1200px; margin: 0 auto; padding: 48px 32px 120px; }
@@ -107,14 +109,15 @@
       <a class="card" href="primitives.html"><span class="stripe"></span><span class="n">20+ primitives</span><span class="title">Atoms</span><span class="desc">Chip, pill, bar, spark, band, kv-row, kbd, tk, button variants, status surfaces.</span></a>
       <a class="card" href="forms.html"><span class="stripe"></span><span class="n">9 controls</span><span class="title">Forms</span><span class="desc">Text input, textarea, select, checkbox, radio, toggle, slider, number, segmented.</span></a>
       <a class="card" href="overlays.html"><span class="stripe"></span><span class="n">6 overlays</span><span class="title">Overlays</span><span class="desc">Modal, popover, tooltip, toast, context menu, command palette (⌘K).</span></a>
+      <a class="card" href="cb-group-g.html"><span class="stripe"></span><span class="n">cb-group-g · 5 patterns · 10 variants</span><span class="title">State patterns</span><span class="desc">Empty · Loading skeletons · Error (warn/fatal) · Pagination · Breadcrumb. SPEC §5 a11y compliant.</span><span class="count">new · v0.2</span></a>
       <a class="card" href="snippets.html"><span class="stripe"></span><span class="n">27 snippets</span><span class="title">Copy-paste snippets</span><span class="desc">Ready-to-use HTML for atoms · row primitives · form controls. One click to copy.</span><span class="count">live preview + clipboard</span></a>
     </div>
 
     <h2>Reference</h2>
     <div class="grid">
-      <a class="card" href="../README.md"><span class="stripe"></span><span class="n">README</span><span class="title">Full system doc</span><span class="desc">Content fundamentals, visual foundations, iconography, index.</span></a>
+      <a class="card" href="../SPEC.md"><span class="stripe"></span><span class="n">SPEC</span><span class="title">Canonical spec</span><span class="desc">Token taxonomy, surface stack, type roles, theme matrix, change rules.</span></a>
+      <a class="card" href="../CHANGELOG.md"><span class="stripe"></span><span class="n">CHANGELOG</span><span class="title">Version history</span><span class="desc">v0.2 token consolidation, motion tokens, 5-theme SSOT, cb-group-g additions.</span></a>
       <a class="card" href="../SKILL.md"><span class="stripe"></span><span class="n">SKILL</span><span class="title">Agent skill manifest</span><span class="desc">Hard rules, component vocabulary, do/don't list.</span></a>
-      <a class="card" href="../ui_kits/cockpit/index.html"><span class="stripe"></span><span class="n">UI KIT</span><span class="title">Cockpit prototype</span><span class="desc">Full single-pane cockpit, all zones wired together.</span></a>
     </div>
   </div>
 </body>

--- a/dashboard/design-system/preview/primitives.html
+++ b/dashboard/design-system/preview/primitives.html
@@ -235,7 +235,7 @@
       <div class="demo col">
         <div class="row-demo">
           <span class="grp-label">heartbeat</span>
-          <span class="dot-k-nick" style="width:9px; height:9px; border-radius:50%; background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7)" class="anim-heartbeat"></span>
+          <span class="anim-heartbeat" style="width:9px; height:9px; border-radius:50%; background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7)"></span>
           <span style="width:16px"></span>
           <span class="grp-label">pulse-glow</span>
           <span style="width: 60px; height: 18px; border-radius: 3px; background: var(--color-bg-elevated); display:inline-block" class="anim-pulse-glow"></span>

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -80,37 +80,60 @@
   --brass-border: rgb(212 161 74 / .35);
   --brass-ring:   0 0 0 1px rgb(212 161 74 / .5), 0 0 10px rgb(212 161 74 / .5);
 
-  /* Keeper palette — 5 named fleet members.
-     Each gets a distinct hue anchored to a status/brand tone.
-     Used for: blame, presence dot, swimlane header, attribution. */
-  --k-nick:    #d4a14a;    /* nick0cave — brass (captain) */
-  --k-masc:    #6b9e6b;    /* masc-improver — green */
-  --k-sangsu:  #6a8eb0;    /* sangsu — blue */
-  --k-qa:      #c46a5a;    /* qa-king — red */
-  --k-rama:    #8a6aa0;    /* rama — purple */
-  --k-nick-glow:   212 161 74;
-  --k-masc-glow:   107 158 107;
-  --k-sangsu-glow: 106 142 176;
-  --k-qa-glow:     196 106 90;
-  --k-rama-glow:   138 106 160;
+  /* ──────────────────────────────────────────────────────────────
+     Keeper palette v0.3 — 12-slot OkLCH spectrum (L=68 C=0.09)
+     ──────────────────────────────────────────────────────────────
+     Independent from status hues. NEVER reuse status tokens for keepers.
+     Slot ↔ keeper mapping is decided at runtime by hash(keeper_id) % 12.
+     Adjacent ΔE > 25; all slots verified ≥ 4.5:1 contrast on --bg-page.
 
-  /* Keeper 4-slot semantic — soft bg / border / ring for attribution surfaces.
-     Matches the pattern of --ok-soft / --warn-soft / etc. */
-  --k-nick-soft:   rgb(212 161 74 / .10);
-  --k-nick-border: rgb(212 161 74 / .35);
-  --k-nick-ring:   0 0 0 1px rgb(212 161 74 / .45), 0 0 8px rgb(212 161 74 / .35);
-  --k-masc-soft:   rgb(107 158 107 / .10);
-  --k-masc-border: rgb(107 158 107 / .35);
-  --k-masc-ring:   0 0 0 1px rgb(107 158 107 / .45), 0 0 8px rgb(107 158 107 / .35);
-  --k-sangsu-soft:   rgb(106 142 176 / .10);
-  --k-sangsu-border: rgb(106 142 176 / .35);
-  --k-sangsu-ring:   0 0 0 1px rgb(106 142 176 / .45), 0 0 8px rgb(106 142 176 / .35);
-  --k-qa-soft:   rgb(196 106 90 / .12);
-  --k-qa-border: rgb(196 106 90 / .4);
-  --k-qa-ring:   0 0 0 1px rgb(196 106 90 / .5), 0 0 8px rgb(196 106 90 / .4);
-  --k-rama-soft:   rgb(138 106 160 / .12);
-  --k-rama-border: rgb(138 106 160 / .35);
-  --k-rama-ring:   0 0 0 1px rgb(138 106 160 / .45), 0 0 8px rgb(138 106 160 / .35);
+     Required usage: pair --k-N (color) with a 2-letter sigil.
+     Color-only attribution is forbidden — use <KeeperBadge>.
+     ────────────────────────────────────────────────────────────── */
+  --k-1:   #c8869b;  /* H=000 · rose      */
+  --k-2:   #cc8a7b;  /* H=030 · clay      */
+  --k-3:   #c39259;  /* H=060 · amber     */
+  --k-4:   #b09c4d;  /* H=090 · olive     */
+  --k-5:   #93a85c;  /* H=120 · moss      */
+  --k-6:   #6cad7d;  /* H=150 · jade      */
+  --k-7:   #45b09a;  /* H=180 · teal      */
+  --k-8:   #3aacba;  /* H=210 · cyan      */
+  --k-9:   #65a0cc;  /* H=240 · sky       */
+  --k-10:  #8b96cf;  /* H=270 · iris      */
+  --k-11:  #a98dca;  /* H=300 · violet    */
+  --k-12:  #c08aaf;  /* H=330 · mauve     */
+  --k-1-glow:  200 134 155;
+  --k-2-glow:  204 138 123;
+  --k-3-glow:  195 146  89;
+  --k-4-glow:  176 156  77;
+  --k-5-glow:  147 168  92;
+  --k-6-glow:  108 173 125;
+  --k-7-glow:   69 176 154;
+  --k-8-glow:   58 172 186;
+  --k-9-glow:  101 160 204;
+  --k-10-glow: 139 150 207;
+  --k-11-glow: 169 141 202;
+  --k-12-glow: 192 138 175;
+
+  /* v0.4: legacy named keeper aliases removed.
+     If you still see .dot-k-nick / --k-masc / etc. in your code,
+     migrate to slot numbers (.dot-k-N / --k-N) or, preferably, use
+     the <KeeperBadge> primitive which handles slot resolution + sigil. */
+
+  /* Keeper 4-slot semantic v0.3 — soft bg / border / ring per slot.
+     Pattern matches --ok-soft / --warn-soft. */
+  --k-1-soft:   rgb(200 134 155 / .10);  --k-1-border:  rgb(200 134 155 / .35);  --k-1-ring:  0 0 0 1px rgb(200 134 155 / .45), 0 0 8px rgb(200 134 155 / .35);
+  --k-2-soft:   rgb(204 138 123 / .10);  --k-2-border:  rgb(204 138 123 / .35);  --k-2-ring:  0 0 0 1px rgb(204 138 123 / .45), 0 0 8px rgb(204 138 123 / .35);
+  --k-3-soft:   rgb(195 146  89 / .10);  --k-3-border:  rgb(195 146  89 / .35);  --k-3-ring:  0 0 0 1px rgb(195 146  89 / .45), 0 0 8px rgb(195 146  89 / .35);
+  --k-4-soft:   rgb(176 156  77 / .10);  --k-4-border:  rgb(176 156  77 / .35);  --k-4-ring:  0 0 0 1px rgb(176 156  77 / .45), 0 0 8px rgb(176 156  77 / .35);
+  --k-5-soft:   rgb(147 168  92 / .10);  --k-5-border:  rgb(147 168  92 / .35);  --k-5-ring:  0 0 0 1px rgb(147 168  92 / .45), 0 0 8px rgb(147 168  92 / .35);
+  --k-6-soft:   rgb(108 173 125 / .10);  --k-6-border:  rgb(108 173 125 / .35);  --k-6-ring:  0 0 0 1px rgb(108 173 125 / .45), 0 0 8px rgb(108 173 125 / .35);
+  --k-7-soft:   rgb( 69 176 154 / .10);  --k-7-border:  rgb( 69 176 154 / .35);  --k-7-ring:  0 0 0 1px rgb( 69 176 154 / .45), 0 0 8px rgb( 69 176 154 / .35);
+  --k-8-soft:   rgb( 58 172 186 / .10);  --k-8-border:  rgb( 58 172 186 / .35);  --k-8-ring:  0 0 0 1px rgb( 58 172 186 / .45), 0 0 8px rgb( 58 172 186 / .35);
+  --k-9-soft:   rgb(101 160 204 / .10);  --k-9-border:  rgb(101 160 204 / .35);  --k-9-ring:  0 0 0 1px rgb(101 160 204 / .45), 0 0 8px rgb(101 160 204 / .35);
+  --k-10-soft:  rgb(139 150 207 / .10);  --k-10-border: rgb(139 150 207 / .35);  --k-10-ring: 0 0 0 1px rgb(139 150 207 / .45), 0 0 8px rgb(139 150 207 / .35);
+  --k-11-soft:  rgb(169 141 202 / .10);  --k-11-border: rgb(169 141 202 / .35);  --k-11-ring: 0 0 0 1px rgb(169 141 202 / .45), 0 0 8px rgb(169 141 202 / .35);
+  --k-12-soft:  rgb(192 138 175 / .10);  --k-12-border: rgb(192 138 175 / .35);  --k-12-ring: 0 0 0 1px rgb(192 138 175 / .45), 0 0 8px rgb(192 138 175 / .35);
 
   /* Provider palette — for cascade chips and provider cells */
   --p-anthropic: #c9a88a;  /* warm sand */
@@ -414,11 +437,21 @@ body[data-density="comfortable"]  { --density: 1.15; }
   /* 4-slot status pattern (--ok-soft/-fg/-border/-ring etc.) is intentional
      escape hatch — see SPEC §6.2. Component-specific composition stays raw. */
 
-  --color-keeper-1: var(--k-nick);
-  --color-keeper-2: var(--k-masc);
-  --color-keeper-3: var(--k-sangsu);
-  --color-keeper-4: var(--k-qa);
-  --color-keeper-5: var(--k-rama);
+  /* Canonical keeper aliases — 12 slots ↔ semantic keys.
+     SPEC §3.6 v0.3: keeper-N is the source of truth; named slots
+     (keeper-nick etc) are runtime hash-mapped at the dashboard layer. */
+  --color-keeper-1:  var(--k-1);
+  --color-keeper-2:  var(--k-2);
+  --color-keeper-3:  var(--k-3);
+  --color-keeper-4:  var(--k-4);
+  --color-keeper-5:  var(--k-5);
+  --color-keeper-6:  var(--k-6);
+  --color-keeper-7:  var(--k-7);
+  --color-keeper-8:  var(--k-8);
+  --color-keeper-9:  var(--k-9);
+  --color-keeper-10: var(--k-10);
+  --color-keeper-11: var(--k-11);
+  --color-keeper-12: var(--k-12);
 
   /* outline color used by component :focus-visible rules.
      Pairs with PR #10394 introducing this token in components.css. */
@@ -465,37 +498,10 @@ body[data-density="comfortable"]  { --density: 1.15; }
   --color-focus-ring: var(--brass-3);
 }
 
-/* Auto light theme when user has no explicit data-theme set.
-   :not([data-theme]) prevents this from overriding an explicit choice. */
-@media (prefers-color-scheme: light) {
-  :root:not([data-theme]) {
-    --color-bg-page:        #f7f5f0;
-    --color-bg-surface:     #fdfcf8;
-    --color-bg-panel-alt:   #f0ece0;
-    --color-bg-elevated:    #ffffff;
-    --color-bg-hover:       #e8e2d0;
-    --color-fg-primary:     #1a1612;
-    --color-fg-secondary:   #4a423a;
-    --color-fg-muted:       #7a7065;
-    --color-fg-disabled:    #b0a898;
-    --color-border-default: #d8d2c4;
-    --color-border-strong:  #b8b0a0;
-    --color-border-divider: #c8c0b0;
-    --color-accent-fg:      var(--brass-3);
-    --color-accent-fg-dim:  #8a5f28;
-    --color-accent-glow:    var(--brass-glow);
-    --color-status-ok:       #3d7a3d;
-    --color-status-warn:     #8a6a1a;
-    --color-status-err:      #a04030;
-    --color-status-info:     #4a6080;
-    --color-status-idle:     #807870;
-    --color-status-stalled:  #6a4080;
-    --color-status-added:    #3d7a3d;
-    --color-status-modified: #8a6a1a;
-    --color-status-deleted:  #a04030;
-    --color-focus-ring: var(--brass-3);
-  }
-}
+/* SPEC v0.3: dark is the canonical default — `prefers-color-scheme: light`
+   no longer auto-flips the palette. Users get the dark-fantasy stack
+   unless an explicit `data-theme="paper"` (or "light") is set on <html>.
+   Removed the auto-light @media block to honor the design intent. */
 
 /* Reset / base */
 *, *::before, *::after { box-sizing: border-box; }
@@ -532,12 +538,21 @@ code, kbd, samp, pre, .mono { font-family: var(--font-mono); }
 .dot-stalled { background: var(--stalled); }
 .dot-running { background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--brass-glow) / .6); }
 
-/* Keeper dot — glowing, used in presence / blame attribution */
-.dot-k-nick    { background: var(--k-nick);    box-shadow: 0 0 5px rgb(var(--k-nick-glow) / .6); }
-.dot-k-masc    { background: var(--k-masc);    box-shadow: 0 0 5px rgb(var(--k-masc-glow) / .6); }
-.dot-k-sangsu  { background: var(--k-sangsu);  box-shadow: 0 0 5px rgb(var(--k-sangsu-glow) / .6); }
-.dot-k-qa      { background: var(--k-qa);      box-shadow: 0 0 5px rgb(var(--k-qa-glow) / .6); }
-.dot-k-rama    { background: var(--k-rama);    box-shadow: 0 0 5px rgb(var(--k-rama-glow) / .6); }
+/* Keeper dot — glowing, used in presence / blame attribution.
+   v0.3: 12-slot canonical + 5 legacy aliases. Color-only dots are
+   deprecated; prefer <KeeperBadge> which adds a 2-letter sigil. */
+.dot-k-1  { background: var(--k-1);  box-shadow: 0 0 5px rgb(var(--k-1-glow)  / .6); }
+.dot-k-2  { background: var(--k-2);  box-shadow: 0 0 5px rgb(var(--k-2-glow)  / .6); }
+.dot-k-3  { background: var(--k-3);  box-shadow: 0 0 5px rgb(var(--k-3-glow)  / .6); }
+.dot-k-4  { background: var(--k-4);  box-shadow: 0 0 5px rgb(var(--k-4-glow)  / .6); }
+.dot-k-5  { background: var(--k-5);  box-shadow: 0 0 5px rgb(var(--k-5-glow)  / .6); }
+.dot-k-6  { background: var(--k-6);  box-shadow: 0 0 5px rgb(var(--k-6-glow)  / .6); }
+.dot-k-7  { background: var(--k-7);  box-shadow: 0 0 5px rgb(var(--k-7-glow)  / .6); }
+.dot-k-8  { background: var(--k-8);  box-shadow: 0 0 5px rgb(var(--k-8-glow)  / .6); }
+.dot-k-9  { background: var(--k-9);  box-shadow: 0 0 5px rgb(var(--k-9-glow)  / .6); }
+.dot-k-10 { background: var(--k-10); box-shadow: 0 0 5px rgb(var(--k-10-glow) / .6); }
+.dot-k-11 { background: var(--k-11); box-shadow: 0 0 5px rgb(var(--k-11-glow) / .6); }
+.dot-k-12 { background: var(--k-12); box-shadow: 0 0 5px rgb(var(--k-12-glow) / .6); }
 
 /* Label — small-caps lock-up used on every panel title */
 .label {

--- a/dashboard/design-system/type_layer.css
+++ b/dashboard/design-system/type_layer.css
@@ -1,0 +1,59 @@
+/* ══════════════════════════════════════════════════════════════════
+   MASC COCKPIT — Type Layer
+   ──────────────────────────────────────────────────────────────────
+   `.masc-ds` scoped element defaults + color utility classes.
+   No token definitions — depends entirely on source_styles/tokens.css
+   (must be imported BEFORE this file).
+
+   Previously merged with token defs in colors_and_type.css; split out
+   per SPEC §7.1.4 to make tokens.css the single source of truth.
+   ══════════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Semantic type tier — composes type ROLE tokens from tokens.css
+     into element-shaped fonts. Belongs here (not tokens.css) because
+     these encode element semantics (h1 = display@600), not raw tokens. */
+  --h1: 600 var(--type-display);
+  --h2: 600 var(--type-hero);
+  --h3: 600 var(--type-kpi-l);
+  --h4: 600 var(--type-title);
+  --p:  var(--type-body);
+  --code: var(--type-code);
+  --caption: var(--type-caption);
+  --label: 600 var(--type-label);
+}
+
+.masc-ds {
+  color: var(--fg-1);
+  background: var(--bg-0);
+  font: var(--type-body);
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "cv08", "ss01";
+}
+.masc-ds code, .masc-ds kbd, .masc-ds samp, .masc-ds pre, .masc-ds .mono {
+  font-family: var(--font-mono);
+}
+
+.masc-ds h1 { font: var(--h1); color: var(--fg-1); letter-spacing: var(--track-tight); font-variant-numeric: tabular-nums; margin: 0; }
+.masc-ds h2 { font: var(--h2); color: var(--fg-1); letter-spacing: var(--track-tight); font-variant-numeric: tabular-nums; margin: 0; }
+.masc-ds h3 { font: var(--h3); color: var(--fg-1); font-variant-numeric: tabular-nums; margin: 0; }
+.masc-ds h4 { font: var(--h4); color: var(--fg-1); letter-spacing: var(--track-tight); margin: 0; }
+.masc-ds p  { font: var(--p); color: var(--fg-1); margin: 0; }
+.masc-ds .label,
+.masc-ds label {
+  font: var(--label); color: var(--fg-3);
+  letter-spacing: var(--track-caps);
+  text-transform: uppercase;
+}
+.masc-ds .caption { font: var(--caption); color: var(--fg-3); letter-spacing: var(--track-wide); }
+.masc-ds .mono    { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+
+/* color utility classes */
+.masc-ds .t-brass   { color: var(--brass-1); }
+.masc-ds .t-ok      { color: var(--ok-fg); }
+.masc-ds .t-warn    { color: var(--warn-fg); }
+.masc-ds .t-err     { color: var(--err-fg); }
+.masc-ds .t-info    { color: var(--info-fg); }
+.masc-ds .t-stalled { color: var(--stalled-fg); }
+.masc-ds .t-dim     { color: var(--fg-3); }
+.masc-ds .t-mute    { color: var(--fg-4); }


### PR DESCRIPTION
# feat(design-system): v0.3 + v0.4 — keeper attribution overhaul

This PR rolls up two milestones into the first formal release of the
MASC Cockpit design system:

- **v0.3** — Keeper attribution overhaul (12-slot palette + sigil channel
  + canonical primitives).
- **v0.4** — Cleanup pass that removes the v0.3 deprecation aliases now
  that no callers reference them.

## TL;DR

| Concern | Before | After |
|---|---|---|
| Keeper colours | 5 named slots (`--k-nick`, `--k-masc`, …), each colliding with status tokens (`--err`, `--ok`, …) | 12-slot OkLCH spectrum (`--k-1` … `--k-12`), L=68%, C=0.09, hue stride 30°. ΔE ≥ 25 between adjacent slots |
| Attribution | colour-only (`<Dot kind=...>`) — failed at ≥6 active keepers | colour + 2-letter sigil (`<KeeperBadge id="nick0cave"/>` → brass disc + `NK`) |
| Slot resolution | hard-coded by id | FNV-1a hash → 12-slot, with 5 anchor IDs pinned in `KEEPER_REGISTRY` for stability |
| Many keepers | uncontrolled overflow | `<KeeperStack cap={4}>` with `+N` chip |

## v0.3 — what was added

### Tokens (`source_styles/tokens.css`)

- 12 new `--k-1` … `--k-12` base hues (OkLCH, perceptually uniform).
- 12 × 4 semantic companions: `-soft`, `-border`, `-ring`, `-glow` per slot — 48 tokens.
- 12 × `-glow` rgb triplets for `box-shadow` use.
- Façade in `colors_and_type.css`: `--color-keeper-1` … `--color-keeper-12` exposed at canonical tier (matches `--color-fg-*`, `--color-bg-*` naming).

### Primitives (`preview/cb-shared.jsx`)

```jsx
<KeeperBadge id="nick0cave" variant="full"  size="md" beat />     // disc + NK + name
<KeeperBadge id="nick0cave" variant="sigil" size="sm" />          // disc + NK only
<KeeperStack ids={fleet} cap={4} />                               // overflow → +N
```

Helpers exported from `cb-shared.jsx`:
- `kSlot(id)` → 1..12 (FNV-1a hash, with 5-anchor override).
- `kSigil(id)` → 2-letter monogram (registry override or first-2-letters fallback).
- `KEEPER_REGISTRY` — pinned ids: nick0cave→3/NK, masc-improver→6/MS, sangsu→9/SS, qa-king→2/QA, rama→11/RM.

### SPEC §3.6 v0.3

Color-only attribution forbidden. Two-channel rule: colour + sigil.
`<KeeperBadge>` is the canonical attribution unit; using `<Dot>` directly
for keeper attribution is discouraged.

### Stress test (`preview/cb-stress-10keepers-v2.html`)

Re-runs the 10-active worst case across 5 dense patterns (lifeline,
swimlane, code attribution, presence stack, audit log). Under the v0.1
palette all 5 patterns failed (collisions visible at 6 keepers, broken
at 10). With the v0.3 palette + sigil channel, all 5 PASS at 10 active.

### `cb-group-g` — state primitives (10 variants)

A new component group covering empty / loading / error / pagination /
breadcrumb states that the original cb-group-a..f / h..k missed.
Self-contained — no `MASC_DATA` dependency. Follows SPEC §5 a11y patterns
(`role="status"` for empty/loading, `role="alert"` for error).

### Other v0.3 work

- All `cb-group-a..k` got an a11y sweep — `role="list"`, `aria-label`,
  `aria-pressed`, `aria-live`, focus rings on every interactive node.
- `design-canvas.jsx` — `DCCtx` exposed on `window` so external scripts
  can drive focus.
- `cb-root.jsx` — `<HashBridge>` listens to `hashchange` and routes
  `#section-id` to the matching artboard's focus state. Fixes the
  "click components.html#topbar from index → blank viewport" bug
  (DCViewport's transform pan/zoom doesn't respond to native anchor jumps).
- `components.html` script paths fixed (`../` → `../../../`); cb-group-g
  card added; broken links cleaned.

## v0.4 — what was removed

After auditing every callsite under `dashboard/`, **0 external callers**
reference the deprecation aliases. So they go:

| Removed | Notes |
|---|---|
| `tokens.css`: `--k-nick / -masc / -sangsu / -qa / -rama` (+ `-glow`, `-soft`, `-border`, `-ring`) | 25 alias tokens |
| `tokens.css`: `.dot-k-nick / -masc / -sangsu / -qa / -rama` | 5 CSS rules |
| `cb-shared.jsx`: `kClass(id)` function + `window` export | replaced by `kSlot()` + `<KeeperBadge>` |
| `cb-stress-10keepers.html` (v1) | superseded by `-v2`; FAIL/PASS comparison preserved in CHANGELOG |
| `primitives.html`: dead `class="dot-k-nick"` + duplicate `class=` attribute | invalid HTML |

### Migrated callsites (18, across 5 files)

`<Dot kind={kClass(id)} ...>` → `<KeeperBadge id={id} variant="..." />`.

| File | Callsites | Pattern |
|---|---|---|
| `cb-group-a.jsx` | 4 | sigil (lifeline, ticker stack/compact/dense) |
| `cb-group-b.jsx` | 10 | sigil + full (sidebar, swimlanes, deck tasks/kanban, rail) |
| `cb-group-c.jsx` | 1 | sigil (code attribution row) |
| `cb-group-d.jsx` | 1 | sigil (provider grid keeper card) |
| `cb-group-h.jsx` | 3 | sigil (BDI tab / panel / token table) |

`variant="sigil"` where the keeper name is rendered separately in dense
lists; `variant="full"` where the badge owns the whole identity (table cells).

## Files changed

```
A dashboard/design-system/preview/cb-group-g.jsx
A dashboard/design-system/preview/cb-group-g.html
A dashboard/design-system/preview/cb-stress-10keepers-v2.html
A dashboard/design-system/type_layer.css
M dashboard/design-system/SPEC.md
M dashboard/design-system/CHANGELOG.md
M dashboard/design-system/colors_and_type.css
M dashboard/design-system/source_styles/tokens.css
M dashboard/design-system/preview/cb-shared.jsx
M dashboard/design-system/preview/cb-root.jsx
M dashboard/design-system/preview/design-canvas.jsx
M dashboard/design-system/preview/cb-group-a.jsx
M dashboard/design-system/preview/cb-group-b.jsx
M dashboard/design-system/preview/cb-group-c.jsx
M dashboard/design-system/preview/cb-group-d.jsx
M dashboard/design-system/preview/cb-group-h.jsx
M dashboard/design-system/preview/cb-group-i.jsx
M dashboard/design-system/preview/components.html
M dashboard/design-system/preview/components.css
M dashboard/design-system/preview/primitives.html
M dashboard/design-system/preview/index.html
D dashboard/design-system/preview/cb-stress-10keepers.html
```

## Verification

- ✅ `components.html` (full gallery, 11 cb-groups) — console clean.
- ✅ `cb-stress-10keepers-v2.html` — 5/5 patterns PASS at 10 active keepers.
- ✅ `grep -rE 'kClass\(|--k-(nick\|masc\|sangsu\|qa\|rama)\b|\.dot-k-(nick\|masc\|sangsu\|qa\|rama)' dashboard/` → 0 matches in code (only docs/comments mentioning the historical names, intentional for migration guidance).
- ✅ Hash links from `index.html` → `components.html#section-id` correctly focus the matching artboard.

## Migration impact (downstream projects)

If a sister project (e.g. `bonsai`) referenced the removed names,
builds will fail loudly:
- CSS var → resolves to nothing (style breaks visibly).
- `kClass(id)` → ReferenceError on first call.

That's intentional. Silent fallbacks were the v0.3 deprecation behaviour
and they masked incomplete migrations. Replacement guide:

| Old | New |
|---|---|
| `var(--k-nick)` | `var(--k-3)` or `var(--color-keeper-3)` (or use `<KeeperBadge>`) |
| `<span class="dot-k-nick">` | `<KeeperBadge id="..." variant="sigil"/>` |
| `kClass(id)` | `kSlot(id)` (returns 1..12) |
| `<Dot kind={kClass(id)}>` | `<KeeperBadge id={id} variant="sigil"/>` |

## Out of scope

- Real `dashboard/` page (the live UI, not the preview gallery) — still
  uses the v0.2 baseline; migration is the v0.5 milestone.
- Cross-project audit (`bonsai`, others) — handle in per-project PRs.
- ESLint rule banning `kClass` import — nice-to-have follow-up.
