### PR TITLE
feat(dashboard): add KeeperBadge primitive (Stage 1)

### DIFF
--- a/dashboard/src/components/keeper-badge.test.ts
+++ b/dashboard/src/components/keeper-badge.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { kSlot, kSigil, KEEPER_REGISTRY } from './keeper-badge'
+
+describe('kSlot', () => {
+  it('returns pinned slot for KEEPER_REGISTRY ids', () => {
+    expect(kSlot('nick0cave')).toBe(3)
+    expect(kSlot('masc-improver')).toBe(6)
+    expect(kSlot('sangsu')).toBe(9)
+    expect(kSlot('qa-king')).toBe(2)
+    expect(kSlot('rama')).toBe(11)
+  })
+
+  it('returns deterministic slot 1..12 for unknown ids', () => {
+    const slot = kSlot('unknown-keeper-7')
+    expect(slot).toBeGreaterThanOrEqual(1)
+    expect(slot).toBeLessThanOrEqual(12)
+    expect(kSlot('unknown-keeper-7')).toBe(slot)
+  })
+
+  it('distributes 100 random ids across at least 8 of 12 slots', () => {
+    const seen = new Set<number>()
+    for (let i = 0; i < 100; i++) seen.add(kSlot(`id-${i}`))
+    expect(seen.size).toBeGreaterThanOrEqual(8)
+  })
+})
+
+describe('kSigil', () => {
+  it('returns pinned sigil for KEEPER_REGISTRY ids', () => {
+    expect(kSigil('nick0cave')).toBe('NK')
+    expect(kSigil('masc-improver')).toBe('MS')
+    expect(kSigil('rama')).toBe('RM')
+  })
+
+  it('extracts first letter + first letter after hyphen for hyphenated ids', () => {
+    expect(kSigil('foo-bar')).toBe('FB')
+    expect(kSigil('alpha-beta-gamma')).toBe('AB')
+  })
+
+  it('falls back to first 2 letters for non-hyphenated ids', () => {
+    expect(kSigil('codex')).toBe('CO')
+    expect(kSigil('gemini')).toBe('GE')
+  })
+
+  it('uppercases lowercase ids', () => {
+    expect(kSigil('alice')).toBe('AL')
+  })
+
+  it('strips non-alphanumeric chars before deriving', () => {
+    expect(kSigil('ab.cd')).toBe('AB')
+    expect(kSigil('foo!bar')).toBe('FO')
+  })
+})
+
+describe('KEEPER_REGISTRY', () => {
+  it('has 5 pinned canonical ids', () => {
+    expect(Object.keys(KEEPER_REGISTRY)).toHaveLength(5)
+  })
+
+  it('all pinned slots are within 1..12', () => {
+    for (const entry of Object.values(KEEPER_REGISTRY)) {
+      expect(entry.slot).toBeGreaterThanOrEqual(1)
+      expect(entry.slot).toBeLessThanOrEqual(12)
+    }
+  })
+
+  it('all sigils are exactly 2 uppercase chars', () => {
+    for (const entry of Object.values(KEEPER_REGISTRY)) {
+      expect(entry.sigil).toMatch(/^[A-Z]{2}$/)
+    }
+  })
+
+  it('all pinned slots are unique', () => {
+    const slots = Object.values(KEEPER_REGISTRY).map((e) => e.slot)
+    expect(new Set(slots).size).toBe(slots.length)
+  })
+})

--- a/dashboard/src/components/keeper-badge.ts
+++ b/dashboard/src/components/keeper-badge.ts
@@ -1,0 +1,211 @@
+// Keeper attribution primitive — color + sigil, two-channel rule.
+//
+// SPEC §3.6 v0.3 (design-system/SPEC.md): color alone never identifies
+// a keeper. Always emit color + sigil. <KeeperBadge> is the canonical
+// attribution unit anywhere in the dashboard.
+//
+// Slot resolution: kSlot(id) → 1..12 deterministic FNV-1a hash, with
+// 5 anchor ids in KEEPER_REGISTRY pinned for brand recall.
+// Sigil: kSigil(id) → 2-letter monogram (registry override or
+// auto-derived from id).
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+
+export interface KeeperRegistryEntry {
+  slot: number
+  sigil: string
+}
+
+export const KEEPER_REGISTRY: Record<string, KeeperRegistryEntry> = {
+  // Canonical 5 — pinned slots for brand recall.
+  // These match the v0.2 alias targets in design-system tokens
+  // so visual identity is preserved across the v0.2→v0.3 migration.
+  'nick0cave':     { slot: 3,  sigil: 'NK' },  /* amber  */
+  'masc-improver': { slot: 6,  sigil: 'MS' },  /* jade   */
+  'sangsu':        { slot: 9,  sigil: 'SS' },  /* sky    */
+  'qa-king':       { slot: 2,  sigil: 'QA' },  /* clay   */
+  'rama':          { slot: 11, sigil: 'RM' },  /* violet */
+}
+
+// FNV-1a 32-bit hash mapped onto 1..12 (avoids 0 so slot is 1-indexed).
+function hash12(str: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return ((h >>> 0) % 12) + 1
+}
+
+export function kSlot(id: string): number {
+  const reg = KEEPER_REGISTRY[id]
+  if (reg) return reg.slot
+  return hash12(String(id))
+}
+
+export function kSigil(id: string): string {
+  const reg = KEEPER_REGISTRY[id]
+  if (reg) return reg.sigil
+  // Auto-derive: first letter + first letter after hyphen, else first 2.
+  const s = String(id).replace(/[^a-z0-9-]/gi, '')
+  const parts = s.split('-').filter(Boolean)
+  const first = parts[0]
+  const second = parts[1]
+  if (first && second && first[0] && second[0]) {
+    return (first[0] + second[0]).toUpperCase()
+  }
+  return s.slice(0, 2).toUpperCase()
+}
+
+const MONO_STACK = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+const SANS_STACK = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
+const HEARTBEAT_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)'
+
+export type KeeperBadgeSize = 'sm' | 'md' | 'lg'
+export type KeeperBadgeVariant = 'sigil' | 'full' | 'name'
+
+export interface KeeperBadgeProps {
+  id: string
+  name?: string
+  size?: KeeperBadgeSize
+  variant?: KeeperBadgeVariant
+  title?: string
+  beat?: boolean
+}
+
+export function KeeperBadge({
+  id,
+  name,
+  size = 'md',
+  variant = 'full',
+  title,
+  beat = false,
+}: KeeperBadgeProps): VNode {
+  const slot = kSlot(id)
+  const sigil = kSigil(id)
+  const display = name ?? id
+  const sizePx = size === 'sm' ? 14 : size === 'lg' ? 24 : 18
+  const fontPx = size === 'sm' ? 8 : size === 'lg' ? 11 : 9
+  const radius = size === 'lg' ? 3 : 2
+
+  const sigilStyle = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: `${sizePx}px`,
+    height: `${sizePx}px`,
+    fontSize: `${fontPx}px`,
+    borderRadius: `${radius}px`,
+    background: `var(--color-keeper-${slot})`,
+    color: 'var(--color-bg-0)',
+    fontFamily: MONO_STACK,
+    fontWeight: 700,
+    letterSpacing: 0,
+    flex: 'none',
+    boxShadow: beat
+      ? `0 0 6px rgb(var(--color-keeper-${slot}-glow) / 0.7)`
+      : undefined,
+    animation: beat
+      ? `keeper-heartbeat 1.4s ${HEARTBEAT_EASING} infinite`
+      : undefined,
+  }
+
+  const sigilEl = html`
+    <span
+      style=${sigilStyle}
+      aria-hidden=${variant === 'full' ? 'true' : 'false'}
+    >${sigil}</span>
+  `
+
+  if (variant === 'sigil') {
+    return html`
+      <span title=${title || display} aria-label=${display}>${sigilEl}</span>
+    `
+  }
+  if (variant === 'name') {
+    return html`
+      <span style=${{ color: `var(--color-keeper-${slot})`, fontWeight: 500 }}>
+        ${display}
+      </span>
+    `
+  }
+  return html`
+    <span
+      style=${{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        verticalAlign: 'middle',
+      }}
+      title=${title}
+    >
+      ${sigilEl}
+      <span
+        style=${{
+          color: `var(--color-keeper-${slot})`,
+          fontFamily: SANS_STACK,
+          fontSize: '11px',
+          fontWeight: 500,
+        }}
+      >${display}</span>
+    </span>
+  `
+}
+
+export interface KeeperStackProps {
+  ids: string[]
+  cap?: number
+  size?: KeeperBadgeSize
+}
+
+export function KeeperStack({
+  ids,
+  cap = 4,
+  size = 'md',
+}: KeeperStackProps): VNode {
+  const visible = ids.slice(0, cap)
+  const overflow = ids.length - visible.length
+  const sizePx = size === 'sm' ? 14 : size === 'lg' ? 24 : 18
+  const surface = 'var(--color-bg-1)'
+
+  const overflowChip = overflow > 0
+    ? html`
+        <span
+          aria-label=${`${overflow} more`}
+          style=${{
+            marginLeft: '-4px',
+            width: `${sizePx}px`,
+            height: `${sizePx}px`,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'var(--color-bg-2)',
+            color: 'var(--color-text-body)',
+            border: `2px solid ${surface}`,
+            borderRadius: '3px',
+            fontFamily: MONO_STACK,
+            fontSize: '10px',
+            fontWeight: 600,
+          }}
+        >+${overflow}</span>
+      `
+    : null
+
+  return html`
+    <span style=${{ display: 'inline-flex', alignItems: 'center' }}>
+      ${visible.map((id, i) => html`
+        <span
+          key=${id}
+          style=${{
+            marginLeft: i === 0 ? '0' : '-4px',
+            border: `2px solid ${surface}`,
+            borderRadius: '3px',
+            display: 'inline-flex',
+          }}
+        ><${KeeperBadge} id=${id} variant="sigil" size=${size} /></span>
+      `)}
+      ${overflowChip}
+    </span>
+  `
+}

--- a/dashboard/src/styles/keyframes.css
+++ b/dashboard/src/styles/keyframes.css
@@ -117,3 +117,9 @@
   from { transform: translateX(100%); opacity: 0; }
   to { transform: translateX(0); opacity: 1; }
 }
+
+@keyframes keeper-heartbeat {
+  0%, 100% { transform: scale(1); }
+  14%, 42% { transform: scale(1.08); }
+  28% { transform: scale(1); }
+}

--- a/dashboard/src/styles/tokens.css
+++ b/dashboard/src/styles/tokens.css
@@ -97,4 +97,35 @@
   --spacing-group: 12px;       /* gap-3  — grouped items */
   --spacing-element: 8px;      /* gap-2  — tight element spacing */
   --spacing-overlay-inset: 24px; /* p-6  — overlay viewport inset */
+
+  /* Keeper attribution — 12-slot hue spectrum (design-system v0.3+ SPEC §3.6).
+     Slots are deterministic via kSlot(id) hash; the canonical 5 ids in
+     KEEPER_REGISTRY (keeper-badge.ts) are pinned for brand recall.
+     Hue stride 30°, perceptually balanced for ≥4.5:1 contrast against bg-0.
+     -glow variants are rgb triplets (space-separated) for box-shadow
+     usage like `rgb(var(--color-keeper-N-glow) / 0.7)`. */
+  --color-keeper-1:  #c8869b;  /* H=000 · rose   */
+  --color-keeper-2:  #cc8a7b;  /* H=030 · clay   */
+  --color-keeper-3:  #c39259;  /* H=060 · amber  */
+  --color-keeper-4:  #b09c4d;  /* H=090 · olive  */
+  --color-keeper-5:  #93a85c;  /* H=120 · moss   */
+  --color-keeper-6:  #6cad7d;  /* H=150 · jade   */
+  --color-keeper-7:  #45b09a;  /* H=180 · teal   */
+  --color-keeper-8:  #3aacba;  /* H=210 · cyan   */
+  --color-keeper-9:  #65a0cc;  /* H=240 · sky    */
+  --color-keeper-10: #8b96cf;  /* H=270 · iris   */
+  --color-keeper-11: #a98dca;  /* H=300 · violet */
+  --color-keeper-12: #c08aaf;  /* H=330 · mauve  */
+  --color-keeper-1-glow:  200 134 155;
+  --color-keeper-2-glow:  204 138 123;
+  --color-keeper-3-glow:  195 146  89;
+  --color-keeper-4-glow:  176 156  77;
+  --color-keeper-5-glow:  147 168  92;
+  --color-keeper-6-glow:  108 173 125;
+  --color-keeper-7-glow:   69 176 154;
+  --color-keeper-8-glow:   58 172 186;
+  --color-keeper-9-glow:  101 160 204;
+  --color-keeper-10-glow: 139 150 207;
+  --color-keeper-11-glow: 169 141 202;
+  --color-keeper-12-glow: 192 138 175;
 }


### PR DESCRIPTION
## Why

Stage 1 of the design-system v0.4 rollout, follow-up to #10898 (which synced the `dashboard/design-system/` folder to v0.4.3). This PR brings the **runtime primitive** that the new SPEC §3.6 keeper-attribution rule requires into `dashboard/src/`: a single `<KeeperBadge>` component that always emits **color + sigil** so identity remains discriminable past 6 simultaneous keepers and survives color-blindness / grayscale.

## What

**Component (`src/components/keeper-badge.ts`)**:
- `KEEPER_REGISTRY` — 5 canonical ids pinned to fixed slots so brand recall survives the v0.2→v0.3 migration: `nick0cave→3/NK`, `masc-improver→6/MS`, `sangsu→9/SS`, `qa-king→2/QA`, `rama→11/RM`.
- `kSlot(id)` — FNV-1a 32-bit hash mapped to 1..12 (registry override first), deterministic.
- `kSigil(id)` — 2-letter monogram (registry override or first-letter-after-hyphen derivation, falls back to first 2 chars).
- `<KeeperBadge>` — variants `sigil` / `full` / `name`, sizes `sm` (14px) / `md` (18px) / `lg` (24px), optional `beat` heartbeat for active keepers.
- `<KeeperStack>` — visible `cap` (default 4) + `+N` overflow chip.

Ported from `dashboard/design-system/preview/cb-shared.jsx`, adapted to the dashboard's `.ts` + `htm/preact` convention. Inline-style approach kept (matches design-system source) so no new CSS classes are needed.

**Tokens (`src/styles/tokens.css`)** — added inside the existing `@theme` block:
- `--color-keeper-1..12` — 12 hues, stride 30°, perceptually balanced.
- `--color-keeper-1-glow..12-glow` — rgb triplets for `box-shadow: rgb(var(--color-keeper-N-glow)/.7)` patterns used by `beat`.

**Animation (`src/styles/keyframes.css`)**:
- `keeper-heartbeat` — 1.4s scale pulse used when `<KeeperBadge beat>`.

## What this PR does NOT change

- **No callsite migration.** Components that currently render keeper ids with raw spans/dots are untouched. Migration to `<KeeperBadge>` ships in follow-up Stage 2 PRs (cb-group-a topbar/ticker, cb-group-b swimlane/sidebar/kanban/rail, cb-group-c code attribution, etc.).
- No light-theme tokens for keepers yet — the existing dark theme covers the production surface; light theme keeper mapping is queued behind callsite migration.
- No Bonsai mirroring — Stage K (optional final stage).

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run src/components/keeper-badge.test.ts` — 12 / 12 pass
  - `kSlot`: pinned registry values, determinism, distribution ≥8 of 12 slots over 100 random ids
  - `kSigil`: registry override, hyphenated / plain / non-alphanumeric ids, uppercase normalization
  - `KEEPER_REGISTRY`: 5 entries, all slots in 1..12, all sigils `^[A-Z]{2}$`, slot uniqueness
- [ ] Visual smoke: render `<KeeperBadge id="nick0cave" beat />` and confirm amber sigil disc with heartbeat (queued behind callsite migration in next PR)

## Refs

- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`
- SPEC §3.6 v0.3: `dashboard/design-system/SPEC.md`
- Predecessor PR: #10898 (design-system folder sync to v0.4.3)
- Source reference: `dashboard/design-system/preview/cb-shared.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
