### PR TITLE
feat(dashboard): localize 6 mixed-language onboarding strings + fix round-44 miss (round-45)

### DIFF
--- a/dashboard/src/components/connector-onboarding.ts
+++ b/dashboard/src/components/connector-onboarding.ts
@@ -60,7 +60,7 @@ function OnboardingCard({ connectorId }: { connectorId: KnownConnectorId }) {
         >${onboardingStartLabel(starting)}</button>
       </div>
       <div class="text-2xs text-[var(--color-fg-disabled)]">
-        <strong>Start</strong>를 누르면 backend가 sidecar를 spawn합니다. 또는 명령을 복사해 새 터미널에서 직접 실행하세요.
+        <strong>Start</strong>를 누르면 백엔드가 사이드카를 실행합니다. 또는 명령을 복사해 새 터미널에서 직접 실행하세요.
       </div>
       <div class="mt-2 grid grid-cols-1 gap-1.5">
         <${CopyableCode} label="start" command=${cmds.start} variant="primary" />
@@ -75,10 +75,10 @@ export function ConnectorOnboardingGrid() {
   return html`
     <div>
       <div class="mb-3">
-        <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">아직 연결된 sidecar가 없습니다</h3>
+        <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">아직 연결된 사이드카가 없습니다</h3>
         <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">
-          4개의 채널 sidecar를 켤 수 있습니다. 카드의 시작 명령을 복사해 새 터미널에서 실행하거나, 아래
-          <strong>Start All</strong>로 한 번에 spawn하세요. spawn 후 이 화면이 라이브 상태로 갱신됩니다.
+          4개의 채널 사이드카를 켤 수 있습니다. 카드의 시작 명령을 복사해 새 터미널에서 실행하거나, 아래
+          <strong>Start All</strong>로 한 번에 실행하세요. 실행 후 이 화면이 라이브 상태로 갱신됩니다.
         </div>
       </div>
       <${ConnectorBulkActions} connectors=${[]} />

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1053,10 +1053,10 @@ function ConnectorLivePanel({
                 </div>
                 <div class="text-2xs text-[var(--color-status-warn)]/80">
                   <div>
-                    <span class="font-medium">원인: </span> sidecar status 파일이 <code class="rounded bg-[var(--white-4)] px-1">${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}</code> 에서 관찰되지 않았습니다.
+                    <span class="font-medium">원인: </span> 사이드카 status 파일이 <code class="rounded bg-[var(--white-4)] px-1">${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}</code> 에서 관찰되지 않았습니다.
                   </div>
                   <div class="mt-1">
-                    <span class="font-medium">다음: </span> <strong>Start</strong> 버튼으로 backend 를 통해 spawn 하거나, 아래 명령을 복사해 터미널에서 실행하세요. 오프라인이 지속되면 <strong>status</strong> 와 <strong>tail logs</strong> 를 사용하세요.
+                    <span class="font-medium">다음: </span> <strong>Start</strong> 버튼으로 백엔드를 통해 실행하거나, 아래 명령을 복사해 터미널에서 실행하세요. 오프라인이 지속되면 <strong>status</strong> 와 <strong>tail logs</strong> 를 사용하세요.
                   </div>
                 </div>
                 <div class="mt-2 grid grid-cols-1 gap-1.5">

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -69,12 +69,12 @@ export function ExcusePatterns() {
   const jsonStr = data ? JSON.stringify(data, null, 2) : '[]'
 
   return html`
-    <${Card} title="Anti-Rationalization Excuse Patterns">
+    <${Card} title="Anti-Rationalization 핑계 패턴">
       <div class="p-4">
         <p class="text-sm text-[var(--color-fg-muted)] mb-4">
-          These patterns are matched against agent completion notes. If matched, the task is rejected.
-          Changes here are saved to <code>config/excuse_patterns.json</code> and applied immediately without restarting.
-          The format must be a JSON array of arrays, each containing two strings: <code>["pattern", "reason"]</code>.
+          이 패턴들은 에이전트 completion note 와 매칭됩니다. 매칭되면 해당 task 는 거부됩니다.
+          변경 사항은 <code>config/excuse_patterns.json</code> 에 저장되며 재시작 없이 즉시 적용됩니다.
+          형식은 두 개의 문자열을 담은 배열들의 JSON 배열이어야 합니다: <code>["pattern", "reason"]</code>.
         </p>
 
         <form onSubmit=${handleSave}>


### PR DESCRIPTION
## Summary

대시보드 라운드 45 — onboarding 영역의 mixed-language 문장 정리 + round-44 missed instance fix.

| File | Element | Before | After |
|---|---|---|---|
| excuse-patterns.ts:72 | Card title | Anti-Rationalization Excuse Patterns | Anti-Rationalization 핑계 패턴 |
| excuse-patterns.ts:75-77 | help paragraph (3 lines) | English explanation | 한국어 설명 + JSON 형식 |
| connector-onboarding.ts:63 | mixed sentence | <strong>Start</strong>를 누르면 backend가 sidecar를 spawn합니다 | <strong>Start</strong>를 누르면 백엔드가 사이드카를 실행합니다 |
| connector-onboarding.ts:78 | heading | 연결된 sidecar가 없습니다 | 연결된 사이드카가 없습니다 |
| connector-onboarding.ts:80-81 | onboarding sentence | spawn하세요. spawn 후 ... | 실행하세요. 실행 후 ... |
| connector-status.ts:1056,1059 | offline banner | sidecar status / backend 를 통해 spawn 하거나 | 사이드카 status / 백엔드를 통해 실행하거나 |

## Round-44 miss 원인 + fix

\`excuse-patterns.ts\` 의 Card title 3 instances (lines 54, 62, 72) 중 round-44 의 \`replace_all=true\` 가 lines 54+62 만 매칭. **이유: 들여쓰기 차이** (54+62 는 6-space, 72 는 4-space). exact match 정책상 다른 string 으로 분류.

→ 향후 sweep 정책: \`replace_all\` 사용 후 \`rg\` 로 동일 substring 잔재 검증. round-45 가 검증 + 수정.

## Domain term consistency (round-34 + round-45 ledger)

| 영문 → 한국어 | round 시작 | 현재 라운드 |
|---|---|---|
| backend | -- | 백엔드 |
| sidecar | round-34 (path label) | 사이드카 (full sweep) |
| spawn | -- | 실행 |
| Start / Start All | (보존) | (보존) |
| status / tail logs | (보존, CLI 명령) | (보존) |
| config/excuse_patterns.json | (보존, file path) | (보존) |

## Test fixture coupling 검증

| 단어 | Test 등장 | 충돌 |
|---|---|---|
| Anti-Rationalization Excuse Patterns | -- | ❌ 0 |
| backend / sidecar / spawn | (단어 자체는 코드 식별자에 등장하지만 visible string assertion 0) | ❌ |

## 라운드 누적 (23-45)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-44 | -- | MERGED | 139 |
| 45 | this | Draft | **6** |

누적 chips ≈ **202**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)