### PR TITLE
chore(dashboard): migrate bg-white/20 to bg-[var(--white-20)] token (2 sites)

### DIFF
--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -220,7 +220,7 @@ function BroadcastReport({ report, index }: { report: { ts: string; content: str
         aria-expanded=${expanded}
       >
         <div class="flex items-center gap-2">
-          <span class="size-2 rounded-sm ${index === 0 ? 'bg-accent' : 'bg-white/20'}"></span>
+          <span class="size-2 rounded-sm ${index === 0 ? 'bg-accent' : 'bg-[var(--white-20)]'}"></span>
           <${TimeAgo} timestamp=${report.ts} />
         </div>
         ${isLong ? html`

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -320,7 +320,7 @@ export function AgentDetailOverlay() {
             <button
               ref=${closeButtonRef}
               type="button"
-              class="px-4 py-2 text-sm font-semibold rounded border border-transparent bg-white/10 text-text-strong hover:bg-white/20 transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
+              class="px-4 py-2 text-sm font-semibold rounded border border-transparent bg-white/10 text-text-strong hover:bg-[var(--white-20)] transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
               onClick=${closeAgentDetail}
             >
               닫기


### PR DESCRIPTION
## Summary

Surgical migration of remaining `bg-white/20` raw class literals to the canonical `--white-20` token, eliminating the 2-site bucket of the `bg-white-alpha` drift family.

## Changes

| file | line | change |
|---|---|---|
| `agent-detail-session-report.ts` | 223 | dot indicator: `bg-white/20` → `bg-[var(--white-20)]` |
| `agent-detail.ts` | 323 | hover state: `hover:bg-white/20` → `hover:bg-[var(--white-20)]` |

Drift count: 73 → 71 (-2). Baseline stays at 73 (no JSON churn this PR).

## Why surgical

`bg-white/N` has 5 buckets remaining: `/3` (14), `/4` (18), `/5` (32), `/10` (7), `/20` (2). This PR closes the smallest (`/20`) cleanly. Larger buckets are deferred follow-ups — keeping each PR small avoids review noise and lets each token migration land independently.

`bg-white/10` co-located on agent-detail.ts:323 is intentionally untouched — belongs to the `/10` bucket, separate follow-up.

## Verification

- `pnpm exec vitest run agent-detail.test.ts agent-detail-session-report.test.ts` — 35/35 pass
- `pnpm exec tsc --noEmit` — clean
- `bash scripts/dashboard-drift-check.sh` — gate OK (`bg-white-alpha: 71 < baseline 73`)
- `rg bg-white/20` in dashboard/src — 0 hits (full bucket cleaned)

## Test plan

- [ ] CI Dashboard green
- [ ] Drift gate green