### PR TITLE
[DS-Drift Track D-4] tokenize remaining 4 production hex (ops + live-monitor + base)

### DIFF
--- a/dashboard/src/styles/base.css
+++ b/dashboard/src/styles/base.css
@@ -21,7 +21,7 @@ body {
     radial-gradient(circle at 88% 14%, var(--ok-10), transparent 22%),
     radial-gradient(circle at 8% 88%, rgba(251, 191, 36, 0.04), transparent 28%),
     radial-gradient(circle at 50% 50%, rgba(71, 184, 255, 0.03), transparent 40%),
-    linear-gradient(180deg, #07111f 0%, #0c1424 48%, #080e1a 100%);
+    linear-gradient(180deg, var(--bg-root-deep) 0%, var(--bg-root) 48%, var(--bg-root-dim) 100%);
   background-attachment: fixed;
   position: relative;
 }

--- a/dashboard/src/styles/live-monitor.css
+++ b/dashboard/src/styles/live-monitor.css
@@ -34,7 +34,7 @@
 @utility activity-kind-chip {
   &.live-event-broadcast { background: var(--blue-400-15); color: var(--accent); }
   &.live-event-task { background: var(--ok-soft); color: var(--ok); }
-  &.live-event-keeper { background: rgba(168,85,247,0.15); color: #a855f7; }
+  &.live-event-keeper { background: rgba(168,85,247,0.15); color: var(--purple-500); }
   &.live-event-system { background: var(--white-6); color: var(--color-fg-muted); }
 }
 

--- a/dashboard/src/styles/ops.css
+++ b/dashboard/src/styles/ops.css
@@ -3,9 +3,9 @@
 /* ── Ops Tab (merged from ops.css) ─────────────────────── */
 
 @utility ops-banner {
-  &.error { background: var(--bad-12); border-color: rgba(239, 68, 68, 0.34); color: #fecaca; }
+  &.error { background: var(--bad-12); border-color: rgba(239, 68, 68, 0.34); color: var(--red-100); }
   &.warn { background: rgba(245, 158, 11, 0.12); border-color: rgba(245, 158, 11, 0.28); color: var(--yellow-100); }
-  &.info { background: var(--cyan-12); border-color: rgba(34, 211, 238, 0.26); color: #cffafe; }
+  &.info { background: var(--cyan-12); border-color: rgba(34, 211, 238, 0.26); color: var(--cyan-100); }
 }
 
 /* ops-action-guide-item hover/tone variants: folded into @utility ops-action-guide-item above */

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -172,6 +172,17 @@
   /* Additional Tailwind-aligned base tokens (Phase H): */
   --slate-600: #475569;
   --yellow-100: #fde68a;
+  /* Tailwind 100-shade text colors for ops-banner siblings of yellow-100.
+     Used in ops.css for error/info banner text against soft fill. */
+  --red-100: #fecaca;
+  --cyan-100: #cffafe;
+  /* Tailwind purple-500 (distinct from --purple = purple-400 #a78bfa).
+     Used in live-monitor.css for keeper-event chip text. */
+  --purple-500: #a855f7;
+  /* Background gradient stops for the dashboard page bg (base.css).
+     #0c1424 mid-stop is the existing --bg-root; deep + dim flank it. */
+  --bg-root-deep: #07111f;
+  --bg-root-dim: #080e1a;
 
   /* Semantic - Yellow Bright. Pure spectrum yellow (#facc15), distinct
      from --warn (251,191,36 = #fbbf24, slightly muted gold). Used for


### PR DESCRIPTION
## Summary

Track D 의 마지막 production var() consolidation. 4 raw hex 가 3 파일에 분산. 5 토큰 추가로 모두 var() 치환.

## Hex inventory + decisions

| File | Hex | Selector | Token | Note |
|------|-----|----------|-------|------|
| ops.css | #fecaca | \`&.error color\` | --red-100 | sibling of existing --yellow-100 |
| ops.css | #cffafe | \`&.info color\` | --cyan-100 | sibling of existing --yellow-100 |
| live-monitor.css | #a855f7 | \`&.live-event-keeper color\` | --purple-500 | distinct from --purple (#a78bfa = purple-400) |
| base.css | #07111f | gradient top stop | --bg-root-deep | flank --bg-root mid |
| base.css | #080e1a | gradient bottom stop | --bg-root-dim | flank --bg-root mid |

base.css 의 \`#0c1424\` mid-stop 은 이미 \`--bg-root\` 로 정의됨 — 이번 PR 에서 var() 치환 합쳐서 처리.

## Why new --purple-500 token

variables.css 의 기존 \`--purple\` 은 \`#a78bfa\` (Tailwind purple-400). live-monitor 는 \`#a855f7\` (purple-500) 사용 — 더 진한 톤. 강제 매핑 시 색상 시프트 발생하므로 stop 신규 추가 (C-β 교훈).

## Verification

- 3 파일 raw hex 잔존: 0
- variables.css +11 lines (5 tokens + 3 comment blocks)
- 색상 시각적 동일

## Files

- \`dashboard/src/styles/variables.css\` (+11)
- \`dashboard/src/styles/ops.css\` (2 hex -> 2 var())
- \`dashboard/src/styles/live-monitor.css\` (1 hex -> 1 var())
- \`dashboard/src/styles/base.css\` (2 hex -> 2 var(), + 1 already-defined --bg-root use)

## Track D 종합 (after this PR)

| PR | hex | files |
|----|----|------|
| #11486 D-1 vote buttons | 6 | board + dashboard |
| #11490 D-2 chat roles | 7 | chat |
| #11502 D-3 state pills | 3 | global |
| **this** D-4 misc | **4** | ops + live-monitor + base |
| **합계** | **20** | 7 production CSS files |

a11y.css 2 hex 는 \`var(--xxx, #fallback)\` 형태로 이미 토큰화 — 의도된 fallback. 잔존 raw hex 영역은 SSOT (variables.css, paper-theme.css, source.ts/tokens.generated.css) 만 남음. **Track D 완료**.