### PR TITLE
feat(keeper-receipt): ReceiptIsAuthoritative runtime invariant helper

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -26,6 +26,29 @@ let outcome_kind_is_terminal_success = function
   | `Ok | `Skipped -> true
   | `Error | `Cancelled -> false
 
+(* TLA+ ReceiptIsAuthoritative invariant
+   (specs/keeper-turn-fsm/KeeperTurnFSM.tla:336):
+     receipt_outcome = "receipt_done" => turn_state = "done"
+   Per ReceiptMatchesState the [Done] state also accepts receipt_skipped
+   (PhaseGateSkip path), so this helper enforces the receipt-authoritative
+   direction for both `Ok and `Skipped: a successful-terminal receipt
+   MUST be paired with turn_state = "done". `Error and `Cancelled are
+   left to ReceiptMatchesState (a separate invariant) and accepted here
+   so this helper is single-concern. *)
+type receipt_authority_violation = {
+  outcome : string;
+  turn_state : string;
+}
+
+let assert_receipt_authoritative ~outcome ~turn_state =
+  match (outcome, turn_state) with
+  | `Ok, "done" | `Skipped, "done" -> Ok ()
+  | `Ok, other ->
+      Error { outcome = "receipt_done"; turn_state = other }
+  | `Skipped, other ->
+      Error { outcome = "receipt_skipped"; turn_state = other }
+  | (`Error | `Cancelled), _ -> Ok ()
+
 type tool_surface =
   { turn_lane : string
   ; tool_surface_class : string

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -29,6 +29,40 @@ val outcome_kind_is_terminal_success : outcome_kind -> bool
     Used by dashboard "healthy" classification and action_radius
     success accounting. *)
 
+type receipt_authority_violation = {
+  outcome : string;
+  turn_state : string;
+}
+(** Witness of a [ReceiptIsAuthoritative] invariant violation.
+    [outcome] holds the receipt-side string (e.g. ["receipt_done"]);
+    [turn_state] is the offending turn-state symbol the caller
+    presented. *)
+
+val assert_receipt_authoritative :
+  outcome:outcome_kind ->
+  turn_state:string ->
+  (unit, receipt_authority_violation) result
+(** Runtime check for the TLA+ [ReceiptIsAuthoritative] invariant
+    (specs/keeper-turn-fsm/KeeperTurnFSM.tla:336):
+    [receipt_outcome = "receipt_done" => turn_state = "done"].
+
+    Per [ReceiptMatchesState] the [Done] state also accepts
+    [receipt_skipped] (PhaseGateSkip path), so this helper enforces
+    the receipt-authoritative direction for both [`Ok] and [`Skipped]:
+    a successful-terminal receipt MUST be paired with [turn_state =
+    "done"]. [`Error] and [`Cancelled] are accepted here without
+    further check; pairing them with the right turn_state is the
+    responsibility of [ReceiptMatchesState] (a separate invariant).
+
+    [turn_state] is the canonical TLA+ symbol form ([\"done\"],
+    [\"failed\"], [\"cancelled\"], ...). Callers that hold a
+    [Keeper_turn_fsm.turn_state] should pass
+    [Keeper_turn_fsm.to_tla_symbol s].
+
+    Returns [Error _] (never raises) so the caller can choose to
+    fail-closed via [Result.Error] propagation or surface a metric.
+    Memory: feedback_keeper_runtime_fail_closed_for_unknown_permissive_default. *)
+
 type tool_surface =
   { turn_lane : string
   ; tool_surface_class : string

--- a/test/dune
+++ b/test/dune
@@ -423,6 +423,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_keeper_receipt_authoritative)
+ (modules test_keeper_receipt_authoritative)
+ (libraries masc_test_deps))
+
+(test
  (name test_telemetry_task_transition_10358)
  (modules test_telemetry_task_transition_10358)
  (libraries masc_test_deps))

--- a/test/test_keeper_receipt_authoritative.ml
+++ b/test/test_keeper_receipt_authoritative.ml
@@ -1,0 +1,110 @@
+(* Unit tests for [Keeper_execution_receipt.assert_receipt_authoritative].
+
+   The function enforces the OCaml-runtime image of the TLA+
+   [ReceiptIsAuthoritative] invariant
+   (specs/keeper-turn-fsm/KeeperTurnFSM.tla:336):
+
+       receipt_outcome = "receipt_done" => turn_state = "done"
+
+   Per [ReceiptMatchesState] the [Done] state also accepts
+   [receipt_skipped] (PhaseGateSkip path), so a successful-terminal
+   receipt ([`Ok] or [`Skipped]) must be paired with [turn_state =
+   "done"]. [`Error] and [`Cancelled] are accepted unconditionally
+   here because their state-pairing is enforced by
+   [ReceiptMatchesState] (a separate invariant) — this helper is
+   single-concern. *)
+
+module R = Masc_mcp.Keeper_execution_receipt
+
+let must_ok ~outcome ~turn_state =
+  match R.assert_receipt_authoritative ~outcome ~turn_state with
+  | Ok () -> ()
+  | Error v ->
+      failwith
+        (Printf.sprintf
+           "expected Ok for outcome=<variant> turn_state=%s but got \
+            Error { outcome=%s; turn_state=%s }"
+           turn_state v.outcome v.turn_state)
+
+let must_error ~outcome ~turn_state ~expected_receipt_label =
+  match R.assert_receipt_authoritative ~outcome ~turn_state with
+  | Ok () ->
+      failwith
+        (Printf.sprintf
+           "expected Error for outcome=<variant> turn_state=%s but got \
+            Ok ()"
+           turn_state)
+  | Error v ->
+      if v.outcome <> expected_receipt_label then
+        failwith
+          (Printf.sprintf
+             "expected violation receipt label %s, got %s"
+             expected_receipt_label v.outcome);
+      if v.turn_state <> turn_state then
+        failwith
+          (Printf.sprintf
+             "expected violation turn_state %s, got %s" turn_state
+             v.turn_state)
+
+let test_ok_done () = must_ok ~outcome:`Ok ~turn_state:"done"
+
+let test_skipped_done () =
+  (* PhaseGateSkip: turn reaches terminal Done without dispatching;
+     this is the canonical case `Skipped invariant must accept. *)
+  must_ok ~outcome:`Skipped ~turn_state:"done"
+
+let test_ok_failed_violation () =
+  must_error ~outcome:`Ok ~turn_state:"failed"
+    ~expected_receipt_label:"receipt_done"
+
+let test_ok_cancelled_violation () =
+  must_error ~outcome:`Ok ~turn_state:"cancelled"
+    ~expected_receipt_label:"receipt_done"
+
+let test_ok_idle_violation () =
+  (* receipt_done arriving while still in idle would be a serious
+     state-machine bug — must surface as Error, never silently passed. *)
+  must_error ~outcome:`Ok ~turn_state:"idle"
+    ~expected_receipt_label:"receipt_done"
+
+let test_skipped_failed_violation () =
+  must_error ~outcome:`Skipped ~turn_state:"failed"
+    ~expected_receipt_label:"receipt_skipped"
+
+let test_skipped_phase_gating_violation () =
+  (* If receipt_skipped is set but the turn is still in phase_gating,
+     the FSM emitted a receipt before the PhaseGateSkip transition
+     completed — invariant violated. *)
+  must_error ~outcome:`Skipped ~turn_state:"phase_gating"
+    ~expected_receipt_label:"receipt_skipped"
+
+let test_error_failed_passes () =
+  (* `Error pairing is the concern of ReceiptMatchesState, not
+     ReceiptIsAuthoritative. Single-concern helper accepts. *)
+  must_ok ~outcome:`Error ~turn_state:"failed"
+
+let test_error_done_passes () =
+  (* Even `Error + "done" passes here — that pairing is checked
+     elsewhere. The receipt-authoritative direction is only about
+     `Ok / `Skipped. *)
+  must_ok ~outcome:`Error ~turn_state:"done"
+
+let test_cancelled_cancelled_passes () =
+  must_ok ~outcome:`Cancelled ~turn_state:"cancelled"
+
+let test_cancelled_done_passes () =
+  must_ok ~outcome:`Cancelled ~turn_state:"done"
+
+let () =
+  test_ok_done ();
+  test_skipped_done ();
+  test_ok_failed_violation ();
+  test_ok_cancelled_violation ();
+  test_ok_idle_violation ();
+  test_skipped_failed_violation ();
+  test_skipped_phase_gating_violation ();
+  test_error_failed_passes ();
+  test_error_done_passes ();
+  test_cancelled_cancelled_passes ();
+  test_cancelled_done_passes ();
+  print_endline "test_keeper_receipt_authoritative: OK"


### PR DESCRIPTION
## Summary

Phase 1-3 of the Kimi AST·PPX audit integration plan. Adds a runtime witness for the TLA+ `ReceiptIsAuthoritative` invariant (`specs/keeper-turn-fsm/KeeperTurnFSM.tla:336`).

**Stacked on #11491** (`feat/receipt-outcome-skipped`); base will flip to `main` once #11491 lands.

## Spec invariant

```
ReceiptIsAuthoritative ==
    receipt_outcome = "receipt_done" => turn_state = "done"
```

Per `ReceiptMatchesState` (separate invariant) the [Done] state also accepts `receipt_skipped` (PhaseGateSkip path). So a successful-terminal receipt — `` `Ok `` (= `receipt_done`) or `` `Skipped `` (= `receipt_skipped`) — MUST be paired with `turn_state = "done"`. `` `Error `` and `` `Cancelled `` are accepted unconditionally because their pairing is enforced by `ReceiptMatchesState`; this helper stays single-concern.

## Why

The invariant was spec-only with no OCaml runtime witness. A receipt written with outcome `ok` while the turn was actually in a non-done state would be a serious state-machine bug — but nothing in the runtime would surface it. This PR adds the boundary check.

## Changes

### `lib/keeper/keeper_execution_receipt.{ml,mli}`
- New type `receipt_authority_violation = { outcome; turn_state }`: violation witness carried by `Result.Error`.
- New helper `assert_receipt_authoritative ~outcome ~turn_state -> (unit, receipt_authority_violation) result`. Never raises. Fail-closed via `Result.Error` so callers choose to propagate or surface a metric (memory: `feedback_keeper_runtime_fail_closed_for_unknown_permissive_default`).
- `turn_state` is canonical TLA+ symbol form (`"done"`, `"failed"`, `"cancelled"`, ...). Callers holding `Keeper_turn_fsm.turn_state` should pass `Keeper_turn_fsm.to_tla_symbol s`.

### `test/test_keeper_receipt_authoritative.ml` (new)
11 cases covering the four outcome variants × representative turn_state values; verifies success cases (`` `Ok ``+done, `` `Skipped ``+done) and violation cases (`` `Ok ``+failed, +cancelled, +idle, `` `Skipped ``+failed, +phase_gating). Asserts the violation witness preserves both the receipt label and the offending turn_state. `` `Error `` and `` `Cancelled `` paired with any state pass (out of scope — handled by ReceiptMatchesState).

### `test/dune`
New `(test)` stanza.

## What is NOT in this PR

| Follow-up | Why deferred |
|-----------|--------------|
| Wire `assert_receipt_authoritative` into `append` / receipt builder | Caller integration is separate concern. Single-PR-per-step. |
| `ReceiptMatchesState` runtime check | Separate invariant. |

## External impact

**Zero.** No existing call site is touched; helper is opt-in.

## Test plan

- [ ] `dune runtest test/test_keeper_receipt_authoritative` exit 0.
- [ ] CI green on `Build`, `Lint`, `Health`, `OCaml Structure Ratchet`.

## Cycle context

Phase 1-3 / plan `serene-napping-glade.md`. Phase 1-1+1-2 = #11491 (this PR's base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
