### PR TITLE
feat(dashboard): Sep atomic primitive (atom 10/14, future SSOT, no callsite swap)

### DIFF
--- a/dashboard/src/components/sep.test.ts
+++ b/dashboard/src/components/sep.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Sep, type SepProps } from './sep'
+
+describe('Sep', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    render(null, host)
+    host.remove()
+  })
+
+  function mount(props: SepProps): HTMLElement {
+    render(html`<${Sep} ...${props} />`, host)
+    return host.firstElementChild as HTMLElement
+  }
+
+  // ── Structural ──
+
+  it('emits a div with role=separator', () => {
+    const el = mount({})
+    expect(el.tagName).toBe('DIV')
+    expect(el.getAttribute('role')).toBe('separator')
+  })
+
+  it('defaults to horizontal orientation', () => {
+    const el = mount({})
+    expect(el.getAttribute('data-orientation')).toBe('horizontal')
+    expect(el.getAttribute('aria-orientation')).toBe('horizontal')
+  })
+
+  it('records vertical orientation', () => {
+    const el = mount({ orientation: 'vertical' })
+    expect(el.getAttribute('data-orientation')).toBe('vertical')
+    expect(el.getAttribute('aria-orientation')).toBe('vertical')
+  })
+
+  it('forwards testId to data-testid', () => {
+    const el = mount({ testId: 'group-sep' })
+    expect(el.getAttribute('data-testid')).toBe('group-sep')
+  })
+
+  it('records tone on data-tone', () => {
+    const el = mount({ tone: 'strong' })
+    expect(el.getAttribute('data-tone')).toBe('strong')
+  })
+
+  // ── SPEC geometry ──
+
+  it('horizontal renders 1px height + 100% width', () => {
+    const el = mount({})
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('height: 1px')
+    expect(style).toContain('width: 100%')
+  })
+
+  it('vertical renders 1px width + 16px height', () => {
+    const el = mount({ orientation: 'vertical' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('width: 1px')
+    expect(style).toContain('height: 16px')
+  })
+
+  it('horizontal uses 8px vertical margin (SPEC sp-2)', () => {
+    const el = mount({})
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('margin: 8px 0')
+  })
+
+  it('vertical uses 8px horizontal margin (SPEC sp-2)', () => {
+    const el = mount({ orientation: 'vertical' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('margin: 0px 8px')
+  })
+
+  it('drops margin when noMargin=true', () => {
+    const el = mount({ noMargin: true })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toMatch(/margin:\s*0(px)?\s*;/)
+  })
+
+  // ── Tone ──
+
+  it('horizontal default uses border-default', () => {
+    const el = mount({})
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('background: var(--color-border-default)')
+  })
+
+  it('vertical default uses border-strong (SPEC per-orientation default)', () => {
+    const el = mount({ orientation: 'vertical' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('background: var(--color-border-strong)')
+  })
+
+  it('horizontal with tone=strong upgrades to border-strong', () => {
+    const el = mount({ tone: 'strong' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('background: var(--color-border-strong)')
+  })
+
+  // ── Layout ──
+
+  it('horizontal is display: block', () => {
+    const el = mount({})
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('display: block')
+  })
+
+  it('vertical is display: inline-block (drops between siblings)', () => {
+    const el = mount({ orientation: 'vertical' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('display: inline-block')
+  })
+
+  it('vertical has flex-shrink: 0 (survives flex squeeze)', () => {
+    const el = mount({ orientation: 'vertical' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('flex-shrink: 0')
+  })
+})

--- a/dashboard/src/components/sep.ts
+++ b/dashboard/src/components/sep.ts
@@ -1,0 +1,108 @@
+// Sep — atomic primitive ported from design-system v0.4 primitives.html
+// (SPEC `.sep-v` / `.sep-h`). Two orientations:
+//
+//   sep-v  — 1px wide × 16px tall vertical bar with 8px horizontal
+//            margin. Drops between inline siblings inside a flex row
+//            (keyboard shortcut hint groups, action button clusters,
+//            breadcrumb separators).
+//   sep-h  — 1px tall horizontal hairline with 8px vertical margin.
+//            Drops between block siblings inside a stacked card or
+//            list (between two paragraph blocks, between a description
+//            and an action row).
+//
+// Distinct from sibling primitives:
+//
+//   Band (band.ts)        — 2px decorative state strip at top of a
+//                            card. Carries kind tone, never neutral.
+//                            Sep is *neutral*, no kind, no state.
+//   Bar (bar.ts)          — 4px progress fill. Conveys quantity, not
+//                            adjacency.
+//   Tailwind `divide-y`   — between-children divider applied via
+//                            parent. Different mechanism (no element
+//                            in the DOM, can't carry margin/spacing
+//                            independently). Sep is a *self-contained
+//                            element* between two adjacent siblings.
+//
+// Why a new atom even though dashboard has no current `w-px h-N`
+// callsites: Sep is a foundational SSOT for the inline-divider intent.
+// Future atoms (key-cap groups, breadcrumb rows, stat-row separators)
+// will need this primitive — introducing it now lets follow-up sweeps
+// reach for `<Sep />` instead of inventing yet another `w-px h-3
+// bg-[var(--color-border-strong)]` chain.
+//
+// SPEC mapping (primitives.css `.sep-v` / `.sep-h`):
+//   .sep-v  width 1px, height 16px, bg --color-border-strong,
+//           margin 0 var(--sp-2)
+//   .sep-h  height 1px, bg --color-border-default,
+//           margin var(--sp-2) 0
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+
+export interface SepProps {
+  /** Orientation. `vertical` = 1px wide × 16px tall (inline row).
+   *  `horizontal` = 1px tall (block stack). Default `horizontal`. */
+  orientation?: 'horizontal' | 'vertical'
+  /** Tone. SPEC defines border-strong for vertical, border-default
+   *  for horizontal — preserved as the per-orientation default. Use
+   *  `strong` to force the heavier tone on a horizontal sep, or vice
+   *  versa, when adjacent context calls for it. */
+  tone?: 'default' | 'strong'
+  /** Drop the SPEC margin (8px on the cross axis). Use when the
+   *  parent layout already provides the gap (flex-gap / space-y-N) or
+   *  when the separator should hug its siblings. Default false. */
+  noMargin?: boolean
+  /** Forwarded to data-testid. */
+  testId?: string
+}
+
+export function Sep(props: SepProps): VNode {
+  const orientation = props.orientation ?? 'horizontal'
+  const tone = props.tone ?? 'default'
+
+  // SPEC defaults:
+  //   vertical → border-strong (inline rows want a heavier tone so
+  //              the eye can resolve the boundary between dense
+  //              sibling clusters)
+  //   horizontal → border-default (block stacks already have generous
+  //                whitespace; a softer tone reads as "section break")
+  const defaultColor = orientation === 'vertical'
+    ? 'var(--color-border-strong)'
+    : 'var(--color-border-default)'
+  const strongColor = 'var(--color-border-strong)'
+  const background = tone === 'strong' ? strongColor : defaultColor
+
+  const isVertical = orientation === 'vertical'
+  const margin = props.noMargin === true
+    ? '0'
+    : isVertical ? '0 8px' : '8px 0'
+
+  const style = isVertical
+    ? {
+        display: 'inline-block',
+        width: '1px',
+        height: '16px',
+        background,
+        margin,
+        flexShrink: 0,
+        verticalAlign: 'middle' as const,
+      }
+    : {
+        display: 'block',
+        height: '1px',
+        width: '100%',
+        background,
+        margin,
+      }
+
+  return html`
+    <div
+      role="separator"
+      aria-orientation=${orientation}
+      data-testid=${props.testId}
+      data-orientation=${orientation}
+      data-tone=${tone}
+      style=${style}
+    ></div>
+  `
+}


### PR DESCRIPTION
## Why — atom score 9/14 → 10/14, **10/14 (71%) 도달**

열 번째 atom. SPEC `.sep-v` / `.sep-h` 의 dashboard 도입.

### 사용자 *"중복 검사"* 패턴 적용 결과

| 카테고리 | 결과 |
|---|---|
| 다른 의도 — 격리 | `inline-spinner`, `sparkline`, `kbd`, `status-{badge,chip,dot}` |
| Tailwind 메커니즘 | `divide-y` — parent-applied between-children rule, 자체 element 부재. Sep 의 *self-contained* + 마진/톤 독립 와 다름 |
| **중복 부재** | dashboard 에 separator/divider primitive 없음 — **진짜 첫 atom 도입** |

### Adoption disclosure (정직)

dashboard 에 현재 `w-px h-N` callsite **0건**. 본 PR 는 **atom-only** — 미래 sweep (key-cap groups / breadcrumb rows / stat-row separators) 가 `<Sep />` 로 reach 할 수 있도록 SSOT 선제 마련. **이 PR 의 visible delta = 0**, 가치는 *미래 SSOT 가용성*.

빠른 진행 + 정직 disclosure 우선. visible delta 큰 다음 atom 은 follow-up cycle 에서.

## 변경

| 파일 | 변경 |
|---|---|
| `dashboard/src/components/sep.ts` (신규) | Atomic Sep primitive. SPEC API 1:1 (`<div class="sep-v">` / `<div class="sep-h">` ↔ `<Sep orientation="vertical" />` / `<Sep />`) |
| `dashboard/src/components/sep.test.ts` (신규) | 16 cases: structural (role=separator + aria-orientation), SPEC geometry (1px sizing per orientation, 8px margin), tone (per-orientation default + strong upgrade), layout (block vs inline-block + flex-shrink:0) |

### SPEC API 매핑

| SPEC | Sep prop |
|---|---|
| `<div class="sep-v">` | `<Sep orientation="vertical" />` |
| `<div class="sep-h">` | `<Sep />` (horizontal default) |
| width 1px / height 16px (v) | hard-coded |
| height 1px / width 100% (h) | hard-coded |
| `margin: 0 var(--sp-2)` (v) | hard-coded `0 8px` (`noMargin` opt-out) |
| `margin: var(--sp-2) 0` (h) | hard-coded `8px 0` (`noMargin` opt-out) |
| border-strong (v default) / border-default (h default) | per-orientation default + `tone="strong"` opt-in |
| no aria | `role="separator"` + `aria-orientation` |

### Visual fidelity: **100% SPEC 정합**

dashboard 런타임의 기존 token 만 사용 (`--color-border-default`, `--color-border-strong`). glow channel 불필요.

## 검증

- `pnpm exec tsc --noEmit` — clean (EXIT 0)
- `pnpm exec vitest run sep` — **16/16 passed**

## 다음 cycle 후보

| 옵션 | 내용 |
|---|---|
| **A** | 다음 atom 더 — **Keycap** (Kbd 와 SPEC 정합 비교), **Density / Grid** (사용자 캡처 image 4 명시) |
| **B** | 사용자 캡처 image 4 의 **cb-group-g state primitives** (empty/loading/error) — visible delta 큼 |
| **C** | Sep 활용 — 새 sweep 에서 key-cap groups / breadcrumb 도입 시 적용 |
| **D** | 누적 atom 의 **추가 callsite sweep** — Tk 의 나머지 3 variants, Surf 의 RemoteWarningBanner / 6 text-only sites |

## Self-review (best-programmer)

- 목표: atom score 9/14 → 10/14. 미래 SSOT 마련 + visible delta 0 정직 disclosure
- 변경 범위: 2 파일, +236 라인. primitive 정의 + 16 단위 test
- 검증: tsc clean + 16 vitest green
- 미검증: 시각 (적용처 없으므로 dev server 도 검증 불가)
- 정직 disclosure: **visible delta 0** — atom score 진행 가치만, 사용자 화면 변화 없음. 다음 cycle 에서 visible delta 큰 atom 진행 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
