### PR TITLE
feat(dashboard): adopt KeeperBadge in safe-autonomy KeeperCard + TimelineList (Stage 3b)

### DIFF
--- a/dashboard/src/components/safe-autonomy.ts
+++ b/dashboard/src/components/safe-autonomy.ts
@@ -237,7 +237,7 @@ function KeeperCard({ item }: { item: KeeperItem }) {
       <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div class="min-w-0">
           <div class="flex items-center gap-2">
-            <div class="text-sm font-semibold text-[var(--color-fg-secondary)]">${item.name}</div>
+            <${KeeperBadge} id=${item.name} variant="full" size="md" />
             <${StatusPill} status=${item.status} />
           </div>
           <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
@@ -313,8 +313,12 @@ function TimelineList({ timeline }: { timeline: TimelineItem[] }) {
           <div class="flex items-start justify-between gap-3">
             <div class="min-w-0">
               <div class="text-xs text-[var(--color-fg-secondary)]">${item.summary}</div>
-              <div class="mt-1 text-3xs text-[var(--color-fg-muted)]">
-                ${item.kind}${item.keeper_name ? ` · ${item.keeper_name}` : ''}
+              <div class="mt-1 flex flex-wrap items-center gap-1 text-3xs text-[var(--color-fg-muted)]">
+                <span>${item.kind}</span>
+                ${item.keeper_name ? html`
+                  <span aria-hidden="true">·</span>
+                  <${KeeperBadge} id=${item.keeper_name} variant="full" size="sm" />
+                ` : null}
               </div>
             </div>
             <div class="shrink-0 text-3xs text-[var(--color-fg-muted)]">


### PR DESCRIPTION
## Why

Sweep the remaining two keeper-name render sites in `safe-autonomy.ts`. After #10970 (FindingsList row), this PR finishes the module: every place that renders a keeper id now uses `<KeeperBadge>`, fully aligning the surface with design-system v0.4 SPEC §3.6 (color + sigil two-channel attribution).

## What

`src/components/safe-autonomy.ts` — two render sites:

### `KeeperCard` (line 240) — card heading
```diff
- <div class="text-sm font-semibold text-[var(--color-fg-secondary)]">${item.name}</div>
+ <${KeeperBadge} id=${item.name} variant="full" size="md" />
```
The card's primary heading is now keeper-colored sigil + name. Identity becomes the *visual anchor* of the card instead of plain text living adjacent to the `StatusPill`. `size="md"` (18px sigil) feels right next to the pill — `lg` would dominate.

### `TimelineList` (line 315) — secondary metadata line
```diff
-  <div class="mt-1 text-3xs text-[var(--color-fg-muted)]">
-    ${item.kind}${item.keeper_name ? ` · ${item.keeper_name}` : ''}
-  </div>
+  <div class="mt-1 flex flex-wrap items-center gap-1 text-3xs text-[var(--color-fg-muted)]">
+    <span>${item.kind}</span>
+    ${item.keeper_name ? html`
+      <span aria-hidden="true">·</span>
+      <${KeeperBadge} id=${item.keeper_name} variant="full" size="sm" />
+    ` : null}
+  </div>
```
Inline string concat (`${kind}${maybe-keeper}`) became a flex row so `<KeeperBadge>` can slot in alongside the kind text. The middle dot is `aria-hidden` (visual separator only). When an operator scans a timeline filtered to one keeper, the same sigil repeating down the column is glanceable from row-scan distance.

## Patterns established (precedent for follow-up callsite PRs)

- **`size="md"`** for card-level primary headings (next to StatusPill or similar tier-1 chrome).
- **`size="sm"`** for inline secondary lines (next to other 3xs/2xs muted metadata).
- **`variant="full"`** everywhere — SPEC §3.6 canonical default. `sigil`/`name` reserved for cases where the other channel is rendered separately by the caller.
- **Replace text only when the rendered string IS the keeper id.** Internal uses (data store keys, `<${KeeperCard} key=${item.name}>`) stay unchanged — those are identity tokens, not display.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [ ] No `safe-autonomy.test.ts` exists (predates this PR series). KeeperBadge primitive has its own 12-test coverage from #10955.
- [ ] Visual smoke: render the safe-autonomy panel with seeded data — confirm sigil consistency across FindingsList row + KeeperCard heading + TimelineList row for the same keeper id. Queued.

## What this PR does NOT do

- Other modules. `agent-roster.ts` is mostly data-merge logic (no visible render of keeper_name there in current form). `keeper-detail.ts`, `keeper-chat-panel.ts`, etc. each get their own PR.
- ErrorRecoverable / ErrorFatal callsites — separate after #10965 merges.

## Refs

- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`
- Predecessors: #10898 (folder sync), #10955 (KeeperBadge primitive — MERGED), #10970 (FindingsList migration — MERGED)
- SPEC §3.6: `dashboard/design-system/SPEC.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
