### PR TITLE
i18n(dashboard): localize 6 mixed-language status detail strings (round-94)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -558,8 +558,8 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
       <div class="flex items-center gap-2 flex-wrap mb-2">
         <${StatusChip} tone=${tone}>${validationLabel(config.validation_status)}<//>
         <span class="text-[var(--color-fg-muted)]">
-          ${config.invalid_profiles.length} invalid profile${config.invalid_profiles.length === 1 ? '' : 's'}
-          · ${config.validation_errors.length} error${config.validation_errors.length === 1 ? '' : 's'}
+          invalid profile ${config.invalid_profiles.length}개
+          · 에러 ${config.validation_errors.length}개
         </span>
       </div>
       <div class="text-[var(--text-strong)] mb-2">
@@ -585,7 +585,7 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
       ${config.invalid_profiles.length > visibleProfiles.length
         ? html`
           <div class="mt-2 text-[var(--color-fg-muted)]">
-            + ${config.invalid_profiles.length - visibleProfiles.length} more invalid profiles
+            + invalid profile ${config.invalid_profiles.length - visibleProfiles.length}개 더
           </div>
         `
         : null}

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -244,7 +244,7 @@ function ControlRoomPanel({ state }: { state: FleetTelemetryState }) {
         <${SummaryCard}
           title="준비 상태"
           value=${readiness.score.toFixed(2)}
-          detail=${`${readiness.blocking_count} blockers · ${readiness.decision_required_count} decisions required.`}
+          detail=${`차단 ${readiness.blocking_count} · 결정 필요 ${readiness.decision_required_count}.`}
           tone=${readinessTone(readiness.status)}
         />
         <${SummaryCard}

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -497,11 +497,11 @@ export function sourceCountClass(source: TelemetrySourceSummary): string {
 export function sourceDetail(source: TelemetrySourceSummary): string {
   const parts: string[] = []
   if (source.keeper_count != null) {
-    parts.push(`${source.keeper_count} keepers tracked`)
+    parts.push(`keeper ${source.keeper_count}개 추적 중`)
   } else if (source.exists === false) {
-    parts.push('store missing')
+    parts.push('store 없음')
   } else {
-    parts.push('store available')
+    parts.push('store 있음')
   }
 
   if (source.entry_count > 0) {


### PR DESCRIPTION
## Summary

Mixed-language inconsistency 6개 해소. 모두 status detail / count suffix 인데 panel label 은 한국어이고 내부만 영어로 남아있던 패턴.

## Changed strings

### `fleet-telemetry-panel.ts:247`
```ts
- detail=${`${readiness.blocking_count} blockers · ${readiness.decision_required_count} decisions required.`}
+ detail=${`차단 ${readiness.blocking_count} · 결정 필요 ${readiness.decision_required_count}.`}
```
SummaryCard `title="준비 상태"` 와 같은 영역 안의 detail.

### `fleet-telemetry-utils.ts:500-504`
```ts
- parts.push(`${source.keeper_count} keepers tracked`)
+ parts.push(`keeper ${source.keeper_count}개 추적 중`)
- parts.push('store missing')
+ parts.push('store 없음')
- parts.push('store available')
+ parts.push('store 있음')
```
같은 함수 `sourceDetail` 의 3 분기 모두.

### `cascade-config-panel.ts:561-562 + 588`
```ts
- ${config.invalid_profiles.length} invalid profile${config.invalid_profiles.length === 1 ? '' : 's'}
- · ${config.validation_errors.length} error${config.validation_errors.length === 1 ? '' : 's'}
+ invalid profile ${config.invalid_profiles.length}개
+ · 에러 ${config.validation_errors.length}개

- + ${config.invalid_profiles.length - visibleProfiles.length} more invalid profiles
+ + invalid profile ${config.invalid_profiles.length - visibleProfiles.length}개 더
```

같은 컴포넌트 안의 line 149/239/577 가 이미 한국어 (`'invalid profile 도 저장은 허용...'`, `'invalid profile 은 제외...'`, `'거부된 프로파일'`) — inconsistency 해소.

## Plural ternary cleanup

영어 plural-s ternary (`length === 1 ? '' : 's'`) 제거. 한국어는 단/복수 형태 동일이라 ternary 가 dead logic.

## Domain term policy

`invalid profile`, `store`, `keeper` 보존 — 도메인/SSOT 용어.

## Scope

- 3 파일, 7줄 (실제 6 strings, plural ternary 정리 포함).
- test 영향 0.
