### PR TITLE
feat(dashboard): focusable atomic primitive (atom 13/14)

### DIFF
--- a/dashboard/src/components/focusable.test.ts
+++ b/dashboard/src/components/focusable.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import {
+  focusable,
+  FOCUSABLE_CLASS,
+  FOCUSABLE_ERR_CLASS,
+} from './focusable'
+
+describe('focusable constants', () => {
+  it('FOCUSABLE_CLASS is the bare SPEC class', () => {
+    expect(FOCUSABLE_CLASS).toBe('focusable')
+  })
+
+  it('FOCUSABLE_ERR_CLASS chains the SPEC `.is-err` modifier', () => {
+    expect(FOCUSABLE_ERR_CLASS).toBe('focusable is-err')
+  })
+})
+
+describe('focusable()', () => {
+  it('returns the bare class when called with no arg', () => {
+    expect(focusable()).toBe('focusable')
+  })
+
+  it('returns the bare class for an empty option bag', () => {
+    expect(focusable({})).toBe('focusable')
+  })
+
+  it('returns the bare class when err is undefined', () => {
+    expect(focusable({ err: undefined })).toBe('focusable')
+  })
+
+  it('returns the bare class when err is explicit false', () => {
+    expect(focusable({ err: false })).toBe('focusable')
+  })
+
+  it('chains is-err only when err is explicit true', () => {
+    expect(focusable({ err: true })).toBe('focusable is-err')
+  })
+
+  it('result is a stable literal — repeated calls return identical strings', () => {
+    expect(focusable()).toBe(focusable())
+    expect(focusable({ err: true })).toBe(focusable({ err: true }))
+  })
+
+  // Concatenation pattern that callers will use — verifies the
+  // returned fragment composes cleanly with arbitrary leading classes
+  // (no leading/trailing whitespace, no double spaces).
+  it('composes with leading classes via template literal', () => {
+    const composed = `btn primary ${focusable()}`
+    expect(composed).toBe('btn primary focusable')
+  })
+
+  it('composes the err variant the same way', () => {
+    const composed = `input mono ${focusable({ err: true })}`
+    expect(composed).toBe('input mono focusable is-err')
+  })
+})

--- a/dashboard/src/components/focusable.ts
+++ b/dashboard/src/components/focusable.ts
@@ -1,0 +1,51 @@
+// Focusable — atomic primitive ported from design-system v0.4
+// primitives.html "Focus ring" section (`<input class="focusable">`,
+// `<button class="focusable">`). The SPEC defines an opt-in brass
+// double-ring keyboard focus treatment that supersedes the dashboard's
+// default global single-ring. SPEC primitives.css line 279-280:
+//
+//   .focusable:focus-visible       { box-shadow: var(--focus-ring); }
+//   .focusable.is-err:focus-visible { box-shadow: var(--focus-ring-err); }
+//
+// Where `--focus-ring` is the brass double-ring (1px solid brass + 3px
+// translucent brass glow) and `--focus-ring-err` swaps brass for err
+// status. The CSS side lives in dashboard/src/styles/a11y.css next to
+// the global `:focus-visible` rule so the layering relationship is
+// explicit: global single-ring is the default; `.focusable` upgrades.
+//
+// This module is the *helper SSOT* — callers use the `focusable()`
+// function rather than reaching for raw `class="focusable"` strings,
+// so an eslint rule (future) can flag bare-string usage and force
+// authors through this module. Same fidelity contract as chip.ts /
+// pill.ts / btn.ts / elev.ts: dashboard owns runtime tokens, atom owns
+// SPEC translation.
+//
+// Usage:
+//   <input class=${focusable()} />
+//   <input class=${focusable({ err: true })} />
+//   <button class=${`btn ${focusable()}`}>...</button>
+//
+// The class string composes with arbitrary user classes via template-
+// literal concatenation; the helper does not own combinator logic
+// because callers already pass user classes through atom `class` props
+// (see Btn / Elev) and adding another collapse path here would
+// duplicate that responsibility.
+
+export const FOCUSABLE_CLASS = 'focusable'
+export const FOCUSABLE_ERR_CLASS = 'focusable is-err'
+
+export interface FocusableOptions {
+  /** When true, the focus ring uses err-status tokens instead of
+   *  brass. Pair with form input invalid states or destructive
+   *  controls that have an error condition. */
+  err?: boolean
+}
+
+/** Returns the SPEC-canonical class string for the brass double-ring
+ *  focus treatment. Pass `{ err: true }` to swap brass for err status.
+ *
+ *  The result is a literal class fragment — caller composes with
+ *  layout / atom classes via template literals or join helpers. */
+export function focusable(opts?: FocusableOptions): string {
+  return opts?.err === true ? FOCUSABLE_ERR_CLASS : FOCUSABLE_CLASS
+}

--- a/dashboard/src/styles/a11y.css
+++ b/dashboard/src/styles/a11y.css
@@ -12,6 +12,27 @@
   outline: none;
 }
 
+/* SPEC v0.4 atom 13/14 — `.focusable` brass double-ring opt-in.
+   Layered on top of the global `:focus-visible` accent ring above:
+   the global single-ring stays as the default for all interactive
+   elements; `.focusable` upgrades to the SPEC primitives.css
+   line 279-280 brass double-ring (1px solid brass + 3px translucent
+   brass glow) when explicitly opted in. `.is-err` swaps brass for
+   err status — same SPEC line 280. */
+.focusable:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 1px var(--color-accent-brass),
+    0 0 0 3px rgb(var(--brass-glow) / 0.25);
+}
+
+.focusable.is-err:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 1px var(--color-status-err),
+    0 0 0 3px rgb(var(--color-status-err-glow) / 0.3);
+}
+
 /* Screen-reader only utility — visually hidden but accessible to assistive tech. */
 .sr-only {
   position: absolute;

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -50,6 +50,9 @@
                                      surfaces (e.g. Pill running state).
                                      Identical to --info-glow because
                                      info ≡ accent in SPEC §3.5. */
+  --brass-glow:  212 161  74;     /* rgb(--color-accent-brass #d4a14a) —
+                                     translucent brass for SPEC v0.4 atom
+                                     13/14 `.focusable` double-ring. */
 
   /* Semantic - Accent (Blue) */
   --accent-soft: rgba(71, 184, 255, 0.16);


### PR DESCRIPTION
## Summary

Thirteenth atomic primitive port from `design-system v0.4 primitives.html` — the **Focus ring** section. **focusable** is the canonical *opt-in keyboard focus* atom: a SPEC brass double-ring treatment that supersedes the dashboard's global single-ring (`a11y.css:5-8`) when explicitly applied. Atom 13/14 ships as **CSS @utility + helper module** rather than a Preact component (chip/pill/btn/elev pattern) because focus ring is applied *to* an interactive element via class composition, not by wrapping — wrapping would change the focusable target.

### 14-atom progress

| # | atom | PR | status |
|---|------|----|--------|
| 1-10 | Chip / Pill / Bar / Band / SectionHead / KvRow / Spark / Surf / Kbd / Tk-Sep | merged | ✓ |
| 11 | Btn | #11215 | merged |
| 12 | Elev | #11219 | open |
| **13** | **focusable** | **this PR** | **draft** |
| 14 | Motion (\`anim-*\`) | — | next (last) |

### What this PR adds

| layer | file | change |
|---|---|---|
| token | \`dashboard/src/styles/variables.css\` | +1 line: \`--brass-glow: 212 161 74\` rgb-triplet (matches \`--color-accent-brass #d4a14a\`) |
| CSS | \`dashboard/src/styles/a11y.css\` | +18 lines: \`.focusable:focus-visible\` + \`.focusable.is-err:focus-visible\` rules |
| helper | \`dashboard/src/components/focusable.ts\` | new — \`focusable()\` function + 2 constants |
| test | \`dashboard/src/components/focusable.test.ts\` | new — 10 pure tests |

### SPEC fidelity

primitives.css line 279-280:

\`\`\`css
.focusable:focus-visible       { box-shadow: var(--focus-ring); }
.focusable.is-err:focus-visible { box-shadow: var(--focus-ring-err); }
\`\`\`

Translates to dashboard runtime via the existing \`--color-accent-brass\` + new \`--brass-glow\` tokens:

\`\`\`css
.focusable:focus-visible {
  box-shadow: 0 0 0 1px var(--color-accent-brass),
              0 0 0 3px rgb(var(--brass-glow) / 0.25);
}
\`\`\`

### Public API

\`\`\`tsx
import { focusable } from './components/focusable'

<input class={focusable()} />
<input class={focusable({ err: true })} />
<button class={\`btn primary \${focusable()}\`}>Save</button>
\`\`\`

The helper SSOT pattern enables a future eslint rule to flag bare \`class=\"focusable\"\` strings.

### Layering with global focus

The dashboard already meets WCAG 2.4.7 via \`a11y.css:5-8\`:

\`\`\`css
:focus-visible { outline: 2px solid var(--accent-45); outline-offset: 2px; }
\`\`\`

\`.focusable\` is an *opt-in upgrade* — global single-ring stays default, brass double-ring activates only on opted-in elements. No regression in baseline a11y.

### No callsite swap (intentional)

Same Sep #11203 / Btn #11215 / Elev #11219 atom-only pattern. Follow-up sweep PRs will adopt \`focusable()\` in form inputs / Btn / interactive cards tier by tier (form fields first, where err-state pairing has the largest delta).

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test focusable\` — 10/10 pass (pure module, no DOM)
- [x] \`pnpm lint\` clean
- [ ] Manual visual: \`pnpm dev\` → http://localhost:5173/dashboard/design-system/preview/primitives.html — Focus ring section, Tab through inputs/buttons
- [ ] CI required checks green before Ready

## Self-review notes

**Goal**: introduce focusable atom (13/14) opt-in over existing global focus.
**Changed files**: 4 (1 token, 1 CSS rule, 1 helper, 1 test).
**Local verification**: typecheck + test + lint green.
**Unverified**: \`:focus-visible\` SPEC visual fidelity vs primitives.html requires keyboard interaction in browser (vitest pure tests cover the helper API only). Same a11y.css + variables.css patterns as existing dashboard tokens — no new architecture surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)