### PR TITLE
[DS-Drift Track D-2] tokenize chat role text colors (7 hex)

### DIFF
--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -34,34 +34,34 @@
   &.user {
     border-color: rgba(71, 184, 255, 0.28);
     background: var(--color-accent-soft);
-    color: #d8f0ff;
+    color: var(--chat-user-avatar);
   }
   &.assistant {
     border-color: rgba(167, 139, 250, 0.3);
     background: rgba(167, 139, 250, 0.18);
-    color: #efe6ff;
+    color: var(--chat-assistant-avatar);
   }
   &.error {
     border-color: rgba(239, 68, 68, 0.32);
     background: rgba(239, 68, 68, 0.18);
-    color: #ffe1e1;
+    color: var(--chat-error-avatar);
   }
 }
 
 @utility chat-role-chip {
   &.user {
     border-color: rgba(71, 184, 255, 0.32);
-    color: #c9ebff;
+    color: var(--chat-user-chip);
     background: var(--accent-14);
   }
   &.assistant {
     border-color: rgba(167, 139, 250, 0.32);
-    color: #ded0ff;
+    color: var(--chat-assistant-chip);
     background: rgba(167, 139, 250, 0.14);
   }
   &.error {
     border-color: rgba(239, 68, 68, 0.35);
-    color: #ffb4b4;
+    color: var(--chat-error-chip);
     background: rgba(239, 68, 68, 0.14);
   }
 }
@@ -76,7 +76,7 @@
     font-family: "Fira Code", monospace;
     font-size: var(--fs-xs);
     line-height: 1.55;
-    color: #95f3bc;
+    color: var(--chat-code-callout);
   }
 }
 

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -93,6 +93,17 @@
   --vote-up: #ff4500;
   --vote-down: #7193ff;
 
+  /* Chat role tinting — light text shades for avatar + role-chip per role.
+     avatar vs chip use deliberately distinct shades (not a typo); preserve
+     hex exactly. Source-of-truth lives here (chat.css consumes via var()). */
+  --chat-user-avatar: #d8f0ff;
+  --chat-user-chip: #c9ebff;
+  --chat-assistant-avatar: #efe6ff;
+  --chat-assistant-chip: #ded0ff;
+  --chat-error-avatar: #ffe1e1;
+  --chat-error-chip: #ffb4b4;
+  --chat-code-callout: #95f3bc;
+
   /* Semantic - Critical (Red) */
   --bad-light: #f87171;
   --bad-soft: rgba(239, 68, 68, 0.15);


### PR DESCRIPTION
## Summary

Track D 두 번째 surgical hex consolidation. \`chat.css\` 의 7 raw hex 를 variables.css 의 chat-* 토큰으로 치환.

## Hex inventory + decision

| Hex | Role | Utility | Token |
|-----|------|---------|-------|
| #d8f0ff | user | chat-avatar | --chat-user-avatar |
| #efe6ff | assistant | chat-avatar | --chat-assistant-avatar |
| #ffe1e1 | error | chat-avatar | --chat-error-avatar |
| #c9ebff | user | chat-role-chip | --chat-user-chip |
| #ded0ff | assistant | chat-role-chip | --chat-assistant-chip |
| #ffb4b4 | error | chat-role-chip | --chat-error-chip |
| #95f3bc | (code) | chat-detail-callout pre | --chat-code-callout |

avatar vs chip 가 동일 role 에서 미묘하게 다른 hex (예: user avatar \`#d8f0ff\` vs user chip \`#c9ebff\`) — typo 가 아닌 의도된 미세 차이. 강제 통합 시 색상 시프트 발생하므로 7 토큰 분리 보존.

## Why variables.css and not source.ts

Per CSS-ARCHITECTURE.md two-tier governance (PR #11475):
- source.ts = muted canon SSOT (codegen)
- variables.css = live-surface bright SSOT (Tailwind 400/500 family)

chat role tinting 은 dashboard 의 live-surface 색상 — variables.css 가 맞는 위치.

## Verification

- chat.css raw hex 잔존: 0
- variables.css +11 lines (7 tokens + comment block)
- 색상 시각적 동일 (exact hex preserved)

## Files

- \`dashboard/src/styles/variables.css\` (+11)
- \`dashboard/src/styles/chat.css\` (7 hex -> 7 var(), +7/-7)

## Track context

| PR | Track | 변경 |
|----|-------|------|
| #11486 (merged) | D-1 vote buttons | board+dashboard 3 hex × 2 |
| **this** | **D-2 chat roles** | chat 7 hex |

Track D 잔여 (per-hex review):
- ops.css 2 hex (Tailwind red-200/cyan-200)
- global.css 3 hex (muted slate idle/offline/todo)
- base.css 1 hex (gradient stop, 보존 권장)
- live-monitor.css 1 hex (purple-500)