### PR TITLE
feat(dashboard): add SidebarRow primitive (cb-group-b, Stage B)

### DIFF
--- a/dashboard/src/components/sidebar-row.test.ts
+++ b/dashboard/src/components/sidebar-row.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { SidebarRow, sidebarRowAriaLabel, type SidebarRowProps } from './sidebar-row'
+
+describe('sidebarRowAriaLabel (pure)', () => {
+  it('returns "keeperId" for the minimal case', () => {
+    expect(sidebarRowAriaLabel({ keeperId: 'nick0cave' })).toBe('nick0cave')
+  })
+
+  it('appends meta when given', () => {
+    expect(
+      sidebarRowAriaLabel({ keeperId: 'nick0cave', meta: 'fixing CI' }),
+    ).toBe('nick0cave · fixing CI')
+  })
+
+  it('appends status when given', () => {
+    expect(
+      sidebarRowAriaLabel({ keeperId: 'a', status: 'running' }),
+    ).toBe('a · running')
+  })
+
+  it('combines meta + status + selected in canonical order', () => {
+    expect(
+      sidebarRowAriaLabel({
+        keeperId: 'nick0cave',
+        meta: 'PK-101',
+        status: 'running',
+        selected: true,
+      }),
+    ).toBe('nick0cave · PK-101 · running · selected')
+  })
+
+  it('caller-supplied ariaLabel wins', () => {
+    expect(
+      sidebarRowAriaLabel({
+        keeperId: 'a',
+        meta: 'm',
+        ariaLabel: 'Custom',
+      }),
+    ).toBe('Custom')
+  })
+})
+
+describe('SidebarRow component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  function mount(props: SidebarRowProps): HTMLElement {
+    render(html`<${SidebarRow} ...${props} />`, container)
+    return container.querySelector('[role="listitem"]') as HTMLElement
+  }
+
+  it('renders role=listitem with composed aria-label', () => {
+    const el = mount({ keeperId: 'nick0cave' })
+    expect(el).toBeTruthy()
+    expect(el.getAttribute('role')).toBe('listitem')
+    expect(el.getAttribute('aria-label')).toBe('nick0cave')
+  })
+
+  it('renders KeeperBadge sigil + keeper id text', () => {
+    const el = mount({ keeperId: 'nick0cave' })
+    expect(el.textContent).toContain('NK')
+    expect(el.textContent).toContain('nick0cave')
+  })
+
+  it('renders meta text when given', () => {
+    const el = mount({ keeperId: 'a', meta: 'PK-101' })
+    expect(el.textContent).toContain('PK-101')
+  })
+
+  it('omits meta span when not given', () => {
+    const el = mount({ keeperId: 'a' })
+    // Only the sigil + keeper name; no meta span child
+    const spans = el.querySelectorAll('span[aria-hidden="true"]')
+    // 1 keeper-name span, no meta span
+    expect(spans.length).toBe(1)
+  })
+
+  it('non-interactive row omits tabindex', () => {
+    const el = mount({ keeperId: 'a' })
+    expect(el.getAttribute('tabindex')).toBeNull()
+  })
+
+  it('interactive row sets tabindex=0 and fires onActivate on click', () => {
+    const onActivate = vi.fn()
+    render(
+      html`<${SidebarRow} keeperId="a" onActivate=${onActivate} />`,
+      container,
+    )
+    const el = container.querySelector('[role="listitem"]') as HTMLElement
+    expect(el.getAttribute('tabindex')).toBe('0')
+    el.click()
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('Enter key activates an interactive row', () => {
+    const onActivate = vi.fn()
+    render(
+      html`<${SidebarRow} keeperId="a" onActivate=${onActivate} />`,
+      container,
+    )
+    const el = container.querySelector('[role="listitem"]') as HTMLElement
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('Space key activates an interactive row', () => {
+    const onActivate = vi.fn()
+    render(
+      html`<${SidebarRow} keeperId="a" onActivate=${onActivate} />`,
+      container,
+    )
+    const el = container.querySelector('[role="listitem"]') as HTMLElement
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('selected=true emits aria-current="true"', () => {
+    const el = mount({ keeperId: 'a', selected: true })
+    expect(el.getAttribute('aria-current')).toBe('true')
+  })
+
+  it('selected=false omits aria-current', () => {
+    const el = mount({ keeperId: 'a' })
+    expect(el.getAttribute('aria-current')).toBeNull()
+  })
+
+  it('idle status dims the row visually', () => {
+    const el = mount({ keeperId: 'a', status: 'idle' })
+    expect(parseFloat(el.style.opacity)).toBeLessThan(1)
+  })
+
+  it('stalled status also dims', () => {
+    const el = mount({ keeperId: 'a', status: 'stalled' })
+    expect(parseFloat(el.style.opacity)).toBeLessThan(1)
+  })
+
+  it('running status renders at full opacity', () => {
+    const el = mount({ keeperId: 'a', status: 'running' })
+    expect(el.style.opacity === '' || el.style.opacity === '1').toBe(true)
+  })
+})

--- a/dashboard/src/components/sidebar-row.ts
+++ b/dashboard/src/components/sidebar-row.ts
@@ -1,0 +1,115 @@
+// Sidebar row — keeper entry in a fleet/standby sidebar list.
+//
+// Ported from design-system v0.4 cb-group-b (preview/cb-group-b.jsx
+// SidebarFleet / SidebarGrouped / SidebarIcons). All three variants
+// share the same row shape: KeeperBadge sigil + keeper id + meta text.
+// The compact variant (SidebarIcons) hides the keeper id and meta
+// behind a tooltip; that's a strip-level concern, not row-level —
+// this primitive renders the full content and the future strip can
+// suppress optional fields via CSS.
+//
+// Token alignment matches #11102 (font-size / spacing scale);
+// KeeperBadge usage matches #10955.
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import { KeeperBadge } from './keeper-badge'
+
+export type SidebarRowStatus = 'running' | 'idle' | 'stalled' | 'fail' | 'pending'
+
+export interface SidebarRowProps {
+  keeperId: string
+  /** Right-aligned secondary text — typically current task slug or
+   *  a short status string ("queued", "fixing CI", etc.). */
+  meta?: string
+  status?: SidebarRowStatus
+  /** Visual selected state — emits aria-current="true" + filled background. */
+  selected?: boolean
+  /** Click + Enter/Space activator. When omitted the row is non-interactive. */
+  onActivate?: () => void
+  /** Custom aria-label override; default composes from keeperId + meta + status. */
+  ariaLabel?: string
+}
+
+const MONO_STACK = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+/** Pure: compose the SR sentence. Exposed for tests + parent strips. */
+export function sidebarRowAriaLabel(props: SidebarRowProps): string {
+  if (props.ariaLabel) return props.ariaLabel
+  const meta = props.meta ? ` · ${props.meta}` : ''
+  const status = props.status ? ` · ${props.status}` : ''
+  const sel = props.selected ? ' · selected' : ''
+  return `${props.keeperId}${meta}${status}${sel}`
+}
+
+function activateOnEnterOrSpace(handler: () => void) {
+  return (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handler()
+    }
+  }
+}
+
+export function SidebarRow(props: SidebarRowProps): VNode {
+  const interactive = props.onActivate !== undefined
+  const ariaLabel = sidebarRowAriaLabel(props)
+  const isIdle = props.status === 'idle' || props.status === 'stalled'
+
+  const containerStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    padding: `4px var(--spacing-element)`,
+    borderRadius: '3px',
+    background: props.selected ? 'var(--bg-panel-hover)' : 'transparent',
+    border: `1px solid ${props.selected ? 'var(--brass-1, var(--color-accent-fg))' : 'transparent'}`,
+    cursor: interactive ? 'pointer' : 'default',
+    fontFamily: MONO_STACK,
+    opacity: isIdle ? 0.6 : 1,
+    minWidth: '0',
+  }
+
+  const nameStyle = {
+    fontSize: 'var(--font-size-2xs)',
+    color: 'var(--color-fg-primary)',
+    fontWeight: 500,
+    overflow: 'hidden' as const,
+    textOverflow: 'ellipsis' as const,
+    whiteSpace: 'nowrap' as const,
+    flex: '0 1 auto',
+  }
+
+  const metaStyle = {
+    fontSize: 'var(--font-size-3xs)',
+    color: 'var(--color-fg-muted)',
+    overflow: 'hidden' as const,
+    textOverflow: 'ellipsis' as const,
+    whiteSpace: 'nowrap' as const,
+    marginLeft: 'auto',
+    flex: '0 1 auto',
+  }
+
+  return html`
+    <div
+      role="listitem"
+      aria-label=${ariaLabel}
+      aria-current=${props.selected ? 'true' : undefined}
+      tabindex=${interactive ? 0 : undefined}
+      onClick=${interactive ? props.onActivate : undefined}
+      onKeyDown=${interactive && props.onActivate ? activateOnEnterOrSpace(props.onActivate) : undefined}
+      style=${containerStyle}
+    >
+      <${KeeperBadge}
+        id=${props.keeperId}
+        variant="sigil"
+        size="sm"
+        beat=${props.status === 'running'}
+      />
+      <span aria-hidden="true" style=${nameStyle}>${props.keeperId}</span>
+      ${props.meta
+        ? html`<span aria-hidden="true" style=${metaStyle}>${props.meta}</span>`
+        : null}
+    </div>
+  `
+}


### PR DESCRIPTION
## Why

Third cb-group-b port (siblings: SwimlaneRow #11106, KanbanCard added in parallel this cycle). `SidebarRow` is the atomic keeper entry in the source's three sibling sidebars (`SidebarFleet`, `SidebarGrouped`, `SidebarIcons`) — they all render the same row shape with different parent layouts.

Token-aligned (#11102) + KeeperBadge composition (#10955).

## What

`src/components/sidebar-row.ts` — two exports:

| Export | Kind | Purpose |
|--------|------|---------|
| `sidebarRowAriaLabel(props)` | pure helper | Composes the SR sentence: `"nick0cave · PK-101 · running · selected"`. |
| `SidebarRow` | atomic component | One keeper row: KeeperBadge sigil + keeper id + meta. |

### Props

| Prop | Default | Purpose |
|------|---------|---------|
| `keeperId` | (required) | Powers the KeeperBadge sigil. |
| `meta` | (omitted) | Right-aligned secondary text ("PK-101", "fixing CI"). |
| `status` | (omitted) | `'running'` / `'idle'` / `'stalled'` / `'fail'` / `'pending'`. |
| `selected` | `false` | Brass border + filled background + `aria-current="true"`. |
| `onActivate` | (none) | When given, row is interactive (tabindex 0 + click + Enter + Space). |
| `ariaLabel` | (composed) | Override. |

### Status → visual

| status | effect |
|--------|--------|
| `running` | `KeeperBadge.beat=true` (pulses sigil) |
| `idle` / `stalled` | 0.6 opacity (the row dims) |
| others | no change |

The sidebar's "active vs standby" two-section layout in `SidebarGrouped` is achieved at the *parent* — caller filters keepers and renders one strip per group. This primitive doesn't try to encode that split.

### Variant collapse

| cb-group-b variant | dashboard equivalent |
|--------------------|----------------------|
| `SidebarFleet` | `SidebarRow`s in one nav, all interactive (`onActivate` for selection) |
| `SidebarGrouped` | Two `SidebarRow` lists; standby section without `onActivate` |
| `SidebarIcons` | Same data shape; the parent strip CSS-hides the meta/name spans (this row renders them; strip suppresses) |

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run src/components/sidebar-row.test.ts`
  - `sidebarRowAriaLabel` (pure): minimal, meta, status, full combo (canonical order), caller override
  - `SidebarRow`: role + aria-label, KeeperBadge "NK" sigil + keeper text, meta presence/absence, aria-hidden span count when meta omitted, non-interactive vs interactive (tabindex 0 + click + Enter + Space), `aria-current="true"` on selected, opacity 0.6 on idle/stalled, full opacity on running

## What this PR does NOT do

- **No `SidebarStrip` composite.** Section heading (`FLEET · 5`), `<nav>` wrapper, density variant ("icons"). Strip-level — defer until 2+ callsites.
- **No goal/task row variant.** SidebarFleet's bottom GOALS section is a different row shape (no keeper); separate primitive when needed.
- **No callsite migration.** Same cadence as predecessor primitives.

## Refs

- Source: `dashboard/design-system/preview/cb-group-b.jsx` (SidebarFleet / SidebarGrouped / SidebarIcons)
- Precedent: #11106 (SwimlaneRow), KanbanCard added in same cycle, #11066 / #11070 / #11088 (cb-group-a primitives), #11102 (token sweep)
- Composition: #10955 (KeeperBadge)
- Stage plan: `~/me/planning/claude-plans/30m-users-dancer-downloads-masc-design-s-fluffy-ripple.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
