### PR TITLE
fix(test): add missing trace_id field to two ST.t literals (#11232 sweep)

### DIFF
--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -755,7 +755,7 @@ let mk_trace_event ?(ts = 0.0) ?(cascade_name = "big_three")
     ?(strategy = "failover") ?(cycle = 0) ?(candidates_in = 3)
     ?(candidates_out = 3) ?(backoff_ms = 0) ?(kind = ST.Ordered) () =
   { ST.ts; cascade_name; strategy; cycle; candidates_in; candidates_out;
-    backoff_ms; kind }
+    backoff_ms; kind; trace_id = None }
 
 let test_trace_record_snapshot_roundtrip () =
   ST.clear ();

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -592,7 +592,8 @@ module ST = Masc_mcp.Cascade_strategy_trace
 
 let mk_trace ?(ts = 0.0) ?(strategy = "failover") ~kind () =
   { ST.ts; cascade_name = "c1"; strategy; cycle = 0;
-    candidates_in = 1; candidates_out = 1; backoff_ms = 0; kind }
+    candidates_in = 1; candidates_out = 1; backoff_ms = 0; kind;
+    trace_id = None }
 
 let assert_field name fields =
   match List.assoc_opt name fields with


### PR DESCRIPTION
## Summary

Build broke after #11232 added \`trace_id : string option\` to
\`Cascade_strategy_trace.t\` but the partial-match update missed two
record literals.  Two helpers now populate \`trace_id = None\`
explicitly:

- \`test/test_dashboard_cascade.ml:594\` (\`mk_trace\` helper)
- \`test/test_cascade_strategy.ml:757\` (\`mk_trace_event\` helper)

Behavior unchanged -- the field defaults to \`None\` for synthetic
test traces that don't have a wall-clock turn correlator.

## Why this slipped past CI on #11232

The two affected files are in separate test suites that compile in
parallel.  #11232 added \`trace_id\` to the type *and* threaded it
through the production callers; the test-helper sites were missed
because they call \`{ ST.ts; ...; kind }\` without listing
\`trace_id\` and rely on positional inference, so the suite that
exercises them only fails when its own dune target rebuilds.

The deeper miss is the same \`variant-add-partial-match-cascade\`
pattern repeatedly noted in repo memory.  Adding a field is sweep-
required across all literal call sites; partial sweep yields a
half-broken main where any new test on a different branch trips
on it.

## Test plan

- [x] \`dune build --root .\` clean on top of \`3c24071e6b\`
  (origin/main HEAD at fix time)
- [x] no behavior change -- \`trace_id\` is \`option\` so \`None\`
  matches the pre-#11232 implicit default

## Plan reference

Outside the bloodflow restoration plan -- this is a fix-forward
unblocking main for #11242 (Step 15 partial: turn_id propagation
sentinel) and any other downstream branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)