### PR TITLE
fix(dashboard): update test expectations for i18n-localized flagTooltip

### DIFF
--- a/dashboard/src/components/fsm-hub-health-panels.test.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.test.ts
@@ -33,7 +33,7 @@ describe('flagTooltip', () => {
     const result = flagTooltip('handoff', true)
     expect(result).toContain('handoff')
     expect(result).toContain('active')
-    expect(result).toContain('trace/generation')
+    expect(result).toContain('이관')
   })
 
   it('returns guardrail active tooltip', () => {

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -538,14 +538,14 @@ describe('flagTooltip', () => {
   it('returns the off-description when the flag is inactive', () => {
     const tip = flagTooltip('reflect', false)
     expect(tip).toContain('reflect (inactive)')
-    expect(tip).toMatch(/예약된 reflection 없음/)
+    expect(tip).toContain('예약된 reflection 없음')
   })
 
   it('swaps description for guardrail based on state', () => {
     const on = flagTooltip('guardrail', true)
     const off = flagTooltip('guardrail', false)
-    expect(on).toMatch(/발동됨/)
-    expect(off).toMatch(/활성 guardrail 없음/)
+    expect(on).toContain('발동됨')
+    expect(off).toContain('활성 guardrail 없음')
   })
 
   it('falls back to a generic tooltip for unknown labels', () => {


### PR DESCRIPTION
## Summary
- Update 12 test assertions in 3 test files to match Korean i18n text in `MEASUREMENT_FLAG_DESCRIPTIONS`
- Pre-existing failures: `flagTooltip` descriptions were migrated to Korean but test expectations still checked English strings
- Fixes: `fsm-hub-health-panels.test.ts` (9 failures), `fsm-hub.test.ts` (2 failures), `fleet-telemetry-utils.test.ts` (1 failure)

## Why
These 12 pre-existing Dashboard failures block CI Gate for ALL PRs that trigger Dashboard tests. Fixing them unblocks the entire merge queue.

## Test plan
- [x] Local assertion text matches `MEASUREMENT_FLAG_DESCRIPTIONS` values in `fsm-hub-health-panels.ts`
- [ ] CI Dashboard job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)