### PR TITLE
refactor(dashboard): Btn atom in config-resolution-panel refresh probe (Btn-sweep #5)

### DIFF
--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -11,6 +11,7 @@ import type {
   KeeperRuntimeField,
 } from '../../api/dashboard'
 import { fetchDashboardRuntimeProbe } from '../../api/dashboard'
+import { Btn } from '../btn'
 import { Card } from '../common/card'
 import { StatusChip } from '../common/status-chip'
 import { CopyIdButton } from '../common/copy-id-button'
@@ -401,12 +402,13 @@ function RuntimeProbePanel() {
               <${StatusChip} tone="neutral" uppercase=${false}>${state.value.data.cache_hit ? 'cached' : 'fresh'} · age ${fmtNumber(state.value.data.cache_age_sec, 1)}s<//>
             `
           : null}
-        <button
-          class="ml-auto rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-2xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
+        <${Btn}
+          size="sm"
+          class="ml-auto"
           onClick=${() => void load(true)}
         >
           ${state.value.loading ? 'probing...' : 'refresh probe'}
-        </button>
+        <//>
       </div>
 
       ${state.value.error


### PR DESCRIPTION
## 목표

\`config-resolution-panel.ts:404\` 의 "refresh probe" 버튼 1 callsite를 Btn atom \`size=\"sm\"\` default variant로 swap. Btn-sweep #1~#4에 이은 마지막 *byte-exact 색 정합* sweep — \`text-fg-secondary\` 색이 Btn default와 정확히 일치.

## 변경 요약

| 파일 | 변경 |
|---|---|
| \`dashboard/src/components/tools/config-resolution-panel.ts\` | +5 / −3 |

### Diff 요약

\`\`\`diff
+import { Btn } from '../btn'
 …
-<button
-  class="ml-auto rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-1 text-2xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
-  onClick=${() => void load(true)}
->
+<\${Btn} size=\"sm\" class=\"ml-auto\" onClick=\${() => void load(true)}>
   \${state.value.loading ? 'probing...' : 'refresh probe'}
-</button>
+<//>
\`\`\`

## 시각 정합 검증

| 속성 | Source | Btn size=\"sm\" default | 결과 |
|---|---|---|---|
| color | \`text-fg-secondary\` | \`var(--color-fg-secondary)\` | ✅ exact |
| border | \`border-default\` | \`border-default\` | ✅ |
| font-size | \`text-2xs\` (10px) | 10px | ✅ exact |
| background | \`bg-page\` (filled) | \`transparent\` | sweep 시리즈 동일 trade-off |
| border-radius | \`rounded\` (4px) | \`3px\` | ≈ sub-perceptual |
| padding | \`px-3 py-1\` | \`0 8px\` (height 20px) | 유사 |
| layout | \`ml-auto\` | Btn \`class\` prop으로 통과 | ✅ |

## 검증

\`\`\`bash
cd dashboard
pnpm exec tsc --noEmit                  # clean
pnpm exec vitest run config-resolution  # 17/17 green
\`\`\`

## Atom adoption progress (Btn series, this sweep wave)

| sweep | callsites | status |
|---|---|---|
| #1 | verification-specs-panel header (1) | merged #11236 |
| #2 | verification-requests-panel header (1) | merged #11251 |
| #3 | verification-requests-panel BTN_PRIMARY rows (3) | open #11259 |
| #4 | telemetry-unified + cascade-config-panel (4) | open #11261 |
| **#5 (본 PR)** | config-resolution-panel refresh probe (1) | this PR |

→ **이번 wave 총 10 callsites SSOT 통합 완료** (모두 Btn default 또는 sm variant, byte-exact 색 정합).

## 향후 sweep (별도 cycle, 본 wave 외)

- BTN_SECONDARY (verification-requests-panel, fg-primary) — Btn에 tone variant 추가 후
- keeper-config-panel \`btnBase\` (border-none + colored bg, 5 callsites) — Btn variant 시각 mismatch
- SPEC primary 후보 (\`bg-accent-fg\` + white text, ~3 callsites) — Btn primary는 \`accent-fg-dim\` 사용, shade 차이
- harness-health, runtime-monitor, feature-health 등 raw \`<button>\` (callsite 정찰 필요)

## 미검증

- 브라우저 시각 확인 (CI screenshot 또는 후속 review에서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)