### PR TITLE
i18n(dashboard): localize board API fallback title (round-77)

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -439,7 +439,7 @@ export async function fetchBoardPost(postId: string): Promise<BoardPost & { comm
       author: 'unknown',
       post_kind: 'direct',
       classification_reason: null,
-      title: 'Post',
+      title: '게시물',
       body: '',
       content: '',
       meta: null,


### PR DESCRIPTION
## 변경
`api/board.ts:442`: `title: 'Post'` → `title: '게시물'` (normalizeBoardPost 실패 시 fallback)

## 영향 범위
1 file, 1 line. Source-only. Test fixture coupling 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)