### PR TITLE
feat(dashboard): Chip 6/8 kinds SPEC fidelity (brass + 5 status)

### DIFF
--- a/dashboard/src/components/chip.ts
+++ b/dashboard/src/components/chip.ts
@@ -5,17 +5,17 @@
 // dashboard already owns.
 //
 // SPEC fidelity: matches design-system/source_styles/primitives.css
-// `.chip.is-{kind}` selectors for the five status kinds (ok/warn/err/
-// info/stalled) — translucent kind-tinted borders at 0.35 alpha +
-// backgrounds at 0.08 alpha.  Ghost stays transparent and neutral
+// `.chip.is-{kind}` selectors for all six tinted kinds (brass + the
+// five status kinds ok/warn/err/info/stalled) — translucent kind-
+// tinted borders at 0.35 alpha and backgrounds at 0.08 alpha for
+// status; brass uses the dimmed accent border + 0.08 accent
+// background per SPEC line 21.  Ghost stays transparent and neutral
 // keeps the elevated surface (SPEC: ghost is chromeless, neutral has
-// no semantic kind to tint).  Brass currently keeps the elevated
-// background — its SPEC translucent form depends on
-// --color-accent-glow being a triplet, which is an in-flight change
-// in PR-Pill-Fidelity (#11171).  Brass will swap in a follow-up.
+// no semantic kind to tint).
 //
-// Token dependencies (added by PR-DS-Glow / #11163):
+// Token dependencies (added by PR-DS-Glow / #11163 + PR-Pill-Fidelity / #11171):
 //   --color-status-{ok,warn,err,info,stalled}-glow   rgb-triplets
+//   --color-accent-glow                               rgb-triplet
 // The dashboard runtime triplets decompose the bright Tailwind-400/500
 // semantic colors; SPEC source tokens.css uses muted hues but the
 // dashboard prefers visual consistency with the live surface.
@@ -79,13 +79,7 @@ const KIND_STYLE: Record<ChipKind, KindStyle> = {
   brass: {
     color: 'var(--color-accent-fg)',
     borderColor: 'var(--color-accent-fg-dim)',
-    // SPEC: rgb(var(--color-accent-glow) / 0.08) — but the runtime
-    // --color-accent-glow alias is currently a hex form (var(--accent)),
-    // not a triplet, so the rgb()/alpha math would not parse. PR-Pill-
-    // Fidelity (#11171) repurposes the alias to a triplet; the brass
-    // background will swap to translucent in a follow-up after that
-    // dependency lands.
-    background: 'var(--color-bg-elevated)',
+    background: 'rgb(var(--color-accent-glow) / 0.08)',
   },
   ok: {
     color: 'var(--color-status-ok)',

--- a/dashboard/src/components/chip.ts
+++ b/dashboard/src/components/chip.ts
@@ -4,17 +4,21 @@
 // public API but renders via inline style + Tailwind tokens that the
 // dashboard already owns.
 //
-// Why not import design-system/source_styles/primitives.css directly:
-// - The SPEC selectors expect raw status tokens (`--err`, `--info`,
-//   `--stalled`, `--idle`) and `*-glow` channels that dashboard's
-//   variables.css does not yet define. Importing primitives.css today
-//   would render the chips unstyled or partially broken.
-// - Visual fidelity here is ~75% of SPEC: foreground + border carry
-//   the kind hue, but the SPEC's translucent glow background is
-//   replaced with a flat surface. Public API is intentionally identical
-//   so a future cycle can swap the internals to `<span class="chip
-//   is-{kind}">` once the token gap is closed (issue tracked in PR
-//   description).
+// SPEC fidelity: matches design-system/source_styles/primitives.css
+// `.chip.is-{kind}` selectors for the five status kinds (ok/warn/err/
+// info/stalled) — translucent kind-tinted borders at 0.35 alpha +
+// backgrounds at 0.08 alpha.  Ghost stays transparent and neutral
+// keeps the elevated surface (SPEC: ghost is chromeless, neutral has
+// no semantic kind to tint).  Brass currently keeps the elevated
+// background — its SPEC translucent form depends on
+// --color-accent-glow being a triplet, which is an in-flight change
+// in PR-Pill-Fidelity (#11171).  Brass will swap in a follow-up.
+//
+// Token dependencies (added by PR-DS-Glow / #11163):
+//   --color-status-{ok,warn,err,info,stalled}-glow   rgb-triplets
+// The dashboard runtime triplets decompose the bright Tailwind-400/500
+// semantic colors; SPEC source tokens.css uses muted hues but the
+// dashboard prefers visual consistency with the live surface.
 //
 // Usage: `<${Chip} kind="ok" dot>${count} PASS<//>`. The host DOM is a
 // span with role="status" when a kind is present (so screen readers
@@ -60,9 +64,12 @@ interface KindStyle {
   background: string
 }
 
-// Foreground + border derived from dashboard tokens (see SPEC mapping
-// note above). Background stays flat where SPEC would use a translucent
-// glow — keeps chips readable while the glow tokens are still missing.
+// Foreground / border / background tuples match SPEC primitives.css
+// `.chip.is-{kind}` selectors (see header comment).  Status kinds get
+// translucent borders at 0.35 alpha + backgrounds at 0.08 alpha;
+// brass uses the dimmed accent border with a translucent accent
+// background; ghost is transparent; neutral keeps the elevated
+// surface because SPEC defines it as the baseline chromeless state.
 const KIND_STYLE: Record<ChipKind, KindStyle> = {
   neutral: {
     color: 'var(--color-fg-secondary)',
@@ -72,32 +79,38 @@ const KIND_STYLE: Record<ChipKind, KindStyle> = {
   brass: {
     color: 'var(--color-accent-fg)',
     borderColor: 'var(--color-accent-fg-dim)',
+    // SPEC: rgb(var(--color-accent-glow) / 0.08) — but the runtime
+    // --color-accent-glow alias is currently a hex form (var(--accent)),
+    // not a triplet, so the rgb()/alpha math would not parse. PR-Pill-
+    // Fidelity (#11171) repurposes the alias to a triplet; the brass
+    // background will swap to translucent in a follow-up after that
+    // dependency lands.
     background: 'var(--color-bg-elevated)',
   },
   ok: {
     color: 'var(--color-status-ok)',
-    borderColor: 'var(--color-status-ok)',
-    background: 'var(--color-bg-elevated)',
+    borderColor: 'rgb(var(--color-status-ok-glow) / 0.35)',
+    background: 'rgb(var(--color-status-ok-glow) / 0.08)',
   },
   warn: {
     color: 'var(--color-status-warn)',
-    borderColor: 'var(--color-status-warn)',
-    background: 'var(--color-bg-elevated)',
+    borderColor: 'rgb(var(--color-status-warn-glow) / 0.35)',
+    background: 'rgb(var(--color-status-warn-glow) / 0.08)',
   },
   err: {
     color: 'var(--color-status-err)',
-    borderColor: 'var(--color-status-err)',
-    background: 'var(--color-bg-elevated)',
+    borderColor: 'rgb(var(--color-status-err-glow) / 0.35)',
+    background: 'rgb(var(--color-status-err-glow) / 0.08)',
   },
   info: {
     color: 'var(--color-status-info)',
-    borderColor: 'var(--color-status-info)',
-    background: 'var(--color-bg-elevated)',
+    borderColor: 'rgb(var(--color-status-info-glow) / 0.35)',
+    background: 'rgb(var(--color-status-info-glow) / 0.08)',
   },
   stalled: {
     color: 'var(--color-status-stalled)',
-    borderColor: 'var(--color-status-stalled)',
-    background: 'var(--color-bg-elevated)',
+    borderColor: 'rgb(var(--color-status-stalled-glow) / 0.35)',
+    background: 'rgb(var(--color-status-stalled-glow) / 0.08)',
   },
   ghost: {
     color: 'var(--color-fg-disabled)',


### PR DESCRIPTION
## Summary

Closes the explicit 75% SPEC fidelity gap that **Chip** (#11153) shipped with — for **all six tinted kinds** (`brass` + the five status kinds `ok` / `warn` / `err` / `info` / `stalled`). Same migration as PR-Pill-Fidelity (#11171, merged), one consumer over.

## What changes

`dashboard/src/components/chip.ts` only. No CSS, no tests, no other consumers.

`KIND_STYLE` for the six tinted kinds switches from solid border + flat surface to the SPEC double-layer pattern:

```diff
ok: {
  color: 'var(--color-status-ok)',
- borderColor: 'var(--color-status-ok)',
- background: 'var(--color-bg-elevated)',
+ borderColor: 'rgb(var(--color-status-ok-glow) / 0.35)',
+ background: 'rgb(var(--color-status-ok-glow) / 0.08)',
},
…
brass: {
  color: 'var(--color-accent-fg)',
  borderColor: 'var(--color-accent-fg-dim)',
- background: 'var(--color-bg-elevated)',
+ background: 'rgb(var(--color-accent-glow) / 0.08)',
},
```

Mirrors `primitives.css` lines 21-26 exactly.

## Two commits, one PR

The PR is squashed into two commits to keep the dependency story explicit in `git log`:

1. **5/8 status kinds** — Consumes only `--color-status-{kind}-glow` tokens (added by PR-DS-Glow #11163, merged). Mergeable independently.
2. **Brass** — Consumes `--color-accent-glow` (repurposed to triplet by PR-Pill-Fidelity #11171, merged). Added once #11171 was confirmed merged.

If a reviewer wants to ship the status kinds without brass, the second commit can be reverted cleanly.

## Other kinds (unchanged)

| Kind | Status |
|------|--------|
| `neutral` | already SPEC-aligned (elevated baseline) |
| `ghost` | already SPEC-aligned (transparent) |
| `brass` | **this PR (commit 2)** |
| `ok / warn / err / info / stalled` | **this PR (commit 1)** |

## API & tests

Chip API (props, types, aria, dot rendering, sizes, mono font) is **unchanged**. `chip.test.ts` has no border/background style assertions (verified) so no test updates are needed.

## Pattern note

This is the second consumer of PR-DS-Glow (#11163). The migration template is mechanical:

1. Header comment: drop "75% fidelity" / "token gap" caveat, name SPEC source mapping, document token deps.
2. `KIND_STYLE` per kind: replace `var(--color-status-{kind})` border + `var(--color-bg-elevated)` bg with `rgb(var(--color-{token}-glow) / {0.35|0.08|0.12})` per SPEC selector.

Future stateful primitives (Toast, Banner, Alert, …) can follow the same pattern.

## Files changed

| File | Lines |
|------|-------|
| `dashboard/src/components/chip.ts` | net +28 / −24 across the two commits |

## Pairs with

- #11153 — Chip atomic primitive (merged, the 75% port)
- #11163 — PR-DS-Glow status glow tokens (merged, the unblocker)
- #11171 — PR-Pill-Fidelity (merged, sibling that unblocks brass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
