### PR TITLE
docs(keeper): explain cwd response format for Docker vs Local keepers

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -41,6 +41,15 @@ Your shell starts at the sandbox root, which is **not** a git repository.
 - Common error: a tool returns `not a git repository` or `path_outside_sandbox`. That is the sandbox root rejecting a git/gh call. Re-issue the call with the repo path in `cwd`.
 - Do not invent host paths like `/Users/...` or `/workspace/`; relative paths under the sandbox root are the only valid form.
 
+### What the `cwd` field in tool responses means
+
+Tool responses include a `cwd` field that reflects where the command actually ran. The exact path you see depends on your sandbox backend:
+
+- **Docker keepers** (sandbox_profile=docker, or Local-meta inside an enabled docker playground): `cwd` is the in-container path, e.g. `/home/keeper/playground/<your-name>/repos/<REPO>`. This is where commands actually executed inside your container. Pass that path back as a `cwd` argument on the next turn — relative form (`repos/<REPO>`) also works because the tool resolves both.
+- **Local keepers** (sandbox_profile=local, no docker upgrade): `cwd` is a host abs path under the operator's filesystem, e.g. `/Users/.../.masc/playground/<your-name>/repos/<REPO>`. This is the only form the tool accepts here.
+
+Older turns in your context may show host paths (`/Users/...`) for what is now a Docker-effective keeper — that history is stale. Ignore the absolute form and re-issue using the relative path (`repos/<REPO>`); the response from the next call will surface the correct in-container `cwd`.
+
 ## Behavior
 
 You have tools. Prefer tool calls over text-only responses.


### PR DESCRIPTION
## Why

PR #11234 가 sandbox cwd 사용 규칙을 문서화했지만, 응답의 `cwd` 필드가 어떤 path 포맷인지 (host vs container) 는 명시되어 있지 않았다. PR-3 시리즈 (#11323/#11336/#11349) 가 wire 되면서 Docker keeper 의 응답 cwd 가 container path 로 바뀐다 — LLM 이 이 변화를 자연스럽게 받아들이도록 prompt 에 명시.

## What

`config/prompts/keeper.unified.system.md` 의 "Sandbox path conventions" 섹션에 새 subsection 추가:

> ### What the `cwd` field in tool responses means
> - **Docker keepers**: container path (`/home/keeper/playground/...`)
> - **Local keepers**: host abs path
> - 과거 turn 의 stale `/Users/...` 는 무시하고 relative form (`repos/<REPO>`) 사용

핵심 메시지:
1. 응답의 `cwd` 는 **실제로 명령이 실행된 위치** 를 반영.
2. Docker / Local backend 별로 path 포맷이 다름 (audience-aware).
3. Stale history (이전 host path) 는 무시하고 relative form 으로 재시도.

## Scope

Doc-only 변경, 9 줄 추가. 코드 의존 없음 — 코드 wiring PR 들과 독립적으로 ship 가능. 오히려 wiring PR 머지 전에 ship 해서 LLM expectation 을 미리 준비할 수 있음.

## Series

- PR-1 #11323 — Keeper_cwd_response 모듈
- PR-2 #11336 — keeper_shell_docker.ml wiring
- PR-3 #11349 — keeper_exec_shell.ml docker-route wiring
- PR-4 — (skipped, false alarm: playground_state.json writer 가 host path 를 직렬화하지 않음, pr_history.jsonl writer 부재)
- **PR-5 (this) — keeper.unified.system.md cwd format 안내**
- PR-6 — MLI gate + CI grep gate

## References

- PR #11234 — sandbox cwd 규칙 (이 PR 의 base 문서)
- PR #11080 — `sandbox_host_root` / `playground_path` 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)