### PR TITLE
refactor(types): add ids.mli (mirror inline sigs, hide dead helpers)

### DIFF
--- a/lib/types/ids.mli
+++ b/lib/types/ids.mli
@@ -1,0 +1,94 @@
+(** MASC MCP Types — newtype IDs that prevent accidental string mixups.
+
+    Each module wraps [string] in an abstract type so the type system
+    rejects passing an [Agent_id.t] where a [Task_id.t] is expected
+    (and vice versa). All modules expose [of_string]/[to_string] and
+    [Yojson] round-trips so JSON boundaries can lift/lower without
+    leaking the underlying representation. *)
+
+(** Agent identifier — random UUIDv4. *)
+module Agent_id : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : unit -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end
+
+(** Task identifier — timestamp-prefixed sequence. *)
+module Task_id : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : unit -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end
+
+(** Conversation thread identifier — timestamp-prefixed sequence. *)
+module Thread_id : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : unit -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end
+
+(** Turn identifier — individual turn within a thread. *)
+module Turn_id : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : thread_id:string -> seq:int -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end
+
+(** Keeper identifier — deterministic UUIDv5 derived from
+    [keeper:<name>:<path>]. Nested {!Keeper_id.Trace_id} and
+    {!Keeper_id.Task_id} modules carry validated string newtypes used
+    on tracing/auth boundaries. *)
+module Keeper_id : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : name:string -> path:string -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+  module Trace_id : sig
+    type t
+    val of_string : string -> (t, string) result
+    val to_string : t -> string
+    val equal : t -> t -> bool
+  end
+  module Task_id : sig
+    type t
+    val of_string : string -> (t, string) result
+    val to_string : t -> string
+    val equal : t -> t -> bool
+  end
+end
+
+(** Credential identifier — random UUIDv4. *)
+module Credential_id : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : unit -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end


### PR DESCRIPTION
## Summary
- Add `.mli` for `lib/types/ids.ml` (217 lines)
- Mirror the existing inline [`sig ... end`] for each of the 6 newtype modules: `Agent_id`, `Task_id`, `Thread_id`, `Turn_id`, `Keeper_id` (with nested `Trace_id`/`Task_id`), `Credential_id`
- Hide the dead-code toplevel helpers `make_global_id` and `decode_global_id` (rg sweep across `lib/ test/ bin/` returned 0 callers)

## Context
- Each ID module is already sealed by its inline sig in the .ml; the file-level `.mli` adds two things:
  (1) explicit interface visible to readers without scrolling through the implementation, and
  (2) actually narrowing the surface by dropping the unused global-ID helpers — they had been silently public via `Types` facade re-export

## Test plan
- Defer to CI build (sibling dune sessions occupy local cache; interface-only change with no behavior delta)