### PR TITLE
fix(ws-standalone): release accepted flow per-connection to stop FD leak

### DIFF
--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -117,12 +117,30 @@ let start
               try
                 let flow, client_addr = Eio.Net.accept ~sw socket in
                 Eio.Fiber.fork ~sw (fun () ->
-                  try connection_handler client_addr flow
-                  with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | exn ->
-                    Log.Server.warn "WS standalone handler error: %s"
-                      (Printexc.to_string exn));
+                  (* Per-connection switch so the accepted [flow] is
+                     released the moment the WS handler exits, not when
+                     the long-lived server [sw] closes. Without this
+                     each connection's FD lingers in the kernel [CLOSED]
+                     state until shutdown — a 1Hz dashboard reconnect
+                     (claude-in-chrome's playwright Chrome polls
+                     [ws://127.0.0.1:8937/]) accumulates ~3 600 FDs/h,
+                     tripping [admission_queue_rejected: fd count >= 90%]
+                     and starving every keeper subprocess. Pattern
+                     matches [http_server_h2.ml]'s accept loop. *)
+                  Eio.Switch.run (fun conn_sw ->
+                    Eio.Switch.on_release conn_sw (fun () ->
+                      try Eio.Flow.close flow with
+                      | Eio.Cancel.Cancelled _ as e -> raise e
+                      | exn ->
+                        Log.Server.warn
+                          "[ws-standalone] flow close failed: %s"
+                          (Printexc.to_string exn));
+                    try connection_handler client_addr flow
+                    with
+                    | Eio.Cancel.Cancelled _ as e -> raise e
+                    | exn ->
+                      Log.Server.warn "WS standalone handler error: %s"
+                        (Printexc.to_string exn)));
                 accept_loop 0.05
               with
               | Eio.Cancel.Cancelled _ as e -> raise e


### PR DESCRIPTION
## Symptom

Production today (KST 21:18 → 00:18) showed three correlated failures:

```
[Misc] admission rejected for oas-governance_judge:
  fd count 3762 >= 90% of threshold 3000
[Governance] refresh_once: compute_judgments failed:
  Internal error: [masc_oas_error] {"kind":"admission_queue_rejected", ...}
[Server] WebSocket session ws-1777216628813-77 connected (standalone port)
[Server] WebSocket session ws-1777216628813-77 closed
... (1 ws session/sec, ~3 600/hr)
```

`lsof -p $PID | grep ":8937" | awk '{print $NF}' | sort | uniq -c`:

```
  280 (CLOSED)     ← FD leak
   29 (TIME_WAIT)
    3 (LISTEN)
    2 (ESTABLISHED)
```

3 분 uptime에 280 FD CLOSED 누적 → ~93/min ≈ 1.5/s, 정확히 dashboard reconnect rate와 일치. 1 시간 후 admission threshold 도달, 모든 keeper subprocess 거부 → stale watchdog 강제 종료.

## Root cause

`lib/server/server_ws_standalone.ml:118-125` accept loop:

```ocaml
let flow, client_addr = Eio.Net.accept ~sw socket in
Eio.Fiber.fork ~sw (fun () ->
  try connection_handler client_addr flow
  with ...);
```

`Eio.Net.accept ~sw socket` 가 반환하는 [flow]는 server-level [sw] 에 등록됨. WS 핸들러가 종료되어도 [flow]는 [sw] 가 살아있는 동안 (= 프로세스 수명 내내) 해제 안 됨. WS protocol close 후 kernel은 socket을 [CLOSED] 로 표시하지만 FD는 OCaml runtime이 잡고 있어 [lsof] 에 영구히 보임.

## Fix

`lib/http_server_h2.ml:286-306` 에 동일 문제 해결책이 이미 존재 — per-connection [Eio.Switch.run] + [Switch.on_release] 로 [flow] 명시적 close. 그 패턴을 verbatim 적용.

```ocaml
Eio.Fiber.fork ~sw (fun () ->
  Eio.Switch.run (fun conn_sw ->
    Eio.Switch.on_release conn_sw (fun () ->
      try Eio.Flow.close flow with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn -> Log.Server.warn "[ws-standalone] flow close failed: %s" ...);
    try connection_handler client_addr flow
    with ...));
```

[conn_sw] 가 핸들러 종료 시 close → [on_release] 발동 → [Eio.Flow.close flow] → FD 즉시 해제.

## Why not also touch http_server_eio.ml / server_bootstrap_http.ml?

`Eio.Net.accept ~sw` + `Fiber.fork ~sw` 패턴은 그쪽들에도 있음 (4 callsite). 그러나:

- 8935 (HTTP MCP) trace에서 동일 leak 미관측 (low connection churn — `lsof | grep :8935` ESTABLISHED 1-2개, CLOSED 0-1개).
- 위 PR는 1 callsite에 surgical fix만 — 다른 4개는 별도 audit + PR.

여러 callsite 묶음 fix 는 이번 PR scope 밖. `audit-bucket-cascade-pattern` 적용 시 후속 lint gate에서 같은 패턴 모두 식별 가능.

## Verification

```bash
DUNE_BUILD_DIR=_build_diag scripts/dune-local.sh build @check --cache=disabled
# exit 0
```

Runtime 검증은 머지 + restart 후 `lsof -p $PID | awk '$NF==\"(CLOSED)\"' | wc -l` 가 5분 후에도 small 으로 유지되는지로 확인.

## Risk

- `Eio.Switch.run` 추가 = per-connection 작은 오버헤드 (switch creation + on_release closure). 1Hz 미만 수준에선 무시 가능.
- [flow] double-close 위험: [connection_handler] 내부에서 [flow] close하면 [on_release] 시 중복. [Eio.Flow.close] 가 idempotent 인지 미검증 — 안전을 위해 try-with 로 wrap (위 fix 코드 참고).
- [http_server_h2.ml] 가 동일 패턴으로 이미 production 운영 중 → 같은 위험 프로파일.

## Out of scope

- governance judge unparseable response (LLM이 contract 무시 conversational 출력). model behavior layer.
- claude-in-chrome dashboard tab 자체가 reconnect 도는 이유 (WS handshake 후 즉시 client 가 close — client 측 버그 추정).
- HTTP/H1 + H2 + WS-on-HTTP-upgrade 의 다른 4 accept site (별도 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)