### PR TITLE
fix(lint): pre-add keeper_types.mli to V10 allow-list

### DIFF
--- a/scripts/check-boundary-guard.sh
+++ b/scripts/check-boundary-guard.sh
@@ -115,6 +115,7 @@ check_forbidden_outside "V10-provider-filter-ownership" \
   'allowed_providers' \
   "lib/" \
   "lib/keeper/keeper_types.ml" \
+  "lib/keeper/keeper_types.mli" \
   "lib/keeper/keeper_meta_json_scrub.ml" \
   "lib/keeper/keeper_meta_json_scrub.mli"
 


### PR DESCRIPTION
## Summary
Mirrors PR #11369 (V11 proof_artifact_reader.mli) — \`lib/keeper/keeper_types.mli\` exists on disk but is missing from the V10 allow-list of \`scripts/check-boundary-guard.sh\`. Currently safe (the .mli does not contain \`allowed_providers\`), but a future docstring/signature edit would surface the same merge-queue blocker that bit V10 in PR #11248.

## V10 boundary-guard area now fully .mli-paired (after this PR)

| .ml | .mli |
|-----|------|
| keeper_types.ml | keeper_types.mli (**this PR**) |
| keeper_meta_json_scrub.ml | keeper_meta_json_scrub.mli (#11283) |

## Mechanism
Same as #11248 / #11369: when boundary-guard sees a forbidden pattern in an unlisted .mli, it fails Lint on every PR until the .mli is added.

PAIR-GATE (PR #11298) is silent here because the .mli is not newly-added in this PR — diff-driven scope only catches first-introduction, so a complementary pre-emptive sweep is justified.

## Test plan
- [x] Local \`bash scripts/check-boundary-guard.sh\` → "BOUNDARY: all checks within baseline"
- [ ] CI Lint green

## Refs
- #11248 → blocked #11272 → fix-forward #11280 / #11283 (V10 first occurrence)
- #11369 (V11 sibling)
- #11298 (PAIR-GATE — diff-driven, complementary)
- memory: \`feedback_jane-street-refactor-sweep-miss\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)