### PR TITLE
fix(server): unbreak main — Prometheus labels arity + audit meta type drift

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -33,7 +33,6 @@ let () =
        so the keeper would fail-closed on every URL command. Labels: \
        keeper. A non-zero rate at boot indicates an operator should \
        seed the policy file before the keeper attempts network egress."
-    ~labels:["keeper"]
     ()
 
 let () =
@@ -46,7 +45,6 @@ let () =
        path, so the orphan file is silently inert and the keeper \
        fail-closes. Labels: keeper. Operator should cp the orphan into \
        the docker-path location and remove the host-direct file."
-    ~labels:["keeper"]
     ()
 
 let () =
@@ -61,7 +59,6 @@ let () =
        tool registry'. Labels: provider. Non-zero at boot means an \
        operator should either remove the provider from the cascade \
        or add an auto-construct entry."
-    ~labels:["provider"]
     ()
 
 let () =
@@ -74,7 +71,6 @@ let () =
        MASC_SYNC_CODEX_MCP_CONFIG=false). Operator must opt in or \
        the keeper will fail tool calls on this lane. Labels: \
        provider, env_flag."
-    ~labels:["provider"; "env_flag"]
     ()
 
 let requested_backend_mode () =
@@ -624,7 +620,7 @@ let audit_keeper_egress_policies (state : Mcp_server.server_state) =
         Sys.readdir keepers_dir
         |> Array.to_list
         |> List.filter_map (fun name ->
-            match Keeper_meta_store.read_meta config name with
+            match Keeper_types.read_meta config name with
             | Ok (Some meta) -> Some meta
             | Ok None -> None
             | Error err ->


### PR DESCRIPTION
## Summary

main HEAD (`origin/main 51e51f7`) **does not compile**. Two blockers landed in PR-Eg2b/Mp3b and were not caught because Build CI wasn't required on those PRs.

```
File "lib/server/server_runtime_bootstrap.ml", line 36:
Error: This constant has type string but an expression was expected of type
         Prometheus.label = string * string
```

After fixing line 36, a second drift surfaces at line 641:

```
Error: The value metas has type Keeper_meta_contract.keeper_meta list
       but an expression was expected of type Keeper_types.keeper_meta list
```

## Root causes

1. **Labels arity (4 sites).** `Prometheus.register_counter` takes `?labels:(string * string) list` (impl: dedupe key = name + label-pair concat). PR #11158/#11160 passed bare strings (`["keeper"]`) treating `~labels` as Prometheus-schema dimension declaration — wrong API. Drop the 4 `~labels` arguments; actual labels are attached at `inc_counter` call sites later in the same file.

2. **Meta type drift.** `keeper_types.mli` redeclares `type keeper_meta = { ... }` independently of `Keeper_meta_contract.keeper_meta` (no `include module type of Keeper_meta_contract`). So `Keeper_meta_store.read_meta` (returns contract type) is nominally distinct from `Keeper_types.keeper_meta`. Switch the boot caller to `Keeper_types.read_meta` (re-exported via the include chain in `keeper_types.ml:41`) — same function, .mli surface routes through the redeclared type, matching `Keeper_egress_audit.audit_all`'s expected type.

## Test plan

- [x] `dune build --root . @check` exit 0
- [ ] CI Build green
- [ ] CI Lint green

## Follow-up

`keeper_types.mli` redeclaring records instead of `include module type of Keeper_meta_contract` is the structural drift that allowed this. Out of scope for this fix-forward — leave for a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)