### PR TITLE
ci(lint): add boundary-guard .mli pairing sweep-miss gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
             build=true
           fi
 
-          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|scripts/install\.sh$|scripts/check-eio-conventions\.sh$|scripts/check-feature-flag-consistency\.sh$|scripts/check-toml-syntax\.sh$|scripts/validate-prompt-paths\.sh$|scripts/check-boundary-guard\.sh$|scripts/check-ssot\.sh$|scripts/gen-grpc-descriptors\.sh$|scripts/lint/no-unknown-permissive-default\.sh$|scripts/lint/no-unknown-permissive-default\.allowlist$|scripts/lint/yojson-option-default\.py$|scripts/lint/yojson-option-default\.allowlist$|scripts/ci/)'; then
+          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|scripts/install\.sh$|scripts/check-eio-conventions\.sh$|scripts/check-feature-flag-consistency\.sh$|scripts/check-toml-syntax\.sh$|scripts/validate-prompt-paths\.sh$|scripts/check-boundary-guard\.sh$|scripts/check-boundary-guard-mli-pairs\.sh$|scripts/check-ssot\.sh$|scripts/gen-grpc-descriptors\.sh$|scripts/lint/no-unknown-permissive-default\.sh$|scripts/lint/no-unknown-permissive-default\.allowlist$|scripts/lint/yojson-option-default\.py$|scripts/lint/yojson-option-default\.allowlist$|scripts/ci/)'; then
             lint=true
           fi
 
@@ -565,6 +565,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Run #8605 family detector
         run: bash scripts/lint/no-unknown-permissive-default.sh
@@ -607,6 +609,13 @@ jobs:
         run: |
           chmod +x scripts/check-boundary-guard.sh
           scripts/check-boundary-guard.sh
+
+      - name: Check boundary-guard .mli pairing (sweep-miss gate)
+        env:
+          BASE_REF: origin/${{ github.base_ref || 'main' }}
+        run: |
+          chmod +x scripts/check-boundary-guard-mli-pairs.sh
+          scripts/check-boundary-guard-mli-pairs.sh
 
       - name: Check SSOT bypass ratchet (#8462)
         run: |

--- a/scripts/check-boundary-guard-mli-pairs.sh
+++ b/scripts/check-boundary-guard-mli-pairs.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Boundary-guard .mli pairing lint (diff-driven)
+#
+# Catches the sweep-miss anti-pattern where a refactor PR newly adds a `.mli`
+# whose paired `.ml` is already in a `check_forbidden_outside` allow-list of
+# `scripts/check-boundary-guard.sh`, but the `.mli` was not added alongside.
+# The newly-exposed docstrings then trigger boundary-guard failures on every
+# subsequent PR until the allow-list is updated.
+#
+# Background: PR #11248 split keeper_meta_json_scrub.mli without adding it to
+# the V10 allow-list, blocking the merge queue (PR #11272). See memory
+# `feedback_jane-street-refactor-sweep-miss` (5 occurrences as of 2026-04-27).
+#
+# This gate is diff-driven and only flags .mli files newly added in the PR
+# whose paired .ml is already allow-listed. It does NOT flag historical .mli
+# files that boundary-guard already accepts (those have no forbidden hits).
+#
+# CI usage:
+#   BASE_REF=origin/${{ github.base_ref }} scripts/check-boundary-guard-mli-pairs.sh
+# Local usage (defaults to origin/main):
+#   scripts/check-boundary-guard-mli-pairs.sh
+#
+# Bash-3.2 compatible.
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GUARD="${REPO_ROOT}/scripts/check-boundary-guard.sh"
+BASE_REF="${BASE_REF:-origin/main}"
+
+if [ ! -f "${GUARD}" ]; then
+  echo "PAIR-GATE: ${GUARD} not found" >&2
+  exit 2
+fi
+
+# git diff requires the base ref to exist locally. Tolerate missing ref by
+# falling back to HEAD~1 (single-commit default), and ultimately skipping if
+# we cannot establish a base. CI workflows that need this gate must set
+# fetch-depth: 0 or fetch the base branch explicitly.
+if ! git -C "${REPO_ROOT}" rev-parse --verify --quiet "${BASE_REF}" >/dev/null; then
+  if git -C "${REPO_ROOT}" rev-parse --verify --quiet HEAD~1 >/dev/null; then
+    echo "PAIR-GATE: BASE_REF '${BASE_REF}' not found, falling back to HEAD~1"
+    BASE_REF="HEAD~1"
+  else
+    echo "PAIR-GATE: skipped — cannot resolve BASE_REF '${BASE_REF}'"
+    exit 0
+  fi
+fi
+
+# Collect newly-added .mli files from the PR diff
+new_mli_list=$(git -C "${REPO_ROOT}" diff --name-only --diff-filter=A \
+  "${BASE_REF}...HEAD" -- '*.mli' || true)
+
+if [ -z "${new_mli_list}" ]; then
+  echo "PAIR-GATE: no newly-added .mli files in diff vs ${BASE_REF}"
+  exit 0
+fi
+
+rc=0
+violations=""
+checked_count=0
+
+for mli in ${new_mli_list}; do
+  ml="${mli%.mli}.ml"
+  # Look up the paired .ml in the boundary-guard allow-list. If the paired
+  # .ml is not allow-listed, this gate is silent — boundary-guard itself
+  # handles the case (the .mli either has no forbidden hits, or boundary-guard
+  # will fail with its own message).
+  if grep -F -q "\"${ml}\"" "${GUARD}"; then
+    checked_count=$((checked_count + 1))
+    if ! grep -F -q "\"${mli}\"" "${GUARD}"; then
+      violations="${violations}
+  - newly-added ${mli} is paired with allow-listed ${ml}, but is missing from scripts/check-boundary-guard.sh"
+      rc=1
+    fi
+  fi
+done
+
+if [ "${rc}" -ne 0 ]; then
+  echo "PAIR-GATE FAIL: boundary-guard allow-list missing .mli companion(s)${violations}"
+  echo
+  echo "fix: add the missing .mli path to the same check_forbidden_outside"
+  echo "     block in scripts/check-boundary-guard.sh"
+  echo "ref: feedback_jane-street-refactor-sweep-miss (5+ occurrences)"
+  echo "     PR #11248 → blocked #11272 → fix-forward #11280 / #11283"
+  exit 1
+fi
+
+echo "PAIR-GATE: checked ${checked_count} newly-added .mli vs allow-list — OK"
+exit 0


### PR DESCRIPTION
## Summary
Adds a diff-driven Lint gate that catches the refactor sweep-miss anti-pattern where a PR newly adds a `.mli` whose paired `.ml` is already in a `check_forbidden_outside` allow-list of `scripts/check-boundary-guard.sh`, but the `.mli` was not added alongside.

## Recent occurrence (the bug this prevents)
- PR #11248 split `keeper_meta_json_scrub.mli` without updating the V10 allow-list.
- The V10 docstring `(** ... allowed_providers ... *)` then triggered `V10-provider-filter-ownership — found 1 forbidden match` on every Lint run.
- This blocked PR #11272 (OAS pin bump) and forced two race fix-forwards (#11280, #11283).

Memory `feedback_jane-street-refactor-sweep-miss` records 5 occurrences of this anti-pattern category as of 2026-04-27, including 3 within this single weekend.

## Implementation
- New `scripts/check-boundary-guard-mli-pairs.sh` (bash 3.2 compatible, diff-driven, silent on no-new-mli).
- Scope is intentionally narrow: only flags `.mli` files newly added in the PR diff whose paired `.ml` is already allow-listed. Historical `.mli` files that boundary-guard already accepts are not touched.
- Wired into the Lint job after `check-boundary-guard.sh`. Requires `fetch-depth: 0` on the Lint Checkout step so `git diff origin/main` works.
- Added the new script path to the Lint trigger filter (line 138) so edits to the gate itself rerun Lint.

## Validation
- Clean run on this branch: `PAIR-GATE: no newly-added .mli files in diff vs origin/main`.
- Sim'd the #11248 mechanism on a throwaway branch (added a new .mli + allow-listed only its paired .ml): gate fired with the exact violation message and exit code 1.

```
PAIR-GATE FAIL: boundary-guard allow-list missing .mli companion(s)
  - newly-added lib/keeper/keeper_test_new.mli is paired with allow-listed lib/keeper/keeper_test_new.ml, but is missing from scripts/check-boundary-guard.sh

fix: add the missing .mli path to the same check_forbidden_outside
     block in scripts/check-boundary-guard.sh
ref: feedback_jane-street-refactor-sweep-miss (5+ occurrences)
     PR #11248 → blocked #11272 → fix-forward #11280 / #11283
```

## Test plan
- [ ] CI Lint green (gate runs on this PR but no new .mli, so should pass with "no newly-added .mli files")
- [ ] CI Build green (no source changes)

## Refs
- #11248 (introduced the bug), #11272 (blocked), #11280 / #11283 (fix-forward)
- memory: \`feedback_jane-street-refactor-sweep-miss\`
- memory: \`feedback_required-check-must-include-lint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)