### PR TITLE
fix(coord): Eio 1.0+ types in coord_utils_backend_setup.mli

### DIFF
--- a/lib/coord/coord_utils_backend_setup.mli
+++ b/lib/coord/coord_utils_backend_setup.mli
@@ -1,0 +1,43 @@
+type storage_backend =
+  | Memory of Backend.Memory.t
+  | FileSystem of Backend.FileSystem.t
+
+type config = {
+  base_path : string;
+  workspace_path : string;
+  lock_expiry_minutes : int;
+  backend_config : Backend_types.config;
+  backend : storage_backend;
+}
+
+val domain_local_pg_backend_diagnostics_json : unit -> Yojson.Safe.t
+val with_domain_local_pg_backend :
+  sw:Eio.Switch.t ->
+  net:[> `Generic | `Unix] Eio.Net.ty Eio.Resource.t ->
+  clock:_ Eio.Time.clock ->
+  mono_clock:Eio.Time.Mono.ty Eio.Resource.t ->
+  config ->
+  config option
+val read_git_file : string -> string option
+val parse_gitdir_to_main_root : string -> string option
+val find_git_root : string -> string option
+val normalize_base_path : string -> string
+val running_under_test_executable : unit -> bool
+val test_base_path_override_env : string
+val test_base_path_override_enabled : unit -> bool
+val sync_test_base_path_env : string -> unit
+val resolve_requested_base_path : string -> string
+val resolve_masc_base_path : string -> string
+val resolve_server_default_base_path : string -> string
+val is_unresolved_template : string -> bool
+val env_opt : string -> string option
+val auto_detect_backend : unit -> string
+val storage_type_from_env : unit -> string
+val sanitize_namespace_segment : string -> string
+val backend_config_for : string -> Backend_types.config
+val create_backend : Backend_types.config -> (storage_backend, Backend_types.error) result
+val create_backend_eio : sw:Eio.Switch.t -> Backend_types.config -> (storage_backend, Backend_types.error) result
+val reset_default_config_cache : unit -> unit
+val build_default_config : string -> config
+val default_config : string -> config
+val default_config_eio : sw:Eio.Switch.t -> ?on_backend_ready:(storage_backend -> unit) -> string -> config


### PR DESCRIPTION
## Summary
- `lib/coord/coord_utils_backend_setup.mli`이 untracked 상태로 root에 존재했고, Eio 1.0+ alias 변경으로 typecheck 불가
- main에 `dune build` 시 `Eio.Net.t expects 1 argument` / `Eio.Time.clock expects 1 argument` 발생
- `mcp_server_eio.mli`, `server_runtime_bootstrap.mli` 등 codebase 표준 패턴으로 수정

## Changes
| 인자 | Before | After |
|------|--------|-------|
| `net` | `Eio.Net.t` | `[> \`Generic \| \`Unix] Eio.Net.ty Eio.Resource.t` |
| `clock` | `Eio.Time.clock` | `_ Eio.Time.clock` |
| `mono_clock` | `Eio.Time.Mono.t` | `Eio.Time.Mono.ty Eio.Resource.t` |

`.ml`은 `let _ = sw, net, clock, mono_clock`으로 인자를 모두 discard하므로 구현 변경 없음.

## Test plan
- [x] `dune build @check` exit 0 (worktree)
- [x] `lib/coord/` 단독 check 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
