### PR TITLE
refactor(auth): introduce Auth_error_kind variant for err_kind labels (#11266 Track 2a)

### DIFF
--- a/lib/auth_error_kind.ml
+++ b/lib/auth_error_kind.ml
@@ -1,0 +1,64 @@
+(** Closed-enum classification of [Types.t] for auth-related logging
+    and prometheus metric labels.
+
+    Replaces inline string-label matching at:
+    - [lib/server/server_auth.ml] dashboard_actor_fallback warn/counter
+    - [lib/mcp_server_eio_execute.ml] silent_auth_token_error_kind (follow-up)
+
+    The string labels are stable contract for prometheus dashboards and
+    must round-trip through [to_string] / [of_string]. The variant is
+    closed so that any new auth-relevant [Types.t] constructor that
+    needs its own label requires an explicit code change here, not a
+    silent fall-through to ["other"]. *)
+
+type t =
+  | Token_mismatch
+  | Token_expired
+  | Unauthorized
+  | Forbidden
+  | Agent_not_found
+  | Io_error
+  | Invalid_json
+  | Other
+
+let to_string = function
+  | Token_mismatch -> "token_mismatch"
+  | Token_expired -> "token_expired"
+  | Unauthorized -> "unauthorized"
+  | Forbidden -> "forbidden"
+  | Agent_not_found -> "agent_not_found"
+  | Io_error -> "io_error"
+  | Invalid_json -> "invalid_json"
+  | Other -> "other"
+
+let of_string = function
+  | "token_mismatch" -> Some Token_mismatch
+  | "token_expired" -> Some Token_expired
+  | "unauthorized" -> Some Unauthorized
+  | "forbidden" -> Some Forbidden
+  | "agent_not_found" -> Some Agent_not_found
+  | "io_error" -> Some Io_error
+  | "invalid_json" -> Some Invalid_json
+  | "other" -> Some Other
+  | _ -> None
+
+let classify : Types.t -> t = function
+  | Types.InvalidToken _ -> Token_mismatch
+  | Types.TokenExpired _ -> Token_expired
+  | Types.Unauthorized _ -> Unauthorized
+  | Types.Forbidden _ -> Forbidden
+  | Types.AgentNotFound _ -> Agent_not_found
+  | Types.IoError _ -> Io_error
+  | Types.InvalidJson _ -> Invalid_json
+  | _ -> Other
+
+let all =
+  [ Token_mismatch
+  ; Token_expired
+  ; Unauthorized
+  ; Forbidden
+  ; Agent_not_found
+  ; Io_error
+  ; Invalid_json
+  ; Other
+  ]

--- a/lib/auth_error_kind.mli
+++ b/lib/auth_error_kind.mli
@@ -1,0 +1,29 @@
+(** Closed-enum classification of [Types.t] for auth-related logging
+    and prometheus metric labels. See [auth_error_kind.ml] for the
+    rationale and migration scope. *)
+
+type t =
+  | Token_mismatch
+  | Token_expired
+  | Unauthorized
+  | Forbidden
+  | Agent_not_found
+  | Io_error
+  | Invalid_json
+  | Other
+
+(** Stable string label used in prometheus metric dimensions and log lines.
+    Round-trips with [of_string]. *)
+val to_string : t -> string
+
+(** Inverse of [to_string]. Returns [None] for unrecognised labels rather
+    than collapsing to [Other], so callers can detect contract drift. *)
+val of_string : string -> t option
+
+(** Map a [Types.t] value to its label. Constructors not modelled here
+    fall through to [Other]; add an explicit arm rather than relying on
+    that fallback when introducing a new auth-relevant error. *)
+val classify : Types.t -> t
+
+(** All inhabitants in declaration order. Used by exhaustiveness tests. *)
+val all : t list

--- a/lib/dune
+++ b/lib/dune
@@ -23,6 +23,7 @@
    auto_responder
    auth
    auth_doctor
+   auth_error_kind
    auth_login
    auth_resolve
    auth_strict_mode

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -315,23 +315,11 @@ let dashboard_actor_for_request ~base_path request =
             | Some s -> s
             | None -> "<none>"
           in
-          let err_kind =
-            match err with
-            | Types.Unauthorized _ -> "unauthorized"
-            | Types.Forbidden _ -> "forbidden"
-            (* InvalidToken/TokenExpired previously collapsed into [other],
-               which made up 100% (136/136) of dashboard fallback events
-               on 2026-04-27.  Use the same [token_mismatch]/[token_expired]
-               labels that [mcp_server_eio_execute.ml:26] already uses for
-               the MCP-side dispatch so dashboards can group across both
-               surfaces. *)
-            | Types.InvalidToken _ -> "token_mismatch"
-            | Types.TokenExpired _ -> "token_expired"
-            | Types.AgentNotFound _ -> "agent_not_found"
-            | Types.IoError _ -> "io_error"
-            | Types.InvalidJson _ -> "invalid_json"
-            | _ -> "other"
-          in
+          (* err_kind is a closed enum in [Auth_error_kind] — issue #11266
+             Track 2a. The inline label match here previously diverged
+             silently from the MCP-side dispatch in
+             [mcp_server_eio_execute.ml:silent_auth_token_error_kind]. *)
+          let err_kind = Auth_error_kind.to_string (Auth_error_kind.classify err) in
           Log.Auth.warn
             "[silent:dashboard_actor_fallback] outcome=error \
              token_hash_prefix=%s err_kind=%s actor_hint=%s err=%s — falling \

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,8 +1,8 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 35,
+  "keeper_mli_missing": 25,
   "coord_mli_missing": 3,
   "godsplit_count": 0,
-  "lib_dune_lines": 952
+  "lib_dune_lines": 953
 }

--- a/test/dune
+++ b/test/dune
@@ -31,7 +31,7 @@
 ; Group 1: Pure synchronous tests
 ; ============================================================
 (tests
- (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
+ (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
         test_attempt_state
         test_sse test_cancellation test_graphql_api
         test_graphql_endpoint
@@ -204,7 +204,7 @@
         test_keeper_turn_fsm_emit
         test_gh_api_classification
         test_actionable_path_action)
- (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
+ (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint

--- a/test/test_auth_error_kind.ml
+++ b/test/test_auth_error_kind.ml
@@ -1,0 +1,129 @@
+(** Round-trip + classification tests for [Auth_error_kind].
+
+    Guards the closed-enum contract that prometheus dashboards depend on
+    (issue #11266 Track 2a). Stable string labels must round-trip and
+    every modelled [Types.t] constructor must classify to a non-[Other]
+    label. *)
+
+open Alcotest
+module Aek = Masc_mcp.Auth_error_kind
+
+let test_to_of_string_round_trip () =
+  List.iter
+    (fun kind ->
+      let s = Aek.to_string kind in
+      match Aek.of_string s with
+      | Some kind' when kind' = kind -> ()
+      | Some _ ->
+          Alcotest.failf "to_string/of_string drift for %s" s
+      | None ->
+          Alcotest.failf "of_string returned None for known label %s" s)
+    Aek.all
+
+let test_of_string_unknown_returns_none () =
+  (* Unrecognised labels must return None rather than collapsing to
+     [Other] — callers rely on that to detect contract drift. *)
+  match Aek.of_string "definitely_not_a_label" with
+  | None -> ()
+  | Some _ ->
+      Alcotest.fail "of_string should return None for unknown label"
+
+let test_classify_invalid_token () =
+  match Aek.classify (Types.InvalidToken "x") with
+  | Aek.Token_mismatch -> ()
+  | other ->
+      Alcotest.failf
+        "InvalidToken should classify as Token_mismatch, got %s"
+        (Aek.to_string other)
+
+let test_classify_token_expired () =
+  match Aek.classify (Types.TokenExpired "x") with
+  | Aek.Token_expired -> ()
+  | other ->
+      Alcotest.failf
+        "TokenExpired should classify as Token_expired, got %s"
+        (Aek.to_string other)
+
+let test_classify_unauthorized () =
+  match Aek.classify (Types.Unauthorized "x") with
+  | Aek.Unauthorized -> ()
+  | other ->
+      Alcotest.failf
+        "Unauthorized should classify as Unauthorized, got %s"
+        (Aek.to_string other)
+
+let test_classify_forbidden () =
+  match Aek.classify (Types.Forbidden { agent = "a"; action = "b" }) with
+  | Aek.Forbidden -> ()
+  | other ->
+      Alcotest.failf
+        "Forbidden should classify as Forbidden, got %s"
+        (Aek.to_string other)
+
+let test_classify_agent_not_found () =
+  match Aek.classify (Types.AgentNotFound "x") with
+  | Aek.Agent_not_found -> ()
+  | other ->
+      Alcotest.failf
+        "AgentNotFound should classify as Agent_not_found, got %s"
+        (Aek.to_string other)
+
+let test_classify_io_error () =
+  match Aek.classify (Types.IoError "x") with
+  | Aek.Io_error -> ()
+  | other ->
+      Alcotest.failf
+        "IoError should classify as Io_error, got %s"
+        (Aek.to_string other)
+
+let test_classify_invalid_json () =
+  match Aek.classify (Types.InvalidJson "x") with
+  | Aek.Invalid_json -> ()
+  | other ->
+      Alcotest.failf
+        "InvalidJson should classify as Invalid_json, got %s"
+        (Aek.to_string other)
+
+let test_classify_unmodelled_falls_to_other () =
+  (* GeneralError is not auth-relevant and intentionally falls through
+     to [Other]. If a future PR moves it under an explicit arm, this
+     test is the breakpoint. *)
+  match Aek.classify (Types.GeneralError "x") with
+  | Aek.Other -> ()
+  | other ->
+      Alcotest.failf
+        "GeneralError should classify as Other, got %s"
+        (Aek.to_string other)
+
+let test_label_set_stable () =
+  (* Lock the prometheus dashboard contract. If a label is renamed,
+     this test must be updated together with the dashboard query. *)
+  let expected =
+    [ "token_mismatch"
+    ; "token_expired"
+    ; "unauthorized"
+    ; "forbidden"
+    ; "agent_not_found"
+    ; "io_error"
+    ; "invalid_json"
+    ; "other"
+    ]
+  in
+  let actual = List.map Aek.to_string Aek.all in
+  Alcotest.(check (list string)) "label set" expected actual
+
+let suite =
+  [ test_case "to_string/of_string round-trip" `Quick test_to_of_string_round_trip
+  ; test_case "of_string returns None for unknown" `Quick test_of_string_unknown_returns_none
+  ; test_case "classify InvalidToken" `Quick test_classify_invalid_token
+  ; test_case "classify TokenExpired" `Quick test_classify_token_expired
+  ; test_case "classify Unauthorized" `Quick test_classify_unauthorized
+  ; test_case "classify Forbidden" `Quick test_classify_forbidden
+  ; test_case "classify AgentNotFound" `Quick test_classify_agent_not_found
+  ; test_case "classify IoError" `Quick test_classify_io_error
+  ; test_case "classify InvalidJson" `Quick test_classify_invalid_json
+  ; test_case "classify unmodelled → Other" `Quick test_classify_unmodelled_falls_to_other
+  ; test_case "label set stable" `Quick test_label_set_stable
+  ]
+
+let () = Alcotest.run "Auth_error_kind" [ ("auth_error_kind", suite) ]


### PR DESCRIPTION
## 목표

Issue #11266 Track 2a — `err_kind` 문자열 라벨을 closed-enum variant `Auth_error_kind.t` 로 마이그레이션. 관련 메모리 피드백: "No string matching for classification or fix logic".

## 변경 내용

- `lib/auth_error_kind.ml` + `.mli` 신규 SSOT 모듈 (`type t = Token_mismatch | Token_expired | Unauthorized | Forbidden | Agent_not_found | Io_error | Invalid_json | Other`).
- `lib/server/server_auth.ml:318-333` 의 inline `match err with ...` 를 `Auth_error_kind.to_string (Auth_error_kind.classify err)` 한 줄로 교체.
- `test/test_auth_error_kind.ml` (11 cases): `to_string ∘ of_string` round-trip, `classify` 7개 modelled 분기, `Other` fallback, label set 안정성 검증.

## 측정 (re-measure for #11266)

`~/me/.masc/logs/system_log_2026-04-27.jsonl` (UTC 기준):

- `silent:dashboard_actor_fallback` 24h 합계: **999 events**
- PR #11041 deploy (UTC 05:36) 후 post-fix 빈도: **686 events / ~10h ≈ 70/h**
- Token hash distribution (post-fix):
  - `bbf7407e...`: 549 events (~30/h, 18h 연속 polling)
  - `48e212d5...`: 128 events
  - `f45b639f...`: 5
  - `17809d3f...`: 4
- Track 1 PR #11256 (host path leak fix) 머지 후에도 빈도 유의 감소 없음 → Track 2a 자체 진행이 정당화됨.

## 로컬 검증

```
$ dune build --root <worktree> @check
EXIT 0

$ dune test --root <worktree> test/test_auth_error_kind.exe
11/11 OK in 0.001s

$ dune test --root <worktree> test/test_auth.exe
3 failures (pre-existing, main에서도 동일 — config/authorization/enable_disable; 본 PR 변경과 무관)
```

## Out of scope (follow-up)

- `lib/mcp_server_eio_execute.ml:silent_auth_token_error_kind` 동일한 라벨 분류 중복. 본 PR 머지 후 별도 PR 에서 `Auth_error_kind.classify` 호출로 교체 예정. 이 PR 은 가장 noisy 한 emitter (server_auth) 만 대상.
- `lib/server/server_dashboard_http_core.ml:dashboard_auth_error_code` 는 다른 라벨 semantic (HTTP error code 용) 이라 통합 대상 아님.

## Refs

- Issue #11266 Track 2a
- Memory feedback: `feedback_no-string-matching-classification.md`, `feedback_ssot-inline-copy-bypasses-root-fix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)