### PR TITLE
feat(masc-trace): include [fsm:transition] log lines in turn timeline (Step 4k)

### DIFF
--- a/bin/masc_trace.ml
+++ b/bin/masc_trace.ml
@@ -47,6 +47,23 @@ let receipts_dir ~base_path ~keeper =
   List.fold_left Filename.concat base_path
     [ ".masc"; "keepers"; keeper; "execution-receipts" ]
 
+let logs_dir ~base_path =
+  List.fold_left Filename.concat base_path [ ".masc"; "logs" ]
+
+(** Naive substring check — avoids pulling in [Str] for one call. *)
+let contains_substring s sub =
+  let lens = String.length s in
+  let lensub = String.length sub in
+  if lensub = 0 then true
+  else if lensub > lens then false
+  else
+    let rec loop i =
+      if i > lens - lensub then false
+      else if String.sub s i lensub = sub then true
+      else loop (i + 1)
+    in
+    loop 0
+
 let dump_receipts ~base_path ~keeper ~turn_id =
   let dir = receipts_dir ~base_path ~keeper in
   if not (Sys.file_exists dir) then begin
@@ -100,11 +117,81 @@ let dump_receipts ~base_path ~keeper ~turn_id =
             ended f cascade outcome reason)
         matches
 
+(** Scan [.masc/logs/system_log_*.jsonl] for [\[fsm:transition\]]
+    lines that match the given (keeper, turn_id).
+
+    Step 4b/c/d/g/i/j wired [Keeper_turn_fsm.emit_transition] at
+    every state transition in [run_keeper_cycle].  This widens
+    the [bin/masc-trace] source set so the timeline shows the
+    typed FSM steps next to the receipt rows. *)
+let dump_fsm_transitions ~base_path ~keeper ~turn_id =
+  let dir = logs_dir ~base_path in
+  if not (Sys.file_exists dir) then ()
+  else
+    let files =
+      Sys.readdir dir
+      |> Array.to_list
+      |> List.filter (fun f ->
+             Filename.check_suffix f ".jsonl"
+             && String.length f >= String.length "system_log_"
+             && String.sub f 0 (String.length "system_log_")
+                = "system_log_")
+      |> List.sort compare
+    in
+    let matches =
+      List.concat_map
+        (fun f ->
+          let path = Filename.concat dir f in
+          read_lines path
+          |> List.filter_map (fun line ->
+                 try
+                   let json = Yojson.Safe.from_string line in
+                   let keeper_match =
+                     string_field json "keeper_name" = Some keeper
+                   in
+                   let turn_match =
+                     int_field json "turn_id" = Some turn_id
+                   in
+                   let msg =
+                     Option.value
+                       (string_field json "message")
+                       ~default:""
+                   in
+                   let is_fsm =
+                     contains_substring msg "[fsm:transition]"
+                   in
+                   if keeper_match && turn_match && is_fsm then
+                     Some json
+                   else None
+                 with _ -> None))
+        files
+    in
+    if matches = [] then
+      Printf.eprintf
+        "[masc-trace] no [fsm:transition] lines for keeper=%s \
+         turn_id=%d\n"
+        keeper turn_id
+    else
+      List.iter
+        (fun json ->
+          let ts =
+            Option.value (string_field json "ts") ~default:"-"
+          in
+          let msg =
+            Option.value
+              (string_field json "message")
+              ~default:"-"
+          in
+          Printf.printf "%s [fsm] %s\n" ts msg)
+        matches
+
 let () =
   match Array.to_list Sys.argv with
   | _ :: base_path :: keeper :: turn_id_str :: _ -> (
       match int_of_string_opt turn_id_str with
-      | Some turn_id -> dump_receipts ~base_path ~keeper ~turn_id
+      | Some turn_id ->
+          dump_receipts ~base_path ~keeper ~turn_id;
+          dump_fsm_transitions ~base_path ~keeper ~turn_id
       | None ->
           prerr_endline "turn_id must be an integer";
           usage_and_exit ())

--- a/bin/masc_trace.ml
+++ b/bin/masc_trace.ml
@@ -50,6 +50,9 @@ let receipts_dir ~base_path ~keeper =
 let logs_dir ~base_path =
   List.fold_left Filename.concat base_path [ ".masc"; "logs" ]
 
+let tool_calls_dir ~base_path =
+  List.fold_left Filename.concat base_path [ ".masc"; "tool_calls" ]
+
 (** Naive substring check — avoids pulling in [Str] for one call. *)
 let contains_substring s sub =
   let lens = String.length s in
@@ -185,13 +188,107 @@ let dump_fsm_transitions ~base_path ~keeper ~turn_id =
           Printf.printf "%s [fsm] %s\n" ts msg)
         matches
 
+(** Scan [.masc/tool_calls/<YYYY-MM>/<DD>.jsonl] for tool call
+    rows whose [keeper] = our keeper and
+    [runtime_contract.keeper_turn_id] = our turn_id.
+
+    Schema (post Step 0a):
+    - top-level [keeper], [tool], [success], [duration_ms], [ts] (epoch float)
+    - nested [runtime_contract.keeper_turn_id] (int option)
+
+    Records pre Step 0a have [keeper_turn_id = null]; those are
+    skipped silently because there's nothing to correlate them
+    with. *)
+let dump_tool_calls ~base_path ~keeper ~turn_id =
+  let root = tool_calls_dir ~base_path in
+  if not (Sys.file_exists root) then ()
+  else
+    (* tool_calls/YYYY-MM/DD.jsonl — recurse one level. *)
+    let month_dirs =
+      Sys.readdir root
+      |> Array.to_list
+      |> List.filter (fun d ->
+             Sys.is_directory (Filename.concat root d))
+      |> List.sort compare
+    in
+    let files =
+      List.concat_map
+        (fun mdir ->
+          let mpath = Filename.concat root mdir in
+          Sys.readdir mpath
+          |> Array.to_list
+          |> List.filter (fun f -> Filename.check_suffix f ".jsonl")
+          |> List.sort compare
+          |> List.map (fun f -> Filename.concat mpath f))
+        month_dirs
+    in
+    let runtime_contract_int_field json key =
+      match Yojson.Safe.Util.member "runtime_contract" json with
+      | `Assoc _ as rc -> int_field rc key
+      | _ -> None
+    in
+    let matches =
+      List.concat_map
+        (fun path ->
+          read_lines path
+          |> List.filter_map (fun line ->
+                 try
+                   let json = Yojson.Safe.from_string line in
+                   let keeper_match =
+                     string_field json "keeper" = Some keeper
+                   in
+                   let turn_match =
+                     runtime_contract_int_field json
+                       "keeper_turn_id"
+                     = Some turn_id
+                   in
+                   if keeper_match && turn_match then Some json
+                   else None
+                 with _ -> None))
+        files
+    in
+    if matches = [] then
+      Printf.eprintf
+        "[masc-trace] no tool_calls for keeper=%s turn_id=%d \
+         (note: pre-Step-0a rows have keeper_turn_id=null and \
+         are unreachable by id)\n"
+        keeper turn_id
+    else
+      List.iter
+        (fun json ->
+          let tool =
+            Option.value (string_field json "tool") ~default:"-"
+          in
+          let success =
+            match Yojson.Safe.Util.member "success" json with
+            | `Bool b -> if b then "ok" else "fail"
+            | _ -> "-"
+          in
+          let duration_ms =
+            match Yojson.Safe.Util.member "duration_ms" json with
+            | `Float f -> Printf.sprintf "%.0f" f
+            | `Int n -> string_of_int n
+            | _ -> "-"
+          in
+          let ts =
+            match Yojson.Safe.Util.member "ts" json with
+            | `Float f -> Printf.sprintf "%.3f" f
+            | `Int n -> string_of_int n
+            | _ -> "-"
+          in
+          Printf.printf
+            "%s [tool %s] %s duration_ms=%s\n"
+            ts tool success duration_ms)
+        matches
+
 let () =
   match Array.to_list Sys.argv with
   | _ :: base_path :: keeper :: turn_id_str :: _ -> (
       match int_of_string_opt turn_id_str with
       | Some turn_id ->
           dump_receipts ~base_path ~keeper ~turn_id;
-          dump_fsm_transitions ~base_path ~keeper ~turn_id
+          dump_fsm_transitions ~base_path ~keeper ~turn_id;
+          dump_tool_calls ~base_path ~keeper ~turn_id
       | None ->
           prerr_endline "turn_id must be an integer";
           usage_and_exit ())


### PR DESCRIPTION
## Summary

Widens \`bin/masc-trace\` from receipts-only to receipts + system_log \`[fsm:transition]\` lines for the same (keeper, turn_id). After Step 4b/c/d/g/i/j the typed FSM trail lives in \`.masc/logs/system_log_*.jsonl\`; this PR makes that trail visible from the CLI an operator already uses. /loop iteration 7 of "fsm 쪽 더 선명하게".

## Output shape

```
$ masc-trace ~/me alice 42
...T... [receipt 04-28.jsonl] cascade=keeper-default outcome=skipped reason=...
...T... [fsm] alice: [fsm:transition] - -> phase_gating
...T... [fsm] alice: [fsm:transition] phase_gating -> cancelled:phase_gate_close
```

Receipts + fsm rows print as separate sections (receipts first, fsm transitions second).

## Implementation notes

- New \`logs_dir\` helper at \`<base-path>/.masc/logs\`.
- Filename filter pins \`system_log_*.jsonl\` (Step 0a's #11154/#11156/#11159 schema with \`keeper_name\` / \`turn_id\` / \`message\`).
- \`contains_substring\` is a 12-line naive scan; pulling in \`Str\` for one substring would have added a dep to the bin's tiny \`(libraries yojson)\` in \`bin/dune\`.
- Reuses existing \`read_lines\` / \`int_field\` / \`string_field\` helpers; no new dune library deps.
- Receipt path keeps its existing "no rows" diagnostics; fsm path is silent on a missing logs dir.

## Test plan

- [x] \`dune build bin/masc_trace.exe\` default + release green locally
- [x] CLI no-arg invocation prints the usage line
- [ ] CI lint + meta-guards green
- [ ] Post-merge: against a real fleet, run \`masc-trace ~/me <keeper> <turn_id>\` for a recent turn and confirm both sections appear

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4k. This iteration sharpens *tooling* rather than runtime emits — operator visibility into the FSM no longer requires running \`grep\` against system_log by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)