### PR TITLE
refactor(keeper): add 4 keeper .mli (batch 2)

### DIFF
--- a/lib/keeper/keeper_event_bus.mli
+++ b/lib/keeper/keeper_event_bus.mli
@@ -1,0 +1,13 @@
+(** Keeper_event_bus — Process-scoped OAS Event_bus reference.
+
+    Holds the shared Event_bus instance set once at server bootstrap.
+    Separate module to avoid dependency cycles between Keeper_keepalive
+    and Keeper_agent_run.
+
+    @since 2.255.0 *)
+
+(** Install the process-wide event bus. Call once at bootstrap. *)
+val set : Oas.Event_bus.t -> unit
+
+(** Read the installed event bus, if any. *)
+val get : unit -> Oas.Event_bus.t option

--- a/lib/keeper/keeper_gh_env.mli
+++ b/lib/keeper/keeper_gh_env.mli
@@ -1,0 +1,56 @@
+(** Keeper-scoped GH credential isolation.
+
+    SSOT for [GH_CONFIG_DIR] handling. Scopes [gh] subprocess
+    invocations to the keeper identity (e.g. [anyang-keepers]) instead
+    of the operator's personal [~/.config/gh] credentials. *)
+
+type keeper_binding = {
+  github_identity : string option;
+  git_identity_mode : string;
+  bundle_root : string option;
+  gh_config_dir : string option;
+}
+
+(** Resolve legacy [$base_path/.masc/gh-auth/] if it exists. *)
+val config_dir : Coord.config -> string option
+
+(** [bundle_root config ~github_identity] is the on-disk root of the
+    GitHub identity bundle: [$base_path/.masc/github-identities/<id>]. *)
+val bundle_root : Coord.config -> github_identity:string -> string
+
+(** [gh_config_dir_of_bundle bundle_root] is the [gh/] subdir of a
+    GitHub identity bundle. *)
+val gh_config_dir_of_bundle : string -> string
+
+(** Resolve the keeper's GitHub identity binding, or an error string
+    explaining why the binding cannot be established (missing identity
+    in profile defaults, missing GH config dir on disk, etc.). *)
+val keeper_binding :
+  Coord.config -> keeper_name:string -> (keeper_binding, string) result
+
+(** Convenience: extract just the [gh_config_dir] from the binding. *)
+val keeper_config_dir :
+  Coord.config -> keeper_name:string -> (string option, string) result
+
+(** Prepend [GH_CONFIG_DIR=<dir>] to a gh shell command when a
+    keeper-scoped config exists. Scoped to the single subprocess
+    invocation — the operator's terminal is unaffected. *)
+val with_env : Coord.config -> string -> string
+
+(** Compose the base environment for a gh/git subprocess: scrub
+    long-lived host credentials, inject non-interactive git constants,
+    and prepend the keeper-scoped [GH_CONFIG_DIR]. RFC-0007 PR-1.
+
+    See [Env_keeper_scrub] and [Env_git_noninteractive] for the
+    canonical lists. *)
+val compose_base_with_gh_config : dir:string -> string array
+
+(** [process_env config] returns the composed env for the operator's
+    GH config dir, or [None] when no [gh-auth/] exists. *)
+val process_env : Coord.config -> string array option
+
+(** [keeper_process_env config ~keeper_name] returns the composed env
+    for a specific keeper's GH identity, or an error if the binding
+    cannot be resolved. *)
+val keeper_process_env :
+  Coord.config -> keeper_name:string -> (string array option, string) result

--- a/lib/keeper/keeper_memory.mli
+++ b/lib/keeper/keeper_memory.mli
@@ -1,0 +1,4 @@
+(** Keeper_memory — memory-bank paths, reward-model evaluation,
+    state snapshots, recall scoring, and metrics summaries. *)
+
+include module type of Keeper_memory_recall

--- a/lib/keeper/keeper_summarizer.mli
+++ b/lib/keeper/keeper_summarizer.mli
@@ -1,0 +1,19 @@
+(** [STATE]-aware summarizer for OAS compaction.
+
+    Wraps OAS's default summarizer with [STATE]...[/STATE] block
+    scrubbing on every Text content block, closing the compaction-layer
+    half of the resonance loop that Gen3 (PR #7647) closed only at the
+    prompt injection layer.
+
+    OAS/MASC boundary: OAS knows nothing about [STATE] markers
+    (feedback_oas-must-not-know-masc). This module supplies the
+    domain-aware callback through OAS's generic
+    [Agent.options.summarizer] API (OAS 0.152.0, PR #973), delegating
+    to [Oas.Budget_strategy.default_summarizer] (OAS 0.153.0, PR #975). *)
+
+(** Scrub [STATE]...[/STATE] from every Text block in a message. *)
+val scrub_text_blocks : Oas.Types.message -> Oas.Types.message
+
+(** Scrub [STATE] blocks then delegate to OAS's default summarizer.
+    Pass this to [Oas.Builder.with_summarizer]. *)
+val keeper_summarizer : Oas.Types.message list -> string


### PR DESCRIPTION
## Summary
PR#2의 mli rollout 이어가는 batch 2. 4개 모듈에 .mli 추가.

| 모듈 | 노출 surface |
|---|---|
| \`keeper_gh_env\`     | keeper_binding record + 9 fns (GH 자격 격리, RFC-0007 PR-1) |
| \`keeper_memory\`     | \`include module type of Keeper_memory_recall\` (1:1 alias) |
| \`keeper_event_bus\`  | set/get 2 fns (process-scoped Atomic.t Event_bus 참조) |
| \`keeper_summarizer\` | scrub_text_blocks, keeper_summarizer ([STATE] 스크럽) |

## Why
\`#11229\` (PR#2 batch 1)이 첫 5 mli만 squash merge되면서 4개가 누락. 동일 base(post-#11229 main)에서 새 PR로 재출. 사용자 메모리 \`Stack PR base force-push loses patches\` 패턴(stack 변환 시 후속 patch 누락)과 동일 — 향후 force-push로 commit 추가하지 말고 batch별 별도 PR이 더 안전하다는 lesson.

## Ratchet impact
- \`keeper_mli_missing\` 46 → 42 (-4)

## Test plan
- [x] \`dune build --root . lib\` exit 0
- [x] \`scripts/ocaml-structure-ratchet.sh --print\`: keeper_mli_missing 42 < baseline 51 ✓
- [ ] CI \`Build and Test\` green (mli/ml 시그니처 일치 검증)
- [ ] CI \`OCaml Structure Ratchet\` green (단조감소 통과)

## Plan reference
\`planning/claude-plans/moonlit-finding-russell.md\` PR#2 batch 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)