### PR TITLE
fix(keeper/watchdog): demote all-default tick to DEBUG (#10908)

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -85,10 +85,25 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
              in
              let failure_loop = noop_count >= noop_threshold () in
              let stale = idle_stale || failure_loop in
-             Log.Keeper.info
-               "%s: watchdog tick noop=%d idle_stale=%b failure_loop=%b stale=%b last_turn=%.0f fiber_age=%.0f grace_rem=%.0f"
-               meta.name noop_count idle_stale failure_loop stale last_turn
-               fiber_age grace_remaining;
+             (* #10908: 92% of ticks are
+                [noop=0 idle_stale=false failure_loop=false stale=false]
+                — every health bool at default.  Logging at INFO drowns
+                actionable ticks (and competing real signals) under
+                ~800 lines/day of identical heartbeat noise.  Same fix
+                pattern as #10881 (WS lifecycle log): keep INFO for
+                anything an operator should see (any flag set or any
+                noop accumulated), demote the all-default heartbeat to
+                DEBUG. *)
+             let actionable = stale || noop_count > 0 in
+             let log_line =
+               Printf.sprintf
+                 "%s: watchdog tick noop=%d idle_stale=%b failure_loop=%b stale=%b last_turn=%.0f fiber_age=%.0f grace_rem=%.0f"
+                 meta.name noop_count idle_stale failure_loop stale last_turn
+                 fiber_age grace_remaining
+             in
+             if actionable
+             then Log.Keeper.info "%s" log_line
+             else Log.Keeper.debug "%s" log_line;
              let cooldown_ok =
                !last_broadcast_ts = 0.0
                || now -. !last_broadcast_ts > threshold


### PR DESCRIPTION
## Why

#10908: 92% of keeper watchdog ticks emit

\`\`\`
noop=0 idle_stale=false failure_loop=false stale=false
\`\`\`

— every health bool at default. Logging this at INFO produces **~800 heartbeat lines/day** across the fleet, drowning actionable ticks and unrelated INFO signals during operator log scans.

Issue body distribution (rolling ~2 days):

| Bucket | Events | % | 정보 가치 |
|---|---|---|---|
| All 3 false (default) | **1505** | **92%** | 0 |
| Any flag true | 133 | 8% | actionable |

## Fix

Mirror #10881 (WS connect/close demotion):

\`\`\`ocaml
let actionable = stale || noop_count > 0 in
if actionable then Log.Keeper.info \"%s\" log_line
else Log.Keeper.debug \"%s\" log_line
\`\`\`

- **INFO** when actionable (idle stale, failure-loop, or any noop accumulated — operator wants these).
- **DEBUG** otherwise (the 92% all-default heartbeat).

Format string unchanged — dashboards parsing the log keep working; only the level shifts.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| All-default tick (92%) | 1× INFO | 1× DEBUG (silent at default threshold) |
| Any actionable flag | 1× INFO | 1× INFO (unchanged) |
| Termination broadcast | unchanged | unchanged |
| Prometheus \`masc_keeper_stale_termination_total\` | unchanged | unchanged |

## Test plan

- [x] \`dune build @check\` EXIT=0
- [ ] CI green
- [ ] Ready transition

No new env knob, no metric change. 1 file, 19 ins / 4 del.

## Refs

- #10908 (this issue)
- #10881 (#10875 fix — same demotion pattern)
- #10097 CLOSED (codex_cli MCP omission WARN spam, same family)
- Memory: \`feedback_no-heuristic-category\` (heuristic-total INFO → sound-partial actionable-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)