### PR TITLE
refactor(design-system): swap keeper-detail clear-context cancel + history refresh buttons to ActionButton ghost (PR-CS66)

### DIFF
--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
+import { ActionButton } from './common/button'
 import { requestConfirm } from './common/confirm-dialog'
 import {
   deleteKeeperHistorySnapshots,
@@ -200,11 +201,11 @@ export function KeeperCheckpointPanel({
             : null}
         </div>
         <div class="flex items-center gap-2">
-          <button
-            type="button"
-            class="rounded border border-[var(--color-border-default)] bg-[var(--white-4)] px-3 py-1.5 text-2xs font-semibold text-[var(--color-fg-primary)] hover:bg-[var(--white-8)] cursor-pointer"
+          <${ActionButton}
+            variant="ghost"
+            size="md"
             onClick=${loadInventory}
-          >새로고침</button>
+          >새로고침<//>
           <button
             type="button"
             class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-1.5 text-2xs font-semibold text-[var(--rose-light)] hover:bg-[var(--bad-soft)] cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -12,6 +12,7 @@ import {
 } from '../lib/keeper-runtime-display'
 import { signal } from '@preact/signals'
 import { useEffect, useRef, useState } from 'preact/hooks'
+import { ActionButton } from './common/button'
 import { requestConfirm } from './common/confirm-dialog'
 import { isRecord } from './common/normalize'
 import { currentDashboardActor, runOperatorAction } from '../api'
@@ -546,12 +547,12 @@ function KeeperClearContextDialog({
         </div>
 
         <div class="flex items-center justify-end gap-2">
-          <button
-            type="button"
-            class="px-4 py-2 rounded text-sm font-medium border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)] hover:bg-[var(--white-8)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+          <${ActionButton}
+            variant="ghost"
+            size="lg"
             disabled=${pending}
             onClick=${onClose}
-          >취소</button>
+          >취소<//>
           <button
             type="button"
             class="px-4 py-2 rounded text-sm font-medium border border-transparent bg-[var(--color-status-err)] text-white hover:bg-[rgba(239,68,68,0.88)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"


### PR DESCRIPTION
## Summary

CS series sweep. dialog cancel + tool refresh raw `<button>` 2건을 ActionButton `ghost` variant로 swap. CS65에 이은 raw button → ActionButton 마이그레이션 (이번엔 ghost 변형 2건).

## 변경

### 1. `dashboard/src/components/keeper-detail.ts:551` — Clear-context dialog 취소
- `<button>` → `<${ActionButton} variant=\"ghost\" size=\"lg\">`
- ActionButton ghost 색조합과 inline class **exact match**:
  - `border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)] hover:bg-[var(--white-8)]`
- `px-4 py-2 text-sm font-medium` → ActionButton size lg `py-2 px-4 text-sm`
- `font-semibold` → ActionButton의 `font-medium` (미세 차이)

### 2. `dashboard/src/components/keeper-detail-history.ts:205` — Inventory 새로고침
- `<button>` → `<${ActionButton} variant=\"ghost\" size=\"md\">`
- 같은 ghost 색조합
- `px-3 py-1.5 text-2xs font-semibold` → ActionButton size md `py-1.5 px-2.5 text-2xs` (px 1px 차이, 시각 동치)

## 시각 변화

ActionButton BASE의 `focus-visible:ring-2 focus-visible:ring-[var(--accent-45)]` + `active:scale-[0.97]` 인터랙션 추가됨. 이전 raw button에는 없던 keyboard 사용자용 a11y feedback.

## Out of scope

같은 keeper-detail-history 파일의 선택 삭제 버튼은 `text-[var(--rose-light)]` (rose-400, #fb7185)을 사용 — ActionButton `danger` variant의 `text-[var(--bad-light)]` (red-400, #f87171)과 다른 token. 향후 token 통합 PR로 처리.

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/keeper-detail`: 105/105 pass (clear-context dialog cancel + history inventory 테스트 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)