### PR TITLE
[DS-Drift Track D-1] tokenize vote button colors (board + dashboard drift)

### DIFF
--- a/dashboard/src/styles/board.css
+++ b/dashboard/src/styles/board.css
@@ -13,9 +13,9 @@
 /* Vote column */
 @utility vote-btn {
   transition: color 0.2s;
-  &:hover { color: #ccc; }
-  &.upvote:hover, &.upvote.active { color: #ff4500; }
-  &.downvote:hover, &.downvote.active { color: #7193ff; }
+  &:hover { color: var(--vote-hover); }
+  &.upvote:hover, &.upvote.active { color: var(--vote-up); }
+  &.downvote:hover, &.downvote.active { color: var(--vote-down); }
   &.animate { animation: votePop 0.3s ease; }
 }
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -94,9 +94,9 @@
 /* Vote column */
 @utility vote-btn {
   transition: color 0.2s;
-  &:hover { color: #ccc; }
-  &.upvote:hover, &.upvote.active { color: #ff4500; }
-  &.downvote:hover, &.downvote.active { color: #7193ff; }
+  &:hover { color: var(--vote-hover); }
+  &.upvote:hover, &.upvote.active { color: var(--vote-up); }
+  &.downvote:hover, &.downvote.active { color: var(--vote-down); }
   &.animate { animation: votePop 0.3s ease; }
 }
 

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -86,6 +86,13 @@
   --warn-10: rgba(251, 191, 36, 0.10);
   --warn-20: rgba(251, 191, 36, 0.20);
 
+  /* Vote button — Reddit-pattern colors used identically in board.css
+     and dashboard.css. Tokenized to remove the cross-file duplication;
+     hex values preserved exactly (Reddit upvote = #ff4500). */
+  --vote-hover: #ccc;
+  --vote-up: #ff4500;
+  --vote-down: #7193ff;
+
   /* Semantic - Critical (Red) */
   --bad-light: #f87171;
   --bad-soft: rgba(239, 68, 68, 0.15);


### PR DESCRIPTION
## Summary

First surgical hex consolidation under Track D (DS-Drift Phase 2 production var() 치환).

\`board.css\` 16-18 과 \`dashboard.css\` 97-99 가 **identical 한 3-hex \`@utility vote-btn\` 블록**을 보유 — 진짜 cross-file drift (same values, two SSOTs).

## Drift evidence

\`\`\`
board.css:16:  &:hover { color: #ccc; }
board.css:17:  &.upvote:hover, &.upvote.active { color: #ff4500; }
board.css:18:  &.downvote:hover, &.downvote.active { color: #7193ff; }
dashboard.css:97:  &:hover { color: #ccc; }
dashboard.css:98:  &.upvote:hover, &.upvote.active { color: #ff4500; }
dashboard.css:99:  &.downvote:hover, &.downvote.active { color: #7193ff; }
\`\`\`

## Change

variables.css 에 3 alias 추가 (CSS-ARCHITECTURE.md two-tier governance 의 \"live-surface bright SSOT\"), 두 call site 를 var() 로 치환.

\`\`\`css
/* variables.css */
--vote-hover: #ccc;
--vote-up: #ff4500;     /* Reddit upvote brand color, intentional */
--vote-down: #7193ff;
\`\`\`

Hex 값 정확히 보존 — Reddit upvote 의 \`#ff4500\` 은 brand color 로서 의도된 값.

## Verification

- Raw hex 잔존: 0 (variables.css 정의 + 주석 안의 #ff4500 만)
- Files: variables.css +7, board.css 0/0 (3 hex -> 3 var()), dashboard.css 0/0 (3 hex -> 3 var())
- Total: 3 files, +13/-6
- 색상 시각적 동일 (exact hex preserved)

## Track context

| PR | Track |
|----|-------|
| #11471 (merged) | B `--ok-35` bug fix |
| #11472 (merged) | A nav governance |
| #11475 (merged) | E SSOT governance docs |
| **this** | **D-1 vote buttons** |

Track D 잔여 (per-hex review):
- chat.css 7 hex (role-tinted bubbles)
- ops.css 2 hex (Tailwind red-200/cyan-200)
- global.css 3 hex (muted slate idle/offline/todo)
- base.css 1 hex (gradient stop)
- live-monitor.css 1 hex (purple-500)
- a11y.css 2 hex = excluded (이미 var() fallback)