### PR TITLE
feat(server): boot-time provider MCP-config audit hook (PR-Mp3b)

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -49,6 +49,34 @@ let () =
     ~labels:["keeper"]
     ()
 
+let () =
+  Prometheus.register_counter
+    ~name:"masc_mcp_audit_no_construct_path_total"
+    ~help:
+      "Boot-time provider × MCP-config-construct audit \
+       (PR-Mp3b / Leak 12): a cascade entry references a provider \
+       with no auto-construct path for the MCP config JSON. The \
+       CLI subprocess starts and the LLM responds, but every \
+       keeper_*/masc_* tool call fails with 'tool not in session's \
+       tool registry'. Labels: provider. Non-zero at boot means an \
+       operator should either remove the provider from the cascade \
+       or add an auto-construct entry."
+    ~labels:["provider"]
+    ()
+
+let () =
+  Prometheus.register_counter
+    ~name:"masc_mcp_audit_default_off_total"
+    ~help:
+      "Boot-time provider × MCP-config-construct audit \
+       (PR-Mp3b / Leak 12): a provider has an auto-construct path \
+       but its env flag defaults to off (e.g. codex_cli + \
+       MASC_SYNC_CODEX_MCP_CONFIG=false). Operator must opt in or \
+       the keeper will fail tool calls on this lane. Labels: \
+       provider, env_flag."
+    ~labels:["provider"; "env_flag"]
+    ()
+
 let requested_backend_mode () =
   Env_config_core.storage_type ()
 
@@ -635,6 +663,93 @@ let audit_keeper_egress_policies (state : Mcp_server.server_state) =
       (List.length missings) (List.length orphans)
   end
 
+let audit_provider_mcp_config_paths (_state : Mcp_server.server_state) =
+  (* PR-Mp3b (Leak 12): on every boot, walk every cascade catalog
+     entry's model strings, extract provider names, and run the SSOT
+     audit (Keeper_mcp_provider_audit) over the deduplicated set.
+
+     Read-only.  Emits one log line per audited provider with a
+     grep-friendly tag plus two Prometheus counters for the failure
+     buckets.  Fail-soft: if the cascade catalog is unloadable the
+     hook logs and returns; cascade load problems surface through
+     other validators (Cascade_catalog_validator) and are not this
+     hook's job to fix. *)
+  let cascade_names =
+    try Keeper_cascade_profile.catalog_names ()
+    with exn ->
+      Log.Misc.warn
+        "[mcp_audit:catalog_load_failed] exn=%s"
+        (Printexc.to_string exn);
+      []
+  in
+  if cascade_names = [] then
+    Log.Misc.info "[mcp_audit:skip] no cascade profiles loaded"
+  else begin
+    let providers =
+      List.concat_map
+        (fun name ->
+          try
+            Cascade_runtime.models_of_cascade_name name
+            |> List.filter_map Cascade_runtime.provider_name_of_label
+          with exn ->
+            Log.Misc.warn
+              "[mcp_audit:cascade_models_failed] cascade=%s exn=%s"
+              name (Printexc.to_string exn);
+            [])
+        cascade_names
+      |> List.sort_uniq String.compare
+    in
+    if providers = [] then
+      Log.Misc.info
+        "[mcp_audit:skip] no provider labels resolved from %d cascades"
+        (List.length cascade_names)
+    else begin
+      let results =
+        Keeper_mcp_provider_audit.audit_providers providers
+      in
+      let active, no_path, http_api =
+        Keeper_mcp_provider_audit.partition results
+      in
+      List.iter (fun r ->
+        Log.Misc.info "%s"
+          (Keeper_mcp_provider_audit.format_log_line r);
+        match r.Keeper_mcp_provider_audit.construct with
+        | Auto_construct_active
+            { default_when_unset = false; env_flag; _ } ->
+            Log.Misc.warn
+              "[mcp_audit:default_off] provider=%s env_flag=%s — \
+               operator must set %s=true for this lane to emit MCP \
+               config"
+              r.provider env_flag env_flag;
+            Prometheus.inc_counter
+              "masc_mcp_audit_default_off_total"
+              ~labels:[("provider", r.provider);
+                       ("env_flag", env_flag)] ()
+        | _ -> ())
+        active;
+      List.iter (fun r ->
+        Log.Misc.warn "%s"
+          (Keeper_mcp_provider_audit.format_log_line r);
+        Prometheus.inc_counter
+          "masc_mcp_audit_no_construct_path_total"
+          ~labels:[("provider", r.Keeper_mcp_provider_audit.provider)]
+          ())
+        no_path;
+      List.iter (fun r ->
+        Log.Misc.info "%s"
+          (Keeper_mcp_provider_audit.format_log_line r))
+        http_api;
+      Log.Misc.info
+        "[mcp_audit:summary] cascades=%d providers=%d active=%d \
+         no_construct_path=%d http_api=%d"
+        (List.length cascade_names)
+        (List.length providers)
+        (List.length active)
+        (List.length no_path)
+        (List.length http_api)
+    end
+  end
+
 let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
   (* Promote legacy room/keeper state before Coord.init seeds fresh root files.
      Otherwise state.json/backlog.json can be created in the destination first
@@ -646,6 +761,7 @@ let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
   migrate_legacy_keeper_dirs_blocking state;
   let (_init_msg : string) = Coord.init state.room_config ~agent_name:None in
   audit_keeper_egress_policies state;
+  audit_provider_mcp_config_paths state;
   Mcp_server.set_sse_callback state Sse.broadcast
 
 let sync_admin_token_env (state : Mcp_server.server_state) =


### PR DESCRIPTION
## Summary

Wires the provider × MCP-config-construct audit module from PR-Mp3 (#11151, merged) into the server boot path so it actually runs in production.

PR-Mp3 shipped:
- `Keeper_mcp_provider_audit` SSOT module (`lookup`, `audit_providers`, `partition`, `format_log_line`)
- 11 unit tests
- `lib/dune` registration

…but no caller invoked `audit_providers` from the boot path. The matrix it answers — "does provider P have an active auto-construct path that supplies an MCP config JSON to its CLI subprocess?" — had no production observability point until this hook.

## Hook placement

`lib/server/server_runtime_bootstrap.ml` `bootstrap_server_state_blocking` — called once per server start. The new function `audit_provider_mcp_config_paths` runs immediately after `Coord.init` so:

- `cascade.json` catalog has been validated and loaded
- The audit operates on the live set of providers actually wired into cascades, not a hard-coded list

## What the hook does

Read-only walk over the cascade catalog:

1. `Keeper_cascade_profile.catalog_names ()` — every cascade name in `cascade.json`
2. For each: `Cascade_runtime.models_of_cascade_name` → list of `provider:model` labels
3. `Cascade_runtime.provider_name_of_label` extracts the provider name; sort + dedup
4. `Keeper_mcp_provider_audit.audit_providers providers` produces per-provider results
5. `partition` into `(active, no_construct_path, http_api)` and emit per-provider log lines tagged `[mcp_audit:active|no_construct_path|http_api]`

## The default-off subtlety

Within the **active** bucket, an entry whose env flag default is **off** (the canonical example: `codex_cli` + `MASC_SYNC_CODEX_MCP_CONFIG=false`) gets an extra warn line:

```
[mcp_audit:default_off] provider=codex_cli env_flag=MASC_SYNC_CODEX_MCP_CONFIG —
  operator must set MASC_SYNC_CODEX_MCP_CONFIG=true for this lane to
  emit MCP config
```

…plus a Prometheus counter increment. This is the dormant Leak 12 root cause: the lane is "active" by code path but does nothing without operator opt-in. The audit makes it visible at every boot.

## Prometheus

| Metric | Labels | When |
|--------|--------|------|
| `masc_mcp_audit_no_construct_path_total` | `provider` | provider in cascade has no auto-construct entry (e.g. gemini_cli, or any unknown provider) |
| `masc_mcp_audit_default_off_total` | `provider`, `env_flag` | active path with env flag default=false (operator opt-in required) |

No metric for `active default=true` or `http_api` — those are the steady-state paths and emitting metrics for them would just add noise.

## Failure modes

- **Read-only**. Reads `cascade.json` catalog and model strings; never writes.
- **Fail-soft**. Catalog load exceptions log a single warn and the hook returns; cascade load problems are surfaced through other validators (`Cascade_catalog_validator`) and are not this hook's job to fix.
- Per-cascade model resolution exceptions are caught with the cascade name and skipped.

## What this catches in production

After deploy, a single grep of today's system log answers:

```bash
LOG=~/.masc/logs/system_log_$(date +%Y-%m-%d).jsonl

grep "\[mcp_audit:" $LOG | head
# [mcp_audit:active] provider=claude_code env_flag=MASC_AUTO_CONSTRUCT_CLAUDE_MCP default=true module=Keeper_cli_mcp_config
# [mcp_audit:active] provider=codex_cli env_flag=MASC_SYNC_CODEX_MCP_CONFIG default=false module=Server_runtime_bootstrap.sync_codex_mcp_config
# [mcp_audit:default_off] provider=codex_cli env_flag=MASC_SYNC_CODEX_MCP_CONFIG — operator must set ...
# [mcp_audit:no_construct_path] provider=gemini_cli reason="no enable path; only OAS_GEMINI_NO_MCP disable flag exists"
# [mcp_audit:http_api] provider=glm reason="HTTP API, no MCP client needed"
# [mcp_audit:summary] cascades=N providers=M active=A no_construct_path=B http_api=C
```

If a future cascade entry adds a new CLI provider but forgets to register an auto-construct entry in `Keeper_mcp_provider_audit.lookup`, the next boot's audit emits `[mcp_audit:no_construct_path]` for that provider. The lookup `reason` references the audit module name so the gap surfaces with a concrete pointer.

## Pairs with

- PR-Mp3 (#11151) — SSOT lookup module + 11 tests (merged, this PR's parent)
- PR-Eg2b — sibling boot-hook integration for the egress audit (same pattern)

## Follow-up

- **PR-Mp1** (longer-term) — unified construct API that *replaces* the three sibling auto-construct paths (claude_code via `Keeper_cli_mcp_config`, codex_cli via `sync_codex_mcp_config`, gemini_cli with no path). The SSOT here becomes its read-only catalog. Not in this PR — provider-specific config schema differences need explicit verification first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
