### PR TITLE
fix(build): unbreak main — DashScope variant sweep (6 sites) + redundant TurnReady

### DIFF
--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -31,7 +31,7 @@ let provider_kind_uses_anthropic_caching
   match kind with
   | Anthropic | Claude_code -> true
   | OpenAI_compat | Ollama | Gemini | Gemini_cli | Kimi | Kimi_cli | Glm
-  | Codex_cli ->
+  | Codex_cli | DashScope ->
       false
 
 let model_label_provider_kind label =

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -341,9 +341,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
-  | Oas.Event_bus.TurnReady _ ->
-      (* TurnReady event added in newer OAS. Skip the relay to avoid flooding SSE. *)
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1256,5 +1256,5 @@ let non_http_transport_of_provider
                           Llm_provider.Transport_codex_cli.default_config with
                           cwd;
                         }))))
-  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi ->
+  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
       Ok None

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -248,6 +248,11 @@ let adapter_canonical_name_of_provider_kind
   | Gemini_cli -> cn_gemini
   | Kimi_cli -> cn_kimi
   | Glm -> cn_glm
+  | DashScope ->
+      (* OAS 0.179+: Alibaba DashScope OpenAI-compat endpoint.  Treated
+         as an OpenAI-compat adapter for canonical naming until masc-mcp
+         needs a dedicated label. *)
+      cn_codex_api
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
 
@@ -1413,6 +1418,7 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   | Ollama ->
       resolve_direct_adapter cn_ollama
   | Glm
+  | DashScope
   | OpenAI_compat ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
 
@@ -1544,6 +1550,7 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Gemini_cli
   | Llm_provider.Provider_config.Kimi_cli
   | Llm_provider.Provider_config.Glm
+  | Llm_provider.Provider_config.DashScope
   | Llm_provider.Provider_config.Claude_code
   | Llm_provider.Provider_config.Codex_cli ->
       auth_env_keys_of_provider_kind cfg.kind

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -39,6 +39,7 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Glm -> Llm_provider.Capabilities.glm_capabilities
     | Gemini -> Llm_provider.Capabilities.gemini_capabilities
     | OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
+    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
     | Claude_code -> Llm_provider.Capabilities.claude_code_capabilities
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
     | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities


### PR DESCRIPTION
## P0 — main 빌드 6개 partial-match + 1개 redundant case

OAS 0.179+ 가 \`Llm_provider.Provider_config.provider_kind\` 에 \`DashScope\` 를 추가. PR #10785 가 cascade_config 한 사이트만 update — 나머지 5 사이트가 strict-match exhaustiveness fail (warning 8 fatal).

### 빌드 에러 (origin/main)

```
File \"lib/keeper/keeper_usage_trust.ml\", lines 31-35:
File \"lib/provider_tool_support.ml\", lines 34-45:
File \"lib/provider_adapter.ml\", lines 242-252:
File \"lib/provider_adapter.ml\", lines 1398-1417:
File \"lib/provider_adapter.ml\", lines 1535-1549:
File \"lib/oas_worker_exec_transport.ml\", lines 1150-1260:
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.

File \"lib/oas_event_bridge.ml\", line 344, characters 4-29:
Error (warning 11 [redundant-case]): this match case is unused.
```

memory \`feedback_variant-add-partial-match-cascade\` 의 정확한 사례.

## 변경

| 파일 | 변경 |
|------|------|
| \`lib/keeper/keeper_usage_trust.ml\` | \`DashScope\` 를 non-anthropic-cache arm 에 추가 |
| \`lib/provider_tool_support.ml\` | \`DashScope -> dashscope_capabilities\` |
| \`lib/provider_adapter.ml\` (3 사이트) | OpenAI-compat 와 동일 arm 으로 라우팅 |
| \`lib/oas_worker_exec_transport.ml\` | \`DashScope -> Ok None\` (CLI transport 없음) |
| \`lib/oas_event_bridge.ml:344\` | redundant \`TurnReady _\` arm 삭제 (line 211 이 처리) |

## 빌드

\`dune build @check\` EXIT=0.

## Supersedes #10815

#10815 가 #10791 (Atomic.get) + #10793 (claim_post_provision_fn mli) 와 동시 머지되며 conflicting 발생. 이 PR 은 origin/main 의 잔여 break 만 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)