### PR TITLE
refactor(design-system): swap connector-status keeper filter to TextInput (CS45)

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1102,14 +1102,14 @@ function ConnectorLivePanel({
         ? html`
             <div class="mt-3 space-y-2" id=${`keepers-${connectorId}`}>
               <div class="flex items-center justify-end">
-                <input
+                <${TextInput}
                   type="search"
                   value=${keeperQuery}
                   placeholder="keeper / model / runtime 필터"
-                  aria-label="Keeper 필터"
-                  data-testid=${`keeper-filter-${connectorId}`}
+                  ariaLabel="Keeper 필터"
+                  testId=${`keeper-filter-${connectorId}`}
                   onInput=${(e: Event) => { patchConnectorUiState(connectorId, { keeperGroupQuery: (e.target as HTMLInputElement).value }) }}
-                  class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
+                  class="min-w-40 max-w-65 flex-1 !px-2 !py-1 !text-2xs"
                 />
               </div>
               ${isFilteringKeepers && visibleKnownGroups.length === 0


### PR DESCRIPTION
## Summary

CS series input sweep #25 — connector-status Keeper 필터. **CS23 `testId` prop의 두 번째 활용 (dynamic per-connector ID)**.

## 변경

`dashboard/src/components/connector-status.ts`:
- inline `<input type="search">` → `<${TextInput} type="search">`
- `data-testid=${\`keeper-filter-${connectorId}\`}` → `testId=${\`keeper-filter-${connectorId}\`}` (E2E selector 보존)

## Palette

Pure design-system tokens (`--white-4`, `--white-10`, `--color-fg-primary`, `--color-fg-disabled`, `--color-accent-fg`).

## 검증

- pnpm typecheck: green
- pnpm test src/components/connector-status: 24 pass + 1 **pre-existing** i18n drift fail (`사이드카` source vs `sidecar` test) — #10826에서 분리 수정. CS45 자체에는 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
