### PR TITLE
feat(ppx-tla): Tier I3 smoke — keeper_turn_fsm.require_active_state + PPX OCaml 5.4 fix

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -106,3 +106,15 @@ let emit_transition ~keeper_name ~turn_id ?prev state =
         ("keeper", keeper_name);
       ]
     ()
+
+(* Cycle 12 / Tier I3 smoke test: first real-module use of [@@fsm_guard].
+
+   [require_active_state] is the identity on its argument; the [@@fsm_guard]
+   payload is parsed by [ppx_tla] and injected as a runtime [assert] at
+   the function body entry. The invariant — turn states that have
+   already terminated must not re-enter execution paths — was previously
+   only guarded by reviewer-eye inspection of call sites. *)
+
+let require_active_state s = s
+[@@fsm_guard
+  "match s with Done | Failed _ | Cancelled _ -> false | _ -> true"]

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -73,6 +73,16 @@ val pp_cancel_reason : Format.formatter -> cancel_reason -> unit
 val pp_failure_reason : Format.formatter -> failure_reason -> unit
 val pp_turn_state : Format.formatter -> turn_state -> unit
 
+val require_active_state : turn_state -> turn_state
+(** Identity on [s]; runtime-asserts that [s] is not a terminal state
+    ([Done], [Failed _], [Cancelled _]).
+
+    Cycle 12 / Tier I3 smoke test for the [@@fsm_guard "..."] PPX:
+    this is the first real-module use that the rewriter operates on.
+    The assert lands in the function body via [ppx_tla] so the runtime
+    cost is one match per call. Adopt at sites that enter execution
+    paths assuming the turn is still in flight. *)
+
 val emit_transition :
   keeper_name:string ->
   turn_id:int ->

--- a/ppx_tla/ppx_tla.ml
+++ b/ppx_tla/ppx_tla.ml
@@ -252,16 +252,29 @@ let parse_guard_expression ~loc s =
       "[@@fsm_guard]: payload is not a valid OCaml boolean expression: %S"
       s
 
-let rec inject_into_body assert_expr expr =
+(* OCaml 5.4 / ppxlib 0.37 unified function representation:
+   [Pexp_function (params, constraint_, body)] where [body] is either
+   [Pfunction_body expr] (right-hand expression of [let f x y = expr])
+   or [Pfunction_cases cases] (pattern-matching [function]).
+
+   For [Pfunction_body], inject the assert at the head of [expr] so the
+   guard fires per application of the innermost lambda — partial
+   applications do not trigger.
+
+   For [Pfunction_cases] and non-function expressions, sequence the
+   assert before the expression itself; the timing differs (per
+   binding-creation rather than per call) but no equivalent injection
+   point is portable across the unified representation. *)
+let inject_into_body assert_expr expr =
   match expr.pexp_desc with
-  | Pexp_fun (label, default, pat, body) ->
-      let new_body = inject_into_body assert_expr body in
-      { expr with pexp_desc = Pexp_fun (label, default, pat, new_body) }
-  | Pexp_function _ ->
-      (* OCaml 5.4 pexp_function with parameter list — wrap whole expr
-         since unwrapping the parameter list is non-portable. The runtime
-         semantics are the same as for non-function bindings. *)
-      Ast_builder.Default.pexp_sequence ~loc:expr.pexp_loc assert_expr expr
+  | Pexp_function (params, constraint_, Pfunction_body body) ->
+      let new_body =
+        Ast_builder.Default.pexp_sequence ~loc:body.pexp_loc
+          assert_expr body
+      in
+      { expr with
+        pexp_desc =
+          Pexp_function (params, constraint_, Pfunction_body new_body); }
   | _ ->
       Ast_builder.Default.pexp_sequence ~loc:expr.pexp_loc assert_expr expr
 

--- a/test/ppx_tla/test_basic.ml
+++ b/test/ppx_tla/test_basic.ml
@@ -90,6 +90,49 @@ let test_mixed_all_symbols () =
     Mixed.all_symbols
     = [ "awaiting_provider"; "awaiting_tool"; "failed"; "cancelled" ])
 
+(* Cycle 12 (PR #11450): [@@fsm_guard "expr"] runtime assertion injection.
+   The guard is parsed as an OCaml boolean expression at PPX time and
+   injected as [assert (...)] into the function body. For curried
+   bindings the assert lands in the innermost lambda so it fires per
+   application, not per partial application. *)
+
+let f_with_guard x = x + 1
+[@@fsm_guard "x >= 0"]
+
+let test_fsm_guard_pass () =
+  assert (f_with_guard 5 = 6);
+  assert (f_with_guard 0 = 1)
+
+let test_fsm_guard_fail () =
+  let raised =
+    try
+      ignore (f_with_guard (-1));
+      false
+    with Assert_failure _ -> true
+  in
+  assert raised
+
+(* Curried form: assert lands in the innermost lambda body so it fires
+   only when the second argument is applied, not when [g_curried 100] is
+   partially evaluated. *)
+
+let g_curried a b = a + b
+[@@fsm_guard "a + b >= 0"]
+
+let test_fsm_guard_curried_pass () =
+  assert (g_curried 2 3 = 5);
+  let _partial = g_curried 100 in
+  ()
+
+let test_fsm_guard_curried_fail () =
+  let raised =
+    try
+      ignore (g_curried 1 (-5));
+      false
+    with Assert_failure _ -> true
+  in
+  assert raised
+
 let () =
   test_color_to_tla_symbol ();
   test_color_all_states ();
@@ -100,4 +143,8 @@ let () =
   test_mixed_to_tla_symbol_override ();
   test_mixed_to_tla_symbol_parameterised ();
   test_mixed_all_symbols ();
-  print_endline "ppx_tla cycle 2 + 3 tests: PASS"
+  test_fsm_guard_pass ();
+  test_fsm_guard_fail ();
+  test_fsm_guard_curried_pass ();
+  test_fsm_guard_curried_fail ();
+  print_endline "ppx_tla cycle 2 + 3 + 12 tests: PASS"


### PR DESCRIPTION
## Summary

Cycle 13/14 of the Kimi keeper FSM review /loop, finishing the Tier I3 work whose scaffold landed in PR #11450 (now MERGED).

Three commits, ordered by build dependency:

1. **`fix(ppx_tla)`** — repairs the OCaml 5.4 / ppxlib 0.37 incompatibility that left `main` itself unable to compile `ppx_tla/`. PR #11450 was admin-merged in a state that depended on the legacy `Pexp_fun` constructor; ppxlib 0.37 unifies it into `Pexp_function (params, constraint_, Pfunction_body | Pfunction_cases)`. The fix matches `Pfunction_body body` directly and injects the assert at the head of `body`, preserving the original "fire per innermost-lambda application" semantics.

2. **`test(ppx_tla)`** — adds four `[@@fsm_guard]` unit tests in `test/ppx_tla/test_basic.ml`:
   - `f_with_guard x = x + 1 [@@fsm_guard "x >= 0"]` → pass on 5/0, raise on -1
   - `g_curried a b = a + b [@@fsm_guard "a + b >= 0"]` → partial application does NOT trigger; full application validates
   These pin the rewriter behaviour so a future regression on either the body-injection path or the partial-application non-firing semantics fails the build.

3. **`feat(keeper-turn-fsm)`** — first real-module use of `[@@fsm_guard]`. Adds `require_active_state : turn_state -> turn_state`, identity on its argument, with a runtime assert that rejects `Done | Failed _ | Cancelled _`. No call sites yet — exposed in the .mli as a sentinel for tool-execution loops to adopt.

## Verification

```
$ dune build --root <worktree> ppx_tla/         # exit 0
$ dune build --root <worktree> lib/keeper/      # exit 0
$ dune exec  --root <worktree> test/ppx_tla/test_basic.exe
ppx_tla cycle 2 + 3 + 12 tests: PASS
```

## Why three commits in one PR

Splitting them would leave intermediate states broken on `main` between merges:

- After commit 1 alone: PPX builds but no fsm_guard test. main passes but coverage gap.
- After commit 2 alone (without commit 1): tests don't compile.
- After commit 3 alone (without commit 1): keeper_turn_fsm.ml doesn't compile.

Three commits that ship together keep the gap to a single CI cycle and let a reviewer cherry-pick if needed.

## Risk

| Axis | Assessment |
|------|------------|
| PPX behaviour change | The `Pfunction_cases` arm now sequences (binding-time) rather than per-call. No current consumer uses `function`-style bindings under `[@@fsm_guard]`, so observable surface = 0. |
| keeper_turn_fsm consumers | None — `require_active_state` is additive and unused. |
| Backwards compat | Fully — `[@@deriving tla]` Cycle 2/3 tests still pass. |
| dune build break | Positive: this PR fixes an existing main-side break. |

## Honest about scope

This is a **smoke test** PR per plan §3 Tier I3 ("Smoke test in its own PR — keeps this Tier I3 scaffold review small"). The `require_active_state` function is intentionally:

- **Identity on its argument** (no behavioural change).
- **Unused** (no caller adoption — that's Step 4b).
- **Exposed in .mli** so call sites *can* adopt it without internal access.

The PPX assertion is the only meaningful runtime addition. Adoption at real call sites (e.g., `keeper_unified_turn.ml` tool-loop entry points) is deferred to a follow-up PR after `require_active_state` is reviewed in isolation.

## Cycle context

| PR | Cycle | Tier | Status |
|----|-------|------|--------|
| #11377 | 2 | I1 (deriver bootstrap) | MERGED |
| #11384 | 3 | I1 (keeper_turn_fsm deriver use) | MERGED |
| #11430 | 10 | I2 (TLA_STATE_MACHINE module type) | MERGED |
| #11450 | 12 | I3 (`[@@fsm_guard]` PPX scaffold) | MERGED |
| **this PR** | 13/14 | I3 (smoke + ppx fix) | OPEN |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
