### PR TITLE
fix(test): expose 14 over-hidden surfaces — main test build clean

### DIFF
--- a/lib/cascade/cascade_health_filter.mli
+++ b/lib/cascade/cascade_health_filter.mli
@@ -6,9 +6,31 @@
     The cascade-failure classification itself lives in
     [Oas_compat.Http_client] so the exhaustive match over the
     [http_error] variants exists in exactly one place; this module
-    only re-exposes the {b decision} predicates needed by the cascade
-    runtime. Internal helpers ([classify_failure],
-    [has_required_api_key], [filter_healthy_internal]) are hidden. *)
+    re-exposes the {b decision} predicates needed by the cascade
+    runtime plus {!classify_failure} for telemetry / tests. Internal
+    helpers ([has_required_api_key], [filter_healthy_internal]) stay
+    hidden. *)
+
+(** Mirror of [Oas_compat.Http_client.cascade_failure_class] so callers
+    can pattern-match without having to depend on the OAS surface. *)
+type cascade_failure_class =
+  Oas_compat.Http_client.cascade_failure_class =
+  | Local_resource_exhaustion
+  | Context_overflow
+  | Provider_parse_error
+  | Transient_http of int
+  | Terminal_http of int
+  | Accept_rejected_capability_mismatch
+  | Accept_rejected_terminal
+  | Cli_transport_required
+  | Network_error
+  | Provider_terminal
+
+val classify_failure :
+  Llm_provider.Http_client.http_error -> cascade_failure_class
+(** Classify [err] into one of the cascade-failure buckets used by the
+    runtime to decide whether to retry, advance, or terminate. Pure
+    delegate to [Oas_compat.Http_client.classify]. *)
 
 val should_cascade_to_next :
   Llm_provider.Http_client.http_error -> bool

--- a/lib/config/env_config_oas_bridge.mli
+++ b/lib/config/env_config_oas_bridge.mli
@@ -41,3 +41,24 @@ val caller_key : caller -> string
 val timeout_sec : caller:caller -> unit -> float
 (** Resolve the OAS bridge timeout (seconds) for [caller] using the
     five-step lookup order documented above. *)
+
+val global_env_var : string
+(** [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] — env var consulted in
+    step 4 of {!timeout_sec}'s lookup order. Exposed for tests
+    (#9629 / #10094) that need to twiddle it via [Unix.putenv]. *)
+
+val per_caller_env_var : caller:caller -> string
+(** [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC] — env var consulted in
+    step 1 of {!timeout_sec}'s lookup order. Exposed for tests. *)
+
+val known_callers : unit -> caller list
+(** The typed-default caller table exposed for tests that want to
+    walk every caller (e.g. assert that the legacy alias map covers
+    them all). *)
+
+val global_default_sec : float
+(** Hardcoded final fallback (seconds) — also reused as the typed
+    default for compute-heavy callers ({!Auto_responder} /
+    {!Dashboard_provider_runs} / {!Governance_judge} /
+    {!Operator_judge}). Exposed so tests can pin the per-caller
+    table without hardcoding the literal. *)

--- a/lib/coord/coord_utils_paths_backend.mli
+++ b/lib/coord/coord_utils_paths_backend.mli
@@ -121,6 +121,12 @@ val key_of_path : config -> string -> string option
     cluster-root-rooted lookups explicit at the call site. *)
 val root_key_of_path : config -> string -> string option
 
+val strip_prefix : string -> string -> string
+(** [strip_prefix prefix s] removes the first [String.length prefix]
+    characters from [s] without verifying that they actually equal
+    [prefix] (callers must check separately). Returns [s] unchanged
+    when it is shorter than [prefix]. *)
+
 (** List directory entries either via [Sys.readdir] (when the
     backend supports a local dir mirror) or via [backend_list_keys]
     over the synthesized prefix. *)

--- a/lib/dashboard/dashboard_governance_metrics.mli
+++ b/lib/dashboard/dashboard_governance_metrics.mli
@@ -38,3 +38,30 @@ val governance_tool_events_json :
 (** Top-level HTTP endpoint payload combining tool-rejection counts
     over the [window_minutes] window with the approval queue summary.
     [now_ts] is injectable for testing. *)
+
+(** {1 Test hooks} *)
+
+val reset_for_testing : unit -> unit
+(** Drop every event from the in-memory ring so an alcotest case can
+    start from a clean state regardless of test order. *)
+
+val inject_for_testing :
+  keeper_name:string ->
+  tool_name:string ->
+  reason_code:string ->
+  ts:float ->
+  unit
+(** Push a synthetic skip event into the ring without going through
+    the production [record_tool_skipped] path so tests can backdate
+    [ts] for window-boundary assertions. *)
+
+val tool_rejection_counts :
+  ?now_ts:float ->
+  window_minutes:int ->
+  unit ->
+  (string * string * int) list
+(** Aggregate [(tool_name, reason_code, count)] over the supplied
+    window. [now_ts] is injectable for testing. Returns a deterministic
+    ordering: count desc, then tool_name asc, then reason_code asc.
+    Exposed for direct test access; the HTTP path consumes it via
+    {!governance_tool_events_json}. *)

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -198,6 +198,36 @@ val load_latest_checkpoint : session_context -> checkpoint option
 val context_of_legacy_checkpoint :
   checkpoint -> primary_model_max_tokens:int -> working_context
 
+val default_max_checkpoint_tool_result_chars : int
+(** Per-tool-result text cap (in chars) applied when projecting
+    Anthropic [tool_result] blocks into a checkpoint. Beyond this
+    threshold the payload collapses to a stub so a single
+    orphan-repair pass cannot inflate one block to multi-MB. *)
+
+val tool_result_text_of_block :
+  tool_use_id:string ->
+  content:string ->
+  json:Yojson.Safe.t option ->
+  string
+(** Project a [tool_result] block to its on-checkpoint string form,
+    applying {!default_max_checkpoint_tool_result_chars}. Exposed so
+    [test_keeper_context_core_dedup] can pin the dedup contract
+    without re-implementing the projection. *)
+
+val sanitize_checkpoint_message :
+  Oas.Types.message -> Oas.Types.message option * checkpoint_sanitize_stats
+(** Apply the per-message portion of {!sanitize_oas_checkpoint}: cap
+    Text and tool_result blocks, drop empties, return the cleaned
+    message (or [None] if every block was dropped) plus its stats.
+    Exposed so [test_keeper_lifecycle] can pin the sanitization
+    contract block-by-block. *)
+
+val checkpoint_text_cap_marker : string
+(** Sentinel suffix appended to a Text or tool_result block when the
+    sanitizer truncates it (newline followed by the [capped] marker).
+    Tests assert against this literal so the marker is part of the
+    public contract. *)
+
 (** Pick the keeper's preferred model for checkpointing —
     canonical cascade name first, then a fallback list of
     provider-default labels. *)

--- a/lib/server/server_routes_http_routes_channel_gate.mli
+++ b/lib/server/server_routes_http_routes_channel_gate.mli
@@ -7,5 +7,23 @@
 
 val add_routes :
   sw:Eio.Switch.t ->
-  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
-  Http_server_eio.Router.t -> Http_server_eio.Router.t
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  Http_server_eio.Router.route list ->
+  Http_server_eio.Router.route list
+
+val record_validation_error_metric :
+  duration_ms:int -> string -> string -> unit
+(** Record a [Validation_error] attempt against [Channel_gate_metrics]
+    using the channel/room/keeper extracted from the request body
+    (best-effort: invalid JSON falls back to [unknown / empty / empty]).
+    Exposed so [test_channel_gate_metrics] can lock the request-metadata
+    extraction contract independently from the HTTP route. *)
+
+val resolve_connector_status_name :
+  ?name:string -> ?channel:string -> unit -> string option
+(** Pick the connector identity for the [/connector/status] endpoint:
+    accepts the canonical [?name] form, falls back to the legacy
+    [?channel] alias, returns [None] when both are empty / blank.
+    Result is trimmed and lowercased. Exposed so
+    [test_channel_gate_connector_routes] can pin the legacy-fallback
+    contract. *)

--- a/lib/server/server_routes_http_routes_dashboard.mli
+++ b/lib/server/server_routes_http_routes_dashboard.mli
@@ -19,3 +19,20 @@ val available_cascade_profiles : unit -> string list
 val invalid_cascade_profiles : unit -> (string * string list) list
 (** Snapshot of [(profile_name, violations)] pairs for cascade
     profiles rejected by the runtime gate. *)
+
+val dashboard_dev_token_path : string -> string
+(** [<base_path>/.masc/auth/dashboard.token] — the canonical
+    dashboard dev-token file written on boot. *)
+
+val legacy_dashboard_dev_token_path : string -> string
+(** [<base_path>/.masc/auth/dashboard-dev.token]. Exposed so the
+    dashboard-keeper-routes test can locate (and clean up) the legacy
+    file the runtime now removes on boot. *)
+
+val ensure_dashboard_dev_token : string -> (string, string) result
+(** Idempotent boot helper: returns the canonical dashboard dev token
+    string, generating + persisting one to {!dashboard_dev_token_path}
+    on first call and removing the legacy file at
+    {!legacy_dashboard_dev_token_path} when present. [Error msg] when
+    the auth dir is unwritable. Exposed so the dashboard-keeper-routes
+    test can drive the boot path directly. *)


### PR DESCRIPTION
## Summary

PR #11519 / #11514 / #11516 가 lib/ 측 cascade 닫은 후 남은 test/ 측 잔여 회귀 정리. 10 .mli 파일에 14 surface 노출 + 시그니처 drift 4건.

\`dune build --root . @check\` 완전 clean (0 errors).

## Per-module changes

### Test surface 노출 (10 symbols)

- \`cascade/cascade_health_filter.mli\` — \`cascade_failure_class\` type mirror + \`classify_failure\`
- \`config/env_config_oas_bridge.mli\` — \`global_env_var\`, \`per_caller_env_var\`, \`known_callers\`, \`global_default_sec\`
- \`coord/coord_utils_paths_backend.mli\` — \`strip_prefix\`
- \`dashboard/dashboard_governance_metrics.mli\` — \`reset_for_testing\`, \`inject_for_testing\`, \`tool_rejection_counts\`
- \`keeper/keeper_context_core.mli\` — \`default_max_checkpoint_tool_result_chars\`, \`tool_result_text_of_block\`, \`sanitize_checkpoint_message\`, \`checkpoint_text_cap_marker\`
- \`server/server_routes_http_routes_dashboard.mli\` — \`dashboard_dev_token_path\`, \`legacy_dashboard_dev_token_path\`, \`ensure_dashboard_dev_token\`
- \`server/server_routes_http_routes_channel_gate.mli\` — \`record_validation_error_metric\`, \`resolve_connector_status_name\`

### 시그니처 drift fix (PR#11519 squash 후 dropped된 cycle-36 변경 재적용)

- \`keeper/keeper_approval_queue.mli\` — \`upsert_rule\` 반환 \`approval_rule * bool\`, \`find_matching_rule\` 반환 \`rule_match option\`, \`audit_approval_event\` 4 optional 노출
- \`server/server_routes_http*.mli\` 4건 — \`clock\` polyvariant → concrete, \`Router.t\` → \`route list\`

## Memory rule applied

- \`feedback_ocaml_docstring_escape_quote_lexer_trap\` — \`\\\\n[capped]\` marker 표기는 escape 없이 plain prose 로 작성. 직전 cycle 에서 같은 lexer trap 한 번 더 발생 (line 226)해서 즉시 plain prose 로 수정.

## Test plan

- [x] \`dune build --root . @check\` clean
- [x] lib + test compile 모두 통과
- [ ] (CI) \`dune runtest\` — PR CI 에서 verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)