### PR TITLE
refactor(design-system): swap kanban task delete button to ActionButton danger (PR-CS65)

### DIFF
--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -108,14 +108,16 @@ function KanbanCard({ task }: { task: Task }) {
           <span class="rounded border border-current/20 px-2 py-0.5 text-2xs font-semibold">${priorityLabel(p)}</span>
           ${scope ? html`<span class="rounded border border-card-border/70 bg-white/5 px-2 py-0.5 text-2xs font-medium text-text-body">${scope}</span>` : null}
         </div>
-        <button
-          type="button"
-          class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-2 py-1 text-3xs font-semibold text-[var(--bad-light)] transition-colors hover:bg-[rgba(239,68,68,0.16)] disabled:opacity-50 disabled:cursor-not-allowed"
+        <${ActionButton}
+          variant="danger"
+          size="sm"
           onClick=${handleDelete}
           disabled=${isDeleting}
+          ariaBusy=${isDeleting}
+          ariaLabel=${`태스크 삭제: ${task.title}`}
         >
           ${isDeleting ? '삭제 중...' : '삭제'}
-        </button>
+        <//>
       </div>
 
       <button


### PR DESCRIPTION
## Summary

CS series sweep. goals/kanban-components 태스크 카드의 raw `<button>` 삭제 버튼을 ActionButton `danger` variant + `size=\"sm\"`로 swap.

**첫 raw button → ActionButton 마이그레이션** (이전 CS PR들은 input/textarea/checkbox/select 위주).

## 변경

`dashboard/src/components/goals/kanban-components.ts:111`:
- `<button>` → `<${ActionButton} variant=\"danger\" size=\"sm\">`
- 제거된 inline class (ActionButton danger + size sm 상속):
  - `border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad-light)]` (변환 동치)
  - `hover:bg-[rgba(239,68,68,0.16)]` → ActionButton의 `hover:bg-[var(--bad-20)]` (token resolve 시 시각 동치)
  - `rounded`, `px-2 py-1 text-3xs`, `transition-colors`, `disabled:opacity-50` (BASE/size 상속)
  - `font-semibold` → ActionButton의 `font-medium` (미세 font-weight 차이)
- 추가:
  - `ariaBusy=${isDeleting}` (a11y: async 작업 중 screen reader 알림)
  - `ariaLabel=\"태스크 삭제: ${task.title}\"` (a11y: 다수 카드 disambiguation — 이전엔 generic \"삭제\")

## Out of scope

`kanban-components`의 다른 raw `<button>` 4건은 SKIP:
- 제목 link button (line 121): `bg-transparent border-none p-0` link-style — ActionButton variant 미일치
- 설명 expand toggle (line 133): `border-card-border/70 bg-white/4 text-text-muted` — production palette
- 검색 초기화 (line 289): `border-card-border/70 bg-white/4 text-text-muted` — production palette
- (line 341): production palette

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/goals`: 100/100 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)