### PR TITLE
chore(types): expose autoresearch_storage surface

### DIFF
--- a/lib/autoresearch/autoresearch_storage.mli
+++ b/lib/autoresearch/autoresearch_storage.mli
@@ -1,0 +1,88 @@
+(** Autoresearch_storage — filesystem persistence for the
+    autoresearch loop.
+
+    Owns the layout under [<base_path>/.masc/autoresearch/<loop_id>/]
+    (cycle results, state JSON, execution link files). Internal path
+    builders ([results_dir]/[results_file]/[state_file]/
+    [loop_link_file]/[session_link_file]) and JSON IO helpers
+    ([load_json_file_result]/[decode_json_file_result]) are hidden —
+    callers consume the typed read/write functions only.
+
+    The [_result]-suffixed loaders return
+    [(T, string) result option] so callers can distinguish
+    [None] (no file on disk), [Some (Ok t)] (parsed), and
+    [Some (Error msg)] (legacy/invalid format with a diagnostic
+    message). The plain loaders log the error and degrade to
+    [option]. *)
+
+(** {1 Filesystem helper} *)
+
+val ensure_dir : string -> unit
+(** [mkdir -p] equivalent. Idempotent; no-op if [path] already
+    exists. *)
+
+(** {1 Worktree path SSOT} *)
+
+val managed_worktree_dir : base_path:string -> string -> string
+(** [<base_path>/.masc/autoresearch/<loop_id>/worktree]. Used by
+    [autoresearch_git.cleanup_managed_worktree] to locate the
+    autoresearch driver's managed git worktree. *)
+
+(** {1 Cycle results (append-only JSONL)} *)
+
+val append_cycle :
+  base_path:string -> string -> Autoresearch_types.cycle_record -> unit
+(** Append a cycle record to [<loop_id>/results.jsonl]. Creates the
+    directory on first call. *)
+
+val latest_cycle_record :
+  base_path:string -> string -> Autoresearch_types.cycle_record option
+(** Last well-formed cycle record from [results.jsonl], or [None] if
+    the file is missing/empty. Malformed lines are logged and
+    skipped. *)
+
+val load_cycle_history :
+  base_path:string -> string -> Autoresearch_types.cycle_record list
+(** Full cycle history (in file order). Malformed lines are logged
+    and skipped. *)
+
+(** {1 Loop state (single-file JSON)} *)
+
+val save_state :
+  base_path:string -> Autoresearch_types.loop_state -> unit
+
+val load_state :
+  base_path:string -> string -> Autoresearch_types.loop_state option
+(** [Some state] on success, [None] if the file is missing or fails
+    to parse. The error path is logged. *)
+
+val load_state_result :
+  base_path:string ->
+  string ->
+  (Autoresearch_types.loop_state, string) result option
+(** [None] = no file on disk. [Some (Ok state)] = parsed (with
+    [updated_at] back-filled from file mtime if absent). [Some (Error
+    msg)] = legacy schema (missing [model_model] field) or decode
+    failure. *)
+
+(** {1 Execution link (per-loop and per-session)} *)
+
+val save_execution_link :
+  base_path:string -> Autoresearch_types.execution_link -> unit
+(** Writes both the [loop -> link] and [session -> link] mappings. *)
+
+val load_execution_link_by_loop :
+  base_path:string -> string -> Autoresearch_types.execution_link option
+
+val load_execution_link_by_loop_result :
+  base_path:string ->
+  string ->
+  (Autoresearch_types.execution_link, string) result option
+
+val load_execution_link_by_session :
+  base_path:string -> string -> Autoresearch_types.execution_link option
+
+val load_execution_link_by_session_result :
+  base_path:string ->
+  string ->
+  (Autoresearch_types.execution_link, string) result option


### PR DESCRIPTION
## Summary

\`lib/autoresearch/autoresearch_storage.ml\` (246줄, autoresearch loop filesystem persistence) 에 selective .mli 추가.

## Surface

| 노출 (13) | 숨김 (7) |
|------|------|
| ensure_dir, managed_worktree_dir | 5 path builders (results_dir, results_file, state_file, loop_link_file, session_link_file) |
| append_cycle, latest_cycle_record, load_cycle_history | 2 JSON IO helpers (load_json_file_result, decode_json_file_result) |
| save_state, load_state, load_state_result | |
| save_execution_link, load_execution_link_by_loop[_result], load_execution_link_by_session[_result] | |

## Type Signatures (verbatim)

3-state 패턴 일관:
- \`_result\` variants: \`(T, string) result option\` — None=missing / Ok=parsed / Error=legacy or decode fail
- 일반 loaders: \`T option\` — error는 log 후 None로 degrade
- save/append: \`unit\` (side effect)

## Caller Audit

- \`save_state\`, \`save_execution_link\`: \`lib/autoresearch.ml\`에서 line-in-line re-export
- \`managed_worktree_dir\`: \`autoresearch_git.cleanup_managed_worktree\`에서 호출 (PR #11495 참조)
- 5 path builder + 2 JSON IO helper 외부 caller 0

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (-1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff