### PR TITLE
[Step 15 partial] test_telemetry_observe — wrapper unit tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -190,7 +190,8 @@
         test_agent_stress_timeout_wire_10341
         test_institution_episodes_failure_learnings_10325
         test_mid_turn_resume
-        test_lockfree_atomic)
+        test_lockfree_atomic
+        test_telemetry_observe)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -351,6 +352,7 @@
           test_institution_episodes_failure_learnings_10325
           test_mid_turn_resume
           test_lockfree_atomic
+          test_telemetry_observe
           )
  (libraries masc_test_deps))
 

--- a/test/test_telemetry_observe.ml
+++ b/test/test_telemetry_observe.ml
@@ -1,0 +1,107 @@
+(** test_telemetry_observe — Unit tests for [Telemetry_observe].
+
+    Step 15 (partial) of the bloodflow restoration plan. Covers the
+    silent-failure wrapper introduced in Step 0b
+    (lib/telemetry_observe.{ml,mli}). Verifies that:
+
+    - [observe_or_fail] returns [Ok] on success.
+    - [observe_or_fail] returns [Error msg] on a generic exception.
+    - [observe_or_fail] re-raises [Eio.Cancel.Cancelled] without
+      silently absorbing it (cooperative-cancel preservation).
+    - [observe_or_default] returns the success value on [Ok].
+    - [observe_or_default] returns the [default] on exception.
+
+    The Cancelled re-raise check is the load-bearing one — Step 5 of
+    the plan removes the [Fun.protect] catch-all at
+    keeper_agent_run.ml:157-164 and depends on this wrapper not
+    swallowing cancel. *)
+
+open Masc_mcp
+
+let test_observe_or_fail_returns_ok () =
+  let result =
+    Telemetry_observe.observe_or_fail ~kind:"test_ok" (fun () -> 42)
+  in
+  Alcotest.(check (result int string)) "Ok 42" (Ok 42) result
+
+let test_observe_or_fail_returns_error () =
+  let result =
+    Telemetry_observe.observe_or_fail ~kind:"test_failure" (fun () ->
+        raise (Failure "synthetic-failure"))
+  in
+  match result with
+  | Ok _ -> Alcotest.fail "expected Error, got Ok"
+  | Error msg ->
+      Alcotest.(check bool)
+        "Error message contains [synthetic-failure]"
+        true
+        (try
+           ignore (Str.search_forward (Str.regexp_string "synthetic-failure") msg 0);
+           true
+         with Not_found -> false)
+
+let test_observe_or_fail_reraises_cancelled () =
+  let raised = ref false in
+  (try
+     let _ =
+       Telemetry_observe.observe_or_fail ~kind:"test_cancel" (fun () ->
+           raise (Eio.Cancel.Cancelled (Failure "synthetic-cancel")))
+     in
+     ()
+   with
+  | Eio.Cancel.Cancelled _ -> raised := true);
+  Alcotest.(check bool)
+    "Eio.Cancel.Cancelled was re-raised, not swallowed"
+    true !raised
+
+let test_observe_or_default_returns_value () =
+  let v =
+    Telemetry_observe.observe_or_default ~kind:"test_default_ok"
+      ~default:0 (fun () -> 7)
+  in
+  Alcotest.(check int) "success returns 7" 7 v
+
+let test_observe_or_default_returns_default_on_exception () =
+  let v =
+    Telemetry_observe.observe_or_default ~kind:"test_default_err"
+      ~default:99 (fun () -> raise (Failure "boom"))
+  in
+  Alcotest.(check int) "exception returns default 99" 99 v
+
+let test_observe_or_default_reraises_cancelled () =
+  let raised = ref false in
+  (try
+     let _ =
+       Telemetry_observe.observe_or_default ~kind:"test_default_cancel"
+         ~default:0 (fun () ->
+           raise (Eio.Cancel.Cancelled (Failure "synthetic-cancel")))
+     in
+     ()
+   with
+  | Eio.Cancel.Cancelled _ -> raised := true);
+  Alcotest.(check bool)
+    "observe_or_default also re-raises Cancelled"
+    true !raised
+
+let () =
+  Alcotest.run "telemetry_observe"
+    [
+      ( "observe_or_fail",
+        [
+          Alcotest.test_case "returns Ok on success" `Quick
+            test_observe_or_fail_returns_ok;
+          Alcotest.test_case "returns Error on exception" `Quick
+            test_observe_or_fail_returns_error;
+          Alcotest.test_case "re-raises Eio.Cancel.Cancelled" `Quick
+            test_observe_or_fail_reraises_cancelled;
+        ] );
+      ( "observe_or_default",
+        [
+          Alcotest.test_case "returns value on success" `Quick
+            test_observe_or_default_returns_value;
+          Alcotest.test_case "returns default on exception" `Quick
+            test_observe_or_default_returns_default_on_exception;
+          Alcotest.test_case "re-raises Eio.Cancel.Cancelled" `Quick
+            test_observe_or_default_reraises_cancelled;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Step 15 of the bloodflow restoration plan: invariant test suite. This PR lands the first sub-test, focused on the silent-failure wrapper introduced in Step 0b (\`lib/telemetry_observe.{ml,mli}\`).

## What this PR adds

\`test/test_telemetry_observe.ml\` (Alcotest) — 6 unit tests across 2 groups:

\`\`\`
observe_or_fail
  0   returns Ok on success.
  1   returns Error on exception.
  2   re-raises Eio.Cancel.Cancelled.
observe_or_default
  0   returns value on success.
  1   returns default on exception.
  2   re-raises Eio.Cancel.Cancelled.
\`\`\`

The Cancelled re-raise checks are the load-bearing ones — Step 5 of the plan removes the \`Fun.protect\` catch-all at \`keeper_agent_run.ml:157-164\` and depends on the wrapper preserving cooperative-cancel semantics. Regression here would silently undo Step 5's contract.

## dune wiring

\`test_telemetry_observe\` added to **both** the \`(names ...)\` and \`(modules ...)\` lists in \`test/dune\` (memory: \`feedback_test-dune-names-modules-not-duplicate\` — both lists are required, dedupe across them breaks the build).

## Test plan

- [x] \`dune build test/test_telemetry_observe.exe\` clean.
- [x] \`dune exec test/test_telemetry_observe.exe\` — 6/6 pass in 0.002s.
- [x] Cancelled re-raise verified by raising \`Eio.Cancel.Cancelled (Failure "synthetic-cancel")\` inside the wrapper closure and asserting the outer \`try\` caught it.

## Out of scope (subsequent Step 15 stacks)

- \`test_receipt_invariant.ml\` — depends on Step 3 (Receipt authoritative + fallback DiD).
- \`test_turn_id_propagation.ml\` — round-trips Step 0a propagation.
- \`test_provider_capability_matrix.ml\` — independent.
- \`test_persona_tool_reachability.ml\` — depends on Step 9 (research preset, already merged).

## Cross-reference

- \`lib/telemetry_observe.{ml,mli}\` (Step 0b OCaml half, merged earlier)
- \`scripts/check_silent_failure.sh\` (Step 0b CI half, #11193)
- \`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Step 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)