### PR TITLE
i18n(dashboard): localize connector tile notice labels (round-65)

### DIFF
--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -674,7 +674,7 @@ describe('deriveTileNotice (pure)', () => {
     }))
     expect(notice).toEqual({
       tone: 'error',
-      label: 'Error',
+      label: '오류',
       detail: 'Discord gateway timeout',
     })
   })
@@ -691,7 +691,7 @@ describe('deriveTileNotice (pure)', () => {
     }))
     expect(notice).toEqual({
       tone: 'stale',
-      label: 'Stale',
+      label: '오래됨',
       detail: '데이터 오래됨 (60s threshold)',
     })
   })

--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -745,7 +745,7 @@ describe('TileErrorNotice component (rendered inside ConnectorOverviewStrip)', (
     )
     const notice = container.querySelector('[data-tile-notice="error"]') as HTMLElement
     expect(notice).toBeTruthy()
-    expect(notice.textContent).toContain('Error')
+    expect(notice.textContent).toContain('오류')
     expect(notice.textContent).toContain('WebSocket closed 4004')
     expect(notice.className).toContain('var(--bad-light)')
     expect(notice.getAttribute('role')).toBe('alert')
@@ -766,7 +766,7 @@ describe('TileErrorNotice component (rendered inside ConnectorOverviewStrip)', (
       container,
     )
     const notice = container.querySelector('[data-tile-notice="stale"]') as HTMLElement
-    expect(notice.textContent).toContain('Stale')
+    expect(notice.textContent).toContain('오래됨')
     expect(notice.className).toContain('var(--color-status-warn)')
   })
 

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -395,7 +395,7 @@ export function deriveTileNotice(
   if (err !== '') {
     return {
       tone: 'error',
-      label: 'Error',
+      label: '오류',
       detail: err,
     }
   }
@@ -404,7 +404,7 @@ export function deriveTileNotice(
     const ageHint = secs > 0 ? ` (${secs}s threshold)` : ''
     return {
       tone: 'stale',
-      label: 'Stale',
+      label: '오래됨',
       detail: `데이터 오래됨${ageHint}`,
     }
   }


### PR DESCRIPTION
## 변경 사항

`connector-overview-strip.ts:398, 407`:
- `'Error'` → `'오류'`
- `'Stale'` → `'오래됨'`

`connector-overview-strip.test.ts:677, 694`: assertion sync (atomic test sync)

## 영향 범위
2 files (source + test), 4 lines. `toEqual` deep equality test → strict sync 필수.

## 자기 점검
- 변경 파일: connector-overview-strip.ts + .test.ts
- 검증: source 'Error'/'Stale' 외 다른 사용처 없음 (rg 확인)
- vitest infra blocker (#10645) 진행 중

🤖 Generated with [Claude Code](https://claude.com/claude-code)