### PR TITLE
feat(dashboard): localize 3 visible strings (round-46)

### DIFF
--- a/dashboard/src/components/fsm-hub-health-panels.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.ts
@@ -50,7 +50,7 @@ export function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapsho
             <${Flag} label="guardrail" on=${m.auto_rules.guardrail_stop} tone="warn" />
             <span
               class="text-3xs text-[var(--color-fg-disabled)] cursor-help"
-              title="Goal drift: 0 = keeper is on-target; higher = keeper output is diverging from its declared goal. Values above ~0.5 typically trigger the guardrail."
+              title="Goal drift: 0 = 키퍼가 목표와 정렬됨; 높을수록 키퍼 출력이 선언된 goal 에서 벗어남. 약 0.5 이상이면 보통 guardrail 발동."
             >drift ${m.auto_rules.goal_drift.toFixed(2)}</span>
           </div>
           ${m.auto_rules.guardrail_reason ? html`

--- a/dashboard/src/components/goals/task-activity-list.test.ts
+++ b/dashboard/src/components/goals/task-activity-list.test.ts
@@ -117,7 +117,7 @@ describe('TaskActivityList', () => {
     await waitFor(() => {
       expect(screen.getByTestId('json-viewer-card')).toBeInTheDocument()
     })
-    expect(screen.getByTestId('json-viewer-card')).toHaveAttribute('data-title', 'Result')
+    expect(screen.getByTestId('json-viewer-card')).toHaveAttribute('data-title', '결과')
     const text = screen.getByTestId('json-viewer-card').textContent ?? ''
     expect(text).toContain('"ok":true')
   })
@@ -146,7 +146,7 @@ describe('TaskActivityList', () => {
       expect(screen.getByTestId('json-viewer-card')).toBeInTheDocument()
     })
     const card = screen.getByTestId('json-viewer-card')
-    expect(card).toHaveAttribute('data-title', 'Detail')
+    expect(card).toHaveAttribute('data-title', '세부')
     const text = card.textContent ?? ''
     expect(text).toContain('keeper-sojin-agent')
     expect(text).toContain('turn_completed')

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -103,12 +103,12 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
           ` : null}
           ${event.toolResult != null ? html`
             <div class="mb-1">
-              <${JsonViewerCard} data=${parseJsonLikeData(event.toolResult)} title="Result" />
+              <${JsonViewerCard} data=${parseJsonLikeData(event.toolResult)} title="결과" />
             </div>
           ` : null}
           ${event.toolArgs == null && event.toolResult == null && event.detail && Object.keys(event.detail).length > 0 ? html`
             <div class="mb-1">
-              <${JsonViewerCard} data=${event.detail} title="Detail" />
+              <${JsonViewerCard} data=${event.detail} title="세부" />
             </div>
           ` : null}
           ${event.error ? html`<div class="text-2xs text-[var(--bad-light)] mt-1">${event.error}</div>` : null}


### PR DESCRIPTION
## Summary

대시보드 라운드 46 — Goal drift 긴 tooltip + task-activity JsonViewerCard 제목 2종 한국어화.

| File | Element | Before | After |
|---|---|---|---|
| fsm-hub-health-panels.ts:53 | tooltip (Goal drift) | "Goal drift: 0 = keeper is on-target; higher = keeper output is diverging from its declared goal. Values above ~0.5 typically trigger the guardrail." | "Goal drift: 0 = 키퍼가 목표와 정렬됨; 높을수록 키퍼 출력이 선언된 goal 에서 벗어남. 약 0.5 이상이면 보통 guardrail 발동." |
| task-activity-list.ts:106 | JsonViewerCard title | Result | 결과 |
| task-activity-list.ts:111 | JsonViewerCard title | Detail | 세부 |

## Test sync (atomic — data-title attribute family)

\`task-activity-list.test.ts\` 의 2 assertion 동기 변경:

\`\`\`diff
-    expect(screen.getByTestId('json-viewer-card')).toHaveAttribute('data-title', 'Result')
+    expect(screen.getByTestId('json-viewer-card')).toHaveAttribute('data-title', '결과')

-    expect(card).toHaveAttribute('data-title', 'Detail')
+    expect(card).toHaveAttribute('data-title', '세부')
\`\`\`

\`data-title\` attribute 패턴은 round-32 에서 처음 발견 (Args 회피), round-37 에서 fallback ariaLabel 적용, round-38 에서 caller-provided ariaLabel + 6 assertion sync. 이번 round-46 은 같은 family 의 \`title\` prop 변경 + assertion sync.

## 후속 라운드 후보 — Args cross-coupling

\`task-activity-list.ts:101\` 의 \`title=\"Args\"\` 는 \`task-activity-list.test.ts:77\` 와 \`session-trace-entry.test.ts:81\` **양쪽** 에서 \`data-title\` assertion. 한 PR 에서 양 surface (\`task-activity-list.ts\` + \`session-trace-entry.ts\`) + 2 test file 동시 변경 필요. 다음 라운드에서 atomic 처리.

## 보존 (도메인 용어)

| 단어 | 이유 |
|---|---|
| Goal | OKR/Goal-tree 도메인 (한국어 \"목표\" 와 의미 분리) |
| guardrail | safety mechanism 도메인 용어 |
| drift | metric 측정 단위 (visible chip text 는 \`drift ${num.toFixed(2)}\` 그대로) |

## Test fixture coupling 검증

| 단어 | Test 등장 | 처리 |
|---|---|---|
| Goal drift | -- | ❌ no couple |
| Result | \`task-activity-list.test.ts:120\` data-title | ✅ atomic test sync (이번 PR) |
| Detail | \`task-activity-list.test.ts:149\` data-title | ✅ atomic test sync (이번 PR) |

## 라운드 누적 (23-46)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-44 | -- | MERGED | 139 |
| 45 | #10757 | Draft | 6 |
| 46 | this | Draft | **3** |

누적 chips ≈ **205**.

## Why Draft

#10645 (vitest infra) 미해결. test sync 가 PR 에 포함되어 vitest 복구 즉시 검증 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)