### PR TITLE
i18n(dashboard): localize transport-beacon + keeper-detail-shell tooltips (round-90)

### DIFF
--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -35,7 +35,7 @@ function KeeperToolPresetChip({ keeperName }: { keeperName: string }) {
         ? 'bg-[var(--ok-10)] text-[var(--ok)] border border-[var(--ok-20)]'
         : 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
       }"
-      title=${`Tool preset: ${preset}${canPR ? ' (clone/PR 가능)' : ''}`}
+      title=${`도구 preset: ${preset}${canPR ? ' (clone/PR 가능)' : ''}`}
     >${preset}</span>
   `
 }

--- a/dashboard/src/components/transport-beacon.ts
+++ b/dashboard/src/components/transport-beacon.ts
@@ -46,14 +46,14 @@ export function computeBeaconView(args: {
     return {
       state: 'gray',
       label: 'WS+SSE (legacy)',
-      title: 'Parallel mode — both transports active. Set VITE_DASHBOARD_WS_ONLY=true to cut over.',
+      title: 'Parallel mode — 두 transport 모두 active. cut over 하려면 VITE_DASHBOARD_WS_ONLY=true 설정.',
     }
   }
   if (!args.connected || !args.ready) {
     return {
       state: 'red',
       label: 'WS-only · disconnected',
-      title: 'WS-only mode and the socket is closed. Events will not arrive until the socket reconnects. Hot rollback: window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()',
+      title: 'WS-only mode 인데 socket 이 닫혀있음. socket 재연결까지 event 가 도착하지 않음. Hot rollback: window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()',
     }
   }
   const silentMs = args.now - args.lastEventAt
@@ -61,13 +61,13 @@ export function computeBeaconView(args: {
     return {
       state: 'yellow',
       label: 'WS-only · silent',
-      title: `WS-only mode and no event in the last ${Math.floor(silentMs / 1000)}s. Either the workload is genuinely idle or the WS fan-out is stuck.`,
+      title: `WS-only mode 인데 최근 ${Math.floor(silentMs / 1000)}s 동안 event 없음. workload 가 실제 idle 이거나 WS fan-out 이 stuck.`,
     }
   }
   return {
     state: 'green',
     label: `WS-only · open · ${args.eventCount60s} events / 60s`,
-    title: `WS-only mode active. Last event ${Math.floor(silentMs / 1000)}s ago.`,
+    title: `WS-only mode active. 마지막 event ${Math.floor(silentMs / 1000)}s 전.`,
   }
 }
 


### PR DESCRIPTION
## Summary

Tooltip surface 5개 한국어화. 모두 status chip hover 시 표시되는 사용자 hint 텍스트.

## Changed strings

### `transport-beacon.ts` — `computeBeaconView` 의 4 BeaconView title

| 분기 | Before | After |
|---|---|---|
| `!wsOnly` (gray, line 49) | `'Parallel mode — both transports active. Set VITE_DASHBOARD_WS_ONLY=true to cut over.'` | `'Parallel mode — 두 transport 모두 active. cut over 하려면 VITE_DASHBOARD_WS_ONLY=true 설정.'` |
| `!connected/!ready` (red, line 56) | `'WS-only mode and the socket is closed. Events will not arrive until the socket reconnects. Hot rollback: window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()'` | `'WS-only mode 인데 socket 이 닫혀있음. socket 재연결까지 event 가 도착하지 않음. Hot rollback: window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()'` |
| silent (yellow, line 64) | `WS-only mode and no event in the last ${N}s. Either the workload is genuinely idle or the WS fan-out is stuck.` | `WS-only mode 인데 최근 ${N}s 동안 event 없음. workload 가 실제 idle 이거나 WS fan-out 이 stuck.` |
| green/active (line 70) | `WS-only mode active. Last event ${N}s ago.` | `WS-only mode active. 마지막 event ${N}s 전.` |

### `keeper-detail-shell.ts` — `ToolPresetBadge` title

| line | Before | After |
|---|---|---|
| 38 | `Tool preset: ${preset}${' (clone/PR 가능)' if canPR else ''}` | `도구 preset: ${preset}${' (clone/PR 가능)' if canPR else ''}` |

`canPR` 분기는 이미 한국어 (`'(clone/PR 가능)'`) 인데 prefix 만 영어였음 — inconsistency 해소.

## Domain term policy

Beacon `label` fields (`'WS+SSE (legacy)'`, `'WS-only · disconnected'`, `'WS-only · silent'`, `'WS-only · open · ...'`) **변경 없음** — 도메인 status badge naming, FSM phase 표기 ('KSM Running' / 'KCL trying') 와 같은 카테고리.

## Scope

- 2 파일, 5줄.
- 테스트 영향 0:
  - `dashboard-shell.test.ts` 의 `describeReconnecting` 매칭은 다른 함수 (transport-beacon 의 'reconnects' 와 무관).
  - 변경 string 들 어떤 것도 toContain assertion 으로 사용되지 않음.
