### PR TITLE
feat(keeper): document sandbox cwd convention for git/gh tools (G5)

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -31,6 +31,16 @@ What you can do:
 When you do not know what tools you have, call `keeper_tool_search` with a keyword before giving up.
 When you do not know what is on the board, call `keeper_board_list` before assuming there is nothing.
 
+## Sandbox path conventions
+
+Your shell starts at the sandbox root, which is **not** a git repository.
+- Repos live at `repos/<REPO_NAME>/`. Worktrees live at `repos/<REPO_NAME>/.worktrees/<task-id>/`.
+- For `git`, `gh`, or anything that needs a working copy, set the tool's `cwd` to the repo path.
+  - Example: `keeper_bash { cmd: "git log --oneline -5", cwd: "repos/masc-mcp" }`.
+  - `keeper_bash` rejects shell chaining (`&&`, `|`, `;`), so prepending `cd repos/<REPO_NAME> && …` does not work — use `cwd` instead.
+- Common error: a tool returns `not a git repository` or `path_outside_sandbox`. That is the sandbox root rejecting a git/gh call. Re-issue the call with the repo path in `cwd`.
+- Do not invent host paths like `/Users/...` or `/workspace/`; relative paths under the sandbox root are the only valid form.
+
 ## Behavior
 
 You have tools. Prefer tool calls over text-only responses.

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -401,6 +401,7 @@ Violations are blocked. Good: cmd='dune build', cmd='ls -la lib/'. \
 Bad: cmd='cd x && dune build', cmd='rg foo | wc -l'. \
 Runs in the keeper sandbox by default; use cwd to target an explicit allowed directory. \
 Paths resolve automatically — never include host storage prefixes such as '.masc/playground/your-name/' in cwd. Use 'repos/X' instead. \
+Sandbox root is NOT a git repository: git/gh calls require cwd='repos/<REPO_NAME>' (or the worktree path under it). 'not a git repository' or 'path_outside_sandbox' from the sandbox root means you forgot the cwd. \
 For read-only ops use keeper_shell, for file edits use keeper_fs_edit. \
 Set run_in_background=true for long-running tasks (returns background_task_id; \
 poll with keeper_bash_output, terminate with keeper_bash_kill).";


### PR DESCRIPTION
## Summary

Executor keepers issued git/gh from the sandbox root and got `not a git repository` or `path_outside_sandbox` failures (~21 incidents/day in measured fleet logs, executor keeper dominant). The unified system prompt and `keeper_bash` description never spelled out that the sandbox root is **not** a git repo and the only working pattern is `cwd: "repos/<REPO_NAME>"`.

Compounds with `keeper_bash`'s no-chaining rule (`&&`, `|`, `;` blocked), so the natural workaround `cd repos/X && git log` is also blocked. The keeper has to use `cwd`, but neither the prompt nor the tool description said so.

## Evidence

Source: `planning/claude-plans/appendix/masc-mcp-keeper-stage0-A.md` (executor 21/day sandbox violations) + Sprint 2 Track E in v0.6 Parallel Sprint plan.

Measured (4/26-27 fleet logs, supporting thread):
- executor keeper sandbox violations: **21/day** (dominant — 21 of 26 actionable failures)
- error pattern: `bash: cd: /Users/.../...: No such file or directory` and `path_outside_sandbox`
- existing `keeper.world.md` already documents the convention but `keeper.unified.system.md` (the active loop prompt) does not surface it

## Changes

| File | Change | LOC |
|------|--------|-----|
| `config/prompts/keeper.unified.system.md` | New "Sandbox path conventions" section before "## Behavior" | +10 |
| `lib/tool_shard.ml` | Extends `keeper_bash` description with the cwd contract | +1 |

Net: +11 / 0 (2 files).

## Test plan

- [x] `dune build --root . lib/` green (tool_shard.ml change)
- [ ] Fleet measurement after merge: executor sandbox violations should drop from ~21/day toward 0 (verify in 4/29 system_log)

## Risk

- Prompt-only addition; no runtime semantics change.
- The new section sits right before the existing "Behavior" block so cooperative ordering with the rest of the prompt is preserved.
- Tool description gains one sentence; format and JSON schema unchanged so callers see the same input shape.
- If a keeper is using a custom system prompt that does not include `keeper.unified.system.md`, the prompt change is a no-op for it; the `tool_shard.ml` description still applies because it is per-tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)