### PR TITLE
feat(keeper): include cascade_name in 4 agent_run error/warn logs

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2218,7 +2218,7 @@ let run_turn
              (String.concat ", " unexpected_tool_names)
          in
          receipt_tool_contract_result_ref := "violated";
-         Log.Keeper.error "keeper:%s %s" meta.name reason;
+         Log.Keeper.error "keeper:%s cascade=%s %s" meta.name meta.cascade_name reason;
          Error (Oas.Error.Internal reason)
        else (
          let should_log_unexpected_tool_partial =
@@ -2552,10 +2552,10 @@ let run_turn
                 with
                 | Ok () -> ()
                 | Error e ->
-                  Log.Keeper.error "keeper:%s OAS checkpoint save failed: %s" meta.name e);
+                  Log.Keeper.error "keeper:%s cascade=%s OAS checkpoint save failed: %s" meta.name meta.cascade_name e);
                Some patched
              | None ->
-               Log.Keeper.error "keeper:%s missing OAS checkpoint after run" meta.name;
+               Log.Keeper.error "keeper:%s cascade=%s missing OAS checkpoint after run" meta.name meta.cascade_name;
                None
            in
            (match result.proof with
@@ -2676,8 +2676,8 @@ let run_turn
             with
             | Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
-                Log.Keeper.warn "keeper:%s compaction failed: %s" meta.name
-                  (Printexc.to_string exn));
+                Log.Keeper.warn "keeper:%s cascade=%s compaction failed: %s" meta.name
+                  meta.cascade_name (Printexc.to_string exn));
            (* Post-turn quality metrics — goal alignment + memory recall.
              Logged to decisions.jsonl for feedback loop analysis. *)
            (try


### PR DESCRIPTION
## Summary
PR #11436 / #11446에 이은 cascade context 진단 인프라 확장. \`keeper_agent_run.ml\` \`run_turn\`의 4 error/warn 메시지에 cascade=<name> 추가:

| Line | Message | Trigger |
|---|---|---|
| 2221 | unexpected tool names violation | tool surface contract 위반 |
| 2555 | OAS checkpoint save failed | session checkpoint 저장 실패 |
| 2558 | missing OAS checkpoint after run | turn 후 checkpoint 부재 |
| 2679 | compaction failed | memory compaction exception |

## Why
PR #11436 (stale_keeper_broadcast) + #11446 (semaphore-wait skip)이 watchdog/keepalive 진단 메시지에 cascade context를 추가했습니다. agent_run 영역의 OAS turn 실패 메시지 4건은 동일 이유로 가장 빈번한 디버깅 grep 대상인데 cascade attribution 부재. 같은 진단 강화 의도, 동일 surgical 패턴.

\`meta : keeper_meta\` 타입 (keeper_types.mli:167)이 4 사이트 모두 in scope → 추가 plumbing 없음.

## Test plan
- [ ] CI Build/Lint/Runtest 통과 (main 직접 base, 22 PR pile-up과 무관)
- [ ] (post-merge) tool surface violation / OAS checkpoint failure 발생 시 cascade= 인라인 검증

## 미검증
- 로컬 dune build 미수행: GH Actions에 위임.
- Format string 변경만, signature/schema 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)