### PR TITLE
feat(dashboard): adopt canonical SPEC tokens in 7 handwritten CSS files (CS107)

### DIFF
--- a/dashboard/src/styles/board.css
+++ b/dashboard/src/styles/board.css
@@ -3,7 +3,7 @@
 /* ── Board (Posts) ─────────────────────────────────────────── */
 
 @utility board-post {
-  border-color: var(--card-border);
+  border-color: var(--color-border-default);
   content-visibility: auto;
   contain-intrinsic-size: auto 120px;
   transition: border-color 0.2s, transform 0.2s, background 0.2s;

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -33,7 +33,7 @@
 @utility chat-avatar {
   &.user {
     border-color: rgba(71, 184, 255, 0.28);
-    background: var(--accent-soft);
+    background: var(--color-accent-soft);
     color: #d8f0ff;
   }
   &.assistant {

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -63,7 +63,7 @@
   justify-content: center;
   padding: 48px 16px;
   font-size: var(--fs-sm);
-  color: var(--text-muted);
+  color: var(--color-fg-muted);
 }
 
 /* ── Responsive (layout) ── */
@@ -84,7 +84,7 @@
 /* ── Board (Posts) ─────────────────────────────────────────── */
 
 @utility board-post {
-  border-color: var(--card-border);
+  border-color: var(--color-border-default);
   content-visibility: auto;
   contain-intrinsic-size: auto 120px;
   transition: border-color 0.2s, transform 0.2s, background 0.2s;

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -43,7 +43,7 @@
 
 @utility card {
   background: var(--card);
-  border: 1px solid var(--card-border);
+  border: 1px solid var(--color-border-default);
   border-radius: 12px;
   padding: 16px;
   box-shadow:
@@ -65,13 +65,13 @@
 
 @utility monitor-subheadline {
   font-size: var(--fs-sm);
-  color: var(--text-muted);
+  color: var(--color-fg-muted);
   line-height: 1.5;
   margin-top: 6px;
 }
 
 @utility monitor-surface-card {
-  border: 1px solid var(--card-border);
+  border: 1px solid var(--color-border-default);
   border-radius: var(--radius-xl);
   background: var(--card);
 }
@@ -119,7 +119,7 @@
   line-height: 1.6;
   white-space: nowrap;
   background: var(--white-6);
-  color: var(--text-muted);
+  color: var(--color-fg-muted);
   &.active { background: var(--ok-22); color: var(--ok); }
   &.busy { background: var(--warn-15); color: var(--warn); }
   &.listening { background: rgba(56,189,248,0.15); color: var(--sky-400); }
@@ -162,7 +162,7 @@ thead th {
   padding: 8px 12px;
   font-size: var(--fs-xs);
   font-weight: 600;
-  color: var(--text-muted);
+  color: var(--color-fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   border-bottom: 1px solid var(--border-slate-16);

--- a/dashboard/src/styles/live-monitor.css
+++ b/dashboard/src/styles/live-monitor.css
@@ -35,7 +35,7 @@
   &.live-event-broadcast { background: var(--blue-400-15); color: var(--accent); }
   &.live-event-task { background: var(--ok-soft); color: var(--ok); }
   &.live-event-keeper { background: rgba(168,85,247,0.15); color: #a855f7; }
-  &.live-event-system { background: var(--white-6); color: var(--text-muted); }
+  &.live-event-system { background: var(--white-6); color: var(--color-fg-muted); }
 }
 
 @utility focus-agent-card {

--- a/dashboard/src/styles/pixel-avatar.css
+++ b/dashboard/src/styles/pixel-avatar.css
@@ -72,7 +72,7 @@
 @utility activity-dot--live { background: var(--agent-working); }
 @utility activity-dot--stale { background: var(--agent-busy); }
 @utility activity-dot--inactive { background: rgba(138, 163, 211, 0.4); }
-@utility activity-dot--unknown { background: var(--card-border); }
+@utility activity-dot--unknown { background: var(--color-border-default); }
 
 /* Speech bubble */
 @utility pixel-avatar__speech-bubble {

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -48,7 +48,7 @@
   & blockquote {
     border-left: 3px solid var(--ff-gold-40);
     padding-left: 12px;
-    color: var(--text-muted);
+    color: var(--color-fg-muted);
     margin: 8px 0;
   }
 
@@ -61,7 +61,7 @@
 
   & a { color: var(--accent); &:hover { text-decoration: underline; } }
   & strong { font-weight: 600; }
-  & del { color: var(--text-muted); }
+  & del { color: var(--color-fg-muted); }
 
   & table { margin: 8px 0; }
 
@@ -136,7 +136,7 @@ button.monitor-row {
 @utility agent-event-badge--broadcast { background: var(--purple-12); color: var(--purple); }
 @utility agent-event-badge--task { background: var(--warn-12); color: var(--warn); }
 @utility agent-event-badge--board { background: var(--cyan-12); color: var(--cyan); }
-@utility agent-event-badge--default { background: var(--border-slate-12); color: var(--text-muted); }
+@utility agent-event-badge--default { background: var(--border-slate-12); color: var(--color-fg-muted); }
 
 /* ── Micro-Interactions (Task 289) ── */
 @utility pressable {


### PR DESCRIPTION
## Summary

Phase G Step 4 extends component-level sweeps to handwritten CSS files. 14 sites across 7 CSS files swap legacy tokens to canonical SPEC §3 names (1:1 alias chain).

## Mapping (1:1 identical color)

| Legacy | Canonical |
|--------|-----------|
| `var(--text-muted)` | `var(--color-fg-muted)` |
| `var(--text-dim)` | `var(--color-fg-disabled)` |
| `var(--card-border)` | `var(--color-border-default)` |
| `var(--accent-soft)` | `var(--color-accent-soft)` |
| `var(--accent-primary)` | `var(--color-accent-fg)` |

## Files (7 total)

| File | Sites |
|------|-------|
| `global.css` | 5 |
| `ui.css` | 3 |
| `dashboard.css` | 2 |
| `board.css` | 1 |
| `chat.css` | 1 |
| `live-monitor.css` | 1 |
| `pixel-avatar.css` | 1 |
| **Total** | **14** |

`variables.css` is intentionally untouched — its `--card-border`, `--text-muted` alias definitions ARE the SSOT mapping legacy → canonical and must remain.

## Test plan

- [x] `pnpm typecheck` green (CSS-only change)
- [x] Pure 1:1 alias swap — no visual diff
- [x] Diff is 1:1 (14 ins / 14 del)