### PR TITLE
refactor(dashboard): introduce --color-accent-brass + align primitives

### DIFF
--- a/dashboard/src/components/kanban-card.test.ts
+++ b/dashboard/src/components/kanban-card.test.ts
@@ -165,14 +165,14 @@ describe('KanbanCard component', () => {
     expect(onActivate).toHaveBeenCalledTimes(1)
   })
 
-  it('running kind paints accent left border', () => {
+  it('running kind paints brass left border', () => {
     const el = mount({
       id: 'PK-1',
       title: 't',
       keeperId: 'a',
       kind: 'running',
     })
-    expect(el.style.borderLeft).toContain('var(--color-accent-fg)')
+    expect(el.style.borderLeft).toContain('var(--color-accent-brass)')
   })
 
   it('fail kind paints err-status left border', () => {

--- a/dashboard/src/components/kanban-card.ts
+++ b/dashboard/src/components/kanban-card.ts
@@ -37,7 +37,7 @@ const MONO_STACK = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "L
 
 const KIND_BORDER_LEFT_BY_KIND: Record<KanbanCardKind, string> = {
   queued: 'transparent',
-  running: 'var(--color-accent-fg)',
+  running: 'var(--color-accent-brass)',
   pending: 'var(--color-status-warn)',
   blocked: 'var(--color-status-warn)',
   fail: 'var(--color-status-err)',

--- a/dashboard/src/components/kpi-cell.ts
+++ b/dashboard/src/components/kpi-cell.ts
@@ -87,8 +87,8 @@ const surfaceStyle = {
 }
 
 const liveOverrideStyle = {
-  borderColor: 'var(--brass-1, var(--color-accent-fg))',
-  boxShadow: '0 0 0 1px var(--brass-1, var(--color-accent-fg)), 0 0 12px rgb(var(--color-keeper-3-glow, 195 146 89) / 0.18)',
+  borderColor: 'var(--color-accent-brass)',
+  boxShadow: '0 0 0 1px var(--color-accent-brass), 0 0 12px rgb(var(--color-keeper-3-glow, 195 146 89) / 0.18)',
 }
 
 export function KpiCell(props: KpiCellProps): VNode {

--- a/dashboard/src/components/lifeline-bar.ts
+++ b/dashboard/src/components/lifeline-bar.ts
@@ -64,7 +64,7 @@ export function Heartbeat({
   phase = 0,
   width = HEARTBEAT_DEFAULT_WIDTH,
   height = HEARTBEAT_DEFAULT_HEIGHT,
-  color = 'var(--color-accent-fg)',
+  color = 'var(--color-accent-brass)',
   withoutPulseDot = false,
 }: HeartbeatProps): VNode {
   const points = heartbeatPoints(phase, width, height)

--- a/dashboard/src/components/sidebar-row.ts
+++ b/dashboard/src/components/sidebar-row.ts
@@ -63,7 +63,7 @@ export function SidebarRow(props: SidebarRowProps): VNode {
     padding: `4px var(--spacing-element)`,
     borderRadius: '3px',
     background: props.selected ? 'var(--bg-panel-hover)' : 'transparent',
-    border: `1px solid ${props.selected ? 'var(--brass-1, var(--color-accent-fg))' : 'transparent'}`,
+    border: `1px solid ${props.selected ? 'var(--color-accent-brass)' : 'transparent'}`,
     cursor: interactive ? 'pointer' : 'default',
     fontFamily: MONO_STACK,
     opacity: isIdle ? 0.6 : 1,

--- a/dashboard/src/components/swimlane-row.ts
+++ b/dashboard/src/components/swimlane-row.ts
@@ -111,7 +111,7 @@ export function SwimlaneRow(props: SwimlaneRowProps): VNode {
     gap: 'var(--spacing-element)',
     padding: `4px var(--spacing-element)`,
     borderRadius: '3px',
-    border: `1px solid ${props.selected ? 'var(--brass-1, var(--color-accent-fg))' : 'transparent'}`,
+    border: `1px solid ${props.selected ? 'var(--color-accent-brass)' : 'transparent'}`,
     background: props.selected ? 'var(--bg-panel)' : 'transparent',
     cursor: interactive ? 'pointer' : 'default',
     outline: 'none',

--- a/dashboard/src/styles/tokens.css
+++ b/dashboard/src/styles/tokens.css
@@ -11,6 +11,12 @@
   --color-text-muted: #a8bfdf;
   --color-accent: #47b8ff;
   --color-accent-soft: rgba(71, 184, 255, 0.16);
+  /* Brass accent — primary identity color for live / running fleet
+     states. Matches design-system v0.4 source_styles/tokens.css
+     --brass-1 (#d4a14a). The pre-existing --color-ff-gold (#c8a84e)
+     is a near-match used in legacy sites; new primitives should reach
+     for --color-accent-brass for SPEC alignment. */
+  --color-accent-brass: #d4a14a;
   --color-ok: #4ade80;
   --color-warn: #fbbf24;
   --color-bad: #ef4444;


### PR DESCRIPTION
## Why

Color was the missing axis in #11102 (the spacing/font-size token sweep). The cb-group-a and cb-group-b primitives that landed since (#11066 KpiCell, #11070 LifelineBar, #11088 TickerItem, #11106 SwimlaneRow, #11108 KanbanCard, #11109 SidebarRow) all reach for *brass* — design-system's `--brass-1` (#d4a14a) — for the live / running / selected identity color. The dashboard never mirrored that token, so the primitives improvised:

- Most used `var(--brass-1, var(--color-accent-fg))` — a nested var() fallback. **happy-dom can't parse it** (silently drops the declaration to `initial`), which is why #11108 had a flaky-looking test. **Production browsers** *can* parse it but resolve to `--color-accent-fg`, which on this dashboard is `#47b8ff` cyan — **not brass**. So the fallback hit the wrong color.
- KanbanCard directly used `var(--color-accent-fg)` (cyan) after the test failure.

Result: every "running" border on the dashboard's new primitives renders **cyan** instead of **brass**. Visible drift from SPEC.

## What

`dashboard/src/styles/tokens.css` — one new token:

```css
/* Brass accent — primary identity color for live / running fleet
   states. Matches design-system v0.4 source_styles/tokens.css
   --brass-1 (#d4a14a). The pre-existing --color-ff-gold (#c8a84e)
   is a near-match used in legacy sites; new primitives should reach
   for --color-accent-brass for SPEC alignment. */
--color-accent-brass: #d4a14a;
```

Six call-sites updated to `var(--color-accent-brass)`:

| File | Site |
|------|------|
| `kpi-cell.ts` | `liveOverrideStyle.borderColor` + box-shadow ring (×2 in one constant) |
| `lifeline-bar.ts` | `Heartbeat` default trace color |
| `sidebar-row.ts` | selected row border |
| `swimlane-row.ts` | selected lane border |
| `kanban-card.ts` | `running` kind left edge |
| `kanban-card.test.ts` | assertion updated to the new token name |

## Why a new token instead of reusing `--color-ff-gold`?

`--color-ff-gold` (#c8a84e) is a legacy near-match that predates the v0.4 SPEC. Two reasons to introduce a new SPEC-named alias:

1. **Intent grep-ability**: `--color-accent-brass` reads as "brass per SPEC" anywhere it appears; `--color-ff-gold` reads as a legacy palette ref.
2. **Migration pacing**: legacy `--color-ff-gold` sites can migrate to `--color-accent-brass` at their own pace without colliding with primitive surface decisions in this PR. Keeping the two refs distinct surfaces the migration boundary.

If consensus later lands on consolidating to `--color-ff-gold`, that's a single alias swap.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run kpi-cell lifeline-bar swimlane-row sidebar-row kanban-card ticker-item`
  → **6 files / 116 cases / all pass**

## What this PR does NOT do

- Migrate non-primitive callsites (e.g. legacy `--color-ff-gold` users in dashboard chrome). The new token is additive; existing surfaces unchanged.
- Touch design-system raw tokens (`--brass-1`/`--brass-2`) — those live in design-system source_styles only and don't ship to dashboard runtime.

## Refs

- design-system: `source_styles/tokens.css --brass-1` (#d4a14a)
- Primitive series: #11066 (KpiCell), #11070 (LifelineBar), #11088 (TickerItem), #11106 (SwimlaneRow), #11108 (KanbanCard), #11109 (SidebarRow)
- Spacing/font-size token sweep: #11102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
