### PR TITLE
feat(cascade): expose keep_alive override via cascade.toml

### DIFF
--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -294,9 +294,23 @@ let profile_field_json ~profile_name ~field_name field_value =
       match api_key_env_json ~path:profile_path field_value with
       | Ok value -> Ok [ (profile_name ^ "_api_key_env", value) ]
       | Error _ as err -> err)
+  | "keep_alive" -> (
+      (* Ollama [keep_alive] override surfaced from cascade.toml. Value is a
+         duration string ("5m", "30m"), integer-as-string ("3600"), or "-1"
+         to keep the model loaded indefinitely. Honored only when the
+         resolved provider is Ollama. The downstream consumer in
+         cascade_config_loader.ml (line 324-328) already reads
+         "<profile>_keep_alive" via read_string_field; without this
+         materializer arm the loader silently falls back to
+         default_keep_alive and the per-cascade override is unreachable
+         from TOML. *)
+      match trimmed_nonempty_string ~path:profile_path field_value with
+      | Ok value ->
+          Ok [ (profile_name ^ "_keep_alive", `String value) ]
+      | Error _ as err -> err)
   | other ->
       errorf
-        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, keeper_assignable, fallback_cascade, api_key_env"
+        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, keeper_assignable, fallback_cascade, api_key_env, keep_alive"
         other profile_name
 
 let profile_table_json_fields ~profile_name value =

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -144,6 +144,54 @@ fallback_cascade = "big_three"
         "big_three"
         (json |> member "ollama_only_fallback_cascade" |> to_string)
 
+let test_keep_alive_field_is_parsed () =
+  match
+    Masc_mcp.Cascade_toml_materializer.render_toml_string_to_json_string
+      {|
+[ollama_only]
+models = ["ollama:qwen3.6:27b-coding-nvfp4"]
+keep_alive = "-1"
+|}
+  with
+  | Error msg -> failf "expected keep_alive to parse, got: %s" msg
+  | Ok json_str ->
+      let json = Yojson.Safe.from_string json_str in
+      check string "keep_alive key is rendered"
+        "-1"
+        (json |> member "ollama_only_keep_alive" |> to_string)
+
+let test_keep_alive_duration_string_is_parsed () =
+  match
+    Masc_mcp.Cascade_toml_materializer.render_toml_string_to_json_string
+      {|
+[ollama_only]
+models = ["ollama:qwen3.6:27b-coding-nvfp4"]
+keep_alive = "30m"
+|}
+  with
+  | Error msg -> failf "expected keep_alive duration string to parse, got: %s" msg
+  | Ok json_str ->
+      let json = Yojson.Safe.from_string json_str in
+      check string "keep_alive duration is rendered as-is"
+        "30m"
+        (json |> member "ollama_only_keep_alive" |> to_string)
+
+let test_keep_alive_absent_is_backward_compatible () =
+  match
+    Masc_mcp.Cascade_toml_materializer.render_toml_string_to_json_string
+      {|
+[ollama_only]
+models = ["ollama:qwen3.6:27b-coding-nvfp4"]
+|}
+  with
+  | Error msg -> failf "minimal profile must parse, got: %s" msg
+  | Ok json_str ->
+      let json = Yojson.Safe.from_string json_str in
+      check bool "keep_alive key absent when not declared" true
+        (match json |> member "ollama_only_keep_alive" with
+         | `Null -> true
+         | _ -> false)
+
 let test_fallback_cascade_absent_is_backward_compatible () =
   match
     Masc_mcp.Cascade_toml_materializer.render_toml_string_to_json_string
@@ -356,6 +404,12 @@ let () =
             test_fallback_cascade_field_is_parsed;
           test_case "fallback_cascade absent is backward compatible" `Quick
             test_fallback_cascade_absent_is_backward_compatible;
+          test_case "keep_alive field is parsed" `Quick
+            test_keep_alive_field_is_parsed;
+          test_case "keep_alive duration string is parsed" `Quick
+            test_keep_alive_duration_string_is_parsed;
+          test_case "keep_alive absent is backward compatible" `Quick
+            test_keep_alive_absent_is_backward_compatible;
           test_case "loader catalog exposes fallback_cascade" `Quick
             test_loader_catalog_exposes_fallback_cascade;
           test_case "keeper profile drops unknown fallback target" `Quick


### PR DESCRIPTION
## Summary

`cascade.toml` 의 profile 에서 `keep_alive` field 를 직접 지정할 수 있도록 materializer whitelist 에 추가. Downstream pipeline (cascade JSON → `OAS Provider_config.t` → inference) 은 이미 이 field 를 읽도록 wired 되어 있었지만, `cascade_toml_materializer.ml` 가 whitelist 에서 빠져 있어 cascade.toml 에서 명시 시 `unknown field` error 로 reject 되어 있었음.

## Why now

`OLLAMA_KEEP_ALIVE=5m` (default) 환경에서 27b model 이 5분 idle 후 GPU memory 에서 unload 됨. 다음 inference 는 ~15-30s cold-start latency. 5-minute keeper watchdog 와 race 발생 (`stale_keeper_broadcast emitted last_turn=322s ago` 등). 

영구 fix 후보:
1. `launchctl setenv OLLAMA_KEEP_ALIVE -1` (process-wide, 모든 cascade 에 영향)
2. **이 PR**: cascade-level 명시 — `[keeper_unified] keep_alive = "-1"` 형식으로 특정 lane 만 pin

#2 가 더 fine-grained — operator 가 특정 cascade (heavy keeper lane) 만 영구 loaded 로 만들고 다른 cascade 는 default 유지 가능.

## Det evidence

- `lib/cascade/cascade_config_loader.ml:324-328` 가 이미 `<profile>_keep_alive` 를 `read_string_field` 로 읽음 (with `default_keep_alive` fallback)
- `oas/lib/llm_provider/provider_config.ml:45` 의 `Provider_config.t.keep_alive : string option` field 가 이미 존재
- 유일한 blocker = `cascade_toml_materializer.ml:299` whitelist 에 `keep_alive` 미포함

## Value semantics

- 정수-as-string: `"-1"` (영구 loaded), `"3600"` (1시간)
- duration string: `"5m"`, `"30m"`
- Honored only when resolved provider 가 Ollama

## Test plan

- [x] `keep_alive integer-as-string ("-1") renders <profile>_keep_alive` PASS
- [x] `keep_alive duration string ("30m") passes through verbatim` PASS
- [x] `keep_alive absent stays backward-compatible (key not emitted)` PASS
- [x] 기존 13 test 영향 없음 (build clean, 2 기존 fail 은 `MASC_CASCADE_TOML_PATH` 환경변수 누락 — 내 변경 무관)

## Refs

- Sibling cycle: `~/.gemini/policies/auto-saved.toml` ReDoS 47-line removal (cascade reject 100% 해소)
- Sibling cycle: cycle15 cascade.toml ollama+spark 50/50 (호출 빈도 mitigation)
- Memory: `feedback_ollama_keepalive_kv_cache_root_cause.md` (Det root cause record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)