### PR TITLE
i18n(dashboard): localize sidecar-log-viewer 2 strings (round-66)

### DIFF
--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -201,13 +201,13 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
               ? hasFilter
                 ? `${filtered.length} / ${entry.lines.length} lines`
                 : `${entry.lines.length} / ${entry.requestedLines} lines`
-              : 'no log yet'}
+              : '로그 없음'}
           </span>
           ${showMore
             ? html`<${ActionButton} variant="ghost" size="sm" disabled=${entry.loading} onClick=${onShowMore}>1000개 더 보기<//>`
             : null}
           <${ActionButton} variant="ghost" size="sm" disabled=${entry.loading} onClick=${onRefresh}>
-            ${entry.loading ? '...' : 'Refresh'}
+            ${entry.loading ? '...' : '새로고침'}
           <//>
         </div>
       </div>


### PR DESCRIPTION
## 변경 사항

`sidecar-log-viewer.ts:204, 210`:
- `'no log yet'` → `'로그 없음'`
- `'Refresh'` (button text) → `'새로고침'`

## 일관성 회복

인접 button `1000개 더 보기` (line 207) 이미 한국어. 본 round 가 같은 파일의 잔여 영문 일관성 회복.

## 영향 범위

1 file, 2 lines. Source-only.

## Test 점검
- `sidecar-log-viewer.test.ts`: 'Refresh'/'no log yet' 어떤 assertion 도 없음
- `telemetry-unified.test.ts`: 'Refresh' assertion 존재하지만 다른 button source 참조 (자체 telemetry 컴포넌트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)