### PR TITLE
feat(dashboard): extend SPEC §3 color alias bridge (CS87)

### DIFF
--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -285,6 +285,8 @@
      migrated per-screen in Stage 2+ PRs. */
   --color-bg-page: var(--bg-root);
   --color-bg-surface: var(--bg-panel);
+  --color-bg-panel-alt: var(--bg-panel);
+  --color-bg-elevated: var(--bg-panel-hover);
   --color-bg-hover: var(--bg-panel-hover);
 
   --color-fg-primary: var(--text-body);
@@ -297,8 +299,16 @@
   --color-border-divider: var(--border-subtle);
 
   --color-accent-fg: var(--accent);
+  --color-accent-fg-dim: var(--accent-30);
+  --color-accent-soft: var(--accent-soft);
+  --color-accent-glow: var(--accent);
 
   --color-status-ok: var(--ok);
   --color-status-warn: var(--warn);
   --color-status-err: var(--bad);
+  --color-status-info: var(--accent);
+  --color-status-idle: var(--text-muted);
+  --color-status-stalled: var(--purple);
+
+  --color-focus-ring: var(--accent);
 }


### PR DESCRIPTION
## Summary

Phase G Step 1 of token convergence: 9 canonical SPEC §3 token aliases added to `variables.css`. Pure additive — no color values change, no component swaps.

## What

Existing alias bridge in `variables.css` (line 282-303) covered 12 canonical names. This PR extends it with the 9 still-missing tokens from `dashboard/design-system/SPEC.md`:

| Added | Maps to |
|------|---------|
| `--color-bg-panel-alt` | `var(--bg-panel)` |
| `--color-bg-elevated` | `var(--bg-panel-hover)` |
| `--color-accent-fg-dim` | `var(--accent-30)` |
| `--color-accent-soft` | `var(--accent-soft)` |
| `--color-accent-glow` | `var(--accent)` |
| `--color-status-info` | `var(--accent)` |
| `--color-status-idle` | `var(--text-muted)` |
| `--color-status-stalled` | `var(--purple)` |
| `--color-focus-ring` | `var(--accent)` |

## Why

CS75~CS83 component swaps started using canonical token names (`--color-fg-secondary`, `--color-status-ok`, etc.) that were already aliased. The remaining ones were not aliased, so any new component using them would silently fall back to undefined.

`prometheus-metrics.ts` already references `--color-bg-panel-alt` at 2 sites (line 304, 359) — currently undefined → no background paints. This PR makes them paint.

## Out of scope

- `--color-fg-primary` / `--color-fg-secondary` SPEC-inversion (currently primary→text-body, SPEC says primary→text-strong; 474 callsites). Deferred to a separate visual-diff-reviewed PR.
- `paper-theme.css` parity for the new aliases (paper theme uses its own `--color-text-*` namespace).
- New `--type-*` / `--fs-*` / `--space-*` tokens (Phase G Step 2 — separate PR CS88).

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test --run` → 245 files / 4111 tests pass
- [x] Diff is purely additive (10 lines, no edits)