### PR TITLE
refactor(design-system): swap connector-onboarding Start button to ActionButton primary (PR-CS69)

### DIFF
--- a/dashboard/src/components/connector-onboarding.test.ts
+++ b/dashboard/src/components/connector-onboarding.test.ts
@@ -79,20 +79,24 @@ describe('ConnectorOnboardingGrid', () => {
     expect(container.textContent ?? '').toContain('아직 연결된 사이드카가 없습니다')
   })
 
-  it('renders a per-card Start button with data-onboarding-start matching each connector id', () => {
+  it('renders a per-card Start button with testId matching each connector id', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
-    const buttons = container.querySelectorAll('[data-onboarding-start]')
+    const buttons = container.querySelectorAll('[data-testid^="onboarding-start-"]')
     expect(buttons.length).toBe(4)
-    const ids = Array.from(buttons).map(b => b.getAttribute('data-onboarding-start'))
+    const ids = Array.from(buttons)
+      .map(b => b.getAttribute('data-testid')!.replace('onboarding-start-', ''))
     expect(ids).toEqual(['discord', 'imessage', 'slack', 'telegram'])
   })
 
   it('per-card Start button starts in the idle "Start" label, not inflight', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
-    const discordBtn = container.querySelector('[data-onboarding-start="discord"]') as HTMLButtonElement
+    const discordBtn = container.querySelector('[data-testid="onboarding-start-discord"]') as HTMLButtonElement
     expect(discordBtn.textContent).toContain('Start')
     expect(discordBtn.textContent).not.toContain('Starting')
-    expect(discordBtn.getAttribute('aria-busy')).toBe('false')
+    // ActionButton omits aria-busy when ariaBusy=false (ARIA default is
+    // already "false" — no need to render it). When the inflight state
+    // flips, ariaBusy=true would render aria-busy="true" instead.
+    expect(discordBtn.getAttribute('aria-busy')).toBeNull()
     expect(discordBtn.disabled).toBe(false)
   })
 })

--- a/dashboard/src/components/connector-onboarding.ts
+++ b/dashboard/src/components/connector-onboarding.ts
@@ -5,6 +5,7 @@
 
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
+import { ActionButton } from './common/button'
 import { CopyableCode } from './common/copyable-code'
 import { SetupGuideCard } from './setup-guide-card'
 import {
@@ -50,14 +51,14 @@ function OnboardingCard({ connectorId }: { connectorId: KnownConnectorId }) {
           <span class="text-base leading-none" aria-hidden="true">${channelIcon(connectorId)}</span>
           <span class="text-sm font-semibold text-[var(--color-fg-primary)]">${CONNECTOR_DISPLAY_NAMES[connectorId]}</span>
         </div>
-        <button
-          type="button"
-          class=${`rounded cursor-pointer transition-all duration-200 font-medium border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--color-fg-secondary)] hover:bg-[var(--accent-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] py-1 px-2 text-3xs ${starting ? 'opacity-50 pointer-events-none' : 'active:scale-[0.97]'}`}
+        <${ActionButton}
+          variant="primary"
+          size="sm"
           disabled=${starting}
-          aria-busy=${starting ? 'true' : 'false'}
-          data-onboarding-start=${connectorId}
+          ariaBusy=${starting}
+          testId=${`onboarding-start-${connectorId}`}
           onClick=${() => { void onStart() }}
-        >${onboardingStartLabel(starting)}</button>
+        >${onboardingStartLabel(starting)}<//>
       </div>
       <div class="text-2xs text-[var(--color-fg-disabled)]">
         <strong>Start</strong>를 누르면 백엔드가 사이드카를 실행합니다. 또는 명령을 복사해 새 터미널에서 직접 실행하세요.


### PR DESCRIPTION
## Summary

CS series sweep. **이번 시리즈에서 가장 깨끗한 ActionButton swap** — 기존 inline class가 ActionButton primary + size sm + BASE를 byte-for-byte 수동 합성한 형태였음. 이미 canonical 매칭이고 migration만 안 되어 있던 케이스.

## 변경

### `dashboard/src/components/connector-onboarding.ts:54` — per-card Start 버튼
- `<button>` → `<${ActionButton} variant=\"primary\" size=\"sm\">`
- 제거된 inline class (1:1 매칭, ActionButton 상속):
  - `border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--color-fg-secondary)] hover:bg-[var(--accent-20)]` → primary variant **exact**
  - `rounded cursor-pointer transition-all duration-200 font-medium` → BASE **exact**
  - `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]` → BASE **exact**
  - `py-1 px-2 text-3xs` → size sm **exact**
  - `active:scale-[0.97]` → BASE **exact**
  - `${starting ? 'opacity-50 pointer-events-none' : 'active:scale-[0.97]'}` → ActionButton의 `disabled` prop이 `disabled:opacity-50 disabled:cursor-not-allowed` 자동 적용
- API 변환:
  - `aria-busy=${starting ? 'true' : 'false'}` → `ariaBusy=${starting}` (boolean prop)
  - `data-onboarding-start=${connectorId}` → `testId=\`onboarding-start-${connectorId}\``

### `dashboard/src/components/connector-onboarding.test.ts` — 3 selector + 1 assertion 정정
- 3건의 selector 업데이트:
  - `[data-onboarding-start]` → `[data-testid^=\"onboarding-start-\"]` (prefix-match, 더 selective)
  - `[data-onboarding-start=\"discord\"]` → `[data-testid=\"onboarding-start-discord\"]`
  - `getAttribute('data-onboarding-start')` → `getAttribute('data-testid').replace('onboarding-start-', '')`
- 1건의 assertion 정정:
  - `aria-busy='false'` → `aria-busy === null`
  - **이유**: ActionButton은 ARIA 표준대로 `ariaBusy=false`일 때 attribute 생략 (default 'false'). 명시 렌더링 불필요.

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/connector-onboarding`: 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)