### PR TITLE
feat(dashboard): localize composite-fsm-flowchart aria-label, header, body

### DIFF
--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -138,17 +138,17 @@ export function CompositeFsmFlowchart(props: CompositeFsmFlowchartProps = {}) {
     <section
       data-testid="composite-fsm-flowchart"
       class="rounded border border-[var(--white-10)] bg-[var(--white-5)] ${props.class ?? ''}"
-      aria-label="Composite FSM flowchart"
+      aria-label="복합 FSM 플로우차트"
     >
       <header class="border-b border-[var(--white-10)] p-3">
         <h2 class="text-sm font-semibold text-[var(--color-fg-muted)]">
-          Composite FSM flowchart (TLA+ spec)
+          복합 FSM 플로우차트 (TLA+ spec)
         </h2>
         <p class="mt-1 text-xs text-[var(--color-fg-muted)]">
-          6 orthogonal axes rendered as Harel parallel regions. Source:
+          6 개의 직교 축을 Harel parallel region 으로 렌더링합니다. 출처:
           <code class="text-[var(--color-fg-muted)]">specs/keeper-state-machine/*.tla</code>.
-          Transitions here are the common-case edges; the TLA+
-          model-checker owns the exhaustive enumeration.
+          여기 표시된 transition 은 common-case edge 이고, exhaustive enumeration 은
+          TLA+ model checker 가 담당합니다.
         </p>
       </header>
       <div class="p-3">


### PR DESCRIPTION
## Summary

`composite-fsm-flowchart.ts` 의 `MermaidGraph` `fallbackText` 는 이미 한국어 (`플로우차트 렌더 실패 — 브라우저 콘솔을 확인하세요.`). 같은 컴포넌트 안의 `aria-label` / `<h2>` / 설명 단락 3곳이 영어로 남아있어 screen reader 와 sighted user 양쪽이 두 언어를 동시에 보게 됨.

## Change

| 위치 | Before | After |
|---|---|---|
| `aria-label` | `Composite FSM flowchart` | `복합 FSM 플로우차트` |
| `<h2>` | `Composite FSM flowchart (TLA+ spec)` | `복합 FSM 플로우차트 (TLA+ spec)` |
| `<p>` | `6 orthogonal axes rendered as Harel parallel regions. Source: ... Transitions here are the common-case edges; the TLA+ model-checker owns the exhaustive enumeration.` | `6 개의 직교 축을 Harel parallel region 으로 렌더링합니다. 출처: ... 여기 표시된 transition 은 common-case edge 이고, exhaustive enumeration 은 TLA+ model checker 가 담당합니다.` |

## Domain term policy

기존 dashboard 관습대로 도메인 용어는 영어 보존: TLA+, FSM, transition, common-case edge, exhaustive enumeration, model checker, parallel region, Harel.

## Scope

- 1 파일, 5줄 (헤더/본문 단락의 표현만 변경, 구조/스타일 동일).
- `composite-fsm-flowchart.test.ts` 는 `buildCompositeFsmMermaid` builder 만 검증, UI 문자열 toContain assertion 0건 → 테스트 영향 없음.