### PR TITLE
fix(keeper): noop backoff + proactive observability (#10474)

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1482,7 +1482,8 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             | Oas_worker_named.Turn_timeout _
             | Oas_worker_named.Admission_queue_timeout _
             | Oas_worker_named.Admission_queue_rejected _
-            | Oas_worker_named.Resumable_cli_session _) ->
+            | Oas_worker_named.Resumable_cli_session _
+            | Oas_worker_named.No_tool_capable_provider _) ->
             true
         | Some _ | None -> false)
     | None -> false

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1008,6 +1008,18 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
             delivery_surface = Social.Visible_reply;
           }
   in
+  (* #10474: proactive outcome counter for successful cycles. *)
+  if update_proactive_rt && is_scheduled_autonomous_cycle then begin
+    let outcome =
+      if has_substantive_tools then "tool_called"
+      else if is_noop_cycle ~has_text ~tools_used:result.tools_used
+      then "noop"
+      else "tool_called"
+    in
+    Prometheus.inc_counter Prometheus.metric_keeper_proactive_outcome
+      ~labels:[ ("keeper", meta.name); ("outcome", outcome) ]
+      ()
+  end;
   {
     meta with
     updated_at = now_iso ();
@@ -1488,6 +1500,26 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
         | Some _ | None -> false)
     | None -> false
   in
+  (* #10474: emit Prometheus counters for no_tool_provider and proactive
+     cycle outcomes so Grafana can surface fleet-wide health ratios. *)
+  (match sdk_error with
+   | Some err ->
+       (match Oas_worker_named.classify_masc_internal_error err with
+        | Some (Oas_worker_named.No_tool_capable_provider
+                  { cascade_name; _ }) ->
+            Prometheus.inc_counter
+              Prometheus.metric_keeper_no_tool_provider
+              ~labels:
+                [ ("keeper", meta.name)
+                ; ("cascade", cascade_name)
+                ]
+              ()
+        | _ -> ())
+   | None -> ());
+  if is_scheduled_autonomous_cycle then
+    Prometheus.inc_counter Prometheus.metric_keeper_proactive_outcome
+      ~labels:[ ("keeper", meta.name); ("outcome", "error") ]
+      ();
   let preview =
     let trimmed = String.trim public_reason in
     if trimmed = "" then "keeper cycle failed"

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -423,6 +423,17 @@ let metric_keeper_profile_config_conflicts =
   "masc_keeper_profile_config_conflicts_total"
 let metric_keeper_oas_timeout_classifications =
   "masc_keeper_oas_timeout_classifications_total"
+(* #10474: no_tool_capable_provider and proactive cycle outcome counters.
+   [metric_keeper_no_tool_provider_total] fires every time a keeper's
+   cascade has zero tool-capable providers, labelled by cascade so
+   the operator sees which cascade definition needs fixing.
+   [metric_keeper_proactive_outcome_total] classifies every scheduled
+   autonomous cycle into tool_called | noop | error, giving a fleet-wide
+   health ratio in Grafana. *)
+let metric_keeper_no_tool_provider =
+  "masc_keeper_no_tool_provider_total"
+let metric_keeper_proactive_outcome =
+  "masc_keeper_proactive_outcome_total"
 (* PR-B: keeper turn skipped due to ollama saturation pre-check.
    Labelled by [keeper] and [cascade]. *)
 let metric_keeper_ollama_saturation_skip =
@@ -924,6 +935,13 @@ let init () =
   add metric_keeper_oas_timeout_classifications
     "Total keeper OAS timeout classifications. Labeled by \
      classification=transient_network|structural_budget|other_timeout."
+    Counter;
+  add metric_keeper_no_tool_provider
+    "Total no_tool_capable_provider errors. Labeled by keeper and cascade."
+    Counter;
+  add metric_keeper_proactive_outcome
+    "Total proactive cycle outcomes. Labeled by keeper and \
+     outcome=tool_called|noop|error."
     Counter;
   add metric_keeper_ollama_saturation_skip
     "Total keeper turns skipped because the resolved cascade is \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -166,6 +166,12 @@ val metric_keeper_require_tool_use_violations : string
 val metric_keeper_tool_alias_canonicalizations : string
 val metric_keeper_profile_config_conflicts : string
 val metric_keeper_oas_timeout_classifications : string
+val metric_keeper_no_tool_provider : string
+(** #10474: counter incremented when a keeper's cascade has zero
+    tool-capable providers.  Labels: keeper, cascade. *)
+val metric_keeper_proactive_outcome : string
+(** #10474: counter classifying each scheduled autonomous cycle outcome.
+    Labels: keeper, outcome={tool_called|noop|error}. *)
 val metric_keeper_ollama_saturation_skip : string
 (** PR-B: counter incremented when [run_keeper_cycle] skips a turn
     because the keeper's resolved cascade is ollama-only and the

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -171,7 +171,7 @@ val metric_keeper_no_tool_provider : string
     tool-capable providers.  Labels: keeper, cascade. *)
 val metric_keeper_proactive_outcome : string
 (** #10474: counter classifying each scheduled autonomous cycle outcome.
-    Labels: keeper, outcome={tool_called|noop|error}. *)
+    Labels: keeper, outcome=[tool_called|noop|error]. *)
 val metric_keeper_ollama_saturation_skip : string
 (** PR-B: counter incremented when [run_keeper_cycle] skips a turn
     because the keeper's resolved cascade is ollama-only and the


### PR DESCRIPTION
## Summary
- Include `No_tool_capable_provider` in `failure_counts_for_proactive_backoff` so consecutive no-tool-provider errors trigger exponential backoff (1x→2x→4x→8x) instead of spinning indefinitely
- Add `masc_keeper_no_tool_provider_total{keeper,cascade}` Prometheus counter for cascade health monitoring
- Add `masc_keeper_proactive_outcome_total{keeper,outcome}` Prometheus counter classifying proactive cycles as tool_called/noop/error

## Root Cause
When all providers in a cascade fail tool capability checks, the keeper's proactive turn immediately returns `Error (No_tool_capable_provider ...)`. The backoff gate in `failure_counts_for_proactive_backoff` did not include this variant, so `consecutive_noop_count` never incremented and the keeper retried every tick with zero cooldown.

## Test plan
- [ ] Verify `masc_keeper_no_tool_provider_total` increments in Prometheus when a cascade has no tool-capable providers
- [ ] Verify `masc_keeper_proactive_outcome_total{outcome="error"}` increments on failure, `{outcome="tool_called"}` on success
- [ ] Verify consecutive no-tool-provider errors increase `consecutive_noop_count` in keeper meta JSON
- [ ] Verify cooldown multiplier applies (base → 2x → 4x → 8x over 4 consecutive failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)