### PR TITLE
feat(dashboard): a11y handoff-timeline — section role=region (round-6 split 3/N)

### DIFF
--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -281,7 +281,7 @@ export function HandoffTimeline({
   const isFiltering = query.value.trim() !== ''
 
   return html`
-    <section class="rounded border border-card-border bg-card-bg p-4 flex flex-col gap-3" aria-label="A2A 이벤트 타임라인">
+    <section role="region" aria-label="A2A 이벤트 타임라인" class="rounded border border-card-border bg-card-bg p-4 flex flex-col gap-3">
       <header class="flex items-baseline justify-between">
         <div>
           <h3 class="text-sm font-semibold text-text">A2A Event Timeline</h3>


### PR DESCRIPTION
## Why

Third slice of the **a11y round-6 split** (siblings: #11017 agent-detail, #11021 auth-status; closed parent: #10871). HandoffTimeline section was missing the `role="region"` landmark — screen readers had no way to land directly on the A2A event timeline view.

This PR is the handoff-timeline slice (1 file, +1/−1).

## What

Single attribute addition:

```diff
- <section class="..." aria-label="A2A 이벤트 타임라인">
+ <section role="region" aria-label="A2A 이벤트 타임라인" class="...">
```

## Cherry-pick provenance

`300c3c8e3b` from `dashboard/a11y-006`. The source commit added 3 attributes (section role + role=alert on error message + aria-label on row buttons). On `main` two of the three are **already in place** — `role="alert"` on the error `<p>` and `aria-label="${row.keeper} 상세 보기"` on the row button (slightly more specific Korean than the source's "이벤트 보기"). HEAD kept for both. The only net-new contribution is the `role="region"` on the timeline section.

This is the typical pattern for these splits: source branch was ahead 8h ago on some attributes, but `main` has been continuously catching up via other PRs, so each cherry-pick yields a smaller diff than the source commit suggests.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean.
- [ ] No vitest changes — pure ARIA addition, behavior identical.
- [ ] Manual SR check: timeline announces as "region, A2A 이벤트 타임라인". Queued.

## Refs

- Predecessor splits: #11017 (agent-detail), #11021 (auth-status)
- Closed parent: #10871
- Source commit: `300c3c8e3b fix(a11y): add ARIA attributes to handoff-timeline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
