### PR TITLE
fix(coord/task): warn on 5-cycle oscillation threshold crossing (#10719)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -1421,6 +1421,23 @@ let transition_task_r
        | Types.Release, Types.Claimed _ | Types.Release, Types.InProgress _
        | Types.Release, Types.AwaitingVerification _ | Types.Release, Types.Done _
        | Types.Release, Types.Cancelled _ -> ());
+        (* #10719: surface tasks that have crossed the oscillation
+           threshold (5 release cycles) so dashboards/triage can pick
+           them up before they reach 20+ cycles with zero progress
+           (task-049 hit cycle 20 still in [todo]).  Pure observation:
+           does not block the release.  Fires once per crossing
+           (cycle_count = 4 → 5) to avoid log amplification on
+           subsequent releases of the same task. *)
+        (match action with
+         | Types.Release when task.cycle_count = 4 ->
+           Log.RoomTask.warn
+             "task_oscillation_threshold task=%s agent=%s cycle_count=%d \
+              threshold=5 (sustained claim->release loop, candidate for triage)"
+             task_id agent_name (task.cycle_count + 1)
+         | Types.Release | Types.Claim | Types.Start
+         | Types.Done_action | Types.Cancel
+         | Types.Submit_for_verification | Types.Approve_verification
+         | Types.Reject_verification -> ());
       if new_status = task.task_status && set_current = None then
         (* Idempotent no-op: status unchanged, skip write/events.
            Match None explicitly so set_current=Some is never silently dropped. *)


### PR DESCRIPTION
## 배경

#10719 — `~/me/.masc/tasks/backlog.json` 분석 결과 11/102 task (10.8%)가 cycle_count > 5의 multi-keeper oscillation 상태. task-049는 cycle 20 도달 후에도 여전히 `todo` 상태로 keeper 20 turn budget 소진. 정상 task는 1-3 cycle 내 `done` 도달.

문제: `coord_task` 가 Release 마다 `cycle_count` 만 증가시키고 threshold escalation 부재. 오실레이팅 task가 정상 task와 log stream 에서 구별 안 됨.

## 변경

`transition_task_r` Release branch에서 `task.cycle_count = 4`일 때 (즉 4→5 crossing) 단 1회 `Log.RoomTask.warn` emit:

```
task_oscillation_threshold task=<id> agent=<name> cycle_count=5
threshold=5 (sustained claim->release loop, candidate for triage)
```

`Types.Release when task.cycle_count = 4` 만 매칭 — `cycle_count >= 5` 가 아니라 정확히 `= 4` 인 이유: 한 번 임계 넘으면 release할 때마다 매번 발화 안 되도록 crossing event 1회만 emit. 후속 release (cycle_count 5→6, 6→7 ...) 는 noop.

## 의도적으로 안 한 것

- **FSM 변경 / claim 차단 없음** — 본 패치는 observation 만. issue body의 "다른 keeper 라우팅" / "do_not_reclaim" 강제는 별도 follow-up. signal 먼저, 정책 나중.
- **Prometheus counter 직접 호출 없음** — `coord_task` 는 의도적으로 `Prometheus` dep 없음 (memory `task_completion_path_observed_fn` 패턴 동일). 향후 hook 추가는 별도 PR.
- **cycle_count threshold env knob 없음** — `5` 는 issue의 "cycle > 5" 분류 기준 직접 사용. 튜닝 필요 시 별도 PR로 hyperparameter 노출 (memory `feedback_no-hyperparameter-as-env-knob` 검토 필요).

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file, +17 insertions
- 단일 crossing event 보장: pattern `task.cycle_count = 4` 로 좁힘

## 후속

- dashboard 에서 `task_oscillation_threshold` log 기반 oscillation tab 추가
- cycle >= 10 / >= 20 시 추가 escalation (issue 본문 # 후보 fix 2/3) 별도 PR
- Audit 카테고리 task가 왜 oscillate 하는지 separate analysis (#10719 # 분석 2)