### PR TITLE
refactor(coord): collapse coord_portal.mli inferred-dump polyvariants to Yojson.Safe.t

### DIFF
--- a/lib/coord/coord_portal.mli
+++ b/lib/coord/coord_portal.mli
@@ -1,30 +1,43 @@
-(** coord_portal inferred mli **)
+(** Portal coordination — agent-to-agent (A2A) bridge state.
+
+    Manages [.masc/portals/] lifecycle: opening a portal between two
+    agents, sending messages, and reporting status. *)
 
 open Types
 open Coord_utils
 
-
-
 val portals_dir : Coord_utils_backend_setup.config -> string
 val a2a_tasks_dir : Coord_utils_backend_setup.config -> string
 val gen_a2a_task_id : unit -> string
-val with_two_file_locks : Coord_utils_backend_setup.config ->
-           string -> string -> (unit -> 'a) -> 'a
-val portal_open_r : Coord_utils_backend_setup.config ->
-           agent_name:string ->
-           target_agent:string ->
-           initial_message:string option -> string Types.masc_result
-val portal_send_r : Coord_utils_backend_setup.config ->
-           agent_name:string -> message:string -> string Types.masc_result
-val get_portal_target : Coord_utils_backend_setup.config ->
-           agent_name:string -> string option
-val portal_close : Coord_utils_backend_setup.config -> agent_name:string -> string
-val portal_status : Coord_utils_backend_setup.config ->
-           agent_name:string ->
-           [> `Assoc of
-                (string *
-                 [> `Assoc of
-                      (string * [> `Int of int | `String of string ]) list
-                  | `Int of int
-                  | `String of string ])
-                list ]
+
+val with_two_file_locks :
+  Coord_utils_backend_setup.config ->
+  string -> string -> (unit -> 'a) -> 'a
+
+val portal_open_r :
+  Coord_utils_backend_setup.config ->
+  agent_name:string ->
+  target_agent:string ->
+  initial_message:string option ->
+  string Types.masc_result
+
+val portal_send_r :
+  Coord_utils_backend_setup.config ->
+  agent_name:string ->
+  message:string ->
+  string Types.masc_result
+
+val get_portal_target :
+  Coord_utils_backend_setup.config ->
+  agent_name:string ->
+  string option
+
+val portal_close :
+  Coord_utils_backend_setup.config -> agent_name:string -> string
+
+(** Portal status snapshot as JSON: portal_from / portal_target /
+    portal_status / task_count and friends. *)
+val portal_status :
+  Coord_utils_backend_setup.config ->
+  agent_name:string ->
+  Yojson.Safe.t


### PR DESCRIPTION
## Why

Same inferred-dump pattern as #11286 / #11290 / #11296 / #11303.
The .mli header literally said \`(** coord_portal inferred mli **)\`
and `portal_status` had a 3-level open polyvariant return.

## What

`portal_status` return → `Yojson.Safe.t`. Header replaced with a
real docstring. Nothing else changed.

## Caller verification

- `test/test_room.ml` uses \`\`Assoc _\`\` pattern — accepts either.
- `lib/a2a_tools.ml` / `lib/tool_portal.ml` only reference the
  *string* `"masc_portal_status"` (tool name), not the function.

## Test plan

- [x] dune build ✓
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)