### PR TITLE
docs(coord): add coord_task_id.mli (#10751 batch)

### DIFF
--- a/lib/coord/coord_task_id.mli
+++ b/lib/coord/coord_task_id.mli
@@ -1,0 +1,29 @@
+(** Coord_task_id — Task ID parsing and archive management.
+
+    Public surface for {!Coord_task_id.ml}.  Encapsulates the lock-protected
+    archive read/merge/write sequence so callers cannot bypass it.
+    See issue #10751 for the broader [coord/] [.mli] coverage push. *)
+
+open Types
+
+(** Parse a [task-N] identifier into its integer suffix.
+    Returns [None] when the string does not match the [task-N] form
+    (missing prefix, empty suffix, or non-integer suffix). *)
+val task_id_to_int : string -> int option
+
+(** Read every task id stored in [tasks-archive.json] under the
+    config's base path.  Returns an empty list when the archive
+    file does not exist. *)
+val read_archive_task_ids : Coord_utils_backend_setup.config -> int list
+
+(** Append [tasks] to [tasks-archive.json], deduplicating by task id.
+    The read/merge/write sequence is wrapped in [with_file_lock] so
+    concurrent callers cannot lose each other's archive entries.
+    No-op when [tasks] is empty. *)
+val append_archive_tasks :
+  Coord_utils_backend_setup.config -> task list -> unit
+
+(** Next task number = [max(existing backlog ids, archive ids) + 1].
+    Returns [1] when both backlog and archive are empty. *)
+val next_task_number :
+  Coord_utils_backend_setup.config -> backlog -> int


### PR DESCRIPTION
## 배경

#10751 — \`lib/coord/\` .mli 커버리지 33% (.ml 30개, .mli 10개). improvement-guide PR-2 (P0) 가 .mli 일괄 추가를 요청. 본 PR 은 missing 7 모듈 중 가장 작은 \`coord_task_id\` (77 lines, 4 public fn) 를 단발로 처리.

## 변경

`lib/coord/coord_task_id.mli` 신규 — 4 public function 시그니처 노출:

| Function | Signature | 비고 |
|---|---|---|
| `task_id_to_int` | `string -> int option` | `task-N` 파싱 |
| `read_archive_task_ids` | `config -> int list` | 아카이브 ID 읽기 |
| `append_archive_tasks` | `config -> task list -> unit` | lock-protected merge |
| `next_task_number` | `config -> backlog -> int` | max+1 |

내부 helper (read_json/write_json from `Coord_utils`, with_file_lock invocation) 는 `.mli` 비포함 — encapsulation 유지. `Coord_utils.archive_path` 등 helper 는 그대로 `Coord_utils` surface 로 남음.

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file (new), +29 lines
- 회귀 0: 호출자 코드 미변경

## 후속 (남은 missing 6)

같은 batch 패턴으로 별도 PR:
- `coord_gc.mli` (434 lines)
- `coord_worktree.mli` (997 lines, B3 batch)
- `coord_utils.mli` (B4 batch — utility 광범위 사용 별도 처리)
- `coord_utils_backend_setup.mli`
- `coord_utils_ops.mli`
- `coord_utils_paths_backend.mli`
- `coord_git.mli`

본 PR 의 `.mli` 패턴 (file header / val signatures / encapsulated internals) 을 templated 으로 재사용.