### PR TITLE
chore(dashboard): replace rounded-[1px] with Tailwind rounded-px utility (3 sites)

### DIFF
--- a/dashboard/src/components/common/heartbeat-strip.ts
+++ b/dashboard/src/components/common/heartbeat-strip.ts
@@ -17,7 +17,7 @@ const COLOR: Record<HeartbeatState, string> = {
 
 const BAR_W = 'w-1'
 const BAR_H = 'h-3'
-const BAR_RADIUS = 'rounded-[1px]'
+const BAR_RADIUS = 'rounded-px'
 
 /** Pure: left-pad the history with 'unknown' so a new connector still
     renders a full-width strip (empty slots read as "no data yet" rather

--- a/dashboard/src/components/connector-overview-skeleton.ts
+++ b/dashboard/src/components/connector-overview-skeleton.ts
@@ -33,7 +33,7 @@ export function overviewSkeletonTileCount(): number {
   return KNOWN_CONNECTOR_IDS.length
 }
 
-const BAR = 'h-3 w-1 rounded-[1px] bg-[var(--white-4)] animate-pulse'
+const BAR = 'h-3 w-1 rounded-px bg-[var(--white-4)] animate-pulse'
 const PILL = 'h-4 flex-1 rounded-sm bg-[var(--white-4)] animate-pulse'
 const LINE = 'h-3 rounded bg-[var(--white-4)] animate-pulse'
 

--- a/dashboard/src/components/observatory/tool-call-track.ts
+++ b/dashboard/src/components/observatory/tool-call-track.ts
@@ -123,7 +123,7 @@ export function ToolCallTrack({ events, windowStart, windowEnd }: Props) {
               const ringClass = isSelected ? 'ring-2 ring-accent ring-offset-1 ring-offset-bg-1' : ''
               return html`
                 <span
-                  class="absolute top-1 bottom-1 w-[3px] ${color} rounded-[1px] hover:w-1.5 transition-all cursor-pointer ${ringClass}"
+                  class="absolute top-1 bottom-1 w-[3px] ${color} rounded-px hover:w-1.5 transition-all cursor-pointer ${ringClass}"
                   style="left: ${pct}%;"
                   title=${`${new Date(ts).toLocaleTimeString()} · ${name} · ${outcome}${count > 1 ? ` · ${count} calls` : ''}`}
                   onClick=${(e: MouseEvent) => {


### PR DESCRIPTION
## Summary

Drift cleanup — `rounded-px-literal` bucket. Tailwind v4's `rounded-px` utility resolves to `border-radius: 1px`, exactly matching the literal arbitrary value but participating in the standard utility namespace (no drift gate trip, no token-system bypass).

## Sites migrated

- `common/heartbeat-strip.ts:20` — `BAR_RADIUS` constant
- `observatory/tool-call-track.ts:126` — selected tool-call marker
- `connector-overview-skeleton.ts:36` — skeleton bar pulse

## Test plan

- [x] `pnpm test src/components/common/heartbeat-strip src/components/observatory/tool-call-track src/components/connector-overview-skeleton` — 31/31 passed
- [x] `pnpm typecheck` — clean
- [x] `bash scripts/dashboard-drift-check.sh` — `rounded-px-literal` decreased — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)