### PR TITLE
feat(dashboard): migrate feature-health overview into KpiStrip (sweep #2)

### DIFF
--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -12,6 +12,7 @@ import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { SectionCap } from './common/section-cap'
 import { KpiCell } from './kpi-cell'
+import { KpiStrip } from './kpi-strip'
 
 type FeatureStatus = 'healthy' | 'warning' | 'inactive' | 'deprecated'
 type StatusFilter = FeatureStatus | 'all'
@@ -227,17 +228,15 @@ export function FeatureHealth() {
                     >새로고침</button>
                   </div>
 
-                  <div
-                    role="list"
-                    aria-label="기능 상태 요약"
-                    class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6"
-                  >
-                    <${KpiCell} bare variant="stacked" label="총 기능" value=${overview.total_features} />
-                    <${KpiCell} bare variant="stacked" label="활성화" value=${overview.enabled_count} />
-                    <${KpiCell} bare variant="stacked" label="정상" value=${overview.healthy_count} kind="ok" />
-                    <${KpiCell} bare variant="stacked" label="실험적" value=${overview.warning_count} kind="warn" />
-                    <${KpiCell} bare variant="stacked" label="비활성" value=${overview.inactive_count} />
-                    <${KpiCell} bare variant="stacked" label="폐기 예정" value=${overview.deprecated_count} kind="err" />
+                  <div class="mt-4">
+                    <${KpiStrip} ariaLabel="기능 상태 요약" variant="standard">
+                      <${KpiCell} variant="stacked" label="총 기능" value=${overview.total_features} />
+                      <${KpiCell} variant="stacked" label="활성화" value=${overview.enabled_count} />
+                      <${KpiCell} variant="stacked" label="정상" value=${overview.healthy_count} kind="ok" />
+                      <${KpiCell} variant="stacked" label="실험적" value=${overview.warning_count} kind="warn" />
+                      <${KpiCell} variant="stacked" label="비활성" value=${overview.inactive_count} />
+                      <${KpiCell} variant="stacked" label="폐기 예정" value=${overview.deprecated_count} kind="err" />
+                    <//>
                   </div>
 
                   <div class="mt-4 text-xs text-[var(--color-fg-disabled)]">


### PR DESCRIPTION
## Why

Sweep #1 (#11128) 가 overview funnel 을 KpiStrip 안으로 옮겼습니다. 본 PR이 같은 패턴 두 번째 적용 — feature-health overview 6칸 stat strip (#11118 이후 KpiCell + \`bare\` 사용 중) 을 KpiStrip 위로.

> 사용자 의도: "갤러리를 두는 이유는? 기존거에서 나오면 안되는건지. 교체를 하나씩 하고싶어서"

매 cycle 기존 페이지에서 *식별 가능한 시각 변화* — Foundation 위에 callsite 1개씩 점진 sweep.

## Visual delta

운영자가 feature-health 화면 (모니터링 → 기능 상태) 에서 즉시 보게 될 변화:

| 항목 | Before (#11118 머지된 main) | After (이 PR) |
|---|---|---|
| 6 cell 사이 분리 | \`gap-3\` 빈 공간 | **1px hairline divider** (\`var(--color-border-default)\`) |
| Strip 마지막 행 아래 | 빈 padding | **1px border-bottom** (\`var(--color-border-strong)\`) — 외부 card border 와 페어링 |
| Cell border | 없음 (\`bare\`) | 없음 (KpiStrip 자동 \`bare\` 주입) |
| Cardinality | \`grid-cols-2 sm:grid-cols-3 md:grid-cols-6\` (responsive) | KpiStrip standard 6 cols |

Cell 의미별 tone (총/활성화 → neutral, 정상 → ok, 실험적 → warn, 비활성 → neutral, 폐기 예정 → err) 은 #11118 그대로 보존.

## What

\`dashboard/src/components/feature-health.ts\` 한 파일 수정:

\`\`\`diff
+ import { KpiStrip } from './kpi-strip'

- <div role="list" aria-label="기능 상태 요약"
-      class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
-   <\${KpiCell} bare variant="stacked" label="총 기능" ... />
-   ... 6 cells with bare ...
- </div>
+ <div class="mt-4">
+   <\${KpiStrip} ariaLabel="기능 상태 요약" variant="standard">
+     <\${KpiCell} variant="stacked" label="총 기능" ... />
+     ... 6 cells, no bare (KpiStrip injects) ...
+   <//>
+ </div>
\`\`\`

\`role=\"list\"\` + \`aria-label\` 가 KpiStrip 의 host element 로 자연 이동. \`bare\` 명시 제거 — KpiStrip 가 cloneElement 로 default 주입.

## Trade-off: mobile breakpoint

기존 \`grid-cols-2 sm:grid-cols-3 md:grid-cols-6\` 반응형 wrap 은 본 PR에서 *제거* 됩니다. KpiStrip 의 \`cols\` 가 단일 number 라 responsive 매핑 미지원. 별도 follow-up 에서 KpiStrip 의 \`cols\` 를 \`number | { sm: number; md: number; ... }\` 로 확장 예정.

좁은 viewport 에서 strip 은 6 cell 한 줄로 좁게 렌더 — operator desktop 영향 0.

## Verification

\`\`\`
pnpm exec tsc --noEmit                                  # clean
pnpm exec vitest run feature-health kpi-strip kpi-cell  # 3 files / 47 cases pass
\`\`\`

\`feature-health.test.ts\` 는 pure helper 기반 (\`featureMatchesSearch\` / \`filterFeatures\`). DOM/selector 의존 0 → swap 무회귀.

## Sweep plan (이후 cycle)

1. ✅ overview funnel → KpiStrip — #11128
2. ✅ feature-health overview → KpiStrip — **이 PR**
3. harness-health.ts StatCard 8 callsites → KpiStrip + KpiCell
4. \`common/stat-card.ts\` 제거 (zero callers 시)
5. KpiCell \`live\` 효과 SPEC 정합 (cell ring → strip pulse + value color)
6. 나머지 5 primitive (LifelineBar / TickerItem / SwimlaneRow / KanbanCard / SidebarRow) 적용 surface 발굴

## Refs

- Foundation: #11122 (KpiStrip)
- Sweep #1: #11128 (overview funnel)
- KpiCell first adoption (this surface 의 전 단계): #11118
- SPEC source: design-system v0.4 cb-group-a (preview/components.css 91-112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)