### PR TITLE
fix(server): wire approval_janitor fork to break HITL death-spiral

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -373,6 +373,37 @@ module Goal_janitor = struct
     get_float ~default:3600.0 "MASC_GOAL_JANITOR_INTERVAL_SEC"
 end
 
+(** {1 Approval Janitor}
+
+    HITL approval queue dead-end fix.  [Keeper_approval_queue.expire_stale]
+    has full implementation (queue removal, audit event, promise reject,
+    on_resolution callback) and a unit test, but was never invoked
+    anywhere in production code.  Result: any HITL approval enqueued
+    by a keeper turn would block [keeper_cycle_decision] forever via
+    [has_pending_for_keeper → Skip Approval_pending].  Once the 300s
+    stale watchdog fired, the supervisor would respawn the fiber, the
+    same approval would still be in the queue, and the cycle would
+    repeat indefinitely.  This fork makes the existing timeout policy
+    actually fire.  See #10765 for the death-spiral observability that
+    surfaced this and #10962 for the [last_skip_observation]
+    instrumentation that distinguishes deliberate-skip from stuck. *)
+module Approval_janitor = struct
+  (** Enable the periodic approval_janitor sweep fiber.  Default: true.
+      Set MASC_APPROVAL_JANITOR_ENABLED=false to disable when
+      debugging — pre-fix behaviour leaves the queue entries immortal
+      until manual resolution or server restart. *)
+  let enabled () =
+    get_bool ~default:true "MASC_APPROVAL_JANITOR_ENABLED"
+
+  (** Sweep interval in seconds.  Default: 60s (every minute).
+      Operators tolerate up to a minute of "approval still pending"
+      after the policy timeout has elapsed; a tighter cadence buys
+      nothing but log churn.  Mirrors [Goal_janitor]'s exposure
+      pattern (interval is operational cadence, not policy). *)
+  let interval_seconds =
+    get_float ~default:60.0 "MASC_APPROVAL_JANITOR_INTERVAL_SEC"
+end
+
 (** {1 Slot Scheduling} *)
 
 module Slot = struct

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -468,6 +468,48 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       in
       loop ()
     end);
+  (* HITL approval queue death-spiral fix.
+     [Keeper_approval_queue.expire_stale] has been a complete
+     implementation (queue removal, audit event, promise [Reject]
+     resolution, on_resolution callback) with a unit test since
+     introduction, but was never invoked by any production caller.
+     Result: a HITL approval enqueued by a keeper turn would block
+     [keeper_cycle_decision] forever via the
+     [has_pending_for_keeper → Skip Approval_pending] branch in
+     [keeper_world_observation.ml:928].  At the 300s stale-watchdog
+     threshold the supervisor would respawn the fiber, the same
+     approval entry would still be in the queue, and the cycle
+     would repeat indefinitely.  Pair with #10962
+     ([last_skip_observation] surface) so operators can see
+     [last_skip=[approval_pending]] alongside the kill warn line.
+     [max_wait_s] is a code constant (policy, not calibration);
+     [interval_seconds] mirrors [Goal_janitor]'s env exposure so
+     ops can tune cadence without changing policy. *)
+  fork_subsystem "approval_janitor" (fun () ->
+    if not (Env_config_runtime.Approval_janitor.enabled ()) then
+      Log.Server.info
+        "approval_janitor: disabled via MASC_APPROVAL_JANITOR_ENABLED=false"
+    else begin
+      let interval = Env_config_runtime.Approval_janitor.interval_seconds in
+      (* 30 minutes — long enough that humans actually have time to
+         respond on dashboard / Slack / etc., short enough that the
+         keeper isn't trapped on the death-spiral kill loop after the
+         operator forgets a request.  Code constant: changes need code
+         review (policy), not a runtime knob. *)
+      let max_wait_s = 1800.0 in
+      let rec loop () =
+        Eio.Time.sleep clock interval;
+        (try
+           Keeper_approval_queue.expire_stale ~max_wait_s
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Server.warn "approval_janitor: sweep failed: %s"
+             (Printexc.to_string exn));
+        loop ()
+      in
+      loop ()
+    end);
   (* Auto-boot keepers from keeper meta and start keepalive loops.
      Retries unbooted keepers up to [max_retries] times so transient
      failures (model resolution, discovery timing) don't permanently


### PR DESCRIPTION
Refs #10765, #10962.

## Why — the dead-end

`lib/keeper/keeper_approval_queue.ml::expire_stale` (line 921) has been
a complete implementation since introduction:

- removes stale entries from the queue
- emits `HITL_APPROVAL_EXPIRED` warn
- emits an `"expired"` audit event
- resolves the awaiting promise with `Oas.Hooks.Reject reason`
- invokes the `on_resolution` callback

It even has a unit test: `test/test_hitl_approval.ml::test_approval_queue_expire_stale`.

**But no production code ever called it.**

```
$ rg -n "expire_stale" lib/ bin/ --type ml
lib/keeper/keeper_approval_queue.ml:921:let expire_stale ~max_wait_s =
```

Result: the moment a keeper enqueues an HITL approval request, the
keeper's own `keeper_cycle_decision` would block at
`keeper_world_observation.ml:928`:

```ocaml
else if Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name then
  blocked Approval_pending
```

…on every subsequent heartbeat tick, forever.

## How it manifests

Death-spiral pattern from #10765:

1. t=0: keeper enqueues approval → queue size 1.
2. Operator hasn't seen it yet (Slack notification, dashboard, etc.).
3. Heartbeat: `should_run=false`, `verdict=Skip Approval_pending`.
4. t=300s: stale watchdog fires (`idle_stale=true`,
   `in_turn_stale=false` — this is **not** mid-turn so #10940's
   active-turn guard doesn't apply).
5. Supervisor respawns the fiber.
6. New fiber: queue still has the entry → same `Skip Approval_pending`
   → same kill at t=600s.
7. Loop forever (or until operator manually resolves /
   server restart).

## What

- **`Env_config_runtime.Approval_janitor`** — kill switch
  (`MASC_APPROVAL_JANITOR_ENABLED`, default `true`) + cadence
  (`MASC_APPROVAL_JANITOR_INTERVAL_SEC`, default `60.0`). Mirrors
  `Goal_janitor`'s exposure pattern from #10405.
- **`fork_subsystem "approval_janitor"`** in
  `lib/server/server_bootstrap_loops.ml`, alongside the existing
  `goal_janitor`. Sweep loop calls
  `Keeper_approval_queue.expire_stale ~max_wait_s:1800.0` every 60s.
- `max_wait_s = 1800.0` is a **code constant**, not an env knob —
  policy, not calibration (per memory
  `feedback_no-hyperparameter-as-env-knob`).

## Det vs non-det

- The dead path was **deterministic**: queue entry exists → block →
  kill → respawn → block. No randomness, no race.
- The fix is **deterministic**: timer fires at known cadence, expires
  entries past a known threshold, resolves their promises with a
  definitive `Reject`.
- Operator response time is the only **non-deterministic** input —
  hence `max_wait_s` as a policy constant operators can change in
  code review, not as a runtime knob you can flip without thinking
  about HITL contract consequences.

## Pairing with #10962

#10962 surfaces `last_skip=[approval_pending]` in the stale-kill warn
line. If this approval_janitor fork has any regression (queue leak,
expire_stale exception, etc.), the death-spiral would *immediately*
surface in operator logs as:

```
*: stale watchdog terminating fiber (idle 312s last_skip=[approval_pending] (4s ago)) [window_count=N/6h]
```

…instead of being buried in `proactive_skip_reason_metric` aggregates.

## Risk

- Approval entries past the policy timeout are now `Reject`-resolved
  automatically. Existing callers of `Keeper_approval_queue.resolve` /
  `resolve_with_policy` are unaffected — their entries get pulled out
  of the queue first.
- `expire_stale` has a unit test in `test/test_hitl_approval.ml`.
- Any HITL request currently sitting in the queue at deploy time
  past 30 min will be immediately rejected. This is a **deliberate
  one-time effect** — those entries were already orphaned.

## Verification

- [x] `dune build --root . lib` clean
- [x] `dune build --root . @check` clean
- After deploy: `HITL_APPROVAL_EXPIRED` warn lines should appear at
  cadence `interval_seconds` for any orphaned entries; from then on
  no keeper should report `Skip Approval_pending` for longer than
  `max_wait_s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
