### PR TITLE
refactor(keeper): add keeper_status_detail.mli (PR#3 batch 30)

### DIFF
--- a/lib/keeper/keeper_status_detail.mli
+++ b/lib/keeper/keeper_status_detail.mli
@@ -1,0 +1,48 @@
+(** Single-keeper status detail handler.
+
+    Owns the [keeper_status] tool dispatch plus the response cache
+    that keeps the dashboard latency manageable. The list /
+    trajectory / eval handlers are in [Keeper_status]; this module
+    only handles the per-keeper detail view.
+
+    Selective .mli — internal helpers (cache hashtable + mutex,
+    [latest_metrics_json], [model_observability_json], the
+    [resolve_status_target] dispatch helpers, etc.) stay private. *)
+
+type tool_result = Keeper_types.tool_result
+
+(** Sort order for tail-window projections (metrics / trajectory). *)
+type tail_order =
+  | Oldest_first
+  | Newest_first
+
+(** Parse the [tail_order] argument from a tool-call JSON.
+    Defaults to [Oldest_first] for unknown / missing values. *)
+val tail_order_of_args : Yojson.Safe.t -> tail_order
+
+val tail_order_to_string : tail_order -> string
+
+(** Every variant in [tail_order]; used by the [Keeper_schema]
+    enum mirror. *)
+val all_tail_orders : tail_order list
+
+(** Variant labels used in tool-input enum schemas. *)
+val valid_tail_order_strings : string list
+
+(** Apply [tail_order] to a list of items. Identity for
+    [Oldest_first], [List.rev] for [Newest_first]. *)
+val apply_tail_order : tail_order -> 'a list -> 'a list
+
+(** Drop the cache entry for a single keeper; called from any
+    state-change path that invalidates the cached snapshot. *)
+val invalidate_status_cache_for : string -> unit
+
+(** Drop the entire status cache; called on global state changes
+    (boot, mass reload). *)
+val invalidate_status_cache_all : unit -> unit
+
+(** [keeper_status] tool handler. Reads from the response cache
+    when the keeper's [updated_at] + args hash is unchanged;
+    otherwise rebuilds the snapshot and refreshes the cache. *)
+val handle_keeper_status :
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result


### PR DESCRIPTION
## Summary

PR#3 batch 30 — third selective-exposure .mli. **Smallest surface yet** relative to module size.

| module | lines | exposed | ratio |
|---|---|---|---|
| `keeper_status_detail` | 1316 | 8 | ~3% |

The single-keeper status detail handler. Owns the
`keeper_status` tool dispatch + the response cache that keeps
the dashboard latency manageable.

Exposed:
- `type tool_result`, `type tail_order`
- 4 tail_order helpers (Variant SSOT for the schema mirror)
- 2 cache invalidation entries
- `handle_keeper_status`

Hidden by .mli:
- `_cache` Hashtbl + `cache_mu` Mutex (internal state)
- `type cache_entry`, helper builders, JSON renderers (~25 entries
  totalling ~400 lines of `_json` builders)

## Surgical

- .ml unchanged.
- 5 external callers all surface here.

## Test plan

- [x] dune build ✓
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)