### PR TITLE
fix(keeper): surface 2 P1 silent failures in registry

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -224,7 +224,16 @@ let update_entry ~base_path name f =
   let rec loop () =
     let current = Atomic.get registry in
     match StringMap.find_opt key current with
-    | None -> ()
+    | None ->
+        (* P1 silent-failure fix: previously this returned () silently,
+           hiding the case where a caller (e.g. a turn-state setter)
+           raced with keeper deregistration and the update was lost.
+           29 callers funnel through here; logging once at the helper
+           makes every such race observable in operator logs without
+           changing any caller's signature. *)
+        Log.Keeper.warn
+          "registry: update_entry name=%s base_path=%s: entry not found, update dropped"
+          name base_path
     | Some entry ->
         let updated = StringMap.add key (f entry) current in
         if not (Atomic.compare_and_set registry current updated) then loop ()
@@ -414,10 +423,22 @@ let broadcast_composite_changed ~name ~ts_unix =
 
 let completed_turn_outcome_of_observation
     (obs : turn_observation) : Keeper_transition_audit.completed_turn_outcome =
-  match obs.decision_stage, obs.cascade_state with
-  | Decision_gate_rejected, _ -> Keeper_transition_audit.Turn_gate_rejected
-  | _, Cascade_done -> Keeper_transition_audit.Turn_substantive
-  | _ -> Keeper_transition_audit.Turn_failed
+  (* P1 silent-failure fix: the previous wildcard `| _ -> Turn_failed`
+     meant that adding a new variant to either ADT (decision_stage or
+     cascade_state) would silently fall through to Turn_failed without
+     a compile error.  Spelling out every variant lets the OCaml
+     exhaustiveness checker catch missing cases at build time. *)
+  match obs.decision_stage with
+  | Decision_gate_rejected -> Keeper_transition_audit.Turn_gate_rejected
+  | Decision_undecided
+  | Decision_guard_ok
+  | Decision_tool_policy_selected ->
+      (match obs.cascade_state with
+       | Cascade_done -> Keeper_transition_audit.Turn_substantive
+       | Cascade_idle
+       | Cascade_selecting
+       | Cascade_trying
+       | Cascade_exhausted -> Keeper_transition_audit.Turn_failed)
 
 let update_current_turn e f =
   let current_turn_observation =


### PR DESCRIPTION
## Why

Quality sweep PR-B — second of three (PR-A: dashboard merged-pending, PR-B: this, PR-C: transport telemetry) targeting the 8 P1 silent-failure findings from the recent scan.  Two patterns in `lib/keeper/keeper_registry.ml` left FSM state inconsistencies undiagnosable in operator logs.

## What

### Fix 1 — \`update_entry\` (line 222–232): entry-not-found silent no-op

```ocaml
(* before *)
| None -> ()
```

\`update_entry\` is the funnel for **29 setter callers** (\`mark_turn_started\`, \`mark_turn_measurement\`, \`set_turn_decision_stage\`, \`set_turn_cascade_state\`, \`set_turn_phase\`, \`set_turn_selected_model\`, plus 23 others).  Previously a race between a turn-state setter and keeper deregistration silently dropped the update.

```ocaml
(* after *)
| None ->
    Log.Keeper.warn
      "registry: update_entry name=%s base_path=%s: entry not found, update dropped"
      name base_path
```

No signature change → 29 caller sites get the surface for free.  This is more honest than fixing only the single \`set_turn_cascade_state\` site originally flagged by scan — the same race window exists for every setter.

### Fix 2 — \`completed_turn_outcome_of_observation\` (line 415–420): wildcard pattern

```ocaml
(* before *)
match obs.decision_stage, obs.cascade_state with
| Decision_gate_rejected, _ -> Turn_gate_rejected
| _, Cascade_done -> Turn_substantive
| _ -> Turn_failed
```

Adding a new variant to either ADT (\`decision_stage\` has 4, \`cascade_state\` has 5) would silently fall through to \`Turn_failed\` — exactly the silent-failure class the codebase forbids.

```ocaml
(* after — exhaustive on both axes *)
match obs.decision_stage with
| Decision_gate_rejected -> Turn_gate_rejected
| Decision_undecided | Decision_guard_ok | Decision_tool_policy_selected ->
    (match obs.cascade_state with
     | Cascade_done -> Turn_substantive
     | Cascade_idle | Cascade_selecting | Cascade_trying | Cascade_exhausted -> Turn_failed)
```

Now the OCaml exhaustiveness checker catches new variants at compile time.

## Scan finding #3 — false positive

The scan flagged \`keeper_registry.ml:1680\` for \`let _ = drain_turn_event_bus ()\`, but the file is actually \`keeper_unified_turn.ml:1680\`.  At that site (and 4 others: 1427, 1457, 1967, 2036) the pattern is **intentional fire-and-forget** — drain accumulates into a ref, the return value is the cumulative summary, not the incremental delta.  Excluded from this PR; documented in the silent-failure plan.

## Stack position

- PR-A (#11038, dashboard, draft) — independent
- **PR-B (this)** — server FSM
- PR-C (next, transport telemetry) — independent
- PR-D / E / F — P2 sweep per layer
- PR-G — P3 cleanup

All P1 PRs are independent (different files, different layers) and can land in any order.

## Build status

Net: 1 file, +20 -3.  Local dune build sanity-checked the changed module signature.  Full \`dune build @check\` pending CI — main has an unrelated pre-existing build error in \`coord_utils_backend_setup.mli\` (Eio.Net.t arity mismatch).  CI will surface whether that pre-existing error blocks PR-B verification or if it's already fixed on the CI base ref.

## Test plan

- [ ] CI \`dune build @check\` succeeds (or surfaces a pre-existing unrelated failure that's expected to be fixed independently)
- [ ] Manual: deregister a keeper while a turn-state setter races (e.g. \`set_turn_cascade_state\` after \`unregister\`) → verify the new warn line appears in operator logs
- [ ] (later) regression test: unit test that triggers \`update_entry\` on a missing name and asserts the warn fires