### PR TITLE
refactor(dashboard): extract createSharedTicker factory + dedup boilerplate

### DIFF
--- a/dashboard/src/components/common/time-ago.ts
+++ b/dashboard/src/components/common/time-ago.ts
@@ -7,10 +7,9 @@
 // "2분 전" without date context. Three render modes let callers pick
 // the density they need.
 
-import { signal } from '@preact/signals'
 import { html } from 'htm/preact'
-import { useEffect } from 'preact/hooks'
 import { formatTimeAgo, formatTimestampKo } from '../../lib/format-time'
+import { createSharedTicker } from '../../lib/shared-ticker'
 
 type TimeAgoMode = 'relative' | 'absolute' | 'both'
 
@@ -22,22 +21,8 @@ interface TimeAgoProps {
 }
 
 const CLOCK_TICK_MS = 30_000
-const relativeClock = signal(Date.now())
-let relativeClockTimer: number | null = null
-let relativeClockSubscribers = 0
-
-function startRelativeClock(): void {
-  if (relativeClockTimer != null || typeof window === 'undefined') return
-  relativeClockTimer = window.setInterval(() => {
-    relativeClock.value = Date.now()
-  }, CLOCK_TICK_MS)
-}
-
-function stopRelativeClock(): void {
-  if (relativeClockTimer == null || typeof window === 'undefined') return
-  window.clearInterval(relativeClockTimer)
-  relativeClockTimer = null
-}
+const clockTicker = createSharedTicker(CLOCK_TICK_MS)
+const relativeClock = clockTicker.signal
 
 /** Normalize a timestamp (ISO string, unix seconds, or unix ms) to ms.
     Exposed for unit tests so the normalization rule is verifiable. */
@@ -87,14 +72,7 @@ export function pickDisplayText(ts: string | number, mode: TimeAgoMode): string 
 }
 
 export function TimeAgo({ timestamp, mode = 'relative', class: cx }: TimeAgoProps) {
-  useEffect(() => {
-    relativeClockSubscribers += 1
-    startRelativeClock()
-    return () => {
-      relativeClockSubscribers = Math.max(0, relativeClockSubscribers - 1)
-      if (relativeClockSubscribers === 0) stopRelativeClock()
-    }
-  }, [])
+  clockTicker.use()
 
   // Subscribe to the tick so relative text refreshes without parent re-render.
   void relativeClock.value

--- a/dashboard/src/lib/now-signal.ts
+++ b/dashboard/src/lib/now-signal.ts
@@ -2,42 +2,24 @@
 //
 // Components that display elapsed durations (`fmtDuration(now - x)`)
 // previously each held a useState `now` and a setInterval, which means
-// every consumer paid for its own per-second/per-5-second re-render
-// scope.  Hoisting to a shared signal lets multiple consumers subscribe
-// to the same tick — and, more importantly, isolates the re-render
-// scope to the leaf component that actually reads the signal value
-// (Preact's signal model rerenders only the component that performed
-// the `.value` read at render time).
+// every consumer paid for its own per-5-second re-render scope.
+// Hoisting to a shared signal lets multiple consumers subscribe to the
+// same tick — and, more importantly, isolates the re-render scope to
+// the leaf component that actually reads the signal value (Preact's
+// signal model rerenders only the component that performed the `.value`
+// read at render time).
 //
-// The interval is module-level and refcounted: it starts on the first
-// `useNowSecondsTicker()` mount and stops when the last consumer
-// unmounts.  No background work runs when no component on the page
-// needs the tick.
+// The interval is module-level and refcounted via `createSharedTicker`:
+// it starts on the first `useNowSecondsTicker()` mount and stops when
+// the last consumer unmounts.  No background work runs when no component
+// on the page needs the tick.
 
-import { signal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { createSharedTicker } from './shared-ticker'
 
 const TICK_MS = 5_000
+const ticker = createSharedTicker(TICK_MS, () => Date.now() / 1000)
 
-export const nowSecondsSignal = signal(Date.now() / 1000)
-
-let intervalId: number | null = null
-let consumerCount = 0
-
-function startTicker(): void {
-  if (intervalId != null) return
-  if (typeof window === 'undefined') return
-  intervalId = window.setInterval(() => {
-    nowSecondsSignal.value = Date.now() / 1000
-  }, TICK_MS)
-}
-
-function stopTicker(): void {
-  if (intervalId == null) return
-  if (typeof window === 'undefined') return
-  window.clearInterval(intervalId)
-  intervalId = null
-}
+export const nowSecondsSignal = ticker.signal
 
 /**
  * Reference-counted hook: while at least one component using this hook
@@ -47,13 +29,4 @@ function stopTicker(): void {
  * Pause-aware callers should still gate via their own visibility logic
  * (the ticker keeps running regardless of `document.visibilityState`).
  */
-export function useNowSecondsTicker(): void {
-  useEffect(() => {
-    consumerCount += 1
-    startTicker()
-    return () => {
-      consumerCount = Math.max(0, consumerCount - 1)
-      if (consumerCount === 0) stopTicker()
-    }
-  }, [])
-}
+export const useNowSecondsTicker = ticker.use

--- a/dashboard/src/lib/shared-ticker.ts
+++ b/dashboard/src/lib/shared-ticker.ts
@@ -1,0 +1,59 @@
+// Refcounted shared interval factory.
+//
+// Both `now-signal.ts` (5 s wall-clock for elapsed-duration displays)
+// and `components/common/time-ago.ts` (30 s relative-clock for
+// `<TimeAgo />`) had near-identical boilerplate: a module-level
+// `signal<number>`, a `setInterval` armed on first consumer mount,
+// cleared on last unmount, plus the two helper functions and the SSR
+// `typeof window === 'undefined'` guard.  This factory captures that
+// shape once so both files are ~10 LOC instead of ~25 each.
+//
+// Returns a `signal` (callers `.value` it from render) and a `use()`
+// hook (callers call it from a component to participate in refcounting).
+// Behaviour is byte-for-byte the same as the prior hand-rolled versions:
+// SSR no-op, lazy start, refcount can never go negative.
+
+import { signal, type Signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+
+export interface SharedTicker {
+  signal: Signal<number>
+  use: () => void
+}
+
+export function createSharedTicker(
+  intervalMs: number,
+  initialValue: () => number = () => Date.now(),
+): SharedTicker {
+  const sig = signal(initialValue())
+  let timerId: number | null = null
+  let consumerCount = 0
+
+  function start(): void {
+    if (timerId != null) return
+    if (typeof window === 'undefined') return
+    timerId = window.setInterval(() => {
+      sig.value = initialValue()
+    }, intervalMs)
+  }
+
+  function stop(): void {
+    if (timerId == null) return
+    if (typeof window === 'undefined') return
+    window.clearInterval(timerId)
+    timerId = null
+  }
+
+  function use(): void {
+    useEffect(() => {
+      consumerCount += 1
+      start()
+      return () => {
+        consumerCount = Math.max(0, consumerCount - 1)
+        if (consumerCount === 0) stop()
+      }
+    }, [])
+  }
+
+  return { signal: sig, use }
+}


### PR DESCRIPTION
## Why

Cycle 12 of the iterative dashboard performance pass — **code-only cleanup, zero behaviour change**.

`now-signal.ts` (5 s wall-clock for elapsed-duration displays, cycle 7) and `components/common/time-ago.ts` (30 s relative-clock for `<TimeAgo />`, predates this series) had near-identical refcounted module-level boilerplate:

```ts
const sig = signal(...)
let timerId: number | null = null
let consumerCount = 0
function start() { /* ... refcount + window guard + setInterval ... */ }
function stop()  { /* ... clearInterval ... */ }
function useTicker() { useEffect(() => { /* ... */ }, []) }
```

Two copies of the same ~25 LOC shape, different only in interval (5 s vs 30 s) and units (Date.now()/1000 vs Date.now()).  This PR extracts the shape into a `createSharedTicker(intervalMs, initialValue?)` factory.

## What

| File | Change |
|------|--------|
| `dashboard/src/lib/shared-ticker.ts` (NEW) | `createSharedTicker(intervalMs, initialValue?): { signal, use }` — refcounted module-level setInterval factory |
| `dashboard/src/lib/now-signal.ts` | Replace inline boilerplate with `createSharedTicker(5000, () => Date.now() / 1000)` call; re-export `signal` and `use` as `nowSecondsSignal` and `useNowSecondsTicker` |
| `dashboard/src/components/common/time-ago.ts` | Replace inline boilerplate with `createSharedTicker(30_000)` call; `<TimeAgo />` body now calls `clockTicker.use()` instead of an inline `useEffect` |

Net: 3 files, +77 -67.

## Behaviour preservation

- **SSR no-op**: factory checks `typeof window === 'undefined'` exactly like both originals
- **Lazy start**: timer only fires after first consumer mounts
- **Refcount can't go negative**: `Math.max(0, count - 1)` matches the prior versions
- **Stop on last unmount**: same condition, same `clearInterval` path

The factory is intentionally not exported to be consumed directly outside these two ticker definitions — call sites still use `useNowSecondsTicker()` and `<TimeAgo />` as before.

## Stack position

- Cycle 1 (#10894 merged) — fsm-hub 1Hz → 5Hz tick
- Cycle 7 (#10918 merged) — `nowSecondsSignal` infra (now factored)
- Cycle 8 (#10949 draft) — live-pulse 1 Hz refcount sweep
- Cycle 9 (#10961 draft) — pipeline-panels children migration
- Cycle 10 (#10969 draft) — timeline-panels children + dwellHistograms move
- **Cycle 12 (this)** — ticker factory dedup
- Cycle 11 (after 9·10 merge) — StatusBar inline + drop fsm-hub's own `useNowSecondsTicker`/`.value` read + integrated measurement

Independent of cycles 8–11 — touches only `lib/now-signal.ts`, `lib/shared-ticker.ts`, `components/common/time-ago.ts`.

## Test plan

- [x] `pnpm run typecheck` succeeds
- [x] `pnpm --filter masc-dashboard build` succeeds
- [ ] After deploy, `<TimeAgo />` instances refresh on 30 s cadence + fsm-hub ticks on 5 s cadence (manual — both should be unchanged from main)