### PR TITLE
feat(dashboard_bonsai): mirror KvRow atom from Preact (bonsai catch-up)

### DIFF
--- a/dashboard_bonsai/src/kv_row.ml
+++ b/dashboard_bonsai/src/kv_row.ml
@@ -1,0 +1,116 @@
+(** KvRow — atomic label/value row primitive (Bonsai mirror of Preact
+    [kv-row.ts]).
+
+    See [kv_row.mli] for the public contract.
+
+    SPEC mapping (primitives.css [.kv-row]):
+    - grid-template-columns: 80px 1fr  ([.is-wide] → 120px 1fr)
+    - gap: var(--sp-3) (12px)
+    - padding: 4px 0
+    - align-items: baseline
+    - font-size: 11px
+    - .k → fg-muted, fs-10, uppercase, letter-spacing 0.06em
+    - .v → fg-primary, mono, fs-11
+
+    Mirrors the Preact [MONO_STACK] literal so the bonsai island
+    renders the same monospace fallback chain as the Preact runtime. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .row {
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    gap: 12px;
+    padding: 4px 0;
+    align-items: baseline;
+    font-size: var(--fs-11, 11px);
+  }
+
+  .row_wide {
+    grid-template-columns: 120px 1fr;
+  }
+
+  .k {
+    color: var(--color-fg-muted);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .v {
+    color: var(--color-fg-primary);
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: var(--fs-11, 11px);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .v_wrap {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    word-break: break-all;
+  }
+|}]
+
+type width =
+  [ `Default
+  | `Wide
+  ]
+
+let width_class : width -> Attr.t list = function
+  | `Default -> []
+  | `Wide -> [ Style.row_wide ]
+;;
+
+let width_data_value : width -> string = function
+  | `Default -> "false"
+  | `Wide -> "true"
+;;
+
+let view
+      ?(width = `Default)
+      ?(wrap = false)
+      ?value
+      ?(children = [])
+      ?testid
+      ~label
+      ()
+  : Node.t
+  =
+  let row_attrs =
+    let base =
+      Style.row
+      :: width_class width
+      @ [ Attr.create "data-kv-row" ""
+        ; Attr.create "data-kv-wide" (width_data_value width)
+        ]
+    in
+    match testid with
+    | Some id -> Attr.create "data-testid" id :: base
+    | None -> base
+  in
+  let key =
+    Node.span
+      ~attrs:[ Style.k; Attr.create "data-kv-key" "" ]
+      [ Node.text label ]
+  in
+  let value_node =
+    match children with
+    | _ :: _ -> Node.div children
+    | [] ->
+      let v_attrs =
+        let base = [ Style.v; Attr.create "data-kv-value" "" ] in
+        if wrap then Style.v_wrap :: base else base
+      in
+      Node.span ~attrs:v_attrs [ Node.text (Option.value value ~default:"") ]
+  in
+  Node.div ~attrs:row_attrs [ key; value_node ]
+;;

--- a/dashboard_bonsai/src/kv_row.mli
+++ b/dashboard_bonsai/src/kv_row.mli
@@ -1,0 +1,55 @@
+(** KvRow — atomic label/value row primitive (Bonsai mirror of Preact
+    [kv-row.ts], PR #11178 atom 6/14).
+
+    SPEC primitives.css [.kv-row]: a single label / value row with a
+    fixed-width label column, baseline alignment, uppercase muted
+    label, and a mono value in primary fg. Used inside drawer details,
+    inspector panels, keeper-detail KV strips — anywhere a screen
+    says "here are the metadata facts about this thing".
+
+    Distinct from sibling primitives:
+    - [Sep] — visual divider between siblings, no semantic content.
+    - [Pill] / [Chip] — tag-like small badges, value-first.
+    - [Caps] / [Tk] — typographic atoms, single-line text shaping.
+
+    Visual contract = SPEC primitives.css [.kv-row] / [.kv-row.is-wide]
+    selectors + Preact reference [dashboard/src/components/kv-row.ts]. *)
+
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type width =
+  [ `Default (** 80px label column. *)
+  | `Wide (** 120px label column ([.kv-row.is-wide]). *)
+  ]
+
+(** [view ?width ?wrap ?value ?children ?testid ~label ()] renders the
+    row.
+
+    [width] (default [`Default]): see {!type:width}.
+
+    [wrap] (default [false]): allow long values to wrap on word
+    boundaries. SPEC default is whitespace:nowrap with ellipsis
+    overflow; long ids / paths often need wrap.
+
+    [value]: SPEC mono value text. Ignored when [children] is non-empty.
+
+    [children] (default [[]]): rich value content (chips, pills,
+    links). Caller controls typography. When non-empty, [value] is
+    ignored.
+
+    [testid]: forwarded to [data-testid] on the row container.
+
+    [label]: required. Rendered uppercase via the SPEC font rule.
+
+    Renders a [<div data-kv-row>] with [<span data-kv-key>] +
+    value cell. *)
+val view
+  :  ?width:width
+  -> ?wrap:bool
+  -> ?value:string
+  -> ?children:Node.t list
+  -> ?testid:string
+  -> label:string
+  -> unit
+  -> Node.t


### PR DESCRIPTION
## Summary

KvRow (atom 6/14) bonsai mirror — extends the Sep mirror pattern from #11276.

- New module: `dashboard_bonsai/src/kv_row.{ml,mli}` (171 lines)
- API mirrors Preact `dashboard/src/components/kv-row.ts`
- Module-isolated build verified; full bonsai build still has pre-existing keyboard API drift errors (unrelated, tracked under #11285)

## Goals

- Close one more bonsai/Preact atom parity gap so future bonsai islands can share the SPEC vocabulary.
- Land the atom first; call-site swaps follow as separate sweep PRs (same cadence as Sep #11276).

## Files changed

- `dashboard_bonsai/src/kv_row.mli` — public contract:
  ```ocaml
  type width = [ `Default | `Wide ]   (* 80px / 120px label column *)
  val view :
    ?width:width -> ?wrap:bool -> ?value:string -> ?children:Node.t list
    -> ?testid:string -> label:string -> unit -> Node.t
  ```
- `dashboard_bonsai/src/kv_row.ml` — ppx_css stylesheet + impl. Mono fallback stack copied verbatim from Preact `MONO_STACK` so both runtimes resolve identically.

## SPEC mapping (`primitives.css .kv-row`)

| SPEC | bonsai mirror |
|------|---------------|
| `grid-template-columns: 80px 1fr` | `.row` |
| `.is-wide` → `120px 1fr` | `.row_wide` (composed via `width_class`) |
| `gap: var(--sp-3)` (12px) | `gap: 12px` |
| `padding: 4px 0` | same |
| `align-items: baseline` | same |
| `.k` muted/uppercase/0.06em | `.k` |
| `.v` mono fg-primary nowrap+ellipsis | `.v` |
| `wrap` opt-in | `.v_wrap` overlay |

`children` wins over `value` — mirrors the Preact branch where caller-provided rich content (chips/pills/links) controls its own typography.

## Verification

```
OPAMSWITCH=bonsai-dashboard dune build --root .../dashboard_bonsai \
  src/.dashboard_bonsai_lib.objs/byte/dashboard_bonsai_lib__Kv_row.cmi    # OK
  src/.dashboard_bonsai_lib.objs/native/dashboard_bonsai_lib__Kv_row.cmx  # OK
```

Full `dune build --root dashboard_bonsai` not run because pre-existing Vdom keyboard API drift errors (3 callsites in keepers_directory.ml + logs_view.ml — out of this PR's scope) still cascade — this was the state #11285 left behind. CI gate `bonsai-dashboard-if-available` skips when OxCaml switch absent so this does not regress merge readiness for the rest of the repo.

## Test plan

- [x] `Kv_row.cmi` + `Kv_row.cmx` build clean
- [ ] CI required checks green
- [ ] (Future sweep PR) migrate hand-rolled key/value grids in bonsai dashboard files to `KvRow.view`

## Out of scope

- Call-site swaps (separate sweep cadence — Tk/Sep pattern)
- Vdom keyboard API migration (#11285 leftover, design decision pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)