### PR TITLE
feat(lint): detect Eio.Net.accept ~sw without per-connection Switch.run [DEPENDS-ON #10840 #10846]

### DIFF
--- a/scripts/ci/check-accept-fd-lifecycle.sh
+++ b/scripts/ci/check-accept-fd-lifecycle.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# CI gate: every Eio.Net.accept ~sw must be followed by a per-connection
+# Eio.Switch.run that closes the accepted flow on release.
+#
+# Background
+#   Eio.Net.accept ~sw socket returns a [flow] resource registered
+#   against the supplied switch. When the same long-lived server [sw]
+#   is passed to both [accept] and the per-connection [Fiber.fork],
+#   the flow stays alive — and its kernel FD lingers in [CLOSED] —
+#   until the server itself shuts down. Under sustained connection
+#   churn the FD count grows unbounded and trips the
+#   [admission_queue_rejected] threshold, starving every keeper
+#   subprocess.
+#
+#   Real fires:
+#   - #10840 fixed the WS standalone accept loop after a 1Hz
+#     dashboard reconnect (claude-in-chrome) leaked ~3 600 FDs/h
+#     and tripped admission at fd count 3762/3000.
+#   - #10846 closed the audit by patching the last unsafe site
+#     in [http_server_eio.ml].
+#
+# Contract
+#   Each [Eio.Net.accept ~sw] callsite must, within the next
+#   [WINDOW_LINES] lines, contain:
+#     1. [Eio.Switch.run] (per-connection switch), AND
+#     2. [Switch.on_release] OR [Eio.Flow.close] (explicit FD close
+#        when the per-connection switch releases).
+#
+#   Either marker absent => the accept site is leaking the FD when
+#   the handler exits.
+#
+# Output
+#   Exit 0 — every accept site is paired with a Switch.run + close.
+#   Exit 1 — at least one site missing the pattern; locations printed.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+WINDOW_LINES=20
+
+failed=0
+
+# Collect every "Eio.Net.accept ~sw" hit as file:line.
+hits=$(rg -n --no-heading 'Eio\.Net\.accept[[:space:]]+~sw' lib/ bin/ 2>/dev/null || true)
+
+if [ -z "$hits" ]; then
+  echo "check-accept-fd-lifecycle: no Eio.Net.accept ~sw callsites found"
+  exit 0
+fi
+
+while IFS= read -r hit; do
+  file=$(printf '%s\n' "$hit" | cut -d: -f1)
+  line=$(printf '%s\n' "$hit" | cut -d: -f2)
+  # Read the next WINDOW_LINES lines (inclusive of the accept line).
+  end=$((line + WINDOW_LINES))
+  window=$(sed -n "${line},${end}p" "$file")
+
+  has_switch_run=0
+  has_close=0
+  printf '%s\n' "$window" | grep -q 'Eio\.Switch\.run' && has_switch_run=1
+  printf '%s\n' "$window" \
+    | grep -qE 'Switch\.on_release|Eio\.Flow\.close|Eio\.Resource\.close' \
+      && has_close=1
+
+  if [ "$has_switch_run" -ne 1 ] || [ "$has_close" -ne 1 ]; then
+    echo "  FAIL  ${file}:${line}: Eio.Net.accept ~sw without per-connection Switch.run + Flow.close within ${WINDOW_LINES} lines"
+    failed=1
+  fi
+done <<< "$hits"
+
+if [ "$failed" -ne 0 ]; then
+  echo ""
+  echo "check-accept-fd-lifecycle: at least one accept site is missing the FD-release pattern."
+  echo "Reference: lib/http_server_h2.ml accept loop, or fixes #10840 + #10846."
+  exit 1
+fi
+
+count=$(printf '%s\n' "$hits" | wc -l | tr -d ' ')
+echo "check-accept-fd-lifecycle: ok (${count} accept site(s) verified)"


### PR DESCRIPTION
## Summary

CI gate (Draft until #10840 + #10846 merge): \`scripts/ci/check-accept-fd-lifecycle.sh\` flags every \`Eio.Net.accept ~sw\` callsite whose flow is not released by a per-connection \`Switch.run\`.

Closes the \`audit-bucket-cascade-pattern\` for the FD-leak class addressed in:
- **#10840** (active leak — WS standalone, 1Hz dashboard reconnect leaking ~3 600 FDs/h)
- **#10846** (latent leak — http-eio MCP port, low churn)

## Why Draft

This lint, run today against \`origin/main\`, fails on the two callsites those PRs are fixing:

\`\`\`
$ bash scripts/ci/check-accept-fd-lifecycle.sh
  FAIL  lib/http_server_eio.ml:667
  FAIL  lib/server/server_ws_standalone.ml:118
\`\`\`

Wiring this into \`.github/workflows/ci.yml\` before those fixes land would block them from merging. PR will:

1. Stay Draft until both fix PRs are MERGED.
2. Rebase on the merged main.
3. Add 1 line to \`ci.yml\` Meta Guards step.
4. Self-test: both callsites now have \`Switch.run\` → exit 0.
5. Mark Ready, auto-merge.

## Heuristic

For each \`Eio.Net.accept ~sw\` hit in \`lib/\` + \`bin/\`, scan the next 20 lines for both markers:

| Marker | Why |
|--------|-----|
| \`Eio.Switch.run\` | Per-connection switch wrapper |
| \`Switch.on_release\` OR \`Eio.Flow.close\` OR \`Eio.Resource.close\` | Explicit FD release at per-connection scope exit |

Either absent → leak. Reference: \`lib/http_server_h2.ml\` accept loop is the canonical safe pattern; alternation matches it exactly. Three accept points in \`lib/server/server_bootstrap_http.ml\` also pass.

## Risk

- 20-line window is heuristic — a future accept loop with unusual indentation or refactored handler structure could false-positive. Bumping window or moving to AST-aware check is option for next iteration.
- String match doesn't verify \`flow\` is the closed resource. False positive possible if a different flow's close sneaks into the window. Acceptable for first pass — 5 callsites all match the canonical pattern.

## Out of scope

- AST-aware version (would require ppx or merlin-based tooling).
- Other Eio resource lifecycle classes (Process, Domain, ...).

🤖 Generated with [Claude Code](https://claude.com/claude-code)