### PR TITLE
feat(dashboard_bonsai): Pill 100% SPEC fidelity verify (capsule + glow + a11y)

### DIFF
--- a/dashboard_bonsai/src/pill.ml
+++ b/dashboard_bonsai/src/pill.ml
@@ -1,22 +1,53 @@
-(** Pill primitive — MASC Design System 상태 pill.
+(** Pill — atomic primitive (Bonsai mirror of Preact [pill.ts]).
 
-    Archive_runs (status pill 6 variant) 와 Goals (status_pill) 에서
-    반복되던 border + uppercase + letter-spacing 박스를 하나로 통합.
+    Visual contract = SPEC §3.5 stateful surface + Preact
+    [dashboard/src/components/pill.ts] (PR #11157).
 
-    [size] 는 탭별 밀도 차이를 수용:
-    - [`Md] : font 11px / padding 4px 8px  (archive_runs 기본)
-    - [`Sm] : font 11px / padding 2px 6px  (goals inline compact)
+    Pill is the *stateful* sibling of Chip: same monospace-uppercase
+    family, but rendered as a 16px capsule (rounded `border-radius:
+    999px`, no border) with a translucent kind-tinted background at
+    0.12 alpha. Use Pill when a thing transitions between states
+    (running → paused, ok → warn). Use Chip for static labels.
 
-    [color] 는 Meta와 동일한 4색 + status-specific 2색:
-    - [`Ok]      live/active/running        (status-ok, green)
-    - [`Warn]    paused                     (status-warn, amber)
-    - [`Bad]     failed/dead                (accent-blood)
-    - [`Brass]   completed/done             (accent-brass)
-    - [`Paused]  stopped/skipped            (text-dim)
-    - [`Neutral] unknown/fallback           (border-main base only)
+    {1 Kind mapping}
 
-    탭별 status enum → color 매핑은 caller 책임. primitive는 색만
-    주입한다. *)
+    Eight kinds, mirroring Preact + a [`Brass] extension retained for
+    Bonsai legacy callers (archive_runs, goals):
+
+    - [`Neutral]: chromeless baseline, fg-secondary on bg-elevated.
+    - [`Running]: accent-glow tint (matches `--color-accent-glow`).
+    - [`Paused]: chromeless muted state (no glow, fg-muted).
+    - [`Ok | `Warn | `Err | `Info | `Stalled]: status semantics with
+      [rgb(var(--color-status-{kind}-glow) / 0.12)] translucent
+      backgrounds (consume the glow tokens introduced in #11163).
+    - [`Brass]: Bonsai-only highlighted accent (used by archive_runs
+      "Completed" state). Uses [--color-accent-glow] triplet with
+      [--color-accent-fg] foreground. Not present in Preact reference;
+      retained here so the existing call sites (archive_runs_view,
+      goals_view) keep working without code churn.
+
+    {1 Dot variant}
+
+    Optional 5px round leading dot in the kind color. Auto-suppressed
+    when [kind = `Neutral] (no semantic state to flag), mirroring
+    Preact behavior.
+
+    {1 Backwards compatibility}
+
+    Existing call sites use the legacy [~color] / [~size] surface
+    ([`Ok | `Warn | `Bad | `Brass | `Paused | `Neutral] with [`Sm |
+    `Md] sizes). Both legacy types remain; [`color] maps to [kind] via
+    [color_to_kind] ([`Bad → `Err]). [size] is preserved but the new
+    Preact-aligned default ([`Md]) renders the SPEC 16px capsule;
+    [`Sm] keeps a 14px compact variant for the goals tab.
+
+    {1 Accessibility}
+
+    - [role="status"] when kind is non-neutral so screen readers
+      announce state transitions.
+    - Computed [aria-label] with kind suffix ("RUNNING (running)"),
+      override via [?aria_label].
+    - Optional [?title] for hover tooltips, [?testid] for E2E. *)
 
 open! Core
 open! Bonsai_web
@@ -26,78 +57,264 @@ module Style =
 [%css
 stylesheet
   {|
-  .pill_md {
-    font-family: 'JetBrains Mono', ui-monospace, monospace;
-    font-size: 11px;
-    letter-spacing: 0.16em;
+  .pill_base {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    line-height: 1;
+    border-radius: 999px;
+    letter-spacing: 0.04em;
     text-transform: uppercase;
-    padding: 4px 8px;
-    text-align: center;
-    border: 1px solid var(--color-border-default, #3a2e20);
-    font-variant-numeric: tabular-nums;
-    color: var(--color-fg-muted, #9a846e);
+    font-weight: 500;
+    white-space: nowrap;
   }
 
-  .pill_sm {
-    font-family: 'JetBrains Mono', ui-monospace, monospace;
-    font-size: 11px;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    padding: 2px 6px;
-    border: 1px solid var(--color-border-default, #3a2e20);
-    text-align: center;
+  .size_sm { height: 14px; padding: 0 7px; font-size: 9px;  }
+  .size_md { height: 16px; padding: 0 8px; font-size: 10px; }
+
+  .k_neutral {
+    color: var(--color-fg-secondary, #c0a878);
+    background: var(--color-bg-elevated, #1a1410);
+  }
+  .k_running {
+    color: var(--color-accent-fg, #968228);
+    background: rgb(var(--color-accent-glow, 150 130 40) / 0.12);
+  }
+  .k_paused {
     color: var(--color-fg-muted, #9a846e);
+    background: var(--color-bg-elevated, #1a1410);
+  }
+  .k_ok {
+    color: var(--color-status-ok, #6a9a4a);
+    background: rgb(var(--color-status-ok-glow, 106 154 74) / 0.12);
+  }
+  .k_warn {
+    color: var(--color-status-warn, #b87828);
+    background: rgb(var(--color-status-warn-glow, 184 120 40) / 0.12);
+  }
+  .k_err {
+    color: var(--color-status-err, #e85050);
+    background: rgb(var(--color-status-err-glow, 232 80 80) / 0.12);
+  }
+  .k_info {
+    color: var(--color-status-info, #968228);
+    background: rgb(var(--color-status-info-glow, 150 130 40) / 0.12);
+  }
+  .k_stalled {
+    color: var(--color-status-stalled, #8a6abf);
+    background: rgb(var(--color-status-stalled-glow, 138 106 191) / 0.12);
+  }
+  .k_brass {
+    color: var(--color-accent-fg, #968228);
+    background: rgb(var(--color-accent-glow, 150 130 40) / 0.12);
   }
 
-  .c_ok      { color: var(--color-status-ok, #6a9a4a); border-color: var(--color-status-ok, #6a9a4a); }
-  .c_warn    { color: var(--color-status-warn, #b87828); border-color: var(--color-status-warn, #b87828); }
-  .c_bad     { color: var(--accent-blood, #e85050); border-color: var(--accent-blood, #e85050); }
-  .c_brass   { color: var(--color-accent-fg, #968228); border-color: var(--color-accent-fg, #968228); }
-  .c_paused  { color: var(--color-fg-muted, #9a846e); border-color: var(--color-border-default, #3a2e20); }
-  .c_neutral { color: var(--color-fg-muted, #9a846e); border-color: var(--color-border-default, #3a2e20); }
+  .dot {
+    display: inline-block;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .dot_running { background: var(--color-accent-fg, #968228); }
+  .dot_paused  { background: var(--color-fg-muted, #9a846e); }
+  .dot_ok      { background: var(--color-status-ok, #6a9a4a); }
+  .dot_warn    { background: var(--color-status-warn, #b87828); }
+  .dot_err     { background: var(--color-status-err, #e85050); }
+  .dot_info    { background: var(--color-status-info, #968228); }
+  .dot_stalled { background: var(--color-status-stalled, #8a6abf); }
+  .dot_brass   { background: var(--color-accent-fg, #968228); }
 
   @media (prefers-contrast: more) {
-    .pill_md, .pill_sm {
-      border-width: 2px;
-      border-color: var(--text-bright);
-    }
-    .c_ok      { border-color: var(--color-status-ok); }
-    .c_warn    { border-color: var(--color-status-warn); }
-    .c_bad     { border-color: var(--accent-blood); }
-    .c_brass   { border-color: var(--color-accent-fg); }
-    .c_paused  { border-color: var(--color-fg-muted); }
-    .c_neutral { border-color: var(--color-fg-muted); }
+    .pill_base { border: 1px solid var(--text-bright); }
+    .k_neutral { border-color: var(--text-bright); }
+    .k_running { border-color: var(--color-accent-fg); }
+    .k_paused  { border-color: var(--color-fg-muted); }
+    .k_ok      { border-color: var(--color-status-ok); }
+    .k_warn    { border-color: var(--color-status-warn); }
+    .k_err     { border-color: var(--color-status-err); }
+    .k_info    { border-color: var(--color-status-info); }
+    .k_stalled { border-color: var(--color-status-stalled); }
+    .k_brass   { border-color: var(--color-accent-fg); }
   }
 
   @media (forced-colors: active) {
-    .pill_md, .pill_sm { border-color: ButtonText; }
-    .c_ok      { border-color: Highlight; color: Highlight; }
-    .c_warn    { border-color: Mark; color: Mark; }
-    .c_bad     { border-color: MarkText; color: MarkText; }
-    .c_brass   { border-color: ButtonText; }
-    .c_paused  { border-color: GrayText; color: GrayText; }
-    .c_neutral { border-color: GrayText; color: GrayText; }
+    .pill_base { border: 1px solid ButtonText; }
+    .k_neutral { border-color: GrayText; color: GrayText; }
+    .k_running { border-color: Highlight; color: Highlight; }
+    .k_paused  { border-color: GrayText; color: GrayText; }
+    .k_ok      { border-color: Highlight; color: Highlight; }
+    .k_warn    { border-color: Mark; color: Mark; }
+    .k_err     { border-color: MarkText; color: MarkText; }
+    .k_info    { border-color: Highlight; color: Highlight; }
+    .k_stalled { border-color: ButtonText; color: ButtonText; }
+    .k_brass   { border-color: ButtonText; color: ButtonText; }
   }
 |}]
 
-type size = [ `Sm | `Md ]
-type color = [ `Ok | `Warn | `Bad | `Brass | `Paused | `Neutral ]
+type kind =
+  [ `Neutral
+  | `Running
+  | `Paused
+  | `Ok
+  | `Warn
+  | `Err
+  | `Info
+  | `Stalled
+  | `Brass
+  ]
 
-let view ?(size : size = `Md) ?(color : color = `Neutral)
-      ~(label : string) () : Node.t =
-  let base =
-    match size with
-    | `Md -> Style.pill_md
-    | `Sm -> Style.pill_sm
+(** Legacy color polyvar kept so existing callers (archive_runs_view,
+    goals_view, keepers_directory) compile unchanged. [`Bad] is the
+    historical name for [`Err]. *)
+type color =
+  [ `Ok
+  | `Warn
+  | `Bad
+  | `Brass
+  | `Paused
+  | `Neutral
+  ]
+
+type size =
+  [ `Sm
+  | `Md
+  ]
+
+let color_to_kind : color -> kind = function
+  | `Ok -> `Ok
+  | `Warn -> `Warn
+  | `Bad -> `Err
+  | `Brass -> `Brass
+  | `Paused -> `Paused
+  | `Neutral -> `Neutral
+;;
+
+let kind_class : kind -> Attr.t = function
+  | `Neutral -> Style.k_neutral
+  | `Running -> Style.k_running
+  | `Paused -> Style.k_paused
+  | `Ok -> Style.k_ok
+  | `Warn -> Style.k_warn
+  | `Err -> Style.k_err
+  | `Info -> Style.k_info
+  | `Stalled -> Style.k_stalled
+  | `Brass -> Style.k_brass
+;;
+
+let size_class : size -> Attr.t = function
+  | `Sm -> Style.size_sm
+  | `Md -> Style.size_md
+;;
+
+let kind_data_attr : kind -> string = function
+  | `Neutral -> "neutral"
+  | `Running -> "running"
+  | `Paused -> "paused"
+  | `Ok -> "ok"
+  | `Warn -> "warn"
+  | `Err -> "err"
+  | `Info -> "info"
+  | `Stalled -> "stalled"
+  | `Brass -> "brass"
+;;
+
+(** [`Neutral] suppresses dot (no semantic state to flag). Mirrors
+    Preact behavior where [showDot = props.dot === true && kind !==
+    'neutral']. *)
+let dot_attr : kind -> Attr.t option = function
+  | `Neutral -> None
+  | `Running -> Some Style.dot_running
+  | `Paused -> Some Style.dot_paused
+  | `Ok -> Some Style.dot_ok
+  | `Warn -> Some Style.dot_warn
+  | `Err -> Some Style.dot_err
+  | `Info -> Some Style.dot_info
+  | `Stalled -> Some Style.dot_stalled
+  | `Brass -> Some Style.dot_brass
+;;
+
+let kind_announce : kind -> string option = function
+  | `Neutral -> None
+  | `Running -> Some "running"
+  | `Paused -> Some "paused"
+  | `Ok -> Some "ok"
+  | `Warn -> Some "warning"
+  | `Err -> Some "failing"
+  | `Info -> Some "info"
+  | `Stalled -> Some "stalled"
+  | `Brass -> Some "completed"
+;;
+
+(** Pure: assemble the screen-reader label. [`Neutral] returns content
+    as-is; stateful kinds append "(<announce>)" suffix. Mirrors Preact
+    [pillAriaLabel]. *)
+let aria_label_of ?aria_label ~(kind : kind) (label : string) : string =
+  match aria_label with
+  | Some explicit -> explicit
+  | None ->
+    (match kind_announce kind with
+     | None -> label
+     | Some suffix -> label ^ " (" ^ suffix ^ ")")
+;;
+
+let view
+      ?(size : size = `Md)
+      ?(color : color = `Neutral)
+      ?(kind : kind option)
+      ?(dot : bool = false)
+      ?testid
+      ?aria_label
+      ?title
+      ~(label : string)
+      ()
+  : Node.t
+  =
+  let resolved_kind : kind =
+    match kind with
+    | Some k -> k
+    | None -> color_to_kind color
   in
-  let c =
-    match color with
-    | `Ok -> Style.c_ok
-    | `Warn -> Style.c_warn
-    | `Bad -> Style.c_bad
-    | `Brass -> Style.c_brass
-    | `Paused -> Style.c_paused
-    | `Neutral -> Style.c_neutral
+  let show_dot = dot && not (Poly.equal resolved_kind `Neutral) in
+  let aria = aria_label_of ?aria_label ~kind:resolved_kind label in
+  let role_attr =
+    if Poly.equal resolved_kind `Neutral
+    then []
+    else [ Attr.create "role" "status" ]
   in
-  Node.span ~attrs:[ base; c ] [ Node.text label ]
+  let testid_attr =
+    match testid with
+    | Some t -> [ Attr.create "data-testid" t ]
+    | None -> []
+  in
+  let title_attr =
+    match title with
+    | Some t -> [ Attr.create "title" t ]
+    | None -> []
+  in
+  let attrs =
+    [ Style.pill_base
+    ; size_class size
+    ; kind_class resolved_kind
+    ; Attr.create "data-kind" (kind_data_attr resolved_kind)
+    ; Attr.create "aria-label" aria
+    ]
+    @ role_attr
+    @ testid_attr
+    @ title_attr
+  in
+  let dot_node =
+    if show_dot
+    then (
+      match dot_attr resolved_kind with
+      | Some d ->
+        [ Node.span
+            ~attrs:[ Style.dot; d; Attr.create "aria-hidden" "true" ]
+            []
+        ]
+      | None -> [])
+    else []
+  in
+  Node.span ~attrs (dot_node @ [ Node.text label ])
 ;;

--- a/dashboard_bonsai/src/pill.mli
+++ b/dashboard_bonsai/src/pill.mli
@@ -1,0 +1,73 @@
+(** Pill — atomic primitive (Bonsai mirror of Preact [pill.ts]).
+
+    Visual contract = SPEC §3.5 stateful surface + Preact PR #11157.
+    16px capsule, translucent kind-tinted background at 0.12 alpha,
+    optional 5px leading dot, computed [aria-label] / [role="status"].
+
+    See [pill.ml] for full visual contract documentation including
+    kind semantics and the Bonsai-only [`Brass] extension retained
+    for legacy callers. *)
+
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+(** SPEC kinds (8 total). Mirrors Preact [PillKind] = neutral |
+    running | paused | ok | warn | err | info | stalled, plus
+    Bonsai-only [`Brass] for archive_runs "Completed" state. *)
+type kind =
+  [ `Neutral
+  | `Running
+  | `Paused
+  | `Ok
+  | `Warn
+  | `Err
+  | `Info
+  | `Stalled
+  | `Brass
+  ]
+
+(** Legacy color polyvar kept for backwards compatibility with
+    archive_runs_view, goals_view, keepers_directory. New code should
+    use [~kind] directly. [`Bad] maps to [`Err]. *)
+type color =
+  [ `Ok
+  | `Warn
+  | `Bad
+  | `Brass
+  | `Paused
+  | `Neutral
+  ]
+
+(** Density selector. [`Md] (default) = 16px capsule per SPEC. [`Sm]
+    = 14px compact variant for inline-dense tabs (goals). *)
+type size =
+  [ `Sm
+  | `Md
+  ]
+
+(** [view ~label ()] renders an inline pill span.
+
+    Kind selection precedence: [~kind] (new API) wins over [~color]
+    (legacy). Default = [`Neutral] (chromeless baseline).
+
+    [?dot] (default [false]): when [true] and kind is non-neutral,
+    prepends a 5px round dot in the kind color. Auto-suppressed for
+    [`Neutral] (no semantic state to flag).
+
+    [?testid]: forwarded to [data-testid] for E2E selectors.
+
+    [?aria_label]: overrides the auto-generated label
+    ("LABEL (kind)"); pass when the host already conveys state.
+
+    [?title]: native hover tooltip. *)
+val view
+  :  ?size:size
+  -> ?color:color
+  -> ?kind:kind
+  -> ?dot:bool
+  -> ?testid:string
+  -> ?aria_label:string
+  -> ?title:string
+  -> label:string
+  -> unit
+  -> Node.t


### PR DESCRIPTION
## Summary

Audit of `dashboard_bonsai/src/pill.ml` against the Preact reference (`dashboard/src/components/pill.ts`, PR #11157) found substantial visual + API gaps. The previous Bonsai pill rendered a rectangular bordered chip-like span; SPEC requires a 16px capsule with translucent kind-tinted background. This PR brings Bonsai pill to 100% SPEC fidelity while keeping legacy callers (`archive_runs_view`, `goals_view`, `keepers_directory`) compiling unchanged.

## Gap analysis

| Aspect | Before (Bonsai) | After (matches Preact) |
|---|---|---|
| Shape | 1px border rectangle | chromeless 16px capsule (`border-radius: 999px`) |
| Background | transparent | `rgb(var(--color-{kind}-glow) / 0.12)` for stateful kinds |
| Font | 11px JetBrains Mono | 10px ui-monospace stack |
| Letter-spacing | 0.16em | 0.04em |
| Kinds | 6 (Ok/Warn/Bad/Brass/Paused/Neutral) | 9 (Neutral/Running/Paused/Ok/Warn/Err/Info/Stalled/Brass) |
| Dot variant | absent | 5px leading dot, auto-suppressed for Neutral |
| A11y | none | `role="status"` for stateful kinds, computed `aria-label`, `data-kind`, `data-testid`, `title` |
| `.mli` | absent | full interface |

## Decision: substantial upgrade (not no-op)

The previous Bonsai pill was visually a different component (rectangular bordered chip-like). It needed full reconstruction to match the Preact 16px capsule + translucent glow + a11y contract from PR #11157.

## Backwards compatibility

Legacy callers continue to compile unchanged. The `~color` polyvar (`Bad -> Err`) and `~size` polyvar are retained; the new `~kind` labelled arg takes precedence when given.

The `Brass` extension is kept as Bonsai-only because `archive_runs_view` uses it for the "Completed" state (no Preact equivalent). It mirrors `Running` visually (uses `--color-accent-glow`).

## Token strategy

Mirrors the `chip.ml` strategy (PR #11181): inline rgb-triplet fallbacks (e.g. `rgb(var(--color-status-ok-glow, 106 154 74) / 0.12)`) because `dashboard_bonsai/static/colors_and_type.css` does not currently define the `status-{kind}-glow` tokens as rgb triplets — the fallback triplets keep visuals correct while the token system catches up. No inline hex outside `var(--color-*, #fallback)` form.

## Test plan

- [x] `dune build --root dashboard_bonsai` for `Pill.cmx` is green
- [x] `dune build --profile=release` for `Pill` + `Archive_runs_view` + `Goals_view` is green (verifies legacy callers still type-check)
- [ ] Visual smoke: render Pill in `/dashboard/b/hello` and confirm 16px capsule + glow background appears
- [ ] A11y smoke: VoiceOver announces "RUNNING (running)" pattern for stateful kinds

Pre-existing build errors in `overview_view.ml:393`, `ctx_chart.ml:239`, `keepers_directory.ml:436` (`Attr.on_key_down`) are unrelated to this change and present in `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)