### PR TITLE
chore(mcp): drop deprecated prompt stubs (execution_session_proof, command_truth)

### DIFF
--- a/lib/mcp_prompt_surface.ml
+++ b/lib/mcp_prompt_surface.ml
@@ -1,4 +1,4 @@
-(** MCP prompt surface for canonical help and proof views. *)
+(** MCP prompt surface for canonical help. *)
 
 type prompt_argument = {
   name : string;
@@ -25,28 +25,6 @@ let prompt_defs =
         [
           { name = "tool_name"; description = "Exact MCP tool name"; required = true };
           { name = "focus"; description = "Optional question or emphasis"; required = false };
-        ];
-    };
-    {
-      name = "execution_session_proof";
-      title = "Execution Session Proof";
-      description = "Summarize auditable collaboration evidence for an execution session (deprecated: team session layer removed).";
-      icons = [ Mcp_server.themed_icon ~label:"TP" ~bg:"#7C3AED" ~fg:"#F5F3FF" ];
-      arguments =
-        [
-          { name = "session_id"; description = "Team session identifier"; required = true };
-          { name = "operation_id"; description = "Optional managed operation identifier"; required = false };
-        ];
-    };
-    {
-      name = "command_truth";
-      title = "Command Truth";
-      description = "Summarize managed command-plane evidence for an operation or run (deprecated: command plane layer removed).";
-      icons = [ Mcp_server.themed_icon ~label:"CT" ~bg:"#9A3412" ~fg:"#FFF7ED" ];
-      arguments =
-        [
-          { name = "operation_id"; description = "Managed operation or trace identifier"; required = false };
-          { name = "run_id"; description = "Optional swarm-live run identifier"; required = false };
         ];
     };
   ]
@@ -83,31 +61,6 @@ let assoc_string args key =
       let trimmed = String.trim value in
       if trimmed = "" then None else Some trimmed
   | _ -> None
-
-let string_contains = Dashboard_utils.string_contains
-let string_contains_ci = Dashboard_utils.string_contains_ci
-
-let run_tokens run_id =
-  let safe = Coord_utils.safe_filename run_id |> String.lowercase_ascii in
-  [ run_id; safe; "run_id=" ^ run_id; "run_id=" ^ safe; "swarm-live:" ^ run_id; "swarm-live:" ^ safe ]
-
-let rec json_contains_run_tokens tokens = function
-  | `String value -> List.exists (fun token -> string_contains_ci ~needle:token value) tokens
-  | `Assoc fields -> List.exists (fun (_, value) -> json_contains_run_tokens tokens value) fields
-  | `List items -> List.exists (json_contains_run_tokens tokens) items
-  | _ -> false
-
-let filter_traces_json_by_run_id run_id = function
-  | `Assoc fields as json -> (
-      match List.assoc_opt "events" fields with
-      | Some (`List events) ->
-          let filtered =
-            events
-            |> List.filter (json_contains_run_tokens (run_tokens run_id))
-          in
-          `Assoc (("events", `List filtered) :: List.remove_assoc "events" fields)
-      | _ -> json)
-  | json -> json
 
 let message_json text =
   `Assoc
@@ -150,51 +103,7 @@ let tool_help_text ~tool_name ~focus schemas =
            @
            (if entry.doc_refs = [] then [] else "" :: "Docs:" :: List.map (fun item -> "- " ^ item) entry.doc_refs)))
 
-let execution_session_proof_text ~config:_ ~session_id ~operation_id:_ =
-  (* Dashboard_proof removed *)
-  String.concat "\n"
-    [
-      "Execution session proof is not available (execution session layer removed).";
-      Printf.sprintf "Session: %s" session_id;
-    ]
-
-let command_truth_text ~config:_ ?operation_id ?run_id () =
-  let summary_json =
-    match run_id with
-    | Some value ->
-        `Assoc
-          [
-            ("scope", `String "run");
-            ("run_id", `String value);
-            ("operation_id", Json_util.string_opt_to_json operation_id);
-            ("traces_filtered", `Bool true);
-          ]
-    | None -> `Assoc []
-  in
-  let summary = summary_json |> Yojson.Safe.pretty_to_string in
-  let _ = operation_id in
-  let traces_json = `Assoc [("events", `List [])] in
-  let traces =
-    (match run_id with
-    | Some value -> filter_traces_json_by_run_id value traces_json
-    | None -> traces_json)
-    |> Yojson.Safe.pretty_to_string
-  in
-  String.concat "\n"
-    [
-      "Command plane evidence is not available (command plane layer removed).";
-      "The summary and traces below reflect the stub state retained for";
-      "backward compatibility with pre-purge MCP clients; they carry no live data.";
-      (match run_id with Some value -> "Focus run_id: " ^ value | None -> "");
-      "";
-      "Summary:";
-      summary;
-      "";
-      "Recent traces:";
-      traces;
-    ]
-
-let get_json ~config ~name ~arguments schemas =
+let get_json ~config:_ ~name ~arguments schemas =
   match lookup name with
   | None -> Error (Printf.sprintf "unknown prompt: %s" name)
   | Some prompt -> (
@@ -206,16 +115,6 @@ let get_json ~config ~name ~arguments schemas =
                 let focus = assoc_string arguments "focus" in
                 tool_help_text ~tool_name ~focus schemas
             | None -> Error "tool_name is required")
-        | "execution_session_proof" -> (
-            match assoc_string arguments "session_id" with
-            | Some session_id ->
-                let operation_id = assoc_string arguments "operation_id" in
-                Ok (execution_session_proof_text ~config ~session_id ~operation_id)
-            | None -> Error "session_id is required")
-        | "command_truth" ->
-            let operation_id = assoc_string arguments "operation_id" in
-            let run_id = assoc_string arguments "run_id" in
-            Ok (command_truth_text ~config ?operation_id ?run_id ())
         | _ -> Error (Printf.sprintf "unsupported prompt: %s" name)
       in
       match text_result with

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -72,12 +72,6 @@ let help_doc_refs name =
 let help_prompt_hints name =
   if String.equal name "masc_tool_help" then
     [ "Use prompt 'tool_help' when the caller needs a guided explanation." ]
-  else if
-    String.starts_with ~prefix:"masc_operation_" name
-    || String.starts_with ~prefix:"masc_dispatch_" name
-    || String.starts_with ~prefix:"masc_observe_" name
-  then
-    [ "Use prompt 'command_truth' for managed execution evidence." ]
   else
     []
 
@@ -157,7 +151,7 @@ let manual_help_entry name =
               "docs/COMMAND-PLANE-RUNBOOK.md";
               "docs/BENCHMARK-RUNBOOK.md";
             ];
-          prompt_hints = [ "Use prompt 'command_truth' to inspect resulting execution evidence." ];
+          prompt_hints = [];
         }
   | "masc_tool_admin_snapshot" ->
       Some

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -2542,7 +2542,7 @@ let test_handle_request_prompts_list_non_empty () =
     | _ -> Alcotest.fail "response not an object"
   in
   Alcotest.(check bool) "prompt inventory is non-empty" true
-    (List.length prompts >= 3);
+    (List.length prompts >= 1);
   cleanup_dir base_path
 
 let test_handle_request_prompts_list_cursor () =
@@ -2575,7 +2575,7 @@ let test_handle_request_prompts_list_cursor () =
         | _ -> Alcotest.fail "result not an object")
     | _ -> Alcotest.fail "response not an object"
   in
-  Alcotest.(check int) "cursor trims first prompt" 2 (List.length prompts);
+  Alcotest.(check int) "cursor trims first prompt" 0 (List.length prompts);
   cleanup_dir base_path
 
 let test_handle_request_prompts_get_tool_help () =


### PR DESCRIPTION
## Summary

Two MCP prompts have been stubbed out to return `"not available (layer removed)"` text since the `team_session` module purge (#7984) and command-plane retirement (#8559). They returned no live data, yet `Tool_help_registry` still actively directed callers to `command_truth` for managed `masc_operation_*` / `masc_dispatch_*` / `masc_observe_*` tools — surfacing a prompt that just announces its own removal. Misleading UX, dead code.

This PR finishes the retirement that was started over a quarter ago. After this:
- MCP prompt inventory shrinks from 3 → 1 (`tool_help` only).
- `Tool_help_registry.help_prompt_hints` no longer hands out broken pointers.
- Auxiliary helpers (`run_tokens`, `json_contains_run_tokens`, `filter_traces_json_by_run_id`, the `swarm-live:` token mangling, and `Dashboard_utils.string_contains*` re-exports) are removed — they were only consumed by `command_truth_text`.

`team_session` and `swarm` legacy terms still survive elsewhere (e.g. `lib/dashboard/dashboard_execution_*` `command_surface = "swarm"` label, `lib/exec/exec_gate.ml` `swarm/goal_loop` route, fixture text); those are scoped intentionally to follow-ups since they touch active surfaces. This PR keeps to dead-code prompt removal only.

## Changes

- `lib/mcp_prompt_surface.ml` (-83 lines): remove `execution_session_proof` and `command_truth` prompt definitions and their stub renderers + run-id token helpers.
- `lib/tool_help_registry.ml` (-7 lines): drop two `command_truth` prompt_hints — one in `help_prompt_hints` (operation/dispatch/observe prefix branch), one in the `masc_operation_start` manual entry.
- `test/test_mcp_server_eio.ml`: update count assertions for the slimmer prompt inventory (`>=3 → >=1`; cursor-trim `2 → 0`).

## Test plan

- [x] `dune build --profile=release @install` — clean
- [x] `dune build @check` — clean
- [x] `_build/default/test/test_mcp_server_eio.exe test eio 6` (`prompts/list non-empty`) — pass
- [x] `_build/default/test/test_mcp_server_eio.exe test eio 7` (`prompts/list cursor`) — pass
- [x] `_build/default/test/test_mcp_server_eio.exe test eio 8` (`prompts/get tool_help`) — pass
- [ ] Required CI checks (Build, Lint, etc.) — to verify on PR

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)