### PR TITLE
chore(ratchet): lower OCaml structure baselines after 6 merged PRs

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,8 +1,8 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 51,
+  "keeper_mli_missing": 37,
   "coord_mli_missing": 3,
-  "godsplit_count": 11,
-  "lib_dune_lines": 962
+  "godsplit_count": 0,
+  "lib_dune_lines": 951
 }


### PR DESCRIPTION
## Summary
6개 PR 머지가 만든 단조감소를 baseline에 lock-in:

| metric | 이전 | 현재 |
|---|---|---|
| keeper_mli_missing | 51 | **37** (-14) |
| godsplit_count | 11 | **0** (-11) |
| lib_dune_lines | 962 | **951** (-11) |
| coord_mli_missing | 3 | 3 |

## Why
PR#0 (#11220)가 깐 ratchet은 단조감소만 허용. 그러나 baseline 자체는 자동 갱신되지 않음 — PR#11226/#11229/#11231/#11239/#11246/#11248가 실제 metric을 줄였지만 baseline은 여전히 51/11/962. baseline을 갱신해야 향후 PR이 더 엄격한 조건에서 검증되고, 회귀가 더 일찍 잡힘.

baseline을 lock-in하지 않으면 사용자 메모리 \`ratchet-naturalization-after-admin-merge\` 사고 가능 — admin override로 metric이 회귀해도 원본 baseline까지 silent rebound 가능.

## Verification
\`\`\`
$ scripts/ocaml-structure-ratchet.sh --print
metric                   current   baseline
keeper_mli_missing            37         37
coord_mli_missing              3          3
godsplit_count                 0          0
lib_dune_lines               951        951
\`\`\`

## Plan reference
\`planning/claude-plans/moonlit-finding-russell.md\` PR#0 follow-up — baseline regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)