### PR TITLE
feat(dashboard): add SwimlaneRow primitive (cb-group-b, Stage A)

### DIFF
--- a/dashboard/src/components/swimlane-row.test.ts
+++ b/dashboard/src/components/swimlane-row.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  SwimlaneRow,
+  swimlaneEventStyle,
+  swimlaneRowAriaLabel,
+  type SwimlaneEvent,
+  type SwimlaneRowProps,
+} from './swimlane-row'
+
+describe('swimlaneEventStyle (pure)', () => {
+  it('point event (no width) returns left + neutral background', () => {
+    const s = swimlaneEventStyle({ x: 0.5 })
+    expect(s.left).toBe('50.00%')
+    expect(s.width).toBeUndefined()
+    expect(s.background).toContain('--color-fg-muted')
+  })
+
+  it('span event (width set) returns both left and width %', () => {
+    const s = swimlaneEventStyle({ x: 0.1, width: 0.25 })
+    expect(s.left).toBe('10.00%')
+    expect(s.width).toBe('25.00%')
+  })
+
+  it('kind drives the background token', () => {
+    expect(swimlaneEventStyle({ x: 0, kind: 'ok' }).background).toContain('--color-status-ok')
+    expect(swimlaneEventStyle({ x: 0, kind: 'warn' }).background).toContain('--color-status-warn')
+    expect(swimlaneEventStyle({ x: 0, kind: 'err' }).background).toContain('--color-status-err')
+    expect(swimlaneEventStyle({ x: 0, kind: 'info' }).background).toContain('--color-accent-fg')
+  })
+
+  it('width=0 falls back to point rendering (no width returned)', () => {
+    expect(swimlaneEventStyle({ x: 0.5, width: 0 }).width).toBeUndefined()
+  })
+
+  it('formats x to 2 decimal places', () => {
+    expect(swimlaneEventStyle({ x: 0.123 }).left).toBe('12.30%')
+  })
+})
+
+describe('swimlaneRowAriaLabel (pure)', () => {
+  it('reports "no events" for an empty lane', () => {
+    expect(
+      swimlaneRowAriaLabel({ keeperId: 'nick0cave', events: [] }),
+    ).toBe('nick0cave timeline: no events')
+  })
+
+  it('singular for one event', () => {
+    expect(
+      swimlaneRowAriaLabel({
+        keeperId: 'sangsu',
+        events: [{ x: 0.5 }],
+      }),
+    ).toBe('sangsu timeline: 1 event')
+  })
+
+  it('plural with last-kind tail when last event is non-neutral', () => {
+    expect(
+      swimlaneRowAriaLabel({
+        keeperId: 'qa-king',
+        events: [{ x: 0.1 }, { x: 0.5, kind: 'err' }],
+      }),
+    ).toBe('qa-king timeline: 2 events, last err')
+  })
+
+  it('omits last-kind tail when last event is neutral or omitted', () => {
+    expect(
+      swimlaneRowAriaLabel({
+        keeperId: 'a',
+        events: [{ x: 0.1, kind: 'err' }, { x: 0.5 }],
+      }),
+    ).toBe('a timeline: 2 events')
+  })
+
+  it('appends ", selected" when selected=true', () => {
+    expect(
+      swimlaneRowAriaLabel({
+        keeperId: 'rama',
+        events: [{ x: 0.5 }],
+        selected: true,
+      }),
+    ).toBe('rama timeline: 1 event, selected')
+  })
+
+  it('caller-supplied ariaLabel wins (composition skipped)', () => {
+    expect(
+      swimlaneRowAriaLabel({
+        keeperId: 'x',
+        events: [{ x: 0.1 }],
+        ariaLabel: 'Custom announcement',
+      }),
+    ).toBe('Custom announcement')
+  })
+})
+
+describe('SwimlaneRow component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  function mount(props: SwimlaneRowProps): HTMLElement {
+    render(html`<${SwimlaneRow} ...${props} />`, container)
+    return container.querySelector('[role="listitem"]') as HTMLElement
+  }
+
+  it('renders role=listitem with composed aria-label', () => {
+    const el = mount({
+      keeperId: 'nick0cave',
+      events: [{ x: 0.5 }],
+    })
+    expect(el).toBeTruthy()
+    expect(el.getAttribute('role')).toBe('listitem')
+    expect(el.getAttribute('aria-label')).toBe('nick0cave timeline: 1 event')
+  })
+
+  it('renders a KeeperBadge sigil + the keeper id text in the head', () => {
+    const el = mount({ keeperId: 'nick0cave', events: [] })
+    // Registry-pinned sigil for nick0cave is "NK"
+    expect(el.textContent).toContain('NK')
+    expect(el.textContent).toContain('nick0cave')
+  })
+
+  it('renders one positioned span per event (track children)', () => {
+    const events: SwimlaneEvent[] = [
+      { x: 0.1 },
+      { x: 0.5, kind: 'ok' },
+      { x: 0.8, kind: 'err' },
+    ]
+    const el = mount({ keeperId: 'a', events })
+    const track = el.querySelector('div[aria-hidden="true"]')!
+    expect(track.children.length).toBe(3)
+  })
+
+  it('point event sets fixed 4px width + negative margin offset', () => {
+    const el = mount({ keeperId: 'a', events: [{ x: 0.5 }] })
+    const span = el.querySelector('div[aria-hidden="true"] span') as HTMLElement
+    expect(span.style.width).toBe('4px')
+    expect(span.style.marginLeft).toBe('-2px')
+  })
+
+  it('span event uses percentage width (Bars pattern)', () => {
+    const el = mount({
+      keeperId: 'a',
+      events: [{ x: 0.1, width: 0.4, kind: 'ok' }],
+    })
+    const span = el.querySelector('div[aria-hidden="true"] span') as HTMLElement
+    expect(span.style.width).toBe('40.00%')
+    expect(span.style.left).toBe('10.00%')
+  })
+
+  it('non-interactive lane omits tabindex and click handlers', () => {
+    const el = mount({ keeperId: 'a', events: [{ x: 0.5 }] })
+    expect(el.getAttribute('tabindex')).toBeNull()
+  })
+
+  it('interactive lane sets tabindex=0 and fires onActivate on click', () => {
+    const onActivate = vi.fn()
+    render(
+      html`<${SwimlaneRow} keeperId="a" events=${[]} onActivate=${onActivate} />`,
+      container,
+    )
+    const el = container.querySelector('[role="listitem"]') as HTMLElement
+    expect(el.getAttribute('tabindex')).toBe('0')
+    el.click()
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('Enter key activates an interactive lane', () => {
+    const onActivate = vi.fn()
+    render(
+      html`<${SwimlaneRow} keeperId="a" events=${[]} onActivate=${onActivate} />`,
+      container,
+    )
+    const el = container.querySelector('[role="listitem"]') as HTMLElement
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('Space key activates an interactive lane', () => {
+    const onActivate = vi.fn()
+    render(
+      html`<${SwimlaneRow} keeperId="a" events=${[]} onActivate=${onActivate} />`,
+      container,
+    )
+    const el = container.querySelector('[role="listitem"]') as HTMLElement
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('selected=true emits aria-current="true"', () => {
+    const el = mount({ keeperId: 'a', events: [], selected: true })
+    expect(el.getAttribute('aria-current')).toBe('true')
+  })
+
+  it('selected=false omits aria-current', () => {
+    const el = mount({ keeperId: 'a', events: [] })
+    expect(el.getAttribute('aria-current')).toBeNull()
+  })
+})

--- a/dashboard/src/components/swimlane-row.ts
+++ b/dashboard/src/components/swimlane-row.ts
@@ -1,0 +1,195 @@
+// Swimlane row — single keeper timeline lane.
+//
+// Ported from design-system v0.4 cb-group-b (preview/cb-group-b.jsx
+// SwimlanesGlyph / SwimlanesDense / SwimlanesBars). Three source
+// variants collapse into one atomic SwimlaneRow + two display knobs:
+//
+//   - Glyph  ≈ SwimlaneRow with point events (event.width undefined)
+//             + selectable: true + onActivate
+//   - Dense  ≈ same as Glyph but parent strip uses density='compact'
+//             (this primitive doesn't care — density is a strip-level
+//             concern, deferred to the future SwimlaneStrip composite)
+//   - Bars   ≈ SwimlaneRow with span events (event.width set, 0..1)
+//
+// Event mode (point vs span) is auto-detected per event by whether
+// `width` is set, so a single lane can mix dot pings and aggregated
+// duration bars. The original .cb-swim / .lane / .ev / .agg CSS
+// selectors live in design-system styles which the dashboard does
+// NOT import — re-implementation against the dashboard token set +
+// KeeperBadge (#10955) + tokens swept in #11102 (spacing/font-size).
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import { KeeperBadge } from './keeper-badge'
+
+export type SwimlaneEventKind = 'ok' | 'warn' | 'err' | 'info' | 'neutral'
+
+export interface SwimlaneEvent {
+  /** Horizontal position along the track, 0..1 (left → right). */
+  x: number
+  /** Optional duration width 0..1. When set the event renders as a
+   *  span (Bars pattern); when omitted a point dot (Glyph pattern). */
+  width?: number
+  /** Tone — drives the event color. Default 'neutral'. */
+  kind?: SwimlaneEventKind
+  /** Optional human-readable label (used in the row's composed
+   *  aria-label so SR users hear "{kid} timeline: 3 events, last err"). */
+  label?: string
+}
+
+export interface SwimlaneRowProps {
+  keeperId: string
+  events: SwimlaneEvent[]
+  /** Drives KeeperBadge.beat — pulses the sigil for active keepers. */
+  running?: boolean
+  /** Visual selected state — emits aria-current="true" + brass border. */
+  selected?: boolean
+  /** Click + Enter/Space activator. When omitted the lane is non-interactive. */
+  onActivate?: () => void
+  /** Custom aria-label override. Default composes from keeperId,
+   *  event count, and `selected`. */
+  ariaLabel?: string
+}
+
+const EVENT_COLOR_BY_KIND: Record<SwimlaneEventKind, string> = {
+  ok: 'var(--color-status-ok)',
+  warn: 'var(--color-status-warn)',
+  err: 'var(--color-status-err)',
+  info: 'var(--color-accent-fg)',
+  neutral: 'var(--color-fg-muted)',
+}
+
+const HEAD_WIDTH_PX = 130 // matches cb-group-b's lane-head fixed width
+
+const MONO_STACK = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+/** Pure: build the inline style for one event. Exposed for tests + for
+ *  callers that want to render events into their own track (e.g. a
+ *  composite SwimlaneStrip with overlapping NOW marker). */
+export function swimlaneEventStyle(event: SwimlaneEvent): {
+  left: string
+  width?: string
+  background: string
+} {
+  const kind = event.kind ?? 'neutral'
+  const left = `${(event.x * 100).toFixed(2)}%`
+  const background = EVENT_COLOR_BY_KIND[kind]
+  if (event.width !== undefined && event.width > 0) {
+    return { left, width: `${(event.width * 100).toFixed(2)}%`, background }
+  }
+  return { left, background }
+}
+
+/** Pure: compose the aria-label for a row. Same inputs always yield
+ *  the same string — testable without DOM. */
+export function swimlaneRowAriaLabel(props: SwimlaneRowProps): string {
+  if (props.ariaLabel) return props.ariaLabel
+  const count = props.events.length
+  const lastKind = count > 0 ? (props.events[count - 1]!.kind ?? 'neutral') : null
+  const tail = lastKind && lastKind !== 'neutral' ? `, last ${lastKind}` : ''
+  const sel = props.selected ? ', selected' : ''
+  const events = count === 0 ? 'no events' : count === 1 ? '1 event' : `${count} events`
+  return `${props.keeperId} timeline: ${events}${tail}${sel}`
+}
+
+function activateOnEnterOrSpace(handler: () => void) {
+  return (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handler()
+    }
+  }
+}
+
+export function SwimlaneRow(props: SwimlaneRowProps): VNode {
+  const interactive = props.onActivate !== undefined
+  const ariaLabel = swimlaneRowAriaLabel(props)
+
+  const containerStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 'var(--spacing-element)',
+    padding: `4px var(--spacing-element)`,
+    borderRadius: '3px',
+    border: `1px solid ${props.selected ? 'var(--brass-1, var(--color-accent-fg))' : 'transparent'}`,
+    background: props.selected ? 'var(--bg-panel)' : 'transparent',
+    cursor: interactive ? 'pointer' : 'default',
+    outline: 'none',
+  }
+
+  const headStyle = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+    width: `${HEAD_WIDTH_PX}px`,
+    flex: 'none',
+    fontFamily: MONO_STACK,
+  }
+
+  const trackStyle = {
+    position: 'relative' as const,
+    flex: 1,
+    height: '14px',
+    background: 'var(--bg-panel)',
+    border: '1px solid var(--border-base)',
+    borderRadius: '2px',
+    overflow: 'hidden',
+  }
+
+  const eventCommon = {
+    position: 'absolute' as const,
+    top: '3px',
+    height: '8px',
+    borderRadius: '1px',
+  }
+
+  return html`
+    <div
+      role="listitem"
+      aria-label=${ariaLabel}
+      aria-current=${props.selected ? 'true' : undefined}
+      tabindex=${interactive ? 0 : undefined}
+      onClick=${interactive ? props.onActivate : undefined}
+      onKeyDown=${interactive && props.onActivate ? activateOnEnterOrSpace(props.onActivate) : undefined}
+      style=${containerStyle}
+    >
+      <div style=${headStyle}>
+        <${KeeperBadge}
+          id=${props.keeperId}
+          variant="sigil"
+          size="sm"
+          beat=${props.running === true}
+        />
+        <span
+          aria-hidden="true"
+          style=${{
+            fontSize: 'var(--font-size-2xs)',
+            color: 'var(--color-fg-secondary)',
+            fontWeight: 500,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >${props.keeperId}</span>
+      </div>
+      <div aria-hidden="true" style=${trackStyle}>
+        ${props.events.map((evt, i) => {
+          const evStyle = swimlaneEventStyle(evt)
+          const isPoint = evt.width === undefined || evt.width <= 0
+          return html`
+            <span
+              key=${i}
+              style=${{
+                ...eventCommon,
+                ...evStyle,
+                width: isPoint ? '4px' : evStyle.width,
+                marginLeft: isPoint ? '-2px' : undefined,
+                opacity: 0.85,
+              }}
+            ></span>
+          `
+        })}
+      </div>
+    </div>
+  `
+}


### PR DESCRIPTION
## Why

First cb-group-b port. SwimlaneRow is a single keeper timeline lane — the atomic row that the source's three `Swimlanes{Glyph,Dense,Bars}` views compose into a fleet swimlanes panel.

Same recipe as KpiCell (#11066) / LifelineBar (#11070) / TickerItem (#11088): primitive only, callsite migration in follow-up PRs. Tokens are aligned to the SPEC scale from the start (#11102).

## What

`src/components/swimlane-row.ts` — three exports:

| Export | Kind | Purpose |
|--------|------|---------|
| `swimlaneEventStyle(event)` | pure helper | Inline style (left/width/background) for one event. Useful for callers that render events into their own track (e.g. a future composite with overlapping NOW marker). |
| `swimlaneRowAriaLabel(props)` | pure helper | Composes the SR sentence: `"nick0cave timeline: 3 events, last err, selected"`. |
| `SwimlaneRow` | atomic component | One lane: KeeperBadge head + horizontal track + positioned events. |

### SwimlaneRow props
| Prop | Default | Purpose |
|------|---------|---------|
| `keeperId` | (required) | Powers the KeeperBadge sigil + identity. |
| `events` | `[]` | Each `{ x, width?, kind?, label? }`. |
| `running` | `false` | Forwards to KeeperBadge.beat. |
| `selected` | `false` | Brass-bordered lane + `aria-current="true"`. |
| `onActivate` | (none) | When given, lane becomes interactive (tabindex=0, click, Enter, Space). |
| `ariaLabel` | (composed) | Override for the row's SR sentence. |

### Per-event auto-detection: point vs span

| `width` | Render |
|---------|--------|
| `undefined` or `0` | 4px circle dot at `x` (Glyph pattern) |
| `> 0` (0..1) | percentage-wide span starting at `x` (Bars pattern) |

This is the *primitive design* value-add. The source kept three sibling variants because they had different CSS files (`.cb-swim`, `.cb-swim.dense`, `.cb-swim.bars`); the underlying data model is one shape with one knob (event mode), and that's what the primitive captures. A single lane can mix dot pings and aggregated bars.

### Variant collapse

| cb-group-b variant | dashboard equivalent |
|--------------------|----------------------|
| `SwimlanesGlyph` | many `SwimlaneRow`s with point events + `onActivate` (lane selection) |
| `SwimlanesDense` | same as Glyph but parent strip uses tighter row spacing (strip-level — deferred) |
| `SwimlanesBars` | many `SwimlaneRow`s with span events (`width` set, no `onActivate`) |

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run src/components/swimlane-row.test.ts`
  - `swimlaneEventStyle` (pure): point vs span detection, kind→color tokens (ok / warn / err / info), `width=0` fallback to point, x percentage formatting
  - `swimlaneRowAriaLabel` (pure): empty / singular / plural with last-kind tail / selected suffix / caller override wins
  - `SwimlaneRow`: `role="listitem"` + composed aria-label, KeeperBadge sigil ("NK" for nick0cave) + keeper id text, one positioned span per event, point sizing (4px width + -2px margin), span percentage width, non-interactive vs interactive (tabindex 0, onClick, Enter, Space activator), `aria-current="true"` on selected, omitted on unselected
- [ ] Visual smoke: queued for first callsite migration.

## What this PR does NOT do

- **No `SwimlaneStrip` composite.** Axis labels, multiple lanes wrapper, NOW marker overlay — all strip-level. Defer until 2+ callsites are picked so we don't over-fit the first.
- **No density variant.** `dense` is a strip-level row-spacing concern.
- **No callsite migration.** Same cadence as predecessor primitives.

## Refs

- Source: `dashboard/design-system/preview/cb-group-b.jsx` (SwimlanesGlyph / SwimlanesDense / SwimlanesBars)
- Precedent (cb-group-a primitives): #11066 (KpiCell), #11070 (Heartbeat + LifelineBar), #11088 (TickerItem + TickerStrip)
- Token alignment trail: #11102 (primitive spacing/font-size sweep)
- Composition: #10955 (KeeperBadge — used for the lane sigil)
- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
