### PR TITLE
refactor(design-system): swap connector-config auto-restart checkbox to Checkbox (PR-CS63)

### DIFF
--- a/dashboard/src/components/connector-config-form.test.ts
+++ b/dashboard/src/components/connector-config-form.test.ts
@@ -343,7 +343,7 @@ describe('ConnectorConfigForm', () => {
     await flushUi()
     await flushUi()
 
-    const toggle = container.querySelector('[data-auto-restart-toggle]') as HTMLInputElement
+    const toggle = container.querySelector('[data-testid="auto-restart-toggle"]') as HTMLInputElement
     expect(toggle).toBeTruthy()
     expect(toggle.checked).toBe(false)
 
@@ -384,7 +384,7 @@ describe('ConnectorConfigForm', () => {
     await flushUi()
     await flushUi()
 
-    const toggle = container.querySelector('[data-auto-restart-toggle]') as HTMLInputElement
+    const toggle = container.querySelector('[data-testid="auto-restart-toggle"]') as HTMLInputElement
     toggle.click()
     await flushUi()
 
@@ -429,7 +429,7 @@ describe('ConnectorConfigForm', () => {
     await flushUi()
     await flushUi()
 
-    ;(container.querySelector('[data-auto-restart-toggle]') as HTMLInputElement).click()
+    ;(container.querySelector('[data-testid="auto-restart-toggle"]') as HTMLInputElement).click()
     await flushUi()
     const btn = Array.from(container.querySelectorAll('button'))
       .find(b => b.textContent?.trim() === 'Save & Apply') as HTMLButtonElement

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -21,6 +21,7 @@ import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { Eye, EyeOff } from 'lucide-preact'
 import { ActionButton } from './common/button'
+import { Checkbox } from './common/checkbox'
 import { CopyableCode } from './common/copyable-code'
 import { LoadingState } from './common/feedback-state'
 import { showToast } from './common/toast'
@@ -476,13 +477,12 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
             class="flex cursor-pointer items-center gap-1 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)]"
             title="저장 직후 자동으로 sidecar 재시작 (stop → 800ms → start)"
           >
-            <input
-              type="checkbox"
-              class="cursor-pointer"
+            <${Checkbox}
               checked=${entry.autoRestart}
-              data-auto-restart-toggle
-              onChange=${(ev: Event) => {
-                setEntry(connectorId, { autoRestart: (ev.target as HTMLInputElement).checked })
+              testId="auto-restart-toggle"
+              ariaLabel="자동 재시작"
+              onChange=${(checked: boolean) => {
+                setEntry(connectorId, { autoRestart: checked })
               }}
             />
             <span>자동 재시작</span>


### PR DESCRIPTION
## Summary

CS series sweep. connector-config-form의 자동 재시작 토글을 raw `<input type=\"checkbox\">`에서 canonical `Checkbox`로 swap.

## 변경

`dashboard/src/components/connector-config-form.ts`:
- `import { Checkbox } from './common/checkbox'` 추가
- `<input type=\"checkbox\" data-auto-restart-toggle>` → `<${Checkbox} testId=\"auto-restart-toggle\">`
- onChange callback 시그니처 변경:
  - Before: `(ev: Event) => setEntry(...((ev.target as HTMLInputElement).checked))`
  - After: `(checked: boolean) => setEntry(..., checked)`
- `ariaLabel=\"자동 재시작\"` 추가 (a11y — 이전엔 wrapping label에 시각 텍스트만 있어 screen reader가 checkbox 자체를 unnamed로 인식)

## 시각 변화

| 측면 | Before | After |
|------|--------|-------|
| 배경 | browser default | `--white-4` (CHECKBOX_BASE) |
| Border | browser default | `--color-border-default` |
| Hover | none | `--white-8` bg + `--white-20` border |
| Focus | browser default outline | focus-visible ring `--accent-45` + offset |
| Checkmark | browser blue | `--color-accent-fg` (theme-aware) |

## 테스트

`dashboard/src/components/connector-config-form.test.ts`:
- 3건의 selector 업데이트:
  - `container.querySelector('[data-auto-restart-toggle]')` → `container.querySelector('[data-testid=\"auto-restart-toggle\"]')`

(Checkbox component은 whitelist 외 prop을 silently drop하므로 `data-*` 직접 attr 대신 `testId` prop 필수.)

## Out of scope

`case 'boolean'` dynamic field renderer (line 351)는 별도 PR로 — per-field 렌더러라 onCheckbox 시그니처 변경 영향 범위가 다름.

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/connector`: 199/199 pass (3 selector-updated 테스트 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)