### PR TITLE
refactor(design-system): swap retry button + channel pick chip to ActionButton ghost (PR-CS73)

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1203,15 +1203,16 @@ function ConnectorLivePanel({
                                           ${observedRooms.slice(0, 8).map(roomId => {
                                             const humanized = humanizeChannel(names, roomId)
                                             return html`
-                                              <button
-                                                type="button"
-                                                class="cursor-pointer rounded-sm border border-[var(--color-border-default)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--color-fg-primary)] hover:bg-[var(--white-8)]"
+                                              <${ActionButton}
+                                                variant="ghost"
+                                                size="sm"
+                                                class="!rounded-sm !py-0.5"
                                                 title=${roomId}
-                                                aria-label=${humanized ? `select ${humanized}` : `select ${truncateMiddle(roomId, 22)}`}
+                                                ariaLabel=${humanized ? `select ${humanized}` : `select ${truncateMiddle(roomId, 22)}`}
                                                 onClick=${() => { patchConnectorUiState(connectorId, { channelDraft: roomId }) }}
                                               >${humanized
                                                 ? html`<span>${humanized}</span><span class="ml-1 text-[var(--color-fg-disabled)]">· ${truncateMiddle(roomId, 10)}</span>`
-                                                : truncateMiddle(roomId, 22)}</button>
+                                                : truncateMiddle(roomId, 22)}<//>
                                             `
                                           })}
                                         </div>

--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -182,11 +182,12 @@ export function KeeperCheckpointPanel({
     return html`
       <div class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-3 text-xs text-[#fda4af]">
         ${error}
-        <button
-          type="button"
-          class="ml-2 rounded border border-[var(--color-border-default)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] hover:bg-[var(--white-8)] cursor-pointer"
+        <${ActionButton}
+          variant="ghost"
+          size="md"
+          class="ml-2 !px-2 !py-1"
           onClick=${loadInventory}
-        >다시 로드</button>
+        >다시 로드<//>
       </div>
     `
   }


### PR DESCRIPTION
## Summary

CS series sweep. 두 ghost-pattern button — error retry + channel pick chip — 을 ActionButton ghost로 swap.

## 변경

### 1. `dashboard/src/components/keeper-detail-history.ts:185` — Error retry button
- `<button>` → `<${ActionButton} variant=\"ghost\" size=\"md\">`
- 제거된 inline class (모두 ghost + BASE 상속):
  - `border border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)] hover:bg-[var(--white-8)]` → ghost **exact**
  - `rounded`, `cursor-pointer` → BASE
- 유지된 override: `ml-2 !px-2 !py-1` (ml-2 layout, compact size)

### 2. `dashboard/src/components/connector-status.ts:1206` — Channel pick chip
- `<button>` → `<${ActionButton} variant=\"ghost\" size=\"sm\">`
- 제거된 inline class (모두 ghost sm + BASE 상속): same color combo
- 유지된 override:
  - `!rounded-sm` (chip-style 더 작은 radius)
  - `!py-0.5` (size sm `py-1` 대비 더 compact)
- `aria-label` → `ariaLabel`
- 자녀(span 2개): humanized + truncated roomId — ActionButton children slot 그대로
- `title` attr 보존 (ActionButton API 지원)

## a11y 영향

- Error retry: focus-visible ring + active:scale 추가
- Channel chip 리스트: keyboard navigation 시 각 chip focus 시각화 (이전엔 outline 없음)

## 검증

- `pnpm typecheck`: green
- `pnpm test src/components/keeper-detail-history src/components/connector-status`: 25/25 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)