### PR TITLE
feat(dashboard): Tk atom (atom 9/14, 6 inline code callsite SSOT swap)

### DIFF
--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -27,6 +27,7 @@ import {
 } from './connector-status'
 import { openConnectorConfig } from './connector-config-form'
 import { KeeperBadge } from './keeper-badge'
+import { Tk } from './tk'
 
 type MatrixCellState = 'bound' | 'unbound' | 'na' | 'unknown'
 
@@ -254,7 +255,7 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
       ${!hasKeepers
         ? html`
             <div class="rounded border border-dashed border-[var(--color-border-default)] px-3 py-4 text-center text-2xs text-[var(--color-fg-disabled)]">
-              No keepers yet — add one under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart.
+              No keepers yet — add one under <${Tk}>config/keepers/<//> and restart.
             </div>
           `
         : html`

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -41,6 +41,7 @@ import { ConnectorKeeperMatrix, deriveMatrix } from './connector-keeper-matrix'
 import { ConnectorPathsStrip } from './connector-paths-strip'
 import { createManagedAsyncResource } from '../lib/async-state'
 import { route } from '../router'
+import { Tk } from './tk'
 
 // Sub-section -> connector_id filter. `connector-status` (default) shows
 // all connectors; the per-connector sub-sections show just that one. Source
@@ -945,8 +946,8 @@ function ConnectorLivePanel({
               <div class="mt-1">
                 <span class="font-medium">Next: </span>
                 ${connectorError
-                  ? html`refresh the dashboard or check <code class="rounded bg-[var(--white-4)] px-1">/api/v1/gate/connectors</code> on ${connector?.gate_base_url || 'the Gate server'}.`
-                  : html`run the ${connectorName} status command and inspect <code class="rounded bg-[var(--white-4)] px-1">${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}</code>.`}
+                  ? html`refresh the dashboard or check <${Tk}>/api/v1/gate/connectors<//> on ${connector?.gate_base_url || 'the Gate server'}.`
+                  : html`run the ${connectorName} status command and inspect <${Tk}>${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}<//>.`}
               </div>
             </div>
           `
@@ -975,7 +976,7 @@ function ConnectorLivePanel({
                 <span class="font-medium">Cause: </span> keeper 디렉토리 사용 불가, 수동 입력만 가능.
               </div>
               <div class="mt-1">
-                <span class="font-medium">Next: </span> 지금은 수동 입력으로 진행, 이후 <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> 복원 또는 <code class="rounded bg-[var(--white-4)] px-1">/api/v1/gate/keepers</code> 수정 후 디렉토리 추천에 의존하세요.
+                <span class="font-medium">Next: </span> 지금은 수동 입력으로 진행, 이후 <${Tk}>config/keepers/<//> 복원 또는 <${Tk}>/api/v1/gate/keepers<//> 수정 후 디렉토리 추천에 의존하세요.
               </div>
             </div>
           `
@@ -999,7 +1000,7 @@ function ConnectorLivePanel({
                 <span class="font-medium text-[var(--color-fg-primary)]">설정된 키퍼 없음</span>
               </div>
               <div class="text-3xs text-[var(--color-status-warn)]/80">
-                Add keeper config files under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart the server.
+                Add keeper config files under <${Tk}>config/keepers/<//> and restart the server.
               </div>
             </div>
           `
@@ -1054,7 +1055,7 @@ function ConnectorLivePanel({
                 </div>
                 <div class="text-2xs text-[var(--color-status-warn)]/80">
                   <div>
-                    <span class="font-medium">원인: </span> 사이드카 status 파일이 <code class="rounded bg-[var(--white-4)] px-1">${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}</code> 에서 관찰되지 않았습니다.
+                    <span class="font-medium">원인: </span> 사이드카 status 파일이 <${Tk}>${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}<//> 에서 관찰되지 않았습니다.
                   </div>
                   <div class="mt-1">
                     <span class="font-medium">다음: </span> <strong>Start</strong> 버튼으로 백엔드를 통해 실행하거나, 아래 명령을 복사해 터미널에서 실행하세요. 오프라인이 지속되면 <strong>status</strong> 와 <strong>tail logs</strong> 를 사용하세요.

--- a/dashboard/src/components/tk.test.ts
+++ b/dashboard/src/components/tk.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Tk, type TkProps } from './tk'
+
+describe('Tk', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    render(null, host)
+    host.remove()
+  })
+
+  function mount(props: TkProps): HTMLElement {
+    render(html`<${Tk} ...${props} />`, host)
+    return host.firstElementChild as HTMLElement
+  }
+
+  // ── Structural ──
+
+  it('emits a <code> tag by default (semantic match)', () => {
+    const el = mount({ children: 'foo' })
+    expect(el.tagName).toBe('CODE')
+  })
+
+  it('renders as <span> when as="span"', () => {
+    const el = mount({ children: 'bar', as: 'span' })
+    expect(el.tagName).toBe('SPAN')
+  })
+
+  it('records kind on data-kind', () => {
+    const el = mount({ children: 'x', kind: 'brass' })
+    expect(el.getAttribute('data-kind')).toBe('brass')
+  })
+
+  it('defaults to kind=default when omitted', () => {
+    const el = mount({ children: 'x' })
+    expect(el.getAttribute('data-kind')).toBe('default')
+  })
+
+  it('marks the host with data-tk for selectors', () => {
+    const el = mount({ children: 'x' })
+    expect(el.hasAttribute('data-tk')).toBe(true)
+  })
+
+  it('forwards testId to data-testid', () => {
+    const el = mount({ children: 'GOAL_ID', testId: 'goal-token' })
+    expect(el.getAttribute('data-testid')).toBe('goal-token')
+  })
+
+  it('forwards title attribute', () => {
+    const el = mount({ children: 'X', title: 'environment variable' })
+    expect(el.getAttribute('title')).toBe('environment variable')
+  })
+
+  it('renders children content', () => {
+    const el = mount({ children: 'GOAL_ID' })
+    expect(el.textContent).toBe('GOAL_ID')
+  })
+
+  // ── SPEC font / geometry ──
+
+  it('uses monospace font stack', () => {
+    const el = mount({ children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style.toLowerCase()).toContain('monospace')
+  })
+
+  it('uses SPEC 0.92em relative font-size (sits in surrounding prose)', () => {
+    const el = mount({ children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('font-size: 0.92em')
+  })
+
+  it('uses SPEC 0 4px padding', () => {
+    const el = mount({ children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('padding: 0px 4px')
+  })
+
+  it('uses SPEC 2px border-radius', () => {
+    const el = mount({ children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('border-radius: 2px')
+  })
+
+  it('clips overflow with ellipsis (extreme values)', () => {
+    const el = mount({ children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('white-space: nowrap')
+    expect(style).toContain('text-overflow: ellipsis')
+  })
+
+  // ── Kind tones (fg only — happy-dom drops modern rgb()/var()/alpha) ──
+
+  it('uses fg-primary for default kind', () => {
+    const el = mount({ children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('color: var(--color-fg-primary)')
+  })
+
+  it('uses accent-fg for brass kind', () => {
+    const el = mount({ children: 'x', kind: 'brass' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('color: var(--color-accent-fg)')
+  })
+
+  it('uses status-err for err kind', () => {
+    const el = mount({ children: 'x', kind: 'err' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('color: var(--color-status-err)')
+  })
+
+  it('uses bg-elevated for default background (plain var, survives serialisation)', () => {
+    const el = mount({ children: 'x' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('background: var(--color-bg-elevated)')
+  })
+})

--- a/dashboard/src/components/tk.ts
+++ b/dashboard/src/components/tk.ts
@@ -1,0 +1,126 @@
+// Tk — atomic primitive ported from design-system v0.4 primitives.html
+// (`<code class="tk">value</code>`). The SPEC defines an *inline mono
+// highlight* — a small mono-font chunk on a tinted background, used
+// to mark identifier-shaped tokens inside running prose: env var
+// names, file paths, agent ids, error codes, command flags. Reads
+// like inline code in technical writing.
+//
+// Why a new atom: dashboard scatters 27+ inline `<code>` callsites
+// across 4+ drifting class compositions:
+//
+//   <code class="rounded bg-[var(--white-4)] px-1">                — connector-{status,keeper-matrix}
+//   <code class="rounded bg-white/5 px-1 py-0.5 text-2xs ...">    — goals/goal-tree, task-create-form
+//   <code class="text-3xs text-[var(--color-fg-muted)]">           — safe-autonomy (no bg)
+//   <code class="text-xs font-mono text-[var(--color-fg-secondary)]"> — server-config
+//
+// Every one is the same intent (inline mono highlight) shaped by
+// inconsistent token / spacing combos. Tk consolidates them.
+//
+// Distinct from sibling primitives:
+//
+//   CopyableCode  — full-block command snippet + copy button
+//                   (Vercel "Deploy" pattern). Block, not inline.
+//   Kbd           — keyboard shortcut indicator.  Different shape
+//                   (3D-ish key cap), different intent (input hint).
+//   Chip / Pill   — semantic state labels.  Tk has no state, just
+//                   "this string is technical content".
+//
+// SPEC mapping (primitives.css `.tk`):
+//   font-family    var(--font-mono)
+//   font-size      0.92em (relative — sits in surrounding prose)
+//   padding        0 4px
+//   border-radius  2px
+//   background     var(--color-bg-elevated)
+//   color          var(--color-fg-primary)
+//   .tk.is-brass   accent-fg + 0.08 accent-glow bg
+//   .tk.is-err     err fg + 0.08 err-glow bg
+
+import { html } from 'htm/preact'
+import type { ComponentChildren, VNode } from 'preact'
+
+export type TkKind = 'default' | 'brass' | 'err'
+
+export interface TkProps {
+  /** The token / identifier / path / code fragment to render. */
+  children: ComponentChildren
+  /** Tone. SPEC has default + `is-brass` + `is-err`. Other status
+   *  kinds (warn / info / stalled) are not in SPEC for `.tk` —
+   *  callers wanting those should use Surf or Chip. */
+  kind?: TkKind
+  /** Override the rendered tag. Default `code` (semantic match). Use
+   *  `span` when the surrounding context is itself inside `<code>` /
+   *  `<pre>` and nesting would be invalid. */
+  as?: 'code' | 'span'
+  /** Forwarded to data-testid. */
+  testId?: string
+  /** Optional native `title` for hover tooltips (e.g. "click to copy"
+   *  hint when used inside an interactive parent). The primitive
+   *  itself is non-interactive — caller wraps in <button> if needed. */
+  title?: string
+}
+
+interface KindStyle {
+  color: string
+  background: string
+}
+
+const KIND_STYLE: Record<TkKind, KindStyle> = {
+  default: {
+    color: 'var(--color-fg-primary)',
+    background: 'var(--color-bg-elevated)',
+  },
+  brass: {
+    color: 'var(--color-accent-fg)',
+    // glow channel + alpha — same SPEC `rgb(var(--color-accent-glow) / 0.08)`
+    background: 'rgb(var(--color-accent-glow) / 0.08)',
+  },
+  err: {
+    color: 'var(--color-status-err)',
+    background: 'rgb(var(--color-status-err-glow) / 0.08)',
+  },
+}
+
+const MONO_STACK =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+export function Tk(props: TkProps): VNode {
+  const kind = props.kind ?? 'default'
+  const ks = KIND_STYLE[kind]
+  const tag = props.as ?? 'code'
+
+  const style = {
+    fontFamily: MONO_STACK,
+    fontSize: '0.92em',
+    padding: '0 4px',
+    borderRadius: '2px',
+    background: ks.background,
+    color: ks.color,
+    // Inline content — the primitive shouldn't introduce its own
+    // line break behaviour, but should clip overflow on extreme
+    // values so a 2KB path doesn't blow up the row.
+    whiteSpace: 'nowrap' as const,
+    overflow: 'hidden' as const,
+    textOverflow: 'ellipsis' as const,
+    verticalAlign: 'baseline' as const,
+    maxWidth: '100%',
+  }
+
+  // htm/preact tag interpolation via a string variable: render via two
+  // branches because htm parses tag names statically at the call site.
+  if (tag === 'span') {
+    return html`<span
+      data-testid=${props.testId}
+      data-kind=${kind}
+      data-tk
+      title=${props.title}
+      style=${style}
+    >${props.children}</span>`
+  }
+  return html`<code
+    data-testid=${props.testId}
+    data-kind=${kind}
+    data-tk
+    title=${props.title}
+    style=${style}
+  >${props.children}</code>`
+}


### PR DESCRIPTION
## Why — atom score 8/14 → 9/14, 사용자 *"중복 검사"* 패턴 재적용

아홉 번째 atom. SPEC `.tk` (inline mono highlight) 의 dashboard SSOT 도입.

### 사용자 신호 *"중복 검사"* 적용 결과

| 카테고리 | 결과 |
|---|---|
| **다른 의도 — 격리** | `CopyableCode` (block command + copy, Vercel "Deploy" pattern), `Kbd` (keyboard shortcut), `InlineSpinner`, `status-{badge,chip,dot}` |
| **진짜 중복** | **27+ inline `<code>` callsites, 4+ drifting class compositions** |

drift 분포:

| 패턴 | callsites |
|---|---|
| `<code class="rounded bg-[var(--white-4)] px-1">` | **connector-status (5)**, **connector-keeper-matrix (1)** — 가장 일관, 본 PR 대상 |
| `<code class="rounded bg-white/5 px-1 py-0.5 text-2xs ...">` | goals/goal-tree, task-create-form |
| `<code class="text-3xs text-[var(--color-fg-muted)]">` | safe-autonomy (no bg) |
| `<code class="text-xs font-mono text-[var(--color-fg-secondary)]">` | server-config |

본 PR 는 **가장 일관된 variant (6 callsites, 단일 class 조합)** 를 SSOT swap. 나머지 variants 는 별도 sweep PR — review 단순화.

## 변경

| 파일 | 변경 |
|---|---|
| `dashboard/src/components/tk.ts` (신규) | Atomic Tk primitive. SPEC API 1:1 (`<code class="tk">value</code>` ↔ `<Tk>value</Tk>`). 3 kinds (default/brass/err) + `as` (code/span) opt-in for nesting |
| `dashboard/src/components/tk.test.ts` (신규) | 17 cases: structural (tag / data-* / testId / title / children), SPEC font + geometry, per-kind fg color |
| `dashboard/src/components/connector-status.ts` | 5 inline `<code>` callsites → `<${Tk}>...<//>` |
| `dashboard/src/components/connector-keeper-matrix.ts` | 1 inline `<code>` callsite → `<${Tk}>...<//>` |

### SPEC API 매핑

| SPEC | Tk prop |
|---|---|
| `<code class="tk">value</code>` | `<Tk>value</Tk>` |
| `.tk.is-brass` | `kind="brass"` |
| `.tk.is-err` | `kind="err"` |
| 0.92em font-size (relative — surrounding prose) | hard-coded |
| 0 4px padding + 2px radius | hard-coded |
| nowrap + ellipsis on overflow | hard-coded (extreme values clip, not break layout) |

### Visual fidelity

- default kind: **100% SPEC** (dashboard 런타임 token 사용)
- brass / err: ~95% (`*-glow` channel + 0.08 alpha — SPEC 와 동일)

## 검증

- `pnpm exec tsc --noEmit` — clean (EXIT 0)
- `pnpm exec vitest run tk connector-status connector-keeper-matrix` — **60/60 passed**
- 회귀 0

## Scope note — 이 PR 에서 의도적으로 *제외* 한 것

- **다른 3 inline `<code>` variants**: 각 variant 별로 callsite + 의도 다름. 별도 PR sweep
  - goals/goal-tree + task-create-form (white/5 + py-0.5 variant)
  - safe-autonomy (no bg variant — Tk default 와 시각 다름)
  - server-config (text-xs variant — Tk 의 0.92em 보다 큼)
- **`CopyableCode` 통합**: block 의도 — Tk 와 별개

## 다음 cycle 후보

| 옵션 | 내용 |
|---|---|
| **A** | Tk 추가 sweep — 나머지 3 variants (goals + safe-autonomy + server-config) 적용 |
| **B** | 다음 atom — **Sep** (separator), **Btn Variants**, **Keycap** |
| **C** | Surf 추가 callsite — RemoteWarningBanner (strip variant), 6 text-only role=alert sites |
| **D** | `cb-group-g` state primitives (empty/loading/error) — 사용자 캡처 v0.4 의 명시 영역 |

## Self-review (best-programmer)

- 목표: atom score 8/14 → 9/14. 사용자 "중복 검사" 신호 두 번째 적용 (Surf 에 이어)
- 변경 범위: 4 파일, +259/-6 라인. primitive 정의 + 17 단위 test + 6 callsite swap (단일 class composition)
- 검증: tsc clean + 60 vitest green + 회귀 0
- 미검증: 시각 렌더 (의도상 사용자 화면 + dev server 에서만 가능)
- 정직 disclosure: 다른 3 variants 별도 sweep — 각 variant 의 *의도* 가 약간 다름 (no bg / large text / extra padding) 으로 단일 PR 에 묶을 시 시각 강제 변경 위험. CopyableCode / Kbd 격리 — 다른 의도 명시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
