### PR TITLE
chore(scripts): add host-ollama-tune.sh — automate KEEP_ALIVE + NUM_PARALLEL

### DIFF
--- a/scripts/host-ollama-tune.sh
+++ b/scripts/host-ollama-tune.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Apply ollama host-level tuning to keep keeper fleet from stalling on
+# 27B model cold-starts and concurrent-request queueing.
+#
+# This script encodes a recurring failure pattern documented across the
+# Vincent operator's memory entries:
+#   - feedback_ollama_keepalive_kv_cache_root_cause.md
+#   - "Ollama keepalive vs watchdog 5m race + KV cache" (cycle15, cycle17b)
+# Each cycle re-applied the same launchctl + restart sequence by hand;
+# this script makes the recovery one command.
+#
+# What it sets:
+#   OLLAMA_KEEP_ALIVE   -1     persistent model load (no 5-minute unload race)
+#   OLLAMA_NUM_PARALLEL 4      allow 4 concurrent inference requests instead
+#                              of serializing the keeper fleet through one
+#                              slot (the symptom in #10828 fleet-batch
+#                              termination logs: 11 keepers stalling on the
+#                              same turn because the lone 27B runner queued
+#                              all of them)
+#
+# What it does NOT do:
+#   - install ollama (assumed already present at /Applications/Ollama.app)
+#   - touch cascade.toml (provider weights are an operator decision; see
+#     ~/me/.masc/config/cascade.toml [keeper_unified] keep_alive setting)
+#   - persist across macOS reboots beyond launchctl scope (login-session
+#     env survives until reboot; for permanent set add to ~/.zshenv too)
+#
+# Usage:
+#   ./scripts/host-ollama-tune.sh             # show current vs target, no change
+#   ./scripts/host-ollama-tune.sh --apply     # apply launchctl env + restart ollama
+#   ./scripts/host-ollama-tune.sh --status    # print current launchctl values
+
+set -euo pipefail
+
+KEEP_ALIVE_TARGET="-1"
+NUM_PARALLEL_TARGET="4"
+
+usage() {
+  sed -n '1,32p' "$0"
+}
+
+show_current() {
+  local ka np
+  ka="$(launchctl getenv OLLAMA_KEEP_ALIVE 2>/dev/null || true)"
+  np="$(launchctl getenv OLLAMA_NUM_PARALLEL 2>/dev/null || true)"
+  printf 'OLLAMA_KEEP_ALIVE   current=%-6s target=%s\n' "${ka:-<unset>}" "$KEEP_ALIVE_TARGET"
+  printf 'OLLAMA_NUM_PARALLEL current=%-6s target=%s\n' "${np:-<unset>}" "$NUM_PARALLEL_TARGET"
+}
+
+apply() {
+  echo "Setting launchctl env (OLLAMA_KEEP_ALIVE=$KEEP_ALIVE_TARGET, OLLAMA_NUM_PARALLEL=$NUM_PARALLEL_TARGET)..."
+  launchctl setenv OLLAMA_KEEP_ALIVE "$KEEP_ALIVE_TARGET"
+  launchctl setenv OLLAMA_NUM_PARALLEL "$NUM_PARALLEL_TARGET"
+
+  if pgrep -x Ollama >/dev/null 2>&1; then
+    echo "Restarting Ollama.app to pick up new env..."
+    osascript -e 'tell application "Ollama" to quit' 2>/dev/null || killall Ollama 2>/dev/null || true
+    # Wait for clean exit before relaunching
+    for _ in 1 2 3 4 5; do
+      if ! pgrep -x Ollama >/dev/null 2>&1; then break; fi
+      sleep 1
+    done
+    open -a Ollama
+    echo "Ollama relaunched. New runner will inherit env from launchctl."
+  else
+    echo "Ollama not running; launching now."
+    open -a Ollama || echo "(Ollama.app not found at /Applications/Ollama.app — install or launch manually.)"
+  fi
+
+  echo ""
+  echo "After-state:"
+  show_current
+
+  echo ""
+  echo "Note: env is scoped to current login session. To persist across"
+  echo "macOS reboots, also add the following to ~/.zshenv:"
+  echo "  export OLLAMA_KEEP_ALIVE=$KEEP_ALIVE_TARGET"
+  echo "  export OLLAMA_NUM_PARALLEL=$NUM_PARALLEL_TARGET"
+}
+
+case "${1:-}" in
+  --apply) apply ;;
+  --status) show_current ;;
+  -h|--help) usage ;;
+  "")
+    echo "Current vs target (dry-run; pass --apply to change):"
+    show_current
+    ;;
+  *) echo "unknown arg: $1" >&2; usage >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

Operator memory 에 4-5 회 반복 기록된 ollama 운영 패턴을 1 명령 helper 로 인코딩.

## Direct symptom this targets

오늘 (2026-04-27 23:27 KST) fleet batch termination 으로 11 keeper 전부 \`stale watchdog terminating fiber (active turn hung 600s+)\` 발생. 진단 결과:

\`\`\`
$ launchctl getenv OLLAMA_KEEP_ALIVE
5m                                  ← target -1
$ launchctl getenv OLLAMA_NUM_PARALLEL
1                                   ← target 4
\`\`\`

\`NUM_PARALLEL=1\` 이라 ollama 가 모든 keeper 호출을 한 slot 에서 직렬 처리. \`local_with_kimi_coding_with_glm\` cascade 의 ollama weight 21% 가 11 keeper 에 fanout 되면 평균 2.3 keeper 가 동시에 ollama 로 라우팅 → queue saturation → \`wall_tok_s=0.6 latency_ms=571629\` (turn 당 ~570s). 600 s watchdog 안에 응답 받는 keeper 는 첫 1 명, 나머지는 cascade 형식으로 terminate.

## What this script does

\`\`\`bash
./scripts/host-ollama-tune.sh             # show current vs target
./scripts/host-ollama-tune.sh --status    # print launchctl values
./scripts/host-ollama-tune.sh --apply     # set launchctl env + restart Ollama.app
\`\`\`

| 환경변수 | 현재 | 목표 | 효과 |
|---------|------|------|------|
| \`OLLAMA_KEEP_ALIVE\` | \`5m\` | \`-1\` | model 영구 로드 (5m unload race 제거) |
| \`OLLAMA_NUM_PARALLEL\` | \`1\` | \`4\` | 동시 inference slot 4 — 11 keeper 분산 가능 |

## What this script does NOT do

- ollama 설치 (이미 \`/Applications/Ollama.app\` 가정)
- \`cascade.toml\` weight 변경 (provider routing 은 operator 결정 영역)
- macOS 재부팅 후 영구 적용 (\`launchctl setenv\` 는 login session scope — 재부팅 영구는 \`~/.zshenv\` export 필요. 스크립트 마지막 hint 출력)

## Memory references encoded

- \`feedback_ollama_keepalive_kv_cache_root_cause.md\`
- \"Ollama keepalive vs watchdog 5m race + KV cache (2026-04-27 cycle15)\"
- \"Cycle17b applied (2026-04-27 16:55 KST)\" cascade.toml \`[keeper_unified]\` 의 \`keep_alive = \"-1\"\` 설정 (cascade-level only — host env 미적용)

## Verification

\`\`\`
$ ./scripts/host-ollama-tune.sh
Current vs target (dry-run; pass --apply to change):
OLLAMA_KEEP_ALIVE   current=5m     target=-1
OLLAMA_NUM_PARALLEL current=1      target=4
\`\`\`

dry-run 동작 확인 완료. \`--apply\` 는 \`launchctl setenv\` + \`open -a Ollama\` 실행 — operator 가 host 에서 직접 실행 시점 결정.

## Related

- 메모리 \`feedback_ollama_keepalive_kv_cache_root_cause.md\`
- #10828 process-level supervisor 부재 — 본 script 는 부분 mitigation (operator 가 fleet 멈추면 1 명령 복구)
- 오늘 fleet batch termination 로그 (analyst, executor, issue_king, janitor, masc-improver, nick0cave, ollama-local, qa-king, ramarama, sangsu, velvet-hammer 11 keeper)