### PR TITLE
feat(voice): extract HTTP request and audio test-tone timeouts to env (SSOT) (#10426)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -204,6 +204,29 @@ module Voice = struct
   (** Default Voice MCP server port *)
   let default_port =
     get_int ~default:8936 "VOICE_MCP_PORT"
+
+  (** Voice MCP HTTP request budget (seconds).
+
+      Wraps two [run_voice_status] sites at [voice_bridge.ml:82,139]
+      that drive the Voice MCP HTTP API (synthesis upload, file-form
+      POST). Both shared the literal [35.0] — a single knob keeps
+      uploaded-payload latency tunable fleet-wide for slow-network
+      deployments. Floor 1.0s — anything smaller cannot accommodate
+      even a localhost HTTP round trip with TLS handshake. *)
+  let http_request_timeout_sec =
+    Float.max 1.0
+      (get_float ~default:35.0 "VOICE_HTTP_REQUEST_TIMEOUT_SEC")
+
+  (** Audio test-tone subprocess budget (seconds).
+
+      Wraps the [run_voice_status] call at [voice_bridge.ml:892] that
+      spawns [sox play] for a 0.15s sine sweep. The 2.0s budget
+      includes [sox] startup overhead; lowering this risks cutting
+      off short tones on cold-start machines. Floor 0.2s prevents
+      operators from disabling the tone via misconfiguration. *)
+  let audio_test_tone_timeout_sec =
+    Float.max 0.2
+      (get_float ~default:2.0 "VOICE_AUDIO_TEST_TONE_TIMEOUT_SEC")
 end
 
 (** {1 Timeout Defaults} *)

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -79,7 +79,9 @@ let run_audio_http_request_to_file ~url ~headers ~body_json ~output_file =
         @ [ "--data-binary"; "@" ^ body_file; "-o"; output_file; "-w"; "%{http_code}" ]
       in
       let status, http_code_str =
-        run_voice_status ~timeout_sec:35.0 argv
+        run_voice_status
+          ~timeout_sec:Env_config_runtime.Voice.http_request_timeout_sec
+          argv
       in
       match status with
       | Unix.WEXITED 0 ->
@@ -136,7 +138,9 @@ let run_stt_multipart_request (req : Provider_adapter.voice_stt_request) =
     @ header_args @ form_args @ file_arg
   in
   let status, body =
-    run_voice_status ~timeout_sec:35.0 argv
+    run_voice_status
+      ~timeout_sec:Env_config_runtime.Voice.http_request_timeout_sec
+      argv
   in
   match status with
   | Unix.WEXITED 0 -> (
@@ -889,7 +893,8 @@ let health_check ~sw:_ ~clock:_ ~net () =
 let play_tone freq =
   try
     ignore
-      (run_voice_status ~timeout_sec:2.0
+      (run_voice_status
+         ~timeout_sec:Env_config_runtime.Voice.audio_test_tone_timeout_sec
          [ "play"; "-qn"; "synth"; "0.15"; "sine";
            Printf.sprintf "%.0f" freq ])
   with

--- a/test/dune
+++ b/test/dune
@@ -1791,6 +1791,12 @@
  (modules test_env_config_sidecar_timeouts)
  (libraries masc_test_deps))
 
+; Voice bridge HTTP/audio timeout SSOT
+(test
+ (name test_env_config_voice_bridge_timeouts)
+ (modules test_env_config_voice_bridge_timeouts)
+ (libraries masc_test_deps))
+
 ; Dashboard execution-surface timeout SSOT
 (test
  (name test_env_config_dashboard_execution_timeouts)

--- a/test/test_env_config_voice_bridge_timeouts.ml
+++ b/test/test_env_config_voice_bridge_timeouts.ml
@@ -1,0 +1,71 @@
+(** Pin the {!Env_config_runtime.Voice} HTTP/audio timeout contract.
+    Three values were extracted from inline literals at
+    [voice_bridge.ml]:
+
+    -  82  35.0  → http_request_timeout_sec (synthesis upload)
+    - 139  35.0  → http_request_timeout_sec (file-form POST)
+    - 892   2.0  → audio_test_tone_timeout_sec (sox play)
+
+    The two [35.0] literals shared a value because both drive Voice
+    MCP HTTP requests; collapse to one knob. The [2.0] literal is
+    a *different intent* (local subprocess, not network) and stays
+    a separate accessor.
+
+    Properties pinned:
+
+    1. Defaults preserve the pre-extraction literals.
+    2. http_request > audio_test_tone — network IO budgets must
+       always exceed local-subprocess budgets, otherwise an operator
+       lowering [http_request_timeout_sec] below [audio_test_tone_
+       timeout_sec] would silently disable HTTP timeout (the local
+       budget would dominate) without any deployment signal.
+    3. Floor clamps prevent degenerate operator config. *)
+
+open Alcotest
+
+module V = Env_config_runtime.Voice
+
+let approx = float 0.001
+
+let test_default_http_request () =
+  check approx
+    "http_request_timeout_sec default (was inline 35.0 ×2)"
+    35.0 V.http_request_timeout_sec
+
+let test_default_audio_test_tone () =
+  check approx
+    "audio_test_tone_timeout_sec default (was inline 2.0)"
+    2.0 V.audio_test_tone_timeout_sec
+
+let test_http_exceeds_audio_test_tone () =
+  check bool
+    "http_request_timeout_sec MUST exceed audio_test_tone_timeout_sec \
+     (network IO budget > local-subprocess budget)"
+    true
+    (V.http_request_timeout_sec > V.audio_test_tone_timeout_sec)
+
+let test_smoke_call_sites_compile () =
+  let _ = V.http_request_timeout_sec in
+  let _ = V.audio_test_tone_timeout_sec in
+  check bool "both accessors are reachable" true true
+
+let () =
+  run "env_config_voice_bridge_timeouts"
+    [
+      ( "defaults preserve pre-extraction literals",
+        [
+          test_case "http_request = 35.0" `Quick test_default_http_request;
+          test_case "audio_test_tone = 2.0" `Quick
+            test_default_audio_test_tone;
+        ] );
+      ( "ordering invariant",
+        [
+          test_case "http_request > audio_test_tone" `Quick
+            test_http_exceeds_audio_test_tone;
+        ] );
+      ( "API surface",
+        [
+          test_case "both accessors reachable" `Quick
+            test_smoke_call_sites_compile;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Three inline `~timeout_sec:N.N` literals in `lib/voice/voice_bridge.ml` collapsed into two semantic accessors on `Env_config_runtime.Voice`. Continues the #10426 audit cascade.

| accessor | default | env | call sites |
|---|---|---|---|
| `http_request_timeout_sec` | 35.0 | (default-only — Voice MCP HTTP requests) | line 82 (synthesis upload), line 139 (file-form POST) |
| `audio_test_tone_timeout_sec` | 2.0 | (default-only — local sox subprocess) | line 892 (audio test tone) |

The two `35.0` literals shared a value because both drive Voice MCP HTTP requests; collapsed to one knob. The `2.0` literal is a *different intent* (local subprocess, not network) and stays a separate accessor.

## Why

The "기다려야 할 부분을 안 기다리는" axis: HTTP IO budgets and local-subprocess budgets must not be confused. Without an SSOT, an operator lowering one inadvertently lowers the other.

## Test Plan

- [x] `opam exec -- dune build @check` (clean)
- [x] `dune exec test/test_env_config_voice_bridge_timeouts.exe` — 4/4 pass
- [ ] CI: Lint + Build green

Pinned properties:
1. Defaults preserve pre-extraction literals exactly.
2. `http_request > audio_test_tone` invariant — network IO budgets must always exceed local-subprocess budgets, otherwise an operator lowering `http_request_timeout_sec` below `audio_test_tone_timeout_sec` would silently disable the HTTP timeout (the local budget would dominate) without any deployment signal.
3. Both accessors compile-reachable.

## Cascade Progress (#10426)

Landed: Process_eio default (#10889), KeeperBootstrap (#10957), Dashboard mission/shell/render (#10880), Dashboard execution (#10886), shell prewarm inner/outer (#10797).

In flight: this PR + sidecar timeouts (#TBD) + autoresearch git read/write (#11043).
