### PR TITLE
fix(coord/task): extend worktree auto-cleanup to Cancel and Release (#10899 followup)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -1655,6 +1655,40 @@ let transition_task_r
                  ?duration_ms
                  ~forced:force
                  ());
+          (* #10899 follow-up — extract worktree auto-cleanup so it can
+             fire on every terminal/handoff transition that orphans the
+             current keeper's worktree, not just [Done_action].  Without
+             this, [Cancel] / [Release] both leave [.masc/playground/
+             <keeper>/repos/.../.worktrees/<task>/] behind: [Cancel] kills
+             the task entirely (no future claimant), [Release] returns the
+             task to claimable for a *different* keeper that creates its
+             own worktree, leaving the original orphaned.  Best-effort
+             matches the existing Done branch: filesystem GC must not
+             fail the state transition. *)
+          let cleanup_worktree_for_transition reason_label =
+            match task.worktree with
+            | None -> ()
+            | Some _ ->
+              (try
+                 match
+                   Coord_worktree.worktree_remove_r config ~agent_name ~task_id
+                 with
+                 | Ok msg ->
+                   Log.RoomTask.info
+                     "%s worktree auto-cleanup: %s" reason_label msg
+                 | Error e ->
+                   Log.RoomTask.warn
+                     "%s worktree auto-cleanup failed \
+                      (best-effort, suppressed): %s"
+                     reason_label (Types.masc_error_to_string e)
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn ->
+                 Log.RoomTask.warn
+                   "%s worktree auto-cleanup raised \
+                    (best-effort, suppressed): %s"
+                   reason_label (Printexc.to_string exn))
+          in
           (match action with
            | Types.Done_action ->
              (* Completion rewards are tied to the real state-changing done path;
@@ -1702,28 +1736,7 @@ let transition_task_r
                 a warn and continue. The state-change is the
                 canonical lifecycle event; filesystem GC must not
                 fail the task transition. *)
-             (match task.worktree with
-              | None -> ()
-              | Some _ ->
-                (try
-                   match
-                     Coord_worktree.worktree_remove_r config ~agent_name ~task_id
-                   with
-                   | Ok msg ->
-                     Log.RoomTask.info
-                       "task_done worktree auto-cleanup: %s" msg
-                   | Error e ->
-                     Log.RoomTask.warn
-                       "task_done worktree auto-cleanup failed \
-                        (best-effort, suppressed): %s"
-                       (Types.masc_error_to_string e)
-                 with
-                 | Eio.Cancel.Cancelled _ as e -> raise e
-                 | exn ->
-                   Log.RoomTask.warn
-                     "task_done worktree auto-cleanup raised \
-                      (best-effort, suppressed): %s"
-                     (Printexc.to_string exn)))
+             cleanup_worktree_for_transition "task_done"
            | Types.Cancel ->
              (try
                 let workers = working_agents config in
@@ -1736,10 +1749,20 @@ let transition_task_r
               | exn ->
                 Log.RoomTask.error
                   "transition hebbian cancel hook: %s"
-                  (Printexc.to_string exn))
+                  (Printexc.to_string exn));
+             (* Cancel is terminal: no future claimant will pick up the
+                worktree, so cleanup unconditionally. *)
+             cleanup_worktree_for_transition "task_cancel"
+           | Types.Release ->
+             (* Release returns the task to claimable.  The releasing
+                keeper's worktree is orphaned because the next claimant
+                (potentially a different keeper) will create its own
+                via [claim_post_provision_fn].  Cleanup the previous
+                keeper's worktree to prevent the leak observed in
+                #10899 (5d / 7 keepers / 3.4 GB). *)
+             cleanup_worktree_for_transition "task_release"
            | Types.Claim
            | Types.Start
-           | Types.Release
            | Types.Submit_for_verification
            | Types.Approve_verification
            | Types.Reject_verification -> ());


### PR DESCRIPTION
Refs #10899. Follow-up to #10956.

## Why

#10956 (`fix(coord/task): auto-cleanup playground worktree on task done`)
closed the **`Done_action`** arm of #10899 — keepers completing tasks
normally no longer leak `.masc/playground/<keeper>/repos/.../.worktrees/`
directories.

But the issue is only **partially** closed. Two terminal/handoff
transitions still orphan worktrees:

| Transition | Why the worktree leaks |
|---|---|
| `Cancel` | Task is dropped; no future claimant ever reuses the worktree. |
| `Release` | Task returns to claimable; the *next* claim runs `claim_post_provision_fn` (`server_bootstrap_loops.ml:20`) which creates a **new** worktree for the claiming keeper. The original keeper's worktree is now orphaned with no owner. |

Field evidence from #10899 stays relevant: 5d / 7 keepers / ~3.4 GB of
stale worktree dirs. With Cancel + Release un-cleaned, the leak rate
just slows rather than stopping.

## What

Extract the existing `Done_action` worktree cleanup block into a
single helper:

```ocaml
let cleanup_worktree_for_transition reason_label = ...
```

…then invoke it from:
- `Done_action` (existing behaviour preserved)
- `Cancel` (new — terminal, no future claimant)
- `Release` (new — handoff to a new keeper that creates its own)

`Reject_verification`, `Submit_for_verification`, and
`Approve_verification` are deliberately **excluded**:
- `Reject_verification`: the task may need more work from the same
  keeper. Worktree is still active state.
- `Submit_for_verification` / `Approve_verification`: intermediate
  states where the worktree is still authoritative.

Best-effort matches the existing `Done_action` arm: any
`Coord_worktree.worktree_remove_r` failure logs a warn and continues.
**The state-change is the canonical lifecycle event; filesystem GC
must not fail the task transition.**

## Det vs non-det

- The leak was deterministic: a transition without cleanup hook leaves
  the worktree directory behind regardless of keeper behaviour.
- The fix is deterministic: pattern match on `task_action`, exhaustive
  enumeration of which transitions trigger cleanup vs preserve.
- Adding a new `task_action` variant in the future will trigger a
  non-exhaustive-match warning, forcing a deliberate cleanup-policy
  decision rather than silent inheritance.

## Pairing with adjacent fixes

- **#10973** (approval_janitor fork): closes the queue-immortality
  dead-end. Different leak class (in-memory queue vs disk dir).
- **#10995** (Critical-skip fix-forward to #10973): closes the
  re-enqueue cycle that #10973 introduced.
- **This PR**: closes the Cancel/Release branch of #10899 that
  #10956 left open.

Each PR closes one leg of a dead-end pattern: *function exists, intent
exists, single missing transition leaves it inert*.

## Risk

Negligible:
- Best-effort cleanup means cleanup failure cannot fail the task
  transition.
- `Coord_worktree.worktree_remove_r` is the same call already used by
  the Done branch — no new code path inside the FS layer.
- Excluded transitions (`Reject_verification` etc.) are documented
  inline.

## Verification

- [x] `dune build --root . lib/coord` clean (my change only).
- Note: `lib/provider_adapter.ml` and `lib/provider_tool_support.ml`
  on main currently emit `redundant-case` warnings (warning 11) from
  a recent variant addition. These are unrelated to this PR and
  affect every PR's CI Build until a separate fix-forward sweep
  lands. My change does not touch those modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
