### PR TITLE
fix(build): expose Coord_hooks.claim_post_provision_fn + drop re-introduced TurnReady arm

### DIFF
--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -57,3 +57,6 @@ val tool_assigned_fn : (agent_id:string ->
            Atomic.t
 val task_completion_path_observed_fn : (path:string -> contract_state:string -> agent_name:string -> unit)
            Atomic.t
+val claim_post_provision_fn : (Coord_utils_backend_setup.config ->
+            agent_name:string -> task_id:string -> unit)
+           Atomic.t

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -341,9 +341,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
-  | Oas.Event_bus.TurnReady _ ->
-      (* TurnReady event added in newer OAS. Skip the relay to avoid flooding SSE. *)
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256


### PR DESCRIPTION
## Summary
Two narrow fixes for the current main build break. **Out of scope: DashScope partial-match cascade — separate PR.**

### 1. \`lib/coord/coord_hooks.mli\`

\`claim_post_provision_fn\` was added to \`.ml\` line 237 but never declared in \`.mli\`. Callers in \`coord_task.ml\` and \`server_bootstrap_loops.ml\` see:
\`\`\`
Error: Unbound value Coord_hooks.claim_post_provision_fn
\`\`\`
Add the missing \`val\` declaration matching the \`.ml\` signature.

### 2. \`lib/oas_event_bridge.ml\`

\`Oas.Event_bus.TurnReady _ -> None\` reappeared at line 344 via PR #10784 (\`refactor: adopt open Base in list_util.ml\`) which merged on a stale base after PR #10750 had already added the canonical handler at line 211. Drop the second copy. Same stale-base pattern as #10758→#10788.

## Out of scope (separate PR needed)
- DashScope partial-match cascade. PR #10747 added the variant; PR #10785 only fixed \`headers_with_auth\`. Other sites (\`lib/keeper/keeper_usage_trust.ml\`, \`lib/llm_provider_capabilities\`, ...) still miss the \`DashScope\` arm. Memory ref: \`feedback_variant-add-partial-match-cascade.md\`.

## Verification
- [x] Affected files compile after fix
- [x] Other build errors are *unrelated* to this PR (DashScope sweep)
- [ ] CI required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)