### PR TITLE
i18n(dashboard): localize lab-inspector focus surface title (round-59)

### DIFF
--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -21,7 +21,7 @@ interface FocusSurface {
 
 const FOCUS_SURFACES: FocusSurface[] = [
   {
-    title: 'Agents & Keepers',
+    title: 'Agent 와 Keeper',
     description: '키퍼 상태, 런타임 품질, 텔레메트리를 가장 빠르게 확인하는 핵심 운영 화면입니다.',
     action: '모니터링으로 이동',
     tab: 'monitoring',


### PR DESCRIPTION
## 변경 사항

- \`lab-inspector.ts:24\`: \`'Agents & Keepers'\` → \`'Agent 와 Keeper'\`

## 이유

\`FOCUS_SURFACES\` 배열의 인접 항목 title 들이 이미 한국어 (\`'운영 큐'\`, \`'보드'\`). 단일 string 영문 잔존이 일관성 깨짐 — 1줄 fix.

## Domain term 보존

- **Agent** — 보존
- **Keeper** — 보존

## 영향 범위

1 file, 1 line. 가장 작은 atomic scope. Test coupling 없음.

## 자기 점검

- 변경 파일: lab-inspector.ts
- 검증: 인접 title 패턴 일치 확인
- vitest infra blocker (#10645) 진행 중 — local lint/test 미수행

🤖 Generated with [Claude Code](https://claude.com/claude-code)