### PR TITLE
refactor(a2a): drop dead SSE endpoint advertisements

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -458,7 +458,7 @@ let delegate config ~agent_name ~target ~message
           ("portal_message", `String msg);
           ("timeout_ms", `Int timeout_ms);
           ("deadline", `Float deadline);
-          ("stream_endpoint", `String "/sse/portal");
+          ("note", `String "Use masc_portal_status to poll for streamed responses");
         ])
 
 (** Subscribe to agent events
@@ -502,8 +502,7 @@ let subscribe ?(agent_filter : string option) ~(events : string list) ()
         | Some a -> `String a);
       ("events", `List (List.map (fun e -> `String (show_event_type e)) event_types));
       ("created_at", `String sub.created_at);
-      ("sse_endpoint", `String "/sse/subscriptions");
-      ("note", `String "Connect to SSE endpoint to receive events");
+      ("note", `String "Buffered events accumulate server-side; retrieval API not yet exposed via MCP. See masc-mcp issue tracker.");
     ])
 
 (** Unsubscribe from events


### PR DESCRIPTION
## Why

`lib/a2a_tools.ml` advertised two SSE endpoint strings in MCP tool responses:

- `masc_a2a_delegate(stream)` returned `"stream_endpoint": "/sse/portal"`
- `masc_a2a_subscribe` returned `"sse_endpoint": "/sse/subscriptions"` + `"note": "Connect to SSE endpoint to receive events"`

**Both endpoints have never been registered on the HTTP router.**  Live verification:

```
$ curl -H "Authorization: Bearer …" https://masc.crying.pictures/sse/portal       → 404
$ curl -H "Authorization: Bearer …" https://masc.crying.pictures/sse/subscriptions → 404
$ rg 'Http.Router.(get|prefix_get)' lib/server/server_routes_*.ml | grep '/sse'
  /sse, /sse/simple   ← only these two are registered
```

The strings were aspirational documentation that became misleading.  The real retrieval mechanism for streamed portal responses is `masc_portal_status` (already noted in the `Sync` branch).  The subscription buffer is filled by `notify_event` server-side but is **not yet exposed** via any MCP tool — `A2a_tools.poll_events` exists as a function but has no entry in `tool_name.ml` / `tool_catalog.ml` / `transport.ml` tool list.

## What

| Site | Before | After |
|------|--------|-------|
| `Stream` task response (line 461) | `("stream_endpoint", String "/sse/portal")` | `("note", String "Use masc_portal_status to poll for streamed responses")` |
| `subscribe()` response (line 505-506) | `("sse_endpoint", String "/sse/subscriptions"); ("note", String "Connect to SSE endpoint to receive events")` | `("note", String "Buffered events accumulate server-side; retrieval API not yet exposed via MCP. See masc-mcp issue tracker.")` |

Net: 1 file, +2 -3.

## Out of scope (separate issue filed)

The deeper finding — `masc_a2a_subscribe` accumulates events in `event_buffers` but no MCP tool exposes `poll_events` to consumers — is a missing feature, not a bug surface this PR touches.  Filed as #10864.  This PR limits itself to honest user-facing strings.

## SSE → WS cutover position

This PR was originally tagged "PR-5: A2A external endpoint migration" in the cutover plan, with the assumption that external agents depended on `/sse/portal` and `/sse/subscriptions`.  Live verification overturned that assumption — there were never registered handlers, so any external client connecting to those URLs has always received 404.  No external coordination required.

## Verification

- `dune build @check` — green (see CI).
- `rg '"/sse/portal"|"/sse/subscriptions"' lib/ test/ docs/` — empty after this PR.
- `rg 'stream_endpoint|sse_endpoint' test/` — no test asserts on the removed fields.

## Test plan

- [x] `dune build @check` succeeds
- [x] No tests assert on `stream_endpoint` or `sse_endpoint` field presence
- [x] Live-server check confirms both `/sse/portal` and `/sse/subscriptions` return 404 today
