### PR TITLE
[Step 4a] Keeper_turn_fsm types (additive)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -541,6 +541,7 @@
    keeper_behavioral_regime_observer
    keeper_unified_prompt
    keeper_unified_metrics
+   keeper_turn_fsm
    keeper_turn_livelock
    keeper_stay_silent_loop_detector
    keeper_error_classify

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -1,0 +1,86 @@
+type cancel_reason =
+  | Cancelled_supervisor_stop
+  | Cancelled_phase_gate_close
+  | Cancelled_provider_timeout
+  | Cancelled_fleet_shutdown
+
+type failure_reason =
+  | Failure_cascade_unavailable of {
+      base : string;
+      resolved : string option;
+    }
+  | Failure_provider_error of { kind : string; detail : string }
+  | Failure_tool_contract_violation of { reason_code : string }
+  | Failure_receipt_lost of {
+      primary_error : string;
+      fallback_path : string option;
+    }
+  | Failure_runtime_error of string
+  | Failure_unexpected_exception of {
+      exn : string;
+      backtrace : string option;
+    }
+
+type turn_state =
+  | Idle
+  | Phase_gating
+  | Cascade_routing
+  | Awaiting_provider
+  | Streaming
+  | Awaiting_tool_result
+  | Completing
+  | Done
+  | Failed of failure_reason
+  | Cancelled of cancel_reason
+
+let cancel_reason_label = function
+  | Cancelled_supervisor_stop -> "supervisor_stop"
+  | Cancelled_phase_gate_close -> "phase_gate_close"
+  | Cancelled_provider_timeout -> "provider_timeout"
+  | Cancelled_fleet_shutdown -> "fleet_shutdown"
+
+let failure_reason_label = function
+  | Failure_cascade_unavailable _ -> "cascade_unavailable"
+  | Failure_provider_error _ -> "provider_error"
+  | Failure_tool_contract_violation _ -> "tool_contract_violation"
+  | Failure_receipt_lost _ -> "receipt_lost"
+  | Failure_runtime_error _ -> "runtime_error"
+  | Failure_unexpected_exception _ -> "unexpected_exception"
+
+let turn_state_label = function
+  | Idle -> "idle"
+  | Phase_gating -> "phase_gating"
+  | Cascade_routing -> "cascade_routing"
+  | Awaiting_provider -> "awaiting_provider"
+  | Streaming -> "streaming"
+  | Awaiting_tool_result -> "awaiting_tool_result"
+  | Completing -> "completing"
+  | Done -> "done"
+  | Failed reason ->
+      "failed:" ^ failure_reason_label reason
+  | Cancelled reason ->
+      "cancelled:" ^ cancel_reason_label reason
+
+let pp_cancel_reason fmt r =
+  Format.pp_print_string fmt (cancel_reason_label r)
+
+let pp_failure_reason fmt = function
+  | Failure_cascade_unavailable { base; resolved } ->
+      Format.fprintf fmt "cascade_unavailable(base=%s,resolved=%s)"
+        base
+        (Option.value resolved ~default:"-")
+  | Failure_provider_error { kind; detail } ->
+      Format.fprintf fmt "provider_error(kind=%s,detail=%s)" kind detail
+  | Failure_tool_contract_violation { reason_code } ->
+      Format.fprintf fmt "tool_contract_violation(%s)" reason_code
+  | Failure_receipt_lost { primary_error; fallback_path } ->
+      Format.fprintf fmt "receipt_lost(err=%s,fallback=%s)"
+        primary_error
+        (Option.value fallback_path ~default:"-")
+  | Failure_runtime_error msg ->
+      Format.fprintf fmt "runtime_error(%s)" msg
+  | Failure_unexpected_exception { exn; _ } ->
+      Format.fprintf fmt "unexpected_exception(%s)" exn
+
+let pp_turn_state fmt s =
+  Format.pp_print_string fmt (turn_state_label s)

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -1,0 +1,60 @@
+(** Typed FSM vocabulary for keeper turn lifecycle.
+
+    Step 4a of the bloodflow restoration plan introduces the
+    state / failure / cancel-reason ADTs only.  The transition
+    function with telemetry emission is left to a follow-up
+    stack so the type surface lands additively first.
+
+    Cross-reference: [docs/keeper-turn-lifecycle.md] (Step 8 diagram). *)
+
+type cancel_reason =
+  | Cancelled_supervisor_stop
+      (** Operator/supervisor requested keeper shutdown. *)
+  | Cancelled_phase_gate_close
+      (** Phase transition closed an in-flight turn. *)
+  | Cancelled_provider_timeout
+      (** Underlying provider (CLI subprocess or HTTP) timed out
+          past the cooperative-cancel deadline. *)
+  | Cancelled_fleet_shutdown
+      (** Process is exiting; no more turns will be dispatched. *)
+
+type failure_reason =
+  | Failure_cascade_unavailable of {
+      base : string;
+      resolved : string option;
+    }
+  | Failure_provider_error of { kind : string; detail : string }
+  | Failure_tool_contract_violation of { reason_code : string }
+  | Failure_receipt_lost of {
+      primary_error : string;
+      fallback_path : string option;
+    }
+  | Failure_runtime_error of string
+  | Failure_unexpected_exception of {
+      exn : string;
+      backtrace : string option;
+    }
+
+(** Turn FSM states.  Mirrors the lanes in
+    [docs/keeper-turn-lifecycle.md]; the runtime [run_keeper_cycle]
+    is currently implicit across multiple files and Step 4b will
+    introduce explicit transitions. *)
+type turn_state =
+  | Idle
+  | Phase_gating
+  | Cascade_routing
+  | Awaiting_provider
+  | Streaming
+  | Awaiting_tool_result
+  | Completing
+  | Done
+  | Failed of failure_reason
+  | Cancelled of cancel_reason
+
+val cancel_reason_label : cancel_reason -> string
+val failure_reason_label : failure_reason -> string
+val turn_state_label : turn_state -> string
+
+val pp_cancel_reason : Format.formatter -> cancel_reason -> unit
+val pp_failure_reason : Format.formatter -> failure_reason -> unit
+val pp_turn_state : Format.formatter -> turn_state -> unit


### PR DESCRIPTION
## Summary

Step 4a of the bloodflow restoration plan: introduce typed FSM vocabulary for the keeper turn lifecycle. **Types only** — the transition function with telemetry emission is left to a follow-up PR (Step 4b) so the type surface lands additively first.

## What this PR adds

`lib/keeper/keeper_turn_fsm.{ml,mli}`:

- `cancel_reason` (4 variants): supervisor stop, phase gate close, provider timeout, fleet shutdown.
- `failure_reason` (6 record-bearing variants): cascade unavailable, provider error, tool contract violation, receipt lost (with fallback path), runtime error, unexpected exception (with backtrace).
- `turn_state` (10 variants): Idle, Phase_gating, Cascade_routing, Awaiting_provider, Streaming, Awaiting_tool_result, Completing, Done, Failed of failure_reason, Cancelled of cancel_reason.
- Label helpers (`*_label : ... -> string`) and Format pretty-printers (`pp_*`).

`lib/dune` — registers the new module between `keeper_unified_metrics` and `keeper_turn_livelock`.

## Why types-first

The keeper turn FSM today is implicit across four files (`keeper_unified_turn`, `keeper_agent_run`, `keeper_execution_receipt`, `keeper_tool_disclosure`). Step 4 of the plan introduces a single SSOT for state, but the transition function changes behavior at every call site. Splitting types-first keeps:

1. The new vocabulary mergeable on its own (no downstream churn).
2. Future stacks (Step 4b receipt wiring, Step 5 Cancelled cleanup, Step 7 TLA+ spec) able to depend on stable variant names.
3. Anyone writing diagnostic tooling (`bin/masc_trace`, dashboards) able to start emitting these labels before the runtime adopts them.

## Label compaction

`turn_state_label (Failed r)` returns `"failed:" ^ failure_reason_label r` (and analogously for `Cancelled`) so a single Prometheus label dimension covers the full state space. Grep over receipt JSONL stays trivial:

```
grep '"state":"failed:cascade_unavailable"'
```

## What this PR does NOT do

- No transition function (Step 4b).
- No callers updated — `run_keeper_cycle` still uses implicit state.
- No Prometheus emission yet (that lands with the transition wiring).
- Does not delete or rename any existing string-state labels — the migration sequence is in Step 4b.

## Cross-reference

- `docs/keeper-turn-lifecycle.md` (Mermaid sequence + state table, merged in earlier stack).
- `planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md` Step 4.

## Test plan

- [x] `dune build` clean (background id brxt071eb, exit 0)
- [x] `.mli` and `.ml` constructor names match
- [x] No existing module references — additive only

🤖 Generated with [Claude Code](https://claude.com/claude-code)