### PR TITLE
fix(auth): surface error_kind + actor_hint in dashboard_actor_fallback warn

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -274,13 +274,36 @@ let dashboard_actor_for_request ~base_path request =
             ~labels:[ ("outcome", "none") ]
             ();
           request_actor_hint request
-      | Error _ ->
+      | Error err ->
+          (* The previous warn line elided the actual error string and the
+             request actor hint, leaving operators with a counter that only
+             told them *something* errored — not what.  Production logs
+             showed the warn firing 1–2 times/second with no diagnostic
+             surface, so the WARN was loud noise without root-cause
+             attribution.  Surface both the error class and the hint. *)
+          let err_str = Types.masc_error_to_string err in
+          let hint =
+            match request_actor_hint request with
+            | Some s -> s
+            | None -> "<none>"
+          in
+          let err_kind =
+            match err with
+            | Types.Unauthorized _ -> "unauthorized"
+            | Types.Forbidden _ -> "forbidden"
+            | Types.AgentNotFound _ -> "agent_not_found"
+            | Types.IoError _ -> "io_error"
+            | Types.InvalidJson _ -> "invalid_json"
+            | _ -> "other"
+          in
           Log.Auth.warn
-            "[silent:dashboard_actor_fallback] outcome=error - bearer token \
-             resolution errored, falling back to request actor hint";
+            "[silent:dashboard_actor_fallback] outcome=error \
+             err_kind=%s actor_hint=%s err=%s — falling back to request \
+             actor hint"
+            err_kind hint err_str;
           Prometheus.inc_counter
             Prometheus.metric_silent_dashboard_actor_fallback
-            ~labels:[ ("outcome", "error") ]
+            ~labels:[ ("outcome", "error"); ("err_kind", err_kind) ]
             ();
           request_actor_hint request)
   | None -> request_actor_hint request


### PR DESCRIPTION
## Why

Production fleet logs (2026-04-26 18:00 KST) show:

```
2026-04-26 18:00:47 WARN  Auth  [silent:dashboard_actor_fallback] outcome=error - bearer token resolution errored, falling back to request actor hint
2026-04-26 18:00:47 WARN  Auth  [silent:dashboard_actor_fallback] outcome=error - bearer token resolution errored, falling back to request actor hint
2026-04-26 17:58:48 WARN  Auth  [silent:dashboard_actor_fallback] outcome=error - bearer token resolution errored, falling back to request actor hint
... (paired, every 1-2s, identical message) ...
```

The current warn surfaces the *fact* of error but **not which error** — `match Auth.resolve_agent_from_token ... with Error _ ->` discards the variant. The counter gains an `outcome=error` label but no class breakdown. Operators see "something is wrong with auth" with zero attribution surface.

This is the same anti-pattern as `feedback_no-collapse-richer-enum-at-sdk-boundary` — collapsing a structured `Types.masc_error` variant into a single opaque warn drops the only signal that could tell us whether the cause is `Unauthorized` (bad token), `AgentNotFound` (storage drift), `IoError` (DB blip), etc.

## What

`lib/server/server_auth.ml::dashboard_actor_for_request`, the `Error err` branch:

1. **Capture the error variant** as `err_kind` (`unauthorized` / `forbidden` / `agent_not_found` / `io_error` / `invalid_json` / `other`).
2. **Include the full `err_str` from `Types.masc_error_to_string`** in the WARN line.
3. **Include the request `actor_hint`** so we know which dashboard caller is failing.
4. **Add `err_kind` label to the Prometheus counter** so PromQL splits error families.

## What this PR does NOT do

- Does not change behavior. The fallback to `request_actor_hint` still happens for every error.
- Does not fix the underlying token resolution failure — that's Phase 2 once we see the actual `err_kind` distribution in production.

## Risk

Very low. Pure logging/labels addition. The hot path now does one extra `match err with ...` and one extra string interpolation per failed resolution. The error path was already taking a Prometheus increment + Log.Auth.warn — adding a few bytes is negligible.

## Verification

- [x] `dune build lib/server` clean
- After deploy: PromQL `sum by (err_kind) (rate(masc_silent_dashboard_actor_fallback_total{outcome="error"}[5m]))` should show distribution.

## Layer boundary

Pure observability. The WARN and counter were already there — this just plumbs the error variant through. No state machine changes, no new persistence, no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
