### PR TITLE
chore(oas-event-bridge): finish module rename leftover (log prefix + docs)

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -64,7 +64,7 @@ OAS  ──does not know──→ MASC
 | Area | Status | Notes |
 |------|--------|-------|
 | Context compaction | Partial complete | `context_compact_oas.ml`는 OAS `Context_reducer`를 사용한다. MASC 전체 context system이 OAS `Context.t`로 통합된 것은 아니다. |
-| Event bus bridge | Complete for current native/custom flow | `oas_sse_bridge.ml` relays both OAS native events and `masc:*` custom events, persists them under `.masc/oas-events/`, and feeds dashboard SSE |
+| Event bus bridge | Complete for current native/custom flow | `oas_event_bridge.ml` relays both OAS native events and `masc:*` custom events, persists them under `.masc/oas-events/`, and feeds dashboard SSE |
 | Dashboard OAS runtime health | Complete with replay/live split | dashboard health SSOT is `durable oas_event replay + live SSE tail`, not live-only counters |
 | Dashboard runtime counts | Complete with truth split | dashboard `counts` means active runtimes; configured keeper inventory is exposed separately as `configured_keepers` |
 | Checkpoint integration | Partial complete | OAS checkpoint is used in shared worker/runtime paths, and the public OAS worker API now keeps the extra JSON as a neutral checkpoint sidecar. Keeper runtime still persists its own `working_context` / serialized checkpoint path in `lib/keeper/keeper_exec_context.ml` |

--- a/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
+++ b/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
@@ -15,14 +15,14 @@ This document is the operator-facing SSOT for:
 - Keeper composite signal path: `lib/keeper/keeper_registry.ml`
 - Keeper heartbeat snapshot path: `lib/keeper/keeper_keepalive.ml`
 - Server-push snapshot loops: `lib/server/server_dashboard_http_core.ml`, `lib/server/server_dashboard_http_execution_surfaces.ml`
-- OAS Event_bus bridge: `lib/oas_events.ml`, `lib/oas_sse_bridge.ml`
+- OAS Event_bus bridge: `lib/oas_events.ml`, `lib/oas_event_bridge.ml`
 
 ## Read Model Rules
 
 - SSE is freshness transport, not the authoritative read model.
 - `keeper_composite_changed` is signal-only. Consumers re-fetch `/api/v1/keepers/:name/composite`.
 - `operator_snapshot` and `operator_digest` are cached server-push surfaces. Default HTTP reads usually return the cache.
-- OAS bridge events are replayable because `oas_sse_bridge` persists them under `.masc/oas-events/`.
+- OAS bridge events are replayable because `oas_event_bridge` persists them under `.masc/oas-events/`.
 
 ## Timing and Trigger Semantics
 
@@ -180,7 +180,7 @@ Source of accepted event names on the dashboard side: `dashboard/src/types/sse.t
 
 ### 2. OAS custom events published by MASC
 
-These originate in `lib/oas_events.ml` and are later relayed by `oas_sse_bridge`.
+These originate in `lib/oas_events.ml` and are later relayed by `oas_event_bridge`.
 
 | Event name | Meaning |
 | --- | --- |
@@ -356,5 +356,5 @@ Meaning:
 - Composite producer: `lib/keeper/keeper_registry.ml`
 - Heartbeat snapshot writer: `lib/keeper/keeper_keepalive.ml`
 - OAS custom event publishers: `lib/oas_events.ml`
-- OAS bridge + durable replay: `lib/oas_sse_bridge.ml`
+- OAS bridge + durable replay: `lib/oas_event_bridge.ml`
 - Server-push snapshot loops: `lib/server/server_dashboard_http_core.ml`, `lib/server/server_dashboard_http_execution_surfaces.ml`, `lib/server/server_dashboard_http_namespace_truth.ml`

--- a/docs/compaction/COMPACTION-LIFECYCLE.md
+++ b/docs/compaction/COMPACTION-LIFECYCLE.md
@@ -148,10 +148,10 @@ Responsibilities are split cleanly:
 | MASC-specific fold (`stub_tool_results`), repair (`repair_broken_tool_call_pairs`) | MASC (`context_compact_oas.ml`) |
 | Token/message count after compaction | OAS (source of truth) |
 | Audit persistence + retention | MASC (`keeper_compact_audit.ml`) |
-| SSE broadcast (dashboard) | MASC (`oas_sse_bridge.ml`) |
+| SSE broadcast (dashboard) | MASC (`oas_event_bridge.ml`) |
 
 Compaction events flow: **OAS publishes** on Event_bus → **multiple
-MASC subscribers** consume independently (oas_sse_bridge for SSE,
+MASC subscribers** consume independently (oas_event_bridge for SSE,
 keeper_compact_audit for persistence). Each subscriber has its own
 bounded stream — back-pressure in one does not affect the other.
 

--- a/docs/rfc/RFC-0004-shared-contract-ocaml-ts.md
+++ b/docs/rfc/RFC-0004-shared-contract-ocaml-ts.md
@@ -50,7 +50,7 @@ masc-mcp contract 표면은 두 갈래:
 
 **범위 실측** — dashboard 가 소비하는 60+ `SSEEventType` 리터럴 중:
 - masc-mcp 자체 emit: 약 **40개** (`agent_*`, `keeper_*`, `board_*`, `approval_*`, `room_*`, `transport_*`, `execution_*` 등)
-- **OAS bridge relay**: **21개** (`oas:*` 접두어) — `agent_sdk` 라이브러리의 `Event_bus.payload` variant 를 `lib/oas_sse_bridge.ml` 이 릴레이
+- **OAS bridge relay**: **21개** (`oas:*` 접두어) — `agent_sdk` 라이브러리의 `Event_bus.payload` variant 를 `lib/oas_event_bridge.ml` 이 릴레이
 
 **OAS 21 이벤트 처리 — Opaque passthrough 채택**:
 

--- a/docs/spec/00-glossary.md
+++ b/docs/spec/00-glossary.md
@@ -373,7 +373,7 @@ OAS에서 LLM 제공자를 구분하는 타입. MASC에서는 `llama`(local), `g
 OAS의 에이전트 실행 진입점. MASC의 always-on keeper loop은 이 API 위에서 실행된다. Keeper 포함 모든 자율 에이전트 루프가 이 경로를 사용한다.
 
 **OAS SSE Bridge**
-OAS 이벤트를 MASC SSE 스트림으로 전달하는 브릿지. OAS 에이전트 실행 중 발생하는 이벤트를 Room의 SSE 구독자에게 전달한다. `-> lib/oas_sse_bridge.mli`
+OAS 이벤트를 MASC SSE 스트림으로 전달하는 브릿지. OAS 에이전트 실행 중 발생하는 이벤트를 Room의 SSE 구독자에게 전달한다. `-> lib/oas_event_bridge.mli`
 
 ---
 

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -839,7 +839,7 @@ sequenceDiagram
 | `mcp_server_eio_governance.ml` | 110 | Governance 설정 |
 | `sse.ml` | 474 | SSE event registry + broadcast |
 | `sse_room_filter.ml` | 63 | Room별 SSE 필터링 |
-| `oas_sse_bridge.ml` | 56 | OAS -> SSE 이벤트 브릿지 |
+| `oas_event_bridge.ml` | 56 | OAS -> SSE 이벤트 브릿지 |
 | `transport.ml` | 674 | 프로토콜 바인딩 추상화 + OpenAPI 생성 |
 | `http_server_eio.ml` | 675 | httpun-eio 래퍼 (Router, Compression) |
 | `http_server_h2.ml` | 325 | h2-eio 래퍼 |

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -57,7 +57,7 @@ graph TB
     CC[context_compact_oas.ml]
     MOB[memory_oas_bridge.ml]
     OE[oas_events.ml]
-    OSB[oas_sse_bridge.ml]
+    OSB[oas_event_bridge.ml]
     OM[oas_message.ml]
     OR[oas_response.ml]
     OMR[oas_model_resolve.ml]
@@ -324,9 +324,9 @@ MASC 조율 이벤트를 OAS `Event_bus`에 `Custom("masc:<type>", json)` 형식
 | `masc:reputation_changed` | 평판 변경 |
 | `masc:institution_episode` | institution 에피소드 기록 |
 
-### 8.2 SSE Relay (oas_sse_bridge.ml)
+### 8.2 SSE Relay (oas_event_bridge.ml)
 
-`oas_sse_bridge.ml`이 Event_bus의 native OAS events와 `masc:*` custom events를 모두 SSE로 중계하고 durable JSONL로도 기록한다.
+`oas_event_bridge.ml`이 Event_bus의 native OAS events와 `masc:*` custom events를 모두 SSE로 중계하고 durable JSONL로도 기록한다.
 
 동작:
 1. `Event_bus.subscribe`로 전체 OAS event bus를 구독

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -385,7 +385,7 @@ let update_relay_queue_depth pending =
 let emit_relay_retry_log ~(pending : pending_relay) ~(stage : relay_stage)
     ~(attempt : int) exn =
   Log.Misc.warn
-    "oas_sse_bridge: retrying event_type=%s stage=%s attempt=%d/%d correlation_id=%s run_id=%s error=%s"
+    "oas_event_bridge: retrying event_type=%s stage=%s attempt=%d/%d correlation_id=%s run_id=%s error=%s"
     (relay_event_type pending.json)
     (relay_stage_to_string stage)
     attempt
@@ -401,7 +401,7 @@ let emit_relay_retry_log ~(pending : pending_relay) ~(stage : relay_stage)
 let emit_relay_drop_log ~(pending : pending_relay) ~(stage_label : string)
     ~(attempts : int) =
   Log.Server.error
-    "oas_sse_bridge: dropping event_type=%s stage=%s attempts=%d correlation_id=%s run_id=%s"
+    "oas_event_bridge: dropping event_type=%s stage=%s attempts=%d correlation_id=%s run_id=%s"
     (relay_event_type pending.json)
     stage_label
     attempts
@@ -442,7 +442,7 @@ let broadcast_drop_marker ~(pending : pending_relay) ~(stage_label : string)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-      Log.Misc.warn "oas_sse_bridge: drop marker broadcast failed: %s"
+      Log.Misc.warn "oas_event_bridge: drop marker broadcast failed: %s"
         (Printexc.to_string exn)
 
 let prepare_pending_event evt =
@@ -638,7 +638,7 @@ let start_impl ~interval_s ~sw ~clock ~(config : Coord.config) ~bus =
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
          Log.Misc.warn
-           "oas_sse_bridge: relay iteration failed: %s"
+           "oas_event_bridge: relay iteration failed: %s"
            (Printexc.to_string exn));
       Eio.Time.sleep clock interval_s;
       loop ()

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -295,7 +295,7 @@ case "${MODE}" in
     echo "OAS API surface drift detected against ${FINGERPRINT_FILE}." >&2
     echo "  Review the delta above against MASC consumer sites:" >&2
     echo "    lib/oas_compat/oas_compat.ml      (Http_client + Metrics — single source)" >&2
-    echo "    lib/oas_sse_bridge.ml             (Event_bus payload matches — until adapter covers it)" >&2
+    echo "    lib/oas_event_bridge.ml           (Event_bus payload matches — until adapter covers it)" >&2
     echo
     echo "  Repair flow (after consumer changes compile clean):" >&2
     echo "    bash scripts/oas-drift-check.sh --regenerate" >&2


### PR DESCRIPTION
## Why

PR #10711 renamed the OCaml module `Oas_sse_bridge` → `Oas_event_bridge` to reflect that the bridge is transport-agnostic (`Sse.broadcast_to All` fans out to both SSE and WS subscribers).  Two trailing residues were deferred from that PR:

1. **Log line prefix** — 4 `Log.{Misc,Server}.{warn,error}` calls in `lib/oas_event_bridge.ml` still emit lines starting with `oas_sse_bridge:`.
2. **Documentation references** — 13 mentions across 7 docs/spec files still spell the old module name.

Both are cosmetic, but the log prefix in particular misleads anyone tailing logs into thinking SSE is the active transport when it could equally be WS.

## Scope check before changing operational strings

Searched repo-wide for `oas_sse_bridge` consumers that would parse the log prefix as a contract:

- `rg '"oas_sse_bridge'` → only the 4 emit sites in this file.
- `rg oas_sse_bridge -t cfg` (toml/yml/yaml/json/sh/conf) → only `scripts/oas-drift-check.sh:298`, a human-readable stale-doc warning that mentions the old filename.

**No CI alerting, Prometheus rule, Grafana board, or external parser depends on this string.**  The Prometheus metric names (`masc_oas_sse_relay_*_total`) are deliberately preserved per the policy documented in #10711 — those are the operational contract.

## What

| File | Change |
|------|--------|
| `lib/oas_event_bridge.ml` | 4 log lines: `oas_sse_bridge:` → `oas_event_bridge:` |
| `scripts/oas-drift-check.sh` | 1 stale-doc warning path string updated |
| `docs/OAS-MASC-BOUNDARY.md` | 1 reference |
| `docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md` | 4 references |
| `docs/compaction/COMPACTION-LIFECYCLE.md` | 2 references |
| `docs/rfc/RFC-0004-shared-contract-ocaml-ts.md` | 1 reference |
| `docs/spec/00-glossary.md` | 1 reference (also `.mli` path) |
| `docs/spec/09-server-transport.md` | 1 reference |
| `docs/spec/13-oas-integration.md` | 3 references (mermaid node, section heading, prose) |

Net: 9 files, +18 -18 (all 1-for-1 token replacements).

## Out of scope (still preserved)

- Prometheus metric strings `masc_oas_sse_relay_*_total` and OCaml identifiers `metric_oas_sse_relay_*` — operational contract, deferred to a separate PR with dashboard migration plan.
- The `Sse` module itself (`lib/sse.ml`/`lib/sse.mli`) — server-side SSE infrastructure stays until parallel-mode soak completes (PR-3 of cutover series).
- A2A external endpoints `/sse/portal`, `/sse/subscriptions` — external agent migration (PR-5).

## Verification

- `dune build @check` — green.
- `rg oas_sse_bridge lib/ scripts/ test/ docs/` — empty after this PR.

## Test plan

- [x] `dune build @check` succeeds
- [x] No string consumers parse the affected log prefix (verified above)
- [ ] Operators tailing logs see `oas_event_bridge:` after deployment (visible side effect; no parser impact)
