### PR TITLE
fix(tool-policy): add masc.coordination to social/messaging/dispatch presets

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -192,17 +192,17 @@ masc_tools = ["masc_status", "masc_tool_help"]
 # ~15 tools. Optimal for 9B tool selection accuracy.
 [presets.social]
 groups = ["base", "board_core", "coordination_core", "filesystem", "voice"]
-masc_groups = ["essential"]
+masc_groups = ["essential", "coordination"]
 
 # Messaging: social + shell, library, github for broader interaction.
 # ~25 tools.
 [presets.messaging]
 groups = ["base", "board_core", "coordination_core", "shell", "filesystem", "library", "voice"]
-masc_groups = ["essential"]
+masc_groups = ["essential", "coordination"]
 
 [presets.dispatch]
 groups = ["base", "board_core", "filesystem", "library", "shell"]
-masc_groups = ["essential", "dispatch", "code_observe"]
+masc_groups = ["essential", "dispatch", "code_observe", "coordination"]
 
 [presets.coding]
 groups = ["base", "board_core", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding", "github", "github_review"]


### PR DESCRIPTION
## Summary
- Add `masc.coordination` group to `social`, `messaging`, and `dispatch` presets in `config/tool_policy.toml`
- These presets previously lacked access to `masc_transition`, `masc_claim_next`, `masc_add_task`
- Keepers using these presets (e.g., ramarama/social, velvet-hammer/dispatch) were stuck in claim-release loops

## Root Cause
Keepers with social/dispatch presets could call `keeper_task_claim` (from `coordination_core`) but not `masc_transition(action=start)` (from `masc.coordination`). This meant they could claim tasks but never progress them to `in_progress`, resulting in immediate release and passive observation loops.

## Test plan
- [x] `dune build` passes (TOML-only change)
- [ ] Verify social/dispatch preset keepers can call `masc_transition` after deploy
- [ ] Monitor `masc_tasks` for `in_progress > 0` within 30 minutes of deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)