### PR TITLE
feat(dashboard): migrate overview funnel into KpiStrip (sweep #1)

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -13,6 +13,7 @@ import { TimeAgo } from '../common/time-ago'
 import { StatusDot } from '../common/status-dot'
 import { RouteLink } from '../common/route-link'
 import { KpiCell, type KpiCellKind } from '../kpi-cell'
+import { KpiStrip } from '../kpi-strip'
 import { AgentAvatar } from './agent-avatar'
 import { missionSnapshot } from '../../mission-store'
 import { tasks, keepers } from '../../store'
@@ -96,17 +97,13 @@ function FunnelCard({ counts }: { counts: FunnelCounts }) {
         <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)]">오늘 상황</h2>
         <span class="text-2xs text-[var(--color-fg-muted)]">task 기준</span>
       </header>
-      <div
-        role="list"
-        aria-label="오늘 funnel"
-        class="grid grid-cols-5 gap-4 max-[640px]:grid-cols-3 max-[640px]:gap-y-4"
-      >
-        <${KpiCell} bare variant="stacked" label="신규" value=${String(counts.created)} testId="funnel-created" />
-        <${KpiCell} bare variant="stacked" label="진행" value=${String(counts.inProgress)} testId="funnel-in-progress" />
-        <${KpiCell} bare variant="stacked" label="검증 대기" value=${String(counts.awaiting)} kind=${awaitingKind} testId="funnel-awaiting" />
-        <${KpiCell} bare variant="stacked" label="완료" value=${String(counts.completed)} kind="ok" testId="funnel-completed" />
-        <${KpiCell} bare variant="stacked" label="목표" value=${formatTargetRatio(counts)} testId="funnel-target" />
-      </div>
+      <${KpiStrip} ariaLabel="오늘 funnel" cols=${5}>
+        <${KpiCell} variant="stacked" label="신규" value=${String(counts.created)} testId="funnel-created" />
+        <${KpiCell} variant="stacked" label="진행" value=${String(counts.inProgress)} testId="funnel-in-progress" />
+        <${KpiCell} variant="stacked" label="검증 대기" value=${String(counts.awaiting)} kind=${awaitingKind} testId="funnel-awaiting" />
+        <${KpiCell} variant="stacked" label="완료" value=${String(counts.completed)} kind="ok" testId="funnel-completed" />
+        <${KpiCell} variant="stacked" label="목표" value=${formatTargetRatio(counts)} testId="funnel-target" />
+      <//>
     </section>
   `
 }


### PR DESCRIPTION
## Why

#11116 가 KpiCell을 overview funnel에 도입할 때 \`bare\` workaround 사용 — SPEC `.cb-kpi` 패턴은 *strip이 surface 책임* 인데 그 host strip이 없어서 cell-level border 를 임시로 끈 거. #11122 (방금 머지) 가 KpiStrip composite 를 추가했고 — 본 PR이 Foundation 위에 *첫 sweep*.

> 사용자: "프리미티브 도입이 안된건가? 안나오네 ... 갤러리를 두는 이유는? 기존거에서 나오면 안되는건지. 교체를 하나씩 하고싶어서"

→ 별도 preview gallery X. 매 cycle 기존 페이지에서 *식별 가능한 시각 변화* 만들기. 본 PR이 그 패턴의 첫 사례.

## Visual delta

운영자가 \`/#overview\` 에서 즉시 보게 될 변화:

| 항목 | Before (#11116 머지된 main) | After (이 PR) |
|---|---|---|
| Funnel cell 사이 분리 | \`gap-4\` 빈 공간 | **1px hairline divider** (\`var(--color-border-default)\`) |
| Funnel 마지막 행 아래 | 빈 padding | **1px border-bottom** (\`var(--color-border-strong)\`) |
| Cell border | 없음 (\`bare\`) | 없음 (KpiStrip 자동 \`bare\` 주입) |
| Layout 책임 | Tailwind grid (\`grid-cols-5\`) | KpiStrip 의 \`grid-template-columns: repeat(5, ...)\` |

→ "Fleet KPI strip" 의 SPEC-aligned 시각 언어가 funnel에 처음 도달.

## What

\`dashboard/src/components/overview/overview.ts\` 한 파일 수정:

\`\`\`diff
- import { KpiCell, type KpiCellKind } from '../kpi-cell'
+ import { KpiCell, type KpiCellKind } from '../kpi-cell'
+ import { KpiStrip } from '../kpi-strip'

- <div role="list" aria-label="오늘 funnel"
-      class="grid grid-cols-5 gap-4 max-[640px]:grid-cols-3 max-[640px]:gap-y-4">
-   <\${KpiCell} bare variant="stacked" label="신규" ... />
-   ... 5 cells with bare ...
- </div>
+ <\${KpiStrip} ariaLabel="오늘 funnel" cols=\${5}>
+   <\${KpiCell} variant="stacked" label="신규" ... />
+   ... 5 cells, no bare (KpiStrip injects) ...
+ <//>
\`\`\`

\`role=\"list\"\` + \`aria-label\` 가 KpiStrip 의 host element 로 자연 이동. 자식 KpiCell 들의 \`bare\` 명시는 제거 — KpiStrip 가 cloneElement 로 default 주입.

## Trade-off: mobile breakpoint

기존 \`max-[640px]:grid-cols-3\` 반응형 wrap 은 본 PR에서 *제거* 됩니다. KpiStrip 의 \`cols\` 가 단일 number 라 responsive 매핑 미지원. 별도 follow-up 에서 KpiStrip 의 \`cols\` 를 \`number | { sm: number; md: number; ... }\` 로 확장 예정.

작은 viewport 에서 funnel 은 5 cell 한 줄로 좁게 렌더 — operator desktop 영향 0.

## Verification

\`\`\`
pnpm exec tsc --noEmit                                    # clean
pnpm exec vitest run overview kpi-strip kpi-cell          # 5 files / 136 cases pass
\`\`\`

\`overview.test.ts\` 는 pure helper 기반 (\`computeFunnelCounts\` 등). DOM/selector 의존 0 → swap 무회귀.

## Sweep plan (별도 cycle, 본 PR scope 밖)

1. ✅ overview funnel 을 KpiStrip 안으로 — **이 PR**
2. feature-health overview 6칸 (#11118) → KpiStrip
3. harness-health.ts StatCard 8 callsites → KpiStrip + KpiCell
4. \`common/stat-card.ts\` 제거 (zero callers 시)
5. KpiCell \`live\` 효과 SPEC 정합 (cell ring → strip pulse + value color)
6. 나머지 5 primitive (LifelineBar / TickerItem / SwimlaneRow / KanbanCard / SidebarRow) 적용 surface 발굴

## Refs

- Foundation: #11122 (KpiStrip)
- First adoption: #11116 (overview funnel KpiCell)
- Second adoption: #11118 (feature-health KpiCell)
- SPEC source: design-system v0.4 cb-group-a (preview/components.css 91-112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)