### PR TITLE
feat(gate): add channel_gate_imessage_state.mli — connector S surface only (cycle 45)

### DIFF
--- a/lib/gate/channel_gate_imessage_state.mli
+++ b/lib/gate/channel_gate_imessage_state.mli
@@ -1,0 +1,54 @@
+(** Channel_gate_imessage_state — iMessage connector state.
+
+    Implements the {!Channel_gate_connector.S} module signature so it
+    can be registered at server startup via
+    [Channel_gate_connector.register (module Channel_gate_imessage_state)].
+
+    Every internal helper (path resolvers, audit log,
+    binding-store IO, JSON lookups, state classifiers) is hidden —
+    only the {!Channel_gate_connector.S} surface is public. The same
+    narrow strategy applied to {!Channel_gate_discord_state} so the
+    two connectors stay structurally interchangeable. *)
+
+(** {1 Connector identity} *)
+
+val connector_id : string
+(** ["imessage"]. *)
+
+val display_name : string
+(** ["iMessage"]. *)
+
+val channel : string
+(** ["imessage"]. *)
+
+(** {1 Connector status} *)
+
+val status_json : ?audit_limit:int -> unit -> Yojson.Safe.t
+(** Runtime status snapshot — bindings, recent audit events,
+    staleness flag, and connector liveness. [audit_limit] caps the
+    audit-history slice (default [10]). *)
+
+val connector_json :
+  ?gate_status_json:Yojson.Safe.t ->
+  ?audit_limit:int ->
+  unit ->
+  Yojson.Safe.t
+(** Full connector descriptor for the dashboard, layering
+    [gate_status_json] (if provided) on top of {!status_json}. *)
+
+(** {1 Binding lifecycle} *)
+
+val bind :
+  channel_id:string ->
+  keeper_name:string ->
+  actor_name:string ->
+  (Yojson.Safe.t, string) result
+(** Create or update a channel→keeper binding, append an audit
+    event, and return the resulting binding row as JSON. *)
+
+val unbind :
+  channel_id:string ->
+  actor_name:string ->
+  (Yojson.Safe.t, string) result
+(** Remove a channel→keeper binding, append an audit event, and
+    return the removed binding row as JSON. *)


### PR DESCRIPTION
## Summary

- \`lib/gate/channel_gate_imessage_state.mli\` 신규 (445줄 모듈, 7 surface).
- Cycle 44 (Discord) 와 같은 \`Channel_gate_connector.S\` signature 정확 일치 → first-class-module registration 컴파일타임 검증.
- gate sub-dir batch 완료 (cycle 44 + 45).

## Exposed (7 — exactly S)

\`connector_id\` (\"imessage\"), \`display_name\` (\"iMessage\"), \`channel\` (\"imessage\"), \`status_json\`, \`connector_json\`, \`bind\`, \`unbind\`

## Hidden

모든 internal helper (path resolvers, audit log, binding store IO, JSON lookups, state classifiers) — discord와 동일 패턴.

## First-class module contract

\`server_routes_http.ml:12\` 의 \`Channel_gate_connector.register (module Channel_gate_imessage_state)\` 가 .mli S subtype 검사.

## Caller audit

- \`lib/server/server_routes_http.ml:12\` — first-class-module registration
- \`test/test_channel_gate_imessage_state.ml\` — \`status_json\` / \`connector_json\` 만 사용 (S subset)

## First-try-clean

\`dune build --root . @check\` 첫 시도 통과.

## Memory rule applied

\`feedback_ocaml_docstring_escape_quote_lexer_trap\` 워크플로 룰 사전 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)