### PR TITLE
fix(dashboard): update test expectations for i18n-localized flag tooltips

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -783,7 +783,7 @@ describe('FleetTelemetryPanel', () => {
     await flushUi()
 
     expect(container.textContent).toContain('3 tool calls')
-    expect(container.textContent).not.toContain('No recent tools')
+    expect(container.textContent).not.toContain('최근 도구 기록 없음')
     expect(container.textContent).toContain('glm-5.1')
   })
 

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -387,7 +387,7 @@ describe('toolSummary', () => {
 
   it('shows no recent tools when activity known but nothing', () => {
     const row = makeRow({ recent_tools: [], tool_calls: 0, tool_activity_known: true })
-    expect(toolSummary(row).label).toContain('No recent tools')
+    expect(toolSummary(row).label).toContain('최근 도구 기록 없음')
   })
 
   it('shows unavailable when activity unknown', () => {

--- a/dashboard/src/components/fsm-hub-health-panels.test.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.test.ts
@@ -19,28 +19,28 @@ describe('flagTooltip', () => {
     const result = flagTooltip('plan', true)
     expect(result).toContain('plan')
     expect(result).toContain('active')
-    expect(result).toContain('re-plan')
+    expect(result).toContain('재계획')
   })
 
   it('returns compact active tooltip', () => {
     const result = flagTooltip('compact', true)
     expect(result).toContain('compact')
     expect(result).toContain('active')
-    expect(result).toContain('compaction')
+    expect(result).toContain('압축')
   })
 
   it('returns handoff active tooltip', () => {
     const result = flagTooltip('handoff', true)
     expect(result).toContain('handoff')
     expect(result).toContain('active')
-    expect(result).toContain('new trace/generation')
+    expect(result).toContain('trace/generation')
   })
 
   it('returns guardrail active tooltip', () => {
     const result = flagTooltip('guardrail', true)
     expect(result).toContain('guardrail')
     expect(result).toContain('active')
-    expect(result).toContain('guardrail has tripped')
+    expect(result).toContain('guardrail 발동됨')
   })
 
   // ── known flags with on=false ──
@@ -49,31 +49,31 @@ describe('flagTooltip', () => {
     const result = flagTooltip('reflect', false)
     expect(result).toContain('reflect')
     expect(result).toContain('inactive')
-    expect(result).toContain('No reflection pending')
+    expect(result).toContain('예약된 reflection 없음')
   })
 
   it('returns plan inactive tooltip', () => {
     const result = flagTooltip('plan', false)
     expect(result).toContain('inactive')
-    expect(result).toContain('No re-plan scheduled')
+    expect(result).toContain('예약된 재계획 없음')
   })
 
   it('returns compact inactive tooltip', () => {
     const result = flagTooltip('compact', false)
     expect(result).toContain('inactive')
-    expect(result).toContain('No compaction pending')
+    expect(result).toContain('예약된 압축 없음')
   })
 
   it('returns handoff inactive tooltip', () => {
     const result = flagTooltip('handoff', false)
     expect(result).toContain('inactive')
-    expect(result).toContain('No handoff scheduled')
+    expect(result).toContain('예약된 handoff 없음')
   })
 
   it('returns guardrail inactive tooltip', () => {
     const result = flagTooltip('guardrail', false)
     expect(result).toContain('inactive')
-    expect(result).toContain('No guardrail active')
+    expect(result).toContain('활성 guardrail 없음')
   })
 
   // ── unknown flag ──

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -538,14 +538,14 @@ describe('flagTooltip', () => {
   it('returns the off-description when the flag is inactive', () => {
     const tip = flagTooltip('reflect', false)
     expect(tip).toContain('reflect (inactive)')
-    expect(tip).toMatch(/no reflection pending/i)
+    expect(tip).toMatch(/예약된 reflection 없음/)
   })
 
   it('swaps description for guardrail based on state', () => {
     const on = flagTooltip('guardrail', true)
     const off = flagTooltip('guardrail', false)
-    expect(on).toMatch(/tripped|halt/i)
-    expect(off).toMatch(/no guardrail active|safety envelope/i)
+    expect(on).toMatch(/발동됨/)
+    expect(off).toMatch(/활성 guardrail 없음/)
   })
 
   it('falls back to a generic tooltip for unknown labels', () => {


### PR DESCRIPTION
## Summary
- `flagTooltip` descriptions were localized to Korean but test assertions still expected English substrings (`re-plan`, `compaction`, `No recent tools`, etc.)
- Updates `fsm-hub-health-panels.test.ts`, `fleet-telemetry-utils.test.ts`, `fleet-telemetry-panel.test.ts` to match actual Korean text

## Root Cause
i18n rounds changed `MEASUREMENT_FLAG_DESCRIPTIONS` to Korean, but the corresponding `toContain()` assertions were not updated, causing **all PRs** to fail Dashboard CI on main.

## Test plan
- [x] `fleet-telemetry-utils.test.ts` passes locally (pure function test, no DOM dependency)
- [ ] `fsm-hub-health-panels.test.ts` — needs CI (htm/preact import)
- [ ] `fleet-telemetry-panel.test.ts` — needs CI (htm/preact import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)