### PR TITLE
feat(dashboard): localize 4 strings (autoscroll tooltip + judge hints) (round-55)

### DIFF
--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -158,7 +158,7 @@ export function AgentLiveTimeline({ name }: { name: string }) {
               ? 'border-[rgba(34,197,94,0.4)] text-[var(--color-status-ok)] bg-[var(--white-4)]'
               : 'border-[var(--white-10)] text-[var(--color-fg-disabled)] bg-[var(--white-4)]'}"
             onClick=${() => { autoScroll.value = !autoScroll.value }}
-            title=${autoScroll.value ? 'Auto-scroll ON' : 'Auto-scroll OFF'}
+            title=${autoScroll.value ? '자동 스크롤 ON' : '자동 스크롤 OFF'}
           >
             ${autoScroll.value ? 'AUTO' : 'MANUAL'}
           </button>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -122,12 +122,12 @@ function GovernanceSummaryStrip() {
       <${KpiCard}
         label="Judge 상태"
         value=${liveJudgeState}
-        hint=${judge?.keeper_name?.trim() || 'live judge'}
+        hint=${judge?.keeper_name?.trim() || '실시간 judge'}
         tone=${judgeUnhealthy ? 'text-warn' : (judgeHealthy ? 'text-ok' : undefined)}
         class=${judgeUnhealthy ? 'border-warn/40 bg-warn/5 ring-1 ring-warn/25' : (judgeHealthy ? 'border-ok/30 bg-ok/5' : '')}
       />
-      <${KpiCard} label="Judge 모델" value=${liveJudgeModel} hint=${judge?.model_used?.trim() ? 'runtime reported' : 'unknown'} />
-      <${KpiCard} label="최근 판단" value=${judgmentCount} hint="live" />
+      <${KpiCard} label="Judge 모델" value=${liveJudgeModel} hint=${judge?.model_used?.trim() ? '런타임 보고' : '알 수 없음'} />
+      <${KpiCard} label="최근 판단" value=${judgmentCount} hint="실시간" />
       <${KpiCard}
         label="관리자 승인 대기"
         value=${approvalCount}


### PR DESCRIPTION
## Summary

대시보드 라운드 55 — autoscroll button tooltip + governance judge KpiCard hints 4 strings 한국어화.

| File | Element | Before | After |
|---|---|---|---|
| agent-monitor/live-timeline.ts:161 | autoscroll tooltip | Auto-scroll ON / Auto-scroll OFF | 자동 스크롤 ON / 자동 스크롤 OFF |
| governance.ts:125 | judge keeper hint fallback | live judge | 실시간 judge |
| governance.ts:129 | model_used hint pair | runtime reported / unknown | 런타임 보고 / 알 수 없음 |
| governance.ts:130 | judgment count hint | live | 실시간 |

## 보존

| 단어 | 이유 |
|---|---|
| AUTO / MANUAL (live-timeline.ts:163) | UI convention button text |
| ON / OFF (tooltip) | 표준 토글 표시 |
| Judge | 도메인 용어 (governance) |

## Test fixture coupling 검증

| 단어 | Test 등장 | 충돌 |
|---|---|---|
| Auto-scroll / live judge / runtime reported / unknown / live | -- | ❌ 0 |

## 라운드 누적 (23-55)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-44 | -- | MERGED | 139 |
| 45-54 | open Draft | -- | 106 |
| 55 | this | Draft | **4** |

누적 chips ≈ **306**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)