### PR TITLE
refactor(dashboard): Btn atom for refresh-pattern buttons (Btn-sweep #4, 2 panels)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -42,6 +42,7 @@ import {
   type CascadeSloStatus,
   type CascadeValidationStatus,
 } from '../api/dashboard'
+import { Btn } from './btn'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
@@ -1164,22 +1165,18 @@ function CascadeRawConfigEditor({
             >
               ${saving.value ? '저장 중...' : mode.saveLabel}
             </button>
-            <button
-              type="button"
-              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50"
+            <${Btn}
               onClick=${handleReset}
               disabled=${saving.value || !editorDirty.value}
             >
               Reset to disk
-            </button>
-            <button
-              type="button"
-              class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--color-bg-hover)] disabled:opacity-50"
+            <//>
+            <${Btn}
               onClick=${() => void onRefresh()}
               disabled=${saving.value}
             >
               Reload snapshot
-            </button>
+            <//>
           </div>
         </form>
         ${mode.previewTitle
@@ -1230,12 +1227,9 @@ export function CascadeConfigPanel() {
   return html`
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
-        <button
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--color-bg-hover)]"
-          onClick=${() => void loadCascadeData(resource)}
-        >
+        <${Btn} onClick=${() => void loadCascadeData(resource)}>
           새로고침
-        </button>
+        <//>
         ${current.loading ? html`<span class="text-xs text-[var(--color-fg-muted)]" role="status">로딩 중...</span>` : null}
         ${config?.updated_at
           ? html`<span class="text-xs text-[var(--color-fg-muted)]">config · ${config.updated_at}</span>`

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -23,6 +23,7 @@ import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-
 import { formatTimeAgo } from '../lib/format-time'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { isAbortError } from '../lib/async-state'
+import { Btn } from './btn'
 import { OasHealthChip } from './oas-health-chip'
 import { CopyIdButton } from './common/copy-id-button'
 
@@ -915,12 +916,9 @@ export function TelemetryUnified() {
           <option value="200">200</option>
           <option value="500">500</option>
         </select>
-        <button
-          class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--color-bg-hover)]"
-          onClick=${() => void load()}
-        >
+        <${Btn} onClick=${() => void load()}>
           Refresh
-        </button>
+        <//>
         <span class="text-xs text-[var(--color-fg-muted)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
         ${loading ? html`<span class="text-xs text-[var(--color-fg-muted)]" role="status">로딩 중...</span>` : null}
       </div>


### PR DESCRIPTION
## 목표

Btn atom default variant와 byte-exact 정합인 4 callsites를 2개 패널에서 일괄 swap. Btn-sweep #1/#2/#3에 이은 sweep 시리즈 진행.

## 변경 요약

| 파일 | callsites |
|---|---|
| \`dashboard/src/components/telemetry-unified.ts\` | 1 (line 919: Refresh) |
| \`dashboard/src/components/cascade-config-panel.ts\` | 3 (line 1169 Reset to disk, 1177 Reload snapshot, 1234 새로고침) |

총 +10 / −18 (4 callsite swap + 2 import)

## 핵심 발견 (token-aliasing)

\`variables.css:6\`:
\`\`\`css
--color-fg-secondary: var(--text-strong);
\`\`\`

→ \`text-[var(--text-strong)]\` 와 \`text-[var(--color-fg-secondary)]\` 는 동일한 값 (\`#eaf1ff\`). Btn default variant가 fg-secondary를 사용하므로, 4 callsite 모두 **byte-exact color match**.

## 시각 정합 검증

| 속성 | 4 callsites | Btn default | 결과 |
|---|---|---|---|
| color | \`text-[var(--text-strong)]\` (#eaf1ff) | \`var(--color-fg-secondary)\` = \`var(--text-strong)\` (#eaf1ff) | ✅ exact |
| border | \`border-default\` | \`var(--color-border-default)\` | ✅ |
| border-radius | \`rounded\` (4px) | \`3px\` | ≈ sub-perceptual |
| background | \`bg-page\` (filled) | \`transparent\` | sweep #1/#2 동일 trade-off (panel surface 위 contrast 유지) |
| padding | \`px-3 py-1\` | \`0 10px\` (height 24px) | 폭 동일, 높이 SPEC default 24px 고정 |
| font-size | \`text-xs\` (12px) | \`11px\` | ≈ 1px 차이 |
| disabled (1169/1177) | \`disabled:opacity-50\` | Btn 내부 처리 (opacity 0.5 + cursor not-allowed) | ✅ semantic 동등 |

## 범위 외

- cascade-config-panel.ts:1162 의 SPEC primary submit 버튼 (\`bg-accent-fg\` 색): Btn primary variant는 \`accent-fg-dim\`로 다른 shade. 별도 cycle에서 처리
- 추가 raw \`<button>\` 자리 (harness-health, runtime-monitor 등): callsite별 시각 정합 사전 검증 후 다음 sweep PR로 분리

## 검증

\`\`\`bash
cd dashboard
pnpm exec tsc --noEmit
pnpm exec vitest run cascade-config-panel telemetry-unified runtime-panel fleet-health-panel
\`\`\`

결과:
- typecheck: clean
- 114/114 tests green (4 test files)

## Atom adoption progress (Btn series)

| sweep | 영역 | callsites | status |
|---|---|---|---|
| #1 | verification-specs-panel header | 1 | merged #11236 |
| #2 | verification-requests-panel header | 1 | merged #11251 |
| #3 | verification-requests-panel BTN_PRIMARY rows | 3 | open #11259 |
| **#4 (본 PR)** | telemetry-unified + cascade-config-panel | 4 | this PR |

## 미검증

- 브라우저 시각 확인 (CI screenshot 또는 후속 review에서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)