### PR TITLE
feat(dashboard): a11y agent-detail — role=log/region/progressbar (round-6 split 1/N)

### DIFF
--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -16,7 +16,7 @@ export function AgentJournalStream({ agentName }: { agentName: string }) {
       ${entries.length === 0
         ? html`<${EmptyState} message="아직 활동 기록이 없습니다" compact />`
         : html`
-            <div class="flex flex-col gap-0.5 max-h-70 overflow-y-auto">
+            <div role="log" aria-label="에이전트 활동 로그" class="flex flex-col gap-0.5 max-h-70 overflow-y-auto">
               ${entries.map((entry: JournalEntry, idx: number) => html`
                 <div class="agent-journal-entry flex items-baseline gap-1.5 py-1 px-2 text-sm transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
                   <span class="agent-journal-kind">${journalKindIcon(entry)}</span>

--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -142,6 +142,10 @@ export function AgentDetailMemory({ agentName }: Props) {
                                     <span class="font-mono flex-1 truncate">${normalizeKeeperName(s.to_agent)}</span>
                                     <div class="w-16 bg-[var(--white-5)] rounded h-1.5">
                                       <div
+                                        role="progressbar"
+                                        aria-valuenow=${Math.round(s.weight * 100)}
+                                        aria-valuemin=${0}
+                                        aria-valuemax=${100}
                                         class="${s.weight >= 0.7 ? 'bg-[var(--ok-10)]' : s.weight >= 0.4 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'} rounded h-1.5"
                                         style="width:${Math.round(s.weight * 100)}%"
                                       ></div>
@@ -167,6 +171,10 @@ export function AgentDetailMemory({ agentName }: Props) {
                                     <span class="font-mono flex-1 truncate">${normalizeKeeperName(s.from_agent)}</span>
                                     <div class="w-16 bg-[var(--white-5)] rounded h-1.5">
                                       <div
+                                        role="progressbar"
+                                        aria-valuenow=${Math.round(s.weight * 100)}
+                                        aria-valuemin=${0}
+                                        aria-valuemax=${100}
                                         class="${s.weight >= 0.7 ? 'bg-[var(--ok-10)]' : s.weight >= 0.4 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'} rounded h-1.5"
                                         style="width:${Math.round(s.weight * 100)}%"
                                       ></div>
@@ -217,7 +225,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                     필터 결과 없음 (${episodes.length}개 중 0)
                   </div>`
                 : html`
-                  <div class="space-y-1.5 max-h-60 overflow-y-auto pr-1 custom-scrollbar">
+                  <div role="log" aria-label="에피소드 목록" class="space-y-1.5 max-h-60 overflow-y-auto pr-1 custom-scrollbar">
                     ${visibleEpisodes
                       .slice()
                       .reverse()

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -182,7 +182,7 @@ export function AgentTimelineSection() {
             ${filtered.length === 0
               ? html`<${EmptyState} message="조건에 맞는 이벤트가 없습니다" compact />`
               : html`
-                  <div class="flex flex-col gap-0.5 max-h-100 overflow-y-auto">
+                  <div role="log" aria-label="활동 타임라인" class="flex flex-col gap-0.5 max-h-100 overflow-y-auto">
                     ${filtered.map((evt: AgentTimelineEvent, idx: number) => {
                       if (evt.type === 'tool_call') {
                         return html`<${ToolCallEventRow} evt=${evt} idx=${idx} />`

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -361,7 +361,7 @@ export function AgentDetailOverlay() {
           <${Card} title="최근 활동">
             ${lines.length === 0
               ? html`<div class="h-full min-h-30"><${EmptyState} message="최근 활동 메시지가 없습니다" compact /></div>`
-              : html`<div class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-xs text-text-body leading-relaxed rounded shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
+              : html`<div role="log" aria-label="최근 활동 로그" class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-xs text-text-body leading-relaxed rounded shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
           <//>
         </div>
 
@@ -371,7 +371,7 @@ export function AgentDetailOverlay() {
           <${AgentDetailMemory} agentName=${agentName} />
           <${AgentWorkerBrief} agentName=${agentName} />
           ${agentFitness.value ? html`
-            <${Card} title="적합도 (7일)">
+            <${Card} title="적합도 (7일)" role="region" ariaLabel="에이전트 적합도">
               <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
                 ${[
                   ['완료율', agentFitness.value.completion_rate],


### PR DESCRIPTION
## Why

First slice of the **a11y round-6 split** that closed PR #10871 (168 files / 100 commits across 20+ component areas, hit `CONFLICTING / DIRTY` after 8h of `main` activity). The work itself stays valuable — its 100 commits already carry per-area scope tags, so we cherry-pick area by area into small PRs that rebase cleanly.

This PR is the agent-detail slice (4 files, +13 -5).

## What

ARIA attribute additions only — zero behavior change.

| File | Add |
|------|-----|
| `agent-detail-journal.ts` | `role="log"` + `aria-label="에이전트 활동 로그"` on the activity stream wrapper |
| `agent-detail-timeline.ts` | `role="log"` + `aria-label="활동 타임라인"` on the event timeline wrapper |
| `agent-detail.ts` | `role="log"` + `aria-label="최근 활동 로그"` on recent-activity stream; `role="region"` + `ariaLabel="에이전트 적합도"` on the fitness card |
| `agent-detail-memory.ts` | `role="progressbar"` + `aria-valuenow` / `aria-valuemin` / `aria-valuemax` on synapse-weight bars (outgoing + incoming) |

These give screen reader users a way to land directly on the event streams (`role="log"`), discover the fitness card as a labeled landmark (`role="region"`), and hear the synapse weights as numeric values rather than empty `<div>`s (`role="progressbar"`).

## Cherry-pick provenance

`5ca3d96950` from branch `dashboard/a11y-006` (PR #10871, now closed). One conflict during pickup:

- `agent-detail-memory.ts` line ~93 (the loading error div). `main` had **already** added `role="alert"` *and* migrated `--warn` → `--color-status-warn` (newer than the source branch). HEAD kept — original commit's contribution at that location is redundant. The progressbar additions further down (lines 142-178) are net-new and are the real value of this cherry-pick.

## What this PR does NOT do

- The other ~99 commits from PR #10871 (auth-status, handoff-timeline, connector, governance, keeper-detail, verification, etc.) — separate per-area PRs to follow over upcoming cycles.
- No structural / functional changes. No new components. No styling tweaks. ARIA only.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean.
- [ ] No new vitest cases — adding ARIA attributes does not warrant a test in this codebase's existing convention. The components already have rendering tests; ARIA presence can be added in a follow-up if regressions ever occur.
- [ ] Manual SR check (NVDA / VoiceOver): activity stream announces as "log", fitness card as "region", synapse bars as "progressbar 73%". Queued.

## Refs

- Closed: #10871 (a11y round-6 — too-big-to-rebase parent)
- Source commit: `5ca3d96950 a11y: add ARIA attributes to agent-detail components`
- Source branch (preserved): `dashboard/a11y-006`
- Memory pattern: `feedback_audit-bucket-cascade-pattern.md` (한 영역 = 한 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
