### PR TITLE
fix(keeper-llm-bridge): surface bucket + inner exception on OAS cancellation (#10716)

### DIFF
--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -51,16 +51,40 @@ let run_with_timeout_and_fallback ~timeout_s fn =
       "keeper_llm_bridge: OAS execution timed out after %.1fs (budget=%.0fs; OAS context rollback only; external tool side effects are not reverted)"
       wall timeout_s;
     Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Timeout after %.1fs (budget=%.0fs)" wall timeout_s }))
-  | Eio.Cancel.Cancelled _ as exn ->
+  | Eio.Cancel.Cancelled inner_exn as exn ->
     (* TLA+: FiberHandlesCancellation -> Rollback context.
        Cancelled means a parent fiber (server shutdown, global stop) requested
        cancellation — NOT a timeout. Re-raise so the keeper exits immediately
-       instead of entering the retry loop. *)
+       instead of entering the retry loop.
+
+       #10716: bimodal distribution observed in production — 21 events in
+       [60, 300)s (short-tail, routine cancel: supervisor pause / cascade
+       rotation) plus 8 events ≥1800s (long-tail, LLM provider hung). Same
+       opaque message for both made root-cause attribution impossible.
+       Categorize wall duration into a discrete bucket and surface the
+       inner cancel exception so operators can split short_tail / mid_tail
+       / long_tail in PromQL and the inner reason ([Eio.Cancel.Cancel_hook]
+       payload, parent-fiber Cancelled, etc.) appears in the log. *)
     let bt = Printexc.get_raw_backtrace () in
     let wall = elapsed () in
+    let bucket =
+      if wall < 60.0 then "fast"
+      else if wall < 300.0 then "short_tail"
+      else if wall < 600.0 then "mid_tail"
+      else if wall < 1800.0 then "long_mid"
+      else "long_tail"
+    in
+    let inner_str =
+      match inner_exn with
+      | Failure msg -> "Failure(" ^ msg ^ ")"
+      | _ -> Printexc.to_string inner_exn
+    in
     Log.Keeper.warn
-      "keeper_llm_bridge: OAS execution cancelled after %.1fs (re-raising; OAS context rollback only; external tool side effects are not reverted)"
-      wall;
+      "keeper_llm_bridge: OAS execution cancelled after %.1fs bucket=%s inner=%s (re-raising; OAS context rollback only; external tool side effects are not reverted)"
+      wall bucket inner_str;
+    Prometheus.inc_counter "masc_keeper_oas_cancel_total"
+      ~labels:[ ("bucket", bucket) ]
+      ();
     Printexc.raise_with_backtrace exn bt
   | exn ->
     (* TLA+: HandleError -> Rollback context *)


### PR DESCRIPTION
Refs #10716.

## Why

Production fleet (24h on 2026-04-26) showed **35 events** of:

```
keeper_llm_bridge: OAS execution cancelled after Ns (re-raising; OAS context rollback only; external tool side effects are not reverted)
```

Bimodal duration distribution:

| bucket | events | likely cause |
|---|---|---|
| `[60s, 300s)` | 21 | routine cancel (supervisor pause, cascade rotation) |
| `[300s, 600s)` | 6 | mid-tail |
| `[1800s, ...)` | 8 | LLM provider hung past watchdog (up to 53 min) |

The current message elides:
1. **Wall duration class** — operators can't split `short_tail` (routine, expected) from `long_tail` (genuinely bad) without grepping individual durations.
2. **Inner exception** — `Eio.Cancel.Cancelled inner_exn` discards the actual cancel reason raised by the parent fiber.

Without these, root-cause attribution between *"supervisor paused us"* vs *"cascade rotated"* vs *"provider hung"* is impossible.

## What

`lib/keeper/keeper_llm_bridge.ml::run_with_timeout_and_fallback` cancel branch:

1. **Compute `bucket`** from wall time:
   - `fast` (<60s)
   - `short_tail` (<300s)
   - `mid_tail` (<600s)
   - `long_mid` (<1800s)
   - `long_tail` (≥1800s)

2. **Surface the inner exception** as `inner=...` in the WARN line.

3. **Add Prometheus counter** `masc_keeper_oas_cancel_total{bucket}` so PromQL can split the bimodal and confirm the two populations are independently steady-state.

## Layer boundary

Pure observability. Behavior is unchanged — `Printexc.raise_with_backtrace` still re-raises so the keeper exits immediately rather than looping. The `bucket` is derived purely from `wall` (deterministic), and the inner exception is read-only.

## Risk

Negligible. One additional `Printexc.to_string` per cancel (rare path, ~1.5/hour at observed rate) and one Prometheus increment.

## Verification

- [x] `dune build lib/keeper` clean
- After deploy: PromQL `sum by (bucket) (rate(masc_keeper_oas_cancel_total[5m]))` should split the population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
