### PR TITLE
feat(dashboard): adopt Ring helper in Bucket B (13 sites, 12 files)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -6,6 +6,7 @@ import { useEffect } from 'preact/hooks'
 import { lazy, Suspense } from 'preact/compat'
 import { signal } from '@preact/signals'
 import { persistentSignal } from './lib/persistent-signal'
+import { ringFocusClasses } from './components/common/ring'
 import { route, initRouter } from './router'
 import {
   connectSSE,
@@ -180,7 +181,7 @@ export function App() {
           <div class="min-w-0 flex items-center gap-3">
             <div class="flex shrink-0 items-center gap-2">
               <button type="button"
-                class="hidden max-[768px]:flex size-9 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-body)] cursor-pointer transition-colors hover:bg-[rgba(255,255,255,0.1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-page)]"
+                class=${`hidden max-[768px]:flex size-9 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-body)] cursor-pointer transition-colors hover:bg-[rgba(255,255,255,0.1)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
                 aria-expanded=${mobileMenuOpen.value}
                 aria-label=${mobileMenuOpen.value ? '탐색 메뉴 닫기' : '탐색 메뉴 열기'}
                 aria-controls="dashboard-side-rail"

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -49,6 +49,7 @@ import { requestConfirm } from './common/confirm-dialog'
 import { showToast } from './common/toast'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
 import { purgeAgent } from '../api/actions'
+import { ringFocusClasses } from './common/ring'
 
 // Re-export public API for external consumers
 export { selectedAgentName, openAgentDetail, closeAgentDetail } from './agent-detail-state'
@@ -283,7 +284,7 @@ export function AgentDetailOverlay() {
                       ? html`<span class="flex items-center gap-1.5">연결된 키퍼:
                           <button
                             type="button"
-                            class="text-text-strong font-semibold hover:text-accent underline underline-offset-2 decoration-dotted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+                            class=${`text-text-strong font-semibold hover:text-accent underline underline-offset-2 decoration-dotted transition-colors ${ringFocusClasses({ tone: 'accent-soft', width: 2 })} rounded`}
                             onClick=${() => { closeAgentDetail(); openKeeperDetail(keeper) }}
                             title="키퍼 상세 페이지 열기"
                             aria-label="${keeper.name} 키퍼 상세 보기"
@@ -320,7 +321,7 @@ export function AgentDetailOverlay() {
             <button
               ref=${closeButtonRef}
               type="button"
-              class="px-4 py-2 text-sm font-semibold rounded border border-transparent bg-[var(--white-10)] text-text-strong hover:bg-[var(--white-20)] transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
+              class=${`px-4 py-2 text-sm font-semibold rounded border border-transparent bg-[var(--white-10)] text-text-strong hover:bg-[var(--white-20)] transition-colors duration-200 shadow-sm ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`}
               onClick=${closeAgentDetail}
             >
               닫기

--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -11,6 +11,7 @@
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
+import { ringFocusClasses } from './ring'
 
 type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'subtle' | 'ok' | 'warn'
 type ButtonSize = 'sm' | 'md' | 'lg'
@@ -45,7 +46,7 @@ const PRESSED_CLASSES: Record<ButtonVariant, string> = {
   warn: 'bg-[var(--warn-24)]',
 }
 
-const BASE = 'rounded cursor-pointer transition-all duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] active:scale-[0.97] active:opacity-90'
+const BASE = `rounded cursor-pointer transition-all duration-200 font-medium ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })} active:scale-[0.97] active:opacity-90`
 
 interface ActionButtonProps {
   variant?: ButtonVariant

--- a/dashboard/src/components/common/checkbox.ts
+++ b/dashboard/src/components/common/checkbox.ts
@@ -11,8 +11,9 @@
 // ended up shipping orphan labels.
 
 import { html } from 'htm/preact'
+import { ringFocusClasses } from './ring'
 
-const CHECKBOX_BASE = 'w-4 h-4 rounded border border-[var(--color-border-default)] bg-[var(--white-4)] cursor-pointer transition-colors hover:bg-[var(--white-8)] hover:border-[var(--white-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] accent-[var(--color-accent-fg)]'
+const CHECKBOX_BASE = `w-4 h-4 rounded border border-[var(--color-border-default)] bg-[var(--white-4)] cursor-pointer transition-colors hover:bg-[var(--white-8)] hover:border-[var(--white-20)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })} accent-[var(--color-accent-fg)]`
 
 interface CheckboxProps {
   checked?: boolean

--- a/dashboard/src/components/common/copy-id-button.ts
+++ b/dashboard/src/components/common/copy-id-button.ts
@@ -5,6 +5,7 @@
 import { html } from 'htm/preact'
 import { Copy, Check } from 'lucide-preact'
 import { useState } from 'preact/hooks'
+import { ringFocusClasses } from './ring'
 import { showToast } from './toast'
 import { copyToClipboard } from './copyable-code'
 
@@ -33,7 +34,7 @@ export function CopyIdButton({ value, label, ariaLabel, size = 12 }: CopyIdButto
   return html`
     <button
       type="button"
-      class="inline-flex shrink-0 cursor-pointer items-center justify-center rounded min-w-6 min-h-6 p-1.5 text-[var(--color-fg-disabled)] opacity-60 transition-all hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)] hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent-30)]"
+      class=${`inline-flex shrink-0 cursor-pointer items-center justify-center rounded min-w-6 min-h-6 p-1.5 text-[var(--color-fg-disabled)] opacity-60 transition-all hover:bg-[var(--white-8)] hover:text-[var(--color-fg-primary)] hover:opacity-100 focus-visible:opacity-100 ${ringFocusClasses({ tone: 'accent-subtle', width: 1 })}`}
       aria-label=${ariaLabel || (label ? `${label} 복사` : '복사')}
       title=${ariaLabel || (label ? `${label} 복사` : '복사')}
       onClick=${onCopy}

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -9,8 +9,9 @@
 // below too.
 
 import { html } from 'htm/preact'
+import { ringFocusClasses } from './ring'
 
-const INPUT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--color-bg-page)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]'
+const INPUT_BASE = `w-full rounded bg-[var(--white-4)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--color-bg-page)] focus-visible:border-[rgba(71,184,255,0.6)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`
 
 interface TextInputProps {
   id?: string

--- a/dashboard/src/components/common/number-input.ts
+++ b/dashboard/src/components/common/number-input.ts
@@ -9,8 +9,9 @@
 // (Pattern mirrors input.ts / button.ts / checkbox.ts.)
 
 import { html } from 'htm/preact'
+import { ringFocusClasses } from './ring'
 
-const INPUT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--color-bg-page)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]'
+const INPUT_BASE = `w-full rounded bg-[var(--white-4)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] placeholder:text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--color-bg-page)] focus-visible:border-[rgba(71,184,255,0.6)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`
 
 interface NumberInputProps {
   value?: number | string

--- a/dashboard/src/components/common/scroll-to-top.ts
+++ b/dashboard/src/components/common/scroll-to-top.ts
@@ -20,6 +20,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { ChevronUp } from 'lucide-preact'
+import { ringFocusClasses } from './ring'
 
 /** Pure: decide whether the button should be visible based on the
     current scroll offset. Threshold matches what Gmail / YouTube
@@ -70,7 +71,7 @@ export function ScrollToTopButton({
 
   return html`<button
     type="button"
-    class=${`fixed bottom-6 right-6 z-[var(--z-overlay-toast,3070)] flex h-10 w-10 items-center justify-center rounded-sm border border-[var(--white-10)] bg-[var(--color-bg-surface)]/90 text-[var(--color-fg-primary)] shadow-[0_6px_18px_rgba(0,0,0,0.32)] backdrop-blur transition-all duration-150 hover:border-[var(--accent-30)] hover:text-[var(--color-accent-fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-page)] cursor-pointer ${cx ?? ''}`}
+    class=${`fixed bottom-6 right-6 z-[var(--z-overlay-toast,3070)] flex h-10 w-10 items-center justify-center rounded-sm border border-[var(--white-10)] bg-[var(--color-bg-surface)]/90 text-[var(--color-fg-primary)] shadow-[0_6px_18px_rgba(0,0,0,0.32)] backdrop-blur transition-all duration-150 hover:border-[var(--accent-30)] hover:text-[var(--color-accent-fg)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })} cursor-pointer ${cx ?? ''}`}
     aria-label="맨 위로"
     title="맨 위로 (Home)"
     data-scroll-to-top

--- a/dashboard/src/components/common/select.ts
+++ b/dashboard/src/components/common/select.ts
@@ -10,8 +10,9 @@
 // (Pattern mirrors input.ts / button.ts / checkbox.ts / number-input.ts.)
 
 import { html } from 'htm/preact'
+import { ringFocusClasses } from './ring'
 
-const SELECT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--color-bg-page)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] appearance-none cursor-pointer'
+const SELECT_BASE = `w-full rounded bg-[var(--white-4)] border border-[var(--color-border-default)] text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--color-bg-page)] focus-visible:border-[rgba(71,184,255,0.6)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })} appearance-none cursor-pointer`
 
 interface SelectOption { value: string; label: string }
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -25,6 +25,7 @@ import { formatElapsedCompact } from '../lib/format-time'
 import { unacknowledgedCount } from './common/error-notification-state'
 import { ErrorPanel } from './common/error-panel'
 import { Bell } from 'lucide-preact'
+import { ringFocusClasses } from './common/ring'
 
 const buildIdentityOpen = signal(false)
 
@@ -226,7 +227,7 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button type="button"
-        class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs text-[var(--color-fg-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--color-fg-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-page)]"
+        class=${`cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs text-[var(--color-fg-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
         aria-expanded=${buildIdentityOpen.value}
         aria-label=${`서버 빌드 정보 ${label}`}
         title=${hoverTitle}
@@ -385,7 +386,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
           </div>
         ` : null}
         <button type="button"
-          class="flex size-7 items-center justify-center rounded text-[var(--color-fg-muted)] cursor-pointer transition-colors duration-200 hover:bg-[var(--white-10)] hover:text-[var(--color-fg-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
+          class=${`flex size-7 items-center justify-center rounded text-[var(--color-fg-muted)] cursor-pointer transition-colors duration-200 hover:bg-[var(--white-10)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`}
           aria-label=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
           onClick=${onToggle}
           title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -36,6 +36,7 @@ import {
 import { OperationalMeaningPanel, HeroPhase, TurnPipelineStrip, CompositeGraphPanel } from './fsm-hub-pipeline-panels'
 import { DwellHistogramPanel, SwimlaneTimeline, TopTransitionsPanel, TransitionTrail } from './fsm-hub-timeline-panels'
 import { MeasurementCard, InvariantsPanel } from './fsm-hub-health-panels'
+import { ringFocusClasses } from './common/ring'
 
 // ── Backward-compatible re-exports ─────────────────────
 // External consumers (agents-unified.ts, fsm-hub.test.ts)
@@ -806,7 +807,7 @@ function StatusBar({
                 role="tab"
                 aria-selected=${active}
                 tabindex=${active ? 0 : -1}
-                class=${`rounded-sm border px-2.5 py-0.5 text-3xs font-mono transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-fg)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-bg-page)] ${cls}`}
+                class=${`rounded-sm border px-2.5 py-0.5 text-3xs font-mono transition-colors cursor-pointer ${ringFocusClasses({ tone: 'accent-fg', width: 2, offset: 1, offsetSurface: 'page' })} ${cls}`}
                 onClick=${() => onSelect(name)}
                 title=${i < 9 ? `${name} — 단축키 ${i + 1}` : name}
                 onKeyDown=${(e: KeyboardEvent) => {

--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -12,6 +12,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { ringFocusClasses } from './common/ring'
 
 type ThemeId = 'paper' | null
 
@@ -56,7 +57,7 @@ export function ThemeSwitch() {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs font-mono uppercase tracking-4 text-[var(--color-fg-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--color-fg-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-page)]"
+      class=${`cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs font-mono uppercase tracking-4 text-[var(--color-fg-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
       aria-label=${TITLE[key]}
       title=${TITLE[key]}
       onClick=${toggleTheme}


### PR DESCRIPTION
## Summary
- multi-permutation focus-ring literal 13 sites를 Ring helper 호출로 swap.
- #11282(helper extension)의 새 tone (accent-medium/soft/subtle/fg) + inset opt 활용.
- 시각 변화 0 — helper output이 raw와 identical 또는 단순 토큰 alias.

## Bucket B 분류
| 패턴 | sites | 파일 |
|---|---|---|
| accent-medium + 2/2/surface | 7 | button/input/number-input/checkbox/select BASE 5 + dashboard-shell:388 + agent-detail:323 |
| accent-medium + 2/2/page | 4 | app:183, theme-switch:59, dashboard-shell:229, scroll-to-top:73 |
| accent-soft + width:2 | 1 | agent-detail:286 (anchor underline focus) |
| accent-subtle + width:1 | 1 | copy-id-button:36 (icon hover focus) |
| accent-fg + 2/1/page | 1 | fsm-hub:809 (tab focus) |

## Out of scope (Bucket C — RFC 후속)
- \`fsm-hub-timeline-panels.ts:223\` — \`focus:outline-none\` + \`focus-visible:ring-inset\` hybrid (helper outline-none prefix와 mismatch)
- \`keeper-detail.ts:881\` — \`ring-offset-[#0d1526]\` hex literal (token 부재)
- \`app.ts:176\` — \`focus:\` (not focus-visible) Skip-to-content link
- \`attribution-panel.ts:137\` — broken syntax + accent-20
- \`keeper-config-panel.ts:436\` — \`focus:\` + accent/50 (helper gap)

## Verification
- [x] \`pnpm tsc --noEmit\`: clean
- [x] \`pnpm vitest run src/components\`: 3335/3337 (2 flaky transient, retry pass — unrelated)
- [x] \`bash scripts/dashboard-drift-check.sh\`: gate OK
- [x] residue: 2 (모두 Bucket C, 의도된 RFC 영역)

## Lint gate (next PR)
sweep 완료 후 raw \`focus-visible:ring-\\[var\\(--accent-(45\\|30)\\)\\]\` 차단 lint pattern을 dashboard-drift-check.sh PATTERNS에 추가하는 follow-up PR. Bucket C RFC 결정 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)