### PR TITLE
feat(masc-trace): include .masc/tool_calls rows in turn timeline (Step 4l)

### DIFF
--- a/bin/masc_trace.ml
+++ b/bin/masc_trace.ml
@@ -50,6 +50,9 @@ let receipts_dir ~base_path ~keeper =
 let logs_dir ~base_path =
   List.fold_left Filename.concat base_path [ ".masc"; "logs" ]
 
+let tool_calls_dir ~base_path =
+  List.fold_left Filename.concat base_path [ ".masc"; "tool_calls" ]
+
 (** Naive substring check — avoids pulling in [Str] for one call. *)
 let contains_substring s sub =
   let lens = String.length s in
@@ -185,13 +188,107 @@ let dump_fsm_transitions ~base_path ~keeper ~turn_id =
           Printf.printf "%s [fsm] %s\n" ts msg)
         matches
 
+(** Scan [.masc/tool_calls/<YYYY-MM>/<DD>.jsonl] for tool call
+    rows whose [keeper] = our keeper and
+    [runtime_contract.keeper_turn_id] = our turn_id.
+
+    Schema (post Step 0a):
+    - top-level [keeper], [tool], [success], [duration_ms], [ts] (epoch float)
+    - nested [runtime_contract.keeper_turn_id] (int option)
+
+    Records pre Step 0a have [keeper_turn_id = null]; those are
+    skipped silently because there's nothing to correlate them
+    with. *)
+let dump_tool_calls ~base_path ~keeper ~turn_id =
+  let root = tool_calls_dir ~base_path in
+  if not (Sys.file_exists root) then ()
+  else
+    (* tool_calls/YYYY-MM/DD.jsonl — recurse one level. *)
+    let month_dirs =
+      Sys.readdir root
+      |> Array.to_list
+      |> List.filter (fun d ->
+             Sys.is_directory (Filename.concat root d))
+      |> List.sort compare
+    in
+    let files =
+      List.concat_map
+        (fun mdir ->
+          let mpath = Filename.concat root mdir in
+          Sys.readdir mpath
+          |> Array.to_list
+          |> List.filter (fun f -> Filename.check_suffix f ".jsonl")
+          |> List.sort compare
+          |> List.map (fun f -> Filename.concat mpath f))
+        month_dirs
+    in
+    let runtime_contract_int_field json key =
+      match Yojson.Safe.Util.member "runtime_contract" json with
+      | `Assoc _ as rc -> int_field rc key
+      | _ -> None
+    in
+    let matches =
+      List.concat_map
+        (fun path ->
+          read_lines path
+          |> List.filter_map (fun line ->
+                 try
+                   let json = Yojson.Safe.from_string line in
+                   let keeper_match =
+                     string_field json "keeper" = Some keeper
+                   in
+                   let turn_match =
+                     runtime_contract_int_field json
+                       "keeper_turn_id"
+                     = Some turn_id
+                   in
+                   if keeper_match && turn_match then Some json
+                   else None
+                 with _ -> None))
+        files
+    in
+    if matches = [] then
+      Printf.eprintf
+        "[masc-trace] no tool_calls for keeper=%s turn_id=%d \
+         (note: pre-Step-0a rows have keeper_turn_id=null and \
+         are unreachable by id)\n"
+        keeper turn_id
+    else
+      List.iter
+        (fun json ->
+          let tool =
+            Option.value (string_field json "tool") ~default:"-"
+          in
+          let success =
+            match Yojson.Safe.Util.member "success" json with
+            | `Bool b -> if b then "ok" else "fail"
+            | _ -> "-"
+          in
+          let duration_ms =
+            match Yojson.Safe.Util.member "duration_ms" json with
+            | `Float f -> Printf.sprintf "%.0f" f
+            | `Int n -> string_of_int n
+            | _ -> "-"
+          in
+          let ts =
+            match Yojson.Safe.Util.member "ts" json with
+            | `Float f -> Printf.sprintf "%.3f" f
+            | `Int n -> string_of_int n
+            | _ -> "-"
+          in
+          Printf.printf
+            "%s [tool %s] %s duration_ms=%s\n"
+            ts tool success duration_ms)
+        matches
+
 let () =
   match Array.to_list Sys.argv with
   | _ :: base_path :: keeper :: turn_id_str :: _ -> (
       match int_of_string_opt turn_id_str with
       | Some turn_id ->
           dump_receipts ~base_path ~keeper ~turn_id;
-          dump_fsm_transitions ~base_path ~keeper ~turn_id
+          dump_fsm_transitions ~base_path ~keeper ~turn_id;
+          dump_tool_calls ~base_path ~keeper ~turn_id
       | None ->
           prerr_endline "turn_id must be an integer";
           usage_and_exit ())


### PR DESCRIPTION
## Summary

**Stacks on top of #11367.** Widens \`bin/masc-trace\` to its third source: tool_calls JSONL. After this PR a single CLI invocation prints all three artefacts of a turn in one timeline. /loop iteration 8 of "fsm 쪽 더 선명하게".

## Output shape

```
$ masc-trace ~/me alice 42
...T...        [receipt 04-28.jsonl] cascade=keeper-default outcome=skipped reason=...
...T...        [fsm] alice: [fsm:transition] - -> phase_gating
1777248791.071 [tool keeper_tasks_list] ok duration_ms=372
1777248794.512 [tool keeper_shell] fail duration_ms=8203
```

## Schema notes

- \`.masc/tool_calls/YYYY-MM/DD.jsonl\` is two levels deep; the new \`dump_tool_calls\` recurses one level into each month directory.
- Match key is \`runtime_contract.keeper_turn_id\` (Step 0a #11154 field).
- Pre-Step-0a rows have \`keeper_turn_id = null\` and are silently skipped — a stderr note explains the gap on zero matches.
- \`ts\` is an epoch float in tool_calls (vs ISO strings in receipts/system_log); the float prints raw to keep the diff trivial and match on-disk format.

## Stack note

Builds on #11367. Both PRs touch \`bin/masc_trace.ml\` at different sites:
- #11367 added \`logs_dir\` / \`contains_substring\` / \`dump_fsm_transitions\`
- this PR adds \`tool_calls_dir\` / \`dump_tool_calls\`

Both \`main\` entry-point edits append a new dump call; once #11367 merges, this PR rebases as a clean append.

## Test plan

- [x] \`dune build bin/masc_trace.exe\` (default) green
- [x] CLI no-arg usage line prints
- [ ] CI green after #11367 lands and this rebases on main
- [ ] Post-merge: run \`masc-trace ~/me <keeper> <turn_id>\` and confirm \`[receipt]\` + \`[fsm]\` + \`[tool]\` sections

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4l. \`bin/masc_trace.ml\`'s docstring promised the three-source union as a "follow-up stack"; this PR delivers the third source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)