### PR TITLE
refactor(design-system): swap harness-health 3 search inputs to TextInput (CS22)

### DIFF
--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -7,6 +7,7 @@ import { navigate } from '../router'
 import { formatTimeAgo, formatTimestampKo } from '../lib/format-time'
 import { SurfaceCard } from './common/card'
 import { CopyIdButton } from './common/copy-id-button'
+import { TextInput } from './common/input'
 import { SectionCap } from './common/section-cap'
 import { StatusChip } from './common/status-chip'
 import { StatusDot } from './common/status-dot'
@@ -365,13 +366,13 @@ export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
   return html`
     <div class="space-y-2">
       <div class="flex justify-end">
-        <input
+        <${TextInput}
           type="search"
+          class="min-w-40 max-w-65 flex-1 !px-2 !py-1 !text-2xs"
           value=${query.value}
           placeholder="task / agent / gate / cascade 필터"
-          aria-label="판정 필터"
+          ariaLabel="판정 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0
@@ -412,13 +413,13 @@ export function PreCompactList({ section }: { section: HarnessSignalSection<PreC
   return html`
     <div class="space-y-2">
       <div class="flex justify-end">
-        <input
+        <${TextInput}
           type="search"
+          class="min-w-40 max-w-65 flex-1 !px-2 !py-1 !text-2xs"
           value=${query.value}
           placeholder="keeper / trigger / model / strategy 필터"
-          aria-label="압축 이벤트 필터"
+          ariaLabel="압축 이벤트 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0
@@ -464,13 +465,13 @@ export function HandoffList({ section }: { section: HarnessSignalSection<Handoff
   return html`
     <div class="space-y-2">
       <div class="flex justify-end">
-        <input
+        <${TextInput}
           type="search"
+          class="min-w-40 max-w-65 flex-1 !px-2 !py-1 !text-2xs"
           value=${query.value}
           placeholder="keeper / model / trace_id 필터"
-          aria-label="세대 교체 필터"
+          ariaLabel="세대 교체 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0


### PR DESCRIPTION
## Summary

CS series input sweep #3 — harness-health-sections **3 search inputs batch**.

## 변경

`dashboard/src/components/harness-health-sections.ts`:
1. 판정 필터 `<input type="search">` → `<${TextInput} type="search">`
2. 압축 이벤트 필터 → `<${TextInput} type="search">`
3. 세대 교체 필터 → `<${TextInput} type="search">`

세 input 모두 동일 class+variant → 일괄 batch swap. `!px-2 !py-1 !text-2xs` override로 dense layout 보존.

palette: design-system 토큰 호환.

## 검증

- pnpm typecheck: green
- pnpm test src/components/harness-health: **129/129 pass**

## CS series progress

- buttons: 30 swap (CS1-9)
- selects: 10 swap (CS10-19)
- inputs: CS20 (1) → CS21 (1) → CS22 (3) = 5 누적

🤖 Generated with [Claude Code](https://claude.com/claude-code)
