### PR TITLE
feat(dashboard): localize 12 toast/save/warning messages (round-56)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -1094,9 +1094,9 @@ function CascadeRawConfigEditor({
       saveMessage.value = 'Saved. Refreshing cascade snapshot...'
       try {
         await onRefresh()
-        saveMessage.value = 'Saved successfully.'
+        saveMessage.value = '저장 완료.'
       } catch (error) {
-        saveMessage.value = `Saved, but refresh failed: ${errorMessage(error)}`
+        saveMessage.value = `저장됨, 새로고침 실패: ${errorMessage(error)}`
       }
     } catch (error) {
       saveMessage.value = `Failed to save: ${errorMessage(error)}`

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -30,15 +30,15 @@ function handleSave(event: Event) {
     saving.value = true
     saveMessage.value = ''
     updateExcusePatterns(parsed).then(() => {
-      saveMessage.value = 'Saved successfully.'
+      saveMessage.value = '저장 완료.'
       refreshExcusePatterns()
     }).catch(err => {
-      saveMessage.value = `Failed to save: ${err.message}`
+      saveMessage.value = `저장 실패: ${err.message}`
     }).finally(() => {
       saving.value = false
     })
   } catch (err: any) {
-    saveMessage.value = `Invalid format: ${err.message}`
+    saveMessage.value = `잘못된 형식: ${err.message}`
   }
 }
 

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -578,7 +578,7 @@ export function FleetTelemetryPanel() {
           ? toolQualityResult.value
           : EMPTY_TOOL_QUALITY
       if (toolQualityResult.status === 'rejected' && !isAbortError(toolQualityResult.reason)) {
-        warnings.push(`Tool quality unavailable: ${errorMessage(toolQualityResult.reason)}`)
+        warnings.push(`도구 품질 데이터 사용 불가: ${errorMessage(toolQualityResult.reason)}`)
       }
 
       const telemetrySummary =
@@ -586,7 +586,7 @@ export function FleetTelemetryPanel() {
           ? telemetrySummaryResult.value
           : { generated_at: '', sources: [], total_entries: 0 }
       if (telemetrySummaryResult.status === 'rejected' && !isAbortError(telemetrySummaryResult.reason)) {
-        warnings.push(`Telemetry store summary unavailable: ${errorMessage(telemetrySummaryResult.reason)}`)
+        warnings.push(`텔레메트리 저장소 요약 사용 불가: ${errorMessage(telemetrySummaryResult.reason)}`)
       }
       warnings.push(...buildTelemetryWarnings(telemetrySummary.sources))
 
@@ -595,7 +595,7 @@ export function FleetTelemetryPanel() {
           ? normalizeNamespaceTruth(namespaceTruthResult.value)
           : null
       if (namespaceTruthResult.status === 'rejected' && !isAbortError(namespaceTruthResult.reason)) {
-        warnings.push(`Control room unavailable: ${errorMessage(namespaceTruthResult.reason)}`)
+        warnings.push(`Control room 사용 불가: ${errorMessage(namespaceTruthResult.reason)}`)
       }
 
       const rows = buildFleetRows(keepers, toolQuality)

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -175,7 +175,7 @@ export function KeeperDiagnosticSummary({
     try {
       await hydrateKeeperStatus(keeper.name, true)
     } catch (err) {
-      const message = err instanceof Error ? err.message : `Failed to inspect ${keeper.name}`
+      const message = err instanceof Error ? err.message : `${keeper.name} 점검 실패`
       showToast(message, 'error')
     }
   }
@@ -283,7 +283,7 @@ export function KeeperConversationPanel({
       await sendKeeperThreadMessage(keeperName, prompt)
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') return
-      const message = err instanceof Error ? err.message : `Failed to message ${keeperName}`
+      const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
       showToast(message, 'error')
     }
   }
@@ -411,7 +411,7 @@ export function KeeperRuntimeActions({
         class=${recommended === 'probe' ? activeGhostBtn : ghostBtn}
         onClick=${() => {
           void probeKeeperRuntime(keeper.name, actor).catch(err => {
-            const message = err instanceof Error ? err.message : `Failed to probe ${keeper.name}`
+            const message = err instanceof Error ? err.message : `${keeper.name} 점검 실패`
             showToast(message, 'error')
           })
         }}
@@ -423,7 +423,7 @@ export function KeeperRuntimeActions({
         class=${recommended === 'recover' ? activeSecondaryBtn : secondaryBtn}
         onClick=${() => {
           void recoverKeeperRuntime(keeper.name, actor).catch(err => {
-            const message = err instanceof Error ? err.message : `Failed to recover ${keeper.name}`
+            const message = err instanceof Error ? err.message : `${keeper.name} 복구 실패`
             showToast(message, 'error')
           })
         }}


### PR DESCRIPTION
## Summary

대시보드 라운드 56 — saveMessage / toast fallback / warnings 12종 한국어화.

## excuse-patterns saveMessage (3)

| Before | After |
|---|---|
| 'Saved successfully.' | '저장 완료.' |
| \`Failed to save: ${msg}\` | \`저장 실패: ${msg}\` |
| \`Invalid format: ${msg}\` | \`잘못된 형식: ${msg}\` |

## cascade-config-panel saveMessage (2)

| Before | After |
|---|---|
| 'Saved successfully.' | '저장 완료.' |
| \`Saved, but refresh failed: ${msg}\` | \`저장됨, 새로고침 실패: ${msg}\` |

## fleet-telemetry-panel warnings (3)

| Before | After |
|---|---|
| \`Tool quality unavailable: ${msg}\` | \`도구 품질 데이터 사용 불가: ${msg}\` |
| \`Telemetry store summary unavailable: ${msg}\` | \`텔레메트리 저장소 요약 사용 불가: ${msg}\` |
| \`Control room unavailable: ${msg}\` | \`Control room 사용 불가: ${msg}\` |

## keeper-shared toast fallbacks (4)

| Before | After |
|---|---|
| \`Failed to inspect ${name}\` | \`${name} 점검 실패\` |
| \`Failed to message ${name}\` | \`${name} 메시지 전송 실패\` |
| \`Failed to probe ${name}\` | \`${name} 점검 실패\` |
| \`Failed to recover ${name}\` | \`${name} 복구 실패\` |

## 보존

| 단어 | 이유 |
|---|---|
| Control room | 도메인 용어 (governance area) |
| err.message (외부 Error 의 .message 그대로 유지) | 시스템 에러 메시지 원문 |

## Test fixture coupling 검증

| 단어 | Test 등장 | 충돌 |
|---|---|---|
| Saved successfully / Failed to save / Invalid format / Tool quality unavailable / etc | -- | ❌ 0 |

## 라운드 누적 (23-56)

| Round | PR | 상태 | chips |
|---|---|---|---|
| 23-30 | -- | MERGED | 57 |
| 31-44 | -- | MERGED | 139 |
| 45-55 | open Draft | -- | 110 |
| 56 | this | Draft | **12** |

누적 chips ≈ **318**.

## Why Draft

#10645 (vitest infra) 미해결. 시각 검증 후 ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)