### PR TITLE
fix(provider-caps): restore DashScope -> dashscope_capabilities (closes #10859)

### DIFF
--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -38,7 +38,7 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Kimi -> Llm_provider.Capabilities.kimi_capabilities
     | Glm -> Llm_provider.Capabilities.glm_capabilities
     | Gemini -> Llm_provider.Capabilities.gemini_capabilities
-    | DashScope -> Llm_provider.Capabilities.openai_chat_capabilities
+    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
     | OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
     | Claude_code -> Llm_provider.Capabilities.claude_code_capabilities
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities


### PR DESCRIPTION
## Summary

#10833 race-fix kept the inferior arm \`| DashScope -> openai_chat_capabilities\` (added by #10804) and dropped #10825's purpose-built \`| DashScope -> dashscope_capabilities\`. #10833's commit message claimed the bodies were identical — they are not.

## Capability regression

| Field | Current (\`openai_chat_capabilities\`) | Should be (\`dashscope_capabilities\`) |
|-------|---------------------------------------|----------------------------------------|
| \`supports_reasoning\` | false | **true** |
| \`supports_extended_thinking\` | false | **true** |
| \`supports_reasoning_budget\` | false | **true** |
| \`supports_top_k\` | false | **true** |
| \`supports_min_p\` | false | **true** |

DashScope hosts Alibaba Qwen3.5 / QwQ which support reasoning + extended thinking. Under-declared caps → OAS request builders skip reasoning/budget params on DashScope turns.

## Fix

\`\`\`diff
-    | DashScope -> Llm_provider.Capabilities.openai_chat_capabilities
+    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
\`\`\`

1 line. Net diff: 1 insertion, 1 deletion.

## Test plan

- [x] \`dune build @check\` EXIT=0
- [ ] CI green
- [ ] Ready transition

## Memory

\`feedback_no-derived-tag-when-existing-identifier-suffices\` — pinned OAS already names \`dashscope_capabilities\`; inventing the wider \`openai_chat_capabilities\` tag is a downgrade.

Closes #10859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)