### PR TITLE
[Step 6b-1] classify_actionable_signal helper (additive)

### DIFF
--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -33,3 +33,19 @@ let pp_contract_status fmt = function
       Format.fprintf fmt "tool_surface_mismatch(missing=[%s])"
         (String.concat ", " missing)
   | other -> Format.pp_print_string fmt (contract_status_label other)
+
+type world_observation = {
+  unclaimed_task_count : int;
+  board_activity_count : int;
+  has_discovered_work_section : bool;
+}
+
+let classify_actionable_signal o =
+  if o.unclaimed_task_count > 0 then Has_unclaimed_tasks
+  else if o.board_activity_count > 0 then Has_board_activity
+  else if o.has_discovered_work_section then Has_discovered_work
+  else No_actionable_signal
+
+let is_actionable = function
+  | No_actionable_signal -> false
+  | Has_unclaimed_tasks | Has_board_activity | Has_discovered_work -> true

--- a/lib/keeper/keeper_contract_classifier.mli
+++ b/lib/keeper/keeper_contract_classifier.mli
@@ -26,3 +26,47 @@ type contract_status =
 val actionable_signal_label : actionable_signal -> string
 val contract_status_label : contract_status -> string
 val pp_contract_status : Format.formatter -> contract_status -> unit
+
+(** Structured per-turn world snapshot consumed by
+    [classify_actionable_signal]. Mirrors the three substring markers
+    that [keeper_agent_run.ml:2285-2298] currently scrapes from the
+    rendered prompt body — the upstream code already knows these as
+    counts and a boolean before formatting them into the string, so
+    Step 6b's caller rewrite will populate this record at the source
+    instead of re-parsing the prompt. *)
+type world_observation = {
+  unclaimed_task_count : int;
+      (** Number of unclaimed tasks in the keeper's queue.
+          Mirrors the integer rendered into the
+          ["**Unclaimed tasks (N total ...) ..."] section. *)
+  board_activity_count : int;
+      (** Count of fresh board entries the keeper has not yet
+          processed. Mirrors the count rendered after
+          ["### Board Activity"]. *)
+  has_discovered_work_section : bool;
+      (** True iff the prompt build emitted a
+          ["## Discovered Work (auto, Ns interval)"] section. *)
+}
+
+(** [classify_actionable_signal o] returns the most-specific
+    actionable signal observed in [o], following the precedence
+    [unclaimed_tasks > board_activity > discovered_work].
+
+    The precedence reflects the action ladder a keeper should
+    descend: a claimable task is the highest-leverage move; engaging
+    with board activity is next; discovery hints are the weakest
+    signal. The current heuristic at [keeper_agent_run.ml:2285-2298]
+    short-circuits as a single boolean and discards the precedence;
+    routing decisions made on top of [actionable_signal] can choose
+    differently for each variant.
+
+    Boolean-compatible:
+    [classify_actionable_signal o <> No_actionable_signal]
+    is the structured equivalent of the existing
+    [actionable_signal_context = true]. *)
+val classify_actionable_signal : world_observation -> actionable_signal
+
+(** [is_actionable s] is [false] iff [s = No_actionable_signal].
+    Provided so callers comparing the structured signal against the
+    legacy boolean can do so without a manual pattern match. *)
+val is_actionable : actionable_signal -> bool

--- a/test/dune
+++ b/test/dune
@@ -193,7 +193,8 @@
         test_lockfree_atomic
         test_telemetry_observe
         test_keeper_typed_labels
-        test_auth_resolve_labels)
+        test_auth_resolve_labels
+        test_keeper_classifier_helper)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -357,6 +358,7 @@
           test_telemetry_observe
           test_keeper_typed_labels
           test_auth_resolve_labels
+          test_keeper_classifier_helper
           )
  (libraries masc_test_deps))
 

--- a/test/test_keeper_classifier_helper.ml
+++ b/test/test_keeper_classifier_helper.ml
@@ -1,0 +1,121 @@
+(** test_keeper_classifier_helper — coverage for the structured
+    [classify_actionable_signal] introduced as the precursor to Step 6b
+    caller adoption. *)
+
+open Masc_mcp
+module C = Keeper_contract_classifier
+
+let s = Alcotest.testable
+  (fun fmt v -> Format.pp_print_string fmt (C.actionable_signal_label v))
+  (=)
+
+let obs ?(tasks = 0) ?(board = 0) ?(discovered = false) () =
+  {
+    C.unclaimed_task_count = tasks;
+    board_activity_count = board;
+    has_discovered_work_section = discovered;
+  }
+
+let test_no_signal_when_empty () =
+  Alcotest.check s "empty observation"
+    C.No_actionable_signal
+    (C.classify_actionable_signal (obs ()))
+
+let test_unclaimed_tasks_take_top_priority () =
+  Alcotest.check s "tasks > board"
+    C.Has_unclaimed_tasks
+    (C.classify_actionable_signal (obs ~tasks:1 ~board:5 ()));
+  Alcotest.check s "tasks > discovered"
+    C.Has_unclaimed_tasks
+    (C.classify_actionable_signal (obs ~tasks:1 ~discovered:true ()));
+  Alcotest.check s "tasks > all"
+    C.Has_unclaimed_tasks
+    (C.classify_actionable_signal
+       (obs ~tasks:1 ~board:5 ~discovered:true ()))
+
+let test_board_takes_second_priority () =
+  Alcotest.check s "board > discovered when no tasks"
+    C.Has_board_activity
+    (C.classify_actionable_signal (obs ~board:1 ~discovered:true ()))
+
+let test_discovered_only_when_no_other () =
+  Alcotest.check s "discovered alone"
+    C.Has_discovered_work
+    (C.classify_actionable_signal (obs ~discovered:true ()))
+
+let test_zero_counts_are_inactive () =
+  (* count = 0 must NOT promote to *_activity (boundary check on ">0"). *)
+  Alcotest.check s "tasks=0, board=0, no_discovery"
+    C.No_actionable_signal
+    (C.classify_actionable_signal (obs ~tasks:0 ~board:0 ()))
+
+let test_negative_counts_are_inactive () =
+  (* defensive: if a buggy upstream sends a negative count, it must
+     not be treated as positive. *)
+  Alcotest.check s "negative tasks behave as zero"
+    C.No_actionable_signal
+    (C.classify_actionable_signal (obs ~tasks:(-1) ~board:(-3) ()))
+
+let test_is_actionable_boolean_consistency () =
+  let cases =
+    [
+      (C.No_actionable_signal, false);
+      (C.Has_unclaimed_tasks, true);
+      (C.Has_board_activity, true);
+      (C.Has_discovered_work, true);
+    ]
+  in
+  List.iter
+    (fun (sig_, expected) ->
+      Alcotest.(check bool) (C.actionable_signal_label sig_) expected
+        (C.is_actionable sig_))
+    cases
+
+let test_is_actionable_matches_classify () =
+  (* Boolean equivalence: classify(...) <> No_actionable_signal
+     iff is_actionable (classify ...) = true. *)
+  let observations =
+    [
+      obs ();
+      obs ~tasks:5 ();
+      obs ~board:3 ();
+      obs ~discovered:true ();
+      obs ~tasks:2 ~board:1 ~discovered:true ();
+    ]
+  in
+  List.iter
+    (fun o ->
+      let sig_ = C.classify_actionable_signal o in
+      let expected = sig_ <> C.No_actionable_signal in
+      Alcotest.(check bool)
+        (Printf.sprintf "is_actionable(%s) = (signal <> No_actionable_signal)"
+           (C.actionable_signal_label sig_))
+        expected (C.is_actionable sig_))
+    observations
+
+let () =
+  Alcotest.run "keeper_classifier_helper"
+    [
+      ( "classify_actionable_signal",
+        [
+          Alcotest.test_case "empty observation -> none" `Quick
+            test_no_signal_when_empty;
+          Alcotest.test_case "unclaimed_tasks beats all" `Quick
+            test_unclaimed_tasks_take_top_priority;
+          Alcotest.test_case "board beats discovered" `Quick
+            test_board_takes_second_priority;
+          Alcotest.test_case "discovered alone" `Quick
+            test_discovered_only_when_no_other;
+          Alcotest.test_case "zero counts are inactive" `Quick
+            test_zero_counts_are_inactive;
+          Alcotest.test_case "negative counts are inactive" `Quick
+            test_negative_counts_are_inactive;
+        ] );
+      ( "is_actionable",
+        [
+          Alcotest.test_case "boolean per variant" `Quick
+            test_is_actionable_boolean_consistency;
+          Alcotest.test_case "matches classify result" `Quick
+            test_is_actionable_matches_classify;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Adds a typed entry point for the keeper contract classifier ahead of the
call-site rewrite. Step 6b is split into 6b-1 (this PR — surface helper) and
6b-proper (follow-up — delete `String_util.contains_substring_ci` heuristic at
`keeper_agent_run.ml:2285-2298` once dual-emission divergence is measured).

### What lands

- `world_observation` record: `unclaimed_task_count`, `board_activity_count`,
  `has_discovered_work_section`. Mirrors the three substring markers the
  current call-site scrapes from the rendered prompt body.
- `classify_actionable_signal : world_observation -> actionable_signal` —
  applies the same precedence as today's heuristic
  (tasks > board > discovered).
- `is_actionable : actionable_signal -> bool` — boolean view that matches
  the existing `actionable_signal_context = true` semantics.

### What does NOT land

The string-match heuristic at `keeper_agent_run.ml:2285-2298` is **untouched**.
Removing it changes turn accept/reject behavior, so the plan calls for
1-release dual-logging with divergence > 0.1% alarm before deletion.

### Tests (8)

- empty observation → No_actionable_signal
- unclaimed_tasks beats board / discovered / both
- board beats discovered when no tasks
- discovered alone
- zero counts inactive (boundary check on `>0`)
- negative counts inactive (defensive)
- `is_actionable` boolean consistency across all 4 variants
- `is_actionable` matches `classify_actionable_signal <> No_actionable_signal`

## Test plan

- [x] `dune build --root .` clean
- [x] `dune exec test/test_keeper_classifier_helper.exe` — 8/8 pass
- [x] rebased on `e0a548f968` (latest main as of 2026-04-27)

## Plan reference

Bloodflow restoration plan, Phase 5 — Step 6b-1 (additive helper, safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)