### PR TITLE
feat(dashboard): introduce SPEC §3 typography & spacing scale (CS88)

### DIFF
--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -311,4 +311,46 @@
   --color-status-stalled: var(--purple);
 
   --color-focus-ring: var(--accent);
+
+  /* SPEC v0.1 §3 — Typography & spacing scale (Phase G Step 2).
+     Numeric scale matches dashboard/design-system/source_styles/tokens.css.
+     Coexists with the t-shirt --fs-xs/sm/... above; new components should
+     prefer the numeric scale, legacy callsites stay on t-shirt aliases. */
+
+  /* Typography — font-size scale */
+  --fs-9: 9px;
+  --fs-10: 10px;
+  --fs-11: 11px;
+  --fs-12: 12px;
+  --fs-13: 13px;
+  --fs-14: 14px;
+  --fs-16: 16px;
+  --fs-20: 20px;
+  --fs-28: 28px;
+  --fs-36: 36px;
+
+  /* Typography — line-height scale */
+  --lh-tight: 1.2;
+  --lh-body: 1.45;
+  --lh-loose: 1.6;
+
+  /* Typography — type role shorthands (font: shorthand). Use with `font:`
+     property: `font: var(--type-body);`. */
+  --type-caption: var(--fs-10)/var(--lh-tight) ui-monospace, "SF Mono", Menlo, monospace;
+  --type-label:   var(--fs-11)/var(--lh-tight) ui-sans-serif, -apple-system, system-ui, sans-serif;
+  --type-meta:    var(--fs-12)/var(--lh-tight) ui-monospace, "SF Mono", Menlo, monospace;
+  --type-body:    var(--fs-13)/var(--lh-body) ui-sans-serif, -apple-system, system-ui, sans-serif;
+  --type-title:   var(--fs-14)/var(--lh-tight) ui-sans-serif, -apple-system, system-ui, sans-serif;
+  --type-kpi-m:   var(--fs-16)/var(--lh-tight) ui-monospace, "SF Mono", Menlo, monospace;
+  --type-kpi-l:   var(--fs-20)/var(--lh-tight) ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* Spacing scale — 4-multiple ladder. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
 }


### PR DESCRIPTION
## Summary

Phase G Step 2 of token convergence. Pure additive — 42 lines, 0 edits. Adds the canonical SPEC numeric font/spacing/line-height/type-role tokens so components can adopt them incrementally.

## Added

| Group | Tokens |
|------|--------|
| Font-size | `--fs-9`, `--fs-10`, `--fs-11`, `--fs-12`, `--fs-13`, `--fs-14`, `--fs-16`, `--fs-20`, `--fs-28`, `--fs-36` |
| Line-height | `--lh-tight` (1.2), `--lh-body` (1.45), `--lh-loose` (1.6) |
| Type roles | `--type-caption`, `--type-label`, `--type-meta`, `--type-body`, `--type-title`, `--type-kpi-m`, `--type-kpi-l` |
| Spacing | `--space-1`..`--space-8` (4 → 64 px ladder) |

## Why

Existing dashboard uses Tailwind arbitrary values (`text-[0.85rem]`, `gap-[10px]`, `leading-[1.4]`) which were not unified. SPEC defines a numeric scale for these; introducing the tokens enables systematic per-file adoption.

Coexists with existing `--fs-xs/sm/base/md/lg` t-shirt scale (which aliases Tailwind v4 `--font-size-*`). New components should prefer numeric; legacy callsites stay on t-shirt aliases until a sweep PR.

## Out of scope

- Component adoption — empty PR; future sweep PRs will swap arbitrary values to `var(--fs-13)` etc.
- Tailwind v4 `@theme` registration in `tokens.css` — could enable utilities like `text-fs-13`, deferred.
- `--font-sans/mono/display/body/ui` — dashboard uses Tailwind defaults, no explicit token needed.

## Test plan

- [x] `pnpm typecheck` green
- [x] Pure additive CSS — no existing token values change
- [x] No JSX/TS changes — selector tests unaffected