### PR TITLE
fix(boot): start Session actor loop + unwrap Tool_registry Atomic counters

### DIFF
--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -529,6 +529,15 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
       base_path
   in
   let registry = Session.create () in
+  (* PR #10664 introduced an actor-model mailbox loop in Session but
+     forgot to start it from this Eio boot path. Without the loop,
+     every Session.* helper that performs `Stream.add` then awaits
+     a Promise (restore_from_disk, register, push_notification_to_active_agents,
+     check_rate_limit, get_session, ...) blocks forever. The most
+     visible symptom is `lazy_task: starting restore_sessions` never
+     reaching `finished`, which freezes the entire keeper autoboot
+     gate behind an indefinite "waiting for lazy startup tasks" log. *)
+  Session.start_loop registry ~sw;
   (* Wire notification harness: subscription events → session queues *)
   Subscriptions.set_session_push_fn (fun event ->
     Session.push_notification_to_active_agents registry ~event

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -36,12 +36,15 @@ let tool_info_to_json (info : tool_info) : Yojson.Safe.t =
   let stats_json = match info.call_stats with
     | None -> `Null
     | Some s ->
+      (* Tool_registry.call_stats fields became `_ Atomic.t` in
+         #10730; the JSON serializer never followed. Read each
+         counter via [Atomic.get] before encoding. *)
       `Assoc [
-        ("call_count", `Int (s.call_count));
-        ("success_count", `Int (s.success_count));
-        ("failure_count", `Int (s.failure_count));
-        ("last_called_at", `Float (s.last_called_at));
-        ("total_duration_ms", `Int (s.total_duration_ms));
+        ("call_count", `Int (Atomic.get s.call_count));
+        ("success_count", `Int (Atomic.get s.success_count));
+        ("failure_count", `Int (Atomic.get s.failure_count));
+        ("last_called_at", `Float (Atomic.get s.last_called_at));
+        ("total_duration_ms", `Int (Atomic.get s.total_duration_ms));
       ]
   in
   `Assoc [
@@ -91,7 +94,7 @@ let summary_report () : Yojson.Safe.t =
        in
        `Assoc ([
          ("name", `String name);
-         ("call_count", `Int (stats.Tool_registry.call_count));
+         ("call_count", `Int (Atomic.get stats.Tool_registry.call_count));
        ] @ latency)
      ) top_20));
     ("never_called_count", `Int (List.length never_called));


### PR DESCRIPTION
## Symptom

Production keeper boot frozen at 15:15:36Z (KST 00:15) — `lazy_task: starting restore_sessions` logged, `finished` never reached. Repeats every 5s:

```
[Keeper] autoboot: waiting for lazy startup tasks to finish before keeper boot
  [restore_sessions, reconcile_active_agents, recover_running_sessions,
   prompt_bootstrap, telemetry_warmup, tool_metrics_restore,
   keeper_history_migration, jsonl_prune, keeper_checkpoint_prune]
```

9 task가 단일 fiber에서 순차 실행 (`server_runtime_bootstrap.ml:1471` `Eio.Fiber.fork ~sw (fun () -> List.iter run_lazy_task tasks)`) — 첫 task hang하면 9개 모두 pending 영구 stuck. Keeper subsystem 부팅 차단, governance/cascade/dashboard 응답 없음, 1시간 후 stale watchdog 강제 종료 → restart → 같은 cycle.

## Root cause — PR #10664 actor 리팩터링 sweep miss

PR #10664가 `Session`을 `Eio.Mutex` + mutable에서 `Eio.Stream` + Promise actor로 전환. 그러나 `lib/mcp_server.ml:create_state_eio`에서 `Session.create ()` 호출 후 `Session.start_loop registry ~sw`를 추가하지 않음.

```ocaml
(* lib/session.ml:418 — restore_from_disk *)
let restore_from_disk registry ~agents_path =
  let p, r = Eio.Promise.create () in
  Eio.Stream.add registry.mailbox (Restore_from_disk_req (...));
  Eio.Promise.await p   (* ← consumer fiber 없음 → 영구 hang *)
```

mailbox에 메시지를 add하지만 `start_loop`이 spawn하는 컨슈머 fiber가 없음 → `Promise.await`이 resolve 받지 못해 무한 wait. 다른 helper 함수들 (`register`, `push_notification_to_active_agents`, `check_rate_limit`, `get_session`, ...) 도 같은 패턴이라 그동안 silent 부분 동작 중.

`grep -rn "Session.start_loop" lib/ bin/` → 0건. `Session.create()` 호출자가 `start_loop`을 절대 부르지 않음.

## Fix 1 — Session actor loop 시작 (1 line + comment)

`lib/mcp_server.ml:create_state_eio`에서 `Session.create ()` 직후 `Session.start_loop registry ~sw` 호출. `~sw`가 이미 인자로 들어와 있어 추가 plumbing 불필요.

비-eio `create_state` path는 test + TUI에서만 사용되며 mailbox API 호출 안 함 → 영향 없음 (deprecate 검토는 별도 PR).

## Fix 2 — Tool_registry.call_stats Atomic unwrap (불가피한 동반 fix)

세션 fix를 로컬 검증하려는 첫 `dune build`에서 main이 깨져 있음을 발견:

```
File "lib/tool_unified.ml", line 54, characters 19-29:
Error: The value stats_json has type
  [> `Float of float Atomic.t | `Int of int Atomic.t ]
  but an expression was expected of type Yojson.Safe.t
```

PR #10730 (Tool_registry Actor Model) 가 `call_stats` 필드를 `int → int Atomic.t`로 바꿨지만 `tool_unified.ml`의 JSON serializer는 그대로. 두 callsite에서 `Atomic.get` 추가 (line 40-44 `tool_info_to_json`, line 97 `summary_report`).

검색 결과 같은 타입 오류로 main이 깨진 상태에 대한 open PR 없음 → 함께 fix해야 build green 됨.

## Verification

```bash
DUNE_BUILD_DIR=_build_diag scripts/dune-local.sh build @check --cache=disabled
# exit 0
```

(런타임 검증은 fix 머지 → server restart → `lazy_task: finished restore_sessions` 로그로 확인 가능. 이 PR diff만으로는 정적 검증.)

## Why both in one PR

같은 Jane Street refactor wave (#10664 + #10730) 의 **sweep miss anti-pattern**. 메모리 `audit-bucket-cascade-pattern`: 같은 bug class 2회 발화 시 묶어 처리. 분리 시 #2가 #1의 build 검증을 막음 → 직렬화 비용 > scope 비용.

## Risk

- `Session.start_loop`은 `Eio.Fiber.fork`로 sw에 background fiber 추가. sw 종료 시 정상 cleanup (Eio 표준).
- 컨슈머가 살아나면서 그동안 silent하게 mailbox에 쌓여 있던 메시지(있다면) 일괄 처리될 수 있음 — 다만 실제 production은 컨슈머 없는 상태에서 대부분 boot timeout으로 reset됐으므로 backlog 거의 없음.
- `Atomic.get`은 무락 read, 부작용 없음. counter snapshot이 약간 stale할 수 있지만 dashboard/JSON 보고용이라 acceptable.

## Out of scope

- WS standalone port FD leak (claude-in-chrome dashboard reconnect → 280 CLOSED FD/3min). 별도 PR 필요.
- governance_judge unparseable response (LLM이 contract 무시하고 conversational 응답). 메모리 `proactive_turn_contract_violation_dominant` — model behavior layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)