### PR TITLE
perf(dashboard): refcount the live-pulse 1 Hz ticker

### DIFF
--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -28,13 +28,37 @@ import { recordHeartbeat, useHeartbeatHistory, lastHeartbeatTickMs, rollingUptim
     "last 45 checks at 30s interval" visual rhythm. */
 const HEARTBEAT_SAMPLE_MS = 30_000
 
-/** Wall-clock tick for the live-pulse indicator — updates every second
-    so the dot can flip from live to stale without needing a prop change.
-    Kept module-scope so every StatusSummaryLine instance shares one
-    timer instead of N. */
+// Wall-clock tick for the live-pulse indicator — updates every second so
+// the dot can flip from live to stale without needing a prop change.
+// Kept module-scope so every StatusSummaryLine instance shares one timer
+// instead of N — but refcounted via `useLivePulseTicker`, so the
+// interval only runs while at least one StatusSummaryLine is mounted.
+// Previously the timer started at module-import time and never stopped,
+// firing 1 Hz even on views that never rendered the strip.
 const livePulseNowMs = signal<number>(Date.now())
-if (typeof window !== 'undefined') {
-  window.setInterval(() => { livePulseNowMs.value = Date.now() }, 1000)
+let livePulseTimer: number | null = null
+let livePulseSubscribers = 0
+
+function startLivePulseTicker(): void {
+  if (livePulseTimer != null || typeof window === 'undefined') return
+  livePulseTimer = window.setInterval(() => { livePulseNowMs.value = Date.now() }, 1000)
+}
+
+function stopLivePulseTicker(): void {
+  if (livePulseTimer == null || typeof window === 'undefined') return
+  window.clearInterval(livePulseTimer)
+  livePulseTimer = null
+}
+
+function useLivePulseTicker(): void {
+  useEffect(() => {
+    livePulseSubscribers += 1
+    startLivePulseTicker()
+    return () => {
+      livePulseSubscribers = Math.max(0, livePulseSubscribers - 1)
+      if (livePulseSubscribers === 0) stopLivePulseTicker()
+    }
+  }, [])
 }
 
 /** Pure: derive the heartbeat state for a connector from the gate info
@@ -632,6 +656,7 @@ function StatusSummaryLine({ summary, connectors }: { summary: ConnectorStripSum
   // One quiet aggregate sentence — always on, never loud. Sits between
   // the loud banners (celebration / incident) and the action row, so the
   // operator always has baseline numbers even when neither banner fires.
+  useLivePulseTicker()
   const now = livePulseNowMs.value
   const lastTick = lastHeartbeatTickMs.value
   const offlineLabel = formatOfflineConnectorLabel(offlineConnectorNames(connectors))


### PR DESCRIPTION
## Why

Cycle 8 of the iterative dashboard performance pass — sweeping the same refcount pattern (cycle 7 `useNowSecondsTicker`, `time-ago.ts`) across remaining always-on tickers.

`livePulseNowMs` in `connector-overview-strip.ts` started a **module-scope 1 Hz `setInterval` at import time** with no stop condition:

```ts
const livePulseNowMs = signal<number>(Date.now())
if (typeof window !== 'undefined') {
  window.setInterval(() => { livePulseNowMs.value = Date.now() }, 1000)
}
```

That fires **every second for the lifetime of the tab**, even on views that never render the connector strip (the strip only renders on `section=connector-status`).  Other ticker patterns in the dashboard already gate properly:

- `chat/primitives.ts:373` — only ticks while `streaming` is truthy
- `sidecar-startup-watch.ts:88` — only ticks while warning is `visible`
- `time-ago.ts` — refcounted to mounted `<TimeAgo />` instances
- `now-signal.ts` (cycle 7) — refcounted to `useNowSecondsTicker()` consumers

This PR brings `livePulseNowMs` into line.

## What

| File | Change |
|------|--------|
| `dashboard/src/components/connector-overview-strip.ts` | Wrap the 1 Hz timer in `useLivePulseTicker()`; call it from `StatusSummaryLine` (the sole reader at line 660) |

Net: 1 file, +31 -6.

## Effect

| | Before | After |
|---|--------|-------|
| 1 Hz timer when strip is rendered | yes | yes |
| 1 Hz timer when strip is not rendered (other dashboard sections) | **yes** (always-on) | **no** |
| Timer instances when strip is mounted | 1 (shared) | 1 (shared) |

No behavior change for the strip itself — `StatusSummaryLine` still subscribes via `livePulseNowMs.value` exactly as before.  Only the **idle case** (any non-connector section) is improved.

## Cycle position

- Cycle 1 (#10894 merged) — fsm-hub 1 Hz → 5 Hz tick
- Cycle 2 (#10897 merged) — opt-in bundle visualizer
- Cycle 3 (no PR) — vis-data manualChunks rejected on measurement
- Cycle 4 (#10907 merged) — sourcemap: 'hidden'
- Cycle 5 (#10914 merged) — fsm-hub pollTick deps cleanup
- Cycle 6 (#10916 merged) — server broadcast `target` label
- Cycle 7 (#10918 merged) — `nowSecondsSignal` + `useNowSecondsTicker` infra
- **Cycle 8 (this)** — refcount the live-pulse 1 Hz ticker

## Test plan

- [x] `pnpm run typecheck` succeeds
- [ ] After deploy, `section=connector-status` view still shows the live-pulse dot transitioning live → stale (manual)
- [ ] DevTools Performance recording on a non-strip view shows no 1 Hz signal-fire activity (manual)