### PR TITLE
feat(tools): tlc_test_gen — nested record fixture + CLI batch mode

### DIFF
--- a/tools/tlc_test_gen/bin/main.ml
+++ b/tools/tlc_test_gen/bin/main.ml
@@ -1,18 +1,74 @@
 let usage () =
-  prerr_endline "usage: tlc_test_gen <path-to-TTrace.tla>";
+  prerr_endline "usage:";
+  prerr_endline "  tlc_test_gen <path-to-TTrace.tla>";
+  prerr_endline "  tlc_test_gen --batch <out-dir> <path-to-TTrace.tla>...";
   exit 2
+
+let render state =
+  let buf = Buffer.create 1024 in
+  Buffer.add_string buf (Tlc_test_gen.Ocaml_emit.emit_let_test state);
+  Buffer.add_char   buf '\n';
+  Buffer.add_string buf (Tlc_test_gen.Ocaml_emit.emit_trace state);
+  Buffer.add_char   buf '\n';
+  Buffer.add_string buf
+    (Tlc_test_gen.Ocaml_emit.emit_let_test_reachability state);
+  Buffer.contents buf
+
+let parse path =
+  match Tlc_test_gen.Ttrace_parser.parse_file path with
+  | Error msg ->
+      Printf.eprintf "tlc_test_gen: %s: %s\n" path msg;
+      None
+  | Ok state -> Some state
+
+(* mkdir -p without depending on the [Unix] library — relies on stdlib only.
+   Returns true if the directory exists (or was created) after the call. *)
+let mkdir_p dir =
+  if Sys.file_exists dir then Sys.is_directory dir
+  else
+    let cmd = Printf.sprintf "mkdir -p %s" (Filename.quote dir) in
+    Sys.command cmd = 0 && Sys.file_exists dir && Sys.is_directory dir
+
+let write_to dir state out =
+  if not (mkdir_p dir) then begin
+    Printf.eprintf "tlc_test_gen: cannot create out-dir: %s\n" dir;
+    false
+  end else
+    let fname =
+      Filename.concat dir
+        (state.Tlc_test_gen.Ttrace_parser.spec_module ^ ".ml")
+    in
+    let oc = open_out fname in
+    output_string oc out;
+    close_out oc;
+    Printf.printf "wrote %s\n" fname;
+    true
+
+let run_one path =
+  match parse path with
+  | None -> false
+  | Some state ->
+      print_string (render state);
+      true
+
+let run_batch out_dir paths =
+  if paths = [] then begin usage () end;
+  let any_error = ref false in
+  List.iter
+    (fun path ->
+      match parse path with
+      | None -> any_error := true
+      | Some state ->
+          let out = render state in
+          if not (write_to out_dir state out) then any_error := true)
+    paths;
+  not !any_error
 
 let () =
   match Array.to_list Sys.argv with
+  | _ :: "--batch" :: out_dir :: paths ->
+      if run_batch out_dir paths then () else exit 1
+  | _ :: ("-h" | "--help") :: _ -> usage ()
   | _ :: path :: _ ->
-      (match Tlc_test_gen.Ttrace_parser.parse_file path with
-       | Error msg ->
-           prerr_endline ("tlc_test_gen: " ^ msg);
-           exit 1
-       | Ok state ->
-           print_string (Tlc_test_gen.Ocaml_emit.emit_let_test state);
-           print_newline ();
-           print_string (Tlc_test_gen.Ocaml_emit.emit_trace state);
-           print_newline ();
-           print_string (Tlc_test_gen.Ocaml_emit.emit_let_test_reachability state))
+      if run_one path then () else exit 1
   | _ -> usage ()

--- a/tools/tlc_test_gen/test/fixtures/nested_record.tla
+++ b/tools/tlc_test_gen/test/fixtures/nested_record.tla
@@ -1,0 +1,25 @@
+---- MODULE NestedSample_TTrace_1700000001 ----
+EXTENDS Sequences, TLCExt, Naturals, TLC
+
+_inv ==
+    ~(
+        TLCGet("level") = Len(_TETrace)
+        /\
+        active = (TRUE)
+        /\
+        retries = (3)
+    )
+====
+
+---- MODULE NestedSample_TTrace_1700000001_TETrace ----
+EXTENDS NestedSample_TTrace_1700000001, TLC
+
+trace ==
+    <<
+    ([active |-> FALSE, retries |-> 0, config |-> [host |-> "init", port |-> 0]]),
+    ([active |-> TRUE, retries |-> 1, config |-> [host |-> "localhost", port |-> 8080]]),
+    ([active |-> TRUE, retries |-> 3, config |-> [host |-> "localhost", port |-> 8080]])
+    >>
+----
+
+====

--- a/tools/tlc_test_gen/test/test_ttrace_parser.ml
+++ b/tools/tlc_test_gen/test/test_ttrace_parser.ml
@@ -111,4 +111,66 @@ let () =
       must_contain ~ctx:"emit_reachability"
         reach "List.assoc_opt \"turn_phase\" last = Some (Tlc_test_gen.Ttrace_parser.V_string \"failed\")";
 
+      (* ---- Nested record fixture (Cycle 21 follow-up) ---- *)
+      (match parse_file (fixture "nested_record.tla") with
+       | Error msg ->
+           Printf.eprintf "FAIL [nested parse_file]: %s\n" msg; exit 1
+       | Ok nst ->
+           assert_eq ~ctx:"nested module name"
+             "NestedSample_TTrace_1700000001" nst.spec_module;
+
+           (* The _inv body uses simple bindings; record-typed bindings fall
+              outside the regex narrower so should not pollute. *)
+           assert_eq ~ctx:"nested binding count"
+             "2" (string_of_int (List.length nst.bindings));
+
+           (* Step sequence has 3 records; each contains a nested record
+              [host |-> ..., port |-> ...] preserved as V_raw. *)
+           assert_eq ~ctx:"nested step count"
+             "3" (string_of_int (List.length nst.steps));
+           let nstep i name =
+             try List.assoc name (List.nth nst.steps i)
+             with Not_found ->
+               Printf.eprintf "FAIL [nested step %d field]: %s\n" i name;
+               exit 1
+           in
+           assert_eq ~ctx:"nested step 0 active"
+             "bool(false)" (value_to_str (nstep 0 "active"));
+           assert_eq ~ctx:"nested step 0 retries"
+             "int(0)" (value_to_str (nstep 0 "retries"));
+
+           (* Critical: nested record value is preserved as V_raw with inner
+              brackets and the embedded "init" string verbatim. *)
+           (match nstep 0 "config" with
+            | V_raw r ->
+                let needle = "host |-> \"init\"" in
+                let len_r = String.length r in
+                let len_n = String.length needle in
+                let rec scan i =
+                  if i + len_n > len_r then begin
+                    Printf.eprintf
+                      "FAIL [nested step 0 config V_raw missing %S, got %S]\n"
+                      needle r;
+                    exit 1
+                  end else if String.sub r i len_n = needle then ()
+                  else scan (i + 1)
+                in
+                scan 0
+            | other ->
+                Printf.eprintf
+                  "FAIL [nested step 0 config not V_raw]: %s\n"
+                  (value_to_str other);
+                exit 1);
+
+           assert_eq ~ctx:"nested step 2 retries"
+             "int(3)" (value_to_str (nstep 2 "retries"));
+
+           (* Emitter quotes the V_raw payload so the embedded "init" stays
+              valid OCaml after generation. *)
+           let nemit = Tlc_test_gen.Ocaml_emit.emit_trace nst in
+           must_contain ~ctx:"nested emit_trace V_raw"
+             nemit "Tlc_test_gen.Ttrace_parser.V_raw";
+           must_contain ~ctx:"nested emit_trace escaped init"
+             nemit "host |-> \\\"init\\\"");
+
       print_endline "PASS"


### PR DESCRIPTION
## Summary

Cycle 20 (#11535) shipped the `_TETrace` step sequence parser. This is Cycle 21 follow-up (Plan §14 / Tier C2 / β2 Phase 1) — adds a nested-record verification fixture and a CLI batch mode.

## Changes

**Nested record fixture (parser verification)**
- New `test/fixtures/nested_record.tla` — 3-step trace where each record carries a nested record `[host |-> "...", port |-> N]`.
- Test asserts the nested value round-trips as `V_raw` with the inner brackets and embedded `"init"` string verbatim.
- Test asserts emitted OCaml escapes the embedded string (`host |-> \"init\"`) so generated code stays syntactically valid.

**CLI batch mode**
```bash
# Single-file (unchanged): prints to stdout
tlc_test_gen <path-to-TTrace.tla>

# New: writes <spec_module>.ml files into <out-dir>
tlc_test_gen --batch <out-dir> <file1.tla> <file2.tla> ...
```
- `mkdir -p` for missing out-dirs via `Sys.command` (stdlib only — no `unix` dep).
- Errors on individual files print to stderr and propagate as exit 1 while remaining files still process.

## Verification

```bash
dune build --root . tools/tlc_test_gen   # ✅
dune test  --root . tools/tlc_test_gen   # ✅ legacy + nested fixtures
```

Smoke batch:
| Input | Output |
|-------|--------|
| AmbiguousPartialCommitBug_TTrace_1777353461.tla | 70-line .ml |
| CascadeStrategy_TTrace_1776849069.tla | 74-line .ml (set/tuple V_raw preserved) |

## Scope

- Isolated dune scope under `tools/tlc_test_gen/`. Zero `lib/` or `test/` dependency. `masc_mcp.opam` unaffected.
- Stacked on `origin/main` (#11535 already merged).

## Test plan

- [x] Build / test pass on isolated scope
- [x] Nested record fixture: V_raw preservation + escape verified
- [x] Batch mode smoke against 2 real spec TTraces

🤖 Generated with [Claude Code](https://claude.com/claude-code)