### PR TITLE
fix(worktree-live-context): migrate single_flight_gate to Eio.Mutex (#10682 EDEADLK fix)

### DIFF
--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -84,70 +84,63 @@ type status_cache_entry = {
 let status_cache : (string, status_cache_entry) Hashtbl.t =
   Hashtbl.create 4
 
-(* Stdlib.Mutex: status_cache may be accessed from keepers on different
-   domains concurrently. *)
-let status_cache_mu = Stdlib.Mutex.create ()
+(* Eio.Mutex: shared between fibers on the same domain.  Stdlib.Mutex with
+   PTHREAD_MUTEX_ERRORCHECK raises Sys_error("Resource deadlock avoided")
+   when a second fiber on the same OS thread tries to acquire while the
+   first is suspended (e.g. waiting on git status fork+exec).  Eio.Mutex
+   suspends the second fiber instead, letting the first complete first.
+   Ref: #10682 EDEADLK at line 165 captured by #10707 diag hook. *)
+let status_cache_mu = Eio.Mutex.create ()
 
 let status_cache_ttl_sec () =
   Env_config_core.get_float ~default:5.0 "MASC_WORKTREE_STATUS_CACHE_TTL_S"
 
 let status_cache_lookup repo_root ~now ~ttl =
   if ttl <= 0.0 then None
-  else begin
-    Stdlib.Mutex.lock status_cache_mu;
-    Fun.protect
-      ~finally:(fun () -> Stdlib.Mutex.unlock status_cache_mu)
-      (fun () ->
-        match Hashtbl.find_opt status_cache repo_root with
-        | Some entry when now -. entry.refreshed_at <= ttl ->
-            Some entry.lines
-        | _ -> None)
-  end
+  else
+    Eio.Mutex.use_rw ~protect:true status_cache_mu (fun () ->
+      match Hashtbl.find_opt status_cache repo_root with
+      | Some entry when now -. entry.refreshed_at <= ttl ->
+          Some entry.lines
+      | _ -> None)
 
 let status_cache_store repo_root lines ~now ~ttl =
-  if ttl > 0.0 then begin
-    Stdlib.Mutex.lock status_cache_mu;
-    Fun.protect
-      ~finally:(fun () -> Stdlib.Mutex.unlock status_cache_mu)
-      (fun () ->
-        Hashtbl.replace status_cache repo_root { lines; refreshed_at = now })
-  end
+  if ttl > 0.0 then
+    Eio.Mutex.use_rw ~protect:true status_cache_mu (fun () ->
+      Hashtbl.replace status_cache repo_root { lines; refreshed_at = now })
 
 let clear_status_cache_for_tests () =
-  Stdlib.Mutex.lock status_cache_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock status_cache_mu)
-    (fun () -> Hashtbl.clear status_cache)
+  Eio.Mutex.use_rw ~protect:true status_cache_mu (fun () ->
+    Hashtbl.clear status_cache)
 
-(* Single-flight gates: per-repo Stdlib.Mutex serialising concurrent cache
+(* Single-flight gates: per-repo Eio.Mutex serialising concurrent cache
    misses so only one [git status] runs per repo at a time.  Without this
    gate N keepers + dashboard fibers hitting an expired cache simultaneously
    each fork+exec git, multiplying the I/O contention that was already
    making git status take 10s+ on a 13-line working tree (#9632).  After
    the winner refreshes the cache, followers re-check and reuse it.
-   Pattern: Go [singleflight.Group], Caffeine loading cache. *)
-let single_flight_registry : (string, Stdlib.Mutex.t) Hashtbl.t =
+   Pattern: Go [singleflight.Group], Caffeine loading cache.
+
+   Originally Stdlib.Mutex; migrated to Eio.Mutex after #10682 captured an
+   EDEADLK backtrace at line 165 — a second fiber on the same domain
+   re-locked while the holder was suspended in run_git_capture_lines. *)
+let single_flight_registry : (string, Eio.Mutex.t) Hashtbl.t =
   Hashtbl.create 4
 
-let single_flight_registry_mu = Stdlib.Mutex.create ()
+let single_flight_registry_mu = Eio.Mutex.create ()
 
 let single_flight_gate repo_root =
-  Stdlib.Mutex.lock single_flight_registry_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock single_flight_registry_mu)
-    (fun () ->
-      match Hashtbl.find_opt single_flight_registry repo_root with
-      | Some mu -> mu
-      | None ->
-          let mu = Stdlib.Mutex.create () in
-          Hashtbl.replace single_flight_registry repo_root mu;
-          mu)
+  Eio.Mutex.use_rw ~protect:true single_flight_registry_mu (fun () ->
+    match Hashtbl.find_opt single_flight_registry repo_root with
+    | Some mu -> mu
+    | None ->
+        let mu = Eio.Mutex.create () in
+        Hashtbl.replace single_flight_registry repo_root mu;
+        mu)
 
 let clear_single_flight_for_tests () =
-  Stdlib.Mutex.lock single_flight_registry_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock single_flight_registry_mu)
-    (fun () -> Hashtbl.clear single_flight_registry)
+  Eio.Mutex.use_rw ~protect:true single_flight_registry_mu (fun () ->
+    Hashtbl.clear single_flight_registry)
 
 let current_status_lines_uncached ~repo_root =
   run_git_capture_lines ~workdir:repo_root
@@ -162,21 +155,18 @@ let current_status_lines ~repo_root =
   | Some lines -> lines
   | None ->
       let gate = single_flight_gate repo_root in
-      Stdlib.Mutex.lock gate;
-      Fun.protect
-        ~finally:(fun () -> Stdlib.Mutex.unlock gate)
-        (fun () ->
-          (* Double-check: the caller that won the race may have refreshed
-             the cache while we were blocked on [gate]. *)
-          match
-            status_cache_lookup repo_root ~now:(Time_compat.now ()) ~ttl
-          with
-          | Some lines -> lines
-          | None ->
-              let lines = current_status_lines_uncached ~repo_root in
-              status_cache_store repo_root lines
-                ~now:(Time_compat.now ()) ~ttl;
-              lines)
+      Eio.Mutex.use_rw ~protect:true gate (fun () ->
+        (* Double-check: the caller that won the race may have refreshed
+           the cache while we were blocked on [gate]. *)
+        match
+          status_cache_lookup repo_root ~now:(Time_compat.now ()) ~ttl
+        with
+        | Some lines -> lines
+        | None ->
+            let lines = current_status_lines_uncached ~repo_root in
+            status_cache_store repo_root lines
+              ~now:(Time_compat.now ()) ~ttl;
+            lines)
 
 let state_dir ~repo_root =
   Filename.concat


### PR DESCRIPTION
## Summary

- Issue #10682 captured an EDEADLK at `lib/worktree_live_context.ml:165` via the diagnostic hook added in #10707.
- Migrated all three mutexes in this module from `Stdlib.Mutex` → `Eio.Mutex`. Pattern matches #10649 (8 keeper hot-paths already migrated).
- Closes the most-frequent EDEADLK call site (24/62 today's events): `keeper_board_get` tool handler.

## Backtrace captured (#10682 trigger)

```
Raised by primitive operation at Masc_mcp__Worktree_live_context.current_status_lines in file "lib/worktree_live_context.ml", line 165, characters 6-28
Called from Masc_mcp__Worktree_live_context.capture_change_block in file "lib/worktree_live_context.ml", line 223, characters 18-49
Called from Masc_mcp__Keeper_tools_oas.make_keeper_tool_handler.(fun) in file "lib/keeper/keeper_tools_oas.ml", lines 282-283, characters 12-62
```

## Why EDEADLK fires

`Stdlib.Mutex` on macOS uses pthread with `PTHREAD_MUTEX_ERRORCHECK`. A second fiber on the same OS thread (single domain) trying to lock is reported by pthread as same-thread re-entry (pthread cannot distinguish fibers) → `Sys_error("Resource deadlock avoided")`. The actual scenario: fiber A holds the gate, suspends inside `run_git_capture_lines` (fork+exec git status); fiber B from a separate keeper tool call wakes, tries to acquire same gate → EDEADLK.

## Why Eio.Mutex is correct

`Eio.Mutex` is fiber-aware. The second fiber suspends until the holder yields/releases, instead of being mis-classified as a reentrant lock attempt.

## Trade-off

Same-fiber re-entry would now hang forever instead of raising EDEADLK. Verified the three call sites do not recurse into `capture_change_block` within a single fiber turn:
- `lib/keeper/keeper_turn.ml:257`
- `lib/keeper/keeper_tools_oas.ml:282`
- `lib/keeper/keeper_world_observation.ml:742`

## Diagnostic provenance

- #10707 added `Prometheus.last_deadlock_backtrace` (this PR consumes it).
- Issue #10682 cycle-5 comment hypothesised `Prometheus.metrics_mutex` as epicenter; actual captured backtrace lands in `worktree_live_context`, not in Prometheus.

## Test plan

- [ ] CI lint/test green
- [ ] Post-merge: monitor `/private/tmp/masc-server.log` (or `~/me/.masc/logs/system_log_<DATE>.jsonl`) for `tool keeper_board_get EDEADLK backtrace` — expect 0 events.
- [ ] EDEADLK count from #10707 diag hook should drop to 0 for `worktree_live_context` call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)