### PR TITLE
chore(types): expose 5 tool_schemas facade .mli files

### DIFF
--- a/lib/tool_schemas/tool_schemas_a2a.mli
+++ b/lib/tool_schemas/tool_schemas_a2a.mli
@@ -1,0 +1,8 @@
+(** Tool schemas for [Tool_a2a] — separated to break the Config
+    dependency cycle.
+
+    All A2A tool schemas have been pruned (poll_events,
+    heartbeat_result removed); the value remains as an empty
+    registration slot. *)
+
+val schemas : Types.tool_schema list

--- a/lib/tool_schemas/tool_schemas_control.mli
+++ b/lib/tool_schemas/tool_schemas_control.mli
@@ -1,0 +1,7 @@
+(** Tool schemas for [Tool_control] — separated to break the Config
+    dependency cycle.
+
+    Carries the [masc_pause] / [masc_resume] schema definitions used
+    by the control surface. *)
+
+val schemas : Types.tool_schema list

--- a/lib/tool_schemas/tool_schemas_coord.mli
+++ b/lib/tool_schemas/tool_schemas_coord.mli
@@ -1,0 +1,6 @@
+(** MCP tool schemas for MASC room operations (facade).
+
+    Concatenates schemas from {!Tool_schemas_coord_core} and
+    {!Tool_schemas_coord_extra}. *)
+
+val schemas : Types.tool_schema list

--- a/lib/tool_schemas/tool_schemas_inline.mli
+++ b/lib/tool_schemas/tool_schemas_inline.mli
@@ -1,0 +1,6 @@
+(** MCP tool schemas for inline-dispatched tools (facade).
+
+    Concatenates schemas from {!Tool_schemas_inline_coord},
+    {!Tool_schemas_inline_infra}, and {!Tool_schemas_inline_episodes}. *)
+
+val schemas : Types.tool_schema list

--- a/lib/tool_schemas/tool_schemas_inline_episodes.mli
+++ b/lib/tool_schemas/tool_schemas_inline_episodes.mli
@@ -1,0 +1,7 @@
+(** Tool schemas for inline-dispatched episode tools.
+
+    Currently empty — episode tools have been pruned from the inline
+    dispatch surface. The module remains as a registration slot for
+    future inline episode schemas. *)
+
+val schemas : Types.tool_schema list


### PR DESCRIPTION
## Summary

5 facade 모듈에 .mli 일괄 추가. 모두 \`val schemas : Types.tool_schema list\` 단일 surface.

| 모듈 | 줄 수 | 내용 |
|------|-------|------|
| tool_schemas_inline_episodes | 1 | 빈 schemas list (pruned) |
| tool_schemas_coord | 2 | core + extra concat |
| tool_schemas_a2a | 4 | pruned 빈 list |
| tool_schemas_inline | 7 | 3 sub-module concat |
| tool_schemas_control | 28 | masc_pause / masc_resume 정의 |

## Caller Audit

5 모듈 모두 외부 사용 = \`M.schemas\`만. open consumer 0. 다른 surface 외부 노출 0 (rg 검증 완료).

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (baseline 125 → -5). batch ROI 최고.

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff (-5)