### PR TITLE
feat(dashboard): localize 5 fallback strings + fleet matrix header (round-49)

### DIFF
--- a/dashboard/src/components/activity-graph-groups.ts
+++ b/dashboard/src/components/activity-graph-groups.ts
@@ -259,14 +259,14 @@ function groupSummary(category: ActivityCategory, events: ActivityGraphTimelineE
 
   switch (category) {
     case 'message':
-      return `${events.length} message events · ${eventPreview(latest)}`
+      return `${events.length} 메시지 이벤트 · ${eventPreview(latest)}`
     case 'board':
-      return `${events.length} board events · ${eventPreview(latest)}`
+      return `${events.length} 보드 이벤트 · ${eventPreview(latest)}`
     case 'lifecycle':
       return eventDetail(latest)
     default: {
       const sequence = sequenceSummary(events)
-      return events.length > 1 ? `${sequence} · ${events.length} events` : sequence
+      return events.length > 1 ? `${sequence} · ${events.length} 이벤트` : sequence
     }
   }
 }

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -841,9 +841,9 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
       class="rounded border border-[var(--white-10)] bg-[var(--white-5)]"
     >
       <header class="flex flex-wrap items-baseline gap-3 border-b border-[var(--white-10)] p-3">
-        <h2 class="text-sm font-semibold text-[var(--color-fg-muted)]">Fleet composite (KSM × KTC × KDP × KCL × KMC × KCB)</h2>
+        <h2 class="text-sm font-semibold text-[var(--color-fg-muted)]">Fleet 통합 (KSM × KTC × KDP × KCL × KMC × KCB)</h2>
         <span class="text-xs text-[var(--color-fg-muted)]0">
-          ${data.count} keepers · updated ${new Date(data.generated_at * 1000).toLocaleTimeString()}
+          키퍼 ${data.count}명 · ${new Date(data.generated_at * 1000).toLocaleTimeString()} 업데이트
         </span>
         <input
           type="search"


### PR DESCRIPTION
## Summary

대시보드 라운드 49 — activity-graph groupSummary fallbacks + fleet matrix header 5종 한국어화.

| File | Element | Before | After |
|---|---|---|---|
| activity-graph-groups.ts:262 | message summary | \`${N} message events · ${preview}\` | \`${N} 메시지 이벤트 · ${preview}\` |
| activity-graph-groups.ts:264 | board summary | \`${N} board events · ${preview}\` | \`${N} 보드 이벤트 · ${preview}\` |
| activity-graph-groups.ts:269 | default summary | \`${seq} · ${N} events\` | \`${seq} · ${N} 이벤트\` |
| fleet-fsm-matrix.ts:844 | h2 heading | Fleet composite (KSM × KTC × KDP × KCL × KMC × KCB) | Fleet 통합 (KSM × KTC × KDP × KCL × KMC × KCB) |
| fleet-fsm-matrix.ts:846 | header subtitle | \`${count} keepers · updated ${time}\` | \`키퍼 ${count}명 · ${time} 업데이트\` |

## 보존

| 단어 | 이유 |
|---|---|
| Fleet | fleet-level identifier (cross-component) |
| KSM × KTC × KDP × KCL × KMC × KCB | FSM acronyms (round-39 ledger) |

## Test fixture coupling 검증

| 단어 | Test 등장 | 분석 | 충돌 |
|---|---|---|---|
| message events | \`activity-graph-groups.test.ts:90\` \`it('chains same-actor message events ...')\` | test name (describe text), not visible string assertion | ❌ |
| board events | \`activity-graph-groups.test.ts:100\` \`it('groups board events ...')\` | test name | ❌ |
| Fleet composite / keepers · updated | -- | -- | ❌ |

## 회피 (atomic test sync 필요 — 다음 라운드)

| 위치 | 단어 | 이유 |
|---|---|---|
| fsm-hub-types.ts:125-127 + keeper-state-diagram.ts:50-52 | Cascade ordering / Compaction atomic / Event priority | \`fsm-hub-invariant-analysis.test.ts:62-64\` 3 assertions, cross-file (2 ts source + 1 test) |
| keeper-detail-panels.ts:32-36 | System prompt / Turn context / Current input | \`keeper-detail-panels.test.ts:50-54\` 2 assertions on \`ctxSegmentLabel\` |

→ 위 batch 들은 다음 라운드에서 atomic 처리.

## 라운드 누적 (23-49)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-44 | -- | MERGED | 139 |
| 45-48 | -- | Draft | 24 |
| 49 | this | Draft | **5** |

누적 chips ≈ **225**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)