### PR TITLE
fix(keeper-shell-docker): make multi-repo sandbox blocker self-correcting (#10680)

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -244,13 +244,30 @@ let run_docker_shell_command_with_status
             (Filename.concat (Filename.concat host_root "repos") single_repo, None)
           | [] -> (cwd, None)
           | many ->
+            (* #10680: keeper-executor-agent saw 17 events / 5min in a single
+               session (mcp_VHsjtow_92C_2a0o, 2026-04-26 08:00→08:06) where
+               the LLM read this descriptive error and still re-issued the
+               same bare git/gh in the next turn.  Make the message
+               self-correcting: include the original cmd and the exact
+               next-call shape so the LLM can copy-paste rather than
+               re-derive the cwd convention from prose. *)
+            let cmd_preview =
+              let s = String.trim cmd in
+              if String.length s > 120 then String.sub s 0 117 ^ "..." else s
+            in
+            let example_repo = List.hd many in
             ( cwd
             , Some
                 (Printf.sprintf
                    "sandbox root에서 git/gh 직접 호출 불가 \
                     (mount point %s는 git repo 아님). \
-                    cd repos/<one of: %s> 먼저 실행하세요."
+                    필수: 다음 호출에서 cwd를 명시. 예: \
+                    keeper_bash { cmd: \"cd repos/%s && %s\" } \
+                    (가능한 repo: %s). \
+                    같은 cmd를 다음 turn에서 cwd 변경 없이 다시 호출하지 마세요."
                    host_root
+                   example_repo
+                   cmd_preview
                    (String.concat ", " many)) )
         else (cwd, None)
       in


### PR DESCRIPTION
## 증상

Issue #10680. \`keeper-executor-agent\` 가 sandbox root 에서 bare \`git\`/\`gh\` 호출을 반복 — 같은 에러가 5분 동안 17회 발생 (single session \`mcp_VHsjtow_92C_2a0o\`, 2026-04-26 08:00→08:06).

기존 에러 메시지는 \`cd repos/<one of: masc-mcp, oas> 먼저 실행하세요\` 라는 명확한 가이드를 포함하지만, LLM 은 다음 turn 에서 같은 패턴 반복 → \"prompt-feedback non-integration\" family.

## 분석

\`lib/keeper/keeper_shell_docker.ml::keeper_shell_docker_internal\` 의 multi-repo blocker:

\`\`\`
sandbox root에서 git/gh 직접 호출 불가 (mount point %s는 git repo 아님).
cd repos/<one of: %s> 먼저 실행하세요.
\`\`\`

→ 산문형 가이드. LLM 이 \"읽긴 했는데\" 다음 호출을 새로 합성할 때 cwd convention 재유도 실패.

## Fix scope

**Self-correcting 메시지** — LLM 이 copy-paste 할 수 있는 next-call shape 직접 제공:

\`\`\`
sandbox root에서 git/gh 직접 호출 불가 (mount point %s는 git repo 아님).
필수: 다음 호출에서 cwd를 명시. 예:
keeper_bash { cmd: \"cd repos/<example_repo> && <원래 cmd>\" }
(가능한 repo: <list>).
같은 cmd를 다음 turn에서 cwd 변경 없이 다시 호출하지 마세요.
\`\`\`

핵심 변경:
1. **원래 cmd 포함** (≤120 chars truncate) — LLM 이 자기가 이미 만든 cmd 를 그대로 prefix 만 붙여 재호출 가능.
2. **keeper_bash 호출 형태 inline** — JSON shape 노출. tool 시그니처 재유도 부담 제거.
3. **\"cwd 변경 없이 반복 금지\" imperative** — 동일 cmd repeat 패턴에 대한 explicit anti-pattern.

## Why not persona patch

Issue 의 단기 후보 \"persona patch\" (executor.toml 에 cwd 규칙 추가) 도 가능하지만:
- persona 는 sandbox 사용 안하는 다른 keeper 도 공유 → cross-context pollution.
- persona 는 LLM 이 이미 \"읽었으나 무시한\" 정보 family 와 같은 약점 (system prompt 의 generic 규칙 < tool error 의 immediate context).

self-correcting blocker 메시지가 LLM 의 next-turn 의사결정 시점에 직접 surface 되므로 ROI 더 높음.

## Auto-prefix injection 미포함

Issue 의 중기 후보 \"가장 최근 cd repos/<repo> 컨텍스트 자동 적용\" 은 multi-repo 환경에서 잘못된 repo 선택 risk 있음 (예: oas 작업 중 masc-mcp 로 자동 chdir → 잘못된 commit). 별도 RFC 필요.

## 검증

- \`dune build @check\` EXIT=0.
- 동작 검증: keeper-executor-agent 의 다음 sandbox-root git 호출 시 새 메시지 surface 후 next turn 의 cmd shape 변화 관찰.

## Cross-ref

- #10424 (single-repo auto-chdir + multi-repo blocker 원본 dispatch).
- memory \`feedback_proactive_turn_contract_violation_dominant.md\` (LLM contract-violation family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)