### PR TITLE
docs(coord): add coord_gc.mli (#10751 batch)

### DIFF
--- a/lib/coord/coord_gc.mli
+++ b/lib/coord/coord_gc.mli
@@ -1,0 +1,48 @@
+(** Coord_gc — heartbeat, zombie cleanup, garbage collection.
+
+    Public surface for {!Coord_gc.ml}.  Extracted from [room.ml] for
+    modularity (#4638).  See issue #10751 for the broader [coord/]
+    [.mli] coverage push.
+
+    Side effects:
+    - All three functions touch [agents_dir config] and the locks
+      under it.  Callers must hold no other coord lock when invoking.
+    - Board artifact cleanup is wired via [Coord_hooks] callbacks at
+      startup; this module does not depend on the board layer
+      directly. *)
+
+(** Update the agent's [last_seen] timestamp on disk.
+
+    [agent_name] is resolved through {!Coord_utils.resolve_agent_name}
+    so canonical/alias forms both work.  Returns a human-readable
+    status string (heartbeat updated / agent missing / file invalid).
+    The agent file is mutated under [with_file_lock]. *)
+val heartbeat :
+  Coord_utils_backend_setup.config -> agent_name:string -> string
+
+(** Sweep [.masc/agents/] and remove agents that have not heartbeated
+    within the threshold.
+
+    [keeper_threshold_sec] applies to keeper agents and defaults to
+    {!Env_config.Zombie.keeper_threshold_seconds}; [agent_threshold_sec]
+    applies to all other agents and defaults to
+    {!Env_config.Zombie.threshold_seconds}.
+
+    Returns a human-readable summary of what was cleaned. *)
+val cleanup_zombies :
+  ?keeper_threshold_sec:float ->
+  ?agent_threshold_sec:float ->
+  Coord_utils_backend_setup.config -> string
+
+(** Run the full coord garbage-collection pass:
+    {ol
+    {- {!cleanup_zombies} (default thresholds)}
+    {- archive backlog tasks older than [days] days that are not
+       already in a terminal state (default [days = 7], clamped to
+       at least 1)}}
+
+    Stale tasks are appended to [tasks-archive.json] via
+    {!Coord_task_id.append_archive_tasks} and the backlog is rewritten
+    with [version + 1].  Returns a multi-line summary string. *)
+val gc :
+  Coord_utils_backend_setup.config -> ?days:int -> unit -> string


### PR DESCRIPTION
## 배경

#10751 — \`lib/coord/\` .mli 커버리지 push 의 일부. 이전 cycle 의 #10950 (`coord_task_id.mli`) 패턴 재사용. 본 PR 은 missing 6 모듈 중 다음 후보 \`coord_gc\` (434 lines, 3 public fn).

## 변경

`lib/coord/coord_gc.mli` 신규:

| Function | Signature |
|---|---|
| `heartbeat` | `config -> agent_name:string -> string` |
| `cleanup_zombies` | `?keeper_threshold_sec:float -> ?agent_threshold_sec:float -> config -> string` |
| `gc` | `config -> ?days:int -> unit -> string` |

문서화된 side effects:
- 모두 `agents_dir config` 의 lock 변경 — caller 가 다른 coord lock 보유 금지.
- Board artifact cleanup 은 `Coord_hooks` callback 으로 startup 시 wiring — 본 모듈은 board layer 직접 의존 없음 (encapsulation 명시).

내부 helper (`ensure_initialized`, `read_agent_with_repair`, `safe_filename`, `archive_path` 등) 는 `Coord_utils` / `Coord_task_id` surface 에 남겨두고 본 `.mli` 비포함.

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file (new), +48 lines
- 호출자 코드 미변경 (regression 0)

## 후속 (남은 missing 5)

| Module | Lines | Notes |
|---|---|---|
| `coord_worktree.mli` | 997 | B3 batch 가장 큼 |
| `coord_utils.mli` | TBD | B4 broad surface |
| `coord_utils_backend_setup.mli` | TBD | B4 |
| `coord_utils_ops.mli` | TBD | B4 |
| `coord_utils_paths_backend.mli` | TBD | B4 |
| `coord_git.mli` | TBD | B4 별도 카테고리 |

이슈 본문이 명시한 \"coord_utils* 4개는 별도 batch\" 규칙 준수.