### PR TITLE
fix(lint): pre-add proof_artifact_reader.mli to V11 allow-list

### DIFF
--- a/scripts/check-boundary-guard.sh
+++ b/scripts/check-boundary-guard.sh
@@ -122,7 +122,8 @@ check_forbidden_outside "V10-provider-filter-ownership" \
 check_forbidden_outside "V11-proof-store-layout" \
   'Filename\.concat .*"proofs"' \
   "lib/" \
-  "lib/proof_artifact_reader.ml"
+  "lib/proof_artifact_reader.ml" \
+  "lib/proof_artifact_reader.mli"
 
 # V12: oas-runtime session root literal must stay inside the runtime path adapter.
 check_forbidden_outside "V12-oas-runtime-layout" \


### PR DESCRIPTION
## Summary
Mirrors PR #11280/#11283 fix-forward for V10 — `lib/proof_artifact_reader.mli` exists on disk but is missing from the V11 allow-list of \`scripts/check-boundary-guard.sh\`. Currently safe (the .mli does not contain the forbidden pattern \`Filename.concat ... "proofs"\`), but a future docstring/signature edit would surface the same merge-queue blocker that bit V10 in PR #11248.

## Mechanism
Same as #11248: when boundary-guard sees a forbidden pattern in an unlisted .mli, it fails Lint on every PR until the .mli is added. Recent occurrence cost 1 fix-forward (#11283) + 1 race PR (#11280).

This is a pre-emptive 1-line addition. PAIR-GATE (PR #11298) is silent here because the .mli is not newly-added in this PR — diff-driven scope only catches first-introduction, so a complementary pre-emptive sweep is justified.

V12 worker_container does not have a paired .mli, so no action needed.

## Test plan
- [x] Local \`bash scripts/check-boundary-guard.sh\` → "BOUNDARY: all checks within baseline"
- [x] Local \`bash scripts/check-boundary-guard-mli-pairs.sh\` → "no newly-added .mli files in diff" (PAIR-GATE silent as expected)
- [ ] CI Lint green

## Refs
- #11248 → blocked #11272 → fix-forward #11280 / #11283 (V10 sibling)
- #11298 (PAIR-GATE — diff-driven, complementary)
- memory: \`feedback_jane-street-refactor-sweep-miss\` (record-literal sub-pattern abandoned, sweep miss class still active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)