### PR TITLE
fix(auth): self-heal dual-identity by archiving stale bare credentials (PR-3a/4)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -865,6 +865,64 @@ let verify_token config ~agent_name ~token : (agent_credential, masc_error) resu
             else
               Ok cred
 
+(* Extract the bare keeper nickname from a canonical agent_name of the
+   form "keeper-<n>-agent". Returns None for non-canonical names. Kept
+   as an inline helper to avoid adding a lib/auth -> lib/keeper
+   dependency for a single string operation. *)
+let bare_keeper_name_from_canonical canonical =
+  let prefix = "keeper-" in
+  let suffix = "-agent" in
+  let plen = String.length prefix in
+  let slen = String.length suffix in
+  let len = String.length canonical in
+  if len > plen + slen
+     && String.sub canonical 0 plen = prefix
+     && String.sub canonical (len - slen) slen = suffix
+  then Some (String.sub canonical plen (len - plen - slen))
+  else None
+
+(* Archive a credential file that we want to retire without deleting.
+   Destination: auth_dir/.archive/<epoch>/<file>. Operator can review
+   and restore. *)
+let archive_credential_file config ~agent_name ~reason =
+  let src = credential_file config agent_name in
+  if not (file_exists src) then ()
+  else
+    try
+      let stamp = string_of_int (int_of_float (Unix.gettimeofday ())) in
+      let dest_dir = Filename.concat (auth_dir config) (Filename.concat ".archive" stamp) in
+      Fs_compat.mkdir_p dest_dir;
+      let dest = Filename.concat dest_dir (agent_name ^ ".json") in
+      Sys.rename src dest;
+      Log.Auth.warn
+        "archived credential %s -> %s (reason: %s)"
+        src dest reason
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Auth.error
+          "archive_credential_file failed for %s: %s"
+          agent_name (Printexc.to_string exn)
+
+(* Self-heal of dual-identity: when the canonical credential is written
+   for [keeper-<n>-agent], if a bare [<n>.json] credential exists with
+   a *different* token hash, archive the bare file. Same-token bare
+   files are harmless (both names resolve to the same identity) and
+   left in place. Idempotent: once archived, subsequent boots see no
+   bare file and become no-ops. Spec: AuthIdentityFSM.tla I1
+   IdentityBindsToken (a token must bind to one principal). *)
+let archive_bare_if_dual_identity config ~canonical_name ~canonical_token_hash =
+  match bare_keeper_name_from_canonical canonical_name with
+  | None -> ()
+  | Some bare_name -> (
+      match load_credential config bare_name with
+      | None -> ()
+      | Some bare_cred when String.equal bare_cred.token canonical_token_hash ->
+          ()
+      | Some _ ->
+          archive_credential_file config ~agent_name:bare_name
+            ~reason:"dual-identity: bare token differs from canonical")
+
 let ensure_keeper_credential config ~agent_name :
     (string * agent_credential, masc_error) result =
   ignore (ensure_internal_keeper_token config);
@@ -893,21 +951,30 @@ let ensure_keeper_credential config ~agent_name :
     save_credential config cred;
     (raw_token, cred)
   in
-  try
-    match load_raw_token config ~agent_name with
-    | Some raw_token -> (
-        match verify_token config ~agent_name ~token:raw_token with
-        | Ok cred when String.equal cred.agent_name agent_name ->
-            Ok (raw_token, cred)
-        | Ok _ | Error _ -> Ok (create_fresh_keeper_token ()))
-    | None -> Ok (create_fresh_keeper_token ())
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    let msg =
-      Printf.sprintf "Failed to save keeper credential: %s"
-        (Printexc.to_string exn)
-    in
-    Log.Auth.error "%s" msg;
-    Error (IoError msg)
+  let result =
+    try
+      match load_raw_token config ~agent_name with
+      | Some raw_token -> (
+          match verify_token config ~agent_name ~token:raw_token with
+          | Ok cred when String.equal cred.agent_name agent_name ->
+              Ok (raw_token, cred)
+          | Ok _ | Error _ -> Ok (create_fresh_keeper_token ()))
+      | None -> Ok (create_fresh_keeper_token ())
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+      let msg =
+        Printf.sprintf "Failed to save keeper credential: %s"
+          (Printexc.to_string exn)
+      in
+      Log.Auth.error "%s" msg;
+      Error (IoError msg)
+  in
+  (match result with
+   | Ok (_raw, cred) ->
+       archive_bare_if_dual_identity config
+         ~canonical_name:agent_name
+         ~canonical_token_hash:cred.token
+   | Error _ -> ());
+  result
 
 (** Refresh a token (generate new one, update credential) *)
 let refresh_token config ~agent_name ~old_token : (string * agent_credential, masc_error) result =

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -432,7 +432,19 @@ let test_verify_token_keeper_exact_match () =
            "keeper credential should verify with exact agent_name: %s"
            (Types.masc_error_to_string e))
 
-let test_verify_token_keeper_alias_accepts_stable_owner_after_bootstrap () =
+(* Was: this test validated a legacy fallback where a bare-form
+   credential ("sangsu") was accepted as a verification source for a
+   canonical lookup ("keeper-sangsu-agent"). That fallback was the
+   mechanism by which dual-identity credentials silently coexisted --
+   any path that minted a bare credential created a second valid
+   identity for the same keeper.
+
+   PR-3a self-heals dual-identity: ensure_keeper_credential archives
+   the bare-form credential when its token differs from the canonical.
+   The bare token therefore must NOT verify against the canonical
+   name after bootstrap. Spec: AuthIdentityFSM.tla I1
+   IdentityBindsToken (a token must bind to exactly one principal). *)
+let test_verify_token_keeper_alias_archives_dual_identity_bare () =
   let dir = setup_test_room () in
   Fun.protect
     ~finally:(fun () -> cleanup_test_room dir)
@@ -442,7 +454,7 @@ let test_verify_token_keeper_alias_accepts_stable_owner_after_bootstrap () =
           fail
             (Printf.sprintf "stable keeper token creation failed: %s"
                (Types.masc_error_to_string e))
-      | Ok (stable_raw_token, _) -> (
+      | Ok (stale_bare_token, _) -> (
           match
             Auth.ensure_keeper_credential dir
               ~agent_name:"keeper-sangsu-agent"
@@ -452,21 +464,22 @@ let test_verify_token_keeper_alias_accepts_stable_owner_after_bootstrap () =
                 (Printf.sprintf "keeper credential bootstrap failed: %s"
                    (Types.masc_error_to_string e))
           | Ok _ -> (
-              check bool "exact alias credential exists" true
+              check bool "canonical credential exists" true
                 (Option.is_some
                    (Auth.load_credential dir "keeper-sangsu-agent"));
+              (* PR-3a behavior: bare credential is archived, the bare
+                 token is now stale and must not authenticate. *)
               match
                 Auth.verify_token dir ~agent_name:"keeper-sangsu-agent"
-                  ~token:stable_raw_token
+                  ~token:stale_bare_token
               with
               | Ok cred ->
-                  check string "stable keeper owner accepted" "sangsu"
-                    cred.agent_name
-              | Error e ->
                   fail
                     (Printf.sprintf
-                       "keeper alias should accept stable owner token after bootstrap: %s"
-                       (Types.masc_error_to_string e)))))
+                       "stale bare token must NOT verify against canonical \
+                        after PR-3a self-heal (got cred owner=%s)"
+                       cred.agent_name)
+              | Error _ -> ())))
 
 let test_load_credential_missing_keeper_alias_stays_quiet () =
   let dir = setup_test_room () in
@@ -575,6 +588,78 @@ let test_ensure_keeper_credential_uses_per_keeper_token () =
             (Printf.sprintf
                "ensure_keeper_credential should mint a per-keeper token: %s"
                (Types.masc_error_to_string e)))
+
+(* PR-3a regression guards: ensure_keeper_credential self-heals
+   dual-identity by archiving any pre-existing bare-form credential
+   whose token differs from the canonical. Spec: AuthIdentityFSM.tla
+   I1 IdentityBindsToken. *)
+
+let archive_dir_of dir = Filename.concat (Auth.auth_dir dir) ".archive"
+
+let archive_contains dir filename =
+  let archive = archive_dir_of dir in
+  if not (Sys.file_exists archive) then false
+  else
+    let stamps = Sys.readdir archive in
+    Array.exists
+      (fun stamp ->
+        let stamp_path = Filename.concat archive stamp in
+        Sys.is_directory stamp_path
+        && Array.exists (String.equal filename) (Sys.readdir stamp_path))
+      stamps
+
+let test_ensure_keeper_credential_archives_dual_identity_bare () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore
+        (Auth.enable_auth dir ~require_token:true
+           ~agent_name:"bootstrap-admin");
+      (* Historical residue: a bare-form credential created by an older
+         path (e.g., pre-#10440 boot, CLI login) with its own token. *)
+      let _ =
+        match Auth.create_token dir ~agent_name:"sangsu" ~role:Types.Worker with
+        | Ok r -> r
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      let bare_path = Auth.credential_file dir "sangsu" in
+      check bool "bare credential pre-exists" true (Sys.file_exists bare_path);
+      (* Now ensure the canonical is created — should self-heal. *)
+      (match
+         Auth.ensure_keeper_credential dir
+           ~agent_name:"keeper-sangsu-agent"
+       with
+       | Ok _ -> ()
+       | Error e -> fail (Types.masc_error_to_string e));
+      check bool "bare credential moved out of agents/" false
+        (Sys.file_exists bare_path);
+      check bool "bare credential archived" true
+        (archive_contains dir "sangsu.json");
+      let canonical_path =
+        Auth.credential_file dir "keeper-sangsu-agent"
+      in
+      check bool "canonical credential remains" true
+        (Sys.file_exists canonical_path))
+
+let test_ensure_keeper_credential_no_archive_when_no_bare () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore
+        (Auth.enable_auth dir ~require_token:true
+           ~agent_name:"bootstrap-admin");
+      (* Clean state: only the canonical is created. No bare residue. *)
+      (match
+         Auth.ensure_keeper_credential dir
+           ~agent_name:"keeper-sangsu-agent"
+       with
+       | Ok _ -> ()
+       | Error e -> fail (Types.masc_error_to_string e));
+      let archive = archive_dir_of dir in
+      check bool "no archive directory created on clean state" false
+        (Sys.file_exists archive))
 
 let test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched () =
   let dir = setup_test_room () in
@@ -927,8 +1012,8 @@ let () =
         test_extract_agent_type_prefix_keeper_aliases;
       test_case "verify_token keeper exact match" `Quick
         test_verify_token_keeper_exact_match;
-      test_case "verify_token keeper alias accepts stable owner after bootstrap" `Quick
-        test_verify_token_keeper_alias_accepts_stable_owner_after_bootstrap;
+      test_case "verify_token keeper alias archives dual-identity bare" `Quick
+        test_verify_token_keeper_alias_archives_dual_identity_bare;
       test_case "load_credential missing keeper alias stays quiet" `Quick
         test_load_credential_missing_keeper_alias_stays_quiet;
       test_case "verify_token dashboard legacy alias fallback" `Quick
@@ -939,6 +1024,10 @@ let () =
         test_ensure_keeper_credential_uses_per_keeper_token;
       test_case "ensure_keeper_credential reuses uuid" `Quick
         test_ensure_keeper_credential_reuses_uuid;
+      test_case "ensure_keeper_credential archives dual-identity bare" `Quick
+        test_ensure_keeper_credential_archives_dual_identity_bare;
+      test_case "ensure_keeper_credential no archive on clean state" `Quick
+        test_ensure_keeper_credential_no_archive_when_no_bare;
     ];
     "permissions", [
       test_case "worker permissions" `Quick test_worker_permissions;


### PR DESCRIPTION
## 목적

masc-mcp Auth/Identity FSM Canonicalization 플랜의 **PR-3a**. 6 keepers(sangsu, issue_king, janitor, masc-improver, nick0cave, qa-king)에게 누적된 dual-identity credential을 *boot 시점에 자가 치유*. PR-1(#11126) TLA+ 불변 **I1 IdentityBindsToken**과 정합. PR-2(#11132) silent default 제거 위에 쌓이는 두 번째 정합화 단계.

전체 플랜: `~/me/planning/claude-plans/partitioned-hopping-hinton.md`

## 진단 (왜 dual-identity가 살아있는가)

코드 분석 + 운영 실측 결과 세 가지 메커니즘이 합쳐져 발생:

1. **`ensure_credential_alias` 메커니즘이 keeper에 대해 broken** (`lib/auth.ml:445-494`). canonical credential이 *redirect stub*이어야만 alias 작성에 성공하는데, `ensure_keeper_credential`은 *direct credential*을 쓴다. 그래서 매 boot마다 `lib/server/server_runtime_bootstrap.ml:949-967`이 `short-form alias write failed` warn을 출력 — alias가 안 만들어짐.

2. **`load_credential_with_aliases` legacy fallback**(`lib/auth.ml:346-352`)이 bare nickname(`sangsu.json`)을 keeper alias 검색의 fallback으로 받아준다. 이 fallback이 *bare credential을 작동시키는 메커니즘* — bare가 작동하니 다른 path가 만들 수 있고, 다른 path가 만든 bare가 *다른 토큰*으로 살아남는다.

3. **호출자 어떤 path가 bare를 만드는가** (Explore 결과):
   - `lib/auth_login.ml:85` (CLI auth login — 사용자 입력 그대로)
   - `lib/server/server_runtime_bootstrap.ml:868` (`sync_client_token_file` — bootstrap)
   - `lib/worker_container_types.ml:607` (worker pool, bare worker name)
   - 또는 #10440 이전의 historical residue

운영 실측: `~/me/.masc/auth/agents/` 에 `sangsu.json`(bare) + `keeper-sangsu-agent.json`(canonical) 같은 *다른 토큰* 페어 6쌍 확인. memory `feedback_dual-identity-credential-coexistence.md`, `feedback_keeper-credential-name-drift.md` (500/day failure on the live fleet)와 일치.

## 변경 요지

`lib/auth.ml`에 boot self-heal 추가:

```ocaml
let bare_keeper_name_from_canonical canonical =
  (* "keeper-<n>-agent" -> Some "<n>", else None. inline 5 lines. *)

let archive_credential_file config ~agent_name ~reason =
  (* auth_dir/.archive/<epoch>/<name>.json 으로 이동. NOT delete. *)

let archive_bare_if_dual_identity config ~canonical_name ~canonical_token_hash =
  (* canonical 작성 후 호출. bare가 다른 토큰으로 존재하면 archive. *)
  (* 같은 토큰이면 무해 = no-op. Idempotent. *)
```

`ensure_keeper_credential` 결과 분기 끝에서 한 줄 호출. 외부 export 없음 (auth.mli 변경 0).

### 핵심 특성

| 속성 | 보장 |
|---|---|
| 비파괴 | `Sys.rename`으로 archive 디렉토리 이동, 삭제 X |
| 멱등 | 한 번 archive된 후엔 bare 파일 없음 → no-op |
| 보수적 | 같은 토큰이면 무해(같은 신원 두 alias) → 그대로 둠 |
| 회복 | operator가 `.archive/<epoch>/`에서 파일 검토/복원 가능 |

### Layering 보존

`lib/keeper/keeper_identity.ml`의 canonical 함수를 끌어다 쓰지 않고 *5줄 inline string strip*으로 처리. `lib/auth → lib/keeper` 의존성 없음.

## Spec 정합 (PR-1 TLA+)

`specs/bug-models/AuthIdentityFSM.tla`의 **I1 IdentityBindsToken**:

```
resolved_agent /= NULL =>
  (request_token /= NULL /\ request_token \in credentials[resolved_agent])
```

기존 legacy fallback은 *bare token이 canonical principal에 매칭*되게 했고, 이건 spec 의미상 I1 위반. 본 PR이 boot 시 bare를 archive로 내려 *한 토큰이 한 principal에만 매칭*되게 복원.

## ⚠️ Breaking change (의도된)

`test_verify_token_keeper_alias_accepts_stable_owner_after_bootstrap` 테스트는 *legacy fallback을 feature로 documentation*하고 있었다. 그 fallback이 정확히 dual-identity의 메커니즘이므로 폐기. 테스트는 `..._archives_dual_identity_bare`로 inverted — 이제 bare 토큰이 canonical에 대해 verify되면 **fail**.

영향 받는 사용 패턴:
- "bare credential 만들고 canonical name으로 verify" → 더 이상 안 됨 (next boot에 archive)
- 적법한 외부 caller가 있으면 canonical name으로 직접 mint해야 함

## 검증

### Unit tests (test/test_auth.ml)

```
[OK]  credentials  14  verify_token keeper alias archives dual-identity bare
[OK]  credentials  20  ensure_keeper_credential archives dual-identity bare
[OK]  credentials  21  ensure_keeper_credential no archive on clean state
```

신규 두 테스트 + rewritten 한 테스트 모두 통과. **test_auth.ml 43/43 OK**.

### Build

`dune build --root . @check` 통과 (no output = success).

### 전체 @runtest 한계

이 worktree에서 `dune build @runtest` 시도했으나 의존성 빌드가 1시간+ 소요 (다른 병렬 worktree의 같은 명령이 1h 30m째 진행 중). cross-file 회귀는 **CI에서 검증**. 호출자 두 곳(`server_runtime_bootstrap.ml:933`, `keeper_turn_up_create.ml:546`)은 `ensure_keeper_credential`의 시그니처/반환 그대로 사용 → 영향 좁음.

## 비-범위 (PR-3b/PR-3c로 분리)

이 영역의 *추가* 결함이지만 본 PR scope를 의도적으로 좁힘:

- **PR-3b** (선택): bare 파일이 더 이상 안 생긴다는 전제 위에서 `load_credential_with_aliases` 단순화 또는 `ensure_credential_alias` 정상화(canonical을 redirect stub으로 변환). PR-3a 머지 후 운영 검증 거친 뒤 결정.
- **PR-3c** (별개 옆문): `MASC_INTERNAL_MCP_TOKEN` 폐기 + `x-masc-keeper-name` 헤더 폐기 + per-keeper unique credential 일원화. 운영 변경 큼, 별도 deeper analysis + 별도 plan PR. `lib/oas_worker_exec_transport.ml:257`의 env var 의존도 변경 필요.

## Self-review

- [x] Single concern (dual-identity boot self-heal)
- [x] 비파괴 (archive, not delete)
- [x] Idempotent (반복 호출 안전)
- [x] dune build pass
- [x] test/test_auth.ml 43/43 pass
- [x] Layering 보존 (lib/auth -> lib/keeper 의존성 없음)
- [x] Breaking change 명시 + test inversion으로 새 행동 pin
- [x] 비-범위 명확히 문서화 (PR-3b/c로 분리)
- [x] PR-1 TLA+ I1 정합

## 운영 권고 (머지 후)

1. masc-mcp 재시작
2. masc-mcp-live.log에서 `archived credential ... (reason: dual-identity ...)` warn 확인 (6 keepers 정도 기대)
3. `ls ~/me/.masc/auth/agents/.archive/<epoch>/` 로 archive 파일 확인
4. `ls ~/me/.masc/auth/agents/` 에서 bare nickname(`sangsu.json` 등) 0건 수렴 확인
5. 다음 dashboard polling 주기에 `metric_silent_dashboard_actor_fallback{outcome=error,err_kind=token_mismatch}` 카운터가 멈추는지 관측

## 다음 단계

PR-3a 머지 + 운영 검증 → PR-3b(alias 메커니즘 cleanup) 또는 곧장 PR-3c(옆문 폐기) 진입. plan에 단계 명시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)