### PR TITLE
perf(dashboard): migrate fsm-hub pipeline children to nowSecondsSignal

### DIFF
--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
 import type { KeeperCompositeSnapshot } from '../api/keeper'
+import { nowSecondsSignal, useNowSecondsTicker } from '../lib/now-signal'
 
 import {
   type CompositeObservation,
@@ -68,12 +69,12 @@ const INSIGHT_PANEL_CLS: Record<InsightTone, string> = {
 export function OperationalMeaningPanel({
   snapshot,
   observations,
-  now,
 }: {
   snapshot: KeeperCompositeSnapshot
   observations: CompositeObservation[]
-  now: number
 }) {
+  useNowSecondsTicker()
+  const now = nowSecondsSignal.value
   const lanes = deriveObservedLaneSummaries(snapshot, observations, now)
   const insight = deriveOperationalInsight(snapshot, observations, now, lanes)
   const panelCls = INSIGHT_PANEL_CLS[insight.tone]
@@ -167,11 +168,11 @@ const PHASE_BAR_FILL: Record<string, string> = {
 
 function PhaseSparkline({
   observations,
-  now,
 }: {
   observations: CompositeObservation[]
-  now: number
 }) {
+  useNowSecondsTicker()
+  const now = nowSecondsSignal.value
   const segments = useMemo(
     () => deriveSwimlaneSegments(observations, 'phase', now),
     [observations, now],
@@ -266,14 +267,14 @@ export function HeroPhase({
   snapshot,
   observations,
   phaseSince,
-  now,
 }: {
   snapshot: KeeperCompositeSnapshot
   phaseLog?: string[]
   observations: CompositeObservation[]
   phaseSince: number | null
-  now: number
 }) {
+  useNowSecondsTicker()
+  const now = nowSecondsSignal.value
   const prevRef = useRef(snapshot.phase)
   const [flash, setFlash] = useState(false)
   useEffect(() => {
@@ -334,7 +335,7 @@ export function HeroPhase({
         </div>
         ${flash ? html`<span class="text-3xs text-[var(--color-accent-fg)] animate-pulse font-mono" aria-live="assertive">상태 변경</span>` : null}
       </div>
-      <${PhaseSparkline} observations=${observations} now=${now} />
+      <${PhaseSparkline} observations=${observations} />
     </div>
   `
 }
@@ -345,7 +346,6 @@ export function PipelineStep({
   value,
   isLast,
   sinceTs,
-  now,
   limited,
 }: {
   label: string
@@ -353,11 +353,12 @@ export function PipelineStep({
   value: string
   isLast?: boolean
   sinceTs: number | null
-  now: number
   /** When true, this lane has limited observability — only a subset of
       states are derivable from the registry. Shown as a subtle indicator. */
   limited?: boolean
 }) {
+  useNowSecondsTicker()
+  const now = nowSecondsSignal.value
   const prevRef = useRef(value)
   const [flash, setFlash] = useState(false)
   useEffect(() => {
@@ -427,22 +428,23 @@ export function PipelineStep({
 export function TurnPipelineStrip({
   snapshot,
   stateEntries,
-  now,
 }: {
   snapshot: KeeperCompositeSnapshot
   stateEntries: StateEntries | null
-  now: number
 }) {
+  // Pure pass-through wrapper: each PipelineStep child subscribes to
+  // nowSecondsSignal independently, so this component itself never reads
+  // the signal and is not re-rendered by 5 s ticks.
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
       <div class="mb-2 text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
         턴 파이프라인
       </div>
       <div class="flex flex-col gap-1 md:flex-row md:gap-0 md:items-stretch" role="list" aria-label="턴 파이프라인 단계">
-        <${PipelineStep} shortLabel="KTC" label="턴 주기" value=${snapshot.turn_phase} sinceTs=${stateEntries?.turn ?? null} now=${now} />
-        <${PipelineStep} shortLabel="KDP" label="의사결정" value=${snapshot.decision.stage} sinceTs=${stateEntries?.decision ?? null} now=${now} limited />
-        <${PipelineStep} shortLabel="KCL" label="캐스케이드" value=${snapshot.cascade.state} sinceTs=${stateEntries?.cascade ?? null} now=${now} limited />
-        <${PipelineStep} shortLabel="KMC" label="컨텍스트 압축" value=${snapshot.compaction.stage} sinceTs=${stateEntries?.compaction ?? null} now=${now} isLast />
+        <${PipelineStep} shortLabel="KTC" label="턴 주기" value=${snapshot.turn_phase} sinceTs=${stateEntries?.turn ?? null} />
+        <${PipelineStep} shortLabel="KDP" label="의사결정" value=${snapshot.decision.stage} sinceTs=${stateEntries?.decision ?? null} limited />
+        <${PipelineStep} shortLabel="KCL" label="캐스케이드" value=${snapshot.cascade.state} sinceTs=${stateEntries?.cascade ?? null} limited />
+        <${PipelineStep} shortLabel="KMC" label="컨텍스트 압축" value=${snapshot.compaction.stage} sinceTs=${stateEntries?.compaction ?? null} isLast />
       </div>
     </div>
   `

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -547,14 +547,13 @@ export function FsmHub(props: FsmHubProps = {}) {
         <${OperationalMeaningPanel}
           snapshot=${snapshot}
           observations=${view.observations}
-          now=${now}
         />
 
         ${/* ── Zone 2: Hero — KSM Phase ── */ ''}
-        <${HeroPhase} snapshot=${snapshot} phaseLog=${phaseLog} observations=${view.observations} phaseSince=${stateEntries?.phase ?? null} now=${now} />
+        <${HeroPhase} snapshot=${snapshot} phaseLog=${phaseLog} observations=${view.observations} phaseSince=${stateEntries?.phase ?? null} />
 
         ${/* ── Zone 2b: Turn Pipeline Strip (always visible) ── */ ''}
-        <${TurnPipelineStrip} snapshot=${snapshot} stateEntries=${stateEntries} now=${now} />
+        <${TurnPipelineStrip} snapshot=${snapshot} stateEntries=${stateEntries} />
 
         ${/* ── Zone 3: Timeline + Analytics (2-column on wide screens) ── */ ''}
         <div class="grid gap-3 lg:grid-cols-2">


### PR DESCRIPTION
## Why

Cycle 9 of the iterative dashboard performance pass.  Cycle 7 (#10918) introduced `nowSecondsSignal` + `useNowSecondsTicker()` infrastructure but only fsm-hub itself consumed it — meaning the 5 s tick still re-rendered the entire 1012-LOC fsm-hub component, defeating the per-leaf-render-scope point of the signal model.

This PR is the first of three (cycles 9, 10, 11) that move the **read site** down to the leaves.  Once all three land, fsm-hub itself reads the signal zero times and the 5 s tick re-renders only the leaves that actually display elapsed durations.

## What

Five components in `fsm-hub-pipeline-panels.ts` now call `useNowSecondsTicker()` + `nowSecondsSignal.value` themselves and drop the `now: number` prop:

| Component | now usage |
|-----------|-----------|
| `OperationalMeaningPanel` | `deriveObservedLaneSummaries` + `deriveOperationalInsight` args |
| `HeroPhase` | `now - phaseSince` for "유지" duration |
| `PhaseSparkline` | `deriveSwimlaneSegments(observations, 'phase', now)` |
| `TurnPipelineStrip` | **pure pass-through** — no signal read, just renders 4 PipelineStep children |
| `PipelineStep` (×4) | `now - sinceTs` for staleness display + color tone |

`fsm-hub.ts` drops `now=${now}` from the 3 children call sites (lines 547, 554, 557).  `const now` and `useNowSecondsTicker()` stay in fsm-hub for cycles 10–11's still-dependent consumers.

| File | Change |
|------|--------|
| `dashboard/src/components/fsm-hub-pipeline-panels.ts` | +import, +`useNowSecondsTicker()`+`const now` in 5 components, -`now` from prop types and grandchild forwarding |
| `dashboard/src/components/fsm-hub.ts` | -3 `now=` props |

Net: 2 files, +19 -18.

## Stack position

- Cycle 1 (#10894 merged) — fsm-hub 1Hz → 5Hz tick
- Cycle 7 (#10918 merged) — `nowSecondsSignal` + `useNowSecondsTicker` infra
- Cycle 8 (#10949 draft) — live-pulse 1 Hz refcount sweep (independent file)
- **Cycle 9 (this)** — pipeline-panels children migration
- Cycle 10 (next) — timeline-panels children + dwellHistograms useMemo move
- Cycle 11 (final) — StatusBar inline + drop fsm-hub's own `useNowSecondsTicker`/`.value` read

## Refcount notes

`useNowSecondsTicker` is mount-counted, so 4 PipelineStep instances each call it = +4 refcount.  Single shared interval still — only the consumer count differs.  When TurnPipelineStrip unmounts, all 4 children unmount too and the count returns to its pre-mount value.

`TurnPipelineStrip` itself does NOT call the hook because it never reads the signal — its only role is rendering 4 PipelineStep children.  This is the cycle's payoff signature: a parent component that no longer re-renders on 5 s ticks because none of its render code reads the signal.

## Test plan

- [x] `pnpm run typecheck` succeeds
- [x] `pnpm --filter masc-dashboard build` succeeds (production rollup)
- [ ] After deploy, visual verification on fsm-hub view: phase "유지" string + pipeline staleness color ticks update on 5 s cadence (manual)