### PR TITLE
feat(dashboard): adopt SPEC fs scale for arbitrary text-[10px]/text-[11px] (CS101)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -482,11 +482,11 @@ function ProfileCard({
                       : null}
                   </div>
                   ${c.model !== displayModel
-                    ? html`<div class="text-[11px] text-[var(--color-fg-muted)] mt-0.5">config: <code>${c.model}</code></div>`
+                    ? html`<div class="text-[length:var(--fs-11)] text-[var(--color-fg-muted)] mt-0.5">config: <code>${c.model}</code></div>`
                     : null}
                   ${expanded.length > 1
                     ? html`
-                      <ol class="mt-1 flex flex-col gap-0.5 text-[11px] text-[var(--color-fg-muted)]">
+                      <ol class="mt-1 flex flex-col gap-0.5 text-[length:var(--fs-11)] text-[var(--color-fg-muted)]">
                         ${expanded.map((model, expandedIdx) => html`
                           <li><span class="tabular-nums">${expandedIdx + 1}.</span> <code>${model}</code></li>
                         `)}

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -198,7 +198,7 @@ function SidecarChecksList({ checks }: { checks: SidecarCheckView[] }) {
                 ${c.autofix_available
                   ? html`
                       <span
-                        class="rounded-full border border-[var(--color-accent-fg)]/40 bg-[var(--color-accent-fg)]/10 px-1.5 py-0.5 text-[10px] text-[var(--color-accent-fg)]"
+                        class="rounded-full border border-[var(--color-accent-fg)]/40 bg-[var(--color-accent-fg)]/10 px-1.5 py-0.5 text-[length:var(--fs-10)] text-[var(--color-accent-fg)]"
                         title=${c.autofix_description
                           ? `자동 치유 시도: ${c.autofix_description} (CLI: masc-mcp doctor --fix)`
                           : '자동 치유 가능 (CLI: masc-mcp doctor --fix)'}
@@ -207,16 +207,16 @@ function SidecarChecksList({ checks }: { checks: SidecarCheckView[] }) {
                       </span>
                     `
                   : ''}
-                <span class="rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${chip}">
+                <span class="rounded-full border px-1.5 py-0.5 text-[length:var(--fs-10)] uppercase tracking-wider ${chip}">
                   ${c.severity}
                 </span>
               </div>
             </div>
-            ${c.detail ? html`<div class="mt-1 text-[11px] text-[var(--color-fg-muted)]">${c.detail}</div>` : ''}
-            ${c.message ? html`<div class="mt-1 text-[11px] text-[var(--color-fg-primary)]">↳ ${c.message}</div>` : ''}
-            ${c.hint ? html`<div class="mt-1 text-[11px] text-[var(--color-fg-muted)]">hint: ${c.hint}</div>` : ''}
+            ${c.detail ? html`<div class="mt-1 text-[length:var(--fs-11)] text-[var(--color-fg-muted)]">${c.detail}</div>` : ''}
+            ${c.message ? html`<div class="mt-1 text-[length:var(--fs-11)] text-[var(--color-fg-primary)]">↳ ${c.message}</div>` : ''}
+            ${c.hint ? html`<div class="mt-1 text-[length:var(--fs-11)] text-[var(--color-fg-muted)]">hint: ${c.hint}</div>` : ''}
             ${c.autofix_available && c.autofix_description
-              ? html`<div class="mt-1 text-[11px] text-[var(--color-accent-fg)]">fix: ${c.autofix_description}</div>`
+              ? html`<div class="mt-1 text-[length:var(--fs-11)] text-[var(--color-accent-fg)]">fix: ${c.autofix_description}</div>`
               : ''}
           </li>
         `
@@ -235,8 +235,8 @@ function ConfigNotesList({ notes }: { notes: ConfigNotesView }) {
       ${warnings.length > 0
         ? html`
             <div>
-              <div class="text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">경고</div>
-              <ul class="mt-1 list-disc space-y-1 pl-5 text-[11px] text-[var(--color-fg-primary)]">
+              <div class="text-[length:var(--fs-11)] uppercase tracking-wider text-[var(--color-fg-muted)]">경고</div>
+              <ul class="mt-1 list-disc space-y-1 pl-5 text-[length:var(--fs-11)] text-[var(--color-fg-primary)]">
                 ${warnings.map((w) => html`<li>${w}</li>`)}
               </ul>
             </div>
@@ -245,8 +245,8 @@ function ConfigNotesList({ notes }: { notes: ConfigNotesView }) {
       ${next_actions.length > 0
         ? html`
             <div>
-              <div class="text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">다음 조치</div>
-              <ul class="mt-1 list-disc space-y-1 pl-5 text-[11px] text-[var(--color-fg-primary)]">
+              <div class="text-[length:var(--fs-11)] uppercase tracking-wider text-[var(--color-fg-muted)]">다음 조치</div>
+              <ul class="mt-1 list-disc space-y-1 pl-5 text-[length:var(--fs-11)] text-[var(--color-fg-primary)]">
                 ${next_actions.map((a) => html`<li>${a}</li>`)}
               </ul>
             </div>
@@ -271,9 +271,9 @@ function DoctorEntryCard({ entry }: { entry: DoctorEntry }) {
       >
         <div class="text-sm font-semibold text-[var(--color-fg-secondary)]">
           ${doctorHeading(entry)}
-          <span class="ml-2 text-[10px] text-[var(--color-fg-muted)]">${expanded.value ? '▾' : '▸'}</span>
+          <span class="ml-2 text-[length:var(--fs-10)] text-[var(--color-fg-muted)]">${expanded.value ? '▾' : '▸'}</span>
         </div>
-        <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider ${chip}">
+        <span class="rounded-full border px-2 py-0.5 text-[length:var(--fs-10)] uppercase tracking-wider ${chip}">
           ${label}
         </span>
       </button>


### PR DESCRIPTION
## Summary

Phase G Step 5 — first component-level adoption of the SPEC typography scale (introduced in CS88). 14 sites of arbitrary Tailwind text-sizes swap to `--fs-N` token references. Both sides resolve to identical pixel values.

## Mapping (1:1 identical px)

| Legacy | Canonical | Sites |
|--------|-----------|-------|
| `text-[10px]` | `text-[length:var(--fs-10)]` | 4 (doctor-panel.ts) |
| `text-[11px]` | `text-[length:var(--fs-11)]` | 10 (doctor-panel.ts: 8, cascade-config-panel.ts: 2) |
| **Total** | | **14** |

## Why

CS88 introduced `--fs-9..36`, `--lh-*`, `--space-*`, `--type-*` tokens but no component yet adopted them. This PR is the first opt-in: arbitrary `text-[10px]` becomes a typed reference to `--fs-10` (which is also 10px), making future scale changes (e.g. mobile responsive) propagate automatically.

## Test plan

- [x] `pnpm typecheck` green
- [x] Visual diff = 0 (same pixel values)
- [x] Diff is 1:1 (14 ins / 14 del)