### PR TITLE
feat(dashboard): adopt canonical bg-surface token in 5 files (CS100)

### DIFF
--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -263,7 +263,7 @@ export function GraphView({ data }: GraphViewProps) {
     </div>
 
     ${selectedNode ? html`
-      <div class="rounded border border-[var(--color-border-default)] bg-[var(--card)] p-4 mt-2">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 mt-2">
         <div class="flex items-center gap-3 mb-3">
           <strong class="text-lg text-[var(--text-near-white)]">${selectedNode.label}</strong>
           <span class="py-0.5 px-2 bg-[var(--slate-gray-15)] text-2xs text-[var(--text-slate)] rounded">${kindLabel(selectedNode.kind)}</span>

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -95,7 +95,7 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
 
   function statCard(label: string, value: number, series: number[], color: string, highlight = false) {
     return html`
-      <div class="rounded border border-[var(--color-border-default)] bg-[var(--card)] py-[15px] px-3.5">
+      <div class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] py-[15px] px-3.5">
         <div class="text-3xs text-[var(--color-fg-muted)] tracking-1 uppercase font-medium">${label}</div>
         <div class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums ${highlight ? 'text-[var(--color-status-ok)]' : ''}">${value}</div>
         ${series.length >= 2 ? html`<div class="mt-2"><${Sparkline} values=${series} color=${color} /></div>` : null}
@@ -173,7 +173,7 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="flex flex-col gap-3 rounded border border-[var(--color-border-default)] bg-[var(--card)]/50 p-4">
+      <div class="flex flex-col gap-3 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/50 p-4">
         <div class="flex flex-col gap-1">
           <div class="text-base font-semibold text-[var(--color-fg-secondary)]">원본 실행 이벤트를 최근 액션 단위로 묶어 보여줍니다.</div>
           <div class="text-xs text-[var(--color-fg-muted)]">
@@ -211,7 +211,7 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
         : filteredGroups.map(group => {
             const expanded = expandedActionGroups.value.has(group.id)
             return html`
-              <div class="rounded border border-[var(--color-border-default)] bg-[var(--card)]/55 p-4 shadow-sm shadow-black/8" key=${group.id}>
+              <div class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/55 p-4 shadow-sm shadow-black/8" key=${group.id}>
                 <div class="flex flex-wrap items-start justify-between gap-3">
                   <div class="min-w-0 flex-1">
                     <div class="flex flex-wrap items-center gap-2">

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -74,7 +74,7 @@ function TransitionDot({ t, idx }: { t: KeeperTransition; idx: number }) {
         style="border-color: ${color}; background: ${color}33"
       />
       <div class="absolute bottom-full mb-2 hidden group-hover:flex flex-col items-center z-10">
-        <div class="rounded border border-[var(--color-border-default)] bg-[var(--card)] px-3 py-2 shadow-sm text-2xs whitespace-nowrap">
+        <div class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 shadow-sm text-2xs whitespace-nowrap">
           <div class="font-semibold">${t.prev_phase} → ${t.new_phase}</div>
           <div class="text-[var(--color-fg-muted)] mt-0.5">${t.event_type ?? eventLabel(t.selected_event)}</div>
           ${signal ? html`

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -241,7 +241,7 @@ function SortBar() {
   const current = boardSortMode.value
   const grouped = splitVisiblePosts(boardPosts.value)
   return html`
-    <div class="flex flex-col gap-3 mb-4 p-3 rounded border border-[var(--color-border-default)] bg-[var(--card)]">
+    <div class="flex flex-col gap-3 mb-4 p-3 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
       <div class="flex items-center gap-1.5 flex-wrap">
         ${SORT_MODES.map(mode => html`
           <button type="button"
@@ -340,7 +340,7 @@ function MemorySummary() {
   const grouped = splitVisiblePosts(boardPosts.value)
   const visibleCount = grouped.groups.reduce((sum, g) => sum + g.posts.length, 0)
   return html`
-    <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded border border-[var(--color-border-default)] bg-[var(--card)] text-xs text-[var(--color-fg-muted)]">
+    <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-xs text-[var(--color-fg-muted)]">
       <span class="font-semibold text-[var(--color-fg-secondary)] tabular-nums text-md">${visibleCount}</span>
       <span>개 표시 중</span>
       ${grouped.groups.map(g => {
@@ -402,7 +402,7 @@ function PostCard({ post }: { post: BoardPost }) {
   return html`
     <button
       type="button"
-      class="board-post group w-full flex gap-3 rounded p-4 border border-[var(--color-border-default)] bg-[var(--card)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+      class="board-post group w-full flex gap-3 rounded p-4 border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
       onClick=${() => navigateToPost(post.id)}
     >
       <!-- Select checkbox -->
@@ -438,7 +438,7 @@ function PostCard({ post }: { post: BoardPost }) {
         <!-- Content preview: rendered markdown, height-capped -->
         <div class="board-post-preview text-sm text-[var(--color-fg-primary)] leading-paragraph mb-2.5 overflow-hidden relative ${richPreview ? 'max-h-[12rem]' : 'max-h-[4.8em]'}">
           <${RichContent} text=${previewBody} class="board-post-preview__content" previewLimit=${1} />
-          <div class="absolute bottom-0 left-0 right-0 ${richPreview ? 'h-10' : 'h-6'} bg-gradient-to-t from-[var(--card)] to-transparent pointer-events-none" />
+          <div class="absolute bottom-0 left-0 right-0 ${richPreview ? 'h-10' : 'h-6'} bg-gradient-to-t from-[var(--color-bg-surface)] to-transparent pointer-events-none" />
         </div>
 
         <!-- Footer: author + meta + badges -->

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -148,23 +148,23 @@ export function ToolMetrics() {
           서버 시작 이후 메모리 기반 집계. 재시작 시 초기화됩니다.
         </div>
         <div class="grid grid-cols-[repeat(5,minmax(0,1fr))] gap-3 max-[880px]:grid-cols-[repeat(2,minmax(0,1fr))]">
-          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--card)] p-3">
+          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
             <span class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${data.total_calls}</span>
             <span class="text-2xs text-[var(--color-fg-muted)] font-medium">총 호출 수</span>
           </div>
-          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--card)] p-3">
+          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
             <span class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${data.distinct_tools_called}</span>
             <span class="text-2xs text-[var(--color-fg-muted)] font-medium">사용된 도구</span>
           </div>
-          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--card)] p-3">
+          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
             <span class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${data.never_called_count}</span>
             <span class="text-2xs text-[var(--color-fg-muted)] font-medium">미사용 도구</span>
           </div>
-          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--card)] p-3">
+          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
             <span class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${data.registered_count}</span>
             <span class="text-2xs text-[var(--color-fg-muted)] font-medium">등록됨 (v2)</span>
           </div>
-          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--card)] p-3">
+          <div class="flex flex-col items-center gap-1 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
             <span class="mt-1.5 text-[var(--color-fg-secondary)] text-3xl font-bold leading-none tabular-nums">${data.dispatch_v2_enabled ? 'ON' : 'OFF'}</span>
             <span class="text-2xs text-[var(--color-fg-muted)] font-medium">Dispatch v2</span>
           </div>


### PR DESCRIPTION
## Summary

Phase G Step 4 (file-disjoint sweep). 14 sites of legacy `var(--card)` (which itself aliases `--bg-panel`) swap to canonical `var(--color-bg-surface)` (also `--bg-panel`). 1:1 identical color via existing alias.

## Files & sites

| File | Sites |
|------|-------|
| `tool-metrics.ts` | 5 |
| `memory.ts` | 4 |
| `activity-graph.ts` | 3 |
| `keeper-phase-strip.ts` | 1 |
| `activity-graph-view.ts` | 1 |
| **Total** | **14** |

File-disjoint with in-flight CS97 (excuse-patterns / server-config / config-resolution-panel) / CS98 (server-config) / CS99 (telemetry-unified, prometheus-metrics, etc.).

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test tool-metrics memory activity-graph` → 141/141 pass
- [x] Diff is 1:1 (14 ins / 14 del)