### PR TITLE
refactor(design-system): swap fleet-fsm-matrix keeper filter to TextInput (CS54)

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -29,6 +29,7 @@ import type {
 import { fleetCompositeSnapshot } from '../composite-signals'
 import { dispatchOperatorAction } from '../operator-store'
 import { showToast } from './common/toast'
+import { TextInput } from './common/input'
 import {
   displayState,
   extractLaneValue,
@@ -845,14 +846,14 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
         <span class="text-xs text-[var(--color-fg-muted)]0">
           키퍼 ${data.count}명 · ${new Date(data.generated_at * 1000).toLocaleTimeString()} 업데이트
         </span>
-        <input
+        <${TextInput}
           type="search"
           value=${query}
           placeholder="name / 상태 필터 (예: gen12, trying)"
-          aria-label="Keeper 필터"
-          data-testid="fleet-fsm-matrix-filter"
+          ariaLabel="Keeper 필터"
+          testId="fleet-fsm-matrix-filter"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-40 max-w-65 rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-xs text-[var(--color-fg-muted)] placeholder:text-[var(--color-fg-muted)]0 focus:border-[var(--white-10)]0 focus:outline-none"
+          class="min-w-40 max-w-65 !bg-[var(--white-5)] !px-2 !py-0.5 !text-xs"
         />
         ${runtimeTallies
           ? html`


### PR DESCRIPTION
## Summary

CS series input sweep #29 — fleet-fsm-matrix Keeper 필터. **CS23 `testId` prop 4번째 활용**.

## 변경

`dashboard/src/components/fleet-fsm-matrix.ts:848`:
- inline `<input type="search">` → `<${TextInput} type="search">`
- `data-testid="fleet-fsm-matrix-filter"` → `testId="fleet-fsm-matrix-filter"`
- `!bg-[var(--white-5)]` override로 matrix dense row darker variant 보존

## 자동 cleanup (원본 typo 제거)

원본 inline 클래스에 두 곳의 typo:
- `placeholder:text-[var(--color-fg-muted)]0` (extra `0`)
- `focus:border-[var(--white-10)]0` (extra `0`)

→ TextInput swap 시 INPUT_BASE의 canonical placeholder/focus ring으로 치환되며 자동 제거.

## 검증

- pnpm typecheck: green
- pnpm test src/components/fleet-fsm-matrix: **41/41 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
