### PR TITLE
feat(dashboard_bonsai): mirror Tk atom from Preact (bonsai catch-up)

### DIFF
--- a/dashboard_bonsai/src/tk.ml
+++ b/dashboard_bonsai/src/tk.ml
@@ -1,0 +1,112 @@
+(** Tk — atomic inline mono highlight (Bonsai mirror of Preact [tk.ts]).
+
+    See [tk.mli] for the public contract.
+
+    SPEC mapping (primitives.css [.tk]):
+    - font-family [--font-mono] (mirrored as the same MONO_STACK
+      literal as Preact, see below)
+    - font-size 0.92em (relative — sits in surrounding prose)
+    - padding 0 4px
+    - border-radius 2px
+    - default → bg [--color-bg-elevated], fg [--color-fg-primary]
+    - [.is-brass] → fg [--color-accent-fg], bg
+      [rgb(var(--color-accent-glow) / 0.08)]
+    - [.is-err] → fg [--color-status-err], bg
+      [rgb(var(--color-status-err-glow) / 0.08)]
+
+    Inline content. Whitespace is forced to nowrap with overflow
+    hidden + ellipsis so a 2KB path inside a row does not blow up
+    layout — same defensive shaping the Preact reference applies. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .tk_base {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 0.92em;
+    padding: 0 4px;
+    border-radius: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: baseline;
+    max-width: 100%;
+  }
+
+  .kind_default {
+    background: var(--color-bg-elevated);
+    color: var(--color-fg-primary);
+  }
+
+  .kind_brass {
+    background: rgb(var(--color-accent-glow) / 0.08);
+    color: var(--color-accent-fg);
+  }
+
+  .kind_err {
+    background: rgb(var(--color-status-err-glow) / 0.08);
+    color: var(--color-status-err);
+  }
+|}]
+
+type kind =
+  [ `Default
+  | `Brass
+  | `Err
+  ]
+
+type tag =
+  [ `Code
+  | `Span
+  ]
+
+let kind_class : kind -> Attr.t = function
+  | `Default -> Style.kind_default
+  | `Brass -> Style.kind_brass
+  | `Err -> Style.kind_err
+;;
+
+let kind_name : kind -> string = function
+  | `Default -> "default"
+  | `Brass -> "brass"
+  | `Err -> "err"
+;;
+
+let tag_name : tag -> string = function
+  | `Code -> "code"
+  | `Span -> "span"
+;;
+
+let view
+      ?(kind = `Default)
+      ?(tag = `Code)
+      ?testid
+      ?title
+      ~children
+      ()
+  : Node.t
+  =
+  let attrs =
+    let base =
+      [ Style.tk_base
+      ; kind_class kind
+      ; Attr.create "data-tk" ""
+      ; Attr.create "data-kind" (kind_name kind)
+      ]
+    in
+    let with_testid =
+      match testid with
+      | Some id -> Attr.create "data-testid" id :: base
+      | None -> base
+    in
+    match title with
+    | Some t -> Attr.create "title" t :: with_testid
+    | None -> with_testid
+  in
+  Node.create (tag_name tag) ~attrs children
+;;

--- a/dashboard_bonsai/src/tk.mli
+++ b/dashboard_bonsai/src/tk.mli
@@ -1,0 +1,53 @@
+(** Tk — atomic inline mono highlight (Bonsai mirror of Preact [tk.ts],
+    PR #11200 atom 9~10/14).
+
+    SPEC primitives.css [.tk]: a small mono-font chunk on a tinted
+    background, used to mark identifier-shaped tokens inside running
+    prose: env var names, file paths, agent ids, error codes, command
+    flags. Reads like inline code in technical writing.
+
+    Distinct from sibling primitives:
+    - [Kbd] — keyboard shortcut indicator (3D key cap).
+    - [Chip] / [Pill] — semantic state labels (Tk has no state).
+    - Block-level command snippets — different layout, not inline.
+
+    Visual contract = SPEC primitives.css [.tk] + [.tk.is-brass] +
+    [.tk.is-err] + Preact reference [dashboard/src/components/tk.ts]. *)
+
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type kind =
+  [ `Default
+  | `Brass (** [.tk.is-brass] — accent fg + 0.08 accent-glow bg. *)
+  | `Err (** [.tk.is-err] — err fg + 0.08 err-glow bg. *)
+  ]
+
+type tag =
+  [ `Code (** Default. Semantic match for inline code fragments. *)
+  | `Span (** Use when nesting inside [<code>] / [<pre>]. *)
+  ]
+
+(** [view ?kind ?tag ?testid ?title ~children ()] renders the inline
+    token highlight.
+
+    [kind] (default [`Default]): tone variant. SPEC has only the three
+    listed tones; warn / info / stalled are not in SPEC for [.tk].
+
+    [tag] (default [`Code]): rendered HTML element. Override to
+    [`Span] when the surrounding context is itself inside [<code>] /
+    [<pre>] and nesting would be invalid.
+
+    [testid]: forwarded to [data-testid].
+
+    [title]: native [title] attribute for hover tooltips. The
+    primitive itself is non-interactive — wrap in a button if click
+    is needed. *)
+val view
+  :  ?kind:kind
+  -> ?tag:tag
+  -> ?testid:string
+  -> ?title:string
+  -> children:Node.t list
+  -> unit
+  -> Node.t


### PR DESCRIPTION
## Summary

Tk (atom 9~10/14) bonsai mirror — extends the Sep (#11276) / KvRow (#11295) / SectionHead (#11299) catch-up cadence.

- New module: `dashboard_bonsai/src/tk.{ml,mli}` (165 lines)
- API mirrors Preact `dashboard/src/components/tk.ts`
- Module-isolated build verified

## API

```ocaml
type kind = [ `Default | `Brass | `Err ]
type tag  = [ `Code | `Span ]

val view :
  ?kind:kind -> ?tag:tag -> ?testid:string -> ?title:string
  -> children:Node.t list -> unit -> Node.t
```

## SPEC mapping (`primitives.css .tk`)

| SPEC | bonsai mirror |
|------|---------------|
| `font-family: var(--font-mono)` | MONO_STACK literal (byte-exact Preact mirror) |
| `font-size: 0.92em` | same (relative — sits in surrounding prose) |
| `padding: 0 4px; border-radius: 2px` | same |
| default bg/fg | `--color-bg-elevated` / `--color-fg-primary` |
| `.is-brass` | `rgb(var(--color-accent-glow) / 0.08)` + `--color-accent-fg` |
| `.is-err` | `rgb(var(--color-status-err-glow) / 0.08)` + `--color-status-err` |
| inline overflow shaping | nowrap + ellipsis + max-width 100% |

`tag` poly-variant lets callers force `<span>` when nesting inside `<code>` / `<pre>` would be invalid HTML — same escape hatch as Preact's `as` prop.

## Verification

```
OPAMSWITCH=bonsai-dashboard dune build --root .../dashboard_bonsai \
  src/.dashboard_bonsai_lib.objs/native/dashboard_bonsai_lib__Tk.cmx  # OK
```

Full `dune build --root dashboard_bonsai` still cascades on pre-existing Vdom keyboard API drift (3 callsites, leftover from #11285 — out of scope).

## Test plan

- [x] `Tk.cmx` builds clean
- [ ] CI required checks green
- [ ] (Future sweep PR) migrate ad-hoc inline `<code>` callsites in bonsai dashboard files to `Tk.view`

## Out of scope

- Call-site swaps (separate sweep PRs)
- Vdom keyboard API migration (#11285 leftover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)