### PR TITLE
fix(keeper): classify keeper_stay_silent as Completion to satisfy require_tool_use contract

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -180,12 +180,21 @@ let claim_context_tool_names : string list =
   |> List.map Tool_name.to_string
 
 let completion_tool_names : string list =
+  (* Stay_silent is the explicit "no work for me this turn" decisive no-op.
+     LLM evaluates the situation via passive reads, then signals stay_silent
+     to terminate the turn intentionally. Classifying it as Completion lets
+     the contract accept the turn as satisfied; abuse is bounded separately
+     by keeper_stay_silent_loop_detector (consecutive-stay metric + circuit
+     breaker). Without this, 4+ events/day were rejected as passive_only
+     even though the LLM had decided no fit (sangsu/janitor/taskmaster on
+     2026-04-27 00:17-00:58 UTC, idle_seconds 28-40h, claimable_count 44-46). *)
   Tool_name.
     [
       Masc Cancel_task;
       Masc Complete_task;
       Masc Deliver;
       Masc Release_task;
+      Keeper Stay_silent;
       Keeper Task_done;
       Keeper Task_force_done;
       Keeper Task_force_release;


### PR DESCRIPTION
## Summary

`keeper_stay_silent` is the explicit "no work for me this turn" decisive no-op. Currently it's misclassified as `Passive_status`, so the `require_tool_use` contract rejects turns where the LLM rationally decided to stay silent after evaluating the situation.

This PR adds `Keeper Stay_silent` to `completion_tool_names` so the contract treats it as a satisfied turn. Abuse defence is unchanged — `keeper_stay_silent_loop_detector` already tracks consecutive-stay metrics + circuit breaker.

## Evidence

`~/me/.masc/keepers/*.decisions.jsonl` 2026-04-27:

| Window | Event count | Detail |
|--------|-------------|--------|
| early-morning burst (00:17-00:58 UTC) | 4 | sangsu(1), janitor(2), taskmaster(1) — all 4 used `keeper_stay_silent + passive reads`, idle_seconds 28-40h, claimable_count 44-46 |
| post-cascade-fix burst (06:28-06:31 UTC, 3min) | 2 | janitor, verifier — same pattern, **40% rejection rate of recent turns** |
| yesterday memory record | 43 | fleet-wide, dominant root after cascade resolved |

Pattern in all events:
- `tools_used`: `keeper_board_get`, `keeper_tasks_list`, `keeper_tasks_audit`, `keeper_stay_silent` (passive reads + decisive no-op)
- `trigger_signals`: claimable_task, failed_task, pending_verification (strong actionable signals)
- `idle_seconds`: 28-40h (LLM correctly recognized inactivity context)
- `claimable_task_count`: 44-46 (work exists but not for this keeper's persona)

## Code change

`lib/keeper/keeper_tool_disclosure.ml`:
- Add `Keeper Stay_silent` to `completion_tool_names` list
- Add comment explaining semantics (decisive no-op, abuse handled separately)

## Tradeoffs

**Pros**:
- Eliminates a 40-100% rejection rate on otherwise-correct LLM turns
- Respects LLM's autonomous role-fit decision
- Removes false positives in `masc_keeper_require_tool_use_violations_total` metric

**Cons**:
- Slightly muddies the semantics of "Completion" class (was task lifecycle endings, now also includes decisive no-op)
- Alternative: dedicated `Decisive_no_op` class — cleaner but ~5x larger change

The minimal-change approach was chosen because:
1. The contract logic only checks class membership (no semantic distinction needed downstream)
2. `keeper_stay_silent_loop_detector` provides defense against abuse independently
3. The comment documents the semantic role for future readers

## Test plan

- [ ] CI Build and Test pass
- [ ] CI Lint pass
- [ ] No regression in `test/test_require_tool_use_violation_counter_10091.ml`
- [ ] Post-deploy: re-measure `require_tool_use` violation count 24h after merge

## References

- Today's measurement: `/tmp/contract_violation_today.py` + `/tmp/recent_events.py`
- Memory: `feedback_proactive_turn_contract_violation_dominant.md`
- Contract code: `lib/keeper/keeper_agent_run.ml:2306-2316` (passive_only branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)