### PR TITLE
refactor(dashboard): align primitive spacing/font-size to canonical SPEC tokens

### DIFF
--- a/dashboard/src/components/kpi-cell.ts
+++ b/dashboard/src/components/kpi-cell.ts
@@ -103,14 +103,14 @@ export function KpiCell(props: KpiCellProps): VNode {
     display: 'flex',
     flexDirection: variant === 'compact' ? ('row' as const) : ('column' as const),
     alignItems: variant === 'compact' ? ('baseline' as const) : ('flex-start' as const),
-    gap: variant === 'compact' ? '8px' : variant === 'stacked' ? '4px' : '6px',
-    padding: variant === 'stacked' ? '14px 16px' : '10px 12px',
+    gap: variant === 'compact' ? 'var(--spacing-element)' : variant === 'stacked' ? '4px' : '6px',
+    padding: variant === 'stacked' ? `14px var(--spacing-card)` : `10px var(--spacing-group)`,
     fontFamily: MONO_STACK,
     minWidth: '0',
   }
 
   const labelStyle = {
-    fontSize: '10px',
+    fontSize: 'var(--font-size-3xs)',
     color: labelColor,
     letterSpacing: '0.08em',
     textTransform: 'uppercase' as const,
@@ -118,7 +118,7 @@ export function KpiCell(props: KpiCellProps): VNode {
   }
 
   const valueStyle = {
-    fontSize: variant === 'stacked' ? '24px' : variant === 'compact' ? '13px' : '17px',
+    fontSize: variant === 'stacked' ? '24px' : variant === 'compact' ? 'var(--font-size-sm)' : '17px',
     color: valueColor,
     fontVariantNumeric: 'tabular-nums' as const,
     fontWeight: variant === 'stacked' ? 700 : 600,
@@ -133,7 +133,7 @@ export function KpiCell(props: KpiCellProps): VNode {
             display: 'inline-flex',
             alignItems: 'center',
             gap: '6px',
-            fontSize: '10px',
+            fontSize: 'var(--font-size-3xs)',
             color: captionColor,
             letterSpacing: '0.06em',
             textTransform: 'uppercase',

--- a/dashboard/src/components/lifeline-bar.ts
+++ b/dashboard/src/components/lifeline-bar.ts
@@ -102,7 +102,7 @@ const surfaceStyle = {
 }
 
 const labelStyle = {
-  fontSize: '10px',
+  fontSize: 'var(--font-size-3xs)',
   color: 'var(--color-fg-disabled)',
   letterSpacing: '0.08em',
   textTransform: 'uppercase' as const,
@@ -110,7 +110,7 @@ const labelStyle = {
 }
 
 const captionStyle = {
-  fontSize: '10px',
+  fontSize: 'var(--font-size-3xs)',
   color: 'var(--color-fg-muted)',
   letterSpacing: '0.06em',
   textTransform: 'uppercase' as const,
@@ -158,8 +158,8 @@ export function LifelineBar({
         ...surfaceStyle,
         display: 'inline-flex',
         alignItems: 'center',
-        gap: '12px',
-        padding: '8px 12px',
+        gap: 'var(--spacing-group)',
+        padding: `var(--spacing-element) var(--spacing-group)`,
         fontFamily: MONO_STACK,
       }}
     >

--- a/dashboard/src/components/ticker-item.ts
+++ b/dashboard/src/components/ticker-item.ts
@@ -78,7 +78,7 @@ export function TickerItem(props: TickerItemProps): VNode {
           aria-hidden="true"
           style=${{
             fontFamily: MONO_STACK,
-            fontSize: '10px',
+            fontSize: 'var(--font-size-3xs)',
             color: 'var(--color-fg-disabled)',
             fontVariantNumeric: 'tabular-nums',
             letterSpacing: '0.04em',
@@ -96,9 +96,9 @@ export function TickerItem(props: TickerItemProps): VNode {
         display: 'inline-flex',
         alignItems: 'center',
         gap: '6px',
-        padding: '2px 8px',
+        padding: `2px var(--spacing-element)`,
         fontFamily: MONO_STACK,
-        fontSize: '11px',
+        fontSize: 'var(--font-size-2xs)',
         whiteSpace: 'nowrap',
       }}
     >
@@ -149,7 +149,7 @@ export function TickerStrip({
       style=${{
         display: 'flex',
         flexDirection: orientation === 'vertical' ? 'column' : 'row',
-        gap: orientation === 'vertical' ? '4px' : '12px',
+        gap: orientation === 'vertical' ? '4px' : 'var(--spacing-group)',
         alignItems: orientation === 'vertical' ? 'stretch' : 'center',
         overflow: 'hidden',
       }}


### PR DESCRIPTION
## Why

Direct response to a user audit: *"Spacing, Color, Size 다 이용하는거지?"*

The cb-group-a primitive series so far (KpiCell #11066, LifelineBar #11070, TickerItem #11088) used canonical **COLOR** tokens but inlined raw `px` values for **spacing** and **font-size** — which means three primitives just shipped that drift from the SPEC §3 scale that #11039 / #11050 / #11053 / #11064 / #11065 are pulling the rest of the dashboard onto.

This PR sweeps the three primitives onto the canonical tokens. Visual output is identical (every replacement maps to the same px); the change is at the *abstraction layer*, so a future SPEC update (e.g. raising `--font-size-3xs` from 10px to 11px) propagates without re-touching component files.

## What

| File | Sites |
|------|-------|
| `kpi-cell.ts` | `--spacing-element`, `--spacing-card`, `--spacing-group`, `--font-size-3xs`, `--font-size-sm` |
| `lifeline-bar.ts` | `--spacing-element`, `--spacing-group`, `--font-size-3xs` |
| `ticker-item.ts` | `--spacing-element`, `--spacing-group`, `--font-size-2xs`, `--font-size-3xs` |

Every changed line replaces a raw `px` literal with the matching SPEC token; line counts: **+13 / −13**.

## Values intentionally left raw (gap docs)

These have no SPEC token at parity yet:

- `17px`, `24px` — KpiCell value fontSize for `standard` / `stacked` variants. They sit *between* the dashboard scale steps (`--font-size-md=15px` and `--font-size-xl=18px`); the original cb-group-a chose this tighter step deliberately. Promoting to a token would need a SPEC RFC, not a sweep.
- `4px`, `6px` gaps; `2px` and `14px` paddings — sub-`--spacing-element` (8px) values where the dashboard scale doesn't define a `--spacing-N` below 8. Documenting the gap rather than fabricating one.

`14px 16px` style padding pairs map heterogeneously: the 16 → `--spacing-card`, the 14 stays raw. Pragmatic — the SPEC token is the half that *will* drift first.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run kpi-cell lifeline-bar ticker-item` — **60 / 60 pass** unchanged. The harness asserts DOM shape (role / aria-label / textContent / styled child counts), not literal style values, so the token swap is invisible to it.

## Why this PR is one sweep, not three

A single-file sweep PR would be three PRs that each say the same thing in commit message + body. Memory pattern `feedback_audit-bucket-cascade-pattern` (한 영역 = 한 PR): "primitive token alignment" is one *category*, the file boundary doesn't change the review unit. Net diff is small (26 lines).

## What this PR does NOT do

- **No new tokens.** SPEC scale extension (e.g. naming the `17px` step) is a separate RFC.
- **No callsite changes.** Primitives still have zero production callsite — the migration cadence in the cb-group series is unchanged.
- **No visual delta.** Every value preserves its original px; this is purely a referencing-layer change.

## Refs

- User audit prompt
- Sweep targets: #11066 (KpiCell), #11070 (LifelineBar), #11088 (TickerItem)
- Parallel SPEC migration trail in main: #11039 / #11050 / #11053 / #11064 / #11065
- SPEC: `dashboard/design-system/SPEC.md` §3
- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
