### PR TITLE
i18n(dashboard): localize 2 inline labels (round-69)

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -214,7 +214,7 @@ function AttentionEventList({ events }: { events: DashboardAttentionEvent[] }) {
               : null}
           </div>
           ${event.recommended_action
-            ? html`<div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">Next: ${event.recommended_action}</div>`
+            ? html`<div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">다음: ${event.recommended_action}</div>`
             : null}
         </div>
       `)}

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -508,7 +508,7 @@ export function MemorySubsystems() {
   const { loading, error, data } = state.value
   if (loading && !data) return html`<${LoadingState} label="기억 서브시스템 로드 중..." />`
   if (error && !data)
-    return html`<div class="p-4 text-[var(--bad-light)]">Error: ${error}</div>`
+    return html`<div class="p-4 text-[var(--bad-light)]">오류: ${error}</div>`
 
   const synapses = data?.hebbian?.synapses ?? []
   const lastConsolidation = data?.hebbian?.last_consolidation ?? 0


### PR DESCRIPTION
## 변경 사항
- `memory-subsystems.ts:511`: `'Error: ${error}'` → `'오류: ${error}'`
- `fleet-telemetry-panel.ts:217`: `'Next: ${event.recommended_action}'` → `'다음: ${event.recommended_action}'`

## 영향 범위
2 files, 2 lines. Source-only. Test coupling 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)