### PR TITLE
refactor(design-system): swap confirm-dialog cancel button to ActionButton ghost (PR-CS71)

### DIFF
--- a/dashboard/src/components/common/confirm-dialog.ts
+++ b/dashboard/src/components/common/confirm-dialog.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { AlertTriangle, AlertCircle, Info } from 'lucide-preact'
+import { ActionButton } from './button'
 
 type ConfirmTone = 'danger' | 'warning' | 'info'
 
@@ -99,10 +100,11 @@ export function ConfirmDialogOverlay() {
             </div>
           </div>
           <div class="mt-6 flex items-center justify-end gap-2">
-            <button type="button"
-              class="px-4 py-2 rounded text-sm font-medium border border-[var(--color-border-default)] bg-[var(--white-4)] text-text-body hover:bg-[var(--white-8)] transition-colors cursor-pointer"
+            <${ActionButton}
+              variant="ghost"
+              size="lg"
               onClick=${state.onCancel}
-            >${state.cancelText}</button>
+            >${state.cancelText}<//>
             <button type="button"
               class="px-4 py-2 rounded text-sm font-medium border border-transparent transition-colors cursor-pointer ${confirmBtnClass}"
               onClick=${state.onConfirm}


### PR DESCRIPTION
## Summary

CS series sweep. confirm-dialog의 cancel 버튼을 ActionButton `ghost` size `lg`로 swap.

**앱 전체에서 가장 많이 보이는 ghost 버튼** — 모든 destructive action (post 삭제, bulk delete, keeper purge, snapshot 삭제 등)에서 등장. 단일 PR로 광범위 a11y 개선.

## 변경

`dashboard/src/components/common/confirm-dialog.ts`:
- `import { ActionButton } from './button'` 추가
- cancel 버튼 (line 102): `<button>` → `<${ActionButton} variant=\"ghost\" size=\"lg\">`
- 제거된 inline class (모두 ghost lg + BASE 상속):
  - `border border-[var(--color-border-default)] bg-[var(--white-4)] hover:bg-[var(--white-8)]` → ghost variant **exact**
  - `px-4 py-2 text-sm font-medium` → size lg `py-2 px-4 text-sm` **exact**
  - `rounded`, `transition-colors`, `cursor-pointer` → BASE
  - `text-text-body` → ghost의 `text-[var(--color-fg-primary)]` — production token이 alias됨 (`--color-fg-primary: var(--text-body)` in variables.css), 시각 동치

## a11y 영향

모든 destructive flow에서 일괄 수령:
- focus-visible ring (`ring-2 ring-[var(--accent-45)]`) — 키보드 사용자 즉각 인지
- active:scale-[0.97] — 클릭 시 피드백
- offset-2 ring offset — surface card 위에서도 ring 분리

## Out of scope

같은 dialog의 confirm 버튼은 tonal solid bg variants 사용 (`--color-status-warn`, `--color-status-err`, `--color-accent-fg`) — ActionButton primary의 transparent-tint 패턴과 다름. \"destructive confirm\" UI는 시각적으로 jump out 해야 하는 의도로 raw `<button>` 유지.

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/keeper-detail*`: 105/105 pass (consumer 파일 — keeper-detail-history, keeper-detail, agent-detail, fleet-telemetry-panel, app — requestConfirm 호출)

🤖 Generated with [Claude Code](https://claude.com/claude-code)