### PR TITLE
feat(dashboard_bonsai): Band atomic primitive (2px card status strip, 6 kinds)

### DIFF
--- a/dashboard_bonsai/src/band.ml
+++ b/dashboard_bonsai/src/band.ml
@@ -1,0 +1,121 @@
+(** Band — atomic primitive (Bonsai mirror of Preact [band.ts]).
+
+    Visual contract = SPEC §3.5 status (data, not chrome) + Preact
+    [dashboard/src/components/band.ts] (PR #11174).
+
+    A 2px tall, 100%-wide decorative strip rendered at the top of cards.
+    Pure decoration: no role, [aria-hidden="true"]. Distinct from Bar
+    (4px progress with fill width%), Chip (label), and Pill (capsule
+    badge): Band is a *card-level* state strip, no quantity, no label.
+
+    SPEC mapping (primitives.css [.band]):
+    - default            → [--color-border-strong] (idle, no state)
+    - [.band.is-running] → [--color-accent-fg] + glow shadow
+    - [.band.is-ok]      → [--color-status-ok]
+    - [.band.is-warn]    → [--color-status-warn]
+    - [.band.is-err]     → [--color-status-err]
+    - [.band.is-stalled] → [--color-status-stalled]
+
+    Kind mapping (mission spec polyvars, 6 kinds):
+    - [`Default]: idle / no-state, uses [--color-border-strong].
+    - [`Running]: accent fg + 6px glow box-shadow consuming
+      [--color-accent-glow] triplet (added in #11163).
+    - [`Ok | `Warn | `Err | `Stalled]: solid status color from
+      [--color-status-{kind}] tokens.
+
+    Polyvar choice: [`Default] (not [`Idle]) mirrors Preact's [default]
+    string literal. Preact band.ts has no [`Ghost`] variant — the 6
+    kinds are: default, running, ok, warn, err, stalled. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .band_base {
+    display: block;
+    height: 2px;
+    width: 100%;
+  }
+
+  .top_radius {
+    border-radius: 1px 1px 0 0;
+  }
+
+  .k_default {
+    background: var(--color-border-strong, #3a2e20);
+  }
+
+  .k_running {
+    background: var(--color-accent-fg, #968228);
+    box-shadow: 0 0 6px rgb(var(--color-accent-glow, 71 184 255) / 0.5);
+  }
+
+  .k_ok {
+    background: var(--color-status-ok, #6a9a4a);
+  }
+
+  .k_warn {
+    background: var(--color-status-warn, #b87828);
+  }
+
+  .k_err {
+    background: var(--color-status-err, #e85050);
+  }
+
+  .k_stalled {
+    background: var(--color-status-stalled, #8a6abf);
+  }
+
+  @media (forced-colors: active) {
+    .band_base    { background: ButtonText; }
+    .k_default    { background: GrayText; }
+    .k_running    { background: Highlight; box-shadow: none; }
+    .k_ok         { background: Highlight; }
+    .k_warn       { background: Mark; }
+    .k_err        { background: MarkText; }
+    .k_stalled    { background: ButtonText; }
+  }
+|}]
+
+type kind =
+  [ `Default
+  | `Running
+  | `Ok
+  | `Warn
+  | `Err
+  | `Stalled
+  ]
+
+let kind_class : kind -> Attr.t = function
+  | `Default -> Style.k_default
+  | `Running -> Style.k_running
+  | `Ok -> Style.k_ok
+  | `Warn -> Style.k_warn
+  | `Err -> Style.k_err
+  | `Stalled -> Style.k_stalled
+;;
+
+let kind_string : kind -> string = function
+  | `Default -> "default"
+  | `Running -> "running"
+  | `Ok -> "ok"
+  | `Warn -> "warn"
+  | `Err -> "err"
+  | `Stalled -> "stalled"
+;;
+
+let view ?(top_radius = true) ?(kind = `Default) () : Node.t =
+  let attrs =
+    [ Style.band_base
+    ; kind_class kind
+    ; Attr.create "aria-hidden" "true"
+    ; Attr.create "data-kind" (kind_string kind)
+    ]
+  in
+  let attrs = if top_radius then Style.top_radius :: attrs else attrs in
+  Node.div ~attrs []
+;;

--- a/dashboard_bonsai/src/band.mli
+++ b/dashboard_bonsai/src/band.mli
@@ -1,0 +1,31 @@
+(** Band — atomic primitive (Bonsai mirror of Preact [band.ts]).
+
+    A 2px tall, 100%-wide decorative card-level state strip. Pure
+    decoration ([aria-hidden="true"]); no role, no content, no label.
+    See [band.ml] for full visual contract documentation. *)
+
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type kind =
+  [ `Default
+  | `Running
+  | `Ok
+  | `Warn
+  | `Err
+  | `Stalled
+  ]
+
+(** [view ?top_radius ?kind ()] renders a 2px decorative state strip.
+
+    [kind] (default [`Default]): tone selector. [`Default] uses
+    [--color-border-strong] (idle, no state). [`Running] uses
+    [--color-accent-fg] plus a 6px box-shadow glow consuming
+    [--color-accent-glow]. [`Ok | `Warn | `Err | `Stalled] use solid
+    fill from [--color-status-{kind}].
+
+    [top_radius] (default [true]): when [true], applies [1px 1px 0 0]
+    border-radius so the strip matches a card's rounded top corners.
+    Set [false] when the band is not at the top of a rounded
+    container. *)
+val view : ?top_radius:bool -> ?kind:kind -> unit -> Node.t


### PR DESCRIPTION
## Summary

OCaml + ppx_css mirror of Preact `dashboard/src/components/band.ts` (PR #11174). Bonsai catch-up for the 2px card-level state strip so `/dashboard/b/*` surfaces stop reinventing the inline-styled top decoration.

- New: `dashboard_bonsai/src/band.ml` (+121 LoC), `dashboard_bonsai/src/band.mli` (+31 LoC).
- 2 new files. **No dune edit, no other module changed.** `dashboard_bonsai/src/dune` uses module auto-discovery (no `(modules ...)` clause), so band registers automatically.

## Visual contract (= Preact band.ts spec)

| Concern | Implementation |
|---------|---------------|
| Geometry | `display: block; height: 2px; width: 100%` |
| A11y | `aria-hidden="true"` (pure decoration; no role) |
| Default kind | `--color-border-strong` (idle, no state) |
| Running kind | `--color-accent-fg` + `0 0 6px rgb(var(--color-accent-glow) / 0.5)` |
| Ok / Warn / Err / Stalled | solid `--color-status-{kind}` |
| top_radius (default true) | `border-radius: 1px 1px 0 0` (matches card rounded top) |
| topRadius=false | omits the radius rule (drops to 0) |
| Hex literals | Only inside `var(--token, #fallback)` (matches `chip.ml` / `pill.ml` convention) |
| `forced-colors: active` | falls back to system `Highlight` / `Mark` / `MarkText` / `GrayText` / `ButtonText` |

## API

```ocaml
type kind =
  [ `Default | `Running | `Ok | `Warn | `Err | `Stalled ]

val view : ?top_radius:bool -> ?kind:kind -> unit -> Vdom.Node.t
```

`data-kind` attribute is emitted on the div (`"default" / "running" / ..."`) for selector / test hooks, mirroring Preact's `data-kind=${kind}` channel.

## Polyvar choice: `Default` (not `Idle` and not `Ghost`)

Preact `band.ts` exposes 6 kinds: `default, running, ok, warn, err, stalled`. The mission-spec polyvar set the prompt named is exactly that 6-kind set, so the API contract is `[ \`Default | \`Running | \`Ok | \`Warn | \`Err | \`Stalled ]`.

Why this differs from the Bonsai chip precedent (which substituted `Idle` for `Ghost`):

1. Chip's `Idle` is a real SPEC §3.5 status semantic with its own `--color-status-idle` token — it earns a polyvar.
2. Band's `default` is *genuinely* the absence of any state (uses `--color-border-strong`, the layout edge token, not a status token). `Default` is the honest spec name.
3. Preact band has no `ghost` variant at all, so there is no Idle/Ghost decision to inherit.

If pixel-parity with a future "no band visible" state is needed, callers simply omit the `<Band>` element rather than adding a 7th polyvar.

## Out of scope

- `SPEC.md`, `README.md`, `dashboard/` (Preact) surfaces.
- Other `ppx_css` modules (pill / hero / chip / surf / …).
- Theme files / `static/colors_and_type.css`.
- Demo wiring into existing card surfaces — keeps PR surgical; demo lands when first consumer needs it.

## Verification

| Check | Result |
|-------|--------|
| `dune build src/.dashboard_bonsai_lib.objs/native/…__Band.cmx` (default profile) | pass |
| same target with `--profile=release` (warn-as-error +8) | pass |
| `band.mli` signature matches `band.ml` (cmi build) | pass |
| `rg ':\s*#[0-9a-fA-F]{3,6}\b' dashboard_bonsai/src/band.ml \| rg -v 'var('` | 0 hits |

(Whole-library `dune build` baseline has 3 pre-existing failures on `origin/main` — `keepers_directory.ml:436`, `overview_view.ml:393`, `ctx_chart.ml:239` — unrelated to this PR. Band module verified in isolation by targeting its specific cmx artifact, same as the Chip PR #11181 did.)

## Self-review (best-programmer)

- 목표: atom score follow-up — Band primitive Bonsai-side parity with Preact band.ts.
- 변경 범위: 2 new files, +152 LoC. primitive 정의만, 콜사이트 swap 없음.
- 검증: cmx (default + release) + cmi green, hex-outside-var = 0 hits.
- 미검증: 시각 렌더 (Wave 5 Storybook 또는 dev server visual diff 단계).
- 정직 disclosure: whole-lib dune build에는 origin/main의 기존 3건 실패 잔존 — 본 PR scope 외.

## Test plan

- [x] `dune build` Band cmx (default + release)
- [x] `dune build` Band cmi (interface match)
- [x] No raw hex outside `var(--token, #fallback)` form
- [ ] Wave 5 Storybook visual baseline vs `dashboard/src/components/band.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)