### PR TITLE
refactor(design-system): swap governance HITL approval filter to TextInput (CS46)

### DIFF
--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -12,6 +12,7 @@ import { EmptyState } from './common/empty-state'
 import { StatusDot } from './common/status-dot'
 import { JsonViewerCard } from './common/json-viewer'
 import { ActionButton } from './common/button'
+import { TextInput } from './common/input'
 import {
   governanceData,
   governanceError,
@@ -491,14 +492,14 @@ function KeeperApprovalQueueSection() {
       </div>
       ${hasItems ? html`
         <div class="mb-3 flex items-center gap-2">
-          <input
+          <${TextInput}
             type="search"
             value=${query.value}
             placeholder="keeper / tool / 위험도 필터"
-            aria-label="Keeper HITL 승인 필터"
-            data-testid="keeper-hitl-approval-filter"
+            ariaLabel="Keeper HITL 승인 필터"
+            testId="keeper-hitl-approval-filter"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-40 max-w-70 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
+            class="min-w-40 max-w-70 flex-1 !px-2 !py-1 !text-2xs"
           />
         </div>
       ` : null}


### PR DESCRIPTION
## Summary

CS series input sweep #26 — governance Keeper HITL 승인 필터. **CS23 `testId` prop의 세 번째 활용 (static testId)**.

## 변경

`dashboard/src/components/governance.ts`:
- inline `<input type="search">` → `<${TextInput} type="search">`
- `data-testid="keeper-hitl-approval-filter"` → `testId="keeper-hitl-approval-filter"`

## Palette

Pure design-system tokens (`--white-4`, `--white-10`, `--color-fg-primary`, `--color-fg-disabled`, `--color-accent-fg`).

## 검증

- pnpm typecheck: green
- pnpm test src/components/governance: 75/75 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
