### PR TITLE
chore(dashboard): migrate bg-white/3 to bg-[var(--white-3)] token (14 sites)

### DIFF
--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -190,7 +190,7 @@ function TaskEventTimeline({ events }: { events: AgentTimelineEvent[] }) {
           const icon = taskEventIcon(evt.type)
           const color = taskEventColor(evt.type)
           return html`
-            <div key=${idx} class="flex items-center gap-2 py-1.5 px-3 rounded hover:bg-white/3 transition-colors">
+            <div key=${idx} class="flex items-center gap-2 py-1.5 px-3 rounded hover:bg-[var(--white-3)] transition-colors">
               <span class="text-3xs font-bold uppercase tracking-wider ${color} bg-white/5 px-2 py-0.5 rounded">${icon}</span>
               <span class="text-xs text-text-body flex-1 truncate">${title}</span>
               ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
@@ -215,7 +215,7 @@ function BroadcastReport({ report, index }: { report: { ts: string; content: str
     <div class="border border-card-border/60 rounded bg-card/30 overflow-hidden hover:border-accent/20 transition-colors">
       <button
         type="button"
-        class="w-full flex items-center justify-between px-4 py-2.5 bg-white/3 border-b border-card-border/40 cursor-pointer select-none text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+        class="w-full flex items-center justify-between px-4 py-2.5 bg-[var(--white-3)] border-b border-card-border/40 cursor-pointer select-none text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
         onClick=${() => setExpanded(!expanded)}
         aria-expanded=${expanded}
       >

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -239,7 +239,7 @@ function timelineSeverityClass(severity: GoalDetailTimelineEvent['severity']): s
   switch (severity) {
     case 'bad': return 'border-bad/25 bg-bad/10 text-bad'
     case 'warn': return 'border-warn/25 bg-warn/10 text-warn'
-    default: return 'border-card-border/50 bg-white/3 text-text-body'
+    default: return 'border-card-border/50 bg-[var(--white-3)] text-text-body'
   }
 }
 
@@ -420,7 +420,7 @@ function coordinationViolationsForGoal(goalId: string): DashboardCoordinationFsm
 
 function TreeTask({ task }: { task: GoalTreeTask }) {
   return html`
-    <div class="flex flex-wrap items-center gap-2 rounded bg-white/3 px-2 py-1.5 text-xs">
+    <div class="flex flex-wrap items-center gap-2 rounded bg-[var(--white-3)] px-2 py-1.5 text-xs">
       <span class="size-2 rounded-sm shrink-0" style="background:${task.status_color}"></span>
       <span class="min-w-0 flex-1 truncate text-text-body">${task.title}</span>
       <span class="rounded border border-card-border/60 bg-white/4 px-1.5 py-0.5 text-3xs font-medium text-text-muted">
@@ -625,7 +625,7 @@ function DetailTabs({ active }: { active: GoalDetailTab }) {
           type="button"
           class="rounded border px-3 py-1.5 text-xs font-semibold uppercase tracking-wider transition-colors ${active === tab
             ? 'border-accent/35 bg-[var(--accent-10)] text-accent'
-            : 'border-card-border/60 bg-white/3 text-text-body hover:border-card-border/90'}"
+            : 'border-card-border/60 bg-[var(--white-3)] text-text-body hover:border-card-border/90'}"
           onClick=${() => { detailTab.value = tab }}
         >
           ${tab}
@@ -676,7 +676,7 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
         <div class="text-right text-text-body">${keeper.cascade_outcome ?? '-'}</div>
       </div>
       ${trustSummary || trust?.approval_state?.state || trust?.next_human_action ? html`
-        <div class="mt-3 rounded border border-card-border/50 bg-white/3 p-3">
+        <div class="mt-3 rounded border border-card-border/50 bg-[var(--white-3)] p-3">
           <div class="text-3xs font-semibold uppercase tracking-widest text-text-muted">검증 요약</div>
           ${trustSummary ? html`
             <div class="mt-2 text-xs leading-relaxed text-text-body">${trustSummary}</div>
@@ -695,7 +695,7 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
         </div>
       ` : null}
       ${latestEvent ? html`
-        <div class="mt-3 rounded border border-card-border/50 bg-white/3 p-3">
+        <div class="mt-3 rounded border border-card-border/50 bg-[var(--white-3)] p-3">
           <div class="flex flex-wrap items-center justify-between gap-2">
             <div class="text-3xs font-semibold uppercase tracking-widest text-text-muted">최근 키퍼 이벤트</div>
             <div class="text-3xs text-text-dim">

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -343,7 +343,7 @@ export function TaskBacklog() {
           ${hasMoreDone ? html`
             <button
               type="button"
-              class="w-full rounded border border-card-border/60 bg-white/3 px-3 py-2 text-xs font-medium text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
+              class="w-full rounded border border-card-border/60 bg-[var(--white-3)] px-3 py-2 text-xs font-medium text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
               onClick=${() => {
                 if (hasSearch) searchDoneVisibleCount.value += DONE_PAGE_SIZE
                 else doneVisibleCount.value += DONE_PAGE_SIZE

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -53,7 +53,7 @@ function ExternalDocLink({ href, label }: { href: string; label: string }) {
       href=${href}
       target="_blank"
       rel="noreferrer"
-      class="inline-flex items-center gap-1 rounded border border-card-border/70 bg-white/3 px-2.5 py-1.5 text-2xs font-medium text-text-body transition-colors hover:border-accent/35 hover:text-text-strong"
+      class="inline-flex items-center gap-1 rounded border border-card-border/70 bg-[var(--white-3)] px-2.5 py-1.5 text-2xs font-medium text-text-body transition-colors hover:border-accent/35 hover:text-text-strong"
     >
       ${label}
       <span aria-hidden="true">\u2197</span>
@@ -93,7 +93,7 @@ function GuideCard({
       </div>
       <p class="text-sm leading-relaxed text-text-muted whitespace-pre-wrap">${summary}</p>
       ${command ? html`
-        <div class="rounded border border-card-border/60 bg-white/3 px-3 py-2 text-xs leading-relaxed text-text-body">
+        <div class="rounded border border-card-border/60 bg-[var(--white-3)] px-3 py-2 text-xs leading-relaxed text-text-body">
           <code class="text-2xs text-text-strong">${command}</code>
         </div>
       ` : null}
@@ -139,7 +139,7 @@ function KeeperToolActivity() {
 
   return html`
     <details class="overview-section-collapsible group overflow-hidden rounded border border-card-border/60 bg-[var(--backdrop-deep)]" open=${true}>
-      <summary class="flex items-center gap-3 border-b border-card-border/60 px-4 py-3.5 cursor-pointer text-base font-bold text-text-strong transition-colors hover:bg-white/3">
+      <summary class="flex items-center gap-3 border-b border-card-border/60 px-4 py-3.5 cursor-pointer text-base font-bold text-text-strong transition-colors hover:bg-[var(--white-3)]">
         <div class="min-w-0">
           <div>도구 활동 요약</div>
           <div class="mt-1 text-xs font-normal text-text-muted">
@@ -175,7 +175,7 @@ function KeeperToolActivity() {
             <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted mb-2">최근 자주 사용된 도구</div>
             <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-1.5">
               ${topTools.map(([name, count]) => html`
-                <div key=${name} class="flex items-center justify-between rounded bg-white/3 px-3 py-1.5 text-xs">
+                <div key=${name} class="flex items-center justify-between rounded bg-[var(--white-3)] px-3 py-1.5 text-xs">
                   <span class="font-mono text-text-body truncate">${name.replace(/^(keeper_|masc_)/, '')}</span>
                   <span class="ml-2 flex-shrink-0 font-mono text-text-dim">${count}</span>
                 </div>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -170,7 +170,7 @@ function JudgeStatusBar() {
     ? 'text-warn'
     : 'text-bad/80'
   return html`
-    <div class="mb-4 flex items-center gap-3 rounded border border-white/5 bg-white/3 px-3.5 py-2 text-xs" data-testid="judge-status">
+    <div class="mb-4 flex items-center gap-3 rounded border border-white/5 bg-[var(--white-3)] px-3.5 py-2 text-xs" data-testid="judge-status">
       <span class="flex items-center gap-1.5">
         <${StatusDot} size="sm" class=${dotClass} />
         <span class="font-medium text-text-muted">평가 모델 ${label}</span>

--- a/dashboard/src/components/task-manage/task-create-form.ts
+++ b/dashboard/src/components/task-manage/task-create-form.ts
@@ -100,7 +100,7 @@ export function TaskCreateForm(props: { goalId?: string | null; goalTitle?: stri
               options=${PRIORITY_OPTIONS}
               onInput=${(v: string) => { priority.value = Number(v) }}
             />
-            <div class="rounded border border-card-border/60 bg-white/3 px-3 py-2 text-2xs leading-relaxed text-text-muted">
+            <div class="rounded border border-card-border/60 bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-text-muted">
               backlog 카드와 동일하게 <strong class="text-text-strong">P1 → P4</strong> 순으로 표시됩니다.
             </div>
           </div>


### PR DESCRIPTION
## Summary

Continues the `bg-white-alpha` bucket migration (#11212 swept /20, #11214 sweeps /10). This handles the 14 `bg-white/3` callsites with surgical scope — only the `bg-white/3` → `bg-[var(--white-3)]` swap.

## Sites migrated

- `governance.ts:173` — judge-status banner background
- `goals/kanban-components.ts:346` — done-column "show more" button
- `task-manage/task-create-form.ts:103` — priority hint card
- `goals/planning.ts:56, 96, 142(hover), 178` — 4 sites
- `goals/goal-tree.ts:242, 423, 628, 679, 698` — 5 sites
- `agent-detail-session-report.ts:193(hover), 218` — 2 sites

Total: 14 callsites across 6 files.

## Concurrency with #11214

Both PRs touch `governance.ts` and `goals/goal-tree.ts` at **non-overlapping line ranges**:
- #11214 edits `governance.ts:115` (refresh button); this PR edits `governance.ts:173` (judge-status banner) plus 5 other lines.
- #11214 edits `goal-tree.ts:333` (progress bar); this PR edits 5 other lines.

Pushing in parallel rather than serially — GitHub auto-merge queue handles the rebase deterministically, saving a CI cycle. If line-conflict surfaces despite the audit, manual rebase resolves it (low cost given the surgical scope).

## Drift

`bg-white-alpha`: 73 (baseline) → 71 (post #11212) → 65 (post #11214) → 51 (post this PR). Baseline regen deferred until /4 and /5 buckets land, then a single regen PR closes the cycle.

## Test plan

- [x] `pnpm test src/components/agent-detail-session-report` — 21/21 passed
- [x] `pnpm test src/components/goals/goal-tree src/components/governance src/components/goals/planning` — 90/90 passed
- [x] `pnpm typecheck` — clean
- [x] `bash scripts/dashboard-drift-check.sh` — `bg-white-alpha: 51 < baseline 73` PASS
- [ ] Reviewer spot-checks visual regression on judge-status banner / kanban done-column / planning hint cards / goal-tree default-tone rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)