### PR TITLE
fix: main-branch build breaks (DashScope + For_testing + TurnReady)

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -43,7 +43,7 @@ let headers_with_auth ~(kind : Llm_provider.Provider_config.provider_kind) ~api_
         ("x-api-key", api_key)
         :: ("anthropic-version", "2023-06-01")
         :: base
-    | OpenAI_compat | Ollama | Gemini | Glm | Claude_code ->
+    | OpenAI_compat | Ollama | Gemini | Glm | Claude_code | DashScope ->
         ("Authorization", "Bearer " ^ api_key) :: base
     | Gemini_cli | Kimi_cli | Codex_cli -> []
 

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -358,3 +358,13 @@ let prune t ~days =
   end
 
 (* Duplicate count_entries removed — canonical definition at line 225 *)
+
+module For_testing = struct
+  let mutex t = Atomic.get t.mutex
+
+  let mutex_for_base_dir = mutex_for_base_dir
+
+  let registry_size () =
+    Stdlib.Mutex.protect mutex_registry_mu (fun () ->
+      Hashtbl.length mutex_registry)
+end

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -341,8 +341,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
-  | Oas.Event_bus.TurnReady _ ->
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -162,6 +162,7 @@ let cn_kimi_api = "kimi-api"
 let cn_glm = "glm-api"
 let cn_glm_coding_plan = "glm-coding-plan"
 let cn_openrouter = "openrouter"
+let cn_dashscope_api = "dashscope-api"
 
 let kimi_api_key_envs = [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
 
@@ -250,6 +251,7 @@ let adapter_canonical_name_of_provider_kind
   | Glm -> cn_glm
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
+  | DashScope -> cn_dashscope_api
 
 (** Single source of truth for all provider/runtime adapters.
     Simple names ([claude], [codex], [gemini]) are CLI runtimes.
@@ -570,6 +572,29 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = Some "OPENROUTER_DEFAULT_MODEL";
+          default_model_fallback = None;
+          auto_models = No_auto_models;
+          expand_auto = false;
+          family = Generic;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
+    };
+    {
+      canonical_name = cn_dashscope_api;
+      runtime_kind = Direct_api;
+      auth_mode = Api_key "DASHSCOPE_API_KEY";
+      aliases = [ cn_dashscope_api; "dashscope"; "qwen" ];
+      spawn_key = None;
+      cascade_prefix = "dashscope";
+      default_voice = None;
+      endpoint_url =
+        Some (env_url_or ~env:"DASHSCOPE_BASE_URL"
+                ~default:(registry_default_base_url "dashscope"));
+      default_model_id = None;
+      model_policy =
+        {
+          default_model_env = Some "DASHSCOPE_DEFAULT_MODEL";
           default_model_fallback = None;
           auto_models = No_auto_models;
           expand_auto = false;
@@ -1413,7 +1438,8 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   | Ollama ->
       resolve_direct_adapter cn_ollama
   | Glm
-  | OpenAI_compat ->
+  | OpenAI_compat
+  | DashScope ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
 
 let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
@@ -1545,7 +1571,8 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Kimi_cli
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli ->
+  | Llm_provider.Provider_config.Codex_cli
+  | Llm_provider.Provider_config.DashScope ->
       auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -43,6 +43,7 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
     | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities
     | Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
+    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
   in
   let caps =
     match provider_cfg.kind with


### PR DESCRIPTION
## Summary

Fixes three independent main-branch build breaks:

1. **DashScope provider variant (CI blocker)** — OAS added `DashScope` as a new `provider_kind`. masc-mcp's match expressions under `warn-error +a` must cover all variants. Adds canonical name, direct adapter definition, and exhausts all match arms in `provider_adapter.ml`, `provider_tool_support.ml`, `cascade_config.ml`.

2. **`dated_jsonl` For_testing module** — PR #10739 renamed `registry` → `mutex_registry` and changed `mutex` type to `Atomic.t`, but removed the `For_testing` module from `.ml` while leaving it in `.mli`. Restored with updated names.

3. **`oas_event_bridge` TurnReady redundant case** — PR #10664 (Eio Actor model) already handles the `TurnReady` variant, making the explicit arm in `oas_event_bridge.ml` redundant (warning 11).

## Test plan
- [ ] CI Lint/Build/Health all pass
- [ ] `dune build @check` passes locally (verified in CI)
- [ ] No dashboard regressions (pre-existing Korean translation failures are out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)