### PR TITLE
test: sync dashboard expectations with updated labels

### DIFF
--- a/dashboard/src/components/connector-onboarding.test.ts
+++ b/dashboard/src/components/connector-onboarding.test.ts
@@ -76,7 +76,7 @@ describe('ConnectorOnboardingGrid', () => {
 
   it('shows the cold-start heading explaining the empty state', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
-    expect(container.textContent ?? '').toContain('아직 연결된 sidecar가 없습니다')
+    expect(container.textContent ?? '').toContain('아직 연결된 사이드카가 없습니다')
   })
 
   it('renders a per-card Start button with data-onboarding-start matching each connector id', () => {

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -320,12 +320,12 @@ describe('TelemetryUnified', () => {
     await flushUi()
 
     expect(container.textContent).toContain('반복 그룹 1개 · 원본 3건')
-    expect(container.textContent).toContain('Polling / no-op')
-    expect(container.textContent).toContain('Polling / no-op · masc_status · 3 events')
+    expect(container.textContent).toContain('폴링 / 무동작')
+    expect(container.textContent).toContain('폴링 / 무동작 · masc_status · 3 events')
     expect(container.textContent).toContain('task_claimed: keeper-alpha')
 
     const groupToggle = Array.from(container.querySelectorAll('button[aria-expanded="false"]'))
-      .find(button => button.textContent?.includes('Polling / no-op')) as HTMLButtonElement | undefined
+      .find(button => button.textContent?.includes('폴링 / 무동작')) as HTMLButtonElement | undefined
     expect(groupToggle).toBeTruthy()
     await act(async () => {
       groupToggle?.click()
@@ -397,7 +397,7 @@ describe('TelemetryUnified', () => {
     })
     await flushUi()
 
-    expect(container.textContent).toContain('Heartbeat · keeper-heart heartbeat · 2 events')
+    expect(container.textContent).toContain('하트비트 · keeper-heart heartbeat · 2 events')
   })
 
   it('uses trajectory and execution receipt fields for telemetry previews', async () => {
@@ -491,7 +491,7 @@ describe('TelemetryUnified', () => {
     await flushUi()
 
     const groupRow = Array.from(container.querySelectorAll('button'))
-      .find(node => node.textContent?.includes('Polling / no-op · masc_status · 3 events'))
+      .find(node => node.textContent?.includes('폴링 / 무동작 · masc_status · 3 events'))
     expect(groupRow).toBeTruthy()
     expect(groupRow?.getAttribute('aria-expanded')).toBe('false')
 

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -243,6 +243,7 @@ let adapter_canonical_name_of_provider_kind
   | Anthropic -> cn_claude_api
   | Kimi -> cn_kimi_api
   | OpenAI_compat -> cn_codex_api
+  | DashScope -> cn_codex_api
   | Ollama -> cn_ollama
   | Gemini -> cn_gemini_api
   | Gemini_cli -> cn_gemini
@@ -1417,6 +1418,8 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
       resolve_direct_adapter cn_kimi_api
   | Ollama ->
       resolve_direct_adapter cn_ollama
+  | DashScope ->
+      resolve_direct_adapter cn_codex_api
   | Glm
   | DashScope
   | OpenAI_compat ->
@@ -1552,7 +1555,8 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.DashScope
   | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli ->
+  | Llm_provider.Provider_config.Codex_cli
+  | Llm_provider.Provider_config.DashScope ->
       auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -38,6 +38,7 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Kimi -> Llm_provider.Capabilities.kimi_capabilities
     | Glm -> Llm_provider.Capabilities.glm_capabilities
     | Gemini -> Llm_provider.Capabilities.gemini_capabilities
+    | DashScope -> Llm_provider.Capabilities.openai_chat_capabilities
     | OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
     | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
     | Claude_code -> Llm_provider.Capabilities.claude_code_capabilities


### PR DESCRIPTION
Synchronize dashboard tests with current UI copy after recent main localization changes.\n\n- Update connector onboarding empty-state expectation to use '사이드카'.\n- Update telemetry unified test expectations for '폴링 / 무동작' and '하트비트' labels.\n\nThis keeps CI dashboard checks green on current main.