### PR TITLE
chore(types): expose env_config facade via include module type of

### DIFF
--- a/lib/config/env_config.mli
+++ b/lib/config/env_config.mli
@@ -1,0 +1,28 @@
+(** MASC Environment Configuration — facade.
+
+    Centralized environment-variable management following 12-Factor
+    App principles. All env vars use the [MASC_*] prefix.
+
+    Re-exports the public surface of {!Env_config_core},
+    {!Env_config_runtime}, {!Env_config_governance}, and
+    {!Env_config_keeper} so callers can [Env_config.<symbol>] without
+    knowing which sub-module owns each knob. The interface uses
+    [include module type of] so the facade auto-tracks the underlying
+    modules without manual maintenance.
+
+    Underlying modules currently have no [.mli] of their own; the
+    inferred surface is what propagates here. When narrower [.mli]
+    files land for those modules, this facade automatically picks up
+    the tightened contract. *)
+
+include module type of Env_config_core
+include module type of Env_config_runtime
+include module type of Env_config_governance
+include module type of Env_config_keeper
+
+val print_summary : unit -> unit
+(** Log a multi-line summary of every nested config category at boot
+    time. Side-effects logging only. *)
+
+val to_json : unit -> Yojson.Safe.t
+(** Compatibility wrapper around {!Env_config_snapshot.to_json}. *)


### PR DESCRIPTION
## Summary

\`lib/config/env_config.ml\` (87줄 facade) 에 \`include module type of\` 패턴 .mli 추가. \`lib/types/types.mli\` (PR #11418)와 동일 전략.

## Pattern

\`\`\`ocaml
include module type of Env_config_core
include module type of Env_config_runtime
include module type of Env_config_governance
include module type of Env_config_keeper
val print_summary : unit -> unit
val to_json : unit -> Yojson.Safe.t
\`\`\`

Sub-module 4개에 .mli 없음 → inferred surface가 facade로 propagate. Sub-module narrowed mli 추가 시 자동 picks up.

## Caller Breadth

- 93 caller files using \`Env_config.<symbol>\`
- nested 모듈 (\`Env_config.Zombie\`, \`Env_config.Lock\`, \`Env_config.Inference\`, \`Env_config.AgentSelection\` 등) auto-track 확인
- 자체 함수 \`print_summary\`, \`to_json\` 명시적 val

## Risk

이 PR 자체는 surface 변경 없음 (.mli가 .ml의 inferred type을 그대로 노출). dune build pass 가 검증 충분.

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (baseline 125 → -1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] 93 caller files 영향 0 확인