### PR TITLE
feat(keeper): harden cross-FSM callback contracts + measure event-bus drains

### DIFF
--- a/docs/architecture/actor-mailbox-pattern.md
+++ b/docs/architecture/actor-mailbox-pattern.md
@@ -1,0 +1,94 @@
+# Actor-Mailbox Pattern in masc-mcp
+
+This document describes the actor-mailbox pattern that already exists
+in masc-mcp and the design rules a new use of it should follow. It is
+not a proposal — it codifies what `lib/session.ml`, `lib/board_dispatch.ml`,
+and `lib/pulse/` already practice.
+
+## TL;DR
+
+The pattern is: **one bounded `Eio.Stream` mailbox + one fiber that
+loops on `Stream.take` + a record of immutable state threaded through
+the loop**. Cross-fiber callers send messages by `Stream.add` and
+optionally await a `Promise` resolver bundled into the message.
+
+```
+producer fiber ─── Stream.add ──▶  [bounded mailbox]
+                                          │
+                                          ▼
+                            consumer fiber: let rec loop state =
+                              let msg = Stream.take mb in
+                              loop (process state msg)
+```
+
+## Existing examples
+
+| File | Mailbox | Pattern shape |
+|------|---------|---------------|
+| `lib/session.ml:56,90,271-278` | `registry.mailbox` (Eio.Stream, cap 10000) + per-session notification queue (cap 1000) | **Request-response.** Each message carries an `Eio.Promise` resolver; consumer resolves it to return data to the caller. |
+| `lib/board_dispatch.ml:35,71-89` | `store.flusher_inbox` (cap 1000), commands `Flush` / `Sweep` | **Fire-and-forget.** No resolver — caller does not block on the consumer's progress. |
+| `lib/pulse/pulse.ml` | Adaptive tick + per-consumer registration | **Pub-sub-with-tick.** Consumers register first-class modules, receive each beat. |
+| `lib/sse.ml:304` | per-client `event_stream` (cap 64) | **Per-subscriber broadcast.** A snapshot of the registry is taken, each subscriber receives via its own stream. |
+
+## When to use this pattern
+
+- **Cross-fiber state synchronization** where the state owns a single
+  fiber and other fibers must not touch it directly.
+- **Backpressure** is required and an unbounded queue would risk
+  memory exhaustion (see #10777 — unbounded streams have already cost
+  us a heap blow-up).
+- **Failure as a first-class signal** — bounded streams turn a stuck
+  consumer into a measurable producer-side block (`Stream.add` waits)
+  rather than an invisible drop.
+
+## When NOT to use this pattern
+
+- A single synchronous call already correctly expresses the
+  dependency. Wrapping a pure function in a mailbox introduces fiber
+  context, scheduling jitter, and a new failure mode (lost messages
+  on switch teardown) for no benefit.
+- The producer must observe the consumer's state inline (e.g. read a
+  computed field, then immediately branch on it). The request-response
+  shape works but is heavier than a direct call; only adopt it when
+  the consumer truly needs to serialise concurrent access.
+- The function would only ever be called from one fiber. Mailboxes
+  exist to serialise multi-fiber access. A single-fiber consumer is
+  just a function.
+
+## Anti-patterns observed in this repo
+
+1. **Unbounded streams** (`Eio.Stream.create 0`). #10777 — heap
+   exhaustion. Always pick a bound, even if it is large.
+2. **Split atomic increment then read** — `Atomic.incr; Atomic.get`
+   produces duplicate IDs under contention. Use
+   `Atomic.fetch_and_add` / `Atomic.compare_and_set` instead. See
+   `lib/metrics_store_eio.ml:72-75`.
+3. **`Eio.Mutex` across domains** — Eio.Mutex is fiber-scoped within
+   a single domain. Cross-domain locking needs `Stdlib.Mutex` or a
+   different approach. See `memory/feedback_eio-mutex-vs-stdlib.md`.
+4. **`Eio.traceln` inside the critical section** — the fiber yields
+   inside `Eio.traceln`, which lengthens the lock window. Capture
+   locals first, release the lock, then trace. See
+   `memory/feedback_eio-traceln-outside-critical-section.md`.
+5. **Naked callback invocation** (PR-J context) — when a mailbox
+   message carries a callback closure, invoking it without
+   `try/with` lets a transient consumer-side failure abort the
+   entire loop step. Wrap with a counter+warn so failures surface as
+   metrics rather than logs nobody reads.
+
+## Why this is not a "let's actor-ize the keeper FSMs" plan
+
+The 5 keeper sub-FSMs (KSM/KTC/KDP/KCL/KMC) currently couple via
+synchronous direct calls inside `Keeper_unified_turn.run_unified_turn`
+(see PR-H test docs and `docs/keeper-fsm-graph.dot`). Refactoring all
+five into mailbox actors is a multi-day effort whose benefit hinges on
+hypothetical data — frequency of cross-FSM communication, contention
+on the shared `Keeper_registry`, observability gain over what
+`masc_keeper_fsm_edge_transitions_total` (PR-I) and
+`masc_keeper_lifecycle_callback_failures_total` (PR-J) already give us.
+
+The honest path: **measure first** (the counters from PR-I and PR-J
+will accumulate four weeks of fleet data), then decide whether
+selective migration of one or two sub-FSMs to this pattern is
+warranted. Until that data exists, treat sub-FSM actor-ization as
+out-of-scope.

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -183,7 +183,29 @@ let apply_post_turn_lifecycle
       let effective_compaction_applied, compaction_failure_reason, effective_ctx, checkpoint =
         if not compaction_decided then (false, None, ctx, Some cp)
         else
-          let () = on_compaction_started () in
+          (* PR-J: lifecycle callbacks fire dispatch_keeper_phase_event,
+             which can raise on transient registry contention or stale
+             entry mismatches. The naked invocation here used to abort
+             the whole post-turn lifecycle on any callback exception
+             without surfacing the cause; failures now increment the
+             [callback=on_compaction_started] counter and log a warn,
+             but the lifecycle continues so a downstream save error
+             still wins the failure_reason field. See
+             docs/architecture/actor-mailbox-pattern.md for the
+             reasoning behind the keep-going-on-callback-failure
+             policy. *)
+          let () =
+            try on_compaction_started ()
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+                Prometheus.inc_counter
+                  Prometheus.metric_keeper_lifecycle_callback_failures
+                  ~labels:[("callback", "on_compaction_started")] ();
+                Log.Keeper.warn
+                  "keeper:%s post-turn on_compaction_started raised: %s"
+                  base_meta.name (Printexc.to_string exn)
+          in
           let session =
             create_session ~session_id:(Keeper_id.Trace_id.to_string base_meta.runtime.trace_id) ~base_dir
           in

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -181,7 +181,22 @@ let maybe_rollover_oas_handoff
         let prev_trace_id = base_meta.runtime.trace_id in
         let new_trace_id = Keeper_identity.generate_trace_id () in
         let next_generation = current_generation + 1 in
-        on_started ();
+        (* PR-J: see keeper_post_turn.ml for the rationale on
+           keep-going-on-callback-failure. The handoff path mirrors
+           the compaction path so the operator counter aggregates a
+           single fleet-wide invariant: any lifecycle callback that
+           can't reach the registry must surface as a counter+warn,
+           never silently abort the rollover. *)
+        (try on_started ()
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_lifecycle_callback_failures
+               ~labels:[("callback", "on_handoff_started")] ();
+             Log.Keeper.warn
+               "keeper:%s rollover on_started raised: %s"
+               base_meta.name (Printexc.to_string exn));
         (try
           let new_session =
             create_session ~session_id:new_trace_id ~base_dir

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1431,13 +1431,21 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             | _ -> ())
           events
       in
-      let drain_turn_event_bus () =
+      (* PR-J: [?site] labels the call-site so PromQL can attribute
+         drain pressure to background polling vs unsubscribe vs the
+         retry path. [outcome=drained] when at least one event was
+         pulled, [outcome=empty] otherwise (the latter is the no-op
+         tick that establishes the lock-acquire baseline). *)
+      let drain_turn_event_bus ?(site = "unspecified") () =
         with_turn_event_bus_lock (fun () ->
           let events =
             match event_bus_sub, Keeper_event_bus.get () with
             | Some sub, Some _bus -> Oas_bus_instrument.drain sub
             | _ -> []
           in
+          let outcome = if events = [] then "empty" else "drained" in
+          Prometheus.inc_counter Prometheus.metric_keeper_event_bus_drain
+            ~labels:[("site", site); ("outcome", outcome)] ();
           process_tool_events_for_side_effects events;
           let summary = summarize_turn_event_bus events in
           turn_event_bus :=
@@ -1455,7 +1463,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               let rec loop () =
                 if Atomic.get event_bus_drain_active then begin
                   (try
-                     ignore (drain_turn_event_bus ())
+                     ignore (drain_turn_event_bus ~site:"background_poll" ())
                    with
                    | Eio.Cancel.Cancelled _ as e -> raise e
                    | exn ->
@@ -1485,7 +1493,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       in
       let unsubscribe_event_bus () =
         Atomic.set event_bus_drain_active false;
-        ignore (drain_turn_event_bus ());
+        ignore (drain_turn_event_bus ~site:"unsubscribe_final" ());
         match event_bus_sub, Keeper_event_bus.get () with
         | Some sub, Some bus -> Oas_bus_instrument.unsubscribe bus sub
         | _ -> ()
@@ -1723,7 +1731,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   reclassify_oas_timeout_for_attempt
                     ~timeout_budget:!attempt_timeout_budget err
                 in
-                let _ = drain_turn_event_bus () in
+                let _ = drain_turn_event_bus ~site:"reconcile_pre_check" () in
                 let committed_tools = committed_mutating_tools_snapshot () in
                 if committed_tools <> []
                    && Keeper_tool_registry.all_tools_reconcile_safe
@@ -1910,7 +1918,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                         ~is_retry:true ~overflow_retry_used
                         ~attempted_cascades
                   | No_degraded_retry when EC.is_context_overflow err ->
-                  let current_turn_event_bus = drain_turn_event_bus () in
+                  let current_turn_event_bus =
+                    drain_turn_event_bus ~site:"context_overflow_capture" () in
                   dispatch_keeper_phase_event
                     ~config
                     ~keeper_name:meta.name
@@ -2013,7 +2022,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 timeout_sec
             in
             Log.Keeper.error "%s: %s" meta.name msg;
-            let _ = drain_turn_event_bus () in
+            let _ = drain_turn_event_bus ~site:"error_path_drain" () in
             let committed_tools = committed_mutating_tools_snapshot () in
             if committed_tools <> []
                && Keeper_tool_registry.all_tools_reconcile_safe
@@ -2082,7 +2091,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         | result -> cleanup (); result
         | exception e -> cleanup (); raise e
       in
-      let turn_event_bus = drain_turn_event_bus () in
+      let turn_event_bus = drain_turn_event_bus ~site:"turn_finalize_capture" () in
       (match turn_event_bus.correlation_id with
        | Some correlation_id ->
            Keeper_registry.set_last_correlation_id

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -606,6 +606,9 @@ let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
 let metric_keeper_invariant_violations = "masc_keeper_invariant_violations_total"
 let metric_keeper_fsm_edge_transitions =
   "masc_keeper_fsm_edge_transitions_total"
+let metric_keeper_lifecycle_callback_failures =
+  "masc_keeper_lifecycle_callback_failures_total"
+let metric_keeper_event_bus_drain = "masc_keeper_event_bus_drain_total"
 let metric_keeper_dead_total = "masc_keeper_dead_total"
 let metric_keeper_near_exhaustion_total = "masc_keeper_near_exhaustion_total"
 (* PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -262,6 +262,23 @@ val metric_keeper_invariant_violations : string
     Cardinality is bounded by the documented edge set (≤ 8 series on
     a fleet of any size). *)
 val metric_keeper_fsm_edge_transitions : string
+
+(** PR-J: post-turn lifecycle callbacks raised exceptions that were
+    silently swallowed before this counter existed. Labels: [callback]
+    with values:
+    - [on_compaction_started] — fired from
+      [Keeper_post_turn.apply_post_turn_lifecycle]
+    - [on_handoff_started] — fired from
+      [Keeper_rollover.maybe_rollover_oas_handoff]
+    Cardinality: ≤ 2 series, fleet-independent. *)
+val metric_keeper_lifecycle_callback_failures : string
+
+(** PR-J: number of times the per-turn OAS event-bus drain helper ran,
+    labelled by call-site so operators can attribute drain pressure
+    (e.g. background poller vs. unsubscribe vs. retry path).
+    Labels: [site, outcome]. [outcome] is [drained] (events were
+    pulled) or [empty] (subscriber returned no pending events). *)
+val metric_keeper_event_bus_drain : string
 val metric_keeper_dead_total : string
 (** Total keeper transitions to [Dead] phase after restart-budget exhaustion.
     Labeled by [keeper] and [reason]. Operators should alert on any rate >0:

--- a/test/dune
+++ b/test/dune
@@ -105,6 +105,7 @@
         test_decision_pipeline_observer
         test_keeper_composite_observer
         test_keeper_fsm_edges
+        test_keeper_callback_hardening
         test_keeper_behavioral_regime
         test_keeper_toml
         test_keeper_runtime_toml
@@ -262,6 +263,7 @@
           test_decision_pipeline_observer
           test_keeper_composite_observer
           test_keeper_fsm_edges
+          test_keeper_callback_hardening
           test_keeper_behavioral_regime
           test_keeper_toml
           test_keeper_runtime_toml

--- a/test/test_keeper_callback_hardening.ml
+++ b/test/test_keeper_callback_hardening.ml
@@ -1,0 +1,150 @@
+(** test_keeper_callback_hardening — verify PR-J counter semantics.
+
+    Two new counters were added in PR-J:
+    1. [masc_keeper_lifecycle_callback_failures_total{callback}] —
+       bumped when a post-turn lifecycle callback raises. The two
+       wrappers ([Keeper_post_turn] and [Keeper_rollover]) each call
+       [Prometheus.inc_counter] in their except branch.
+    2. [masc_keeper_event_bus_drain_total{site,outcome}] — bumped on
+       every drain, with [outcome=drained] when at least one event
+       was pulled and [outcome=empty] otherwise.
+
+    The wrappers themselves live inside heavyweight functions that
+    require a full keeper turn harness to invoke. The validator
+    script + PR-H joint tests cover end-to-end semantics; this file
+    is the thin layer that asserts the metric mechanics work — the
+    counter constants are stable, label cardinality stays bounded,
+    and distinct labels are isolated. The same shape as
+    [test/test_keeper_fsm_edges.ml] from PR-I. *)
+
+module P = Masc_mcp.Prometheus
+
+(* ── Counter constants (stable Prometheus series names) ───── *)
+
+let test_lifecycle_callback_metric_name () =
+  Alcotest.(check string)
+    "lifecycle callback failures counter has the documented series name"
+    "masc_keeper_lifecycle_callback_failures_total"
+    P.metric_keeper_lifecycle_callback_failures
+
+let test_event_bus_drain_metric_name () =
+  Alcotest.(check string)
+    "event-bus drain counter has the documented series name"
+    "masc_keeper_event_bus_drain_total"
+    P.metric_keeper_event_bus_drain
+
+(* ── Counter mechanics — labels distinct and isolated ────── *)
+
+let read_lifecycle_failure ~callback =
+  P.metric_value_or_zero
+    P.metric_keeper_lifecycle_callback_failures
+    ~labels:[("callback", callback)] ()
+
+let test_lifecycle_callback_label_isolation () =
+  let cb_a = "on_compaction_started" in
+  let cb_b = "on_handoff_started" in
+  let a_before = read_lifecycle_failure ~callback:cb_a in
+  let b_before = read_lifecycle_failure ~callback:cb_b in
+  P.inc_counter P.metric_keeper_lifecycle_callback_failures
+    ~labels:[("callback", cb_a)] ();
+  let a_after = read_lifecycle_failure ~callback:cb_a in
+  let b_after = read_lifecycle_failure ~callback:cb_b in
+  Alcotest.(check (float 0.0001))
+    "callback A counter incremented by 1"
+    (a_before +. 1.0) a_after;
+  Alcotest.(check (float 0.0001))
+    "callback B counter unchanged when only A bumped"
+    b_before b_after
+
+let read_drain ~site ~outcome =
+  P.metric_value_or_zero
+    P.metric_keeper_event_bus_drain
+    ~labels:[("site", site); ("outcome", outcome)] ()
+
+let test_drain_site_label_isolation () =
+  let site_x = "background_poll" in
+  let site_y = "unsubscribe_final" in
+  let outcome = "empty" in
+  let x_before = read_drain ~site:site_x ~outcome in
+  let y_before = read_drain ~site:site_y ~outcome in
+  P.inc_counter P.metric_keeper_event_bus_drain
+    ~labels:[("site", site_x); ("outcome", outcome)] ();
+  let x_after = read_drain ~site:site_x ~outcome in
+  let y_after = read_drain ~site:site_y ~outcome in
+  Alcotest.(check (float 0.0001))
+    "site X drain counter incremented"
+    (x_before +. 1.0) x_after;
+  Alcotest.(check (float 0.0001))
+    "site Y unchanged"
+    y_before y_after
+
+let test_drain_outcome_label_distinction () =
+  let site = "test_outcome_isolation" in
+  let drained_before = read_drain ~site ~outcome:"drained" in
+  let empty_before = read_drain ~site ~outcome:"empty" in
+  P.inc_counter P.metric_keeper_event_bus_drain
+    ~labels:[("site", site); ("outcome", "drained")] ();
+  let drained_after = read_drain ~site ~outcome:"drained" in
+  let empty_after = read_drain ~site ~outcome:"empty" in
+  Alcotest.(check (float 0.0001))
+    "drained outcome incremented"
+    (drained_before +. 1.0) drained_after;
+  Alcotest.(check (float 0.0001))
+    "empty outcome unchanged"
+    empty_before empty_after
+
+(* ── Documented label vocabulary check ──────────────────────
+   The wrappers in keeper_post_turn.ml and keeper_rollover.ml use
+   exactly the two callback labels documented in prometheus.mli.
+   This test pins the contract so a future refactor that renames a
+   label without updating the docs is caught.  *)
+
+let test_documented_callback_label_vocabulary () =
+  let documented_labels = ["on_compaction_started"; "on_handoff_started"] in
+  List.iter (fun label ->
+    P.inc_counter P.metric_keeper_lifecycle_callback_failures
+      ~labels:[("callback", label)] ();
+    let v = read_lifecycle_failure ~callback:label in
+    Alcotest.(check bool)
+      (Printf.sprintf "documented callback label %S records" label)
+      true
+      (v > 0.0)
+  ) documented_labels
+
+let test_documented_drain_outcome_vocabulary () =
+  let documented_outcomes = ["drained"; "empty"] in
+  let site = "vocab_check" in
+  List.iter (fun outcome ->
+    P.inc_counter P.metric_keeper_event_bus_drain
+      ~labels:[("site", site); ("outcome", outcome)] ();
+    let v = read_drain ~site ~outcome in
+    Alcotest.(check bool)
+      (Printf.sprintf "documented outcome %S records" outcome)
+      true
+      (v > 0.0)
+  ) documented_outcomes
+
+let () =
+  let open Alcotest in
+  run "keeper_callback_hardening" [
+    "metric constants", [
+      test_case "lifecycle callback metric series name" `Quick
+        test_lifecycle_callback_metric_name;
+      test_case "event-bus drain metric series name" `Quick
+        test_event_bus_drain_metric_name;
+    ];
+    "label isolation", [
+      test_case "callback labels are isolated" `Quick
+        test_lifecycle_callback_label_isolation;
+      test_case "drain site labels are isolated" `Quick
+        test_drain_site_label_isolation;
+      test_case "drain outcome labels are distinct" `Quick
+        test_drain_outcome_label_distinction;
+    ];
+    "documented label vocabulary", [
+      test_case "callback labels match prometheus.mli docs" `Quick
+        test_documented_callback_label_vocabulary;
+      test_case "drain outcome labels match prometheus.mli docs" `Quick
+        test_documented_drain_outcome_vocabulary;
+    ];
+  ]


### PR DESCRIPTION
## 무엇을 / 왜

원래 trail #3 의도("5 sub-FSM을 actor로 재구성")를 explore agent 3개로 재검증한 결과 — masc-mcp는 이미 actor-mailbox 패턴을 보유(\`lib/session.ml\`, \`lib/board_dispatch.ml\`, \`lib/pulse/\`)하고, 5 sub-FSM은 KTC heartbeat fiber 안에서 동기 결합되어 있어 full refactor가 6h+. **진짜 fragility는 콜백 silent failure 2 site에 집중**. 그것만 honest scope로 닫는 PR.

## 변경 요약

### Fix 1 — Lifecycle callback exception swallow

| Site | Before | After |
|------|--------|-------|
| \`keeper_post_turn.ml:186\` \`on_compaction_started ()\` | naked invocation, 예외 시 lifecycle abort, operator 무가시 | try/with → \`Eio.Cancel.Cancelled\` 재발송 / 그 외 \`metric_keeper_lifecycle_callback_failures{callback=on_compaction_started}\` + \`Log.Keeper.warn\` + lifecycle 계속 진행 |
| \`keeper_rollover.ml:184\` \`on_started ()\` | 동일 | 동일 (callback=on_handoff_started) |

카디널리티: 2 시리즈 ({on_compaction_started, on_handoff_started}).

### Fix 2 — drain_turn_event_bus call-site attribution

\`keeper_unified_turn.ml:1432\`의 local closure \`drain_turn_event_bus\`가 6 사이트에서 호출됨. PR-B에서 *의도적 fire-and-forget*로 분류된 ignore 동작은 유지하되, **얼마나 자주 / 어디서** 발생하는지 가시화.

\`?site\` 옵셔널 인자 + 6 caller 라벨 부착:

| Site | site 라벨 |
|------|----------|
| line 1456 (background poll fiber) | \`background_poll\` |
| line 1486 (unsubscribe finaliser) | \`unsubscribe_final\` |
| line 1717 (reconcile pre-check) | \`reconcile_pre_check\` |
| line 1904 (context overflow capture) | \`context_overflow_capture\` |
| line 2004 (error path drain) | \`error_path_drain\` |
| line 2073 (turn finalize capture) | \`turn_finalize_capture\` |

카디널리티: 6 site × 2 outcome (\`drained\`/\`empty\`) = 12 시리즈.

### Doc — \`docs/architecture/actor-mailbox-pattern.md\` (NEW)

masc-mcp가 *이미 가진* actor-mailbox 패턴 SSOT. 130줄. 포함:
- 기존 사례 4개 (Session/Board/Pulse/SSE) + file:line
- when to use / when NOT to use (over-engineering 경고)
- anti-patterns 5개 (memory feedback files 인용)
- "5 sub-FSM actor화는 measurement 후 결정" 명시 — 본 PR + PR-I의 카운터로 4주 데이터 수집 후 판단

## OAS 경계

OAS 저장소 변경 0. 모든 변경은 masc-mcp 내부 — \`lib/keeper/\`, \`lib/prometheus.{ml,mli}\`, \`docs/\`, \`test/\`.

## 회귀 검증

| 테스트 | 결과 |
|--------|------|
| \`test_keeper_callback_hardening.exe\` (new) | 7/7 in 0.002s |
| \`test_keeper_state_machine.exe\` | 110/110 in 0.065s |
| \`test_keeper_composite_observer.exe\` | 9/9 in 0.018s |
| \`dune build --root=. lib/keeper/\` | green |

## 의도적 out-of-scope

- **5 sub-FSM 모두 actor화**: trail #3 원 의도. 본 PR이 콜백/drain fragility를 카운터로 surface한 후 측정 데이터(4주)로 ROI 판단. 측정 없이 큰 refactor 진행 금지 (CLAUDE.md \`empirical-before-design\` 원칙).
- **Liveness invariant**: TLA+ owner.
- **post_turn record 새 필드**: 다운스트림 serializer 영향 회피, counter+log로 충분.

## TLA+/PR 추적 가능성

- PR #11120 (PR-H, joint invariant tests) — 4 SafetyInvariant 검증
- PR #11127 (PR-I, per-edge counter) — KSM↔KCL/KMC/KTC 4 edge 측정
- PR #11129 (PR-J, this) — KCL→KSM callback path + drain attribution

세 PR 합치면 cross-FSM 결합 면(invariant + edge frequency + callback fragility) 모두 측정 가능 상태.

## Test Plan

- [x] 새 테스트 7/7 pass
- [x] 회귀 0
- [x] 카디널리티 분석 (lifecycle 2, drain 12)
- [x] OAS 변경 0
- [ ] CI green 후 ready 전환