### PR TITLE
fix(coord): log_event signature is string not Yojson.Safe.t (main-broken)

### DIFF
--- a/lib/coord/coord_utils_ops.mli
+++ b/lib/coord/coord_utils_ops.mli
@@ -159,6 +159,9 @@ val with_file_lock_r :
 
 (** {1 Event logging} *)
 
-(** Append [event_json] to the YYYY-MM/DD.jsonl event log under
-    [.masc/events/]. *)
-val log_event : config -> Yojson.Safe.t -> unit
+(** Append [event_line] (a JSON-shaped string, callers hand-build via
+    [Printf.sprintf]) to the YYYY-MM/DD.jsonl event log under
+    [.masc/events/]. The implementation appends a literal "\n" via
+    string concatenation; passing a [Yojson.Safe.t] would not match
+    that interface and would also break every existing caller. *)
+val log_event : config -> string -> unit


### PR DESCRIPTION
## Summary

PR #11400 (`refactor(coord): add coord_utils_ops.mli`) declared:

```ocaml
val log_event : config -> Yojson.Safe.t -> unit
```

but the implementation in `coord_utils_ops.ml:580` does:

```ocaml
Fs_compat.append_file log_file (event_json ^ "\n")
```

(string concatenation), and every caller hand-builds a JSON-shaped string via `Printf.sprintf "{...}"`:

| File | Lines |
|------|-------|
| `coord_lifecycle.ml` | 111, 177, 242 |
| `coord_gc.ml` | 142, 168, 428 |
| `coord_agent.ml` | 63, 134 |
| `coord_task.ml` | 182, 197 |
| `coord_task_schedule.ml` | 320 |

This is one of several main-broken errors blocking the ~30 Ready PR queue.

## Fix

Update `.mli` to `string` to align all three layers (`.mli`, `.ml`, callers). The .mli reflected the structurally-better intent (pass typed JSON, serialize at the boundary), but until the .ml is rewritten and every call site is migrated, the .mli must match the existing impl.

## Out of scope

The structured-JSON migration (rewrite .ml + 11 caller sites to use `Yojson.Safe.t`) is left for a separate PR — that's a behavior-preserving refactor, not a build-fix.

Other main-broken errors observed but not in this PR:
- `lib/coord/coord_utils_ops.ml:210` — `Backend_types.error result` mismatch
- `lib/coord/coord_bootstrap.ml:40`, `coord_init.ml:29` — Unbound `root_state_path`
- `lib/coord/coord_broadcast.ml:59` — Unbound `project_prefix`
- `lib/coord/{coord_query,coord_status,coord_task}.ml` — `backlog.tasks` field type mismatch
- `lib/coord/{coord_backlog,coord_state,coord_utils_paths_backend}.ml` — pp.ml interface conflicts

## Verification

`dune build lib/coord/` removes 5 caller errors that all reported `expression has type string but expected Yojson.Safe.t`.

## Test plan

- [x] Local build progresses past the log_event errors
- [ ] CI green
- [ ] Combined with the other in-flight coord cascade fixes, BLOCKED PR queue starts unblocking
