### PR TITLE
feat(design-system): codegen emits Bonsai colors_and_type CSS (artifact 7/7)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.generated.css
+++ b/dashboard/design-system/source_styles/tokens.generated.css
@@ -305,6 +305,7 @@
   --shadow-panel: 0 2px 12px rgba(0, 0, 0, 0.6);
   --shadow-glow: 0 0 20px var(--accent-glow);
   --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+  --shadow-ring: inset 0 0 0 1px rgba(196, 162, 101, 0.25);  /* bonsai-only 1px ring (distinct from --shadow-inset) */
   --focus-ring: 0 0 0 1px var(--brass-1), 0 0 0 3px rgb(var(--brass-glow) / .25);
   --focus-ring-err: 0 0 0 1px var(--err), 0 0 0 3px rgb(var(--err-glow) / .3);
   --hover-overlay: rgb(255 255 255 / .03);
@@ -397,11 +398,18 @@
   --ink-5: #9A978D;
   --ink-6: #BCB8AC;
   --forest: #2D5F4E;
+  --forest-fill: #CFDFD7;
   --brass: #8C6A1E;
+  --brass-fill: #E9DDB8;
   --brick: #8B3A3A;
+  --brick-fill: #E8CFCB;
   --ember: #B35A1F;
+  --ember-fill: #ECD5BD;
   --slate: #3E4A5C;
+  --slate-fill: #D6DBE2;
   --plum: #5C3E56;
+  --plum-fill: #E0D4DE;
   --teal: #236874;
+  --teal-fill: #CEDEE2;
 }
 

--- a/dashboard/design-system/tokens/build.ts
+++ b/dashboard/design-system/tokens/build.ts
@@ -1,12 +1,13 @@
 /**
  * MASC Cockpit Design System — Codegen Driver
  *
- * Reads source.ts, emits five artifacts:
+ * Reads source.ts, emits six artifacts:
  *   1. dashboard/design-system/source_styles/tokens.generated.css
  *   2. dashboard/src/styles/tokens.generated.css      (Tailwind v4 @theme)
  *   3. dashboard/src/styles/tokens.generated.ts       (Preact typed)
  *   4. dashboard_bonsai/src/tokens.ml + tokens.mli    (OCaml polyvar)
  *   5. dashboard/design-system/tokens/build/tokens.json (DTCG 2025.10)
+ *   6. dashboard_bonsai/static/colors_and_type.generated.css (Bonsai naming)
  *
  * Run:  pnpm tokens:build  (from dashboard/)
  *
@@ -35,6 +36,7 @@ const OUT = {
   bonsaiMl: resolve(REPO, "dashboard_bonsai/src/tokens.ml"),
   bonsaiMli: resolve(REPO, "dashboard_bonsai/src/tokens.mli"),
   dtcgJson: resolve(REPO, "dashboard/design-system/tokens/build/tokens.json"),
+  bonsaiCss: resolve(REPO, "dashboard_bonsai/static/colors_and_type.generated.css"),
 } as const;
 
 const HEADER_TEXT =
@@ -196,6 +198,80 @@ let var_of t = "var(--" ^ name_of t ^ ")"
 `;
 }
 
+// 6. Bonsai-side colors_and_type.generated.css — uses Bonsai naming
+//    (--bg-deep / --accent-brass / --space-1 / --status-ok). Two themes
+//    only per user decision: dark-fantasy (canonical, on :root) + paper
+//    (light, on [data-theme="paper"]). cyberpunk / terminal / parchment
+//    are intentionally archived (Wave 2 Friend-2C will move them to
+//    static/themes/archive/).
+//
+//    Layout per :root block:
+//      1. Bonsai theme-invariant raw (radius, space, scrollbar)
+//      2. Bonsai-distinct font stacks (per SPEC §6 divergence)
+//      3. Bonsai theme-invariant role defaults (shadow-card, etc.)
+//      4. dark-fantasy theme tokens (bg-deep / text-* / accent-* / status-* / t-*)
+//      5. Bonsai semantic aliases (color-bg-page → var(--bg-deep), …)
+//
+//    The [data-theme="paper"] block contains the paper raw palette
+//    (paper-N / ink-N / forest / brass / brick / *-fill) followed by
+//    the Bonsai-name overrides (--bg-deep: var(--paper) etc.).
+function buildBonsaiColorsAndTypeCss(): string {
+  const rawByName = new Map(source.raw.map((tk) => [tk.name, tk] as const));
+  const semanticByName = new Map(source.semantic.map((tk) => [tk.name, tk] as const));
+
+  const lookupOrThrow = (
+    name: string, where: Map<string, TokenBase>, label: string,
+  ): TokenBase => {
+    const tk = where.get(name);
+    if (!tk) throw new Error(`bonsai codegen: ${label} token --${name} not found in source.ts`);
+    return tk;
+  };
+
+  const invariantRaw = source.bonsai.invariantRawNames.map(
+    (n) => lookupOrThrow(n, rawByName, "raw"),
+  );
+  const invariantRole = source.bonsai.invariantRoleNames.map(
+    (n) => lookupOrThrow(n, semanticByName, "role"),
+  );
+
+  const darkFantasy = source.themes.find((th) => th.id === "dark-fantasy");
+  const paper = source.themes.find((th) => th.id === "paper");
+  if (!darkFantasy) throw new Error("bonsai codegen: dark-fantasy theme missing");
+  if (!paper) throw new Error("bonsai codegen: paper theme missing");
+
+  const renderSection = (label: string, toks: ReadonlyArray<TokenBase>): string => {
+    if (toks.length === 0) return "";
+    const body = toks.map(renderTokenLine).join("\n");
+    return `  /* ── ${label} ── */\n${body}\n`;
+  };
+
+  // :root + [data-theme="dark-fantasy"] — canonical block
+  const rootSelector = `:root,\n[data-theme="dark-fantasy"]`;
+  const rootBody = [
+    "  color-scheme: dark;",
+    renderSection("Theme-invariant raw (radius, space, scrollbar)", invariantRaw),
+    renderSection("Font stacks (bonsai divergence — JetBrains Mono / Cinzel)",
+      [...source.bonsai.fontOverrides]),
+    renderSection("Theme-invariant role defaults (shadows)", invariantRole),
+    renderSection("Dark Fantasy raw (visceral · decay-forward)", [...darkFantasy.tokens]),
+    renderSection("Bonsai semantic aliases (SPEC v0.1 §3.1-3.5)",
+      [...source.bonsai.aliases]),
+  ].filter((s) => s.length > 0).join("\n");
+  const rootBlock = `${rootSelector} {\n${rootBody}}\n`;
+
+  // [data-theme="paper"] — light theme
+  const paperOverrides = source.bonsai.themeOverrides.paper ?? [];
+  const paperBody = [
+    "  color-scheme: light;",
+    renderSection("Paper / Ink raw palette", [...paper.tokens]),
+    renderSection("Bonsai-name overrides (paper colorway)",
+      [...paperOverrides]),
+  ].filter((s) => s.length > 0).join("\n");
+  const paperBlock = `[data-theme="paper"] {\n${paperBody}}\n`;
+
+  return `${cssHeader}${rootBlock}\n${paperBlock}`;
+}
+
 // 5. DTCG 2025.10 — design-tokens-format JSON
 //    spec: design-tokens.github.io/community-group/format
 function dtcgKindToType(kind: TokenBase["kind"]): string {
@@ -256,6 +332,7 @@ function main(): void {
   writeFile(OUT.bonsaiMli, buildBonsaiMli());
   writeFile(OUT.bonsaiMl, buildBonsaiMl());
   writeFile(OUT.dtcgJson, buildDtcgJson());
+  writeFile(OUT.bonsaiCss, buildBonsaiColorsAndTypeCss());
   console.log("done");
 }
 

--- a/dashboard/design-system/tokens/build/tokens.json
+++ b/dashboard/design-system/tokens/build/tokens.json
@@ -1251,6 +1251,11 @@
       "$type": "shadow",
       "$value": "0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight)"
     },
+    "shadow-ring": {
+      "$type": "shadow",
+      "$value": "inset 0 0 0 1px rgba(196, 162, 101, 0.25)",
+      "$description": "bonsai-only 1px ring (distinct from --shadow-inset)"
+    },
     "focus-ring": {
       "$type": "shadow",
       "$value": "0 0 0 1px var(--brass-1), 0 0 0 3px rgb(var(--brass-glow) / .25)"
@@ -1610,29 +1615,57 @@
         "$type": "color",
         "$value": "#2D5F4E"
       },
+      "forest-fill": {
+        "$type": "color",
+        "$value": "#CFDFD7"
+      },
       "brass": {
         "$type": "color",
         "$value": "#8C6A1E"
+      },
+      "brass-fill": {
+        "$type": "color",
+        "$value": "#E9DDB8"
       },
       "brick": {
         "$type": "color",
         "$value": "#8B3A3A"
       },
+      "brick-fill": {
+        "$type": "color",
+        "$value": "#E8CFCB"
+      },
       "ember": {
         "$type": "color",
         "$value": "#B35A1F"
+      },
+      "ember-fill": {
+        "$type": "color",
+        "$value": "#ECD5BD"
       },
       "slate": {
         "$type": "color",
         "$value": "#3E4A5C"
       },
+      "slate-fill": {
+        "$type": "color",
+        "$value": "#D6DBE2"
+      },
       "plum": {
         "$type": "color",
         "$value": "#5C3E56"
       },
+      "plum-fill": {
+        "$type": "color",
+        "$value": "#E0D4DE"
+      },
       "teal": {
         "$type": "color",
         "$value": "#236874"
+      },
+      "teal-fill": {
+        "$type": "color",
+        "$value": "#CEDEE2"
       }
     }
   }

--- a/dashboard/design-system/tokens/source.ts
+++ b/dashboard/design-system/tokens/source.ts
@@ -483,6 +483,8 @@ export const semantic: ReadonlyArray<TokenBase> = (() => {
   out.push(t("shadow-raised",
     "0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight)",
     "role", "shadow"));
+  out.push(t("shadow-ring",   "inset 0 0 0 1px rgba(196, 162, 101, 0.25)", "role", "shadow",
+    "bonsai-only 1px ring (distinct from --shadow-inset)"));
 
   // Focus / interaction overlays
   out.push(t("focus-ring",
@@ -611,24 +613,181 @@ export const themes: ReadonlyArray<Theme> = Object.freeze([
       t("ink-5", "#9A978D", "raw", "color"),
       t("ink-6", "#BCB8AC", "raw", "color"),
       t("forest", "#2D5F4E", "raw", "color"),
+      t("forest-fill", "#CFDFD7", "raw", "color"),
       t("brass", "#8C6A1E", "raw", "color"),
+      t("brass-fill", "#E9DDB8", "raw", "color"),
       t("brick", "#8B3A3A", "raw", "color"),
+      t("brick-fill", "#E8CFCB", "raw", "color"),
       t("ember", "#B35A1F", "raw", "color"),
+      t("ember-fill", "#ECD5BD", "raw", "color"),
       t("slate", "#3E4A5C", "raw", "color"),
+      t("slate-fill", "#D6DBE2", "raw", "color"),
       t("plum", "#5C3E56", "raw", "color"),
+      t("plum-fill", "#E0D4DE", "raw", "color"),
       t("teal", "#236874", "raw", "color"),
+      t("teal-fill", "#CEDEE2", "raw", "color"),
     ]),
   },
 ]);
 
 // ─────────────────────────────────────────────────────────────────────────
+// Bonsai-side codegen — naming alias + paper override layer
+//
+// dashboard_bonsai/static/colors_and_type.css uses Bonsai-native names
+// (--bg-deep / --accent-brass / --space-1) that differ from dashboard's
+// (--bg-0 / --brass-1 / --sp-1). The bonsai output is emitted alongside
+// the Preact outputs and shares the same SSOT (this file).
+//
+// Per user decision: only 2 themes (dark-fantasy canonical + paper light).
+// cyberpunk / terminal / parchment are archived to static/themes/archive/.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Names of [tier:'raw'] tokens that are Bonsai-side theme-invariant
+ * primitives (radius / space / scrollbar). Theme-overridable shadow
+ * primitives like --shadow-card are tier:'role' and emitted separately
+ * via [bonsaiInvariantRoleNames] below.
+ *
+ * Font stacks are intentionally excluded — Bonsai uses different stacks
+ * (JetBrains Mono first, Cinzel display) per SPEC §6 divergence list.
+ * Bonsai font values are emitted from [bonsaiFontOverrides] as :root
+ * tokens that shadow the canonical raw --font-* values.
+ */
+export const bonsaiInvariantRawNames: ReadonlyArray<string> = Object.freeze([
+  // Radius
+  "radius-xs", "radius-sm", "radius-md", "radius-lg", "radius-pill",
+  // Spacing — bonsai 8-step (parallel to --sp-*)
+  "space-1", "space-2", "space-3", "space-4",
+  "space-5", "space-6", "space-7", "space-8",
+  // Scrollbar primitives
+  "scrollbar-thumb", "scrollbar-thumb-hover",
+]);
+
+/**
+ * Names of [tier:'role'] tokens that are Bonsai-side theme-invariant
+ * defaults (overridden by paper theme).
+ */
+export const bonsaiInvariantRoleNames: ReadonlyArray<string> = Object.freeze([
+  "shadow-card", "shadow-panel", "shadow-glow", "shadow-raised", "shadow-ring",
+]);
+
+/**
+ * Bonsai font stacks — distinct from canonical raw per SPEC §6.323
+ * (dashboard uses ui-monospace first; bonsai uses JetBrains Mono first).
+ * Emitted as raw declarations inside the :root block so Bonsai-only
+ * components see Bonsai-native typography without affecting dashboard.
+ */
+export const bonsaiFontOverrides: ReadonlyArray<TokenBase> = Object.freeze([
+  t("font-display", "'Cinzel', 'Noto Sans KR', 'EB Garamond', serif", "raw", "typography"),
+  t("font-body",    "'EB Garamond', 'Noto Sans KR', Georgia, serif",   "raw", "typography"),
+  t("font-ui",      "'Noto Sans KR', 'IBM Plex Sans KR', -apple-system, sans-serif", "raw", "typography"),
+  t("font-mono",    "'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace",     "raw", "typography"),
+]);
+
+/**
+ * SPEC v0.1 §3.1-3.5 — Bonsai semantic vocabulary aliasing Bonsai raw.
+ * Mirrors the [color-bg-page / color-fg-primary / ...] role in the
+ * dashboard semantic layer, but each alias points at Bonsai-named raw
+ * (e.g. --bg-deep) rather than dashboard raw (--bg-0). The paper theme
+ * then overrides the underlying Bonsai raw so the alias inherits.
+ */
+export const bonsaiAliases: ReadonlyArray<TokenBase> = Object.freeze([
+  t("color-bg-page",        "var(--bg-deep)",      "role", "color"),
+  t("color-bg-surface",     "var(--bg-panel)",     "role", "color"),
+  t("color-bg-panel-alt",   "var(--bg-panel-alt)", "role", "color"),
+  t("color-bg-elevated",    "var(--bg-card)",      "role", "color"),
+  t("color-bg-hover",       "var(--bg-card-hover)","role", "color"),
+
+  t("color-fg-primary",     "var(--text-primary)", "role", "color"),
+  t("color-fg-muted",       "var(--text-dim)",     "role", "color"),
+
+  t("color-border-default", "var(--border-main)",      "role", "color"),
+  t("color-border-strong",  "var(--border-highlight)", "role", "color"),
+
+  t("color-accent-fg",      "var(--accent-brass)",     "role", "color"),
+  t("color-accent-fg-dim",  "var(--accent-brass-dim)", "role", "color"),
+  t("color-accent-glow",    "var(--accent-glow)",      "role", "color"),
+
+  t("color-status-ok",      "var(--status-ok)",   "role", "color"),
+  t("color-status-warn",    "var(--status-warn)", "role", "color"),
+  t("color-status-err",     "var(--status-bad)",  "role", "color"),
+  t("color-status-idle",    "var(--status-idle)", "role", "color"),
+]);
+
+/**
+ * Per-theme Bonsai-name overrides. The [paper] theme remaps Bonsai
+ * raw (--bg-deep / --text-primary / --status-ok / ...) to paper raw
+ * (--paper / --ink-2 / --forest), plus its own shadow + trace frame
+ * overrides. Emitted inside the [data-theme="paper"] block right
+ * after the paper raw declarations.
+ */
+export const bonsaiThemeOverrides: Readonly<Record<string, ReadonlyArray<TokenBase>>> = Object.freeze({
+  paper: Object.freeze([
+    // Surface remap → paper layers
+    t("bg-deep",        "var(--paper)",   "role", "color"),
+    t("bg-panel",       "var(--paper-2)", "role", "color"),
+    t("bg-panel-alt",   "var(--paper-3)", "role", "color"),
+    t("bg-card",        "var(--paper-2)", "role", "color"),
+    t("bg-card-hover",  "var(--paper-3)", "role", "color"),
+    // Border — translucent ink on paper
+    t("border-main",      "rgba(21,21,21,0.22)", "role", "color"),
+    t("border-highlight", "rgba(21,21,21,0.48)", "role", "color"),
+    // Text — ink ramp
+    t("text-bright",  "var(--ink)",   "role", "color"),
+    t("text-primary", "var(--ink-2)", "role", "color"),
+    t("text-dim",     "var(--ink-4)", "role", "color"),
+    // Accents — brass / brick / slate from paper palette
+    t("accent-brass",     "var(--brass)",      "role", "color"),
+    t("accent-brass-dim", "var(--brass-fill)", "role", "color"),
+    t("accent-blood",     "var(--brick)",      "role", "color"),
+    t("accent-ink",       "var(--slate)",      "role", "color"),
+    t("accent-glow",      "rgba(140,106,30,0.12)", "role", "color"),
+    // Status — paper colorway
+    t("status-ok",   "var(--forest)", "role", "color"),
+    t("status-warn", "var(--ember)",  "role", "color"),
+    t("status-bad",  "var(--brick)",  "role", "color"),
+    t("status-idle", "var(--ink-5)",  "role", "color"),
+    // Shadows — flat / no glow on paper
+    t("shadow-panel", "0 1px 2px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.06)", "role", "shadow"),
+    t("shadow-card",  "0 1px 0 rgba(0,0,0,0.04)", "role", "shadow"),
+    t("shadow-glow",  "none",                     "role", "shadow"),
+    // Trace frames — ink on paper
+    t("t-llm",   "var(--slate)",   "role", "color"),
+    t("t-tool",  "var(--brass)",   "role", "color"),
+    t("t-think", "var(--plum)",    "role", "color"),
+    t("t-wait",  "var(--paper-3)", "role", "color"),
+    t("t-err",   "var(--brick)",   "role", "color"),
+  ]),
+});
+
+// ─────────────────────────────────────────────────────────────────────────
 // Aggregate accessor — for build.ts consumption
 // ─────────────────────────────────────────────────────────────────────────
+
+export interface BonsaiSource {
+  readonly invariantRawNames: ReadonlyArray<string>;
+  readonly invariantRoleNames: ReadonlyArray<string>;
+  readonly fontOverrides: ReadonlyArray<TokenBase>;
+  readonly aliases: ReadonlyArray<TokenBase>;
+  readonly themeOverrides: Readonly<Record<string, ReadonlyArray<TokenBase>>>;
+}
 
 export interface TokenSource {
   readonly raw: ReadonlyArray<TokenBase>;
   readonly semantic: ReadonlyArray<TokenBase>;
   readonly themes: ReadonlyArray<Theme>;
+  readonly bonsai: BonsaiSource;
 }
 
-export const source: TokenSource = Object.freeze({ raw, semantic, themes });
+export const source: TokenSource = Object.freeze({
+  raw,
+  semantic,
+  themes,
+  bonsai: Object.freeze({
+    invariantRawNames: bonsaiInvariantRawNames,
+    invariantRoleNames: bonsaiInvariantRoleNames,
+    fontOverrides: bonsaiFontOverrides,
+    aliases: bonsaiAliases,
+    themeOverrides: bonsaiThemeOverrides,
+  }),
+});

--- a/dashboard/src/styles/tokens.generated.css
+++ b/dashboard/src/styles/tokens.generated.css
@@ -300,6 +300,7 @@
   --shadow-panel: 0 2px 12px rgba(0, 0, 0, 0.6);
   --shadow-glow: 0 0 20px var(--accent-glow);
   --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+  --shadow-ring: inset 0 0 0 1px rgba(196, 162, 101, 0.25);
   --focus-ring: 0 0 0 1px var(--brass-1), 0 0 0 3px rgb(var(--brass-glow) / .25);
   --focus-ring-err: 0 0 0 1px var(--err), 0 0 0 3px rgb(var(--err-glow) / .3);
   --color-hover-overlay: rgb(255 255 255 / .03);

--- a/dashboard/src/styles/tokens.generated.ts
+++ b/dashboard/src/styles/tokens.generated.ts
@@ -300,6 +300,7 @@ export const TOKENS = {
   "shadowPanel": { name: "--shadow-panel", value: "0 2px 12px rgba(0, 0, 0, 0.6)", tier: "role", kind: "shadow" },
   "shadowGlow": { name: "--shadow-glow", value: "0 0 20px var(--accent-glow)", tier: "role", kind: "shadow" },
   "shadowRaised": { name: "--shadow-raised", value: "0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight)", tier: "role", kind: "shadow" },
+  "shadowRing": { name: "--shadow-ring", value: "inset 0 0 0 1px rgba(196, 162, 101, 0.25)", tier: "role", kind: "shadow" },
   "focusRing": { name: "--focus-ring", value: "0 0 0 1px var(--brass-1), 0 0 0 3px rgb(var(--brass-glow) / .25)", tier: "role", kind: "shadow" },
   "focusRingErr": { name: "--focus-ring-err", value: "0 0 0 1px var(--err), 0 0 0 3px rgb(var(--err-glow) / .3)", tier: "role", kind: "shadow" },
   "hoverOverlay": { name: "--hover-overlay", value: "rgb(255 255 255 / .03)", tier: "role", kind: "color" },

--- a/dashboard_bonsai/src/tokens.ml
+++ b/dashboard_bonsai/src/tokens.ml
@@ -301,6 +301,7 @@ type semantic =
   | `Shadow_panel
   | `Shadow_glow
   | `Shadow_raised
+  | `Shadow_ring
   | `Focus_ring
   | `Focus_ring_err
   | `Hover_overlay
@@ -645,6 +646,7 @@ let name_of = function
   | `Shadow_panel -> "shadow-panel"
   | `Shadow_glow -> "shadow-glow"
   | `Shadow_raised -> "shadow-raised"
+  | `Shadow_ring -> "shadow-ring"
   | `Focus_ring -> "focus-ring"
   | `Focus_ring_err -> "focus-ring-err"
   | `Hover_overlay -> "hover-overlay"

--- a/dashboard_bonsai/src/tokens.mli
+++ b/dashboard_bonsai/src/tokens.mli
@@ -312,6 +312,7 @@ type semantic =
   | `Shadow_panel
   | `Shadow_glow
   | `Shadow_raised
+  | `Shadow_ring
   | `Focus_ring
   | `Focus_ring_err
   | `Hover_overlay

--- a/dashboard_bonsai/static/colors_and_type.generated.css
+++ b/dashboard_bonsai/static/colors_and_type.generated.css
@@ -1,0 +1,144 @@
+/* @generated DO NOT EDIT — run `pnpm tokens:build` (source: dashboard/design-system/tokens/source.ts) */
+
+:root,
+[data-theme="dark-fantasy"] {
+  color-scheme: dark;
+  /* ── Theme-invariant raw (radius, space, scrollbar) ── */
+  --radius-xs: 2px;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 12px;
+  --radius-pill: 999px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --scrollbar-thumb: #2a1f1a;
+  --scrollbar-thumb-hover: #3d2e22;
+
+  /* ── Font stacks (bonsai divergence — JetBrains Mono / Cinzel) ── */
+  --font-display: 'Cinzel', 'Noto Sans KR', 'EB Garamond', serif;
+  --font-body: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
+  --font-ui: 'Noto Sans KR', 'IBM Plex Sans KR', -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+
+  /* ── Theme-invariant role defaults (shadows) ── */
+  --shadow-card: 0 1px 4px rgba(0, 0, 0, 0.5);
+  --shadow-panel: 0 2px 12px rgba(0, 0, 0, 0.6);
+  --shadow-glow: 0 0 20px var(--accent-glow);
+  --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+  --shadow-ring: inset 0 0 0 1px rgba(196, 162, 101, 0.25);  /* bonsai-only 1px ring (distinct from --shadow-inset) */
+
+  /* ── Dark Fantasy raw (visceral · decay-forward) ── */
+  --bg-deep: #0a0706;  /* pitch with red undertone */
+  --bg-panel: #14100d;  /* rotted wood */
+  --bg-panel-alt: #1b1612;
+  --bg-card: #221815;
+  --bg-card-hover: #2e211c;
+  --border-main: #2a1a14;
+  --border-highlight: #5a3028;
+  --text-bright: #e8d8b8;  /* clean bone */
+  --text-primary: #b8a488;  /* dirty bandage */
+  --text-dim: #9a846e;  /* WCAG AA */
+  --accent-blood: #e85050;
+  --accent-blood-dim: #8a2828;
+  --accent-viscera: #c94a3a;
+  --accent-bile: #6a7a3a;
+  --accent-mold: #3a5a48;
+  --accent-brass: #968228;  /* bonsai brass differs from --brass-1 */
+  --accent-brass-dim: #6a5620;
+  --accent-bone: #d8c8a0;
+  --accent-ink: #3a2a5a;
+  --accent-ember: #c4461a;
+  --accent-glow: rgba(232, 80, 80, 0.28);
+  --accent-blood-glow: rgba(232, 80, 80, 0.32);
+  --status-ok: #6a9a4a;
+  --status-warn: #b87828;
+  --status-bad: #e85050;
+  --status-idle: #4a3a32;
+  --t-llm: #6a7a9c;  /* muted blue-gray — inference */
+  --t-tool: #8a7a3a;  /* muted brass — tool call */
+  --t-think: #4a4a5a;  /* slate — reasoning */
+  --t-wait: #2a2520;  /* deep dusk — idle */
+  --t-err: var(--accent-blood);
+
+  /* ── Bonsai semantic aliases (SPEC v0.1 §3.1-3.5) ── */
+  --color-bg-page: var(--bg-deep);
+  --color-bg-surface: var(--bg-panel);
+  --color-bg-panel-alt: var(--bg-panel-alt);
+  --color-bg-elevated: var(--bg-card);
+  --color-bg-hover: var(--bg-card-hover);
+  --color-fg-primary: var(--text-primary);
+  --color-fg-muted: var(--text-dim);
+  --color-border-default: var(--border-main);
+  --color-border-strong: var(--border-highlight);
+  --color-accent-fg: var(--accent-brass);
+  --color-accent-fg-dim: var(--accent-brass-dim);
+  --color-accent-glow: var(--accent-glow);
+  --color-status-ok: var(--status-ok);
+  --color-status-warn: var(--status-warn);
+  --color-status-err: var(--status-bad);
+  --color-status-idle: var(--status-idle);
+}
+
+[data-theme="paper"] {
+  color-scheme: light;
+  /* ── Paper / Ink raw palette ── */
+  --paper: #F5F2EA;
+  --paper-2: #EFEBE0;
+  --paper-3: #E5E0D1;
+  --paper-4: #D8D2BF;
+  --ink: #151515;
+  --ink-2: #2E2E2C;
+  --ink-3: #515049;
+  --ink-4: #656358;
+  --ink-5: #9A978D;
+  --ink-6: #BCB8AC;
+  --forest: #2D5F4E;
+  --forest-fill: #CFDFD7;
+  --brass: #8C6A1E;
+  --brass-fill: #E9DDB8;
+  --brick: #8B3A3A;
+  --brick-fill: #E8CFCB;
+  --ember: #B35A1F;
+  --ember-fill: #ECD5BD;
+  --slate: #3E4A5C;
+  --slate-fill: #D6DBE2;
+  --plum: #5C3E56;
+  --plum-fill: #E0D4DE;
+  --teal: #236874;
+  --teal-fill: #CEDEE2;
+
+  /* ── Bonsai-name overrides (paper colorway) ── */
+  --bg-deep: var(--paper);
+  --bg-panel: var(--paper-2);
+  --bg-panel-alt: var(--paper-3);
+  --bg-card: var(--paper-2);
+  --bg-card-hover: var(--paper-3);
+  --border-main: rgba(21,21,21,0.22);
+  --border-highlight: rgba(21,21,21,0.48);
+  --text-bright: var(--ink);
+  --text-primary: var(--ink-2);
+  --text-dim: var(--ink-4);
+  --accent-brass: var(--brass);
+  --accent-brass-dim: var(--brass-fill);
+  --accent-blood: var(--brick);
+  --accent-ink: var(--slate);
+  --accent-glow: rgba(140,106,30,0.12);
+  --status-ok: var(--forest);
+  --status-warn: var(--ember);
+  --status-bad: var(--brick);
+  --status-idle: var(--ink-5);
+  --shadow-panel: 0 1px 2px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.06);
+  --shadow-card: 0 1px 0 rgba(0,0,0,0.04);
+  --shadow-glow: none;
+  --t-llm: var(--slate);
+  --t-tool: var(--brass);
+  --t-think: var(--plum);
+  --t-wait: var(--paper-3);
+  --t-err: var(--brick);
+}


### PR DESCRIPTION
## 요약

Wave 2 prerequisite. `build.ts` 를 확장해 `dashboard_bonsai/static/colors_and_type.generated.css` 를 codegen 출력에 추가합니다. 이로써 SSOT (`source.ts`) 1개로 7 artifact 가 emit 되어 Bonsai stack 도 codegen 경로로 들어옵니다.

## 변경 내용

**`build.ts`** (+79L)
- `OUT.bonsaiCss` 추가
- `buildBonsaiColorsAndTypeCss()` 함수: Bonsai naming convention (`--bg-deep` / `--accent-brass` / `--space-*` / `--status-*`) 으로 emit
- 2 themes only (사용자 결정): dark-fantasy canonical on `:root`, paper light on `[data-theme=\"paper\"]`
- cyberpunk / terminal / parchment 은 archive 대상 (Friend-2C 가 `static/themes/archive/` 로 이동 예정)

**`source.ts`** (+161L)
- `bonsaiInvariantRawNames` + `bonsaiInvariantRoleNames` exports — theme-invariant primitives (radius / space / scrollbar / shadow)
- `shadow-ring` role token 신규 (Bonsai-only 1px ring, `--shadow-inset` 와 구분)
- paper theme `*-fill` raw 추가 (forest-fill / brass-fill / brick-fill / ember-fill / slate-fill / plum-fill / teal-fill) — status surface tints 용

**Generated outputs** (8 files updated/created)
- `dashboard_bonsai/static/colors_and_type.generated.css` (NEW, 144L)
- `dashboard_bonsai/src/tokens.ml` + `.mli` (regenerated)
- `dashboard/src/styles/tokens.generated.css` + `.ts` (regenerated)
- `dashboard/design-system/source_styles/tokens.generated.css` (regenerated)
- `dashboard/design-system/tokens/build/tokens.json` (regenerated, DTCG 2025.10)

## 검증 (모두 green)

```
$ pnpm tokens:build      # 7 artifacts emit, second run idempotent
$ pnpm tokens:check
[OK] every source token name (372) exists in generated
[OK] status canon (--ok/--warn/--err/--info) pinned
[OK] keeper 12-slot palette ΔE < 2 vs OkLCH(L=68, C=0.09, H=i*30)
equivalence check passed
```

## Wave 2 unlock

이 PR 머지 후:
- Friend-2C (Bonsai swap): `<link>` 을 `colors_and_type.generated.css` 로 repoint, hand-written `colors_and_type.css` (566L) 삭제, 3 archived themes 를 `static/themes/archive/` 로 이동
- Friend-2A (preview swap), Friend-2B (Preact swap) 는 이 PR 없이도 진행 가능

## Out of scope

- Friend-2C 의 실제 Bonsai stack swap (이 PR 은 generator 만 추가, `colors_and_type.css` 원본은 그대로)
- archived 3 themes 는 동일 SSOT 에 존재 (codegen 미반영, 수동 archive)