### PR TITLE
refactor(design-system): add Checkbox onClick prop + swap memory post-selection (PR-CS64)

### DIFF
--- a/dashboard/src/components/common/checkbox.test.ts
+++ b/dashboard/src/components/common/checkbox.test.ts
@@ -99,6 +99,35 @@ describe('Checkbox', () => {
     expect(spy.mock.calls[0]![0]).toBe(false)
   })
 
+  it('onClick fires with the raw Event (for stopPropagation in clickable parents)', async () => {
+    // The motivating case: a checkbox inside a row whose row-onClick
+    // navigates somewhere. Without onClick + stopPropagation, toggling
+    // the checkbox would also navigate. This test verifies the prop
+    // forwards and the event reaches the handler with target intact.
+    const spy = vi.fn((e: Event) => { e.stopPropagation() })
+    render(html`<${Checkbox} onClick=${spy} />`, container)
+    const cb = container.querySelector('input') as HTMLInputElement
+    const ev = new MouseEvent('click', { bubbles: true, cancelable: true })
+    cb.dispatchEvent(ev)
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+    const passed = spy.mock.calls[0]![0] as Event
+    expect(passed.target).toBe(cb)
+  })
+
+  it('onClick does not block onChange — both fire independently', async () => {
+    // Regression guard: forwarding onClick must not steal the change event.
+    const onClickSpy = vi.fn()
+    const onChangeSpy = vi.fn()
+    render(html`<${Checkbox} onClick=${onClickSpy} onChange=${onChangeSpy} />`, container)
+    const cb = container.querySelector('input') as HTMLInputElement
+    cb.checked = true
+    cb.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(onChangeSpy).toHaveBeenCalledOnce()
+    expect(onChangeSpy.mock.calls[0]![0]).toBe(true)
+  })
+
   it('extra `class` prop is appended to the base class string', () => {
     render(html`<${Checkbox} class="extra-hook" />`, container)
     expect(container.querySelector('input')!.className).toContain('extra-hook')

--- a/dashboard/src/components/common/checkbox.ts
+++ b/dashboard/src/components/common/checkbox.ts
@@ -36,6 +36,12 @@ interface CheckboxProps {
       checkbox without coupling to DOM position. */
   testId?: string
   onChange?: (checked: boolean) => void
+  /** Click handler that receives the raw Event. Use this when the
+      checkbox sits inside a clickable parent (a row or a card) and
+      you need `event.stopPropagation()` to prevent the parent's
+      click from also firing. `onChange` runs alongside it for state
+      updates; `onClick` is purely for event-flow control. */
+  onClick?: (e: Event) => void
 }
 
 export function Checkbox({
@@ -49,6 +55,7 @@ export function Checkbox({
   value,
   testId,
   onChange,
+  onClick,
 }: CheckboxProps) {
   const handleChange = (e: Event) => { onChange?.((e.target as HTMLInputElement).checked) }
   return html`
@@ -64,6 +71,7 @@ export function Checkbox({
       aria-labelledby=${ariaLabelledby}
       data-testid=${testId}
       onChange=${handleChange}
+      onClick=${onClick}
     />
   `
 }

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -7,6 +7,7 @@ import { requestConfirm } from './common/confirm-dialog'
 import { EmptyState } from './common/empty-state'
 import { LoadingState } from './common/feedback-state'
 import { TextInput } from './common/input'
+import { Checkbox } from './common/checkbox'
 import { RichComposer } from './common/rich-composer'
 import { RichContent } from './common/rich-content'
 import { stripStateBlocks } from '../keeper-message'
@@ -401,9 +402,9 @@ function PostCard({ post }: { post: BoardPost }) {
     >
       <!-- Select checkbox -->
       <div class="flex items-start pt-1">
-        <input type="checkbox"
-          aria-label=${`게시글 선택: ${post.id}`}
-          class="w-3.5 h-3.5 rounded cursor-pointer accent-[var(--color-accent-fg)]"
+        <${Checkbox}
+          ariaLabel=${`게시글 선택: ${post.id}`}
+          class="!w-3.5 !h-3.5"
           checked=${selectedPostIds.value.has(post.id)}
           onClick=${(e: Event) => togglePostSelection(post.id, e)}
         />


### PR DESCRIPTION
## Summary

CS series sweep. **Combined canonical extension + first consumer in one PR** (CS59 패턴 재사용).

**배경**: memory.ts post-selection checkbox는 row의 `onClick(navigateToPost)`을 `event.stopPropagation()`으로 막아야 함. 기존 Checkbox component은 `onChange(checked: boolean)`만 노출 — event 접근 불가. 첫 consumer migration이 이 한계 때문에 막혀 있었음.

## 변경

### 1. `dashboard/src/components/common/checkbox.ts` — Checkbox에 `onClick` 추가
- `onClick?: (e: Event) => void` prop 추가
- 함수 destructure + JSX `onClick=${onClick}` forwarding
- 주석으로 사용 의도 명시 (clickable parent에서 event-flow control 용도)
- `onChange(checked: boolean)`은 그대로 — `onClick`은 event control 전용, `onChange`는 state shortcut. 두 개 독립 fire.

### 2. `dashboard/src/components/common/checkbox.test.ts`
- `onClick fires with the raw Event (for stopPropagation in clickable parents)` 추가
- `onClick does not block onChange — both fire independently` 회귀 가드 추가
- 15 tests pass (이전 13 + 2)

### 3. `dashboard/src/components/memory.ts:404` — post-selection swap
- `<input type=\"checkbox\">` (게시글 selection) → `<${Checkbox}>`
- `togglePostSelection(post.id, e)` callback이 그대로 동작 — event.stopPropagation 보존되어 row navigateToPost 차단 정상
- 제거된 inline class (CHECKBOX_BASE 상속):
  - `cursor-pointer`
  - `accent-[var(--color-accent-fg)]`
  - `rounded`
- 유지된 override:
  - `!w-3.5 !h-3.5` (CHECKBOX_BASE의 `w-4 h-4` 대비 compact, post row 시각 보존)
- 시각 회복: hover bg/border, focus-visible ring + offset (이전엔 browser default)

## Why this matters

이전에는 memory.ts:404의 checkbox가 raw `<input>`로 남아 있었음. CS64로:
1. 다른 "row 안 checkbox" use case (selection checkbox 패턴) 모두 unblock
2. memory.ts post selection이 design-system 표준에 합류

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/common/checkbox`: 15/15 pass (2 신규 포함)
- `pnpm test src/components/memory`: 71/71 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)