### PR TITLE
refactor(design-system): swap verification-requests reject input to TextInput (CS35)

### DIFF
--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -266,12 +266,13 @@ function RowActions({
     const canSubmit = reason.trim().length > 0
     return html`
       <div class="flex items-center gap-1 flex-wrap">
-        <input
+        <${TextInput}
           type="text"
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] w-50"
+          class="!px-2 !py-1 !text-2xs w-50"
           placeholder="반려 사유 (필수)"
+          ariaLabel="반려 사유"
           value=${reason}
-          autofocus
+          autoFocus
           onInput=${(e: Event) => setRowAction(requestId, {
             kind: 'compose-reject',
             reason: (e.target as HTMLInputElement).value,


### PR DESCRIPTION
## Summary

CS series input sweep #15 — verification-requests-panel 반려 사유 입력. **CS23 autoFocus prop 활용 첫 사례.**

## 변경

`dashboard/src/components/verification-requests-panel.ts`:
- inline `<input type="text" autofocus>` → `<${TextInput} type="text" autoFocus>`
- `ariaLabel="반려 사유"` 추가
- onKeyDown(Enter submit / Escape cancel) handler 보존

## Palette

Pure design-system tokens (`--color-border-default`, `--color-bg-page`, `--color-fg-primary`). Production divergence 없음.

## 검증

- pnpm typecheck: green
- pnpm test src/components/verification-requests-panel: 22/22 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
