### PR TITLE
fix(keeper): surface 5 P2 silent failures (telemetry gaps)

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -1251,7 +1251,13 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
     Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
       ~session_id:trace_id
   in
-  (* Log non-trivial load errors (Not_found is normal on first boot) *)
+  (* P2 silent-failure fix: previously `Error Not_found | Ok _ -> ()`
+     coalesced two semantically distinct outcomes — Not_found means
+     "no prior checkpoint, expected on first boot" while Ok means
+     "checkpoint loaded successfully."  Splitting the cases lets a
+     `debug` log mark when the legacy fallback path is being taken,
+     which is the signal an operator wants when investigating "why
+     did this restart use defaults instead of the OAS checkpoint?" *)
   (match oas_result with
    | Error (Parse_error detail) ->
        Log.Keeper.error "keeper:%s OAS checkpoint parse error: %s" trace_id detail
@@ -1261,7 +1267,9 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
        Log.Keeper.error "keeper:%s OAS checkpoint I/O error: %s" trace_id detail
    | Error (Sdk_other_error detail) ->
        Log.Keeper.error "keeper:%s OAS checkpoint SDK error: %s" trace_id detail
-   | Error Not_found | Ok _ -> ());
+   | Error Not_found ->
+       Log.Keeper.debug "keeper:%s OAS checkpoint not found, falling back to legacy loader" trace_id
+   | Ok _ -> ());
   let oas_checkpoint = Result.to_option oas_result in
   let legacy_checkpoint =
     try load_latest_checkpoint session

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1095,7 +1095,21 @@ let make_hooks
                  ("total_turns", `Int meta.runtime.usage.total_turns);
                  ("ts_unix", `Float (Unix.gettimeofday ()));
                ])
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             (* P2 silent-failure fix: turn-complete event was previously
+                dropped without trace.  Dashboard's per-turn marker would
+                go missing intermittently and operators had no signal that
+                the broadcast itself failed.  PR-C (#11075) added a
+                broadcast-failures counter on the SSE side, but it only
+                catches per-client failures inside broadcast_impl —
+                exceptions thrown from Sse.broadcast at the call boundary
+                bypass that counter.  Logging here makes the loss visible
+                at the producer site. *)
+             Log.Keeper.warn
+               "keeper:%s turn=%d sse_turn_complete broadcast failed: %s"
+               meta.name turn (Printexc.to_string exn));
         (* Reset same-name streak at turn boundary so it doesn't
            carry across turns (e.g., 4 calls in turn N + 1 in turn N+1
            should not hit threshold 5). *)
@@ -1183,7 +1197,17 @@ let make_hooks
              ?sandbox_profile ?network_mode
              ?shared_memory_scope ?approval_mode
              ~result_bytes ?truncated_to ()
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             (* P2 silent-failure fix (same pattern as the broadcast site
+                above at line ~1098): tool-call audit log write failures
+                were dropped without trace.  Loss of these rows leaves
+                downstream replay / debugging tools with gaps that look
+                identical to "no tool calls in this turn." *)
+             Log.Keeper.warn
+               "keeper:%s tool=%s log_call write failed: %s"
+               (!meta_ref).name tool_name (Printexc.to_string exn));
         (match trajectory_acc with
          | None -> ()
          | Some acc ->

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -326,11 +326,20 @@ let recover_latest_checkpoint_for_overflow_retry
     Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
       ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
   in
+  (* P2 silent-failure fix (mirrors keeper_context_core.ml:1264 fix):
+     splitting `Error Not_found | Ok _` into two arms lets a debug log
+     mark when the overflow-retry path falls back from "OAS checkpoint
+     missing" to a fresh start.  Operators investigating "why did
+     overflow recovery use defaults?" now have the signal. *)
   (match oas_result with
    | Error (Parse_error d | Store_error d | Io_error d | Sdk_other_error d) ->
        Log.Keeper.error "keeper:%s overflow retry OAS load error: %s"
          (Keeper_id.Trace_id.to_string meta.runtime.trace_id) d
-   | Error Not_found | Ok _ -> ());
+   | Error Not_found ->
+       Log.Keeper.debug
+         "keeper:%s overflow-retry OAS checkpoint not found, starting fresh"
+         (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+   | Ok _ -> ());
   let oas_checkpoint =
     Result.to_option oas_result
     |> Option.map (fun checkpoint ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -429,7 +429,19 @@ let broadcast_composite_changed ~name ~ts_unix =
        ])
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | _exn -> ()
+  | exn ->
+      (* P2 silent-failure fix: previously this discarded the exception
+         silently, hiding the case where the SSE broadcast pipe is dead
+         (subscriber cleanup race, transport tear-down).  Operators
+         investigating "dashboard stopped updating" had no signal that
+         the broadcast itself was failing.  PR-C (#11075) added a
+         counter on the SSE side, but only for per-client failures
+         inside broadcast_impl — exceptions thrown out of
+         Sse.broadcast itself bypass that counter.  Logging here
+         makes the exception visible at the call site. *)
+      Log.Keeper.warn
+        "registry: broadcast_composite_changed name=%s failed: %s"
+        name (Printexc.to_string exn)
 
 let completed_turn_outcome_of_observation
     (obs : turn_observation) : Keeper_transition_audit.completed_turn_outcome =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1397,7 +1397,23 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 { tool_name; output = Ok _; _ } ->
                 let input_opt = pop_pending_input tool_name in
                 let input =
-                  match input_opt with Some i -> i | None -> `Null
+                  match input_opt with
+                  | Some i -> i
+                  | None ->
+                      (* P2 silent-failure fix: pop_pending_input returns
+                         None either when there's no queue for this tool
+                         name, or when the queue is empty.  Either case
+                         means a ToolCompleted arrived without a matching
+                         ToolCalled — likely a race or an OAS event-bus
+                         ordering bug.  Falling back to `Null` lets
+                         downstream `has_mutating_side_effect_with_input`
+                         continue, but it can undercount mutations.
+                         Logging surfaces the mismatch so it can be
+                         diagnosed instead of silently skewing audit data. *)
+                      Log.Keeper.debug
+                        "keeper:%s tool=%s ToolCompleted without matching ToolCalled — using Null input"
+                        meta.name tool_name;
+                      `Null
                 in
                 if
                   Keeper_exec_tools.has_mutating_side_effect_with_input


### PR DESCRIPTION
## Why

Quality sweep PR-E — second of three P2 PRs (D: dashboard #11094, E: this, F: server transport).  Six findings from the keeper FSM scan, of which 5 are real fixes and 1 is documented as false positive.

## What

| # | File | Pattern | Fix |
|---|------|---------|-----|
| 1 | \`keeper_registry.ml:422-432\` | \`broadcast_composite_changed\` discarded all non-Cancelled exceptions | Log warn at producer site (PR-C's per-client failure counter doesn't catch exceptions thrown out of Sse.broadcast itself) |
| 2 | \`keeper_hooks_oas.ml:1098\` | turn-complete SSE event broadcast silently dropped | Same pattern fix as #1 — log warn |
| 3 | \`keeper_hooks_oas.ml:1186\` | \`Keeper_tool_call_log.log_call\` write failure silently dropped | Same pattern fix |
| 4 | \`keeper_context_core.ml:1264\` | \`Error Not_found \| Ok _ -> ()\` coalesces "no prior checkpoint" with "checkpoint loaded" | Split into separate arms; debug log on Not_found marks fallback path |
| 5 | \`keeper_post_turn.ml:333\` | Same \`Error Not_found \| Ok _\` for overflow-retry path | Same fix as #4 |
| 6 | \`keeper_unified_turn.ml:1387\` | \`pop_pending_input\` None silently coerced to \`Null\` JSON, undercounting mutations | Debug log surfaces ToolCompleted-without-ToolCalled mismatch |

Net: 5 files, +76 -7.

## Scan finding #2 (`keeper_exec_task.ml`) — false positive

The two \`let _ = Coord.broadcast ...\` sites at lines 165–174 and 195–197 look like silent-result-discarding, but Coord.broadcast already logs publish failures internally (\`coord_broadcast.ml:89\` — \`Log.Misc.error "broadcast publish failed: ..."\`) and returns a broadcast id string that the caller intentionally discards.  No fix needed; documented in commit message and PR body to prevent future re-flag.

## Severity rationale (why P2 not P1)

These failures all leave **partial functionality in place** (a single missed broadcast, a single skewed audit row, a single fallback path taken).  In contrast, the 3 P1 fixes in PR-B (\`update_entry\` race + exhaustive variant check) hit failure modes that could leave **state machines inconsistent across many subsequent operations**.

Escalation pattern is identical: silent → log warn/debug.

## Stack position

- PR-A (#11038, dashboard P1) — independent
- PR-B (#11074, server FSM P1, MERGED) — independent
- PR-C (#11075, server transport P1) — independent
- PR-D (#11094, dashboard P2) — independent
- **PR-E (this, server FSM P2)** — touches 5 files in lib/keeper/, all hunks distinct from PR-B
- PR-F (next, server transport P2)
- PR-G (last, P3 cleanup)

## Test plan

- [ ] CI \`dune build @check\` succeeds
- [ ] After deploy, monitor operator logs for the new warn/debug lines:
  - \`keeper:<name> sse_turn_complete broadcast failed: ...\` (#2)
  - \`keeper:<name> tool=<X> log_call write failed: ...\` (#3)
  - \`keeper:<name> OAS checkpoint not found, falling back to legacy loader\` (#4)
  - \`keeper:<name> overflow-retry OAS checkpoint not found, starting fresh\` (#5)
  - \`keeper:<name> tool=<X> ToolCompleted without matching ToolCalled — using Null input\` (#6)