### PR TITLE
feat(dashboard): adopt canonical SPEC status tokens in 10 files (CS106)

### DIFF
--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -58,10 +58,10 @@ export function resetAutoresearchState(): void {
 
 function statusColor(status: string): string {
   switch (status) {
-    case 'running': return 'text-[var(--ok)]'
+    case 'running': return 'text-[var(--color-status-ok)]'
     case 'completed': return 'text-[var(--color-accent-fg)]'
-    case 'stopped': return 'text-[var(--warn)]'
-    case 'error': return 'text-[var(--bad)]'
+    case 'stopped': return 'text-[var(--color-status-warn)]'
+    case 'error': return 'text-[var(--color-status-err)]'
     default: return 'text-[var(--color-fg-muted)]'
   }
 }
@@ -210,15 +210,15 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
           </div>
           <div>
             <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-0.5">최고 점수</div>
-            <div class="text-[var(--ok)] text-sm font-mono font-semibold">${loop.best_score.toFixed(4)}</div>
+            <div class="text-[var(--color-status-ok)] text-sm font-mono font-semibold">${loop.best_score.toFixed(4)}</div>
           </div>
         </div>
         <div>
           <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">유지 / 삭제</div>
           <div class="flex items-center gap-2">
-            <span class="text-[var(--ok)] text-sm font-mono font-semibold">${loop.total_keeps}</span>
+            <span class="text-[var(--color-status-ok)] text-sm font-mono font-semibold">${loop.total_keeps}</span>
             <span class="text-[var(--color-fg-muted)] text-xs">/</span>
-            <span class="text-[var(--bad)] text-sm font-mono font-semibold">${loop.total_discards}</span>
+            <span class="text-[var(--color-status-err)] text-sm font-mono font-semibold">${loop.total_discards}</span>
             <span class="text-[var(--color-fg-muted)] text-xs ml-1">(${keepPct}% keep)</span>
           </div>
           ${totalCycles > 0 ? html`
@@ -246,7 +246,7 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
     </div>
 
     ${loop.error ? html`
-      <div class="mt-3 px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--bad)] text-xs">
+      <div class="mt-3 px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--color-status-err)] text-xs">
         ${loop.error}
       </div>
     ` : null}
@@ -300,12 +300,12 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
                     <td class="py-2 px-3 text-[var(--text-body)] max-w-50 truncate" title=${c.hypothesis}>${c.hypothesis}</td>
                     <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_before.toFixed(4)}</td>
                     <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_after.toFixed(4)}</td>
-                    <td class="py-2 px-3 text-right font-mono ${c.delta >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">${formatDelta(c.delta)}</td>
+                    <td class="py-2 px-3 text-right font-mono ${c.delta >= 0 ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-err)]'}">${formatDelta(c.delta)}</td>
                     <td class="py-2 px-3 text-center">
                       <span class="px-1.5 py-0.5 rounded text-3xs font-semibold ${
                         c.decision === 'keep'
-                          ? 'bg-[var(--ok-soft)] text-[var(--ok)] border border-[var(--ok-20)]'
-                          : 'bg-[var(--bad-soft)] text-[var(--bad)] border border-[var(--bad-20)]'
+                          ? 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border border-[var(--ok-20)]'
+                          : 'bg-[var(--bad-soft)] text-[var(--color-status-err)] border border-[var(--bad-20)]'
                       }">${decisionLabel(c.decision)}</span>
                     </td>
                     <td class="py-2 px-3 text-right text-[var(--color-fg-muted)] font-mono">${formatTimestampKo(c.timestamp)}</td>
@@ -342,7 +342,7 @@ function WarningsList({ warnings }: { warnings: string[] }) {
   return html`
     <div class="flex flex-col gap-1.5">
       ${warnings.map((w, i) => html`
-        <div key=${i} class="px-3 py-1.5 rounded bg-[var(--warn-10)] border border-[var(--warn-20)] text-[var(--warn)] text-xs">
+        <div key=${i} class="px-3 py-1.5 rounded bg-[var(--warn-10)] border border-[var(--warn-20)] text-[var(--color-status-warn)] text-xs">
           ${w}
         </div>
       `)}
@@ -449,7 +449,7 @@ function LoopDetailView() {
 
   if (detailError.value) {
     return html`
-      <div class="px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--bad)] text-xs">
+      <div class="px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--color-status-err)] text-xs">
         ${detailError.value}
       </div>
     `
@@ -491,7 +491,7 @@ function LoopDetailView() {
         </div>
         <${LoopOverview} loop=${loop} />
         ${loopActionError.value ? html`
-          <div class="mt-3 px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--bad)] text-xs">
+          <div class="mt-3 px-3 py-2 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--color-status-err)] text-xs">
             ${loopActionError.value}
           </div>
         ` : null}
@@ -499,7 +499,7 @@ function LoopDetailView() {
 
       ${warnings.length > 0 ? html`
         <${SurfaceCard} variant="compact">
-          <div class="text-3xs uppercase tracking-wider text-[var(--warn)]/80 mb-3 font-medium">경고</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-status-warn)]/80 mb-3 font-medium">경고</div>
           <${WarningsList} warnings=${warnings} />
         <//>
       ` : null}
@@ -538,7 +538,7 @@ export function Autoresearch() {
   if (state.status === 'error') {
     return html`
       <div class="flex flex-col gap-4">
-        <div class="px-4 py-3 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--bad)] text-sm">
+        <div class="px-4 py-3 rounded bg-[var(--bad-10)] border border-[var(--bad-20)] text-[var(--color-status-err)] text-sm">
           ${state.message}
         </div>
         <${ActionButton}

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -315,7 +315,7 @@ export function keepersWithUnknownCanonical(
 function KeeperChip({ row }: { row: KeeperCascadeRow }) {
   const base = 'rounded border px-2 py-0.5 text-xs flex items-center gap-1'
   const borderTone = row.drift
-    ? 'border-[var(--warn)] text-[var(--text-strong)]'
+    ? 'border-[var(--color-status-warn)] text-[var(--text-strong)]'
     : 'border-[var(--color-border-default)] text-[var(--text-strong)]'
   return html`
     <span
@@ -508,7 +508,7 @@ function ProfileCard({
 function OrphanKeeperList({ orphans }: { orphans: readonly CascadeKeeperProfile[] }) {
   if (orphans.length === 0) return null
   return html`
-    <div class="rounded border border-[var(--warn)] bg-[var(--color-bg-page)] p-3 text-xs">
+    <div class="rounded border border-[var(--color-status-warn)] bg-[var(--color-bg-page)] p-3 text-xs">
       <div class="font-semibold text-[var(--text-strong)] mb-1">
         등록된 프로필 없음 (${orphans.length})
       </div>
@@ -521,7 +521,7 @@ function OrphanKeeperList({ orphans }: { orphans: readonly CascadeKeeperProfile[
             <span class="font-semibold text-[var(--text-strong)]">${o.keeper}</span>
             <code>${o.cascade_name}</code>
             <span class="text-[var(--color-fg-muted)]">→</span>
-            <code class="text-[var(--warn)]">${o.canonical}</code>
+            <code class="text-[var(--color-status-warn)]">${o.canonical}</code>
           </li>
         `)}
       </ul>
@@ -549,8 +549,8 @@ function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) 
   if (config.validation_status === 'validated') return null
   const tone = validationTone(config.validation_status)
   const boxTone = tone === 'bad'
-    ? 'border-[var(--bad)]/40 bg-[var(--bad)]/10'
-    : 'border-[var(--warn)]/40 bg-[var(--warn)]/10'
+    ? 'border-[var(--color-status-err)]/40 bg-[var(--color-status-err)]/10'
+    : 'border-[var(--color-status-warn)]/40 bg-[var(--color-status-warn)]/10'
   const visibleErrors = config.validation_errors.slice(0, 3)
   const visibleProfiles = config.invalid_profiles.slice(0, 4)
   return html`
@@ -681,9 +681,9 @@ export function filterHealthProviders(
 }
 
 const TONE_DOT: Record<string, string> = {
-  ok: 'bg-[var(--ok)]',
-  warn: 'bg-[var(--warn)]',
-  bad: 'bg-[var(--bad)]',
+  ok: 'bg-[var(--color-status-ok)]',
+  warn: 'bg-[var(--color-status-warn)]',
+  bad: 'bg-[var(--color-status-err)]',
 }
 
 function HealthTable({
@@ -765,7 +765,7 @@ function HealthTable({
                 <td class="py-1">
                   <code class="text-[var(--text-strong)]">${p.provider_key}</code>
                   ${orphaned
-                    ? html`<span class="ml-1 text-2xs text-[var(--warn)]" title="Provider 가 추적되었지만 cascade.json 에 더 이상 선언되어 있지 않음">orphan</span>`
+                    ? html`<span class="ml-1 text-2xs text-[var(--color-status-warn)]" title="Provider 가 추적되었지만 cascade.json 에 더 이상 선언되어 있지 않음">orphan</span>`
                     : null}
                 </td>
                 <td class="py-1">
@@ -778,7 +778,7 @@ function HealthTable({
                 <td class="py-1 text-right tabular-nums">${p.events_in_window}</td>
                 <td class="py-1 text-right tabular-nums">
                   ${rejected > 0
-                    ? html`<span class="text-[var(--warn)]">${rejected}</span>`
+                    ? html`<span class="text-[var(--color-status-warn)]">${rejected}</span>`
                     : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
                 </td>
                 <td class="py-1 text-right tabular-nums">${fmtPerfTokPerSec(p.avg_prompt_tok_per_sec)}</td>
@@ -1134,13 +1134,13 @@ function CascadeRawConfigEditor({
           />
 
           <div class="flex items-center gap-3 flex-wrap text-xs">
-            <span class=${editorDirty.value ? 'text-[var(--warn)]' : 'text-[var(--color-fg-muted)]'}>
+            <span class=${editorDirty.value ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-fg-muted)]'}>
               ${editorDirty.value ? 'unsaved changes' : 'in sync with disk'}
             </span>
             ${syntaxError
               ? html`<span class="text-[var(--bad-light)]">syntax: ${syntaxError}</span>`
               : html`
-                <span class="text-[var(--ok)]">
+                <span class="text-[var(--color-status-ok)]">
                   ${raw?.source_kind === 'toml' ? 'syntax: validated on save (TOML)' : 'syntax: valid JSON'}
                 </span>
               `}

--- a/dashboard/src/components/common/feedback-state.ts
+++ b/dashboard/src/components/common/feedback-state.ts
@@ -97,7 +97,7 @@ export function ErrorRecoverable({
   return html`
     <section
       role="alert"
-      class="flex flex-col gap-2 rounded border border-[var(--warn-20)] border-l-[3px] border-l-[var(--warn)] bg-[var(--warn-soft)] px-4 py-3 ${cx ?? ''}"
+      class="flex flex-col gap-2 rounded border border-[var(--warn-20)] border-l-[3px] border-l-[var(--color-status-warn)] bg-[var(--warn-soft)] px-4 py-3 ${cx ?? ''}"
     >
       <div class="flex items-center gap-2">
         <${AlertTriangle} size=${16} class="shrink-0 text-[var(--warn-bright)]" aria-hidden="true" />
@@ -149,7 +149,7 @@ export function ErrorFatal({
   return html`
     <section
       role="alert"
-      class="flex flex-col gap-2 rounded border border-[var(--bad-20)] border-l-[3px] border-l-[var(--bad)] bg-[var(--bad-soft)] px-4 py-3 ${cx ?? ''}"
+      class="flex flex-col gap-2 rounded border border-[var(--bad-20)] border-l-[3px] border-l-[var(--color-status-err)] bg-[var(--bad-soft)] px-4 py-3 ${cx ?? ''}"
     >
       <div class="flex items-center gap-2">
         <${AlertOctagon} size=${16} class="shrink-0 text-[var(--bad-light)]" aria-hidden="true" />

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -120,14 +120,14 @@ function statusLabel(status: FeatureStatus): string {
 function statusChipClass(status: FeatureStatus): string {
   switch (status) {
     case 'healthy':
-      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--ok)]'
+      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--color-status-ok)]'
     case 'warning':
-      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--warn)]'
+      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--color-status-warn)]'
     case 'inactive':
       return 'border-[var(--white-12)] bg-[var(--white-4)] text-[var(--color-fg-muted)]'
     case 'deprecated':
     default:
-      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--bad)]'
+      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--color-status-err)]'
   }
 }
 
@@ -148,7 +148,7 @@ function FeatureItem({ item }: { item: FeatureHealthItem }) {
             <code class="text-xs font-medium text-[var(--text-strong)]">${item.env_name}</code>
             <${StatusPill} status=${item.status} />
             ${item.is_enabled ? html`
-              <span class="inline-flex items-center rounded border border-[var(--ok-30)] bg-[var(--ok-12)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--ok)]">
+              <span class="inline-flex items-center rounded border border-[var(--ok-30)] bg-[var(--ok-12)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--color-status-ok)]">
                 ON
               </span>
             ` : html`

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -442,7 +442,7 @@ function runtimeActionBusyLabel(action: FleetRuntimeAction): string {
 
 function runtimeActionTone(action: FleetRuntimeAction): string {
   if (action.action_type === 'keeper_recover') {
-    return 'text-[var(--warn)]'
+    return 'text-[var(--color-status-warn)]'
   }
   return 'text-[var(--color-accent-fg)]'
 }

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -359,7 +359,7 @@ function Callout({
 }) {
   const toneClass =
     tone === 'warn'
-      ? 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]'
+      ? 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
       : 'border-card-border/60 bg-card/35 text-text-body'
   return html`
     <div class="rounded border px-3 py-3 shadow-sm ${toneClass}">
@@ -405,9 +405,9 @@ function LongText({ text, truncateAt = 200 }: { text: string; truncateAt?: numbe
 function PromptSourceBadge({ source }: { source: string }) {
   const tone =
     source === 'override'
-      ? 'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]'
+      ? 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]'
       : source === 'file'
-        ? 'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]'
+        ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]'
         : 'bg-white/5 text-text-dim border-white/10'
   return html`<span class="text-3xs font-bold px-2 py-0.5 rounded border ${tone} shadow-sm">${source.toUpperCase()}</span>`
 }
@@ -694,7 +694,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     <div class="flex gap-2 items-center mb-3">
       ${isEditing ? html`
         <button type="button"
-          class="${btnBase} bg-[var(--ok)] text-[#000]"
+          class="${btnBase} bg-[var(--color-status-ok)] text-[#000]"
           onClick=${saveConfig}
           disabled=${isSaving}
         >${isSaving ? '저장 중...' : '저장'}</button>
@@ -709,7 +709,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           onClick=${enterEditMode}
         >편집</button>
       `}
-      ${saveError.value ? html`<span class="text-xs text-[var(--bad)]" role="alert">${saveError.value}</span>` : null}
+      ${saveError.value ? html`<span class="text-xs text-[var(--color-status-err)]" role="alert">${saveError.value}</span>` : null}
     </div>
   `
 
@@ -831,10 +831,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                     : '변경 시 keeper manifest의 cascade_name 이 즉시 갱신됩니다.'}
               </span>
               ${cascadeSaveError.value
-                ? html`<span class="text-2xs text-[var(--bad)]" role="alert">${cascadeSaveError.value}</span>`
+                ? html`<span class="text-2xs text-[var(--color-status-err)]" role="alert">${cascadeSaveError.value}</span>`
                 : null}
               ${invalidCascadeProfiles.length > 0
-                ? html`<span class="text-2xs text-[var(--warn)]">invalid profile ${invalidCascadeProfiles.length}개: ${invalidCascadeSummary}</span>`
+                ? html`<span class="text-2xs text-[var(--color-status-warn)]">invalid profile ${invalidCascadeProfiles.length}개: ${invalidCascadeSummary}</span>`
                 : null}
             </label>
           `
@@ -1054,7 +1054,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         ${goalState.status === 'loading' ? html`
           <div class="text-2xs text-[var(--color-fg-muted)]" role="status">목표 목록 로딩 중...</div>
         ` : goalState.status === 'error' ? html`
-          <div class="text-2xs text-[var(--bad)]">${goalState.message}</div>
+          <div class="text-2xs text-[var(--color-status-err)]">${goalState.message}</div>
         ` : goalOptions.length > 0 && rd ? html`
           <div class="grid gap-1.5">
             ${goalOptions.map((goal) => {
@@ -1081,7 +1081,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           <div class="text-2xs text-[var(--color-fg-muted)]">활성 목표가 연결되어 있지 않습니다.</div>
         `}
         ${unknownSelectedGoalIds.length > 0 ? html`
-          <div class="mt-2 text-2xs text-[var(--warn)]">
+          <div class="mt-2 text-2xs text-[var(--color-status-warn)]">
             Goal Store에서 찾을 수 없는 연결: ${unknownSelectedGoalIds.join(', ')}
           </div>
         ` : null}
@@ -1125,7 +1125,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ${runtimeHasChanges ? html`
         <div class="flex gap-2 items-center mt-4 mb-2 p-3 rounded border border-accent/30 bg-accent/5">
           <button type="button"
-            class="${btnBase} bg-[var(--ok)] text-[#000]"
+            class="${btnBase} bg-[var(--color-status-ok)] text-[#000]"
             onClick=${saveRuntimeConfig}
             disabled=${runtimeSaving.value}
           >${runtimeSaving.value ? '저장 중...' : '런타임 설정 저장'}</button>
@@ -1158,7 +1158,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
             ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${allEntries.length} slots)</div>`
             : visibleEntries.map(([name, slot]) => html`
                 <div class="flex items-start gap-2 py-2 px-3 rounded border border-card-border/50 bg-card/20 mb-1.5">
-                  <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--color-fg-disabled)]'}" aria-hidden="true"></span>
+                  <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--color-status-ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--color-fg-disabled)]'}" aria-hidden="true"></span>
                   <div class="flex-1 min-w-0">
                     <div class="flex justify-between">
                       <span class="text-xs font-semibold text-text-strong">${name}</span>

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -32,7 +32,7 @@ function KeeperToolPresetChip({ keeperName }: { keeperName: string }) {
   return html`
     <span class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-semibold uppercase tracking-wide
       ${canPR
-        ? 'bg-[var(--ok-10)] text-[var(--ok)] border border-[var(--ok-20)]'
+        ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border border-[var(--ok-20)]'
         : 'bg-[var(--white-5)] text-[var(--color-fg-muted)] border border-[var(--white-8)]'
       }"
       title=${`도구 preset: ${preset}${canPR ? ' (clone/PR 가능)' : ''}`}

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -153,8 +153,8 @@ function fmtValue(value: number, type: string, name: string): string {
 function typeBadge(type: string): ReturnType<typeof html> {
   const colors: Record<string, string> = {
     counter: 'bg-[var(--accent-10)] text-[var(--color-accent-fg)]',
-    gauge: 'bg-[var(--ok-10)] text-[var(--ok)]',
-    summary: 'bg-[var(--warn-10)] text-[var(--warn)]',
+    gauge: 'bg-[var(--ok-10)] text-[var(--color-status-ok)]',
+    summary: 'bg-[var(--warn-10)] text-[var(--color-status-warn)]',
   }
   return html`<span class="inline-block rounded px-1.5 py-0.5 text-3xs font-mono ${colors[type] ?? 'bg-[var(--white-5)] text-[var(--color-fg-muted)]'}">${type}</span>`
 }
@@ -176,7 +176,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
     }
     if (k === 'tool_name' || k === 'tool') {
       return html`<button
-        class="rounded bg-[var(--warn-10)] px-1 py-0.5 text-3xs text-[var(--warn)] font-mono hover:bg-[var(--warn-10)] hover:text-[var(--warn)] transition-colors cursor-pointer"
+        class="rounded bg-[var(--warn-10)] px-1 py-0.5 text-3xs text-[var(--color-status-warn)] font-mono hover:bg-[var(--warn-10)] hover:text-[var(--color-status-warn)] transition-colors cursor-pointer"
         title="도구 품질 보기"
         aria-label="도구 품질 보기"
         onClick=${(e: Event) => {
@@ -360,7 +360,7 @@ export function PrometheusMetrics() {
                   ${catMetrics.length}개 메트릭
                 </span>
                 ${activeSamples > 0 && html`
-                  <span class="rounded-sm bg-[var(--ok-10)] px-2 py-0.5 text-3xs text-[var(--ok)]">
+                  <span class="rounded-sm bg-[var(--ok-10)] px-2 py-0.5 text-3xs text-[var(--color-status-ok)]">
                     ${activeSamples}개 활성
                   </span>
                 `}
@@ -397,7 +397,7 @@ export function PrometheusMetrics() {
                                 ${i === 0 && html`<div class="text-3xs text-[var(--color-fg-muted)] font-sans">${m.help}</div>`}
                               </td>
                               <td class="py-1.5">${i === 0 ? typeBadge(m.type) : null}</td>
-                              <td class="py-1.5 text-right font-mono tabular-nums ${s.value !== 0 ? 'text-[var(--ok)]' : 'text-[var(--color-fg-muted)]'}">
+                              <td class="py-1.5 text-right font-mono tabular-nums ${s.value !== 0 ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-fg-muted)]'}">
                                 ${fmtValue(s.value, m.type, s.name)}
                               </td>
                             </tr>

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -473,7 +473,7 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
 }
 
 function DiagnosisCard({ title, value, detail, tone }: { title: string; value: string; detail: string; tone: 'ok' | 'warn' | 'neutral' }) {
-  const toneColor = tone === 'ok' ? 'text-[var(--ok)]' : tone === 'warn' ? 'text-[var(--warn)]' : 'text-[var(--color-fg-muted)]'
+  const toneColor = tone === 'ok' ? 'text-[var(--color-status-ok)]' : tone === 'warn' ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-fg-muted)]'
   return html`
     <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-1)] p-3 min-w-35">
       <div class="text-xs font-medium text-[var(--color-fg-muted)] mb-1">${title}</div>
@@ -508,7 +508,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
             ${timeAgoSafe(ts)}
           </span>
           ${success != null ? html`
-            <span class="flex-shrink-0 w-4 ${success ? 'text-[var(--ok)]' : 'text-[var(--bad-light)]'}">
+            <span class="flex-shrink-0 w-4 ${success ? 'text-[var(--color-status-ok)]' : 'text-[var(--bad-light)]'}">
               ${success ? 'O' : 'X'}
             </span>
           ` : html`<span class="w-4"></span>`}

--- a/dashboard/src/components/transport-beacon.ts
+++ b/dashboard/src/components/transport-beacon.ts
@@ -75,9 +75,9 @@ export function computeBeaconView(args: {
 // dashboard design-system aliases to stay consistent with neighbouring
 // status chips (ConnectionStatus, ErrorCounterBadge).
 const STATE_CLASS: Record<BeaconState, string> = {
-  green: 'text-[#9af3ba] bg-[var(--ok-soft)] border-[var(--ok)]',
-  yellow: 'text-[#f3df9a] bg-[var(--warn-soft)] border-[var(--warn)]',
-  red: 'text-[#f7b7b7] bg-[var(--bad-soft)] border-[var(--bad)]',
+  green: 'text-[#9af3ba] bg-[var(--ok-soft)] border-[var(--color-status-ok)]',
+  yellow: 'text-[#f3df9a] bg-[var(--warn-soft)] border-[var(--color-status-warn)]',
+  red: 'text-[#f7b7b7] bg-[var(--bad-soft)] border-[var(--color-status-err)]',
   gray: 'text-[var(--color-fg-muted)] bg-[var(--white-4)] border-[var(--color-border-default)]',
 }
 


### PR DESCRIPTION
## Summary

Phase G Step 4 (file-disjoint sweep). 56 sites across 10 files swap legacy raw status tokens to canonical SPEC §3.5 names (1:1 alias chain).

## Mapping (1:1 identical color)

| Legacy | Canonical | Resolves to |
|--------|-----------|------|
| `var(--ok)` | `var(--color-status-ok)` | `--ok` |
| `var(--warn)` | `var(--color-status-warn)` | `--warn` |
| `var(--bad)` | `var(--color-status-err)` | `--bad` |

Note: SPEC names error as `err`, not `bad` — the `--color-status-err` alias was added in CS87 and resolves to `--bad`.

## Files (10 total)

| File | Sites |
|------|-------|
| `autoresearch.ts` | 15 |
| `cascade-config-panel.ts` | 12 |
| `keeper-config-panel.ts` | 11 |
| `prometheus-metrics.ts` | 5 |
| `feature-health.ts` | 4 |
| `transport-beacon.ts` | 3 |
| `telemetry-unified.ts` | 2 |
| `common/feedback-state.ts` | 2 |
| `keeper-detail-shell.ts` | 1 |
| `fleet-fsm-matrix.ts` | 1 |
| **Total** | **56** |

File-disjoint with in-flight CS105 (activity-graph + agent-roster + memory + filter-chips + live/keeper-health-strip).

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test autoresearch cascade-config keeper-config feedback-state` → 139/139 pass
- [x] Diff is 1:1 (56 ins / 56 del)