### PR TITLE
ci: add OCaml structural-debt ratchet gate (PR#0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -671,6 +671,20 @@ jobs:
         working-directory: dashboard
         run: pnpm test
 
+  structure-ratchet:
+    name: OCaml Structure Ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [pr-sync-check, changes]
+    if: ${{ !cancelled() && (needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run OCaml structure ratchet
+        run: scripts/ocaml-structure-ratchet.sh
+
   tla-specs:
     name: TLA+ Model Checking
     runs-on: ubuntu-latest
@@ -701,7 +715,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [pr-sync-check, changes, meta, build, lint, dashboard, health, tla-specs]
+    needs: [pr-sync-check, changes, meta, build, lint, dashboard, health, structure-ratchet, tla-specs]
     if: ${{ !cancelled() }}
     timeout-minutes: 2
 
@@ -754,6 +768,7 @@ jobs:
           LINT_RESULT: ${{ needs.lint.result }}
           DASHBOARD_RESULT: ${{ needs.dashboard.result }}
           HEALTH_RESULT: ${{ needs.health.result }}
+          STRUCTURE_RATCHET_RESULT: ${{ needs.structure-ratchet.result }}
           TLA_RESULT: ${{ needs.tla-specs.result }}
           BUILD_ADVISORY_STATUS: ${{ needs.build.outputs.advisory_status }}
         run: |
@@ -796,5 +811,6 @@ jobs:
           check "lint"            "$LINT_RESULT"
           check "dashboard"       "$DASHBOARD_RESULT"
           check "health"          "$HEALTH_RESULT"
+          check "structure-ratchet" "$STRUCTURE_RATCHET_RESULT"
           check "tla-specs"       "$TLA_RESULT"
           [ "$fail" -eq 0 ]

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
+  "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
+  "keeper_mli_missing": 51,
+  "coord_mli_missing": 3,
+  "godsplit_count": 11,
+  "lib_dune_lines": 962
+}

--- a/scripts/ocaml-structure-ratchet.sh
+++ b/scripts/ocaml-structure-ratchet.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# OCaml structural-debt ratchet gate.
+#
+# Tracks 4 metrics that capture structural debt called out by external review
+# (Jane-Street-style large-OCaml expectations):
+#
+#   - keeper_mli_missing: count of lib/keeper/keeper_*.ml files without a
+#     matching .mli (interface-first design gap)
+#   - coord_mli_missing : same metric for lib/coord/
+#   - godsplit_count    : occurrences of `;; godsplit` markers in lib/dune
+#     (god-file decomposition stubs left as comments — should converge to 0
+#     by sub-library extraction)
+#   - lib_dune_lines    : raw line count of lib/dune (proxy for the
+#     monolithic-library debt; sub-library splits should reduce this)
+#
+# Policy: ratchet only — current value must be <= committed baseline. PRs
+# that reduce debt may regenerate the baseline (intentional "downward
+# ratchet"). Increases must be justified by --regenerate with a paired
+# follow-up issue (anti-pattern: silent baseline rebound after admin
+# override; see masc-mcp memory feedback_ratchet-naturalization-after-admin-merge).
+#
+# Usage:
+#   scripts/ocaml-structure-ratchet.sh              # check; exit 0 ok / 2 drift up / 1 error
+#   scripts/ocaml-structure-ratchet.sh --regenerate # rewrite baseline from current counts
+#   scripts/ocaml-structure-ratchet.sh --print      # print current counts, no compare
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BASELINE_FILE="${REPO_ROOT}/scripts/ocaml-structure-baseline.json"
+
+count_mli_missing() {
+  local dir="$1"
+  local prefix_glob="$2"
+  local ml_count mli_count
+  ml_count=$(find "${REPO_ROOT}/${dir}" -maxdepth 1 -type f -name "${prefix_glob}.ml" 2>/dev/null | wc -l | tr -d ' ')
+  mli_count=$(find "${REPO_ROOT}/${dir}" -maxdepth 1 -type f -name "${prefix_glob}.mli" 2>/dev/null | wc -l | tr -d ' ')
+  echo $((ml_count - mli_count))
+}
+
+count_godsplit() {
+  rg -c '^\s*;;\s*godsplit' "${REPO_ROOT}/lib/dune" 2>/dev/null || echo 0
+}
+
+count_lib_dune_lines() {
+  wc -l < "${REPO_ROOT}/lib/dune" | tr -d ' '
+}
+
+# Metric definitions: name|hint
+METRICS=(
+  "keeper_mli_missing|Add .mli for the new lib/keeper/keeper_*.ml file. See planning/claude-plans/moonlit-finding-russell.md PR#2-4."
+  "coord_mli_missing|Add .mli for the new lib/coord/*.ml file."
+  "godsplit_count|Do not add new ';; godsplit' markers in lib/dune — extract a real sub-library instead. See PR#7-10."
+  "lib_dune_lines|lib/dune is growing — consider extracting modules into a sub-library (lib/keeper/dune, lib/oas/dune, lib/dashboard/dune)."
+)
+
+current_value() {
+  case "$1" in
+    keeper_mli_missing) count_mli_missing "lib/keeper" "keeper_*" ;;
+    coord_mli_missing)  count_mli_missing "lib/coord"  "*" ;;
+    godsplit_count)     count_godsplit ;;
+    lib_dune_lines)     count_lib_dune_lines ;;
+    *) echo "unknown metric: $1" >&2; exit 1 ;;
+  esac
+}
+
+baseline_value() {
+  local name="$1"
+  if [[ -f "$BASELINE_FILE" ]]; then
+    python3 -c "
+import json, sys
+with open('$BASELINE_FILE') as f:
+    data = json.load(f)
+print(data.get('$name', 0))
+"
+  else
+    echo 0
+  fi
+}
+
+print_counts() {
+  printf "%-22s %9s  %9s\n" "metric" "current" "baseline"
+  echo "------------------------------------------------"
+  for spec in "${METRICS[@]}"; do
+    local name="${spec%%|*}"
+    local current baseline
+    current=$(current_value "$name")
+    baseline=$(baseline_value "$name")
+    printf "%-22s %9d  %9d\n" "$name" "$current" "$baseline"
+  done
+}
+
+regenerate() {
+  local tmpfile
+  tmpfile=$(mktemp)
+  {
+    echo '{'
+    echo '  "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",'
+    echo '  "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",'
+    local first=1
+    for spec in "${METRICS[@]}"; do
+      local name="${spec%%|*}"
+      local current
+      current=$(current_value "$name")
+      if [[ $first -eq 1 ]]; then first=0; else echo ','; fi
+      printf '  "%s": %s' "$name" "$current"
+    done
+    echo
+    echo '}'
+  } > "$tmpfile"
+  mv "$tmpfile" "$BASELINE_FILE"
+  echo "Baseline written to $BASELINE_FILE"
+  print_counts
+}
+
+check() {
+  if [[ ! -f "$BASELINE_FILE" ]]; then
+    echo "ERROR: baseline file not found: $BASELINE_FILE" >&2
+    echo "Run: $0 --regenerate" >&2
+    exit 1
+  fi
+
+  local drift_up=0
+  local drift_down=0
+
+  for spec in "${METRICS[@]}"; do
+    local name="${spec%%|*}"
+    local hint="${spec#*|}"
+    local current baseline
+    current=$(current_value "$name")
+    baseline=$(baseline_value "$name")
+
+    if [[ "$current" -gt "$baseline" ]]; then
+      echo "FAIL $name: $current > baseline $baseline" >&2
+      echo "     Fix: $hint" >&2
+      drift_up=$((drift_up + 1))
+    elif [[ "$current" -lt "$baseline" ]]; then
+      echo "OK   $name: $current < baseline $baseline (baseline can be lowered)" >&2
+      drift_down=$((drift_down + 1))
+    fi
+  done
+
+  if [[ $drift_up -gt 0 ]]; then
+    echo >&2
+    echo "OCaml structure ratchet: $drift_up metric(s) exceeded baseline." >&2
+    echo "Either fix the regression, or (if intentional) run: $0 --regenerate" >&2
+    echo "and pair the regenerate commit with a follow-up issue." >&2
+    exit 2
+  fi
+
+  if [[ $drift_down -gt 0 ]]; then
+    echo >&2
+    echo "Hint: $drift_down metric(s) dropped below baseline. Consider: $0 --regenerate" >&2
+  fi
+
+  echo "OCaml structure ratchet: OK"
+  exit 0
+}
+
+case "${1:-check}" in
+  --regenerate) regenerate ;;
+  --print)      print_counts ;;
+  check|"")     check ;;
+  -h|--help)
+    sed -n '1,28p' "$0"
+    exit 0
+    ;;
+  *)
+    echo "Unknown arg: $1" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- 4종 OCaml 구조 부채 metric에 단방향 단조감소 ratchet gate 추가:
  - `keeper_mli_missing` = 51 (lib/keeper/*.ml 중 .mli 없는 개수)
  - `coord_mli_missing`  = 3
  - `godsplit_count`     = 11 (`;; godsplit` 주석 개수)
  - `lib_dune_lines`     = 962 (단일 lib 라이브러리 비대화 proxy)
- 패턴은 기존 `scripts/dashboard-drift-check.sh`를 그대로 차용 (zero/ratchet policy, baseline JSON, `--regenerate`/`--print`/`check`, exit 0/2/1).
- `.github/workflows/ci.yml`에 `structure-ratchet` job 추가, ci-gate aggregate에 포함.

## Why
외부 평가 보고서가 masc-mcp의 OCaml 구조 부채(라이브러리 분리 D, .mli 불균형 C+, godsplit 누적)를 **종합 C+**로 평가했고, 그 영역을 점진적으로 갚아 나가는 PR 시퀀스(`planning/claude-plans/moonlit-finding-russell.md`의 PR#1-#12)가 예정되어 있다. 본 PR이 회귀 방지 게이트를 먼저 깔아 baseline 단조감소만 허용한다.

이미 머지된 #11216 같은 ratchet-related fix와 정렬: 기존 dashboard-drift 게이트와 동일한 contract라 review 비용을 최소화한다.

## Anti-pattern guarded
- `ratchet-naturalization-after-admin-merge` (memory): admin override로 baseline이 silent rebound되는 사고. `--regenerate`은 의도적 호출만 가능, 단조감소 위반 시 hard-fail.
- godsplit 무한반복: 신규 `;; godsplit` 주석이 baseline=11에서 단조감소만 가능.

## Test plan
- [x] `scripts/ocaml-structure-ratchet.sh --print` — current/baseline 일치 확인
- [x] `scripts/ocaml-structure-ratchet.sh` — exit 0
- [x] baseline 인위적 감소 후 re-run — exit 2 + FAIL 메시지 + hint
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` 통과
- [ ] CI `structure-ratchet` job green
- [ ] CI gate aggregate에 `PASS structure-ratchet` 출력

## Follow-ups (별도 PR)
- branch protection의 required-checks 목록에 `structure-ratchet` 추가 (GitHub 설정 권한 필요)
- PR#1: godsplit 11 → 0
- PR#2-#4: keeper_mli_missing 51 → 0
- PR#7-#10: lib_dune_lines 962 → ~600

🤖 Generated with [Claude Code](https://claude.com/claude-code)