### PR TITLE
refactor(keeper): typed stale_kill_class for stale watchdog (Phase B PR-6)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -32,10 +32,29 @@ type ambiguous_partial_commit = {
   detail : string;
 }
 
+(** Phase B PR-6 (2026-04-28): typed sub-class of stale-watchdog kills.
+    See keeper_registry.mli for rationale. *)
+type stale_kill_class =
+  | Idle_turn of { stall_seconds : float }
+  | In_turn_hung of {
+      active_seconds : float;
+      timeout_threshold : float;
+    }
+  | Noop_failure_loop of { noop_count : int }
+
+let stale_kill_class_to_string = function
+  | Idle_turn { stall_seconds } ->
+      Printf.sprintf "idle_turn(%.0fs)" stall_seconds
+  | In_turn_hung { active_seconds; timeout_threshold } ->
+      Printf.sprintf "in_turn_hung(active=%.0fs threshold=%.0fs)"
+        active_seconds timeout_threshold
+  | Noop_failure_loop { noop_count } ->
+      Printf.sprintf "noop_failure_loop(noop=%d)" noop_count
+
 type failure_reason =
   | Heartbeat_consecutive_failures of int
   | Turn_consecutive_failures of int
-  | Stale_turn_timeout of float
+  | Stale_turn_timeout of stale_kill_class
   | Stale_termination_storm of { count : int }
       (** #10765 Phase 2: latched when [record_stale_termination] returns a
           window count >= [escalation_threshold]. The supervisor's
@@ -56,8 +75,9 @@ let failure_reason_to_string = function
       Printf.sprintf "heartbeat_consecutive_failures(%d)" n
   | Turn_consecutive_failures n ->
       Printf.sprintf "turn_consecutive_failures(%d)" n
-  | Stale_turn_timeout sec ->
-      Printf.sprintf "stale_turn_timeout(%.0fs)" sec
+  | Stale_turn_timeout cls ->
+      Printf.sprintf "stale_turn_timeout(%s)"
+        (stale_kill_class_to_string cls)
   | Stale_termination_storm { count } ->
       Printf.sprintf "stale_termination_storm(count=%d)" count
   | Ambiguous_partial_commit { kind; detail } ->

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -22,10 +22,39 @@ type ambiguous_partial_commit = {
   detail : string;
 }
 
+(** Phase B PR-6 (2026-04-28): the stale watchdog's three distinct kill
+    causes used to collapse into a single [Stale_turn_timeout of float]
+    variant.  Operators / dashboards could not tell whether a kill was an
+    idle stall (turn never started), an active turn hang (turn running
+    too long), or a no-op failure loop (turn fired but produced no tool
+    calls) — three different root causes that need different operator
+    actions.  Splitting the payload preserves the [Stale_turn_timeout]
+    cohort key so existing dashboards keep working, while exposing the
+    typed sub-class to anything that wants to discriminate. *)
+type stale_kill_class =
+  | Idle_turn of { stall_seconds : float }
+      (** [last_turn_ts] older than the idle threshold while the keeper
+          phase is [Running] but no [current_turn_observation] is
+          recorded. *)
+  | In_turn_hung of {
+      active_seconds : float;
+      timeout_threshold : float;
+    }
+      (** A turn started ([current_turn_observation = Some]) and ran past
+          [timeout_threshold] seconds. *)
+  | Noop_failure_loop of { noop_count : int }
+      (** Turns kept firing but produced no tool calls; the keepalive's
+          [consecutive_noop_count] reached the watchdog threshold. *)
+
+val stale_kill_class_to_string : stale_kill_class -> string
+(** Operator-facing label.  Used in [failure_reason_to_string] for the
+    [Stale_turn_timeout] arm and exposed for dashboards / metrics that
+    want to attribute kills by class. *)
+
 type failure_reason =
   | Heartbeat_consecutive_failures of int
   | Turn_consecutive_failures of int
-  | Stale_turn_timeout of float
+  | Stale_turn_timeout of stale_kill_class
   | Stale_termination_storm of { count : int }
       (** #10765 Phase 2: latched when [record_stale_termination] returns a
           window count >= [escalation_threshold]. The supervisor's

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -190,20 +190,42 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                      (String.concat "," reasons) (now -. ts)
                  | _ -> ""
                in
+               (* Phase B PR-6 (2026-04-28): the kill reason now carries
+                  a typed [stale_kill_class] so dashboards can attribute
+                  the kill to the correct root cause (idle stall vs
+                  active turn hang vs no-op loop) instead of every kill
+                  collapsing to a single [stale_turn_timeout(<seconds>)]
+                  string.  The three sub-causes need different operator
+                  actions, so they need different typed labels.  The
+                  surrounding [reason_desc] log line still embeds the
+                  same human-readable text via [stale_kill_class_to_string]. *)
+               let kill_class : Keeper_registry.stale_kill_class =
+                 if in_turn_stale then
+                   In_turn_hung
+                     { active_seconds = in_turn_age;
+                       timeout_threshold = active_turn_timeout_sec;
+                     }
+                 else if idle_stale then
+                   Idle_turn { stall_seconds = now -. last_turn }
+                 else
+                   Noop_failure_loop { noop_count }
+               in
                let reason_desc =
-                 if idle_stale then
+                 match kill_class with
+                 | Idle_turn { stall_seconds } ->
                    Printf.sprintf "idle %.0fs%s"
-                     (now -. last_turn) skip_reason_label
-                 else if in_turn_stale then
+                     stall_seconds skip_reason_label
+                 | In_turn_hung { active_seconds; timeout_threshold } ->
                    Printf.sprintf "active turn hung %.0fs (timeout %.0fs)"
-                     in_turn_age active_turn_timeout_sec
-                 else Printf.sprintf "failure-loop noop=%d" noop_count
+                     active_seconds timeout_threshold
+                 | Noop_failure_loop { noop_count = n } ->
+                   Printf.sprintf "failure-loop noop=%d" n
                in
                let stall_seconds =
                  if in_turn_stale then in_turn_age else now -. last_turn
                in
                Keeper_registry.set_failure_reason ~base_path meta.name
-                 (Some (Keeper_registry.Stale_turn_timeout stall_seconds));
+                 (Some (Keeper_registry.Stale_turn_timeout kill_class));
                Atomic.set reg.fiber_stop true;
                let window_count = record_stale_termination meta.name now in
                Prometheus.inc_counter

--- a/test/dune
+++ b/test/dune
@@ -203,7 +203,8 @@
         test_auth_strict_mode
         test_keeper_turn_fsm_emit
         test_gh_api_classification
-        test_actionable_path_action)
+        test_actionable_path_action
+        test_stale_kill_class)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -377,6 +378,7 @@
           test_keeper_turn_fsm_emit
           test_gh_api_classification
           test_actionable_path_action
+          test_stale_kill_class
           )
  (libraries masc_test_deps))
 

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -1,0 +1,95 @@
+(** test_stale_kill_class — Phase B PR-6 typed [stale_kill_class].
+
+    The stale-watchdog kill reason used to collapse three distinct root
+    causes (idle stall, active-turn hang, no-op failure loop) into a
+    single [Stale_turn_timeout of float] variant.  Dashboards could not
+    discriminate; operators had to grep the text log to figure out
+    which class triggered.  This test pins the typed surface so a
+    rename or signature change in [stale_kill_class] fails at the test
+    boundary, not in production telemetry. *)
+
+open Masc_mcp.Keeper_registry
+
+let r = Alcotest.(check string)
+
+let test_idle_turn_label () =
+  r "idle_turn label" "idle_turn(305s)"
+    (stale_kill_class_to_string (Idle_turn { stall_seconds = 305.0 }))
+
+let test_in_turn_hung_label () =
+  r "in_turn_hung label"
+    "in_turn_hung(active=720s threshold=600s)"
+    (stale_kill_class_to_string
+       (In_turn_hung
+          { active_seconds = 720.0; timeout_threshold = 600.0 }))
+
+let test_noop_failure_loop_label () =
+  r "noop_failure_loop label" "noop_failure_loop(noop=4)"
+    (stale_kill_class_to_string
+       (Noop_failure_loop { noop_count = 4 }))
+
+let test_failure_reason_to_string_idle () =
+  r "Stale_turn_timeout(Idle_turn) wraps with prefix"
+    "stale_turn_timeout(idle_turn(305s))"
+    (failure_reason_to_string
+       (Stale_turn_timeout (Idle_turn { stall_seconds = 305.0 })))
+
+let test_failure_reason_to_string_in_turn () =
+  r "Stale_turn_timeout(In_turn_hung) wraps with prefix"
+    "stale_turn_timeout(in_turn_hung(active=720s threshold=600s))"
+    (failure_reason_to_string
+       (Stale_turn_timeout
+          (In_turn_hung
+             { active_seconds = 720.0; timeout_threshold = 600.0 })))
+
+let test_failure_reason_to_string_noop () =
+  r "Stale_turn_timeout(Noop_failure_loop) wraps with prefix"
+    "stale_turn_timeout(noop_failure_loop(noop=4))"
+    (failure_reason_to_string
+       (Stale_turn_timeout
+          (Noop_failure_loop { noop_count = 4 })))
+
+let test_cohort_key_collapses_subclasses () =
+  (* The cohort key intentionally ignores the sub-class — every stale
+     kill is one cohort for dashboard rate computation.  Operators
+     drill down via [failure_reason_to_string] when they need the
+     class. *)
+  r "Idle_turn cohort_key" "stale_turn_timeout"
+    (failure_reason_cohort_key
+       (Some (Stale_turn_timeout (Idle_turn { stall_seconds = 1.0 }))));
+  r "In_turn_hung cohort_key" "stale_turn_timeout"
+    (failure_reason_cohort_key
+       (Some
+          (Stale_turn_timeout
+             (In_turn_hung
+                { active_seconds = 1.0; timeout_threshold = 1.0 }))));
+  r "Noop_failure_loop cohort_key" "stale_turn_timeout"
+    (failure_reason_cohort_key
+       (Some (Stale_turn_timeout (Noop_failure_loop { noop_count = 1 }))))
+
+let () =
+  Alcotest.run "stale_kill_class"
+    [
+      ( "stale_kill_class_to_string",
+        [
+          Alcotest.test_case "Idle_turn label" `Quick test_idle_turn_label;
+          Alcotest.test_case "In_turn_hung label" `Quick
+            test_in_turn_hung_label;
+          Alcotest.test_case "Noop_failure_loop label" `Quick
+            test_noop_failure_loop_label;
+        ] );
+      ( "failure_reason_to_string",
+        [
+          Alcotest.test_case "Stale_turn_timeout(Idle_turn) wraps" `Quick
+            test_failure_reason_to_string_idle;
+          Alcotest.test_case "Stale_turn_timeout(In_turn_hung) wraps" `Quick
+            test_failure_reason_to_string_in_turn;
+          Alcotest.test_case "Stale_turn_timeout(Noop_failure_loop) wraps"
+            `Quick test_failure_reason_to_string_noop;
+        ] );
+      ( "failure_reason_cohort_key",
+        [
+          Alcotest.test_case "all sub-classes collapse to one cohort"
+            `Quick test_cohort_key_collapses_subclasses;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Phase B PR-6 of the keeper FSM bloodflow restoration plan.  Splits the
stale-watchdog kill payload from a single ``Stale_turn_timeout of
float`` into a typed ``stale_kill_class`` discriminator.

## Why

Three distinct kill causes used to collapse to one float:

| Cause | Operator action |
|---|---|
| ``Idle_turn``         | Investigate: legitimate idle, or misrouted scheduling? |
| ``In_turn_hung``      | Provider / cascade hang — check token, network, OAS upstream |
| ``Noop_failure_loop`` | Contract violation — check prompt, allowlist, capability |

User hard rule: *"no string matching for classification"*.  The
watchdog already knew which case fired (``if idle_stale``,
``if in_turn_stale``, etc.), but downstream consumers received a
float that lost the structure — they had to grep the log line to
recover it.

## Changes

| File | Change |
|---|---|
| ``lib/keeper/keeper_registry.{ml,mli}`` | New ``stale_kill_class`` variant + ``stale_kill_class_to_string`` helper. ``Stale_turn_timeout`` payload changes from ``float`` → ``stale_kill_class``. |
| ``lib/keeper/keeper_stale_watchdog.ml`` | Compute the typed ``kill_class`` once at the kill site, derive ``reason_desc`` via ``match`` instead of an ``if idle_stale then ...`` ladder. |
| ``test/test_stale_kill_class.ml`` | 7 unit tests pinning the typed surface (three ``_to_string`` labels, three ``failure_reason_to_string`` wraps, and one assertion that ``failure_reason_cohort_key`` collapses all sub-classes to a single ``"stale_turn_timeout"`` cohort so existing dashboards keep working). |

## Backward compatibility

All callers of ``Stale_turn_timeout`` use wildcard patterns
(``Some (Stale_turn_timeout _)`` in ``keeper_supervisor.ml:163``).
The payload type change is compile-checked but does not require
call-site refactor in this PR.  Future PRs that *want* to discriminate
sub-classes (e.g. supervisor restart policy keyed on
``Noop_failure_loop`` only) can match on the typed value.

## Test plan

- [x] ``dune build @check --root .`` green
- [x] ``./_build/default/test/test_stale_kill_class.exe`` → 7/7 pass
- [ ] CI Build + Lint green

## Plan reference

``planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-sunny-starfish.md``
section 6, Phase B PR-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)