### PR TITLE
feat(dashboard): adopt KpiCell in overview funnel

### DIFF
--- a/dashboard/src/components/kpi-cell.ts
+++ b/dashboard/src/components/kpi-cell.ts
@@ -45,6 +45,15 @@ export interface KpiCellProps {
   delta?: KpiCellDelta
   /** Optional id reference forwarded to the host listitem. */
   id?: string
+  /** Drop the cell-level surface (background + border + radius). Use when
+   *  an outer strip already owns the surface and the cells should look
+   *  like flat columns inside it. `live` styling is also suppressed
+   *  in bare mode because the live ring assumes a cell-level border. */
+  bare?: boolean
+  /** Optional `data-testid` forwarded to the host listitem. Lets call
+   *  sites preserve existing test selectors when swapping in from
+   *  hand-rolled cells. */
+  testId?: string
 }
 
 /** Assemble the screen-reader announcement for one KPI cell.
@@ -97,14 +106,19 @@ export function KpiCell(props: KpiCellProps): VNode {
   const labelColor = 'var(--color-fg-disabled)'
   const captionColor = 'var(--color-fg-muted)'
 
+  const bare = props.bare === true
   const containerStyle = {
-    ...surfaceStyle,
-    ...(props.live ? liveOverrideStyle : {}),
+    ...(bare ? {} : surfaceStyle),
+    ...(!bare && props.live ? liveOverrideStyle : {}),
     display: 'flex',
     flexDirection: variant === 'compact' ? ('row' as const) : ('column' as const),
     alignItems: variant === 'compact' ? ('baseline' as const) : ('flex-start' as const),
     gap: variant === 'compact' ? 'var(--spacing-element)' : variant === 'stacked' ? '4px' : '6px',
-    padding: variant === 'stacked' ? `14px var(--spacing-card)` : `10px var(--spacing-group)`,
+    padding: bare
+      ? '0'
+      : variant === 'stacked'
+        ? `14px var(--spacing-card)`
+        : `10px var(--spacing-group)`,
     fontFamily: MONO_STACK,
     minWidth: '0',
   }
@@ -157,6 +171,7 @@ export function KpiCell(props: KpiCellProps): VNode {
     <div
       role="listitem"
       id=${props.id}
+      data-testid=${props.testId}
       aria-label=${kpiCellAriaLabel(props)}
       style=${containerStyle}
     >

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -12,6 +12,7 @@ import { useMemo } from 'preact/hooks'
 import { TimeAgo } from '../common/time-ago'
 import { StatusDot } from '../common/status-dot'
 import { RouteLink } from '../common/route-link'
+import { KpiCell, type KpiCellKind } from '../kpi-cell'
 import { AgentAvatar } from './agent-avatar'
 import { missionSnapshot } from '../../mission-store'
 import { tasks, keepers } from '../../store'
@@ -81,25 +82,6 @@ export function computeFunnelCounts(
   return { created, inProgress, awaiting, completed, target }
 }
 
-function FunnelCell({
-  label,
-  value,
-  toneClass,
-  testId,
-}: {
-  label: string
-  value: string
-  toneClass?: string
-  testId?: string
-}) {
-  return html`
-    <div class="flex flex-col gap-1 min-w-0" data-testid=${testId}>
-      <span class="text-2xs uppercase tracking-wider text-[var(--color-fg-muted)]">${label}</span>
-      <span class=${`text-2xl font-semibold tabular-nums ${toneClass ?? 'text-[var(--color-fg-secondary)]'}`}>${value}</span>
-    </div>
-  `
-}
-
 export function formatTargetRatio(counts: FunnelCounts): string {
   if (counts.target === null) return String(counts.completed)
   const pct = Math.min(100, Math.round((counts.completed / counts.target) * 100))
@@ -107,19 +89,23 @@ export function formatTargetRatio(counts: FunnelCounts): string {
 }
 
 function FunnelCard({ counts }: { counts: FunnelCounts }) {
-  const awaitingTone = counts.awaiting > 0 ? 'text-[var(--color-status-warn)]' : undefined
+  const awaitingKind: KpiCellKind | undefined = counts.awaiting > 0 ? 'warn' : undefined
   return html`
     <section class=${CARD} aria-label="오늘 상황" data-testid="overview-funnel">
       <header class="flex items-center justify-between mb-3">
         <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)]">오늘 상황</h2>
         <span class="text-2xs text-[var(--color-fg-muted)]">task 기준</span>
       </header>
-      <div class="grid grid-cols-5 gap-4 max-[640px]:grid-cols-3 max-[640px]:gap-y-4">
-        <${FunnelCell} label="신규" value=${String(counts.created)} testId="funnel-created" />
-        <${FunnelCell} label="진행" value=${String(counts.inProgress)} testId="funnel-in-progress" />
-        <${FunnelCell} label="검증 대기" value=${String(counts.awaiting)} toneClass=${awaitingTone} testId="funnel-awaiting" />
-        <${FunnelCell} label="완료" value=${String(counts.completed)} toneClass="text-[var(--color-status-ok)]" testId="funnel-completed" />
-        <${FunnelCell} label="목표" value=${formatTargetRatio(counts)} testId="funnel-target" />
+      <div
+        role="list"
+        aria-label="오늘 funnel"
+        class="grid grid-cols-5 gap-4 max-[640px]:grid-cols-3 max-[640px]:gap-y-4"
+      >
+        <${KpiCell} bare variant="stacked" label="신규" value=${String(counts.created)} testId="funnel-created" />
+        <${KpiCell} bare variant="stacked" label="진행" value=${String(counts.inProgress)} testId="funnel-in-progress" />
+        <${KpiCell} bare variant="stacked" label="검증 대기" value=${String(counts.awaiting)} kind=${awaitingKind} testId="funnel-awaiting" />
+        <${KpiCell} bare variant="stacked" label="완료" value=${String(counts.completed)} kind="ok" testId="funnel-completed" />
+        <${KpiCell} bare variant="stacked" label="목표" value=${formatTargetRatio(counts)} testId="funnel-target" />
       </div>
     </section>
   `


### PR DESCRIPTION
## Why

cb-group-a 프리미티브 시리즈(#11066 KpiCell · #11070 LifelineBar · #11088 TickerItem)와 cb-group-b 시리즈(#11106 SwimlaneRow · #11108 KanbanCard · #11109 SidebarRow)가 `dashboard/src/components/`에 포팅됐고 #11102 spacing/font 토큰 sweep + #11113 brass 토큰 정합까지 정리됐습니다.

**다만 검증 결과** — `dashboard/src/`에서 새 primitive 6종을 import하는 코드가 **0건**. 컴포넌트 라이브러리만 확장된 상태로 SPEC 정합 개선이 운영자 화면에 도달하지 않은 상태입니다 (KeeperBadge만 자연 채택됨).

이 PR은 **첫 적용 cycle** — `overview/overview.ts`의 FunnelCard (5칸 task 카운터: 신규/진행/검증 대기/완료/목표)를 손-구현 `FunnelCell`에서 `KpiCell` 로 교체합니다.

## What

### KpiCell (`dashboard/src/components/kpi-cell.ts`) — 두 prop 추가 (additive only)

| prop | 의도 | 효과 |
|------|------|------|
| `bare?: boolean` | cell-level surface 끄기 | `bg-panel + border + radius` 안 그림, `live` ring도 함께 suppress (cell-level border 가정 깨지므로) |
| `testId?: string` | `data-testid` forward | swap 시 기존 test selector 보존 |

`bare` 가 필요한 이유: FunnelCard는 이미 `<section class=${CARD}>` 가 outer surface. 그 안에 KpiCell의 cell-level surface가 들어가면 *5개 mini card in 1 outer card* 형태로 시각적 double-surface. `bare` mode로 KpiCell이 합성 컨텍스트에 surface 책임을 양보합니다.

기본값 둘 다 off → 기존 호출부/test 영향 0.

### overview.ts swap

| 기존 FunnelCell prop | KpiCell prop | 변환 |
|---|---|---|
| `label="신규"` | `label="신규"` | 그대로 |
| `value="3"` | `value="3"` | 그대로 |
| `toneClass="text-[var(--color-status-ok)]"` | `kind="ok"` | string → enum |
| `toneClass="text-[var(--color-status-warn)]"` | `kind="warn"` | string → enum |
| `toneClass=undefined` | (neutral) | 기본값 |
| `testId="funnel-completed"` | `testId="funnel-completed"` | 그대로 |
| (없음) | `variant="stacked"` + `bare` | 24px tabular-nums col-flow + outer surface 위임 |

추가로 grid container에 `role="list"` + `aria-label="오늘 funnel"` 부여 — KpiCell의 `role="listitem"` 과 짝 맞춰 screen reader semantic이 *primitive swap의 side effect로* 자연 개선됩니다.

`FunnelCell` 함수 (unexported, 외부 caller 0)는 완전 제거.

## Verification

```
pnpm exec tsc --noEmit                          # clean
pnpm exec vitest run kpi-cell overview          # 4 files / 124 cases pass
```

`overview.test.ts` 가 *pure helper* (`computeFunnelCounts`, `formatTargetRatio`, `pickActiveSession`, `progressPct`, `pickActiveKeepers`, `severityToneClass`) 만 검증하는 구조라 DOM selector / data-testid 의존이 0이고, swap이 *regression-safe by construction*.

## What this PR does NOT do

- 다른 primitive (LifelineBar/TickerItem/SwimlaneRow/KanbanCard/SidebarRow) 적용 — 별도 cycle.
- KpiCell SPEC variant 추가 (예: `live` + `bare` 결합 ring) — 현재 케이스 불필요. 후속 적용에서 needed면 추가.
- Visual screenshot 회귀 — Playwright 작업은 별도 task.

## Refs

- cb-group-a primitives: #11066 #11070 #11088
- cb-group-b primitives: #11106 #11108 #11109
- token sweep: #11102 #11113
- design-system v0.4 SPEC: cell typography/tone, strip surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)