### PR TITLE
feat(dashboard): extract execution-surface timeouts to env (SSOT step 3)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -610,6 +610,31 @@ module Dashboard = struct
     Float.max 5.0
       (get_float ~default:35.0
          "MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC")
+
+  (** Execution surface compute timeout (light + parameterized).
+
+      Wraps two [Dashboard_cache.get_or_compute_with_timeout] sites at
+      [server_dashboard_http_execution_surfaces.ml:437,449] (execution
+      light/parameterized). Default 120s preserves the inline literals.
+      Floor 5s ensures the budget can complete a typical projection
+      hydration even under aggressive operator override. *)
+  let execution_timeout_sec =
+    Float.max 5.0
+      (get_float ~default:120.0 "MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC")
+
+  (** Execution-trust surface compute timeout.
+
+      Wraps [Dashboard_cache.get_or_compute_with_timeout] at
+      [server_dashboard_http_execution_surfaces.ml:463] (execution-trust
+      score). Default 30s preserves the inline literal. Smaller than
+      [execution_timeout_sec] because the trust projection is
+      intentionally lighter — keeping the split visible lets operators
+      diagnose when trust scoring is the bottleneck vs. the full
+      execution surface. *)
+  let execution_trust_timeout_sec =
+    Float.max 1.0
+      (get_float ~default:30.0
+         "MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC")
 end
 
 (** {1 Internal Timers and TTLs}

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -435,7 +435,8 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
          misses its first build window. *)
       cached_surface_or_first_success_json _execution_cache
         ~cache_key:"execution:default:light" ~ttl:120.0 ~clock
-        ~timeout_sec:120.0 (compute ~light:true)
+        ~timeout_sec:Env_config_runtime.Dashboard.execution_timeout_sec
+        (compute ~light:true)
   | _ ->
       (* Parameterized requests (fixture/actor/full): on-demand with SWR cache.
          These are rare (test fixtures, actor-specific views, full mode). *)
@@ -446,7 +447,9 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
           (if full_mode then "full" else "light")
       in
       Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
-        ~clock ~timeout_sec:120.0 (compute ?actor ?fixture ~light)
+        ~clock
+        ~timeout_sec:Env_config_runtime.Dashboard.execution_timeout_sec
+        (compute ?actor ?fixture ~light)
 
 let dashboard_execution_trust_http_json ~state ~sw ~clock _request =
   let compute () =
@@ -465,7 +468,7 @@ let dashboard_execution_trust_http_json ~state ~sw ~clock _request =
       "execution-trust:default"
       ~ttl:15.0
       ~clock
-      ~timeout_sec:30.0
+      ~timeout_sec:Env_config_runtime.Dashboard.execution_trust_timeout_sec
       compute
   | None ->
     Dashboard_cache.get_or_compute

--- a/test/dune
+++ b/test/dune
@@ -1773,3 +1773,9 @@
  (name test_env_config_dashboard_shell_prewarm)
  (modules test_env_config_dashboard_shell_prewarm)
  (libraries masc_test_deps))
+
+; Dashboard execution-surface timeout SSOT
+(test
+ (name test_env_config_dashboard_execution_timeouts)
+ (modules test_env_config_dashboard_execution_timeouts)
+ (libraries masc_test_deps))

--- a/test/test_env_config_dashboard_execution_timeouts.ml
+++ b/test/test_env_config_dashboard_execution_timeouts.ml
@@ -1,0 +1,72 @@
+(** Pin the {!Env_config_runtime.Dashboard} execution-surface timeout
+    contract. Three values were extracted from inline literals at
+    [server_dashboard_http_execution_surfaces.ml]:
+
+    - line 437/438  120.0  → execution_timeout_sec (light path)
+    - line 448/449  120.0  → execution_timeout_sec (parameterized path)
+    - line 467/468   30.0  → execution_trust_timeout_sec
+
+    The two execution literals (light + parameterized) shared a value
+    by coincidence — we collapse them to one knob so future operator
+    overrides apply to both consistently. The trust literal is kept
+    separate because the trust projection is intentionally lighter and
+    the split signal helps operators diagnose which surface is the
+    bottleneck.
+
+    Properties pinned:
+
+    1. Defaults preserve the pre-extraction literals.
+    2. Trust budget < execution budget — the trust projection is
+       lighter, and the split lets operators distinguish "trust
+       scoring is slow" from "the full execution surface is slow".
+    3. Floor clamps prevent degenerate operator config. *)
+
+open Alcotest
+
+module D = Env_config_runtime.Dashboard
+
+let approx = float 0.001
+
+let test_default_execution () =
+  check approx
+    "execution_timeout_sec default (was inline 120.0 ×2)"
+    120.0 D.execution_timeout_sec
+
+let test_default_execution_trust () =
+  check approx
+    "execution_trust_timeout_sec default (was inline 30.0)"
+    30.0 D.execution_trust_timeout_sec
+
+let test_trust_strictly_less_than_execution () =
+  check bool
+    "execution_trust_timeout_sec must be < execution_timeout_sec \
+     (else the split-budget signal between trust vs full surface \
+     becomes meaningless)"
+    true
+    (D.execution_trust_timeout_sec < D.execution_timeout_sec)
+
+let test_smoke_call_sites_compile () =
+  let _ = D.execution_timeout_sec in
+  let _ = D.execution_trust_timeout_sec in
+  check bool "both accessors are reachable" true true
+
+let () =
+  run "env_config_dashboard_execution_timeouts"
+    [
+      ( "defaults preserve pre-extraction literals",
+        [
+          test_case "execution = 120.0" `Quick test_default_execution;
+          test_case "execution_trust = 30.0" `Quick
+            test_default_execution_trust;
+        ] );
+      ( "trust < execution ordering",
+        [
+          test_case "execution_trust < execution" `Quick
+            test_trust_strictly_less_than_execution;
+        ] );
+      ( "API surface",
+        [
+          test_case "both accessors reachable" `Quick
+            test_smoke_call_sites_compile;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#10797 + #10880의 후속. \`server_dashboard_http_execution_surfaces.ml\`에 남은 3개 inline literal을 \`Env_config_runtime.Dashboard\` SSOT로 통합.

| Before | After |
|--------|-------|
| line 437/438: \`~timeout_sec:120.0\` (execution:light) | \`Env_config_runtime.Dashboard.execution_timeout_sec\` |
| line 448/449: \`~timeout_sec:120.0\` (execution:parameterized) | \`Env_config_runtime.Dashboard.execution_timeout_sec\` |
| line 467/468: \`~timeout_sec:30.0\` (execution-trust) | \`Env_config_runtime.Dashboard.execution_trust_timeout_sec\` |

두 execution literal(light + parameterized)은 같은 값(120.0)을 _우연히_ 공유하던 케이스라 하나의 knob으로 collapse — 향후 operator override가 양쪽에 일관되게 적용됨. trust는 의도적으로 더 가벼운 surface라 분리 유지.

## 새 env (default 동작 동일)

- \`MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC\` (default 120.0, floor 5s)
- \`MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC\` (default 30.0, floor 1s)

## Invariant pinned

\`test_env_config_dashboard_execution_timeouts.ml\` (4 case):
1. defaults preserve 120.0 / 30.0
2. **execution_trust < execution** — split-budget signal 보존
3. API surface 컴파일 보장

## Test plan

- [x] \`dune build --root . @check\` green
- [x] \`dune exec test_env_config_dashboard_execution_timeouts.exe\` 4/4 pass

## 누적 dashboard SSOT (3 PR series)

| PR | Constants | Env |
|----|-----------|-----|
| #10797 | shell_prewarm inner/outer | 2 |
| #10880 | mission/shell/shell_light/render | 4 |
| 이 PR | execution/execution_trust | 2 |
| **총** | **8 timeout** | **8 env var** |

## Out of scope

- \`process_eio.ml\` \`?(timeout_sec = 60.0)\` × 8 default (별 axis: process subsystem)
- \`server_bootstrap_loops.ml\` \`Eio.Time.sleep 0.25\` × 2 + \`5.0\` (polling/settle, different intent)
- \`with_unix_capture\` 0.05s busy-poll (sync/async misuse axis, separate correctness track)

Refs #10426