### PR TITLE
chore(types): expose config_boot_overrides surface

### DIFF
--- a/lib/config/config_boot_overrides.mli
+++ b/lib/config/config_boot_overrides.mli
@@ -1,0 +1,28 @@
+(** Process-local boot override store.
+
+    Holds startup-loaded configuration defaults that behave like
+    process-env inputs for readers, without mutating the real process
+    environment.
+
+    Precedence used by {!source} and standard readers:
+    real process env > boot override store > hardcoded default.
+
+    The backing [StringMap] and the [Atomic.t] cell are intentionally
+    hidden — callers interact only through the [get/set/clear/source]
+    surface. *)
+
+val get_opt : string -> string option
+(** Read the boot override for [name]. [None] if no override is set. *)
+
+val set : string -> string -> unit
+(** Set a boot override. CAS-based; safe under contention. *)
+
+val clear : string -> unit
+(** Drop the boot override for [name]. CAS-based. *)
+
+val reset_for_tests : unit -> unit
+(** Test-only: reset the entire store to empty. *)
+
+val source : string -> string
+(** Report which layer would supply [name]: ["env"] | ["boot_override"]
+    | ["default"]. *)


### PR DESCRIPTION
## Summary

\`lib/config/config_boot_overrides.ml\` (44줄) 에 selective .mli 추가.

| 노출 (5 fn) | 숨김 (2) |
|---|---|
| \`get_opt\`, \`set\`, \`clear\` | \`module StringMap\` (Map.Make 인스턴스) |
| \`reset_for_tests\` | \`table : string StringMap.t Atomic.t\` (mutable backing) |
| \`source\` | |

## Caller Audit

- 6 caller files
- 5 함수 모두 사용 (qualified, open consumer 0)
- mutable state는 의도적으로 hide — CAS invariant 보호

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (baseline 125 → -1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff