### PR TITLE
fix(keeper): persona audit repair + completion tool contract exemption

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -307,6 +307,16 @@ let keeper_schemas : tool_schema list = [
           ("default", `Bool true);
           ("description", `String "If false, return only keepers with audit issues while keeping summary counts over all audited keepers.");
         ]);
+        ("repair", `Assoc [
+          ("type", `String "boolean");
+          ("default", `Bool false);
+          ("description", `String "If true, run Keeper_goal_repair.run after audit: create goals from keeper purpose statements and assign to keepers with empty active_goal_ids.");
+        ]);
+        ("dry_run_repair", `Assoc [
+          ("type", `String "boolean");
+          ("default", `Bool false);
+          ("description", `String "If true, run Keeper_goal_repair.dry_run after audit: preview what repair would do without making changes.");
+        ]);
       ]);
     ];
   };

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -229,33 +229,45 @@ let is_completion_tool_name name =
 
 let tool_name_can_satisfy_required_contract name =
   let name = canonical_tool_name name in
-  match Tool_catalog.effect_domain name with
-  | Some Tool_catalog.Read_only -> false
-  | Some
-      ( Tool_catalog.Masc_coordination
-      | Tool_catalog.Playground_write
-      | Tool_catalog.Main_worktree_write ) ->
-      true
-  | None -> not (Tool_dispatch.is_read_only name)
+  (* Completion tools (stay_silent, release, done, etc.) intentionally
+     satisfy the contract even though their effect_domain is Read_only.
+     Without this exemption, analyst/janitor keepers that correctly
+     call keeper_stay_silent alongside status reads trigger false
+     contract violations — observed 2026-04-28 when codex-spark
+     returned stay_silent + keeper_task_list on an actionable signal. *)
+  if is_completion_tool_name name then true
+  else
+    match Tool_catalog.effect_domain name with
+    | Some Tool_catalog.Read_only -> false
+    | Some
+        ( Tool_catalog.Masc_coordination
+        | Tool_catalog.Playground_write
+        | Tool_catalog.Main_worktree_write ) ->
+        true
+    | None -> not (Tool_dispatch.is_read_only name)
 
 let required_tool_satisfaction
       (call : Oas.Completion_contract.tool_call)
   : (unit, string) result
   =
   let tool_name = canonical_tool_name call.name in
-  let mutates =
-    match Tool_catalog.effect_domain tool_name with
-    | Some Tool_catalog.Read_only -> false
-    | _ ->
-      Keeper_exec_tools.has_mutating_side_effect_with_input
-        ~tool_name ~input:call.input
-  in
-  if mutates then Ok ()
+  (* Completion tools intentionally satisfy the contract.  See
+     tool_name_can_satisfy_required_contract for the same exemption. *)
+  if is_completion_tool_name tool_name then Ok ()
   else
-    Error
-      (Printf.sprintf
-         "tool '%s' is read-only/passive and cannot satisfy a required-tool contract"
-         tool_name)
+    let mutates =
+      match Tool_catalog.effect_domain tool_name with
+      | Some Tool_catalog.Read_only -> false
+      | _ ->
+        Keeper_exec_tools.has_mutating_side_effect_with_input
+          ~tool_name ~input:call.input
+    in
+    if mutates then Ok ()
+    else
+      Error
+        (Printf.sprintf
+           "tool '%s' is read-only/passive and cannot satisfy a required-tool contract"
+           tool_name)
 
 let classify_tool_progress name =
   let name = canonical_tool_name name in

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5076,6 +5076,35 @@ let test_actionable_tool_contract_allows_execution_tools () =
        ~actionable_signal_context:false
        ~tool_names:[])
 
+let test_stay_silent_satisfies_required_contract_despite_read_only_effect () =
+  (* keeper_stay_silent has effect_domain=Read_only in tool_catalog but is
+     classified as Completion in completion_tool_names.  When the LLM
+     correctly signals "no work for me" via stay_silent alongside status
+     reads, the contract must not fire a false violation.  Observed
+     2026-04-28: analyst/janitor cycles rejected with "passive status/read
+     tools: keeper_stay_silent, keeper_task_list". *)
+  check bool "stay_silent satisfies required contract" true
+    (KTD.tool_name_can_satisfy_required_contract "keeper_stay_silent");
+  check bool "completion tool set includes stay_silent" true
+    (KTD.is_completion_tool_name "keeper_stay_silent");
+  check (option string) "stay_silent + passive tools = no violation" None
+    (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:true
+       ~actionable_signal_context:true
+       ~tool_names:[ "keeper_stay_silent"; "keeper_tasks_list" ]);
+  check (option string) "stay_silent alone = no violation" None
+    (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:true
+       ~actionable_signal_context:true
+       ~tool_names:[ "keeper_stay_silent" ]);
+  (* Without stay_silent, passive-only still violates *)
+  check bool "passive-only still violates" true
+    (Option.is_some
+       (KTD.actionable_tool_contract_violation_reason
+          ~claim_context_allowed:true
+          ~actionable_signal_context:true
+          ~tool_names:[ "keeper_tasks_list"; "masc_status" ]))
+
 let required_tool_call name input
   : Agent_sdk.Completion_contract.tool_call
   =
@@ -5090,7 +5119,10 @@ let test_required_tool_satisfaction_rejects_passive_tools () =
     (satisfies_required_tool "masc_status" (`Assoc []));
   check bool "keeper_tasks_list is passive" false
     (satisfies_required_tool "keeper_tasks_list" (`Assoc []));
-  check bool "keeper_stay_silent is passive" false
+  (* keeper_stay_silent is a Completion tool and intentionally satisfies
+     the required-tool contract despite its Read_only effect_domain.
+     See keeper_tool_disclosure.ml is_completion_tool_name exemption. *)
+  check bool "keeper_stay_silent satisfies as completion" true
     (satisfies_required_tool "keeper_stay_silent" (`Assoc []));
   check bool "Read alias is passive" false
     (satisfies_required_tool "Read" (`Assoc []));
@@ -6394,6 +6426,8 @@ let () =
             test_claim_tool_classification_covers_masc_claim_task;
           test_case "actionable signal allows execution tools" `Quick
             test_actionable_tool_contract_allows_execution_tools;
+          test_case "stay_silent satisfies required contract despite read-only effect" `Quick
+            test_stay_silent_satisfies_required_contract_despite_read_only_effect;
           test_case "required tool predicate rejects passive tools" `Quick
             test_required_tool_satisfaction_rejects_passive_tools;
           test_case "required tool predicate accepts mutating tools" `Quick


### PR DESCRIPTION
## Summary

- **Persona audit repair params**: Expose `repair`/`dry_run_repair` params in `keeper_persona_audit` schema so that `masc_keeper_persona_audit` can detect and fix configuration drift between persona profiles, TOML keeper metadata, and live runtime state.
- **Completion tool contract exemption**: `keeper_stay_silent` has `effect_domain=Read_only` in `tool_catalog` but is `Completion` in `completion_tool_names`. The contract checker used `effect_domain` exclusively, causing false `require_tool_use` violations for analyst/janitor keepers that correctly signal "no work" via `stay_silent`. Observed 2026-04-28: cycles rejected with "passive status/read tools: keeper_stay_silent, keeper_task_list".

## Root Cause

`keeper_stay_silent` dual identity:
- `tool_catalog.ml`: classified as `Read_only` effect_domain (correct — it doesn't mutate filesystem)
- `keeper_tool_disclosure.ml`: classified as `Completion` in `completion_tool_names` (correct — it's a decisive turn-ending action)

Both classifications are independently correct, but the contract checkers (`tool_name_can_satisfy_required_contract` and `required_tool_satisfaction`) only consulted `effect_domain`, missing the `Completion` class.

## Changes

### keeper_schema.ml
- Add `repair` and `dry_run_repair` params to `keeper_persona_audit` input schema

### keeper_tool_disclosure.ml
- Add completion tool exemption to `tool_name_can_satisfy_required_contract` (violation reason path)
- Add same exemption to `required_tool_satisfaction` (OAS worker path)
- Both functions now check `is_completion_tool_name` before consulting `effect_domain`

### test_keeper_unified.ml
- New test: `stay_silent satisfies required contract despite read-only effect`
- Updated: `keeper_stay_silent` assertion changed from `false` (rejected) to `true` (accepted as completion)

### Purge (commit 1)
- Dead code removal: stale .mli files, unused dashboard components, removed test files for deleted modules
- ppx_tla removal (unused macro)
- CI workflow cleanup

## Test plan

- [x] `dune build --root .` passes
- [x] `dune runtest` for `test_keeper_unified.ml` — all contract tests pass (5 pre-existing failures unrelated)
- [x] New test `stay_silent satisfies required contract despite read-only effect` passes
- [x] Updated `keeper_stay_silent` assertion in `test_required_tool_satisfaction_rejects_passive_tools` passes
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)