### PR TITLE
i18n(dashboard): localize last 2 fsm-hub-invariant headlines (round-82)

### DIFF
--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -102,7 +102,7 @@ export function deriveOperationalInsight(
   if (brokenInvariant) {
     return {
       tone: 'error',
-      headline: `Spec drift: ${INVARIANT_LABELS[brokenInvariant]}`,
+      headline: `Spec drift 감지: ${INVARIANT_LABELS[brokenInvariant]}`,
       detail: invariantDetail(snapshot, brokenInvariant, false),
       nextStep: 'Treat this as an observer-level contract breach before trusting downstream state transitions.',
       evidence: [
@@ -171,7 +171,7 @@ export function deriveOperationalInsight(
       : ''
     return {
       tone: 'warn',
-      headline: `${snapshot.phase} is the active lifecycle edge`,
+      headline: `${snapshot.phase} 가 활성 lifecycle edge`,
       detail: `The keeper is transitioning between stable lifecycle states, so the parent FSM matters more than sub-turn activity right now.${collapsedDetail}`,
       nextStep: nextExpectedStep(snapshot),
       evidence: [


### PR DESCRIPTION
## Summary

Round 71/72/73/74 가 9 headlines 중 7개를 처리. 남은 2개를 마무리해 `deriveOperationalInsight` 의 모든 headline 이 한국어로 렌더되도록 함.

## Change

| line | Before | After | toContain anchor |
|---|---|---|---|
| 105 | `\`Spec drift: \${INVARIANT_LABELS[brokenInvariant]}\`` | `\`Spec drift 감지: \${...}\`` | `'Spec drift'` (test:120) |
| 174 | `\`\${snapshot.phase} is the active lifecycle edge\`` | `\`\${snapshot.phase} 가 활성 lifecycle edge\`` | `'Overflowed'` (test:191) |

## After this PR

9 headlines 모두 한국어 또는 한국어/도메인 용어 혼합:
1. ✓ Spec drift 감지
2. ✓ cascade exhaustion 후 실패
3. ✓ Guardrail 가 턴 차단
4. ✓ \${field} 정체 — not moving
5. ✓ Compaction 가 현재 턴 소유
6. ✓ \${phase} 가 활성 lifecycle edge
7. ✓ Idle 스냅샷 정상
8. ✓ Provider 작업이 활성 frontier
9. ✓ 라이브 턴 progressing normally

## Domain terms preserved

`lifecycle edge`, `frontier`, `progressing normally`, `Spec drift`, `Compaction`, `Guardrail`, `cascade exhaustion` — substring anchor 역할 + 도메인 용어이므로 보존.

## Scope

- 1 파일, 2줄.
- 테스트 변경 없음 (toContain substring 보존).