### PR TITLE
i18n(dashboard): localize keeper.ts streaming API errors (round-67)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -177,7 +177,7 @@ export async function streamKeeperMessage(
 
   if (!res.ok) {
     const raw = await res.text()
-    let message = raw || `Streaming request failed (${res.status})`
+    let message = raw || `스트리밍 요청 실패 (${res.status})`
     try {
       const parsed = JSON.parse(raw) as { error?: { message?: string }; message?: string }
       message = parsed.error?.message ?? parsed.message ?? message
@@ -188,7 +188,7 @@ export async function streamKeeperMessage(
   }
 
   if (!res.body) {
-    throw new Error('Streaming response body is unavailable')
+    throw new Error('스트리밍 응답 본문 사용 불가')
   }
 
   const reader = res.body.getReader()


### PR DESCRIPTION
## 변경 사항

`api/keeper.ts:180, 191`:
- ``Streaming request failed (${res.status})`` (template) → ``스트리밍 요청 실패 (${res.status})``
- `'Streaming response body is unavailable'` → `'스트리밍 응답 본문 사용 불가'`

## 영향

API layer thrown errors. caller (toast/console handler) 가 message 그대로 표시.

## 영향 범위
1 file, 2 lines. Source-only. Test 커플링 없음 (`rg` 검증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)