### PR TITLE
fix(ws-transport): downgrade per-session lifecycle log to DEBUG (#10875)

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -782,7 +782,9 @@ let cleanup_session session_id =
     (with_sessions_rw (fun () -> Hashtbl.length sessions));
   Sse.unsubscribe_external session_id;
   if removed then
-    Log.Server.info "WebSocket session %s closed" session_id
+    (* #10875: see server_ws_standalone — per-session lifecycle is DEBUG
+       to avoid logging amplification during WS storm (#10701). *)
+    Log.Server.debug "WebSocket session %s closed" session_id
 
 (** Number of active WebSocket sessions. *)
 let session_count () =
@@ -823,7 +825,9 @@ let upgrade_connection
               then
                 cleanup_session session_id)
             ();
-          Log.Server.info "WebSocket session %s connected" session_id;
+          (* #10875: see cleanup_session — per-session lifecycle is DEBUG
+             to avoid logging amplification during WS storm (#10701). *)
+          Log.Server.debug "WebSocket session %s connected" session_id;
           { Httpun_ws.Websocket_connection.
             frame = (fun ~opcode ~is_fin ~len payload ->
               match opcode with

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -52,7 +52,11 @@ let make_websocket_handler ~on_message _client_addr (wsd : Ws.Wsd.t) :
       then
         Server_mcp_transport_ws.cleanup_session session_id)
     ();
-  Log.Server.info "WebSocket session %s connected (standalone port)" session_id;
+  (* #10875: WS storm (#10701) emits ~190k connect/close lines/day at INFO,
+     drowning real signal in noise. Per-session lifecycle is DEBUG; aggregate
+     state surfaces via Transport_metrics.set_ws_sessions and shutdown_hooks
+     summary INFO. *)
+  Log.Server.debug "WebSocket session %s connected (standalone port)" session_id;
   { Ws.Websocket_connection.
     frame = (fun ~opcode ~is_fin ~len payload ->
       match opcode with


### PR DESCRIPTION
## 증상

Issue #10875. WS connect/close 마다 INFO 2 lines 발화 — WS reconnect storm (#10701) 결합 시 logging amplification 2×.

\`\`\`
INFO Server: WebSocket session ws-1777224754791-1997 connected (standalone port)
INFO Server: WebSocket session ws-1777224754791-1997 closed
\`\`\`

| 지표 | 값 |
|---|---|
| 31분 윈도우 (17:00:54 ~ 17:32) | 4051 events |
| INFO Server 점유율 | 99%+ (4029/4051) |
| 일일 환산 | ~190k lines/day, ~30 MB/day |
| storm 시 cadence | 1Hz (매 초 새 session) |

## Fix

3 site 의 \`Log.Server.info\` → \`Log.Server.debug\`:
- \`lib/server/server_ws_standalone.ml::run_session\` — standalone-port connect.
- \`lib/server/server_mcp_transport_ws.ml::handle_upgrade\` — HTTP-upgrade connect.
- \`lib/server/server_mcp_transport_ws.ml::cleanup_session\` — close.

## Why DEBUG

INFO 가 정상 long-lived 세션과 1Hz storm 을 같은 level 로 logging — operator readability 손해. aggregate 상태는 이미 두 곳에 surface:
- \`Transport_metrics.set_ws_sessions\` (Prometheus gauge, connect/close 마다 업데이트).
- \`shutdown_hooks: \"Closed N WebSocket sessions\"\` (서버 stop 시 summary INFO).

Anomaly 시그널은 그대로 유지:
- \`Log.Server.warn \"WS close failed for %s\"\` (close 실패) — 그대로 WARN.
- drift / cadence anomaly 는 metric ts-delta 로 detect 가능.

## 미포함 (별도 PR 후보)

Issue 의 단기 옵션 (2) \"immediate-close at ERROR\" — connect-time vs close-time 비교 상태 필요. WS storm root cause (#10701) 도 같은 state 필요해서 묶어서 처리 권장.

## 검증

- \`dune build @check\` EXIT=0.
- 동작 검증: server 재시작 후 INFO 레벨 로그에서 WS connect/close 라인 부재 확인 + DEBUG 레벨에선 이전과 동일하게 노출.

## Cross-ref

- #10701 (WS reconnect storm — 본 logging hygiene 의 root cause).
- #10745 (fd-leak — WS fd consumer).
- #10097 / #9580 (closed) — same logging hygiene family.
- memory \`feedback_dashboard-observation-focus.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)