### PR TITLE
refactor(design-system): add ActionButton warn variant + migrate keeper wakeup (PR-CS75)

### DIFF
--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -12,7 +12,7 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'subtle' | 'ok'
+type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'subtle' | 'ok' | 'warn'
 type ButtonSize = 'sm' | 'md' | 'lg'
 type ButtonType = 'button' | 'submit' | 'reset'
 
@@ -28,6 +28,7 @@ const VARIANT_CLASSES: Record<ButtonVariant, string> = {
   danger: 'border border-solid border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-20)]',
   subtle: 'border-none bg-transparent text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] hover:bg-[var(--white-6)]',
   ok: 'border border-solid border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)] hover:bg-[var(--ok-20)]',
+  warn: 'border-none bg-[var(--warn-14)] text-[var(--color-status-warn)] hover:bg-[var(--warn-24)]',
 }
 
 // Pressed-state overrides per variant. Applied when `pressed=true` so the
@@ -41,6 +42,7 @@ const PRESSED_CLASSES: Record<ButtonVariant, string> = {
   danger: 'bg-[var(--bad-20)]',
   subtle: 'bg-[var(--white-6)] text-[var(--color-fg-primary)]',
   ok: 'bg-[var(--ok-20)]',
+  warn: 'bg-[var(--warn-24)]',
 }
 
 const BASE = 'rounded cursor-pointer transition-all duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] active:scale-[0.97] active:opacity-90'

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -302,12 +302,14 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
               onClick=${() => handleDirective('pause')}
             >일시정지</button>
             ${(hbStale || runtimeBlockerClass === 'oas_timeout_budget' || runtimeBlockerClass === 'cascade_exhausted' || runtimeBlockerClass === 'turn_timeout')
-              ? html`<button
-                  class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--warn-14)] hover:bg-[var(--warn-24)] text-[var(--color-status-warn)] transition-colors disabled:opacity-50"
+              ? html`<${ActionButton}
+                  variant="warn"
+                  size="sm"
+                  class="!py-0.5 inline-flex items-center"
                   disabled=${directiveLoading.value}
                   onClick=${() => handleDirective('wakeup')}
                   title="자고 있는 keeper의 sleep을 깨워 다음 turn을 시도합니다. fiber가 살아 있을 때만 효과가 있습니다."
-                >깨우기</button>`
+                >깨우기<//>`
               : null}`}
         ${keeper.paused && keeper.keepalive_running && continueGate
           ? html`<span>하트비트는 유지되지만 승인 전까지 자동 재개하지 않습니다.</span>`


### PR DESCRIPTION
## 요약
- ActionButton에 warn-tone `warn` variant 추가 (총 6 variant: primary/ghost/danger/subtle/ok/warn).
- keeper-detail.ts wakeup chip 즉시 마이그레이션해 variant 실작동 검증.

## Why
warn-tone 인라인 chip은 dashboard NEEDS-VARIANT 후보 12+ callsite. 기존 5 variant로 amber/warn 의도 표현 불가 → file-parallel batch 마이그레이션 차단.

이 PR은 v0.4 design-system 전체 적용 plan의 **Phase A (Sequential, button.ts 잠금)** 첫 PR. CS75(warn) → CS76(tonal) → Phase B/C/D file-parallel batches.

## Tokens
- `warn`: `border-none bg-[var(--warn-14)] text-[var(--color-status-warn)] hover:bg-[var(--warn-24)]`
- `pressed.warn`: `bg-[var(--warn-24)]`
- 다른 variant와 달리 `border-none` 채택 — 실제 dashboard의 유일한 warn-button 패턴(keeper-detail wakeup chip)이 borderless이기 때문. 변형이 실 사용에 맞춰 정의됨.

## Migrated
- `keeper-detail.ts:305` wakeup chip → `variant=\"warn\" size=\"sm\"`, `class=\"!py-0.5 inline-flex items-center\"` (chip padding 보존).

## Test
- vitest 25/25 (button.test) 그린
- pnpm typecheck pass
- 시각 회귀 0 — token/hover/border-none 모두 동치

## 후속
- **PR-CS76**: tonal variant 추가 (accent-soft 기반, 18 callsite unblock)
- **Phase B (parallel x3)**: file-disjoint CLEAN 마이그레이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)