### PR TITLE
fix(coord): narrow last_nonempty_line catch-all to preserve Cancelled (#10395)

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -171,7 +171,9 @@ let last_nonempty_line path =
            | exception End_of_file -> last
          in
          loop None)
-  with _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Sys_error _ -> None
 
 let latest_json_in_receipt_dir base_dir =
   jsonl_files_under base_dir


### PR DESCRIPTION
Refs #10395 (Pattern 2 site, surgical scope).

## 증상

`lib/coord/coord_task_schedule.ml:160-174` 의 `last_nonempty_line` 가 `Fun.protect` 안에서 file 읽고, 외부에 bare `try ... with _ -> None` 로 감싸져 있음. 이 catch-all 이 `Eio.Cancel.Cancelled`, `Fun.Finally_raised`, `Sys_error` 모두를 동일하게 swallow.

`Eio.Cancel.Cancelled` 가 swallow 되면 fiber cancellation 신호가 propagation 되지 않아 상위 switch 가 fiber 잔존 / resource leak 으로 이어짐. CLAUDE.md 의 "Eio Cancelled re-raise" 가이드라인 (memory `feedback_eio-mutex-vs-stdlib`) 위반.

## Root cause

```ocaml
let last_nonempty_line path =
  try
    let input = open_in path in
    Fun.protect
      ~finally:(fun () -> close_in_noerr input)
      (fun () -> ...)
  with _ -> None     ← Cancelled, Finally_raised, Sys_error 모두 swallow
```

이슈 #10395 본문이 Pattern 2 의 정확한 사이트로 인용한 코드.

## Fix

bare `with _` 를 두 분기로 좁힘:

```ocaml
with
| Eio.Cancel.Cancelled _ as e -> raise e
| Sys_error _ -> None
```

- `Eio.Cancel.Cancelled` → re-raise. fiber cancellation propagation 보존.
- `Sys_error` → None. 함수 의도된 swallow (file disappeared, permission, ENOENT). 호출자 (`latest_json_in_receipt_dir`) 가 `find_map` 으로 다음 file 시도하는 graceful path.
- 그 외 (`Fun.Finally_raised`, `Yojson.Json_error`, ...) → propagate. silent drop 대신 surface.

`close_in_noerr` 는 문서상 raise 안 함 (suffix `_noerr`) → `Fun.Finally_raised` 도달 가능성 0 에 가까움. 만약 발생하면 silently None 보다 surface 가 안전.

## Smoke

```
$ DUNE_BUILD_DIR=$(pwd)/_build dune build --root $(pwd) lib/coord
(no output — clean rebuild)
```

`@check` 전체에서는 main HEAD (`51e51f7331`) 의 `lib/server/server_runtime_bootstrap.ml:36` Prometheus label type mismatch 가 등장하지만 본 PR diff 와 무관 — PR 의 1 file (+3 −1) 변경은 `lib/coord/` 안에서만 build 영향.

## Out of scope

이슈 #10395 의 나머지 126 `Fun.protect` 사이트는 **audit-bucket-cascade-pattern** (메모리) 에 따라 per-site Tolerant / NeedsPBT / DeadCode 분류가 선행되어야 함. 이번 PR 은 본문이 직접 인용한 Pattern 2 1 사이트만.

후속 작업 후보:
- `lib/transport_read_model.ml` / `lib/fs_compat/fs_compat.ml` / `lib/backend/backend.ml` — 이미 Cancelled re-raise pattern 명시 (3/127 의 reference)
- 나머지 124 사이트 — finally 안에서 Eio I/O 호출하는 케이스 식별 후 sweep PR

## Test plan

- [x] `lib/coord/` 빌드 clean
- [x] diff 1 file (+3 −1)
- [ ] CI required check 모두 green