### PR TITLE
fix(boot): start Oas_worker_cascade actor consumer fiber

### DIFF
--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -535,6 +535,14 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
      get_sessions) hangs forever — the mailbox has no consumer.
      Missed when #10664 introduced the actor model. *)
   Session.start_loop registry ~sw;
+  (* Same sweep miss as Session.start_loop above: PR #10730 introduced
+     [Oas_worker_cascade] as an Eio actor (mailbox + Promise.await) but
+     never wired its [start_actor_if_needed] into a bootstrap path.
+     [cascade_metrics_json ()] (called from [tool_unified.ml:summary_report],
+     which the dashboard tool inspector hits) does
+     [Stream.add Get_metrics_json u; Promise.await p]. Without an actor
+     fiber draining [stream], the await blocks forever. *)
+  Oas_worker_cascade.start_actor_if_needed ~sw;
   (* Wire notification harness: subscription events → session queues *)
   Subscriptions.set_session_push_fn (fun event ->
     Session.push_notification_to_active_agents registry ~event


### PR DESCRIPTION
## Summary

3rd Jane Street refactor sweep miss in the same wave as #10664/#10730. \`Oas_worker_cascade.start_actor_if_needed\` is defined but never called from anywhere — \`cascade_metrics_json ()\` does \`Stream.add + Promise.await\` against a stream with no consumer, blocking the request fiber forever.

\`\`\`bash
$ rg -n "start_actor" lib/ bin/
lib/oas_worker_cascade.ml:let start_actor_if_needed ~sw =
\`\`\`

Zero callers, same as Session.start_loop pre-#10777.

## User-facing context

User reported "플릿 텔레메트리 잘 안잡히는 버그" (fleet telemetry not capturing well). Audit of \`/api/v1/dashboard/telemetry/summary\` shows 9 sources tracked, all healthy except 2 SLO/missing flags that turn out to be expected behavior (low-volume admin tool surface, no goal verifications yet). The actual silent bug is this cascade actor hang — \`tool_unified.summary_report\` (dashboard tool inspector) hangs whenever it reaches \`Oas_worker.cascade_metrics_json ()\`. Latent until that surface is hit.

## Fix

\`lib/mcp_server.ml:create_state_eio\` already starts \`Session.start_loop registry ~sw\` (added in #10777 for the symmetric Session bug). Add \`Oas_worker_cascade.start_actor_if_needed ~sw\` right after — same place, same shape.

\`\`\`ocaml
Session.start_loop registry ~sw;
(* Same sweep miss... *)
Oas_worker_cascade.start_actor_if_needed ~sw;
\`\`\`

## Verification

\`\`\`bash
DUNE_BUILD_DIR=_build_diag scripts/dune-local.sh build @check --cache=disabled
# exit 0
\`\`\`

Runtime verification: post-merge restart + dashboard tool inspector should respond instead of hanging.

## Risk

- Adds 1 background fiber per server boot. Low overhead.
- Pre-fix calls to \`cascade_metrics_json\` were hung fibers — those go away. Any consumer waiting on those will resume (could surface as bursty initial responses, but acceptable).
- Same fix pattern as #10777 already in production — risk profile equivalent.

## Out of scope (separate audit)

- \`tool_usage stale (latest_age_s 997 > SLO 900)\` — system_internal admin tools have low volume; SLO too aggressive for sparse sources. Not a write bug.
- \`goal_event missing (file doesn't exist)\` — \`goal_fsm\` only writes on goal verification; user hasn't verified goals → expected.
- Memory: \`feedback_jane-street-refactor-sweep-miss\` already captures this anti-pattern. This PR is the 3rd instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)