### PR TITLE
fix(keeper): cap cascade rotation at 1 for contract_violation

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1741,6 +1741,37 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                       err_preview;
                   mark_terminal_error reclassified;
                   Error reclassified
+                end else if
+                  (* Fast-fail on second consecutive contract violation: if
+                     we already rotated once because the LLM only used
+                     passive/read-only tools, rotating to a weaker cascade
+                     is unlikely to change the LLM's choice on the same
+                     prompt.  Each rotation eats ~600s of turn budget, and
+                     in production we observe 4–5 rotations all hitting
+                     the same violation before the OAS retry guard
+                     finally aborts the cycle (see fleet logs:
+                     "passive status/read tools" cascade=big_three →
+                     keeper_unified → kimi_cli_keeper → … →
+                     oas_timeout_budget at 1064s/1200s).  Cap rotation
+                     at 1 for this error class so the keeper releases
+                     its turn budget for actionable work. *)
+                  EC.is_required_tool_contract_violation err
+                  && List.length attempted_cascades >= 1
+                then begin
+                  Log.Keeper.warn
+                    "%s: required_tool_contract_violation on second cascade \
+                     (%s after %d prior rotation(s)) — skipping further \
+                     rotation; rotating again is unlikely to change the \
+                     model's passive-tool choice. Error: %s"
+                    meta.name execution.cascade_name
+                    (List.length attempted_cascades)
+                    (short_preview (Oas.Error.to_string err));
+                  Prometheus.inc_counter
+                    "masc_keeper_contract_violation_rotation_capped_total"
+                    ~labels:[ ("keeper", meta.name) ]
+                    ();
+                  mark_terminal_error err;
+                  Error err
                 end else
                   match
                     next_fail_open_cascade_for_turn_with_budget


### PR DESCRIPTION
## Why

Fleet log analysis on 2026-04-26 (43 events today) shows `required_tool_contract_violation` is the **dominant** proactive-termination root cause — more frequent than `oas_timeout_budget` (40) and `hard_quota` (5). The two are causally linked:

```
contract_violation on cascade A
  → rotate to cascade B (~600s budget eaten)
  → contract_violation again (same prompt, weaker model)
  → rotate to cascade C
  → ... 4–5 rotations
  → oas_timeout_budget at 1064/1200s   ← visible terminal
```

Refs:
- `memory/feedback_proactive_turn_contract_violation_dominant.md`
- `memory/feedback_oas_timeout_budget_late_cascade_exhaustion.md`

## What

`lib/keeper/keeper_unified_turn.ml`, `run_keeper_cycle` post-error branch:

After the first cascade rotation due to `required_tool_contract_violation`, fast-fail with the original error instead of rotating again.

The behavioral signal (LLM chose passive tools) is unchanged across cascades on the same prompt — rotating to a weaker cascade does not change the model's choice. Releasing the turn budget lets the keeper get a fresh prompt next cycle.

## Layer boundary

This is a **behavior layer** mitigation, not an infrastructure fix. The contract itself (require_tool_use) and its enforcement remain unchanged. We're only stopping the cascade-eats-budget anti-pattern that turns one violation into a 1064s dead turn.

## Observability

New Prometheus counter:
- `masc_keeper_contract_violation_rotation_capped_total{keeper}` — fires on every cap.

This pairs the gate with measurement so we can see whether the violation rate itself drops (good) or stays constant with shorter turns (acceptable — keeper recovers faster).

## Verification

- [x] `DUNE_CACHE=disabled dune build @check` clean
- [ ] Integration smoke: induce contract_violation on one keeper, observe single cascade attempt + fast-fail counter increment
- [ ] 24h fleet measurement: cascade duration distribution tail < 1000s

## Risk

Low. The change is one new `else if` branch in error-handling; the original cascade rotation path remains for first attempts and for non-contract_violation errors. False positive (legit observation phase) cost: one extra cycle vs. ~1000s wasted.

## Labels

- `do-not-merge` (manual review of behavior-layer mitigation desired)
- Draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)