### PR TITLE
chore(types): expose autoresearch_git surface

### DIFF
--- a/lib/autoresearch/autoresearch_git.mli
+++ b/lib/autoresearch/autoresearch_git.mli
@@ -1,0 +1,73 @@
+(** Autoresearch_git — git invocation helpers for the autoresearch
+    loop's managed worktree.
+
+    Wraps the small subset of git commands the autoresearch driver
+    needs (commit/restore/reset/tag/branch/worktree). Internal
+    [run_git_with_status] / [run_capture_lines] / [is_in_git_repo]
+    helpers are hidden — callers interact with the per-action
+    functions only.
+
+    Functions returning [unit] (e.g. {!git_reset_last},
+    {!git_restore_head}, {!git_tag_best}) silently no-op when [workdir]
+    is not inside a git repo or when the underlying git command
+    fails. The [Result]-returning variants surface errors verbatim. *)
+
+(** {1 Status / introspection} *)
+
+val git_top_level : workdir:string -> (string, string) result
+(** [git rev-parse --show-toplevel] in [workdir]. *)
+
+val git_current_branch : workdir:string -> string option
+(** [git rev-parse --abbrev-ref HEAD], or [None] outside a repo. *)
+
+val git_head_short : workdir:string -> string option
+(** Short HEAD SHA from [git rev-parse --short HEAD], or [None]. *)
+
+val git_is_dirty : workdir:string -> bool
+(** [true] iff [git status --porcelain] reports any tracked changes. *)
+
+(** {1 Mutating actions (no-op outside a repo)} *)
+
+val git_restore_head :
+  workdir:string -> unit
+(** [git restore --source=HEAD --worktree -- .] — discard all local
+    edits. *)
+
+val git_reset_last :
+  workdir:string -> unit
+(** [git reset --soft HEAD~1]. *)
+
+val git_commit :
+  workdir:string -> message:string -> (string option, string) result
+(** Stages tracked changes ([git add --update]), then [git commit -m
+    message]. Returns [Ok (Some sha)] for the new commit, [Ok None] if
+    there was nothing to commit, [Error msg] otherwise. *)
+
+val git_commit_cycle :
+  workdir:string ->
+  cycle:int ->
+  hypothesis:string ->
+  baseline:float ->
+  (string option, string) result
+(** Convenience wrapper around {!git_commit} that builds the canonical
+    autoresearch cycle commit message
+    [\[autoresearch\] cycle <n>: <hypothesis> (baseline=<b>)]. The
+    hypothesis is sanitized: control characters collapse to single
+    spaces and surrounding whitespace is trimmed. *)
+
+val git_tag_best :
+  workdir:string -> cycle:int -> score:float -> unit
+(** Force-create a tag [ar-best-c<cycle>-<score>] on the current HEAD.
+    Silently swallows tag-creation errors. *)
+
+(** {1 Managed worktree lifecycle} *)
+
+val cleanup_managed_worktree :
+  base_path:string ->
+  source_workdir:string ->
+  loop_id:string ->
+  (bool * bool, string) result
+(** Removes the autoresearch managed worktree directory and the
+    associated branch (if any). Returns [Ok (workdir_removed,
+    branch_removed)] flagging whether each artifact existed and was
+    deleted; [Error] only when [git_top_level source_workdir] fails. *)


### PR DESCRIPTION
## Summary

\`lib/autoresearch/autoresearch_git.ml\` (267줄, autoresearch loop git invocation 헬퍼) 에 selective .mli 추가.

| 노출 (10) | 숨김 (7) |
|------|------|
| 4 status: git_top_level / git_current_branch / git_head_short / git_is_dirty | is_in_git_repo, exec_gate_raw_source |
| 5 mutating: git_restore_head / git_reset_last / git_commit / git_commit_cycle / git_tag_best | run_git_with_status, run_capture_lines |
| 1 worktree: cleanup_managed_worktree | managed_branch_name, prepare_managed_worktree, local_branch_exists |

## Type Sources (모두 .ml verbatim 추출, cycle 12 사고 회피)

- \`(T, string) result\` patterns: \`git_top_level\`, \`git_commit\`, \`git_commit_cycle\`, \`cleanup_managed_worktree\`
- \`string option\`: \`git_current_branch\`, \`git_head_short\` (missing-repo no-op)
- \`bool\`: \`git_is_dirty\`
- \`unit\`: \`git_restore_head\`, \`git_reset_last\`, \`git_tag_best\` (silent no-op outside repo)

## Skip Notes

- \`autoresearch_storage\` (246줄): batch 후보였지만 \`load_state_result\` 반환 타입이 \`(Autoresearch_types.loop_state, string) result option\` nested 형태. cycle 12 사고 회피 — 별도 PR로 분리 후 verbatim 시그니처 검증.
- \`masc_http_client\` (190줄): \`Cohttp_eio.Client.t\` + \`[\`Generic] Eio.Net.ty Eio.Resource.t\` alias 위험으로 보류.

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (-1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff