### PR TITLE
feat(design-system): restore tokens:check (status canon + keeper ΔE)

### DIFF
--- a/dashboard/design-system/tokens/scripts/check-equivalence.mjs
+++ b/dashboard/design-system/tokens/scripts/check-equivalence.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * MASC Cockpit Design System — equivalence check
+ *
+ * Verifies generated CSS conforms to canonical invariants:
+ *
+ *   1. Status canon — --ok/--warn/--err/--info hex values pinned to
+ *      #6b9e6b/#c9a24a/#c46a5a/#6a8eb0 (warm dim palette per SPEC §3.5).
+ *   2. Keeper 12-slot palette is within ΔE < 2 (CIE2000) of the
+ *      OkLCH-generated palette (L=0.68, C=0.09, H=(i-1)*30).
+ *
+ * Token name set superset is enforced by the idempotent build gate
+ * (tokens-drift workflow Gate 1) — re-running tokens:build with no
+ * source change must produce zero diff. That makes a separate name-set
+ * check redundant here.
+ *
+ * Exits 0 only on full pass. Prints diffs to stderr on failure.
+ *
+ * Usage:  pnpm tokens:check
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import postcss from "postcss";
+import { formatHex, parseHex, differenceCiede2000 } from "culori";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, "..", "..", "..", "..");
+
+const GENERATED_CSS = resolve(REPO, "dashboard/design-system/source_styles/tokens.generated.css");
+
+const STATUS_CANON = {
+  ok: "#6b9e6b",
+  warn: "#c9a24a",
+  err: "#c46a5a",
+  info: "#6a8eb0",
+};
+
+function collectRootTokens(cssText) {
+  const root = postcss.parse(cssText);
+  const out = new Map();
+  root.walkRules((rule) => {
+    const selectors = rule.selector.split(",").map((s) => s.trim());
+    if (!selectors.some((s) => s === ":root" || s.startsWith(":root"))) return;
+    rule.walkDecls((decl) => {
+      if (decl.prop.startsWith("--")) {
+        const name = decl.prop.slice(2);
+        out.set(name, decl.value.trim());
+      }
+    });
+  });
+  return out;
+}
+
+function toHex6(value) {
+  const m = /^#([0-9a-fA-F]{6})$/.exec(value);
+  if (!m) return null;
+  return `#${m[1].toLowerCase()}`;
+}
+
+function expectedKeeperHex(slot) {
+  const c = { mode: "oklch", l: 0.68, c: 0.09, h: (slot - 1) * 30 };
+  return formatHex(c);
+}
+
+function checkStatusCanon(genMap) {
+  const errors = [];
+  for (const [name, expected] of Object.entries(STATUS_CANON)) {
+    const got = genMap.get(name);
+    const gotHex = got ? toHex6(got) : null;
+    if (gotHex !== expected) {
+      errors.push(`status canon drift: --${name} expected ${expected}, got ${got ?? "<missing>"}`);
+    }
+  }
+  return errors;
+}
+
+function checkKeeperPalette(genMap) {
+  const errors = [];
+  for (let i = 1; i <= 12; i++) {
+    const value = genMap.get(`k-${i}`);
+    if (!value) {
+      errors.push(`keeper slot --k-${i} missing in generated`);
+      continue;
+    }
+    const gotHex = toHex6(value);
+    if (!gotHex) {
+      errors.push(`keeper slot --k-${i} unparseable: ${value}`);
+      continue;
+    }
+    const expectedHex = expectedKeeperHex(i);
+    if (!expectedHex) {
+      errors.push(`OkLCH formatting failed for slot ${i}`);
+      continue;
+    }
+    const got = parseHex(gotHex);
+    const expected = parseHex(expectedHex);
+    const dE = differenceCiede2000()(got, expected);
+    if (dE >= 2) {
+      errors.push(`keeper slot --k-${i} ΔE=${dE.toFixed(3)} >= 2  got=${gotHex} expected=${expectedHex}`);
+    }
+  }
+  return errors;
+}
+
+function main() {
+  let genText;
+  try {
+    genText = readFileSync(GENERATED_CSS, "utf8");
+  } catch (e) {
+    console.error(`generated not found: ${GENERATED_CSS} — run \`pnpm tokens:build\` first`);
+    process.exit(2);
+  }
+
+  const genMap = collectRootTokens(genText);
+
+  let failed = false;
+
+  const statusErrors = checkStatusCanon(genMap);
+  if (statusErrors.length > 0) {
+    console.error(`[FAIL] status canon mismatch:`);
+    for (const e of statusErrors) console.error(`  - ${e}`);
+    failed = true;
+  } else {
+    console.log(`[OK] status canon (--ok/--warn/--err/--info) pinned`);
+  }
+
+  const keeperErrors = checkKeeperPalette(genMap);
+  if (keeperErrors.length > 0) {
+    console.error(`[FAIL] keeper palette ΔE check:`);
+    for (const e of keeperErrors) console.error(`  - ${e}`);
+    failed = true;
+  } else {
+    console.log(`[OK] keeper 12-slot palette ΔE < 2 vs OkLCH(L=68, C=0.09, H=i*30)`);
+  }
+
+  if (failed) {
+    console.error("\nequivalence check FAILED");
+    process.exit(1);
+  }
+  console.log("\nequivalence check passed");
+}
+
+main();

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,7 +17,8 @@
     "test": "vitest run --no-file-parallelism --maxWorkers=1",
     "test:serial": "pnpm test",
     "test:watch": "vitest",
-    "tokens:build": "tsx design-system/tokens/build.ts"
+    "tokens:build": "tsx design-system/tokens/build.ts",
+    "tokens:check": "node design-system/tokens/scripts/check-equivalence.mjs"
   },
   "dependencies": {
     "@formkit/auto-animate": "^0.9.0",


### PR DESCRIPTION
## 요약

PR #11250 (preview swap) 머지 시 `dashboard/design-system/tokens/scripts/check-equivalence.mjs` (190L) 와 `dashboard/package.json` 의 `tokens:check` script 가 hand-written `tokens.css` 와 함께 통째로 삭제됐습니다. 본 PR 은 두 invariant check 만 보존한 형태로 복원합니다.

## 변경 내용

### 복원 (single-axis 검증으로 단순화)

**`dashboard/design-system/tokens/scripts/check-equivalence.mjs`** (NEW, 147L)
- Status canon pin: `--ok/--warn/--err/--info` 가 `#6b9e6b/#c9a24a/#c46a5a/#6a8eb0` 로 고정 (SPEC §3.5 warm dim)
- Keeper 12-slot ΔE < 2 (CIE2000) vs `OkLCH(L=0.68, C=0.09, H=(i-1)*30)` — culori 알고리즘 회귀 탐지

**`dashboard/package.json`** (+1)
- `\"tokens:check\": \"node design-system/tokens/scripts/check-equivalence.mjs\"`

### 옛 script 에서 제거된 부분

- **Hand-written `tokens.css` name-set diff**: PR #11250 에서 reference 파일이 삭제됐고, 더 중요한 건 **tokens-drift workflow Gate 1** (idempotent build, PR #11293) 가 source.ts ↔ generated sync 를 구조적으로 보장합니다. `pnpm tokens:build` 후 git diff 가 zero 여야 pass — 이 invariant 가 name-set superset 를 자연 포함합니다.

## 검증 (로컬)

```
$ pnpm tokens:check
[OK] status canon (--ok/--warn/--err/--info) pinned
[OK] keeper 12-slot palette ΔE < 2 vs OkLCH(L=68, C=0.09, H=i*30)
equivalence check passed
```

## PR #11293 unlock

본 PR 머지 후 PR #11293 (tokens-drift workflow) 의 **Gate 2 conditional skip 패턴이 자동 활성화**됩니다 — script 와 npm entry 가 들어오면 즉시 검증 시작.

## Out of scope

- source.ts 자체를 reference 로 사용하는 더 강한 검증 (tsx 도입 필요): name-set 검증을 다시 활성화하려면 .ts 로 rewrite + tsx 실행. 본 PR 은 .mjs 로 단순 복원, 강화는 후속 PR 권고.
- branch protection 등록은 사용자 결정 영역 (PR #11293 body 에 권고)

## Related

- PR #11189: codegen scaffold (원본 script 작성)
- PR #11250: preview swap (script 누락 삭제)
- PR #11293: tokens-drift workflow (Gate 2 활성화 대기 중)