### PR TITLE
i18n(dashboard): localize 2 empty state strings (round-68)

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -489,7 +489,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
 
 function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] }) {
   if (sources.length === 0) {
-    return html`<div class="text-2xs text-[var(--color-fg-disabled)]">Telemetry store summary is unavailable.</div>`
+    return html`<div class="text-2xs text-[var(--color-fg-disabled)]">Telemetry store 요약 사용 불가.</div>`
   }
 
   const sorted = [...sources].sort((a, b) => b.entry_count - a.entry_count)

--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -610,7 +610,7 @@ export function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
                 })}
               </div>
             `
-            : html`<div class="text-2xs text-[var(--color-fg-muted)]">No recorded handoff entries yet.</div>`}
+            : html`<div class="text-2xs text-[var(--color-fg-muted)]">기록된 핸드오프 항목이 아직 없습니다.</div>`}
         </div>
 
         ${manifestPath || indexPath


### PR DESCRIPTION
## 변경 사항

- `keeper-detail-history.ts:613`: `'No recorded handoff entries yet.'` → `'기록된 핸드오프 항목이 아직 없습니다.'`
- `fleet-telemetry-panel.ts:492`: `'Telemetry store summary is unavailable.'` → `'Telemetry store 요약 사용 불가.'`

## Domain term 보존
- **Telemetry store** — 보존

## 영향 범위
2 files, 2 lines. Source-only. Test coupling 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)