### PR TITLE
refactor(keeper): add keeper_status.mli (PR#3 batch 14)

### DIFF
--- a/lib/keeper/keeper_status.mli
+++ b/lib/keeper/keeper_status.mli
@@ -1,0 +1,28 @@
+(** Keeper_status — keeper list/trajectory/eval handlers and status dispatch.
+
+    Single-keeper detail lives in [Keeper_status_detail]. This module
+    is the dispatcher facade for the keeper status tools. *)
+
+include module type of Keeper_status_bridge
+
+type tool_result = Keeper_types.tool_result
+
+(** Detail handler re-exported from [Keeper_status_detail]; returns
+    a JSON-encoded keeper status snapshot for [args.name]. *)
+val handle_keeper_status :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result
+
+(** List up to [args.limit] keepers (default 50) with optional
+    [args.detailed] meta projection. *)
+val handle_keeper_list :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result
+
+(** Read recent trajectory entries (default 20) for the keeper named
+    in [args.name], scoped to its current trace_id. *)
+val handle_keeper_trajectory :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result
+
+(** Run the keeper-eval projection (continuity/blocker summary) for
+    [args.name]. *)
+val handle_keeper_eval :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result


### PR DESCRIPTION
## Summary

PR#3 batch 14.

| module | lines |
|---|---|
| `keeper_status` | 366 |

This is the keeper status tool dispatch facade — single-keeper
detail lives in `Keeper_status_detail`.

Exposed:
- `include module type of Keeper_status_bridge` (mirrors the .ml's `include`)
- `type tool_result = Keeper_types.tool_result`
- `handle_keeper_status` (re-export from `Keeper_status_detail`)
- `handle_keeper_list`, `handle_keeper_trajectory`, `handle_keeper_eval`

All handler signatures follow the standard
`_ Keeper_types.context -> Yojson.Safe.t -> tool_result` pattern.

## Surgical

- .ml unchanged.

## Test plan

- [x] dune build ✓
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)