### PR TITLE
i18n(dashboard): localize activity-stream filter labels (round-63)

### DIFF
--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -14,10 +14,10 @@ import { EmptyState, ErrorState } from '../common/feedback-state'
 import { formatTimeAgo } from '../common/time-ago'
 
 const FILTER_OPTIONS: { kind: LiveFilterKind; label: string; cssClass: string }[] = [
-  { kind: 'broadcast', label: 'Broadcast', cssClass: 'live-event-broadcast' },
-  { kind: 'tasks', label: 'Task', cssClass: 'live-event-task' },
+  { kind: 'broadcast', label: '브로드캐스트', cssClass: 'live-event-broadcast' },
+  { kind: 'tasks', label: '작업', cssClass: 'live-event-task' },
   { kind: 'keepers', label: 'Keeper', cssClass: 'live-event-keeper' },
-  { kind: 'system', label: 'System', cssClass: 'live-event-system' },
+  { kind: 'system', label: '시스템', cssClass: 'live-event-system' },
 ]
 
 function FilterBar() {


### PR DESCRIPTION
## 변경 사항

`activity-stream.ts:16-21` FILTER_OPTIONS 4 labels 중 3 개:
- `'Broadcast'` → `'브로드캐스트'`
- `'Task'` → `'작업'`
- `'Keeper'` → `'Keeper'` (preserve)
- `'System'` → `'시스템'`

## Domain term 보존
- **Keeper** — 보존
- `cssClass` 값 (live-event-broadcast/task/keeper/system) 변경 없음

## Test 점검
`workflow-context.test.ts` 의 `title: 'Task'` fixtures 는 JSON test 데이터 의 title 필드로, FILTER_OPTIONS 와 무관. coupling 없음.

## 영향 범위
1 file, 5 lines (4 labels + comment unchanged). Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)