### PR TITLE
chore(ci): add keeper-cwd-leak-gate to prevent host_cwd echo regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,6 +697,20 @@ jobs:
       - name: Run OCaml structure ratchet
         run: scripts/ocaml-structure-ratchet.sh
 
+  keeper-cwd-leak-gate:
+    name: Keeper Cwd Leak Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [pr-sync-check]
+    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run keeper cwd leak gate
+        run: scripts/keeper-cwd-leak-gate.sh
+
   tla-specs:
     name: TLA+ Model Checking
     runs-on: ubuntu-latest

--- a/scripts/keeper-cwd-leak-gate.sh
+++ b/scripts/keeper-cwd-leak-gate.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Keeper host_cwd leak gate.
+#
+# Rule: no `("cwd", `String cwd)` literal may appear in an Assoc list
+# that also contains `("via", `String "docker")` within ±15 lines, in
+# any file under lib/keeper/.
+#
+# Background: PR #11080 fixed the host path leak in
+# keeper_status_detail.execution_context. Sibling response builders
+# in keeper_shell_docker.ml and keeper_exec_shell.ml had the same
+# bug class — Docker `--workdir` was translated to the in-container
+# path, but the response JSON echoed the host abs path, so the LLM
+# emitted `cd /Users/...` on the next turn (invalid inside the
+# container). PRs #11323 / #11336 / #11349 introduced the
+# `Keeper_cwd_response` audience-tagged type and wired it through
+# the Docker-route response builders. This gate prevents future
+# regressions of the same bug class by failing CI when the
+# leak-prone literal pattern reappears near a docker-route tag.
+#
+# Usage:
+#   scripts/keeper-cwd-leak-gate.sh         # check; exit 0 ok / 1 leak found
+#
+# Exit codes:
+#   0  no leak detected
+#   1  one or more leaks detected (file:line printed for each)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET_DIR="${REPO_ROOT}/lib/keeper"
+LITERAL_PATTERN='("cwd", `String cwd)'
+DOCKER_PATTERN='("via", `String "docker")'
+WINDOW=15
+
+if [ ! -d "${TARGET_DIR}" ]; then
+  echo "ERROR: target directory not found: ${TARGET_DIR}" >&2
+  exit 1
+fi
+
+failures=0
+failure_lines=""
+
+# shellcheck disable=SC2044
+for f in $(find "${TARGET_DIR}" -name '*.ml' -type f); do
+  rel="${f#${REPO_ROOT}/}"
+  # Find every line containing the leak literal.
+  while IFS=: read -r ln content; do
+    [ -z "${ln}" ] && continue
+    # Compute window bounds, clamped to [1, file_lines].
+    start=$(( ln > WINDOW ? ln - WINDOW : 1 ))
+    end=$(( ln + WINDOW ))
+    # Look for docker-route tag within the window.
+    if sed -n "${start},${end}p" "${f}" | grep -F -q "${DOCKER_PATTERN}"; then
+      failure_lines="${failure_lines}${rel}:${ln}: ${content}"$'\n'
+      failures=$(( failures + 1 ))
+    fi
+  done < <(grep -nF "${LITERAL_PATTERN}" "${f}" 2>/dev/null || true)
+done
+
+if [ "${failures}" -gt 0 ]; then
+  printf '%s' "${failure_lines}" >&2
+  echo "" >&2
+  echo "${failures} host_cwd leak(s) detected near a (\"via\", \`String \"docker\") tag." >&2
+  echo "Wire the response builder through Keeper_cwd_response.to_yojson_response." >&2
+  echo "Reference: lib/keeper/keeper_cwd_response.mli (PR #11323), and the wiring patterns in" >&2
+  echo "  lib/keeper/keeper_shell_docker.ml (PR #11336)" >&2
+  echo "  lib/keeper/keeper_exec_shell.ml (PR #11349)" >&2
+  exit 1
+fi
+
+echo "OK: no host_cwd leak in ${TARGET_DIR#${REPO_ROOT}/}"


### PR DESCRIPTION
## Why

PRs #11323 / #11336 / #11349 fix 4 + ~7 host_cwd echo leaks in keeper LLM-facing response builders. Without a gate the same class of bug can re-emerge — a future contributor adds a new docker-route response builder and writes `(\"cwd\", \`String cwd)` instead of going through `Keeper_cwd_response.to_yojson_response`. Memory `feedback_audit-bucket-cascade-pattern`: 같은 bug class 가 2회+ 등장하면 sweep + lint gate 동시 적용.

## What

- `scripts/keeper-cwd-leak-gate.sh` (72 lines): bash gate. Scans `lib/keeper/**/*.ml` for the literal pattern `(\"cwd\", \`String cwd)`, then for each match looks ±15 lines for a sibling `(\"via\", \`String \"docker\")` tag. Any pair = leak. Exits 1 with `file:line` pointers and a remediation hint pointing to the wiring patterns.
- `.github/workflows/ci.yml`: new `keeper-cwd-leak-gate` job (timeout 2 min, runs alongside structure-ratchet).

## Verification

```bash
# Positive (integrated PR-1 + PR-2 + PR-3 state):
$ bash scripts/keeper-cwd-leak-gate.sh
OK: no host_cwd leak in lib/keeper

# Negative (revert lib/keeper/keeper_shell_docker.ml to main):
$ git checkout origin/main -- lib/keeper/keeper_shell_docker.ml
$ bash scripts/keeper-cwd-leak-gate.sh
lib/keeper/keeper_shell_docker.ml:552:                 (\"cwd\", \`String cwd);
lib/keeper/keeper_shell_docker.ml:572:                (\"cwd\", \`String cwd);
lib/keeper/keeper_shell_docker.ml:621:                 (\"cwd\", \`String cwd);
lib/keeper/keeper_shell_docker.ml:645:                (\"cwd\", \`String cwd);
4 host_cwd leak(s) detected near a (\"via\", \`String \"docker\") tag.
exit=1
```

정확히 PR-2 가 fix 한 4 site 검출. False negative / false positive 없음.

## Stack note

이 PR 의 branch `chore/keeper-cwd-leak-gate` 는 `feat/keeper-cwd-response-exec-shell` (PR-3) 위에 `feat/keeper-cwd-response-shell-docker` (PR-2) 를 merge 한 통합 상태에서 시작. 이로써 gate 가 end-to-end 로 통과하는 것을 verify 가능. 

Base 는 `feat/keeper-cwd-response` (PR-1) — PR-1 머지 후 base 를 main 으로 변경 + rebase 하면 diff 는 gate script + workflow 변경만 남는다.

## Series 종료

| PR | 역할 | 상태 |
|----|------|------|
| #11323 | `Keeper_cwd_response` 모듈 | Draft |
| #11336 | `keeper_shell_docker.ml` wiring | Draft |
| #11349 | `keeper_exec_shell.ml` wiring | Draft |
| #11352 | `keeper.unified.system.md` doc | Draft |
| (skipped) | PR-4: `playground_state.json` sanitizer — false alarm (writer 가 host path 직렬화 안 함) |
| #이 PR | CI gate | Draft |

이 PR 머지 후 같은 클래스의 누수 재발 = compile-time (type boundary, PR-1) + lint-time (이 gate) 양쪽 차단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)