### PR TITLE
feat(dashboard): adopt canonical SPEC tokens in cascade-config-panel (CS89)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -316,7 +316,7 @@ function KeeperChip({ row }: { row: KeeperCascadeRow }) {
   const base = 'rounded border px-2 py-0.5 text-xs flex items-center gap-1'
   const borderTone = row.drift
     ? 'border-[var(--warn)] text-[var(--text-strong)]'
-    : 'border-[var(--card-border)] text-[var(--text-strong)]'
+    : 'border-[var(--color-border-default)] text-[var(--text-strong)]'
   return html`
     <span
       class=${`${base} ${borderTone}`}
@@ -326,7 +326,7 @@ function KeeperChip({ row }: { row: KeeperCascadeRow }) {
     >
       <span class="font-semibold">${row.keeper}</span>
       ${row.drift
-        ? html`<code class="text-3xs text-[var(--text-muted)]">${row.raw_cascade_name}</code>`
+        ? html`<code class="text-3xs text-[var(--color-fg-muted)]">${row.raw_cascade_name}</code>`
         : null}
     </span>
   `
@@ -371,7 +371,7 @@ function ProfileCard({
   }
 
   return html`
-    <article class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] p-3">
+    <article class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] p-3">
       <header class="flex items-center gap-2 mb-2 flex-wrap">
         <span class="font-semibold text-[var(--text-strong)]">${profile.name}</span>
         <${StatusChip} tone=${sourceTone(profile.source)}>
@@ -380,7 +380,7 @@ function ProfileCard({
         ${!profile.keeper_assignable
           ? html`<${StatusChip} tone="neutral" uppercase=${false}>manual/system-only<//>`
           : null}
-        <span class="text-xs text-[var(--text-muted)]">
+        <span class="text-xs text-[var(--color-fg-muted)]">
           ${profileSummaryText(profile, keepers)}
         </span>
         ${driftCount > 0
@@ -388,7 +388,7 @@ function ProfileCard({
           : null}
       </header>
       ${assignmentNote
-        ? html`<div class="text-xs text-[var(--text-muted)] mb-2">${assignmentNote}</div>`
+        ? html`<div class="text-xs text-[var(--color-fg-muted)] mb-2">${assignmentNote}</div>`
         : null}
       ${keepers.length > 0
         ? html`
@@ -400,12 +400,12 @@ function ProfileCard({
       ${profile.keeper_assignable
         ? html`
           <form
-            class="rounded border border-[var(--card-border)] bg-[var(--bg-panel)] p-2 mb-3"
+            class="rounded border border-[var(--color-border-default)] bg-[var(--bg-panel)] p-2 mb-3"
             onSubmit=${handleAssignKeeper}
           >
             <div class="flex items-center gap-2 flex-wrap mb-2">
               <span class="text-xs font-medium text-[var(--text-strong)]">키퍼 할당</span>
-              <span class="text-xs text-[var(--text-muted)]">
+              <span class="text-xs text-[var(--color-fg-muted)]">
                 current profile로 keeper를 이동합니다.
               </span>
             </div>
@@ -414,7 +414,7 @@ function ProfileCard({
                 <div class="flex items-center gap-2 flex-wrap">
                   <select
                     aria-label="키퍼 선택"
-                    class="min-w-44 rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--text-strong)]"
+                    class="min-w-44 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-xs text-[var(--text-strong)]"
                     value=${selectedKeeper.value}
                     disabled=${assigning.value}
                     onChange=${(event: Event) => {
@@ -428,7 +428,7 @@ function ProfileCard({
                   </select>
                   <button
                     type="submit"
-                    class="rounded border border-[var(--accent-primary)] bg-[var(--accent-primary)] px-3 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
+                    class="rounded border border-[var(--color-accent-fg)] bg-[var(--color-accent-fg)] px-3 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
                     disabled=${assigning.value || selectedKeeper.value === ''}
                   >
                     ${assigning.value ? '할당 중...' : '키퍼 할당'}
@@ -436,7 +436,7 @@ function ProfileCard({
                 </div>
               `
               : html`
-                <div class="text-xs text-[var(--text-muted)]">
+                <div class="text-xs text-[var(--color-fg-muted)]">
                   currently known keepers are already assigned to this profile.
                 </div>
               `}
@@ -446,7 +446,7 @@ function ProfileCard({
                   class=${`mt-2 text-xs ${
                     assignmentMessage.value.startsWith('Failed')
                       ? 'text-[var(--bad-light)]'
-                      : 'text-[var(--text-muted)]'
+                      : 'text-[var(--color-fg-muted)]'
                   }`}
                 >
                   ${assignmentMessage.value}
@@ -457,7 +457,7 @@ function ProfileCard({
         `
         : null}
       ${profile.candidates.length === 0
-        ? html`<div class="text-xs text-[var(--text-muted)]">no candidates resolved</div>`
+        ? html`<div class="text-xs text-[var(--color-fg-muted)]">no candidates resolved</div>`
         : html`
           <ol class="flex flex-col gap-1 text-xs">
             ${profile.candidates.map((c, idx) => {
@@ -466,8 +466,8 @@ function ProfileCard({
               const displayProvider = c.display_provider_name ?? c.provider_name ?? null
               const runtimeLabel = runtimeKindLabel(c.runtime_kind)
               return html`
-              <li class="flex items-start gap-2 py-1 border-b border-[var(--card-border)] last:border-b-0">
-                <span class="tabular-nums text-[var(--text-muted)] w-5">${idx + 1}.</span>
+              <li class="flex items-start gap-2 py-1 border-b border-[var(--color-border-default)] last:border-b-0">
+                <span class="tabular-nums text-[var(--color-fg-muted)] w-5">${idx + 1}.</span>
                 <${StatusChip} tone=${candidateTone(c)}>
                   ${c.in_cooldown ? 'cooldown' : fmtPct(c.success_rate)}
                 <//>
@@ -475,18 +475,18 @@ function ProfileCard({
                   <div class="flex items-center gap-2 flex-wrap">
                     <code class="text-[var(--text-strong)]">${displayModel}</code>
                     ${displayProvider
-                      ? html`<span class="text-[var(--text-muted)]">${displayProvider}</span>`
+                      ? html`<span class="text-[var(--color-fg-muted)]">${displayProvider}</span>`
                       : null}
                     ${runtimeLabel
-                      ? html`<span class="text-[var(--text-muted)]">${runtimeLabel}</span>`
+                      ? html`<span class="text-[var(--color-fg-muted)]">${runtimeLabel}</span>`
                       : null}
                   </div>
                   ${c.model !== displayModel
-                    ? html`<div class="text-[11px] text-[var(--text-muted)] mt-0.5">config: <code>${c.model}</code></div>`
+                    ? html`<div class="text-[11px] text-[var(--color-fg-muted)] mt-0.5">config: <code>${c.model}</code></div>`
                     : null}
                   ${expanded.length > 1
                     ? html`
-                      <ol class="mt-1 flex flex-col gap-0.5 text-[11px] text-[var(--text-muted)]">
+                      <ol class="mt-1 flex flex-col gap-0.5 text-[11px] text-[var(--color-fg-muted)]">
                         ${expanded.map((model, expandedIdx) => html`
                           <li><span class="tabular-nums">${expandedIdx + 1}.</span> <code>${model}</code></li>
                         `)}
@@ -494,7 +494,7 @@ function ProfileCard({
                     `
                     : null}
                 </div>
-                <span class="tabular-nums text-[var(--text-muted)]">
+                <span class="tabular-nums text-[var(--color-fg-muted)]">
                   w ${c.config_weight}${c.effective_weight === c.config_weight ? '' : ` → ${c.effective_weight}`}
                 </span>
               </li>
@@ -512,7 +512,7 @@ function OrphanKeeperList({ orphans }: { orphans: readonly CascadeKeeperProfile[
       <div class="font-semibold text-[var(--text-strong)] mb-1">
         등록된 프로필 없음 (${orphans.length})
       </div>
-      <div class="text-[var(--text-muted)] mb-2">
+      <div class="text-[var(--color-fg-muted)] mb-2">
         아래 keeper 는 canonical cascade 가 현재 profile 목록에 없어 해당 cascade 로 라우팅할 수 없습니다.
       </div>
       <ul class="flex flex-col gap-1">
@@ -520,7 +520,7 @@ function OrphanKeeperList({ orphans }: { orphans: readonly CascadeKeeperProfile[
           <li class="flex gap-2">
             <span class="font-semibold text-[var(--text-strong)]">${o.keeper}</span>
             <code>${o.cascade_name}</code>
-            <span class="text-[var(--text-muted)]">→</span>
+            <span class="text-[var(--color-fg-muted)]">→</span>
             <code class="text-[var(--warn)]">${o.canonical}</code>
           </li>
         `)}
@@ -537,9 +537,9 @@ function InvalidProfileSummary({
   return html`
     <li class="flex flex-wrap items-start gap-2">
       <code class="text-[var(--text-strong)]">${invalidProfile.name}</code>
-      <span class="text-[var(--text-muted)]">${firstError}</span>
+      <span class="text-[var(--color-fg-muted)]">${firstError}</span>
       ${extraErrors > 0
-        ? html`<span class="text-[var(--text-muted)]">+${extraErrors} more</span>`
+        ? html`<span class="text-[var(--color-fg-muted)]">+${extraErrors} more</span>`
         : null}
     </li>
   `
@@ -557,7 +557,7 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
     <div class=${`rounded border ${boxTone} p-3 text-xs mb-3`}>
       <div class="flex items-center gap-2 flex-wrap mb-2">
         <${StatusChip} tone=${tone}>${validationLabel(config.validation_status)}<//>
-        <span class="text-[var(--text-muted)]">
+        <span class="text-[var(--color-fg-muted)]">
           ${config.invalid_profiles.length} invalid profile${config.invalid_profiles.length === 1 ? '' : 's'}
           · ${config.validation_errors.length} error${config.validation_errors.length === 1 ? '' : 's'}
         </span>
@@ -567,7 +567,7 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
       </div>
       ${visibleErrors.length > 0
         ? html`
-          <ul class="flex flex-col gap-1 mb-2 text-[var(--text-muted)]">
+          <ul class="flex flex-col gap-1 mb-2 text-[var(--color-fg-muted)]">
             ${visibleErrors.map(error => html`<li>${error}</li>`)}
           </ul>
         `
@@ -575,7 +575,7 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
       ${visibleProfiles.length > 0
         ? html`
           <div class="text-[var(--text-strong)] mb-1">거부된 프로파일</div>
-          <ul class="flex flex-col gap-1 text-[var(--text-muted)]">
+          <ul class="flex flex-col gap-1 text-[var(--color-fg-muted)]">
             ${visibleProfiles.map(invalidProfile => html`
               <${InvalidProfileSummary} invalidProfile=${invalidProfile} />
             `)}
@@ -584,7 +584,7 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
         : null}
       ${config.invalid_profiles.length > visibleProfiles.length
         ? html`
-          <div class="mt-2 text-[var(--text-muted)]">
+          <div class="mt-2 text-[var(--color-fg-muted)]">
             + ${config.invalid_profiles.length - visibleProfiles.length} more invalid profiles
           </div>
         `
@@ -706,15 +706,15 @@ function HealthTable({
         onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
       />
       ${isFiltering
-        ? html`<span class="text-xs text-[var(--text-muted)]">${filtered.length}/${health.providers.length}건</span>`
+        ? html`<span class="text-xs text-[var(--color-fg-muted)]">${filtered.length}/${health.providers.length}건</span>`
         : null}
     </div>
     ${isFiltering && filtered.length === 0
-      ? html`<div class="py-4 text-center text-2xs text-[var(--text-muted)]">필터 결과 없음 (${health.providers.length} providers)</div>`
+      ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-muted)]">필터 결과 없음 (${health.providers.length} providers)</div>`
       : html`
         <table class="w-full text-xs" aria-label="cascade provider 상태">
           <thead>
-            <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+            <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
               <th scope="col" class="text-left py-1 w-4"></th>
               <th scope="col" class="text-left py-1">제공자</th>
               <th
@@ -760,7 +760,7 @@ function HealthTable({
               // too old to carry the field — don't decorate in that case.
               const orphaned = p.declared === false
               return html`
-              <tr class="border-b border-[var(--card-border)] last:border-b-0">
+              <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
                 <td class="py-1"><span class=${`inline-block w-2 h-2 rounded-full ${TONE_DOT[tone]}`}></span></td>
                 <td class="py-1">
                   <code class="text-[var(--text-strong)]">${p.provider_key}</code>
@@ -771,7 +771,7 @@ function HealthTable({
                 <td class="py-1">
                   ${status
                     ? html`<${StatusChip} tone=${providerStatusTone(status)} uppercase=${false}>${status}<//>`
-                    : html`<span class="text-[var(--text-muted)]">—</span>`}
+                    : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
                 </td>
                 <td class="py-1 text-right tabular-nums">${fmtPct(p.success_rate)}</td>
                 <td class="py-1 text-right tabular-nums">${p.consecutive_failures}</td>
@@ -779,7 +779,7 @@ function HealthTable({
                 <td class="py-1 text-right tabular-nums">
                   ${rejected > 0
                     ? html`<span class="text-[var(--warn)]">${rejected}</span>`
-                    : html`<span class="text-[var(--text-muted)]">—</span>`}
+                    : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
                 </td>
                 <td class="py-1 text-right tabular-nums">${fmtPerfTokPerSec(p.avg_prompt_tok_per_sec)}</td>
                 <td class="py-1 text-right tabular-nums">${fmtPerfTokPerSec(p.avg_decode_tok_per_sec)}</td>
@@ -787,7 +787,7 @@ function HealthTable({
                 <td class="py-1 text-right">
                   ${p.in_cooldown
                     ? html`<${StatusChip} tone="bad">${fmtCooldownExpiry(p.cooldown_expires_at)}<//>`
-                    : html`<span class="text-[var(--text-muted)]">—</span>`}
+                    : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
                 </td>
               </tr>
             `})}
@@ -896,7 +896,7 @@ function SloCard({ slo }: { slo: CascadeSloResponse }) {
     <div class="flex flex-col gap-3">
       <div class="flex items-center gap-2 flex-wrap">
         <${StatusChip} tone=${tone}>${sloStatusLabel(slo.status)}<//>
-        <span class="text-xs text-[var(--text-muted)]">sample ${totalEvents}/${slo.window_sample_size}</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">sample ${totalEvents}/${slo.window_sample_size}</span>
         ${slo.violations.length > 0
           ? html`<span class="text-xs text-[var(--bad-light)]">violating: ${slo.violations.join(', ')}</span>`
           : null}
@@ -934,10 +934,10 @@ function StrategyTraceTable({
     ? trace.events.filter(e => traceEventMatchesSearch(e, query))
     : trace.events
   return html`
-    ${query ? html`<div class="text-xs text-[var(--text-muted)] mb-2">${filtered.length}/${trace.events.length}건</div>` : null}
+    ${query ? html`<div class="text-xs text-[var(--color-fg-muted)] mb-2">${filtered.length}/${trace.events.length}건</div>` : null}
     <table class="w-full text-xs" aria-label="strategy trace 이벤트">
       <thead>
-        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+        <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
           <th scope="col" class="text-left py-1 w-20">시간</th>
           <th scope="col" class="text-left py-1">캐스케이드</th>
           <th scope="col" class="text-left py-1">전략</th>
@@ -951,10 +951,10 @@ function StrategyTraceTable({
         ${filtered.map((e: CascadeStrategyTraceEvent) => {
           const tone = traceKindTone(e.kind)
           return html`
-          <tr class="border-b border-[var(--card-border)] last:border-b-0">
-            <td class="py-1 text-[var(--text-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
+          <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
+            <td class="py-1 text-[var(--color-fg-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
             <td class="py-1"><code class="text-[var(--text-strong)]">${e.cascade_name}</code></td>
-            <td class="py-1 text-[var(--text-muted)]">${e.strategy}</td>
+            <td class="py-1 text-[var(--color-fg-muted)]">${e.strategy}</td>
             <td class="py-1 text-right tabular-nums">${e.cycle}</td>
             <td class="py-1 text-right tabular-nums">${e.candidates_in}/${e.candidates_out}</td>
             <td class="py-1 text-right tabular-nums">${e.backoff_ms > 0 ? e.backoff_ms : '–'}</td>
@@ -975,7 +975,7 @@ function ClientCapacityHistoryTable({
   return html`
     <table class="w-full text-xs" aria-label="capacity 이벤트 이력">
       <thead>
-        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+        <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
           <th scope="col" class="text-left py-1 w-20">시간</th>
           <th scope="col" class="text-left py-1">종류</th>
           <th scope="col" class="text-left py-1">키</th>
@@ -986,8 +986,8 @@ function ClientCapacityHistoryTable({
         ${history.events.map((e: CascadeClientCapacityHistoryEvent) => {
           const tone = eventKindTone(e.kind)
           return html`
-          <tr class="border-b border-[var(--card-border)] last:border-b-0">
-            <td class="py-1 text-[var(--text-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
+          <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
+            <td class="py-1 text-[var(--color-fg-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
             <td class="py-1"><${StatusChip} tone=${tone}>${eventKindLabel(e.kind)}<//></td>
             <td class="py-1"><code class="text-[var(--text-strong)]">${e.key}</code></td>
             <td class="py-1 text-right tabular-nums">${e.active_after}</td>
@@ -1005,7 +1005,7 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
   return html`
     <table class="w-full text-xs" aria-label="client capacity 슬롯">
       <thead>
-        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+        <tr class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
           <th scope="col" class="text-left py-1 w-4"></th>
           <th scope="col" class="text-left py-1">종류</th>
           <th scope="col" class="text-left py-1">키</th>
@@ -1018,7 +1018,7 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
         ${capacity.entries.map((e: CascadeClientCapacityEntry) => {
           const tone = capacityTone(e)
           return html`
-          <tr class="border-b border-[var(--card-border)] last:border-b-0">
+          <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
             <td class="py-1"><span class=${`inline-block w-2 h-2 rounded-full ${TONE_DOT[tone]}`}></span></td>
             <td class="py-1"><${StatusChip} tone=${tone === 'ok' ? 'neutral' : tone}>${capacityKindLabel(e.kind)}<//></td>
             <td class="py-1"><code class="text-[var(--text-strong)]">${e.key}</code></td>
@@ -1114,15 +1114,15 @@ function CascadeRawConfigEditor({
   return html`
     <${Card} title=${mode.title}>
       <div class="flex flex-col gap-3 p-4">
-        <p class="text-sm text-[var(--text-muted)]">${mode.primary}</p>
-        <p class="text-xs text-[var(--text-muted)]">
+        <p class="text-sm text-[var(--color-fg-muted)]">${mode.primary}</p>
+        <p class="text-xs text-[var(--color-fg-muted)]">
           ${mode.secondary}
         </p>
 
         <form class="flex flex-col gap-3" onSubmit=${handleSave}>
           <textarea
             aria-label="설정 편집기"
-            class="h-96 w-full rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
+            class="h-96 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
             spellcheck="false"
             readonly=${!sourceEditable}
             value=${editorText.value}
@@ -1134,7 +1134,7 @@ function CascadeRawConfigEditor({
           />
 
           <div class="flex items-center gap-3 flex-wrap text-xs">
-            <span class=${editorDirty.value ? 'text-[var(--warn)]' : 'text-[var(--text-muted)]'}>
+            <span class=${editorDirty.value ? 'text-[var(--warn)]' : 'text-[var(--color-fg-muted)]'}>
               ${editorDirty.value ? 'unsaved changes' : 'in sync with disk'}
             </span>
             ${syntaxError
@@ -1148,7 +1148,7 @@ function CascadeRawConfigEditor({
               ? html`
                 <span class=${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid')
                   ? 'text-[var(--bad-light)]'
-                  : 'text-[var(--text-muted)]'}
+                  : 'text-[var(--color-fg-muted)]'}
                 >
                   ${saveMessage.value}
                 </span>
@@ -1159,14 +1159,14 @@ function CascadeRawConfigEditor({
           <div class="flex items-center gap-3 flex-wrap">
             <button
               type="submit"
-              class="rounded border border-[var(--accent-primary)] bg-[var(--accent-primary)] px-3 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
+              class="rounded border border-[var(--color-accent-fg)] bg-[var(--color-accent-fg)] px-3 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
               disabled=${saveDisabled}
             >
               ${saving.value ? '저장 중...' : mode.saveLabel}
             </button>
             <button
               type="button"
-              class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
+              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
               onClick=${handleReset}
               disabled=${saving.value || !editorDirty.value}
             >
@@ -1174,7 +1174,7 @@ function CascadeRawConfigEditor({
             </button>
             <button
               type="button"
-              class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
+              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
               onClick=${() => void onRefresh()}
               disabled=${saving.value}
             >
@@ -1188,12 +1188,12 @@ function CascadeRawConfigEditor({
               <div class="text-xs font-medium text-[var(--text-strong)]">
                 ${mode.previewTitle}
               </div>
-              <div class="text-xs text-[var(--text-muted)]">
+              <div class="text-xs text-[var(--color-fg-muted)]">
                 ${raw?.config_path ?? 'unresolved'}
               </div>
               <textarea
                 aria-label="설정 미리보기"
-                class="h-72 w-full rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
+                class="h-72 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
                 spellcheck="false"
                 readonly
                 value=${raw?.raw_json ?? ''}
@@ -1231,14 +1231,14 @@ export function CascadeConfigPanel() {
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <button
-          class="rounded border border-[var(--card-border)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
           onClick=${() => void loadCascadeData(resource)}
         >
           새로고침
         </button>
-        ${current.loading ? html`<span class="text-xs text-[var(--text-muted)]" role="status">로딩 중...</span>` : null}
+        ${current.loading ? html`<span class="text-xs text-[var(--color-fg-muted)]" role="status">로딩 중...</span>` : null}
         ${config?.updated_at
-          ? html`<span class="text-xs text-[var(--text-muted)]">config · ${config.updated_at}</span>`
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">config · ${config.updated_at}</span>`
           : null}
       </div>
 

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -203,7 +203,7 @@ describe('fsm-hub derived state', () => {
 
     expect(result.tone).toBe('ok')
     expect(result.headline).toContain('Idle 스냅샷 정상')
-    expect(result.detail).toContain('25s ago')
+    expect(result.detail).toContain('25s 전')
   })
 
   it('marks long-running observed execution as stalled on screen', () => {


### PR DESCRIPTION
## Summary

Phase G Step 3 (file-disjoint sweep) of token convergence. 64 sites in `cascade-config-panel.ts` swap legacy tokens to canonical SPEC §3 names already aliased in variables.css.

## Mapping (all 1:1 identical color via existing alias)

| Legacy | Canonical | Sites |
|--------|-----------|-------|
| `var(--text-muted)` | `var(--color-fg-muted)` | 42 |
| `var(--card-border)` | `var(--color-border-default)` | 18 |
| `var(--accent-primary)` | `var(--color-accent-fg)` | 4 |
| **Total** | | **64** |

`--accent-primary` was undefined → 4 buttons silently had no color. Now resolves correctly via the alias.

## Out of scope

- `--text-strong` (21 sites in this file) — current `--color-fg-primary`/`secondary` alias is SPEC-inverted (primary→text-body, secondary→text-strong). Inversion fix will land in a separate visual-diff-reviewed PR before sweeping these.
- Other production tokens not present in this file.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test cascade-config-panel` → 71/71 pass
- [x] No JSX changes — selector tests unaffected
- [x] Diff is 1:1 (58 ins / 58 del)

Stacked behind: #11013 (CS87 alias bridge) — independent file, no merge dependency.