### PR TITLE
fix(coord): expose read_backlog as Types.backlog facade (main-broken)

### DIFF
--- a/lib/coord/coord_backlog.mli
+++ b/lib/coord/coord_backlog.mli
@@ -6,8 +6,8 @@ open Coord_utils
 
 val backlog_recovery_path : Coord_utils_backend_setup.config -> string
 val decode_backlog : path:string ->
-           Yojson.Safe.t -> (Types_core.backlog, string) result
+           Yojson.Safe.t -> (Types.backlog, string) result
 val read_backlog_r : Coord_utils_backend_setup.config ->
-           (Types_core.backlog, string) result
-val read_backlog : Coord_utils_backend_setup.config -> Types_core.backlog
-val write_backlog : Coord_utils_backend_setup.config -> Types_core.backlog -> unit
+           (Types.backlog, string) result
+val read_backlog : Coord_utils_backend_setup.config -> Types.backlog
+val write_backlog : Coord_utils_backend_setup.config -> Types.backlog -> unit

--- a/lib/coord/coord_state.mli
+++ b/lib/coord/coord_state.mli
@@ -22,16 +22,16 @@ val append_archive_tasks :
   Coord_utils_backend_setup.config -> Types_core.task list -> unit
 
 val next_task_number :
-  Coord_utils_backend_setup.config -> Types_core.backlog -> int
+  Coord_utils_backend_setup.config -> Types.backlog -> int
 
 val read_backlog_r :
   Coord_utils_backend_setup.config ->
-  (Types_core.backlog, string) result
+  (Types.backlog, string) result
 
-val read_backlog : Coord_utils_backend_setup.config -> Types_core.backlog
+val read_backlog : Coord_utils_backend_setup.config -> Types.backlog
 
 val write_backlog :
-  Coord_utils_backend_setup.config -> Types_core.backlog -> unit
+  Coord_utils_backend_setup.config -> Types.backlog -> unit
 
 val non_empty_string_opt : string option -> string option
 val normalized_string_list : string list -> string list


### PR DESCRIPTION
## Summary

Mirror of #11473's coord_hooks fix, applied to `read_backlog`.

After PR #11418 introduced `lib/types/types.mli` as a facade with `include module type of Types_core`, the strengthened signature treats `Types.X` and `Types_core.X` as distinct paths under signature ascription — even though they are the same underlying type.

Three coord/* call sites accessed `backlog.tasks` and got:

```
Error: The field access backlog.tasks has type Types_core.task list
       but an expression was expected of type task list
       Type Types_core.task is not compatible with type task
```

The callers `(t : task)` resolve through `open Types` to `Types.task`, which doesn't unify with `Types_core.task` after the facade was added.

## Fix

Flip `Types_core.backlog` → `Types.backlog` in `coord_backlog.mli` and `coord_state.mli` (the two `read_backlog` declarations). Same one-line approach #11473 used for `Types_core.task_action` → `Types.task_action` in `coord_hooks.mli`.

## Affected (resolved)

- `lib/coord/coord_query.ml:18, :25, :147, :296, :310` — `(t : task)` annotations
- `lib/coord/coord_status.ml:78, :106`
- `lib/coord/coord_task.ml:80`

## Verification

`dune build lib/coord/` removes 3 backlog.tasks errors.

## Out of scope

Other main-broken errors observed but not in this PR:

- `coord_utils_ops.ml:210` — `Backend_types.error result` mismatch
- `coord_bootstrap.ml:40`, `coord_init.ml:29` — Unbound `root_state_path`
- `coord_broadcast.ml:59` — Unbound `project_prefix`
- `coord_worktree.ml:887` + 4 others — `string` vs `Yojson.Safe.t` (5 callers; the .mli mismatch itself is fixed in #11504)
- `coord_backlog.ml`, `coord_state.ml`, `coord_utils_paths_backend.ml` — pp.ml interface conflicts (likely auto-resolve once underlying types unify)

## Test plan

- [x] Local `dune build lib/coord/` — backlog.tasks errors gone
- [ ] CI green
- [ ] Combined with #11504 + other in-flight fixes, BLOCKED PR queue starts unblocking
