### PR TITLE
fix(build): unbreak main — sweep DashScope partial-matches + drop redundant TurnReady

### DIFF
--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -31,7 +31,7 @@ let provider_kind_uses_anthropic_caching
   match kind with
   | Anthropic | Claude_code -> true
   | OpenAI_compat | Ollama | Gemini | Gemini_cli | Kimi | Kimi_cli | Glm
-  | Codex_cli ->
+  | Codex_cli | DashScope ->
       false
 
 let model_label_provider_kind label =

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -339,10 +339,11 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
       (* Per-token telemetry from OAS#1202; not surfaced over SSE — the
          dashboard receives token usage via the existing AgentCompleted
          payload aggregate. Skip the relay to avoid flooding SSE
-         consumers with high-frequency low-value events. *)
-      None
-  | Oas.Event_bus.TurnReady _ ->
-      (* TurnReady event added in newer OAS. Skip the relay to avoid flooding SSE. *)
+         consumers with high-frequency low-value events.
+         The catch-all wildcard below also covers TurnReady (OAS#1201)
+         and any future variant that the bridge does not relay; an
+         explicit arm here was redundant after the wildcard landed
+         and tripped warning-as-error 11. *)
       None
 
 let relay_max_attempts = 3

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1256,5 +1256,5 @@ let non_http_transport_of_provider
                           Llm_provider.Transport_codex_cli.default_config with
                           cwd;
                         }))))
-  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi ->
+  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
       Ok None

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -162,6 +162,7 @@ let cn_kimi_api = "kimi-api"
 let cn_glm = "glm-api"
 let cn_glm_coding_plan = "glm-coding-plan"
 let cn_openrouter = "openrouter"
+let cn_dashscope = "dashscope"
 
 let kimi_api_key_envs = [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
 
@@ -250,6 +251,7 @@ let adapter_canonical_name_of_provider_kind
   | Glm -> cn_glm
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
+  | DashScope -> cn_dashscope
 
 (** Single source of truth for all provider/runtime adapters.
     Simple names ([claude], [codex], [gemini]) are CLI runtimes.
@@ -1413,7 +1415,8 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   | Ollama ->
       resolve_direct_adapter cn_ollama
   | Glm
-  | OpenAI_compat ->
+  | OpenAI_compat
+  | DashScope ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
 
 let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
@@ -1545,7 +1548,8 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Kimi_cli
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli ->
+  | Llm_provider.Provider_config.Codex_cli
+  | Llm_provider.Provider_config.DashScope ->
       auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -43,6 +43,8 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
     | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities
     | Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
+    (* DashScope speaks OpenAI-compatible chat API; reuse the same caps. *)
+    | DashScope -> Llm_provider.Capabilities.openai_chat_capabilities
   in
   let caps =
     match provider_cfg.kind with


### PR DESCRIPTION
## 요약

main이 두 가지 warning-as-error로 BLOCKED 상태입니다.

1. **DashScope variant sweep 누락** — \`Llm_provider.Provider_config.provider_kind\`에 DashScope가 추가됐지만 6개 consumer 사이트에서 partial-match 발생.
2. **TurnReady redundant-case** — \`lib/oas_event_bridge.ml\`의 같은 match 안에 \`TurnReady _ -> None\` 두 번 등장 (line 211, line 344).

\`dune build @check\` exit 0으로 검증 완료.

## 수정 사이트

### DashScope arm 추가 (6곳)
- \`lib/keeper/keeper_usage_trust.ml:31\` — anthropic caching 감지: \`false\`
- \`lib/provider_adapter.ml:242\` — canonical name lookup: \`cn_dashscope = \"dashscope\"\`
- \`lib/provider_adapter.ml:1399\` — adapter resolution: \`resolve_adapter_by_cascade_prefix\` (Glm/OpenAI_compat과 동일 경로)
- \`lib/provider_adapter.ml:1537\` — docker auth-env keys: \`auth_env_keys_of_provider_kind\`
- \`lib/provider_tool_support.ml:34\` — OAS capability: \`openai_chat_capabilities\` 재사용 (DashScope는 OpenAI-compat API)
- \`lib/oas_worker_exec_transport.ml:1150\` — worker exec config: \`Ok None\` (provider-specific transport 없음)

### TurnReady redundant 제거 (1곳)
- \`lib/oas_event_bridge.ml:344\` — 동일 arm이 line 211에서 이미 매치됨

## 영향

- main BLOCKED 상태 해제
- 큐 saturation 25+ PR cascade 회복 트리거
- #10810 (DashScope sweep follow-up) 의 superset — 이 PR이 더 종합적이므로 #10810 close 가능

## Verification

\`\`\`
$ cd .worktrees/fix-main-comprehensive
$ dune build --root . @check
exit=0
\`\`\`

## Memory references

- \`feedback_variant-add-partial-match-cascade\` — variant 추가 후 sweep 누락은 반복 패턴
- \`feedback_circular-ci-dependency-unblock\` — main fix 1 PR이 큐 전체 unblock

🤖 Generated with [Claude Code](https://claude.com/claude-code)