### PR TITLE
fix(dashboard): hex literals in Mermaid classDef across panels (sweep)

### DIFF
--- a/dashboard/src/components/harness-health.test.ts
+++ b/dashboard/src/components/harness-health.test.ts
@@ -317,6 +317,8 @@ describe('HarnessHealth', () => {
     expect(source).toContain('class evaluator activeRail;')
     expect(source).toContain('교체 신호')
     expect(source).toContain('/api/v1/dashboard/harness-health')
+    // Mermaid classDef parser cannot lex CSS var(--token) — colors must stay as hex literals.
+    expect(source).not.toMatch(/classDef[^\n]*var\(/)
   })
 
   it('updates the handoff rail immediately on keeper_handoff SSE events', async () => {

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -136,12 +136,12 @@ export function buildHarnessFlowMermaid(data: HarnessHealthData): string {
   const currentRail = activeRail(data)
   const source = [
     'flowchart LR',
-    '  classDef source fill:var(--panel-dark),stroke:var(--slate-600),color:#cbd5e1;',
-    '  classDef hub fill:#111827,stroke:var(--sky-400),color:#e0f2fe;',
-    '  classDef healthyRail fill:#082f1d,stroke:var(--color-status-ok),color:#dcfce7;',
-    '  classDef warningRail fill:#3b2a07,stroke:var(--color-status-warn),color:var(--yellow-100);',
-    '  classDef staleRail fill:#1f2937,stroke:var(--slate-400),color:var(--frost-100),stroke-dasharray: 5 3;',
-    '  classDef idleRail fill:#111827,stroke:var(--slate-600),color:var(--slate-400),stroke-dasharray: 3 4;',
+    '  classDef source fill:#0f172a,stroke:#475569,color:#cbd5e1;',
+    '  classDef hub fill:#111827,stroke:#38bdf8,color:#e0f2fe;',
+    '  classDef healthyRail fill:#082f1d,stroke:#4ade80,color:#dcfce7;',
+    '  classDef warningRail fill:#3b2a07,stroke:#fbbf24,color:#fde68a;',
+    '  classDef staleRail fill:#1f2937,stroke:#94a3b8,color:#e2e8f0,stroke-dasharray: 5 3;',
+    '  classDef idleRail fill:#111827,stroke:#475569,color:#94a3b8,stroke-dasharray: 3 4;',
     '  classDef activeRail stroke:#7dd3fc,stroke-width:3px;',
     '  taskDone["작업 완료<br/>판정 검증"]',
     '  keeperTurn["keeper 턴<br/>압축 압력"]',


### PR DESCRIPTION
## 증상

dashboard \"감시 흐름도\" Mermaid 그래프가 *render 안 되고* 본문에 raw parse error 가 그대로 노출.

\`\`\`
Parse error on line 2: ...sDef source fill:var(--panel-dark),strok
-----------------------^
Expecting ... got '(-'
\`\`\`

## 원인 + 같은 결함 3번째 발화

Mermaid \`classDef\` parser 는 CSS \`var(--token)\` 의 \`(\` 를 property delimiter 로 오해석 → 전체 다이어그램 fallback. **이 bug class 가 dashboard 에서 세 번째 발화**:

| # | 위치 | 시점 | 결과 |
|---|---|---|---|
| 1 | \`composite-fsm-flowchart.ts\` | PR #8843 | fix + negative assertion 추가 |
| 2 | \`harness-health.ts\` | 본 PR (이번 cycle) | fix + same assertion 신설 |
| 3 | \`memory-subsystems.ts\` | 본 PR (audit sweep) | fix + same assertion 신설 |

#8843 시점에 *같은 root cause 의 sweep 누락* — 같은 fix 패턴을 다른 mermaid 사용처에서 sweep 안 함. 직전에 기록한 \"Jane Street refactor sweep miss\" lesson 의 정확한 사례.

## 변경

| 파일 | 변경 |
|---|---|
| \`harness-health.ts\` (lines 139-145) | classDef 7줄 \`var()\` → hex |
| \`harness-health.test.ts\` | \`not.toMatch(/classDef[^\\n]*var\\(/)\` |
| \`memory-subsystems.ts\` (lines 50, 52) | \`var(--slate-800)\` / \`var(--warn-bright)\` → hex |
| \`memory-subsystems.test.ts\` | \`ARCHITECTURE_FLOW\` export + 동일 negative assertion |

### Token → hex 매핑 (런타임 SSOT: \`dashboard/src/styles/variables.css\`)

| token | hex | line |
|---|---|---|
| \`--panel-dark\` | \`#0f172a\` | 210 |
| \`--slate-600\` | \`#475569\` | 122 |
| \`--slate-400\` | \`#94a3b8\` | 198 |
| \`--slate-800\` | \`#1e293b\` | 200 |
| \`--sky-400\` | \`#38bdf8\` | 202 |
| \`--yellow-100\` | \`#fde68a\` | 123 |
| \`--frost-100\` | \`#e2e8f0\` | 204 |
| \`--ok\` | \`#4ade80\` | 27 |
| \`--warn\` | \`#fbbf24\` | 28 |
| \`--warn-bright\` | \`#f97316\` | 57 |

## 검증

- \`pnpm exec tsc --noEmit\` — clean (EXIT 0)
- \`pnpm exec vitest run harness-health.test.ts memory-subsystems.test.ts\` — 32/32 passed
- 두 negative assertion 으로 \`var()\` 재유입 차단

## 미검증 / 알려진 잔재

- 시각 검증: \`pnpm dev\` 띄워서 \`#harness-health\` + memory-subsystems 패널 그래프 렌더 확인은 별도 cycle (happy-dom 은 mermaid 실제 render 안 함)
- **Lint-level gate**: 모든 mermaid source 자동 sweep 은 별도 PR — \`rg \"classDef[^\\n]*var\\(\" dashboard/src/components/\` 의 결과를 CI 에서 fail 시키는 lint script. 현재는 파일별 inline assertion 이라 새 파일에서 같은 sweep miss 가능
- 더 깔끔한 미래 해결: Mermaid \`init\` directive 의 \`themeVariables\` 로 토큰 주입 — 별도 RFC

## Self-review (best-programmer)

- 목표: Mermaid parse error 제거 + 회귀 차단 + 같은 root cause sweep
- 변경 범위: 4 파일. sweep 외 코드 미변경
- 검증: tsc clean + 32/32 vitest green
- 미검증: 시각 렌더 (dev server 필요), lint-level sweep automation (별도 cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)