### PR TITLE
perf(dashboard/fsm-hub): drop 1 Hz tick to 5 s for re-render reduction

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -410,7 +410,12 @@ export function FsmHub(props: FsmHubProps = {}) {
 
   useEffect(() => {
     if (paused) return undefined
-    const id = setInterval(() => setNow(Date.now() / 1000), 1_000)
+    // 5s tick: full FSM hub re-renders + deriveLaneDwellHistograms recomputes
+    // each interval. Operator-visible elapsed strings (`fmtDuration`) read
+    // sub-minute precision; 5s granularity is below visual perception
+    // threshold for the dwell/transition surfaces and divides per-second
+    // re-render cost by 5x for a 1012-line component with 9 child renders.
+    const id = setInterval(() => setNow(Date.now() / 1000), 5_000)
     return () => clearInterval(id)
   }, [paused])
 


### PR DESCRIPTION
## Why

Cycle 1 of an iterative dashboard performance pass.  Profiling spotlight: `dashboard/src/components/fsm-hub.ts` (1012 LOC, 12 useEffect, 9 child renders) re-rendered itself **once per second** because of:

```ts
const id = setInterval(() => setNow(Date.now() / 1000), 1_000)
```

This `now` value is consumed by:

- `useMemo(() => deriveLaneDwellHistograms(view.observations, now), [view.observations, now])` — **per-second O(N log N) recompute** over the observation buffer (segments → dwell map → sort)
- 9 child components that receive `now` as a prop (`HeroPhase`, `TurnPipelineStrip`, `TransitionTrail`, dwell strips …) — every tick triggers a render in all of them

For a 1012-line component plus 9 children, a 1 Hz tick is the dominant render cost on the FSM hub view.

## What

Single-line change: tick interval `1_000 → 5_000`.

Comment block documents the reasoning so a future contributor doesn't restore 1 Hz without understanding the tradeoff.

## Tradeoff

Operator-visible elapsed strings (`fmtDuration(now - x)`) on the FSM hub now refresh every 5 s instead of 1 s.  Below visual perception threshold for the dwell/transition surfaces (which already represent multi-second to multi-minute durations).  The compositeTick (`compositeTick.value` at line 417) is independent of `now` and continues to fire on event-driven updates, so anything tied to actual FSM transitions remains real-time.

## Expected effect

- **5x reduction** in fsm-hub.ts render count while the view is open and not paused
- **5x reduction** in `deriveLaneDwellHistograms` invocations (the expensive recompute)
- **5x reduction** in render cost across 9 child components that depend on `now`

No measurement is included in this PR (cycle 1 is the change; cycle 2 will measure with browser DevTools profile against a known scenario).

## Out of scope

The deeper structural fix is hoisting `now` to a shared signal so individual children subscribe directly and the hub itself doesn't re-render — that's a multi-file change with prop→signal conversions across 9 children.  Deferred to a later cycle once this single-line change is validated.

Two other 1 Hz tickers exist in the codebase:

| Site | Pattern | Notes |
|------|---------|-------|
| `dashboard/src/components/connector-overview-strip.ts:37` | `livePulseNowMs.value = Date.now()` | Already signal-based; not a useState re-render storm |
| `dashboard/src/components/chat/primitives.ts:373` | `setInterval(tick, 1000)` | Different scope; will profile separately if needed |

## Verification

- Typecheck: green (`pnpm run typecheck`).
- Tests: `dashboard/src/components/fsm-hub.test.ts` — 57 pass, 2 pre-existing failures (`flagTooltip` localization, unrelated to this change; identical failures on `origin/main` HEAD).

## Test plan

- [x] Typecheck passes
- [x] No new test failures (pre-existing `flagTooltip` failures verified identical on main)
- [ ] Operator opens FSM hub for 60 s on a busy keeper and confirms reduced jank (manual)
