### PR TITLE
fix(coord/backend): demote per-call backend init logs to DEBUG (#10919)

### DIFF
--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -342,12 +342,21 @@ let default_config base_path =
   let resolved_path = resolve_masc_base_path base_path in
   sync_test_base_path_env resolved_path;
   let backend_config = backend_config_for resolved_path in
-  Log.Backend.info "MASC Backend: type=%s"
+  (* #10919: this factory is invoked per-tool-dispatch (8 call sites:
+     mcp_server_eio_call_tool, tool_autoresearch, inline_dispatch_coord,
+     keeper_rollover, ...) — 1745 inits / 2 days = 3490 INFO events
+     for what is conceptually a static config.  Demote the success
+     path to DEBUG; the failure / fallback paths below stay at
+     WARN so operators still see degraded backend selection.  A
+     per-base_path memoization patch (root fix for the per-call
+     factory pattern itself) is left for a follow-up since it needs
+     concurrency-safe state and broader test coverage. *)
+  Log.Backend.debug "MASC Backend: type=%s"
     (Backend_types.show_backend_type backend_config.backend_type);
   let backend =
     match create_backend backend_config with
     | Ok backend ->
-        Log.Backend.info "Backend initialized: %s"
+        Log.Backend.debug "Backend initialized: %s"
           (match backend with
            | Memory _ -> "Memory"
            | FileSystem _ -> "FileSystem");
@@ -379,12 +388,14 @@ let default_config_eio ~sw ?(on_backend_ready = fun _backend -> ()) base_path =
   let resolved_path = resolve_masc_base_path base_path in
   sync_test_base_path_env resolved_path;
   let backend_config = backend_config_for resolved_path in
-  Log.Backend.info "MASC Backend: type=%s"
+  (* #10919: same noise pattern as [default_config]; demote success
+     path to DEBUG.  Failure / fallback paths below stay at WARN. *)
+  Log.Backend.debug "MASC Backend: type=%s"
     (Backend_types.show_backend_type backend_config.backend_type);
   let backend =
     match create_backend_eio ~sw backend_config with
     | Ok backend ->
-        Log.Backend.info "Backend initialized: %s"
+        Log.Backend.debug "Backend initialized: %s"
           (match backend with
            | Memory _ -> "Memory"
            | FileSystem _ -> "FileSystem");


### PR DESCRIPTION
## 배경

#10919 — `Coord.default_config` / `default_config_eio` 가 8 call site 에서 매 tool dispatch / autoresearch / rollover 마다 호출됨. 각 호출 당 INFO 2 lines (`MASC Backend: type=...` + `Backend initialized: ...`).

2일 rolling window:
- 1745 inits × 2 logs = **3490 INFO events**
- Server restart 21회, 1 restart 당 ~83 init bunched (정상이면 1 init/restart 기대)
- 17:51:35 부터 5-8분 윈도우에 ~20 inits 집중

`Backend init` 은 conceptually static config 인데도 매 호출마다 출력 — 실제 actionable signal (failure / fallback) 이 noise 에 묻힘.

## 변경

`default_config` + `default_config_eio` 의 success path 만 DEBUG 로 demote. 4 sites:

| 위치 | 변경 | 이유 |
|---|---|---|
| `default_config` line 345 (entry log) | INFO → DEBUG | 매 호출마다 type 출력 noise |
| `default_config` line 350 (Ok branch) | INFO → DEBUG | 정상 init 동일 |
| `default_config_eio` line 382 (entry log) | INFO → DEBUG | 동일 패턴 |
| `default_config_eio` line 387 (Ok branch) | INFO → DEBUG | 동일 |

**Failure / fallback path 의 WARN 은 그대로 유지** — operator 가 degraded backend selection 을 여전히 볼 수 있어야 함.

## 의도적으로 안 한 것

### Per-base_path memoization (이슈 본문 후보 fix #1)
이슈 본문은 `Hashtbl` 기반 memo 를 root fix 로 제시. 하지만 실제 적용엔:
- 동시성 안전 (Eio.Mutex / Stdlib.Mutex 선택 — memory `feedback_ocaml5-mutex-selection`)
- Backend init failure 시 cache 처리 (실패는 cache 안 함)
- Test setup 의 base_path 변경 interaction 검증

→ logging hygiene 보다 큰 scope. 별도 PR 로 분리.

### Cause-first vs symptom-first
이번 PR 은 symptom (log noise) 만 처리. Per-call factory 패턴 자체 (cause) 는 그대로. 이건 의도적 — `feedback_ai-pair-interaction-depth` 의 \"2번째 fix → 근본 수정 강제\" 규칙은 같은 영역의 두 번째 fix 일 때 발동. 본 영역의 첫 INFO→DEBUG fix 이고, 다음 #10919 follow-up 이 memo 를 다루면 거기서 root fix.

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file, +15 / -4
- Family precedent: #10881 (WS lifecycle INFO→DEBUG, 머지됨), #10908 (watchdog tick all-default INFO→DEBUG, #10910 으로 머지됨)

## 후속

- Follow-up PR: `default_config_cache` (Hashtbl + Eio.Mutex) 로 per-base_path memo
- 추가 쌍둥이 후보 검토: `tool_autoresearch_cycle.ml` 등에서 per-cycle Backend init 직접 호출이 있는지 확인 (이번 PR scope 밖)