### PR TITLE
fix(keeper): include unknown_toml_keys in merge_overlay (main red)

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -1280,6 +1280,8 @@ let merge_keeper_profile_defaults
          List.filter (fun (k, _) -> not (List.mem k overlay_keys)) base.oas_env
        in
        surviving_base @ overlay.oas_env);
+    unknown_toml_keys =
+      merge_string_list ~base:base.unknown_toml_keys overlay.unknown_toml_keys;
   }
 
 (* Derived transport guards for combinations that are otherwise easy to


### PR DESCRIPTION
## Why
main is red on \`dune build bin/main_eio.exe\`:

\`\`\`
File "lib/keeper/keeper_types_profile.ml", lines 1207-1283:
Error: Some record fields are undefined: unknown_toml_keys
\`\`\`

PR #11011 (task-100 PR-A, merged 2026-04-27 02:05 UTC) added
\`unknown_toml_keys : string list\` on \`keeper_profile_defaults\` and
populated it in loader/parsers, but did **not sweep** \`merge_overlay\`
(line 1207-1283 of the same file). Strict record construction therefore
fails — classic Jane Street refactor sweep miss
(\`feedback_jane-street-refactor-sweep-miss\`).

Effect: \`main_eio.exe\` cannot be rebuilt → blocks OP-F verification
window for PR-M (#10972, Leak 9 cycle FAILED → fiber crash propagation).

## What
1 file, 2 lines:

\`\`\`ocaml
unknown_toml_keys =
  merge_string_list ~base:base.unknown_toml_keys overlay.unknown_toml_keys;
\`\`\`

Reuses the existing \`merge_string_list\` helper (same pattern as
\`mention_targets\` two screens up). Additive semantics: unknown keys
from either persona-default or keeper-TOML layer survive the merge,
so downstream surfaces (keeper_status_detail, dashboards) still see
drift instead of silently losing it.

## Verification
- Local: \`dune build bin/main_eio.exe\` passes (exit 0).
- Diff: 2 insertions, 0 deletions in \`lib/keeper/keeper_types_profile.ml\`.
- No behaviour change beyond unblocking compilation; identical to PR
  #11011's stated intent ("the field is purely additive").

## Related
- PR #11011 (introduced the field)
- PR-M / #10972 (downstream consumer of a working build)