### PR TITLE
feat(observability): emit [substrate:system_prompt] per keeper turn (Phase 2)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -356,6 +356,23 @@ let run_turn
     build_prompt_metrics ~system_prompt:turn_system_prompt ~dynamic_context
       ~user_message
   in
+  (* [substrate:system_prompt] — single grep-friendly line per turn carrying
+     the system prompt's deterministic identity (length + 16-char SHA256
+     prefix).  Operators can confirm at a glance whether a keeper's system
+     prompt drifted across turns or differs from the persona file, without
+     dumping the raw prompt text.  Companion to [substrate:tool_surface]
+     emitted from the OAS Event_bus.TurnReady arm.  Phase 2 of substrate
+     observability. *)
+  (let segment = prompt_metrics.system_prompt_segment in
+   let hash16 =
+     match segment.fingerprint with
+     | Some hex when String.length hex >= 16 -> String.sub hex 0 16
+     | Some hex -> hex
+     | None -> "empty"
+   in
+   Log.Keeper.info
+     "[substrate:system_prompt] agent=%s turn=%d length=%d hash=%s"
+     meta.agent_name (start_turn_count + 1) segment.bytes hash16);
   (* 6. Append user message and persist.
      On retry (is_retry=true), the user message was already persisted by the
      first attempt.  Checkpoint reload does not include it (checkpoint is


### PR DESCRIPTION
## Summary

Phase 2 of substrate observability — companion to the `[substrate:tool_surface]` emission landed in #11125. Each keeper turn now emits a single grep-friendly line carrying the system prompt's deterministic identity (length in bytes + 16-char SHA256 prefix), so operators can confirm whether a keeper's system prompt drifted across turns or differs from the persona file, without dumping the raw prompt text.

## Hook point

`lib/keeper/keeper_agent_run.ml`, right after `build_prompt_metrics` has already computed the SHA256 fingerprint and byte count for the system prompt segment. Reusing the existing metrics avoids duplicate hashing on the hot path.

## Format

```
[substrate:system_prompt] agent=<X> turn=<N> length=<L> hash=<H16>
```

The 16-char prefix matches the truncation used by `[substrate:tool_surface]` so cross-event grep stays consistent.

When fingerprint computation yields `None` (empty system prompt — should not happen in practice), the hash field renders `empty` so the line is still emitted and the anomaly stays visible. No silent path.

## Phase plan

| # | Signal | Hook point | Status |
|---|--------|-----------|--------|
| 1 | tool_surface | `Event_bus.TurnReady` | merged via #11125 (CI pending at the time of writing) |
| 2 | system_prompt | `keeper_agent_run.ml:356` (post-`build_prompt_metrics`) | **this PR** |
| 3 | task_assignment | turn entry | follow-up |
| 4 | context_pollution | retrospective scan | follow-up |

## Test plan

- [x] Manual mental syntax check (record field access matches `prompt_segment_metrics` definition; `Log.Keeper.info` printf-style)
- [ ] CI Build + Lint green
- [ ] After merge: `grep '\[substrate:system_prompt\]' system_log` shows N lines per keeper turn with stable hash for unchanged personas

🤖 Generated with [Claude Code](https://claude.com/claude-code)
