### PR TITLE
refactor: Jane Street Phase 6 (Monadic Error Handling & ppx_let)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -48,6 +48,7 @@
   (domain-name (>= 0.4))
   (ca-certs (>= 0.2))
   (ppx_deriving_yojson (>= 3.6))
+  (ppx_let (>= v0.17.0))
   (ppx_deriving (>= 5.2))
   (sqlite3 (>= 5.1))
   (mirage-crypto (>= 1.0))

--- a/lib/dune
+++ b/lib/dune
@@ -947,7 +947,7 @@
    ambient-context
    ambient-context-eio
    )
- (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq))
+ (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_let))
  (instrumentation (backend bisect_ppx)))
  
 ; Core library for MASC MCP

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -84,15 +84,7 @@ let agent_status_of_string_r s : (agent_status, string) result =
   | Some status -> Ok status
   | None -> Error (Printf.sprintf "unknown agent_status: %S" s)
 
-[@@@ocaml.warning "-3"]
-let agent_status_of_string s =
-  (* #10748: legacy "permissive default" — kept for source compatibility.
-     New code should call {!agent_status_of_string_r} (Result-based) or
-     {!agent_status_of_string_opt}. *)
-  match agent_status_of_string_opt s with
-  | Some status -> status
-  | None -> Active
-[@@ocaml.warning "-3"]
+
 
 (* Custom yojson converters for lowercase JSON compatibility *)
 let agent_status_to_yojson status = `String (agent_status_to_string status)

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -32,6 +32,7 @@ depends: [
   "domain-name" {>= "0.4"}
   "ca-certs" {>= "0.2"}
   "ppx_deriving_yojson" {>= "3.6"}
+  "ppx_let" {>= "v0.17.0"}
   "ppx_deriving" {>= "5.2"}
   "sqlite3" {>= "5.1"}
   "mirage-crypto" {>= "1.0"}

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -199,19 +199,6 @@ let test_agent_status_of_string_opt_unknown () =
   | Some _ -> fail "expected None"
 
 (* ============================================================
-   agent_status_of_string Tests
-   ============================================================ *)
-
-let test_agent_status_of_string_active () =
-  let s = Types.agent_status_of_string "active" in
-  check bool "is Active" true (s = Types.Active)
-
-let test_agent_status_of_string_unknown_defaults () =
-  (* Unknown strings default to Active *)
-  let s = Types.agent_status_of_string "invalid" in
-  check bool "defaults to Active" true (s = Types.Active)
-
-(* ============================================================
    agent_status_to_yojson Tests
    ============================================================ *)
 
@@ -1563,10 +1550,6 @@ let () =
       test_case "listening" `Quick test_agent_status_of_string_opt_listening;
       test_case "inactive" `Quick test_agent_status_of_string_opt_inactive;
       test_case "unknown" `Quick test_agent_status_of_string_opt_unknown;
-    ];
-    "agent_status_of_string", [
-      test_case "active" `Quick test_agent_status_of_string_active;
-      test_case "unknown defaults" `Quick test_agent_status_of_string_unknown_defaults;
     ];
     "agent_status_to_yojson", [
       test_case "active" `Quick test_agent_status_to_yojson_active;

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -125,13 +125,6 @@ let test_agent_status_to_string () =
   check string "Listening" "listening" (Types.agent_status_to_string Types.Listening);
   check string "Inactive" "inactive" (Types.agent_status_to_string Types.Inactive)
 
-let test_agent_status_of_string () =
-  check bool "active" true (Types.agent_status_of_string "active" = Types.Active);
-  check bool "busy" true (Types.agent_status_of_string "busy" = Types.Busy);
-  check bool "listening" true (Types.agent_status_of_string "listening" = Types.Listening);
-  check bool "inactive" true (Types.agent_status_of_string "inactive" = Types.Inactive);
-  check bool "unknown defaults to Active" true (Types.agent_status_of_string "unknown" = Types.Active)
-
 let test_agent_status_of_string_opt () =
   check bool "active Some" true (Types.agent_status_of_string_opt "active" = Some Types.Active);
   check bool "unknown None" true (Types.agent_status_of_string_opt "unknown" = None)
@@ -887,7 +880,6 @@ let timestamp_tests = [
 
 let agent_status_tests = [
   "to_string all", `Quick, test_agent_status_to_string;
-  "of_string all", `Quick, test_agent_status_of_string;
   "of_string_opt", `Quick, test_agent_status_of_string_opt;
   "of_string_r (#10748)", `Quick, test_agent_status_of_string_r;
   "to_yojson", `Quick, test_agent_status_to_yojson;


### PR DESCRIPTION
Phase 6 of Jane Street refactoring:
- Removed legacy permissive fallback from `agent_status_of_string`
- Added `ppx_let` for monadic let%bind syntax support across the codebase