### PR TITLE
fix(lint): replace docstring escape-quote in server_routes_http_routes_verification.mli

### DIFF
--- a/lib/server/server_routes_http_routes_verification.mli
+++ b/lib/server/server_routes_http_routes_verification.mli
@@ -13,8 +13,8 @@ val add_routes :
 
 val verifier_of_request :
   base_path:string -> Httpun.Request.t -> string
-(** Derive the [\"operator:<actor>\"] verifier identity for a resolve
-    request. Falls back to [\"operator:dashboard\"] when no
+(** Derive the ["operator:<actor>"] verifier identity for a resolve
+    request. Falls back to ["operator:dashboard"] when no
     sanitizable actor hint is present. Tested directly by
     [test_dashboard_http_core] for the token-owner canonicalization
     path. *)


### PR DESCRIPTION
## Summary
- Replace `[\"operator:<actor>\"]` with `["operator:<actor>"]` in `server_routes_http_routes_verification.mli:16`
- Bare `\"` inside `(** *)` docstring puts the OCaml lexer into string mode, flagged by `no-docstring-escape-quote.sh` lint gate
- Follow-up to #11473 which fixed 2 .mli type drifts but missed this docstring lint violation

## Test plan
- [ ] Lint job passes (no-docstring-escape-quote.sh)
- [ ] Build unchanged (comment-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)