### PR TITLE
feat(infra): add ppx_tla_derive PPX deriver (Cycle 2 / Tier I1)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -50,6 +50,7 @@
   (ppx_deriving_yojson (>= 3.6))
   (ppx_let (>= v0.17.0))
   (ppx_deriving (>= 5.2))
+  (ppxlib (>= 0.30))
   (sqlite3 (>= 5.1))
   (mirage-crypto (>= 1.0))
   (mirage-crypto-rng (>= 1.0))

--- a/ppx_tla/dune
+++ b/ppx_tla/dune
@@ -1,0 +1,5 @@
+(library
+ (name ppx_tla)
+ (public_name masc_mcp.ppx_tla)
+ (kind ppx_rewriter)
+ (libraries ppxlib))

--- a/ppx_tla/ppx_tla.ml
+++ b/ppx_tla/ppx_tla.ml
@@ -1,0 +1,106 @@
+(* ppx_tla — derive TLA+ symbol mappings from OCaml variant types.
+   Cycle 2 / Tier I1 of the Kimi keeper FSM review plan.
+   Plan: planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md
+
+   Goal: eliminate the maintenance cost of keeping OCaml `type t = | A | B`
+   in lock-step with TLA+ `TurnStateSet = {"a", "b"}`. With this PPX, the
+   OCaml type is the single source of truth and a simple `[@@deriving tla]`
+   attribute generates the symbol/list helpers that previously required
+   hand-written matches that drift over time.
+
+   This is Part 1 (Cycle 2): minimal nullary-only generator producing
+   `to_tla_symbol` and `all_states`. Cycle 3 adds attribute-driven
+   classification (`[@tla.terminal]`, `[@tla.idle]`) and applies it to
+   `Keeper_turn_fsm.turn_state` for the first real consumer. *)
+
+open Ppxlib
+
+let symbol_of_constructor (cd : constructor_declaration) =
+  String.lowercase_ascii cd.pcd_name.txt
+
+let lid_of_constructor ~loc (cd : constructor_declaration) =
+  Loc.make ~loc (Longident.Lident cd.pcd_name.txt)
+
+let make_to_tla_symbol ~loc cds =
+  let cases =
+    List.map
+      (fun (cd : constructor_declaration) ->
+        let lid = lid_of_constructor ~loc cd in
+        let pat = Ast_builder.Default.ppat_construct ~loc lid None in
+        let rhs =
+          Ast_builder.Default.estring ~loc (symbol_of_constructor cd)
+        in
+        Ast_builder.Default.case ~lhs:pat ~guard:None ~rhs)
+      cds
+  in
+  (* OCaml 5.4 AST changed [pexp_function] to take a parameter list;
+     stay portable by building [fun __x -> match __x with ...] from
+     [pexp_fun] + [pexp_match] rather than relying on [pexp_function]. *)
+  let arg_name = "__tla_arg" in
+  let arg_pat =
+    Ast_builder.Default.ppat_var ~loc (Loc.make ~loc arg_name)
+  in
+  let arg_expr = Ast_builder.Default.evar ~loc arg_name in
+  let match_expr = Ast_builder.Default.pexp_match ~loc arg_expr cases in
+  let func =
+    Ast_builder.Default.pexp_fun ~loc Nolabel None arg_pat match_expr
+  in
+  let pat =
+    Ast_builder.Default.ppat_var ~loc (Loc.make ~loc "to_tla_symbol")
+  in
+  let binding = Ast_builder.Default.value_binding ~loc ~pat ~expr:func in
+  Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
+
+let make_all_states ~loc cds =
+  let exprs =
+    List.map
+      (fun (cd : constructor_declaration) ->
+        let lid = lid_of_constructor ~loc cd in
+        Ast_builder.Default.pexp_construct ~loc lid None)
+      cds
+  in
+  let list_expr = Ast_builder.Default.elist ~loc exprs in
+  let pat = Ast_builder.Default.ppat_var ~loc (Loc.make ~loc "all_states") in
+  let binding =
+    Ast_builder.Default.value_binding ~loc ~pat ~expr:list_expr
+  in
+  Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
+
+let constructor_is_nullary (cd : constructor_declaration) =
+  match cd.pcd_args with
+  | Pcstr_tuple [] -> true
+  | Pcstr_tuple _ | Pcstr_record _ -> false
+
+let derive_for_variant ~loc cds =
+  if List.exists (fun cd -> not (constructor_is_nullary cd)) cds then
+    Location.raise_errorf ~loc
+      "[@@deriving tla]: only nullary constructors are supported in Cycle \
+       2. Cycle 3 (planned) will add [@tla.terminal] / [@tla.idle] \
+       attributes for parameterised constructors."
+  else
+    [ make_to_tla_symbol ~loc cds; make_all_states ~loc cds ]
+
+let str_type_decl ~ctxt (_rec_flag, type_decls) =
+  let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+  match type_decls with
+  | [ td ] -> (
+      match td.ptype_kind with
+      | Ptype_variant cds -> derive_for_variant ~loc cds
+      | Ptype_abstract | Ptype_record _ | Ptype_open ->
+          Location.raise_errorf ~loc
+            "[@@deriving tla]: only variant types are supported (got %s)"
+            (match td.ptype_kind with
+             | Ptype_abstract -> "abstract"
+             | Ptype_record _ -> "record"
+             | Ptype_open -> "open"
+             | Ptype_variant _ -> "variant"))
+  | _ ->
+      Location.raise_errorf ~loc
+        "[@@deriving tla]: a single type declaration is supported per \
+         attribute"
+
+let _ : Deriving.t =
+  let str_type_decl =
+    Deriving.Generator.V2.make_noarg str_type_decl
+  in
+  Deriving.add "tla" ~str_type_decl

--- a/test/ppx_tla/dune
+++ b/test/ppx_tla/dune
@@ -1,0 +1,4 @@
+(test
+ (name test_basic)
+ (preprocess
+  (pps ppx_tla)))

--- a/test/ppx_tla/test_basic.ml
+++ b/test/ppx_tla/test_basic.ml
@@ -1,0 +1,53 @@
+(* Cycle 2 minimal test for ppx_tla deriver.
+   Verifies that [@@deriving tla] generates [to_tla_symbol] mapping
+   constructors to lowercased names, and [all_states] enumerating
+   every constructor in declaration order.
+
+   Each type is wrapped in its own module because [@@deriving tla]
+   generates [to_tla_symbol] / [all_states] in the surrounding scope;
+   nesting modules keeps the helpers per-type rather than the second
+   type silently shadowing the first. *)
+
+module Color = struct
+  type t = Red | Green | Blue [@@deriving tla]
+end
+
+module Turn_state = struct
+  type t =
+    | Idle
+    | Phase_gating
+    | Cascade_routing
+    | Done
+  [@@deriving tla]
+end
+
+let test_color_to_tla_symbol () =
+  assert (Color.to_tla_symbol Color.Red = "red");
+  assert (Color.to_tla_symbol Color.Green = "green");
+  assert (Color.to_tla_symbol Color.Blue = "blue")
+
+let test_color_all_states () =
+  assert (Color.all_states = [ Color.Red; Color.Green; Color.Blue ])
+
+let test_turn_state_to_tla_symbol () =
+  assert (Turn_state.to_tla_symbol Turn_state.Idle = "idle");
+  assert (Turn_state.to_tla_symbol Turn_state.Phase_gating = "phase_gating");
+  assert (Turn_state.to_tla_symbol Turn_state.Cascade_routing = "cascade_routing");
+  assert (Turn_state.to_tla_symbol Turn_state.Done = "done")
+
+let test_turn_state_all_states () =
+  assert (
+    Turn_state.all_states
+    = [
+        Turn_state.Idle;
+        Turn_state.Phase_gating;
+        Turn_state.Cascade_routing;
+        Turn_state.Done;
+      ])
+
+let () =
+  test_color_to_tla_symbol ();
+  test_color_all_states ();
+  test_turn_state_to_tla_symbol ();
+  test_turn_state_all_states ();
+  print_endline "ppx_tla basic test: PASS"


### PR DESCRIPTION
## Summary

First Cycle 2 deliverable of the Kimi keeper FSM review plan: a minimal `[@@deriving tla]` PPX rewriter that auto-generates `to_tla_symbol` (lowercased constructor name) and `all_states` (declaration-order list) for nullary variant types.

This is **infrastructure only** — Cycle 3 will apply the deriver to `Keeper_turn_fsm.turn_state` and add classification attributes (`[@tla.terminal]`, `[@tla.idle]`, `[@tla.active]`) to derive the corresponding TLA+ subsets.

## Why (formalized incompleteness)

Per plan §3 Tier I1 (`planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md`), the goal is to **remove the human cost of keeping OCaml variants in lock-step with TLA+ spec symbol sets**. Today every `type t = | A | B` is paired with a hand-written `to_tla_symbol` and `terminal_states` that drifts when constructors are added or renamed. With this PPX:

- The OCaml type is the single source of truth.
- The PPX guarantees coverage (no missing constructor → no missing entry).
- A constructor rename triggers test failure if the spec also changed, surfacing drift instead of hiding it.

ROI is **★★★★** (plan §11.3): a one-time infrastructure cost (~170 LOC) amortised across all future spec-OCaml mappings. PPX I1 was ranked second only to outcome tri-state (PR #11360, Cycle 1a) for that reason.

## What changed

- New `ppx_tla/` library at the repo top level. `lib/` uses `(include_subdirs unqualified)` so a separate library cannot nest under it; placing PPX at the root mirrors the conventional layout used by `ppx_let`, `ppx_deriving_yojson`, etc.
- `dune-project`: add `ppxlib (>= 0.30)` to `depends`. ppxlib is already a transitive dep through `ppx_deriving`, but `(implicit_transitive_deps false)` requires explicit declaration.
- `test/ppx_tla/test_basic.ml`: validates `to_tla_symbol` and `all_states` for two sample variants. Each type is wrapped in its own module because `[@@deriving tla]` generates helpers in the surrounding scope; nesting modules keeps the helpers per-type rather than the second type silently shadowing the first.

## Generated code (example)

Input:
```ocaml
type turn_state = Idle | Phase_gating | Done [@@deriving tla]
```

Output:
```ocaml
let to_tla_symbol __tla_arg = match __tla_arg with
  | Idle -> "idle"
  | Phase_gating -> "phase_gating"
  | Done -> "done"
let all_states = [Idle; Phase_gating; Done]
```

The `match`-on-fresh-arg form rather than `function` avoids the OCaml 5.4 `pexp_function` AST split (it now takes a `function_param list` rather than `case list`); the equivalent runtime behaviour stays portable across ppxlib versions.

## What is NOT in this PR (follow-up)

| Follow-up | Cycle |
|-----------|-------|
| Apply `[@@deriving tla]` to `Keeper_turn_fsm.turn_state` and verify the generated symbols match `KeeperTurnFSM.tla` `TurnStateSet` | Cycle 3 |
| Classification attributes: `[@tla.terminal]`, `[@tla.idle]`, `[@tla.active]` to derive `terminal_states` / `active_states` subsets | Cycle 3 |
| Constructor parameters (e.g. `Failed of failure_reason`) — currently rejected with an explanatory error | Cycle 3+ |
| TLA+ symbol parity test that compares generated `to_tla_symbol`/`all_states` against the spec's `TurnStateSet` | Cycle 3 |

## Test plan

- [x] `dune build --root <worktree> ppx_tla/` passes.
- [x] `dune build --root <worktree> test/ppx_tla/` passes (PPX is correctly applied at compile time).
- [x] `dune runtest --root <worktree> test/ppx_tla/` prints `ppx_tla basic test: PASS`.
- [ ] Full repo `dune build` not yet verified in this PR (the new library is not consumed anywhere yet).

## Spec link

Plan §3 Tier I1 — Infrastructure: AST/PPX/GADT.
ROI table at plan §11.3.
Sibling Cycle 1a foundation: PR #11360 (`outcome_kind` tri-state).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
