### PR TITLE
[DS-Drift Track B] add --ok-35 alpha stop (fix .pulse-working border)

### DIFF
--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -78,6 +78,7 @@
   --ok-soft: rgba(74, 222, 128, 0.15);
   --ok-10: rgba(74, 222, 128, 0.10);
   --ok-20: rgba(74, 222, 128, 0.20);
+  --ok-35: rgba(74, 222, 128, 0.35);
 
   /* Semantic - Warning (Yellow) */
   --warn-bright: #f97316;


### PR DESCRIPTION
## Summary

Production bug fix discovered in DS-Drift W06 audit (PR #11324):
`dashboard/src/styles/live-monitor.css:11` references `var(--ok-35)`
which was never defined → `.pulse-working` border-color resolved to `unset`.

## Root cause

`dashboard/src/styles/variables.css` defines an ok-alpha ladder:
- `--ok-soft: rgba(74, 222, 128, 0.15)` (15%)
- `--ok-10: rgba(74, 222, 128, 0.10)`
- `--ok-20: rgba(74, 222, 128, 0.20)`

The 35% stop was consumed by live-monitor.css but never declared.

## Fix

Single-line addition in `variables.css`, matching the existing pattern:

\`\`\`css
--ok-35: rgba(74, 222, 128, 0.35);
\`\`\`

## Why variables.css and not source.ts

`--ok-35` belongs to the **alpha-ladder system** (`--ok-soft/-10/-20/-35`)
which lives in `variables.css` (the "live surface bright" SSOT, see
audit `2026-04-28-production-css-drift.md`). It is not a `--color-*`
canonical token, so `tokens/source.ts` codegen is not the right surface.

This keeps the fix surgical (1 file, 1 line) and consistent with the
existing variables.css convention.

## Verification

- `rg -n '\-\-ok-35' dashboard/src/styles/variables.css` → defined at line 81
- `rg -n '\-\-ok-35' dashboard/src/styles/live-monitor.css` → still references at line 11 (now resolves correctly)
- No other files reference `--ok-35`
- variables.css token alias names preserved — 30+ production CSS that consume `var(--ok-*)` continue to work unchanged

## Files changed

- `dashboard/src/styles/variables.css` (+1 line)

## Track context

Part of DS-Drift cleanup. Track A (preview nav governance) is parallel
work in `feature/ds-drift-track-a-nav` (handled separately).
Tracks C/D (variables.css → source.ts lift, production var() sweep)
remain pending sub-agent dispatch.