### PR TITLE
i18n(dashboard): localize 3 sidecar liveness hints (round-60)

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -773,7 +773,7 @@ function ConnectorLivePanel({
         label: 'Server → Sidecar',
         state: 'warn',
         detail: `stale · last heartbeat ${timeAgo(connector.updated_at)}`,
-        hint: 'Sidecar heartbeats stopped — tail its log',
+        hint: 'Sidecar heartbeat 중단 — 로그 확인',
       }
     }
     return {
@@ -806,14 +806,14 @@ function ConnectorLivePanel({
         label: `Sidecar → ${connectorName}`,
         state: 'warn',
         detail: 'stale heartbeat',
-        hint: 'Sidecar process may have stopped',
+        hint: 'Sidecar 프로세스 중단 가능성',
       }
     }
     return {
       label: `Sidecar → ${connectorName}`,
       state: 'warn',
       detail: 'gateway link not yet up',
-      hint: 'Check token and network reachability',
+      hint: '토큰 및 네트워크 도달성 확인',
     }
   })()
   const livenessDots: LivenessDot[] = [browserDot, serverDot, sidecarDot]


### PR DESCRIPTION
## 변경 사항

- \`connector-status.ts:776\`: \`'Sidecar heartbeats stopped — tail its log'\` → \`'Sidecar heartbeat 중단 — 로그 확인'\`
- \`connector-status.ts:809\`: \`'Sidecar process may have stopped'\` → \`'Sidecar 프로세스 중단 가능성'\`
- \`connector-status.ts:816\`: \`'Check token and network reachability'\` → \`'토큰 및 네트워크 도달성 확인'\`

## Domain term 보존

- **Sidecar** — 보존
- **heartbeat** — 보존 (네트워크 용어, line 776)

## 영향 범위

1 file, 3 lines. Source-only. Test coupling 없음. Round-58 (#10858) 의 같은 파일에 추가 분량.

## 자기 점검

- 변경 파일: connector-status.ts
- 검증: \`rg\` 로 test 커플링 부재 확인 + race PR 부재 확인
- vitest infra blocker (#10645) 진행 중 — local lint/test 미수행
- Round-58 (#10858) 머지 시 충돌 없음 (다른 라인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)