### PR TITLE
feat(dashboard): localize 19 invariant + ctx segment labels (round-50 🎉)

### DIFF
--- a/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
@@ -58,10 +58,10 @@ describe('invariantRows', () => {
   it('includes labels for each invariant', () => {
     const rows = invariantRows(makeSnapshot())
     const labels = rows.map(r => r.label)
-    expect(labels).toContain('Phase ⇔ Turn')
-    expect(labels).toContain('Cascade ordering')
-    expect(labels).toContain('Compaction atomic')
-    expect(labels).toContain('Event priority')
+    expect(labels).toContain('단계 ⇔ 턴')
+    expect(labels).toContain('Cascade 순서')
+    expect(labels).toContain('압축 원자성')
+    expect(labels).toContain('이벤트 우선순위')
   })
 
   it('includes detail string for each row', () => {

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -121,10 +121,10 @@ export const TRANSITION_FIELDS: Array<{ field: string; key: LaneKey }> = [
 ]
 
 export const INVARIANT_LABELS: Record<keyof KeeperCompositeInvariants, string> = {
-  phase_turn_alignment: 'Phase ⇔ Turn',
-  no_cascade_before_measurement: 'Cascade ordering',
-  compaction_atomicity: 'Compaction atomic',
-  event_priority_monotone: 'Event priority',
+  phase_turn_alignment: '단계 ⇔ 턴',
+  no_cascade_before_measurement: 'Cascade 순서',
+  compaction_atomicity: '압축 원자성',
+  event_priority_monotone: '이벤트 우선순위',
 }
 
 export const LANE_LABELS: Record<LaneKey, string> = {

--- a/dashboard/src/components/keeper-detail-panels.test.ts
+++ b/dashboard/src/components/keeper-detail-panels.test.ts
@@ -47,15 +47,15 @@ describe('ctxColor', () => {
 
 describe('ctxSegmentLabel', () => {
   it('returns known label for system_prompt', () => {
-    expect(ctxSegmentLabel('system_prompt')).toBe('System prompt')
+    expect(ctxSegmentLabel('system_prompt')).toBe('시스템 프롬프트')
   })
 
   it('returns known label for dynamic_context', () => {
-    expect(ctxSegmentLabel('dynamic_context')).toBe('Turn context')
+    expect(ctxSegmentLabel('dynamic_context')).toBe('턴 컨텍스트')
   })
 
   it('returns known label for history_tool_use', () => {
-    expect(ctxSegmentLabel('history_tool_use')).toBe('History · tool use')
+    expect(ctxSegmentLabel('history_tool_use')).toBe('히스토리 · tool use')
   })
 
   it('replaces underscores for unknown keys', () => {
@@ -257,9 +257,9 @@ describe('filterCtxCompositionEntries', () => {
   })
 
   it('matches human label when raw key misses', () => {
-    // Raw key is `system_prompt`, label is `System prompt`.
-    // Searching for exactly `system prompt` (with the space) only hits the label.
-    const out = filterCtxCompositionEntries(ctxSample, 'system prompt')
+    // Raw key is `system_prompt`, label is `시스템 프롬프트` (round-50).
+    // Searching for the Korean label substring only hits the label, not the key.
+    const out = filterCtxCompositionEntries(ctxSample, '시스템 프롬프트')
     expect(out.map(([k]) => k)).toEqual(['system_prompt'])
   })
 

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -29,17 +29,17 @@ export function autonomyHint(count: number | undefined, proactiveEnabled: boolea
 }
 
 const CTX_SEGMENT_LABELS: Record<string, string> = {
-  system_prompt: 'System prompt',
-  dynamic_context: 'Turn context',
-  memory_context: 'Memory',
-  temporal_context: 'Temporal',
-  user_message: 'Current input',
-  history_user: 'History · user',
-  history_assistant_text: 'History · assistant',
-  history_tool_use: 'History · tool use',
-  history_tool_result: 'History · tool result',
-  history_other: 'History · other',
-  unattributed: 'Unattributed',
+  system_prompt: '시스템 프롬프트',
+  dynamic_context: '턴 컨텍스트',
+  memory_context: '메모리',
+  temporal_context: '시간',
+  user_message: '현재 입력',
+  history_user: '히스토리 · user',
+  history_assistant_text: '히스토리 · assistant',
+  history_tool_use: '히스토리 · tool use',
+  history_tool_result: '히스토리 · tool result',
+  history_other: '히스토리 · 기타',
+  unattributed: '미할당',
 }
 
 const CTX_SEGMENT_COLORS: Record<string, string> = {

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -46,10 +46,10 @@ const PHASE_ID_MAP: Record<string, string> = {
 }
 
 const INVARIANT_LABELS: Array<[keyof KeeperCompositeSnapshot['invariants'], string]> = [
-  ['phase_turn_alignment', 'Phase ⇔ Turn'],
-  ['no_cascade_before_measurement', 'Cascade ordering'],
-  ['compaction_atomicity', 'Compaction atomic'],
-  ['event_priority_monotone', 'Event priority'],
+  ['phase_turn_alignment', '단계 ⇔ 턴'],
+  ['no_cascade_before_measurement', 'Cascade 순서'],
+  ['compaction_atomicity', '압축 원자성'],
+  ['event_priority_monotone', '이벤트 우선순위'],
 ]
 
 function normalizePhase(phase: string | null | undefined): string | null {


### PR DESCRIPTION
## Summary

🎉 **대시보드 라운드 50 milestone** — invariant labels + ctx segment labels atomic batch (5 files, 19 source strings, 8 test assertions).

## INVARIANT_LABELS — duplicated across 2 source files (4 strings × 2)

| key | Before | After |
|---|---|---|
| phase_turn_alignment | Phase ⇔ Turn | 단계 ⇔ 턴 |
| no_cascade_before_measurement | Cascade ordering | Cascade 순서 |
| compaction_atomicity | Compaction atomic | 압축 원자성 |
| event_priority_monotone | Event priority | 이벤트 우선순위 |

→ \`fsm-hub-types.ts\` (canonical Record) + \`keeper-state-diagram.ts\` (Array dup)

## CTX_SEGMENT_LABELS — \`keeper-detail-panels.ts:32-42\` (11 strings)

| key | Before | After |
|---|---|---|
| system_prompt | System prompt | 시스템 프롬프트 |
| dynamic_context | Turn context | 턴 컨텍스트 |
| memory_context | Memory | 메모리 |
| temporal_context | Temporal | 시간 |
| user_message | Current input | 현재 입력 |
| history_user | History · user | 히스토리 · user |
| history_assistant_text | History · assistant | 히스토리 · assistant |
| history_tool_use | History · tool use | 히스토리 · tool use |
| history_tool_result | History · tool result | 히스토리 · tool result |
| history_other | History · other | 히스토리 · 기타 |
| unattributed | Unattributed | 미할당 |

## 보존 (도메인/식별자)

| 단어 | 이유 |
|---|---|
| Cascade | MASC 도메인 용어 (cross-system identifier) |
| user / assistant / tool use / tool result | OpenAI/Anthropic chat role standard identifier |

## Test sync (atomic — 8 assertions)

| Test file | Lines | 변경 |
|---|---|---|
| \`fsm-hub-invariant-analysis.test.ts\` | 61-64 | 4 invariant label assertions |
| \`keeper-detail-panels.test.ts\` | 50, 54, 58 | 3 ctxSegmentLabel direct asserts |
| \`keeper-detail-panels.test.ts\` | 260 | filter test query 'system prompt' → '시스템 프롬프트' |

\`filterCtxCompositionEntries\` 로직 보존: key + label + value 3-tier matching. 한국어 label search 신규 동작, 영문 key search ('system_prompt') 기존 동작 유지.

## 라운드 누적 (23-50)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-44 | -- | MERGED | 139 |
| 45-49 | open Draft | -- | 29 |
| **50** | **this** | **Draft** | **19 🎉** |

누적 chips ≈ **244**.

## 50 round 마일스톤 회고

| 통계 | 값 |
|---|---|
| 총 라운드 | 50 |
| 누적 chips | ~244 |
| 평균 chips/round | ~4.9 |
| 최대 chips (single round) | 30 (round-43 keeper-detail field titles) |
| 최소 chips (single round) | 3 (round-39, 46, 47) |
| 누적 수정 파일 | 50+ unique |
| Test sync rounds | 11 (round-30, 35, 37, 38, 41, 46, 47, 50, ...) |

## Why Draft

#10645 (vitest infra) 미해결. 8 test assertion sync 가 PR 에 포함되어 vitest 복구 즉시 atomic 검증 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)