### PR TITLE
feat(specs): AuthIdentityFSM bug-model — silent identity fallback (PR-1/5)

### DIFF
--- a/specs/bug-models/AuthIdentityFSM-buggy.cfg
+++ b/specs/bug-models/AuthIdentityFSM-buggy.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    Agents = {"a1", "a2", "dashboard"}
+    Tokens = {"t1", "t2", "t3", "t_stale"}
+
+INVARIANT TypeOK
+INVARIANT SafetyInvariant

--- a/specs/bug-models/AuthIdentityFSM.cfg
+++ b/specs/bug-models/AuthIdentityFSM.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Agents = {"a1", "a2", "dashboard"}
+    Tokens = {"t1", "t2", "t3", "t_stale"}
+
+INVARIANT TypeOK
+INVARIANT SafetyInvariant

--- a/specs/bug-models/AuthIdentityFSM.tla
+++ b/specs/bug-models/AuthIdentityFSM.tla
@@ -1,0 +1,170 @@
+---- MODULE AuthIdentityFSM ----
+\* Models the masc-mcp request authentication FSM:
+\*   transport bytes -> identify(token) -> policy(principal) -> decision
+\*
+\* Forensic root being modelled (PR #9657 / commit 277aa2698b, 2026-04-23):
+\*   The OCaml refactor merged three changes in one PR --
+\*     (1) shared internal_keeper.token.hash (one token, many keepers)
+\*     (2) x-masc-keeper-name header asserts identity (token does not)
+\*     (3) `Option.value ~default:"dashboard" agent_name_opt` silent rewrite
+\*         in lib/server/server_auth.ml:183, 210, 233
+\*   The pre-PR code was fail-closed; the post-PR code is fail-open with the
+\*   substitute principal "dashboard". This spec encodes the silent rewrite
+\*   as a BugAction so the SafetyInvariant fails under SpecBuggy and holds
+\*   under Spec.
+\*
+\* Invariants verified:
+\*   I1 IdentityBindsToken : resolved principal owns the request token
+\*   I2 NoSilentRewrite    : resolved principal == deterministic Identify(token)
+\*   I3 FailClosedDefault  : no token => decision in {Pending, Deny}
+\*
+\* Spec Bug-Model contract (CLAUDE.md software-development.md):
+\*   Spec      under AuthIdentityFSM.cfg       => TLC: no error
+\*   SpecBuggy under AuthIdentityFSM-buggy.cfg => TLC: invariant violated
+\*   Both must hold. Clean-passes-only means the invariant is too weak.
+
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS
+    Agents,        \* set of agent names; must include "dashboard" for the bug
+                   \* to be reachable, mirroring the OCaml default literal
+    Tokens         \* set of token identifiers (abstract; SHA-256 in production)
+
+NULL == "_NULL_"
+ASSUME NullDistinct ==
+    /\ NULL \notin Agents
+    /\ NULL \notin Tokens
+
+\* "dashboard" must be a real agent for SilentRewrite to substitute it.
+ASSUME DashboardPresent == "dashboard" \in Agents
+
+VARIABLES
+    credentials,      \* [Agents -> SUBSET Tokens]  (an agent may rotate -> multiple tokens)
+    request_token,    \* current request's bearer token: Tokens \cup {NULL}
+    resolved_agent,   \* identify result: Agents \cup {NULL}
+    decision          \* {"Allow", "Deny", "Pending"}
+
+vars == <<credentials, request_token, resolved_agent, decision>>
+
+\* ── Identify: pure AuthN ────────────────────────────────────
+\* Returns NULL if zero or multiple agents match the token.
+\* The multiple-match case models the 2026-04-25 incident where 14 keepers
+\* shared one token (memory: feedback_shared-token-systemic-identity-violation.md).
+\* A safe identifier MUST refuse to disambiguate -> NULL.
+
+Matches(tok) == { a \in Agents : tok \in credentials[a] }
+
+Identify(tok) ==
+    IF tok = NULL THEN NULL
+    ELSE IF Matches(tok) = {} THEN NULL
+    ELSE IF Cardinality(Matches(tok)) > 1 THEN NULL
+    ELSE CHOOSE a \in Matches(tok) : TRUE
+
+\* ── Type invariant ──────────────────────────────────────────
+
+TypeOK ==
+    /\ credentials \in [Agents -> SUBSET Tokens]
+    /\ request_token \in (Tokens \cup {NULL})
+    /\ resolved_agent \in (Agents \cup {NULL})
+    /\ decision \in {"Allow", "Deny", "Pending"}
+
+\* ── Init ────────────────────────────────────────────────────
+\* Deterministic credential assignment so the spec explores a single
+\* initial state and "t_stale" is unambiguously the token NOT owned by
+\* any agent (mirrors a rotated-out token still cached by the dashboard
+\* browser; admin.json was rotated twice on 2026-04-27).
+
+InitialCredentials == [a \in Agents |->
+    IF a = "a1" THEN {"t1"}
+    ELSE IF a = "a2" THEN {"t2"}
+    ELSE IF a = "dashboard" THEN {"t3"}
+    ELSE {}]
+
+Init ==
+    /\ credentials = InitialCredentials
+    /\ request_token = NULL
+    /\ resolved_agent = NULL
+    /\ decision = "Pending"
+
+\* ── Honest actions (clean spec) ─────────────────────────────
+
+\* Receive a request: the network hands us a token (or none).
+\* Identification happens immediately and deterministically.
+ReceiveRequest ==
+    /\ decision = "Pending"
+    /\ resolved_agent = NULL
+    /\ \E tok \in (Tokens \cup {NULL}) :
+         /\ request_token' = tok
+         /\ resolved_agent' = Identify(tok)
+    /\ UNCHANGED <<credentials, decision>>
+
+\* Decide policy. Fail-closed: any unresolved principal -> Deny.
+DecidePolicy ==
+    /\ decision = "Pending"
+    /\ request_token /= NULL
+    /\ IF resolved_agent = NULL
+       THEN decision' = "Deny"
+       ELSE decision' = "Allow"
+    /\ UNCHANGED <<credentials, request_token, resolved_agent>>
+
+\* Reset for the next request.
+Reset ==
+    /\ decision \in {"Allow", "Deny"}
+    /\ request_token' = NULL
+    /\ resolved_agent' = NULL
+    /\ decision' = "Pending"
+    /\ UNCHANGED credentials
+
+\* Terminal stutter (prevents TLC deadlock false-positives at Allow/Deny).
+Done ==
+    /\ decision \in {"Allow", "Deny"}
+    /\ UNCHANGED vars
+
+\* ── Bug action (only in SpecBuggy) ──────────────────────────
+\* Models the production code at lib/server/server_auth.ml:183, 210, 233:
+\*   let agent_name = Option.value ~default:"dashboard" agent_name_opt
+\* When Identify returned NULL but a token was present, the system
+\* silently substitutes "dashboard" as the principal and continues.
+\* This is exactly the silent identity rewrite that the user reported
+\* on 2026-04-27 and which #10933 / #11041 / #11072 only added telemetry
+\* for, without fixing.
+
+SilentRewrite ==
+    /\ decision = "Pending"
+    /\ resolved_agent = NULL
+    /\ request_token /= NULL          \* a token was sent but did not resolve
+    /\ resolved_agent' = "dashboard"  \* OCaml: Option.value ~default:"dashboard"
+    /\ UNCHANGED <<credentials, request_token, decision>>
+
+\* ── Spec wirings ────────────────────────────────────────────
+
+Next      == ReceiveRequest \/ DecidePolicy \/ Reset \/ Done
+NextBuggy == Next \/ SilentRewrite
+
+Spec      == Init /\ [][Next]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+\* ── Safety invariants ──────────────────────────────────────
+
+\* I1: every resolved principal owns the token in its credential set.
+IdentityBindsToken ==
+    (resolved_agent /= NULL) =>
+        /\ request_token /= NULL
+        /\ request_token \in credentials[resolved_agent]
+
+\* I2: the resolved principal must equal the deterministic Identify().
+\* Catches silent rewrites that change the principal after identification.
+NoSilentRewrite ==
+    (resolved_agent /= NULL) => (Identify(request_token) = resolved_agent)
+
+\* I3: no token => no Allow decision.
+\* The pending decision is acceptable (transient); only Allow is forbidden.
+FailClosedDefault ==
+    (request_token = NULL) => (decision \in {"Pending", "Deny"})
+
+SafetyInvariant ==
+    /\ IdentityBindsToken
+    /\ NoSilentRewrite
+    /\ FailClosedDefault
+
+====


### PR DESCRIPTION
## 목적

masc-mcp Auth/Identity FSM Canonicalization 플랜의 **PR-1**. OCaml 코드 변경 없이 TLA+ spec 한 개를 추가해, 이후 PR-2~5(silent default 제거 → header-identity 폐기 → check_permission 분해 → transport boundary)가 회귀를 도입할 수 없도록 CI 가드를 깐다.

전체 플랜: `~/me/planning/claude-plans/partitioned-hopping-hinton.md`

## 무엇을 모형화하나

- 요청 인증 FSM: `transport bytes -> identify(token) -> policy(principal) -> decision`
- Bug action: `Option.value ~default:"dashboard" agent_name_opt` (lib/server/server_auth.ml:183/210/233) — 토큰 매칭 실패 시 silent 신원 치환

## 검증 invariants

| 약어 | 정의 | 위반 의미 |
|---|---|---|
| **I1 IdentityBindsToken** | `resolved_agent /= NULL => request_token \in credentials[resolved_agent]` | resolved principal이 자기 token을 안 가짐 = 신원 위변조 |
| **I2 NoSilentRewrite** | `resolved_agent /= NULL => Identify(request_token) = resolved_agent` | 결정 함수와 결정 결과가 불일치 = silent 치환 발생 |
| **I3 FailClosedDefault** | `request_token = NULL => decision \in {Pending, Deny}` | 토큰 없이 Allow 발생 |

## 로컬 검증 결과 (tla2tools v1.8.0)

```
$ make -C specs check-bug-models 2>&1 | grep AuthIdentityFSM
CHECK AuthIdentityFSM                          ...
OK    AuthIdentityFSM                          (  0s)
CHECK AuthIdentityFSM-buggy (buggy)            ...
OK    AuthIdentityFSM-buggy (buggy)            (violation exit 12,   2s)
```

- **Spec (clean)**: 9 distinct states, no error
- **SpecBuggy**: 10 states, invariant violated in 3 steps

### Buggy trace (TLC 자동 생성, production incident와 1:1 대응)

```
State 1 (Init):
  credentials = [a1 |-> {t1}, a2 |-> {t2}, dashboard |-> {t3}]
  request_token = NULL, resolved_agent = NULL, decision = Pending

State 2 (ReceiveRequest):
  request_token = t_stale     # 회전된 후 dashboard 탭이 들고 있는 만료 토큰
  resolved_agent = NULL       # Identify가 매칭 실패 → NULL
  decision = Pending

State 3 (SilentRewrite):       # <-- BUG: lib/server/server_auth.ml:183 동등
  resolved_agent = "dashboard" # Option.value ~default:"dashboard"
  request_token = t_stale      # 여전히 dashboard credential에 없음
  → IdentityBindsToken VIOLATED
```

이 3-state trace는 운영 사고 시나리오(2026-04-27 dashboard credential 만료)와 정확히 일치한다.

## CLAUDE.md TLA+ Bug Model 컨트랙트

> "양쪽 cfg 모두 통과해야 spec이 유효하다: clean이 pass하는데 buggy도 pass하면 invariant가 너무 약한 것. clean이 fail하면 모델이 잘못된 것."

본 PR은 양쪽 모두 기대대로 동작 ✓.

## 변경 범위

- `specs/bug-models/AuthIdentityFSM.tla` (신규, 186 lines)
- `specs/bug-models/AuthIdentityFSM.cfg` (신규, clean)
- `specs/bug-models/AuthIdentityFSM-buggy.cfg` (신규, buggy)

`specs/bug-models/`는 `make check-bug-models` 자동 picked up. CI scope key `tla`는 `specs/*.tla` 변경 시 자동 트리거(.github/workflows/ci.yml:162). Makefile/scripts 변경 0.

## Forensic 근거

- 단일 PR `277aa2698b` (#9657, 2026-04-23, "hard cut auth and task RBAC legacy")이 (a) `internal_keeper.token.hash` 공유 토큰 + (b) `x-masc-keeper-name` 헤더 식별 + (c) silent fallback **셋을 동시에** 도입. 그 전엔 fail-closed였음.
- 오늘만 silent fallback 디버깅 PR 3건(#10933 / #11041 / #11072) — 모두 telemetry만 추가, root는 그대로. 이 spec이 root fix(PR-2~5)의 회귀 가드.

## 비-범위

- OCaml 변경 0 (PR-2가 silent default 제거를 surgical하게 처리)
- 마이그레이션 스크립트 없음
- 인접 RFC `~/me/planning/2026-04-25-keeper-identity-canonicalization-rfc.md` (keeper name 6-필드 drift)는 *이미 정해진 canonical name을 입력으로 받는다*는 가정. 두 작업은 보완적

## Self-review

- [x] Single concern (TLA+ spec 추가)
- [x] No code change (dune build 영향 0)
- [x] 로컬 TLC clean=pass + buggy=violation 양쪽 확인
- [x] 기존 컨벤션 준수 (`bug-models/`, `<Name>.cfg`/`-buggy.cfg`)
- [x] 인접 RFC와 충돌 없음

## 다음 단계 (이 PR 머지 후)

PR-2: `lib/server/server_auth.ml:183/210/233`의 `Option.value ~default:"dashboard"` 3줄 제거 → `Error Unauthorized`로 fail-closed 복원.

🤖 Generated with [Claude Code](https://claude.com/claude-code)