### PR TITLE
i18n(dashboard): localize cascade-config save/preview labels (round-70)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.test.ts
+++ b/dashboard/src/components/cascade-config-panel.test.ts
@@ -207,8 +207,8 @@ describe('rawConfigModeSummary', () => {
     expect(summary.primary).toContain('/tmp/config/cascade.toml')
     expect(summary.primary).toContain('cascade.toml SSOT')
     expect(summary.secondary).toContain('/tmp/config/cascade.json')
-    expect(summary.saveLabel).toBe('Save cascade.toml')
-    expect(summary.previewTitle).toBe('Generated cascade.json Preview')
+    expect(summary.saveLabel).toBe('cascade.toml 저장')
+    expect(summary.previewTitle).toBe('생성된 cascade.json 미리보기')
   })
 
   it('keeps JSON mode editable', () => {

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -158,8 +158,8 @@ export function rawConfigModeSummary(
       '저장 시 TOML parse 검증 뒤 generated runtime JSON을 다시 materialize 합니다.',
     secondary:
       `아래 preview는 ${jsonPath} 에 기록되는 generated cascade.json runtime artifact 입니다.`,
-    saveLabel: 'Save cascade.toml',
-    previewTitle: 'Generated cascade.json Preview',
+    saveLabel: 'cascade.toml 저장',
+    previewTitle: '생성된 cascade.json 미리보기',
   }
 }
 


### PR DESCRIPTION
## 변경 사항

`cascade-config-panel.ts:161-162`:
- `'Save cascade.toml'` → `'cascade.toml 저장'`
- `'Generated cascade.json Preview'` → `'생성된 cascade.json 미리보기'`

`cascade-config-panel.test.ts:210-211`: assertion sync (atomic test sync)

## Domain term 보존
- **cascade.toml** / **cascade.json** — 도메인 파일명 보존

## 영향 범위
2 files (source + test), 4 lines. `toBe` strict equality test → atomic sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)