### PR TITLE
verify-bloodflow: precise F4/F5 grep patterns

### DIFF
--- a/scripts/verify-bloodflow-restoration.sh
+++ b/scripts/verify-bloodflow-restoration.sh
@@ -126,25 +126,52 @@ echo "F3 empty_tool_universe blocker events:   $f3"
 echo "   (broken down by lane in dashboard via labels turn_lane / fallback_used)"
 
 # ----- F4: contains_substring SSOT --------------------------------------
-# Static check: scan lib/keeper for [contains_substring].  After Phase B
-# PR-5 main, this should be 0.  Currently 1 (the SSOT in
-# Keeper_failure_circuit_breaker.classify_error).
-f4_hits=$(grep -rln 'contains_substring' "$ROOT/lib/keeper/" 2>/dev/null | wc -l | tr -d ' ')
+# Static check: count call sites of [String_util.contains_substring] only
+# (function calls, not the [_ci] sibling and not doc-comments referencing
+# the symbol by name).  Pattern requires a non-word char after
+# [contains_substring] so [contains_substring_ci] does not match.
+# Phase A F4 collapsed only the SSOT consumer; PR-5 main (the producer
+# refactor) is what drives this count to 0.
+f4_files=$(grep -rlE 'String_util\.contains_substring[^_a-zA-Z]' \
+  "$ROOT/lib/keeper/" 2>/dev/null | wc -l | tr -d ' ')
 echo
-echo "F4 contains_substring sites in lib/keeper/: $f4_hits"
-if [ "$f4_hits" -le 1 ]; then
+echo "F4 contains_substring caller files in lib/keeper/: $f4_files"
+if [ "$f4_files" -eq 0 ]; then
+  echo "  -> Phase B PR-5 main complete (target 0 reached)."
+elif [ "$f4_files" -le 1 ]; then
   echo "  -> Phase A F4 SSOT collapse holds (target after PR-5: 0)."
 else
-  echo "  -> Phase A F4 SSOT regression — investigate."
+  echo "  -> Phase B PR-5 main scope: $f4_files files still call SSOT."
 fi
 
 # ----- F5: gh-api token-aware + strip_keeper_prefix helpers in use -------
-# Static check: legacy literal patterns should be 0 outside SSOT.
-prefix_literals=$(grep -rln 'String\.sub trimmed 0 [0-9]\+ = "keeper-"' "$ROOT/lib/keeper/" 2>/dev/null | wc -l | tr -d ' ')
-api_prefix=$(grep -rln 'is_prefix cmd_lower ~prefix:"api"' "$ROOT/lib/keeper/" 2>/dev/null | wc -l | tr -d ' ')
+# Static check: legacy literal slice patterns.  We count files that
+# contain the slice as **executable code**, not as prose inside a
+# doc-comment reference (e.g. [String.sub trimmed 0 7 = "keeper-"] in a
+# Phase A F5 comment that documents the now-collapsed legacy pattern).
+# Heuristic: drop lines starting with a continuation `*` (multi-line
+# OCaml comment body) before counting unique files.
+count_files_excluding_doc_prose() {
+  local pattern="$1"
+  local dir="$2"
+  # Drop two false-positive forms before counting unique files:
+  # 1. multi-line OCaml comment continuation (line starts with ` * `)
+  # 2. doc-comment bracketed pseudo-code references like `[String.sub ...]`
+  #    (the bracketed form never appears in real OCaml code paths since
+  #    OCaml lists do not wrap boolean expressions).
+  grep -rnE "$pattern" "$dir" 2>/dev/null \
+    | grep -vE ':[[:space:]]*\*[[:space:]]+' \
+    | grep -vF '[String.sub' \
+    | grep -vF '[is_prefix' \
+    | cut -d: -f1 | sort -u | wc -l | tr -d ' '
+}
+prefix_literals=$(count_files_excluding_doc_prose \
+  'String\.sub [a-z_]+ 0 [0-9]+ = "keeper-"' "$ROOT/lib/keeper/")
+api_prefix=$(count_files_excluding_doc_prose \
+  'is_prefix [a-z_]+ ~prefix:"api"' "$ROOT/lib/keeper/")
 echo
-echo "F5 legacy keeper- literal slice sites:   $prefix_literals (target 0)"
-echo "   legacy is_prefix \"api\" sites:         $api_prefix (target 0)"
+echo "F5 legacy keeper- literal slice files:   $prefix_literals (target 0)"
+echo "   legacy is_prefix \"api\" files:         $api_prefix (target 0)"
 
 # ----- Composite KPI: mutation_to_passive_ratio --------------------------
 echo


### PR DESCRIPTION
## Summary

Follow-up to #11344 (verify-bloodflow-restoration.sh).  The initial
F4 / F5 grep patterns were too broad and counted every textual mention
of the symbol — doc-comment references that document the *legacy*
pattern after a refactor inflated the count and made the script's
output indistinguishable from a real regression.

## Sample comparison (run against current main)

| Pattern | Before | After |
|---|---:|---:|
| F4 ``contains_substring`` | **30** | **11** |
| F5 ``keeper-`` literal slice | 1 | 0 |
| F5 ``is_prefix "api"`` | 0 | 0 |

## What was inflating the count

**F4 (30 → 11)** was double-counting:
1. ``String_util.contains_substring_ci`` — sibling utility, not a
   regression.  Pattern now requires a non-word char immediately after
   the symbol so the ``_ci`` sites no longer match.
2. Doc-comments that describe the legacy pattern in OCaml
   bracketed-pseudo-code form — e.g. the F4 PR's own comment in
   ``keeper_exec_shared.ml:46`` cites the previous ladder shape.

**F5 (1 → 0)** was hitting one multi-line doc-comment in
``keeper_identity.ml`` that cites the legacy pattern by name.  A
two-stage filter handles both forms:

```bash
grep -rnE "<pattern>" "$dir" \
  | grep -vE ':[[:space:]]*\*[[:space:]]+'   # multi-line comment continuation
  | grep -vF '[String.sub'                   # bracketed pseudo-code reference
  | cut -d: -f1 | sort -u | wc -l
```

The bracketed-pseudo-code filter is correct because OCaml lists never
wrap boolean expressions like ``String.sub ... = "keeper-"`` — every
real bracketed match is a doc reference.

## Why this matters

The post-fix F4 = 11 is the **true Phase B PR-5 main scope** — eleven
caller files in ``lib/keeper/`` still hold raw error strings and route
them through ``Keeper_failure_circuit_breaker.classify_error``.  Phase
B PR-5 main turns each of those return paths into typed
``error_class`` values.  Without this precision fix, the verify script
was reporting a 30-file scope that included false positives, making
the PR-5 sizing decision noisier than it needed to be.

## Test plan

- [x] Local run shows F4=11, F5=0/0 against current main
- [x] Bash 3.2 (macOS) compatible — no GNU-only grep flags
- [ ] CI: shell scripts not currently linted in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)