### PR TITLE
fix(keeper-unified-turn): receipt outcome="cancelled" matches FSM Cancelled transition (Cycle 1b-i)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1077,9 +1077,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~meta
         ~generation
         ~cascade_name:meta.cascade_name
-        ~outcome:"skipped"
+        ~outcome:"cancelled"
         ~terminal_reason_code
-        ~activity_kind:"keeper.turn_skipped"
+        ~activity_kind:"keeper.turn_cancelled"
         ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
         ~keeper_turn_id
         ();


### PR DESCRIPTION
## Summary

**Cycle 1b-i** of the Kimi keeper FSM review plan — first concrete producer of the "cancelled" outcome value introduced by PR #11360 (Cycle 1a, MERGED).

The phase-gate-close path in `run_keeper_cycle` emits two telemetry records that **previously disagreed**:

| Telemetry | Value (before) | Value (after) |
|-----------|----------------|---------------|
| `Keeper_turn_fsm.emit_transition` (line 1086-1090) | `Cancelled (Cancelled_phase_gate_close)` ✅ truthful | unchanged |
| `record_pre_dispatch_terminal_observation` (line 1075-1085) | `outcome="skipped"`, `activity_kind="keeper.turn_skipped"` ❌ downgraded | `outcome="cancelled"`, `activity_kind="keeper.turn_cancelled"` ✅ aligned |

This is the textbook **Drift** category from plan §1 — sayang and code disagreed. The KeeperTurnFSM is source of truth; the receipt now mirrors it.

## Why this is the right fix

```
plan §3 Tier S1: outcome = if cancelled then "cancelled" else if success then "ok" else "error"
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                          this PR provides the only producer.
```

PR #11360 (Cycle 1a) added `outcome_kind = [\`Ok | \`Error | \`Cancelled]` and helpers, but the value `"cancelled"` was never produced anywhere in the codebase — making the `\`Cancelled` variant dead code. This PR is its first producer.

## Diff

```diff
@@ -1077,9 +1077,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~meta
         ~generation
         ~cascade_name:meta.cascade_name
-        ~outcome:"skipped"
+        ~outcome:"cancelled"
         ~terminal_reason_code
-        ~activity_kind:"keeper.turn_skipped"
+        ~activity_kind:"keeper.turn_cancelled"
         ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
```

2 lines changed in 1 file.

## Safety analysis

| Axis | Assessment |
|------|------------|
| FSM transition | Unchanged (still `Cancelled (Cancelled_phase_gate_close)`). |
| `terminal_reason_code` | Unchanged (`non_executable_phase:<phase>`); external observers retain diagnostic detail. |
| `outcome_kind_of_string` | Already accepts `"cancelled"` since #11360 — no new validation needed. |
| Consumer impact | 6 sites in `keeper_hooks_oas.ml` branch on `outcome = "ok"` only; treat any non-"ok" as failure. Semantically equivalent for `"cancelled"` (not a success). |
| Test fixtures | None of the 50+ test fixtures with `outcome = "..."` strings touch the phase-gate-close path. |

## Plan §3 Tier S1 vs reality (honest accounting)

The plan estimated this fix at "본체 surface 4 라인 + 타입 정의 1". This PR delivers the value-side fix (2 lines) only. The type-narrowing piece is Cycle 1b-iii (follow-up). Tier S1 is *partially* honored by #11360 (infrastructure), now this PR (first producer), and 1b-iii (type narrowing).

## What is NOT in this PR

| Follow-up | Why deferred | Tracked as |
|-----------|--------------|-----------|
| line 1193 ollama_saturated `"skipped"` → `"error"` | Semantically less clear-cut (receipt "한 일" view vs FSM "왜" view); deserves separate cherry-pickable PR | Cycle 1b-ii |
| `outcome` field type `string` → `outcome_kind` | Surface size (4 producer + 6 consumer + 50+ fixtures); rebases on this | Cycle 1b-iii |
| External Cancel handler for supervisor / fleet stop | Captures cancellations that bypass phase-gate; orthogonal | Cycle 1b-iv |

## Cycle context

Part of the autonomous Kimi keeper FSM review /loop:

- #11360 Cycle 1a `outcome_kind` infra (**MERGED**)
- this PR Cycle 1b-i first cancelled producer
- (next) Cycle 1b-ii ollama saturated drift
- (next) Cycle 1b-iii type narrowing
- (next) Cycle 1b-iv external Cancel handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
