### PR TITLE
refactor(design-system): swap fsm-hub keeper filter input to TextInput (PR-CS60)

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useReducer, useRef, useState } from 'preact/hooks'
 import { InlineSpinner } from './common/inline-spinner'
+import { TextInput } from './common/input'
 
 import {
   fetchKeeperComposite,
@@ -785,13 +786,13 @@ function StatusBar({
         </div>
         <div class="flex items-center gap-1.5 flex-wrap" role="tablist" aria-label="Keeper 선택">
           ${keeperNames.length > 0 ? html`
-            <input
+            <${TextInput}
               type="search"
               value=${keeperFilter}
               placeholder="keeper 이름 필터"
-              aria-label="Keeper 이름 필터"
+              ariaLabel="Keeper 이름 필터"
               onInput=${(e: Event) => onKeeperFilterChange((e.target as HTMLInputElement).value)}
-              class="min-w-30 max-w-45 rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-0.5 text-3xs font-mono text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--accent-30)]"
+              class="min-w-30 max-w-45 !rounded-sm !bg-[var(--white-3)] !px-2.5 !py-0.5 !text-3xs font-mono"
             />
           ` : null}
           ${keeperFilterHasNoMatch ? html`


### PR DESCRIPTION
## Summary

CS series sweep. fsm-hub Keeper 선택 tablist의 inline `<input type=\"search\">`를 canonical `TextInput`으로 swap.

## 변경

`dashboard/src/components/fsm-hub.ts`:
- `import { TextInput } from './common/input'` 추가
- `<input type=\"search\">` (line 788, keeper 이름 필터) → `<${TextInput}>`
- 제거된 inline class (INPUT_BASE 상속으로 대체):
  - `border border-[var(--white-10)]`
  - `text-[var(--color-fg-primary)]`
  - `placeholder:text-[var(--color-fg-disabled)]` → INPUT_BASE의 `placeholder:text-[var(--color-fg-muted)]`
  - `focus:outline-none focus:border-[var(--accent-30)]` → INPUT_BASE focus-visible ring + offset (a11y 향상)
- 유지된 override (compact tab-row 시각 보존):
  - `min-w-30 max-w-45` (sizing — Tailwind native)
  - `!rounded-sm` (INPUT_BASE rounded override)
  - `!bg-[var(--white-3)]` (tab row 톤 일치, INPUT_BASE의 `--white-4`보다 어둡게)
  - `!px-2.5 !py-0.5 !text-3xs` (compact)
  - `font-mono` (Keeper 이름 monospace)
- `aria-label` → `ariaLabel` (TextInput convention)

## Palette

순수 design-system 토큰만 사용 (production 토큰 없음). SKIP 후보 아니었음.

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/fsm-hub`: 254/254 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)