### PR TITLE
fix(http-eio): release accepted flow per-connection (close FD-leak audit)

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -667,17 +667,32 @@ let run ~sw ~net ~clock config routes =
          let flow, client_addr = Eio.Net.accept ~sw socket in
          reset_backoff ();
          Eio.Fiber.fork ~sw (fun () ->
-           try
-             Httpun_eio.Server.create_connection_handler
-               ~sw
-               ~request_handler
-               ~error_handler
-               client_addr
-               flow
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             Log.Http.error "Connection error: %s" (Printexc.to_string exn))
+           (* Per-connection switch so the accepted [flow] is released
+              when the H1 handler exits, not when the long-lived server
+              [sw] closes. Without this each connection's TCP FD lingers
+              in [CLOSED] state until shutdown — same class of bug
+              addressed for the WS standalone accept loop in #10840 and
+              already adopted by [http_server_h2.ml] and three accept
+              points in [server_bootstrap_http.ml]. Currently latent
+              here because the MCP HTTP port has low connection churn. *)
+           Eio.Switch.run (fun conn_sw ->
+             Eio.Switch.on_release conn_sw (fun () ->
+               try Eio.Flow.close flow with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn ->
+                 Log.Http.warn "[http-eio] flow close failed: %s"
+                   (Printexc.to_string exn));
+             try
+               Httpun_eio.Server.create_connection_handler
+                 ~sw:conn_sw
+                 ~request_handler
+                 ~error_handler
+                 client_addr
+                 flow
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               Log.Http.error "Connection error: %s" (Printexc.to_string exn)))
        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          if is_cancelled exn then raise exn;
          let delay = !backoff_s in


### PR DESCRIPTION
## Summary

Last accept callsite in the codebase still using the unsafe \`Eio.Net.accept ~sw + Fiber.fork ~sw\` pattern. Closes the FD-leak audit started in #10840.

## Audit (5 accept callsites — before this PR)

| File | Status |
|------|--------|
| \`lib/http_server_h2.ml:281\` | ✓ already wraps in per-connection \`Switch.run\` + \`on_release\` |
| \`lib/server/server_bootstrap_http.ml:76\` | ✓ correct pattern |
| \`lib/server/server_bootstrap_http.ml:136\` | ✓ correct pattern |
| \`lib/server/server_bootstrap_http.ml:186\` | ✓ correct pattern |
| \`lib/server/server_ws_standalone.ml:118\` | ✓ fixed in **#10840** (active leak — 1 Hz dashboard reconnect → 280 CLOSED FD/3min) |
| **\`lib/http_server_eio.ml:667\`** | **✗ this PR** (latent leak — low MCP HTTP churn) |

## Why fix latent leak now

\`audit-bucket-cascade-pattern\` 메모리: 같은 bug class 발화 시 sweep + lint gate 동시 적용. #10840이 active leak 1건을 fix 했으니, 같은 class의 마지막 instance까지 함께 닫는 것이 정합. 분리하지 않으면 후속 lint gate가 false positive로 이 callsite를 영구 flag.

Active 발화 안 했지만:
- MCP HTTP port (8935)에 reconnect storm이 발생하면 FD 누적 동일 mechanism.
- 부하 테스트, 외부 client 버그, 또는 미래 dashboard가 /mcp/* polling으로 전환 시 active 됨.

## Fix

\`http_server_h2.ml:286-306\` 의 검증된 패턴 verbatim 적용:

\`\`\`ocaml
Eio.Fiber.fork ~sw (fun () ->
  Eio.Switch.run (fun conn_sw ->
    Eio.Switch.on_release conn_sw (fun () ->
      try Eio.Flow.close flow with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn -> Log.Http.warn "[http-eio] flow close failed: %s" (Printexc.to_string exn));
    try
      Httpun_eio.Server.create_connection_handler
        ~sw:conn_sw  (* ← was ~sw, now per-connection *)
        ~request_handler ~error_handler client_addr flow
    with ...))
\`\`\`

\`~sw:conn_sw\` 변경: connection_handler 내부에서 spawn하는 fiber/리소스도 per-connection sw에 종속되도록. 다른 4 fixed callsite도 동일.

## Verification

\`\`\`bash
DUNE_BUILD_DIR=_build_diag scripts/dune-local.sh build @check --cache=disabled
# exit 0
\`\`\`

## Risk

- 패턴이 production에서 4개 callsite로 검증됨 — 위험 프로파일 동일.
- \`~sw\` → \`~sw:conn_sw\` 전환은 connection lifecycle을 fiber boundary로 좁힘. handler 내부에서 per-request switch를 expect하는 코드는 영향받지 않음 (Httpun_eio는 sw를 connection 수명 내에서만 사용).

## Out of scope

- Lint gate (audit-bucket-cascade-pattern 후속): \`Eio.Net.accept ~sw\` 다음 \`Switch.run\` 부재 검출. 별도 PR.
- claude-in-chrome dashboard reconnect 자체 (client 측 문제).

🤖 Generated with [Claude Code](https://claude.com/claude-code)