### PR TITLE
feat(dashboard): a11y auth-status — aria-expanded/haspopup + alert + label (round-6 split 2/N)

### DIFF
--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -145,6 +145,8 @@ export function AuthStatus() {
     <div class="relative">
       <button type="button"
         class="flex items-center gap-1.5 text-2xs py-1 px-2 rounded border border-solid border-[var(--color-border-default)] bg-[var(--white-4)] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[var(--white-8)] text-[var(--color-fg-muted)]"
+        aria-expanded=${popoverOpen.value}
+        aria-haspopup="true"
         onClick=${() => { popoverOpen.value ? (popoverOpen.value = false) : openPopover() }}
         title="인증 상태"
         aria-label="인증 상태"
@@ -255,11 +257,12 @@ export function RemoteWarningBanner() {
         : '원격 접속이 감지되었습니다. Mutation 작업을 위해 검증된 Bearer token을 설정하세요.'
 
   return html`
-    <div class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[var(--warn-10)] border-b border-[var(--warn-20)] text-xs text-[var(--color-status-warn)]">
+    <div role="alert" class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[var(--warn-10)] border-b border-[var(--warn-20)] text-xs text-[var(--color-status-warn)]">
       <span>${message}</span>
       <div class="flex items-center gap-2 shrink-0">
         <button type="button"
           class="px-2 py-0.5 rounded text-2xs border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
+          aria-label="인증 패널 열기"
           onClick=${openPopover}
         >인증 열기</button>
         <button type="button"


### PR DESCRIPTION
## Why

Second slice of the **a11y round-6 split** (followed #11017 agent-detail; closed parent: #10871). Auth-status component had no ARIA hooks — popover trigger lacked expanded-state, the remote-access banner lacked alert role, and the inline buttons lacked accessible labels.

This PR is the auth-status slice (1 file, +4 −1).

## What

ARIA attribute additions only — zero behavior change.

| Surface | Add |
|---------|-----|
| Popover trigger button | `aria-expanded={popoverOpen.value}` + `aria-haspopup="true"` so SR users learn the button opens a popover and whether it's currently expanded |
| `RemoteWarningBanner` wrapper | `role="alert"` so the banner is announced when it appears |
| "인증 열기" button | `aria-label="인증 패널 열기"` (button text "인증 열기" is short; the longer label clarifies the action) |

## Cherry-pick provenance

`4575ca6f66` from `dashboard/a11y-006`. Conflicts at 4 hunks — every one was the same shape: **`main` had migrated tokens** (`--card-border` → `--color-border-default`, `--text-muted` → `--color-fg-muted`, `--warn` → `--color-status-warn`, `--accent` → `--color-accent-fg`) **and added some ARIA labels** (`aria-label="인증 상태"` on popover trigger, `aria-label="인증 배너 닫기"` on dismiss button) — while the source commit was pre-migration and added a different set of ARIA hooks.

Resolution rule used: **HEAD's tokens + incoming's net-new ARIA**. Specifically:
- The dismiss `×` button's `aria-label="경고 닫기"` from the source commit was **dropped** — `main` already has the more specific `aria-label="인증 배너 닫기"`.
- All four `class=` lines kept HEAD's modern tokens; the new attributes (`aria-expanded`, `aria-haspopup`, `role="alert"`, `aria-label="인증 패널 열기"`) were merged in next to them.

## What this PR does NOT do

- Other ~98 commits from PR #10871 — separate per-area PRs to follow.
- No structural or styling change. ARIA only.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [ ] No new vitest cases. Existing auth-status tests cover render behavior; ARIA-attribute coverage can be a follow-up if regressions ever occur.
- [ ] Manual SR check: collapsed popover button announces "Authentication status, collapsed, has popup". Banner announces as alert when it appears. Queued.

## Refs

- Predecessor split: #11017 (agent-detail 1/N)
- Closed parent: #10871 (a11y round-6 — too-big-to-rebase)
- Source commit: `4575ca6f66 a11y: add ARIA attributes to auth-status component`
- Source branch (preserved): `dashboard/a11y-006`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
