### PR TITLE
refactor(keeper): add 2 keeper_meta/turn .mli (PR#3 batch 2)

### DIFF
--- a/lib/keeper/keeper_meta_json_scrub.mli
+++ b/lib/keeper/keeper_meta_json_scrub.mli
@@ -1,0 +1,45 @@
+(** Keeper meta JSON legacy scrub helpers.
+
+    Lives below the codec/parser facade so persisted runtime JSON can
+    be migrated before strict [keeper_meta] decoding. *)
+
+(** Drop the named keys from a top-level JSON object; passes through
+    non-objects unchanged. *)
+val drop_assoc_keys : string list -> Yojson.Safe.t -> Yojson.Safe.t
+
+(** Returns [Error msg] if any [removed_keeper_meta_key_names] is
+    present at the top level (these have been deleted from the schema
+    and must not appear). *)
+val reject_removed_keeper_meta_fields :
+  Yojson.Safe.t -> (unit, string) result
+
+(** Legacy tool-policy keys that are scrubbed via
+    [scrub_legacy_tool_policy_meta_json]. *)
+val legacy_keeper_meta_tool_policy_key_names : string list
+
+(** Combined legacy key names (allowed_providers + tool-policy keys). *)
+val legacy_keeper_meta_key_names : string list
+
+(** Returns [Error msg] if any legacy key is present without going
+    through [read_meta_file_path] (which scrubs them). *)
+val reject_legacy_keeper_meta_fields :
+  Yojson.Safe.t -> (unit, string) result
+
+(** True if the top-level [tool_access.kind] is a legacy variant
+    ("restricted" / "unrestricted") that needs migration. *)
+val legacy_tool_access_kind_needs_scrub : Yojson.Safe.t -> bool
+
+(** Scrub legacy tool-policy keys, returning the new JSON and the list
+    of rewrite reasons (key names + tool_access(defaulted/legacy-kind)
+    pseudo-keys). Empty rewrite list means no change was needed. *)
+val scrub_legacy_tool_policy_meta_json :
+  Yojson.Safe.t -> Yojson.Safe.t * string list
+
+(** [scrub_persisted_keeper_meta_json ~path json] migrates persisted
+    keeper meta to the current schema (drops removed keys, rewrites
+    legacy tool-policy, migrates presence_keepalive=false→paused=true)
+    and writes the scrubbed content back to [path] when changes were
+    needed. Returns the scrubbed JSON and a [bool] indicating whether
+    the file was rewritten. *)
+val scrub_persisted_keeper_meta_json :
+  path:string -> Yojson.Safe.t -> Yojson.Safe.t * bool

--- a/lib/keeper/keeper_turn_telemetry.mli
+++ b/lib/keeper/keeper_turn_telemetry.mli
@@ -1,0 +1,57 @@
+(** Keeper_turn_telemetry — post-turn observability logging.
+
+    Extracted from keeper_agent_run.ml as part of #5732 god-module
+    split. Contains logging helpers for CDAL proofs, contract
+    verdicts, friction projections, and memory-bank writes. *)
+
+(** Convert a list of strings to a JSON list of strings. *)
+val string_list_json : string list -> Yojson.Safe.t
+
+(** Artifact names for completeness gaps that block the verdict
+    (sorted, deduplicated). *)
+val blocking_gap_artifacts :
+  Cdal_types.contract_verdict -> string list
+
+(** Artifact names for evidence-gap groups in a friction projection
+    (sorted, deduplicated). *)
+val friction_gap_artifacts :
+  Cdal_friction_projection.friction_projection -> string list
+
+(** Activity-payload JSON for a contract verdict, suitable for
+    dashboard / event-bus consumption. *)
+val contract_verdict_activity_payload :
+  keeper_name:string ->
+  Cdal_types.contract_verdict ->
+  Yojson.Safe.t
+
+(** Activity-payload JSON for a friction projection. *)
+val friction_activity_payload :
+  keeper_name:string ->
+  Cdal_friction_projection.friction_projection ->
+  Yojson.Safe.t
+
+(** Log a CDAL proof at debug (Completed) or warn level. *)
+val log_keeper_proof :
+  keeper_name:string -> Oas.Cdal_proof.t -> unit
+
+(** Log a contract verdict at debug (Satisfied) or warn (Violated,
+    Inconclusive) level. *)
+val log_keeper_contract_verdict :
+  keeper_name:string ->
+  Cdal_types.contract_verdict ->
+  unit
+
+(** Log a friction projection. Severity escalates with tripwires
+    (warn) or any blocked attempts (debug). *)
+val log_keeper_friction :
+  keeper_name:string ->
+  Cdal_friction_projection.friction_projection ->
+  unit
+
+(** Log a memory-bank write summary. Promoted to info level when
+    [notes_written >= 10], otherwise debug. *)
+val log_keeper_memory_write :
+  keeper_name:string ->
+  notes_written:int ->
+  kinds_written:string list ->
+  unit


### PR DESCRIPTION
## Summary
PR#3 batch 2 — 중간 크기(133/177줄) keeper 모듈 2개에 .mli 추가.

| 모듈 | 노출 surface |
|---|---|
| \`keeper_meta_json_scrub\`  | 8 fns (legacy keeper-meta JSON scrub: drop_assoc_keys, reject_*, scrub_legacy_tool_policy_meta_json, scrub_persisted_keeper_meta_json — presence_keepalive→paused migration 포함) |
| \`keeper_turn_telemetry\`   | 9 fns (CDAL proof/contract verdict/friction projection/memory-write 로깅, activity payload builders) |

## Why
\`keeper_meta_json_scrub\`는 schema migration의 contract surface — interface로 노출 의도가 가장 분명한 후보. \`keeper_turn_telemetry\`는 #5732 god-module split 산물로 keeper_agent_run.ml에서 추출된 helper 모듈, 9개 logging/payload helper의 의도를 mli로 명확화.

## Ratchet impact
- \`keeper_mli_missing\` 42 → 40 (-2)

## Test plan
- [x] \`dune build --root . lib\` exit 0
- [ ] CI \`Build and Test\` green
- [ ] CI \`OCaml Structure Ratchet\` green

## Plan reference
\`planning/claude-plans/moonlit-finding-russell.md\` PR#3 — batch 2 (5/13 누적).

🤖 Generated with [Claude Code](https://claude.com/claude-code)