### PR TITLE
refactor(keeper): add keeper_shell_docker.mli (PR#3 batch 27)

### DIFF
--- a/lib/keeper/keeper_shell_docker.mli
+++ b/lib/keeper/keeper_shell_docker.mli
@@ -1,0 +1,159 @@
+(** Docker / sandbox shell execution infrastructure.
+
+    Extracted from keeper_exec_shell.ml — Docker container
+    lifecycle, sandbox profile resolution, and container
+    invocation. Pure infrastructure; command dispatch remains in
+    keeper_exec_shell.ml. *)
+
+(** Diagnostic label for a [Unix.process_status]:
+    [exit=N] / [signal=N] / [stopped=N]. *)
+val docker_exec_status_label : Unix.process_status -> string
+
+(** Build a structured failure message used by docker exec
+    diagnostics, emphasising the exit/signal status and (when
+    blank) flagging empty output explicitly. *)
+val docker_exec_failure_message :
+  image:string ->
+  status:Unix.process_status ->
+  output:string ->
+  string
+
+(** Per-keeper dedupe set guarding [warn_sandbox_gh_token_missing]. *)
+val gh_token_warn_emitted : (string, unit) Hashtbl.t
+
+val gh_token_warn_mu : Eio.Mutex.t
+
+(** Emit one structured warning + Prometheus counter increment
+    when the sandbox GH_TOKEN resolution chain collapses to "" for
+    [keeper_name]. *)
+val warn_sandbox_gh_token_missing : string -> unit
+
+(** Path of the per-keeper egress policy file
+    [<sandbox_root>/egress.json]. *)
+val egress_policy_path :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  string
+
+(** Check [cmd] against [Masc_exec.Egress_policy] for the keeper.
+    Returns [Some blocked_json] when blocked, [None] when allowed. *)
+val check_egress :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cmd:string ->
+  string option
+
+(** Per-invocation container name [masc-keeper-<safe>-<pid>-<ms>]. *)
+val keeper_sandbox_container_name :
+  Keeper_types.keeper_meta -> string
+
+val keeper_private_container_root : Keeper_types.keeper_meta -> string
+
+(** Translate a host cwd into the in-container path mirror,
+    falling back to the container root when [host_cwd] is outside
+    the keeper sandbox root. *)
+val docker_private_workspace_cwd :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  string ->
+  string
+
+(** Resolve [(sandbox_profile, network_mode)] given the keeper's
+    declared profile and whether the cwd is in-playground. Hard
+    mode forces the keeper's declared profile; otherwise [Local]
+    in playground may be auto-promoted to [Docker / Network_inherit]
+    when [DockerPlayground.enabled]. *)
+val effective_sandbox_profile :
+  meta:Keeper_types.keeper_meta ->
+  in_playground:bool ->
+  Keeper_types.sandbox_profile * Keeper_types.network_mode
+
+(** Tokens flagged as nested container-runtime invocations. *)
+val nested_container_runtime_tokens : string list
+
+(** Filesystem markers indicating host container-socket access
+    (docker.sock, podman.sock, containerd.sock, ...). *)
+val sandbox_socket_markers : string list
+
+(** [true] iff [cmd] mentions a nested container runtime token or
+    references a host container socket. *)
+val command_uses_nested_container_runtime : string -> bool
+
+(** Re-export of [Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime]. *)
+val ensure_keeper_sandbox_runtime :
+  timeout_sec:float -> (unit, string) result
+
+val cmd_targets_git_or_gh : string -> bool
+val cmd_targets_gh : string -> bool
+
+(** [#10855] LLM hallucinated [gh --repo X api Y] (108 events / 24h).
+    Returns [Some (repo_arg, endpoint)] when the misuse pattern is
+    detected, [None] otherwise — caller emits a self-correcting
+    error pre-exec. *)
+val detect_gh_repo_flag_with_api_misuse :
+  string -> (string * string) option
+
+(** Emit a [("gh_exit_class", ...)] JSON field when [cmd] targets
+    gh (otherwise []), and bump the matching [Legendary_counters]
+    bucket. Caller appends the returned list to its assoc payload
+    unconditionally — the empty case keeps callsite shapes stable. *)
+val gh_exit_class_field :
+  cmd:string ->
+  status:Unix.process_status ->
+  output:string ->
+  (string * Yojson.Safe.t) list
+
+(** [-v <host>:<container>:ro] mount list, or [[]] when [host] is
+    blank or missing. *)
+val optional_ro_mount :
+  host:string -> container:string -> string list
+
+(** Result envelope returned by [run_docker_shell_command_with_status]. *)
+type docker_shell_result =
+  { status : Unix.process_status
+  ; output : string
+  ; image : string
+  ; network_label : string
+  }
+
+(** Cold-start floor (seconds) for [docker run --rm]. *)
+val docker_run_min_timeout_sec : float
+
+(** Run [cmd] inside the keeper Docker sandbox; clamps
+    [timeout_sec] to [docker_run_min_timeout_sec], honours
+    [git_creds_enabled] and [network_mode], records errors via
+    [Keeper_registry]. *)
+val run_docker_shell_command_with_status :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  timeout_sec:float ->
+  cmd:string ->
+  git_creds_enabled:bool ->
+  network_mode:Keeper_types.network_mode ->
+  (docker_shell_result, string) result
+
+(** Run [cmd] inside the Docker sandbox with git credentials
+    forwarded (Network_inherit). Returns the JSON envelope to
+    surface to the LLM, including [gh_exit_class] when applicable. *)
+val run_docker_with_git_bash :
+  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  timeout_sec:float ->
+  cmd:string ->
+  unit ->
+  string
+
+(** Run [cmd] inside the hardened Docker sandbox with the caller's
+    [network_mode] (no git creds). *)
+val run_docker_hardened_bash :
+  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  timeout_sec:float ->
+  cmd:string ->
+  network_mode:Keeper_types.network_mode ->
+  string


### PR DESCRIPTION
## Summary

PR#3 batch 27.

| module | lines |
|---|---|
| `keeper_shell_docker` | 653 |

Docker / sandbox shell execution infrastructure — container
lifecycle, profile resolution, and container invocation.
Locks the **Docker boundary** for keeper shell tools.

Exposed (~25 entries):
- 2 diagnostic helpers: `docker_exec_status_label`,
  `docker_exec_failure_message`
- 3 GH_TOKEN dedup entries (Hashtbl + Mutex + emit)
- 2 egress policy entries: `egress_policy_path`, `check_egress`
- 3 container naming entries
- `effective_sandbox_profile` (hard mode + DockerPlayground promotion)
- 3 nested-runtime detection entries
- 2 gh classifiers + `detect_gh_repo_flag_with_api_misuse`
  (#10855 LLM hallucination guard)
- `gh_exit_class_field` (Legendary_counters bucket emit)
- `type docker_shell_result` (4-field envelope)
- 3 docker invocation entries: raw, git_bash, hardened_bash

## Surgical

- .ml unchanged.

## Test plan

- [x] dune build ✓
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)