### PR TITLE
feat(keeper): include cascade_name in semaphore-wait skip log

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1610,8 +1610,8 @@ let run_keepalive_unified_turn
              once a slot opens up. Meta is left untouched so failure counters
              do not tick. *)
           Log.Keeper.warn
-            "%s: skipping turn (semaphore wait > %.0fs, peers holding slot)"
-            meta_after_triage.name wait_sec;
+            "%s: skipping turn (semaphore wait > %.0fs, peers holding slot, cascade=%s)"
+            meta_after_triage.name wait_sec meta_after_triage.cascade_name;
           meta_after_triage)
       else if (not has_message_signal) && obs.message_cursor_updates <> [] then
         meta_after_observe


### PR DESCRIPTION
## Summary
\`keeper_keepalive.ml:1613\` Log.Keeper.warn 메시지에 \`cascade=<name>\` 인라인 추가.

Before:
\`\`\`
qa-king: skipping turn (semaphore wait > 60s, peers holding slot)
\`\`\`

After:
\`\`\`
qa-king: skipping turn (semaphore wait > 60s, peers holding slot, cascade=local_with_kimi_coding_with_glm)
\`\`\`

## Why
2026-04-28 01:00~01:06 fleet stall 윈도우에서 4 keeper(qa-king/sangsu/ramarama/velvet-hammer)가 10분간 40+회 이 WARN을 emit. 현재 메시지로는 contention 분포를 분석하려면 매번 keeper → \`.masc/keepers/<name>.json\` cross-reference 필요.

cascade_name 인라인 노출 시:
- **단일 cascade 집중**: peer-cascade saturation (해당 cascade의 LLM provider/quota 문제)
- **분산**: 광역 semaphore/rate-limit 제약

이번 fleet event는 4 keeper 모두 \`local_with_kimi_coding_with_glm\` cascade로 의심되지만, 메시지만으로는 즉시 단정 불가.

## Cohesion with #11436
PR #11436은 stale_keeper_broadcast / watchdog termination log에 cascade_name 추가. 이번 PR은 같은 진단 강화 의도를 keepalive skip 경로로 확장. 두 PR 머지 후 fleet stall 진단의 3개 핵심 메시지 모두 cascade context 일관 노출:
1. \`stale_keeper_broadcast emitted\` (#11436)
2. \`stale watchdog terminating fiber\` (#11436)
3. \`skipping turn (semaphore wait > Ns)\` (this PR)

## Test plan
- [ ] CI Build/Lint/Runtest 통과
- [ ] (post-merge) 다음 fleet stall 윈도우에서 cascade_name 인라인 표시 확인

## 미검증
- 로컬 dune build/runtest 미수행: 다른 세션이 dune 점유 중이라 CI 위임.
- \`meta_after_triage : keeper_meta\`로 \`cascade_name : string\` 필드 안전 접근 (keeper_types.mli:167).

🤖 Generated with [Claude Code](https://claude.com/claude-code)