### PR TITLE
i18n(dashboard): localize lineageVerdictMeta 4 verdicts (round-76)

### DIFF
--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -392,23 +392,23 @@ export function lineageVerdictMeta(verdict: string | undefined): LineageVerdictM
   switch (verdict) {
     case 'verified':
       return {
-        badgeLabel: 'state preserved',
-        detail: 'Continuity checks whether the keeper goal, instructions, and saved state summary carried across the handoff.',
+        badgeLabel: '상태 보존',
+        detail: 'keeper 목표, 지침, 저장된 상태 요약이 핸드오프를 통해 전달됐는지 continuity 가 검사합니다.',
       }
     case 'drift_detected':
       return {
-        badgeLabel: 'review drift',
-        detail: 'The handoff completed, but the saved continuity summary changed enough that an operator should review it.',
+        badgeLabel: '드리프트 검토',
+        detail: '핸드오프는 완료됐지만 저장된 continuity 요약이 충분히 변경되어 operator 의 검토가 필요합니다.',
       }
     case 'unavailable':
       return {
-        badgeLabel: 'needs evidence',
-        detail: 'The handoff completed, but there was not enough saved continuity data to compare generations.',
+        badgeLabel: '증거 필요',
+        detail: '핸드오프는 완료됐지만 generation 비교에 필요한 continuity 데이터가 충분하지 않습니다.',
       }
     default:
       return {
-        badgeLabel: 'unknown',
-        detail: 'A continuity signal exists, but this verdict is not yet mapped to an operator-facing explanation.',
+        badgeLabel: '알 수 없음',
+        detail: 'continuity 신호는 존재하지만 본 판정이 아직 operator-facing 설명에 매핑되지 않았습니다.',
       }
   }
 }

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -246,22 +246,22 @@ describe('filterCheckpointHistory', () => {
 describe('lineageVerdictMeta', () => {
   it('maps verified to an operator-facing preserved-state explanation', () => {
     expect(lineageVerdictMeta('verified')).toEqual({
-      badgeLabel: 'state preserved',
-      detail: 'Continuity checks whether the keeper goal, instructions, and saved state summary carried across the handoff.',
+      badgeLabel: '상태 보존',
+      detail: 'keeper 목표, 지침, 저장된 상태 요약이 핸드오프를 통해 전달됐는지 continuity 가 검사합니다.',
     })
   })
 
   it('maps drift_detected to a review-oriented explanation', () => {
     expect(lineageVerdictMeta('drift_detected')).toEqual({
-      badgeLabel: 'review drift',
-      detail: 'The handoff completed, but the saved continuity summary changed enough that an operator should review it.',
+      badgeLabel: '드리프트 검토',
+      detail: '핸드오프는 완료됐지만 저장된 continuity 요약이 충분히 변경되어 operator 의 검토가 필요합니다.',
     })
   })
 
   it('falls back to unknown for unmapped verdicts', () => {
     expect(lineageVerdictMeta('mystery')).toEqual({
-      badgeLabel: 'unknown',
-      detail: 'A continuity signal exists, but this verdict is not yet mapped to an operator-facing explanation.',
+      badgeLabel: '알 수 없음',
+      detail: 'continuity 신호는 존재하지만 본 판정이 아직 operator-facing 설명에 매핑되지 않았습니다.',
     })
   })
 })


### PR DESCRIPTION
## 변경 사항

### Source: `keeper-detail-history.ts:393-412`
4 verdict cases × 2 fields = 8 strings 한국어화:
| Verdict | badgeLabel | detail (요약) |
|---|---|---|
| verified | 상태 보존 | continuity 검사 설명 |
| drift_detected | 드리프트 검토 | review 필요 설명 |
| unavailable | 증거 필요 | generation 비교 데이터 부족 |
| default | 알 수 없음 | mapping 부재 |

### Test: `keeper-detail.test.ts:248-265`
3 verdict 의 `toEqual` deep equality 동기 sync (6 strings)

## Domain term 보존
continuity / generation / operator / operator-facing — keeper 도메인 보존

## 영향 범위
2 files (source + test), 14 lines. `toEqual` strict equality 패턴 → atomic test sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)