### PR TITLE
fix(build): drop duplicate For_testing + Atomic.get on tool_unified call_stats

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -373,14 +373,3 @@ module For_testing = struct
 end
 
 (* Duplicate count_entries removed — canonical definition at line 225 *)
-
-module For_testing = struct
-  let mutex (t : t) : Eio.Mutex.t = Atomic.get t.mutex
-
-  let mutex_for_base_dir base_dir : Eio.Mutex.t =
-    Atomic.get (mutex_for_base_dir ~base_dir ~injected:None)
-
-  let registry_size () : int =
-    Stdlib.Mutex.protect mutex_registry_mu (fun () ->
-      Hashtbl.length mutex_registry)
-end

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -37,11 +37,11 @@ let tool_info_to_json (info : tool_info) : Yojson.Safe.t =
     | None -> `Null
     | Some s ->
       `Assoc [
-        ("call_count", `Int (s.call_count));
-        ("success_count", `Int (s.success_count));
-        ("failure_count", `Int (s.failure_count));
-        ("last_called_at", `Float (s.last_called_at));
-        ("total_duration_ms", `Int (s.total_duration_ms));
+        ("call_count", `Int (Atomic.get s.call_count));
+        ("success_count", `Int (Atomic.get s.success_count));
+        ("failure_count", `Int (Atomic.get s.failure_count));
+        ("last_called_at", `Float (Atomic.get s.last_called_at));
+        ("total_duration_ms", `Int (Atomic.get s.total_duration_ms));
       ]
   in
   `Assoc [
@@ -91,7 +91,7 @@ let summary_report () : Yojson.Safe.t =
        in
        `Assoc ([
          ("name", `String name);
-         ("call_count", `Int (stats.Tool_registry.call_count));
+         ("call_count", `Int (Atomic.get stats.Tool_registry.call_count));
        ] @ latency)
      ) top_20));
     ("never_called_count", `Int (List.length never_called));


### PR DESCRIPTION
## Summary
Two unrelated build breaks on main. Surgical fix.

### 1. `lib/dated_jsonl/dated_jsonl.ml` — Multiple definition of For_testing

Two PRs added the same module on top of each other:
- PR #10750 (`c2dd18dba`, 2026-04-27 00:11) — canonical add at line 363
- PR #10758 (`aa446db51`, 00:36) — **stale base** re-added the same module at line 377

Result: \`Error: Multiple definition of the module name For_testing\`. Dropped the second copy.

This is the exact stale-base cascade pattern from \`feedback_stale-base-reveals-via-diff-stat-anomaly.md\`.

### 2. `lib/tool_unified.ml` — Atomic.t leaking into Yojson

\`Tool_registry.call_stats\` fields are \`int Atomic.t\` / \`float Atomic.t\`. Six emit-sites emitted them straight into \`\\\`Int (s.call_count)\\\`\` etc., which the type-checker rightly rejects. Added \`Atomic.get\`:

- 5 sites in \`tool_info_to_json\` (call_count, success_count, failure_count, last_called_at, total_duration_ms)
- 1 site in \`summary_report\` top_20 list (\`stats.Tool_registry.call_count\`)

\`Tool_metrics.stats\` fields stay raw int — those sites are unchanged.

## Verification
- [x] \`dune build @check\` — green
- [x] \`dune build bin/main_eio.exe\` — green
- [ ] CI required checks

## Notes
- PR #10774 is OPEN with a redundant For_testing fix (already in main via #10750). Not closing it here, but it's stale and should be closed by its author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)