### PR TITLE
feat(dashboard): adopt canonical border tokens in 11 files (CS103)

### DIFF
--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -194,7 +194,7 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
           <button
             type="button"
             class="inline-flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-2xs transition-all duration-150 ${showLifecycle.value
-              ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--color-fg-secondary)]'
+              ? 'border-[var(--color-border-default)] bg-[var(--accent-soft)] text-[var(--color-fg-secondary)]'
               : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)]'}"
             onClick=${() => { showLifecycle.value = !showLifecycle.value }}
           >

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -576,7 +576,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             <div class="flex min-w-0 flex-col gap-2">
               <div class="flex flex-wrap items-center gap-3">
                 <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">디렉터리 필터</span>
-                <span class="inline-flex items-center rounded-sm border border-[var(--border-slate-22)] bg-[var(--accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]">${resultCountLabel}</span>
+                <span class="inline-flex items-center rounded-sm border border-[var(--color-border-default)] bg-[var(--accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]">${resultCountLabel}</span>
               </div>
               <p class="m-0 max-w-180 text-sm leading-loose text-[var(--color-fg-primary)]">${pageDescription}</p>
             </div>
@@ -705,7 +705,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           return html`
             <button type="button"
-              class="monitor-surface-card monitor-surface-card-medium group flex w-full flex-col gap-3.5 rounded-card p-4 text-left transition-all duration-200 cursor-pointer hover:border-[var(--border-slate-22)] hover:bg-[var(--color-bg-surface)] hover:-translate-y-0.5"
+              class="monitor-surface-card monitor-surface-card-medium group flex w-full flex-col gap-3.5 rounded-card p-4 text-left transition-all duration-200 cursor-pointer hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)] hover:-translate-y-0.5"
               key=${agent.name}
               aria-label=${detailLabel}
               onClick=${openDetail}
@@ -759,7 +759,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               ` : null}
 
               ${isKeeper && (monitoringEvidence?.phase || monitoringEvidence?.stage) ? html`
-                <div class="rounded-[16px] border border-[var(--border-slate-12)] bg-[linear-gradient(180deg,var(--white-3),var(--white-1))] px-3 py-2.5">
+                <div class="rounded-[16px] border border-[var(--color-border-divider)] bg-[linear-gradient(180deg,var(--white-3),var(--white-1))] px-3 py-2.5">
                   <div class="flex flex-wrap items-center gap-2">
                     ${monitoringEvidence?.phase && fsmPhaseKey
                       ? html`<${KeeperPhaseBadge} phase=${fsmPhaseKey} compact />`

--- a/dashboard/src/components/common/filter-chips.ts
+++ b/dashboard/src/components/common/filter-chips.ts
@@ -36,10 +36,10 @@ export function FilterChips<T extends string>({
     ? 'inline-flex min-h-9 items-center gap-1.5 rounded border px-3 py-2 text-2xs font-medium'
     : 'inline-flex items-center gap-1.5 rounded border px-2 py-1 text-[length:var(--fs-xs)]'
   const activeToneClass = tone === 'accent'
-    ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--color-fg-secondary)]'
+    ? 'border-[var(--color-border-default)] bg-[var(--accent-soft)] text-[var(--color-fg-secondary)]'
     : 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn-bright)]'
   const idleToneClass = tone === 'accent'
-    ? 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:border-[var(--border-slate-22)] hover:text-[var(--color-fg-primary)]'
+    ? 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:border-[var(--color-border-default)] hover:text-[var(--color-fg-primary)]'
     : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-disabled)] hover:bg-[var(--white-8)] hover:border-[rgba(200,168,78,0.4)]'
 
   return html`

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -577,7 +577,7 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
   const isOffline = isOfflineStatus(keeper.status)
 
   return html`
-    <div class="border-t border-[var(--border-slate-12)] pt-5">
+    <div class="border-t border-[var(--color-border-divider)] pt-5">
       <h3 class="m-0 mb-3 text-sm font-semibold text-[var(--color-fg-secondary)] uppercase tracking-[0.06em]">직접 통신</h3>
 
       ${isOffline ? html`
@@ -1034,7 +1034,7 @@ export function KeeperDetailPage() {
               keeper=${keeper}
               onSocialSweep=${() => { void runSocialSweep() }}
             />
-            <div class="pt-3 border-t border-[var(--border-slate-12)]">
+            <div class="pt-3 border-t border-[var(--color-border-divider)]">
               <h4 class="m-0 mb-3 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">호출 검사기</h4>
               ${diagOpen ? html`<${KeeperToolCallInspector} keeperName=${keeper.name} />` : null}
             </div>

--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -29,7 +29,7 @@ export function Live({ variant = 'full' }: LiveProps) {
       ` : null}
 
       ${!observatoryMode ? html`
-        <section class="rounded-[var(--radius-xl)] border border-[var(--border-slate-12)] bg-[var(--white-3)] p-4" aria-label="이벤트 펄스 현황">
+        <section class="rounded-[var(--radius-xl)] border border-[var(--color-border-divider)] bg-[var(--white-3)] p-4" aria-label="이벤트 펄스 현황">
           <${PulseStrip} />
         </section>
       ` : null}

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -46,7 +46,7 @@ export function ActivityStream() {
 
   return html`
     <div class="grid gap-3 grid-rows-[auto_auto_1fr] min-h-0">
-      <div class="activity-stream-head flex items-center justify-between gap-3 border-b border-[var(--border-slate-12)] pb-3">
+      <div class="activity-stream-head flex items-center justify-between gap-3 border-b border-[var(--color-border-divider)] pb-3">
         <h3 class="m-0 text-[0.95rem] font-semibold text-[var(--color-fg-secondary)]">활동 스트림</h3>
         <span class="text-xs text-[var(--color-fg-muted)]">${totalEvents.value} 수신 · ${entries.length} 표시</span>
       </div>
@@ -61,7 +61,7 @@ export function ActivityStream() {
           : entries.map((entry, i) => html`
             <div
               key=${`${entry.timestamp}-${i}`}
-              class="activity-item rounded border border-[var(--border-slate-12)] border-l-2 bg-[var(--white-2)] px-3.5 py-3 ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
+              class="activity-item rounded border border-[var(--color-border-divider)] border-l-2 bg-[var(--white-2)] px-3.5 py-3 ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
             >
               <div class="activity-item-head flex items-center gap-2">
                 <span class="activity-kind-chip rounded px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.04em] ${eventKindColor(entry)}">${eventKindLabel(entry)}</span>

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -34,7 +34,7 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
       ${compact
         ? null
         : html`
-            <div class="focus-sidebar-head flex items-center justify-between gap-3 border-b border-[var(--border-slate-12)] pb-3">
+            <div class="focus-sidebar-head flex items-center justify-between gap-3 border-b border-[var(--color-border-divider)] pb-3">
               <h3 class="m-0 text-[0.95rem] font-semibold text-[var(--color-fg-secondary)]">에이전트</h3>
               <span class="text-xs text-[var(--color-fg-muted)]">${list.length}명 활성</span>
             </div>
@@ -46,7 +46,7 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
             <button
               type="button"
               key=${agent.name}
-              class="focus-agent-card w-full rounded border border-[var(--border-slate-12)] bg-[var(--white-3)] p-3.5 transition-colors duration-200 text-left cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent ${selected === agent.name ? 'focus-agent-selected' : ''}"
+              class="focus-agent-card w-full rounded border border-[var(--color-border-divider)] bg-[var(--white-3)] p-3.5 transition-colors duration-200 text-left cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent ${selected === agent.name ? 'focus-agent-selected' : ''}"
               onClick=${() => openAgentDetail(agent.name)}
             >
               <div class="focus-agent-header">
@@ -60,7 +60,7 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
                 </span>
               </div>
               ${agent.currentTask
-                ? html`<div class="text-[0.75rem] text-[var(--color-fg-primary)] py-[3px] px-2 bg-[var(--white-2)] border border-[var(--border-slate-12)] whitespace-nowrap overflow-hidden text-ellipsis rounded">${agent.currentTask}</div>`
+                ? html`<div class="text-[0.75rem] text-[var(--color-fg-primary)] py-[3px] px-2 bg-[var(--white-2)] border border-[var(--color-border-divider)] whitespace-nowrap overflow-hidden text-ellipsis rounded">${agent.currentTask}</div>`
                 : null}
               <div class="flex items-center gap-2 mt-1">
                 ${agent.lastActivityText

--- a/dashboard/src/components/live/keeper-health-strip.ts
+++ b/dashboard/src/components/live/keeper-health-strip.ts
@@ -34,7 +34,7 @@ export function KeeperHealthStrip() {
   const alertCount = summary.warningCount + summary.criticalCount
 
   return html`
-    <div class="flex items-center gap-4 rounded border border-[var(--border-slate-12)] bg-[var(--white-3)] px-4 py-2.5">
+    <div class="flex items-center gap-4 rounded border border-[var(--color-border-divider)] bg-[var(--white-3)] px-4 py-2.5">
       <div class="flex items-center gap-2 min-w-0">
         <span class="text-sm font-medium text-[var(--color-fg-secondary)] whitespace-nowrap">
           Keeper

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -142,7 +142,7 @@ function CommentItem({
 
   return html`
     <div class="${indent}">
-      <div class="board-comment rounded p-3 bg-[var(--white-3)] border border-[var(--border-slate-12)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
+      <div class="board-comment rounded p-3 bg-[var(--white-3)] border border-[var(--color-border-divider)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
         <div class="flex items-center gap-2 mb-1.5">
           <span class="text-xs">${authorAvatar(authorAvatarKey)}</span>
           <${ActionButton} variant="subtle" size="sm" class="text-xs font-medium text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] bg-transparent border-none p-0" title=${authorTitle} ariaLabel=${`작성자 ${authorLabel} 프로필로 이동`} onClick=${() => navigateToAuthor(comment.author, undefined, comment.author_identity)}>${authorLabel}<//>
@@ -325,7 +325,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
           </div>
 
           <!-- Author and meta -->
-          <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
+          <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--color-border-divider)]">
             <span class="text-sm">${authorAvatar(authorAvatarKey)}</span>
             <${ActionButton} variant="subtle" size="sm" class="text-xs text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] bg-transparent border-none p-0" title=${authorTitle} ariaLabel=${`작성자 ${authorLabel} 프로필로 이동`} onClick=${() => navigateToAuthor(post.author, undefined, post.author_identity)}>${authorLabel}<//>
             <span class="text-2xs text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
@@ -354,7 +354,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
             ? html`
                 <details class="mt-1">
                   <summary class="cursor-pointer text-xs text-[var(--color-fg-muted)] py-1.5 hover:text-[var(--color-fg-primary)] transition-colors">운영 메타</summary>
-                  <div class="mt-2 p-3 rounded bg-[var(--white-3)] border border-[var(--border-slate-12)]">
+                  <div class="mt-2 p-3 rounded bg-[var(--white-3)] border border-[var(--color-border-divider)]">
                     ${post.meta.source ? html`<div class="text-xs text-[var(--color-fg-primary)]"><span class="text-[var(--color-fg-muted)]">출처:</span> ${post.meta.source}</div>` : null}
                     ${post.meta.state_block
                       ? html`<pre class="whitespace-pre-wrap mt-2 text-2xs text-[var(--color-fg-muted)] leading-relaxed">${post.meta.state_block}</pre>`

--- a/dashboard/src/components/memory-state.ts
+++ b/dashboard/src/components/memory-state.ts
@@ -155,8 +155,8 @@ export function categoryBadgeColor(cat: ContentCategory): string {
     case 'article': return 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)]'
     case 'review': return 'bg-[var(--purple-10)] text-[var(--purple)] border-[var(--purple-20)]'
     case 'notice': return 'bg-[var(--warn-10)] text-[var(--warn-bright)] border-[var(--warn-20)]'
-    case 'system': return 'bg-[var(--slate-gray-15)] text-[var(--text-slate)] border-[var(--border-slate-22)]'
-    default: return 'bg-[var(--white-8)] text-[var(--color-fg-muted)] border-[var(--border-slate-16)]'
+    case 'system': return 'bg-[var(--slate-gray-15)] text-[var(--text-slate)] border-[var(--color-border-default)]'
+    default: return 'bg-[var(--white-8)] text-[var(--color-fg-muted)] border-[var(--color-border-default)]'
   }
 }
 
@@ -252,10 +252,10 @@ export function kindLabel(kind: string): string {
 
 export function kindBadgeColor(kind: string): string {
   switch (kind) {
-    case 'direct': return 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--border-slate-12)]'
+    case 'direct': return 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--color-border-divider)]'
     case 'automation': return 'bg-[var(--cyan-16)] text-[var(--color-accent-fg)] border-[var(--cyan-16)]'
-    case 'system': return 'bg-[var(--slate-gray-15)] text-[var(--text-slate)] border-[var(--border-slate-22)]'
-    default: return 'bg-[var(--white-8)] text-[var(--color-fg-muted)] border-[var(--border-slate-16)]'
+    case 'system': return 'bg-[var(--slate-gray-15)] text-[var(--text-slate)] border-[var(--color-border-default)]'
+    default: return 'bg-[var(--white-8)] text-[var(--color-fg-muted)] border-[var(--color-border-default)]'
   }
 }
 
@@ -271,7 +271,7 @@ export function visibilityLabel(vis: string): string | null {
 
 export function visibilityBadgeColor(vis: string): string {
   if (vis === 'internal') return 'bg-[var(--white-10)] text-[var(--purple)] border-[var(--white-20)]'
-  return 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--border-slate-16)]'
+  return 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border-[var(--color-border-default)]'
 }
 
 // ── Data operations ────────────────────────────────────────────────

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -156,7 +156,7 @@ function renderCategorySection(
   if (posts.length === 0 && hidden === 0) return null
   if (posts.length === 0 && hidden > 0) {
     return html`
-      <div class="mb-3 px-3 py-2 rounded border border-dashed border-[var(--border-slate-16)] text-xs text-[var(--color-fg-muted)]">
+      <div class="mb-3 px-3 py-2 rounded border border-dashed border-[var(--color-border-default)] text-xs text-[var(--color-fg-muted)]">
         ${label} — ${hidden}건 숨김
       </div>
     `
@@ -174,7 +174,7 @@ function renderCategorySection(
         }} />
         <div class="text-center py-3">
           <button type="button"
-            class="px-4 py-2 rounded text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] transition-all cursor-pointer disabled:opacity-50"
+            class="px-4 py-2 rounded text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--color-border-default)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] transition-all cursor-pointer disabled:opacity-50"
             disabled=${loadingMore}
             onClick=${() => {
               expandCategory(category, limits, limit, posts.length)
@@ -271,7 +271,7 @@ function SortBar() {
               class="px-2.5 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer
                 ${isHidden
                   ? 'bg-[var(--accent-12)] text-[var(--color-accent-fg)] border-[var(--accent-18)] line-through opacity-60'
-                  : 'bg-transparent text-[var(--color-fg-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
+                  : 'bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-default)] hover:bg-[var(--white-6)]'
                 }"
               onClick=${() => {
                 const next = new Set(boardHiddenCategories.value)
@@ -318,12 +318,12 @@ function SortBar() {
               ${bulkDeleting.value ? '삭제 중...' : `선택 삭제 (${selectedPostIds.value.size})`}
             <//>
             <button type="button"
-              class="px-2 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]"
+              class="px-2 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-default)] hover:bg-[var(--white-6)]"
               onClick=${() => { selectedPostIds.value = new Set() }}
             >선택 해제</button>
           ` : null}
           <button type="button"
-            class="px-3 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] disabled:opacity-50 disabled:cursor-not-allowed"
+            class="px-3 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-default)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] disabled:opacity-50 disabled:cursor-not-allowed"
             onClick=${refreshBoard}
             disabled=${boardLoading.value}
           >
@@ -514,7 +514,7 @@ export function Memory() {
           <div>
             <${MemorySummary} />
             <button type="button"
-              class="mb-4 px-3 py-1.5 rounded text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] transition-all cursor-pointer"
+              class="mb-4 px-3 py-1.5 rounded text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--color-border-default)] hover:bg-[var(--white-6)] hover:text-[var(--color-fg-primary)] transition-all cursor-pointer"
               onClick=${() => navigate('workspace', { section: 'board' })}
             >← 게시판으로 돌아가기</button>
             ${detailLoading.value
@@ -529,7 +529,7 @@ export function Memory() {
       <${MemorySummary} />
       <${SortBar} />
       ${hint ? html`
-        <div class="mb-4 px-3 py-2 rounded border border-[var(--border-slate-16)] bg-[var(--white-3)] text-xs text-[var(--color-fg-muted)]">
+        <div class="mb-4 px-3 py-2 rounded border border-[var(--color-border-default)] bg-[var(--white-3)] text-xs text-[var(--color-fg-muted)]">
           ${hint}
         </div>
       ` : null}


### PR DESCRIPTION
## Summary

Phase G Step 4 (file-disjoint sweep). 31 sites across 11 files swap legacy `var(--border-slate-N)` opacity-bucket aliases to canonical SPEC §3.3 border tokens.

## Mapping (1:1 identical color via existing alias chain)

| Legacy | Canonical | Was |
|--------|-----------|-----|
| `--border-slate-8` / `--border-slate-12` | `--color-border-divider` | `--border-subtle` |
| `--border-slate-16` / `--border-slate-22` | `--color-border-default` | `--border-base` |
| `--border-slate-30` / `--border-slate-35` | `--color-border-strong` | `--border-strong` |

## Files (11 total)

| File | Sites |
|------|-------|
| `memory.ts` | 7 |
| `memory-state.ts` | 6 |
| `agent-roster.ts` | 3 |
| `live/focus-sidebar.ts` | 3 |
| `memory-post-detail.ts` | 3 |
| `keeper-detail.ts` | 2 |
| `common/filter-chips.ts` | 2 |
| `live/activity-stream.ts` | 2 |
| `activity-graph.ts` | 1 |
| `live.ts` | 1 |
| `live/keeper-health-strip.ts` | 1 |
| **Total** | **31** |

File-disjoint with in-flight CS102 (cascade-config-panel + telemetry-unified).

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test memory filter-chips activity-stream focus-sidebar` → 101/101 pass
- [x] Diff is 1:1 (31 ins / 31 del)