### PR TITLE
i18n(dashboard): localize keeper directory error panel (round-78)

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -411,8 +411,8 @@ describe('ConnectorStatusPanel', () => {
     expect(text).toContain('stale')
     expect(text).toContain('Gate metrics unavailable')
     expect(text).toContain('게이트가 광고하는 connector runtime 은 보이지만')
-    expect(text).toContain('keeper directory unavailable, manual entry only')
-    expect(text).toContain('Next: continue with manual entry now')
+    expect(text).toContain('keeper 디렉토리 사용 불가, 수동 입력만 가능')
+    expect(text).toContain('Next: 지금은 수동 입력으로 진행')
     expect(text).toContain('config/keepers/')
     expect(text).toContain('/api/v1/gate/keepers')
 

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -971,10 +971,10 @@ function ConnectorLivePanel({
                 ? html`<span class="text-3xs text-[var(--color-fg-disabled)]">checked ${timeAgo(connector.gate_health_checked_at)}</span>`
                 : null}
               <div class="mt-1">
-                <span class="font-medium">Cause: </span> keeper directory unavailable, manual entry only.
+                <span class="font-medium">Cause: </span> keeper 디렉토리 사용 불가, 수동 입력만 가능.
               </div>
               <div class="mt-1">
-                <span class="font-medium">Next: </span> continue with manual entry now, then restore <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> or fix <code class="rounded bg-[var(--white-4)] px-1">/api/v1/gate/keepers</code> before relying on directory suggestions.
+                <span class="font-medium">Next: </span> 지금은 수동 입력으로 진행, 이후 <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> 복원 또는 <code class="rounded bg-[var(--white-4)] px-1">/api/v1/gate/keepers</code> 수정 후 디렉토리 추천에 의존하세요.
               </div>
             </div>
           `


### PR DESCRIPTION
## 변경
`connector-status.ts:974, 977`:
- Cause body: `keeper 디렉토리 사용 불가, 수동 입력만 가능`
- Next body: `지금은 수동 입력으로 진행, 이후 ...`

`Cause:`/`Next:` labels는 같은 파일의 다른 panels 일관성으로 보존.

## Test sync
`connector-status.test.ts:414-415`: `toContain` substring 한국어 동기.

## 영향 범위
2 files (source + test), 4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)