### PR TITLE
refactor(design-system): swap keeper-detail-runtime signal filter to TextInput (CS31)

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -6,6 +6,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect, useState } from 'preact/hooks'
 import { DistributionBars, type DistributionItem } from './common/distribution-bars'
+import { TextInput } from './common/input'
 import { TimeAgo } from './common/time-ago'
 import { toolCategory } from './tool-call-shared'
 import type { Keeper } from '../types'
@@ -451,11 +452,11 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
       ${totalRows > 0
         ? html`
             <div class="flex items-center gap-2">
-              <input
+              <${TextInput}
                 type="search"
-                class="flex-1 min-w-0 py-1.5 px-2 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)] focus:outline-none focus:border-[var(--accent-30)]"
+                class="flex-1 min-w-0 !py-1.5 !px-2 !text-2xs"
                 placeholder="신호 지표 필터 (예: 폴백, 메모리, 컴팩션)"
-                aria-label="런타임 신호 지표 필터"
+                ariaLabel="런타임 신호 지표 필터"
                 value=${signalQuery}
                 onInput=${(event: Event) => {
                   const target = event.currentTarget as HTMLInputElement | null


### PR DESCRIPTION
## Summary

CS series input sweep #11 — keeper-detail-runtime 신호 지표 필터.

## 변경

`dashboard/src/components/keeper-detail-runtime.ts`:
- inline `<input type="search">` → `<${TextInput} type="search">`

palette: design-system 토큰 호환.

## 검증

- pnpm typecheck: green
- pnpm test src/components/keeper-detail-runtime: 30/30 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
