### PR TITLE
feat(dashboard): localize Args → 인자 cross-file atomic (round-47)

### DIFF
--- a/dashboard/src/components/goals/task-activity-list.test.ts
+++ b/dashboard/src/components/goals/task-activity-list.test.ts
@@ -74,7 +74,7 @@ describe('TaskActivityList', () => {
     if (!firstBlock) return
     const text = firstBlock.textContent ?? ''
     expect(text).toContain('*literal* `ticks`')
-    expect(firstBlock).toHaveAttribute('data-title', 'Args')
+    expect(firstBlock).toHaveAttribute('data-title', '인자')
   })
 
   it('passes object args into the structured viewer when expanded', async () => {

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -98,7 +98,7 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
         <div class="px-3 pb-2 pt-1 ml-7">
           ${event.toolArgs != null ? html`
             <div class="mb-1">
-              <${JsonViewerCard} data=${parseJsonLikeData(event.toolArgs)} title="Args" />
+              <${JsonViewerCard} data=${parseJsonLikeData(event.toolArgs)} title="인자" />
             </div>
           ` : null}
           ${event.toolResult != null ? html`

--- a/dashboard/src/components/session-trace/session-trace-entry.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.test.ts
@@ -78,7 +78,7 @@ describe('SessionTraceEntry', () => {
     // Args card is always rendered via JsonViewerCard
     const cards = screen.getAllByTestId('json-viewer-card')
     expect(cards).toHaveLength(1)
-    expect(cards[0]?.getAttribute('data-title')).toBe('Args')
+    expect(cards[0]?.getAttribute('data-title')).toBe('인자')
 
     // Plain-text errors render through ResultViewer <pre>, not JsonViewerCard
     const errorPre = container.querySelector('pre')

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -241,8 +241,8 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
     <div class="mt-2 space-y-2">
       ${event.toolArgs ? html`
         <div>
-          <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">Args</div>
-          <${JsonViewerCard} title="Args" data=${parseJsonLikeData(event.toolArgs)} />
+          <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">인자</div>
+          <${JsonViewerCard} title="인자" data=${parseJsonLikeData(event.toolArgs)} />
         </div>
       ` : null}
       ${resultText ? html`


### PR DESCRIPTION
## Summary

대시보드 라운드 47 — \`Args\` cross-file atomic localization. round-32 부터 deferred 됐던 surface 처리 완료.

| File | Line | Element | Before | After |
|---|---|---|---|---|
| task-activity-list.ts | 101 | JsonViewerCard title | Args | 인자 |
| session-trace-entry.ts | 244 | visible heading <div> | Args | 인자 |
| session-trace-entry.ts | 245 | JsonViewerCard title | Args | 인자 |

## Test sync (atomic — data-title attribute family)

| Test file | Line | Before | After |
|---|---|---|---|
| task-activity-list.test.ts | 77 | toHaveAttribute('data-title', 'Args') | '인자' |
| session-trace-entry.test.ts | 81 | getAttribute('data-title') === 'Args' | '인자' |

## Round-32 → round-47 progression (deferred 후속)

\`data-title\` attribute pattern 의 단계적 처리:

| Round | Surface | 결과 |
|---|---|---|
| **round-32** | Args 발견, test-coupled (cross-file) → defer | identification |
| **round-37** | copyable-code fallback ariaLabel + test sync | learning |
| **round-38** | telemetry-unified caller-provided ariaLabel + 6 assertion sync | scaling |
| **round-46** | task-activity-list 'Result'/'Detail' (single test file) + 2 sync | partial |
| **round-47 (this)** | Args cross-file atomic (2 ts + 2 test ts) | **completion** |

총 5 round 에 걸쳐 같은 family pattern 의 risk-managed rollout. 단일 PR 에 cross-file 변경을 일찍 시도했으면 #10645 (vitest infra) 미해결 상태에서 회귀 검증 불가능했을 risk 회피.

## 보존 (identifier 유지)

| 식별자 | 위치 | 이유 |
|---|---|---|
| \`toolArgs\` | task-activity-list.ts, session-trace-entry.ts | TypeScript 필드명 |
| \`formatArgs\` / \`sharedFormatArgs\` | session-trace-entry.ts | 함수명 |
| \`event.toolArgs\` | 다수 | data path |

## Test fixture coupling 검증 — 100% atomic sync

| 단어 | Test 위치 | 처리 |
|---|---|---|
| Args | \`task-activity-list.test.ts:77\` data-title | ✅ atomic test sync |
| Args | \`session-trace-entry.test.ts:81\` data-title | ✅ atomic test sync |

## 라운드 누적 (23-47)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-44 | -- | MERGED | 139 |
| 45 | #10757 | Draft | 6 |
| 46 | #10768 | Draft | 3 |
| 47 | this | Draft | **3 (Args x3)** |

누적 chips ≈ **208**.

## Why Draft

#10645 (vitest infra) 미해결. cross-file atomic test sync 가 PR 에 포함되어 vitest 복구 즉시 양쪽 test file 동시 검증 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)