### PR TITLE
i18n(dashboard): localize 4 operator-actions extractApiError fallbacks (round-92)

### DIFF
--- a/dashboard/src/operator-actions.ts
+++ b/dashboard/src/operator-actions.ts
@@ -88,7 +88,7 @@ export async function refreshOperatorSnapshot(opts?: RefreshOptions): Promise<vo
       operatorSnapshot.value = normalizeOperatorSnapshot(raw)
       lastSnapshotRefreshAt = Date.now()
     } catch (err) {
-      const summary = extractApiError(err, 'Failed to load operator snapshot')
+      const summary = extractApiError(err, 'operator 스냅샷 로드 실패')
       operatorError.value = summary.message
       operatorErrorStatus.value = summary.status
     } finally {
@@ -111,7 +111,7 @@ export async function refreshOperatorRoomDigest(opts?: RefreshOptions): Promise<
       operatorRoomDigest.value = normalizeOperatorDigest(raw)
       lastRoomDigestRefreshAt = Date.now()
     } catch (err) {
-      const summary = extractApiError(err, 'Failed to load operator digest')
+      const summary = extractApiError(err, 'operator 다이제스트 로드 실패')
       operatorDigestError.value = summary.message
       operatorDigestErrorStatus.value = summary.status
     } finally {
@@ -140,7 +140,7 @@ export async function dispatchOperatorAction(request: OperatorActionRequest): Pr
     await refreshOperatorRoomDigest({ force: true })
     return result
   } catch (err) {
-    const summary = extractApiError(err, 'Operator action failed')
+    const summary = extractApiError(err, 'operator 액션 실패')
     const message = summary.message
     operatorError.value = message
     operatorErrorStatus.value = summary.status
@@ -179,7 +179,7 @@ export async function confirmOperatorPendingAction(
     await refreshOperatorRoomDigest({ force: true })
     return result
   } catch (err) {
-    const summary = extractApiError(err, 'Operator confirmation failed')
+    const summary = extractApiError(err, 'operator 확인 실패')
     const message = summary.message
     operatorError.value = message
     operatorErrorStatus.value = summary.status


### PR DESCRIPTION
## Summary

`operator-actions.ts` 4 곳의 `extractApiError(err, ...)` fallback 영어 message 를 한국어화. 모두 operator panel 의 error banner 로 노출되는 사용자 면 텍스트.

## Changed strings

| line | Before | After |
|---|---|---|
| 91 | `'Failed to load operator snapshot'` | `'operator 스냅샷 로드 실패'` |
| 114 | `'Failed to load operator digest'` | `'operator 다이제스트 로드 실패'` |
| 143 | `'Operator action failed'` | `'operator 액션 실패'` |
| 182 | `'Operator confirmation failed'` | `'operator 확인 실패'` |

## Domain term policy

`operator` 보존 — 기존 dashboard 관습 (operator panel, operator action 등 도메인 용어).

## Scope

- 1 파일, 4줄.
- `core.test.ts:518/524` 의 `'Failed to load'` 는 generic test mock context 라 호출 site 가 다름 — 영향 없음.
- 변경 string 어떤 것도 toBe/toContain assertion 에서 사용되지 않음.
