### PR TITLE
feat(dashboard): KpiCell progress prop (0-100, kind-tinted) — sweep #5 prerequisite

### DIFF
--- a/dashboard/src/components/kpi-cell.test.ts
+++ b/dashboard/src/components/kpi-cell.test.ts
@@ -165,4 +165,41 @@ describe('KpiCell component', () => {
     const el = mount({ label: 'N', value: 12 })
     expect(el.getAttribute('aria-label')).toBe('N: 12')
   })
+
+  // ── progress prop ──
+  // The progress bar fill carries `transition: width 500ms` + a width% — a
+  // stable signature happy-dom can resolve, even though it doesn't compute
+  // layout. aria-label encodes a rounded, clamped progress for SR users.
+
+  it('omits the progress bar when progress is undefined', () => {
+    const el = mount({ label: 'CTX', value: '40k' })
+    expect(el.innerHTML).not.toContain('width 500ms')
+  })
+
+  it('renders a progress bar when progress is supplied', () => {
+    const el = mount({ label: 'CTX', value: '40k', progress: 73 })
+    expect(el.innerHTML).toContain('width 500ms')
+    expect(el.innerHTML).toContain('width: 73%')
+  })
+
+  it('clamps progress >100 to 100% in the rendered fill', () => {
+    const el = mount({ label: 'CTX', value: 'overflow', progress: 142 })
+    expect(el.innerHTML).toContain('width: 100%')
+    expect(el.innerHTML).not.toContain('width: 142%')
+  })
+
+  it('clamps progress <0 to 0% in the rendered fill', () => {
+    const el = mount({ label: 'CTX', value: 'reset', progress: -25 })
+    expect(el.innerHTML).toContain('width: 0%')
+  })
+
+  it('describes progress in the aria-label (rounded, clamped)', () => {
+    const el = mount({ label: 'CTX', value: '40k', progress: 73.4 })
+    expect(el.getAttribute('aria-label')).toContain('progress 73%')
+  })
+
+  it('uses the kind value-color for the progress fill', () => {
+    const el = mount({ label: 'CTX', value: '90k', progress: 95, kind: 'warn' })
+    expect(el.innerHTML).toContain('var(--color-status-warn)')
+  })
 })

--- a/dashboard/src/components/kpi-cell.ts
+++ b/dashboard/src/components/kpi-cell.ts
@@ -54,6 +54,12 @@ export interface KpiCellProps {
    *  sites preserve existing test selectors when swapping in from
    *  hand-rolled cells. */
   testId?: string
+  /** Optional 0-100 progress bar rendered below the value. The bar fill
+   *  follows `kind` (or fg-secondary when neutral). Out-of-range values
+   *  are clamped, not rejected — caller decides whether 113% is a bug
+   *  or just "saturated". `kind` mapping is the caller's job: this
+   *  component intentionally doesn't pick warn/err thresholds. */
+  progress?: number
 }
 
 /** Assemble the screen-reader announcement for one KPI cell.
@@ -73,7 +79,10 @@ export function kpiCellAriaLabel(props: KpiCellProps): string {
           ? ' (warning)'
           : ''
   const cap = props.caption ? ` ${props.caption}` : ''
-  return `${props.label}: ${props.value}${cap}${delta}${kind}${live}`
+  const prog = props.progress != null
+    ? `, progress ${Math.round(Math.min(Math.max(props.progress, 0), 100))}%`
+    : ''
+  return `${props.label}: ${props.value}${cap}${delta}${prog}${kind}${live}`
 }
 
 const VALUE_COLOR_BY_KIND: Record<KpiCellKind, string> = {
@@ -139,6 +148,31 @@ export function KpiCell(props: KpiCellProps): VNode {
     lineHeight: 1.1,
   }
 
+  const progressRow = props.progress != null
+    ? html`
+        <div
+          aria-hidden="true"
+          style=${{
+            width: '100%',
+            height: '2px',
+            background: 'var(--color-border-default)',
+            borderRadius: '1px',
+            overflow: 'hidden',
+            marginTop: '2px',
+          }}
+        >
+          <div
+            style=${{
+              height: '100%',
+              width: `${Math.min(Math.max(props.progress, 0), 100)}%`,
+              background: valueColor,
+              transition: 'width 500ms',
+            }}
+          ></div>
+        </div>
+      `
+    : null
+
   const captionRow = (variant === 'standard' || variant === 'stacked') && (props.caption || props.delta)
     ? html`
         <span
@@ -178,6 +212,7 @@ export function KpiCell(props: KpiCellProps): VNode {
       <span aria-hidden="true" style=${labelStyle}>${props.label}</span>
       <span aria-hidden="true" style=${valueStyle}>${props.value}</span>
       ${captionRow}
+      ${progressRow}
     </div>
   `
 }


### PR DESCRIPTION
## Why

Sweep #5 (keeper-detail-panels.ts inline `KpiCard` 9 callsites → `KpiCell`) 의 prerequisite. inline `KpiCard` 는 `progress?: number` (0-100, in-cell progress bar) 를 가지고 있는데 `KpiCell` 에 없음. callsite swap 전에 primitive 부터 확장해야 시각 회귀 없이 이전 가능.

직전 회고 lesson 반영해서 한 PR 에 ① primitive 확장 + ② 9 callsite swap 안 묶음. #11135 같은 대형 PR risk 회피.

## 변경

| 파일 | 변경 |
|---|---|
| `kpi-cell.ts` | `progress?: number` prop. 2px 높이 bar, 색은 `kind` 의 valueColor 재사용. clamp 0-100. aria-label 에 rounded percent 포함 |
| `kpi-cell.test.ts` | 6 신규 케이스: clamp(<0, >100), presence/absence, kind→color forward, aria-label encoding |

설계 결정:
- **threshold (warn/err) 결정은 caller 의 domain** — `KpiCell` 은 generic primitive. caller 가 `ctxColor` 또는 자기 도메인 매핑으로 `kind` 결정해 넘김
- **bar 색은 `kind` 의 valueColor 재사용** — 새 token 추가 0건. neutral 인 경우 fg-secondary
- **aria-label 에 progress 포함** — SR 사용자가 시각 percent 와 동일한 정보 받음

## 검증

- `pnpm exec tsc --noEmit` — clean (EXIT 0)
- `pnpm exec vitest run kpi-cell.test.ts` — **19/19 passed** (기존 13 + 신규 6)
- `pnpm exec vitest run kpi-strip + overview + feature-health + harness-health + governance` — **100/100 passed** (기존 KpiStrip + 5 adopting panel 회귀 0)

## 미검증 / 잔재

- 시각 검증: dev server `pnpm dev` 띄워서 직접 보는 것은 *adopting PR* 에서 의미 있음 (이 PR 는 callsite 0 변경이라 시각 차이 없음). 다음 PR 에서 callsite 한 두 개 swap 후 사용자 화면에서 직접 검증
- happy-dom 은 layout 계산 안 하므로 *width %* 는 inline style attribute 검사로만 보장 — 실 렌더 width 의 정확성은 별도 cycle (Playwright visual diff)
- 직전 회고에서 짚은 *bare cell + KpiStrip surface 충돌 가설* 은 이 PR 와 별개. progress bar 는 cell 안쪽 element 라 strip-grid-gap 패턴과 무관

## Self-review (best-programmer)

- 목표: keeper-detail-panels sweep 의 primitive 확장 (callsite 변경 0)
- 변경 범위: 2 파일, 73 라인 (+73 / -1). 문서 + 작은 production code + 단위 test
- 검증: tsc clean + 119 vitest green (회귀 0)
- 미검증: 시각 렌더 (의도상 다음 PR 에서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
