### PR TITLE
fix(types): unterminated string literal in severity.mli docblock

### DIFF
--- a/lib/types/severity.mli
+++ b/lib/types/severity.mli
@@ -20,7 +20,7 @@ val to_string : t -> string
 
 val of_string : string -> (t, string) result
 (** Parse a severity name. Aliases recognized:
-    [\"warn\" → Warning], [\"bad\" → Error], [\"fatal\" → Critical].
+    ["warn"] -> Warning, ["bad"] -> Error, ["fatal"] -> Critical.
     Returns [Error msg] for unknown inputs. *)
 
 val of_string_default : default:t -> string -> t


### PR DESCRIPTION
## Summary

\`lib/types/severity.mli\` (PR #11419) 의 of_string docstring 안에서 \`\\"warn\\"\` 형태로 escape했는데, OCaml 코멘트 파서가 \`\\"\`를 string literal 시작으로 해석해서 unterminated string literal로 빌드 실패.

## Symptom

\`\`\`
File "lib/types/severity.mli", line 22, characters 0-3:
Error: This comment contains an unterminated string literal
File "lib/types/severity.mli", line 23, characters 6-7:
  String literal begins here
\`\`\`

## Root Cause

OCaml 코멘트 \`(** ... *)\` 안에서도 \`\"\` (백슬래시-escape된 따옴표)가 string literal 시작으로 해석된다. 메모리 \`feedback_ocaml-comment-parses-strings\`에 정확히 기록된 패턴.

## Fix

docstring escape 제거, raw 페어 따옴표 사용:

\`\`\`diff
- [\\"warn\\" → Warning], [\\"bad\\" → Error], [\\"fatal\\" → Critical].
+ ["warn"] -> Warning, ["bad"] -> Error, ["fatal"] -> Critical.
\`\`\`

\`["warn"]\`은 odoc cross-reference 마커 \`[..]\` 안에 페어 따옴표를 둔 형태로 OCaml 파서에 안전.

## Priority

Ready for merge — main 빌드 차단 상태.

## Test plan
- [x] \`dune build\` (after fix) 컴파일 통과
- [ ] CI green