### PR TITLE
fix(coord): paths_backend.mli — expose root_state_path/project_prefix + correct backend_exists (main-broken)

### DIFF
--- a/lib/coord/coord_utils_paths_backend.mli
+++ b/lib/coord/coord_utils_paths_backend.mli
@@ -49,8 +49,13 @@ val backend_set :
 val backend_delete :
   config -> key:string -> (bool, Backend_types.error) result
 
+(** [backend_exists config ~key] returns whether [key] is present in
+    the configured backend. The implementation delegates to
+    [Backend.{Memory,FileSystem}.exists], both of which return [bool]
+    (validation errors are mapped to [false]); no [Result] wrapper is
+    propagated. *)
 val backend_exists :
-  config -> key:string -> (bool, Backend_types.error) result
+  config -> key:string -> bool
 
 val backend_list_keys :
   config -> prefix:string -> (string list, Backend_types.error) result
@@ -111,6 +116,15 @@ val root_key_of_path : config -> string -> string option
 val list_dir : config -> string -> string list
 
 (** {1 Initialization check} *)
+
+(** Path to the canonical cluster-root state file
+    ([<masc_root>/root-state.json]). Callers (coord_init,
+    coord_bootstrap) need this to gate one-time initialization. *)
+val root_state_path : config -> string
+
+(** Backend-key prefix for the current room's broadcast/lock namespace.
+    Used by coord_broadcast and Memory-backend-aware key composition. *)
+val project_prefix : config -> string
 
 (** [true] iff the cluster-root state file exists (independent of
     the current room). Used by room/cluster management features. *)


### PR DESCRIPTION
## Summary

Three corrections to `lib/coord/coord_utils_paths_backend.mli`, all unblocking main:

### 1. `backend_exists` return type

| | |
|--|--|
| .mli claimed | `(bool, Backend_types.error) result` |
| .ml returns | `bool` (delegates to `Backend.{Memory,FileSystem}.exists`, both return plain bool — validation errors map to false at the leaf, no Result wrapper) |
| Affected | 4 call sites in `coord_utils_ops.ml:210, :211, :345, :346` relied on bool semantics |

### 2. `root_state_path : config -> string`

Defined in `.ml:229`, consumed by `coord_init.ml:29` and `coord_bootstrap.ml:40`, but never exposed in `.mli`. Those consumers see `Unbound value root_state_path` via the `Coord_utils` facade (which `include Coord_utils_paths_backend`).

### 3. `project_prefix : config -> string`

Defined in `.ml:171`, consumed by `coord_broadcast.ml:59` for `"broadcast:%s:default"` key composition. Also unexposed, same Unbound chain.

## Root cause

All three are part of the `.mli` generation in PR #11400 (`refactor(coord): add coord_utils_ops.mli`). It missed several public functions and wrote a few wrong signatures. The implementations were already correct.

## Verification

`dune build lib/coord/` removes 4 errors:

- `coord_utils_ops.ml:210, :211, :345, :346` (backend_exists usage)
- `coord_init.ml:29, :46, :49, :50` (root_state_path)
- `coord_bootstrap.ml:40` (root_state_path)
- `coord_broadcast.ml:59` (project_prefix)

## Out of scope

More `.mli` generation gaps surface as the cascade peels back:

- `backend_publish` mli says `(unit, Backend_types.error) result` but ml returns `int Backend_types.result`
- `backend_get` and others — likely similar
- `coord_state_meta`, `coord_init` lifecycle — `room_state` type mismatch
- `pp.ml` interface conflicts (auto-resolve as upstream .mli's are corrected)

These need separate PRs to keep review surfaces small. The complete sweep also overlaps with the in-flight refactor (coord_utils_ops.mli + types.mli + coord_hooks fix series).

## Test plan

- [x] Local `dune build lib/coord/` removes the 4 listed errors
- [ ] CI green
- [ ] Combined with #11473 (merged), #11505 (Draft, backlog facade), and the next paths/backend mli sweep, BLOCKED PR queue (~30) starts unblocking
