### PR TITLE
fix(oas-worker-exec-transport): remove unreachable catch-all (cascade residual after #11008)

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1258,4 +1258,3 @@ let non_http_transport_of_provider
                         }))))
   | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
       Ok None
-  | _ -> Ok None


### PR DESCRIPTION
## Summary

`main` has been red on `opam exec -- dune build @check` since #11008 merged. That PR swept four `_ -> Ok None` catch-alls (provider_adapter.ml ×3, provider_tool_support.ml ×1) but missed this fifth site in `oas_worker_exec_transport.ml:1261`.

The arm immediately above already enumerates every remaining `provider_kind` variant:

```ocaml
| Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
    Ok None
| _ -> Ok None    (* unreachable — warning 11 under warn-error +8 *)
```

Behavior is unchanged: both the deleted arm and the kept arm return `Ok None`.

## Test Plan

- [x] `opam exec -- dune build @check` (clean)
- [ ] CI green
- [ ] Required: Lint + Build

This is the 5th site of the same cascade originally identified in (now-closed) #11009. Closed in favor of #11008's race-winner; this fix-forward closes the residual.
