### PR TITLE
fix(coord): log_event mli restore Yojson.Safe.t (#11504/#11507 race resolution)

### DIFF
--- a/lib/coord/coord_utils_ops.mli
+++ b/lib/coord/coord_utils_ops.mli
@@ -159,9 +159,8 @@ val with_file_lock_r :
 
 (** {1 Event logging} *)
 
-(** Append [event_line] (a JSON-shaped string, callers hand-build via
-    [Printf.sprintf]) to the YYYY-MM/DD.jsonl event log under
-    [.masc/events/]. The implementation appends a literal "\n" via
-    string concatenation; passing a [Yojson.Safe.t] would not match
-    that interface and would also break every existing caller. *)
-val log_event : config -> string -> unit
+(** Append [event_json], serialized via [Yojson.Safe.to_string], to the
+    YYYY-MM/DD.jsonl event log under [.masc/events/]. PR #11507 migrated
+    the implementation and every caller to typed JSON; the .mli must
+    track. *)
+val log_event : config -> Yojson.Safe.t -> unit


### PR DESCRIPTION
## Summary

Restore `lib/coord/coord_utils_ops.mli`'s `log_event` signature to `Yojson.Safe.t` to match the migration PR #11507 completed.

## Race condition history

| Time (UTC) | PR | Action |
|------------|-----|--------|
| 04:51:08Z | **#11504** (mine) | Aligned .mli `string` ← (.ml was string concat, callers Printf.sprintf strings) |
| 04:53:58Z | **#11507** | Migrated .ml to `Yojson.Safe.to_string event_json ^ "\n"` AND every caller to `Yojson.Safe.from_string (Printf.sprintf ...)` |
| (now) | broken | .mli still says `string` from #11504, but .ml + callers now expect `Yojson.Safe.t` |

The two fixes were complementary in intent — both targeted .mli/.ml/callers alignment — but #11504's narrower mli-only revert beat #11507's broader migration to merge by ~3 minutes. The end state should be #11507's: typed JSON throughout.

## Fix

Restore `.mli` to `val log_event : config -> Yojson.Safe.t -> unit` to match the canonical post-#11507 implementation.

## Verification

`dune build lib/coord/` exit 0 (clean — all `lib/coord/*` errors gone).

## Out of scope

Other main-broken errors remain in different domains (separate PRs):

- `lib/autoresearch/autoresearch_storage.ml:55` — `Autoresearch_types.loop_state` mismatch
- `lib/autoresearch.ml:72` — Unbound `Autoresearch_storage.results_dir`
- `lib/keeper/keeper_execution_receipt.mli:45` — docstring `\"escape\"` lexer trap (matches feedback memory `feedback_ocaml_docstring_escape_quote_lexer_trap`)
- `lib/keeper/keeper_approval_queue.ml` — pp.ml interface
- `lib/keeper/keeper_context_core.mli:131` — type mismatch

The keeper area is in the active Kimi parallel-session refactor (per memory `feedback_kimi_plan_parallel_session_dont_duplicate`); leave to that session.

## Test plan

- [x] Local `dune build lib/coord/` exit 0
- [ ] CI green
- [ ] coord cascade fully unblocked (modulo non-coord errors above)
