### PR TITLE
refactor(keeper): add 3 keeper_turn_* .mli (PR#3 batch 1)

### DIFF
--- a/lib/keeper/keeper_turn_lifecycle.mli
+++ b/lib/keeper/keeper_turn_lifecycle.mli
@@ -1,0 +1,11 @@
+(** Keeper_turn_lifecycle — keeper shutdown handlers.
+
+    Extracted from keeper_turn.ml. *)
+
+type tool_result = Keeper_types.tool_result
+
+(** Handle the [masc_keeper_down] MCP tool call: stop keepalive,
+    optionally remove meta and/or session directory, broadcast
+    Operator_pause to the registry. *)
+val handle_keeper_down :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result

--- a/lib/keeper/keeper_turn_setup.mli
+++ b/lib/keeper/keeper_turn_setup.mli
@@ -1,0 +1,10 @@
+(** Keeper_turn_setup — keeper setup helpers.
+
+    Extracted from keeper_turn.ml. *)
+
+(** Resolve a keeper by name and return its meta record. Returns
+    [Error] if the keeper does not exist or the meta is unreadable. *)
+val ensure_keeper_exists :
+  ctx:_ Keeper_types.context ->
+  name:string ->
+  (Keeper_types.keeper_meta, string) result

--- a/lib/keeper/keeper_turn_up.mli
+++ b/lib/keeper/keeper_turn_up.mli
@@ -1,0 +1,12 @@
+(** Keeper_turn_up — keeper start/reconfigure handler.
+
+    Orchestrates the [masc_keeper_up] tool by delegating to
+    [Keeper_turn_up_args] (parse/validate), [Keeper_turn_up_create]
+    (new keeper), and [Keeper_turn_up_update] (existing keeper). *)
+
+type tool_result = Keeper_types.tool_result
+
+(** Handle the [masc_keeper_up] MCP tool call: parse args, look up the
+    existing keeper meta, and dispatch to create or update. *)
+val handle_keeper_up :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result


### PR DESCRIPTION
## Summary
PR#3 (keeper_meta_* / keeper_turn_* .mli 보강)의 첫 batch. keeper_turn_* 모듈 3개에 인터페이스 추가.

| 모듈 | 노출 surface |
|---|---|
| \`keeper_turn_setup\`     | \`ensure_keeper_exists\` (1 fn) |
| \`keeper_turn_up\`        | \`handle_keeper_up\` + \`tool_result\` alias (masc_keeper_up tool 오케스트레이션) |
| \`keeper_turn_lifecycle\` | \`handle_keeper_down\` + \`tool_result\` alias (masc_keeper_down: stop keepalive, remove meta, Operator_pause broadcast) |

## Why
keeper_turn_* 모듈군에서 .mli 누락 7개. 작은 것부터 surgical하게 인터페이스 추가. .ml 변경 0, public surface preserving.

## Ratchet impact
- \`keeper_mli_missing\` post-#11239 baseline 42 → 39 (-3)

## Test plan
- [x] \`dune build --root . lib\` exit 0
- [ ] CI \`Build and Test\` green
- [ ] CI \`OCaml Structure Ratchet\` green (단조감소 통과)

## Plan reference
\`planning/claude-plans/moonlit-finding-russell.md\` PR#3 — batch 1 (3/13 keeper_meta_*/turn_*).

## Follow-ups
- batch 2: keeper_meta_json_scrub, keeper_turn_telemetry, keeper_meta_json
- batch 3: 나머지 7개 (turn_up_args/create/update, meta_contract/store/tool_access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)