### PR TITLE
chore(opam): regenerate masc_mcp.opam to include ppxlib dep (5-SSOT sweep)

### DIFF
--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -34,6 +34,7 @@ depends: [
   "ppx_deriving_yojson" {>= "3.6"}
   "ppx_let" {>= "v0.17.0"}
   "ppx_deriving" {>= "5.2"}
+  "ppxlib" {>= "0.30"}
   "sqlite3" {>= "5.1"}
   "mirage-crypto" {>= "1.0"}
   "mirage-crypto-rng" {>= "1.0"}


### PR DESCRIPTION
## Summary

PR #11377 (\`feat(infra): add ppx_tla_derive PPX deriver\`) added \`(ppxlib (>= 0.30))\` to \`dune-project\` but did not regenerate/commit \`masc_mcp.opam\`. \`dune build\` regenerates the opam locally on every build, so the missing dep is invisible to in-repo development — but opam-resolver-driven installs (release smoke, downstream pins) silently miss \`ppxlib\`.

\`\`\`diff
   "ppx_deriving" {>= \"5.2\"}
+  \"ppxlib\" {>= \"0.30\"}
   \"sqlite3\" {>= \"5.1\"}
\`\`\`

Same pattern as PR #11429 (v0.18.7 → v0.18.8 sweep + V6 baseline) and exactly the case documented in \`feedback_masc-version-bump-five-ssot\`: when \`dune-project\` changes, the regenerated opam must be committed in the same PR.

## Why

\`dune-project\` is the SSOT for opam metadata. Local devs see \`M masc_mcp.opam\` after every \`dune build\` until this lands. Opam package consumers (CI release smoke, anyone pinning this opam package) currently get an under-specified depends list.

## Test plan

- [x] \`dune build masc_mcp.opam\` is idempotent on this branch (no further diff)
- [ ] CI Lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)