### PR TITLE
feat(codex-doctor): add codex_mcp_config_doctor.mli — typed report surface (cycle 39)

### DIFF
--- a/lib/codex_mcp_config_doctor.mli
+++ b/lib/codex_mcp_config_doctor.mli
@@ -1,0 +1,64 @@
+(** Codex_mcp_config_doctor — diagnose the Codex MCP client config.
+
+    Reads [<HOME>/.codex/config.toml] (or whatever
+    [MASC_CODEX_CONFIG_PATH] points at) and produces a {!type-t}
+    report consumed by [Auth_doctor] and the dashboard. The report
+    splits into a flat record of resolved values plus a list of
+    {!stage}s with [pass] / [warn] / [fail] / [skip] verdicts.
+
+    Internal parsing helpers ([table_fields_opt], [assoc_opt],
+    [assoc_ci_opt], [string_opt], [string_ci_opt], [sorted_keys],
+    [accept_header_ok], [server_names_detail], [config_path_opt],
+    [analyze_content], [analyze_path], [oauth_login_stage], [empty],
+    [stage_to_yojson], [option_field] / [option_bool_field], and the
+    expected-value constants [expected_server_name],
+    [expected_token_env_var], [expected_x_masc_agent],
+    [codex_config_path_env_key]) are hidden — callers consume the
+    typed report and the {!analyze_default} / {!to_yojson} /
+    {!warnings} / {!next_actions} accessors only. *)
+
+type stage_status =
+  | Stage_pass
+  | Stage_warn
+  | Stage_fail
+  | Stage_skip
+
+type stage = {
+  name : string;
+  status : stage_status;
+  detail : string;
+}
+
+type t = {
+  config_path : string option;
+  file_present : bool;
+  parse_error : string option;
+  server_names : string list;
+  server_present : bool;
+  url : string option;
+  bearer_token_env_var : string option;
+  bearer_token_env_matches : bool option;
+  authorization_header_present : bool option;
+  accept_header : string option;
+  accept_header_ok : bool option;
+  x_masc_agent : string option;
+  x_masc_agent_ok : bool option;
+  stages : stage list;
+}
+
+val stage_status_to_string : stage_status -> string
+
+val analyze_default : unit -> t
+(** Build a report from the resolved Codex config path. When neither
+    [HOME] nor [MASC_CODEX_CONFIG_PATH] is set, every dependent stage
+    short-circuits to {!Stage_skip}. *)
+
+val to_yojson : t -> Yojson.Safe.t
+
+val warnings : t -> string list
+(** Human-readable lines of the form
+    [Codex MCP pipeline <stage>: <detail>] for stages whose status
+    is {!Stage_fail} or {!Stage_warn}. *)
+
+val next_actions : t -> string list
+(** Concrete remediation hints (one per failing/warned stage). *)


### PR DESCRIPTION
## Summary

- \`lib/codex_mcp_config_doctor.mli\` 신규 (433줄 모듈, 8 surface 노출 / 17 internal 숨김).
- typed report (stage_status / stage / t) 고정 → \`Auth_doctor\` 와 dashboard caller 가 parsing helper 못 만짐.

## Hidden (17)

- TOML/Yojson lookup: \`table_fields_opt\`, \`assoc_opt\`, \`assoc_ci_opt\`, \`string_opt\`, \`string_ci_opt\`, \`sorted_keys\`
- Validators: \`accept_header_ok\`, \`server_names_detail\`
- Path resolver: \`config_path_opt\`
- Stage builders: \`stage\`, \`oauth_login_stage\`, \`empty\`
- Pipeline: \`analyze_content\`, \`analyze_path\`
- Yojson helpers: \`stage_to_yojson\`, \`option_field\`, \`option_bool_field\`
- Expected-value 상수 4: \`expected_server_name\`, \`expected_token_env_var\`, \`expected_x_masc_agent\`, \`codex_config_path_env_key\`

## Exposed (8)

- 3 types: \`stage_status\` (4 variants), \`stage\` record, \`t\` (14-field main report)
- \`stage_status_to_string\` 컨버터
- \`analyze_default\` 엔트리포인트
- \`to_yojson\` 시리얼라이저
- \`warnings\` + \`next_actions\` accessor

## Caller audit

\`lib/auth_doctor.ml\` + \`test/test_auth_doctor.ml\` 외부 사용 전부 노출 surface 매칭:
- \`analyze_default\`, \`t\` 필드 접근, stage variants (Stage_pass/Warn/Fail/Skip), \`stage_status_to_string\`, \`to_yojson\`, \`warnings\`, \`next_actions\`.

## Memory rule applied

- 첫 빌드에서 \`[\\\"Codex MCP pipeline ...\\\"]\` lexer trap 다시 발생 → 같은 cycle 38 의 trap 재현. 메모리 \`feedback_ocaml_docstring_escape_quote_lexer_trap\` 에 \"recidivism\" 섹션 + \"드래프트 시 \`rg -n '\\\\\"' <new_files>\` 검사\" 워크플로 룰 추가.

## Test plan

- [x] \`dune build --root . @check\` codex_mcp_config_doctor 관련 에러 0 (lexer trap 1차 fix 후 clean)
- [x] caller audit (auth_doctor + test 양쪽) 외부 사용 8 symbol 모두 mli 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)