### PR TITLE
fix: restore dated_jsonl For_testing + remove TurnReady redundant case

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -358,3 +358,13 @@ let prune t ~days =
   end
 
 (* Duplicate count_entries removed — canonical definition at line 225 *)
+
+module For_testing = struct
+  let mutex t = Atomic.get t.mutex
+
+  let mutex_for_base_dir = mutex_for_base_dir
+
+  let registry_size () =
+    Stdlib.Mutex.protect mutex_registry_mu (fun () ->
+      Hashtbl.length mutex_registry)
+end

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -341,8 +341,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
-  | Oas.Event_bus.TurnReady _ ->
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256


### PR DESCRIPTION
## Summary
- Restore `For_testing` module in `dated_jsonl.ml` — PR #10739 changed `t.mutex` to `Atomic.t` but removed the module from `.ml` while leaving it in `.mli`, breaking `dune build @check`
- Remove redundant `TurnReady _` match arm from `oas_event_bridge.ml` — PR #10664 already handles this variant, causing warning 11 [redundant-case] under `warn-error +a`

## Root cause
Two independent regressions from recent merges that both break main-branch build.

## Test plan
- [x] `dune build @check` passes (CI will verify)
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)