### PR TITLE
feat(dashboard): Tk sweep — goal_id + P1 highlight (callsite 6→8)

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -17,6 +17,7 @@ import { FilterChips } from '../common/filter-chips'
 import { StatusBadge } from '../common/status-badge'
 import { TimeAgo } from '../common/time-ago'
 import { TaskCreateForm } from '../task-manage/task-create-form'
+import { Tk } from '../tk'
 import type {
   DashboardGoalDetailResponse,
   DashboardCoordinationFsmViolation,
@@ -1029,7 +1030,7 @@ export function GoalTree() {
             <h3 class="mt-1 text-2xl font-semibold tracking-[-0.02em] text-text-strong">목표 중심 계획 뷰</h3>
             <p class="mt-1.5 text-sm leading-relaxed text-text-muted">
               goal-task 연결, keeper evidence, approval 대기, sandbox/cascade 신호를 한 표면에서 봅니다.
-              신규 태스크는 <code class="rounded bg-white/5 px-1 py-0.5 text-2xs text-text-strong">goal_id</code>로 직접 연결됩니다.
+              신규 태스크는 <${Tk}>goal_id<//>로 직접 연결됩니다.
             </p>
           </div>
           <div class="flex flex-wrap items-center gap-2">

--- a/dashboard/src/components/task-manage/task-create-form.ts
+++ b/dashboard/src/components/task-manage/task-create-form.ts
@@ -5,6 +5,7 @@ import { Select } from '../common/select'
 import { ActionButton } from '../common/button'
 import { RichComposer } from '../common/rich-composer'
 import { showTaskCreate, taskCreating, createTask } from './task-manage-state'
+import { Tk } from '../tk'
 
 const title = signal('')
 const description = signal('')
@@ -33,7 +34,7 @@ export function TaskCreateForm(props: { goalId?: string | null; goalTitle?: stri
               에 직접 연결된 backlog 태스크를 생성합니다.
             `
             : html`
-              이 프로젝트의 백로그에 바로 추가됩니다. 우선순위는 <code class="rounded bg-white/5 px-1 py-0.5 text-2xs text-text-strong">P1</code>이 가장 높습니다.
+              이 프로젝트의 백로그에 바로 추가됩니다. 우선순위는 <${Tk}>P1<//>이 가장 높습니다.
             `}
         </div>
         <${ActionButton}


### PR DESCRIPTION
## Why — Tk callsite 확장 (6 → 8), atom score 동일 9/14

Tk atom (#11200) 의 follow-up sweep. 사용자 의도 *"실제 사용하는곳도 궁금"* 직접 응답 — 새 atom 도입보다 기존 atom 의 visible delta 확대.

### 직전 cycle 검토 결과

이번 cron tick 에서 새 atom 후보들 모두 *이미 cover* 발견:

| 후보 | 결과 |
|---|---|
| `cb-group-g state primitives` (Empty/Loading/Error) | **`feedback-state.ts` 가 이미 G1+G2+G3 cover** — EmptyState / LoadingState / ErrorState / ErrorRecoverable / ErrorFatal |
| `Keycap` | **`Kbd` 가 이미 SPEC `.kbd` 100% 정합** — 코멘트에 명시 ("SPEC mapping (primitives.css `.kbd`, lines 174-183)") |
| `Btn Variants` | **`ActionButton` 이 SPEC `.btn` superset** — 6 variants vs SPEC 3 |

→ 새 atom 도입 부적절. **path 전환**: 사용자 *"실제 사용하는곳"* 신호 + plan tick 의 "다음 컴포넌트 PR" (atom 명시 X) → Tk additional sweep.

## 변경

| 파일 | 변경 |
|---|---|
| `dashboard/src/components/goals/goal-tree.ts` line 1032 | `<code class="rounded bg-white/5 px-1 py-0.5 text-2xs text-text-strong">goal_id</code>` → `<${Tk}>goal_id<//>` |
| `dashboard/src/components/task-manage/task-create-form.ts` line 36 | `<code class="rounded bg-white/5 px-1 py-0.5 text-2xs text-text-strong">P1</code>` → `<${Tk}>P1<//>` |

두 callsite 모두 *helper copy 안의 inline identifier highlight* 의도 — Tk 의 default kind 와 정합. swap 후 connector-{status,keeper-matrix} 의 6 callsites 와 동일한 SPEC bg-elevated + 0 4px padding shape.

### Tk callsite 누적

| 시기 | 사이트 |
|---|---|
| #11200 (atom 도입) | connector-status (5) + connector-keeper-matrix (1) = 6 |
| **이 PR (sweep)** | + goal-tree (1) + task-create-form (1) = **8** |

## 검증

- `pnpm exec tsc --noEmit` — clean (EXIT 0)
- `pnpm exec vitest run goal-tree task-create-form` — **15/15 passed**

## Scope note — 이 PR 에서 의도적으로 *제외* 한 것

dashboard 의 inline `<code>` 잔여 2 variants — 의도 다름 → Tk 와 정합 부족:

| 파일 | 패턴 | 이유 |
|---|---|---|
| `safe-autonomy.ts` | `text-3xs text-[var(--color-fg-muted)]` (no bg) | Tk 의 default 가 bg-elevated 가짐 → swap 시 *시각적으로 평면 → 박스* 강제 변경 |
| `server-config.ts` | `text-xs font-mono text-[var(--color-fg-secondary)]` (12px) | Tk 의 0.92em (~10px) 와 size 의도 다름 — 별도 primitive 또는 Tk size variant 필요 |

→ 이 두 variants 는 *atom 자체 변경* 또는 *별도 atom* 필요. 본 PR 에서 강제 통합 거부 — review 단순화 + 시각 의도 보존.

## 다음 cycle 후보

| 옵션 | 내용 |
|---|---|
| **A** | Tk 의 size variant (`size?: 'xs' \| 'default'`) 추가 → server-config 흡수 가능 |
| **B** | Tk 의 `tone="muted-no-bg"` 추가 → safe-autonomy 흡수 가능 (또는 별도 atom) |
| **C** | 다른 atom 의 callsite sweep — Surf 의 6 text-only role=alert sites, Bar/Band 의 추가 적용 |
| **D** | 새 atom — **Density / Grid** (사용자 캡처 image 4 명시) 또는 **Elevation helpers** (5-tier box-shadow ladder) |

## Self-review (best-programmer)

- 목표: Tk callsite 6 → 8 (+33%) — 사용자 *"실제 사용하는곳"* 신호 직접 응답
- 변경 범위: 2 파일, +4/-2 라인. 단순 swap 만, atom 정의 변경 0
- 검증: tsc clean + 15 vitest green + 회귀 0
- 미검증: 시각 (Tk atom 자체는 #11200 에서 이미 검증)
- 정직 disclosure: 잔여 2 variants 별도 PR — 의도 다름 (no-bg / large-size). atom 도입 후보 모두 이미 cover 사실 PR 본문에 명시 → 다음 cycle 의 정확한 path 결정 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)
