### PR TITLE
fix(build): drop 4 redundant catch-all arms after DashScope sweep

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1258,4 +1258,3 @@ let non_http_transport_of_provider
                         }))))
   | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
       Ok None
-  | _ -> Ok None

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -251,7 +251,6 @@ let adapter_canonical_name_of_provider_kind
   | Glm -> cn_glm
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
-  | _ -> cn_codex_api
 
 (** Single source of truth for all provider/runtime adapters.
     Simple names ([claude], [codex], [gemini]) are CLI runtimes.
@@ -1419,8 +1418,6 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   | Glm
   | OpenAI_compat ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
-  | _ ->
-      resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
 
 let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
   match adapter_of_provider_config cfg with
@@ -1552,8 +1549,7 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.DashScope
   | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli
-  | _ ->
+  | Llm_provider.Provider_config.Codex_cli ->
       auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -44,7 +44,6 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
     | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities
     | Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
-    | _ -> Llm_provider.Capabilities.openai_chat_capabilities
   in
   let caps =
     match provider_cfg.kind with


### PR DESCRIPTION
## Summary

main이 \`Error (warning 11 [redundant-case])\`로 빨간 상태. DashScope sweep PR #10825/#10833 시리즈가 \`provider_kind\` 모든 variant를 명시적으로 enumerate한 후, 옛 fallback \`| _ -> ...\` arm이 unreachable dead code로 남았음. \`warn-error +8\`이 이를 build error로 승격.

## Sites

| File:Line | Context | Removed |
|-----------|---------|---------|
| \`provider_adapter.ml:254\` | adapter name mapping | \`\| _ -> cn_codex_api\` |
| \`provider_adapter.ml:1422\` | \`adapter_of_provider_config\` | \`\| _ -> resolve_adapter_by_cascade_prefix ...\` |
| \`provider_adapter.ml:1556\` | \`docker_auth_env_keys_of_provider_config\` | \`\| _ -> auth_env_keys_of_provider_kind cfg.kind\` |
| \`provider_tool_support.ml:47\` | provider capabilities | \`\| _ -> openai_chat_capabilities\` |
| \`oas_worker_exec_transport.ml:1261\` | transport fallback | \`\| _ -> Ok None\` |

## Behavior preservation

각 catch-all은 이미 enumerated arm 중 하나와 동일한 값을 반환하던 fallback. 제거해도 동작 변경 없음.

## 부작용 (의도된)

향후 \`provider_kind\`에 새 variant가 추가되면 이 5 사이트가 **컴파일 에러**로 즉시 발화 — silent fallthrough 대신 **explicit handling**을 강제. 메모리 룰 \"Variant addition partial-match cascade\" 정확한 케이스 대비.

## Test plan

- [x] \`dune build --root . @check\` green
- [x] \`dune build --root . lib/\` green

Refs #10426