### PR TITLE
fix(keeper): wire Keeper_cwd_response into keeper_shell_docker response builders

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -558,12 +558,24 @@ let run_docker_with_git_bash
              (docker_exec_failure_message ~image ~status:st ~output:out)
          else
            Keeper_registry.clear_error ~base_path:config.base_path meta.name;
+         (* PR #11080 sibling fix: emit the in-container cwd so the
+            keeper LLM does not [cd] back to the host abs path on the
+            next turn (which fails inside the container). The runtime
+            already exposes its host→container translation via
+            [container_cwd_of_host]. *)
+         let cwd_response =
+           Keeper_cwd_response.docker
+             ~host_cwd:cwd
+             ~container_cwd:
+               (Keeper_turn_sandbox_runtime.container_cwd_of_host runtime
+                  ~host_cwd:cwd)
+         in
          Yojson.Safe.to_string
            (`Assoc
               ([
                 ("ok", `Bool (st = Unix.WEXITED 0));
                 ("via", `String "docker");
-                ("cwd", `String cwd);
+                ("cwd", Keeper_cwd_response.to_yojson_response cwd_response);
                 ("sandbox_profile", `String "docker");
                 ("git_creds_enabled", `Bool true);
                 ("network_mode", `String (network_mode_to_string Network_inherit));
@@ -578,12 +590,17 @@ let run_docker_with_git_bash
       with
       | Error message -> error_json message
       | Ok result ->
+        let cwd_response =
+          Keeper_cwd_response.docker
+            ~host_cwd:cwd
+            ~container_cwd:(docker_private_workspace_cwd ~config ~meta cwd)
+        in
         Yojson.Safe.to_string
           (`Assoc
              ([
                ("ok", `Bool (result.status = Unix.WEXITED 0));
                ("via", `String "docker");
-               ("cwd", `String cwd);
+               ("cwd", Keeper_cwd_response.to_yojson_response cwd_response);
                ("sandbox_profile", `String "docker");
                ("git_creds_enabled", `Bool true);
                ("network_mode", `String result.network_label);
@@ -625,12 +642,19 @@ let run_docker_hardened_bash
              (docker_exec_failure_message ~image ~status:st ~output:out)
          else
            Keeper_registry.clear_error ~base_path:config.base_path meta.name;
+         let cwd_response =
+           Keeper_cwd_response.docker
+             ~host_cwd:cwd
+             ~container_cwd:
+               (Keeper_turn_sandbox_runtime.container_cwd_of_host runtime
+                  ~host_cwd:cwd)
+         in
          Yojson.Safe.to_string
            (`Assoc
               ([
                 ("ok", `Bool (st = Unix.WEXITED 0));
                 ("via", `String "docker");
-                ("cwd", `String cwd);
+                ("cwd", Keeper_cwd_response.to_yojson_response cwd_response);
                 ("sandbox_profile", `String "docker");
                 ("git_creds_enabled", `Bool false);
                 ("network_mode", `String (network_mode_to_string network_mode));
@@ -649,12 +673,17 @@ let run_docker_hardened_bash
       with
       | Error message -> error_json message
       | Ok result ->
+        let cwd_response =
+          Keeper_cwd_response.docker
+            ~host_cwd:cwd
+            ~container_cwd:(docker_private_workspace_cwd ~config ~meta cwd)
+        in
         Yojson.Safe.to_string
           (`Assoc
              ([
                ("ok", `Bool (result.status = Unix.WEXITED 0));
                ("via", `String "docker");
-               ("cwd", `String cwd);
+               ("cwd", Keeper_cwd_response.to_yojson_response cwd_response);
                ("sandbox_profile", `String "docker");
                ("git_creds_enabled", `Bool false);
                ("network_mode", `String result.network_label);

--- a/test/dune
+++ b/test/dune
@@ -1588,6 +1588,11 @@
  (libraries astring alcotest))
 
 (test
+ (name test_keeper_shell_docker_cwd_response)
+ (modules test_keeper_shell_docker_cwd_response)
+ (libraries masc_mcp astring alcotest yojson unix))
+
+(test
  (name test_keeper_memory_bank_consensus_re_10399)
  (modules test_keeper_memory_bank_consensus_re_10399)
  (libraries masc_mcp alcotest eio eio_main))

--- a/test/test_keeper_shell_docker_cwd_response.ml
+++ b/test/test_keeper_shell_docker_cwd_response.ml
@@ -1,0 +1,151 @@
+(** Integration pin for PR-2 of the [Keeper_cwd_response] series.
+
+    Asserts that the helper functions wired into
+    [keeper_shell_docker.ml] response builders produce the
+    in-container path (not the host abs path) when composed.
+
+    Background: PR #11080 removed [sandbox_host_root] /
+    [playground_path] from [execution_context], but sibling
+    [cwd] response fields in [run_docker_with_git_bash] /
+    [run_docker_hardened_bash] still echoed the host abs path.
+    PR-1 introduced [Keeper_cwd_response]; this PR (PR-2)
+    replaces the four [("cwd", `String cwd)] literals with
+    [Keeper_cwd_response.to_yojson_response]. This test pins
+    the composition contract so a future refactor cannot
+    silently revert to host-path echo. *)
+
+open Alcotest
+open Masc_mcp
+
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir path =
+  let rec rm p =
+    match Unix.lstat p with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter
+        (fun name -> rm (Filename.concat p name))
+        (Sys.readdir p);
+      Unix.rmdir p
+    | _ -> Unix.unlink p
+    | exception Unix.Unix_error _ -> ()
+  in
+  rm path
+
+let make_docker_meta ~name : Keeper_types.keeper_meta =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("agent-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "cwd response leak pin");
+        ("allowed_paths", `List [ `String "*" ]);
+        ( "sandbox_profile"
+        , `String
+            (Keeper_types.sandbox_profile_to_string Keeper_types.Docker) );
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok meta -> meta
+  | Error e -> Alcotest.fail e
+
+let test_container_path_translation_under_sandbox () =
+  let base = temp_dir "shell_docker_cwd_resp_" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+      let config = Coord.default_config base in
+      let meta = make_docker_meta ~name:"cwd-pin-keeper" in
+      let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+      let host_cwd = Filename.concat host_root "repos/foo" in
+      let container_cwd =
+        Keeper_shell_docker.docker_private_workspace_cwd ~config ~meta
+          host_cwd
+      in
+      (* Sanity: translation produced an in-container path rooted
+         at the SSOT container playground prefix. *)
+      check bool "container_cwd does NOT contain base dir" false
+        (Astring.String.is_infix ~affix:base container_cwd);
+      check bool
+        "container_cwd is rooted at /home/keeper/playground"
+        true
+        (Astring.String.is_prefix ~affix:"/home/keeper/playground"
+           container_cwd);
+      let cwd_response =
+        Keeper_cwd_response.docker ~host_cwd ~container_cwd
+      in
+      let json_str =
+        Keeper_cwd_response.to_yojson_response cwd_response
+        |> Yojson.Safe.to_string
+      in
+      check bool "response JSON does NOT contain host base dir" false
+        (Astring.String.is_infix ~affix:base json_str);
+      check bool "response JSON does NOT contain host_cwd" false
+        (Astring.String.is_infix ~affix:host_cwd json_str);
+      check bool "response JSON does contain container_cwd" true
+        (Astring.String.is_infix ~affix:container_cwd json_str);
+      check string "operator_host accessor returns the host_cwd"
+        host_cwd
+        (Keeper_cwd_response.operator_host cwd_response))
+
+(* Source-level pin: assert that no [("cwd", `String <ident>)]
+   literal remains in keeper_shell_docker.ml. The four sites
+   from #11080's sibling leak class must be wired through
+   [Keeper_cwd_response.to_yojson_response]. Belt-and-braces
+   guard against accidental revert. *)
+let test_source_has_no_raw_cwd_string_literal () =
+  let candidate_paths =
+    [
+      "lib/keeper/keeper_shell_docker.ml"
+    ; "../lib/keeper/keeper_shell_docker.ml"
+    ; "../../lib/keeper/keeper_shell_docker.ml"
+    ]
+  in
+  let path =
+    List.find_opt Sys.file_exists candidate_paths
+  in
+  match path with
+  | None ->
+    (* Test invocation cwd may differ; skip silently rather
+       than fail. The integration test above already pins the
+       composition. *)
+    ()
+  | Some path ->
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let buf = Buffer.create 8192 in
+        (try
+           while true do
+             Buffer.add_string buf (input_line ic);
+             Buffer.add_char buf '\n'
+           done
+         with End_of_file -> ());
+        let src = Buffer.contents buf in
+        check bool
+          "no raw (\"cwd\", `String cwd) literal in keeper_shell_docker.ml"
+          false
+          (Astring.String.is_infix ~affix:"(\"cwd\", `String cwd)" src))
+
+let () =
+  run "keeper_shell_docker_cwd_response"
+    [
+      ( "translation"
+      , [
+          test_case
+            "host_cwd → container_cwd → JSON does not leak host"
+            `Quick test_container_path_translation_under_sandbox
+        ] )
+    ; ( "source-pin"
+      , [
+          test_case
+            "no raw (\"cwd\", `String cwd) literal remains in source"
+            `Quick test_source_has_no_raw_cwd_string_literal
+        ] )
+    ]


### PR DESCRIPTION
## Why

PR #11323 (PR-1) 가 `Keeper_cwd_response` type boundary 를 도입했지만 아직 어떤 callsite 도 사용하지 않습니다. 이 PR (PR-2) 가 `keeper_shell_docker.ml` 의 4 응답 builder site 에 wire 합니다.

진단 (Phase 1 요약):
- `lib/keeper/keeper_shell_docker.ml:82-103` `docker_private_workspace_cwd` 가 host_cwd → container_cwd 변환을 수행하고, 그 결과를 docker `--workdir` 인자에는 사용 (line 370, 479-480). 하지만 응답 JSON 의 `cwd` 필드 (552/572/621/645) 에는 원본 host_cwd 를 그대로 echo. → LLM 이 `cd /Users/dancer/me/.masc/playground/<keeper>/...` 를 다음 turn 에 시도하다 container 안에서 invalid path → 명령 실패.
- 같은 클래스의 누수를 PR #11080 이 `execution_context.sandbox_host_root` / `playground_path` 에서 fix 했지만, sibling 인 shell op response 는 잔존.

## What

4 site 모두 `Keeper_cwd_response.to_yojson_response` 사용으로 전환:

| Site | 함수 | container_cwd 출처 |
|------|------|-------------------|
| 552 | `run_docker_with_git_bash` (turn_sandbox_runtime branch) | `Keeper_turn_sandbox_runtime.container_cwd_of_host` |
| 572 | `run_docker_with_git_bash` (fallback) | `docker_private_workspace_cwd ~config ~meta cwd` |
| 621 | `run_docker_hardened_bash` (turn_sandbox_runtime branch) | `Keeper_turn_sandbox_runtime.container_cwd_of_host` |
| 645 | `run_docker_hardened_bash` (fallback) | `docker_private_workspace_cwd ~config ~meta cwd` |

동작 변경:
- **LLM-facing `cwd` (Docker keeper)**: host abs path → container path (`/home/keeper/playground/<keeper>/...`)
- **Operator-facing log fields** (`~fields:[...; "cwd", ...]` in `Log.Keeper.*`): unchanged. operator 가 `.masc/logs/system_log_*.jsonl` 에서 host path 로 ssh + filesystem 디버깅 가능.

## Test

`test/test_keeper_shell_docker_cwd_response.ml` 추가, 2 testcase, 0.002s.

1. **Composition test**: temp dir 을 base 로 삼아 Docker keeper meta 를 빌드. `Keeper_shell_docker.docker_private_workspace_cwd` 로 container_cwd 를 얻고 `Keeper_cwd_response.docker` 로 합쳐서 JSON 직렬화. JSON 이 (a) host base 를 포함하지 않고, (b) host_cwd 를 포함하지 않으며, (c) container_cwd 를 포함하는지 검증.
2. **Source-level pin**: `lib/keeper/keeper_shell_docker.ml` 를 grep 해 `("cwd", \`String cwd)` literal 이 남아있지 않은지 확인. 미래에 누가 응답 builder 에 같은 패턴을 다시 추가하면 alcotest 가 실패.

```bash
dune build --root . @check
dune exec --root . test/test_keeper_shell_docker_cwd_response.exe
# Test Successful in 0.002s. 2 tests run.

dune exec --root . test/test_keeper_cwd_response.exe   # PR-1 회귀 없음
# Test Successful in 0.001s. 7 tests run.
```

## Stack

```
main
└── feat/keeper-cwd-response (#11323, PR-1)
    └── feat/keeper-cwd-response-shell-docker (this PR, PR-2)
```

**Important**: PR #11323 이 main 으로 squash merge 된 후 이 PR 의 base 를 main 으로 변경 필요 (`gh pr edit <N> --base main`). 그렇지 않으면 stack patch 가 손실될 수 있음 (memory: `feedback_stack-pr-base-force-push-loses-patches`).

## Series

- PR-1 #11323 — `Keeper_cwd_response` 모듈 + property test ✅ (in review)
- **PR-2 (this) — `keeper_shell_docker.ml` 4 site wiring**
- PR-3 — `keeper_exec_shell.ml` 응답 Assoc site (~13곳)
- PR-4 — `keeper_status_detail.ml` `playground_repos` / `pr_history` sanitizer
- PR-5 — `keeper.unified.system.md` cwd format 안내
- PR-6 — MLI gate + CI grep gate

## References

- PR #10650 — `default_cwd` fix (sibling 누락)
- PR #11080 — `sandbox_host_root` / `playground_path` 제거 (~890 docker fail/day 감소)
- PR #11234 — sandbox cwd 규칙 문서화
- PR #11256 — `via:"host"` 태그

🤖 Generated with [Claude Code](https://claude.com/claude-code)