### PR TITLE
docs(coord): add coord_git.mli (#10751 batch)

### DIFF
--- a/lib/coord/coord_git.mli
+++ b/lib/coord/coord_git.mli
@@ -1,0 +1,97 @@
+(** Coord_git — MASC git worktree operations.
+
+    Public surface for {!Coord_git.ml}.  Provides per-agent / per-task
+    worktree isolation for parallel work.  All git invocations are
+    argv-based (no shell) to avoid injection.  See issue #10751 for
+    the broader [coord/] [.mli] coverage push.
+
+    Threading: every function below shells out via [Process] /
+    [Masc_exec] with bounded timeouts.  No coord-level lock is
+    acquired here, so callers may invoke concurrently as long as the
+    underlying git repo permits parallel reads.  [create] and [remove]
+    mutate the worktree set and assume git's own locking.
+
+    Naming: worktree paths and branch names are derived from
+    {!Playground_paths.worktree_dir_name} and
+    {!Playground_paths.worktree_branch_name}; this module does not
+    own the naming scheme. *)
+
+(** [path_is_masc_worktree p] reports whether [p] sits under the MASC
+    [.worktrees/] sentinel.  Substring check; no [Re] compile per call. *)
+val path_is_masc_worktree : string -> bool
+
+(** [has_git_marker path] returns [true] if [path] (or any ancestor)
+    contains a [.git] entry.  Used as a fast-fail guard before calling
+    git subprocesses on non-repo directories. *)
+val has_git_marker : string -> bool
+
+(** [git_root ~base_path] resolves the git toplevel containing
+    [base_path] via [git rev-parse --show-toplevel].  Returns [None]
+    when the path is outside any git repo or git fails. *)
+val git_root : base_path:string -> string option
+
+(** [is_git_repo ~base_path] is [true] when {!git_root} succeeds. *)
+val is_git_repo : base_path:string -> bool
+
+(** [remote_branch_exists root branch] queries [origin/<branch>] via
+    [git rev-parse --verify].  No fetch is performed; the answer
+    reflects whatever the local refs cache holds. *)
+val remote_branch_exists : string -> string -> bool
+
+(** [origin_head_branch root] returns the branch [origin/HEAD]
+    resolves to (typically [main] or [master]).  [None] when
+    [origin/HEAD] is not set. *)
+val origin_head_branch : string -> string option
+
+(** [resolve_base_branch root requested] picks the actual base ref to
+    create a new worktree from:
+    - returns [Ok (requested, None)] if [origin/requested] exists
+    - otherwise falls back to [origin/HEAD] / [main] / [master] in
+      order and returns [Ok (resolved, Some requested)]
+    - returns [Error _] when no candidate exists. *)
+val resolve_base_branch :
+  string -> string ->
+  (string * string option, Types.masc_error) result
+
+(** [create ~base_path ~agent_name ~task_id ~base_branch] adds a new
+    worktree at [<root>/.worktrees/<agent>-<task>] tracking a fresh
+    branch from [origin/<base_branch>] (after a mandatory [git fetch
+    origin] under the configured timeout — #9587).  Returns a human-
+    readable success message or an [IoError] describing the first
+    git command that failed. *)
+val create :
+  base_path:string ->
+  agent_name:string ->
+  task_id:string ->
+  base_branch:string ->
+  string Types.masc_result
+
+(** [remove ~base_path ~agent_name ~task_id] removes the worktree and
+    deletes its tracking branch.  Returns success with any non-fatal
+    warnings (branch delete or prune returning non-zero are reported
+    in the message but do not fail the operation). *)
+val remove :
+  base_path:string ->
+  agent_name:string ->
+  task_id:string ->
+  string Types.masc_result
+
+(** [list ~base_path] returns a JSON object describing every worktree
+    in the repository:
+    {v
+    { "worktrees": [ { "path": ..., "branch": ..., "is_masc": bool } ],
+      "count":     int,
+      "masc_hint": string }
+    v}
+    Errors surface as [{ "error": "Not a git repository" }]. *)
+val list : base_path:string -> Yojson.Safe.t
+
+(** [get_info ~base_path ~agent_name ~task_id] returns
+    [Some (worktree_path, branch_name)] when the corresponding
+    worktree directory exists, [None] otherwise.  Does not invoke git;
+    a pure filesystem check. *)
+val get_info :
+  base_path:string ->
+  agent_name:string ->
+  task_id:string ->
+  (string * string) option


### PR DESCRIPTION
## 배경

#10751 — \`lib/coord/\` .mli coverage push. 이전 cycle 의 #10950 (\`coord_task_id\`), #10958 (\`coord_gc\`) 패턴 재사용. 본 PR 은 \`coord_git\` (337 lines, 11 public fn) 처리.

## 변경

`lib/coord/coord_git.mli` 신규 — git worktree 운영 11 함수 노출:

| 그룹 | Function | 외부 caller |
|---|---|---|
| Predicate | `path_is_masc_worktree` | (internal use only) |
| Predicate | `has_git_marker` | `worktree_live_context` |
| Resolution | `git_root` | `tool_code_write`, `task_sandbox`, `tool_code` |
| Resolution | `is_git_repo` | `coord_worktree` |
| Branch | `remote_branch_exists` | (utility) |
| Branch | `origin_head_branch` | (utility) |
| Branch | `resolve_base_branch` | `coord_worktree` |
| CRUD | `create` | (Coord layer) |
| CRUD | `remove` | (Coord layer) |
| Query | `list` | `coord_worktree` |
| Query | `get_info` | (Coord layer) |

## 의도적으로 안 노출

내부 subprocess wrapper / utility:
- `run_argv_line`, `run_argv_exit`, `run_argv_lines`
- `exec_gate_raw_source` (raw_source generator)
- `is_valid_branch_name`, `unique_strings`, `auto_base_branch_candidates`

→ Encapsulation 유지. 외부 callers 가 subprocess invocation 직접 못 쓰게 차단.

## 문서화 added

- threading rationale (no coord lock; git's own locking)
- timeout source (`Env_config_core.git_fetch_timeout_sec`, #9587)
- naming derivation (`Playground_paths.worktree_dir_name` — coord_git 는 naming scheme 안 소유)
- JSON shape of `list` 반환값

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file (new), +97 lines
- 호출자 코드 미변경 (regression 0)
- `grep -rn 'Coord_git\\.'` 로 외부 11 site 확인

## 후속 (남은 missing 5)

| Module | Lines | 비고 |
|---|---|---|
| `coord_worktree.mli` | 997 | B3 — 가장 큼 |
| `coord_utils_paths_backend.mli` | 270 | B4 |
| `coord_utils_backend_setup.mli` | 470 | B4 |
| `coord_utils_ops.mli` | 580 | B4 |
| `coord_utils.mli` | 5 | B4 — re-export, 위 3개 mli 의존 |