### PR TITLE
feat(dashboard): adopt canonical bg-hover token in 2 files (CS102)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -1166,7 +1166,7 @@ function CascadeRawConfigEditor({
             </button>
             <button
               type="button"
-              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
+              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50"
               onClick=${handleReset}
               disabled=${saving.value || !editorDirty.value}
             >
@@ -1174,7 +1174,7 @@ function CascadeRawConfigEditor({
             </button>
             <button
               type="button"
-              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
+              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50"
               onClick=${() => void onRefresh()}
               disabled=${saving.value}
             >
@@ -1231,7 +1231,7 @@ export function CascadeConfigPanel() {
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <button
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--color-bg-hover)]"
           onClick=${() => void loadCascadeData(resource)}
         >
           새로고침

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -493,7 +493,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
 
   return html`
     <div
-      class="border-b border-[var(--color-border-default)] hover:bg-[var(--bg-panel-hover)] transition-colors"
+      class="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
       style="content-visibility:auto;contain-intrinsic-size:36px"
     >
       <div class="flex items-center gap-1">
@@ -567,7 +567,7 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
 
   return html`
     <div
-      class="border-b border-[var(--color-border-default)] bg-[rgba(255,255,255,0.015)] hover:bg-[var(--bg-panel-hover)] transition-colors"
+      class="border-b border-[var(--color-border-default)] bg-[rgba(255,255,255,0.015)] hover:bg-[var(--color-bg-hover)] transition-colors"
       style="content-visibility:auto;contain-intrinsic-size:36px"
     >
       <div class="flex items-center gap-1">
@@ -916,7 +916,7 @@ export function TelemetryUnified() {
           <option value="500">500</option>
         </select>
         <button
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--color-bg-hover)]"
           onClick=${() => void load()}
         >
           Refresh


### PR DESCRIPTION
## Summary

Phase G Step 4 (file-disjoint sweep). 6 sites of legacy `var(--bg-panel-hover)` swap to canonical `var(--color-bg-hover)` which aliases the same value (1:1 identical).

## Files & sites

| File | Sites |
|------|-------|
| `cascade-config-panel.ts` | 3 |
| `telemetry-unified.ts` | 3 |
| **Total** | **6** |

File-disjoint with in-flight CS100 / CS101.

## Test plan

- [x] `pnpm typecheck` green
- [x] Pure 1:1 alias swap — no visual diff
- [x] Diff is 1:1 (6 ins / 6 del)