### PR TITLE
fix(build): unblock dune — approval_queue + routes clock-ty narrowing

### DIFF
--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -94,7 +94,11 @@ val list_rules_dashboard_json : ?base_path:string -> unit -> Yojson.Safe.t
 val policy_summary_json :
   base_path:string -> keeper_name:string -> Yojson.Safe.t
 
-(** Insert or replace an approval rule. Returns the persisted rule. *)
+(** Insert or fetch an approval rule. Returns [(rule, created)]:
+    [created = true] when a new rule was persisted, [false] when an
+    equivalent rule already existed for the
+    [(keeper_name, tool_name, request_fingerprint)] key. Save errors
+    are logged but not surfaced to the caller. *)
 val upsert_rule :
   ?base_path:string ->
   keeper_name:string ->
@@ -105,7 +109,7 @@ val upsert_rule :
   ?created_by:string ->
   ?source_approval_id:string ->
   unit ->
-  (approval_rule, string) result
+  approval_rule * bool
 
 (** Delete the rule whose [id] matches. *)
 val delete_rule :
@@ -121,7 +125,7 @@ val find_matching_rule :
   risk_level:risk_level ->
   ?runtime_contract:Yojson.Safe.t ->
   unit ->
-  (approval_rule * rule_match) option
+  rule_match option
 
 (** {1 Audit log} *)
 
@@ -135,11 +139,14 @@ val audit_approval_event :
   ?turn_id:int ->
   ?task_id:string ->
   ?goal_id:string ->
-  goal_ids:string list ->
+  ?goal_ids:string list ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
   ?disposition:string ->
   ?disposition_reason:string ->
+  ?rule_match:rule_match ->
+  ?source_approval_id:string ->
+  ?auto_approved:bool ->
   ?decision:string ->
   unit ->
   unit

--- a/lib/server/server_routes_http.mli
+++ b/lib/server/server_routes_http.mli
@@ -23,7 +23,7 @@ val make_routes :
   port:int ->
   host:string ->
   sw:Eio.Switch.t ->
-  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
   Http.Router.t
 (** Compose the full route table. Side-effect: registers connectors
     ([Channel_gate_discord_state], [Channel_gate_imessage_state]) on

--- a/lib/server/server_routes_http_routes_activity.mli
+++ b/lib/server/server_routes_http_routes_activity.mli
@@ -7,5 +7,5 @@
 
 val add_routes :
   sw:Eio.Switch.t ->
-  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
   Http_server_eio.Router.t -> Http_server_eio.Router.t

--- a/lib/server/server_routes_http_routes_dashboard.mli
+++ b/lib/server/server_routes_http_routes_dashboard.mli
@@ -9,7 +9,7 @@
 
 val add_routes :
   sw:Eio.Switch.t ->
-  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
   Http_server_eio.Router.t -> Http_server_eio.Router.t
 
 val available_cascade_profiles : unit -> string list


### PR DESCRIPTION
## Summary

After #11519 landed the bulk of the .mli surface restoration, 4 mismatches in lib/ still block dune. This PR clears them so [dune build lib bin] exits 0.

## Diffs (14 lines, 4 files)

### 1. lib/keeper/keeper_approval_queue.mli — 3 signatures drift

| fn | mli (before) | actual .ml |
|---|---|---|
| upsert_rule | (approval_rule, string) result | approval_rule * bool |
| find_matching_rule | (approval_rule * rule_match) option | rule_match option |
| audit_approval_event | missing 3 optional args; goal_ids required | matches .ml |

\`governance_pipeline.ml:387\` calls \`audit_approval_event ... ~auto_approved:true ()\`, blocked by the older mli surface.

### 2. clock_ty open→closed narrowing (3 mli files)

\`clock:[> float Eio.Time.clock_ty ] Eio.Resource.t\` (mli) vs \`clock:float Eio.Time.clock_ty Eio.Resource.t\` (inferred ml). Subsumption can't narrow open→closed at signature ascription. mli matches the .ml.

- server_routes_http.mli
- server_routes_http_routes_activity.mli
- server_routes_http_routes_dashboard.mli

## Test plan

- [x] [dune build --root . lib bin] exit 0
- [x] No diff impact outside lib/
- [ ] CI green
- [ ] Unblocks remaining BLOCKED PRs queued behind dune build

## Out of scope

test/ failures (~5 files referencing test-only / private helpers) are separate fix PRs.

## Note

This is a pared-down subset of an earlier draft that overlapped with #11514 / #11516 / #11519. Kept only what those PRs left behind.