### PR TITLE
feat(keeper): split Failure_runtime_error catch-all for sharper FSM labels (Step 4f)

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -15,6 +15,7 @@ type failure_reason =
       primary_error : string;
       fallback_path : string option;
     }
+  | Failure_turn_livelock_blocked of { reason : string }
   | Failure_runtime_error of string
   | Failure_unexpected_exception of {
       exn : string;
@@ -44,6 +45,7 @@ let failure_reason_label = function
   | Failure_provider_error _ -> "provider_error"
   | Failure_tool_contract_violation _ -> "tool_contract_violation"
   | Failure_receipt_lost _ -> "receipt_lost"
+  | Failure_turn_livelock_blocked _ -> "turn_livelock_blocked"
   | Failure_runtime_error _ -> "runtime_error"
   | Failure_unexpected_exception _ -> "unexpected_exception"
 
@@ -77,6 +79,8 @@ let pp_failure_reason fmt = function
       Format.fprintf fmt "receipt_lost(err=%s,fallback=%s)"
         primary_error
         (Option.value fallback_path ~default:"-")
+  | Failure_turn_livelock_blocked { reason } ->
+      Format.fprintf fmt "turn_livelock_blocked(%s)" reason
   | Failure_runtime_error msg ->
       Format.fprintf fmt "runtime_error(%s)" msg
   | Failure_unexpected_exception { exn; _ } ->

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -29,6 +29,11 @@ type failure_reason =
       primary_error : string;
       fallback_path : string option;
     }
+  | Failure_turn_livelock_blocked of { reason : string }
+      (** Pre-dispatch livelock guard ([Keeper_turn_livelock])
+          rejected this turn because the keeper is stuck in a
+          loop on the same task.  Distinct from [runtime_error]
+          so PromQL can chart livelock incidence on its own. *)
   | Failure_runtime_error of string
   | Failure_unexpected_exception of {
       exn : string;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1285,7 +1285,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~keeper_name:meta.name ~turn_id:keeper_turn_id
             ~prev:Keeper_turn_fsm.Cascade_routing
             (Keeper_turn_fsm.Failed
-               (Keeper_turn_fsm.Failure_runtime_error error_message));
+               (Keeper_turn_fsm.Failure_provider_error
+                  { kind = sdk_error_kind err;
+                    detail = error_message }));
           Error err
       | Ok initial_execution ->
       let turn_id = meta.runtime.usage.total_turns in
@@ -1324,8 +1326,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              ~keeper_name:meta.name ~turn_id:keeper_turn_id
              ~prev:Keeper_turn_fsm.Cascade_routing
              (Keeper_turn_fsm.Failed
-                (Keeper_turn_fsm.Failure_runtime_error
-                   ("turn_livelock:" ^ reason_string)));
+                (Keeper_turn_fsm.Failure_turn_livelock_blocked
+                   { reason = reason_string }));
            Ok meta
        | Keeper_turn_livelock.Started _ ->
       (* Yield before CPU-bound prompt construction so the Eio scheduler

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -88,6 +88,8 @@ let test_failure_reason_labels_documented () =
       ( F.Failure_receipt_lost
           { primary_error = "e"; fallback_path = None },
         "receipt_lost" );
+      ( F.Failure_turn_livelock_blocked { reason = "stuck_after_sec" },
+        "turn_livelock_blocked" );
       (F.Failure_runtime_error "msg", "runtime_error");
       ( F.Failure_unexpected_exception
           { exn = "Boom"; backtrace = None },


### PR DESCRIPTION
## Summary

Adds \`Failure_turn_livelock_blocked of {reason}\` variant and re-routes the two existing \`Failure_runtime_error\` call sites to typed variants that match what actually happened. The new Prometheus counter from #11326 and \`bin/masc-trace\` timeline can now distinguish livelock from cascade-build error from a pure runtime fault on a Prometheus label alone — what /loop "fsm 쪽 더 선명하게" iteration 2 was after.

## Variant change

| failure_reason variant            | label                      | added/changed |
|-----------------------------------|----------------------------|---------------|
| Failure_turn_livelock_blocked     | \`turn_livelock_blocked\`  | new           |
| Failure_runtime_error             | \`runtime_error\`           | unchanged (now actual catch-all) |

## Call-site rewrites

\`keeper_unified_turn.ml\`:

1. **Cascade build error (line 1284)**: \`Failure_runtime_error error_message\` → \`Failure_provider_error { kind = sdk_error_kind err; detail = error_message }\`. The error is an \`Oas.Error.sdk_error\` from \`build_cascade_execution\`; \`Failure_provider_error\` is the variant the mli already documents for "underlying provider reported an error".

2. **Turn livelock (line 1323)**: \`Failure_runtime_error ("turn_livelock:" ^ reason_string)\` → \`Failure_turn_livelock_blocked { reason = reason_string }\`. The string prefix \`turn_livelock:\` was a label-discrimination workaround.

## Operator-visible effect

```
rate(masc_keeper_turn_fsm_transitions_total{to="failed:runtime_error"}[5m])
  → drops to ~0
rate(masc_keeper_turn_fsm_transitions_total{to="failed:turn_livelock_blocked"}[5m])
  → picks up livelock incidence
rate(masc_keeper_turn_fsm_transitions_total{to="failed:provider_error"}[5m])
  → picks up cascade-build sdk-errors
```

\`[fsm:transition]\` log line text changes accordingly.

No production dashboard depends on the old labels yet (the counter only landed in #11326), so no panel rename required.

## Test plan

- [x] \`dune build\` (default + release) green locally
- [x] \`test_keeper_turn_fsm_emit\` 4/4 OK locally — the new variant is asserted in the failure_reason label coverage case
- [ ] CI lint + meta-guards green
- [ ] Post-merge manual smoke: trigger a livelock (or wait for the next natural one) and confirm \`failed:turn_livelock_blocked\` appears

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4f — /loop iteration 2 of "FSM 쪽 더 선명하게".

🤖 Generated with [Claude Code](https://claude.com/claude-code)