### PR TITLE
feat(keeper-receipt): outcome_kind tri-state classification (Cycle 1a foundation)

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -1,3 +1,26 @@
+(* Receipt outcome classification. Tri-state mirrors the TLA+ spec
+   [ReceiptOutcomeSet] (see [specs/keeper-state-machine/
+   KeeperOutcomesConservation.tla]). The receipt record still stores
+   the legacy string for JSON compatibility; consumers and producers
+   that care about Cancelled vs Error must use these helpers to avoid
+   silently folding a cancellation into a failure. *)
+type outcome_kind = [ `Ok | `Error | `Cancelled ]
+
+let outcome_kind_to_string = function
+  | `Ok -> "ok"
+  | `Error -> "error"
+  | `Cancelled -> "cancelled"
+
+let outcome_kind_of_string = function
+  | "ok" -> Some `Ok
+  | "error" -> Some `Error
+  | "cancelled" -> Some `Cancelled
+  | _ -> None
+
+let outcome_kind_is_terminal_success = function
+  | `Ok -> true
+  | `Error | `Cancelled -> false
+
 type tool_surface =
   { turn_lane : string
   ; tool_surface_class : string
@@ -167,12 +190,18 @@ let operator_disposition (receipt : t) =
      error AND cascade reached the configured terminal. Any other fallthrough
      is an unmapped state — surface it as "unknown" so a new cascade_outcome
      or terminal_reason_code does not silently display as "healthy" on the
-     dashboard. See #9900 and CLAUDE.md anti-pattern #2. *)
-  else if
-    String.equal receipt.outcome "ok"
-    && String.equal cascade_outcome "completed"
-  then ("pass", "healthy")
-  else ("unknown", "unmapped_cascade_state")
+     dashboard. See #9900 and CLAUDE.md anti-pattern #2.
+
+     Cancelled is split out from the legacy binary outcome so dashboards
+     and replay decoders can distinguish a user-initiated cancellation
+     from a true failure. Spec parity with [ReceiptOutcomeSet] in
+     [specs/keeper-state-machine/KeeperOutcomesConservation.tla]. *)
+  else
+    match outcome_kind_of_string receipt.outcome with
+    | Some `Cancelled -> ("user_cancelled", "cancelled")
+    | Some `Ok when String.equal cascade_outcome "completed" ->
+      ("pass", "healthy")
+    | _ -> ("unknown", "unmapped_cascade_state")
 
 let to_json (receipt : t) =
   let operator_disposition, operator_disposition_reason =
@@ -226,7 +255,10 @@ let to_json (receipt : t) =
              ("target_kind", `String "keeper");
              ("target_path", string_opt_json receipt.sandbox_root);
            ])
-      ~success:(String.equal receipt.outcome "ok")
+      ~success:
+        (match outcome_kind_of_string receipt.outcome with
+         | Some kind -> outcome_kind_is_terminal_success kind
+         | None -> false (* unknown outcome: fail-closed *))
       ~duration_ms:(receipt_duration_ms receipt)
       ?error:receipt.error_message
       ~sandbox_target:receipt.sandbox_kind

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -1,3 +1,25 @@
+(** Receipt outcome classification. Tri-state matches the TLA+ spec
+    [ReceiptOutcomeSet = {"receipt_done", "receipt_failed", "receipt_cancelled"}]
+    rather than the previous binary string. Cancelled turns must be
+    distinguished from errors so that dashboards and replay decoders do
+    not silently fold cancellations into failures. See [Spec:
+    KeeperOutcomesConservation.tla], invariant [ReceiptMatchesState]. *)
+type outcome_kind = [ `Ok | `Error | `Cancelled ]
+
+val outcome_kind_to_string : outcome_kind -> string
+(** Stable serialisation: [`Ok -> "ok"], [`Error -> "error"],
+    [`Cancelled -> "cancelled"]. Used at the JSON boundary while the
+    receipt record still stores the legacy string form. *)
+
+val outcome_kind_of_string : string -> outcome_kind option
+(** Parse the legacy string form. Returns [None] for unknown values so
+    callers can decide whether to fail-closed or surface as [`Error]. *)
+
+val outcome_kind_is_terminal_success : outcome_kind -> bool
+(** [true] only for [`Ok]. Cancelled turns are NOT successful for the
+    purpose of dashboard "healthy" classification or action_radius
+    success accounting. *)
+
 type tool_surface =
   { turn_lane : string
   ; tool_surface_class : string


### PR DESCRIPTION
## Summary

Introduce `outcome_kind = [` `` `Ok `` ` | ` `` `Error `` ` | ` `` `Cancelled `` `]` named type in `Keeper_execution_receipt` to start closing the spec-implementation drift where the TLA+ spec defines a tri-state `ReceiptOutcomeSet` while OCaml collapses cancellations into `"error"`.

This PR is the **foundation only**: it adds the type, helpers, and updates the two visible consumers (`operator_disposition` and the `to_json` action_radius `~success` field) so that any string outcome parsed as `` `Cancelled `` is routed to a separate `user_cancelled` disposition rather than being misclassified as a failure.

## Why (formalized incompleteness)

Per the integration plan at `planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md` this is a **Drift fix** (not a refinement): the TLA+ spec `specs/keeper-state-machine/KeeperOutcomesConservation.tla` allows three outcomes; OCaml collapses two and the gap caused cancelled turns to be retried by dashboards expecting an error classification.

The fix prioritises **safety** (no silent fold) over **liveness** (producer-side cancellation propagation is left as a follow-up that requires a larger code-flow change).

## What changed

- New named type `outcome_kind = [` `` `Ok `` ` | ` `` `Error `` ` | ` `` `Cancelled `` `]` with three helpers:
  - `outcome_kind_to_string` (stable serialisation)
  - `outcome_kind_of_string` (parse legacy string, `None` for unknown)
  - `outcome_kind_is_terminal_success` (only `` `Ok `` is success)
- `operator_disposition` (consumer #1): cancelled outcomes route to `("user_cancelled", "cancelled")` instead of falling through to `"unknown"` or being misclassified as healthy.
- `to_json` action_radius `~success` (consumer #2): parses outcome through the helper; unknown outcomes are fail-closed (success=false).

## What is NOT in this PR (follow-up)

| Follow-up | Rationale |
|-----------|-----------|
| **Post-dispatch producer** in `keeper_agent_run.ml:2847-2850` setting `outcome="cancelled"` when the turn was cancelled | OAS `Oas.Error` has no Cancelled variant; `turn_result` cannot represent cancellation. Requires a new outer Cancel-handler that captures cancellation before re-raising and propagates a flag to the receipt builder. Larger surface, separate PR. |
| **Pre-dispatch producer** in `keeper_unified_turn.ml:145` (`record_pre_dispatch_terminal_observation`) — caller chain at lines 1075, 1188, 1275, 1318 — passing `~outcome:"cancelled"` where applicable | Each caller needs its own classification audit; safer one PR per call site. |
| `cascade_rotation_attempt.outcome` and `tool_execution_summary.outcome` | Different semantic domain (per-cascade-attempt and per-tool-call); the spec mapping is not the same as receipt outcome. Out of scope. |
| Unit tests for the new helpers and disposition routing | Will land with the post-dispatch producer PR so the test exercises the full path. |
| Narrowing the receipt record `outcome` field type from `string` to `outcome_kind` | Larger surface (13+ generator/consumer sites). Will land after producer PR confirms the helper API is stable. |

## Test plan

- [x] `dune build @check` (worktree) passes — background task `bxyhv104m` exit 0; `_build/default/lib/keeper/` populated 03:31:42.
- [ ] `dune runtest` — pending (no new tests yet; existing tests should still pass since the wire format is unchanged).
- [ ] Add unit test for `operator_disposition` cancelled case in the follow-up PR.

## Spec link

`specs/keeper-state-machine/KeeperOutcomesConservation.tla` — invariant `ReceiptMatchesState` and the `ReceiptOutcomeSet` tri-state definition.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
