### PR TITLE
feat(dashboard_bonsai): Bar atomic primitive (4px progress, kind-tinted fill)

### DIFF
--- a/dashboard_bonsai/src/bar.ml
+++ b/dashboard_bonsai/src/bar.ml
@@ -1,0 +1,147 @@
+(** Bar — atomic primitive (Bonsai mirror of Preact [bar.ts]).
+
+    Visual contract = SPEC primitives §[bar] (4px progress bar with
+    kind-tinted fill) + Preact [dashboard/src/components/bar.ts] (PR
+    #11170). Pure quantity primitive — shows "how full" without
+    announcing a state transition. Distinct from Pill (16px stateful
+    capsule) and Chip (sharp 2px label).
+
+    [role="progressbar"] on the host gives assistive tech the
+    value/min/max contract directly.
+
+    Fill token mapping (no glow channel — Bar is solid fill):
+    - [`Default] → [--color-accent-fg]    (brass)
+    - [`Ok]      → [--color-status-ok]
+    - [`Warn]    → [--color-status-warn]
+    - [`Err]     → [--color-status-err]
+
+    Width is data-driven (depends on value), so it is applied as an
+    inline style. Static geometry (4px height, 2px radius, track
+    background, transition) lives in [ppx_css]. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .track {
+    display: block;
+    width: 100%;
+    height: 4px;
+    background: var(--color-bg-elevated, #1a1410);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .fill_base {
+    display: block;
+    height: 100%;
+    transition: width 500ms;
+  }
+
+  .fill_no_transition {
+    display: block;
+    height: 100%;
+  }
+
+  .k_default { background: var(--color-accent-fg, #968228); }
+  .k_ok      { background: var(--color-status-ok, #6a9a4a); }
+  .k_warn    { background: var(--color-status-warn, #b87828); }
+  .k_err     { background: var(--color-status-err, #e85050); }
+
+  @media (prefers-contrast: more) {
+    .track { border: 1px solid var(--text-bright); }
+  }
+
+  @media (forced-colors: active) {
+    .track     { border: 1px solid ButtonText; background: Canvas; }
+    .k_default { background: Highlight; }
+    .k_ok      { background: Highlight; }
+    .k_warn    { background: Mark; }
+    .k_err     { background: MarkText; }
+  }
+|}]
+
+type kind =
+  [ `Default
+  | `Ok
+  | `Warn
+  | `Err
+  ]
+
+(** [bar_percent v] clamps [v] to [[0, 100]] and rounds to integer
+    percent. Mirrors Preact's [barPercent] (pure helper). [Float.is_nan
+    v] coerces to [0] to match Preact's [Number.isNaN] guard. *)
+let bar_percent (v : float) : int =
+  if Float.is_nan v
+  then 0
+  else (
+    let clamped = Float.max 0.0 (Float.min 100.0 v) in
+    Float.iround_nearest_exn clamped)
+;;
+
+let kind_class : kind -> Attr.t = function
+  | `Default -> Style.k_default
+  | `Ok -> Style.k_ok
+  | `Warn -> Style.k_warn
+  | `Err -> Style.k_err
+;;
+
+let kind_data : kind -> string = function
+  | `Default -> "default"
+  | `Ok -> "ok"
+  | `Warn -> "warn"
+  | `Err -> "err"
+;;
+
+let view
+      ?(kind : kind = `Default)
+      ?(aria_label : string option)
+      ?(test_id : string option)
+      ?(title : string option)
+      ?(no_transition : bool = false)
+      ~(value : int)
+      ()
+  : Node.t
+  =
+  let pct = bar_percent (Float.of_int value) in
+  let announce =
+    match aria_label with
+    | Some s -> s
+    | None -> Printf.sprintf "%d%%" pct
+  in
+  let host_attrs =
+    [ Style.track
+    ; Attr.create "role" "progressbar"
+    ; Attr.create "aria-valuenow" (Int.to_string pct)
+    ; Attr.create "aria-valuemin" "0"
+    ; Attr.create "aria-valuemax" "100"
+    ; Attr.create "aria-label" announce
+    ; Attr.create "data-kind" (kind_data kind)
+    ]
+  in
+  let host_attrs =
+    match test_id with
+    | Some t -> Attr.create "data-testid" t :: host_attrs
+    | None -> host_attrs
+  in
+  let host_attrs =
+    match title with
+    | Some t -> Attr.create "title" t :: host_attrs
+    | None -> host_attrs
+  in
+  let fill_base =
+    if no_transition then Style.fill_no_transition else Style.fill_base
+  in
+  let fill_attrs =
+    [ fill_base
+    ; kind_class kind
+    ; Attr.create "aria-hidden" "true"
+    ; Attr.style (Css_gen.create ~field:"width" ~value:(Printf.sprintf "%d%%" pct))
+    ]
+  in
+  Node.div ~attrs:host_attrs [ Node.span ~attrs:fill_attrs [] ]
+;;

--- a/dashboard_bonsai/src/bar.mli
+++ b/dashboard_bonsai/src/bar.mli
@@ -1,0 +1,50 @@
+(** Bar — atomic primitive (Bonsai mirror of Preact [bar.ts]).
+
+    Visual contract = SPEC primitives §[bar] (4px progress bar with
+    kind-tinted fill) + Preact PR #11170. See [bar.ml] for full visual
+    contract documentation. *)
+
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type kind =
+  [ `Default
+  | `Ok
+  | `Warn
+  | `Err
+  ]
+
+(** [bar_percent v] clamps [v] to [[0, 100]] and rounds to integer
+    percent. [Float.is_nan v] coerces to [0]. Pure — exposed so callers
+    that label a Bar inside a parent label can reuse the same rounding
+    without mounting the component. Mirrors Preact [barPercent]. *)
+val bar_percent : float -> int
+
+(** [view ?kind ?aria_label ?test_id ?title ?no_transition ~value ()]
+    renders a 4px progress bar.
+
+    [value] (required, integer 0–100): Out-of-range values clamp on
+    render. Float-precision is intentionally not exposed at the
+    primitive boundary — callers that need fractional percent should
+    pre-round via [bar_percent].
+
+    [kind] (default [`Default]): fill tone selector. [`Default] = brass
+    accent; [`Ok] / [`Warn] / [`Err] = status tokens.
+
+    [aria_label] (default [Some "<pct>%"]): override the auto label.
+
+    [test_id]: forwarded to [data-testid].
+
+    [title]: native [title] attribute for hover tooltips.
+
+    [no_transition] (default [false]): drop the 500ms width transition
+    when [true]. Useful for first paint or non-animating contexts. *)
+val view
+  :  ?kind:kind
+  -> ?aria_label:string
+  -> ?test_id:string
+  -> ?title:string
+  -> ?no_transition:bool
+  -> value:int
+  -> unit
+  -> Node.t


### PR DESCRIPTION
## Summary

OCaml + ppx_css mirror of Preact `dashboard/src/components/bar.ts` (PR #11170).
Provides the SPEC primitives §[bar] 4px progress bar as a reusable Bonsai
primitive so `/dashboard/b/*` surfaces stop reinventing the inline-styled
progress fill.

- 4px height track, 2px radius, `--color-bg-elevated` background
- 4 kinds: `Default` (`--color-accent-fg`) / `Ok` / `Warn` / `Err` (`--color-status-{kind}`)
- 500ms width transition, opt-out via `~no_transition:true`
- ARIA: `role=progressbar` with `aria-valuenow/min/max`; default `aria-label` is `"<pct>%"` (caller can override)
- `prefers-contrast: more` and `forced-colors: active` fallbacks
- Inline hex literals only inside `var()` fallbacks (matches `chip.ml` convention)

## API

```ocaml
type kind = [`Default | `Ok | `Warn | `Err]

val bar_percent : float -> int

val view
  :  ?kind:kind
  -> ?aria_label:string
  -> ?test_id:string
  -> ?title:string
  -> ?no_transition:bool
  -> value:int
  -> unit
  -> Vdom.Node.t
```

`bar_percent` is exported (mirrors Preact `barPercent`) so callers that
embed a Bar inside a parent label can reuse the same clamp+round without
mounting the component. NaN coerces to 0 to match Preact's `Number.isNaN`
guard.

## Preact contract parity

| Preact (`bar.ts`) | Bonsai (`bar.ml`) |
|---|---|
| `BarKind = 'default' \| 'ok' \| 'warn' \| 'err'` | `kind = [\`Default \| \`Ok \| \`Warn \| \`Err]` |
| `barPercent(v)` clamp+round, NaN→0 | `bar_percent : float -> int` (same) |
| Track inline style: 4px / `--color-bg-elevated` / 2px radius | `Style.track` (ppx_css) |
| Fill inline style: kind color | `Style.k_default` / `k_ok` / `k_warn` / `k_err` (ppx_css) |
| `transition: width 500ms` (default) | `Style.fill_base` (ppx_css) |
| `noTransition: true` drops transition | `~no_transition:true` selects `fill_no_transition` |
| `aria-valuenow={pct}`, etc. | `Attr.create "aria-valuenow" ...` |
| `data-kind={kind}` | `Attr.create "data-kind" ...` |
| `data-testid={testId}` | optional `~test_id` |
| `title={title}` | optional `~title` |
| `aria-label={ariaLabel ?? "<pct>%"}` | `?aria_label`, default `"<pct>%"` |
| Inner `<span aria-hidden="true">` with width inline | `Node.span` with `Css_gen.create ~field:"width"` |

## Deviations from Preact

- `value` typed as `int` (not `float`). Float-precision is not exposed at the primitive boundary. Callers needing fractional input should pre-round via `bar_percent`. (Pure helper still accepts `float` for parity.)
- Width is the only inline style — applied via `Css_gen.create ~field:"width"` matching the established pattern in `logs_view.ml` / `keepers_directory.ml`. All other styling lives in ppx_css.

## Verification

- LoC: 197 (`bar.ml` 147, `bar.mli` 50)
- `dashboard_bonsai_lib__Bar.cmo` and `dashboard_bonsai_lib__Bar.cmx` build clean under the `bonsai-dashboard` opam switch (5.2.0+ox), both `default` and `release` profiles.
- Pre-existing unrelated syntax errors in `overview_view.ml`, `ctx_chart.ml`, `keepers_directory.ml` on `origin/main` (`b87b99d403`) prevent a full library build but are out of scope for this PR.

## Test plan

- [ ] Verify `dune build --root dashboard_bonsai _build/default/src/.dashboard_bonsai_lib.objs/byte/dashboard_bonsai_lib__Bar.cmo` succeeds
- [ ] Visual check at first callsite (next PR mounts Bar in a real surface)
- [ ] No inline hex outside `var(...)` fallback
- [ ] Pixel parity vs Preact `<Bar value={50} />`

🤖 Generated with [Claude Code](https://claude.com/claude-code)