### PR TITLE
refactor(server): collapse sidecar.mli inferred-dump polyvariants to Yojson.Safe.t

### DIFF
--- a/lib/server/server_routes_http_routes_sidecar.mli
+++ b/lib/server/server_routes_http_routes_sidecar.mli
@@ -182,18 +182,10 @@ val desired_state_of_string : string -> desired_state option
 val observed_state_to_string : observed_state -> string
 val reconcile_result_to_string : reconcile_result -> string
 
-val attempt_record_json :
-  attempt_record ->
-  [> `Assoc of (string * [> `Int of int | `Null | `String of string ]) list ]
-val attempt_record_of_json :
-  [> `Assoc of (string * [> `Int of int | `Null | `String of string ]) list ] ->
-  attempt_record option
-val desired_record_json :
-  desired_record ->
-  [> `Assoc of (string * [> `Int of int | `String of string ]) list ]
-val desired_record_of_json :
-  [> `Assoc of (string * [> `Int of int | `String of string ]) list ] ->
-  desired_record option
+val attempt_record_json : attempt_record -> Yojson.Safe.t
+val attempt_record_of_json : Yojson.Safe.t -> attempt_record option
+val desired_record_json : desired_record -> Yojson.Safe.t
+val desired_record_of_json : Yojson.Safe.t -> desired_record option
 
 val sidecar_desired_path : base_path:string -> string -> string
 val sidecar_attempt_path : base_path:string -> string -> string
@@ -220,8 +212,7 @@ val write_desired_record :
 val write_attempt_record :
   base_path:string -> id:string -> attempt_record -> (unit, string) result
 
-val observed_state_of_status_json :
-  [> `Assoc of (string * [> `Bool of bool ]) list ] -> observed_state
+val observed_state_of_status_json : Yojson.Safe.t -> observed_state
 (** Project [status.json] into the reconciler's observed-state. *)
 
 val retry_backoff_seconds : unit -> float
@@ -257,14 +248,14 @@ val reconcile_preview :
 (** Dry-run preview suitable for a dashboard tooltip. *)
 
 val attempt_fields :
-  attempt_record option -> (string * [> `Null | `String of string ]) list
+  attempt_record option -> (string * Yojson.Safe.t) list
 (** Render attempt fields as JSON-friendly assoc list (possibly empty). *)
 
 val lifecycle_json :
   base_path:string ->
   string ->
-  [> `Assoc of (string * [> `Bool of bool ]) list ] ->
-  [> `Assoc of (string * [> `Int of int | `Null | `String of string ]) list ]
+  Yojson.Safe.t ->
+  Yojson.Safe.t
 (** Combined lifecycle JSON: status fields + desired/attempt projection. *)
 
 val append_assoc : 'a -> 'b -> ([> `Assoc of ('a * 'b) list ] as 'c) -> 'c
@@ -279,8 +270,7 @@ val respond_json :
   Httpun.Request.t ->
   Httpun.Reqd.t -> status:Httpun.Status.t -> Yojson.Safe.t -> unit
 val bad_request : Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
-val read_status_json :
-  base_path:string -> string -> [> `Assoc of (string * Yojson.Safe.t) list ]
+val read_status_json : base_path:string -> string -> Yojson.Safe.t
 
 val handle_status :
   Mcp_server.server_state ->


### PR DESCRIPTION
## Why

Same root pattern as #11286 (keeper_schema) and #11290 (coord_agent):
inferred polymorphic variants left in the .mli leak structural
shape into callers. `server_routes_http_routes_sidecar.mli` had 6
such helpers plus their round-trip pairs.

## What

Tightened to `Yojson.Safe.t`:

| function | direction | before |
|---|---|---|
| `attempt_record_json` | output | 3-level open polyvariant |
| `attempt_record_of_json` | input | 3-level open polyvariant |
| `desired_record_json` | output | 2-level open polyvariant |
| `desired_record_of_json` | input | 2-level open polyvariant |
| `observed_state_of_status_json` | input | 2-level open polyvariant |
| `attempt_fields` | element type | open polyvariant in tuple |
| `lifecycle_json` | both | 2-level + 3-level |
| `read_status_json` | output | open polyvariant |

`-10 net lines`. `.ml` unchanged.

## Preserved on purpose

`append_assoc : 'a -> 'b -> ([> \`Assoc of ('a * 'b) list ] as 'c) -> 'c`
— intentional preserve-the-input-shape helper. Kept as-is.

## Caller verification

External callers: `lib/server/server_routes_http.ml` only invokes
`add_routes`. The polyvariant helpers are private to the module's
internal round-trip serialization and the dashboard JSON projection.

## Round-trip guarantee

`attempt_record_json` / `_of_json` and `desired_record_json` /
`_of_json` keep the round-trip property — both sides typed at
`Yojson.Safe.t`, just no longer through structural polyvariants.

## Test plan

- [x] dune build ✓
- [x] structure-ratchet OK
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)