### PR TITLE
[DS-Impl Phase F-K1a] extract BdiSection (will/needs/desires) for K1 BDI variant

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -607,6 +607,29 @@ function ProfileField({ label, value, color }: { label: string; value: string; c
   `
 }
 
+// ── BDI panel (will / needs / desires) ──────────────────
+// Preview spec K1 BDI variant — extraction of inline fragments.
+// Returns null when all three identity fields are absent so callers
+// can place this unconditionally without an outer guard.
+function BdiSection({
+  will,
+  needs,
+  desires,
+}: {
+  will: string | null | undefined
+  needs: string | null | undefined
+  desires: string | null | undefined
+}) {
+  if (!will && !needs && !desires) return null
+  return html`
+    <div class="mt-3 flex flex-col gap-1.5">
+      ${will ? html`<${ProfileField} label="의지" value=${will} color="var(--cyan)" />` : null}
+      ${needs ? html`<${ProfileField} label="필요" value=${needs} color="var(--color-status-warn)" />` : null}
+      ${desires ? html`<${ProfileField} label="열망" value=${desires} color="var(--purple)" />` : null}
+    </div>
+  `
+}
+
 // ── Playground Repos Panel ──────────────────────────────
 
 interface PlaygroundRepo {
@@ -1076,16 +1099,8 @@ export function KeeperDetailPage() {
               ? html`<div class="text-2xs text-[var(--color-fg-muted)] mt-1 leading-relaxed">${keeper.skill_reason}</div>`
               : null}
 
-            ${'' /* ── Identity: will / needs / desires ── */}
-            ${keeper.will || keeper.needs || keeper.desires
-              ? html`
-                <div class="mt-3 flex flex-col gap-1.5">
-                  ${keeper.will ? html`<${ProfileField} label="의지" value=${keeper.will} color="var(--cyan)" />` : null}
-                  ${keeper.needs ? html`<${ProfileField} label="필요" value=${keeper.needs} color="var(--color-status-warn)" />` : null}
-                  ${keeper.desires ? html`<${ProfileField} label="열망" value=${keeper.desires} color="var(--purple)" />` : null}
-                </div>
-              `
-              : null}
+            ${'' /* ── Identity: will / needs / desires (extracted to BdiSection) ── */}
+            <${BdiSection} will=${keeper.will} needs=${keeper.needs} desires=${keeper.desires} />
               <//>
 
           ${keeper.inventory && keeper.inventory.length > 0


### PR DESCRIPTION
## Summary

Phase A audit (PR #11523) finding: preview K1 Keeper Inspector v2 의 **BDI panel variant** 가 production 에서 \`keeper-detail.ts:1080-1086\` 의 inline fragments 로 존재. 별도 컴포넌트로 추출하지 않은 상태.

이 PR 은 inline fragments 를 \`BdiSection\` 함수로 추출 — 신규 파일 없음, 시각적 변경 zero (byte-equivalent rendering).

## Change

\`dashboard/src/components/keeper-detail.ts\`:
- 신규 \`BdiSection\` 함수 추가 (line 614 부근, ProfileField 바로 다음)
- keeper-detail 의 inline 8-line BDI 블록을 \`<\${BdiSection} ... />\` 한 줄로 대체

\`\`\`ts
function BdiSection({ will, needs, desires }: { ... }) {
  if (!will && !needs && !desires) return null
  return html\`
    <div class=\"mt-3 flex flex-col gap-1.5\">
      \${will ? html\`<\${ProfileField} label=\"의지\" value=\${will} color=\"var(--cyan)\" />\` : null}
      \${needs ? html\`<\${ProfileField} label=\"필요\" value=\${needs} color=\"var(--color-status-warn)\" />\` : null}
      \${desires ? html\`<\${ProfileField} label=\"열망\" value=\${desires} color=\"var(--purple)\" />\` : null}
    </div>
  \`
}
\`\`\`

## Why same file

ProfileField 는 keeper-detail 의 internal helper. 별도 파일로 분리하면 import 필요 + cross-keeper aggregate (예: 모든 keeper 의 BDI matrix) 같은 미래 확장 시점에 함께 옮기는게 정합. 이번 PR 은 surgical extraction 만.

## Verification

- 시각적 동일 (byte-equivalent: 같은 ProfileField 호출, 같은 classes, 같은 colors)
- BdiSection 가 \`null\` 리턴 시 호출 site outer guard 불필요 (단순화)
- 변경 라인: +25/-10

## Track context

| PR | Phase | 작업 |
|----|-------|------|
| #11523 (merged) | A audit | 6 zone gap matrix |
| #11524 (merged) | F-K4 | K4 spec deprecation |
| **this** | **F-K1a** | K1 BDI extraction (smaller half) |

Phase F 잔여:
- K1b cross-keeper TokenStats aggregate (Mid, 1 PR — 신규 코드)
- O3 Trend variant (Mid, backend 의존 가능성)
- G1 Frontend derived progress (Mid, 1 PR)
- G2 Stale+Wall (Mid, 2 PR)
- O1 Cascade Inspector new surface (Large, 2 PR — backend + frontend)