### PR TITLE
feat(dashboard): Chip atomic primitive (foundation gap closure, 0/14 → 1/14)

### DIFF
--- a/dashboard/src/components/chip.test.ts
+++ b/dashboard/src/components/chip.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Chip, chipAriaLabel, type ChipProps } from './chip'
+
+describe('chipAriaLabel (pure)', () => {
+  it('returns the raw content when kind is undefined', () => {
+    expect(chipAriaLabel({ children: '47 PASS' }, '47 PASS')).toBe('47 PASS')
+  })
+
+  it('appends (passing) for ok', () => {
+    expect(
+      chipAriaLabel({ children: '47 PASS', kind: 'ok' }, '47 PASS'),
+    ).toBe('47 PASS (passing)')
+  })
+
+  it('appends (failing) for err', () => {
+    expect(
+      chipAriaLabel({ children: '3 FAIL', kind: 'err' }, '3 FAIL'),
+    ).toBe('3 FAIL (failing)')
+  })
+
+  it('appends (warning) for warn', () => {
+    expect(
+      chipAriaLabel({ children: 'FLAKE', kind: 'warn' }, 'FLAKE'),
+    ).toBe('FLAKE (warning)')
+  })
+
+  it('appends (stalled) for stalled', () => {
+    expect(
+      chipAriaLabel({ children: 'STALLED', kind: 'stalled' }, 'STALLED'),
+    ).toBe('STALLED (stalled)')
+  })
+
+  it('lets caller override via ariaLabel', () => {
+    expect(
+      chipAriaLabel(
+        { children: '3', kind: 'err', ariaLabel: '3 failed runs' },
+        '3',
+      ),
+    ).toBe('3 failed runs')
+  })
+
+  it('does not append for neutral or ghost', () => {
+    expect(chipAriaLabel({ children: 'tag', kind: 'neutral' }, 'tag')).toBe('tag')
+    expect(chipAriaLabel({ children: 'tag', kind: 'ghost' }, 'tag')).toBe('tag')
+  })
+})
+
+describe('Chip', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    render(null, host)
+    host.remove()
+  })
+
+  function mount(props: ChipProps): HTMLElement {
+    render(html`<${Chip} ...${props} />`, host)
+    return host.firstElementChild as HTMLElement
+  }
+
+  // ── Structural ──
+
+  it('emits a span with data-kind and data-size', () => {
+    const el = mount({ children: 'P1', kind: 'brass', size: 'lg' })
+    expect(el.tagName).toBe('SPAN')
+    expect(el.getAttribute('data-kind')).toBe('brass')
+    expect(el.getAttribute('data-size')).toBe('lg')
+  })
+
+  it('defaults to kind=neutral / size=default when omitted', () => {
+    const el = mount({ children: 'tag' })
+    expect(el.getAttribute('data-kind')).toBe('neutral')
+    expect(el.getAttribute('data-size')).toBe('default')
+  })
+
+  it('forwards testId to data-testid', () => {
+    const el = mount({ children: '47 PASS', kind: 'ok', testId: 'pass-chip' })
+    expect(el.getAttribute('data-testid')).toBe('pass-chip')
+  })
+
+  // ── Aria + role ──
+
+  it('sets role=status when kind is semantic (ok/warn/err/info/stalled/brass)', () => {
+    const el = mount({ children: 'PASS', kind: 'ok' })
+    expect(el.getAttribute('role')).toBe('status')
+  })
+
+  it('omits role when kind is neutral or ghost', () => {
+    const neutral = mount({ children: 'tag', kind: 'neutral' })
+    expect(neutral.getAttribute('role')).toBe(null)
+    const ghost = mount({ children: 'tag', kind: 'ghost' })
+    expect(ghost.getAttribute('role')).toBe(null)
+  })
+
+  it('encodes kind in aria-label suffix', () => {
+    const el = mount({ children: '47 PASS', kind: 'ok' })
+    expect(el.getAttribute('aria-label')).toBe('47 PASS (passing)')
+  })
+
+  // ── Dot variant ──
+
+  it('renders a leading dot when dot=true and kind is semantic', () => {
+    const el = mount({ children: 'PASS', kind: 'ok', dot: true })
+    const dotEl = el.querySelector('span[aria-hidden="true"]')
+    expect(dotEl).not.toBeNull()
+  })
+
+  it('omits the dot for neutral kind even when dot=true', () => {
+    const el = mount({ children: 'tag', kind: 'neutral', dot: true })
+    expect(el.querySelector('span[aria-hidden="true"]')).toBeNull()
+  })
+
+  it('omits the dot for ghost kind even when dot=true', () => {
+    const el = mount({ children: 'tag', kind: 'ghost', dot: true })
+    expect(el.querySelector('span[aria-hidden="true"]')).toBeNull()
+  })
+
+  it('omits the dot when dot is undefined', () => {
+    const el = mount({ children: 'PASS', kind: 'ok' })
+    expect(el.querySelector('span[aria-hidden="true"]')).toBeNull()
+  })
+
+  // ── Visual fidelity (style attr inspection) ──
+
+  it('uses ok status token for foreground', () => {
+    const el = mount({ children: 'PASS', kind: 'ok' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-status-ok)')
+  })
+
+  it('applies size geometry for sm', () => {
+    const el = mount({ children: 'tag', size: 'sm' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('14px')
+  })
+
+  it('applies size geometry for lg', () => {
+    const el = mount({ children: 'tag', size: 'lg' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('22px')
+  })
+
+  it('ghost has transparent background', () => {
+    const el = mount({ children: 'tag', kind: 'ghost' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style.toLowerCase()).toContain('transparent')
+  })
+})

--- a/dashboard/src/components/chip.ts
+++ b/dashboard/src/components/chip.ts
@@ -1,0 +1,209 @@
+// Chip — atomic primitive ported from design-system v0.4 primitives.html
+// (`<span class="chip is-{kind}">…</span>`). The SPEC defines 8 kinds ×
+// 3 sizes + a leading dot variant; this implementation matches the
+// public API but renders via inline style + Tailwind tokens that the
+// dashboard already owns.
+//
+// Why not import design-system/source_styles/primitives.css directly:
+// - The SPEC selectors expect raw status tokens (`--err`, `--info`,
+//   `--stalled`, `--idle`) and `*-glow` channels that dashboard's
+//   variables.css does not yet define. Importing primitives.css today
+//   would render the chips unstyled or partially broken.
+// - Visual fidelity here is ~75% of SPEC: foreground + border carry
+//   the kind hue, but the SPEC's translucent glow background is
+//   replaced with a flat surface. Public API is intentionally identical
+//   so a future cycle can swap the internals to `<span class="chip
+//   is-{kind}">` once the token gap is closed (issue tracked in PR
+//   description).
+//
+// Usage: `<${Chip} kind="ok" dot>${count} PASS<//>`. The host DOM is a
+// span with role="status" when a kind is present (so screen readers
+// announce status updates), no role otherwise.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren, VNode } from 'preact'
+
+export type ChipKind =
+  | 'neutral'
+  | 'brass'
+  | 'ok'
+  | 'warn'
+  | 'err'
+  | 'info'
+  | 'stalled'
+  | 'ghost'
+
+export type ChipSize = 'sm' | 'default' | 'lg'
+
+export interface ChipProps {
+  children: ComponentChildren
+  /** Tone. `undefined` ≡ `neutral`. `ghost` is a transparent variant. */
+  kind?: ChipKind
+  /** `sm` 14px / `default` 18px / `lg` 22px. */
+  size?: ChipSize
+  /** Render a 5px leading dot in the kind color. Auto-suppressed when
+   *  `kind` is undefined / 'neutral' / 'ghost' (no semantic color to
+   *  show). */
+  dot?: boolean
+  /** Forwarded to data-testid. */
+  testId?: string
+  /** Override the auto aria-label (kind + content). */
+  ariaLabel?: string
+  /** Optional native `title` attribute for hover tooltips. Surfaces
+   *  forwarded since chips frequently anchor diagnostic context. */
+  title?: string
+}
+
+interface KindStyle {
+  color: string
+  borderColor: string
+  background: string
+}
+
+// Foreground + border derived from dashboard tokens (see SPEC mapping
+// note above). Background stays flat where SPEC would use a translucent
+// glow — keeps chips readable while the glow tokens are still missing.
+const KIND_STYLE: Record<ChipKind, KindStyle> = {
+  neutral: {
+    color: 'var(--color-fg-secondary)',
+    borderColor: 'var(--color-border-default)',
+    background: 'var(--color-bg-elevated)',
+  },
+  brass: {
+    color: 'var(--color-accent-fg)',
+    borderColor: 'var(--color-accent-fg-dim)',
+    background: 'var(--color-bg-elevated)',
+  },
+  ok: {
+    color: 'var(--color-status-ok)',
+    borderColor: 'var(--color-status-ok)',
+    background: 'var(--color-bg-elevated)',
+  },
+  warn: {
+    color: 'var(--color-status-warn)',
+    borderColor: 'var(--color-status-warn)',
+    background: 'var(--color-bg-elevated)',
+  },
+  err: {
+    color: 'var(--color-status-err)',
+    borderColor: 'var(--color-status-err)',
+    background: 'var(--color-bg-elevated)',
+  },
+  info: {
+    color: 'var(--color-status-info)',
+    borderColor: 'var(--color-status-info)',
+    background: 'var(--color-bg-elevated)',
+  },
+  stalled: {
+    color: 'var(--color-status-stalled)',
+    borderColor: 'var(--color-status-stalled)',
+    background: 'var(--color-bg-elevated)',
+  },
+  ghost: {
+    color: 'var(--color-fg-disabled)',
+    borderColor: 'var(--color-border-strong)',
+    background: 'transparent',
+  },
+}
+
+interface SizeStyle {
+  height: string
+  padding: string
+  fontSize: string
+}
+
+const SIZE_STYLE: Record<ChipSize, SizeStyle> = {
+  sm: { height: '14px', padding: '0 5px', fontSize: '9px' },
+  default: { height: '18px', padding: '0 7px', fontSize: '10px' },
+  lg: { height: '22px', padding: '0 9px', fontSize: '11px' },
+}
+
+const MONO_STACK =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+const KIND_ANNOUNCE: Record<Exclude<ChipKind, 'neutral' | 'ghost'>, string> = {
+  brass: 'highlighted',
+  ok: 'passing',
+  warn: 'warning',
+  err: 'failing',
+  info: 'info',
+  stalled: 'stalled',
+}
+
+/** Pure: assemble the screen-reader label. Exported for tests + for
+ *  callers that want to wire their own aria-label outside the host. */
+export function chipAriaLabel(props: ChipProps, content: string): string {
+  if (props.ariaLabel) return props.ariaLabel
+  const kind = props.kind
+  if (kind && kind in KIND_ANNOUNCE) {
+    return `${content} (${KIND_ANNOUNCE[kind as keyof typeof KIND_ANNOUNCE]})`
+  }
+  return content
+}
+
+function plainText(children: ComponentChildren): string {
+  // Best-effort flattening for the aria-label. Component children that
+  // aren't strings/numbers fall back to '' (the visible chip still
+  // shows them; aria-label just loses non-text branches).
+  if (children == null) return ''
+  if (typeof children === 'string') return children
+  if (typeof children === 'number') return String(children)
+  if (Array.isArray(children)) return children.map(plainText).join('')
+  return ''
+}
+
+export function Chip(props: ChipProps): VNode {
+  const kind = props.kind ?? 'neutral'
+  const size = props.size ?? 'default'
+  const ks = KIND_STYLE[kind]
+  const ss = SIZE_STYLE[size]
+
+  const showDot =
+    props.dot === true && kind !== 'neutral' && kind !== 'ghost'
+
+  const containerStyle = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '4px',
+    height: ss.height,
+    padding: ss.padding,
+    fontFamily: MONO_STACK,
+    fontSize: ss.fontSize,
+    lineHeight: 1,
+    color: ks.color,
+    border: `1px solid ${ks.borderColor}`,
+    background: ks.background,
+    borderRadius: '2px',
+    letterSpacing: '0.04em',
+    textTransform: 'uppercase' as const,
+    fontWeight: 500,
+    whiteSpace: 'nowrap' as const,
+  }
+
+  const dotStyle = {
+    display: 'inline-block',
+    width: '5px',
+    height: '5px',
+    borderRadius: '50%',
+    background: ks.color,
+    flexShrink: 0,
+  }
+
+  const announce = chipAriaLabel(props, plainText(props.children))
+  const role = kind !== 'neutral' && kind !== 'ghost' ? 'status' : undefined
+
+  return html`
+    <span
+      role=${role}
+      data-testid=${props.testId}
+      data-kind=${kind}
+      data-size=${size}
+      title=${props.title}
+      aria-label=${announce}
+      style=${containerStyle}
+    >
+      ${showDot ? html`<span aria-hidden="true" style=${dotStyle}></span>` : null}
+      ${props.children}
+    </span>
+  `
+}

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -13,6 +13,7 @@ import { createAsyncResource, type AsyncResource } from '../lib/async-state'
 import { AsyncContainer } from './common/async-container'
 import { Card } from './common/card'
 import { SectionCap } from './common/section-cap'
+import { Chip } from './chip'
 
 export type DoctorKind = 'config' | 'sidecar'
 
@@ -197,14 +198,15 @@ function SidecarChecksList({ checks }: { checks: SidecarCheckView[] }) {
               <div class="flex items-center gap-1">
                 ${c.autofix_available
                   ? html`
-                      <span
-                        class="rounded-full border border-[var(--color-accent-fg)]/40 bg-[var(--color-accent-fg)]/10 px-1.5 py-0.5 text-[length:var(--fs-10)] text-[var(--color-accent-fg)]"
+                      <${Chip}
+                        kind="brass"
+                        size="sm"
                         title=${c.autofix_description
                           ? `자동 치유 시도: ${c.autofix_description} (CLI: masc-mcp doctor --fix)`
                           : '자동 치유 가능 (CLI: masc-mcp doctor --fix)'}
                       >
                         자동 치유
-                      </span>
+                      <//>
                     `
                   : ''}
                 <span class="rounded-full border px-1.5 py-0.5 text-[length:var(--fs-10)] uppercase tracking-wider ${chip}">


### PR DESCRIPTION
## Why — 직전 cycle 의 충격적 발견

사용자가 보여준 캡처 (Claude Design 안의 v0.42.1 *Atomic primitives* 페이지) 와 비교한 결과:

- dashboard 의 **14 atom primitives 적용도 = 0/14**
- 머지된 6 composite sweep (#11116 ~ #11149) 모두 *backbone 없는 floating composite*
- 즉 *cb-group-a 의 KPI strip* 만 적용했고, *Chip / Pill / Bar / Spark / Band / Key-Value row / Buttons / Keycap / Separators / Inline token / Status surfaces / Elevation / Focus ring / Motion* 14 atom 중 **0개** 가 dashboard 에 존재

본 PR 는 **Foundation level 의 첫 atom 진입** — `Chip`.

## 변경

| 파일 | 변경 |
|---|---|
| `dashboard/src/components/chip.ts` (신규) | Atomic Chip primitive. SPEC API 1:1 (`<span class="chip is-{kind}">…</span>` ↔ `<Chip kind="…">…</Chip>`) |
| `dashboard/src/components/chip.test.ts` (신규) | 21 cases: kinds × dot, role=status semantics, ariaLabel synthesis |
| `dashboard/src/components/doctor-panel.ts` | 첫 callsite swap — "자동 치유" hand-rolled brass span → `<${Chip} kind="brass" size="sm">` |

### SPEC API 매핑

| SPEC | Chip prop |
|---|---|
| `<span class="chip is-brass">` | `<Chip kind="brass">` |
| 8 kinds | `neutral / brass / ok / warn / err / info / stalled / ghost` |
| 3 sizes | `sm 14px / default 18px / lg 22px` |
| `.chip .dot` | `dot?: boolean` (auto-suppress for neutral/ghost) |

### Internal 의도적 trade-off

design-system/source_styles/primitives.css 직접 import **안 함**. 이유:

- SPEC `.chip.is-err` 가 `var(--err)`, `var(--err-glow)` 등 raw token 의존
- dashboard variables.css 에 `--err / --info / --stalled / --idle / *-glow` **부재**
- 지금 import 하면 chip 일부가 unstyled 또는 깨진 색으로 render

대안: dashboard 가 보유한 token (`--color-status-{ok,warn,err,info,stalled}`, `--color-accent-fg{,-dim}`, etc.) 만 사용. 시각 fidelity ~75% (foreground + border 정합, glow background 평면). 사용자 화면에서 *즉시 작동* + *정확한 SPEC 의도* 표시.

**Public API 는 SPEC 와 1:1**. 다음 cycle 에서 token gap 닫히면 internal 만 `<span class="chip is-${kind}">` 로 갈아끼움 — *callsite 0 변경*.

## 검증

- `pnpm exec tsc --noEmit` — clean (EXIT 0)
- `pnpm exec vitest run chip.test.ts` — **21/21 passed**
- `pnpm exec vitest run doctor-panel.test.ts` — **23/23 passed** (회귀 0)

## 미검증 / 잔재

- 시각 검증: dev server 직접 확인 필요. doctor-panel 의 "자동 치유" chip 이 brass tone 으로 정상 표시되는지 (사용자 캡처 image 2 의 SPEC 와 비교)
- happy-dom 은 layout 안 함 — chip geometry (14/18/22px height, padding) 의 *시각* 정합은 dev server 에서만 확인 가능
- 다음 cycle 에서 (a) token gap 정리 + SPEC primitives.css import 또는 (b) 더 많은 callsite swap 결정

## 다음 cycle 후보

| 옵션 | 내용 |
|---|---|
| **A** | Chip swap 더 — fleet-fsm-matrix / live/activity-stream 의 status badge 들 |
| **B** | 다음 atom — Pill (`is-running` / `is-paused` 등 stateful) 또는 Bar (keeper-detail-panels 9 inline progress) |
| **C** | Token gap closure — `--err / --info / --stalled / --idle` raw + `*-glow` channel 추가 |
| **D** | SPEC primitives.css 직접 import 시도 + 결과 보고 (Foundation 정합 100%) |

## Self-review (best-programmer)

- 목표: Foundation 0/14 → 1/14. 첫 atomic primitive 도입 + visible callsite swap
- 변경 범위: 3 파일, +370/-3 라인. primitive 정의 + 21 단위 test + 1 callsite swap
- 검증: tsc clean + 44 vitest green + 회귀 0
- 미검증: 시각 렌더 (의도상 사용자 화면 + dev server 에서만 가능)
- 정직 disclosure: SPEC import 미진행 + token gap 정확히 list. 가짜 SPEC 정합 만들지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
