### PR TITLE
refactor(keeper): add 3 keeper .mli (PR#3 batch 7)

### DIFF
--- a/lib/keeper/keeper_agent_memory_episode.mli
+++ b/lib/keeper/keeper_agent_memory_episode.mli
@@ -1,0 +1,49 @@
+(** Keeper_agent_memory_episode -- post-run episode persistence adapter.
+
+    Keeps OAS memory persistence details out of [Keeper_agent_run],
+    preserving the keeper runner as a thin orchestration layer. *)
+
+(** Emit an [episode.flush] activity payload via [Coord_hooks.activity_emit_fn].
+    No-op if both [episodes] and [procedures] are zero. Swallows non-cancel
+    exceptions; re-raises [Eio.Cancel.Cancelled]. *)
+val emit_flush_activity :
+  config:Coord_utils.config ->
+  keeper_name:string ->
+  turn:int ->
+  episodes:int ->
+  procedures:int ->
+  ?outcome:string ->
+  tags:string list ->
+  unit ->
+  unit
+
+(** Persist a successful turn snapshot as an OAS episode and flush incremental
+    procedures. Logs and swallows non-cancel exceptions. *)
+val record_success :
+  config:Coord_utils.config ->
+  keeper_name:string ->
+  memory:Oas.Memory.t ->
+  turn:int ->
+  trace_id:string ->
+  snapshot:Keeper_memory_policy.keeper_state_snapshot ->
+  unit ->
+  unit
+
+(** Classify [error_kind] into the matching {!Agent_stress.stress_kind}.
+    Returns [None] for kinds that do not map to a pre-existing stress
+    dimension. *)
+val stress_kind_of_error_kind : string -> Agent_stress.stress_kind option
+
+(** Persist a failed-turn episode and surface the failure to
+    [Agent_stress] for non-keepalive failure modes. Logs and swallows
+    non-cancel exceptions. *)
+val record_failure :
+  config:Coord_utils.config ->
+  keeper_name:string ->
+  memory:Oas.Memory.t ->
+  turn:int ->
+  trace_id:string ->
+  error_kind:string ->
+  error_message:string ->
+  unit ->
+  unit

--- a/lib/keeper/keeper_shell_gh_context.mli
+++ b/lib/keeper/keeper_shell_gh_context.mli
@@ -1,0 +1,54 @@
+(** GH repo context resolution for keeper shell commands.
+
+    Extracted from keeper_exec_shell.ml — types and resolution logic
+    for binding a keeper's active task to a git repository context,
+    including worktree path validation and origin slug detection. *)
+
+(** Successfully resolved GitHub repo context for a keeper's active task. *)
+type gh_repo_context =
+  { task_id : string
+  ; git_root : string
+  ; worktree_cwd : string
+  ; repo_slug : string option
+  }
+
+(** Failure to resolve a [gh_repo_context], with structured fields for
+    JSON serialization. *)
+type gh_repo_context_error =
+  { code : string
+  ; detail : string
+  ; hint : string
+  ; task_id : string option
+  ; git_root : string option
+  ; worktree_path : string option
+  }
+
+(** Smart-constructor for [gh_repo_context_error] that takes optional
+    location fields. *)
+val gh_repo_context_error :
+  ?task_id:string ->
+  ?git_root:string ->
+  ?worktree_path:string ->
+  code:string ->
+  detail:string ->
+  hint:string ->
+  unit ->
+  gh_repo_context_error
+
+(** Common hint instructing the keeper to call [keeper_task_claim] before
+    using [keeper_shell op=gh]. *)
+val gh_claim_first_hint : string
+
+(** Render a [gh_repo_context_error] as the canonical
+    [{ ok=false; op; command; error; error_category; ... }] JSON envelope. *)
+val gh_repo_context_error_json :
+  op:string -> cmd_display:string -> gh_repo_context_error -> string
+
+(** Resolve the active task's repo context for [keeper_shell op=gh].
+    Falls back to a sandbox context when [meta.current_task_id] is
+    [None]; otherwise validates the task's worktree and origin slug. *)
+val resolve_gh_repo_context :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  (gh_repo_context, gh_repo_context_error) result

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -1,0 +1,71 @@
+(** Keeper_types_support — model selection, path utilities,
+    and JSONL append/rotation helpers.
+
+    Extracted from keeper_types.ml to reduce file size.
+    Depends only on Keeper_config (no Keeper_types dependency). *)
+
+include module type of Keeper_config
+
+(** Backward-compatible mkdir_p: delegates to [Keeper_fs.ensure_dir]. *)
+val mkdir_p : string -> unit
+
+(** Resolve the keeper base directory ([.masc/keepers]) for [config],
+    creating it if missing. *)
+val keeper_dir_ : Coord.config -> string
+
+(** Resolve the trace base directory ([.masc/traces]) for [config],
+    creating it if missing. *)
+val session_base_dir_ : Coord.config -> string
+
+(** Check API key availability for the given model labels via
+    [Cascade_runtime]. *)
+val ensure_api_keys_for_labels : string list -> (unit, string) result
+
+(** Single-file metrics path kept for fallback reads. *)
+val keeper_metrics_path : Coord.config -> string -> string
+
+(** Date-split metrics store: [.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl].
+    Cached per keeper name so all callers share the same Eio.Mutex. *)
+val keeper_metrics_store : Coord.config -> string -> Dated_jsonl.t
+
+(** Date-split execution-receipt store:
+    [.masc/keepers/<name>/execution-receipts/YYYY-MM/DD.jsonl]. *)
+val keeper_execution_receipt_store : Coord.config -> string -> Dated_jsonl.t
+
+val keeper_memory_bank_path : Coord.config -> string -> string
+val keeper_progress_path : Coord.config -> string -> string
+val keeper_generation_index_path : Coord.config -> string -> string
+
+(** Per-trace session directory under [.masc/traces/<trace_id>]. *)
+val keeper_session_dir : Coord.config -> string -> string
+
+val keeper_generation_manifest_path : Coord.config -> string -> string
+val keeper_history_path : Coord.config -> string -> string
+val keeper_internal_history_path : Coord.config -> string -> string
+
+(** Trim + lowercase a history-source label. *)
+val normalize_history_source : string -> string
+
+(** Whether [source] denotes the world-state prompt history channel. *)
+val is_prompt_history_source : string -> bool
+
+(** Whether [source] denotes a turn-internal (non-user-facing) history
+    channel. *)
+val is_internal_history_source : string -> bool
+
+val keeper_policy_log_path : Coord.config -> string -> string
+val keeper_decision_log_path : Coord.config -> string -> string
+val keeper_feedback_log_path : Coord.config -> string -> string
+val keeper_dataset_export_path : Coord.config -> string -> string
+val keeper_alerts_path : Coord.config -> string
+val keeper_alert_retry_path : Coord.config -> string
+val keeper_alert_deadletter_path : Coord.config -> string
+
+(** Rotate [path] if it exceeds the configured size threshold.
+    Keeps at most [Env_config.KeeperMetrics.max_rotated_files] numbered
+    backups (.1, .2, ...). *)
+val maybe_rotate_file : string -> unit
+
+(** Append [json] as a single UTF-8-repaired JSONL line to [path],
+    rotating first if needed. *)
+val append_jsonl_line : string -> Yojson.Safe.t -> unit


### PR DESCRIPTION
## Summary

PR#3 batch 7 — add `.mli` for the next-smallest keeper modules without interface files.

| module | lines | exports |
|---|---|---|
| `keeper_agent_memory_episode` | 149 | post-run episode persistence (record_success/failure, stress mapper) |
| `keeper_types_support` | 154 | path/JSONL helpers; re-exports `Keeper_config` via `include module type of` |
| `keeper_shell_gh_context` | 156 | gh repo context types + resolve for `keeper_shell op=gh` |

## Surgical guarantees

- `.ml` files **unchanged**.
- All toplevel `let`/`type`/`exception` exposed conservatively.
- External callers verified before authoring:
  - `Keeper_types_support`: 5 functions across 6 callers.
  - `Keeper_agent_memory_episode`: 3 functions (record_success/record_failure/stress_kind_of_error_kind).
  - `Keeper_shell_gh_context`: 5 (all toplevel — types + resolver + JSON renderer).

## Ratchet

```
metric                   current   baseline   note
------------------------------------------------------
keeper_mli_missing            28         35   -3 this PR (-7 cumulative)
coord_mli_missing              3          3
godsplit_count                 0          0
lib_dune_lines               952        952
```

Baseline regen deferred — next batch landing will trigger one
combined regen PR.

## Test plan

- [x] `dune build` ✓
- [x] `scripts/ocaml-structure-ratchet.sh` OK
- [ ] CI: structure-ratchet + dune build

🤖 Generated with [Claude Code](https://claude.com/claude-code)