### PR TITLE
feat(keeper): emit FSM Streaming -> Failed at run_turn dispatch error exit (Step 4j)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2197,6 +2197,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let is_ambiguous_partial = EC.is_ambiguous_side_effect_error err in
           Prometheus.inc_counter Prometheus.metric_keeper_turns
             ~labels:[("keeper_name", meta.name); ("outcome", "failure")] ();
+          Keeper_turn_fsm.emit_transition
+            ~keeper_name:meta.name ~turn_id:keeper_turn_id
+            ~prev:Keeper_turn_fsm.Streaming
+            (Keeper_turn_fsm.Failed
+               (Keeper_turn_fsm.Failure_provider_error
+                  { kind = sdk_error_kind err;
+                    detail = short_preview e_str }));
           Log.Keeper.error
             "%s: keeper cycle FAILED cascade=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s latency=%dms%s error=%s"
             meta.name final_execution.cascade_name


### PR DESCRIPTION
## Summary

Closes the \`Streaming -> Failed\` gap on the dispatch failure side. When \`retry_loop\` exhausts all cascades and \`run_keeper_cycle\` receives \`Error err\`, emit the typed FSM transition alongside the existing failure counter + log line. /loop iteration 6 of "fsm 쪽 더 선명하게".

## Site

| line | prev      | turn_state                                                            |
|------|-----------|-----------------------------------------------------------------------|
| 2199 | Streaming | Failed (Failure_provider_error {kind = sdk_error_kind err; detail})   |

\`detail\` is \`short_preview e_str\` (220-char truncated sdk_error string), matching the existing Step 4f cascade-build site shape.

## Why

After Steps 4b-i the success path showed end-to-end (\`awaiting_provider → streaming → completing → done\`) but the failure path was silent past \`streaming\`:

```
awaiting_provider -> streaming
(cascade exhausted, Error err returned — nothing emitted)
```

After this PR:

```
awaiting_provider -> streaming
streaming -> failed:provider_error    (this PR)
```

PromQL alerts can fire on \`to=failed:provider_error\` spikes; \`bin/masc-trace\` shows the same timeline shape for both outcomes.

## Variant choice

\`Failure_provider_error\` is the same variant Step 4f routes the cascade-build error through. An \`sdk_error\` from \`run_turn\` is structurally identical, so reusing the variant keeps the operator's mental model simple. \`kind\` discriminates sub-categories.

## Volume

One extra emit per failed turn. No control-flow change.

## Test plan

- [x] \`dune build\` (default + release) green locally
- [x] \`test_keeper_turn_fsm_emit\` 4/4 OK
- [ ] CI lint + meta-guards green
- [ ] Post-merge: trigger or wait for a cascade-exhaustion and confirm \`streaming -> failed:provider_error\` line + Prometheus split

## Out of scope

The remaining \`Streaming ⇄ Awaiting_tool_result\` tool-cycle toggling inside \`run_turn\` would emit at every tool call (5-10x per turn) — volume risk warrants a separate design discussion before wiring.

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4j.

🤖 Generated with [Claude Code](https://claude.com/claude-code)