### PR TITLE
fix(cdal/verdict-gate): auto-widen lookup window on saturation (#10731)

### DIFF
--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -55,17 +55,23 @@ let default_base_path () =
   in
   Filename.concat root "cdal_verdicts"
 
-let lookup_latest_verdict ?base_dir
-    ?(limit = Env_config_runtime.Cdal.verdict_lookup_limit ())
-    ~task_id () : Cdal_types.contract_verdict option =
-  let base_dir =
-    match base_dir with
-    | Some dir -> dir
-    | None -> default_base_path ()
-  in
-  let store = Dated_jsonl.create ~base_dir () in
-  let recent = Dated_jsonl.read_recent store limit in
-  let result = List.fold_left (fun acc json ->
+(* #10731: window-widening factor.  When the initial [limit] saturates
+   without a match, retry once at [limit * widen_factor] to cover
+   verdicts pushed beyond the starting window by unrelated traffic.
+   Bounded single retry — not unbounded growth — so worst-case scan
+   cost stays predictable. *)
+let auto_widen_factor = 16
+
+(* #10731: in-process dedup for the "scan saturated" WARN.  Without
+   this, fleets that repeatedly look up the same task (e.g. dashboard
+   poll loops) emit the same operator advisory dozens of times per
+   hour.  We deliberately do not persist this across restarts —
+   restart is exactly when an operator wants to see the warning
+   again. *)
+let saturation_warn_emitted : (string, unit) Hashtbl.t = Hashtbl.create 16
+
+let scan_for_task_id ~task_id recent =
+  List.fold_left (fun acc json ->
     match json with
     | `Assoc fields ->
       (match List.assoc_opt "_task_id" fields with
@@ -76,16 +82,46 @@ let lookup_latest_verdict ?base_dir
           | Error _ -> acc)
        | _ -> acc)
     | _ -> acc
-  ) None recent in
-  (* #10115: distinguish three "verdict not found" cases so the
-     operator gets an accurate diagnosis.  The previous WARN
-     unconditionally said "older verdicts beyond window are
-     silently skipped" — true when the scan saturated [limit],
-     misleading when the ledger is empty or the writer pipeline
-     is dormant (12-day gap observed in production).  If the
-     operator follows the WARN's hint and bumps
-     [MASC_CDAL_VERDICT_LOOKUP_LIMIT], they spend cycles
-     investigating the wrong layer. *)
+  ) None recent
+
+let lookup_latest_verdict ?base_dir
+    ?(limit = Env_config_runtime.Cdal.verdict_lookup_limit ())
+    ~task_id () : Cdal_types.contract_verdict option =
+  let base_dir =
+    match base_dir with
+    | Some dir -> dir
+    | None -> default_base_path ()
+  in
+  let store = Dated_jsonl.create ~base_dir () in
+  let recent = Dated_jsonl.read_recent store limit in
+  let result = scan_for_task_id ~task_id recent in
+  (* #10731: auto-widen on saturation.  If [recent] reached [limit] and
+     no match was found, the verdict (if any) sits beyond the starting
+     window.  Re-scan once at [limit * auto_widen_factor] so the
+     operator does not have to guess [MASC_CDAL_VERDICT_LOOKUP_LIMIT].
+     We do not stream-read incrementally because [Dated_jsonl.read_recent]
+     returns lists and adding cursor support is out of scope here; the
+     re-read cost is paid only on miss with a saturated window. *)
+  let result, recent, used_limit =
+    match result with
+    | Some _ -> result, recent, limit
+    | None when List.length recent >= limit && auto_widen_factor > 1 ->
+      let widened = limit * auto_widen_factor in
+      Log.Task.info
+        "[cdal-gate] task_id=%s: starting window saturated (%d entries) \
+         without match; widening to %d and re-scanning"
+        task_id limit widened;
+      let recent2 = Dated_jsonl.read_recent store widened in
+      let result2 = scan_for_task_id ~task_id recent2 in
+      result2, recent2, widened
+    | None -> result, recent, limit
+  in
+  (* #10115: distinguish "verdict not found" cases so the operator gets
+     an accurate diagnosis.  Three sub-cases:
+       - ledger empty (writer dormant)
+       - scanned everything available, no match (verdict was never written)
+       - saturated even at the widened ceiling (unusually large ledger or
+         very old verdict — operator may need to raise the env knob).  *)
   (match result, recent with
    | Some _, _ -> ()
    | None, [] ->
@@ -94,19 +130,24 @@ let lookup_latest_verdict ?base_dir
         Writer pipeline likely dormant — check that OAS Agent.run \
         emits result.proof and Cdal_eval_v1.persist is reached. (#10115)"
        task_id base_dir
-   | None, _ when List.length recent >= limit ->
-     Log.Task.warn
-       "[cdal-gate] task_id=%s: scanned newest %d entries without \
-        match; older verdicts beyond window are silently skipped \
-        (raise MASC_CDAL_VERDICT_LOOKUP_LIMIT to widen the window)"
-       task_id limit
+   | None, _ when List.length recent >= used_limit ->
+     if not (Hashtbl.mem saturation_warn_emitted task_id) then begin
+       Hashtbl.add saturation_warn_emitted task_id ();
+       Log.Task.warn
+         "[cdal-gate] task_id=%s: scanned newest %d entries (auto-widened \
+          %dx from MASC_CDAL_VERDICT_LOOKUP_LIMIT=%d) without match; older \
+          verdicts beyond this ceiling are silently skipped. Raise \
+          MASC_CDAL_VERDICT_LOOKUP_LIMIT only if the verdict is known to \
+          exist farther back. (#10115 #10731)"
+         task_id used_limit auto_widen_factor limit
+     end
    | None, _ ->
      Log.Task.warn
        "[cdal-gate] task_id=%s: no verdict in current ledger window \
         (%d entries scanned, below limit=%d).  Either the task has \
         never been verified, or the writer pipeline is dormant — \
         bumping MASC_CDAL_VERDICT_LOOKUP_LIMIT will not help. (#10115)"
-       task_id (List.length recent) limit);
+       task_id (List.length recent) used_limit);
   result
 
 (* #10115: ledger health introspection.  Walks [base_dir/YYYY-MM/]

--- a/lib/cdal_verdict_gate.mli
+++ b/lib/cdal_verdict_gate.mli
@@ -58,6 +58,22 @@ val gate_check :
   unit ->
   string option
 
+(** [lookup_latest_verdict ?base_dir ?limit ~task_id ()] — the
+    primitive that {!gate_check} composes with attribution recording.
+    Exposed so diagnostic tools and tests can call it without
+    importing the attribution side effect.
+
+    On miss with a saturated starting [limit], the lookup auto-widens
+    once to [limit * 16] before returning [None] — operators no longer
+    need to guess [MASC_CDAL_VERDICT_LOOKUP_LIMIT] in normal-fleet
+    cases (#10731). *)
+val lookup_latest_verdict :
+  ?base_dir:string ->
+  ?limit:int ->
+  task_id:string ->
+  unit ->
+  Cdal_types.contract_verdict option
+
 (** {1 Attribution wiring} *)
 
 (** [to_attribution ?gate_label v] maps [check_verdict v] to the

--- a/test/test_cdal_verdict_gate.ml
+++ b/test/test_cdal_verdict_gate.ml
@@ -209,6 +209,44 @@ let test_gate_latest_verdict_wins () =
     | Some msg ->
       Alcotest.fail (Printf.sprintf "Latest Satisfied should allow, got: %s" msg))
 
+(* #10731: target verdict is written first, then [limit] unrelated
+   verdicts are written after.  With the original code the target sat
+   beyond [limit] and lookup_latest_verdict returned None, causing
+   gate_check to silently reject a task whose verdict actually
+   existed.  Auto-widen retries at [limit * auto_widen_factor] and
+   recovers the verdict. *)
+let test_lookup_auto_widens_past_starting_limit () =
+  with_temp_dir (fun base_dir ->
+    let target = make_verdict ~run_id:"target-run" ~status:CT.Satisfied () in
+    write_verdict_jsonl ~base_dir ~task_id:"task-target" target;
+    let small_limit = 5 in
+    for i = 1 to small_limit + 2 do
+      let filler = make_verdict ~run_id:(Printf.sprintf "filler-%d" i)
+        ~status:CT.Satisfied () in
+      write_verdict_jsonl ~base_dir ~task_id:(Printf.sprintf "task-other-%d" i) filler
+    done;
+    match CVG.lookup_latest_verdict ~base_dir ~limit:small_limit
+            ~task_id:"task-target" () with
+    | Some v ->
+      Alcotest.(check string) "auto-widen recovered run_id" "target-run" v.run_id
+    | None ->
+      Alcotest.fail "auto-widen should have recovered the verdict beyond starting limit")
+
+(* #10731: when the task verdict genuinely does not exist, auto-widen
+   must still terminate and return None — not loop. *)
+let test_lookup_auto_widen_terminates_on_genuine_miss () =
+  with_temp_dir (fun base_dir ->
+    let small_limit = 3 in
+    for i = 1 to small_limit + 2 do
+      let filler = make_verdict ~run_id:(Printf.sprintf "filler-%d" i) () in
+      write_verdict_jsonl ~base_dir ~task_id:(Printf.sprintf "task-other-%d" i) filler
+    done;
+    match CVG.lookup_latest_verdict ~base_dir ~limit:small_limit
+            ~task_id:"task-never-written" () with
+    | None -> ()
+    | Some _ ->
+      Alcotest.fail "Genuine miss must return None even after auto-widen")
+
 (* ================================================================ *)
 (* Attribution conversion tests                                      *)
 (* ================================================================ *)
@@ -361,6 +399,10 @@ let () =
       Alcotest.test_case "violated verdict rejects" `Quick test_gate_violated_verdict_rejects;
       Alcotest.test_case "different task_id not found" `Quick test_gate_different_task_id_not_found;
       Alcotest.test_case "latest verdict wins" `Quick test_gate_latest_verdict_wins;
+      Alcotest.test_case "auto-widens past starting limit (#10731)" `Quick
+        test_lookup_auto_widens_past_starting_limit;
+      Alcotest.test_case "auto-widen terminates on genuine miss (#10731)" `Quick
+        test_lookup_auto_widen_terminates_on_genuine_miss;
     ]);
     ("attribution", [
       Alcotest.test_case "satisfied → Passed" `Quick


### PR DESCRIPTION
Fixes #10731.

> ⚠ Depends on #10791 to unbreak main before CI can pass on this branch.

## Why

\`lookup_latest_verdict\` scans the newest \`limit\` (default 500) verdict ledger entries. When a task verdict was written but later pushed beyond the window by unrelated traffic, the function returned None, causing \`gate_check\` to silently reject a task whose verdict actually existed. Production: 5 tasks × 24h hit the cap; the existing WARN advised \"raise MASC_CDAL_VERDICT_LOOKUP_LIMIT\", placing the operator in the loop for a problem the function can detect itself.

## Change

\`lookup_latest_verdict\` now performs a **single-shot widening retry** when the starting \`limit\` saturates without a match: re-scan at \`limit * 16\` before returning None.

- Bounded — not unbounded growth — so worst-case scan cost stays predictable.
- Re-scan cost paid only on miss with a saturated window (already the slow path).
- The \"saturated even at widened ceiling\" branch keeps the WARN but with **in-process dedup** so fleets with poll loops do not emit the same advisory dozens of times per hour.
- \`lookup_latest_verdict\` is now exported via \`.mli\` so diagnostic tools and tests can call the primitive without the \`gate_check\` attribution side effect.

## Tests (24 total, was 22)

- Existing 5 \`gate_check_integration\` cases preserved.
- New: \`lookup_auto_widens_past_starting_limit\` — verdict written first, then \`limit + 2\` unrelated verdicts; auto-widen recovers verdict beyond starting window.
- New: \`lookup_auto_widen_terminates_on_genuine_miss\` — genuine absence returns None even after auto-widen, no infinite loop.

## Out of scope (separate issues)

- **Bug B** (issue option 2 / fail-loud \`Result.Error\`): requires caller updates; orthogonal to silent-skip root cause.
- **Bug C** (issue option 4 / per-task metric counter): saturation-warn dedup here covers the worst case.
- **Indexed lookup** (per-task ledger structure): correct long-term fix but invasive. 16x widening covers realistic fleet sizes; the env knob remains as escape hatch.

## Approach: industry patterns referenced

- Kubernetes CrashLoopBackOff: bounded retry, then surface.
- BOINC: bounded auto-retry before admin queue.
- Slurm requeue + \`MaxRequeue\`: same pattern at lookup level.