### PR TITLE
refactor(design-system): swap session-trace-filter event search to TextInput (CS39)

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-filter.ts
+++ b/dashboard/src/components/session-trace/session-trace-filter.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import { FilterChips } from '../common/filter-chips'
+import { TextInput } from '../common/input'
 import {
   getKindCounts, getTraceFilter, setTraceFilter,
   getStatusCounts, getTraceStatusFilter, setTraceStatusFilter,
@@ -58,15 +59,16 @@ export function SessionTraceFilter({ agentName }: { agentName: string }) {
     <div class="space-y-2">
       <!-- Search -->
       <div class="relative">
-        <input
+        <${TextInput}
           type="text"
           placeholder="이벤트 검색..."
+          ariaLabel="세션 이벤트 검색"
           value=${searchQuery}
           onInput=${(e: Event) => {
             const v = (e.target as HTMLInputElement).value
             setTraceSearchQuery(agentName, v)
           }}
-          class="w-full px-3 py-1.5 text-xs rounded bg-[var(--white-3)] border border-[var(--white-6)] text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] outline-none focus:border-[var(--color-accent-fg)]"
+          class="w-full !bg-[var(--white-3)] !border-[var(--white-6)] !px-3 !py-1.5 !text-xs"
         />
         ${searchQuery ? html`
           <button


### PR DESCRIPTION
## Summary

CS series input sweep #19 — session-trace-filter 이벤트 검색.

## 변경

`dashboard/src/components/session-trace/session-trace-filter.ts`:
- inline `<input type="text">` → `<${TextInput} type="text">`
- `ariaLabel="세션 이벤트 검색"` 추가
- `!bg-[var(--white-3)]` + `!border-[var(--white-6)]` overrides로 darker variant 보존

## Palette

Design-system tokens. INPUT_BASE 기본은 `--white-4`이나 원본은 살짝 더 진한 `--white-3` 채택 — override로 시각 동일성 유지. 다른 토큰(`--color-fg-primary`, `--color-fg-disabled`, `--color-accent-fg`)은 INPUT_BASE와 일치.

## 검증

- pnpm typecheck: green
- pnpm test src/components/session-trace: 29/29 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
