### PR TITLE
docs: fix P0 doc issues from Kimi audit (version, phantom tool, transport, cascade)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,8 @@ Cross-model review evidence should use direct `sb glm-text` when available. If a
 
 ### MODEL Cascade
 
-- Slots tried in order: GLM → Gemini → Claude
+- Runtime order is controlled by `Provider_registry` and `config/cascade.json` (hot-reloaded)
+- The hardcoded fallback order when `cascade.json` is absent: ollama → GLM → anthropic → gemini → openai_compat → claude_code → …
 - If a slot returns empty or errors, the next slot is tried
 - Claude API keys are rotated round-robin per heartbeat tick
 - Configuration in `config/cascade.json`, hot-reloaded by mtime check

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # masc-mcp
 
 [![OCaml](https://img.shields.io/badge/OCaml-5.4+-orange.svg)](https://ocaml.org/)
-[![OAS](https://img.shields.io/badge/agent__sdk-%E2%89%A50.160.1-blue.svg)](https://github.com/jeong-sik/oas)
+[![OAS](https://img.shields.io/badge/agent__sdk-%E2%89%A50.181.0-blue.svg)](https://github.com/jeong-sik/oas)
 
 > Personal project. No production SLA, no external support, no compatibility guarantees. The API surface, schema, and dashboard change on the author's schedule.
 >
@@ -69,13 +69,13 @@ All protocols run concurrently from a single Eio fiber pool:
 | HTTP/1.1 + HTTP/2 | `:8935` | Primary MCP endpoint at `/mcp` |
 | SSE | `:8935` | Unlimited streams per h2 connection |
 | gRPC | `:8936` | Keeper queries and subscriptions |
-| WebSocket | `:8937` | Standalone + discovery via `/ws` |
-| WebRTC | `:8935` | Signaling endpoints `POST /webrtc/offer` and `POST /webrtc/answer` (gated by `Server_webrtc_transport.is_enabled`) |
+| WebSocket | `:8937` | Standalone + discovery via `/ws` (experimental; see ROADMAP #3408) |
+| WebRTC | `:8935` | Signaling endpoints `POST /webrtc/offer` / `POST /webrtc/answer` (experimental; `Server_webrtc_transport.is_enabled` gate) |
 
 ### Tech Stack
 
 - **OCaml 5.4+** with Eio structured concurrency (no Lwt)
-- **agent_sdk** >= 0.174.0 (OAS agent runtime; pinned floor in `masc_mcp.opam` and `dune-project`)
+- **agent_sdk** >= 0.181.0 (OAS agent runtime; pinned floor in `dune-project`)
 - **mcp_protocol** >= 1.3.0 (MCP JSON-RPC contract)
 - **h2-eio** (HTTP/2), **grpc-direct** (gRPC), **ocaml-webrtc** (WebRTC)
 - **caqti** + PostgreSQL (optional), **sqlite3** (fallback), **neo4j_bolt** (optional graph)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -26,8 +26,6 @@ Use this before any real work:
 4. `masc_plan_set_task` after `masc_transition(action=claim)`
 5. `masc_heartbeat`
 
-`masc_set_room` remains callable as a compatibility alias, but it only selects project scope and should not be treated as the primary onboarding path.
-
 ### 2. Keeper runtime
 
 Use this when long-running autonomous execution is needed:

--- a/llms.txt
+++ b/llms.txt
@@ -17,8 +17,8 @@
 
 ## Rules
 
-- Treat `masc_set_room` as a compatibility alias only; prefer `masc_start` for onboarding.
+- Use `masc_start` for onboarding; it is the canonical entry point.
 - Treat `Social Board`, `TRPG`, and `RISC` as secondary surfaces unless the task explicitly needs them.
-- Team-session, operator, and command-plane compatibility surfaces are retired from the supported front door.
+- Team-session and command-plane compatibility surfaces are retired. The operator surface (`/mcp/operator`) is in supporting status — see README for current surface map.
 
 See `llms-full.txt` for the expanded contract.


### PR DESCRIPTION
## Summary

Kimi Agent 2026-04-28 감사에서 발견된 P0 문서 불일치 5건 수정.

- **#11477** README badge/text: `agent_sdk` 버전 삼중 불일치 → `0.181.0`으로 통일 (SSOT: `dune-project`)
- **#11478** `llms.txt`, `llms-full.txt`: 존재하지 않는 `masc_set_room` alias 주장 제거
- **#11479** README transport 표: WebSocket `:8937`, WebRTC를 `(experimental)` 명시 (ROADMAP #3408)
- **#11481** `CONTRIBUTING.md`: MODEL cascade 순서가 hardcoded fallback임을 명시, 실제 순서(`ollama → glm → anthropic → gemini`) 추가
- **#11482** `llms.txt`: operator 표면이 'retired'가 아닌 'supporting'임을 README와 일치시킴

## 변경 파일

- `README.md` — badge + text 버전, WebSocket/WebRTC experimental 표시
- `CONTRIBUTING.md` — cascade 순서 clarification
- `llms.txt` — masc_set_room 제거, operator 분류 수정
- `llms-full.txt` — masc_set_room 단락 제거

## 검증

코드 변경 없음. 문서 정확성 수정만.

Closes #11477
Closes #11478
Closes #11479
Closes #11481
Closes #11482
