### PR TITLE
fix(keeper-shell-docker): replace List.hd with pattern match (Health ratchet)

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -243,7 +243,7 @@ let run_docker_shell_command_with_status
           | [single_repo] ->
             (Filename.concat (Filename.concat host_root "repos") single_repo, None)
           | [] -> (cwd, None)
-          | many ->
+          | example_repo :: _ as many ->
             (* #10680: keeper-executor-agent saw 17 events / 5min in a single
                session (mcp_VHsjtow_92C_2a0o, 2026-04-26 08:00→08:06) where
                the LLM read this descriptive error and still re-issued the
@@ -255,7 +255,6 @@ let run_docker_shell_command_with_status
               let s = String.trim cmd in
               if String.length s > 120 then String.sub s 0 117 ^ "..." else s
             in
-            let example_repo = List.hd many in
             ( cwd
             , Some
                 (Printf.sprintf


### PR DESCRIPTION
## Why

PR #10869 (sandbox cwd self-correcting error, merged earlier today) introduced:

```ocaml
let example_repo = List.hd many in
```

at `lib/keeper/keeper_shell_docker.ml:258`. This bumped the Health snapshot's `lib_list_hd` count from **0 → 1**, breaking the ratchet baseline:

```
Ratchet: fail (lib_list_hd 0->1)
```

Every PR opened after #10869 fails the Health check until this is restored, regardless of what the PR itself changes. Observed on PR #10857 (and likely on others). This is a fix-forward to unblock the queue.

## What

Replace `let example_repo = List.hd many` with a pattern match in the surrounding `match` arm:

```ocaml
| example_repo :: _ as many ->
```

The `as many` binding keeps the rest of the function unchanged. Total function instead of partial — same runtime behavior (the `[]` case is already separated above), and the ratchet returns to 0.

## Risk

None. The `[]` case already exits earlier in the same `match`, so the head is non-empty by exhaustiveness — `List.hd` was technically safe but the ratchet (and the `software-development.md` "Total functions over partial functions" rule) flag the unsafe API.

## Verification

- [x] `DUNE_CACHE=disabled dune build @check` clean
- Health snapshot should report `lib_list_hd 0->0` after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
