### PR TITLE
feat(keeper): emit FSM Awaiting_provider -> Streaming at run_turn dispatch (Step 4i)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1675,6 +1675,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 (Option.map Keeper_id.Task_id.to_string
                    run_meta.current_task_id)
               (fun () ->
+                Keeper_turn_fsm.emit_transition
+                  ~keeper_name:meta.name ~turn_id:keeper_turn_id
+                  ~prev:Keeper_turn_fsm.Awaiting_provider
+                  Keeper_turn_fsm.Streaming;
                 Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
                   ~max_context:execution.max_context ~build_turn_prompt
                   ~user_message ~cascade_name:execution.cascade_name


### PR DESCRIPTION
## Summary

Closes the last in-cycle gap of the dispatch lane. Right before each \`Keeper_agent_run.run_turn\` attempt fires (inside the retry_loop wrapping closure), emit \`Awaiting_provider -> Streaming\`. /loop iteration 5 of "fsm 쪽 더 선명하게".

## Site

| line | prev              | turn_state |
|------|-------------------|------------|
| 1678 | Awaiting_provider | Streaming  |

Inside the \`perform_with_inflight\` closure that wraps the \`run_turn\` call, so every cascade-rotation attempt produces its own line — a turn that fails over Codex → Kimi → Claude shows three streaming entries on its \`bin/masc-trace\` timeline, one per attempt.

## Why

After Step 4g (#11347) the dispatch lane already had:

```
- -> phase_gating
phase_gating -> cascade_routing
cascade_routing -> awaiting_provider
streaming -> completing            ← gap!
completing -> done
```

The \`streaming -> completing\` line appeared without an \`awaiting_provider -> streaming\` line above; an operator reading \`bin/masc-trace\` had to know the gap was intentional. This PR fills it.

The \`Streaming ⇄ Awaiting_tool_result\` toggling inside \`run_turn\` still has no emit; that lives in \`keeper_agent_run.ml\` and is left as the next \`run_turn\`-side adoption step. This PR keeps everything inside \`keeper_unified_turn.ml\` so the diff stays trivially reviewable.

## Volume

One extra \`Log.Keeper.info\` + Prometheus increment per \`run_turn\` attempt. Cascade-rotated turns produce one emit per attempt — right cardinality since each attempt hits a distinct provider. ~120-160 lines/min on top of system_log ~5k+/min. No control-flow change.

## Test plan

- [x] \`dune build\` (default + release) green locally
- [x] \`test_keeper_turn_fsm_emit\` 4/4 OK locally
- [ ] CI lint + meta-guards green
- [ ] Post-merge: pick a turn_id from \`bin/masc-trace\` and confirm \`awaiting_provider -> streaming\` appears above \`streaming -> completing\`

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4i.

🤖 Generated with [Claude Code](https://claude.com/claude-code)