### PR TITLE
fix(post_verifier): add Korean filler phrases (#10882)

### DIFF
--- a/lib/post_verifier.ml
+++ b/lib/post_verifier.ml
@@ -119,10 +119,24 @@ let is_repetitive_tokens s =
 (** Filler phrases that indicate low-substance content.
     Removed Korean informal expressions (ㅋㅋ, ㅎㅎ, ㅠㅠ) — these are valid
     social communication in agent broadcasts, not filler. Penalizing them
-    via Thompson Sampling suppresses agent autonomy for legitimate expression. *)
+    via Thompson Sampling suppresses agent autonomy for legitimate expression.
+
+    #10882: the original list was English-only — masc-mcp keeper personas
+    output predominantly Korean, so 0 filler events fired across a 2-day
+    window even for genuine low-substance posts.  This biases Thompson
+    sampling Pass→[alpha boost] for Korean keepers regardless of actual
+    quality.  Add a small, conservative Korean filler set: only phrases
+    whose meaning is unambiguously "no content".  Deliberately exclude
+    common-but-ambiguous expressions ("확인 필요", "좀 봐주세요", "왜
+    이래요") that may appear in legitimate posts; promoting those would
+    swap a false-negative bias for a false-positive bias. *)
 let filler_phrases = [
+  (* English *)
   "nothing to say"; "no comment"; "test post";
   "hello world"; "asdf"; "qwerty"; "lorem ipsum";
+  (* Korean — limited to phrases that mean "nothing to say" / placeholder *)
+  "할 말 없음"; "할말 없음"; "내용 없음"; "그냥 테스트"; "테스트 메시지";
+  "tbd"; "n/a";
 ]
 
 let contains_filler s =


### PR DESCRIPTION
## 배경

#10882 — `lib/post_verifier.ml` 의 `contains_filler` 가 7개 영문 phrase substring match 만 사용. masc-mcp keeper persona 들이 주로 한국어 출력 → 2일 rolling window 에서 `filler/placeholder` Warn event **0건**.

Critical path 영향: `Post_verifier.Pass` → `Thompson_sampling` alpha boost. 한국어 keeper 가 substance 무관하게 quality credit 받아 routing posterior 왜곡.

## 변경

보수적 Korean filler set 추가. \"명확하게 no content 의미\" 만 등재:

```
"할 말 없음"; "할말 없음"; "내용 없음";
"그냥 테스트"; "테스트 메시지";
"tbd"; "n/a";
```

`String.lowercase_ascii` 가 한국어 byte 변경 안 함 → 한국어 substring match byte-level 정확.

## 의도적으로 제외

| Phrase | 제외 사유 |
|---|---|
| "확인 필요" | 정상적인 status 표현 (\"this needs review\") 으로 사용 가능 |
| "좀 봐주세요" | 정중한 부탁 표현 — legitimate request |
| "왜 이래요" | 디버깅/문의 표현 가능 |
| "ㅋㅋ", "ㅎㅎ", "ㅠㅠ" | 본문 주석 명시 — agent autonomy 보호 |

이슈 본문에서 candidate 로 든 위 phrase 들을 자동 등재하면 false-negative 편향을 false-positive 편향으로 교환만 함. 등재 기준은 \"phrase 자체로 substance 가 zero\".

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file, +15 / -1
- byte-level test: `String.sub` Korean substring 매치 정상 (bytes 변경 없음)

## 후속

- Toggle off + investigate (이슈 candidate #3): 0 events 가 dead path 인지 별도 확인 필요. 본 PR 후 Korean filler event 가 발화되기 시작하는지 모니터.
- Semantic embedding 기반 discriminator (#10882 candidate #2): hardcoded list 대체. 별도 RFC 필요.