### PR TITLE
refactor(keeper): add keeper_turn_up_update.mli (PR#3 batch 4)

### DIFF
--- a/lib/keeper/keeper_turn_up_update.mli
+++ b/lib/keeper/keeper_turn_up_update.mli
@@ -1,0 +1,26 @@
+(** Keeper_turn_up_update — keeper reconfiguration handler.
+
+    Updates an existing keeper's meta record from the parsed args of
+    a [masc_keeper_up] tool call. Pairs with [Keeper_turn_up_create]
+    for the new-keeper path. *)
+
+(** Resolve the active goal-ids for an updated keeper: prefer the
+    explicit value from parsed args, fall back to profile defaults,
+    finally to the existing meta's value. Validates each goal id
+    exists in [Goal_store]; returns [Error] listing unknown ids. *)
+val resolve_active_goal_ids :
+  Coord.config ->
+  Keeper_turn_up_args.parsed_args ->
+  string list ->
+  (string list, string) result
+
+(** Update an existing keeper's meta record. Validates tool-access
+    transitions, resolves active goals, applies parsed-arg overrides,
+    persists the new meta, and broadcasts state-machine events.
+    Returns [(true, json)] on success or [(false, msg)] on validation
+    or persistence failure. *)
+val update_keeper :
+  _ Keeper_types.context ->
+  Keeper_turn_up_args.parsed_args ->
+  Keeper_types.keeper_meta ->
+  Keeper_types.tool_result


### PR DESCRIPTION
## Summary
\`keeper_turn_up_update\`에 .mli 추가. \`masc_keeper_up\` tool의 reconfigure 경로 인터페이스 노출.

| 노출 | 시그니처 |
|---|---|
| \`resolve_active_goal_ids\` | \`Coord.config -> parsed_args -> string list -> (string list, string) result\` |
| \`update_keeper\` | \`_ context -> parsed_args -> keeper_meta -> tool_result\` |

## Why
keeper_turn family에서 가장 작은 잔여 모듈(319줄, 2 toplevel let). 큰 형제들(turn_up_args 476줄/40 fields, turn_up_create 605줄)은 별도 cycle에 분리 — 한 PR 안에 묶지 않음으로써 squash race 위험을 낮추고 review 단위를 균질하게 유지.

## Ratchet impact
- \`keeper_mli_missing\` 37 → 36 (post-#11254 baseline 36)

## Test plan
- [x] \`dune build --root . lib\` exit 0 (첫 시도 통과)
- [ ] CI \`Build and Test\` green
- [ ] CI \`OCaml Structure Ratchet\` green

## Plan reference
\`planning/claude-plans/moonlit-finding-russell.md\` PR#3 — batch 4. 잔여 6/13 → 5/13.

## Follow-ups
- batch 5: keeper_turn_up_args (40 fields parsed_args + ~20 helpers, 별도 cycle)
- batch 6: keeper_turn_up_create
- batch 7: keeper_meta_contract / keeper_meta_store / keeper_meta_tool_access

🤖 Generated with [Claude Code](https://claude.com/claude-code)