### PR TITLE
feat(dashboard): ErrorRecoverable + ErrorFatal 2-tier error (Stage 2)

### DIFF
--- a/dashboard/src/components/common/feedback-state.test.ts
+++ b/dashboard/src/components/common/feedback-state.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { ErrorRecoverable, ErrorFatal } from './feedback-state'
+
+describe('ErrorRecoverable', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a role=alert section with title text', () => {
+    render(html`<${ErrorRecoverable} title="Cascade fallback exhausted" />`, container)
+    const section = container.querySelector('section')!
+    expect(section).toBeTruthy()
+    expect(section.getAttribute('role')).toBe('alert')
+    expect(section.textContent).toContain('Cascade fallback exhausted')
+    expect(section.textContent).toContain('복구 가능')
+  })
+
+  it('renders detail line when provided', () => {
+    render(
+      html`<${ErrorRecoverable}
+        title="provider:openai"
+        detail="2 fallback hops, timed out at 12.4s"
+      />`,
+      container,
+    )
+    expect(container.textContent).toContain('2 fallback hops, timed out at 12.4s')
+  })
+
+  it('omits the retry button when onRetry is not supplied', () => {
+    render(html`<${ErrorRecoverable} title="t" />`, container)
+    expect(container.querySelector('button')).toBeNull()
+  })
+
+  it('renders a retry button that calls onRetry on click', () => {
+    const onRetry = vi.fn()
+    render(html`<${ErrorRecoverable} title="t" onRetry=${onRetry} />`, container)
+    const btn = container.querySelector('button')!
+    expect(btn).toBeTruthy()
+    expect(btn.textContent).toContain('다시 시도')
+    btn.click()
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors a custom retryLabel', () => {
+    render(
+      html`<${ErrorRecoverable}
+        title="t"
+        onRetry=${() => {}}
+        retryLabel="재시도"
+      />`,
+      container,
+    )
+    expect(container.querySelector('button')!.textContent).toContain('재시도')
+  })
+})
+
+describe('ErrorFatal', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a role=alert section with title text', () => {
+    render(html`<${ErrorFatal} title="Cockpit lost connection" />`, container)
+    const section = container.querySelector('section')!
+    expect(section.getAttribute('role')).toBe('alert')
+    expect(section.textContent).toContain('Cockpit lost connection')
+    expect(section.textContent).toContain('치명적')
+  })
+
+  it('renders detail line when provided', () => {
+    render(
+      html`<${ErrorFatal}
+        title="WebSocket closed"
+        detail="Reconnect attempts: 3/3 exhausted"
+      />`,
+      container,
+    )
+    expect(container.textContent).toContain('Reconnect attempts: 3/3 exhausted')
+  })
+
+  it('omits the reload button when onReload is not supplied', () => {
+    render(html`<${ErrorFatal} title="t" />`, container)
+    expect(container.querySelector('button')).toBeNull()
+  })
+
+  it('renders a reload button that calls onReload on click', () => {
+    const onReload = vi.fn()
+    render(html`<${ErrorFatal} title="t" onReload=${onReload} />`, container)
+    const btn = container.querySelector('button')!
+    expect(btn).toBeTruthy()
+    expect(btn.textContent).toContain('다시 불러오기')
+    btn.click()
+    expect(onReload).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors a custom reloadLabel', () => {
+    render(
+      html`<${ErrorFatal}
+        title="t"
+        onReload=${() => {}}
+        reloadLabel="새로고침"
+      />`,
+      container,
+    )
+    expect(container.querySelector('button')!.textContent).toContain('새로고침')
+  })
+
+  it('uses the danger variant button (background tint)', () => {
+    render(html`<${ErrorFatal} title="t" onReload=${() => {}} />`, container)
+    const btn = container.querySelector('button')!
+    // ActionButton danger variant maps to bg-[var(--bad-10)] in button.ts.
+    expect(btn.className).toContain('bg-[var(--bad-10)]')
+  })
+})

--- a/dashboard/src/components/common/feedback-state.ts
+++ b/dashboard/src/components/common/feedback-state.ts
@@ -1,8 +1,17 @@
 // FeedbackState primitives — consistent empty/loading/error messages.
+//
+// 1-tier (existing): EmptyState, LoadingState, ErrorState — single
+// message. ErrorState is the catch-all for unstructured failures.
+//
+// 2-tier (added per design-system v0.4 cb-group-g SPEC §G3): split
+// recoverable/fatal so callers can distinguish "tried-and-bounced,
+// retry will likely work" from "session/connection broken, reload
+// is the only path forward". Each tier exposes a primary action slot.
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
-import { AlertTriangle, Loader2 } from 'lucide-preact'
+import { AlertTriangle, AlertOctagon, Loader2, RefreshCw } from 'lucide-preact'
+import { ActionButton } from './button'
 
 interface EmptyStateProps {
   message?: string
@@ -58,5 +67,105 @@ export function ErrorState({ message, class: cx }: ErrorStateProps) {
       <${AlertTriangle} size=${16} class="mt-0.5 shrink-0" aria-hidden="true" />
       <span>${message}</span>
     </div>
+  `
+}
+
+interface ErrorRecoverableProps {
+  /** One-line summary surfaced as the alert headline. */
+  title: string
+  /** Optional second line — caller-supplied context (timing, provider,
+      retry count). Rendered in the muted secondary tone. */
+  detail?: string
+  /** Click handler for the inline retry action. When omitted the button
+      is not rendered (caller may be queueing retries elsewhere). */
+  onRetry?: () => void
+  /** Override the retry button label. Default: "다시 시도". */
+  retryLabel?: string
+  class?: string
+}
+
+/** Soft / amber tier — the operation bounced through fallback paths
+    and ended up in a state where another attempt will likely succeed
+    (e.g. cascade exhausted at provider X, retry will rotate to Y). */
+export function ErrorRecoverable({
+  title,
+  detail,
+  onRetry,
+  retryLabel = '다시 시도',
+  class: cx,
+}: ErrorRecoverableProps) {
+  return html`
+    <section
+      role="alert"
+      class="flex flex-col gap-2 rounded border border-[var(--warn-20)] border-l-[3px] border-l-[var(--warn)] bg-[var(--warn-soft)] px-4 py-3 ${cx ?? ''}"
+    >
+      <div class="flex items-center gap-2">
+        <${AlertTriangle} size=${16} class="shrink-0 text-[var(--warn-bright)]" aria-hidden="true" />
+        <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--warn-bright)]">
+          복구 가능
+        </span>
+        ${onRetry ? html`
+          <span class="ml-auto">
+            <${ActionButton} variant="ghost" size="sm" onClick=${onRetry}>
+              <span class="inline-flex items-center gap-1">
+                <${RefreshCw} size=${12} aria-hidden="true" />
+                ${retryLabel}
+              </span>
+            <//>
+          </span>
+        ` : null}
+      </div>
+      <div class="text-sm text-[var(--color-fg-primary)]">${title}</div>
+      ${detail ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${detail}</div>` : null}
+    </section>
+  `
+}
+
+interface ErrorFatalProps {
+  /** One-line summary surfaced as the alert headline. */
+  title: string
+  /** Optional second line — caller-supplied context (which connection,
+      when it dropped, exhausted reconnect count). */
+  detail?: string
+  /** Click handler for the inline reload action. When omitted the
+      button is not rendered (caller may have a different recovery
+      surface like a top-level reload modal). */
+  onReload?: () => void
+  /** Override the reload button label. Default: "다시 불러오기". */
+  reloadLabel?: string
+  class?: string
+}
+
+/** Hard / bad tier — the underlying connection or session is gone and
+    no retry of the in-flight operation will help. Reload is the path
+    forward (e.g. WebSocket closed, auth token expired). */
+export function ErrorFatal({
+  title,
+  detail,
+  onReload,
+  reloadLabel = '다시 불러오기',
+  class: cx,
+}: ErrorFatalProps) {
+  return html`
+    <section
+      role="alert"
+      class="flex flex-col gap-2 rounded border border-[var(--bad-20)] border-l-[3px] border-l-[var(--bad)] bg-[var(--bad-soft)] px-4 py-3 ${cx ?? ''}"
+    >
+      <div class="flex items-center gap-2">
+        <${AlertOctagon} size=${16} class="shrink-0 text-[var(--bad-light)]" aria-hidden="true" />
+        <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--bad-light)]">
+          치명적
+        </span>
+        ${onReload ? html`
+          <span class="ml-auto">
+            <${ActionButton} variant="danger" size="sm" onClick=${onReload}>
+              ${reloadLabel}
+            <//>
+          </span>
+        ` : null}
+      </div>
+      <div class="text-sm text-[var(--color-fg-primary)]">${title}</div>
+      ${detail ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${detail}</div>` : null}
+    </section>
   `
 }


### PR DESCRIPTION
## Why

Stage 2 of the design-system v0.4 rollout, follow-up to #10898 (folder sync) and #10955 (KeeperBadge primitive). The dashboard's existing `ErrorState` is 1-tier — a single message inside a single tone. The design-system v0.4 cb-group-g SPEC §G3 splits this into **recoverable** (retry will likely succeed) and **fatal** (reload is the only path forward) so error UI matches the actual recovery path.

This PR introduces both tiers as **additions** — `ErrorState` is unchanged, so no caller is forced to migrate.

## What

`src/components/common/feedback-state.ts` — added `ErrorRecoverable` and `ErrorFatal` exports.

| Tier | Tone | Icon | Action |
|------|------|------|--------|
| `ErrorRecoverable` | warn / amber + 3px left border | AlertTriangle | `ActionButton variant=ghost` (default label "다시 시도") |
| `ErrorFatal` | bad / red + 3px left border | AlertOctagon | `ActionButton variant=danger` (default label "다시 불러오기") |

Both:
- Render `role="alert"` + headline + optional muted detail line.
- Render the action button **only when** its handler (`onRetry` / `onReload`) is supplied — caller may queue retries elsewhere or have a higher-level reload modal.
- Accept a `class` for outer-layout integration and a label override for non-default verbiage.
- Keep the existing 1-tier `ErrorState` import surface intact.

## Why split, not parameterize?

Considered a single `ErrorState({ tier: 'recoverable' | 'fatal' })` API but rejected: the two tiers diverge in **semantic intent + button variant + icon**, and parameterizing would push that conditional into every caller. Splitting names the intent at the import site (`import { ErrorFatal } from './feedback-state'`) and lets future tier-specific extensions land without growing a single switch statement.

## What this PR does NOT change

- `ErrorState` 1-tier — still exported, still the right choice for unstructured failure messages.
- No callsite migration. Existing `ErrorState` callers stay as-is. Stage 3+ will sweep specific surfaces to the appropriate tier (cascade fallback exhausted → `ErrorRecoverable`, WebSocket closed → `ErrorFatal`).
- No `LoadingState` / `EmptyState` changes. Skeleton primitives are intentionally out of scope — `dashboard/src/components/common/skeleton.ts` already exists with its own design decisions.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run src/components/common/feedback-state.test.ts` — 11/11 pass
  - Rendering: `role="alert"`, title text, "복구 가능" / "치명적" sublabel
  - Optional detail line surfaces when provided
  - Action button absence when no handler / presence when handler supplied
  - Click invokes handler exactly once
  - `retryLabel` / `reloadLabel` overrides honored
  - Danger-variant button class surfaces (`bg-[var(--bad-10)]`)
- [ ] Visual smoke: render both tiers under default (dark) theme — queued for the migration PR that picks the first callsite

## Refs

- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`
- SPEC: `dashboard/design-system/preview/cb-group-g.jsx` (ErrorRecoverable + ErrorFatal at lines 211–303)
- Predecessors: #10898 (design-system folder sync), #10955 (KeeperBadge primitive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
