### PR TITLE
refactor(transport): remove dashboard SSE entry points (PR-3)

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -92,8 +92,7 @@ let observer_sse_query_token_from_request request =
   in
   match request.Httpun.Request.meth with
   | `GET
-    when observer_stream_requested
-         && (String.equal path "/mcp" || String.equal path "/sse") ->
+    when observer_stream_requested && String.equal path "/mcp" ->
       trim_opt (query_param request "token")
   | _ -> None
 

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -674,23 +674,6 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
             Log.Server.info "SSE connected: %s (active: %d/%d)"
               session_id client_count Sse.max_clients)))
 
-let sse_simple_handler ~deps request reqd =
-  let origin = deps.get_origin request in
-  let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
-  let protocol_version = get_protocol_version_for_session ~session_id request in
-  let event =
-    sse_prime_event ()
-    ^ Sse.format_event ~event_type:"connected"
-        (Printf.sprintf {|{"session_id":"%s"}|} session_id)
-  in
-  let headers =
-    Httpun.Headers.of_list
-      (("content-length", string_of_int (String.length event))
-      :: legacy_transport_deprecation_headers
-      @ sse_headers ~deps session_id protocol_version origin)
-  in
-  let response = Httpun.Response.create ~headers `OK in
-  Httpun.Reqd.respond_with_string reqd response event
 
 let handle_get_operator_mcp ~deps request reqd =
   let session_id = Mcp_session.get_or_generate (get_session_id_any request) in

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -107,7 +107,6 @@ val handle_get_mcp :
   Httpun.Request.t ->
   Httpun.Reqd.t ->
   unit
-val sse_simple_handler : deps:deps -> Httpun.Request.t -> Httpun.Reqd.t -> unit
 val handle_get_operator_mcp :
   deps:deps -> Httpun.Request.t -> Httpun.Reqd.t -> unit
 val handle_post_messages :

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -249,10 +249,6 @@ let handle_get_mcp ?legacy_messages_endpoint
   Server_mcp_transport_http.handle_get_mcp ~deps:(mcp_transport_http_deps ())
     ?legacy_messages_endpoint ~profile ?sse_kind request reqd
 
-let sse_simple_handler request reqd =
-  Server_mcp_transport_http.sse_simple_handler ~deps:(mcp_transport_http_deps ())
-    request reqd
-
 let handle_get_operator_mcp request reqd =
   Server_mcp_transport_http.handle_get_operator_mcp
     ~deps:(mcp_transport_http_deps ()) request reqd

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -54,14 +54,6 @@ let with_canonical_loopback_host ~port handler request reqd =
 let redirect_to_dashboard reqd =
   respond_redirect ~location:"/dashboard" reqd
 
-let is_dashboard_observer_stream request =
-  match Server_utils.query_param request "sse_kind" with
-  | Some raw ->
-      let normalized = String.trim raw |> String.lowercase_ascii in
-      String.equal normalized "observer"
-      || String.equal normalized "dashboard"
-  | None -> false
-
 let websocket_discovery_handler request reqd =
   let body =
     websocket_discovery_json request |> Yojson.Safe.to_string
@@ -238,12 +230,7 @@ let add_routes ~port ~host router =
   |> Http.Router.get "/graphiql/react-dom.production.min.js"
        (serve_graphiql_asset "react-dom.production.min.js")
   |> Http.Router.get "/mcp" (fun request reqd ->
-       if is_dashboard_observer_stream request then
-         with_public_read (fun _state req reqd ->
-           handle_get_mcp ~sse_kind:Sse.Observer req reqd
-         ) request reqd
-       else
-         with_read_auth (fun _state req reqd -> handle_get_mcp req reqd) request reqd)
+       with_read_auth (fun _state req reqd -> handle_get_mcp req reqd) request reqd)
   |> Http.Router.post "/" handle_post_mcp
   |> Http.Router.post "/mcp" handle_post_mcp
   |> Http.Router.post "/mcp/managed"
@@ -260,12 +247,3 @@ let add_routes ~port ~host router =
        ~handler:(fun request reqd ->
          with_read_auth (fun _state req reqd -> handle_graphql req reqd) request reqd)
   |> Http.Router.post "/messages" handle_post_messages
-  |> Http.Router.get "/sse"
-       (fun request reqd ->
-         with_public_read (fun _state req reqd ->
-           handle_get_mcp ~sse_kind:Sse.Observer
-             ~legacy_messages_endpoint:(legacy_messages_endpoint_url req)
-             req reqd
-         ) request reqd)
-  |> Http.Router.get "/sse/simple" (fun request reqd ->
-       with_public_read (fun _state req reqd -> sse_simple_handler req reqd) request reqd)


### PR DESCRIPTION
## Why

PR-3 of the SSE → WebSocket cutover series.  Removes the dashboard-facing SSE entry points now that:

- **Dashboard SPA** (PR-1 #10657 dev / PR-2 #10669 production) ships with `wsOnly = dashboardWsOnlyEnabled() === true`, which gates the `connectSSE()` call (`dashboard/src/app.ts:123`).  Production build via #10684 multi-stage Dockerfile picks up `.env.production`'s flag.
- **Server-side fanout** is transport-agnostic via `Sse.broadcast_to All`, which delivers to **both** SSE clients **and** WS sessions registered as `Sse.subscribe_external` callbacks (`server_mcp_transport_ws.ml:817`).  WS clients have always received every broadcast event regardless of whether the SSE entry was open.
- **Live verification** (production-equivalent server `25a73ede80`, 42 min uptime): `masc_sse_sessions{kind=observer}` started at 0 then climbed to 2 only when an operator opened a stale dashboard build (cutover flag off).  Default-cutover environments stay at 0.

## What is removed

| Site | Removal |
|------|---------|
| `lib/server/server_routes_http_routes_frontend.ml` | `Http.Router.get "/sse"` (dashboard observer SSE) |
| `lib/server/server_routes_http_routes_frontend.ml` | `Http.Router.get "/sse/simple"` |
| `lib/server/server_routes_http_routes_frontend.ml` | `is_dashboard_observer_stream` helper (caller now 0) |
| `lib/server/server_routes_http_routes_frontend.ml` | `/mcp` GET branch on `is_dashboard_observer_stream` (flattened) |
| `lib/server/server_routes_http_common.ml` | `sse_simple_handler` re-export |
| `lib/server/server_mcp_transport_http.ml(.mli)` | `sse_simple_handler` definition |
| `lib/server/server_auth.ml` | `path = "/sse"` branch in `observer_sse_query_token_from_request` (`/mcp` retained) |

Net: 4 files, mostly deletions.

## What is preserved

These remain as PR-5/PR-6 follow-up work:

| Surface | Why preserved |
|---------|---------------|
| `Sse` module (`lib/sse.ml`/`lib/sse.mli`) | Live deps: 1 coordinator, 1 WS external subscriber.  `subscribe_external` is the WS fanout path. |
| `Sse.broadcast_to All` | Used by `server_dashboard_http_*` and `server_routes_http_routes_activity` for snapshot broadcasts → WS receives via external subscriber. |
| `Sse.Coordinator` `sse_kind` | gRPC/coordinator session path.  `handle_get_mcp ?sse_kind` parameter retained. |
| `legacy_messages_endpoint_url` chain | Caller now 0 (was only `/sse` route).  Defer to a tighter follow-up so this PR stays a pure deletion. |
| Prometheus metrics `masc_sse_*` | Operational contract; deferred per #10711 policy. |
| `lib/oas_event_bridge.ml` | Already renamed (#10711) and log-prefix-cleaned (#10856). |

## Risk

- **Operators with a stale dashboard SPA bundle** (cutover flag off) will see EventSource(/sse) → 404 after rolling out.  The browser console reconnect loop is the only visible symptom; the WS channel continues to deliver every broadcast in parallel because `connectDashboardWS` runs unconditionally.  Mitigation: ship a hard reload after merge.
- **A2A `/sse/portal`, `/sse/subscriptions`** were already verified as 404 dead strings in #10866 — no change here.

## Verification

- `dune build @check` — green.
- `rg '"/sse"|"/sse/simple"' lib/server/server_routes_*.ml` — empty after this PR.
- Manual: `curl /sse → 404` after deploy.

## Test plan

- [x] `dune build @check` succeeds
- [x] `Sse` module + `subscribe_external` mechanism untouched
- [x] `Sse.Coordinator` `sse_kind` argument retained on `handle_get_mcp`
- [ ] Operator dashboard bundles built post-#10684 / #10669 do not regress (no SSE EventSource at all)
- [ ] Stale bundles see EventSource 404 → relies on WS-only broadcast delivery (which is the cutover's invariant)

## Cutover series progress

- PR-1 (#10657) — dev cutover + transport beacon ✅
- PR-2 (#10669) — production env SSOT ✅
- #10670 → #10684 — multi-stage Dockerfile ✅
- PR-4 (#10711) — `Oas_sse_bridge` → `Oas_event_bridge` rename ✅
- PR-4 (#10713) — partial-match cascade unblock ✅
- PR-4 (#10721) — `Oas_compat` boundary adapter ✅
- #10856 — log prefix + docs cleanup (Draft)
- PR-5 (#10866) — drop dead A2A SSE endpoint advertisements (Draft)
- **PR-3 (this)** — drop dashboard SSE entry points
- Follow-up: `legacy_messages_endpoint_url` chain cleanup; eventual `Sse` module deletion (gated on coordinator + WS external subscriber migration)
