### PR TITLE
feat(observability): emit [substrate:tool_surface] log + SSE on TurnReady

### DIFF
--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -80,7 +80,21 @@ let emit_native_event_log (evt : Oas.Event_bus.event) (json : Yojson.Safe.t) =
         (Printf.sprintf
            "tool completed agent=%s tool_name=%s"
            agent_name tool_name)
-  | Oas.Event_bus.TurnReady _ -> ()
+  | Oas.Event_bus.TurnReady { agent_name; turn; tool_names } ->
+      (* [substrate:tool_surface] — deterministic per-turn snapshot of the
+         tool list the LLM actually sees this turn (after guardrails,
+         operator policy, tool_filter_override).  Emitted as a single
+         grep-friendly line with a stable hash so operators can confirm
+         which tools were on the LLM's surface for a given turn without
+         enabling verbose tool dumps. *)
+      let names_hash =
+        Digest.to_hex (Digest.string (String.concat "\n" tool_names))
+      in
+      log
+        (Printf.sprintf
+           "[substrate:tool_surface] agent=%s turn=%d count=%d names_hash=%s"
+           agent_name turn (List.length tool_names)
+           (String.sub names_hash 0 16))
   | Oas.Event_bus.ContextCompacted
       { agent_name; before_tokens; after_tokens; phase } ->
       log
@@ -193,7 +207,22 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
           ]
       in
       Some (wrap ~event_type:"turn_completed" ~payload ~agent_name ~turn ())
-  | Oas.Event_bus.TurnReady _ -> None
+  | Oas.Event_bus.TurnReady { agent_name; turn; tool_names } ->
+      let names_hash =
+        Digest.to_hex (Digest.string (String.concat "\n" tool_names))
+      in
+      let payload =
+        `Assoc
+          [
+            ("agent_name", `String agent_name);
+            ("turn", `Int turn);
+            ("count", `Int (List.length tool_names));
+            ("names_hash", `String (String.sub names_hash 0 16));
+            ( "tool_names",
+              `List (List.map (fun name -> `String name) tool_names) );
+          ]
+      in
+      Some (wrap ~event_type:"turn_ready" ~payload ~agent_name ~turn ())
   | Oas.Event_bus.HandoffRequested { from_agent; to_agent; reason } ->
       let payload =
         `Assoc


### PR DESCRIPTION
## Summary

OAS `Event_bus.TurnReady` fires after guardrails + operator policy + tool_filter_override have been applied to the agent's tool registry, exposing the deterministic list of tools the LLM actually sees for that turn. MASC was throwing the event away — no-op log arm at `lib/oas_event_bridge.ml:83`, `None` in the SSE serializer at `:196`.

Hook both arms:

* **`emit_native_event_log`** prints
  ```
  [substrate:tool_surface] agent=<X> turn=<N> count=<K> names_hash=<H16>
  ```
  Single grep-friendly line. Operators can confirm "did this keeper's surface include `keeper_shell` at turn 7?" without flipping a verbose flag.

* **`native_event_to_json`** serializes as a `turn_ready` SSE event with `agent_name`, `turn`, `count`, `names_hash` and the full `tool_names` list, so the dashboard can show the tool surface diff between turns.

Hash uses the existing `Digest.string |> Digest.to_hex` pattern (4 prior sites in `lib/`), truncated to 16 hex chars for log readability while remaining stable across turns with identical surfaces.

## Phase 1 of substrate observability

This is the `tool_surface` emission only.

The full substrate observability covers four signals:

| # | Signal | Hook point | Status |
|---|--------|-----------|--------|
| 1 | tool_surface | `Event_bus.TurnReady` | **this PR** |
| 2 | system_prompt | prompt construction site | follow-up |
| 3 | task_assignment | turn entry | follow-up |
| 4 | context_pollution | retrospective scan | follow-up |

Splitting them avoids review explosion and keeps test isolation clean.

## Test plan

- [x] Manual mental syntax check (record destructure, types match `oas/lib/event_bus.ml:40` definition)
- [ ] CI Build + Lint green
- [ ] Verify a turn-ready event lands in `~/.masc/logs/system_log_*.jsonl` after merge with `grep '\[substrate:tool_surface\]'`
- [ ] Verify the SSE event surfaces in dashboard event stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)
