### PR TITLE
feat(keeper-turn-fsm): pin TLA+ TurnStateSet alignment via tla_state_symbol

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -63,6 +63,33 @@ let turn_state_label = function
   | Cancelled reason ->
       "cancelled:" ^ cancel_reason_label reason
 
+let tla_state_symbol = function
+  | Idle -> "idle"
+  | Phase_gating -> "phase_gating"
+  | Cascade_routing -> "cascade_routing"
+  | Awaiting_provider -> "awaiting_provider"
+  | Streaming -> "streaming"
+  | Awaiting_tool_result -> "awaiting_tool"
+  | Completing -> "completing"
+  | Done -> "done"
+  | Failed _ -> "failed"
+  | Cancelled _ -> "cancelled"
+
+let all_turn_state_symbols =
+  [
+    tla_state_symbol Idle;
+    tla_state_symbol Phase_gating;
+    tla_state_symbol Cascade_routing;
+    tla_state_symbol Awaiting_provider;
+    tla_state_symbol Streaming;
+    tla_state_symbol Awaiting_tool_result;
+    tla_state_symbol Completing;
+    tla_state_symbol Done;
+    tla_state_symbol (Failed (Failure_runtime_error ""));
+    tla_state_symbol (Cancelled Cancelled_phase_gate_close);
+  ]
+  |> List.sort_uniq String.compare
+
 let pp_cancel_reason fmt r =
   Format.pp_print_string fmt (cancel_reason_label r)
 

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -60,6 +60,26 @@ val cancel_reason_label : cancel_reason -> string
 val failure_reason_label : failure_reason -> string
 val turn_state_label : turn_state -> string
 
+val tla_state_symbol : turn_state -> string
+(** Project [turn_state] to the symbol used in the TLA+
+    [TurnStateSet] of [specs/keeper-turn-fsm/KeeperTurnFSM.tla].
+
+    Distinct from [turn_state_label]: the runtime label
+    ([Awaiting_tool_result -> "awaiting_tool_result"]) is operator-
+    facing and stable for trace regex; the TLA+ symbol
+    ([Awaiting_tool_result -> "awaiting_tool"]) follows the spec's
+    abbreviated naming.  The mapping was previously documented only
+    in a TLA+ comment (KeeperTurnFSM.tla:32) and not enforceable.
+
+    Pinned by [test_keeper_turn_fsm_tla_alignment]: the set of
+    symbols produced by this function must equal [TurnStateSet],
+    so a spec rename or constructor addition fails the build. *)
+
+val all_turn_state_symbols : string list
+(** Sorted set of TLA+ symbols emitted by [tla_state_symbol] over
+    every [turn_state] constructor.  Used by the alignment test to
+    cross-check against [TurnStateSet] in the spec file. *)
+
 val pp_cancel_reason : Format.formatter -> cancel_reason -> unit
 val pp_failure_reason : Format.formatter -> failure_reason -> unit
 val pp_turn_state : Format.formatter -> turn_state -> unit

--- a/test/dune
+++ b/test/dune
@@ -203,6 +203,7 @@
         test_per_keeper_token_fallback
         test_auth_strict_mode
         test_keeper_turn_fsm_emit
+        test_keeper_turn_fsm_tla_alignment
         test_gh_api_classification
         test_actionable_path_action
         test_stale_kill_class)
@@ -378,6 +379,7 @@
           test_per_keeper_token_fallback
           test_auth_strict_mode
           test_keeper_turn_fsm_emit
+          test_keeper_turn_fsm_tla_alignment
           test_gh_api_classification
           test_actionable_path_action
           test_stale_kill_class

--- a/test/test_keeper_turn_fsm_tla_alignment.ml
+++ b/test/test_keeper_turn_fsm_tla_alignment.ml
@@ -1,0 +1,112 @@
+(** test_keeper_turn_fsm_tla_alignment
+
+    Pins the OCaml [Keeper_turn_fsm.tla_state_symbol] surface to the
+    TLA+ [TurnStateSet] in
+    [specs/keeper-turn-fsm/KeeperTurnFSM.tla].
+
+    Why this exists: the runtime label
+    ([Awaiting_tool_result -> "awaiting_tool_result"]) deliberately
+    differs from the TLA+ symbol
+    ([Awaiting_tool_result -> "awaiting_tool"], spec line 32 alias
+    table).  Until [tla_state_symbol] was added the alias mapping
+    lived only in a TLA+ comment, with no compile-time or test-time
+    enforcement that the OCaml side stayed aligned.  A
+    constructor rename, a missed addition, or a spec edit could
+    drift silently.
+
+    Pattern lifted from [test_keeper_social_model_magentic_ledger_fsm]
+    which already cross-checks [PhaseSet]/[EventSet]. *)
+
+open Alcotest
+module F = Masc_mcp.Keeper_turn_fsm
+
+let has_prompt_root path =
+  Sys.file_exists
+    (Filename.concat path "config/prompts/keeper.unified.system.md")
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_prompt_root root -> root
+  | _ ->
+      let rec ascend path =
+        if has_prompt_root path then path
+        else
+          let parent = Filename.dirname path in
+          if String.equal parent path then Sys.getcwd () else ascend parent
+      in
+      ascend (Sys.getcwd ())
+
+let read_file path = In_channel.with_open_bin path In_channel.input_all
+
+let substring_index haystack needle =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > hay_len then None
+    else if String.sub haystack i needle_len = needle then Some i
+    else loop (i + 1)
+  in
+  if needle_len = 0 then Some 0 else loop 0
+
+let extract_quoted_set source name =
+  let prefix = name ^ " ==" in
+  match substring_index source prefix with
+  | None -> fail ("missing set definition: " ^ name)
+  | Some start ->
+      let body_start =
+        match String.index_from_opt source start '{' with
+        | Some idx -> idx + 1
+        | None -> fail ("no '{' after " ^ name)
+      in
+      let rest =
+        String.sub source body_start (String.length source - body_start)
+      in
+      let body_end =
+        match String.index_opt rest '}' with
+        | Some idx -> idx
+        | None -> fail ("unterminated set: " ^ name)
+      in
+      String.sub rest 0 body_end
+      |> String.split_on_char ','
+      |> List.map String.trim
+      |> List.filter (fun item -> item <> "")
+      |> List.map (fun item ->
+             if String.length item >= 2 && item.[0] = '"' then
+               String.sub item 1 (String.length item - 2)
+             else item)
+      |> List.sort_uniq String.compare
+
+let tla_path () =
+  Filename.concat (repo_root ())
+    "specs/keeper-turn-fsm/KeeperTurnFSM.tla"
+
+let test_turn_state_symbols_match_tla () =
+  let source = read_file (tla_path ()) in
+  check (list string)
+    "Keeper_turn_fsm.tla_state_symbol covers TurnStateSet exactly"
+    (extract_quoted_set source "TurnStateSet")
+    F.all_turn_state_symbols
+
+let test_label_distinct_from_symbol_for_alias () =
+  (* Document the deliberate alias: runtime label and TLA symbol
+     diverge for [Awaiting_tool_result].  If a future refactor
+     accidentally collapses them the test fails here, prompting
+     a spec/runtime decision rather than a silent change. *)
+  let label = F.turn_state_label F.Awaiting_tool_result in
+  let symbol = F.tla_state_symbol F.Awaiting_tool_result in
+  check string "runtime label keeps the verbose form"
+    "awaiting_tool_result" label;
+  check string "TLA+ symbol keeps the spec abbreviation"
+    "awaiting_tool" symbol
+
+let () =
+  run "keeper_turn_fsm_tla_alignment"
+    [
+      ( "alignment",
+        [
+          test_case "tla_state_symbol covers TurnStateSet" `Quick
+            test_turn_state_symbols_match_tla;
+          test_case "label vs symbol alias documented" `Quick
+            test_label_distinct_from_symbol_for_alias;
+        ] );
+    ]


### PR DESCRIPTION
## 배경 (Kimi AST/PPX 문서 cross-check 산출)

[Kimi 에이전트 문서](attached) Section 1.2가 `keeper_turn_fsm` ↔ TLA+ `TurnStateSet`의 수동 매핑 drift를 지적. HEAD `e5007ec581` cross-check 결과:

| TLA+ 라인 | OCaml 위치 | 비고 |
|----------|----------|------|
| `KeeperTurnFSM.tla:69` `"awaiting_tool"` | `keeper_turn_fsm.ml:58` `"awaiting_tool_result"` | 의도적 alias |
| `KeeperTurnFSM.tla:32` 자기 인정 주석 | (없음) | enforcement 0 |

문서 진단의 큰 그림은 정확하나, 진짜 root는 단순 drift가 아닌 **alias mapping이 spec 주석에만 존재 → 컴파일/테스트 enforcement 부재**.

## Fix

`tla_state_symbol : turn_state -> string`을 신설해 spec 명명을 코드로 승격하고, `test_keeper_turn_fsm_tla_alignment`으로 `TurnStateSet` 파일과 cross-check.

prior art: `test_keeper_social_model_magentic_ledger_fsm.test_tla_sets_match_ocaml`이 동일 패턴으로 `PhaseSet`/`EventSet` 정렬을 이미 보장. 본 PR은 turn FSM에 같은 형태를 lift.

## 의도적 비목표

- PPX deriver 파이프라인 (Kimi 문서 Section 4 Week 1) 도입 안 함. 신규 도구 0.
- `ReceiptOutcomeSet` 정렬 후속 (같은 패턴, 별 PR)
- 런타임 라벨 (`turn_state_label`) 변경 0 — operator-facing trace/receipt JSON 호환성 보존.

## Verification

```
$ dune exec test/test_keeper_turn_fsm_tla_alignment.exe
[OK] alignment 0 tla_state_symbol covers TurnStateSet.
[OK] alignment 1 label vs symbol alias documented.
Test Successful in 0.002s. 2 tests run.
```

## 향후 drift 시나리오
- 누가 `TurnStateSet`에 새 상태 추가 → 본 test fail (OCaml 누락)
- 누가 OCaml에 새 variant 추가 → exhaustive match 빌드 fail (`tla_state_symbol`)
- 누가 alias 통일 시도 → 두 번째 test fail (의도된 안전망)

## 미충족 가드

- `ratchet` step이 main에서 exit 127 (PR #11428 진단 중) — 본 PR도 같은 영향 받지만 별도 fix.