### PR TITLE
fix(oas/cascade): promote [max_turns] cascade-fallback to WARN (#10982)

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1631,7 +1631,29 @@ let run_named
                 then "[max_turns] "
                 else ""
               in
-              Log.Misc.info "[cascade-fallback] cascade %s: %s failed (%s%s), trying next" cascade_name provider_cfg.model_id class_label (Oas.Error.to_string sdk_err);
+              (* #10982: [max_turns] failures cost ~$2.74 mean per
+                 fallback (24h sample: 11 events / $30.20 sunk).  The
+                 cost is incurred but the result is unusable, so the
+                 next tier re-runs from scratch.  At INFO this signal
+                 was buried in normal cascade traffic and the cost
+                 dashboard never saw it.  Promote [max_turns] to WARN
+                 — still "expected, recoverable" (the cascade escape
+                 hatch worked) but visible enough that operators can
+                 correlate cost gauges with cascade traffic.
+                 [hard_quota] stays INFO for now: quota signals fire
+                 normally during ratelimits and warrant a different
+                 promotion threshold (separate issue). *)
+              if sdk_error_is_max_turns_exceeded sdk_err then
+                Log.Misc.warn
+                  "[cascade-fallback] cascade %s: %s failed (%s%s), trying \
+                   next [sunk cost; see #10982]"
+                  cascade_name provider_cfg.model_id class_label
+                  (Oas.Error.to_string sdk_err)
+              else
+                Log.Misc.info
+                  "[cascade-fallback] cascade %s: %s failed (%s%s), trying next"
+                  cascade_name provider_cfg.model_id class_label
+                  (Oas.Error.to_string sdk_err);
               Oas_worker_cascade.record_fallback_event capture ~candidate_cfgs
                 ~from_model:provider_cfg.model_id ~to_model:"next"
                 ~reason:(class_label ^ Oas.Error.to_string sdk_err);


### PR DESCRIPTION
## 배경

#10982 — `[cascade-fallback] cascade keeper_unified: ... [max_turns] ...total_cost_usd:X.XX` 가 INFO 레벨. 24h sample:

| 지표 | 값 |
|---|---|
| Events | 11 |
| Total cost | $30.20 sunk |
| Mean per event | $2.74 |
| Primary model | claude-opus-4-7[1m] |

cost = 사용 안 된 결과 (max_turns 도달 → cascade fallback 으로 다음 provider 재시도). INFO 가 cascade traffic noise 에 묻혀 cost dashboard 미인지. $900/month 누수 estimated.

## 변경

`lib/oas_worker_named.ml:1634` 의 단일 INFO emit 을 `[max_turns]` 케이스에 한해 WARN 으로 분기:

```ocaml
if sdk_error_is_max_turns_exceeded sdk_err then
  Log.Misc.warn "[cascade-fallback] cascade %s: %s failed (%s%s), trying \
                 next [sunk cost; see #10982]" ...
else
  Log.Misc.info "[cascade-fallback] cascade %s: %s failed (%s%s), trying next" ...
```

기존 `class_label` 계산 그대로 유지 — 분기는 sdk error 분류기 재사용. payload 변경 없음.

## 의도적으로 안 한 것

| 항목 | 사유 |
|---|---|
| `[hard_quota]` 도 WARN 격상 | quota 는 ratelimit 중 정상 signal — 별도 promotion threshold 필요. 별도 이슈로 |
| Prometheus counter `cascade_fallback_wasted_cost_usd` 추가 (이슈 후보) | metric 추가는 cross-cutting (Audit_log, dashboard). 본 PR 은 surface log only |
| max_turns 자체 tuning (이슈 후보 C) | configuration policy — 본 PR scope 밖 |
| tool-loop early-exit detection (이슈 후보 B) | #10617 family root cause fix — 별도 PR |

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file, +23 / -1
- branch logic 만 추가; payload / cascade flow 미변경

## Family precedent (logging-tier severity split, 6번째 인스턴스)

- #10881 (WS lifecycle INFO→DEBUG, MERGED)
- #10908/#10910 (watchdog tick INFO→DEBUG, MERGED)
- #10919/#10937 (backend init INFO→DEBUG, MERGED)
- #10887/#10945 (SP universal suppression WARN→ERROR, MERGED)
- #10975/#10978 (tool_call_failure ERROR→WARN, MERGED)
- 본 PR (#10982) — cascade-fallback INFO→WARN

같은 anti-pattern: single emit path 가 정상 + 비정상 두 케이스를 같은 severity 로 출력. 6번째 도달 = `feedback_audit-bucket-cascade-pattern` lint gate 후보 시점.