### PR TITLE
i18n(dashboard): finish fsm-hub-lane-analysis (round-98)

### DIFF
--- a/dashboard/src/components/fsm-hub-lane-analysis.ts
+++ b/dashboard/src/components/fsm-hub-lane-analysis.ts
@@ -129,19 +129,19 @@ function laneMeaning(
       // it is never observed at snapshot time (see display_state.mli).
       switch (value) {
         case 'clean':
-          return { tone: 'ok', meaning: 'circuit breaker is clean — no recent tool failure streak' }
+          return { tone: 'ok', meaning: 'circuit breaker clean — 최근 tool failure streak 없음' }
         case 'warning':
-          return { tone: 'warn', meaning: 'consecutive tool failures are accumulating — a trip is possible if the class stays the same' }
+          return { tone: 'warn', meaning: '연속된 tool failure 누적 중 — class 가 동일하게 유지되면 trip 가능' }
         case 'cooling':
-          return { tone: 'info', meaning: 'breaker has tripped in the past; currently reset with no active streak' }
+          return { tone: 'info', meaning: 'breaker 가 과거에 trip — 현재 reset 됐고 active streak 없음' }
         default:
-          return { tone: 'info', meaning: 'circuit breaker state observed' }
+          return { tone: 'info', meaning: 'circuit breaker state 관측됨' }
       }
     }
   })()
 
   if (base.tone !== 'error' && isObservedStall(key, value, observedForSec)) {
-    return { tone: 'warn', meaning: 'state movement looks stalled on this screen' }
+    return { tone: 'warn', meaning: 'state movement 이 이 화면에서 정체된 것으로 보임' }
   }
   return base
 }


### PR DESCRIPTION
## Summary

`deriveLaneInsight` 의 마지막 surface — `breaker` switch (4 entries) + observed-stall fallback (1 entry).

## Changed strings

| line | scenario | After |
|---|---|---|
| 132 | breaker `'clean'` | `'circuit breaker clean — 최근 tool failure streak 없음'` |
| 134 | breaker `'warning'` | `'연속된 tool failure 누적 중 — class 가 동일하게 유지되면 trip 가능'` |
| 136 | breaker `'cooling'` | `'breaker 가 과거에 trip — 현재 reset 됐고 active streak 없음'` |
| 138 | breaker default | `'circuit breaker state 관측됨'` |
| 144 | stall fallback | `'state movement 이 이 화면에서 정체된 것으로 보임'` |

## Stack progress (rounds 96-98)

```
96 (#11069 merged?)  phase switch (9 entries)
97 (#11071 open)     turn + decision + cascade + compaction (23 entries)
98 (this PR)         breaker (4) + stall fallback (1)
```

`fsm-hub-lane-analysis.ts` 의 모든 사용자 면 `meaning` 문자열이 한국어 (도메인 anchor 보존). `deriveLaneInsight` surface 완전 i18n.

## Domain term policy

`circuit breaker`, `tool failure`, `streak`, `trip`, `class`, `breaker`, `reset`, `active streak`, `state movement` 보존 — FSM/circuit-breaker 도메인 용어.

## Scope

- 1 파일, 5줄.
- test 영향 0 (test 가 `isObservedStall` 함수만 검증).
