### PR TITLE
fix: main lint - escape + type drift 3건

### DIFF
--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -44,7 +44,7 @@ val observe_agent_lifecycle_fn : (Coord_utils_backend_setup.config ->
 val observe_task_transition_fn : (Coord_utils_backend_setup.config ->
             agent_name:string ->
             task_id:string ->
-            transition:Types_core.task_action ->
+            transition:Types.task_action ->
             details:Yojson.Safe.t -> unit)
            Atomic.t
 val cleanup_board_artifacts_fn : (unit -> int) Atomic.t

--- a/lib/coord/coord_utils_paths_backend.mli
+++ b/lib/coord/coord_utils_paths_backend.mli
@@ -74,7 +74,7 @@ val backend_extend_lock :
   (bool, Backend_types.error) result
 
 val backend_health_check :
-  config -> (Backend_types.health_status, Backend_types.error) result
+  config -> (Backend_types.health_result, Backend_types.error) result
 
 val backend_publish :
   config -> channel:string -> message:string ->

--- a/lib/types/severity.mli
+++ b/lib/types/severity.mli
@@ -20,7 +20,7 @@ val to_string : t -> string
 
 val of_string : string -> (t, string) result
 (** Parse a severity name. Aliases recognized:
-    [\"warn\" → Warning], [\"bad\" → Error], [\"fatal\" → Critical].
+    [{"warn" → Warning}], [{"bad" → Error}], [{"fatal" → Critical}].
     Returns [Error msg] for unknown inputs. *)
 
 val of_string_default : default:t -> string -> t


### PR DESCRIPTION
## Summary

main 의 lint 깨짐 3건 동시 복구.

| File | Line | Before | After | Cause |
|------|------|--------|-------|-------|
| `lib/types/severity.mli` | 23 | `[\"warn\"`등 escape | `[{"warn"`등 block-wrap | OCaml ppx doc comment 가 `\\\"` escape 를 string mode 진입으로 lex |
| `lib/coord/coord_utils_paths_backend.mli` | 77 | `Backend_types.health_status` | `Backend_types.health_result` | Backend_types 에 `health_status` 없음 (typo) |
| `lib/coord/coord_hooks.mli` | 47 | `Types_core.task_action` | `Types.task_action` | `.ml` 은 `open Types` 사용 → #11418 (types.mli facade) 머지 후 nominal drift |

## 발견 경위

PR #11439 (CHANGELOG) 의 Draft Auto-Merge Guard 가 stuck → empty commit 으로 re-trigger → 모든 SKIPPED job reset → Lint job 이 path filter 우회로 전체 돌면서 main 의 dormant lint break expose.

세 건 모두 single commit/PR 에서 안 잡힌 채 main 으로 슬며시 누적된 패턴. branch protection 에 Lint required 부재 결과 (memory `feedback_required-check-must-include-lint.md`).

## Test plan

- [ ] CI Lint job pass (관찰 대상)
- [ ] Build + OCaml Structure Ratchet pass
- [x] 로컬 dune 검증 — worktree 격리로 실행 불가 (root anchor)
- [x] 각 fix 의 root cause 검증 완료 (Backend_types.mli/coord_hooks.ml 직접 inspect)

## Auto-merge

SQUASH auto-merge 활성화. CI green → 자동 머지 → main 복구 → PR #11439 (CHANGELOG) chain unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)