### PR TITLE
perf(transport): label sse_broadcast_events_total by target

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -692,7 +692,12 @@ let broadcast_impl target json =
   List.iter (fun sid -> unregister sid) !failed;
   (* Record broadcast duration for transport observability *)
   let elapsed = Time_compat.now () -. t0 in
-  Transport_metrics.observe_broadcast_duration elapsed;
+  let target_label = match target with
+    | All -> "all"
+    | Observers -> "observers"
+    | Coordinators -> "coordinators"
+  in
+  Transport_metrics.observe_broadcast_duration ~target:target_label elapsed;
   sync_transport_snapshot ();
   (* Notify external subscribers (gRPC streams, etc.) *)
   notify_external_subscribers event

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -24,9 +24,13 @@ let set_sse_sessions ~kind count =
   Prometheus.set_gauge Prometheus.metric_sse_sessions
     ~labels:[("kind", kind)] (float_of_int count)
 
-let observe_broadcast_duration seconds =
+let observe_broadcast_duration ?target seconds =
   Prometheus.observe_histogram Prometheus.metric_sse_broadcast_duration seconds;
-  Prometheus.inc_counter Prometheus.metric_sse_broadcast_events ()
+  let labels = match target with
+    | None -> []
+    | Some t -> [("target", t)]
+  in
+  Prometheus.inc_counter Prometheus.metric_sse_broadcast_events ~labels ()
 
 let set_sse_queue_depth ~session_id depth =
   Prometheus.set_gauge Prometheus.metric_sse_stream_queue_depth


### PR DESCRIPTION
## Why

Cycle 6 of the iterative dashboard performance pass — server-side measurement infra.

The `masc_sse_broadcast_events_total` counter currently aggregates **every** broadcast across `All`, `Observers`, and `Coordinators` targets into a single number.  When investigating broadcast hot paths there's no way to separate, say, a chatty `Observers`-targeted snapshot fan-out from a low-volume `Coordinators` heartbeat — both contribute to the same scalar.

Adding a `target` label (cardinality 3) makes per-target rates queryable in Prometheus / Grafana without measurable runtime cost.

## What

| File | Change |
|------|--------|
| `lib/transport_metrics.ml` | `observe_broadcast_duration` accepts optional `?target` and forwards it to `inc_counter` as a `("target", t)` label |
| `lib/sse.ml` | In `broadcast_impl`, derive `target_label` from the `broadcast_target` variant (`All` → `"all"`, `Observers` → `"observers"`, `Coordinators` → `"coordinators"`) and pass it into the metric |

Net: 2 files, +12 -3.

## Cardinality safety

The `target` label is bounded by the `broadcast_target` ADT (`All | Observers | Coordinators`) — there are exactly **3 possible label values**, no caller-controlled strings or JSON-derived event types.  This deliberately stays away from per-event-type labels (which would have unbounded cardinality and were considered then deferred — see "Out of scope" below).

## Out of scope

- **Per-event-type label** (`event_type=project_snapshot|...`): rejected this cycle because event types are JSON-derived and would need a curated whitelist + `"other"` bucket to stay safe.  Worth a separate PR if the bounded `target` label proves insufficient for diagnosis.
- **Histogram by target**: `masc_sse_broadcast_duration_seconds` keeps a single un-labeled histogram for now; per-target latency split can land later if the data justifies it.

## Cycle position

- Cycle 1 (#10894) — fsm-hub 1 Hz → 5 Hz tick (5x re-render reduction)
- Cycle 2 (#10897) — opt-in bundle visualizer (client measurement infra)
- Cycle 3 (no PR) — vis-data manualChunks rejected on measurement
- Cycle 4 (#10907) — sourcemap: 'hidden' (DevTools auto-fetch)
- Cycle 5 (#10914) — fsm-hub pollTick deps cleanup
- **Cycle 6 (this)** — server broadcast `target` label

## Verification

- `dune build @check` — green.

## Test plan

- [x] `dune build @check` succeeds
- [ ] After deploy, `sum by (target) (rate(masc_sse_broadcast_events_total[5m]))` returns 3 series in Prometheus (manual)
