### PR TITLE
feat(cascade): add optional trace_id to strategy trace event (G2a)

### DIFF
--- a/lib/cascade/cascade_strategy_trace.ml
+++ b/lib/cascade/cascade_strategy_trace.ml
@@ -11,6 +11,7 @@ type event = {
   candidates_out : int;
   backoff_ms : int;
   kind : event_kind;
+  trace_id : string option;
 }
 
 let kind_to_string = function

--- a/lib/cascade/cascade_strategy_trace.mli
+++ b/lib/cascade/cascade_strategy_trace.mli
@@ -54,6 +54,18 @@ type event = {
   candidates_out : int;
   backoff_ms : int;
   kind : event_kind;
+  trace_id : string option;
+      (** Optional outer trace identifier for cross-system correlation.
+
+          Step 0a (PR #11154) added [keeper_turn_id] propagation through
+          [log.ml] and [keeper_tool_call_log.ml]; this field carries the
+          same identifier into the cascade strategy ring so the dashboard
+          and [bin/masc_trace] can join cascade decisions to the originating
+          turn timeline.
+
+          Producers that do not yet thread the identifier should pass
+          [None]; downstream consumers must treat [None] as "unknown",
+          not as failure. *)
 }
 
 val record : event -> unit

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -772,6 +772,11 @@ let client_capacity_history_json ?limit ?kind ?since_ts () =
 
 let strategy_trace_event_to_json (ev : Cascade_strategy_trace.event)
   : Yojson.Safe.t =
+  let trace_id_json =
+    match ev.trace_id with
+    | None -> `Null
+    | Some id -> `String id
+  in
   `Assoc [
     ("ts", `Float ev.ts);
     ("cascade_name", `String ev.cascade_name);
@@ -781,6 +786,7 @@ let strategy_trace_event_to_json (ev : Cascade_strategy_trace.event)
     ("candidates_out", `Int ev.candidates_out);
     ("backoff_ms", `Int ev.backoff_ms);
     ("kind", `String (Cascade_strategy_trace.kind_to_string ev.kind));
+    ("trace_id", trace_id_json);
   ]
 
 let strategy_trace_json ?limit ?cascade () =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1952,6 +1952,11 @@ let run_named
       candidates_out;
       backoff_ms;
       kind;
+      (* trace_id is left [None] until the keeper_turn_id wired by
+         Step 0a is threaded into [try_cascade]; downstream consumers
+         (dashboard_cascade, bin/masc_trace) already render [None] as
+         a JSON [null] so producers can adopt incrementally. *)
+      trace_id = None;
     }
   in
   let rec cycle_loop n =


### PR DESCRIPTION
## Summary

Cascade strategy trace events lack any cross-system identifier — the dashboard ring shows *what* cascade decisions happened but operators cannot join those decisions to the originating turn timeline that `bin/masc_trace` (PR #11168) and Step 0a (PR #11154) wired through `log.ml` + `keeper_tool_call_log.ml`.

Adds `trace_id : string option` to the `Cascade_strategy_trace.event` record. **Additive**: producers that do not yet thread the identifier pass `None`; the existing `oas_worker_named.ml` record site does so explicitly with a TODO. The dashboard JSON projection emits `null` for `None` and `string` for `Some`, so downstream consumers adopt incrementally.

## Evidence

Source: `planning/claude-plans/appendix/README.md` (v4) Sprint 1 Track A in v0.6 Parallel Sprint plan.

Forensic: `appendix/masc-mcp-keeper-stage0-C.md` (cascade_audit telemetry gap — null 95% on concurrent-cascade trace fields).

## Changes

| File | Change | LOC |
|------|--------|-----|
| `lib/cascade/cascade_strategy_trace.mli` | New `trace_id : string option` field with docstring | +12 |
| `lib/cascade/cascade_strategy_trace.ml` | Same field on the record | +1 |
| `lib/oas_worker_named.ml` | Pass `trace_id = None` at the single record site (TODO for wiring) | +5 |
| `lib/dashboard_cascade.ml` | JSON projection emits `null`/`string` for the new field | +6 |

Net: +24 / 0 (4 files).

## Test plan

- [x] `dune build --root . lib/` green
- [x] `dune build --root . test/` green (test file builds + record literal sites unchanged elsewhere)
- [ ] Follow-up PR threads `keeper_turn_id` from `try_cascade` callers into `record_trace`, replacing the `None` placeholder

## Risk

- Behavior change: dashboard JSON now includes a new `trace_id` field. Consumers must tolerate the additional field — Yojson Assoc traversal in masc-mcp ignores unknown fields, so this is safe.
- No runtime semantics change — `trace_id = None` everywhere until follow-up wiring.
- No new tests added because behavior is equivalent (`None` projection); follow-up wiring PR will add coverage when the field carries a real value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)