### PR TITLE
docs(observability): add Keeper_turn_fsm sub-axis to KTC drift audit (Step 4r)

### DIFF
--- a/docs/observability/fsm-spec-code-drift.md
+++ b/docs/observability/fsm-spec-code-drift.md
@@ -39,6 +39,8 @@ Neutral diff between TLA+ specs, OCaml types, and the composite observer project
 
 **Note**: `KeeperCompactionLifecycle.tla:30` declares `TurnPhaseSet` without `"finalizing"` (4 states), using the cascade spec's 5-state set via `EXTENDS`. Confirmed consistent at model-check time; the spec simply doesn't need `finalizing` for compaction reasoning.
 
+**Sub-axis (Step 4, 2026-04-28)**: `Keeper_turn_fsm.turn_state` (`lib/keeper/keeper_turn_fsm.mli`) introduces a 10-state typed ADT *inside* a single KTC turn — `Idle / Phase_gating / Cascade_routing / Awaiting_provider / Streaming / Awaiting_tool_result / Completing / Done / Failed of failure_reason / Cancelled of cancel_reason`. This is a finer-grained projection than the 5-state KTC vocabulary above; the two coexist (KTC tracks the registry-visible turn cycle, `turn_state` tracks the in-process FSM emit chain). The ADT pairs with `specs/keeper-turn-fsm/KeeperTurnFSM.tla` at the abstraction level the TLA+ spec uses (`{"failed", "cancelled"}` collapsed; reasons abstracted), so spec-code drift on the ADT side stays bounded to the reason variants and is checked by the `test_keeper_turn_fsm_emit` sentinel. Operator counter / dashboard / alerts use the `turn_state` labels, not the KTC ones — see `docs/observability/keeper-turn-fsm-metrics.md`.
+
 ---
 
 ### KDP — Keeper Decision Pipeline


### PR DESCRIPTION
## Summary

Adds a one-paragraph sub-axis note to \`docs/observability/fsm-spec-code-drift.md\`'s KTC section so a future drift auditor finds the typed \`Keeper_turn_fsm.turn_state\` ADT (Step 4) inside the existing 5-state KTC catalog. /loop iteration 17. Closes the doc cross-reference loop.

## Why

The drift audit catalogues KTC at the registry-visible 5-state vocabulary (\`idle / prompting / executing / compacting / finalizing\`). Step 4 introduced a 10-state typed ADT *inside* a single KTC turn (Phase_gating / Cascade_routing / Awaiting_provider / Streaming / Awaiting_tool_result / Completing / Done / Failed of failure_reason / Cancelled of cancel_reason).

The two coexist:
- **KTC** = registry-visible turn cycle (composite observer, dashboards, original audit)
- **turn_state** = in-process FSM emit chain (Step 4 Prometheus counter + masc-trace + alerts)

No drift to fix — the sub-axis is *additional* surface, not a contradiction. \`test_keeper_turn_fsm_emit\` sentinel keeps the ADT label set aligned with runtime emit sites.

## Companion files

- \`specs/keeper-turn-fsm/KeeperTurnFSM.tla\` (#11190)
- \`lib/keeper/keeper_turn_fsm.mli\` (#11184 + #11340)
- \`docs/observability/keeper-turn-fsm-metrics.md\` (#11376)
- \`docs/keeper-turn-lifecycle.md\` (#11260, #11354)

## Test plan

- [x] No code changes
- [ ] CI lint + meta-guards green
- [ ] Markdown render visual check

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4r.

🤖 Generated with [Claude Code](https://claude.com/claude-code)