### PR TITLE
feat(dashboard): add KpiStrip composite (cb-group-a SPEC alignment)

### DIFF
--- a/dashboard/src/components/kpi-strip.test.ts
+++ b/dashboard/src/components/kpi-strip.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { KpiStrip, resolveStripCols } from './kpi-strip'
+import { KpiCell } from './kpi-cell'
+
+describe('resolveStripCols (pure)', () => {
+  it('maps the SPEC variant cardinality table', () => {
+    expect(resolveStripCols('standard', undefined)).toBe(6)
+    expect(resolveStripCols('compact', undefined)).toBe(6)
+    expect(resolveStripCols('stacked', undefined)).toBe(3)
+  })
+
+  it('defaults missing variant to standard (6 cols)', () => {
+    expect(resolveStripCols(undefined, undefined)).toBe(6)
+  })
+
+  it('lets a positive override win over the SPEC default', () => {
+    expect(resolveStripCols('standard', 5)).toBe(5)
+    expect(resolveStripCols('stacked', 4)).toBe(4)
+  })
+
+  it('falls back to the SPEC default when override is non-positive', () => {
+    expect(resolveStripCols('standard', 0)).toBe(6)
+    expect(resolveStripCols('compact', -1)).toBe(6)
+  })
+})
+
+describe('KpiStrip component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  function mount(node: ReturnType<typeof html>): HTMLElement {
+    render(node, container)
+    return container.querySelector('[role="list"]') as HTMLElement
+  }
+
+  it('renders role=list with the supplied aria-label', () => {
+    const el = mount(html`
+      <${KpiStrip} ariaLabel="Fleet KPI strip">
+        <${KpiCell} label="A" value="1" />
+      <//>
+    `)
+    expect(el.getAttribute('role')).toBe('list')
+    expect(el.getAttribute('aria-label')).toBe('Fleet KPI strip')
+  })
+
+  it('paints the SPEC strip surface (gap=1px hairline + bottom border)', () => {
+    const el = mount(html`
+      <${KpiStrip} ariaLabel="t">
+        <${KpiCell} label="A" value="1" />
+      <//>
+    `)
+    expect(el.style.display).toBe('grid')
+    expect(el.style.gap).toBe('1px')
+    // The 1px gap is shown as a hairline because the strip's
+    // background bleeds through; cell surfaces sit on top.
+    expect(el.style.background).toContain('--color-border-default')
+    expect(el.style.borderBottom).toContain('--color-border-strong')
+  })
+
+  it('uses 6 cols for variant=standard', () => {
+    const el = mount(html`
+      <${KpiStrip} ariaLabel="t" variant="standard">
+        <${KpiCell} label="A" value="1" />
+      <//>
+    `)
+    expect(el.getAttribute('data-cols')).toBe('6')
+    expect(el.style.gridTemplateColumns).toContain('repeat(6')
+  })
+
+  it('uses 3 cols for variant=stacked', () => {
+    const el = mount(html`
+      <${KpiStrip} ariaLabel="t" variant="stacked">
+        <${KpiCell} label="A" value="1" />
+      <//>
+    `)
+    expect(el.getAttribute('data-cols')).toBe('3')
+    expect(el.style.gridTemplateColumns).toContain('repeat(3')
+  })
+
+  it('honors a numeric cols override (e.g. 5-cell funnel)', () => {
+    const el = mount(html`
+      <${KpiStrip} ariaLabel="t" cols=${5}>
+        <${KpiCell} label="A" value="1" />
+      <//>
+    `)
+    expect(el.getAttribute('data-cols')).toBe('5')
+    expect(el.style.gridTemplateColumns).toContain('repeat(5')
+  })
+
+  it('injects bare into KpiCell children that have no bare prop', () => {
+    mount(html`
+      <${KpiStrip} ariaLabel="t">
+        <${KpiCell} label="A" value="1" testId="cell-a" />
+      <//>
+    `)
+    const cell = container.querySelector('[data-testid="cell-a"]') as HTMLElement
+    // bare cells render no border (they sit on the strip's surface).
+    expect(cell.style.border ?? '').toBe('')
+    // padding=0 is the bare signature in kpi-cell.ts.
+    expect(cell.style.padding).toBe('0px')
+  })
+
+  it('preserves an explicit bare={false} override on a child', () => {
+    // Caller deliberately wants the cell to keep its own surface — the
+    // strip shouldn't override that.
+    mount(html`
+      <${KpiStrip} ariaLabel="t">
+        <${KpiCell} label="A" value="1" bare=${false} testId="cell-a" />
+      <//>
+    `)
+    const cell = container.querySelector('[data-testid="cell-a"]') as HTMLElement
+    // Non-bare cells paint the standard surface.
+    expect(cell.style.background).toContain('--bg-panel')
+    expect(cell.style.border).toContain('1px solid')
+  })
+
+  it('renders all KpiCell children in order', () => {
+    mount(html`
+      <${KpiStrip} ariaLabel="t">
+        <${KpiCell} label="A" value="1" testId="cell-a" />
+        <${KpiCell} label="B" value="2" testId="cell-b" />
+        <${KpiCell} label="C" value="3" testId="cell-c" />
+      <//>
+    `)
+    expect(container.querySelector('[data-testid="cell-a"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="cell-b"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="cell-c"]')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/kpi-strip.ts
+++ b/dashboard/src/components/kpi-strip.ts
@@ -1,0 +1,114 @@
+// KPI strip — composite container for a row of KpiCell tiles.
+//
+// Ports the design-system v0.4 cb-group-a `.cb-kpi` strip pattern
+// (preview/components.css lines 91-112). The strip owns the surface,
+// the cells are flat columns inside it:
+//
+//   .cb-kpi {
+//     display:grid; grid-template-columns: repeat(6, 1fr);
+//     gap:1px;                                  /* hairline divider */
+//     background: var(--color-border-default);  /* gap shows as 1px line */
+//     border-bottom:1px solid var(--color-border-strong);
+//   }
+//   .cb-kpi.stacked { grid-template-columns: 1fr 1fr 1fr; }
+//   .cb-kpi.compact .cell { min-height:36px; padding: 5px 8px; }
+//
+// SPEC variant cardinality:
+//   standard  — 6 cols, default density
+//   compact   — 6 cols, denser cells (callers tighten spacing themselves)
+//   stacked   — 3 cols, larger cells
+//
+// The variant decides the grid layout. KpiCell's own variant decides
+// the cell typography / spacing — they're independent axes named the
+// same. KpiStrip default-applies `bare` to its KpiCell children
+// because the strip itself draws the surface (background / hairline /
+// border-bottom); cells must not paint a second border.
+//
+// Callers can override the column count with `cols` when the data
+// length doesn't fit the SPEC default (e.g. 5-cell funnel, 4-cell
+// infra grid). Doing so is a deliberate dashboard-side variation,
+// not a SPEC variant.
+
+import { html } from 'htm/preact'
+import { cloneElement, toChildArray, type VNode, type ComponentChildren } from 'preact'
+
+export type KpiStripVariant = 'standard' | 'compact' | 'stacked'
+
+export interface KpiStripProps {
+  /** Strip layout variant. Drives the column count + density. */
+  variant?: KpiStripVariant
+  /** Override the column count when the data length doesn't match the
+   *  SPEC default for this variant. Use sparingly — most callers
+   *  should align their data to one of the SPEC cardinalities. */
+  cols?: number
+  /** Required for screen readers. The strip is `role="list"`, so the
+   *  label must announce the contents (e.g. "Fleet KPI strip"). */
+  ariaLabel: string
+  /** KpiCell children. The strip injects `bare` so cells render flat
+   *  inside the strip's grid; pre-existing `bare` on a child is
+   *  preserved (no override). */
+  children: ComponentChildren
+  /** Optional id reference forwarded to the strip container. */
+  id?: string
+  /** Extra Tailwind utility classes appended to the container. Kept
+   *  narrow so callers cannot reset the strip's surface tokens. */
+  class?: string
+}
+
+const COLS_BY_VARIANT: Record<KpiStripVariant, number> = {
+  standard: 6,
+  compact: 6,
+  stacked: 3,
+}
+
+/** Resolve the grid column count for a strip. Pure: exposed for tests
+ *  + for callers that compose their own grid wrapper but want SPEC
+ *  alignment with the strip cardinality table. */
+export function resolveStripCols(
+  variant: KpiStripVariant | undefined,
+  override: number | undefined,
+): number {
+  if (typeof override === 'number' && override > 0) return override
+  return COLS_BY_VARIANT[variant ?? 'standard']
+}
+
+/** Inject `bare` into a single KpiCell vnode. Preserves any prop the
+ *  caller already supplied — including a deliberate `bare={false}`. */
+function withBareDefault(child: VNode<Record<string, unknown>>): VNode {
+  const props = (child.props ?? {}) as Record<string, unknown>
+  if ('bare' in props) return child
+  return cloneElement(child, { bare: true })
+}
+
+export function KpiStrip(props: KpiStripProps): VNode {
+  const variant = props.variant ?? 'standard'
+  const cols = resolveStripCols(variant, props.cols)
+  const children = toChildArray(props.children)
+    .map((child) =>
+      child !== null && typeof child === 'object'
+        ? withBareDefault(child as VNode<Record<string, unknown>>)
+        : child,
+    )
+
+  const containerStyle = {
+    display: 'grid',
+    gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+    gap: '1px',
+    background: 'var(--color-border-default)',
+    borderBottom: '1px solid var(--color-border-strong)',
+  }
+
+  return html`
+    <div
+      role="list"
+      id=${props.id}
+      aria-label=${props.ariaLabel}
+      data-variant=${variant}
+      data-cols=${cols}
+      class=${props.class}
+      style=${containerStyle}
+    >
+      ${children}
+    </div>
+  `
+}


### PR DESCRIPTION
## Why

design-system v0.4 cb-group-a `.cb-kpi` SPEC (`preview/components.css` 91-112) 은 **strip이 surface 책임**:

\`\`\`css
.cb-kpi {
  display: grid; grid-template-columns: repeat(6, 1fr);
  gap: 1px;                                  /* hairline divider */
  background: var(--color-border-default);   /* bleeds through gap */
  border-bottom: 1px solid var(--color-border-strong);
}
.cb-kpi.stacked { grid-template-columns: 1fr 1fr 1fr; }
.cb-kpi.compact .cell { min-height: 36px; padding: 5px 8px; }
\`\`\`

`KpiCell` (#11066) 은 host strip 없이 standalone으로 포팅돼서 cell-level surface (border + bg)를 가짐. 첫 두 adoption (#11116 overview funnel, #11118 feature-health overview) 에서 \`bare\` prop을 도입해 *outer card 안에 들어갈 때* surface 끄는 workaround. **strip이 빠진 임시 fix**였음.

이 PR이 SPEC 패턴을 제자리에:

## What

\`KpiStrip\` 신규 컴포넌트 (\`dashboard/src/components/kpi-strip.ts\`):

| 책임 | 구현 |
|---|---|
| Grid + 1px hairline | \`display:grid\` + \`gap:1px\` + \`background:var(--color-border-default)\` |
| Bottom border | \`border-bottom:1px solid var(--color-border-strong)\` |
| Variant cardinality | \`standard:6\`, \`compact:6\`, \`stacked:3\` (SPEC) |
| Cols override | dashboard 데이터 (5-cell funnel 등) 가 SPEC와 안 맞을 때 |
| Bare 자동 주입 | 자식 KpiCell들에 \`cloneElement\` 로 \`bare:true\` 주입. 명시적 \`bare={false}\` 는 보존 |
| A11y | \`role=\"list\"\` + author-supplied \`aria-label\` |
| Debug hooks | \`data-variant\` + \`data-cols\` host attributes |

Pure helper \`resolveStripCols(variant, override)\` 노출 — 자체 grid wrapper 만드는 caller도 SPEC cardinality 표 동기화 가능.

## Test

\`\`\`
pnpm exec tsc --noEmit                          # clean
pnpm exec vitest run kpi-strip kpi-cell         # 2 files / 31 cases pass
\`\`\`

추가된 테스트:
- \`resolveStripCols\` 4 cases (variant 표 + override + invalid override fallback)
- \`KpiStrip\` 컴포넌트 8 cases (role/aria, surface 토큰, variant cols, override, bare 주입, bare={false} 보존, children 순서)
- 기존 \`kpi-cell.test.ts\` 회귀 0건

## Sweep plan (별도 cycle, 본 PR scope 밖)

1. #11116 overview funnel 을 \`<KpiStrip cols={5}>\` 안으로 이동
2. #11118 feature-health overview 를 \`<KpiStrip>\` 안으로 이동
3. \`common/stat-card.ts\` 잔존 callers (\`harness-health.ts\` 8 callsites) 를 KpiStrip + KpiCell 로 마이그레이션
4. StatCard zero-caller 시 제거
5. KpiCell \`live\` 효과를 SPEC pulse animation + value color shift 로 정정 (현 cell-level border ring 은 drift)

## Refs

- cb-group-a primitives: #11066 (KpiCell), #11070 (LifelineBar), #11088 (TickerItem)
- First adoptions: #11116 (overview funnel), #11118 (feature-health)
- Token sweep: #11102 (spacing/font-size), #11113 (brass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)