### PR TITLE
fix(meta-guards): wire KeeperTurnFSM.tla into tla-check.sh

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -171,6 +171,8 @@ run_tlc "$REPO_ROOT/specs/state-product" "CoordinationProduct.tla"
 run_tlc_buggy "$REPO_ROOT/specs/state-product" "CoordinationProduct.tla"
 run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
+run_tlc "$REPO_ROOT/specs/keeper-turn-fsm" "KeeperTurnFSM.tla"
+run_tlc_buggy "$REPO_ROOT/specs/keeper-turn-fsm" "KeeperTurnFSM.tla"
 
 # Optional: run TraceSpec if --trace flag provided
 if [ "${1:-}" = "--trace" ]; then


### PR DESCRIPTION
## Summary

PR #11190 added \`specs/keeper-turn-fsm/KeeperTurnFSM.{tla,cfg,buggy.cfg}\` but didn't register the spec in \`scripts/tla-check.sh\`. Result: Meta Guards gate fails on every PR opened against post-#11190 main:

\`\`\`
FAIL: cfg-backed TLA+ specs not covered by scripts/tla-check.sh:
  specs/keeper-turn-fsm/KeeperTurnFSM.tla
\`\`\`

This unblocks PR #11186 (and any subsequent PR).

## Change

Add the standard \`run_tlc\` + \`run_tlc_buggy\` pair after the task-lifecycle entries. cfg filenames already follow the convention:

- \`KeeperTurnFSM.cfg\` — \`run_tlc\` reads \`\${tla%.tla}.cfg\`
- \`KeeperTurnFSM-buggy.cfg\` — \`run_tlc_buggy\` reads \`\${tla%.tla}-buggy.cfg\`

## Test plan

- [x] git diff scoped to 2 added lines in scripts/tla-check.sh
- [ ] Meta Guards gate green on this PR

## Follow-up

This is the same class of bug as #11188 (a recently-merged feature PR that didn't wire its CI hook). Lint + Meta Guards aren't required checks → merging red is the same hidden hazard as PR #11158/#11160 (#10747-class regression). Consider promoting both gates to required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)