### PR TITLE
refactor(keeper): expose typed actionable_path action mapping (PR-5 precursor)

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -13,34 +13,50 @@ let error_json ?(fields = []) (message : string) =
 
 let tool_result_or_error (ok, msg) = if ok then msg else error_json msg
 
+(** Phase B PR-5 precursor (2026-04-28): the action mapping itself,
+    parameterised by the typed [Keeper_failure_circuit_breaker.error_class].
+    Callers that already hold a typed class (sandbox / shell typed
+    error paths in Phase B PR-5) call this directly and skip the
+    string → class round-trip entirely.  String-only callers go through
+    [actionable_path_error] below, which classifies once and delegates. *)
+let actionable_path_action_for_class
+      ~(playground : string)
+      ~(raw_path : string)
+      (cls : Keeper_failure_circuit_breaker.error_class) : string =
+  if String.length raw_path = 0 then
+    "Provide a path. Your playground root is " ^ playground
+  else
+    match cls with
+    | Path_not_found ->
+      Printf.sprintf "File does not exist. Run `keeper_shell op=ls path=%s` first to see available files." playground
+    | Path_not_allowed ->
+      Printf.sprintf "Path is outside your allowed roots. Stay inside %s or use keeper_context_status to see allowed paths." playground
+    | Cwd_not_directory ->
+      "The cwd is not a directory. Omit cwd to use your default playground root."
+    | Shell_exit_nonzero | Other ->
+      Printf.sprintf "Check the path. Your playground: %s" playground
+
 (** Actionable error for path resolution failures.
     Follows Samchon harness pattern: field-level diagnostics with
     exact path, expected constraint, and concrete next action.
     Claude Code pattern: validateInput returns actionable guidance.
 
-    Phase A F4 (2026-04-27): the error → action mapping now dispatches
-    on the typed [Keeper_failure_circuit_breaker.error_class] instead of
-    a parallel [contains_substring] ladder.  String-matching collapses
-    from two sites (here + circuit_breaker) to one (the SSOT).  Phase B
-    PR-5 will then push the typed class up to the caller so the final
-    site disappears. *)
+    Phase A F4 (2026-04-27): the error → action mapping dispatches on
+    the typed [Keeper_failure_circuit_breaker.error_class] instead of a
+    parallel [contains_substring] ladder.  String-matching collapses
+    from two sites (here + circuit_breaker) to one (the SSOT).
+
+    Phase B PR-5 precursor (2026-04-28): the action mapping is now
+    parameterised on the typed class via
+    [actionable_path_action_for_class].  This keeps the string-input
+    entry point (for callers that only have a raw error message) but
+    exposes the typed mapping so Phase B PR-5 can route typed callers
+    directly without a redundant classify pass. *)
 let actionable_path_error ~(op : string) ~(meta : keeper_meta)
       ~(raw_path : string) ~(error : string) =
   let playground = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
-  let action =
-    if String.length raw_path = 0 then
-      "Provide a path. Your playground root is " ^ playground
-    else
-      match Keeper_failure_circuit_breaker.classify_error error with
-      | Path_not_found ->
-        Printf.sprintf "File does not exist. Run `keeper_shell op=ls path=%s` first to see available files." playground
-      | Path_not_allowed ->
-        Printf.sprintf "Path is outside your allowed roots. Stay inside %s or use keeper_context_status to see allowed paths." playground
-      | Cwd_not_directory ->
-        "The cwd is not a directory. Omit cwd to use your default playground root."
-      | Shell_exit_nonzero | Other ->
-        Printf.sprintf "Check the path. Your playground: %s" playground
-  in
+  let cls = Keeper_failure_circuit_breaker.classify_error error in
+  let action = actionable_path_action_for_class ~playground ~raw_path cls in
   Yojson.Safe.to_string (`Assoc [
     "ok", `Bool false;
     "op", `String op;

--- a/test/dune
+++ b/test/dune
@@ -202,7 +202,8 @@
         test_per_keeper_token_fallback
         test_auth_strict_mode
         test_keeper_turn_fsm_emit
-        test_gh_api_classification)
+        test_gh_api_classification
+        test_actionable_path_action)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -375,6 +376,7 @@
           test_auth_strict_mode
           test_keeper_turn_fsm_emit
           test_gh_api_classification
+          test_actionable_path_action
           )
  (libraries masc_test_deps))
 

--- a/test/test_actionable_path_action.ml
+++ b/test/test_actionable_path_action.ml
@@ -1,0 +1,104 @@
+(** test_actionable_path_action — Phase B PR-5 precursor.
+
+    [actionable_path_action_for_class] is the typed action mapping
+    extracted from [actionable_path_error].  Callers that already hold a
+    [Keeper_failure_circuit_breaker.error_class] use this directly and
+    skip the string → class round-trip.  This test pins the action
+    string for each class so a copy-paste rename or reorder fails at
+    the test boundary, not in production operator-facing output. *)
+
+open Masc_mcp.Keeper_exec_shared
+module CB = Masc_mcp.Keeper_failure_circuit_breaker
+
+let r = Alcotest.(check string)
+
+let pg = ".masc/playground/test"
+
+let test_path_not_found () =
+  let action =
+    actionable_path_action_for_class
+      ~playground:pg ~raw_path:"missing.ml" CB.Path_not_found
+  in
+  Alcotest.(check bool) "mentions ls hint" true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "keeper_shell op=ls") action 0);
+       true
+     with Not_found -> false);
+  Alcotest.(check bool) "mentions playground" true
+    (try
+       ignore (Str.search_forward (Str.regexp_string pg) action 0);
+       true
+     with Not_found -> false)
+
+let test_path_not_allowed () =
+  let action =
+    actionable_path_action_for_class
+      ~playground:pg ~raw_path:"/etc/passwd" CB.Path_not_allowed
+  in
+  Alcotest.(check bool) "mentions allowed-roots constraint" true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "outside your allowed roots") action 0);
+       true
+     with Not_found -> false)
+
+let test_cwd_not_directory () =
+  r "cwd guidance"
+    "The cwd is not a directory. Omit cwd to use your default playground root."
+    (actionable_path_action_for_class
+       ~playground:pg ~raw_path:"foo" CB.Cwd_not_directory)
+
+let test_shell_exit_nonzero_falls_back () =
+  let action =
+    actionable_path_action_for_class
+      ~playground:pg ~raw_path:"foo" CB.Shell_exit_nonzero
+  in
+  Alcotest.(check bool) "uses generic fallback for non-path classes" true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "Check the path") action 0);
+       true
+     with Not_found -> false)
+
+let test_other_falls_back () =
+  let action =
+    actionable_path_action_for_class
+      ~playground:pg ~raw_path:"foo" CB.Other
+  in
+  Alcotest.(check bool) "Other == Shell_exit_nonzero on action surface" true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "Check the path") action 0);
+       true
+     with Not_found -> false)
+
+let test_empty_raw_path_overrides_class () =
+  (* The "provide a path" guidance fires regardless of class when the
+     caller passed an empty raw_path — Phase A F4 preserved this
+     behavior; this PR re-asserts it under the typed surface. *)
+  let action =
+    actionable_path_action_for_class
+      ~playground:pg ~raw_path:"" CB.Path_not_found
+  in
+  Alcotest.(check bool) "empty raw_path -> 'Provide a path' guidance" true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "Provide a path") action 0);
+       true
+     with Not_found -> false)
+
+let () =
+  Alcotest.run "actionable_path_action"
+    [
+      ( "by_error_class",
+        [
+          Alcotest.test_case "Path_not_found" `Quick test_path_not_found;
+          Alcotest.test_case "Path_not_allowed" `Quick test_path_not_allowed;
+          Alcotest.test_case "Cwd_not_directory" `Quick
+            test_cwd_not_directory;
+          Alcotest.test_case "Shell_exit_nonzero falls back" `Quick
+            test_shell_exit_nonzero_falls_back;
+          Alcotest.test_case "Other falls back" `Quick test_other_falls_back;
+        ] );
+      ( "raw_path_override",
+        [
+          Alcotest.test_case "empty raw_path -> Provide a path" `Quick
+            test_empty_raw_path_overrides_class;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Phase B PR-5 precursor.  Extracts the action-string mapping from
``actionable_path_error`` into a reusable typed entry
``actionable_path_action_for_class`` so Phase B PR-5 callers (sandbox /
shell typed-error paths) can route directly without a redundant
``string → error_class`` round-trip.

## Why

Phase A F4 collapsed two parallel ``contains_substring`` ladders into
one SSOT (``Keeper_failure_circuit_breaker.classify_error``).  Phase B
PR-5 will then push the typed class up to the caller so the SSOT
itself stops needing string-matching.  But PR-5's call-site refactor
needs a typed entry point on the consumer side first — otherwise the
caller would build a typed ``error_class`` only to immediately
``error_class_to_string`` it for ``actionable_path_error`` and pay a
re-classify pass.

This PR adds that typed entry point.

## Layering

```
caller has typed error_class
  -> actionable_path_action_for_class (no classify pass)

caller has raw error string
  -> actionable_path_error (classify once, then delegate)
  -> actionable_path_action_for_class
```

## Behavior change

None.  ``actionable_path_error`` produces byte-identical action
strings for every input.  The empty-raw_path override ("Provide a
path") is preserved at the helper layer so the typed entry shares the
contract.

## Files

- ``lib/keeper/keeper_exec_shared.ml`` — extract
  ``actionable_path_action_for_class``; ``actionable_path_error``
  delegates
- ``test/test_actionable_path_action.ml`` — 6 unit tests pinning the
  typed surface

## Test plan

- [x] ``dune build @check --root .`` green
- [x] ``./_build/default/test/test_actionable_path_action.exe`` → 6/6 pass
- [ ] CI Build + Lint green

## Plan reference

Phase B PR-5 of
``planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-sunny-starfish.md``
section 6.  This PR lands the consumer-side hook so PR-5 proper can
focus on the caller-side typed-error construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)