### PR TITLE
fix(tla-check): remove duplicate KeeperTurnFSM run_tlc invocations

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -173,8 +173,6 @@ run_tlc "$REPO_ROOT/specs/state-product" "CoordinationProduct.tla"
 run_tlc_buggy "$REPO_ROOT/specs/state-product" "CoordinationProduct.tla"
 run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
-run_tlc "$REPO_ROOT/specs/keeper-turn-fsm" "KeeperTurnFSM.tla"
-run_tlc_buggy "$REPO_ROOT/specs/keeper-turn-fsm" "KeeperTurnFSM.tla"
 
 # Optional: run TraceSpec if --trace flag provided
 if [ "${1:-}" = "--trace" ]; then


### PR DESCRIPTION
## Summary

Two prior fix attempts for #11197 merged in parallel, leaving `scripts/tla-check.sh` with duplicate `KeeperTurnFSM` invocations:

- `b1c1822980` — added at line 164-165 (after `OperatorPauseBroadcast`)
- `483d947ffc` — added at line 176-177 (after `TaskLifecycle`)

Both pairs are currently present, so TLC model-checks `KeeperTurnFSM.tla` twice on every CI run.

## Change

Remove the later duplicate (line 176-177). The earlier placement (164-165, adjacent to `OperatorPauseBroadcast` in the keeper-state-machine cluster) is retained.

```diff
-run_tlc "$REPO_ROOT/specs/keeper-turn-fsm" "KeeperTurnFSM.tla"
-run_tlc_buggy "$REPO_ROOT/specs/keeper-turn-fsm" "KeeperTurnFSM.tla"
```

## Verification

- `rg 'KeeperTurnFSM' scripts/tla-check.sh` → 2 matches (164-165)
- `bash -n scripts/tla-check.sh` → syntax OK
- `specs/keeper-turn-fsm/KeeperTurnFSM.{cfg,-buggy.cfg}` already exist, so the single remaining invocation pair has both clean and buggy specs to check.

## Background — autocoder duplicate squash-merge race

The duplicate is the result of two autocoder PRs racing on the same fix and both squash-merging within seconds of each other (a recurring pattern documented in MEMORY `feedback_autocoder-duplicate-squash-merge.md`). This PR is purely deduplication — no behavior change beyond CI runtime.

Closes #11197