### PR TITLE
fix(keeper): promote repeated oas_timeout_budget to fiber crash (PR-M / Leak 9)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -295,6 +295,60 @@ let reset_autonomous_completion_for_test () : unit =
   with_completion_table (fun () ->
     Hashtbl.reset last_autonomous_completion)
 
+(* PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
+   per keeper.
+
+   [oas_timeout_budget] means the keeper cycle hit its structural budget
+   (see [Keeper_unified_turn.resolve_bounded_oas_timeout_budget_with_turn_budget]).
+   Re-running on the same fiber gives the same context and the same
+   shape of failure repeats — the budget does not magically grow
+   between cycles. Pre-fix the only escape was
+   [Keeper_supervisor.sweep_and_recover], which only triggers on
+   [Keeper_fiber_crash]; with the fiber alive but cycle-failing, the
+   sweep reports ["Alive — skip"] (see [keeper_supervisor.ml:599-602])
+   and the keeper stays zombie for hours. Real evidence 2026-04-26:
+   5 keepers were 4h+ silent post-budget-exhaustion in a 15-minute
+   window with 0 restart.
+
+   Promote to [Keeper_fiber_crash] after [oas_timeout_budget_strike_limit]
+   consecutive strikes so a fresh fiber retries with a clean context.
+   Counter is reset on any successful turn (see [Ok updated] branch). *)
+let consecutive_budget_exhaustions : (string, int) Hashtbl.t =
+  Hashtbl.create 16
+let consecutive_budget_exhaustions_mutex = Eio.Mutex.create ()
+let oas_timeout_budget_strike_limit = 3
+
+let with_budget_exhaustions f =
+  Eio.Mutex.use_rw ~protect:true consecutive_budget_exhaustions_mutex f
+
+let bump_budget_exhaustion ~keeper_name : int =
+  with_budget_exhaustions (fun () ->
+    let prior =
+      Hashtbl.find_opt consecutive_budget_exhaustions keeper_name
+      |> Option.value ~default:0
+    in
+    let next = prior + 1 in
+    Hashtbl.replace consecutive_budget_exhaustions keeper_name next;
+    next)
+
+let reset_budget_exhaustion ~keeper_name : unit =
+  with_budget_exhaustions (fun () ->
+    Hashtbl.remove consecutive_budget_exhaustions keeper_name)
+
+(* Test-only seam so unit tests can pre-load strike counts and exercise
+   the promote/reset branches without driving a full keeper cycle. *)
+let peek_budget_exhaustion_for_test ~keeper_name : int =
+  with_budget_exhaustions (fun () ->
+    Hashtbl.find_opt consecutive_budget_exhaustions keeper_name
+    |> Option.value ~default:0)
+
+let set_budget_exhaustion_for_test ~keeper_name ~strikes : unit =
+  with_budget_exhaustions (fun () ->
+    if strikes <= 0 then
+      Hashtbl.remove consecutive_budget_exhaustions keeper_name
+    else
+      Hashtbl.replace consecutive_budget_exhaustions keeper_name strikes)
+
 (** Test-only: stamp a completion time directly without going through
     [Time_compat.now].  Allows deterministic fairness-cooldown scenarios. *)
 let record_autonomous_completion_at_for_test ~(keeper_name : string) ~(ts : float) : unit =
@@ -1476,6 +1530,51 @@ let run_keepalive_unified_turn
                     (Printf.sprintf "fatal environment error: %s" e_str)));
                 raise Keeper_registry.Keeper_fiber_crash
               end;
+              (* PR-M (Leak 9): N-strike promotion for repeated
+                 [oas_timeout_budget]. See the comment block above
+                 [consecutive_budget_exhaustions] for why a single
+                 strike must not trip the crash but
+                 [oas_timeout_budget_strike_limit] in a row should —
+                 same-fiber retry has the same context budget, so a
+                 budget exhaustion is unrecoverable in place and only
+                 [sweep_and_recover] can clear it. *)
+              if String_util.contains_substring e_str "oas_timeout_budget"
+              then begin
+                let keeper_name = meta_after_observe.name in
+                let strikes = bump_budget_exhaustion ~keeper_name in
+                if strikes >= oas_timeout_budget_strike_limit then begin
+                  Log.Keeper.error
+                    "%s: %d consecutive oas_timeout_budget strikes \
+                     (>= %d) — promoting to Keeper_fiber_crash for \
+                     sweep_and_recover restart"
+                    keeper_name strikes oas_timeout_budget_strike_limit;
+                  Prometheus.inc_counter
+                    Prometheus.metric_keeper_oas_timeout_budget_strike
+                    ~labels:[
+                      ("keeper", keeper_name);
+                      ("outcome", "promote");
+                    ] ();
+                  reset_budget_exhaustion ~keeper_name;
+                  Keeper_registry.set_failure_reason
+                    ~base_path:ctx.config.base_path keeper_name
+                    (Some (Keeper_registry.Exception
+                      (Printf.sprintf
+                        "%d consecutive oas_timeout_budget strikes"
+                        strikes)));
+                  raise Keeper_registry.Keeper_fiber_crash
+                end else begin
+                  Log.Keeper.warn
+                    "%s: oas_timeout_budget strike %d/%d \
+                     (next strike will trigger fiber crash + restart)"
+                    keeper_name strikes oas_timeout_budget_strike_limit;
+                  Prometheus.inc_counter
+                    Prometheus.metric_keeper_oas_timeout_budget_strike
+                    ~labels:[
+                      ("keeper", keeper_name);
+                      ("outcome", "warn");
+                    ] ()
+                end
+              end;
               (match read_meta ctx.config meta_after_observe.name with
                | Ok (Some latest) -> latest
                | Ok None ->
@@ -1487,6 +1586,10 @@ let run_keepalive_unified_turn
                    meta_after_observe.name e;
                  meta_after_observe)
             | Ok updated ->
+              (* PR-M: success clears the strike counter so a single
+                 transient budget exhaustion does not trickle into the
+                 next 4h-window's strike limit. *)
+              reset_budget_exhaustion ~keeper_name:meta_after_observe.name;
               updated)
         with
         | Ok meta -> meta

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -93,6 +93,29 @@ val record_autonomous_completion_at_for_test : keeper_name:string -> ts:float ->
 (** Test-only: clear all per-keeper completion timestamps. *)
 val reset_autonomous_completion_for_test : unit -> unit
 
+(** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
+    per keeper. Promoted to [Keeper_fiber_crash] at
+    [oas_timeout_budget_strike_limit]; reset on any successful turn.
+    Counter survives within a server lifetime — restart resets it,
+    which is the desired behavior since the new fiber starts with
+    a fresh budget context. *)
+val oas_timeout_budget_strike_limit : int
+
+val bump_budget_exhaustion : keeper_name:string -> int
+(** Increment the strike count for [keeper_name] and return the new
+    count.  Thread-safe under [Eio.Mutex]. *)
+
+val reset_budget_exhaustion : keeper_name:string -> unit
+(** Drop any strike count for [keeper_name].  Idempotent. *)
+
+val peek_budget_exhaustion_for_test : keeper_name:string -> int
+(** Test-only: read current strike count without mutating. *)
+
+val set_budget_exhaustion_for_test :
+  keeper_name:string -> strikes:int -> unit
+(** Test-only: pre-load strike count.  [strikes <= 0] is equivalent
+    to [reset_budget_exhaustion]. *)
+
 (** Test-only wrapper around the keeper turn slot acquisition path. *)
 val with_keeper_turn_slot_for_test :
   keeper_name:string ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -601,6 +601,14 @@ let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
 let metric_keeper_invariant_violations = "masc_keeper_invariant_violations_total"
 let metric_keeper_dead_total = "masc_keeper_dead_total"
 let metric_keeper_near_exhaustion_total = "masc_keeper_near_exhaustion_total"
+(* PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
+   per keeper. Counter increments on each strike; a strike at
+   [outcome=promote] means [Keeper_fiber_crash] was raised so
+   [Keeper_supervisor.sweep_and_recover] will respawn the fiber. Without
+   the strike→crash promotion these failures repeated silently for
+   hours (4h+ zombie keepers observed 2026-04-26). *)
+let metric_keeper_oas_timeout_budget_strike =
+  "masc_keeper_oas_timeout_budget_strike_total"
 let metric_oas_bus_subscriber_stream_depth = "masc_oas_bus_subscriber_stream_depth"
 let metric_oas_bus_publish_block_seconds = "masc_oas_bus_publish_block_seconds_total"
 let metric_oas_bus_publish = "masc_oas_bus_publish_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -257,6 +257,17 @@ val metric_keeper_near_exhaustion_total : string
 (** Total times a keeper restart attempt landed at
     [restart_count = max_restarts - 1], i.e. one attempt away from Dead.
     Soft pre-warning; labeled by [keeper]. *)
+
+val metric_keeper_oas_timeout_budget_strike : string
+(** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes.
+    Labeled by [keeper] and [outcome]:
+    - [outcome=warn]: strike below [oas_timeout_budget_strike_limit];
+      cycle continues, supervisor not yet involved.
+    - [outcome=promote]: strike at or above limit; [Keeper_fiber_crash]
+      raised so [Keeper_supervisor.sweep_and_recover] respawns the
+      fiber with a fresh context budget. Counter reset on any
+      successful turn. *)
+
 val metric_oas_bus_subscriber_stream_depth : string
 val metric_oas_bus_publish_block_seconds : string
 val metric_oas_bus_publish : string

--- a/test/dune
+++ b/test/dune
@@ -1572,6 +1572,11 @@
  (libraries masc_mcp masc_mcp.config masc_coord masc_types alcotest unix))
 
 (test
+ (name test_oas_timeout_budget_strike)
+ (modules test_oas_timeout_budget_strike)
+ (libraries masc_mcp alcotest eio eio_main))
+
+(test
  (name test_keeper_fs)
  (modules test_keeper_fs)
  (libraries masc_mcp alcotest yojson unix eio eio_main))

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -1,0 +1,101 @@
+(* PR-M (Leak 9): unit tests for the per-keeper [oas_timeout_budget]
+   strike counter exposed by [Keeper_keepalive].
+
+   These do not drive a full keeper cycle — that path requires Eio
+   switches, registry state, and a meta on disk. Instead they exercise
+   the file-local strike table directly through the test seam helpers
+   to verify:
+     1. bump returns 1, 2, 3 in order for the same keeper
+     2. reset wipes the count back to 0
+     3. distinct keeper names get independent counters
+     4. set_for_test with strikes <= 0 is equivalent to remove
+*)
+
+open Masc_mcp
+module KK = Keeper_keepalive
+
+let reset_table k = KK.set_budget_exhaustion_for_test ~keeper_name:k ~strikes:0
+
+let test_bump_increments () =
+  let k = "alpha" in
+  reset_table k;
+  Alcotest.(check int)
+    "starts at 0" 0
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:k);
+  Alcotest.(check int) "bump 1" 1 (KK.bump_budget_exhaustion ~keeper_name:k);
+  Alcotest.(check int) "bump 2" 2 (KK.bump_budget_exhaustion ~keeper_name:k);
+  Alcotest.(check int) "bump 3" 3 (KK.bump_budget_exhaustion ~keeper_name:k);
+  Alcotest.(check int)
+    "peek mirrors last bump" 3
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:k);
+  reset_table k
+
+let test_reset_clears () =
+  let k = "beta" in
+  reset_table k;
+  let _ = KK.bump_budget_exhaustion ~keeper_name:k in
+  let _ = KK.bump_budget_exhaustion ~keeper_name:k in
+  KK.reset_budget_exhaustion ~keeper_name:k;
+  Alcotest.(check int)
+    "reset clears" 0
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:k);
+  Alcotest.(check int)
+    "next bump starts again at 1" 1
+    (KK.bump_budget_exhaustion ~keeper_name:k);
+  reset_table k
+
+let test_keepers_are_independent () =
+  let a = "gamma" and b = "delta" in
+  reset_table a;
+  reset_table b;
+  let _ = KK.bump_budget_exhaustion ~keeper_name:a in
+  let _ = KK.bump_budget_exhaustion ~keeper_name:a in
+  let _ = KK.bump_budget_exhaustion ~keeper_name:b in
+  Alcotest.(check int)
+    "a strikes" 2
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:a);
+  Alcotest.(check int)
+    "b strikes" 1
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:b);
+  KK.reset_budget_exhaustion ~keeper_name:a;
+  Alcotest.(check int)
+    "a cleared" 0
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:a);
+  Alcotest.(check int)
+    "b untouched by a's reset" 1
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:b);
+  reset_table a;
+  reset_table b
+
+let test_set_zero_or_negative_removes () =
+  let k = "epsilon" in
+  KK.set_budget_exhaustion_for_test ~keeper_name:k ~strikes:5;
+  Alcotest.(check int)
+    "set 5" 5
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:k);
+  KK.set_budget_exhaustion_for_test ~keeper_name:k ~strikes:0;
+  Alcotest.(check int)
+    "set 0 removes" 0
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:k);
+  KK.set_budget_exhaustion_for_test ~keeper_name:k ~strikes:7;
+  KK.set_budget_exhaustion_for_test ~keeper_name:k ~strikes:(-1);
+  Alcotest.(check int)
+    "negative also removes" 0
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:k)
+
+(* The strike table is guarded by [Eio.Mutex], which requires an Eio
+   fiber context. Run every case inside [Eio_main.run]. *)
+let in_eio f () = Eio_main.run (fun _env -> f ())
+
+let () =
+  Alcotest.run "oas_timeout_budget_strike"
+    [ ( "strike-counter"
+      , [ Alcotest.test_case "bump increments" `Quick
+            (in_eio test_bump_increments)
+        ; Alcotest.test_case "reset clears" `Quick (in_eio test_reset_clears)
+        ; Alcotest.test_case "keepers independent" `Quick
+            (in_eio test_keepers_are_independent)
+        ; Alcotest.test_case "set_for_test 0 or negative removes" `Quick
+            (in_eio test_set_zero_or_negative_removes)
+        ] )
+    ]


### PR DESCRIPTION
## Summary

- Adds a per-keeper consecutive-strike counter for [oas_timeout_budget] cycle FAILED in [Keeper_keepalive].
- Below 3 strikes: cycle continues (transient tolerance). At 3: [set_failure_reason] + raise [Keeper_fiber_crash] so [Keeper_supervisor.sweep_and_recover] respawns the fiber with a fresh budget.
- New metric [masc_keeper_oas_timeout_budget_strike_total] labelled by keeper + outcome (warn|promote).
- Threshold is a code constant per [feedback_no-hyperparameter-as-env-knob].

## Why

[Keeper_keepalive]'s pre-fix Error branch logged [oas_timeout_budget] at debug, kept the fiber alive, and re-entered the same cycle. The structural budget is computed from the same context that just exhausted it, so the next cycle fails the same way and the keeper becomes zombie — [sweep_and_recover] sees "Alive" and skips. Real evidence 2026-04-26: 5 keepers (sangsu, nick0cave, masc-improver, scholar, janitor) were silent 4h+ in a 15-minute burst window with 0 restart.

This is Leak 9 in the swiss-cheese plan (`/Users/dancer/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-k-wise-pudding.md`). Plan v6 머지 순서에서 PR-M으로 명명. PR-N (#10504, dashboard wake button) 가 같은 침묵을 사후 unblock 하는 UX, 본 PR이 root-cause 자동 복구.

## Test plan

- [x] `dune build --root .` clean
- [x] `dune build --root . --profile=release` clean (variant cascade 사전 차단)
- [x] `dune exec test/test_oas_timeout_budget_strike.exe` — 4/4 OK (bump increments, reset clears, keepers independent, set_for_test boundary)
- [ ] OP-F 머지 후 검증: production log에서 `[oas_timeout_budget strike` warn → `consecutive oas_timeout_budget strikes — promoting` ERROR → 1-2분 내 새 fiber spawn 시퀀스가 실측되는지

## Notes

- Counter는 file-local Hashtbl + Eio.Mutex (`last_autonomous_completion` 패턴 차용). 서버 lifetime 안에서만 유지 — 재시작 시 reset이 정상.
- 단일 strike에서 fiber crash를 트리거하지 않는 이유: 정상 운영에서도 가끔 한 번씩 budget exhaustion이 transient로 발생할 수 있음. 3-strike는 plan v6의 보수적 권고.
- Cycle Error 분기 자체의 회귀 테스트는 본 PR에 포함하지 않음 — Eio switch + registry state + meta on disk 조합이라 크고 별도 fixture 필요. OP-F 윈도우의 production log가 효과를 confirm하면 후속 PR에서 fixture 도입 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)