### PR TITLE
fix(coord): repair lib/coord build cascade — Types facade, log_event sig, mli surface

### DIFF
--- a/lib/coord/coord_agent.ml
+++ b/lib/coord/coord_agent.ml
@@ -60,11 +60,11 @@ let register_capabilities config ~agent_name ~capabilities =
           write_json config agent_file (agent_to_yojson updated);
 
           (* Log event *)
-          log_event config (Printf.sprintf
+          log_event config (Yojson.Safe.from_string (Printf.sprintf
             "{\"type\":\"capabilities_registered\",\"agent\":\"%s\",\"capabilities\":%s,\"ts\":\"%s\"}"
             actual_name
             (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) capabilities)))
-            (now_iso ()));
+            (now_iso ())));
 
           Printf.sprintf "📡 %s capabilities: %s" actual_name (String.concat ", " capabilities)
       | Error _ ->
@@ -131,12 +131,12 @@ let update_agent_r config ~agent_name ?status ?capabilities () : string Types.ma
                               last_seen = now_iso ();
                             } in
                             write_json config agent_file (agent_to_yojson updated);
-                            log_event config (Printf.sprintf
+                            log_event config (Yojson.Safe.from_string (Printf.sprintf
                               "{\"type\":\"agent_update\",\"agent\":\"%s\",\"status\":\"%s\",\"capabilities\":%s,\"ts\":\"%s\"}"
                               actual_name
                               (Types.agent_status_to_string updated_status)
                               (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) updated_caps)))
-                              (now_iso ()));
+                              (now_iso ())));
                             Ok (Printf.sprintf "✅ %s updated" actual_name)
                        ))
             )

--- a/lib/coord/coord_backlog.mli
+++ b/lib/coord/coord_backlog.mli
@@ -6,8 +6,8 @@ open Coord_utils
 
 val backlog_recovery_path : Coord_utils_backend_setup.config -> string
 val decode_backlog : path:string ->
-           Yojson.Safe.t -> (Types_core.backlog, string) result
+           Yojson.Safe.t -> (Types.backlog, string) result
 val read_backlog_r : Coord_utils_backend_setup.config ->
-           (Types_core.backlog, string) result
-val read_backlog : Coord_utils_backend_setup.config -> Types_core.backlog
-val write_backlog : Coord_utils_backend_setup.config -> Types_core.backlog -> unit
+           (Types.backlog, string) result
+val read_backlog : Coord_utils_backend_setup.config -> Types.backlog
+val write_backlog : Coord_utils_backend_setup.config -> Types.backlog -> unit

--- a/lib/coord/coord_bootstrap.mli
+++ b/lib/coord/coord_bootstrap.mli
@@ -4,5 +4,5 @@
 open Types
 open Coord_utils
 
-val default_room_state : Coord_utils_backend_setup.config -> Types_core.room_state
+val default_room_state : Coord_utils_backend_setup.config -> Types.room_state
 val ensure_room_bootstrap : Coord_utils_backend_setup.config -> unit

--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -139,9 +139,9 @@ let cleanup_zombies
              | Error e ->
                  if not (List.mem assignee !release_failed_agents) then
                    release_failed_agents := assignee :: !release_failed_agents;
-                 log_event config (Printf.sprintf
+                 log_event config (Yojson.Safe.from_string (Printf.sprintf
                    "{\"type\":\"zombie_cascade_error\",\"task_id\":\"%s\",\"agent\":\"%s\",\"error\":\"%s\",\"ts\":\"%s\"}"
-                   task.id assignee (Types.masc_error_to_string e) (now_iso ())))
+                   task.id assignee (Types.masc_error_to_string e) (now_iso ()))))
         | Types.Claimed _ | Types.InProgress _
         | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> ()
       ) backlog.tasks;
@@ -165,12 +165,12 @@ let cleanup_zombies
           { s with active_agents =
               List.filter (fun a -> not (List.mem a !successfully_cleaned)) s.active_agents }
         ) in
-        log_event config (Printf.sprintf
+        log_event config (Yojson.Safe.from_string (Printf.sprintf
           "{\"type\":\"zombie_cleanup\",\"agents\":%s,\"released_tasks\":%d,\"skipped\":%d,\"ts\":\"%s\"}"
           (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) !successfully_cleaned)))
           (List.length !released_tasks)
           (List.length !zombie_entries - List.length !successfully_cleaned)
-          (now_iso ()))
+          (now_iso ())))
       end;
 
       let total = List.length !zombie_entries in
@@ -425,10 +425,10 @@ let gc config ?(days=7) () =
      Startup migration (migrate_room_to_flat) moves active room to root. *)
   results := "✅ Rooms flattened (no room archival needed)" :: !results;
 
-  log_event config (Printf.sprintf
+  log_event config (Yojson.Safe.from_string (Printf.sprintf
     "{\"type\":\"gc\",\"stale_tasks\":%d,\"old_messages\":%d,\"preserved\":%d,\"pubsub_cleaned\":%d,\"keeper_orphans\":%d,\"sessions_archived\":%d,\"board_artifacts\":%d,\"rooms_archived\":%d,\"cp_cleanup\":%s,\"days\":%d,\"ts\":\"%s\"}"
     !stale_count !old_msg_count !preserved_count !pubsub_cleanup_count !keeper_orphan_count !session_archive_count
     board_artifact_count
-    0 cp_json days (now_iso ()));
+    0 cp_json days (now_iso ())));
 
   String.concat "\n" (List.rev !results)

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -108,9 +108,9 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
            broadcast config ~from_agent:nickname
              ~content:(Printf.sprintf "👋 %s rejoined the namespace" nickname)
          in
-         log_event config (Printf.sprintf
+         log_event config (Yojson.Safe.from_string (Printf.sprintf
            "{\"type\":\"agent_join\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
-           nickname agent_type new_session_id (now_iso ()));
+           nickname agent_type new_session_id (now_iso ())));
          (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:nickname
            ~event:Coord_hooks.Lifecycle_rejoin
            ~details:
@@ -174,13 +174,13 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
   in
 
   (* Log event with metadata *)
-  log_event config (Printf.sprintf
+  log_event config (Yojson.Safe.from_string (Printf.sprintf
     "{\"type\":\"agent_join\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"capabilities\":%s,\"ts\":\"%s\"}"
     nickname
     agent_type
     session_id
     (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) capabilities)))
-    (now_iso ()));
+    (now_iso ())));
   (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:nickname
     ~event:Coord_hooks.Lifecycle_join
     ~details:
@@ -239,9 +239,9 @@ let leave config ~agent_name =
     in
 
     (* Log event *)
-    log_event config (Printf.sprintf
+    log_event config (Yojson.Safe.from_string (Printf.sprintf
       "{\"type\":\"agent_leave\",\"agent\":\"%s\",\"ts\":\"%s\"}"
-      actual_name (now_iso ()));
+      actual_name (now_iso ())));
     (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:actual_name
       ~event:Coord_hooks.Lifecycle_leave
       ~details:`Null;

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -34,9 +34,9 @@ let update_priority config ~task_id ~priority =
           } in
           write_backlog config new_backlog;
 
-          log_event config (Printf.sprintf
+          log_event config (Yojson.Safe.from_string (Printf.sprintf
             "{\"type\":\"priority_change\",\"task\":\"%s\",\"old\":%d,\"new\":%d,\"ts\":\"%s\"}"
-            task_id old_priority priority (now_iso ()));
+            task_id old_priority priority (now_iso ())));
           (Atomic.get Coord_hooks.on_task_mutation_fn) ();
 
           Printf.sprintf "✅ Task %s priority: P%d → P%d" task_id old_priority priority

--- a/lib/coord/coord_state.mli
+++ b/lib/coord/coord_state.mli
@@ -4,7 +4,7 @@ open Types
 open Coord_utils
 
 val default_room_state :
-  Coord_utils_backend_setup.config -> Types_core.room_state
+  Coord_utils_backend_setup.config -> Types.room_state
 
 val ensure_room_bootstrap : Coord_utils_backend_setup.config -> unit
 val generate_session_id : unit -> string
@@ -19,19 +19,19 @@ val task_id_to_int : string -> int option
 val read_archive_task_ids : Coord_utils_backend_setup.config -> int list
 
 val append_archive_tasks :
-  Coord_utils_backend_setup.config -> Types_core.task list -> unit
+  Coord_utils_backend_setup.config -> Types.task list -> unit
 
 val next_task_number :
-  Coord_utils_backend_setup.config -> Types_core.backlog -> int
+  Coord_utils_backend_setup.config -> Types.backlog -> int
 
 val read_backlog_r :
   Coord_utils_backend_setup.config ->
-  (Types_core.backlog, string) result
+  (Types.backlog, string) result
 
-val read_backlog : Coord_utils_backend_setup.config -> Types_core.backlog
+val read_backlog : Coord_utils_backend_setup.config -> Types.backlog
 
 val write_backlog :
-  Coord_utils_backend_setup.config -> Types_core.backlog -> unit
+  Coord_utils_backend_setup.config -> Types.backlog -> unit
 
 val non_empty_string_opt : string option -> string option
 val normalized_string_list : string list -> string list
@@ -43,17 +43,17 @@ val recover_active_agent_name : Yojson.Safe.t -> string option
 
 val recover_room_state :
   Coord_utils_backend_setup.config ->
-  Yojson.Safe.t -> Types_core.room_state
+  Yojson.Safe.t -> Types.room_state
 
 val write_state :
-  Coord_utils_backend_setup.config -> Types_core.room_state -> unit
+  Coord_utils_backend_setup.config -> Types.room_state -> unit
 
-val read_state : Coord_utils_backend_setup.config -> Types_core.room_state
+val read_state : Coord_utils_backend_setup.config -> Types.room_state
 
 val update_state :
   Coord_utils_backend_setup.config ->
-  (Types_core.room_state -> Types_core.room_state) ->
-  Types_core.room_state
+  (Types.room_state -> Types.room_state) ->
+  Types.room_state
 
 val next_seq : Coord_utils_backend_setup.config -> int
 val is_paused : Coord_utils_backend_setup.config -> bool

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -180,32 +180,30 @@ let required_tool_claim_guard config ~agent_name ?agent_tool_names task =
   | [], _ -> Ok ()
   | _ :: _, None ->
     log_event config
-      (Yojson.Safe.to_string
-         (`Assoc
-             [ "type", `String "task_claim_required_tools_unknown_surface"
-             ; "agent", `String agent_name
-             ; "task", `String task.id
-             ; ( "required_tools",
-                 `List (List.map (fun name -> `String name) required_tools) )
-             ; "ts", `String (now_iso ())
-             ]));
+      (`Assoc
+         [ "type", `String "task_claim_required_tools_unknown_surface"
+         ; "agent", `String agent_name
+         ; "task", `String task.id
+         ; ( "required_tools",
+             `List (List.map (fun name -> `String name) required_tools) )
+         ; "ts", `String (now_iso ())
+         ]);
     Ok ()
   | _ :: _, Some allowed ->
     let missing = missing_required_tools ~allowed required_tools in
     if missing = [] then Ok ()
     else (
       log_event config
-        (Yojson.Safe.to_string
-           (`Assoc
-               [ "type", `String "task_claim_required_tools_blocked"
-               ; "agent", `String agent_name
-               ; "task", `String task.id
-               ; ( "required_tools",
-                   `List (List.map (fun name -> `String name) required_tools) )
-               ; ( "missing_tools",
-                   `List (List.map (fun name -> `String name) missing) )
-               ; "ts", `String (now_iso ())
-               ]));
+        (`Assoc
+           [ "type", `String "task_claim_required_tools_blocked"
+           ; "agent", `String agent_name
+           ; "task", `String task.id
+           ; ( "required_tools",
+               `List (List.map (fun name -> `String name) required_tools) )
+           ; ( "missing_tools",
+               `List (List.map (fun name -> `String name) missing) )
+           ; "ts", `String (now_iso ())
+           ]);
       Error
         (Types.TaskInvalidState
            (Printf.sprintf
@@ -838,14 +836,13 @@ let claim_task config ~agent_name ~task_id =
                     ~payload:(`Assoc [ "task_id", `String task_id ]);
                   log_event
                     config
-                    (Yojson.Safe.to_string
-                       (`Assoc
+                    (`Assoc
                            [ "type", `String "task_claim"
                            ; "agent", `String agent_name
                            ; "actor_kind", `String (task_actor_kind agent_name)
                            ; "task", `String task_id
                            ; "ts", `String (now_iso ())
-                           ]));
+                           ]);
                   observe_task_transition
                     config
                     ~agent_name
@@ -972,14 +969,13 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
              ~payload:(`Assoc [ "task_id", `String task_id ]);
            log_event
              config
-             (Yojson.Safe.to_string
-                (`Assoc
+             (`Assoc
                     [ "type", `String "task_claim"
                     ; "agent", `String agent_name
                     ; "actor_kind", `String (task_actor_kind agent_name)
                     ; "task", `String task_id
                     ; "ts", `String (now_iso ())
-                    ]));
+                    ]);
            observe_task_transition
              config
              ~agent_name
@@ -1536,8 +1532,7 @@ let transition_task_r
               else agent);
           log_event
             config
-            (Yojson.Safe.to_string
-               (transition_log_event
+            (transition_log_event
                   ~event_type:Task_transition
                   ~agent_name
                   ~task_id
@@ -1551,7 +1546,7 @@ let transition_task_r
                     (match handoff_context with
                      | Some _ when action = Types.Release -> handoff_context
                      | _ -> None)
-                  ()));
+                  ());
           (match action with
            | Types.Claim ->
              emit_task_activity
@@ -1916,8 +1911,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                        ]);
                log_event
                  config
-                 (Yojson.Safe.to_string
-                    (transition_log_event
+                 (transition_log_event
                        ~event_type:Task_cancelled
                        ~agent_name
                        ~task_id
@@ -1929,7 +1923,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                             ; reason = (if reason = "" then None else Some reason)
                             })
                        ?reason:(if reason = "" then None else Some reason)
-                       ()));
+                       ());
                observe_task_transition
                  config
                  ~agent_name
@@ -2062,8 +2056,7 @@ let link_task_execution_artifacts_r
                       | None -> []));
              log_event
                config
-               (Yojson.Safe.to_string
-                  (`Assoc
+               (`Assoc
                       ([ "type", `String "task_linked"
                        ; "agent", `String "system"
                        ; "actor_kind", `String "system"
@@ -2080,7 +2073,7 @@ let link_task_execution_artifacts_r
                        match trim_opt autoresearch_loop_id with
                        | Some autoresearch_loop_id ->
                          [ "autoresearch_loop_id", `String autoresearch_loop_id ]
-                       | None -> [])));
+                       | None -> []));
              Ok (Printf.sprintf "✅ Linked execution artifacts for %s" task_id))
       with
       | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -147,7 +147,7 @@ val clear_soft_do_not_reclaim_reason : Types.task -> Types.task
 (** {1 Task transitions} *)
 
 val transition_task_r :
-  config -> agent_name:string -> task_id:string -> action:Types_core.task_action ->
+  config -> agent_name:string -> task_id:string -> action:Types.task_action ->
   ?agent_tool_names:string list ->
   ?prepare_verification_request:
     (task:Types.task ->

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -317,9 +317,9 @@ let reconcile_agent_current_task_with_backlog config ~agent_name backlog =
               in
               write_json config agent_file (agent_to_yojson updated);
               log_event config
-                (Printf.sprintf
+                (Yojson.Safe.from_string (Printf.sprintf
                    "{\"type\":\"agent_current_task_reconciled\",\"agent\":\"%s\",\"stale_task\":\"%s\",\"ts\":\"%s\"}"
-                   agent_name task_id (now_iso ()))
+                   agent_name task_id (now_iso ())))
           | Some _ | None -> ())
       | Error msg ->
           Log.Misc.error "agent state reconcile failed: %s" msg)
@@ -385,9 +385,9 @@ let claim_next_r
                and then re-entered claim_next).  Same reason vocabulary
                the structured observation already uses. *)
             let from_status = task_status_label prev.task_status in
-            log_event config (Printf.sprintf
+            log_event config (Yojson.Safe.from_string (Printf.sprintf
               "{\"type\":\"task_claim_next_auto_release\",\"agent\":\"%s\",\"released_task\":\"%s\",\"from_status\":\"%s\",\"reason\":\"prev_claim_implicit_replaced\",\"ts\":\"%s\"}"
-              agent_name prev.id from_status (now_iso ()));
+              agent_name prev.id from_status (now_iso ())));
             (* #10421: warn-level log so dashboards see the implicit
                release at fleet scale. [InProgress → Todo] is the
                more concerning subset (mid-work churn) — from_status
@@ -451,14 +451,14 @@ let claim_next_r
       in
       if blocked_todo <> [] then
         log_event config
-          (Printf.sprintf
+          (Yojson.Safe.from_string (Printf.sprintf
              "{\"type\":\"task_claim_next_skip_blocked\",\"agent\":\"%s\",\"blocked\":%d,\"ts\":\"%s\"}"
-             agent_name (List.length blocked_todo) (now_iso ()));
+             agent_name (List.length blocked_todo) (now_iso ())));
       if verification_blocked_todo <> [] then
         log_event config
-          (Printf.sprintf
+          (Yojson.Safe.from_string (Printf.sprintf
              "{\"type\":\"task_claim_next_skip_verification\",\"agent\":\"%s\",\"blocked\":%d,\"ts\":\"%s\"}"
-             agent_name (List.length verification_blocked_todo) (now_iso ()));
+             agent_name (List.length verification_blocked_todo) (now_iso ())));
 
       let primary_unclaimed =
         List.filter task_is_primary_claim_pool_candidate sorted
@@ -493,12 +493,12 @@ let claim_next_r
          && List.exists (fun task -> task_required_tools task <> []) unclaimed
       then
         log_event config
-          (Printf.sprintf
+          (Yojson.Safe.from_string (Printf.sprintf
              "{\"type\":\"task_claim_next_required_tools_unknown_surface\",\"agent\":\"%s\",\"candidate_count\":%d,\"ts\":\"%s\"}"
              agent_name
              (List.length
                 (List.filter (fun task -> task_required_tools task <> []) unclaimed))
-             (now_iso ()));
+             (now_iso ())));
       let required_tool_claim_allowed (task : task) =
         let required_tools = task_required_tools task in
         required_tools_allowed ?agent_tool_names required_tools
@@ -514,13 +514,13 @@ let claim_next_r
       in
       if required_tool_excluded <> [] then
         log_event config
-          (Printf.sprintf
+          (Yojson.Safe.from_string (Printf.sprintf
              "{\"type\":\"task_claim_next_skip_required_tools\",\"agent\":\"%s\",\"blocked\":%d,\"receipt_blocked\":%b,\"agent_tool_names_known\":%b,\"ts\":\"%s\"}"
              agent_name
              (List.length required_tool_excluded)
              (List.exists receipt_blocks_task required_tool_excluded)
              (Option.is_some agent_tool_names)
-             (now_iso ()));
+             (now_iso ())));
       let effective_task_filter task =
         task_filter task && required_tool_claim_allowed task
       in
@@ -636,9 +636,9 @@ let claim_next_r
                   ("priority", `Int task.priority);
                 ]);
 
-          log_event config (Printf.sprintf
+          log_event config (Yojson.Safe.from_string (Printf.sprintf
             "{\"type\":\"task_claim_next\",\"agent\":\"%s\",\"task\":\"%s\",\"priority\":%d,\"ts\":\"%s\"}"
-            agent_name task.id task.priority (now_iso ()));
+            agent_name task.id task.priority (now_iso ())));
           Coord_task.observe_task_transition config ~agent_name ~task_id:task.id
             ~transition:Types.Claim
             ~details:
@@ -704,18 +704,18 @@ let release_stale_claims config ~ttl_seconds =
               let ts = parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) claimed_at in
               if now_f -. ts > ttl_seconds then begin
                 stale_tasks := (task.id, assignee) :: !stale_tasks;
-                log_event config (Printf.sprintf
+                log_event config (Yojson.Safe.from_string (Printf.sprintf
                   "{\"type\":\"stale_claim_released\",\"task_id\":\"%s\",\"assignee\":\"%s\",\"age_s\":%.0f,\"ts\":\"%s\"}"
-                  task.id assignee (now_f -. ts) now_str);
+                  task.id assignee (now_f -. ts) now_str));
                 { task with task_status = Todo }
               end else task
           | InProgress { assignee; started_at } ->
               let ts = parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) started_at in
               if now_f -. ts > ttl_seconds then begin
                 stale_tasks := (task.id, assignee) :: !stale_tasks;
-                log_event config (Printf.sprintf
+                log_event config (Yojson.Safe.from_string (Printf.sprintf
                   "{\"type\":\"stale_inprogress_released\",\"task_id\":\"%s\",\"assignee\":\"%s\",\"age_s\":%.0f,\"ts\":\"%s\"}"
-                  task.id assignee (now_f -. ts) now_str);
+                  task.id assignee (now_f -. ts) now_str));
                 { task with task_status = Todo }
               end else task
           | AwaitingVerification _ -> task  (* leave alone; awaiting verifier *)

--- a/lib/coord/coord_task_schedule.mli
+++ b/lib/coord/coord_task_schedule.mli
@@ -10,10 +10,10 @@ include module type of Coord_state
 type verification_claim_state =
   [ `Pending | `Assigned | `Passed | `Rejected ]
 
-val task_status_label : Types_core.task_status -> string
-val task_is_claim_pool_candidate : Types_core.task -> bool
-val task_is_primary_claim_pool_candidate : Types_core.task -> bool
-val task_is_soft_reclaim_candidate : Types_core.task -> bool
+val task_status_label : Types.task_status -> string
+val task_is_claim_pool_candidate : Types.task -> bool
+val task_is_primary_claim_pool_candidate : Types.task -> bool
+val task_is_soft_reclaim_candidate : Types.task -> bool
 
 val verification_claim_state_of_status :
   Coord_verification_store.request_status -> verification_claim_state
@@ -23,9 +23,9 @@ val latest_verification_status_by_task :
 
 val verification_blocks_claim :
   (string, 'a * verification_claim_state) Hashtbl.t ->
-  Types_core.task -> bool
+  Types.task -> bool
 
-val task_required_tools : Types_core.task -> string list
+val task_required_tools : Types.task -> string list
 val string_list_contains : string list -> string -> bool
 
 val required_tools_allowed :
@@ -62,19 +62,19 @@ val latest_receipt_blocks_required_tool_claim :
   config -> agent_name:string -> required_tools:string list -> bool
 
 val agent_current_task_matches_backlog :
-  Types_core.backlog -> agent_name:string -> string -> bool
+  Types.backlog -> agent_name:string -> string -> bool
 
 val reconcile_agent_current_task_with_backlog :
-  config -> agent_name:string -> Types_core.backlog -> unit
+  config -> agent_name:string -> Types.backlog -> unit
 
 val claim_next_r :
   config ->
   agent_name:string ->
   ?agent_tool_names:string list ->
   ?exclude_task_ids:string list ->
-  ?task_filter:(Types_core.task -> bool) ->
+  ?task_filter:(Types.task -> bool) ->
   unit ->
-  Types_core.claim_next_result
+  Types.claim_next_result
 
 val claim_next : config -> agent_name:string -> string
 

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -5,12 +5,14 @@ open Coord_utils_paths_backend
 let contains_substring = String_util.contains_substring
 
 let validate_agent_name name =
-  (* Delegate to Validation module for consistent security checks *)
-  Validation.Agent_id.validate name
+  match Validation.Agent_id.validate name with
+  | Ok _ -> Ok name
+  | Error msg -> Error msg
 
 let validate_task_id id =
-  (* Delegate to Validation module for consistent security checks *)
-  Validation.Task_id.validate id
+  match Validation.Task_id.validate id with
+  | Ok _ -> Ok id
+  | Error msg -> Error msg
 
 (* Allowed character class for room ids: [A-Za-z0-9._-]+, anchored.
    Hoisted to module load so room-id validation (called per MCP
@@ -577,4 +579,4 @@ let log_event config event_json =
   in
   let log_file = Filename.concat month_dir day in
 
-  Fs_compat.append_file log_file (event_json ^ "\n")
+  Fs_compat.append_file log_file (Yojson.Safe.to_string event_json ^ "\n")

--- a/lib/coord/coord_utils_ops.mli
+++ b/lib/coord/coord_utils_ops.mli
@@ -81,7 +81,7 @@ val should_dual_write_local : config -> bool
 (** Backend-routed JSON write; respects [should_dual_write_local]. *)
 val write_json : config -> string -> Yojson.Safe.t -> unit
 
-val write_text_local : string -> string -> unit
+val write_text_local : string -> string -> (unit, string) result
 val write_text : config -> string -> string -> unit
 val delete_path : config -> string -> unit
 val path_exists : config -> string -> bool

--- a/lib/coord/coord_utils_paths_backend.mli
+++ b/lib/coord/coord_utils_paths_backend.mli
@@ -34,6 +34,18 @@ val state_path : config -> string
 val backlog_path : config -> string
 val archive_path : config -> string
 
+(** Cluster-root state.json path. Used by bootstrap/init to gate
+    one-time root setup. *)
+val root_state_path : config -> string
+
+(** Pre-rename cluster-root state path (legacy [.masc/state.json]).
+    Kept exposed for fallback existence checks during migration. *)
+val legacy_root_state_path : config -> string
+
+(** Project-scoped key prefix for backend keys (e.g.
+    ["proj:default"]). Used by broadcast/pubsub channel naming. *)
+val project_prefix : config -> string
+
 (** {1 Backend dispatch} *)
 
 (** Always [false] — postgres backend was removed. *)
@@ -49,8 +61,10 @@ val backend_set :
 val backend_delete :
   config -> key:string -> (bool, Backend_types.error) result
 
+(** Plain [bool] (not [result]); the underlying backend implementations
+    do not return errors here, and call sites compose with [||]. *)
 val backend_exists :
-  config -> key:string -> (bool, Backend_types.error) result
+  config -> key:string -> bool
 
 val backend_list_keys :
   config -> prefix:string -> (string list, Backend_types.error) result
@@ -76,9 +90,11 @@ val backend_extend_lock :
 val backend_health_check :
   config -> (Backend_types.health_result, Backend_types.error) result
 
+(** Returns [Ok n] where [n] is the number of subscribers notified
+    (forwarded from [Pubsub_mem.publish]). *)
 val backend_publish :
   config -> channel:string -> message:string ->
-  (unit, Backend_types.error) result
+  (int, Backend_types.error) result
 
 val backend_subscribe :
   config -> channel:string -> callback:(string -> unit) ->

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -884,7 +884,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                   let event = Printf.sprintf
                     "{\"type\":\"worktree_create\",\"agent\":\"%s\",\"branch\":\"%s\",\"path\":\"%s\",\"repo\":\"%s\",\"task_id\":\"%s\",\"ts\":\"%s\"}"
                     agent_name branch_name worktree_path repo_name task_id (now_iso ()) in
-                  log_event config event;
+                  log_event config (Yojson.Safe.from_string event);
 
                   Ok (Printf.sprintf "✅ Worktree created:\n  Path: %s\n  Branch: %s\n  Repo: %s%s%s\n\nNext: cd %s && work && gh pr create --draft"
                       worktree_path branch_name repo_name note
@@ -978,7 +978,7 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
                 let event = Printf.sprintf
                   "{\"type\":\"worktree_remove\",\"agent\":\"%s\",\"branch\":\"%s\",\"branch_delete\":\"%s\",\"prune\":\"%s\",\"ts\":\"%s\"}"
                   agent_name branch_name branch_status prune_status (now_iso ()) in
-                log_event config event;
+                log_event config (Yojson.Safe.from_string event);
 
                 (* Return result with post-processing status *)
                 let msg = Printf.sprintf "✅ Worktree removed: %s\n   Branch: %s (delete: %s)\n   Prune: %s"


### PR DESCRIPTION
## Summary

main is broken — `dune build` fails with 14+ errors across lib/coord. This PR clears the lib/coord layer cleanly. lib/keeper, lib/dashboard, lib/server, lib/autoresearch errors remain (separate scope, separate owners).

## Root causes (5 distinct)

| Layer | Pattern | Fix |
|---|---|---|
| Types facade (#11418 follow-up) | `Types.X` vs `Types_core.X` not equated under signature ascription. #11473 fixed coord_hooks; missed 5 more modules | mli sweep `Types_core.` → `Types.` |
| log_event signature drift | mli says `Yojson.Safe.t`, ml impl + 13 callsites still string | impl: `to_string` before append; callsites: `from_string` wrap or remove `to_string` |
| paths_backend.mli surface gaps (#11399) | `root_state_path` / `legacy_root_state_path` / `project_prefix` defined in ml but not exposed | add `val` declarations |
| paths_backend.mli return shapes | `backend_exists` declared `(bool, error) result` but returns `bool`. `backend_publish` declared `(unit, error) result` but returns `(int, error) result` | correct mli |
| utils_ops validate_*: Agent_id.t leakage | `Validation.Agent_id.validate` returns `(Agent_id.t, string) result` but mli says `(string, string)` | wrap `Ok _ -> Ok name` |

## Test plan

- [x] `dune build --root . lib/coord` exit 0
- [x] No diff impact outside lib/coord
- [ ] CI Build/Lint green on this PR
- [ ] Unblocks BLOCKED PR queue (~29 PRs per #11476's earlier triage)
- Note: full `dune build` still fails on lib/keeper, lib/dashboard, lib/server, lib/autoresearch — separate fixes needed (Oas.Types.usage, Autoresearch_git.is_in_git_repo, Keeper_types.tool_search_fn, multiple .pp.ml mismatches)

## Out of scope

- `lib/keeper/keeper_context_core.mli`: `Unbound type constructor Oas.Types.usage`
- `lib/autoresearch.ml:105`: `Unbound value Autoresearch_git.is_in_git_repo` (likely #11495 mli surface miss)
- `lib/keeper/keeper_tools_oas.mli`: `Unbound type constructor Keeper_types.tool_search_fn`
- Multiple `lib/keeper/*` and `lib/dashboard/*` .pp.ml mismatches
- `ppx_tla.ml:257 Pexp_fun` was independently fixed in #11492 between my reproduction and this commit