### PR TITLE
perf(dashboard): migrate fsm-hub timeline children + move dwellHistograms

### DIFF
--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -3,17 +3,18 @@ import { useSignal } from '@preact/signals'
 import { useEffect, useMemo, useRef } from 'preact/hooks'
 import { DashedNotice } from './common/dashed-notice'
 import { TextInput } from './common/input'
+import { nowSecondsSignal, useNowSecondsTicker } from '../lib/now-signal'
 
 import {
   type CompositeObservation,
   type HoveredSegment,
-  type LaneDwell,
   type LaneKey,
   type TopTransition,
   fmtDuration,
   displayState,
 } from './fsm-hub-types'
 import {
+  deriveLaneDwellHistograms,
   deriveSwimlaneSegments,
   deriveTimeAxisTicks,
   inferTransitionReason,
@@ -118,15 +119,15 @@ function handleSwimlaneKey(
 
 export function SwimlaneTimeline({
   observations,
-  now,
   hoveredSegment,
   onHoverSegment,
 }: {
   observations: CompositeObservation[]
-  now: number
   hoveredSegment: HoveredSegment | null
   onHoverSegment: (seg: HoveredSegment | null) => void
 }) {
+  useNowSecondsTicker()
+  const now = nowSecondsSignal.value
   if (observations.length === 0) {
     return html`
       <${DashedNotice} borderTone="subtle">
@@ -348,13 +349,13 @@ export function filterTransitionHistory(
 
 export function TransitionTrail({
   history,
-  now,
   hoveredSegment,
 }: {
   history: TransitionHistoryEntry[]
-  now: number
   hoveredSegment: HoveredSegment | null
 }) {
+  useNowSecondsTicker()
+  const now = nowSecondsSignal.value
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const query = useSignal('')
   const visibleHistory = useMemo(
@@ -507,12 +508,23 @@ const BAR_COLOR: Record<string, string> = {
 }
 
 export function DwellHistogramPanel({
-  histograms,
+  observations,
   hoveredSegment,
 }: {
-  histograms: LaneDwell[]
+  observations: CompositeObservation[]
   hoveredSegment: HoveredSegment | null
 }) {
+  // Owns its own 5 s clock subscription + dwell-histogram derivation —
+  // previously the parent fsm-hub computed dwellHistograms in a useMemo
+  // with `now` as a dep, causing the parent to recompute every 5 s.
+  // Moving the derivation here keeps fsm-hub stable on ticks; only this
+  // panel and its render output update.
+  useNowSecondsTicker()
+  const now = nowSecondsSignal.value
+  const histograms = useMemo(
+    () => deriveLaneDwellHistograms(observations, now),
+    [observations, now],
+  )
   if (histograms.length === 0) {
     return html`
       <${DashedNotice} borderTone="subtle">

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -29,7 +29,6 @@ import {
   observeSnapshot,
   appendCompositeObservation,
   deriveTopTransitions,
-  deriveLaneDwellHistograms,
   deriveTransitionHistory,
   derivePhaseLog,
   deriveStateEntries,
@@ -505,10 +504,10 @@ export function FsmHub(props: FsmHubProps = {}) {
     () => deriveStateEntries(view.observations),
     [view.observations],
   )
-  const dwellHistograms = useMemo(
-    () => deriveLaneDwellHistograms(view.observations, now),
-    [view.observations, now],
-  )
+  // dwellHistograms moved into DwellHistogramPanel itself — that panel
+  // owns its own 5 s clock subscription so this component stays stable
+  // on ticks. (Previously this useMemo recomputed every 5 s because of
+  // the `now` dep, dragging fsm-hub through the same render every time.)
   const { snapshot, loading, error, lastFetchAt } = view
 
   const rootGap = density === 'compact' ? 'gap-1.5' : 'gap-3'
@@ -563,20 +562,19 @@ export function FsmHub(props: FsmHubProps = {}) {
             <${CollapsibleZone} id="swimlane" title="상태 타임라인" defaultOpen=${true}>
               <${SwimlaneTimeline}
                 observations=${view.observations}
-                now=${now}
                 hoveredSegment=${hoveredSegment}
                 onHoverSegment=${setHoveredSegment}
               />
             <//>
             ${/* ── Zone 3b: Transition History ── */ ''}
             <${CollapsibleZone} id="transition-trail" title="전환 이력" defaultOpen=${true}>
-              <${TransitionTrail} history=${history} now=${now} hoveredSegment=${hoveredSegment} />
+              <${TransitionTrail} history=${history} hoveredSegment=${hoveredSegment} />
             <//>
           </div>
           <div class="flex flex-col gap-3">
             ${/* ── Zone 3c: State Dwell Time ── */ ''}
             <${CollapsibleZone} id="dwell-histogram" title="상태 체류 시간" defaultOpen=${true}>
-              <${DwellHistogramPanel} histograms=${dwellHistograms} hoveredSegment=${hoveredSegment} />
+              <${DwellHistogramPanel} observations=${view.observations} hoveredSegment=${hoveredSegment} />
             <//>
             ${/* ── Zone 3d: Top Transitions ── */ ''}
             <${CollapsibleZone} id="top-transitions" title="빈발 전환" defaultOpen=${true}>


### PR DESCRIPTION
## Why

Cycle 10 of the iterative dashboard performance pass.  Second-of-three (cycles 9, 10, 11) that move the `nowSecondsSignal` read site from fsm-hub down to its leaves.  This PR is the **largest perf payoff** of the series because of the dwellHistograms useMemo move described below.

## What

Three components in `fsm-hub-timeline-panels.ts` now subscribe to `nowSecondsSignal` directly and drop the `now: number` prop:

| Component | now usage |
|-----------|-----------|
| `SwimlaneTimeline` | `Math.max(now, observations[last]?.ts ?? now)` for spanEnd |
| `TransitionTrail` | `fmtDuration(now - entry.ts)` for "ago" display |
| `DwellHistogramPanel` | **Moved useMemo inside** — props changed from `histograms` to `observations`. Internally calls `useNowSecondsTicker()` + `useMemo(() => deriveLaneDwellHistograms(observations, now), [observations, now])`. |

`fsm-hub.ts` removes the corresponding `dwellHistograms` useMemo (lines 508–511) and the `deriveLaneDwellHistograms` internal import (re-export at line 62 stays for backward compat).

| File | Change |
|------|--------|
| `dashboard/src/components/fsm-hub-timeline-panels.ts` | +import (now-signal + deriveLaneDwellHistograms), +`useNowSecondsTicker()`+`const now` in 3 components, -`now`/`histograms` from prop types, +useMemo inside DwellHistogramPanel |
| `dashboard/src/components/fsm-hub.ts` | -dwellHistograms useMemo, -3 `now=`/`histograms=` props, -unused internal import |

Net: 2 files, +25 -15.

## Why this PR is the largest payoff

The dwellHistograms useMemo had `now` as a dep, so it **recomputed every 5 s** and forced fsm-hub through the same render path every tick — even though only `DwellHistogramPanel` consumed the result.  Moving the derivation to the leaf means:

- Same wall-clock tick → only `DwellHistogramPanel` recomputes + re-renders
- fsm-hub itself is no longer pulled into the render scope by this useMemo
- Observation data invalidation (the `view.observations` dep) still triggers recomputation correctly because `observations` is still an input

## Stack position

- Cycle 1 (#10894 merged) — fsm-hub 1Hz → 5Hz tick
- Cycle 7 (#10918 merged) — `nowSecondsSignal` infra
- Cycle 8 (#10949 draft) — live-pulse 1 Hz refcount sweep (independent file)
- Cycle 9 (#10961 draft) — pipeline-panels children migration
- **Cycle 10 (this)** — timeline-panels children + dwellHistograms move
- Cycle 11 (next) — StatusBar inline + drop fsm-hub's own `useNowSecondsTicker`/`.value` read

Independent of cycle 9 — touches different fsm-hub.ts hunks (lines 508–511 useMemo + 564–579 children), auto-rebases cleanly.

## Test plan

- [x] `pnpm run typecheck` succeeds
- [x] `pnpm --filter masc-dashboard build` succeeds (production rollup, 1m 33s)
- [ ] After deploy, fsm-hub view: swimlane spanEnd advances, "전이 이력" rows tick the "X ago" string, "상태 체류 시간" histogram bars update on 5 s cadence (manual)