### PR TITLE
refactor(coord): add coord_utils_paths_backend.mli

### DIFF
--- a/lib/coord/coord_utils_paths_backend.mli
+++ b/lib/coord/coord_utils_paths_backend.mli
@@ -1,0 +1,121 @@
+(** Coord paths + backend dispatch.
+
+    Resolves the canonical [.masc/] directory layout (per-cluster +
+    legacy room paths), and dispatches CRUD/lock/pubsub calls to
+    the active [Backend] implementation (Memory / FileSystem). *)
+
+open Coord_utils_backend_setup
+
+(** Compute the masc_root directory from primitives.
+    [cluster_name = "" | "default"] resolves to [<base>/.masc/];
+    other names produce [<base>/.masc/clusters/<sanitized>/]. *)
+val masc_root_dir_from :
+  base_path:string -> cluster_name:string -> string
+
+val masc_root_dir : config -> string
+
+(** Default-cluster shortcut for callers holding only [base_path]
+    (#8355: stops re-inlining [<base>/.masc] across non-coord
+    callsites). *)
+val masc_dir_from_base_path : base_path:string -> string
+
+val current_room_root_path : config -> string
+val room_dir_for : config -> string -> string
+
+(** Always [Some "default"] — the operational namespace is
+    single-room. *)
+val read_current_room : config -> string option
+
+val masc_dir : config -> string
+val agents_dir : config -> string
+val tasks_dir : config -> string
+val messages_dir : config -> string
+val state_path : config -> string
+val backlog_path : config -> string
+val archive_path : config -> string
+
+(** {1 Backend dispatch} *)
+
+(** Always [false] — postgres backend was removed. *)
+val is_pg_backend : config -> bool
+
+val backend_get :
+  config -> key:string -> (string option, Backend_types.error) result
+
+val backend_set :
+  config -> key:string -> value:string -> (unit, Backend_types.error) result
+
+(** Returns [Ok true] if a key was deleted, [Ok false] if absent. *)
+val backend_delete :
+  config -> key:string -> (bool, Backend_types.error) result
+
+val backend_exists :
+  config -> key:string -> (bool, Backend_types.error) result
+
+val backend_list_keys :
+  config -> prefix:string -> (string list, Backend_types.error) result
+
+val backend_get_all :
+  config -> prefix:string -> ((string * string) list, Backend_types.error) result
+
+val backend_set_if_not_exists :
+  config -> key:string -> value:string -> (bool, Backend_types.error) result
+
+val backend_acquire_lock :
+  config -> key:string -> ttl_seconds:int -> owner:string ->
+  (bool, Backend_types.error) result
+
+val backend_release_lock :
+  config -> key:string -> owner:string ->
+  (bool, Backend_types.error) result
+
+val backend_extend_lock :
+  config -> key:string -> ttl_seconds:int -> owner:string ->
+  (bool, Backend_types.error) result
+
+val backend_health_check :
+  config -> (Backend_types.health_status, Backend_types.error) result
+
+val backend_publish :
+  config -> channel:string -> message:string ->
+  (unit, Backend_types.error) result
+
+val backend_subscribe :
+  config -> channel:string -> callback:(string -> unit) ->
+  (unit, Backend_types.error) result
+
+val backend_name : config -> string
+
+(** [true] iff the backend mirrors keys to local-filesystem
+    directories (FileSystem backend). *)
+val backend_supports_local_dir : storage_backend -> bool
+
+val backend_cleanup_pubsub :
+  config -> days:int -> max_messages:int ->
+  (int, Backend_types.error) result
+
+(** {1 Path / key conversion} *)
+
+(** Convert an absolute filesystem path to a backend key.
+    Returns [None] when the path is not rooted under
+    [masc_root_dir]. *)
+val key_of_path : config -> string -> string option
+
+(** Same as [key_of_path] — kept as a separate alias to make
+    cluster-root-rooted lookups explicit at the call site. *)
+val root_key_of_path : config -> string -> string option
+
+(** List directory entries either via [Sys.readdir] (when the
+    backend supports a local dir mirror) or via [backend_list_keys]
+    over the synthesized prefix. *)
+val list_dir : config -> string -> string list
+
+(** {1 Initialization check} *)
+
+(** [true] iff the cluster-root state file exists (independent of
+    the current room). Used by room/cluster management features. *)
+val root_is_initialized : config -> bool
+
+(** [true] iff the current room is initialized (state.json
+    present). Backend-agnostic check. *)
+val is_initialized : config -> bool


### PR DESCRIPTION
## Summary

PR#3 시리즈가 keeper_mli_missing을 closing한 시점에서, lib/coord/
디렉토리에 남은 3개 잔여 .mli 중 첫 번째.

| module | lines | exposed |
|---|---|---|
| `coord_utils_paths_backend` | 270 | ~30 |

Canonical .masc/ directory layout resolver + backend
(Memory / FileSystem) dispatch.

Exposed:
- 3 masc-root resolvers
- 7 directory / path builders
- 13 backend dispatch entries (CRUD + lock + pubsub + health)
- key_of_path conversions
- root_is_initialized + is_initialized

## Caller surface

0 direct external callers — module is consumed via the
`Coord_utils` facade (`include` in `coord_utils.ml`). Same
indirect-facade pattern as keeper_meta_json_parse (PR#3 batch 26):
the .mli locks every signature so the facade cannot leak
unintended drift on field renames.

## Surgical

- .ml unchanged.

## Test plan

- [x] dune build ✓
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)