### PR TITLE
feat(autoboot): per-task elapsed diagnostic in lazy-startup wait log (#10843)

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -61,16 +61,58 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
           (Printexc.to_string exn))
   in
   let wait_for_lazy_startup () =
+    (* #10843: per-task elapsed tracking so the autoboot wait log surfaces
+       which lazy task is hung instead of repeating an opaque pending list
+       every 5s. The hash table is local to this fiber — no global state,
+       no product-state machine changes. Threshold 60s mirrors the issue's
+       short-term recommendation; tasks above it are flagged HUNG and the
+       wait log escalates from INFO to WARN. *)
+    let started_at = Hashtbl.create 16 in
+    let hung_threshold_sec = 60.0 in
+    let format_pending now pending =
+      pending
+      |> List.map (fun task ->
+          let elapsed =
+            match Hashtbl.find_opt started_at task with
+            | Some t -> now -. t
+            | None -> 0.0
+          in
+          let tag =
+            if elapsed >= hung_threshold_sec then "HUNG" else "running"
+          in
+          Printf.sprintf "%s (%s %.1fs)" task tag elapsed)
+      |> String.concat ", "
+    in
     let rec loop last_log_at =
       let pending = Server_startup_state.pending_lazy_tasks () in
       if pending = [] then ()
       else begin
         let now = Eio.Time.now clock in
+        List.iter
+          (fun task ->
+            if not (Hashtbl.mem started_at task) then
+              Hashtbl.add started_at task now)
+          pending;
+        Hashtbl.filter_map_inplace
+          (fun task t -> if List.mem task pending then Some t else None)
+          started_at;
         let last_log_at =
           if now -. last_log_at >= 5.0 then begin
-            Log.Keeper.info
+            let max_elapsed =
+              List.fold_left
+                (fun m task ->
+                  match Hashtbl.find_opt started_at task with
+                  | Some s -> Float.max m (now -. s)
+                  | None -> m)
+                0.0 pending
+            in
+            let log_fn =
+              if max_elapsed >= hung_threshold_sec then Log.Keeper.warn
+              else Log.Keeper.info
+            in
+            log_fn
               "autoboot: waiting for lazy startup tasks to finish before keeper boot [%s]"
-              (String.concat ", " pending);
+              (format_pending now pending);
             now
           end else
             last_log_at


### PR DESCRIPTION
## 증상

Issue #10843. \`server_bootstrap_loops.ml::wait_for_lazy_startup\` 가 lazy task 한 개라도 hang 하면 무한 대기. 진단 정보 부재.

2026-04-26 15:15:36 → 15:32:38 (17분 02초) 동안 \`restore_sessions\` hang. 199번 동일 log:

\`\`\`
autoboot: waiting for lazy startup tasks to finish before keeper boot [restore_sessions, ...]
\`\`\`

어떤 task 가 stuck 인지 / 얼마나 오래인지 표시 안 됨. 결국 다른 cause(governance fail / fd leak / WS storm)로 process hard crash.

## Fix scope

Issue #10843 의 \"단기 (per-task timeout + diagnostic)\" 일부만 적용:

- ✅ task starting timestamp 기록 (fiber-local Hashtbl).
- ✅ wait log 에 \`task (running 902.3s)\` 형태 elapsed 표시.
- ✅ elapsed ≥ 60s task 는 \`HUNG\` 으로 분류 + log level INFO → WARN escalation.
- ❌ per-task timeout / skip mechanism — state-machine 의 \`Hung\` phase 및 \"skip 가능 task\" 정책 결정 필요. 별도 PR.
- ❌ overall autoboot deadline — 위와 동일.

## 변경

\`lib/server/server_bootstrap_loops.ml::wait_for_lazy_startup\` 내부:
- \`started_at : (string, float) Hashtbl.t\` — first-seen timestamps, fiber-local.
- 매 iteration 에서 신규 pending task 등록 + 사라진 task 제거.
- 5s 간격 log:
  - \`max_elapsed >= 60s\` 면 \`Log.Keeper.warn\`, 아니면 \`Log.Keeper.info\`.
  - format: \`task (running %.1fs)\` 또는 \`task (HUNG %.1fs)\`.

## Why fiber-local

- product-state machine (\`Server_state_product.Lazy_task_queue\`) 변경 회피.
- global state 추가 회피 — 다른 reader 없음, 진단 전용.
- crash 시 자동 cleanup. 다음 boot 에 stale 없음.

## 검증

- \`dune build @check\` EXIT=0.
- 동작 검증은 hang 재현 시점에 wait log shape 으로 확인 가능. unit test 는 Eio Time 모킹 필요해 별도 PR 후보.

## 향후

- 후속 PR: \`task_state = Pending | Running of float | Hung\` state-machine surface 추가.
- 후속 PR: env knob \`MASC_LAZY_TASK_TIMEOUT_SEC\` (default 60) 으로 운영 조정.
- 후속 PR: outer autoboot deadline (예: 5분 초과 시 fail-fast restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)