### PR TITLE
fix(auth): stop classifying keeper-<id>-agent as a transient alias

### DIFF
--- a/lib/coord/nickname.ml
+++ b/lib/coord/nickname.ml
@@ -74,6 +74,25 @@ let is_generated_nickname name =
   let parts = String.split_on_char '-' name in
   List.length parts >= 3
 
+(** Strict check: returns true only when the trailing components match the
+    actual [adjectives]/[animals] word lists used by [generate]/[generate_unique].
+
+    The looser [is_generated_nickname] uses a 3+ part shape rule so that
+    structured fixture names ("admin-board-keeper", "agent-test-alpha") are
+    accepted as nicknames by the join/coord_lifecycle path. Auth code that
+    decides whether to rewrite an inferred alias to its bearer-token owner
+    must NOT do so for structured operator names like [keeper-<id>-agent];
+    they only happen to share the [a-b-c] shape. Use this strict variant
+    on that path. *)
+let is_dictionary_generated_nickname name =
+  let parts = String.split_on_char '-' name in
+  match List.rev parts with
+  | hex :: animal :: adj :: _ :: _ when is_hex4 hex ->
+      array_contains adjectives adj && array_contains animals animal
+  | animal :: adj :: _ :: _ ->
+      array_contains adjectives adj && array_contains animals animal
+  | _ -> false
+
 (** Extract the stable agent prefix from a generated nickname.
     "claude-swift-fox" -> Some "claude"
     "qa-king-warm-heron" -> Some "qa-king"

--- a/lib/coord/nickname.mli
+++ b/lib/coord/nickname.mli
@@ -4,7 +4,16 @@ val generate : string -> string
 (** [generate agent_type] returns a nickname like "swift-fox-a3b". *)
 
 val is_generated_nickname : string -> bool
-(** [is_generated_nickname name] returns true if [name] matches the generated pattern. *)
+(** [is_generated_nickname name] returns true if [name] has the 3+ part shape used
+    by [generate]. This is permissive — any [a-b-c]-shaped string passes. Used by
+    the join/coord_lifecycle path so structured operator fixtures stay acceptable. *)
+
+val is_dictionary_generated_nickname : string -> bool
+(** [is_dictionary_generated_nickname name] returns true only when the trailing
+    components match the [adjectives]/[animals] word lists. Use on auth paths
+    that must distinguish real generated nicknames from structured operator
+    names like [keeper-<id>-agent] (avoids the [silent:auth_token_resolve_error]
+    storm produced by misclassifying them as transient aliases). *)
 
 val generate_unique : string -> string
 (** [generate_unique agent_type] returns a nickname with a random hex suffix. *)

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -19,7 +19,8 @@ let is_ephemeral_agent_name name =
   Base.String.is_prefix name ~prefix:"agent-"
 
 let is_transient_agent_name name =
-  is_ephemeral_agent_name name || Nickname.is_generated_nickname name
+  is_ephemeral_agent_name name
+  || Nickname.is_dictionary_generated_nickname name
 
 let silent_auth_token_error_kind = function
   | Types.InvalidToken _ -> "token_mismatch"

--- a/test/test_nickname_coverage.ml
+++ b/test/test_nickname_coverage.ml
@@ -78,6 +78,44 @@ let test_is_generated_nickname_short () =
 let test_is_generated_nickname_empty () =
   check bool "empty invalid" false (Nickname.is_generated_nickname "")
 
+(* The strict variant is what auth code uses. It must accept real generated
+   nicknames (dictionary adjective + animal) while rejecting structured
+   operator names like [keeper-<id>-agent], which only happen to share the
+   3-part shape. Pre-fix the auth path used the loose [is_generated_nickname],
+   misclassified those names, sent each keeper subprocess through the
+   bearer-token rewrite path, and produced [silent:auth_token_resolve_error]
+   storms (~20 events / 5min observed in fleet logs 2026-04-26). *)
+let test_is_dictionary_generated_nickname_accepts_real () =
+  check bool "claude-swift-fox" true
+    (Nickname.is_dictionary_generated_nickname "claude-swift-fox");
+  check bool "claude-swift-fox-a3b2" true
+    (Nickname.is_dictionary_generated_nickname "claude-swift-fox-a3b2");
+  check bool "qa-king-warm-heron multi-part type" true
+    (Nickname.is_dictionary_generated_nickname "qa-king-warm-heron");
+  check bool "fresh generated" true
+    (Nickname.is_dictionary_generated_nickname (Nickname.generate "claude"));
+  check bool "fresh unique" true
+    (Nickname.is_dictionary_generated_nickname
+       (Nickname.generate_unique "claude"))
+
+let test_is_dictionary_generated_nickname_rejects_structured () =
+  check bool "keeper-sangsu-agent" false
+    (Nickname.is_dictionary_generated_nickname "keeper-sangsu-agent");
+  check bool "keeper-issue_king-agent" false
+    (Nickname.is_dictionary_generated_nickname "keeper-issue_king-agent");
+  check bool "keeper-verifier-agent" false
+    (Nickname.is_dictionary_generated_nickname "keeper-verifier-agent");
+  check bool "keeper-nick0cave-agent" false
+    (Nickname.is_dictionary_generated_nickname "keeper-nick0cave-agent");
+  check bool "admin-board-keeper" false
+    (Nickname.is_dictionary_generated_nickname "admin-board-keeper");
+  check bool "non-list adj/animal" false
+    (Nickname.is_dictionary_generated_nickname "claude-foo-bar");
+  check bool "two parts" false
+    (Nickname.is_dictionary_generated_nickname "claude-opus");
+  check bool "empty" false
+    (Nickname.is_dictionary_generated_nickname "")
+
 (* ============================================================
    extract_agent_type Tests
    ============================================================ *)
@@ -144,6 +182,12 @@ let () =
       test_case "manual valid" `Quick test_is_generated_nickname_manual;
       test_case "short invalid" `Quick test_is_generated_nickname_short;
       test_case "empty invalid" `Quick test_is_generated_nickname_empty;
+    ];
+    "is_dictionary_generated_nickname", [
+      test_case "accepts real" `Quick
+        test_is_dictionary_generated_nickname_accepts_real;
+      test_case "rejects structured" `Quick
+        test_is_dictionary_generated_nickname_rejects_structured;
     ];
     "extract_agent_type", [
       test_case "generated" `Quick test_extract_agent_type_generated;


### PR DESCRIPTION
## Symptom

Fleet dashboard shows ~20 \`[silent:auth_token_resolve_error]\` warnings every 5min across 7 keepers (sangsu, verifier, nick0cave, ramarama, taskmaster, executor, scholar):

\`\`\`
[silent:auth_token_resolve_error] agent=keeper-sangsu-agent error_kind=token_mismatch — token resolve failed, keeping caller alias
\`\`\`

## Root cause

\`Nickname.is_generated_nickname\` accepts any \`a-b-c\` shape (\`List.length parts >= 3\`). \`keeper-<id>-agent\` is structured (3 parts: \`keeper\`, \`<id>\`, \`agent\`) but **not** a generated nickname — generated ones have the form \`{agent_type}-{adjective}-{animal}[-hex4]\` with \`adjective ∈ adjectives\` and \`animal ∈ animals\`.

The auth path in \`Mcp_server_eio_execute.execute_tool_eio\` uses \`is_transient_agent_name\` (= ephemeral OR \`is_generated_nickname\`) to decide whether to rewrite the inferred caller alias to the bearer-token's owner. Because every \`keeper-<id>-agent\` is misclassified as transient, every keeper subprocess request goes through the rewrite path. When the subprocess token does not match a per-keeper credential (the known \`internal_keeper.token vs credential.token\` divergence — see \`feedback_silent-auth-token-internal-vs-per-keeper\`), \`Auth.resolve_agent_from_token\` returns \`InvalidToken\` and the warn fires.

## Why not just tighten \`is_generated_nickname\`

\`coord_lifecycle.join\` uses the same predicate as a "name has nickname shape, treat as nickname instead of an agent_type" hint. Tightening it breaks fixture names that rely on the loose shape rule (\`admin-board-keeper\`, \`agent-test-alpha\`) — confirmed by 3 \`test_room\` regressions on first attempt.

## Fix

Separate concerns:

- Keep \`is_generated_nickname\` (loose 3-part shape) for the join/coord_lifecycle hint.
- Add \`is_dictionary_generated_nickname\` (strict — verifies trailing components against \`adjectives\`/\`animals\` word lists) for the auth path.
- Wire \`Mcp_server_eio_execute.is_transient_agent_name\` to the strict variant.

## Verification

- \`dune build @check\` clean.
- \`test_nickname_coverage\`: 20/20 (existing 18 + 2 new for strict variant).
- \`test_room\`: 1 baseline failure (pre-existing CRNG init in \`board_admin.003\`, also fails on \`origin/main\`); regression count unchanged.

## Acceptance

- [ ] CI green
- [ ] Fleet \`[silent:auth_token_resolve_error]\` rate drops to ~0 for keeper-<id>-agent forms (verify via dashboard after merge)
- [ ] Per-keeper credential drift (\`internal_keeper.token vs credential.token\`) remains a separate concern — this PR only stops the **misclassification** that triggers the warn; it does not fix the underlying token mismatch when an actual transient alias is used.

## Related memory

- \`feedback_silent-auth-token-internal-vs-per-keeper\`
- \`feedback_keeper-credential-name-drift\`