### PR TITLE
[DS-Impl Phase D-G3] ErrorBoundary severity (recoverable/fatal) + reload

### DIFF
--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -1,13 +1,24 @@
 import { html } from 'htm/preact'
 import { Component, type ComponentChildren } from 'preact'
-import { AlertOctagon, RefreshCcw } from 'lucide-preact'
+import { AlertOctagon, AlertTriangle, RefreshCcw, RotateCw } from 'lucide-preact'
 
 interface ErrorBoundaryInfo {
   componentStack?: string
 }
 
+// Phase 2 spec (`design-system/preview/cb-group-g.jsx:G3`) defines two
+// inline error-banner tones:
+//   - 'recoverable' (warn) + retry — soft amber, retry resets boundary
+//   - 'fatal' (err) + retry + reload — soft red, reload reloads the window
+// Production has historically rendered only the fatal tone with a single
+// retry. Adding `severity` keeps the existing default while letting callers
+// opt into the gentler recoverable framing, and the fatal default now also
+// carries an explicit reload button per spec.
+export type ErrorBoundarySeverity = 'recoverable' | 'fatal'
+
 interface Props {
   label?: string
+  severity?: ErrorBoundarySeverity
   fallback?: (error: Error, reset: () => void) => ComponentChildren
   onError?: (error: Error, info: ErrorBoundaryInfo) => void
   children: ComponentChildren
@@ -28,6 +39,12 @@ export class ErrorBoundary extends Component<Props, State> {
     this.setState({ error: null })
   }
 
+  private reload = (): void => {
+    if (typeof window !== 'undefined') {
+      window.location.reload()
+    }
+  }
+
   componentDidCatch(error: Error, info: ErrorBoundaryInfo) {
     console.error(`[ErrorBoundary:${this.props.label ?? 'unknown'}]`, error)
     this.props.onError?.(error, info)
@@ -38,21 +55,67 @@ export class ErrorBoundary extends Component<Props, State> {
       if (this.props.fallback) {
         return this.props.fallback(this.state.error, this.reset)
       }
+
+      const severity: ErrorBoundarySeverity = this.props.severity ?? 'fatal'
+      if (severity === 'recoverable') {
+        return html`
+          <div
+            class="error-card my-3 flex items-start gap-4 rounded border border-[var(--color-status-warn)]/30 bg-[var(--color-status-warn)]/10 p-5 shadow-sm"
+            style="border-left: 3px solid var(--color-status-warn);"
+            role="alert"
+          >
+            <div class="mt-0.5 shrink-0 text-[var(--color-status-warn)]">
+              <${AlertTriangle} size=${24} />
+            </div>
+            <div class="min-w-0 flex-1">
+              <h3 class="mb-1 text-2xs font-semibold uppercase tracking-1 text-[var(--color-status-warn)]">
+                recoverable · ${this.props.label ?? '컴포넌트'}
+              </h3>
+              <pre class="overflow-x-auto whitespace-pre-wrap rounded bg-[var(--black-20)] p-2 text-sm text-[var(--color-fg-primary)] opacity-80">${this.state.error.message}</pre>
+              <button
+                type="button"
+                class="mt-3 inline-flex cursor-pointer items-center justify-center gap-1.5 rounded border border-[var(--color-status-warn)]/40 bg-[var(--color-status-warn)]/10 px-3 py-1.5 text-sm text-[var(--color-status-warn)] transition-colors hover:bg-[var(--color-status-warn)]/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-status-warn)]"
+                onClick=${this.reset}
+              >
+                <${RefreshCcw} size=${14} />
+                다시 시도
+              </button>
+            </div>
+          </div>
+        `
+      }
+
+      // severity === 'fatal' — original tone + an explicit reload button
       return html`
-        <div class="error-card rounded my-3 border border-[var(--color-status-err)]/30 bg-[rgba(10,22,40,0.92)] p-5 flex gap-4 items-start shadow-sm" role="alert">
-          <div class="shrink-0 text-[var(--color-status-err)] mt-0.5">
+        <div
+          class="error-card my-3 flex items-start gap-4 rounded border border-[var(--color-status-err)]/30 bg-[rgba(10,22,40,0.92)] p-5 shadow-sm"
+          style="border-left: 3px solid var(--color-status-err);"
+          role="alert"
+        >
+          <div class="mt-0.5 shrink-0 text-[var(--color-status-err)]">
             <${AlertOctagon} size=${24} />
           </div>
-          <div class="flex-1 min-w-0">
-            <h3 class="text-base font-semibold text-[var(--color-status-err)] tracking-tight mb-1">${this.props.label ?? 'Component'} 렌더링 오류</h3>
-            <pre class="text-sm whitespace-pre-wrap opacity-80 text-[var(--color-fg-primary)] overflow-x-auto bg-[var(--black-20)] p-2 rounded">${this.state.error.message}</pre>
-            <button type="button"
-              class="mt-3 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 cursor-pointer rounded border border-[var(--color-border-default)] bg-[var(--white-5)] text-[var(--color-fg-secondary)] text-sm hover:bg-[var(--white-10)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-status-err)]"
-              onClick=${this.reset}
-            >
-              <${RefreshCcw} size=${14} />
-              다시 시도
-            </button>
+          <div class="min-w-0 flex-1">
+            <h3 class="mb-1 text-base font-semibold tracking-tight text-[var(--color-status-err)]">${this.props.label ?? 'Component'} 렌더링 오류</h3>
+            <pre class="overflow-x-auto whitespace-pre-wrap rounded bg-[var(--black-20)] p-2 text-sm text-[var(--color-fg-primary)] opacity-80">${this.state.error.message}</pre>
+            <div class="mt-3 flex flex-wrap gap-2">
+              <button
+                type="button"
+                class="inline-flex cursor-pointer items-center justify-center gap-1.5 rounded border border-[var(--color-border-default)] bg-[var(--white-5)] px-3 py-1.5 text-sm text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--white-10)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-status-err)]"
+                onClick=${this.reset}
+              >
+                <${RefreshCcw} size=${14} />
+                다시 시도
+              </button>
+              <button
+                type="button"
+                class="inline-flex cursor-pointer items-center justify-center gap-1.5 rounded border border-[var(--color-status-err)]/50 bg-[var(--color-status-err)]/15 px-3 py-1.5 text-sm font-medium text-[var(--color-status-err)] transition-colors hover:bg-[var(--color-status-err)]/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-status-err)]"
+                onClick=${this.reload}
+              >
+                <${RotateCw} size=${14} />
+                세션 리로드
+              </button>
+            </div>
           </div>
         </div>
       `


### PR DESCRIPTION
## Summary

Phase 2 spec (\`design-system/preview/cb-group-g.jsx:G3\`) defines two inline error-banner tones (recoverable + fatal). Production \`ErrorBoundary\` has historically rendered only fatal tone with one retry button. This PR aligns with the spec.

## Changes

\`dashboard/src/components/common/error-boundary.ts\` (+76 / -13):
- New \`severity?: 'recoverable' | 'fatal'\` prop (default: \`'fatal'\` — preserves existing behavior).
- **Recoverable** mode: warn tone (amber border-left + soft bg), \`AlertTriangle\` icon, retry-only.
- **Fatal** mode: err tone (preserved) + new "세션 리로드" button next to retry per spec's two-action pattern.

## Decisions / Trade-offs

- **Default unchanged.** All existing call sites (no \`severity\` prop) get the original fatal banner — just with an extra reload button beside retry. No breaking change.
- **Reload uses \`window.location.reload()\`** — matches spec's "session lost" intent. Guarded for SSR (\`typeof window !== 'undefined'\`).
- **Custom \`fallback\` prop bypasses both modes** — escape hatch for callers that need full control.

## Audit alignment

The audit didn't list G3 as a separate zone (it's a UI primitive, not a data zone), but the spec card exists in \`cb-root.jsx\` and a reconciliation was natural. K1 / G1 / G2 / K4 / O4 zones now joined by G3 reconciliation.

## Test plan

- [ ] \`pnpm --filter dashboard typecheck\` (CI)
- [ ] \`pnpm --filter dashboard lint\` (CI)
- [ ] Existing \`error-boundary.test.ts\` still passes (default fatal mode preserved)
- [ ] Throw an error in a tab with \`severity=\"recoverable\"\` → amber banner with retry only
- [ ] Throw in default \`severity\` → red banner with retry + reload buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)