### PR TITLE
fix(dashboard): surface 6 P2 silent failures (telemetry gaps)

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -159,13 +159,26 @@ export async function refreshAgentDetail(): Promise<void> {
   agentFitness.value = null
 
   try {
-    // Fetch namespace (room) messages, task histories, timeline, and fitness in parallel
+    // Fetch namespace (room) messages, task histories, timeline, and fitness in parallel.
+    //
+    // P2 silent-failure fix: previously both .catch(() => null) calls
+    // silently coerced fetch failures into null, indistinguishable from
+    // "agent has no timeline / no fitness data" — operator saw blank
+    // panels with no signal that the underlying fetch had failed.  Now
+    // each catch logs the error so DevTools surfaces the failure even
+    // though the UI still degrades gracefully (other data still shows).
     const [lines, timelineResult, fitnessResult] = await Promise.all([
       fetchRoomMessages(80),
-      fetchAgentTimeline(agentName, 24, 50).catch(() => null),
+      fetchAgentTimeline(agentName, 24, 50).catch((err: unknown) => {
+        console.warn('[agent-detail-state] fetchAgentTimeline failed', { agentName, err })
+        return null
+      }),
       callMcpTool('masc_agent_fitness', { agent_name: agentName, days: 7 })
         .then(raw => JSON.parse(raw) as AgentFitness)
-        .catch(() => null),
+        .catch((err: unknown) => {
+          console.warn('[agent-detail-state] masc_agent_fitness fetch/parse failed', { agentName, err })
+          return null
+        }),
     ])
 
     const matchNames = agentMatchNames(agentName)

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -50,8 +50,19 @@ async function loadAll() {
   if (names.length === 0) return
   loading.value = true
   try {
+    // P2 silent-failure fix: a partial fleet outage previously produced
+    // a phase-strip with random keepers missing — visually identical to
+    // "those keepers have no transitions yet" — and operators had no way
+    // to tell.  Per-name catch now logs which keeper's fetch failed so
+    // the gap pattern is diagnosable from DevTools, while the strip
+    // still degrades gracefully for the keepers that did succeed.
     const results = await Promise.all(
-      names.map(name => fetchKeeperTransitions(name, 30).catch(() => null)),
+      names.map(name =>
+        fetchKeeperTransitions(name, 30).catch((err: unknown) => {
+          console.warn('[keeper-phase-strip] fetchKeeperTransitions failed', { name, err })
+          return null
+        }),
+      ),
     )
     const next = new Map<string, KeeperTransitionsResponse>()
     for (let i = 0; i < names.length; i++) {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -284,8 +284,16 @@ export function parseWebSocketSseFrames(data: string): unknown[] {
     if (!body || body === '[DONE]') continue
     try {
       payloads.push(JSON.parse(body))
-    } catch {
-      // Non-JSON SSE frames are ignored; dashboard pushes are JSON.
+    } catch (err) {
+      // P2 silent-failure fix: dashboard pushes are JSON by contract,
+      // so a non-JSON SSE frame here is either a server-side encoding
+      // bug or network corruption.  Previously dropped silently —
+      // operators investigating "stale dashboard" had no signal that
+      // frames were being parsed-but-malformed.  Logging includes a
+      // body sample so the malformed shape is recoverable from
+      // DevTools.  body length is capped to keep the log line bounded.
+      const sample = body.length > 200 ? `${body.slice(0, 200)}…(${body.length} bytes total)` : body
+      console.warn('[dashboard-ws] non-JSON SSE frame dropped', { sample, err })
     }
   }
   return payloads

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -104,7 +104,17 @@ export async function loadFullKeeperHistory(name: string): Promise<void> {
       tail_messages: KEEPER_HISTORY_TAIL_MESSAGES,
     })
     let parsed: unknown = null
-    try { parsed = JSON.parse(text) } catch { parsed = null }
+    try {
+      parsed = JSON.parse(text)
+    } catch (err) {
+      // P2 silent-failure fix: malformed status response previously
+      // produced an empty detail UI indistinguishable from "no data
+      // yet."  Logging surfaces the parse failure to DevTools while
+      // normalizeStatusDetail still degrades gracefully (uses raw
+      // text + null parsed).
+      console.warn('[keeper] masc_keeper_status response parse failed', { keeperName, err })
+      parsed = null
+    }
     const detail = normalizeStatusDetail(keeperName, text, parsed)
     setStatusDetail(keeperName, detail)
   } catch (err) {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -222,13 +222,31 @@ function handleOperatorDigest(payload: unknown): void {
   }
 }
 
+// P2 silent-failure fix: previously the dynamic import retried on every
+// SSE transport-health event with only console.debug on failure (hidden
+// from default DevTools view).  Two improvements:
+//   1. Cache the imported module so failure is signalled exactly once
+//      per session, not on every SSE tick.
+//   2. Promote the failure log to console.warn so operators see it
+//      when investigating "transport health widget is missing/stale."
+let transportHealthModule: Promise<typeof import('./components/transport-health')> | null = null
+let transportHealthImportFailed = false
+
 function handleTransportHealth(payload: unknown): void {
-  void import('./components/transport-health')
+  if (transportHealthImportFailed) return
+  if (transportHealthModule === null) {
+    transportHealthModule = import('./components/transport-health')
+  }
+  void transportHealthModule
     .then(({ hydrateTransportHealthFromSSE }) => {
       hydrateTransportHealthFromSSE(payload)
     })
-    .catch(err => {
-      console.debug('[SSE] transport health hydration failed', err instanceof Error ? err.message : '')
+    .catch((err: unknown) => {
+      transportHealthImportFailed = true
+      console.warn(
+        '[SSE] transport health module import failed — widget hydration disabled for this session',
+        err,
+      )
     })
 }
 

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -140,15 +140,31 @@ const REFRESHERS: Record<RefreshTask, (routeState: Pick<RouteState, 'tab' | 'par
 
 const VISIT_COUNTER_KEY = 'masc_dashboard_tab_visits'
 
+// In-memory fallback when localStorage is unavailable (private mode,
+// quota exceeded, etc.) — keeps visit counters useful for the duration
+// of the tab session even when persistence is broken.
+let inMemoryVisitCounts: Record<string, number> | null = null
+
 function recordTabVisit(tab: string, section?: string): void {
+  const key = section ? `${tab}/${section}` : tab
   try {
     const raw = localStorage.getItem(VISIT_COUNTER_KEY)
     const counts: Record<string, number> = raw ? JSON.parse(raw) : {}
-    const key = section ? `${tab}/${section}` : tab
     counts[key] = (counts[key] ?? 0) + 1
     localStorage.setItem(VISIT_COUNTER_KEY, JSON.stringify(counts))
-  } catch {
-    // localStorage unavailable or quota exceeded — skip silently
+    inMemoryVisitCounts = null
+  } catch (err) {
+    // P2 silent-failure fix: localStorage unavailable (private mode,
+    // quota exceeded, sandboxed iframe).  Previously the visit counter
+    // froze entirely for the rest of the tab session and analytics
+    // lost the navigation pattern.  Now: log once on the first
+    // failure, then maintain an in-memory counter so the data is at
+    // least available within the session even if not persisted.
+    if (inMemoryVisitCounts === null) {
+      console.warn('[tab-refresh] localStorage unavailable, falling back to in-memory visit counter', err)
+      inMemoryVisitCounts = {}
+    }
+    inMemoryVisitCounts[key] = (inMemoryVisitCounts[key] ?? 0) + 1
   }
 }
 


### PR DESCRIPTION
## Why

Quality sweep PR-D — first of three P2 PRs targeting the 17 P2 silent-failure findings.  Each site previously dropped a fetch / parse / import failure into a UI state indistinguishable from "no data" — lower urgency than P1 because partial degradation was already in place, but still a telemetry gap that prevented operator diagnosis.

## What

| File | Pattern | Fix |
|------|---------|-----|
| \`components/agent-detail-state.ts:165-168\` | Promise.all with two \`.catch(() => null)\` calls in cascade | Per-promise catch logs which call failed (timeline / fitness) |
| \`components/keeper-phase-strip.ts:54\` | \`names.map(... .catch(() => null))\` — array of nulls hides per-keeper failures | Per-name catch logs which keeper's fetch failed |
| \`dashboard-ws.ts:285-289\` | \`parseWebSocketSseFrames\` empty catch silently drops non-JSON frames | Log bounded body sample (200 bytes max) — server pushes are JSON by contract so this signals encoding bug or corruption |
| \`tab-refresh.ts:144-152\` | localStorage quota/private-mode error swallowed, visit counter frozen for the session | One-time warn on first failure + in-memory fallback so counter still works within the tab |
| \`keeper-actions.ts:107\` | \`JSON.parse\` on \`masc_keeper_status\` silently → null, blank detail UI | Log parse error, normalizeStatusDetail still degrades gracefully |
| \`sse-store.ts:225-233\` | \`import('./components/transport-health')\` retried on every SSE event with only console.debug | Cache import promise (one warn per session) + promote to console.warn |

Net: 6 files, +89 -13.

## Severity rationale (why P2 not P1)

These failures all have **partial degradation already in place** (other panels still load, other keepers still show, the next event still tries to import).  In contrast, the 3 P1 fixes in PR-A produced **no degradation** — the entire selector / notification / transcript was missing with no signal at all.

The escalation pattern is identical though: **silent → console.warn (with bounded payload)**.

## Stack position

- PR-A (#11038, dashboard P1) — independent
- PR-B (#11074, server FSM P1) — independent
- PR-C (#11075, server transport P1) — independent
- **PR-D (this, dashboard P2)** — different files / hunks from PR-A; auto-rebases cleanly even if PR-A merges first
- PR-E (next, server FSM P2)
- PR-F (next, server transport P2)
- PR-G (last, P3 cleanup)

## Test plan

- [x] \`pnpm run typecheck\` succeeds
- [x] \`pnpm --filter masc-dashboard build\` succeeds (10.5s)
- [ ] After deploy, simulate each failure (network throttle / storage quota / corrupt payload) and verify the new \`console.warn\` lines in DevTools