### PR TITLE
fix(session): bound registry + mcp-store mailboxes (was max_int) — #10777 root-cause class

### DIFF
--- a/lib/session.ml
+++ b/lib/session.ml
@@ -45,9 +45,15 @@ type registry_state = {
   rate_trackers: rate_tracker AgentMap.t;
 }
 
+(* Bound: 10x the per-session [max_notification_queue] (1000), sized to
+   absorb a keeper-fleet boot burst (16 keepers × ~30 messages each =
+   ~500) with 20x headroom. Unbounded ([max_int]) caused #10777-class
+   heap exhaustion when the consumer fiber stalled. *)
+let max_registry_mailbox = 10_000
+
 let create ?(config = default_rate_limit) () = {
   config;
-  mailbox = Eio.Stream.create max_int;
+  mailbox = Eio.Stream.create max_registry_mailbox;
 }
 
 let create_tracker now = {
@@ -442,7 +448,13 @@ module McpSessionStore = struct
     | List_all of mcp_session list Eio.Promise.u
     | Remove of string * bool Eio.Promise.u
 
-  let mailbox = Eio.Stream.create max_int
+  (* Bound: same rationale as [max_registry_mailbox] above. McpSessionStore
+     handles 4 message types (Put/Get/Cleanup_stale/List_all/Remove); 10k
+     entries is well above any realistic concurrent HTTP request burst and
+     prevents heap exhaustion if the consumer fiber stalls. *)
+  let max_mcp_session_mailbox = 10_000
+
+  let mailbox = Eio.Stream.create max_mcp_session_mailbox
 
   let max_age = ref Env_config.Session.max_age_seconds
 


### PR DESCRIPTION
## Why

`Session.create` (lib/session.ml:50) and `Session.McpSessionStore` (lib/session.ml:445) both allocate their inbound mailboxes with `Eio.Stream.create max_int`. Under back-pressure (consumer fiber stalled, slow `process_msg`, lock contention), producers enqueue without limit and exhaust the heap.

This is the root-cause **class** behind the production fire chain:

- **#10777**: `Session.start_loop` never called → `restore_sessions` enqueued forever, blocking keeper autoboot for ~3 min per restart cycle
- **#10895**: same pattern in `Oas_worker_cascade`
- **#10904**: lint added to ensure starters are wired

The lint guarantees the consumer is started, but does not bound the mailbox. **An unbounded mailbox masks slowdowns by silently growing instead of pushing back**, so even with the consumer wired, a slow `process_msg` can still cascade-hang every caller via heap pressure.

## What

| Site | Before | After |
|------|--------|-------|
| `Session.create` (line 50) | `Eio.Stream.create max_int` | `Eio.Stream.create max_registry_mailbox` (10_000) |
| `McpSessionStore` (line 445) | `Eio.Stream.create max_int` | `Eio.Stream.create max_mcp_session_mailbox` (10_000) |

Bound rationale (inline comment in code):

- The existing per-session `max_notification_queue` (1000, with explicit drop policy at session.ml:134) is the SSOT for a reasonable per-stream cap.
- 10× that gives 10k slot capacity, sized to absorb a keeper-fleet boot burst (16 keepers × ~30 startup messages = ~500) with 20× headroom.
- Producer back-pressure triggers long before heap pressure becomes problematic.

## Behaviour

- **Common path**: no change (mailbox under capacity → `Eio.Stream.add` returns immediately)
- **Saturated path**: producer now blocks on `add` instead of consuming heap. The blocking propagates back through the call stack, surfacing the slow consumer as a localized hang at the production site rather than as a cascading OOM.
- No type / interface change
- No new dependency
- `dune build @check` green

## Audit context

Identified by an Actor-pattern audit covering all 7 actor modules in `lib/`. Top-3 risks ranked:

1. 🔴 Unbounded mailbox in Session (this PR)
2. 🔴 Request-reply Promise.await without timeout (follow-up)
3. 🟡 Cancellation guard absent in 4 of 7 actor loops (follow-up)

## Follow-ups (separate PRs)

- Add `Eio.Time.with_timeout` around `Promise.await` for `Session.{register, push_message, check_rate_limit_ex, get_session}` — completes the back-pressure story by bounding caller wait
- Cancellation guard sweep in 4 missing actor loops (Session.start_loop, McpSessionStore.start_loop, Oas_worker_cascade, Metrics_store_eio.start_flush_fiber)
- Lint rule: every `Eio.Stream.create N` must have `N > 0` and `N != max_int` (fills a gap in `check-actor-consumer-wired.sh`)

## Memory

- `feedback_jane-street-refactor-sweep-miss` — actor pattern introduction without sweep was the original sin; #10777 / #10895 / this PR are progressively deeper layers of the same lesson

🤖 Generated with [Claude Code](https://claude.com/claude-code)