### PR TITLE
fix(lint): add keeper_meta_json_scrub.mli to V10 boundary allowlist

### DIFF
--- a/scripts/check-boundary-guard.sh
+++ b/scripts/check-boundary-guard.sh
@@ -109,11 +109,14 @@ check "V9-masc-llama-envvar" 4 \
   "lib/"
 
 # V10: OAS-owned provider filters must not be re-owned outside compatibility loaders/scrubbers.
+# The .mli of keeper_meta_json_scrub is the public interface for the already-allowed
+# .ml; the doc-comment legitimately surfaces the legacy key name in its API contract.
 check_forbidden_outside "V10-provider-filter-ownership" \
   'allowed_providers' \
   "lib/" \
   "lib/keeper/keeper_types.ml" \
-  "lib/keeper/keeper_meta_json_scrub.ml"
+  "lib/keeper/keeper_meta_json_scrub.ml" \
+  "lib/keeper/keeper_meta_json_scrub.mli"
 
 # V11: proof-store layout knowledge must stay inside the proof reader adapter.
 check_forbidden_outside "V11-proof-store-layout" \


### PR DESCRIPTION
## 목표

main의 V10 boundary check 실패 해결 — \`allowed_providers\` 리터럴이 \`keeper_meta_json_scrub.mli:20\` 의 doc comment에서 발견되나 V10 allowlist에는 \`.ml\`만 등록. \`.mli\`는 이미 허용된 \`.ml\`의 공개 인터페이스이므로 allowlist에 추가.

## 발견 경위

Btn-sweep #5 (PR #11265) CI에서 Lint FAIL 관찰:
\`\`\`
BOUNDARY FAIL: V10-provider-filter-ownership — found 1 forbidden match(es)
lib/keeper/keeper_meta_json_scrub.mli:20:(** Combined legacy key names (allowed_providers + tool-policy keys). *)
\`\`\`

PR #11265는 dashboard TS 변경만 포함 (config-resolution-panel.ts 1 callsite). OCaml lib에 영향 없음. 검증:

\`\`\`bash
$ git log --oneline -1 lib/keeper/keeper_meta_json_scrub.mli
3cf4d48c3c refactor(keeper): add 2 keeper_meta/turn .mli interfaces (PR#3 batch 2) (#11248)
\`\`\`

\`\`\`bash
$ gh pr checks 11248 | grep Lint
Lint  fail  8m11s
\`\`\`

→ **PR #11248이 Lint=FAIL 상태로 admin override 머지**, V10 위반이 main에 잔재. memory 패턴 \`feedback_required-check-must-include-lint\` (#10747 OAS pin bump 사고와 동일).

## 변경

\`scripts/check-boundary-guard.sh\` V10 rule allowed list에 1줄 추가:

\`\`\`diff
 check_forbidden_outside "V10-provider-filter-ownership" \\
   'allowed_providers' \\
   "lib/" \\
   "lib/keeper/keeper_types.ml" \\
-  "lib/keeper/keeper_meta_json_scrub.ml"
+  "lib/keeper/keeper_meta_json_scrub.ml" \\
+  "lib/keeper/keeper_meta_json_scrub.mli"
\`\`\`

## 정합성 (V10 invariant 보존)

V10 rule: "OAS-owned provider filters must not be re-owned outside compatibility loaders/scrubbers"

- \`.ml\`은 scrubber 모듈 본체 — 이미 허용 (정합)
- \`.mli\`은 같은 scrubber 모듈의 공개 인터페이스 — 같은 module surface
- \`.mli\` line 20는 doc comment로 legacy key 이름을 API contract에 명시 (legitimate)

→ 두 파일 모두 *같은 모듈의 표면*. 하나만 허용하고 다른 하나를 금지하는 건 boundary check의 *모듈 단위 ownership 의도*와 모순. 본 fix는 V10 invariant를 강화하지 않으나 weakening도 없음 (이미 .ml에서 같은 심볼을 자유롭게 쓸 수 있고, .mli도 같은 모듈).

## 검증

\`\`\`bash
$ bash scripts/check-boundary-guard.sh 2>&1 | rg V10
BOUNDARY INFO: V10-provider-filter-ownership — no forbidden matches
\`\`\`

다른 V1-V12 boundary check 영향 없음 (rule이 V10에만 한정).

## 영향

- 본 PR 머지 후 모든 후속 PR이 깨끗한 V10 boundary 받음
- main의 Lint required check (실패 잔재)가 정상화

## 후속 권고 (별도 cycle)

- Required check 설정 검토: Lint가 required인데 admin override 가능한 구조 → branch protection rule 강화 검토 (memory \`feedback_required-check-must-include-lint\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)