### PR TITLE
fix(ratchet): exit 0 at rg-no-match pipe boundary in inferred_dump_headers

### DIFF
--- a/scripts/ocaml-structure-ratchet.sh
+++ b/scripts/ocaml-structure-ratchet.sh
@@ -69,9 +69,13 @@ count_lib_dune_lines() {
 }
 
 count_inferred_dump_headers() {
-  # rg exits 1 with no matches; pipe to wc -l so an empty stream still
-  # prints 0. Using -l (file count) — one self-incriminating header per file.
-  rg -l "inferred mli" "${REPO_ROOT}/lib" 2>/dev/null | wc -l | tr -d ' '
+  # rg exits 1 with no matches. Under `set -euo pipefail`, that exit
+  # propagates through the pipe and dies the surrounding `current=$(...)`
+  # capture before lib_other_mli_missing is reached. After the
+  # 7-PR closure series (#11286/.../#11401) eliminated every header,
+  # this metric measures 0, so the bug emerged silently. Force exit 0
+  # at the pipe boundary so wc -l always sees a clean stream.
+  { rg -l "inferred mli" "${REPO_ROOT}/lib" 2>/dev/null || true; } | wc -l | tr -d ' '
 }
 
 count_lib_other_mli_missing() {


### PR DESCRIPTION
## Summary

\`scripts/ocaml-structure-ratchet.sh\`의 \`count_inferred_dump_headers()\`가 \`set -euo pipefail\` 환경에서 ripgrep no-match exit 1을 propagate시켜 후속 metric (lib_other_mli_missing)이 측정 안 되는 silent bug 수정.

## Root Cause

\`\`\`bash
rg -l "inferred mli" "${REPO_ROOT}/lib" 2>/dev/null | wc -l | tr -d ' '
\`\`\`

7-PR closure series(#11286/11290/11296/11303/11309/11321/11401)가 모든 \`(** X inferred mli **)\` 헤더를 제거 → rg 매치 0 → exit 1.
pipefail이 그걸 잡아 \`current=\$(current_value ...)\` 가 죽음. \`set -e\`가 그 다음 metric 측정 전에 스크립트 종료시킴.

## Symptom (verified on origin/main 0478525868)

\`\`\`
$ bash scripts/ocaml-structure-ratchet.sh
OK   keeper_mli_missing: 3 < baseline 10
OK   coord_mli_missing: 1 < baseline 3
exit=1   ← stops here, lib_other never measured
\`\`\`

## Fix

\`\`\`diff
- rg -l "inferred mli" "${REPO_ROOT}/lib" 2>/dev/null | wc -l | tr -d ' '
+ { rg -l "inferred mli" "${REPO_ROOT}/lib" 2>/dev/null || true; } | wc -l | tr -d ' '
\`\`\`

같은 패턴이 \`count_godsplit\`에는 이미 적용되어 있다 (\`|| echo 0\`). 일관성 회복.

## Verification

\`\`\`
$ bash scripts/ocaml-structure-ratchet.sh
OK   keeper_mli_missing: 3 < baseline 10
OK   coord_mli_missing: 1 < baseline 3
OK   inferred_dump_headers: 0 < baseline 6
OK   lib_other_mli_missing: 115 < baseline 125
exit=0
\`\`\`

## CI Impact

이 fix 이전에는 라쳇이 lib_other_mli_missing 측정 자체를 못함. CI Lint는 exit 0(early termination)으로 거짓 통과했을 가능성. fix 후 lib_other가 진짜로 load-bearing.

## Side Effect — Baseline Regenerate 권장

라쳇 fix 후 4 metric이 baseline보다 낮음:
- keeper_mli_missing: 10 → 3
- coord_mli_missing: 3 → 1  
- inferred_dump_headers: 6 → 0
- lib_other_mli_missing: 125 → 115

별도 후속 PR로 \`scripts/ocaml-structure-ratchet.sh --regenerate\` 권장 (현재 baseline은 stale).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] 라쳇이 6 metric 모두 측정하는지 확인