### PR TITLE
fix(build): unbreak main — Atomic.get on Tool_registry stats + drop duplicate For_testing

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -373,14 +373,3 @@ module For_testing = struct
 end
 
 (* Duplicate count_entries removed — canonical definition at line 225 *)
-
-module For_testing = struct
-  let mutex (t : t) : Eio.Mutex.t = Atomic.get t.mutex
-
-  let mutex_for_base_dir base_dir : Eio.Mutex.t =
-    Atomic.get (mutex_for_base_dir ~base_dir ~injected:None)
-
-  let registry_size () : int =
-    Stdlib.Mutex.protect mutex_registry_mu (fun () ->
-      Hashtbl.length mutex_registry)
-end

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -37,11 +37,11 @@ let tool_info_to_json (info : tool_info) : Yojson.Safe.t =
     | None -> `Null
     | Some s ->
       `Assoc [
-        ("call_count", `Int (s.call_count));
-        ("success_count", `Int (s.success_count));
-        ("failure_count", `Int (s.failure_count));
-        ("last_called_at", `Float (s.last_called_at));
-        ("total_duration_ms", `Int (s.total_duration_ms));
+        ("call_count", `Int (Atomic.get s.call_count));
+        ("success_count", `Int (Atomic.get s.success_count));
+        ("failure_count", `Int (Atomic.get s.failure_count));
+        ("last_called_at", `Float (Atomic.get s.last_called_at));
+        ("total_duration_ms", `Int (Atomic.get s.total_duration_ms));
       ]
   in
   `Assoc [
@@ -91,7 +91,7 @@ let summary_report () : Yojson.Safe.t =
        in
        `Assoc ([
          ("name", `String name);
-         ("call_count", `Int (stats.Tool_registry.call_count));
+         ("call_count", `Int (Atomic.get stats.Tool_registry.call_count));
        ] @ latency)
      ) top_20));
     ("never_called_count", `Int (List.length never_called));


### PR DESCRIPTION
## P0 — main build broken

Two independent breaks blocking `dune build` on current main HEAD (`759781e9bb`):

### 1. `lib/tool_unified.ml` — missing `Atomic.get` on Tool_registry call_stats

PR #10730 (Jane Street Phase 3 Tool_registry Actor Model) changed `Tool_registry.call_stats` fields from `int` to `int Atomic.t`. `lib/tool_unified.ml` was not swept and reads `s.call_count` etc. directly into `\`Int`. Yojson rejects with:

```
Error: The value stats_json has type
  [> `Assoc of (string * [> `Float of float Atomic.t | `Int of int Atomic.t ]) list | `Null ]
  but an expression was expected of type Yojson.Safe.t
```

6 read sites fixed (5 in `tool_info_to_json`, 1 in `summary_report` top-20 loop) by wrapping with `Atomic.get`.

### 2. `lib/dated_jsonl/dated_jsonl.ml` — duplicate `module For_testing`

Two nearly identical `For_testing` modules at lines 363 and 377. OCaml rejects with `Error: Multiple definition of the module name For_testing`. Likely a leftover from an aborted dedupe (see comment "Duplicate count_entries removed — canonical definition at line 225" between them).

Kept the type-annotated version at line 363, removed duplicate at line 377.

## Verification

- `dune build --root .` exits 0 cleanly with this branch applied
- No behavior change — `Atomic.get` returns the int the field used to hold pre-#10730
- The retained `For_testing` is the more complete one (proper docstring, `Atomic.get` for both `t.mutex` and registry cell)

## Why is this a separate PR

Memory `feedback_parallel-autocoder-race-search-window` — there's an existing PR #10774 attempting the For_testing fix but it's CONFLICTING/DIRTY. This PR fixes both breaks together, scoped to the actual lines that fail to compile. Operator can choose to merge this OR re-resolve #10774; both lead to the same green main.

## Test plan

- [x] Build clean
- [ ] CI green
- [ ] Unblocks v0.18.1 release cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)
