### PR TITLE
i18n(dashboard): localize 'Tool telemetry unavailable' fallback (round-88)

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -600,8 +600,8 @@ export function toolSummary(row: FleetRow): { label: string; title: string } {
     }
   }
   return {
-    label: 'Tool telemetry unavailable',
-    title: 'Tool telemetry unavailable',
+    label: '도구 telemetry 없음',
+    title: '도구 telemetry 없음',
   }
 }
 


### PR DESCRIPTION
## Summary

`fleet-telemetry-utils.ts:596-600` 의 `tool_activity_known` 분기는 한국어 (`'최근 도구 기록 없음'`) 인데 바로 다음 fallback 분기 (line 602-604) 는 영어 (`'Tool telemetry unavailable'`). 같은 함수 안 일관성 맞춤.

## Change

- label: `'Tool telemetry unavailable'` → `'도구 telemetry 없음'`
- title: `'Tool telemetry unavailable'` → `'도구 telemetry 없음'`

도메인 용어 `telemetry` 보존.

## Scope

- 1 파일, 2줄.
- `rg 'Tool telemetry unavailable'` 결과: dashboard/src/ 외 0 hits — test 영향 없음.
