### PR TITLE
fix(coord): qualify Types_core.task_action in coord_hooks.ml (main-broken)

### DIFF
--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -115,7 +115,7 @@ let observe_task_transition_fn
   : (Coord_utils_backend_setup.config ->
      agent_name:string ->
      task_id:string ->
-     transition:task_action ->
+     transition:Types_core.task_action ->
      details:Yojson.Safe.t ->
      unit) Atomic.t
   = Atomic.make


### PR DESCRIPTION
## Summary

main is currently broken — every PR's CI fails on this `.mli`/`.ml` mismatch. 1-line fix.

`lib/coord/coord_hooks.ml:118` uses unqualified `task_action` (resolved via `open Types`), but `coord_hooks.mli:47` declares `transition:Types_core.task_action`. After PR #11418 (`refactor(types): add types.mli (facade re-export)`) introduced an explicit `types.mli` with `include module type of Types_core`, the OCaml signature check started treating the qualified vs unqualified spellings as incompatible at the interface boundary.

## Reproducer

```bash
git checkout main && dune build lib/coord/
```

```
File "lib/coord/coord_hooks.mli", lines 44-49, characters 0-19:
  Expected declaration
File "lib/coord/coord_hooks.ml", line 114, characters 4-30:
  Actual declaration
Type Types.task_action is not compatible with type Types_core.task_action
```

## Fix

Single-line change to fully qualify the .ml type, matching the canonical spelling already used in the .mli (since `cbfe1e38063` / PR #10781).

## Out of scope

Two other main-broken errors observed but not addressed here (separate PRs):

- `lib/coord/coord_utils_paths_backend.mli:77` — `Unbound type constructor Backend_types.health_status`
- `ppx_tla/ppx_tla.ml:257` — `Pexp_fun` constructor missing (ppxlib version mismatch)

## Verification

- `dune build lib/coord/coord_hooks.ml` exit 0
- `dune build lib/coord/` advances past coord_hooks (now blocks on the separate Backend_types issue, addressed in follow-up PR)

## Test plan

- [x] Local single-file build green
- [ ] CI green on this PR
- [ ] BLOCKED PR queue (~29 PRs) starts unblocking once this lands + the two follow-ups
