### PR TITLE
chore(telemetry): bump Tool_usage SLO 900 → 3600 to match sparse admin source

### DIFF
--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -94,7 +94,9 @@ let source_freshness_slo_s = function
   | Execution_receipt -> 300.0
   | Oas_event -> 300.0
   | Agent_event -> 900.0
-  | Tool_usage -> 900.0
+  (* Tool_usage covers Tool_catalog_surfaces.System_internal admin-only
+     tools — sparse by design. Match the SSOT in tool_usage_log.ml. *)
+  | Tool_usage -> 3600.0
   | Goal_event -> 604800.0
   | Tool_metric -> 900.0
 

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -26,7 +26,14 @@ let store_ref : Dated_jsonl.t option ref = ref None
 let source_name = "tool_usage"
 let source_producer = "tool_usage_log"
 let dashboard_surface = "/api/v1/dashboard/tools"
-let freshness_slo_s = 900.0
+(* Sparse-source SLO. Tool_usage logs only Tool_catalog_surfaces.System_internal
+   surface tools, which are admin-only invocations driven by operators. Real
+   workloads can legitimately go an hour or more without an admin tool call,
+   so the original 900 s SLO inherited from high-volume sources caused false
+   "stale" alerts on healthy fleets. 3600 s matches the operational rhythm
+   without masking a true write-pipeline failure — Dated_jsonl append errors
+   already record a coverage_gap that bypasses this SLO. *)
+let freshness_slo_s = 3600.0
 
 let store_dir masc_root = Filename.concat masc_root "tool_usage"
 


### PR DESCRIPTION
## Summary

\`Tool_usage\` source covers only \`Tool_catalog_surfaces.System_internal\` (admin-only) tools — sparse by design. The inherited 900 s freshness SLO classified a healthy fleet as "stale" within 16 minutes of the last admin call, which the user observed on the "플릿 텔레메트리" surface today.

## Evidence

\`\`\`bash
$ curl -s http://127.0.0.1:8935/api/v1/dashboard/telemetry/summary | jq '.sources[] | select(.source=="tool_usage")'
{
  "source": "tool_usage",
  "entry_count": 14,         # ← total, lifetime
  "freshness_slo_s": 900,
  "latest_age_s": 997,        # ← 16 min, just past SLO
  "health": "stale",
  "stale_reason": "freshness_slo_exceeded"
}
\`\`\`

14 entries lifetime. The fleet is healthy; admins simply don't issue \`masc_help\` / \`set_max_tokens\` / similar every 15 min. 3600 s matches the operational rhythm.

## Why not silent write-failure risk?

True \`Dated_jsonl.append\` failures bypass the freshness SLO entirely — \`record_coverage_gap\` sets \`health="coverage_gap"\` with the actual error message. SLO only governs the freshness label, not the write-pipeline truth.

## Two callsites kept in sync

| File | Line | What |
|------|------|------|
| \`lib/tool_usage_log.ml\` | 29 | Per-source SSOT constant (used by \`/api/v1/dashboard/tools\`) |
| \`lib/telemetry_unified.ml\` | 97 | \`Tool_usage\` variant in \`source_freshness_slo_s\` (used by \`/api/v1/dashboard/telemetry/summary\`) |

Future work: collapse the two definitions to a single SSOT (\`Tool_usage_log.freshness_slo_s\` consumed by \`telemetry_unified\`). Out of scope for this surgical bump.

## Risk

- Pure threshold tuning. No behavior change for healthy/coverage-gap states.
- A genuine write-pipeline stall longer than 1 hour will now show "stale" instead of "coverage_gap" if append never fails — but a stall without append failures is a different bug class (queue full, fiber dead) handled elsewhere.

## Out of scope

- \`Goal_event missing\` UX (file doesn't exist when no goal verified) — separate signal, separate fix.
- SSOT consolidation of the two SLO definitions.
- Source-type-aware SLO framework (per-source profile classification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)