### PR TITLE
chore(types): expose operator_digest_guidance surface

### DIFF
--- a/lib/operator/operator_digest_guidance.mli
+++ b/lib/operator/operator_digest_guidance.mli
@@ -1,0 +1,29 @@
+(** Active-guidance layer for operator digest.
+
+    Resolves whether a fresh operator judgment exists for the given
+    target and builds the guidance fields accordingly. Falls back to
+    deterministic recommendations when no judgment is available.
+
+    Internal helpers ([normalize_target_type],
+    [judgment_surface_for_target_type], [fresh_operator_judgment],
+    [judgment_summary_json]) are intentionally hidden — only the
+    composer used by [operator_digest.ml] is exposed. *)
+
+val active_guidance_fields :
+  config:Coord.config ->
+  actor:string ->
+  target_type:string ->
+  target_id:string option ->
+  fallback_recommendations:Operator_digest_types.recommended_action list ->
+  fallback_summary:Yojson.Safe.t ->
+  (string * Yojson.Safe.t) list
+(** Build the digest's [active_*] guidance fields. When a fresh
+    operator judgment exists for [(target_type, target_id)] under the
+    judgment surface implied by [target_type], emits
+    [judgment_owner = "operator_keeper"] with the judgment's
+    summary/recommendation; otherwise emits
+    [judgment_owner = "fallback_read_model"] with the supplied
+    fallback summary and recommendations.
+
+    Returns the field list (not wrapped in [`Assoc]) so the caller
+    can splice it into a larger digest object. *)


### PR DESCRIPTION
## Summary

\`lib/operator/operator_digest_guidance.ml\` (87줄) 에 strict selective .mli 추가.

| 노출 (1 fn) | 숨김 (4 internal) |
|------|------|
| \`active_guidance_fields\` (digest composer) | \`normalize_target_type\` |
| | \`judgment_surface_for_target_type\` |
| | \`fresh_operator_judgment\` |
| | \`judgment_summary_json\` |

## Caller Audit

- \`lib/operator/operator_digest.ml\` — \`open Operator_digest_guidance\` 후 \`active_guidance_fields\`만 사용 (다른 4개 unused)
- \`test/test_operator_control_judgment.ml\` — \`active_guidance_fields\` 직접 호출
- 외부 caller가 다른 4개 helper를 사용하지 않음 → safe hide

## Type Sources

추측 회피, 코드 추적으로 확정:
- \`config\` → \`Coord.config\` (\`operator_dir → Coord.masc_dir\`)
- \`target_id\` → \`string option\` (test에서 \`~target_id:None\` verbatim)
- \`fallback_recommendations\` → \`Operator_digest_types.recommended_action list\`

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (-1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff