### PR TITLE
refactor(types): add severity.mli (exhaustive expose)

### DIFF
--- a/lib/types/severity.mli
+++ b/lib/types/severity.mli
@@ -1,0 +1,36 @@
+(** Severity — canonical severity levels shared across MASC modules.
+
+    Domain-specific severity types ([Response.severity],
+    [Failure_envelope.severity], [Dashboard_attention.severity])
+    remain for backwards compatibility; each provides a
+    [to_severity] coercion for cross-module communication.
+
+    @since SSOT audit 2026-04-09, closes #5989 *)
+
+type t =
+  | Debug
+  | Info
+  | Warning
+  | Error
+  | Critical
+[@@deriving show, eq, yojson]
+
+val to_string : t -> string
+(** Lowercase canonical name ([{Debug → "debug"}], …). *)
+
+val of_string : string -> (t, string) result
+(** Parse a severity name. Aliases recognized:
+    [\"warn\" → Warning], [\"bad\" → Error], [\"fatal\" → Critical].
+    Returns [Error msg] for unknown inputs. *)
+
+val of_string_default : default:t -> string -> t
+(** Like {!of_string} but yields [default] on parse failure. *)
+
+val to_int : t -> int
+(** Numeric ordering [{Debug = 0 .. Critical = 4}]; higher is more severe. *)
+
+val compare : t -> t -> int
+(** Total order on severity, by {!to_int}. *)
+
+val at_least : threshold:t -> t -> bool
+(** [at_least ~threshold s] is [s >= threshold] under {!compare}. *)


### PR DESCRIPTION
## Summary
- Add exhaustive `.mli` for `lib/types/severity.ml` (47 lines)
- Expose 5-variant type `t`, the 3 derivers (`show`/`eq`/`yojson`), and the 6 behavior helpers

## Context
- Canonical severity SSOT used by 6 caller files (`lib/response/`, `lib/dashboard/`, etc.) for cross-module coercion
- Behavior boundary (string conversion, ordering, threshold predicate) — NOT a type-SSOT anti-target

## Test plan
- Defer to CI build (sibling dune sessions occupy local cache; interface-only change with no behavior delta)