### PR TITLE
refactor(dashboard): add dashboard_projection_cache.mli (selective expose)

### DIFF
--- a/lib/dashboard/dashboard_projection_cache.mli
+++ b/lib/dashboard/dashboard_projection_cache.mli
@@ -1,0 +1,27 @@
+(** Shared actor-scoped projection caching for dashboard surfaces.
+
+    Execution and mission both derive top-level summaries from the same
+    operator snapshot. This module funnels them through a short-lived
+    actor-scoped cache so warm refresh loops and repeated navigation
+    do not recompute identical reads. *)
+
+val normalize_actor_name : string option -> string
+(** Trim and default a missing/empty actor to ["dashboard"]. *)
+
+val get_or_compute_snapshot_json :
+  config:Coord_utils.config ->
+  actor:string option ->
+  (string -> Yojson.Safe.t) ->
+  Yojson.Safe.t
+(** Cached read with TTL [3.0 s]. The compute callback receives the
+    normalized actor name produced by {!normalize_actor_name}. *)
+
+val invalidate_snapshot_json : config:Coord_utils.config -> unit
+(** Drop every snapshot cache entry for the given config (all actors). *)
+
+val get_or_compute_digest_json :
+  config:Coord_utils.config ->
+  actor:string option ->
+  (string -> Yojson.Safe.t) ->
+  Yojson.Safe.t
+(** Cached read with TTL [5.0 s] for the heavier digest projection. *)


### PR DESCRIPTION
## Summary
- Add selective `.mli` for `lib/dashboard/dashboard_projection_cache.ml` (30 lines)
- Expose 4 actually-used entries: `normalize_actor_name`, `get_or_compute_snapshot_json`, `invalidate_snapshot_json`, `get_or_compute_digest_json`
- Hide internal helpers `cache_partition_segment`, `actor_cache_key` (no external callers — `rg` verified)

## Context
- External callers: `lib/server/server_dashboard_http_keeper_api.ml`, `lib/dashboard/dashboard_execution.ml`, `lib/dashboard/dashboard_mission.ml`, plus `test/test_dashboard_cache.ml`
- TTLs (`3.0 s` snapshot, `5.0 s` digest) documented in the .mli for reader clarity

## Test plan
- Defer to CI build (sibling dune sessions occupy local cache; interface-only change with no behavior delta)