### PR TITLE
feat(keeper): emit Phase_gating -> Cascade_routing -> Awaiting_provider transitions (Step 4g)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1092,6 +1092,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
   | phase_opt ->
       (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade).
          At this point [phase] is executable; blocked phases returned above. *)
+      Keeper_turn_fsm.emit_transition
+        ~keeper_name:meta.name ~turn_id:keeper_turn_id
+        ~prev:Keeper_turn_fsm.Phase_gating
+        Keeper_turn_fsm.Cascade_routing;
       let effective_cascade_name =
         let phase = match phase_opt with
           | Some p -> p
@@ -1328,6 +1332,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                    ("turn_livelock:" ^ reason_string)));
            Ok meta
        | Keeper_turn_livelock.Started _ ->
+      Keeper_turn_fsm.emit_transition
+        ~keeper_name:meta.name ~turn_id:keeper_turn_id
+        ~prev:Keeper_turn_fsm.Cascade_routing
+        Keeper_turn_fsm.Awaiting_provider;
       (* Yield before CPU-bound prompt construction so the Eio scheduler
          can service HTTP handlers between keeper turn setups. *)
       Eio.Fiber.yield ();


### PR DESCRIPTION
## Summary

Fills two missing in-cycle transitions so the FSM timeline flows end-to-end through the dispatch lane instead of jumping from \`phase_gating\` straight to a silent-skip exit or to \`completing\`. /loop iteration 3 of "fsm 쪽 더 선명하게".

## Sites

| line | prev            | turn_state          | when                                                            |
|------|-----------------|---------------------|-----------------------------------------------------------------|
| 1095 | Phase_gating    | Cascade_routing     | \`phase_opt\` branch entry (phase gate confirmed turn OK)       |
| 1334 | Cascade_routing | Awaiting_provider   | \`Keeper_turn_livelock.Started\` branch (about to call run_turn) |

The two sites bracket the cascade routing + capability gate work; failures in the middle land at the existing Step 4b emits (\`failed:cascade_unavailable\` for ollama saturation, \`failed:provider_error\` for cascade build error, \`failed:turn_livelock_blocked\` for livelock).

## Timeline impact

Before (post 4c/d only):
```
[fsm:transition] - -> phase_gating
[fsm:transition] streaming -> completing
[fsm:transition] completing -> done
```

After:
```
[fsm:transition] - -> phase_gating
[fsm:transition] phase_gating -> cascade_routing       (new)
[fsm:transition] cascade_routing -> awaiting_provider  (new)
[fsm:transition] streaming -> completing
[fsm:transition] completing -> done
```

\`bin/masc-trace\` now shows where in the dispatch lane a turn currently sits, and \`masc_keeper_turn_fsm_transitions_total\` splits cascade-routing pass-through from cascade-unavailable failure as separate series.

## Volume

Two extra \`Log.Keeper.info\` + Prometheus increments per successful dispatch (skipped turns short-circuit before either site fires). At ~60-80 dispatches/min that's ~2-3% bump on system_log. No control-flow change.

## Test plan

- [x] \`dune build\` (default + release) green locally
- [x] \`test_keeper_turn_fsm_emit\` 4/4 OK locally
- [ ] CI lint + meta-guards green
- [ ] Post-merge: pick a turn_id from \`bin/masc-trace\` and confirm both new lines appear

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4g — /loop iteration 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)