### PR TITLE
docs(monitoring): add infrastructure/monitoring/README catalog (Step 4s)

### DIFF
--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -1,0 +1,54 @@
+# Monitoring artefacts
+
+Prometheus / Grafana files that live alongside the masc-mcp source so deployments can apply them without a separate ops repo.
+
+## Catalogue
+
+| File | Domain | Kind | Companion doc |
+|------|--------|------|---------------|
+| `cascade-alerts.yml` | cascade | alerts | `docs/observability/cascade-metrics.md` |
+| `cascade-slo.yml` | cascade | recording rules + SLO alerts | `docs/observability/cascade-metrics.md` |
+| `grafana-cascade-dashboard.json` | cascade | Grafana dashboard | `docs/observability/cascade-metrics.md` |
+| `grafana-keeper-turn-fsm-dashboard.json` | keeper turn FSM | Grafana dashboard | `docs/observability/keeper-turn-fsm-metrics.md` |
+| `keeper-turn-fsm-alerts.yml` | keeper turn FSM | alerts | `docs/observability/keeper-turn-fsm-metrics.md` |
+| `keeper-turn-fsm-slo.yml` | keeper turn FSM | recording rules | `docs/observability/keeper-turn-fsm-metrics.md` |
+
+## Domains
+
+The two domains are **deliberately separate**.
+
+### Cascade
+
+Tracks cascade-routing decisions inside `Oas_worker_named.cycle_loop`. Counters: `masc_cascade_strategy_decisions_total{cascade,strategy,kind}`, `masc_cascade_capacity_events_total{kind,key_type}`. State vocabulary: `ordered / filtered_empty / exhausted` (TLA+ `KeeperCascadeLifecycle`).
+
+### Keeper turn FSM
+
+Tracks the typed turn-state ADT inside `run_keeper_cycle`. Counter: `masc_keeper_turn_fsm_transitions_total{from,to,keeper}`. State vocabulary: 10 typed states with `failure_reason` / `cancel_reason` carriers (TLA+ `KeeperTurnFSM`).
+
+The two domains overlap *only* at `cascade_routing` — when the keeper FSM enters cascade routing, the cascade subsystem takes over until a provider is selected (or exhausted). Both surfaces emit independently; an operator chasing a turn that died at cascade exhaustion sees:
+
+- `masc_keeper_turn_fsm_transitions_total{to="failed:cascade_unavailable",keeper=...}` — keeper view
+- `masc_cascade_strategy_decisions_total{kind="exhausted",cascade=...}` — cascade view
+
+Both should fire for the same turn; if only one fires the runtime path skipped a layer.
+
+## Apply
+
+Prometheus picks up the alert / recording files via the standard rule_files glob; Grafana imports the JSON via File → Import. There's no apply script — deployments use whatever IaC they already run for the cascade rules.
+
+## Companion code references
+
+- `lib/prometheus.{ml,mli}` — counter + label declarations
+- `lib/keeper/keeper_turn_fsm.{ml,mli}` — typed FSM ADT
+- `lib/cascade/cascade_strategy_trace.ml` — cascade decision events
+- `bin/masc_trace.ml` — per-turn timeline CLI (reads receipts + system_log + tool_calls)
+
+## Adding a new artefact
+
+1. Pick a domain (cascade / keeper-turn-fsm / new-domain). Don't mix domains in one file — each file maps to one companion doc.
+2. Match the filename pattern: `<domain>-<kind>.{yml,json}`.
+3. Update the catalogue table above.
+4. Add a `## Counter` or `## Recording rule` section to the companion doc in `docs/observability/`.
+5. If a new domain is being introduced, add a `### <Domain>` subsection to the **Domains** section above.
+
+The catalogue + companion doc pairing is what keeps spec-code-drift audits tractable; see `docs/observability/fsm-spec-code-drift.md`.


### PR DESCRIPTION
## Summary

Adds \`infrastructure/monitoring/README.md\` that lists every yaml/json artefact in the dir, maps each to its companion operator doc, and explains the two coexisting domains (cascade vs keeper turn FSM). /loop iteration 18.

## Why

The dir grew from 3 files (cascade-only) to 6 files (cascade + keeper turn FSM) over the Step 4 sprint. A new operator landing here can't tell which file pairs with which \`docs/observability/*.md\` without grepping. This README makes the pairing explicit.

## Sections

- **Catalogue table** — file → domain → kind → companion doc (6 rows)
- **Domains** — cascade vs keeper turn FSM, with the one explicit overlap point (\`cascade_routing\`). Documents the dual-emit invariant — a cascade-exhausted turn should fire *both* surface counters.
- **Apply** — short note that IaC already handles this.
- **Companion code references** — links to the OCaml that emits the metrics.
- **Adding a new artefact** — 5-step convention so the catalogue stays current.

## Test plan

- [x] No code changes
- [ ] CI lint + meta-guards green
- [ ] Markdown render visual check

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4s. Closes the discoverability loop in the monitoring directory itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)