### PR TITLE
test(telemetry): lock in Goal_event 'not_yet' vs Tool_call_io 'missing' asymmetry

### DIFF
--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -850,6 +850,49 @@ let test_goal_event_source_and_summary () =
     "/api/v1/dashboard/goals"
     (json_string_field "dashboard_surface" goal_summary)
 
+let test_goal_event_missing_reports_not_yet () =
+  (* Goal_event store is created lazily by goal_fsm on the first verification.
+     A fleet that has not yet verified a goal MUST surface as a neutral
+     [not_yet] state, not the alarming [missing] state used for sources that
+     should always exist (Tool_call_io, Keeper_metric, ...).
+     Locks in the contract added by #10921. *)
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_goal_event_missing" in
+  let root = masc_root dir in
+  Fs_compat.mkdir_p root;
+  (* Intentionally do NOT create goal_events.jsonl. *)
+  let summary = Telemetry_unified.summary_json ~base_path:dir ~masc_root:root () in
+  let goal_summary = source_summary "goal_event" summary in
+  Alcotest.(check int) "no goal events yet" 0
+    (json_int_field "entry_count" goal_summary);
+  Alcotest.(check string) "missing-but-optional surfaces as not_yet"
+    "not_yet"
+    (json_string_field "health" goal_summary);
+  Alcotest.(check string) "stale_reason describes the not-yet state"
+    "no_entries_yet"
+    (json_string_field "stale_reason" goal_summary)
+
+let test_tool_call_io_missing_still_reports_missing () =
+  (* Counterpart to [test_goal_event_missing_reports_not_yet]: a non-optional
+     source must NOT silently slide into [not_yet]. Tool_call_io is written by
+     every keeper turn, so absence of its store is a real write-pipeline alarm.
+     Locks in the asymmetry between the two health classifications. *)
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_tool_call_io_missing" in
+  let root = masc_root dir in
+  Fs_compat.mkdir_p root;
+  (* Intentionally do NOT create tool_calls/. *)
+  let summary = Telemetry_unified.summary_json ~base_path:dir ~masc_root:root () in
+  let tool_summary = source_summary "tool_call_io" summary in
+  Alcotest.(check string) "non-optional missing source stays loud"
+    "missing"
+    (json_string_field "health" tool_summary);
+  Alcotest.(check string) "stale_reason names the missing store"
+    "store_missing"
+    (json_string_field "stale_reason" tool_summary)
+
 let test_summary_surfaces_coverage_gaps () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1016,6 +1059,10 @@ let () =
             test_summary_includes_trajectory_and_execution_receipt_sources;
           Alcotest.test_case "surfaces coverage gaps" `Quick
             test_summary_surfaces_coverage_gaps;
+          Alcotest.test_case "goal_event missing reports not_yet" `Quick
+            test_goal_event_missing_reports_not_yet;
+          Alcotest.test_case "tool_call_io missing stays missing" `Quick
+            test_tool_call_io_missing_still_reports_missing;
           Alcotest.test_case "counts all rows beyond recent cap" `Quick
             test_summary_counts_all_entries_beyond_recent_cap;
         ] );


### PR DESCRIPTION
## Why

#10921이 `Goal_event` source의 missing-when-not-yet UX를 도입했지만, 분류 자체는 1줄 헬퍼 (`source_optional_when_missing : source -> bool`)로만 강제됨. 누가 default를 `_ -> true`로 바꾸거나 `Tool_call_io -> true`를 추가해도 컴파일은 통과하고 silent regression.

대시보드 fatigue를 다시 부르지 않도록 두 방향을 묶어서 테스트로 잠금.

## What

`test/test_telemetry_unified.ml`에 회귀 테스트 2건 추가:

| 테스트 | 검증 내용 |
|--------|----------|
| `goal_event missing reports not_yet` | `goal_events.jsonl` 없을 때 `health=not_yet`, `stale_reason=no_entries_yet` |
| `tool_call_io missing stays missing` | `tool_calls/` 없을 때 `health=missing`, `stale_reason=store_missing` |

두 테스트가 같은 contract의 두 면 — non-optional source가 silent하게 `not_yet`로 빠지는 변화를 잡는다.

## Test

```
$ dune test test/test_telemetry_unified.exe
...
[OK] summary 6 goal_event missing reports not_yet.
[OK] summary 7 tool_call_io missing stays missing.
...
Test Successful in 0.410s. 29 tests run.
```

## Behaviour

코드 변경 없음. test/dune은 이미 `test_telemetry_unified` 등록되어있어 추가 stanza 불요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)