### PR TITLE
fix(keeper-supervisor): promote universal SP suppression to ERROR (#10887)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -575,9 +575,28 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
       ) cohorts ("", [])
     in
     if List.length dominant_entries >= sp_min then begin
-      Log.Keeper.warn
-        "self-preservation: suppressing %d/%d restarts (ratio=%.2f, cohort=%s)"
-        (List.length dominant_entries) n_total ratio dominant_key;
+      (* #10887: when [ratio >= 0.99] every keeper in the candidate set
+         shares the same failure cohort and SP suppresses 100% of
+         restarts.  At that point the fleet has lost auto-recovery —
+         the next reconcile will re-detect the same condition and
+         re-suppress, indefinitely (125 events / 2 days observed,
+         ratio=1.00 in every event).  Promote that case to ERROR with
+         operator-actionable hint text so it stops blending into the
+         steady WARN stream of partial suppressions (which are normal
+         circuit-breaker behaviour).  Threshold uses 0.99 not 1.0 to
+         tolerate float rounding from the int division above. *)
+      if ratio >= 0.99 then
+        Log.Keeper.error
+          "self-preservation: UNIVERSAL suppression %d/%d (ratio=%.2f, \
+           cohort=%s) — auto-recovery is OFF until operator clears the \
+           shared failure mode (e.g. cascade.toml hot-reload, token \
+           rotation, or kill the dominant cohort to let SP release).  \
+           See #10887 / #10765."
+          (List.length dominant_entries) n_total ratio dominant_key
+      else
+        Log.Keeper.warn
+          "self-preservation: suppressing %d/%d restarts (ratio=%.2f, cohort=%s)"
+          (List.length dominant_entries) n_total ratio dominant_key;
       publish_lifecycle
         ~event:(Keeper_lifecycle_events.Custom_event
                   { verb = Keeper_lifecycle_events.Self_preservation;


### PR DESCRIPTION
## 배경

#10887 — \`apply_self_preservation\` 가 \`ratio=1.00, cohort=stale_turn_timeout\` 상태로 2일간 **125 events**, variation 0%. 모든 활성 keeper 가 동일 사유로 crash → SP 가 100% 억제 → 다음 reconcile 동일 조건 재감지 → 영구 lock.

문제: WARN \"suppressing N/M restarts\" 1줄로 partial suppression(circuit breaker 정상 동작) 과 universal suppression(auto-recovery off) 이 같은 surface 출력. operator dashboard 에서 차이 안 보임.

## 변경

`apply_self_preservation` 의 log 경로 분기:

| 조건 | 이전 | 이후 |
|---|---|---|
| `ratio < 0.99` | WARN | WARN (변경 없음, partial suppression = circuit breaker 정상) |
| `ratio >= 0.99` | WARN | **ERROR + actionable hint** |

ERROR 메시지 형식:
```
self-preservation: UNIVERSAL suppression N/M (ratio=1.00, cohort=stale_turn_timeout)
— auto-recovery is OFF until operator clears the shared failure mode
(e.g. cascade.toml hot-reload, token rotation, or kill the dominant
cohort to let SP release).  See #10887 / #10765.
```

threshold 0.99 (not 1.0) — int division `n_candidates /. n_total` 의 float rounding 흡수.

## 의도적으로 안 한 것

이슈 본문 candidates 중 다음은 본 PR scope 밖:
- **escape valve** (#1, medium): SP 발동 후 N분 경과 시 cohort 재평가 + 일부 restart 시도. State 추적 필요 → 별도 PR.
- **cohort-aware action** (#3, medium-large): cascade.toml hot-reload 자동 시도 등. governance integration 필요.
- **FSM Suppressed phase** (#4, large): keeper state machine 변경. ratchet-style 도입 필요.
- **dashboard UX** (#5): UI tier 별도.

본 PR 은 가장 작은 surface — log 격상만. ERROR alert 가 dashboard / pager 에 surface 되면 operator manual intervention 가속. 구조 fix 는 별도 follow-up.

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file, +22 / -3
- 두 분기 모두 동일 lifecycle event (`Self_preservation`) + crash_persistence enqueue 유지 — log level 만 분기.

## 관련

- #10887 (본 issue), #10765 (death-spiral 116 events / 14 keepers, 본 SP 의 root cause cohort)
- #10940 (방금 머지된 watchdog idle-stale 정정 — same family)