### PR TITLE
feat(sidecar): extract subprocess timeouts to env (SSOT) (#10426)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -785,6 +785,34 @@ module Sidecar = struct
       inline literal that landed in #8919). *)
   let reconcile_backoff_sec =
     get_float ~default:30.0 "MASC_SIDECAR_RECONCILE_BACKOFF_SEC"
+
+  (** Subprocess timeout (seconds) for sidecar control commands —
+      [stop], [tail], and similar quick housekeeping operations.
+
+      Wraps two [Process_eio.run_argv_with_status] sites at
+      [server_routes_http_routes_sidecar.ml:780,835]. Default 5s
+      preserves the inline literals; floor 1s prevents an operator
+      typo from making every control command return "timeout" before
+      the sidecar even handles the signal. *)
+  let control_command_timeout_sec =
+    Float.max 1.0
+      (get_float ~default:5.0 "MASC_SIDECAR_CONTROL_TIMEOUT_SEC")
+
+  (** Subprocess timeout (seconds) for sidecar Python schema
+      generation. Wraps [Process_eio.run_argv_with_status] at
+      [server_routes_http_routes_sidecar.ml:882]. Default 10s
+      preserves the inline literal; this path runs Python interp +
+      schema introspection so it needs more headroom than the
+      lightweight control commands. Floor 1s.
+
+      Must satisfy [schema_generation > control_command] — schema
+      gen is strictly heavier than control commands, so an operator
+      lowering schema budget below the control budget would silently
+      reorder the implicit precedence and surprise downstream
+      diagnostics. *)
+  let schema_generation_timeout_sec =
+    Float.max 1.0
+      (get_float ~default:10.0 "MASC_SIDECAR_SCHEMA_TIMEOUT_SEC")
 end
 
 (** {1 Internal Safety Configuration} *)

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -777,7 +777,8 @@ let handle_stop state request reqd =
                   (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
             | Ok desired ->
                 let (_status, stdout) =
-                  Process_eio.run_argv_with_status ~timeout_sec:5.0
+                  Process_eio.run_argv_with_status
+                    ~timeout_sec:Env_config_runtime.Sidecar.control_command_timeout_sec
                     [ script; "stop" ]
                 in
                 let trimmed = String.trim stdout in
@@ -832,7 +833,8 @@ let handle_logs state request reqd =
            ])
       else
         let (_status, stdout) =
-          Process_eio.run_argv_with_status ~timeout_sec:5.0
+          Process_eio.run_argv_with_status
+            ~timeout_sec:Env_config_runtime.Sidecar.control_command_timeout_sec
             [ "tail"; "-n"; string_of_int lines; path ]
         in
         let line_list =
@@ -879,7 +881,9 @@ let fetch_schema ?base_path id =
        | Ok sidecar_dir ->
            let argv = python_argv_for sidecar_dir in
            let (status, stdout) =
-             Process_eio.run_argv_with_status ~timeout_sec:10.0 ~cwd:sidecar_dir argv
+             Process_eio.run_argv_with_status
+               ~timeout_sec:Env_config_runtime.Sidecar.schema_generation_timeout_sec
+               ~cwd:sidecar_dir argv
            in
            (match status with
             | Unix.WEXITED 0 ->

--- a/test/dune
+++ b/test/dune
@@ -1785,6 +1785,12 @@
  (modules test_env_config_dashboard_shell_prewarm)
  (libraries masc_test_deps))
 
+; Sidecar subprocess timeout SSOT
+(test
+ (name test_env_config_sidecar_timeouts)
+ (modules test_env_config_sidecar_timeouts)
+ (libraries masc_test_deps))
+
 ; Dashboard execution-surface timeout SSOT
 (test
  (name test_env_config_dashboard_execution_timeouts)

--- a/test/test_env_config_sidecar_timeouts.ml
+++ b/test/test_env_config_sidecar_timeouts.ml
@@ -1,0 +1,86 @@
+(** Pin the {!Env_config_runtime.Sidecar} subprocess timeout
+    contract. Three values were extracted from inline literals at
+    [server_routes_http_routes_sidecar.ml]:
+
+    - 780  5.0   → control_command_timeout_sec ([stop])
+    - 835  5.0   → control_command_timeout_sec ([tail])
+    - 884  10.0  → schema_generation_timeout_sec (Python schema gen)
+
+    The two [5.0] literals shared a value because both drive
+    quick housekeeping subprocesses; collapse to one knob. The
+    [10.0] is a *different intent* (Python interpreter + schema
+    introspection) so it stays a separate accessor.
+
+    Properties pinned:
+
+    1. Defaults preserve pre-extraction literals.
+    2. schema_generation > control_command — the schema path is
+       strictly heavier (Python startup + introspection); operators
+       lowering schema budget below control budget would silently
+       reorder the implicit precedence and surprise downstream
+       diagnostics ("schema timed out faster than tail?").
+    3. Floor 1.0s on both — sub-second budgets cannot capture even
+       a trivial sidecar subprocess startup. *)
+
+open Alcotest
+
+module S = Env_config_runtime.Sidecar
+
+let approx = float 0.001
+
+let test_default_control_command () =
+  check approx
+    "control_command_timeout_sec default (was inline 5.0 ×2)"
+    5.0 S.control_command_timeout_sec
+
+let test_default_schema_generation () =
+  check approx
+    "schema_generation_timeout_sec default (was inline 10.0)"
+    10.0 S.schema_generation_timeout_sec
+
+let test_schema_exceeds_control () =
+  check bool
+    "schema_generation_timeout_sec MUST exceed control_command_timeout_sec \
+     (else operator lowering schema budget would reorder implicit precedence)"
+    true
+    (S.schema_generation_timeout_sec > S.control_command_timeout_sec)
+
+let test_floor () =
+  check bool
+    "control_command_timeout_sec satisfies the documented >= 1.0 floor"
+    true
+    (S.control_command_timeout_sec >= 1.0);
+  check bool
+    "schema_generation_timeout_sec satisfies the documented >= 1.0 floor"
+    true
+    (S.schema_generation_timeout_sec >= 1.0)
+
+let test_smoke_call_sites_compile () =
+  let _ = S.control_command_timeout_sec in
+  let _ = S.schema_generation_timeout_sec in
+  check bool "both accessors are reachable" true true
+
+let () =
+  run "env_config_sidecar_timeouts"
+    [
+      ( "defaults preserve pre-extraction literals",
+        [
+          test_case "control_command = 5.0" `Quick test_default_control_command;
+          test_case "schema_generation = 10.0" `Quick
+            test_default_schema_generation;
+        ] );
+      ( "ordering invariant",
+        [
+          test_case "schema > control" `Quick
+            test_schema_exceeds_control;
+        ] );
+      ( "floor",
+        [
+          test_case ">= 1.0s on both" `Quick test_floor;
+        ] );
+      ( "API surface",
+        [
+          test_case "both accessors reachable" `Quick
+            test_smoke_call_sites_compile;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Three inline subprocess timeout literals in `lib/server/server_routes_http_routes_sidecar.ml` collapsed into two semantic accessors on `Env_config_runtime.Sidecar`. Continues the #10426 audit cascade.

| accessor | default | call sites |
|---|---|---|
| `control_command_timeout_sec` | 5.0 | line 780 (stop), line 835 (tail) |
| `schema_generation_timeout_sec` | 10.0 | line 884 (Python schema gen) |

The two `5.0` literals shared a value because both drive lightweight control subprocesses; collapsed to one knob. The `10.0` literal is a *different intent* (Python interp + introspection) and stays separate — same lesson from #10880 (shell vs. shell_light).

## Why

The "기다려야 할 부분을 안 기다리는" axis: a slow Python startup (e.g. cold venv) needs schema generation budget independent of control commands. Without the SSOT, an operator who lowered the global to fix a flaky stop call would also starve schema generation.

## Test Plan

- [x] `opam exec -- dune build @check` (clean)
- [x] `dune exec test/test_env_config_sidecar_timeouts.exe` — all pass
- [ ] CI: Lint + Build green

Pinned properties:
1. Defaults preserve pre-extraction literals exactly.
2. `schema > control` invariant — schema generation spawns a Python interpreter, which dominates the latency tail of control ops.

## Cascade Progress (#10426)

Landed: Process_eio default (#10889), KeeperBootstrap (#10957), Dashboard mission/shell/render (#10880), Dashboard execution (#10886), shell prewarm inner/outer (#10797).

In flight: voice timeouts (#11045), autoresearch git read/write (#11043), this PR.
