### PR TITLE
refactor(design-system): swap keeper-detail-history snapshot checkbox to Checkbox (CS52)

### DIFF
--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -8,6 +8,7 @@ import {
   type KeeperCheckpointSummary,
 } from '../api/keeper'
 import { TextInput } from './common/input'
+import { Checkbox } from './common/checkbox'
 import { TimeAgo } from './common/time-ago'
 import { keeperStatusDetails } from '../keeper-state'
 import { isRecord } from './common/normalize'
@@ -247,11 +248,11 @@ export function KeeperCheckpointPanel({
                 <div class="flex flex-col">
                   ${visibleHistory.map(item => html`
                     <label class="flex gap-3 border-b border-[var(--color-border-default)] px-3 py-3 text-xs last:border-b-0">
-                      <input
-                        type="checkbox"
+                      <${Checkbox}
                         class="mt-1"
                         checked=${selectedIds.includes(item.snapshot_id)}
-                        onChange=${(event: Event) => toggleSnapshot(item.snapshot_id, (event.currentTarget as HTMLInputElement).checked)}
+                        ariaLabel=${`snapshot ${item.snapshot_id} 선택`}
+                        onChange=${(checked: boolean) => toggleSnapshot(item.snapshot_id, checked)}
                       />
                       <div class="min-w-0 flex-1">
                         <div class="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary

CS series Checkbox sweep #5 — keeper-detail-history snapshot 선택 체크박스.

## 변경

`dashboard/src/components/keeper-detail-history.ts`:
- inline `<input type="checkbox">` → `<${Checkbox}>`
- dynamic `ariaLabel=${\`snapshot ${id} 선택\`}` 추가 (per-row a11y; 기존 inline 미설정)

## 검증

- pnpm typecheck: green
- keeper-detail-history 자체 test 없음 → pnpm test `src/components/common/checkbox`: 13/13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
