### PR TITLE
feat(masc-trace): print FSM path summary at end of timeline (Step 4q)

### DIFF
--- a/bin/masc_trace.ml
+++ b/bin/masc_trace.ml
@@ -186,7 +186,37 @@ let dump_fsm_transitions ~base_path ~keeper ~turn_id =
               ~default:"-"
           in
           Printf.printf "%s [fsm] %s\n" ts msg)
-        matches
+        matches;
+    (* Path summary: extract the [to_state] from each [fsm:transition]
+       line and join with arrows.  An operator scanning for "did this
+       turn reach done?" gets the answer in one line without scrolling
+       through the per-row trail above. *)
+    let extract_to_state msg =
+      let needle = "-> " in
+      let lens = String.length msg in
+      let lensub = String.length needle in
+      let rec find i =
+        if i > lens - lensub then None
+        else if String.sub msg i lensub = needle then
+          let rest = String.sub msg (i + lensub) (lens - i - lensub) in
+          Some (String.trim rest)
+        else find (i + 1)
+      in
+      find 0
+    in
+    if matches <> [] then begin
+      let states =
+        List.filter_map
+          (fun json ->
+            string_field json "message"
+            |> Option.value ~default:""
+            |> extract_to_state)
+          matches
+      in
+      if states <> [] then
+        Printf.printf "=== fsm path === %s -> %s\n" keeper
+          (String.concat " -> " states)
+    end
 
 (** Scan [.masc/tool_calls/<YYYY-MM>/<DD>.jsonl] for tool call
     rows whose [keeper] = our keeper and


### PR DESCRIPTION
## Summary

Adds a one-line \`=== fsm path === <keeper> -> s1 -> s2 -> ... -> sN\` summary after the per-row \`[fsm]\` section. An operator running \`masc-trace\` for a single turn gets "did this turn reach done?" in one glance. /loop iteration 14.

## Output shape

```
$ masc-trace ~/me alice 42
...T... [receipt 04-28.jsonl] cascade=keeper-default outcome=skipped reason=...
...T... [fsm] alice: [fsm:transition] - -> phase_gating
...T... [fsm] alice: [fsm:transition] phase_gating -> cancelled:phase_gate_close
=== fsm path === alice -> phase_gating -> cancelled:phase_gate_close
1777248791.071 [tool keeper_tasks_list] ok duration_ms=372
```

## Implementation

\`extract_to_state\` walks the message text for the first \` -> \` substring and returns the trimmed remainder. Robust to the \`<keeper_name>: \` prefix \`Log.Keeper\` prepends, and to trailing whitespace. No \`Str\` dep added — bin's \`(libraries yojson)\` stays minimal.

If no \`fsm:transition\` rows matched, no summary line prints — operator sees the existing \`no [fsm:transition] lines for ...\` diagnostic.

## Test plan

- [x] \`dune build bin/masc_trace.exe\` green
- [x] CLI no-arg invocation works (no crash with empty matches)
- [ ] CI lint + meta-guards green
- [ ] Post-merge: against a real fleet, confirm summary shows correct path

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4q. Smallest ergonomic win on top of the 14 underlying observability PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)