### PR TITLE
fix(keeper): use configured turn_timeout_sec as watchdog ceiling

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -119,11 +119,16 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                 [last_turn_ts] and could fire while a turn was actively
                 running, killing the keeper mid-LLM-call.  Active turns
                 get a separate (larger) threshold so legitimately slow
-                turns aren't mistaken for hangs.  Default 600s; the
-                env override [MASC_KEEPER_WATCHDOG_TURN_TIMEOUT_SEC]
-                was inlined in Step 14(b) -- hyperparameters belong
-                in code, not in [Sys.getenv_opt]. *)
-             let active_turn_timeout_sec = Float.max 600.0 threshold in
+                turns aren't mistaken for hangs.  Use
+                [Keeper_runtime_resolved.turn_timeout_sec] as the ceiling
+                so the watchdog never kills a turn still within its
+                configured budget (default 3600s, range [60, 7200]).
+                Previous 600s hardcoded minimum caused fleet-wide
+                termination when local models take 900s+ turns. *)
+             let active_turn_timeout_sec =
+               let turn_timeout = Keeper_runtime_resolved.turn_timeout_sec () in
+               Float.max turn_timeout threshold
+             in
              let idle_stale, in_turn_stale, in_turn_age =
                match entry.current_turn_observation with
                | Some obs ->


### PR DESCRIPTION
## Summary
- Replace hardcoded `Float.max 600.0 threshold` in `keeper_stale_watchdog.ml` with `Float.max (Keeper_runtime_resolved.turn_timeout_sec ()) threshold`
- The previous 600s hardcoded minimum caused fleet-wide termination when local models (Ollama qwen3.6:27b, 56 tok/s) take 900s+ turns within their configured budget
- Now uses the configured `MASC_KEEPER_TURN_TIMEOUT_SEC` (default 3600s, range [60, 7200]) as the watchdog ceiling

## Root Cause
11 keepers hit simultaneous `FLEET BATCH TERMINATION` because `active_turn_timeout_sec` was capped at `Float.max(600, 300) = 600s`, well below legitimate turn durations for local inference (observed 907s turns, 51094 tokens).

## Test plan
- [x] `dune exec masc_mcp --help` — build succeeds
- [ ] CI Lint passes (boundary guard unchanged)
- [ ] CI Build and Test passes
- [ ] Verify watchdog tick logs show correct `in_turn_stale=false` for active turns within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)