### PR TITLE
refactor(coord): collapse coord_agent.mli inferred-dump polyvariants to Yojson.Safe.t

### DIFF
--- a/lib/coord/coord_agent.mli
+++ b/lib/coord/coord_agent.mli
@@ -1,34 +1,32 @@
-(** coord_agent inferred mli **)
+(** Agent registry status and capability queries.
+
+    Reads from [Coord_state] / [Coord_utils] and renders the result
+    as a [Yojson.Safe.t] document for the MCP resource handlers and
+    the [tool_agent] tool. *)
 
 open Types
 include module type of Coord_utils
 include module type of Coord_state
 
+(** Render the full agents/rooms snapshot as a JSON document with
+    [{ count; agents = [...] }] shape. *)
+val get_agents_status : config -> Yojson.Safe.t
 
+(** Register or update an agent's capability list; returns a
+    human-readable status line. *)
+val register_capabilities :
+  config -> agent_name:string -> capabilities:string list -> string
 
-val get_agents_status : config ->
-           [> `Assoc of
-                (string *
-                 [> `Int of int
-                  | `List of
-                      [> `Assoc of (string * Yojson.Safe.t) list ] list ])
-                list ]
-val register_capabilities : config -> agent_name:string -> capabilities:string list -> string
-val update_agent_r : config ->
-           agent_name:string ->
-           ?status:string ->
-           ?capabilities:string list -> unit -> string Types.masc_result
-val find_agents_by_capability : config ->
-           capability:string ->
-           [> `Assoc of
-                (string *
-                 [> `Int of int
-                  | `List of
-                      [> `Assoc of
-                           (string *
-                            [> `List of [> `String of string ] list
-                             | `String of string ])
-                           list ]
-                      list
-                  | `String of string ])
-                list ]
+(** Update an agent's [status] and/or [capabilities]. *)
+val update_agent_r :
+  config ->
+  agent_name:string ->
+  ?status:string ->
+  ?capabilities:string list ->
+  unit ->
+  string Types.masc_result
+
+(** Find every registered agent advertising [capability]; returns
+    [{ count; capability; agents = [...] }] or an error envelope. *)
+val find_agents_by_capability :
+  config -> capability:string -> Yojson.Safe.t


### PR DESCRIPTION
## Why

`coord_agent.mli` header literally said:

\`\`\`ocaml
(** coord_agent inferred mli **)
\`\`\`

— a one-shot inferred-type dump. `get_agents_status` had a 3-level
open polyvariant return; `find_agents_by_capability` had a 4-level
nested polyvariant. Both `.ml` builders produce ordinary Yojson trees.

## What

Tightened to `Yojson.Safe.t`. The .mli now has a real docstring
instead of the \`inferred\` placeholder, and dropped 24 lines of
nested type machinery.

## Caller verification

- `lib/tool_agent.ml`, `lib/mcp_server_eio_resource.ml`:
  `Yojson.Safe.pretty_to_string json` — needs ground type, not poly.
- `test/test_room.ml`: \`Assoc fields\` pattern — works on either.

## Same root pattern as #11286

Both PRs collapse inferred-dump polyvariants. Same downstream effect:
prevents subtype-mismatch chains when adding new .mli files that
plug ground-typed Yojson values into these helpers.

## Test plan

- [x] dune build ✓
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)