### PR TITLE
chore(dashboard): regen drift baseline (bg-white-alpha 74→73, text-px-literal 20→6)

### DIFF
--- a/scripts/dashboard-drift-baseline.json
+++ b/scripts/dashboard-drift-baseline.json
@@ -1,12 +1,12 @@
 {
   "_comment": "Dashboard styling-drift baseline. Regenerate with scripts/dashboard-drift-check.sh --regenerate.",
   "_patterns": "See scripts/dashboard-drift-check.sh PATTERNS array.",
-  "bg-white-alpha": 74,
+  "bg-white-alpha": 73,
   "border-white-alpha": 29,
   "text-zinc": 0,
   "bg-zinc": 0,
   "border-zinc": 0,
   "rounded-px-literal": 15,
   "text-9px": 0,
-  "text-px-literal": 20
+  "text-px-literal": 6
 }


### PR DESCRIPTION
## Summary

Locks in two ratchet improvements accumulated since the last regen at #10338 (2026-04-25):

| pattern | was | now | delta |
|---|---|---|---|
| `bg-white-alpha` | 74 | 73 | -1 |
| `text-px-literal` | 20 | 6 | -14 |

## Why now

`scripts/dashboard-drift-check.sh` has been emitting `baseline can be lowered` hints for both patterns in recent PR runs (most recently #11196 Kbd SPEC alignment, where `text-px-literal: 6 < baseline 20` was visible in the gate output). Without locking, a future regression can creep back up to the old baseline silently — defeating the purpose of the ratchet.

The `bg-white-alpha` -1 mostly came from #11208 Tk sweep (replacing two `bg-white/N` raw chip patterns with `<Tk>` atom usage). `text-px-literal` -14 is accumulated cleanup across many PRs.

## Verification

- `bash scripts/dashboard-drift-check.sh` — gate OK at new baselines
- No source changes — baseline JSON only (1 file, +2/-2)

## Test plan

- [ ] Dashboard CI green
- [ ] Drift gate green on this PR (and on subsequent PRs — looser baseline would actually be a regression here)

## Out of scope

- Atom 10/14 selection (sep is taken by another worktree, tk just shipped #11200)
- Audit of remaining 16 worktrees