### PR TITLE
feat(dashboard): add KanbanCard primitive (cb-group-b, Stage B)

### DIFF
--- a/dashboard/src/components/kanban-card.test.ts
+++ b/dashboard/src/components/kanban-card.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { KanbanCard, kanbanCardAriaLabel, type KanbanCardProps } from './kanban-card'
+
+describe('kanbanCardAriaLabel (pure)', () => {
+  it('composes id · title · keeper for the minimal case', () => {
+    expect(
+      kanbanCardAriaLabel({
+        id: 'PK-101',
+        title: 'Auth refactor',
+        keeperId: 'nick0cave',
+      }),
+    ).toBe('PK-101 · Auth refactor · nick0cave')
+  })
+
+  it('appends " · <kind>" when kind is non-queued', () => {
+    expect(
+      kanbanCardAriaLabel({
+        id: 'PK-1',
+        title: 't',
+        keeperId: 'a',
+        kind: 'running',
+      }),
+    ).toBe('PK-1 · t · a · running')
+  })
+
+  it('omits kind word when kind is "queued" (default state)', () => {
+    expect(
+      kanbanCardAriaLabel({
+        id: 'PK-1',
+        title: 't',
+        keeperId: 'a',
+        kind: 'queued',
+      }),
+    ).toBe('PK-1 · t · a')
+  })
+
+  it('appends " · <time>" when given', () => {
+    expect(
+      kanbanCardAriaLabel({
+        id: 'PK-1',
+        title: 't',
+        keeperId: 'a',
+        time: '2m',
+      }),
+    ).toBe('PK-1 · t · a · 2m')
+  })
+
+  it('combines kind + time in canonical order', () => {
+    expect(
+      kanbanCardAriaLabel({
+        id: 'PK-9',
+        title: 'Fix CI',
+        keeperId: 'qa-king',
+        kind: 'fail',
+        time: '13:42',
+      }),
+    ).toBe('PK-9 · Fix CI · qa-king · fail · 13:42')
+  })
+
+  it('caller-supplied ariaLabel wins over composition', () => {
+    expect(
+      kanbanCardAriaLabel({
+        id: 'PK-1',
+        title: 't',
+        keeperId: 'a',
+        ariaLabel: 'Custom announcement',
+      }),
+    ).toBe('Custom announcement')
+  })
+})
+
+describe('KanbanCard component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  function mount(props: KanbanCardProps): HTMLElement {
+    render(html`<${KanbanCard} ...${props} />`, container)
+    return container.querySelector('[role="listitem"]') as HTMLElement
+  }
+
+  it('renders role=listitem with composed aria-label', () => {
+    const el = mount({
+      id: 'PK-101',
+      title: 'Auth refactor',
+      keeperId: 'nick0cave',
+    })
+    expect(el).toBeTruthy()
+    expect(el.getAttribute('role')).toBe('listitem')
+    expect(el.getAttribute('aria-label')).toBe('PK-101 · Auth refactor · nick0cave')
+  })
+
+  it('renders id, title, keeper id text', () => {
+    const el = mount({
+      id: 'PK-101',
+      title: 'Auth refactor',
+      keeperId: 'nick0cave',
+    })
+    const txt = el.textContent ?? ''
+    expect(txt).toContain('PK-101')
+    expect(txt).toContain('Auth refactor')
+    expect(txt).toContain('nick0cave')
+  })
+
+  it('renders the embedded KeeperBadge sigil text', () => {
+    const el = mount({
+      id: 'PK-1',
+      title: 't',
+      keeperId: 'nick0cave',
+    })
+    // Registry-pinned sigil for nick0cave is "NK".
+    expect(el.textContent).toContain('NK')
+  })
+
+  it('renders relative time when given', () => {
+    const el = mount({
+      id: 'PK-1',
+      title: 't',
+      keeperId: 'a',
+      time: '2m',
+    })
+    expect(el.textContent).toContain('2m')
+  })
+
+  it('omits time chip when not given', () => {
+    const el = mount({ id: 'PK-1', title: 't', keeperId: 'a' })
+    // " · 2m" pattern absence
+    expect(el.textContent).not.toContain('· 2m')
+  })
+
+  it('non-interactive card omits tabindex', () => {
+    const el = mount({ id: 'PK-1', title: 't', keeperId: 'a' })
+    expect(el.getAttribute('tabindex')).toBeNull()
+  })
+
+  it('interactive card sets tabindex=0 and fires onActivate on click', () => {
+    const onActivate = vi.fn()
+    render(
+      html`<${KanbanCard} id="PK-1" title="t" keeperId="a" onActivate=${onActivate} />`,
+      container,
+    )
+    const el = container.querySelector('[role="listitem"]') as HTMLElement
+    expect(el.getAttribute('tabindex')).toBe('0')
+    el.click()
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('Enter key activates an interactive card', () => {
+    const onActivate = vi.fn()
+    render(
+      html`<${KanbanCard} id="PK-1" title="t" keeperId="a" onActivate=${onActivate} />`,
+      container,
+    )
+    const el = container.querySelector('[role="listitem"]') as HTMLElement
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('running kind paints accent left border', () => {
+    const el = mount({
+      id: 'PK-1',
+      title: 't',
+      keeperId: 'a',
+      kind: 'running',
+    })
+    expect(el.style.borderLeft).toContain('var(--color-accent-fg)')
+  })
+
+  it('fail kind paints err-status left border', () => {
+    const el = mount({
+      id: 'PK-1',
+      title: 't',
+      keeperId: 'a',
+      kind: 'fail',
+    })
+    // Status err token surfaces in the inline border-left style
+    expect(el.style.borderLeft).toContain('var(--color-status-err)')
+  })
+})

--- a/dashboard/src/components/kanban-card.ts
+++ b/dashboard/src/components/kanban-card.ts
@@ -1,0 +1,142 @@
+// Kanban card — single task tile with keeper attribution.
+//
+// Ported from design-system v0.4 cb-group-b (preview/cb-group-b.jsx
+// DeckKanban). Each card carries: task id + title + keeper attribution
+// (full KeeperBadge with sigil + name) + relative time. Visual state
+// follows the task status — `running` lifts a brass accent border,
+// `fail` paints a danger left edge.
+//
+// Token alignment matches #11102 (font-size / spacing scale).
+// KeeperBadge usage matches #10955 (sigil for compact rows, full for
+// card foots where the keeper is the primary attribution).
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import { KeeperBadge } from './keeper-badge'
+
+export type KanbanCardKind = 'queued' | 'running' | 'pending' | 'blocked' | 'fail' | 'done'
+
+export interface KanbanCardProps {
+  /** Stable task id ("PK-12345" or similar). */
+  id: string
+  /** Task title — the headline of the card. */
+  title: string
+  /** Keeper currently attributed to the task. */
+  keeperId: string
+  /** Optional relative time string ("2m", "13:42", etc.). */
+  time?: string
+  /** Visual state. */
+  kind?: KanbanCardKind
+  /** Click + Enter/Space activator. When given the card is interactive. */
+  onActivate?: () => void
+  /** Custom aria-label override; default composes from id + title + keeper + time. */
+  ariaLabel?: string
+}
+
+const MONO_STACK = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+const KIND_BORDER_LEFT_BY_KIND: Record<KanbanCardKind, string> = {
+  queued: 'transparent',
+  running: 'var(--color-accent-fg)',
+  pending: 'var(--color-status-warn)',
+  blocked: 'var(--color-status-warn)',
+  fail: 'var(--color-status-err)',
+  done: 'var(--color-status-ok)',
+}
+
+/** Pure: compose the SR sentence. Exposed for tests + for callers
+ *  (e.g. a column composite) that want to consolidate labels. */
+export function kanbanCardAriaLabel(props: KanbanCardProps): string {
+  if (props.ariaLabel) return props.ariaLabel
+  const kind = props.kind && props.kind !== 'queued' ? ` · ${props.kind}` : ''
+  const time = props.time ? ` · ${props.time}` : ''
+  return `${props.id} · ${props.title} · ${props.keeperId}${kind}${time}`
+}
+
+function activateOnEnterOrSpace(handler: () => void) {
+  return (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handler()
+    }
+  }
+}
+
+export function KanbanCard(props: KanbanCardProps): VNode {
+  const interactive = props.onActivate !== undefined
+  const kind = props.kind ?? 'queued'
+  const ariaLabel = kanbanCardAriaLabel(props)
+
+  const containerStyle = {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '4px',
+    padding: `var(--spacing-element) var(--spacing-group)`,
+    borderRadius: '3px',
+    background: 'var(--bg-panel)',
+    border: '1px solid var(--border-base)',
+    borderLeft: `3px solid ${KIND_BORDER_LEFT_BY_KIND[kind]}`,
+    cursor: interactive ? 'pointer' : 'default',
+    fontFamily: MONO_STACK,
+    minWidth: '0',
+  }
+
+  const idStyle = {
+    fontSize: 'var(--font-size-3xs)',
+    color: 'var(--color-fg-disabled)',
+    letterSpacing: '0.06em',
+    fontVariantNumeric: 'tabular-nums' as const,
+    textTransform: 'uppercase' as const,
+  }
+
+  const titleStyle = {
+    fontSize: 'var(--font-size-2xs)',
+    color: 'var(--color-fg-primary)',
+    fontWeight: 500,
+    lineHeight: 1.3,
+    overflow: 'hidden' as const,
+    textOverflow: 'ellipsis' as const,
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical' as const,
+  }
+
+  const footStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    fontSize: 'var(--font-size-3xs)',
+    color: 'var(--color-fg-muted)',
+    marginTop: '2px',
+  }
+
+  return html`
+    <div
+      role="listitem"
+      aria-label=${ariaLabel}
+      tabindex=${interactive ? 0 : undefined}
+      onClick=${interactive ? props.onActivate : undefined}
+      onKeyDown=${interactive && props.onActivate ? activateOnEnterOrSpace(props.onActivate) : undefined}
+      style=${containerStyle}
+    >
+      <span aria-hidden="true" style=${idStyle}>${props.id}</span>
+      <span aria-hidden="true" style=${titleStyle}>${props.title}</span>
+      <span aria-hidden="true" style=${footStyle}>
+        <${KeeperBadge}
+          id=${props.keeperId}
+          variant="full"
+          size="sm"
+          beat=${kind === 'running'}
+        />
+        ${props.time
+          ? html`
+              <span style=${{
+                color: 'var(--color-fg-disabled)',
+                fontVariantNumeric: 'tabular-nums',
+              }}>· ${props.time}</span>
+            `
+          : null}
+      </span>
+    </div>
+  `
+}


### PR DESCRIPTION
## Why

Second cb-group-b port (SwimlaneRow #11106 was first). `KanbanCard` is the atomic task tile in the source's `DeckKanban` view — a board-of-cards layout where each card surfaces task identity (`id` + `title`) and keeper attribution (`KeeperBadge` full variant) together.

Same recipe as the cb-group-a primitives: token-aligned (#11102) from the start, KeeperBadge composition (#10955), pure helper export.

## What

`src/components/kanban-card.ts` — two exports:

| Export | Kind | Purpose |
|--------|------|---------|
| `kanbanCardAriaLabel(props)` | pure helper | Composes the SR sentence: `"PK-101 · Auth refactor · nick0cave · running · 2m"`. |
| `KanbanCard` | atomic component | One task tile: id chip + title + keeper foot row, with kind-driven left edge. |

### Props

| Prop | Default | Purpose |
|------|---------|---------|
| `id` | (required) | Task slug ("PK-101"). |
| `title` | (required) | Headline. |
| `keeperId` | (required) | Powers the foot KeeperBadge (full variant: sigil + name). |
| `time` | (omitted) | Relative time chip ("2m", "13:42"). |
| `kind` | `'queued'` | Visual state — drives the left-edge accent. |
| `onActivate` | (none) | When given, card is interactive (tabindex=0, click, Enter, Space). |
| `ariaLabel` | (composed) | Override. |

### kind → left-edge color

| kind | left edge |
|------|-----------|
| `queued` | transparent |
| `running` | brass-1 (also pulses KeeperBadge.beat) |
| `pending` / `blocked` | `--color-status-warn` |
| `fail` | `--color-status-err` |
| `done` | `--color-status-ok` |

This keeps the keeper attribution channel and the task state channel **orthogonal** — keeper color is in the sigil, task state is on the card edge. Per SPEC §3.6 neither is the sole signal.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run src/components/kanban-card.test.ts`
  - `kanbanCardAriaLabel` (pure): minimal, kind insertion (queued skipped as default), time, full combo (canonical order), caller override
  - `KanbanCard`: role + aria-label, id / title / keeper text, KeeperBadge "NK" sigil for nick0cave, time chip presence/absence, non-interactive vs interactive (tabindex 0 + click + Enter activator), running kind paints brass border, fail kind paints `var(--color-status-err)` border

## What this PR does NOT do

- **No `KanbanColumn` / `KanbanBoard` composite.** Column header (`Queued · 7`) + role=region wrapper + role=tabpanel parent — all column/board level. Defer until 2+ callsites.
- **No drag-and-drop.** Source DeckKanban is static; D&D is a follow-up.
- **No callsite migration.** Same cadence as predecessor primitives.

## Refs

- Source: `dashboard/design-system/preview/cb-group-b.jsx` (DeckKanban)
- Precedent: #11106 (SwimlaneRow — first cb-group-b primitive), #11066 / #11070 / #11088 (cb-group-a primitives), #11102 (token sweep)
- Composition: #10955 (KeeperBadge)
- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
