### PR TITLE
fix(anti-rationalization): discriminate cascade-config-dead from transient verifier failure (#10474)

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -602,12 +602,49 @@ let review
           same Prometheus counter so monitoring sees the fallback rate
           regardless of the chosen policy. *)
        let msg = Oas.Error.to_string err in
+       (* #10474: discriminate "permanent cascade configuration issue"
+          from "transient verifier failure".  [No_tool_capable_provider]
+          means every provider in the [evaluator_cascade] failed the
+          tool-use gate at filter time — there are zero callable
+          models, and there will not be any until the cascade config
+          (or provider capabilities) changes.  Treating that as a
+          fail-closed safety-net reject blocks every keeper trying to
+          finish a task with a perfectly legitimate "out of scope"
+          phrase, which is the cascade's bug, not the keeper's
+          purview.  Promote to operator-actionable ERROR and approve
+          by liveness — the operator must fix the cascade definition
+          before the safety net can do useful work. *)
+       let cascade_permanently_dead =
+         match Oas_worker_named.classify_masc_internal_error err with
+         | Some (Oas_worker_named.No_tool_capable_provider _) -> true
+         | _ -> false
+       in
        let mode = Env_config.AntiRationalization.fail_mode in
        let mode_str = Env_config.AntiRationalization.fail_mode_to_string mode in
        Prometheus.inc_counter
          Prometheus.metric_anti_rationalization_fallback
          ~labels:[ ("mode", mode_str); ("cascade", evaluator_cascade) ]
          ();
+       if cascade_permanently_dead then begin
+         Log.Task.error
+           "[anti-rationalization] cascade %s has zero callable \
+            providers — ALL keepers using this evaluator are blocked \
+            from task completion.  Approving by liveness; OPERATOR \
+            ACTION REQUIRED: fix the cascade definition (provider \
+            capabilities, MCP policy, or tool requirements).  See \
+            #10474.  err=%s"
+           evaluator_cascade msg;
+         emit
+           { verdict = Approve
+           ; evaluator_cascade
+           ; generator_cascade
+           ; gate = Fallback
+           ; fallback_reason =
+               Some (sprintf "cascade %s has no callable providers (#10474)"
+                       evaluator_cascade)
+           }
+       end
+       else
        (* #10113: when an excuse pattern was detected at gate 2 AND
           the LLM evaluator is unavailable, the advisory is upgraded
           to a Reject regardless of [fail_mode].  The advisory mode


### PR DESCRIPTION
## 배경

#10474 — \`cross_verifier\` cascade 영구 dead 상태 (모든 provider 가 tool-use gate filter 에서 reject) 일 때 anti-rationalization gate-3 의 fail-closed 안전망이 keeper task-done 을 영구 block.

**실측**: 2026-04-26 05:36, keeper-sangsu task-056 \"[Bug] TOML loader silent skip regression\" 합리적 \"out of scope\" 표현 → gate-2 advisory 매치 → gate-3 LLM 호출 → cross_verifier no_callable_models → fail-closed reject → keeper retry loop.

## 근본 원인

\`Error err\` branch (anti_rationalization.ml:597) 가 두 종류 실패를 같은 path 로 처리:

| Error kind | 분류 | 적절한 대응 |
|---|---|---|
| \`Cascade_exhausted\` (provider 시도 모두 fail) | transient | fail-closed 안전망 (현재 OK) |
| \`Resumable_cli_session\` | transient | fail-closed 안전망 (현재 OK) |
| \`Admission_queue_*\` | transient | fail-closed 안전망 (현재 OK) |
| \`Turn_timeout\`, \`Oas_timeout_budget\` | transient | fail-closed 안전망 (현재 OK) |
| **\`No_tool_capable_provider\`** | **config issue (영구)** | **현재 fail-closed → 모든 keeper block. 잘못된 대응** |

\`No_tool_capable_provider\` 는 cascade 의 모든 provider 가 tool-use gate 에서 filter-out 됨을 의미. cascade 정의 / provider capability / MCP policy 가 바뀌기 전엔 영구 0 callable model. 안전망이 안전망이 아니라 deadlock.

## 변경

\`anti_rationalization.ml\` 의 \`Error err\` branch 에 분류 추가:

\`\`\`ocaml
let cascade_permanently_dead =
  match Oas_worker_named.classify_masc_internal_error err with
  | Some (Oas_worker_named.No_tool_capable_provider _) -> true
  | _ -> false
in
\`\`\`

| 상태 | 이전 | 이후 |
|---|---|---|
| transient + advisory match | reject (safety net) | reject (변경 없음) |
| transient + mode=open | approve | approve (변경 없음) |
| transient + mode=closed | reject | reject (변경 없음) |
| **cascade_permanently_dead** | **reject (잘못)** | **operator-actionable ERROR + Approve by liveness** |

operator-actionable 로그:
\`\`\`
[ERROR] [anti-rationalization] cascade cross_verifier has zero callable
providers — ALL keepers using this evaluator are blocked from task
completion. Approving by liveness; OPERATOR ACTION REQUIRED: fix the
cascade definition (provider capabilities, MCP policy, or tool
requirements). See #10474. err=...
\`\`\`

## 설계 결정

| 결정 | 근거 |
|---|---|
| Approve by liveness (vs blocking) | cascade config issue 는 keeper 책임 아님. block 은 잘못된 대상 처벌 |
| operator-actionable ERROR 로그 | 운영자가 dashboard 에서 즉시 인지. memory \`feedback_keeper-fleet-investigation.md\` 의 RFC B 가시성 차원 |
| 분류는 기존 \`classify_masc_internal_error\` 재사용 | 새 분류 abstraction 안 만듦 |
| \`fallback_reason\` 에 issue 번호 포함 | audit ledger 가 root cause 보존 |

## Acceptance criteria

- [x] \`dune build @check\` pass
- [x] Behavior unchanged for transient failures (Cascade_exhausted/Resumable/Admission/Turn_timeout/Oas_timeout)
- [x] cascade_permanently_dead 만 새 path
- [ ] 머지 후 cross_verifier dead 시 operator ERROR 로그 등장 + keeper 진행 가능 확인
- [ ] cross_verifier 정상 시 기존 동작 유지 확인

## Cross-references

- memory \`feedback_cascade-declared-vs-runtime-two-filter-layers\`
- #9864 (codex_cli + runtime_mcp_auth — 같은 class)
- #10681 (P0 fleet-wide cascade dead — 다른 cascade 의 같은 root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)