### PR TITLE
chore(types): expose 3 small util .mli files (otel/core/gate)

### DIFF
--- a/lib/core/executor_pool_ref.mli
+++ b/lib/core/executor_pool_ref.mli
@@ -1,0 +1,18 @@
+(** Executor_pool_ref — shared reference to the [Eio.Executor_pool].
+
+    Set once at server startup ([server_runtime_bootstrap.ml]); read
+    by dashboard compute and (future) chain adapter offloading. Backed
+    by [Atomic.t] (not a plain [ref]) so cross-domain workers see a
+    consistent view without explicit memory barriers. *)
+
+val get : unit -> Eio.Executor_pool.t option
+(** [None] before {!set} or in test environments without a pool. *)
+
+val set : Eio.Executor_pool.t -> unit
+(** Install the pool reference. Idempotent overwrite. *)
+
+val submit_or_inline : ?weight:float -> (unit -> 'a) -> 'a
+(** Run [f] on the executor pool when available, else inline in the
+    caller's fiber. [Eio.Cancel.Cancelled] is re-raised so structured
+    concurrency is preserved; other pool-side exceptions trigger
+    inline fallback with a warn log. *)

--- a/lib/gate/gate_time_util.mli
+++ b/lib/gate/gate_time_util.mli
@@ -1,0 +1,15 @@
+(** ISO-8601 timestamp helpers local to [masc_gate].
+
+    Kept here so the library does not depend on
+    [lib/server/server_utils.ml] (HTTP types) nor on [lib/types/]
+    (which would drag the whole [masc_types] surface in for a 17-line
+    helper). When Gate moves out of the MASC monolith (Track B4), the
+    remaining external deps reduce to yojson/eio/unix/fs_compat. *)
+
+val iso8601_of_unix : float -> string
+(** Format a Unix epoch timestamp as ["YYYY-MM-DDTHH:MM:SSZ"] (UTC). *)
+
+val parse_iso8601_opt : string -> float option
+(** Parse ["YYYY-MM-DDTHH:MM:SSZ"] back to a Unix epoch. Behavior is
+    byte-identical to [Types.parse_iso8601_opt] (intentional fork to
+    sever the [masc_types] dependency). *)

--- a/lib/otel/otel_config.mli
+++ b/lib/otel/otel_config.mli
@@ -1,0 +1,14 @@
+(** OTel Configuration — environment-derived OpenTelemetry setup.
+
+    Feature-flagged via [MASC_OTEL_ENABLED] (default: false). When
+    disabled, all span operations are no-ops with zero allocation. *)
+
+val enabled : bool
+(** [true] iff [MASC_OTEL_ENABLED] is ["true"] or ["1"]. *)
+
+val endpoint : string
+(** OTLP exporter endpoint from [OTEL_EXPORTER_OTLP_ENDPOINT], falling
+    back to {!Masc_network_defaults.otel_default_url}. *)
+
+val service_name : string
+(** [OTEL_SERVICE_NAME] or ["masc-mcp"]. *)


### PR DESCRIPTION
## Summary

3 small SSOT modules에 .mli 일괄 추가. 단순 surface + open consumer 0 + qualified-only caller 패턴 일치.

| 모듈 | 줄 수 | surface |
|------|-------|---------|
| \`lib/otel/otel_config\` | 17 | 3 vals (\`enabled\`, \`endpoint\`, \`service_name\`) |
| \`lib/core/executor_pool_ref\` | 35 | 3 vals (\`get\`, \`set\`, \`submit_or_inline\`) — internal \`Atomic.t\` 숨김 |
| \`lib/gate/gate_time_util\` | 33 | 2 vals (\`iso8601_of_unix\`, \`parse_iso8601_opt\`) |

## Caller Audit

- \`open\` consumer 0 (3개 모듈 모두)
- qualified usage 모두 .mli expose 함수만 사용
- \`executor_pool_ref\`의 internal \`pool\` Atomic은 외부 caller 0 → safe hide (cross-domain memory barrier invariant 보호)

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (-3). 다른 subdir 3개에 동시 효과.

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff