### PR TITLE
refactor(types): add types.mli (facade re-export)

### DIFF
--- a/lib/types/types.mli
+++ b/lib/types/types.mli
@@ -1,0 +1,15 @@
+(** MASC MCP Types — domain model facade.
+
+    Re-exports the public surface of {!Ids}, {!Types_core}, and
+    {!Types_auth} so callers can import a single namespace. The
+    interface is computed via [include module type of …] so it
+    auto-tracks the underlying modules without manual maintenance.
+
+    Underlying modules currently have no [.mli] of their own; the
+    inferred surface is what propagates here. When narrower [.mli]
+    files land for those modules, this facade automatically picks up
+    the tightened contract. *)
+
+include module type of Ids
+include module type of Types_core
+include module type of Types_auth


### PR DESCRIPTION
## Summary
- Add `.mli` for the 4-line `lib/types/types.ml` facade
- Mirror the [include module type of …] chain so the surface auto-tracks `Ids`, `Types_core`, and `Types_auth` without manual maintenance

## Context
- 428 caller files reach domain types through `Types.<symbol>`
- The underlying modules have no [.mli] yet; this facade still benefits from an interface declaration because future narrowing of `Ids`/`Types_core`/`Types_auth` propagates automatically

## Test plan
- Defer to CI build (sibling dune sessions occupy local cache; pure interface-only change with no behavior delta)