### PR TITLE
feat(dashboard): adopt KeeperBadge in ConnectorKeeperMatrix row (Stage 3c)

### DIFF
--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -26,6 +26,7 @@ import {
   type KnownConnectorId,
 } from './connector-status'
 import { openConnectorConfig } from './connector-config-form'
+import { KeeperBadge } from './keeper-badge'
 
 type MatrixCellState = 'bound' | 'unbound' | 'na' | 'unknown'
 
@@ -359,7 +360,7 @@ function MatrixRowRender({ row }: { row: MatrixRow }) {
       aria-label=${row.known ? row.keeperName : `${row.keeperName} — directory 밖 keeper`}
     >
       ${row.known ? null : html`<span class="text-[var(--color-status-warn)]" aria-hidden="true">⚠</span>`}
-      <span class="truncate">${row.keeperName}</span>
+      <${KeeperBadge} id=${row.keeperName} variant="full" size="sm" />
     </button>
     ${row.cells.map(cell => html`<${MatrixCellButton} cell=${cell} />`)}
     <${RowCoverageChip} keeperName=${row.keeperName} counts=${counts} />


### PR DESCRIPTION
## Why

Continues the v0.4 keeper-attribution rollout (#10955 primitive, #10970 / #10983 safe-autonomy callsites) into a *higher-traffic* surface: `ConnectorKeeperMatrix`, the K×M grid of keepers × connectors. Each row's label is the keeper id. Plain text gave the operator no way to track the same keeper *across multiple matrix views or list surfaces* without re-reading every label. With this PR, identity is one sigil + one color anywhere keeper attribution appears.

## What

`src/components/connector-keeper-matrix.ts` — `MatrixRowRender`:

```diff
- <span class="truncate">${row.keeperName}</span>
+ <${KeeperBadge} id=${row.keeperName} variant="full" size="sm" />
```

Plus the `KeeperBadge` import.

## Two-channel separation preserved

The matrix uses *two orthogonal signals* for each row:

| Signal | Channel (before this PR) | Channel (after) |
|---|---|---|
| Keeper identity | label text + button text-color | KeeperBadge sigil + keeper-color |
| Directory state (`known`?) | ⚠ icon + button-level warn color | ⚠ icon (unchanged) |

The two were *already* split, but the keeper-identity channel was thin (plain text). KeeperBadge thickens it without disturbing the directory-state channel. ⚠ stays exactly where it was.

The button-level `text-[var(--color-status-warn)]` for `!row.known` now mostly tints whitespace — kept as the visual envelope for unknown rows, but its semantic load moved into the icon.

## A11y intact

`aria-label` / `title` on the button (lines 358-359) still pass `row.keeperName`, so SR users get the same row announcement. KeeperBadge itself emits the keeper id as its own `aria-label` for sigil variants; in `full` it renders the name as visible text.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run src/components/connector-keeper-matrix.test.ts` — 18/18 pass unchanged. The harness asserts via `data-matrix-cell` / `data-matrix-row-coverage` / `data-matrix-coverage-header` etc., not row label text, so the swap is invisible to existing tests.
- [ ] Visual smoke: render the matrix view with seeded keepers (known + unknown rows) — confirm sigil consistency vs the same keepers in safe-autonomy panel. Queued.

## Patterns confirmed (now spans 4 callsites across 2 modules)

- `variant="full"` everywhere — canonical SPEC §3.6 default.
- `size="sm"` for inline / list / matrix label slots; `size="md"` for card-level primary headings (#10983 KeeperCard).
- ⚠ / status icons stay separate from KeeperBadge so identity (color) and state (icon) remain orthogonal.
- aria-label on container preserved when the keeper name was previously the text; KeeperBadge's own a11y is composable.

## Refs

- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`
- Predecessors: #10898, #10955 (primitive — MERGED), #10970 (FindingsList — MERGED), #10983 (KeeperCard + TimelineList — MERGED)
- SPEC §3.6 v0.3: `dashboard/design-system/SPEC.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
