### PR TITLE
refactor(keeper): add 3 keeper .mli (PR#3 batch 6)

### DIFF
--- a/lib/keeper/keeper_cdal_contract.mli
+++ b/lib/keeper/keeper_cdal_contract.mli
@@ -1,0 +1,6 @@
+(* Team session contract system removed (#6107). *)
+
+(** Risk-contract projection of a [keeper_meta]. Always returns
+    [None] since the team-session contract system was removed. *)
+val of_keeper_meta :
+  Keeper_types.keeper_meta -> Oas.Risk_contract.t option

--- a/lib/keeper/keeper_shell_bg_task.mli
+++ b/lib/keeper/keeper_shell_bg_task.mli
@@ -1,0 +1,30 @@
+(** Background task lifecycle management for keeper shell.
+
+    Extracted from keeper_exec_shell.ml — poll and kill operations
+    for background bash tasks spawned by handle_keeper_bash. *)
+
+(** Encode a [Unix.process_status option] (None = still running) as
+    JSON via [Keeper_alerting_path.process_status_to_json]. *)
+val status_to_json_opt : Unix.process_status option -> Yojson.Safe.t
+
+(** Map the [signal] arg ("TERM", "KILL", numeric, etc.) to a Unix
+    signal int. Default [Sys.sigterm] for missing/unknown values. *)
+val signal_of_name_or_num : Yojson.Safe.t -> int
+
+(** [masc_keeper_bash_output] handler: poll a background bash task
+    started by [handle_keeper_bash], returning new stdout/stderr
+    bytes since [since_stdout]/[since_stderr], the closed flag, and
+    optional exec-semantic hint. Returns a JSON-encoded string. *)
+val handle_keeper_bash_output :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string
+
+(** [masc_keeper_bash_kill] handler: terminate a background bash task
+    with the given signal and grace seconds (clamped to 0..30). *)
+val handle_keeper_bash_kill :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string

--- a/lib/keeper/keeper_tool_guidance.mli
+++ b/lib/keeper/keeper_tool_guidance.mli
@@ -1,0 +1,47 @@
+(** Policy-derived keeper tool guidance.
+
+    Prompts must not advertise tools outside the active keeper
+    policy. The model already receives the real schema set from OAS;
+    this module renders short human-readable hints by filtering
+    curated affordances through that same allowed-name set. *)
+
+type hint =
+  { name : string
+  ; call : string
+  ; description : string
+  }
+
+(** Curated affordance hints (name + call template + description) for
+    every keeper-preferred tool. Filtered at render time by the
+    keeper's active tool-name allowlist. *)
+val hints : hint list
+
+(** Build a hashtable lookup of allowed tool names. Used internally
+    by [allowed_hints] but exposed for callers that want to reuse the
+    same allowed set. *)
+val allowed_lookup : string list -> (string, unit) Hashtbl.t
+
+(** Filter [hints] down to those whose [name] is in
+    [allowed_tool_names]. *)
+val allowed_hints : allowed_tool_names:string list -> hint list
+
+(** Render a single [hint] as a bullet line for prompt embedding. *)
+val line_of_hint : hint -> string
+
+(** Render a "Preferred keeper tools" prompt section, falling back to
+    a runtime-only schema notice when no hints match. *)
+val render_preferred_tools :
+  allowed_tool_names:string list -> string
+
+(** Membership test on the allowed-tool-names list. *)
+val has : string list -> string -> bool
+
+(** Render an optional GitHub/code workflow guidance paragraph,
+    chosen by which keeper tools are present in the allowlist. *)
+val render_gh_workflow :
+  allowed_tool_names:string list -> string option
+
+(** Render the unknown-tool guard paragraph (always-on, no policy
+    dependency). Reminds the model not to call masc_*/lifecycle tools
+    that aren't in its runtime schema. *)
+val render_unknown_tool_guard : unit -> string


### PR DESCRIPTION
## Summary
keeper 영역에서 .mli 누락된 작은 모듈 3개 처리. PR#3 영역 mix-in.

| 모듈 | 노출 | 비고 |
|---|---|---|
| \`keeper_cdal_contract\`  | 1 fn | #6107 이후 vestigial — \`of_keeper_meta = None\` |
| \`keeper_shell_bg_task\`  | 4 fns | masc_keeper_bash_output/kill 핸들러 (background task poll/kill) |
| \`keeper_tool_guidance\`  | type hint + 8 fns | policy-filtered tool guidance prompt rendering |

## Why
가장 작은 잔여 모듈부터 처리해서 ratchet 단조감소 36→33. 큰 모듈(keeper_meta_contract 375, keeper_meta_store 395, keeper_turn_up_args 476, keeper_turn_up_create 605)은 별도 cycle에 따로 분리. cycle 단위 일관 유지.

## Ratchet impact
- \`keeper_mli_missing\` 36 → 33 (-3)
- baseline 37(post-#11253 lock-in) 대비 단조감소 4개 누적

## Test plan
- [x] \`dune build --root . lib\` exit 0 (한 번에 통과)
- [ ] CI \`Build and Test\` green
- [ ] CI \`OCaml Structure Ratchet\` green

## Plan reference
\`planning/claude-plans/moonlit-finding-russell.md\` PR#3 — batch 6.

## Follow-ups
- batch 7: keeper_meta_contract (375, ADTs + 11 types)
- batch 8: keeper_meta_store (395, 26 fns)
- batch 9: keeper_turn_up_args / create (큰 모듈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)