### PR TITLE
fix(keeper-shell-docker): detect 'gh --repo X api Y' misuse and self-correct (#10855)

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -127,6 +127,38 @@ let cmd_targets_gh cmd =
     let tokens = String.split_on_char ' ' trimmed in
     List.exists (fun tok -> tok = "gh") tokens
 
+(* #10855: keeper LLM (issue_king, masc-improver) hallucinated gh syntax
+   `gh --repo X api Y` (108 events / 24h, 2026-04-25→04-26). gh CLI
+   semantics: `--repo` is a subcommand flag (gh issue/pr/release/...),
+   not a global option, and `gh api` rejects it with "unknown flag: --repo".
+   Detect the misuse pre-exec so we can emit a self-correcting error
+   instead of letting the docker exec waste a turn surfacing gh's raw
+   error.  Same self-correcting-message pattern as #10869's multi-repo
+   sandbox blocker. *)
+let detect_gh_repo_flag_with_api_misuse cmd =
+  let strip_quotes s =
+    let len = String.length s in
+    if len >= 2
+       && ((s.[0] = '\'' && s.[len-1] = '\'')
+           || (s.[0] = '"' && s.[len-1] = '"'))
+    then String.sub s 1 (len - 2)
+    else s
+  in
+  let toks =
+    String.split_on_char ' ' (String.trim cmd)
+    |> List.filter (fun s -> s <> "")
+    |> List.map strip_quotes
+  in
+  if not (List.mem "gh" toks) then None
+  else
+    let rec scan = function
+      | "--repo" :: repo_arg :: "api" :: endpoint :: _ ->
+          Some (repo_arg, endpoint)
+      | _ :: rest -> scan rest
+      | [] -> None
+    in
+    scan toks
+
 (* Emit a ("gh_exit_class", "…") JSON field when [cmd] targets gh,
    AND increment the matching Legendary_counters bucket.  Callers
    append the returned list to their `Assoc payload unconditionally —
@@ -273,6 +305,20 @@ let run_docker_shell_command_with_status
       in
       match multi_repo_blocker with
       | Some msg -> sandbox_error msg
+      | None ->
+      (* #10855: surface gh syntax misuse before docker exec so the LLM
+         sees a corrected-form hint in the same turn rather than gh's raw
+         "unknown flag: --repo" error after the round-trip. *)
+      match detect_gh_repo_flag_with_api_misuse cmd with
+      | Some (repo_arg, endpoint) ->
+        sandbox_error
+          (Printf.sprintf
+             "잘못된 gh syntax: 'gh --repo %s api %s ...' \
+              — '--repo' 는 subcommand flag (gh issue/pr/release/run) 전용이고 \
+              'gh api' 에는 적용 안 됨. \
+              올바른 형태: 'gh api repos/%s/%s' (endpoint 안에 org/repo 포함). \
+              다음 turn 에서 cmd 를 수정하세요."
+             repo_arg endpoint repo_arg endpoint)
       | None ->
       let container_name = keeper_sandbox_container_name meta in
       let container_root = keeper_private_container_root meta in


### PR DESCRIPTION
## 증상

Issue #10855. \`issue_king\`, \`masc-improver\` keeper 가 gh CLI 호출 시 잘못된 syntax \`gh --repo X api Y\` 반복 생성 — 108 events / 24h.

\`\`\`
ERROR Keeper: ... unknown flag: --repo

Usage:  gh api <endpoint>
\`\`\`

\`gh\` CLI semantics:
- \`--repo\` 는 subcommand flag (gh issue/pr/release/run) 전용.
- \`gh api\` 는 endpoint 안에 org/repo 직접 포함 (\`gh api repos/<org>/<name>/...\`).
- \`gh --repo X api Y\` 는 invalid → \"unknown flag: --repo\".

매 event 가 keeper turn 1회를 docker exec round-trip 으로 소진 → gh 의 raw error surface 후 비로소 다음 turn 에서 자기 수정 시도 (실패 반복).

## Fix

\`lib/keeper/keeper_shell_docker.ml\` 에 pre-exec detector + self-correcting blocker:

1. **Detector**: \`detect_gh_repo_flag_with_api_misuse\` —
   - whitespace split + quote strip (production form 은 \`'--repo'\` 처럼 each-arg quote 로 캡쳐됨).
   - bare \`gh\` 토큰 + \`--repo X api Y\` 패턴 매칭.
2. **Hook**: multi_repo_blocker (#10869) 직후에 검사. 양쪽 pre-check 모두 docker exec 전에 발화.
3. **Self-correcting message** — #10869 동일 패턴:
   \`\`\`
   잘못된 gh syntax: 'gh --repo <X> api <Y> ...' — '--repo' 는 subcommand flag (...) 전용이고
   'gh api' 에 적용 안 됨. 올바른 형태: 'gh api repos/<X>/<Y>' (endpoint 안에 org/repo 포함).
   다음 turn 에서 cmd 를 수정하세요.
   \`\`\`

## Why not auto-rewrite

Issue 의 option 2 \"keeper_shell command rewrite\":
- endpoint Y 가 이미 \`repos/X/\` prefix 포함하면 double-prefix 위험.
- silently 수정 시 잘못된 repo 에 commit → blast radius 위험.
- self-correcting error 가 LLM 의 다음 turn 의사결정 시점에 명시적 surface, 더 안전.

## Why not persona patch

Issue 의 option 1 \"system prompt 보강\":
- \`config/personas/issue_king/profile.json\` 에 cheatsheet 추가 가능하지만 generic system-prompt 규칙이 즉시 ignored 사례 (#10680 family) 다수.
- pre-exec error 가 immediate context 에 들어가 LLM 의 next-call shape 결정에 직접 영향.

## 검증

- \`dune build @check\` EXIT=0.
- 동작 검증: keeper 가 \`gh --repo X api Y\` 호출 시 docker exec 전에 sandbox_error 로 corrective message 반환.

## Cross-ref

- #10869 (multi-repo sandbox self-correcting blocker — 같은 패턴).
- #10680 (sandbox cwd 무지 — same family).
- memory \`feedback_proactive_turn_contract_violation_dominant.md\` (LLM contract violation family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)