### PR TITLE
chore(dashboard): migrate border-white/{5,10} residue → token (4 sites)

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -708,7 +708,7 @@ function StatusBar({
   const liveBadge = snapshot
     ? snapshot.is_live
       ? html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono text-[var(--color-status-ok)] border-[var(--ok-20)] bg-[var(--ok-10)] animate-pulse">● 실행 중</span>`
-      : html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono ${idleIsLong ? 'text-[var(--color-fg-muted)] border-[var(--warn-20)]' : 'text-[var(--color-fg-disabled)] border-white/10'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-3xs opacity-70"><span aria-hidden="true">· </span>턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
+      : html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono ${idleIsLong ? 'text-[var(--color-fg-muted)] border-[var(--warn-20)]' : 'text-[var(--color-fg-disabled)] border-[var(--white-10)]'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-3xs opacity-70"><span aria-hidden="true">· </span>턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
     : null
   const receiptLabel = snapshot ? executionReceiptLabel(snapshot.execution) : null
 

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -466,7 +466,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
         <div class="min-w-0 flex-1">
           <div class="mb-1 flex flex-wrap items-center gap-2">
             <span
-              class="shrink-0 rounded-md border border-white/10 bg-[var(--white-5)] px-2 py-0.5 text-3xs font-bold uppercase tracking-widest"
+              class="shrink-0 rounded-md border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-3xs font-bold uppercase tracking-widest"
               style="color:${horizonColor(node.horizon)}"
             >
               ${horizonLabel(node.horizon)}
@@ -777,7 +777,7 @@ function GoalDetailPanel({
             <${HealthBadge} health=${selectedNode.health} />
             <${StatusBadge} status=${selectedNode.status} />
             <${StatusBadge} status=${goalPhaseStatus(selectedNode.phase)} label=${goalPhaseLabel(selectedNode.phase)} />
-            <span class="rounded border border-white/10 bg-[var(--white-5)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-widest" style="color:${horizonColor(selectedNode.horizon)}">
+            <span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-widest" style="color:${horizonColor(selectedNode.horizon)}">
               ${horizonLabel(selectedNode.horizon)}
             </span>
           </div>
@@ -1041,7 +1041,7 @@ export function GoalTree() {
                 placeholder="목표 / 태스크 제목 필터"
                 aria-label="목표 트리 필터"
                 onInput=${(e: Event) => { filterQuery.value = (e.target as HTMLInputElement).value }}
-                class="min-w-45 max-w-65 rounded border border-white/10 bg-[var(--white-5)] px-2 py-1 text-xs text-text-body placeholder:text-text-dim focus:outline-none focus:border-accent"
+                class="min-w-45 max-w-65 rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-1 text-xs text-text-body placeholder:text-text-dim focus:outline-none focus:border-accent"
               />
               <${ActionButton} variant="ghost" size="sm" onClick=${() => expandAll(data.tree)}>
                 모두 펼치기


### PR DESCRIPTION
## Summary
- border-white-alpha residue 마무리 — fsm-hub (1) + goal-tree (3)
- raw alpha utility → design-system 토큰 참조

## Sites
- \`goals/goal-tree.ts\`:469, 780, 1044 (border + bg pair)
- \`fsm-hub.ts\`:711 (nested template literal)

## Verification
- [x] \`pnpm tsc --noEmit\`: clean
- [x] \`pnpm vitest run goals fsm-hub\`: 354/354 pass
- [x] \`bash scripts/dashboard-drift-check.sh\`: gate OK
- [x] residue check: real code 0

Note: id-pill.ts:25,27는 documentation comment 라 미변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)