### PR TITLE
chore(audit): add cross-module exhaustive-match audit script (#10584 Option C)

### DIFF
--- a/scripts/audit-cross-module-exhaustive-match.sh
+++ b/scripts/audit-cross-module-exhaustive-match.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Audit exhaustive matches on cross-module variants.
+#
+# Issue #10584: variant-extending PRs in module A do not see exhaustive
+# match sites in module B/C/D, so adding a constructor breaks `main`
+# the moment the upstream variant ships (e.g. #10490 InferenceTelemetry,
+# #10574 Stale_turn_timeout). Build's -warn-error catches it, but only
+# AFTER the variant lands on main.
+#
+# This script implements Option C from the issue: it does NOT enforce
+# anything. It scans for `match Module.expr with` patterns and surfaces
+# them as candidate sites that PR reviewers / authors should consider
+# adding a defensive arm to (or migrating to a source-of-truth converter
+# in the type's own module — Option B).
+#
+# Always exits 0; treat output as informational.
+#
+# Usage:
+#   scripts/audit-cross-module-exhaustive-match.sh           # default: stdout
+#   scripts/audit-cross-module-exhaustive-match.sh --counts  # per-source summary
+#
+# Tracked source-of-truth modules can be extended via $EXTRA_MATCH_SOURCES
+# (whitespace-separated list of module-prefix patterns suitable for ripgrep).
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Modules whose variants have historically broken main when extended.
+# Order matches the issue's "Concrete sites to audit" list.
+MATCH_SOURCES=(
+  'Oas\.Event_bus\.'
+  'Oas\.Error\.'
+  'Keeper_registry\.'
+  'Keeper_types\.'
+  ${EXTRA_MATCH_SOURCES:-}
+)
+
+MODE="list"
+case "${1:-}" in
+  ""|--list) MODE="list" ;;
+  --counts)  MODE="counts" ;;
+  -h|--help)
+    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0 ;;
+  *) echo "unknown arg: $1" >&2; exit 2 ;;
+esac
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) is required" >&2
+  exit 2
+fi
+
+cd "$REPO_ROOT"
+
+scan_one() {
+  # Match arms of the form `| Module.Constructor` (constructor =
+  # capital letter after the dot). Plain function calls
+  # `Module.lowercase_fn` do not match. The two-line context is
+  # ripgrep's `--multiline` so we still find single-line matches
+  # with `| Module.Foo -> ...`.
+  local pattern="$1"
+  rg -n --no-heading --type ml "\\|[[:space:]]*${pattern}[A-Z]" lib/ \
+    2>/dev/null \
+    | grep -v '/test/' || true
+}
+
+case "$MODE" in
+  list)
+    for src in "${MATCH_SOURCES[@]}"; do
+      [ -z "$src" ] && continue
+      hits="$(scan_one "$src")"
+      [ -z "$hits" ] && continue
+      printf '\n=== source: %s ===\n' "$src"
+      printf '%s\n' "$hits"
+    done
+    ;;
+  counts)
+    printf '%-32s %s\n' "source pattern" "site count"
+    printf '%-32s %s\n' "--------------" "----------"
+    for src in "${MATCH_SOURCES[@]}"; do
+      [ -z "$src" ] && continue
+      n="$(scan_one "$src" | wc -l | tr -d ' ')"
+      printf '%-32s %s\n' "$src" "$n"
+    done
+    ;;
+esac


### PR DESCRIPTION
## 배경

#10584 — variant-extending PR (모듈 A) 가 다른 모듈 (B/C/D) 의 exhaustive match 사이트 미인지. constructor 추가 즉시 main 빌드 break:

| 사고 | 영향 |
|---|---|
| #10490 (`InferenceTelemetry` 추가) | `oas_sse_bridge.ml` partial-match → main red |
| #10574 (`Stale_turn_timeout` 추가) | `keeper_supervisor.ml` partial-match → main red |

`-warn-error` 가 잡지만 **variant 머지 후** = main 깨진 후. 같은 주에 2번.

## 변경

`scripts/audit-cross-module-exhaustive-match.sh` 신규 — 이슈 본문 Option C 의 **non-enforcing audit script**.

추적 source-of-truth 모듈 (확장 가능 via `EXTRA_MATCH_SOURCES`):

| Module | 현재 site count |
|---|---|
| `Oas.Event_bus.` | 42 |
| `Oas.Error.` | 59 |
| `Keeper_registry.` | 8 |
| `Keeper_types.` | 23 |

총 132 candidate 사이트.

### 패턴 정확도

`| Module.Constructor` (dot 이후 첫 char uppercase) 만 매치. 일반 함수 호출 `Module.lowercase_fn` 는 false positive 회피.

```bash
# 1차 시도 (false positive 다수)
rg -n 'match[[:space:]]+[^|]*Keeper_registry\\.' lib/  # 46 sites (대부분 fn 호출)

# 정정 (constructor only)
rg -n '\\|[[:space:]]*Keeper_registry\\.[A-Z]' lib/    # 8 sites
```

### 사용법

```bash
scripts/audit-cross-module-exhaustive-match.sh           # list mode (default)
scripts/audit-cross-module-exhaustive-match.sh --counts  # per-source summary
EXTRA_MATCH_SOURCES='Other_module\\.' scripts/audit-cross-module-exhaustive-match.sh
```

Always exits 0. CI integration 시 `--counts` 출력만 PR 코멘트로 게시 가능.

## 의도적으로 안 한 것

| 항목 | 사유 |
|---|---|
| Option A (defensive `_ -> "unknown"` arms) | issue 본문 verdict: \"step backwards, loses signal that catches inconsistency\" |
| Option B (source-of-truth converter migration) | 132 사이트 migration = 별도 follow-up. 본 PR 은 surface 만 |
| CI gate (실패 시 fail) | issue 본문 명시: \"Doesn't enforce a fix; just makes the asymmetric coupling visible\" |
| Lint annotations on detected sites | `_ -> ...` 추가는 silent drop 위험 (Option A 와 같은 trap) |

## 검증

- smoke test: `--counts` 출력 정확 (4 source × 사이트 카운트 표시)
- `--list` 출력: `oas_event_bridge.ml` 의 `Oas.Event_bus.AgentStarted/Completed/...` 사이트 정확 매치
- 호출자 코드 미변경 (script-only PR)

## Family precedent (audit script)

`scripts/audit-*.sh` 12+ 기존 스크립트:
- `audit-event-linkage.sh`
- `audit-keeper-credential-drift.sh`
- `audit-hardcoding-truth.sh`
- ...

본 PR 은 같은 family — informational, exit 0, human triage 우선.

## 관련 메모리

- `feedback_variant-add-partial-match-cascade` — 같은 anti-pattern documented
- `feedback_audit-bucket-cascade-pattern` — N+ instances → audit gate trigger