### PR TITLE
perf(dashboard): isolate fsm-hub render scope from 5 s tick

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -248,13 +248,13 @@ export function FsmHub(props: FsmHubProps = {}) {
   const [hub, dispatch] = useReducer(reduceHubState, initialHubState)
   const [keeperFilter, setKeeperFilter] = useState('')
   const [pollTick, setPollTick] = useState(0)
-  // `now` was a per-component useState ticker (5 s setInterval calling
-  // setNow). Hoisted to the shared module-level signal so multiple
-  // components on the page share one interval — and so future cycles
-  // can migrate children to subscribe directly, isolating render scope
-  // to the leaves that actually display elapsed strings.
-  useNowSecondsTicker()
-  const now = nowSecondsSignal.value
+  // The 5 s wall-clock signal is now subscribed to by each leaf that
+  // actually displays elapsed durations — this hub component itself
+  // never reads `nowSecondsSignal.value`, so 5 s ticks no longer
+  // re-render the full FsmHub render tree.  Each leaf (StatusBar,
+  // OperationalMeaningPanel, HeroPhase + PhaseSparkline, PipelineStep,
+  // SwimlaneTimeline, TransitionTrail, DwellHistogramPanel) calls
+  // `useNowSecondsTicker` on its own and refcounts the shared interval.
   const [graphOpen, setGraphOpen] = useState(false)
   const [hoveredSegment, setHoveredSegment] = useState<HoveredSegment | null>(null)
   const [gateKeeperNames, setGateKeeperNames] = useState<string[]>([])
@@ -516,7 +516,6 @@ export function FsmHub(props: FsmHubProps = {}) {
       ${/* ── Zone 1: Status Bar ── */ ''}
       <${StatusBar}
         snapshot=${snapshot}
-        now=${now}
         lastFetchAt=${lastFetchAt}
         density=${density}
         onDensityToggle=${() => setDensity(d => d === 'comfortable' ? 'compact' : 'comfortable')}
@@ -665,7 +664,6 @@ function ShortcutsOverlay({
 
 function StatusBar({
   snapshot,
-  now,
   lastFetchAt,
   density,
   onDensityToggle,
@@ -683,7 +681,6 @@ function StatusBar({
   observationCount,
 }: {
   snapshot: KeeperCompositeSnapshot | null
-  now: number
   lastFetchAt: number
   density: 'comfortable' | 'compact'
   onDensityToggle: () => void
@@ -700,6 +697,8 @@ function StatusBar({
   transitionCount: number
   observationCount: number
 }) {
+  useNowSecondsTicker()
+  const now = nowSecondsSignal.value
   const isFilteringKeepers = keeperFilter.trim() !== ''
   const keeperFilterHasNoMatch =
     isFilteringKeepers && visibleKeeperNames.length === 0 && keeperNames.length > 0


### PR DESCRIPTION
## Why

Cycle 11 — the **final** reaper of the cycle 7 (#10918) shared-signal infrastructure.  Cycles 9 (#10961) and 10 (#10969) migrated the pipeline-panels and timeline-panels children to subscribe to `nowSecondsSignal` directly.  This PR migrates the last consumer in fsm-hub itself — `StatusBar` — and removes the `useNowSecondsTicker()` + `const now = nowSecondsSignal.value` from the outer `FsmHub` component.

After this PR, `FsmHub` reads `nowSecondsSignal.value` **zero times** in its render scope.  The 5 s tick no longer re-renders the 1012-LOC hub component; only the seven leaf consumers re-render on each tick.

## What

| File | Change |
|------|--------|
| `dashboard/src/components/fsm-hub.ts` | Remove `useNowSecondsTicker()`/`const now` in `FsmHub`; remove `now=${now}` from `<StatusBar>` call site; add `useNowSecondsTicker()` + `const now = nowSecondsSignal.value` inside `StatusBar`; remove `now: number` from `StatusBar`'s prop type and destructure |

Net: 1 file, +9 -10.

## Render-scope before / after

**Before (main as of last week):**
- 5 s tick fires → `nowSecondsSignal.value` updates → `FsmHub` re-renders (entire tree)

**Cycles 9 + 10 alone (pre-cycle 11):**
- 5 s tick fires → 6 leaf children re-render isolated, BUT `FsmHub` itself still re-renders because it still calls `nowSecondsSignal.value` and passes `now` to `StatusBar`

**After cycle 11 (this PR):**
- 5 s tick fires → 7 leaves re-render isolated. `FsmHub` does not re-render. The hub render path runs only on data change (`view.observations`, snapshot deltas, hover state).

## Stack position

- Cycle 1 (#10894 merged) — fsm-hub 1Hz → 5Hz tick
- Cycle 7 (#10918 merged) — `nowSecondsSignal` infra
- Cycle 8 (#10949 merged) — live-pulse 1 Hz refcount sweep
- Cycle 9 (#10961 merged) — pipeline-panels children migration
- Cycle 10 (#10969 merged) — timeline-panels children + dwellHistograms move
- Cycle 12 (#10971 merged) — `createSharedTicker` factory dedup
- **Cycle 11 (this)** — StatusBar + drop fsm-hub's own `useNowSecondsTicker`/`.value` read

## Test plan

- [x] `pnpm run typecheck` succeeds
- [x] `pnpm --filter masc-dashboard build` succeeds (1m 44s)
- [ ] After deploy, `pnpm --filter masc-dashboard dev` + browser fsm-hub view: idle duration, staleness countdown, phase "유지", pipeline staleness color, swimlane spanEnd, transition "ago" rows, dwell-histogram bars all tick on 5 s cadence (manual)
- [ ] DevTools React/Preact Profiler 5 s recording: `FsmHub` renders only on data change, never on a wall-clock tick (manual)

## Series wrap-up

This closes the perf series (cycles 1–12).  Subsequent perf work should target the bigger structural items deferred earlier: mermaid lazy-load (576 KB chunk), fsm-hub's other 12 useEffect inventory, and snapshot prop-drilling depth.