### PR TITLE
fix(keeper): turn ID persistence and HTTP cancellation

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1495,6 +1495,17 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
          block clears the field, preventing stale state on idle keepers. *)
       Keeper_registry.mark_turn_started
         ~base_path:config.base_path meta.name;
+      let meta =
+        match Keeper_registry.get ~base_path:config.base_path meta.name with
+        | Some entry ->
+          let _ =
+            write_meta_with_merge
+              ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+              config entry.meta
+          in
+          entry.meta
+        | None -> meta
+      in
       Keeper_registry.mark_turn_measurement
         ~base_path:config.base_path meta.name;
       (match Keeper_registry.get ~base_path:config.base_path meta.name with

--- a/lib/masc_http_client/dune
+++ b/lib/masc_http_client/dune
@@ -2,4 +2,4 @@
 (library
  (name masc_http_client)
  (public_name masc_mcp.http_client)
- (libraries eio eio.unix cohttp cohttp-eio uri))
+ (libraries eio eio.unix cstruct cohttp cohttp-eio uri))

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -122,19 +122,18 @@ let post_sync ?clock ?timeout_sec ~net ?(https = None) ~url ~headers ~body () =
     in
     let body_str =
       let max_size = 8 * 1024 * 1024 in
-      let reader = Eio.Buf_read.of_flow resp_body ~max_size in
       let buf = Buffer.create 4096 in
+      let chunk = Cstruct.create 4096 in
       let rec read_chunks () =
         if Buffer.length buf > max_size then
           raise (Failure (Printf.sprintf "masc_http_client: body size exceeds %d MB" (max_size / 1024 / 1024)))
         else
-          match Eio.Buf_read.peek_char reader with
-          | None -> Buffer.contents buf
-          | Some _ ->
-            let chunk = Eio.Buf_read.take_at_most 4096 reader in
-            Buffer.add_string buf chunk;
+          match Eio.Flow.single_read resp_body chunk with
+          | n ->
+            Buffer.add_string buf (Cstruct.to_string ~off:0 ~len:n chunk);
             Eio.Fiber.yield ();
             read_chunks ()
+          | exception End_of_file -> Buffer.contents buf
       in
       read_chunks ()
     in
@@ -164,19 +163,18 @@ let get_response_sync ?clock ?timeout_sec ~net ?(https = None) ~url ~headers () 
     in
     let body_str =
       let max_size = 8 * 1024 * 1024 in
-      let reader = Eio.Buf_read.of_flow resp_body ~max_size in
       let buf = Buffer.create 4096 in
+      let chunk = Cstruct.create 4096 in
       let rec read_chunks () =
         if Buffer.length buf > max_size then
           raise (Failure (Printf.sprintf "masc_http_client: body size exceeds %d MB" (max_size / 1024 / 1024)))
         else
-          match Eio.Buf_read.peek_char reader with
-          | None -> Buffer.contents buf
-          | Some _ ->
-            let chunk = Eio.Buf_read.take_at_most 4096 reader in
-            Buffer.add_string buf chunk;
+          match Eio.Flow.single_read resp_body chunk with
+          | n ->
+            Buffer.add_string buf (Cstruct.to_string ~off:0 ~len:n chunk);
             Eio.Fiber.yield ();
             read_chunks ()
+          | exception End_of_file -> Buffer.contents buf
       in
       read_chunks ()
     in

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -121,7 +121,22 @@ let post_sync ?clock ?timeout_sec ~net ?(https = None) ~url ~headers ~body () =
       Cohttp.Response.status resp |> Cohttp.Code.code_of_status
     in
     let body_str =
-      Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:(8 * 1024 * 1024)
+      let max_size = 8 * 1024 * 1024 in
+      let reader = Eio.Buf_read.of_flow resp_body ~max_size in
+      let buf = Buffer.create 4096 in
+      let rec read_chunks () =
+        if Buffer.length buf > max_size then
+          raise (Failure (Printf.sprintf "masc_http_client: body size exceeds %d MB" (max_size / 1024 / 1024)))
+        else
+          match Eio.Buf_read.peek_char reader with
+          | None -> Buffer.contents buf
+          | Some _ ->
+            let chunk = Eio.Buf_read.take_at_most 4096 reader in
+            Buffer.add_string buf chunk;
+            Eio.Fiber.yield ();
+            read_chunks ()
+      in
+      read_chunks ()
     in
     Ok (code, body_str)
   with
@@ -148,7 +163,22 @@ let get_response_sync ?clock ?timeout_sec ~net ?(https = None) ~url ~headers () 
       Cohttp.Response.headers resp |> Cohttp.Header.to_list
     in
     let body_str =
-      Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:(8 * 1024 * 1024)
+      let max_size = 8 * 1024 * 1024 in
+      let reader = Eio.Buf_read.of_flow resp_body ~max_size in
+      let buf = Buffer.create 4096 in
+      let rec read_chunks () =
+        if Buffer.length buf > max_size then
+          raise (Failure (Printf.sprintf "masc_http_client: body size exceeds %d MB" (max_size / 1024 / 1024)))
+        else
+          match Eio.Buf_read.peek_char reader with
+          | None -> Buffer.contents buf
+          | Some _ ->
+            let chunk = Eio.Buf_read.take_at_most 4096 reader in
+            Buffer.add_string buf chunk;
+            Eio.Fiber.yield ();
+            read_chunks ()
+      in
+      read_chunks ()
     in
     Ok { status = code; headers = response_headers; body = body_str }
   with


### PR DESCRIPTION
This PR addresses two critical keeper efficiency issues:
1. Resolves #11020 by moving total_turns increment to the start of the turn and persisting it immediately.
2. Resolves #11007 by ensuring Masc_http_client yields frequently while reading response bodies.