### PR TITLE
i18n(dashboard): localize 5 more nextExpectedStep return strings (round-84)

### DIFF
--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -49,23 +49,23 @@ function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
   const collapsedFrom = snapshot.phase === 'Stable' ? snapshot.collapsed_from : null
   if (!snapshot.is_live) {
     return snapshot.last_outcome
-      ? 'The next live turn should repopulate KTC/KDP/KCL from idle placeholders.'
+      ? '다음 live turn 이 idle placeholder 로부터 KTC/KDP/KCL 을 repopulate 해야 함.'
       : '아직 완료된 턴 없음 — first live turn 이 observer 를 채워야 함.'
   }
   if (snapshot.phase === 'Failing' && snapshot.cascade.state === 'exhausted') {
     return '정상 provider path 또는 명시적 recovery clearance 가 Failing 을 해제해야 Running 재개 가능.'
   }
   if (snapshot.phase === 'Overflowed') {
-    return 'Context overflow must resolve through compaction or explicit operator clearance before the lifecycle can settle.'
+    return 'context overflow 은 compaction 또는 명시적 operator clearance 로 해소되어야 lifecycle 이 정착 가능.'
   }
   if (snapshot.phase === 'Compacting' || snapshot.compaction.stage === 'compacting') {
-    return 'KMC should reach done and then KSM should hand control back to Running.'
+    return 'KMC 가 done 에 도달한 뒤 KSM 이 Running 으로 control 을 반환해야 함.'
   }
   if (snapshot.phase === 'HandingOff') {
-    return 'The current keeper should stop once handoff completion is observed.'
+    return 'handoff completion 이 관측되면 현재 keeper 는 stop 해야 함.'
   }
   if (snapshot.phase === 'Draining') {
-    return 'Draining should complete before the lifecycle settles into Stopped.'
+    return 'lifecycle 가 Stopped 로 정착되기 전에 Draining 이 완료되어야 함.'
   }
   if (snapshot.phase === 'Stable') {
     return collapsedFrom


### PR DESCRIPTION
## Summary

Round-83 (#10990) 가 5/13 branches 를 처리, 이 PR 은 **다른 5 branches** 를 처리. 두 PR 의 변경 line 이 겹치지 않아 동시 머지 가능.

## Localized branches

| line | 분기 | toContain anchor |
|---|---|---|
| 52 | `!is_live` with `last_outcome` | (없음) |
| 59 | `Overflowed` | (없음) |
| 62 | `Compacting` (KMC done → Running) | (없음) |
| 65 | `HandingOff` | (없음) |
| 68 | `Draining` | (없음) |

5개 모두 `fsm-hub-invariant-analysis.test.ts` 에 toContain assertion 없음 → 테스트 영향 0.

## Domain term policy

기존 dashboard 관습대로 spec 도메인 용어 보존:
- KTC (KeeperTurnController), KDP (KeeperDecisionPipeline), KCL (KeeperCascadeLane), KMC (KeeperMemoryCompaction), KSM (KeeperStateMachine)
- idle placeholder, repopulate, context overflow, compaction, operator clearance, lifecycle, handoff completion, Stopped, Running

## Stack progress (rounds 71–84)

| Round | Surface | Branches |
|---|---|---|
| 71/72/73/74/82 | headlines (9 total) | ✓ 9/9 완료 |
| 83 (#10990) | nextExpectedStep | 5/13 |
| **84 (this PR)** | nextExpectedStep | 5/13 (different lines) |
| **남은 backlog** | nextExpectedStep | **3/13** |

## Remaining (next round)

| line | 분기 | anchor |
|---|---|---|
| 72-73 | `Stable` (collapsedFrom present/absent) | `'paused'` (test:241 indirect) |
| 79 | `cascade selecting/trying` | (없음) |
| 85, 87, 91 | `executing/compacting/default` | (없음) |

## Scope

- 1 파일, 5줄.
- round-83 PR (#10990) 과 변경 line 겹침 0 (52/59/62/65/68 vs 53/56/76/83/89).
- 테스트 영향 0건.
