### PR TITLE
feat(dashboard): adopt canonical accent token in 6 files (CS99)

### DIFF
--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -59,7 +59,7 @@ export function resetAutoresearchState(): void {
 function statusColor(status: string): string {
   switch (status) {
     case 'running': return 'text-[var(--ok)]'
-    case 'completed': return 'text-[var(--accent)]'
+    case 'completed': return 'text-[var(--color-accent-fg)]'
     case 'stopped': return 'text-[var(--warn)]'
     case 'error': return 'text-[var(--bad)]'
     default: return 'text-[var(--color-fg-muted)]'
@@ -274,7 +274,7 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
           placeholder="가설 / 판정 / # 필터"
           aria-label="사이클 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
         />
       </div>
       ${isFiltering && visibleCycles.length === 0

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -444,7 +444,7 @@ function runtimeActionTone(action: FleetRuntimeAction): string {
   if (action.action_type === 'keeper_recover') {
     return 'text-[var(--warn)]'
   }
-  return 'text-[var(--accent)]'
+  return 'text-[var(--color-accent-fg)]'
 }
 
 function runtimeActionsForSnapshot(

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1151,7 +1151,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
               placeholder="슬롯 이름 / source / gate 필터"
               aria-label="훅 슬롯 필터"
               onInput=${(e: Event) => { hookFilterQuery.value = (e.target as HTMLInputElement).value }}
-              class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--accent)]"
+              class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
             />
           </div>
           ${isFiltering && visibleEntries.length === 0 && allEntries.length > 0
@@ -1167,7 +1167,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                     ${(slot.gates ?? slot.effects ?? slot.features ?? []).length > 0 ? html`
                       <div class="flex flex-wrap gap-1 mt-1">
                         ${(slot.gates ?? slot.effects ?? slot.features ?? []).map((d: string) => html`
-                          <span class="text-3xs px-1.5 py-0.5 rounded ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--color-fg-disabled)]' : 'bg-[var(--accent-10)] text-[var(--accent)] opacity-80'}">${d}</span>
+                          <span class="text-3xs px-1.5 py-0.5 rounded ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--color-fg-disabled)]' : 'bg-[var(--accent-10)] text-[var(--color-accent-fg)] opacity-80'}">${d}</span>
                         `)}
                       </div>
                     ` : null}

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -19,7 +19,7 @@ function KeeperModelChip({ keeper }: { keeper: Keeper }) {
   if (!display) return null
   return html`
     <span
-      class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-mono bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-20)]"
+      class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-mono bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-20)]"
       title=${`${display.label}: ${display.value}`}
     >${display.value}</span>
   `

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -152,7 +152,7 @@ function fmtValue(value: number, type: string, name: string): string {
 
 function typeBadge(type: string): ReturnType<typeof html> {
   const colors: Record<string, string> = {
-    counter: 'bg-[var(--accent-10)] text-[var(--accent)]',
+    counter: 'bg-[var(--accent-10)] text-[var(--color-accent-fg)]',
     gauge: 'bg-[var(--ok-10)] text-[var(--ok)]',
     summary: 'bg-[var(--warn-10)] text-[var(--warn)]',
   }
@@ -165,7 +165,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
   return html`<span class="ml-2 inline-flex gap-1 flex-wrap">${entries.map(([k, v]) => {
     if (k === 'keeper') {
       return html`<button
-        class="rounded bg-[var(--accent-10)] px-1 py-0.5 text-3xs text-[var(--accent)] font-mono hover:bg-[var(--accent-10)] hover:text-[var(--accent)] transition-colors cursor-pointer"
+        class="rounded bg-[var(--accent-10)] px-1 py-0.5 text-3xs text-[var(--color-accent-fg)] font-mono hover:bg-[var(--accent-10)] hover:text-[var(--color-accent-fg)] transition-colors cursor-pointer"
         title="키퍼 상세 보기"
         aria-label="키퍼 상세 보기"
         onClick=${(e: Event) => {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -87,12 +87,12 @@ const CONDENSED_CATEGORY_META: Record<TelemetryCondensedCategory, {
   heartbeat: {
     label: '하트비트',
     icon: 'H',
-    color: 'text-[var(--accent)]',
+    color: 'text-[var(--color-accent-fg)]',
   },
   polling: {
     label: '폴링 / 무동작',
     icon: 'P',
-    color: 'text-[var(--accent)]',
+    color: 'text-[var(--color-accent-fg)]',
   },
 }
 


### PR DESCRIPTION
## Summary

Phase G Step 4 (file-disjoint sweep). 10 raw `var(--accent)` sites across 6 files swap to canonical `var(--color-accent-fg)` which aliases `var(--accent)` (1:1, identical color).

## Files & sites

| File | Sites |
|------|-------|
| `autoresearch.ts` | 2 |
| `fleet-fsm-matrix.ts` | 1 |
| `keeper-config-panel.ts` | 2 |
| `keeper-detail-shell.ts` | 1 |
| `prometheus-metrics.ts` | 2 |
| `telemetry-unified.ts` | 2 |
| **Total** | **10** |

File-disjoint with in-flight CS96 (feature-health) / CS97 (excuse-patterns, server-config, config-resolution-panel) / CS98 (server-config).

## Test plan

- [x] `pnpm typecheck` green
- [x] Pure 1:1 alias swap — no visual diff
- [x] Diff is 1:1 (10 ins / 10 del)