### PR TITLE
refactor(keeper): typed actionable_signal classifier in violation log (#11266 Track 2c Step 6b)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2286,34 +2286,46 @@ let run_turn
            in
            search 0
          in
-         let actionable_signal_context =
+         (* Classify the most-specific actionable signal observed in the
+            prompt body, applying the P1 affordance-tool intersection so
+            keepers without the corresponding action tool degrade to
+            [No_actionable_signal] (cf. [keeper_contract_classifier.mli]
+            precedence: unclaimed > board > discovered).
+
+            The boolean [actionable_signal_context] is derived from the
+            kind for backward compatibility with downstream callers; the
+            kind itself flows into violation log/metric labels so
+            operators can see *which* signal class the LLM failed on
+            (issue #11266 Track 2c, Step 6b caller rewrite). *)
+         let actionable_signal_kind : Keeper_contract_classifier.actionable_signal =
            let haystack = user_message ^ "\n" ^ dynamic_context in
            let has_any_tool tools =
              List.exists (fun t -> List.mem t all_tool_names) tools
            in
-           (* P1 affordance-tool intersection: an actionable signal only
-              counts when the keeper actually has a tool that can act on
-              it.  Without this filter, presets like [social] see
-              "Unclaimed tasks=N" or board activity but lack the
-              corresponding action tools, so [Require_tool_use] becomes
-              unwinnable and the turn fails as [Failure_run_error]. *)
+           if has_positive_count_after_marker haystack "Unclaimed tasks"
+              && has_any_tool
+                   [ "keeper_task_claim"; "masc_claim_next";
+                     "masc_claim_task" ]
+           then Has_unclaimed_tasks
+           else if has_positive_count_after_marker haystack "### Board Activity"
+                   && has_any_tool
+                        [ "keeper_board_post"; "keeper_board_comment";
+                          "masc_broadcast"; "masc_keeper_msg" ]
+           then Has_board_activity
+           else if String_util.contains_substring_ci haystack "## Discovered Work"
+                   && has_any_tool
+                        [ "keeper_task_claim"; "masc_claim_next";
+                          "masc_claim_task";
+                          "keeper_board_post"; "masc_add_task";
+                          "keeper_tasks_audit" ]
+           then Has_discovered_work
+           else No_actionable_signal
+         in
+         let actionable_signal_context =
            Keeper_agent_tool_surface
              .turn_affordances_require_tool_gate_with_allowed
              ~allowed_tool_names:all_tool_names turn_affordances
-           || (String_util.contains_substring_ci haystack "## Discovered Work"
-               && has_any_tool
-                    [ "keeper_task_claim"; "masc_claim_next";
-                      "masc_claim_task";
-                      "keeper_board_post"; "masc_add_task";
-                      "keeper_tasks_audit" ])
-           || (has_positive_count_after_marker haystack "### Board Activity"
-               && has_any_tool
-                    [ "keeper_board_post"; "keeper_board_comment";
-                      "masc_broadcast"; "masc_keeper_msg" ])
-           || (has_positive_count_after_marker haystack "Unclaimed tasks"
-               && has_any_tool
-                    [ "keeper_task_claim"; "masc_claim_next";
-                      "masc_claim_task" ])
+           || Keeper_contract_classifier.is_actionable actionable_signal_kind
          in
          let actionable_tool_contract_violation_reason =
            Keeper_tool_disclosure.actionable_tool_contract_violation_reason
@@ -2403,16 +2415,22 @@ let run_turn
                  ~keeper_name:meta.name
                  ~has_current_task:(keeper_has_owned_active_task ())
                  ~contract_status;
+               let signal_label =
+                 Keeper_contract_classifier.actionable_signal_label
+                   actionable_signal_kind
+               in
                Log.Keeper.error
                  "keeper:%s required tool contract violated \
-                  (turn=%d, tools=%d). Rejecting no-op/passive actionable turn. \
+                  (turn=%d, tools=%d, signal=%s). Rejecting no-op/passive actionable turn. \
                  Reason: %s"
                  meta.name result.turns
                  (List.length actual_keeper_tool_names)
+                 signal_label
                  reason;
                Prometheus.inc_counter
                  Prometheus.metric_keeper_contract_violations
-                 ~labels:[ ("keeper_name", meta.name); ("kind", "passive") ]
+                 ~labels:[ ("keeper_name", meta.name); ("kind", "passive");
+                           ("signal", signal_label) ]
                  ();
                Error (contract_violation_error reason)
            | Ok (), None ->
@@ -2433,16 +2451,21 @@ let run_turn
                  | Keeper_tool_disclosure.Allow_text_or_tool -> "Allow_text_or_tool"
                  | Keeper_tool_disclosure.Require_tool_use -> "Require_tool_use"
                in
+               let signal_label =
+                 Keeper_contract_classifier.actionable_signal_label
+                   actionable_signal_kind
+               in
                Log.Keeper.error
                  "keeper:%s required tool contract violated \
-                  (turn=%d, tools=%d, contract=%s). \
+                  (turn=%d, tools=%d, contract=%s, signal=%s). \
                   Rejecting text-only response. Reason: %s"
                  meta.name result.turns
                  (List.length actual_keeper_tool_names)
-                 contract_str reason;
+                 contract_str signal_label reason;
                Prometheus.inc_counter
                  Prometheus.metric_keeper_contract_violations
-                 ~labels:[ ("keeper_name", meta.name); ("kind", "text_only") ]
+                 ~labels:[ ("keeper_name", meta.name); ("kind", "text_only");
+                           ("signal", signal_label) ]
                  ();
                Error (contract_violation_error reason)
          in

--- a/test/test_keeper_typed_labels.ml
+++ b/test/test_keeper_typed_labels.ml
@@ -152,6 +152,62 @@ let test_actionable_signal_labels_unique () =
   Alcotest.(check (list string))
     "no duplicate actionable_signal labels" [] (duplicates labels)
 
+(* Precedence is documented contract in [keeper_contract_classifier.mli]:
+   unclaimed_tasks > board_activity > discovered_work. The caller in
+   [keeper_agent_run.ml] (issue #11266 Track 2c) relies on this ordering
+   to attribute violation log lines to the strongest available signal. *)
+let test_classify_precedence_unclaimed_dominates_board () =
+  let o : Keeper_contract_classifier.world_observation =
+    { unclaimed_task_count = 1
+    ; board_activity_count = 1
+    ; has_discovered_work_section = true
+    }
+  in
+  match Keeper_contract_classifier.classify_actionable_signal o with
+  | Has_unclaimed_tasks -> ()
+  | other ->
+      Alcotest.failf
+        "expected Has_unclaimed_tasks (highest precedence), got %s"
+        (Keeper_contract_classifier.actionable_signal_label other)
+
+let test_classify_precedence_board_dominates_discovered () =
+  let o : Keeper_contract_classifier.world_observation =
+    { unclaimed_task_count = 0
+    ; board_activity_count = 1
+    ; has_discovered_work_section = true
+    }
+  in
+  match Keeper_contract_classifier.classify_actionable_signal o with
+  | Has_board_activity -> ()
+  | other ->
+      Alcotest.failf
+        "expected Has_board_activity (board > discovered), got %s"
+        (Keeper_contract_classifier.actionable_signal_label other)
+
+let test_classify_no_signal_returns_no_actionable () =
+  let o : Keeper_contract_classifier.world_observation =
+    { unclaimed_task_count = 0
+    ; board_activity_count = 0
+    ; has_discovered_work_section = false
+    }
+  in
+  match Keeper_contract_classifier.classify_actionable_signal o with
+  | No_actionable_signal -> ()
+  | other ->
+      Alcotest.failf
+        "expected No_actionable_signal, got %s"
+        (Keeper_contract_classifier.actionable_signal_label other)
+
+let test_is_actionable_matches_variants () =
+  Alcotest.(check bool) "Has_unclaimed_tasks is actionable" true
+    (Keeper_contract_classifier.is_actionable Has_unclaimed_tasks);
+  Alcotest.(check bool) "Has_board_activity is actionable" true
+    (Keeper_contract_classifier.is_actionable Has_board_activity);
+  Alcotest.(check bool) "Has_discovered_work is actionable" true
+    (Keeper_contract_classifier.is_actionable Has_discovered_work);
+  Alcotest.(check bool) "No_actionable_signal is not actionable" false
+    (Keeper_contract_classifier.is_actionable No_actionable_signal)
+
 (* ── Keeper_contract_classifier.contract_status ──────────────── *)
 
 let all_contract_statuses
@@ -224,6 +280,14 @@ let () =
         [
           Alcotest.test_case "labels unique" `Quick
             test_actionable_signal_labels_unique;
+          Alcotest.test_case "precedence: unclaimed > board" `Quick
+            test_classify_precedence_unclaimed_dominates_board;
+          Alcotest.test_case "precedence: board > discovered" `Quick
+            test_classify_precedence_board_dominates_discovered;
+          Alcotest.test_case "empty observation → No_actionable_signal" `Quick
+            test_classify_no_signal_returns_no_actionable;
+          Alcotest.test_case "is_actionable matches all variants" `Quick
+            test_is_actionable_matches_variants;
         ] );
       ( "contract_status",
         [


### PR DESCRIPTION
## 목표

Issue #11266 Track 2c (Step 6b caller rewrite). 4-way boolean OR-chain 을 typed `Keeper_contract_classifier.actionable_signal` variant 사용으로 교체하고 violation log/metric 에 signal kind 라벨 노출. **LLM behavior 변화 zero, observability 만 강화**.

## 사용자 신호 + 측정 데이터

사용자 보고: "얘들 아무일도 안함." 24h 활동 측정:

| 메트릭 | 값 |
|---|---|
| board posts (24h) | 12 |
| board comments | 10 |
| board votes | 0 |
| **합계 / (14 keeper × 24h)** | **0.065 actions/keeper-hour** |
| contract violations | **8** (janitor 4, taskmaster 2, sangsu 1, verifier 1) |
| violation rate | ~27% of attempted turns |

violation 분석 결과 두 패턴:
- 3건: `tools=0` (verifier 70, janitor 100/101) — LLM 이 텍스트만 응답하고 종료
- 5건: 같은 read tool 반복 (taskmaster `keeper_tasks_list` 12회, janitor `board_list/tasks_audit` 등)

진짜 root: prompt body 에 actionable signal 정보는 있지만 **어떤 action tool 을 써야 하는지 explicit guidance 부재** + 어떤 signal class 가 trigger 됐는지 violation 로그에 미노출 → 우선순위 작업 결정 불가.

## 변경 내용

`lib/keeper/keeper_agent_run.ml:2289-2317`:

```diff
- let actionable_signal_context =
-   ...
-   gate || (Discovered Work + tools)
-       || (Board Activity + tools)
-       || (Unclaimed tasks + tools)
+ let actionable_signal_kind : Keeper_contract_classifier.actionable_signal =
+   if Unclaimed tasks > 0 + tools then Has_unclaimed_tasks
+   else if Board Activity > 0 + tools then Has_board_activity
+   else if Discovered Work + tools then Has_discovered_work
+   else No_actionable_signal
+ in
+ let actionable_signal_context = gate || is_actionable kind
```

violation log 두 사이트에 `signal=<kind>` 추가:

```
keeper:janitor required tool contract violated (turn=99, tools=4, signal=has_unclaimed_tasks). Rejecting...
```

prometheus `metric_keeper_contract_violations` 에 `signal` 라벨 추가.

## 검증

- `dune build @check`: EXIT 0
- `dune test test/test_keeper_typed_labels.exe`: **13/13 OK** (4 신규 precedence/exhaustiveness cases)
- 행동 보존: boolean disjunct 4개 → kind precedence cascade. 동일 입력에 대한 boolean 결과 동일.

## 다음 작업 (이 PR 머지 후)

24h 측정 후 dominant signal kind 확인:
- `Has_unclaimed_tasks` dominant → claim_next prompt hint 우선 추가
- `Has_board_activity` dominant → board_post prompt hint 우선
- `Has_discovered_work` dominant → add_task hint

prompt-level explicit action hint 주입은 별도 PR 에서 (이 PR 의 측정 데이터 확보 후).

## Refs

- Issue #11266 Track 2c (Step 6b caller rewrite)
- `keeper_contract_classifier.mli` (precedence 계약)
- Memory feedback: `feedback_no-string-matching-classification.md`, `feedback_proactive_turn_contract_violation_dominant.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)