### PR TITLE
fix(keeper-unified-turn): receipt outcome="error" matches FSM Failed (Cycle 1b-ii)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1190,9 +1190,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 ~meta
                 ~generation
                 ~cascade_name:effective_cascade_name
-                ~outcome:"skipped"
+                ~outcome:"error"
                 ~terminal_reason_code:"ollama_saturated"
-                ~activity_kind:"keeper.turn_skipped"
+                ~activity_kind:"keeper.turn_failed"
                 ~trajectory_outcome:(Trajectory.Gated "ollama_saturated")
                 ~keeper_turn_id
                 ();


### PR DESCRIPTION
## Summary

**Cycle 1b-ii** of the Kimi keeper FSM review plan — second drift fix in the receipt-vs-FSM alignment series (after #11457 / 1b-i, MERGED).

The ollama-saturation skip path in `run_keeper_cycle` (lines 1182-1209 of `lib/keeper/keeper_unified_turn.ml`) emits two telemetry records that previously disagreed:

| Telemetry | Value (before) | Value (after) |
|-----------|----------------|---------------|
| `Keeper_turn_fsm.emit_transition` (line 1199-1204) | `Failed (Failure_cascade_unavailable {base, resolved})` ✅ truthful | unchanged |
| `record_pre_dispatch_terminal_observation` (line 1188-1198) | `outcome="skipped"`, `activity_kind="keeper.turn_skipped"` ❌ downgraded | `outcome="error"`, `activity_kind="keeper.turn_failed"` ✅ aligned |

Same drift category as Cycle 1b-i (PR #11457) on a different transition: there the FSM was `Cancelled`, here it's `Failed`. The KeeperTurnFSM is source of truth.

## Diff

2 lines, 1 file:

```diff
-        ~outcome:"skipped"
+        ~outcome:"error"
         ~terminal_reason_code:"ollama_saturated"
-        ~activity_kind:"keeper.turn_skipped"
+        ~activity_kind:"keeper.turn_failed"
```

## Why this is NOT refinement

In Cycle 13 I considered whether "skipped" might be an intentional refinement layer encoding "FSM Failed but receipt sub-classified as not-attempted". Re-reviewing line 1199-1204 confirms the FSM emits plain `Failed (Failure_cascade_unavailable)` — no sub-state qualifier. So the receipt "skipped" is a pure downgrade with no extra information, putting it firmly in **Drift** per plan §1 4-way classification.

## Compatibility

- Receipt outcome remains `string` field; this is a value-side fix, not type-narrowing (that's 1b-iii).
- `outcome_kind_of_string` (PR #11360 infra) already accepts `"error"`.
- Prometheus metric `metric_keeper_ollama_saturation_skip` keeps its name — "skip" there is the producer-side semantics, orthogonal to receipt outcome.

## Cycle context

| PR | Cycle | Status |
|----|-------|--------|
| #11360 | 1a outcome_kind tri-state | MERGED |
| #11457 | 1b-i first cancelled producer | MERGED |
| this PR | 1b-ii ollama saturated drift | OPEN |
| (parallel) | 1b-iv outer Cancel handler | OPEN |
| (deferred) | 1b-iii outcome type narrowing | not yet |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
