### PR TITLE
fix(main): revert #11511 caller-side direction (conflicts with #11505/#11507 facade direction)

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -250,7 +250,7 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
     let backlog = Coord.read_backlog config in
     let unclaimed_tasks =
       List.filter
-        (fun (t : Types_core.task) -> t.task_status = Types_core.Todo)
+        (fun (t : Types.task) -> t.task_status = Types.Todo)
         backlog.tasks
     in
     let unclaimed = List.length unclaimed_tasks in

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -96,8 +96,8 @@ let handle_read_resource_eio state id params =
               ("text/markdown", text_opt)
           | "status" -> ("text/markdown", Some (Coord.status config))
           | "status.json" ->
-              let state_json = Types_core.room_state_to_yojson (Coord.read_state config) in
-              let backlog_json = Types_core.backlog_to_yojson (Coord.read_backlog config) in
+              let state_json = Types.room_state_to_yojson (Coord.read_state config) in
+              let backlog_json = Types.backlog_to_yojson (Coord.read_backlog config) in
               let connected_agents = Session.get_agent_statuses registry in
               let json = `Assoc [
                 ("base_path", `String config.base_path);
@@ -108,7 +108,7 @@ let handle_read_resource_eio state id params =
               ("application/json", Some (Yojson.Safe.pretty_to_string json))
           | "tasks" -> ("text/markdown", Some (Coord.list_tasks config))
           | "tasks.json" ->
-              let backlog_json = Types_core.backlog_to_yojson (Coord.read_backlog config) in
+              let backlog_json = Types.backlog_to_yojson (Coord.read_backlog config) in
               ("application/json", Some (Yojson.Safe.pretty_to_string backlog_json))
           | "who" -> ("text/markdown", Some (Session.status_string registry))
           | "who.json" ->

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -341,25 +341,25 @@ let status_summary_string (ctx : context) =
     List.fold_left
       (fun
          (active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt, cancelled_cnt)
-         (task : Types_core.task) ->
+         (task : Types.task) ->
         Coord_query.safe_yield ();
         match task.task_status with
-        | Types_core.Todo ->
+        | Types.Todo ->
             (task :: active, todo_cnt + 1, claimed_cnt, in_progress_cnt,
              done_cnt, cancelled_cnt)
-        | Types_core.Claimed _ ->
+        | Types.Claimed _ ->
             (task :: active, todo_cnt, claimed_cnt + 1, in_progress_cnt,
              done_cnt, cancelled_cnt)
-        | Types_core.InProgress _ ->
+        | Types.InProgress _ ->
             (task :: active, todo_cnt, claimed_cnt, in_progress_cnt + 1,
              done_cnt, cancelled_cnt)
-        | Types_core.Done _ ->
+        | Types.Done _ ->
             (active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt + 1,
              cancelled_cnt)
-        | Types_core.AwaitingVerification _ ->
+        | Types.AwaitingVerification _ ->
             (task :: active, todo_cnt, claimed_cnt, in_progress_cnt + 1,
              done_cnt, cancelled_cnt)
-        | Types_core.Cancelled _ ->
+        | Types.Cancelled _ ->
             (active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt,
              cancelled_cnt + 1))
       ([], 0, 0, 0, 0, 0)

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -321,9 +321,9 @@ let check_timeouts ~(config : Coord.config) =
     try
       let backlog = Coord.read_backlog config in
       let now = Time_compat.now () in
-      List.iter (fun (task : Types_core.task) ->
+      List.iter (fun (task : Types.task) ->
         match task.task_status with
-        | Types_core.AwaitingVerification { assignee; verification_id; deadline = Some dl; _ } ->
+        | Types.AwaitingVerification { assignee; verification_id; deadline = Some dl; _ } ->
           (match Types.parse_iso8601_opt dl with
            | Some deadline_ts when now > deadline_ts ->
              let () =


### PR DESCRIPTION
fix(main): revert PR #11511 caller-side directions that conflict with #11505/#11507 framework

PR #11511 (admin-merged) repaired 9 mli/ml drifts surgically by changing
4 caller sites to use `Types_core.X` while keeping `Coord.read_*`
returning `Types_core` types. In parallel, the user landed PR #11505
("expose read_backlog as Types.backlog facade") and #11507 ("repair
lib/coord build cascade — Types facade") that took the **opposite
direction**: change `Coord.read_*` to return `Types.X` and keep callers
on `Types.X`.

Both PRs admin-merged. Net effect on main: callers on `Types_core.X`
calling functions returning `Types.X` — phantom mismatch reintroduced
in 5 places.

This commit reverts the 4 ml caller-side direction choices from #11511
to align with the user's facade-side framework:

| File | #11511 had | This commit |
|------|------------|-------------|
| `lib/mcp_server_eio_resource.ml:99` | `Types_core.room_state_to_yojson` | `Types.room_state_to_yojson` |
| `lib/mcp_server_eio_resource.ml:100` | `Types_core.backlog_to_yojson` | `Types.backlog_to_yojson` |
| `lib/mcp_server_eio_resource.ml:111` | `Types_core.backlog_to_yojson` (separate site) | `Types.backlog_to_yojson` |
| `lib/tool_coord.ml:344-362` | `(task : Types_core.task)` + `Types_core.{Todo,...}` | `(task : Types.task)` + `Types.{Todo,...}` |
| `lib/verification_protocol.ml:324-326` | `Types_core.task` + `Types_core.AwaitingVerification` | `Types.task` + `Types.AwaitingVerification` |
| `lib/keeper/keeper_world_observation.ml:253` | `Types_core.task` + `Types_core.Todo` | `Types.task` + `Types.Todo` |

## What this PR does NOT revert

The .mli changes from #11511 stay — they were genuine mli/ml drifts
(narrowed sigs that the .ml could not provide), independent of the
Types/Types_core direction question:

- `lib/keeper/keeper_persona_authoring.mli` — `(string, string) result`
- `lib/keeper/keeper_exec_shell.mli` — `(string list, string) result`
- `lib/keeper/keeper_shell_docker.mli` — `(string list, string) result`
- `lib/dashboard/dashboard_operator_judge.mli` — `Types.tool_schema list`

## Status

Local `dune build lib/` after this commit: 5 mismatch errors gone.
Two unrelated cascades remain on main and are NOT touched by this PR:

- `lib/dashboard/dashboard_http_autoresearch.ml:9` — `Autoresearch_types.cycle_record` vs `Autoresearch_serde.cycle_record`
- `lib/keeper/keeper_tools_oas.mli:67` — unbound `Keeper_types.tool_search_fn`

Those are separate refactor cascades the user is mid-flight on; they
predate #11511 and are unaffected by this revert.

## Why surgical fixes failed here

memory: `feedback_admin_merge_can_bypass_build_ci.md` already covers
the "admin-merge bypasses build CI" pattern. This PR adds the **second
hazard**: when two PRs simultaneously fix the same root family in
**opposite directions**, both admin-merging cleanly produces a
contradictory main. The two PRs' diffs do not overlap line-by-line so
git reports no conflict, but the type-system contracts they enforce
are mutually exclusive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
