### PR TITLE
i18n(dashboard): localize 4 user-facing strings outside components/ (round-91)

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -65,9 +65,9 @@ describe('derivePostTitle expanded', () => {
     expect(derivePostTitle('1. First item')).toBe('First item')
   })
 
-  it('returns "Untitled post" for empty content', () => {
-    expect(derivePostTitle('')).toBe('Untitled post')
-    expect(derivePostTitle('   ')).toBe('Untitled post')
+  it('returns "제목 없음" for empty content', () => {
+    expect(derivePostTitle('')).toBe('제목 없음')
+    expect(derivePostTitle('   ')).toBe('제목 없음')
   })
 
   it('truncates long titles', () => {

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -278,7 +278,7 @@ export function derivePostTitle(content: string): string {
     if (title) return truncatePostTitle(title)
   }
 
-  return 'Untitled post'
+  return '제목 없음'
 }
 
 export function sanitizeBoardTitle(title: string, fallbackBody = ''): string {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -191,10 +191,10 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
       finalizeAssistantEntry(keeperName, assistantId, {
         delivery: 'timeout',
         streamState: null,
-        error: 'Stream cancelled',
+        error: '스트림 취소됨',
         timestamp: new Date().toISOString(),
       })
-      setRecordValue(keeperActionErrors, keeperName, 'Stream cancelled')
+      setRecordValue(keeperActionErrors, keeperName, '스트림 취소됨')
       throw err
     }
 

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -25,7 +25,7 @@ export function abortKeeperThreadMessage(name: string): void {
     finalizeAssistantEntry(keeperName, entryId, {
       delivery: 'timeout',
       streamState: null,
-      error: 'Stream cancelled',
+      error: '스트림 취소됨',
       timestamp: new Date().toISOString(),
     })
   }

--- a/dashboard/src/operator-actions.ts
+++ b/dashboard/src/operator-actions.ts
@@ -64,7 +64,7 @@ function appendLog(entry: Omit<OperatorActionLogEntry, 'id' | 'at'>): void {
 
 function logMessageFromResult(result: OperatorActionResult): string {
   if (result.confirm_required) {
-    return stringifyUnknown(result.preview) || 'Confirmation required'
+    return stringifyUnknown(result.preview) || '확인 필요'
   }
   return stringifyUnknown(result.result)
     || stringifyUnknown(result.delegated_tool_result)


### PR DESCRIPTION
## Summary

Search expanded `dashboard/src/components/` → `dashboard/src/` 로 확장, 새로 4 user-facing 영어 string 발견. 4 strings 한국어화 + 1 test sync.

## Changed strings

| 파일 | line | Before | After |
|---|---|---|---|
| `operator-actions.ts` | 67 | `'Confirmation required'` | `'확인 필요'` |
| `keeper-actions.ts` | 194 | `'Stream cancelled'` | `'스트림 취소됨'` |
| `keeper-actions.ts` | 197 | `'Stream cancelled'` | `'스트림 취소됨'` |
| `keeper-stream.ts` | 28 | `'Stream cancelled'` | `'스트림 취소됨'` |
| `api/board.ts` | 281 | `'Untitled post'` | `'제목 없음'` |

## Test sync

| 파일 | line | Before | After |
|---|---|---|---|
| `api/board.test.ts` | 68 | `it('returns "Untitled post" for empty content')` | `it('returns "제목 없음" for empty content')` |
| `api/board.test.ts` | 69 | `expect(derivePostTitle('')).toBe('Untitled post')` | `expect(derivePostTitle('')).toBe('제목 없음')` |
| `api/board.test.ts` | 70 | `expect(derivePostTitle('   ')).toBe('Untitled post')` | `expect(derivePostTitle('   ')).toBe('제목 없음')` |

`derivePostTitle` 의 toBe 정확 매칭이라 atomic test sync 필요.

## Why these strings matter

- `operator-actions.ts:67`: dashboard operator action log 의 fallback message
- `keeper-actions.ts/keeper-stream.ts`: keeper chat 의 stream cancellation error 표시 (3 places, dedup 후보지만 이 round 는 그대로 변환)
- `api/board.ts:281`: keeper board 게시물의 fallback title (이전 round-77 #10959 에서 `'Post'` 를 `'게시물'` 로 변환했고, 이건 다른 fallback path)

## Scope

- 5 파일, 8줄.
- atomic test sync 1 file (toBe).
- `'Stream cancelled'` 가 3 곳 — 향후 SSOT 상수로 dedup 가능 후보 (이번 round 외 backlog).
