### PR TITLE
[DS-Drift Track D-3] tokenize keeper state-pill colors (global.css 3 hex)

### DIFF
--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -123,9 +123,9 @@
   &.active { background: var(--ok-22); color: var(--ok); }
   &.busy { background: var(--warn-15); color: var(--warn); }
   &.listening { background: rgba(56,189,248,0.15); color: var(--sky-400); }
-  &.idle { background: rgba(136,136,136,0.22); color: #b8c0cc; }
-  &.offline { background: rgba(85,85,85,0.22); color: #7a8494; }
-  &.todo { background: rgba(136,136,136,0.22); color: #b8c0cc; }
+  &.idle { background: rgba(136,136,136,0.22); color: var(--state-idle); }
+  &.offline { background: rgba(85,85,85,0.22); color: var(--state-offline); }
+  &.todo { background: rgba(136,136,136,0.22); color: var(--state-idle); }
   &.in-progress, &.in_progress { background: var(--warn-15); color: var(--warn); }
   &.done, &.completed { background: var(--ok-22); color: var(--ok); }
   &.running { background: var(--warn-15); color: var(--warn); }

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -104,6 +104,12 @@
   --chat-error-chip: #ffb4b4;
   --chat-code-callout: #95f3bc;
 
+  /* State chip text — keeper status pills (idle/offline/todo).
+     idle and todo intentionally share the same shade (visual rest).
+     offline is darker to signal hard inactivity. */
+  --state-idle: #b8c0cc;
+  --state-offline: #7a8494;
+
   /* Semantic - Critical (Red) */
   --bad-light: #f87171;
   --bad-soft: rgba(239, 68, 68, 0.15);


### PR DESCRIPTION
## Summary

Track D 세 번째 surgical hex consolidation. \`global.css\` 의 keeper state-pill 3 raw hex 를 variables.css 의 state-* 토큰으로 치환.

## Hex inventory

| Selector | Hex | Token |
|----------|-----|-------|
| \`&.idle\` color | #b8c0cc | --state-idle |
| \`&.offline\` color | #7a8494 | --state-offline |
| \`&.todo\` color | #b8c0cc | --state-idle (shared with idle) |

idle 과 todo 가 동일 hex 공유 — visual rest semantic. offline 은 더 어두운 hex 로 hard inactivity 표현. 단일 토큰 (--state-idle) 으로 idle+todo 통합, --state-offline 별도.

## Why variables.css

Per CSS-ARCHITECTURE.md two-tier governance (PR #11475): variables.css 는 live-surface bright SSOT. keeper state semantic 은 여기가 정합.

## Verification

- global.css raw hex 잔존 (state pills): 0
- variables.css +6 lines (2 tokens + comment)
- 색상 시각적 동일

## Files

- \`dashboard/src/styles/variables.css\` (+6)
- \`dashboard/src/styles/global.css\` (3 hex -> 3 var())

## Track context

| PR | Track | hex |
|----|-------|-----|
| #11486 (merged) | D-1 vote buttons | 6 |
| #11490 (merged) | D-2 chat roles | 7 |
| **this** | **D-3 global state pills** | **3** |

Track D 잔여:
- ops.css 2 hex (Tailwind red-200/cyan-200)
- base.css 1 hex (gradient stop, 보존 권장)
- live-monitor.css 1 hex (purple-500)