### PR TITLE
chore(ratchet): re-baseline after legitimate lib growth (#11257)

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,8 +1,8 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 37,
+  "keeper_mli_missing": 35,
   "coord_mli_missing": 3,
   "godsplit_count": 0,
-  "lib_dune_lines": 951
+  "lib_dune_lines": 952
 }


### PR DESCRIPTION
## Summary
PR #11257 (auth_strict_mode 모듈 추가)로 \`lib_dune_lines\`가 951 → 952가 되어 ratchet 강제 단조감소 검증이 fail. 정당한 lib growth(새 모듈)이라 baseline을 따라잡아야 함.

| metric | 이전 | 현재 |
|---|---|---|
| keeper_mli_missing | 37 | **35** (-2 from #11262 mli landings) |
| godsplit_count | 0 | 0 (locked) |
| lib_dune_lines | 951 | **952** (+1 legitimate from auth_strict_mode) |
| coord_mli_missing | 3 | 3 |

## Why
\`lib_dune_lines\`는 monolithic library 비대화 proxy로 박혔지만, 새 모듈 추가는 정당한 lib growth — strict 단조감소만 강제하면 lib growth가 막힘. baseline을 forward update해서 \"silent rebound\"가 아닌 \"의도적 갱신\"임을 commit message로 lock-in.

사용자 메모리 \`ratchet-naturalization-after-admin-merge\` 사고 회피: admin override 없이 explicit commit으로 baseline 변경, follow-up issue로 metric 정책 재검토(monitor vs ratchet) 명시.

## Open follow-up
\`lib_dune_lines\`를 strict ratchet에서 monitor-only로 강등할지 검토 — sub-library 분해(PR#7-10)가 진행되면 962 → ~600 범위로 큰 감소 예상, 그러나 새 모듈 추가는 정당한 growth라 strict gate가 noise. 다른 metric(mli, godsplit)은 strict 유지.

## Test plan
- [x] \`scripts/ocaml-structure-ratchet.sh --print\` — 모든 metric current = baseline
- [ ] CI \`OCaml Structure Ratchet\` green
- [ ] 후속 PR(#11268, #11270)이 base rebase 후 ratchet 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)