### PR TITLE
test(keeper): wiring-site count sentinel for Keeper_turn_fsm.emit_transition (Step 4t)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -207,7 +207,8 @@
         test_actionable_path_action
         test_stale_kill_class
         test_provider_capability_matrix
-        test_keeper_synthetic_marker)
+        test_keeper_synthetic_marker
+        test_keeper_turn_fsm_wired_sites)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -385,6 +386,7 @@
           test_stale_kill_class
           test_provider_capability_matrix
           test_keeper_synthetic_marker
+          test_keeper_turn_fsm_wired_sites
           )
  (libraries masc_test_deps))
 

--- a/test/test_keeper_turn_fsm_wired_sites.ml
+++ b/test/test_keeper_turn_fsm_wired_sites.ml
@@ -1,0 +1,109 @@
+(** test_keeper_turn_fsm_wired_sites — Step 4 wiring sentinel.
+
+    [test_keeper_turn_fsm_emit] pins the [Keeper_turn_fsm.emit_transition]
+    *type surface*: a future signature drift fails compile.
+
+    But a future PR could *delete* one of the 11 wired
+    [emit_transition] call sites in [keeper_unified_turn.ml]
+    without breaking the build -- the build doesn't care if a
+    function is called.  Result: the fleet observability stack
+    silently regresses (Prometheus counter loses a series, the
+    Grafana dashboard's panel goes flat, [bin/masc-trace]
+    timeline jumps over a state).
+
+    This sentinel reads [lib/keeper/keeper_unified_turn.ml]
+    and asserts that the [Keeper_turn_fsm.emit_transition] call
+    count meets the documented floor.  A delete fails this
+    test with a clear message; an add (more emits) is a no-op
+    on this test (the floor is a >=, not an =).
+
+    Cross-reference: [docs/observability/keeper-turn-fsm-metrics.md]
+    "Wiring sites" table lists every emit call with its PR. *)
+
+open Masc_mcp
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let n = in_channel_length ic in
+      let buf = Bytes.create n in
+      really_input ic buf 0 n;
+      Bytes.unsafe_to_string buf)
+
+let rec find_repo_root dir =
+  if Sys.file_exists (Filename.concat dir "dune-project") then Some dir
+  else
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None else find_repo_root parent
+
+let locate_keeper_unified_turn () =
+  match find_repo_root (Sys.getcwd ()) with
+  | Some root ->
+      Filename.concat root "lib/keeper/keeper_unified_turn.ml"
+  | None ->
+      Alcotest.fail "could not locate dune-project ancestor of cwd"
+
+(** Naive non-overlapping substring counter. *)
+let count_substring haystack needle =
+  let lens = String.length haystack in
+  let lensub = String.length needle in
+  if lensub = 0 || lensub > lens then 0
+  else
+    let rec loop i acc =
+      if i > lens - lensub then acc
+      else if String.sub haystack i lensub = needle then
+        loop (i + lensub) (acc + 1)
+      else loop (i + 1) acc
+    in
+    loop 0 0
+
+(** Documented floor: 11 wired sites in [keeper_unified_turn.ml]
+    after Steps 4b/4c/4d/4g/4i/4j.  Composition:
+
+    | Step | site                                                  | count |
+    |------|-------------------------------------------------------|-------|
+    | 4c   | run_keeper_cycle entry [Idle -> Phase_gating]         | 1     |
+    | 4b   | phase-gate skip [Phase_gating -> Cancelled]           | 1     |
+    | 4g   | phase pass [Phase_gating -> Cascade_routing]          | 1     |
+    | 4b   | ollama saturated skip                                 | 1     |
+    | 4b   | cascade build error                                   | 1     |
+    | 4g   | livelock Started [Cascade_routing -> Awaiting_provider] | 1   |
+    | 4b   | livelock Blocked                                      | 1     |
+    | 4i   | run_turn pre-call [Awaiting_provider -> Streaming]    | 1     |
+    | 4j   | retry_loop exhaustion [Streaming -> Failed]           | 1     |
+    | 4d   | stop_reason [Streaming -> Completing]                 | 1     |
+    | 4c   | success exit [Completing -> Done]                     | 1     |
+    *)
+let documented_floor = 11
+
+let test_emit_call_count_floor () =
+  let path = locate_keeper_unified_turn () in
+  let body = read_file path in
+  let n = count_substring body "Keeper_turn_fsm.emit_transition" in
+  if n < documented_floor then
+    Alcotest.failf
+      "Keeper_turn_fsm.emit_transition call count regressed: \
+       found=%d, floor=%d.  See docs/observability/\
+       keeper-turn-fsm-metrics.md \"Wiring sites\" table for \
+       the documented sites.  If a deletion is intentional, \
+       update [documented_floor] in this test and the table \
+       in the doc together."
+      n documented_floor;
+  Alcotest.(check bool)
+    (Printf.sprintf
+       "Keeper_turn_fsm.emit_transition call count >= %d (found %d)"
+       documented_floor n)
+    true (n >= documented_floor)
+
+let () =
+  Alcotest.run "keeper_turn_fsm_wired_sites"
+    [
+      ( "wiring",
+        [
+          Alcotest.test_case
+            "emit_transition call count meets documented floor"
+            `Quick test_emit_call_count_floor;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Adds \`test_keeper_turn_fsm_wired_sites\` — fails the build when the \`Keeper_turn_fsm.emit_transition\` call count in \`keeper_unified_turn.ml\` drops below 11 (Step 4 documented floor). /loop iteration 19.

## What this catches that \`test_keeper_turn_fsm_emit\` does not

\`test_keeper_turn_fsm_emit\` pins the function's **type surface** — signature drift fails compile.

A future PR could *delete* a wired call site without breaking the build (build doesn't care if a function is called). Result: silent observability regression — Prometheus loses a series, Grafana panel goes flat, \`bin/masc-trace\` jumps over a state.

This sentinel fills the gap. Greps the file, asserts \`count >= 11\`. An *add* is a no-op; only a *delete* fails.

## Floor table (11 sites)

| Step | site | count |
|------|------|-------|
| 4c | run_keeper_cycle entry \`Idle → Phase_gating\` | 1 |
| 4b | phase-gate skip | 1 |
| 4g | phase pass \`Phase_gating → Cascade_routing\` | 1 |
| 4b | ollama saturated skip | 1 |
| 4b | cascade build error | 1 |
| 4g | livelock Started → \`Awaiting_provider\` | 1 |
| 4b | livelock Blocked | 1 |
| 4i | run_turn pre-call \`Awaiting_provider → Streaming\` | 1 |
| 4j | retry_loop exhaustion \`Streaming → Failed\` | 1 |
| 4d | stop_reason \`Streaming → Completing\` | 1 |
| 4c | success exit \`Completing → Done\` | 1 |

Cross-reference: \`docs/observability/keeper-turn-fsm-metrics.md\` "Wiring sites" table lists the same 11 with PR refs.

## Failure message

```
Keeper_turn_fsm.emit_transition call count regressed:
found=N, floor=11.  See docs/observability/keeper-turn-fsm-metrics.md
"Wiring sites" table for the documented sites.  If a deletion is
intentional, update [documented_floor] in this test and the table
in the doc together.
```

## Test plan

- [x] \`dune build\` green
- [x] \`test_keeper_turn_fsm_wired_sites\` 1/1 OK (count = 11 ≥ floor 11)
- [ ] CI lint + meta-guards green
- [ ] Mutation check (manual): delete one call, confirm test fails

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4t. Closes the regression loop on Step 4 caller adoption: type surface + wiring count + alerting all guard against silent regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)