### PR TITLE
fix(provider): sweep remaining DashScope partial-match sites (follow-up to #10785)

### DIFF
--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -31,7 +31,7 @@ let provider_kind_uses_anthropic_caching
   match kind with
   | Anthropic | Claude_code -> true
   | OpenAI_compat | Ollama | Gemini | Gemini_cli | Kimi | Kimi_cli | Glm
-  | Codex_cli ->
+  | Codex_cli | DashScope ->
       false
 
 let model_label_provider_kind label =

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -341,9 +341,8 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
-  | Oas.Event_bus.TurnReady _ ->
-      (* TurnReady event added in newer OAS. Skip the relay to avoid flooding SSE. *)
-      None
+  (* TurnReady is already handled at line 211; the duplicate arm
+     introduced as a lint quick-fix has been removed (warning 11). *)
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1256,5 +1256,5 @@ let non_http_transport_of_provider
                           Llm_provider.Transport_codex_cli.default_config with
                           cwd;
                         }))))
-  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi ->
+  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
       Ok None

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -162,6 +162,7 @@ let cn_kimi_api = "kimi-api"
 let cn_glm = "glm-api"
 let cn_glm_coding_plan = "glm-coding-plan"
 let cn_openrouter = "openrouter"
+let cn_dashscope = "dashscope"
 
 let kimi_api_key_envs = [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
 
@@ -250,6 +251,7 @@ let adapter_canonical_name_of_provider_kind
   | Glm -> cn_glm
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
+  | DashScope -> cn_dashscope
 
 (** Single source of truth for all provider/runtime adapters.
     Simple names ([claude], [codex], [gemini]) are CLI runtimes.
@@ -1413,7 +1415,8 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   | Ollama ->
       resolve_direct_adapter cn_ollama
   | Glm
-  | OpenAI_compat ->
+  | OpenAI_compat
+  | DashScope ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
 
 let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
@@ -1545,7 +1548,8 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Kimi_cli
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli ->
+  | Llm_provider.Provider_config.Codex_cli
+  | Llm_provider.Provider_config.DashScope ->
       auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -43,6 +43,7 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
     | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities
     | Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
+    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
   in
   let caps =
     match provider_cfg.kind with


### PR DESCRIPTION
## Summary

Follow-up to #10785. After that fix, CI Lint surfaced 5 more partial-match sites for `DashScope` (OAS 96491352) under `-warn-error +8`.

## Sites

| File | Lines | Grouping |
|---|---|---|
| `lib/keeper/keeper_usage_trust.ml` | 31-35 | DashScope → no Anthropic cache (OpenAI-compat group) |
| `lib/provider_adapter.ml` | 240-252 | new constant `cn_dashscope = \"dashscope\"` + canonical arm |
| `lib/provider_adapter.ml` | 1397-1417 | DashScope joins `Glm \| OpenAI_compat` (resolve_adapter_by_cascade_prefix) |
| `lib/provider_adapter.ml` | 1534-1549 | DashScope joins `auth_env_keys_of_provider_kind` (DASHSCOPE_API_KEY) |
| `lib/provider_tool_support.ml` | 34-45 | `DashScope -> Capabilities.dashscope_capabilities` (matches OAS complete.ml:100) |

Site `lib/provider_tool_support.ml:48-52` already exhaustive via wildcard fall-through.

## Pattern

memory `feedback_variant-add-partial-match-cascade` — variant addition without sweep cascades into warning-8 errors.

## Test plan

- [ ] CI Lint green on this PR (no further partial-match warnings).
- [ ] After merge, all open PRs unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)