### PR TITLE
refactor(keeper): add keeper_meta_json.mli (PR#3 batch 3)

### DIFF
--- a/lib/keeper/keeper_meta_json.mli
+++ b/lib/keeper/keeper_meta_json.mli
@@ -1,0 +1,30 @@
+(** Keeper meta JSON codec facade.
+
+    Included by [Keeper_types] so existing [Keeper_types.*] callers
+    keep their public API while scrubbing, parsing, and serialization
+    stay in smaller private modules. *)
+
+include module type of Keeper_meta_json_scrub
+
+include module type of Keeper_meta_json_parse
+
+(** Serialize a [keeper_meta] record to JSON. Centralizes the write
+    side of the personality-fields contract (Layer 2 PR-B,
+    Keeper_personality_io.to_json) so that round-trip symmetry with
+    [meta_of_json] is preserved (#10479 PR-A drift fix). *)
+val meta_to_json : Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
+
+(** Canonical key list, used as fallback if dynamic seed-based key
+    extraction fails. ~95 keys covering identity, intent, social
+    state, runtime telemetry, proactive/work-discovery surfaces. *)
+val fallback_canonical_keeper_meta_key_names : string list
+
+(** Canonical key list, computed at startup by serializing a seed
+    keeper_meta and extracting field names. Falls back to
+    [fallback_canonical_keeper_meta_key_names] if serialization fails. *)
+val canonical_keeper_meta_key_names : string list
+
+(** Log a warning for any top-level keys in [json] that aren't in the
+    canonical key list — catches schema drift early. *)
+val warn_unknown_keeper_meta_keys :
+  path:string -> Yojson.Safe.t -> unit


### PR DESCRIPTION
## Summary
\`keeper_meta_json\` 모듈에 .mli 추가. JSON codec facade가 \`Keeper_meta_json_scrub\` + \`Keeper_meta_json_parse\` 양쪽을 re-export하는 구조를 mli에 반영.

| 노출 surface | 출처 |
|---|---|
| 8 fns | \`include module type of Keeper_meta_json_scrub\` |
| meta_of_json + 기타 | \`include module type of Keeper_meta_json_parse\` |
| meta_to_json | own |
| fallback_canonical_keeper_meta_key_names (95 keys) | own |
| canonical_keeper_meta_key_names | own |
| warn_unknown_keeper_meta_keys | own |

## Why
\`keeper_meta_json.ml\`은 facade이라 noop \`include\`만으로 다양한 모듈을 노출. mli에서 \`include module type of\`를 빼먹으면 lib downstream(keeper_meta_store.ml:28에서 meta_of_json 사용)이 컴파일 안 됨. 첫 시도에서 빌드 실패로 즉시 발견 → 두 번째 시도에서 \`include module type of Keeper_meta_json_parse\` 추가.

이 lesson은 facade 모듈의 mli 작성 시 \`.ml\`의 모든 \`include\`/\`open\` 줄을 sweep해야 한다는 것 — 사용자 메모리 \`Jane Street refactor wave sweep miss\`와 같은 패턴.

## Ratchet impact
- \`keeper_mli_missing\` 37 → 36 (-1)

## Test plan
- [x] \`dune build --root . lib\` exit 0 (두 번째 시도)
- [ ] CI \`Build and Test\` green
- [ ] CI \`OCaml Structure Ratchet\` green

## Plan reference
\`planning/claude-plans/moonlit-finding-russell.md\` PR#3 — batch 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)