### PR TITLE
quality(types): remove unused ExnError/GeneralError/WithCode catch-all variants

### DIFF
--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -97,9 +97,6 @@ type t =
   | CacheError of cache_error
   | StorageError of string
   | ValidationError of string
-  | GeneralError of string
-  | ExnError of exn
-  | WithCode of { code : int; msg : string }
 
 let rec to_string = function
   | NotInitialized -> "❌ MASC not initialized. Use masc_init first."
@@ -139,18 +136,11 @@ let rec to_string = function
       | CacheCorrupted path -> Printf.sprintf "❌ Cache: Corrupted [path=%s]" path)
   | StorageError msg -> Printf.sprintf "Storage error: %s" msg
   | ValidationError msg -> Printf.sprintf "Validation error: %s" msg
-  | GeneralError msg -> msg
-  | ExnError e -> Printexc.to_string e
-  | WithCode { code; msg } -> Printf.sprintf "HTTP %d: %s" code msg
 
 let show = to_string
 
 let to_yojson err =
   `String (to_string err)
-
-let of_string s = GeneralError s
-let of_exn e = ExnError e
-let with_code ~code msg = WithCode { code; msg }
 
 let code = function
   | Unauthorized _ | TokenExpired _ | InvalidToken _ -> 401
@@ -158,5 +148,4 @@ let code = function
   | AgentNotFound _ | TaskNotFound _ -> 404
   | RateLimitExceeded _ -> 429
   | InvalidJson _ | InvalidAgentName _ | InvalidTaskId _ | InvalidFilePath _ | ValidationError _ -> 400
-  | WithCode { code; _ } -> code
   | _ -> 500

--- a/lib/types/masc_error.mli
+++ b/lib/types/masc_error.mli
@@ -42,13 +42,6 @@ type t =
   | CacheError of cache_error
   | StorageError of string
   | ValidationError of string
-  | GeneralError of string
-  | ExnError of exn
-  | WithCode of { code : int; msg : string }
-
-val of_string : string -> t
-val of_exn : exn -> t
-val with_code : code:int -> string -> t
 
 val to_string : t -> string
 val show : t -> string

--- a/test/test_auth_error_kind.ml
+++ b/test/test_auth_error_kind.ml
@@ -85,14 +85,14 @@ let test_classify_invalid_json () =
         (Aek.to_string other)
 
 let test_classify_unmodelled_falls_to_other () =
-  (* GeneralError is not auth-relevant and intentionally falls through
+  (* IoError is not auth-relevant and intentionally falls through
      to [Other]. If a future PR moves it under an explicit arm, this
      test is the breakpoint. *)
-  match Aek.classify (Types.GeneralError "x") with
+  match Aek.classify (Types.IoError "disk") with
   | Aek.Other -> ()
   | other ->
       Alcotest.failf
-        "GeneralError should classify as Other, got %s"
+        "IoError should classify as Other, got %s"
         (Aek.to_string other)
 
 let test_label_set_stable () =


### PR DESCRIPTION
## Summary

Kimi Audit M7 (#11485): `Masc_error`의 catch-all 변형 3종을 제거합니다.

## 발견 사실

이슈 작성 시점에는 "도메인별 에러 분리"가 큰 리팩토링으로 보였지만, 실제 코드를 확인하니:

| 항목 | 사용처 |
|------|--------|
| `Masc_error.of_string` helper | **0건** |
| `Masc_error.of_exn` helper | **0건** |
| `Masc_error.with_code` helper | **0건** |
| 직접 `GeneralError "..."` 생성자 | masc_error.ml 자체 + 단일 negative test |
| 직접 `ExnError exn` 생성자 | 0건 |
| 직접 `WithCode {...}` 생성자 | 0건 |

즉 catch-all은 정의만 되어 있고 실제로는 사용되지 않는 dead code였습니다. 도메인별 에러 변형이 이미 충분합니다 (IoError, AgentNotFound, TaskNotFound, InvalidJson, ValidationError 등 25+).

## 변경 내용

**`lib/types/masc_error.mli`** — 7줄 감소:
- `GeneralError of string`, `ExnError of exn`, `WithCode of {...}` 제거
- `of_string`, `of_exn`, `with_code` 시그니처 제거

**`lib/types/masc_error.ml`** — 11줄 감소:
- 동일 변형 + helper 구현 제거
- `to_string`에서 3개 case 제거
- `code`에서 `WithCode { code; _ }` case 제거

**`test/test_auth_error_kind.ml`** — `GeneralError "x"` → `IoError "disk"` (auth-irrelevant 확인 negative test 유지)

## 효과

| | Before | After |
|--|--------|-------|
| 타입 안전성 | catch-all로 임의 string/exn 포장 가능 | 모든 에러는 도메인 variant |
| Exhaustive matching | 의미 없음 (catch-all에서 끝남) | 컴파일러가 누락된 case 잡음 |
| Dead code | 3개 variant + 3개 helper | 0 |

총 18줄 감소, 0줄 추가.

Closes #11485
