### PR TITLE
feat(observability): Grafana dashboard for the keeper turn FSM (Step 4n)

### DIFF
--- a/infrastructure/monitoring/grafana-keeper-turn-fsm-dashboard.json
+++ b/infrastructure/monitoring/grafana-keeper-turn-fsm-dashboard.json
@@ -1,0 +1,173 @@
+{
+  "__meta": {
+    "purpose": "MASC keeper turn FSM observability — imports into Grafana 10+ via File → Import.",
+    "metrics": [
+      "masc_keeper_turn_fsm_transitions_total{from, to, keeper}"
+    ],
+    "companion_doc": "docs/observability/keeper-turn-fsm-metrics.md",
+    "companion_lifecycle": "docs/keeper-turn-lifecycle.md",
+    "code_refs": [
+      "lib/keeper/keeper_turn_fsm.ml",
+      "lib/keeper/keeper_unified_turn.ml",
+      "lib/prometheus.ml"
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "datasource", "uid": "grafana" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Turn FSM transitions by to-state — rate / 5m",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Aggregate transitions to each terminal/intermediate state. done (green) == success; failed:* (red shades) == typed failure; cancelled:* (orange) == operator/supervisor stop.",
+      "targets": [
+        {
+          "expr": "sum by (to) (rate(masc_keeper_turn_fsm_transitions_total[5m]))",
+          "legendFormat": "{{to}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "done" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": "failed:.*" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": "cancelled:.*" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Failure breakdown by failure_reason — rate / 5m",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Step 4f split runtime_error catch-all into typed variants. After this PR, livelock_blocked and provider_error have their own series.",
+      "targets": [
+        {
+          "expr": "sum by (to) (rate(masc_keeper_turn_fsm_transitions_total{to=~\"failed:.*\"}[5m]))",
+          "legendFormat": "{{to}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Per-keeper completion rate (to=done) — rate / 5m",
+      "gridPos": { "x": 0, "y": 8, "w": 24, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "How many turns each keeper closes per minute. A keeper line dropping to zero while others stay flat == that keeper is stuck.",
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_turn_fsm_transitions_total{to=\"done\"}[5m]))",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Cancellation rate by cancel_reason — rate / 5m",
+      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "phase_gate_close == phase blocked turn entry; supervisor_stop / fleet_shutdown == externally requested halt; provider_timeout == cooperative cancel deadline crossed.",
+      "targets": [
+        {
+          "expr": "sum by (to) (rate(masc_keeper_turn_fsm_transitions_total{to=~\"cancelled:.*\"}[5m]))",
+          "legendFormat": "{{to}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["masc", "keeper", "fsm"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MASC Keeper Turn FSM",
+  "uid": "masc-keeper-turn-fsm",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

Caps the FSM observability stack with a visual layer. /loop iteration 10 of "fsm 쪽 더 선명하게" — runtime emit (4b-j) + tooling (4k-l) + docs (4h, 4m) + **visualisation (this PR)**.

## Panels

| panel                                | gridPos      | what                                                                  |
|--------------------------------------|--------------|------------------------------------------------------------------------|
| Transitions by to-state              | 0,0,12,8     | \`sum by (to)\` — \`done\` green, \`failed:*\` red, \`cancelled:*\` orange |
| Failure breakdown by reason          | 12,0,12,8    | \`failed:*\` only — post-Step-4f variant separation                    |
| Per-keeper completion rate (to=done) | 0,8,24,8     | \`sum by (keeper)\` — per-keeper turn-close rate                       |
| Cancellation rate by reason          | 0,16,24,8    | \`cancelled:*\` only                                                   |

Grafana 10+, single \`DS_PROMETHEUS\` datasource var. Imports via File → Import like the existing \`grafana-cascade-dashboard.json\`.

## Why

The PromQL examples in #11376 (\`docs/observability/keeper-turn-fsm-metrics.md\`) cover the queries; this PR shapes them into a paste-and-load dashboard so a new operator doesn't compose the queries by hand. The four panels are deliberately aggregate-only (no per-(from,to) series explosion) so the dashboard loads cleanly even at the full ~1600-series upper bound.

## Companion

- \`docs/observability/keeper-turn-fsm-metrics.md\` (#11376) — counter reference
- \`docs/keeper-turn-lifecycle.md\` (#11260, #11354) — state diagram
- \`bin/masc_trace.ml\` (#11168, #11367, #11371) — per-turn timeline CLI
- \`lib/keeper/keeper_turn_fsm.{ml,mli}\` — ADT + emit_transition

## Test plan

- [x] \`python3 -c "import json; json.load(open(...))"\` passes
- [ ] Manual: import into Grafana 10.x, confirm all four panels render
- [ ] CI lint + meta-guards green

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4n. **Natural endpoint** of the sharpening cycle. Further sharpening lands in RISKY territory (Step 3 / 5 / 6b-2) or volume-sensitive \`run_turn\`-side adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)