### PR TITLE
feat(claim): auto-provision sandbox worktree for docker keepers (task-103)

### DIFF
--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -215,3 +215,25 @@ let tool_assigned_fn
 let task_completion_path_observed_fn
   : (path:string -> contract_state:string -> agent_name:string -> unit) Atomic.t
   = Atomic.make (fun ~path:_ ~contract_state:_ ~agent_name:_ -> ())
+
+(** task-103: Auto-provision a sandbox worktree on successful task claim.
+
+    [Coord_task.claim_task_r] flips a task to [Claimed] but does not create
+    the per-task git worktree the keeper subprocess will need (the LLM is
+    expected to invoke [masc_worktree_create] explicitly, but in practice
+    keepers often skip that step and immediately try to [cd] into the
+    worktree path inside docker, which fails with [fatal: not a git
+    repository: .../keeper-<agent>-<task>]).
+
+    This hook is called best-effort right after a successful claim. The
+    consumer (lib/keeper) decides whether to actually provision based on
+    keeper [sandbox_profile] (only [Docker] keepers benefit; local-host
+    keepers operate on the project root directly). Failures are logged but
+    do not block the claim — claim semantics stay independent of sandbox
+    state.
+
+    Wired in [lib/keeper/keeper_runtime.ml] at startup; the default no-op
+    keeps [masc_coord] free of a direct dependency on [masc_mcp]. *)
+let claim_post_provision_fn
+  : (Coord_utils_backend_setup.config -> agent_name:string -> task_id:string -> unit) Atomic.t
+  = Atomic.make (fun _ ~agent_name:_ ~task_id:_ -> ())

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -991,6 +991,16 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
                   ~to_status:
                     (Types.Claimed { assignee = agent_name; claimed_at = now_iso () })
                   ());
+           (* task-103: best-effort auto-provision a sandbox worktree for
+              docker keepers. The hook itself decides whether to act based
+              on keeper sandbox_profile; failures inside the hook are
+              logged by the hook implementation and must not block the
+              claim. *)
+           (try
+              (Atomic.get Coord_hooks.claim_post_provision_fn) config ~agent_name ~task_id
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | _ -> ());
            Ok (Printf.sprintf "✅ %s claimed %s" agent_name task_id)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -12,6 +12,38 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
   Sse.set_clock clock;
   (* Wire stop_keeper hook so zombie GC can terminate keeper fibers *)
   Atomic.set Coord_hooks.stop_keeper_fn Keeper_keepalive.stop_keepalive;
+  (* task-103: auto-provision a per-task sandbox worktree on successful
+     claim for keepers running with sandbox_profile=Docker. Best-effort —
+     failures are logged and the claim succeeds regardless, keeping claim
+     semantics decoupled from sandbox state. Local-profile keepers work on
+     the project root directly and do not need provisioning. *)
+  Atomic.set Coord_hooks.claim_post_provision_fn
+    (fun config ~agent_name ~task_id ->
+      let outcome =
+        match Keeper_identity.keeper_name_from_agent_name agent_name with
+        | None -> "skip_not_keeper"
+        | Some keeper_name ->
+          (match Keeper_meta_store.read_meta config keeper_name with
+           | Error _ | Ok None -> "skip_no_meta"
+           | Ok (Some meta) ->
+             (match meta.Keeper_meta_contract.sandbox_profile with
+              | Keeper_types.Local -> "skip_local"
+              | Keeper_types.Docker ->
+                (match Task_sandbox.create ~config ~task_id ~agent_name () with
+                 | Ok _sandbox ->
+                   Log.Misc.info
+                     "[claim_auto_provision] keeper=%s task=%s worktree provisioned"
+                     keeper_name task_id;
+                   "created"
+                 | Error msg ->
+                   Log.Misc.warn
+                     "[claim_auto_provision] keeper=%s task=%s worktree provisioning failed: %s"
+                     keeper_name task_id msg;
+                   "error")))
+      in
+      Prometheus.inc_counter "masc_keeper_claim_auto_provision_total"
+        ~labels:[ ("outcome", outcome); ("agent_name", agent_name) ]
+        ());
   (* Shared Agent_sdk Event_bus used as the runtime transport between subsystems. *)
   let event_bus = Oas.Event_bus.create () in
   (* Eio fiber isolation: each subsystem runs in its own fiber.

--- a/test/dune
+++ b/test/dune
@@ -109,6 +109,7 @@
         test_keeper_runtime_toml
         test_keeper_tool_policy_config
         test_coord_worktree_policy_path
+        test_claim_post_provision_hook
         test_keeper_toml_config_validation
         test_keeper_id
         test_exec_core
@@ -264,6 +265,7 @@
           test_keeper_runtime_toml
           test_keeper_tool_policy_config
           test_coord_worktree_policy_path
+          test_claim_post_provision_hook
           test_keeper_toml_config_validation
           test_keeper_id
           test_exec_core

--- a/test/test_claim_post_provision_hook.ml
+++ b/test/test_claim_post_provision_hook.ml
@@ -1,0 +1,93 @@
+(** Regression test for [Coord_hooks.claim_post_provision_fn] dispatch.
+
+    task-103: a successful [Coord.claim_task_r] must invoke the
+    post-provision hook with the same agent_name + task_id, so the keeper
+    layer can auto-create a sandbox worktree for docker keepers. The hook
+    is best-effort — claim must succeed even when the hook raises. *)
+
+open Alcotest
+open Masc_mcp
+module CH = Coord_hooks
+
+let with_test_env f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let tmp_dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_claim_hook_%d_%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1000.)))
+  in
+  Unix.mkdir tmp_dir 0o755;
+  let config = Coord.default_config tmp_dir in
+  let _ = Coord.init config ~agent_name:(Some "claude") in
+  let prev = Atomic.get CH.claim_post_provision_fn in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set CH.claim_post_provision_fn prev;
+      let _ = Coord.reset config in
+      try Unix.rmdir tmp_dir with _ -> ())
+    (fun () -> f config)
+
+let test_hook_invoked_on_successful_claim () =
+  with_test_env @@ fun config ->
+  let calls = ref [] in
+  Atomic.set CH.claim_post_provision_fn (fun _ ~agent_name ~task_id ->
+      calls := (agent_name, task_id) :: !calls);
+  let _ = Coord.add_task config ~title:"task-103 t1" ~priority:1 ~description:"" in
+  (match
+     Coord.claim_task_r config ~agent_name:"claude" ~task_id:"task-001" ()
+   with
+   | Ok _ -> ()
+   | Error e ->
+     fail (Printf.sprintf "claim failed: %s" (Types.show_masc_error e)));
+  match !calls with
+  | [ (agent_name, task_id) ] ->
+    check string "hook agent_name" "claude" agent_name;
+    check string "hook task_id" "task-001" task_id
+  | other ->
+    failf "expected 1 hook call, got %d" (List.length other)
+
+let test_hook_failure_does_not_block_claim () =
+  with_test_env @@ fun config ->
+  Atomic.set CH.claim_post_provision_fn (fun _ ~agent_name:_ ~task_id:_ ->
+      raise (Failure "synthetic worktree provisioning failure"));
+  let _ = Coord.add_task config ~title:"task-103 t2" ~priority:1 ~description:"" in
+  match
+    Coord.claim_task_r config ~agent_name:"claude" ~task_id:"task-001" ()
+  with
+  | Ok msg ->
+    check bool "claim succeeded despite hook failure" true
+      (Astring.String.is_infix ~affix:"claimed" msg)
+  | Error e ->
+    failf "claim must succeed even if hook raises; got: %s"
+      (Types.show_masc_error e)
+
+let test_hook_not_invoked_on_already_claimed () =
+  with_test_env @@ fun config ->
+  let _ = Coord.add_task config ~title:"task-103 t3" ~priority:1 ~description:"" in
+  (match
+     Coord.claim_task_r config ~agent_name:"claude" ~task_id:"task-001" ()
+   with
+   | Ok _ -> ()
+   | Error e ->
+     fail (Printf.sprintf "first claim failed: %s" (Types.show_masc_error e)));
+  let calls = ref 0 in
+  Atomic.set CH.claim_post_provision_fn (fun _ ~agent_name:_ ~task_id:_ ->
+      incr calls);
+  let _ = Coord.claim_task_r config ~agent_name:"claude" ~task_id:"task-001" () in
+  check int "hook does not fire for already_mine repeat" 0 !calls
+
+let () =
+  Alcotest.run "claim_post_provision_fn dispatch"
+    [
+      ( "claim hook",
+        [
+          test_case "fires on successful first claim" `Quick
+            test_hook_invoked_on_successful_claim;
+          test_case "does not block claim on hook failure" `Quick
+            test_hook_failure_does_not_block_claim;
+          test_case "skips already-claimed repeat" `Quick
+            test_hook_not_invoked_on_already_claimed;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Keepers running with \`sandbox_profile=Docker\` need a per-task git worktree at \`<keeper-playground>/repos/<repo>/.worktrees/keeper-<agent>-<task>\` before docker exec can run \`git\` / \`keeper_bash\` inside it. Today the worktree is created only when the LLM explicitly invokes \`masc_worktree_create\`; in practice keepers skip that step and the docker exec immediately fails with \`fatal: not a git repository: .../keeper-<agent>-<task>\` (evidence: \`~/me/.masc/logs/system_log_2026-04-25.jsonl\`, sangsu / masc-improver / issue_king all hit this independently).

This PR adds a best-effort post-claim hook that auto-creates the worktree for docker keepers right after a successful \`Coord.claim_task_r\`, decoupling claim from explicit \`masc_worktree_create\` calls.

## Why this matters (root cause for task-103)

User reports (2026-04-26): "오케이 아직도 docker 생긴 다음 아무도 거기서 작업 하지 않음." Three sibling defects were diagnosed:

| Sibling | Symptom | Status |
|---|---|---|
| task-102 | \`coord_worktree.ml\` reads policy from wrong path → empty \`allowed_orgs\` | Merged in #10693 |
| **task-103 (this PR)** | claim does not provision worktree → docker exec \`fatal: not a git repository\` | This PR |
| task-104 | LLM mis-infers \`git_clone\` owner from local path | Pending |

## Design

- New hook \`Coord_hooks.claim_post_provision_fn : config -> agent_name:string -> task_id:string -> unit\` (default no-op).
- \`Coord_task.claim_task_r\` invokes it inside the \`Claimed_ok\` branch, *after* status is persisted and observers fire. Wrapped in \`try ... with _ -> ()\` so any hook failure is invisible to claim callers; \`Eio.Cancel.Cancelled\` is re-raised.
- Wiring lives in \`lib/server/server_bootstrap_loops.ml\` (where \`Keeper_meta_store\` + \`Task_sandbox\` are already accessible). Wiring in \`lib/coord.ml\` would form a \`Coord → Task_sandbox → Coord\` dep cycle.
- The wired implementation:
  1. Resolves \`agent_name → keeper_name\` via \`Keeper_identity.keeper_name_from_agent_name\`. Non-keeper agents are skipped (outcome=\`skip_not_keeper\`).
  2. Reads keeper meta. Missing meta → outcome=\`skip_no_meta\`.
  3. \`sandbox_profile = Local\` → outcome=\`skip_local\`.
  4. \`sandbox_profile = Docker\` → calls \`Task_sandbox.create\`. \`Ok\` logs info + outcome=\`created\`; \`Error\` logs warn + outcome=\`error\`.
  5. Increments \`masc_keeper_claim_auto_provision_total{outcome,agent_name}\` so operators can see fleet behaviour at a glance.

## Why the hook does not block claim

Claim is the *coordination* event. Sandbox provisioning is *infrastructure*. Coupling them tightly would mean a transient docker / git failure could leave the backlog in an inconsistent state where the task is unclaimable but no worktree exists. By making the hook best-effort:
- Claim semantics stay deterministic and unchanged for non-docker keepers.
- Existing tests still pass.
- Failure modes degrade gracefully — old behaviour (LLM re-invokes \`masc_worktree_create\`) still works.

## Changes

| File | Why |
|---|---|
| \`lib/coord/coord_hooks.ml\` | New \`claim_post_provision_fn\` Atomic with no-op default |
| \`lib/coord/coord_task.ml\` | Best-effort hook invocation in \`claim_task_r\` \`Claimed_ok\` branch |
| \`lib/server/server_bootstrap_loops.ml\` | Wires the hook to \`Task_sandbox.create\` for docker keepers + Prometheus counter |
| \`test/test_claim_post_provision_hook.ml\` | New regression: dispatch on success, claim survives hook failure, no re-fire on already_mine |
| \`test/dune\` | Wires the new test in both \`tests\` lists |

## Test plan

- [x] \`dune build\` of full \`lib/\` clean
- [x] \`dune exec test/test_claim_post_provision_hook.exe\` — 3/3 OK (hook fires once on first claim, claim survives raising hook, no re-fire on already_mine)
- [ ] After merge + server restart: tail \`~/me/.masc/logs/system_log_$(date +%Y-%m-%d).jsonl\` and confirm \`masc-improver\` (and any other docker keeper that claims) gets a fresh \`[claim_auto_provision]...worktree provisioned\` line on first claim, and \`fatal: not a git repository: .../keeper-<agent>-<task>\` errors stop appearing.
- [ ] \`masc_keeper_claim_auto_provision_total\` shows non-zero \`created\` count after a claim.

## Out of scope

- task-104 (URL parser) — separate PR.
- Supervisor / fiber crash propagation (Leak 9, PR-M) — keeper supervisor still does not auto-restart zombie keepers; that is orthogonal to claim provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)