### PR TITLE
fix(keeper): record stale-termination history and emit threshold-breach signal

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -17,6 +17,34 @@
 
 open Keeper_types
 
+(* Process-global termination history per keeper.  Survives keeper
+   unregister/re-register because the watchdog module's state lives
+   for the server process lifetime.  Each entry records the
+   timestamps of recent stale terminations within a sliding window;
+   when the count exceeds [escalation_threshold] we emit a loud
+   warn line and a Prometheus counter so operators see the death
+   spiral pattern (#10765 — 116 stale terminations / 24h, single
+   keeper hit 13× with no escalation under the previous design).
+
+   This is observability only — we still let the supervisor restart
+   the keeper.  Phase 2 (deciding whether to auto-pause) is left
+   for a follow-up PR with measurement evidence in hand. *)
+let termination_window_sec = 21600.0  (* 6h *)
+let escalation_threshold = 5
+let termination_history : (string, float list) Hashtbl.t = Hashtbl.create 16
+let termination_history_mu = Eio.Mutex.create ()
+
+let record_stale_termination keeper_name now : int =
+  Eio.Mutex.use_rw ~protect:true termination_history_mu (fun () ->
+    let prev =
+      Hashtbl.find_opt termination_history keeper_name
+      |> Option.value ~default:[]
+    in
+    let window_start = now -. termination_window_sec in
+    let pruned = List.filter (fun ts -> ts >= window_start) (now :: prev) in
+    Hashtbl.replace termination_history keeper_name pruned;
+    List.length pruned)
+
 let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
     (reg : Keeper_registry.registry_entry) =
   let base_path = ctx.config.base_path in
@@ -75,9 +103,29 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  (Some (Keeper_registry.Stale_turn_timeout
                           (now -. last_turn)));
                Atomic.set reg.fiber_stop true;
+               let window_count = record_stale_termination meta.name now in
+               Prometheus.inc_counter
+                 "masc_keeper_stale_termination_total"
+                 ~labels:[ ("keeper", meta.name) ]
+                 ();
                Log.Keeper.error
-                 "%s: stale watchdog terminating fiber (%s)"
-                 meta.name reason_desc;
+                 "%s: stale watchdog terminating fiber (%s) [window_count=%d/6h]"
+                 meta.name reason_desc window_count;
+               if window_count >= escalation_threshold then begin
+                 Prometheus.inc_counter
+                   "masc_keeper_stale_termination_threshold_breached_total"
+                   ~labels:[ ("keeper", meta.name) ]
+                   ();
+                 Log.Keeper.error
+                   "%s: STALE-TERMINATION THRESHOLD BREACHED — %d \
+                    terminations in last %.0fs (threshold=%d). The \
+                    supervisor will continue to restart this keeper, \
+                    but the underlying root cause (cascade dead, fd \
+                    leak, provider auth, etc.) needs operator review. \
+                    See issue #10765."
+                   meta.name window_count termination_window_sec
+                   escalation_threshold
+               end;
                (try
                   Keeper_execution_receipt.emit_stale_keeper_broadcast
                     ctx.config


### PR DESCRIPTION
Refs #10765.

## Why

The stale watchdog terminates a keeper via `fiber_stop = true`. The heartbeat loop sees `stop=true` and returns through the **`record_stopped "normal exit"`** path — phase becomes Stopped, not Crashed. `sweep_and_recover` then `unregister`s the keeper and reconcile re-launches it as a fresh entry with `restart_count = 0`.

Net effect: the supervisor's `max_restarts` budget never accumulates for stale-watchdog-triggered terminations. Production observation in #10765:

- 116 stale terminations / 24h
- 14 keepers all affected
- Single keeper hits 13× without escalation
- 84/116 events are idle ≥1h (real long stalls)

The supervisor's existing escalation (`keeper_dead_total`) only fires after `max_restarts` Crashed transitions; stale terminations bypass it.

## What this PR does (observability only)

1. **Process-global termination history** in `keeper_stale_watchdog.ml`. A `Hashtbl` (mutex-protected) stores recent termination timestamps per keeper, sliding 6h window. Survives the keeper unregister/re-register cycle because the watchdog module's state outlives any single keeper entry.

2. **Two new Prometheus counters**:
   - `masc_keeper_stale_termination_total{keeper}` — every termination.
   - `masc_keeper_stale_termination_threshold_breached_total{keeper}` — fires only when window_count ≥ 5/6h.

3. **Loud warn log on threshold breach**, naming the candidate roots (cascade dead #10474, fd leak #10745, provider auth) so operators know where to look.

## What this PR does NOT do

- Does not change FSM behavior. The supervisor still restarts the keeper.
- Does not auto-pause keepers.

The death spiral root causes (#10474 cascade dead, #10745 fd leak) are separate and out of scope. This PR gives operators a measurable signal so we can:

(a) confirm the death spiral pattern in production with named keepers, and
(b) make an informed Phase 2 decision about auto-pause behavior with real data.

## Risk

Very low. New code paths are additive — counter increments and an extra log line. The hot path (cooldown_ok branch) is unchanged.

## Verification

- [x] `DUNE_CACHE=disabled dune build @check` clean
- [ ] Smoke: induce 5 stale terminations on one keeper, observe threshold_breached counter increment + warn log

## Layer boundary

Pure observability — no FSM transitions, no policy decisions. The deterministic surface area is one process-global Hashtbl with a mutex. Follow-up PR (Phase 2) will use the metrics emitted here to decide policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)