### PR TITLE
refactor(coord): replace 6 'inferred mli' headers with real docstrings

### DIFF
--- a/lib/coord/coord_backlog.mli
+++ b/lib/coord/coord_backlog.mli
@@ -1,9 +1,8 @@
-(** coord_backlog inferred mli **)
+(** Coord backlog persistence — read / write the canonical
+    [tasks/backlog.json] document with structural recovery. *)
 
 open Types
 open Coord_utils
-
-
 
 val backlog_recovery_path : Coord_utils_backend_setup.config -> string
 val decode_backlog : path:string ->

--- a/lib/coord/coord_bootstrap.mli
+++ b/lib/coord/coord_bootstrap.mli
@@ -1,9 +1,8 @@
-(** coord_bootstrap inferred mli **)
+(** Coord room bootstrap — initialize the default room state on
+    first boot. *)
 
 open Types
 open Coord_utils
-
-
 
 val default_room_state : Coord_utils_backend_setup.config -> Types_core.room_state
 val ensure_room_bootstrap : Coord_utils_backend_setup.config -> unit

--- a/lib/coord/coord_broadcast.mli
+++ b/lib/coord/coord_broadcast.mli
@@ -1,9 +1,8 @@
-(** coord_broadcast inferred mli **)
+(** Coord broadcast — emit room-wide messages and the
+    accompanying message-activity event. *)
 
 open Types
 open Coord_utils
-
-
 
 val emit_message_activity : Coord_utils_backend_setup.config ->
            from_agent:string ->

--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -1,4 +1,10 @@
-(** coord_hooks inferred mli **)
+(** Coord lifecycle hook registry.
+
+    Atomic refs filled at boot by the runtime so the coord layer
+    can call back into keeper / agent / economy / relation
+    subsystems without a static dependency. Default values are
+    no-ops; the runtime overrides each ref via the wiring in
+    [lib/coord.ml]. *)
 
 open Types
 

--- a/lib/coord/coord_identity.mli
+++ b/lib/coord/coord_identity.mli
@@ -1,8 +1,7 @@
-(** coord_identity inferred mli **)
+(** Coord identity helpers — session id, hostname, tty, and
+    agent-name resolution. *)
 
 open Coord_utils
-
-
 
 val generate_session_id : unit -> string
 val get_hostname : unit -> string option

--- a/lib/coord/coord_status.mli
+++ b/lib/coord/coord_status.mli
@@ -1,9 +1,8 @@
-(** coord_status inferred mli **)
+(** Coord status snapshot — render the room/agent state as a
+    human-readable string for the [masc_status] tool. *)
 
 open Types
 open Coord_utils
 open Coord_state
-
-
 
 val status : Coord_utils_backend_setup.config -> string


### PR DESCRIPTION
## Summary

Closes the inferred-dump header cleanup series.

The lib/coord/ tree had 6 .mli files still carrying the
auto-generated `(** X inferred mli **)` header. Each is replaced
with a 1-2 line docstring describing the module's role:

| file | docstring |
|---|---|
| `coord_bootstrap.mli` | room state initialization |
| `coord_backlog.mli` | tasks/backlog.json read/write |
| `coord_status.mli` | masc_status human-readable snapshot |
| `coord_hooks.mli` | atomic-ref hook registry filled at boot |
| `coord_identity.mli` | session_id / hostname / tty / agent name |
| `coord_broadcast.mli` | room-wide message + activity event emit |

After this PR: `rg "inferred mli" lib/` returns **zero matches**.

## Series timeline

This sweep closes the inferred-dump cleanup chain:
- #11286 keeper_schema (50→6 lines + persona contract mli)
- #11290 coord_agent (24 lines removed)
- #11296 sidecar (6 helpers + round-trip pair)
- #11303 dashboard_keeper_api (-11 net lines)
- #11309 coord_portal (portal_status)
- #11321 coord 4-file sweep (variant alias normalization)
- **#this** — final 6-file header sweep

## Surgical

- All .ml files unchanged.
- Only header lines + adjacent whitespace touched.
- masc_mcp.opam version bump (0.18.7→0.18.8) is dune-generated
  from `dune-project (version 0.18.8)` already on main; not part
  of this PR's intent.

## Test plan

- [x] dune build ✓
- [x] `rg "inferred mli" lib/` returns 0 results
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)