### PR TITLE
feat(observability): emit [substrate:task_assignment] per keeper turn (Phase 3)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -373,6 +373,26 @@ let run_turn
    Log.Keeper.info
      "[substrate:system_prompt] agent=%s turn=%d length=%d hash=%s"
      meta.agent_name (start_turn_count + 1) segment.bytes hash16);
+  (* [substrate:task_assignment] — turn-level fingerprint of the user
+     message (the task body the LLM actually sees this turn) plus the
+     dynamic_context that wraps it (current task, memory continuity,
+     temporal summary, route hint). Operators can confirm whether the
+     task body changed between turns ("did the keeper get a new task,
+     or replay the same prompt?") without dumping the raw text. Phase 3
+     of substrate observability. *)
+  (let user_seg = prompt_metrics.user_message_segment in
+   let dyn_seg = prompt_metrics.dynamic_context_segment in
+   let pick_hash16 segment =
+     match segment.fingerprint with
+     | Some hex when String.length hex >= 16 -> String.sub hex 0 16
+     | Some hex -> hex
+     | None -> "empty"
+   in
+   Log.Keeper.info
+     "[substrate:task_assignment] agent=%s turn=%d user_length=%d \
+      user_hash=%s dyn_length=%d dyn_hash=%s"
+     meta.agent_name (start_turn_count + 1) user_seg.bytes
+     (pick_hash16 user_seg) dyn_seg.bytes (pick_hash16 dyn_seg));
   (* 6. Append user message and persist.
      On retry (is_retry=true), the user message was already persisted by the
      first attempt.  Checkpoint reload does not include it (checkpoint is


### PR DESCRIPTION
## Summary

Phase 3 of substrate observability. Phases 1+2 (#11125 — tool_surface, #11133 — system_prompt) covered the static surface. This phase covers the per-turn dynamic input: the user message (task body) and the dynamic_context (current task + memory + temporal + route hints).

## Hook point

Same site as Phase 2 (`keeper_agent_run.ml`, right after `build_prompt_metrics`). Both segments' fingerprints + byte counts are already computed by `build_prompt_metrics`, so this PR only adds a single log line per turn — no new hashing on the hot path.

## Format

```
[substrate:task_assignment] agent=<X> turn=<N>
  user_length=<L1> user_hash=<H16>
  dyn_length=<L2> dyn_hash=<H16>
```

## Why two segments

| Field | Question it answers | Drift behavior |
|-------|---------------------|----------------|
| `user_length` / `user_hash` | Did the keeper receive a new task body, or replay the same prompt? | Stable across retries; changes when `claim`/`board` returns a new task |
| `dyn_length` / `dyn_hash` | Did continuity / memory / temporal context shift? | Drifts naturally turn-to-turn as memory accumulates; useful for spotting `context_compact` transitions |

## Phase plan

| # | Signal | Hook point | Status |
|---|--------|-----------|--------|
| 1 | tool_surface | `Event_bus.TurnReady` | #11125 (Build/Test pending; Lint/TLA+/Health/Dashboard already passed) |
| 2 | system_prompt | `keeper_agent_run.ml:356` | merged via #11133 |
| 3 | task_assignment | `keeper_agent_run.ml:356` (same site, different segments) | **this PR** |
| 4 | context_pollution | retrospective analyzer | follow-up |

## Test plan

- [x] Manual mental syntax check (record field access matches `prompt_segment_metrics` definition)
- [ ] CI Build + Lint green
- [ ] After merge: a single keeper turn produces all three substrate lines (`tool_surface`, `system_prompt`, `task_assignment`)
- [ ] `user_hash` stable across retries of the same task; `dyn_hash` drifts as memory accumulates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
