### PR TITLE
fix(build): unbreak main — DashScope sweep + coord_hooks.mli expose + drop redundant TurnReady arm

### DIFF
--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -57,3 +57,8 @@ val tool_assigned_fn : (agent_id:string ->
            Atomic.t
 val task_completion_path_observed_fn : (path:string -> contract_state:string -> agent_name:string -> unit)
            Atomic.t
+
+val claim_post_provision_fn : (Coord_utils_backend_setup.config ->
+            agent_name:string ->
+            task_id:string -> unit)
+           Atomic.t

--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -31,7 +31,7 @@ let provider_kind_uses_anthropic_caching
   match kind with
   | Anthropic | Claude_code -> true
   | OpenAI_compat | Ollama | Gemini | Gemini_cli | Kimi | Kimi_cli | Glm
-  | Codex_cli ->
+  | Codex_cli | DashScope ->
       false
 
 let model_label_provider_kind label =

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -341,9 +341,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
-  | Oas.Event_bus.TurnReady _ ->
-      (* TurnReady event added in newer OAS. Skip the relay to avoid flooding SSE. *)
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1256,5 +1256,5 @@ let non_http_transport_of_provider
                           Llm_provider.Transport_codex_cli.default_config with
                           cwd;
                         }))))
-  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi ->
+  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
       Ok None

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -162,6 +162,7 @@ let cn_kimi_api = "kimi-api"
 let cn_glm = "glm-api"
 let cn_glm_coding_plan = "glm-coding-plan"
 let cn_openrouter = "openrouter"
+let cn_dashscope = "dashscope-api"
 
 let kimi_api_key_envs = [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
 
@@ -250,6 +251,7 @@ let adapter_canonical_name_of_provider_kind
   | Glm -> cn_glm
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
+  | DashScope -> cn_dashscope
 
 (** Single source of truth for all provider/runtime adapters.
     Simple names ([claude], [codex], [gemini]) are CLI runtimes.
@@ -1412,6 +1414,8 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
       resolve_direct_adapter cn_kimi_api
   | Ollama ->
       resolve_direct_adapter cn_ollama
+  | DashScope ->
+      resolve_direct_adapter cn_dashscope
   | Glm
   | OpenAI_compat ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
@@ -1545,7 +1549,8 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Kimi_cli
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli ->
+  | Llm_provider.Provider_config.Codex_cli
+  | Llm_provider.Provider_config.DashScope ->
       auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -43,6 +43,7 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
     | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities
     | Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
+    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
   in
   let caps =
     match provider_cfg.kind with


### PR DESCRIPTION
## Summary

main (HEAD `2f8cdf60f0`)이 빌드 깨짐 — 세 가지 root 동시 발생. 한 PR로 묶어 unblock.

### 1. `DashScope` partial-match cascade (5 sites)

OAS pin `4de9926b` (#10747)이 `Llm_provider.Provider_kind.t`에 `DashScope` variant 추가. masc-mcp 측 sweep 누락으로 5개 exhaustive match가 warning 8 (partial-match)로 빌드 실패.

- `lib/provider_tool_support.ml` `oas_capabilities_of_config` → `Llm_provider.Capabilities.dashscope_capabilities` 라우팅.
- `lib/keeper/keeper_usage_trust.ml` `provider_kind_uses_anthropic_caching` → `DashScope -> false` (OpenAI-compat API, Anthropic-shape 아님).
- `lib/provider_adapter.ml` × 3:
  - `cn_dashscope = "dashscope-api"` canonical name 추가
  - `adapter_canonical_name_of_provider_kind`: `DashScope -> cn_dashscope`
  - `adapter_of_provider_config`: `DashScope -> resolve_direct_adapter cn_dashscope`
  - `docker_auth_env_keys_of_provider_config`: `auth_env_keys_of_provider_kind` 경로 (`DASHSCOPE_API_KEY` 이미 처리됨)
- `lib/oas_worker_exec_transport.ml` provider transport match: `DashScope -> Ok None` (default HTTP).

### 2. `Coord_hooks.claim_post_provision_fn` mli 미노출

#10771이 `coord_hooks.ml:237`에 `claim_post_provision_fn` 추가 (`coord_task.ml:1000`, `server_bootstrap_loops.ml:20`에서 사용). #10781(.mli 재생성)이 이 함수를 빼먹음. mli에 val 선언 추가.

### 3. `TurnReady _ -> None` redundant case

`oas_event_bridge.ml:344`에 중복 `TurnReady` arm. #10750 (InferenceTelemetry/TurnReady refactor)이 라인 83/211에서 처리 완료한 후에도 라인 344가 남아 warning 11. 제거.

## Memory tag

오늘 발생한 `audit-bucket-cascade-pattern` 3번째 instance: OAS variant 변경 → 다운스트림 sweep cascade. `variant-add-partial-match-cascade`도 동일 패턴.

## Test plan

- [x] `dune build --root .` exit 0 clean (agent_sdk@4de9926b, `scripts/oas-agent-sdk-pin.sh`와 일치)
- [x] 5개 partial-match arm 타입체크 통과
- [x] redundant-case warning 제거 확인
- [ ] CI green
