### PR TITLE
test(receipt): drift sentinel matrix for ReceiptIsAuthoritative + .mli quote escape fix

### DIFF
--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -54,8 +54,8 @@ val assert_receipt_authoritative :
     further check; pairing them with the right turn_state is the
     responsibility of [ReceiptMatchesState] (a separate invariant).
 
-    [turn_state] is the canonical TLA+ symbol form ([\"done\"],
-    [\"failed\"], [\"cancelled\"], ...). Callers that hold a
+    [turn_state] is the canonical TLA+ symbol form (e.g. [done],
+    [failed], [cancelled], ...). Callers that hold a
     [Keeper_turn_fsm.turn_state] should pass
     [Keeper_turn_fsm.to_tla_symbol s].
 

--- a/test/dune
+++ b/test/dune
@@ -428,6 +428,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_keeper_receipt_authoritative_matrix)
+ (modules test_keeper_receipt_authoritative_matrix)
+ (libraries masc_test_deps))
+
+(test
  (name test_telemetry_task_transition_10358)
  (modules test_telemetry_task_transition_10358)
  (libraries masc_test_deps))

--- a/test/test_keeper_receipt_authoritative_matrix.ml
+++ b/test/test_keeper_receipt_authoritative_matrix.ml
@@ -1,0 +1,128 @@
+(* Cartesian sentinel matrix for [assert_receipt_authoritative].
+
+   The single-concern helper enforces the OCaml-runtime image of the
+   TLA+ [ReceiptIsAuthoritative] invariant
+   (specs/keeper-turn-fsm/KeeperTurnFSM.tla:336):
+
+       receipt_outcome = "receipt_done" => turn_state = "done"
+
+   Per [ReceiptMatchesState] the [Done] state also accepts
+   [receipt_skipped] (PhaseGateSkip path), so the helper rejects
+   [`Ok] or [`Skipped] paired with anything but ["done"]. The
+   [`Error] / [`Cancelled] pair is the concern of
+   [ReceiptMatchesState], not this helper, so it accepts.
+
+   The companion file [test_keeper_receipt_authoritative.ml] pins
+   representative cases. This matrix instead enumerates every
+   [(outcome, turn_state)] cell from [Keeper_turn_fsm.all_symbols]
+   (ppx_tla derived, kept in sync with [TurnStateSet] by
+   [test_keeper_turn_fsm_tla_parity]) so any of the following surfaces
+   as a build failure:
+
+   - a new turn_state added to the spec without considering its
+     receipt-authority pairing,
+   - a new [outcome_kind] variant that the helper does not classify,
+   - a regression that loosens the helper to accept a forbidden pair.
+
+   Production callers in [keeper_unified_turn] and [keeper_agent_run]
+   currently derive [outcome] and the implied [turn_state] from the
+   same [turn_result] expression, so wiring the helper into the
+   runtime is trivially [Ok ()] today. The drift sentinel here is the
+   value-bearing piece of Phase 1-3: it locks the helper's behaviour
+   so that when callers do diverge (a concern that surfaces in
+   [ReceiptMatchesState] coverage work) the helper is already pinned. *)
+
+module R = Masc_mcp.Keeper_execution_receipt
+module F = Masc_mcp.Keeper_turn_fsm
+
+let all_outcomes : R.outcome_kind list =
+  [ `Ok; `Skipped; `Error; `Cancelled ]
+
+let outcome_label : R.outcome_kind -> string = function
+  | `Ok -> "`Ok"
+  | `Skipped -> "`Skipped"
+  | `Error -> "`Error"
+  | `Cancelled -> "`Cancelled"
+
+type expectation = Ok_expected | Error_expected
+
+let expected_of outcome turn_state =
+  match outcome, turn_state with
+  | (`Ok | `Skipped), "done" -> Ok_expected
+  | (`Ok | `Skipped), _ -> Error_expected
+  | (`Error | `Cancelled), _ -> Ok_expected
+
+let expected_violation_label = function
+  | `Ok -> "receipt_done"
+  | `Skipped -> "receipt_skipped"
+  | `Error | `Cancelled ->
+      (* Never reached: these variants pass the helper for every
+         turn_state. If a future change makes them violate, the
+         caller's pattern match below will hit the [Error v] arm with
+         these variants and we want a loud failure here. *)
+      "<unreachable: error/cancelled never violate>"
+
+let test_matrix_size () =
+  let outcome_count = List.length all_outcomes in
+  let state_count = List.length F.all_symbols in
+  if outcome_count <> 4 then
+    failwith
+      (Printf.sprintf
+         "expected 4 outcome_kind variants, got %d — \
+          extend [all_outcomes] and reconsider expected_of"
+         outcome_count);
+  if state_count < 10 then
+    failwith
+      (Printf.sprintf
+         "expected at least 10 turn states in [Keeper_turn_fsm.all_symbols] \
+          (TurnStateSet floor); got %d"
+         state_count);
+  Printf.printf
+    "receipt-authoritative matrix: %d outcomes × %d turn_states = %d cells\n"
+    outcome_count state_count (outcome_count * state_count)
+
+let test_matrix_completeness () =
+  let mismatches = ref [] in
+  List.iter
+    (fun outcome ->
+      List.iter
+        (fun turn_state ->
+          let actual = R.assert_receipt_authoritative ~outcome ~turn_state in
+          let expected = expected_of outcome turn_state in
+          match actual, expected with
+          | Ok (), Ok_expected -> ()
+          | Error v, Error_expected ->
+              let want = expected_violation_label outcome in
+              if v.outcome <> want || v.turn_state <> turn_state then
+                mismatches :=
+                  Printf.sprintf
+                    "[label-drift] outcome=%s turn_state=%s got receipt=%s state=%s want receipt=%s"
+                    (outcome_label outcome) turn_state v.outcome v.turn_state want
+                  :: !mismatches
+          | Ok (), Error_expected ->
+              mismatches :=
+                Printf.sprintf
+                  "[expected-violation] outcome=%s turn_state=%s helper returned Ok"
+                  (outcome_label outcome) turn_state
+                :: !mismatches
+          | Error v, Ok_expected ->
+              mismatches :=
+                Printf.sprintf
+                  "[unexpected-violation] outcome=%s turn_state=%s receipt=%s state=%s"
+                  (outcome_label outcome) turn_state v.outcome v.turn_state
+                :: !mismatches)
+        F.all_symbols)
+    all_outcomes;
+  match !mismatches with
+  | [] -> ()
+  | xs ->
+      List.iter print_endline (List.rev xs);
+      failwith
+        (Printf.sprintf
+           "%d mismatch(es) in receipt-authoritative matrix"
+           (List.length xs))
+
+let () =
+  test_matrix_size ();
+  test_matrix_completeness ();
+  print_endline "test_keeper_receipt_authoritative_matrix: OK"


### PR DESCRIPTION
## Phase 1-3 follow-up: drift sentinel matrix

### Why this PR

PR #11497 (Phase 1-3 helper) 머지된 `assert_receipt_authoritative`의 invariant은 main 코드 trace 결과 production caller wire가 *trivially Ok* 가 됨을 발견.

- `keeper_agent_run.ml:2848` outcome = `match turn_result | Ok _ -> "ok" | Error _ -> "error"`
- `keeper_unified_turn.ml:145` (`record_pre_dispatch_terminal_observation`) 함수 시그니처에 `turn_state` 인자 없음

즉 `receipt.outcome` 과 turn_state 가 같은 source에서 derive 되므로 helper는 잡을 violation이 없음. plan 가정과 main 코드 구조가 mismatch.

대신 **drift sentinel matrix** 로 1-3을 단단히 lock:
- 4 outcome_kind variants × `Keeper_turn_fsm.all_symbols` (10 turn_states) = 40 cells
- 각 cell의 expected (Ok | Error) 명시
- helper와 expected 어긋나면 build 실패

### Changes

1. **`lib/keeper/keeper_execution_receipt.mli`** — docstring escape fix
   - `[\"done\"]` 패턴이 OCaml lexer를 string mode 로 빠뜨려 line 45에서 "unterminated string literal" 오류. 실제 escape는 line 57.
   - PR #11497이 admin merge로 build CI 우회 → main 회귀 발생. 이 PR이 fix.
   - Memory: `feedback_ocaml_docstring_escape_quote_lexer_trap.md`, `feedback_admin_merge_can_bypass_build_ci.md`

2. **`test/test_keeper_receipt_authoritative_matrix.ml`** (신규)
   - Cartesian sentinel matrix
   - `Keeper_turn_fsm.all_symbols` (ppx_tla derived) 으로 enumerate → spec drift도 자동 cover
   - 11개 case-by-case 테스트 (`test_keeper_receipt_authoritative.ml`) 와 보완. matrix는 모든 페어 cover, case-by-case는 readability.

3. **`test/dune`** — 새 test stanza 등록

### Local verification

- 우리 변경분(`.mli` quote fix + matrix test)은 빌드 통과
- main이 평행 세션 #11503-11515로 churning 중 (`server_routes_http_routes_activity`, `keeper_world_observation`, `keeper_approval_queue` 등 Types/Types_core split 회귀 fix). 정착 후 CI에서 검증 예상

### Not in scope

- Production caller wire 자체 (trivially Ok 이므로 가치 없음)
- Phase 1-3 caller integration follow-up은 ReceiptMatchesState 작업이 receipt.outcome / turn_state source separation을 만들 때 의미 발생

Plan: `planning/serene-napping-glade.md` Phase 1-3
