### PR TITLE
fix(keeper): annotate pick_hash16 segment as prompt_segment_metrics

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -382,7 +382,7 @@ let run_turn
      of substrate observability. *)
   (let user_seg = prompt_metrics.user_message_segment in
    let dyn_seg = prompt_metrics.dynamic_context_segment in
-   let pick_hash16 segment =
+   let pick_hash16 (segment : Keeper_agent_prompt_metrics.prompt_segment_metrics) =
      match segment.fingerprint with
      | Some hex when String.length hex >= 16 -> String.sub hex 0 16
      | Some hex -> hex


### PR DESCRIPTION
## Summary
- main 빌드가 `keeper_agent_run.ml:387`에서 깨짐: `match segment.fingerprint with | Some hex ...` 가 string option을 기대했지만 OCaml은 string 타입의 fingerprint 필드를 가진 다른 record(예: `Keeper_failure_circuit_breaker.t`)와 충돌
- 1줄 fix: `pick_hash16` 파라미터에 명시적 타입 annotation 추가 — `(segment : Keeper_agent_prompt_metrics.prompt_segment_metrics)`
- 동작 변경 없음 — row resolution만 명시화

## 검증
- [x] `dune build --root . @check` exit 0

## 컨텍스트
- 같은 fix는 PR #11134(`feat(keeper): harden cross-FSM callback contracts`)에 이미 amend되어 있지만, 그 PR은 review 중이라 main은 그동안 빨간 상태
- 이 PR은 standalone fast-forward fix — 1줄 변경, low risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
