### PR TITLE
fix: include No_tool_capable_provider in proactive backoff

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1482,7 +1482,8 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             | Oas_worker_named.Turn_timeout _
             | Oas_worker_named.Admission_queue_timeout _
             | Oas_worker_named.Admission_queue_rejected _
-            | Oas_worker_named.Resumable_cli_session _) ->
+            | Oas_worker_named.Resumable_cli_session _
+            | Oas_worker_named.No_tool_capable_provider _) ->
             true
         | Some _ | None -> false)
     | None -> false


### PR DESCRIPTION
## Summary
- `no_tool_capable_provider` 에러가 `consecutive_noop_count` 백오프에서 제외되어 keeper가 동일 에러를 무한 반복하는 문제 수정
- `update_metrics_from_failure`의 `failure_counts_for_proactive_backoff` 매치 리스트에 `No_tool_capable_provider` variant 추가 (1줄)

## Root Cause
`keeper_unified_metrics.ml:1474-1489`에서 `failure_counts_for_proactive_backoff`는 `Oas_timeout_budget`, `Turn_timeout`, `Admission_queue_timeout`, `Admission_queue_rejected`, `Resumable_cli_session`만 매치. `No_tool_capable_provider`는 `Some _ | None -> false` 폴스루로 분류되어 noop 카운터가 0으로 리셋됨.

결과: keeper가 매 tick마다 동일 에러 반복 → 로그 노이즈 + 백오프 없음 → watchdog noop_threshold(3)에도 도달 불가.

## Fix
매치 리스트에 `No_tool_capable_provider` 추가. 기존 백오프 메커니즘(1x→2x→4x→8x)과 watchdog noop 탐지가 자동으로 동작.

## Test plan
- [ ] `dune build` 통과 (variant 타입 일치 확인)
- [ ] keeper decision log에서 `no_tool_capable_provider` 발생 시 `consecutive_noop_count` 증가 확인
- [ ] 3회 누적 후 watchdog이 fiber 종료하는지 확인
- [ ] 백오프 주기가 1x→2x→4x→8x로 증가하는지 로그로 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)