### PR TITLE
feat(dashboard): add TickerItem + TickerStrip primitives (cb-group-a)

### DIFF
--- a/dashboard/src/components/ticker-item.test.ts
+++ b/dashboard/src/components/ticker-item.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  TickerItem,
+  TickerStrip,
+  tickerItemAriaLabel,
+  type TickerItemProps,
+} from './ticker-item'
+
+describe('tickerItemAriaLabel (pure)', () => {
+  it('renders "keeper: text" for the minimal case', () => {
+    expect(
+      tickerItemAriaLabel({ keeperId: 'nick0cave', text: 'pushed PR #123' }),
+    ).toBe('nick0cave: pushed PR #123')
+  })
+
+  it('inserts kind between keeper and colon (when not neutral)', () => {
+    expect(
+      tickerItemAriaLabel({ keeperId: 'qa-king', text: 'gate red', kind: 'err' }),
+    ).toBe('qa-king err: gate red')
+  })
+
+  it('omits kind word when kind is "neutral"', () => {
+    expect(
+      tickerItemAriaLabel({ keeperId: 'sangsu', text: 'merged', kind: 'neutral' }),
+    ).toBe('sangsu: merged')
+  })
+
+  it('appends ", at <time>" when time is given', () => {
+    expect(
+      tickerItemAriaLabel({
+        keeperId: 'rama',
+        text: 'merged',
+        time: '14:32:18',
+      }),
+    ).toBe('rama: merged, at 14:32:18')
+  })
+
+  it('truncates body via bodyMaxChars (chunks pattern)', () => {
+    expect(
+      tickerItemAriaLabel({
+        keeperId: 'a',
+        text: 'this is a very long event description that overflows',
+        bodyMaxChars: 10,
+      }),
+    ).toBe('a: this is a ')
+  })
+
+  it('skips truncation when bodyMaxChars is 0 or omitted', () => {
+    expect(
+      tickerItemAriaLabel({ keeperId: 'a', text: 'long body', bodyMaxChars: 0 }),
+    ).toBe('a: long body')
+  })
+
+  it('combines kind + time + truncation', () => {
+    expect(
+      tickerItemAriaLabel({
+        keeperId: 'masc-improver',
+        text: 'reviewing audit cascade results',
+        kind: 'warn',
+        time: '09:01:15',
+        bodyMaxChars: 8,
+      }),
+    ).toBe('masc-improver warn: reviewin, at 09:01:15')
+  })
+})
+
+describe('TickerItem component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  function mount(props: TickerItemProps): HTMLElement {
+    render(html`<${TickerItem} ...${props} />`, container)
+    return container.querySelector('[role="listitem"]') as HTMLElement
+  }
+
+  it('renders role=listitem with the composed aria-label', () => {
+    const el = mount({ keeperId: 'nick0cave', text: 'pushed PR #123' })
+    expect(el).toBeTruthy()
+    expect(el.getAttribute('role')).toBe('listitem')
+    expect(el.getAttribute('aria-label')).toBe('nick0cave: pushed PR #123')
+  })
+
+  it('renders keeper id text alongside the sigil', () => {
+    const el = mount({ keeperId: 'sangsu', text: 'merged' })
+    expect(el.textContent).toContain('sangsu')
+    expect(el.textContent).toContain('merged')
+  })
+
+  it('renders the trailing time chip by default', () => {
+    const el = mount({
+      keeperId: 'a',
+      text: 'event',
+      time: '14:32:18',
+    })
+    expect(el.textContent).toContain('14:32:18')
+  })
+
+  it('moves the time chip in front when timePosition=leading', () => {
+    const el = mount({
+      keeperId: 'a',
+      text: 'event',
+      time: '14:32:18',
+      timePosition: 'leading',
+    })
+    const txt = el.textContent ?? ''
+    expect(txt.indexOf('14:32:18')).toBeLessThan(txt.indexOf('a'))
+  })
+
+  it('omits time visually when timePosition=none', () => {
+    const el = mount({
+      keeperId: 'a',
+      text: 'event',
+      time: '14:32:18',
+      timePosition: 'none',
+    })
+    expect(el.textContent).not.toContain('14:32:18')
+    expect(el.getAttribute('aria-label')).toContain('14:32:18')
+  })
+
+  it('truncates body text in the visible row when bodyMaxChars given', () => {
+    const long = 'this is a very long event description that overflows'
+    const el = mount({ keeperId: 'a', text: long, bodyMaxChars: 8 })
+    expect(el.textContent).toContain('this is ')
+    expect(el.textContent).not.toContain('overflows')
+  })
+
+  it('renders the embedded KeeperBadge sigil span (sigil variant)', () => {
+    const el = mount({ keeperId: 'nick0cave', text: 'event' })
+    // For nick0cave (registry-pinned) the sigil is "NK".
+    expect(el.textContent).toContain('NK')
+  })
+})
+
+describe('TickerStrip component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  const sample: TickerItemProps[] = [
+    { keeperId: 'nick0cave', text: 'pushed', time: '14:00:01' },
+    { keeperId: 'qa-king', text: 'gate red', kind: 'err', time: '14:00:05' },
+  ]
+
+  it('renders role=log + aria-live=polite + default Korean aria-label', () => {
+    render(html`<${TickerStrip} events=${sample} />`, container)
+    const root = container.querySelector('[role="log"]')!
+    expect(root.getAttribute('aria-live')).toBe('polite')
+    expect(root.getAttribute('aria-label')).toBe('플릿 이벤트 티커')
+  })
+
+  it('renders one listitem per event', () => {
+    render(html`<${TickerStrip} events=${sample} />`, container)
+    expect(container.querySelectorAll('[role="listitem"]')).toHaveLength(2)
+  })
+
+  it('honors a caller-supplied aria-label', () => {
+    render(
+      html`<${TickerStrip} events=${sample} ariaLabel="A2A 활동 스트림" />`,
+      container,
+    )
+    const root = container.querySelector('[role="log"]')!
+    expect(root.getAttribute('aria-label')).toBe('A2A 활동 스트림')
+  })
+
+  it('vertical orientation stacks column-direction', () => {
+    render(
+      html`<${TickerStrip} events=${sample} orientation="vertical" />`,
+      container,
+    )
+    const root = container.querySelector('[role="log"]') as HTMLElement
+    expect(root.style.flexDirection).toBe('column')
+  })
+
+  it('horizontal orientation (default) uses row direction', () => {
+    render(html`<${TickerStrip} events=${sample} />`, container)
+    const root = container.querySelector('[role="log"]') as HTMLElement
+    expect(root.style.flexDirection).toBe('row')
+  })
+
+  it('empty events array renders an empty log region', () => {
+    render(html`<${TickerStrip} events=${[]} />`, container)
+    expect(container.querySelector('[role="log"]')).toBeTruthy()
+    expect(container.querySelectorAll('[role="listitem"]')).toHaveLength(0)
+  })
+})

--- a/dashboard/src/components/ticker-item.ts
+++ b/dashboard/src/components/ticker-item.ts
@@ -1,0 +1,160 @@
+// Ticker item — single event row in a fleet activity ticker.
+//
+// Ported from design-system v0.4 cb-group-a (preview/cb-group-a.jsx
+// TickerMarquee / TickerChunks / TickerVertical). Two primitives:
+//
+//   TickerItem  — atomic event row: keeper sigil + name + body
+//                 (+ optional time prefix/suffix). Drop-in for any
+//                 list-style activity stream.
+//
+//   TickerStrip — composite container: role="log" + aria-live="polite",
+//                 arrays TickerItems. Layout is a flex row by default
+//                 ("marquee/chunks" stripe); pass orientation="vertical"
+//                 to stack rows.
+//
+// The original .cb-ticker / .evt CSS selectors live in design-system
+// styles which the dashboard does NOT import — re-implementation
+// against the dashboard token set + KeeperBadge (#10955) + htm/preact.
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import { KeeperBadge } from './keeper-badge'
+
+export type TickerItemKind = 'ok' | 'warn' | 'err' | 'info' | 'neutral'
+export type TickerTimePosition = 'leading' | 'trailing' | 'none'
+
+export interface TickerItemProps {
+  /** Keeper id powering the sigil + identity color (via KeeperBadge). */
+  keeperId: string
+  /** Event description body. */
+  text: string
+  /** Tone of the event — drives the body color. Default 'neutral'. */
+  kind?: TickerItemKind
+  /** Pre-formatted time string ("14:32:18Z" or "14:32:18"). When
+   *  omitted the time slot is empty regardless of `timePosition`. */
+  time?: string
+  /** Where the time appears relative to the keeper. Default 'trailing'. */
+  timePosition?: TickerTimePosition
+  /** Truncate body to N chars (chunks pattern). 0 or undefined = no truncation. */
+  bodyMaxChars?: number
+}
+
+const MONO_STACK = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+const BODY_COLOR_BY_KIND: Record<TickerItemKind, string> = {
+  ok: 'var(--color-status-ok)',
+  warn: 'var(--color-status-warn)',
+  err: 'var(--color-status-err)',
+  info: 'var(--color-accent-fg)',
+  neutral: 'var(--color-fg-secondary)',
+}
+
+/** Pure: build the ARIA announcement for a ticker item — exposed for
+ *  tests and for parent strips that want to compose a single
+ *  consolidated label. The rendered visual surface is aria-hidden so
+ *  this is the only thing SR users hear. */
+export function tickerItemAriaLabel(props: TickerItemProps): string {
+  const kind = props.kind && props.kind !== 'neutral' ? ` ${props.kind}` : ''
+  const time = props.time ? `, at ${props.time}` : ''
+  const text = truncate(props.text, props.bodyMaxChars)
+  return `${props.keeperId}${kind}: ${text}${time}`
+}
+
+function truncate(s: string, max?: number): string {
+  if (max === undefined || max <= 0) return s
+  return s.length > max ? s.slice(0, max) : s
+}
+
+export function TickerItem(props: TickerItemProps): VNode {
+  const kind = props.kind ?? 'neutral'
+  const timePosition = props.timePosition ?? 'trailing'
+  const bodyText = truncate(props.text, props.bodyMaxChars)
+  const showLeadingTime = timePosition === 'leading' && props.time !== undefined
+  const showTrailingTime = timePosition === 'trailing' && props.time !== undefined
+
+  const timeNode = props.time
+    ? html`
+        <span
+          aria-hidden="true"
+          style=${{
+            fontFamily: MONO_STACK,
+            fontSize: '10px',
+            color: 'var(--color-fg-disabled)',
+            fontVariantNumeric: 'tabular-nums',
+            letterSpacing: '0.04em',
+            flex: 'none',
+          }}
+        >${props.time}</span>
+      `
+    : null
+
+  return html`
+    <span
+      role="listitem"
+      aria-label=${tickerItemAriaLabel(props)}
+      style=${{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '2px 8px',
+        fontFamily: MONO_STACK,
+        fontSize: '11px',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      ${showLeadingTime ? timeNode : null}
+      <${KeeperBadge} id=${props.keeperId} variant="sigil" size="sm" />
+      <span
+        aria-hidden="true"
+        style=${{
+          color: 'var(--color-fg-primary)',
+          fontWeight: 500,
+        }}
+      >${props.keeperId}</span>
+      <span
+        aria-hidden="true"
+        style=${{
+          color: BODY_COLOR_BY_KIND[kind],
+          fontWeight: 400,
+          textOverflow: 'ellipsis',
+          overflow: 'hidden',
+        }}
+      >${bodyText}</span>
+      ${showTrailingTime ? timeNode : null}
+    </span>
+  `
+}
+
+export type TickerOrientation = 'horizontal' | 'vertical'
+
+export interface TickerStripProps {
+  events: TickerItemProps[]
+  /** `horizontal` = inline flex row (marquee/chunks pattern).
+   *  `vertical` = stacked column (vertical pattern). Default 'horizontal'. */
+  orientation?: TickerOrientation
+  /** Required label for the log region (Korean default). */
+  ariaLabel?: string
+}
+
+export function TickerStrip({
+  events,
+  orientation = 'horizontal',
+  ariaLabel = '플릿 이벤트 티커',
+}: TickerStripProps): VNode {
+  return html`
+    <div
+      role="log"
+      aria-live="polite"
+      aria-label=${ariaLabel}
+      style=${{
+        display: 'flex',
+        flexDirection: orientation === 'vertical' ? 'column' : 'row',
+        gap: orientation === 'vertical' ? '4px' : '12px',
+        alignItems: orientation === 'vertical' ? 'stretch' : 'center',
+        overflow: 'hidden',
+      }}
+    >
+      ${events.map((evt, i) => html`<${TickerItem} key=${i} ...${evt} />`)}
+    </div>
+  `
+}


### PR DESCRIPTION
## Why

Third cb-group-a port (KpiCell #11066 / Heartbeat+LifelineBar #11070 preceded). The activity ticker is the most data-driven element in cb-group-a — every event is a `(keeper, kind, text, time)` tuple, and three "variants" (Marquee / Chunks / Vertical) all collapse into the same atomic row with two display knobs (`timePosition`, `bodyMaxChars`) plus a strip-level `orientation`.

Same recipe as KeeperBadge / KpiCell / LifelineBar: **primitive only, callsite migration in follow-up PRs**.

## What

`src/components/ticker-item.ts` — three exports:

| Export | Kind | Purpose |
|--------|------|---------|
| `tickerItemAriaLabel(props)` | pure helper | Builds the SR announcement (`"nick0cave: pushed PR #123, at 14:32:18"`). Exposed for tests + for callers that compose their own consolidated label. |
| `TickerItem` | atomic component | Single event row: KeeperBadge sigil + keeper id + body + optional time. |
| `TickerStrip` | composite container | `role="log"` + `aria-live="polite"`, arrays TickerItems horizontally or vertically. |

### TickerItem props
| Prop | Default | Purpose |
|------|---------|---------|
| `keeperId` | (required) | Powers the KeeperBadge sigil + identity color. |
| `text` | (required) | Event body. |
| `kind` | `'neutral'` | Tone — `'ok' \| 'warn' \| 'err' \| 'info' \| 'neutral'`. Colors the body via `--color-status-*` / `--color-accent-fg` / `--color-fg-secondary`. |
| `time` | (omitted) | Pre-formatted time string. |
| `timePosition` | `'trailing'` | `'leading'` (vertical pattern) / `'trailing'` (marquee/chunks) / `'none'` (hide visually but keep in aria-label). |
| `bodyMaxChars` | (no truncate) | Trim long bodies (chunks pattern). |

### Variant collapse

| cb-group-a variant | dashboard equivalent |
|--------------------|----------------------|
| `TickerMarquee` | `TickerStrip(orientation='horizontal')` of items with `timePosition='trailing'` |
| `TickerChunks`  | same + `bodyMaxChars=40` per item |
| `TickerVertical`| `TickerStrip(orientation='vertical')` of items with `timePosition='leading'` |

Three components → one + two knobs. This is the *primitive design* value-add; the source happened to keep them as three sibling components but the data shape was identical.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run src/components/ticker-item.test.ts`
  - `tickerItemAriaLabel` (pure): minimal "keeper: text", kind insertion, neutral skip, time suffix, bodyMaxChars truncation, all-combo
  - `TickerItem`: role + aria-label, keeper text + KeeperBadge "NK" sigil for nick0cave, trailing time (default), leading time positioning (text-index check), `none` hides visually but keeps aria, body truncation
  - `TickerStrip`: `role="log"` + `aria-live="polite"` + Korean default label "플릿 이벤트 티커", listitem count, custom label, vertical column-direction, horizontal row-direction (default), empty events array
- [ ] Visual smoke: queued for first callsite migration.

## What this PR does NOT do

- **No marquee animation.** cb-group-a's marquee uses a CSS infinite translate animation. Deferred — callers can wrap in their own auto-scroll if they want it; the primitive stays declarative so vertical/static usages don't fight an animation they don't need.
- **No kind → icon mapping.** Tone is color-only; an icon channel can be added when 2+ callsites need the same icons.
- **No callsite migration.** Same cadence as predecessor primitives.

## Refs

- Source: `dashboard/design-system/preview/cb-group-a.jsx` (TickerMarquee / TickerChunks / TickerVertical)
- Precedent: #11066 (KpiCell), #11070 (Heartbeat + LifelineBar), #10955 (KeeperBadge — used here)
- SPEC: `dashboard/design-system/SPEC.md` §3 (typography + tokens)
- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
