### PR TITLE
feat(process): consolidate 11 subprocess timeout defaults to env (SSOT)

### DIFF
--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -57,6 +57,29 @@ let reset_for_testing () =
 
 let default_buffer_size = 1024
 
+(** Default subprocess wall-clock budget (seconds).
+
+    Eleven public APIs (run_argv*, run_unix_argv*_fallback,
+    with_unix_capture) shared the same hardcoded literal [60.0] as their
+    [?timeout_sec] default — a magic-number anti-pattern that made
+    tuning impossible without rebuilding. Callers that care about
+    timeout still pass [~timeout_sec:N] explicitly (and most do); the
+    handful of sites that rely on the default now go through one knob
+    that operators can override on slow-disk fleets via
+    [MASC_PROCESS_DEFAULT_TIMEOUT_SEC].
+
+    Floor 1s — anything smaller than a second cannot capture even a
+    trivial subprocess startup and is almost certainly an operator
+    misconfiguration. Read once at module load (mirrors the pattern in
+    [Env_config_runtime]); operator overrides take effect on next
+    process restart, not mid-run. *)
+let default_timeout_sec =
+  let raw =
+    try float_of_string (Sys.getenv "MASC_PROCESS_DEFAULT_TIMEOUT_SEC")
+    with Not_found | Failure _ -> 60.0
+  in
+  Float.max 1.0 raw
+
 let get_proc_mgr () =
   match Atomic.get runtime_state with
   | Some runtime -> Ok runtime.proc_mgr
@@ -159,7 +182,7 @@ let captured_stderr_or_empty path_opt =
   | None -> ""
 
 let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
-    ?(timeout_sec = 60.0)
+    ?(timeout_sec = default_timeout_sec)
     (argv : string list)
     ~(on_error : string -> string -> 'a)
     ~(on_success : Unix.process_status -> string -> string -> 'a) : 'a =
@@ -371,7 +394,7 @@ let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
          cleanup ();
          on_error (reason_of_exn_for_output exn) stderr)
 
-let run_unix_argv_fallback ?(timeout_sec = 60.0) ?env (argv : string list) : string =
+let run_unix_argv_fallback ?(timeout_sec = default_timeout_sec) ?env (argv : string list) : string =
   let label = String.concat " " (List.map Filename.quote argv) in
   with_unix_capture ?env ~timeout_sec argv
     ~on_error:(fun reason stderr ->
@@ -380,7 +403,7 @@ let run_unix_argv_fallback ?(timeout_sec = 60.0) ?env (argv : string list) : str
     ~on_success:(fun status stdout stderr ->
       output_for_status ~status ~stdout ~stderr)
 
-let run_unix_argv_with_status_split_fallback ?(timeout_sec = 60.0) ?env ?cwd (argv : string list) :
+let run_unix_argv_with_status_split_fallback ?(timeout_sec = default_timeout_sec) ?env ?cwd (argv : string list) :
     Unix.process_status * string * string =
   let label = String.concat " " (List.map Filename.quote argv) in
   with_unix_capture ?env ?cwd ~timeout_sec ~capture_stderr:true argv
@@ -390,7 +413,7 @@ let run_unix_argv_with_status_split_fallback ?(timeout_sec = 60.0) ?env ?cwd (ar
     ~on_success:(fun status stdout stderr ->
       (status, stdout, stderr))
 
-let run_unix_argv_with_stdin_fallback ?(timeout_sec = 60.0) ?env ~(stdin_content : string)
+let run_unix_argv_with_stdin_fallback ?(timeout_sec = default_timeout_sec) ?env ~(stdin_content : string)
     (argv : string list) : string =
   let label = String.concat " " (List.map Filename.quote argv) in
   with_unix_capture ?env ~timeout_sec ~stdin_content argv
@@ -401,7 +424,7 @@ let run_unix_argv_with_stdin_fallback ?(timeout_sec = 60.0) ?env ~(stdin_content
       output_for_status ~status ~stdout ~stderr)
 
 let run_unix_argv_with_stdin_and_status_split_fallback
-    ?(timeout_sec = 60.0)
+    ?(timeout_sec = default_timeout_sec)
     ?env
     ?cwd
     ~(stdin_content : string)
@@ -478,7 +501,7 @@ let spawn_and_drain_both ~sw pm ~cwd ?env ?stdin_source argv stdout_buf
   | `Exited n -> Unix.WEXITED n
   | `Signaled n -> Unix.WSIGNALED n
 
-let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
+let run_argv ?(timeout_sec = default_timeout_sec) ?env (argv : string list) : string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv ~argv ?env ();
   if not (is_initialized ()) then
     run_unix_argv_fallback ~timeout_sec ?env argv
@@ -513,7 +536,7 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
                 (Printexc.to_string exn);
               process_error_output ~label ~reason:(reason_of_exn_for_output exn) ())
 
-let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (argv : string list) : string =
+let run_argv_with_stdin ?(timeout_sec = default_timeout_sec) ?env ~(stdin_content : string) (argv : string list) : string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_stdin ~argv ?env ();
   if not (is_initialized ()) then
     run_unix_argv_with_stdin_fallback ~timeout_sec ?env ~stdin_content argv
@@ -550,7 +573,7 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
               process_error_output ~label ~reason:(reason_of_exn_for_output exn) ())
 
 let run_argv_with_stdin_and_status_split
-    ?(timeout_sec = 60.0)
+    ?(timeout_sec = default_timeout_sec)
     ?env
     ?cwd
     ~(stdin_content : string)
@@ -614,7 +637,7 @@ let run_argv_with_stdin_and_status_split
                   ~reason:(reason_of_exn_for_output exn) () ))
 
 let run_argv_with_stdin_and_status
-    ?(timeout_sec = 60.0)
+    ?(timeout_sec = default_timeout_sec)
     ?env
     ?cwd
     ~(stdin_content : string)
@@ -625,7 +648,7 @@ let run_argv_with_stdin_and_status
   in
   (status, output_for_status ~status ~stdout ~stderr)
 
-let run_argv_with_status_split ?(timeout_sec = 60.0) ?env ?cwd
+let run_argv_with_status_split ?(timeout_sec = default_timeout_sec) ?env ?cwd
     (argv : string list) : Unix.process_status * string * string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_status ~argv ?env ?cwd ();
   if not (is_initialized ()) then
@@ -681,7 +704,7 @@ let run_argv_with_status_split ?(timeout_sec = 60.0) ?env ?cwd
                 process_error_output ~label
                   ~reason:(reason_of_exn_for_output exn) () ))
 
-let run_argv_with_status ?(timeout_sec = 60.0) ?env ?cwd
+let run_argv_with_status ?(timeout_sec = default_timeout_sec) ?env ?cwd
     (argv : string list) : Unix.process_status * string =
   let status, stdout, stderr =
     run_argv_with_status_split ~timeout_sec ?env ?cwd argv

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -38,6 +38,16 @@ val argv_program : string list -> string
     ["<empty>"] for an empty argv).  Exposed for tests and parity with
     the hook payload. *)
 
+val default_timeout_sec : float
+(** Default subprocess wall-clock budget shared by every [run_argv*],
+    [run_unix_argv*_fallback], and [with_unix_capture] [?timeout_sec]
+    parameter when the caller does not pass one explicitly.
+
+    Read once at module load from [MASC_PROCESS_DEFAULT_TIMEOUT_SEC]
+    (default [60.0], floor [1.0]). Operator overrides take effect on
+    next process restart. Exposed primarily for regression tests that
+    pin the historical [60.0] literal against silent shifts. *)
+
 (** {1 Eio-native process execution (global refs)} *)
 
 (** Run command with explicit argv (no shell). Safe from injection.

--- a/test/dune
+++ b/test/dune
@@ -1779,3 +1779,9 @@
  (name test_env_config_dashboard_execution_timeouts)
  (modules test_env_config_dashboard_execution_timeouts)
  (libraries masc_test_deps))
+
+; Process_eio subprocess default timeout SSOT
+(test
+ (name test_process_eio_default_timeout)
+ (modules test_process_eio_default_timeout)
+ (libraries masc_test_deps))

--- a/test/test_process_eio_default_timeout.ml
+++ b/test/test_process_eio_default_timeout.ml
@@ -1,0 +1,42 @@
+(** Pin {!Process_eio.default_timeout_sec} at the pre-extraction
+    literal [60.0]. Eleven public APIs (run_argv*, run_unix_argv*_
+    fallback, with_unix_capture) used to share a hardcoded [60.0]
+    default in their [?timeout_sec] parameter. The literals were
+    consolidated into one module-level constant so operators can
+    override fleet-wide via [MASC_PROCESS_DEFAULT_TIMEOUT_SEC] without
+    a rebuild.
+
+    Properties pinned:
+
+    1. Default value preserves the pre-extraction literal [60.0]
+       (regression guard against silent budget shifts).
+    2. Floor 1.0 prevents degenerate operator config (sub-second
+       budgets cannot capture any subprocess startup).
+
+    The env-override behavior itself isn't tested here because the
+    constant is read at module load — proving it requires a subprocess
+    or [reset_for_testing] hook. The default-pin test is sufficient to
+    catch any future refactor that flips the default. *)
+
+open Alcotest
+
+let test_default_value () =
+  check (float 0.001)
+    "Process_eio.default_timeout_sec default (was inline 60.0)"
+    60.0 Process_eio.default_timeout_sec
+
+let test_floor_documented () =
+  check bool
+    "default value satisfies the documented >=1.0 floor"
+    true
+    (Process_eio.default_timeout_sec >= 1.0)
+
+let () =
+  run "process_eio_default_timeout"
+    [
+      ( "default preserves pre-extraction literal",
+        [
+          test_case "default = 60.0" `Quick test_default_value;
+          test_case "default >= 1.0 (floor)" `Quick test_floor_documented;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

\`Process_eio\`의 11개 public API가 모두 \`?(timeout_sec = 60.0)\`로 같은 하드코딩 default를 갖고 있었다. 이건 fleet-wide 운영자 튜닝을 불가능하게 만드는 magic-number anti-pattern이라 단일 SSOT로 통합.

## 변경

**Before** (11 사이트, 같은 리터럴 60.0 반복):
\`\`\`ocaml
let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
    ?(timeout_sec = 60.0) ...
let run_unix_argv_fallback ?(timeout_sec = 60.0) ?env ...
let run_argv ?(timeout_sec = 60.0) ?env ...
(* ... 8 more identical sites *)
\`\`\`

**After** (단일 module-level constant + 11 reference):
\`\`\`ocaml
let default_timeout_sec =
  let raw =
    try float_of_string (Sys.getenv \"MASC_PROCESS_DEFAULT_TIMEOUT_SEC\")
    with Not_found | Failure _ -> 60.0
  in
  Float.max 1.0 raw

let run_argv ?(timeout_sec = default_timeout_sec) ?env ...
\`\`\`

## 새 env (default 동작 동일)

- \`MASC_PROCESS_DEFAULT_TIMEOUT_SEC\` (default 60.0, floor 1.0)

## 설계 결정

- **Module-load read, not per-call**: \`get_float\`이 \`Env_config_runtime\`에서 module-load 시점 1회 평가하는 패턴을 거울. subprocess hot path에서 \`Sys.getenv\`가 매번 호출되지 않도록.
- **mli expose**: \`val default_timeout_sec : float\`을 .mli에 노출 — regression test가 default를 pin할 수 있게. \`default_buffer_size\`(internal)와는 다른 결정. timeout default는 운영자가 신경 쓸 값.
- **Floor 1.0**: 1초 미만은 어떤 subprocess startup도 capture 못 함. 운영자 mistype 가드.

## Test plan

- [x] \`dune build --root . @check\` green
- [x] \`dune build --root . lib/\` green
- [x] \`dune exec test_process_eio_default_timeout.exe\` 2/2 pass

## 영향 범위 검증

11 호출 사이트 모두 default 값 변경 없음 (60.0 → 60.0). 명시적으로 \`~timeout_sec:N\`을 전달하는 caller는 영향 없음 — 그게 대부분의 caller.

\`\`\`bash
$ rg -n 'Process_eio\.run_(argv|argv_with)' lib/ --type ml | wc -l
35  # callers; 대부분 ~timeout_sec:N 명시
\`\`\`

명시적 caller 예시 (영향 없음):
- \`exec_dispatch.ml:47\`: \`~timeout_sec:120.0\`
- \`server_routes_http_routes_sidecar.ml:780\`: \`~timeout_sec:5.0\`
- \`tool_code.ml:348\`: \`~timeout_sec:30.0\`

default(60.0)에 의존하던 사이트:
- \`tool_inline_dispatch_types.ml:38\`: \`Process_eio.run_argv_with_status ~timeout_sec:60.0 args\` (명시)
- \`operator/operator_control.ml:107\`: \`Process_eio.run_argv_with_status\` (default 의존)

후자만 env override의 영향을 받음.

Refs #10426