### PR TITLE
feat(dashboard): fix --text-primary undefined references in server-config (CS98)

### DIFF
--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -62,7 +62,7 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
     <div class="flex items-start gap-3 py-2 px-3 rounded hover:bg-[var(--color-bg-hover)] transition-colors">
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
-          <code class="text-xs font-mono text-[var(--text-primary)]">${entry.env}</code>
+          <code class="text-xs font-mono text-[var(--color-fg-secondary)]">${entry.env}</code>
           ${isEnv ? html`
             <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
           ` : null}
@@ -109,7 +109,7 @@ function CategoryPanel({ name, entries }: { name: string; entries: ConfigEntry[]
       >
         <div class="flex items-center gap-2">
           <span class="text-xs text-[var(--color-fg-muted)]">${isExpanded ? '\u25BC' : '\u25B6'}</span>
-          <span class="text-sm font-medium text-[var(--text-primary)] capitalize">${name}</span>
+          <span class="text-sm font-medium text-[var(--color-fg-secondary)] capitalize">${name}</span>
           <span class="text-xs text-[var(--color-fg-muted)]">(${filtered.length})</span>
         </div>
         ${customCount > 0 ? html`
@@ -137,19 +137,19 @@ function ServerMeta() {
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
         <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">버전</div>
-        <div class="text-sm font-mono text-[var(--text-primary)]">${server.version}</div>
+        <div class="text-sm font-mono text-[var(--color-fg-secondary)]">${server.version}</div>
       </div>
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
         <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">가동시간</div>
-        <div class="text-sm font-mono text-[var(--text-primary)]">${formatUptime(server.uptime_seconds)}</div>
+        <div class="text-sm font-mono text-[var(--color-fg-secondary)]">${formatUptime(server.uptime_seconds)}</div>
       </div>
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
         <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">OCaml</div>
-        <div class="text-sm font-mono text-[var(--text-primary)]">${server.ocaml_version}</div>
+        <div class="text-sm font-mono text-[var(--color-fg-secondary)]">${server.ocaml_version}</div>
       </div>
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
         <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">PID</div>
-        <div class="text-sm font-mono text-[var(--text-primary)]">${server.pid}</div>
+        <div class="text-sm font-mono text-[var(--color-fg-secondary)]">${server.pid}</div>
       </div>
     </div>
   `
@@ -177,7 +177,7 @@ export function ServerConfig() {
           onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
         />
         <button
-          class="px-3 py-1.5 text-xs rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)] text-[var(--color-fg-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
+          class="px-3 py-1.5 text-xs rounded bg-[var(--bg-surface)] border border-[var(--color-border-divider)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors"
           onClick=${() => void refreshServerConfig()}
           disabled=${loading}
         >


### PR DESCRIPTION
## Summary

Phase G Step 4 hot-fix. Swap 7 sites of legacy `var(--text-primary)` (undefined at runtime → silent no-color bug) to canonical `var(--color-fg-secondary)` which resolves to `var(--text-strong)` #eaf1ff via the variables.css alias.

## Why

`--text-primary` is defined only in `dashboard/design-system/source_styles/tokens.css` (the SPEC canvas, not loaded at runtime). At runtime it cascades to no-value, so 7 server-config text elements were silently rendering with no color (inheriting whatever ancestor set).

After this PR they paint in the dashboard's bright primary text color.

## Mapping (1:1)

| Legacy | Canonical | Sites |
|--------|-----------|-------|
| `var(--text-primary)` | `var(--color-fg-secondary)` | 7 |

## Note on alias inversion

`--color-fg-primary`/`secondary` mapping in `variables.css` is currently SPEC-inverted (primary→`--text-body`, secondary→`--text-strong`). This PR uses `--color-fg-secondary` because it today resolves to bright text — semantically what `--text-primary` wanted.

A future inversion-fix PR would route `--color-fg-secondary` to `--text-body` (dimmer); those callsites would be swapped to `--color-fg-primary` in that same PR.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test server-config` → 1/1 pass
- [x] Diff is 1:1 (7 ins / 7 del)