### PR TITLE
feat(keeper): include cascade_name in stale_keeper_broadcast

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -438,13 +438,14 @@ let append (config : Coord.config) (receipt : t) =
    "KSM=Running but no live turn" failure mode where the heartbeat fiber is
    blocked on a long call and would otherwise never produce a receipt. *)
 let emit_stale_keeper_broadcast config
-    ~keeper_name ~agent_name ~trace_id ~generation
+    ~keeper_name ~agent_name ~cascade_name ~trace_id ~generation
     ~stale_seconds ~last_turn_ts =
   let payload =
     `Assoc
       [ "schema", `String "keeper.operator_broadcast_required.v1"
       ; "keeper_name", `String keeper_name
       ; "agent_name", `String agent_name
+      ; "cascade_name", `String cascade_name
       ; "trace_id", `String trace_id
       ; "generation", `Int generation
       ; "disposition", `String "stalled"
@@ -463,8 +464,8 @@ let emit_stale_keeper_broadcast config
       ()
   in
   Log.Keeper.error
-    "%s: stale_keeper_broadcast emitted last_turn=%.0fs ago seq=%d"
-    keeper_name stale_seconds event.seq
+    "%s: stale_keeper_broadcast emitted last_turn=%.0fs ago cascade=%s seq=%d"
+    keeper_name stale_seconds cascade_name event.seq
 
 let latest_json (config : Coord.config) keeper_name =
   let store =

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -108,6 +108,7 @@ val emit_stale_keeper_broadcast :
   Coord.config ->
   keeper_name:string ->
   agent_name:string ->
+  cascade_name:string ->
   trace_id:string ->
   generation:int ->
   stale_seconds:float ->

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -238,8 +238,8 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  ~labels:[ ("keeper", meta.name) ]
                  ();
                Log.Keeper.error
-                 "%s: stale watchdog terminating fiber (%s) [window_count=%d/6h]"
-                 meta.name reason_desc window_count;
+                 "%s: stale watchdog terminating fiber (%s) [cascade=%s window_count=%d/6h]"
+                 meta.name reason_desc meta.cascade_name window_count;
                if window_count >= escalation_threshold then begin
                  Prometheus.inc_counter
                    "masc_keeper_stale_termination_threshold_breached_total"

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -288,6 +288,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                     ctx.config
                     ~keeper_name:meta.name
                     ~agent_name:meta.agent_name
+                    ~cascade_name:meta.cascade_name
                     ~trace_id:
                       (Keeper_id.Trace_id.to_string
                          entry.meta.runtime.trace_id)


### PR DESCRIPTION
## Summary
fleet stall 진단 시 cascade 식별을 인라인으로 노출하기 위해 두 곳에 \`cascade_name\` 추가:

1. **\`emit_stale_keeper_broadcast\`** (\`keeper_execution_receipt.{ml,mli}\`):
   - 시그니처에 \`cascade_name:string\` 추가
   - watchdog payload \`keeper.operator_broadcast_required.v1\`에 \`cascade_name\` 필드
   - ERROR log: \`stale_keeper_broadcast emitted last_turn=315s ago cascade=keeper_unified seq=16278\`
2. **stale watchdog termination log** (\`keeper_stale_watchdog.ml:235\`):
   - ERROR log: \`stale watchdog terminating fiber (idle 311s) [cascade=keeper_unified window_count=1/6h]\`

caller (\`keeper_stale_watchdog.ml:283\`)에서 \`meta.cascade_name\` 전달.

## Why
2026-04-28 시스템 로그에서 fleet batch termination 패턴이 다시 관찰 (00:33:53 4-keeper 묶음 stale). 현재 두 메시지 모두 keeper 이름만 노출:

\`\`\`
nick0cave: stale_keeper_broadcast emitted last_turn=315s ago seq=16278
nick0cave: stale watchdog terminating fiber (idle 311s) [window_count=1/6h]
\`\`\`

cycle 23 finding의 \"cascade rotation chain leakage\" 진단 시 매번 keeper → \`.masc/keepers/<name>.json\` cross-reference로 cascade를 찾아야 합니다. cascade_name을 인라인 노출하면 batch event가 단일 cascade에 집중됐는지(rotation leak 후보)/분산됐는지(provider/auth 광역 장애 후보) 그 자리에서 판단 가능합니다.

### Schema consistency
같은 schema \`keeper.operator_broadcast_required.v1\`을 \`emit_operator_broadcast\` (append path, line 347) 와 \`emit_stale_keeper_broadcast\` (watchdog path, line 408) 두 함수가 emit하는데, append path 만 \`receipt.cascade_name\`을 payload에 포함하고 watchdog path는 누락이었음. 본 PR이 그 격차를 메워 schema v1 onset이 일관됨.

## Test plan
- [ ] CI Build/Lint/Runtest 통과
- [ ] (post-merge) 다음 fleet batch termination 시 cascade_name 인라인 표시 확인

## 미검증 (Best Programmer self-review)
- 로컬 dune build/runtest 미수행: 다른 세션이 \`dune runtest --root .\`로 _build 점유 중이라 cross-session corruption 회피 위해 CI에 위임 (memory pattern: \`feedback_dune_shared_build_cross_session_corruption\`).
- caller 1곳 (\`keeper_stale_watchdog.ml:283\`)만 \`emit_stale_keeper_broadcast\` 호출. \`rg emit_stale_keeper_broadcast lib/ test/\` 결과 2 hits (선언 + caller) 확인.
- \`test/\`에 \`operator_broadcast_required\` schema reader 또는 메시지 텍스트 매치 0건 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)