### PR TITLE
chore(lib/dune): remove 11 godsplit comment markers (PR#1)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -631,13 +631,10 @@
    tool_autoresearch_broadcast
    tool_autoresearch_cycle
    tool_autoresearch
-   ;; godsplit-catalog: tool_catalog decomposition (private sub-modules)
    tool_catalog_surfaces
-   ;; godsplit-misc: tool_misc decomposition (private sub-modules)
    tool_misc_transport
    tool_misc_admin
    tool_misc_web_search
-  ;; godsplit-safety: variant unification & godfile decomposition
   gate_diff_types
   gh_command_validation
   gh_exit_class
@@ -759,9 +756,7 @@
   keeper_memory_policy
   keeper_memory_bank
   keeper_memory_recall
-  ;; godsplit-phase1: file split sub-modules
   keeper_status_bridge
-  ;; godsplit-phase2: additional sub-modules
   autoresearch_codegen
   autoresearch_knowledge
   autoresearch_lineage
@@ -789,29 +784,23 @@
   tool_inline_dispatch_comm
   ;; tool_schema_dsl — shared JSON Schema builder (added by #3640)
   tool_schema_dsl
-  ;; godsplit-catalog: tool_catalog decomposition
   tool_catalog_surfaces
-  ;; godsplit-misc: tool_misc decomposition
   tool_misc_transport
   tool_misc_admin
   tool_misc_web_search
-  ;; godsplit-oas-worker: oas_worker decomposition
   oas_worker_cascade
   oas_worker_exec_agent
   oas_worker_exec
   oas_worker_exec_checkpoint
   oas_worker_exec_transport
   oas_worker_named
-  ;; godsplit-meta-cognition: meta_cognition decomposition
   meta_cognition_types
   meta_cognition_rules
   meta_cognition_snapshot
   meta_cognition_parse
   meta_cognition_interpret
   meta_cognition_digest
-  ;; godsplit-tool-task: schema extraction
   tool_task_schemas
-  ;; godsplit-board-core: board_core decomposition
   board_core_classify
   board_core_payload
   )


### PR DESCRIPTION
## Summary
\`lib/dune\`의 \`;; godsplit-*:\` 임시 마커 11개를 모두 제거합니다. 11 deletions, 0 additions. 모듈 이름·private/public 그루핑·라이브러리 와이어링 변경 없음.

| 파일 | 변경 |
|---|---|
| \`lib/dune\` | 962줄 → 951줄 (-11) |

## 제거된 godsplit 마커 (11곳)
- \`godsplit-catalog\` (×2)
- \`godsplit-misc\` (×2)
- \`godsplit-safety\`
- \`godsplit-phase1\`
- \`godsplit-phase2\`
- \`godsplit-oas-worker\`
- \`godsplit-meta-cognition\`
- \`godsplit-tool-task\`
- \`godsplit-board-core\`

## Why
godsplit 마커는 god-file 점진 분해 과정의 임시 breadcrumb. 분해는 이미 완료되었고 마커는 \`lib/dune\` 가독성을 저해할 뿐. 외부 평가 보고서가 \"분해를 시도하다가 포기한 흔적\"으로 읽혔을 가능성도 제거.

향후 godsplit 마커가 다시 추가되는 회귀를 PR#0의 OCaml 구조 ratchet (\`godsplit_count\`)이 차단합니다.

## Ratchet impact
- \`godsplit_count\` 11 → 0
- \`lib_dune_lines\` 962 → 951

## Test plan
- [x] \`dune build --root . lib\` exit 0 (lib/dune syntax 유효)
- [ ] CI \`Build and Test\` green
- [ ] CI \`OCaml Structure Ratchet\` green (PR#0 머지 후 활성)

## Plan reference
\`planning/claude-plans/moonlit-finding-russell.md\` PR#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)