### PR TITLE
i18n(dashboard): localize 2 short matrix tooltip titles (round-89)

### DIFF
--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -315,7 +315,7 @@ function MatrixColumnTotalsRow({ matrix }: { matrix: MatrixData }) {
     `)}
     <div
       class=${`flex items-center justify-end gap-1 px-1 py-1 text-3xs tabular-nums ${totalBound > 0 ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-fg-disabled)]'}`}
-      title=${`Grand total: ${totalBound} bound cells across all keepers × connectors`}
+      title=${`전체 합계: 모든 keeper × connector 의 bound cell ${totalBound}개`}
       data-matrix-grand-total
       data-matrix-grand-total-bound=${totalBound}
     >

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -895,7 +895,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                     <span
                       data-invariant=${k}
                       class="rounded border px-2 py-0.5 text-xs ${tone}"
-                      title=${`Violating keepers: ${count}`}
+                      title=${`위반 keeper: ${count}`}
                     >
                       ${INVARIANT_LABELS[k]}: ${count}
                     </span>


### PR DESCRIPTION
## Summary

Matrix grid 위에 마우스 호버 시 표시되는 짧은 tooltip 2개를 한국어화. 두 곳 모두 single-line, anchor 없음.

## Change

| 파일 | line | Before | After |
|---|---|---|---|
| `connector-keeper-matrix.ts` | 318 | `Grand total: ${N} bound cells across all keepers × connectors` | `전체 합계: 모든 keeper × connector 의 bound cell ${N}개` |
| `fleet-fsm-matrix.ts` | 898 | `Violating keepers: ${count}` | `위반 keeper: ${count}` |

## Domain term policy

`keeper`, `connector`, `bound cell` 보존 (도메인 용어).

## Scope

- 2 파일, 2줄.
- test 영향 0:
  - `connector-keeper-matrix.test.ts:180` 에 `// Grand total chip = 3 bound.` 코드 코멘트만 있음. test assertion 0건.
- 시각적 hover tooltip 만 변경.
