### PR TITLE
refactor(memory): add memory_jsonl.mli (selective expose make_backend)

### DIFF
--- a/lib/memory/memory_jsonl.mli
+++ b/lib/memory/memory_jsonl.mli
@@ -1,0 +1,22 @@
+(** Memory_jsonl — Session-based JSONL backend for OAS Memory.long_term_backend.
+
+    Each session gets its own .jsonl file under
+    [<base_dir>/memory/<agent_name>/<session_id>.jsonl]. Lines are
+    append-only; the latest entry per key wins on read. Tombstones
+    (value=null) mark removals. *)
+
+val make_backend :
+  base_dir:string ->
+  agent_name:string ->
+  session_id:string ->
+  Oas.Memory.long_term_backend
+(** [make_backend ~base_dir ~agent_name ~session_id] builds a
+    {!Oas.Memory.long_term_backend} that persists/retrieves/removes/queries
+    against the per-session JSONL file. Persist and remove append; retrieve
+    and query fold the file with last-write-wins semantics. Errors from the
+    underlying I/O are logged and surfaced through the backend's [Result]
+    return types ([persist]/[remove]/[batch_persist]) or as empty
+    [retrieve]/[query] results.
+
+    Files exceeding 50 MB log a warning but are still read. Individual
+    values exceeding 1 MB are truncated and re-wrapped as JSON strings. *)


### PR DESCRIPTION
## Summary
- Add selective `.mli` for `lib/memory/memory_jsonl.ml`
- Expose only the public entry point `make_backend`
- Keep helpers (`encode_line`/`parse_line`/`read_lines`/`session_path`/`ensure_dir`/`now`) private

## Context
- Single external caller: `lib/memory_oas_bridge.ml:251` uses `Memory_jsonl.make_backend ~base_dir ~agent_name ~session_id`
- 219-line module with one public API → fits "selective expose" per `feedback_mli_exposure_strategy_by_module_size`
- Reduces `lib_other_mli_missing` once #11404 baseline lands (this PR is based on pre-#11404 main; rebase will pick up the metric automatically)

## Test plan
- Defer to CI build (sibling dune sessions occupy local cache; per `feedback_dune_shared_build_cross_session_corruption` low-risk facade-style .mli verifies via CI)
- `.mli` only exposes existing public function with the actual `Oas.Memory.long_term_backend` return type — no behavioral change