### PR TITLE
chore(types): expose validation surface (4 sub-modules + 2 stats)

### DIFF
--- a/lib/core/validation.mli
+++ b/lib/core/validation.mli
@@ -1,0 +1,72 @@
+(** MASC Input Validation — security module.
+
+    Prevents path injection and invalid-input attacks for MCP tool
+    arguments. Each validator returns a [Result] type and logs
+    rejections at WARN level for security monitoring (#9787 quote-strip
+    fallback applies for ID validators).
+
+    Internal helpers ([log_rejection], [try_strip_outer_quotes]) and
+    the rejection counters are hidden — callers interact with the
+    typed sub-modules and the two read-only stat accessors. *)
+
+(** {1 Rejection statistics (observability)} *)
+
+val get_rejection_stats : unit -> int * float
+(** [(count, last_rejection_unix_ts)]. *)
+
+val reset_rejection_stats : unit -> unit
+
+(** {1 Agent ID} *)
+
+module Agent_id : sig
+  type t
+
+  val validate : string -> (t, string) result
+  (** Validates [a-zA-Z0-9_-]+ with optional single colon namespace
+      ([keeper:keeper-test-X]), length 1–64. Rejects path separators
+      and traversal segments. On strict failure, retries after
+      stripping surrounding ASCII quotes (#9787 LLM behavior). *)
+
+  val to_string : t -> string
+
+  val of_string_unsafe : string -> t
+  (** Bypasses validation. Internal use only — never call with
+      untrusted input. *)
+end
+
+(** {1 Task ID} *)
+
+module Task_id : sig
+  type t
+
+  val validate : string -> (t, string) result
+  (** Validates [a-zA-Z0-9_:-]+, length 1–128. Same path-traversal
+      and quote-strip rules as {!Agent_id.validate}. *)
+
+  val to_string : t -> string
+
+  val of_string_unsafe : string -> t
+  (** Internal use only. *)
+end
+
+(** {1 Filesystem paths} *)
+
+module Safe_path : sig
+  val validate_relative : string -> (string, string) result
+  (** Reject empty paths, absolute paths, and any segment containing
+      [..]. Returns the unchanged input on success. *)
+
+  val sanitize_filename : string -> string
+  (** Replace path separators, [..] sequences, and characters outside
+      [a-zA-Z0-9_.\-] with [_]. *)
+end
+
+(** {1 Numeric validation} *)
+
+module Safe_float : sig
+  val validate : float -> name:string -> float
+  (** Map [NaN] / [Inf] to [0.0] with a WARN log; pass through
+      otherwise. *)
+
+  val clamp : float -> min:float -> max:float -> float
+end


### PR DESCRIPTION
## Summary

\`lib/core/validation.ml\` (208줄, MCP tool 입력 validation security module) 에 selective .mli 추가.

## Surface

| 노출 | 숨김 |
|------|------|
| \`get_rejection_stats : unit -> int * float\` | \`rejection_count : int Atomic.t\` |
| \`reset_rejection_stats : unit -> unit\` | \`last_rejection_time : float ref\` |
| \`module Agent_id\` (4 sig members) | \`log_rejection\` (internal WARN logger) |
| \`module Task_id\` (4 sig members) | \`try_strip_outer_quotes\` (#9787 fallback) |
| \`module Safe_path\` (2 sig members) | |
| \`module Safe_float\` (2 sig members) | |

## Caller Audit

- 6 qualified usage: \`Validation.Agent_id\` / \`.Task_id\` / \`.Safe_path\` / \`.Safe_float\` / \`get_rejection_stats\` / \`reset_rejection_stats\`
- open consumer 0
- mutable state 외부 caller 0 → safe hide

## Skip Note

\`lib/types/types_auth.ml\` (181줄)도 후보였지만 \`include Masc_error\` + 수동 \`to_yojson\` + ppx \`[@@deriving show, yojson]\` 다층 의존으로 cycle 8 평가에서 high-risk 분류 (4-axis dependency). verbatim 시그니처 추출 후 별도 PR로 분리.

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (-1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff