### PR TITLE
i18n(dashboard): localize 2 nullish-coalesce English fallbacks (round-102)

### DIFF
--- a/dashboard/src/components/fsm-hub-health-panels.test.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.test.ts
@@ -137,13 +137,13 @@ describe('invariantDescription', () => {
 
   it('returns default for unknown key', () => {
     expect(invariantDescription('unknown_invariant')).toBe(
-      'Invariant defined by the keeper composite contract.',
+      'keeper composite contract 가 정의한 invariant.',
     )
   })
 
   it('returns default for empty string key', () => {
     expect(invariantDescription('')).toBe(
-      'Invariant defined by the keeper composite contract.',
+      'keeper composite contract 가 정의한 invariant.',
     )
   })
 

--- a/dashboard/src/components/fsm-hub-health-panels.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.ts
@@ -99,7 +99,7 @@ const INVARIANT_DESCRIPTIONS: Record<string, string> = {
 }
 
 export function invariantDescription(key: string): string {
-  return INVARIANT_DESCRIPTIONS[key] ?? 'Invariant defined by the keeper composite contract.'
+  return INVARIANT_DESCRIPTIONS[key] ?? 'keeper composite contract 가 정의한 invariant.'
 }
 
 export function InvariantsPanel({

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -110,7 +110,7 @@ function CoordinationViolationRow({ violation }: { violation: DashboardCoordinat
         <span class="font-mono text-2xs text-text-strong">${violation.code ?? violation.axis ?? 'coordination'}</span>
         ${violation.axis ? html`<span class="text-3xs text-text-dim">${violation.axis}</span>` : null}
       </div>
-      <div class="mt-1 text-xs leading-relaxed text-text-body">${violation.message ?? 'Coordination invariant needs attention.'}</div>
+      <div class="mt-1 text-xs leading-relaxed text-text-body">${violation.message ?? 'coordination invariant 검토 필요.'}</div>
       <div class="mt-1 truncate text-3xs text-text-dim" title=${refsLabel(violation.refs)}>${refsLabel(violation.refs)}</div>
       ${evidence.length > 0 ? html`
         <ul class="mt-2 grid gap-1">


### PR DESCRIPTION
## Summary

새 slice (`?? 'English fallback'`) 가 마지막 영어 surface 2개 발견. 두 곳 모두 nullish-coalesce 의 default — INVARIANT_DESCRIPTIONS map miss + violation.message null 시 표시.

## Changed strings

| 파일 | line | Before | After |
|---|---|---|---|
| `fsm-hub-health-panels.ts` | 102 | `'Invariant defined by the keeper composite contract.'` | `'keeper composite contract 가 정의한 invariant.'` |
| `planning-panel.ts` | 113 | `'Coordination invariant needs attention.'` | `'coordination invariant 검토 필요.'` |

## Atomic test sync

`fsm-hub-health-panels.test.ts` 의 line 140 / 146 toBe assertion 둘 다 새 한국어 string 으로 동기화 (replace_all=true).

```ts
// Before
expect(invariantDescription('unknown_invariant')).toBe(
  'Invariant defined by the keeper composite contract.',
)
// After
expect(invariantDescription('unknown_invariant')).toBe(
  'keeper composite contract 가 정의한 invariant.',
)
```

## Domain term policy

`invariant`, `keeper composite contract`, `coordination` 보존.

## Scope

- 3 파일, 4줄.
- atomic test sync 1 file, 2 assertion line.
- planning-panel 의 violation.message default 는 test reference 0건.
