### PR TITLE
chore(dashboard): migrate bg-white/10 to bg-[var(--white-10)] token (6 sites)

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -263,7 +263,7 @@ export function AgentDetailOverlay() {
                   <${StatusBadge} status=${unified.canonical} />
                   ${unified.description !== unified.label ? html`<span class="text-3xs font-medium py-1 px-2 border border-white/10 bg-white/5 text-text-muted whitespace-nowrap rounded" title=${unified.description}>${unified.description}</span>` : null}
                   ${isArchivedParticipant ? html`<${IdPill}>이전 세션 참여자<//>` : null}
-                  ${agent?.model ? html`<span class="font-mono text-3xs font-medium bg-white/10 border border-white/5 px-2 py-1 rounded text-text-muted shadow-sm">${agent.model}</span>` : ''}
+                  ${agent?.model ? html`<span class="font-mono text-3xs font-medium bg-[var(--white-10)] border border-white/5 px-2 py-1 rounded text-text-muted shadow-sm">${agent.model}</span>` : ''}
                   ${!agent && missionBrief?.archived_reason
                     ? html`<span class="text-xs text-text-dim italic">${missionBrief.archived_reason}</span>`
                     : null}
@@ -320,7 +320,7 @@ export function AgentDetailOverlay() {
             <button
               ref=${closeButtonRef}
               type="button"
-              class="px-4 py-2 text-sm font-semibold rounded border border-transparent bg-white/10 text-text-strong hover:bg-[var(--white-20)] transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
+              class="px-4 py-2 text-sm font-semibold rounded border border-transparent bg-[var(--white-10)] text-text-strong hover:bg-[var(--white-20)] transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
               onClick=${closeAgentDetail}
             >
               닫기

--- a/dashboard/src/components/common/observatory-filter-bar.ts
+++ b/dashboard/src/components/common/observatory-filter-bar.ts
@@ -33,7 +33,7 @@ function Chip({
       <span class="font-mono text-text-strong">${value}</span>
       <button
         type="button"
-        class="ml-0.5 rounded-sm min-w-6 min-h-6 p-1 text-text-muted hover:bg-white/10 hover:text-text-strong transition-colors inline-flex items-center justify-center"
+        class="ml-0.5 rounded-sm min-w-6 min-h-6 p-1 text-text-muted hover:bg-[var(--white-10)] hover:text-text-strong transition-colors inline-flex items-center justify-center"
         onClick=${onClear}
         aria-label=${`${label} 필터 제거`}
       >

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -330,7 +330,7 @@ function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' 
   const h = size === 'sm' ? 'h-1.5' : 'h-2.5'
   return html`
     <div class="flex items-center gap-2">
-      <div class="flex-1 ${h} rounded-sm bg-white/10 overflow-hidden">
+      <div class="flex-1 ${h} rounded-sm bg-[var(--white-10)] overflow-hidden">
         <div class="${h} rounded-sm transition-all duration-500" style="width:${clamped}%;background:${barColor}"></div>
       </div>
       <span class="text-2xs font-semibold tabular-nums text-text-muted w-9 text-right">${clamped}%</span>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -112,7 +112,7 @@ function GovernanceSummaryStrip() {
         <${ActionButton}
           variant="ghost"
           size="sm"
-          class="rounded border-transparent bg-[var(--white-3)] px-2.5 py-1 text-xs font-semibold text-text-muted hover:bg-white/10 hover:text-text-strong"
+          class="rounded border-transparent bg-[var(--white-3)] px-2.5 py-1 text-xs font-semibold text-text-muted hover:bg-[var(--white-10)] hover:text-text-strong"
           onClick=${refreshGovernance}
           disabled=${governanceLoading.value}
         >

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -442,7 +442,7 @@ function InlineToggleRow({ label, value, onChange }: { label: string; value: boo
     <div class="flex items-center justify-between py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
       <span class="text-xs font-medium text-text-muted">${label}</span>
       <button type="button"
-        class="relative inline-flex h-5 w-9 items-center rounded-sm transition-colors cursor-pointer ${value ? 'bg-ok/60' : 'bg-white/10'}"
+        class="relative inline-flex h-5 w-9 items-center rounded-sm transition-colors cursor-pointer ${value ? 'bg-ok/60' : 'bg-[var(--white-10)]'}"
         aria-label=${`${label} ${value ? '비활성화' : '활성화'}`}
         aria-pressed=${value ? 'true' : 'false'}
         onClick=${() => onChange(!value)}


### PR DESCRIPTION
## Summary

Continues the `bg-white-alpha` bucket migration started in #11212 (which swept the 2 `bg-white/20` sites). This sweep handles the 6 `bg-white/10` callsites with surgical scope — only the `bg-white/10` → `bg-[var(--white-10)]` swap, leaving other white-alpha variants on the same lines (`bg-white/3 / /4 / /5`, `border-white/N`) for separate bucket PRs (per `feedback_audit-bucket-cascade-pattern`).

## Sites migrated

- `governance.ts:115` — refresh button hover state
- `goals/goal-tree.ts:333` — progress-bar track background
- `agent-detail.ts:266` — agent model badge background
- `agent-detail.ts:323` — close button background
- `keeper-config-panel.ts:445` — toggle off-state background
- `common/observatory-filter-bar.ts:36` — clear button hover state

## Drift

`bg-white-alpha`: 73 (baseline) → 71 (post #11212) → 65 (post this PR). `dashboard-drift-check.sh` PASS. Baseline regen deferred to a follow-up PR after the next bucket lands (avoids touching the SSOT JSON every PR).

## Test plan

- [x] `pnpm test src/components/common/observatory-filter-bar src/components/agent-detail-session-report` — 21/21 passed
- [x] `pnpm typecheck` — clean
- [x] `bash scripts/dashboard-drift-check.sh` — `bg-white-alpha: 65 < baseline 73` PASS
- [ ] Reviewer spot-checks visual regression on governance refresh / goal-tree progress-bar / agent-detail close button

🤖 Generated with [Claude Code](https://claude.com/claude-code)