### PR TITLE
fix(keeper): relax oas_timeout retry guard 30→15 (band-aid for cohttp hang)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -542,9 +542,22 @@ let record_turn_failure_stress
     timestamp = Unix.gettimeofday ();
   }
 
-let oas_timeout_guard_sec = 30.0
+(* Retry guard floor: relaxed 30→15 (2026-04-27).
+   Original 60s threshold (guard 30 + min 30) caused keeper cycle FAILED when
+   remaining turn budget fell into the 30-60s band, increasing noop count and
+   eventually fleet auto-pause. Field evidence (post v0.18.4): keepers hung on
+   cohttp-eio bulk read for ~600s and arrived at the retry branch with <60s
+   remaining → guarded out → cycle terminal.
 
-let min_oas_timeout_budget_sec = 30.0
+   New threshold (15+15=30s) accommodates small-tail retries:
+   - cohttp connect 1s + first-token 2-5s = ~6s baseline
+   - 30s leaves ~9-12s headroom for actual response
+
+   Root cause is OAS HTTP body lacking timeout (`http_client.ml take_all`);
+   this is a band-aid until that lands. *)
+let oas_timeout_guard_sec = 15.0
+
+let min_oas_timeout_budget_sec = 15.0
 
 type oas_timeout_budget_resolution = {
   effective_timeout_sec : float;


### PR DESCRIPTION
## Summary

Lower `oas_timeout_guard_sec` and `min_oas_timeout_budget_sec` from 30→15 in `lib/keeper/keeper_unified_turn.ml`, restoring small-tail retries that the 60s combined threshold was guarding out.

## Field evidence (post v0.18.4 fleet snapshot, 2026-04-27 02:48 UTC)

- `analyst` keeper hung 620s on cohttp-eio bulk read in `ollama_only` cascade
- watchdog killed at 600s timeout
- arrived at retry branch with <60s remaining → guarded out → cycle terminal
- 8/14 keepers eventually quiet (5min idle → `stale_keeper_broadcast`)

Concrete log lines:
```
02:48:47Z  keeper_llm_bridge: OAS execution timed out after 599.9s (budget=600s)
02:48:47Z  analyst: recoverable cascade failure in ollama_only; rotation retry on cascade=b...
02:49:07Z  analyst: stale watchdog terminating fiber (active turn hung 620s (timeout 600s))
```

## What this changes

```diff
-let oas_timeout_guard_sec = 30.0
-let min_oas_timeout_budget_sec = 30.0
+let oas_timeout_guard_sec = 15.0
+let min_oas_timeout_budget_sec = 15.0
```

Effective retry threshold: 60s → 30s. Sizing rationale:
- cohttp-eio connect ~1s + first-token 2-5s = ~6s baseline
- 30s budget leaves ~9-12s headroom for actual response
- Hangs (>600s) still terminal — only restores small-tail retries

## What this does NOT fix (root cause)

OAS HTTP body lacks timeout. `lib/llm_provider/http_client.ml` sites at lines 300/336/374/415 use `Eio.Buf_read.take_all` without `Eio.Time.with_timeout`. cohttp-eio Body type prevents safe wrapping (`take_all` has no internal cancel point in `ensure` loop, partial buffer + socket close issues). 

This patch is a **band-aid**: it lets keepers recover from the smaller 30-60s budget cliff. Hangs >600s still kill the keeper.

## Investigation refs

- cycle 1-3: identified retry guard precise location (`keeper_unified_turn.ml:545-547,575-576,1837-1846`)
- cycle 4: applied cascade narrow A in `~/me/.masc/config/cascade.toml` (`keeper_unified` 4-provider → spark-only) — measured `oas_timeout_budget` 0/h post-restart for keeper_unified context
- cycle 5: server auto-restarted with v0.18.4 + A applied
- cycle 6: confirmed `ollama_only` cascade also hangs → A insufficient → this complement (B) needed

## Test impact

`test/test_keeper_turn_timeout_default_10456.ml` mentions the constant only in a doc comment as historical math (`1200 - 30 = 1170s`); no value assertions on this constant. Test suite should pass unchanged.

## Test plan

- [ ] CI Build + Lint green
- [ ] `dune runtest test/test_keeper_turn_timeout_default_10456.ml` passes
- [ ] Manual: deploy → measure `keeper cycle FAILED` rate over 4h post-merge vs pre-merge baseline
- [ ] Watch for any new failure pattern in the 30-60s budget band that the relaxed threshold now allows

## Follow-ups (separate PRs, not in scope)

- **B2** — `Degraded_retry_budget_exhausted` branch with bounded short-retry attempt before terminal (requires deeper code path analysis)
- **C** — OAS HTTP body chunked-read with per-chunk timeout (requires cohttp-eio API design or upstream contribution)
- **D2** — `cross_verifier` cascade narrow if v0.18.4 `tool_lane_unsupported` rejection persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
