### PR TITLE
fix(build): unbreak main — duplicate For_testing + Tool_registry Atomic JSON

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -357,23 +357,13 @@ let prune t ~days =
     !deleted
   end
 
-(* Test hooks declared in the .mli — implementation lives in this
-   module so tests can verify mutex-registry sharing without
-   widening the public API surface. *)
-module For_testing = struct
-  let mutex (t : t) = Atomic.get t.mutex
-
-  let mutex_for_base_dir base_dir =
-    let cell = mutex_for_base_dir ~base_dir ~injected:None in
-    Atomic.get cell
-
-  let registry_size () =
-    Stdlib.Mutex.protect mutex_registry_mu (fun () ->
-      Hashtbl.length mutex_registry)
-end
-
 (* Duplicate count_entries removed — canonical definition at line 225 *)
 
+(* Test hooks declared in the .mli — implementation lives in this
+   module so tests can verify mutex-registry sharing without
+   widening the public API surface.  Two identical bodies landed
+   from #10750 (build-break repair) and #10758 (env-knob extraction)
+   merging in close succession; this is the single canonical copy. *)
 module For_testing = struct
   let mutex (t : t) : Eio.Mutex.t = Atomic.get t.mutex
 

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -36,12 +36,17 @@ let tool_info_to_json (info : tool_info) : Yojson.Safe.t =
   let stats_json = match info.call_stats with
     | None -> `Null
     | Some s ->
+      (* #10730 (Tool_registry Actor Model) made these fields
+         [int Atomic.t] / [float Atomic.t]; this serializer was not
+         migrated in the same PR, leaving the build broken.  Snapshot
+         each Atomic once into a primitive before wrapping in the
+         JSON variant. *)
       `Assoc [
-        ("call_count", `Int (s.call_count));
-        ("success_count", `Int (s.success_count));
-        ("failure_count", `Int (s.failure_count));
-        ("last_called_at", `Float (s.last_called_at));
-        ("total_duration_ms", `Int (s.total_duration_ms));
+        ("call_count", `Int (Atomic.get s.call_count));
+        ("success_count", `Int (Atomic.get s.success_count));
+        ("failure_count", `Int (Atomic.get s.failure_count));
+        ("last_called_at", `Float (Atomic.get s.last_called_at));
+        ("total_duration_ms", `Int (Atomic.get s.total_duration_ms));
       ]
   in
   `Assoc [
@@ -91,7 +96,9 @@ let summary_report () : Yojson.Safe.t =
        in
        `Assoc ([
          ("name", `String name);
-         ("call_count", `Int (stats.Tool_registry.call_count));
+         (* #10730 (Tool_registry Actor Model) made call_count an
+            [int Atomic.t]; snapshot it before JSON-wrapping. *)
+         ("call_count", `Int (Atomic.get stats.Tool_registry.call_count));
        ] @ latency)
      ) top_20));
     ("never_called_count", `Int (List.length never_called));


### PR DESCRIPTION
## P0 — main 빌드 두 곳에서 깨짐

### 1. dated_jsonl.ml: 중복 \`For_testing\` 모듈

```
File \"lib/dated_jsonl/dated_jsonl.ml\", lines 377-386, characters 0-3:
Error: Multiple definition of the module name For_testing.
```

#10750 (build-break repair) 가 `For_testing` 추가, #10758 (env-knob extraction) 이 동일한 본문을 또 추가. 두 PR 이 시간차로 머지되며 race.

### 2. tool_unified.ml: Tool_registry Atomic 필드 직렬화 누락

```
File \"lib/tool_unified.ml\", line 54, characters 19-29:
Error: ... Type [> `Float of float Atomic.t | `Int of int Atomic.t ]
       is not compatible with type Yojson.Safe.t
```

#10730 (Jane Street Phase 3 Tool_registry Actor Model) 가 \`call_stats\` 필드를 모두 \`int Atomic.t\` / \`float Atomic.t\` 로 마이그레이션했지만, 같은 PR 에서 `tool_unified.ml` 의 JSON 직렬화 사이트는 update 되지 않음.

## 변경

| 파일 | 변경 |
|------|------|
| `lib/dated_jsonl/dated_jsonl.ml` | 중복 `For_testing` 모듈 하나만 유지 (canonical, 타입 어노테이션 있는 쪽). 주석에 머지 race 명시. |
| `lib/tool_unified.ml` | `Atomic.get` snapshot 6 개 사이트 (`call_count` x2, `success_count`, `failure_count`, `last_called_at`, `total_duration_ms`). |

## 빌드

`dune build @check` EXIT=0.

## 영향

- 모든 open PR 이 main rebase 시 즉시 build green 회복.
- runtime semantics 변경 없음 — duplicate definition 제거 + atomic 값 snapshot 만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)