### PR TITLE
i18n(dashboard): localize 10 api/ thrown Error payloads (round-100 milestone)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -804,7 +804,7 @@ function decodeRuntimeModelMetricsResponse(raw: unknown): DashboardRuntimeModelM
 export async function fetchRuntimeProviders(opts?: AbortableRequestOptions): Promise<DashboardRuntimeProvidersResponse> {
   const raw = await get<Record<string, unknown>>('/api/v1/providers', { signal: opts?.signal })
   const decoded = decodeRuntimeProvidersResponse(raw)
-  if (!decoded) throw new Error('invalid runtime providers payload')
+  if (!decoded) throw new Error('유효하지 않은 runtime providers payload')
   return decoded
 }
 
@@ -816,7 +816,7 @@ export async function fetchRuntimeModelMetrics(
   const bParam = bucketMinutes > 0 ? `&bucket_min=${bucketMinutes}` : ''
   const raw = await get<Record<string, unknown>>(`/api/v1/models/metrics?window=${windowMinutes}${bParam}`, { signal: opts?.signal })
   const decoded = decodeRuntimeModelMetricsResponse(raw)
-  if (!decoded) throw new Error('invalid runtime model metrics payload')
+  if (!decoded) throw new Error('유효하지 않은 runtime model metrics payload')
   return decoded
 }
 
@@ -1187,14 +1187,14 @@ function decodeDashboardGoalDetailResponse(raw: unknown): DashboardGoalDetailRes
 export async function fetchDashboardGoalsTree(): Promise<DashboardGoalsTreeResponse> {
   const raw = await get<unknown>('/api/v1/dashboard/goals')
   const decoded = decodeDashboardGoalsTreeResponse(raw)
-  if (!decoded) throw new Error('invalid dashboard goals payload')
+  if (!decoded) throw new Error('유효하지 않은 dashboard goals payload')
   return decoded
 }
 
 export async function fetchDashboardGoalDetail(goalId: string): Promise<DashboardGoalDetailResponse> {
   const raw = await get<unknown>(`/api/v1/dashboard/goals/detail?goal_id=${encodeURIComponent(goalId)}`)
   const decoded = decodeDashboardGoalDetailResponse(raw)
-  if (!decoded) throw new Error('invalid dashboard goal detail payload')
+  if (!decoded) throw new Error('유효하지 않은 dashboard goal detail payload')
   return decoded
 }
 
@@ -2007,7 +2007,7 @@ export function fetchKeeperToolStats(
     { signal: opts?.signal },
   ).then((raw) => {
     const decoded = decodeToolStatsResponse(raw)
-    if (!decoded) throw new Error('invalid keeper tool stats payload')
+    if (!decoded) throw new Error('유효하지 않은 keeper tool stats payload')
     return decoded
   })
 }
@@ -2119,7 +2119,7 @@ export function fetchKeeperToolCalls(
     { signal: opts?.signal },
   ).then((raw) => {
     const decoded = decodeToolCallsResponse(raw)
-    if (!decoded) throw new Error('invalid keeper tool call payload')
+    if (!decoded) throw new Error('유효하지 않은 keeper tool call payload')
     return decoded
   })
 }
@@ -2289,7 +2289,7 @@ export function fetchTelemetry(opts?: {
   return get<Record<string, unknown>>(`/api/v1/dashboard/telemetry${qs ? '?' + qs : ''}`, { signal: opts?.signal })
     .then((raw) => {
       const decoded = decodeTelemetryResponse(raw)
-      if (!decoded) throw new Error('invalid telemetry payload')
+      if (!decoded) throw new Error('유효하지 않은 telemetry payload')
       return decoded
     })
 }
@@ -2298,7 +2298,7 @@ export function fetchTelemetrySummary(opts?: AbortableRequestOptions): Promise<T
   return get<Record<string, unknown>>('/api/v1/dashboard/telemetry/summary', { signal: opts?.signal })
     .then((raw) => {
       const decoded = decodeTelemetrySummaryResponse(raw)
-      if (!decoded) throw new Error('invalid telemetry summary payload')
+      if (!decoded) throw new Error('유효하지 않은 telemetry summary payload')
       return decoded
     })
 }

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -324,11 +324,11 @@ export async function listMcpTools(cursor?: string): Promise<McpToolsListResult>
   })
   const parsed = parseMcpListResponse(text)
   if (parsed.error) {
-    const message = parsed.error.message || 'tools/list: server returned an error without a message'
+    const message = parsed.error.message || 'tools/list: 서버가 message 없이 error 반환'
     throw new Error(message)
   }
   if (!parsed.result) {
-    throw new Error('tools/list: missing result in response')
+    throw new Error('tools/list: 응답에 result 없음')
   }
   return parsed.result
 }


### PR DESCRIPTION
## Summary

🎉 **Round-100 milestone**. Round-99 (#11086) 가 keeper checkpoint thrown errors 3개 처리. 이 round 는 같은 layer (api/) 에서 다른 file (dashboard.ts + mcp.ts) 의 thrown Error 10개 통합.

## Changed strings

### `api/dashboard.ts` — 8 validation errors (uniform `'invalid X payload'` pattern)

| line | X | After |
|---|---|---|
| 807 | `runtime providers` | `유효하지 않은 runtime providers payload` |
| 819 | `runtime model metrics` | `유효하지 않은 runtime model metrics payload` |
| 1190 | `dashboard goals` | `유효하지 않은 dashboard goals payload` |
| 1197 | `dashboard goal detail` | `유효하지 않은 dashboard goal detail payload` |
| 2010 | `keeper tool stats` | `유효하지 않은 keeper tool stats payload` |
| 2122 | `keeper tool call` | `유효하지 않은 keeper tool call payload` |
| 2292 | `telemetry` | `유효하지 않은 telemetry payload` |
| 2301 | `telemetry summary` | `유효하지 않은 telemetry summary payload` |

8 entries 모두 sed transform 으로 일관 처리:
```bash
sed -i.bak "s/throw new Error('invalid \([a-z ]*\) payload')/throw new Error('유효하지 않은 \1 payload')/g" \
  dashboard/src/api/dashboard.ts
```

### `api/mcp.ts` — 2 tools/list errors

| line | Before | After |
|---|---|---|
| 327 | `'tools/list: server returned an error without a message'` | `'tools/list: 서버가 message 없이 error 반환'` |
| 331 | `'tools/list: missing result in response'` | `'tools/list: 응답에 result 없음'` |

## Domain term policy

`payload`, `runtime`, `telemetry`, `tools/list`, `result`, `message` 보존 — JSON-RPC / domain terms.

## Stack progress: i18n round 80→100 milestone

| 범위 | 주요 surface | 누적 PR |
|---|---|---|
| 80-82 | composite-fsm-flowchart, status, fsm-hub headlines | 3 |
| 83-87 | fsm-hub-invariant-analysis 4 surfaces | 5 |
| 88-93 | fleet-telemetry-utils, matrix tooltips, transport-beacon, connector-status | 6 |
| 94-95 | mixed-language status detail, vs env | 2 |
| 96-98 | fsm-hub-lane-analysis 5 switches + breaker | 3 |
| 99-100 | api/keeper + api/dashboard + api/mcp thrown errors | 2 |
| **Total** | | **21 PRs** |

## Scope

- 2 파일, 10줄.
- test 영향 0.
