### PR TITLE
fix(health): replace List.hd with pattern match in keepers_directory

### DIFF
--- a/dashboard_bonsai/src/keepers_directory.ml
+++ b/dashboard_bonsai/src/keepers_directory.ml
@@ -416,7 +416,7 @@ let default_selected_name rows =
     match row.band with
     | `Active | `Attention -> Some row.name
     | `Paused | `Offline -> None)
-  |> Option.first_some (List.hd rows |> Option.map ~f:(fun row -> row.name))
+  |> Option.first_some (match rows with first :: _ -> Some first.name | [] -> None)
 ;;
 
 let selected_row rows selected_name =


### PR DESCRIPTION
## Summary
- Replace `List.hd rows |> Option.map ~f:(fun row -> row.name)` with pattern match `match rows with first :: _ -> Some first.name | [] -> None`
- Fixes Health ratchet regression `lib_list_hd 0→1`

## Test plan
- [x] Semantically identical transformation
- [ ] CI Health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)