### PR TITLE
refactor(design-system): swap connector-config-form text+password inputs to TextInput (PR-CS62)

### DIFF
--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -23,6 +23,7 @@ import { Eye, EyeOff } from 'lucide-preact'
 import { ActionButton } from './common/button'
 import { CopyableCode } from './common/copyable-code'
 import { LoadingState } from './common/feedback-state'
+import { TextInput } from './common/input'
 import { showToast } from './common/toast'
 
 type FieldType = 'string' | 'integer' | 'number' | 'boolean' | 'unknown'
@@ -342,7 +343,15 @@ function FieldWidget({ id, field, value, revealed }: {
     setEntry(id, { reveal: { ...getEntry(id).reveal, [field.name]: !revealed } })
   }
 
+  // baseInput — preserved for the type=number branch which still uses
+  // a raw <input type="number"> until NumberInput migration handles
+  // signal-typed numeric values across the form.
   const baseInput = 'w-full rounded border border-[var(--white-8)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-2xs text-[var(--color-fg-primary)] focus:border-[var(--accent-1)] focus:outline-none'
+  // tightMonoOverride — TextInput class extension. INPUT_BASE owns
+  // border/text/placeholder/focus-visible. Only the size/font/bg need
+  // overrides to match the compact mono-style of the connector form
+  // (INPUT_BASE defaults to text-sm + py-2 + bg-white-4).
+  const tightMonoOverride = '!border-[var(--white-8)] !bg-[var(--color-bg-page)] !px-2 !py-1 !text-2xs font-mono'
 
   switch (field.type) {
     case 'boolean':
@@ -373,12 +382,12 @@ function FieldWidget({ id, field, value, revealed }: {
       if (isSensitive(field.name)) {
         return html`
           <div class="flex items-center gap-1">
-            <input
+            <${TextInput}
               type=${revealed ? 'text' : 'password'}
               value=${value}
               onInput=${onInput}
               placeholder=${field.required ? '필수 — 토큰을 붙여넣으세요' : ''}
-              class=${baseInput}
+              class=${tightMonoOverride}
             />
             <button
               type="button"
@@ -392,12 +401,12 @@ function FieldWidget({ id, field, value, revealed }: {
         `
       }
       return html`
-        <input
+        <${TextInput}
           type="text"
           value=${value}
           onInput=${onInput}
           placeholder=${defaultToString(field.default)}
-          class=${baseInput}
+          class=${tightMonoOverride}
         />
       `
     default:


### PR DESCRIPTION
## Summary

CS series sweep. connector config field renderer의 string + sensitive(password) inputs를 canonical `TextInput`으로 swap. `type=\"number\"` 분기는 NumberInput 마이그레이션 대기로 `baseInput` 보존.

## 변경

`dashboard/src/components/connector-config-form.ts`:
- `import { TextInput } from './common/input'` 추가
- `<input type=\"text\">` (string field, line 395) → `<${TextInput} type=\"text\">`
- `<input type=\${revealed ? 'text' : 'password'}>` (sensitive field, line 376) → `<${TextInput}>`
- `type=\"number\"` 분기는 그대로 유지 (signal-typed numeric value 마이그레이션 미완)
- 새 const `tightMonoOverride`: INPUT_BASE override를 명시적으로 분리
  - `!border-[var(--white-8)]` (INPUT_BASE의 `--color-border-default` 대비 lighter)
  - `!bg-[var(--color-bg-page)]` (form 컨테이너 톤 보존)
  - `!px-2 !py-1 !text-2xs font-mono` (compact mono)
- 제거 (INPUT_BASE 상속):
  - `text-[var(--color-fg-primary)]`
  - `focus:border-[var(--accent-1)] focus:outline-none` → INPUT_BASE focus-visible ring + offset (a11y 향상)

## Reveal toggle

Eye/EyeOff 버튼은 inline `<button>` 그대로 유지 (Lucide icons + custom hover state).

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/connector`: 199/199 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)