### PR TITLE
refactor(keeper): collapse keeper_schema.mli polyvariant callback hell to Yojson.Safe.t

### DIFF
--- a/lib/keeper/keeper_persona_authoring_contract.mli
+++ b/lib/keeper/keeper_persona_authoring_contract.mli
@@ -1,0 +1,88 @@
+(** Shared persona authoring contract.
+
+    The persona generator schema, persona schema explanation, and
+    generation logic must agree on archetype choices, choice effects,
+    and draft defaults. Keep those values here so adding or renaming
+    a choice is one edit instead of a schema/runtime mirror. *)
+
+type archetype_choice_effect =
+  { value : string
+  ; effect_text : string
+  ; generated_fields : string list
+  ; default_tool_preset : string option
+  }
+
+type archetype_axis =
+  { name : string
+  ; choices : string list
+  ; choice_effects : archetype_choice_effect list
+  ; effect_text : string
+  ; schema_description : string
+  }
+
+(** {1 Generation defaults} *)
+
+val default_generation_language : string
+val default_generation_cascade_name : string
+val default_tool_preset : string
+val default_temperature : float
+val default_max_tokens : int
+val default_proactive_enabled : bool
+
+(** {1 JSON helpers} *)
+
+val string_list_to_json : string list -> Yojson.Safe.t
+
+(** [option_field name value] returns [[(name, json)]] when [value]
+    is [Some json], [[]] otherwise — handy for building [`Assoc]
+    fields conditionally. *)
+val option_field :
+  string -> Yojson.Safe.t option -> (string * Yojson.Safe.t) list
+
+(** {1 Archetype choice effects} *)
+
+val choice_effect :
+  ?default_tool_preset:string ->
+  value:string ->
+  effect_text:string ->
+  generated_fields:string list ->
+  unit ->
+  archetype_choice_effect
+
+val choice_effect_fields :
+  archetype_choice_effect -> (string * Yojson.Safe.t) list
+
+val choice_effect_to_json : archetype_choice_effect -> Yojson.Safe.t
+val choice_effects_to_json : archetype_choice_effect list -> Yojson.Safe.t
+val choice_values : archetype_choice_effect list -> string list
+
+val choice_effect_for :
+  string -> archetype_choice_effect list -> archetype_choice_effect option
+
+(** {1 Per-axis choice effects (SSOT)} *)
+
+val alignment_choice_effects : archetype_choice_effect list
+val operating_style_choice_effects : archetype_choice_effect list
+val risk_posture_choice_effects : archetype_choice_effect list
+
+val alignment_choices : string list
+val operating_style_choices : string list
+val risk_posture_choices : string list
+
+(** {1 Archetype axes} *)
+
+val alignment_axis : archetype_axis
+val operating_style_axis : archetype_axis
+val risk_posture_axis : archetype_axis
+
+(** All archetype axes in declaration order. *)
+val axes : archetype_axis list
+
+val axis_to_json : archetype_axis -> Yojson.Safe.t
+val archetype_axes_json : unit -> Yojson.Safe.t
+
+(** Lookup an axis by [name]. Returns [None] if absent. *)
+val axis_by_name : string -> archetype_axis option
+
+(** Convenience: choices of the named axis, or [None] if absent. *)
+val choices_for_axis : string -> string list option

--- a/lib/keeper/keeper_schema.mli
+++ b/lib/keeper/keeper_schema.mli
@@ -24,46 +24,13 @@ val shared_memory_scope_enum_strings : string list
 val tail_order_enum_strings : string list
 (** Allowed values for log-tail ordering options. *)
 
-val string_array_schema :
-  [> `Assoc of
-       (string *
-        [> `Assoc of (string * [> `String of string ]) list
-         | `String of string ])
-       list ]
+val string_array_schema : Yojson.Safe.t
 (** JSON schema fragment for a free-form [string list] field. *)
 
-val persona_axis_schema :
-  Persona_contract.archetype_axis ->
-  [> `Assoc of
-       (string *
-        [> `List of [> `String of string ] list | `String of string ])
-       list ]
+val persona_axis_schema : Persona_contract.archetype_axis -> Yojson.Safe.t
 (** Schema fragment for one archetype axis (ranged enum + description). *)
 
-val tool_access_schema :
-  string ->
-  [> `Assoc of
-       (string *
-        [> `List of
-             [> `Assoc of
-                  (string *
-                   [> `Assoc of
-                        (string *
-                         [> `Assoc of
-                              (string *
-                               [> `Assoc of
-                                    (string * [> `String of string ]) list
-                                | `List of [> `String of string ] list
-                                | `String of string ])
-                              list ])
-                        list
-                    | `Bool of bool
-                    | `List of [> `String of string ] list
-                    | `String of string ])
-                  list ]
-             list
-         | `String of string ])
-       list ]
+val tool_access_schema : string -> Yojson.Safe.t
 (** Schema fragment for [meta.tool_access] (preset + per-tool overrides);
     parameterised on the property description so create vs update tools
     can vary the surface without duplicating the body. *)


### PR DESCRIPTION
## Why

`keeper_schema.mli` had three JSON-builder helpers declared with
3-, 3-, and **8-level** open polymorphic-variant return types:

\`\`\`ocaml
val tool_access_schema :
  string ->
  [> \`Assoc of
       (string *
        [> \`List of
             [> \`Assoc of
                  (string *
                   [> \`Assoc of
                        (string *
                         [> \`Assoc of
                              (string *
                               [> \`Assoc of
                                    (string * [> \`String of string ]) list
                                | \`List of [> \`String of string ] list
                                | \`String of string ])
                              list ])
                        list
                    | ... ])
                  list ]
             list ])
       list ]
\`\`\`

That is a one-shot dump of the inferred type that nobody normalized.
The `.ml` just builds standard Yojson trees — `Yojson.Safe.t`
covers them.

The wide polyvariant return leaks: it forces every nested caller
into the same subtype shape. PR#3 batch 8 hit this when adding
`keeper_persona_authoring_contract.mli` exposing
`string_list_to_json : string list -> Yojson.Safe.t` —
`Persona_contract.string_list_to_json axis.choices` plugged into
`persona_axis_schema`'s declared open polyvariant failed to unify.

## What

- `keeper_schema.mli`: 3 helpers → `Yojson.Safe.t` (50 lines → 6 lines).
- `keeper_persona_authoring_contract.mli`: full interface (was
  carved out of PR#3 batch 8 because of this blocker).

## Surgical guarantees

- `.ml` files unchanged.
- `test/test_types.ml` uses `Yojson.Safe.Util.member` on the
  return — already typed against `Yojson.Safe.t`. No churn.
- Internal call chains in `keeper_schema.ml` widen by construction
  (every nested tuple is wrapped in `\`Assoc`).

## Ratchet

\`\`\`
keeper_mli_missing  30 (baseline 35)  -1 this PR (persona_authoring_contract)
\`\`\`

## Test plan

- [x] dune build ✓
- [x] structure-ratchet OK
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)