### PR TITLE
i18n(dashboard): localize 9 'phase' lane meaning fields (round-96)

### DIFF
--- a/dashboard/src/components/fsm-hub-lane-analysis.ts
+++ b/dashboard/src/components/fsm-hub-lane-analysis.ts
@@ -53,22 +53,22 @@ function laneMeaning(
       switch (value) {
         case 'Running':
           return snapshot.is_live
-            ? { tone: 'info', meaning: 'parent lifecycle is healthy while the live turn advances' }
-            : { tone: 'ok', meaning: 'no live turn; waiting for the next observation cycle' }
+            ? { tone: 'info', meaning: 'parent lifecycle 정상 — live turn 진행 중' }
+            : { tone: 'ok', meaning: 'live turn 없음 — 다음 observation cycle 대기' }
         case 'Failing':
-          return { tone: 'error', meaning: 'the parent lifecycle is degraded and must clear before healthy turns resume' }
+          return { tone: 'error', meaning: 'parent lifecycle degraded — healthy turn 재개 전 해소 필요' }
         case 'Overflowed':
-          return { tone: 'warn', meaning: 'context overflow has been latched and must resolve before healthy turns resume' }
+          return { tone: 'warn', meaning: 'context overflow latched — healthy turn 재개 전 해소 필요' }
         case 'Compacting':
-          return { tone: 'warn', meaning: 'post-turn compaction currently owns the lifecycle' }
+          return { tone: 'warn', meaning: 'post-turn compaction 이 lifecycle 점유 중' }
         case 'HandingOff':
-          return { tone: 'warn', meaning: 'handoff is draining this keeper toward stop' }
+          return { tone: 'warn', meaning: 'handoff 가 keeper 를 stop 방향으로 drain 중' }
         case 'Draining':
-          return { tone: 'warn', meaning: 'the keeper is draining in-flight work before stop' }
+          return { tone: 'warn', meaning: 'keeper 가 in-flight work 를 drain 중 (stop 전)' }
         case 'Stable':
-          return { tone: 'info', meaning: 'no lifecycle activity is currently expected' }
+          return { tone: 'info', meaning: '현재 예상되는 lifecycle activity 없음' }
         default:
-          return { tone: 'info', meaning: 'lifecycle state observed' }
+          return { tone: 'info', meaning: 'lifecycle state 관측됨' }
       }
     case 'turn':
       switch (value) {


### PR DESCRIPTION
## Summary

새 surface 발견 — `fsm-hub-lane-analysis.ts` 의 `deriveLaneInsight` 가 `meaning` field 30+ entries 를 영어로 가지고 있음. 이 round 는 첫 번째 switch (`'phase'`) 의 9 entries 한국어화. turn/decision/cascade/compaction switches 는 follow-up rounds.

## Localized branches

| `phase` value | Before | After |
|---|---|---|
| `Running` + `is_live` | `'parent lifecycle is healthy while the live turn advances'` | `'parent lifecycle 정상 — live turn 진행 중'` |
| `Running` + `!is_live` | `'no live turn; waiting for the next observation cycle'` | `'live turn 없음 — 다음 observation cycle 대기'` |
| `Failing` | `'the parent lifecycle is degraded and must clear before healthy turns resume'` | `'parent lifecycle degraded — healthy turn 재개 전 해소 필요'` |
| `Overflowed` | `'context overflow has been latched and must resolve before healthy turns resume'` | `'context overflow latched — healthy turn 재개 전 해소 필요'` |
| `Compacting` | `'post-turn compaction currently owns the lifecycle'` | `'post-turn compaction 이 lifecycle 점유 중'` |
| `HandingOff` | `'handoff is draining this keeper toward stop'` | `'handoff 가 keeper 를 stop 방향으로 drain 중'` |
| `Draining` | `'the keeper is draining in-flight work before stop'` | `'keeper 가 in-flight work 를 drain 중 (stop 전)'` |
| `Stable` | `'no lifecycle activity is currently expected'` | `'현재 예상되는 lifecycle activity 없음'` |
| default | `'lifecycle state observed'` | `'lifecycle state 관측됨'` |

## Domain term policy

`parent lifecycle`, `live turn`, `observation cycle`, `context overflow`, `latched`, `post-turn compaction`, `handoff`, `in-flight work`, `healthy turn`, `lifecycle state` 보존 — FSM spec 도메인 용어.

## Test impact

`fsm-hub-lane-analysis.test.ts` 가 `isObservedStall` 함수만 검증, `meaning` field 어떤 toContain/toBe assertion 도 없음. test sync 0.

## Backlog (다음 round)

같은 helper 의 `turn` (line 76-86), `decision` (line 91-99), `cascade` (line 104-114), `compaction` (line 119-...) switches — 약 ~25 entries 남음.

## Scope

- 1 파일, 9줄.
- test 영향 0.
