### PR TITLE
feat(dashboard_bonsai): mirror Sep atom from Preact (bonsai catch-up)

### DIFF
--- a/dashboard_bonsai/src/sep.ml
+++ b/dashboard_bonsai/src/sep.ml
@@ -1,0 +1,130 @@
+(** Sep — atomic divider primitive (Bonsai mirror of Preact [sep.ts]).
+
+    See [sep.mli] for the public contract.
+
+    Visual reference:
+    - SPEC primitives.css [.sep-v]: width 1px, height 16px,
+      background [var(--color-border-strong)], margin 0 var(--sp-2).
+    - SPEC primitives.css [.sep-h]: height 1px,
+      background [var(--color-border-default)], margin var(--sp-2) 0.
+    - Preact [dashboard/src/components/sep.ts] (PR #11203) maps
+      [--sp-2] to a literal 8px since the dashboard runtime does not
+      ship the [--sp-N] scale; this mirror does the same.
+
+    Per-orientation tone defaults (SPEC):
+    - Vertical → [.sep-v] uses [--color-border-strong]
+    - Horizontal → [.sep-h] uses [--color-border-default]
+    The bonsai mirror preserves both defaults; passing [tone]
+    explicitly overrides them.
+
+    Distinct from sibling primitives:
+    - [Band] — 2px decorative state strip at top of a card. Carries
+      kind tone, never neutral. Sep is *neutral*, no kind, no state.
+    - [Bar] — 4px progress fill. Conveys quantity, not adjacency.
+    - Tailwind [divide-y] (Preact-side equivalent) — between-children
+      divider applied via parent. Sep is a *self-contained element*
+      between two adjacent siblings. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .sep_base {
+    flex-shrink: 0;
+  }
+
+  .orient_h {
+    display: block;
+    height: 1px;
+    width: 100%;
+    margin: 8px 0;
+  }
+
+  .orient_v {
+    display: inline-block;
+    width: 1px;
+    height: 16px;
+    margin: 0 8px;
+    vertical-align: middle;
+  }
+
+  .tone_default {
+    background: var(--color-border-default, #3a2e20);
+  }
+
+  .tone_strong {
+    background: var(--color-border-strong, #5a4632);
+  }
+
+  .no_margin_h { margin: 0; }
+  .no_margin_v { margin: 0; }
+|}]
+
+type orientation =
+  [ `Horizontal
+  | `Vertical
+  ]
+
+type tone =
+  [ `Default
+  | `Strong
+  ]
+
+(** SPEC per-orientation default tone:
+    - Vertical → strong (heavier inline-row separator)
+    - Horizontal → default (softer block-stack section break) *)
+let default_tone : orientation -> tone = function
+  | `Horizontal -> `Default
+  | `Vertical -> `Strong
+;;
+
+let orientation_class : orientation -> Attr.t = function
+  | `Horizontal -> Style.orient_h
+  | `Vertical -> Style.orient_v
+;;
+
+let tone_class : tone -> Attr.t = function
+  | `Default -> Style.tone_default
+  | `Strong -> Style.tone_strong
+;;
+
+let orientation_name : orientation -> string = function
+  | `Horizontal -> "horizontal"
+  | `Vertical -> "vertical"
+;;
+
+let tone_name : tone -> string = function
+  | `Default -> "default"
+  | `Strong -> "strong"
+;;
+
+let no_margin_class : orientation -> Attr.t = function
+  | `Horizontal -> Style.no_margin_h
+  | `Vertical -> Style.no_margin_v
+;;
+
+let view ?(orientation = `Horizontal) ?tone ?(no_margin = false) () : Node.t =
+  let resolved_tone =
+    match tone with
+    | Some t -> t
+    | None -> default_tone orientation
+  in
+  let base_attrs =
+    [ Style.sep_base
+    ; orientation_class orientation
+    ; tone_class resolved_tone
+    ; Attr.create "role" "separator"
+    ; Attr.create "aria-orientation" (orientation_name orientation)
+    ; Attr.create "data-orientation" (orientation_name orientation)
+    ; Attr.create "data-tone" (tone_name resolved_tone)
+    ]
+  in
+  let attrs =
+    if no_margin then no_margin_class orientation :: base_attrs else base_attrs
+  in
+  Node.div ~attrs []
+;;

--- a/dashboard_bonsai/src/sep.mli
+++ b/dashboard_bonsai/src/sep.mli
@@ -1,0 +1,56 @@
+(** Sep — atomic divider primitive (Bonsai mirror of Preact [sep.ts]).
+
+    1px hairline rule between adjacent siblings. Two orientations:
+
+    - [`Horizontal] (default) — 1px tall, full-width, with 8px vertical
+      margin. Drops between block siblings inside a stacked card or
+      list (between two paragraph blocks, between a description and an
+      action row).
+    - [`Vertical] — 1px wide × 16px tall with 8px horizontal margin.
+      Drops between inline siblings inside a flex row (keyboard
+      shortcut hint groups, action button clusters, breadcrumb
+      separators).
+
+    Two tones (per-orientation default reflects SPEC):
+    - [`Vertical] → [`Strong] default ([--color-border-strong]) — inline
+      rows want a heavier tone so the eye can resolve the boundary
+      between dense sibling clusters.
+    - [`Horizontal] → [`Default] default ([--color-border-default]) —
+      block stacks already have generous whitespace; a softer tone
+      reads as "section break".
+
+    Either default can be overridden when the adjacent context calls
+    for it.
+
+    Visual contract = SPEC primitives.css [.sep-h] / [.sep-v]
+    selectors + Preact reference [dashboard/src/components/sep.ts]
+    (PR #11203 atom 10/14). *)
+
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type orientation =
+  [ `Horizontal
+  | `Vertical
+  ]
+
+type tone =
+  [ `Default
+  | `Strong
+  ]
+
+(** [view ?orientation ?tone ?no_margin ()] renders the separator.
+
+    [orientation] (default [`Horizontal]): see {!type:orientation}.
+
+    [tone] (default per-orientation): SPEC default is [`Strong] for
+    vertical and [`Default] for horizontal. Pass explicitly to flip
+    the per-orientation default.
+
+    [no_margin] (default [false]): drops the 8px SPEC margin. Use
+    when the parent layout already provides the gap (flex-gap,
+    space-y-N) or when the separator should hug its siblings.
+
+    Renders a [<div role="separator">] with [aria-orientation] set to
+    the chosen axis. *)
+val view : ?orientation:orientation -> ?tone:tone -> ?no_margin:bool -> unit -> Node.t


### PR DESCRIPTION
## 목표

Preact Sep atom (atom 10/14, PR #11203)을 Bonsai (OCaml + js_of_ocaml) island에 mirror. dashboard_bonsai parallel mirror catch-up의 일환 (Chip #11181, Band #11194, Bar #11195, Pill #11205, Spark/Caps/Keeper_badge #11207, Dot #11209에 이은 9번째 atom mirror).

## 변경 파일

| 파일 | 라인 | 역할 |
|---|---|---|
| \`dashboard_bonsai/src/sep.ml\` | 124 | ppx_css stylesheet + polymorphic variant view function |
| \`dashboard_bonsai/src/sep.mli\` | 53 | Public contract + visual contract docs |

## API

\`\`\`ocaml
type orientation = [ `Horizontal | `Vertical ]
type tone = [ `Default | `Strong ]

val view : ?orientation:orientation -> ?tone:tone -> ?no_margin:bool -> unit -> Node.t
\`\`\`

### 사용 예시

\`\`\`ocaml
Sep.view ()                                       (* horizontal default tone *)
Sep.view ~orientation:\`Vertical ()                (* vertical → SPEC strong tone default *)
Sep.view ~orientation:\`Horizontal ~tone:\`Strong () (* override tone *)
Sep.view ~no_margin:true ()                       (* drop the 8px SPEC margin *)
\`\`\`

## SPEC 정합

| 속성 | SPEC primitives.css | Preact sep.ts | Bonsai sep.ml |
|---|---|---|---|
| Horizontal width × height | full × 1px | full × 1px | full × 1px ✅ |
| Vertical width × height | 1px × 16px | 1px × 16px | 1px × 16px ✅ |
| Margin | var(--sp-2) (8px) | 8px (literal) | 8px (literal) ✅ |
| Horizontal default tone | --color-border-default | border-default | --color-border-default ✅ |
| Vertical default tone | --color-border-strong | border-strong | --color-border-strong ✅ |

Both Preact / Bonsai map \`--sp-2 → 8px\` literal since neither runtime ships the SPEC \`--sp-N\` scale.

## 검증

\`\`\`bash
OPAMSWITCH=bonsai-dashboard opam exec -- \\
  dune build --root dashboard_bonsai \\
  src/.dashboard_bonsai_lib.objs/{byte,native}/dashboard_bonsai_lib__Sep.{cmi,cmx}
\`\`\`

→ clean (.cmi + .cmx 모두 정상 컴파일)

### 알려진 사전 이슈 (본 PR과 무관)

\`make bonsai-dashboard\` 풀 빌드 시 \`overview_view.ml\` / \`ctx_chart.ml\` / \`keepers_directory.ml\` 에서 main에 이미 존재하는 syntax/Unbound-value 에러가 발생. CI 게이트는 \`bonsai-dashboard-if-available\` 타겟을 사용해 OxCaml switch 없는 환경에서 skip되므로 default-CI에서는 미감지. **본 PR은 이 사전 이슈를 수정하지 않으며**, Sep 모듈 자체는 격리 빌드로 검증됐습니다.

## Bonsai mirror 진행 상황

| Preact atom | bonsai mirror | 상태 |
|---|---|---|
| 1. Chip | chip.ml | merged #11181 |
| 2. Pill | pill.ml | merged #11205 |
| 3. Bar | bar.ml | merged #11195 |
| 4. Band | band.ml | merged #11194 |
| 5. SectionHead | — | not mirrored |
| 6. KvRow | — | not mirrored |
| 7. Spark | spark.ml | merged #11207 |
| 8. Surf | — | not mirrored |
| 9. Kbd | — | not mirrored |
| 9-10. Tk | — | not mirrored |
| 10. **Sep** | **sep.ml** | **this PR** |
| 11. Btn | — | not mirrored |
| 12. Elev | — | not mirrored |
| 13. focusable | — | not mirrored (helper-class atom) |
| 14. motion | — | not mirrored (helper-class atom) |
| (Dot — bonsai-only primitive) | dot.ml | merged #11209 |

→ 본 PR로 9 atom mirrored. 남은 9 atom + 사전 빌드 이슈 수정은 별도 cycle.

## 미검증

- 풀 빌드 (사전 main-level 이슈 차단)
- 시각 회귀 테스트 (Bonsai island 의 sep adoption은 후속 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)