### PR TITLE
refactor(design-system): swap keeper-tool-call-inspector tool filter to TextInput (CS33)

### DIFF
--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -13,6 +13,7 @@ import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { parseToolBlobMarker } from '../lib/tool-blob-marker'
 import { CopyIdButton } from './common/copy-id-button'
+import { TextInput } from './common/input'
 
 // Delegated to lib/format-time (SSOT)
 const formatTimestamp = formatTimeHms
@@ -240,10 +241,11 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
           <span class=${successRate < 80 ? 'text-[var(--color-status-warn)]' : ''}>${successRate}% ok</span>
         </div>
         <${FreshnessLine} data=${response ?? { source: 'tool_call_io' }} />
-        <input
+        <${TextInput}
           type="text"
           placeholder="도구 필터..."
-          class="text-xs font-mono bg-[var(--bg-deep)] border border-[var(--color-border-default)] rounded px-2 py-1 w-40 text-[var(--color-fg-secondary)]"
+          ariaLabel="도구 필터"
+          class="!bg-[var(--bg-deep)] !px-2 !py-1 !text-xs font-mono w-40"
           value=${filterTool.value}
           onInput=${(e: Event) => { filterTool.value = (e.target as HTMLInputElement).value }}
         />


### PR DESCRIPTION
## Summary

CS series input sweep #13 — keeper-tool-call-inspector 도구 필터.

## 변경

`dashboard/src/components/keeper-tool-call-inspector.ts`:
- inline `<input type="text">` → `<${TextInput} type="text">`
- `ariaLabel="도구 필터"` 추가 (a11y 향상)
- `!bg-[var(--bg-deep)]` override로 dense table header dark variant 보존

## Palette

대부분 design-system 토큰. `--bg-deep`는 design-system `tokens.css`에 정의된 canonical token (per-theme variant). production divergence 아님.

## 검증

- pnpm typecheck: green
- pnpm test src/components/keeper-tool-call-inspector: 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
