### PR TITLE
i18n(dashboard): localize 2 readiness rail labels (round-64)

### DIFF
--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -259,7 +259,7 @@ export function deriveRail(
     {
       key: 'process',
       state: processState,
-      label: 'Process',
+      label: '프로세스',
       detail: processDetail,
       hint: processState === 'bad' ? '클릭하면 sidecar Start' : '클릭하면 sidecar Stop',
       onClick: on.toggleProcess,
@@ -277,7 +277,7 @@ export function deriveRail(
     {
       key: 'bindings',
       state: bindingsState,
-      label: 'Bindings',
+      label: '바인딩',
       detail: bindingsDetail,
       hint: bindingsState !== 'ok' ? 'keeper 디렉토리로 스크롤' : null,
       onClick: on.scrollToBindings,


### PR DESCRIPTION
## 변경 사항

`connector-readiness-rail.ts:262, 280`:
- `'Process'` → `'프로세스'`
- `'Bindings'` → `'바인딩'`

## Domain term 보존
- **Gate** (line 271) — Gate sidecar identifier 도메인 보존
- **Token** (line 253) — fixture + 3 equality assertion 4점 test coupling, 별도 round 에서 sync 필요

## 영향 범위
1 file, 2 lines. Source-only. Test 커플링 없음 (Process / Bindings 둘 다).

## 자기 점검
- 변경 파일: connector-readiness-rail.ts
- 검증: `rg` 로 source 외부에서 'Process' / 'Bindings' literal 사용 없음 확인
- vitest infra blocker (#10645) 진행 중

🤖 Generated with [Claude Code](https://claude.com/claude-code)