### PR TITLE
i18n(dashboard): localize 5 nextExpectedStep return strings (round-83)

### DIFF
--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -50,10 +50,10 @@ function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
   if (!snapshot.is_live) {
     return snapshot.last_outcome
       ? 'The next live turn should repopulate KTC/KDP/KCL from idle placeholders.'
-      : 'No turn has completed yet; the first live turn should populate the observer.'
+      : '아직 완료된 턴 없음 — first live turn 이 observer 를 채워야 함.'
   }
   if (snapshot.phase === 'Failing' && snapshot.cascade.state === 'exhausted') {
-    return 'A healthy provider path or explicit recovery clearance must clear Failing before Running can resume.'
+    return '정상 provider path 또는 명시적 recovery clearance 가 Failing 을 해제해야 Running 재개 가능.'
   }
   if (snapshot.phase === 'Overflowed') {
     return 'Context overflow must resolve through compaction or explicit operator clearance before the lifecycle can settle.'
@@ -73,20 +73,20 @@ function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
       : 'The lifecycle is outside the active turn cycle; the next meaningful edge should come from a new live turn or operator action.'
   }
   if (snapshot.decision.stage === 'gate_rejected') {
-    return 'The blocked turn should finalize back to idle without entering cascade/tool execution.'
+    return 'blocked turn 은 cascade/tool execution 진입 없이 idle 로 finalize 되어야 함.'
   }
   if (snapshot.cascade.state === 'selecting' || snapshot.cascade.state === 'trying') {
     return 'KCL should settle into done or exhausted once provider routing returns.'
   }
   switch (snapshot.turn_phase) {
     case 'prompting':
-      return 'KTC should advance into executing once prompt assembly is complete.'
+      return 'prompt assembly 완료 시 KTC 가 executing 으로 진행해야 함.'
     case 'executing':
       return 'Execution should either finalize the turn or drive cascade/compaction transitions.'
     case 'compacting':
       return 'Turn finalization is waiting on compaction to finish.'
     case 'finalizing':
-      return 'The next stable state should be idle with last_outcome updated.'
+      return '다음 stable state 는 last_outcome 갱신된 idle 이어야 함.'
     default:
       return 'The next meaningful edge should come from the next observed lifecycle event.'
   }


### PR DESCRIPTION
## Summary

Headlines (rounds 71/72/73/74/82) 가 완성된 후 같은 helper 의 두 번째 surface 인 `nextExpectedStep` 13 return strings 중 5개를 한국어화. 8개는 다음 round.

## Localized branches

| line | 분기 | toContain anchor (test) |
|---|---|---|
| 53 | `!is_live` without outcome | `'first live turn'` (test:361) |
| 56 | `Failing` + `cascade.state === 'exhausted'` | `'recovery'` (test:370) |
| 76 | `decision.stage === 'gate_rejected'` | `'blocked turn'` + `'idle'` (test:400, 418 일부) |
| 83 | `turn_phase === 'prompting'` | `'prompt'` (test:409) |
| 89 | `turn_phase === 'finalizing'` | `'idle'` (test:418) |

5개 모두 anchor substring 보존 → 테스트 동기 변경 없음.

## Domain term policy

기존 dashboard 관습대로 spec 도메인 용어 보존:
- KTC (KeeperTurnController), KCL (KeeperCascadeLane)
- recovery clearance, prompt assembly, finalize, idle
- provider path, blocked turn, stable state, last_outcome

## Remaining (next round)

| line | 분기 | anchor 후보 |
|---|---|---|
| 52 | `is_live=false with last_outcome` | (no toContain) |
| 59 | `Overflowed` | (no toContain) |
| 62 | `Compacting` | (no toContain) |
| 65 | `HandingOff` | (no toContain) |
| 68 | `Draining` | (no toContain) |
| 72-73 | `Stable` (collapsedFrom present/absent) | `'paused'` (test:241 indirectly) |
| 79 | `cascade.state in ['selecting','trying']` | (no toContain) |
| 85, 87, 91 | `executing/compacting/default` | (no toContain) |

## Scope

- 1 파일, 5줄.
- 테스트 영향 0건 (toContain anchor substring 보존).
