### PR TITLE
fix(dashboard): update fsm-hub test regex for i18n fallback

### DIFF
--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -565,7 +565,7 @@ describe('invariantDescription', () => {
     for (const key of keys) {
       const desc = invariantDescription(key)
       expect(desc.length).toBeGreaterThan(40)
-      expect(desc).not.toMatch(/^Invariant defined by/)
+      expect(desc).not.toMatch(/composite contract/)
     }
   })
 
@@ -577,7 +577,7 @@ describe('invariantDescription', () => {
   })
 
   it('falls back to generic text for unknown keys', () => {
-    expect(invariantDescription('mystery_invariant')).toMatch(/^Invariant defined by/)
+    expect(invariantDescription('mystery_invariant')).toMatch(/composite contract/)
   })
 })
 


### PR DESCRIPTION
## Summary
- `fsm-hub.test.ts` used `/^Invariant defined by/` regex to detect generic fallback
- i18n PR #11112 changed the fallback to Korean, breaking the regex match
- Updated both regex patterns to match language-agnostic `composite contract`

## Test plan
- [x] Dashboard CI will validate the regex change

🤖 Generated with [Claude Code](https://claude.com/claude-code)