### PR TITLE
[DS-Impl Phase F-G1b] surface goal metric + target_value in GoalTree

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -481,6 +481,14 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
             <${HealthBadge} health=${node.health} />
             <${StatusBadge} status=${node.status} />
             ${node.task_count > 0 ? html`<span>${node.task_done_count}/${node.task_count} 태스크</span>` : null}
+            ${node.metric ? html`
+              <span
+                class="rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-1.5 py-0.5 font-mono text-3xs text-text-secondary"
+                title=${`metric · ${node.metric}${node.target_value ? ` → ${node.target_value}` : ''}`}
+              >
+                <span aria-hidden="true">↗ </span>${node.metric}${node.target_value ? html`<span class="ml-1 text-text-strong"> · ${node.target_value}</span>` : null}
+              </span>
+            ` : null}
             ${(() => {
               const awaiting = countAwaitingVerificationTasks(node.tasks)
               return awaiting > 0 ? html`
@@ -781,6 +789,19 @@ function GoalDetailPanel({
             <span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-widest" style="color:${horizonColor(selectedNode.horizon)}">
               ${horizonLabel(selectedNode.horizon)}
             </span>
+            ${selectedNode.metric ? html`
+              <span
+                class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 font-mono text-3xs text-text-secondary"
+                title="이 목표가 추적하는 metric"
+              >
+                <span class="text-text-muted">metric</span>
+                <span class="ml-1.5">${selectedNode.metric}</span>
+                ${selectedNode.target_value ? html`
+                  <span class="text-text-muted">·</span>
+                  <span class="ml-1 text-text-strong">${selectedNode.target_value}</span>
+                ` : null}
+              </span>
+            ` : null}
           </div>
         </div>
         <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Phase F-G1b reconciliation per audit `dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md`.

Preview spec `GoalMetricTree` (`cb-group-d.jsx`) lists `metric` and `target_value` next to title / progress / phase. The data already exists on `GoalTreeNode` (`types/dashboard-execution.ts:622-623`) — production simply doesn't render it. This PR adds the missing surface.

## Changes

- **Tree row** (`goal-tree.ts:480` area, +9 lines): small monospace pill rendered when `metric` is present. `target_value` appended after a separator when it exists.
- **Selected-goal detail header** (`goal-tree.ts:790` area, +12 lines): richer metric block in the detail panel header next to the horizon badge.

## Decisions / Trade-offs

- **No backend change** — the field is already in the API response; just unrendered.
- **Conditional render** — both surfaces hide entirely when `metric` is null, so goals without metrics stay compact.
- **`target_value` is optional** — when missing, only the metric name renders. Memory: `feedback_dont-overgeneralize-review-findings` — surfacing what's available rather than inventing placeholder targets.

## Audit alignment

| Variant | Status |
|---------|--------|
| G1-A (Horizon track) | ✅ #11533 (horizon strip + progressbars) |
| **G1-B (Metric tree)** | ✅ this PR |
| G1-C (Snapshot diff) | Deferred — needs `goal_snapshots` data source |

## Test plan

- [ ] `pnpm --filter dashboard typecheck` (CI)
- [ ] `pnpm --filter dashboard lint` (CI)
- [ ] Local: `workspace?section=planning&view=goal-tree` → goals with `metric` set show the pill on each row + metric block in detail header
- [ ] Goals without `metric` render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)