### PR TITLE
refactor(design-system): swap setup-guide-card step checkbox to Checkbox (PR-CS72)

### DIFF
--- a/dashboard/src/components/setup-guide-card.test.ts
+++ b/dashboard/src/components/setup-guide-card.test.ts
@@ -98,7 +98,7 @@ describe('SetupGuideCard', () => {
     const progress = container.querySelector('[data-setup-progress="discord"]')!
     expect(progress.textContent).toMatch(/\d+ steps/)
 
-    const firstCheckbox = container.querySelector('[data-setup-step="discord:0"]') as HTMLInputElement
+    const firstCheckbox = container.querySelector('[data-testid="setup-step-discord:0"]') as HTMLInputElement
     expect(firstCheckbox).toBeTruthy()
     firstCheckbox.click()
     await flushUi()
@@ -125,7 +125,7 @@ describe('SetupGuideCard', () => {
     render(html`<${SetupGuideCard} connectorId="discord" />`, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
     await flushUi()
-    const cb = container.querySelector('[data-setup-step="discord:0"]') as HTMLInputElement
+    const cb = container.querySelector('[data-testid="setup-step-discord:0"]') as HTMLInputElement
     cb.click()
     await flushUi()
 
@@ -157,7 +157,7 @@ describe('SetupGuideCard', () => {
     render(html`<${SetupGuideCard} connectorId="discord" />`, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
     await flushUi()
-    ;(container.querySelector('[data-setup-step="discord:0"]') as HTMLInputElement).click()
+    ;(container.querySelector('[data-testid="setup-step-discord:0"]') as HTMLInputElement).click()
     await flushUi()
     const firstCircle = container.querySelector('[data-setup-step-circle="discord:0"]') as HTMLElement
     expect(firstCircle.textContent).toBe('✓')
@@ -168,7 +168,7 @@ describe('SetupGuideCard', () => {
     render(html`<${SetupGuideCard} connectorId="discord" />`, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
     await flushUi()
-    const checkboxes = Array.from(container.querySelectorAll('[data-setup-step^="discord:"]')) as HTMLInputElement[]
+    const checkboxes = Array.from(container.querySelectorAll('[data-testid^="setup-step-discord:"]')) as HTMLInputElement[]
     for (const cb of checkboxes) {
       cb.click()
       await flushUi()
@@ -186,7 +186,7 @@ describe('SetupGuideCard', () => {
     render(html`<${SetupGuideCard} connectorId="slack" />`, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
     await flushUi()
-    const box = container.querySelector('[data-setup-step="slack:0"]') as HTMLInputElement
+    const box = container.querySelector('[data-testid="setup-step-slack:0"]') as HTMLInputElement
     box.click()
     await flushUi()
     expect(container.querySelector('[data-setup-progress="slack"]')!.textContent).toMatch(/1 of \d+ done/)
@@ -200,7 +200,7 @@ describe('SetupGuideCard', () => {
     render(html`<${SetupGuideCard} connectorId="discord" />`, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
     await flushUi()
-    ;(container.querySelector('[data-setup-step="discord:0"]') as HTMLInputElement).click()
+    ;(container.querySelector('[data-testid="setup-step-discord:0"]') as HTMLInputElement).click()
     await flushUi()
 
     // Switch to Telegram — header should still say "N steps" (not "X of N done")

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -5,6 +5,7 @@
 import { html } from 'htm/preact'
 import { ChevronRight, ExternalLink } from 'lucide-preact'
 import { signal } from '@preact/signals'
+import { Checkbox } from './common/checkbox'
 import { CONNECTOR_SETUP_GUIDES } from './connector-setup-guides'
 
 // Per-connector expand state — keyed so jumping between bridge sub-sections
@@ -186,17 +187,16 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
                         aria-hidden="true"
                         data-setup-step-circle=${`${connectorId}:${idx}`}
                       >${done ? '✓' : idx + 1}</span>
-                      <input
-                        type="checkbox"
-                        class="mt-[5px] shrink-0 cursor-pointer accent-emerald-400"
+                      <${Checkbox}
+                        class="mt-[5px] shrink-0 !accent-emerald-400"
                         id=${`setup-step-${connectorId}-${idx}`}
-                        data-setup-step=${`${connectorId}:${idx}`}
+                        testId=${`setup-step-${connectorId}:${idx}`}
                         checked=${done}
+                        ariaLabel=${`step ${idx + 1} done`}
                         onClick=${(ev: Event) => {
                           ev.stopPropagation()
                           toggleStepCompletion(connectorId, idx)
                         }}
-                        aria-label=${`step ${idx + 1} done`}
                       />
                       <label
                         for=${`setup-step-${connectorId}-${idx}`}


### PR DESCRIPTION
## Summary

CS series sweep. setup-guide-card의 step completion checkbox를 raw `<input type=\"checkbox\">`에서 Checkbox component로 swap. **CS64의 `onClick` prop 확장 덕분에 stopPropagation 패턴 보존 가능** (이전 turn에서 SKIP된 케이스).

## 변경

### `dashboard/src/components/setup-guide-card.ts`
- `import { Checkbox } from './common/checkbox'` 추가
- Step completion checkbox (line 190): `<input type=\"checkbox\">` → `<${Checkbox}>`
- 제거된 inline class:
  - `cursor-pointer` (CHECKBOX_BASE 상속)
- 유지된 override:
  - `mt-[5px] shrink-0` (layout)
  - `!accent-emerald-400` (CHECKBOX_BASE의 `accent-[var(--color-accent-fg)]` override — 완료 상태 녹색 ✓ semantic 보존)
- API 변환:
  - `data-setup-step=${...}` → `testId=${...}`
  - `aria-label` → `ariaLabel`
  - `id`, `checked`, `onClick` 그대로 — Checkbox forward
- `onClick`의 `event.stopPropagation()` 패턴 보존 (CS64 onClick 확장 덕분)

### `dashboard/src/components/setup-guide-card.test.ts` — 5건 selector + 1건 prefix match
- `[data-setup-step=\"discord:0\"]` (4건) → `[data-testid=\"setup-step-discord:0\"]`
- `[data-setup-step=\"slack:0\"]` (1건) → `[data-testid=\"setup-step-slack:0\"]`
- `[data-setup-step^=\"discord:\"]` (prefix-match) → `[data-testid^=\"setup-step-discord:\"]`

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/setup-guide`: 30/30 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)