### PR TITLE
feat(dashboard): adopt canonical accent-soft token in 5 files (CS104)

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -216,7 +216,7 @@ function ChatMessageBubble({
       ${showMetadata && detailItems.length > 0
         ? html`<div class=${`flex flex-wrap gap-1.5 ${isMessenger ? 'pt-0.5' : ''}`}>
             ${detailItems.map(item => html`
-              <span class="inline-flex items-center rounded-sm border border-[var(--accent-soft)] bg-[var(--accent-10)] px-2.5 py-1 text-3xs font-medium text-[var(--color-fg-secondary)]">
+              <span class="inline-flex items-center rounded-sm border border-[var(--color-accent-soft)] bg-[var(--accent-10)] px-2.5 py-1 text-3xs font-medium text-[var(--color-fg-secondary)]">
                 ${item}
               </span>
             `)}
@@ -266,7 +266,7 @@ function ChatMessageBubble({
                       <div class="text-3xs font-semibold uppercase tracking-3 text-[var(--color-fg-muted)]">상태 스냅샷</div>
                       <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                         ${state.map(item => html`
-                          <div class="rounded border border-[var(--accent-soft)] bg-[rgba(71,184,255,0.06)] px-3 py-2.5">
+                          <div class="rounded border border-[var(--color-accent-soft)] bg-[rgba(71,184,255,0.06)] px-3 py-2.5">
                             <div class="text-3xs font-semibold uppercase tracking-2 text-[var(--color-accent-fg)]">${item.label}</div>
                             <div class="mt-1 text-xs leading-paragraph text-[var(--color-fg-primary)]">${item.value}</div>
                           </div>

--- a/dashboard/src/components/common/stat-tile.ts
+++ b/dashboard/src/components/common/stat-tile.ts
@@ -13,7 +13,7 @@ interface StatTileProps {
 const VARIANT_STYLES = {
   default: 'bg-[var(--white-4)] border-[var(--color-border-default)] text-[var(--color-fg-secondary)]',
   gold: 'bg-[rgba(200,168,78,0.05)] border-[var(--ff-gold-10)] text-[var(--color-fg-secondary)]',
-  accent: 'bg-[var(--accent-soft)] border-[var(--accent-20)] text-[var(--color-fg-secondary)]',
+  accent: 'bg-[var(--color-accent-soft)] border-[var(--accent-20)] text-[var(--color-fg-secondary)]',
   warn: 'bg-[rgba(230,167,0,0.06)] border-[rgba(230,167,0,0.2)] text-[var(--color-status-warn)]',
 } as const
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -405,7 +405,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex items-center justify-center w-full rounded border p-2 cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive ? 'bg-[var(--accent-soft)] text-[var(--color-fg-secondary)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'border-transparent text-[var(--color-fg-muted)] hover:bg-[var(--white-5)]'}"
+                  class="flex items-center justify-center w-full rounded border p-2 cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive ? 'bg-[var(--color-accent-soft)] text-[var(--color-fg-secondary)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'border-transparent text-[var(--color-fg-muted)] hover:bg-[var(--white-5)]'}"
                   title=${surface.label}
                   aria-label=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
@@ -440,7 +440,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                           role="listitem"
                           tab=${surface.id}
                           params=${item.params}
-                          class="w-full rounded border px-2 py-1 text-left cursor-pointer text-sm transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[var(--accent-soft)] text-[var(--color-accent-fg)] font-medium shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-soft)]' : 'border-transparent text-[var(--color-fg-muted)] hover:bg-[var(--white-5)] hover:text-[var(--color-fg-primary)]'}"
+                          class="w-full rounded border px-2 py-1 text-left cursor-pointer text-sm transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)] font-medium shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--color-accent-soft)]' : 'border-transparent text-[var(--color-fg-muted)] hover:bg-[var(--white-5)] hover:text-[var(--color-fg-primary)]'}"
                           ariaCurrent=${isSectionActive ? 'page' : undefined}
                         >
                           <div class="truncate">${item.label}</div>

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -269,7 +269,7 @@ function renderLogRow(entry: LogEntry) {
           ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">${entry.raw_level}</span>`
           : null}
         ${clientName
-          ? html`<span class="rounded-sm border border-[var(--accent-soft)] px-2 py-0.5 text-3xs text-[#dff3ff]">${clientName}</span>`
+          ? html`<span class="rounded-sm border border-[var(--color-accent-soft)] px-2 py-0.5 text-3xs text-[#dff3ff]">${clientName}</span>`
           : null}
         ${toolName
           ? html`<span class="inline-flex items-center gap-1 rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span class="text-[var(--color-fg-muted)]">${toolName}</span></span>`

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -385,7 +385,7 @@ function ToolSearchPicker({
                     ...${getItemProps({ item: name, index: idx })}
                     class=${`w-full flex items-start gap-2 text-left px-3 py-1.5 cursor-pointer transition-colors ${
                       highlightedIndex === idx
-                        ? 'bg-[var(--accent-soft)] text-[var(--color-accent-fg)]'
+                        ? 'bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)]'
                         : 'hover:bg-[var(--accent-10)]'
                     }`}
                   >
@@ -561,7 +561,7 @@ export function ToolAllowlistEditor({
           <button type="button"
             class=${`py-1 px-3 rounded text-3xs font-medium border transition-colors cursor-pointer ${
               policyMode.value === mode
-                ? 'border-[var(--accent-30)] bg-[var(--accent-soft)] text-[var(--color-accent-fg)]'
+                ? 'border-[var(--accent-30)] bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)]'
                 : 'border-[var(--color-border-default)] bg-[var(--white-3)] text-[var(--color-fg-muted)]'
             }`}
             onClick=${() => { policyMode.value = mode; textInputSection.value = null }}


### PR DESCRIPTION
## Summary

Phase G Step 4 (file-disjoint sweep). 8 sites of legacy `var(--accent-soft)` swap to canonical `var(--color-accent-soft)` (1:1 alias added in CS87).

## Files & sites

| File | Sites |
|------|-------|
| `chat/primitives.ts` | 2 |
| `common/stat-tile.ts` | 1 |
| `dashboard-shell.ts` | 2 |
| `logs.ts` | 1 |
| `tools/tool-allowlist-editor.ts` | 2 |
| **Total** | **8** |

File-disjoint with in-flight CS102 (cascade-config-panel + telemetry-unified) / CS103 (memory + activity-graph + agent-roster + live/* + filter-chips + keeper-detail).

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test stat-tile tool-allowlist` → 11/11 pass
- [x] Diff is 1:1 (8 ins / 8 del)