### PR TITLE
i18n(dashboard): localize last 6 nextExpectedStep return strings (round-85)

### DIFF
--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -69,26 +69,26 @@ function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
   }
   if (snapshot.phase === 'Stable') {
     return collapsedFrom
-      ? `The lifecycle is collapsed into Stable from raw phase ${collapsedFrom}; the next meaningful edge should clear that underlying condition before turn activity resumes.`
-      : 'The lifecycle is outside the active turn cycle; the next meaningful edge should come from a new live turn or operator action.'
+      ? `lifecycle 가 raw phase ${collapsedFrom} 에서 Stable 로 collapse 됨; 다음 meaningful edge 가 turn activity 재개 전에 그 underlying condition 을 clear 해야 함.`
+      : 'lifecycle 가 active turn cycle 밖에 있음; 다음 meaningful edge 는 새 live turn 또는 operator action 에서 시작되어야 함.'
   }
   if (snapshot.decision.stage === 'gate_rejected') {
     return 'blocked turn 은 cascade/tool execution 진입 없이 idle 로 finalize 되어야 함.'
   }
   if (snapshot.cascade.state === 'selecting' || snapshot.cascade.state === 'trying') {
-    return 'KCL should settle into done or exhausted once provider routing returns.'
+    return 'provider routing 이 반환되면 KCL 이 done 또는 exhausted 로 정착해야 함.'
   }
   switch (snapshot.turn_phase) {
     case 'prompting':
       return 'prompt assembly 완료 시 KTC 가 executing 으로 진행해야 함.'
     case 'executing':
-      return 'Execution should either finalize the turn or drive cascade/compaction transitions.'
+      return 'execution 은 turn 을 finalize 하거나 cascade/compaction transition 을 유도해야 함.'
     case 'compacting':
-      return 'Turn finalization is waiting on compaction to finish.'
+      return 'turn finalization 이 compaction 종료를 대기 중.'
     case 'finalizing':
       return '다음 stable state 는 last_outcome 갱신된 idle 이어야 함.'
     default:
-      return 'The next meaningful edge should come from the next observed lifecycle event.'
+      return '다음 meaningful edge 는 다음 관측된 lifecycle event 에서 시작되어야 함.'
   }
 }
 


### PR DESCRIPTION
## Summary

Round-83 (#10990 MERGED) + round-84 (#10996 OPEN) 가 nextExpectedStep 의 10/13 branches 를 처리. 이 PR 이 **마지막 3 분기 (6 strings)** 를 한국어화. round-84 와 변경 line 겹침 0.

## Localized branches (이 PR)

| line | 분기 | toContain anchor |
|---|---|---|
| 72 | `Stable` + `collapsedFrom` present | `'paused'` (test:241, `${collapsedFrom}` interpolation 으로 보존) |
| 73 | `Stable` + `collapsedFrom` absent | (없음) |
| 79 | `cascade.state in ['selecting','trying']` | (없음) |
| 85 | `turn_phase === 'executing'` | (없음) |
| 87 | `turn_phase === 'compacting'` | (없음) |
| 91 | `switch default` | (없음) |

## paused anchor 보존 검증

```ts
// test/fsm-hub-invariant-analysis.test.ts:241
expect(insight.nextStep).toContain('paused')
```

이 시나리오는 `snapshot.phase === 'Stable'` + `snapshot.collapsed_from === 'paused'` 일 때 line 72 분기를 타고:

```ts
return collapsedFrom
  ? `lifecycle 가 raw phase ${collapsedFrom} 에서 Stable 로 collapse 됨; ...`
//                          ^^^^^^^^^^^^^^ 'paused' 가 여기 interpolation 됨
```

interpolation 으로 substring 'paused' 가 그대로 출력 → toContain 충족.

## After this PR (with round-84 merged)

13/13 nextExpectedStep branches 모두 한국어. 

| Round | PR | line range |
|---|---|---|
| 71/72/73/74/82 | merged | 9 headlines |
| 83 | #10990 merged | 53/56/76/83/89 |
| 84 | #10996 open | 52/59/62/65/68 |
| **85 (this)** | — | **72/73/79/85/87/91** |

## Backlog (다음 surface)

`fsm-hub-invariant-analysis.ts` 안에는 `detail` field (line 122/135/148/등) 의 영어 explanation 이 남음. 다음 round 후보.

## Scope

- 1 파일, 6줄.
- round-84 PR (#10996) 과 변경 line 겹침 0 → 두 PR 동시 머지 가능.
- 테스트 영향 0 ('paused' anchor 는 interpolation 으로 보존).
