### PR TITLE
chore(heuristic-metrics): remove 3 dead emit sites + dangling relay TODO

### DIFF
--- a/lib/drift_guard.ml
+++ b/lib/drift_guard.ml
@@ -208,14 +208,6 @@ let text_similarity original received =
 let verify_handoff ~original ~received ?threshold () =
   let threshold = Option.value threshold ~default:(default_threshold ()) in
   let summary, tokens_a, tokens_b = summarize ~original ~received ~threshold in
-  (* RFC-0001 Gate A: record drift guard observation *)
-  Heuristic_metrics.record {
-    module_name = "drift_guard"; site = "verify_handoff";
-    raw_value = summary.similarity; threshold;
-    triggered = summary.similarity < threshold;
-    provenance = Drift_guard "handoff";
-    timestamp = Unix.gettimeofday ();
-  };
   if summary.similarity >= threshold then Verified summary
   else
     let drift_type =

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -232,16 +232,6 @@ let keeper_alert_signal
   end;
   let score = max 0.0 (min 1.0 !score) in
   let keywords = keyword_hits |> List.map fst |> dedup_strings in
-  let threshold = alert_emit_threshold () in
-  Heuristic_metrics.record {
-    module_name = "keeper_alerting";
-    site = "keeper_alert_signal";
-    raw_value = score;
-    threshold;
-    triggered = score >= threshold;
-    provenance = Alert_scoring (String.concat "," (List.rev !reasons));
-    timestamp = Unix.gettimeofday ();
-  };
   (score, List.rev !reasons, keywords)
 
 let keeper_alert_text

--- a/lib/post_verifier.ml
+++ b/lib/post_verifier.ml
@@ -226,18 +226,7 @@ let verify ~content =
     | (_, _, Warn r) -> Warn (Printf.sprintf "safety: %s" r)
     | (Pass, Pass, Pass) -> Pass
   in
-  let result = { relevance; quality; safety; overall } in
-  (* RFC-0001 Gate A: record per-dimension heuristic observations *)
-  let verdict_score = function Pass -> 1.0 | Warn _ -> 0.5 | Fail _ -> 0.0 in
-  List.iter (fun (dim, v) ->
-    Heuristic_metrics.record {
-      module_name = "post_verifier"; site = "verify";
-      raw_value = verdict_score v; threshold = 0.5;
-      triggered = (match v with Fail _ -> true | Pass | Warn _ -> false);
-      provenance = Post_verifier (match dim with Relevance -> "relevance" | Quality -> "quality" | Safety -> "safety");
-      timestamp = Unix.gettimeofday ();
-    }) [(Relevance, relevance); (Quality, quality); (Safety, safety)];
-  result
+  { relevance; quality; safety; overall }
 
 (** Check if content passes verification (Pass or Warn). *)
 let is_acceptable result =

--- a/lib/post_verifier.mli
+++ b/lib/post_verifier.mli
@@ -38,9 +38,7 @@ type verification_result = {
 
 (** {1 Verification} *)
 
-(** Verify [content] across Relevance, Quality, Safety. Side effect:
-    records per-dimension {!Heuristic_metrics} observations tagged with
-    provenance [Post_verifier _]. *)
+(** Verify [content] across Relevance, Quality, Safety. *)
 val verify : content:string -> verification_result
 
 (** [true] when [overall] is [Pass] or [Warn], [false] on [Fail]. *)

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -155,9 +155,6 @@ let resolve_max_context model =
     Provenance: initial values set during v2.100 development (2026-01) based
     on informal observation of Claude/local model conversations.
     No formal benchmark has validated these specific numbers.
-
-    TODO(RFC-0001 Phase 0): Replace with empirical calibration once
-    heuristic_metrics.jsonl collects actual token counts per message type.
     Governable via [Governance_registry.relay_tokens_per_*]. *)
 let tokens_per_user_msg () = Runtime_params.get Governance_registry.relay_tokens_per_user_msg
 let tokens_per_assistant_msg () = Runtime_params.get Governance_registry.relay_tokens_per_assistant_msg


### PR DESCRIPTION
## Summary

\`heuristic_metrics.jsonl\` 가 \`#10363\` 의 time-based flush 패치 머지 후에도 24h+ 0 bytes 상태로 남아있어, emit sites 자체가 거의/전혀 fire 하지 않는다는 #10348 의 진단을 확인했습니다. 이 PR 은 issue 의 **Option A (cleanup)** 에 따라 3 emit sites 와 relay 의 dangling TODO 만 제거합니다.

## Changes

| 파일 | 변경 |
|------|-----|
| \`lib/post_verifier.ml\` | per-dimension \`Heuristic_metrics.record\` (verify 결과 후 List.iter 블록) 제거 |
| \`lib/drift_guard.ml\` | \`verify_handoff\` 의 record 호출 제거 |
| \`lib/keeper/keeper_alerting.ml\` | \`keeper_alert_signal\` scoring record 제거 |
| \`lib/relay.ml\` | RFC-0001 Phase 0 \`TODO\` (heuristic_metrics.jsonl 을 calibration source 로 기다리던 주석) 제거 |
| \`lib/post_verifier.mli\` | 제거된 side effect 를 언급하던 doc 주석 정리 |

총 5 파일, +2 / -36 lines.

## What's NOT in this PR

\`Heuristic_metrics\` 모듈 자체와 \`shutdown_hooks.ml\` / \`server_runtime_bootstrap.ml\` 의 init / diagnostics wiring 은 **유지**합니다.

이유:
- \`server_runtime_bootstrap.ml:338-364\` 의 boot-time \`Heuristic_metrics_diagnostics.analyze\` 는 #9919 instrumentation-theatre 검출에 사용되고 모듈 API surface 가 필요합니다.
- 모듈 제거는 \`heuristic_metrics_diagnostics\` + 4-5 개 테스트 + dune 정리 까지 동반되어 medium-scope 가 됩니다 — 그건 **별도 follow-up issue** 로 분리하는 게 정직합니다.

이 PR 머지 후 emit sites caller list 가 0 이 되면 모듈을 retire 할지 / 다른 emit source 로 살릴지 결정하는 follow-up 이 자연스럽게 따릅니다.

## Verification

- \`dune build --root . @check\` clean (worktree 빌드)
- 변경 site 모두 record 호출 외 동작 영향 없음 (verdict 계산은 그대로 반환)
- relay TODO 제거 외 \`tokens_per_*\` 함수 시그니처/사용 변경 없음

## Related

- \`#10348\` — 본 issue
- \`#10363\` — time-based flush partial fix (머지 후에도 ledger 0 byte 잔존)
- \`#9919\` — heuristic_metrics audit (4 emit sites 제거, 3 sites 잔존)

Closes #10348