### PR TITLE
fix(keeper-tools): skip consecutive-failure budget on transient EDEADLK (#10567)

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -346,7 +346,6 @@ let make_keeper_tool_handler
         let ts = Time_compat.now () in
         let duration_ms =
           int_of_float ((ts -. t0) *. 1000.0) in
-        let count = prior_fails + 1 in
         let error_text = Printexc.to_string exn in
         let edeadlk_backtrace =
           (* Mutex EDEADLK signature on macOS / Linux pthread errorcheck
@@ -358,7 +357,18 @@ let make_keeper_tool_handler
           then Some (Printexc.raw_backtrace_to_string raw_bt)
           else None
         in
-        Hashtbl.replace failure_counts key count;
+        let is_edeadlk = edeadlk_backtrace <> None in
+        (* #10567: EDEADLK is a transient mutex-contention race in shared
+           coord/keeper Stdlib.Mutex sites, not a real keeper-side failure.
+           Counting it toward [failure_counts] burns the consecutive-failure
+           budget (max 3) and ends the keeper turn even when the next call
+           would succeed.  Skip the counter bump and downgrade the log to
+           warn so dashboards don't conflate transient EDEADLK with real
+           tool errors. The #10682 EDEADLK backtrace logging stays so the
+           underlying Stdlib.Mutex site can still be pinpointed. *)
+        let count = if is_edeadlk then prior_fails else prior_fails + 1 in
+        if not is_edeadlk then
+          Hashtbl.replace failure_counts key count;
         Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
         !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:false ~duration_ms;
         (* Tool-call observability via OAS Event_bus. See above. *)
@@ -373,10 +383,18 @@ let make_keeper_tool_handler
             ("ts_unix", `Float ts);
           ])
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-        let msg = Printf.sprintf "tool %s failed (%d/%d): %s"
-          name count max_consecutive_failures
-          (Printexc.to_string exn) in
-        Log.Keeper.error "%s" msg;
+        let msg =
+          if is_edeadlk then
+            Printf.sprintf
+              "tool %s hit transient mutex contention (EDEADLK); not counted toward consecutive-failure budget. Retry the same call or pick a different tool."
+              name
+          else
+            Printf.sprintf "tool %s failed (%d/%d): %s"
+              name count max_consecutive_failures
+              (Printexc.to_string exn)
+        in
+        if is_edeadlk then Log.Keeper.warn "%s" msg
+        else Log.Keeper.error "%s" msg;
         (match edeadlk_backtrace with
          | Some bt ->
              Log.Keeper.error


### PR DESCRIPTION
## 증상

Issue #10567. \`Sys_error(\"Mutex.lock: Resource deadlock avoided\")\` (POSIX EDEADLK) 가 keeper read-only tool 4종에서 발생. 같은 Eio fiber 가 자기가 이미 lock 한 Stdlib.Mutex 를 재-lock 시도 → POSIX 가 deadlock 감지 → exception.

| Tool | Count | Affected keeper |
|---|---|---|
| keeper_tasks_list | 2 | ollama-local |
| keeper_memory_search | 2 | ollama-local |
| keeper_context_status | 2 | taskmaster |
| keeper_board_get | 2 | ramarama |
| nick0cave: keeper cycle exception | 1 | nick0cave |
| **합계** | **9** | 4 keepers |

## Root cause (issue 분석)

남은 \`Stdlib.Mutex\` hot-spots (\`lib/coord/\`):
- \`coord_utils_backend_setup.logged_lines_mutex\`
- \`mention.is_mentioned_cache_mu\`
- \`coord_verification_store.warned_legacy_dirs_mutex\`

dual-context (test executable + Eio server) trade-off 으로 \`Stdlib.Mutex\` 선택. test 호환은 되지만 Eio fiber 의 reentrant call path 에서 EDEADLK.

## Fix scope (이 PR)

**부수 피해 차단** — root cause fix 가 아니라 EDEADLK 가 keeper turn 에 미치는 collateral damage 제거.

#10682 가 이미 EDEADLK 시그니처 (\"Resource deadlock avoided\") 을 detect 해 backtrace 캡처. 같은 flag 를 재사용해서:

1. **failure_counts 미증가**: EDEADLK 는 keeper-side 책임 아닌 transient 경합. \`Hashtbl.replace failure_counts key count\` skip → consecutive-failure budget (max 3) 보존.
2. **로그 레벨 강등**: \`Log.Keeper.error\` → \`Log.Keeper.warn\`. 대시보드가 transient 와 real tool error 를 구분.
3. **LLM-readable 메시지**: \"transient mutex contention; not counted toward consecutive-failure budget. Retry the same call or pick a different tool.\"

\`Log.Keeper.error \"tool %s EDEADLK backtrace (#10682):...\"\` 는 그대로 유지 — 정확한 Stdlib.Mutex site 식별을 위한 #10682 work.

## Why root cause fix 미포함

- 현재 system_log 에 EDEADLK 기록 0건 — backtrace data 부재 → 정확한 site 추정 어려움.
- coord_utils_backend_setup / mention / coord_verification_store 3 사이트 중 하나를 \"감으로\" Eio.Mutex 또는 reentry-guard 로 마이그레이션하면 dual-context (test 호환) regression 위험.
- 이 PR 은 9 events/day 의 ROI 손실(turn termination → wasted cascade budget)을 즉시 차단. 진짜 fix 는 backtrace 데이터 수집 후 별도 PR.

## 검증

- \`dune build @check\` EXIT=0.
- 동작 검증은 EDEADLK 재발 시점에 (a) \`failure_counts\` 가 증가하지 않음 (b) Log.Keeper.warn 으로 surface 되는지 확인.

## Cross-ref

- #10682 (EDEADLK backtrace capture).
- memory \`feedback_ocaml5-mutex-selection.md\` (Eio vs Stdlib mutex selection).
- memory \`feedback_local-llm-tool-calling-limitation.md\` (ramarama / ollama-local family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)