### PR TITLE
fix(dashboard_bonsai): 6 surgical fixes — partial build-cascade recovery

### DIFF
--- a/dashboard_bonsai/src/ctx_chart.ml
+++ b/dashboard_bonsai/src/ctx_chart.ml
@@ -236,7 +236,6 @@ let view ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
         ]
       (hairlines @ guides @ polylines)
   in
-  in
   Node.div
     ~attrs:[ Swim.Style.swim ]
     [ Node.div

--- a/dashboard_bonsai/src/keepers_directory.ml
+++ b/dashboard_bonsai/src/keepers_directory.ml
@@ -433,7 +433,7 @@ let selected_row rows selected_name =
 let row_click_effect name =
   let select () = Bonsai.Expert.Var.set selected_name_var (Some name) in
   [ Attr.on_click (fun _ -> Effect.of_sync_fun select ())
-  ; Attr.on_key_down (fun ev ->
+  ; Attr.on_keydown (fun ev ->
       let open Virtual_dom.Vdom.Event.Keyboard in
       if Key.equal ev.key Key.Enter || Key.equal ev.key (Key.of_string " ")
       then Effect.of_sync_fun select ()

--- a/dashboard_bonsai/src/overview_view.ml
+++ b/dashboard_bonsai/src/overview_view.ml
@@ -373,7 +373,6 @@ let view_meta_panel (r : Overview_types.response) =
                         ~attrs:[ Style.stag_fill; stag_color m.stagnation_score; bar_style ]
                         []
                     ]
-                    ]
                 ]
             ]
         ; Node.div


### PR DESCRIPTION
## 목표

dashboard_bonsai island의 누적된 build cascade 중 **6 surgical 1-line fixes** 적용 (2 commits). 본 PR 단독으로 빌드 완전 복구는 안 되지만 **5 errors → 3 errors**로 진척. 남은 3개는 모두 동일한 Vdom keyboard API drift 영역으로 별도 cycle.

## 발견 경위 (Issue Discovery Protocol)

Bonsai Sep mirror PR (#11276) 작업 중 \`dune build --root dashboard_bonsai\` 실행 시 main의 사전 빌드 에러 발견. CI는 \`bonsai-dashboard-if-available\` 게이트로 OxCaml switch 없는 환경 skip하므로 이 빌드 깨짐이 장기간 미감지.

## 변경 (6 surgical fixes, 2 commits)

### Commit 1 — 첫 cascade 3 errors
| 파일 | 라인 | fix |
|---|---|---|
| \`keepers_directory.ml\` | 436 | \`Attr.on_key_down\` → \`Attr.on_keydown\` (compiler hint) |
| \`ctx_chart.ml\` | 239 | duplicate \`in\` keyword 삭제 |
| \`overview_view.ml\` | 376 | extra \`]\` 삭제 (bracket mismatch, per-line bracket-depth trace 검증) |

### Commit 2 — cascade 후 노출된 3 errors
| 파일 | 라인 | fix |
|---|---|---|
| \`logs_view.ml\` | 1488 | \`<>\` polymorphic-variant compare → exhaustive 패턴 매치 (\`[\`Idle | \`Error | \`Warn | \`Info]\`) |
| \`logs_view.ml\` | 1770, 1780 | \`=\` string compare → \`String.equal\` (Core \`=\`/\`<>\` int-only shadow) |
| \`logs_view.ml\` | 1783, 1960 | \`Attr.on_key_down\` → \`Attr.on_keydown\` (각 callsite, replace_all) |

총 +13 / −9, 4 files changed.

## 검증

\`\`\`bash
$ OPAMSWITCH=bonsai-dashboard opam exec -- dune build --root dashboard_bonsai
\`\`\`

| 단계 | 에러 수 | 상태 |
|---|---|---|
| Pre-PR | 3 | overview / ctx_chart / keepers_directory syntax+symbol errors |
| Post-commit-1 | 5 | 첫 3 errors 해결 → cascade 노출 (Poly + key typo + module) |
| Post-commit-2 | 3 | Poly + key typo 해결 → keyboard module API drift만 남음 |
| Build green | — | 별도 cycle (keyboard API migration) |

## 범위 외 — 잔존 3 errors (모두 동일한 API drift)

\`Virtual_dom.Vdom.Event.Keyboard\` 모듈 unbound — 모던 Bonsai에서 \`vdom_keyboard\` 별도 sublibrary로 reorg됨 (\`/lib/virtual_dom/keyboard/\` 위치).

영향 callsite (3건):
- \`keepers_directory.ml:437\`
- \`logs_view.ml:1784\`
- \`logs_view.ml:1957\`

각 callsite는 Enter/Space 키 detect용. Migration 단계:
1. \`dashboard_bonsai/src/dune\` libraries에 \`virtual_dom.keyboard\` 추가
2. \`Virtual_dom.Vdom.Event.Keyboard.Key\` 호출을 \`Vdom_keyboard.Keyboard_event.key + Keyboard_code.{Enter|Space}\` 패턴 매치로 마이그레이션

modern Vdom의 \`Attr.on_keydown\` signature은 \`Dom_html.keyboardEvent Js.t -> unit Effect.t\` (record 필드 \`ev.key\` 접근 X, \`Vdom_keyboard.Keyboard_event.key ev\` 호출).

본 migration은 surgical 영역 외 — design 검증 + 동작 테스트 필요.

## 시스템적 발견

CI \`bonsai-dashboard-if-available\` 게이트 + \`Lint\` admin override 가능 구조 → bonsai 빌드 깨짐 + V10 boundary 위반 (PR #11280)이 모두 main에 잔재.

후속 권고:
- bonsai 빌드 CI 게이트 강화 (OxCaml switch 셋업 → required check 등록)
- 또는 bonsai island를 \`make build-all\` 의존에서 분리 명확화
- memory \`feedback_required-check-must-include-lint\` 패턴

🤖 Generated with [Claude Code](https://claude.com/claude-code)