### PR TITLE
fix(mcp/call_tool): demote policy/workflow rejections to WARN (#10975)

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -36,6 +36,32 @@ let contains_casefold haystack needle =
   String.length needle = 0
   || String_util.contains_substring_ci haystack needle
 
+(* #10975: tool-call failure severity classification.
+
+   Without this, every [success=false] result downstream is logged
+   at [Log.Error], including normal policy/workflow rejections like
+   [awaiting_approval] (governance critical-risk pending),
+   [Join required] (keeper called masc_transition before masc_join),
+   [egress_blocked] (network policy denial), [path_outside_sandbox]
+   (sandbox boundary), and [team memory is disabled] (config-disabled
+   scope).  Single 24h window: 41 such events at ERROR, polluting
+   alert ROC, supervisor escape-valve heuristics (#10887 SP cohort
+   detection counts ERROR rate), and the dashboard red counter that
+   operators use to triage genuine system errors.
+
+   Demote those byte-substring-matched rejection patterns to WARN.
+   Anything else stays ERROR.  Same family pattern as #10881 / #10908
+   / #10919 (single-flag split between normal and catastrophic). *)
+let classify_tool_failure_severity error_detail : Log.level =
+  let detail = Option.value ~default:"" error_detail in
+  if contains_casefold detail "awaiting_approval"
+     || contains_casefold detail "join required"
+     || contains_casefold detail "egress_blocked"
+     || contains_casefold detail "path_outside_sandbox"
+     || contains_casefold detail "team memory is disabled"
+  then Log.Warn
+  else Log.Error
+
 let parse_status_from_message ~success ~message =
   if not success then
     if
@@ -648,7 +674,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     ~agent_id:agent_name ~tool_name:name ~success ~error_msg:error_detail
     ?trace_id:otel_trace_id ();
   if not success then
-    Log.Mcp.emit Log.Error
+    Log.Mcp.emit (classify_tool_failure_severity error_detail)
       ~details:
         (`Assoc
           [


### PR DESCRIPTION
## 배경

#10975 — `mcp_server_eio_call_tool` 가 모든 `success=false` tool result 를 `Log.Mcp.emit Log.Error` 로 emit. 단일 24h window 41 events 가 정상 정책/워크플로우 거부:

| 패턴 | 본질 |
|---|---|
| `awaiting_approval` | governance critical-risk pending |
| `Join required` | masc_transition before masc_join |
| `egress_blocked` | network policy denial |
| `path_outside_sandbox` | sandbox boundary |
| `team memory is disabled` | config-disabled scope |

Downstream 영향:
- alert ROC false ERROR rate 부풀림
- SP cohort detection (#10887) 가 ERROR rate signal — noise 가 false-positive cohort bump
- dashboard 빨간 카운트가 정책 거부 + 진짜 system error 혼동

## 변경

`classify_tool_failure_severity error_detail -> Log.level` helper 추가, line 35 의 `contains_casefold` / `parse_status_from_message` ladder 옆에 배치. byte-substring 5 패턴 매치 시 `Log.Warn`, 그 외 `Log.Error` 유지.

`details` JSON payload (event_family, outcome, error_detail 등) 미변경 — 다운스트림 filter by error_detail 는 그대로 작동.

## 의도적으로 안 한 것

이슈 본문이 더 큰 fix candidate (outcome enum 도입, Policy_rejected/Workflow_violation/Config_disabled/System_error variant) 도 제안. 본 PR 은 surgical pattern-match helper 만:

- variant 추가는 partial-match cascade risk (memory `feedback_variant-add-partial-match-cascade`)
- enum 은 `Tool_registry`, `Audit_log`, dashboard 등 cross-cutting 변경 필요
- 본 PR 은 single-file +27/-1 — log severity 정정 즉시 효과, 구조 변경은 별도 PR

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file, +27 / -1
- 호출자 코드 미변경

## Family precedent (logging-tier severity split)

같은 patterm 으로 머지된 family:
- #10881 (WS lifecycle INFO→DEBUG, MERGED)
- #10908/#10910 (watchdog tick all-default INFO→DEBUG, MERGED)
- #10919/#10937 (backend init INFO→DEBUG, MERGED)
- #10887/#10945 (SP universal suppression WARN→ERROR, MERGED)
- 본 PR (#10975) 은 reverse 방향 — ERROR→WARN demote

## 후속

- outcome enum (`Tool_outcome`) 도입 + Audit_log/dashboard refactor (별도 RFC)
- 이슈 본문이 언급한 lint gate ("같은 bug class N+ 인스턴스") — pattern-tier audit script