### PR TITLE
chore(scripts): add cleanup-stale-worktrees.sh (time-based, #11040 follow-up)

### DIFF
--- a/scripts/cleanup-stale-worktrees.sh
+++ b/scripts/cleanup-stale-worktrees.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Remove worktrees whose last commit is older than N days (default 7).
+#
+# Complements scripts/cleanup-merged-worktrees.sh — that script only handles
+# branches that already merged into main. This one targets the larger leak:
+# stale autocoder/feature worktrees whose PR was abandoned, closed without
+# merge, or never opened. Without explicit removal these accumulate
+# indefinitely (#11040: 539 worktrees, 53x over guideline).
+#
+# Conservative by design:
+#   - dry-run by default; --apply required to actually remove
+#   - skips dirty worktrees (uncommitted or staged changes)
+#   - skips worktrees containing nested worktrees (.worktrees/ inside)
+#   - never uses --force
+#   - leaves the branch in place (only removes the worktree directory)
+#
+# Usage:
+#   ./scripts/cleanup-stale-worktrees.sh                # dry run, 7-day threshold
+#   ./scripts/cleanup-stale-worktrees.sh --days 14      # 14-day threshold
+#   ./scripts/cleanup-stale-worktrees.sh --apply        # actually remove
+
+set -euo pipefail
+
+APPLY=0
+DAYS=7
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) APPLY=1; shift ;;
+    --days) DAYS="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '1,22p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! [[ "$DAYS" =~ ^[0-9]+$ ]]; then
+  echo "--days must be a non-negative integer (got: $DAYS)" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+CUTOFF_TS=$(( $(date +%s) - DAYS * 86400 ))
+
+stale=0
+dirty=0
+nested=0
+removed=0
+skipped=0
+
+# `git worktree list --porcelain` emits one stanza per worktree, separated by
+# blank lines. Stanzas always start with `worktree <path>`. Process via
+# substitution (not pipe) so loop runs in the current shell — pipes spawn a
+# subshell and counter increments are lost.
+while read -r wt_path; do
+  [ -z "$wt_path" ] && continue
+  [ "$wt_path" = "$REPO_ROOT" ] && continue
+
+  # Last-commit timestamp (Unix epoch). If the working tree is broken or
+  # detached, skip — operator should diagnose manually.
+  if ! last_ts=$(git -C "$wt_path" log -1 --format='%ct' 2>/dev/null); then
+    echo "BROKEN  $wt_path (cannot read HEAD) — skipped"
+    skipped=$((skipped+1))
+    continue
+  fi
+  [ -z "$last_ts" ] && continue
+
+  if [ "$last_ts" -ge "$CUTOFF_TS" ]; then
+    continue
+  fi
+
+  # Dirty check — unstaged or staged changes
+  if ! git -C "$wt_path" diff --quiet 2>/dev/null \
+     || ! git -C "$wt_path" diff --cached --quiet 2>/dev/null; then
+    echo "DIRTY   $wt_path — skipped (has uncommitted changes)"
+    dirty=$((dirty+1))
+    continue
+  fi
+
+  # Nested-worktree guard: never remove a directory that itself contains
+  # other worktrees (memory: feedback_masc-mcp-nested-worktree-containers).
+  if [ -d "$wt_path/.worktrees" ]; then
+    echo "NESTED  $wt_path — skipped (contains nested .worktrees/)"
+    nested=$((nested+1))
+    continue
+  fi
+
+  age_days=$(( ( $(date +%s) - last_ts ) / 86400 ))
+  stale=$((stale+1))
+
+  if [ "$APPLY" -eq 1 ]; then
+    if git worktree remove "$wt_path" 2>/dev/null; then
+      echo "REMOVED $wt_path (last commit ${age_days}d ago)"
+      removed=$((removed+1))
+    else
+      echo "SKIP    $wt_path (remove failed — likely locked)"
+      skipped=$((skipped+1))
+    fi
+  else
+    echo "CANDID  $wt_path (last commit ${age_days}d ago)"
+  fi
+done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
+
+if [ "$APPLY" -eq 1 ]; then
+  git worktree prune
+  echo ""
+  echo "Summary (--days $DAYS --apply): stale=$stale removed=$removed dirty=$dirty nested=$nested skipped=$skipped"
+else
+  echo ""
+  echo "Summary (--days $DAYS dry-run): stale=$stale dirty=$dirty nested=$nested skipped=$skipped"
+  echo "Pass --apply to remove the listed candidates."
+fi


### PR DESCRIPTION
## Summary

\`scripts/cleanup-merged-worktrees.sh\` 가 이미 머지된 branch 의 worktree 만 청소합니다. 그러나 #11040 이 측정한 539-worktree 누적의 다수는 **branch 가 머지되지 않았지만 stale (PR abandoned / never opened / closed-without-merge)** 한 case 였습니다 — 이 script 는 그 gap 을 시간 기반으로 닫습니다.

기본 7일 cutoff, dry-run 우선, conservative guard 다수.

## Changes

| 파일 | 추가 |
|------|------|
| \`scripts/cleanup-stale-worktrees.sh\` | 신규 (114 lines) |

특징:
- **Dry-run 기본**, \`--apply\` 명시 시에만 실제 제거
- **\`--days N\`** 으로 cutoff 조정 (default 7)
- **Dirty 보호**: unstaged + staged change 있는 worktree skip
- **Nested 보호**: \`.worktrees/feature/\` 같은 nested container 는 sub-worktree 보유 시 skip (메모리 \`feedback_masc-mcp-nested-worktree-containers\`)
- **Branch 유지**: worktree directory 만 제거, branch 자체는 보존 (operator decision)
- **Process substitution**: \`while ... done < <(...)\` 로 loop counter 가 parent shell 에 반영되도록 처리 (pipe 로 작성하면 subshell 이라 counter 손실)

## Verification

\`\`\`
$ ./scripts/cleanup-stale-worktrees.sh --days 7
Summary (--days 7 dry-run): stale=0 dirty=0 nested=0 skipped=0
Pass --apply to remove the listed candidates.
\`\`\`

현재 40 worktree 모두 today HEAD — leak window 가 일시적으로 닫힌 상태. 본 script 는 **미래 regression 방지** 와 향후 누적 시 매뉴얼 정리 도구로 의미.

\`\`\`
$ wc -l ~/me/workspace/yousleepwhen/masc-mcp/.worktrees/* | tail -1
       40  # currently
\`\`\`

(이슈 본문이 측정한 539 는 이미 outdated 한 데이터. 그 사이 cleanup 이 적용되어 40 으로 회복됨.)

## Out of scope

이슈가 제안한 두 가지 systemic fix:

- **A. Periodic janitor** (keeper janitor 가 daily 자동 실행) — 별도 PR / RFC 필요
- **B. PR merge hook** (GitHub Action 으로 머지 시 자동 worktree 제거) — 별도 PR 필요

본 PR 은 **manual-invocation script** 만 추가하여 operator 가 필요 시 실행. 자동화는 후속.

## Related

- \`scripts/cleanup-merged-worktrees.sh\` — branch-merged 기반 cleanup (이미 존재)
- 메모리 \`feedback_masc-mcp-nested-worktree-containers\` — nested worktree 보호 근거

Refs #11040 (partial — manual janitor script 추가, 자동화는 별도)