### PR TITLE
feat(dashboard): add Ring atom helpers (focus / select / inner)

### DIFF
--- a/dashboard/src/components/common/ring.test.ts
+++ b/dashboard/src/components/common/ring.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import {
+  ringFocusClasses,
+  ringSelectClasses,
+  ringInnerClasses,
+} from './ring'
+
+describe('ringFocusClasses (pure)', () => {
+  it('default = accent / width 1 / no offset / focus-visible variant', () => {
+    const cls = ringFocusClasses()
+    expect(cls).toBe(
+      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent',
+    )
+  })
+
+  it('always includes outline-none reset', () => {
+    expect(ringFocusClasses()).toContain('focus-visible:outline-none')
+    expect(ringFocusClasses({ width: 2 })).toContain('focus-visible:outline-none')
+    expect(ringFocusClasses({ tone: 'ok' })).toContain('focus-visible:outline-none')
+  })
+
+  it('width 2 uses ring-2', () => {
+    const cls = ringFocusClasses({ width: 2 })
+    expect(cls).toContain('focus-visible:ring-2')
+    expect(cls).not.toContain('focus-visible:ring-1')
+  })
+
+  it('every tone produces a focus-visible:ring-* class', () => {
+    const tones = [
+      'accent',
+      'accent-soft',
+      'border',
+      'muted',
+      'ok',
+      'warn',
+      'bad',
+      'info',
+    ] as const
+    for (const tone of tones) {
+      const cls = ringFocusClasses({ tone })
+      // each tone string must appear *exactly once* under focus-visible:
+      expect(cls).toMatch(/focus-visible:ring-/)
+    }
+  })
+
+  it('accent-soft uses /40 alpha', () => {
+    expect(ringFocusClasses({ tone: 'accent-soft' })).toContain(
+      'focus-visible:ring-accent/40',
+    )
+  })
+
+  it('offset 0 (default) emits no ring-offset class', () => {
+    expect(ringFocusClasses()).not.toContain('ring-offset')
+    expect(ringFocusClasses({ offset: 0 })).not.toContain('ring-offset')
+  })
+
+  it('offset 2 + page surface (default) → matches main app focus pattern', () => {
+    const cls = ringFocusClasses({ width: 2, offset: 2, offsetSurface: 'page' })
+    expect(cls).toContain('focus-visible:ring-offset-2')
+    expect(cls).toContain('focus-visible:ring-offset-[var(--color-bg-page)]')
+  })
+
+  it('offset 2 + surface → keeper-config / agent-detail button pattern', () => {
+    const cls = ringFocusClasses({
+      width: 2,
+      offset: 2,
+      offsetSurface: 'surface',
+    })
+    expect(cls).toContain('focus-visible:ring-offset-2')
+    expect(cls).toContain('focus-visible:ring-offset-[var(--color-bg-surface)]')
+  })
+
+  it('offset 1 + bg-1 → list-item selection pattern', () => {
+    const cls = ringFocusClasses({
+      width: 2,
+      offset: 1,
+      offsetSurface: 'bg-1',
+    })
+    expect(cls).toContain('focus-visible:ring-offset-1')
+    expect(cls).toContain('focus-visible:ring-offset-bg-1')
+  })
+
+  it('visible=false uses bare focus: prefix (legacy mouse+keyboard)', () => {
+    const cls = ringFocusClasses({ visible: false })
+    expect(cls).toBe('focus:outline-none focus:ring-1 focus:ring-accent')
+    expect(cls).not.toContain('focus-visible:')
+  })
+
+  it('regression: outline-none must precede ring classes', () => {
+    // CSS specificity isn't affected by class order, but a few
+    // browsers respect the source order for tie-breaks. Keep the
+    // reset first so the override semantics read consistently.
+    const cls = ringFocusClasses()
+    const outlineIdx = cls.indexOf('outline-none')
+    const ringIdx = cls.indexOf(':ring-')
+    expect(outlineIdx).toBeGreaterThanOrEqual(0)
+    expect(ringIdx).toBeGreaterThan(outlineIdx)
+  })
+})
+
+describe('ringSelectClasses (pure)', () => {
+  it('default = ring-2 ring-accent (no focus-visible prefix)', () => {
+    const cls = ringSelectClasses()
+    expect(cls).toBe('ring-2 ring-accent')
+  })
+
+  it('does NOT add outline-none (selection ring is persistent, not focus)', () => {
+    expect(ringSelectClasses()).not.toContain('outline-none')
+  })
+
+  it('does NOT use focus-visible: prefix', () => {
+    expect(ringSelectClasses()).not.toContain('focus-visible:')
+    expect(ringSelectClasses({ tone: 'ok', width: 1 })).not.toContain(
+      'focus-visible:',
+    )
+  })
+
+  it('offset 1 + bg-1 (default surface) → event-track pattern', () => {
+    const cls = ringSelectClasses({ offset: 1 })
+    expect(cls).toBe('ring-2 ring-accent ring-offset-1 ring-offset-bg-1')
+  })
+
+  it('width 1 produces ring-1', () => {
+    expect(ringSelectClasses({ width: 1 })).toContain('ring-1')
+    expect(ringSelectClasses({ width: 1 })).not.toContain('ring-2')
+  })
+
+  it('every tone produces a ring-* class', () => {
+    const tones = [
+      'accent',
+      'accent-soft',
+      'border',
+      'muted',
+      'ok',
+      'warn',
+      'bad',
+      'info',
+    ] as const
+    for (const tone of tones) {
+      expect(ringSelectClasses({ tone })).toMatch(/^ring-\d/)
+    }
+  })
+})
+
+describe('ringInnerClasses (pure)', () => {
+  it('default = ring-1 ring-white/5 (modal panel pattern)', () => {
+    expect(ringInnerClasses()).toBe('ring-1 ring-white/5')
+  })
+
+  it('accepts tone + width override', () => {
+    expect(ringInnerClasses('border', 2)).toBe(
+      'ring-2 ring-[var(--color-border-strong)]',
+    )
+  })
+
+  it('does NOT add focus-visible / outline-none / ring-offset', () => {
+    const cls = ringInnerClasses()
+    expect(cls).not.toContain('focus-visible:')
+    expect(cls).not.toContain('outline-none')
+    expect(cls).not.toContain('ring-offset')
+  })
+})

--- a/dashboard/src/components/common/ring.ts
+++ b/dashboard/src/components/common/ring.ts
@@ -1,0 +1,173 @@
+// Ring — focus / selection / inner-highlight ring atom (helper-only).
+//
+// Tailwind ring utilities are CSS, not a component — but the *combinations*
+// drift wildly across dashboard. Audit (2026-04-27, 18 callsites with
+// `ring-1|ring-2|ring-accent|ring-inset`):
+//
+//   13 sites — keyboard focus indicator
+//              `focus-visible:outline-none focus-visible:ring-1 ring-accent`
+//              with 5 distinct offset/color permutations
+//                (`ring-offset-2 ring-offset-[var(--color-bg-page)]`,
+//                 `ring-offset-1 ring-offset-bg-1`, `ring-offset-2 ring-offset-[var(--color-bg-surface)]`,
+//                 no-offset, `ring-accent/40` color variant).
+//    4 sites — persistent selection highlight on list items / event tracks
+//              (`ring-2 ring-accent ring-offset-1 ring-offset-bg-1`).
+//    1 site  — decorative inner ring on a modal panel
+//              (`ring-1 ring-white/5`).
+//
+// Intent groups:
+//
+//   focus  — keyboard-only outline. Applied via the `focus-visible:`
+//            prefix. Disappears on mouse interaction. Most-used.
+//   select — persistent (non-focus) selection indicator. Applied
+//            conditionally on isSelected / isActive state.
+//   inner  — purely decorative interior outline (no state semantics).
+//            Use sparingly — most cards prefer `border` over `ring`.
+//
+// SPEC mapping: Tailwind v4 ring-* utilities, with kind tones from the
+// dashboard token system (`--color-status-ok|warn|err|info`,
+// `--color-accent-fg`, `--color-border-strong`, `--white-N`).
+//
+// Why a helper rather than a VNode component: per
+// `feedback_tailwind-only-dashboard`, Preact dashboard uses Tailwind
+// utility classes only — no handwritten CSS, no wrapper components for
+// pure styling. Ring stays in the same idiom as `kbdClasses()` /
+// `statusChipClasses()` / `idPillClasses()`.
+
+export type RingTone =
+  | 'accent'
+  | 'accent-soft'
+  | 'border'
+  | 'muted'
+  | 'ok'
+  | 'warn'
+  | 'bad'
+  | 'info'
+
+export type RingWidth = 1 | 2
+
+export type RingOffset = 0 | 1 | 2
+
+/** Color token for the ring *offset gap*. The offset is a transparent
+ *  band between the ring and the element bg, so its color must match
+ *  the *parent surface*, not the element itself. Three values cover
+ *  the 5 callsite permutations seen in the audit. */
+export type RingOffsetSurface = 'page' | 'surface' | 'bg-1'
+
+const TONE_CLASS: Record<RingTone, string> = {
+  accent: 'ring-accent',
+  // `accent-soft` = `ring-accent/40` — same hue, half-strength.
+  // Used by agent-detail.ts:286 anchor underline focus, where a
+  // full-strength accent ring would compete with the underline.
+  'accent-soft': 'ring-accent/40',
+  border: 'ring-[var(--color-border-strong)]',
+  muted: 'ring-white/5',
+  ok: 'ring-[var(--color-status-ok)]',
+  warn: 'ring-[var(--color-status-warn)]',
+  bad: 'ring-[var(--color-status-err)]',
+  info: 'ring-[var(--color-status-info)]',
+}
+
+const WIDTH_CLASS: Record<RingWidth, string> = {
+  1: 'ring-1',
+  2: 'ring-2',
+}
+
+const OFFSET_SURFACE_CLASS: Record<RingOffsetSurface, string> = {
+  page: 'ring-offset-[var(--color-bg-page)]',
+  surface: 'ring-offset-[var(--color-bg-surface)]',
+  'bg-1': 'ring-offset-bg-1',
+}
+
+export interface RingFocusOpts {
+  /** Tone token. Default `accent` — matches the existing 13 callsites. */
+  tone?: RingTone
+  /** Ring stroke width in 1px units. Default `1`. Use `2` for primary
+   *  controls / dialog buttons where the focus needs to be unambiguous. */
+  width?: RingWidth
+  /** Offset gap between the ring and the element. Default `0` (ring
+   *  hugs the element). Use `1` or `2` when the element sits on a
+   *  surface that would otherwise blend into the ring. */
+  offset?: RingOffset
+  /** Color of the offset gap (must match parent surface). Required
+   *  whenever `offset > 0`, otherwise the offset would render as the
+   *  wrong color. Default `page`. */
+  offsetSurface?: RingOffsetSurface
+  /** Focus ring uses the `focus-visible:` Tailwind variant by default
+   *  (keyboard-only). Set `false` to use bare `focus:` (mouse + keyboard
+   *  — rare, but matches a few legacy callsites). */
+  visible?: boolean
+}
+
+/** Compose the canonical focus-ring class string.
+ *
+ *  Default produces:
+ *    `focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent`
+ *
+ *  The `outline-none` reset is included because every callsite in the
+ *  audit pairs the ring with `outline-none` to suppress the browser's
+ *  native focus ring (which would otherwise stack with the Tailwind
+ *  ring and produce a doubled outline). Forgetting it is a frequent
+ *  drift bug — the helper bakes it in.
+ */
+export function ringFocusClasses(opts: RingFocusOpts = {}): string {
+  const tone = opts.tone ?? 'accent'
+  const width = opts.width ?? 1
+  const offset = opts.offset ?? 0
+  const visible = opts.visible !== false
+  const prefix = visible ? 'focus-visible:' : 'focus:'
+
+  const parts: string[] = [
+    `${prefix}outline-none`,
+    `${prefix}${WIDTH_CLASS[width]}`,
+    `${prefix}${TONE_CLASS[tone]}`,
+  ]
+
+  if (offset > 0) {
+    parts.push(`${prefix}ring-offset-${offset}`)
+    const offsetSurface = opts.offsetSurface ?? 'page'
+    parts.push(`${prefix}${OFFSET_SURFACE_CLASS[offsetSurface]}`)
+  }
+
+  return parts.join(' ')
+}
+
+export interface RingSelectOpts {
+  tone?: RingTone
+  width?: RingWidth
+  offset?: RingOffset
+  offsetSurface?: RingOffsetSurface
+}
+
+/** Compose a persistent (non-focus) selection ring. Apply
+ *  conditionally based on `isSelected` / `isActive` state.
+ *
+ *  Default: `ring-2 ring-accent` — matches the dominant select pattern
+ *  on event-track / tool-call-track (selection vs hover distinction
+ *  needs higher visual weight than focus). */
+export function ringSelectClasses(opts: RingSelectOpts = {}): string {
+  const tone = opts.tone ?? 'accent'
+  const width = opts.width ?? 2
+  const offset = opts.offset ?? 0
+
+  const parts: string[] = [WIDTH_CLASS[width], TONE_CLASS[tone]]
+
+  if (offset > 0) {
+    parts.push(`ring-offset-${offset}`)
+    const offsetSurface = opts.offsetSurface ?? 'bg-1'
+    parts.push(OFFSET_SURFACE_CLASS[offsetSurface])
+  }
+
+  return parts.join(' ')
+}
+
+/** Compose a decorative inner ring (no state semantics). Use sparingly
+ *  — most cards prefer `border` over `ring`. The single audit callsite
+ *  (agent-detail.ts:249 modal panel) uses `ring-1 ring-white/5`, mapped
+ *  here to tone=`muted` width=1. */
+export function ringInnerClasses(
+  tone: RingTone = 'muted',
+  width: RingWidth = 1,
+): string {
+  return `${WIDTH_CLASS[width]} ${TONE_CLASS[tone]}`
+}


### PR DESCRIPTION
## Summary

Adds `Ring` atom helper module at `dashboard/src/components/common/ring.ts`, consolidating the drifting `ring-*` patterns (18 callsites, 5 distinct compositions) into 3 pure helpers matching the actual intents found in the audit:

- `ringFocusClasses(opts)` — keyboard focus (`focus-visible:` prefix). 13 callsites. Bakes in the `outline-none` reset that every callsite pairs with the ring (forgetting it is a frequent drift bug — the helper makes it impossible to forget).
- `ringSelectClasses(opts)` — persistent selection ring on event-track / tool-call-track. 4 callsites.
- `ringInnerClasses(tone, width)` — decorative interior ring. 1 callsite (modal panel).

Supports 8 tones (`accent / accent-soft / border / muted / ok / warn / bad / info`), widths `1|2`, ring-offset `0|1|2`, and 3 offset surface tokens (`page / surface / bg-1`) covering all 5 audit permutations.

## Why helpers, not a VNode

Per `feedback_tailwind-only-dashboard`, Preact `dashboard/` uses Tailwind utility classes only. `Ring` follows the same idiom as `kbdClasses()` / `statusChipClasses()` / `idPillClasses()` — pure functions returning class strings, no wrapper components.

## Scope

**Component-only PR.** Adoption sweep follows in a separate PR (Phase 2-F per `planning/claude-plans/atomic-sauteeing-hickey.md`) once reviewers confirm the intent grouping matches the callsite vocabulary. This keeps the API review independent from the 18-site refactor.

## Test plan

- [x] `pnpm test src/components/common/ring` — 20/20 passed
- [x] `pnpm typecheck` — clean
- [x] `bash scripts/dashboard-drift-check.sh` — PASS (component-only, no callsite churn)
- [ ] Reviewer confirms 3-helper API matches callsite vocabulary (focus / select / inner)
- [ ] Phase 2-F adoption sweep PR uses these helpers without inline string drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)