### PR TITLE
refactor(cdal): delegate proof_artifact_reader to Oas.Proof_store (eliminates layout hardcode)

### DIFF
--- a/lib/proof_artifact_reader.ml
+++ b/lib/proof_artifact_reader.ml
@@ -1,56 +1,18 @@
 (** Proof_artifact_reader — Dereference proof-store:// artifact refs.
 
+    Delegates to [Oas.Proof_store] which owns the canonical path layout.
+    Eliminates the previous hardcoded directory layout mirror.
+
     @since CDAL eval content-based redesign *)
-
-let prefix = "proof-store://"
-let prefix_len = String.length prefix
-
-let proofs_root (config : Oas.Proof_store.config) =
-  Filename.concat config.root "proofs"
-
-let validate_relative_path ~raw ~label =
-  let segments = String.split_on_char '/' raw in
-  let has_traversal =
-    String.contains raw '\000'
-    || List.exists (fun segment -> segment = "..") segments
-  in
-  if has_traversal then
-    Error (Printf.sprintf "path traversal rejected in %s: %s" label raw)
-  else
-    Ok raw
-
-let run_artifact_path (config : Oas.Proof_store.config)
-    ~(run_id : string) ~(relative_path : string) : (string, string) result =
-  Result.bind
-    (validate_relative_path ~raw:run_id ~label:"run_id")
-    (fun clean_run_id ->
-      Result.bind
-        (validate_relative_path ~raw:relative_path ~label:"relative_path")
-        (fun clean_relative_path ->
-          Ok
-            (Filename.concat
-               (Filename.concat (proofs_root config) clean_run_id)
-               clean_relative_path)))
 
 let resolve_path (config : Oas.Proof_store.config)
     (ref_ : Oas.Cdal_proof.artifact_ref) : (string, string) result =
-  if String.length ref_ > prefix_len
-     && String.sub ref_ 0 prefix_len = prefix then
-    let rel = String.sub ref_ prefix_len (String.length ref_ - prefix_len) in
-    validate_relative_path ~raw:rel ~label:"artifact_ref"
-    |> Result.map (fun clean_rel -> Filename.concat (proofs_root config) clean_rel)
-  else
-    Error (Printf.sprintf "invalid artifact ref: %s" ref_)
+  Oas.Proof_store.resolve_ref config ref_
+  |> Result.map (fun r -> r.Oas.Proof_store.path)
 
-let read_json (config : Oas.Proof_store.config)
-    (ref_ : Oas.Cdal_proof.artifact_ref)
-    : (Yojson.Safe.t, string) result =
-  match resolve_path config ref_ with
-  | Error e -> Error e
-  | Ok path ->
-    if Sys.file_exists path then
-      (try Ok (Yojson.Safe.from_file path)
-       with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printf.sprintf "JSON parse error in %s: %s"
-                            path (Printexc.to_string exn)))
-    else
-      Error (Printf.sprintf "artifact not found: %s" path)
+let run_artifact_path (config : Oas.Proof_store.config)
+    ~(run_id : string) ~(relative_path : string) : (string, string) result =
+  let ref_ = Oas.Proof_store.make_ref ~run_id ~subpath:relative_path in
+  resolve_path config ref_
+
+let read_json = Oas.Proof_store.read_json

--- a/lib/proof_artifact_reader.mli
+++ b/lib/proof_artifact_reader.mli
@@ -12,9 +12,6 @@ val resolve_path :
   Agent_sdk.Cdal_proof.artifact_ref ->
   (string, string) result
 
-(** Root directory for proof-store artifacts under the configured store. *)
-val proofs_root : Agent_sdk.Proof_store.config -> string
-
 (** Resolve a relative artifact path under a run directory.
     Returns [Error] when the run id or relative path attempts traversal. *)
 val run_artifact_path :


### PR DESCRIPTION
## Summary

Kimi Audit O5 (#1219): `proof_artifact_reader.ml`이 OAS 내부 디렉토리 레이아웃을 직접 하드코딩하는 대신 `Oas.Proof_store` 공개 API를 위임합니다.

## 발견 당시 상황

감사 보고서는 OAS에 Read API가 없다고 했으나, `Proof_store.resolve_ref`, `Proof_store.make_ref`, `Proof_store.read_json`이 이미 존재했습니다. 실제 문제는 MASC가 이 API를 쓰지 않고 동일한 로직을 자체 구현한 것이었습니다.

## 변경 내용

`lib/proof_artifact_reader.ml` 57줄 → 17줄:
- `proofs_root` 제거 — 하드코딩된 `config.root/proofs/` 레이아웃 미러
- `validate_relative_path` 제거 — OAS `resolve_ref`의 validation이 더 엄격함
- `run_artifact_path` → `Oas.Proof_store.make_ref` + `resolve_ref` 위임
- `resolve_path` → `Oas.Proof_store.resolve_ref` 위임
- `read_json` → `Oas.Proof_store.read_json` 위임

`lib/proof_artifact_reader.mli`: `proofs_root` 제거 (외부 caller 0건 확인)

## 호출자

`cdal_loader.ml`, `cdal_friction_projection.ml` — 시그니처 변경 없으므로 무수정.

## 보안 개선

기존 `validate_relative_path`는 `\0`과 `..` segment만 거부했으나, OAS `resolve_ref`는 추가로 빈 segment(`""`)와 `"."` segment도 거부합니다.

Closes #1219
