### PR TITLE
feat(masc-trace): show ts on each state in fsm path summary (Step 4v)

### DIFF
--- a/bin/masc_trace.ml
+++ b/bin/masc_trace.ml
@@ -205,17 +205,30 @@ let dump_fsm_transitions ~base_path ~keeper ~turn_id =
       find 0
     in
     if matches <> [] then begin
-      let states =
+      (* Pair each transition's [to_state] with its [ts] field so the
+         summary line carries timestamps the operator can eyeball for
+         per-state duration.  No OCaml-side mutable accumulation: the
+         emit calls are stateless, and any duration derivation is a
+         pure projection of the already-emitted [ts] timeline.  PromQL
+         and this CLI are the right boundary for time-series math. *)
+      let state_with_ts =
         List.filter_map
           (fun json ->
-            string_field json "message"
-            |> Option.value ~default:""
-            |> extract_to_state)
+            let msg =
+              string_field json "message" |> Option.value ~default:""
+            in
+            let ts =
+              string_field json "ts" |> Option.value ~default:"-"
+            in
+            extract_to_state msg
+            |> Option.map (fun s -> (s, ts)))
           matches
       in
-      if states <> [] then
+      if state_with_ts <> [] then
+        let render (state, ts) = Printf.sprintf "%s @%s" state ts in
         Printf.printf "=== fsm path === %s -> %s\n" keeper
-          (String.concat " -> " states)
+          (String.concat " -> "
+             (List.map render state_with_ts))
     end
 
 (** Scan [.masc/tool_calls/<YYYY-MM>/<DD>.jsonl] for tool call


### PR DESCRIPTION
## Summary

Operator critique: *"mutable 은 없애야하는거아님?"* — correct. The Phase-8 retrospective listed "per-transition \`duration_ms\`" as needing mutable state in OCaml. **Wrong layer.** The right boundary is:

1. **OCaml emit** — stateless, records \`ts\` only (already wired by Step 0a).
2. **PromQL / \`bin/masc-trace\`** — pure projections of the emitted \`ts\` timeline.

This PR proves half 2: the \`fsm path\` summary now pairs each state with its \`ts\` so an operator can eyeball per-state duration. **OCaml emit side never owns the math.**

## Output

Before:
```
=== fsm path === alice -> phase_gating -> cascade_routing -> done
```

After:
```
=== fsm path === alice -> phase_gating @2026-04-28T15:23:45.123Z -> cascade_routing @2026-04-28T15:23:45.135Z -> done @2026-04-28T15:23:46.421Z
```

ISO timestamps are lexically sortable so the order matches the underlying file order.

## Why no mutable

Three failure modes that disappear when we stay stateless:

1. **Concurrency**: two fibers emitting concurrently on the same keeper race on the cell. Mutex/Atomic adds machinery for a derived value.
2. **Lifecycle**: cell must be reset at every turn entry, with crash-recovery. Adds a code path.
3. **Test surface**: a mutable cell needs runtime fixtures in \`test_keeper_turn_fsm_emit\` and the wiring sentinel both — compile-time invariants don't cover it.

Pure ts-on-emit + boundary-side derivation has none. Each transition is a self-contained event.

## Test plan

- [x] \`dune build bin/masc_trace.exe\` green
- [x] CLI usage line prints
- [ ] CI lint + meta-guards green
- [ ] Post-merge: confirm \`<state> @<ts>\` pairs

## Plan ref

\`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-hashed-pretzel.md\` Phase 7: Step 4v. Correction to the Phase 8 retrospective's wrong-layer framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)