### PR TITLE
feat(dashboard): localize 12 mermaid subgraph + activity-group fallback labels (round-48)

### DIFF
--- a/dashboard/src/components/activity-graph-groups.ts
+++ b/dashboard/src/components/activity-graph-groups.ts
@@ -233,19 +233,19 @@ function groupTitle(category: ActivityCategory, events: ActivityGraphTimelineEve
   const subjectId = groupSubjectId(events)
   const actor = groupActor(events)
   const latest = events[events.length - 1]
-  if (!latest) return 'Activity'
+  if (!latest) return '활동'
 
   switch (category) {
     case 'task':
-      return payloadString(latest, ['task_title', 'title']) || subjectId || 'Task activity'
+      return payloadString(latest, ['task_title', 'title']) || subjectId || '태스크 활동'
     case 'session':
-      return subjectId || payloadString(latest, ['session_id', 'operation_id']) || 'Session activity'
+      return subjectId || payloadString(latest, ['session_id', 'operation_id']) || '세션 활동'
     case 'message':
-      return actor ? `${actor} message burst` : 'Message burst'
+      return actor ? `${actor} 메시지 다발` : '메시지 다발'
     case 'board':
-      return payloadString(latest, ['title']) || subjectId || 'Board activity'
+      return payloadString(latest, ['title']) || subjectId || '보드 활동'
     case 'governance':
-      return subjectId || 'Governance activity'
+      return subjectId || '거버넌스 활동'
     case 'lifecycle':
       return actor || eventKindLabel(latest.kind)
     default:

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -34,7 +34,7 @@ import { MermaidGraph } from './common/mermaid-graph'
 // Labels displayed to the operator stay bare for readability.
 const MERMAID_COMPOSITE: string = `flowchart TB
   %% ─ KSM (Lifecycle, 12 states) ──────────────────────────
-  subgraph KSM ["Lifecycle · KSM"]
+  subgraph KSM ["라이프사이클 · KSM"]
     direction LR
     ksm_offline["Offline"] --> ksm_running["Running"]
     ksm_running --> ksm_failing["Failing"]
@@ -56,7 +56,7 @@ const MERMAID_COMPOSITE: string = `flowchart TB
   end
 
   %% ─ KTC (Turn cycle, 5 states) ──────────────────────────
-  subgraph KTC ["Turn · KTC"]
+  subgraph KTC ["턴 · KTC"]
     direction LR
     ktc_idle["idle"] --> ktc_prompting["prompting"]
     ktc_prompting --> ktc_executing["executing"]
@@ -67,7 +67,7 @@ const MERMAID_COMPOSITE: string = `flowchart TB
   end
 
   %% ─ KDP (Decision pipeline, 4 states) ───────────────────
-  subgraph KDP ["Decision · KDP"]
+  subgraph KDP ["결정 · KDP"]
     direction LR
     kdp_undecided["undecided"] --> kdp_guard_ok["guard_ok"]
     kdp_undecided --> kdp_gate_rejected["gate_rejected"]
@@ -85,7 +85,7 @@ const MERMAID_COMPOSITE: string = `flowchart TB
   end
 
   %% ─ KMC (Memory compaction, 3 states) ───────────────────
-  subgraph KMC ["Compaction · KMC"]
+  subgraph KMC ["압축 · KMC"]
     direction LR
     kmc_accumulating["accumulating"] --> kmc_compacting["compacting"]
     kmc_compacting --> kmc_done["done"]

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -18,7 +18,7 @@ import { openAgentDetail } from './agent-detail-state'
 const REFRESH_MS = 30_000
 
 const ARCHITECTURE_FLOW = `graph LR
-    subgraph Keeper["Keeper Turn"]
+    subgraph Keeper["키퍼 턴"]
       K1[LLM 응답 생성] --> K2["[STATE] 파싱"]
       K2 --> K3{STATE 있음?}
     end
@@ -29,7 +29,7 @@ const ARCHITECTURE_FLOW = `graph LR
     M3 --> F1[(institution_episodes.jsonl)]
     F1 -->|cap 500| F1
 
-    subgraph Task["Task Completion"]
+    subgraph Task["태스크 완료"]
       T1[keeper_task_done] --> T2[transition_task_r]
       T2 --> T3[Done_action 분기]
     end


### PR DESCRIPTION
## Summary

대시보드 라운드 48 — Mermaid FSM/architecture flowchart subgraph 제목 + activity-graph fallback label 12종 한국어화.

## composite-fsm-flowchart (Mermaid FSM diagram, 4)

| Subgraph | Before | After |
|---|---|---|
| KSM | Lifecycle · KSM | 라이프사이클 · KSM |
| KTC | Turn · KTC | 턴 · KTC |
| KDP | Decision · KDP | 결정 · KDP |
| KMC | Compaction · KMC | 압축 · KMC |
| ~~KCL~~ | Cascade · KCL | (보존 — MASC 도메인 용어) |
| ~~KCB~~ | Circuit breaker · KCB | (보존 — 표준 엔지니어링 용어) |

## memory-subsystems (Mermaid architecture diagram, 2)

| Subgraph | Before | After |
|---|---|---|
| Keeper | Keeper Turn | 키퍼 턴 |
| Task | Task Completion | 태스크 완료 |
| ~~Dashboard~~ | Dashboard | (보존 — 제품명 + identifier) |

## activity-graph-groups groupTitle fallbacks (6)

| Category | Before | After |
|---|---|---|
| (없음 latest) | Activity | 활동 |
| task | Task activity | 태스크 활동 |
| session | Session activity | 세션 활동 |
| message | \`${actor} message burst\` / Message burst | \`${actor} 메시지 다발\` / 메시지 다발 |
| board | Board activity | 보드 활동 |
| governance | Governance activity | 거버넌스 활동 |

## 보존 (FSM state identifier)

\`composite-fsm-flowchart.ts\` 의 inner state names (Offline/Running/Failing/Overflowed/Compacting/HandingOff/Paused/Draining/Stopped/Dead/Crashed/Restarting 등) 모두 보존:
- \`FsmState\` TypeScript type 으로 매핑
- string mismatch 시 fail-loud (memory \`feedback_priority-audit-lessons.md\`)
- backend OCaml 의 fsm 모듈과 cross-language identifier

## Test fixture coupling 검증

| 단어 | Test 등장 | 충돌 |
|---|---|---|
| Lifecycle / Turn / Decision / Compaction | -- | ❌ 0 |
| Keeper Turn / Task Completion | -- | ❌ 0 |
| Activity / Task activity / Session activity / Message burst / Board activity / Governance activity | -- | ❌ 0 |

## 라운드 누적 (23-48)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-44 | -- | MERGED | 139 |
| 45-47 | #10757/#10768/#10772 | Draft | 12 |
| 48 | this | Draft | **12** |

누적 chips ≈ **220**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)