### PR TITLE
feat(dashboard): adopt KeeperBadge in safe-autonomy FindingsList (Stage 3a)

### DIFF
--- a/dashboard/src/components/safe-autonomy.ts
+++ b/dashboard/src/components/safe-autonomy.ts
@@ -7,6 +7,7 @@ import { Card } from './common/card'
 import { StatCard } from './common/stat-card'
 import { JsonViewerCard } from './common/json-viewer'
 import { EmptyState } from './common/empty-state'
+import { KeeperBadge } from './keeper-badge'
 import { formatTimeAgo } from '../lib/format-time'
 import {
   asBoolean,
@@ -282,7 +283,7 @@ function FindingsList({ findings }: { findings: FindingItem[] }) {
               <div class="flex flex-wrap items-center gap-2">
                 <code class="text-3xs text-[var(--color-fg-muted)]">${item.reason_code}</code>
                 <${StatusPill} status=${item.severity} />
-                ${item.keeper_name ? html`<span class="text-3xs text-[var(--color-fg-muted)]">${item.keeper_name}</span>` : null}
+                ${item.keeper_name ? html`<${KeeperBadge} id=${item.keeper_name} variant="full" size="sm" />` : null}
               </div>
               <div class="mt-1 text-sm text-[var(--color-fg-secondary)]">${item.summary}</div>
               <div class="mt-1 text-xs text-[var(--color-fg-muted)]">${item.suggested_next_action}</div>


### PR DESCRIPTION
## Why

**First callsite migration of `<KeeperBadge>`** (introduced in #10955) — the moment Stage 0–2's primitive work translates into a visible production change. The smallest possible scope so this PR doubles as a *pattern reference* for subsequent migrations: import path, prop choice, design-system SPEC §3.6 alignment.

`safe-autonomy.ts > FindingsList` previously rendered `keeper_name` as a small muted text span (`text-3xs text-fg-muted`), visually indistinguishable from the row's other secondary metadata (`reason_code` code chip, etc.). When an operator scans a list of safe-autonomy findings to triage scope, "who flagged this" is the *primary* axis they group on — the existing styling pushed it to the same hierarchy as throwaway codes.

After: 14px keeper-colored sigil + 11px keeper-colored name. Glanceable at a row-scan, two-channel (color + sigil) discriminable past the 6-keeper mark per SPEC §3.6, and survives grayscale / color-blindness via the sigil channel.

## What

`src/components/safe-autonomy.ts`:
- Import `KeeperBadge` from `./keeper-badge`.
- `FindingsList` row (line 285): replace the muted-span keeper_name render with `<KeeperBadge id={item.keeper_name} variant="full" size="sm" />`.

That's it. 2 lines, 1 file.

## Variant choice (`full` size `sm`)

| variant | renders | when |
|---|---|---|
| `sigil` | colored disc only | dense lists where name is rendered separately |
| **`full`** | **disc + name** | **canonical attribution, this case** |
| `name` | colored name only | discouraged (no two-channel) |

`size="sm"` (14px disc / 11px name) is the closest match to the previous `text-3xs` size; `md`/`lg` would visually dominate the row.

## What this PR does NOT do

- Other `keeper_name` sites in this file:
  - **Line 316 (TimelineList)** inlines the name into a description string (`"${item.kind} · ${item.keeper_name}"`). Different pattern shape — separate follow-up PR.
  - **Line 381 (KeeperCard)** is a separate `per_keeper` card module, not touched here.
- Other dashboard surfaces (`agent-detail-*`, `keeper-detail-*`, `keeper-chat-panel`, etc.) — each gets its own callsite-migration PR.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [ ] `pnpm exec vitest run` — no `safe-autonomy.test.ts` exists for this module (predates this PR), and `keeper-badge` already has full coverage from #10955. The change is too narrow to introduce a fresh test file.
- [ ] Visual smoke: trigger a safe-autonomy finding (or seed via mock data) and confirm the keeper renders with sigil + colored name. Queued for the next migration PR which will include a Playwright run.

## Refs

- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`
- Predecessors: #10898 (folder sync), #10955 (KeeperBadge primitive — MERGED)
- Sibling Stage 2 (still Draft): #10965 (ErrorRecoverable / ErrorFatal 2-tier)
- SPEC §3.6 v0.3: `dashboard/design-system/SPEC.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
