### PR TITLE
fix(test): add trace_id to cascade_strategy_trace.event record literals

### DIFF
--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -753,9 +753,10 @@ let test_history_prometheus_counter_increments () =
 
 let mk_trace_event ?(ts = 0.0) ?(cascade_name = "big_three")
     ?(strategy = "failover") ?(cycle = 0) ?(candidates_in = 3)
-    ?(candidates_out = 3) ?(backoff_ms = 0) ?(kind = ST.Ordered) () =
+    ?(candidates_out = 3) ?(backoff_ms = 0) ?(kind = ST.Ordered)
+    ?(trace_id = None) () =
   { ST.ts; cascade_name; strategy; cycle; candidates_in; candidates_out;
-    backoff_ms; kind }
+    backoff_ms; kind; trace_id }
 
 let test_trace_record_snapshot_roundtrip () =
   ST.clear ();

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -590,9 +590,9 @@ let test_declared_provider_schemes_handles_malformed_config () =
 
 module ST = Masc_mcp.Cascade_strategy_trace
 
-let mk_trace ?(ts = 0.0) ?(strategy = "failover") ~kind () =
+let mk_trace ?(ts = 0.0) ?(strategy = "failover") ?(trace_id = None) ~kind () =
   { ST.ts; cascade_name = "c1"; strategy; cycle = 0;
-    candidates_in = 1; candidates_out = 1; backoff_ms = 0; kind }
+    candidates_in = 1; candidates_out = 1; backoff_ms = 0; kind; trace_id }
 
 let assert_field name fields =
   match List.assoc_opt name fields with


### PR DESCRIPTION
## Summary

main release build is broken. #11228 added optional \`trace_id : string option\` to \`Cascade_strategy_trace.event\` but missed two test sites that construct the record positionally without the new field.

\`\`\`
test/test_cascade_strategy.ml:757-758:
  Some record fields are undefined: trace_id
test/test_dashboard_cascade.ml:594-595:
  Some record fields are undefined: trace_id
\`\`\`

Surgical fix: add optional \`?(trace_id = None)\` arg to both helpers and include the field in the record construction.

## Why now

main \`dune build --profile=release\` fails on \`origin/main\` (verified at \`3c24071e6b\`). Every open PR's CI is blocked on this. Fix-forward instead of revert (#11228 itself is correct; the sweep was incomplete).

## Test plan

- [x] Local: \`dune build --profile=release\` exit 0
- [ ] CI: lint + test green

Pattern: variant/field addition partial-match cascade. Required-check should include Lint to catch this earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)