### PR TITLE
fix(session): start actor consumer fiber on server bootstrap

### DIFF
--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -529,6 +529,12 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
       base_path
   in
   let registry = Session.create () in
+  (* Start the registry's actor consumer fiber. Without this, every
+     [Session.*] helper that awaits a reply (register, restore_from_disk,
+     check_rate_limit, push_message, push_notification, get_session,
+     get_sessions) hangs forever — the mailbox has no consumer.
+     Missed when #10664 introduced the actor model. *)
+  Session.start_loop registry ~sw;
   (* Wire notification harness: subscription events → session queues *)
   Subscriptions.set_session_push_fn (fun event ->
     Session.push_notification_to_active_agents registry ~event


### PR DESCRIPTION
## 요약

#10664 가 session registry를 Eio actor model로 전환하면서 consumer fiber 시작 호출을 누락했습니다. 결과: `Session.*` helper 중 mailbox 응답을 기다리는 모든 호출이 영원히 hang.

## 증상

서버 시작 시 5초마다 무한히:

```
[Keeper] autoboot: waiting for lazy startup tasks to finish before keeper boot
[restore_sessions, reconcile_active_agents, recover_running_sessions,
 prompt_bootstrap, telemetry_warmup, tool_metrics_restore,
 keeper_history_migration, jsonl_prune, keeper_checkpoint_prune]
```

순차 실행되는 lazy task의 **첫 단계 `restore_sessions`** 가 `Session.restore_from_disk` → mailbox에 `Restore_from_disk_req` push → consumer 없음 → `Eio.Promise.await` 영원 hang. 이후 8개 task + keeper autoboot 모두 대기.

대시보드 결과: `KSM=Running 이지만 live turn 없음 · last receipt: degraded_retry` — keeper가 부팅 못 했으니 `current_turn_observation` 절대 채워지지 않음 (`is_live = current_turn_observation <> None` `lib/keeper/keeper_composite_observer.ml:416`).

## 영향 받는 helper

`mailbox`에 reply promise를 넣고 `await`하는 모든 호출:
- `Session.register`
- `Session.restore_from_disk`
- `Session.check_rate_limit`
- `Session.get_rate_limit_status`
- `Session.push_message`
- `Session.push_notification`
- `Session.get_session`
- `Session.get_sessions`

## Root cause

`lib/mcp_server.ml:531` `create_state_eio`:

```ocaml
let registry = Session.create () in
(* (*** missing: Session.start_loop registry ~sw ***) *)
Subscriptions.set_session_push_fn ...
```

`Session.start_loop` (lib/session.ml:265) 는 `#10664` 에서 신규 추가됐지만, 호출 위치가 어디에도 없음 (`rg "Session\.start_loop" lib/ test/` 결과 0건). 같은 PR이 추가한 `McpSessionStore.start_loop` 만 사용 중.

## Fix

```ocaml
let registry = Session.create () in
Session.start_loop registry ~sw;  (* ← 추가 *)
```

1줄. mailbox consumer fiber를 서버 switch에 부착.

## 검증

- `dune build lib/.masc_mcp.objs/byte/masc_mcp__Mcp_server.cmi` 성공
- repo-wide `dune build @check` 는 `lib/tool_unified.ml` 의 별개 main break (Atomic 래핑 json 값) 로 실패. 이 break는 main이 이미 깨진 상태이며 별도 fix-forward 진행 중.

## Memory references

- `feedback_no-lifecycle-invasion-from-masc` — actor 도입 시 lifecycle 시작 누락 회귀 패턴
- `feedback_check-existing-prs-before-fix` — 기존 open PR 검색 완료, 같은 fix 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)