### PR TITLE
refactor(design-system): swap persona-generator 2 checkboxes to Checkbox (CS49)

### DIFF
--- a/dashboard/src/components/keeper-spawn/persona-generator.ts
+++ b/dashboard/src/components/keeper-spawn/persona-generator.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { ActionButton } from '../common/button'
 import { Select } from '../common/select'
+import { Checkbox } from '../common/checkbox'
 import { showToast } from '../common/toast'
 import {
   generatePersonaDraft,
@@ -149,10 +150,10 @@ export function PersonaGenerator() {
             />
           </label>
           <label class="flex items-center gap-2 pt-5 text-2xs text-[var(--color-fg-primary)]">
-            <input
-              type="checkbox"
+            <${Checkbox}
               checked=${proactiveEnabled.value}
-              onChange=${(e: Event) => { proactiveEnabled.value = (e.target as HTMLInputElement).checked }}
+              ariaLabel="proactive"
+              onChange=${(checked: boolean) => { proactiveEnabled.value = checked }}
             />
             proactive
           </label>
@@ -180,10 +181,10 @@ export function PersonaGenerator() {
             onClick=${() => void saveDraft(false)}
           >${personaSaving.value ? '저장 중...' : '저장'}<//>
           <label class="flex items-center gap-1.5 text-3xs text-[var(--color-fg-muted)]">
-            <input
-              type="checkbox"
+            <${Checkbox}
               checked=${overwrite.value}
-              onChange=${(e: Event) => { overwrite.value = (e.target as HTMLInputElement).checked }}
+              ariaLabel="overwrite"
+              onChange=${(checked: boolean) => { overwrite.value = checked }}
             />
             overwrite
           </label>


### PR DESCRIPTION
## Summary

CS series Checkbox sweep #2 — persona-generator **2 checkboxes batch**.

CS47에서 같은 파일의 2 text inputs 처리, CS49에서 2 checkboxes 처리 → element type별 vertical sweep 패턴.

## 변경

`dashboard/src/components/keeper-spawn/persona-generator.ts`:
1. `<input type="checkbox">` (proactive) → `<${Checkbox} ariaLabel="proactive">`
2. `<input type="checkbox">` (overwrite) → `<${Checkbox} ariaLabel="overwrite">`

## 검증

- pnpm typecheck: green
- pnpm test src/components/keeper-spawn: 19/19 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
