### PR TITLE
fix(design-system): correct cockpit data.js paths in components.html

### DIFF
--- a/dashboard/design-system/preview/components.html
+++ b/dashboard/design-system/preview/components.html
@@ -11,8 +11,8 @@
   <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
-  <script src="../../../ui_kits/cockpit/data.js"></script>
-  <script src="../../../ui_kits/cockpit/data-p2.js"></script>
+  <script src="../ui_kits/cockpit/data.js"></script>
+  <script src="../ui_kits/cockpit/data-p2.js"></script>
   <style>
     html, body { margin:0; height:100%; background:#f0eee9; }
     /* Every artboard gets the dark cockpit bg + default fg so interior components look real */


### PR DESCRIPTION
## Summary

PR #10756 commit 5 incorrectly changed `components.html` script paths from `../ui_kits/cockpit/...` to `../../../ui_kits/cockpit/...`, assuming `ui_kits/cockpit/` lived at the repo root. **The directory actually lives at `dashboard/design-system/ui_kits/cockpit/`**, so the deeper path 404s.

## Impact

- **Dev preview broken**: 185 console errors when opening `components.html` from a dev server. `data.js` + `data-p2.js` 404 → `MASC_DATA` undefined → every cb-group component throws `TypeError: Cannot read properties of undefined (reading '<keepers|events|tasks|messages|...>')`.
- **Prod impact**: zero. Lookbook only.

## Verification

```bash
# pre-#10756 path (verified correct, design-system 내부 ui_kits)
git show 32c9fddea8^:dashboard/design-system/preview/components.html | grep ui_kits
  <script src="../ui_kits/cockpit/data.js"></script>
  <script src="../ui_kits/cockpit/data-p2.js"></script>

# Files exist at expected location
ls dashboard/design-system/ui_kits/cockpit/data*.js
  data.js (6,095 bytes)
  data-p2.js (36,807 bytes)
```

## Diff (2 lines)

```diff
-  <script src="../../../ui_kits/cockpit/data.js"></script>
-  <script src="../../../ui_kits/cockpit/data-p2.js"></script>
+  <script src="../ui_kits/cockpit/data.js"></script>
+  <script src="../ui_kits/cockpit/data-p2.js"></script>
```

## Other preview pages

`primitives.html`, `index.html`, `cb-stress-10keepers-v2.html`, `cb-group-g.html` — checked, no equivalent broken paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)