### PR TITLE
refactor(design-system): swap persona-generator textareas to TextArea (PR-CS79)

### DIFF
--- a/dashboard/src/components/keeper-spawn/persona-generator.ts
+++ b/dashboard/src/components/keeper-spawn/persona-generator.ts
@@ -4,7 +4,7 @@ import { signal } from '@preact/signals'
 import { ActionButton } from '../common/button'
 import { Select } from '../common/select'
 import { Checkbox } from '../common/checkbox'
-import { TextInput } from '../common/input'
+import { TextArea, TextInput } from '../common/input'
 import { showToast } from '../common/toast'
 import {
   generatePersonaDraft,
@@ -97,13 +97,14 @@ export function PersonaGenerator() {
       <div class="space-y-3">
         <div class="grid gap-2">
           <label class="text-3xs text-[var(--color-fg-muted)]" for="persona-concept">컨셉</label>
-          <textarea
+          <${TextArea}
             id="persona-concept"
             rows=${5}
             value=${concept.value}
             placeholder="good evil chaos research keeper"
+            ariaLabel="persona concept"
             onInput=${(e: Event) => { concept.value = (e.target as HTMLTextAreaElement).value }}
-            class="w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-2 text-2xs text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
+            class="!px-2 !py-2 !text-2xs"
           />
         </div>
 
@@ -223,13 +224,14 @@ export function PersonaGenerator() {
             <label class="text-3xs text-[var(--color-fg-muted)]" for="persona-profile-json">profile.json</label>
             ${draft ? html`<span class="text-3xs text-[var(--color-fg-muted)]">${draft.handle}</span>` : null}
           </div>
-          <textarea
+          <${TextArea}
             id="persona-profile-json"
             rows=${18}
             value=${profileText.value}
             placeholder="초안을 생성하면 profile.json이 표시됩니다"
+            ariaLabel="persona profile.json"
             onInput=${(e: Event) => { profileText.value = (e.target as HTMLTextAreaElement).value }}
-            class="w-full rounded border border-[var(--white-10)] bg-[var(--color-bg-page)] px-2 py-2 font-mono text-3xs leading-5 text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
+            class="!bg-[var(--color-bg-page)] !px-2 !py-2 !text-3xs font-mono leading-5"
           />
         </div>
 


### PR DESCRIPTION
## 요약
- persona-generator.ts의 2개 inline textarea를 canonical TextArea로 전환
- concept input + profile.json editor 양쪽 처리

## Why
v0.4 design-system 적용 plan의 **Phase E (input migration)** 첫 PR. file-disjoint이므로 CS75(warn)/CS78(filter chips)/CS76 등과 race 0. 동시 머지 안전.

## 변경
- \`:100\` concept textarea → TextArea + \`class=\"!px-2 !py-2 !text-2xs\"\` (padding/text-size 보존)
- \`:226\` profile.json textarea → TextArea + \`class=\"!bg-[var(--color-bg-page)] !px-2 !py-2 !text-3xs font-mono leading-5\"\` (bg/font/leading 보존)
- Import: \`{ TextInput }\` → \`{ TextArea, TextInput }\`

## 시각 변화
- TextArea base가 hover \`bg-[var(--white-6)]\` + focus-visible ring 추가 — 기존 minimal focus border 대비 인터랙션 affordance 향상.
- placeholder color: \`fg-disabled\` → \`fg-muted\` (밝아짐).

## Test
- pnpm typecheck pass
- persona-generator 전용 test 없음 (vitest no test files for that path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)