### PR TITLE
fix(doc): align PRODUCT-OPERATING-PLAN version line with ROADMAP (v0.18.8)

### DIFF
--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -9,9 +9,9 @@ code_refs:
 
 # Product Operating Plan
 
-> Current package version: v0.18.7
-> Latest release: v0.18.7 (2026-04-27)
-> Updated: 2026-04-27
+> Current package version: v0.18.8
+> Latest release: v0.18.8 (2026-04-28)
+> Updated: 2026-04-28
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 
 Execution companion for capsule-only coordination hardening:


### PR DESCRIPTION
ROADMAP.md was bumped to v0.18.8 (2026-04-28) but `docs/PRODUCT-OPERATING-PLAN.md` was left at v0.18.7. Meta Guards `doc truth` check fails on every subsequent PR with: `doc truth check failed: ROADMAP current package version (0.18.8) != PRODUCT-OPERATING-PLAN current package version (0.18.7)`. Currently blocking #11401, and triggers on any PR rebased past the ROADMAP bump. Bump the version block (3 lines: Current / Latest / Updated) to match ROADMAP. No semantic content changes.