### PR TITLE
refactor(design-system): swap fsm-hub-pipeline lane filter to TextInput (CS30)

### DIFF
--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -15,6 +15,7 @@ import { deriveOperationalInsight } from './fsm-hub-invariant-analysis'
 import { deriveObservedLaneSummaries } from './fsm-hub-lane-analysis'
 import { deriveSwimlaneSegments } from './fsm-hub-derivations'
 import { CytoscapeFsm } from './common/cytoscape-fsm'
+import { TextInput } from './common/input'
 import { buildCompositeFsmSpec } from './keeper-fsm-specs'
 
 /**
@@ -118,13 +119,13 @@ export function OperationalMeaningPanel({
         <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
           관찰 레인
         </div>
-        <input
+        <${TextInput}
           type="search"
+          class="min-w-40 max-w-65 flex-1 !px-2 !py-1 !text-2xs"
           value=${query}
           placeholder="field / label / state / meaning 필터"
-          aria-label="관찰 레인 필터"
+          ariaLabel="관찰 레인 필터"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
 


### PR DESCRIPTION
## Summary

CS series input sweep #10 — fsm-hub-pipeline 관찰 레인 필터.

## 변경

`dashboard/src/components/fsm-hub-pipeline-panels.ts`:
- inline `<input type="search">` → `<${TextInput} type="search">`

palette: design-system 토큰 호환.

## 검증

- pnpm typecheck: green
- pnpm test src/components/fsm-hub-pipeline: 10/10 pass

## CS series progress

- buttons: 30 (CS1-9)
- selects: 10 (CS10-19)
- inputs: 10 (CS20-22, CS24-30)
- canonical extension: 2 (CS4 ActionButton.pressed, CS23 TextInput.testId/autoFocus)
- drift fixes: 2 (#10734, #10769)

**Total ~55+ inline pattern → canonical** 누적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
