### PR TITLE
chore(types): expose masc_time_constants surface

### DIFF
--- a/lib/config/masc_time_constants.mli
+++ b/lib/config/masc_time_constants.mli
@@ -1,0 +1,22 @@
+(** Time constants — SSOT for commonly used durations.
+
+    All values are in seconds (float) unless suffixed with [_int]. The
+    module exists to eliminate magic numbers like [86400.0] / [3600.0]
+    scattered across the codebase.
+
+    @since 0.4.0 *)
+
+val minute : float
+(** Seconds in one minute. *)
+
+val hour : float
+(** Seconds in one hour. *)
+
+val day : float
+(** Seconds in one day (24 h). *)
+
+val day_int : int
+(** Integer seconds in one day. *)
+
+val days_to_seconds : int -> float
+(** [days_to_seconds n] returns [float_of_int n *. day]. *)


### PR DESCRIPTION
## Summary

\`lib/config/masc_time_constants.ml\` (22줄) 에 exhaustive .mli 추가. 5 surface (minute/hour/day/day_int/days_to_seconds) 노출.

## Caller Audit

- 22 caller files
- qualified 외부 사용 3종 — \`Masc_time_constants.day\`, \`day_int\`, \`days_to_seconds\`
- \`minute\`, \`hour\` 외부 사용 0이지만 **SSOT 보존 의도**로 .mli expose 유지 (시간 상수 모음 모듈은 부분 surface가 SSOT 신뢰도를 깎음)
- open consumer 0

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (baseline 125 → -1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff