### PR TITLE
fix(cascade): add DashScope arm to cascade_config (unblock CI lint)

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -43,7 +43,7 @@ let headers_with_auth ~(kind : Llm_provider.Provider_config.provider_kind) ~api_
         ("x-api-key", api_key)
         :: ("anthropic-version", "2023-06-01")
         :: base
-    | OpenAI_compat | Ollama | Gemini | Glm | Claude_code ->
+    | OpenAI_compat | Ollama | Gemini | Glm | Claude_code | DashScope ->
         ("Authorization", "Bearer " ^ api_key) :: base
     | Gemini_cli | Kimi_cli | Codex_cli -> []
 


### PR DESCRIPTION
## Summary

Fix-forward for the partial-match cascade triggered by OAS commit `96491352` adding `DashScope` to `provider_kind`. All masc-mcp PRs are currently failing CI Lint with warning 8 partial-match at `lib/cascade/cascade_config.ml:41-48`.

## Pattern

`memory feedback_variant-add-partial-match-cascade` — 1-line variant arm; never revert when upstream feature is wanted.

## Why DashScope joins the OpenAI-compat Bearer arm

DashScope is Alibaba Cloud's OpenAI-compatible API for Qwen models. OAS itself groups it with `Ollama | OpenAI_compat | DashScope` at:
- `provider_bridge.ml:72`
- `provider.ml:567`

So a Bearer auth header is the right grouping in masc-mcp's `headers_with_auth`.

## CI Lint failure (current main)

```
File "lib/cascade/cascade_config.ml", lines 41-48, characters 7-45:
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
  Here is an example of a case that is not matched: DashScope
```

## Other potential partial-match sites (not yet flagged by CI; may need follow-up)

- `lib/provider_adapter.ml` (3 sites at 252, 1401, 1548)
- `lib/oas_worker_exec_transport.ml:1243`
- `lib/oas_worker_named.ml:634`
- `lib/provider_tool_support.ml:45,52`
- `lib/keeper/keeper_usage_trust.ml:34`

This PR addresses the one site that lint actually flagged. Follow-up sweep PR(s) will handle others if CI surfaces them.

## Test plan

- [ ] CI Lint job green on this PR
- [ ] Then any other red PRs should green up after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)