### PR TITLE
fix(autoresearch): cleanup worktree on stop transition

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -328,6 +328,7 @@ let stop_loop ~base_path ?reason loop_id =
       status = Stopped;
       error_message = reason;
       updated_at = Time_compat.now () } in
+    cleanup_terminal_artifacts_best_effort ~base_path state;
     save_state ~base_path state;
     Hashtbl.replace active_loops loop_id state;
     state


### PR DESCRIPTION
Resolves #10892 by ensuring that the managed worktree is cleaned up when an autoresearch loop is manually stopped, matching the existing behavior for completed loops.