### PR TITLE
feat(lint): detect Eio actor consumer fibers that are never wired up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,7 @@ jobs:
           bash scripts/audit-hardcoding-truth.sh --fail-on-confirmed
           bash scripts/ci/check-credential-audits.sh
           bash scripts/ci/check-accept-fd-lifecycle.sh
+          bash scripts/ci/check-actor-consumer-wired.sh
 
   health:
     name: Health

--- a/scripts/ci/check-actor-consumer-wired.sh
+++ b/scripts/ci/check-actor-consumer-wired.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# CI gate: every Eio actor consumer fiber must be wired up at boot.
+#
+# Background
+#   Jane Street refactor wave (#10664 Session, #10730 Tool_registry +
+#   Oas_worker_cascade) introduced multiple actor-pattern modules.
+#   Each defines a consumer fiber starter — typically named
+#   [start_loop] or [start_actor_if_needed] — but several were
+#   defined and never called from a bootstrap path.
+#
+#   Without the consumer running, every helper that does
+#   [Eio.Stream.add msg; Eio.Promise.await reply] blocks forever.
+#   Visible production fires:
+#     - #10777: Session.start_loop never called → restore_sessions
+#       hung the entire keeper autoboot for ~3 minutes per restart
+#       cycle until watchdog killed the server.
+#     - #10895: Oas_worker_cascade.start_actor_if_needed never
+#       called → cascade_metrics_json hangs the dashboard tool
+#       inspector silently.
+#
+# Contract
+#   For each module that defines a top-level consumer-starter (matched
+#   by name pattern: [start_loop] or [start_actor*]), there must be at
+#   least one CALLER outside the defining file itself. Self-calls
+#   (the module calling its own starter from the same .ml) are
+#   common for internal helpers and don't prove external bootstrap.
+#
+# Heuristic
+#   1. Grep [^let start_(loop|actor)] in lib/ — collect (module, fn).
+#   2. For each match, grep [Module.fn] in lib/ + bin/ EXCLUDING the
+#      defining file. If zero hits, the consumer is unwired.
+#
+# Known false positives
+#   - Internal-only helpers re-using the [start_loop]/[start_actor]
+#     name. If a module legitimately exposes a starter for tests or
+#     dependency-injection callers that live in [test/], extend the
+#     search to test/ — but a starter that is *only* called from a
+#     test is still a production-runtime hang risk in the dev server.
+#
+# Output
+#   Exit 0 — every starter has at least one external caller in lib/ + bin/.
+#   Exit 1 — at least one starter is unwired; emit (file, fn) pairs.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+failed=0
+checked=0
+
+# Find each top-level "let start_loop ..." or "let start_actor*" in lib/.
+# The grep is anchored to column 0 to skip nested helpers.
+hits=$(rg -n '^let start_(loop|actor)' lib/ 2>/dev/null || true)
+
+if [ -z "$hits" ]; then
+  echo "check-actor-consumer-wired: no actor consumer starters found"
+  exit 0
+fi
+
+while IFS= read -r hit; do
+  file=$(printf '%s\n' "$hit" | cut -d: -f1)
+  body=$(printf '%s\n' "$hit" | cut -d: -f3-)
+
+  # Extract the function name (token after "let ").
+  fn=$(printf '%s\n' "$body" | sed -E 's/^let ([a-zA-Z_0-9]+).*/\1/')
+  [ -z "$fn" ] && continue
+
+  # Module name = capitalised basename without extension.
+  base=$(basename "$file" .ml)
+  mod=$(printf '%s' "$base" | awk '{ printf "%s%s", toupper(substr($1,1,1)), substr($1,2) }')
+
+  checked=$((checked + 1))
+
+  # Search for [Mod.fn] anywhere in lib/ + bin/ EXCLUDING the defining file.
+  # A bare [fn] match would catch internal calls — we want to verify an
+  # external bootstrap path imports the module and invokes it.
+  callers=$(rg -l "${mod}\.${fn}\b" lib/ bin/ 2>/dev/null | grep -v "^${file}$" || true)
+
+  if [ -z "$callers" ]; then
+    echo "  FAIL  ${file}: ${mod}.${fn} defined but no external caller in lib/ or bin/"
+    echo "        actor consumer unwired → Promise.await on this stream will hang"
+    failed=1
+  fi
+done <<< "$hits"
+
+if [ "$failed" -ne 0 ]; then
+  echo ""
+  echo "check-actor-consumer-wired: at least one actor consumer is unwired."
+  echo "Reference: #10777 (Session.start_loop) and #10895 (Oas_worker_cascade)"
+  echo "called the missing starter from lib/mcp_server.ml:create_state_eio."
+  exit 1
+fi
+
+echo "check-actor-consumer-wired: ok (${checked} starter(s) verified)"


### PR DESCRIPTION
## Summary

CI gate that flags every top-level \`start_loop\` / \`start_actor*\` function in \`lib/\` whose module is not invoked anywhere outside the defining file. Closes the audit on the **Jane Street refactor wave sweep miss** anti-pattern that landed two production fires this week.

## Why

This week's two silent hangs:

| PR | Symptom | Root |
|----|---------|------|
| #10777 | \`restore_sessions\` blocked 5 min per restart, watchdog killed server | \`Session.start_loop\` defined, never called from boot |
| #10895 | \`cascade_metrics_json\` hangs dashboard tool inspector silently | \`Oas_worker_cascade.start_actor_if_needed\` defined, never called |

Both were trivially detectable by \`grep\` — but only after production blew up. Every actor in this codebase uses the pattern \`Stream.add msg; Promise.await reply\`, which is **silent-infinite-hang** if no consumer drains the mailbox. Build green, tests pass, runtime hangs.

## Heuristic

\`\`\`bash
# 1. Find each top-level starter
rg "^let start_(loop|actor)" lib/

# 2. Resolve module from filename (foo.ml -> Foo)

# 3. Check at least one external caller exists
rg "Mod.fn" lib/ bin/ --exclude-self
\`\`\`

\`^let\` anchored to column 0 skips nested helpers.

## Self-test

| Scenario | Result |
|----------|--------|
| Current main (post-#10777, post-#10895) | exit 0, 3 starters verified |
| Synthetic \`foo.ml\` with \`start_actor_if_needed\` + no caller | exit 1, FAIL emitted |

3 starters in main:
- \`Session.start_loop\` (called from \`mcp_server.ml:537\`)
- \`Oas_worker_cascade.start_actor_if_needed\` (called from \`mcp_server.ml:545\`)
- \`Dashboard_http_autoresearch.start_loop_json\` (called from \`server_routes_http_routes_dashboard.ml:1080\`)

## Risk / known FPs

- Generic name \`start_loop\` could match unrelated helpers. Both current matches are legitimate consumer starters; if a future contributor names a non-actor function \`start_loop\`/\`start_actor*\`, the lint will demand an external caller. Documenting via convention is acceptable cost.
- Test-only callers in \`test/\` aren't checked. A starter only invoked from tests is still a runtime-hang risk in dev-server code paths — the gate enforces "production bootstrap path must wire it".

## Wire-up

Appended to Meta Guards "bug-class gates" step alongside \`check-credential-audits.sh\` and \`check-accept-fd-lifecycle.sh\`.

## Out of scope

- Detecting \`Eio.Stream.create\` + \`Promise.await\` patterns where the starter is hand-rolled (no \`start_loop\` / \`start_actor*\` name). AST-aware future iteration.
- Cross-module actor topology (e.g., a starter that calls another starter). Heuristic only verifies presence of a caller, not the call chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)