### PR TITLE
fix(keeper): warn once when sandbox credential mounts skipped

### DIFF
--- a/lib/keeper/host_config_provider.ml
+++ b/lib/keeper/host_config_provider.ml
@@ -7,6 +7,92 @@ let mount_if_present ~host ~container : Credential_provider.ro_mount list =
   else if not (Sys.file_exists host) then []
   else [ { host; container } ]
 
+(* ── Skipped credential mount warn dedup ───────────────────────
+
+   [mount_if_present] silently drops mounts whose host path is empty
+   or missing.  When called for the 3 critical credential mounts
+   (gh CLI config, gitconfig, ssh dir) the keeper subprocess then
+   runs inside docker without the corresponding credential; [gh pr
+   create] returns 401 / [git push] returns permission denied; the
+   keeper turn output shows only the raw CLI error.
+
+   Symmetric to #11025 (sandbox GH_TOKEN env warn): function exists,
+   policy exists, single missing log line at the composition layer
+   leaves operators blind.  Per-keeper one-shot WARN with explicit
+   list of which paths were skipped + reason (empty/not_found), plus
+   a Prometheus counter labelled by keeper + mount + reason.
+
+   Fires at [compose_ro_mounts] (one observation point per keeper
+   sandbox launch), not inside [mount_if_present] which is exposed
+   via [For_testing] and must stay pure. *)
+let mount_skip_warn_emitted : (string, unit) Hashtbl.t = Hashtbl.create 16
+let mount_skip_warn_mu = Eio.Mutex.create ()
+
+type mount_attempt = {
+  label : string;
+  host : string;
+  status : [ `Mounted | `Empty | `Not_found ];
+}
+
+let classify_mount_attempt ~label ~host : mount_attempt =
+  let status =
+    if host = "" then `Empty
+    else if not (Sys.file_exists host) then `Not_found
+    else `Mounted
+  in
+  { label; host; status }
+
+let warn_mount_skips_if_any ~keeper_name (attempts : mount_attempt list) =
+  let skipped =
+    List.filter
+      (fun a -> match a.status with `Mounted -> false | _ -> true)
+      attempts
+  in
+  if skipped = [] then ()
+  else begin
+    let should_emit =
+      Eio.Mutex.use_rw ~protect:true mount_skip_warn_mu (fun () ->
+        if Hashtbl.mem mount_skip_warn_emitted keeper_name then false
+        else begin
+          Hashtbl.add mount_skip_warn_emitted keeper_name ();
+          true
+        end)
+    in
+    if should_emit then begin
+      List.iter
+        (fun a ->
+          let reason =
+            match a.status with
+            | `Empty -> "empty"
+            | `Not_found -> "not_found"
+            | `Mounted -> "mounted"
+          in
+          Prometheus.inc_counter
+            "masc_keeper_credential_mount_skipped_total"
+            ~labels:[ ("keeper", keeper_name); ("mount", a.label);
+                      ("reason", reason) ]
+            ())
+        skipped;
+      let pp_skip a =
+        let r = match a.status with
+          | `Empty -> "empty"
+          | `Not_found -> "not_found"
+          | `Mounted -> "mounted"
+        in
+        Printf.sprintf "%s=%s(%s)" a.label
+          (if a.host = "" then "<empty>" else a.host) r
+      in
+      Log.Keeper.warn
+        "%s: sandbox credential mount(s) skipped — keeper inside docker \
+         will be missing the corresponding host credential.  Skipped: \
+         [%s].  Resolution: ensure host paths exist or override via \
+         [Env_config_sandbox.Auth_paths] env knobs.  See \
+         [host_config_provider.ml compose_ro_mounts]."
+        keeper_name
+        (String.concat "; " (List.map pp_skip skipped))
+    end
+  end
+
 (* RFC-0008 PR-1: env composition mirrors the inline block at
    keeper_shell_docker.ml:271-329 (pre-extraction).  No new env keys
    are introduced; this is the same surface, concentrated. *)
@@ -25,7 +111,7 @@ let compose_env ~git_author_name ~git_author_email =
   ]
   @ Env_git_noninteractive.env
 
-let compose_ro_mounts (kb : Keeper_gh_env.keeper_binding) =
+let compose_ro_mounts ?keeper_name (kb : Keeper_gh_env.keeper_binding) =
   let gh_creds =
     match kb.gh_config_dir with
     | Some dir -> dir
@@ -33,6 +119,14 @@ let compose_ro_mounts (kb : Keeper_gh_env.keeper_binding) =
   in
   let gitconfig = Env_config_sandbox.Auth_paths.gitconfig () in
   let ssh_dir = Env_config_sandbox.Auth_paths.ssh_dir () in
+  let attempts = [
+    classify_mount_attempt ~label:"gh_creds" ~host:gh_creds;
+    classify_mount_attempt ~label:"gitconfig" ~host:gitconfig;
+    classify_mount_attempt ~label:"ssh_dir" ~host:ssh_dir;
+  ] in
+  Option.iter
+    (fun name -> warn_mount_skips_if_any ~keeper_name:name attempts)
+    keeper_name;
   mount_if_present ~host:gh_creds
     ~container:(Filename.concat cred_root ".config/gh")
   @ mount_if_present ~host:gitconfig
@@ -69,7 +163,7 @@ let resolve ~config ~identity:keeper_name =
         resolve_git_identity kb ~keeper_name
       in
       let env = compose_env ~git_author_name ~git_author_email in
-      let ro_mounts = compose_ro_mounts kb in
+      let ro_mounts = compose_ro_mounts ~keeper_name kb in
       let metadata = metadata_of_binding kb in
       Ok
         Credential_provider.{


### PR DESCRIPTION
## Summary

SSOT pair to #11025 — same dead-end anti-pattern at the kindred composition layer.

`Host_config_provider.compose_ro_mounts` composes 3 read-only credential mounts for the keeper sandbox:

| Label | Host path | In-container purpose |
|---|---|---|
| `gh_creds` | gh CLI config dir | `gh pr create` auth |
| `gitconfig` | `~/.gitconfig` | git author / safe.directory |
| `ssh_dir` | `~/.ssh/` | `git push` over SSH |

Each goes through `mount_if_present`, which silently drops any mount whose host path is empty or doesn't exist on the filesystem. When that happens, the keeper subprocess inside docker runs **without** the corresponding credential — `gh pr create` returns 401 / `git push` returns permission denied — and operators see only the raw CLI error from the turn output. No signal from masc-mcp pointing at *which* of the 3 mounts went missing.

This is the **5th instance of the dead-end anti-pattern** found this session:

| # | PR | Pattern instance |
|---|---|---|
| 1 | #10973 | `expire_stale` never called → HITL death-spiral |
| 2 | #10956/#11001 | worktree cleanup only on Done_action / missing on Cancel/Release |
| 3 | #10962 | skip reasons buried in Prometheus aggregates |
| 4 | #11025 | `gh_token=""` silent fallthrough at the env layer |
| 5 | #11042 (this PR) | `mount_if_present` silent skip at the composition layer |

## What this PR does

1. New per-keeper one-shot WARN at `compose_ro_mounts` listing which labelled mounts were skipped and why (`empty` / `not_found`).
2. New Prometheus counter `masc_keeper_credential_mount_skipped_total{keeper, mount, reason}` for fleet aggregation.
3. `mount_if_present` stays pure — still exposed via `For_testing`, all 3 existing white-box tests pass unchanged.
4. The warn fires at the composition layer where `keeper_name` is available; `compose_ro_mounts` takes a new optional `?keeper_name` parameter.

## Behaviour change

- Before: silent on missing host paths. Keeper boots into docker without credentials, fails on first push/pr, operator must guess.
- After: at most one structured WARN per keeper per server lifetime when any expected mount is missing, plus per-(keeper, mount, reason) Prometheus counter. No change to argv, no change to ro_mounts list shape, no change to which keepers can/cannot use git_creds.

## Verification

- `DUNE_CACHE=disabled dune build` — green.
- `dune exec test/test_credential_provider.exe` — 9/9 PASS, including all 3 `mount_if_present` white-box tests.
- Field validation: after merge + restart, watch `masc_keeper_credential_mount_skipped_total` to identify which keepers are launching without which credentials.

## Test plan

- [ ] Build green
- [ ] `test_credential_provider` 9/9 PASS
- [ ] CI Lint + Health pass
- [ ] After merge: monitor `masc_keeper_credential_mount_skipped_total` on production fleet for the first hour.

Refs: #11025 (env-layer GH_TOKEN warn — kindred fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)