### PR TITLE
fix(dashboard): sweep memory-subsystems classDef var() to hex (Mermaid parse audit)

### DIFF
--- a/dashboard/src/components/memory-subsystems.test.ts
+++ b/dashboard/src/components/memory-subsystems.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { MemorySubsystemsSynapse } from '../api/dashboard'
-import { filterSynapses } from './memory-subsystems'
+import { ARCHITECTURE_FLOW, filterSynapses } from './memory-subsystems'
 
 function makeSynapse(
   overrides: Partial<MemorySubsystemsSynapse> = {},
@@ -81,5 +81,19 @@ describe('filterSynapses', () => {
     expect(result).toHaveLength(2)
     expect(result.map(r => r.from_agent)).toContain('router-delta')
     expect(result.map(r => r.to_agent)).toContain('router-delta')
+  })
+})
+
+describe('ARCHITECTURE_FLOW', () => {
+  // Mermaid classDef cannot lex CSS var(--token); paren confuses the property
+  // delimiter and the whole diagram falls back to the parse error bomb SVG.
+  // Same root cause as PR #8843 (composite-fsm-flowchart) and #11141
+  // (harness-health). Keep colors as hex literals here too.
+  it('uses literal hex colors in classDef (no CSS var())', () => {
+    const classDefLines = ARCHITECTURE_FLOW.split('\n').filter(l => /^\s*classDef\s+/.test(l))
+    expect(classDefLines.length).toBeGreaterThan(0)
+    for (const line of classDefLines) {
+      expect(line).not.toMatch(/var\(--/)
+    }
   })
 })

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -18,7 +18,7 @@ import { openAgentDetail } from './agent-detail-state'
 
 const REFRESH_MS = 30_000
 
-const ARCHITECTURE_FLOW = `graph LR
+export const ARCHITECTURE_FLOW = `graph LR
     subgraph Keeper["키퍼 턴"]
       K1[LLM 응답 생성] --> K2["[STATE] 파싱"]
       K2 --> K3{STATE 있음?}
@@ -47,9 +47,9 @@ const ARCHITECTURE_FLOW = `graph LR
     G1 --> D1
     D1 --> UI[기억 서브시스템 패널]
 
-    classDef store fill:var(--slate-800),stroke:#334155,color:#f1f5f9
+    classDef store fill:#1e293b,stroke:#334155,color:#f1f5f9
     classDef action fill:#0f766e,stroke:#14b8a6,color:#f0fdfa
-    classDef ui fill:#7c2d12,stroke:var(--warn-bright),color:#ffedd5
+    classDef ui fill:#7c2d12,stroke:#f97316,color:#ffedd5
     class F1,G1 store
     class M1,M3,H1,H2,T2 action
     class UI ui`


### PR DESCRIPTION
## Context

#11141 머지 완료 후 (\`ceddae0dbe\`) 같은 audit 의 잔존 발생처를 sweep. 같은 PR 에 묶으려 한 commit 이 *#11141 squash merge 직후 머지된 branch 에 push 된 cycle 결함* 으로 main 미도달 → 새 branch + 새 PR 로 복구.

## 결함 위치

\`dashboard/src/components/memory-subsystems.ts:50,52\` 에 \`classDef ... fill:var(--slate-800)\` / \`stroke:var(--warn-bright)\` 가 잔존. 이는 Mermaid \`classDef\` parser 의 \`(\` lex 결함을 *3번째* 발화시킨다.

| # | 위치 | 시점 |
|---|---|---|
| 1 | \`composite-fsm-flowchart.ts\` | PR #8843 |
| 2 | \`harness-health.ts\` | PR #11141 |
| 3 | \`memory-subsystems.ts\` | **본 PR** |

#8843 시점 sweep miss + #11141 도 같은 PR 안에 묶지 못함 — 직전에 갱신한 \"Jane Street refactor sweep miss\" lesson 에 본 사례 추가 기록함.

## 변경

| 파일 | 변경 |
|---|---|
| \`memory-subsystems.ts\` | \`var(--slate-800)\` → \`#1e293b\`, \`var(--warn-bright)\` → \`#f97316\`. \`ARCHITECTURE_FLOW\` export (test 가능하도록) |
| \`memory-subsystems.test.ts\` | \`classDef\` 라인에 \`var(\` 없음을 검사하는 negative assertion (#8843, #11141 과 동일 패턴) |

## 검증

- \`pnpm exec tsc --noEmit\` — clean (EXIT 0)
- \`pnpm exec vitest run memory-subsystems.test.ts harness-health.test.ts composite-fsm-flowchart.test.ts\` — 42/42 passed
- 세 mermaid source 모두 동일 negative assertion 으로 보호됨

## 미검증 / 잔재

- 시각 검증: \`pnpm dev\` 띄워 memory-subsystems 패널 그래프 렌더 확인은 별도 cycle (happy-dom 은 mermaid 실 render 안 함)
- **Lint-level gate**: 새 mermaid source 가 추가될 때 자동 검사하는 CI script — 별도 cycle. 현재는 파일별 inline assertion 이라 새 파일에서 같은 sweep miss 가능

## Cycle self-critique

- 본 commit 은 원래 #11141 안에 함께 가야 했지만, push 전 \`gh pr view --json state\` 확인 누락으로 머지된 branch 에 push 되어 main 미도달
- 직전 cycle 메모리에 정확히 같은 lesson (\"Squash merge 후 브랜치 push 금지\") 이 있었음에도 같은 cycle 안에서 위반 — 메타인지 실패. 본 PR 는 그 복구

🤖 Generated with [Claude Code](https://claude.com/claude-code)