### PR TITLE
chore(ci): wire check-accept-fd-lifecycle.sh into Meta Guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,7 @@ jobs:
           bash scripts/ci/check-determinism-contract.sh
           bash scripts/audit-hardcoding-truth.sh --fail-on-confirmed
           bash scripts/ci/check-credential-audits.sh
+          bash scripts/ci/check-accept-fd-lifecycle.sh
 
   health:
     name: Health


### PR DESCRIPTION
## Summary

1-line addition to \`.github/workflows/ci.yml\` Meta Guards step. Activates the FD-lifecycle lint gate that #10848 added to \`scripts/ci/\` but didn't wire to CI.

## Why now

Three-PR sweep just landed:

| PR | What | Merged |
|----|------|--------|
| #10840 | WS standalone FD leak fix (active — 1Hz dashboard reconnect) | 17:34Z |
| #10846 | http-eio FD leak fix (latent — low MCP churn) | 17:37Z |
| #10848 | Lint script (\`check-accept-fd-lifecycle.sh\`) — but no ci.yml wire | 17:12Z |

Pre-#10840/#10846 the lint flagged both callsites:
\`\`\`
FAIL  lib/http_server_eio.ml:667
FAIL  lib/server/server_ws_standalone.ml:118
\`\`\`

Post-fix, all 6 callsites verified clean:
\`\`\`
$ bash scripts/ci/check-accept-fd-lifecycle.sh
check-accept-fd-lifecycle: ok (6 accept site(s) verified)
\`\`\`

## Closes audit-bucket-cascade-pattern

\`feedback_audit-bucket-cascade-pattern\` 메모리: detection + fix + lint gate 3-단 sweep이 표준. detection만 있고 lint gate 부재면 회귀가 silent. 이 PR이 마지막 단계.

## Risk

- 1줄 추가, 기존 Meta Guards step에 명령어 한 줄. ci.yml workflow 구조 변경 없음.
- 새로운 accept callsite 추가 시 즉시 fail → contributor가 패턴 인지하도록 강제. 단 false positive 가능성 존재 (string match 휴리스틱, 20-line window) — Out of scope에 명시한 AST-aware 후속 PR로 대응.

🤖 Generated with [Claude Code](https://claude.com/claude-code)