### PR TITLE
refactor(design-system): add ActionButton ok variant + migrate Start/Stop All (PR-CS74)

### DIFF
--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -12,7 +12,7 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'subtle'
+type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'subtle' | 'ok'
 type ButtonSize = 'sm' | 'md' | 'lg'
 type ButtonType = 'button' | 'submit' | 'reset'
 
@@ -27,6 +27,7 @@ const VARIANT_CLASSES: Record<ButtonVariant, string> = {
   ghost: 'border border-solid border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)] hover:bg-[var(--white-8)]',
   danger: 'border border-solid border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-20)]',
   subtle: 'border-none bg-transparent text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] hover:bg-[var(--white-6)]',
+  ok: 'border border-solid border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)] hover:bg-[var(--ok-20)]',
 }
 
 // Pressed-state overrides per variant. Applied when `pressed=true` so the
@@ -39,6 +40,7 @@ const PRESSED_CLASSES: Record<ButtonVariant, string> = {
   ghost: 'bg-[var(--accent-12)] border-[var(--accent-30)] text-[var(--color-fg-secondary)]',
   danger: 'bg-[var(--bad-20)]',
   subtle: 'bg-[var(--white-6)] text-[var(--color-fg-primary)]',
+  ok: 'bg-[var(--ok-20)]',
 }
 
 const BASE = 'rounded cursor-pointer transition-all duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] active:scale-[0.97] active:opacity-90'

--- a/dashboard/src/components/connector-onboarding.test.ts
+++ b/dashboard/src/components/connector-onboarding.test.ts
@@ -68,7 +68,7 @@ describe('ConnectorOnboardingGrid', () => {
 
   it('includes bulk Start All action for cold-start spawn of all 4 at once', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
-    const startAll = container.querySelector('[data-bulk-action="start"]') as HTMLButtonElement
+    const startAll = container.querySelector('[data-testid="bulk-action-start"]') as HTMLButtonElement
     expect(startAll).toBeTruthy()
     // With zero registered connectors, all 4 count as "down".
     expect(startAll.textContent).toContain('(4)')

--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -84,8 +84,8 @@ describe('ConnectorOverviewStrip', () => {
       />`,
       container,
     )
-    const startBtn = container.querySelector('[data-bulk-action="start"]') as HTMLButtonElement
-    const stopBtn = container.querySelector('[data-bulk-action="stop"]') as HTMLButtonElement
+    const startBtn = container.querySelector('[data-testid="bulk-action-start"]') as HTMLButtonElement
+    const stopBtn = container.querySelector('[data-testid="bulk-action-stop"]') as HTMLButtonElement
     // 2 of 4 are up → 2 down → Start All shows (2). 2 up → Stop All (2).
     expect(startBtn.textContent).toContain('(2)')
     expect(stopBtn.textContent).toContain('(2)')
@@ -100,7 +100,7 @@ describe('ConnectorOverviewStrip', () => {
       html`<${ConnectorOverviewStrip} connectors=${allUp} keeperCount=${0} />`,
       container,
     )
-    const startBtn = container.querySelector('[data-bulk-action="start"]') as HTMLButtonElement
+    const startBtn = container.querySelector('[data-testid="bulk-action-start"]') as HTMLButtonElement
     expect(startBtn.disabled).toBe(true)
     expect(startBtn.title).toContain('이미 실행')
   })
@@ -111,7 +111,7 @@ describe('ConnectorOverviewStrip', () => {
       html`<${ConnectorOverviewStrip} connectors=${[]} keeperCount=${0} />`,
       container,
     )
-    const stopBtn = container.querySelector('[data-bulk-action="stop"]') as HTMLButtonElement
+    const stopBtn = container.querySelector('[data-testid="bulk-action-stop"]') as HTMLButtonElement
     expect(stopBtn.disabled).toBe(true)
     expect(stopBtn.title).toContain('실행 중인 sidecar 없음')
   })

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -16,6 +16,7 @@ import { ConnectorReadinessRail, deriveRail, getRailInflight, withRailInflight }
 import { CONNECTOR_DISPLAY_NAMES, KNOWN_CONNECTOR_IDS, channelIcon, connectorAccentStyle, connectorStateLabel, startSidecar, stopSidecar, type KnownConnectorId } from './connector-status'
 import { openConnectorConfig } from './connector-config-form'
 import { formatElapsedCompact } from '../lib/format-time'
+import { ActionButton } from './common/button'
 import { HeartbeatStrip } from './common/heartbeat-strip'
 import { HeartbeatStreakChip } from './common/heartbeat-streak-chip'
 import { HeartbeatUptimeChip } from './common/heartbeat-uptime-chip'
@@ -523,28 +524,30 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
   const stopBusy = bulkInflight.value.stop
   return html`
     <div class="flex items-center gap-2 text-2xs text-[var(--color-fg-disabled)]">
-      <button
-        type="button"
-        class="cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-2 py-1 text-2xs text-[var(--color-status-ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-40"
+      <${ActionButton}
+        variant="ok"
+        size="sm"
         disabled=${startBusy || downCount === 0}
         title=${downCount === 0 ? '모두 이미 실행 중' : `${downCount} 개 sidecar 시작`}
-        aria-label=${`모든 sidecar 시작 (${downCount}개)`}
+        ariaLabel=${`모든 sidecar 시작 (${downCount}개)`}
+        ariaBusy=${startBusy}
+        testId="bulk-action-start"
         onClick=${() => { void runBulk('start', c => c?.available !== true, connectors) }}
-        data-bulk-action="start"
       >
         ${startBusy ? '시작 중...' : `▶ Start All (${downCount})`}
-      </button>
-      <button
-        type="button"
-        class="cursor-pointer rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-2xs text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:cursor-not-allowed disabled:opacity-40"
+      <//>
+      <${ActionButton}
+        variant="danger"
+        size="sm"
         disabled=${stopBusy || upCount === 0}
         title=${upCount === 0 ? '실행 중인 sidecar 없음' : `${upCount} 개 sidecar 정지`}
-        aria-label=${`모든 sidecar 정지 (${upCount}개)`}
+        ariaLabel=${`모든 sidecar 정지 (${upCount}개)`}
+        ariaBusy=${stopBusy}
+        testId="bulk-action-stop"
         onClick=${() => { void runBulk('stop', c => c?.available === true, connectors) }}
-        data-bulk-action="stop"
       >
         ${stopBusy ? '정지 중...' : `■ Stop All (${upCount})`}
-      </button>
+      <//>
     </div>
   `
 }


### PR DESCRIPTION
## 요약
- ActionButton에 success-tone `ok` variant 추가 (총 5 variant: primary/ghost/danger/subtle/ok).
- connector-overview-strip의 bulk Start All → ok, Stop All → danger 즉시 마이그레이션해 variant 실작동 검증.

## Why
ok-tone 인라인 버튼은 dashboard에 10+ 파일에서 사용 중(`keeper-shared`, `setup-guide-card`, `observatory` 등). 기존 4 variant로는 success 의도 표현 불가 → 후속 PR-CS migration 차단 상태. 이번 cycle 검사한 36+ inline buttons에서 clean 후보가 0건이었던 주된 원인 1/3.

## Tokens
- `ok`: `border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)] hover:bg-[var(--ok-20)]`
- `pressed.ok`: `bg-[var(--ok-20)]` (다른 variant 패턴 일치)

## Migrated
- `connector-overview-strip.ts:526` Start All → `variant=\"ok\" size=\"sm\"`
- `connector-overview-strip.ts:538` Stop All → `variant=\"danger\" size=\"sm\"`
- 기존 `hover:bg-[var(--ok-10)]` (no-op) → ActionButton hover-darken (개선)
- `data-bulk-action` attr → `testId=\"bulk-action-{start,stop}\"` (data-testid 자동 렌더)

## Test
- vitest 91/91 그린 (button.test 25 + connector-overview-strip 66)
- pnpm typecheck pass
- selector 업데이트: `[data-bulk-action=\"...\"]` → `[data-testid=\"bulk-action-...\"]` (5 callsite)

## 후속 후보 (별도 PR)
- `keeper-shared.ts:404` activeGhostBtn → ok variant 적용
- `setup-guide-card.ts` ok-tone 버튼 발굴
- ActionButton에 `warn` variant 추가 후 keeper-shared.ts secondaryBtn 마이그레이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)