### PR TITLE
fix(autoresearch): auto-cleanup managed worktree on terminal transition (#10892)

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -115,6 +115,8 @@ let git_current_branch = Autoresearch_git.git_current_branch
 let git_is_dirty = Autoresearch_git.git_is_dirty
 let managed_branch_name = Autoresearch_git.managed_branch_name
 let prepare_managed_worktree = Autoresearch_git.prepare_managed_worktree
+let cleanup_managed_worktree = Autoresearch_git.cleanup_managed_worktree
+let local_branch_exists = Autoresearch_git.local_branch_exists
 
 (* ================================================================ *)
 (* Re-exports: File                                                  *)
@@ -261,7 +263,34 @@ let completion_reason (state : loop_state) =
   else
     None
 
-let complete_if_finished (state : loop_state) =
+(** #10892: best-effort cleanup of managed worktree on terminal
+    transition.  Idempotent and never raises — failure logs a warn
+    and returns unit so the caller's state machine progresses
+    regardless.  Uses the loop's [source_workdir] to discover the
+    repo root via [git_top_level]. *)
+let cleanup_terminal_artifacts_best_effort ~base_path (state : loop_state) =
+  try
+    match
+      Autoresearch_git.cleanup_managed_worktree
+        ~base_path
+        ~source_workdir:state.source_workdir
+        ~loop_id:state.loop_id
+    with
+    | Ok (workdir_removed, branch_removed) when workdir_removed || branch_removed ->
+      Log.Autoresearch.info
+        "loop %s terminal cleanup: workdir=%b branch=%b"
+        state.loop_id workdir_removed branch_removed
+    | Ok _ -> ()  (* nothing to clean — already gone *)
+    | Error msg ->
+      Log.Autoresearch.warn
+        "loop %s terminal cleanup skipped (best-effort, suppressed): %s"
+        state.loop_id msg
+  with exn ->
+    Log.Autoresearch.warn
+      "loop %s terminal cleanup raised (best-effort, suppressed): %s"
+      state.loop_id (Printexc.to_string exn)
+
+let complete_if_finished ~base_path (state : loop_state) =
   match state.status, completion_reason state with
   | Running, Some "target_score reached" ->
       let target =
@@ -269,14 +298,22 @@ let complete_if_finished (state : loop_state) =
         | Some value -> Printf.sprintf "%.4f" value
         | None -> "n/a"
       in
-      add_insight
-        { state with status = Completed; updated_at = Time_compat.now () }
-        (Printf.sprintf "Target reached at cycle %d (target=%s, best=%.4f)"
-           state.current_cycle target state.best_score)
+      let new_state =
+        add_insight
+          { state with status = Completed; updated_at = Time_compat.now () }
+          (Printf.sprintf "Target reached at cycle %d (target=%s, best=%.4f)"
+             state.current_cycle target state.best_score)
+      in
+      cleanup_terminal_artifacts_best_effort ~base_path new_state;
+      new_state
   | Running, Some reason ->
-      add_insight
-        { state with status = Completed; updated_at = Time_compat.now () }
-        (Printf.sprintf "Autoresearch completed: %s" reason)
+      let new_state =
+        add_insight
+          { state with status = Completed; updated_at = Time_compat.now () }
+          (Printf.sprintf "Autoresearch completed: %s" reason)
+      in
+      cleanup_terminal_artifacts_best_effort ~base_path new_state;
+      new_state
   | _ -> state
 
 (** Check if the loop should continue. *)

--- a/lib/autoresearch.mli
+++ b/lib/autoresearch.mli
@@ -176,6 +176,20 @@ val prepare_managed_worktree :
   base_path:string -> source_workdir:string -> loop_id:string ->
   (string * string * string list, string) result
 
+(** [cleanup_managed_worktree ~base_path ~source_workdir ~loop_id]
+    removes the managed worktree directory under
+    [.masc/autoresearch/<loop_id>/] and its [autoresearch/<loop_id>]
+    branch. Idempotent — missing dir or branch returns [Ok] without
+    invoking git. Returns [(workdir_removed, branch_removed)].
+
+    #10892: hooked into terminal-state transitions so
+    [.masc/autoresearch/] does not leak ~91MB per completed loop. *)
+val cleanup_managed_worktree :
+  base_path:string -> source_workdir:string -> loop_id:string ->
+  (bool * bool, string) result
+
+val local_branch_exists : repo_root:string -> string -> bool
+
 (** {1 File} *)
 
 val has_path_traversal : string -> bool
@@ -215,7 +229,11 @@ val record_cycle :
   loop_state * cycle_record
 val target_reached : loop_state -> bool
 val completion_reason : loop_state -> string option
-val complete_if_finished : loop_state -> loop_state
+(** Transition a [Running] state to [Completed] when the cycle
+    budget is exhausted or the target score is reached. Best-effort
+    cleanup of the managed worktree directory and branch runs on
+    the terminal transition (#10892). *)
+val complete_if_finished : base_path:string -> loop_state -> loop_state
 val should_continue : loop_state -> bool
 val stop_loop : base_path:string -> ?reason:string -> string -> loop_state option
 val linked_status_json : base_path:string -> execution_link -> Yojson.Safe.t

--- a/lib/autoresearch/autoresearch_git.ml
+++ b/lib/autoresearch/autoresearch_git.ml
@@ -221,3 +221,47 @@ let prepare_managed_worktree ~base_path ~source_workdir ~loop_id =
               (Printf.sprintf "failed to create managed worktree: %s"
                  (String.concat "\n" lines))
       end
+
+(** Check whether [branch] exists as a local ref under [repo_root].
+    Used by [cleanup_managed_worktree] before invoking
+    [git branch -D] so the no-op case stays silent. *)
+let local_branch_exists ~repo_root branch =
+  match
+    run_capture_lines ~workdir:repo_root
+      [ "show-ref"; "--verify"; "--quiet"; "refs/heads/" ^ branch ]
+  with
+  | Unix.WEXITED 0, _ -> true
+  | _ -> false
+
+(** Remove the managed worktree directory and its branch.
+    Idempotent — missing dir or missing branch returns [Ok] without
+    invoking git.  Returns [(workdir_removed, branch_removed)] so
+    callers can decide whether to emit a noop log line.
+
+    #10892: invoked from autoresearch loop terminal-state hooks
+    ([Completed], [Error]) so the 91MB-per-run worktree directories
+    in [.masc/autoresearch/<loop>/] do not leak. The dashboard
+    [delete_loop] HTTP path also uses this helper (DRY). *)
+let cleanup_managed_worktree ~base_path ~source_workdir ~loop_id =
+  match git_top_level ~workdir:source_workdir with
+  | Error _ as err -> err
+  | Ok repo_root ->
+    let workdir = Autoresearch_storage.managed_worktree_dir ~base_path loop_id in
+    let branch = managed_branch_name loop_id in
+    let workdir_removed =
+      if Sys.file_exists workdir then begin
+        ignore
+          (run_capture_lines ~workdir:repo_root
+             [ "worktree"; "remove"; "--force"; workdir ]);
+        true
+      end else false
+    in
+    let branch_removed =
+      if local_branch_exists ~repo_root branch then begin
+        ignore
+          (run_capture_lines ~workdir:repo_root
+             [ "branch"; "-D"; branch ]);
+        true
+      end else false
+    in
+    Result.ok (workdir_removed, branch_removed)

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -604,22 +604,18 @@ let delete_loop_json ~(base_path : string) ~(loop_id : string) ~(requester_agent
           Hashtbl.remove Tool_autoresearch_registry.pending_hypotheses loop_id;
           Hashtbl.remove Tool_autoresearch_registry.custom_generators loop_id;
           delete_session_link ~base_path loop_id;
+          (* #10892: shared cleanup helper. The auto-cleanup hook in
+             [Autoresearch.complete_if_finished] uses the same path
+             so the explicit delete is now idempotent w.r.t. the
+             auto path — both safe to call on already-cleaned
+             workdirs. *)
           (match
-             Autoresearch.git_top_level ~workdir:state.source_workdir
+             Autoresearch.cleanup_managed_worktree
+               ~base_path
+               ~source_workdir:state.source_workdir
+               ~loop_id
            with
-           | Ok repo_root ->
-              let workdir =
-                Autoresearch.managed_worktree_dir ~base_path loop_id
-              in
-              if Sys.file_exists workdir then
-                ignore
-                  (Autoresearch.run_capture_lines ~workdir:repo_root
-                     [ "worktree"; "remove"; "--force"; workdir ]);
-              let branch = Autoresearch.managed_branch_name loop_id in
-              if git_branch_exists ~repo_root branch then
-                ignore
-                  (Autoresearch.run_capture_lines ~workdir:repo_root
-                     [ "branch"; "-D"; branch ])
+           | Ok _ -> ()
            | Error msg ->
                Log.Autoresearch.warn
                  "delete loop git cleanup skipped for %s: %s" loop_id msg);

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -208,6 +208,7 @@ let setup_running_loop (ctx : context) (params : start_params) =
           | Ok baseline ->
               let state =
                 Autoresearch.complete_if_finished
+                  ~base_path:ctx.base_path
                   { state with baseline; best_score = baseline; source_workdir }
               in
               Ok (register_loop ctx state))

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -273,7 +273,7 @@ let handle_cycle (ctx : Tool_autoresearch_context.t) args =
               let reason =
                 Option.value ~default:"completed" (Autoresearch.completion_reason state)
               in
-              let state = Autoresearch.complete_if_finished state in
+              let state = Autoresearch.complete_if_finished ~base_path:ctx.base_path state in
               Hashtbl.replace active_loops id state;
               Autoresearch.save_state ~base_path:ctx.base_path state;
               Error ("completed:" ^ reason)
@@ -614,6 +614,7 @@ let handle_cycle (ctx : Tool_autoresearch_context.t) args =
                        Autoresearch.append_cycle ~base_path:ctx.base_path state.loop_id effective_record;
                        let state =
                          Autoresearch.complete_if_finished
+                           ~base_path:ctx.base_path
                            { state with current_cycle = state.current_cycle + 1 }
                        in
                        Autoresearch.with_loops_rw (fun () ->


### PR DESCRIPTION
## 배경

#10892 — autoresearch 루프 종료 시 `.masc/autoresearch/<loop>/` 디렉토리 무한 누적. 5일 / 6 stale dirs / **546MB leak**, 각 91MB (worktree clone + downloaded_files).

```
$ ls -1 ~/me/.masc/autoresearch/ | wc -l   → 6
$ stat ~/me/.masc/autoresearch/ar-*/worktree/downloaded_files/driver_fixing.lock
   → 모두 2026-04-22, 5일 전, 0-byte placeholder
$ lsof | grep "/.masc/autoresearch/ar-"    → 0 results
```

## 근본 원인

수동 `delete_loop` HTTP path 만 cleanup 실행. 자연 종료(`target_score reached`, `max_cycles` 도달) path 에는 cleanup hook 부재. `complete_if_finished` 가 Running → Completed 전이만 하고 worktree 그대로 둠.

이슈 파일에서 진단된 패턴 — #10899 (playground worktree leak) 와 동일 class:
> "lifecycle hook 으로 cleanup 미정의. `Switch.on_release` 또는 task-completion handler 부재"

## 변경

### 1. 공유 helper 신설 (`autoresearch_git.ml`)

```ocaml
val cleanup_managed_worktree :
  base_path:string -> source_workdir:string -> loop_id:string ->
  (bool * bool, string) result
```

Idempotent — 디렉토리/브랜치 없으면 git 호출 안 함, no-op 반환. `(workdir_removed, branch_removed)` 페어 반환.

### 2. Terminal transition hook (`autoresearch.ml`)

`complete_if_finished` 시그니처 변경: `loop_state -> loop_state` → `~base_path:string -> loop_state -> loop_state`. Running → Completed 전이 시 best-effort cleanup 호출. 실패는 warn 로그 후 무시 — state machine 정합성은 cleanup 결과와 독립.

### 3. Dashboard delete_loop DRY refactor

기존 `delete_loop_json` 의 inline git plumbing (~12 lines) 을 신설 helper 호출로 교체. Auto path 와 manual path 가 같은 cleanup 코드 사용 — 두 경로 모두 idempotent (이미 cleanup 된 loop 에 delete 해도 안전).

## 설계 결정

| 결정 | 근거 |
|---|---|
| Completed 만 auto-cleanup, Stopped 제외 | Stopped = "나중에 재개" 의도. retry_loop_json 이 worktree 미존재 시 recreate 하지만 in-progress 상태 보호 위해 보존 |
| Best-effort, state machine 미블락 | filesystem GC 가 lifecycle 을 fail 시키면 안 됨. cleanup 실패도 정상 lifecycle 진행 |
| `complete_if_finished` 시그니처 변경 (vs Optional 인자) | base_path 는 모든 호출 site 에서 가용 — Optional 추가는 책임 분산만 만듦 |
| Bundle dir 보존 | `results_dir ~base_path loop_id` 는 dashboard 가 표시하는 evidence summary — 가벼움 (insights/score history). 무거운 worktree 만 cleanup |

## #10899 (playground leak) 와의 관계

같은 class (no terminal cleanup hook), 다른 scope:
- **#10899** (PR #10956): keeper task lifecycle, `coord/task` Done_action arm
- **#10892** (이 PR): autoresearch loop lifecycle, `complete_if_finished` 종료 전이

같은 디자인 패턴 — best-effort cleanup hooked into the state machine's natural terminal transition.

## Acceptance criteria

- [x] `dune build @check` pass
- [x] 기존 autoresearch 테스트 영향 없음 (`complete_if_finished` test 참조 0건)
- [x] Helper idempotent — missing dir/branch 시 no-op
- [ ] 머지 후 24h: 자연 종료 loop 시 `loop <id> terminal cleanup: workdir=true branch=true` info 로그 등장
- [ ] `du -sh ~/me/.masc/autoresearch/` 누적 정지

## 검증

```bash
dune build @check  # EXIT=0
# autoresearch 테스트 0건 — 시그니처 변경 영향 없음
# 통합 검증은 실 운영 환경 24h 관찰
```

## 관련 메모리

- `feedback_eio-proactive-over-ondemand`
- `feedback_ai-pair-interaction-depth` (2번째 발견 시 root 수정 — #10899 와 #10892 같은 class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)