### PR TITLE
[DS-Impl Phase F-K1c] read-only ToolAccess summary panel

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -19,6 +19,7 @@ import { formatTokens } from '../lib/format-number'
 import { isVerifierRoleKeeper } from '../lib/keeper-utils'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
+import { KeeperToolAccessSummary } from './keeper-tool-access'
 import { createAsyncResource, loaded } from '../lib/async-state'
 import { SetupGuideCard } from './setup-guide-card'
 
@@ -781,6 +782,8 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   return html`
     <div class="flex flex-col gap-1.5">
       ${toolbar}
+
+      <${KeeperToolAccessSummary} config=${c} />
 
       <${Callout}
         title="편집 가능 범위"

--- a/dashboard/src/components/keeper-tool-access.ts
+++ b/dashboard/src/components/keeper-tool-access.ts
@@ -1,0 +1,81 @@
+// MASC Dashboard — K1 · ToolAccess summary variant (read-only)
+//
+// Phase 2 spec (`design-system/preview/cb-group-h.jsx:KeeperToolAccess`)
+// expects a compact <dl> of cascade / tools_preset / sandbox / network /
+// auto_handoff / handoff_threshold / proactive_idle / mention targets,
+// rendered as a quick-scan summary before the operator dives into the
+// editable form. Production has all the data on `KeeperConfig` but only
+// surfaces it through the editable `KeeperConfigPanel` form.
+//
+// Audit: `dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md`.
+// This panel is intentionally read-only — mutations go through the existing
+// editable form below it. The intent is "what are the current tool/exec
+// settings for this keeper?" answered without scrolling.
+
+import { html } from 'htm/preact'
+import type { KeeperConfig } from '../types'
+
+function ToolAccessRow({
+  label, value,
+}: {
+  label: string
+  value: unknown
+}) {
+  const display: unknown = value === null || value === undefined || value === '' ? '—' : value
+  return html`
+    <div class="grid grid-cols-[120px_1fr] items-baseline gap-3 py-1">
+      <dt class="text-2xs uppercase tracking-1 text-text-muted">${label}</dt>
+      <dd class="font-mono text-xs text-text-strong">${display}</dd>
+    </div>
+  `
+}
+
+function presetLabel(c: KeeperConfig): string {
+  const tools = c.tools
+  if (tools.tool_policy_mode === 'custom') return 'custom'
+  return tools.tool_preset ?? 'unset'
+}
+
+function mentionsLabel(targets: readonly string[]): string {
+  if (targets.length === 0) return '—'
+  return targets.map(t => `@${t}`).join(' · ')
+}
+
+export function KeeperToolAccessSummary({ config }: { config: KeeperConfig }) {
+  const cascade = config.execution.selected_cascade_name || '—'
+  const preset = presetLabel(config)
+  const sandbox = config.sandbox_profile ?? 'local'
+  const network = config.network_mode ?? 'inherit'
+  const handoff = `${config.handoff.auto ? 'on' : 'off'} · threshold ${config.handoff.threshold}`
+  const idle = `${config.proactive.idle_sec}s${config.proactive.enabled ? '' : ' (disabled)'}`
+  const mentions = mentionsLabel(config.coordination.mention_targets)
+  const allowlistCount = config.tools.resolved_allowlist.length
+  const denylistCount = config.tools.tool_denylist.length
+
+  return html`
+    <section
+      class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4"
+      aria-label="툴 / 실행 접근 요약 (read-only)"
+    >
+      <header class="mb-2 flex items-baseline justify-between gap-2">
+        <h3 class="text-xs font-semibold uppercase tracking-1 text-text-muted">
+          툴 / 실행 접근 요약
+        </h3>
+        <span class="text-2xs text-text-disabled">read-only · 변경은 아래 편집 영역</span>
+      </header>
+      <dl class="grid grid-cols-1 gap-x-6 md:grid-cols-2">
+        <${ToolAccessRow} label="cascade" value=${cascade} />
+        <${ToolAccessRow} label="tools preset" value=${preset} />
+        <${ToolAccessRow} label="sandbox" value=${sandbox} />
+        <${ToolAccessRow} label="network" value=${network} />
+        <${ToolAccessRow} label="auto handoff" value=${handoff} />
+        <${ToolAccessRow} label="proactive idle" value=${idle} />
+        <${ToolAccessRow} label="mention targets" value=${mentions} />
+        <${ToolAccessRow}
+          label="allow / deny"
+          value=${`${allowlistCount} allow · ${denylistCount} deny`}
+        />
+      </dl>
+    </section>
+  `
+}


### PR DESCRIPTION
## Summary

Phase F-K1c reconciliation per audit `dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md`.

Preview spec `KeeperToolAccess` (`cb-group-h.jsx`) renders a compact read-only \`<dl>\` of cascade / tools_preset / sandbox / network / auto_handoff / handoff_threshold / proactive_idle / mention targets. Production has all the data on \`KeeperConfig\` but only surfaces it through the editable \`KeeperConfigPanel\` form (mixed read+write — operator has to scroll/scan to find a single setting).

This PR adds a quick-scan summary at the top of the config panel.

## Changes

- **New** \`dashboard/src/components/keeper-tool-access.ts\` (81 LOC)
  - \`KeeperToolAccessSummary({ config })\` — read-only \`<dl>\`, 2-col grid on md+
  - \`presetLabel\` collapses \`tool_policy_mode === 'custom'\` to display \"custom\"
  - \`mentionsLabel\` joins targets with \`@\` prefix; \"—\" when empty
  - Adds an \"allow / deny\" row showing rule counts (the second-most asked question and free since the data is right there on \`tools\`)
- **Mount** \`dashboard/src/components/keeper-config-panel.ts\` (+3 lines: 1 import + 2 mount)
  - Renders below the toolbar, above the \"편집 가능 범위\" callout

## Decisions / Trade-offs

- **Read-only — no overlap with the editable form below.** Quick-scan layer; mutations still go through the existing form.
- **Includes allow/deny counter beyond the spec.** Spec lists \`tools_preset\` only; preset alone hides whether the keeper has custom additions. Counts are derived from \`config.tools.resolved_allowlist\` / \`tool_denylist\`.
- **Empty / null collapsed to \"—\".** Avoids rendering literal \`undefined\` or empty strings.

## Audit alignment

| Variant | Status |
|---------|--------|
| K1-A (BDI panel) | ✅ #11526 (extract from KeeperDetailPage) |
| **K1-B (ToolAccess summary)** | ✅ this PR |
| K1-C (Cross-keeper TokenStats) | ✅ #11532 |

K1 zone fully covered.

## Test plan

- [ ] \`pnpm --filter dashboard typecheck\` (CI)
- [ ] \`pnpm --filter dashboard lint\` (CI)
- [ ] Local: open keeper detail → KeeperConfigPanel renders the summary panel at top
- [ ] Keeper with no mention targets → \"—\" renders (not literal undefined)
- [ ] Keeper with \`tool_policy_mode === 'custom'\` → preset row shows \"custom\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)