### PR TITLE
fix(keeper-shell): surface exit/signal status in docker exec failure log

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -8,6 +8,24 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(* docker exec 실패 시 진단성 보강용 helper. 이전 message format
+   `failed (image): <output>` 에서 output 이 empty 면 진단 불가
+   (cycle22 fleet log: 30분간 5건 발생, detail 모두 empty).
+   exit/signal status + output empty placeholder 로 root cause 식별
+   가능하게 한다. *)
+let docker_exec_status_label = function
+  | Unix.WEXITED n -> Printf.sprintf "exit=%d" n
+  | Unix.WSIGNALED n -> Printf.sprintf "signal=%d" n
+  | Unix.WSTOPPED n -> Printf.sprintf "stopped=%d" n
+
+let docker_exec_failure_message ~image ~status ~output =
+  let truncated = Worker_dev_tools.truncate_for_log output in
+  let output_label =
+    if String.trim truncated = "" then "<no output>" else truncated
+  in
+  Printf.sprintf "sandbox docker exec failed (%s, %s): %s"
+    image (docker_exec_status_label status) output_label
+
 (* ── Sandbox GH_TOKEN warn dedup ───────────────────────────
 
    When [git_creds_enabled = true] but [Env_config_keeper.KeeperSandbox.gh_token]
@@ -495,9 +513,7 @@ let run_docker_shell_command_with_status
          in
          if status <> Unix.WEXITED 0 then
            Keeper_registry.record_error ~base_path:config.base_path meta.name
-             (Printf.sprintf "sandbox docker exec failed (%s): %s"
-                image
-                (Worker_dev_tools.truncate_for_log output))
+             (docker_exec_failure_message ~image ~status ~output)
          else
            Keeper_registry.clear_error ~base_path:config.base_path meta.name;
          Ok { status; output; image; network_label }
@@ -539,9 +555,7 @@ let run_docker_with_git_bash
        | Ok (st, out) ->
          if st <> Unix.WEXITED 0 then
            Keeper_registry.record_error ~base_path:config.base_path meta.name
-             (Printf.sprintf "sandbox docker exec failed (%s): %s"
-                image
-                (Worker_dev_tools.truncate_for_log out))
+             (docker_exec_failure_message ~image ~status:st ~output:out)
          else
            Keeper_registry.clear_error ~base_path:config.base_path meta.name;
          Yojson.Safe.to_string
@@ -608,9 +622,7 @@ let run_docker_hardened_bash
        | Ok (st, out) ->
          if st <> Unix.WEXITED 0 then
            Keeper_registry.record_error ~base_path:config.base_path meta.name
-             (Printf.sprintf "sandbox docker exec failed (%s): %s"
-                image
-                (Worker_dev_tools.truncate_for_log out))
+             (docker_exec_failure_message ~image ~status:st ~output:out)
          else
            Keeper_registry.clear_error ~base_path:config.base_path meta.name;
          Yojson.Safe.to_string


### PR DESCRIPTION
## 목표

`keeper_shell_docker.ml` 의 sandbox docker exec 실패 메시지 진단성 보강. 현재 `failed (image): <output>` 인데 output 이 empty 면 message 가 `failed (image): ` 로 끝남 — diagnose 불가.

## 측정 (cycle 22 fleet log, 2026-04-27 18:43~19:23 UTC, 30min)

| keeper | 빈도 |
|---|---|
| executor | 5 events / 30min ≈ 10/h |

5건 모두 message 끝이 ": <empty>" — exit code 도, output 도 없어서 root cause 식별 불가.

## 변경 내용

`lib/keeper/keeper_shell_docker.ml` 에 helper 추가:

```ocaml
let docker_exec_status_label = function
  | Unix.WEXITED n -> Printf.sprintf "exit=%d" n
  | Unix.WSIGNALED n -> Printf.sprintf "signal=%d" n
  | Unix.WSTOPPED n -> Printf.sprintf "stopped=%d" n

let docker_exec_failure_message ~image ~status ~output =
  let truncated = Worker_dev_tools.truncate_for_log output in
  let output_label =
    if String.trim truncated = "" then "<no output>" else truncated
  in
  Printf.sprintf "sandbox docker exec failed (%s, %s): %s"
    image (docker_exec_status_label status) output_label
```

3 inline sprintf 사이트 (line 498, 542, 611) 를 helper 호출로 교체. behavior 변화 없음 — 로그/레지스트리 message format 만 변경.

## 검증

- `dune build @check`: EXIT 0
- 기존 test 들은 메시지 format 직접 검증 안 함 → 회귀 위험 zero (string format 만 변경)
- helper 가 module-private 라 unit test 추가는 skip (작은 surgical PR scope)

## 효과 (예상)

before:
```
sandbox docker exec failed (masc-keeper-sandbox:local): 
```

after (예시):
```
sandbox docker exec failed (masc-keeper-sandbox:local, exit=125): <no output>
sandbox docker exec failed (masc-keeper-sandbox:local, signal=9): killed
```

Operator 가 exit=125 (docker run failed before container start) vs exit=137 (OOM kill) vs signal=9 (manual kill) 등을 즉시 구별 가능.

## Refs

- Memory feedback: 자백 주석 evidence-driven 원칙 (자백 string 으로 분류 X, status enum 으로 진단)

🤖 Generated with [Claude Code](https://claude.com/claude-code)