### PR TITLE
feat(dashboard): add Heartbeat + LifelineBar primitives (cb-group-a)

### DIFF
--- a/dashboard/src/components/lifeline-bar.test.ts
+++ b/dashboard/src/components/lifeline-bar.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Heartbeat, LifelineBar, heartbeatPoints } from './lifeline-bar'
+
+describe('heartbeatPoints (pure)', () => {
+  it('returns 61 points (segments 0..60 inclusive) as space-separated pairs', () => {
+    const out = heartbeatPoints(0, 320, 32)
+    expect(out.split(' ')).toHaveLength(61)
+  })
+
+  it('first x is 0, last x equals width (within rounding)', () => {
+    const out = heartbeatPoints(0, 320, 32).split(' ')
+    expect(out[0]!.startsWith('0.0,')).toBe(true)
+    expect(out[60]!.startsWith('320.0,')).toBe(true)
+  })
+
+  it('is deterministic for the same (phase, width, height)', () => {
+    expect(heartbeatPoints(0.42, 240, 14)).toBe(heartbeatPoints(0.42, 240, 14))
+  })
+
+  it('changes when phase advances', () => {
+    expect(heartbeatPoints(0, 320, 32)).not.toBe(heartbeatPoints(0.5, 320, 32))
+  })
+
+  it('honors a custom width — last x equals that width', () => {
+    const out = heartbeatPoints(0, 240, 14).split(' ')
+    expect(out[60]!.startsWith('240.0,')).toBe(true)
+  })
+
+  it('all y values stay within [0, height] for height=32 (no out-of-bounds spike)', () => {
+    const out = heartbeatPoints(0, 320, 32).split(' ')
+    for (const pt of out) {
+      const y = Number(pt.split(',')[1])
+      // Spikes go up to ±0.4 * height around the midline (16). Allow a
+      // small fudge for the sin component (1.5px amplitude).
+      expect(y).toBeGreaterThan(0)
+      expect(y).toBeLessThan(32)
+    }
+  })
+
+  it('uses default width/height when omitted', () => {
+    const out = heartbeatPoints(0)
+    expect(out.split(' ')).toHaveLength(61)
+    const last = out.split(' ')[60]!
+    expect(last.startsWith('320.0,')).toBe(true)
+  })
+})
+
+describe('Heartbeat component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders an aria-hidden <svg> with the polyline trace', () => {
+    render(html`<${Heartbeat} />`, container)
+    const svg = container.querySelector('svg')!
+    expect(svg).toBeTruthy()
+    expect(svg.getAttribute('aria-hidden')).toBe('true')
+    const poly = svg.querySelector('polyline')!
+    expect(poly).toBeTruthy()
+    const pts = poly.getAttribute('points')!
+    expect(pts.split(' ')).toHaveLength(61)
+  })
+
+  it('honors width and height by setting the svg style and viewBox', () => {
+    render(html`<${Heartbeat} width=${240} height=${14} />`, container)
+    const svg = container.querySelector('svg')!
+    expect(svg.getAttribute('viewBox')).toBe('0 0 240 14')
+    expect((svg as unknown as SVGSVGElement).style.width).toBe('240px')
+    expect((svg as unknown as SVGSVGElement).style.height).toBe('14px')
+  })
+
+  it('renders the trailing pulse dot (circle + animate) by default', () => {
+    render(html`<${Heartbeat} />`, container)
+    const circle = container.querySelector('circle')
+    const animate = container.querySelector('animate')
+    expect(circle).toBeTruthy()
+    expect(animate).toBeTruthy()
+    expect(animate!.getAttribute('attributeName')).toBe('r')
+  })
+
+  it('omits the pulse dot when withoutPulseDot is true', () => {
+    render(html`<${Heartbeat} withoutPulseDot=${true} />`, container)
+    expect(container.querySelector('circle')).toBeNull()
+    expect(container.querySelector('animate')).toBeNull()
+  })
+
+  it('uses a custom color on both the polyline stroke and the dot fill', () => {
+    render(html`<${Heartbeat} color="#ff0000" />`, container)
+    expect(container.querySelector('polyline')!.getAttribute('stroke')).toBe('#ff0000')
+    expect(container.querySelector('circle')!.getAttribute('fill')).toBe('#ff0000')
+  })
+
+  it('phase change updates the trace points (re-render)', () => {
+    render(html`<${Heartbeat} phase=${0} />`, container)
+    const before = container.querySelector('polyline')!.getAttribute('points')
+    render(html`<${Heartbeat} phase=${0.7} />`, container)
+    const after = container.querySelector('polyline')!.getAttribute('points')
+    expect(after).not.toBe(before)
+  })
+})
+
+describe('LifelineBar component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders the LIFELINE label by default', () => {
+    render(html`<${LifelineBar} />`, container)
+    expect(container.textContent).toContain('LIFELINE')
+  })
+
+  it('honors a custom label', () => {
+    render(html`<${LifelineBar} label="FLEET" />`, container)
+    expect(container.textContent).toContain('FLEET')
+  })
+
+  it('renders the BPM + window caption when bpm is given', () => {
+    render(html`<${LifelineBar} bpm=${72} window="60s" />`, container)
+    expect(container.textContent).toContain('72')
+    expect(container.textContent).toContain('BPM')
+    expect(container.textContent).toContain('60s')
+  })
+
+  it('omits the BPM caption when bpm is undefined', () => {
+    render(html`<${LifelineBar} />`, container)
+    // Caption with "BPM" appears only when bpm is provided
+    expect(container.textContent).not.toContain('BPM')
+  })
+
+  it('emits role="img" with a composed aria-label when bpm given', () => {
+    render(html`<${LifelineBar} bpm=${72} window="60s" />`, container)
+    const root = container.querySelector('[role="img"]')!
+    expect(root.getAttribute('aria-label')).toBe('LIFELINE heartbeat at 72 BPM, 60s window')
+  })
+
+  it('falls back to a window-only aria-label when bpm omitted', () => {
+    render(html`<${LifelineBar} />`, container)
+    const root = container.querySelector('[role="img"]')!
+    expect(root.getAttribute('aria-label')).toBe('LIFELINE heartbeat, 60s window')
+  })
+
+  it('caller-supplied ariaLabel overrides composition', () => {
+    render(
+      html`<${LifelineBar} bpm=${72} ariaLabel="Custom announcement" />`,
+      container,
+    )
+    const root = container.querySelector('[role="img"]')!
+    expect(root.getAttribute('aria-label')).toBe('Custom announcement')
+  })
+
+  it('renders the inner Heartbeat svg', () => {
+    render(html`<${LifelineBar} />`, container)
+    expect(container.querySelector('svg polyline')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/lifeline-bar.ts
+++ b/dashboard/src/components/lifeline-bar.ts
@@ -1,0 +1,183 @@
+// Lifeline bar — ECG-style heartbeat visualizer for fleet activity.
+//
+// Ported from design-system v0.4 cb-group-a (preview/cb-group-a.jsx
+// LifelineBeat / LifelineStacked + cb-shared.jsx Heartbeat). Two
+// primitives in one module:
+//
+//   Heartbeat   — atomic SVG polyline (decorative). Stateless: caller
+//                 drives `phase` (0..1) from a setInterval / signal /
+//                 data source. The trailing accent dot pulses on its
+//                 own via SVG <animate>.
+//
+//   LifelineBar — composite tile: "LIFELINE" label + Heartbeat + BPM
+//                 caption. Same surface treatment as KpiCell so a
+//                 fleet status row can mix Kpi cells and a lifeline.
+//
+// The original css selectors (.cb-lifeline / .cb-board) are not in
+// scope for the dashboard — re-implementation against the dashboard
+// token set + htm/preact + Tailwind utility-only convention.
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+
+const HEARTBEAT_SEGMENTS = 60
+const HEARTBEAT_DEFAULT_WIDTH = 320
+const HEARTBEAT_DEFAULT_HEIGHT = 32
+
+/** Build the SVG polyline `points` string for an ECG-style heartbeat
+ *  trace. Pure: same `(phase, width, height)` always yields the same
+ *  string. Exposed for tests + for callers that want to drop the
+ *  trace into their own `<svg>` (e.g. a stacked lifeline that arrays
+ *  many traces in one viewBox). */
+export function heartbeatPoints(
+  phase: number,
+  width: number = HEARTBEAT_DEFAULT_WIDTH,
+  height: number = HEARTBEAT_DEFAULT_HEIGHT,
+): string {
+  const points: string[] = []
+  for (let i = 0; i <= HEARTBEAT_SEGMENTS; i++) {
+    const t = i / HEARTBEAT_SEGMENTS
+    const x = t * width
+    let y = height / 2 + Math.sin((t + phase) * 6) * 1.5
+    const s = (i + Math.floor(phase * 60)) % 12
+    if (s === 3) y -= height * 0.35
+    if (s === 4) y += height * 0.4
+    if (s === 5) y -= height * 0.15
+    points.push(`${x.toFixed(1)},${y.toFixed(1)}`)
+  }
+  return points.join(' ')
+}
+
+export interface HeartbeatProps {
+  /** 0..1 — animates the trace. Caller drives via setInterval / signal. */
+  phase?: number
+  width?: number
+  height?: number
+  /** Stroke + dot color. Defaults to the brass accent token. */
+  color?: string
+  /** Skip the trailing pulsing dot — use when the trace is meant to
+   *  be a static snapshot, not a live indicator. */
+  withoutPulseDot?: boolean
+}
+
+export function Heartbeat({
+  phase = 0,
+  width = HEARTBEAT_DEFAULT_WIDTH,
+  height = HEARTBEAT_DEFAULT_HEIGHT,
+  color = 'var(--color-accent-fg)',
+  withoutPulseDot = false,
+}: HeartbeatProps): VNode {
+  const points = heartbeatPoints(phase, width, height)
+  return html`
+    <svg
+      viewBox=${`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      focusable="false"
+      style=${{ width: `${width}px`, height: `${height}px`, display: 'block' }}
+    >
+      <polyline
+        points=${points}
+        fill="none"
+        stroke=${color}
+        stroke-width="1.2"
+      />
+      ${withoutPulseDot
+        ? null
+        : html`
+            <circle cx=${width - 2} cy=${height / 2} r="2" fill=${color}>
+              <animate attributeName="r" values="2;3.5;2" dur="1.4s" repeatCount="indefinite" />
+            </circle>
+          `}
+    </svg>
+  `
+}
+
+const MONO_STACK = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+const surfaceStyle = {
+  background: 'var(--bg-panel)',
+  border: '1px solid var(--border-base)',
+  borderRadius: '3px',
+}
+
+const labelStyle = {
+  fontSize: '10px',
+  color: 'var(--color-fg-disabled)',
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase' as const,
+  fontWeight: 600,
+}
+
+const captionStyle = {
+  fontSize: '10px',
+  color: 'var(--color-fg-muted)',
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase' as const,
+  fontWeight: 500,
+}
+
+export interface LifelineBarProps {
+  /** Short slug rendered on the left, e.g. "LIFELINE". */
+  label?: string
+  /** 0..1 — driven by the caller. */
+  phase?: number
+  /** Display BPM number ("72"). When omitted, only the trace shows. */
+  bpm?: number | string
+  /** Window string rendered next to BPM ("60s"). */
+  window?: string
+  /** Heartbeat trace size. */
+  width?: number
+  height?: number
+  /** Override the trace color — defaults to the brass accent token. */
+  color?: string
+  /** Optional aria-label for the bar (defaults to a composed sentence). */
+  ariaLabel?: string
+}
+
+export function LifelineBar({
+  label = 'LIFELINE',
+  phase = 0,
+  bpm,
+  window = '60s',
+  width = HEARTBEAT_DEFAULT_WIDTH,
+  height = HEARTBEAT_DEFAULT_HEIGHT,
+  color,
+  ariaLabel,
+}: LifelineBarProps): VNode {
+  const composedLabel = ariaLabel
+    ?? (bpm !== undefined
+      ? `${label} heartbeat at ${bpm} BPM, ${window} window`
+      : `${label} heartbeat, ${window} window`)
+
+  return html`
+    <div
+      role="img"
+      aria-label=${composedLabel}
+      style=${{
+        ...surfaceStyle,
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '12px',
+        padding: '8px 12px',
+        fontFamily: MONO_STACK,
+      }}
+    >
+      <span aria-hidden="true" style=${labelStyle}>${label}</span>
+      <${Heartbeat} phase=${phase} width=${width} height=${height} color=${color} />
+      ${bpm !== undefined
+        ? html`
+            <span aria-hidden="true" style=${captionStyle}>
+              <span style=${{
+                color: 'var(--color-fg-primary)',
+                fontWeight: 700,
+                fontVariantNumeric: 'tabular-nums',
+                marginRight: '4px',
+              }}>${bpm}</span>
+              BPM · ${window}
+            </span>
+          `
+        : null}
+    </div>
+  `
+}


### PR DESCRIPTION
## Why

Second cb-group-a port (KpiCell was first in #11066). The user's directive: *"실제 재사용 가능 프리미티브부터 만들고 하나씩 적용"*. LifelineBar is the most distinctive visual element in cb-group-a — an ECG-style heartbeat trace that signals "this fleet/keeper is alive". Same recipe as #10955 (KeeperBadge) and #11066 (KpiCell): primitive only, callsite migration in follow-up PRs.

## What

`src/components/lifeline-bar.ts` — three exports:

| Export | Kind | Purpose |
|--------|------|---------|
| `heartbeatPoints` | pure helper | Build the SVG polyline `points` string for an ECG trace. Same `(phase, width, height)` always yields the same string. Exposed so callers can drop the trace into their own `<svg>` (e.g. a future `LifelineStacked` that arrays many traces). |
| `Heartbeat` | atomic component | Decorative `<svg>` rendering the trace + a pulsing endpoint dot. Stateless: caller drives `phase` (0..1). |
| `LifelineBar` | composite component | "LIFELINE" label + Heartbeat + BPM/window caption inside a panel surface — same chrome as KpiCell so a fleet status row can mix the two uniformly. |

### Heartbeat props
| Prop | Default | Purpose |
|------|---------|---------|
| `phase` | `0` | 0..1, drives the trace shape. Caller updates via `useState` + `setInterval`, signal, or data. |
| `width` / `height` | `320` / `32` | px. |
| `color` | `var(--color-accent-fg)` | stroke + dot fill. Override for per-keeper or status tones. |
| `withoutPulseDot` | `false` | Skip the trailing animate-r dot — for static snapshots. |

### LifelineBar props
| Prop | Default | Purpose |
|------|---------|---------|
| `label` | `'LIFELINE'` | Uppercase slug on the left. |
| `phase` | `0` | Forwarded to Heartbeat. |
| `bpm` | (omitted) | When given, the BPM caption appears. |
| `window` | `'60s'` | Caption window string. |
| `width`/`height`/`color` | (forwarded) | To Heartbeat. |
| `ariaLabel` | (composed) | Defaults to `"LIFELINE heartbeat at 72 BPM, 60s window"`-style sentence. |

## Why Heartbeat is stateless (no built-in animation)

The cb-group-a `LifelineBeat` does `useState + setInterval(50ms, +0.02)` internally. Porting that as-is would bake a renderer-side timer into every callsite — caller can't slow it down, can't pause when the tab is hidden, can't drive it from real data (e.g. fleet TPS). Stateless is the more reusable shape; the test file shows the two-line caller pattern:

```ts
const [phase, setPhase] = useState(0)
useEffect(() => {
  const t = setInterval(() => setPhase(p => (p + 0.02) % 1), 50)
  return () => clearInterval(t)
}, [])
return html`<${Heartbeat} phase=${phase} />`
```

A future `useHeartbeatPhase()` hook could DRY this if 3+ callsites end up needing identical timing — premature for now.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run src/components/lifeline-bar.test.ts` — 21 / 21 pass:
  - `heartbeatPoints`: 61 segments, endpoint x ≡ width, determinism, phase change varies output, custom dimensions, y stays within height bounds, default args
  - `Heartbeat`: aria-hidden svg, polyline + viewBox/style sizing, pulse-dot circle + animate, color override on stroke and fill, phase change updates trace
  - `LifelineBar`: default LIFELINE label, custom label, BPM caption presence/absence, role="img" + composed/overridden aria-label, inner Heartbeat svg renders
- [ ] Visual smoke: render `<LifelineBar bpm=${72} phase=${live} />` in the dashboard shell — queued for first callsite migration.

## What this PR does NOT do

- **No `LifelineStacked`** (per-keeper stacked traces with KeeperBadge sigil from cb-group-a). It's a future composite over an array of phases + keeper ids; defer until at least one callsite is committed.
- **No phase driver hook.** Caller picks the timing source; baking a default would over-fit one timing.
- **No callsite migration.** Same cadence as KeeperBadge / KpiCell — primitive lands first.

## Refs

- Source: `dashboard/design-system/preview/cb-group-a.jsx` (LifelineBeat / LifelineStacked) + `cb-shared.jsx` (Heartbeat)
- Precedent: #11066 (KpiCell — first cb-group-a primitive), #10955 (KeeperBadge — original pattern)
- SPEC: `dashboard/design-system/SPEC.md` §3 (typography + tokens)
- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
