### PR TITLE
feat(keeper): emit FSM transition Streaming -> Completing on stop_reason (Step 4d)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2770,6 +2770,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                  Log.Keeper.error
                    "write_meta failed after keeper cycle: %s" msg);
           (* 8. Handle stop reason *)
+          Keeper_turn_fsm.emit_transition
+            ~keeper_name:meta.name ~turn_id:keeper_turn_id
+            ~prev:Keeper_turn_fsm.Streaming
+            Keeper_turn_fsm.Completing;
           (match result.stop_reason with
            | Oas_worker.TurnBudgetExhausted { turns_used; limit } ->
              (* INFO, not WARN: mirrors MutationBoundaryReached below.


### PR DESCRIPTION
## Summary

Closes the last in-cycle gap of the dispatch lane in \`run_keeper_cycle\`. After \`run_turn\` returns and the result reaches the post-dispatch section, the keeper transitions out of the streaming / awaiting-tool loop into the completing phase (persist meta, handle stop_reason, write receipt). This PR emits that transition.

## Site

| line | prev      | turn_state |
|------|-----------|------------|
| 2773 | Streaming | Completing |

Inserted right before the \`(match result.stop_reason with\` block so the emit fires once per dispatched turn — regardless of whether the stop_reason is Completed / TurnBudgetExhausted / MutationBoundaryReached.

## Why

Without this emit \`bin/masc-trace\` for a successful turn (after #11288 lands) reads:

```
[fsm:transition] - -> phase_gating
[fsm:transition] completing -> done
```

with no entry between describing the turn's middle. After this PR:

```
[fsm:transition] - -> phase_gating
[fsm:transition] streaming -> completing
[fsm:transition] completing -> done
```

The \`Completing\` state in \`docs/keeper-turn-lifecycle.md\`'s \`stateDiagram-v2\` is no longer a label that only appears as a \`prev\` on the next line.

## Volume impact

One extra \`Log.Keeper.info\` line per dispatched turn (does NOT fire on the four pre-dispatch silent-skip paths — those already emit at #11269 and never reach this point). At the fleet's ~60-80 turns/min, ~1-2% bump. No control-flow change.

## Stack note

Touches the same function as #11288 (entry / success exit at line 1064 / 2800). Inserts at line 2773 (different region). If the two PRs land in different orders the merge tool should resolve it cleanly; flagged here for reviewer awareness.

## Test plan

- [x] \`dune build\` (default + release) green locally
- [x] \`test_keeper_turn_fsm_emit\` 4/4 OK locally
- [ ] CI lint + meta-guards green
- [ ] Post-merge manual smoke: confirm \`[fsm:transition] streaming -> completing\` appears between entry and done lines for a normal turn

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4d. Cancelled / Failed dispatch exits remain RISKY (Step 5 / 3) and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)