### PR TITLE
chore(types): expose briefing_sections surface

### DIFF
--- a/lib/dashboard/briefing_sections.mli
+++ b/lib/dashboard/briefing_sections.mli
@@ -1,0 +1,25 @@
+(** Section builders for mission briefing (communication / alignment /
+    watch).
+
+    The full surface (section labels, signal classifiers, predicate
+    helpers, per-section builders) is internal — only the top-level
+    composer {!build_briefing_sections} is consumed externally by
+    [dashboard_mission_briefing.ml]. *)
+
+val build_briefing_sections :
+  mission_summary_json:Yojson.Safe.t ->
+  sessions:Yojson.Safe.t list ->
+  agents:Yojson.Safe.t list ->
+  recent_messages:Yojson.Safe.t list ->
+  metadata_gaps:Yojson.Safe.t list ->
+  string * Yojson.Safe.t list
+(** Build the three briefing sections (communication, alignment, watch)
+    from operator facts plus the metadata gaps from
+    {!Briefing_gaps.collect_metadata_gaps}.
+
+    Returns [(watch_summary, sections_json)] where [watch_summary] is
+    the Watch section's prose summary (used as the briefing's lead
+    line) and [sections_json] is a list of three annotated section
+    objects with [id / label / status / summary / evidence /
+    signal_class / evidence_quality / provenance / authoritative]
+    fields. *)


### PR DESCRIPTION
## Summary

\`lib/dashboard/briefing_sections.ml\` (243줄) 에 strict selective .mli 추가.

| 노출 (1 fn) | 숨김 (11) |
|---|---|
| \`build_briefing_sections\` (top-level composer) | \`section_id_string\`, \`section_label\` (변환 헬퍼) |
| | \`has_operational_signal\`, \`annotate_section\` (signal classifier) |
| | \`int_field_direct\`, \`sum_int_field\`, \`count_matching_field\` (JSON aggregator) |
| | \`status_is_active_agent\`, \`evidence_add_if\` (predicate) |
| | \`build_communication_section\`, \`build_alignment_section\`, \`build_watch_section\` (per-section) |

## Caller Audit

- \`build_briefing_sections\` → \`dashboard_mission_briefing.ml\` (1)
- \`open Briefing_sections\` consumer 0
- 숨김 11개 외부 caller 0

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (baseline 125 → -1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff