### PR TITLE
feat(spec-impl): keeper_turn_fsm derives TLA+ symbol mapping via ppx_tla (Cycle 3)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -949,7 +949,7 @@
    ambient-context
    ambient-context-eio
    )
- (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_let))
+ (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_let ppx_tla))
  (instrumentation (backend bisect_ppx)))
  
 ; Core library for MASC MCP

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -28,11 +28,12 @@ type turn_state =
   | Cascade_routing
   | Awaiting_provider
   | Streaming
-  | Awaiting_tool_result
+  | Awaiting_tool_result [@tla.symbol "awaiting_tool"]
   | Completing
   | Done
   | Failed of failure_reason
   | Cancelled of cancel_reason
+[@@deriving tla]
 
 let cancel_reason_label = function
   | Cancelled_supervisor_stop -> "supervisor_stop"

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -50,11 +50,20 @@ type turn_state =
   | Cascade_routing
   | Awaiting_provider
   | Streaming
-  | Awaiting_tool_result
+  | Awaiting_tool_result [@tla.symbol "awaiting_tool"]
   | Completing
   | Done
   | Failed of failure_reason
   | Cancelled of cancel_reason
+[@@deriving tla]
+(** TLA+ symbol mapping derived by [ppx_tla].
+
+    [to_tla_symbol] / [all_symbols] match [TurnStateSet] in
+    [specs/keeper-turn-fsm/KeeperTurnFSM.tla] (verified by
+    [test_keeper_turn_fsm_tla_parity]).
+
+    [@tla.symbol "awaiting_tool"] on [Awaiting_tool_result] covers the
+    OCaml-vs-TLA+ naming difference without renaming either side. *)
 
 val cancel_reason_label : cancel_reason -> string
 val failure_reason_label : failure_reason -> string

--- a/ppx_tla/ppx_tla.ml
+++ b/ppx_tla/ppx_tla.ml
@@ -8,34 +8,76 @@
    attribute generates the symbol/list helpers that previously required
    hand-written matches that drift over time.
 
-   This is Part 1 (Cycle 2): minimal nullary-only generator producing
-   `to_tla_symbol` and `all_states`. Cycle 3 adds attribute-driven
-   classification (`[@tla.terminal]`, `[@tla.idle]`) and applies it to
-   `Keeper_turn_fsm.turn_state` for the first real consumer. *)
+   Cycle 2 (PR #11377): minimal nullary-only generator producing
+     [to_tla_symbol] and [all_states].
+
+   Cycle 3 (this commit) extends the deriver to handle realistic ADTs:
+   - Parameterised constructors (e.g. [Failed of failure_reason]) — the
+     match-pattern uses [_] for the payload; [to_tla_symbol] needs no
+     extra information from the args.
+   - [@tla.symbol "explicit_name"] override per constructor — covers
+     drift between OCaml [Awaiting_tool_result] and TLA+ "awaiting_tool"
+     without renaming either side.
+   - [all_symbols : string list] — replaces [all_states] as the safe
+     enumeration for types with parameterised constructors. [all_states]
+     remains generated only when every constructor is nullary, because
+     a list literal cannot construct a payload-bearing variant.
+   - sig_type_decl: applying the deriver to a .mli now produces the
+     corresponding [val to_tla_symbol] / [val all_symbols] / [val all_states]
+     declarations so the type can carry [@@deriving tla] in its public
+     interface as well as its implementation.
+
+   Classification attributes ([@tla.terminal] / [@tla.idle] / [@tla.active])
+   that derive [terminal_states] / [idle_states] / [active_states] subsets
+   are intentionally deferred to a follow-up cycle to keep this commit
+   focused on the parity test for the existing TurnStateSet. *)
 
 open Ppxlib
 
+(* [@tla.symbol "explicit_name"] override per constructor.
+   Without an override the symbol is the lowercased constructor name. *)
+let symbol_attr =
+  Attribute.declare "tla.symbol"
+    Attribute.Context.constructor_declaration
+    Ast_pattern.(single_expr_payload (estring __))
+    (fun s -> s)
+
 let symbol_of_constructor (cd : constructor_declaration) =
-  String.lowercase_ascii cd.pcd_name.txt
+  match Attribute.get symbol_attr cd with
+  | Some s -> s
+  | None -> String.lowercase_ascii cd.pcd_name.txt
 
 let lid_of_constructor ~loc (cd : constructor_declaration) =
   Loc.make ~loc (Longident.Lident cd.pcd_name.txt)
 
-let make_to_tla_symbol ~loc cds =
+let constructor_is_nullary (cd : constructor_declaration) =
+  match cd.pcd_args with
+  | Pcstr_tuple [] -> true
+  | Pcstr_tuple _ | Pcstr_record _ -> false
+
+(* Pattern that ignores any payload: [Constructor _] for parameterised,
+   [Constructor] for nullary. *)
+let constructor_pattern ~loc (cd : constructor_declaration) =
+  let lid = lid_of_constructor ~loc cd in
+  match cd.pcd_args with
+  | Pcstr_tuple [] -> Ast_builder.Default.ppat_construct ~loc lid None
+  | Pcstr_tuple _ | Pcstr_record _ ->
+      let any_pat = Ast_builder.Default.ppat_any ~loc in
+      Ast_builder.Default.ppat_construct ~loc lid (Some any_pat)
+
+(* ── Implementation generators (str_type_decl) ──────────────────── *)
+
+let make_to_tla_symbol_impl ~loc cds =
   let cases =
     List.map
       (fun (cd : constructor_declaration) ->
-        let lid = lid_of_constructor ~loc cd in
-        let pat = Ast_builder.Default.ppat_construct ~loc lid None in
+        let pat = constructor_pattern ~loc cd in
         let rhs =
           Ast_builder.Default.estring ~loc (symbol_of_constructor cd)
         in
         Ast_builder.Default.case ~lhs:pat ~guard:None ~rhs)
       cds
   in
-  (* OCaml 5.4 AST changed [pexp_function] to take a parameter list;
-     stay portable by building [fun __x -> match __x with ...] from
-     [pexp_fun] + [pexp_match] rather than relying on [pexp_function]. *)
   let arg_name = "__tla_arg" in
   let arg_pat =
     Ast_builder.Default.ppat_var ~loc (Loc.make ~loc arg_name)
@@ -51,7 +93,23 @@ let make_to_tla_symbol ~loc cds =
   let binding = Ast_builder.Default.value_binding ~loc ~pat ~expr:func in
   Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
 
-let make_all_states ~loc cds =
+let make_all_symbols_impl ~loc cds =
+  let exprs =
+    List.map
+      (fun cd ->
+        Ast_builder.Default.estring ~loc (symbol_of_constructor cd))
+      cds
+  in
+  let list_expr = Ast_builder.Default.elist ~loc exprs in
+  let pat =
+    Ast_builder.Default.ppat_var ~loc (Loc.make ~loc "all_symbols")
+  in
+  let binding =
+    Ast_builder.Default.value_binding ~loc ~pat ~expr:list_expr
+  in
+  Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
+
+let make_all_states_impl ~loc cds =
   let exprs =
     List.map
       (fun (cd : constructor_declaration) ->
@@ -66,41 +124,92 @@ let make_all_states ~loc cds =
   in
   Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
 
-let constructor_is_nullary (cd : constructor_declaration) =
-  match cd.pcd_args with
-  | Pcstr_tuple [] -> true
-  | Pcstr_tuple _ | Pcstr_record _ -> false
-
-let derive_for_variant ~loc cds =
-  if List.exists (fun cd -> not (constructor_is_nullary cd)) cds then
-    Location.raise_errorf ~loc
-      "[@@deriving tla]: only nullary constructors are supported in Cycle \
-       2. Cycle 3 (planned) will add [@tla.terminal] / [@tla.idle] \
-       attributes for parameterised constructors."
+let derive_impl_for_variant ~loc cds =
+  let to_tla = make_to_tla_symbol_impl ~loc cds in
+  let all_symbols = make_all_symbols_impl ~loc cds in
+  if List.for_all constructor_is_nullary cds then
+    [ to_tla; all_symbols; make_all_states_impl ~loc cds ]
   else
-    [ make_to_tla_symbol ~loc cds; make_all_states ~loc cds ]
+    [ to_tla; all_symbols ]
 
 let str_type_decl ~ctxt (_rec_flag, type_decls) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   match type_decls with
   | [ td ] -> (
       match td.ptype_kind with
-      | Ptype_variant cds -> derive_for_variant ~loc cds
+      | Ptype_variant cds -> derive_impl_for_variant ~loc cds
       | Ptype_abstract | Ptype_record _ | Ptype_open ->
           Location.raise_errorf ~loc
-            "[@@deriving tla]: only variant types are supported (got %s)"
-            (match td.ptype_kind with
-             | Ptype_abstract -> "abstract"
-             | Ptype_record _ -> "record"
-             | Ptype_open -> "open"
-             | Ptype_variant _ -> "variant"))
+            "[@@deriving tla]: only variant types are supported")
   | _ ->
       Location.raise_errorf ~loc
         "[@@deriving tla]: a single type declaration is supported per \
          attribute"
 
+(* ── Signature generators (sig_type_decl) ───────────────────────── *)
+
+let type_t ~loc ~type_name =
+  Ast_builder.Default.ptyp_constr ~loc
+    (Loc.make ~loc (Longident.Lident type_name))
+    []
+
+let string_t ~loc =
+  Ast_builder.Default.ptyp_constr ~loc
+    (Loc.make ~loc (Longident.Lident "string"))
+    []
+
+let list_t ~loc element_t =
+  Ast_builder.Default.ptyp_constr ~loc
+    (Loc.make ~loc (Longident.Lident "list"))
+    [ element_t ]
+
+let make_value_sig ~loc ~name ~type_ =
+  Ast_builder.Default.psig_value ~loc
+    (Ast_builder.Default.value_description ~loc
+       ~name:(Loc.make ~loc name) ~type_ ~prim:[])
+
+let derive_sig_for_variant ~loc ~type_name cds =
+  let t = type_t ~loc ~type_name in
+  let to_tla_sig =
+    let arrow =
+      Ast_builder.Default.ptyp_arrow ~loc Nolabel t (string_t ~loc)
+    in
+    make_value_sig ~loc ~name:"to_tla_symbol" ~type_:arrow
+  in
+  let all_symbols_sig =
+    make_value_sig ~loc ~name:"all_symbols"
+      ~type_:(list_t ~loc (string_t ~loc))
+  in
+  let all_states_sig_opt =
+    if List.for_all constructor_is_nullary cds then
+      [ make_value_sig ~loc ~name:"all_states" ~type_:(list_t ~loc t) ]
+    else
+      []
+  in
+  to_tla_sig :: all_symbols_sig :: all_states_sig_opt
+
+let sig_type_decl ~ctxt (_rec_flag, type_decls) =
+  let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+  match type_decls with
+  | [ td ] -> (
+      match td.ptype_kind with
+      | Ptype_variant cds ->
+          derive_sig_for_variant ~loc ~type_name:td.ptype_name.txt cds
+      | Ptype_abstract | Ptype_record _ | Ptype_open ->
+          Location.raise_errorf ~loc
+            "[@@deriving tla]: only variant types are supported")
+  | _ ->
+      Location.raise_errorf ~loc
+        "[@@deriving tla]: a single type declaration is supported per \
+         attribute"
+
+(* ── Registration ───────────────────────────────────────────────── *)
+
 let _ : Deriving.t =
   let str_type_decl =
     Deriving.Generator.V2.make_noarg str_type_decl
   in
-  Deriving.add "tla" ~str_type_decl
+  let sig_type_decl =
+    Deriving.Generator.V2.make_noarg sig_type_decl
+  in
+  Deriving.add "tla" ~str_type_decl ~sig_type_decl

--- a/test/dune
+++ b/test/dune
@@ -409,6 +409,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_keeper_turn_fsm_tla_parity)
+ (modules test_keeper_turn_fsm_tla_parity)
+ (libraries masc_test_deps))
+
+(test
  (name test_telemetry_task_transition_10358)
  (modules test_telemetry_task_transition_10358)
  (libraries masc_test_deps))

--- a/test/ppx_tla/test_basic.ml
+++ b/test/ppx_tla/test_basic.ml
@@ -1,12 +1,16 @@
-(* Cycle 2 minimal test for ppx_tla deriver.
-   Verifies that [@@deriving tla] generates [to_tla_symbol] mapping
-   constructors to lowercased names, and [all_states] enumerating
-   every constructor in declaration order.
+(* Cycle 2 + Cycle 3 tests for ppx_tla deriver.
+
+   Cycle 2 (PR #11377): nullary [to_tla_symbol] and [all_states].
+   Cycle 3 (this commit) extensions exercised below:
+   - parameterised constructors (match with [_] payload)
+   - [@tla.symbol "explicit"] override
+   - [all_symbols] always generated
+   - [all_states] generated only when every constructor is nullary
 
    Each type is wrapped in its own module because [@@deriving tla]
-   generates [to_tla_symbol] / [all_states] in the surrounding scope;
-   nesting modules keeps the helpers per-type rather than the second
-   type silently shadowing the first. *)
+   generates [to_tla_symbol] / [all_symbols] / [all_states] in the
+   surrounding scope; nesting modules keeps the helpers per-type
+   rather than the second type silently shadowing the first. *)
 
 module Color = struct
   type t = Red | Green | Blue [@@deriving tla]
@@ -21,6 +25,22 @@ module Turn_state = struct
   [@@deriving tla]
 end
 
+(* Cycle 3: parameterised constructors with [@tla.symbol] override. *)
+module Reason = struct
+  type t = string
+
+  let of_string s = s
+end
+
+module Mixed = struct
+  type t =
+    | Awaiting_provider
+    | Awaiting_tool_result [@tla.symbol "awaiting_tool"]
+    | Failed of Reason.t
+    | Cancelled of Reason.t
+  [@@deriving tla]
+end
+
 let test_color_to_tla_symbol () =
   assert (Color.to_tla_symbol Color.Red = "red");
   assert (Color.to_tla_symbol Color.Green = "green");
@@ -29,10 +49,14 @@ let test_color_to_tla_symbol () =
 let test_color_all_states () =
   assert (Color.all_states = [ Color.Red; Color.Green; Color.Blue ])
 
+let test_color_all_symbols () =
+  assert (Color.all_symbols = [ "red"; "green"; "blue" ])
+
 let test_turn_state_to_tla_symbol () =
   assert (Turn_state.to_tla_symbol Turn_state.Idle = "idle");
   assert (Turn_state.to_tla_symbol Turn_state.Phase_gating = "phase_gating");
-  assert (Turn_state.to_tla_symbol Turn_state.Cascade_routing = "cascade_routing");
+  assert (
+    Turn_state.to_tla_symbol Turn_state.Cascade_routing = "cascade_routing");
   assert (Turn_state.to_tla_symbol Turn_state.Done = "done")
 
 let test_turn_state_all_states () =
@@ -45,9 +69,35 @@ let test_turn_state_all_states () =
         Turn_state.Done;
       ])
 
+(* Cycle 3 verifications. *)
+
+let test_mixed_to_tla_symbol_default () =
+  assert (Mixed.to_tla_symbol Mixed.Awaiting_provider = "awaiting_provider")
+
+let test_mixed_to_tla_symbol_override () =
+  (* [@tla.symbol "awaiting_tool"] overrides the default
+     [String.lowercase_ascii "Awaiting_tool_result"]. *)
+  assert (Mixed.to_tla_symbol Mixed.Awaiting_tool_result = "awaiting_tool")
+
+let test_mixed_to_tla_symbol_parameterised () =
+  let r = Reason.of_string "irrelevant" in
+  assert (Mixed.to_tla_symbol (Mixed.Failed r) = "failed");
+  assert (Mixed.to_tla_symbol (Mixed.Cancelled r) = "cancelled")
+
+let test_mixed_all_symbols () =
+  (* all_symbols works even when constructors carry payloads. *)
+  assert (
+    Mixed.all_symbols
+    = [ "awaiting_provider"; "awaiting_tool"; "failed"; "cancelled" ])
+
 let () =
   test_color_to_tla_symbol ();
   test_color_all_states ();
+  test_color_all_symbols ();
   test_turn_state_to_tla_symbol ();
   test_turn_state_all_states ();
-  print_endline "ppx_tla basic test: PASS"
+  test_mixed_to_tla_symbol_default ();
+  test_mixed_to_tla_symbol_override ();
+  test_mixed_to_tla_symbol_parameterised ();
+  test_mixed_all_symbols ();
+  print_endline "ppx_tla cycle 2 + 3 tests: PASS"

--- a/test/test_keeper_turn_fsm_tla_parity.ml
+++ b/test/test_keeper_turn_fsm_tla_parity.ml
@@ -1,0 +1,88 @@
+(* Parity test: [Keeper_turn_fsm.all_symbols] (derived by [ppx_tla])
+   must match the [TurnStateSet] enumerated in
+   [specs/keeper-turn-fsm/KeeperTurnFSM.tla].
+
+   This test makes the spec-implementation drift visible at build time.
+   When a constructor is added, removed, or renamed in either side, the
+   other side must follow within the same PR or this test fails — which
+   is the entire point of [@@deriving tla].
+
+   Cycle 3 of the Kimi keeper FSM review plan; see
+   [planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md]
+   §10 ("formalized incompleteness") for the OCaml ↔ TLA+ identity goal. *)
+
+(* Hardcoded copy of TurnStateSet from the spec. Kept in sync by hand
+   for now — Cycle 3+ may parse the .tla file directly so this list is
+   no longer a second source of truth. *)
+let spec_turn_state_set =
+  [
+    "idle";
+    "phase_gating";
+    "cascade_routing";
+    "awaiting_provider";
+    "streaming";
+    "awaiting_tool";
+    "completing";
+    "done";
+    "failed";
+    "cancelled";
+  ]
+
+let sort = List.sort String.compare
+
+let test_all_symbols_match_spec () =
+  let ocaml = sort Masc_mcp.Keeper_turn_fsm.all_symbols in
+  let spec = sort spec_turn_state_set in
+  if ocaml <> spec then begin
+    Printf.printf "OCaml all_symbols  : [%s]\n"
+      (String.concat "; " ocaml);
+    Printf.printf "Spec  TurnStateSet : [%s]\n"
+      (String.concat "; " spec);
+    let only_ocaml = List.filter (fun s -> not (List.mem s spec)) ocaml in
+    let only_spec = List.filter (fun s -> not (List.mem s ocaml)) spec in
+    Printf.printf "Only in OCaml      : [%s]\n"
+      (String.concat "; " only_ocaml);
+    Printf.printf "Only in spec       : [%s]\n"
+      (String.concat "; " only_spec);
+    failwith
+      "Keeper_turn_fsm.all_symbols differs from spec TurnStateSet — \
+       update either the OCaml type, the [@tla.symbol] override, or the \
+       spec."
+  end
+
+let test_to_tla_symbol_for_each_constructor () =
+  (* Sanity: every nullary constructor round-trips through to_tla_symbol
+     into the spec set. Parameterised constructors are exercised with a
+     dummy payload. *)
+  let probe_nullary symbol_should_be ctor =
+    assert (Masc_mcp.Keeper_turn_fsm.to_tla_symbol ctor = symbol_should_be)
+  in
+  probe_nullary "idle" Masc_mcp.Keeper_turn_fsm.Idle;
+  probe_nullary "phase_gating" Masc_mcp.Keeper_turn_fsm.Phase_gating;
+  probe_nullary "cascade_routing" Masc_mcp.Keeper_turn_fsm.Cascade_routing;
+  probe_nullary "awaiting_provider" Masc_mcp.Keeper_turn_fsm.Awaiting_provider;
+  probe_nullary "streaming" Masc_mcp.Keeper_turn_fsm.Streaming;
+  (* [@tla.symbol "awaiting_tool"] override exercised here. *)
+  probe_nullary "awaiting_tool"
+    Masc_mcp.Keeper_turn_fsm.Awaiting_tool_result;
+  probe_nullary "completing" Masc_mcp.Keeper_turn_fsm.Completing;
+  probe_nullary "done" Masc_mcp.Keeper_turn_fsm.Done;
+  let dummy_failure =
+    Masc_mcp.Keeper_turn_fsm.Failure_runtime_error "probe"
+  in
+  let dummy_cancel =
+    Masc_mcp.Keeper_turn_fsm.Cancelled_supervisor_stop
+  in
+  assert (
+    Masc_mcp.Keeper_turn_fsm.to_tla_symbol
+      (Masc_mcp.Keeper_turn_fsm.Failed dummy_failure)
+    = "failed");
+  assert (
+    Masc_mcp.Keeper_turn_fsm.to_tla_symbol
+      (Masc_mcp.Keeper_turn_fsm.Cancelled dummy_cancel)
+    = "cancelled")
+
+let () =
+  test_all_symbols_match_spec ();
+  test_to_tla_symbol_for_each_constructor ();
+  print_endline "keeper_turn_fsm TLA+ parity test: PASS"


### PR DESCRIPTION
## Summary

Cycle 3 of the Kimi keeper FSM review plan: extend `ppx_tla` to handle realistic ADTs and apply `[@@deriving tla]` to `Keeper_turn_fsm.turn_state`. A parity test pins the PPX-generated symbols against the spec's `TurnStateSet` so future drift surfaces at build time.

This PR is **stacked on top of PR #11377** (Cycle 2 PPX bootstrap). Once #11377 merges to main, this PR's base will follow.

## Why

`Keeper_turn_fsm.turn_state` and `KeeperTurnFSM.tla` both list 10 states, but they were diverging silently. Today the OCaml side has `Awaiting_tool_result` while the spec calls it `awaiting_tool`. Without an automated check, the next constructor rename or addition would only surface as a runtime error — exactly the spec-implementation drift plan §1 calls **Drift** rather than **Refinement**.

`[@@deriving tla]` makes the OCaml type the single source of truth for the symbol mapping, and the new parity test fails the build whenever either side is changed without the other.

## What changed

### PPX extensions (`ppx_tla/ppx_tla.ml`)

- **`[@tla.symbol "explicit_name"]` per-constructor override**. Used here for `Awaiting_tool_result [@tla.symbol "awaiting_tool"]` so neither the OCaml constructor nor the spec keyword has to be renamed.
- **Parameterised constructors** (`Failed of failure_reason`, `Cancelled of cancel_reason`). The match-pattern uses `_` for the payload; symbol mapping is unaffected.
- **`all_symbols : string list`** always generated; safe for types where some constructors carry payloads (the previous `all_states : t list` is now generated only when every constructor is nullary, because a list literal cannot construct a payload-bearing variant).
- **`sig_type_decl` support** — `[@@deriving tla]` now also works on `.mli` and emits the corresponding `val to_tla_symbol` / `val all_symbols` / `val all_states` declarations.

### Application (`lib/keeper/keeper_turn_fsm.{ml,mli}`)

- Add `[@@deriving tla]` to `turn_state` in both `.ml` and `.mli`.
- Mark `Awaiting_tool_result` with `[@tla.symbol "awaiting_tool"]`.
- Add `ppx_tla` to `lib/dune` `preprocess` pps list.

### Parity test (`test/test_keeper_turn_fsm_tla_parity.ml`)

- Compare `Keeper_turn_fsm.all_symbols` against a hardcoded copy of the spec's `TurnStateSet`. On mismatch the test prints both sets plus the symmetric difference and fails with a clear remediation hint.
- Probe `to_tla_symbol` for every constructor — including the override and the two parameterised ones with dummy payloads — to make sure the override is exercised at runtime.

```
$ dune exec test/test_keeper_turn_fsm_tla_parity.exe
keeper_turn_fsm TLA+ parity test: PASS
```

## What is NOT in this PR (follow-up)

| Follow-up | Cycle |
|-----------|-------|
| Classification attributes `[@tla.terminal]` / `[@tla.idle]` / `[@tla.active]` deriving `terminal_states` / `idle_states` / `active_states` subsets | Cycle 3b or 4 |
| Spec parser that reads `TurnStateSet` directly from the `.tla` file so the parity test stops carrying its own hardcoded copy | follow-up |
| Apply `[@@deriving tla]` to other keeper FSMs (`keeper_state_machine`, `keeper_turn_fsm.cancel_reason`, etc.) | follow-up |
| Extend the receipt-outcome work in PR #11360 to use `ppx_tla` for the `outcome_kind` ↔ string mapping | natural follow-on |

## Test plan

- [x] `dune build --root <worktree> @lib/check` passes.
- [x] `dune build --root <worktree> ppx_tla/ test/ppx_tla/` passes.
- [x] `dune runtest --root <worktree> test/ppx_tla/` prints `ppx_tla cycle 2 + 3 tests: PASS`.
- [x] `dune exec --root <worktree> test/test_keeper_turn_fsm_tla_parity.exe` prints `keeper_turn_fsm TLA+ parity test: PASS`.
- [ ] Full repo `dune build` not yet verified in this PR (stacked PR; full check will happen post-rebase to main once #11377 merges).

## Spec link

- `specs/keeper-turn-fsm/KeeperTurnFSM.tla` — `TurnStateSet` (line 63).
- Plan §3 Tier I1 (PPX deriver) and §11.3 ROI table.
- Stacked on PR #11377 (Cycle 2 ppx_tla bootstrap).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
