### PR TITLE
feat(dashboard): extract mission/shell/render timeouts to env (SSOT step 2)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -635,6 +635,49 @@ module Dashboard = struct
     Float.max 1.0
       (get_float ~default:30.0
          "MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC")
+
+  (** Mission card compute timeout.
+
+      Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at
+      [server_dashboard_http_core.ml:624,633,678] (mission projections).
+      Default 25s preserves the pre-extraction inline literal. Floor 1s
+      protects against degenerate operator config. *)
+  let mission_timeout_sec =
+    Float.max 1.0
+      (get_float ~default:25.0 "MASC_DASHBOARD_MISSION_TIMEOUT_SEC")
+
+  (** Shell render compute timeout (full path).
+
+      Used by [Dashboard_cache.get_or_compute_with_timeout] for the full
+      shell render. Default 16s preserves the pre-extraction literal at
+      [server_dashboard_http_core.ml:790]. *)
+  let shell_timeout_sec =
+    Float.max 1.0
+      (get_float ~default:16.0 "MASC_DASHBOARD_SHELL_TIMEOUT_SEC")
+
+  (** Shell render compute timeout (light path).
+
+      Default 8s. Must remain strictly less than [shell_timeout_sec] so
+      the split-budget signal (light vs full) stays meaningful: if a
+      light render takes longer than the full budget, that means light
+      has accidentally taken on full's work. Floor clamps at 0.5s to
+      keep the comparison meaningful even under operator override. *)
+  let shell_light_timeout_sec =
+    Float.max 0.5
+      (get_float ~default:8.0 "MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC")
+
+  (** Maximum wall-clock for a single dashboard render
+      ([Dashboard_execution.json_render]).
+
+      Wraps the entire render pipeline including PG stalls and cold-start
+      projection hydration. Default 60s preserves the pre-extraction
+      literal at [dashboard_execution.ml:204]. Floor 5s ensures even
+      aggressive operator overrides leave room for cold-start hydration.
+      Render budget should comfortably exceed the longest inner compute
+      budget (currently [mission_timeout_sec] = 25s). *)
+  let render_timeout_sec =
+    Float.max 5.0
+      (get_float ~default:60.0 "MASC_DASHBOARD_RENDER_TIMEOUT_SEC")
 end
 
 (** {1 Internal Timers and TTLs}

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -200,8 +200,10 @@ let message_json (message : Types.message) =
 
 (** Maximum wall-clock time for a single dashboard render.
     Keep a real guard for PG stalls, but allow slow cold-start projections
-    to finish at least once so cached surfaces can hydrate. *)
-let render_timeout_s = 60.0
+    to finish at least once so cached surfaces can hydrate. The default
+    (60s) is preserved by [Env_config_runtime.Dashboard.render_timeout_sec];
+    operators can override via [MASC_DASHBOARD_RENDER_TIMEOUT_SEC]. *)
+let render_timeout_s = Env_config_runtime.Dashboard.render_timeout_sec
 
 let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       let ctx : _ Operator_control.context =

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -75,7 +75,8 @@ let dashboard_cache_key (config : Coord.config) prefix suffix =
   Printf.sprintf "%s:%s:%s:%s" prefix config.base_path
     (cache_partition_segment config) suffix
 
-let dashboard_mission_timeout_s = 25.0
+let dashboard_mission_timeout_s =
+  Env_config_runtime.Dashboard.mission_timeout_sec
 
 let attach_projection_diagnostics json diagnostics =
   match json with
@@ -787,8 +788,10 @@ let provider_capacity_json () : Yojson.Safe.t =
    work. Splitting the budget makes that distinction visible: a light
    timeout means "light path is doing too much"; a full timeout means
    "the full path needs more headroom or a real perf fix". *)
-let dashboard_shell_timeout_s = 16.0
-let dashboard_shell_light_timeout_s = 8.0
+let dashboard_shell_timeout_s =
+  Env_config_runtime.Dashboard.shell_timeout_sec
+let dashboard_shell_light_timeout_s =
+  Env_config_runtime.Dashboard.shell_light_timeout_sec
 let dashboard_shell_timeout_for ~light =
   if light then dashboard_shell_light_timeout_s else dashboard_shell_timeout_s
 

--- a/test/dune
+++ b/test/dune
@@ -1780,6 +1780,12 @@
  (modules test_env_config_dashboard_execution_timeouts)
  (libraries masc_test_deps))
 
+; Dashboard mission/shell/render compute-timeout SSOT
+(test
+ (name test_env_config_dashboard_compute_timeouts)
+ (modules test_env_config_dashboard_compute_timeouts)
+ (libraries masc_test_deps))
+
 ; Process_eio subprocess default timeout SSOT
 (test
  (name test_process_eio_default_timeout)

--- a/test/test_env_config_dashboard_compute_timeouts.ml
+++ b/test/test_env_config_dashboard_compute_timeouts.ml
@@ -1,0 +1,113 @@
+(** Pin the {!Env_config_runtime.Dashboard} compute-timeout contract
+    for mission/shell/render. Four values were extracted from inline
+    literals:
+
+    - [server_dashboard_http_core.ml:78]   25.0  → mission_timeout_sec
+    - [server_dashboard_http_core.ml:790]  16.0  → shell_timeout_sec
+    - [server_dashboard_http_core.ml:791]   8.0  → shell_light_timeout_sec
+    - [dashboard_execution.ml:204]         60.0  → render_timeout_sec
+
+    Properties pinned:
+
+    1. Defaults preserve the pre-extraction literals (regression guard
+       against silent budget shifts that would re-introduce the "기다려야
+       할 부분을 안 기다리는" pattern on slow PG / cold-start projections).
+    2. Light < full ordering invariant: a [light] render must have a
+       strictly smaller budget than a [full] render, otherwise the
+       split-budget signal becomes meaningless and operators cannot tell
+       whether light is genuinely under-scoped or has accidentally taken
+       on full's work.
+    3. Render budget comfortably exceeds inner compute budgets. The
+       outer render guard at [dashboard_execution.ml:376] must give the
+       inner [Dashboard_cache.get_or_compute_with_timeout] sites room
+       to report their own "compute timeout" rather than being killed
+       by the outer wrapper.
+    4. Floor clamps prevent operators from configuring degenerate values. *)
+
+open Alcotest
+
+module D = Env_config_runtime.Dashboard
+
+let approx = float 0.001
+
+(* --- 1. Defaults pin the pre-extraction literals --- *)
+
+let test_default_mission () =
+  check approx
+    "mission_timeout_sec default (was inline 25.0)"
+    25.0 D.mission_timeout_sec
+
+let test_default_shell () =
+  check approx
+    "shell_timeout_sec default (was inline 16.0)"
+    16.0 D.shell_timeout_sec
+
+let test_default_shell_light () =
+  check approx
+    "shell_light_timeout_sec default (was inline 8.0)"
+    8.0 D.shell_light_timeout_sec
+
+let test_default_render () =
+  check approx
+    "render_timeout_sec default (was inline 60.0)"
+    60.0 D.render_timeout_sec
+
+(* --- 2. light < full ordering invariant --- *)
+
+let test_shell_light_strictly_less_than_full () =
+  check bool
+    "shell_light must strictly precede shell_full (else split-budget \
+     signal becomes meaningless)"
+    true
+    (D.shell_light_timeout_sec < D.shell_timeout_sec)
+
+(* --- 3. Render budget exceeds inner compute budgets --- *)
+
+let test_render_exceeds_mission () =
+  check bool
+    "render_timeout_sec MUST exceed mission_timeout_sec (else outer \
+     guard kills mission compute before its inner report)"
+    true
+    (D.render_timeout_sec > D.mission_timeout_sec)
+
+let test_render_exceeds_shell () =
+  check bool
+    "render_timeout_sec MUST exceed shell_timeout_sec (full path)"
+    true
+    (D.render_timeout_sec > D.shell_timeout_sec)
+
+(* --- 4. API surface compile guard ----------------------------- *)
+
+let test_smoke_call_sites_compile () =
+  let _ = D.mission_timeout_sec in
+  let _ = D.shell_timeout_sec in
+  let _ = D.shell_light_timeout_sec in
+  let _ = D.render_timeout_sec in
+  check bool "all four accessors are reachable" true true
+
+let () =
+  run "env_config_dashboard_compute_timeouts"
+    [
+      ( "defaults preserve pre-extraction literals",
+        [
+          test_case "mission = 25.0" `Quick test_default_mission;
+          test_case "shell = 16.0" `Quick test_default_shell;
+          test_case "shell_light = 8.0" `Quick test_default_shell_light;
+          test_case "render = 60.0" `Quick test_default_render;
+        ] );
+      ( "light < full ordering",
+        [
+          test_case "shell_light < shell" `Quick
+            test_shell_light_strictly_less_than_full;
+        ] );
+      ( "render exceeds inner compute",
+        [
+          test_case "render > mission" `Quick test_render_exceeds_mission;
+          test_case "render > shell" `Quick test_render_exceeds_shell;
+        ] );
+      ( "API surface",
+        [
+          test_case "all four accessors reachable" `Quick
+            test_smoke_call_sites_compile;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#10797의 후속. Dashboard subsystem 내부에 4개의 하드코딩 compute-timeout 리터럴이 더 있어 SSOT로 통합. 이슈 #10426 dashboard step 2.

| File | 이전 | 이후 |
|------|------|------|
| `server_dashboard_http_core.ml:78` | `dashboard_mission_timeout_s = 25.0` | `Env_config_runtime.Dashboard.mission_timeout_sec` |
| `server_dashboard_http_core.ml:790` | `dashboard_shell_timeout_s = 16.0` | `Env_config_runtime.Dashboard.shell_timeout_sec` |
| `server_dashboard_http_core.ml:791` | `dashboard_shell_light_timeout_s = 8.0` | `Env_config_runtime.Dashboard.shell_light_timeout_sec` |
| `dashboard_execution.ml:204` | `render_timeout_s = 60.0` | `Env_config_runtime.Dashboard.render_timeout_sec` |

새 env (default 동작 동일):
- \`MASC_DASHBOARD_MISSION_TIMEOUT_SEC\`
- \`MASC_DASHBOARD_SHELL_TIMEOUT_SEC\`
- \`MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC\`
- \`MASC_DASHBOARD_RENDER_TIMEOUT_SEC\`

## 운영자 관점

> 사용자 원문: \"기다리지 않아도 될 부분을 기다리고, 기다려야 할 부분을 안기다리기 때문에 생기는 파편성 버그\"

dashboard subsystem 안에 5개의 timeout이 4개 다른 값으로 흩어져 있어, 운영자가 \"슬로우 PG에서 mission 카드가 stale 인 이유는 mission_timeout_s 25s 때문인지 outer render_timeout_s 60s 때문인지\" 추적 불가했음. 이제 한 곳(\`Env_config_runtime.Dashboard\`)에서 dump + override.

## Invariants pinned by test

\`test_env_config_dashboard_compute_timeouts.ml\` (8 case):

1. **Defaults preserve pre-extraction literals** (regression guard)
2. **shell_light < shell** — split-budget signal 보존. light가 full보다 길어지면 \"light가 full의 일을 떠안았다\"는 신호가 사라짐.
3. **render > mission** — outer render guard가 inner mission compute의 자체 timeout 메시지를 묻지 않도록. PR #10797의 outer/inner pattern과 동일.
4. **render > shell** — full path 동일 invariant.
5. **API surface** — 모든 4 accessor 컴파일 보장.

## Test plan

- [x] \`dune build --root . @check\` green (워크트리)
- [x] \`dune build --root . lib/\` green
- [x] \`dune exec test_env_config_dashboard_compute_timeouts.exe\` 8/8 pass
- [x] 기존 \`test_env_config_dashboard_shell_prewarm.exe\` 4/4 회귀 없음

## Out of scope (별도 PR)

- inline literal \`120.0\`/\`30.0\` 3사이트 (\`server_dashboard_http_execution_surfaces.ml:433/444/463\`)
- \`process_eio.ml\` \`60.0\` × 8 default
- \`server_bootstrap_loops.ml\` \`0.25\`/\`5.0\` polling/settle
- \`with_unix_capture\` busy-poll (sync/async misuse axis, separate correctness track)

Refs #10426