### PR TITLE
refactor(keeper): add keeper_turn_up_create.mli (PR#3 batch 17)

### DIFF
--- a/lib/keeper/keeper_turn_up_create.mli
+++ b/lib/keeper/keeper_turn_up_create.mli
@@ -1,0 +1,28 @@
+(** Keeper_turn_up_create — create a new keeper from parsed arguments.
+
+    Extracted from [keeper_turn_up.ml]'s [Ok None] branch. Handles
+    initial keeper meta construction, checkpoint creation,
+    keepalive start, and response JSON generation. *)
+
+open Keeper_types
+
+(** Resolve the tool_preset from [profile_defaults.tool_preset]
+    via [Keeper_preset_defaults.preset_of_defaults_warn] with
+    [call_site:"keeper_turn_up_create"]. Returns [None] when the
+    defaults field is unset or names an unknown preset. *)
+val preset_of_defaults :
+  keeper_profile_defaults -> tool_preset option
+
+(** Persist a freshly-built keeper_meta with field-merging CAS
+    retry — preserves heartbeat-owned cursors when bootstrap races
+    a supervisor write (#9749). *)
+val write_initial_meta :
+  Coord.config -> keeper_meta -> (unit, string) result
+
+(** Create a new keeper from parsed args: build initial meta,
+    write checkpoint, start keepalive, return the [keeper_up]
+    response envelope. *)
+val create_keeper :
+  _ Keeper_types.context ->
+  Keeper_turn_up_args.parsed_args ->
+  tool_result


### PR DESCRIPTION
## Summary

PR#3 batch 17 — keeper creation handler.

| module | lines | toplevel |
|---|---|---|
| `keeper_turn_up_create` | 605 | 3 |

Despite the file size, only 3 toplevel functions — most lines
belong to the sequential build pipeline inside `create_keeper`.

Exposed:
- `preset_of_defaults` — wraps `Keeper_preset_defaults.preset_of_defaults_warn`
- `write_initial_meta` — `write_meta_with_merge` with heartbeat merge
- `create_keeper` — keeper_up create-branch handler

## Surgical

- .ml unchanged.

## Test plan

- [x] dune build ✓
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)