### PR TITLE
fix(coord/task): auto-cleanup playground worktree on task done (#10899)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -1661,7 +1661,43 @@ let transition_task_r
               | exn ->
                 Log.RoomTask.error
                   "transition relation/hebbian done hook: %s"
-                  (Printexc.to_string exn))
+                  (Printexc.to_string exn));
+             (* #10899: auto-cleanup playground worktree on task done.
+                Keepers used to be expected to call
+                [masc_worktree_remove] themselves at task completion,
+                but that is a fragile contract — keeper crashes,
+                watchdog termination, and forgetfulness all leave
+                worktree directories behind. Field log: 5d / 7
+                keepers / ~3.4GB stale worktrees in
+                [.masc/playground/<keeper>/repos/.../.worktrees/].
+
+                Best-effort: if cleanup fails (uncommitted changes,
+                race with another fiber, missing worktree dir), log
+                a warn and continue. The state-change is the
+                canonical lifecycle event; filesystem GC must not
+                fail the task transition. *)
+             (match task.worktree with
+              | None -> ()
+              | Some _ ->
+                (try
+                   match
+                     Coord_worktree.worktree_remove_r config ~agent_name ~task_id
+                   with
+                   | Ok msg ->
+                     Log.RoomTask.info
+                       "task_done worktree auto-cleanup: %s" msg
+                   | Error e ->
+                     Log.RoomTask.warn
+                       "task_done worktree auto-cleanup failed \
+                        (best-effort, suppressed): %s"
+                       (Types.masc_error_to_string e)
+                 with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
+                   Log.RoomTask.warn
+                     "task_done worktree auto-cleanup raised \
+                      (best-effort, suppressed): %s"
+                     (Printexc.to_string exn)))
            | Types.Cancel ->
              (try
                 let workers = working_agents config in


### PR DESCRIPTION
## 배경

#10899 — keeper playground worktree 무한 누적. `~/me/.masc/playground/<keeper>/repos/<repo>/.worktrees/` 가 task 별로 생성만 되고 정리 코드 부재.

실측: 5d / 7 keepers / **~3.4GB stale**, 단조 증가.

```
sangsu-task-029, sangsu-task-011, sangsu-task-005, sangsu-task-004
fix-dashboard-remove-execution-scope (4d ago)
masc-improver(docker) 892 MB, sangsu(docker) 688 MB ...
```

## 근본 원인

기존 contract: keeper LLM 이 task 완료 시 `masc_worktree_remove` 를 직접 호출해야 정리됨.

이 contract 가 깨지는 path 다수:
- keeper crash mid-task
- watchdog stale termination (#10765)
- self-preservation suppression (#10887)
- LLM 이 단순히 호출을 잊음
- task 가 admin 에 의해 force-done 처리됨

**LLM discipline 에 의존하는 lifecycle 은 안정적이지 않음.** State 전이는 이미 `transition_task_r` 가 결정론적으로 보장 — filesystem GC 도 같은 곳에 묶여야 함.

## 변경

`lib/coord/coord_task.ml` 의 `transition_task_r` Done_action arm 에 자동 cleanup 추가:

```ocaml
(match task.worktree with
 | None -> ()
 | Some _ ->
   try
     match Coord_worktree.worktree_remove_r config ~agent_name ~task_id with
     | Ok msg -> Log.RoomTask.info "task_done worktree auto-cleanup: %s" msg
     | Error e ->
       Log.RoomTask.warn
         "task_done worktree auto-cleanup failed (best-effort, suppressed): %s"
         (Types.masc_error_to_string e)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     Log.RoomTask.warn
       "task_done worktree auto-cleanup raised (best-effort, suppressed): %s"
       (Printexc.to_string exn))
```

기존 economy/relation/hebbian hook 들과 같은 best-effort 패턴 사용.

## 설계 결정

| 결정 | 근거 |
|---|---|
| Done_action 만 auto-cleanup | Cancel/Release 는 in-progress work 보존 — operator 검사 필요 path. Done = "끝났음, commit 됐음" 명시 |
| Best-effort, transition 실패 안 시킴 | 정합성 보장은 state machine, filesystem GC 는 부수적. uncommitted/race/missing 모두 warn 로그 후 통과 |
| 새 hook 모듈 안 만듦 | `coord_task` 와 `coord_worktree` 가 같은 `masc_coord` library — 직접 호출 가능. hook indirection 은 cross-library dep 깨는 용도, 이 경우 불필요 |
| Keeper task `worktree` 필드 None 인 경우 skip | `link_task=false` 로 생성된 task (예: 임시/테스트) 보호 |

## #10892 (autoresearch leak) 와의 관계

같은 class (no cleanup mechanism on task lifecycle) 다른 scope. autoresearch 는 별도 디렉토리(`~/me/.masc/autoresearch/`) 와 별도 lifecycle 이라 동일 패턴이지만 fix site 분리. follow-up PR 후보.

## Acceptance criteria

- [x] `dune build @check` pass
- [x] 기존 task 테스트 영향 없음 (worktree=None 인 mock task 들은 skip 분기로 우회)
- [ ] 머지 후 24h 관찰: keeper task done 시 `task_done worktree auto-cleanup` info 로그 등장
- [ ] `du -sh ~/me/.masc/playground/<keeper>/` 누적 정지 확인
- [ ] uncommitted state 인 worktree 는 warn 로그 + 디렉토리 잔존 확인 (의도된 보호 동작)

## 검증

```bash
dune build @check  # EXIT=0
# 기존 task 테스트는 worktree=None 으로 새 분기 영향 없음
# 통합 검증은 keeper 실 운영 환경에서 24h 관찰
```

## 관련 메모리

- `feedback_eio-proactive-over-ondemand` (lifecycle hook 패턴)
- `feedback_keeper-credential-name-drift` (keeper lifecycle 일반)

🤖 Generated with [Claude Code](https://claude.com/claude-code)