### PR TITLE
refactor(coord): sweep 4 inferred-dump coord_*.mli — Yojson + variant alias normalization

### DIFF
--- a/lib/coord/coord_init.mli
+++ b/lib/coord/coord_init.mli
@@ -1,15 +1,29 @@
-(** coord_init inferred mli **)
+(** Coord init / pause / resume / reset.
+
+    Boot-time room state initialisation, pause/resume gating for
+    agent claims, and a destructive [reset] hook used by the
+    [masc_reset] tool. *)
 
 open Types
 open Coord_utils
 open Coord_state
 open Coord_broadcast
 
+(** Initialise room state; auto-joins [agent_name] when given. *)
+val init :
+  Coord_utils_backend_setup.config -> agent_name:'a option -> string
 
+(** Mark the room as paused with metadata for [pause_info]. *)
+val pause :
+  Coord_utils_backend_setup.config ->
+  by:string -> reason:string -> unit
 
-val init : Coord_utils_backend_setup.config -> agent_name:'a option -> string
-val pause : Coord_utils_backend_setup.config ->
-           by:string -> reason:string -> unit
-val resume : Coord_utils_backend_setup.config ->
-           by:string -> [> `Already_running | `Resumed ]
+(** Clear an active pause. [`Already_running] when no pause was
+    set, [`Resumed] otherwise. *)
+val resume :
+  Coord_utils_backend_setup.config ->
+  by:string -> [> `Already_running | `Resumed ]
+
+(** Destructive reset of the room state — primarily for the
+    [masc_reset] tool. *)
 val reset : Coord_utils_backend_setup.config -> string

--- a/lib/coord/coord_lifecycle.mli
+++ b/lib/coord/coord_lifecycle.mli
@@ -1,24 +1,30 @@
-(** coord_lifecycle inferred mli **)
+(** Coord lifecycle — agent join / leave and registry parse-error
+    diagnostics. *)
 
 open Types
 open Coord_utils
 open Coord_state
 open Coord_broadcast
 
+(** JSON snapshot used when an agent file fails to parse — surfaces
+    [agent_name], [agent_file], and a short error message. *)
+val agent_parse_error_snapshot :
+  agent_name:string -> agent_file:string -> Yojson.Safe.t
 
+val join :
+  Coord_utils_backend_setup.config ->
+  agent_name:string ->
+  ?agent_type_override:string option ->
+  capabilities:string list ->
+  ?pid:int option ->
+  ?hostname:string option ->
+  ?tty:string option ->
+  ?worktree:string option ->
+  ?parent_task:string option ->
+  ?keeper_name:string option ->
+  ?keeper_id:string option ->
+  unit ->
+  string
 
-val agent_parse_error_snapshot : agent_name:string ->
-           agent_file:string ->
-           [> `Assoc of (string * [> `Null | `String of string ]) list ]
-val join : Coord_utils_backend_setup.config ->
-           agent_name:string ->
-           ?agent_type_override:string option ->
-           capabilities:string list ->
-           ?pid:int option ->
-           ?hostname:string option ->
-           ?tty:string option ->
-           ?worktree:string option ->
-           ?parent_task:string option ->
-           ?keeper_name:string option ->
-           ?keeper_id:string option -> unit -> string
-val leave : Coord_utils_backend_setup.config -> agent_name:string -> string
+val leave :
+  Coord_utils_backend_setup.config -> agent_name:string -> string

--- a/lib/coord/coord_state.mli
+++ b/lib/coord/coord_state.mli
@@ -1,39 +1,67 @@
-(** coord_state inferred mli **)
+(** Coord state — backlog, room state, and recovery helpers. *)
 
 open Types
 open Coord_utils
 
+val default_room_state :
+  Coord_utils_backend_setup.config -> Types_core.room_state
 
-
-val default_room_state : Coord_utils_backend_setup.config -> Types_core.room_state
 val ensure_room_bootstrap : Coord_utils_backend_setup.config -> unit
 val generate_session_id : unit -> string
 val get_hostname : unit -> string option
 val get_tty : unit -> string option
-val resolve_agent_name : Coord_utils_backend_setup.config -> string -> string
+
+val resolve_agent_name :
+  Coord_utils_backend_setup.config -> string -> string
+
 val task_id_to_int : string -> int option
+
 val read_archive_task_ids : Coord_utils_backend_setup.config -> int list
-val append_archive_tasks : Coord_utils_backend_setup.config -> Types_core.task list -> unit
-val next_task_number : Coord_utils_backend_setup.config -> Types_core.backlog -> int
-val read_backlog_r : Coord_utils_backend_setup.config ->
-           (Types_core.backlog, string) result
+
+val append_archive_tasks :
+  Coord_utils_backend_setup.config -> Types_core.task list -> unit
+
+val next_task_number :
+  Coord_utils_backend_setup.config -> Types_core.backlog -> int
+
+val read_backlog_r :
+  Coord_utils_backend_setup.config ->
+  (Types_core.backlog, string) result
+
 val read_backlog : Coord_utils_backend_setup.config -> Types_core.backlog
-val write_backlog : Coord_utils_backend_setup.config -> Types_core.backlog -> unit
+
+val write_backlog :
+  Coord_utils_backend_setup.config -> Types_core.backlog -> unit
+
 val non_empty_string_opt : string option -> string option
 val normalized_string_list : string list -> string list
-val recover_active_agent_name : [> `Assoc of (string * Yojson.Safe.t) list | `String of string ] ->
-           string option
-val recover_room_state : Coord_utils_backend_setup.config ->
-           Yojson.Safe.t -> Types_core.room_state
-val write_state : Coord_utils_backend_setup.config -> Types_core.room_state -> unit
+
+(** Project a JSON entry of the [active_agents] array to the agent
+    name it identifies, accepting either a bare [`String name] or
+    an object with a [name]/[agent_name] field. *)
+val recover_active_agent_name : Yojson.Safe.t -> string option
+
+val recover_room_state :
+  Coord_utils_backend_setup.config ->
+  Yojson.Safe.t -> Types_core.room_state
+
+val write_state :
+  Coord_utils_backend_setup.config -> Types_core.room_state -> unit
+
 val read_state : Coord_utils_backend_setup.config -> Types_core.room_state
-val update_state : Coord_utils_backend_setup.config ->
-           (Types_core.room_state -> Types_core.room_state) ->
-           Types_core.room_state
+
+val update_state :
+  Coord_utils_backend_setup.config ->
+  (Types_core.room_state -> Types_core.room_state) ->
+  Types_core.room_state
+
 val next_seq : Coord_utils_backend_setup.config -> int
 val is_paused : Coord_utils_backend_setup.config -> bool
-val pause_info : Coord_utils_backend_setup.config ->
-           (string option * string option * string option) option
+
+val pause_info :
+  Coord_utils_backend_setup.config ->
+  (string option * string option * string option) option
+
 val heartbeat_timeout_seconds : float
 val parse_iso_time_opt : string -> float option
 val parse_iso_time : string -> float

--- a/lib/coord/coord_task_schedule.mli
+++ b/lib/coord/coord_task_schedule.mli
@@ -1,9 +1,12 @@
-(** coord_task_schedule inferred mli **)
+(** Coord task scheduling — claim pool gating, verification block
+    state, and the [claim_next] / [release_stale_claims] entries. *)
 
 open Types
 include module type of Coord_utils
 include module type of Coord_state
 
+(** Lifecycle state of a verification request, used by the claim
+    gate to decide whether a task can be reclaimed. *)
 type verification_claim_state =
   [ `Pending | `Assigned | `Passed | `Rejected ]
 
@@ -11,40 +14,69 @@ val task_status_label : Types_core.task_status -> string
 val task_is_claim_pool_candidate : Types_core.task -> bool
 val task_is_primary_claim_pool_candidate : Types_core.task -> bool
 val task_is_soft_reclaim_candidate : Types_core.task -> bool
-val verification_claim_state_of_status : Coord_verification_store.request_status ->
-           [> `Assigned | `Passed | `Pending | `Rejected ]
-val latest_verification_status_by_task : config ->
-           (string, float * [> `Assigned | `Passed | `Pending | `Rejected ])
-           Hashtbl.t
-val verification_blocks_claim : (string, 'a * [< `Assigned | `Passed | `Pending | `Rejected ])
-           Hashtbl.t -> Types_core.task -> bool
+
+val verification_claim_state_of_status :
+  Coord_verification_store.request_status -> verification_claim_state
+
+val latest_verification_status_by_task :
+  config -> (string, float * verification_claim_state) Hashtbl.t
+
+val verification_blocks_claim :
+  (string, 'a * verification_claim_state) Hashtbl.t ->
+  Types_core.task -> bool
+
 val task_required_tools : Types_core.task -> string list
 val string_list_contains : string list -> string -> bool
-val required_tools_allowed : ?agent_tool_names:string list -> string list -> bool
+
+val required_tools_allowed :
+  ?agent_tool_names:string list -> string list -> bool
+
 val underscore_name : string -> string
 val hyphen_name : string -> string
 val keeper_name_from_agent_name : string -> string option
-val agent_record_keeper_name : config -> agent_name:string -> string option
-val keeper_receipt_candidate_names : config -> agent_name:string -> string list
+
+val agent_record_keeper_name :
+  config -> agent_name:string -> string option
+
+val keeper_receipt_candidate_names :
+  config -> agent_name:string -> string list
+
 val directory_exists : string -> bool
 val directory_entries : string -> string list
 val jsonl_files_under : string -> string list
 val last_nonempty_line : string -> string option
+
 val latest_json_in_receipt_dir : string -> Yojson.Safe.t option
+
 val json_member_path : string list -> Yojson.Safe.t -> Yojson.Safe.t
 val json_raw_string_path : string list -> Yojson.Safe.t -> string option
 val json_string_path : string list -> Yojson.Safe.t -> string option
 val receipt_sort_key : Yojson.Safe.t -> string
-val latest_execution_receipt_json : config -> agent_name:string -> Yojson.Safe.t option
+
+val latest_execution_receipt_json :
+  config -> agent_name:string -> Yojson.Safe.t option
+
 val json_string_list : string -> Yojson.Safe.t -> string list
-val latest_receipt_blocks_required_tool_claim : config -> agent_name:string -> required_tools:string list -> bool
-val agent_current_task_matches_backlog : Types_core.backlog -> agent_name:string -> string -> bool
-val reconcile_agent_current_task_with_backlog : config -> agent_name:string -> Types_core.backlog -> unit
-val claim_next_r : config ->
-           agent_name:string ->
-           ?agent_tool_names:string list ->
-           ?exclude_task_ids:string list ->
-           ?task_filter:(Types_core.task -> bool) ->
-           unit -> Types_core.claim_next_result
+
+val latest_receipt_blocks_required_tool_claim :
+  config -> agent_name:string -> required_tools:string list -> bool
+
+val agent_current_task_matches_backlog :
+  Types_core.backlog -> agent_name:string -> string -> bool
+
+val reconcile_agent_current_task_with_backlog :
+  config -> agent_name:string -> Types_core.backlog -> unit
+
+val claim_next_r :
+  config ->
+  agent_name:string ->
+  ?agent_tool_names:string list ->
+  ?exclude_task_ids:string list ->
+  ?task_filter:(Types_core.task -> bool) ->
+  unit ->
+  Types_core.claim_next_result
+
 val claim_next : config -> agent_name:string -> string
-val release_stale_claims : config -> ttl_seconds:float -> (string * string) list
+
+val release_stale_claims :
+  config -> ttl_seconds:float -> (string * string) list


### PR DESCRIPTION
## Why

5th PR in the inferred-dump cleanup series (after #11286 keeper_schema,
#11290 coord_agent, #11296 sidecar, #11303 dashboard_keeper_api, #11309
coord_portal). Sweeps the remaining `\`(** X inferred mli **)\`` headers
under `lib/coord/`.

## What

| file | change |
|---|---|
| `coord_init.mli` | header → docstring; `resume`'s \`[> \\\`Already_running | \\\`Resumed]\` kept (intentional API enum) |
| `coord_lifecycle.mli` | header + `agent_parse_error_snapshot` return → `Yojson.Safe.t` |
| `coord_state.mli` | header + `recover_active_agent_name` input → `Yojson.Safe.t` |
| `coord_task_schedule.mli` | header + 3 signatures normalized to use the existing `verification_claim_state` alias |

## The interesting one — verification_claim_state

`coord_task_schedule.mli` already declared:

\`\`\`ocaml
type verification_claim_state =
  [ \`Pending | \`Assigned | \`Passed | \`Rejected ]
\`\`\`

…but three downstream signatures restated the polyvariant inline,
so a `Hashtbl` produced by `latest_verification_status_by_task`
could not be passed directly to `verification_blocks_claim` without
manually pinning the row. Aliasing all three through
`verification_claim_state` makes the trio self-consistent.

## Excluded on purpose

- `coord_worktree.mli` — real docstring already, and
  \`[> \\\`Directory | \\\`File | \\\`Missing]\` is an intentional API enum.
- `coord_utils_backend_setup.mli` — Eio capability phantom rows
  (\`[> \\\`Generic | \\\`Unix] Eio.Net.ty\`) are the standard
  structurally-typed Eio resource interface.

## Surgical guarantees

- All .ml files unchanged.
- Zero external callers for any touched signature (`rg` over
  lib/ test/ bin/ — empty result outside coord_*).

## Test plan

- [x] dune build ✓
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)