### PR TITLE
i18n(dashboard): localize connector-status warning headers (round-58)

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -447,7 +447,7 @@ describe('ConnectorStatusPanel', () => {
     const warningPanel = container.querySelector('[data-connector-warning-panel]') as HTMLElement | null
     expect(warningPanel).not.toBeNull()
     const text = warningPanel!.textContent?.replace(/\s+/g, ' ').trim() ?? ''
-    expect(text).toContain('Connector API unavailable')
+    expect(text).toContain('Connector API 사용 불가')
     expect(text).toContain('Cause: GET /api/v1/gate/connectors: 503 Service Unavailable')
     expect(text).toContain('Next: refresh the dashboard')
     expect(text).toContain('/api/v1/gate/connectors')

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -936,7 +936,7 @@ function ConnectorLivePanel({
         ? html`
             <div class="mt-3 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--color-status-warn)]" data-connector-warning-panel>
               <div class="font-semibold text-[var(--color-fg-primary)]">
-                ${connectorError ? 'Connector API unavailable' : 'Sidecar status warning'}
+                ${connectorError ? 'Connector API 사용 불가' : 'Sidecar 상태 경고'}
               </div>
               <div class="mt-1">
                 <span class="font-medium">Cause: </span> ${connectorError ?? connector?.error}


### PR DESCRIPTION
## 변경 사항

- \`connector-status.ts:939\`: 2 warning headers 한국어화
  - \`'Connector API unavailable'\` → \`'Connector API 사용 불가'\`
  - \`'Sidecar status warning'\` → \`'Sidecar 상태 경고'\`
- \`connector-status.test.ts:450\`: assertion sync (atomic pattern)

## Domain term 보존

- **Connector** (UI/API connector 도메인) — 보존
- **Sidecar** (sidecar process 도메인) — 보존

## 영향 범위

Source 1, test 1. 2 lines changed. Conservative scope.

## 자기 점검 (Best Programmer self-review)

- 로컬 lint/test 미수행 (vitest infra blocker #10645 진행 중)
- 변경 파일: connector-status.ts, connector-status.test.ts
- 검증: source 의 string change + test substring assertion 동기. atomic 패턴
- 미검증: 실제 dashboard 렌더 시 WARN box 표시 (UI 가시화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)