### PR TITLE
feat(coord): generate .mli files for public signatures and resolve warning 34 (#106)

### DIFF
--- a/lib/coord/coord_agent.mli
+++ b/lib/coord/coord_agent.mli
@@ -1,0 +1,34 @@
+(** coord_agent inferred mli **)
+
+open Types
+include module type of Coord_utils
+include module type of Coord_state
+
+
+
+val get_agents_status : config ->
+           [> `Assoc of
+                (string *
+                 [> `Int of int
+                  | `List of
+                      [> `Assoc of (string * Yojson.Safe.t) list ] list ])
+                list ]
+val register_capabilities : config -> agent_name:string -> capabilities:string list -> string
+val update_agent_r : config ->
+           agent_name:string ->
+           ?status:string ->
+           ?capabilities:string list -> unit -> string Types.masc_result
+val find_agents_by_capability : config ->
+           capability:string ->
+           [> `Assoc of
+                (string *
+                 [> `Int of int
+                  | `List of
+                      [> `Assoc of
+                           (string *
+                            [> `List of [> `String of string ] list
+                             | `String of string ])
+                           list ]
+                      list
+                  | `String of string ])
+                list ]

--- a/lib/coord/coord_backlog.mli
+++ b/lib/coord/coord_backlog.mli
@@ -1,0 +1,14 @@
+(** coord_backlog inferred mli **)
+
+open Types
+open Coord_utils
+
+
+
+val backlog_recovery_path : Coord_utils_backend_setup.config -> string
+val decode_backlog : path:string ->
+           Yojson.Safe.t -> (Types_core.backlog, string) result
+val read_backlog_r : Coord_utils_backend_setup.config ->
+           (Types_core.backlog, string) result
+val read_backlog : Coord_utils_backend_setup.config -> Types_core.backlog
+val write_backlog : Coord_utils_backend_setup.config -> Types_core.backlog -> unit

--- a/lib/coord/coord_bootstrap.mli
+++ b/lib/coord/coord_bootstrap.mli
@@ -1,0 +1,9 @@
+(** coord_bootstrap inferred mli **)
+
+open Types
+open Coord_utils
+
+
+
+val default_room_state : Coord_utils_backend_setup.config -> Types_core.room_state
+val ensure_room_bootstrap : Coord_utils_backend_setup.config -> unit

--- a/lib/coord/coord_broadcast.mli
+++ b/lib/coord/coord_broadcast.mli
@@ -1,0 +1,20 @@
+(** coord_broadcast inferred mli **)
+
+open Types
+open Coord_utils
+
+
+
+val emit_message_activity : Coord_utils_backend_setup.config ->
+           from_agent:string ->
+           content:string ->
+           mention:string option ->
+           ?session_id:string ->
+           ?operation_id:string ->
+           ?worker_run_id:string ->
+           ?evidence_refs:string list -> unit -> unit
+val broadcast_channel : Coord_utils_backend_setup.config -> string
+val on_broadcast_mention : (string option -> unit) ref
+val broadcast : ?trace_context:string ->
+           Coord_utils_backend_setup.config ->
+           from_agent:string -> content:string -> string

--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -1,0 +1,59 @@
+(** coord_hooks inferred mli **)
+
+open Types
+
+type activity_entity = { kind: string; id: string }
+type agent_lifecycle_event =
+  | Lifecycle_join
+  | Lifecycle_rejoin
+  | Lifecycle_leave
+
+val force_release_task_fn : (Coord_utils_backend_setup.config ->
+            agent_name:string ->
+            task_id:string -> unit -> string Types.masc_result)
+           Atomic.t
+val activity_emit_fn : (Coord_utils_backend_setup.config ->
+            actor:activity_entity ->
+            ?subject:activity_entity ->
+            kind:string ->
+            payload:Yojson.Safe.t -> tags:string list -> unit -> unit)
+           Atomic.t
+val agent_economy_earn_fn : (base_path:string -> agent_name:string -> reason:string -> unit)
+           Atomic.t
+val stop_keeper_fn : (string -> unit) Atomic.t
+val relation_on_leave_fn : (leaving_agent:string -> active_agents:string list -> unit)
+           Atomic.t
+val relation_on_task_done_fn : (assignee:string -> active_agents:string list -> unit) Atomic.t
+val hebbian_on_task_done_fn : (Coord_utils_backend_setup.config ->
+            assignee:string -> active_agents:string list -> unit)
+           Atomic.t
+val hebbian_on_task_cancelled_fn : (Coord_utils_backend_setup.config ->
+            agent_name:string -> active_agents:string list -> unit)
+           Atomic.t
+val agent_lifecycle_event_to_string : agent_lifecycle_event -> string
+val observe_agent_lifecycle_fn : (Coord_utils_backend_setup.config ->
+            agent_id:string ->
+            event:agent_lifecycle_event -> details:Yojson.Safe.t -> unit)
+           Atomic.t
+val observe_task_transition_fn : (Coord_utils_backend_setup.config ->
+            agent_name:string ->
+            task_id:string ->
+            transition:Types_core.task_action ->
+            details:Yojson.Safe.t -> unit)
+           Atomic.t
+val cleanup_board_artifacts_fn : (unit -> int) Atomic.t
+val on_task_mutation_fn : (unit -> unit) Atomic.t
+val subscribe_messages_fn : (subscriber:string -> unit) Atomic.t
+val fsm_drift_observer_fn : (variant:string -> force:bool -> agent_name:string -> unit)
+           Atomic.t
+val distributed_lock_acquire_failed_fn : (key:string -> attempts:int -> unit) Atomic.t
+val tool_assigned_fn : (agent_id:string ->
+            profile:string ->
+            ?preset:string ->
+            tool_list:string list ->
+            ?allow_set:string list ->
+            ?deny_set:string list ->
+            ?config_hash:string -> ?reason:string -> unit -> string)
+           Atomic.t
+val task_completion_path_observed_fn : (path:string -> contract_state:string -> agent_name:string -> unit)
+           Atomic.t

--- a/lib/coord/coord_identity.mli
+++ b/lib/coord/coord_identity.mli
@@ -1,0 +1,10 @@
+(** coord_identity inferred mli **)
+
+open Coord_utils
+
+
+
+val generate_session_id : unit -> string
+val get_hostname : unit -> string option
+val get_tty : unit -> string option
+val resolve_agent_name : Coord_utils_backend_setup.config -> string -> string

--- a/lib/coord/coord_init.mli
+++ b/lib/coord/coord_init.mli
@@ -1,0 +1,15 @@
+(** coord_init inferred mli **)
+
+open Types
+open Coord_utils
+open Coord_state
+open Coord_broadcast
+
+
+
+val init : Coord_utils_backend_setup.config -> agent_name:'a option -> string
+val pause : Coord_utils_backend_setup.config ->
+           by:string -> reason:string -> unit
+val resume : Coord_utils_backend_setup.config ->
+           by:string -> [> `Already_running | `Resumed ]
+val reset : Coord_utils_backend_setup.config -> string

--- a/lib/coord/coord_lifecycle.mli
+++ b/lib/coord/coord_lifecycle.mli
@@ -1,0 +1,24 @@
+(** coord_lifecycle inferred mli **)
+
+open Types
+open Coord_utils
+open Coord_state
+open Coord_broadcast
+
+
+
+val agent_parse_error_snapshot : agent_name:string ->
+           agent_file:string ->
+           [> `Assoc of (string * [> `Null | `String of string ]) list ]
+val join : Coord_utils_backend_setup.config ->
+           agent_name:string ->
+           ?agent_type_override:string option ->
+           capabilities:string list ->
+           ?pid:int option ->
+           ?hostname:string option ->
+           ?tty:string option ->
+           ?worktree:string option ->
+           ?parent_task:string option ->
+           ?keeper_name:string option ->
+           ?keeper_id:string option -> unit -> string
+val leave : Coord_utils_backend_setup.config -> agent_name:string -> string

--- a/lib/coord/coord_portal.mli
+++ b/lib/coord/coord_portal.mli
@@ -1,0 +1,30 @@
+(** coord_portal inferred mli **)
+
+open Types
+open Coord_utils
+
+
+
+val portals_dir : Coord_utils_backend_setup.config -> string
+val a2a_tasks_dir : Coord_utils_backend_setup.config -> string
+val gen_a2a_task_id : unit -> string
+val with_two_file_locks : Coord_utils_backend_setup.config ->
+           string -> string -> (unit -> 'a) -> 'a
+val portal_open_r : Coord_utils_backend_setup.config ->
+           agent_name:string ->
+           target_agent:string ->
+           initial_message:string option -> string Types.masc_result
+val portal_send_r : Coord_utils_backend_setup.config ->
+           agent_name:string -> message:string -> string Types.masc_result
+val get_portal_target : Coord_utils_backend_setup.config ->
+           agent_name:string -> string option
+val portal_close : Coord_utils_backend_setup.config -> agent_name:string -> string
+val portal_status : Coord_utils_backend_setup.config ->
+           agent_name:string ->
+           [> `Assoc of
+                (string *
+                 [> `Assoc of
+                      (string * [> `Int of int | `String of string ]) list
+                  | `Int of int
+                  | `String of string ])
+                list ]

--- a/lib/coord/coord_state.mli
+++ b/lib/coord/coord_state.mli
@@ -1,0 +1,41 @@
+(** coord_state inferred mli **)
+
+open Types
+open Coord_utils
+
+
+
+val default_room_state : Coord_utils_backend_setup.config -> Types_core.room_state
+val ensure_room_bootstrap : Coord_utils_backend_setup.config -> unit
+val generate_session_id : unit -> string
+val get_hostname : unit -> string option
+val get_tty : unit -> string option
+val resolve_agent_name : Coord_utils_backend_setup.config -> string -> string
+val task_id_to_int : string -> int option
+val read_archive_task_ids : Coord_utils_backend_setup.config -> int list
+val append_archive_tasks : Coord_utils_backend_setup.config -> Types_core.task list -> unit
+val next_task_number : Coord_utils_backend_setup.config -> Types_core.backlog -> int
+val read_backlog_r : Coord_utils_backend_setup.config ->
+           (Types_core.backlog, string) result
+val read_backlog : Coord_utils_backend_setup.config -> Types_core.backlog
+val write_backlog : Coord_utils_backend_setup.config -> Types_core.backlog -> unit
+val non_empty_string_opt : string option -> string option
+val normalized_string_list : string list -> string list
+val recover_active_agent_name : [> `Assoc of (string * Yojson.Safe.t) list | `String of string ] ->
+           string option
+val recover_room_state : Coord_utils_backend_setup.config ->
+           Yojson.Safe.t -> Types_core.room_state
+val write_state : Coord_utils_backend_setup.config -> Types_core.room_state -> unit
+val read_state : Coord_utils_backend_setup.config -> Types_core.room_state
+val update_state : Coord_utils_backend_setup.config ->
+           (Types_core.room_state -> Types_core.room_state) ->
+           Types_core.room_state
+val next_seq : Coord_utils_backend_setup.config -> int
+val is_paused : Coord_utils_backend_setup.config -> bool
+val pause_info : Coord_utils_backend_setup.config ->
+           (string option * string option * string option) option
+val heartbeat_timeout_seconds : float
+val parse_iso_time_opt : string -> float option
+val parse_iso_time : string -> float
+val is_zombie_agent : agent_name:string -> string -> bool
+val take : int -> 'a list -> 'a list

--- a/lib/coord/coord_status.mli
+++ b/lib/coord/coord_status.mli
@@ -1,0 +1,9 @@
+(** coord_status inferred mli **)
+
+open Types
+open Coord_utils
+open Coord_state
+
+
+
+val status : Coord_utils_backend_setup.config -> string

--- a/lib/coord/coord_task_schedule.mli
+++ b/lib/coord/coord_task_schedule.mli
@@ -1,0 +1,50 @@
+(** coord_task_schedule inferred mli **)
+
+open Types
+include module type of Coord_utils
+include module type of Coord_state
+
+type verification_claim_state =
+  [ `Pending | `Assigned | `Passed | `Rejected ]
+
+val task_status_label : Types_core.task_status -> string
+val task_is_claim_pool_candidate : Types_core.task -> bool
+val task_is_primary_claim_pool_candidate : Types_core.task -> bool
+val task_is_soft_reclaim_candidate : Types_core.task -> bool
+val verification_claim_state_of_status : Coord_verification_store.request_status ->
+           [> `Assigned | `Passed | `Pending | `Rejected ]
+val latest_verification_status_by_task : config ->
+           (string, float * [> `Assigned | `Passed | `Pending | `Rejected ])
+           Hashtbl.t
+val verification_blocks_claim : (string, 'a * [< `Assigned | `Passed | `Pending | `Rejected ])
+           Hashtbl.t -> Types_core.task -> bool
+val task_required_tools : Types_core.task -> string list
+val string_list_contains : string list -> string -> bool
+val required_tools_allowed : ?agent_tool_names:string list -> string list -> bool
+val underscore_name : string -> string
+val hyphen_name : string -> string
+val keeper_name_from_agent_name : string -> string option
+val agent_record_keeper_name : config -> agent_name:string -> string option
+val keeper_receipt_candidate_names : config -> agent_name:string -> string list
+val directory_exists : string -> bool
+val directory_entries : string -> string list
+val jsonl_files_under : string -> string list
+val last_nonempty_line : string -> string option
+val latest_json_in_receipt_dir : string -> Yojson.Safe.t option
+val json_member_path : string list -> Yojson.Safe.t -> Yojson.Safe.t
+val json_raw_string_path : string list -> Yojson.Safe.t -> string option
+val json_string_path : string list -> Yojson.Safe.t -> string option
+val receipt_sort_key : Yojson.Safe.t -> string
+val latest_execution_receipt_json : config -> agent_name:string -> Yojson.Safe.t option
+val json_string_list : string -> Yojson.Safe.t -> string list
+val latest_receipt_blocks_required_tool_claim : config -> agent_name:string -> required_tools:string list -> bool
+val agent_current_task_matches_backlog : Types_core.backlog -> agent_name:string -> string -> bool
+val reconcile_agent_current_task_with_backlog : config -> agent_name:string -> Types_core.backlog -> unit
+val claim_next_r : config ->
+           agent_name:string ->
+           ?agent_tool_names:string list ->
+           ?exclude_task_ids:string list ->
+           ?task_filter:(Types_core.task -> bool) ->
+           unit -> Types_core.claim_next_result
+val claim_next : config -> agent_name:string -> string
+val release_stale_claims : config -> ttl_seconds:float -> (string * string) list


### PR DESCRIPTION
Resolves #106 (MASC Task 106)

### Description
This PR addresses the lack of explicit interface definitions (.mli files) in the `lib/coord` module to improve encapsulation and type safety.

- Created 12 missing `.mli` files in `lib/coord/` (`coord_agent`, `coord_backlog`, `coord_bootstrap`, `coord_broadcast`, `coord_hooks`, `coord_identity`, `coord_init`, `coord_lifecycle`, `coord_portal`, `coord_state`, `coord_status`, `coord_task_schedule`).
- Inferred accurate signatures directly from compiler output to ensure 100% preservation of existing public signatures.
- Transformed `include` directives into `include module type of` where appropriate to safely inherit signatures without re-exporting internal implementations.
- Ensured warning 34 (unused type/value) is suppressed natively via strict, tailored public signatures.