### PR TITLE
fix(build): drop 4 redundant DashScope arms from stale-base merge race

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -249,11 +249,6 @@ let adapter_canonical_name_of_provider_kind
   | Gemini_cli -> cn_gemini
   | Kimi_cli -> cn_kimi
   | Glm -> cn_glm
-  | DashScope ->
-      (* OAS 0.179+: Alibaba DashScope OpenAI-compat endpoint.  Treated
-         as an OpenAI-compat adapter for canonical naming until masc-mcp
-         needs a dedicated label. *)
-      cn_codex_api
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
 
@@ -1421,7 +1416,6 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   | DashScope ->
       resolve_direct_adapter cn_codex_api
   | Glm
-  | DashScope
   | OpenAI_compat ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
 
@@ -1555,8 +1549,7 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.DashScope
   | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli
-  | Llm_provider.Provider_config.DashScope ->
+  | Llm_provider.Provider_config.Codex_cli ->
       auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -40,7 +40,6 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Gemini -> Llm_provider.Capabilities.gemini_capabilities
     | DashScope -> Llm_provider.Capabilities.openai_chat_capabilities
     | OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
-    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
     | Claude_code -> Llm_provider.Capabilities.claude_code_capabilities
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
     | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities


### PR DESCRIPTION
## Summary
Two PRs merged 51 seconds apart on stale bases, each adding \`DashScope\` arms at different positions in the same files. After both landed, the second-to-match arm in each site became unreachable.

| Commit | Time | Sites added |
|--------|------|-------------|
| \`0ecf0b48087\` | 01:31:09Z | provider_tool_support.ml:43, provider_adapter.ml:252-256, provider_adapter.ml:1424 |
| \`de5fc86e56d\` | 01:32:00Z | provider_tool_support.ml:41, provider_adapter.ml:246, provider_adapter.ml:1421-1422, provider_adapter.ml:1556 |

Build under \`warn-error +8/+a\`:
\`\`\`
warning 11 [redundant-case]: this match case is unused.    ← 2 sites
warning 12 [redundant-subpat]: this sub-pattern is unused. ← 2 sites
\`\`\`

## Removed (semantic-preserving — bodies identical at each site)

1. \`provider_tool_support.ml:43\` — duplicate \`DashScope -> dashscope_capabilities\` (line 41 already maps \`openai_chat_capabilities\`)
2. \`provider_adapter.ml:252-256\` — duplicate dedicated arm (line 246 already maps \`cn_codex_api\`)
3. \`provider_adapter.ml:1424\` — sub-pattern \`| DashScope\` (dedicated arm at line 1421 catches it first)
4. \`provider_adapter.ml:1559\` — duplicate \`Provider_config.DashScope\` in OR group (line 1556 already lists it); moved \`->\` to line 1558 (Codex_cli) for case end

## Verification
- [x] \`dune build @check\` — green
- [x] \`dune build bin/main_eio.exe\` — green

## Pattern recurrence
This is **5th** stale-base merge cascade in the same 7-hour window (memory: \`feedback_variant-add-partial-match-cascade.md\`, \`feedback_stale-base-reveals-via-diff-stat-anomaly.md\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)