### PR TITLE
refactor(design-system): swap fleet-telemetry-panel keeper filter to TextInput (CS43)

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -21,6 +21,7 @@ import { formatTimeAgo } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
 import { requestConfirm } from './common/confirm-dialog'
 import { Sparkline } from './common/sparkline'
+import { TextInput } from './common/input'
 import { pushSnapshot, getTrend, type MetricKey, type TrendDirection } from './fleet-trend-store'
 import type { DashboardAttentionEvent, DashboardReadinessPillar } from '../types'
 import {
@@ -754,13 +755,13 @@ export function FleetTelemetryPanel() {
       <div>
         <div class="mb-1 flex items-center justify-between gap-2">
           <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">Keeper 비교</div>
-          <input
+          <${TextInput}
             type="search"
             value=${query.value}
             placeholder="name / model / blocker 필터"
-            aria-label="Keeper 필터"
+            ariaLabel="Keeper 필터"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
+            class="min-w-40 max-w-60 flex-1 !px-2 !py-1 !text-2xs"
           />
         </div>
         ${isFiltering && visibleRows.length === 0 && value.rows.length > 0


### PR DESCRIPTION
## Summary

CS series input sweep #23 — fleet-telemetry-panel Keeper 비교 필터.

## 변경

`dashboard/src/components/fleet-telemetry-panel.ts`:
- inline `<input type="search">` → `<${TextInput} type="search">`

## Palette

Pure design-system tokens (`--white-4`, `--white-10`, `--color-fg-primary`, `--color-fg-disabled`, `--color-accent-fg`).

## 검증

- pnpm typecheck: green
- pnpm test src/components/fleet-telemetry-panel: 29/29 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
