### PR TITLE
fix(auth): archive bare-form keeper credentials regardless of shape (PR-3b2)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -904,24 +904,32 @@ let archive_credential_file config ~agent_name ~reason =
           "archive_credential_file failed for %s: %s"
           agent_name (Printexc.to_string exn)
 
-(* Self-heal of dual-identity: when the canonical credential is written
-   for [keeper-<n>-agent], if a bare [<n>.json] credential exists with
-   a *different* token hash, archive the bare file. Same-token bare
-   files are harmless (both names resolve to the same identity) and
-   left in place. Idempotent: once archived, subsequent boots see no
-   bare file and become no-ops. Spec: AuthIdentityFSM.tla I1
-   IdentityBindsToken (a token must bind to one principal). *)
-let archive_bare_if_dual_identity config ~canonical_name ~canonical_token_hash =
+(* Boot self-heal of bare-form keeper credential files.
+
+   PR-3a (#11146) introduced this as a dual-identity guard, archiving
+   only the case where the bare file's token differed from the
+   canonical's. After PR-3b1 (#11152) starved the runtime caller
+   (lib/tool_coord.ml now asks for the canonical form via
+   Keeper_runtime.canonicalize_if_keeper), every bare-form file is a
+   dead reference at runtime regardless of its shape:
+
+     - direct credential, different token  -> dual-identity (3a case)
+     - direct credential, same token       -> redundant alias
+     - redirect stub to canonical's UUID   -> unused after starvation
+
+   PR-3b2 generalises the helper to archive any of those without
+   inspecting the token, because none of them can route a request now.
+   The .archive/ destination preserves the file for operator review.
+   Idempotent: once archived, subsequent boots see no bare file and
+   become no-ops. Spec: AuthIdentityFSM.tla I1 IdentityBindsToken. *)
+let archive_bare_for_canonical config ~canonical_name =
   match bare_keeper_name_from_canonical canonical_name with
   | None -> ()
-  | Some bare_name -> (
-      match load_credential config bare_name with
-      | None -> ()
-      | Some bare_cred when String.equal bare_cred.token canonical_token_hash ->
-          ()
-      | Some _ ->
-          archive_credential_file config ~agent_name:bare_name
-            ~reason:"dual-identity: bare token differs from canonical")
+  | Some bare_name ->
+      let bare_file = credential_file config bare_name in
+      if file_exists bare_file then
+        archive_credential_file config ~agent_name:bare_name
+          ~reason:"bare-form keeper credential is dead after PR-3b1 starvation"
 
 let ensure_keeper_credential config ~agent_name :
     (string * agent_credential, masc_error) result =
@@ -969,10 +977,8 @@ let ensure_keeper_credential config ~agent_name :
       Error (IoError msg)
   in
   (match result with
-   | Ok (_raw, cred) ->
-       archive_bare_if_dual_identity config
-         ~canonical_name:agent_name
-         ~canonical_token_hash:cred.token
+   | Ok _ ->
+       archive_bare_for_canonical config ~canonical_name:agent_name
    | Error _ -> ());
   result
 

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -642,6 +642,36 @@ let test_ensure_keeper_credential_archives_dual_identity_bare () =
       check bool "canonical credential remains" true
         (Sys.file_exists canonical_path))
 
+(* PR-3b2: bare-form file may also be a redirect stub (PR #10440
+   pattern -- {"redirect_to": "<uuid>.json"}) rather than a direct
+   credential. After PR-3b1 starvation, even redirect stubs are dead
+   references. The generalised archive_bare_for_canonical archives
+   them too. This is the production shape for all 8 keepers in
+   ~/.masc/auth/agents/ as of 2026-04-27. *)
+let test_ensure_keeper_credential_archives_redirect_stub_bare () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore
+        (Auth.enable_auth dir ~require_token:true
+           ~agent_name:"bootstrap-admin");
+      let bare_path = Auth.credential_file dir "sangsu" in
+      Auth.save_private_text_file bare_path
+        {|{ "redirect_to": "some-uuid.json" }|};
+      check bool "bare redirect stub pre-exists" true
+        (Sys.file_exists bare_path);
+      (match
+         Auth.ensure_keeper_credential dir
+           ~agent_name:"keeper-sangsu-agent"
+       with
+       | Ok _ -> ()
+       | Error e -> fail (Types.masc_error_to_string e));
+      check bool "bare redirect stub moved out of agents/" false
+        (Sys.file_exists bare_path);
+      check bool "bare redirect stub archived" true
+        (archive_contains dir "sangsu.json"))
+
 let test_ensure_keeper_credential_no_archive_when_no_bare () =
   let dir = setup_test_room () in
   Fun.protect
@@ -1026,6 +1056,8 @@ let () =
         test_ensure_keeper_credential_reuses_uuid;
       test_case "ensure_keeper_credential archives dual-identity bare" `Quick
         test_ensure_keeper_credential_archives_dual_identity_bare;
+      test_case "ensure_keeper_credential archives redirect stub bare" `Quick
+        test_ensure_keeper_credential_archives_redirect_stub_bare;
       test_case "ensure_keeper_credential no archive on clean state" `Quick
         test_ensure_keeper_credential_no_archive_when_no_bare;
     ];


### PR DESCRIPTION
## 목적

masc-mcp Auth/Identity FSM Canonicalization 플랜의 **PR-3b2**. PR-3b1(#11152) starvation 후 bare-form keeper credential 파일이 *런타임 dead reference*가 됐으므로, 모양과 무관하게 archive로 내려 disk 정리.

전체 플랜: `~/me/planning/claude-plans/partitioned-hopping-hinton.md`

## 컨텍스트

PR-3a(#11146) `archive_bare_if_dual_identity`는 *다른 token*인 bare만 archive — 보수적 자가 치유. PR-3b1(#11152) 후 `tool_coord`가 항상 canonical로 lookup하므로 *어떤 모양의 bare든* 더 이상 routing path가 없음:

- direct credential, 다른 token → dual-identity (PR-3a 케이스)
- direct credential, 같은 token → redundant alias
- redirect stub → unused after starvation ← **8 production keeper의 현재 모양**

## 변경 요지

`lib/auth.ml`:
- `archive_bare_if_dual_identity` → **`archive_bare_for_canonical`** rename
- `canonical_token_hash` 인자 폐기 — 토큰 비교 없이 file 존재만 확인
- 호출자 `ensure_keeper_credential` 한 줄 업데이트
- 비파괴 + 멱등 (PR-3a 보장 그대로)

```ocaml
let archive_bare_for_canonical config ~canonical_name =
  match bare_keeper_name_from_canonical canonical_name with
  | None -> ()
  | Some bare_name ->
      let bare_file = credential_file config bare_name in
      if file_exists bare_file then
        archive_credential_file config ~agent_name:bare_name
          ~reason:"bare-form keeper credential is dead after PR-3b1 starvation"
```

## Spec 정합 (PR-1 #11126)

`AuthIdentityFSM.tla` **I1 IdentityBindsToken**: 토큰이 한 principal에만 매칭. bare 파일 archive로 두 번째 principal-name 바인딩 제거 → spec 불변 강화.

## 검증

### Unit tests (test/test_auth.ml)

신규 + 회귀 보호:
```
[OK] credentials  test_ensure_keeper_credential_archives_dual_identity_bare    (PR-3a)
[OK] credentials  test_ensure_keeper_credential_archives_redirect_stub_bare    (PR-3b2 신규)
[OK] credentials  test_ensure_keeper_credential_no_archive_when_no_bare         (PR-3a)
[OK] credentials  test_verify_token_keeper_alias_archives_dual_identity_bare    (PR-3a)
Test Successful in 0.2s. 44 tests run (was 43).
```

### Build
`dune build --root . @check` pass.

### 운영 (post-merge)

masc-mcp 재시작 후 다음 확인:
1. `masc-mcp-live.log`에서 8건의 archive warn:
   ```
   archived credential ~/.masc/auth/agents/sangsu.json -> ~/.masc/auth/agents/.archive/<epoch>/sangsu.json
     (reason: bare-form keeper credential is dead after PR-3b1 starvation)
   ```
2. `ls ~/me/.masc/auth/agents/` 결과에 bare nickname (`sangsu.json` 등 8개) 0건
3. `.archive/<epoch>/`에 8 stub 파일 보존
4. canonical credential (`keeper-X-agent.json`)과 UUID credential은 그대로 (사용 중)

## 비-범위 (PR-3c/PR-3d로 인계)

- **PR-3c**: UUID indirection 폐기. canonical을 *direct credential*로 (현재는 redirect stub). save_credential / rotate_shared_tokens 인터페이스 변경 + 더 큰 리팩터.
- **PR-3d**: `MASC_INTERNAL_MCP_TOKEN` + `x-masc-keeper-name` 옆문 폐기. 별개 차원.
- **server_auth header 정규화**: PR-3b1으로 lookup-side가 이미 canonical → header는 display/log only. 코드 변경 불필요.
- **auth_login mint 정규화**: CLI-only, 사용자 1명. 운영 가이드로 충분.

## Self-review

- [x] Single concern (bare credential archive 일반화)
- [x] PR-3a + PR-3b1 자연 연장 (chain의 다음 layer)
- [x] 비파괴 (.archive/로 이동)
- [x] 멱등 (한 번 archive 후 no-op)
- [x] dune build pass
- [x] test/test_auth.ml 44/44 pass (신규 1 포함)
- [x] PR-1 TLA+ I1 정합

## Risk

- **낮음**: 변경 1 함수, 호출자 1곳, scope 좁음
- bare로 lookup하던 *발견 안 된* runtime caller가 있다면 영향 — PR-3b1 머지 후 운영 검증에서 안 보이면 안전 확정

## Auth/Identity FSM chain 진행 (5 PR)

| # | 단계 | 상태 |
|---|---|---|
| 11126 | PR-1 TLA+ AuthIdentityFSM | MERGED ✓ |
| 11132 | PR-2 silent default 제거 | MERGED ✓ |
| 11146 | PR-3a 자가 치유 예방 | MERGED ✓ |
| 11152 | PR-3b1 runtime caller starvation | MERGED ✓ |
| **이번** | **PR-3b2 bare stub archive** | **Draft, CI 진행** |
| 다음 | PR-3c UUID indirection 폐기 (선택) | TBD |
| 별개 | PR-3d 옆문 폐기 | TBD |

🤖 Generated with [Claude Code](https://claude.com/claude-code)