### PR TITLE
refactor(keeper): token-aware gh-api classifier + keeper-prefix helper (Phase A F5)

### DIFF
--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -115,33 +115,42 @@ let canonical_keeper_name_from_agent_name agent_name =
       else
         None
 
-let canonical_keeper_name raw_name =
-  let trimmed = String.trim raw_name in
+(** Phase A F5 (2026-04-27): single source of truth for the
+    ["keeper-<name>"] prefix pattern.  Two call sites used to embed
+    [String.sub trimmed 0 7 = "keeper-"] manually; both now go through
+    this helper. *)
+let strip_keeper_prefix (s : string) : string option =
   let prefix = "keeper-" in
   let plen = String.length prefix in
-  let alen = String.length trimmed in
+  let slen = String.length s in
+  if slen > plen && String.sub s 0 plen = prefix then
+    Some (String.sub s plen (slen - plen))
+  else None
+
+let canonical_keeper_name raw_name =
+  let trimmed = String.trim raw_name in
   if trimmed = "" then None
   else if is_keeper_agent_alias trimmed then
     canonical_keeper_name_from_agent_name trimmed
-  else if alen > plen && String.sub trimmed 0 plen = prefix then
-    let candidate = String.sub trimmed plen (alen - plen) in
-    if Keeper_config.validate_name candidate then Some candidate else None
-  else if Keeper_config.validate_name trimmed then
-    Some trimmed
   else
-    canonical_keeper_name_from_agent_name trimmed
+    match strip_keeper_prefix trimmed with
+    | Some candidate when Keeper_config.validate_name candidate ->
+      Some candidate
+    | Some _ -> None
+    | None ->
+      if Keeper_config.validate_name trimmed then Some trimmed
+      else canonical_keeper_name_from_agent_name trimmed
 
 let explicit_keeper_name raw_name =
   let trimmed = String.trim raw_name in
-  let prefix = "keeper-" in
-  let plen = String.length prefix in
-  let alen = String.length trimmed in
   if trimmed = "" then None
-  else if alen > plen && String.sub trimmed 0 plen = prefix then
-    let candidate = String.sub trimmed plen (alen - plen) in
-    if Keeper_config.validate_name candidate then Some candidate else None
-  else if Keeper_config.validate_name trimmed then Some trimmed
-  else None
+  else
+    match strip_keeper_prefix trimmed with
+    | Some candidate when Keeper_config.validate_name candidate ->
+      Some candidate
+    | Some _ -> None
+    | None ->
+      if Keeper_config.validate_name trimmed then Some trimmed else None
 
 type name_bundle = {
   persona_name : string;

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -10,6 +10,13 @@ val keeper_name_from_agent_name : string -> string option
 val canonical_keeper_name_from_agent_name : string -> string option
 val canonical_keeper_name : string -> string option
 
+val strip_keeper_prefix : string -> string option
+(** [strip_keeper_prefix s] returns [Some suffix] if [s] starts with the
+    literal ["keeper-"] prefix and the suffix after the prefix is non-empty;
+    [None] otherwise.  Centralises the repeated [String.sub trimmed 0 7 =
+    "keeper-"] check so callers no longer embed the literal — Phase A F5
+    of the bloodflow restoration plan. *)
+
 type parsed_identity = {
   keeper_name : string;
   agent_name : string;

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -157,15 +157,28 @@ let gh_read_only_prefixes =
     - `-X`/`--method` specifies POST/PUT/PATCH/DELETE
     - `-f`/`-F`/`--field`/`--raw-field` is present (implies POST)
     - The subcommand is `graphql` (always POST)
-    The input [cmd_lower] must already be lowercased and trimmed. *)
+    The input [cmd_lower] must already be lowercased and trimmed.
+
+    Phase A F5 (2026-04-27): tokenize first, then match on the typed
+    structure.  Pre-fix used [String.is_prefix] which silently classified
+    [api2 ...] (a hypothetical sibling subcommand) as a gh-api call and
+    [graphqlx ...] as the graphql subcommand.  User hard rule: "no
+    string matching for classification". *)
 let is_gh_api_read_only (cmd_lower : string) : bool =
-  if not (Base.String.is_prefix cmd_lower ~prefix:"api") then false
-  else
-    let rest = String.trim (String.sub cmd_lower 3 (String.length cmd_lower - 3)) in
-    (* graphql subcommand is always POST *)
-    if Base.String.is_prefix rest ~prefix:"graphql" then false
+  let tokens =
+    cmd_lower
+    |> String.split_on_char ' '
+    |> List.filter (fun token -> token <> "")
+  in
+  match tokens with
+  | "api" :: rest_after_api ->
+    let is_graphql_subcommand =
+      match rest_after_api with
+      | "graphql" :: _ -> true
+      | _ -> false
+    in
+    if is_graphql_subcommand then false
     else
-      let tokens = String.split_on_char ' ' cmd_lower in
       let has_method_flag =
         let rec check = function
           | [] -> false
@@ -197,6 +210,7 @@ let is_gh_api_read_only (cmd_lower : string) : bool =
         ) tokens
       in
       not has_method_flag && not has_field_flag
+  | _ -> false
 
 (** Extract the effective gh command string from keeper_shell op=gh input.
     [keeper_exec_shell] uses the [cmd] field. *)

--- a/test/dune
+++ b/test/dune
@@ -201,7 +201,8 @@
         test_turn_id_propagation
         test_per_keeper_token_fallback
         test_auth_strict_mode
-        test_keeper_turn_fsm_emit)
+        test_keeper_turn_fsm_emit
+        test_gh_api_classification)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -373,6 +374,7 @@
           test_per_keeper_token_fallback
           test_auth_strict_mode
           test_keeper_turn_fsm_emit
+          test_gh_api_classification
           )
  (libraries masc_test_deps))
 

--- a/test/test_gh_api_classification.ml
+++ b/test/test_gh_api_classification.ml
@@ -1,0 +1,106 @@
+(** test_gh_api_classification — Phase A F5 token-aware [gh api]
+    classifier.
+
+    Pre-fix [is_gh_api_read_only] used [String.is_prefix cmd_lower
+    ~prefix:"api"] which silently classified [api2 ...] (a hypothetical
+    sibling subcommand) as a gh-api call and [graphqlx ...] as the
+    graphql subcommand.  This test pins the post-fix behaviour:
+    classification dispatches on tokenised structure, not literal
+    prefix slices. *)
+
+open Masc_mcp
+
+let r = Alcotest.(check bool)
+
+let test_basic_read_only () =
+  r "api repos/foo/bar = read-only" true
+    (Keeper_tool_registry.is_gh_api_read_only "api repos/foo/bar");
+  r "api user = read-only" true
+    (Keeper_tool_registry.is_gh_api_read_only "api user");
+  r "api repos/o/r/issues = read-only" true
+    (Keeper_tool_registry.is_gh_api_read_only "api repos/o/r/issues")
+
+let test_graphql_is_mutating () =
+  (* graphql is always POST, even without flags *)
+  r "api graphql = mutating" false
+    (Keeper_tool_registry.is_gh_api_read_only "api graphql");
+  r "api graphql -f query=... = mutating" false
+    (Keeper_tool_registry.is_gh_api_read_only "api graphql -f query=foo")
+
+let test_graphqlx_is_not_graphql () =
+  (* Pre-F5 [String.is_prefix "graphql"] ate this; post-F5 token match
+     treats it as an unknown path, so the api-classifier still runs and
+     it ends up read-only because no method/field flags are present. *)
+  r "api graphqlx/foo = read-only (NOT graphql subcommand)" true
+    (Keeper_tool_registry.is_gh_api_read_only "api graphqlx/foo")
+
+let test_method_flag_makes_mutating () =
+  r "api -X POST repos/o/r = mutating" false
+    (Keeper_tool_registry.is_gh_api_read_only "api -x post repos/o/r");
+  r "api -X=delete = mutating" false
+    (Keeper_tool_registry.is_gh_api_read_only "api -x=delete repos/o/r");
+  r "api --method=patch = mutating" false
+    (Keeper_tool_registry.is_gh_api_read_only "api --method=patch repos/o/r");
+  r "api -X GET = read-only (explicit GET)" true
+    (Keeper_tool_registry.is_gh_api_read_only "api -x get repos/o/r")
+
+let test_field_flag_makes_mutating () =
+  r "api -f field=value = mutating" false
+    (Keeper_tool_registry.is_gh_api_read_only "api -f title=foo repos/o/r/issues");
+  r "api --field key=v = mutating" false
+    (Keeper_tool_registry.is_gh_api_read_only "api --field x=1 repos/o/r")
+
+let test_non_api_is_not_classified () =
+  r "pr list is not gh api" false
+    (Keeper_tool_registry.is_gh_api_read_only "pr list");
+  r "issue view is not gh api" false
+    (Keeper_tool_registry.is_gh_api_read_only "issue view 123");
+  (* Pre-F5 [String.is_prefix "api"] would treat this as an api call;
+     post-F5 token match correctly rejects it. *)
+  r "api2 (hypothetical) is not gh api" false
+    (Keeper_tool_registry.is_gh_api_read_only "api2 foo")
+
+let test_strip_keeper_prefix_basic () =
+  Alcotest.(check (option string)) "extracts suffix" (Some "vincent")
+    (Keeper_identity.strip_keeper_prefix "keeper-vincent");
+  Alcotest.(check (option string)) "extracts hyphenated suffix"
+    (Some "analyst-001")
+    (Keeper_identity.strip_keeper_prefix "keeper-analyst-001")
+
+let test_strip_keeper_prefix_rejects () =
+  Alcotest.(check (option string)) "no prefix → None" None
+    (Keeper_identity.strip_keeper_prefix "vincent");
+  Alcotest.(check (option string)) "exact prefix only → None (empty suffix)"
+    None
+    (Keeper_identity.strip_keeper_prefix "keeper-");
+  Alcotest.(check (option string)) "empty input → None" None
+    (Keeper_identity.strip_keeper_prefix "");
+  Alcotest.(check (option string)) "wrong case → None (case-sensitive)" None
+    (Keeper_identity.strip_keeper_prefix "Keeper-vincent")
+
+let () =
+  Alcotest.run "gh_api_classification"
+    [
+      ( "is_gh_api_read_only",
+        [
+          Alcotest.test_case "basic read-only paths" `Quick
+            test_basic_read_only;
+          Alcotest.test_case "graphql is mutating" `Quick
+            test_graphql_is_mutating;
+          Alcotest.test_case "graphqlx token is NOT graphql" `Quick
+            test_graphqlx_is_not_graphql;
+          Alcotest.test_case "method flag → mutating" `Quick
+            test_method_flag_makes_mutating;
+          Alcotest.test_case "field flag → mutating" `Quick
+            test_field_flag_makes_mutating;
+          Alcotest.test_case "non-api command → false" `Quick
+            test_non_api_is_not_classified;
+        ] );
+      ( "strip_keeper_prefix",
+        [
+          Alcotest.test_case "extracts suffix" `Quick
+            test_strip_keeper_prefix_basic;
+          Alcotest.test_case "rejects non-matches" `Quick
+            test_strip_keeper_prefix_rejects;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Phase A F5 of the keeper FSM bloodflow restoration plan.  Removes two
literal-prefix slices in the keeper classification surface.

## Why

User hard rule: *"no string matching for classification — use variant /
enum / capability"*.  Two ``String.is_prefix`` / ``String.sub`` slices
classified by literal byte ranges instead of structured tokens, producing
silent misclassifications on any near-miss input.

## Changes

### (a) ``is_gh_api_read_only`` — token-aware

| Input | Before | After |
|---|---|---|
| ``api repos/o/r`` | read-only | read-only (same) |
| ``api graphql ...`` | mutating | mutating (same) |
| ``api2 foo`` | **read-only (BUG)** | not classified |
| ``api graphqlx/foo`` | **mutating (BUG — substring match on graphql)** | read-only |
| ``api -X POST ...`` | mutating | mutating (same) |
| ``api -f field=v`` | mutating | mutating (same) |

Post-fix dispatches on tokenised structure: ``"api" :: rest`` then
``"graphql" :: _`` for the always-POST subcommand.

### (b) ``Keeper_identity.strip_keeper_prefix``

New helper centralising the ``"keeper-<name>"`` pattern.  Two call
sites (``canonical_keeper_name`` + ``explicit_keeper_name``) used to
embed ``String.sub trimmed 0 7 = "keeper-"`` directly; both now go
through the helper.  Returns ``Some suffix`` only when the suffix is
non-empty.

## Test plan

- [x] ``dune build @check --root .`` green
- [x] ``./_build/default/test/test_gh_api_classification.exe`` → 8/8 pass
  - ``graphql`` subcommand → mutating
  - ``graphqlx`` token → NOT graphql (post-fix correctness)
  - ``api2`` hypothetical → not classified (post-fix correctness)
  - method / field flag detection unchanged
  - ``strip_keeper_prefix`` happy path + edge cases (``"keeper-"``,
    empty, wrong case)
- [ ] CI Build + Lint green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)