### PR TITLE
[DS-Drift W13a] dashboard layout coverage

### DIFF
--- a/dashboard/design-system/preview/index.html
+++ b/dashboard/design-system/preview/index.html
@@ -48,6 +48,7 @@
       <a class="card" href="brand.html"><span class="stripe"></span><span class="n">04</span><span class="title">Brand</span><span class="desc">Wordmark, fleet colors, cascade chain, glyph vocabulary.</span></a>
       <a class="card" href="themes.html"><span class="stripe"></span><span class="n">05</span><span class="title">Themes</span><span class="desc">5-theme matrix entry · paper-theme override side-by-side · Phase 2 token candidates.</span><span class="count">W02 · paper first cut</span></a>
       <a class="card" href="motion.html"><span class="stripe"></span><span class="n">06</span><span class="title">Motion</span><span class="desc">6 motion tokens · 27 keyframes from src/styles/keyframes.css. Hover demos + token×keyframe map.</span></a>
+      <a class="card" href="layout.html"><span class="stripe"></span><span class="n">07 · drift W13a</span><span class="title">Layout</span><span class="desc">dashboard.css layout primitives — collapsible · card grid · board feed · swimlane · scroll chrome.</span><span class="count">production mirror</span></a>
     </div>
 
     <h2>DS-Drift · Phase 1</h2>

--- a/dashboard/design-system/preview/layout.html
+++ b/dashboard/design-system/preview/layout.html
@@ -1,0 +1,682 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>MASC · Dashboard Layout (drift coverage W13a)</title>
+<link rel="stylesheet" href="_preview.css">
+<style>
+  /* ════════════════════════════════════════════════════════════
+     W13a — dashboard.css layout drift coverage.
+     Mirrors production layout primitives from
+     dashboard/src/styles/dashboard.css. Read-only preview;
+     dashboard.css itself is not edited.
+     Token discipline: only var(--*) — no raw hex outside the
+     Phase 2 candidate inventory at the bottom.
+     ══════════════════════════════════════════════════════════ */
+
+  /* Banner / source-of-truth strip */
+  .pv-banner {
+    display: flex; flex-wrap: wrap; gap: 10px 18px;
+    align-items: center;
+    padding: 10px 14px;
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--r-1);
+    font: var(--type-caption);
+    color: var(--color-fg-muted);
+  }
+  .pv-banner code {
+    font-family: var(--font-mono);
+    font-size: var(--fs-10);
+    color: var(--color-fg-secondary);
+  }
+  .pv-banner .lbl {
+    font-weight: 600;
+    letter-spacing: var(--track-caps);
+    text-transform: uppercase;
+    color: var(--color-fg-secondary);
+  }
+
+  /* Card with explicit production line back-pointer */
+  .pv-cell .pv-src {
+    margin-top: auto;
+    padding-top: 8px;
+    border-top: 1px dashed var(--color-border-default);
+    font-family: var(--font-mono);
+    font-size: var(--fs-9);
+    color: var(--color-fg-muted);
+    letter-spacing: var(--track-wide);
+  }
+  .pv-cell .pv-src b { color: var(--color-fg-secondary); font-weight: 600; }
+
+  /* ── Mini cockpit mockup ─────────────────────────────────── */
+  .mini-cockpit {
+    display: grid;
+    grid-template-columns: 180px 1fr 240px;
+    grid-template-rows: 28px 28px 1fr 1fr 36px 18px;
+    gap: 4px;
+    background: var(--color-bg-page);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--r-1);
+    padding: 6px;
+    height: 360px;
+  }
+  .mini-cockpit > div {
+    background: var(--color-bg-panel-alt);
+    border: 1px solid var(--color-border-default);
+    display: flex; align-items: center; justify-content: center;
+    font: 600 var(--fs-9)/1 var(--font-mono);
+    letter-spacing: var(--track-caps);
+    text-transform: uppercase;
+    color: var(--color-fg-muted);
+    padding: 4px;
+    text-align: center;
+    overflow: hidden;
+  }
+  .mini-cockpit .mc-topbar  { grid-column: 1 / -1; grid-row: 1; background: var(--color-bg-surface); color: var(--color-fg-secondary); }
+  .mini-cockpit .mc-section { grid-column: 1 / -1; grid-row: 2; background: var(--color-bg-elevated); color: var(--color-accent-fg); }
+  .mini-cockpit .mc-side    { grid-column: 1; grid-row: 3 / span 2; background: var(--color-bg-surface); }
+  .mini-cockpit .mc-board   { grid-column: 2; grid-row: 3; background: var(--color-bg-page); color: var(--color-fg-secondary); }
+  .mini-cockpit .mc-swim    { grid-column: 2; grid-row: 4; background: var(--color-bg-page); color: var(--color-fg-secondary); }
+  .mini-cockpit .mc-rail    { grid-column: 3; grid-row: 3 / span 2; background: var(--color-bg-surface); }
+  .mini-cockpit .mc-control { grid-column: 1 / -1; grid-row: 5; background: var(--color-bg-elevated); color: var(--color-fg-secondary); }
+  .mini-cockpit .mc-status  { grid-column: 1 / -1; grid-row: 6; background: var(--color-bg-surface); font-size: var(--fs-9); }
+  .mini-cockpit .mc-board::after,
+  .mini-cockpit .mc-swim::after {
+    content: ""; position: absolute;
+  }
+
+  /* Collapsible section demo (mirrors .overview-section-collapsible) */
+  .demo-collapsible > summary {
+    cursor: pointer;
+    padding: 6px 10px;
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--r-1);
+    font: 600 var(--type-label);
+    letter-spacing: var(--track-caps);
+    text-transform: uppercase;
+    color: var(--color-fg-secondary);
+    list-style: none;
+    transition: background 0.15s;
+  }
+  .demo-collapsible > summary:hover { background: var(--color-bg-hover); }
+  .demo-collapsible > summary::before {
+    content: '\25B8';
+    display: inline-block;
+    margin-right: 8px;
+    font-size: var(--fs-10);
+    color: var(--color-fg-muted);
+    transition: transform 0.15s;
+  }
+  .demo-collapsible[open] > summary::before { transform: rotate(90deg); }
+  .demo-collapsible .body {
+    margin-top: 8px;
+    padding: 10px;
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--r-1);
+    background: var(--color-bg-page);
+    color: var(--color-fg-muted);
+    font: var(--type-caption);
+  }
+
+  /* Empty / Loading state slots (mirrors @utility empty-state / loading-state) */
+  .demo-state-slot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 48px 16px;
+    text-align: center;
+    gap: 6px;
+    background: var(--color-bg-page);
+    border: 1px dashed var(--color-border-default);
+    border-radius: var(--r-1);
+    color: var(--color-fg-muted);
+    font: var(--type-caption);
+  }
+  .demo-state-slot.loading { color: var(--color-fg-secondary); font-size: var(--fs-12); }
+
+  /* control-row responsive grid (mirrors .control-row + media query) */
+  .demo-control-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 10px;
+    padding: 10px;
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--r-1);
+  }
+  .demo-control-row > div {
+    height: 36px;
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--r-1);
+    display: flex; align-items: center; justify-content: center;
+    font: 600 var(--fs-10) var(--font-mono);
+    letter-spacing: var(--track-caps);
+    text-transform: uppercase;
+    color: var(--color-fg-muted);
+  }
+  @media (max-width: 880px) {
+    .demo-control-row { grid-template-columns: 1fr; }
+  }
+
+  /* Card-grid hover-lift (mirrors .card:hover + .agent-card:hover) */
+  .demo-card-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+  }
+  .demo-card {
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    padding: 14px;
+    transition:
+      transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+      box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+      border-color 0.25s;
+    display: flex; flex-direction: column; gap: 6px;
+  }
+  .demo-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px var(--color-bg-page);
+    border-color: var(--color-accent-fg-dim);
+  }
+  .demo-card .name {
+    font: 600 var(--type-label);
+    letter-spacing: var(--track-caps);
+    text-transform: uppercase;
+    color: var(--color-fg-secondary);
+  }
+  .demo-card .meta { font: var(--type-micro); color: var(--color-fg-muted); }
+
+  /* Board feed virtualization (mirrors @utility board-post + content-visibility) */
+  .demo-feed {
+    display: flex; flex-direction: column; gap: 8px;
+    max-height: 220px;
+    overflow-y: auto;
+    padding-right: 4px;
+    /* mirrors .custom-scrollbar */
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border-strong) transparent;
+  }
+  .demo-feed::-webkit-scrollbar { width: 6px; height: 6px; }
+  .demo-feed::-webkit-scrollbar-track { background: transparent; }
+  .demo-feed::-webkit-scrollbar-thumb { background: var(--color-border-strong); border-radius: var(--radius-md); }
+  .demo-feed::-webkit-scrollbar-thumb:hover { background: var(--color-accent-fg-dim); }
+  .demo-feed-post {
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--r-1);
+    padding: 10px 12px;
+    background: var(--color-bg-surface);
+    content-visibility: auto;
+    contain-intrinsic-size: auto 80px;
+    transition: border-color 0.2s, transform 0.2s, background 0.2s;
+    display: grid;
+    grid-template-columns: 28px 1fr;
+    gap: 10px;
+    align-items: start;
+  }
+  .demo-feed-post:hover {
+    border-color: var(--color-accent-fg-dim);
+    background: var(--color-bg-elevated);
+    transform: translateY(-1px);
+  }
+  .demo-feed-post .vote {
+    display: flex; flex-direction: column; align-items: center; gap: 2px;
+    font: 600 var(--fs-10) var(--font-mono);
+    color: var(--color-fg-muted);
+  }
+  .demo-feed-post .body p {
+    font: var(--type-caption);
+    color: var(--color-fg-secondary);
+    line-height: var(--lh-body);
+    overflow-wrap: anywhere;
+  }
+  .demo-feed-post .body p + p { margin-top: 6px; }
+  .demo-feed-post .body .head {
+    font: 600 var(--type-label);
+    color: var(--color-fg-primary);
+    letter-spacing: var(--track-caps);
+    text-transform: uppercase;
+    margin-bottom: 4px;
+  }
+
+  /* Swimlane timeline panels (mirrors .swimlane-vis-container) */
+  .demo-swim {
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    grid-template-rows: 1fr 1fr 1fr 18px;
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--r-1);
+    overflow: hidden;
+    background: var(--color-bg-surface);
+    height: 180px;
+  }
+  .demo-swim .label {
+    border-bottom: 1px solid var(--color-border-default);
+    border-right: 1px solid var(--color-border-default);
+    background: var(--color-bg-elevated);
+    display: flex; align-items: center;
+    padding: 0 10px;
+    font: var(--type-caption);
+    color: var(--color-fg-muted);
+  }
+  .demo-swim .label.hl {
+    color: var(--color-accent-fg);
+    background: var(--color-bg-hover);
+  }
+  .demo-swim .lane {
+    border-bottom: 1px solid var(--color-border-default);
+    position: relative;
+    background: var(--color-bg-page);
+  }
+  .demo-swim .lane .item {
+    position: absolute; top: 8px; height: 14px;
+    background: var(--color-accent-fg-dim);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--radius-xs);
+  }
+  .demo-swim .lane .item.sel {
+    background: var(--color-accent-fg);
+    box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .6);
+  }
+  .demo-swim .axis {
+    grid-column: 1 / -1;
+    background: var(--color-bg-elevated);
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 10px;
+    font: var(--type-micro);
+    color: var(--color-fg-muted);
+  }
+
+  /* Phase 2 raw-literal inventory table */
+  .ph2 {
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--r-1);
+    overflow: hidden;
+    font-family: var(--font-mono);
+    font-size: var(--fs-10);
+  }
+  .ph2 .hdr,
+  .ph2 .row {
+    display: grid;
+    grid-template-columns: 90px 200px 1fr;
+    gap: 10px;
+    padding: 8px 12px;
+    align-items: center;
+  }
+  .ph2 .hdr {
+    background: var(--color-bg-elevated);
+    color: var(--color-fg-secondary);
+    font-weight: 600;
+    letter-spacing: var(--track-caps);
+    text-transform: uppercase;
+    border-bottom: 1px solid var(--color-border-default);
+  }
+  .ph2 .row {
+    border-bottom: 1px solid var(--color-border-default);
+    color: var(--color-fg-muted);
+    background: var(--color-bg-surface);
+  }
+  .ph2 .row:last-child { border-bottom: none; }
+  .ph2 .row .lit { color: var(--color-fg-primary); }
+  .ph2 .row .ctx { color: var(--color-fg-secondary); }
+
+  .caption { font: var(--type-caption); color: var(--color-fg-muted); }
+</style>
+</head>
+<body class="masc-ds">
+<div class="pv-root">
+
+  <header class="pv-head">
+    <div class="pv-eyebrow">Drift coverage W13a · dashboard.css layout primitives</div>
+    <h1 class="pv-title">Dashboard layout — production mirror</h1>
+    <p class="pv-sub">
+      Visualization of every layout primitive defined in
+      <code>dashboard/src/styles/dashboard.css</code> (252 lines, layout-only
+      after PR-3915 split). Each card carries a back-pointer to the production
+      line. dashboard.css itself is not edited; this preview is read-only.
+      W13b (responsive.css orphan) is parked pending orphan-triage.
+    </p>
+    <div class="pv-banner" style="margin-top:14px">
+      <span class="lbl">Source</span>
+      <code>dashboard/src/styles/dashboard.css</code>
+      <span class="lbl">Imported by</span>
+      <code>dashboard/src/main.ts:L27</code>
+      <span class="lbl">Cascades after</span>
+      <code>global.css:L26</code>
+    </div>
+  </header>
+
+  <!-- ── 1. Mini cockpit mockup ───────────────────────────────── -->
+  <section class="pv-sect">
+    <div class="pv-sect-h">
+      <h2>Mini cockpit · zone map</h2>
+      <span class="sub">production layout grid at preview scale</span>
+    </div>
+    <div class="pv-cell">
+      <div class="pv-cell-h">
+        <span class="pv-cell-label">cockpit · 3-col grid</span>
+        <span class="pv-cell-meta">sidebar · main · rail · composer · status</span>
+      </div>
+      <div class="mini-cockpit">
+        <div class="mc-topbar">TOPBAR</div>
+        <div class="mc-section">▸ OVERVIEW SECTION (collapsible)</div>
+        <div class="mc-side">SIDEBAR</div>
+        <div class="mc-board">BOARD FEED · scrollable · content-visibility</div>
+        <div class="mc-swim">SWIMLANE · vis-timeline panels</div>
+        <div class="mc-rail">RAIL</div>
+        <div class="mc-control">CONTROL-ROW · 3 cols → 1 col @880px</div>
+        <div class="mc-status">STATUS</div>
+      </div>
+      <p class="caption">
+        Zones map to dashboard.css responsibilities:
+        <b>collapsible header</b> (L8–26),
+        <b>card grid &amp; hover-lift</b> (L74–78, L218–226),
+        <b>board feed virtualization</b> (L86–92),
+        <b>swimlane panels</b> (L152–214),
+        <b>responsive control-row</b> (L70–72).
+      </p>
+      <div class="pv-src">mirrors production <b>dashboard.css:L1–L252</b> (file-level zone composition)</div>
+    </div>
+  </section>
+
+  <!-- ── 2. Collapsible section ───────────────────────────────── -->
+  <section class="pv-sect">
+    <div class="pv-sect-h">
+      <h2>Collapsible section disclosure</h2>
+      <span class="sub">.overview-section-collapsible</span>
+    </div>
+    <div class="pv-grid-2">
+      <div class="pv-cell">
+        <div class="pv-cell-h">
+          <span class="pv-cell-label">closed</span>
+          <span class="pv-cell-meta">▸ rotates 90° on [open]</span>
+        </div>
+        <details class="demo-collapsible">
+          <summary>Crew · 12 keepers</summary>
+          <div class="body">collapsed body (hidden until [open])</div>
+        </details>
+        <div class="pv-src">mirrors production <b>dashboard.css:L8–L26</b></div>
+      </div>
+      <div class="pv-cell">
+        <div class="pv-cell-h">
+          <span class="pv-cell-label">open</span>
+          <span class="pv-cell-meta">summary :hover → bg-4</span>
+        </div>
+        <details class="demo-collapsible" open>
+          <summary>Activity · 87 events</summary>
+          <div class="body">
+            Body content lives inside the &lt;details&gt; box; transition is
+            background 0.15s on summary, transform 0.15s on the ▸ glyph.
+          </div>
+        </details>
+        <div class="pv-src">mirrors production <b>dashboard.css:L24–L26</b> (rotate marker)</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── 3. State slots ────────────────────────────────────────── -->
+  <section class="pv-sect">
+    <div class="pv-sect-h">
+      <h2>Layout state slots</h2>
+      <span class="sub">@utility empty-state · loading-state</span>
+    </div>
+    <div class="pv-grid-2">
+      <div class="pv-cell">
+        <div class="pv-cell-h">
+          <span class="pv-cell-label">empty</span>
+          <span class="pv-cell-meta">padding 48px 16px</span>
+        </div>
+        <div class="demo-state-slot">
+          <span style="font-size:var(--fs-20)">∅</span>
+          <span>No items in this section yet.</span>
+        </div>
+        <div class="pv-src">mirrors production <b>dashboard.css:L50–L57</b></div>
+      </div>
+      <div class="pv-cell">
+        <div class="pv-cell-h">
+          <span class="pv-cell-label">loading</span>
+          <span class="pv-cell-meta">muted fg, fs-sm</span>
+        </div>
+        <div class="demo-state-slot loading">
+          <span>Loading…</span>
+        </div>
+        <div class="pv-src">mirrors production <b>dashboard.css:L60–L67</b></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── 4. control-row responsive ────────────────────────────── -->
+  <section class="pv-sect">
+    <div class="pv-sect-h">
+      <h2>Responsive control row</h2>
+      <span class="sub">.control-row · 3 cols → 1 col @ max-width:880px</span>
+    </div>
+    <div class="pv-cell">
+      <div class="pv-cell-h">
+        <span class="pv-cell-label">control-row</span>
+        <span class="pv-cell-meta">grid-template-columns toggles at 880px</span>
+      </div>
+      <div class="demo-control-row">
+        <div>filter</div>
+        <div>scope</div>
+        <div>action</div>
+      </div>
+      <p class="caption">
+        Resize the viewport below 880px to see the layout fold to a single
+        column. Single breakpoint defined inline in dashboard.css; W13b
+        (responsive.css) holds the broader set.
+      </p>
+      <div class="pv-src">mirrors production <b>dashboard.css:L69–L72</b></div>
+    </div>
+  </section>
+
+  <!-- ── 5. Card grid + hover-lift ────────────────────────────── -->
+  <section class="pv-sect">
+    <div class="pv-sect-h">
+      <h2>Card grid · hover lift</h2>
+      <span class="sub">.card · .agent-card</span>
+    </div>
+    <div class="pv-cell">
+      <div class="pv-cell-h">
+        <span class="pv-cell-label">card · hover</span>
+        <span class="pv-cell-meta">translateY(-2px), border accent</span>
+      </div>
+      <div class="demo-card-grid">
+        <div class="demo-card">
+          <span class="name">nick0cave</span>
+          <span class="meta">running · 12 turns</span>
+        </div>
+        <div class="demo-card">
+          <span class="name">sangsu</span>
+          <span class="meta">idle · 3 turns</span>
+        </div>
+        <div class="demo-card">
+          <span class="name">analyst</span>
+          <span class="meta">listening</span>
+        </div>
+      </div>
+      <p class="caption">
+        Hover any card. Production timing is
+        <code>cubic-bezier(0.4, 0, 0.2, 1)</code> over 0.25s for transform and
+        box-shadow; 0.25s linear for border-color. Same lift used by
+        <code>.agent-card:hover</code> with a tighter shadow.
+      </p>
+      <div class="pv-src">mirrors production <b>dashboard.css:L74–L78</b> (.agent-card) and <b>L218–L226</b> (.card)</div>
+    </div>
+  </section>
+
+  <!-- ── 6. Board feed virtualization ─────────────────────────── -->
+  <section class="pv-sect">
+    <div class="pv-sect-h">
+      <h2>Board feed · scroll virtualization</h2>
+      <span class="sub">@utility board-post · content-visibility:auto</span>
+    </div>
+    <div class="pv-cell">
+      <div class="pv-cell-h">
+        <span class="pv-cell-label">board-post · feed</span>
+        <span class="pv-cell-meta">contain-intrinsic-size auto 120px</span>
+      </div>
+      <div class="demo-feed">
+        <div class="demo-feed-post">
+          <div class="vote">▲<span>12</span>▼</div>
+          <div class="body">
+            <div class="head">cascade-fallback · L3</div>
+            <p>oas_timeout_budget hit on codex_cli during turn 4. spark-only narrow stable.</p>
+          </div>
+        </div>
+        <div class="demo-feed-post">
+          <div class="vote">▲<span>4</span>▼</div>
+          <div class="body">
+            <div class="head">heartbeat · idle</div>
+            <p>nick0cave heartbeat continues; ratio 0.42, no compaction needed.</p>
+          </div>
+        </div>
+        <div class="demo-feed-post">
+          <div class="vote">▲<span>9</span>▼</div>
+          <div class="body">
+            <div class="head">keeper · proactive turn</div>
+            <p>analyst opened a new task: triage W13b orphan responsive.css.</p>
+          </div>
+        </div>
+        <div class="demo-feed-post">
+          <div class="vote">▲<span>2</span>▼</div>
+          <div class="body">
+            <div class="head">broadcast · all</div>
+            <p>fixing dashboard.css drift coverage in worktree feature/ds-drift-w13a.</p>
+          </div>
+        </div>
+        <div class="demo-feed-post">
+          <div class="vote">▲<span>6</span>▼</div>
+          <div class="body">
+            <div class="head">task · claimed</div>
+            <p>governance_judge claimed W13a; ETA 45m, soft heartbeat 5m.</p>
+          </div>
+        </div>
+      </div>
+      <p class="caption">
+        Each post uses <code>content-visibility:auto</code> +
+        <code>contain-intrinsic-size: auto 120px</code> so off-screen rows
+        skip layout/paint. Hover lifts <code>translateY(-1px)</code>. Vote
+        column is intentionally raw-color in production (Phase 2 candidate).
+      </p>
+      <div class="pv-src">
+        mirrors production <b>dashboard.css:L86–L92</b> (board-post),
+        <b>L95–L101</b> (vote-btn), <b>L110–L139</b> (markdown-content overflow)
+      </div>
+    </div>
+  </section>
+
+  <!-- ── 7. Swimlane timeline panels ──────────────────────────── -->
+  <section class="pv-sect">
+    <div class="pv-sect-h">
+      <h2>Swimlane · vis-timeline panels</h2>
+      <span class="sub">.swimlane-vis-container .vis-*</span>
+    </div>
+    <div class="pv-cell">
+      <div class="pv-cell-h">
+        <span class="pv-cell-label">swimlane · zoned</span>
+        <span class="pv-cell-meta">label · lane · time-axis</span>
+      </div>
+      <div class="demo-swim">
+        <div class="label">nick0cave</div>
+        <div class="lane">
+          <div class="item" style="left:12%; width:18%;"></div>
+          <div class="item sel" style="left:42%; width:14%;"></div>
+        </div>
+        <div class="label hl">sangsu</div>
+        <div class="lane">
+          <div class="item" style="left:8%; width:24%;"></div>
+          <div class="item" style="left:60%; width:30%;"></div>
+        </div>
+        <div class="label">analyst</div>
+        <div class="lane">
+          <div class="item" style="left:30%; width:10%;"></div>
+        </div>
+        <div class="axis">
+          <span>−1h</span><span>−30m</span><span>now</span>
+        </div>
+      </div>
+      <p class="caption">
+        Production rules style
+        <code>.vis-panel</code>, <code>.vis-labelset .vis-label</code>,
+        <code>.vis-time-axis .vis-text</code>,
+        <code>.vis-current-time</code>, <code>.vis-tooltip</code>, and the
+        <code>.vis-item.vis-selected</code> ring. Highlighted-group label uses
+        a warm bg ramp (raw rgba in production — Phase 2 candidate).
+      </p>
+      <div class="pv-src">mirrors production <b>dashboard.css:L152–L214</b></div>
+    </div>
+  </section>
+
+  <!-- ── 8. Custom scrollbar ──────────────────────────────────── -->
+  <section class="pv-sect">
+    <div class="pv-sect-h">
+      <h2>Scroll surface chrome</h2>
+      <span class="sub">.custom-scrollbar @ layer utilities</span>
+    </div>
+    <div class="pv-grid-2">
+      <div class="pv-cell">
+        <div class="pv-cell-h">
+          <span class="pv-cell-label">thin scrollbar</span>
+          <span class="pv-cell-meta">6px · webkit + scrollbar-width</span>
+        </div>
+        <div class="demo-feed" style="max-height:140px">
+          <div class="demo-feed-post"><div class="vote">▲<span>1</span>▼</div><div class="body"><p>line one of a long log buffer.</p></div></div>
+          <div class="demo-feed-post"><div class="vote">▲<span>1</span>▼</div><div class="body"><p>line two of a long log buffer.</p></div></div>
+          <div class="demo-feed-post"><div class="vote">▲<span>1</span>▼</div><div class="body"><p>line three of a long log buffer.</p></div></div>
+          <div class="demo-feed-post"><div class="vote">▲<span>1</span>▼</div><div class="body"><p>line four of a long log buffer.</p></div></div>
+          <div class="demo-feed-post"><div class="vote">▲<span>1</span>▼</div><div class="body"><p>line five of a long log buffer.</p></div></div>
+        </div>
+        <div class="pv-src">mirrors production <b>dashboard.css:L229–L252</b></div>
+      </div>
+      <div class="pv-cell">
+        <div class="pv-cell-h">
+          <span class="pv-cell-label">refresh button</span>
+          <span class="pv-cell-meta">@utility logs-refresh-btn :hover</span>
+        </div>
+        <button class="demo-card" style="cursor:pointer; align-self:flex-start; padding:6px 12px; transition: border-color 0.15s">
+          <span class="name">⟳ refresh logs</span>
+          <span class="meta">border-color → accent on hover</span>
+        </button>
+        <div class="pv-src">mirrors production <b>dashboard.css:L80</b> (logs-refresh-btn) · <b>L82</b> (logs-row)</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── 9. Phase 2 candidate inventory ───────────────────────── -->
+  <section class="pv-sect">
+    <div class="pv-sect-h">
+      <h2>Phase 2 candidates · raw literals in dashboard.css</h2>
+      <span class="sub">grep <code>'#[0-9a-f]+'</code> + <code>'rgba\\('</code> — token-ization backlog</span>
+    </div>
+    <div class="ph2">
+      <div class="hdr">
+        <span>line</span><span>literal</span><span>context · token target (proposed)</span>
+      </div>
+      <div class="row"><span>L97</span><span class="lit">#ccc</span><span class="ctx">vote-btn :hover color → <code>--color-fg-secondary</code></span></div>
+      <div class="row"><span>L98</span><span class="lit">#ff4500</span><span class="ctx">upvote active color → new <code>--vote-up-fg</code></span></div>
+      <div class="row"><span>L99</span><span class="lit">#7193ff</span><span class="ctx">downvote active color → new <code>--vote-down-fg</code></span></div>
+      <div class="row"><span>L174</span><span class="lit">rgba(100,116,139,0.12)</span><span class="ctx">vis-label border-bottom → <code>--color-border-default</code></span></div>
+      <div class="row"><span>L179</span><span class="lit">rgba(251,191,36,0.08)</span><span class="ctx">highlighted group bg → new <code>--swim-hl-bg</code></span></div>
+      <div class="row"><span>L191</span><span class="lit">rgba(100,116,139,0.12)</span><span class="ctx">vis-panel border-color → <code>--color-border-default</code></span></div>
+      <div class="row"><span>L199</span><span class="lit">rgba(15,23,42,0.95)</span><span class="ctx">vis-tooltip background → <code>--color-bg-elevated</code></span></div>
+      <div class="row"><span>L200</span><span class="lit">rgba(100,116,139,0.3)</span><span class="ctx">vis-tooltip border → <code>--color-border-strong</code></span></div>
+      <div class="row"><span>L205</span><span class="lit">rgba(0,0,0,0.1)</span><span class="ctx">vis-tooltip box-shadow → <code>--shadow-tooltip</code> (new)</span></div>
+      <div class="row"><span>L212</span><span class="lit">rgba(251,191,36,0.5)</span><span class="ctx">vis-item selected glow → <code>--color-accent-glow</code></span></div>
+      <div class="row"><span>L224</span><span class="lit">rgba(71,184,255,0.08)</span><span class="ctx">card :hover blue glow tint → new <code>--card-hover-glow</code></span></div>
+      <div class="row"><span>L226</span><span class="lit">rgba(71,184,255,0.25)</span><span class="ctx">card :hover border tint → new <code>--card-hover-border</code></span></div>
+    </div>
+    <p class="caption" style="margin-top:8px">
+      12 raw literals total. Phase 2 will token-ize these in a separate PR;
+      W13a is preview-only (append-new-file).
+    </p>
+  </section>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

W13a of the design-system ↔ production CSS drift workstream — the **non-orphan half** of W13. Adds a single new preview file `dashboard/design-system/preview/layout.html` that mirrors every layout primitive defined in `dashboard/src/styles/dashboard.css` (252 lines, layout-only after the PR-3915 split).

W13b (responsive.css, orphan) is intentionally **deferred pending orphan-triage** — that file is not currently imported in production (verified during Phase 0 audit) so coverage there is blocked on a triage decision (delete vs wire-up vs preview-only).

**Plan**: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-h-curious-dusk.md`
**Phase 0 audit**: #11300
**W12 ref pattern**: #11314 (ui core primitives)

## What ships

A single new file: `dashboard/design-system/preview/layout.html` (+682 lines), plus a 1-line nav entry in `preview/index.html` (Foundations · Layout, slot 05).

| Section | Production primitive | Source pointer |
|---|---|---|
| Mini cockpit zone map | full layout grid composition | dashboard.css:L1–L252 |
| Collapsible section disclosure | `.overview-section-collapsible` + `▸` rotation | dashboard.css:L8–L26 |
| Empty / loading state slots | `@utility empty-state` · `@utility loading-state` | dashboard.css:L50–L67 |
| Responsive control-row | `.control-row` · 3 → 1 col @ 880px | dashboard.css:L69–L72 |
| Card grid · hover-lift | `.card` · `.agent-card` hover | dashboard.css:L74–L78, L218–L226 |
| Board feed virtualization | `@utility board-post` · `content-visibility:auto` | dashboard.css:L86–L92, L95–L101, L110–L139 |
| Swimlane vis-timeline panels | `.swimlane-vis-container .vis-*` | dashboard.css:L152–L214 |
| Custom scrollbar · refresh button | `.custom-scrollbar` · `@utility logs-refresh-btn` | dashboard.css:L80, L82, L229–L252 |
| Phase 2 inventory | 12 raw color literals (hex + rgba) still in dashboard.css | line-anchored table |

Every card carries an explicit `mirrors production dashboard.css:L<n>` back-pointer, and the page header banner records the import location (`main.ts:L27`) and cascade order (after `global.css:L26`).

## Mini cockpit mockup

The first section renders an 8-zone grid (Topbar · Section header · Sidebar · Board feed · Swimlane · Rail · Control row · Status) at preview scale, using the production cockpit shape so the layout reader can see how every primitive composes. Zone dividers are visible because each `.mini-cockpit > div` carries a 1px border in `var(--color-border-default)`.

## Measurements (acceptance criteria)

| Criterion | Required | Actual |
|---|---|---|
| Diff is append-only on preview/ | yes | new file + 1-line nav entry |
| Production line pointers in comments | ≥ 5 | **11** |
| `var(--*)` usages in preview/layout.html | ≥ 12 | **135** |
| Raw hex outside Phase 2 inventory | 0 | **0** (3 hits all inside `class="lit"` cells) |
| Source-of-truth files modified | 0 | dashboard.css, tokens.generated.css, source.ts, main.ts untouched |
| Phase 2 candidate inventory rows | n/a | **12** (line-anchored to L97/L98/L99/L174/L179/L191/L199/L200/L205/L212/L224/L226) |

```
$ git diff --stat origin/main
 dashboard/design-system/preview/index.html  |   1 +
 dashboard/design-system/preview/layout.html | 682 ++++++++++++++++++++++++++++
 2 files changed, 683 insertions(+)
```

## Out of scope

- **W13b (responsive.css)** — orphan-triage pending. Will be a separate PR once the triage decision lands.
- **No edits** to `dashboard/src/styles/dashboard.css`, `tokens.generated.css`, `source.ts`, or any other source-of-truth file.
- **Phase 2 token-ization** of the 12 inventoried raw literals is intentionally a separate PR.
- No restructuring of pre-existing preview pages; only an additive nav entry.

## Test plan

- [ ] Open `dashboard/design-system/preview/layout.html` in a browser at the design-system preview URL; confirm all 8 sections render against `tokens.generated.css` only.
- [ ] Confirm the mini cockpit shows visible zone dividers (sidebar/main/rail/composer/status).
- [ ] Confirm the Phase 2 inventory table lists 12 line-anchored raw literals.
- [ ] Confirm the Foundations group on `preview/index.html` shows a new "Layout" card (slot 05).
- [ ] Confirm responsive control-row folds to 1 column when viewport ≤ 880px.