### PR TITLE
fix(server/autoboot): per-task boot guard so a single hung lazy task can't block keeper boot

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -61,14 +61,24 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
           (Printexc.to_string exn))
   in
   let wait_for_lazy_startup () =
-    (* #10843: per-task elapsed tracking so the autoboot wait log surfaces
-       which lazy task is hung instead of repeating an opaque pending list
-       every 5s. The hash table is local to this fiber — no global state,
-       no product-state machine changes. Threshold 60s mirrors the issue's
-       short-term recommendation; tasks above it are flagged HUNG and the
-       wait log escalates from INFO to WARN. *)
+    (* Combines #10843 (per-task elapsed diagnostic, merged via #10854) with
+       a per-task boot guard.  The diagnostic surface stays as #10854
+       intended — running/HUNG tags + INFO→WARN escalation at 60s — and
+       the boot guard kicks in at [boot_guard_sec] (default 120s) to
+       fail-out tasks that exceed it via [Server_startup_state.fail_lazy_task].
+       Without a hard ceiling, a single hung task (e.g. [restore_sessions]
+       hanging 17 min, #10843) blocks keeper boot indefinitely; the 240s
+       startup watchdog does NOT cover this case because [activate_lazy]
+       sets state_ready=true before the lazy fibers finish. *)
     let started_at = Hashtbl.create 16 in
     let hung_threshold_sec = 60.0 in
+    let boot_guard_sec =
+      match Sys.getenv_opt "MASC_LAZY_TASK_BOOT_GUARD_SEC" with
+      | Some v -> (match float_of_string_opt (String.trim v) with
+                   | Some f when f > 0.0 -> f
+                   | _ -> 120.0)
+      | None -> 120.0
+    in
     let format_pending now pending =
       pending
       |> List.map (fun task ->
@@ -96,29 +106,57 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
         Hashtbl.filter_map_inplace
           (fun task t -> if List.mem task pending then Some t else None)
           started_at;
-        let last_log_at =
-          if now -. last_log_at >= 5.0 then begin
-            let max_elapsed =
-              List.fold_left
-                (fun m task ->
-                  match Hashtbl.find_opt started_at task with
-                  | Some s -> Float.max m (now -. s)
-                  | None -> m)
-                0.0 pending
-            in
-            let log_fn =
-              if max_elapsed >= hung_threshold_sec then Log.Keeper.warn
-              else Log.Keeper.info
-            in
-            log_fn
-              "autoboot: waiting for lazy startup tasks to finish before keeper boot [%s]"
-              (format_pending now pending);
-            now
-          end else
-            last_log_at
+        let stuck =
+          List.filter (fun task ->
+            match Hashtbl.find_opt started_at task with
+            | Some seen_at -> now -. seen_at >= boot_guard_sec
+            | None -> false)
+            pending
         in
-        Eio.Time.sleep clock 0.25;
-        loop last_log_at
+        if stuck <> [] then begin
+          List.iter (fun task ->
+            let elapsed =
+              match Hashtbl.find_opt started_at task with
+              | Some seen_at -> now -. seen_at
+              | None -> 0.0
+            in
+            Log.Keeper.error
+              "autoboot: lazy task %s exceeded boot guard %.0fs (elapsed %.1fs) — failing it so keeper boot can proceed"
+              task boot_guard_sec elapsed;
+            Prometheus.inc_counter
+              "masc_lazy_task_boot_guard_fired_total"
+              ~labels:[ ("task", task) ]
+              ();
+            Server_startup_state.fail_lazy_task
+              ~task
+              ~error:(Printf.sprintf "lazy_task_boot_guard:%.0fs" boot_guard_sec))
+            stuck;
+          loop last_log_at
+        end else begin
+          let last_log_at =
+            if now -. last_log_at >= 5.0 then begin
+              let max_elapsed =
+                List.fold_left
+                  (fun m task ->
+                    match Hashtbl.find_opt started_at task with
+                    | Some s -> Float.max m (now -. s)
+                    | None -> m)
+                  0.0 pending
+              in
+              let log_fn =
+                if max_elapsed >= hung_threshold_sec then Log.Keeper.warn
+                else Log.Keeper.info
+              in
+              log_fn
+                "autoboot: waiting for lazy startup tasks to finish before keeper boot [%s]"
+                (format_pending now pending);
+              now
+            end else
+              last_log_at
+          in
+          Eio.Time.sleep clock 0.25;
+          loop last_log_at
+        end
       end
     in
     loop (Eio.Time.now clock)


### PR DESCRIPTION
Refs #10843 (companion to #10854).

## Why

`#10854` added per-task elapsed diagnostics so operators can see *which* lazy task is hung. That PR explicitly notes:

> per-task timeout / skip mechanism — state-machine 의 `Hung` phase 및 "skip 가능 task" 정책 결정 필요. 별도 PR.

This PR is that follow-up: a per-task **boot guard** that fail-outs stuck tasks so keeper boot can actually proceed.

Without a hard ceiling, the diagnostic from #10854 keeps logging "HUNG 1020s" forever — the diagnosis is loud, but the system still doesn't recover. Production observation in #10843: a single hang held the boot for 17 minutes until the process hard-crashed.

The startup watchdog at 240s does NOT cover this case. `activate_lazy` flips `state_ready=true` *before* the lazy fibers finish, so the watchdog passes while keeper boot is still gated in `wait_for_lazy_startup`.

## What

`lib/server/server_bootstrap_loops.ml::wait_for_lazy_startup`:

- Keeps #10854's diagnostic surface verbatim (`started_at` Hashtbl, `format_pending` with running/HUNG tag, INFO→WARN escalation at 60s).
- Adds a per-task boot guard at 120s (env-overridable via `MASC_LAZY_TASK_BOOT_GUARD_SEC`). When a task exceeds it, calls `Server_startup_state.fail_lazy_task ~task ~error:"lazy_task_boot_guard:120s"`, which:
  1. Removes the task from pending → loop releases keeper boot.
  2. Marks the system Degraded with `last_error` populated → dashboards see it.
  3. Emits `masc_lazy_task_boot_guard_fired_total{task}` counter.

## Layer boundary

Deterministic infrastructure fix. The lazy-task-fiber's actual hang root cause (whatever made `restore_sessions` not finish) is a separate non-deterministic problem; this PR only ensures the keeper boot loop has liveness. The diagnostic from #10854 still fires first (60s WARN); the boot guard is the safety net (120s fail-out).

## Risk

- A legitimate slow task (cold cache, large jsonl prune) taking >120s would be failed-out. Override via `MASC_LAZY_TASK_BOOT_GUARD_SEC=300` if observed.
- `fail_lazy_task` correctly marks the system Degraded — the lazy task did not complete.

## Verification

- [x] `DUNE_CACHE=disabled dune build @check` clean (post-rebase against #10854 main).
- [ ] Smoke: induce a hang on `restore_sessions`, confirm keeper boot proceeds at 120s with Degraded state and counter increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
