### PR TITLE
feat(dashboard_bonsai): mirror SectionHead atom from Preact (bonsai catch-up)

### DIFF
--- a/dashboard_bonsai/src/section_head.ml
+++ b/dashboard_bonsai/src/section_head.ml
@@ -1,0 +1,139 @@
+(** SectionHead — atomic panel header strip (Bonsai mirror of Preact
+    [section-head.ts]).
+
+    See [section_head.mli] for the public contract.
+
+    SPEC mapping (primitives.css [.section-head]):
+    - min-height 28px, padding 0 12px
+    - border-bottom 1px solid [--color-border-default]
+    - background [--color-bg-surface]
+    - font-size 11px, weight 600, letter-spacing 0.08em, uppercase
+    - color [--color-fg-muted]
+
+    Right slot via [.count] (tabular-nums, fg-disabled) or [.tail]
+    (flex container) — both push to right with [margin-left:auto].
+    [count] is rendered with the same MONO_STACK literal as Preact
+    so both runtimes resolve to the same monospace fallback chain.
+
+    [no_border] uses longhand [border-bottom-{width,style,color}]
+    explicitly — happy-dom (Preact tests) misparses the [border-bottom]
+    shorthand when combined with [var(--token)], splitting the var
+    across all three sub-properties. The Preact reference uses
+    longhand for the same reason; the bonsai mirror keeps the same
+    pattern for byte-exact CSS parity. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 28px;
+    padding: 0 12px;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
+    border-bottom-color: var(--color-border-default);
+    background: var(--color-bg-surface);
+    font-size: var(--fs-11, 11px);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-fg-muted);
+    flex-shrink: 0;
+  }
+
+  .head_no_border {
+    border-bottom-width: 0;
+    border-bottom-style: none;
+    border-bottom-color: transparent;
+  }
+
+  .label {
+    flex-shrink: 0;
+  }
+
+  .count {
+    margin-left: auto;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    color: var(--color-fg-disabled);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* When count is present, tail sits 8px to its right; otherwise
+     tail itself takes the margin-left:auto right-push role. */
+  .tail_with_count {
+    margin-left: 8px;
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+  }
+
+  .tail_no_count {
+    margin-left: auto;
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+  }
+|}]
+
+let view
+      ?count
+      ?tail
+      ?(no_border = false)
+      ?testid
+      ?aria_label
+      ~label
+      ()
+  : Node.t
+  =
+  let host_attrs =
+    let base =
+      if no_border
+      then [ Style.head; Style.head_no_border ]
+      else [ Style.head ]
+    in
+    let with_testid =
+      match testid with
+      | Some id -> Attr.create "data-testid" id :: base
+      | None -> base
+    in
+    match aria_label with
+    | Some s -> Attr.create "aria-label" s :: with_testid
+    | None -> with_testid
+  in
+  let label_node = Node.span ~attrs:[ Style.label ] label in
+  let count_node =
+    match count with
+    | Some s ->
+      Some
+        (Node.span
+           ~attrs:[ Style.count; Attr.create "data-section-head-count" "" ]
+           [ Node.text s ])
+    | None -> None
+  in
+  let tail_node =
+    match tail with
+    | Some children ->
+      let tail_class =
+        match count with
+        | Some _ -> Style.tail_with_count
+        | None -> Style.tail_no_count
+      in
+      Some
+        (Node.span
+           ~attrs:[ tail_class; Attr.create "data-section-head-tail" "" ]
+           children)
+    | None -> None
+  in
+  let body =
+    label_node :: List.filter_opt [ count_node; tail_node ]
+  in
+  Node.div ~attrs:host_attrs body
+;;

--- a/dashboard_bonsai/src/section_head.mli
+++ b/dashboard_bonsai/src/section_head.mli
@@ -1,0 +1,56 @@
+(** SectionHead — atomic panel header strip primitive (Bonsai mirror of
+    Preact [section-head.ts], PR #11176 atom 5/14).
+
+    SPEC primitives.css [.section-head]: 28px panel header strip with
+    uppercase label on the left, optional count or arbitrary tail
+    content right-aligned, and a hairline border-bottom separating the
+    head from the body of a card / panel.
+
+    Distinct from sibling primitives:
+    - [section_cap] (when ported) — pure label *style*, no surface, no
+      flex layout.
+    - [section_header] (when ported) — flex container with heading +
+      right slot, but no border-bottom, no surface, no 28px min-height.
+    - [SectionHead] (this module) — full SPEC: strip surface (bg +
+      border-bottom + min-height + padding) + uppercase label + count
+      / tail right slot.
+
+    Visual contract = SPEC primitives.css [.section-head] selectors +
+    Preact reference [dashboard/src/components/section-head.ts]. *)
+
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+(** [view ?count ?tail ?no_border ?testid ?aria_label ~label ()]
+    renders the header strip.
+
+    [label]: required. Label content (typically text). Rendered
+    uppercase via SPEC font rule. Pass a list of nodes when the label
+    needs inline shaping (icon + text, etc.).
+
+    [count] (optional): right-aligned numeric badge. Rendered with
+    tabular-nums + fg-disabled tone (SPEC [.count]). Pass a pre-
+    formatted string ([Int.to_string n] for integer counts).
+
+    [tail] (optional): right-aligned arbitrary content (Pill, Chip,
+    button row). Compatible with [count]: count renders first, tail
+    after, both inside the same right-flex container.
+
+    [no_border] (default [false]): drop the bottom hairline. Useful
+    when the head sits above a custom divider or another strip.
+
+    [testid]: forwarded to [data-testid] on the host.
+
+    [aria_label]: override the auto aria-label. Default no aria — the
+    heading text is read directly.
+
+    Renders a [<div>] with flex layout. *)
+val view
+  :  ?count:string
+  -> ?tail:Node.t list
+  -> ?no_border:bool
+  -> ?testid:string
+  -> ?aria_label:string
+  -> label:Node.t list
+  -> unit
+  -> Node.t


### PR DESCRIPTION
## Summary

SectionHead (atom 5/14) bonsai mirror — extends the Sep (#11276) / KvRow (#11295) catch-up cadence.

- New module: `dashboard_bonsai/src/section_head.{ml,mli}` (195 lines)
- API mirrors Preact `dashboard/src/components/section-head.ts`
- Module-isolated build verified

## Goals

- Close one more bonsai/Preact atom parity gap so cards in the bonsai island can adopt the SPEC head strip without re-implementing it.
- Land the atom first; call-site swaps follow as separate sweep PRs.

## API

```ocaml
val view :
  ?count:string
  -> ?tail:Node.t list
  -> ?no_border:bool
  -> ?testid:string
  -> ?aria_label:string
  -> label:Node.t list
  -> unit -> Node.t
```

## SPEC mapping (`primitives.css .section-head`)

| SPEC | bonsai mirror |
|------|---------------|
| `min-height: 28px; padding: 0 12px` | `.head` |
| `border-bottom: 1px solid var(--color-border-default)` | longhand `border-bottom-{width,style,color}` (happy-dom shorthand+var bug — see Preact comment) |
| `bg var(--color-bg-surface)` | same |
| `fs 11 / weight 600 / ls 0.08em / uppercase / fg-muted` | same |
| `.count` mono + tabular-nums + fg-disabled, right-push | `.count` |
| `.tail` flex + 4px gap, 8px right of count or auto-margin | `.tail_with_count` / `.tail_no_count` |

Mono stack literal copied verbatim from Preact `MONO_STACK`. The longhand border decomposition mirrors Preact reasoning — the comment in `section-head.ts` notes happy-dom mis-parses the shorthand when combined with `var(--token)`. Keeping the same pattern preserves byte-exact CSS parity.

## Verification

```
OPAMSWITCH=bonsai-dashboard dune build --root .../dashboard_bonsai \
  src/.dashboard_bonsai_lib.objs/native/dashboard_bonsai_lib__Section_head.cmx  # OK
```

Full `dune build --root dashboard_bonsai` still cascades on the pre-existing Vdom keyboard API drift (3 callsites in keepers_directory.ml + logs_view.ml — out of scope here, leftover from #11285). CI gate `bonsai-dashboard-if-available` skips when OxCaml switch absent.

## Test plan

- [x] `Section_head.cmx` builds clean
- [ ] CI required checks green
- [ ] (Future sweep PR) migrate hand-rolled card headers in bonsai dashboard files to `Section_head.view`

## Out of scope

- Call-site swaps (separate sweep PRs)
- Vdom keyboard API migration (#11285 leftover)
- `section_cap` / `section_header` mirrors (later atoms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)