### PR TITLE
fix(coord/config): memoize default_config — drop 1745 redundant Backend inits (#10919)

### DIFF
--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -337,7 +337,43 @@ let create_backend_eio ~sw cfg =
   let _ = sw in
   create_backend cfg
 
-let default_config base_path =
+(* #10919: per-call Backend init was producing 1745 inits / 2 days
+   (~83 inits per server lifetime against an expected 1) plus 3490
+   INFO log lines.  Hot callers — [Coord.default_config] from every
+   MCP tool dispatch, [tool_autoresearch_cycle] per cycle iteration,
+   [keeper_rollover] per rollover — were paying both filesystem
+   resolution and a fresh Backend handshake per invocation.
+
+   The returned [config] is an immutable record and the underlying
+   storage is already deduplicated upstream:
+
+   - [Backend.Memory.shared_instances] keys by base_path (line 685),
+     so two Memory backends for the same path were already pointing
+     at identical hashtable state — the wrapper [config] was the
+     duplicate.
+   - FileSystem backends are pointers to on-disk state; multiple
+     handles for the same directory share the underlying files.
+
+   Caching [config] keyed by the input [base_path] therefore avoids
+   1744 redundant inits without changing observable semantics.  Tests
+   that need a fresh config (e.g. resetting filesystem state between
+   cases) call [reset_default_config_cache] from outside this module
+   when needed. *)
+let default_config_cache : (string, config) Hashtbl.t = Hashtbl.create 4
+let default_config_cache_mutex = Mutex.create ()
+
+let with_default_config_cache_mutex f =
+  Mutex.lock default_config_cache_mutex;
+  Fun.protect ~finally:(fun () -> Mutex.unlock default_config_cache_mutex) f
+
+(** Drop the cached configs.  Intended for tests that need to force a
+    re-init (e.g. after relocating the on-disk state).  Production
+    code should never call this. *)
+let reset_default_config_cache () =
+  with_default_config_cache_mutex (fun () ->
+    Hashtbl.clear default_config_cache)
+
+let build_default_config base_path =
   (* Resolve to git root for worktree support - all worktrees share same .masc/ *)
   let resolved_path = resolve_masc_base_path base_path in
   sync_test_base_path_env resolved_path;
@@ -371,6 +407,15 @@ let default_config base_path =
     backend_config;
     backend;
   }
+
+let default_config base_path =
+  with_default_config_cache_mutex (fun () ->
+    match Hashtbl.find_opt default_config_cache base_path with
+    | Some cfg -> cfg
+    | None ->
+        let cfg = build_default_config base_path in
+        Hashtbl.replace default_config_cache base_path cfg;
+        cfg)
 
 (** Create config with Eio context.
     [on_backend_ready] is called after backend creation, allowing callers


### PR DESCRIPTION
## Why

Fleet log analysis (rolling 2 days, ~21 server restarts):

\`\`\`
1745 INFO MASC Backend: type=Backend_types.FileSystem
1745 INFO Backend initialized: FileSystem
\`\`\`

= **3490 INFO emissions**, ~83 inits per server lifetime against an expected 1. \`Coord.default_config\` was a per-call factory: every MCP tool dispatch, autoresearch cycle iteration, and keeper rollover paid filesystem path resolution + a fresh Backend handshake just to assemble an immutable \`config\` record.

## Root

The upstream storage was already deduplicated:

| Layer | Dedup mechanism |
|-------|-----------------|
| \`Backend.Memory.shared_instances\` | Hashtbl keyed by base_path (line 685) |
| \`Backend.FileSystem.t\` | Pointer to on-disk state, files shared by directory |
| \`Coord.default_config.t\` | **Was the duplicate** — wrapper rebuilt every call |

## Fix

Memoize \`default_config\` keyed by the input \`base_path\`.

- Cache: \`(string, config) Hashtbl.t\` + \`Mutex.t\` for thread safety (callers come from multiple fibers / domains).
- Hit path: O(1) hashtable lookup, **no logs**.
- Miss path: existing init body (extracted as \`build_default_config\`).
- \`reset_default_config_cache\` exposed for tests that need a forced re-init after relocating on-disk state. Production code should never call it.

\`default_config_eio\` left unchanged: it is called once at server startup (\`create_state_eio\` is the sole caller) and its \`on_backend_ready\` hook owns Board init — caching that path would skip Board init on hypothetical re-call without benefit.

## Behavior

| Metric | Before | After |
|--------|--------|-------|
| Inits / 2 days | 1745 | ~1 per base_path |
| INFO Backend lines | 3490 / 2d | 2 per (base_path × server lifetime) |
| Hot tool dispatch | Backend handshake | Hashtbl lookup |
| FD churn (#10745 contributor) | per-call | once |

## Test plan

- [x] \`dune build @check\` EXIT=0
- [ ] CI green
- [ ] Ready transition

1 file, 46 ins / 1 del.

## Memory

\`feedback_no-derived-tag-when-existing-identifier-suffices\` — \`Backend.Memory.get_or_create\` already declared the \"deduplicated by base_path\" semantic; this PR brings the \`config\` wrapper into alignment instead of re-inventing dedup at a higher layer.

## Refs

- #10919 (this issue)
- #10881 / #10908 (logging hygiene family — same noise reduction direction)
- #10745 (FD leak — Backend churn was a partial contributor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)