### PR TITLE
[Step 15 partial] test_keeper_typed_labels — FSM + classifier label uniqueness

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -191,7 +191,8 @@
         test_institution_episodes_failure_learnings_10325
         test_mid_turn_resume
         test_lockfree_atomic
-        test_telemetry_observe)
+        test_telemetry_observe
+        test_keeper_typed_labels)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -353,6 +354,7 @@
           test_mid_turn_resume
           test_lockfree_atomic
           test_telemetry_observe
+          test_keeper_typed_labels
           )
  (libraries masc_test_deps))
 

--- a/test/test_keeper_typed_labels.ml
+++ b/test/test_keeper_typed_labels.ml
@@ -1,0 +1,235 @@
+(** test_keeper_typed_labels — label uniqueness for the keeper-side ADTs
+    landed by the bloodflow restoration plan.
+
+    Step 15 (partial): catches the silent regression where two
+    constructors of the same ADT collapse to the same string label. A
+    label collision would cause Prometheus dimensions to merge across
+    distinct semantic states, hiding the very signal these ADTs were
+    introduced to make legible.
+
+    Coverage:
+    - [Keeper_turn_fsm.cancel_reason] (4 variants, Step 4a)
+    - [Keeper_turn_fsm.failure_reason] (6 variants, Step 4a)
+    - [Keeper_turn_fsm.turn_state]     (10 variants, Step 4a)
+    - [Keeper_contract_classifier.actionable_signal] (4 variants, Step 6a)
+    - [Keeper_contract_classifier.contract_status]   (7 variants, Step 6a)
+    - [Keeper_turn_fsm.pp_failure_reason] surfaces record-bearing fields
+    - [Keeper_contract_classifier.pp_contract_status] surfaces missing list
+*)
+
+open Masc_mcp
+
+(* ── Helpers ─────────────────────────────────────────────────── *)
+
+(** Returns the duplicate labels in a list, or [] if all unique. *)
+let duplicates labels =
+  let seen = Hashtbl.create 16 in
+  List.filter
+    (fun s ->
+      let dup = Hashtbl.mem seen s in
+      Hashtbl.replace seen s ();
+      dup)
+    labels
+
+let format_to_string pp v =
+  let buf = Buffer.create 32 in
+  let fmt = Format.formatter_of_buffer buf in
+  pp fmt v;
+  Format.pp_print_flush fmt ();
+  Buffer.contents buf
+
+(* ── Keeper_turn_fsm.cancel_reason ───────────────────────────── *)
+
+let all_cancel_reasons : Keeper_turn_fsm.cancel_reason list =
+  [
+    Cancelled_supervisor_stop;
+    Cancelled_phase_gate_close;
+    Cancelled_provider_timeout;
+    Cancelled_fleet_shutdown;
+  ]
+
+let test_cancel_reason_labels_unique () =
+  let labels =
+    List.map Keeper_turn_fsm.cancel_reason_label all_cancel_reasons
+  in
+  Alcotest.(check (list string))
+    "no duplicate cancel_reason labels" [] (duplicates labels)
+
+(* ── Keeper_turn_fsm.failure_reason ──────────────────────────── *)
+
+let all_failure_reasons : Keeper_turn_fsm.failure_reason list =
+  [
+    Failure_cascade_unavailable { base = "x"; resolved = None };
+    Failure_provider_error { kind = "k"; detail = "d" };
+    Failure_tool_contract_violation { reason_code = "rc" };
+    Failure_receipt_lost { primary_error = "e"; fallback_path = None };
+    Failure_runtime_error "msg";
+    Failure_unexpected_exception { exn = "exn"; backtrace = None };
+  ]
+
+let test_failure_reason_labels_unique () =
+  let labels =
+    List.map Keeper_turn_fsm.failure_reason_label all_failure_reasons
+  in
+  Alcotest.(check (list string))
+    "no duplicate failure_reason labels" [] (duplicates labels)
+
+let test_pp_failure_reason_includes_payload () =
+  let s =
+    format_to_string Keeper_turn_fsm.pp_failure_reason
+      (Failure_cascade_unavailable
+         { base = "claude_api"; resolved = Some "claude_code" })
+  in
+  Alcotest.(check bool)
+    "pp_failure_reason surfaces base"
+    true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "claude_api") s 0);
+       true
+     with Not_found -> false);
+  Alcotest.(check bool)
+    "pp_failure_reason surfaces resolved"
+    true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "claude_code") s 0);
+       true
+     with Not_found -> false)
+
+(* ── Keeper_turn_fsm.turn_state ──────────────────────────────── *)
+
+let all_turn_states : Keeper_turn_fsm.turn_state list =
+  [
+    Idle;
+    Phase_gating;
+    Cascade_routing;
+    Awaiting_provider;
+    Streaming;
+    Awaiting_tool_result;
+    Completing;
+    Done;
+    Failed (Failure_runtime_error "x");
+    Cancelled Cancelled_supervisor_stop;
+  ]
+
+let test_turn_state_labels_unique () =
+  let labels = List.map Keeper_turn_fsm.turn_state_label all_turn_states in
+  Alcotest.(check (list string))
+    "no duplicate turn_state labels" [] (duplicates labels)
+
+let test_failed_label_carries_reason () =
+  let s =
+    Keeper_turn_fsm.turn_state_label
+      (Failed (Failure_cascade_unavailable { base = "b"; resolved = None }))
+  in
+  Alcotest.(check string)
+    "Failed label uses 'failed:' prefix + reason"
+    "failed:cascade_unavailable" s
+
+let test_cancelled_label_carries_reason () =
+  let s =
+    Keeper_turn_fsm.turn_state_label (Cancelled Cancelled_fleet_shutdown)
+  in
+  Alcotest.(check string)
+    "Cancelled label uses 'cancelled:' prefix + reason"
+    "cancelled:fleet_shutdown" s
+
+(* ── Keeper_contract_classifier.actionable_signal ────────────── *)
+
+let all_actionable_signals
+    : Keeper_contract_classifier.actionable_signal list =
+  [
+    Has_unclaimed_tasks;
+    Has_board_activity;
+    Has_discovered_work;
+    No_actionable_signal;
+  ]
+
+let test_actionable_signal_labels_unique () =
+  let labels =
+    List.map Keeper_contract_classifier.actionable_signal_label
+      all_actionable_signals
+  in
+  Alcotest.(check (list string))
+    "no duplicate actionable_signal labels" [] (duplicates labels)
+
+(* ── Keeper_contract_classifier.contract_status ──────────────── *)
+
+let all_contract_statuses
+    : Keeper_contract_classifier.contract_status list =
+  [
+    Tool_surface_mismatch { missing = [ "x" ] };
+    Missing_required_tool_use;
+    Claim_only_after_owned_task;
+    Needs_execution_progress;
+    Passive_only;
+    Satisfied_completion;
+    Satisfied_execution;
+  ]
+
+let test_contract_status_labels_unique () =
+  let labels =
+    List.map Keeper_contract_classifier.contract_status_label
+      all_contract_statuses
+  in
+  Alcotest.(check (list string))
+    "no duplicate contract_status labels" [] (duplicates labels)
+
+let test_pp_contract_status_surfaces_missing_list () =
+  let s =
+    format_to_string Keeper_contract_classifier.pp_contract_status
+      (Tool_surface_mismatch { missing = [ "keeper_task_claim"; "masc_claim_next" ] })
+  in
+  Alcotest.(check bool)
+    "pp_contract_status surfaces first missing tool"
+    true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "keeper_task_claim") s 0);
+       true
+     with Not_found -> false);
+  Alcotest.(check bool)
+    "pp_contract_status surfaces second missing tool"
+    true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "masc_claim_next") s 0);
+       true
+     with Not_found -> false)
+
+(* ── Test runner ─────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "keeper_typed_labels"
+    [
+      ( "cancel_reason",
+        [
+          Alcotest.test_case "labels unique" `Quick
+            test_cancel_reason_labels_unique;
+        ] );
+      ( "failure_reason",
+        [
+          Alcotest.test_case "labels unique" `Quick
+            test_failure_reason_labels_unique;
+          Alcotest.test_case "pp surfaces payload" `Quick
+            test_pp_failure_reason_includes_payload;
+        ] );
+      ( "turn_state",
+        [
+          Alcotest.test_case "labels unique" `Quick
+            test_turn_state_labels_unique;
+          Alcotest.test_case "Failed carries reason" `Quick
+            test_failed_label_carries_reason;
+          Alcotest.test_case "Cancelled carries reason" `Quick
+            test_cancelled_label_carries_reason;
+        ] );
+      ( "actionable_signal",
+        [
+          Alcotest.test_case "labels unique" `Quick
+            test_actionable_signal_labels_unique;
+        ] );
+      ( "contract_status",
+        [
+          Alcotest.test_case "labels unique" `Quick
+            test_contract_status_labels_unique;
+          Alcotest.test_case "pp surfaces missing list" `Quick
+            test_pp_contract_status_surfaces_missing_list;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Step 15 of the bloodflow restoration plan: invariant test suite. Lands label-uniqueness coverage for the keeper-side ADTs introduced by Steps 4a (\`Keeper_turn_fsm\`) and 6a (\`Keeper_contract_classifier\`).

## Why label uniqueness matters

A label collision (two variants of the same ADT returning the same string from \`*_label\`) would silently merge Prometheus dimensions across distinct semantic states — the very problem the typed ADTs were introduced to eliminate. A future variant rename or addition that trips a collision would compile cleanly but lose observability. This test catches that regression at \`dune test\` time.

## Coverage

| ADT | Variants | Test |
|-----|----------|------|
| \`Keeper_turn_fsm.cancel_reason\` | 4 | labels unique |
| \`Keeper_turn_fsm.failure_reason\` | 6 (record-bearing) | labels unique + pp surfaces payload |
| \`Keeper_turn_fsm.turn_state\` | 10 | labels unique + Failed/Cancelled label composition |
| \`Keeper_contract_classifier.actionable_signal\` | 4 | labels unique |
| \`Keeper_contract_classifier.contract_status\` | 7 | labels unique + pp surfaces missing list |

## Composite-label assertions

The plan's design has \`turn_state_label\` compose Failed/Cancelled labels as \`failed:<reason>\` / \`cancelled:<reason>\` so a single Prometheus dimension covers the full state space without cardinality explosion. This PR pins that composition with two assertions:

\`\`\`ocaml
turn_state_label (Failed (Failure_cascade_unavailable ...))
  = "failed:cascade_unavailable"

turn_state_label (Cancelled Cancelled_fleet_shutdown)
  = "cancelled:fleet_shutdown"
\`\`\`

## Verification

\`\`\`
$ dune exec test/test_keeper_typed_labels.exe
Testing 'keeper_typed_labels'.
  cancel_reason       0   labels unique.
  failure_reason      0   labels unique.
  failure_reason      1   pp surfaces payload.
  turn_state          0   labels unique.
  turn_state          1   Failed carries reason.
  turn_state          2   Cancelled carries reason.
  actionable_signal   0   labels unique.
  contract_status     0   labels unique.
  contract_status     1   pp surfaces missing list.
Test Successful in 0.001s. 9 tests run.
\`\`\`

## dune wiring

\`test_keeper_typed_labels\` added to **both** the \`(names ...)\` and \`(modules ...)\` lists in \`test/dune\` (memory: \`feedback_test-dune-names-modules-not-duplicate\`).

## Test plan

- [x] \`dune build test/test_keeper_typed_labels.exe\` clean.
- [x] \`dune exec test/test_keeper_typed_labels.exe\` — 9/9 pass.
- [x] Failed/Cancelled label composition exact-match asserted.
- [x] pp printers surface payload (cascade base/resolved + missing tool list).

## Cross-reference

- \`lib/keeper/keeper_turn_fsm.{ml,mli}\` (Step 4a, #11184)
- \`lib/keeper/keeper_contract_classifier.{ml,mli}\` (Step 6a, #11172)
- \`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Step 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)