### PR TITLE
refactor(design-system): swap connector-config boolean field renderer to Checkbox (PR-CS68)

### DIFF
--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -336,9 +336,8 @@ function FieldWidget({ id, field, value, revealed }: {
     const target = ev.target as HTMLInputElement
     setEntry(id, { values: { ...getEntry(id).values, [field.name]: target.value } })
   }
-  const onCheckbox = (ev: Event) => {
-    const target = ev.target as HTMLInputElement
-    setEntry(id, { values: { ...getEntry(id).values, [field.name]: target.checked ? 'true' : 'false' } })
+  const onCheckbox = (checked: boolean) => {
+    setEntry(id, { values: { ...getEntry(id).values, [field.name]: checked ? 'true' : 'false' } })
   }
   const toggleReveal = () => {
     setEntry(id, { reveal: { ...getEntry(id).reveal, [field.name]: !revealed } })
@@ -358,11 +357,10 @@ function FieldWidget({ id, field, value, revealed }: {
     case 'boolean':
       return html`
         <label class="flex items-center gap-2 text-2xs text-[var(--color-fg-primary)]">
-          <input
-            type="checkbox"
+          <${Checkbox}
             checked=${value === 'true'}
-            onInput=${onCheckbox}
-            class="cursor-pointer"
+            ariaLabel=${field.name}
+            onChange=${onCheckbox}
           />
           <span>${value === 'true' ? 'enabled' : 'disabled'}</span>
         </label>


### PR DESCRIPTION
## Summary

CS series sweep. CS63에서 미루어둔 connector-config-form `case 'boolean'` field renderer의 raw `<input type=\"checkbox\">`를 Checkbox component로 swap. CS62/CS63 머지 후 진행.

## 변경

`dashboard/src/components/connector-config-form.ts`:

### onCheckbox 시그니처 리팩토링
- Before: `(ev: Event) => { (ev.target as HTMLInputElement).checked ? 'true' : 'false' }`
- After: `(checked: boolean) => { checked ? 'true' : 'false' }`
- Closure-local 변경, 호출처 1곳만 — DOM event reach-in이 boolean 직접 참조로 collapse

### case 'boolean' field renderer (line 358)
- `<input type=\"checkbox\">` → `<${Checkbox}>`
- 제거된 inline class:
  - `cursor-pointer` (CHECKBOX_BASE 상속)
- 추가:
  - `ariaLabel=${field.name}` (a11y) — 이전엔 wrapping label에 \"enabled\"/\"disabled\" 시각 텍스트만 있어 AT user가 *어느* setting인지 모름
- `onInput` → `onChange` (Checkbox convention; 동작 동치)

## 시각 변화

Browser default checkbox → CHECKBOX_BASE (design-system bg/border/hover + focus-visible ring + accent-fg checkmark color)

## connector-config-form raw input migration 완료 표

| Field type | Status | PR |
|------------|--------|-----|
| `string` (text) | ✅ TextInput | CS62 |
| `string` (sensitive/password) | ✅ TextInput | CS62 |
| `boolean` (auto-restart toggle) | ✅ Checkbox | CS63 |
| `boolean` (field renderer) | ✅ Checkbox | **CS68 (this)** |
| `integer` / `number` | ⏳ Raw `<input type=\"number\">` (NumberInput migration 대기, signal-typed numeric) | — |

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/connector`: 199/199 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)