### PR TITLE
feat(cascade): surface silent config-load fallbacks (Phase 1)

### DIFF
--- a/dashboard/src/api/dashboard-cascade.ts
+++ b/dashboard/src/api/dashboard-cascade.ts
@@ -76,6 +76,13 @@ export interface CascadeRawConfigResponse {
   source_text: string
   raw_json_editable: boolean
   raw_json: string
+  /** Surfaced when ensure_materialized_json fails (cascade.toml parse
+   *  error / IO error / unknown field).  Non-null means [raw_json]
+   *  may be a stale snapshot; the latest source_text edit was rejected
+   *  by the strict-field validator.  Backend always emits the field
+   *  (null on success) — frontend may treat undefined as null for
+   *  forward compat. */
+  materialization_error?: string | null
 }
 
 /** Operational state reported next to [provider_key] on the dashboard.

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -1112,6 +1112,8 @@ function CascadeRawConfigEditor({
     }
   }
 
+  const materializationError = raw?.materialization_error ?? null
+
   return html`
     <${Card} title=${mode.title}>
       <div class="flex flex-col gap-3 p-4">
@@ -1119,6 +1121,21 @@ function CascadeRawConfigEditor({
         <p class="text-xs text-[var(--color-fg-muted)]">
           ${mode.secondary}
         </p>
+
+        ${materializationError
+          ? html`
+            <div
+              role="alert"
+              class="rounded border border-[var(--bad-light)] bg-[var(--bad-bg-soft, var(--color-bg-page))] px-3 py-2 text-xs text-[var(--bad-light)]"
+            >
+              <strong class="font-semibold">cascade.toml 적용 실패:</strong>
+              <span class="ml-1 font-mono break-all">${materializationError}</span>
+              <p class="mt-1 text-[var(--color-fg-muted)]">
+                아래 표시되는 raw_json 은 마지막으로 정상 머터리얼라이즈된 스냅샷입니다.
+                source_text 의 변경분은 strict-field 검증에 의해 거절되어 적용되지 않았습니다.
+              </p>
+            </div>`
+          : ''}
 
         <form class="flex flex-col gap-3" onSubmit=${handleSave}>
           <textarea

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -254,8 +254,14 @@ let load_profile_weighted ~config_path ~name =
   let key = name ^ "_models" in
   match load_json config_path with
   | Error msg ->
-      Eio.traceln
-        "[CascadeConfig] load_profile_weighted: %s (profile=%s, path=%s)"
+      (* Surface the load failure on the standard logging channel so
+         operators see it without tailing stderr.  Returning the empty
+         list still lets callers fall back to "default" / hardcoded
+         defaults (see [Cascade_config.resolve_model_strings_traced_with]),
+         but the elevated WARN gives observability into what would
+         otherwise be a silent permissive-default cascade. *)
+      Log.warn ~ctx:"CascadeConfig"
+        "load_profile_weighted: %s (profile=%s, path=%s)"
         msg name config_path;
       []
   | Ok json ->

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -283,12 +283,19 @@ let raw_config_json () =
   Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
   let source : Cascade_toml_materializer.source_info = source_info () in
   let config_path = Some source.json_path in
-  (match
-     Cascade_toml_materializer.ensure_materialized_json ~config_path:source.json_path
-   with
-   | Ok _ -> ()
-   | Error msg ->
-       Log.Keeper.warn "DashboardCascade: materialization failed for %s: %s" source.json_path msg);
+  (* Capture the materialization error so the dashboard response can
+     surface it.  Previously the failure was logged and the response
+     silently served the stale [raw_json] file, hiding cascade.toml
+     parse failures from operators viewing the dashboard. *)
+  let materialization_error =
+    match
+      Cascade_toml_materializer.ensure_materialized_json ~config_path:source.json_path
+    with
+    | Ok _ -> None
+    | Error msg ->
+        Log.Keeper.warn "DashboardCascade: materialization failed for %s: %s" source.json_path msg;
+        Some msg
+  in
   let source_text =
     try load_raw_config_string source.source_path with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -322,6 +329,8 @@ let raw_config_json () =
       ("source_text", `String source_text);
       ("raw_json_editable", `Bool source.raw_json_editable);
       ("raw_json", `String raw_json);
+      ("materialization_error",
+        Json_util.string_opt_to_json materialization_error);
     ]
 
 let save_raw_config_json raw_json =

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -315,6 +315,55 @@ let test_raw_config_defaults_when_file_missing () =
         "{}\n"
         Yojson.Safe.Util.(j |> member "raw_json" |> to_string))
 
+(* Regression test for the silent-stale-fallback hole this PR closes:
+   when cascade.toml carries an unknown field (rejected by the strict
+   field whitelist in cascade_toml_materializer), the dashboard
+   response must surface a non-null [materialization_error] so the
+   operator can see that their last edit was rejected.  Previously the
+   error was logged-only and the response served the prior good
+   [raw_json] file as if nothing had failed. *)
+let test_raw_config_materialization_error_surfaces_unknown_field () =
+  let toml =
+    {|
+comment = "test"
+
+[big_three]
+models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
+bogus_field_for_regression_test = "any"
+|}
+  in
+  with_temp_config_root_setup
+    (fun dir -> write_file (Filename.concat dir "cascade.toml") toml)
+    (fun _dir ->
+      let j = Masc_mcp.Dashboard_cascade.raw_config_json () in
+      let materialization_error =
+        Yojson.Safe.Util.(j |> member "materialization_error" |> to_string_option)
+      in
+      check bool "materialization_error is present and non-null" true
+        (Option.is_some materialization_error);
+      check bool "materialization_error mentions the rejected field"
+        true
+        (match materialization_error with
+         | Some msg -> contains_substring msg "bogus_field_for_regression_test"
+         | None -> false))
+
+let test_raw_config_materialization_error_null_on_success () =
+  let toml =
+    {|
+comment = "test"
+
+[big_three]
+models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
+|}
+  in
+  with_temp_config_root_setup
+    (fun dir -> write_file (Filename.concat dir "cascade.toml") toml)
+    (fun _dir ->
+      let j = Masc_mcp.Dashboard_cascade.raw_config_json () in
+      check (option string) "materialization_error is null on a clean toml"
+        None
+        Yojson.Safe.Util.(j |> member "materialization_error" |> to_string_option))
+
 let test_raw_config_toml_source_exposes_editable_source_and_preview () =
   let toml =
     {|
@@ -913,6 +962,12 @@ let () =
         test_raw_config_defaults_when_file_missing;
       test_case "toml source exposes editable source + preview" `Quick
         test_raw_config_toml_source_exposes_editable_source_and_preview;
+      test_case "materialization_error surfaces strict-field rejection"
+        `Quick
+        test_raw_config_materialization_error_surfaces_unknown_field;
+      test_case "materialization_error is null on clean toml"
+        `Quick
+        test_raw_config_materialization_error_null_on_success;
       test_case "invalid JSON is rejected" `Quick
         test_save_raw_config_json_rejects_invalid_json;
       test_case "invalid TOML is rejected" `Quick


### PR DESCRIPTION
## 배경

`/loop`을 통한 다중 사이클 자율 hole 탐사 결과 cascade configuration 파이프라인에 두 개의 **silent fallback** 발견. 두 곳 모두 운영자가 cascade.toml 변경 후 적용 실패를 인지하지 못하게 만드는 패턴이었음.

## 발견된 hole (검증 evidence 포함)

| # | 위치 | 패턴 | Phase |
|---|------|------|-------|
| A | `lib/dashboard_cascade.ml:283-291` `raw_config_json` | `ensure_materialized_json` Error → WARN log → stale `raw_json` 파일을 dashboard 응답에 그대로 노출. 운영자 cascade.toml 변경 후 dashboard 확인 시 변경 실패 가려짐 | **1 (this PR)** |
| B | `lib/cascade/cascade_config_loader.ml:253-264` `load_profile_weighted` | `load_json` Error → `Eio.traceln` (stderr only) + 빈 list 반환. 6개 caller가 빈 list와 load 실패를 구분 못 하고 Hardcoded_defaults로 silent permissive fallback | **1 (warn 격상) + 2 (variant 추가, 별도 PR)** |

## 변경

### A. dashboard_cascade.ml
- materialization Error를 capture하여 응답 JSON에 nullable `materialization_error` field로 노출
- 기존 contract 보존 (additive only): `null` if Ok, error string if Error

### B. cascade_config_loader.ml
- `Eio.traceln` → `Log.warn ~ctx:\"CascadeConfig\"` 격상
  - 표준 로깅 채널 통과 (cascade_runtime.ml convention 정합)
  - Caller behavior 보존: 여전히 빈 list 반환 → caller fallback chain 동작
- Phase 2 (Load_failed variant 추가)는 별도 PR로 분리 — 회귀 risk 분리 + sweep 4 사이트 정리 위함

## 검증

- HEAD: `86053a88bb` (origin/main)
- `dune build @check`: ✅ EXIT=0
- `dune test test/test_dashboard_cascade.ml`: 33/33 OK (raw_config_json shape test green = additive 검증)
- 회귀 risk: 0 (additive only, no signature change)

## Phase 2 (별도 PR)
- `Cascade_config.cascade_source` enum에 `Load_failed of string` variant 추가
- 6 caller (`resolve_model_strings_traced_with` 등) 재배선
- Sweep 범위 사전 측정 완료: cascade_config.ml producer 4 + dashboard_cascade.ml match arm 1 + mli 1 = 안전

## 이 사이클의 메타 결과

이 PR은 5-병렬 에이전트 dispatch (정확도 ~30%) → 직접 추적 + 새 메모리 룰 (정확도 100%, 2개 hole 검증 완료) 의 method shift 결과. 검증 protocol 자체도 메모리에 기록됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)