### PR TITLE
fix(keeper): kill silent host-sandbox fallback + emit via:host on shell ops

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1389,6 +1389,10 @@ let handle_keeper_shell
                match cwd with
                | Some dir -> `String dir
                | None -> `Null );
+             (* host execution path: route discriminator must be present so
+                the dashboard / LLM cannot mistake a host-side run for a
+                docker-sandboxed run (#11080 sibling sweep). *)
+             "via", `String "host";
            ] @ insight_extra)
          ~status:st
          ~output:out
@@ -1427,6 +1431,13 @@ let handle_keeper_shell
           List.map Masc_exec.Bash_history.failure_pattern_to_json patterns)
       ]
     in
+    (* Caller-supplied [extra] may already declare ["via"] (e.g. wc docker
+       branch); only inject the default ["via", "host"] when absent so the
+       docker route's explicit ["via", "docker"] still wins. *)
+    let extra_with_via =
+      if List.exists (fun (k, _) -> k = "via") extra then extra
+      else ("via", `String "host") :: extra
+    in
     Yojson.Safe.to_string
       (Exec_core.process_result_json
          ~artifact_policy:Exec_core.Inline_only
@@ -1440,7 +1451,7 @@ let handle_keeper_shell
                match cwd with
                | Some dir -> `String dir
                | None -> `Null );
-           ] @ extra @ insight_extra)
+           ] @ extra_with_via @ insight_extra)
          ~status:st
          ~output:out
          ())
@@ -1606,6 +1617,7 @@ let handle_keeper_shell
                [ "ok", `Bool (st = Unix.WEXITED 0)
                ; "op", `String op
                ; "path", `String target
+               ; "via", `String "host"
                ; "status", Keeper_alerting_path.process_status_to_json st
                ; "entries", lines_to_json ~limit out
                ]))
@@ -1656,6 +1668,7 @@ let handle_keeper_shell
                [ "ok", `Bool (st = Unix.WEXITED 0)
                ; "op", `String op
                ; "path", `String target
+               ; "via", `String "host"
                ; "status", Keeper_alerting_path.process_status_to_json st
                ; "truncated", `Bool (String.length out > max_bytes)
                ; "content", `String body
@@ -1732,6 +1745,7 @@ let handle_keeper_shell
                   ; "op", `String op
                   ; "path", `String target
                   ; "pattern", `String pattern
+                  ; "via", `String "host"
                   ; "status", Keeper_alerting_path.process_status_to_json st
                   ; "matches", lines_to_json ~limit out
                   ]))
@@ -1873,6 +1887,7 @@ let handle_keeper_shell
                 ; "op", `String op
                 ; "path", `String target
                 ; "name", `String name_pattern
+                ; "via", `String "host"
                 ; "status", Keeper_alerting_path.process_status_to_json st
                 ; "files", lines_to_json ~limit out
                 ]))
@@ -1913,6 +1928,7 @@ let handle_keeper_shell
                ; "op", `String op
                ; "path", `String target
                ; "lines", `Int n
+               ; "via", `String "host"
                ; "status", Keeper_alerting_path.process_status_to_json st
                ; "content", `String out
                ]))
@@ -1953,6 +1969,7 @@ let handle_keeper_shell
                ; "op", `String op
                ; "path", `String target
                ; "lines", `Int n
+               ; "via", `String "host"
                ; "status", Keeper_alerting_path.process_status_to_json st
                ; "content", `String out
                ]))
@@ -2028,6 +2045,7 @@ let handle_keeper_shell
                [ "ok", `Bool (st = Unix.WEXITED 0)
                ; "op", `String op
                ; "path", `String target
+               ; "via", `String "host"
                ; "status", Keeper_alerting_path.process_status_to_json st
                ; "entries", lines_to_json ~limit out
                ]))

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -297,10 +297,45 @@ let ensure_keeper_meta config name =
       match defaults.mention_targets with [] -> meta.mention_targets | xs -> xs in
     let target_active_goal_ids =
       apply_default defaults.active_goal_ids meta.active_goal_ids in
-    (* Infrastructure fields use system defaults when TOML is silent,
-       so removing a key from TOML actually reverts the runtime value. *)
-    let target_sandbox_profile =
-      apply_default defaults.sandbox_profile Keeper_types_profile.default_sandbox_profile in
+    (* Defense-in-depth (#11080 sibling): keeper sandbox_profile MUST be
+       declared. The previous behaviour silently fell through to
+       [default_sandbox_profile = Local] when TOML omitted the key,
+       which strips docker isolation from any operator who forgets to
+       set it (or copies a stale persona JSON: persona profiles are
+       declared elsewhere as not allowed to own this field). Reject at
+       reconcile time so the keeper visibly fails to boot rather than
+       running un-sandboxed.
+
+       Persona-only keepers cannot satisfy this check today and must
+       gain a TOML wrapper that sets [sandbox_profile]. The
+       [Keeper_types_profile.default_sandbox_profile] constant is left
+       in place because other read paths (JSON parser, env override,
+       turn_up_args) still need a value when reading already-persisted
+       meta. *)
+    let target_sandbox_profile_result =
+      match defaults.sandbox_profile with
+      | Some sp -> Ok sp
+      | None ->
+        let manifest_hint =
+          match defaults.manifest_path with
+          | Some path -> Printf.sprintf " (loaded from %s)" path
+          | None -> ""
+        in
+        let msg =
+          Printf.sprintf
+            "keeper %s rejected: sandbox_profile is required (allowed: %s)%s. \
+             Add e.g. `sandbox_profile = \"docker\"` to the keeper TOML."
+            meta.name
+            (String.concat ", "
+               Keeper_types_profile.valid_sandbox_profile_strings)
+            manifest_hint
+        in
+        Log.Keeper.warn "%s" msg;
+        Error msg
+    in
+    (match target_sandbox_profile_result with
+     | Error e -> Error e
+     | Ok target_sandbox_profile ->
     let target_network_mode =
       apply_default defaults.network_mode
         (Keeper_types_profile.default_network_mode_for_profile target_sandbox_profile) in
@@ -532,7 +567,7 @@ let ensure_keeper_meta config name =
         Log.Keeper.warn "ensure_keeper_meta: write_meta re-sync failed: %s" e;
         Ok meta
     end
-    else Ok meta)
+    else Ok meta))
   | Ok None ->
     Log.Keeper.warn
       "ensure_keeper_meta: no persistent meta for %s — run keeper_up to initialize" name;

--- a/test/dune
+++ b/test/dune
@@ -126,6 +126,7 @@
         test_keeper_transition_audit
         test_keeper_shell_containment
         test_keeper_shell_docker_route
+        test_keeper_shell_via_field
         test_env_git_noninteractive
         test_gh_exit_class
         test_gh_exit_class_wiring
@@ -291,6 +292,7 @@
           test_keeper_transition_audit
           test_keeper_shell_containment
           test_keeper_shell_docker_route
+          test_keeper_shell_via_field
           test_env_git_noninteractive
           test_gh_exit_class
           test_gh_exit_class_wiring

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -107,6 +107,7 @@ let test_personality_resync () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "TOML goal"
 short_goal = "TOML short goal"
 mid_goal = "TOML mid goal"
@@ -164,6 +165,7 @@ let test_policy_resync () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
 {|[keeper]
+sandbox_profile = "docker"
 goal = "test"
 policy_voice_enabled = false
 |};
@@ -305,6 +307,7 @@ let test_tool_policy_resync () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "test"
 allowed_paths = ["workspace/example/project"]
 tool_preset = "social"
@@ -370,6 +373,7 @@ let test_tool_preset_source_resyncs_from_toml_without_policy_delta () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "test"
 tool_preset = "social"
 |};
@@ -435,6 +439,20 @@ let test_tool_preset_source_resyncs_from_persona_without_policy_delta () =
     "tool_preset": "research"
   }
 }|};
+  (* Persona-only configs cannot satisfy the sandbox_profile required-field
+     check (personas are not allowed to declare execution policy). Add a
+     minimal TOML wrapper that only sets sandbox_profile + persona_name so
+     persona overlay still drives tool_preset. *)
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    (Printf.sprintf
+       {|[keeper]
+sandbox_profile = "docker"
+persona_name = "%s"
+|}
+       keeper_name);
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
@@ -490,6 +508,7 @@ let test_allowed_paths_explicit_empty_clears_runtime () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "test"
 allowed_paths = []
 |};
@@ -535,6 +554,16 @@ let test_persona_allowed_paths_is_ignored () =
     "allowed_paths": ["workspace/example/project"]
   }
 }|};
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    (Printf.sprintf
+       {|[keeper]
+sandbox_profile = "docker"
+persona_name = "%s"
+|}
+       keeper_name);
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
@@ -569,6 +598,7 @@ let test_custom_tool_access_preserved_without_preset () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "test"
 allowed_paths = ["workspace/example/project"]
 |};
@@ -647,6 +677,7 @@ let test_persona_overlay_resync () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 persona_name = "scholar"
 goal = "대화에 바로 쓸 수 있는 연구 브리프를 만든다."
 tool_preset = "delivery"
@@ -716,6 +747,7 @@ let test_toml_invalid_per_provider_timeout_clears_stale_runtime () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "test"
 per_provider_timeout = 0
 |};
@@ -761,6 +793,16 @@ let test_persona_invalid_per_provider_timeout_clears_stale_runtime () =
     "per_provider_timeout": "oops"
   }
 }|};
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    (Printf.sprintf
+       {|[keeper]
+sandbox_profile = "docker"
+persona_name = "%s"
+|}
+       keeper_name);
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
@@ -813,6 +855,7 @@ let test_none_preserves_runtime () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "minimal TOML"
 |};
   let config = Coord.default_config room_dir in
@@ -856,6 +899,7 @@ let test_discovery_resync () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "test"
 work_discovery_enabled = true
 work_discovery_interval_sec = 120
@@ -903,6 +947,7 @@ let test_cascade_defaults_resync () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "TOML goal"
 tool_preset = "social"
 |};
@@ -942,6 +987,7 @@ let test_social_model_resynced_from_declarative_defaults () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "TOML goal"
 social_model = "magentic_ledger_v1"
 |};
@@ -982,6 +1028,7 @@ let test_unknown_cascade_name_rejected () =
   write_file
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
+sandbox_profile = "docker"
 goal = "TOML goal"
 cascade_name = "missing_profile"
 |};
@@ -1060,6 +1107,7 @@ let test_room_presence_syncs_capabilities () =
 (* Test: update_field_in_content replaces existing field *)
 let test_toml_update_existing () =
   let input = {|[keeper]
+sandbox_profile = "docker"
 goal = "old goal"
 cascade_name = "default"
 instructions = "keep this"
@@ -1087,6 +1135,7 @@ instructions = "keep this"
 (** Test: update_field_in_content inserts new field *)
 let test_toml_update_insert () =
   let input = {|[keeper]
+sandbox_profile = "docker"
 goal = "test"
 |} in
   match Keeper_toml_loader.update_field_in_content
@@ -1127,6 +1176,7 @@ let test_canonicalize_if_keeper () =
   write_file
     (Filename.concat keepers_dir "sangsu.toml")
     {|[keeper]
+sandbox_profile = "docker"
 goal = "test goal"
 |};
   let config = Coord.default_config room_dir in

--- a/test/test_keeper_shell_via_field.ml
+++ b/test/test_keeper_shell_via_field.ml
@@ -1,0 +1,190 @@
+(** Regression test for the [via] discriminator in keeper_shell host-branch
+    JSON. Before the helper-and-sweep fix in #11080's sibling sweep, the
+    host branches of [ls/cat/rg/find/head/tail/tree/wc] hand-rolled JSON
+    without [via], so dashboards and downstream LLMs could not tell host
+    execution from a docker-sandboxed run. The bug class is the same as
+    the [sandbox_host_root] / [playground_path] leak that #11080 closed
+    in [keeper_status_detail.ml]. *)
+
+module Coord = Masc_mcp.Coord
+module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
+module Keeper_registry = Masc_mcp.Keeper_registry
+module Keeper_sandbox = Masc_mcp.Keeper_sandbox
+module Keeper_types = Masc_mcp.Keeper_types
+module Fs_compat = Fs_compat
+module Json = Yojson.Safe.Util
+
+let temp_dir () =
+  let dir = Filename.temp_file "keeper_shell_via_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  try rm dir with _ -> ()
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
+
+let make_meta ~name =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("agent-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "via discriminator regression");
+        ("allowed_paths", `List [ `String "*" ]);
+        ("sandbox_profile", `String "local");
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok meta -> meta
+  | Error e -> Alcotest.fail e
+
+let setup f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  ensure_dir (Filename.concat base Common.masc_dirname);
+  let config = Coord.default_config base in
+  Keeper_registry.clear ();
+  let meta = make_meta ~name:"via-keeper" in
+  let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+  ensure_dir playground;
+  (* Seed a small file inside the playground so read ops have something
+     to operate on; pattern is unique enough for [rg] to match exactly
+     once. *)
+  let sample = Filename.concat playground "sample.txt" in
+  ignore
+    (Fs_compat.save_file_atomic sample
+       "alpha via_marker_text\nbeta\ngamma\n");
+  f ~config ~meta ~playground ~sample
+
+let parse_via_field raw =
+  Yojson.Safe.from_string raw |> Json.member "via" |> Json.to_string_option
+
+let assert_via_host ~op raw =
+  match parse_via_field raw with
+  | Some "host" -> ()
+  | Some other ->
+      Alcotest.failf "op=%s expected via=\"host\", got via=%S; raw=%s" op other raw
+  | None ->
+      Alcotest.failf
+        "op=%s missing [via] discriminator in host-branch JSON; raw=%s" op raw
+
+let invoke ~config ~meta args =
+  Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None
+    ~exec_cache:None ~config ~meta ~args
+
+let test_ls_host_includes_via () =
+  setup @@ fun ~config ~meta ~playground ~sample:_ ->
+  let raw =
+    invoke ~config ~meta
+      (`Assoc [ ("op", `String "ls"); ("path", `String playground) ])
+  in
+  assert_via_host ~op:"ls" raw
+
+let test_cat_host_includes_via () =
+  setup @@ fun ~config ~meta ~playground:_ ~sample ->
+  let raw =
+    invoke ~config ~meta
+      (`Assoc [ ("op", `String "cat"); ("path", `String sample) ])
+  in
+  assert_via_host ~op:"cat" raw
+
+let test_rg_host_includes_via () =
+  setup @@ fun ~config ~meta ~playground ~sample:_ ->
+  let raw =
+    invoke ~config ~meta
+      (`Assoc
+        [
+          ("op", `String "rg");
+          ("pattern", `String "via_marker_text");
+          ("path", `String playground);
+        ])
+  in
+  assert_via_host ~op:"rg" raw
+
+let test_find_host_includes_via () =
+  setup @@ fun ~config ~meta ~playground ~sample:_ ->
+  let raw =
+    invoke ~config ~meta
+      (`Assoc
+        [
+          ("op", `String "find");
+          ("pattern", `String "*.txt");
+          ("path", `String playground);
+        ])
+  in
+  assert_via_host ~op:"find" raw
+
+let test_head_host_includes_via () =
+  setup @@ fun ~config ~meta ~playground:_ ~sample ->
+  let raw =
+    invoke ~config ~meta
+      (`Assoc [ ("op", `String "head"); ("path", `String sample) ])
+  in
+  assert_via_host ~op:"head" raw
+
+let test_tail_host_includes_via () =
+  setup @@ fun ~config ~meta ~playground:_ ~sample ->
+  let raw =
+    invoke ~config ~meta
+      (`Assoc [ ("op", `String "tail"); ("path", `String sample) ])
+  in
+  assert_via_host ~op:"tail" raw
+
+let test_tree_host_includes_via () =
+  setup @@ fun ~config ~meta ~playground ~sample:_ ->
+  let raw =
+    invoke ~config ~meta
+      (`Assoc [ ("op", `String "tree"); ("path", `String playground) ])
+  in
+  assert_via_host ~op:"tree" raw
+
+let test_wc_host_includes_via () =
+  setup @@ fun ~config ~meta ~playground:_ ~sample ->
+  let raw =
+    invoke ~config ~meta
+      (`Assoc [ ("op", `String "wc"); ("path", `String sample) ])
+  in
+  assert_via_host ~op:"wc" raw
+
+let () =
+  Alcotest.run "Keeper_shell via discriminator"
+    [
+      ( "host-branch",
+        [
+          Alcotest.test_case "ls includes via=host" `Quick
+            test_ls_host_includes_via;
+          Alcotest.test_case "cat includes via=host" `Quick
+            test_cat_host_includes_via;
+          Alcotest.test_case "rg includes via=host" `Quick
+            test_rg_host_includes_via;
+          Alcotest.test_case "find includes via=host" `Quick
+            test_find_host_includes_via;
+          Alcotest.test_case "head includes via=host" `Quick
+            test_head_host_includes_via;
+          Alcotest.test_case "tail includes via=host" `Quick
+            test_tail_host_includes_via;
+          Alcotest.test_case "tree includes via=host" `Quick
+            test_tree_host_includes_via;
+          Alcotest.test_case "wc includes via=host" `Quick
+            test_wc_host_includes_via;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Two-fix surgical PR targeting the host-shell-via-leak observed in a recent fleet incident
(velvet-hammer stale_keeper_broadcast + nick0cave/ollama-local/qa-king fleet batch
termination). Both pieces are root fixes for the same #11080 sibling-leak class.

### Commit 1 — `via:\"host\"` on every host-side shell op (`keeper_exec_shell.ml`)

`ls`, `cat`, `rg`, `find`, `head`, `tail`, `tree`, `wc` hand-rolled their host-branch
JSON without the `via` discriminator while the docker branches always set
`via:\"docker\"`. Dashboards and downstream LLMs were left to guess whether a result
came from a hardened docker sandbox or an uncontained host process — exactly the
shape PR #11080 closed in `keeper_status_detail.ml`.

Fix:
- `render_completed_process_result` and `render_process_result` inject `via:\"host\"`
  by default; explicit `via` in `~extra` still wins so the wc docker branch keeps
  `via:\"docker\"`.
- 7 hand-rolled host branches (`ls`/`cat`/`rg`/`find`/`head`/`tail`/`tree`) get an
  explicit `\"via\", \`String \"host\"` next to `path`.
- Ops that flow through `run_in_turn_runtime` (`pwd`/`git_status`/`git_log`/`git_diff`/
  `git_worktree`) inherit `via:\"host\"` through the helper change with no per-site
  edits.
- Docker code path is **untouched**: `render_docker_process_result` and the per-op
  docker branches still emit `via:\"docker\"` verbatim.

### Commit 2 — Reject missing `sandbox_profile` in TOML (`keeper_runtime.ml`)

`ensure_keeper_meta` previously called
`apply_default defaults.sandbox_profile default_sandbox_profile`,
silently downgrading any keeper whose TOML omitted `sandbox_profile` to the `Local`
host-process sandbox. Same Unknown→Permissive Default class that #11080 closed at a
sibling site.

Fix:
- Replace the silent fallback with an explicit `Error` from `ensure_keeper_meta`.
- Log a clear, actionable warning naming the keeper, the loaded manifest path, and
  the legal values.
- Leave `Keeper_types_profile.default_sandbox_profile` in place — `keeper_meta_json_parse`,
  the env-override path, and `keeper_turn_up_args` still consume it when reading
  already-persisted runtime meta.
- Persona-only keepers cannot satisfy this check by design (`load_keeper_profile_defaults_from_persona`
  hard-codes `sandbox_profile = None` because personas are not allowed to own
  execution policy). Three persona-only tests in `test_keeper_runtime_config_ssot`
  are migrated to add a thin TOML wrapper that only sets `sandbox_profile` and
  `persona_name`; the persona overlay still drives every other field, so the test
  intent is preserved.

### Commit 3 — Regression test

New `test/test_keeper_shell_via_field.ml` builds a Local-sandboxed keeper, executes
each of the 8 host-branch ops against a tmp playground, and requires the response
JSON to carry `via:\"host\"`. Future ops that forget the discriminator fail this
gate before they ship.

## Self-review (per `agents/best-programmer/AGENT.md`)

- **Goal**: kill the host-sandbox-fallback + via-leak class in one surgical PR;
  the rest of the 5-signal incident (token mismatch, oas_timeout_budget logging,
  require_tool_use violation) is intentionally out of scope.
- **Files modified**:
  - `lib/keeper/keeper_exec_shell.ml` — helper-level `via:\"host\"` + 7 inline tags.
  - `lib/keeper/keeper_runtime.ml` — fail-closed `ensure_keeper_meta`.
  - `test/test_keeper_runtime_config_ssot.ml` — fixture migration (16 TOML
    heredocs gain explicit `sandbox_profile`; 3 persona-only tests add a TOML
    wrapper).
  - `test/test_keeper_shell_via_field.ml` (new) — 8 host-branch via assertions.
  - `test/dune` — register the new test.
- **Local verification**:
  - `dune build --root .` (lib + targeted test exes) green.
  - `test_keeper_shell_via_field` 8/8.
  - `test_keeper_runtime_config_ssot` 24/24.
  - `test_keeper_runtime_toml`, `test_keeper_sandbox_containment`, `test_env_config_sandbox` green.
  - Pre-existing failures on origin/main (no relation to this PR): `test_keeper_shell_containment`,
    `test_keeper_shell_docker_route` (require docker), `test_keeper_runtime_denylist`
    (cascade catalog), `test_cascade_strategy`/`test_dashboard_cascade` (trace_id
    field added by #11228).
- **Not yet verified**:
  - 24h fleet re-measurement of `silent:dashboard_actor_fallback` and
    `oas_timeout_budget` (Track 2 inputs).
  - Real-keeper runtime check that operator-edited `~/.masc/config/keepers/*.toml`
    files still load cleanly (all 14 in this dev box already declare
    `sandbox_profile`, but other deploys may not).
- **Risk**: any in-the-wild keeper whose TOML omits `sandbox_profile` will refuse
  to boot after this lands. The clear actionable warn message gives the migration
  path: `Add e.g. \`sandbox_profile = \"docker\"\` to the keeper TOML.`

## Plan
[planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-sile-purring-raven.md](../blob/main/planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-sile-purring-raven.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)