### PR TITLE
[Step 14b cont] Inline three remaining hyperparameter env knobs

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -67,13 +67,10 @@ let dedup_by_key (key_of : 'a -> string) (items : 'a list) : 'a list =
 
 let jaccard_similarity = Text_similarity.jaccard_similarity
 
-let semantic_dedup_similarity_threshold () =
-  match Sys.getenv_opt "MASC_KEEPER_MEMORY_DEDUP_SIMILARITY_THRESHOLD" with
-  | None -> 0.85
-  | Some raw ->
-      (match float_of_string_opt (String.trim raw) with
-       | Some f when f >= 0.0 && f <= 1.0 -> f
-       | _ -> 0.85)
+(* Step 14(b) of the bloodflow restoration plan inlined the env knob
+   [MASC_KEEPER_MEMORY_DEDUP_SIMILARITY_THRESHOLD]: hyperparameters
+   belong in code, not in [Sys.getenv_opt]. *)
+let semantic_dedup_similarity_threshold () = 0.85
 
 let dedup_memory_candidates
     (items : (string * string * int) list) : (string * string * int) list =

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -119,15 +119,11 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                 [last_turn_ts] and could fire while a turn was actively
                 running, killing the keeper mid-LLM-call.  Active turns
                 get a separate (larger) threshold so legitimately slow
-                turns aren't mistaken for hangs.  Default 600s; override
-                via [MASC_KEEPER_WATCHDOG_TURN_TIMEOUT_SEC]. *)
-             let active_turn_timeout_sec =
-               match Sys.getenv_opt "MASC_KEEPER_WATCHDOG_TURN_TIMEOUT_SEC" with
-               | Some v -> (match float_of_string_opt (String.trim v) with
-                            | Some f when f > 0.0 -> Float.max f threshold
-                            | _ -> Float.max 600.0 threshold)
-               | None -> Float.max 600.0 threshold
-             in
+                turns aren't mistaken for hangs.  Default 600s; the
+                env override [MASC_KEEPER_WATCHDOG_TURN_TIMEOUT_SEC]
+                was inlined in Step 14(b) -- hyperparameters belong
+                in code, not in [Sys.getenv_opt]. *)
+             let active_turn_timeout_sec = Float.max 600.0 threshold in
              let idle_stale, in_turn_stale, in_turn_age =
                match entry.current_turn_observation with
                | Some obs ->

--- a/lib/keeper/keeper_stay_silent_loop_detector.ml
+++ b/lib/keeper/keeper_stay_silent_loop_detector.ml
@@ -1,12 +1,9 @@
 let default_threshold = 10
 
-let threshold () =
-  match Sys.getenv_opt "MASC_STAY_SILENT_LOOP_THRESHOLD" with
-  | Some v when v <> "" ->
-      (match int_of_string_opt v with
-       | Some n when n >= 1 -> n
-       | _ -> default_threshold)
-  | _ -> default_threshold
+(* Step 14(b) of the bloodflow restoration plan inlined the env knob
+   [MASC_STAY_SILENT_LOOP_THRESHOLD]: hyperparameters belong in code,
+   not in [Sys.getenv_opt]. *)
+let threshold () = default_threshold
 
 (* Per-keeper state: current streak + latched flag so the
    detected-counter only bumps once per loop episode, not on every


### PR DESCRIPTION
## Summary

Step 14(b) continuation: inline three calibration knobs whose values belong in code, not in `Sys.getenv_opt`.

| Env var | File | Default |
|---|---|---|
| `MASC_KEEPER_WATCHDOG_TURN_TIMEOUT_SEC` | `keeper_stale_watchdog.ml` | 600s |
| `MASC_KEEPER_MEMORY_DEDUP_SIMILARITY_THRESHOLD` | `keeper_memory_bank.ml` | 0.85 |
| `MASC_STAY_SILENT_LOOP_THRESHOLD` | `keeper_stay_silent_loop_detector.ml` | 10 |

Defaults preserved. Operators tuning these had no way to discover sane ranges and silent overrides hid calibration decisions from review.

Together with #11175 (turn_drain_interval), this completes 4 of the 5 hyperparameter knobs called out in plan Step 14(b).

## Stack position

Branched from main. Independent of in-flight #11154/#11169/#11175.

## Test plan

- [x] `dune build --root . @check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)