### PR TITLE
chore(exec/risk): exhaustive match in risk_classifier (forward-compat)

### DIFF
--- a/lib/exec/risk_classifier.ml
+++ b/lib/exec/risk_classifier.ml
@@ -17,13 +17,21 @@ let risk_class_to_string = function
 let risk_class_to_json rc =
   `String (risk_class_to_string rc)
 
+(* Both helpers below replace [_ -> false] wildcards with explicit
+   arms.  Behaviour is identical for the four current variants
+   (locked by test_risk_classifier; Read/Write/Network/Destructive
+   each asserted directly), but adding a future variant — e.g.
+   Privileged, External_call — now triggers a non-exhaustive-match
+   compile error instead of silently inheriting the false branch.
+   Defends against the inverse of the
+   "Variant addition partial-match cascade" pattern. *)
 let is_cacheable = function
   | Read -> true
-  | _ -> false
+  | Write | Network | Destructive -> false
 
 let requires_approval = function
   | Destructive -> true
-  | _ -> false
+  | Read | Write | Network -> false
 
 let default_timeout_ms = function
   | Read -> 30_000


### PR DESCRIPTION
## Goal

`is_cacheable` 와 `requires_approval` 양쪽 모두 `_ -> false` wildcard 사용 중. 4개 현존 variant (Read/Write/Network/Destructive) 행동은 동일하지만, **새 variant 추가 시 자동 silent permissive default** — \"Variant addition partial-match cascade\" 패턴의 inverse.

## 변경

```ocaml
- let is_cacheable = function
-   | Read -> true
-   | _ -> false

+ let is_cacheable = function
+   | Read -> true
+   | Write | Network | Destructive -> false

- let requires_approval = function
-   | Destructive -> true
-   | _ -> false

+ let requires_approval = function
+   | Destructive -> true
+   | Read | Write | Network -> false
```

15 lines added (helper comment + 2 explicit unions), 6 lines deleted.

## 행동 변화: zero

`test_risk_classifier.ml:31-34`:
```ocaml
Alcotest.(check bool) \"destructive\" true (RC.requires_approval RC.Destructive);
Alcotest.(check bool) \"read\" false (RC.requires_approval RC.Read);
Alcotest.(check bool) \"write\" false (RC.requires_approval RC.Write);
Alcotest.(check bool) \"network\" false (RC.requires_approval RC.Network)
```

각 4개 variant 명시 assert. `_ -> false` 와 explicit `Read|Write|Network -> false` 모두 동일 통과.

## 회귀 surface 변화: one

향후 `lib/exec/risk_classifier.mli` 에 새 variant (예: `Privileged`, `External_call`, `System_modify`) 추가 시:
- **Before**: 두 함수 자동 `false` 반환, 컴파일러 silent. 운영자가 \"no approval needed\" 로 새 risk class 가 silently 통과.
- **After**: 두 함수 모두 `non-exhaustive match` 컴파일 에러. 변경자가 명시적으로 안전 결정 강제.

## 검증

HEAD: `c264fe8e42` (origin/main)
- `dune build` (full): ✅ EXIT=0
- `dune test lib/exec/test/test_risk_classifier.ml`: ✅ EXIT=0 (8 assertions)
- 회귀 risk: **0** (행동 변화 없음, 컴파일 강제만 추가)

## Memory rule alignment

- \"Variant addition partial-match cascade\" — 이번 PR 이 정확한 inverse 케이스 (silent permissive default 방지)
- \"No string matching for classification\" — variant/enum 의 구조적 신호로 결정 강제
- \"Audit-bucket-cascade pattern\" — 같은 file 두 함수 같은 anti-pattern → sweep 적용

## 메타

이 PR 은 18 cycle 자율 hole 탐사의 사이드 deliverable. cascade silent fallback (PR #11328 + #11361) 과 별개 family 의 작은 defensive hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)