### PR TITLE
refactor(design-system): swap attribution-panel filter input to TextInput + fix dead focus ring (PR-CS61)

### DIFF
--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -18,6 +18,7 @@ import {
 import { SurfaceCard } from './common/card'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { EmptyState } from './common/empty-state'
+import { TextInput } from './common/input'
 import { highlightMatch } from '../lib/highlight-match'
 
 const POLL_INTERVAL_MS = 5_000
@@ -328,16 +329,16 @@ export function AttributionPanel() {
               </button>
             </div>`
           : html`<div></div>`}
-        <input
+        <${TextInput}
           type="search"
           value=${query.value}
           placeholder="gate / origin / reason 필터"
-          aria-label="Attribution 이벤트 필터"
+          ariaLabel="Attribution 이벤트 필터"
           onInput=${(e: Event) => {
             query.value = (e.target as HTMLInputElement).value
             selectedEventIdx.value = null
           }}
-          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--color-border-default)] bg-[var(--white-5)]/20 px-2 py-1 text-2xs text-[var(--text-primary)] placeholder:text-[var(--color-fg-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50"
+          class="min-w-40 max-w-60 flex-1 !bg-[var(--white-5)]/20 !px-2 !py-1 !text-2xs"
         />
       </div>
 


### PR DESCRIPTION
## Summary

CS series sweep. attribution-panel의 inline filter `<input>`를 canonical `TextInput`으로 swap. **부수 효과**: silent typo로 dead 상태였던 focus ring을 자연스럽게 복구.

## 변경

`dashboard/src/components/attribution-panel.ts`:
- `import { TextInput } from './common/input'` 추가
- `<input type=\"search\">` (gate/origin/reason 필터, line 331) → `<${TextInput}>`
- 제거된 inline class:
  - `border border-[var(--color-border-default)]` (INPUT_BASE 동일 token으로 상속)
  - `text-[var(--text-primary)]` → INPUT_BASE의 `text-[var(--color-fg-primary)]` (production → design-system)
  - `placeholder:text-[var(--color-fg-muted)]` (INPUT_BASE 동일)
  - `focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50` ← **silent typo**: arbitrary value 뒤 `0/50` suffix가 Tailwind parser를 깨뜨려 focus ring class drop. INPUT_BASE focus-visible ring(--accent-45)로 복구.
- 유지된 inline override (반투명 변형 보존):
  - `min-w-40 max-w-60 flex-1` (sizing)
  - `!bg-[var(--white-5)]/20` (INPUT_BASE의 solid `--white-4` override)
  - `!px-2 !py-1 !text-2xs` (compact)
- `aria-label` → `ariaLabel`

## 부수 fix

이전 focus ring class `focus:ring-[var(--accent-20)]0/50`은 Tailwind에서 invalid arbitrary value로 처리되어 class 자체가 drop. 이번 swap으로 INPUT_BASE의 작동하는 focus ring으로 자연스럽게 교체.

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/attribution`: 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)