### PR TITLE
fix(test): unbreak main — thread trace_id through cascade trace mk_trace helpers

### DIFF
--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -753,9 +753,10 @@ let test_history_prometheus_counter_increments () =
 
 let mk_trace_event ?(ts = 0.0) ?(cascade_name = "big_three")
     ?(strategy = "failover") ?(cycle = 0) ?(candidates_in = 3)
-    ?(candidates_out = 3) ?(backoff_ms = 0) ?(kind = ST.Ordered) () =
+    ?(candidates_out = 3) ?(backoff_ms = 0) ?(kind = ST.Ordered)
+    ?trace_id () =
   { ST.ts; cascade_name; strategy; cycle; candidates_in; candidates_out;
-    backoff_ms; kind }
+    backoff_ms; kind; trace_id }
 
 let test_trace_record_snapshot_roundtrip () =
   ST.clear ();

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -590,9 +590,9 @@ let test_declared_provider_schemes_handles_malformed_config () =
 
 module ST = Masc_mcp.Cascade_strategy_trace
 
-let mk_trace ?(ts = 0.0) ?(strategy = "failover") ~kind () =
+let mk_trace ?(ts = 0.0) ?(strategy = "failover") ?trace_id ~kind () =
   { ST.ts; cascade_name = "c1"; strategy; cycle = 0;
-    candidates_in = 1; candidates_out = 1; backoff_ms = 0; kind }
+    candidates_in = 1; candidates_out = 1; backoff_ms = 0; kind; trace_id }
 
 let assert_field name fields =
   match List.assoc_opt name fields with


### PR DESCRIPTION
## Summary

🚨 **main currently fails `dune build`** with:

```
File "test/test_cascade_strategy.ml", lines 757-758:
Error: Some record fields are undefined: trace_id
File "test/test_dashboard_cascade.ml", lines 594-595:
Error: Some record fields are undefined: trace_id
```

PR #11228 (G2a, merged 2026-04-27 14:06:22Z) added `trace_id : string option` to `Cascade_strategy_trace.event`. Two test `mk_trace` helpers construct event records by hand and were not updated.

Adds an optional `?trace_id : string option` argument to both helpers and threads it into the record literal. Existing call sites pass no trace_id, so behaviour is identical to pre-#11228 except the field is now defined.

**Fix-forward unblock** — keeps the additive trace_id field for future wiring (PR #11228 design intent), not reverting the field.

## Changes

| File | Change | LOC |
|------|--------|-----|
| `test/test_cascade_strategy.ml` | `mk_trace_event` gets `?trace_id` optional + record literal | +2 / -2 |
| `test/test_dashboard_cascade.ml` | `mk_trace` gets `?trace_id` optional + record literal | +2 / -2 |

Net: +5 / -4 (2 files, both test/).

## Test plan

- [x] `dune build --root .` green (full repo)
- [x] No production code changed; only test helpers
- [ ] Required check (Build) passes — recommend marking Ready as soon as Build is green so main is unblocked

## Risk

- Test helpers only; zero runtime behaviour change.
- Existing test call sites pass no `trace_id`, so the helpers default to `None` — behaviour identical to before #11228 was merged except the field is now defined on the record.
- Memory: `required-check-must-include-lint` pattern (#10747) reminder — Build CI was not required on the PR that introduced these record literals, so the breakage landed silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)