### PR TITLE
fix(keeper): wire Keeper_cwd_response into keeper_exec_shell docker-route response builders

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1510,6 +1510,16 @@ let handle_keeper_shell
     with
     | Error msg -> error_json ~fields:[ "op", `String op; "cwd", `String cwd ] msg
     | Ok result ->
+      (* PR #11080 sibling sweep: this helper always routes through
+         docker exec, so the LLM-facing [cwd] field must hold the
+         in-container path.  Operator-side log fields above keep the
+         host path. *)
+      let cwd_response =
+        Keeper_cwd_response.docker ~host_cwd:cwd
+          ~container_cwd:
+            (Keeper_shell_docker.docker_private_workspace_cwd ~config
+               ~meta cwd)
+      in
       Yojson.Safe.to_string
         (Exec_core.process_result_json
            ~artifact_policy:Exec_core.Inline_only
@@ -1520,7 +1530,7 @@ let handle_keeper_shell
              [
                "op", `String op;
                "cmd", `String cmd;
-               "cwd", `String cwd;
+               "cwd", Keeper_cwd_response.to_yojson_response cwd_response;
                "via", `String "docker";
              ]
            ~status:result.status
@@ -1817,11 +1827,20 @@ let handle_keeper_shell
                error_json
                  ~fields:[ "op", `String op; "cwd", `String cwd ] msg
              | Ok (st, out) ->
+               (* PR #11080 sibling sweep: docker-route response — use
+                  the in-container cwd to keep the LLM aligned with the
+                  actual exec environment. *)
+               let cwd_response =
+                 Keeper_cwd_response.docker ~host_cwd:cwd
+                   ~container_cwd:
+                     (Keeper_turn_sandbox_runtime.container_cwd_of_host
+                        runtime ~host_cwd:cwd)
+               in
                Yojson.Safe.to_string
                  (`Assoc
                      [ "ok", `Bool true
                      ; "op", `String op
-                     ; "cwd", `String cwd
+                     ; "cwd", Keeper_cwd_response.to_yojson_response cwd_response
                      ; "count", `Int count
                      ; "via", `String "docker"
                      ; "status", Keeper_alerting_path.process_status_to_json st
@@ -2184,6 +2203,26 @@ let handle_keeper_shell
            (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd_str with
             | Error e -> path_error e
             | Ok () ->
+              (* PR #11080 sibling sweep: when [turn_sandbox_runtime]
+                 is bound the bash exec runs inside the keeper's
+                 container, so the LLM-facing [cwd] field must hold
+                 the in-container path.  When the runtime is absent
+                 (Local-effective keepers) the host path is what the
+                 keeper sees and the [Local] variant passes it
+                 through unchanged. *)
+              let cwd_response =
+                match turn_sandbox_runtime with
+                | Some runtime ->
+                  Keeper_cwd_response.docker ~host_cwd:cwd
+                    ~container_cwd:
+                      (Keeper_turn_sandbox_runtime.container_cwd_of_host
+                         runtime ~host_cwd:cwd)
+                | None ->
+                  Keeper_cwd_response.local ~host_cwd:cwd
+              in
+              let cwd_field =
+                Keeper_cwd_response.to_yojson_response cwd_response
+              in
               (* P21: exec cache — skip execution on hit, store on miss *)
               (match exec_cache with
                | Some cache ->
@@ -2198,7 +2237,7 @@ let handle_keeper_shell
                          ~cmd:cmd_str
                          ~extra:
                            [ "op", `String op
-                           ; "cwd", `String cwd
+                           ; "cwd", cwd_field
                            ; "command", `String cmd_str
                            ; "cached", `Bool true
                            ; "cache_age_ms",
@@ -2244,7 +2283,7 @@ let handle_keeper_shell
                            ~cmd:cmd_str
                            ~extra:
                              [ "op", `String op
-                             ; "cwd", `String cwd
+                             ; "cwd", cwd_field
                              ; "command", `String cmd_str
                              ; "error", `String "command_timed_out"
                              ; "timeout_sec", `Float timeout_sec
@@ -2261,7 +2300,7 @@ let handle_keeper_shell
                            ~cmd:cmd_str
                            ~extra:
                              [ "op", `String op
-                             ; "cwd", `String cwd
+                             ; "cwd", cwd_field
                              ; "command", `String cmd_str
                              ]
                            ~status:st
@@ -2290,7 +2329,7 @@ let handle_keeper_shell
                         ~cmd:cmd_str
                         ~extra:
                           [ "op", `String op
-                          ; "cwd", `String cwd
+                          ; "cwd", cwd_field
                           ; "command", `String cmd_str
                           ; "error", `String "command_timed_out"
                           ; "timeout_sec", `Float timeout_sec
@@ -2307,7 +2346,7 @@ let handle_keeper_shell
                         ~cmd:cmd_str
                         ~extra:
                           [ "op", `String op
-                          ; "cwd", `String cwd
+                          ; "cwd", cwd_field
                           ; "command", `String cmd_str
                           ]
                         ~status:st

--- a/test/dune
+++ b/test/dune
@@ -1583,6 +1583,11 @@
  (libraries masc_mcp astring alcotest yojson))
 
 (test
+ (name test_keeper_exec_shell_cwd_response)
+ (modules test_keeper_exec_shell_cwd_response)
+ (libraries astring alcotest))
+
+(test
  (name test_keeper_memory_bank_consensus_re_10399)
  (modules test_keeper_memory_bank_consensus_re_10399)
  (libraries masc_mcp alcotest eio eio_main))

--- a/test/test_keeper_exec_shell_cwd_response.ml
+++ b/test/test_keeper_exec_shell_cwd_response.ml
@@ -1,0 +1,195 @@
+(** Integration pin for PR-3 of the [Keeper_cwd_response] series.
+
+    PR-3 wires [Keeper_cwd_response.to_yojson_response] into the
+    Docker-route response builders inside [keeper_exec_shell.ml]:
+
+    - [render_docker_process_result] (op=pwd / git_status / git_diff / ...)
+    - [op="bash"] runtime branch (5 cwd-echo sites in one match arm)
+    - [op="git_log"] runtime branch (1 cwd-echo site under [via=docker])
+
+    All other [cwd] usages in the file are intentionally left
+    unchanged:
+
+    - [~fields:] / [~extra:] params to [error_json] / [Log.Keeper.*]
+      (operator-facing — host path is what operators ssh into)
+    - [keeper_bash] Local-execution branch (after the Docker
+      dispatch at lines 765/779; for Local keepers the host path
+      IS the keeper-visible path)
+    - [op] read-style ops with a [path] field (no [cwd] in
+      response Assoc — those echo the input target, separate
+      concern)
+    - [gh_base] under [op="gh"] — multiple route paths
+      (docker / brokered / host) deferred to a follow-up PR
+
+    This test is the source-level guard that pins the wired
+    sites. The runtime composition contract is already pinned
+    by [test_keeper_cwd_response] (PR-1) and
+    [test_keeper_shell_docker_cwd_response] (PR-2). *)
+
+open Alcotest
+
+let read_source path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let buf = Buffer.create 16384 in
+      (try
+         while true do
+           Buffer.add_string buf (input_line ic);
+           Buffer.add_char buf '\n'
+         done
+       with End_of_file -> ());
+      Buffer.contents buf)
+
+let find_source_path () =
+  List.find_opt Sys.file_exists
+    [
+      "lib/keeper/keeper_exec_shell.ml"
+    ; "../lib/keeper/keeper_exec_shell.ml"
+    ; "../../lib/keeper/keeper_exec_shell.ml"
+    ]
+
+let count_substring src needle =
+  let rec loop i count =
+    match Astring.String.find_sub ~start:i ~sub:needle src with
+    | None -> count
+    | Some j -> loop (j + String.length needle) (count + 1)
+  in
+  loop 0 0
+
+(* The wiring uses [Keeper_cwd_response.to_yojson_response cwd_response]
+   for the dispatcher helper and [cwd_field] (a let-bound
+   [to_yojson_response] result reused across the 5 op="bash" sites)
+   for the bash arm. Both forms must appear at least once each. *)
+
+let test_render_docker_process_result_uses_cwd_response () =
+  match find_source_path () with
+  | None -> ()
+  | Some path ->
+    let src = read_source path in
+    check bool
+      "render_docker_process_result references Keeper_cwd_response.docker"
+      true
+      (Astring.String.is_infix
+         ~affix:"Keeper_cwd_response.docker ~host_cwd:cwd"
+         src);
+    check bool
+      "Keeper_cwd_response.to_yojson_response is referenced \
+       (rendering uses it)"
+      true
+      (Astring.String.is_infix
+         ~affix:"Keeper_cwd_response.to_yojson_response"
+         src)
+
+let test_bash_op_has_runtime_aware_cwd_field () =
+  match find_source_path () with
+  | None -> ()
+  | Some path ->
+    let src = read_source path in
+    (* The op="bash" arm threads cwd_response via a [cwd_field]
+       let-binding that is reused across cached/uncached and
+       timeout/success branches. Pinning the binding shape
+       prevents accidental revert to literal `String cwd`. *)
+    check bool
+      "cwd_field let-binding (Keeper_cwd_response result) exists"
+      true
+      (Astring.String.is_infix ~affix:"let cwd_field" src);
+    check bool "cwd_field references to_yojson_response" true
+      (Astring.String.is_infix
+         ~affix:"Keeper_cwd_response.to_yojson_response cwd_response"
+         src);
+    (* The bash arm previously had 5 [`String cwd] echo sites; all
+       should now read [cwd_field]. We assert at least 4 occurrences
+       of [cwd_field] in the response Assoc lists. *)
+    let cwd_field_uses = count_substring src "; \"cwd\", cwd_field" in
+    check bool
+      (Printf.sprintf
+         "cwd_field used in >= 4 Assoc lists (found %d)"
+         cwd_field_uses)
+      true (cwd_field_uses >= 4)
+
+let test_git_log_runtime_branch_uses_cwd_response () =
+  match find_source_path () with
+  | None -> ()
+  | Some path ->
+    let src = read_source path in
+    (* The git_log runtime branch builds its own cwd_response.
+       Verify at least 2 distinct [cwd_response = Keeper_cwd_response.docker]
+       constructions in the file (render_docker + git_log; the
+       op="bash" arm uses [match turn_sandbox_runtime] form
+       which differs). *)
+    let docker_ctor_uses =
+      count_substring src "Keeper_cwd_response.docker ~host_cwd:cwd"
+    in
+    check bool
+      (Printf.sprintf
+         "Keeper_cwd_response.docker constructor used >= 2 times \
+          (found %d)"
+         docker_ctor_uses)
+      true (docker_ctor_uses >= 2)
+
+(* Negative pin: a raw [String cwd] literal must not appear
+   in the same Assoc as a [via=docker] tag. For each line
+   that contains the cwd-string-literal pattern, scan up to
+   12 lines forward for a sibling docker-via line; any match
+   is a regression and fails the test with the offending
+   line numbers. *)
+
+let test_no_raw_cwd_in_docker_route () =
+  match find_source_path () with
+  | None -> ()
+  | Some path ->
+    let src = read_source path in
+    let lines = String.split_on_char '\n' src in
+    let arr = Array.of_list lines in
+    let n = Array.length arr in
+    let leaks = ref [] in
+    for i = 0 to n - 1 do
+      if
+        Astring.String.is_infix ~affix:"\"cwd\", `String cwd"
+          arr.(i)
+      then begin
+        (* Look forward up to 12 lines for a sibling
+           [via, `String "docker"] in the same Assoc. *)
+        let upper = min (n - 1) (i + 12) in
+        let found_docker_via = ref false in
+        for j = i + 1 to upper do
+          if
+            Astring.String.is_infix
+              ~affix:"\"via\", `String \"docker\""
+              arr.(j)
+          then found_docker_via := true
+        done;
+        if !found_docker_via then leaks := (i + 1) :: !leaks
+      end
+    done;
+    let leaks = List.rev !leaks in
+    if leaks <> [] then
+      Alcotest.failf
+        "raw (\"cwd\", `String cwd) literal found near a \
+         (\"via\", `String \"docker\") site at line(s): %s"
+        (String.concat ", " (List.map string_of_int leaks))
+
+let () =
+  run "keeper_exec_shell_cwd_response"
+    [
+      ( "wiring-pins"
+      , [
+          test_case
+            "render_docker_process_result wires Cwd_response"
+            `Quick
+            test_render_docker_process_result_uses_cwd_response
+        ; test_case "op=bash uses runtime-aware cwd_field" `Quick
+            test_bash_op_has_runtime_aware_cwd_field
+        ; test_case
+            "git_log runtime branch wires Cwd_response"
+            `Quick test_git_log_runtime_branch_uses_cwd_response
+        ] )
+    ; ( "no-leak-near-docker-via"
+      , [
+          test_case
+            "no raw (\"cwd\", `String cwd) literal near via=docker"
+            `Quick test_no_raw_cwd_in_docker_route
+        ] )
+    ]


### PR DESCRIPTION
## Why

PR #11336 (PR-2) 가 `keeper_shell_docker.ml` 의 4 응답 site 를 fix 했지만, `keeper_exec_shell.ml` 에도 같은 클래스의 docker-route response builder 가 여러 곳 있어 host path 가 LLM 에 echo 된다. 이 PR (PR-3) 가 그 중 fix 가능한 7 site 를 wire 한다.

## What

3 곳의 Docker-route 응답 builder 에 `Keeper_cwd_response.to_yojson_response` 적용:

### Site 1: `render_docker_process_result` (1 echo)
op=`pwd`, `git_status`, `git_diff` 등이 `Keeper_docker_read.should_route_read` 로 docker route 선택될 때 사용되는 helper. host_cwd → `Keeper_shell_docker.docker_private_workspace_cwd` → container_cwd 변환 후 응답.

### Site 2: `op="bash"` arm (5 echoes in 1 match arm)
cached hit / cached miss 의 timeout / success / no-cache 의 timeout / success 5 가지 분기 모두 host cwd echo. 단일 `cwd_field` let-binding 으로 통합. Audience signal 은 `turn_sandbox_runtime` presence:
- `Some runtime` → `Keeper_cwd_response.docker` (container path)
- `None` → `Keeper_cwd_response.local` (host path 통과)

### Site 3: `op=\"git_log\"` runtime branch (1 echo)
`Some runtime` 경로에서 `via=docker` Assoc 안의 cwd 가 host path. `Keeper_turn_sandbox_runtime.container_cwd_of_host` 로 변환.

## 의도적 미변경 (Out of scope)

| 분류 | 위치 | 이유 |
|------|------|------|
| Operator log | 963, 1500, 1511, 1773, 1828, 2110 (`~fields`/`~extra`) | `error_json`/`Log.Keeper.*` operator-facing — host path 가 디버깅에 필요 (plan §4 audience policy) |
| Local-only branch | 1000, 1067, 1118, 1156, 1201, 1227 (keeper_bash Local 분기) | line 787 이후. Local-effective keeper 는 호스트에서 실행 → host == keeper-visible |
| Read-style ops | ls/cat/rg/find/head Assoc | `path` field 만 echo (cwd 없음). 별도 follow-up |
| `gh_base` | 2561 (op=`gh`) | docker / brokered / host 3-way 분기, brokered 의미 분석 필요. 별도 PR |

## Test

`test/test_keeper_exec_shell_cwd_response.ml` 추가, 4 testcase, 0.008s.

1. **Wiring pin (Site 1)**: `render_docker_process_result` 가 `Keeper_cwd_response.docker ~host_cwd:cwd` 를 사용하는지.
2. **Wiring pin (Site 2)**: op=`bash` 가 `cwd_field` let-binding 을 사용하고 4+ Assoc list 에서 재사용되는지.
3. **Wiring pin (Site 3)**: `Keeper_cwd_response.docker` 생성자가 2회 이상 호출되는지 (Site 1 + Site 3).
4. **Negative pin**: 어떤 Assoc 에서도 raw `(\"cwd\", \`String cwd)` literal 이 `via=docker` 태그 인접에 등장하지 않는지.

```bash
dune build --root . @check
dune exec --root . test/test_keeper_exec_shell_cwd_response.exe
# Test Successful in 0.008s. 4 tests run.

# 회귀 검증
dune exec --root . test/test_keeper_cwd_response.exe   # PR-1: 7/7
```

## Stack

```
main
└── feat/keeper-cwd-response (PR #11323, PR-1)
    ├── feat/keeper-cwd-response-shell-docker (PR #11336, PR-2)
    └── feat/keeper-cwd-response-exec-shell (this, PR-3)
```

PR-2 와 PR-3 는 parallel stack — 둘 다 PR-1 만 의존, 서로 독립. PR-1 머지 후 양쪽 모두 base 를 main 으로 바꿔 rebase (memory: `feedback_stack-pr-base-force-push-loses-patches`).

## References

- PR #10650 — `default_cwd` fix (sibling 누락)
- PR #11080 — `sandbox_host_root` / `playground_path` 제거 (~890 docker fail/day 감소)
- PR #11234 — sandbox cwd 규칙 문서화
- PR #11256 — `via:\"host\"` 태그

## Series

- PR-1 #11323 — module + property test ✅
- PR-2 #11336 — keeper_shell_docker.ml wiring ✅
- **PR-3 (this) — keeper_exec_shell.ml docker-route wiring**
- PR-4 — keeper_status_detail.ml playground_repos sanitizer
- PR-5 — keeper.unified.system.md cwd format
- PR-6 — MLI gate + CI grep gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)