### PR TITLE
feat(keeper): observe empty-tool-universe blocker volume (Phase A F3)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1235,6 +1235,21 @@ let run_turn
             && initial_tool_surface.all_allowed = []
     then (
       receipt_tool_contract_result_ref := "no_tool_capable_provider";
+      (* Phase A F3 (2026-04-28): surface the empty-tool-universe
+         blocker volume so operators can attribute the silent
+         "tools_used_count=0" pattern (janitor / verifier connect
+         turns ≤ 5) before Phase B PR-4 promotes this to a typed
+         terminal state with LLM-visible feedback. Behavior is
+         unchanged: the blocker is still set below. *)
+      Prometheus.inc_counter
+        Prometheus.metric_empty_tool_universe_observed
+        ~labels:
+          [ ("keeper_name", meta.name);
+            ("turn_lane", initial_tool_surface.lane);
+            ( "fallback_used",
+              string_of_bool initial_tool_surface.tool_surface_fallback_used );
+          ]
+        ();
       initial_tool_surface_blocker_ref :=
         Some
           (sdk_error_of_keeper_internal_error

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -710,6 +710,9 @@ let metric_silent_dashboard_actor_fallback =
 let metric_auth_strict_would_reject =
   "masc_auth_strict_would_reject_total"
 
+let metric_empty_tool_universe_observed =
+  "masc_empty_tool_universe_observed_total"
+
 (** Counter for Coord.join preflight outcomes (RFC P3-a, logging-only mode).
    Labels: outcome (ok | empty_input | persona_not_found | credential_missing
    | name_ambiguous | ephemeral_suffix_rejected). Cross-reference with
@@ -1102,6 +1105,16 @@ let init () =
      measure how many of those would-be-rejections happen under each \
      MASC_AUTH_STRICT mode before Phase B PR-2 promotes Strict to a typed \
      reject. Labels: mode (off | dry_run | strict), error_kind, agent."
+    Counter;
+  add metric_empty_tool_universe_observed
+    "Phase A F3 (2026-04-28): increments every time the keeper turn enters \
+     the [Keeper_tool_surface_empty] blocker branch in keeper_agent_run \
+     (i.e. tool_gate_requested && all_allowed = []). Pre-fix the blocker \
+     fired silently with no operator-visible counter; this surfaces the \
+     volume so Phase B PR-4 can promote it to a typed terminal state with \
+     LLM-visible feedback. Labels: keeper_name, turn_lane (text_only \
+     | tool_optional | tool_required | retry | tool_disabled), \
+     fallback_used (true | false)."
     Counter;
   add metric_coord_join_normalize_outcome
     "Total Coord.join calls preflighted by Keeper_identity.normalize_all_names \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -363,6 +363,18 @@ val metric_auth_strict_would_reject : string
     [error_kind] = same kinds as silent_auth,
     [agent] = the alias the request would have kept. *)
 
+val metric_empty_tool_universe_observed : string
+(** Phase A F3 (2026-04-28): increments every time
+    [keeper_agent_run] enters the [Keeper_tool_surface_empty] blocker
+    branch — tool gate is required but the visible tool surface is
+    empty.  Phase B PR-4 will promote this from "blocker emit" to a
+    typed terminal state with LLM-visible feedback; this counter is
+    the soak-window measurement that motivates the promotion.  Labels:
+    [keeper_name],
+    [turn_lane] = "text_only" | "tool_optional" | "tool_required"
+                | "retry" | "tool_disabled",
+    [fallback_used] = "true" | "false". *)
+
 val metric_coord_join_normalize_outcome : string
 (** RFC P3-a (2026-04-26): Coord.join preflighted by
     [Keeper_identity.normalize_all_names] in logging-only mode.


### PR DESCRIPTION
## Summary

Phase A F3 of the keeper FSM bloodflow restoration plan.  Telemetry
only — surfaces the volume of the existing
``Keeper_tool_surface_empty`` blocker so Phase B PR-4 can promote it
to a typed terminal state with LLM-visible feedback.

## Why

Production reality (24h baseline, 2026-04-26):

- Janitor / verifier keepers exhibit ``tools_used_count=0`` streaks of
  14+ turns
- ``goal_alignment`` median 0.02 in those windows

The plan's hypothesis: a fraction of these turns enter
``keeper_agent_run.ml:~1234`` where ``tool_gate_requested &&
all_allowed = []`` triggers ``Keeper_tool_surface_empty``, but the
blocker fires silently — there is no operator-visible counter to
attribute the silent text-only output to this branch.

This PR adds the counter so the soak window can prove (or falsify)
the hypothesis before Phase B PR-4 touches the LLM-call path.

## Behavior change

None.  Pure telemetry addition.

| Path | Before | After |
|---|---|---|
| ``tool_gate_requested && all_allowed = []`` | blocker set, receipt records ``no_tool_capable_provider`` | counter increments, then same blocker behavior |
| any other path | unchanged | unchanged |

## Files

- ``lib/prometheus.{ml,mli}`` — register
  ``masc_empty_tool_universe_observed_total`` with labels
  ``(keeper_name, turn_lane, fallback_used)``
- ``lib/keeper/keeper_agent_run.ml`` — emit counter inside the
  existing blocker branch

## Test plan

- [x] ``dune build @check --root .`` green
- [ ] CI Build + Lint green on PR
- [ ] After 48h soak: ``masc_empty_tool_universe_observed_total{turn_lane=\"tool_required\"}``
  rate per keeper.  Expected: janitor / verifier dominate the
  cardinality.

## Phase B follow-up

Phase B PR-4 will use this metric's soak data to:
1. Promote the blocker to a typed terminal state (``Tool_universe.t``
   variant ``Empty of {reason}``)
2. Write LLM-visible feedback via ``keeper_chat_store`` so the next
   turn knows why the previous one was tool-skipped
3. Decide whether ``tool_gate_requested = false`` empty-surface cases
   also deserve the same terminal handling (currently silent)

## Plan reference

``planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-sunny-starfish.md``
section 5, Phase A F3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)