### PR TITLE
fix(build): restore dated_jsonl For_testing + drop duplicate TurnReady arm

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -358,3 +358,14 @@ let prune t ~days =
   end
 
 (* Duplicate count_entries removed — canonical definition at line 225 *)
+
+module For_testing = struct
+  let mutex t = Atomic.get t.mutex
+
+  let mutex_for_base_dir base_dir =
+    Atomic.get (mutex_for_base_dir ~base_dir ~injected:None)
+
+  let registry_size () =
+    Stdlib.Mutex.protect mutex_registry_mu (fun () ->
+      Hashtbl.length mutex_registry)
+end

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -341,8 +341,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
-  | Oas.Event_bus.TurnReady _ ->
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256


### PR DESCRIPTION
## Summary
Two independent build breaks on main blocking local `dune build`:

**1. `lib/dated_jsonl/dated_jsonl.ml`**
Interface declares `module For_testing : sig val mutex : t -> Eio.Mutex.t  val mutex_for_base_dir : string -> Eio.Mutex.t  val registry_size : unit -> int end` (lines 51-62) but the implementation lost the wrapper after the format/rebase commits (`8ae21ab6f`, `d6e74251f`).

```
Error: The implementation lib/dated_jsonl/dated_jsonl.ml
       does not match the interface lib/dated_jsonl/dated_jsonl.mli:
       The module For_testing is required but not provided
```

Re-added as thin wrappers — the underlying file-scope `mutex_registry` and `mutex_for_base_dir` are already present in the `.ml`, so this is purely a missing facade.

**2. `lib/oas_event_bridge.ml:344`**
`| Oas.Event_bus.TurnReady _ -> None` was matched twice (line 211 and again at line 344). Second arm is unreachable, fails under `(env (dev (flags (:standard -warn-error +8))))`:

```
Error (warning 11 [redundant-case]): this match case is unused.
```

Dropped the duplicate.

## Why now
Both blocks `dune build` from a clean checkout. Self-review per `@~/me/agents/best-programmer/AGENT.md`: surgical, ~13 LoC, no behavior change.

## Test plan
- [x] `dune build @check` — green
- [x] `dune build bin/main_eio.exe` — green
- [ ] CI required checks
- [ ] No PR conflict (race-checked: `#10758` open but unrelated scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)