### PR TITLE
fix(main): unblock dune — restore mli surfaces / drop nominal type leak

### DIFF
--- a/lib/autoresearch/autoresearch_git.mli
+++ b/lib/autoresearch/autoresearch_git.mli
@@ -2,10 +2,11 @@
     loop's managed worktree.
 
     Wraps the small subset of git commands the autoresearch driver
-    needs (commit/restore/reset/tag/branch/worktree). Internal
-    [run_git_with_status] / [run_capture_lines] / [is_in_git_repo]
-    helpers are hidden — callers interact with the per-action
-    functions only.
+    needs (commit/restore/reset/tag/branch/worktree). Most callers
+    interact with the per-action functions and the
+    {!is_in_git_repo} predicate; {!run_git_with_status} and
+    {!run_capture_lines} are exposed because {!Autoresearch}
+    re-exports them as part of its public surface.
 
     Functions returning [unit] (e.g. {!git_reset_last},
     {!git_restore_head}, {!git_tag_best}) silently no-op when [workdir]
@@ -13,6 +14,26 @@
     fails. The [Result]-returning variants surface errors verbatim. *)
 
 (** {1 Status / introspection} *)
+
+val is_in_git_repo : string -> bool
+(** [true] iff [<dir>] (or any ancestor) contains a [.git] entry.
+    Pure filesystem walk; does not invoke [git]. *)
+
+val run_git_with_status :
+  ?timeout_sec:float ->
+  workdir:string ->
+  string list ->
+  Unix.process_status * string
+(** Run [git -C <workdir> <argv>] through the exec gate; returns the
+    raw exit status and combined stdout/stderr. Default timeout 30s. *)
+
+val run_capture_lines :
+  workdir:string ->
+  ?timeout_sec:float ->
+  string list ->
+  Unix.process_status * string list
+(** Run [git -C <workdir> <argv>] and split stdout into non-empty
+    lines. Default timeout 30s. *)
 
 val git_top_level : workdir:string -> (string, string) result
 (** [git rev-parse --show-toplevel] in [workdir]. *)
@@ -61,6 +82,23 @@ val git_tag_best :
     Silently swallows tag-creation errors. *)
 
 (** {1 Managed worktree lifecycle} *)
+
+val managed_branch_name : string -> string
+(** [autoresearch/<loop_id>] — branch name used by
+    {!prepare_managed_worktree}. *)
+
+val prepare_managed_worktree :
+  base_path:string ->
+  source_workdir:string ->
+  loop_id:string ->
+  (string * string * string list, string) result
+(** [Ok (workdir, repo_root, warnings)] on success; [Error msg] when
+    [git_top_level] fails or the target [workdir] already exists.
+    [warnings] flags [source_workdir_dirty] and non-trunk source
+    branches. *)
+
+val local_branch_exists : repo_root:string -> string -> bool
+(** [true] iff [refs/heads/<branch>] exists under [repo_root]. *)
 
 val cleanup_managed_worktree :
   base_path:string ->

--- a/lib/autoresearch/autoresearch_serde.mli
+++ b/lib/autoresearch/autoresearch_serde.mli
@@ -1,10 +1,12 @@
 (** Autoresearch_serde — JSON serialization for autoresearch types.
 
-    Re-exports the type SSOT from {!Autoresearch_types} via
-    [include module type of] and adds typed converters between those
-    domain records and [Yojson.Safe.t]. The [_result]-suffixed
-    decoders return [(T, string) result] so callers can surface
-    legacy-schema and parse failures verbatim.
+    Adds typed converters between the {!Autoresearch_types} domain
+    records and [Yojson.Safe.t]. The type SSOT remains
+    {!Autoresearch_types}; this module does not re-export it (an
+    earlier [include module type of] copy generated nominally distinct
+    record types and broke caller compilation). The
+    [_result]-suffixed decoders return [(T, string) result] so callers
+    can surface legacy-schema and parse failures verbatim.
 
     Internal field-extraction helpers ([required_string_field],
     [optional_int_field], etc.) and the [field_error] /
@@ -13,34 +15,37 @@
 
     @since 2.80.0 *)
 
-include module type of Autoresearch_types
-
 (** {1 Enum string conversions} *)
 
-val decision_to_string : decision -> string
+val decision_to_string : Autoresearch_types.decision -> string
 (** ["keep"] / ["discard"]. *)
 
-val decision_of_string_result : string -> (decision, string) result
+val decision_of_string_result :
+  string -> (Autoresearch_types.decision, string) result
 
-val status_to_string : status -> string
+val status_to_string : Autoresearch_types.status -> string
 (** ["running"] / ["completed"] / ["stopped"] / ["error"]. *)
 
-val status_of_string_result : string -> (status, string) result
+val status_of_string_result :
+  string -> (Autoresearch_types.status, string) result
 
 (** {1 JSON converters} *)
 
-val cycle_to_yojson : cycle_record -> Yojson.Safe.t
-val cycle_of_yojson_result : Yojson.Safe.t -> (cycle_record, string) result
+val cycle_to_yojson : Autoresearch_types.cycle_record -> Yojson.Safe.t
 
-val state_to_yojson : loop_state -> Yojson.Safe.t
+val cycle_of_yojson_result :
+  Yojson.Safe.t -> (Autoresearch_types.cycle_record, string) result
+
+val state_to_yojson : Autoresearch_types.loop_state -> Yojson.Safe.t
 
 val state_of_yojson_result :
-  Yojson.Safe.t -> (persisted_summary, string) result
+  Yojson.Safe.t -> (Autoresearch_types.persisted_summary, string) result
 (** Decoded shape is the persisted summary record (a wider view than
     [loop_state]), so callers can lift the [updated_at] back-fill in
     {!Autoresearch_storage.load_state_result}. *)
 
-val execution_link_to_yojson : execution_link -> Yojson.Safe.t
+val execution_link_to_yojson :
+  Autoresearch_types.execution_link -> Yojson.Safe.t
 
 val execution_link_of_yojson_result :
-  Yojson.Safe.t -> (execution_link, string) result
+  Yojson.Safe.t -> (Autoresearch_types.execution_link, string) result

--- a/lib/autoresearch/autoresearch_storage.mli
+++ b/lib/autoresearch/autoresearch_storage.mli
@@ -2,11 +2,12 @@
     autoresearch loop.
 
     Owns the layout under [<base_path>/.masc/autoresearch/<loop_id>/]
-    (cycle results, state JSON, execution link files). Internal path
-    builders ([results_dir]/[results_file]/[state_file]/
-    [loop_link_file]/[session_link_file]) and JSON IO helpers
-    ([load_json_file_result]/[decode_json_file_result]) are hidden —
-    callers consume the typed read/write functions only.
+    (cycle results, state JSON, execution link files). Path builders
+    ([results_dir] / [results_file] / [state_file] / [loop_link_file]
+    / [session_link_file]) are exposed because {!Autoresearch} re-
+    exports them as part of its public surface; JSON IO helpers
+    ([load_json_file_result] / [decode_json_file_result]) remain
+    hidden — callers consume the typed read/write functions only.
 
     The [_result]-suffixed loaders return
     [(T, string) result option] so callers can distinguish
@@ -20,6 +21,24 @@
 val ensure_dir : string -> unit
 (** [mkdir -p] equivalent. Idempotent; no-op if [path] already
     exists. *)
+
+(** {1 Path builders (per [loop_id] under [base_path])} *)
+
+val results_dir : base_path:string -> string -> string
+(** [<base_path>/.masc/autoresearch/<loop_id>/]. Parent directory for
+    every other layout artifact below. *)
+
+val results_file : base_path:string -> string -> string
+(** [<results_dir>/results.jsonl]. *)
+
+val state_file : base_path:string -> string -> string
+(** [<results_dir>/state.json]. *)
+
+val loop_link_file : base_path:string -> string -> string
+(** [<results_dir>/swarm.json] keyed by [loop_id]. *)
+
+val session_link_file : base_path:string -> string -> string
+(** Per-session execution link mirror; keyed by [session_id]. *)
 
 (** {1 Worktree path SSOT} *)
 
@@ -52,18 +71,24 @@ val save_state :
   base_path:string -> Autoresearch_types.loop_state -> unit
 
 val load_state :
-  base_path:string -> string -> Autoresearch_types.loop_state option
-(** [Some state] on success, [None] if the file is missing or fails
-    to parse. The error path is logged. *)
+  base_path:string -> string -> Autoresearch_types.persisted_summary option
+(** [Some summary] on success, [None] if the file is missing or fails
+    to parse. The error path is logged. The decoded shape is the
+    persisted summary (a wider view than [loop_state]). *)
 
 val load_state_result :
   base_path:string ->
   string ->
-  (Autoresearch_types.loop_state, string) result option
-(** [None] = no file on disk. [Some (Ok state)] = parsed (with
+  (Autoresearch_types.persisted_summary, string) result option
+(** [None] = no file on disk. [Some (Ok summary)] = parsed (with
     [updated_at] back-filled from file mtime if absent). [Some (Error
     msg)] = legacy schema (missing [model_model] field) or decode
     failure. *)
+
+val scan_persisted_loop_ids : base_path:string -> string list
+(** Loop IDs whose [state.json] currently exists under
+    [<base_path>/.masc/autoresearch/]. Used by callers that want to
+    enumerate every persisted loop without opening each one. *)
 
 (** {1 Execution link (per-loop and per-session)} *)
 

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -127,11 +127,11 @@ val persist_message :
 
 (** {1 Re-exports from Inference_utils} *)
 
-val timed : (unit -> 'a) -> 'a * float
-val zero_usage : Oas.Types.usage
+val timed : (unit -> 'a) -> 'a * int
+val zero_usage : Agent_sdk.Types.api_usage
 val usage_of_response :
-  ?prior:Oas.Types.usage -> Oas.Types.run_result -> Oas.Types.usage
-val total_tokens : Oas.Types.usage -> int
+  Oas_response.api_response -> Agent_sdk.Types.api_usage
+val total_tokens : Agent_sdk.Types.api_usage -> int
 
 (** {1 Checkpoint store delegation} *)
 
@@ -149,14 +149,54 @@ val save_oas_checkpoint :
   (Oas.Checkpoint.t, string) result
 
 (** Wrap [create_checkpoint] + [save_session_checkpoint] for the
-    legacy on-disk checkpoint store. *)
+    legacy on-disk checkpoint store; returns the persisted
+    checkpoint so callers can use it without re-reading from disk. *)
 val save_checkpoint :
-  session_context -> working_context -> generation:int -> unit
+  session_context -> working_context -> generation:int -> checkpoint
 
 (** {1 OAS checkpoint inspection} *)
 
 val checkpoint_generation : Oas.Checkpoint.t -> fallback:int -> int
 val checkpoint_max_tokens : Oas.Checkpoint.t -> fallback:int -> int
+
+(** Drop orphan [tool_result] blocks (those without a matching
+    preceding [tool_use]) so a checkpoint payload satisfies the
+    Anthropic API invariant that every tool_result references a known
+    tool_use. Public so [Keeper_rollover] / [Keeper_post_turn] can
+    reuse it before persisting a checkpoint. *)
+val repair_orphan_tool_result_messages :
+  Oas.Types.message list -> Oas.Types.message list
+
+type checkpoint_sanitize_stats = {
+  dropped_messages : int;
+  dropped_blocks : int;
+  dropped_chars : int;
+  truncated_blocks : int;
+  truncated_chars : int;
+}
+
+(** Apply [sanitize_checkpoint_messages] (cap blocks / drop oversize
+    payloads) and, when [repair_orphans] is [true] (default), also
+    drop orphan tool_use/tool_result pairs so the resulting checkpoint
+    is safe to persist. Returns the cleaned checkpoint plus
+    aggregated stats. *)
+val sanitize_oas_checkpoint :
+  ?repair_orphans:bool ->
+  Oas.Checkpoint.t ->
+  Oas.Checkpoint.t * checkpoint_sanitize_stats
+
+val checkpoint_sanitize_changed : checkpoint_sanitize_stats -> bool
+(** [true] iff any of the counters in [stats] is non-zero. *)
+
+(** Load the newest legacy checkpoint persisted under
+    [session.session_dir]; returns [None] when nothing has been
+    persisted yet. *)
+val load_latest_checkpoint : session_context -> checkpoint option
+
+(** Recover a [working_context] from the legacy on-disk checkpoint
+    shape, capping by [primary_model_max_tokens]. *)
+val context_of_legacy_checkpoint :
+  checkpoint -> primary_model_max_tokens:int -> working_context
 
 (** Pick the keeper's preferred model for checkpointing —
     canonical cascade name first, then a fallback list of

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -64,8 +64,8 @@ val make_keeper_tool_handler :
   ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
   ?turn_sandbox_runtime_git:Keeper_turn_sandbox_runtime.t ->
   exec_cache:Masc_exec.Exec_cache.t option ->
-  ?search_fn:Keeper_types.tool_search_fn ->
-  ?on_tool_called:(string -> Yojson.Safe.t -> unit) ->
+  ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
+  ?on_tool_called:(string -> unit) ->
   ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t) ->
   failure_counts:(string, int) Hashtbl.t ->
   unit ->
@@ -79,8 +79,8 @@ val make_tool_bundle :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   ctx_snapshot:Keeper_types.working_context ->
-  ?search_fn:Keeper_types.tool_search_fn ->
-  ?on_tool_called:(string -> Yojson.Safe.t -> unit) ->
+  ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
+  ?on_tool_called:(string -> unit) ->
   unit ->
   tool_bundle
 
@@ -89,7 +89,7 @@ val make_tools :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   ctx_snapshot:Keeper_types.working_context ->
-  ?search_fn:Keeper_types.tool_search_fn ->
-  ?on_tool_called:(string -> Yojson.Safe.t -> unit) ->
+  ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
+  ?on_tool_called:(string -> unit) ->
   unit ->
   Oas.Tool.t list


### PR DESCRIPTION
## Summary

Main build cascade에서 16/24 dune 에러 해결. PR #11503 / #11504 / #11506 / #11510 / #11511이 동시 머지되며 발생한 회귀.

## Root causes addressed

- **autoresearch_serde.mli** — \`include module type of Autoresearch_types\` (PR #11503)가 \`decision\` / \`cycle_record\` / \`loop_state\` / \`persisted_summary\` / \`execution_link\` 의 nominally distinct 사본 생성. 3 caller (\`lib/autoresearch.ml\`, \`lib/autoresearch_codegen.ml\`, \`lib/dashboard/dashboard_http_autoresearch.ml\`)가 컴파일 안 됨. include 제거, fully-qualified \`Autoresearch_types.X\` 사용. SSOT는 Autoresearch_types에 그대로 유지.

- **autoresearch_storage.mli** — path builder 5개 + \`scan_persisted_loop_ids\` 가 \`lib/autoresearch.ml\` re-export 대상인데 hidden. 노출. \`load_state\` / \`load_state_result\` 반환 타입 \`loop_state\` → \`persisted_summary\` 로 .ml 과 align.

- **autoresearch_git.mli** — \`is_in_git_repo\` / \`run_git_with_status\` / \`run_capture_lines\` / \`managed_branch_name\` / \`prepare_managed_worktree\` / \`local_branch_exists\` 가 \`lib/autoresearch.ml\` re-export 대상인데 hidden. 노출.

- **coord/coord_utils_ops.mli** — \`log_event\` 시그니처가 \`string\` 으로 적혀있지만 .ml은 \`Yojson.Safe.t\` 받음. PR #11504 가 .mli 만 변경하고 .ml + 7 caller 미반영 상태로 머지됨. .mli 를 .ml 과 일치시킴.

- **keeper/keeper_execution_receipt.mli** — docstring 안 \`\\\"warn\\\"\` 이 OCaml comment lexer를 string mode 로 빠뜨려 다른 라인에서 spurious "unterminated literal". plain \`\"\` 사용 (memory: feedback_ocaml_docstring_escape_quote_lexer_trap).

- **keeper/keeper_context_core.mli** — \`zero_usage\` / \`usage_of_response\` / \`total_tokens\` 가 pre-#11506 \`Oas.Types.usage\` 시그니처. \`Agent_sdk.Types.api_usage\` 로 align. \`timed\` \`'a * float\` → \`'a * int\`. \`save_checkpoint\` \`unit\` → \`checkpoint\`. \`repair_orphan_tool_result_messages\` / \`sanitize_oas_checkpoint\` / \`checkpoint_sanitize_changed\` / \`load_latest_checkpoint\` / \`context_of_legacy_checkpoint\` + \`checkpoint_sanitize_stats\` type 노출 (\`keeper_rollover.ml\` / \`keeper_post_turn.ml\` 의존).

- **keeper/keeper_tools_oas.mli** — \`?search_fn:Keeper_types.tool_search_fn\` 의 alias 가 unbound. inline \`(query:string -> max_results:int -> Yojson.Safe.t)\`. \`?on_tool_called:(string -> Yojson.Safe.t -> unit)\` → \`(string -> unit)\`.

## Remaining (follow-up PR 필요)

이 PR 범위 밖, 별도 surgery 필요:

- \`governance_pipeline.ml\` \`~auto_approved\` arg drift
- \`keeper/keeper_approval_queue\` \`upsert_rule\` return shape
- \`server/server_routes_http_routes_activity\` mli/ml drift
- **Types/Types_core nominal identity leak** — \`lib/types/types.mli\` 의 \`include module type of Types_core\` 가 \`Types.task\` 와 \`Types_core.task\` 를 같은 nominal type 으로 collapse 안 함. \`tool_coord\` / \`verification_protocol\` / \`keeper_world_observation\` / \`mcp_server_eio_resource\` 4 site 영향. PR #11505 의도가 깨졌거나 후속 PR이 facade 망가뜨림. 별도 root cause 분석 필요.

## Test plan

- [x] \`dune build --root . @check\` autoresearch 관련 에러 0
- [x] \`dune build --root . @check\` keeper_context_core / keeper_tools_oas / keeper_execution_receipt 관련 에러 0
- [x] \`dune build --root . @check\` coord/log_event 관련 에러 0 (7 site 동시 해결)

🤖 Generated with [Claude Code](https://claude.com/claude-code)