### PR TITLE
feat(cascade): Soft_rate_limited outcome — fast 429 fallover (PR 1/4)

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -24,23 +24,26 @@
     key so operators can update their deployment config. *)
 let deprecation_warned : (string, unit) Hashtbl.t = Hashtbl.create 4
 
-let getenv_with_alias ~primary ~deprecated =
+let getenv_with_alias ~primary ?deprecated () =
   match Sys.getenv_opt primary with
   | Some v -> Some v
   | None ->
-    (match Sys.getenv_opt deprecated with
-     | Some _ as some ->
-       if not (Hashtbl.mem deprecation_warned deprecated) then begin
-         Hashtbl.add deprecation_warned deprecated ();
-         Printf.eprintf
-           "[warn] env var %s is deprecated; use %s (same semantics)\n%!"
-           deprecated primary
-       end;
-       some
-     | None -> None)
+    (match deprecated with
+     | None -> None
+     | Some dep ->
+       (match Sys.getenv_opt dep with
+        | Some _ as some ->
+          if not (Hashtbl.mem deprecation_warned dep) then begin
+            Hashtbl.add deprecation_warned dep ();
+            Printf.eprintf
+              "[warn] env var %s is deprecated; use %s (same semantics)\n%!"
+              dep primary
+          end;
+          some
+        | None -> None))
 
-let read_float_setting ~primary ~deprecated ~default =
-  match getenv_with_alias ~primary ~deprecated with
+let read_float_setting ~primary ?deprecated ~default () =
+  match getenv_with_alias ~primary ?deprecated () with
   | None -> default
   | Some raw ->
     let trimmed = String.trim raw in
@@ -53,8 +56,8 @@ let read_float_setting ~primary ~deprecated ~default =
           primary raw default;
         default
 
-let read_int_setting ~primary ~deprecated ~default =
-  match getenv_with_alias ~primary ~deprecated with
+let read_int_setting ~primary ?deprecated ~default () =
+  match getenv_with_alias ~primary ?deprecated () with
   | None -> default
   | Some raw ->
     let trimmed = String.trim raw in
@@ -75,6 +78,7 @@ let window_sec =
     ~primary:"MASC_CASCADE_HEALTH_WINDOW_SEC"
     ~deprecated:"OAS_CASCADE_HEALTH_WINDOW_SEC"
     ~default:300.0
+    ()
 
 (** Number of consecutive failures before cooldown activates.
     Default: 3, matching LiteLLM's [allowed_fails] concept. *)
@@ -83,6 +87,7 @@ let cooldown_threshold =
     ~primary:"MASC_CASCADE_COOLDOWN_THRESHOLD"
     ~deprecated:"OAS_CASCADE_COOLDOWN_THRESHOLD"
     ~default:3
+    ()
 
 (** Cooldown duration in seconds.  During cooldown, the provider is
     skipped (not attempted).  Default: 60s.
@@ -99,6 +104,7 @@ let cooldown_sec =
     ~primary:"MASC_CASCADE_COOLDOWN_SEC"
     ~deprecated:"OAS_CASCADE_COOLDOWN_SEC"
     ~default:60.0
+    ()
 
 (** Cooldown duration for provider calls classified as hard-quota exhaustion
     (account balance depleted, monthly quota reached, resource exhausted).
@@ -118,6 +124,7 @@ let hard_quota_cooldown_sec =
     ~primary:"MASC_CASCADE_HARD_QUOTA_COOLDOWN_SEC"
     ~deprecated:"OAS_CASCADE_HARD_QUOTA_COOLDOWN_SEC"
     ~default:3600.0
+    ()
 
 (** Cooldown duration for provider calls classified as terminal structural
     failures, where retrying the same provider on the next cascade tick is
@@ -135,6 +142,29 @@ let terminal_failure_cooldown_sec =
     ~primary:"MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC"
     ~deprecated:"OAS_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC"
     ~default:3600.0
+    ()
+
+(** Default cooldown applied immediately on a transient HTTP 429.  See the
+    [.mli] for the design rationale; the short default (10s) is calibrated
+    so that a single 429 deprioritizes the provider for the remainder of
+    the current cascade cycle without locking it out long enough to disturb
+    the rolling success-rate window. *)
+let soft_rate_limit_cooldown_sec =
+  read_float_setting
+    ~primary:"MASC_CASCADE_SOFT_RATE_LIMIT_COOLDOWN_SEC"
+    ~default:10.0
+    ()
+
+(** Upper clamp for caller-supplied Retry-After.  Anything past 2 minutes
+    is "hard quota in disguise" and should be classified as such by the
+    caller — see {!record_soft_rate_limited}.  The clamp protects us from
+    silently honoring a 3600-second Retry-After that would otherwise
+    blackhole the provider for an hour under transient-error semantics. *)
+let soft_rate_limit_max_clamp_sec =
+  read_float_setting
+    ~primary:"MASC_CASCADE_SOFT_RATE_LIMIT_MAX_CLAMP_SEC"
+    ~default:120.0
+    ()
 
 
 (* ── Types ────────────────────────────────────── *)
@@ -157,7 +187,18 @@ let terminal_failure_cooldown_sec =
    conflict is the motivating case: fallback is correct for the current call,
    but repeatedly attempting Kimi first on every later call only adds latency
    and silently degrades cascade diversity. *)
-type outcome = Success | Failure | Rejected | Hard_quota | Terminal_failure
+(* [Soft_rate_limited] represents a transient HTTP 429 — provider is healthy
+   but momentarily over its rate budget.  Distinct from [Failure] so a single
+   event triggers an immediate (short) cooldown without waiting for the
+   [cooldown_threshold] consecutive-failure count.  Distinct from [Hard_quota]
+   because the provider is expected to recover within seconds, not hours. *)
+type outcome =
+  | Success
+  | Failure
+  | Rejected
+  | Hard_quota
+  | Terminal_failure
+  | Soft_rate_limited
 
 type event = {
   time: float;  (* Unix timestamp *)
@@ -264,7 +305,8 @@ let prune_old_events now events =
   let cutoff = now -. window_sec in
   List.filter (fun e -> e.time >= cutoff) events
 
-let record t ~provider_key ~outcome ?error_kind ?error_reason ~now () =
+let record t ~provider_key ~outcome ?error_kind ?error_reason ?retry_after_s
+    ~now () =
   with_lock t (fun () ->
     let state = get_or_create_state t provider_key in
     let event = { time = now; outcome } in
@@ -290,6 +332,27 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason ~now () =
       bump_failure_fp ();
       if state.consecutive_failures >= cooldown_threshold then
         state.cooldown_until <- now +. cooldown_sec
+    | Soft_rate_limited ->
+      (* Transient HTTP 429.  Apply an immediate short cooldown so the
+         current cascade cycle skips this provider for the next selection
+         tick — without forcing the [cooldown_threshold] count-to-three
+         that [Failure] uses.  Honor caller-supplied Retry-After when
+         present; clamp positive values to [soft_rate_limit_max_clamp_sec]
+         to prevent a misclassified hard quota from silently producing
+         a multi-minute blackout.  Negative / zero / absent values fall
+         back to [soft_rate_limit_cooldown_sec].  As with the other
+         immediate-cooldown paths, never shorten an already-longer
+         cooldown (e.g. concurrent hard_quota + soft_rl events). *)
+      state.consecutive_failures <- state.consecutive_failures + 1;
+      bump_failure_fp ();
+      let cooldown_dur =
+        match retry_after_s with
+        | Some s when s > 0.0 -> Float.min s soft_rate_limit_max_clamp_sec
+        | _ -> soft_rate_limit_cooldown_sec
+      in
+      let new_until = now +. cooldown_dur in
+      if new_until > state.cooldown_until then
+        state.cooldown_until <- new_until
     | Hard_quota ->
       (* Hard-quota errors (balance depleted, quota exceeded, resource
          exhausted) don't recover on short-window retries — set a long
@@ -334,6 +397,11 @@ let record_hard_quota t ~provider_key ?error_kind ?error_reason () =
 let record_terminal_failure t ~provider_key ?error_kind ?error_reason () =
   record t ~provider_key ~outcome:Terminal_failure ?error_kind ?error_reason
     ~now:(Unix.gettimeofday ()) ()
+
+let record_soft_rate_limited t ~provider_key ?retry_after_s ?error_kind
+    ?error_reason () =
+  record t ~provider_key ~outcome:Soft_rate_limited ?error_kind ?error_reason
+    ?retry_after_s ~now:(Unix.gettimeofday ()) ()
 
 (* ── Queries ──────────────────────────────────── *)
 

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -42,6 +42,26 @@ val terminal_failure_cooldown_sec : float
     Env: [MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC] (with deprecated
     [OAS_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC] alias). *)
 
+val soft_rate_limit_cooldown_sec : float
+(** Default cooldown applied immediately on a transient HTTP 429 (soft
+    rate-limit) when no Retry-After hint is available.  Distinct from
+    {!cooldown_sec} because a single 429 should already deprioritize the
+    provider for the remainder of the current cascade cycle — the
+    [cooldown_threshold] count-to-three semantics are wrong for transient
+    rate limits.  Default 10.0 (10s).
+
+    Env: [MASC_CASCADE_SOFT_RATE_LIMIT_COOLDOWN_SEC]. *)
+
+val soft_rate_limit_max_clamp_sec : float
+(** Upper clamp for caller-supplied [retry_after_s] when recording a soft
+    rate-limit event.  Providers occasionally return Retry-After values
+    measured in minutes or hours; honoring those literally would silently
+    promote a transient 429 into a long blackout.  Anything that exceeds
+    this clamp should be classified as {!record_hard_quota} by the
+    caller, not as a soft rate-limit.  Default 120.0 (2 min).
+
+    Env: [MASC_CASCADE_SOFT_RATE_LIMIT_MAX_CLAMP_SEC]. *)
+
 
 (** Opaque health tracker state. *)
 type t
@@ -133,6 +153,35 @@ val record_hard_quota :
 val record_terminal_failure :
   t ->
   provider_key:string ->
+  ?error_kind:string ->
+  ?error_reason:string ->
+  unit ->
+  unit
+
+(** Record a transient HTTP 429 (rate-limit) response.
+
+    Unlike {!record_failure}, a single soft rate-limit triggers an
+    immediate short cooldown so the cascade can fall over to the next
+    candidate within the same turn instead of returning to the same
+    provider on the next selection tick.  No threshold applies.
+
+    [retry_after_s] is the value parsed from the upstream HTTP
+    [Retry-After] header (RFC 7231: integer seconds or HTTP-date).
+    When present, cooldown is set to [min retry_after_s
+    soft_rate_limit_max_clamp_sec]; otherwise cooldown defaults to
+    {!soft_rate_limit_cooldown_sec}.  Negative or zero values fall back
+    to the default.  Caller is responsible for upgrading sustained 429
+    bursts to {!record_hard_quota} when appropriate (e.g. monthly quota
+    boundaries) — this function intentionally never extends past
+    [soft_rate_limit_max_clamp_sec] regardless of header value.
+
+    Preserves an already-longer cooldown if one exists (no regression).
+
+    See {!record_failure} for [error_kind] / [error_reason] semantics. *)
+val record_soft_rate_limited :
+  t ->
+  provider_key:string ->
+  ?retry_after_s:float ->
   ?error_kind:string ->
   ?error_reason:string ->
   unit ->

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1154,6 +1154,26 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
        false)
   | _ -> false
 
+(* When the SDK surfaces a transient HTTP 429 that is *not* a hard-quota
+   in disguise, expose the [retry_after] hint that [Llm_provider.Retry]
+   already extracted from the response body.  Used by the cascade error
+   classifier to feed [Cascade_health_tracker.record_soft_rate_limited]
+   so a single 429 trips an immediate short cooldown instead of waiting
+   for [cooldown_threshold] consecutive [record_failure] events.
+
+   Returns [None] when the error is not a non-quota [RateLimited], or
+   when [retry_after] is absent.  A [Some 0.] / [Some <0.] is preserved
+   here and clamped/defaulted at the tracker boundary so the caller's
+   semantics ("the 429 still happened, so cool down at least the
+   default") are maintained centrally. *)
+let sdk_error_soft_rate_limited (err : Oas.Error.sdk_error)
+  : float option option =
+  match err with
+  | Oas.Error.Api (Llm_provider.Retry.RateLimited { retry_after; _ } as api_err)
+    when not (Llm_provider.Retry.is_hard_quota api_err) ->
+    Some retry_after
+  | _ -> None
+
 let sdk_error_is_max_turns_exceeded (err : Oas.Error.sdk_error) : bool =
   match classify_masc_internal_error err with
   | Some
@@ -1704,7 +1724,21 @@ let run_named
           Cascade_health_tracker.(
             record_terminal_failure global ~provider_key:provider_cfg.model_id
               ~error_kind:"resumable_cli_session" ~error_reason:err_str ())
-        else (
+        else (match sdk_error_soft_rate_limited sdk_err with
+        | Some retry_after_opt ->
+          (* Transient 429 (not a hard quota in disguise).  Trip an
+             immediate short cooldown so the next selection tick falls
+             over to a different provider; honor [retry_after] when the
+             upstream parsed one out of the response body, otherwise let
+             the tracker apply [soft_rate_limit_cooldown_sec] (10s default).
+             Caller is responsible for upgrading sustained 429 bursts to
+             hard_quota; the tracker's max-clamp guards against a
+             misclassified hard quota silently producing a long blackout. *)
+          Cascade_health_tracker.(
+            record_soft_rate_limited global ~provider_key:provider_cfg.model_id
+              ?retry_after_s:retry_after_opt
+              ~error_kind:"http_429" ~error_reason:err_str ())
+        | None -> (
           (* Classify the err_str into named buckets so Cascade_health_tracker
              fingerprint groups separate codex internal-state corruption
              (transient_codex_rollout — auto-recovers on next call) from
@@ -1740,7 +1774,7 @@ let run_named
           in
           Cascade_health_tracker.(
             record_failure global ~provider_key:provider_cfg.model_id
-              ~error_kind ~error_reason:err_str ()));
+              ~error_kind ~error_reason:err_str ())));
         (* FSM: Call_err → decide *)
         (match sdk_error_to_cascade_outcome sdk_err with
          | Some outcome ->

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -365,6 +365,122 @@ let test_terminal_failure_records_fingerprint () =
     check int "terminal failure fingerprint count" 1 count
   | _ -> failwith "expected exactly one terminal failure fingerprint"
 
+(* ── Soft_rate_limited outcome (HTTP 429) ───────────────────── *)
+
+let test_soft_rate_limit_triggers_immediate_cooldown () =
+  (* The whole point of the new outcome: a single 429 must trip cooldown
+     so the cascade's next selection tick falls over to a different
+     provider — without waiting for [cooldown_threshold] consecutive
+     failures the way [record_failure] does. *)
+  let t = H.create () in
+  H.record_soft_rate_limited t ~provider_key:"p" ();
+  check bool "single 429 trips cooldown immediately"
+    true (H.is_in_cooldown t ~provider_key:"p")
+
+let test_soft_rate_limit_default_cooldown_short () =
+  (* When no Retry-After is supplied, cooldown defaults to
+     [soft_rate_limit_cooldown_sec] (10s by default).  We only assert
+     bounds — the constant is env-tunable so an exact compare would be
+     brittle in CI.  Lower bound > 0 (cooldown active), upper bound
+     well under hard_quota_cooldown_sec to confirm we picked the soft
+     bucket, not the hard one. *)
+  let t = H.create () in
+  H.record_soft_rate_limited t ~provider_key:"p" ();
+  match H.provider_info t ~provider_key:"p" with
+  | None | Some { cooldown_expires_at = None; _ } ->
+    fail "expected cooldown_expires_at = Some _"
+  | Some { cooldown_expires_at = Some expires; _ } ->
+    let now = Unix.gettimeofday () in
+    let remaining = expires -. now in
+    check bool
+      (Printf.sprintf "soft_rl default cooldown remaining=%.1fs > 0" remaining)
+      true (remaining > 0.0);
+    check bool
+      (Printf.sprintf "soft_rl default cooldown remaining=%.1fs << hard_quota (3600s)" remaining)
+      true (remaining < 300.0)
+
+let test_soft_rate_limit_honors_retry_after () =
+  (* Retry-After=30 should produce a ~30s cooldown, materially longer
+     than the 10s default.  This is the core of the Retry-After plumbing. *)
+  let t = H.create () in
+  H.record_soft_rate_limited t ~provider_key:"p" ~retry_after_s:30.0 ();
+  match H.provider_info t ~provider_key:"p" with
+  | None | Some { cooldown_expires_at = None; _ } ->
+    fail "expected cooldown_expires_at = Some _"
+  | Some { cooldown_expires_at = Some expires; _ } ->
+    let now = Unix.gettimeofday () in
+    let remaining = expires -. now in
+    check bool
+      (Printf.sprintf "Retry-After=30 → cooldown ≈ 30s, got %.1fs" remaining)
+      true (remaining > 25.0 && remaining < 35.0)
+
+let test_soft_rate_limit_clamps_oversized_retry_after () =
+  (* A misclassified hard quota that returns Retry-After=999999 must
+     not silently produce a multi-day blackout; the implementation
+     clamps to [soft_rate_limit_max_clamp_sec] (default 120s).  Caller
+     is responsible for upgrading sustained 429 bursts to record_hard_quota. *)
+  let t = H.create () in
+  H.record_soft_rate_limited t ~provider_key:"p" ~retry_after_s:999_999.0 ();
+  match H.provider_info t ~provider_key:"p" with
+  | None | Some { cooldown_expires_at = None; _ } ->
+    fail "expected cooldown_expires_at = Some _"
+  | Some { cooldown_expires_at = Some expires; _ } ->
+    let now = Unix.gettimeofday () in
+    let remaining = expires -. now in
+    check bool
+      (Printf.sprintf "Retry-After clamped to ≤120s, got %.1fs" remaining)
+      true (remaining <= 121.0)
+
+let test_soft_rate_limit_negative_retry_after_uses_default () =
+  (* Caller plumbing bugs (negative or zero retry_after_s) must fall
+     back to the default cooldown rather than skipping cooldown entirely
+     — the 429 still happened. *)
+  let t = H.create () in
+  H.record_soft_rate_limited t ~provider_key:"p" ~retry_after_s:(-5.0) ();
+  check bool "negative retry_after still trips cooldown"
+    true (H.is_in_cooldown t ~provider_key:"p")
+
+let test_soft_rate_limit_success_clears_cooldown () =
+  (* The recovery story: as soon as the provider responds successfully,
+     it should be re-eligible.  The transient 429 is per-request, not a
+     sticky failure mode like hard_quota. *)
+  let t = H.create () in
+  H.record_soft_rate_limited t ~provider_key:"p" ();
+  H.record_success t ~provider_key:"p";
+  check bool "success after 429 clears cooldown"
+    false (H.is_in_cooldown t ~provider_key:"p")
+
+let test_soft_rate_limit_does_not_shorten_hard_quota () =
+  (* If the provider was already in a long hard_quota cooldown, a
+     subsequent 429 must not accidentally shorten that to 10s. *)
+  let t = H.create () in
+  H.record_hard_quota t ~provider_key:"p" ();
+  let expires_after_quota =
+    match H.provider_info t ~provider_key:"p" with
+    | Some { cooldown_expires_at = Some x; _ } -> x
+    | _ -> fail "no cooldown after hard_quota"
+  in
+  H.record_soft_rate_limited t ~provider_key:"p" ();
+  let expires_after_soft =
+    match H.provider_info t ~provider_key:"p" with
+    | Some { cooldown_expires_at = Some x; _ } -> x
+    | _ -> fail "cooldown unexpectedly cleared by soft 429"
+  in
+  check bool "soft 429 must not shorten existing hard_quota cooldown"
+    true (expires_after_soft >= expires_after_quota)
+
+let test_soft_rate_limit_records_fingerprint () =
+  let t = H.create () in
+  H.record_soft_rate_limited t ~provider_key:"claude-cli"
+    ~error_kind:"http_429"
+    ~error_reason:"rate limit exceeded for tier" ();
+  let info = info_or_fail t ~provider_key:"claude-cli" in
+  match info.top_fingerprints with
+  | [ (fp, count) ] ->
+    check bool "soft 429 fingerprint keeps kind"
+      true (String.starts_with ~prefix:"http_429" fp);
+    check int "soft 429 fingerprint count" 1 count
+  | _ -> failwith "expected exactly one soft 429 fingerprint"
 
 let () =
   run "cascade_health_tracker" [
@@ -441,5 +557,23 @@ let () =
         test_terminal_failure_preserves_longer_existing_cooldown;
       test_case "terminal_failure records fingerprint" `Quick
         test_terminal_failure_records_fingerprint;
+    ];
+    "soft_rate_limit", [
+      test_case "single 429 trips immediate cooldown" `Quick
+        test_soft_rate_limit_triggers_immediate_cooldown;
+      test_case "default cooldown is short (between 0 and hard_quota)" `Quick
+        test_soft_rate_limit_default_cooldown_short;
+      test_case "Retry-After honored in cooldown duration" `Quick
+        test_soft_rate_limit_honors_retry_after;
+      test_case "oversized Retry-After clamped" `Quick
+        test_soft_rate_limit_clamps_oversized_retry_after;
+      test_case "negative Retry-After falls back to default" `Quick
+        test_soft_rate_limit_negative_retry_after_uses_default;
+      test_case "success clears 429 cooldown" `Quick
+        test_soft_rate_limit_success_clears_cooldown;
+      test_case "soft 429 must not shorten longer cooldown" `Quick
+        test_soft_rate_limit_does_not_shorten_hard_quota;
+      test_case "soft 429 records fingerprint" `Quick
+        test_soft_rate_limit_records_fingerprint;
     ];
   ]


### PR DESCRIPTION
## Summary

Single transient HTTP 429 now trips an immediate short cooldown on the offending provider so the next cascade selection tick falls over to a different candidate, instead of waiting the `cooldown_threshold` (3) consecutive `record_failure` events. The new outcome variant `Soft_rate_limited` lives between `Failure` (3-strike threshold, 60 s cooldown) and `Hard_quota` (1 h immediate cooldown). When the upstream OAS `Retry` layer parsed a `Retry-After` value out of the response body, that value is honored — clamped at `soft_rate_limit_max_clamp_sec` (default 120 s) so a misclassified hard quota cannot silently produce a multi-minute blackout under transient-error semantics.

This is **PR 1 of 4** in the cascade resilience track. Plan: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-c-cuddly-crab.md`.

## Why

Today's classification in `oas_worker_named.ml` lumps 429 with general `record_failure`, classified by message-substring buckets (`transient_codex_rollout` / `permanent_kimi_rejected` / `network_*_other`). Cooldown only activates after 3 consecutive failures, so a single 429 leaves the offending provider as the highest-weighted candidate on the next selection tick. The cascade does fall over within the same turn (FSM `Try_next` already classifies 429 as cascadable) — but the *next* turn often retries the same provider, producing the slow drip on quota-pressed paid tiers.

The existing `Hard_quota` already demonstrates the right pattern (immediate cooldown, no threshold) but its 1-hour duration is wrong for transient 429. New variant gives 429 the structural signal it deserves without conflating with quota exhaustion.

## What changed

- **`cascade_health_tracker.{ml,mli}`** (commit 1)
  - New constants `soft_rate_limit_cooldown_sec` (default 10 s, env `MASC_CASCADE_SOFT_RATE_LIMIT_COOLDOWN_SEC`) and `soft_rate_limit_max_clamp_sec` (default 120 s, env `MASC_CASCADE_SOFT_RATE_LIMIT_MAX_CLAMP_SEC`).
  - New `Soft_rate_limited` outcome variant + `record` match arm.
  - New public `record_soft_rate_limited ?retry_after_s ?error_kind ?error_reason` — mirrors the existing `record_*` shape.
  - Helper plumbing: `getenv_with_alias` / `read_*_setting` now take `?deprecated` as optional so the new MASC-only env vars can be declared without an empty-string sentinel. Existing call sites updated to pass trailing `()`.
- **`oas_worker_named.ml`** (commit 2)
  - New `sdk_error_soft_rate_limited`: returns `Some retry_after` when the SDK surfaced `Llm_provider.Retry.RateLimited` that is *not* a hard quota; otherwise `None`. Reuses the `retry_after` that `Llm_provider.Retry` already extracts from the response body — no new header parsing needed.
  - New branch in the per-tier classification ladder: `hard_quota → terminal (resumable_cli_session) → soft_rl → failure`. Soft 429s call `record_soft_rate_limited` with `error_kind="http_429"` for fingerprint accumulation, leaving the existing `transient_codex_rollout` / CLI-network buckets untouched.
- **`test/test_cascade_health_tracker.ml`** (commit 1): 8 new test cases under `soft_rate_limit` group.

## Behavioral guarantees (encoded in tests)

- Single 429 → `is_in_cooldown = true` immediately (no threshold).
- Default cooldown is short (>0, ≪ hard_quota 3600 s).
- `Retry-After: 30` → cooldown ≈ 30 s.
- `Retry-After: 999_999` → clamped to ≤ 120 s.
- Negative / zero `Retry-After` → fallback to default (cooldown still trips — the 429 still happened).
- `record_success` after 429 clears cooldown.
- Soft 429 never shortens an existing longer cooldown (e.g. concurrent `hard_quota`).
- Fingerprint accumulation works the same as other `record_*` variants.

## Test plan

- [x] `dune build --root . @check` clean (with `DUNE_CACHE=disabled` to bypass local content-addressed cache flake — see "Notes" below).
- [x] `dune build --root . --profile=release` clean.
- [x] `test_cascade_health_tracker.exe` — 39/39 pass (8 new + 31 existing).
- [x] Adjacent suites unchanged at commit 1: `test_cascade_strategy` 52/52, `test_cascade_trust_persist` 6/6, `test_dashboard_cascade` 33/33.
- [ ] CI on clean infra validates the integration commit's `test_oas_worker` etc. (local cache flake doesn't repro on CI).
- [ ] Self-review against `~/me/agents/best-programmer/AGENT.md` before Ready transition.

## Notes

- `oas_worker_named.ml` has no `.mli` (signature is inferred). Adding a top-level helper `sdk_error_soft_rate_limited` extends the inferred public signature. Local builds in this worktree hit a `~/.cache/dune` content-addressed-cache flake (stale `.cmi` returned across worktrees that share the global cache); `DUNE_CACHE=disabled` clears it. No change to interface that other modules depend on — `record_soft_rate_limited` is an *additive* public function in `Cascade_health_tracker`, and the new helper in `oas_worker_named` is module-local from `try_cascade`'s perspective.
- Plan doc: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-c-cuddly-crab.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)