### PR TITLE
feat(design-system): add status glow channel tokens (Pill SPEC gap)

### DIFF
--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -28,6 +28,25 @@
   --warn: #fbbf24;
   --bad: #ef4444;
 
+  /* Status glow triplets (rgb space-separated) — for box-shadow alpha
+     and translucent state-glow backgrounds (e.g. Pill atomic primitive
+     SPEC selectors). Triplets decompose the corresponding hex semantic
+     color (--accent / --ok / --warn / --bad / --purple) so callers
+     compose the alpha at use site:
+       box-shadow: 0 0 8px rgb(var(--ok-glow) / 0.35)
+       background: rgb(var(--err-glow) / 0.08)
+     SPEC source: dashboard/design-system/source_styles/tokens.css §
+     "Status glow triplets". The dashboard runtime uses brighter hues
+     than the SPEC source (Tailwind 400/500 vs muted), so the rgb
+     decomposition matches the dashboard's existing semantic colors
+     above; visual fidelity prefers consistency with the live surface
+     over the SPEC source's muted palette. */
+  --ok-glow:      74 222 128;     /* rgb(--ok #4ade80) */
+  --warn-glow:   251 191  36;     /* rgb(--warn #fbbf24) */
+  --err-glow:    239  68  68;     /* rgb(--bad #ef4444) */
+  --info-glow:    71 184 255;     /* rgb(--accent #47b8ff) */
+  --stalled-glow: 167 139 250;    /* rgb(--purple #a78bfa, see line 258) */
+
   /* Semantic - Accent (Blue) */
   --accent-soft: rgba(71, 184, 255, 0.16);
   --accent-6: rgba(71, 184, 255, 0.06);
@@ -313,6 +332,16 @@
   --color-status-info: var(--accent);
   --color-status-idle: var(--text-muted);
   --color-status-stalled: var(--purple);
+
+  /* Status glow channel aliases (canonical SPEC §3.5).  Use these in
+     atomic primitives (Pill, future stateful tokens) so callers don't
+     reach into the raw --{kind}-glow triplet directly.  Idle has no
+     glow (silent state, no chrome). */
+  --color-status-ok-glow:      var(--ok-glow);
+  --color-status-warn-glow:    var(--warn-glow);
+  --color-status-err-glow:     var(--err-glow);
+  --color-status-info-glow:    var(--info-glow);
+  --color-status-stalled-glow: var(--stalled-glow);
 
   --color-focus-ring: var(--accent);
 


### PR DESCRIPTION
## Summary

Adds the five status glow channel tokens that the **Pill** atomic primitive (#11157) explicitly calls out as missing — closing the 75% → 100% SPEC visual fidelity gap without touching any consumer.

## The gap

`dashboard/src/components/pill.ts:7-15` documents the blocker:

> Why not import design-system/source_styles/primitives.css directly:
> - SPEC selectors expect `--{ok,warn,err,info,stalled}-glow` channels
>   that dashboard's variables.css does not yet define. Importing
>   would render the tinted backgrounds unstyled.
> - Visual fidelity here is ~75% of SPEC: foreground hue carried; SPEC
>   translucent glow background replaced with a flat elevated surface.

The SPEC source `dashboard/design-system/source_styles/tokens.css:40-45` defines all five tokens already. Only the dashboard runtime was missing them.

## What this adds

### Raw rgb-triplet channels (near `--accent` / `--ok` / `--warn` / `--bad`)

```css
--ok-glow:      74 222 128;     /* rgb(--ok #4ade80) */
--warn-glow:   251 191  36;     /* rgb(--warn #fbbf24) */
--err-glow:    239  68  68;     /* rgb(--bad #ef4444) */
--info-glow:    71 184 255;     /* rgb(--accent #47b8ff) */
--stalled-glow: 167 139 250;    /* rgb(--purple #a78bfa) */
```

### Canonical SPEC §3.5 aliases (next to existing `--color-status-{kind}` block)

```css
--color-status-ok-glow:      var(--ok-glow);
--color-status-warn-glow:    var(--warn-glow);
--color-status-err-glow:     var(--err-glow);
--color-status-info-glow:    var(--info-glow);
--color-status-stalled-glow: var(--stalled-glow);
```

`idle` deliberately has no glow — silent state, no chrome (matches SPEC §3.5 intent).

## Why dashboard-bright not SPEC-muted

The dashboard runtime uses brighter Tailwind-400/500 semantic colors than the SPEC source palette:

| Token | Dashboard runtime | SPEC source |
|-------|-------------------|-------------|
| `--ok` | `#4ade80` | `#6b9e6b` |
| `--warn` | `#fbbf24` | `#c9a24a` |
| `--bad`/`--err` | `#ef4444` | `#c46a5a` |
| `--info` (`--accent`) | `#47b8ff` | `#6a8eb0` |
| `--stalled` (`--purple`) | `#a78bfa` | `#8a6aa0` |

The triplets in this PR decompose the **dashboard's live** semantic colors so glow effects layer correctly on the existing surface. Migrating dashboard runtime to the SPEC source palette is a separate, larger discussion (visual breaking change requires explicit authorization).

## Usage pattern (atomic primitives)

```css
.is-ok {
  box-shadow:  0 0 8px rgb(var(--color-status-ok-glow) / 0.35);
  background:  rgb(var(--color-status-ok-glow) / 0.08);
  color:       var(--color-status-ok);
}
```

## Out of scope

- **Pill consumer migration** — Pill itself is untouched. The visual-fidelity sweep that swaps Pill's flat-surface internals for `<span class="pill is-{kind}">` SPEC selectors belongs in a dedicated consumer PR so this token addition can ship and be reviewed in isolation.
- **Future stateful primitives** (Toast/Banner/Alert) — they can now adopt the same channels without blocking on Pill.

## Files changed

| File | Lines |
|------|-------|
| `dashboard/src/styles/variables.css` | +29 / −0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
