### PR TITLE
refactor(server): collapse dashboard_keeper_api.mli inferred-dump polyvariants to Yojson.Safe.t

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -61,8 +61,7 @@ val merge_keeper_trace_lines :
 (** {1 Tools route} *)
 
 val keeper_tools_response_json :
-  Keeper_types.keeper_meta ->
-  [> `Assoc of (string * Yojson.Safe.t) list ]
+  Keeper_types.keeper_meta -> Yojson.Safe.t
 (** JSON shape returned by [GET /tools]. *)
 
 val handle_keeper_tools_post :
@@ -115,9 +114,7 @@ val continuity_summary_of_messages :
 
 (** {1 Checkpoint inventory} *)
 
-val stat_json_of_path :
-  string ->
-  [> `Assoc of (string * [> `Float of float | `Int of int ]) list | `Null ]
+val stat_json_of_path : string -> Yojson.Safe.t
 (** [stat] result as JSON; [`Null] when the file is missing. *)
 
 val oas_checkpoint_summary_json :
@@ -127,15 +124,7 @@ val oas_checkpoint_summary_json :
   is_current:bool ->
   fallback_generation:int ->
   Oas.Checkpoint.t ->
-  [> `Assoc of
-       (string *
-        [> `Assoc of (string * [> `Float of float | `Int of int ]) list
-         | `Bool of bool
-         | `Float of float
-         | `Int of int
-         | `Null
-         | `String of string ])
-       list ]
+  Yojson.Safe.t
 (** JSON summary of an OAS checkpoint, used by the inventory listing. *)
 
 val keeper_checkpoint_inventory_json :


### PR DESCRIPTION
## Why

Same inferred-dump pattern as #11286 (keeper_schema), #11290
(coord_agent), #11296 (sidecar). Three JSON return types declared
as open polymorphic variants in the .mli, while the .ml just
builds ground-typed Yojson trees.

## What

| function | before | after |
|---|---|---|
| `keeper_tools_response_json` | 1-level Assoc poly | `Yojson.Safe.t` |
| `stat_json_of_path` | \`Assoc | \`Null poly | `Yojson.Safe.t` |
| `oas_checkpoint_summary_json` | 2-level multi-tag poly | `Yojson.Safe.t` |

`-11 net lines`, .ml unchanged.

## Preserved on purpose

`clock:[> float Eio.Time.clock_ty] Eio.Time.clock` — Eio capability
phantom row, structurally-typed resource interface. NOT an inferred
dump. Kept verbatim.

## Caller verification

External callers: `test/test_keeper_masc_bridge.ml` uses
`Yojson.Safe.Util.member` on `keeper_tools_response_json`'s return
— needs ground type. Other two helpers used internally only.

## Test plan

- [x] dune build ✓
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)