### PR TITLE
i18n(dashboard): localize 'vs env' delta suffix (round-95)

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -218,8 +218,8 @@ function BudgetRow({ label, slot, manifest, clamp }: {
   const deltaText = delta === 0
     ? null
     : delta > 0
-      ? `+${delta} vs env`
-      : `${delta} vs env`
+      ? `+${delta} (env 기준)`
+      : `${delta} (env 기준)`
 
   let valueClass: string
   let pill


### PR DESCRIPTION
## Summary

`keeper-detail-runtime.ts` 의 runtime override pill 안 짧은 영어 suffix 2곳 한국어화. effective value 와 env_default 의 차이를 표시하는 inline annotation.

## Change

```ts
// line 218-222
const deltaText = delta === 0
  ? null
  : delta > 0
-    ? `+${delta} vs env`
-    : `${delta} vs env`
+    ? `+${delta} (env 기준)`
+    : `${delta} (env 기준)`
```

## Domain term policy

`env` 보존 — `env_default` field name 과 일치.

## Scope

- 1 파일, 2줄.
- `rg 'vs env'` 결과 source 2 line 외 reference 0건 — test 영향 없음.
