### PR TITLE
fix(keeper): split allowlist/denylist prompt formatters so empty allowlist reads as gate OFF

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -18,8 +18,25 @@ let exact_direct_mention_present ~(targets : string list) (content : string) :
 let keeper_constitution () =
   Prompt_registry.get_prompt Keeper_prompt_names.constitution
 
-(** Format a string list for prompt rendering. Empty list -> "(none)". *)
-let format_list_for_prompt (items : string list) : string =
+(** Format an *allowlist* for prompt rendering.  An empty allowlist means
+    the gate is OFF (any account-accessible repo is permitted), so we
+    render that intent explicitly — otherwise the LLM sees the literal
+    "(none)" produced by a generic empty-list formatter and reads the
+    allowlist as "no orgs allowed", which is the inverse of the operator
+    intent behind an empty list.  Pairs with [validate_gh_command] in
+    [gh_command_validation], where an empty [allowed_orgs] argument also
+    means "skip the org check".
+
+    Replaces the earlier [format_list_for_prompt] which collapsed both
+    semantics to "(none)". *)
+let format_allowlist_for_prompt (items : string list) : string =
+  match items with
+  | [] -> "(any — allowlist gate is OFF, the operator's gh credential surface is the only repo boundary)"
+  | xs -> String.concat ", " xs
+
+(** Format a *denylist* for prompt rendering.  An empty denylist means
+    no repo is explicitly blocked, so "(none)" reads correctly here. *)
+let format_denylist_for_prompt (items : string list) : string =
   match items with
   | [] -> "(none)"
   | xs -> String.concat ", " xs
@@ -34,8 +51,8 @@ let format_list_for_prompt (items : string list) : string =
 let render_world_prompt ~allowed_orgs ~denied_repos : string =
   let vars =
     [
-      ("allowed_orgs", format_list_for_prompt allowed_orgs);
-      ("denied_repos", format_list_for_prompt denied_repos);
+      ("allowed_orgs", format_allowlist_for_prompt allowed_orgs);
+      ("denied_repos", format_denylist_for_prompt denied_repos);
     ]
   in
   match

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -26,8 +26,15 @@ val build_keeper_system_prompt :
     the keeper sees the live git_clone allow/deny lists without having
     to query [tool_policy.toml].  Callers should pass the values from
     [Keeper_tool_policy.git_clone_allowed_orgs] /
-    [git_clone_denied_repos]; omitted or empty lists render as
-    ["(none)"]. *)
+    [git_clone_denied_repos].
+
+    Empty-list semantics differ between the two:
+    - Empty [allowed_orgs] = "gate OFF, any account-accessible repo is
+      permitted" (matches [validate_gh_command]'s skip-check behaviour).
+    - Empty [denied_repos] = "no repos blocked" (renders as "(none)").
+
+    Earlier revisions collapsed both to "(none)", which led the LLM to
+    read an empty allowlist as "no orgs allowed" — the inverse of intent. *)
 
 val append_direct_reply_mode_prompt :
   base_prompt:string ->


### PR DESCRIPTION
## Summary

Followup to #11080 which set \`allowed_orgs = []\` in \`config/tool_policy.toml\` to widen the org gate. The code-layer behaviour is correct (\`validate_gh_command\` treats an empty list as "skip check"), but the world prompt rendered the same empty list as \`(none)\`, and the LLM reads \`(none)\` as **"no orgs allowed"** — the inverse of operator intent.

## Two distinct semantics, one formatter

\`lib/keeper/keeper_prompt.ml\` previously collapsed both allowlist and denylist into the same generic \`format_list_for_prompt\`. Empty allowlist and empty denylist mean opposite things:

| List | Empty intent |
|------|-------------|
| \`allowed_orgs\` (allowlist) | gate OFF — any account-accessible repo allowed |
| \`denied_repos\` (denylist) | no repos explicitly blocked |

This PR splits the formatter:

\`\`\`ocaml
format_allowlist_for_prompt [] = "(any — allowlist gate is OFF, the
  operator's gh credential surface is the only repo boundary)"

format_denylist_for_prompt  [] = "(none)"
\`\`\`

Non-empty lists render the same as before (comma-separated). \`format_list_for_prompt\` is removed (no other callers).

## Why this matters

The world prompt explicitly tells the keeper:

> Never invent an org or repo that is not in ALLOWED.

With \`{{allowed_orgs}}\` rendering as \`(none)\`, that line tells the LLM "there are no allowed orgs at all", and a conservative LLM would skip every clone. Post-merge fleet log shows zero \`masc_code_git clone\` attempts since A1 deployed (UTC 04:00+) — consistent with the prompt being read this way, though not by itself conclusive (NonDet).

## Scope

- \`lib/keeper/keeper_prompt.ml\` — split formatter, update \`render_world_prompt\` callsite
- \`lib/keeper/keeper_prompt.mli\` — docstring updated to describe the asymmetric empty-list semantics

No world prompt template changes (\`config/prompts/keeper.world.md\` is untouched). The asymmetry is in the OCaml formatter, not the prompt text.

## Test plan

- [x] \`dune build\` clean (lib + main_eio.exe link)
- [ ] CI \`Build and Test\`
- [ ] Post-deploy fleet log: \`grep -c "masc_code_git" ~/me/.masc/logs/system_log_<DATE>.jsonl\` for clone attempts after this PR's deploy. Currently zero per-day; expected to recover toward the pre-#11080 baseline once the prompt no longer reads as "no orgs allowed".

Refs: #11080