### PR TITLE
fix(transport): surface 4 P2 silent failures (broadcast + boot health)

### DIFF
--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -427,6 +427,14 @@ let broadcast_drop_marker ~(pending : pending_relay) ~(stage_label : string)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
+      (* P2 silent-failure fix: previously only logged.  The drop
+         marker is the operator-visible signal that an OAS event was
+         dropped after exhausting retries; if the drop marker also
+         fails to broadcast, operators are blind to the drop entirely.
+         Counter is distinct from masc_sse_broadcast_failures_total
+         (PR-C #11075) so the recovery-path failure rate is visible
+         in isolation from normal broadcast failures. *)
+      Transport_metrics.inc_relay_drop_marker_failure ();
       Log.Misc.warn "oas_event_bridge: drop marker broadcast failed: %s"
         (Printexc.to_string exn)
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -495,6 +495,8 @@ let metric_sse_broadcast_events = "masc_sse_broadcast_events_total"
 let metric_sse_broadcast_failures = "masc_sse_broadcast_failures_total"
 let metric_sse_external_subscriber_callback_failures =
   "masc_sse_external_subscriber_callback_failures_total"
+let metric_oas_sse_relay_drop_marker_failures =
+  "masc_oas_sse_relay_drop_marker_failures_total"
 let metric_sse_stream_queue_depth = "masc_sse_stream_queue_depth"
 let metric_sse_queue_depth_avg = "masc_sse_queue_depth_avg"
 let metric_sse_queue_depth_max = "masc_sse_queue_depth_max"
@@ -1111,6 +1113,14 @@ let init () =
      stream errors).  A non-zero rate indicates that a downstream \
      consumer is failing to accept events even though the SSE fanout \
      considers the broadcast successful."
+    Counter;
+  add metric_oas_sse_relay_drop_marker_failures
+    "OAS relay drop-marker broadcasts that themselves failed to emit. \
+     The drop marker is the operator-visible signal that an OAS event \
+     was dropped after exhausting retries; if the drop marker also \
+     fails to broadcast, operators are blind to the drop entirely. \
+     Distinct from masc_sse_broadcast_failures_total because the drop \
+     marker is the recovery path's last resort, not a normal broadcast."
     Counter;
   add metric_sse_stream_queue_depth
     "Per-session SSE event stream queue depth" Gauge;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -341,6 +341,7 @@ val metric_sse_broadcast_duration : string
 val metric_sse_broadcast_events : string
 val metric_sse_broadcast_failures : string
 val metric_sse_external_subscriber_callback_failures : string
+val metric_oas_sse_relay_drop_marker_failures : string
 val metric_sse_stream_queue_depth : string
 val metric_sse_queue_depth_avg : string
 val metric_sse_queue_depth_max : string

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -329,10 +329,23 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
                    ("voter_identity", Server_utils.board_actor_identity_json voter);
                    ("direction", `String dir)])
     in
-    ignore (Activity_graph.emit state.room_config
-      ~actor:activity_actor ?subject:activity_subject
-      ~kind:activity_kind ~payload:activity_payload
-      ~tags:["board"; activity_kind] ()));
+    (* P2 silent-failure fix: Activity_graph.emit failures (Discord
+       webhook, audit trail writes, etc.) were previously ignored
+       entirely.  An operator seeing board activity on the dashboard
+       had no signal that the external systems failed to receive the
+       event.  Catch + warn surfaces the failure in operator logs
+       without aborting the SSE broadcast that already succeeded. *)
+    (try
+       ignore (Activity_graph.emit state.room_config
+         ~actor:activity_actor ?subject:activity_subject
+         ~kind:activity_kind ~payload:activity_payload
+         ~tags:["board"; activity_kind] ())
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+         Log.Misc.warn
+           "board: Activity_graph.emit kind=%s failed: %s"
+           activity_kind (Printexc.to_string exn)));
   (* Wire broadcast → keeper wakeup: any broadcast wakes keepers so they
      can react to new tasks, mentions, or room activity immediately.
      Coord_state.on_broadcast_mention is the active path (Coord.broadcast uses

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -136,6 +136,16 @@ let make_health_json ?(listener = "http/1.1") request =
       ("minor_heap_size", `Int (let c = Gc.get () in c.minor_heap_size));
     ]);
     ("keeper_fibers", `Int (Keeper_registry.count_running ()));
+    (* P2 silent-failure fix: lazy_task_boot_guard fires when a keeper
+       startup task exceeds the boot timeout (server_bootstrap_loops.ml:116).
+       The Prometheus counter `masc_lazy_task_boot_guard_fired_total`
+       was already incremented but `/health` did not surface it, so an
+       operator hitting /health would see "ok" while keepers had
+       silently failed to start.  Exposing the cumulative count here
+       lets dashboards / health probes alert on a non-zero value. *)
+    ("lazy_task_boot_guard_fires_total",
+     `Int (int_of_float
+             (Prometheus.metric_total "masc_lazy_task_boot_guard_fired_total")));
   ]
 
 (** Health check handler *)

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -55,6 +55,17 @@ let inc_external_subscriber_callback_failure () =
   Prometheus.inc_counter
     Prometheus.metric_sse_external_subscriber_callback_failures ()
 
+(* P2 silent-failure fix (transport scan):
+   The OAS relay drop-marker is the operator-visible signal that an
+   OAS event was dropped after exhausting retries.  If the drop marker
+   broadcast itself fails (oas_event_bridge.ml:430), operators get no
+   indication a drop happened.  Distinct from inc_broadcast_failure
+   so the recovery-path failure rate is isolated from normal broadcast
+   failures. *)
+let inc_relay_drop_marker_failure () =
+  Prometheus.inc_counter
+    Prometheus.metric_oas_sse_relay_drop_marker_failures ()
+
 let set_sse_queue_depth ~session_id depth =
   Prometheus.set_gauge Prometheus.metric_sse_stream_queue_depth
     ~labels:[("session_id", session_id)] (float_of_int depth)


### PR DESCRIPTION
## Why

Quality sweep PR-F — third of three P2 PRs (D: #11094 dashboard merged-pending, E: #11099 server FSM, F: this).  Four findings from the transport scan, of which 3 are real fixes and 1 is a documented false positive.

## What

| # | File | Pattern | Fix |
|---|------|---------|-----|
| 1 | \`server_bootstrap_loops.ml:332\` | \`ignore (Activity_graph.emit ...)\` swallowed all exceptions, hiding Discord webhook / audit trail failures while board activity still appeared on the dashboard | Wrap in try/catch + warn log with kind |
| 2 | \`oas_event_bridge.ml:430\` | drop-marker broadcast failure had only a warn log, no counter — operators couldn't measure the recovery-path failure rate | New counter \`masc_oas_sse_relay_drop_marker_failures_total\` (distinct from PR-C's \`masc_sse_broadcast_failures_total\` so the recovery path is isolated) |
| 3 | \`server_routes_http_runtime.ml:make_health_json\` | \`masc_lazy_task_boot_guard_fired_total\` Prometheus counter was incremented but \`/health\` returned "ok" regardless | Expose cumulative count as \`lazy_task_boot_guard_fires_total\` in health JSON |

Net: 6 files, +57 -4.

## Scan finding (`server_routes_http_routes_dashboard.ml:213`) — false positive

Same pattern as PR-E's \`keeper_exec_task.ml\` exclusion: \`let _ = Coord.broadcast config ~from_agent ~content ...\`.  \`Coord.broadcast\` already logs publish failures internally (\`coord_broadcast.ml:89\`).  The discarded result is a broadcast id string, not a fail signal.  Documented in commit message.

## Why this matters operationally

Each fix closes a different "operator blindness" gap:

- **#1**: dashboard says "board active" while external systems are dead — operators can't see the discrepancy until someone manually checks Discord / audit
- **#2**: an OAS event was dropped AND the drop-notification was lost — operator has zero signal that data went missing
- **#3**: `/health` returns 200 OK while keepers silently failed to boot — health probes pass while the system is degraded

## Stack position

- PR-A (#11038, dashboard P1) — independent
- PR-B (#11074, server FSM P1, MERGED) — independent
- PR-C (#11075, server transport P1) — depended-on for the failure-counter pattern in fix #2
- PR-D (#11094, dashboard P2) — independent
- PR-E (#11099, server FSM P2) — independent
- **PR-F (this, server transport P2)** — touches \`prometheus.{ml,mli}\` and \`transport_metrics.ml\` like PR-C; auto-rebases cleanly
- PR-G (next, P3 cleanup)

## Test plan

- [ ] CI \`dune build @check\` succeeds
- [ ] After deploy: \`curl /health | jq .lazy_task_boot_guard_fires_total\` returns an integer (likely 0)
- [ ] After deploy: \`curl /metrics | grep masc_oas_sse_relay_drop_marker_failures_total\` returns the new counter line
- [ ] Manual: trigger an Activity_graph emit failure (e.g. drop network to Discord) → verify warn log + board still works