### PR TITLE
i18n(dashboard): localize fleet-fsm-matrix 5 lane labels (round-62)

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -60,12 +60,12 @@ export const FLEET_HISTORY_LEN = 30
 // cascade's tool calls (failure streak counter), so it is temporally
 // downstream of the other five for any given turn.
 const AXES: Array<{ key: LaneKey; label: string; acronym: string }> = [
-  { key: 'phase',      label: 'Lifecycle',   acronym: 'KSM' },
-  { key: 'turn',       label: 'Turn',        acronym: 'KTC' },
-  { key: 'decision',   label: 'Decision',    acronym: 'KDP' },
-  { key: 'cascade',    label: 'Cascade',     acronym: 'KCL' },
-  { key: 'compaction', label: 'Compaction',  acronym: 'KMC' },
-  { key: 'breaker',    label: 'Breaker',     acronym: 'KCB' },
+  { key: 'phase',      label: '생명주기',   acronym: 'KSM' },
+  { key: 'turn',       label: '턴',        acronym: 'KTC' },
+  { key: 'decision',   label: '결정',      acronym: 'KDP' },
+  { key: 'cascade',    label: 'Cascade',   acronym: 'KCL' },
+  { key: 'compaction', label: '압축',      acronym: 'KMC' },
+  { key: 'breaker',    label: '차단기',    acronym: 'KCB' },
 ]
 
 const INVARIANT_KEYS = Object.keys(INVARIANT_LABELS) as Array<


### PR DESCRIPTION
## 변경 사항

\`fleet-fsm-matrix.ts:62-69\` AXES 6 lane 중 5 개 한국어화:

| Acronym | Before | After |
|---|---|---|
| KSM | \`Lifecycle\` | \`생명주기\` |
| KTC | \`Turn\` | \`턴\` |
| KDP | \`Decision\` | \`결정\` |
| KCL | \`Cascade\` | \`Cascade\` (preserve) |
| KMC | \`Compaction\` | \`압축\` |
| KCB | \`Breaker\` | \`차단기\` |

## Domain term 보존

- **Cascade** — 보존 (도메인 ledger).
- **KSM/KTC/KDP/KCL/KMC/KCB** acronym 필드 변경 없음.

## 영향 범위

1 file, 6 lines (5 changed labels + Cascade unchanged). Source-only.

## Test 점검

\`fsm-hub-invariant-analysis.test.ts\` 의 fixtures (line 334 \`label: 'Turn'\`) 는 source AXES 와 무관 — fixture 자체 데이터로 \`deriveOperationalInsight\` 동작만 검증하며 label 값에 의존하는 assertion 없음. 

\`expect(insight.headline).toContain('Compaction')\` (line 179) 도 \`fsm-hub-invariant-analysis.ts\` 의 headline 문자열 ↔ 이 file의 source 와 별개. AXES 변경은 안전.

## 자기 점검

- 변경 파일: fleet-fsm-matrix.ts
- 검증: \`rg\` 로 race PR 부재 확인. Test fixture 와 독립.
- vitest infra blocker (#10645) 진행 중 — local lint/test 미수행

🤖 Generated with [Claude Code](https://claude.com/claude-code)