### PR TITLE
feat(coord/task): Prometheus counter + warn log for task_claim_next auto-release (#10421)

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -242,6 +242,26 @@ let () =
   Atomic.set Coord_hooks.task_completion_path_observed_fn
     record_task_completion_path
 
+(* #10421: implicit auto-release rate from [task_claim_next].
+   Field log showed 43 claimed→todo vs 24 todo→claimed in one
+   day (179% release/claim ratio) with only 1/71 transitions
+   reaching done — same task hot-potatoed up to 5x.  Counter
+   gives operators a fleet-wide rate, broken down by keeper
+   and by [from_status] so [InProgress → Todo] (mid-work
+   churn) is separable from [Claimed → Todo] (just-claimed
+   churn).  Cardinality bounded at ~fleet × 2. *)
+let task_auto_release_metric = "masc_task_auto_release_total"
+
+let record_task_auto_release ~agent_name ~from_status =
+  Prometheus.inc_counter task_auto_release_metric
+    ~labels:[ ("agent_name", agent_name);
+              ("from_status", from_status) ]
+    ()
+
+let () =
+  Atomic.set Coord_hooks.task_auto_release_observed_fn
+    record_task_auto_release
+
 (* #9632: Process_eio timeout observability.
    Fleet-wide rate of subprocess timeouts, broken down by program
    (argv[0] basename) and configured budget.  Lets operators answer

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -216,6 +216,31 @@ let task_completion_path_observed_fn
   : (path:string -> contract_state:string -> agent_name:string -> unit) Atomic.t
   = Atomic.make (fun ~path:_ ~contract_state:_ ~agent_name:_ -> ())
 
+(** #10421: task_claim_next implicit auto-release observability.
+
+    When a keeper calls [task_claim_next] while still holding a
+    previous claim, the scheduler implicitly transitions that prior
+    claim back to [Todo] before issuing the new one.  Field log
+    showed 43 [claimed → todo] transitions vs 24 [todo → claimed]
+    in a single day (179% release/claim ratio), with only 1/71
+    transitions reaching [done] — the same task hot-potatoed up to
+    5x as keepers churned through claim_next without finishing.
+
+    The structured event already carries [reason] and
+    [from_status], but a Prometheus counter is the missing surface:
+    operators cannot alert on auto-release rate or split it by
+    keeper from a JSONL tail alone.  The split by [from_status]
+    matters because [Claimed → Todo] (just claimed, no work yet)
+    and [InProgress → Todo] (mid-work, lost progress) are
+    operationally distinct symptoms.
+
+    Cardinality bounded by fleet size (~10 keepers) ×
+    [from_status] (claimed | in_progress) = ~20 series.  Emit at
+    [lib/coord.ml] to avoid a [masc_coord → Prometheus] dep cycle. *)
+let task_auto_release_observed_fn
+  : (agent_name:string -> from_status:string -> unit) Atomic.t
+  = Atomic.make (fun ~agent_name:_ ~from_status:_ -> ())
+
 (** task-103: Auto-provision a sandbox worktree on successful task claim.
 
     [Coord_task.claim_task_r] flips a task to [Claimed] but does not create

--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -57,6 +57,8 @@ val tool_assigned_fn : (agent_id:string ->
            Atomic.t
 val task_completion_path_observed_fn : (path:string -> contract_state:string -> agent_name:string -> unit)
            Atomic.t
+val task_auto_release_observed_fn :
+  (agent_name:string -> from_status:string -> unit) Atomic.t
 val claim_post_provision_fn : (Coord_utils_backend_setup.config ->
             agent_name:string ->
             task_id:string -> unit)

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -386,6 +386,25 @@ let claim_next_r
             log_event config (Printf.sprintf
               "{\"type\":\"task_claim_next_auto_release\",\"agent\":\"%s\",\"released_task\":\"%s\",\"from_status\":\"%s\",\"reason\":\"prev_claim_implicit_replaced\",\"ts\":\"%s\"}"
               agent_name prev.id from_status (now_iso ()));
+            (* #10421: warn-level log so dashboards see the implicit
+               release at fleet scale. [InProgress → Todo] is the
+               more concerning subset (mid-work churn) — from_status
+               surfaces that distinction in a single line. *)
+            Log.RoomTask.warn
+              "task_claim_next auto-released prev claim: agent=%s task=%s \
+               from_status=%s — keeper called claim_next without \
+               releasing/finishing the prior task (#10421)"
+              agent_name prev.id from_status;
+            (* #10421: Prometheus counter so operators can graph rate
+               and split by keeper. Hook indirection lives in
+               [coord_hooks]; emit wired in [lib/coord.ml] to avoid
+               a [masc_coord → Prometheus] dep cycle. *)
+            (try
+               (Atomic.get Coord_hooks.task_auto_release_observed_fn)
+                 ~agent_name ~from_status
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | _ -> ());
             (* No broadcast — internal state transition, log_event suffices. *)
             let updated = List.map (fun (t : Types.task) ->
               if String.equal t.id prev.id then { t with task_status = Todo }


### PR DESCRIPTION
## 배경

#10421 — \`task_claim_next\` 가 keeper 의 prev claim 을 implicit auto-release. 결과:

- 43 claimed→todo vs 24 todo→claimed (179% release/claim ratio)
- 1/71 transitions 만 done 도달 (1.4%)
- 같은 task 5x hot-potato (task-056)

선행 PR 에서 JSONL 이벤트에 \`reason=\"prev_claim_implicit_replaced\"\` + \`from_status\` 추가됨. 하지만 운영자가 fleet-wide rate / per-keeper breakdown 을 graph 하려면 Prometheus counter 가 필요.

## 변경

| 항목 | 추가 |
|---|---|
| **Prometheus counter** | \`masc_task_auto_release_total{agent_name, from_status}\` (~fleet × 2 cardinality) |
| **Warn log** | \`Log.RoomTask.warn\` — keeper, task, from_status 포함 |
| **Hook indirection** | \`Coord_hooks.task_auto_release_observed_fn\` (#10449/#9795 패턴 따름) |

\`from_status\` 분리 이유:
- \`Claimed → Todo\`: just-claimed churn (덜 우려)
- \`InProgress → Todo\`: mid-work churn (실제 work 손실, 우려)

이 split 으로 dashboard 가 두 케이스를 따로 alert 가능.

## Behavior unchanged

Auto-release 동작 자체는 그대로. **observability layer 만 추가**. #10421 의 option D 에 해당.

향후 후속 PR 결정에 데이터 제공:
- option A: implicit auto-release 제거 (keeper migration risk)
- option B: \`task_release_then_claim_next\` 명시 분리 (API 변경)

먼저 metric 수집 → 데이터 기반 결정. \`feedback_no-heuristic-category.md\` 의 \"sound partial > heuristic total\" 원칙.

## Acceptance criteria

- [x] \`dune build @check\` pass
- [x] Behavior unchanged — auto-release 동작 동일
- [x] Hook indirection 패턴 (#10449/#9795 와 동일)
- [ ] 머지 후 24h: \`masc_task_auto_release_total\` graph 에서 per-keeper rate 확인
- [ ] \`InProgress → Todo\` rate 가 0 인지 확인 (0 이 아니면 mid-work loss 발생 신호)

## Cross-references

- #10405 (goals dead governance — 같은 progress-tracking dormant 패턴)
- #10411 (Goal FSM Awaiting_verification dead-end)
- #10449 (task completion path observability — 같은 hook indirection 패턴)
- memory \`feedback_keeper-fleet-investigation.md\`
- memory \`feedback_no-heuristic-category.md\` (sound partial > heuristic total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)