### PR TITLE
i18n(dashboard): localize 3 keeper API thrown errors (round-99)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -433,7 +433,7 @@ export async function fetchKeeperCheckpoints(
   )
   if (!resp.ok) {
     const text = await resp.text().catch(() => resp.statusText)
-    throw new Error(`Failed to load checkpoints for ${name} (${resp.status}): ${text}`)
+    throw new Error(`${name} 의 checkpoint 로드 실패 (${resp.status}): ${text}`)
   }
   return resp.json() as Promise<KeeperCheckpointInventory>
 }
@@ -455,7 +455,7 @@ export async function deleteKeeperHistorySnapshots(
   )
   if (!resp.ok) {
     const text = await resp.text().catch(() => resp.statusText)
-    throw new Error(`Failed to delete checkpoint history for ${name} (${resp.status}): ${text}`)
+    throw new Error(`${name} 의 checkpoint history 삭제 실패 (${resp.status}): ${text}`)
   }
   return resp.json() as Promise<KeeperCheckpointDeleteResponse>
 }
@@ -539,7 +539,7 @@ export async function editKeeperTools(
   )
   if (!resp.ok) {
     const text = await resp.text().catch(() => resp.statusText)
-    throw new Error(`Tool edit failed (${resp.status}): ${text}`)
+    throw new Error(`도구 편집 실패 (${resp.status}): ${text}`)
   }
   return resp.json() as Promise<ToolEditResponse>
 }


### PR DESCRIPTION
## Summary

`dashboard/src/api/keeper.ts` 의 3 thrown Error message 한국어화. `throw new Error(...)` 의 message field 가 JS Error.message 로 전파되어 UI error banner 또는 console 에 노출.

## Changed strings

| line | Before | After |
|---|---|---|
| 436 | `Failed to load checkpoints for ${name} (${status}): ${text}` | `${name} 의 checkpoint 로드 실패 (${status}): ${text}` |
| 458 | `Failed to delete checkpoint history for ${name} (${status}): ${text}` | `${name} 의 checkpoint history 삭제 실패 (${status}): ${text}` |
| 542 | `Tool edit failed (${status}): ${text}` | `도구 편집 실패 (${status}): ${text}` |

## Domain term policy

`checkpoint`, `checkpoint history` 보존 — 도메인 용어. `Tool edit` 은 `도구 편집` 으로 변환 — 다른 한국어 UI copy 와 일관성.

## Scope

- 1 파일, 3줄.
- test 영향 0 (toContain/toBe assertion 어떤 것도 이 문자열 사용 안 함).
- API surface (`api/keeper.ts`) 의 첫 i18n round.
