### PR TITLE
feat(dashboard): Btn atomic primitive (atom 11/14)

### DIFF
--- a/dashboard/design-system/source_styles/primitives.css
+++ b/dashboard/design-system/source_styles/primitives.css
@@ -162,6 +162,7 @@
 
 .btn.sm { height: 20px; padding: 0 8px; font-size: var(--fs-10); }
 .btn.xs { height: 18px; padding: 0 6px; font-size: var(--fs-9); letter-spacing: .06em; }
+.btn.lg { height: 28px; padding: 0 14px; font-size: var(--fs-12); }
 
 /* icon-only button — square */
 .btn.icon {

--- a/dashboard/src/components/btn.test.ts
+++ b/dashboard/src/components/btn.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Btn, resolveVariant, type BtnProps } from './btn'
+
+describe('resolveVariant (pure)', () => {
+  it('returns "default" when variant is undefined', () => {
+    expect(resolveVariant(undefined)).toBe('default')
+  })
+
+  it('passes through explicit variants', () => {
+    expect(resolveVariant('primary')).toBe('primary')
+    expect(resolveVariant('danger')).toBe('danger')
+    expect(resolveVariant('ghost')).toBe('ghost')
+  })
+})
+
+describe('Btn', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    render(null, host)
+    host.remove()
+  })
+
+  function mount(props: BtnProps): HTMLButtonElement {
+    render(html`<${Btn} ...${props} />`, host)
+    return host.firstElementChild as HTMLButtonElement
+  }
+
+  // ── Structural ──
+
+  it('emits a <button> with data-variant and data-size', () => {
+    const el = mount({ children: 'SAVE', variant: 'primary', size: 'sm' })
+    expect(el.tagName).toBe('BUTTON')
+    expect(el.getAttribute('data-variant')).toBe('primary')
+    expect(el.getAttribute('data-size')).toBe('sm')
+  })
+
+  it('defaults to variant=default / size=default when omitted', () => {
+    const el = mount({ children: 'click' })
+    expect(el.getAttribute('data-variant')).toBe('default')
+    expect(el.getAttribute('data-size')).toBe('default')
+  })
+
+  it('defaults type to "button" (not submit) so it does not auto-submit forms', () => {
+    const el = mount({ children: 'click' })
+    expect(el.getAttribute('type')).toBe('button')
+  })
+
+  it('preserves explicit type="submit" for form callsites', () => {
+    const el = mount({ children: 'Save', type: 'submit' })
+    expect(el.getAttribute('type')).toBe('submit')
+  })
+
+  it('forwards testId to data-testid', () => {
+    const el = mount({ children: 'X', testId: 'cancel-btn' })
+    expect(el.getAttribute('data-testid')).toBe('cancel-btn')
+  })
+
+  // ── Click + disabled ──
+
+  it('invokes onClick when activated', () => {
+    const onClick = vi.fn()
+    const el = mount({ children: 'click', onClick })
+    el.click()
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors the disabled attribute', () => {
+    const el = mount({ children: 'click', disabled: true })
+    expect(el.disabled).toBe(true)
+    expect(el.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('does not emit disabled attribute when disabled is false/undefined', () => {
+    const el = mount({ children: 'click' })
+    expect(el.hasAttribute('disabled')).toBe(false)
+  })
+
+  // ── Variant fidelity (style attr inspection) ──
+
+  it('primary uses brass accent surface', () => {
+    const el = mount({ children: 'SAVE', variant: 'primary' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-accent-fg-dim)')
+    expect(style).toContain('var(--color-bg-page)')
+  })
+
+  it('danger uses err status fg over a transparent surface', () => {
+    // Note: happy-dom drops `border: 1px solid rgb(var(--x) / 0.4)`
+    // shorthand because its CSS parser rejects custom-property arms,
+    // so we assert the fg + transparent surface (matches chip.ts /
+    // pill.ts test pattern). Border-color fidelity is verified by
+    // primitives.html in the manual visual pass.
+    const el = mount({ children: 'RETIRE', variant: 'danger' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-status-err)')
+    expect(style.toLowerCase()).toContain('transparent')
+  })
+
+  it('ghost has transparent background and border', () => {
+    const el = mount({ children: 'cancel', variant: 'ghost' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style.toLowerCase()).toContain('transparent')
+    expect(style).toContain('var(--color-fg-muted)')
+  })
+
+  it('default variant uses fg-secondary + border-default', () => {
+    const el = mount({ children: 'click' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-fg-secondary)')
+    expect(style).toContain('var(--color-border-default)')
+  })
+
+  // ── Size geometry ──
+
+  it('xs is 18px tall with 0.06em letter-spacing', () => {
+    const el = mount({ children: 'xs', size: 'xs' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('18px')
+    expect(style).toContain('0.06em')
+  })
+
+  it('sm is 20px tall', () => {
+    const el = mount({ children: 'sm', size: 'sm' })
+    expect(el.getAttribute('style') ?? '').toContain('20px')
+  })
+
+  it('default is 24px tall', () => {
+    const el = mount({ children: 'def' })
+    expect(el.getAttribute('style') ?? '').toContain('24px')
+  })
+
+  it('lg is 28px tall (atom 11/14 codification — primitives.css addition)', () => {
+    const el = mount({ children: 'lg', size: 'lg' })
+    expect(el.getAttribute('style') ?? '').toContain('28px')
+  })
+
+  // ── Icon modifier ──
+
+  it('icon flips geometry to 22×22 square and emits data-icon', () => {
+    const el = mount({ children: '▸', icon: true, ariaLabel: 'expand' })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('22px')
+    expect(el.getAttribute('data-icon')).toBe('true')
+  })
+
+  it('non-icon button omits data-icon', () => {
+    const el = mount({ children: 'click' })
+    expect(el.getAttribute('data-icon')).toBe(null)
+  })
+
+  // ── Class + aria pass-through ──
+
+  it('forwards user class without overwriting atom-owned style', () => {
+    const el = mount({ children: 'click', class: 'mt-2 flex-1' })
+    expect(el.getAttribute('class')).toBe('mt-2 flex-1')
+  })
+
+  it('forwards ariaLabel for icon-only buttons', () => {
+    const el = mount({ children: '▸', icon: true, ariaLabel: 'expand row' })
+    expect(el.getAttribute('aria-label')).toBe('expand row')
+  })
+
+  it('forwards title for native tooltip', () => {
+    const el = mount({ children: 'X', title: 'close panel' })
+    expect(el.getAttribute('title')).toBe('close panel')
+  })
+})

--- a/dashboard/src/components/btn.ts
+++ b/dashboard/src/components/btn.ts
@@ -1,0 +1,210 @@
+// Btn — atomic primitive ported from design-system v0.4 primitives.html
+// (`<button class="btn ...">…</button>`). The SPEC defines a base button
+// (warm border, transparent surface) plus three semantic variants
+// (primary / danger / ghost), four sizes (xs / sm / default / lg), and
+// an `icon` square modifier. Distinct from Chip / Pill (display-only):
+// Btn is the canonical *interactive* element — keyboard focusable,
+// click-dispatching, hover-transition.
+//
+// SPEC fidelity: matches design-system/source_styles/primitives.css
+// `.btn.{primary,danger,ghost}` and `.btn.{xs,sm,lg,icon}` selectors,
+// and the `button, .btn` base in tokens.css line 467. The dashboard
+// runtime does not import the design-system CSS files (Preact owns its
+// styles via styles/), so this primitive translates the SPEC's
+// `.btn` rules into inline style + the runtime semantic tokens defined
+// by styles/variables.css. Same fidelity contract as chip.ts / pill.ts.
+//
+// Token dependencies (all in dashboard/src/styles/variables.css):
+//   --color-fg-{primary,secondary,muted}
+//   --color-bg-{page,panel-alt,elevated}
+//   --color-border-default
+//   --color-accent-fg / --color-accent-fg-dim
+//   --color-status-err / --color-status-err-glow (rgb-triplet)
+//
+// Usage: `<${Btn} variant="primary" size="sm" onClick=${handler}>SAVE<//>`
+// — host DOM is `<button type="button">` by default. `type="submit"` is
+// preserved when explicitly passed (forms).
+//
+// Hover transition is handled inline (Preact useState + mouseenter/leave)
+// since SPEC defines the transition declaratively; focus-visible relies
+// on the browser default until atom 13/14 (Focus ring) lands.
+
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import type { ComponentChildren, JSX, VNode } from 'preact'
+
+export type BtnVariant = 'primary' | 'danger' | 'ghost'
+export type BtnSize = 'xs' | 'sm' | 'default' | 'lg'
+
+type ResolvedVariant = 'default' | BtnVariant
+
+export interface BtnProps {
+  children?: ComponentChildren
+  /** Semantic tone. `undefined` ≡ default (warm-bordered base). */
+  variant?: BtnVariant
+  /** `xs` 18px / `sm` 20px / `default` 24px / `lg` 28px. */
+  size?: BtnSize
+  /** Square 22×22 icon-only button. Overrides `size` geometry, keeps
+   *  `size`-derived font-size for the glyph. */
+  icon?: boolean
+  /** Native disabled state. Pointer cursor swaps to not-allowed and the
+   *  surface drops to 50% opacity. */
+  disabled?: boolean
+  /** Native button type. Defaults to `button` (does not submit forms). */
+  type?: 'button' | 'submit' | 'reset'
+  /** Click handler forwarded to the underlying `<button>`. */
+  onClick?: JSX.MouseEventHandler<HTMLButtonElement>
+  /** Forwarded to data-testid for E2E selectors. */
+  testId?: string
+  /** Override for screen-reader label. Required for `icon` buttons that
+   *  render only a glyph (no readable child text). */
+  ariaLabel?: string
+  /** Optional native `title` attribute for hover tooltips. */
+  title?: string
+  /** Extra class names appended verbatim. The atom does not need a class
+   *  for its own styling (everything is inline) — this slot exists for
+   *  callers that want layout utilities (e.g. `mt-2`, `flex-1`). */
+  class?: string
+}
+
+interface VariantStyle {
+  color: string
+  borderColor: string
+  background: string
+  fontWeight?: number
+  hover: { color: string; background: string; borderColor?: string }
+}
+
+// Foreground / border / background tuples match SPEC primitives.css
+// `.btn.{primary,danger,ghost}` selectors plus the unstyled base.
+// Hover state is read off the same SPEC `:hover` rules.
+const VARIANT_STYLE: Record<ResolvedVariant, VariantStyle> = {
+  default: {
+    color: 'var(--color-fg-secondary)',
+    borderColor: 'var(--color-border-default)',
+    background: 'transparent',
+    hover: {
+      color: 'var(--color-fg-primary)',
+      background: 'var(--color-bg-elevated)',
+    },
+  },
+  primary: {
+    color: 'var(--color-bg-page)',
+    borderColor: 'var(--color-accent-fg-dim)',
+    background: 'var(--color-accent-fg-dim)',
+    fontWeight: 600,
+    hover: {
+      color: 'var(--color-bg-page)',
+      background: 'var(--color-accent-fg)',
+      borderColor: 'var(--color-accent-fg)',
+    },
+  },
+  danger: {
+    color: 'var(--color-status-err)',
+    borderColor: 'rgb(var(--color-status-err-glow) / 0.4)',
+    background: 'transparent',
+    hover: {
+      color: 'var(--color-status-err)',
+      background: 'rgb(var(--color-status-err-glow) / 0.1)',
+    },
+  },
+  ghost: {
+    color: 'var(--color-fg-muted)',
+    borderColor: 'transparent',
+    background: 'transparent',
+    hover: {
+      color: 'var(--color-fg-primary)',
+      background: 'var(--color-bg-panel-alt)',
+    },
+  },
+}
+
+interface SizeStyle {
+  height: string
+  padding: string
+  fontSize: string
+  letterSpacing?: string
+}
+
+// Sizes match SPEC primitives.css: xs (line 164), sm (163), default
+// (tokens.css line 467 base — derived 24px height from `padding 4px 10px`
+// + 11px font line-height), lg (line 165 — added by this PR, fs-12 paired
+// with the 28px geometry inferred from the xs(18)→sm(20)→default(24)→
+// lg(28) +2px progression that primitives.html demos).
+const SIZE_STYLE: Record<BtnSize, SizeStyle> = {
+  xs: { height: '18px', padding: '0 6px', fontSize: '9px', letterSpacing: '0.06em' },
+  sm: { height: '20px', padding: '0 8px', fontSize: '10px' },
+  default: { height: '24px', padding: '0 10px', fontSize: '11px' },
+  lg: { height: '28px', padding: '0 14px', fontSize: '12px' },
+}
+
+const TRANSITION =
+  'background 120ms ease, color 120ms ease, border-color 120ms ease'
+
+/** Pure: resolve the variant default. Exported for tests so the variant
+ *  defaulting rule stays observable without a DOM mount. */
+export function resolveVariant(variant: BtnVariant | undefined): ResolvedVariant {
+  return variant ?? 'default'
+}
+
+export function Btn(props: BtnProps): VNode {
+  const variant = resolveVariant(props.variant)
+  const size = props.size ?? 'default'
+  const vs = VARIANT_STYLE[variant]
+  const ss = SIZE_STYLE[size]
+
+  const [hovered, setHovered] = useState(false)
+  const active = hovered && !props.disabled
+
+  const color = active ? vs.hover.color : vs.color
+  const background = active ? vs.hover.background : vs.background
+  const borderColor =
+    active && vs.hover.borderColor ? vs.hover.borderColor : vs.borderColor
+
+  // Icon mode swaps the geometry to a 22×22 square but keeps the size-
+  // derived font-size so the glyph (▸, ⌃, ⊘ etc.) scales with the chosen
+  // size token rather than always rendering at 11px.
+  const geometry: Pick<JSX.CSSProperties, 'width' | 'height' | 'padding'> =
+    props.icon
+      ? { width: '22px', height: '22px', padding: '0' }
+      : { height: ss.height, padding: ss.padding }
+
+  const style: JSX.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...geometry,
+    fontFamily: 'inherit',
+    fontSize: ss.fontSize,
+    fontWeight: vs.fontWeight,
+    letterSpacing: ss.letterSpacing,
+    color,
+    background,
+    border: `1px solid ${borderColor}`,
+    borderRadius: '3px',
+    cursor: props.disabled ? 'not-allowed' : 'pointer',
+    opacity: props.disabled ? 0.5 : 1,
+    transition: TRANSITION,
+  }
+
+  return html`
+    <button
+      type=${props.type ?? 'button'}
+      class=${props.class}
+      data-testid=${props.testId}
+      data-variant=${variant}
+      data-size=${size}
+      data-icon=${props.icon ? 'true' : undefined}
+      disabled=${props.disabled || undefined}
+      aria-label=${props.ariaLabel}
+      title=${props.title}
+      style=${style}
+      onClick=${props.onClick}
+      onMouseEnter=${() => setHovered(true)}
+      onMouseLeave=${() => setHovered(false)}
+      onBlur=${() => setHovered(false)}
+    >
+      ${props.children}
+    </button>
+  `
+}


### PR DESCRIPTION
## Summary

Eleventh atomic primitive port from `design-system v0.4 primitives.html`. **Btn** is the canonical *interactive* element — three semantic variants (`primary` / `danger` / `ghost`), four sizes (`xs` / `sm` / `default` / `lg`), and an `icon` square modifier. Public API matches the SPEC `<button class=\"btn ...\">` literal.

Same fidelity contract as `chip.ts` / `pill.ts`: dashboard runtime does not import design-system source CSS, so the atom translates SPEC `.btn.{variant}` rules into inline `style` + the runtime semantic tokens (`styles/variables.css`).

### 14-atom progress

| # | atom | PR | status |
|---|------|----|--------|
| 1 | Chip | #11153 | merged |
| 2 | Pill | #11157 | merged |
| 3 | Bar | #11170 | merged |
| 4 | Band | #11174 | merged |
| 5 | SectionHead | #11176 | merged |
| 6 | KvRow | #11178 | merged |
| 7 | Spark | #11183 | merged |
| 8 | Surf | #11187 | merged |
| 9 | Kbd | #11196 | merged |
| 10 | Tk / Sep | #11200 / #11203 | merged |
| **11** | **Btn** | **this PR** | **draft** |
| 12 | Elevation (`elev-0..6`) | — | next |
| 13 | Focus ring (`.focusable`) | — | next |
| 14 | Motion (`anim-*`) | — | next |

### Variant × size matrix

| | xs (18px) | sm (20px) | default (24px) | lg (28px) | icon (22×22) |
|---|---|---|---|---|---|
| **default** | warm border, transparent | … | … | … | square |
| **primary** | brass-2 surface, dark fg, weight 600 | … | … | … | square |
| **danger** | err fg + translucent err border | … | … | … | square |
| **ghost** | transparent border, muted fg | … | … | … | square |

5 variants × 4 sizes + icon mode = 21 visual states, all backed by 23 vitest assertions.

### CSS sync — `.btn.lg` codified

`primitives.css` was missing `.btn.lg` (sizes had `xs` / `sm` / icon, but `lg` only existed in `primitives.html` demo line 152). Added inline with the xs(18) → sm(20) → default(24) → **lg(28)** progression that the SPEC demo already implies. Pure codification — source CSS consumers had no rule to drop.

```diff
 .btn.sm { height: 20px; padding: 0 8px; font-size: var(--fs-10); }
 .btn.xs { height: 18px; padding: 0 6px; font-size: var(--fs-9); letter-spacing: .06em; }
+.btn.lg { height: 28px; padding: 0 14px; font-size: var(--fs-12); }
```

### No callsite swap (intentional)

Dashboard runtime has 3 stale `<button class=\"btn ...\">` callsites (`logs.ts`, `memory.ts`, `memory-post-detail.ts`) and 191 raw `<button>` callsites — but `.btn` is **not defined in `dashboard/src/styles/`**. Those 3 stale callsites render with **no class effect**. A swap would *add* visual change rather than preserve it, which is the wrong semantics for an atom-introduction PR.

→ This PR follows the **Sep #11203 pattern** (atom-only, no callsite swap). Follow-up sweep PRs will swap callsites tier by tier with Playwright screenshot diffs (Btn-sweep-1 / -2 / -3).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test btn` — 23/23 pass (4 pure + 19 DOM)
- [x] `pnpm lint` clean
- [ ] Manual visual: `pnpm dev` → http://localhost:5173/dashboard/design-system/preview/primitives.html — Buttons section variant×size matrix + lg size addition
- [ ] CI required checks green before Ready
- [ ] Self-review per `@~/me/agents/best-programmer/AGENT.md` after CI

## Self-review notes

**Goal**: introduce Btn atom (11/14) without disturbing existing surface.
**Changed files**: 3 (1 CSS codify, 1 atom, 1 test).
**Local verification**: typecheck + test + lint green.
**Unverified**: hover transition timing (120ms ease) under reduced-motion preference — reduced-motion handling is owned by atom 14/14 (Motion). Manual visual fidelity vs. primitives.html — relies on reviewer or follow-up Playwright PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)