### PR TITLE
feat(keeper-bootstrap): extract autoboot polling/settle intervals to env (SSOT)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -31,6 +31,43 @@ module KeeperBootstrap = struct
   (** Maximum concurrently active keepers. Guards keeper creation and bootstrap. *)
   let max_active_keepers =
     get_int ~default:10000 "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS"
+
+  (** Polling interval (seconds) for the lazy-startup wait loop in
+      [server_bootstrap_loops.ml]. The autoboot fiber wakes up every
+      [lazy_startup_poll_interval_sec] to re-check whether all
+      registered lazy startup tasks have completed before kicking off
+      keeper bootstrap. Default 0.25s preserves the inline literal at
+      [server_bootstrap_loops.ml:157] (responsive enough for unit
+      tests while keeping the idle CPU cost negligible). Floor 0.05s
+      protects against operator typos that would burn CPU. *)
+  let lazy_startup_poll_interval_sec =
+    Float.max 0.05
+      (get_float ~default:0.25
+         "MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC")
+
+  (** Polling interval (seconds) for the keeper-lifecycle listener
+      retry loop in [server_bootstrap_loops.ml]. After a listener
+      iteration raises (non-cancellation) the loop sleeps for this
+      interval before retrying — keeping the spinning under control
+      when an upstream subsystem is briefly down. Default 0.25s
+      preserves the inline literal at [server_bootstrap_loops.ml:240]. *)
+  let keeper_listener_retry_interval_sec =
+    Float.max 0.05
+      (get_float ~default:0.25
+         "MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC")
+
+  (** Settle delay (seconds) between lazy-startup completion and the
+      keeper bootstrap fan-out. The autoboot fiber sleeps for this
+      duration so SSE/board/orchestrator subsystems get a chance to
+      finish their first tick before keeper boot competes for them.
+      Default 5.0s preserves the inline literal at
+      [server_bootstrap_loops.ml:482]. Operators on cold-start machines
+      may raise this; setting to 0 is allowed (no settle) but unwise
+      under load. *)
+  let post_startup_settle_sec =
+    Float.max 0.0
+      (get_float ~default:5.0
+         "MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC")
 end
 
 (** {1 Keeper Metrics Rotation Configuration} *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -154,7 +154,8 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
             end else
               last_log_at
           in
-          Eio.Time.sleep clock 0.25;
+          Eio.Time.sleep clock
+            Env_config_keeper.KeeperBootstrap.lazy_startup_poll_interval_sec;
           loop last_log_at
         end
       end
@@ -237,7 +238,8 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       | exn ->
         Log.Dashboard.error "keeper lifecycle listener iteration failed: %s"
           (Printexc.to_string exn));
-      Eio.Time.sleep clock 0.25;
+      Eio.Time.sleep clock
+        Env_config_keeper.KeeperBootstrap.keeper_listener_retry_interval_sec;
       loop ()
     in
     loop ());
@@ -479,7 +481,8 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       wait_for_lazy_startup ();
       Log.Keeper.info "autoboot: lazy startup complete; keeper bootstrap will start last";
       (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
-      Eio.Time.sleep clock 5.0;
+      Eio.Time.sleep clock
+        Env_config_keeper.KeeperBootstrap.post_startup_settle_sec;
       let config = state.room_config in
       let masc_root = Coord.masc_root_dir config in
       let keeper_dir = Keeper_fs.keeper_dir config in

--- a/test/dune
+++ b/test/dune
@@ -1768,6 +1768,12 @@
  (modules test_env_config_keeper_poll_intervals)
  (libraries masc_test_deps))
 
+; Keeper bootstrap polling/settle interval SSOT
+(test
+ (name test_env_config_keeper_bootstrap_intervals)
+ (modules test_env_config_keeper_bootstrap_intervals)
+ (libraries masc_test_deps))
+
 ; Dashboard shell-cache pre-warm timeout SSOT
 (test
  (name test_env_config_dashboard_shell_prewarm)

--- a/test/test_env_config_keeper_bootstrap_intervals.ml
+++ b/test/test_env_config_keeper_bootstrap_intervals.ml
@@ -1,0 +1,85 @@
+(** Pin the {!Env_config_keeper.KeeperBootstrap} polling/settle
+    interval contract. Three values were extracted from inline
+    literals at [server_bootstrap_loops.ml]:
+
+    - line 157  0.25  → lazy_startup_poll_interval_sec
+    - line 240  0.25  → keeper_listener_retry_interval_sec
+    - line 482  5.0   → post_startup_settle_sec
+
+    The two [0.25] values shared a literal but encode *different*
+    intents (lazy-startup polling vs. listener-retry backoff). The
+    SSOT keeps them as separate knobs so future operator overrides
+    can tune one without affecting the other.
+
+    Properties pinned:
+
+    1. Defaults preserve the pre-extraction literals (regression
+       guard against silent shifts that would change autoboot wall-
+       clock or burn CPU on busy-poll).
+    2. Polling intervals have a >= 0.05s floor (50ms) so an operator
+       typo doesn't accidentally turn the loop into a CPU sink.
+    3. [post_startup_settle_sec] allows 0 (no settle) but caps at
+       no upper bound — operators on slow machines may raise. *)
+
+open Alcotest
+
+module KB = Env_config_keeper.KeeperBootstrap
+
+let approx = float 0.001
+
+let test_default_lazy_startup_poll () =
+  check approx
+    "lazy_startup_poll_interval_sec default (was inline 0.25)"
+    0.25 KB.lazy_startup_poll_interval_sec
+
+let test_default_listener_retry () =
+  check approx
+    "keeper_listener_retry_interval_sec default (was inline 0.25)"
+    0.25 KB.keeper_listener_retry_interval_sec
+
+let test_default_post_startup_settle () =
+  check approx
+    "post_startup_settle_sec default (was inline 5.0)"
+    5.0 KB.post_startup_settle_sec
+
+let test_polling_floor () =
+  check bool
+    "lazy_startup_poll_interval_sec must satisfy the documented \
+     >= 0.05s floor (else the loop becomes a CPU sink)"
+    true
+    (KB.lazy_startup_poll_interval_sec >= 0.05);
+  check bool
+    "keeper_listener_retry_interval_sec must satisfy the documented \
+     >= 0.05s floor"
+    true
+    (KB.keeper_listener_retry_interval_sec >= 0.05)
+
+let test_smoke_call_sites_compile () =
+  let _ = KB.lazy_startup_poll_interval_sec in
+  let _ = KB.keeper_listener_retry_interval_sec in
+  let _ = KB.post_startup_settle_sec in
+  check bool "all three accessors are reachable" true true
+
+let () =
+  run "env_config_keeper_bootstrap_intervals"
+    [
+      ( "defaults preserve pre-extraction literals",
+        [
+          test_case "lazy_startup_poll = 0.25" `Quick
+            test_default_lazy_startup_poll;
+          test_case "listener_retry = 0.25" `Quick
+            test_default_listener_retry;
+          test_case "post_startup_settle = 5.0" `Quick
+            test_default_post_startup_settle;
+        ] );
+      ( "polling floors",
+        [
+          test_case ">= 0.05s floor on both polling intervals" `Quick
+            test_polling_floor;
+        ] );
+      ( "API surface",
+        [
+          test_case "all three accessors reachable" `Quick
+            test_smoke_call_sites_compile;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#10797/#10880/#10886/#10889의 후속. \`server_bootstrap_loops.ml\`에 남아 있던 3개 inline sleep literal을 \`Env_config_keeper.KeeperBootstrap\` SSOT로 통합.

| File:Line | Before | After | Intent |
|-----------|--------|-------|--------|
| 157 | \`Eio.Time.sleep clock 0.25\` | \`KB.lazy_startup_poll_interval_sec\` | autoboot lazy-startup wait polling |
| 240 | \`Eio.Time.sleep clock 0.25\` | \`KB.keeper_listener_retry_interval_sec\` | lifecycle-listener exception retry |
| 482 | \`Eio.Time.sleep clock 5.0\` | \`KB.post_startup_settle_sec\` | startup settle before keeper fan-out |

**핵심**: 두 \`0.25\`는 *우연히 같은 값*이지만 의도가 다름 (polling vs retry). #10880에서 \`shell_timeout_s\` vs \`shell_light_timeout_s\`를 분리한 것과 동일한 패턴 — operator가 둘 중 하나만 튜닝할 수 있게.

## 새 env (default 동작 동일)

- \`MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC\` (default 0.25, floor 0.05)
- \`MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC\` (default 0.25, floor 0.05)
- \`MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC\` (default 5.0, floor 0)

## Floor 설계

- **Polling 0.05s 하한**: 운영자 typo (\`0.05\` → \`0.005\`)로 loop가 CPU sink되지 않도록.
- **Settle 0 허용**: 빠른 부팅 환경에선 0이 의도적 선택. 단 cold-start under load에서 race 위험.

## Test plan

- [x] \`dune build --root . @check\` green
- [x] \`dune exec test_env_config_keeper_bootstrap_intervals.exe\` 5/5 pass

## 누적 timeout SSOT (지금까지 5 PR series)

| PR | Domain | Constants | Env |
|----|--------|-----------|-----|
| #10797 ✅ | Dashboard.shell_prewarm | 2 | 2 |
| #10880 ✅ | Dashboard.mission/shell/render | 4 | 4 |
| #10886 ✅ | Dashboard.execution | 2 | 2 |
| #10889 ✅ | Process_eio.default | 1 | 1 |
| 이 PR | KeeperBootstrap.intervals | 3 | 3 |
| **합계** | **12 timeout, 12 env, 23+ callsite** | | |

## Out of scope (다음 PR)

- \`with_unix_capture\`의 \`Unix.select\` 0.05s busy-poll (#10426 sync/async misuse axis, separate correctness track)
- keeper/exec/git 30+ \`~timeout_sec:N.N\` 사이트 (#10426 본문 step 1)
- voice_bridge / sidecar 사이트 (#10426 본문 step 4)

Refs #10426