### PR TITLE
chore(dashboard): add Ring helper lint gate (3 patterns, ratchet)

### DIFF
--- a/scripts/dashboard-drift-baseline.json
+++ b/scripts/dashboard-drift-baseline.json
@@ -8,5 +8,8 @@
   "border-zinc": 0,
   "rounded-px-literal": 9,
   "text-9px": 0,
-  "text-px-literal": 6
+  "text-px-literal": 6,
+  "ring-accent-raw": 1,
+  "ring-accent-fg-raw": 1,
+  "ring-accent-soft-raw": 0
 }

--- a/scripts/dashboard-drift-check.sh
+++ b/scripts/dashboard-drift-check.sh
@@ -33,6 +33,9 @@ PATTERNS=(
   "rounded-px-literal|rounded-\\[[0-9]+px\\]|ratchet|Use rounded-{xs,sm,md,lg,xl,card} (tokens.css)"
   "text-9px|text-\\[9px\\]|zero|Use text-3xs (10px) or text-2xs (11px)"
   "text-px-literal|text-\\[[0-9]+px\\]|ratchet|Use text-{4xs,3xs,2xs,xs,sm,base,md,lg} (tokens.css)"
+  "ring-accent-raw|focus-visible:ring-\\[var\\(--accent-[0-9]+\\)\\]|ratchet|Use ringFocusClasses tone (accent-medium=45, accent-subtle=30) from common/ring.ts"
+  "ring-accent-fg-raw|focus-visible:ring-\\[var\\(--color-accent-fg\\)\\]|ratchet|Use ringFocusClasses({tone: 'accent-fg'}) from common/ring.ts"
+  "ring-accent-soft-raw|focus-visible:ring-accent/40|ratchet|Use ringFocusClasses({tone: 'accent-soft'}) from common/ring.ts"
 )
 
 count_pattern() {


### PR DESCRIPTION
## Summary
audit-bucket-cascade-pattern의 마지막 단계: sweep 완료 후 raw \`focus-visible:ring\` 토큰을 lint gate로 차단하여 회귀 방지.

## 추가된 patterns (모두 ratchet)
| Pattern | Detect | Locked | Bucket C 잔재 |
|---|---|---|---|
| \`ring-accent-raw\` | \`focus-visible:ring-[var(--accent-N)]\` | 1 | keeper-detail.ts:881 (hex offset) |
| \`ring-accent-fg-raw\` | \`focus-visible:ring-[var(--color-accent-fg)]\` | 1 | fsm-hub-timeline-panels.ts:223 (hybrid focus + ring-inset) |
| \`ring-accent-soft-raw\` | \`focus-visible:ring-accent/40\` | 0 | (cleanup 완료) |

## 구현 노트
PATTERN spec 구분자가 \`|\`이므로 정규식 alternation \`(45|30)\`이 spec 파싱을 깨뜨림. 해결: character class \`[0-9]+\`로 모든 accent-N 토큰 매칭. 부수 효과: 미래 추가 \`accent-N\` raw 토큰도 자동 차단 (강한 lint).

## Verification
- [x] \`bash scripts/dashboard-drift-check.sh\`: gate OK
- [x] baseline counts = actual residue (1/1/0)
- [x] file-disjoint: scripts/dashboard-drift-{check.sh,baseline.json} 만 변경

## 후속
- Bucket C 2 sites RFC: hex offset (keeper-detail) → token 추가, hybrid focus prefix (fsm-hub-timeline-panels) → helper 확장 또는 callsite 정상화
- 기존 ratchet patterns(text-px-literal=6, rounded-px-literal=9)도 sweep 진행 시 자연 감소

🤖 Generated with [Claude Code](https://claude.com/claude-code)