### PR TITLE
docs(keeper_llm_bridge): correct falsified "uncancellable region" diagnosis

### DIFF
--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -32,11 +32,28 @@ let run_with_timeout_and_fallback ~timeout_s fn =
   with
   | Eio.Time.Timeout ->
     let wall = elapsed () in
-    (* #9639/#9662: Eio cancel is cooperative. When the fiber blocks inside
-       an uncancellable region (native HTTP bulk read, syscall, non-yielding
-       loop), [with_timeout_exn] fires but the fiber continues until the
-       next yield. Surface that overshoot as a structured warn so the
-       condition is observable instead of silently inflating wall time. *)
+    (* #9639/#9662: Eio cancel is cooperative — [with_timeout_exn] fires
+       but the fiber must reach a cancel point (single_read, yield, etc.)
+       to actually interrupt. Surface overshoot as a structured warn so
+       stalls remain observable instead of silently inflating wall time.
+
+       2026-04-27 correction: the original "uncancellable region (native
+       HTTP bulk read, syscall, non-yielding loop)" diagnosis was a
+       guess and has been *falsified* by four raw-TCP reproducers ported
+       to the OAS regression guard (jeong-sik/oas#1210,
+       test/test_eio_cancellability.ml).  Buf_read.line + slow drip and
+       read_sse + fast stream with trivial / sleeping / CPU-bound on_data
+       callbacks all exit Eio.Time.with_timeout_exn within 1-2ms.  The
+       layer producing prod hangs (>=1170s) is *not* yet identified;
+       remaining suspects are caller on_event handlers, post_sync
+       take_all + connection-not-closed, Switch cleanup, or TLS.
+
+       Action: do NOT add yield points to OAS read_sse / Buf_read based
+       on the original guess — that wrong-layer fix was almost shipped.
+       During the next overshoot, run
+       ~/me/scripts/oas-hung-keeper-dump.sh to capture the fiber stack
+       and identify the real layer.  Cross-ref:
+       jeong-sik/me planning/claude-plans/oas-execution-cancellability.md *)
     let deadline =
       Timeout_policy.Deadline.make
         ~layer:Timeout_policy.Layer.Oas_bridge


### PR DESCRIPTION
## Summary

`lib/keeper/keeper_llm_bridge.ml:35-39` 의 5줄 자백 주석을 측정 결과 반영해 정정. 코드 변경 0, 주석만 +22/-5.

## Why

원본 주석은 `Eio.Time.with_timeout_exn` fire 후 fiber가 *"uncancellable region (native HTTP bulk read, syscall, non-yielding loop)"* 에서 block되어 다음 yield까지 진행한다고 자백.

2026-04-27 forensic이 4개 raw-TCP reproducer로 *모든 부분을 falsify*:

| 시나리오 | overshoot |
|---------|-----------|
| raw TCP + `Buf_read.line` + slow drip server (1byte/sec, no newline) | 1ms |
| read_sse + fast stream (100ms gap) + trivial on_data | 2ms |
| read_sse + fast stream + on_data sleeps 50ms (`Eio_unix.sleep`) | 2ms |
| read_sse + fast stream + on_data CPU-bound 50ms (no Eio yield) | 2ms |

reproducer는 jeong-sik/oas#1210로 OAS 회귀 가드(`test/test_eio_cancellability.ml`)에 포함돼 머지됨.

원본 자백을 신뢰해 OAS read_sse / Buf_read에 yield point 삽입 PR을 깔 뻔했으나 측정이 그 판단을 차단. 이 PR은:

1. 측정 결과를 *주석에 영구 박아둠* — 미래 사람(또는 미래 자신)이 같은 함정에 빠지지 않게.
2. *"진짜 hung 위치는 미확정"*이라는 사실을 명시. 남은 suspects (caller on_event / post_sync take_all + connection-not-closed / Switch cleanup / TLS) 4개 나열.
3. *"prior evidence 없이 원본 guess 따라 fix하지 말 것"* 명시 가드.
4. 다음 hang 발생 시 stack dump 명령(`~/me/scripts/oas-hung-keeper-dump.sh`) 안내.

## Changes

```
lib/keeper/keeper_llm_bridge.ml | 27 +++++++++++++++++++--------
1 file changed, 22 insertions(+), 5 deletions(-)
```

순수 주석 변경. 빌드 영향 0.

## Cross-ref

- jeong-sik/oas#1210 (회귀 가드, merged) — 4 시나리오 측정을 alcotest case로 정착
- jeong-sik/oas#1209 (body_timeout_s mitigation, merged) — cascade rotation 친화적 fail-fast
- jeong-sik/me#1071 (oas-hung-keeper-dump.sh, merged) — prod hung 시 stack 캡처
- jeong-sik/me planning/claude-plans/oas-execution-cancellability.md — 전체 forensic plan

## Test plan

- [x] `dune build --root . @check` exit 0
- [x] git diff: comment-only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)