### PR TITLE
[Step 0b CI] check_silent_failure.sh lint script

### DIFF
--- a/scripts/check_silent_failure.sh
+++ b/scripts/check_silent_failure.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Lint for [try ... with _ -> ()] / [Result.iter_error ~f:ignore]
+# anti-patterns.
+#
+# Step 0b of the bloodflow restoration plan introduced
+# [Telemetry_observe.observe_or_fail] / [observe_or_default] as the
+# typed alternative. This script reports remaining call sites so the
+# baseline can be ratcheted down over time.
+#
+# Patterns flagged:
+#   - try ... with _ -> ()            — silent unit-return swallow
+#   - try ... with _exn -> ()         — silent unit-return swallow (named)
+#   - Result.iter_error ~f:ignore     — Result.Error swallowed
+#   - Result.iter_error (fun _ -> ()) — Result.Error swallowed (lambda)
+#
+# Patterns NOT flagged (intentional):
+#   - with _ -> None / [] / false / 0 — option/list/bool/int defaults
+#     are a conversion idiom, not a unit-side-effect swallow.
+#   - lines tagged [@observe-allowed: <reason>] — opt-out marker.
+#   - lib/telemetry_observe.{ml,mli}    — the wrapper itself.
+#   - lib/**/test/, test/, **/_test_*.ml — test code.
+#
+# Usage:
+#   scripts/check_silent_failure.sh           — warn-only, exit 0
+#   scripts/check_silent_failure.sh --strict  — fail on findings, exit 1
+#
+# Cross-reference:
+#   - lib/telemetry_observe.{ml,mli}
+#   - planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md (Step 0b)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+STRICT=0
+if [ "${1:-}" = "--strict" ]; then
+  STRICT=1
+fi
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "rg (ripgrep) not found — install via 'brew install ripgrep'." >&2
+  exit 2
+fi
+
+# Search scopes: lib/ and bin/ only. test/ paths are excluded by glob below.
+SEARCH_PATHS=(lib bin)
+
+# Patterns to flag. Each is an extended regex anchored on the silent
+# tail (-> () or ~f:ignore / (fun _ -> ())). Captured separately so the
+# report tags each finding with which anti-pattern it tripped.
+declare -a FINDINGS=()
+
+scan_pattern() {
+  local label="$1"
+  local pattern="$2"
+
+  # rg --vimgrep gives file:line:col:line_text — easy to filter and report.
+  # -g excludes glob patterns the lint should ignore.
+  while IFS= read -r line; do
+    [ -n "$line" ] && FINDINGS+=("[${label}] ${line}")
+  done < <(
+    rg --vimgrep -e "$pattern" \
+       -g '!lib/telemetry_observe.{ml,mli}' \
+       -g '!**/test/**' \
+       -g '!**/_test_*.ml' \
+       -g '!**/test_*.ml' \
+       "${SEARCH_PATHS[@]}" 2>/dev/null \
+    | rg -v '@observe-allowed' || true
+  )
+}
+
+# Named exception handlers (e.g., [with End_of_file -> ()]) are
+# intentionally NOT flagged: catching a specific exception is structured
+# error handling, not a blanket swallow. Only anonymous-shaped patterns
+# (_, _exn, _e, _x — identifiers that start with underscore) qualify.
+scan_pattern "try-unit-swallow"     'try .* with _[a-z_]* -> \(\)'
+scan_pattern "iter_error-ignore"    'Result\.iter_error[[:space:]]+~f:ignore'
+scan_pattern "iter_error-lambda"    'Result\.iter_error[[:space:]]+\(fun _ -> \(\)\)'
+
+# Dedupe: rg may report the same line under more than one regex when
+# patterns overlap; collapse to a unique set keyed on file:line:col.
+if [ "${#FINDINGS[@]}" -gt 0 ]; then
+  IFS=$'\n' read -r -d '' -a FINDINGS < <(printf '%s\n' "${FINDINGS[@]}" | awk '!seen[$0]++' && printf '\0')
+fi
+
+COUNT="${#FINDINGS[@]}"
+
+echo "check_silent_failure: ${COUNT} silent-failure anti-pattern site(s) found."
+
+if [ "$COUNT" -gt 0 ]; then
+  echo
+  echo "Findings:"
+  for f in "${FINDINGS[@]}"; do
+    echo "  $f"
+  done
+  echo
+  echo "Remediation:"
+  echo "  - Replace [try ... with _ -> ()] with"
+  echo "      Telemetry_observe.observe_or_fail ~kind:\"<descriptive>\" (fun () -> ...)"
+  echo "    or [Telemetry_observe.observe_or_default ~kind ~default ...]"
+  echo "    when a value-returning fall-back is needed."
+  echo "  - Replace [Result.iter_error ~f:ignore] with explicit handling:"
+  echo "      Result.iter_error r ~f:(fun e -> Log.<Module>.warn \"%s\" e)"
+  echo "  - To accept a finding intentionally, add [@observe-allowed: <reason>]"
+  echo "    on the same line."
+fi
+
+if [ "$STRICT" -eq 1 ] && [ "$COUNT" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Step 0b of the bloodflow restoration plan introduced \`Telemetry_observe.observe_or_fail\` (lib/telemetry_observe.{ml,mli}) as the typed alternative to silent-failure patterns. The CI lint half was deferred — this PR lands it.

## What this PR adds

\`scripts/check_silent_failure.sh\` — warn-only by default, \`--strict\` for CI gate.

### Patterns flagged

- \`try ... with _ -> ()\` (anonymous unit-swallow)
- \`try ... with _exn -> ()\` (named-anonymous unit-swallow)
- \`Result.iter_error ~f:ignore\`
- \`Result.iter_error (fun _ -> ())\`

### Patterns intentionally NOT flagged

- \`try ... with End_of_file -> ()\` — specific exception is structured handling, not a blanket swallow.
- \`with _ -> None / [] / false / 0\` — conversion idiom (option/list/bool/int defaults), not a unit-side-effect swallow.
- \`lib/telemetry_observe.{ml,mli}\` — the wrapper itself.
- \`test/\`, \`**/test_*.ml\` — test code.
- Any line tagged \`[@observe-allowed: <reason>]\` — opt-out marker for legitimate cleanup paths.

## Current baseline

\`\`\`
$ scripts/check_silent_failure.sh
check_silent_failure: 2 silent-failure anti-pattern site(s) found.

Findings:
  [try-unit-swallow] lib/exec/bash_history.ml:58:3:  try close_out oc with _ -> ()
  [try-unit-swallow] lib/exec/bash_history.ml:61:3:  try close_in ic with _ -> ()
\`\`\`

Both are file-close cleanups — candidates for \`[@observe-allowed: file-close cleanup]\` annotation in a follow-up.

## Adoption sequence

1. CI calls \`scripts/check_silent_failure.sh\` (warn-only) — baseline visible in build logs.
2. Stacked PRs migrate sites to \`Telemetry_observe.observe_or_fail\` or annotate \`[@observe-allowed: <reason>]\`.
3. Once baseline reaches zero, flip CI to \`--strict\`.

## Modes

\`\`\`
scripts/check_silent_failure.sh           — warn-only, exit 0
scripts/check_silent_failure.sh --strict  — fail on findings, exit 1
\`\`\`

## Test plan

- [x] Default mode reports 2 findings, exit 0.
- [x] \`--strict\` mode reports 2 findings, exit 1.
- [x] Named exception handlers (\`with End_of_file -> ()\` at \`lib/grpc/masc_grpc_server.ml:371\`) NOT flagged.
- [x] Conversion idioms (\`with _ -> None\`, \`with _ -> []\`) NOT flagged.
- [x] \`[@observe-allowed: <reason>]\` line marker filters out a hit (verified via stdin).

## Cross-reference

- \`lib/telemetry_observe.{ml,mli}\` (Step 0b OCaml half, merged earlier)
- \`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Step 0b

🤖 Generated with [Claude Code](https://claude.com/claude-code)