### PR TITLE
feat(design-system): TextInput supports testId + autoFocus props (CS23)

### DIFF
--- a/dashboard/src/components/common/input.test.ts
+++ b/dashboard/src/components/common/input.test.ts
@@ -99,6 +99,16 @@ describe('TextInput', () => {
     render(html`<${TextInput} class="extra-hook" />`, container)
     expect(container.querySelector('input')!.className).toContain('extra-hook')
   })
+
+  it('testId renders as data-testid (E2E target without coupling to placeholder text)', () => {
+    render(html`<${TextInput} testId="search-filter" />`, container)
+    expect(container.querySelector('input')!.getAttribute('data-testid')).toBe('search-filter')
+  })
+
+  it('autoFocus=true sets the autofocus attribute', () => {
+    render(html`<${TextInput} autoFocus=${true} />`, container)
+    expect(container.querySelector('input')!.hasAttribute('autofocus')).toBe(true)
+  })
 })
 
 describe('TextArea', () => {

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -23,6 +23,12 @@ interface TextInputProps {
   name?: string
   ariaLabel?: string
   autoComplete?: string
+  /** Rendered as `data-testid` so E2E / unit tests can target this
+      <input> without coupling to placeholder text (which may be i18n'd).
+      Mirrors the same prop on Select. */
+  testId?: string
+  /** Native autofocus — applied on initial mount. */
+  autoFocus?: boolean
   onInput?: (e: Event) => void
   onKeyDown?: (e: KeyboardEvent) => void
 }
@@ -38,6 +44,8 @@ export function TextInput({
   name,
   ariaLabel,
   autoComplete,
+  testId,
+  autoFocus,
   onInput,
   onKeyDown,
 }: TextInputProps) {
@@ -53,6 +61,8 @@ export function TextInput({
       name=${name}
       aria-label=${ariaLabel}
       autocomplete=${autoComplete}
+      data-testid=${testId}
+      autofocus=${autoFocus}
       onInput=${onInput}
       onKeyDown=${onKeyDown}
     />


### PR DESCRIPTION
## Summary

**Canonical 확장** (CS4 ActionButton.pressed의 후속). TextInput에 `testId` + `autoFocus` 추가. 다수의 inline `<input>` swap PR을 unblock.

## 변경

### `dashboard/src/components/common/input.ts`

- TextInput Props에 `testId?: string` 추가 → `data-testid=${testId}` 렌더
- TextInput Props에 `autoFocus?: boolean` 추가 → `autofocus=${autoFocus}` 렌더
- testId는 Select canonical 의 동일 prop과 mirror

```tsx
interface TextInputProps {
  // ...
  testId?: string  // ✨ E2E target without coupling to placeholder
  autoFocus?: boolean  // ✨ Native autofocus
}
```

### `dashboard/src/components/common/input.test.ts`

- `testId renders as data-testid` 신규
- `autoFocus=true sets the autofocus attribute` 신규

## 동기

input swap이 다음 파일들에서 막힘:
- `governance.ts` data-testid="keeper-hitl-approval-filter"
- `verification-requests-panel.ts` autofocus
- 기타 4+ 파일

이 두 prop이 추가되면 단일 swap PR로 일괄 처리 가능.

## 검증

- pnpm typecheck: green
- pnpm test src/components/common/input: **16/16 pass** (12 → 14 + 2 신규)

## CS series progress

- buttons: 30 swap (CS1-9) + ActionButton.pressed (CS4)
- selects: 10 swap (CS10-19)
- inputs: 5 swap (CS20-22)
- canonical 확장 (this): TextInput.testId + autoFocus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
