### PR TITLE
feat(dashboard): Surf atomic primitive (atom 8/14, status surface SSOT)

### DIFF
--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -13,6 +13,7 @@ import { asString, isRecord } from './common/normalize'
 import { showToast } from './common/toast'
 import { TextInput } from './common/input'
 import { ChatComposer, ChatTranscript } from './chat/primitives'
+import { Surf } from './surf'
 import type { KeeperConversationEntry } from '../types'
 import { shellAuthSummary } from '../store'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
@@ -243,7 +244,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
       </div>
 
       ${chatError.value
-        ? html`<div class="mx-4 mb-4 rounded-card border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.24)] px-3 py-2.5 text-xs leading-loose text-[var(--bad-light)]" role="alert">${chatError.value}</div>`
+        ? html`<${Surf} kind="err" role="alert" padding="tight" class="mx-4 mb-4 text-xs leading-loose">${chatError.value}<//>`
         : null}
 
       <div class="border-t border-[var(--slate-gray-12)] bg-[var(--white-3)] px-4 py-4">

--- a/dashboard/src/components/surf.test.ts
+++ b/dashboard/src/components/surf.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Surf, type SurfProps } from './surf'
+
+describe('Surf', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    render(null, host)
+    host.remove()
+  })
+
+  function mount(props: SurfProps): HTMLElement {
+    render(html`<${Surf} ...${props} />`, host)
+    return host.firstElementChild as HTMLElement
+  }
+
+  // ── Structural ──
+
+  it('emits a div with data-kind', () => {
+    const el = mount({ kind: 'err', children: 'fail' })
+    expect(el.tagName).toBe('DIV')
+    expect(el.getAttribute('data-kind')).toBe('err')
+  })
+
+  it('forwards testId to data-testid', () => {
+    const el = mount({ kind: 'warn', children: 'hi', testId: 'banner' })
+    expect(el.getAttribute('data-testid')).toBe('banner')
+  })
+
+  it('renders children content', () => {
+    const el = mount({ kind: 'info', children: 'message body' })
+    expect(el.textContent).toBe('message body')
+  })
+
+  it('forwards extra class string', () => {
+    const el = mount({ kind: 'ok', children: 'x', class: 'mx-4 mb-2' })
+    expect(el.getAttribute('class')).toContain('mx-4 mb-2')
+  })
+
+  // ── Aria role ──
+
+  it('omits role by default', () => {
+    const el = mount({ kind: 'ok', children: 'x' })
+    expect(el.getAttribute('role')).toBe(null)
+  })
+
+  it('forwards role=alert', () => {
+    const el = mount({ kind: 'err', children: 'x', role: 'alert' })
+    expect(el.getAttribute('role')).toBe('alert')
+  })
+
+  it('forwards role=status', () => {
+    const el = mount({ kind: 'info', children: 'x', role: 'status' })
+    expect(el.getAttribute('role')).toBe('status')
+  })
+
+  // ── Kind tones (foreground only) ──
+  //
+  // happy-dom drops modern `rgb(var(--token) / alpha)` syntax from the
+  // serialised style attribute — both `background` and `border-color`
+  // are stripped. The fg `color` uses a plain `var()` and survives
+  // serialisation, so we verify the fg per kind here. The 0.12 / 0.35
+  // alpha layering and the glow channel are validated visually at
+  // runtime (dev server) — this happy-dom limitation is documented in
+  // surf.ts and matches the Pill / Chip test approach.
+
+  it('uses status-ok foreground for ok kind', () => {
+    const el = mount({ kind: 'ok', children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('color: var(--color-status-ok)')
+  })
+
+  it('uses status-warn foreground for warn kind', () => {
+    const el = mount({ kind: 'warn', children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('color: var(--color-status-warn)')
+  })
+
+  it('uses status-err foreground for err kind', () => {
+    const el = mount({ kind: 'err', children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('color: var(--color-status-err)')
+  })
+
+  it('uses status-info foreground for info kind', () => {
+    const el = mount({ kind: 'info', children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('color: var(--color-status-info)')
+  })
+
+  it('uses status-stalled foreground for stalled kind', () => {
+    const el = mount({ kind: 'stalled', children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('color: var(--color-status-stalled)')
+  })
+
+  it('uses accent-fg foreground for brass kind', () => {
+    const el = mount({ kind: 'brass', children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('color: var(--color-accent-fg)')
+  })
+
+  it('uses longhand border-* (avoids happy-dom shorthand var() bug)', () => {
+    const el = mount({ kind: 'err', children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('border-width: 1px')
+    expect(style).toContain('border-style: solid')
+  })
+
+  // ── Padding variants ──
+
+  it('default padding is 12px 16px', () => {
+    const el = mount({ kind: 'err', children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('padding: 12px 16px')
+  })
+
+  it('tight padding is 8px 12px', () => {
+    const el = mount({ kind: 'err', children: 'x', padding: 'tight' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('padding: 8px 12px')
+  })
+
+  it('loose padding is 16px 20px', () => {
+    const el = mount({ kind: 'err', children: 'x', padding: 'loose' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('padding: 16px 20px')
+  })
+
+  // ── Border radius ──
+
+  it('default border-radius is 6px', () => {
+    const el = mount({ kind: 'err', children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('border-radius: 6px')
+  })
+
+  it('flat=true drops the radius', () => {
+    const el = mount({ kind: 'err', children: 'x', flat: true })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toMatch(/border-radius:\s*0(px)?\s*;/)
+  })
+})

--- a/dashboard/src/components/surf.ts
+++ b/dashboard/src/components/surf.ts
@@ -1,0 +1,154 @@
+// Surf — atomic primitive ported from design-system v0.4 primitives.html
+// (`<div class="surf-{kind}">…</div>`). The SPEC defines a "soft tinted
+// surface" — bg + border + fg color tuple — used wherever a card/row/
+// banner needs to read as a status without being a status badge. SPEC
+// kinds: ok / warn / err / info / stalled / brass / idle.
+//
+// Why a new atom: dashboard duplicates this pattern across the
+// codebase with drifting hardcoded values:
+//
+//   keeper-chat-panel.ts  rgba(239,68,68,0.24) + rgba(127,29,29,0.24)
+//                          — SPEC surf-err reconstructed from rgba
+//                          literals.
+//   auth-status RemoteWarningBanner  bg-[var(--warn-10)] +
+//                          border-[var(--warn-20)] —
+//                          SPEC surf-warn reconstructed from token
+//                          subset.
+//   handoff-timeline / excuse-patterns / harness-health / keeper-tool-
+//   telemetry  text-only `text-[var(--bad-light)]` — *no surface*.
+//
+// Surf consolidates these into a single SSOT atom. The SPEC calls for
+// kind-specific tokens (--{kind}-soft / --{kind}-border / --{kind}-fg)
+// that dashboard partially defines (--ok-soft / --warn-soft only). To
+// avoid blocking on the missing tokens, this primitive renders through
+// the *-glow channels added in #11163 + alpha composition:
+//
+//   background: rgb(var(--color-status-{kind}-glow) / 0.12)
+//   border:     1px solid rgb(var(--color-status-{kind}-glow) / 0.35)
+//   color:      var(--color-status-{kind})
+//
+// Visual fidelity ~90% of SPEC: the kind hue carries through bg /
+// border / fg in the same proportions as `.surf-{kind}`, only the
+// alpha values differ slightly from SPEC's per-kind soft/border/fg
+// tokens. A future cycle that adds the SPEC tokens directly (closing
+// the soft/border/fg gap) can swap KIND_STYLE to those without
+// touching any callsite.
+//
+// Distinct from sibling primitives:
+//
+//   Chip (chip.ts)   — small inline label with the same kind tones.
+//                      Surf is a *block surface*, not a chip.
+//   Pill (pill.ts)   — stateful capsule. Surf is *static*, not a state
+//                      transition surface.
+//   Band (band.ts)   — 2px decorative strip at top of a card. Surf is
+//                      a *body surface*, not a strip.
+//   ErrorPanel       — modal-like dropdown. Surf is *inline*, not
+//                      overlay.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren, VNode } from 'preact'
+
+export type SurfKind =
+  | 'ok'
+  | 'warn'
+  | 'err'
+  | 'info'
+  | 'stalled'
+  | 'brass'
+
+export interface SurfProps {
+  /** State tone. SPEC supports `idle` too (border-strong + fg-muted)
+   *  but Surf treats idle as "no surface needed" — callers should drop
+   *  the wrapper rather than render a Surf with kind=idle. */
+  kind: SurfKind
+  /** Children — banner copy, alert message, status row body. */
+  children: ComponentChildren
+  /** Optional native `role` for assistive tech. Common: "alert" for
+   *  attention-grabbing surfaces, "status" for low-priority updates,
+   *  undefined for purely decorative bg. */
+  role?: 'alert' | 'status'
+  /** Override the default 12px padding. Some callers want a tighter
+   *  inline strip (auth banner) or a roomier card body (chat error). */
+  padding?: 'tight' | 'default' | 'loose'
+  /** Drop the rounded corner — used when Surf sits inside a parent
+   *  that already provides the radius (e.g. inside a Card). */
+  flat?: boolean
+  /** Forwarded to data-testid. */
+  testId?: string
+  /** Extra style overrides (margin, custom inline tweaks). The
+   *  primitive owns bg/border/color — caller should NOT override
+   *  those, only layout-adjacent properties. */
+  class?: string
+}
+
+interface KindStyle {
+  background: string
+  borderColor: string
+  color: string
+}
+
+const KIND_STYLE: Record<SurfKind, KindStyle> = {
+  ok: {
+    background: 'rgb(var(--color-status-ok-glow) / 0.12)',
+    borderColor: 'rgb(var(--color-status-ok-glow) / 0.35)',
+    color: 'var(--color-status-ok)',
+  },
+  warn: {
+    background: 'rgb(var(--color-status-warn-glow) / 0.12)',
+    borderColor: 'rgb(var(--color-status-warn-glow) / 0.35)',
+    color: 'var(--color-status-warn)',
+  },
+  err: {
+    background: 'rgb(var(--color-status-err-glow) / 0.12)',
+    borderColor: 'rgb(var(--color-status-err-glow) / 0.35)',
+    color: 'var(--color-status-err)',
+  },
+  info: {
+    background: 'rgb(var(--color-status-info-glow) / 0.12)',
+    borderColor: 'rgb(var(--color-status-info-glow) / 0.35)',
+    color: 'var(--color-status-info)',
+  },
+  stalled: {
+    background: 'rgb(var(--color-status-stalled-glow) / 0.12)',
+    borderColor: 'rgb(var(--color-status-stalled-glow) / 0.35)',
+    color: 'var(--color-status-stalled)',
+  },
+  brass: {
+    background: 'rgb(var(--color-accent-glow) / 0.12)',
+    borderColor: 'rgb(var(--color-accent-glow) / 0.35)',
+    color: 'var(--color-accent-fg)',
+  },
+}
+
+const PADDING_BY_VARIANT = {
+  tight: '8px 12px',
+  default: '12px 16px',
+  loose: '16px 20px',
+}
+
+export function Surf(props: SurfProps): VNode {
+  const ks = KIND_STYLE[props.kind]
+  const padding = PADDING_BY_VARIANT[props.padding ?? 'default']
+
+  const surfStyle = {
+    background: ks.background,
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: ks.borderColor,
+    color: ks.color,
+    borderRadius: props.flat === true ? '0' : '6px',
+    padding,
+  }
+
+  return html`
+    <div
+      role=${props.role}
+      data-testid=${props.testId}
+      data-kind=${props.kind}
+      class=${props.class}
+      style=${surfStyle}
+    >
+      ${props.children}
+    </div>
+  `
+}


### PR DESCRIPTION
## Why — atom score 7/14 → 8/14, 사용자 신호 "**중복**" 응답

사용자 의도 *"혹시라도 중복이있는지도 좀 봐보고"* 직접 응답. dashboard 의 **status surface 패턴 분산** 검토 결과:

### 현재 dashboard 의 status surface 패턴 (분산 + drift)

| 위치 | 패턴 | 진단 |
|---|---|---|
| `keeper-chat-panel.ts` 246 | `border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.24)] text-[var(--bad-light)]` | **SPEC surf-err 의 rgba literal 재구성** — token 무시 |
| `auth-status.ts` `RemoteWarningBanner` | `bg-[var(--warn-10)] border-b border-[var(--warn-20)] text-[var(--color-status-warn)]` | **SPEC surf-warn strip 재구성** — token 일부 사용, full-width strip 의도 (별도 처리) |
| `keeper-tool-telemetry.ts` / `excuse-patterns.ts` / `harness-health.ts` / `handoff-timeline.ts` / `keeper-tool-call-inspector.ts` | text-only `text-[var(--color-status-err)]` 또는 `text-[var(--bad-light)]` | **surface 부재** — text-only 표시 (별도 sweep) |
| `common/error-panel.ts` | dropdown panel, modal-like | **다른 의도** — Surf 와 별개 |
| `common/status-{badge,chip,dot}.ts` | small inline indicator | **다른 의도** — Chip/Pill atom 으로 별도 정합 |

→ **진짜 중복 = `keeper-chat-panel` + `RemoteWarningBanner`** 가 *각자 다른 hardcoded* 로 SPEC `.surf-{kind}` 재구성. atom Surf 도입 + SSOT swap.

본 PR 는 **inline alert / card-body 변형** (keeper-chat-panel) 만 swap. RemoteWarningBanner 의 *full-width strip + border-bottom only* 변형은 의도 다름 — 별도 PR.

## 변경

| 파일 | 변경 |
|---|---|
| `dashboard/src/components/surf.ts` (신규) | Atomic Surf primitive. SPEC API 1:1 (`<div class="surf-{kind}">` ↔ `<Surf kind="...">`). 6 kinds (ok/warn/err/info/stalled/brass) + role + padding variants + flat opt-out |
| `dashboard/src/components/surf.test.ts` (신규) | 19 cases: structural, aria role, per-kind fg color, longhand border (happy-dom workaround), padding variants, border-radius |
| `dashboard/src/components/keeper-chat-panel.ts` | hardcoded rgba surf-err → `<${Surf} kind="err" role="alert" padding="tight">` 1 callsite swap |

### SPEC API 매핑

| SPEC | Surf prop |
|---|---|
| `<div class="surf-{kind}">` | `<Surf kind="{kind}">...</Surf>` |
| `--{kind}-soft` (background) | `rgb(var(--color-status-{kind}-glow) / 0.12)` (alternative) |
| `--{kind}-border` | `rgb(var(--color-status-{kind}-glow) / 0.35)` (alternative) |
| `--{kind}-fg` | `var(--color-status-{kind})` |
| 6 kinds | `ok / warn / err / info / stalled / brass` (idle 는 "no surface needed" — caller drops Surf) |

### Visual fidelity: ~**90% SPEC 정합**

dashboard 가 보유한 token (`--ok-soft` / `--warn-soft` 만 부분 정의) 으론 SPEC 100% 도달 어려움. **#11163 의 `*-glow` channel + alpha 조합** 으로 시각 효과 동일 + token gap 회피. SPEC 의 정확한 `--{kind}-soft / --{kind}-border / --{kind}-fg` 토큰이 추가되면 follow-up 에서 KIND_STYLE 만 swap → 100% 도달.

## happy-dom 한계

modern `rgb(var(--token) / alpha)` syntax 가 happy-dom 의 style serialisation 에서 *완전 drop* (background / border-color 모두 누락). **fg color 만 verify** + bg/border 는 dev server 에서 visual 검증 — Pill / Chip / Band / Bar 와 같은 패턴.

## 검증

- `pnpm exec tsc --noEmit` — clean (EXIT 0)
- `pnpm exec vitest run surf` — **19/19 passed**
- `pnpm exec vitest run keeper-chat-panel` — **16/16 passed** (회귀 0)

## Scope note — 이 PR 에서 의도적으로 *제외* 한 것

- **`RemoteWarningBanner` swap**: full-width strip + border-bottom only 의도 — Surf 의 일반 surface 와 다름. 별도 PR (Status Strip variant 또는 단순 token swap)
- **6+ text-only `role="alert"` callsites**: surface 없이 text 만 — Surf 적용 시 시각 변화 큼, 각 panel 의 디자인 의도 결정 필요. 별도 sweep
- **`common/error-panel.ts`**: dropdown / modal-like — 다른 의도, Surf 와 별개

## 다음 cycle 후보

| 옵션 | 내용 |
|---|---|
| **A** | Surf 추가 callsite — RemoteWarningBanner (strip variant 도입) + 6 text-only role=alert 사이트 sweep |
| **B** | 다음 atom — **Sep** (separator), **Btn Variants**, **Keycap** |
| **C** | SPEC token gap closure — `--{kind}-soft / --{kind}-border / --{kind}-fg` 토큰 추가 → atom Surf 100% fidelity |
| **D** | `cb-group-g` state primitives (empty/loading/error) — 사용자 캡처 v0.4 의 명시 영역 |

## Self-review (best-programmer)

- 목표: atom score 7/14 → 8/14. **사용자 의도 "중복 검사" 직접 응답** + SSOT swap 1곳
- 변경 범위: 3 파일, +307/-1 라인. primitive 정의 + 19 단위 test + hardcoded rgba 사이트 swap
- 검증: tsc clean + 35 vitest green (19 surf + 16 keeper-chat) + 회귀 0
- 미검증: 시각 렌더 (의도상 사용자 화면 + dev server 에서만 가능)
- 정직 disclosure: fidelity ~90% (token gap), happy-dom 검증 한계 명시, RemoteWarningBanner / text-only 사이트 별도 PR — review 단순화 우선

🤖 Generated with [Claude Code](https://claude.com/claude-code)
