### PR TITLE
refactor(design-system): swap memory content search to TextInput (CS53)

### DIFF
--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -525,13 +525,13 @@ export function Memory() {
         <${NewPostForm} />
       </div>
       <div class="mb-3 flex items-center gap-2">
-        <input
+        <${TextInput}
           type="search"
           value=${contentQuery}
           placeholder="제목/본문에서 검색"
-          aria-label="게시글 본문 필터"
+          ariaLabel="게시글 본문 필터"
           onInput=${(e: Event) => setContentQuery((e.target as HTMLInputElement).value)}
-          class="min-w-45 max-w-80 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
+          class="min-w-45 max-w-80 flex-1 !px-2 !py-1 !text-xs"
         />
       </div>
       ${isFiltering && posts.length === 0 && rawPosts.length > 0


### PR DESCRIPTION
## Summary

CS series input sweep #28 — memory 게시글 본문 필터.
(Checkbox sweep CS48-52 후 TextInput 라인 재개)

## 변경

`dashboard/src/components/memory.ts:528`:
- inline `<input type="search">` → `<${TextInput} type="search">`

## 같은 파일 escape hatches (이 PR 범위 밖)

- line 285 작성자 input — production palette (`--text`, `--border-slate-16`)
- line 404 게시글 선택 checkbox — `onClick(Event)` shift+click 멀티셀렉트, Checkbox API에서 Event 비제공

## Palette

Pure design-system tokens (`--white-4`, `--white-10`, `--color-fg-primary`, `--color-fg-disabled`, `--color-accent-fg`).

## 검증

- pnpm typecheck: green
- pnpm test src/components/memory: **71/71 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
