### PR TITLE
chore(ratchet): bump lib_dune_lines baseline 955 → 957 (sweep miss after #11365 + #11384)

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 10,
   "coord_mli_missing": 3,
   "godsplit_count": 0,
-  "lib_dune_lines": 955,
+  "lib_dune_lines": 957,
   "inferred_dump_headers": 6,
   "lib_other_mli_missing": 125
 }


### PR DESCRIPTION
## Summary

Bump \`lib_dune_lines\` baseline from 955 → 957 to unblock the merge queue.

## Why

Two recent PRs grew \`lib/dune\` by 1 line each but did not regenerate the ratchet baseline:
- #11384 — \`ppx_tla_derive\` PPX deriver wiring (1 line)
- #11365 — cascade per-provider latency ring buffer, PR 2/4 (1 line)

Baseline at #11323 was 955; current count on origin/main is 957. The drift slipped past CI because the ratchet script was silently exiting mid-loop on the \`count_inferred_dump_headers\` rg-pipefail bug — fix in flight as PR #11452. **Once #11452 lands, every PR touching lib/ will fail the ratchet on this 2-line drift.** This PR pre-empts that by bumping the baseline now.

Same downward-ratchet hygiene as:
- #11429 (V6-oas-orchestration 5 → 3)
- #11271 (re-baseline after legit lib growth, post 6-PR batch)

Cross-link: \`feedback_ratchet-naturalization-after-admin-merge\`.

## Verification

\`\`\`bash
bash scripts/ocaml-structure-ratchet.sh --print
# lib_dune_lines  current=957  baseline=957  → no drift
\`\`\`

## Test plan

- [x] \`scripts/ocaml-structure-baseline.json\` updated (1 char delta)
- [ ] Ratchet job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)