### PR TITLE
feat(keeper): surface deliberate-skip reasons on stale watchdog kill

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1367,6 +1367,17 @@ let run_keepalive_unified_turn
               ("reason", reason_str);
             ] ())
           verdict_strs;
+        (* #10940 follow-up — Prometheus counters aggregate skip reasons
+           across time, but operators need to see *which* reasons were
+           live just before a stale-watchdog [idle_stale=true]
+           termination.  Stamping the registry on every skip lets
+           [Keeper_stale_watchdog] surface the most recent reasons in
+           the kill warn line, distinguishing deliberate-skip dead
+           paths from genuinely stuck fibers. *)
+        Keeper_registry.record_skip_reasons
+          ~base_path:ctx.config.base_path
+          meta_after_triage.name
+          ~reasons:verdict_strs;
         let log_not_scheduled =
           match turn_decision.verdict with
           | Keeper_world_observation.Skip { reasons = (Keeper_world_observation.Scheduled_autonomous_disabled, []) } ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -148,6 +148,7 @@ type registry_entry = {
   pending_turn_measurement : turn_measurement option;
   current_turn_observation : turn_observation option;
   last_completed_turn : completed_turn_observation option;
+  last_skip_observation : (float * string list) option;
   compaction_stage : compaction_stage;
 }
 
@@ -275,6 +276,7 @@ let register_with_state ~base_path name meta
     pending_turn_measurement = None;
     current_turn_observation = None;
     last_completed_turn = None;
+    last_skip_observation = None;
     compaction_stage = Compaction_accumulating;
   } in
   put_entry key entry;
@@ -582,6 +584,16 @@ let mark_turn_finished ~base_path name =
     (Keeper_transition_audit.record_completed_turn ~keeper_name:name)
     !completed_turn_to_record;
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
+
+let record_skip_reasons ~base_path name ~reasons =
+  (* Only stamp when there's at least one reason — empty lists from a
+     [Run] verdict path would otherwise overwrite the last legitimate
+     skip stamp with a no-op. *)
+  if reasons <> [] then begin
+    let now = Time_compat.now () in
+    update_entry ~base_path name (fun e ->
+      { e with last_skip_observation = Some (now, reasons) })
+  end
 
 let increment_turn_failures ~base_path name =
   update_entry ~base_path name (fun e ->

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -142,6 +142,19 @@ type registry_entry = {
           result": idle keepers never surface stale terminal states
           on the live sub-FSM fields, but operators can still see
           the most recent outcome in [last_outcome]. *)
+  last_skip_observation : (float * string list) option;
+      (** Most recent [keeper_cycle_decision] skip outcome captured by
+          the keepalive loop (#10940 follow-up).  The [Prometheus]
+          [proactive_skip_reason_metric] aggregates skip reasons over
+          time, but at stale-watchdog kill the operator wants to see
+          *which* reasons were active *just before* the 300s idle
+          timeout fired.  [Some (ts, reasons)] = wall clock + verdict
+          reason strings ([cooldown_pending], [no_signal],
+          [scheduled_autonomous_disabled], etc.) from the last skip;
+          [None] until the first skip is observed.  Read by
+          [Keeper_stale_watchdog] to enrich the kill warn line so an
+          [idle_stale=true] termination is no longer indistinguishable
+          from a *stuck* fiber. *)
   compaction_stage : compaction_stage;
       (** Explicit KMC projection owned by the runtime, not derived from
           parent phase on read. This lets the observer surface
@@ -263,6 +276,14 @@ val mark_turn_gate_rejected_by_name : string -> unit
     so the composite observer reverts to idle. Idempotent — safe to
     call in finally blocks even if [mark_turn_started] was not called. *)
 val mark_turn_finished : base_path:string -> string -> unit
+
+(** Record the verdict reasons from a [keeper_cycle_decision] that
+    chose to skip the next turn.  Stamps [last_skip_observation] with
+    [(now, reasons)] so the stale watchdog can surface *why* a keeper
+    was deliberately skipping turns when an [idle_stale=true]
+    termination fires.  No-op if no entry is registered for [name]. *)
+val record_skip_reasons :
+  base_path:string -> string -> reasons:string list -> unit
 
 (** Increment turn consecutive failure counter. *)
 val increment_turn_failures : base_path:string -> string -> unit

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -137,8 +137,31 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                || now -. !last_broadcast_ts > threshold
              in
              if stale && cooldown_ok then begin
+               (* #10940 follow-up: surface the most recent skip reasons
+                  alongside [idle %.0fs] so operators can tell whether
+                  the kill targeted a *stuck* fiber or a *deliberately
+                  skipping* one.  [last_skip_observation] is stamped by
+                  the keepalive loop on every [should_run_turn=false]
+                  decision; we only quote it if it's recent enough to
+                  be the proximate cause of the idle window
+                  ([recency_window] = the same idle threshold that
+                  triggered the kill).  Older stamps are ignored to
+                  avoid surfacing labels from before the current idle
+                  window. *)
+               let recency_window = threshold in
+               let skip_reason_label =
+                 match entry.last_skip_observation with
+                 | Some (ts, reasons)
+                   when reasons <> []
+                        && now -. ts <= recency_window ->
+                   Printf.sprintf " last_skip=[%s] (%.0fs ago)"
+                     (String.concat "," reasons) (now -. ts)
+                 | _ -> ""
+               in
                let reason_desc =
-                 if idle_stale then Printf.sprintf "idle %.0fs" (now -. last_turn)
+                 if idle_stale then
+                   Printf.sprintf "idle %.0fs%s"
+                     (now -. last_turn) skip_reason_label
                  else if in_turn_stale then
                    Printf.sprintf "active turn hung %.0fs (timeout %.0fs)"
                      in_turn_age active_turn_timeout_sec


### PR DESCRIPTION
Refs #10765. Follow-up to #10940.

## Why

Production fleet log (2026-04-27 09:22-09:23):

```
09:22:17 [Keeper] janitor:  stale watchdog terminating fiber (idle 312s) [window_count=1/6h]
09:23:16 [Keeper] executor: stale watchdog terminating fiber (idle 327s) [window_count=1/6h]
09:23:17 [Keeper] ramarama: stale watchdog terminating fiber (idle 317s) [window_count=1/6h]
09:23:17 [Keeper] sangsu:   stale watchdog terminating fiber (idle 301s) [window_count=1/6h]
```

For all four: `in_turn_stale=false`, `in_turn_age=0`. **Not mid-turn**
(#10940's mid-turn guard doesn't apply). The keepers had finished a
turn ~5 min earlier and the dispatch loop simply chose not to start a
new turn for 300s+.

`lib/keeper/keeper_keepalive.ml::1336-1351` computes
`should_run_turn = !stop && turn_decision.should_run`. When
`should_run = false`, the loop falls through silently after
incrementing `proactive_skip_reason_metric{reason}` and emitting an
`info` line that the operator typically does not have open at the
moment of the kill.

The kill warn line itself collapses two populations:

| Symptom | Possible root |
|---|---|
| **Stuck** | turn dispatch loop blocked, OAS uncancellable region, supervisor handoff missing |
| **Deliberate skip** | `cooldown_pending`, `no_signal`, `scheduled_autonomous_disabled`, `idle_gate_pending`, `keeper_paused`, ... |

Without the reason at the kill site, an operator cannot tell whether
to chase an infrastructure bug (stuck) or a configuration / signal
shortage (deliberate skip).

## What

1. **New registry field**:
   ```ocaml
   last_skip_observation : (float * string list) option
   ```
   `(now, verdict reason strings)` from the most recent skip.

2. **New setter** `Keeper_registry.record_skip_reasons`.

3. **Keepalive loop wiring** (`lib/keeper/keeper_keepalive.ml`):
   the `if not should_run_turn` branch already iterates `verdict_strs`
   for the Prometheus counter; the new call stamps the registry with
   the same list.

4. **Stale watchdog enrichment** (`lib/keeper/keeper_stale_watchdog.ml`):
   the `idle_stale` branch of `reason_desc` becomes:
   ```
   idle 312s last_skip=[cooldown_pending,no_signal] (5.2s ago)
   ```
   The stamp is only quoted if it's within the same idle threshold
   that triggered the kill (so stale labels from before the current
   idle window are dropped).

## Layer boundary

Pure observability. The decision logic in
`Keeper_world_observation.keeper_cycle_decision` is unchanged; the
kill timing in `Keeper_stale_watchdog` is unchanged; the broadcast,
the supervisor restart, all unchanged. We just thread the
already-computed `verdict_strs` into the registry so the kill warn
line can read it.

## Det vs non-det

- The decision (`should_run`) is **deterministic** — function of
  observation and meta. Already audit-traced.
- The skip-vs-stuck *attribution at kill time* was the missing link;
  this PR makes it deterministic too (read from registry, no
  inference).

## Risk

Negligible:
- One additional `update_entry` per heartbeat-tick-skip (already a
  hot path that does many).
- Empty-list guard in `record_skip_reasons` prevents `Run`-verdict
  paths from overwriting legitimate skip stamps.
- Recency window prevents surfacing labels from before the current
  idle accumulation.

## Verification

- [x] `dune build --root . lib` clean
- [x] `dune build --root . @check` clean
- After deploy: stale-kill warn lines should split into two clearly
  labelled populations:
  ```
  *: stale watchdog terminating fiber (idle 312s last_skip=[cooldown_pending] (4s ago)) [window_count=1/6h]   # deliberate-skip
  *: stale watchdog terminating fiber (idle 312s)                                       [window_count=1/6h]   # stuck (no recent stamp)
  ```
  The "stuck" population is the genuine root-cause backlog (OAS
  uncancellable region, dispatch-loop hang, etc.); the
  "deliberate-skip" population becomes a cooldown / signal-supply
  problem instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
