### PR TITLE
feat(dashboard): localize sectionLabel for fleet-health and safe-autonomy

### DIFF
--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -50,9 +50,9 @@ function sectionLabel(section: StatusSection): string {
     case 'runtime':
       return '런타임'
     case 'fleet-health':
-      return 'Fleet Health'
+      return '플릿 상태'
     case 'safe-autonomy':
-      return 'Safe Autonomy'
+      return '안전 자율성'
     case 'memory-subsystems':
       return '메모리 서브시스템'
     case 'attribution':


### PR DESCRIPTION
## Summary

`status.ts:sectionLabel` 의 8 케이스 중 6개는 이미 한국어 (관찰소/여정/런타임/메모리 서브시스템/기여 분석/에이전트 상태). 남은 2개 (`Fleet Health`, `Safe Autonomy`) 만 영어로 남아있어 섹션 네비에 두 언어가 섞여 보임.

## Change

- `'fleet-health'` → `'플릿 상태'`
- `'safe-autonomy'` → `'안전 자율성'`

## Scope

- 1 파일, 2줄.
- `rg "Fleet Health|Safe Autonomy" dashboard/src/` 결과: 컴포넌트 코멘트와 테스트 코멘트만 영어 보존, UI 표시 문자열은 이 두 곳만.
- 관련 테스트 영향 없음 (toContain/toEqual 매칭 site 없음).