### PR TITLE
feat(transport): add P1 failure-path counters for SSE broadcast

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -492,6 +492,9 @@ let metric_mcp_tool_schema_tokens_approx =
 let metric_sse_sessions = "masc_sse_sessions_total"
 let metric_sse_broadcast_duration = "masc_sse_broadcast_duration_seconds"
 let metric_sse_broadcast_events = "masc_sse_broadcast_events_total"
+let metric_sse_broadcast_failures = "masc_sse_broadcast_failures_total"
+let metric_sse_external_subscriber_callback_failures =
+  "masc_sse_external_subscriber_callback_failures_total"
 let metric_sse_stream_queue_depth = "masc_sse_stream_queue_depth"
 let metric_sse_queue_depth_avg = "masc_sse_queue_depth_avg"
 let metric_sse_queue_depth_max = "masc_sse_queue_depth_max"
@@ -1098,6 +1101,17 @@ let init () =
   register_histogram ~name:metric_sse_broadcast_duration
     ~help:"Time to fan-out a broadcast to all SSE clients" ();
   add metric_sse_broadcast_events "Total SSE broadcast events emitted" Counter;
+  add metric_sse_broadcast_failures
+    "SSE broadcast deliveries that failed (stream full or enqueue exception). \
+     Labelled by target so the failure rate can be compared against \
+     masc_sse_broadcast_events_total per target."
+    Counter;
+  add metric_sse_external_subscriber_callback_failures
+    "External SSE subscriber callback exceptions (e.g. gRPC bridge \
+     stream errors).  A non-zero rate indicates that a downstream \
+     consumer is failing to accept events even though the SSE fanout \
+     considers the broadcast successful."
+    Counter;
   add metric_sse_stream_queue_depth
     "Per-session SSE event stream queue depth" Gauge;
   add metric_sse_queue_depth_avg

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -339,6 +339,8 @@ val metric_coord_join_normalize_outcome : string
 val metric_sse_sessions : string
 val metric_sse_broadcast_duration : string
 val metric_sse_broadcast_events : string
+val metric_sse_broadcast_failures : string
+val metric_sse_external_subscriber_callback_failures : string
 val metric_sse_stream_queue_depth : string
 val metric_sse_queue_depth_avg : string
 val metric_sse_queue_depth_max : string

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -591,6 +591,10 @@ let notify_external_subscribers event =
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
+        (* P1 silent-failure fix: previously only logged.  Increment a
+           counter so dashboards distinguish "all subscribers healthy"
+           from "subscribers exist but every callback throws." *)
+        Transport_metrics.inc_external_subscriber_callback_failure ();
         Log.Misc.warn "External subscriber %s failed: %s"
           sub.sub_id (Printexc.to_string exn)
     end
@@ -659,6 +663,11 @@ let broadcast_impl target json =
      subscribe/unsubscribe), so we iterate it directly with [SMap.iter].
      Skipping the [(k, v) :: acc] fold trims one tuple + cons cell per
      client per broadcast on this hot fan-out path. *)
+  let target_label = match target with
+    | All -> "all"
+    | Observers -> "observers"
+    | Coordinators -> "coordinators"
+  in
   let clients_entries = (Atomic.get clients).entries in
   let failed = ref [] in
   SMap.iter (fun session_id client ->
@@ -672,6 +681,10 @@ let broadcast_impl target json =
          See TLA+ SSEBroadcastBlock spec. *)
       (let queue_len = Eio.Stream.length client.event_stream in
        if queue_len >= stream_capacity then begin
+         (* P1 silent-failure fix: previously only logged.  Counter
+            lets operators see "all clients backlogged" as a Prometheus
+            rate, distinct from successful broadcasts. *)
+         Transport_metrics.inc_broadcast_failure ~target:target_label ();
          Log.Server.warn "Broadcast skip: session %s stream full (%d/%d)"
            session_id queue_len stream_capacity;
          failed := session_id :: !failed
@@ -683,6 +696,8 @@ let broadcast_impl target json =
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | e ->
+             (* Same P1 fix on the unexpected-exception defense path. *)
+             Transport_metrics.inc_broadcast_failure ~target:target_label ();
              Log.Server.error "Broadcast enqueue failed for session %s: %s"
                session_id (Printexc.to_string e);
              failed := session_id :: !failed)
@@ -692,11 +707,6 @@ let broadcast_impl target json =
   List.iter (fun sid -> unregister sid) !failed;
   (* Record broadcast duration for transport observability *)
   let elapsed = Time_compat.now () -. t0 in
-  let target_label = match target with
-    | All -> "all"
-    | Observers -> "observers"
-    | Coordinators -> "coordinators"
-  in
   Transport_metrics.observe_broadcast_duration ~target:target_label elapsed;
   sync_transport_snapshot ();
   (* Notify external subscribers (gRPC streams, etc.) *)

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -32,6 +32,29 @@ let observe_broadcast_duration ?target seconds =
   in
   Prometheus.inc_counter Prometheus.metric_sse_broadcast_events ~labels ()
 
+(* P1 silent-failure fix (transport scan):
+   masc_sse_broadcast_events_total only counts successes, so an operator
+   reading "0 events / sec" cannot tell whether the system is genuinely
+   idle or whether every broadcast is failing.  Pair with the success
+   counter and the same target label so health is computable as
+   `rate(failures[5m]) / (rate(events[5m]) + rate(failures[5m]))`. *)
+let inc_broadcast_failure ?target () =
+  let labels = match target with
+    | None -> []
+    | Some t -> [("target", t)]
+  in
+  Prometheus.inc_counter Prometheus.metric_sse_broadcast_failures ~labels ()
+
+(* P1 silent-failure fix (transport scan):
+   notify_external_subscribers in lib/sse.ml previously only logged
+   callback exceptions (Log.Misc.warn), leaving gRPC subscriber
+   flapping invisible to dashboards.  Counter is unlabelled because
+   the subscriber identity is high-cardinality (sub_id is gRPC stream
+   id); operators can correlate via the warn log line if needed. *)
+let inc_external_subscriber_callback_failure () =
+  Prometheus.inc_counter
+    Prometheus.metric_sse_external_subscriber_callback_failures ()
+
 let set_sse_queue_depth ~session_id depth =
   Prometheus.set_gauge Prometheus.metric_sse_stream_queue_depth
     ~labels:[("session_id", session_id)] (float_of_int depth)


### PR DESCRIPTION
## Why

Quality sweep PR-C — third of three (PR-A: dashboard #11038, PR-B: server FSM #11074, PR-C: this) targeting the 8 P1 silent-failure findings.  Two metrics that previously left operators blind to broadcast failures.

Cycle 6 (#10916) added \`target\` labels to \`masc_sse_broadcast_events_total\`, but only counts **successful** broadcasts.  An operator reading "0 events / sec" cannot tell whether the system is genuinely idle or whether every broadcast is failing.  Same blindness for external subscriber callbacks (gRPC bridge stream errors only land in \`Log.Misc.warn\`).

## What

### New metrics

\`\`\`ocaml
let metric_sse_broadcast_failures =
  "masc_sse_broadcast_failures_total"
let metric_sse_external_subscriber_callback_failures =
  "masc_sse_external_subscriber_callback_failures_total"
\`\`\`

### \`masc_sse_broadcast_failures_total{target}\`

Same \`target\` label as the success counter (cardinality 3: \`all\` / \`observers\` / \`coordinators\`).  Wired at the two failure paths in \`Sse.broadcast_impl\`:

| Path | Reason |
|------|--------|
| \`queue_len >= stream_capacity\` (stream full pre-check) | client backlogged |
| \`Eio.Stream.add\` defense \`with\` (enqueue exception) | unexpected concurrency violation |

Health is now computable as:

\`\`\`promql
sum by (target) (rate(masc_sse_broadcast_failures_total[5m]))
  /
sum by (target) (
  rate(masc_sse_broadcast_events_total[5m])
  + rate(masc_sse_broadcast_failures_total[5m])
)
\`\`\`

### \`masc_sse_external_subscriber_callback_failures_total\`

Unlabelled (subscriber identity is high-cardinality gRPC stream id).  Wired in \`Sse.notify_external_subscribers\` next to the existing \`Log.Misc.warn\` line.  Operator correlates a non-zero rate with the warn log to identify the flapping subscriber.

## What this PR does NOT change

- \`masc_sse_broadcast_events_total\` semantics (still success-only) — distinct counter, not a histogram split, so existing dashboards continue to work unchanged
- Broadcast / callback behaviour — purely additive metric wiring next to existing log lines

## File breakdown

| File | Change |
|------|--------|
| \`lib/prometheus.ml\` | 2 new metric constants + 2 \`add\` registrations |
| \`lib/prometheus.mli\` | 2 new \`val\` exports |
| \`lib/transport_metrics.ml\` | 2 new helper functions: \`inc_broadcast_failure ?target ()\` and \`inc_external_subscriber_callback_failure ()\` |
| \`lib/sse.ml\` | 3 wiring sites in \`broadcast_impl\` + \`notify_external_subscribers\`; lifted \`target_label\` computation up so failure paths can use it |

Net: 4 files, +54 -5.

## Stack position

- PR-A (#11038, dashboard) — independent
- PR-B (#11074, server FSM) — independent
- **PR-C (this)** — independent (different files: \`prometheus.{ml,mli}\`, \`transport_metrics.ml\`, \`sse.ml\`)

All three P1 PRs land in any order.

## Test plan

- [ ] CI \`dune build @check\` succeeds (or surfaces the pre-existing \`coord_utils_backend_setup.mli\` Eio.Net.t arity issue noted in PR-B's description)
- [ ] After deploy: \`curl http://localhost:<metrics-port>/metrics | grep masc_sse_broadcast_failures_total\` returns the 2 new metric lines (TYPE + zero or non-zero counter)
- [ ] Manual: simulate a stream-full client (suspend dashboard tab so the SSE queue fills) → verify \`masc_sse_broadcast_failures_total{target="observers"}\` increments
- [ ] Manual: simulate gRPC subscriber callback exception → verify \`masc_sse_external_subscriber_callback_failures_total\` increments + existing warn log fires