### PR TITLE
chore(dashboard): replace rounded-[16px] with Tailwind rounded-2xl (3 sites)

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -759,7 +759,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               ` : null}
 
               ${isKeeper && (monitoringEvidence?.phase || monitoringEvidence?.stage) ? html`
-                <div class="rounded-[16px] border border-[var(--color-border-divider)] bg-[linear-gradient(180deg,var(--white-3),var(--white-1))] px-3 py-2.5">
+                <div class="rounded-2xl border border-[var(--color-border-divider)] bg-[linear-gradient(180deg,var(--white-3),var(--white-1))] px-3 py-2.5">
                   <div class="flex flex-wrap items-center gap-2">
                     ${monitoringEvidence?.phase && fsmPhaseKey
                       ? html`<${KeeperPhaseBadge} phase=${fsmPhaseKey} compact />`

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -343,7 +343,7 @@ export function KeeperConversationPanel({
         <div class="px-4 py-4">
           ${chatAccess.message
             ? html`
-                <div class="mb-4 rounded-[16px] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-loose text-[var(--warn-bright)]">
+                <div class="mb-4 rounded-2xl border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-loose text-[var(--warn-bright)]">
                   ${chatAccess.message}
                 </div>
               `
@@ -358,7 +358,7 @@ export function KeeperConversationPanel({
 
         ${!showInternal && hiddenCount > 0
           ? html`
-              <div class="mx-4 mb-4 rounded-[16px] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-paragraph text-[var(--warn-bright)]">
+              <div class="mx-4 mb-4 rounded-2xl border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-paragraph text-[var(--warn-bright)]">
                 ${hiddenCount}개의 내부 메시지가 숨겨져 있습니다. "내부 메시지 표시"로 볼 수 있습니다.
               </div>
             `


### PR DESCRIPTION
## Summary
Exact 1:1 deterministic mapping: \`16px = 1rem = rounded-2xl\` (Tailwind default).

## Sites
- \`keeper-shared.ts\`:346, 361
- \`agent-roster.ts\`:762

## Why deterministic only
Tailwind 기본 토큰에서 16px만 정확 매핑 가능. 다른 잔재 (28/20/26/10px)는 token 부재 → design-system token RFC 영역으로 분리.

## Verification
- [x] \`pnpm tsc --noEmit\`: clean
- [x] \`pnpm vitest run keeper-shared agent-roster\`: 72/72 pass
- [x] \`bash scripts/dashboard-drift-check.sh\`: gate OK (rounded-px-literal 12 → 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)