### PR TITLE
feat(dashboard): a11y connector-config-form — role=alert/form (round-6 split 4/N)

### DIFF
--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -438,7 +438,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
 
   if (entry.error !== null) {
     return html`
-      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] p-3 text-2xs text-[var(--bad-light)]">
+      <div id=${`connector-config-${connectorId}`} role="alert" class="mt-3 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] p-3 text-2xs text-[var(--bad-light)]">
         <div class="font-semibold">schema 가져오기 실패</div>
         <div class="mt-1 text-3xs opacity-80">${entry.error}</div>
         <button
@@ -462,7 +462,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
   const envBlock = buildEnvBlock(entry)
 
   return html`
-    <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--white-8)] bg-[var(--color-bg-surface)] p-3">
+    <div id=${`connector-config-${connectorId}`} role="form" aria-label="${connectorId} 설정" class="mt-3 rounded border border-[var(--white-8)] bg-[var(--color-bg-surface)] p-3">
       <div class="mb-2 flex items-center justify-between">
         <div class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">
           ${entry.fields.length} fields · ${entry.fields.filter(f => f.required).length} required


### PR DESCRIPTION
## Why

Fourth slice of the **a11y round-6 split** (siblings: #11017 agent-detail, #11021 auth-status, #11044 handoff-timeline; closed parent: #10871). `connector-config-form` had no landmark for the form region and no live-region semantics on the schema-fetch error block.

This PR is the connector-config-form slice (1 file, +2/−2).

## What

Two attribute additions:

| Surface | Add |
|---------|-----|
| schema-fetch error `<div>` | `role="alert"` so screen readers announce the failure when it surfaces |
| Config form container `<div>` | `role="form"` + `aria-label="${connectorId} 설정"` so AT users can land on the form as a labeled landmark |

## Cherry-pick provenance

`131a73ca0b` from `dashboard/a11y-006`. Source touched 5 spots (3 ARIA additions + 2 button-level labels). On `main`:

- The retry button already has a more specific Korean label (`"config schema 다시 가져오기"` vs source's `"schema 다시 불러오기"`) — HEAD kept.
- The restart button is now an `<ActionButton ariaBusy={...} ariaLabel="sidecar 재시작">` (uses our component-level ARIA props from earlier work) — HEAD kept; the source's raw `aria-label` / `aria-busy` HTML attributes would not even reach the rendered element through the ActionButton prop whitelist.
- Token migration on the form container (`--bg-1` → `--color-bg-surface`) — HEAD kept; source's role+label merged onto HEAD's modern token.

So the only net-new ARIA contributions of this cherry-pick are the two listed above.

## What this PR does NOT do

- The companion `8021adbf` source commit (connector-keeper-matrix + connector-onboarding + connector-overview-strip) — separate follow-up. It overlaps `connector-keeper-matrix.ts`, which we touched in #10997 (KeeperBadge adoption), so it warrants its own conflict-resolution pass.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [ ] No vitest changes — pure ARIA addition.
- [ ] Manual SR check: form announces as "form, ${connectorId} 설정"; error block announces immediately on appear.

## Refs

- Predecessor splits: #11017 (agent-detail), #11021 (auth-status), #11044 (handoff-timeline)
- Closed parent: #10871
- Source commit: `131a73ca0b fix(a11y): add ARIA attributes to connector-config-form`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
