### PR TITLE
feat(coord): extract local git op timeout to env (SSOT) (#10426)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -815,4 +815,45 @@ module Sidecar = struct
       (get_float ~default:10.0 "MASC_SIDECAR_SCHEMA_TIMEOUT_SEC")
 end
 
+(** {1 Coord local git operation timeouts}
+
+    Inline literals extracted from {!Coord_git} and
+    {!Coord_worktree} (#10426 audit):
+
+    - [coord_git.ml:45]        30.0  → run_argv_line  helper default
+    - [coord_git.ml:74]        30.0  → run_argv_lines helper default
+    - [coord_worktree.ml:21]   30.0  → run_argv_lines helper default
+    - [coord_worktree.ml:868]  30.0  → direct [worktree add -B] call
+
+    All four sites share the same semantic bucket: "local-only git
+    operations" (rev-parse, status, branch, worktree add — no
+    network IO).  Network-bound git ops (fetch, push) already use
+    {!Env_config_core.git_fetch_timeout_sec}, which is the long
+    counterpart and is intentionally a separate knob.
+
+    The two budgets must remain separable: bundling local + network
+    under one knob would force an operator who needs to extend a
+    flaky [git fetch] over a slow proxy to also extend every
+    [git rev-parse] subprocess on hot paths, padding tail latency
+    needlessly.  Conversely, an operator narrowing local ops on a
+    fast workstation would not expect to also narrow network ops. *)
+
+module Coord_git = struct
+  (** Budget (seconds) for local-only git operations under
+      [Masc_exec.Exec_gate.run_argv*] in {!Coord_git} and
+      {!Coord_worktree}: [rev-parse], [status], [branch],
+      [worktree add], etc.
+
+      Default 30.0 preserves the four inline literals.  Floor 5.0
+      keeps the budget above subprocess startup + small index
+      reads even on a busy system; misconfiguring lower than that
+      would silently kill perfectly healthy commands.
+
+      Network-bound ops (fetch, push) intentionally use a separate
+      knob — see {!Env_config_core.git_fetch_timeout_sec}. *)
+  let local_op_timeout_sec =
+    Float.max 5.0
+      (get_float ~default:30.0 "MASC_COORD_GIT_LOCAL_OP_TIMEOUT_SEC")
+end
+
 (** {1 Internal Safety Configuration} *)

--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -42,7 +42,7 @@ let run_argv_line (argv : string list) : string option =
       ~actor:"coord/git"
       ~raw_source:(exec_gate_raw_source argv)
       ~summary:"coord_git argv"
-      ~timeout_sec:30.0
+      ~timeout_sec:Env_config_runtime.Coord_git.local_op_timeout_sec
       argv
   in
   match String.split_on_char '\n' output |> List.map String.trim |> List.filter (fun s -> s <> "") with
@@ -50,10 +50,13 @@ let run_argv_line (argv : string list) : string option =
   | h :: _ -> Some h
 
 (** Run argv and return exit code.
-    [timeout_sec] defaults to 30s for local-only operations.  Network-
-    bound commands (git fetch / push) should pass an explicit longer
-    budget — see {!Env_config_core.git_fetch_timeout_sec}. *)
-let run_argv_exit ?(timeout_sec = 30.0) (argv : string list) : int =
+    [timeout_sec] defaults to {!Env_config_runtime.Coord_git.local_op_timeout_sec}
+    for local-only operations.  Network-bound commands (git fetch /
+    push) should pass an explicit longer budget — see
+    {!Env_config_core.git_fetch_timeout_sec}. *)
+let run_argv_exit
+    ?(timeout_sec = Env_config_runtime.Coord_git.local_op_timeout_sec)
+    (argv : string list) : int =
   match
     Masc_exec.Exec_gate.run_argv_with_status
       ~actor:"coord/git"
@@ -71,7 +74,7 @@ let run_argv_lines (argv : string list) : string list =
     ~actor:"coord/git"
     ~raw_source:(exec_gate_raw_source argv)
     ~summary:"coord_git argv"
-    ~timeout_sec:30.0
+    ~timeout_sec:Env_config_runtime.Coord_git.local_op_timeout_sec
     argv
   |> String.split_on_char '\n'
   |> List.map String.trim

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -18,17 +18,21 @@ let run_argv_lines argv =
     ~actor:"coord/worktree"
     ~raw_source:(exec_gate_raw_source argv)
     ~summary:"coord_worktree argv"
-    ~timeout_sec:30.0
+    ~timeout_sec:Env_config_runtime.Coord_git.local_op_timeout_sec
     argv
   |> String.split_on_char '\n'
   |> List.filter (fun s -> s <> "")
 
 (** Run argv and get process status + combined output.
-    [timeout_sec] defaults to the short 30s window appropriate for
-    local-only git operations (status, branch, rev-parse).  Network-
-    bound operations like [git fetch origin] should pass an explicit
-    longer budget — see {!Env_config.git_fetch_timeout_sec}. *)
-let run_argv_with_status ?(timeout_sec = 30.0) argv =
+    [timeout_sec] defaults to
+    {!Env_config_runtime.Coord_git.local_op_timeout_sec}, the short
+    window appropriate for local-only git operations (status, branch,
+    rev-parse).  Network-bound operations like [git fetch origin]
+    should pass an explicit longer budget — see
+    {!Env_config_core.git_fetch_timeout_sec}. *)
+let run_argv_with_status
+    ?(timeout_sec = Env_config_runtime.Coord_git.local_op_timeout_sec)
+    argv =
   Masc_exec.Exec_gate.run_argv_with_status
     ~actor:"coord/worktree"
     ~raw_source:(exec_gate_raw_source argv)
@@ -865,7 +869,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                     ~actor:"coord/worktree"
                     ~raw_source:(exec_gate_raw_source argv)
                     ~summary:"coord_worktree worktree add"
-                    ~timeout_sec:30.0
+                    ~timeout_sec:Env_config_runtime.Coord_git.local_op_timeout_sec
                     argv
                 in
 

--- a/test/dune
+++ b/test/dune
@@ -1803,6 +1803,12 @@
  (modules test_env_config_dashboard_compute_timeouts)
  (libraries masc_test_deps))
 
+; Coord local git operation timeout SSOT
+(test
+ (name test_env_config_coord_git_local_timeout)
+ (modules test_env_config_coord_git_local_timeout)
+ (libraries masc_test_deps))
+
 ; Process_eio subprocess default timeout SSOT
 (test
  (name test_process_eio_default_timeout)

--- a/test/test_env_config_coord_git_local_timeout.ml
+++ b/test/test_env_config_coord_git_local_timeout.ml
@@ -1,0 +1,69 @@
+(** Pin the {!Env_config_runtime.Coord_git} local-op timeout
+    contract.  Six values were extracted from inline literals at
+    [coord_git.ml] and [coord_worktree.ml]:
+
+    - [coord_git.ml:45]        30.0  (run_argv_line   helper)
+    - [coord_git.ml:56]        30.0  (run_argv_exit   default arg)
+    - [coord_git.ml:74]        30.0  (run_argv_lines  helper)
+    - [coord_worktree.ml:21]   30.0  (run_argv_lines  helper)
+    - [coord_worktree.ml:31]   30.0  (run_argv_with_status default arg)
+    - [coord_worktree.ml:868]  30.0  (worktree add -B direct call)
+
+    All six sites share the same semantic bucket: "local-only git
+    operations" (rev-parse, status, branch, worktree add — no
+    network IO).  Network-bound git ops (fetch, push) intentionally
+    use a separate knob ({!Env_config_core.git_fetch_timeout_sec}).
+
+    Properties pinned:
+
+    1. Default preserves the pre-extraction literal exactly.
+    2. The local-op budget is strictly less than the network-bound
+       fetch budget.  An operator who inverted this — by lowering
+       fetch below local — would silently break the implicit
+       precedence (a network fetch should always carry more headroom
+       than a local rev-parse), turning what should be a slow-network
+       failure into a fast-local timeout.
+    3. Floor clamp (5.0) prevents degenerate operator config that
+       would race subprocess startup. *)
+
+open Alcotest
+
+module C = Env_config_runtime.Coord_git
+
+let approx = float 0.001
+
+let test_default_local_op () =
+  check approx
+    "local_op_timeout_sec default (was inline 30.0 ×6)"
+    30.0 C.local_op_timeout_sec
+
+let test_local_strictly_less_than_fetch () =
+  check bool
+    "local_op_timeout_sec MUST stay below \
+     Env_config_core.git_fetch_timeout_sec (network fetch needs more \
+     headroom than a local rev-parse)"
+    true
+    (C.local_op_timeout_sec < Env_config_core.git_fetch_timeout_sec ())
+
+let test_smoke_call_site_compiles () =
+  let _ = C.local_op_timeout_sec in
+  check bool "accessor is reachable" true true
+
+let () =
+  run "env_config_coord_git_local_timeout"
+    [
+      ( "default preserves pre-extraction literal",
+        [
+          test_case "local_op = 30.0" `Quick test_default_local_op;
+        ] );
+      ( "ordering invariant",
+        [
+          test_case "local_op < git_fetch" `Quick
+            test_local_strictly_less_than_fetch;
+        ] );
+      ( "API surface",
+        [
+          test_case "accessor reachable" `Quick
+            test_smoke_call_site_compiles;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Six inline `~timeout_sec:30.0` literals in `lib/coord/coord_git.ml` and `lib/coord/coord_worktree.ml` collapsed into one accessor on `Env_config_runtime.Coord_git`. Continues the #10426 audit cascade.

| accessor | default | floor | env | call sites |
|---|---|---|---|---|
| `local_op_timeout_sec` | 30.0 | 5.0 | `MASC_COORD_GIT_LOCAL_OP_TIMEOUT_SEC` | `coord_git.ml:45/56/74` + `coord_worktree.ml:21/31/868` |

Default `30.0` preserves the inline literal exactly — no behavior change.

## Why

The two existing comments (`coord_git.ml:53-55` and `coord_worktree.ml:27-30`) already document the semantic split: "local-only operations" vs network-bound (which uses `Env_config_core.git_fetch_timeout_sec`). The two budgets must remain separate knobs — bundling them would force an operator who needs to extend a flaky `git fetch` over a slow proxy to also extend every `git rev-parse` on hot paths, padding tail latency needlessly.

This is the "기다리지 않아도 될 부분을 기다리고" axis — local rev-parse should not wait for a fetch-timeout-sized budget.

No new library deps required — `lib/coord/dune` already lists `masc_config`.

## Test Plan

- [x] `opam exec -- dune build @check` (clean)
- [x] `dune exec test/test_env_config_coord_git_local_timeout.exe` — 3/3 pass
- [ ] CI: Lint + Build green

Pinned properties:
1. Default preserves pre-extraction literal exactly.
2. `local_op < git_fetch` invariant — network fetch must always carry more headroom than a local rev-parse, otherwise a slow-network failure would manifest as a fast-local timeout.
3. Floor clamp (5.0) prevents subprocess startup race.

## Cascade Progress (#10426)

Landed: Process_eio default (#10889), KeeperBootstrap (#10957), Dashboard mission/shell/render (#10880), Dashboard execution (#10886), shell prewarm inner/outer (#10797), Sidecar (#11049), Voice (#11045 in-flight).

This PR: Coord local git ops.

Remaining (sample): keeper/keeper_exec_*, dashboard helpers, autoresearch_git (closed #11043 — possibly needs different approach without cross-library dep).
