### PR TITLE
chore(types): expose server_dashboard_http_agent_api surface

### DIFF
--- a/lib/server/server_dashboard_http_agent_api.mli
+++ b/lib/server/server_dashboard_http_agent_api.mli
@@ -1,0 +1,15 @@
+(** Server_dashboard_http_agent_api — Agent API HTTP handlers.
+
+    Registers GET handlers for the agent observability surface,
+    extracted from [server_routes_http_routes_dashboard.ml]:
+
+    - [GET /api/v1/agent-activity] — per-agent tool call stats from telemetry
+    - [GET /api/v1/tool-metrics] — aggregate tool metrics
+    - [GET /api/v1/agent-timeline] — per-agent timeline view
+    - [GET /api/v1/agent-relations] — agent-relation graph
+
+    Internal request/response helpers are intentionally hidden — only
+    the route registration entry point is exposed. *)
+
+val add_agent_api_routes :
+  Http_server_eio.Router.t -> Http_server_eio.Router.t


### PR DESCRIPTION
## Summary

\`lib/server/server_dashboard_http_agent_api.ml\` (95줄) 에 strict selective .mli 추가. 외부 surface 단일 함수 \`add_agent_api_routes\`만 노출.

| 노출 (1 fn) | 숨김 |
|------|------|
| \`add_agent_api_routes\` (Router → Router) | 모든 GET handler 헬퍼, JSON 응답 빌더 |

## 등록 라우트

- \`GET /api/v1/agent-activity\` — 텔레메트리 per-agent tool call stats
- \`GET /api/v1/tool-metrics\` — aggregate tool metrics
- \`GET /api/v1/agent-timeline\` — per-agent timeline
- \`GET /api/v1/agent-relations\` — agent relation graph

## Caller Audit

- \`server_dashboard_http.ml\` router chain에서만 호출
- \`open Server_dashboard_http_agent_api\` consumer 0

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (-1).

## Skip Note

\`server_dashboard_http_runtime_support.ml\` (47줄)도 후보였지만 \`type runtime\` record 노출 + \`run_dashboard_compute\`의 clock type alias 위험 (cycle 12 사고 패턴 #11432). 별도 PR로 분리 — verbatim 시그니처 사용 보장 후 진행.

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff