### PR TITLE
refactor(design-system): swap memory bulk + individual delete buttons to ActionButton danger (PR-CS67)

### DIFF
--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback, useMemo, useState } from 'preact/hooks'
+import { ActionButton } from './common/button'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
@@ -305,13 +306,17 @@ function SortBar() {
         />
         <div class="ml-auto flex items-center gap-2">
           ${selectedPostIds.value.size > 0 ? html`
-            <button type="button"
-              class="px-3 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-30)] hover:bg-[var(--bad-20)] disabled:opacity-50 disabled:cursor-not-allowed"
+            <${ActionButton}
+              variant="danger"
+              size="md"
+              class="!px-3"
               onClick=${bulkDeleteSelected}
               disabled=${bulkDeleting.value}
+              ariaBusy=${bulkDeleting.value}
+              ariaLabel="선택한 게시글 일괄 삭제"
             >
               ${bulkDeleting.value ? '삭제 중...' : `선택 삭제 (${selectedPostIds.value.size})`}
-            </button>
+            <//>
             <button type="button"
               class="px-2 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]"
               onClick=${() => { selectedPostIds.value = new Set() }}
@@ -457,14 +462,18 @@ function PostCard({ post }: { post: BoardPost }) {
           ${post.hearth ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
           ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
 
-          <!-- Delete button -->
-          <button type="button"
-            class="ml-auto px-2 py-0.5 rounded text-3xs font-semibold border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-20)] transition-all cursor-pointer opacity-0 group-hover:opacity-100 disabled:opacity-50 disabled:cursor-not-allowed"
+          <!-- Delete button — reveal on row hover via opacity utilities -->
+          <${ActionButton}
+            variant="danger"
+            size="sm"
+            class="ml-auto !py-0.5 opacity-0 group-hover:opacity-100"
             onClick=${handleDelete}
             disabled=${isDeleting}
+            ariaBusy=${isDeleting}
+            ariaLabel=${`게시글 삭제: ${post.id}`}
           >
             ${isDeleting ? '삭제 중...' : '삭제'}
-          </button>
+          <//>
         </div>
       </div>
     </button>


### PR DESCRIPTION
## Summary

CS series sweep. memory.ts의 raw `<button>` 삭제 버튼 2건을 ActionButton `danger` variant로 swap. CS65/CS66에 이은 raw button → ActionButton 마이그레이션.

## 변경

`dashboard/src/components/memory.ts`:
- `import { ActionButton } from './common/button'` 추가

### 1. Line 308 — Bulk delete (`선택 삭제 (N)`)
- `<button>` → `<${ActionButton} variant=\"danger\" size=\"md\" class=\"!px-3\">`
- 제거된 inline class (danger + size md + BASE 상속):
  - `border bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-30)] hover:bg-[var(--bad-20)]`
  - `rounded`, `transition-all duration-150` → BASE `duration-200`
  - `disabled:opacity-50 disabled:cursor-not-allowed`
- 유지된 override: `!px-3` (size md `px-2.5` 대비 약간 넓게, 기존 시각 유지)
- 추가: `ariaBusy=${bulkDeleting.value}` + `ariaLabel=\"선택한 게시글 일괄 삭제\"`

### 2. Line 461 — Individual post delete (`삭제`)
- `<button>` → `<${ActionButton} variant=\"danger\" size=\"sm\" class=\"ml-auto !py-0.5 opacity-0 group-hover:opacity-100\">`
- 같은 danger 색조합 inline 제거
- 유지된 override:
  - `ml-auto` (layout)
  - `!py-0.5` (size sm `py-1` 대비 더 compact)
  - `opacity-0 group-hover:opacity-100` (row hover 시에만 reveal — 핵심 UX 보존)
- 추가: `ariaBusy=${isDeleting}` + `ariaLabel=\`게시글 삭제: ${post.id}\`` (다수 카드 환경 disambiguation)

## Group hover pattern

ActionButton의 `class` extension prop이 `opacity-0 group-hover:opacity-100`을 그대로 받음. Tailwind `group-hover`는 부모 `:hover`를 트래킹하므로 ActionButton 자체의 `:hover`와 충돌 없음.

## Out of scope

- 같은 toolbar의 \"선택 해제\" 버튼: production palette (`text-[var(--color-fg-muted)] border-[var(--border-slate-16)] bg-transparent`) — ActionButton variant 매칭 안 됨

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/memory`: 71/71 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)