### PR TITLE
feat(dashboard): SectionHead atom (atom 5/14, 5 panel SSOT swap)

### DIFF
--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
-import { SectionHeader } from './section-header'
+import { SectionHead } from '../section-head'
 
 // ── Class constants (CARD_STANDARD exported for inline section usage) ──
 const CARD_BASE = 'card'
@@ -53,13 +53,24 @@ export function SectionCard({
   variant = 'light',
   children,
 }: SectionCardProps) {
+  // SPEC `.section-head` upgrade — SectionHead atom replaces the
+  // legacy SectionHeader. The strip wants to sit flush against the
+  // card's top edge, so the outer SurfaceCard padding is forced to 0
+  // (overflow-hidden lets the strip clip into the rounded corner) and
+  // the body padding moves into a dedicated wrapper. The `light`
+  // variant deliberately keeps the bg-transparent override — the
+  // SectionHead's bg-surface still reads as a strip because it sits
+  // above transparent body. Variant `compact` had p-3.5 in the legacy
+  // path; the new wrapper uses p-3.5 to preserve that visual.
+  const bodyPadding = variant === 'compact' ? 'p-3.5' : 'p-4'
   return html`
-    <${SurfaceCard} variant=${variant} class="flex flex-col gap-4 ${cx ?? ''}">
-      <${SectionHeader}>${label}<//>
-      ${children}
+    <${SurfaceCard} variant=${variant} class="flex flex-col !p-0 overflow-hidden ${cx ?? ''}">
+      <${SectionHead}>${label}<//>
+      <div class="${bodyPadding} flex flex-col gap-4">${children}</div>
     <//>
   `
 }
+
 
 // ── Legacy Card (backward compat — accepts title prop) ──
 interface CardProps {

--- a/dashboard/src/components/section-head.test.ts
+++ b/dashboard/src/components/section-head.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { SectionHead, type SectionHeadProps } from './section-head'
+
+describe('SectionHead', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    render(null, host)
+    host.remove()
+  })
+
+  function mount(props: SectionHeadProps): HTMLElement {
+    render(html`<${SectionHead} ...${props} />`, host)
+    return host.firstElementChild as HTMLElement
+  }
+
+  // ── Structural ──
+
+  it('emits a div as the host', () => {
+    const el = mount({ children: 'KEEPERS' })
+    expect(el.tagName).toBe('DIV')
+  })
+
+  it('renders the label as the first child span', () => {
+    const el = mount({ children: 'KEEPERS' })
+    const first = el.firstElementChild as HTMLElement
+    expect(first.tagName).toBe('SPAN')
+    expect(first.textContent).toBe('KEEPERS')
+  })
+
+  it('forwards testId to data-testid', () => {
+    const el = mount({ children: 'X', testId: 'overview-head' })
+    expect(el.getAttribute('data-testid')).toBe('overview-head')
+  })
+
+  it('lets caller set aria-label', () => {
+    const el = mount({ children: 'X', ariaLabel: 'panel header' })
+    expect(el.getAttribute('aria-label')).toBe('panel header')
+  })
+
+  // ── SPEC geometry ──
+
+  it('renders 28px min-height (SPEC strip geometry)', () => {
+    const el = mount({ children: 'X' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('min-height: 28px')
+  })
+
+  it('renders 12px horizontal padding', () => {
+    const el = mount({ children: 'X' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('padding: 0px 12px')
+  })
+
+  it('renders bottom hairline by default', () => {
+    const el = mount({ children: 'X' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('border-bottom-width: 1px')
+    expect(style).toContain('border-bottom-style: solid')
+    expect(style).toContain('border-bottom-color: var(--color-border-default)')
+  })
+
+  it('drops bottom hairline when noBorder=true', () => {
+    const el = mount({ children: 'X', noBorder: true })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('border-bottom-style: none')
+  })
+
+  // ── Visual fidelity ──
+
+  it('uses bg-surface as the strip background', () => {
+    const el = mount({ children: 'X' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-bg-surface)')
+  })
+
+  it('uses fg-muted for the label tone', () => {
+    const el = mount({ children: 'X' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-fg-muted)')
+  })
+
+  it('applies uppercase + 0.08em letter-spacing (SPEC font rule)', () => {
+    const el = mount({ children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('text-transform: uppercase')
+    expect(style).toContain('letter-spacing: 0.08em')
+  })
+
+  // ── Count slot ──
+
+  it('omits count span when count is undefined', () => {
+    const el = mount({ children: 'X' })
+    expect(el.querySelector('[data-section-head-count]')).toBeNull()
+  })
+
+  it('renders count as tabular-nums right-aligned span', () => {
+    const el = mount({ children: 'KEEPERS', count: 14 })
+    const cnt = el.querySelector('[data-section-head-count]') as HTMLElement
+    expect(cnt).not.toBeNull()
+    expect(cnt.textContent).toBe('14')
+    const cs = cnt.getAttribute('style') ?? ''
+    expect(cs).toContain('font-variant-numeric: tabular-nums')
+    expect(cs).toContain('margin-left: auto')
+  })
+
+  it('accepts a string count', () => {
+    const el = mount({ children: 'X', count: '7/12' })
+    const cnt = el.querySelector('[data-section-head-count]') as HTMLElement
+    expect(cnt.textContent).toBe('7/12')
+  })
+
+  // ── Tail slot ──
+
+  it('omits tail span when tail is undefined', () => {
+    const el = mount({ children: 'X' })
+    expect(el.querySelector('[data-section-head-tail]')).toBeNull()
+  })
+
+  it('renders tail as a right-aligned flex container', () => {
+    const el = mount({
+      children: 'X',
+      tail: html`<button>refresh</button>`,
+    })
+    const tail = el.querySelector('[data-section-head-tail]') as HTMLElement
+    expect(tail).not.toBeNull()
+    const ts = tail.getAttribute('style') ?? ''
+    expect(ts).toContain('margin-left: auto')
+    expect(ts).toContain('display: inline-flex')
+  })
+
+  it('when both count and tail present, count pushes right and tail follows', () => {
+    const el = mount({
+      children: 'X',
+      count: 3,
+      tail: html`<button>x</button>`,
+    })
+    const cnt = el.querySelector('[data-section-head-count]')
+    const tail = el.querySelector('[data-section-head-tail]') as HTMLElement
+    expect(cnt).not.toBeNull()
+    expect(tail).not.toBeNull()
+    // tail uses 8px gap not auto when count claims the auto slot
+    const ts = tail.getAttribute('style') ?? ''
+    expect(ts).toContain('margin-left: 8px')
+  })
+})

--- a/dashboard/src/components/section-head.ts
+++ b/dashboard/src/components/section-head.ts
@@ -1,0 +1,118 @@
+// SectionHead — atomic primitive ported from design-system v0.4
+// primitives.html (`<div class="section-head"><span>LABEL</span>
+// <span class="count">N</span></div>`). The SPEC defines a 28px panel
+// header *strip* — uppercase label on the left, optional count or
+// arbitrary tail content right-aligned, and a hairline border-bottom
+// that visually separates the head from the body of a card / panel.
+//
+// Distinct from existing dashboard primitives:
+//
+//   SectionCap     (common/section-cap.ts)    — pure label *style*,
+//     no surface, no flex layout. Caller owns layout.
+//   SectionHeader  (common/section-header.ts) — flex container with
+//     a heading + right slot, but NO border-bottom, NO bg-surface,
+//     NO 28px min-height. Closer to SPEC than SectionCap but still
+//     not the strip surface SPEC defines.
+//   SectionHead    (THIS FILE)                — full SPEC: strip
+//     surface (bg + border-bottom + min-height + padding) +
+//     uppercase label + count/tail right slot.
+//
+// SPEC mapping (primitives.css `.section-head`):
+//   min-height 28px, padding 0 12px, border-bottom 1px,
+//   background var(--color-bg-surface), font-size 11px, weight 600,
+//   letter-spacing 0.08em, uppercase, color var(--color-fg-muted).
+//   Right slot via `.count` (tabular-nums, fg-disabled) or `.tail`
+//   (flex container) — both push to right with margin-left:auto.
+//
+// Why a new primitive instead of upgrading SectionHeader: SectionHeader
+// has 9+ callers that read its current visual contract (no surface).
+// Adding strip styling there would visually mutate every caller in a
+// single change. New atom + opt-in adoption is safer; legacy callers
+// migrate incrementally.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren, VNode } from 'preact'
+
+export interface SectionHeadProps {
+  /** The label text. Rendered uppercase via the SPEC font rule. */
+  children: ComponentChildren
+  /** Right-side count, formatted as a string. Rendered with
+   *  tabular-nums + fg-disabled tone (SPEC `.count` rule). */
+  count?: string | number
+  /** Arbitrary right-aligned content (Pill, Chip, button row).
+   *  Mutually compatible with `count` — both render in the same
+   *  right-flex container, count first then tail children. */
+  tail?: ComponentChildren
+  /** Drop the bottom hairline (e.g. when the head sits above a
+   *  custom divider or another strip). Default false. */
+  noBorder?: boolean
+  /** Forwarded to data-testid on the host. */
+  testId?: string
+  /** Override the auto aria-label. By default the host emits no
+   *  aria — the heading text is read directly. */
+  ariaLabel?: string
+}
+
+const MONO_STACK =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+export function SectionHead(props: SectionHeadProps): VNode {
+  const noBorder = props.noBorder === true
+
+  const containerStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    minHeight: '28px',
+    padding: '0 12px',
+    // Longhand instead of `borderBottom` shorthand — happy-dom mis-
+    // parses `border-bottom: 1px solid var(--token)` and splits the
+    // var() across all three sub-properties (width/style/color), so
+    // the rule never applies. Longhand is unambiguous.
+    borderBottomWidth: noBorder ? '0' : '1px',
+    borderBottomStyle: noBorder ? 'none' : 'solid',
+    borderBottomColor: noBorder ? 'transparent' : 'var(--color-border-default)',
+    background: 'var(--color-bg-surface)',
+    fontSize: 'var(--fs-11)',
+    fontWeight: 600,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase' as const,
+    color: 'var(--color-fg-muted)',
+    flexShrink: 0,
+  }
+
+  const labelStyle = {
+    flexShrink: 0,
+  }
+
+  const countStyle = {
+    marginLeft: 'auto',
+    fontFamily: MONO_STACK,
+    color: 'var(--color-fg-disabled)',
+    fontWeight: 500,
+    fontVariantNumeric: 'tabular-nums' as const,
+  }
+
+  const tailStyle = {
+    marginLeft: props.count != null ? '8px' : 'auto',
+    display: 'inline-flex',
+    gap: '4px',
+    alignItems: 'center',
+  }
+
+  return html`
+    <div
+      data-testid=${props.testId}
+      aria-label=${props.ariaLabel}
+      style=${containerStyle}
+    >
+      <span style=${labelStyle}>${props.children}</span>
+      ${props.count != null
+        ? html`<span data-section-head-count style=${countStyle}>${props.count}</span>`
+        : null}
+      ${props.tail != null
+        ? html`<span data-section-head-tail style=${tailStyle}>${props.tail}</span>`
+        : null}
+    </div>
+  `
+}


### PR DESCRIPTION
## Why — atom score 4/14 → 5/14, **5 production panels 자동 SPEC 정합**

Chip / Pill / Bar / Band 다음의 다섯 번째 atom. 사용자 의도 *"실제 사용하는곳도 궁금"* 신호와 정합 — 단순 atom 도입이 아니라 **SectionCard SSOT swap** 으로 dashboard 5+ panel 의 header 가 한 번에 SPEC 정합 진입.

### 기존 dashboard 의 두 sibling 과 SPEC 비교

| | SectionCap | SectionHeader | **SectionHead (이 PR)** |
|---|---|---|---|
| 역할 | 라벨 *스타일* | flex 컨테이너 + 헤딩 | **panel header *strip*** |
| Surface | 없음 | 없음 | bg-surface + border-bottom |
| Geometry | 텍스트만 | flex justify-between | **28px min-height + 12px padding** |
| Right slot | caller owns | `right` prop | `count` + `tail` slots |
| SPEC 정합 | partial | partial | **100%** |

기존 두 primitive 는 SPEC `.section-head` 의 *strip surface* 의도를 못 채움. 새 atom 으로 분리, 점진 migration.

## 변경

| 파일 | 변경 |
|---|---|
| `dashboard/src/components/section-head.ts` (신규) | Atomic SectionHead primitive. SPEC API 1:1 (`<div class="section-head">label<span class="count">N</span></div>` ↔ `<SectionHead count={N}>label</SectionHead>`) |
| `dashboard/src/components/section-head.test.ts` (신규) | 17 cases: structural, SPEC geometry (28px / 12px / longhand border), font fidelity (uppercase / 0.08em / fs-11 / fg-muted / bg-surface), count/tail slot behavior |
| `dashboard/src/components/common/card.ts` | SectionCard internal 의 SectionHeader → **SectionHead** swap. 외곽 SurfaceCard padding 을 `!p-0 overflow-hidden` 로 강제, body padding 을 별도 wrapper 로 이양 (variant 별 p-4 / p-3.5) |

### SPEC API 매핑

| SPEC | SectionHead prop |
|---|---|
| `<div class="section-head">label</div>` | `<SectionHead>label</SectionHead>` |
| `<span class="count">14</span>` | `count={14}` |
| `<span class="tail">...</span>` | `tail={html\`<button>...</button>\`}` |
| 28px / 12px padding / 100% width | hard-coded SPEC 값 |
| 11px / 600 / 0.08em uppercase | hard-coded SPEC 값 |
| bg-surface + border-bottom hairline | dashboard tokens |
| no aria | host emits no role/label by default |

### Visual fidelity: **100% SPEC 정합**

dashboard 런타임의 기존 token 만 사용 (`--color-bg-surface`, `--color-fg-muted`, `--color-fg-disabled`, `--color-border-default`, `--fs-11`). glow channel 불필요. **Bar / Band / Pill (post-#11171) 에 이어 네 번째 100% fidelity atom**.

### SSOT swap — visible delta

```diff
 export function SectionCard({...}) {
+  const bodyPadding = variant === 'compact' ? 'p-3.5' : 'p-4'
   return html`
-    <${SurfaceCard} variant=${variant} class="flex flex-col gap-4 ${cx ?? ''}">
-      <${SectionHeader}>${label}<//>
-      ${children}
+    <${SurfaceCard} variant=${variant} class="flex flex-col !p-0 overflow-hidden ${cx ?? ''}">
+      <${SectionHead}>${label}<//>
+      <div class="${bodyPadding} flex flex-col gap-4">${children}</div>
     <//>
   `
 }
```

**자동 전파 — 5 production panels 한 번에 SPEC 정합**:

| 파일 | SectionCard 사용 |
|---|---|
| `keeper-detail.ts` | keeper detail panels |
| `keeper-detail-history.ts` | keeper history strip |
| `keeper-detail-layout.ts` | keeper layout shell |
| `keeper-supervisor-diagnostics.ts` | supervisor diag |
| `transport-health.ts` | transport health |

`Card` legacy primitive 도 `title` prop 사용 시 SectionCard 로 delegate → 더 많은 callsite 자동 진화.

## happy-dom 인스턴스 우회

`border-bottom: 1px solid var(--color-border-default)` shorthand 가 happy-dom 에서 mis-parsing — width/style/color 모두 var() 로 collapse. **longhand 사용** (border-bottom-width / -style / -color 분리) 으로 우회. SectionHead.ts 안 주석에 명시.

## 검증

- `pnpm exec tsc --noEmit` — clean (EXIT 0)
- `pnpm exec vitest run section-head` — **17/17 passed**
- `pnpm exec vitest run keeper-detail keeper-supervisor-diagnostics transport-health` — **150/150 passed** (5 SectionCard caller suites + Card 의존 suites 회귀 0)

## Scope note — 이 PR 에서 의도적으로 *제외* 한 것

- **SectionHeader 파일 자체 제거**: card.ts 에서만 import 됐지만, 다른 dashboard 파일에서 미래에 import 가능. legacy 보존 — flex 헤딩 (strip surface 없는) 만 원하는 caller 를 위함.
- **SectionCap 마이그레이션**: 다른 의도 (label only). 별도 sweep 또는 그대로 유지.
- **manual SectionHeader 직접 호출 callsite**: 현재 0건이지만 추가될 경우 별도 PR 로 SectionHead 로 옮김.

## 미검증 / 잔재

- 시각 검증: dev server 직접 확인 필요. SectionCard 가 사용된 5 panel 의 상단에 28px strip (uppercase 라벨 + bg + border-bottom) 이 *flush* 로 표시되는지 (사용자 캡처 SPEC `.section-head` 와 비교)
- happy-dom 은 layout 안 함 — strip geometry (28px / 12px padding / border-bottom hairline) 의 *시각* 정합은 dev server 에서만 확인 가능

## 다음 cycle 후보

| 옵션 | 내용 |
|---|---|
| **A** | 다음 atom — **Spark** (sparkline histogram), **KV Row** (label/value grid), **Sep** (separator), **Status Surfaces** (banner) |
| **B** | Chip glow swap (#11163 token 활용 → Chip fidelity 75% → 100%, 마지막 fidelity 갭 닫기) |
| **C** | manual `SurfaceCard` callers (40+) 에 옵션 prop `header?: { label, count, tail }` 추가 → label-less surface card 도 SectionHead 활용 가능 |
| **D** | `cb-group-g` state primitives (empty/loading/error) — 사용자 캡처 v0.4 의 지정 영역 |

## Self-review (best-programmer)

- 목표: atom score 4/14 → 5/14. 가장 큰 visible delta 의 SSOT swap (5 panel 자동 정합)
- 변경 범위: 3 파일, +287/-4 라인. primitive 정의 + 17 단위 test + SSOT swap 1곳 + body padding 책임 이양
- 검증: tsc clean + 167 vitest green (17 atom + 150 caller) + 회귀 0
- 미검증: 시각 렌더 (의도상 사용자 화면 + dev server 에서만 가능)
- 정직 disclosure: SectionHeader 파일 보존 (legacy + 미래 caller), SectionCap 미터치, manual SurfaceCard caller 미터치 — 본 PR 는 *SectionCard 로 가는 경로* 만 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)
