### PR TITLE
fix(keeper-watchdog): emit fleet batch-termination ERROR (#10765)

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -45,6 +45,42 @@ let record_stale_termination keeper_name now : int =
     Hashtbl.replace termination_history keeper_name pruned;
     List.length pruned)
 
+(* #10765 phase 2: fleet-wide batch termination detection.
+
+   Each keeper runs its watchdog as an independent fiber, so the
+   per-keeper [record_stale_termination] above never sees the
+   cross-keeper pattern.  Issue evidence: 8 keepers terminated
+   within the same second at 12:54:13Z (analyst, executor,
+   issue_king, janitor, masc-improver, nick0cave, ollama-local,
+   qa-king).  That shape is a *systemic* signal — typically cascade
+   dead (#10474), provider auth failure, or fd exhaustion (#10745) —
+   not 8 independent stuck fibers.  The supervisor will keep
+   restarting each one individually unless an operator notices.
+
+   Track recent terminations across all keepers in a small bounded
+   window.  When the number of distinct keepers in the window
+   reaches the threshold we emit a fleet-tier ERROR pointing at the
+   systemic root-cause issue list, plus a Prometheus counter.  No
+   state-machine change: the per-keeper restart still proceeds.  The
+   point is to make the batch event visible at all. *)
+let batch_window_sec = 30.0
+let batch_threshold = 3
+let batch_terminations : (string * float) list Atomic.t = Atomic.make []
+
+let record_batch_termination keeper_name now : string list =
+  let rec atomic_update () =
+    let prev = Atomic.get batch_terminations in
+    let pruned =
+      List.filter (fun (_, ts) -> now -. ts <= batch_window_sec) prev
+    in
+    let next = (keeper_name, now) :: pruned in
+    if Atomic.compare_and_set batch_terminations prev next
+    then next
+    else atomic_update ()
+  in
+  let entries = atomic_update () in
+  List.sort_uniq compare (List.map fst entries)
+
 let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
     (reg : Keeper_registry.registry_entry) =
   let base_path = ctx.config.base_path in
@@ -195,6 +231,22 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                     See issue #10765."
                    meta.name window_count termination_window_sec
                    escalation_threshold
+               end;
+               (* #10765 phase 2: fleet batch detection.  See module-level
+                  comment on [batch_terminations] for rationale. *)
+               let batch = record_batch_termination meta.name now in
+               if List.length batch >= batch_threshold then begin
+                 Prometheus.inc_counter
+                   "masc_keeper_stale_termination_batch_total"
+                   ();
+                 Log.Keeper.error
+                   "FLEET BATCH TERMINATION: %d distinct keepers \
+                    terminated in last %.0fs [%s] — systemic signal \
+                    (cascade dead, provider auth, fd leak).  \
+                    Per-keeper restarts will loop without operator \
+                    intervention.  See #10765, #10474, #10745."
+                   (List.length batch) batch_window_sec
+                   (String.concat ", " batch)
                end;
                (try
                   Keeper_execution_receipt.emit_stale_keeper_broadcast


### PR DESCRIPTION
## 배경

#10765 — 24h 116 stale terminations / 14 keeper 전체. 12:54:13Z 8 keepers 동시 termination = 시스템 차원 사건. 기존 per-keeper escalation (`record_stale_termination`/`escalation_threshold`) 은 cross-keeper 패턴 미인지.

## 변경

`lib/keeper/keeper_stale_watchdog.ml` 에 module-level Atomic-based fleet 트래커 추가:

```ocaml
let batch_window_sec = 30.0
let batch_threshold = 3
let batch_terminations : (string * float) list Atomic.t = Atomic.make []

let record_batch_termination keeper_name now : string list = ...
```

각 watchdog fiber 가 termination 직후 호출 → 30s 윈도우 내 distinct keeper ≥3 도달 시:
- `masc_keeper_stale_termination_batch_total` Prometheus counter
- ERROR log: keeper 목록 + `#10765 / #10474 / #10745` 링크

State-machine 변경 없음 — per-keeper restart 그대로 진행. 본 PR 은 batch 가시성만.

## 의도적으로 안 한 것

| 항목 | 사유 |
|---|---|
| Trust pause / circuit break | FSM 변경 — supervisor restart 정책 영향, 별도 PR |
| Cascade health pre-check | death spiral root cause (#10474 / #10745) — surface PR 아님 |
| 30s window / 3-keeper threshold env knob | calibration 후 결정 — 첫 production sample 후 |

`feedback_no-hyperparameter-as-env-knob` 준수 — 단일 boolean 만 추가하는 대신 코드 상수.

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file, +52
- Atomic.compare_and_set retry loop = lock-free + race-safe

## 효과 예상

12:54:13Z 8-keeper batch 같은 사건이 다음 발생 시:
```
ERROR FLEET BATCH TERMINATION: 8 distinct keepers terminated in last 30.0s
[analyst, executor, issue_king, janitor, masc-improver, nick0cave,
ollama-local, qa-king] — systemic signal (cascade dead, provider auth,
fd leak). Per-keeper restarts will loop without operator intervention.
See #10765, #10474, #10745.
```

기존 per-keeper "STALE-TERMINATION THRESHOLD BREACHED" 메시지는 그대로 — partial death spiral (1 keeper 7-13 회) 경로 유지.

## Related

- #10474 (cascade keeper_unified dead — 가설의 step 1)
- #10745 (fd leak — 가설의 step 4)