### PR TITLE
[DS-Impl Phase F-K1b] cross-keeper TokenStats aggregate panel

### DIFF
--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -14,6 +14,7 @@ import { RouteLink } from './common/route-link'
 import { namespaceTruth } from '../namespace-truth-store'
 import { resolveRuntimeCounts } from '../runtime-counts'
 import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
+import { KeeperTokenStats } from './keeper-token-stats'
 import { FsmHub } from './fsm-hub'
 import { FleetFsmMatrix } from './fleet-fsm-matrix'
 import { HandoffTimeline } from './handoff-timeline'
@@ -109,6 +110,8 @@ export function AgentsUnified() {
         ? html`<${FleetAndFsmHubPanel} />`
         : html`
           ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
+
+          ${currentView === 'keepers' ? html`<${KeeperTokenStats} />` : null}
 
           <${AgentRoster}
             keeperFilter=${currentView === 'keepers' ? 'keeper-only'

--- a/dashboard/src/components/keeper-token-stats.ts
+++ b/dashboard/src/components/keeper-token-stats.ts
@@ -1,0 +1,123 @@
+// MASC Dashboard — K1 · TokenStats variant (cross-keeper aggregate)
+//
+// Phase 2 spec (`design-system/preview/cb-group-h.jsx:KeeperTokenStats`)
+// asks for a fleet-wide token table. Production exposes per-keeper trend
+// only via `TokenTrendChart`. This panel reads the existing `keepers`
+// signal (which already carries `total_tokens` / `total_turns`) and
+// renders a sorted aggregate so the operator can see relative load
+// without opening each keeper detail page.
+//
+// Audit: `dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md`
+// Decision: derive from `keepers` signal (no new fetch). In/out split
+// is omitted because per-keeper in/out values live behind separate
+// `KeeperConfigPanel` fetches; the spec's primary intent is rank +
+// distribution which `total_tokens` covers.
+
+import { html } from 'htm/preact'
+import { computed } from '@preact/signals'
+import { keepers } from '../store'
+
+interface KeeperTokenRow {
+  name: string
+  displayName: string
+  emoji: string
+  turns: number
+  tokens: number
+}
+
+const rows = computed<KeeperTokenRow[]>(() => {
+  return keepers.value
+    .map(k => ({
+      name: k.name,
+      displayName: k.koreanName ?? k.name,
+      emoji: k.emoji ?? '',
+      turns: k.total_turns ?? k.turn_count ?? 0,
+      tokens: k.total_tokens ?? 0,
+    }))
+    .filter(r => r.tokens > 0 || r.turns > 0)
+    .sort((a, b) => b.tokens - a.tokens)
+})
+
+export function KeeperTokenStats() {
+  const data = rows.value
+
+  if (data.length === 0) {
+    return html`
+      <section
+        class="monitor-muted-panel p-4 text-xs text-[var(--color-fg-muted)]"
+        aria-label="키퍼 토큰 사용량 집계"
+      >
+        <header class="mb-1 text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
+          키퍼 토큰 사용량 (집계)
+        </header>
+        <p>아직 토큰을 소비한 키퍼가 없습니다.</p>
+      </section>
+    `
+  }
+
+  const totalTurns = data.reduce((sum, r) => sum + r.turns, 0)
+  const totalTokens = data.reduce((sum, r) => sum + r.tokens, 0)
+  const maxTokens = Math.max(1, ...data.map(r => r.tokens))
+
+  return html`
+    <section
+      class="monitor-muted-panel flex flex-col gap-3 p-4"
+      aria-label="키퍼 토큰 사용량 집계"
+    >
+      <header class="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 class="text-xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
+          키퍼 토큰 사용량 (집계)
+        </h3>
+        <span class="text-2xs text-[var(--color-fg-disabled)]">
+          ${data.length} keepers · 총 ${totalTokens.toLocaleString()} tok / ${totalTurns.toLocaleString()} turns
+        </span>
+      </header>
+      <div class="overflow-x-auto">
+        <table class="w-full font-mono text-xs">
+          <thead>
+            <tr class="border-b border-[var(--color-border-default)] text-left text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">
+              <th class="py-1 pr-2">keeper</th>
+              <th class="py-1 px-2 text-right">turns</th>
+              <th class="py-1 px-2 text-right">total tokens</th>
+              <th class="py-1 pl-2 min-w-[120px]">distribution</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${data.map(r => html`
+              <tr
+                key=${r.name}
+                class="border-b border-[var(--color-border-default)]/40"
+              >
+                <td class="py-1 pr-2">
+                  <span aria-hidden="true">${r.emoji}</span>
+                  <span class="ml-1">${r.displayName}</span>
+                </td>
+                <td class="py-1 px-2 text-right">${r.turns.toLocaleString()}</td>
+                <td class="py-1 px-2 text-right">${r.tokens.toLocaleString()}</td>
+                <td class="py-1 pl-2">
+                  <div
+                    class="h-1.5 rounded-sm bg-[var(--color-bg-surface)]"
+                    role="presentation"
+                  >
+                    <div
+                      class="h-full rounded-sm bg-[var(--color-accent-fg)]"
+                      style=${`width: ${((r.tokens / maxTokens) * 100).toFixed(1)}%`}
+                    ></div>
+                  </div>
+                </td>
+              </tr>
+            `)}
+          </tbody>
+          <tfoot>
+            <tr class="text-2xs uppercase tracking-1 text-[var(--color-fg-muted)]">
+              <td class="pt-2 pr-2">total</td>
+              <td class="pt-2 px-2 text-right">${totalTurns.toLocaleString()}</td>
+              <td class="pt-2 px-2 text-right">${totalTokens.toLocaleString()}</td>
+              <td class="pt-2 pl-2">${data.length} keepers</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </section>
+  `
+}


### PR DESCRIPTION
## Summary

Phase F-K1b reconciliation per audit `dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md`.

Adds a fleet-wide token usage table next to the keeper roster — preview spec `KeeperTokenStats` from `cb-group-h.jsx` was the only K1 variant with **zero production coverage** (production has per-keeper `TokenTrendChart` only).

## Changes

- **New** `dashboard/src/components/keeper-token-stats.ts` (110 LOC)
  - Reads existing `keepers` signal (no new fetch)
  - Per-keeper row: emoji + name + turns + total tokens + horizontal distribution bar (relative to max)
  - Footer aggregates: total turns / total tokens / keeper count
  - Sorted by `total_tokens` desc; filters out keepers with zero usage
  - Empty-state copy when no keeper has run yet
- **Mount** `dashboard/src/components/agents-unified.ts` (+3 lines)
  - Renders only inside the `keepers` view chip (not in `all` / `agents` / `fsm`) so the mixed roster stays uncluttered

## Decisions / Trade-offs

- **In/out split omitted** — preview shows `in tok / out tok / in distribution`, but `Keeper.total_tokens` is a single number. Per-keeper input/output values live in `KeeperConfigMetrics` (separate `KeeperConfigPanel` fetch). Rank + distribution is what the spec primarily encodes; in/out split would require N parallel fetches or a backend aggregate endpoint.
- **No new route** — sub-section under existing `monitoring?section=agents&view=keepers` keeps router surface unchanged.

## Audit alignment

| Item | Status |
|------|--------|
| K1 BDI panel extraction (`KeeperBDIPanel`) | ✅ Done in #11526 (Phase F-K1a) |
| K1 ToolAccess summary extraction | Deferred |
| **K1 cross-keeper TokenStats** | ✅ this PR |

## Test plan

- [ ] `pnpm --filter dashboard typecheck` (CI)
- [ ] `pnpm --filter dashboard build` (CI)
- [ ] Local: `pnpm --filter dashboard dev` → `monitoring?section=agents&view=keepers` → table renders with sorted rows + footer totals
- [ ] Empty state: clear keepers signal → empty-state copy renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)