### PR TITLE
fix(security): redact absolute paths in keeper_alerting_path errors (Cycle 6 / Tier A3)

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -127,10 +127,15 @@ let maybe_resolve_missing_relative_read_path ~(roots : string list) ~(raw_path :
        | [] -> Ok None
        | [match_path] -> Ok (Some match_path)
        | many ->
+           (* Tier A3 / Cycle 6: do not echo the resolved match paths
+              into the error string — that leaks the host filesystem
+              layout to the caller (LLM) and dashboards. The match
+              count alone is enough for the caller to course-correct. *)
            Error
              (Printf.sprintf
-                "ambiguous_relative_read_path: %s (matches: [%s])"
-                raw_path (String.concat ", " many)))
+                "ambiguous_relative_read_path: %s (%d candidate matches; \
+                 disambiguate the relative segment)"
+                raw_path (List.length many)))
 
 let allows_missing_leaf_read ~(raw : string) ~(candidate : string) : bool =
   let parts = split_relative_components raw in
@@ -157,10 +162,15 @@ let absolute_allowed_paths_result ~(config : Coord.config)
     ~(allowed_paths : string list) : (string list, string) result =
   let normalized = absolute_allowed_paths ~config ~allowed_paths in
   if allowed_paths <> [] && normalized = [] then
+    (* Tier A3 / Cycle 6: redact the raw [allowed_paths] list — those
+       strings frequently include host-absolute prefixes that should
+       not flow back to the LLM caller. The count is enough for the
+       caller to know "you provided N entries, none were valid". *)
     Error
       (Printf.sprintf
-         "allowed_paths_normalized_empty: [%s]"
-         (String.concat ", " allowed_paths))
+         "allowed_paths_normalized_empty: %d entries provided, none \
+          resolved to a valid path"
+         (List.length allowed_paths))
   else
     Ok normalized
 
@@ -233,9 +243,13 @@ let resolve_keeper_target_path ~(config : Coord.config)
       || starts_with ~prefix:(root_norm ^ "/") target_norm
     in
     if not within_root then
+      (* Tier A3 / Cycle 6: do not echo the resolved [target_norm] or
+         [root_norm] absolute paths — both reveal the host sandbox
+         layout to the caller (LLM). Echo only the caller's [raw]
+         input. The "outside_project_root" label is enough for the
+         caller to course-correct without enumerating the host. *)
       Error
-        (Printf.sprintf "path_outside_project_root: %s (root=%s)"
-           target_norm root_norm)
+        (Printf.sprintf "path_outside_project_root: %s" raw)
     else if allowed_paths = [] then
       Ok candidate
     else
@@ -332,9 +346,13 @@ let resolve_keeper_read_path ~(config : Coord.config)
       || starts_with ~prefix:(root_norm ^ "/") target_norm
     in
     if not within_root then
+      (* Tier A3 / Cycle 6: do not echo the resolved [target_norm] or
+         [root_norm] absolute paths — both reveal the host sandbox
+         layout to the caller (LLM). Echo only the caller's [raw]
+         input. The "outside_project_root" label is enough for the
+         caller to course-correct without enumerating the host. *)
       Error
-        (Printf.sprintf "path_outside_project_root: %s (root=%s)"
-           target_norm root_norm)
+        (Printf.sprintf "path_outside_project_root: %s" raw)
     else
       let allowed_norms =
         if allowed_paths = [] then []
@@ -343,10 +361,12 @@ let resolve_keeper_read_path ~(config : Coord.config)
           |> List.filter_map (normalize_allowed_path_for_check ~root:root_norm)
       in
       if allowed_paths <> [] && allowed_norms = [] then
+        (* Tier A3 / Cycle 6: redact the raw [allowed_paths] list. *)
         Error
           (Printf.sprintf
-             "allowed_paths_normalized_empty: [%s]"
-             (String.concat ", " allowed_paths))
+             "allowed_paths_normalized_empty: %d entries provided, none \
+              resolved to a valid path"
+             (List.length allowed_paths))
       else
       let within_allowed =
         allowed_norms = [] || is_within_allowed_norms ~target_norm allowed_norms


### PR DESCRIPTION
## Summary

Cycle 6 / Tier A3 of the Kimi keeper FSM review plan: redact host-absolute paths and raw allow-list strings from `keeper_alerting_path.ml` error formatters. The same error labels are preserved so the LLM caller can still course-correct, but the absolute-path leaks that used to enumerate the sandbox layout to anyone reading the error are gone.

## Why

Plan §3 Tier A3 ("Path leak 제거") and the security-audit report flag this module as the dominant info-leak surface in the keeper boundary: every rejected path reflected back not just the user's input but also the resolved absolute path and the raw allow-list. That gives a curious caller (or an attacker steering the LLM) a high-fidelity map of the host filesystem and sandbox boundary — exactly what a sandboxed agent should not need to communicate.

## What changed

`lib/keeper/keeper_alerting_path.ml` — three formatters edited. Same labels, redacted bodies.

| Site | Before | After |
|------|--------|-------|
| `ambiguous_relative_read_path` (line 132) | `... (matches: [<every match path>])` | `... (N candidate matches; disambiguate the relative segment)` |
| `allowed_paths_normalized_empty` (lines 161 & 358) | `... [<every raw allowed path>]` | `... N entries provided, none resolved to a valid path` |
| `path_outside_project_root` (lines 247 & 346) | `... %s (root=%s)` echoing `target_norm` and `root_norm` | `... %s` echoing only the caller's `raw` input |

Untouched (not leaks):
- `format_path_rejection` and `path_outside_sandbox` already echo only the caller-supplied `raw`.
- `is_within_allowed_norms` and friends do not produce error strings.

## What is NOT in this PR (follow-up)

| Follow-up | Why now |
|-----------|---------|
| Unit test asserting no `/Users/`, `/home/`, `/tmp/` prefixes survive in any error path | Requires constructing a `Coord.config` fixture; heavier than this Cycle 6 budget. The redactions are small and inspectable in the diff. |
| Sweep of adjacent modules (`keeper_exec_shell`, `keeper_sandbox*`, `keeper_alerting`) that may format paths into errors | Independent surface; separate PR per file keeps the review unit small. |
| Replace user-supplied `raw` with hash + basename when even the raw input could leak (e.g. an attacker probing the existence of a file) | Stricter redaction; needs a UX trade-off discussion. The current change handles the *unsupplied-by-caller* leaks; user-supplied paths are echoed back as a hint. |

## Test plan

- [x] `dune build --root <worktree> @lib/check` passes.
- [ ] No new unit test added (see follow-up table above).
- [x] Manual diff inspection: every removed substitution previously emitted either an absolute path string (`target_norm`, `root_norm`) or the raw allow-list values; replacements emit only counts plus the caller's own input.

## Spec link

Plan §3 Tier A3 — Path leak 제거.
Plan §11.3 ROI ★★★ (security + ops hygiene; small surface).

## Cycle 6 task A note

Sibling task A — rebase of PR #11391 (Cycle 4 AuthIdentityFSM.tla) onto current `origin/main` to clear the Meta Guards stale-base FAILURE — is also done in this cycle (force-pushed to `feat/auth-identity-fsm-spec`). That PR's CI should re-run automatically.

Sibling Cycle PRs in this plan:
- #11360 (Cycle 1a outcome_kind tri-state)
- #11377 (Cycle 2 ppx_tla bootstrap)
- #11384 (Cycle 3 ppx_tla extensions + keeper_turn_fsm parity)
- #11391 (Cycle 4 AuthIdentityFSM.tla — rebased)
- #11398 (Cycle 5 receipt append → Result.Error)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
