### PR TITLE
chore(types): expose dashboard_governance_metrics surface

### DIFF
--- a/lib/dashboard/dashboard_governance_metrics.mli
+++ b/lib/dashboard/dashboard_governance_metrics.mli
@@ -1,0 +1,40 @@
+(** Dashboard_governance_metrics — operator-visible aggregates of tool
+    rejections and the live approval queue.
+
+    Two ingestion paths backing the public surface:
+    - In-memory ring of recent tool-skip events fed by
+      {!record_tool_skipped} (called from [Keeper_hooks_oas]).
+    - Live approval queue read of
+      {!Keeper_approval_queue.list_pending_json}.
+
+    The ring buffer, rejection event record, and supporting helpers
+    (snapshot, percentile, JSON projection) are intentionally hidden:
+    callers consume the top-level [governance_tool_events_json] payload
+    and the {!approval_summary} record only. *)
+
+(** Approval queue snapshot computed from the live pending set.
+    [depth] is the count of pending approvals; the percentile fields
+    are [None] only when [depth = 0]. *)
+type approval_summary = {
+  depth : int;
+  p50_wait_sec : float option;
+  p95_wait_sec : float option;
+  oldest_pending_sec : float option;
+}
+
+val record_tool_skipped :
+  keeper_name:string -> tool_name:string -> reason_code:string -> unit
+(** Record a tool-skip event into the bounded ring. Safe to call from
+    cancellable Eio fibers — internal cancellation is re-raised, all
+    other exceptions are swallowed so SSE broadcast can never fail
+    because of metrics bookkeeping. *)
+
+val approval_queue_summary : unit -> approval_summary
+(** Read the current approval queue and produce depth + wait-time
+    percentiles. *)
+
+val governance_tool_events_json :
+  ?now_ts:float -> window_minutes:int -> unit -> Yojson.Safe.t
+(** Top-level HTTP endpoint payload combining tool-rejection counts
+    over the [window_minutes] window with the approval queue summary.
+    [now_ts] is injectable for testing. *)


### PR DESCRIPTION
## Summary

\`lib/dashboard/dashboard_governance_metrics.ml\` (201줄) 에 selective .mli 추가.

| 노출 (3 fn + 1 type) | 숨김 (10+) |
|------|------|
| \`type approval_summary\` (record) | \`type rejection_event\` |
| \`record_tool_skipped\` | \`max_ring_size\`, ring state |
| \`approval_queue_summary\` | \`reset_for_testing\`, \`inject_for_testing\` |
| \`governance_tool_events_json\` | \`snapshot_ring\`, \`tool_rejection_counts\` |
| | \`percentile_sorted\`, \`json_of_float_opt\` |
| | \`tool_rejections_json\`, \`approval_queue_json\` |

## Caller Audit

- \`record_tool_skipped\` → \`keeper_guards.ml\` (1)
- \`approval_queue_summary\`, \`approval_summary.depth\` → \`dashboard_safe_autonomy.ml\` (1)
- \`governance_tool_events_json\` → \`server_dashboard_http.ml\` (1)
- \`open Dashboard_governance_metrics\` consumer 0
- 숨김 대상 외부 caller 0 (test/ 포함 검증)

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (baseline 125 → -1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff