### PR TITLE
refactor(keeper): add .mli interfaces for 5 keeper modules (PR#2 batch 1)

### DIFF
--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -1,0 +1,46 @@
+(** Error translation helpers for keeper Agent.run orchestration. *)
+
+type keeper_internal_error =
+  | Keeper_tool_surface_empty of
+      { keeper_name : string
+      ; turn_lane : string
+      ; affordances : string list
+      ; fallback_used : bool
+      }
+  | Keeper_tool_surface_mismatch of
+      { keeper_name : string
+      ; required_tools : string list
+      ; missing_required_tools : string list
+      ; visible_tools : string list
+      }
+
+(** Prefix prepended to the JSON-encoded internal-error message. *)
+val keeper_internal_error_prefix : string
+
+(** Encode a [keeper_internal_error] as a JSON object suitable for log
+    payloads and dashboard surfaces. *)
+val keeper_internal_error_to_json : keeper_internal_error -> Yojson.Safe.t
+
+(** Wrap a [keeper_internal_error] inside [Oas.Error.Internal] so it
+    flows through the standard SDK error channel with a recognizable
+    prefix. *)
+val sdk_error_of_keeper_internal_error : keeper_internal_error -> Oas.Error.sdk_error
+
+(** Coarse categorisation of [Oas.Error.sdk_error] (for dashboards). *)
+val sdk_error_kind : Oas.Error.sdk_error -> string
+
+(** Per-variant terminal reason code for [Oas.Error.api_error] —
+    differentiates rate_limited / overloaded / server / auth / etc. so
+    that dashboard chips and broadcast payloads stay distinguishable.
+    Memory: no-collapse-richer-enum-at-sdk-boundary. *)
+val api_error_terminal_reason_code : Oas.Error.api_error -> string
+
+(** Combined terminal-reason-code mapping for any [Oas.Error.sdk_error],
+    delegating to [api_error_terminal_reason_code] for [Api] cases and
+    embedding the contract id for completion-contract violations. *)
+val terminal_reason_code_of_sdk_error : Oas.Error.sdk_error -> string
+
+(** Map an optional cascade observation to a textual outcome label
+    ("passed_to_next_model" / "completed" / "not_observed"). *)
+val cascade_outcome_of_observation :
+  Oas_worker.cascade_observation option -> string

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -1,0 +1,42 @@
+(** Keeper Agent.run result surface helpers. *)
+
+type tool_call_detail =
+  { tool_name : string
+  ; provider : string
+  ; outcome : string
+  ; latency_ms : float
+  }
+
+(** Result of a single Agent.run() keeper turn. *)
+type run_result =
+  { response_text : string
+  ; model_used : string
+  ; prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics
+  ; ctx_composition : Keeper_agent_prompt_metrics.ctx_composition_metrics
+  ; cascade_observation : Oas_worker.cascade_observation option
+  ; turn_count : int
+  ; tool_calls_made : int
+  ; usage : Oas.Types.api_usage
+  ; usage_reported : bool
+  ; tools_used : string list
+  ; tool_calls : tool_call_detail list
+  ; checkpoint : Oas.Checkpoint.t option
+  ; proof : Oas.Cdal_proof.t option
+  ; trace_ref : Oas.Raw_trace.run_ref option
+  ; run_validation : Oas.Raw_trace.run_validation option
+  ; stop_reason : Oas_worker.stop_reason
+  ; inference_telemetry : Oas.Types.inference_telemetry option
+  ; tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
+  }
+
+(** Trim and return [None] if the result is empty. *)
+val nonempty_trimmed : string -> string option
+
+(** Resolve the model name to display in user-facing surfaces.
+    Prefers cascade-observation [model_label] over [model_id], falls
+    back to provider-reported [model_used]. *)
+val surface_model_used : run_result -> string
+
+(** Resolve the concrete model id (always prefers [model_id] over any
+    cascade label) for accountability. See #9953. *)
+val surface_resolved_model_id : run_result -> string

--- a/lib/keeper/keeper_persona.mli
+++ b/lib/keeper/keeper_persona.mli
@@ -1,0 +1,21 @@
+(** Keeper_persona — persona list and persona-backed keeper creation handlers. *)
+
+type tool_result = Keeper_types.tool_result
+
+val handle_persona_list :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result
+
+val handle_persona_schema :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result
+
+val handle_persona_generate :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result
+
+val handle_persona_save :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result
+
+(** Create a keeper from a persona definition. Honors a [dry_run] arg
+    that returns a preview without invoking [handle_keeper_up]. Applies
+    per-persona shard configuration after successful creation. *)
+val handle_keeper_create_from_persona :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result

--- a/lib/keeper/keeper_prompt_names.mli
+++ b/lib/keeper/keeper_prompt_names.mli
@@ -1,0 +1,12 @@
+(** Keeper_prompt_names — SSOT for Prompt_registry template keys
+    used by keeper modules.
+
+    All keeper prompt lookups must reference these constants
+    instead of string literals. *)
+
+val constitution : string
+val world : string
+val capabilities : string
+val deliberation : string
+val unified_system : string
+val reply_guidelines : string

--- a/lib/keeper/keeper_timing.mli
+++ b/lib/keeper/keeper_timing.mli
@@ -1,0 +1,8 @@
+(** Keeper_timing — deterministic timing helpers for turn cycle telemetry. *)
+
+(** Round to 1 decimal place for compact JSON output. *)
+val round1 : float -> float
+
+(** [timed f] runs [f ()], returning its result and elapsed time in ms.
+    Uses [Time_compat.now] as the single timing source. *)
+val timed : (unit -> 'a) -> 'a * float


### PR DESCRIPTION
## Summary
keeper 모듈 5개에 누락되어 있던 .mli 인터페이스를 추가합니다. 외부 평가 보고서가 지적한 lib/keeper의 51개 미존재 .mli 부채를 batch 단위로 해소.

| 모듈 | 노출 surface |
|---|---|
| `keeper_prompt_names` | 6 string 상수 (prompt-registry SSOT) |
| `keeper_timing` | round1, timed |
| `keeper_agent_result` | tool_call_detail / run_result types + 3 helpers |
| `keeper_agent_error` | keeper_internal_error variant + 5 translator 함수 |
| `keeper_persona` | persona handler 5종 |

## Why
.mli 부재는 OCaml의 캡슐화 도구를 포기한 상태. 평가 보고서는 lib/keeper의 32%(51/161) .mli 누락을 **C+ → A-**로 끌어올릴 핵심 영역으로 지목. surgical 원칙으로 (a) .ml 변경 0, (b) 노출되는 binding은 ml의 toplevel let 시그니처를 보수적으로 그대로 옮김.

## Ratchet impact
`keeper_mli_missing` 51 → 46 (-5). PR#0(#11220)의 ratchet gate 머지 후 base rebase 시 단조감소 자동 검증.

## Test plan
- [ ] CI \`Build and Test\` green (mli/ml 시그니처 일치 검증)
- [ ] CI \`Lint\` green
- [ ] CI \`OCaml Structure Ratchet\` green (PR#0 머지 후 활성)

## Plan reference
\`planning/claude-plans/moonlit-finding-russell.md\` PR#2 — 첫 batch (5/51).

## Follow-ups
- batch 2: keeper_meta_*, keeper_turn_* (PR#3 예정)
- batch 3: 잔여 ~41개 (PR#4 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)