### PR TITLE
feat(cascade): surface load failure in normalize_priority_tiers (Phase 2c)

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -1187,6 +1187,19 @@ let model_ids_of_specs (specs : string list) : string list =
   |> List.sort_uniq String.compare
 
 let normalize_priority_tiers ~config_path ~name raw_tiers =
+  (* Phase 2c: probe load_json before delegating so that an unreadable
+     cascade.toml/json surfaces as a load-failure error instead of the
+     generic "no configured models" message — the latter mis-leads
+     operators into thinking the profile is empty when the file is
+     actually broken.  Mirrors the probe pattern in
+     resolve_model_strings_traced_with / _with_trace (PR #11361). *)
+  match Cascade_config_loader.load_json config_path with
+  | Error msg ->
+      Error
+        (Printf.sprintf
+           "priority_tier validation skipped: cascade config load failed: %s"
+           msg)
+  | Ok _ ->
   let configured_model_ids =
     Cascade_config_loader.load_profile_weighted ~config_path ~name
     |> List.map (fun (entry : Cascade_config_loader.weighted_entry) -> entry.model)

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -403,6 +403,31 @@ unknown_field_for_load_failed_test = "x"
          Hardcoded_defaults instead of Load_failed (PR #11361)"
   | _ -> fail "expected Load_failed source variant"
 
+(* Phase 2c regression: when cascade.json fails to load,
+   normalize_priority_tiers must surface the underlying load failure
+   instead of returning the misleading "no configured models"
+   message.  Without this, an operator sees an empty-profile error
+   while the real problem is an unreadable config file. *)
+let test_priority_tiers_load_failure_message () =
+  with_temp_dir "cascade-priority-tiers-load-failed" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  let json_path = Filename.concat config_dir "cascade.json" in
+  write_file json_path "{ malformed";
+  with_config_dir config_dir @@ fun () ->
+  match
+    Masc_mcp.Cascade_config.normalize_priority_tiers
+      ~config_path:json_path
+      ~name:"any_profile"
+      [ [ "ollama:any-model" ] ]
+  with
+  | Ok _ -> fail "expected Error, got Ok"
+  | Error msg ->
+      check bool
+        "Error message must mention the load failure, not the generic \
+         'no configured models' fallback (PR Phase 2c)" true
+        (contains_substring msg "cascade config load failed")
+
 let test_weight_zero_is_accepted () =
   (* #10571: weight=0 = "configured but disabled" (cascade dispatcher
      skips). #10097 introduced this idiom for codex_cli; pre-fix the
@@ -483,6 +508,9 @@ let () =
             `Quick test_load_failed_source_on_malformed_json;
           test_case "Load_failed source on unknown toml field"
             `Quick test_load_failed_source_on_unknown_toml_field;
+          test_case
+            "normalize_priority_tiers surfaces load failure (Phase 2c)"
+            `Quick test_priority_tiers_load_failure_message;
         ] );
       ( "runtime",
         [


### PR DESCRIPTION
## Goal

Third (and final) caller in the cascade silent-fallback family. PR #11328 (Phase 1), PR #11361 (Phase 2a+2b) covered the dashboard read path and the two `resolve_model_strings_*` producers.  This PR closes the last surfaced caller: `normalize_priority_tiers`.

## 변경

`lib/cascade/cascade_config.ml:1189` — probe `Cascade_config_loader.load_json` before delegating to `load_profile_weighted`.  On Error, return a specific `\"priority_tier validation skipped: cascade config load failed: <msg>\"` instead of the generic `\"priority_tier has no configured models to validate against\"` — operator now sees the real cause.

`test/test_cascade_toml_materialization.ml` — regression test under `validation` suite asserts the new message shape.

## 검증

- HEAD: `3549d11675` (origin/main, PR #11361 already merged)
- `dune build` (full): ✅ EXIT=0
- `dune test test_cascade_toml_materialization.ml validation #13`: ✅ OK
- 회귀 risk: **0** (Error path 변경만, 성공 path 보존, additive Error message)

## Family complete

| PR | Caller | Phase |
|----|--------|-------|
| #11328 | dashboard read path (raw_config_json) | 1 |
| #11361 | resolve_model_strings_traced_with + _with_trace | 2a + 2b |
| this | normalize_priority_tiers | 2c |

`load_profile_weighted` 시그니처 자체 변경(Result)은 6 caller sweep 필요 + 회귀 위험 큼 — 그 대신 모든 caller가 자기 path에서 load_json probe를 하는 패턴으로 일관성 확보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)