### PR TITLE
refactor(design-system): swap keeper-detail clear-context textarea to TextArea (CS58, stacked on CS57)

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -26,6 +26,7 @@ import {
 } from '../api/keeper'
 import { TimeAgo } from './common/time-ago'
 import { Checkbox } from './common/checkbox'
+import { TextArea } from './common/input'
 import type { Keeper } from '../types'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
 import { hydrateKeeperStatus, selectKeeper } from '../keeper-runtime'
@@ -515,14 +516,15 @@ function KeeperClearContextDialog({
 
         <label class="flex flex-col gap-2">
           <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">사유</span>
-          <textarea
-            ref=${reasonRef}
-            class="min-h-[112px] resize-y rounded border border-[var(--color-border-default)] bg-[var(--white-3)] px-3 py-2 text-sm leading-paragraph text-[var(--color-fg-primary)] outline-none focus:border-[var(--accent-45)] focus:ring-2 focus:ring-[var(--accent-18)]"
+          <${TextArea}
+            inputRef=${reasonRef}
+            class="!bg-[var(--white-3)] !min-h-[112px] !text-sm leading-paragraph"
             placeholder="예: stale continuity replay 제거"
+            ariaLabel="비우기 사유"
             disabled=${pending}
             value=${reason}
             onInput=${(event: Event) => onReasonInput((event.currentTarget as HTMLTextAreaElement).value)}
-          ></textarea>
+          />
         </label>
 
         <label class="flex items-start gap-3 rounded border border-[var(--color-border-default)] bg-[var(--white-2)] px-3 py-3 text-xs text-[var(--color-fg-primary)]">


### PR DESCRIPTION
## Summary

CS series TextArea sweep #2. **CS57 `inputRef` prop의 첫 consumer (imperative focus 패턴)**.

**Stacked on**: #10860 (CS57). 머지 순서 — CS57 먼저, CS58 자동 머지 뒤따름.

## 변경

`dashboard/src/components/keeper-detail.ts`:
- `<textarea ref=${reasonRef}>` (비우기 사유) → `<${TextArea} inputRef=${reasonRef}>`
- `ariaLabel="비우기 사유"` 추가 (기존 inline 미설정)
- `!bg-[var(--white-3)]` + `!min-h-[112px]` overrides로 dialog 시각 보존
- DialogOverlay의 `initialFocusRef={reasonRef}` 동작 유지 — TextArea가 inputRef를 inner `<textarea>`로 forwarding

## 검증

- pnpm typecheck: green
- pnpm test src/components/keeper-detail: **105/105 pass** (DialogOverlay focus 테스트 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
