### PR TITLE
refactor(keeper): add 2 keeper .mli (PR#3 batch 8)

### DIFF
--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -1,0 +1,39 @@
+(** Keeper_compact_policy — compaction gate and strategy application.
+
+    Decides whether compaction should run based on ratio/message/token
+    gates and cooldown, then applies OAS strategies + persona fold.
+
+    Extracted from Keeper_exec_context as part of #4955 god-file split. *)
+
+(** Fraction of context window at which compaction is treated as an
+    emergency, bypassing the continuity-reflection cooldown gate. *)
+val emergency_compact_ratio_threshold : float
+
+(** Tool-heavy compaction gate: minimum message count before the
+    [tool_heavy] gate becomes eligible. *)
+val tool_heavy_msg_threshold : int
+
+(** Tool-heavy compaction gate: minimum context ratio before the
+    [tool_heavy] gate becomes eligible. *)
+val tool_heavy_ratio_floor : float
+
+(** Project [meta] to its [(ratio_gate, message_gate, token_gate)]
+    tuple. *)
+val compaction_policy_of_keeper :
+  Keeper_types.keeper_meta -> float * int * int
+
+(** [compact_if_needed ~meta ~now_ts ctx] evaluates the compaction
+    gates and either returns [ctx] unchanged or applies the OAS
+    strategy chain plus the keeper-private fold reducer.
+
+    Return triple:
+    - the (possibly compacted) working context;
+    - [Some reason] when compaction was applied, [None] otherwise;
+    - a status string of the form
+      [{"applied:<reason>", "blocked:below_thresholds",
+       "skipped:continuity_reflection(<elapsed>s<<cooldown>s)"}]. *)
+val compact_if_needed :
+  meta:Keeper_types.keeper_meta ->
+  now_ts:float ->
+  Keeper_context_core.working_context ->
+  Keeper_context_core.working_context * string option * string

--- a/lib/keeper/keeper_skill_routing.mli
+++ b/lib/keeper/keeper_skill_routing.mli
@@ -1,0 +1,57 @@
+(** Keeper_skill_routing — automated and model-assisted skill routing.
+
+    Keepers always have access to all 'keeper' shard tools, but they
+    are routed to specific meta-skills (heartbeat, autonomy) based on
+    the user's request. *)
+
+type selection_mode =
+  | Heuristic
+  | Model_selected of string
+  | Model_rejected of string
+
+type keeper_skill_route =
+  { primary_skill : string
+  ; secondary_skill : string option
+  ; reason : string
+  ; selection_mode : selection_mode
+  }
+
+(** Skills routable to keepers. *)
+val keeper_allowed_skills : string list
+
+val is_valid_keeper_skill : string -> bool
+
+(** Case-insensitive substring match on UTF-8 strings. *)
+val contains_ci : string -> string -> bool
+
+(** Count keywords in [keywords] that occur (case-insensitively) in
+    [text]. *)
+val skill_match_count_ci : text:string -> keywords:string list -> int
+
+(** Lower-is-higher priority used as a secondary sort key when scores
+    tie. *)
+val keeper_skill_priority : string -> int
+
+(** Heuristic routing of [message] to a primary/secondary keeper skill. *)
+val route_keeper_skill : message:string -> keeper_skill_route
+
+val format_skill_route_line : keeper_skill_route -> string
+val format_skill_route_reason : keeper_skill_route -> string
+
+(** Drop SKILL: / SKILL_REASON: lines from a model response. *)
+val strip_skill_route_lines : string -> string
+
+(** Parse a model response's SKILL: / SKILL_REASON: header into a
+    route. Falls back to [fallback_route] (with adjusted
+    [selection_mode]) if the header is missing or invalid. *)
+val parse_skill_route_response :
+  string -> fallback_route:keeper_skill_route -> keeper_skill_route
+
+(** Build the model-facing instruction block describing the skill
+    routing contract and the heuristic fallback. *)
+val keeper_skill_routing_instructions :
+  fallback_route:keeper_skill_route -> string
+
+(** Compose [keeper_skill_routing_instructions] with the current
+    heuristic route into a wrapped " SKILL ROUTING " context block. *)
+val skill_route_context_text : fallback_route:keeper_skill_route -> string


### PR DESCRIPTION
## Summary

PR#3 batch 8 — 2 small keeper modules.

| module | lines |
|---|---|
| keeper_compact_policy | 208 |
| keeper_skill_routing | 215 |

## Carved out — needs upstream cleanup

`keeper_persona_authoring_contract.mli` was prepared but blocked by
open polymorphic-variant return types declared in
`keeper_schema.mli`. Sample (lib/keeper/keeper_schema.mli:30-65):

\`\`\`ocaml
val persona_axis_schema :
  Persona_contract.archetype_axis ->
  [> \`Assoc of
       (string *
        [> \`List of [> \`String of string ] list | \`String of string ])
       list ]

val tool_access_schema :
  string ->
  [> \`Assoc of
       (string *
        [> \`List of [> \`Assoc of (string * [> \`Assoc of ...]) list ] list ]) list ]
\`\`\`

These should be `Yojson.Safe.t` (one line) — the multi-level open
polyvariants are AI-generated callback-hell. Will land as a
separate cleanup PR before persona_authoring_contract.mli.

## Ratchet

\`\`\`
keeper_mli_missing  29 (baseline 35)  -2 this PR
\`\`\`

## Test plan

- [x] dune build
- [x] structure-ratchet OK
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)