### PR TITLE
fix(keeper): stamp last_failure_reason on first cascade_exhausted (not just threshold)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2266,6 +2266,28 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~consecutive:count
             ~threshold
             ~err;
+          (* Stamp [last_failure_reason] on FIRST cascade_exhausted-class
+             failure (not just at threshold).  Without this, the stale
+             watchdog kills with [idle 328s] and operators see no signal
+             until the 3rd failure trips auto-pause below — by which time
+             the keeper has been silently burning cycles for ~90s on a
+             cascade with zero callable models.
+
+             Production evidence (2026-04-27 system_log): 18 events of
+             "no callable models" today on cascade=keeper_unified, but
+             [last_failure_reason] stayed None for the affected keepers
+             so the watchdog kill message read [idle 328s] with no
+             attribution.  Operators had no way to distinguish
+             "stuck=cascade_exhausted" from "stuck=genuinely idle".
+
+             Reset path is unchanged: any successful turn clears the
+             field via [reset_turn_failures] + [set_failure_reason None]
+             at line 966-967.  Auto-pause site below (line 2275) still
+             stamps the same value at threshold — idempotent overwrite. *)
+          if EC.is_cascade_exhausted_error err && count > 0 then
+            Keeper_registry.set_failure_reason ~base_path:config.base_path
+              meta.name
+              (Some (Keeper_registry.Turn_consecutive_failures count));
           (* task-074 (#fleet-stall 2026-04-26): break the supervisor restart
              loop on cascade_exhausted. Without this guard, [count >= threshold]
              below raises [Keeper_fiber_crash], the supervisor restarts the


### PR DESCRIPTION
## Summary

Surface what's silently invisible: 18 "no callable models" events today produced 0 attribution in stale-watchdog kill messages because `last_failure_reason` only stamps at threshold=3, and `last_skip_observation` only stamps for Skip-verdict cycles (these were Run-verdict + cascade-exhausted-fail).

## Production evidence

`/Users/dancer/me/.masc/logs/system_log_2026-04-27.jsonl`:
- 18 events of `cascade keeper_unified: no callable models available — configured=[codex_cli:gpt-5.3-codex-spark]`
- 44 stale watchdog terminations across 11 keepers
- 0 instances of `last_skip=...` in any kill message
- 0 instances of `last_failure_reason` populated for affected keepers
- Watchdog kill messages all read `(idle 328s)` — misleading; keepers were actively attempting cycles and failing

## Diagnosis (3 parallel Explore agents, cycle 35)

| Agent | Finding |
|---|---|
| A: trace cascade selection error flow | The error at `oas_worker_named.ml:1214` DOES reach `increment_turn_failures` at `keeper_unified_turn.ml:2253-2254` |
| B: skip-reason coverage gap | But `set_failure_reason` only fires at threshold=3 (auto-pause site `keeper_unified_turn.ml:2275`). First 1-2 failures stamp nothing. |
| C: spark tool_choice limitation | Origin is `agent_sdk` upstream constraint, not masc-mcp config bug — config-level revert is user decision |

**Coverage gap**: a keeper failing every 30s cycle to "no callable models" produces:
- no `last_skip=...` (verdict was `Run`, not `Skip` — `record_skip_reasons` at `keepalive:1431` only fires on `Skip`)
- no `last_failure_reason` (counter < 3 — `set_failure_reason` at `unified_turn:2275` only fires on auto-pause threshold)

The stale watchdog then kills at 300s idle with no attribution.

## Fix

Stamp `last_failure_reason = Turn_consecutive_failures count` on the FIRST cascade_exhausted-class failure (before the auto-pause guard). Operators now see meaningful failure_reason from the very first occurrence.

## Behaviour

| Counter | Before | After |
|---|---|---|
| count=1 cascade_exhausted | None | Turn_consecutive_failures(1) |
| count=2 cascade_exhausted | None | Turn_consecutive_failures(2) |
| count=3 (auto-pause) | Turn_consecutive_failures(3) | Turn_consecutive_failures(3) (idempotent) |
| Successful turn | None (reset) | None (reset) |

No accumulation across recoveries — `reset_turn_failures` + `set_failure_reason None` at `unified_turn:966-967` clears the stamp on every successful turn.

## Verification

- `DUNE_CACHE=disabled dune build` — green.
- 1 file changed, 22 insertions, 0 deletions (only added the new stamp).
- No behavior change to existing flows — purely additive observability.

## Test plan

- [ ] Build green
- [ ] CI Lint + Health pass
- [ ] After merge: server restart, verify stale watchdog kill messages now include `last_failure_reason` attribution for cascade_exhausted-stuck keepers

Refs: #10765 (stale termination death-spiral observability), #10940 (mid-turn watchdog guard — kindred fix at active-turn layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)