### PR TITLE
fix(approval-queue): skip Critical risk in expire_stale (re-enqueue cycle fix for #10973)

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -917,15 +917,38 @@ let has_pending_for_keeper ~keeper_name : bool =
 (* ── Timeout cleanup ──────────────────────────────────────── *)
 
 (** Reject all approvals that have been waiting longer than [max_wait_s].
-    Call periodically from a health loop. *)
+    Call periodically from a health loop.
+
+    [Critical] risk-level entries are NEVER auto-expired.  They originate
+    from indefinite-wait operator gates ([keeper_continue_after_reconcile],
+    [keeper_continue_after_partial_commit] — see callers in
+    [Keeper_supervisor] and [Keeper_unified_turn]) where:
+
+    - Auto-rejecting would cause the supervisor's Phase-2 sweep to
+      re-enqueue the same approval on the next tick (since the
+      paused-meta blocker class is unchanged), creating a 30-min
+      expire / re-enqueue / expire cycle that flooded the audit log
+      and starved the operator of agency.
+    - Critical decisions (auto-compact retry exhaustion, partial-commit
+      ambiguity) are exactly the cases where a human MUST decide; a
+      stale 30-min default would silently push the keeper into a
+      permanent [paused = true] state that no autonomous logic can
+      recover from.
+
+    Operators escalate a stuck Critical entry by manual resolve via
+    dashboard / mcp / CLI — the timeout policy applies to
+    [Low / Medium / High] tool approvals only. *)
 let expire_stale ~max_wait_s =
   let now = Unix.gettimeofday () in
   let stale_ref = ref [] in
   atomic_update pending (fun map ->
     let stale = SMap.fold (fun id entry acc ->
-      if now -. entry.requested_at > max_wait_s
-      then (id, entry) :: acc
-      else acc
+      match entry.risk_level with
+      | Critical -> acc
+      | Low | Medium | High ->
+        if now -. entry.requested_at > max_wait_s
+        then (id, entry) :: acc
+        else acc
     ) map [] in
     stale_ref := stale;
     List.fold_left (fun acc (id, _) -> SMap.remove id acc) map stale

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -297,13 +297,14 @@ let test_approval_queue_expire_stale () =
         ~keeper_name:"test-keeper"
         ~tool_name:"masc_dangerous_tool"
         ~input:(`Assoc [])
-        ~risk_level:AQ.Critical
+        ~risk_level:AQ.High
         ()
     in
     result := Some decision
   );
   Eio.Fiber.yield ();
-  (* Expire with max_wait_s=0 → everything is stale *)
+  (* Expire with max_wait_s=0 → everything past the threshold is stale.
+     [High] (and below) is auto-expired by the periodic janitor. *)
   AQ.expire_stale ~max_wait_s:0.0;
   Eio.Fiber.yield ();
   match !result with
@@ -311,6 +312,36 @@ let test_approval_queue_expire_stale () =
     Alcotest.(check bool) "timeout reason" true
       (String.starts_with ~prefix:"approval timed out" reason)
   | _ -> Alcotest.fail "expected Reject from timeout"
+
+let test_approval_queue_expire_skips_critical () =
+  (* [Critical] entries originate from indefinite-wait operator gates
+     ([keeper_continue_after_reconcile] etc.). Auto-rejection would
+     create a 30-min expire / re-enqueue cycle and silently push the
+     keeper into a permanent paused state. The janitor must skip them. *)
+  Eio_main.run @@ fun _env ->
+  let resolution = ref None in
+  let id =
+    AQ.submit_pending
+      ~keeper_name:"test-keeper-critical"
+      ~tool_name:"keeper_continue_after_reconcile"
+      ~input:(`Assoc [])
+      ~risk_level:AQ.Critical
+      ~on_resolution:(fun decision -> resolution := Some decision)
+      ()
+  in
+  let pending_before = AQ.pending_count_for_keeper ~keeper_name:"test-keeper-critical" in
+  Alcotest.(check int) "Critical entry enqueued" 1 pending_before;
+  (* Aggressive max_wait_s=0: would expire High/Medium/Low immediately. *)
+  AQ.expire_stale ~max_wait_s:0.0;
+  let pending_after = AQ.pending_count_for_keeper ~keeper_name:"test-keeper-critical" in
+  Alcotest.(check int) "Critical NOT expired by janitor" 1 pending_after;
+  Alcotest.(check (option string)) "on_resolution NOT called" None
+    (match !resolution with
+     | None -> None
+     | Some _ -> Some "resolved");
+  (* Cleanup: manually resolve so subsequent tests don't see stray state. *)
+  match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup") with
+  | Ok () | Error _ -> ()
 
 let test_approval_resolve_nonexistent () =
   Eio_main.run @@ fun _env ->
@@ -975,6 +1006,7 @@ let () =
       Alcotest.test_case "submit and approve" `Quick test_approval_queue_submit_and_resolve;
       Alcotest.test_case "submit and reject" `Quick test_approval_queue_reject;
       Alcotest.test_case "expire stale" `Quick test_approval_queue_expire_stale;
+      Alcotest.test_case "expire skips Critical" `Quick test_approval_queue_expire_skips_critical;
       Alcotest.test_case "resolve nonexistent" `Quick test_approval_resolve_nonexistent;
       Alcotest.test_case "cancel cleans up" `Quick test_approval_queue_cancel_cleans_up;
       Alcotest.test_case "background pending callback" `Quick


### PR DESCRIPTION
Refs #10973. Fix-forward.

## Why

#10973 wired `Keeper_approval_queue.expire_stale` into a periodic
janitor (every 60s, default `max_wait_s = 1800.0`). I missed a
critical interaction with the supervisor's reconcile-recovery flow:

**Re-enqueue cycle for `paused_meta_requires_reconcile_recovery`
keepers** — `Keeper_supervisor.sweep_and_recover` Phase 2 (line
760-769) detects the `Ambiguous_post_commit_*` blocker class and
re-enqueues `keeper_continue_after_reconcile`:

```ocaml
match read_meta ctx.config name with
| Ok (Some meta)
  when paused_meta_requires_reconcile_recovery meta
       && not (Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name) ->
    restore_reconcile_continue_gate ctx meta
```

So when #10973's janitor fires:
1. t=0: approval enqueued.
2. t=30 min: `expire_stale` rejects → `on_resolution(Reject)` →
   keeper "remains paused" log line.
3. t=30 min + sweep_tick: `paused_meta_requires_reconcile_recovery`
   still true (blocker class unchanged), no pending → re-enqueue.
4. t=60 min: `expire_stale` rejects again. Goto 2.

That's **48 audit events / day per stuck keeper, no operator agency,
keeper never recovers**.

There's a second symptom for `keeper_continue_after_partial_commit`
(`Keeper_unified_turn:958`): on `Reject`, `sync_keeper_paused_state
~paused:true` writes a permanent paused flag. A 30-min auto-rejection
silently pushes the keeper into "paused, no one knows why" state.

## What

`expire_stale` skips `Critical` risk-level entries:

```ocaml
let stale = SMap.fold (fun id entry acc ->
  match entry.risk_level with
  | Critical -> acc
  | Low | Medium | High ->
    if now -. entry.requested_at > max_wait_s
    then (id, entry) :: acc
    else acc
) map [] in
```

`Critical` is currently used by exactly two callers, both intentional
indefinite-wait operator gates:
- `Keeper_supervisor.restore_reconcile_continue_gate:415`
- `Keeper_unified_turn.continue_gate_required:958`

Operators escalate stuck `Critical` entries by manual resolve via
dashboard / mcp / CLI — the timeout policy applies to
`Low / Medium / High` tool approvals only, where rejection-on-timeout
is a sane safety default.

## Det vs non-det

- The bug was deterministic: queue removal → Reject resolves promise
  → next sweep tick re-enqueues. No race.
- The fix is deterministic: pattern match on `risk_level`, exhaustive,
  total. Critical entries pass through `expire_stale` unchanged.
- Operator response time on Critical decisions is non-deterministic
  by definition — that's why it's `Critical`, that's why we don't
  auto-resolve.

## Test

Existing `test_approval_queue_expire_stale` re-typed to `High` (it
was using `Critical` to test "any level expires"; that contract is
no longer true). New `test_approval_queue_expire_skips_critical`
verifies a `Critical` entry survives `max_wait_s=0.0` aggressive
sweep and `on_resolution` is NOT invoked.

## Risk

Negligible. Behaviour change is strictly more conservative: stuck
Critical entries that #10973 would have force-rejected now wait for
operator. The pre-#10973 baseline already had immortal Critical
entries (no janitor at all), so this returns to the same baseline
for that subset.

## Verification

- [x] `dune build --root . lib` clean
- [x] No call sites of `expire_stale` outside the janitor itself
  (single-purpose function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
