### PR TITLE
fix(keeper-watchdog): Phase 2 — auto-pause on stale termination storm (closes #10765)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -36,6 +36,13 @@ type failure_reason =
   | Heartbeat_consecutive_failures of int
   | Turn_consecutive_failures of int
   | Stale_turn_timeout of float
+  | Stale_termination_storm of { count : int }
+      (** #10765 Phase 2: latched when [record_stale_termination] returns a
+          window count >= [escalation_threshold]. The supervisor's
+          [`Crashed] branch checks this variant and skips [to_restart],
+          persisting [meta.paused = true] instead so an operator must
+          investigate the underlying cascade/provider/fd issue before
+          resuming the keeper. *)
   | Ambiguous_partial_commit of ambiguous_partial_commit
   | Fiber_unresolved
   | Exception of string
@@ -51,6 +58,8 @@ let failure_reason_to_string = function
       Printf.sprintf "turn_consecutive_failures(%d)" n
   | Stale_turn_timeout sec ->
       Printf.sprintf "stale_turn_timeout(%.0fs)" sec
+  | Stale_termination_storm { count } ->
+      Printf.sprintf "stale_termination_storm(count=%d)" count
   | Ambiguous_partial_commit { kind; detail } ->
       Printf.sprintf "ambiguous_partial_commit(%s:%s)"
         (ambiguous_partial_commit_kind_to_string kind)
@@ -71,6 +80,7 @@ let failure_reason_cohort_key = function
   | Some (Heartbeat_consecutive_failures _) -> "heartbeat_failures"
   | Some (Turn_consecutive_failures _) -> "turn_failures"
   | Some (Stale_turn_timeout _) -> "stale_turn_timeout"
+  | Some (Stale_termination_storm _) -> "stale_termination_storm"
   | Some (Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
   | Some Fiber_unresolved -> "fiber_unresolved"
   | Some (Exception _) -> "exception"

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -26,6 +26,13 @@ type failure_reason =
   | Heartbeat_consecutive_failures of int
   | Turn_consecutive_failures of int
   | Stale_turn_timeout of float
+  | Stale_termination_storm of { count : int }
+      (** #10765 Phase 2: latched when [record_stale_termination] returns a
+          window count >= [escalation_threshold]. The supervisor's
+          [`Crashed] branch checks this variant and skips [to_restart],
+          persisting [meta.paused = true] instead so an operator must
+          investigate the underlying cascade/provider/fd issue before
+          resuming the keeper. *)
   | Ambiguous_partial_commit of ambiguous_partial_commit
   | Fiber_unresolved
   | Exception of string

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -222,12 +222,24 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    "masc_keeper_stale_termination_threshold_breached_total"
                    ~labels:[ ("keeper", meta.name) ]
                    ();
+                 (* Phase 2 (#10765): override the [Stale_turn_timeout] latch
+                    set above with the storm-pattern variant so the
+                    supervisor's [`Crashed] branch can route this entry to
+                    auto-pause + [meta.paused = true] persistence instead of
+                    blindly enqueuing it for restart.  This breaks the
+                    restart-loop-back-to-stale cycle observed when the
+                    underlying cascade/provider/fd issue persists across
+                    restarts (24h evidence: 116 events, single keeper 13×). *)
+                 Keeper_registry.set_failure_reason ~base_path meta.name
+                   (Some (Keeper_registry.Stale_termination_storm
+                            { count = window_count }));
                  Log.Keeper.error
                    "%s: STALE-TERMINATION THRESHOLD BREACHED — %d \
-                    terminations in last %.0fs (threshold=%d). The \
-                    supervisor will continue to restart this keeper, \
-                    but the underlying root cause (cascade dead, fd \
-                    leak, provider auth, etc.) needs operator review. \
+                    terminations in last %.0fs (threshold=%d). \
+                    Phase 2: keeper will be auto-paused; supervisor will \
+                    NOT restart until an operator investigates the \
+                    underlying root cause (cascade dead, fd leak, \
+                    provider auth, etc.) and resumes the keeper. \
                     See issue #10765."
                    meta.name window_count termination_window_sec
                    escalation_threshold

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -151,12 +151,17 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
               crash recovery instead of a clean stop. When the stale
               watchdog sets fiber_stop + Stale_turn_timeout, the heartbeat
               loop exits normally but the supervisor must treat this as a
-              crash so sweep_and_recover restarts the keeper. *)
+              crash so sweep_and_recover restarts the keeper.
+              #10765 Phase 2: [Stale_termination_storm] also funnels through
+              the crash path, but [sweep_and_recover]'s [`Crashed] branch
+              detects this variant and routes to auto-pause instead of
+              [to_restart], breaking the restart-loop-back-to-stale cycle. *)
            let watchdog_triggered =
              match Keeper_registry.get ~base_path meta.name with
              | Some e -> (
                  match e.last_failure_reason with
-                 | Some (Keeper_registry.Stale_turn_timeout _) -> true
+                 | Some (Keeper_registry.Stale_turn_timeout _)
+                 | Some (Keeper_registry.Stale_termination_storm _) -> true
                  | _ -> false)
              | None -> false
            in
@@ -765,6 +770,56 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
     to_restart
   end
 
+(** #10765 Phase 2: persist [meta.paused = true] for a keeper whose stale
+    watchdog detected a termination storm (window count >= threshold).  The
+    caller must skip enqueuing the entry into [to_restart] so the supervisor
+    no longer auto-restarts the keeper into the same dead-cascade environment.
+
+    Ordering rationale: write meta first, then publish lifecycle + counter.
+    A failed meta write is logged but does not abort the pause path — the
+    in-memory [last_failure_reason] still routes the next sweep through this
+    branch, so the supervisor remains correct even if the disk write loses
+    a CAS race.  The keeper would re-resume on a server restart in that
+    edge case, but that is strictly less bad than the pre-Phase-2 baseline
+    (continuous restart loop). *)
+let handle_stale_storm_pause (ctx : _ context)
+    (entry : Keeper_registry.registry_entry) ~count =
+  (match read_meta ctx.config entry.name with
+   | Ok (Some meta) ->
+       (match
+          write_meta_with_merge
+            ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+            ctx.config { meta with paused = true }
+        with
+        | Ok () -> ()
+        | Error err ->
+            Log.Keeper.warn
+              "%s: stale_storm pause meta write failed (in-memory \
+               failure_reason still gates restart, but persisted state \
+               will not survive server restart): %s"
+              entry.name err)
+   | Ok None ->
+       Log.Keeper.warn
+         "%s: stale_storm pause: meta missing, cannot persist paused=true"
+         entry.name
+   | Error err ->
+       Log.Keeper.warn
+         "%s: stale_storm pause read_meta failed: %s"
+         entry.name err);
+  Prometheus.inc_counter
+    "masc_keeper_stale_storm_paused_total"
+    ~labels:[ ("keeper", entry.name) ]
+    ();
+  publish_phase_lifecycle
+    ~phase:Keeper_state_machine.Paused
+    entry.name
+    (Printf.sprintf "stale_termination_storm count=%d" count) ();
+  Log.Keeper.error
+    "%s: STALE STORM AUTO-PAUSED (count=%d in 6h window). \
+     Operator must investigate cascade/provider/fd issue and \
+     resume the keeper manually. See issue #10765."
+    entry.name count
+
 let sweep_and_recover (ctx : _ context) =
   let now = Time_compat.now () in
   let max_restarts = Runtime_params.get Governance_registry.keeper_supervisor_max_restarts in
@@ -800,13 +855,27 @@ let sweep_and_recover (ctx : _ context) =
       | Some `Stopped ->
           to_unregister := entry :: !to_unregister
       | Some (`Crashed msg) ->
-          if entry.restart_count >= max_restarts then
-            to_mark_dead := (entry, msg) :: !to_mark_dead
-          else begin
-            let delay = backoff_delay entry.restart_count in
-            if now -. entry.last_restart_ts >= delay then
-              to_restart := (entry, msg) :: !to_restart
-          end)
+          (match entry.last_failure_reason with
+           | Some (Keeper_registry.Stale_termination_storm { count }) ->
+               (* #10765 Phase 2: skip [to_restart] AND in-memory unregister.
+                  The watchdog detected a termination storm (>= escalation_
+                  threshold within the 6h window).  [handle_stale_storm_pause]
+                  persists [meta.paused = true] so reconcile + future sweeps
+                  honor the pause across server restarts; we then add the
+                  entry to [to_unregister] so the in-memory registry slot is
+                  cleared and subsequent sweep ticks within the same server
+                  do NOT re-fire the storm-pause path (counter must increment
+                  once per storm, not once per sweep tick). *)
+               handle_stale_storm_pause ctx entry ~count;
+               to_unregister := entry :: !to_unregister
+           | _ ->
+               if entry.restart_count >= max_restarts then
+                 to_mark_dead := (entry, msg) :: !to_mark_dead
+               else begin
+                 let delay = backoff_delay entry.restart_count in
+                 if now -. entry.last_restart_ts >= delay then
+                   to_restart := (entry, msg) :: !to_restart
+               end))
   ) entries;
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
     Keeper_registry.unregister ~base_path entry.name

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -368,6 +368,154 @@ let test_max_restarts_exhaustion_emits_dead_alert () =
       check bool "keeper phase advanced to Dead"
         true (phase = Masc_mcp.Keeper_state_machine.Dead))
 
+(* ── Phase 2 (#10765): stale-termination storm auto-pause ──────── *)
+
+(* Reproduces the Mode A failure pattern from 2026-04-27 fleet observation:
+   keeper proactive turn fails (cascade dead / oas_timeout_budget) → stale
+   watchdog kills fiber → supervisor restarts → 30 min later same stale →
+   restart loop with no operator-actionable signal beyond log ERROR.
+
+   With Phase 2 latched as last_failure_reason = Stale_termination_storm,
+   sweep_and_recover must:
+   1. Skip [to_restart] enqueue (the regression we are preventing).
+   2. Persist [meta.paused = true] on disk so reconcile + future sweeps
+      respect the pause across server restarts.
+   3. Increment [masc_keeper_stale_storm_paused_total] for observability.
+   4. Leave [restart_count] unchanged (storm is not a restart attempt). *)
+let test_stale_storm_pause_skips_restart () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
+      let name = "stale-storm-keeper" in
+      let meta = make_meta name in
+      (match KT.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register ~base_path:config.base_path name meta in
+      Eio.Promise.resolve reg.done_r (`Crashed "synthetic stale storm");
+      (* [restore_supervisor_state] resets [last_failure_reason] to [None],
+         so it MUST run before [set_failure_reason] (otherwise the storm
+         latch is wiped and the supervisor sweeps the entry through the
+         default crash path).  Order matters here. *)
+      Reg.restore_supervisor_state ~base_path:config.base_path name
+        ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
+      Reg.set_failure_reason ~base_path:config.base_path name
+        (Some (Reg.Stale_termination_storm { count = 5 }));
+      let baseline_pause =
+        Masc_mcp.Prometheus.metric_total "masc_keeper_stale_storm_paused_total"
+      in
+      let baseline_dead =
+        Masc_mcp.Prometheus.metric_total
+          Masc_mcp.Prometheus.metric_keeper_dead_total
+      in
+      let ctx : _ KT.context =
+        {
+          config;
+          agent_name = "supervisor";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      Sup.sweep_and_recover ctx;
+      let after_pause =
+        Masc_mcp.Prometheus.metric_total "masc_keeper_stale_storm_paused_total"
+      in
+      let after_dead =
+        Masc_mcp.Prometheus.metric_total
+          Masc_mcp.Prometheus.metric_keeper_dead_total
+      in
+      check (float 0.001) "stale_storm_paused counter incremented by 1"
+        (baseline_pause +. 1.0) after_pause;
+      check (float 0.001) "dead counter NOT incremented (storm is not death)"
+        baseline_dead after_dead;
+      (* meta.paused must be true on disk so reconcile + future sweeps
+         honor the pause across server restarts. *)
+      (match KT.read_meta config name with
+       | Ok (Some m) ->
+           check bool "meta.paused = true after storm pause"
+             true m.paused
+       | Ok None -> fail "meta missing after storm pause"
+       | Error err -> fail ("read_meta failed: " ^ err));
+      (* In-memory registry entry is unregistered so subsequent sweeps do
+         NOT re-fire the storm-pause path within the same server instance.
+         Reconcile_keepalive_keepers will skip this keeper on its next pass
+         because [meta.paused = true]. *)
+      check bool "registry entry unregistered after storm pause"
+        false (Reg.is_registered ~base_path:config.base_path name))
+
+(* Regression guard: a `Crashed entry whose last_failure_reason is NOT a
+   storm must still flow through the existing restart-or-mark-dead branch.
+   Verifies the new gate is variant-specific, not a blanket short-circuit. *)
+let test_non_storm_crashed_restarts_normally () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
+      let name = "non-storm-keeper" in
+      let meta = make_meta name in
+      (match KT.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register ~base_path:config.base_path name meta in
+      Eio.Promise.resolve reg.done_r (`Crashed "ordinary crash");
+      let max_restarts =
+        Masc_mcp.Runtime_params.get
+          Masc_mcp.Governance_registry.keeper_supervisor_max_restarts
+      in
+      (* Set restart_count to max_restarts so the default crash branch routes
+         to [to_mark_dead] (not [to_restart]).  The point of this regression
+         test is verifying the storm-gate is variant-specific, not exercising
+         the restart path (which would fork a heartbeat fiber and hang). *)
+      Reg.restore_supervisor_state ~base_path:config.base_path name
+        ~restart_count:max_restarts ~last_restart_ts:0.0 ~crash_log:[];
+      Reg.set_failure_reason ~base_path:config.base_path name
+        (Some (Reg.Heartbeat_consecutive_failures 3));
+      let baseline_pause =
+        Masc_mcp.Prometheus.metric_total "masc_keeper_stale_storm_paused_total"
+      in
+      let ctx : _ KT.context =
+        {
+          config;
+          agent_name = "supervisor";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      Sup.sweep_and_recover ctx;
+      let after_pause =
+        Masc_mcp.Prometheus.metric_total "masc_keeper_stale_storm_paused_total"
+      in
+      check (float 0.001) "stale_storm_paused counter NOT incremented for non-storm"
+        baseline_pause after_pause;
+      (* meta.paused stays false. *)
+      (match KT.read_meta config name with
+       | Ok (Some m) ->
+           check bool "meta.paused stays false after non-storm crash"
+             false m.paused
+       | Ok None -> fail "meta missing"
+       | Error err -> fail ("read_meta failed: " ^ err)))
+
 (* ── Test runner ────────────────────────────────────────── *)
 
 let () =
@@ -411,5 +559,11 @@ let () =
     "dead_state_alert", [
       test_case "max_restarts exhaustion emits Dead alert" `Quick
         test_max_restarts_exhaustion_emits_dead_alert;
+    ];
+    "stale_storm_phase2", [
+      test_case "Stale_termination_storm skips restart, persists paused, increments counter" `Quick
+        test_stale_storm_pause_skips_restart;
+      test_case "non-storm Crashed still routes to restart (regression guard)" `Quick
+        test_non_storm_crashed_restarts_normally;
     ];
   ]


### PR DESCRIPTION
## Why now

Closes **#10765** (stale watchdog death-spiral, 116 events/24h, single keeper 13×).

Today's fleet observation (2026-04-27, 7h+ tracking):
- `taskmaster/ramarama/nick0cave/...` dashboard "stale": _KSM=Running but no live turn for 39-43m, last receipt healthy_.
- 사용자 mental model: "잠만 자다 한 20분 있으면 다시 잠으로 돌아가서 proactive를 전혀 안해" — 5h+ 측정으로 검증.

The pre-existing `record_stale_termination` (keeper_stale_watchdog.ml:37-46) already counted terminations in a 6h window and emitted a threshold-breach log + Prometheus counter, but auto-pause was deferred:

> `(* Phase 2 (deciding whether to auto-pause) is left for a follow-up PR with measurement evidence in hand. *)`

We now have 24h+ of evidence. This PR implements Phase 2.

## Pipeline change

```
[before — restart loop, no operator-actionable signal]
proactive_loop → cascade dead → turn fail → idle accumulates
  → stale watchdog: fiber_stop=true → Crashed
  → supervisor sweep: Some `Crashed → to_restart (always) → restart
  → ↺ same cascade, loop forever

[after — break the loop on storm pattern]
proactive_loop → cascade dead → turn fail → idle accumulates
  → stale watchdog: record_stale_termination → window_count >= 5
  → set_failure_reason Stale_termination_storm                 ← NEW
  → supervisor sweep: Some `Crashed →
      if last_failure_reason = Stale_termination_storm:        ← NEW gate
        skip to_restart
        persist meta.paused = true (write_meta_with_merge)
        Prometheus inc keeper_stale_storm_paused_total
        publish_phase_lifecycle Paused
        in-memory unregister (counter increments once per storm)
      else: existing restart-or-mark-dead path (unchanged)
```

## Why a `failure_reason` variant, not FSM priority change

`derive_phase` (keeper_state_machine.ml:325-367) has Crashed=priority-5, Paused=priority-8. Once `fiber_alive=false`, phase derives to Crashed regardless of `operator_paused=true`. Reordering FSM priorities is a wide blast radius (TLA+ spec, every consumer of phase, dashboard semantics). Routing the storm signal through `last_failure_reason` is variant-local and the supervisor gate is the only consumer added.

## Files changed

| 파일 | 역할 |
|-----|------|
| `lib/keeper/keeper_registry.ml` + `.mli` | `Stale_termination_storm of { count : int }` variant + `failure_reason_to_string` + `failure_reason_cohort_key` arms |
| `lib/keeper/keeper_stale_watchdog.ml` | threshold breach 분기에서 `set_failure_reason` 으로 latch 변경 (override Stale_turn_timeout) |
| `lib/keeper/keeper_supervisor.ml` | `supervise_keepalive` watchdog_triggered gate + `sweep_and_recover` `Crashed branch + 신규 helper `handle_stale_storm_pause` |
| `test/test_keeper_supervisor.ml` | 2 integration test (storm pause + non-storm regression guard) |

## Tests

`dune runtest --root . --profile=release test/test_keeper_supervisor.exe` — **21/21 PASS** (직전 19 + Phase 2 신규 2건).

신규 테스트:
- `stale_storm_phase2/0`: storm latch → counter +1 + meta.paused=true 영구화 + 등록 해제 + dead counter 미증가.
- `stale_storm_phase2/1`: non-storm crash (Heartbeat_consecutive_failures) → storm counter 미증가, meta.paused 유지 false.

테스트가 `[restore_supervisor_state → set_failure_reason]` ordering 함정을 노출했고 코멘트로 문서화 (restore가 last_failure_reason을 None으로 reset).

## Out of scope (별도 PR)

- **Mode B (completion contract require_tool_use 위반)**: dedicated issue 부재 확인됨, 별도 등록 candidate.
- **#10474 cascade gate `no_tool_capable_provider`** + **#10558 cascade greedy budget**: cascade 정책 수준 결정 필요.
- **OAS upstream `oas_timeout_budget` recovery**: OAS 레포 영역.

## Production smoke (24h after merge)

```
# 1) 발동 카운트
curl -s localhost:9090/metrics | grep masc_keeper_stale_storm_paused_total
# 2) paused keeper 리스트
sb graphql keepers --filter 'phase = "Paused"'
# 3) restart_count frozen 확인
sb neo4j query 'MATCH (k:Keeper)-[:HAS_LIFECYCLE]->(l) WHERE l.event="stale_storm_paused" RETURN k.name, l.timestamp ORDER BY l.timestamp DESC LIMIT 20'
```

기대 신호: 24h 내 ≥ 1 발동 (현재 fleet 상태 기준). restart_count가 storm 시점 값에 frozen됨.

Refs #10691 #10872 #10999 #10940 #10962