### PR TITLE
chore(types): expose otel_dispatch_hook surface

### DIFF
--- a/lib/otel/otel_dispatch_hook.mli
+++ b/lib/otel/otel_dispatch_hook.mli
@@ -1,0 +1,22 @@
+(** OTel Dispatch Hook — registers a [Tool_dispatch] post-hook that
+    records each tool call as both a Prometheus histogram observation
+    (always active) and an OpenTelemetry span (gated by
+    {!Otel_config.enabled}).
+
+    Span attributes are dual-emitted: legacy [tool.*] keys for
+    existing custom dashboards, and OpenTelemetry GenAI semantic
+    convention keys ([gen_ai.tool.name], [gen_ai.operation.name]) so
+    Datadog v1.37+/Grafana auto-categorise these spans as AI/LLM
+    activity. The dual-emit also hedges against semconv churn while
+    GenAI fields remain Stability.Experimental.
+
+    Internal helper [on_tool_result] is intentionally hidden — the
+    hook is registered through {!install} once at startup, after
+    which dispatch invokes it implicitly.
+
+    @since 2.103.0 *)
+
+val install : unit -> unit
+(** Register {!on_tool_result} as a [Tool_dispatch] post-hook.
+    Idempotent at the call site (calling twice would register the
+    callback twice — server bootstrap calls it exactly once). *)


### PR DESCRIPTION
## Summary

\`lib/otel/otel_dispatch_hook.ml\` (57줄) 에 strict selective .mli 추가. \`install\` 1개만 expose.

| 노출 | 숨김 |
|------|------|
| \`install : unit -> unit\` | \`on_tool_result\` (post-hook callback, 외부 caller 0) |
| | \`module OT = Opentelemetry\` (internal alias) |

## Caller Audit

- \`Otel_dispatch_hook.install\` — server bootstrap 1회 호출
- \`on_tool_result\`은 \`Tool_dispatch\` post-hook callback이라 implicit invoke만, 외부 직접 호출 0

## Skip Note

\`lib/activity_graph/activity_graph_registry.ml\` (69줄)도 후보였지만 \`activity_graph.ml\`이 \`include\` 패턴 + \`clients\` Hashtbl 직접 접근 + record field mutable update로 caller가 internal state 통째로 의존. abstract 불가, .mli expose 시 information hiding 가치 0. cycle 27 \`prompt_registry_store\` 스킵과 같은 패턴 — 별도 ROI 검토.

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (-1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff