### PR TITLE
i18n(dashboard): localize 6 connector-status liveness dot strings (round-93)

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -757,15 +757,15 @@ function ConnectorLivePanel({
     label: 'Browser → Server',
     state: connectorError ? 'down' : 'ok',
     detail: connectorError ? 'gate fetch failed' : 'live',
-    hint: connectorError ? `Check server at ${connector?.gate_base_url || 'localhost:8935'}` : '',
+    hint: connectorError ? `${connector?.gate_base_url || 'localhost:8935'} 에서 서버 확인` : '',
   }
   const serverDot: LivenessDot = (() => {
     if (!connector?.available) {
       return {
         label: 'Server → Sidecar',
         state: 'down',
-        detail: 'no status.json yet',
-        hint: `Run ./run.sh from sidecars/${connectorId}-bot/`,
+        detail: '아직 status.json 없음',
+        hint: `sidecars/${connectorId}-bot/ 에서 ./run.sh 실행`,
       }
     }
     if (connector.stale) {
@@ -788,7 +788,7 @@ function ConnectorLivePanel({
       return {
         label: `Sidecar → ${connectorName}`,
         state: 'unknown',
-        detail: 'sidecar offline',
+        detail: 'sidecar 오프라인',
         hint: '',
       }
     }
@@ -805,14 +805,14 @@ function ConnectorLivePanel({
       return {
         label: `Sidecar → ${connectorName}`,
         state: 'warn',
-        detail: 'stale heartbeat',
+        detail: 'heartbeat stale',
         hint: 'Sidecar 프로세스 중단 가능성',
       }
     }
     return {
       label: `Sidecar → ${connectorName}`,
       state: 'warn',
-      detail: 'gateway link not yet up',
+      detail: 'gateway link 미수립',
       hint: '토큰 및 네트워크 도달성 확인',
     }
   })()


### PR DESCRIPTION
## Summary

`connector-status.ts` 의 `serverDot` / `sidecarDot` LivenessDot factory 안에서 한국어 hint 두 개와 영어 detail/hint 6개가 섞여있던 inconsistency 해소.

## Changed strings

| line | field | Before | After |
|---|---|---|---|
| 760 | hint | `Check server at ${url}` | `${url} 에서 서버 확인` |
| 767 | detail | `'no status.json yet'` | `'아직 status.json 없음'` |
| 768 | hint | `Run ./run.sh from sidecars/${id}-bot/` | `sidecars/${id}-bot/ 에서 ./run.sh 실행` |
| 791 | detail | `'sidecar offline'` | `'sidecar 오프라인'` |
| 808 | detail | `'stale heartbeat'` | `'heartbeat stale'` (mixed-language anchor token reorder) |
| 815 | detail | `'gateway link not yet up'` | `'gateway link 미수립'` |

## Pre-existing Korean siblings

| line | Korean (untouched) |
|---|---|
| 776 | `'Sidecar heartbeat 중단 — 로그 확인'` |
| 783 | `''` (no hint when ok) |
| 816 | `'토큰 및 네트워크 도달성 확인'` |

이번 round 후 같은 두 factory 내 모든 hint/detail 이 한국어 (또는 빈 string).

## Domain term policy

`status.json`, `run.sh`, `sidecars/`, `sidecar`, `gateway link`, `heartbeat` 보존 — 도메인/SSOT 용어.

## Scope

- 1 파일, 6줄.
- `connector-status.test.ts` 에 toContain/toBe assertion 0건 — `it('shows sidecar-off empty state when no bindings and sidecar offline'…)` 의 description literal 은 test runner 의 description 만 사용 (assertion content 아님).
