### PR TITLE
fix(keeper-sandbox): map Network_inherit to host network (#10431)

### DIFF
--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -201,7 +201,14 @@ let docker_label_args ?ttl_sec ~base_path ~keeper_name ~container_kind ~network_
 
 let docker_network_args = function
   | Keeper_types.Network_none -> ([ "--network"; "none" ], "none")
-  | Keeper_types.Network_inherit -> ([], "inherit")
+  | Keeper_types.Network_inherit ->
+      (* Host network — matches the variant name and the docstring on
+         [keeper_types_profile.ml:20-24] (git/gh dispatcher upgrade with
+         read-only mounts of ~/.config/gh / ~/.gitconfig). Empty args
+         (docker default) gives bridge mode (NAT, no host egress) which
+         broke `git clone` / `gh push` for keepers running under this
+         profile. See #10431. *)
+      ([ "--network"; "host" ], "inherit")
 
 let docker_nofile_args () =
   let limit = Env_config_keeper.KeeperSandbox.nofile_limit () in

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -468,8 +468,8 @@ let test_docker_network_args_follow_masc_policy () =
   let args_inherit, label_inherit =
     Keeper_sandbox_runtime.docker_network_args Keeper_types.Network_inherit
   in
-  Alcotest.(check (list string)) "network inherit omits docker flag"
-    [] args_inherit;
+  Alcotest.(check (list string)) "network inherit uses host network (#10431)"
+    [ "--network"; "host" ] args_inherit;
   Alcotest.(check string) "network inherit label" "inherit" label_inherit
 
 let test_docker_nofile_args_follow_config () =


### PR DESCRIPTION
## Summary

Fixes #10431. `Network_inherit` mapped to `[]` (no `--network` flag), which means docker default = bridge mode (NAT'd, no host egress). The variant is named "inherit" and its docstring at `lib/keeper/keeper_types_profile.ml:20-24` says it pairs with read-only mounts of `~/.config/gh` / `~/.gitconfig` for git/gh operations — which is meaningless without host egress.

Evidence the historical intent was host network:
- `network_mode_of_string` accepts `"host"` as a deprecated alias for `Network_inherit` (line 94-98).
- Docstring describes "git/gh dispatcher upgrades the container to [Network_inherit] with read-only mounts of ~/.config/gh and ~/.gitconfig" — only useful with host network.
- Issue #10431 traces show masc-improver Egress blocked across 10+ events.
- This explains the operator complaint "sandbox docker 사용이 올바르게 안되고 clone, 및 pr 올리는거 자체가 진행이 안되는" — clone/push hit bridge NAT and fail to reach GitHub.

## Change

`lib/keeper/keeper_sandbox_runtime.ml`:
```ocaml
| Keeper_types.Network_inherit -> ([], "inherit")
```
→
```ocaml
| Keeper_types.Network_inherit ->
    (* Host network — matches the variant name and the docstring on
       [keeper_types_profile.ml:20-24] (git/gh dispatcher upgrade with
       read-only mounts of ~/.config/gh / ~/.gitconfig). Empty args
       (docker default) gives bridge mode (NAT, no host egress) which
       broke `git clone` / `gh push` for keepers running under this
       profile. See #10431. *)
    ([ "--network"; "host" ], "inherit")
```

Test updated to assert `["--network"; "host"]` instead of `[]` (it was previously asserting the broken behavior — a "test for what the code does, not what it should do" anti-pattern).

## Verification

- `dune build --root .` clean
- `dune runtest test/test_keeper_docker_read.exe` — 32/32 tests green, including the updated `test_docker_network_args_follow_masc_policy`

## Security note

`--network host` exposes the container to host's network stack. Keepers using `Network_inherit` were always intended to have credential access (`~/.config/gh` mounted) and the docstring already implies host-level network. PR #9743 already established `host` as the explicit choice for `issue_king`. This change makes the implicit `Network_inherit` semantics consistent with that established pattern.

Operators wanting full network isolation should explicitly set `network_mode = "none"` (`Network_none`).

## Test plan

- [x] Build clean (`dune build --root .`)
- [x] Tests green (`test_keeper_docker_read.exe` 32/32)
- [ ] CI green
- [ ] Live smoke: rebuild masc-improver sandbox after merge, verify `git clone` works inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
