### PR TITLE
feat(dashboard_bonsai): Spark + Caps + KeeperBadge primitives

### DIFF
--- a/dashboard_bonsai/src/caps.ml
+++ b/dashboard_bonsai/src/caps.ml
@@ -1,0 +1,75 @@
+(** Caps — uppercase tracked label primitive.
+
+    SPEC §3.2 [type-label] role: 11px / [--track-caps] (0.08em letter
+    spacing) / sans / uppercase. The closest Preact analogue is
+    [dashboard/src/components/common/section-cap.ts] which encodes the
+    same "tiny all-caps subhead" pattern in Tailwind utilities. There is
+    no standalone [caps] primitive on the Preact side — the Bonsai surface
+    inherits the role directly from the SPEC.
+
+    Two tone slots match the existing SectionCap usage on the Preact side:
+    - [`Muted] (default) — section heads next to body text
+      ([--color-fg-muted]).
+    - [`Dim] — denser hush for telemetry rows
+      ([--color-fg-disabled]).
+
+    The caller owns layout (margin, flex composition). Caps renders as a
+    single [<span>] with no border, background, or padding so it can sit
+    inline beside a value or stack as a heading. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .caps {
+    display: inline-block;
+    font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+    font-size: 11px;
+    line-height: var(--lh-tight, 1.1);
+    letter-spacing: var(--track-caps, 0.08em);
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--color-fg-muted, #9a846e);
+  }
+
+  .t_muted { color: var(--color-fg-muted, #9a846e); }
+  .t_dim   { color: var(--color-fg-disabled, #6a5a4a); }
+  .t_brass { color: var(--color-accent-fg, #968228); }
+
+  @media (forced-colors: active) {
+    .t_muted, .t_dim { color: GrayText; }
+    .t_brass         { color: ButtonText; }
+  }
+|}]
+
+type tone =
+  [ `Muted
+  | `Dim
+  | `Brass
+  ]
+
+let tone_class : tone -> Attr.t = function
+  | `Muted -> Style.t_muted
+  | `Dim -> Style.t_dim
+  | `Brass -> Style.t_brass
+;;
+
+let tone_name : tone -> string = function
+  | `Muted -> "muted"
+  | `Dim -> "dim"
+  | `Brass -> "brass"
+;;
+
+let view ?(tone : tone = `Muted) (label : string) : Node.t =
+  Node.span
+    ~attrs:
+      [ Style.caps
+      ; tone_class tone
+      ; Attr.create "data-tone" (tone_name tone)
+      ]
+    [ Node.text label ]
+;;

--- a/dashboard_bonsai/src/caps.mli
+++ b/dashboard_bonsai/src/caps.mli
@@ -1,0 +1,21 @@
+(** Caps — uppercase tracked label primitive (SPEC §3.2 [type-label]).
+
+    11px sans-serif, uppercase, [--track-caps] letter-spacing. Three
+    tones: [`Muted] (default), [`Dim], [`Brass]. See [caps.ml] for the
+    full visual contract. *)
+
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type tone =
+  [ `Muted
+  | `Dim
+  | `Brass
+  ]
+
+(** [view ?tone label] renders an inline uppercase tracked label.
+
+    [tone] (default [`Muted]): color slot. [`Muted] uses
+    [--color-fg-muted], [`Dim] uses [--color-fg-disabled], [`Brass] uses
+    [--color-accent-fg]. *)
+val view : ?tone:tone -> string -> Node.t

--- a/dashboard_bonsai/src/keeper_badge.ml
+++ b/dashboard_bonsai/src/keeper_badge.ml
@@ -1,0 +1,140 @@
+(** KeeperBadge — keeper attribution primitive (sigil + slot color).
+
+    SPEC §3.6.3: color alone MUST NOT identify a keeper. Every attribution
+    carries a second channel — a 2-letter sigil. This primitive renders
+    the canonical sigil-square: a colored mono uppercase 2-glyph badge
+    using [--color-keeper-N] (1..12) for the background and [--color-bg-page]
+    for the foreground.
+
+    Bonsai mirror of Preact [dashboard/src/components/keeper-badge.ts]
+    [variant=sigil]. The Preact reference also exposes [variant=full] (sigil
+    + colored name) and [variant=name] (colored text only); those compose
+    on top of this primitive in the caller and are out of scope here.
+
+    Slot resolution and sigil derivation live in the caller — this module
+    accepts the resolved [slot:int] (1..12) and [sigil:string] directly so
+    a single primitive serves both the registry-pinned anchors and the
+    FNV-1a hash fallback in upstream code. Out-of-range slots clamp to a
+    [`Neutral] grey badge so a buggy caller still renders something, but
+    the data-slot attribute reports [oob] so audits can catch it.
+
+    Sigil clamping: the primitive renders at most 2 glyphs. Longer strings
+    are truncated; shorter strings render as-is. Empty string renders as a
+    chromeless square (no text). *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace);
+    font-weight: 700;
+    letter-spacing: 0;
+    color: var(--color-bg-page, #0c0b08);
+    flex: none;
+  }
+
+  .size_sm { width: 14px; height: 14px; font-size: 8px;  border-radius: 2px; }
+  .size_md { width: 18px; height: 18px; font-size: 9px;  border-radius: 2px; }
+  .size_lg { width: 24px; height: 24px; font-size: 11px; border-radius: 3px; }
+
+  .s_1  { background: var(--color-keeper-1,  #b8826e); }
+  .s_2  { background: var(--color-keeper-2,  #b8946a); }
+  .s_3  { background: var(--color-keeper-3,  #aaa15c); }
+  .s_4  { background: var(--color-keeper-4,  #91a85c); }
+  .s_5  { background: var(--color-keeper-5,  #74ad6f); }
+  .s_6  { background: var(--color-keeper-6,  #5ead8a); }
+  .s_7  { background: var(--color-keeper-7,  #5aaaa5); }
+  .s_8  { background: var(--color-keeper-8,  #6ba2c0); }
+  .s_9  { background: var(--color-keeper-9,  #8e96cf); }
+  .s_10 { background: var(--color-keeper-10, #a98ac8); }
+  .s_11 { background: var(--color-keeper-11, #b87fb6); }
+  .s_12 { background: var(--color-keeper-12, #b87a98); }
+  .s_oob {
+    background: var(--color-fg-muted, #9a846e);
+    color: var(--color-bg-page, #0c0b08);
+  }
+
+  @media (prefers-contrast: more) {
+    .badge { outline: 1px solid var(--text-bright); }
+  }
+
+  @media (forced-colors: active) {
+    .badge { background: ButtonText; color: ButtonFace; }
+    .s_oob { background: GrayText; color: ButtonFace; }
+  }
+|}]
+
+type size =
+  [ `Sm
+  | `Md
+  | `Lg
+  ]
+
+let size_class : size -> Attr.t = function
+  | `Sm -> Style.size_sm
+  | `Md -> Style.size_md
+  | `Lg -> Style.size_lg
+;;
+
+let size_name : size -> string = function
+  | `Sm -> "sm"
+  | `Md -> "md"
+  | `Lg -> "lg"
+;;
+
+(** Map slot [1..12] to the matching ppx_css class. Out-of-range slots
+    clamp to [s_oob] (neutral grey) so a malformed input still renders. *)
+let slot_class (slot : int) : Attr.t =
+  match slot with
+  | 1 -> Style.s_1
+  | 2 -> Style.s_2
+  | 3 -> Style.s_3
+  | 4 -> Style.s_4
+  | 5 -> Style.s_5
+  | 6 -> Style.s_6
+  | 7 -> Style.s_7
+  | 8 -> Style.s_8
+  | 9 -> Style.s_9
+  | 10 -> Style.s_10
+  | 11 -> Style.s_11
+  | 12 -> Style.s_12
+  | _ -> Style.s_oob
+;;
+
+let slot_name (slot : int) : string =
+  if slot >= 1 && slot <= 12 then Int.to_string slot else "oob"
+;;
+
+(** Truncate the sigil to at most 2 visible glyphs. Uses a byte slice
+    rather than a grapheme-cluster slice — keepers are conventionally
+    ASCII (FNV-1a derived monograms or 2-char registry overrides) so a
+    naive prefix is safe; non-ASCII inputs degrade to the byte prefix
+    rather than throwing. *)
+let clamp_sigil (s : string) : string =
+  let len = String.length s in
+  if len <= 2 then s else String.sub s ~pos:0 ~len:2
+;;
+
+let view ?(size : size = `Md) ~(slot : int) ~(sigil : string) () : Node.t =
+  let label = clamp_sigil sigil in
+  let aria = if String.is_empty label then "keeper" else label in
+  Node.span
+    ~attrs:
+      [ Style.badge
+      ; size_class size
+      ; slot_class slot
+      ; Attr.create "data-slot" (slot_name slot)
+      ; Attr.create "data-size" (size_name size)
+      ; Attr.create "aria-label" aria
+      ; Attr.role "img"
+      ]
+    [ Node.text label ]
+;;

--- a/dashboard_bonsai/src/keeper_badge.mli
+++ b/dashboard_bonsai/src/keeper_badge.mli
@@ -1,0 +1,28 @@
+(** KeeperBadge — keeper attribution sigil-square primitive.
+
+    SPEC §3.6.3 attribution rule: color + sigil. Renders a colored
+    [--color-keeper-N] background with a 2-letter mono uppercase sigil in
+    [--color-bg-page] foreground. See [keeper_badge.ml] for the full
+    visual contract. *)
+
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type size =
+  [ `Sm
+  | `Md
+  | `Lg
+  ]
+
+(** [view ?size ~slot ~sigil ()] renders a keeper sigil-square.
+
+    [size] (default [`Md]): badge edge length. [`Sm] = 14px / 8px font,
+    [`Md] = 18px / 9px font, [`Lg] = 24px / 11px font.
+
+    [slot]: 1..12 keeper color slot per SPEC §3.6.1. Out-of-range values
+    clamp to a neutral grey badge (data-slot="oob") so malformed callers
+    still render.
+
+    [sigil]: 2-letter monogram. Longer strings are byte-truncated to the
+    first 2 chars; empty strings render as a chromeless square. *)
+val view : ?size:size -> slot:int -> sigil:string -> unit -> Node.t

--- a/dashboard_bonsai/src/spark.ml
+++ b/dashboard_bonsai/src/spark.ml
@@ -1,0 +1,142 @@
+(** Spark — inline mini-chart primitive (bar variant).
+
+    Bonsai analogue of Preact [dashboard/src/components/common/sparkline.ts]
+    adapted to the SPEC §primitives bar layout: 16px height, 2px bars, 1px
+    gap. Unlike the Preact canvas-based sparkline (polyline + filled area),
+    this primitive renders one inline-block per data point so it composes
+    inside ppx_css and survives forced-colors mode without a custom paint
+    path.
+
+    Layout contract:
+    - Outer wrapper height = 16px (SPEC primitive row).
+    - Each bar width = 2px, gap = 1px (rendered as flex gap).
+    - Bar height proportional to [v / max] of the series; minimum visible
+      height 1px so a zero value still has a baseline tick.
+    - Empty list (or all-zero) renders as a chromeless 16px placeholder so
+      callers can keep layout stable.
+
+    Kind axis mirrors [Chip.kind] minus a [`Neutral] / [`Idle] dot
+    suppression — every kind has a fill color because there's nothing else
+    on a sparkline to carry attribution. [`Brass] uses the accent-fg
+    triplet; statuses use [--color-status-{kind}]. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .spark {
+    display: inline-flex;
+    align-items: flex-end;
+    height: 16px;
+    gap: 1px;
+    line-height: 1;
+    vertical-align: middle;
+  }
+
+  .bar {
+    display: inline-block;
+    width: 2px;
+    flex: none;
+    border-radius: 0;
+  }
+
+  .k_ok      { background: var(--color-status-ok, #6a9a4a); }
+  .k_warn    { background: var(--color-status-warn, #b87828); }
+  .k_err     { background: var(--color-status-err, #e85050); }
+  .k_info    { background: var(--color-status-info, #968228); }
+  .k_idle    { background: var(--color-status-idle, #807870); }
+  .k_stalled { background: var(--color-status-stalled, #8a6abf); }
+  .k_brass   { background: var(--color-accent-fg, #968228); }
+  .k_neutral { background: var(--color-fg-muted, #9a846e); }
+
+  @media (prefers-contrast: more) {
+    .bar { outline: 1px solid var(--text-bright); }
+  }
+
+  @media (forced-colors: active) {
+    .k_ok, .k_info, .k_brass { background: Highlight; }
+    .k_warn                  { background: Mark; }
+    .k_err                   { background: MarkText; }
+    .k_idle, .k_neutral      { background: GrayText; }
+    .k_stalled               { background: ButtonText; }
+  }
+|}]
+
+type kind =
+  [ `Ok
+  | `Warn
+  | `Err
+  | `Info
+  | `Idle
+  | `Stalled
+  | `Brass
+  | `Neutral
+  ]
+
+let kind_class : kind -> Attr.t = function
+  | `Ok -> Style.k_ok
+  | `Warn -> Style.k_warn
+  | `Err -> Style.k_err
+  | `Info -> Style.k_info
+  | `Idle -> Style.k_idle
+  | `Stalled -> Style.k_stalled
+  | `Brass -> Style.k_brass
+  | `Neutral -> Style.k_neutral
+;;
+
+let kind_name : kind -> string = function
+  | `Ok -> "ok"
+  | `Warn -> "warn"
+  | `Err -> "err"
+  | `Info -> "info"
+  | `Idle -> "idle"
+  | `Stalled -> "stalled"
+  | `Brass -> "brass"
+  | `Neutral -> "neutral"
+;;
+
+(** Pure: largest non-negative value in [vs], or [1] when the series is
+    empty / all-zero. The fallback keeps the height divisor non-zero and
+    renders an all-zero series as a flat baseline rather than dividing by
+    zero. *)
+let series_max (vs : int list) : int =
+  let m =
+    List.fold vs ~init:0 ~f:(fun acc v -> if v > acc then v else acc)
+  in
+  if m <= 0 then 1 else m
+;;
+
+(** Map [v] in [0..max] to a pixel height in [1..16]. Negative / zero
+    values clamp to a 1px baseline tick so the column still reads as a
+    data point. *)
+let bar_height ~(max_v : int) (v : int) : int =
+  if v <= 0
+  then 1
+  else (
+    let raw = v * 16 / max_v in
+    if raw < 1 then 1 else if raw > 16 then 16 else raw)
+;;
+
+let view ~(values : int list) ~(kind : kind) : Node.t =
+  let max_v = series_max values in
+  let bars =
+    List.map values ~f:(fun v ->
+      let h = bar_height ~max_v v in
+      let style = Attr.create "style" (Printf.sprintf "height:%dpx" h) in
+      Node.span
+        ~attrs:[ Style.bar; kind_class kind; style ]
+        [])
+  in
+  Node.span
+    ~attrs:
+      [ Style.spark
+      ; Attr.role "img"
+      ; Attr.create "data-kind" (kind_name kind)
+      ; Attr.create "data-count" (Int.to_string (List.length values))
+      ]
+    bars
+;;

--- a/dashboard_bonsai/src/spark.mli
+++ b/dashboard_bonsai/src/spark.mli
@@ -1,0 +1,29 @@
+(** Spark — inline mini bar-chart primitive.
+
+    16px row of 2px-wide bars (1px gap) with each bar height proportional
+    to its value over the series max. See [spark.ml] for layout and color
+    contract. *)
+
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type kind =
+  [ `Ok
+  | `Warn
+  | `Err
+  | `Info
+  | `Idle
+  | `Stalled
+  | `Brass
+  | `Neutral
+  ]
+
+(** [view ~values ~kind] renders an inline mini-chart.
+
+    [values]: bar magnitudes. Negative or zero values clamp to a 1px
+    baseline tick. Empty list renders an empty 16px placeholder.
+
+    [kind]: bar fill color. Status kinds consume
+    [--color-status-{kind}]; [`Brass] uses [--color-accent-fg]; [`Neutral]
+    uses [--color-fg-muted]. *)
+val view : values:int list -> kind:kind -> Node.t


### PR DESCRIPTION
Three small atomic primitives for the Bonsai surface, each mirroring a SPEC role that callers across `/dashboard/b/*` reinvent inline.

## Modules

| Module | LoC (.ml + .mli) | API | SPEC role |
|--------|------------------|-----|-----------|
| `Spark` | 142 + 29 | `view : ~values:int list -> ~kind:kind -> Node.t` | inline mini-chart, 16px / 2px bars / 1px gap |
| `Caps`  | 75 + 21 | `view : ?tone:tone -> string -> Node.t` | SPEC §3.2 `--type-label` (uppercase 11px, `--track-caps`) |
| `KeeperBadge` | 140 + 28 | `view : ?size:size -> ~slot:int -> ~sigil:string -> unit -> Node.t` | SPEC §3.6.3 attribution sigil-square |

## Pattern decisions

**Spark — bars instead of canvas**. Preact `dashboard/src/components/common/sparkline.ts` is a Canvas 2D polyline+filled area+latest-point dot. The Bonsai port uses inline-block bars per the SPEC primitives bar layout (16px / 2px / 1px gap) so it composes inside `ppx_css`, survives `forced-colors: active` without a custom paint path, and stays accessible without a `useEffect` dance. 8 kinds matching `Chip.kind`. Empty / all-zero series renders a flat baseline tick rather than dividing by zero.

**Caps — no Preact analogue**. There is no standalone `caps` primitive in `dashboard/src/components/`. The closest match is `common/section-cap.ts` which encodes the same SPEC §3.2 `type-label` role (11px / uppercase / 0.05em tracking / muted color) in Tailwind utilities. Bonsai inherits the role directly from SPEC §3.2 with `--track-caps` (0.08em) and `--type-label` semantics. Three tones: `Muted` (default), `Dim`, `Brass`. Caller owns layout (margin / flex composition).

**KeeperBadge — sigil slice only, slot resolution in caller**. Mission spec accepts `~slot:int + ~sigil:string`, mirroring the Preact reference's `variant=sigil` slice. Slot resolution (registry-pinned 5 anchors + FNV-1a fallback) and sigil derivation (`kSlot` / `kSigil` in Preact) live in the caller — this lets one primitive serve both code paths without dragging the registry table into Bonsai. Out-of-range slots clamp to `Neutral` grey with `data-slot=oob` so audits catch buggy callers without crashing the render. `variant=full` / `variant=name` (sigil + colored name / colored text only) are out of scope here — they compose on top of this primitive in the caller.

## Constraints

- 6 new files only (3 `.ml` + 3 `.mli`). No other module touched.
- 0 inline hex outside `var(--token, #fallback)` (verified `rg '#[0-9a-fA-F]{3,8}' | grep -v 'var('` → 0 hits).
- `dune build --root .` and `--profile release` both produce native (`.cmx` + `.o`) + bytecode (`.cmo`) artifacts for all 3 modules.
- No dune file diff — auto-discovery picks up the new modules from `dashboard_bonsai/src/`.

## Verification

```bash
$ rg '#[0-9a-fA-F]{3,8}' dashboard_bonsai/src/{spark,caps,keeper_badge}.ml | grep -v 'var('
# (no output — 0 hex outside var() fallback)

$ ls dashboard_bonsai/_build/default/src/.dashboard_bonsai_lib.objs/byte/ | grep -iE 'spark|caps|keeper_badge'
dashboard_bonsai_lib__Caps.cmi
dashboard_bonsai_lib__Caps.cmo
...
dashboard_bonsai_lib__Spark.cmi
dashboard_bonsai_lib__Spark.cmo
```

Pre-existing baseline failures (`overview_view.ml` line 393 syntax, `ctx_chart.ml` line 239 syntax, `keepers_directory.ml on_key_down`) on `origin/main` are unrelated to this PR and reproduce without the new files (same baseline noted in Chip PR #11181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)