### PR TITLE
feat(design-system): add inputRef prop to TextInput + TextArea (CS57)

### DIFF
--- a/dashboard/src/components/common/input.test.ts
+++ b/dashboard/src/components/common/input.test.ts
@@ -109,6 +109,13 @@ describe('TextInput', () => {
     render(html`<${TextInput} autoFocus=${true} />`, container)
     expect(container.querySelector('input')!.hasAttribute('autofocus')).toBe(true)
   })
+
+  it('inputRef.current points to the inner <input> after mount', () => {
+    const ref: { current: HTMLInputElement | null } = { current: null }
+    render(html`<${TextInput} inputRef=${ref} />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    expect(ref.current).toBe(input)
+  })
 })
 
 describe('TextArea', () => {
@@ -148,5 +155,12 @@ describe('TextArea', () => {
     ta.dispatchEvent(new Event('input', { bubbles: true }))
     await flushUi()
     expect(spy).toHaveBeenCalledOnce()
+  })
+
+  it('inputRef.current points to the inner <textarea> after mount', () => {
+    const ref: { current: HTMLTextAreaElement | null } = { current: null }
+    render(html`<${TextArea} inputRef=${ref} />`, container)
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(ref.current).toBe(ta)
   })
 })

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -29,6 +29,11 @@ interface TextInputProps {
   testId?: string
   /** Native autofocus — applied on initial mount. */
   autoFocus?: boolean
+  /** Forwards a Preact ref to the inner <input>. Distinct from `id` —
+      use this when callers need imperative focus control (e.g. an
+      external "edit" button that focuses this field) or when a parent
+      dialog component takes `initialFocusRef`. Pass a `useRef` result. */
+  inputRef?: { current: HTMLInputElement | null }
   onInput?: (e: Event) => void
   onKeyDown?: (e: KeyboardEvent) => void
 }
@@ -46,11 +51,13 @@ export function TextInput({
   autoComplete,
   testId,
   autoFocus,
+  inputRef,
   onInput,
   onKeyDown,
 }: TextInputProps) {
   return html`
     <input
+      ref=${inputRef}
       id=${id}
       type=${type}
       class="${INPUT_BASE} px-3 py-2 text-sm ${cx ?? ''}"
@@ -79,6 +86,10 @@ interface TextAreaProps {
   ariaLabel?: string
   disabled?: boolean
   required?: boolean
+  /** Forwards a Preact ref to the inner <textarea>. Mirrors TextInput —
+      see that component's docstring for when this is needed (imperative
+      focus, dialog `initialFocusRef`, etc.). */
+  inputRef?: { current: HTMLTextAreaElement | null }
   onInput?: (e: Event) => void
 }
 
@@ -92,10 +103,12 @@ export function TextArea({
   ariaLabel,
   disabled,
   required,
+  inputRef,
   onInput,
 }: TextAreaProps) {
   return html`
     <textarea
+      ref=${inputRef}
       id=${id}
       class="${INPUT_BASE} px-3 py-2 text-sm min-h-20 resize-y ${cx ?? ''}"
       placeholder=${placeholder}


### PR DESCRIPTION
## Summary

CS series **3번째 canonical extension** PR (after CS4 `ActionButton.pressed`, CS23 `TextInput.testId/autoFocus`).

TextInput + TextArea에 `inputRef` prop 추가 — Preact ref forwarding으로 imperative focus 패턴 지원.

## 변경

`dashboard/src/components/common/input.ts`:
- `TextInputProps.inputRef?: { current: HTMLInputElement | null }` 추가
- `TextAreaProps.inputRef?: { current: HTMLTextAreaElement | null }` 추가
- 두 컴포넌트 모두 inner DOM에 `ref=${inputRef}` forwarding

## 언락되는 사이트

이 prop이 있어야 swap 가능했던 escape hatch:
- `keeper-detail.ts:517` — `<textarea ref=${reasonRef}>` (DialogOverlay의 `initialFocusRef={reasonRef}`로 초기 포커스 라우팅)

## 테스트

`dashboard/src/components/common/input.test.ts` +2:
- `inputRef.current` points to the inner `<input>` after mount
- `inputRef.current` points to the inner `<textarea>` after mount

## 검증

- pnpm typecheck: green
- pnpm test src/components/common/input: **18/18 pass** (이전 16/16, +2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
