### PR TITLE
[DS-Impl Phase F-G2] task stale-alert + per-keeper wall

### DIFF
--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -17,6 +17,8 @@ import {
   groupedByHorizon,
 } from './goal-helpers'
 import { TaskBacklog } from './kanban-components'
+import { TaskStaleAlert } from './task-stale-alert'
+import { TaskWall } from './task-wall'
 import { TaskCreateForm } from '../task-manage/task-create-form'
 
 const QUICK_START_DOC_URL = 'https://github.com/jeong-sik/masc-mcp/blob/main/docs/QUICK-START.md'
@@ -261,7 +263,11 @@ export function Planning() {
         </div>
       </section>
 
+      <${TaskStaleAlert} />
+
       <${TaskBacklog} />
+
+      <${TaskWall} />
 
       <${KeeperToolActivity} />
 

--- a/dashboard/src/components/goals/task-stale-alert.ts
+++ b/dashboard/src/components/goals/task-stale-alert.ts
@@ -1,0 +1,118 @@
+// MASC Dashboard — G2 · Stale-claim alert variant
+//
+// Phase 2 spec (`design-system/preview/cb-group-d.jsx:TaskStaleAlert`)
+// surfaces tasks whose claim has gone cold so the operator can nudge,
+// force-release, or reassign. Backend `Task` does not expose
+// `claim_age` directly, but the audit
+// (`design-system/audits/2026-04-29-phase2-implementation-gap.md`)
+// authorises a frontend derivation: any task in `claimed` or
+// `in_progress` whose `updated_at` is older than the stale threshold.
+
+import { html } from 'htm/preact'
+import { computed } from '@preact/signals'
+import { tasks } from '../../store'
+import { navigate } from '../../router'
+import type { Task } from '../../types'
+
+// 30 minutes in seconds. Matches the spec's "claim_age ends in `h` or
+// > 10 minutes" rule of thumb but lifted slightly to avoid noise on
+// fast-iterating tasks. Keep this as a named constant — `feedback_no-hyperparameter-as-env-knob`.
+const STALE_THRESHOLD_SECONDS = 30 * 60
+
+interface StaleEntry {
+  task: Task
+  ageSeconds: number
+  label: string
+}
+
+function ageSeconds(task: Task): number | null {
+  const ref = task.updated_at ?? task.created_at
+  if (!ref) return null
+  const ts = Date.parse(ref)
+  if (Number.isNaN(ts)) return null
+  return Math.max(0, Math.floor((Date.now() - ts) / 1000))
+}
+
+function ageLabel(s: number): string {
+  if (s < 60) return `${s}s`
+  if (s < 3600) return `${Math.floor(s / 60)}m`
+  if (s < 86400) return `${Math.floor(s / 3600)}h`
+  return `${Math.floor(s / 86400)}d`
+}
+
+const staleEntries = computed<StaleEntry[]>(() => {
+  const acc: StaleEntry[] = []
+  for (const t of tasks.value) {
+    if (t.status !== 'claimed' && t.status !== 'in_progress') continue
+    const age = ageSeconds(t)
+    if (age == null || age < STALE_THRESHOLD_SECONDS) continue
+    acc.push({ task: t, ageSeconds: age, label: ageLabel(age) })
+  }
+  acc.sort((a, b) => b.ageSeconds - a.ageSeconds)
+  return acc
+})
+
+export function TaskStaleAlert() {
+  const entries = staleEntries.value
+  if (entries.length === 0) return null
+
+  return html`
+    <section
+      class="rounded border border-warn/30 bg-warn/5 p-3"
+      aria-label="오래된 태스크 점유"
+    >
+      <header class="mb-2 flex items-baseline justify-between gap-2">
+        <h3 class="text-xs font-semibold uppercase tracking-1 text-warn">
+          오래 점유 중인 태스크 (${entries.length})
+        </h3>
+        <span class="text-2xs text-text-muted">
+          updated_at 이 ${Math.floor(STALE_THRESHOLD_SECONDS / 60)}분 이상 묶여 있는 claim
+        </span>
+      </header>
+      <ul class="flex flex-col gap-1.5">
+        ${entries.map(e => html`
+          <li
+            key=${e.task.id}
+            class="flex flex-wrap items-center gap-2 rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1.5 text-xs"
+          >
+            <button
+              type="button"
+              class="font-mono text-text-strong hover:underline"
+              title=${e.task.id}
+              onClick=${() => navigate('workspace', { section: 'planning', task: e.task.id })}
+            >
+              ${e.task.id.slice(0, 12)}
+            </button>
+            <span class="grow truncate">${e.task.title}</span>
+            ${e.task.assignee ? html`
+              <span class="text-text-muted">@${e.task.assignee}</span>
+            ` : null}
+            <span class="rounded border border-warn/40 bg-warn/10 px-1.5 py-0.5 text-2xs text-warn">
+              ${e.label}
+            </span>
+            <div class="flex gap-1">
+              ${e.task.assignee ? html`
+                <button
+                  type="button"
+                  class="rounded border border-accent/30 bg-[var(--accent-10)] px-2 py-0.5 text-2xs text-accent hover:bg-[var(--accent-15)]"
+                  title="해당 키퍼 상세로 이동해 직접 nudge"
+                  onClick=${() => e.task.assignee && navigate('monitoring', { section: 'agents', view: 'keepers', keeper: e.task.assignee })}
+                >
+                  nudge
+                </button>
+              ` : null}
+              <button
+                type="button"
+                class="rounded border border-text-muted/30 px-2 py-0.5 text-2xs text-text-muted hover:bg-[var(--color-bg-panel-alt)]"
+                title="태스크 상세 패널 열기"
+                onClick=${() => navigate('workspace', { section: 'planning', task: e.task.id })}
+              >
+                상세
+              </button>
+            </div>
+          </li>
+        `)}
+      </ul>
+    </section>
+  `
+}

--- a/dashboard/src/components/goals/task-wall.ts
+++ b/dashboard/src/components/goals/task-wall.ts
@@ -1,0 +1,113 @@
+// MASC Dashboard — G2 · Per-keeper task wall variant
+//
+// Phase 2 spec (`design-system/preview/cb-group-d.jsx:TaskWall`)
+// renders an N-column grid keyed by keeper, with each cell holding the
+// task chips for that keeper. Production has the data (`Task.assignee`)
+// but no surface that flattens it into a wall view; per-keeper filtering
+// today only surfaces inside `KeeperToolActivity` strips.
+//
+// Audit: `dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md`.
+// `cancelled` and `done` tasks are excluded — the wall is meant to show
+// what each keeper is *currently* responsible for, not historical load.
+
+import { html } from 'htm/preact'
+import { computed } from '@preact/signals'
+import { tasks } from '../../store'
+import { navigate } from '../../router'
+import type { Task } from '../../types'
+
+interface KeeperColumn {
+  keeper: string
+  tasks: Task[]
+}
+
+const UNASSIGNED = '__unassigned__'
+
+function statusGlyph(status: Task['status']): string {
+  switch (status) {
+    case 'todo': return '·'
+    case 'claimed': return '◔'
+    case 'in_progress': return '◑'
+    case 'awaiting_verification': return '⋯'
+    default: return '·'
+  }
+}
+
+const wallColumns = computed<KeeperColumn[]>(() => {
+  const grouped = new Map<string, Task[]>()
+  for (const t of tasks.value) {
+    if (t.status === 'done' || t.status === 'cancelled') continue
+    const key = t.assignee?.trim() || UNASSIGNED
+    let bucket = grouped.get(key)
+    if (!bucket) {
+      bucket = []
+      grouped.set(key, bucket)
+    }
+    bucket.push(t)
+  }
+  for (const list of grouped.values()) {
+    list.sort((a, b) => (a.priority ?? 4) - (b.priority ?? 4))
+  }
+  const cols: KeeperColumn[] = []
+  for (const [keeper, list] of grouped.entries()) {
+    cols.push({ keeper, tasks: list })
+  }
+  cols.sort((a, b) => {
+    if (a.keeper === UNASSIGNED) return 1
+    if (b.keeper === UNASSIGNED) return -1
+    return b.tasks.length - a.tasks.length
+  })
+  return cols
+})
+
+export function TaskWall() {
+  const cols = wallColumns.value
+  if (cols.length === 0) return null
+
+  return html`
+    <section
+      class="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
+      aria-label="키퍼별 태스크 월"
+    >
+      <header class="mb-2 flex items-baseline justify-between">
+        <h3 class="text-xs font-semibold uppercase tracking-1 text-text-muted">
+          키퍼별 태스크 월
+        </h3>
+        <span class="text-2xs text-text-muted">
+          ${cols.length} 키퍼 · 진행 중 ${cols.reduce((s, c) => s + c.tasks.length, 0)} 건
+        </span>
+      </header>
+      <div class="grid gap-2 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
+        ${cols.map(col => html`
+          <div
+            key=${col.keeper}
+            class="flex flex-col gap-1 rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-2"
+          >
+            <div class="flex items-baseline justify-between gap-1 text-2xs">
+              <span class="font-mono ${col.keeper === UNASSIGNED ? 'text-text-disabled' : 'text-text-strong'}">
+                ${col.keeper === UNASSIGNED ? '미할당' : col.keeper}
+              </span>
+              <span class="text-text-muted">${col.tasks.length}</span>
+            </div>
+            <ul class="flex flex-col gap-0.5">
+              ${col.tasks.map(t => html`
+                <li key=${t.id}>
+                  <button
+                    type="button"
+                    class="flex w-full items-center gap-1.5 rounded-sm border border-[var(--color-border-default)]/50 bg-[var(--color-bg-surface)] px-1.5 py-0.5 text-left text-2xs hover:border-accent/40 hover:bg-[var(--accent-10)]"
+                    title=${`${t.id} · ${t.status ?? 'unknown'}`}
+                    onClick=${() => navigate('workspace', { section: 'planning', task: t.id })}
+                  >
+                    <span aria-hidden="true" class="text-text-muted">${statusGlyph(t.status)}</span>
+                    <span class="font-mono text-text-disabled">${t.id.slice(0, 6)}</span>
+                    <span class="grow truncate">${t.title}</span>
+                  </button>
+                </li>
+              `)}
+            </ul>
+          </div>
+        `)}
+      </div>
+    </section>
+  `
+}


### PR DESCRIPTION
## Summary

Phase F-G2 reconciliation per audit `dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md`.

Adds the two G2 variants that had zero production surface:

- **TaskStaleAlert** — claimed/in_progress tasks whose `updated_at` is > 30 minutes old, with nudge/detail shortcut buttons.
- **TaskWall** — per-keeper grid; each column is one assignee, cells contain open task chips ordered by priority.

Both mounted into `Planning` around the existing kanban (stale alert above for urgency, wall below for overview).

## Changes

- **New** `dashboard/src/components/goals/task-stale-alert.ts` (113 LOC)
- **New** `dashboard/src/components/goals/task-wall.ts` (109 LOC)
- **Mount** `dashboard/src/components/goals/planning.ts` (+6 lines: 2 imports + 2 mounts)

## Decisions / Trade-offs

- **No backend change.** Spec asks for `claim_age` / `drift` / `branch` fields on `Task`. We derive `claim_age` from `updated_at` (since this captures the same intent — \"how long has this been sitting\"). `drift` and `branch` are dropped — neither is exposed via any current `Task`-adjacent type, and adding them would require backend work outside Phase F scope.
- **Threshold as named constant.** `STALE_THRESHOLD_SECONDS = 30 * 60` lives in the file, not env. Memory: `feedback_no-hyperparameter-as-env-knob` — algorithmic calibration is code, not knobs.
- **Wall excludes `done` / `cancelled`.** The wall represents *current* load. History view belongs to the kanban's `done` column.
- **Stale alert hidden when empty.** No \"0 stale tasks\" noise on a healthy board.
- **Action buttons are navigation, not mutations.** \"nudge\" → keeper detail, \"상세\" → task detail. The spec's `force-release` / `reassign` are deferred until backend mutation endpoints exist for those operations.

## Audit alignment

| Variant | Status |
|---------|--------|
| G2-A (Backlog flat-table view) | Deferred — kanban already covers this surface; flat-table would require alternate `view=` param |
| **G2-B (Stale alert)** | ✅ this PR |
| **G2-C (Wall)** | ✅ this PR |

## Test plan

- [ ] `pnpm --filter dashboard typecheck` (CI)
- [ ] `pnpm --filter dashboard lint` (CI)
- [ ] Local: `workspace?section=planning` → with no stale tasks, alert section is hidden; with a >30min claim, alert renders sorted desc
- [ ] Wall renders one column per assignee + an `미할당` column when tasks lack assignee
- [ ] Click nudge / 상세 buttons → router navigates without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)