### PR TITLE
fix(build): unbreak main — DashScope sweep + claim_post_provision mli + redundant TurnReady

### DIFF
--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -57,3 +57,12 @@ val tool_assigned_fn : (agent_id:string ->
            Atomic.t
 val task_completion_path_observed_fn : (path:string -> contract_state:string -> agent_name:string -> unit)
            Atomic.t
+
+val claim_post_provision_fn : (Coord_utils_backend_setup.config ->
+            agent_name:string ->
+            task_id:string -> unit)
+           Atomic.t
+(** Post-claim provisioning hook (e.g., sandbox warm-up, runtime
+    contract write) wired by [keeper_runtime] at startup.  Default
+    no-op keeps [masc_coord] free of a direct dependency on
+    [masc_mcp]. *)

--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -31,7 +31,7 @@ let provider_kind_uses_anthropic_caching
   match kind with
   | Anthropic | Claude_code -> true
   | OpenAI_compat | Ollama | Gemini | Gemini_cli | Kimi | Kimi_cli | Glm
-  | Codex_cli ->
+  | Codex_cli | DashScope ->
       false
 
 let model_label_provider_kind label =

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -341,9 +341,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
-  | Oas.Event_bus.TurnReady _ ->
-      (* TurnReady event added in newer OAS. Skip the relay to avoid flooding SSE. *)
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1256,5 +1256,5 @@ let non_http_transport_of_provider
                           Llm_provider.Transport_codex_cli.default_config with
                           cwd;
                         }))))
-  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi ->
+  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
       Ok None

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -248,6 +248,11 @@ let adapter_canonical_name_of_provider_kind
   | Gemini_cli -> cn_gemini
   | Kimi_cli -> cn_kimi
   | Glm -> cn_glm
+  | DashScope ->
+      (* OAS 0.179+: Alibaba DashScope OpenAI-compat endpoint.  Treated
+         as an OpenAI-compat adapter for canonical naming until masc-mcp
+         needs a dedicated label. *)
+      cn_codex_api
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
 
@@ -1413,6 +1418,7 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   | Ollama ->
       resolve_direct_adapter cn_ollama
   | Glm
+  | DashScope
   | OpenAI_compat ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
 
@@ -1544,6 +1550,7 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Gemini_cli
   | Llm_provider.Provider_config.Kimi_cli
   | Llm_provider.Provider_config.Glm
+  | Llm_provider.Provider_config.DashScope
   | Llm_provider.Provider_config.Claude_code
   | Llm_provider.Provider_config.Codex_cli ->
       auth_env_keys_of_provider_kind cfg.kind

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -39,6 +39,7 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Glm -> Llm_provider.Capabilities.glm_capabilities
     | Gemini -> Llm_provider.Capabilities.gemini_capabilities
     | OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
+    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
     | Claude_code -> Llm_provider.Capabilities.claude_code_capabilities
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
     | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities


### PR DESCRIPTION
## P0 — main 빌드 3개 break

### 1. DashScope variant cascade (5+ 사이트 partial-match)

OAS 0.179 가 `Llm_provider.Provider_config.provider_kind` 에 `DashScope` variant 추가. PR #10785 가 cascade_config 한 사이트만 update — 나머지 5 사이트가 **partial-match cascade** (warning 8 fatal):

- `lib/provider_tool_support.ml:32` capabilities resolver
- `lib/keeper/keeper_usage_trust.ml:31` anthropic-cache predicate
- `lib/provider_adapter.ml:240` canonical name resolver
- `lib/provider_adapter.ml:1402` config → adapter
- `lib/provider_adapter.ml:1540` docker auth env keys
- `lib/oas_worker_exec_transport.ml:1259` CLI transport selector

memory `feedback_variant-add-partial-match-cascade` 의 정확한 사례. ADT variant 추가 PR이 모든 매치 사이트 sweep 안 하면 strict mode partial-match로 cascade.

### 2. coord_hooks.mli 누락

```
File \"lib/server/server_bootstrap_loops.ml\", line 20, characters 13-48:
Error: Unbound value Coord_hooks.claim_post_provision_fn
```

`coord_hooks.ml:237` 가 정의하지만 `.mli` 누락 — server_bootstrap_loops 가 외부에서 set 시도.

### 3. oas_event_bridge.ml redundant arm (#10802 cycle 재발)

```
File \"lib/oas_event_bridge.ml\", line 344, characters 4-29:
Error (warning 11 [redundant-case]): this match case is unused.
```

같은 match 블록 line 211 이미 `TurnReady _ -> None` 처리. 또 다른 PR 이 line 344 에 추가했지만 unreachable.

## 변경

| 파일 | 변경 |
|------|------|
| `cascade_config.ml` | (이미 #10785 처리됨, 보존) |
| `provider_tool_support.ml` | `DashScope -> dashscope_capabilities` 추가 |
| `keeper_usage_trust.ml` | `DashScope` 를 \"non-anthropic-cache\" arm 에 추가 |
| `provider_adapter.ml` (3 사이트) | `DashScope` 를 OpenAI-compat 와 동일 arm 으로 라우팅 |
| `oas_worker_exec_transport.ml` | `DashScope -> Ok None` (CLI transport 없음) |
| `coord_hooks.mli` | `val claim_post_provision_fn ...` 추가 |
| `oas_event_bridge.ml:344-346` | redundant `TurnReady _` arm 삭제 |

## 빌드

`rm -rf _build && dune build @check` EXIT=0.

캐시 stale 상태에서 한 번 실수로 DashScope 자체를 제거 시도했다가, 클린 빌드 후 OAS 가 실제로 DashScope 를 갖고 있음을 확인 → 6 사이트 모두 sweep.

## 영향

- 모든 open PR 이 main rebase 시 즉시 build green 회복.
- runtime semantics 변경 없음 — 모든 사이트가 \"DashScope 를 OpenAI-compat 처럼 처리\" (가장 가까운 기존 의미).

🤖 Generated with [Claude Code](https://claude.com/claude-code)