### PR TITLE
refactor(design-system): swap persona-generator handle/display inputs to TextInput (CS47)

### DIFF
--- a/dashboard/src/components/keeper-spawn/persona-generator.ts
+++ b/dashboard/src/components/keeper-spawn/persona-generator.ts
@@ -4,6 +4,7 @@ import { signal } from '@preact/signals'
 import { ActionButton } from '../common/button'
 import { Select } from '../common/select'
 import { Checkbox } from '../common/checkbox'
+import { TextInput } from '../common/input'
 import { showToast } from '../common/toast'
 import {
   generatePersonaDraft,
@@ -123,20 +124,24 @@ export function PersonaGenerator() {
         <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
           <label class="grid gap-1 text-3xs text-[var(--color-fg-muted)]">
             handle
-            <input
+            <${TextInput}
+              type="text"
               value=${handle.value}
               placeholder="auto"
+              ariaLabel="persona handle"
               onInput=${(e: Event) => { handle.value = (e.target as HTMLInputElement).value }}
-              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--color-fg-primary)] focus:outline-none focus:border-[var(--color-accent-fg)]"
+              class="!px-2 !py-1.5 !text-2xs"
             />
           </label>
           <label class="grid gap-1 text-3xs text-[var(--color-fg-muted)]">
             display
-            <input
+            <${TextInput}
+              type="text"
               value=${displayName.value}
               placeholder="auto"
+              ariaLabel="persona display name"
               onInput=${(e: Event) => { displayName.value = (e.target as HTMLInputElement).value }}
-              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--color-fg-primary)] focus:outline-none focus:border-[var(--color-accent-fg)]"
+              class="!px-2 !py-1.5 !text-2xs"
             />
           </label>
           <label class="grid gap-1 text-3xs text-[var(--color-fg-muted)]">


### PR DESCRIPTION
## Summary

CS series input sweep #27 — persona-generator **2 inputs batch** (handle + display name).

## 변경

`dashboard/src/components/keeper-spawn/persona-generator.ts`:
1. inline handle `<input>` → `<${TextInput} type="text">` + `ariaLabel="persona handle"`
2. inline displayName `<input>` → `<${TextInput} type="text">` + `ariaLabel="persona display name"`

(2 checkboxes 같은 파일 내 — Checkbox sweep 별도 처리 예정)

## Palette

Pure design-system tokens (`--white-4`, `--white-10`, `--color-fg-primary`, `--color-accent-fg`).

## 검증

- pnpm typecheck: green
- persona-generator 자체 test 없음 → pnpm test `src/components/keeper-spawn`: **19/19 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
