### PR TITLE
feat(keeper): add Keeper_cwd_response audience-tagged cwd module

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -457,6 +457,7 @@
    keeper_memory_recall
    keeper_skill_routing
    keeper_sandbox
+   keeper_cwd_response
    keeper_sandbox_control
    keeper_repo_readiness
    keeper_alerting

--- a/lib/keeper/keeper_cwd_response.ml
+++ b/lib/keeper/keeper_cwd_response.ml
@@ -1,0 +1,25 @@
+type t =
+  | Local of { abs : string }
+  | Sandboxed of { host_abs : string; container_abs : string }
+
+let local ~host_cwd = Local { abs = host_cwd }
+
+let docker ~host_cwd ~container_cwd =
+  Sandboxed { host_abs = host_cwd; container_abs = container_cwd }
+
+let of_sandbox ~(sandbox : Keeper_sandbox.t) ~host_cwd
+    ~container_cwd_for_docker =
+  match sandbox.backend with
+  | Keeper_sandbox.Local -> local ~host_cwd
+  | Keeper_sandbox.Docker ->
+    docker ~host_cwd ~container_cwd:container_cwd_for_docker
+
+let keeper_visible = function
+  | Local { abs } -> abs
+  | Sandboxed { container_abs; _ } -> container_abs
+
+let operator_host = function
+  | Local { abs } -> abs
+  | Sandboxed { host_abs; _ } -> host_abs
+
+let to_yojson_response t = `String (keeper_visible t)

--- a/lib/keeper/keeper_cwd_response.mli
+++ b/lib/keeper/keeper_cwd_response.mli
@@ -1,0 +1,88 @@
+(** Audience-tagged cwd value for keeper shell tool responses.
+
+    Tool responses sent back to the keeper LLM must surface a cwd
+    the LLM can actually [cd] into. For Local-backend keepers this
+    is the host abs path; for Docker-backend keepers it is the
+    in-container path under {!Keeper_sandbox.container_root}.
+
+    Operator-facing diagnostics ([Log.Keeper.*],
+    [.masc/logs/system_log_*.jsonl], dashboard log ring) keep the
+    host-side path because operators ssh into the host filesystem.
+
+    Construction is restricted to two named smart constructors so
+    that no caller can accidentally produce a [Sandboxed] value
+    without also having computed the container counterpart. The
+    serializer {!to_yojson_response} never emits the [host_abs]
+    side of [Sandboxed] (fail-closed): the host path can leave
+    the module only via {!operator_host}, which the caller must
+    invoke explicitly.
+
+    Background: PR #11080 removed [sandbox_host_root] and
+    [playground_path] from [keeper_status_detail]'s
+    [execution_context], but sibling [cwd] fields in
+    [keeper_shell_docker] and [keeper_exec_shell] response
+    builders still echoed the host abs path. The Docker
+    [--workdir] argument was correctly translated via
+    [Keeper_shell_docker.docker_private_workspace_cwd], yet the
+    same translation was not propagated to the response JSON.
+    The LLM then re-emitted [cd /Users/...] on the next turn,
+    which fails inside the container. *)
+
+(** {1 Type} *)
+
+type t = private
+  | Local of { abs : string }
+  | Sandboxed of { host_abs : string; container_abs : string }
+
+(** {1 Smart constructors} *)
+
+(** [local ~host_cwd] is the cwd response for a Local-backend
+    keeper. The host abs path is also what the keeper LLM sees,
+    because Local keepers run directly against the host
+    filesystem. *)
+val local : host_cwd:string -> t
+
+(** [docker ~host_cwd ~container_cwd] is the cwd response for a
+    Docker-backend keeper.
+
+    [container_cwd] is the in-container path the LLM should see
+    in tool responses; [host_cwd] is retained only so operator
+    logs can surface the host-side location.
+
+    Callers typically compute [container_cwd] via
+    [Keeper_shell_docker.docker_private_workspace_cwd] for the
+    docker [--workdir] argument and pass the same value here so
+    the response and the actual exec environment stay in sync. *)
+val docker : host_cwd:string -> container_cwd:string -> t
+
+(** [of_sandbox ~sandbox ~host_cwd ~container_cwd_for_docker]
+    dispatches on [sandbox.backend]:
+    - [Local]  → [local ~host_cwd]
+    - [Docker] → [docker ~host_cwd ~container_cwd:container_cwd_for_docker]
+
+    [container_cwd_for_docker] is required by the type but
+    unused (and never read) when the backend is Local. *)
+val of_sandbox :
+  sandbox:Keeper_sandbox.t ->
+  host_cwd:string ->
+  container_cwd_for_docker:string ->
+  t
+
+(** {1 Audience-aware accessors} *)
+
+(** Path the keeper LLM should see in tool response JSON.
+    [Local {abs}]                        → [abs]
+    [Sandboxed {container_abs; _}]       → [container_abs] *)
+val keeper_visible : t -> string
+
+(** Path the operator should see in logs / debugging output.
+    Always returns the host-side path supplied at construction. *)
+val operator_host : t -> string
+
+(** {1 Serialization} *)
+
+(** [to_yojson_response t] returns [`String (keeper_visible t)].
+    Use only for LLM-facing JSON tool responses; for operator
+    logs use {!operator_host} explicitly so the audience choice
+    is visible at the call site. *)
+val to_yojson_response : t -> Yojson.Safe.t

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 10,
   "coord_mli_missing": 3,
   "godsplit_count": 0,
-  "lib_dune_lines": 954,
+  "lib_dune_lines": 955,
   "inferred_dump_headers": 6,
   "lib_other_mli_missing": 125
 }

--- a/test/dune
+++ b/test/dune
@@ -1576,6 +1576,11 @@
   unix))
 
 (test
+ (name test_keeper_cwd_response)
+ (modules test_keeper_cwd_response)
+ (libraries masc_mcp astring alcotest yojson))
+
+(test
  (name test_keeper_memory_bank_consensus_re_10399)
  (modules test_keeper_memory_bank_consensus_re_10399)
  (libraries masc_mcp alcotest eio eio_main))

--- a/test/test_keeper_cwd_response.ml
+++ b/test/test_keeper_cwd_response.ml
@@ -1,0 +1,217 @@
+(** Property tests for [Keeper_cwd_response].
+
+    These pin the contract that LLM-facing JSON responses
+    constructed via {!Keeper_cwd_response.to_yojson_response}
+    never reveal the host abs path of a Docker-backend keeper.
+
+    Background: PR #11080 removed [sandbox_host_root] /
+    [playground_path] from [execution_context], but sibling
+    [cwd] fields in [keeper_shell_docker] / [keeper_exec_shell]
+    response builders still echoed the host abs path. The Docker
+    [--workdir] argument was translated via
+    [docker_private_workspace_cwd], yet that translation was not
+    propagated into the response JSON, so the LLM re-emitted
+    [cd /Users/...] on the next turn — invalid inside the
+    container.
+
+    These tests are the layer-1 guard: they pin the audience
+    semantics of the [Keeper_cwd_response] module itself. The
+    layer-2/3 guards (response builders + MLI gate) live in
+    follow-up PRs. *)
+
+open Alcotest
+open Masc_mcp
+
+(* Sentinel host-root prefix that must never appear in a
+   Docker-keeper LLM-facing response.  Using a recognizable
+   constant lets the assertion fail loudly in future regressions
+   even if the offending path component is renamed. *)
+let host_root_sentinel = "/tmp/HOST_ROOT_SENTINEL_NEVER_LEAK"
+
+let mk_local_sandbox () : Keeper_sandbox.t =
+  { keeper_name = "test-local"
+  ; sandbox_id = "keeper:test-local"
+  ; backend = Local
+  ; sandbox_profile = "local"
+  ; network_mode = "inherit"
+  ; host_root_rel = ".masc/playground/test-local/"
+  ; host_root_abs = host_root_sentinel ^ "/.masc/playground/test-local"
+  ; container_root = None
+  ; root_arg = "."
+  ; mind_arg = "mind"
+  ; repos_arg = "repos"
+  ; task_overlay_pattern = "repos/<repo>/.worktrees/<keeper>-<task_id>"
+  }
+
+let mk_docker_sandbox () : Keeper_sandbox.t =
+  { keeper_name = "test-docker"
+  ; sandbox_id = "keeper:test-docker"
+  ; backend = Docker
+  ; sandbox_profile = "docker"
+  ; network_mode = "inherit"
+  ; host_root_rel = ".masc/playground/docker/test-docker/"
+  ; host_root_abs =
+      host_root_sentinel ^ "/.masc/playground/docker/test-docker"
+  ; container_root = Some "/home/keeper/playground/test-docker"
+  ; root_arg = "."
+  ; mind_arg = "mind"
+  ; repos_arg = "repos"
+  ; task_overlay_pattern = "repos/<repo>/.worktrees/<keeper>-<task_id>"
+  }
+
+(* --- Local backend: passthrough semantics ------------------- *)
+
+let test_local_constructor_passthrough () =
+  let host_cwd =
+    host_root_sentinel ^ "/.masc/playground/test-local/repos/foo"
+  in
+  let r = Keeper_cwd_response.local ~host_cwd in
+  check string "keeper_visible == host_cwd" host_cwd
+    (Keeper_cwd_response.keeper_visible r);
+  check string "operator_host == host_cwd" host_cwd
+    (Keeper_cwd_response.operator_host r)
+
+let test_local_json_emits_host_path () =
+  (* For Local backend the host path IS the keeper-visible path,
+     so the JSON response will (correctly) contain it. The
+     positive check here is that [to_yojson_response] returns
+     exactly the host_cwd string. *)
+  let host_cwd =
+    host_root_sentinel ^ "/.masc/playground/test-local/repos/foo"
+  in
+  let r = Keeper_cwd_response.local ~host_cwd in
+  let json = Keeper_cwd_response.to_yojson_response r in
+  match json with
+  | `String s -> check string "JSON String == host_cwd" host_cwd s
+  | _ -> fail "expected `String yojson value"
+
+(* --- Docker backend: container path in response, host hidden  *)
+
+let test_docker_constructor_keeper_visible_is_container () =
+  let host_cwd =
+    host_root_sentinel ^ "/.masc/playground/docker/test-docker/repos/foo"
+  in
+  let container_cwd = "/home/keeper/playground/test-docker/repos/foo" in
+  let r = Keeper_cwd_response.docker ~host_cwd ~container_cwd in
+  check string "keeper_visible == container_cwd" container_cwd
+    (Keeper_cwd_response.keeper_visible r);
+  check string "operator_host == host_cwd (retained for logs)"
+    host_cwd
+    (Keeper_cwd_response.operator_host r)
+
+let test_docker_json_does_not_leak_host_root () =
+  let host_cwd =
+    host_root_sentinel ^ "/.masc/playground/docker/test-docker/repos/foo"
+  in
+  let container_cwd = "/home/keeper/playground/test-docker/repos/foo" in
+  let r = Keeper_cwd_response.docker ~host_cwd ~container_cwd in
+  let json_str =
+    Keeper_cwd_response.to_yojson_response r |> Yojson.Safe.to_string
+  in
+  check bool "JSON response does NOT contain host root sentinel" false
+    (Astring.String.is_infix ~affix:host_root_sentinel json_str);
+  check bool "JSON response does NOT contain host_cwd" false
+    (Astring.String.is_infix ~affix:host_cwd json_str);
+  check bool "JSON response contains container_cwd" true
+    (Astring.String.is_infix ~affix:container_cwd json_str)
+
+(* --- of_sandbox dispatches on backend ----------------------- *)
+
+let test_of_sandbox_local_dispatch () =
+  let sandbox = mk_local_sandbox () in
+  let host_cwd = sandbox.host_root_abs ^ "/repos/x" in
+  let r =
+    Keeper_cwd_response.of_sandbox ~sandbox ~host_cwd
+      ~container_cwd_for_docker:"IGNORED_FOR_LOCAL_BACKEND"
+  in
+  check string "Local of_sandbox returns host path" host_cwd
+    (Keeper_cwd_response.keeper_visible r);
+  let json_str =
+    Keeper_cwd_response.to_yojson_response r |> Yojson.Safe.to_string
+  in
+  check bool
+    "ignored container_cwd_for_docker value never appears in JSON"
+    false
+    (Astring.String.is_infix ~affix:"IGNORED_FOR_LOCAL_BACKEND" json_str)
+
+let test_of_sandbox_docker_dispatch () =
+  let sandbox = mk_docker_sandbox () in
+  let host_cwd = sandbox.host_root_abs ^ "/repos/x" in
+  let container_cwd =
+    "/home/keeper/playground/test-docker/repos/x"
+  in
+  let r =
+    Keeper_cwd_response.of_sandbox ~sandbox ~host_cwd
+      ~container_cwd_for_docker:container_cwd
+  in
+  check string "Docker of_sandbox returns container path"
+    container_cwd
+    (Keeper_cwd_response.keeper_visible r);
+  let json_str =
+    Keeper_cwd_response.to_yojson_response r |> Yojson.Safe.to_string
+  in
+  check bool "Docker JSON does not contain host sentinel" false
+    (Astring.String.is_infix ~affix:host_root_sentinel json_str)
+
+(* --- Property: docker JSON never contains host_cwd ---------- *)
+
+let test_property_docker_response_never_leaks_host () =
+  let cases =
+    [
+      ( "/tmp/HOST/repos/a"
+      , "/home/keeper/playground/k/repos/a" )
+    ; ( "/Users/dancer/me/.masc/playground/docker/k/repos/long/path"
+      , "/home/keeper/playground/k/repos/long/path" )
+    ; "/var/HOST_ROOT/x", "/home/keeper/playground/k/x"
+    ; ( host_root_sentinel ^ "/edge/case/with spaces"
+      , "/home/keeper/playground/k/edge/case/with spaces" )
+    ]
+  in
+  List.iter
+    (fun (host_cwd, container_cwd) ->
+      let r = Keeper_cwd_response.docker ~host_cwd ~container_cwd in
+      let json_str =
+        Keeper_cwd_response.to_yojson_response r
+        |> Yojson.Safe.to_string
+      in
+      check bool
+        (Printf.sprintf "host '%s' does not leak in JSON" host_cwd)
+        false
+        (Astring.String.is_infix ~affix:host_cwd json_str);
+      check bool
+        (Printf.sprintf "container '%s' does appear in JSON"
+           container_cwd)
+        true
+        (Astring.String.is_infix ~affix:container_cwd json_str))
+    cases
+
+let () =
+  run "keeper_cwd_response"
+    [
+      ( "local-backend"
+      , [
+          test_case "local constructor: passthrough" `Quick
+            test_local_constructor_passthrough
+        ; test_case "local JSON emits host path (== visible)" `Quick
+            test_local_json_emits_host_path
+        ; test_case "of_sandbox dispatches Local to host path" `Quick
+            test_of_sandbox_local_dispatch
+        ] )
+    ; ( "docker-backend"
+      , [
+          test_case
+            "docker constructor: keeper_visible is container path"
+            `Quick
+            test_docker_constructor_keeper_visible_is_container
+        ; test_case "docker JSON does not leak host root sentinel"
+            `Quick test_docker_json_does_not_leak_host_root
+        ; test_case "of_sandbox dispatches Docker to container path"
+            `Quick test_of_sandbox_docker_dispatch
+        ] )
+    ; ( "no-host-leak-property"
+      , [
+          test_case
+            "docker response JSON never contains host_cwd substring"
+            `Quick test_property_docker_response_never_leaks_host
+        ] )
+    ]


### PR DESCRIPTION
## Why

Docker-backend keeper 가 bash 를 실행하면 LLM tool response 의 `cwd` 필드에 host abs path (`/Users/.../.masc/playground/<keeper>/...`) 가 그대로 echo 된다. LLM 은 그 path 를 다음 turn `cd` 인자로 재사용하지만 container 안에서는 invalid path 라 실패한다. PR #11080 이 같은 클래스의 누수를 `keeper_status_detail.execution_context` 에서 fix 했지만 sibling `cwd` 필드들은 잔존한다.

진단 결과: Docker `--workdir` 인자에는 `docker_private_workspace_cwd` 변환이 적용되지만, 같은 변환 결과가 응답 JSON 의 `cwd` 필드에는 전파되지 않음. (`lib/keeper/keeper_shell_docker.ml:552,572,621,645` 와 `lib/keeper/keeper_exec_shell.ml` 의 응답 Assoc 분기 ~13곳)

## What

`lib/keeper/keeper_cwd_response.ml(.mli)` 를 추가했습니다. 작은 fail-closed boundary 타입.

```ocaml
type t = private
  | Local of { abs : string }
  | Sandboxed of { host_abs : string; container_abs : string }

val local : host_cwd:string -> t
val docker : host_cwd:string -> container_cwd:string -> t
val of_sandbox :
  sandbox:Keeper_sandbox.t ->
  host_cwd:string ->
  container_cwd_for_docker:string ->
  t

val keeper_visible : t -> string  (* LLM-facing *)
val operator_host  : t -> string  (* operator-facing *)
val to_yojson_response : t -> Yojson.Safe.t  (* keeper_visible only *)
```

원칙:
- **Parse Don't Validate**: caller 는 audience (LLM vs operator) 를 명시적으로 declare. 두 accessor 분리.
- **Fail-closed**: `to_yojson_response` 는 절대 `host_abs` 를 emit 하지 않음. host path 는 `operator_host` 로만 노출.
- **No string matching**: backend 분기는 `Keeper_sandbox.t.backend` variant 만 사용. "starts with /Users" 휴리스틱 금지.

## Test

`test/test_keeper_cwd_response.ml` 추가. 7 testcase, 0.002s.

- Local 의 host_cwd passthrough (positive)
- Docker 의 keeper_visible == container_cwd, operator_host == host_cwd
- JSON response 가 host root sentinel `/tmp/HOST_ROOT_SENTINEL_NEVER_LEAK` 를 포함하지 않음 (substring property)
- `of_sandbox` dispatch (Local / Docker)
- 다양한 host/container 쌍에 대한 누수 부재 property

```bash
dune build --root . @check
dune exec --root . test/test_keeper_cwd_response.exe
# 7 tests run. Test Successful in 0.002s.
```

## Scope

PR-1 only — module + property test. No callsite changes (behavior unchanged).

후속 PR 시리즈:
- PR-2: `keeper_shell_docker.ml` 4 site (552/572/621/645)
- PR-3: `keeper_exec_shell.ml` 응답 Assoc site (~13곳, 로그 필드는 유지)
- PR-4: `keeper_status_detail.ml` `playground_repos`/`pr_history` sanitizer
- PR-5: `keeper.unified.system.md` cwd format 안내 추가
- PR-6: MLI gate + CI grep gate

## References

- PR #10650 — fixed `default_cwd` (sibling 누락)
- PR #11080 — fixed `sandbox_host_root` / `playground_path` (~890 docker fail/day 감소)
- PR #11234 — sandbox cwd 규칙 문서화
- PR #11256 — `via:"host"` 태그 + silent host fallback 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)