### PR TITLE
feat(dashboard): adopt canonical SPEC accent token in 3 remaining files (CS97)

### DIFF
--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -87,7 +87,7 @@ export function ExcusePatterns() {
           <div class="flex items-center gap-3">
             <button
               type="submit"
-              class="px-4 py-2 bg-[var(--accent-primary)] text-white rounded hover:opacity-90 disabled:opacity-50 text-sm font-medium"
+              class="px-4 py-2 bg-[var(--color-accent-fg)] text-white rounded hover:opacity-90 disabled:opacity-50 text-sm font-medium"
               disabled=${saving.value}
             >
               ${saving.value ? '저장 중...' : '패턴 저장'}

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -56,7 +56,7 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
     ? 'text-[var(--color-fg-muted)] italic'
     : isDefault
       ? 'text-[var(--color-fg-muted)]'
-      : 'text-[var(--accent-primary)] font-medium'
+      : 'text-[var(--color-accent-fg)] font-medium'
 
   return html`
     <div class="flex items-start gap-3 py-2 px-3 rounded hover:bg-[var(--color-bg-hover)] transition-colors">
@@ -64,7 +64,7 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
         <div class="flex items-center gap-2">
           <code class="text-xs font-mono text-[var(--text-primary)]">${entry.env}</code>
           ${isEnv ? html`
-            <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
+            <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--color-accent-fg)]/10 text-[var(--color-accent-fg)]">custom</span>
           ` : null}
           ${!isEnv && entry.source !== 'default' ? html`
             <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--color-bg-hover)] text-[var(--color-fg-muted)]">${entry.source}</span>
@@ -113,7 +113,7 @@ function CategoryPanel({ name, entries }: { name: string; entries: ConfigEntry[]
           <span class="text-xs text-[var(--color-fg-muted)]">(${filtered.length})</span>
         </div>
         ${customCount > 0 ? html`
-          <span class="text-3xs px-2 py-0.5 rounded-sm bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">
+          <span class="text-3xs px-2 py-0.5 rounded-sm bg-[var(--color-accent-fg)]/10 text-[var(--color-accent-fg)]">
             ${customCount} custom
           </span>
         ` : null}

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -303,7 +303,7 @@ const KEEPER_RUNTIME_ROWS: Array<{
 
 function sourceTone(source: string): string {
   switch (source) {
-    case 'env': return 'border-[var(--accent-primary)]/30 bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]'
+    case 'env': return 'border-[var(--color-accent-fg)]/30 bg-[var(--color-accent-fg)]/10 text-[var(--color-accent-fg)]'
     case 'toml': return 'border-[var(--emerald-28)] bg-[var(--emerald-10)] text-[#bbf7d0]'
     case 'derived': return 'border-[var(--yellow-bright-28)] bg-[var(--yellow-bright-10)] text-[var(--yellow-100)]'
     default: return 'border-[var(--color-border-default)] bg-[var(--white-6)] text-[var(--color-fg-muted)]'


### PR DESCRIPTION
## Summary

Phase G Step 4 (file-disjoint sweep). Final 5 remaining `--accent-primary` callsites swap to canonical `--color-accent-fg`. Closes the `--accent-primary` migration started in CS89.

## Mapping

| File | Sites |
|------|-------|
| `excuse-patterns.ts` | 1 (CTA button) |
| `server-config.ts` | 3 (custom badge + TabHeader) |
| `tools/config-resolution-panel.ts` | 1 (env-source tag class) |
| **Total** | **5** |

`--accent-primary` was undefined at runtime → these 5 elements silently rendered with no border/background color. After this PR they paint correctly via `--color-accent-fg → --accent (#47b8ff)`.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test server-config` → 1/1 pass
- [x] Diff is 1:1 (5 ins / 5 del)