### PR TITLE
refactor(keeper): SSOT for [SYNTHETIC] marker — collapse 3-file hardcoding

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -455,6 +455,7 @@
    keeper_memory_policy
    keeper_memory_bank
    keeper_memory_recall
+   keeper_synthetic_marker
    keeper_skill_routing
    keeper_sandbox
    keeper_cwd_response

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -135,7 +135,7 @@ let search_memory_bank
            | _ -> 0.0
          in
          let synthetic_penalty =
-           if contains_ci m.text "[SYNTHETIC]" then -0.1 else 0.0
+           if Keeper_synthetic_marker.contains_marker m.text then -0.1 else 0.0
          in
          let score =
            ((float_of_int m.priority /. 100.0) *. recency_weight *. horizon_weight)

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -194,7 +194,7 @@ let is_meaningful_memory_text (s : string) : bool =
   let key = normalize_memory_text_key s in
   let placeholders = memory_placeholders () in
   not (List.mem key placeholders)
-  && not (String_util.contains_substring s "[SYNTHETIC]")
+  && not (Keeper_synthetic_marker.contains_marker s)
   && not (String.equal (String.trim s) "No tools used this generation")
   && not (has_inflated_consensus_marker s)
   && not (String_util.contains_substring s "[turn budget exhausted")

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -923,8 +923,8 @@ let synthesize_state_from_run_result
   in
   let decisions =
     match response_hint with
-    | Some hint -> [Printf.sprintf "[SYNTHETIC] Last output: %s" hint]
-    | None -> ["[SYNTHETIC] No visible output this generation"]
+    | Some hint -> [Keeper_synthetic_marker.tag (Printf.sprintf "Last output: %s" hint)]
+    | None -> [Keeper_synthetic_marker.tag "No visible output this generation"]
   in
   { goal = (let g = String.trim goal in if g = "" then None else Some g);
     progress;

--- a/lib/keeper/keeper_synthetic_marker.ml
+++ b/lib/keeper/keeper_synthetic_marker.ml
@@ -1,0 +1,8 @@
+(** See [keeper_synthetic_marker.mli] for the contract. *)
+
+let marker_prefix = "[SYNTHETIC]"
+
+let tag (text : string) : string = marker_prefix ^ " " ^ text
+
+let contains_marker (s : string) : bool =
+  String_util.contains_substring s marker_prefix

--- a/lib/keeper/keeper_synthetic_marker.mli
+++ b/lib/keeper/keeper_synthetic_marker.mli
@@ -1,0 +1,25 @@
+(** [SYNTHETIC] marker — single source of truth.
+
+    Producer ([keeper_memory_policy]) tags synthetic generation outputs
+    with this marker so consumers ([keeper_memory_bank] for filtering,
+    [keeper_exec_memory] for ranking) can identify and de-prioritise
+    them.
+
+    Pre-fix: the literal ["[SYNTHETIC]"] was hardcoded in three files.
+    A divergence (typo, case variant, prefix change) on the producer
+    side could silently break the consumer-side detection — exactly the
+    "Scattered Hardcoded Defaults" anti-pattern from the user's hard
+    rules.  This module is the SSOT. *)
+
+val marker_prefix : string
+(** [marker_prefix] is the exact byte sequence emitted by producers and
+    looked up by consumers.  Currently ["[SYNTHETIC]"]. *)
+
+val tag : string -> string
+(** [tag text] returns ["[SYNTHETIC] <text>"].  Producer-side helper.
+    Use instead of inline [Printf.sprintf] so a future marker change
+    flows through one site. *)
+
+val contains_marker : string -> bool
+(** [contains_marker s] is [true] iff [s] contains [marker_prefix] as a
+    substring.  Consumer-side helper. *)

--- a/test/dune
+++ b/test/dune
@@ -206,7 +206,8 @@
         test_gh_api_classification
         test_actionable_path_action
         test_stale_kill_class
-        test_provider_capability_matrix)
+        test_provider_capability_matrix
+        test_keeper_synthetic_marker)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -383,6 +384,7 @@
           test_actionable_path_action
           test_stale_kill_class
           test_provider_capability_matrix
+          test_keeper_synthetic_marker
           )
  (libraries masc_test_deps))
 

--- a/test/test_keeper_synthetic_marker.ml
+++ b/test/test_keeper_synthetic_marker.ml
@@ -1,0 +1,65 @@
+(** test_keeper_synthetic_marker — SSOT for the [SYNTHETIC] marker.
+
+    Pre-fix the literal ["[SYNTHETIC]"] was hardcoded in three files
+    (keeper_memory_policy producer, keeper_memory_bank +
+    keeper_exec_memory consumers).  This test pins the SSOT contract so
+    a marker rename or accidental case-shift cannot silently break the
+    producer-consumer detection pair. *)
+
+open Masc_mcp
+
+let r = Alcotest.(check string)
+let b = Alcotest.(check bool)
+
+let test_marker_prefix_value () =
+  r "marker_prefix is the literal" "[SYNTHETIC]"
+    Keeper_synthetic_marker.marker_prefix
+
+let test_tag_prepends_with_space () =
+  r "tag prepends marker + single space"
+    "[SYNTHETIC] hello world"
+    (Keeper_synthetic_marker.tag "hello world")
+
+let test_tag_round_trips_through_contains () =
+  let text = "anything at all" in
+  let tagged = Keeper_synthetic_marker.tag text in
+  b "tagged text is detected by contains_marker" true
+    (Keeper_synthetic_marker.contains_marker tagged)
+
+let test_contains_marker_negative () =
+  b "untagged text -> false" false
+    (Keeper_synthetic_marker.contains_marker "no marker here");
+  b "lowercase variant -> false (case-sensitive on purpose)" false
+    (Keeper_synthetic_marker.contains_marker "[synthetic]");
+  b "empty string -> false" false
+    (Keeper_synthetic_marker.contains_marker "")
+
+let test_contains_marker_substring () =
+  (* The detection path is substring, not prefix — a [SYNTHETIC] marker
+     embedded mid-string still flags the entry.  This matches the
+     pre-refactor behavior of [String_util.contains_substring s
+     "[SYNTHETIC]"]. *)
+  b "marker as substring is detected" true
+    (Keeper_synthetic_marker.contains_marker
+       "decision: [SYNTHETIC] last output: ...")
+
+let () =
+  Alcotest.run "keeper_synthetic_marker"
+    [
+      ( "marker_prefix",
+        [ Alcotest.test_case "literal value" `Quick test_marker_prefix_value ] );
+      ( "tag",
+        [
+          Alcotest.test_case "prepends with space" `Quick
+            test_tag_prepends_with_space;
+          Alcotest.test_case "round-trips through contains_marker" `Quick
+            test_tag_round_trips_through_contains;
+        ] );
+      ( "contains_marker",
+        [
+          Alcotest.test_case "negative cases" `Quick
+            test_contains_marker_negative;
+          Alcotest.test_case "marker as substring" `Quick
+            test_contains_marker_substring;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

User hard rule: *"Scattered Hardcoded Defaults"* anti-pattern.  The
literal ``"[SYNTHETIC]"`` was hardcoded in three lib/keeper files:

| File | Role | Line(s) |
|---|---|---|
| ``keeper_memory_policy.ml`` | producer | 926-927 emit ``"[SYNTHETIC] Last output: %s"`` |
| ``keeper_memory_bank.ml`` | consumer | 197 filters by ``contains_substring s "[SYNTHETIC]"`` |
| ``keeper_exec_memory.ml`` | consumer | 138 deprioritises by ``contains_ci m.text "[SYNTHETIC]"`` |

A divergence on the producer side (typo, case-shift, prefix change)
would silently break consumer detection.  Synthetic memory entries
would suddenly be treated as meaningful — exactly the
silent-failure category that triggered Phase A's bloodflow work.

## Solution

New SSOT module ``lib/keeper/keeper_synthetic_marker.{ml,mli}``:

```ocaml
val marker_prefix : string                 (** "[SYNTHETIC]" *)
val tag : string -> string                 (** producer helper *)
val contains_marker : string -> bool       (** consumer detection *)
```

Both producer call sites and both consumer call sites now go through
this module.  Future marker changes flow through one constant.

## Behavior preservation

- **Producer**: ``tag(text) = "[SYNTHETIC] " ^ text`` is byte-identical
  to the pre-refactor ``Printf.sprintf "[SYNTHETIC] %s" text``
- **Consumer**: ``contains_marker`` uses
  ``String_util.contains_substring``.  The ``keeper_exec_memory`` site
  loses its previous ``contains_ci`` case-insensitivity — intentional,
  since the producer always emits canonical case and case-fold matching
  only ever masked accidental divergence (which the SSOT now prevents
  at compile time)

## Test plan

- [x] ``dune build @check --root .`` green
- [x] ``./_build/default/test/test_keeper_synthetic_marker.exe`` → 5/5 pass
  - literal ``marker_prefix`` value
  - ``tag`` prepends with single space
  - round-trip ``tag`` → ``contains_marker``
  - negative cases (untagged, lowercase variant, empty)
  - substring detection (marker mid-string)
- [ ] CI Build + Lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)