### PR TITLE
chore(exec): annotate bash_history close-cleanup as @observe-allowed

### DIFF
--- a/lib/exec/bash_history.ml
+++ b/lib/exec/bash_history.ml
@@ -55,10 +55,10 @@ let failure_pattern_to_json = function
 (* --- helpers --- *)
 
 let close_out_no_err oc =
-  try close_out oc with _ -> ()
+  try close_out oc with _ -> () (* @observe-allowed: file-close cleanup *)
 
 let close_in_no_err ic =
-  try close_in ic with _ -> ()
+  try close_in ic with _ -> () (* @observe-allowed: file-close cleanup *)
 
 let mkdir_p path =
   let rec aux built = function


### PR DESCRIPTION
## Summary

The two \`try ... with _ -> ()\` sites in \`lib/exec/bash_history.ml\` are file-handle close cleanups — both flagged by \`scripts/check_silent_failure.sh\` (introduced in #11193) as the only baseline silent-failure anti-pattern hits in lib/. This PR annotates them \`@observe-allowed: file-close cleanup\` so the lint baseline reaches zero, unlocking \`--strict\` mode.

## Why \`@observe-allowed\`, not \`Telemetry_observe.observe_or_fail\`

\`close_out\` / \`close_in\` failures are not a fault to surface:

1. There is no upstream consumer of the failure — the helper is called from finally-style cleanup, not from a path that propagates \`Result\`.
2. The exception thrown (\`Sys_error\` on a double-close) is an idempotency concern, not a defect — there is nothing for the caller to do with it.

The \`[@observe-allowed: <reason>]\` marker was introduced in the check_silent_failure.sh CI lint precisely for sites like this — intentionally silent paths whose justification a reviewer can verify inline.

## After this commit

\`\`\`
$ scripts/check_silent_failure.sh
check_silent_failure: 0 silent-failure anti-pattern site(s) found.
\`\`\`

A follow-up can flip CI to \`--strict\` so any new silent-failure pattern blocks merge.

## Test plan

- [x] \`dune build lib/exec/bash_history.ml\` clean (only comments changed).
- [x] \`scripts/check_silent_failure.sh\` reports 0 sites.

## Cross-reference

- \`scripts/check_silent_failure.sh\` (#11193)
- \`lib/telemetry_observe.{ml,mli}\` (Step 0b OCaml half)

🤖 Generated with [Claude Code](https://claude.com/claude-code)