### PR TITLE
perf: hoist per-call Re.compile to module-level bindings

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -100,10 +100,10 @@ let bool_of_env_opt name =
       else if v = "0" || v = "false" || v = "no" || v = "n" || v = "off" then Some false
       else None
 
+let valid_name_re = Re.Pcre.re "^[A-Za-z0-9._-]+$" |> Re.compile
+
 let validate_name name =
-  (* Same rule as keeper script: conservative handle chars only. *)
-  let re = Re.Pcre.re "^[A-Za-z0-9._-]+$" |> Re.compile in
-  name <> "" && Re.execp re name
+  name <> "" && Re.execp valid_name_re name
 
 let default_proactive_enabled = true
 let default_proactive_idle_sec = 120

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -3,6 +3,11 @@
 
 open Keeper_types
 
+(* Static patterns for [STATE] block detection, hoisted from
+   [find_state_block].  [Re.compile] runs once at module load. *)
+let state_start_re = Re.str "[STATE]" |> Re.compile
+let state_end_re = Re.str "[/STATE]" |> Re.compile
+
 type keeper_policy_observation = {
   source_kind: string;
   room_id: string option;
@@ -229,14 +234,12 @@ let strip_prefix_ci ~(prefix : string) (s : string) : string option =
       None
 
 let find_state_block (reply : string) : string option =
-  let start_re = Re.str "[STATE]" |> Re.compile in
-  let end_re = Re.str "[/STATE]" |> Re.compile in
-  match Re.exec_opt start_re reply with
+  match Re.exec_opt state_start_re reply with
   | None -> None
   | Some g ->
     let start_idx = Re.Group.start g 0 in
     let body_start = start_idx + String.length "[STATE]" in
-    (match Re.exec_opt ~pos:body_start end_re reply with
+    (match Re.exec_opt ~pos:body_start state_end_re reply with
      | None -> None
      | Some g2 ->
        let end_idx = Re.Group.start g2 0 in

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -4,6 +4,15 @@ open Keeper_types
 
 include Keeper_memory_bank
 
+(* Static string-match patterns hoisted from evaluate_memory_recall.
+   [Re.str] + [Re.compile] is pure, so a single DFA build at module
+   load replaces one per-call compile on every weather/first-question
+   recall evaluation. *)
+let re_weather_ko = Re.str "날씨" |> Re.compile
+let re_weather_en = Re.str "weather" |> Re.compile
+let re_first_ko = Re.str "첫" |> Re.compile
+let re_first_en = Re.str "first" |> Re.compile
+
 let cost_usd_of_usage (usage : Oas.Types.api_usage) ~(model_id : string) : float =
   let pricing = Llm_provider.Pricing.pricing_for_model model_id in Llm_provider.Pricing.estimate_cost ~pricing
         ~input_tokens:usage.input_tokens ~output_tokens:usage.output_tokens ()
@@ -676,8 +685,8 @@ let evaluate_memory_recall
   let expected_topic = expected_topic_hint user_message in
   let has_weather_word (s : string) =
     let q = String.lowercase_ascii s in
-    Re.execp (Re.str "날씨" |> Re.compile) s
-    || Re.execp (Re.str "weather" |> Re.compile) q
+    Re.execp re_weather_ko s
+    || Re.execp re_weather_en q
   in
   (* Similarity threshold for recall match acceptance.
      0.18 (default): Jaccard + character n-gram combined score.
@@ -747,8 +756,8 @@ let evaluate_memory_recall
           if has_weather_reply then 0.08 else -.0.08
       | Some "first_question" ->
           let has_first =
-            Re.execp (Re.str "첫" |> Re.compile) assistant_reply
-            || Re.execp (Re.str "first" |> Re.compile) (String.lowercase_ascii assistant_reply)
+            Re.execp re_first_ko assistant_reply
+            || Re.execp re_first_en (String.lowercase_ascii assistant_reply)
           in
           if has_first then 0.05 else -.0.05
       | _ -> 0.0

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -14,6 +14,8 @@ let runtime_meta_write_sync_hook : (Coord.config -> keeper_meta -> unit) ref =
 
 let register_runtime_meta_write_sync f = runtime_meta_write_sync_hook := f
 
+let version_conflict_re = Re.Pcre.re "meta version conflict" |> Re.compile
+
 let read_meta_file_path path : (keeper_meta option, string) result =
   if not (Fs_compat.file_exists path)
   then Ok None
@@ -304,9 +306,8 @@ let write_meta ?(force = false) config (m : keeper_meta) : (unit, string) result
 ;;
 
 let is_version_conflict_error msg =
-  let re = Re.Pcre.re "meta version conflict" |> Re.compile in
   try
-    ignore (Re.exec re msg);
+    ignore (Re.exec version_conflict_re msg);
     true
   with
   | Not_found -> false


### PR DESCRIPTION
## Summary
- Hoist 7 static regex compilations from function bodies to module-level `let` bindings in 4 files
- `Re.compile` builds a DFA table per call; module-level binding constructs it once at load time
- No behavior change — purely mechanical relocation of pure expressions

## Files
- `keeper_memory_recall.ml`: 4 patterns (weather ko/en, first ko/en)
- `keeper_memory_policy.ml`: 2 patterns (`[STATE]`, `[/STATE]`)
- `keeper_meta_store.ml`: 1 pattern (version conflict)
- `keeper_config.ml`: 1 pattern (name validation)

## Test plan
- [x] `dune build` passes
- [ ] `dune runtest` (in CI)

Follow-up to #10250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)