### PR TITLE
fix(admission): inline fd-growth rate in admission rejection log (#10745)

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -84,12 +84,52 @@ let wait_ms_since enqueue_ts = int_of_float ((now_ts () -. enqueue_ts) *. 1000.0
 
 (* ── Public API ────────────────────────────────────────── *)
 
+(* #10745: track previous rejection per keeper so successive rejection
+   logs carry the fd-growth rate inline.  Issue evidence: fd count
+   3110 → 3157 → 3215 (+47 fd/min steady) over 22 rejections / 24h,
+   100% on [oas-governance_judge].  Without the rate, operators have
+   to scrub timestamps to confirm a leak vs. a transient burst.  Hash
+   keyed by [keeper_name]; protected by [rejection_history_mu]. *)
+let rejection_history : (string, float * int) Hashtbl.t = Hashtbl.create 16
+let rejection_history_mu = Eio.Mutex.create ()
+
+let format_fd_growth_hint ~keeper_name ~fd_count ~now =
+  Eio.Mutex.use_rw ~protect:true rejection_history_mu (fun () ->
+    let prev = Hashtbl.find_opt rejection_history keeper_name in
+    Hashtbl.replace rejection_history keeper_name (now, fd_count);
+    match prev with
+    | None -> ""
+    | Some (prev_ts, prev_fd) ->
+      let dt = now -. prev_ts in
+      let dfd = fd_count - prev_fd in
+      if dt <= 0.0 then ""
+      else
+        let rate_per_min = float_of_int dfd /. dt *. 60.0 in
+        let trend =
+          if dfd > 0 then "growing"
+          else if dfd < 0 then "shrinking"
+          else "steady"
+        in
+        Printf.sprintf
+          " [Δ%+d fd in %.0fs = %+.1f fd/min, %s; previous fd=%d at %.0fs ago]"
+          dfd dt rate_per_min trend prev_fd dt)
+
 let check_host_resources ~keeper_name =
   let fd_count = Prometheus.approximate_open_fd_count () in
   let threshold = Prometheus.fd_warn_threshold in
   if fd_count >= threshold * 9 / 10 then begin
+    (* #10745: include fd-growth rate inline so the leak signal does
+       not require log scrubbing.  Monotonic positive trend across
+       successive rejections of the same keeper points at fd leak
+       (see issue #10745 root-cause discussion: subprocess close miss,
+       sandbox docker exec residue, WS standalone handler write-after-
+       close).  The hint is empty on the first rejection and on
+       reset (clock skew). *)
+    let now = now_ts () in
+    let hint = format_fd_growth_hint ~keeper_name ~fd_count ~now in
     let msg =
-      Printf.sprintf "fd count %d >= 90%% of threshold %d" fd_count threshold
+      Printf.sprintf "fd count %d >= 90%% of threshold %d%s"
+        fd_count threshold hint
     in
     Log.Misc.warn "admission rejected for %s: %s" keeper_name msg;
     Error (`Host_resource_saturated msg)


### PR DESCRIPTION
## 배경

#10745 — `oas-governance_judge` admission queue 가 fd 임계 (90% of 3000 = 2700) 도달로 22 rejections / 24h. fd count monotonic 증가 (3110 → 3157 → 3215, +47 fd/min). 기존 WARN 메시지:

```
admission rejected for oas-governance_judge: fd count 3110 >= 90% of threshold 3000
```

→ 단일 timestamp 만 — 누수 vs transient burst 구별 위해 operator 가 timestamp scrubbing 필요.

## 변경

`format_fd_growth_hint` helper 추가 + `check_host_resources` 에서 호출. 이전 rejection (timestamp, fd_count) 추적 → 다음 rejection 시 inline delta:

```
admission rejected for oas-governance_judge: fd count 3157 >= 90% of threshold 3000
[Δ+47 fd in 60s = +47.0 fd/min, growing; previous fd=3110 at 60s ago]
```

| 시나리오 | suffix |
|---|---|
| 첫 rejection (no previous) | `""` (변경 없음) |
| 누수 (monotonic up) | `[Δ+N fd in Ts = +R fd/min, growing; previous fd=N at Ts ago]` |
| 회복 (fd dropped) | `[Δ-N fd in Ts = -R fd/min, shrinking; ...]` |
| 평형 (steady) | `[Δ+0 fd in Ts = +0.0 fd/min, steady; ...]` |

## 의도적으로 안 한 것

| 항목 | 사유 |
|---|---|
| Threshold raise | 누수 면역 X, 시간 지연만 (이슈 본문 verdict) |
| `lsof -p <pid>` shell-out | platform-dependent, fd 자체 사용 (race), test 어려움 — 별도 진단 script |
| Per-keeper fd budget tracking (장기 후보) | 큰 architectural — 별도 RFC |
| WARN→ERROR 격상 | partial signal — N+ rejection 도달 escalation 은 별도 PR (#10887/#10999 패턴) |

## 검증

- `dune build --root . @check` exit 0
- diff: 1 file, +44 / -2
- Eio.Mutex.use_rw 로 race-safe (Hashtbl 동시 접근 보호)
- 호출자 코드 미변경 (returns same `Error (\`Host_resource_saturated msg)` 형태)

## 효과

operator 가 `rg "Δ+\\d+ fd.*growing"` 로 누수 즉시 감지. dashboard alert query: `count(matches{"growing"} in admission rejection logs over 1h) > 5` → fd leak alarm.

## Family precedent

같은 family (logging-tier diagnostic add):
- #10881/#10908/#10919 (severity demote)
- #10887/#10945 (universal SP ERROR)
- #10975/#10978 (tool_call_failure WARN demote)
- #10982/#10988 (cascade-fallback max_turns WARN promote)
- #10765/#10999 (fleet batch-termination ERROR — same author)

본 PR (#10745) — admission rejection 에 trend 정보 추가. 7번째 instance.