### PR TITLE
i18n(dashboard): localize 4 fallback error literals (round-101)

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -202,7 +202,7 @@ export async function refreshAgentDetail(): Promise<void> {
           const text = await fetchTaskHistory(task.id, 25)
           return { taskId: task.id, text: text.trim() }
         } catch (err) {
-          const message = err instanceof Error ? err.message : 'history load failed'
+          const message = err instanceof Error ? err.message : 'history 로드 실패'
           return { taskId: task.id, text: `이력 로드 실패: ${message}` }
         }
       }),

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -107,7 +107,7 @@ async function fetchLogs(id: string, lines: number) {
   } catch (err) {
     setEntry(id, {
       loading: false,
-      error: err instanceof Error ? err.message : 'log fetch failed',
+      error: err instanceof Error ? err.message : 'log fetch 실패',
     })
   }
 }

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -134,9 +134,9 @@ export function PromptRegistryPanel() {
     try {
       const response = await savePromptOverride(selectedPrompt.key, draft)
       if (!response.ok) {
-        throw new Error(response.error ?? 'prompt override failed')
+        throw new Error(response.error ?? 'prompt override 실패')
       }
-      setStatus(response.message ?? 'override set')
+      setStatus(response.message ?? 'override 설정됨')
       await loadPrompts(selectedPrompt.key)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))


### PR DESCRIPTION
## Summary

3 component 의 try/catch fallback 영어 literal 4개 한국어화. 모두 catch 시 fallback 으로 사용되는 짧은 message 인데 surrounding code 는 이미 한국어.

## Changed strings

| 파일 | line | Before | After |
|---|---|---|---|
| `agent-detail-state.ts` | 205 | `'history load failed'` | `'history 로드 실패'` |
| `prompt-registry-panel.ts` | 137 | `'prompt override failed'` | `'prompt override 실패'` |
| `prompt-registry-panel.ts` | 139 | `'override set'` | `'override 설정됨'` |
| `sidecar-log-viewer.ts` | 110 | `'log fetch failed'` | `'log fetch 실패'` |

## Inconsistency context

`agent-detail-state.ts:206` 이미 `\`이력 로드 실패: ${message}\`` 한국어 wrapping 인데 fallback (line 205) 만 영어. 같은 try/catch block 안 inconsistency 해소.

## Domain term policy

`history`, `prompt override`, `log fetch` 보존 — 도메인 용어.

## Scope

- 3 파일, 4줄.
- test 영향 0.
