### PR TITLE
refactor(design-system): swap tool-full-inventory 3 checkboxes to Checkbox (CS48)

### DIFF
--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -7,6 +7,7 @@ import { EmptyState } from '../common/empty-state'
 import { ErrorState } from '../common/feedback-state'
 import { TextInput } from '../common/input'
 import { Select } from '../common/select'
+import { Checkbox } from '../common/checkbox'
 import { route } from '../../router'
 import type { DashboardToolInventoryItem } from '../../api'
 import { InventoryRow } from './tool-inventory-row'
@@ -154,32 +155,26 @@ export function FullInventoryView({
           onInput=${(v: string) => { categoryFilter.value = v }}
         />
         <label class="inline-flex items-center gap-2 text-xs text-[var(--color-fg-primary)]">
-          <input
-            type="checkbox"
+          <${Checkbox}
             checked=${directOnly.value}
-            onChange=${(e: Event) => {
-              directOnly.value = (e.target as HTMLInputElement).checked
-            }}
+            ariaLabel="직접 호출만"
+            onChange=${(checked: boolean) => { directOnly.value = checked }}
           />
           <span>직접 호출만</span>
         </label>
         <label class="inline-flex items-center gap-2 text-xs text-[var(--color-fg-primary)]">
-          <input
-            type="checkbox"
+          <${Checkbox}
             checked=${showHidden.value}
-            onChange=${(e: Event) => {
-              showHidden.value = (e.target as HTMLInputElement).checked
-            }}
+            ariaLabel="숨김 표시"
+            onChange=${(checked: boolean) => { showHidden.value = checked }}
           />
           <span>숨김 표시</span>
         </label>
         <label class="inline-flex items-center gap-2 text-xs text-[var(--color-fg-primary)]">
-          <input
-            type="checkbox"
+          <${Checkbox}
             checked=${showDeprecated.value}
-            onChange=${(e: Event) => {
-              showDeprecated.value = (e.target as HTMLInputElement).checked
-            }}
+            ariaLabel="지원 중단 표시"
+            onChange=${(checked: boolean) => { showDeprecated.value = checked }}
           />
           <span>지원 중단 표시</span>
         </label>


### PR DESCRIPTION
## Summary

CS series — **first Checkbox sweep PR** (TextInput 누적 27개 후 element type 전환).
tool-full-inventory **3 checkboxes batch**.

## 변경

`dashboard/src/components/tools/tool-full-inventory.ts`:
1. `<input type="checkbox">` (직접 호출만) → `<${Checkbox} ariaLabel="직접 호출만">`
2. `<input type="checkbox">` (숨김 표시) → `<${Checkbox} ariaLabel="숨김 표시">`
3. `<input type="checkbox">` (지원 중단 표시) → `<${Checkbox} ariaLabel="지원 중단 표시">`

## API 단순화

- inline: `onChange=${(e) => { x.value = (e.target as HTMLInputElement).checked }}`
- canonical: `onChange=${(checked: boolean) => { x.value = checked }}`

(Checkbox 가 이미 `e.target.checked` 추출 → boolean 콜백 시그니처 노출)

## Palette

Checkbox 자체가 `--color-border-default`, `--white-4/8/20`, `--accent-45`, `--color-accent-fg` 사용 — 시각 동일.

## 검증

- pnpm typecheck: green
- pnpm test src/components/tools: **76/76 pass**
- pnpm test src/components/common/checkbox: 13/13 pass (regression 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
