### PR TITLE
fix(auth): canonicalize keeper credential lookup name in tool_coord (PR-3b1/4)

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -130,6 +130,21 @@ let bootable_keeper_names config =
               | Some true | None -> true)
          | Error _ -> true)
 
+(* PR-3b1: convert a credential lookup name to its canonical
+   keeper-<n>-agent form when it refers to a bootable keeper.
+   Non-keeper names (dashboard, admin, codex-mcp-client, ...) are
+   returned unchanged so this is safe to apply at any lookup site.
+   Spec: AuthIdentityFSM.tla I1 IdentityBindsToken (a token must
+   bind to one principal -- the bare-name lookup path that
+   scaffolded dual-identity is starved by callers always asking for
+   the canonical form). *)
+let canonicalize_if_keeper config name =
+  let stable = Keeper_types_profile.strip_keeper_prefix name in
+  if List.mem stable (configured_keeper_names config) then
+    Keeper_types_profile.keeper_agent_name stable
+  else
+    name
+
 (** Apply a TOML profile default to a runtime meta value.
     [Some v] from TOML overrides; [None] keeps the current runtime value. *)
 let apply_default opt current = match opt with Some v -> v | None -> current

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -45,6 +45,15 @@ val bootable_keeper_names : Coord.config -> string list
 (** Names of every keeper whose [keepers/<name>/keeper.toml] exists and
     looks bootable on disk. *)
 
+val canonicalize_if_keeper : Coord.config -> string -> string
+(** [canonicalize_if_keeper config name] returns [keeper-<n>-agent]
+    when [name] (bare or already canonical) refers to a configured
+    keeper, else returns [name] unchanged. Safe to apply at credential
+    lookup sites: dashboard / admin / codex-mcp-client pass through
+    untouched, keeper bare names get canonicalized so the bare-stub
+    redirect path stops being load-bearing. (PR-3b1, AuthIdentityFSM
+    invariant I1 IdentityBindsToken.) *)
+
 val apply_default : 'a option -> 'a -> 'a
 (** [apply_default opt default] returns [v] when [opt = Some v], else
     [default]. *)

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -124,7 +124,13 @@ let credential_state (ctx : context) ~actual_name =
          (fun name ->
            is_initial_admin name
            || internal_keeper_credential_available name
-           || Option.is_some (Auth.load_credential ctx.config.base_path name))
+           (* PR-3b1: ask Auth for the canonical [keeper-<n>-agent]
+              form so a configured keeper's credential is never
+              resolved through the bare-name redirect stub. Non-keeper
+              names pass through unchanged. Spec: AuthIdentityFSM I1. *)
+           || Option.is_some
+                (Auth.load_credential ctx.config.base_path
+                   (Keeper_runtime.canonicalize_if_keeper ctx.config name)))
          credential_candidates
   in
   { credential_required; credential_available; credential_candidates }

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -1113,6 +1113,39 @@ goal = "orphan"
   | Ok _ -> fail "should have returned Error for missing table"
   | Error _ -> ()
 
+(* PR-3b1: canonicalize_if_keeper redirects bare lookup names to
+   their [keeper-<n>-agent] canonical form when the name belongs to
+   a configured keeper, leaving non-keeper credentials (dashboard,
+   admin, codex-mcp-client, ...) untouched. Spec: AuthIdentityFSM
+   I1 IdentityBindsToken. *)
+let test_canonicalize_if_keeper () =
+  with_temp_dir "canonicalize-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  let keepers_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_dir 0o755;
+  write_file
+    (Filename.concat keepers_dir "sangsu.toml")
+    {|[keeper]
+goal = "test goal"
+|};
+  let config = Coord.default_config room_dir in
+  check string "bare keeper name -> canonical"
+    "keeper-sangsu-agent"
+    (Keeper_runtime.canonicalize_if_keeper config "sangsu");
+  check string "canonical keeper name -> canonical (idempotent)"
+    "keeper-sangsu-agent"
+    (Keeper_runtime.canonicalize_if_keeper config "keeper-sangsu-agent");
+  check string "non-keeper name (dashboard) passes through untouched"
+    "dashboard"
+    (Keeper_runtime.canonicalize_if_keeper config "dashboard");
+  check string "non-keeper name (admin) passes through untouched"
+    "admin"
+    (Keeper_runtime.canonicalize_if_keeper config "admin");
+  check string "non-keeper name (codex-mcp-client) passes through untouched"
+    "codex-mcp-client"
+    (Keeper_runtime.canonicalize_if_keeper config "codex-mcp-client")
+
 let () =
   run "Keeper_runtime config SSOT resync"
     [
@@ -1222,5 +1255,12 @@ let () =
             "returns Error when table is missing"
             `Quick
             test_toml_update_no_table;
+        ] );
+      ( "canonicalize",
+        [
+          test_case
+            "canonicalize_if_keeper bare->canonical, passthrough non-keeper"
+            `Quick
+            test_canonicalize_if_keeper;
         ] );
     ]


### PR DESCRIPTION
## 목적

masc-mcp Auth/Identity FSM Canonicalization 플랜의 **PR-3b1**. PR-3a(#11146 머지 완료)가 *예방*이라면 본 PR은 *런타임 caller 마이그레이션* — bare-name credential lookup path를 starve해서 dual-identity scaffolding의 존재 이유를 제거.

전체 플랜: `~/me/planning/claude-plans/partitioned-hopping-hinton.md`

## Forensic 근거

운영 실측 (`~/me/.masc/auth/agents/`):
- 8 keeper(sangsu/issue_king/janitor/masc-improver/nick0cave/qa-king/executor/analyst) 각각 3 파일:
  - `<bare>.json` — redirect stub
  - `keeper-<bare>-agent.json` — redirect stub  
  - `<uuid>.json` — 진짜 credential
- 두 stub은 같은 UUID로 redirect → 같은 token, 같은 identity. *현재 SAFE*.
- 그러나 stub이 작동하는 한 *bare credential을 만드는 다른 path*(CLI auth_login, worker pool)가 dual-identity를 다시 만들 수 있음.

Explore verdict (이전 분석):
- **UUID indirection은 load-bearing이 아님** — token rotation은 `cred.id`를 보존하지만 direct credential로도 동작 가능
- **bare lookup의 high-risk runtime caller**: `lib/tool_coord.ml:127` `credential_state` — `Auth.load_credential ctx.config.base_path name`로 bare name 그대로 lookup. 이 caller가 살아있으면 bare stub이 dead reference가 안 됨.
- **`legacy_credential_aliases`(auth.ml:255)**는 dashboard ↔ dashboard-dev 전용 (keeper 무관) — 건드리지 않음.

## 변경 요지

### 1. 새 헬퍼 `Keeper_runtime.canonicalize_if_keeper`

`lib/keeper/keeper_runtime.ml` (+ `.mli` export):
```ocaml
val canonicalize_if_keeper : Coord.config -> string -> string
(* bare keeper name -> [keeper-<n>-agent], non-keeper passes through *)
```

- configured keeper name인지 `configured_keeper_names`로 판별
- 그 경우만 `Keeper_types_profile.keeper_agent_name`으로 변환 (이미 존재하는 SSOT 재사용)
- dashboard, admin, codex-mcp-client 등은 그대로

### 2. tool_coord caller 마이그레이션

`lib/tool_coord.ml:127`:
```ocaml
- || Option.is_some (Auth.load_credential ctx.config.base_path name)
+ || Option.is_some
+      (Auth.load_credential ctx.config.base_path
+         (Keeper_runtime.canonicalize_if_keeper ctx.config name))
```

이 한 줄이 PR-3b1 효과의 핵심 — runtime credential lookup이 항상 canonical을 거쳐 가므로, bare stub은 *dead reference*가 됨.

## Spec 정합 (PR-1 #11126)

`AuthIdentityFSM.tla` **I1 IdentityBindsToken**:
> resolved_agent ≠ NULL ⇒ request_token ∈ credentials[resolved_agent]

bare-name redirect path는 *같은 token을 두 principal name(bare + canonical)에 silent하게 바인딩*. 본 PR은 그 path의 runtime caller를 제거해 I1을 코드 레벨에서 강화.

## 검증

### Unit test (test/test_keeper_runtime_config_ssot.ml)

신규 `test_canonicalize_if_keeper`:
- bare keeper name → canonical
- canonical → canonical (idempotent)
- dashboard / admin / codex-mcp-client → passthrough

```
[OK] canonicalize 0 canonicalize_if_keeper bare->canonical, passthrough non-keeper
Test Successful in 31s. 24 tests run (was 23).
```

### Build

`dune build --root . @check` pass.

### 운영 (post-merge)

masc-mcp 재시작 후 `masc-mcp-live.log`에서 다음 확인:
- `[load_credential] parse error for sangsu` (또는 다른 bare 이름) 패턴이 *나타나지 않아야 함* (#283 historical note 참고: live fleet에서 ~0.3/min 발생했던 노이즈)
- tool_coord credential_state credential_available가 정상 (false 카운트 안 늘어나야 함)

## 비-범위 (PR-3b2 / PR-3c로 분리)

본 PR은 의도적으로 *runtime caller 한 곳*에 집중. 다음은 명시적으로 다음 PR에 인계:

- **PR-3b2**:
  - 8 bare stub 파일을 `.archive/<epoch>/`로 이동 (PR-3a `archive_credential_file` 재사용)
  - `lib/server/server_auth.ml agent_from_request`의 X-MASC-Agent 헤더 정규화 (또는 호출자 측)
  - `lib/auth_login.ml mint`의 입력 정규화 (Coord.config 의존 해결 필요)
- **PR-3c**: UUID indirection 자체 폐기 (canonical을 direct credential로). save_credential / rotate_shared_tokens 인터페이스 변경. 더 큰 작업.
- **PR-3d**: `MASC_INTERNAL_MCP_TOKEN` + `x-masc-keeper-name` 옆문 폐기 (별개).

## Self-review

- [x] Single concern (runtime credential lookup canonical 보장)
- [x] 코드 변경 최소 (1 helper + 1 caller line)
- [x] dune build pass
- [x] test/test_keeper_runtime_config_ssot.ml 24/24 pass
- [x] 비-keeper credential(dashboard, admin) 영향 0 — passthrough
- [x] PR-3a archive 메커니즘과 정합 — 같은 plan의 다음 layer
- [x] PR-1 TLA+ I1 정합

## Risk

- *낮음*: tool_coord 한 곳, helper 자체는 idempotent + non-keeper passthrough
- 잠재적: tool_coord 외에 bare로 lookup하는 *발견 안 된 caller*가 있다면 영향 받지 않음 (그 caller는 PR-3b2에서 server_auth + auth_login에 같은 패턴 적용 시 정리)

## 다음 단계

1. PR-3b1 머지 → masc-mcp 재시작 → 운영 검증 (load_credential parse error 노이즈 0)
2. PR-3b2: stub archive + server header 정규화
3. PR-3c: UUID indirection 청소 (선택, larger)
4. PR-3d: 옆문(MASC_INTERNAL_MCP_TOKEN/x-masc-keeper-name) 폐기 (별개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)