### PR TITLE
perf(dashboard): hide sourceMappingURL to stop browser map auto-fetch

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -14,7 +14,12 @@ export default defineConfig(({ command }) => {
     build: {
       outDir: '../assets/dashboard',
       emptyOutDir: true,
-      sourcemap: true,
+      // 'hidden' produces .map files but omits the sourceMappingURL
+      // comment from JS, so browsers don't auto-fetch maps. Maps stay
+      // available for manual attach via DevTools "Add source map" or
+      // out-of-band tooling. Cuts the deployment artifact (Docker image
+      // copy step) from ~30 MB to ~7.3 MB without losing debug coverage.
+      sourcemap: 'hidden',
       rollupOptions: {
         output: {
           manualChunks: {


### PR DESCRIPTION
## Why

Cycle 4 of the iterative dashboard performance pass.  `assets/dashboard/` builds to **30 MB total**, of which **22.7 MB is sourcemaps** (.map files).  With the current `sourcemap: true` setting Vite emits a `//# sourceMappingURL=…` comment in every JS file, so any browser with DevTools open auto-fetches all maps for chunks the page loads.

For a dashboard that operators leave running in a tab, this is a non-trivial bandwidth tax on every navigation that pulls a new lazy chunk.

## What

`dashboard/vite.config.ts`: `sourcemap: true` → `sourcemap: 'hidden'`.

- `.map` files are still produced (166 of them) so production debugging via manual DevTools "Add source map" or out-of-band symbolication still works.
- The `sourceMappingURL` comment is **omitted** from every JS file, so browsers stop auto-fetching maps.

Verified post-build:
```
$ grep -l sourceMappingURL ../assets/dashboard/assets/*.js
(no output)

$ ls ../assets/dashboard/assets/*.map | wc -l
166
```

## Effect

| Audience | Before | After |
|---|---|---|
| Operator with no DevTools | No map fetch (browser inactive) | Same |
| Operator with DevTools open on a page | Auto-fetch all maps for visible chunks (~10–22 MB extra over the session) | No auto-fetch; manual attach available if needed |
| Server bandwidth | Serves `.map` whenever requested | Same physical files; just rarely requested |
| Production debugging | Easy (auto-attach) | Slightly slower (manual attach via "Add source map" in DevTools) |

The deployment artifact size on disk is unchanged (the .map files still live in `assets/dashboard/`).  A future PR can drop them from the Docker image copy step if disk size matters; this PR only fixes the browser auto-fetch path, which is the user-visible perf cost.

## Cycle position + retrospective

- Cycle 1 (#10894) — fsm-hub 1 Hz → 5 Hz tick (5x re-render reduction predicted)
- Cycle 2 (#10897) — opt-in bundle visualizer (measurement infra)
- Cycle 3 (no PR) — `manualChunks: { 'vis-data': [...] }` was tested and **measurement rejected the hypothesis** — the chunks supposedly sharing vis-data turned out to be dominated by their own `vis-timeline`/`vis-network` deps; manual splitting only added a 114 kB orphan chunk without shrinking either consumer.  Rollback retained, no PR opened.
- **Cycle 4 (this)** — `sourcemap: 'hidden'`

The cycle 3 negative result is the reason cycle 4 went after deployment overhead instead of more chunk-splitting heuristics.

## Test plan

- [x] `pnpm run build` succeeds
- [x] No JS file contains `sourceMappingURL`
- [x] All 166 .map files still emitted (manual attach available)
- [ ] Operator confirms DevTools manual map attach works for a sample chunk (manual)
