### PR TITLE
refactor(server-bootstrap): demote 5 recoverable cleanup Errors → Warn (§ 3.3 audit)

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1051,7 +1051,7 @@ let warm_tool_registry_from_telemetry (state : Mcp_server.server_state) =
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
-     Log.Misc.error "tool registry warm-up failed: %s"
+     Log.Misc.warn "tool registry warm-up failed: %s (lazy init on first call)"
        (Printexc.to_string exn))
 
 let restore_tool_metrics_from_disk (state : Mcp_server.server_state) =
@@ -1063,7 +1063,7 @@ let restore_tool_metrics_from_disk (state : Mcp_server.server_state) =
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
-     Log.Misc.error "tool metrics restore failed: %s"
+     Log.Misc.warn "tool metrics restore failed: %s (metrics empty until next emission)"
        (Printexc.to_string exn))
 
 let startup_prune_jsonl (state : Mcp_server.server_state) =
@@ -1103,7 +1103,7 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
          total days
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn -> Log.Misc.error "startup prune failed: %s" (Printexc.to_string exn))
+   | exn -> Log.Misc.warn "startup prune failed: %s (next boot retries; disk impact bounded by retention)" (Printexc.to_string exn))
 
 let startup_prune_keeper_checkpoints (state : Mcp_server.server_state) =
   (try
@@ -1140,7 +1140,7 @@ let startup_prune_keeper_checkpoints (state : Mcp_server.server_state) =
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
-     Log.Misc.error "startup checkpoint prune failed: %s"
+     Log.Misc.warn "startup checkpoint prune failed: %s (next boot retries)"
        (Printexc.to_string exn))
 
 let startup_migrate_keeper_histories (state : Mcp_server.server_state) =
@@ -1183,7 +1183,7 @@ let startup_migrate_keeper_histories (state : Mcp_server.server_state) =
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
-       Log.Misc.error "startup history migration failed: %s"
+       Log.Misc.warn "startup history migration failed: %s (next boot retries; legacy format readable)"
          (Printexc.to_string exn))
 
 (* bootstrap_keepers removed: the keeper_autoboot subsystem in


### PR DESCRIPTION
## Why

Phase 2 of the migration plan in `docs/spec/18-log-severity-taxonomy.md` (#10963) — first hotspot file (`lib/server/server_runtime_bootstrap.ml`, 104 Log call sites).

Audit goal: reclassify everything per § 2-3 of the taxonomy. Plan started at 33 candidates from an Explore inventory. Manual verification reduced to **5 confirmed demotions**. The other 28 candidates were either correctly classified, borderline, or over-flagged.

## Honest audit log (Plan vs Reality)

| Bucket | Plan (Explore inventory) | Verified | Outcome |
|--------|--------------------------|----------|---------|
| § 3.1 silent fallback W→E | 10 sites | **0** | All 10 candidates have explicit operator messages (\"Ignoring...\", \"refusing...\", \"continuing with env defaults\"). § 3.1 targets messages that self-describe as silent (\"logging-only mode\", \"silent:\" prefix). The candidates are deprecation/skip warnings, correctly Warn. |
| § 3.3 recoverable E→W | 16 sites | **5** | 11 of the 16 are auth/token failures (`token persist`, `token mint`, `Codex MCP config sync`). When auth bootstrapping fails the agent has no valid bearer → MCP calls fail → keeper effectively broken. Real Error, KEEP. The other 5 (this PR) are cleanup paths that retry on next boot. |
| § 3.4/3.5 noise I→D | 13 sites | **0** | The candidates are one-shot lifecycle events (boot prune, lazy task start/finish per task), not periodic ticks. § 2 Info marker excludes \"periodic tick\", but a per-task one-shot is bounded by event count and belongs at Info as a boot audit trail. |

The audit was honest — Phase 2 PRs should not promise headline reclassification numbers from a sub-agent inventory without manual verification. **Verification reduced 33 → 5.**

## What

Demote 5 `Log.Misc.error` calls in `server_runtime_bootstrap.ml`:

| Line | Task | Recovery |
|------|------|----------|
| 1054 | tool registry warm-up | lazy init on first call |
| 1066 | tool metrics restore | metrics empty until next emission |
| 1106 | startup JSONL prune | next boot retries; disk impact bounded by retention |
| 1143 | startup checkpoint prune | next boot retries |
| 1186 | startup history migration | next boot retries; legacy format readable |

Each demoted message now also describes the recovery inline so the operator can confirm system health from the log line alone.

## Behaviour

- 5 lines changed (severity function swap + recovery hint suffix)
- No code path change
- No type / interface change
- Build: `dune build @check` green

## Lint baseline impact

`scripts/ci/check-log-severity-anti-patterns.sh` baselines: **no change**. The 5 demoted sites match no current rule (L1a/L1b/L2/L4/L5 are narrower regex). The cleanup is taxonomy-driven, not lint-driven — and that's the point: lint catches drift, audit reduces inflation.

## Follow-up

Remaining Phase 2 hotspots (top-5 file plan, § 6 of taxonomy):
- `lib/keeper/keeper_keepalive.ml` (69 sites) — production noise, periodic tick suspect
- `lib/keeper/keeper_unified_turn.ml` (57 sites)
- `lib/server/server_bootstrap_loops.ml` (49 sites)
- `lib/keeper/keeper_agent_run.ml` (40 sites)

Each will follow the same **verify-first** discipline: Explore inventory → manual spot-check → conservative apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)