### PR TITLE
chore(types): expose 2 type-SSOT .mli (parsed, rate_limit_types)

### DIFF
--- a/lib/exec/parsed.mli
+++ b/lib/exec/parsed.mli
@@ -1,0 +1,37 @@
+(** Parsed — four-way result of the bash subset parser.
+
+    [Too_complex] is deliberately a polymorphic variant so the corpus
+    tap can aggregate frequencies per construct type after the
+    observation window (e.g. ["Cmd_subst > 30%"] -> promote in
+    Phase B). Pure type-SSOT module; no value surface. *)
+
+type reason_aborted =
+  [ `Timeout_50ms | `Depth_limit | `Token_limit_50k ]
+
+type reason_too_complex =
+  [ `Heredoc
+  | `Here_string
+  | `Cmd_subst
+  | `Proc_subst
+  | `Subshell
+  | `Arith_expansion
+  | `Control_flow
+  | `Logic_op
+  | `Function_def
+  | `Glob_brace
+  | `Background
+  | `Redirect
+  | `Unknown_construct of string
+  ]
+
+type parse_error = {
+  pos : Lexing.position;
+  token : string;
+  expected : string list;
+}
+
+type 'a t =
+  | Parsed of 'a
+  | Parse_error of parse_error
+  | Parse_aborted of reason_aborted
+  | Too_complex of reason_too_complex

--- a/lib/types/rate_limit_types.mli
+++ b/lib/types/rate_limit_types.mli
@@ -1,0 +1,35 @@
+(** Foundational rate limit types — kept here to avoid circular
+    dependencies between [masc_error] and the rate-limit consumers.
+
+    Re-exported by {!Masc_error} via [include module type of
+    Rate_limit_types]; downstream callers reach these types as
+    [Masc_error.rate_limit_*] / [Types.rate_limit_*] depending on the
+    re-export chain. *)
+
+(** Rate limit categories. *)
+type rate_limit_category =
+  | GeneralLimit
+  | BroadcastLimit
+  | TaskOpsLimit
+[@@deriving show { with_path = false }]
+
+(** Rate limit configuration record. *)
+type rate_limit_config = {
+  per_minute : int;
+  burst_allowed : int;
+  priority_agents : string list;
+  worker_multiplier : float;
+  admin_multiplier : float;
+  broadcast_per_minute : int;
+  task_ops_per_minute : int;
+}
+[@@deriving show]
+
+(** Returned when a rate limit is exceeded. *)
+type rate_limit_error = {
+  limit : int;
+  current : int;
+  wait_seconds : int;
+  category : rate_limit_category;
+}
+[@@deriving show]


### PR DESCRIPTION
## Summary

2 pure type-SSOT modules에 exhaustive mirror .mli 추가. 두 모듈 모두 함수 0, type 정의만.

| 모듈 | 줄 | type 수 | ppx |
|------|-----|---------|-----|
| \`lib/exec/parsed\` | 36 | 4 (2 polyvariant + 1 record + 1 GADT 4-variant) | 없음 |
| \`lib/types/rate_limit_types\` | 27 | 3 (1 variant + 2 record) | [@@deriving show] |

## Caller Audit

- **parsed**: 9 surface 모두 외부 사용 (\`Parsed.t\`, \`Parsed.Parsed\`, \`Parsed.parse_error\`, etc.)
- **rate_limit_types**: 직접 caller 0이지만 \`lib/types/masc_error.mli\`가 \`include module type of Rate_limit_types\`로 surface propagate. .mli mirror 추가 시 surface 변경 0.

## Skip Note

\`lib/prompt_registry/prompt_registry_store.ml\` (29줄)도 후보였지만 record \`t\`가 mutable Hashtbl ×4 + Mutex + ref ×2로 caller (\`prompt_registry.ml\`)가 모든 6 fields 직접 접근. abstract type \`type t\` 불가 → \`.mli\` expose가 record 전체 노출이라 information hiding 가치 0. 별도 ROI 검토 후 진행.

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (-2).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff