### PR TITLE
chore(dashboard): migrate border-white/{5,10} → token in agent-detail (5 sites)

### DIFF
--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -169,7 +169,7 @@ function SessionMeta({ agentName }: { agentName: string }) {
   return html`
     <div class="flex flex-wrap gap-2 mb-4">
       ${meta.map(m => html`
-        <span key=${m.label} class="inline-flex items-center gap-1.5 text-2xs font-medium py-1 px-2.5 bg-white/5 border border-white/10 rounded text-text-muted">
+        <span key=${m.label} class="inline-flex items-center gap-1.5 text-2xs font-medium py-1 px-2.5 bg-white/5 border border-[var(--white-10)] rounded text-text-muted">
           <span class="text-text-dim">${m.label}</span>
           <span class="text-text-strong font-mono text-3xs">${m.value}</span>
         </span>
@@ -277,7 +277,7 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
             </div>
           ` : null}
           ${summary.messages_sent > 0 ? html`
-            <div class="flex items-center gap-1.5 text-xs font-medium text-text-muted bg-white/5 border border-white/10 px-3 py-1.5 rounded">
+            <div class="flex items-center gap-1.5 text-xs font-medium text-text-muted bg-white/5 border border-[var(--white-10)] px-3 py-1.5 rounded">
               <span class="font-bold">${summary.messages_sent}</span> 메시지
             </div>
           ` : null}

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -252,7 +252,7 @@ export function AgentDetailOverlay() {
         <div class="flex justify-between items-start gap-4">
           <div class="flex flex-col gap-3 flex-1">
             <div class="flex items-center gap-4">
-              ${agentEmoji ? html`<div class="size-12 rounded bg-white/5 border border-white/10 flex items-center justify-center text-3xl shadow-inner">${agentEmoji}</div>` : ''}
+              ${agentEmoji ? html`<div class="size-12 rounded bg-white/5 border border-[var(--white-10)] flex items-center justify-center text-3xl shadow-inner">${agentEmoji}</div>` : ''}
               <div>
                 <h2 id=${titleId} class="m-0 flex items-baseline gap-3 text-text-strong text-2xl font-bold tracking-tight">
                   ${displayName}
@@ -261,9 +261,9 @@ export function AgentDetailOverlay() {
                 </h2>
                 <div class="flex items-center gap-2 mt-2 flex-wrap">
                   <${StatusBadge} status=${unified.canonical} />
-                  ${unified.description !== unified.label ? html`<span class="text-3xs font-medium py-1 px-2 border border-white/10 bg-white/5 text-text-muted whitespace-nowrap rounded" title=${unified.description}>${unified.description}</span>` : null}
+                  ${unified.description !== unified.label ? html`<span class="text-3xs font-medium py-1 px-2 border border-[var(--white-10)] bg-white/5 text-text-muted whitespace-nowrap rounded" title=${unified.description}>${unified.description}</span>` : null}
                   ${isArchivedParticipant ? html`<${IdPill}>이전 세션 참여자<//>` : null}
-                  ${agent?.model ? html`<span class="font-mono text-3xs font-medium bg-[var(--white-10)] border border-white/5 px-2 py-1 rounded text-text-muted shadow-sm">${agent.model}</span>` : ''}
+                  ${agent?.model ? html`<span class="font-mono text-3xs font-medium bg-[var(--white-10)] border border-[var(--white-5)] px-2 py-1 rounded text-text-muted shadow-sm">${agent.model}</span>` : ''}
                   ${!agent && missionBrief?.archived_reason
                     ? html`<span class="text-xs text-text-dim italic">${missionBrief.archived_reason}</span>`
                     : null}


### PR DESCRIPTION
## Summary

Continues the white-alpha bucket migration. 5 `border-white/N` callsites in agent-detail family.

## Sites migrated

- `agent-detail.ts:255, 264` — `border-white/10` (agent emoji frame, unified description chip)
- `agent-detail.ts:266` — `border-white/5` (model badge border)
- `agent-detail-session-report.ts:172, 280` — `border-white/10` (session meta chips, message stat chip)

## Test plan

- [x] `pnpm test src/components/agent-detail src/components/agent-detail-session-report` — 87/87 passed
- [x] `pnpm typecheck` — clean
- [x] `bash scripts/dashboard-drift-check.sh` — `border-white-alpha` decreased — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)