### PR TITLE
fix(keeper): seed last_turn_ts to bootstrap time (watchdog zombie blindspot)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -2369,12 +2369,30 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
     in
     let synced = ensure_keeper_room_presence ctx.config m in
     (* Reset stale timestamp from previous server lifecycle.
-       Without this, the stale watchdog reads the old last_turn_ts
-       and immediately terminates the fiber on server restart. *)
+
+       Use [Time_compat.now ()] (not [0.0]). The original intent was to
+       prevent the stale watchdog from immediately terminating the fiber
+       on server restart by clearing an old [last_turn_ts]. Setting it
+       to [0.0] worked for that — but [keeper_stale_watchdog.ml:141]
+       gates the stall check on [last_turn > 0.0], so [0.0] permanently
+       blinds the watchdog: a keeper that never runs a real turn (auth
+       failure, OAS budget exhaustion, no work signal) stays in a
+       zombie state the watchdog cannot detect.
+
+       Resetting to [now_ts] preserves the original goal — grace_period
+       (180s default) covers the bootstrap window so the watchdog still
+       doesn't fire prematurely — while restoring detection for a
+       truly idle keeper after grace elapses. Real turns continue to
+       overwrite this with the actual turn time as before.
+
+       Production evidence (2026-04-27): 7 of 11 keepers had
+       [last_turn_ts = 0.0] for 50-65 min after server restart with no
+       watchdog stall fired despite obvious silence. *)
+    let bootstrap_ts = Time_compat.now () in
     let synced =
       { synced with
         runtime = { synced.runtime with
-          usage = { synced.runtime.usage with last_turn_ts = 0.0 };
+          usage = { synced.runtime.usage with last_turn_ts = bootstrap_ts };
         };
       }
     in


### PR DESCRIPTION
## Why

`keeper_keepalive.ml` resets `last_turn_ts = 0.0` on bootstrap (originally to prevent the stale watchdog from firing immediately on server restart). But `keeper_stale_watchdog.ml:141` gates the stall check on `last_turn > 0.0`:

```ocaml
let stale =
  last_turn > 0.0
  && now -. last_turn > threshold
  && fiber_age >= grace_period_sec ()
```

So `0.0` permanently blinds the watchdog: a keeper that never runs a real turn after boot (auth failure, OAS budget exhaustion, no work signal) stays in a **zombie state the watchdog cannot detect or terminate**.

## Production evidence (2026-04-27 03:44 UTC)

7 of 11 keepers had `last_turn_ts = 0.0` for 50–65 min after server restart with no watchdog stall fired despite obvious silence:

| Keeper | Silent | last_turn_ts |
|--------|--------|--------------|
| analyst | 55 min | 0.0 |
| scholar | 65 min | 0.0 |
| taskmaster | 65 min | 0.0 |
| masc-improver | 54 min | 0.0 |
| verifier | 65 min | 0.0 |
| ollama-local | 16.3 h | 0.0 (paused: true) |
| velvet-hammer | 16.3 h | 0.0 (paused: true) |

ollama-local had OAS timeout-budget exhaustion (3569.9 s hard cap) — exactly the kind of failure the watchdog should surface to the supervisor for automatic restart. Instead, it persisted indefinitely.

## What

`lib/keeper/keeper_keepalive.ml:2374-2380` — reset to `Time_compat.now ()` instead of `0.0`. Comment expanded to document:
- Original intent (prevent immediate fire on restart) preserved by existing `grace_period_sec` (default 180s)
- Real turns continue to overwrite with actual turn time (no behavior change in common path)
- Production evidence inline so a future reviewer can verify the failure mode without re-deriving it

## Why this isn't observability noise

Reviewed the watchdog action chain to confirm the gate's failure has real consequences:

| `keeper_stale_watchdog.ml` line | Action |
|---------------------------------|--------|
| 211 | `Atomic.set reg.fiber_stop true` (terminates fiber) |
| 213 | Prometheus `masc_keeper_stale_termination_total` (alertable) |
| 220 | 6-hour escalation w/ operator-review message (#10765) |
| 237 | Fleet-batch detection emits "PER-KEEPER RESTARTS WILL LOOP WITHOUT OPERATOR INTERVENTION" |
| 252 | `emit_stale_keeper_broadcast` (operator-facing) |

Watchdog firing triggers the supervisor's automatic restart loop. Blinding it removes the only mechanism that recovers a zombie keeper without manual intervention.

## Behaviour

- 1 line code change + comment expansion (21 insertions, 3 deletions)
- No interface change
- No type change
- `dune build @check` green

## Out of scope

Two related findings from the same diagnosis (deferred to separate PRs):

1. **Token mismatch in dashboard auth** (separate from keeper auth — verified in `lib/server/server_auth.ml:260–309`). Currently fires `[silent:dashboard_actor_fallback]` WARN twice in same second; falls back to `request_actor_hint` which masks which keeper's token failed. Top action: log token hash prefix to enable correlation.
2. **Keeper JSON schema lacks `credential_id`** — cannot detect mid-flight token invalidation. Larger refactor.

## Diagnosis trail

Production log (2026-04-27 03:44 UTC silent dashboard fallback) → diagnosis agent on `/Users/dancer/me/.masc/keepers/*.json` → identified 7/11 with `last_turn_ts=0.0` → traced to bootstrap reset → verified watchdog gate would skip these → fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)