### PR TITLE
fix(build): unbreak main — tool_unified Atomic.get + dated_jsonl For_testing dedup

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -373,14 +373,3 @@ module For_testing = struct
 end
 
 (* Duplicate count_entries removed — canonical definition at line 225 *)
-
-module For_testing = struct
-  let mutex (t : t) : Eio.Mutex.t = Atomic.get t.mutex
-
-  let mutex_for_base_dir base_dir : Eio.Mutex.t =
-    Atomic.get (mutex_for_base_dir ~base_dir ~injected:None)
-
-  let registry_size () : int =
-    Stdlib.Mutex.protect mutex_registry_mu (fun () ->
-      Hashtbl.length mutex_registry)
-end

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -36,12 +36,16 @@ let tool_info_to_json (info : tool_info) : Yojson.Safe.t =
   let stats_json = match info.call_stats with
     | None -> `Null
     | Some s ->
+      (* #10730 changed [Tool_registry.call_stats] fields from plain
+         scalars to [Atomic.t] cells but missed two consumer sites
+         here.  Read each cell once at JSON build time so the report
+         sees a consistent snapshot. *)
       `Assoc [
-        ("call_count", `Int (s.call_count));
-        ("success_count", `Int (s.success_count));
-        ("failure_count", `Int (s.failure_count));
-        ("last_called_at", `Float (s.last_called_at));
-        ("total_duration_ms", `Int (s.total_duration_ms));
+        ("call_count", `Int (Atomic.get s.call_count));
+        ("success_count", `Int (Atomic.get s.success_count));
+        ("failure_count", `Int (Atomic.get s.failure_count));
+        ("last_called_at", `Float (Atomic.get s.last_called_at));
+        ("total_duration_ms", `Int (Atomic.get s.total_duration_ms));
       ]
   in
   `Assoc [
@@ -91,7 +95,7 @@ let summary_report () : Yojson.Safe.t =
        in
        `Assoc ([
          ("name", `String name);
-         ("call_count", `Int (stats.Tool_registry.call_count));
+         ("call_count", `Int (Atomic.get stats.Tool_registry.call_count));
        ] @ latency)
      ) top_20));
     ("never_called_count", `Int (List.length never_called));


### PR DESCRIPTION
**main is currently RED for every open PR.** Two independent build breaks landed concurrently and need a single follow-up patch to clear @check.

## Break 1 — \`lib/tool_unified.ml\` reads non-Atomic fields

#10730 (Phase 3 Actor Model) PR description says \"Replaced Atomic.t fields in call_stats with pure values\" but the merged code retains the \`Atomic.t\` cells from #7834. Two consumer sites in \`tool_unified\` were missed by the sweep:

- \`tool_info_to_json\`: 5 fields (call_count, success_count, failure_count, last_called_at, total_duration_ms)
- \`summary_report\` top_20 entry: call_count

Compiler caught it (warning 8 / type incompatibility) — but only on the first build after merge.

**Fix**: wrap each read in \`Atomic.get\` so the JSON build sees a consistent snapshot. Same idiom \`tool_registry.ml\` itself uses everywhere it reads these cells.

## Break 2 — \`lib/dated_jsonl/dated_jsonl.ml\` duplicate \`For_testing\` module

Two CI-fix PRs landed within 25 minutes of each other:

- #10750 \"unbreak main — add For_testing module\" → added \`module For_testing\` at line 363
- #10758 \"restore main CI\" → added another \`module For_testing\` at line 377 without noticing #10750 had merged

Both bodies are functionally identical (the second has explicit type annotations). The compiler hits *Multiple definition of the module name For_testing*.

**Fix**: remove the second (later) copy. The first body is sufficient.

## Verification

\`\`\`
$ dune build --root=. @check
EXIT=0
\`\`\`

vs. before this PR:

\`\`\`
File \"lib/tool_unified.ml\", line 54, characters 19-29:
Error: The value stats_json has type … Types for tag \`Int are incompatible

File \"lib/dated_jsonl/dated_jsonl.ml\", lines 377-386:
Error: Multiple definition of the module name For_testing.
\`\`\`

## Why the parallel-PR coordination failed

Per memory \`feedback_check-existing-prs-before-fix.md\` and \`feedback_circular-ci-dependency-unblock.md\`: when main is red and multiple operators race to fix it, duplicate work cascades into duplicate definitions. PR #10774 also targets break 2 but is now stale (\`CONFLICTING\`) — opened before #10750 merged, references the pre-#10739 \`registry_guard\`/\`registry\` names that no longer exist. Closing it after this PR merges is recommended.

A pre-merge \`rg 'module For_testing' lib/ | wc -l\` and \`dune build @check\` gate on every CI-fix PR would catch this class.