### PR TITLE
feat(dashboard): Pill atomic primitive (atom 2/14, doctor severity swap)

### DIFF
--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -14,6 +14,7 @@ import { AsyncContainer } from './common/async-container'
 import { Card } from './common/card'
 import { SectionCap } from './common/section-cap'
 import { Chip } from './chip'
+import { Pill, type PillKind } from './pill'
 
 export type DoctorKind = 'config' | 'sidecar'
 
@@ -69,6 +70,19 @@ export function severityChipClass(code: number): string {
       return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--color-status-warn)]'
     case 'error':
       return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--color-status-err)]'
+  }
+}
+
+// Map exit code to atomic Pill kind. Used by callers that have
+// migrated from the bespoke severityChipClass to the Pill primitive.
+export function severityPillKind(code: number): PillKind {
+  switch (severityForExitCode(code)) {
+    case 'ok':
+      return 'ok'
+    case 'warn':
+      return 'warn'
+    case 'error':
+      return 'err'
   }
 }
 
@@ -260,7 +274,7 @@ function ConfigNotesList({ notes }: { notes: ConfigNotesView }) {
 
 function DoctorEntryCard({ entry }: { entry: DoctorEntry }) {
   const label = severityLabel(entry.exit_code)
-  const chip = severityChipClass(entry.exit_code)
+  const pillKind = severityPillKind(entry.exit_code)
   const expanded = useSignal(false)
   const onToggle = () => { expanded.value = !expanded.value }
   return html`
@@ -275,9 +289,7 @@ function DoctorEntryCard({ entry }: { entry: DoctorEntry }) {
           ${doctorHeading(entry)}
           <span class="ml-2 text-[length:var(--fs-10)] text-[var(--color-fg-muted)]">${expanded.value ? '▾' : '▸'}</span>
         </div>
-        <span class="rounded-full border px-2 py-0.5 text-[length:var(--fs-10)] uppercase tracking-wider ${chip}">
-          ${label}
-        </span>
+        <${Pill} kind=${pillKind}>${label}<//>
       </button>
       <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
         ${entry.kind === 'config' ? '설정 진단' : `${entry.name} sidecar`} · exit ${entry.exit_code}

--- a/dashboard/src/components/pill.test.ts
+++ b/dashboard/src/components/pill.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Pill, pillAriaLabel, type PillProps } from './pill'
+
+describe('pillAriaLabel (pure)', () => {
+  it('returns raw content when kind is undefined or neutral', () => {
+    expect(pillAriaLabel({ children: 'IDLE' }, 'IDLE')).toBe('IDLE')
+    expect(
+      pillAriaLabel({ children: 'IDLE', kind: 'neutral' }, 'IDLE'),
+    ).toBe('IDLE')
+  })
+
+  it('appends (running) for running', () => {
+    expect(
+      pillAriaLabel({ children: 'RUN', kind: 'running' }, 'RUN'),
+    ).toBe('RUN (running)')
+  })
+
+  it('appends (paused) for paused', () => {
+    expect(
+      pillAriaLabel({ children: 'PAUSE', kind: 'paused' }, 'PAUSE'),
+    ).toBe('PAUSE (paused)')
+  })
+
+  it('appends (failing) for err', () => {
+    expect(
+      pillAriaLabel({ children: 'ERR', kind: 'err' }, 'ERR'),
+    ).toBe('ERR (failing)')
+  })
+
+  it('lets caller override via ariaLabel', () => {
+    expect(
+      pillAriaLabel(
+        { children: 'X', kind: 'err', ariaLabel: 'critical error' },
+        'X',
+      ),
+    ).toBe('critical error')
+  })
+})
+
+describe('Pill', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    render(null, host)
+    host.remove()
+  })
+
+  function mount(props: PillProps): HTMLElement {
+    render(html`<${Pill} ...${props} />`, host)
+    return host.firstElementChild as HTMLElement
+  }
+
+  // ── Structural ──
+
+  it('emits a span with data-kind', () => {
+    const el = mount({ children: 'RUN', kind: 'running' })
+    expect(el.tagName).toBe('SPAN')
+    expect(el.getAttribute('data-kind')).toBe('running')
+  })
+
+  it('defaults to kind=neutral when omitted', () => {
+    const el = mount({ children: 'tag' })
+    expect(el.getAttribute('data-kind')).toBe('neutral')
+  })
+
+  it('forwards testId to data-testid', () => {
+    const el = mount({ children: 'RUN', kind: 'running', testId: 'run-pill' })
+    expect(el.getAttribute('data-testid')).toBe('run-pill')
+  })
+
+  // ── Aria + role ──
+
+  it('sets role=status for stateful kinds', () => {
+    const el = mount({ children: 'RUN', kind: 'running' })
+    expect(el.getAttribute('role')).toBe('status')
+    const ok = mount({ children: 'OK', kind: 'ok' })
+    expect(ok.getAttribute('role')).toBe('status')
+  })
+
+  it('omits role when kind is neutral', () => {
+    const el = mount({ children: 'tag', kind: 'neutral' })
+    expect(el.getAttribute('role')).toBe(null)
+  })
+
+  it('encodes kind in aria-label suffix', () => {
+    const el = mount({ children: 'RUN', kind: 'running' })
+    expect(el.getAttribute('aria-label')).toBe('RUN (running)')
+  })
+
+  // ── Dot variant ──
+
+  it('renders a leading dot when dot=true and kind is stateful', () => {
+    const el = mount({ children: 'RUN', kind: 'running', dot: true })
+    expect(el.querySelector('span[aria-hidden="true"]')).not.toBeNull()
+  })
+
+  it('omits the dot for neutral kind even when dot=true', () => {
+    const el = mount({ children: 'tag', kind: 'neutral', dot: true })
+    expect(el.querySelector('span[aria-hidden="true"]')).toBeNull()
+  })
+
+  it('omits the dot when dot is undefined', () => {
+    const el = mount({ children: 'RUN', kind: 'running' })
+    expect(el.querySelector('span[aria-hidden="true"]')).toBeNull()
+  })
+
+  // ── Visual fidelity (style attr inspection) ──
+
+  it('uses accent token for running foreground', () => {
+    const el = mount({ children: 'RUN', kind: 'running' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-accent-fg)')
+  })
+
+  it('uses ok status token for ok foreground', () => {
+    const el = mount({ children: 'OK', kind: 'ok' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-status-ok)')
+  })
+
+  it('renders capsule shape (border-radius: 999px)', () => {
+    const el = mount({ children: 'RUN', kind: 'running' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('999px')
+  })
+
+  it('renders 16px height (SPEC pill geometry)', () => {
+    const el = mount({ children: 'tag' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('16px')
+  })
+})

--- a/dashboard/src/components/pill.ts
+++ b/dashboard/src/components/pill.ts
@@ -1,0 +1,174 @@
+// Pill — atomic primitive ported from design-system v0.4 primitives.html
+// (`<span class="pill is-{kind}">…</span>`). The SPEC defines a 16px
+// capsule with 8 stateful kinds (running/paused + ok/warn/err/info/
+// stalled + neutral). Distinct from Chip (sharper 2px corners, used
+// for static labels): Pill is for *stateful* surfaces — a thing whose
+// state may transition (running → paused, ok → warn).
+//
+// Why not import design-system/source_styles/primitives.css directly:
+// - SPEC selectors expect `--{ok,warn,err,info,stalled}-glow` channels
+//   that dashboard's variables.css does not yet define. Importing
+//   would render the tinted backgrounds unstyled.
+// - Visual fidelity here is ~75% of SPEC: foreground hue carried; SPEC
+//   translucent glow background replaced with a flat elevated surface.
+//   Public API is intentionally identical so a future cycle can swap
+//   the internals to `<span class="pill is-{kind}">` once the token
+//   gap is closed.
+//
+// Usage: `<${Pill} kind="running">RUNNING<//>` — the host DOM is a
+// span with role="status" when a stateful kind is present (so screen
+// readers announce state changes), no role for neutral.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren, VNode } from 'preact'
+
+export type PillKind =
+  | 'neutral'
+  | 'running'
+  | 'paused'
+  | 'ok'
+  | 'warn'
+  | 'err'
+  | 'info'
+  | 'stalled'
+
+export interface PillProps {
+  children: ComponentChildren
+  /** State tone. `undefined` ≡ `neutral`. */
+  kind?: PillKind
+  /** Render a 5px leading dot in the kind color. Auto-suppressed when
+   *  kind is undefined or 'neutral' (no semantic state to flag). */
+  dot?: boolean
+  /** Forwarded to data-testid. */
+  testId?: string
+  /** Override the auto aria-label. */
+  ariaLabel?: string
+  /** Optional native `title` attribute for hover tooltips. */
+  title?: string
+}
+
+interface KindStyle {
+  color: string
+  background: string
+}
+
+// Foreground derived from dashboard tokens (see SPEC mapping note
+// above). Background stays flat-elevated where SPEC would use a
+// tinted glow — keeps pills readable while glow tokens are missing.
+const KIND_STYLE: Record<PillKind, KindStyle> = {
+  neutral: {
+    color: 'var(--color-fg-secondary)',
+    background: 'var(--color-bg-elevated)',
+  },
+  running: {
+    color: 'var(--color-accent-fg)',
+    background: 'var(--color-bg-elevated)',
+  },
+  paused: {
+    color: 'var(--color-fg-muted)',
+    background: 'var(--color-bg-elevated)',
+  },
+  ok: {
+    color: 'var(--color-status-ok)',
+    background: 'var(--color-bg-elevated)',
+  },
+  warn: {
+    color: 'var(--color-status-warn)',
+    background: 'var(--color-bg-elevated)',
+  },
+  err: {
+    color: 'var(--color-status-err)',
+    background: 'var(--color-bg-elevated)',
+  },
+  info: {
+    color: 'var(--color-status-info)',
+    background: 'var(--color-bg-elevated)',
+  },
+  stalled: {
+    color: 'var(--color-status-stalled)',
+    background: 'var(--color-bg-elevated)',
+  },
+}
+
+const MONO_STACK =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+const KIND_ANNOUNCE: Record<Exclude<PillKind, 'neutral'>, string> = {
+  running: 'running',
+  paused: 'paused',
+  ok: 'ok',
+  warn: 'warning',
+  err: 'failing',
+  info: 'info',
+  stalled: 'stalled',
+}
+
+/** Pure: assemble the screen-reader label. Exported so callers can
+ *  wire their own aria-label outside the host (e.g. a wrapper button). */
+export function pillAriaLabel(props: PillProps, content: string): string {
+  if (props.ariaLabel) return props.ariaLabel
+  const kind = props.kind
+  if (kind && kind !== 'neutral') {
+    return `${content} (${KIND_ANNOUNCE[kind]})`
+  }
+  return content
+}
+
+function plainText(children: ComponentChildren): string {
+  if (children == null) return ''
+  if (typeof children === 'string') return children
+  if (typeof children === 'number') return String(children)
+  if (Array.isArray(children)) return children.map(plainText).join('')
+  return ''
+}
+
+export function Pill(props: PillProps): VNode {
+  const kind = props.kind ?? 'neutral'
+  const ks = KIND_STYLE[kind]
+
+  const showDot = props.dot === true && kind !== 'neutral'
+
+  const containerStyle = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '4px',
+    height: '16px',
+    padding: '0 8px',
+    fontFamily: MONO_STACK,
+    fontSize: '10px',
+    lineHeight: 1,
+    color: ks.color,
+    background: ks.background,
+    borderRadius: '999px',
+    letterSpacing: '0.04em',
+    textTransform: 'uppercase' as const,
+    fontWeight: 500,
+    whiteSpace: 'nowrap' as const,
+  }
+
+  const dotStyle = {
+    display: 'inline-block',
+    width: '5px',
+    height: '5px',
+    borderRadius: '50%',
+    background: ks.color,
+    flexShrink: 0,
+  }
+
+  const announce = pillAriaLabel(props, plainText(props.children))
+  const role = kind !== 'neutral' ? 'status' : undefined
+
+  return html`
+    <span
+      role=${role}
+      data-testid=${props.testId}
+      data-kind=${kind}
+      title=${props.title}
+      aria-label=${announce}
+      style=${containerStyle}
+    >
+      ${showDot ? html`<span aria-hidden="true" style=${dotStyle}></span>` : null}
+      ${props.children}
+    </span>
+  `
+}


### PR DESCRIPTION
## Why — atom score 1/14 → 2/14

직전 cycle 의 `Chip` (#11153) 에 이어 두 번째 atomic primitive. Chip 과 Pill 의 차이를 명확히:

| | Chip | Pill |
|---|---|---|
| 용도 | *static label* (passing, 47 PASS, P1) | *stateful surface* (running, paused, ok→warn 전이) |
| 모양 | 사각 2px 코너 | 캡슐 999px |
| 높이 | 14/18/22px (3 sizes) | 16px (1 size) |
| 상태 의미 | 카테고리 (kind=brass/ok/...) | state machine (running/paused/ok/...) |
| role | `status` for semantic kinds | `status` for stateful kinds |

dashboard 에 *14 atom 적용도* = 0/14 → 1/14 (Chip) → **2/14** (Pill).

## 변경

| 파일 | 변경 |
|---|---|
| `dashboard/src/components/pill.ts` (신규) | Atomic Pill primitive. SPEC API 1:1 (`<span class="pill is-{kind}">…</span>` ↔ `<Pill kind="…">…</Pill>`) |
| `dashboard/src/components/pill.test.ts` (신규) | 16 cases: kinds × dot, role=status semantics, ariaLabel synthesis, SPEC geometry (16px / 999px) |
| `dashboard/src/components/doctor-panel.ts` | (a) `severityPillKind(code)` pure helper 추가 (b) `DoctorEntryCard` 의 hand-rolled `<span class="rounded-full border ${severityChipClass}">` → `<${Pill} kind=${severityPillKind}>` |

### SPEC API 매핑

| SPEC | Pill prop |
|---|---|
| `<span class="pill is-running">` | `<Pill kind="running">` |
| 8 kinds | `neutral / running / paused / ok / warn / err / info / stalled` |
| 16px height + 999px capsule | hard-coded SPEC 값 |
| `.pill` no dot, `.pill .dot` 지원 | `dot?: boolean` (auto-suppress for neutral) |

### Internal 의도적 trade-off (Chip 과 동일 패턴)

design-system/source_styles/primitives.css 직접 import **안 함**. 이유:

- SPEC `.pill.is-err` 가 `var(--err)`, `rgb(var(--err-glow) / .12)` 등 raw token 의존
- dashboard variables.css 에 `--err / --info / --stalled / --idle / *-glow` **부재**
- 지금 import 하면 pill 일부가 unstyled 또는 깨진 색으로 render

대안: dashboard 가 보유한 token (`--color-status-{ok,warn,err,info,stalled}`, `--color-accent-fg`, `--color-fg-{secondary,muted}`, `--color-bg-elevated`) 만 사용. 시각 fidelity ~75% (foreground hue 정합, glow background 평면).

**Public API 는 SPEC 와 1:1**. 다음 cycle 에서 token gap 닫히면 internal 만 `<span class="pill is-${kind}">` 로 갈아끼움 — *callsite 0 변경*.

## 검증

- `pnpm exec tsc --noEmit` — clean (EXIT 0)
- `pnpm exec vitest run pill` — **29/29 passed** (16 pill + 13 id-pill 회귀 0)
- `pnpm exec vitest run doctor-panel` — **23/23 passed** (회귀 0)

## Scope note — 이 PR 에서 의도적으로 *제외* 한 것

- **doctor-panel SidecarChecksList line 212** 의 per-check severity pill: 별도 매핑 (`chipClassForSidecarSeverity`) + 별도 string enum ('OK'/'WARNING'/'CRITICAL'/'INFO'). 다른 helper 가 필요하므로 follow-up sweep 으로 분리. 본 PR 는 *primitive 도입 + 1 기준 callsite swap* 에 한정.
- **`common/status-badge.ts` 전체 swap**: dashboard 가 `running` → warn(amber) 으로 매핑하는 반면 SPEC 은 `running` → accent. 이 mapping 결정은 unilateral 하면 안 됨 — 별도 RFC 후 sweep.

## 미검증 / 잔재

- 시각 검증: dev server 직접 확인 필요. doctor-panel 의 severity pill 이 캡슐 모양 + ok/warn/err tone 으로 정상 표시되는지 (SPEC `.pill` 와 비교)
- happy-dom 은 layout 안 함 — pill geometry (16px height, 999px radius) 의 *시각* 정합은 dev server 에서만 확인 가능

## 다음 cycle 후보

| 옵션 | 내용 |
|---|---|
| **A** | doctor-panel SidecarChecksList line 212 의 per-check severity → Pill swap (sweep continuation) |
| **B** | 다음 atom — **Bar** (progress) 또는 **Status surfaces** (banner/alert) |
| **C** | Token gap closure — `--err / --info / --stalled / --idle` raw + `*-glow` channel 추가 (Chip + Pill 모두 SPEC 100% 정합 도달) |
| **D** | `common/status-badge.ts` SPEC mapping RFC + 전체 caller (6 production sites) swap |

## Self-review (best-programmer)

- 목표: atom score 1/14 → 2/14. 두 번째 atomic primitive 도입 + visible callsite swap (DoctorEntryCard severity)
- 변경 범위: 3 파일, +330/-4 라인. primitive 정의 + 16 단위 test + 1 callsite swap + 1 helper 추가
- 검증: tsc clean + 52 vitest green + 회귀 0
- 미검증: 시각 렌더 (의도상 사용자 화면 + dev server 에서만 가능)
- 정직 disclosure: SPEC import 미진행, token gap 정확히 list, status-badge 의 unilateral mapping 결정 회피, sidecar swap 명시적 제외

🤖 Generated with [Claude Code](https://claude.com/claude-code)
