### PR TITLE
feat(keeper): emit FSM transition at turn entry and success exit (Step 4c)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1058,6 +1058,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
      pre-dispatch checks (see turn_livelock guard below), leaving silent
      skip paths without a turn correlator. *)
   let keeper_turn_id = meta.runtime.usage.total_turns in
+  Keeper_turn_fsm.emit_transition
+    ~keeper_name:meta.name ~turn_id:keeper_turn_id
+    ~prev:Keeper_turn_fsm.Idle
+    Keeper_turn_fsm.Phase_gating;
   match Keeper_registry.get_phase ~base_path:registry_base_path meta.name with
   | Some phase when not (Keeper_state_machine.can_execute_turn phase) ->
       let phase_string = Keeper_state_machine.phase_to_string phase in
@@ -2793,6 +2797,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
            | Oas_worker.Completed ->
              Keeper_registry.reset_turn_failures ~base_path:config.base_path
                updated_meta.name);
+          Keeper_turn_fsm.emit_transition
+            ~keeper_name:meta.name ~turn_id:keeper_turn_id
+            ~prev:Keeper_turn_fsm.Completing
+            Keeper_turn_fsm.Done;
           Ok updated_meta))
 
 let run_unified_turn = run_keeper_cycle


### PR DESCRIPTION
## Summary

Symmetric follow-up to #11269 (Step 4b's 4 silent-skip exits). Adds two missing observation points so every turn produces at least one \`[fsm:transition]\` line, and a successful turn ends in a typed \`Done\` state instead of falling off the end of the function silently.

## Sites

| Site                          | line | prev       | turn_state   |
|-------------------------------|------|------------|--------------|
| \`run_keeper_cycle\` entry    | 1064 | Idle       | Phase_gating |
| \`run_keeper_cycle\` success  | 2800 | Completing | Done         |

Both emit via \`Log.Keeper.info\` with the \`keeper_turn_id\` correlator wired in Step 0a (#11154); \`bin/masc-trace\` picks the lines up automatically.

## Why

Before this PR a turn that dispatched successfully went through `receipt outcome=done -> Ok updated_meta` with no FSM line, and a turn that never reached one of the four pre-dispatch gates left no entry signal at all. \`bin/masc-trace\` could see the receipt but not "keeper started a turn".

After this PR every turn has at least \`[fsm:transition] - -> phase_gating\` and a successful one ends with \`[fsm:transition] completing -> done\`.

The \`Streaming -> Completing\` transition still has no explicit emit; that lives inside \`run_turn\` (\`keeper_agent_run.ml\`) and is left for the dispatch-side adoption stack (separate PR).

## Volume impact

Two extra \`Log.Keeper.info\` lines per turn. At ~16 keepers × ~4-5 turns/min the fleet adds ~120-160 lines/min on top of system_log's existing ~5k+/min — a 2-3% bump. No control-flow change.

## Test plan

- [x] \`dune build\` (default + release) green locally
- [x] \`test_keeper_turn_fsm_emit\` 4/4 OK locally
- [ ] CI lint + meta-guards green
- [ ] Post-merge manual smoke: tail \`~/.masc/logs/system_log_*.jsonl\` for a single turn_id and confirm both lines appear

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)