### PR TITLE
feat(dashboard): localize 7 live-timeline filter labels (round-54)

### DIFF
--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -17,13 +17,13 @@ const activeFilter = signal<FilterKind>('all')
 const autoScroll = signal(true)
 
 const FILTER_CHIPS: { key: FilterKind; label: string }[] = [
-  { key: 'all', label: 'All' },
-  { key: 'heartbeat', label: 'Heartbeat' },
-  { key: 'message', label: 'Message/Board' },
-  { key: 'oas_turn', label: 'OAS Turn' },
-  { key: 'tool', label: 'Tool' },
-  { key: 'error', label: 'Error' },
-  { key: 'lifecycle', label: 'Lifecycle' },
+  { key: 'all', label: '전체' },
+  { key: 'heartbeat', label: '하트비트' },
+  { key: 'message', label: '메시지/보드' },
+  { key: 'oas_turn', label: 'OAS 턴' },
+  { key: 'tool', label: '도구' },
+  { key: 'error', label: '오류' },
+  { key: 'lifecycle', label: '라이프사이클' },
 ]
 
 export function eventMatchesFilter(entry: JournalEntry, filter: FilterKind): boolean {


### PR DESCRIPTION
## Summary

대시보드 라운드 54 — \`agent-monitor/live-timeline.ts\` FILTER_CHIPS 7 labels 한국어화.

| Key | Before | After |
|---|---|---|
| all | All | 전체 |
| heartbeat | Heartbeat | 하트비트 |
| message | Message/Board | 메시지/보드 |
| oas_turn | OAS Turn | OAS 턴 |
| tool | Tool | 도구 |
| error | Error | 오류 |
| lifecycle | Lifecycle | 라이프사이클 |

## 보존

| 단어 | 이유 |
|---|---|
| OAS | cross-system identifier |
| filter \`key\` (all/heartbeat/message/oas_turn/tool/error/lifecycle) | TypeScript identifier, dictionary key |

## Test fixture coupling 검증

| 단어 | Test 등장 | 충돌 |
|---|---|---|
| All / Heartbeat / Message / OAS Turn / Tool / Error / Lifecycle | -- | ❌ 0 (live-timeline.test.ts 는 \`eventMatchesFilter\` 함수만 import; FILTER_CHIPS 데이터에 대한 assertion 없음) |

## 라운드 누적 (23-54)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-44 | -- | MERGED | 139 |
| 45-53 | open Draft | -- | 99 |
| 54 | this | Draft | **7** |

누적 chips ≈ **302**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)