### PR TITLE
feat(safety): receipt append failure escalates to turn-level error (Cycle 5 / Tier A2)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2900,37 +2900,65 @@ let run_turn
         ended_at = receipt_ended_at;
       }
     in
-    (try
-       Keeper_execution_receipt.append config receipt
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Log.Keeper.warn
-         "keeper:%s execution_receipt append failed: %s"
-         meta.name
-         (Printexc.to_string exn);
-       (try
-          let masc_root = Coord.masc_root_dir config in
-          Telemetry_coverage_gap.record
-            ~masc_root
-            ~source:"execution_receipt"
-            ~producer:"keeper_agent_run.execution_receipt"
-            ~durable_store:
-              (Filename.concat
-                 (Filename.concat (Filename.concat masc_root "keepers") meta.name)
-                 "execution-receipts")
-            ~dashboard_surface:"/api/v1/dashboard/execution-trust"
-            ~stale_reason:"execution_receipt_append_failed"
-            ~keeper_name:meta.name
-            ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-            ~error:(Printexc.to_string exn)
-            ()
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | gap_exn ->
-          Log.Keeper.warn
-            "keeper:%s execution_receipt coverage gap append failed: %s"
-            meta.name
-            (Printexc.to_string gap_exn)));
-    turn_result
+    (* Tier A2 / Cycle 5: receipt append failure escalates to a
+       turn-level Error.
+
+       Pre-Cycle 5 the catch arm logged a WARN, recorded a coverage-gap
+       and let [turn_result] fall through unchanged. That violates the
+       [EveryTurnHasTerminalReceipt] safety property (KeeperTurnFSM
+       and KeeperOutcomesConservation specs): a turn whose authoritative
+       receipt is silently dropped cannot be reported as Ok. The
+       coverage-gap helper is still called so the gap surface keeps
+       working; the difference is the caller now sees the failure too. *)
+    let receipt_append_outcome : (unit, string) result =
+      try
+        Keeper_execution_receipt.append config receipt;
+        Ok ()
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        let err_msg = Printexc.to_string exn in
+        Log.Keeper.warn
+          "keeper:%s execution_receipt append failed: %s"
+          meta.name err_msg;
+        (try
+           let masc_root = Coord.masc_root_dir config in
+           Telemetry_coverage_gap.record
+             ~masc_root
+             ~source:"execution_receipt"
+             ~producer:"keeper_agent_run.execution_receipt"
+             ~durable_store:
+               (Filename.concat
+                  (Filename.concat (Filename.concat masc_root "keepers") meta.name)
+                  "execution-receipts")
+             ~dashboard_surface:"/api/v1/dashboard/execution-trust"
+             ~stale_reason:"execution_receipt_append_failed"
+             ~keeper_name:meta.name
+             ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+             ~error:err_msg
+             ()
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | gap_exn ->
+           Log.Keeper.warn
+             "keeper:%s execution_receipt coverage gap append failed: %s"
+             meta.name
+             (Printexc.to_string gap_exn));
+        Error err_msg
+    in
+    match turn_result, receipt_append_outcome with
+    | Error _, _ ->
+      (* Turn already failed; preserve the original error rather than
+         masking it with a receipt-lost wrapper. The coverage-gap record
+         above keeps the receipt-store side observable. *)
+      turn_result
+    | Ok _, Ok () -> turn_result
+    | Ok _, Error err_msg ->
+      (* Safety escalation: turn-body succeeded but the authoritative
+         receipt could not be persisted. Surface a structured internal
+         error so the caller's [match turn_result with Ok _ | Error _]
+         no longer sees a fictitious success. *)
+      Error
+        (Oas.Error.Internal
+           (Printf.sprintf "execution_receipt_append_failed: %s" err_msg))
 ;;


### PR DESCRIPTION
## Summary

Cycle 5 / Tier A2 of the Kimi keeper FSM review plan: receipt append failure now escalates to a turn-level `Error` instead of being swallowed by a WARN log. Pre-Cycle 5 a turn whose authoritative receipt was silently dropped still surfaced as `Ok _` to every downstream consumer — directly violating the `EveryTurnHasTerminalReceipt` safety property declared in `KeeperTurnFSM` / `KeeperOutcomesConservation`.

## Why

The user flagged this in the integration plan (§3 Tier A2 / §11.2 "Safety only" / §10 formalized incompleteness):

> "keeper_agent_run.ml:2880-2888의 receipt append 실패 처리는 safety property를 손실합니다… 이것은 refinement로 정당화할 수 없습니다. 이것은 버그입니다."

A receipt-store failure is a real safety violation, not a refinement. Other consumers (dashboard, replay, accountability) treat receipts as the *authoritative* terminal record. Surfacing a turn as `Ok _` while its receipt is missing means the system lies to itself — exactly the kind of silent drift this plan was created to remove.

## What changed

`lib/keeper/keeper_agent_run.ml` line 2903–2935 — post-dispatch receipt append site at the tail of `run_turn`.

**Before** (catch arm returns unit; `turn_result` falls through unchanged):

```ocaml
(try Keeper_execution_receipt.append config receipt
 with
 | Eio.Cancel.Cancelled _ as e -> raise e
 | exn ->
   Log.Keeper.warn ...;
   try Telemetry_coverage_gap.record ... with ...);
turn_result
```

**After** (catch arm returns `Error err_msg`; `turn_result` is rebuilt by matching on `(turn_result, receipt_append_outcome)`):

```ocaml
let receipt_append_outcome : (unit, string) result =
  try Keeper_execution_receipt.append config receipt; Ok ()
  with
  | Eio.Cancel.Cancelled _ as e -> raise e
  | exn ->
    let err_msg = Printexc.to_string exn in
    Log.Keeper.warn ...;
    (try Telemetry_coverage_gap.record ... with ...);
    Error err_msg
in
match turn_result, receipt_append_outcome with
| Error _, _      -> turn_result               (* preserve original error *)
| Ok _, Ok ()     -> turn_result               (* both succeeded         *)
| Ok _, Error err_msg ->
  Error
    (Oas.Error.Internal
       (Printf.sprintf "execution_receipt_append_failed: %s" err_msg))
```

Three semantics points:

1. **Cancellation is still re-raised.** No swallowing of `Eio.Cancel.Cancelled`.
2. **An already-failing turn keeps its original error.** No masking with a receipt-lost wrapper — the turn-body error is more useful for diagnosis than the bookkeeping error.
3. **Coverage-gap recording is unchanged.** The existing `Telemetry_coverage_gap` surface keeps working; the difference is that the caller now sees the failure too.

## What is NOT in this PR (follow-up)

| Follow-up | Why now |
|-----------|---------|
| **Pre-dispatch site** in `keeper_unified_turn.ml:217` | The enclosing `record_pre_dispatch_terminal_observation` returns `unit` and has 4 callers; converting it to `(unit, error) result` is a wider surface than Cycle 5 should land. Same `receipt_append_outcome` shape will lift here cleanly in a follow-up PR. |
| **Prometheus counter** `masc_keeper_receipt_lost_total` | Plan §3 Tier A2 mentions it; keeping the type-shape change minimal first. The error_msg already includes the failure detail, so observability is partially covered until the counter lands. |
| **Unit test** with injected append failure | Mocking `Keeper_execution_receipt.append` requires either a filesystem fault or a functor seam — neither exists yet. The right home is a property-test infra task that introduces a fixture-level seam. The new control flow itself is covered by the type-checker (the `Ok _, Error _` arm is exhaustive). |

## Test plan

- [x] `dune build --root <worktree> @lib/check` passes — type-checker confirms the new match is exhaustive and the new return type matches the function signature.
- [ ] `dune runtest` and full `dune build` not yet verified (worktree first build hasn't happened in this PR; the keeper module type-checks cleanly via the targeted `@lib/check` alias).
- [ ] No new unit test added (see follow-up table above).

## Spec link

- `specs/keeper-state-machine/KeeperOutcomesConservation.tla` — conservation invariant; this fix prevents a silent receipt loss from breaking the bucket math downstream.
- `specs/keeper-turn-fsm/KeeperTurnFSM.tla` — `EveryTurnHasTerminalReceipt` is the safety property the silent WARN was violating.

Sibling cycles in this plan:
- #11360 (Cycle 1a outcome_kind tri-state)
- #11377 (Cycle 2 ppx_tla bootstrap)
- #11384 (Cycle 3 ppx_tla extensions + keeper_turn_fsm parity)
- #11391 (Cycle 4 AuthIdentityFSM.tla integration)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
