### PR TITLE
feat(cascade): scale weighted_random by latency p50 (PR 3a/4)

### DIFF
--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -9,6 +9,62 @@ type signal_ctx = {
   cascade_name : string;
 }
 
+(* ── Latency-aware weight scaling (Phase: PR3 of cascade resilience) ──
+
+   The cascade's effective weight has historically been
+   [config_weight × success_rate], so two providers with comparable
+   reliability rank identically even if one is 10× slower than the other.
+   When latency samples are available (post-PR2 ring buffer), the
+   weighted_random strategy multiplies in a [0.0–1.0] latency factor so
+   the faster provider wins ties without zeroing out the slow one
+   (which would create a thrashing single-provider cascade).
+
+   Formula (intentionally simple, easy to predict):
+
+     [latency_score = min 1.0 (latency_baseline_ms / max(p50, 1.0))]
+
+   - p50 ≤ baseline → score = 1.0 (no penalty).
+   - p50 = 2 × baseline → score = 0.5.
+   - p50 = 10 × baseline → score = 0.1.
+   - Unknown / no samples / [latency_ring_size <= 0] → score = 1.0
+     (optimistic default — same convention as success_rate for unknown
+     providers).
+   - p50 < 1 ms is clamped at 1 ms in the denominator to avoid
+     overflowing the score above 1.0 on extremely fast local providers
+     (ollama on warm cache).
+
+   The baseline (default 2000 ms) is tuned for cloud LLM tiers — claude
+   / gpt / gemini typical p50 lands in the 1–3 second range.  Local
+   providers (ollama) are typically far below baseline, so they get full
+   weight; slow tail tiers (kimi cli, gemini cli) get fractional weight
+   when their p50 drifts above baseline. *)
+let latency_baseline_ms =
+  match Sys.getenv_opt "MASC_CASCADE_LATENCY_BASELINE_MS" with
+  | None -> 2000.0
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then 2000.0
+    else
+      match Safe_ops.float_of_string_safe trimmed with
+      | Some n when n > 0.0 -> n
+      | _ ->
+        Log.Misc.warn
+          "Invalid float for MASC_CASCADE_LATENCY_BASELINE_MS=%S, using default 2000.0"
+          raw;
+        2000.0
+
+let latency_score_of_p50 p50 =
+  let denom = Float.max p50 1.0 in
+  Float.min 1.0 (latency_baseline_ms /. denom)
+
+let latency_score_for_provider health ~provider_key =
+  match Cascade_health_tracker.provider_info health ~provider_key with
+  | None -> 1.0
+  | Some info ->
+    (match info.p50_latency_ms with
+     | None -> 1.0
+     | Some p50 -> latency_score_of_p50 p50)
+
 type cycle_policy = {
   max_cycles : int;
   backoff_base_ms : int;
@@ -126,14 +182,29 @@ let filter_cooldown adapter ctx cands =
    filtered-empty state instead of reviving a provider that was
    intentionally put into cooldown (e.g. hard quota exhausted). *)
 let weighted_shuffle adapter ctx cands =
-  (* Compute health-adjusted weight per candidate. *)
+  (* Compute health-adjusted weight per candidate.  The base weight from
+     the tracker reflects [config_weight * success_rate], with [0] for
+     cooled-down providers.  We multiply in a [0.0–1.0] latency factor
+     when the tracker has accumulated p50 samples; cooled-down providers
+     stay at 0 (the multiplication preserves zero), and providers
+     without latency samples get factor 1.0 (no change vs prior behavior).
+     The [max 1] guard prevents a slow-but-alive provider from getting
+     zeroed out purely from latency — strategy still gives it a chance
+     each cycle, just with less probability than its peers. *)
   let weighted = List.map
       (fun c ->
+         let provider_key = adapter.health_key c in
          let ew = Cascade_health_tracker.effective_weight ctx.health
-             ~provider_key:(adapter.health_key c)
+             ~provider_key
              ~config_weight:(adapter.weight c)
          in
-         (c, max 0 ew))
+         let final =
+           if ew <= 0 then 0
+           else
+             let lat = latency_score_for_provider ctx.health ~provider_key in
+             max 1 (int_of_float (float_of_int ew *. lat))
+         in
+         (c, final))
       cands
   in
   let active = List.filter (fun (_, w) -> w > 0) weighted in

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -79,6 +79,23 @@ val backoff_ms : cycle_policy -> cycle:int -> int
     before the next cascade attempt.  [cycle] is 1-indexed: the first
     retry after cycle 0 uses [backoff_ms ~cycle:1]. *)
 
+val latency_score_for_provider :
+  Cascade_health_tracker.t -> provider_key:string -> float
+(** [latency_score_for_provider health ~provider_key] returns a
+    [0.0–1.0] multiplier reflecting how the provider's recent p50
+    response time compares to {!latency_baseline_ms}.
+
+    - p50 ≤ baseline → [1.0] (no penalty).
+    - p50 > baseline → fractional score, decaying as [baseline / p50].
+    - Unknown provider, no latency samples, or latency tracking disabled
+      ([latency_ring_size <= 0]) → [1.0] (optimistic default).
+
+    Used internally by {!Weighted_random} to prefer faster providers
+    when success rates are comparable.  Exposed for inspection /
+    testability — strategies do not need to call this directly.
+
+    @since 0.181.0 (PR3 of cascade resilience track) *)
+
 (** {1 Strategy kind} *)
 
 type kind =

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -153,6 +153,127 @@ let test_weighted_random_all_cooldown_yields_empty () =
   check (list string) "all-cooldown → empty"
     [] (names ordered)
 
+(* ── Latency-aware weight scaling (PR3) ──────────────────────── *)
+
+(* For these tests we exercise weight scaling indirectly through the
+   internal RNG.  With [rand_int n = always n - 1] we always pick the
+   *last* candidate within the active list — so a candidate with weight
+   1 ends up at the head of the returned ordering only when it survived
+   the weighted draw.  By comparing two configurations that differ only
+   in latency samples, we can observe whether the latency factor
+   actually shifted the per-candidate weight. *)
+
+let pick_first_with_rand_max () =
+  (* rand_int returning (n - 1) always selects the last candidate first
+     in [weighted_shuffle], so the head of the result ≈ the candidate
+     with the smallest weighted partition relative to the running total.
+     For a simpler invariant we just ensure the function returns a
+     deterministic permutation. *)
+  ()
+
+let test_latency_no_samples_preserves_baseline_order () =
+  (* Without latency samples, latency_score = 1.0 for both providers,
+     so the per-candidate weight is unchanged from the pre-PR3
+     behaviour.  Pin rand to 0 → left-to-right ordering. *)
+  let h = H.create () in
+  let cands = [mk_cand ~w:30 "a"; mk_cand ~w:30 "b"; mk_cand ~w:30 "c"] in
+  let ctx = mk_ctx ~health:h ~rand:(fun _ -> 0) () in
+  let strat = mk_t S.Weighted_random in
+  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "no latency samples → input order with rand=0"
+    ["a"; "b"; "c"] (names ordered)
+
+let test_latency_below_baseline_full_weight () =
+  (* p50 below baseline → score = 1.0 → no penalty.  Verify by feeding
+     fast samples (10ms) and confirming weight stays at config.  We
+     observe via [Cascade_health_tracker.effective_weight] before and
+     [latency_score_for_provider] separately. *)
+  let h = H.create () in
+  H.record_success h ~provider_key:"a" ~latency_ms:10.0 ();
+  H.record_success h ~provider_key:"b" ~latency_ms:10.0 ();
+  let score = S.latency_score_for_provider h ~provider_key:"a" in
+  check (float 0.001) "fast provider gets score 1.0" 1.0 score
+
+let test_latency_above_baseline_fractional () =
+  (* p50 = 4 × baseline (default 2000ms) → score should be ~0.25.
+     We feed 8000ms samples and verify the score is well below 1.0. *)
+  let h = H.create () in
+  H.record_success h ~provider_key:"slow" ~latency_ms:8000.0 ();
+  let score = S.latency_score_for_provider h ~provider_key:"slow" in
+  check bool
+    (Printf.sprintf "slow provider score=%.3f should be < 0.5" score)
+    true (score < 0.5);
+  check bool
+    (Printf.sprintf "slow provider score=%.3f should be > 0" score)
+    true (score > 0.0)
+
+let test_latency_unknown_provider_neutral () =
+  (* Provider with no entry in the tracker → score = 1.0 (optimistic
+     default, matches success_rate convention). *)
+  let h = H.create () in
+  let score = S.latency_score_for_provider h ~provider_key:"never-seen" in
+  check (float 0.001) "unknown provider score = 1.0" 1.0 score
+
+let test_latency_changes_weighted_ordering () =
+  (* When providers have identical config_weight and success_rate, but
+     one is materially slower, weighted_shuffle's per-candidate weight
+     for the slow provider must drop below the fast one.  We probe the
+     effect by running shuffle many times with a varying [rand_int] and
+     confirming the slow provider lands at the head less often than
+     the fast ones. *)
+  let h = H.create () in
+  H.record_success h ~provider_key:"fast" ~latency_ms:50.0 ();
+  H.record_success h ~provider_key:"medium" ~latency_ms:500.0 ();
+  H.record_success h ~provider_key:"slow" ~latency_ms:8000.0 ();
+  let cands = [mk_cand ~w:100 "fast"; mk_cand ~w:100 "medium"; mk_cand ~w:100 "slow"] in
+  let strat = mk_t S.Weighted_random in
+  (* Sweep all possible rand_int draws across the total weight.  With
+     rand=k we get a deterministic head pick for a given total; counting
+     how often each candidate is the head over k=0..total-1 approximates
+     the head-probability distribution. *)
+  let head_counts = Hashtbl.create 3 in
+  let trials = 500 in
+  for i = 0 to trials - 1 do
+    let ctx = mk_ctx ~health:h ~rand:(fun n -> i mod (max 1 n)) () in
+    let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+    match ordered with
+    | head :: _ ->
+      let key = adapter.health_key head in
+      let prev = try Hashtbl.find head_counts key with Not_found -> 0 in
+      Hashtbl.replace head_counts key (prev + 1)
+    | [] -> ()
+  done;
+  let count k = try Hashtbl.find head_counts k with Not_found -> 0 in
+  let fast_n = count "fast" in
+  let medium_n = count "medium" in
+  let slow_n = count "slow" in
+  check bool
+    (Printf.sprintf "fast(%d) head-rate >= medium(%d) head-rate" fast_n medium_n)
+    true (fast_n >= medium_n);
+  check bool
+    (Printf.sprintf "medium(%d) head-rate >= slow(%d) head-rate" medium_n slow_n)
+    true (medium_n >= slow_n);
+  check bool
+    (Printf.sprintf "fast(%d) > slow(%d) (strict)" fast_n slow_n)
+    true (fast_n > slow_n)
+
+let test_latency_does_not_zero_alive_provider () =
+  (* Even at extreme p50 (e.g. 60s), an alive provider must still get
+     weight ≥ 1 — the [max 1] guard prevents zero-out from latency
+     alone, only cooldown can produce 0. *)
+  let h = H.create () in
+  H.record_success h ~provider_key:"slow" ~latency_ms:60_000.0 ();
+  H.record_success h ~provider_key:"fast" ~latency_ms:50.0 ();
+  let cands = [mk_cand ~w:10 "slow"; mk_cand ~w:10 "fast"] in
+  let ctx = mk_ctx ~health:h ~rand:(fun _ -> 0) () in
+  let strat = mk_t S.Weighted_random in
+  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check int "extreme-slow provider still appears in ordering"
+    2 (List.length ordered);
+  check bool "extreme-slow not filtered as cooldown"
+    true (List.exists (fun c -> adapter.health_key c = "slow") ordered);
+  ignore pick_first_with_rand_max
+
 (* ── S4 Circuit_breaker_cycling ──────────────────────────────── *)
 
 let test_cb_cycling_excludes_cooldown_and_busy () =
@@ -906,6 +1027,20 @@ let () =
         test_weighted_random_deterministic_with_rand0;
       test_case "all cooldown yields empty" `Quick
         test_weighted_random_all_cooldown_yields_empty;
+    ];
+    "weighted_random_latency", [
+      test_case "no samples → input order preserved at rand=0" `Quick
+        test_latency_no_samples_preserves_baseline_order;
+      test_case "p50 below baseline → score 1.0" `Quick
+        test_latency_below_baseline_full_weight;
+      test_case "p50 well above baseline → fractional score" `Quick
+        test_latency_above_baseline_fractional;
+      test_case "unknown provider → score 1.0 (optimistic)" `Quick
+        test_latency_unknown_provider_neutral;
+      test_case "latency shifts head-rate (fast > medium > slow)" `Quick
+        test_latency_changes_weighted_ordering;
+      test_case "extreme p50 does not zero alive provider" `Quick
+        test_latency_does_not_zero_alive_provider;
     ];
     "circuit_breaker_cycling", [
       test_case "excludes cooldown and busy" `Quick


### PR DESCRIPTION
## Summary

Multiply a [0.0–1.0] latency factor into `Cascade_strategy.weighted_shuffle`'s per-candidate weight so two providers with comparable success rates no longer rank identically when one is materially slower. Consumes the per-provider p50 ring buffer added in PR2.

This is **PR 3a of 4** — covers the latency factor only. **PR 3b** will follow up with the rate-limit factor that consumes the `Soft_rate_limited` outcome variant from PR1, kept separate so each factor lands independently.

## Stacking

- **Base**: `feat/cascade-latency-ema` (PR #11365 / PR 2/4) — needs the `provider_info.p50_latency_ms` field.
- **Independent of PR1** (#11341 / `Soft_rate_limited`) — that's PR 3b's input.
- When PR2 lands on main first, this branch rebases onto main with no conflicts.

## Why

Pre-PR3 the strategy uses `effective_weight = config_weight × success_rate`. With identical success rates and weights, the RNG distributes head-rate uniformly across alive providers — so a 50-ms ollama and an 8-second cloud provider compete on equal footing for the first slot. The user sees this as keeper turns drifting to whichever provider the RNG happened to pick first.

## Formula

```
latency_score = min 1.0 (latency_baseline_ms / max(p50, 1.0))
```

- `p50 ≤ baseline` → `score 1.0` (no penalty).
- `p50 = 4 × baseline` → `score ≈ 0.25`.
- Unknown / no samples / `latency_ring_size <= 0` → `score 1.0` (optimistic default, matches `success_rate` convention).

Default baseline 2000 ms (env `MASC_CASCADE_LATENCY_BASELINE_MS`), tuned for cloud LLM tiers — claude / gpt / gemini typical p50 lands in 1–3 s. Local providers (ollama on warm cache) sit well below baseline and keep full weight; tail tiers whose p50 drifts above baseline get fractional weight.

## Behavioral guarantees (encoded in tests)

- Cooled-down providers stay at weight 0. Multiplier only applied when `effective_weight > 0`.
- Slow-but-alive providers never zeroed out by latency alone. The `max 1` guard keeps them in rotation.
- Providers without samples behave exactly as before — no regression for unmeasured population.

## What changed

- `lib/cascade/cascade_strategy.ml` — new `latency_baseline_ms` env-tunable constant; new helpers `latency_score_of_p50` and `latency_score_for_provider`; `weighted_shuffle` multiplies in the latency factor with a `max 1` floor.
- `lib/cascade/cascade_strategy.mli` — exposes `latency_score_for_provider` for inspection / tests.
- `test/test_cascade_strategy.ml` — 6 new cases under `weighted_random_latency`.

## Test plan

- [x] `dune build --root . @check` clean (with `DUNE_CACHE=disabled` for the worktree-cache flake).
- [x] `dune build --root . --profile=release` clean.
- [x] `test_cascade_strategy.exe` 58/58 (52 baseline + 6 new).
- [x] Adjacent: `test_cascade_health_tracker` 38/38, `test_dashboard_cascade` 33/33.
- [ ] CI green.
- [ ] Self-review against `~/me/agents/best-programmer/AGENT.md` before Ready transition.

## Notes

- `latency_score_for_provider` reuses `Cascade_health_tracker.provider_info`, which acquires the tracker's `Stdlib.Mutex`. Combined with the existing `effective_weight` call inside `weighted_shuffle`, that's two lock acquisitions per candidate per shuffle. Cost is negligible (16 candidates × 2 locks × ~µs = <1 ms total) and avoids changing the `effective_weight` API contract.
- PR3b (rate-limit factor) lands after PR1 (#11341) merges; that PR will introduce `Cascade_health_tracker.recent_outcome_counts` and a `score_recent_rate_limits` helper following the same `min 1.0` pattern.
- Plan doc: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-c-cuddly-crab.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)