### PR TITLE
chore(types): expose env_config_oas_bridge surface

### DIFF
--- a/lib/config/env_config_oas_bridge.mli
+++ b/lib/config/env_config_oas_bridge.mli
@@ -1,0 +1,43 @@
+(** Env_config_oas_bridge — per-caller OAS bridge timeout SSOT (#10094).
+
+    Replaces seven hardcoded [Masc_oas_bridge.run_safe ~timeout_s:N.N]
+    literals scattered across the lib tree. Each caller is named so
+    its hardcoded default is preserved (compute-heavy budgets at
+    120/180s) or raised (fantasy 60s budgets at 300s), while the
+    operator can tune any single caller via env without touching the
+    others.
+
+    Lookup order in {!timeout_sec} (top wins):
+    1. Per-caller env [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC].
+    2. Legacy per-caller env (#9629 migration window).
+    3. Per-caller checked-in default.
+    4. Global env [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] — only for
+       unknown callers; not an override.
+    5. [300.0] hardcoded fallback.
+
+    The default-resolution table, env-var name builders, and
+    legacy-alias map are intentionally hidden — callers interact
+    through [timeout_sec ~caller ()] only. *)
+
+(** Named caller identity. [Unknown of <key>] handles a future caller
+    without a typed default; resolution falls through to the global
+    env / hardcoded fallback rather than failing closed. *)
+type caller =
+  | Auto_responder
+  | Dashboard_provider_runs
+  | Autoresearch_codegen
+  | Keeper_persona_authoring
+  | Server_openai_compat
+  | Tool_deep_review
+  | Anti_rationalization
+  | Governance_judge
+  | Operator_judge
+  | Unknown of string
+
+val caller_key : caller -> string
+(** Stable lowercase string identifier for [caller], used by
+    Prometheus labels and env-var name construction. *)
+
+val timeout_sec : caller:caller -> unit -> float
+(** Resolve the OAS bridge timeout (seconds) for [caller] using the
+    five-step lookup order documented above. *)


### PR DESCRIPTION
## Summary

\`lib/config/env_config_oas_bridge.ml\` (180줄, OAS bridge timeout SSOT #10094) 에 strict selective .mli 추가.

| 노출 (2 fn + 1 ADT) | 숨김 (8 internal) |
|---|---|
| \`type caller\` (10 variants) | \`global_default_sec\` |
| \`caller_key\` | \`known_callers\` (stale "exported for tests" 주석) |
| \`timeout_sec\` | \`known_default_sec\` |
| | \`upper_case\` |
| | \`per_caller_env_var\`, \`legacy_per_caller_env_var\`, \`global_env_var\` |
| | \`trimmed_value_opt\` |

## Caller Audit

- 12 caller files
- 외부 사용 = type \`caller\` 변형들 + \`caller_key\` + \`timeout_sec\`
- \`known_callers\` 주석에 "Exported for tests"라 적혀있지만 실제 test caller 0 — 자기-증언 제거 (memory \`feedback_self_confession_comments_must_be_measured\`)
- \`open\` consumer 0

## .mli 가치

- 5단계 lookup order semantics를 docblock에 명시 — caller가 override 시 영향 범위를 surface에서 확인 가능
- internal helper 숨김으로 향후 lookup 순서 변경 시 .mli 변경 불필요

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (baseline 125 → -1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff