### PR TITLE
fix(telemetry): cascade_audit JSONL emits keeper_name + top_level_reason (#11081)

### DIFF
--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -445,25 +445,47 @@ let cascade_outcome_to_string = function
   | `Failure -> "failure"
   | `Rejected -> "rejected"
 
-let cascade_audit_json ~now ~cascade_name ~observation ~outcome =
+(* Promotes the most-recent fallback event reason as a top-level field for
+   first-class aggregation/alerting (issue #11081).  Last (not first) event
+   is chosen because for terminal Failure/Rejected outcomes the final event's
+   reason is the actual cause of exhaustion; the first event reflects only
+   the initial fallback trigger.  Empty list -> null. *)
+let top_level_reason_of_observation (observation : cascade_observation option) =
+  match observation with
+  | None -> `Null
+  | Some obs ->
+      (match List.rev obs.fallback_events with
+      | last :: _ -> `String last.reason
+      | [] -> `Null)
+
+let keeper_name_to_json keeper_name =
+  match keeper_name with
+  | Some name when String.trim name <> "" -> `String name
+  | _ -> `Null
+
+let cascade_audit_json ~now ~keeper_name ~cascade_name ~observation ~outcome =
   `Assoc
     [
       ("ts", `Float now);
+      ("keeper_name", keeper_name_to_json keeper_name);
       ("cascade_name", `String cascade_name);
       ("outcome", `String (cascade_outcome_to_string outcome));
+      ("top_level_reason", top_level_reason_of_observation observation);
       ( "observation",
         match observation with
         | Some obs -> cascade_observation_to_json obs
         | None -> `Null );
     ]
 
-let record_cascade_audit store_opt ~now ~cascade_name ~observation ~outcome =
+let record_cascade_audit store_opt ~now ~keeper_name ~cascade_name ~observation
+    ~outcome =
   match store_opt with
   | None -> ()
   | Some store ->
       (try
          Dated_jsonl.append store
-           (cascade_audit_json ~now ~cascade_name ~observation ~outcome)
+           (cascade_audit_json ~now ~keeper_name ~cascade_name ~observation
+              ~outcome)
        with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
@@ -500,6 +522,7 @@ let attempt_model_display (attempt : cascade_attempt) =
 
 type msg =
   | Record_cascade of {
+      keeper_name : string option;
       cascade_name : string;
       observation : cascade_observation option;
       outcome : [ `Success | `Failure | `Rejected ];
@@ -515,7 +538,7 @@ type state = {
 
 let stream = Eio.Stream.create 1024
 
-let handle_record state ~now ~cascade_name ~observation ~outcome =
+let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
   let counters = state.counters in
   let counter, counters, evicted =
     match StringMap.find_opt cascade_name counters with
@@ -576,7 +599,8 @@ let handle_record state ~now ~cascade_name ~observation ~outcome =
         cascade_max_keys)
     evicted;
   let audit_store_next = get_cascade_audit_store state.audit_store in
-  record_cascade_audit audit_store_next ~now ~cascade_name ~observation ~outcome;
+  record_cascade_audit audit_store_next ~now ~keeper_name ~cascade_name
+    ~observation ~outcome;
   { counters = StringMap.add cascade_name counter counters; audit_store = audit_store_next }
 
 let handle_get_metrics state p =
@@ -632,8 +656,10 @@ let handle_get_metrics state p =
 let run_actor () =
   let rec loop state =
     match Eio.Stream.take stream with
-    | Record_cascade { cascade_name; observation; outcome; now } ->
-        loop (handle_record state ~now ~cascade_name ~observation ~outcome)
+    | Record_cascade { keeper_name; cascade_name; observation; outcome; now } ->
+        loop
+          (handle_record state ~now ~keeper_name ~cascade_name ~observation
+             ~outcome)
     | Get_metrics_json p ->
         handle_get_metrics state p;
         loop state
@@ -645,9 +671,10 @@ let run_actor () =
 let start_actor_if_needed ~sw =
   Eio.Fiber.fork ~sw run_actor
 
-let record_cascade ~observation ~cascade_name ~outcome =
+let record_cascade ?keeper_name ~observation ~cascade_name ~outcome () =
   let now = Time_compat.now () in
-  Eio.Stream.add stream (Record_cascade { cascade_name; observation; outcome; now })
+  Eio.Stream.add stream
+    (Record_cascade { keeper_name; cascade_name; observation; outcome; now })
 
 let cascade_metrics_json () =
   let p, u = Eio.Promise.create () in

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1471,7 +1471,8 @@ let run_named
           ?strategy:!cascade_strategy_name_ref ~configured_labels
           ~candidate_cfgs ~selected_model_raw:None ~capture ()
       in
-      Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
+      Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+        ~outcome:`Failure ~observation:(Some observation) ();
       let terminal_error =
         match last_err with
         | Some (Llm_provider.Http_client.NetworkError { message; _ })
@@ -1529,7 +1530,8 @@ let run_named
             ~capture ()
         in
         let result = { result with cascade_observation = Some observation } in
-        Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
+        Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+          ~outcome:`Success ~observation:(Some observation) ();
         on_success ~provider_key:provider_cfg.model_id;
         Ok result
       | Ok result ->
@@ -1557,7 +1559,8 @@ let run_named
                ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
-           Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
+           Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+          ~outcome:`Success ~observation:(Some observation) ();
            on_success ~provider_key:provider_cfg.model_id;
            Ok result
          | Cascade_fsm.Try_next { last_err = new_err } ->
@@ -1575,7 +1578,8 @@ let run_named
                ~candidate_cfgs ~selected_model_raw:(Some result.response.model)
                ~capture ()
            in
-           Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Rejected ~observation:(Some observation);
+           Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+             ~outcome:`Rejected ~observation:(Some observation) ();
            Log.Misc.error "cascade %s exhausted: all tiers rejected by accept predicate (last model=%s, reason=%s)"
              cascade_name result.response.model reason;
            Error
@@ -1595,7 +1599,8 @@ let run_named
                ~candidate_cfgs ~selected_model_raw:(Some resp.model) ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
-           Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
+           Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+          ~outcome:`Success ~observation:(Some observation) ();
            on_success ~provider_key:provider_cfg.model_id;
            Ok result)
       | Error sdk_err ->
@@ -1716,7 +1721,8 @@ let run_named
                   ?strategy:!cascade_strategy_name_ref ~configured_labels
                   ~candidate_cfgs ~selected_model_raw:None ~capture ()
               in
-              Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
+              Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+        ~outcome:`Failure ~observation:(Some observation) ();
               Log.Misc.error "cascade %s exhausted: all tiers failed (last model=%s, error=%s)"
                 cascade_name provider_cfg.model_id (Oas.Error.to_string sdk_err);
               Error sdk_err
@@ -1728,7 +1734,8 @@ let run_named
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_cfgs ~selected_model_raw:None ~capture ()
            in
-           Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
+           Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+        ~outcome:`Failure ~observation:(Some observation) ();
            Log.Misc.error "cascade %s: non-cascadable error from %s: %s"
              cascade_name provider_cfg.model_id (Oas.Error.to_string sdk_err);
            Error sdk_err))
@@ -1850,8 +1857,8 @@ let run_named
         ?strategy:!cascade_strategy_name_ref ~configured_labels
         ~candidate_cfgs ~selected_model_raw:None ~capture ()
     in
-    Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure
-      ~observation:(Some observation);
+    Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+      ~outcome:`Failure ~observation:(Some observation) ();
     Error
       (sdk_error_of_masc_internal_error
          (Cascade_exhausted { cascade_name; reason = Keeper_types.Candidates_filtered_after_cycles }))

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -513,6 +513,7 @@ let test_cascade_metrics_concurrent_recording () =
                    ~cascade_name:"concurrent-cascade"
                    ~observation:None
                    ~outcome:`Success
+                   ()
                done));
       match
         find_cascade_metric_entry "concurrent-cascade"
@@ -536,30 +537,35 @@ let test_cascade_metrics_evicts_lowest_call_key () =
       Masc_mcp.Oas_worker_cascade.record_cascade
         ~cascade_name:"victim-key"
         ~observation:None
-        ~outcome:`Success;
+        ~outcome:`Success
+        ();
       for i = 1 to 254 do
         let name = Printf.sprintf "stable-%03d" i in
         Masc_mcp.Oas_worker_cascade.record_cascade
           ~cascade_name:name
           ~observation:None
-          ~outcome:`Success;
+          ~outcome:`Success
+          ();
         Masc_mcp.Oas_worker_cascade.record_cascade
           ~cascade_name:name
           ~observation:None
           ~outcome:`Success
+          ()
       done;
       for _ = 1 to 3 do
         Masc_mcp.Oas_worker_cascade.record_cascade
           ~cascade_name:"hot-key"
           ~observation:None
           ~outcome:`Success
+          ()
       done;
       let before = Yojson.Safe.Util.to_list (Oas_worker.cascade_metrics_json ()) in
       Alcotest.(check int) "table capped before admit" 256 (List.length before);
       Masc_mcp.Oas_worker_cascade.record_cascade
         ~cascade_name:"new-key"
         ~observation:None
-        ~outcome:`Success;
+        ~outcome:`Success
+        ();
       let after_json = Oas_worker.cascade_metrics_json () in
       let after = Yojson.Safe.Util.to_list after_json in
       Alcotest.(check int) "table stays capped" 256 (List.length after);
@@ -630,9 +636,11 @@ let test_cascade_audit_persists_observation () =
         }
       in
       Masc_mcp.Oas_worker_cascade.record_cascade
+        ~keeper_name:"keeper-glm-agent-test"
         ~cascade_name:"audit-cascade"
         ~observation:(Some observation)
-        ~outcome:`Failure;
+        ~outcome:`Failure
+        ();
       let store =
         Dated_jsonl.create
           ~base_dir:(Filename.concat base ".masc/cascade_audit")
@@ -642,6 +650,12 @@ let test_cascade_audit_persists_observation () =
       | [ json ] ->
           Alcotest.(check string) "cascade name persisted" "audit-cascade"
             Yojson.Safe.Util.(json |> member "cascade_name" |> to_string);
+          Alcotest.(check string) "keeper_name persisted (#11081)"
+            "keeper-glm-agent-test"
+            Yojson.Safe.Util.(json |> member "keeper_name" |> to_string);
+          Alcotest.(check string) "top_level_reason promoted (#11081)"
+            "HTTP 503"
+            Yojson.Safe.Util.(json |> member "top_level_reason" |> to_string);
           Alcotest.(check string) "outcome persisted" "failure"
             Yojson.Safe.Util.(json |> member "outcome" |> to_string);
           Alcotest.(check string) "selected model persisted"


### PR DESCRIPTION
Closes #11081.

## Why

Yesterday's `cascade_audit/2026-04/26.jsonl` had 39/230 (17%) failures all emit `{keeper_name:null, reason:null}` because the schema only carried `cascade_name` and `outcome`. Per-keeper failure attribution required walking `observation.fallback_events[0].reason` — making dashboards / alerting disaggregation impractical and masking which keeper was hit hardest.

## Changes

- `lib/oas_worker_cascade.ml`
  - `Record_cascade` mailbox variant gains `keeper_name : string option`.
  - `cascade_audit_json` emits two new top-level fields:
    - `keeper_name` — threaded from `run_named` (already in lexical scope at every `record_cascade` call site). Empty keeper context emits `null` not empty string, so jq filters distinguish unattributed records.
    - `top_level_reason` — promotes the **last** fallback event's reason. For Failure/Rejected outcomes the terminal event is the actual cause of exhaustion; the issue's `[0]` sketch reflects only the first stumble. Empty event list emits `null`.
  - `record_cascade` adopts an optional `?keeper_name` parameter, requiring trailing unit at call sites.
- `lib/oas_worker_named.ml` — sweep all 8 `record_cascade` call sites to pass `~keeper_name`.
- `test/test_oas_worker.ml` — sweep all 7 call sites for the new signature; the `cascade audit persists observation` test now asserts both new fields.

Per feedback_jane-street-refactor-sweep-miss the wrapper-introduction sweep covered all consumers in the same PR.

## Local verification

- `dune build @install --profile=release` → exit 0 (the actual CI lint target).
- `dune build test/test_oas_worker.exe` → exit 0.

## Out-of-scope (followups)

- Option C (Prometheus counter `cascade_audit_outcome_total{cascade_name, outcome, top_level_reason}`) — schema gap is the prerequisite; landing this lets that metric carry meaningful labels.
- The pre-existing `cascade audit persists observation` test was already failing in isolation on `origin/main` (same EXIT=0 + 1 failure), confirmed by stash + checkout origin/main + run. The actor never starts in alcotest test context; this PR's diff doesn't introduce that flakiness — the assertion strengthens what the test *will* verify when the suite is run together (where preceding tests start the actor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)