### PR TITLE
feat(metrics): expose turn-FSM transitions as a typed Prometheus counter (Step 4e)

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -93,4 +93,11 @@ let emit_transition ~keeper_name ~turn_id ?prev state =
   in
   let state_label = turn_state_label state in
   Log.Keeper.info ~keeper_name ~turn_id
-    "[fsm:transition] %s -> %s" prev_label state_label
+    "[fsm:transition] %s -> %s" prev_label state_label;
+  Prometheus.inc_counter Prometheus.metric_keeper_turn_fsm_transitions
+    ~labels:
+      [ ("from", prev_label);
+        ("to", state_label);
+        ("keeper", keeper_name);
+      ]
+    ()

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -606,6 +606,8 @@ let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
 let metric_keeper_invariant_violations = "masc_keeper_invariant_violations_total"
 let metric_keeper_fsm_edge_transitions =
   "masc_keeper_fsm_edge_transitions_total"
+let metric_keeper_turn_fsm_transitions =
+  "masc_keeper_turn_fsm_transitions_total"
 let metric_keeper_lifecycle_callback_failures =
   "masc_keeper_lifecycle_callback_failures_total"
 let metric_keeper_event_bus_drain = "masc_keeper_event_bus_drain_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -263,6 +263,26 @@ val metric_keeper_invariant_violations : string
     a fleet of any size). *)
 val metric_keeper_fsm_edge_transitions : string
 
+(** Step 4 (bloodflow plan): typed turn-FSM transition counter.
+
+    Bumped once per [Keeper_turn_fsm.emit_transition] call so
+    operators can chart turn-state distribution per keeper.
+    Labels:
+    - [from] — previous [turn_state_label] ("-" if absent)
+    - [to]   — new [turn_state_label]
+    - [keeper] — keeper name
+
+    Distinct from [metric_keeper_fsm_edge_transitions], which
+    encodes TLA+ edge names ("ksm_to_kcl_routing", etc.) as a
+    single [edge] label.  This counter exposes the typed ADT
+    states directly so downstream PromQL can filter on
+    individual states (e.g.
+    [count_over_time(masc_keeper_turn_fsm_transitions_total{to=~"failed:.*"}[5m])]).
+
+    Cardinality upper bound: 10 turn_state labels × 10 prev × ~16
+    keepers = ≤ 1600 series; reachable subset is much smaller. *)
+val metric_keeper_turn_fsm_transitions : string
+
 (** PR-J: post-turn lifecycle callbacks raised exceptions that were
     silently swallowed before this counter existed. Labels: [callback]
     with values:


### PR DESCRIPTION
## Summary

Adds \`masc_keeper_turn_fsm_transitions_total\` and bumps it inside \`Keeper_turn_fsm.emit_transition\` alongside the existing \`Log.Keeper.info\` line. Every call site already wired by #11269 / #11288 / queued #11308 starts emitting Prometheus series without any caller change.

## Why "FSM 쪽 더 선명하게"

Today the typed FSM transition is observable only as a plain \`[fsm:transition] prev -> state\` log line. \`bin/masc-trace\` can extract it per-turn, but the fleet has no aggregate signal:

- A Grafana panel cannot chart "phase-gate skips per minute per keeper".
- A PromQL alert cannot fire on "\`failed:cascade_unavailable\` spikes 5x baseline".
- The existing \`metric_keeper_fsm_edge_transitions\` uses TLA+ edge strings (\`ksm_to_kcl_routing\`) collapsed into a single \`edge\` label — different vocabulary from the typed \`Keeper_turn_fsm\` ADT.

This PR closes that gap. Operators can now write:

```promql
rate(masc_keeper_turn_fsm_transitions_total{to=~"failed:.*", keeper="alice"}[5m])
```

and stay in ADT vocabulary.

## Cardinality

Labels \`from\` / \`to\` / \`keeper\`. Upper bound: 10 turn_state × 10 prev × ~16 keepers = 1600 series. Reachable subset much smaller (currently 5 distinct edges across the four wired sites + entry/exit).

## Fail-open

\`Prometheus.inc_counter\` is fail-open. An unexpected metric write failure cannot block a turn — same contract as the existing log emit.

## Test plan

- [x] \`dune build\` (default + release) green locally
- [x] \`test_keeper_turn_fsm_emit\` 4/4 OK locally (signature unchanged)
- [ ] CI lint + meta-guards green
- [ ] Post-merge: confirm series appears on Prometheus scrape after the next phase-gate-skipped turn

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)