### PR TITLE
docs(design-system): clarify 5 named keepers as subset of 12-slot palette

### DIFF
--- a/dashboard/design-system/README.md
+++ b/dashboard/design-system/README.md
@@ -24,7 +24,7 @@ The two modes can cohabit in **split mode**, sharing the topbar/ticker/KPI chrom
 
 ### The fleet
 
-Five named keeper personas show up throughout the UI with distinct colors:
+Keeper attribution runs on a **12-slot palette** (infrastructure capability — see [SPEC §3.6](SPEC.md#36-attribution-dashboard-only--phase-0-v03-revised)). 12 slots are reserved as OkLCH-distinct colors (L=68%, C=0.09, H stride 30°) so the roster can grow without remapping. The currently named subset is 5 of those 12 reserved slots:
 
 | Keeper | Role | Color |
 |---|---|---|
@@ -34,7 +34,7 @@ Five named keeper personas show up throughout the UI with distinct colors:
 | **qa-king** | QA | Red `#c46a5a` |
 | **rama** (ramarama) | Researcher | Purple `#8a6aa0` |
 
-There are also supporting roles (scholar, janitor, issue_king, taskmaster, verifier, executor, velvet-hammer, ollama-local) and providers (Anthropic, Moonshot, OpenAI, xAI) that appear in the cascade chain and provider matrix.
+There are also supporting roles (scholar, janitor, issue_king, taskmaster, verifier, executor, velvet-hammer, ollama-local) and providers (Anthropic, Moonshot, OpenAI, xAI) that appear in the cascade chain and provider matrix. Unnamed keepers hash onto the remaining slots via `kSlot(id)` (FNV-1a mod 12).
 
 ### Goals seen in the system (Korean + English mixed)
 
@@ -183,7 +183,7 @@ touching component CSS.
 │ ▼                                                            │
 │ semantic    --color-bg-page   --color-accent-fg              │
 │             --color-fg-primary  --color-status-added         │
-│             --color-keeper-1..5  --color-focus-ring          │
+│             --color-keeper-1..12 --color-focus-ring          │
 │ ▼                                                            │
 │ component   .ix-tree { background: var(--color-bg-surface) } │
 │             .chip   { color: var(--color-accent-fg) }        │
@@ -211,7 +211,7 @@ semantic alias unless you genuinely need a literal palette pick.
 | `--color-status-added` | `--ok` | diff added / created |
 | `--color-status-modified` | `--warn` | diff modified / at-risk |
 | `--color-status-deleted` | `--err` | diff deleted / failed |
-| `--color-keeper-1..5` | `--k-{nick,masc,sangsu,qa,rama}` | fleet attribution |
+| `--color-keeper-1..12` | `--k-1..12` (12-slot OkLCH palette; named subset 1–5, see [SPEC §3.6](SPEC.md#36-attribution-dashboard-only--phase-0-v03-revised)) | fleet attribution |
 | `--color-focus-ring` | `--brass-1` | `:focus-visible` outline color |
 
 **Component tier** — the actual component CSS. References semantic


### PR DESCRIPTION
## Scope

`dashboard/design-system/README.md` only — phrasing reconciliation with SPEC.

README described keeper attribution as "Five named keeper personas", which contradicts the rest of the design system:
- `SPEC.md §3.6` defines a 12-slot OkLCH palette (`--k-1..12` / `--color-keeper-1..12`).
- `SPEC.md §3.6.1` notes old named tokens (`--k-nick`, `--k-masc`, ...) were removed in v0.4.
- `source_styles/tokens.css` already exposes the 12-slot palette.

Wave 1a 마지막 미완 항목 마무리. SPEC / SKILL / tokens.css 는 변경 불필요 (already canonical).

## Changes (4 lines, 3 edit blocks, README only)

| Line | Before | After |
|---|---|---|
| 27 | `Five named keeper personas show up throughout the UI with distinct colors:` | `Keeper attribution runs on a **12-slot palette** (infrastructure capability — see [SPEC §3.6](...)). 12 slots are reserved as OkLCH-distinct colors (L=68%, C=0.09, H stride 30°) so the roster can grow without remapping. The currently named subset is 5 of those 12 reserved slots:` |
| 37 | `... cascade chain and provider matrix.` | `... cascade chain and provider matrix. Unnamed keepers hash onto the remaining slots via \`kSlot(id)\` (FNV-1a mod 12).` |
| 186 | `--color-keeper-1..5  --color-focus-ring` | `--color-keeper-1..12 --color-focus-ring` |
| 214 | `\| \`--color-keeper-1..5\` \| \`--k-{nick,masc,sangsu,qa,rama}\` \| fleet attribution \|` | `\| \`--color-keeper-1..12\` \| \`--k-1..12\` (12-slot OkLCH palette; named subset 1–5, see [SPEC §3.6](...)) \| fleet attribution \|` |

5 keeper 표 (nick0cave / masc-improver / sangsu / qa-king / rama) 자체는 보존. 정보 가치 있고, 현재 named subset 의 ground truth.

## Phrasing tradeoffs

- "infrastructure capability" 어휘는 SPEC §3.6 의 톤과 매칭 (palette = capability, roster = currently named).
- `--k-{nick,masc,sangsu,qa,rama}` raw token mapping 은 v0.4 에서 제거되었으므로 README 도 `--k-1..12` 로 정정 (이게 단순 docs reconciliation 이상이라면 stop 해야 했지만, SPEC §3.6.1 이 이미 명시적으로 "Old named tokens were removed in v0.4. New code MUST use \`--k-N\`" 라 docs follow-through).

## Verification

```bash
rg -nP 'Five named keeper personas' dashboard/design-system/README.md
# → 0 hits

rg -nP '12.?slot' dashboard/design-system/README.md
# → 2 hits (line 27, line 214)

git diff --name-only main | grep -v 'dashboard/design-system/README.md' | wc -l
# → 0
```

## Out of scope

- SPEC.md, SKILL.md, tokens.css, codegen, Bonsai chip.ml — handled by other friends in own worktrees.

## Test plan

- [x] `rg 'Five named keeper personas'` → 0 hits
- [x] `rg '12.?slot'` → ≥1 hits
- [x] only README.md modified
- [ ] CI checks green (docs PR — minimal)

🤖 Friend-0-finish (parallel design-system hardening)