### PR TITLE
fix(scripts): resolve log path via lsof on running server, eliminate $HOME drift

### DIFF
--- a/scripts/lib/masc-log-path.sh
+++ b/scripts/lib/masc-log-path.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# masc-log-path.sh - SSOT helper for resolving the active MASC server's
+# structured log file path.
+#
+# Resolution order (deterministic-first, hardcode-last):
+#   1. $MASC_LOG       - explicit override, used as-is.
+#   2. running server  - lsof on the listening socket detects the actual
+#                        log file the server has open. Authoritative when
+#                        the server is running, regardless of how it was
+#                        started (argv --base-path, env, or anything else).
+#   3. $MASC_BASE_PATH - env-provided base path; <base>/.masc/logs/system_log_TODAY.jsonl
+#   4. $HOME/me        - second-brain default, only as last fallback.
+#
+# Sourced by scripts/logs-follow.sh and scripts/op-f-leak-verification.sh.
+#
+# Functions provided:
+#   masc_log_path        - echo today's resolved log path.
+#   masc_log_resolve_base - echo the resolved base path (without /.masc/logs/...).
+
+masc_log_resolve_base() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    echo "$MASC_BASE_PATH"
+    return 0
+  fi
+  echo "${HOME}/me"
+}
+
+# Detect the log file currently held open by the running MASC server.
+# Echoes the path on success, prints nothing and returns non-zero if
+# detection fails.
+_masc_log_detect_from_running_server() {
+  local port="${MASC_PORT:-8935}"
+  local pid
+  pid=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | head -1)
+  if [ -z "$pid" ]; then
+    return 1
+  fi
+  local detected
+  detected=$(lsof -p "$pid" 2>/dev/null \
+    | awk '/system_log_[0-9-]+\.jsonl/ {print $NF; exit}')
+  if [ -z "$detected" ]; then
+    return 1
+  fi
+  echo "$detected"
+}
+
+masc_log_path() {
+  if [ -n "${MASC_LOG:-}" ]; then
+    echo "$MASC_LOG"
+    return 0
+  fi
+
+  local detected
+  if detected=$(_masc_log_detect_from_running_server); then
+    echo "$detected"
+    return 0
+  fi
+
+  local base
+  base=$(masc_log_resolve_base)
+  echo "${base}/.masc/logs/system_log_$(date +%Y-%m-%d).jsonl"
+}
+
+# Echo the directory containing today's log file.
+# Same resolution order as masc_log_path; dirname of the result.
+masc_log_dir() {
+  dirname "$(masc_log_path)"
+}

--- a/scripts/logs-follow.sh
+++ b/scripts/logs-follow.sh
@@ -21,7 +21,9 @@ Follow MASC structured server logs from <base-path>/.masc/logs/system_log_YYYY-M
 If you pass a repo or worktree path, the script resolves it to the owning repo root automatically.
 
 Options:
-  --base-path <path>    Override MASC base path (default: MASC_BASE_PATH or HOME)
+  --base-path <path>    Override MASC base path (default: detected via lsof
+                        from the running server; falls back to MASC_BASE_PATH
+                        or $HOME/me when no server is running)
   --date <YYYY-MM-DD>   Read a specific log file instead of today's rotating file
   --lines <n>           Tail last N lines before following (default: 40, use 0 for only new lines)
   --level <level>       Minimum level: debug|info|warn|error (default: debug)
@@ -185,9 +187,22 @@ require_cmd jq
 require_cmd tail
 validate_args
 
-BASE_PATH_INPUT="${BASE_PATH_OVERRIDE:-${MASC_BASE_PATH:-${HOME:-$REPO_ROOT}}}"
-BASE_PATH="$(resolve_base_path "$BASE_PATH_INPUT")"
-LOG_DIR="$BASE_PATH/.masc/logs"
+# Resolution order for the log directory (deterministic-first):
+#   1. --base-path override          (user-provided path, run through worktree-aware resolver)
+#   2. helper masc_log_dir           (detects via lsof on the running server when available;
+#                                     falls back to MASC_BASE_PATH or $HOME/me)
+# This avoids the historical drift where logs-follow defaulted to $HOME
+# while the server actually wrote under <base>/.masc/logs/, leaving
+# operators staring at an empty directory.
+if [ -n "$BASE_PATH_OVERRIDE" ]; then
+  BASE_PATH="$(resolve_base_path "$BASE_PATH_OVERRIDE")"
+  LOG_DIR="$BASE_PATH/.masc/logs"
+else
+  # shellcheck disable=SC1091
+  . "$SCRIPT_DIR/lib/masc-log-path.sh"
+  LOG_DIR="$(masc_log_dir)"
+  BASE_PATH="$(dirname "$(dirname "$LOG_DIR")")"
+fi
 
 jq_filter='
   def rank:

--- a/scripts/op-f-leak-verification.sh
+++ b/scripts/op-f-leak-verification.sh
@@ -7,10 +7,12 @@
 # observed window.
 #
 # Designed to be re-runnable: each criterion is a single grep against a
-# JSONL log produced by the masc-mcp server (default
-# ~/.masc/logs/system_log_<YYYY-MM-DD>.jsonl).  No state is kept
-# between runs — re-execute after any merge or restart to refresh the
-# snapshot.
+# JSONL log produced by the masc-mcp server.  The log path is resolved
+# via scripts/lib/masc-log-path.sh, which detects the active file from
+# the running server (lsof on the listening socket) and falls back to
+# $MASC_BASE_PATH or $HOME/me when no server is running.  No state is
+# kept between runs — re-execute after any merge or restart to refresh
+# the snapshot.
 #
 # Origin: 2026-04-25 keeper docker git_clone E2E investigation
 # (memory/procedural-memory/2026-04-25-keeper-docker-clone-end-to-end-evidence-record.md).

--- a/scripts/op-f-leak-verification.sh
+++ b/scripts/op-f-leak-verification.sh
@@ -23,13 +23,15 @@
 
 set -u
 
-# Default log path follows MASC_BASE_PATH (the server's --base-path
-# argument).  Falls back to ~/me which is the second-brain layout that
-# masc-mcp ships with, so the script "just works" for the common
-# operator on a fresh checkout.  Override with $1 or $MASC_LOG when the
-# log lives elsewhere (e.g. /tmp/masc-postmerge.log).
-DEFAULT_BASE="${MASC_BASE_PATH:-${HOME}/me}"
-LOG="${1:-${MASC_LOG:-${DEFAULT_BASE}/.masc/logs/system_log_$(date +%Y-%m-%d).jsonl}}"
+# Resolve the active log path through the SSOT helper.  When the server
+# is running, this detects the actual file via lsof on the listening
+# socket — authoritative regardless of how the server was started.
+# Otherwise falls back to MASC_BASE_PATH or $HOME/me.  Override with $1
+# or $MASC_LOG when the log lives elsewhere (e.g. /tmp/masc-postmerge.log).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/lib/masc-log-path.sh"
+LOG="${1:-$(masc_log_path)}"
 
 if [ ! -r "${LOG}" ]; then
   echo "error: cannot read log file: ${LOG}" >&2


### PR DESCRIPTION
## Summary

The server writes structured logs to `<base-path>/.masc/logs/` where `<base-path>` is set by `--base-path` on the command line. Two operator scripts (`logs-follow.sh`, `op-f-leak-verification.sh`) were guessing the base path from `\$MASC_BASE_PATH` or falling back to `\$HOME` (logs-follow) or `\$HOME/me` (op-f). When the server was launched with an explicit `--base-path` argv and neither env was set, the operator scripts watched the wrong directory and silently saw nothing.

**Real-world cost**: 30-minute OP-F watch yesterday emitted `[no log file yet]` for all 60 ticks while the server was correctly writing 2.3MB of structured events to a different absolute path. That measurement window was useless, and several downstream conclusions (\"PR-M wiring fail?\", \"system_log infrastructure drift?\") were built on the false premise.

## Fix

Add `scripts/lib/masc-log-path.sh` as the SSOT for resolving the active log file. Resolution order (deterministic-first):

| # | Source | Authority |
|---|--------|-----------|
| 1 | `\$MASC_LOG` | explicit override |
| 2 | `lsof` on listening socket | the actual file the running server has open — works regardless of argv vs env |
| 3 | `\$MASC_BASE_PATH` | env-provided base path |
| 4 | `\$HOME/me` | last-resort fallback (Second Brain layout) |

Both consumer scripts now source the helper and stop guessing. `logs-follow.sh` preserves the `--base-path` override semantics; only the default fallback is delegated.

## Why \`lsof\` over a sentinel file

- **No server-side change required.** A health endpoint or sentinel file would force a binary update + careful upgrade ordering.
- **Authoritative for *any* base path**, including ad-hoc runs (`/tmp/foo`).
- **Process-tied invariant**: stale sentinel files survive a crash; `lsof` cannot lie about open fds.

When the server is not running, falls through to env/hardcode — at that point hardcode is the only signal available, and it is clearly labeled as fallback rather than primary.

## Smoke

Verified against the live server (PID 43409, port 8935):

\`\`\`
masc_log_path  : /Users/dancer/me/.masc/logs/system_log_2026-04-27.jsonl
masc_log_dir   : /Users/dancer/me/.masc/logs

# port override → no detection → falls through to MASC_BASE_PATH:
MASC_PORT=9999 ... → /Users/dancer/me/.masc/logs/system_log_2026-04-27.jsonl

# fake HOME with no MASC_BASE_PATH → last fallback:
HOME=/tmp/fakehome ... → /tmp/fakehome/me/.masc/logs/system_log_2026-04-27.jsonl
\`\`\`

Running \`scripts/op-f-leak-verification.sh\` now reads the correct 2.4MB file (7278 lines) and returns real PASS/FAIL on each criterion instead of \"cannot read log file\".

## Files

- `scripts/lib/masc-log-path.sh` (new, sourced helper)
- `scripts/logs-follow.sh` (default fallback delegated; \`--base-path\` override semantics preserved)
- `scripts/op-f-leak-verification.sh` (default fallback delegated; \`\$1\` and \`\$MASC_LOG\` overrides preserved)

## Test plan

- [x] `bash -n` syntax check on all three files
- [x] Smoke detection against running server (lsof path matches what the server has open)
- [x] Fallback against non-existent port (env path)
- [x] Fallback with empty `\$MASC_BASE_PATH` (`\$HOME/me` path)
- [ ] CI lint + build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)