### PR TITLE
chore(types): expose autoresearch_serde surface

### DIFF
--- a/lib/autoresearch/autoresearch_serde.mli
+++ b/lib/autoresearch/autoresearch_serde.mli
@@ -1,0 +1,46 @@
+(** Autoresearch_serde — JSON serialization for autoresearch types.
+
+    Re-exports the type SSOT from {!Autoresearch_types} via
+    [include module type of] and adds typed converters between those
+    domain records and [Yojson.Safe.t]. The [_result]-suffixed
+    decoders return [(T, string) result] so callers can surface
+    legacy-schema and parse failures verbatim.
+
+    Internal field-extraction helpers ([required_string_field],
+    [optional_int_field], etc.) and the [field_error] /
+    [yojson_type_name] diagnostic builders are hidden — they exist
+    only to keep the converter bodies short.
+
+    @since 2.80.0 *)
+
+include module type of Autoresearch_types
+
+(** {1 Enum string conversions} *)
+
+val decision_to_string : decision -> string
+(** ["keep"] / ["discard"]. *)
+
+val decision_of_string_result : string -> (decision, string) result
+
+val status_to_string : status -> string
+(** ["running"] / ["completed"] / ["stopped"] / ["error"]. *)
+
+val status_of_string_result : string -> (status, string) result
+
+(** {1 JSON converters} *)
+
+val cycle_to_yojson : cycle_record -> Yojson.Safe.t
+val cycle_of_yojson_result : Yojson.Safe.t -> (cycle_record, string) result
+
+val state_to_yojson : loop_state -> Yojson.Safe.t
+
+val state_of_yojson_result :
+  Yojson.Safe.t -> (persisted_summary, string) result
+(** Decoded shape is the persisted summary record (a wider view than
+    [loop_state]), so callers can lift the [updated_at] back-fill in
+    {!Autoresearch_storage.load_state_result}. *)
+
+val execution_link_to_yojson : execution_link -> Yojson.Safe.t
+
+val execution_link_of_yojson_result :
+  Yojson.Safe.t -> (execution_link, string) result


### PR DESCRIPTION
## Summary

\`lib/autoresearch/autoresearch_serde.ml\` (356줄, JSON serde) 에 selective .mli 추가. \`include module type of\` 패턴으로 6 type re-export + 10 converter expose.

## Surface

| 노출 | 비고 |
|------|------|
| \`include module type of Autoresearch_types\` | 6 types (decision/cycle_record/status/loop_state/execution_link/persisted_summary) |
| decision_to_string, decision_of_string_result | enum |
| status_to_string, status_of_string_result | enum |
| cycle_to_yojson, cycle_of_yojson_result | record JSON |
| state_to_yojson, state_of_yojson_result | record JSON (returns persisted_summary) |
| execution_link_to_yojson, execution_link_of_yojson_result | record JSON |

## Hidden

| 숨김 (9) | 비고 |
|------|------|
| yojson_type_name, field_error | diagnostic builders |
| required/optional × string/int/float (6 field extractors) | converter 내부 helper |
| loop_target_reached | 외부 caller 0, internal domain logic |

## Pattern Reuse

cycle 32-33 (autoresearch_git/storage)와 같은 \`(T, string) result\` 패턴 유지. \`include module type of\` 는 cycle 17 (env_config), 27 (rate_limit_types), 32-33의 \`Autoresearch_types\` chain과 일관.

## Status

이 PR 머지로 lib/autoresearch sub-dir 3 모듈 (.mli 누적 -3): \`autoresearch_git\` (#11495), \`autoresearch_storage\` (#11496), \`autoresearch_serde\` (#11497) 모두 정리 완료.

## Ratchet

\`lib_other_mli_missing\` 단조 감소 (-1).

## Test plan
- [ ] CI: dune build / dune runtest
- [ ] ratchet baseline diff