### PR TITLE
fix(build): drop 4 redundant wildcards in provider_kind matches (queue unblocker)

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1258,4 +1258,3 @@ let non_http_transport_of_provider
                         }))))
   | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
       Ok None
-  | _ -> Ok None

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -251,7 +251,6 @@ let adapter_canonical_name_of_provider_kind
   | Glm -> cn_glm
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
-  | _ -> cn_codex_api
 
 (** Single source of truth for all provider/runtime adapters.
     Simple names ([claude], [codex], [gemini]) are CLI runtimes.
@@ -1419,8 +1418,6 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   | Glm
   | OpenAI_compat ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
-  | _ ->
-      resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
 
 let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
   match adapter_of_provider_config cfg with
@@ -1552,8 +1549,7 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.DashScope
   | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli
-  | _ ->
+  | Llm_provider.Provider_config.Codex_cli ->
       auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -38,13 +38,12 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     | Kimi -> Llm_provider.Capabilities.kimi_capabilities
     | Glm -> Llm_provider.Capabilities.glm_capabilities
     | Gemini -> Llm_provider.Capabilities.gemini_capabilities
-    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
     | OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
     | Claude_code -> Llm_provider.Capabilities.claude_code_capabilities
     | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
     | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities
     | Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
-    | _ -> Llm_provider.Capabilities.openai_chat_capabilities
+    | DashScope -> Llm_provider.Capabilities.dashscope_capabilities
   in
   let caps =
     match provider_cfg.kind with


### PR DESCRIPTION
Queue-unblocker fix-forward. Since #10992 every PR's CI Build/Lint has been red with:

\`\`\`
File "lib/provider_adapter.ml", line 254: Error (warning 11 [redundant-case])
File "lib/provider_adapter.ml", line 1422: Error (warning 11 [redundant-case])
File "lib/provider_adapter.ml", line 1556: Error (warning 12 [redundant-subpat])
File "lib/provider_tool_support.ml", line 47: Error (warning 11 [redundant-case])
\`\`\`

The 11-variant \`Llm_provider.Provider_kind.t\` now exhaustively covers every match arm without a fallthrough wildcard.  Drop the 4 dead wildcards.

This is the same anti-pattern called out in memory \`feedback_variant-add-partial-match-cascade\`: when a variant lifts from "added under a wildcard" to "explicit arm", the wildcard becomes redundant and the compiler will complain on the next CI run.

Bonus: removing the wildcards makes the next \`Provider_kind\` variant addition trigger a \`partial-match\` warning instead of silently dispatching to whichever generic handler the wildcard pointed to.

## Verification

- [x] \`dune build --root . lib\` clean (was red on origin/main).
- All 4 redundant cases removed; no behavioural change.

This PR is **Ready (not Draft)** — same cadence as #10905 (List.hd ratchet fix-forward) since it unblocks the entire PR queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)