### PR TITLE
fix(build): unbreak main — DashScope sweep + drop redundant TurnReady arm

### DIFF
--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -31,7 +31,7 @@ let provider_kind_uses_anthropic_caching
   match kind with
   | Anthropic | Claude_code -> true
   | OpenAI_compat | Ollama | Gemini | Gemini_cli | Kimi | Kimi_cli | Glm
-  | Codex_cli ->
+  | DashScope | Codex_cli ->
       false
 
 let model_label_provider_kind label =

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -341,9 +341,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
-  | Oas.Event_bus.TurnReady _ ->
-      (* TurnReady event added in newer OAS. Skip the relay to avoid flooding SSE. *)
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1256,5 +1256,5 @@ let non_http_transport_of_provider
                           Llm_provider.Transport_codex_cli.default_config with
                           cwd;
                         }))))
-  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi ->
+  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | DashScope | Kimi ->
       Ok None

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -161,6 +161,7 @@ let cn_gemini_api = "gemini-api"
 let cn_kimi_api = "kimi-api"
 let cn_glm = "glm-api"
 let cn_glm_coding_plan = "glm-coding-plan"
+let cn_dashscope = "dashscope"
 let cn_openrouter = "openrouter"
 
 let kimi_api_key_envs = [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
@@ -248,6 +249,7 @@ let adapter_canonical_name_of_provider_kind
   | Gemini_cli -> cn_gemini
   | Kimi_cli -> cn_kimi
   | Glm -> cn_glm
+  | DashScope -> cn_dashscope
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
 
@@ -1413,6 +1415,7 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   | Ollama ->
       resolve_direct_adapter cn_ollama
   | Glm
+  | DashScope
   | OpenAI_compat ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
 
@@ -1544,6 +1547,7 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Gemini_cli
   | Llm_provider.Provider_config.Kimi_cli
   | Llm_provider.Provider_config.Glm
+  | Llm_provider.Provider_config.DashScope
   | Llm_provider.Provider_config.Claude_code
   | Llm_provider.Provider_config.Codex_cli ->
       auth_env_keys_of_provider_kind cfg.kind

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -39,6 +39,7 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Glm -> Llm_provider.Capabilities.glm_capabilities
     | Gemini -> Llm_provider.Capabilities.gemini_capabilities
     | OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
+    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
     | Claude_code -> Llm_provider.Capabilities.claude_code_capabilities
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
     | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities


### PR DESCRIPTION
**main is currently RED.** Open PRs (#10791 was merged — main has moved past it; latest break is the DashScope cascade plus the same For_testing-pattern redundant TurnReady arm).

## Break — OAS pin DashScope variant addition

OAS pinned a new commit that adds the \`DashScope\` provider variant (\`Provider_kind.t\`, oas#1196 / b6decd42 → 0.178.0). 6 consumer sites under \`-warn-error +8\` broke the main build:

| File | Line | Function |
|------|------|----------|
| \`lib/keeper/keeper_usage_trust.ml\` | 31 | \`provider_kind_uses_anthropic_caching\` |
| \`lib/provider_tool_support.ml\` | 34 | \`oas_capabilities_of_config\` (base caps) |
| \`lib/provider_adapter.ml\` | 242 | \`adapter_canonical_name_of_provider_kind\` |
| \`lib/provider_adapter.ml\` | 1398 | \`adapter_of_provider_config\` |
| \`lib/provider_adapter.ml\` | 1535 | \`docker_auth_env_keys_of_provider_config\` |
| \`lib/oas_worker_exec_transport.ml\` | 1259 | transport selection |

Each got an explicit \`DashScope\` arm wired to the corresponding existing helper:

- caching: \`false\` (Anthropic prompt caching is provider-specific)
- capabilities: \`Llm_provider.Capabilities.dashscope_capabilities\` (already present in OAS upstream)
- canonical name: \`let cn_dashscope = \"dashscope\"\`, matching \`Provider_kind.to_string\`
- adapter routing: \`resolve_adapter_by_cascade_prefix\` alongside \`Glm\`/\`OpenAI_compat\` (DashScope is an OpenAI-compatible Chat Completions endpoint)
- auth env: \`DASHSCOPE_API_KEY\` via the same generic path

## Break — \`oas_event_bridge.ml\` redundant TurnReady arm

\`lib/oas_event_bridge.ml:344\` had a duplicate \`TurnReady _ -> None\` arm; the first one at line 211 already covers the case. Same pattern as the For_testing dup that #10750/#10758 created — concurrent CI-fix PRs landing without seeing each other.

Dropped the second arm.

## Verification

\`\`\`
$ dune build --root=. lib test
EXIT=0
\`\`\`

vs. before this PR:

\`\`\`
6× Error (warning 8 [partial-match]): … : DashScope
1× Error (warning 11 [redundant-case]): … TurnReady
\`\`\`

## Supersedes

- **#10810** (Draft, MERGEABLE, 3 files) — covers keeper_usage_trust, provider_adapter, provider_tool_support but missing oas_worker_exec_transport + the redundant TurnReady arm.
- **#10815** (Draft, CONFLICTING, 5 files) — covers more files but stale base.

## Pattern

Exactly the recurring P0 documented in #10584 (\"Recurring P0: exhaustive match on cross-module variant breaks main on variant addition\"). The OAS-side helper opened in [oas#1205 (\`payload_kind\` SSOT)](https://github.com/jeong-sik/oas/pull/1205) is the parallel fix for \`Event_bus.payload\` variant additions; the same Option B pattern applied to \`provider_kind\` would let OAS itself ship a default arm so consumers degrade gracefully instead of failing the build.