### PR TITLE
feat(dashboard): adopt canonical SPEC tokens in keeper-detail-shell (CS93)

### DIFF
--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -33,7 +33,7 @@ function KeeperToolPresetChip({ keeperName }: { keeperName: string }) {
     <span class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-semibold uppercase tracking-wide
       ${canPR
         ? 'bg-[var(--ok-10)] text-[var(--ok)] border border-[var(--ok-20)]'
-        : 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
+        : 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border border-[var(--white-8)]'
       }"
       title=${`Tool preset: ${preset}${canPR ? ' (clone/PR 가능)' : ''}`}
     >${preset}</span>
@@ -80,7 +80,7 @@ function KeeperCascadeSelector({ keeper }: { keeper: Keeper }) {
     <div class="flex items-center gap-1.5">
       <select
         aria-label="Cascade 프로필 선택"
-        class="py-0.5 px-1 rounded text-3xs font-mono bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)] cursor-pointer"
+        class="py-0.5 px-1 rounded text-3xs font-mono bg-[var(--white-5)] text-[var(--color-fg-muted)] border border-[var(--white-8)] cursor-pointer"
         title=${invalidProfiles.length > 0
           ? `Cascade 프로필\n\n비활성화된 잘못된 preset:\n${invalidSummary}`
           : 'Cascade 프로필'}
@@ -136,8 +136,8 @@ export function KeeperDetailMissingState({
 }) {
   return html`
     <div class="mx-auto flex w-full max-w-[1100px] flex-col gap-4">
-      <div class="rounded-[28px] border border-[var(--card-border)] bg-[rgba(9,14,24,0.92)] px-6 py-6 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
-        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">키퍼 상세</div>
+      <div class="rounded-[28px] border border-[var(--color-border-default)] bg-[rgba(9,14,24,0.92)] px-6 py-6 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
+        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">키퍼 상세</div>
         <h2 class="m-0 mt-2 text-xl font-semibold text-[var(--text-strong)]">${keeperName}</h2>
         <p class="m-0 mt-2 text-sm leading-relaxed text-[var(--text-secondary)]">
           현재 스냅샷에서 keeper를 찾지 못했습니다. 목록으로 돌아가서 다시 선택하거나, 최신 dashboard refresh 이후 다시 열어 보세요.
@@ -179,7 +179,7 @@ export function KeeperDetailHeaderInfo({
       </button>
       <div class="size-12 shrink-0 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-2xl">${keeper.emoji}</div>
       <div class="flex flex-col gap-0.5">
-        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">모니터링 / 에이전트 / 키퍼 상세</div>
+        <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">모니터링 / 에이전트 / 키퍼 상세</div>
         <div class="mt-1 flex flex-wrap items-center gap-2.5">
           <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--text-strong)]">${keeper.name}</h2>
           <${KeeperPhaseAndStage} phase=${keeper.phase} pipelineStage=${keeper.pipeline_stage} phaseEnteredAtSec=${phaseEnteredAtSec} />
@@ -188,7 +188,7 @@ export function KeeperDetailHeaderInfo({
           <${KeeperCascadeSelector} keeper=${keeper} />
         </div>
         ${keeper.koreanName || keeper.created_at ? html`
-          <div class="flex flex-wrap items-center gap-2 text-xs text-[var(--text-muted)]">
+          <div class="flex flex-wrap items-center gap-2 text-xs text-[var(--color-fg-muted)]">
             ${keeper.koreanName ? html`<span>${keeper.koreanName}</span>` : null}
             ${keeper.created_at ? html`<span class="font-mono tabular-nums opacity-60"><${TimeAgo} timestamp=${keeper.created_at} /></span>` : null}
           </div>
@@ -256,7 +256,7 @@ function KeeperDetailQuickFact({
 }) {
   return html`
     <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] px-3.5 py-3">
-      <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">${label}</div>
+      <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">${label}</div>
       <div class="mt-1 text-sm font-medium leading-snug text-[var(--text-strong)]">${children}</div>
     </div>
   `
@@ -287,9 +287,9 @@ export function KeeperDetailOverviewSidebar({
 }) {
   return html`
     <aside class="order-2 xl:order-1 xl:sticky xl:top-[104px] xl:self-start" aria-label="키퍼 프로필 요약">
-      <div class="flex flex-col gap-4 rounded-[28px] border border-[var(--card-border)] bg-[rgba(9,14,24,0.84)] p-4 shadow-[0_20px_48px_rgba(0,0,0,0.18)]">
+      <div class="flex flex-col gap-4 rounded-[28px] border border-[var(--color-border-default)] bg-[rgba(9,14,24,0.84)] p-4 shadow-[0_20px_48px_rgba(0,0,0,0.18)]">
         <div>
-          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">개요</div>
+          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">개요</div>
           <p class="m-0 mt-2 text-sm leading-relaxed text-[var(--text-secondary)]">
             긴 단일 모달 대신 keeper 상세를 별도 화면으로 펼쳤습니다. 운영자가 자주 오가는 맥락 단위로 나눠서 바로 점프할 수 있습니다.
           </p>
@@ -305,7 +305,7 @@ export function KeeperDetailOverviewSidebar({
         </div>
 
         <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] p-3.5">
-          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">빠른 이동</div>
+          <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">빠른 이동</div>
           <div class="mt-3 flex flex-col gap-2">
             ${KEEPER_DETAIL_SECTIONS.map((section) => html`
               <button
@@ -314,7 +314,7 @@ export function KeeperDetailOverviewSidebar({
                 onClick=${() => scrollToKeeperDetailSection(section.id)}
               >
                 <div class="text-sm font-medium text-[var(--text-strong)]">${section.label}</div>
-                <div class="mt-1 text-2xs leading-relaxed text-[var(--text-muted)]">${section.summary}</div>
+                <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${section.summary}</div>
               </button>
             `)}
           </div>
@@ -340,11 +340,11 @@ export function KeeperDetailSection({
   return html`
     <section
       id=${id}
-      class="scroll-mt-24 rounded-[28px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(12,19,34,0.94),rgba(8,13,24,0.98))] shadow-[0_24px_48px_rgba(0,0,0,0.22)]"
+      class="scroll-mt-24 rounded-[28px] border border-[var(--color-border-default)] bg-[linear-gradient(180deg,rgba(12,19,34,0.94),rgba(8,13,24,0.98))] shadow-[0_24px_48px_rgba(0,0,0,0.22)]"
       aria-label=${title}
     >
       <div class="border-b border-[var(--white-8)] px-5 py-4 sm:px-6">
-        <div class="text-3xs font-semibold uppercase tracking-[0.22em] text-[var(--text-muted)]">${eyebrow}</div>
+        <div class="text-3xs font-semibold uppercase tracking-[0.22em] text-[var(--color-fg-muted)]">${eyebrow}</div>
         <div class="mt-1 flex flex-col gap-1 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <h3 class="m-0 text-lg font-semibold text-[var(--text-strong)]">${title}</h3>


### PR DESCRIPTION
## Summary

Phase G Step 4 of token convergence. 13 sites in `keeper-detail-shell.ts` swap legacy tokens to canonical SPEC §3 names already aliased in variables.css.

## Mapping (all 1:1 identical color via existing alias)

| Legacy | Canonical | Sites |
|--------|-----------|-------|
| `var(--text-muted)` | `var(--color-fg-muted)` | 10 |
| `var(--card-border)` | `var(--color-border-default)` | 3 |
| **Total** | | **13** |

## Out of scope

- `--text-strong` (7 sites) — deferred to inversion-fix PR.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test keeper-detail` → 105/105 pass
- [x] Diff is 1:1 (13 ins / 13 del)