### PR TITLE
fix(coord): repair dormant main lint - health_result + Types facade

### DIFF
--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -44,7 +44,7 @@ val observe_agent_lifecycle_fn : (Coord_utils_backend_setup.config ->
 val observe_task_transition_fn : (Coord_utils_backend_setup.config ->
             agent_name:string ->
             task_id:string ->
-            transition:Types_core.task_action ->
+            transition:Types.task_action ->
             details:Yojson.Safe.t -> unit)
            Atomic.t
 val cleanup_board_artifacts_fn : (unit -> int) Atomic.t

--- a/lib/coord/coord_utils_paths_backend.mli
+++ b/lib/coord/coord_utils_paths_backend.mli
@@ -74,7 +74,7 @@ val backend_extend_lock :
   (bool, Backend_types.error) result
 
 val backend_health_check :
-  config -> (Backend_types.health_status, Backend_types.error) result
+  config -> (Backend_types.health_result, Backend_types.error) result
 
 val backend_publish :
   config -> channel:string -> message:string ->


### PR DESCRIPTION
## Summary

Main 의 lint 깨짐 2건 dormant. 두 file 변경하는 다음 PR 에서 expose 될 위험.

| File | Line | Before | After | Cause |
|------|------|--------|-------|-------|
| `lib/coord/coord_utils_paths_backend.mli` | 77 | `Backend_types.health_status` | `Backend_types.health_result` | typo — Backend_types 에 `health_status` 없음 |
| `lib/coord/coord_hooks.mli` | 47 | `Types_core.task_action` | `Types.task_action` | facade drift — `.ml` 은 `open Types` 사용 (#11418 facade 머지 후 nominal 불일치) |

## 발견 경위

PR #11455 (closed, escape fix 는 #11447 에 흡수) 의 empty commit re-trigger 가 path filter 우회 → Lint job 전체 실행 → 두 dormant breakage expose. PR #11447 lint gate 는 escape 만 잡고 OCaml typer 차원의 type drift 는 잡지 못함.

## 영향

- 현재 main 빌드 가능 (path-filtered lint job 이 두 file 안 건드는 PR 에서 SKIP)
- 두 file 중 하나 변경하는 PR 들어오는 순간 lint expose → false positive 로 무관한 PR blocked

## 검증

- `Backend_types.mli` 직접 inspect → `health_result` 만 정의 (`health_status` 없음)
- `coord_hooks.ml:114` line `open Types` 후 unqualified `task_action` 사용 → ml 의 inferred type 은 `Types.task_action`
- 두 fix 모두 alias resolution 만으로 type-check 통과

## Test plan

- [ ] CI Lint job pass (path filter 우회 — `lib/coord/*.mli` 변경)
- [ ] Build + OCaml Structure Ratchet pass
- [x] root cause 검증 완료 (Backend_types/coord_hooks.ml 직접 inspect)

## 후속

memory `feedback_required-check-must-include-lint.md` 패턴 — branch protection 의 required check 에 Lint 포함하면 재발 방지. 별도 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)