### PR TITLE
feat(dashboard): Elev atomic primitive (atom 12/14)

### DIFF
--- a/dashboard/src/components/elev.test.ts
+++ b/dashboard/src/components/elev.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Elev, resolveLevel, type ElevProps } from './elev'
+
+describe('resolveLevel (pure)', () => {
+  it('returns 0 when level is undefined', () => {
+    expect(resolveLevel(undefined)).toBe(0)
+  })
+
+  it('passes through explicit levels 0..6', () => {
+    for (const lvl of [0, 1, 2, 3, 4, 5, 6] as const) {
+      expect(resolveLevel(lvl)).toBe(lvl)
+    }
+  })
+})
+
+describe('Elev', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    render(null, host)
+    host.remove()
+  })
+
+  function mount(props: ElevProps): HTMLDivElement {
+    render(html`<${Elev} ...${props} />`, host)
+    return host.firstElementChild as HTMLDivElement
+  }
+
+  // ── Structural ──
+
+  it('emits a <div> with data-elev', () => {
+    const el = mount({ children: 'card', level: 2 })
+    expect(el.tagName).toBe('DIV')
+    expect(el.getAttribute('data-elev')).toBe('2')
+  })
+
+  it('defaults to level 0 when omitted', () => {
+    const el = mount({ children: 'inset' })
+    expect(el.getAttribute('data-elev')).toBe('0')
+  })
+
+  it('forwards testId to data-testid', () => {
+    const el = mount({ children: 'x', testId: 'modal-shell' })
+    expect(el.getAttribute('data-testid')).toBe('modal-shell')
+  })
+
+  // ── Level fidelity (style attr inspection) ──
+
+  it('level 0 is chromeless (no shadow, transparent border)', () => {
+    const el = mount({ children: 'page', level: 0 })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-bg-page)')
+    expect(style.toLowerCase()).toContain('transparent')
+    expect(style).toContain('none')
+  })
+
+  it('level 1 uses panel-alt + thin downward shadow', () => {
+    const el = mount({ children: 'panel', level: 1 })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-bg-panel-alt)')
+    expect(style).toContain('0 1px 0')
+  })
+
+  it('level 2 uses elevated surface + inner highlight', () => {
+    const el = mount({ children: 'card', level: 2 })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-bg-elevated)')
+    expect(style).toContain('inset 0 1px 0')
+  })
+
+  it('level 3 introduces ambient drop shadow', () => {
+    const el = mount({ children: 'hover', level: 3 })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('var(--color-bg-hover)')
+    expect(style).toContain('0 2px 6px')
+  })
+
+  it('level 4 uses popover stack with outset ring', () => {
+    const el = mount({ children: 'menu', level: 4 })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('0 6px 18px')
+    expect(style).toContain('0 0 0 1px var(--color-border-strong)')
+  })
+
+  it('level 5 is drawer / sheet (12px drop)', () => {
+    const el = mount({ children: 'drawer', level: 5 })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('0 12px 32px')
+  })
+
+  it('level 6 is modal cap (24px drop, heaviest alpha)', () => {
+    const el = mount({ children: 'modal', level: 6 })
+    const style = el.getAttribute('style') ?? ''
+    expect(style).toContain('0 24px 64px')
+    expect(style).toContain('rgb(0 0 0 / 0.7)')
+  })
+
+  // ── Pass-through ──
+
+  it('forwards user class for layout / geometry', () => {
+    const el = mount({ children: 'x', level: 2, class: 'rounded-xs p-4' })
+    expect(el.getAttribute('class')).toBe('rounded-xs p-4')
+  })
+
+  it('forwards role + aria-label for semantic surfaces', () => {
+    const el = mount({
+      children: 'x',
+      level: 6,
+      role: 'dialog',
+      ariaLabel: 'Confirm retire',
+    })
+    expect(el.getAttribute('role')).toBe('dialog')
+    expect(el.getAttribute('aria-label')).toBe('Confirm retire')
+  })
+
+  it('renders children', () => {
+    const el = mount({ children: 'card body', level: 2 })
+    expect(el.textContent).toContain('card body')
+  })
+})

--- a/dashboard/src/components/elev.ts
+++ b/dashboard/src/components/elev.ts
@@ -1,0 +1,141 @@
+// Elev — atomic primitive ported from design-system v0.4 primitives.html
+// "Elevation" section (`<div class="elev-{N}">`). The SPEC defines a 7-
+// step (0..6) elevation stack — each step bundles three surface fields
+// (background + border + shadow). Step 0 is the page/inset surface
+// (chromeless), steps 1..2 are resting panel and card, 3 is hovered
+// card / selected row, 4..6 climb through floating menu / popover →
+// drawer / sheet → modal overlay (the cap).
+//
+// SPEC fidelity: matches design-system/source_styles/tokens.css
+// `--elev-{0..6}-{bg,border,shadow}` triples (lines 273-299) and
+// primitives.css `.elev-{0..6}` selectors (lines 247-253). Same
+// fidelity contract as chip.ts / pill.ts / btn.ts: dashboard runtime
+// does not import design-system source CSS, so the atom translates
+// the SPEC triples into inline style + the runtime semantic tokens
+// from styles/variables.css. Shadow stacks come through verbatim
+// because dashboard runtime has no shadow tier — the SPEC shadow
+// values are baked into the atom as the SSOT.
+//
+// Token dependencies (all in dashboard/src/styles/variables.css):
+//   --color-bg-page / -panel-alt / -elevated / -hover  (level surfaces)
+//   --color-border-divider / -default / -strong         (level borders)
+//
+// Usage: `<${Elev} level=${2} class="rounded-xs p-4">…<//>` — host DOM
+// is `<div>` by default. Layout (`display`, `padding`, `border-radius`)
+// is the caller's responsibility — Elev owns surface only (bg + border
+// + shadow), never geometry.
+//
+// Modals top out at 6 per SPEC (line 297-299 in tokens.css). Higher
+// levels are rejected at the type tier (`ElevLevel` is 0..6 union).
+
+import { html } from 'htm/preact'
+import type { ComponentChildren, JSX, VNode } from 'preact'
+
+export type ElevLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+export interface ElevProps {
+  children?: ComponentChildren
+  /** Elevation step. `undefined` ≡ level 0 (page / inset surface). */
+  level?: ElevLevel
+  /** Layout / geometry classes. Atom only owns surface tokens; padding,
+   *  display, border-radius all flow through here. */
+  class?: string
+  /** Forwarded to data-testid for E2E selectors. */
+  testId?: string
+  /** ARIA role override. Default is no role (a plain surface div). */
+  role?: string
+  /** Override for screen-reader label. */
+  ariaLabel?: string
+}
+
+interface LevelStyle {
+  background: string
+  border: string
+  boxShadow: string
+}
+
+// Surface triples match SPEC tokens.css lines 273-299 (`--elev-N-*`).
+// Background tokens map dashboard semantic surface tier to SPEC bg-N
+// (page / panel / panel-alt / elevated / hover); shadow stacks are
+// inlined verbatim because dashboard has no shadow scale equivalent.
+// Border-color tokens map SPEC line-N (subtle / default / strong) to
+// the dashboard `--color-border-*` semantic tier.
+const LEVEL_STYLE: Record<ElevLevel, LevelStyle> = {
+  // Page / inset — chromeless. Lives at SPEC bg-0.
+  0: {
+    background: 'var(--color-bg-page)',
+    border: '1px solid transparent',
+    boxShadow: 'none',
+  },
+  // Resting panel (sticky chrome). Single thin downward shadow.
+  1: {
+    background: 'var(--color-bg-panel-alt)',
+    border: '1px solid var(--color-border-divider)',
+    boxShadow: '0 1px 0 rgb(0 0 0 / 0.4)',
+  },
+  // Card / default section surface. Adds inner highlight.
+  2: {
+    background: 'var(--color-bg-elevated)',
+    border: '1px solid var(--color-border-default)',
+    boxShadow:
+      '0 1px 0 rgb(0 0 0 / 0.4), inset 0 1px 0 rgb(255 255 255 / 0.02)',
+  },
+  // Hovered card / selected row. First step with real ambient shadow.
+  3: {
+    background: 'var(--color-bg-hover)',
+    border: '1px solid var(--color-border-strong)',
+    boxShadow:
+      '0 2px 6px rgb(0 0 0 / 0.45), inset 0 1px 0 rgb(255 255 255 / 0.03)',
+  },
+  // Floating menu / popover. Outset ring for crisp edge over content.
+  4: {
+    background: 'var(--color-bg-hover)',
+    border: '1px solid var(--color-border-strong)',
+    boxShadow:
+      '0 6px 18px rgb(0 0 0 / 0.55), 0 0 0 1px var(--color-border-strong), inset 0 1px 0 rgb(255 255 255 / 0.03)',
+  },
+  // Drawer / sheet. Long drop, brighter inner highlight.
+  5: {
+    background: 'var(--color-bg-hover)',
+    border: '1px solid var(--color-border-strong)',
+    boxShadow:
+      '0 12px 32px rgb(0 0 0 / 0.6), 0 0 0 1px var(--color-border-strong), inset 0 1px 0 rgb(255 255 255 / 0.04)',
+  },
+  // Modal overlay — SPEC cap. Heaviest shadow, same chrome as drawer.
+  6: {
+    background: 'var(--color-bg-hover)',
+    border: '1px solid var(--color-border-strong)',
+    boxShadow:
+      '0 24px 64px rgb(0 0 0 / 0.7), 0 0 0 1px var(--color-border-strong), inset 0 1px 0 rgb(255 255 255 / 0.04)',
+  },
+}
+
+/** Pure: resolve the level default. Exported for tests so the
+ *  defaulting rule stays observable without a DOM mount. */
+export function resolveLevel(level: ElevLevel | undefined): ElevLevel {
+  return level ?? 0
+}
+
+export function Elev(props: ElevProps): VNode {
+  const level = resolveLevel(props.level)
+  const ls = LEVEL_STYLE[level]
+
+  const style: JSX.CSSProperties = {
+    background: ls.background,
+    border: ls.border,
+    boxShadow: ls.boxShadow,
+  }
+
+  return html`
+    <div
+      class=${props.class}
+      data-testid=${props.testId}
+      data-elev=${String(level)}
+      role=${props.role}
+      aria-label=${props.ariaLabel}
+      style=${style}
+    >
+      ${props.children}
+    </div>
+  `
+}


### PR DESCRIPTION
## Summary

Twelfth atomic primitive port from `design-system v0.4 primitives.html` — the **Elevation** section. **Elev** is the canonical *surface* atom: a 7-step elevation scale (level 0..6) where each step bundles three surface fields (background + border + shadow). Step 6 is the SPEC modal cap.

Same fidelity contract as `chip.ts` / `pill.ts` / `btn.ts`: dashboard runtime does not import design-system source CSS, so the atom translates SPEC `.elev-{0..6}` rules into inline `style` + the runtime semantic tokens (`styles/variables.css`).

### 14-atom progress

| # | atom | PR | status |
|---|------|----|--------|
| 1-10 | Chip / Pill / Bar / Band / SectionHead / KvRow / Spark / Surf / Kbd / Tk-Sep | merged | ✓ |
| 11 | Btn | #11215 | merged |
| **12** | **Elev** | **this PR** | **draft** |
| 13 | Focus ring (\`.focusable\`) | — | next |
| 14 | Motion (\`anim-*\`) | — | next |

### 7-step elevation matrix

| level | use | bg | shadow signature |
|---|---|---|---|
| 0 | page / inset | bg-page | none (chromeless) |
| 1 | resting panel / sticky chrome | bg-panel-alt | \`0 1px 0\` thin downward |
| 2 | card / default section | bg-elevated | \`0 1px 0\` + \`inset 0 1px 0\` (inner highlight) |
| 3 | hovered card / selected row | bg-hover | \`0 2px 6px\` first ambient drop |
| 4 | floating menu / popover | bg-hover | \`0 6px 18px\` + \`0 0 0 1px\` outset ring |
| 5 | drawer / sheet | bg-hover | \`0 12px 32px\` long drop |
| 6 | modal overlay (cap) | bg-hover | \`0 24px 64px\` heaviest, \`0.7\` alpha |

### Layout discipline

Elev owns *surface* only — background, border, box-shadow. Padding, display, border-radius all flow through the \`class\` prop to the caller. This flips the convention from chip/pill/btn (which own geometry) because the same elevation level can wrap a 24px popover or a full-viewport drawer; atom-level geometry would lock surface to a single use case.

\`\`\`tsx
<\${Elev} level=\${4} class=\"rounded-xs p-3 min-w-[200px]\">
  <ul>...</ul>
</\${Elev}>
\`\`\`

### No callsite swap (intentional)

Dashboard runtime has **0 callsites** referencing \`--elev-N-*\` tokens (\`tokens.generated.css\` is not imported by \`main.ts\`). Elev is a pure SSOT introduction — no existing surface to disturb. Follow-up sweep PRs will adopt Elev in dashboard surfaces tier by tier (modal/popover/drawer first, where the SPEC visual delta is largest). Same Sep #11203 / Btn #11215 atom-only pattern.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test elev\` — 15/15 pass (2 pure + 13 DOM)
- [x] \`pnpm lint\` clean
- [ ] Manual visual: \`pnpm dev\` → http://localhost:5173/dashboard/design-system/preview/primitives.html — Elevation section level 0..6 stack
- [ ] CI required checks green before Ready

## Self-review notes

**Goal**: introduce Elev atom (12/14) without disturbing existing surface.
**Changed files**: 2 (1 atom, 1 test). No CSS sync needed — primitives.css already complete for elev.
**Local verification**: typecheck + test + lint green.
**Unverified**: shadow stacks render fidelity vs. SPEC primitives.html — relies on reviewer or follow-up Playwright PR. Same happy-dom limitation applies (CSS custom properties in \`box-shadow\` reflect, in \`border\` shorthand drop) as Btn #11215, mitigated in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)