### PR TITLE
chore(types): expose goal_phase state machine surface

### DIFF
--- a/lib/goal/goal_phase.mli
+++ b/lib/goal/goal_phase.mli
@@ -1,0 +1,67 @@
+(** Goal_phase — state machine SSOT for goal lifecycle.
+
+    Encodes the seven phases a goal can be in, the operator/system
+    actions that drive transitions, and the deterministic decision
+    function {!decide_transition}. Used by the goal subsystem to keep
+    transition logic out of caller code. *)
+
+(** Goal lifecycle phases. *)
+type t =
+  | Executing
+  | Awaiting_verification
+  | Awaiting_approval
+  | Blocked
+  | Paused
+  | Completed
+  | Dropped
+
+val to_string : t -> string
+(** Lowercase canonical name ([Executing -> "executing"], …). *)
+
+val of_string : string -> t option
+(** Inverse of {!to_string}. Returns [None] for unknown input. *)
+
+val parse : string -> t option
+(** Like {!of_string} but trims whitespace and lowercases first. *)
+
+val to_yojson : t -> Yojson.Safe.t
+
+val of_yojson : Yojson.Safe.t -> (t, string) result
+
+(** Operator / system actions that may drive a transition. *)
+type action =
+  | Request_complete
+  | Approve_completion
+  | Reject_completion
+  | Pause
+  | Resume
+  | Operator_block
+  | Operator_unblock
+  | Drop
+  | Reopen
+
+val action_to_string : action -> string
+val action_of_string : string -> action option
+val parse_action : string -> action option
+
+(** Outcome of {!decide_transition}. [Move_to] is a direct phase
+    change; [Open_verification] / [Open_approval] gate completion
+    behind verifier or operator review; [Complete] is the terminal
+    success transition. *)
+type transition_outcome =
+  | Move_to of t
+  | Open_verification
+  | Open_approval
+  | Complete
+
+val decide_transition :
+  phase:t ->
+  action:action ->
+  has_effective_verifier_policy:bool ->
+  require_completion_approval:bool ->
+  (transition_outcome, string) result
+(** Pure transition decider. Returns [Error msg] for invalid
+    [(phase, action)] pairs (the message names both for diagnostics).
+    [Awaiting_verification] mirrors [Awaiting_approval] outcomes for
+    verifier verdicts (#10411 fix — verification-pinned goals could
+    not exit before this). *)


### PR DESCRIPTION
## Summary

\`lib/goal/goal_phase.ml\` (125줄, goal lifecycle state machine SSOT) 에 exhaustive mirror .mli 추가.

| 노출 | 설명 |
|------|------|
| \`type t\` (7 variants) | 7-phase lifecycle (Executing/Awaiting_verification/Awaiting_approval/Blocked/Paused/Completed/Dropped) |
| \`type action\` (9 variants) | 9 operator/system actions |
| \`type transition_outcome\` (4 variants) | Move_to / Open_verification / Open_approval / Complete |
| 9 fns | to_string, of_string, parse, to_yojson, of_yojson, action_*, parse_action, decide_transition |

## Caller Audit

28 surface 모두 외부 사용 (모든 variants + 9 fns). open consumer 0.

## Type Sources

\`decide_transition\` 시그니처:
\`\`\`ocaml
val decide_transition :
  phase:t ->
  action:action ->
  has_effective_verifier_policy:bool ->
  require_completion_approval:bool ->
  (transition_outcome, string) result
\`\`\`

#10411 코멘트 docblock에 보존 — \`Awaiting_verification\`이 \`Awaiting_approval\`을 mirror하도록 fix된 history.

## Strategy

State machine SSOT은 selective hide 불가 — 모든 variant + transition fn이 외부 surface. 메모리 \`feedback_mli_exposure_strategy_by_module_size\` exhaustive mirror category.

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (-1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff