### PR TITLE
refactor(design-system): swap keeper-detail pause/resume chips to ActionButton ghost (PR-CS80)

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -291,16 +291,20 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${keeper.paused
           ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--color-status-warn)]">일시정지</span>
             ${hasActivitySignal ? html`<span class="text-[var(--color-fg-muted)]">${renderActivitySignal()}</span>` : null}
-            <button
-              class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--color-fg-secondary)] transition-colors disabled:opacity-50"
+            <${ActionButton}
+              variant="ghost"
+              size="sm"
+              class="!py-0.5 !bg-[var(--white-6)] !text-[var(--color-fg-secondary)] inline-flex items-center"
               disabled=${directiveLoading.value}
               onClick=${() => handleDirective('resume')}
-            >재개</button>`
-          : html`<button
-              class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--color-fg-secondary)] transition-colors disabled:opacity-50"
+            >재개<//>`
+          : html`<${ActionButton}
+              variant="ghost"
+              size="sm"
+              class="!py-0.5 !bg-[var(--white-6)] !text-[var(--color-fg-secondary)] inline-flex items-center"
               disabled=${directiveLoading.value}
               onClick=${() => handleDirective('pause')}
-            >일시정지</button>
+            >일시정지<//>
             ${(hbStale || runtimeBlockerClass === 'oas_timeout_budget' || runtimeBlockerClass === 'cascade_exhausted' || runtimeBlockerClass === 'turn_timeout')
               ? html`<${ActionButton}
                   variant="warn"


### PR DESCRIPTION
## 요약
- keeper-detail.ts의 pause/resume directive chip 2개 → ActionButton ghost size=sm
- CS75에서 wakeup chip만 처리했던 것을 같은 그룹 전체로 확장

## Why
v0.4 design-system 적용 plan의 Phase B 연장. file-disjoint이므로 CS78/CS79/CS76와 race 0. 같은 directive group(pause/resume/wakeup) 3 chip 중 2개가 inline 잔존하던 일관성 갭 해소.

## 변경
- \`:294\` resume chip → \`variant=\"ghost\" size=\"sm\"\` + override
- \`:299\` pause chip → 동일 패턴
- Override: \`!py-0.5 !bg-[var(--white-6)] !text-[var(--color-fg-secondary)] inline-flex items-center\` (chip 패딩/색상 보존)

## 시각 변화
- 0 (override로 기존 white-6 bg + fg-secondary text 그대로)
- ActionButton BASE의 focus ring + active scale 추가 (인터랙션 affordance 향상)

## Test
- vitest 105/105 (keeper-detail 4 test files) 그린
- pnpm typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)