### PR TITLE
feat(telemetry): add telemetry_eio.mli — typed event ADT (cycle 43)

### DIFF
--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -1,0 +1,215 @@
+(** Telemetry_eio — event tracking + analytics over a date-split
+    JSONL store.
+
+    Public surface covers: typed events ({!event} / {!event_record} /
+    {!metrics}) with their auto-derived JSON / show converters, the
+    [track_*] convenience emitters, the read-side aggregations
+    ([read_all_events], [read_events_since], [summarize_tool_usage],
+    [summarize_agent_activity], [get_metrics]), the pure metric
+    calculators, plus the [rotate] maintenance entry point.
+
+    Internal helpers ([empty_tool_usage_stats], [update_tool_usage],
+    [telemetry_file], the [telemetry_store_cache] Hashtbl + mutex,
+    [get_telemetry_store], [telemetry_eio_surface] /
+    [observe_telemetry_drop] / [report_telemetry_drop],
+    [read_all_events_from_path], [event_to_json], [track], and the
+    [nonempty_opt] string utility) are hidden — callers consume the
+    typed event ADT and the convenience emitters / readers only. *)
+
+type config = Coord_utils.config
+
+(** {1 Events} *)
+
+type event =
+  | Agent_joined of { agent_id : string; capabilities : string list }
+  | Agent_left of { agent_id : string; reason : string }
+  | Task_started of { task_id : string; agent_id : string }
+  | Task_completed of {
+      task_id : string;
+      duration_ms : int;
+      success : bool;
+    }
+  | Handoff_triggered of {
+      from_agent : string;
+      to_agent : string;
+      reason : string;
+    }
+  | Error_occurred of {
+      code : string;
+      message : string;
+      context : string;
+    }
+  | Tool_called of {
+      tool_name : string;
+      success : bool;
+      duration_ms : int;
+      agent_id : string option;
+      source : string option;
+      session_id : string option;
+      operation_id : string option;
+      worker_run_id : string option;
+      error_kind : string option;
+      error_message : string option;
+      exit_code : int option;
+      stderr_excerpt : string option;
+    }
+  | Tool_assigned of {
+      agent_id : string;
+      profile : string;
+      preset : string option;
+      tool_count : int;
+      assignment_id : string;
+    }
+[@@deriving yojson, show]
+
+type event_record = {
+  timestamp : float;
+  event : event;
+} [@@deriving yojson, show]
+
+(** {1 Aggregated metrics} *)
+
+type metrics = {
+  active_agents : int;
+  tasks_in_progress : int;
+  tasks_completed_24h : int;
+  avg_task_duration_ms : float;
+  handoff_rate : float;
+  error_rate : float;
+} [@@deriving yojson, show]
+
+type tool_usage_stats = {
+  count : int;
+  success_count : int;
+  failure_count : int;
+  last_used_at : float option;
+}
+
+type tool_usage_summary = {
+  telemetry_path : string;
+  telemetry_available : bool;
+  total_calls : int;
+  stats_by_tool : (string, tool_usage_stats) Hashtbl.t;
+}
+
+type agent_activity = {
+  agent_id : string;
+  tool_calls : int;
+  success_count : int;
+  failure_count : int;
+  first_seen : float;
+  last_seen : float;
+}
+
+(** {1 Read side} *)
+
+val read_all_events : ?fs:'a -> config -> event_record list
+
+val read_events_since :
+  ?fs:'a -> config -> since:float -> event_record list
+
+val parse_event_records : Yojson.Safe.t list -> event_record list
+
+val event_to_json : event -> Yojson.Safe.t
+(** Project [event] to its JSONL row shape (with the current
+    timestamp stamped in, then [event_record_to_yojson] applied).
+    Exposed for the telemetry coverage test that asserts JSON
+    payload shape directly. *)
+
+val summarize_tool_usage : ?fs:'a -> config -> tool_usage_summary
+
+val summarize_agent_activity :
+  ?fs:'a -> config -> since:float -> agent_activity list
+
+val tool_usage_fields :
+  tool_usage_summary -> string -> (string * Yojson.Safe.t) list
+
+val get_metrics : ?fs:'a -> config -> metrics
+
+(** {1 Pure metric calculators} *)
+
+val count_active_agents : event_record list -> int
+val count_tasks_in_progress : event_record list -> int
+val count_completed_tasks : event_record list -> int
+val avg_duration : event_record list -> float
+val calculate_handoff_rate : event_record list -> float
+val calculate_error_rate : event_record list -> float
+
+(** {1 Convenience emitters} *)
+
+val track_agent_joined :
+  ?fs:'a ->
+  config ->
+  agent_id:string ->
+  ?capabilities:string list ->
+  unit ->
+  unit
+
+val track_agent_left :
+  ?fs:'a -> config -> agent_id:string -> reason:string -> unit
+
+val track_task_started :
+  ?fs:'a -> config -> task_id:string -> agent_id:string -> unit
+
+val track_task_completed :
+  ?fs:'a ->
+  config ->
+  task_id:string ->
+  duration_ms:int ->
+  success:bool ->
+  unit
+
+val track_handoff :
+  ?fs:'a ->
+  config ->
+  from_agent:string ->
+  to_agent:string ->
+  reason:string ->
+  unit
+
+val track_error :
+  ?fs:'a ->
+  config ->
+  code:string ->
+  message:string ->
+  context:string ->
+  unit
+
+val track_tool_called :
+  ?fs:'a ->
+  config ->
+  tool_name:string ->
+  success:bool ->
+  duration_ms:int ->
+  ?agent_id:string ->
+  ?source:string ->
+  ?session_id:string ->
+  ?operation_id:string ->
+  ?worker_run_id:string ->
+  ?error_kind:string ->
+  ?error_message:string ->
+  ?exit_code:int ->
+  ?stderr_excerpt:string ->
+  unit ->
+  unit
+(** When [success = false] and [error_kind] is provided, additionally
+    emits a paired [Error_occurred] row with a context envelope built
+    from the non-empty optional fields (#10358). *)
+
+val track_tool_assigned :
+  ?fs:'a ->
+  config ->
+  agent_id:string ->
+  profile:string ->
+  ?preset:string ->
+  tool_count:int ->
+  assignment_id:string ->
+  unit ->
+  unit
+
+(** {1 Maintenance} *)
+
+val rotate : fs:'a -> config -> max_age_days:int -> unit
+(** Drop telemetry day-files older than [max_age_days] days. The
+    [fs] argument is currently ignored but kept in the signature for
+    forward compatibility with a future stub-fs override. *)


### PR DESCRIPTION
## Summary

- \`lib/telemetry_eio.mli\` 신규 (452줄 모듈, 26 surface 노출 / 9 internal 숨김).
- typed event ADT (8 variants) + ppx_yojson/ppx_show 자동 derive — JSON round-trip 정합성 유지.

## Hidden (9)

- \`empty_tool_usage_stats\`, \`update_tool_usage\`
- \`telemetry_file\` 경로 resolver
- \`telemetry_store_cache\` Hashtbl + mutex
- \`get_telemetry_store\` cache accessor
- Drop instrumentation 3개 (\`telemetry_eio_surface\`, \`observe_telemetry_drop\`, \`report_telemetry_drop\`)
- 내부 reader: \`read_all_events_from_path\`
- 제네릭 emitter \`track\` (caller는 typed wrapper 사용)
- 문자열 utility \`nonempty_opt\`

## Exposed (26)

- \`config\` alias
- event ADT (8 variants) + \`event_record\` / \`metrics\` / \`tool_usage_stats\` / \`tool_usage_summary\` / \`agent_activity\` records
- ppx 자동 yojson + show derive
- Read 8개 (\`read_all_events\`, \`read_events_since\`, \`parse_event_records\`, \`event_to_json\`, \`summarize_*\` 2, \`tool_usage_fields\`, \`get_metrics\`)
- 순수 metric 계산기 6
- typed track_* 8 wrapper
- \`rotate\` maintenance

## Iterations

- (1) \`event_to_json\` 누락 — \`test_telemetry_eio_coverage\` 가 직접 사용 → 노출 추가.

## Memory rule applied

\`feedback_ocaml_docstring_escape_quote_lexer_trap\` 워크플로 룰 \`rg -n '\\\\\"' lib/telemetry_eio.mli\` 사전 통과.

## Test plan

- [x] \`dune build --root . @check\` telemetry_eio 관련 에러 0
- [x] caller audit (lib/coord, lib/dashboard, test) 26 symbol 매칭
- [x] lexer trap 사전 검사 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)