### PR TITLE
docs(supervisor): clarify scope is per-process fiber, not OS process (#10828)

### DIFF
--- a/lib/supervisor.ml
+++ b/lib/supervisor.ml
@@ -1,13 +1,10 @@
-(** Supervisor — One-for-one Eio fiber supervisor
+(** Supervisor — One-for-one Eio {b fiber} supervisor.
 
-    Manages a set of named child fibers with restart policies.
-    When a child crashes, the supervisor decides whether to restart,
-    back off and retry, or escalate.
-
-    Erlang/OTP-inspired but adapted to Eio's cooperative model:
-    - Children are (unit -> unit) functions, not processes
-    - Restart uses Eio.Fiber.fork, not process spawn
-    - Backoff uses Eio.Time.sleep, not erlang timers
+    See [supervisor.mli] for the full contract.  Briefly: this module
+    supervises {b fibers within a single OS process}.  It does not
+    restart the process itself — process-level recovery (launchd,
+    systemd, respawn-loop wrapper) is out of scope.  Tracking:
+    [#10828].
 
     @since 2.102.0 *)
 

--- a/lib/supervisor.mli
+++ b/lib/supervisor.mli
@@ -1,8 +1,22 @@
-(** Supervisor — One-for-one Eio fiber supervisor.
+(** Supervisor — One-for-one Eio {b fiber} supervisor.
 
-    Manages a set of named child fibers with restart policies.
-    When a child crashes, the supervisor decides whether to restart,
-    back off and retry, or escalate.
+    {1 Scope of protection}
+
+    Manages a set of named child fibers within a {b single OS process}.
+    When a child fiber crashes, the supervisor decides whether to
+    restart, back off and retry, or escalate within the same process.
+
+    {b This module does NOT supervise the OS process itself.}  If the
+    process exits — uncaught exception in a non-supervised fiber, OOM
+    kill, signal, or kernel panic — there is no automatic restart from
+    this layer.  Process-level recovery is the responsibility of an
+    outer supervisor (launchd / systemd / a respawn-loop wrapper
+    script) which is intentionally not bundled here per repo policy.
+
+    Tracking: [#10828] ([no process-level supervisor]) records the
+    gap and proposes operator-side runbook options.
+
+    {1 Mechanics}
 
     Erlang/OTP-inspired but adapted to Eio's cooperative model:
     - Children are [(unit -> unit)] functions, not OS processes


### PR DESCRIPTION
## Why

#10828 records masc-mcp server **dead 16+ hours with no auto-restart**. The only thing in the codebase named \"Supervisor\" is \`lib/supervisor.{ml,mli}\` and its module doc reads:

> Supervisor — One-for-one Eio fiber supervisor.
> Manages a set of named child fibers with restart policies.

The \"Erlang/OTP-inspired\" framing reinforces an Erlang-shaped mental model (which **does** survive process death via the BEAM VM), but the actual scope is fibers within a single OS process. Operators have mistaken this for OS-process supervision (per #10828 root analysis).

## Fix (doc-only)

- Promote \"fiber, not OS process\" to a section header with **bold**.
- Add explicit \"This module does NOT supervise the OS process itself\" warning callout, calling out OOM kill / signal / kernel panic / uncaught exception in non-supervised fibers as the exit paths.
- Reference repo policy that intentionally bundles no launchd / systemd integration (\`CLAUDE.md\` \`<launchd>\` section).
- Cross-link #10828 so future readers can trace the gap.

## What this PR is NOT

- Not adding process-level supervision (launchd / systemd / wrapper script) — repo policy reserves that for explicit operator approval.
- Not renaming the module (rename would touch ~20 call sites; doc strengthening is the lower-risk first step).

## Test plan

- [x] \`dune build @check\` EXIT=0
- [ ] CI green
- [ ] Ready transition

No behaviour change. Doc-only.

## Memory

\`feedback_no-derived-tag-when-existing-identifier-suffices\` — naming honesty class. Generic \"Supervisor\" implies wider scope than it actually has; existing identifier (\"fiber supervisor\") was already in the body but not loud enough at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)