### PR TITLE
fix(coord): export claim_post_provision_fn in coord_hooks.mli

### DIFF
--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -57,3 +57,7 @@ val tool_assigned_fn : (agent_id:string ->
            Atomic.t
 val task_completion_path_observed_fn : (path:string -> contract_state:string -> agent_name:string -> unit)
            Atomic.t
+val claim_post_provision_fn : (Coord_utils_backend_setup.config ->
+            agent_name:string ->
+            task_id:string -> unit)
+           Atomic.t


### PR DESCRIPTION
## Summary
- #10771 added `claim_post_provision_fn` to `coord_hooks.ml` but #10781's auto-generated `.mli` missed it (18-minute merge race)
- `coord_task.ml:1000` calls `Atomic.get Coord_hooks.claim_post_provision_fn` → unbound value error
- Originally included `tool_unified.ml` Atomic.get fix, but #10786/#10788 already fixed that

## Root Cause
Two PRs merged in quick succession:
1. `#10771` (00:42) — added `claim_post_provision_fn` to `coord_hooks.ml`
2. `#10781` (01:00) — auto-generated `.mli` from a base that didn't include the new function

## Test plan
- [ ] CI Build and Test passes
- [ ] `dune build` succeeds on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)