### PR TITLE
feat(keeper): wire FSM transition emit at all 4 pre-dispatch silent-skip sites (Step 4b)

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -84,3 +84,13 @@ let pp_failure_reason fmt = function
 
 let pp_turn_state fmt s =
   Format.pp_print_string fmt (turn_state_label s)
+
+let emit_transition ~keeper_name ~turn_id ?prev state =
+  let prev_label =
+    match prev with
+    | Some s -> turn_state_label s
+    | None -> "-"
+  in
+  let state_label = turn_state_label state in
+  Log.Keeper.info ~keeper_name ~turn_id
+    "[fsm:transition] %s -> %s" prev_label state_label

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -58,3 +58,24 @@ val turn_state_label : turn_state -> string
 val pp_cancel_reason : Format.formatter -> cancel_reason -> unit
 val pp_failure_reason : Format.formatter -> failure_reason -> unit
 val pp_turn_state : Format.formatter -> turn_state -> unit
+
+val emit_transition :
+  keeper_name:string ->
+  turn_id:int ->
+  ?prev:turn_state ->
+  turn_state ->
+  unit
+(** Emit a structured FSM transition log line.
+
+    Step 4b kicks off the call-site adoption stack: this is an
+    observe-only secondary emit alongside the existing receipt
+    path.  The runtime branch shape is unchanged; the line
+    surfaces in [bin/masc-trace] via the [turn_id] correlator
+    wired in Step 0a (#11154 / #11156 / #11159) so an operator
+    can see the state the runtime *intended* without parsing
+    the receipt JSON.
+
+    The line format is [\[fsm:transition\] <prev> -> <state>];
+    a missing [?prev] renders as ["-"].  Stable for operator
+    regex parsing and pinned by the [test_keeper_turn_fsm_emit]
+    sentinel so a future signature drift fails the build. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1188,6 +1188,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 ~trajectory_outcome:(Trajectory.Gated "ollama_saturated")
                 ~keeper_turn_id
                 ();
+              Keeper_turn_fsm.emit_transition
+                ~keeper_name:meta.name ~turn_id:keeper_turn_id
+                ~prev:Keeper_turn_fsm.Cascade_routing
+                (Keeper_turn_fsm.Failed
+                   (Keeper_turn_fsm.Failure_cascade_unavailable
+                      { base = base_url; resolved = None }));
               Prometheus.inc_counter
                 Prometheus.metric_keeper_ollama_saturation_skip
                 ~labels:[ ("keeper", meta.name);
@@ -1271,6 +1277,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~error_message
             ~keeper_turn_id
             ();
+          Keeper_turn_fsm.emit_transition
+            ~keeper_name:meta.name ~turn_id:keeper_turn_id
+            ~prev:Keeper_turn_fsm.Cascade_routing
+            (Keeper_turn_fsm.Failed
+               (Keeper_turn_fsm.Failure_runtime_error error_message));
           Error err
       | Ok initial_execution ->
       let turn_id = meta.runtime.usage.total_turns in
@@ -1305,6 +1316,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
              ~keeper_turn_id
              ();
+           Keeper_turn_fsm.emit_transition
+             ~keeper_name:meta.name ~turn_id:keeper_turn_id
+             ~prev:Keeper_turn_fsm.Cascade_routing
+             (Keeper_turn_fsm.Failed
+                (Keeper_turn_fsm.Failure_runtime_error
+                   ("turn_livelock:" ^ reason_string)));
            Ok meta
        | Keeper_turn_livelock.Started _ ->
       (* Yield before CPU-bound prompt construction so the Eio scheduler

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1079,6 +1079,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
         ~keeper_turn_id
         ();
+      Keeper_turn_fsm.emit_transition
+        ~keeper_name:meta.name ~turn_id:keeper_turn_id
+        ~prev:Keeper_turn_fsm.Phase_gating
+        (Keeper_turn_fsm.Cancelled
+           Keeper_turn_fsm.Cancelled_phase_gate_close);
       Ok meta
   | phase_opt ->
       (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade).

--- a/test/dune
+++ b/test/dune
@@ -200,7 +200,8 @@
         test_cascade_strategy_labels
         test_turn_id_propagation
         test_per_keeper_token_fallback
-        test_auth_strict_mode)
+        test_auth_strict_mode
+        test_keeper_turn_fsm_emit)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -371,6 +372,7 @@
           test_turn_id_propagation
           test_per_keeper_token_fallback
           test_auth_strict_mode
+          test_keeper_turn_fsm_emit
           )
  (libraries masc_test_deps))
 

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -1,0 +1,121 @@
+(** test_keeper_turn_fsm_emit — Step 4b sentinel.
+
+    Pins the [Keeper_turn_fsm.emit_transition] surface so a future
+    refactor that drops [?prev] or renames a cancel/failure
+    variant fails compilation here, not at runtime.
+
+    The function emits via [Log.Keeper.info] which is fail-open;
+    we don't assert on the log ring contents (that would couple
+    the test to log buffer internals).  What we *do* pin:
+    - the function exists with the documented labels
+    - every cancel_reason and failure_reason variant is reachable
+      via the public [turn_state_label] surface so that
+      [bin/masc-trace] grouping does not silently lose a state
+*)
+
+open Masc_mcp
+module F = Keeper_turn_fsm
+
+(* ── Compile-time signature anchor ─────────────────────────── *)
+
+let test_emit_transition_signature_stable () =
+  (* Pass concrete values so a signature drift (e.g. removing
+     [?prev], or moving [keeper_name] off labelled args) fails
+     to type-check. *)
+  F.emit_transition ~keeper_name:"alice" ~turn_id:42
+    ~prev:F.Phase_gating
+    (F.Cancelled F.Cancelled_phase_gate_close);
+  F.emit_transition ~keeper_name:"bob" ~turn_id:0
+    (F.Failed (F.Failure_runtime_error "noop"));
+  F.emit_transition ~keeper_name:"carol" ~turn_id:1
+    F.Idle;
+  Alcotest.(check bool)
+    "emit_transition accepts ?prev / labelled args / int turn_id"
+    true true
+
+(* ── Label coverage ────────────────────────────────────────── *)
+
+let test_turn_state_labels_cover_every_variant () =
+  let pairs : (F.turn_state * string) list =
+    [
+      (F.Idle, "idle");
+      (F.Phase_gating, "phase_gating");
+      (F.Cascade_routing, "cascade_routing");
+      (F.Awaiting_provider, "awaiting_provider");
+      (F.Streaming, "streaming");
+      (F.Awaiting_tool_result, "awaiting_tool_result");
+      (F.Completing, "completing");
+      (F.Done, "done");
+      ( F.Failed (F.Failure_runtime_error "x"),
+        "failed:runtime_error" );
+      ( F.Cancelled F.Cancelled_phase_gate_close,
+        "cancelled:phase_gate_close" );
+    ]
+  in
+  List.iter
+    (fun (s, expected) ->
+      Alcotest.(check string)
+        ("turn_state_label " ^ expected)
+        expected (F.turn_state_label s))
+    pairs
+
+let test_cancel_reason_labels_documented () =
+  let pairs : (F.cancel_reason * string) list =
+    [
+      (F.Cancelled_supervisor_stop, "supervisor_stop");
+      (F.Cancelled_phase_gate_close, "phase_gate_close");
+      (F.Cancelled_provider_timeout, "provider_timeout");
+      (F.Cancelled_fleet_shutdown, "fleet_shutdown");
+    ]
+  in
+  List.iter
+    (fun (r, expected) ->
+      Alcotest.(check string)
+        ("cancel_reason " ^ expected)
+        expected (F.cancel_reason_label r))
+    pairs
+
+let test_failure_reason_labels_documented () =
+  let pairs : (F.failure_reason * string) list =
+    [
+      ( F.Failure_cascade_unavailable
+          { base = "ollama:7b"; resolved = None },
+        "cascade_unavailable" );
+      ( F.Failure_provider_error { kind = "k"; detail = "d" },
+        "provider_error" );
+      ( F.Failure_tool_contract_violation { reason_code = "rc" },
+        "tool_contract_violation" );
+      ( F.Failure_receipt_lost
+          { primary_error = "e"; fallback_path = None },
+        "receipt_lost" );
+      (F.Failure_runtime_error "msg", "runtime_error");
+      ( F.Failure_unexpected_exception
+          { exn = "Boom"; backtrace = None },
+        "unexpected_exception" );
+    ]
+  in
+  List.iter
+    (fun (r, expected) ->
+      Alcotest.(check string)
+        ("failure_reason " ^ expected)
+        expected (F.failure_reason_label r))
+    pairs
+
+let () =
+  Alcotest.run "keeper_turn_fsm_emit"
+    [
+      ( "signature_anchor",
+        [
+          Alcotest.test_case "emit_transition surface stable"
+            `Quick test_emit_transition_signature_stable;
+        ] );
+      ( "labels",
+        [
+          Alcotest.test_case "turn_state covers every variant"
+            `Quick test_turn_state_labels_cover_every_variant;
+          Alcotest.test_case "cancel_reason labels match docs"
+            `Quick test_cancel_reason_labels_documented;
+          Alcotest.test_case "failure_reason labels match docs"
+            `Quick test_failure_reason_labels_documented;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Step 4b of the bloodflow restoration plan: starts call-site adoption of the FSM ADT introduced in Step 4a (#11184). Every pre-dispatch silent-skip path in `run_keeper_cycle` now emits a typed FSM transition alongside the existing receipt path. Branch shape unchanged at every site.

## Site map

| Site                  | line | prev            | turn_state                                                    |
|-----------------------|------|-----------------|---------------------------------------------------------------|
| phase-gate skip       | 1082 | Phase_gating    | Cancelled Cancelled_phase_gate_close                          |
| ollama saturated skip | 1190 | Cascade_routing | Failed (Failure_cascade_unavailable {base; resolved=None})    |
| cascade build error   | 1273 | Cascade_routing | Failed (Failure_runtime_error error_message)                  |
| turn_livelock blocked | 1307 | Cascade_routing | Failed (Failure_runtime_error ("turn_livelock:" ^ reason))    |

## Why this shape

- New `Keeper_turn_fsm.emit_transition ~keeper_name ~turn_id ?prev state -> unit` emits `[fsm:transition] <prev> -> <state>` via `Log.Keeper.info`. Stable line format for regex parsing and `bin/masc-trace`.
- Every site already has `keeper_turn_id` from Step 0a (#11154) and a receipt write; the FSM emit lands right after the receipt so the two stay aligned.
- Variant choices:
  - `phase_gate_close` cancel reason was named for exactly this scenario.
  - `Failure_cascade_unavailable` matches the ollama-saturation story (cascade resolved to one provider that's at capacity).
  - `Failure_runtime_error` is the documented catch-all for operational failures that don't fit the typed cascade/provider/contract buckets (cascade build error, livelock guard).

## Tests

`test/test_keeper_turn_fsm_emit.ml` (new) pins:
- `emit_transition` signature (labelled args, `?prev`, `int` `turn_id`)
- Every `turn_state` variant label
- Every `cancel_reason` and `failure_reason` label

A future variant rename or signature drift fails the build here, not silently in production.

## Behavior change

One additional `Log.Keeper.info` line per silent-skipped turn. No control-flow change at any site. `Log` is fail-open so an unexpected emission failure cannot block the turn.

## Test plan

- [x] `dune build` default + release green locally
- [x] `test_keeper_turn_fsm_emit` 4/4 OK locally
- [ ] CI lint + meta-guards green
- [ ] Post-merge manual smoke (one example per site):
  - `\[fsm:transition\] phase_gating -> cancelled:phase_gate_close`
  - `\[fsm:transition\] cascade_routing -> failed:cascade_unavailable`
  - `\[fsm:transition\] cascade_routing -> failed:runtime_error`

## Plan ref

`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md` — Phase 6 caller-adoption stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)