### PR TITLE
[DS-Drift W15] provider palette

### DIFF
--- a/dashboard/design-system/preview/colors.html
+++ b/dashboard/design-system/preview/colors.html
@@ -337,6 +337,55 @@
     </div>
   </section>
 
+  <!-- PROVIDER PALETTE (W15) -->
+  <section class="pv-sect">
+    <div class="pv-sect-h">
+      <h2>Provider Palette (W15)</h2>
+      <span class="sub">LLM provider tints — desaturated, muted. Source: <code>tokens.generated.css</code> <code>--p-anthropic</code> etc.</span>
+    </div>
+    <div class="pv-grid-4">
+      <div class="sw-chip" style="background:var(--p-anthropic); border:none">
+        <div class="sw-top"><span class="sw-name" style="color:var(--color-bg-page)">--p-anthropic</span></div>
+        <div class="sw-role" style="color:var(--color-bg-page)">Anthropic · warm sand</div>
+      </div>
+      <div class="sw-chip" style="background:var(--p-moonshot); border:none">
+        <div class="sw-top"><span class="sw-name" style="color:var(--color-bg-page)">--p-moonshot</span></div>
+        <div class="sw-role" style="color:var(--color-bg-page)">Moonshot · cool indigo</div>
+      </div>
+      <div class="sw-chip" style="background:var(--p-openai); border:none">
+        <div class="sw-top"><span class="sw-name" style="color:var(--color-bg-page)">--p-openai</span></div>
+        <div class="sw-role" style="color:var(--color-bg-page)">OpenAI · muted teal</div>
+      </div>
+      <div class="sw-chip" style="background:var(--p-xai); border:none">
+        <div class="sw-top"><span class="sw-name" style="color:var(--color-bg-page)">--p-xai</span></div>
+        <div class="sw-role" style="color:var(--color-bg-page)">xAI · mauve</div>
+      </div>
+    </div>
+
+    <div class="pv-sect-h" style="margin-top:16px">
+      <h3 style="margin:0; font-size:13px; color:var(--color-fg-muted)">Soft fills (badge backgrounds)</h3>
+      <span class="sub"><code>--p-*-soft</code> — alpha .10 of base</span>
+    </div>
+    <div class="pv-grid-4">
+      <div class="sw-chip" style="background:var(--p-anthropic-soft); border:1px solid var(--p-anthropic-border)">
+        <div class="sw-top"><span class="sw-name" style="color:var(--color-fg-primary)">--p-anthropic-soft</span></div>
+        <div class="sw-role" style="color:var(--color-fg-muted)">+ <code>--p-anthropic-border</code></div>
+      </div>
+      <div class="sw-chip" style="background:var(--p-moonshot-soft); border:1px solid var(--p-moonshot-border)">
+        <div class="sw-top"><span class="sw-name" style="color:var(--color-fg-primary)">--p-moonshot-soft</span></div>
+        <div class="sw-role" style="color:var(--color-fg-muted)">+ <code>--p-moonshot-border</code></div>
+      </div>
+      <div class="sw-chip" style="background:var(--p-openai-soft); border:1px solid var(--p-openai-border)">
+        <div class="sw-top"><span class="sw-name" style="color:var(--color-fg-primary)">--p-openai-soft</span></div>
+        <div class="sw-role" style="color:var(--color-fg-muted)">+ <code>--p-openai-border</code></div>
+      </div>
+      <div class="sw-chip" style="background:var(--p-xai-soft); border:1px solid var(--p-xai-border)">
+        <div class="sw-top"><span class="sw-name" style="color:var(--color-fg-primary)">--p-xai-soft</span></div>
+        <div class="sw-role" style="color:var(--color-fg-muted)">+ <code>--p-xai-border</code></div>
+      </div>
+    </div>
+  </section>
+
   <!-- RULES -->
   <section class="pv-sect">
     <div class="pv-sect-h">


### PR DESCRIPTION
## Summary

Append a **Provider Palette (W15)** section to `dashboard/design-system/preview/colors.html`, exposing the LLM provider palette tokens already defined in `tokens.generated.css` but previously not surfaced in the preview.

- **Plan**: `planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-h-curious-dusk.md`
- **Phase 0 audit**: #11300
- **Scope**: design-system drift remediation, W15 (visualization only)

## What changes

- New section appended after the "Applied — Row States" / before "Usage Rules" card
- Two grids of swatches:
  - **Base palette** (4): `--p-anthropic`, `--p-moonshot`, `--p-openai`, `--p-xai`
  - **Soft fill + border variants** (4): `--p-{provider}-soft` paired with `--p-{provider}-border`
- Provider swatch count: **8** (4 base + 4 soft) — covers every `--p-*` token in `tokens.generated.css`
- `var(--p-*)` references: **8**; foregrounds use `var(--color-bg-page)` / `var(--color-fg-primary)` / `var(--color-fg-muted)`
- **Zero hardcoded hex** in the new section

## Diff stat

```
 dashboard/design-system/preview/colors.html | 49 +++++++++++++++++++++++++++++
 1 file changed, 49 insertions(+)
```

`git diff origin/main -- preview/colors.html` is **append-only**: existing cards untouched.

## Test plan

- [ ] Open `dashboard/design-system/preview/colors.html` in a browser, confirm the Provider Palette section renders with 8 distinct tints (warm sand / cool indigo / muted teal / mauve, plus their .10-alpha soft fills).
- [ ] Verify token names render as labels and match `tokens.generated.css` lines 56-59 (base) and 219-226 (soft/border).
- [ ] Confirm no other section visually regressed.

## Out of scope

- `tokens/source.ts` and other generated outputs are not modified (visualization only).
- No CSS rules in `_preview.css` changed; the new section reuses existing `pv-sect`, `pv-grid-4`, `sw-chip` patterns.