### PR TITLE
chore(dashboard): migrate bg-white/5 → token (32 sites, final bg-white-alpha bucket)

### DIFF
--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -169,7 +169,7 @@ function SessionMeta({ agentName }: { agentName: string }) {
   return html`
     <div class="flex flex-wrap gap-2 mb-4">
       ${meta.map(m => html`
-        <span key=${m.label} class="inline-flex items-center gap-1.5 text-2xs font-medium py-1 px-2.5 bg-white/5 border border-[var(--white-10)] rounded text-text-muted">
+        <span key=${m.label} class="inline-flex items-center gap-1.5 text-2xs font-medium py-1 px-2.5 bg-[var(--white-5)] border border-[var(--white-10)] rounded text-text-muted">
           <span class="text-text-dim">${m.label}</span>
           <span class="text-text-strong font-mono text-3xs">${m.value}</span>
         </span>
@@ -191,7 +191,7 @@ function TaskEventTimeline({ events }: { events: AgentTimelineEvent[] }) {
           const color = taskEventColor(evt.type)
           return html`
             <div key=${idx} class="flex items-center gap-2 py-1.5 px-3 rounded hover:bg-[var(--white-3)] transition-colors">
-              <span class="text-3xs font-bold uppercase tracking-wider ${color} bg-white/5 px-2 py-0.5 rounded">${icon}</span>
+              <span class="text-3xs font-bold uppercase tracking-wider ${color} bg-[var(--white-5)] px-2 py-0.5 rounded">${icon}</span>
               <span class="text-xs text-text-body flex-1 truncate">${title}</span>
               ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
             </div>
@@ -277,7 +277,7 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
             </div>
           ` : null}
           ${summary.messages_sent > 0 ? html`
-            <div class="flex items-center gap-1.5 text-xs font-medium text-text-muted bg-white/5 border border-[var(--white-10)] px-3 py-1.5 rounded">
+            <div class="flex items-center gap-1.5 text-xs font-medium text-text-muted bg-[var(--white-5)] border border-[var(--white-10)] px-3 py-1.5 rounded">
               <span class="font-bold">${summary.messages_sent}</span> 메시지
             </div>
           ` : null}

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -252,16 +252,16 @@ export function AgentDetailOverlay() {
         <div class="flex justify-between items-start gap-4">
           <div class="flex flex-col gap-3 flex-1">
             <div class="flex items-center gap-4">
-              ${agentEmoji ? html`<div class="size-12 rounded bg-white/5 border border-[var(--white-10)] flex items-center justify-center text-3xl shadow-inner">${agentEmoji}</div>` : ''}
+              ${agentEmoji ? html`<div class="size-12 rounded bg-[var(--white-5)] border border-[var(--white-10)] flex items-center justify-center text-3xl shadow-inner">${agentEmoji}</div>` : ''}
               <div>
                 <h2 id=${titleId} class="m-0 flex items-baseline gap-3 text-text-strong text-2xl font-bold tracking-tight">
                   ${displayName}
                   ${koreanName ? html`<span class="text-sm text-text-dim font-medium tracking-normal">(${koreanName})</span>` : ''}
-                  ${showSecondaryLabel ? html`<span class="font-mono text-xs text-text-dim bg-white/5 px-2 py-0.5 rounded">${secondaryLabel}</span>` : ''}
+                  ${showSecondaryLabel ? html`<span class="font-mono text-xs text-text-dim bg-[var(--white-5)] px-2 py-0.5 rounded">${secondaryLabel}</span>` : ''}
                 </h2>
                 <div class="flex items-center gap-2 mt-2 flex-wrap">
                   <${StatusBadge} status=${unified.canonical} />
-                  ${unified.description !== unified.label ? html`<span class="text-3xs font-medium py-1 px-2 border border-[var(--white-10)] bg-white/5 text-text-muted whitespace-nowrap rounded" title=${unified.description}>${unified.description}</span>` : null}
+                  ${unified.description !== unified.label ? html`<span class="text-3xs font-medium py-1 px-2 border border-[var(--white-10)] bg-[var(--white-5)] text-text-muted whitespace-nowrap rounded" title=${unified.description}>${unified.description}</span>` : null}
                   ${isArchivedParticipant ? html`<${IdPill}>이전 세션 참여자<//>` : null}
                   ${agent?.model ? html`<span class="font-mono text-3xs font-medium bg-[var(--white-10)] border border-[var(--white-5)] px-2 py-1 rounded text-text-muted shadow-sm">${agent.model}</span>` : ''}
                   ${!agent && missionBrief?.archived_reason
@@ -292,7 +292,7 @@ export function AgentDetailOverlay() {
                           ${keeperIdentity ? html`<span class="text-text-dim text-xs"><span aria-hidden="true">· </span>${keeperIdentity}</span>` : ''}
                         </span>`
                       : null}
-                    ${missionBrief?.related_session_id ? html`<span class="flex items-center gap-1.5">세션: <strong class="font-mono text-text-strong text-xs bg-white/5 px-1.5 rounded">${missionBrief.related_session_id}</strong></span>` : null}
+                    ${missionBrief?.related_session_id ? html`<span class="flex items-center gap-1.5">세션: <strong class="font-mono text-text-strong text-xs bg-[var(--white-5)] px-1.5 rounded">${missionBrief.related_session_id}</strong></span>` : null}
                     ${continuitySummary ? html`<span class="text-accent/90 bg-[var(--accent-10)] px-2 py-0.5 rounded border border-accent/10">${continuitySummary}</span>` : null}
                   </div>
                 `

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -165,8 +165,8 @@ function EventRow({
 }) {
   const a = event.attribution
   const rowBg = active
-    ? 'bg-white/5'
-    : 'hover:bg-white/5'
+    ? 'bg-[var(--white-5)]'
+    : 'hover:bg-[var(--white-5)]'
   const reasonText = reasonOf(a)
   return html`
     <button

--- a/dashboard/src/components/common/id-pill.ts
+++ b/dashboard/src/components/common/id-pill.ts
@@ -22,7 +22,7 @@
 //   different pill shape (name tag, not id badge). P7 rounded
 //   sweep.
 // • agent-detail:228 (unified.description) — neutral tone with
-//   drifted opacities (bg-white/5 border-white/10). Needs a
+//   drifted opacities (bg-[var(--white-5)] border-white/10). Needs a
 //   neutral tone variant which itself has drift vs line 230
 //   (mono version: reversed bg-white/10 border-white/5). Both
 //   belong in P6 color normalisation.

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -466,7 +466,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
         <div class="min-w-0 flex-1">
           <div class="mb-1 flex flex-wrap items-center gap-2">
             <span
-              class="shrink-0 rounded-md border border-white/10 bg-white/5 px-2 py-0.5 text-3xs font-bold uppercase tracking-widest"
+              class="shrink-0 rounded-md border border-white/10 bg-[var(--white-5)] px-2 py-0.5 text-3xs font-bold uppercase tracking-widest"
               style="color:${horizonColor(node.horizon)}"
             >
               ${horizonLabel(node.horizon)}
@@ -777,7 +777,7 @@ function GoalDetailPanel({
             <${HealthBadge} health=${selectedNode.health} />
             <${StatusBadge} status=${selectedNode.status} />
             <${StatusBadge} status=${goalPhaseStatus(selectedNode.phase)} label=${goalPhaseLabel(selectedNode.phase)} />
-            <span class="rounded border border-white/10 bg-white/5 px-2 py-0.5 text-3xs font-semibold uppercase tracking-widest" style="color:${horizonColor(selectedNode.horizon)}">
+            <span class="rounded border border-white/10 bg-[var(--white-5)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-widest" style="color:${horizonColor(selectedNode.horizon)}">
               ${horizonLabel(selectedNode.horizon)}
             </span>
           </div>
@@ -1041,7 +1041,7 @@ export function GoalTree() {
                 placeholder="목표 / 태스크 제목 필터"
                 aria-label="목표 트리 필터"
                 onInput=${(e: Event) => { filterQuery.value = (e.target as HTMLInputElement).value }}
-                class="min-w-45 max-w-65 rounded border border-white/10 bg-white/5 px-2 py-1 text-xs text-text-body placeholder:text-text-dim focus:outline-none focus:border-accent"
+                class="min-w-45 max-w-65 rounded border border-white/10 bg-[var(--white-5)] px-2 py-1 text-xs text-text-body placeholder:text-text-dim focus:outline-none focus:border-accent"
               />
               <${ActionButton} variant="ghost" size="sm" onClick=${() => expandAll(data.tree)}>
                 모두 펼치기

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -44,7 +44,7 @@ function priorityToneClass(priority: number): string {
     case 1: return 'border-l-[var(--rose-light)] bg-[var(--color-status-err)]/10 text-[var(--rose-fg)]'
     case 2: return 'border-l-[var(--color-status-warn)] bg-[var(--color-status-warn)]/10 text-[var(--yellow-100)]'
     case 3: return 'border-l-[var(--blue-400)] bg-[var(--blue-400)]/10 text-[#bfdbfe]'
-    default: return 'border-l-[rgba(148,163,184,0.45)] bg-white/5 text-text-muted'
+    default: return 'border-l-[rgba(148,163,184,0.45)] bg-[var(--white-5)] text-text-muted'
   }
 }
 
@@ -106,7 +106,7 @@ function KanbanCard({ task }: { task: Task }) {
       <div class="flex items-start justify-between gap-3">
         <div class="flex flex-wrap items-center gap-2">
           <span class="rounded border border-current/20 px-2 py-0.5 text-2xs font-semibold">${priorityLabel(p)}</span>
-          ${scope ? html`<span class="rounded border border-card-border/70 bg-white/5 px-2 py-0.5 text-2xs font-medium text-text-body">${scope}</span>` : null}
+          ${scope ? html`<span class="rounded border border-card-border/70 bg-[var(--white-5)] px-2 py-0.5 text-2xs font-medium text-text-body">${scope}</span>` : null}
         </div>
         <${ActionButton}
           variant="danger"

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -400,7 +400,7 @@ function KeeperApprovalEmptyState() {
     ? 'border-warn/30 bg-warn/10 text-warn'
     : ctx.tone === 'ok'
       ? 'border-accent/20 bg-[var(--accent-10)] text-accent'
-      : 'border-[var(--white-10)] bg-white/5 text-text-muted'
+      : 'border-[var(--white-10)] bg-[var(--white-5)] text-text-muted'
   return html`
     <div data-testid="keeper-hitl-empty">
       <${EmptyState} message=${ctx.primary} compact />
@@ -549,15 +549,15 @@ function KeeperApprovalQueueSection() {
                       ? html`<div class="mt-2 text-xs leading-relaxed text-text-muted break-words">${item.input_preview}</div>`
                       : null}
                     <div class="mt-2 flex flex-wrap gap-1.5 text-2xs">
-                      ${item.task_id ? html`<span class="rounded border border-[var(--white-10)] bg-white/5 px-1.5 py-0.5 text-text-muted">task ${item.task_id}</span>` : null}
-                      ${item.goal_id ? html`<span class="rounded border border-[var(--white-10)] bg-white/5 px-1.5 py-0.5 text-text-muted">goal ${item.goal_id}</span>` : null}
+                      ${item.task_id ? html`<span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-1.5 py-0.5 text-text-muted">task ${item.task_id}</span>` : null}
+                      ${item.goal_id ? html`<span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-1.5 py-0.5 text-text-muted">goal ${item.goal_id}</span>` : null}
                       ${item.runtime_contract?.sandbox_profile
-                        ? html`<span class="rounded border border-[var(--white-10)] bg-white/5 px-1.5 py-0.5 text-text-muted">
+                        ? html`<span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-1.5 py-0.5 text-text-muted">
                           sandbox ${item.runtime_contract.sandbox_profile}${item.runtime_contract.backend ? ` / ${item.runtime_contract.backend}` : ''}
                         </span>`
                         : null}
                       ${item.selected_model
-                        ? html`<span class="rounded border border-[var(--white-10)] bg-white/5 px-1.5 py-0.5 text-text-muted font-mono">${item.selected_model}</span>`
+                        ? html`<span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-1.5 py-0.5 text-text-muted font-mono">${item.selected_model}</span>`
                         : null}
                       ${item.disposition
                         ? html`<span class="rounded border px-1.5 py-0.5 font-bold ${approvalDispositionToneClass(item.disposition)}">
@@ -637,10 +637,10 @@ function ApprovalRulesSection() {
                       </span>
                     </div>
                     <div class="mt-2 flex flex-wrap gap-1.5 text-2xs">
-                      ${rule.sandbox_profile ? html`<span class="rounded border border-[var(--white-10)] bg-white/5 px-1.5 py-0.5 text-text-muted">sandbox ${rule.sandbox_profile}${rule.backend ? ` / ${rule.backend}` : ''}</span>` : null}
-                      ${rule.request_fingerprint_preview ? html`<span class="rounded border border-[var(--white-10)] bg-white/5 px-1.5 py-0.5 text-text-muted font-mono">fp ${rule.request_fingerprint_preview}</span>` : null}
-                      ${typeof rule.match_count === 'number' ? html`<span class="rounded border border-[var(--white-10)] bg-white/5 px-1.5 py-0.5 text-text-muted">match ${rule.match_count}</span>` : null}
-                      ${rule.source_approval_id ? html`<span class="rounded border border-[var(--white-10)] bg-white/5 px-1.5 py-0.5 text-text-muted">from ${rule.source_approval_id}</span>` : null}
+                      ${rule.sandbox_profile ? html`<span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-1.5 py-0.5 text-text-muted">sandbox ${rule.sandbox_profile}${rule.backend ? ` / ${rule.backend}` : ''}</span>` : null}
+                      ${rule.request_fingerprint_preview ? html`<span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-1.5 py-0.5 text-text-muted font-mono">fp ${rule.request_fingerprint_preview}</span>` : null}
+                      ${typeof rule.match_count === 'number' ? html`<span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-1.5 py-0.5 text-text-muted">match ${rule.match_count}</span>` : null}
+                      ${rule.source_approval_id ? html`<span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-1.5 py-0.5 text-text-muted">from ${rule.source_approval_id}</span>` : null}
                     </div>
                     <div class="mt-3 flex justify-end">
                       <${ActionButton}

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -372,7 +372,7 @@ function Callout({
 function BoolBadge({ value }: { value: boolean }) {
   return value
     ? html`<span class="text-2xs font-bold px-2 py-0.5 rounded bg-ok/10 text-ok border border-ok/20 shadow-sm shadow-ok/5">ON</span>`
-    : html`<span class="text-2xs font-bold px-2 py-0.5 rounded bg-white/5 text-text-dim border border-[var(--white-10)] shadow-sm">OFF</span>`
+    : html`<span class="text-2xs font-bold px-2 py-0.5 rounded bg-[var(--white-5)] text-text-dim border border-[var(--white-10)] shadow-sm">OFF</span>`
 }
 
 function formatHookDestructiveTools(value: string[] | string): string {
@@ -408,7 +408,7 @@ function PromptSourceBadge({ source }: { source: string }) {
       ? 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]'
       : source === 'file'
         ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]'
-        : 'bg-white/5 text-text-dim border-[var(--white-10)]'
+        : 'bg-[var(--white-5)] text-text-dim border-[var(--white-10)]'
   return html`<span class="text-3xs font-bold px-2 py-0.5 rounded border ${tone} shadow-sm">${source.toUpperCase()}</span>`
 }
 

--- a/dashboard/src/components/observatory/detail-pane.ts
+++ b/dashboard/src/components/observatory/detail-pane.ts
@@ -31,7 +31,7 @@ function outcomeTag(entry: TelemetryEntry): { label: string; tone: 'ok' | 'bad' 
 function toneClass(tone: 'ok' | 'bad' | 'neutral'): string {
   if (tone === 'ok') return 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]'
   if (tone === 'bad') return 'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]'
-  return 'bg-white/5 text-text-dim border-card-border'
+  return 'bg-[var(--white-5)] text-text-dim border-card-border'
 }
 
 function keeperOf(entry: TelemetryEntry): string | null {
@@ -79,7 +79,7 @@ export function DetailPane() {
         </div>
         <button
           type="button"
-          class="rounded px-2 py-0.5 text-2xs text-text-dim hover:text-text-strong hover:bg-white/5"
+          class="rounded px-2 py-0.5 text-2xs text-text-dim hover:text-text-strong hover:bg-[var(--white-5)]"
           onClick=${clearSelection}
           aria-label="상세 패널 닫기"
         >

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -130,7 +130,7 @@ function RangeSelector() {
           class="rounded px-2 py-0.5 font-medium transition-colors ${
             current === preset
               ? 'bg-accent/20 text-accent'
-              : 'text-text-muted hover:text-text-strong hover:bg-white/5'
+              : 'text-text-muted hover:text-text-strong hover:bg-[var(--white-5)]'
           }"
           onClick=${() => setTimeRangeFilter(preset)}
           aria-pressed=${current === preset}
@@ -160,7 +160,7 @@ function ViewSelector({
           class="rounded px-2 py-0.5 font-medium transition-colors ${
             current === view.key
               ? 'bg-accent/20 text-accent'
-              : 'text-text-muted hover:text-text-strong hover:bg-white/5'
+              : 'text-text-muted hover:text-text-strong hover:bg-[var(--white-5)]'
           }"
           onClick=${() => onSelect(view.key)}
           aria-pressed=${current === view.key}
@@ -294,7 +294,7 @@ export function Observatory() {
               class="inline-flex items-center gap-1.5 rounded border px-2.5 py-1 text-2xs font-medium transition-colors ${
                 liveMode.value
                   ? 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]'
-                  : 'border-card-border text-text-muted hover:text-text-strong hover:bg-white/5'
+                  : 'border-card-border text-text-muted hover:text-text-strong hover:bg-[var(--white-5)]'
               }"
               onClick=${() => {
                 liveMode.value = !liveMode.value

--- a/dashboard/src/components/tk.ts
+++ b/dashboard/src/components/tk.ts
@@ -9,7 +9,7 @@
 // across 4+ drifting class compositions:
 //
 //   <code class="rounded bg-[var(--white-4)] px-1">                — connector-{status,keeper-matrix}
-//   <code class="rounded bg-white/5 px-1 py-0.5 text-2xs ...">    — goals/goal-tree, task-create-form
+//   <code class="rounded bg-[var(--white-5)] px-1 py-0.5 text-2xs ...">    — goals/goal-tree, task-create-form
 //   <code class="text-3xs text-[var(--color-fg-muted)]">           — safe-autonomy (no bg)
 //   <code class="text-xs font-mono text-[var(--color-fg-secondary)]"> — server-config
 //


### PR DESCRIPTION
## Summary
- bg-white-alpha family 마지막 bucket 정리 (32 sites, 11 files)
- raw Tailwind alpha utility → design-system 토큰 참조 (`bg-[var(--white-5)]`)
- governance / goal-tree / agent-detail / keeper-config-panel / observatory / kanban-components / tk / detail-pane / observatory.ts / attribution-panel / id-pill 변경

## Verification
- [x] `pnpm tsc --noEmit`: clean
- [x] `pnpm vitest run`: 4510/4510 pass
- [x] `bash scripts/dashboard-drift-check.sh`: gate OK
- [x] residue check: `rg 'bg-white/5\b' dashboard/src` → 0

## Drift baseline
bg-white-alpha 73 → 1 (baseline regen 가능). 본 PR은 drift만 처리, baseline 자연화는 별도 PR로 분리(coupling 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)