### PR TITLE
feat(auth): MASC_AUTH_STRICT dry-run telemetry (Phase A F2)

### DIFF
--- a/lib/auth_strict_mode.ml
+++ b/lib/auth_strict_mode.ml
@@ -1,0 +1,20 @@
+(** See [auth_strict_mode.mli] for the contract. *)
+
+type t = Off | Dry_run | Strict
+
+let to_label = function
+  | Off -> "off"
+  | Dry_run -> "dry_run"
+  | Strict -> "strict"
+
+let of_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "off" | "0" | "false" -> Off
+  | "strict" | "1" | "true" -> Strict
+  | "dry_run" | "dry-run" | "" -> Dry_run
+  | _ -> Dry_run
+
+let current () =
+  match Sys.getenv_opt "MASC_AUTH_STRICT" with
+  | None -> Dry_run
+  | Some raw -> of_string raw

--- a/lib/auth_strict_mode.mli
+++ b/lib/auth_strict_mode.mli
@@ -1,0 +1,38 @@
+(** Auth strictness flag (Phase A F2).
+
+    Controls how [mcp_server_eio_execute] handles a bearer token that resolves
+    to no credential.  The pre-Phase-A behavior was to silently keep the
+    caller-supplied alias and emit a [silent:auth_token_resolve_error] warn —
+    936 events/day in production (2026-04-26 measurement).
+
+    Phase A F2 does not change behavior; it only adds a [would_reject]
+    counter so operators can measure how many of those silent fallbacks
+    represent legitimate vs illegitimate callers before Phase B PR-2 promotes
+    [Strict] to a typed reject.
+
+    Env flag values (canonical, case-insensitive):
+    - [off]            : keep silent fallback, no [would_reject] emit
+    - [dry_run]        : keep silent fallback, emit [would_reject] for soak
+    - [strict]         : (Phase B PR-2) actually reject the request
+
+    Default: [Dry_run].  The 48h soak collects [would_reject] cardinality so
+    we can identify dashboard / internal callers that need their token wiring
+    fixed before strict mode lands. *)
+
+type t = Off | Dry_run | Strict
+
+val current : unit -> t
+(** Read [MASC_AUTH_STRICT] from the environment.  Unknown / missing values
+    default to [Dry_run] so that operator omissions do not silently disable
+    measurement. *)
+
+val of_string : string -> t
+(** Pure parser exposed for unit tests.  Accepts ["off" | "0" | "false" |
+    "dry_run" | "dry-run" | "strict" | "1" | "true"], case-insensitive.
+    Any other input returns [Dry_run] (fail-open for telemetry, fail-closed
+    promotion happens in Phase B). *)
+
+val to_label : t -> string
+(** [to_label Off = "off"], [Dry_run = "dry_run"], [Strict = "strict"].
+    Used as the Prometheus [mode] label so operators can break down
+    [masc_auth_strict_would_reject_total] by mode. *)

--- a/lib/dune
+++ b/lib/dune
@@ -25,6 +25,7 @@
    auth_doctor
    auth_login
    auth_resolve
+   auth_strict_mode
    codex_mcp_config_doctor
    board
    board_core

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -329,6 +329,28 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
                Prometheus.metric_silent_auth_token_resolve_error
                ~labels:[ ("error_kind", error_kind); ("agent", agent_name) ]
                ();
+             (* Phase A F2 (2026-04-27): pair the silent counter with a
+                [would_reject] emission so operators can measure how many of
+                these fall-throughs would be rejected under MASC_AUTH_STRICT.
+                Behavior is unchanged: this PR only adds telemetry + a flag
+                surface so Phase B PR-2 can flip [Strict] safely. *)
+             let mode = Auth_strict_mode.current () in
+             let mode_label = Auth_strict_mode.to_label mode in
+             (match mode with
+              | Auth_strict_mode.Off -> ()
+              | Auth_strict_mode.Dry_run | Auth_strict_mode.Strict ->
+                  Log.Auth.warn
+                    "[would_reject:auth_token_resolve_error] mode=%s agent=%s \
+                     error_kind=%s - Phase B PR-2 will reject this request"
+                    mode_label agent_name error_kind;
+                  Prometheus.inc_counter
+                    Prometheus.metric_auth_strict_would_reject
+                    ~labels:
+                      [ ("mode", mode_label);
+                        ("error_kind", error_kind);
+                        ("agent", agent_name);
+                      ]
+                    ());
              agent_name)
     | _ -> agent_name
   in

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -707,6 +707,9 @@ let metric_silent_auth_token_resolve_error =
 let metric_silent_dashboard_actor_fallback =
   "masc_silent_dashboard_actor_fallback_total"
 
+let metric_auth_strict_would_reject =
+  "masc_auth_strict_would_reject_total"
+
 (** Counter for Coord.join preflight outcomes (RFC P3-a, logging-only mode).
    Labels: outcome (ok | empty_input | persona_not_found | credential_missing
    | name_ambiguous | ephemeral_suffix_rejected). Cross-reference with
@@ -1092,6 +1095,13 @@ let init () =
      from the bearer token (Ok None / Error _) and fell back to \
      request_actor_hint. Labels: outcome (none | error). Counter exposes \
      the path that masks identity drift in the HTTP transport."
+    Counter;
+  add metric_auth_strict_would_reject
+    "Phase A F2 (2026-04-27): every silent_auth_token_resolve_error fall-through \
+     in mcp_server_eio_execute also increments this counter so operators can \
+     measure how many of those would-be-rejections happen under each \
+     MASC_AUTH_STRICT mode before Phase B PR-2 promotes Strict to a typed \
+     reject. Labels: mode (off | dry_run | strict), error_kind, agent."
     Counter;
   add metric_coord_join_normalize_outcome
     "Total Coord.join calls preflighted by Keeper_identity.normalize_all_names \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -354,6 +354,15 @@ val metric_silent_dashboard_actor_fallback : string
     token resolved to no agent ([Ok None]) or an error.
     Labels: [outcome] = "none" | "error". *)
 
+val metric_auth_strict_would_reject : string
+(** Phase A F2 (2026-04-27): paired with
+    [metric_silent_auth_token_resolve_error] to measure "how many of
+    those silent fallbacks would be rejected under Strict mode" before
+    Phase B PR-2 actually performs the rejection.  Labels:
+    [mode] = "off" | "dry_run" | "strict",
+    [error_kind] = same kinds as silent_auth,
+    [agent] = the alias the request would have kept. *)
+
 val metric_coord_join_normalize_outcome : string
 (** RFC P3-a (2026-04-26): Coord.join preflighted by
     [Keeper_identity.normalize_all_names] in logging-only mode.

--- a/test/dune
+++ b/test/dune
@@ -198,7 +198,8 @@
         test_persona_tool_reachability
         test_cascade_strategy_labels
         test_turn_id_propagation
-        test_per_keeper_token_fallback)
+        test_per_keeper_token_fallback
+        test_auth_strict_mode)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -367,6 +368,7 @@
           test_cascade_strategy_labels
           test_turn_id_propagation
           test_per_keeper_token_fallback
+          test_auth_strict_mode
           )
  (libraries masc_test_deps))
 

--- a/test/test_auth_strict_mode.ml
+++ b/test/test_auth_strict_mode.ml
@@ -1,0 +1,94 @@
+(** test_auth_strict_mode — pure parser of [Auth_strict_mode] (Phase A F2).
+
+    The runtime [current ()] reads [MASC_AUTH_STRICT] from the process
+    environment and is therefore not unit-testable in isolation.  We pin
+    [of_string] / [to_label] here because Phase B PR-2 will branch real
+    behavior on this variant, so a silent rename or unknown-handling change
+    must fail at the test boundary rather than in production telemetry. *)
+
+open Masc_mcp
+
+let mode_testable =
+  Alcotest.testable
+    (fun fmt -> function
+      | Auth_strict_mode.Off -> Format.fprintf fmt "Off"
+      | Auth_strict_mode.Dry_run -> Format.fprintf fmt "Dry_run"
+      | Auth_strict_mode.Strict -> Format.fprintf fmt "Strict")
+    ( = )
+
+let test_of_string_off () =
+  List.iter
+    (fun raw ->
+      Alcotest.check mode_testable (Printf.sprintf "%S -> Off" raw)
+        Auth_strict_mode.Off (Auth_strict_mode.of_string raw))
+    [ "off"; "OFF"; "Off"; "0"; "false"; "FALSE"; "  off  " ]
+
+let test_of_string_strict () =
+  List.iter
+    (fun raw ->
+      Alcotest.check mode_testable
+        (Printf.sprintf "%S -> Strict" raw)
+        Auth_strict_mode.Strict
+        (Auth_strict_mode.of_string raw))
+    [ "strict"; "STRICT"; "Strict"; "1"; "true"; "TRUE"; "  strict  " ]
+
+let test_of_string_dry_run () =
+  List.iter
+    (fun raw ->
+      Alcotest.check mode_testable
+        (Printf.sprintf "%S -> Dry_run" raw)
+        Auth_strict_mode.Dry_run
+        (Auth_strict_mode.of_string raw))
+    [ "dry_run"; "Dry_Run"; "DRY-RUN"; "dry-run"; "" ]
+
+let test_of_string_unknown_defaults_dry_run () =
+  (* Operator omissions and typos must not silently disable measurement.
+     Unknown values fall through to Dry_run so the [would_reject] counter
+     keeps firing and we notice the misconfiguration. *)
+  List.iter
+    (fun raw ->
+      Alcotest.check mode_testable
+        (Printf.sprintf "%S -> Dry_run (unknown)" raw)
+        Auth_strict_mode.Dry_run
+        (Auth_strict_mode.of_string raw))
+    [ "yes"; "no"; "enabled"; "disabled"; "2"; "STRIKT" ]
+
+let test_to_label_canonical () =
+  Alcotest.(check string) "Off label" "off"
+    (Auth_strict_mode.to_label Auth_strict_mode.Off);
+  Alcotest.(check string) "Dry_run label" "dry_run"
+    (Auth_strict_mode.to_label Auth_strict_mode.Dry_run);
+  Alcotest.(check string) "Strict label" "strict"
+    (Auth_strict_mode.to_label Auth_strict_mode.Strict)
+
+let test_to_label_round_trips_through_of_string () =
+  List.iter
+    (fun mode ->
+      let label = Auth_strict_mode.to_label mode in
+      Alcotest.check mode_testable
+        (Printf.sprintf "round-trip via label %S" label)
+        mode
+        (Auth_strict_mode.of_string label))
+    [ Auth_strict_mode.Off; Auth_strict_mode.Dry_run; Auth_strict_mode.Strict ]
+
+let () =
+  Alcotest.run "auth_strict_mode"
+    [
+      ( "of_string",
+        [
+          Alcotest.test_case "Off canonical + aliases" `Quick
+            test_of_string_off;
+          Alcotest.test_case "Strict canonical + aliases" `Quick
+            test_of_string_strict;
+          Alcotest.test_case "Dry_run canonical + aliases" `Quick
+            test_of_string_dry_run;
+          Alcotest.test_case "unknown -> Dry_run" `Quick
+            test_of_string_unknown_defaults_dry_run;
+        ] );
+      ( "to_label",
+        [
+          Alcotest.test_case "canonical labels" `Quick test_to_label_canonical;
+          Alcotest.test_case "round-trip" `Quick
+            test_to_label_round_trips_through_of_string;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Phase A F2 of the keeper FSM bloodflow restoration plan. Adds a measurement
surface for the **936 [silent:auth_token_resolve_error] events/day**
(2026-04-26 production measurement) before Phase B PR-2 promotes them
to typed rejects.

**Behavior is unchanged.** This PR only adds telemetry + an env-flag
surface so the 48h soak can quantify which silent fall-throughs come
from legitimate internal callers (dashboards, etc.) vs. illegitimate
ones — and pre-fix any that need their token wiring repaired before
strict mode lands.

## Why telemetry-first instead of immediate strict reject

The plan calls for ``MASC_AUTH_STRICT=1`` strict reject, but a 936/day
fall-through volume hides legitimate internal callers under the
illegitimate ones. Promoting to strict without a soak would cut
dashboards / webhooks that depend on the silent fallback.

This PR splits the work:
- **F2 (this PR)**: dry-run telemetry, default behavior unchanged
- **Phase B PR-2** (later): actual typed reject through ``Auth_error``,
  flip default to ``Strict`` after the soak

## Changes

| File | Change |
|------|--------|
| ``lib/auth_strict_mode.{ml,mli}`` | New 3-state variant ``Off \| Dry_run \| Strict`` + env reader. Default = ``Dry_run``. Unknown values fall through to ``Dry_run`` (fail-open for telemetry). |
| ``lib/prometheus.{ml,mli}`` | New counter ``masc_auth_strict_would_reject_total`` with labels ``(mode, error_kind, agent)``. |
| ``lib/mcp_server_eio_execute.ml`` | At the existing silent fall-through (line ~318), emit ``[would_reject:auth_token_resolve_error]`` warn + counter alongside the existing ``[silent:auth_token_resolve_error]``. Keeps caller alias as before. |
| ``test/test_auth_strict_mode.ml`` | 6 unit tests: canonical labels, case-insensitivity, alias inputs (``0/1/true/false``), round-trip, and unknown-input fail-open. |

## Test plan

- [x] ``dune build @check --root .`` green
- [x] ``./_build/default/test/test_auth_strict_mode.exe`` → 6/6 pass (1ms)
- [ ] CI Build + Lint green on PR
- [ ] After merge: ``rg '\[would_reject:auth_token_resolve_error\]' ~/.masc/logs/*.jsonl`` shows volume by mode label

## Verification (post-merge, 48h soak)

Phase B PR-2 promotion gate: ``masc_auth_strict_would_reject_total{mode=\"dry_run\"}``
cardinality stable for 48h with no unexpected internal-caller spikes.
Operators can drill into ``agent`` label to identify any caller that
needs token wiring fixed before strict mode lands.

## Plan reference

``planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-sunny-starfish.md``
section 5, Phase A F2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)