### PR TITLE
refactor(design-system): swap sidecar-log-viewer keyword filter to TextInput (CS25)

### DIFF
--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -11,6 +11,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { ActionButton } from './common/button'
+import { TextInput } from './common/input'
 import { SkeletonText } from './common/skeleton'
 
 interface LogResponse {
@@ -214,12 +215,12 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
         ? html`
             <div class="mb-2 flex flex-wrap items-center gap-2">
               <${LevelPills} connectorId=${connectorId} active=${entry.level} />
-              <input
+              <${TextInput}
                 type="search"
+                class="min-w-0 flex-1 !px-2 !py-0.5 !text-2xs"
                 value=${entry.keyword}
                 placeholder="keyword 필터 (case-insensitive)"
-                class="min-w-0 flex-1 rounded border border-[var(--white-8)] bg-[var(--color-bg-page)] px-2 py-0.5 text-2xs text-[var(--color-fg-primary)] focus:border-[var(--accent-1)] focus:outline-none"
-                data-log-keyword
+                ariaLabel="sidecar log keyword 필터"
                 onInput=${(ev: Event) => {
                   const v = (ev.target as HTMLInputElement).value
                   setEntry(connectorId, { keyword: v })


### PR DESCRIPTION
## Summary

CS series input sweep #5 — sidecar-log-viewer keyword 필터.

## 변경

`dashboard/src/components/sidecar-log-viewer.ts`:
- inline `<input type="search">` → `<${TextInput} type="search">`
- ariaLabel 추가 (a11y)
- **미사용 `data-log-keyword` 속성 제거** (codebase 어디서도 참조 0건)

palette: design-system 토큰. `--color-bg-page` vs TextInput `--white-4` minor 차이 (둘 다 DS).

## 검증

- pnpm typecheck: green
- pnpm test src/components/sidecar-log-viewer: 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
