### PR TITLE
fix(lint): allow allowed_providers in keeper_meta_json_scrub.mli — unbreak main

### DIFF
--- a/scripts/check-boundary-guard.sh
+++ b/scripts/check-boundary-guard.sh
@@ -113,7 +113,8 @@ check_forbidden_outside "V10-provider-filter-ownership" \
   'allowed_providers' \
   "lib/" \
   "lib/keeper/keeper_types.ml" \
-  "lib/keeper/keeper_meta_json_scrub.ml"
+  "lib/keeper/keeper_meta_json_scrub.ml" \
+  "lib/keeper/keeper_meta_json_scrub.mli"
 
 # V11: proof-store layout knowledge must stay inside the proof reader adapter.
 check_forbidden_outside "V11-proof-store-layout" \


### PR DESCRIPTION
## Summary
PR #11248 (refactor: add 2 keeper_meta/turn .mli interfaces) split out `keeper_meta_json_scrub.mli`, exposing the docstring:

\`\`\`
(** Combined legacy key names (allowed_providers + tool-policy keys). *)
\`\`\`

The V10 boundary check (\`scripts/check-boundary-guard.sh\`) only allow-listed the \`.ml\` file. The new \`.mli\` interface now triggers \`V10-provider-filter-ownership — found 1 forbidden match\` on every PR that runs Lint, blocking the merge queue (PR #11272 OAS pin bump observed this).

## Surgical fix
Add \`lib/keeper/keeper_meta_json_scrub.mli\` to the V10 allow-list. The docstring is legitimate documentation referring to the legacy key being scrubbed; it does not re-own the OAS provider filter.

## Pattern recognition
Refactor sweep miss — same anti-pattern as #10664 / #10730 / DashScope where wrapper introduction did not sweep all allow-lists / match arms. Memory: \`feedback_jane-street-refactor-sweep-miss\` (5th occurrence in this category).

## Test plan
- [x] Local \`bash scripts/check-boundary-guard.sh\` → "BOUNDARY: all checks within baseline"
- [ ] CI Lint green
- [ ] CI Build green

## Refs
- Introduced by: #11248 (merged 2026-04-27 23:32 KST)
- Blocked: #11272 (OAS pin bump #1211)
- Pattern: \`feedback_jane-street-refactor-sweep-miss\`, \`feedback_required-check-must-include-lint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)