### PR TITLE
feat(keeper): provider × MCP-config-construct SSOT audit (PR-Mp3)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -476,6 +476,7 @@
    keeper_exec_fs
    keeper_shell_docker
    keeper_egress_audit
+   keeper_mcp_provider_audit
    keeper_shell_gh_context
    keeper_shell_bg_task
    keeper_exec_shell
@@ -695,6 +696,7 @@
    keeper_exec_fs
    keeper_shell_docker
    keeper_egress_audit
+   keeper_mcp_provider_audit
    keeper_shell_gh_context
    keeper_shell_bg_task
    keeper_exec_shell

--- a/lib/keeper/keeper_mcp_provider_audit.ml
+++ b/lib/keeper/keeper_mcp_provider_audit.ml
@@ -1,0 +1,134 @@
+(** Boot-time audit for the provider × MCP-config-construct matrix.
+
+    Leak 12 (2026-04-27): masc-mcp ships three sibling code paths
+    that each construct (or fail to construct) a Bearer-token MCP
+    config JSON for a CLI subprocess, so that an LLM running inside
+    that subprocess can reach the masc-mcp HTTP server.  The defaults
+    are inconsistent and the surface is not enumerable from any
+    single SSOT —
+
+    | provider     | construct path                                     | env flag                          | default |
+    |--------------|----------------------------------------------------|-----------------------------------|---------|
+    | claude_code  | [Keeper_cli_mcp_config.try_construct_for_keeper]   | MASC_AUTO_CONSTRUCT_CLAUDE_MCP    | true    |
+    | kimi_cli     | (same module)                                      | (same)                            | true    |
+    | codex_cli    | [Server_runtime_bootstrap.sync_codex_mcp_config]   | MASC_SYNC_CODEX_MCP_CONFIG        | false   |
+    | gemini_cli   | none — only [OAS_GEMINI_NO_MCP] disable flag       | (only disable, no enable)         | n/a     |
+    | glm          | n/a — HTTP API, OAS-side dispatch                  | n/a                               | n/a     |
+    | ollama       | n/a — HTTP API, OAS-side dispatch                  | n/a                               | n/a     |
+
+    A docker keeper whose cascade routes to a CLI provider with no
+    or disabled construct path will still produce LLM responses but
+    every [keeper_*] / [masc_*] tool call will fail with
+    "tool not in session's tool registry."  Operators have no
+    runtime signal that this is happening — there is no audit that
+    reports "cascade refers to provider P, P has no construct
+    path."
+
+    This module is the SSOT for the per-provider "is auto-construct
+    active" answer.  Boot hooks consume it.  PR-Mp1 (the unified
+    construct API) will read from it as well so the inconsistency
+    only lives in one place. *)
+
+type construct_path =
+  | Auto_construct_active of {
+      env_flag : string;
+      default_when_unset : bool;
+      module_name : string;
+    }
+  | No_auto_construct_path of { reason : string }
+  | Not_applicable_http_api
+
+type result = {
+  provider : string;
+  construct : construct_path;
+}
+
+(** SSOT table.  Sourced from direct code inspection on 2026-04-27:
+
+    - [keeper_cli_mcp_config.ml:16,22] — claude_code + kimi_cli
+    - [server_runtime_bootstrap.ml:625,798,801] — codex_cli
+    - [keeper_types_profile.ml:1298] — gemini_cli (disable flag only)
+    - [llm_provider/transport_*.ml] — glm, ollama (no MCP client) *)
+let lookup provider =
+  let construct =
+    match provider with
+    | "claude_code" | "claude" ->
+        Auto_construct_active
+          {
+            env_flag = "MASC_AUTO_CONSTRUCT_CLAUDE_MCP";
+            default_when_unset = true;
+            module_name = "Keeper_cli_mcp_config";
+          }
+    | "kimi_cli" | "kimi" ->
+        (* kimi_cli reuses claude_code's construct path; the env
+           flag and default_when_unset are therefore identical. *)
+        Auto_construct_active
+          {
+            env_flag = "MASC_AUTO_CONSTRUCT_CLAUDE_MCP";
+            default_when_unset = true;
+            module_name = "Keeper_cli_mcp_config";
+          }
+    | "codex_cli" | "codex" ->
+        Auto_construct_active
+          {
+            env_flag = "MASC_SYNC_CODEX_MCP_CONFIG";
+            default_when_unset = false;
+            module_name = "Server_runtime_bootstrap.sync_codex_mcp_config";
+          }
+    | "gemini_cli" | "gemini" ->
+        No_auto_construct_path
+          {
+            reason =
+              "no enable path; only OAS_GEMINI_NO_MCP disable flag exists \
+               (keeper_types_profile.ml:1298)";
+          }
+    | "glm" | "glm-coding" | "ollama" ->
+        Not_applicable_http_api
+    | other ->
+        No_auto_construct_path
+          {
+            reason =
+              Printf.sprintf
+                "provider %S not registered in MCP config matrix; either \
+                 unknown or new — add it to keeper_mcp_provider_audit.lookup"
+                other;
+          }
+  in
+  { provider; construct }
+
+(** Active-default check: is the auto-construct path on by the time
+    the server boots without operator env intervention? *)
+let auto_construct_active_by_default (r : result) =
+  match r.construct with
+  | Auto_construct_active { default_when_unset; _ } -> default_when_unset
+  | No_auto_construct_path _ -> false
+  | Not_applicable_http_api -> true (* HTTP API providers don't need it *)
+
+let format_log_line (r : result) =
+  match r.construct with
+  | Auto_construct_active { env_flag; default_when_unset; module_name } ->
+      Printf.sprintf
+        "[mcp_audit:active] provider=%s default=%b env=%s module=%s"
+        r.provider default_when_unset env_flag module_name
+  | No_auto_construct_path { reason } ->
+      Printf.sprintf
+        "[mcp_audit:no_construct_path] provider=%s reason=%s" r.provider
+        reason
+  | Not_applicable_http_api ->
+      Printf.sprintf "[mcp_audit:http_api] provider=%s" r.provider
+
+(** Audit a list of providers (typically extracted from a cascade
+    config).  Pure mapping over [lookup]. *)
+let audit_providers providers =
+  List.map lookup providers
+
+(** Severity buckets: callers route [active] at debug, [http_api] at
+    info, [no_construct_path] at warn. *)
+let partition (results : result list) =
+  List.fold_left
+    (fun (active, no_path, http_api) r ->
+      match r.construct with
+      | Auto_construct_active _ -> (r :: active, no_path, http_api)
+      | No_auto_construct_path _ -> (active, r :: no_path, http_api)
+      | Not_applicable_http_api -> (active, no_path, r :: http_api))
+    ([], [], []) results

--- a/lib/keeper/keeper_mcp_provider_audit.mli
+++ b/lib/keeper/keeper_mcp_provider_audit.mli
@@ -1,0 +1,49 @@
+(** Provider × MCP-config-construct matrix audit (Leak 12).
+
+    SSOT for "does provider P have an active auto-construct path
+    that supplies an MCP config JSON to its CLI subprocess?"
+
+    This is the matrix that PR-Mp1 (unified construct API) will
+    eventually collapse.  Until then, this module is the single
+    place a boot hook (or a developer auditing the system) can ask
+    the question and get a structured answer per provider. *)
+
+type construct_path =
+  | Auto_construct_active of {
+      env_flag : string;
+      default_when_unset : bool;
+      module_name : string;
+    }
+  | No_auto_construct_path of { reason : string }
+  | Not_applicable_http_api
+
+type result = {
+  provider : string;
+  construct : construct_path;
+}
+
+val lookup : string -> result
+(** SSOT lookup.  Recognises the canonical provider names plus a
+    handful of common short forms (e.g. [claude] for [claude_code]).
+    Unknown providers map to [No_auto_construct_path] with a reason
+    that points at this module — the goal is fail-loud rather than
+    fail-silent for any new provider added to a cascade. *)
+
+val auto_construct_active_by_default : result -> bool
+(** True iff the auto-construct path is on at server boot without
+    requiring operator env intervention.  HTTP API providers count
+    as "true" because they have no MCP client and therefore need no
+    construct path. *)
+
+val format_log_line : result -> string
+(** Grep-friendly tag:
+    [[mcp_audit:active|no_construct_path|http_api]]. *)
+
+val audit_providers : string list -> result list
+(** Pure mapping over [lookup]; the typical input is a cascade's
+    provider list extracted from cascade.toml. *)
+
+val partition :
+  result list -> result list * result list * result list
+(** Bucket into [(active, no_construct_path, http_api)] in input
+    order. *)

--- a/test/dune
+++ b/test/dune
@@ -139,6 +139,7 @@
         test_keeper_docker_read
         test_keeper_path_ssot
         test_keeper_egress_audit
+        test_keeper_mcp_provider_audit
         test_keeper_github_read_only
         test_worktree_live_context
         test_worktree_status_single_flight_9632
@@ -298,6 +299,7 @@
           test_keeper_docker_read
           test_keeper_path_ssot
         test_keeper_egress_audit
+        test_keeper_mcp_provider_audit
           test_keeper_github_read_only
           test_worktree_live_context
           test_worktree_status_single_flight_9632

--- a/test/test_keeper_mcp_provider_audit.ml
+++ b/test/test_keeper_mcp_provider_audit.ml
@@ -1,0 +1,175 @@
+(** Tests for [Keeper_mcp_provider_audit] (Leak 12 / PR-Mp3). *)
+
+module Audit = Masc_mcp.Keeper_mcp_provider_audit
+
+(* ── SSOT entries ──────────────────────────────────────────────── *)
+
+let test_claude_code_active_default_true () =
+  let r = Audit.lookup "claude_code" in
+  match r.construct with
+  | Audit.Auto_construct_active { env_flag; default_when_unset; _ } ->
+      Alcotest.(check string)
+        "env flag" "MASC_AUTO_CONSTRUCT_CLAUDE_MCP" env_flag;
+      Alcotest.(check bool) "default true" true default_when_unset
+  | _ -> Alcotest.fail "claude_code must be Auto_construct_active"
+
+let test_kimi_cli_aliases_to_claude_path () =
+  let r = Audit.lookup "kimi_cli" in
+  match r.construct with
+  | Audit.Auto_construct_active { env_flag; module_name; _ } ->
+      Alcotest.(check string)
+        "shares claude env flag" "MASC_AUTO_CONSTRUCT_CLAUDE_MCP" env_flag;
+      Alcotest.(check string)
+        "shares claude module" "Keeper_cli_mcp_config" module_name
+  | _ -> Alcotest.fail "kimi_cli must reuse claude_code construct path"
+
+let test_codex_cli_active_default_false () =
+  let r = Audit.lookup "codex_cli" in
+  match r.construct with
+  | Audit.Auto_construct_active { env_flag; default_when_unset; _ } ->
+      Alcotest.(check string) "env flag" "MASC_SYNC_CODEX_MCP_CONFIG" env_flag;
+      Alcotest.(check bool)
+        "default false (operator must opt in)" false default_when_unset
+  | _ -> Alcotest.fail "codex_cli must be Auto_construct_active"
+
+let test_gemini_cli_no_construct_path () =
+  let r = Audit.lookup "gemini_cli" in
+  match r.construct with
+  | Audit.No_auto_construct_path _ -> ()
+  | _ ->
+      Alcotest.fail
+        "gemini_cli has no enable path; only OAS_GEMINI_NO_MCP disable flag"
+
+let test_glm_is_http_api () =
+  let r = Audit.lookup "glm" in
+  match r.construct with
+  | Audit.Not_applicable_http_api -> ()
+  | _ -> Alcotest.fail "glm is HTTP API, no MCP client"
+
+let test_ollama_is_http_api () =
+  let r = Audit.lookup "ollama" in
+  match r.construct with
+  | Audit.Not_applicable_http_api -> ()
+  | _ -> Alcotest.fail "ollama is HTTP API, no MCP client"
+
+let test_unknown_provider_fails_loud () =
+  let r = Audit.lookup "totally-fake-provider-xyz" in
+  match r.construct with
+  | Audit.No_auto_construct_path { reason } ->
+      (* Reason must point at this module so a new cascade entry
+         that adds an unknown provider surfaces the audit gap
+         rather than silently returning a permissive default. *)
+      let mentions_module =
+        let needle = "keeper_mcp_provider_audit" in
+        let h = String.lowercase_ascii reason in
+        let n = String.length needle in
+        let h_len = String.length h in
+        let rec loop i =
+          if i + n > h_len then false
+          else if String.sub h i n = needle then true
+          else loop (i + 1)
+        in
+        loop 0
+      in
+      Alcotest.(check bool)
+        "reason references audit module" true mentions_module
+  | _ ->
+      Alcotest.fail
+        "unknown provider must be No_auto_construct_path with diagnostic"
+
+(* ── auto_construct_active_by_default semantics ───────────────── *)
+
+let test_active_default_claude_true () =
+  Alcotest.(check bool)
+    "claude_code default-on" true
+    (Audit.auto_construct_active_by_default (Audit.lookup "claude_code"))
+
+let test_active_default_codex_false () =
+  Alcotest.(check bool)
+    "codex_cli default-off — Leak 12 root cause" false
+    (Audit.auto_construct_active_by_default (Audit.lookup "codex_cli"))
+
+let test_active_default_gemini_false () =
+  Alcotest.(check bool)
+    "gemini_cli has no construct path" false
+    (Audit.auto_construct_active_by_default (Audit.lookup "gemini_cli"))
+
+let test_active_default_glm_true () =
+  (* HTTP API providers don't need a construct path; treating them
+     as "active by default" lets boot hooks emit a single warn list
+     of providers that actually need attention. *)
+  Alcotest.(check bool)
+    "glm is HTTP API, considered satisfied" true
+    (Audit.auto_construct_active_by_default (Audit.lookup "glm"))
+
+(* ── audit_providers + partition ─────────────────────────────── *)
+
+let test_audit_providers_partitions_correctly () =
+  let providers =
+    [ "claude_code"; "codex_cli"; "gemini_cli"; "glm"; "ollama" ]
+  in
+  let results = Audit.audit_providers providers in
+  Alcotest.(check int) "5 providers in" 5 (List.length results);
+  let active, no_path, http_api = Audit.partition results in
+  Alcotest.(check int) "2 active (claude+codex)" 2 (List.length active);
+  Alcotest.(check int) "1 no construct path (gemini)" 1 (List.length no_path);
+  Alcotest.(check int) "2 http api (glm+ollama)" 2 (List.length http_api)
+
+(* ── log line tags ───────────────────────────────────────────── *)
+
+let starts_with prefix s =
+  String.length s >= String.length prefix
+  && String.sub s 0 (String.length prefix) = prefix
+
+let test_format_log_tags () =
+  Alcotest.(check bool)
+    "active tag" true
+    (starts_with "[mcp_audit:active]"
+       (Audit.format_log_line (Audit.lookup "claude_code")));
+  Alcotest.(check bool)
+    "no_construct_path tag" true
+    (starts_with "[mcp_audit:no_construct_path]"
+       (Audit.format_log_line (Audit.lookup "gemini_cli")));
+  Alcotest.(check bool)
+    "http_api tag" true
+    (starts_with "[mcp_audit:http_api]"
+       (Audit.format_log_line (Audit.lookup "ollama")))
+
+let () =
+  Alcotest.run "Keeper MCP Provider Audit"
+    [
+      ( "SSOT entries",
+        [
+          Alcotest.test_case "claude_code default true" `Quick
+            test_claude_code_active_default_true;
+          Alcotest.test_case "kimi_cli aliases claude" `Quick
+            test_kimi_cli_aliases_to_claude_path;
+          Alcotest.test_case "codex_cli default false" `Quick
+            test_codex_cli_active_default_false;
+          Alcotest.test_case "gemini_cli no construct path" `Quick
+            test_gemini_cli_no_construct_path;
+          Alcotest.test_case "glm is HTTP API" `Quick test_glm_is_http_api;
+          Alcotest.test_case "ollama is HTTP API" `Quick
+            test_ollama_is_http_api;
+          Alcotest.test_case "unknown provider fails loud" `Quick
+            test_unknown_provider_fails_loud;
+        ] );
+      ( "auto_construct_active_by_default semantics",
+        [
+          Alcotest.test_case "claude default-on" `Quick
+            test_active_default_claude_true;
+          Alcotest.test_case "codex default-off (Leak 12 root)" `Quick
+            test_active_default_codex_false;
+          Alcotest.test_case "gemini no path => false" `Quick
+            test_active_default_gemini_false;
+          Alcotest.test_case "glm http_api => true" `Quick
+            test_active_default_glm_true;
+        ] );
+      ( "aggregation",
+        [
+          Alcotest.test_case "audit_providers + partition" `Quick
+            test_audit_providers_partitions_correctly;
+        ] );
+      ( "log format",
+        [ Alcotest.test_case "tag prefixes" `Quick test_format_log_tags ] );
+    ]


### PR DESCRIPTION
## Summary

Leak 12 (2026-04-27, plan v6 §2.10): masc-mcp ships three sibling code paths that each construct (or fail to construct) a Bearer-token MCP config JSON for a CLI subprocess. Defaults disagree and the matrix is not enumerable from any one place:

| provider | construct path | env flag | default |
|----------|----------------|----------|---------|
| `claude_code` | `Keeper_cli_mcp_config.try_construct_for_keeper` | `MASC_AUTO_CONSTRUCT_CLAUDE_MCP` | **true** |
| `kimi_cli` | (same module, aliased) | (same) | **true** |
| `codex_cli` | `Server_runtime_bootstrap.sync_codex_mcp_config` | `MASC_SYNC_CODEX_MCP_CONFIG` | **false** |
| `gemini_cli` | none — only `OAS_GEMINI_NO_MCP` disable flag | — | n/a |
| `glm` | n/a — HTTP API, OAS dispatch | — | n/a |
| `ollama` | n/a — HTTP API, OAS dispatch | — | n/a |

A docker keeper whose cascade routes to `codex_cli` (without operator opt-in) or `gemini_cli` will produce LLM responses but every `keeper_*` / `masc_*` tool call fails as "tool not in session's tool registry." There is no boot-time signal pointing at the gap.

This PR adds `Keeper_mcp_provider_audit`, a static SSOT lookup table that boot hooks consume — and that PR-Mp1 (the eventual unified construct API) will read from so the disagreement only lives in one place.

## Module shape

```ocaml
type construct_path =
  | Auto_construct_active of {
      env_flag : string;
      default_when_unset : bool;
      module_name : string;
    }
  | No_auto_construct_path of { reason : string }
  | Not_applicable_http_api

val lookup : string -> result
val auto_construct_active_by_default : result -> bool
val format_log_line : result -> string
val audit_providers : string list -> result list
val partition : result list -> result list * result list * result list
```

`lookup` recognises canonical names (`claude_code`, `codex_cli`, …) plus a few common short forms (`claude`, `codex`, `gemini`). **Unknown providers fail loud** — the `reason` references this module so any new cascade entry without a registered construct path surfaces the gap at boot rather than getting a permissive default.

## What this catches

- A future cascade entry that adds a new CLI provider but forgets to wire up its construct path (the audit emits `no_construct_path`).
- The dormant `codex_cli default=false` problem: an operator running with the documented defaults gets MCP for claude but **not** for codex without realising it.
- The gemini gap (no enable path, only a disable flag).

## Test coverage (11 cases)

- Every SSOT entry — claude / kimi (alias) / codex / gemini / glm / ollama / unknown
- `auto_construct_active_by_default` semantics — claude=true, **codex=false (Leak 12 root)**, gemini=false, glm=true (HTTP API treated as satisfied)
- `audit_providers` + `partition` over a mixed list
- Log tag prefixes `[mcp_audit:active|no_construct_path|http_api]`

## Follow-up

- **PR-Mp3b** (next): walk `cascade.toml` provider lists at server boot and emit the audit, routing `Auto_construct_active` at debug, `No_auto_construct_path` at warn, `Not_applicable_http_api` at info.
- **PR-Mp1** (longer-term, separate review): unified construct API that *replaces* the three sibling paths. The SSOT table here becomes its read-only catalog.

## Pairs with

- Leak 11 PRs: PR-Eg1 #11147, PR-Eg3 #11148, PR-Eg2 #11150 — same audit pattern applied to egress policy file placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
