### PR TITLE
[Step 6a] Typed contract classifier types (additive)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -531,6 +531,7 @@
    keeper_agent_error
    keeper_agent_memory_episode
    keeper_agent_run
+   keeper_contract_classifier
    keeper_world_observation
    keeper_decision_audit
    keeper_composite_observer

--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -1,0 +1,35 @@
+type actionable_signal =
+  | Has_unclaimed_tasks
+  | Has_board_activity
+  | Has_discovered_work
+  | No_actionable_signal
+
+type contract_status =
+  | Tool_surface_mismatch of { missing : string list }
+  | Missing_required_tool_use
+  | Claim_only_after_owned_task
+  | Needs_execution_progress
+  | Passive_only
+  | Satisfied_completion
+  | Satisfied_execution
+
+let actionable_signal_label = function
+  | Has_unclaimed_tasks -> "has_unclaimed_tasks"
+  | Has_board_activity -> "has_board_activity"
+  | Has_discovered_work -> "has_discovered_work"
+  | No_actionable_signal -> "no_actionable_signal"
+
+let contract_status_label = function
+  | Tool_surface_mismatch _ -> "tool_surface_mismatch"
+  | Missing_required_tool_use -> "missing_required_tool_use"
+  | Claim_only_after_owned_task -> "claim_only_after_owned_task"
+  | Needs_execution_progress -> "needs_execution_progress"
+  | Passive_only -> "passive_only"
+  | Satisfied_completion -> "satisfied_completion"
+  | Satisfied_execution -> "satisfied_execution"
+
+let pp_contract_status fmt = function
+  | Tool_surface_mismatch { missing } ->
+      Format.fprintf fmt "tool_surface_mismatch(missing=[%s])"
+        (String.concat ", " missing)
+  | other -> Format.pp_print_string fmt (contract_status_label other)

--- a/lib/keeper/keeper_contract_classifier.mli
+++ b/lib/keeper/keeper_contract_classifier.mli
@@ -1,0 +1,28 @@
+(** Typed classifier for keeper turn completion contract.
+
+    Step 6a of the bloodflow restoration plan introduces only the
+    type vocabulary; the call-site rewrite that replaces the
+    [String_util.contains_substring_ci haystack ...] heuristic in
+    [keeper_agent_run.ml:2285-2298] is left to a follow-up stack
+    so the type surface lands additively first. *)
+
+type actionable_signal =
+  | Has_unclaimed_tasks
+  | Has_board_activity
+  | Has_discovered_work
+  | No_actionable_signal
+      (** Caller observed neither tasks, board activity, nor
+          discovered-work markers in the structured world snapshot. *)
+
+type contract_status =
+  | Tool_surface_mismatch of { missing : string list }
+  | Missing_required_tool_use
+  | Claim_only_after_owned_task
+  | Needs_execution_progress
+  | Passive_only
+  | Satisfied_completion
+  | Satisfied_execution
+
+val actionable_signal_label : actionable_signal -> string
+val contract_status_label : contract_status -> string
+val pp_contract_status : Format.formatter -> contract_status -> unit


### PR DESCRIPTION
## Summary

Introduces `lib/keeper/keeper_contract_classifier.{ml,mli}` — a typed surface for the keeper turn completion contract decision. Branched from `main` after the Step 0a/0b/1/2/9/10/12/13 stack auto-merged.

## What this PR does

Two ADTs:

```ocaml
type actionable_signal =
  | Has_unclaimed_tasks
  | Has_board_activity
  | Has_discovered_work
  | No_actionable_signal

type contract_status =
  | Tool_surface_mismatch of { missing : string list }
  | Missing_required_tool_use
  | Claim_only_after_owned_task
  | Needs_execution_progress
  | Passive_only
  | Satisfied_completion
  | Satisfied_execution
```

Plus label helpers and `pp_contract_status` for logs.

## What this PR does NOT do

- Does **not** rewrite the call sites in `keeper_agent_run.ml:2285-2349`. Those replace the `String_util.contains_substring_ci haystack "## Discovered Work"` heuristic with a typed input drawn from `Keeper_world_observation.world_observation` and the existing `Keeper_tool_disclosure.tool_progress_class` ADT. That sweep is the next stacked PR (Step 6b).
- Does **not** export `tool_progress_class` from `keeper_tool_disclosure.mli` (currently `.ml`-only). That coupling lives in Step 6b along with the rewrite.

## Why split

The classifier's behaviour change touches contract-violation decisions; co-locating type definitions and call-site rewrite in one PR mixes "introduce vocabulary" with "behaviour change", making review noisier. Step 6a is purely additive.

## Stack position

Branched from `main` (post Step 0a/0b/1/2/9/10/12/13 merges). Independent of in-flight `feat/0a-turn-id-propagation` (#11154) and `feat/0b-telemetry-observe-module` (#11169) auto-merge queue.

## Test plan

- [x] `dune build --root . @check` clean
- [ ] full link build
- [ ] CI green
- [ ] follow-up: Step 6b call-site rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)