### PR TITLE
refactor(design-system): swap surface filter chips to ActionButton ghost (PR-CS78)

### DIFF
--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -119,13 +119,17 @@ export function FullInventoryView({
 
       <div class="flex flex-wrap gap-2 mb-4">
         ${(Object.keys(SURFACE_LABELS) as SurfaceFilter[]).map(key => html`
-          <button type="button"
-            class=${`px-3 py-1.5 rounded text-sm font-medium border transition-colors cursor-pointer ${surfaceFilter.value === key ? 'border-[var(--color-accent-fg)]/40 text-[var(--color-accent-fg)] bg-[var(--accent-8)]' : 'border-[var(--color-border-default)] bg-[var(--white-4)] hover:bg-[var(--white-8)] text-[var(--color-fg-primary)]'}`}
+          <${ActionButton}
+            variant="ghost"
+            size="md"
+            class="!text-sm !px-3 !py-1.5"
+            pressed=${surfaceFilter.value === key}
+            ariaLabel=${`surface filter ${SURFACE_LABELS[key]}`}
             onClick=${() => { surfaceFilter.value = key }}
           >
             ${SURFACE_LABELS[key]}
             <span class="inline-flex items-center justify-center min-w-5 h-[18px] px-[5px] text-3xs font-semibold bg-[var(--white-8)] text-[var(--color-fg-muted)] rounded-sm ml-1">${surfaceCountForFilter(inventory, key)}</span>
-          </button>
+          <//>
         `)}
       </div>
 


### PR DESCRIPTION
## 요약
- tool-full-inventory.ts의 4개 surface filter chip을 ActionButton ghost + pressed prop으로 전환.
- 부분 마이그레이션 파일(Select/TextInput import 있음 + button 잔존) 정상화.

## Why
v0.4 design-system 전체 적용 plan의 Phase B (file-disjoint parallel) 첫 PR. button.ts 미터치이므로 CS75/CS76과 race 0. 이미 import된 ActionButton을 추가 callsite에서 활용해 import 비용 분산.

## 변경
- 4 surface filter button (mcp_public/internal_only/hidden/all) → \`variant=\"ghost\" size=\"md\" pressed={surfaceFilter==key}\`
- class override \`!text-sm !px-3 !py-1.5\`로 기존 text-sm/3 padding 보존

## 시각 변화
- Unpressed: 변화 없음 (ghost variant가 원래 클래스와 정확히 동치)
- **Pressed**: sky-blue text(\`text-[var(--color-accent-fg)]\`) → light-gray text(\`text-[var(--color-fg-secondary)]\`). 캐노니컬 표준화 의도 — 다른 dashboard 필터(예: keeper view tabs)와 일관됨.

## Test
- vitest 4100/4100 그린 (full suite)
- pnpm typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)