### PR TITLE
feat(keeper): include slot availability in semaphore-skip warn

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1609,9 +1609,22 @@ let run_keepalive_unified_turn
              keeper failure. Skip this cycle and let the next heartbeat retry
              once a slot opens up. Meta is left untouched so failure counters
              do not tick. *)
+          (* #11446 follow-up: include slot availability snapshot so operators
+             can distinguish "all slots full" (provider contention) from
+             "autonomous starved while turn slots free" (autonomous-only cap
+             hit).  Same fields already emitted at DEBUG by [semaphore_acquire]
+             on line ~466; mirroring them at WARN here makes the skip event
+             self-contained for diagnosis without log re-correlation.  Values
+             are read post-timeout so they reflect the current pool state, not
+             the moment of acquire-attempt — but for fleet contention (74/day
+             skips, 2026-04-28) the persistent-saturation pattern is what
+             matters and that survives the read-time gap. *)
+          let auto_avail = Eio.Semaphore.get_value autonomous_turn_semaphore in
+          let turn_avail = Eio.Semaphore.get_value turn_semaphore in
           Log.Keeper.warn
-            "%s: skipping turn (semaphore wait > %.0fs, peers holding slot, cascade=%s)"
-            meta_after_triage.name wait_sec meta_after_triage.cascade_name;
+            "%s: skipping turn (semaphore wait > %.0fs, peers holding slot, cascade=%s, autonomous_available=%d turn_available=%d)"
+            meta_after_triage.name wait_sec meta_after_triage.cascade_name
+            auto_avail turn_avail;
           meta_after_triage)
       else if (not has_message_signal) && obs.message_cursor_updates <> [] then
         meta_after_observe


### PR DESCRIPTION
## 배경

PR #11446 이 semaphore-skip 메시지에 `cascade=%s` 라벨을 추가했습니다. 이번 PR은 그 follow-up — slot 가용성 정보까지 메시지에 포함시켜 skip 사건을 자체 완결적으로 진단할 수 있게 합니다.

## 측정

`~/me/.masc/logs/system_log_2026-04-28.jsonl` 기준:

| 지표 | 값 |
|---|---|
| `semaphore wait > 60s` skip 누적 | **74/day** |
| sangsu plan A unpause 시도 → storm-paused | 6분, count=6/6h, turn 0회 |
| `autonomous_turn_semaphore` 기본 capacity | 3 |
| `turn_semaphore` 기본 capacity | 12 |

74 skip 의 root cause 가 ① 모든 슬롯 saturation 인지 ② autonomous-only cap 적중인지 현재 메시지로 구분 불가. cross-correlate 위해 line ~466 의 `semaphore_acquire` debug 로그를 찾아야 하는데 DEBUG는 production 에서 suppressed.

## 변경

`lib/keeper/keeper_keepalive.ml:1607-1622` 의 `Semaphore_wait_timeout` 처리 분기에 slot 가용성 snapshot 추가.

```diff
-          Log.Keeper.warn
-            "%s: skipping turn (semaphore wait > %.0fs, peers holding slot, cascade=%s)"
-            meta_after_triage.name wait_sec meta_after_triage.cascade_name;
+          let auto_avail = Eio.Semaphore.get_value autonomous_turn_semaphore in
+          let turn_avail = Eio.Semaphore.get_value turn_semaphore in
+          Log.Keeper.warn
+            "%s: skipping turn (semaphore wait > %.0fs, peers holding slot, cascade=%s, autonomous_available=%d turn_available=%d)"
+            meta_after_triage.name wait_sec meta_after_triage.cascade_name
+            auto_avail turn_avail;
```

## Trade-offs

- **장점**: skip 메시지 자체로 어느 풀에서 starve 됐는지 식별 가능. cross-log 상관관계 분석 불필요.
- **단점**: snapshot 읽는 시점이 timeout 직후라 acquire 시도 순간과 lag 존재. 단 fleet contention 의 persistent-saturation 패턴에서는 무관.

## 후속 작업 (이 PR 범위 밖)

- line 495-499 의 INFO `semaphore_wait: ...` 메시지에도 같은 정보 추가 검토 (별도 PR)
- root fix: provider별 (ollama vs cloud) semaphore 분리 RFC 작성 (architectural change, 별도 RFC)

## Test plan

- [ ] CI Build + Lint pass
- [ ] 머지 후 server restart 시점에 production 로그에서 새 format 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)