### PR TITLE
feat(masc_oas_bridge): cancel reason bucket + inner exception (mirrors #10942)

### DIFF
--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -16,10 +16,25 @@
     accepts a typed caller and pulls the configured budget from
     [Env_config_oas_bridge]. *)
 let run_safe ?(caller = "unknown") ~timeout_s fn =
-  let do_timeout fn =
+  let clock_opt =
     match Masc_eio_env.get_opt () with
-    | Some { clock = Some clock; _ } -> Eio.Time.with_timeout_exn clock timeout_s fn
-    | Some { clock = None; _ } | None -> fn ()
+    | Some { clock; _ } -> clock
+    | None -> None
+  in
+  let t0 =
+    match clock_opt with
+    | Some clock -> Eio.Time.now clock
+    | None -> Unix.gettimeofday ()
+  in
+  let elapsed () =
+    match clock_opt with
+    | Some clock -> Eio.Time.now clock -. t0
+    | None -> Unix.gettimeofday () -. t0
+  in
+  let do_timeout fn =
+    match clock_opt with
+    | Some clock -> Eio.Time.with_timeout_exn clock timeout_s fn
+    | None -> fn ()
   in
   try
     do_timeout fn
@@ -40,9 +55,37 @@ let run_safe ?(caller = "unknown") ~timeout_s fn =
       "masc_oas_bridge: OAS execution timed out after %.1fs (caller=%s)"
       timeout_s caller;
     Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Execution timed out after %.1fs" timeout_s }))
-  | Eio.Cancel.Cancelled _ as exn ->
+  | Eio.Cancel.Cancelled inner_exn as exn ->
+    (* Mirror of #10942 (keeper_llm_bridge) for masc_oas_bridge: same opaque
+       cancel message ate both wall-duration class and the inner cancel reason.
+       Bucket boundaries are kept identical so PromQL can union the two
+       sources into one bimodal view (fast/short_tail/mid_tail/long_mid/
+       long_tail). [inner=...] surfaces the parent fiber's exception payload
+       so [Eio.Cancel.Cancel_hook] vs supervisor-pause vs cascade-rotation
+       can be told apart at the WARN line. *)
     let bt = Printexc.get_raw_backtrace () in
-    Log.Misc.warn "masc_oas_bridge: OAS execution cancelled (caller=%s)" caller;
+    let wall = elapsed () in
+    let bucket =
+      if wall < 60.0 then "fast"
+      else if wall < 300.0 then "short_tail"
+      else if wall < 600.0 then "mid_tail"
+      else if wall < 1800.0 then "long_mid"
+      else "long_tail"
+    in
+    let inner_str =
+      match inner_exn with
+      | Failure msg -> "Failure(" ^ msg ^ ")"
+      | _ -> Printexc.to_string inner_exn
+    in
+    Prometheus.inc_counter
+      Prometheus.metric_oas_bridge_cancel
+      ~labels:[
+        ("caller", caller);
+        ("bucket", bucket);
+      ] ();
+    Log.Misc.warn
+      "masc_oas_bridge: OAS execution cancelled caller=%s wall=%.1fs bucket=%s inner=%s (re-raising)"
+      caller wall bucket inner_str;
     Printexc.raise_with_backtrace exn bt
   | exn ->
     let bt = Printexc.get_backtrace () in

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -461,6 +461,15 @@ let metric_telemetry_coverage_gap =
 let metric_oas_bridge_timeout =
   "masc_oas_bridge_timeout_total"
 
+(* #10942 mirror for masc_oas_bridge cancel branch.  Same bucket
+   semantics as [masc_keeper_oas_cancel_total] (fast/short_tail/
+   mid_tail/long_mid/long_tail) so PromQL can union the two
+   sources by [bucket] for a fleet-wide bimodal view of cancels.
+   [caller] preserves the timeout-counter pairing so each caller's
+   timeout vs cancel populations stay separable. *)
+let metric_oas_bridge_cancel =
+  "masc_oas_bridge_cancel_total"
+
 
 (* OAS event relay (oas_event_bridge.ml).  Metric strings keep the
    historical [oas_sse_*] prefix for Grafana/alert continuity; renaming

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -189,6 +189,12 @@ val metric_oas_bridge_timeout : string
 (** #10094: labelled [caller, timeout_s] so operators can
     distinguish fantasy 60s budgets from intentional 120/180s
     budgets when both fire timeouts in the same session. *)
+val metric_oas_bridge_cancel : string
+(** #10942 mirror for [masc_oas_bridge].  Labelled [caller, bucket]
+    where bucket is wall-class (fast<60s, short_tail<300s,
+    mid_tail<600s, long_mid<1800s, long_tail>=1800s) — identical
+    boundaries to [masc_keeper_oas_cancel_total] so PromQL can
+    union the two sources for a fleet-wide bimodal view. *)
 val metric_oas_sse_relay_retries : string
 val metric_oas_sse_relay_drops : string
 val metric_oas_sse_relay_queue_depth : string


### PR DESCRIPTION
Refs #10716. Mirrors #10942.

## Why

`#10942` fixed the same opaque cancel WARN in `keeper_llm_bridge.ml`. The
parallel cancel branch in `lib/masc_oas_bridge.ml` (line 58 pre-patch)
had the identical defect:

```
Log.Misc.warn "masc_oas_bridge: OAS execution cancelled (caller=%s)" caller
```

This drops:
1. **Wall-duration class** — bridge cancels collapse into one string, so
   operators cannot tell a routine supervisor pause from a provider that
   hung past the watchdog.
2. **Inner exception** — `Eio.Cancel.Cancelled inner_exn` payload is
   discarded, removing the only signal of which parent fiber asked for
   the cancel (Cancel_hook vs cascade rotation vs server shutdown).

`#10094` already labels the timeout counter with `caller`, but the
cancel counterpart was unlabelled — so for the same caller you could
see "27 timeouts, X cancels" but X had no internal structure.

## What

`lib/masc_oas_bridge.ml::run_safe` cancel branch (mirrors #10942):

1. **Wall tracking** — reuses the `clock_opt` / `t0` / `elapsed`
   helpers introduced in this PR (lifted out of the timeout branch
   so both branches share the same time source).
2. **Bucket classification** with **identical boundaries** to
   `masc_keeper_oas_cancel_total`:
   - `fast` (<60s)
   - `short_tail` (<300s)
   - `mid_tail` (<600s)
   - `long_mid` (<1800s)
   - `long_tail` (≥1800s)
3. **`inner=...` surfaced** in the WARN line.
4. **Prometheus counter** `masc_oas_bridge_cancel_total{caller, bucket}`
   paired with the existing `masc_oas_bridge_timeout_total{caller, timeout_s}`.

## PromQL union with #10942

Identical bucket vocabulary lets a single dashboard panel cover both
sources:

```promql
sum by (bucket) (
  rate(masc_keeper_oas_cancel_total[5m])
  or
  rate(masc_oas_bridge_cancel_total[5m])
)
```

Or split by source via labels:

```promql
sum by (bucket, source) (
  label_replace(rate(masc_keeper_oas_cancel_total[5m]), "source", "keeper", "", "")
  or
  label_replace(rate(masc_oas_bridge_cancel_total[5m]), "source", "bridge", "", "")
)
```

## Layer boundary

Pure observability. `Printexc.raise_with_backtrace exn bt` still
re-raises so structured-concurrency rollback is preserved. The bucket
is derived purely from `wall` (deterministic), and the inner exception
is read-only.

## Risk

Negligible. One `Printexc.to_string` per cancel (rare path) and one
counter increment.

## Verification

- [x] `dune build --root . lib` clean
- [x] `dune build --root . @check` clean
- After deploy: `sum by (caller, bucket) (rate(masc_oas_bridge_cancel_total[5m]))` should split bridge cancels by both caller and wall class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
