### PR TITLE
[DS-Impl Phase F-G1] derived goal progress per horizon

### DIFF
--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -3,6 +3,7 @@
 import { signal, computed } from '@preact/signals'
 import {
   goals,
+  tasks,
 } from '../../store'
 import type { Goal, Task } from '../../types'
 
@@ -83,6 +84,91 @@ export const groupedByHorizon = computed(() => {
 
 export function goalById(id: string): Goal | undefined {
   return goals.value.find(g => g.id === id)
+}
+
+// -- Derived progress (Phase F-G1) -------------------------------
+// Phase 2 spec (`design-system/preview/cb-group-d.jsx:GoalHorizonTrack`)
+// expects per-goal `progress` / `total`. Backend `Goal` does not surface
+// these — we derive them from linked tasks. `cancelled` tasks are excluded
+// from the denominator so cancelling a task moves the ratio up rather than
+// counting it as failed work.
+
+export interface GoalProgress {
+  done: number
+  total: number
+  ratio: number
+}
+
+const ZERO_PROGRESS: GoalProgress = { done: 0, total: 0, ratio: 0 }
+
+function isCountedTask(t: Task): boolean {
+  return t.status !== 'cancelled'
+}
+
+function isDoneTask(t: Task): boolean {
+  return t.status === 'done'
+}
+
+export const goalProgressMap = computed<Map<string, GoalProgress>>(() => {
+  const map = new Map<string, GoalProgress>()
+  for (const g of goals.value) {
+    map.set(g.id, { done: 0, total: 0, ratio: 0 })
+  }
+  for (const t of tasks.value) {
+    const gid = t.goal_id
+    if (!gid) continue
+    const entry = map.get(gid)
+    if (!entry) continue
+    if (!isCountedTask(t)) continue
+    entry.total += 1
+    if (isDoneTask(t)) entry.done += 1
+  }
+  for (const v of map.values()) {
+    v.ratio = v.total > 0 ? v.done / v.total : 0
+  }
+  return map
+})
+
+export function goalProgressFor(goalId: string): GoalProgress {
+  return goalProgressMap.value.get(goalId) ?? ZERO_PROGRESS
+}
+
+export const horizonProgress = computed<Record<'short' | 'mid' | 'long', GoalProgress>>(() => {
+  const goalsByHorizon: Record<'short' | 'mid' | 'long', Set<string>> = {
+    short: new Set(),
+    mid: new Set(),
+    long: new Set(),
+  }
+  for (const g of goals.value) {
+    const bucket = goalsByHorizon[g.horizon as 'short' | 'mid' | 'long']
+    if (bucket) bucket.add(g.id)
+  }
+  const acc: Record<'short' | 'mid' | 'long', GoalProgress> = {
+    short: { done: 0, total: 0, ratio: 0 },
+    mid: { done: 0, total: 0, ratio: 0 },
+    long: { done: 0, total: 0, ratio: 0 },
+  }
+  for (const t of tasks.value) {
+    const gid = t.goal_id
+    if (!gid || !isCountedTask(t)) continue
+    for (const h of ['short', 'mid', 'long'] as const) {
+      if (goalsByHorizon[h].has(gid)) {
+        acc[h].total += 1
+        if (isDoneTask(t)) acc[h].done += 1
+        break
+      }
+    }
+  }
+  for (const h of ['short', 'mid', 'long'] as const) {
+    const bucket = acc[h]
+    bucket.ratio = bucket.total > 0 ? bucket.done / bucket.total : 0
+  }
+  return acc
+})
+
+export function formatProgressPct(p: GoalProgress): string {
+  if (p.total === 0) return '0%'
+  return `${Math.round(p.ratio * 100)}%`
 }
 
 // -- Helpers -----------------------------------------------------

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -15,6 +15,8 @@ import {
 import { navigate } from '../../router'
 import {
   groupedByHorizon,
+  horizonProgress,
+  formatProgressPct,
 } from './goal-helpers'
 import { TaskBacklog } from './kanban-components'
 import { TaskCreateForm } from '../task-manage/task-create-form'
@@ -196,6 +198,7 @@ export function Planning() {
   const highPriority = [...todo, ...inProgress].filter(t => (t.priority ?? 4) <= 2).length
 
   const grouped = groupedByHorizon.value
+  const hp = horizonProgress.value
   const hasGoals = goals.value.length > 0
   const onlyBacklogActive = totalTasks > 0 && !hasGoals
   const planStatusHeadline = onlyBacklogActive
@@ -283,21 +286,81 @@ export function Planning() {
           </button>
         </div>
         ${hasGoals ? html`
-          <div class="mt-3 flex flex-wrap gap-2">
-            ${(grouped.short ?? []).length > 0 ? html`
-              <span class="rounded border border-ok/25 bg-ok/10 px-2 py-0.5 text-2xs text-ok">
-                단기 ${(grouped.short ?? []).length}
-              </span>
-            ` : null}
-            ${(grouped.mid ?? []).length > 0 ? html`
-              <span class="rounded border border-warn/25 bg-warn/10 px-2 py-0.5 text-2xs text-warn">
-                중기 ${(grouped.mid ?? []).length}
-              </span>
-            ` : null}
-            ${(grouped.long ?? []).length > 0 ? html`
-              <span class="rounded border border-accent/25 bg-[var(--accent-10)] px-2 py-0.5 text-2xs text-accent">
-                장기 ${(grouped.long ?? []).length}
-              </span>
+          <div class="mt-3 flex flex-col gap-2">
+            <div class="flex flex-wrap gap-2">
+              ${(grouped.short ?? []).length > 0 ? html`
+                <span class="rounded border border-ok/25 bg-ok/10 px-2 py-0.5 text-2xs text-ok">
+                  단기 ${(grouped.short ?? []).length}${hp.short.total > 0 ? ` · ${hp.short.done}/${hp.short.total} (${formatProgressPct(hp.short)})` : ''}
+                </span>
+              ` : null}
+              ${(grouped.mid ?? []).length > 0 ? html`
+                <span class="rounded border border-warn/25 bg-warn/10 px-2 py-0.5 text-2xs text-warn">
+                  중기 ${(grouped.mid ?? []).length}${hp.mid.total > 0 ? ` · ${hp.mid.done}/${hp.mid.total} (${formatProgressPct(hp.mid)})` : ''}
+                </span>
+              ` : null}
+              ${(grouped.long ?? []).length > 0 ? html`
+                <span class="rounded border border-accent/25 bg-[var(--accent-10)] px-2 py-0.5 text-2xs text-accent">
+                  장기 ${(grouped.long ?? []).length}${hp.long.total > 0 ? ` · ${hp.long.done}/${hp.long.total} (${formatProgressPct(hp.long)})` : ''}
+                </span>
+              ` : null}
+            </div>
+            ${(hp.short.total + hp.mid.total + hp.long.total) > 0 ? html`
+              <div class="flex flex-col gap-1">
+                ${hp.short.total > 0 ? html`
+                  <div class="flex items-center gap-2 text-2xs">
+                    <span class="w-8 shrink-0 text-text-muted">단기</span>
+                    <div
+                      class="relative h-1.5 grow overflow-hidden rounded-sm bg-[var(--color-bg-surface)]"
+                      role="progressbar"
+                      aria-valuenow=${Math.round(hp.short.ratio * 100)}
+                      aria-valuemin="0"
+                      aria-valuemax="100"
+                      aria-label=${`단기 목표 진행 ${hp.short.done}/${hp.short.total}`}
+                    >
+                      <div
+                        class="absolute inset-y-0 left-0 bg-ok"
+                        style=${`width: ${(hp.short.ratio * 100).toFixed(1)}%`}
+                      ></div>
+                    </div>
+                  </div>
+                ` : null}
+                ${hp.mid.total > 0 ? html`
+                  <div class="flex items-center gap-2 text-2xs">
+                    <span class="w-8 shrink-0 text-text-muted">중기</span>
+                    <div
+                      class="relative h-1.5 grow overflow-hidden rounded-sm bg-[var(--color-bg-surface)]"
+                      role="progressbar"
+                      aria-valuenow=${Math.round(hp.mid.ratio * 100)}
+                      aria-valuemin="0"
+                      aria-valuemax="100"
+                      aria-label=${`중기 목표 진행 ${hp.mid.done}/${hp.mid.total}`}
+                    >
+                      <div
+                        class="absolute inset-y-0 left-0 bg-warn"
+                        style=${`width: ${(hp.mid.ratio * 100).toFixed(1)}%`}
+                      ></div>
+                    </div>
+                  </div>
+                ` : null}
+                ${hp.long.total > 0 ? html`
+                  <div class="flex items-center gap-2 text-2xs">
+                    <span class="w-8 shrink-0 text-text-muted">장기</span>
+                    <div
+                      class="relative h-1.5 grow overflow-hidden rounded-sm bg-[var(--color-bg-surface)]"
+                      role="progressbar"
+                      aria-valuenow=${Math.round(hp.long.ratio * 100)}
+                      aria-valuemin="0"
+                      aria-valuemax="100"
+                      aria-label=${`장기 목표 진행 ${hp.long.done}/${hp.long.total}`}
+                    >
+                      <div
+                        class="absolute inset-y-0 left-0 bg-accent"
+                        style=${`width: ${(hp.long.ratio * 100).toFixed(1)}%`}
+                      ></div>
+                    </div>
+                  </div>
+                ` : null}
+              </div>
             ` : null}
           </div>
         ` : html`


### PR DESCRIPTION
## Summary

Phase F-G1 reconciliation per audit `dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md`.

Preview spec `GoalHorizonTrack` (`cb-group-d.jsx`) expects per-goal `progress` / `total` fields. Production `Goal` type carries neither. Per the audit's recommendation and the user's product decision (\"Frontend derived computation\"), this PR derives them from linked tasks instead of extending the backend schema.

## Changes

- **`dashboard/src/components/goals/goal-helpers.ts`** (+86 lines)
  - `GoalProgress` interface, `goalProgressMap` (per-goal computed Map)
  - `goalProgressFor(id)` — single goal lookup
  - `horizonProgress` — short / mid / long aggregate computed signal
  - `formatProgressPct` — render helper
  - `cancelled` tasks excluded from the denominator (cancelling moves ratio up, not down)
  - Counts only `done` as completed (not `awaiting_verification`) — matches `tasksByStatus` semantics in `planning.ts`
- **`dashboard/src/components/goals/planning.ts`** (+78 / -15)
  - Horizon pill suffix: `단기 N · 5/12 (42%)`
  - Per-horizon progressbar row beneath the pills (only when at least one horizon has linked tasks)
  - Each progressbar has `role=\"progressbar\"` + `aria-valuenow/min/max` + Korean `aria-label`

## Decisions / Trade-offs

- **No backend change** — `Goal` schema stays untouched. If we later add native `progress` / `target_value` fields, this derivation can become the fallback rather than the only source.
- **`cancelled` excluded** — alternative was \"counted as failed, hurts ratio\". Excluding matches the way the kanban board treats cancellation (terminal but not a failure).
- **`awaiting_verification` not counted as done** — keeps parity with `tasksByStatus.done` definition elsewhere in the file. Verified work that re-opens stays in progress.

## Audit alignment

| Variant | Status |
|---------|--------|
| G1-A (Horizon track) | Partial — pill + bars rendered (no per-goal cards yet) |
| G1-B (Metric tree) | Deferred — needs `metric` / `target_value` columns in `GoalTree` |
| G1-C (Snapshot diff) | Deferred — requires `goal_snapshots` data source |

## Test plan

- [ ] `pnpm --filter dashboard typecheck` (CI)
- [ ] `pnpm --filter dashboard lint` (CI)
- [ ] Local: `pnpm --filter dashboard dev` → `workspace?section=planning` → horizon pill shows `done/total (%)` + 3 progressbars
- [ ] Empty state: clear all tasks → progressbars hidden, pills show count only
- [ ] Cancel a task linked to a goal → ratio increases (not decreases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)