### PR TITLE
test(connector-status): sync test expectation to localized 사이드카 (drift #3)

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -659,7 +659,7 @@ describe('ConnectorStatusPanel', () => {
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(text).toContain('사이드카 미시작')
     expect(text).toContain('cd sidecars/discord-bot && ./run.sh')
-    expect(text).toContain('원인: sidecar status 파일이')
+    expect(text).toContain('원인: 사이드카 status 파일이')
     expect(text).toContain('/tmp/discord_status.json')
     expect(text).toContain('관찰되지 않았습니다')
     expect(text).toContain('다음:')


### PR DESCRIPTION
## Summary

connector-status 3rd i18n drift fix — 동일 패턴 (#10734, #10769)에 이어 3번째.

## Drift

`connector-status.ts:1056` source가 한국어로 localize:
- `사이드카 status 파일이`

`connector-status.test.ts:662` expectation은 영어 그대로:
- `'원인: sidecar status 파일이'`

→ `pnpm test src/components/connector-status` 1/25 fail. design-system CS45+ 작업이 같은 테스트로 blocking됨.

## 변경

`dashboard/src/components/connector-status.test.ts:662`:
```ts
- expect(text).toContain('원인: sidecar status 파일이')
+ expect(text).toContain('원인: 사이드카 status 파일이')
```

## 검증

- pnpm test src/components/connector-status: **25/25 pass** (이전 24/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
