### PR TITLE
feat(keeper-unified-turn): outer Cancel handler emits cancelled receipt (Cycle 1b-iv)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1679,36 +1679,70 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   ~keeper_name:meta.name ~turn_id:keeper_turn_id
                   ~prev:Keeper_turn_fsm.Awaiting_provider
                   Keeper_turn_fsm.Streaming;
-                Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
-                  ~max_context:execution.max_context ~build_turn_prompt
-                  ~user_message ~cascade_name:execution.cascade_name
-                  ~turn_affordances
-                  ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
-                  ~generation:run_generation
-                  ~max_turns
-                  ~max_idle_turns
-                  ~history_user_source:"world_state_prompt"
-                  ~history_assistant_source:"internal_assistant"
-                  ~degraded_retry_applied:(Option.is_some !degraded_retry_info)
-                  ?degraded_retry_cascade:
-                    (Option.map
-                       (fun (retry : EC.degraded_retry) -> retry.next_cascade)
-                       !degraded_retry_info)
-                  ?fallback_reason:
-                    (Option.map
-                       (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
-                       !degraded_retry_info)
-                  ~cascade_rotation_attempts:
-                    (List.rev !cascade_rotation_attempts)
-                  ~temperature:execution.temperature
-                  ~max_tokens:execution.max_tokens
-                  ~oas_timeout_s
-                  ?max_cost_usd
-                  ~trajectory_acc
-                  ~is_retry
-                  ?shared_context
-                  ?event_bus:(Keeper_event_bus.get ())
-                  ())
+                try
+                  Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
+                    ~max_context:execution.max_context ~build_turn_prompt
+                    ~user_message ~cascade_name:execution.cascade_name
+                    ~turn_affordances
+                    ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
+                    ~generation:run_generation
+                    ~max_turns
+                    ~max_idle_turns
+                    ~history_user_source:"world_state_prompt"
+                    ~history_assistant_source:"internal_assistant"
+                    ~degraded_retry_applied:(Option.is_some !degraded_retry_info)
+                    ?degraded_retry_cascade:
+                      (Option.map
+                         (fun (retry : EC.degraded_retry) -> retry.next_cascade)
+                         !degraded_retry_info)
+                    ?fallback_reason:
+                      (Option.map
+                         (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
+                         !degraded_retry_info)
+                    ~cascade_rotation_attempts:
+                      (List.rev !cascade_rotation_attempts)
+                    ~temperature:execution.temperature
+                    ~max_tokens:execution.max_tokens
+                    ~oas_timeout_s
+                    ?max_cost_usd
+                    ~trajectory_acc
+                    ~is_retry
+                    ?shared_context
+                    ?event_bus:(Keeper_event_bus.get ())
+                    ()
+                with Eio.Cancel.Cancelled _ as e ->
+                  (* Cycle 1b-iv: external cancellation that escapes the
+                     in-band receipt builder in [Keeper_agent_run.run_turn].
+                     The 14 inner Cancel handlers all re-raise; without an
+                     outer catch the receipt for this turn is silently
+                     dropped (FSM emits Streaming then nothing — the turn
+                     just disappears from the operator's timeline).
+
+                     Emit a minimal cancelled receipt + matching FSM
+                     Cancelled transition before re-raising. The cancel
+                     reason is conservatively classified as
+                     [Cancelled_supervisor_stop] because Eio.Cancel does
+                     not expose the originating cancel context here;
+                     refining this via supervisor / fleet flag inspection
+                     is a follow-up. *)
+                  record_pre_dispatch_terminal_observation
+                    ~config
+                    ~meta:run_meta
+                    ~generation:run_generation
+                    ~cascade_name:execution.cascade_name
+                    ~outcome:"cancelled"
+                    ~terminal_reason_code:"external_cancel"
+                    ~activity_kind:"keeper.turn_cancelled"
+                    ~trajectory_outcome:
+                      (Trajectory.Gated "external_cancel")
+                    ~keeper_turn_id
+                    ();
+                  Keeper_turn_fsm.emit_transition
+                    ~keeper_name:meta.name ~turn_id:keeper_turn_id
+                    ~prev:Keeper_turn_fsm.Streaming
+                    (Keeper_turn_fsm.Cancelled
+                       Keeper_turn_fsm.Cancelled_supervisor_stop);
+                  raise e)
           in
           let fail_open_rotation_cascades =
             active_fail_open_rotation_cascades ()


### PR DESCRIPTION
feat(keeper-unified-turn): outer Cancel handler emits cancelled receipt before re-raise (Cycle 1b-iv)

Closes the silent-receipt path that opens when an external cancellation
escapes Keeper_agent_run.run_turn before its in-band receipt builder
completes.

## Pre-Cycle 1b-iv behaviour

Keeper_agent_run.run_turn (lib/keeper/keeper_agent_run.ml:114-2964)
contains 14 inner `Eio.Cancel.Cancelled _ as e -> raise e` handlers.
When any of them re-raises:

- The receipt builder at line 2847-2901 may not have run yet (depends
  on which inner site cancelled first).
- The receipt-append at line 2913-2947 may not have run yet (only the
  builder happens before append).
- The Eio cancel propagates to the caller in keeper_unified_turn.ml
  line 1682, which is itself inside a `with_keeper_turn_span` span
  callback.
- That callback re-raises, the Otel span is closed via the standard
  exception propagation path, and the outer call frame returns.

Net effect: the FSM emitted [Streaming] when the turn began, then
nothing. The operator's timeline shows a turn that started but never
terminated — no receipt written, no FSM Cancelled transition.

## Cycle 1b-iv fix

Wrap the `Keeper_agent_run.run_turn` call in keeper_unified_turn.ml
line 1677-1711 with a try/with that catches `Eio.Cancel.Cancelled`,
emits a minimal cancelled receipt via the existing
`record_pre_dispatch_terminal_observation` helper (also used by
Cycle 1b-i / PR #11457), emits the matching FSM Cancelled transition,
then re-raises so the outer cancellation continues to propagate.

The receipt fields:

- outcome = "cancelled" (matches FSM, leverages PR #11360 outcome_kind
  infrastructure)
- terminal_reason_code = "external_cancel"
- activity_kind = "keeper.turn_cancelled"
- trajectory_outcome = Trajectory.Gated "external_cancel"

## What is NOT in this PR

| Follow-up | Why deferred |
|-----------|--------------|
| Refine cancel_reason classification (Cancelled_supervisor_stop vs Cancelled_fleet_shutdown vs Cancelled_provider_timeout) | Eio.Cancel does not expose the originating cancel context here. Refinement requires reading supervisor / fleet flags in scope; orthogonal to the silent-path closure that this PR is targeting. |
| Inner-site coverage gap inventory | The 14 inner Cancel re-raise sites in keeper_agent_run.ml could each emit a richer terminal_reason_code if they trapped + re-raised. Out of scope for the outer-handler bootstrap. |
| Cycle 1b-iii outcome type narrowing | Receipt outcome is still `string`; this PR keeps that surface. Tier S1 type narrowing happens in 1b-iii. |

## Risk

| Axis | Assessment |
|------|------------|
| Cancellation behaviour change | None — the cancel still propagates (raise e at the end of the with arm). |
| Receipt cardinality | +1 record per externally-cancelled turn. Previously 0 records. The producer cap is 1-per-turn so no cardinality blow-up. |
| FSM emit cardinality | +1 Cancelled transition per externally-cancelled turn (was 0). |
| Otel span | Cancel still propagates from the with arm; the with_keeper_turn_span error path is unchanged. |
| Test fixtures | None of the existing fixtures exercise external-cancel-escapes-receipt-builder — they test the inner Cancel handler chain in isolation. |

## Cycle context

| PR | Cycle | Status |
|----|-------|--------|
| #11360 | 1a outcome_kind tri-state | MERGED |
| #11457 | 1b-i first cancelled producer (phase-gate-close) | MERGED |
| this PR | 1b-iv outer Cancel handler (run_turn escape path) | OPEN |
| (prior commit on parallel branch) | 1b-ii ollama saturated outcome="error" | OPEN (PR pending) |
| (deferred) | 1b-iii outcome type narrowing | not yet started |

Plan: planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md
Plan §3 Cycle 1b-iv (outer Cancel handler for supervisor / fleet stop).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
