### PR TITLE
chore(oas-pin): bump agent_sdk pin v0.181.0 → v0.182.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -41,7 +41,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.181.0))
+  (agent_sdk (>= 0.182.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -25,7 +25,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.181.0"}
+  "agent_sdk" {>= "0.182.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.181.0"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.182.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="aae5b48a33d2d5a0ccc3a1ea7cfa618b3cc8b6dd"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.181.0"
+readonly OAS_AGENT_SDK_SHA="1b8d55193143893104836ddb3d606d0507c91bab"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.182.0"


### PR DESCRIPTION
## Summary

Pulls in [OAS v0.182.0](https://github.com/jeong-sik/oas/releases/tag/v0.182.0) (SHA `1b8d5519`).

| File | Old | New |
|------|-----|-----|
| `dune-project` (L44) | `(agent_sdk (>= 0.181.0))` | `(>= 0.182.0)` |
| `masc_mcp.opam` (L28) | `\"agent_sdk\" {>= \"0.181.0\"}` | `{>= \"0.182.0\"}` |
| `scripts/oas-agent-sdk-pin.sh` | `BASE_VERSION=v0.181.0` / `SHA=aae5b48a` / `MIN_VERSION=0.181.0` | `v0.182.0` / `1b8d5519` / `0.182.0` |

## What's in OAS 0.182.0

- feat(provider): `Provider_config.internal_model_rotation_count` hint (oas#1211)
- refactor(lib): remove thin re-export shims for `Retry`/`Sse_parser` (oas#1220 via #1225)
- test: Eio HTTP body cancellation regression guard (oas#1210)
- test(dune): register orphan `test_tool_set` with QCheck deps (oas#1179 via #1224)
- docs: CLAUDE.md/CONTRIBUTING.md SSOT alignment + provider table expansion (oas#1215-#1218 via #1222)

## Three-file lockstep

Memory rule: \"OAS pin must bump version floor — pin 업데이트 시 `dune-project` + `opam` version floor 동시 변경 필수.\" All three sources moved together so opam-solver and the pin script stay consistent.

## Why no local build verify

A sibling Codex/Claude session was running 22 active `dune build`/`ocamlc` processes when this PR was opened. Memory rule \"dune cross-session _build corruption\" — running another build would race and corrupt `_build/`. CI will exercise the pin in its own clean environment.

## Test plan

- [ ] CI green (Build, lint, downstream gates)
- [ ] No new `Retry.X` / `Sse_parser.X` references in masc-mcp that need migration (the OAS shim removal kept the public surface via `Agent_sdk.Retry = Llm_provider.Retry`, so nothing should break)