### PR TITLE
feat(gate): add channel_gate_discord_state.mli — connector S surface only (cycle 44)

### DIFF
--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -1,0 +1,63 @@
+(** Channel_gate_discord_state — Discord connector state.
+
+    Implements the {!Channel_gate_connector.S} module signature so it
+    can be registered at server startup via
+    [Channel_gate_connector.register (module Channel_gate_discord_state)].
+
+    Internal helpers (the [U] / [Names] aliases, the [binding] /
+    [audit_event] records, the [default_*_path] / [legacy_*_path] /
+    [status_path] / [status_write_path] / [binding_store_path] /
+    [binding_store_read_path] / [binding_audit_path] /
+    [binding_audit_read_path] resolvers, [stale_after_sec],
+    [read_json_file_opt], [normalize_bindings_json],
+    [read_bindings] / [save_bindings] / [binding_json] /
+    [audit_event_json] / [append_audit_event] / [read_recent_audit] /
+    [drop_left], the [string_member] / [int_member] / [bool_member] /
+    [bool_option_member] yojson lookups, [stale_of_updated_at],
+    [connector_state_label], [list_assoc_field],
+    [find_assoc_by_string_field], and [rollback_bindings]) are
+    hidden — only the {!Channel_gate_connector.S} surface is
+    public. *)
+
+(** {1 Connector identity} *)
+
+val connector_id : string
+(** ["discord"]. *)
+
+val display_name : string
+(** ["Discord"]. *)
+
+val channel : string
+(** ["discord"]. *)
+
+(** {1 Connector status} *)
+
+val status_json : ?audit_limit:int -> unit -> Yojson.Safe.t
+(** Runtime status snapshot — bindings, recent audit events,
+    staleness flag, and connector liveness. [audit_limit] caps the
+    audit-history slice (default [10]). *)
+
+val connector_json :
+  ?gate_status_json:Yojson.Safe.t ->
+  ?audit_limit:int ->
+  unit ->
+  Yojson.Safe.t
+(** Full connector descriptor for the dashboard, layering
+    [gate_status_json] (if provided) on top of {!status_json}. *)
+
+(** {1 Binding lifecycle} *)
+
+val bind :
+  channel_id:string ->
+  keeper_name:string ->
+  actor_name:string ->
+  (Yojson.Safe.t, string) result
+(** Create or update a channel→keeper binding, append an audit
+    event, and return the resulting binding row as JSON. *)
+
+val unbind :
+  channel_id:string ->
+  actor_name:string ->
+  (Yojson.Safe.t, string) result
+(** Remove a channel→keeper binding, append an audit event, and
+    return the removed binding row as JSON. *)


### PR DESCRIPTION
## Summary

- \`lib/gate/channel_gate_discord_state.mli\` 신규 (491줄 모듈, 7 surface 노출 / ~30 internal 숨김).
- \`Channel_gate_connector.S\` module signature 정확히 만족 → first-class-module registration의 컴파일타임 가드.
- gate sub-dir batch 1번째 (cycle 45 후보: imessage_state).

## Hidden (~30)

- 모듈 alias 2: \`U\`, \`Names\`
- 내부 record 2: \`binding\`, \`audit_event\`
- Path resolver 12개 (default/legacy/status/binding 모두)
- File IO + JSON projection 6
- Audit log helper 3
- JSON lookup 4
- State helper 5

## Exposed (7 — exactly S)

\`connector_id\`, \`display_name\`, \`channel\`, \`status_json\`, \`connector_json\`, \`bind\`, \`unbind\`

## First-class module contract

\`server_routes_http.ml\` 의 \`Channel_gate_connector.register (module Channel_gate_discord_state)\` 가 .mli S subtype 검사. narrow가 곧 contract 확보.

## Caller audit

- \`lib/server/server_routes_http.ml:11\` — first-class module registration (S subtype)
- \`test/test_channel_gate_discord_state.ml\` — bind / status_json / unbind 만 사용
- \`lib/server/server_routes_http.mli:29\` — docstring 언급만, symbol 사용 0

## First-try-clean

\`dune build --root . @check\` 첫 시도 통과.

## Memory rule applied

\`feedback_ocaml_docstring_escape_quote_lexer_trap\` 워크플로 룰 사전 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)