### PR TITLE
fix(scripts/cleanup-autoresearch): help no longer bleeds non-comment lines

### DIFF
--- a/scripts/cleanup-autoresearch.sh
+++ b/scripts/cleanup-autoresearch.sh
@@ -31,7 +31,7 @@ APPLY=0
 for arg in "$@"; do
   case "$arg" in
     --apply) APPLY=1 ;;
-    -h|--help) sed -n '1,30p' "$0"; exit 0 ;;
+    -h|--help) awk '/^[^#]/ && NF { exit } { print }' "$0"; exit 0 ;;
     *) echo "unknown arg: $arg" >&2; exit 2 ;;
   esac
 done


### PR DESCRIPTION
## Why

`/simplify` 리뷰에서 발견된 **help 출력 버그**:

`-h | --help` 플래그가 `sed -n '1,30p' "$0"` 를 실행 — 하드코딩된 30 라인 출력. 실제 주석 블록은 L1-27 (1 shebang + 25 comment lines + 1 blank). L28-30 (`set -euo pipefail` + blank + `APPLY=0`) 이 help 출력에 끼어 있었음.

## Fix

```bash
# Before
-h|--help) sed -n '1,30p' "$0"; exit 0 ;;
# After
-h|--help) awk '/^[^#]/ && NF { exit } { print }' "$0"; exit 0 ;;
```

`awk` 가 첫 non-empty non-comment 라인에서 exit. 라인 수 하드코딩 제거. 향후 주석 추가/제거 시 자동 따라감.

## Self-test

```
$ bash scripts/cleanup-autoresearch.sh --help | wc -l
27        # was 30 with bleed-through

$ bash scripts/cleanup-autoresearch.sh --help | tail -1
# files and unrelated tools that happen to be reading the dir.
                                                              # (last comment line, no `set -euo pipefail`)
```

## Out of scope

`/simplify` 가 추가로 발견한 항목들 — 전부 보류:
- Reuse: `cleanup-merged-worktrees.sh` 와 arg-parser/help/counter 패턴 중복 — 별도 helper 추출 PR 필요.
- Efficiency: dry-run `du -sh` per-candidate cost — 일반적 입력 (<20 candidates) 에서 1-4s 허용 범위.
- Smell: `TTL_DAYS` 가 L53 + L56 에서 두 번 참조 — 단일 변경 시 양쪽 수정 필요한 미세 결합.

## Refs

- Source: PR #10913 (cleanup-autoresearch.sh 신설)
- Issue: #10892 (autoresearch leak option A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)