### PR TITLE
feat(dashboard): extend Ring helper with 3 accent tones + ring-inset opt

### DIFF
--- a/dashboard/src/components/common/ring.test.ts
+++ b/dashboard/src/components/common/ring.test.ts
@@ -30,6 +30,9 @@ describe('ringFocusClasses (pure)', () => {
     const tones = [
       'accent',
       'accent-soft',
+      'accent-medium',
+      'accent-subtle',
+      'accent-fg',
       'border',
       'muted',
       'ok',
@@ -39,7 +42,6 @@ describe('ringFocusClasses (pure)', () => {
     ] as const
     for (const tone of tones) {
       const cls = ringFocusClasses({ tone })
-      // each tone string must appear *exactly once* under focus-visible:
       expect(cls).toMatch(/focus-visible:ring-/)
     }
   })
@@ -47,6 +49,38 @@ describe('ringFocusClasses (pure)', () => {
   it('accent-soft uses /40 alpha', () => {
     expect(ringFocusClasses({ tone: 'accent-soft' })).toContain(
       'focus-visible:ring-accent/40',
+    )
+  })
+
+  it('accent-medium maps to ring-[var(--accent-45)] (form/button focus)', () => {
+    expect(ringFocusClasses({ tone: 'accent-medium' })).toContain(
+      'focus-visible:ring-[var(--accent-45)]',
+    )
+  })
+
+  it('accent-subtle maps to ring-[var(--accent-30)] (icon hover focus)', () => {
+    expect(ringFocusClasses({ tone: 'accent-subtle' })).toContain(
+      'focus-visible:ring-[var(--accent-30)]',
+    )
+  })
+
+  it('accent-fg maps to ring-[var(--color-accent-fg)] (high-contrast)', () => {
+    expect(ringFocusClasses({ tone: 'accent-fg' })).toContain(
+      'focus-visible:ring-[var(--color-accent-fg)]',
+    )
+  })
+
+  it('full Bucket B form-control pattern composes correctly', () => {
+    // app/theme-switch/dashboard-shell/keeper-detail and common helpers
+    // (button/input/select/checkbox) all use this exact composition.
+    const cls = ringFocusClasses({
+      tone: 'accent-medium',
+      width: 2,
+      offset: 2,
+      offsetSurface: 'surface',
+    })
+    expect(cls).toBe(
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]',
     )
   })
 
@@ -85,6 +119,26 @@ describe('ringFocusClasses (pure)', () => {
     const cls = ringFocusClasses({ visible: false })
     expect(cls).toBe('focus:outline-none focus:ring-1 focus:ring-accent')
     expect(cls).not.toContain('focus-visible:')
+  })
+
+  it('inset=true emits ring-inset and suppresses offset', () => {
+    const cls = ringFocusClasses({ width: 2, tone: 'accent-fg', inset: true })
+    expect(cls).toContain('focus-visible:ring-inset')
+    expect(cls).not.toContain('ring-offset')
+  })
+
+  it('inset=true overrides offset opt (mutually exclusive)', () => {
+    // Even when offset > 0 is passed, inset wins. Documents the
+    // mutual-exclusion contract called out in the helper jsdoc.
+    const cls = ringFocusClasses({
+      tone: 'accent-fg',
+      width: 2,
+      offset: 2,
+      offsetSurface: 'page',
+      inset: true,
+    })
+    expect(cls).toContain('focus-visible:ring-inset')
+    expect(cls).not.toContain('ring-offset')
   })
 
   it('regression: outline-none must precede ring classes', () => {
@@ -130,6 +184,9 @@ describe('ringSelectClasses (pure)', () => {
     const tones = [
       'accent',
       'accent-soft',
+      'accent-medium',
+      'accent-subtle',
+      'accent-fg',
       'border',
       'muted',
       'ok',

--- a/dashboard/src/components/common/ring.ts
+++ b/dashboard/src/components/common/ring.ts
@@ -37,6 +37,9 @@
 export type RingTone =
   | 'accent'
   | 'accent-soft'
+  | 'accent-medium'
+  | 'accent-subtle'
+  | 'accent-fg'
   | 'border'
   | 'muted'
   | 'ok'
@@ -60,6 +63,21 @@ const TONE_CLASS: Record<RingTone, string> = {
   // Used by agent-detail.ts:286 anchor underline focus, where a
   // full-strength accent ring would compete with the underline.
   'accent-soft': 'ring-accent/40',
+  // `accent-medium` = `ring-[var(--accent-45)]` — accent at 45%
+  // opacity. Dominant focus-ring tone for primary form controls and
+  // buttons (8+ callsites: app/theme-switch/dashboard-shell, common
+  // helpers button/input/select/checkbox/number-input/scroll-to-top,
+  // keeper-detail, agent-detail). Pairs with `width: 2 + offset: 2`.
+  'accent-medium': 'ring-[var(--accent-45)]',
+  // `accent-subtle` = `ring-[var(--accent-30)]` — accent at 30%
+  // opacity. Used for hover-fade focus indicators on icon buttons
+  // (copy-id-button). Pairs with `width: 1 + offset: 0`.
+  'accent-subtle': 'ring-[var(--accent-30)]',
+  // `accent-fg` = `ring-[var(--color-accent-fg)]` — full-strength
+  // accent foreground token (different from `accent` which uses the
+  // bare `accent` Tailwind class). Used by fsm-hub timeline panels
+  // where the swimlane segment focus needs maximum contrast.
+  'accent-fg': 'ring-[var(--color-accent-fg)]',
   border: 'ring-[var(--color-border-strong)]',
   muted: 'ring-white/5',
   ok: 'ring-[var(--color-status-ok)]',
@@ -97,6 +115,11 @@ export interface RingFocusOpts {
    *  (keyboard-only). Set `false` to use bare `focus:` (mouse + keyboard
    *  — rare, but matches a few legacy callsites). */
   visible?: boolean
+  /** Render the ring inside the element instead of outside (`ring-inset`).
+   *  Used when the element has no padding/margin headroom for an external
+   *  ring (e.g. swimlane segments in fsm-hub-timeline-panels). Mutually
+   *  exclusive with `offset > 0` — inset rings cannot have an offset gap. */
+  inset?: boolean
 }
 
 /** Compose the canonical focus-ring class string.
@@ -123,7 +146,9 @@ export function ringFocusClasses(opts: RingFocusOpts = {}): string {
     `${prefix}${TONE_CLASS[tone]}`,
   ]
 
-  if (offset > 0) {
+  if (opts.inset) {
+    parts.push(`${prefix}ring-inset`)
+  } else if (offset > 0) {
     parts.push(`${prefix}ring-offset-${offset}`)
     const offsetSurface = opts.offsetSurface ?? 'page'
     parts.push(`${prefix}${OFFSET_SURFACE_CLASS[offsetSurface]}`)


### PR DESCRIPTION
## Summary
Bucket B audit 결과 누락된 tone 12+ callsite 지원을 위한 helper 확장. **Additive only** — 기존 callsite 출력 변경 0.

## 추가된 tone (3개)
| Tone | Output | 용도 (callsite 수) |
|---|---|---|
| \`accent-medium\` | \`ring-[var(--accent-45)]\` | primary form/button focus (8+) |
| \`accent-subtle\` | \`ring-[var(--accent-30)]\` | icon hover focus (1) |
| \`accent-fg\` | \`ring-[var(--color-accent-fg)]\` | swimlane high-contrast (2) |

## RingFocusOpts.inset
\`inset?: boolean\` 추가 — \`ring-inset\` 패턴 지원 (fsm-hub-timeline-panels:223). \`offset > 0\` 와 mutually exclusive.

## Verification
- [x] \`pnpm tsc --noEmit\`: clean
- [x] \`pnpm vitest run ring.test.ts\`: 26/26 pass (was 20)
- [x] \`bash scripts/dashboard-drift-check.sh\`: gate OK
- [x] file-disjoint: \`common/ring.{ts,test.ts}\` 만 수정. #11252 (fsm-hub + goal-tree), #11274 (Bucket A 11 callsite) 와 충돌 0.

## Next cycle
Bucket B sweep PR — 12+ raw callsite를 새 tone으로 swap + lint gate (raw \`ring-[var(--accent-N)]\` 차단). audit-bucket-cascade-pattern 의 sweep + lint 동시 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)