### PR TITLE
feat(dashboard): adopt ringFocusClasses() helper in 11 callsites (Bucket A)

### DIFF
--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -7,6 +7,7 @@ import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { Markdown } from './common/markdown'
 import { TextInput } from './common/input'
+import { ringFocusClasses } from './common/ring'
 import {
   agentTimeline,
   selectedAgent,
@@ -215,7 +216,7 @@ function BroadcastReport({ report, index }: { report: { ts: string; content: str
     <div class="border border-card-border/60 rounded bg-card/30 overflow-hidden hover:border-accent/20 transition-colors">
       <button
         type="button"
-        class="w-full flex items-center justify-between px-4 py-2.5 bg-[var(--white-3)] border-b border-card-border/40 cursor-pointer select-none text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+        class=${`w-full flex items-center justify-between px-4 py-2.5 bg-[var(--white-3)] border-b border-card-border/40 cursor-pointer select-none text-left ${ringFocusClasses()}`}
         onClick=${() => setExpanded(!expanded)}
         aria-expanded=${expanded}
       >

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -15,6 +15,7 @@ import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { FilterChips } from '../common/filter-chips'
 import { StatusBadge } from '../common/status-badge'
+import { ringFocusClasses } from '../common/ring'
 import { TimeAgo } from '../common/time-ago'
 import { TaskCreateForm } from '../task-manage/task-create-form'
 import { Tk } from '../tk'
@@ -450,7 +451,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
     <div class="flex flex-col" style="margin-left:${indent}px">
       <button
         type="button"
-        class="${headerBase} ${hasContent ? 'cursor-pointer' : ''} focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+        class="${headerBase} ${hasContent ? 'cursor-pointer' : ''} ${ringFocusClasses()}"
         onClick=${() => {
           selectGoal(node.id)
           if (hasContent) toggleNode(node.id)

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -29,6 +29,7 @@ import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { fetchTelemetry, type TelemetryEntry } from '../api/dashboard'
 import { useSavedSignal } from '../lib/saved-signal'
+import { ringFocusClasses } from './common/ring'
 
 type A2aEventKind = 'lifecycle' | 'failure' | 'tool' | 'handoff' | 'context' | 'unknown'
 
@@ -356,7 +357,7 @@ export function HandoffTimeline({
                   const rowLabelCls =
                     `w-32 shrink-0 truncate text-2xs font-mono rounded px-1 text-left ${labelCls}` +
                     (clickable
-                      ? ' cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent'
+                      ? ` cursor-pointer ${ringFocusClasses()}`
                       : '')
                   return html`
                   <div class="flex items-center gap-3">

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -14,6 +14,7 @@ import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { parseToolBlobMarker } from '../lib/tool-blob-marker'
 import { CopyIdButton } from './common/copy-id-button'
 import { TextInput } from './common/input'
+import { ringFocusClasses } from './common/ring'
 
 // Delegated to lib/format-time (SSOT)
 const formatTimestamp = formatTimeHms
@@ -140,7 +141,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
     >
       <button
         type="button"
-        class="w-full flex items-center gap-2 px-3 py-2 text-xs cursor-pointer text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+        class=${`w-full flex items-center gap-2 px-3 py-2 text-xs cursor-pointer text-left ${ringFocusClasses()}`}
         aria-expanded=${expanded.value}
         onClick=${() => { expanded.value = !expanded.value }}
       >

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { focusAgents } from '../../live-store'
 import { openAgentDetail, selectedAgentName } from '../agent-detail-state'
 import { TimeAgo } from '../common/time-ago'
+import { ringFocusClasses } from '../common/ring'
 
 function pressureClass(pressure: 'calm' | 'normal' | 'hot'): string {
   switch (pressure) {
@@ -46,7 +47,7 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
             <button
               type="button"
               key=${agent.name}
-              class="focus-agent-card w-full rounded border border-[var(--color-border-divider)] bg-[var(--white-3)] p-3.5 transition-colors duration-200 text-left cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent ${selected === agent.name ? 'focus-agent-selected' : ''}"
+              class=${`focus-agent-card w-full rounded border border-[var(--color-border-divider)] bg-[var(--white-3)] p-3.5 transition-colors duration-200 text-left cursor-pointer ${ringFocusClasses()} ${selected === agent.name ? 'focus-agent-selected' : ''}`}
               onClick=${() => openAgentDetail(agent.name)}
             >
               <div class="focus-agent-header">

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -15,6 +15,7 @@ import { formatTimeAgo } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
 import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { openAgentDetail } from './agent-detail-state'
+import { ringFocusClasses } from './common/ring'
 
 const REFRESH_MS = 30_000
 
@@ -343,19 +344,19 @@ function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) 
             <div class="flex items-center gap-2 text-xs font-mono px-1 py-0.5 rounded ${active ? 'ring-1 ring-[var(--white-10)] bg-[var(--white-5)]' : 'hover:bg-[var(--white-5)]'}">
               <button
                 type="button"
-                class="text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] truncate w-32 text-right focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+                class=${`text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] truncate w-32 text-right ${ringFocusClasses()}`}
                 onClick=${() => openAgentDetail(s.from_agent)}
               >${shortAgentLabel(s.from_agent)}</button>
               <button
                 type="button"
                 aria-pressed=${active ? 'true' : 'false'}
                 title="이 쌍의 에피소드만 필터"
-                class="text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent ${active ? 'text-[var(--color-accent-fg)]' : ''}"
+                class=${`text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] ${ringFocusClasses()} ${active ? 'text-[var(--color-accent-fg)]' : ''}`}
                 onClick=${() => toggleSynapsePairFilter(s.from_agent, s.to_agent)}
               >→</button>
               <button
                 type="button"
-                class="text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] truncate w-32 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+                class=${`text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] truncate w-32 text-left ${ringFocusClasses()}`}
                 onClick=${() => openAgentDetail(s.to_agent)}
               >${shortAgentLabel(s.to_agent)}</button>
               <div class="flex-1 bg-[var(--white-5)] rounded h-1.5 min-w-15">

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -22,6 +22,7 @@ import {
   stripInlineMarkdown,
 } from '../lib/board-utils'
 import { hasRichMarkdownSignals } from './common/rich-content-utils'
+import { ringFocusClasses } from './common/ring'
 import {
   boardPosts,
   boardSortMode,
@@ -402,7 +403,7 @@ function PostCard({ post }: { post: BoardPost }) {
   return html`
     <button
       type="button"
-      class="board-post group w-full flex gap-3 rounded p-4 border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+      class=${`board-post group w-full flex gap-3 rounded p-4 border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer text-left ${ringFocusClasses()}`}
       onClick=${() => navigateToPost(post.id)}
     >
       <!-- Select checkbox -->

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -26,6 +26,7 @@ import { isAbortError } from '../lib/async-state'
 import { Btn } from './btn'
 import { OasHealthChip } from './oas-health-chip'
 import { CopyIdButton } from './common/copy-id-button'
+import { ringFocusClasses } from './common/ring'
 
 interface StoreSnapshot {
   keepers: number
@@ -500,7 +501,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
       <div class="flex items-center gap-1">
         <button
           type="button"
-          class="min-w-0 flex-1 flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+          class=${`min-w-0 flex-1 flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none text-left ${ringFocusClasses()}`}
           onClick=${() => { expanded.value = !expanded.value }}
           aria-expanded=${expanded.value}
         >
@@ -574,7 +575,7 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
       <div class="flex items-center gap-1">
         <button
           type="button"
-          class="min-w-0 flex-1 flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+          class=${`min-w-0 flex-1 flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none text-left ${ringFocusClasses()}`}
           aria-expanded=${expanded.value}
           aria-controls=${contentId}
           onClick=${() => { expanded.value = !expanded.value }}


### PR DESCRIPTION
## Summary
- raw \`focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent\` 11 callsite를 \`ringFocusClasses()\` helper 호출로 swap.
- Helper output string은 raw와 100% 동일 — syntactic refactor, 시각 변화 0.

## Bucket 분류
- **Bucket A (이 PR)**: 11 callsite — helper default output과 1:1 exact match.
- **Bucket B (별도 audit)**: 5 permutation (width=2 + offset=2 + accent-45/accent-20/etc) — common helpers (button/input/select/checkbox/route-link/scroll-to-top) 다수 + app/theme-switch/dashboard-shell/keeper-detail/agent-detail/fsm-hub-* 등. multi-permutation 분류 후 sweep.
- **Bucket C (RFC)**: \`focus:ring\` (no -visible) variants, \`accent/40\`, \`accent-20\` etc.

## Sites
- handoff-timeline.ts:359
- telemetry-unified.ts:503, 577
- keeper-tool-call-inspector.ts:143
- agent-detail-session-report.ts:218
- memory.ts:405
- memory-subsystems.ts:346, 353, 358
- live/focus-sidebar.ts:49
- goals/goal-tree.ts:453

## Verification
- [x] \`pnpm tsc --noEmit\`: clean
- [x] \`pnpm vitest run src/components\`: 3331/3331 pass
- [x] \`bash scripts/dashboard-drift-check.sh\`: gate OK
- [x] residue check: 0 (raw literal 잔재 없음, doc 참조만)

Note: \`feedback_audit-bucket-cascade-pattern\` 적용 — 도메인별 분류 후 deterministic 1:1 sweep만 처리. lint gate는 Bucket B audit 완료 후 PR로 분리 (multi-permutation 분류가 lint 규칙에 영향).

🤖 Generated with [Claude Code](https://claude.com/claude-code)