### PR TITLE
refactor(dashboard): Btn atom for BTN_PRIMARY row actions (Btn-sweep #3)

### DIFF
--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -221,9 +221,10 @@ async function submitResolve(
 
 // ── Row actions (approve/reject UI) ───────────────────
 
-const BTN_PRIMARY =
-  'rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-2xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
-
+// BTN_SECONDARY uses fg-primary (more emphasis) — the naming inverts
+// the convention but is preserved since it's a deliberate visual choice
+// for the cancel/reject actions in this panel. Btn default variant uses
+// fg-secondary, so this constant stays until a tone variant ships.
 const BTN_SECONDARY =
   'rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-2xs text-[var(--color-fg-primary)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
 
@@ -250,10 +251,10 @@ function RowActions({
     return html`
       <div class="flex items-center gap-1 flex-wrap">
         <span class="text-2xs text-[var(--color-fg-secondary)]">승인 확정?</span>
-        <button
-          class=${BTN_PRIMARY}
+        <${Btn}
+          size="sm"
           onClick=${() => void submitResolve(row, 'approve', '', refresh)}
-        >예</button>
+        >예<//>
         <button
           class=${BTN_SECONDARY}
           onClick=${() => setRowAction(requestId, { kind: 'idle' })}
@@ -286,11 +287,11 @@ function RowActions({
             }
           }}
         />
-        <button
-          class=${BTN_PRIMARY}
+        <${Btn}
+          size="sm"
           disabled=${!canSubmit}
           onClick=${() => void submitResolve(row, 'reject', reason.trim(), refresh)}
-        >확정</button>
+        >확정<//>
         <button
           class=${BTN_SECONDARY}
           onClick=${() => setRowAction(requestId, { kind: 'idle' })}
@@ -302,10 +303,10 @@ function RowActions({
   // idle or error — show primary action buttons; error surfaces retry hint
   return html`
     <div class="flex items-center gap-1 flex-wrap">
-      <button
-        class=${BTN_PRIMARY}
+      <${Btn}
+        size="sm"
         onClick=${() => setRowAction(requestId, { kind: 'confirm-approve' })}
-      >승인</button>
+      >승인<//>
       <button
         class=${BTN_SECONDARY}
         onClick=${() => setRowAction(requestId, { kind: 'compose-reject', reason: '' })}


### PR DESCRIPTION
## 목표

verification-requests-panel.ts의 row-action UI에서 \`BTN_PRIMARY\` 상수 사용 3 callsites를 Btn atom \`size=\"sm\"\` default variant로 교체. Btn-sweep #1 (#11236) / #2 (#11251)에 이은 sweep 시리즈 진행.

## 변경 요약

| 파일 | 변경 |
|---|---|
| \`dashboard/src/components/verification-requests-panel.ts\` | +13 / −12 (3 swap + BTN_PRIMARY 제거) |

### 3 callsites swapped

| line | label | trigger |
|---|---|---|
| 254 | 예 | submitResolve approve |
| 290 | 확정 | submitResolve reject (+ disabled when reason empty) |
| 306 | 승인 | open confirm-approve flow |

### BTN_SECONDARY 유지 사유

\`BTN_SECONDARY\` (3 callsites: 취소/취소/반려)는 본 PR에 포함하지 않습니다.

\`\`\`typescript
const BTN_SECONDARY =
  '… text-[var(--color-fg-primary)] …'  // PRIMARY와 색만 다름
\`\`\`

→ \`fg-primary\` (강조 색)는 의도된 시각 위계. Btn default variant는 \`fg-secondary\` 고정이므로 swap 시 색 변화 발생. tone variant 추가 또는 별도 의사결정 필요.

코드에 사유 주석 명시:
\`\`\`typescript
// BTN_SECONDARY uses fg-primary (more emphasis) — the naming inverts
// the convention but is preserved since it's a deliberate visual choice
// for the cancel/reject actions in this panel.
\`\`\`

## 시각 정합 검증

| 속성 | BTN_PRIMARY | Btn size=\"sm\" default | 결과 |
|---|---|---|---|
| color | fg-secondary | fg-secondary | ✅ exact |
| border | border-default | border-default | ✅ |
| border-radius | rounded (4px) | 3px | ≈ sub-perceptual |
| background | bg-page (filled) | transparent | 패널 elevated surface 위 contrast 유지 (sweep #1/#2와 동일 trade-off) |
| padding | px-2 py-1 | 0 8px | 폭 동일, 높이 SPEC sm 20px 고정 |
| font-size | text-2xs (10px) | 10px | ✅ exact |
| disabled | \`disabled:opacity-50\` + \`disabled:cursor-not-allowed\` | Btn 내부 처리 (opacity 0.5 + not-allowed) | ✅ semantic 동등 |
| hover bg | bg-hover | bg-elevated | semantic 동등, 토큰만 다름 |

## 검증

\`\`\`bash
cd dashboard
pnpm exec tsc --noEmit                            # clean
pnpm exec vitest run verification-requests        # 22/22 green
\`\`\`

## Atom adoption progress (Btn series)

| sweep | 파일 / 영역 | callsites | status |
|---|---|---|---|
| #1 | verification-specs-panel header | 1 | merged #11236 |
| #2 | verification-requests-panel header | 1 | merged #11251 |
| **#3 (본 PR)** | verification-requests-panel BTN_PRIMARY rows | 3 | this PR |
| #4 (deferred) | verification-requests-panel BTN_SECONDARY | 3 | tone variant 결정 후 |
| #5+ (deferred) | harness-health / runtime-monitor / feature-health | TBD | callsite 정찰 후 |

## 미검증

- 브라우저 시각 확인 (CI screenshot 또는 후속 review에서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)