### PR TITLE
chore(dashboard): clear bg/border-white-alpha drift residue

### DIFF
--- a/dashboard/src/components/common/id-pill.ts
+++ b/dashboard/src/components/common/id-pill.ts
@@ -22,10 +22,10 @@
 //   different pill shape (name tag, not id badge). P7 rounded
 //   sweep.
 // • agent-detail:228 (unified.description) — neutral tone with
-//   drifted opacities (bg-[var(--white-5)] border-white/10). Needs a
+//   drifted opacities (bg-[var(--white-N)] border-white/N). Needs a
 //   neutral tone variant which itself has drift vs line 230
-//   (mono version: reversed bg-white/10 border-white/5). Both
-//   belong in P6 color normalisation.
+//   (mono version: reversed bg/border alpha pair). Both belong
+//   in P6 color normalisation.
 // • agent-detail:230 (agent.model) — mono neutral pill with
 //   reversed opacities to 228. P6.
 // • agent-detail-worker:45 (signal_truth) — `rounded-sm` with

--- a/scripts/dashboard-drift-baseline.json
+++ b/scripts/dashboard-drift-baseline.json
@@ -1,8 +1,8 @@
 {
   "_comment": "Dashboard styling-drift baseline. Regenerate with scripts/dashboard-drift-check.sh --regenerate.",
   "_patterns": "See scripts/dashboard-drift-check.sh PATTERNS array.",
-  "bg-white-alpha": 1,
-  "border-white-alpha": 2,
+  "bg-white-alpha": 0,
+  "border-white-alpha": 0,
   "text-zinc": 0,
   "bg-zinc": 0,
   "border-zinc": 0,


### PR DESCRIPTION
## Summary

3건의 'residue'가 실제 callsite drift가 아닌 `id-pill.ts` P6 audit-trail 주석에 박힌 raw class literal이었음 (lint regex가 comment-aware하지 않음).

| pattern | before | after |
|---|---|---|
| bg-white-alpha | 1 | 0 |
| border-white-alpha | 2 | 0 |

`bg-white/10` / `border-white/5` 등 구체 magic number를 `bg-white/N` / `border-white/N` generic 표기로 변경. P6 audit 의도는 보존(어느 callsite에 drift 있는지 명시), 다만 specific alpha bucket은 P6 sweep에서 변할 수 있어 generic이 더 정확한 표현이기도 함.

baseline regen으로 floor lock (1,2 → 0,0).

## Test plan

- [x] `bash scripts/dashboard-drift-check.sh --print` — bg/border-white-alpha 둘 다 current=0
- [x] `git diff` — 의도 외 변경 없음 (주석 5줄 + baseline 2줄)
- 관련: Ring atom audit-bucket-cascade 후속, 자연 ratchet floor 정리.