### PR TITLE
fix(build): unbreak main — drop duplicate DashScope arms (#10804/#10825 race)

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -243,7 +243,6 @@ let adapter_canonical_name_of_provider_kind
   | Anthropic -> cn_claude_api
   | Kimi -> cn_kimi_api
   | OpenAI_compat -> cn_codex_api
-  | DashScope -> cn_codex_api
   | Ollama -> cn_ollama
   | Gemini -> cn_gemini_api
   | Gemini_cli -> cn_gemini
@@ -1418,8 +1417,6 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
       resolve_direct_adapter cn_kimi_api
   | Ollama ->
       resolve_direct_adapter cn_ollama
-  | DashScope ->
-      resolve_direct_adapter cn_codex_api
   | Glm
   | DashScope
   | OpenAI_compat ->
@@ -1555,8 +1552,7 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.DashScope
   | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli
-  | Llm_provider.Provider_config.DashScope ->
+  | Llm_provider.Provider_config.Codex_cli ->
       auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -38,7 +38,6 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Kimi -> Llm_provider.Capabilities.kimi_capabilities
     | Glm -> Llm_provider.Capabilities.glm_capabilities
     | Gemini -> Llm_provider.Capabilities.gemini_capabilities
-    | DashScope -> Llm_provider.Capabilities.openai_chat_capabilities
     | OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
     | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
     | Claude_code -> Llm_provider.Capabilities.claude_code_capabilities


### PR DESCRIPTION
## Summary

main is RED again. **#10825** (DashScope sweep, richer/correct) and **#10804** (stale-base re-add) merged within 51 seconds of each other. #10804 didn't realize the file already had DashScope coverage and re-added arms in 4 sites → `-warn-error +8/+11/+12` rejection.

```
Error (warning 11 [redundant-case]): this match case is unused.
Error (warning 12 [redundant-subpat]): this sub-pattern is unused.
```

## Sites cleaned (drop #10804 duplicate, keep #10825 richer arm)

| File | Dropped | Kept |
|------|---------|------|
| `provider_tool_support.ml:41` | `\| DashScope -> openai_chat_capabilities` (#10804, inferior) | `\| DashScope -> dashscope_capabilities` (#10825, purpose-built) |
| `provider_adapter.ml:246` | `\| DashScope -> cn_codex_api` (one-liner) | L252-256 arm with semantic comment |
| `provider_adapter.ml:1421-1422` | `\| DashScope -> resolve_direct_adapter cn_codex_api` | OR-pattern `\| Glm \| DashScope \| OpenAI_compat -> resolve_adapter_by_cascade_prefix ...` |
| `provider_adapter.ml:1559` | trailing duplicate `\| ...DashScope ->` | already covered in earlier OR-chain |

Net diff: **1 insertion, 6 deletions**.

## Test plan

- [x] `dune build @check` EXIT=0
- [ ] CI green on this branch
- [ ] Ready + admin merge once green (main blocker)

## Pattern recurrence

`memory/feedback_parallel-autocoder-race-search-window` — same class as #10492/#10504/#10507. #10804 should have run `gh pr list --search "DashScope"` immediately before push to detect #10825's open PR. Both PRs touched the same partial-match class within seconds.

Possible mitigation (separate work): pre-merge gate `rg 'DashScope' lib/ | sort | uniq -c | awk '\$1>1'` to flag duplicate match arms structurally, mentioned in #10791 PR body but not yet implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)