### PR TITLE
fix(keeper): stop leaking host playground paths to LLM tool responses

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -156,12 +156,15 @@ max_output_bytes = 8192
 # URLs not matching any org here are rejected.
 
 [git_clone]
-# Two GitHub identity surfaces for the operator:
-#   jeong-sik    — current canonical user (commit author, gh CLI default)
-#   yousleepwhen — personal namespace used in workspace/yousleepwhen/*
-# Both are explicitly listed so the keeper can clone repos referenced by
-# the workspace tree (#9783).
-allowed_orgs = ["jeong-sik", "yousleepwhen"]
+# Org allowlist for `masc_code_git clone`.  Empty list = skip check; the
+# keeper may clone any repo reachable through the operator's gh credential
+# (subject to denied_repos below).  This matches the operator intent that
+# repo/org gating is a soft secondary control — the primary boundary is
+# the gh credential surface itself plus denied_repos.  Earlier values
+# (#9783: ["jeong-sik", "yousleepwhen"]) only listed the operator's two
+# self-owned namespaces and blocked clones referenced from upstream
+# workspace trees.
+allowed_orgs = []
 # Repos blocked even if org is allowed. Format: "org/repo" (lowercase).
 denied_repos = ["jeong-sik/me"]
 # Clone depth: 0 = full clone, N = shallow --depth N.

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1241,14 +1241,17 @@ let handle_keeper_status ctx args : tool_result =
                    (Coord_utils.safe_filename (Keeper_id.Trace_id.to_string m.runtime.trace_id)))));
            ]);
            (let sandbox = Keeper_sandbox.of_meta ~config:ctx.config ~meta:m in
-           let playground_rel = sandbox.host_root_rel in
            let playground_abs = sandbox.host_root_abs in
-           (* #10650: default_cwd / private_workspace_root must be a path
-              that resolves *inside* the keeper's runtime.  For Docker
-              keepers the host abs path does not exist inside the
-              container, so the LLM emitted [cd <host_abs>] which fails
-              ~890/day.  keeper_visible_root_abs picks container_root for
-              Docker, host_root_abs for Local. *)
+           (* #10650 + B1 follow-up: keeper-LLM-facing execution_context must
+              not surface host paths.  For Docker keepers the host abs path
+              does not exist inside the container, so the LLM previously
+              echoed [cd <host_abs>] producing ~890/day [No such file or
+              directory] errors.  default_cwd / private_workspace_root use
+              [keeper_visible_root_abs] (container path for Docker, host
+              path for Local).  Host-only fields (sandbox_host_root,
+              playground_path) are intentionally omitted — server-side
+              file reads below still use [playground_abs] but never expose
+              it through the JSON response. *)
            let keeper_visible_abs = Keeper_sandbox.keeper_visible_root_abs sandbox in
            "execution_context", `Assoc [
              ("sandbox_id", `String sandbox.sandbox_id);
@@ -1256,9 +1259,7 @@ let handle_keeper_status ctx args : tool_result =
              ("sandbox_root", `String sandbox.root_arg);
              ("sandbox_repos", `String sandbox.repos_arg);
              ("sandbox_mind", `String sandbox.mind_arg);
-             ("sandbox_host_root", `String sandbox.host_root_abs);
              ("sandbox_container_root", Json_util.string_opt_to_json sandbox.container_root);
-             ("playground_path", `String playground_rel);
              ("default_cwd", `String keeper_visible_abs);
              ("private_workspace_root", `String keeper_visible_abs);
              ("sandbox_profile", `String (sandbox_profile_to_string m.sandbox_profile));

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2155,14 +2155,21 @@ let test_keeper_config_uses_backend_scoped_private_workspace_root () =
       let status_json = parse_json_exn status_body in
       let open Yojson.Safe.Util in
       let execution_context = status_json |> member "execution_context" in
-      Alcotest.(check string) "status playground path"
-        docker_rel
-        (execution_context |> member "playground_path" |> to_string);
-      (* #10650: for a Docker keeper, private_workspace_root in the
-         keeper-LLM-facing status response is the in-container path
-         ([/home/keeper/playground/<sanitized>]), NOT the host abs path.
-         The host path is inaccessible inside the container; surfacing
-         it caused ~890/day [cd: No such file or directory] errors. *)
+      (* #10650 + B1 follow-up: keeper-LLM-facing execution_context must
+         not surface host paths.  The host path is inaccessible inside the
+         container; surfacing it caused ~890/day [cd: No such file or
+         directory] errors.  default_cwd / private_workspace_root carry
+         the in-container path; host-only fields (playground_path,
+         sandbox_host_root) are intentionally omitted from the JSON
+         response.  docker_rel / docker_abs remain used for the
+         assert_config_root call above (admin-only dashboard surface). *)
+      let _ = docker_rel and _ = docker_abs in
+      Alcotest.(check bool) "status playground_path omitted (no host leak)"
+        true
+        (execution_context |> member "playground_path" = `Null);
+      Alcotest.(check bool) "status sandbox_host_root omitted (no host leak)"
+        true
+        (execution_context |> member "sandbox_host_root" = `Null);
       let docker_container_root =
         Masc_mcp.Keeper_sandbox.container_root keeper_name
       in
@@ -2171,10 +2178,7 @@ let test_keeper_config_uses_backend_scoped_private_workspace_root () =
         (execution_context |> member "private_workspace_root" |> to_string);
       Alcotest.(check string) "status default cwd"
         docker_container_root
-        (execution_context |> member "default_cwd" |> to_string);
-      Alcotest.(check string) "status sandbox host root preserved"
-        docker_abs
-        (execution_context |> member "sandbox_host_root" |> to_string))
+        (execution_context |> member "default_cwd" |> to_string))
 
 let test_snapshot_keeper_tool_audit_fallback () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary

Two surgical changes that complete the partial #10650 fix:

1. **`lib/keeper/keeper_status_detail.ml`** — remove `sandbox_host_root` and `playground_path` from the `execution_context` JSON returned by `masc_keeper_status`. Both fields surfaced absolute / relative *host* paths that do not resolve inside the Docker container, so the LLM echoed them in `cd <host_abs>` arguments and produced ~890/day `No such file or directory` failures.
2. **`config/tool_policy.toml`** — widen `allowed_orgs` from `["jeong-sik","yousleepwhen"]` to `[]` (skip check). The org allowlist is a soft secondary control; the primary boundary is the operator's gh credential surface plus `denied_repos`.

## Smoking gun (Det evidence)

Existing comment in `keeper_status_detail.ml` (this file, just above the deleted lines) already documented the partial fix:

> #10650: default_cwd / private_workspace_root must be a path that resolves *inside* the keeper's runtime. For Docker keepers the host abs path does not exist inside the container, so the LLM emitted `[cd <host_abs>]` which fails ~890/day.

`#10650` only repaired `default_cwd` and `private_workspace_root`. The two sibling fields (`sandbox_host_root`, `playground_path`) kept emitting the host path next to the corrected ones, so the LLM had a working source of host paths and continued echoing them.

Concrete fleet log (2026-04-25..27, two days):

```
sandbox docker exec failed (masc-keeper-sandbox:local):
  cd: /Users/dancer/me/.masc/playground/docker/issue_king/repos/grpc-direct/.worktrees/...:
  No such file or directory
```

114 such events / 2 days. All carry the host path inside the container.

## Why widening allowed_orgs

The operator described the org/repo allowlist as a soft secondary control. The actual boundary is what the gh credential surface can reach plus `denied_repos`. Empty `allowed_orgs = []` skips the org gate but leaves `denied_repos = ["jeong-sik/me"]` in place to keep the second-brain repo blocked even by accident.

## Scope kept narrow

| Out of scope (separate PR / RFC) | Reason |
|---|---|
| Remove `playground/<keeper>/repos/` mandate | Multi-file refactor (keeper_alerting_path, keeper_sandbox, ~5-10 tests) plus migration of existing playgrounds |
| gh credential mode (per-keeper / token-only / host-creds) | Adds a new keeper-meta field, separate design |
| Container-path SSOT runtime guard (reject host paths in tool args) | Lint / runtime check; better evaluated after this PR's effect is measured |
| World prompt update (`{{allowed_orgs}}` rendered as `[]`, `repos/<REPO>/` guidance) | Prompt-only change, NonDet effect, deserves its own measurement window |
| Per-keeper masc-mcp clone cleanup (issue_king / qa-king / sangsu / verifier) | Reversible cleanup, but operator decision |

## External consumer audit

```
$ rg '"sandbox_host_root"|"playground_path"' lib/ test/ dashboard/
lib/keeper/keeper_status_detail.ml:1259, 1261   (the fields, removed)
test/test_operator_control_keeper.ml:2160, 2177 (assertions, updated)
```

No production consumer outside the LLM-facing JSON. Dashboard, operator UI, and bin/ have no references.

## Test plan

- [x] `dune build` clean (B1 type-checks, lib + test executables link)
- [ ] CI `Build and Test` (verifies the two updated assertions in `test_keeper_config_uses_backend_scoped_private_workspace_root`)
- [ ] Post-deploy fleet log measurement: `grep -c "sandbox docker exec failed" ~/me/.masc/logs/system_log_<DATE>.jsonl` should drop from ~109/day toward ≤10/day
- [ ] Post-deploy: `grep "/Users/dancer/me/.masc/playground" ~/me/.masc/logs/system_log_<DATE>.jsonl` for keeper bash commands — expected to drop to zero

Refs: #10650