### PR TITLE
fix(dashboard): surface 3 P1 silent failures

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -231,23 +231,26 @@ export async function streamKeeperMessage(
 export async function fetchKeeperChatHistory(
   name: string,
 ): Promise<KeeperChatHistoryMessage[]> {
-  try {
-    const resp = await fetch(
-      `/api/v1/keepers/${encodeURIComponent(name)}/chat/history`,
-      { headers: jsonHeaders() },
-    )
-    if (!resp.ok) return []
-    const data: unknown = await resp.json()
-    if (!Array.isArray(data)) return []
-    // Per-item safeParse: drop invalid entries silently to match the prior
-    // hand-rolled type guard. Individual failures are non-fatal; operators
-    // keep seeing a clean transcript during backend drift windows.
-    return data
-      .map(safeParseKeeperChatHistoryMessage)
-      .filter((m): m is KeeperChatHistoryMessage => m !== null)
-  } catch {
-    return []
+  // P1 silent-failure fix: previously HTTP non-2xx and network/parse
+  // errors both mapped to `return []`, leaving the caller unable to
+  // distinguish "no chat history yet" from "fetch failed."  Now both
+  // throw, and the caller (keeper-chat-panel.ts) is responsible for
+  // surfacing via chatError.value.  Per-item safeParse drift remains
+  // tolerant — only network / HTTP / shape errors throw.
+  const resp = await fetch(
+    `/api/v1/keepers/${encodeURIComponent(name)}/chat/history`,
+    { headers: jsonHeaders() },
+  )
+  if (!resp.ok) {
+    throw new Error(`fetchKeeperChatHistory: HTTP ${resp.status} ${resp.statusText}`)
   }
+  const data: unknown = await resp.json()
+  if (!Array.isArray(data)) {
+    throw new Error('fetchKeeperChatHistory: response is not an array')
+  }
+  return data
+    .map(safeParseKeeperChatHistoryMessage)
+    .filter((m): m is KeeperChatHistoryMessage => m !== null)
 }
 
 // --- Keeper lifecycle (boot / shutdown) ---

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -153,16 +153,26 @@ export function KeeperChatPanel({ name }: { name: string }) {
     chatMessages.value = []
     searchQuery.value = ''
     let stale = false
-    void fetchKeeperChatHistory(name).then((history) => {
-      if (stale) return
-      if (history.length > 0) {
-        chatMessages.value = history.map((m) => ({
-          role: m.role === 'assistant' ? 'assistant' as const : 'user' as const,
-          content: m.content,
-          timestamp: m.ts * 1000,
-        }))
-      }
-    })
+    void fetchKeeperChatHistory(name)
+      .then((history) => {
+        if (stale) return
+        if (history.length > 0) {
+          chatMessages.value = history.map((m) => ({
+            role: m.role === 'assistant' ? 'assistant' as const : 'user' as const,
+            content: m.content,
+            timestamp: m.ts * 1000,
+          }))
+        }
+      })
+      .catch((err: unknown) => {
+        // P1 silent-failure fix: fetchKeeperChatHistory now throws on
+        // HTTP non-2xx / network / shape errors instead of returning [].
+        // Surface via chatError so the operator distinguishes "no
+        // history yet" from "load failed" in the UI.
+        if (stale) return
+        const msg = err instanceof Error ? err.message : String(err)
+        chatError.value = `이전 대화 불러오기 실패: ${msg}`
+      })
     return () => { stale = true }
   }, [name])
 

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -54,7 +54,16 @@ function KeeperCascadeSelector({ keeper }: { keeper: Keeper }) {
       .then((next) => {
         if (!cancelled) setCascadeProfiles(next)
       })
-      .catch(() => {})
+      .catch((err) => {
+        // P1 silent-failure fix: an empty selector previously rendered
+        // identically to "no profiles to switch between" (line 69 returns
+        // null when profiles + invalid_profiles <= 1).  Surfacing the
+        // failure to the console lets an operator distinguish "fetch
+        // failed" from "no profiles configured" via DevTools.
+        if (!cancelled) {
+          console.warn('[keeper-cascade-selector] fetchCascadeProfiles failed', err)
+        }
+      })
     return () => {
       cancelled = true
     }

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -167,8 +167,14 @@ function sendNotification(method: string, params: JsonObject): void {
   const currentSocket = socket
   try {
     currentSocket.send(JSON.stringify({ jsonrpc: '2.0', method, params }))
-  } catch {
+  } catch (err) {
     // Best-effort telemetry; the close/error path owns reconnect decisions.
+    // P1 silent-failure fix: previously the catch was empty, so a flood
+    // of dropped notifications (e.g. socket transitioning to closing
+    // mid-send, or readyState lying) was completely invisible.  At least
+    // surface to the console so operators can see the drop pattern in
+    // DevTools when investigating "server keeps re-sending stale deltas."
+    console.warn('[dashboard-ws] sendNotification failed', { method, err })
   }
 }
 


### PR DESCRIPTION
## Why

Quality sweep — first of three (PR-A: dashboard, PR-B: server FSM, PR-C: server transport telemetry) targeting the 8 P1 silent-failure findings from the recent scan.  All three sites in this PR share the same anti-pattern: an exception/non-OK path that produces a value visually indistinguishable from a legitimate empty state, leaving operators unable to diagnose connection problems.

## What

| File | Before | After |
|------|--------|-------|
| `dashboard/src/components/keeper-detail-shell.ts:57` | `.catch(() => {})` — cascade selector silently empty on fetch fail | console.warn surfaces failure to DevTools |
| `dashboard/src/dashboard-ws.ts:170` | empty `catch` in `sendNotification` — dropped notifications invisible | console.warn with method + error |
| `dashboard/src/api/keeper.ts:229–251` | `if (!resp.ok) return []` + `catch { return [] }` collapses fetch fail into empty transcript | throws on HTTP non-2xx / network / shape errors |
| `dashboard/src/components/keeper-chat-panel.ts:156` | `.then(...)` only — fetch failure dropped on the floor | adds `.catch` that writes to existing `chatError` signal → UI shows "이전 대화 불러오기 실패: …" |

Net: 4 files, +56 -28.

## Severity rationale (why P1)

For each finding, the operator-visible state when the silent failure fires is **byte-for-byte identical** to a legitimate empty state:

- "no cascade profiles configured" vs "fetch failed" → same: selector hidden
- "no notifications to send" vs "all sends failing" → same: nothing in network tab
- "first chat with this keeper" vs "history endpoint 500" → same: blank transcript

That makes them undiagnosable in the field without code reading.  This PR escalates from "completely silent" to "console.warn + UI banner where applicable" — the minimum surface change that makes the failure mode visible.

## Out of scope (deferred to PR-D)

Dashboard P2 findings (6 sites) — `agent-detail-state.ts:165–168` cascading null catches, `keeper-phase-strip.ts:54` array of nulls, `dashboard-ws.ts:281,293` unhandled JSON parse, `tab-refresh.ts:150` localStorage swallow, `keeper-actions.ts:107` JSON parse → null, `sse-store.ts:226–232` async import swallow.

## Stack position

Independent of PR-B / PR-C (different files, different layers).  All three P1 PRs can land in any order.

## Test plan

- [x] `pnpm run typecheck` succeeds
- [x] `pnpm --filter masc-dashboard build` succeeds (12.7s)
- [ ] Manual: trigger HTTP 500 on `/api/v1/keepers/<n>/chat/history` (devtools network throttle / mock) → verify `keeper-chat-panel` shows error banner instead of empty transcript
- [ ] Manual: trigger fetch failure on cascade profiles endpoint → verify DevTools console shows `[keeper-cascade-selector] fetchCascadeProfiles failed`
- [ ] Manual: force WS send failure (suspend tab, send notification) → verify DevTools console shows `[dashboard-ws] sendNotification failed`

## Series position

- **PR-A (this)** — Dashboard P1 (3 fix)
- PR-B (next, parallel) — Server FSM P1 (3 fix in `lib/keeper/keeper_registry.ml`)
- PR-C (next, parallel) — Server transport P1 (2 metric counters in `lib/sse.ml` + `lib/transport_metrics.ml`)
- PR-D / E / F — P2 sweep per layer
- PR-G — P3 cleanup