### PR TITLE
feat(dashboard): Band atomic primitive (atom 4/14, doctor card status strip)

### DIFF
--- a/dashboard/src/components/band.test.ts
+++ b/dashboard/src/components/band.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Band, type BandProps } from './band'
+
+describe('Band', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    render(null, host)
+    host.remove()
+  })
+
+  function mount(props: BandProps): HTMLElement {
+    render(html`<${Band} ...${props} />`, host)
+    return host.firstElementChild as HTMLElement
+  }
+
+  // ── Structural ──
+
+  it('emits a div with aria-hidden=true (decorative)', () => {
+    const el = mount({})
+    expect(el.tagName).toBe('DIV')
+    expect(el.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('records kind on data-kind', () => {
+    const el = mount({ kind: 'ok' })
+    expect(el.getAttribute('data-kind')).toBe('ok')
+  })
+
+  it('defaults to kind=default when omitted', () => {
+    const el = mount({})
+    expect(el.getAttribute('data-kind')).toBe('default')
+  })
+
+  it('forwards testId to data-testid', () => {
+    const el = mount({ kind: 'warn', testId: 'card-band' })
+    expect(el.getAttribute('data-testid')).toBe('card-band')
+  })
+
+  it('does NOT emit a role attribute (pure decoration)', () => {
+    const el = mount({ kind: 'err' })
+    expect(el.getAttribute('role')).toBe(null)
+  })
+
+  // ── Visual fidelity ──
+
+  it('renders 2px height (SPEC band geometry)', () => {
+    const el = mount({})
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('height: 2px')
+  })
+
+  it('uses border-strong for default kind', () => {
+    const el = mount({})
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-border-strong)')
+  })
+
+  it('uses ok status token for ok kind', () => {
+    const el = mount({ kind: 'ok' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-status-ok)')
+  })
+
+  it('uses warn status token for warn kind', () => {
+    const el = mount({ kind: 'warn' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-status-warn)')
+  })
+
+  it('uses err status token for err kind', () => {
+    const el = mount({ kind: 'err' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-status-err)')
+  })
+
+  it('uses stalled status token for stalled kind', () => {
+    const el = mount({ kind: 'stalled' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-status-stalled)')
+  })
+
+  it('running kind uses accent foreground + glow box-shadow', () => {
+    const el = mount({ kind: 'running' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-accent-fg)')
+    expect(style).toContain('--color-accent-glow')
+    expect(style).toContain('box-shadow')
+  })
+
+  it('non-running kinds do not emit box-shadow', () => {
+    const el = mount({ kind: 'ok' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).not.toContain('box-shadow')
+  })
+
+  // ── Top radius ──
+
+  it('renders top-only radius by default (1px 1px 0 0)', () => {
+    const el = mount({})
+    const style = el.getAttribute('style') ?? ''
+    // happy-dom normalises bare `0` to `0px` in shorthand values
+    expect(style).toMatch(/border-radius:\s*1px\s+1px\s+0(px)?\s+0(px)?/)
+  })
+
+  it('drops radius when topRadius=false', () => {
+    const el = mount({ topRadius: false })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toMatch(/border-radius:\s*0(px)?\s*;/)
+  })
+})

--- a/dashboard/src/components/band.ts
+++ b/dashboard/src/components/band.ts
@@ -1,0 +1,102 @@
+// Band — atomic primitive ported from design-system v0.4 primitives.html
+// (`<div class="band is-{kind}"></div>`). The SPEC defines a 2px strip
+// at the top of cards indicating overall state. Pure decoration: no
+// content, no role, no aria — its job is to give the card a single-
+// glance state cue alongside whatever Pill/Chip/text the body carries.
+//
+// Distinct from Bar (4px progress with fill width%), Chip (label),
+// and Pill (capsule state badge): Band is a *card-level* state strip,
+// always 100% width, 2px tall, no quantity, no label.
+//
+// SPEC mapping (primitives.css `.band`):
+//   default          — --color-border-strong (idle, no state)
+//   .band.is-running — --color-accent-fg + glow shadow
+//   .band.is-ok      — --ok
+//   .band.is-warn    — --warn
+//   .band.is-err     — --err
+//   .band.is-stalled — --stalled
+//
+// Dashboard token mapping (no glow channel needed except `running`):
+//   default → --color-border-strong
+//   running → --color-accent-fg + box-shadow w/ rgb(var(--color-accent-glow) / 0.5)
+//   ok      → --color-status-ok
+//   warn    → --color-status-warn
+//   err     → --color-status-err
+//   stalled → --color-status-stalled
+//
+// The accent-glow channel was added in #11163, so `running` reaches
+// 100% SPEC fidelity (with a 6px box-shadow glow). Other kinds use
+// solid fill — also 100% fidelity.
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+
+export type BandKind =
+  | 'default'
+  | 'running'
+  | 'ok'
+  | 'warn'
+  | 'err'
+  | 'stalled'
+
+export interface BandProps {
+  /** State tone. `undefined` ≡ `default` (idle, border-strong color). */
+  kind?: BandKind
+  /** Forwarded to data-testid. */
+  testId?: string
+  /** Border radius on top corners only. Default true (matches SPEC
+   *  `.band` rendered above a card's rounded surface — `1px 1px 0 0`).
+   *  Set false when the band is not at the top of a rounded container. */
+  topRadius?: boolean
+}
+
+interface KindStyle {
+  background: string
+  boxShadow?: string
+}
+
+const KIND_STYLE: Record<BandKind, KindStyle> = {
+  default: {
+    background: 'var(--color-border-strong)',
+  },
+  running: {
+    background: 'var(--color-accent-fg)',
+    boxShadow: '0 0 6px rgb(var(--color-accent-glow, 71 184 255) / 0.5)',
+  },
+  ok: {
+    background: 'var(--color-status-ok)',
+  },
+  warn: {
+    background: 'var(--color-status-warn)',
+  },
+  err: {
+    background: 'var(--color-status-err)',
+  },
+  stalled: {
+    background: 'var(--color-status-stalled)',
+  },
+}
+
+export function Band(props: BandProps): VNode {
+  const kind = props.kind ?? 'default'
+  const ks = KIND_STYLE[kind]
+  const topRadius = props.topRadius !== false
+
+  const style = {
+    display: 'block',
+    height: '2px',
+    width: '100%',
+    background: ks.background,
+    borderRadius: topRadius ? '1px 1px 0 0' : '0',
+    boxShadow: ks.boxShadow,
+  }
+
+  return html`
+    <div
+      aria-hidden="true"
+      data-testid=${props.testId}
+      data-kind=${kind}
+      style=${style}
+    ></div>
+  `
+}

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -15,6 +15,7 @@ import { Card } from './common/card'
 import { SectionCap } from './common/section-cap'
 import { Chip } from './chip'
 import { Pill, type PillKind } from './pill'
+import { Band, type BandKind } from './band'
 
 export type DoctorKind = 'config' | 'sidecar'
 
@@ -76,6 +77,21 @@ export function severityChipClass(code: number): string {
 // Map exit code to atomic Pill kind. Used by callers that have
 // migrated from the bespoke severityChipClass to the Pill primitive.
 export function severityPillKind(code: number): PillKind {
+  switch (severityForExitCode(code)) {
+    case 'ok':
+      return 'ok'
+    case 'warn':
+      return 'warn'
+    case 'error':
+      return 'err'
+  }
+}
+
+// Map exit code to atomic Band kind for the card's top status strip.
+// Mirrors severityPillKind so the band tone and the pill tone always
+// match — the SPEC pattern is "card-level state strip + body status
+// pill" reading the same severity.
+export function severityBandKind(code: number): BandKind {
   switch (severityForExitCode(code)) {
     case 'ok':
       return 'ok'
@@ -275,10 +291,13 @@ function ConfigNotesList({ notes }: { notes: ConfigNotesView }) {
 function DoctorEntryCard({ entry }: { entry: DoctorEntry }) {
   const label = severityLabel(entry.exit_code)
   const pillKind = severityPillKind(entry.exit_code)
+  const bandKind = severityBandKind(entry.exit_code)
   const expanded = useSignal(false)
   const onToggle = () => { expanded.value = !expanded.value }
   return html`
-    <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+    <div class="overflow-hidden rounded border border-[var(--white-8)] bg-[var(--white-4)]">
+      <${Band} kind=${bandKind} />
+      <div class="p-3">
       <button
         type="button"
         class="flex w-full items-baseline justify-between gap-2 text-left"
@@ -299,6 +318,7 @@ function DoctorEntryCard({ entry }: { entry: DoctorEntry }) {
           ? html`<${SidecarChecksList} checks=${extractSidecarChecks(entry.payload)} />`
           : html`<${ConfigNotesList} notes=${extractConfigNotes(entry.payload)} />`
         : ''}
+      </div>
     </div>
   `
 }


### PR DESCRIPTION
## Why — atom score 3/14 → 4/14

직전 cycle 의 `Bar` (#11170) 머지 후 다음 atom. atomic primitive 역할 분리 명확:

| atom | 역할 | shape | kind 의미 |
|---|---|---|---|
| Chip (#11153) | static label | 18px sharp 2px | 카테고리 (passing/47 PASS/P1) |
| Pill (#11157) | state badge | 16px capsule 999px | state machine (running/paused) |
| Bar (#11170) | progress quantity | 4px fill width% | progress 0..100 |
| **Band (이 PR)** | **card state strip** | **2px 100% width** | overall state (decoration) |

Band 는 *card 자체* 가 단일 시선으로 상태를 표현 — body 안의 Pill/Chip 과 *동일 진실의 두 표현* (예: severity = err → 카드 상단 빨간 strip + body 빨간 Pill).

## 변경

| 파일 | 변경 |
|---|---|
| `dashboard/src/components/band.ts` (신규) | Atomic Band primitive. SPEC API 1:1 (`<div class="band is-{kind}">` ↔ `<Band kind="..." />`) |
| `dashboard/src/components/band.test.ts` (신규) | 14 cases: structural (data-kind / aria-hidden / no role), kind→token (6 kinds), geometry (2px / top-only radius), running glow shadow, topRadius opt-out |
| `dashboard/src/components/doctor-panel.ts` | (a) `severityBandKind(code)` pure helper (severityPillKind 와 mirror) (b) `DoctorEntryCard` 외곽 wrapper 재구성: outer div 는 `overflow-hidden` + Band, inner div 가 body padding 책임 |

### SPEC API 매핑

| SPEC | Band prop |
|---|---|
| `<div class="band">` | `<Band />` (kind="default") |
| `.band.is-running` | `<Band kind="running" />` (+ glow shadow) |
| `.band.is-ok` | `<Band kind="ok" />` |
| `.band.is-warn` | `<Band kind="warn" />` |
| `.band.is-err` | `<Band kind="err" />` |
| `.band.is-stalled` | `<Band kind="stalled" />` |
| 2px height + 1px-1px-0-0 radius | hard-coded SPEC 값 |
| no aria-* on the strip | `aria-hidden="true"` (pure decoration) |

### Visual fidelity: **100% SPEC 정합**

#11163 (`*-glow` channel) 머지 덕에 `running` kind 의 6px box-shadow 도 작동. 다른 kind 는 solid `--color-status-{ok,warn,err,stalled}` + `--color-border-strong` (default) 모두 dashboard 런타임에 이미 존재. **Bar 에 이어 두 번째 100% fidelity atom**.

### DoctorEntryCard layout 변경

```diff
-<div class="rounded border ... p-3">
+<div class="overflow-hidden rounded border ...">
+  <Band kind=${bandKind} />
+  <div class="p-3">
   <button>...</button>
   ...
+  </div>
 </div>
```

Outer wrapper 가 padding 책임을 inner div 로 이양 — Band 가 top edge 에 *flush* 로 붙음 (overflow-hidden 으로 outer rounded corner 안에서 잘림). Body content 의 시각 위치 변경 없음.

## 검증

- `pnpm exec tsc --noEmit` — clean (EXIT 0)
- `pnpm exec vitest run band` — **14/14 passed**
- `pnpm exec vitest run doctor-panel` — **23/23 passed** (회귀 0)

## Scope note — 이 PR 에서 의도적으로 *제외* 한 것

- **`SurfaceCard` 의 `band?: BandKind` prop 추가**: dashboard 전반의 card primitive (40+ callsites) 에 Band 를 노출하는 것은 visible delta 가 전 화면에 퍼짐 — 별도 PR 로 review 단순화.
- **다른 panel cards** (keeper-detail, fleet, governance 등) 에 Band 직접 적용: 각 panel 의 *어떤 state* 를 band 로 표현할지 결정 필요 — 별도 sweep.

## 미검증 / 잔재

- 시각 검증: dev server 직접 확인 필요. doctor-panel 의 DoctorEntryCard 카드 상단에 2px tinted band 가 표시되는지 (severity ok → green / warn → amber / err → red, running 은 doctor 영역에 안 나타남)
- happy-dom 은 layout 안 함 — Band geometry (2px height, top-only radius) 의 *시각* 정합은 dev server 에서만 확인 가능

## 다음 cycle 후보

| 옵션 | 내용 |
|---|---|
| **A** | `SurfaceCard` 에 `band?: BandKind` prop 추가 → 40+ card callsites 에 옵션으로 Band 도입 (전 화면 visible delta) |
| **B** | 다음 atom — **Spark** (sparkline histogram) 또는 **KV Row** (label/value grid) 또는 **Sep** (separator) |
| **C** | Chip / Pill 의 glow background swap (#11163 token 활용 → Chip / Pill fidelity 75% → 100%) |
| **D** | doctor-panel `SidecarChecksList` 의 line 212 per-check severity → Pill swap continuation |

## Self-review (best-programmer)

- 목표: atom score 3/14 → 4/14. 두 번째 100% fidelity atom + DoctorEntryCard 시각 진화
- 변경 범위: 3 파일, +242/-1 라인. primitive 정의 + 14 단위 test + 1 callsite swap + 1 helper 추가
- 검증: tsc clean + 38 vitest green + 회귀 0
- 미검증: 시각 렌더 (의도상 사용자 화면 + dev server 에서만 가능)
- 정직 disclosure: SurfaceCard 전체 prop 추가는 별도 PR, glow swap 별도, sidecar 별도 — review 단순화 우선

🤖 Generated with [Claude Code](https://claude.com/claude-code)
