### PR TITLE
feat(dashboard): adopt canonical SPEC tokens in autoresearch (CS92)

### DIFF
--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -62,7 +62,7 @@ function statusColor(status: string): string {
     case 'completed': return 'text-[var(--accent)]'
     case 'stopped': return 'text-[var(--warn)]'
     case 'error': return 'text-[var(--bad)]'
-    default: return 'text-[var(--text-muted)]'
+    default: return 'text-[var(--color-fg-muted)]'
   }
 }
 
@@ -112,7 +112,7 @@ function LoopSelector() {
   return html`
     <div class="flex flex-col gap-3">
       <div class="flex items-center gap-2">
-        <label class="text-2xs text-[var(--text-muted)] font-medium">실행자 필터</label>
+        <label class="text-2xs text-[var(--color-fg-muted)] font-medium">실행자 필터</label>
         <select
           aria-label="실행자 필터"
           class="bg-card border border-card-border text-[var(--text-body)] text-xs rounded px-2 py-1 outline-none focus:border-accent"
@@ -145,7 +145,7 @@ function LoopSelector() {
             <//>
           `
         })}
-        ${loops.length === 0 ? html`<div class="text-[var(--text-muted)] text-xs py-1.5">선택된 실행자의 루프가 없습니다.</div>` : null}
+        ${loops.length === 0 ? html`<div class="text-[var(--color-fg-muted)] text-xs py-1.5">선택된 실행자의 루프가 없습니다.</div>` : null}
         ${hasMoreLoops.value ? html`
           <${ActionButton}
             variant="ghost"
@@ -167,36 +167,36 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div class="flex flex-col gap-3">
         <div>
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-1">목표</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">목표</div>
           <div class="text-[var(--text-body)] text-sm leading-relaxed">${loop.goal}</div>
         </div>
         <div class="grid grid-cols-2 gap-3">
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">상태</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">상태</div>
             <div class="text-sm font-medium ${statusColor(loop.status)}">${statusLabel(loop.status)}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">사이클</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">사이클</div>
             <div class="text-[var(--text-strong)] text-sm font-mono">${loop.current_cycle} / ${loop.max_cycles}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">경과 시간</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">경과 시간</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${formatElapsedCompact(loop.elapsed_s)}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">실행자</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">실행자</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${loop.author ?? '알 수 없음'}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">모델</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">모델</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${loop.model_model}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">소스</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">소스</div>
             <div class="text-[var(--text-body)] text-sm">${liveLabel(loop)}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">최근 갱신</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">최근 갱신</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${loop.updated_at != null ? formatTimestampKo(loop.updated_at) : '알 수 없음'}</div>
           </div>
         </div>
@@ -205,21 +205,21 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
       <div class="flex flex-col gap-3">
         <div class="grid grid-cols-2 gap-3">
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">기준선</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">기준선</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${loop.baseline.toFixed(4)}</div>
           </div>
           <div>
-            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">최고 점수</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">최고 점수</div>
             <div class="text-[var(--ok)] text-sm font-mono font-semibold">${loop.best_score.toFixed(4)}</div>
           </div>
         </div>
         <div>
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-1">유지 / 삭제</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">유지 / 삭제</div>
           <div class="flex items-center gap-2">
             <span class="text-[var(--ok)] text-sm font-mono font-semibold">${loop.total_keeps}</span>
-            <span class="text-[var(--text-muted)] text-xs">/</span>
+            <span class="text-[var(--color-fg-muted)] text-xs">/</span>
             <span class="text-[var(--bad)] text-sm font-mono font-semibold">${loop.total_discards}</span>
-            <span class="text-[var(--text-muted)] text-xs ml-1">(${keepPct}% keep)</span>
+            <span class="text-[var(--color-fg-muted)] text-xs ml-1">(${keepPct}% keep)</span>
           </div>
           ${totalCycles > 0 ? html`
             <div class="mt-1.5 h-2 rounded-sm bg-[var(--white-6)] overflow-hidden flex">
@@ -235,11 +235,11 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
           ` : null}
         </div>
         <div>
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">대상 파일</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">대상 파일</div>
           <div class="text-[var(--text-body)] text-xs font-mono truncate" title=${loop.target_file}>${loop.target_file}</div>
         </div>
         <div>
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">메트릭</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">메트릭</div>
           <div class="text-[var(--text-body)] text-xs font-mono truncate" title=${loop.metric_fn}>${loop.metric_fn}</div>
         </div>
       </div>
@@ -274,16 +274,16 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
           placeholder="가설 / 판정 / # 필터"
           aria-label="사이클 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleCycles.length === 0
-        ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${cycles.length} cycles)</div>`
+        ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${cycles.length} cycles)</div>`
         : html`
           <div class="overflow-x-auto overflow-y-auto max-h-100 custom-scrollbar rounded border border-[var(--white-6)] bg-[rgba(0,0,0,0.1)]">
             <table class="w-full text-xs" aria-label="자율 연구 사이클 목록">
               <thead>
-                <tr class="text-[var(--text-muted)] text-3xs uppercase tracking-wider border-b border-[var(--white-10)]">
+                <tr class="text-[var(--color-fg-muted)] text-3xs uppercase tracking-wider border-b border-[var(--white-10)]">
                   <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-left py-2.5 px-3 font-medium">#</th>
                   <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-left py-2.5 px-3 font-medium">가설</th>
                   <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-right py-2.5 px-3 font-medium">이전</th>
@@ -296,7 +296,7 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
               <tbody>
                 ${visibleCycles.map(c => html`
                   <tr key=${c.cycle} class="border-b border-[var(--white-5)] hover:bg-[var(--white-4)] transition-colors duration-150">
-                    <td class="py-2 px-3 font-mono text-[var(--text-muted)]">${c.cycle}</td>
+                    <td class="py-2 px-3 font-mono text-[var(--color-fg-muted)]">${c.cycle}</td>
                     <td class="py-2 px-3 text-[var(--text-body)] max-w-50 truncate" title=${c.hypothesis}>${c.hypothesis}</td>
                     <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_before.toFixed(4)}</td>
                     <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_after.toFixed(4)}</td>
@@ -308,7 +308,7 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
                           : 'bg-[var(--bad-soft)] text-[var(--bad)] border border-[var(--bad-20)]'
                       }">${decisionLabel(c.decision)}</span>
                     </td>
-                    <td class="py-2 px-3 text-right text-[var(--text-muted)] font-mono">${formatTimestampKo(c.timestamp)}</td>
+                    <td class="py-2 px-3 text-right text-[var(--color-fg-muted)] font-mono">${formatTimestampKo(c.timestamp)}</td>
                   </tr>
                 `)}
               </tbody>
@@ -328,7 +328,7 @@ function InsightsList({ insights }: { insights: string[] }) {
     <ul class="flex flex-col gap-1.5">
       ${insights.map((insight, i) => html`
         <li key=${i} class="flex items-start gap-2 text-xs text-[var(--text-body)]">
-          <span class="text-[var(--text-muted)] mt-0.5 shrink-0">${i + 1}.</span>
+          <span class="text-[var(--color-fg-muted)] mt-0.5 shrink-0">${i + 1}.</span>
           <span class="leading-relaxed">${insight}</span>
         </li>
       `)}
@@ -357,7 +357,7 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
     <${SurfaceCard} variant="compact">
       <div class="flex flex-col gap-3">
         <div>
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-1 font-medium">연구 브리프</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-1 font-medium">연구 브리프</div>
           <div class="text-sm leading-paragraph text-[var(--text-body)]">
             이 루프는 <span class="font-semibold text-[var(--text-strong)]">${loop.goal}</span> 를 목표로
             <span class="font-mono text-[var(--text-strong)]"> ${loop.target_file} </span>
@@ -369,16 +369,16 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">무엇을 연구하나</div>
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">무엇을 연구하나</div>
             <div class="leading-relaxed text-[var(--text-body)]">${loop.goal}</div>
           </div>
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">무엇으로 성공을 보나</div>
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">무엇으로 성공을 보나</div>
             <div class="font-mono text-[var(--text-body)]">${loop.metric_fn}</div>
-            <div class="mt-1 text-[var(--text-dim)]">baseline ${loop.baseline.toFixed(4)} -> best ${loop.best_score.toFixed(4)}</div>
+            <div class="mt-1 text-[var(--color-fg-disabled)]">baseline ${loop.baseline.toFixed(4)} -> best ${loop.best_score.toFixed(4)}</div>
           </div>
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">연결된 실행 컨텍스트</div>
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">연결된 실행 컨텍스트</div>
             <div class="flex flex-col gap-1 text-[var(--text-body)]">
               <span>session ${loop.session_id ?? '없음'}</span>
               <span>operation ${loop.operation_id ?? '없음'}</span>
@@ -386,15 +386,15 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
             </div>
           </div>
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">현재 가설 / 메모</div>
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">현재 가설 / 메모</div>
             <div class="flex flex-col gap-1 text-[var(--text-body)] leading-relaxed">
               <span>${loop.queued_hypothesis ?? '대기 가설 없음'}</span>
-              <span class="text-[var(--text-dim)]">${loop.program_note ?? 'program note 없음'}</span>
+              <span class="text-[var(--color-fg-disabled)]">${loop.program_note ?? 'program note 없음'}</span>
             </div>
           </div>
         </div>
 
-        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-xs leading-normal text-[var(--text-muted)]">
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-xs leading-normal text-[var(--color-fg-muted)]">
           이 화면은 generator loop 자체를 설명합니다. Safety Harness는 evaluator와 장기 실행 safety rail을 보여주며,
           각 cycle의 keep/discard 판정을 직접 대체하지 않습니다.
         </div>
@@ -408,7 +408,7 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
     <${SurfaceCard} variant="compact">
       <div class="grid grid-cols-1 gap-3 md:grid-cols-[1.3fr_1fr]">
         <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">실험 결과</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">실험 결과</div>
           <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">이 화면은 keep/discard 루프를 봅니다.</div>
           <div class="mt-2 text-sm leading-loose text-[var(--text-body)]">
             어떤 파일을 바꾸고 어떤 metric을 밀어 올리려는지, 그리고 현재 ${loopCount}개 루프가 어떤 cycle에 있는지 직접 봅니다.
@@ -416,7 +416,7 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
         </div>
 
         <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-3">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">안전 하네스</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">안전 하네스</div>
           <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">심판 기계의 건강도는 별도로 봅니다.</div>
           <div class="mt-2 text-sm leading-loose text-[var(--text-body)]">
             평가 모델, 압축 전 상태, 세대 교체 rail 상태는 하네스에서 봅니다.
@@ -466,7 +466,7 @@ function LoopDetailView() {
 
       <${SurfaceCard} variant="compact">
         <div class="flex items-start justify-between gap-3 mb-3">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">루프 개요</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] font-medium">루프 개요</div>
           ${canRepairErrorLoop ? html`
             <div class="flex items-center gap-2">
               <${ActionButton}
@@ -506,7 +506,7 @@ function LoopDetailView() {
 
       <${SurfaceCard} variant="compact">
         <div class="flex items-center justify-between mb-3">
-          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] font-medium">
             사이클 이력 ${detail ? `(${detail.history_count}건)` : ''}
           </div>
         </div>
@@ -514,7 +514,7 @@ function LoopDetailView() {
       <//>
 
       <${SurfaceCard} variant="compact">
-        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-3 font-medium">인사이트</div>
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-3 font-medium">인사이트</div>
         <${InsightsList} insights=${insights} />
       <//>
     </div>
@@ -573,7 +573,7 @@ export function Autoresearch() {
       <${OutcomeVsHarnessCallout} loopCount=${loops.length} />
 
       <div class="flex items-center justify-between">
-        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] font-medium">
           전체 ${loops.length}개 루프
         </div>
         <div class="flex items-center gap-2">
@@ -581,7 +581,7 @@ export function Autoresearch() {
             class="px-2.5 py-1 rounded text-2xs text-accent border border-accent/40 hover:bg-[var(--accent-10)] transition-colors"
           />
           <a href="/api/v1/autoresearch/loops/csv" download="autoresearch_loops.csv"
-            class="px-2.5 py-1 rounded text-2xs text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors no-underline"
+            class="px-2.5 py-1 rounded text-2xs text-[var(--color-fg-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors no-underline"
           >
             CSV 다운로드
           </a>


### PR DESCRIPTION
## Summary

Phase G Step 4 of token convergence. 39 sites in `autoresearch.ts` swap legacy tokens to canonical SPEC §3 names already aliased in variables.css.

## Mapping (all 1:1 identical color via existing alias)

| Legacy | Canonical | Sites |
|--------|-----------|-------|
| `var(--text-muted)` | `var(--color-fg-muted)` | 35 |
| `var(--text-dim)` | `var(--color-fg-disabled)` | 4 |
| **Total** | | **39** |

## Out of scope

- `--text-body` (23 sites) and `--text-strong` (6 sites) — deferred to inversion-fix PR.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test autoresearch` → 28/28 pass
- [x] Diff is 1:1 (39 ins / 39 del)