### PR TITLE
refactor(design-system): swap tool-full-inventory refresh button to ActionButton ghost (PR-CS70)

### DIFF
--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback } from 'preact/hooks'
+import { ActionButton } from '../common/button'
 import { VirtualList } from '../common/virtual-list'
 import { EmptyState } from '../common/empty-state'
 import { ErrorState } from '../common/feedback-state'
@@ -178,13 +179,16 @@ export function FullInventoryView({
           />
           <span>지원 중단 표시</span>
         </label>
-        <button type="button"
-          class="px-3 py-1.5 rounded text-sm font-medium border border-[var(--color-border-default)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--color-fg-primary)]"
+        <${ActionButton}
+          variant="ghost"
+          size="md"
+          class="!px-3 !text-sm"
           onClick=${() => { void loadTools() }}
           disabled=${loading}
+          ariaBusy=${loading}
         >
           ${loading ? '새로고침 중...' : '새로고침'}
-        </button>
+        <//>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

CS series sweep. tool-full-inventory의 새로고침 버튼을 ActionButton ghost로 swap.

## 변경

`dashboard/src/components/tools/tool-full-inventory.ts`:
- `import { ActionButton } from '../common/button'` 추가
- 새로고침 버튼 (line 182): `<button>` → `<${ActionButton} variant=\"ghost\" size=\"md\" class=\"!px-3 !text-sm\">`
- 제거된 inline class (ghost + size md + BASE 상속):
  - `border border-[var(--color-border-default)] bg-[var(--white-4)] hover:bg-[var(--white-8)] text-[var(--color-fg-primary)]` → ghost **exact**
  - `rounded`, `transition-colors`, `cursor-pointer`, `font-medium` → BASE 상속
- 유지된 override:
  - `!px-3` (size md `px-2.5` 대비)
  - `!text-sm` (size md `text-2xs` 대비, 기존 시각 보존)
- 추가 a11y:
  - `ariaBusy=${loading}` — 이전엔 disabled만 있어서 AT user가 일시 busy인지 영구 disabled인지 구분 불가

## Out of scope

같은 파일의 surface filter tabs (line 122): pressed 시 `bg-[var(--accent-8)]` + `text-[var(--color-accent-fg)]` + `border-[var(--color-accent-fg)]/40` 사용 — ActionButton ghost의 `PRESSED_CLASSES`와 다름. 시각 drift 우려로 SKIP.

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/tools`: 76/76 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)