### PR TITLE
chore(types): expose dashboard_operator_judge surface

### DIFF
--- a/lib/dashboard/dashboard_operator_judge.mli
+++ b/lib/dashboard/dashboard_operator_judge.mli
@@ -1,0 +1,45 @@
+(** Dashboard_operator_judge — periodic LLM-driven room judgment loop.
+
+    Runs as an Eio daemon fiber per [base_path]: every
+    [Env_config.Operator.judge_interval_sec], it asks an operator-judge
+    keeper to evaluate room health using freshly built facts, then
+    caches the verdict (and "is the judge online?" status) for HTTP
+    consumption.
+
+    The internal mutable per-base-path state, lock helpers, env-knob
+    accessors, prompt construction, parsing, refresh loop, and backoff
+    accounting are all hidden — the public surface is [start] (daemon
+    spawn) plus [runtime_status] (snapshot read). *)
+
+(** Read-only snapshot of judge runtime state, returned by
+    {!runtime_status} and serialized into operator pending-confirm
+    payloads. All fields are read externally. *)
+type runtime_snapshot = {
+  enabled : bool;
+  judge_online : bool;
+  refreshing : bool;
+  generated_at : string option;
+  expires_at : string option;
+  model_used : string option;
+  keeper_name : string;
+  last_error : string option;
+}
+
+val runtime_status : string -> runtime_snapshot
+(** Snapshot the current judge state for [base_path]. Creates an empty
+    state on first call, so always returns a well-defined record. *)
+
+val start :
+  sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  config:Coord.config ->
+  masc_tools:Types_core.tool_schema list ->
+  dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->
+  build_facts:(unit -> Yojson.Safe.t) ->
+  unit ->
+  unit
+(** Spawn the judge daemon for [config.base_path] iff
+    [Env_config.Operator.judge_enabled] and not already running.
+    Backoff doubles up to 5x and caps at 300s when local cascade slots
+    are saturated. Idempotent: subsequent calls are no-ops. *)


### PR DESCRIPTION
## Summary

\`lib/dashboard/dashboard_operator_judge.ml\` (321줄) 에 strict selective .mli 추가.

| 노출 (2 fn + 1 type) | 숨김 (~20) |
|---|---|
| \`type runtime_snapshot\` (record, 8 fields) | \`type state\` (mutable record, 7 mutable fields) |
| \`runtime_status : string -> runtime_snapshot\` | \`states\` Hashtbl + \`outer_mu\`, \`with_outer_rw\`, \`with_lock\`, \`get_state\` |
| \`start : ~sw ~clock ~net ~config ~masc_tools ~dispatch ~build_facts -> unit -> unit\` | \`keeper_name\`, \`backoff_status\` 상수 |
| | env knob 4종 (\`enabled\`, \`interval_sec\`, \`room_ttl_sec\`, \`session_ttl_sec\`) |
| | \`iso_of_unix\`, \`normalize_text\`, \`parse_string_list\` |
| | \`allowed_action_type\`, \`confirm_required\`, \`build_recommended_action\` |
| | \`prompt_for_facts\`, \`parse_room_judgment\`, \`compute_judgments\` |
| | \`should_backoff\`, \`refresh_once\` |

## Caller Audit

- \`runtime_status\` → \`operator_pending_confirm.ml\` (1, all 8 record fields read)
- \`start\` → \`server_bootstrap_loops.ml\` (1)
- \`open Dashboard_operator_judge\` consumer 0
- 숨김 대상 외부 caller 0

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (baseline 125 → -1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff