### PR TITLE
feat(dashboard): adopt KpiCell in feature-health overview

### DIFF
--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -11,7 +11,7 @@ import { Card } from './common/card'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { SectionCap } from './common/section-cap'
-import { StatCard } from './common/stat-card'
+import { KpiCell } from './kpi-cell'
 
 type FeatureStatus = 'healthy' | 'warning' | 'inactive' | 'deprecated'
 type StatusFilter = FeatureStatus | 'all'
@@ -227,13 +227,17 @@ export function FeatureHealth() {
                     >새로고침</button>
                   </div>
 
-                  <div class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
-                    <${StatCard} label="총 기능" value=${overview.total_features} />
-                    <${StatCard} label="활성화" value=${overview.enabled_count} />
-                    <${StatCard} label="정상" value=${overview.healthy_count} />
-                    <${StatCard} label="실험적" value=${overview.warning_count} />
-                    <${StatCard} label="비활성" value=${overview.inactive_count} />
-                    <${StatCard} label="폐기 예정" value=${overview.deprecated_count} />
+                  <div
+                    role="list"
+                    aria-label="기능 상태 요약"
+                    class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6"
+                  >
+                    <${KpiCell} bare variant="stacked" label="총 기능" value=${overview.total_features} />
+                    <${KpiCell} bare variant="stacked" label="활성화" value=${overview.enabled_count} />
+                    <${KpiCell} bare variant="stacked" label="정상" value=${overview.healthy_count} kind="ok" />
+                    <${KpiCell} bare variant="stacked" label="실험적" value=${overview.warning_count} kind="warn" />
+                    <${KpiCell} bare variant="stacked" label="비활성" value=${overview.inactive_count} />
+                    <${KpiCell} bare variant="stacked" label="폐기 예정" value=${overview.deprecated_count} kind="err" />
                   </div>
 
                   <div class="mt-4 text-xs text-[var(--color-fg-disabled)]">


### PR DESCRIPTION
## Why

#11116 (overview Funnel)에 이은 **두 번째 KpiCell 적용**. feature-health 페이지의 overview card 안 6칸 stat strip (총 기능 / 활성화 / 정상 / 실험적 / 비활성 / 폐기 예정) 을 손-구현 \`common/stat-card.ts\` → \`KpiCell\` 로 마이그레이션.

기존 \`StatCard\`의 두 가지 SPEC drift:

1. **value 색이 \`--color-accent-fg\` 로 고정** — 이 토큰은 dashboard에서 cyan (#47b8ff) 으로 resolve되지만 design-system v0.4 의도는 brass/SPEC tone. #11113 brass alignment와 같은 drift 패턴.
2. **모든 cell이 동일 색** — 같은 페이지의 \`statusChipClass\` (ok/warn/inactive/err) 가 이미 의미별 tone을 갖고 있는데, 그 옆 strip은 *flat*. 의미가 색에 매핑 안 됨.

## What

\`StatCard\` 6 호출을 \`KpiCell\` 로 교체하면서 의미별 tone 매핑:

| label | KpiCell kind | 근거 |
|---|---|---|
| 총 기능 | (neutral) | total — 판단 없음 |
| 활성화 | (neutral) | enabled count — 판단 없음 |
| 정상 | \`ok\` | \`statusChipClass.healthy\` 일치 |
| 실험적 | \`warn\` | \`statusChipClass.warning\` 일치 |
| 비활성 | (neutral) | \`statusChipClass.inactive\` 일치 |
| 폐기 예정 | \`err\` | \`statusChipClass.deprecated\` 일치 |

\`bare\` + \`variant=\"stacked\"\` 사용 — 외부 overview card가 surface를 책임지므로 cell-level surface 끄기 (#11116과 동일 패턴). grid container에 \`role=\"list\"\` + \`aria-label=\"기능 상태 요약\"\` 추가 → KpiCell의 \`role=\"listitem\"\` 과 페어링하여 screen reader semantic 자연 개선.

## Verification

\`\`\`
pnpm exec tsc --noEmit                          # clean
pnpm exec vitest run feature-health kpi-cell    # 2 files / 35 cases pass
\`\`\`

\`feature-health.test.ts\`는 pure helper 만 검증 (\`featureMatchesSearch\` / \`featureMatchesStatus\` / \`filterFeatures\`) — DOM/StatCard selector 의존 0이라 swap이 *regression-safe by construction*.

## What this PR does NOT do

- \`common/stat-card.ts\` 자체 제거 — \`harness-health.ts\` 가 8 callsites 보유. 별도 cycle에서 마이그레이션.
- \`harness-health.ts\` 동시 swap — PR 범위를 좁게 유지.
- Visual regression test (Playwright) — 별도 task.

## Refs

- First adoption: #11116 (overview funnel)
- cb-group-a primitive: #11066 (KpiCell)
- Brass/cyan drift class: #11113

🤖 Generated with [Claude Code](https://claude.com/claude-code)