### PR TITLE
fix(server-auth): decompose dashboard fallback err_kind beyond [other]

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -291,6 +291,14 @@ let dashboard_actor_for_request ~base_path request =
             match err with
             | Types.Unauthorized _ -> "unauthorized"
             | Types.Forbidden _ -> "forbidden"
+            (* InvalidToken/TokenExpired previously collapsed into [other],
+               which made up 100% (136/136) of dashboard fallback events
+               on 2026-04-27.  Use the same [token_mismatch]/[token_expired]
+               labels that [mcp_server_eio_execute.ml:26] already uses for
+               the MCP-side dispatch so dashboards can group across both
+               surfaces. *)
+            | Types.InvalidToken _ -> "token_mismatch"
+            | Types.TokenExpired _ -> "token_expired"
             | Types.AgentNotFound _ -> "agent_not_found"
             | Types.IoError _ -> "io_error"
             | Types.InvalidJson _ -> "invalid_json"


### PR DESCRIPTION
## Production evidence (the why)

Measured today (2026-04-27) in `system_log_2026-04-27.jsonl`:

```
136 dashboard_actor_fallback events
100% (136/136) err_kind=other
100% (136/136) err="🔑 Invalid token: Token mismatch"
```

The #10933 surface is firing correctly, but the err_kind label collapses every `InvalidToken` / `TokenExpired` into `[other]`. PromQL `sum by (err_kind)` cannot distinguish "dashboard SPA cached stale token" from "internal config corruption" or any other future auth class.

## What this PR does

Adds two arms to the err_kind classifier in `lib/server/server_auth.ml:290-297`:
- `Types.InvalidToken _ -> "token_mismatch"`
- `Types.TokenExpired _ -> "token_expired"`

Uses the **same labels** that `lib/mcp_server_eio_execute.ml:26` already uses for the MCP-side auth dispatch, so dashboards can group across both surfaces with one PromQL query.

## Behaviour change

- Zero. Only Prometheus label refinement.
- No new metric, no new code path, no log volume change.
- Existing alert rules keyed on `err_kind=other` may need to expand to include the new buckets, but since `[other]` currently captures 100% of auth failures anyway, that's the desired refactor.

## Verification

- `DUNE_CACHE=disabled dune build` — green.
- Post-merge: PromQL `sum by (err_kind)(rate(masc_silent_dashboard_actor_fallback_total{outcome="error"}[5m]))` should show `token_mismatch` as the dominant bucket (predicted ≥99% based on today's sample), with `other` dropping near zero.

## Test plan

- [ ] Build green
- [ ] CI Lint + Health pass
- [ ] After merge: verify `err_kind=token_mismatch` shows up in production log within 1 minute (current rate: 1 event / ~30s).

Refs: #10933 (introduced the surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)