### PR TITLE
perf(dashboard/fsm-hub): drop self-triggering pollTick from interval deps

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -404,9 +404,12 @@ export function FsmHub(props: FsmHubProps = {}) {
 
   useEffect(() => {
     if (paused) return undefined
+    // pollTick was previously a dep, but the interval body already
+    // self-triggers via setPollTick(t => t + 1) — including pollTick
+    // forced clearInterval + setInterval every 30 s for nothing.
     const id = setInterval(() => setPollTick(t => t + 1), 30_000)
     return () => clearInterval(id)
-  }, [paused, pollTick])
+  }, [paused])
 
   useEffect(() => {
     if (paused) return undefined


### PR DESCRIPTION
## Why

Cycle 5 of the iterative dashboard performance pass.  `fsm-hub.ts` had a useEffect-as-anti-pattern in its 30 s polling tick:

```ts
useEffect(() => {
  if (paused) return undefined
  const id = setInterval(() => setPollTick(t => t + 1), 30_000)
  return () => clearInterval(id)
}, [paused, pollTick])  // ← pollTick is in deps but the interval already self-triggers it
```

Because `pollTick` is in the deps, every fire of the interval (which itself increments `pollTick`) tears down the interval and creates a new one.  Net behaviour is correct but every 30 s does:

1. `clearInterval(prev)` — old interval removed
2. `setInterval(new)` — new interval scheduled

This was effectively a self-triggering deps loop where the deps change is caused only by the interval's own write.

## What

Single-line change: drop `pollTick` from deps, leaving `[paused]`.  The interval continues to self-trigger via `setPollTick(t => t + 1)` exactly as before.

## Effect

- 30 s `clearInterval`/`setInterval` churn eliminated (no behavioural change)
- One fewer effect re-run per polling cycle
- Comment block left in code so a future contributor doesn't restore the dep without reading the analysis

## Cycle position

- Cycle 1 (#10894) — fsm-hub 1 Hz → 5 Hz tick (5x re-render reduction)
- Cycle 2 (#10897) — opt-in bundle visualizer
- Cycle 3 (no PR) — vis-data manualChunks rejected on measurement
- Cycle 4 (#10907) — sourcemap: 'hidden' (DevTools auto-fetch)
- **Cycle 5 (this)** — fsm-hub pollTick deps cleanup

The remaining 11 useEffects in fsm-hub.ts were inspected; the others are either DOM-event subscriptions, legitimate one-shot mounts, or side-effect-free state mirrors with no perf cost.

## Test plan

- [x] `pnpm run typecheck` succeeds
- [x] No new test failures (pre-existing flagTooltip localization failures verified identical on main)
