### PR TITLE
fix(types): remove failwith from agent_credential_of_yojson

### DIFF
--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -69,17 +69,17 @@ let agent_credential_to_yojson (c : agent_credential) =
 
 let agent_credential_of_yojson json =
   let open Yojson.Safe.Util in
-  try
-    let agent_name = json |> member "agent_name" |> to_string in
-    let token = json |> member "token" |> to_string in
-    let role_str = json |> member "role" |> to_string in
-    let role = match agent_role_of_string role_str with Ok r -> r | Error e -> failwith e in
+  let agent_name = json |> member "agent_name" |> to_string in
+  let token = json |> member "token" |> to_string in
+  let role_str = json |> member "role" |> to_string in
+  match agent_role_of_string role_str with
+  | Error e -> Error e
+  | Ok role ->
     let created_at = json |> member "created_at" |> to_string in
     let expires_at = json |> member "expires_at" |> to_string_option in
     let id = json |> member "id" |> to_string_option |> Option.map Credential_id.of_string in
     let agent_id = json |> member "agent_id" |> to_string_option |> Option.map Agent_id.of_string in
     Ok { id; agent_id; agent_name; token; role; created_at; expires_at }
-  with e -> Error (Printexc.to_string e)
 
 (** Auth configuration *)
 type auth_config = {


### PR DESCRIPTION
## Summary
- Replace `failwith e` + `try..with` in `agent_credential_of_yojson` with direct `match` on `agent_role_of_string` Result
- Restores CI ratchet baseline: `lib_failwith` count drops from 1 → 0
- Regression introduced by #11191 (Phase 8 types refactor)

## Test plan
- [x] `dune build` passes
- [ ] CI ratchet check passes (`lib_failwith 0->0`)
- [ ] Existing test suite green