### PR TITLE
feat(shared_types): Tier I5 — Resilience_outcome stub GADT (Cycle 19)

### DIFF
--- a/lib/shared_audit/dune
+++ b/lib/shared_audit/dune
@@ -1,0 +1,6 @@
+(include_subdirs no)
+
+(library
+ (name shared_audit)
+ (public_name masc_mcp.shared_audit)
+ (libraries unix yojson digestif digestif.c))

--- a/lib/shared_audit/envelope.ml
+++ b/lib/shared_audit/envelope.ml
@@ -1,0 +1,110 @@
+type t = {
+  id : string;
+  ts : float;
+  category : string;
+  payload : Yojson.Safe.t;
+  prev_hash : string option;
+}
+
+let initialized = ref false
+
+let init_random () =
+  if not !initialized then begin
+    Random.self_init ();
+    initialized := true
+  end
+
+(* ULID-lite: 16 hex chars timestamp-ms + "-" + 26 hex chars random. *)
+let generate_id () =
+  init_random ();
+  let now_ms = Int64.of_float (Unix.gettimeofday () *. 1000.0) in
+  let ts_hex = Printf.sprintf "%016Lx" now_ms in
+  let r1 = Random.int64 0x100000000L in
+  let r2 = Random.int64 0x100000000L in
+  let r3 = Random.int64 0x10000L in
+  let r_hex = Printf.sprintf "%08Lx%08Lx%04Lx" r1 r2 r3 in
+  ts_hex ^ "-" ^ r_hex
+
+let make ~category ~payload ~prev_hash =
+  { id = generate_id ();
+    ts = Unix.gettimeofday ();
+    category;
+    payload;
+    prev_hash;
+  }
+
+let canonical_json t =
+  let prev =
+    match t.prev_hash with
+    | None -> `Null
+    | Some h -> `String h
+  in
+  let fields = [
+    "id", `String t.id;
+    "ts", `Float t.ts;
+    "category", `String t.category;
+    "payload", t.payload;
+    "prev_hash", prev;
+  ] in
+  Yojson.Safe.to_string (`Assoc fields)
+
+let compute_hash t =
+  let s = canonical_json t in
+  Digestif.SHA256.digest_string s |> Digestif.SHA256.to_hex
+
+let hash_for_chain = compute_hash
+
+let to_json t =
+  let prev =
+    match t.prev_hash with
+    | None -> `Null
+    | Some h -> `String h
+  in
+  `Assoc [
+    "id", `String t.id;
+    "ts", `Float t.ts;
+    "category", `String t.category;
+    "payload", t.payload;
+    "prev_hash", prev;
+  ]
+
+let of_json = function
+  | `Assoc fields ->
+    let get_string k =
+      match List.assoc_opt k fields with
+      | Some (`String s) -> Ok s
+      | _ -> Error (Printf.sprintf "Envelope.of_json: missing or bad %s" k)
+    in
+    let get_float k =
+      match List.assoc_opt k fields with
+      | Some (`Float f) -> Ok f
+      | Some (`Int i) -> Ok (float_of_int i)
+      | _ -> Error (Printf.sprintf "Envelope.of_json: missing or bad %s" k)
+    in
+    let get_payload () =
+      match List.assoc_opt "payload" fields with
+      | Some v -> Ok v
+      | None -> Error "Envelope.of_json: missing payload"
+    in
+    let get_prev_hash () =
+      match List.assoc_opt "prev_hash" fields with
+      | Some `Null -> Ok None
+      | Some (`String s) -> Ok (Some s)
+      | None -> Ok None
+      | _ -> Error "Envelope.of_json: bad prev_hash"
+    in
+    (match
+       get_string "id",
+       get_float "ts",
+       get_string "category",
+       get_payload (),
+       get_prev_hash ()
+     with
+     | Ok id, Ok ts, Ok category, Ok payload, Ok prev_hash ->
+       Ok { id; ts; category; payload; prev_hash }
+     | Error e, _, _, _, _
+     | _, Error e, _, _, _
+     | _, _, Error e, _, _
+     | _, _, _, Error e, _
+     | _, _, _, _, Error e -> Error e)
+  | _ -> Error "Envelope.of_json: expected object"

--- a/lib/shared_audit/envelope.mli
+++ b/lib/shared_audit/envelope.mli
@@ -1,0 +1,56 @@
+(** Shared_audit envelope — Merkle-chained immutable audit entry.
+
+    Each entry carries:
+    - [id]: ULID-like identifier (timestamp prefix + random hex)
+    - [ts]: Unix epoch seconds (UTC)
+    - [category]: domain-specific string. CREW uses
+      ["DeliberationTransition"]; Resilience uses ["DegradationTriggered"],
+      ["RecoveryAttempted"], etc. The shared envelope leaves category
+      meaning to each domain.
+    - [payload]: arbitrary JSON sub-tree
+    - [prev_hash]: SHA256 of previous entry's canonical JSON, or [None]
+      for the genesis entry.
+
+    The hash chain ensures tamper detection: any modification to an
+    entry breaks the [prev_hash] field of the next entry, surfaced via
+    {!Store.verify_chain}.
+
+    {b Canonical JSON} is computed with deterministic field order
+    ([id; ts; category; payload; prev_hash]) so that equivalent entries
+    hash to the same digest regardless of input order. The shared
+    envelope is the unifying storage backend per INTEGRATED §3.2.
+
+    @stability Evolving
+    @since 0.18.9 *)
+
+type t = {
+  id : string;
+  ts : float;
+  category : string;
+  payload : Yojson.Safe.t;
+  prev_hash : string option;
+}
+
+val make :
+  category:string ->
+  payload:Yojson.Safe.t ->
+  prev_hash:string option ->
+  t
+(** Construct a fresh entry. Generates a new [id] and uses the current
+    wall-clock time as [ts]. *)
+
+val canonical_json : t -> string
+(** Deterministic JSON serialization (canonical field order). This is
+    the input to the hash function. *)
+
+val compute_hash : t -> string
+(** SHA256 hex-digest of {!canonical_json}. *)
+
+val hash_for_chain : t -> string
+(** Hash of this entry, suitable as the [prev_hash] of the next entry.
+    Currently identical to {!compute_hash}; named separately to allow
+    a future Merkle-tree variant without API breakage. *)
+
+val to_json : t -> Yojson.Safe.t
+
+val of_json : Yojson.Safe.t -> (t, string) result

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -1,0 +1,144 @@
+type t = {
+  base_dir : string;
+  mutable latest_hash : string option;
+}
+
+let format_path ~base_dir ~ts =
+  let tm = Unix.gmtime ts in
+  let yyyy_mm = Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900)
+                  (tm.Unix.tm_mon + 1)
+  in
+  let dd = Printf.sprintf "%02d" tm.Unix.tm_mday in
+  Filename.concat (Filename.concat base_dir yyyy_mm) (dd ^ ".jsonl")
+
+let rec mkdir_p dir =
+  if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    try Unix.mkdir dir 0o755
+    with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+  end
+
+let ensure_dir_exists path = mkdir_p (Filename.dirname path)
+
+let read_jsonl_file path =
+  let ic = open_in path in
+  let entries = ref [] in
+  (try
+     while true do
+       let line = input_line ic in
+       if String.length line > 0 then
+         match Yojson.Safe.from_string line |> Envelope.of_json with
+         | Ok env -> entries := env :: !entries
+         | Error _ -> ()  (* Skip malformed lines silently. *)
+     done
+   with End_of_file -> close_in ic);
+  List.rev !entries
+
+let load_latest_hash ~base_dir =
+  if not (Sys.file_exists base_dir) then None
+  else if not (Sys.is_directory base_dir) then None
+  else
+    let months =
+      Sys.readdir base_dir
+      |> Array.to_list
+      |> List.filter (fun s -> String.length s = 7 && s.[4] = '-')
+      |> List.sort (fun a b -> String.compare b a)
+    in
+    let rec find_in_months = function
+      | [] -> None
+      | m :: rest ->
+        let m_dir = Filename.concat base_dir m in
+        if not (Sys.is_directory m_dir) then find_in_months rest
+        else
+          let days =
+            Sys.readdir m_dir
+            |> Array.to_list
+            |> List.filter (fun s -> Filename.check_suffix s ".jsonl")
+            |> List.sort (fun a b -> String.compare b a)
+          in
+          (match days with
+           | [] -> find_in_months rest
+           | d :: _ ->
+             let path = Filename.concat m_dir d in
+             let entries = read_jsonl_file path in
+             (match List.rev entries with
+              | last :: _ -> Some (Envelope.hash_for_chain last)
+              | [] -> find_in_months rest))
+    in
+    find_in_months months
+
+let create ~base_dir =
+  if not (Sys.file_exists base_dir) then mkdir_p base_dir;
+  let latest_hash = load_latest_hash ~base_dir in
+  { base_dir; latest_hash }
+
+let base_dir t = t.base_dir
+
+let append t ~category ~payload =
+  let entry = Envelope.make ~category ~payload ~prev_hash:t.latest_hash in
+  let path = format_path ~base_dir:t.base_dir ~ts:entry.ts in
+  ensure_dir_exists path;
+  let oc = open_out_gen [Open_append; Open_creat; Open_wronly] 0o644 path in
+  output_string oc (Yojson.Safe.to_string (Envelope.to_json entry));
+  output_char oc '\n';
+  close_out oc;
+  t.latest_hash <- Some (Envelope.hash_for_chain entry);
+  entry
+
+let read_all_entries t =
+  if not (Sys.file_exists t.base_dir) then []
+  else if not (Sys.is_directory t.base_dir) then []
+  else
+    let entries = ref [] in
+    let months =
+      Sys.readdir t.base_dir
+      |> Array.to_list
+      |> List.filter (fun s -> String.length s = 7 && s.[4] = '-')
+      |> List.sort String.compare
+    in
+    List.iter (fun m ->
+      let m_dir = Filename.concat t.base_dir m in
+      if Sys.is_directory m_dir then begin
+        let days =
+          Sys.readdir m_dir
+          |> Array.to_list
+          |> List.filter (fun s -> Filename.check_suffix s ".jsonl")
+          |> List.sort String.compare
+        in
+        List.iter (fun d ->
+          let path = Filename.concat m_dir d in
+          List.iter (fun e -> entries := e :: !entries) (read_jsonl_file path)
+        ) days
+      end
+    ) months;
+    List.rev !entries
+
+let recent t ~n =
+  let all = read_all_entries t in
+  let len = List.length all in
+  if len <= n then all
+  else
+    let rec drop k l =
+      if k <= 0 then l
+      else match l with
+        | [] -> []
+        | _ :: r -> drop (k - 1) r
+    in
+    drop (len - n) all
+
+let since t ~ts =
+  read_all_entries t
+  |> List.filter (fun (e : Envelope.t) -> e.ts >= ts)
+
+let verify_chain entries =
+  let rec check idx prev = function
+    | [] -> Ok ()
+    | (e : Envelope.t) :: rest ->
+      if e.prev_hash <> prev then
+        Error (idx, Printf.sprintf "prev_hash mismatch at index %d" idx)
+      else
+        let h = Envelope.hash_for_chain e in
+        check (idx + 1) (Some h) rest
+  in
+  check 0 None entries

--- a/lib/shared_audit/store.mli
+++ b/lib/shared_audit/store.mli
@@ -1,0 +1,52 @@
+(** Shared_audit store — dated JSONL append-only store.
+
+    Mirrors the storage pattern from [keeper_approval_queue.ml] and
+    [keeper_crash_persistence.ml]. Entries are appended to
+    [<base_dir>/YYYY-MM/DD.jsonl], one JSON object per line. The
+    YYYY-MM/DD partitioning keeps individual files manageable and
+    enables date-range queries via filesystem listing.
+
+    The store maintains in-memory state for the latest entry's hash
+    so [append] can chain automatically without re-reading the
+    full log on each call. On creation, the latest hash is loaded
+    from the most recent JSONL file (if any) so sessions that resume
+    an existing audit log continue the chain correctly.
+
+    {b Single-process design}: this implementation does not coordinate
+    across processes. For multi-process audit (e.g., concurrent keepers
+    writing to the same log), a follow-up PR will add file-locking
+    or a single-writer dispatcher.
+
+    @stability Evolving
+    @since 0.18.9 *)
+
+type t
+
+val create : base_dir:string -> t
+(** Create or open a store rooted at [base_dir]. The directory is
+    created (with parents) if it does not exist. The latest entry's
+    hash is loaded from the most recent JSONL file in [base_dir],
+    so [append] continues the chain across sessions. *)
+
+val append :
+  t ->
+  category:string ->
+  payload:Yojson.Safe.t ->
+  Envelope.t
+(** Append a new entry with [prev_hash] computed from the latest
+    on-disk entry. Returns the appended entry. *)
+
+val recent : t -> n:int -> Envelope.t list
+(** Read the most recent [n] entries (chronologically increasing). *)
+
+val since : t -> ts:float -> Envelope.t list
+(** Read all entries whose [ts] is >= the given timestamp. *)
+
+val verify_chain : Envelope.t list -> (unit, int * string) result
+(** Verify the [prev_hash] chain over a list of entries assumed in
+    chronological order. Returns [Ok ()] if the chain is intact;
+    [Error (idx, reason)] at the first broken link. The first entry
+    must have [prev_hash = None]. *)
+
+val base_dir : t -> string
+(** Inspector for the base directory (mainly for tests). *)

--- a/lib/shared_types/artifact_id.ml
+++ b/lib/shared_types/artifact_id.ml
@@ -1,0 +1,86 @@
+type t = string
+
+let initialized = ref false
+
+let init_random () =
+  if not !initialized then begin
+    Random.self_init ();
+    initialized := true
+  end
+
+let hex_byte n = Printf.sprintf "%02x" (n land 0xFF)
+
+let generate () =
+  init_random ();
+  let now_ms = Int64.of_float (Unix.gettimeofday () *. 1000.0) in
+  let ts48 = Int64.logand now_ms 0xFFFFFFFFFFFFL in
+  let byte_at shift =
+    Int64.to_int (Int64.shift_right_logical ts48 shift) land 0xFF
+  in
+  let b0 = byte_at 40 in
+  let b1 = byte_at 32 in
+  let b2 = byte_at 24 in
+  let b3 = byte_at 16 in
+  let b4 = byte_at 8 in
+  let b5 = byte_at 0 in
+  let rand_12 = Random.int 0x1000 in
+  let b6 = 0x70 lor ((rand_12 lsr 8) land 0x0F) in
+  let b7 = rand_12 land 0xFF in
+  let rand_14 = Random.int 0x4000 in
+  let b8 = 0x80 lor ((rand_14 lsr 8) land 0x3F) in
+  let b9 = rand_14 land 0xFF in
+  let r1 = Random.int 0x1000000 in
+  let r2 = Random.int 0x1000000 in
+  let b10 = (r1 lsr 16) land 0xFF in
+  let b11 = (r1 lsr 8) land 0xFF in
+  let b12 = r1 land 0xFF in
+  let b13 = (r2 lsr 16) land 0xFF in
+  let b14 = (r2 lsr 8) land 0xFF in
+  let b15 = r2 land 0xFF in
+  Printf.sprintf "%s%s%s%s-%s%s-%s%s-%s%s-%s%s%s%s%s%s"
+    (hex_byte b0) (hex_byte b1) (hex_byte b2) (hex_byte b3)
+    (hex_byte b4) (hex_byte b5)
+    (hex_byte b6) (hex_byte b7)
+    (hex_byte b8) (hex_byte b9)
+    (hex_byte b10) (hex_byte b11) (hex_byte b12)
+    (hex_byte b13) (hex_byte b14) (hex_byte b15)
+
+let is_hex c =
+  (c >= '0' && c <= '9')
+  || (c >= 'a' && c <= 'f')
+  || (c >= 'A' && c <= 'F')
+
+let of_string s =
+  if String.length s <> 36 then
+    Error (Printf.sprintf "Artifact_id.of_string: expected 36 chars, got %d"
+             (String.length s))
+  else if s.[8] <> '-' || s.[13] <> '-' || s.[18] <> '-' || s.[23] <> '-' then
+    Error "Artifact_id.of_string: missing dashes at expected positions"
+  else if s.[14] <> '7' then
+    Error (Printf.sprintf "Artifact_id.of_string: expected version '7', got %c"
+             s.[14])
+  else
+    let v = Char.lowercase_ascii s.[19] in
+    if v <> '8' && v <> '9' && v <> 'a' && v <> 'b' then
+      Error (Printf.sprintf "Artifact_id.of_string: invalid variant nibble %c" v)
+    else begin
+      let valid = ref true in
+      for i = 0 to 35 do
+        if i <> 8 && i <> 13 && i <> 18 && i <> 23 && not (is_hex s.[i]) then
+          valid := false
+      done;
+      if !valid then Ok (String.lowercase_ascii s)
+      else Error "Artifact_id.of_string: non-hex character in body"
+    end
+
+let to_string t = t
+
+let compare = String.compare
+
+let equal = String.equal
+
+let to_json t = `String t
+
+let of_json = function
+  | `String s -> of_string s
+  | _ -> Error "Artifact_id.of_json: expected string"

--- a/lib/shared_types/artifact_id.mli
+++ b/lib/shared_types/artifact_id.mli
@@ -1,0 +1,37 @@
+(** Artifact_id — UUID v7 (time-ordered) opaque identifier.
+
+    UUID v7 (RFC 9562 §5.7) places a 48-bit Unix-epoch-millisecond
+    timestamp in the high bits, ensuring monotonic sort by creation time.
+    This makes UUID v7 friendly to B-tree indexing and natural-order
+    timeline rendering (Multimodal Workspace.timeline).
+
+    The internal representation is the canonical 36-character lowercase
+    string form (e.g. [01890e2a-4c8e-7b21-9f3c-...]). Construction is
+    restricted to {!generate} and {!of_string}, which validates structure
+    and version.
+
+    @stability Evolving
+    @since 0.18.9 *)
+
+type t = private string
+(** Private string. The only constructors are {!generate} and {!of_string}. *)
+
+val generate : unit -> t
+(** Generate a fresh UUID v7. Side-effecting: reads current wall-clock
+    time and the OCaml [Random] state. The first call seeds [Random]
+    via [Random.self_init] if not already seeded by the caller. *)
+
+val of_string : string -> (t, string) result
+(** Parse a 36-character UUID string. Validates dashes at positions
+    8/13/18/23, version digit (must be ['7']), and variant nibble
+    (must be one of [{8,9,a,b}]). Returns [Error] for malformed input. *)
+
+val to_string : t -> string
+
+val compare : t -> t -> int
+
+val equal : t -> t -> bool
+
+val to_json : t -> Yojson.Safe.t
+
+val of_json : Yojson.Safe.t -> (t, string) result

--- a/lib/shared_types/budget.ml
+++ b/lib/shared_types/budget.ml
@@ -1,0 +1,71 @@
+type t = {
+  tokens : int;
+  turns : int;
+  time_ms : int;
+  cost_usd : float;
+}
+
+let make ~tokens ~turns ~time_ms ~cost_usd =
+  { tokens; turns; time_ms; cost_usd }
+
+let zero = { tokens = 0; turns = 0; time_ms = 0; cost_usd = 0.0 }
+
+let is_exhausted t =
+  t.tokens <= 0 || t.turns <= 0 || t.time_ms <= 0
+
+let sub_tokens t n = { t with tokens = t.tokens - n }
+
+let sub_turns t n = { t with turns = t.turns - n }
+
+let sub_time_ms t n = { t with time_ms = t.time_ms - n }
+
+let sub_cost_usd t f = { t with cost_usd = t.cost_usd -. f }
+
+let compare a b =
+  let c = Int.compare a.tokens b.tokens in
+  if c <> 0 then c
+  else
+    let c = Int.compare a.turns b.turns in
+    if c <> 0 then c
+    else
+      let c = Int.compare a.time_ms b.time_ms in
+      if c <> 0 then c
+      else Float.compare a.cost_usd b.cost_usd
+
+let equal a b =
+  a.tokens = b.tokens
+  && a.turns = b.turns
+  && a.time_ms = b.time_ms
+  && Float.equal a.cost_usd b.cost_usd
+
+let to_json t =
+  `Assoc [
+    "tokens", `Int t.tokens;
+    "turns", `Int t.turns;
+    "time_ms", `Int t.time_ms;
+    "cost_usd", `Float t.cost_usd;
+  ]
+
+let of_json = function
+  | `Assoc fields ->
+    let get_int k =
+      match List.assoc_opt k fields with
+      | Some (`Int i) -> Ok i
+      | Some _ -> Error (Printf.sprintf "Budget.of_json: %s not int" k)
+      | None -> Error (Printf.sprintf "Budget.of_json: missing %s" k)
+    in
+    let get_float k =
+      match List.assoc_opt k fields with
+      | Some (`Float f) -> Ok f
+      | Some (`Int i) -> Ok (float_of_int i)
+      | Some _ -> Error (Printf.sprintf "Budget.of_json: %s not float" k)
+      | None -> Error (Printf.sprintf "Budget.of_json: missing %s" k)
+    in
+    (match get_int "tokens", get_int "turns", get_int "time_ms", get_float "cost_usd" with
+     | Ok tokens, Ok turns, Ok time_ms, Ok cost_usd ->
+       Ok { tokens; turns; time_ms; cost_usd }
+     | Error e, _, _, _
+     | _, Error e, _, _
+     | _, _, Error e, _
+     | _, _, _, Error e -> Error e)
+  | _ -> Error "Budget.of_json: expected object"

--- a/lib/shared_types/budget.mli
+++ b/lib/shared_types/budget.mli
@@ -1,0 +1,53 @@
+(** Budget — Unified envelope for tokens, turns, wall-clock time, cost.
+
+    INTEGRATED §3.1 unifies the divergent budget types from Autonomous
+    ([tokens, turns, time]) and Resilience ([tokens, time, cost]) into
+    a single superset record. Each module projects only the fields it
+    needs for cross-module composition.
+
+    Fields are monotonically decreasing during execution; [is_exhausted]
+    treats any non-positive [tokens], [turns], or [time_ms] as terminal.
+    [cost_usd] is informational only — it may go negative during accounting
+    drift and does not gate execution.
+
+    @stability Evolving
+    @since 0.18.9 *)
+
+type t = {
+  tokens : int;
+  (** LLM tokens (input + output) remaining. 0 = exhausted. *)
+
+  turns : int;
+  (** Loop iterations or task invocations remaining. *)
+
+  time_ms : int;
+  (** Wall-clock budget remaining in milliseconds. *)
+
+  cost_usd : float;
+  (** USD cost cap remaining. May be negative; informational. *)
+}
+
+val make : tokens:int -> turns:int -> time_ms:int -> cost_usd:float -> t
+
+val zero : t
+(** All gating fields zero; [cost_usd = 0.0]. *)
+
+val is_exhausted : t -> bool
+(** [true] iff [tokens <= 0 || turns <= 0 || time_ms <= 0]. *)
+
+val sub_tokens : t -> int -> t
+
+val sub_turns : t -> int -> t
+
+val sub_time_ms : t -> int -> t
+
+val sub_cost_usd : t -> float -> t
+
+val compare : t -> t -> int
+(** Lexicographic on [(tokens, turns, time_ms, cost_usd)]. *)
+
+val equal : t -> t -> bool
+
+val to_json : t -> Yojson.Safe.t
+
+val of_json : Yojson.Safe.t -> (t, string) result

--- a/lib/shared_types/confidence.ml
+++ b/lib/shared_types/confidence.ml
@@ -1,0 +1,28 @@
+type t = float
+
+let clamp x =
+  if Float.is_nan x then 0.0
+  else if x < 0.0 then 0.0
+  else if x > 1.0 then 1.0
+  else x
+
+let make raw = clamp raw
+
+let to_float t = t
+
+let zero = 0.0
+
+let one = 1.0
+
+let combine a b = sqrt (a *. b)
+
+let compare = Float.compare
+
+let equal = Float.equal
+
+let to_json t = `Float t
+
+let of_json = function
+  | `Float f -> Ok (make f)
+  | `Int i -> Ok (make (float_of_int i))
+  | _ -> Error "Confidence.of_json: expected float or int"

--- a/lib/shared_types/confidence.mli
+++ b/lib/shared_types/confidence.mli
@@ -1,0 +1,41 @@
+(** Confidence — Defensive-normalized [0.0, 1.0] scalar.
+
+    Constructed only via {!make}, which clamps any out-of-range input to
+    the valid interval. The internal representation is private to enforce
+    the invariant: code that pattern-matches on a {!t} cannot accidentally
+    see a [1.5] or [-0.3] value.
+
+    Decision rationale (INTEGRATED §5 Decision 3): eliminating raw [float]
+    confidence at the type boundary kills the "confidence > 1.0" bug
+    class that would corrupt downstream Resilience confidence evaluation.
+
+    @stability Evolving
+    @since 0.18.9 *)
+
+type t
+(** Abstract confidence value in [0.0, 1.0]. *)
+
+val make : float -> t
+(** [make raw] clamps [raw] to [0.0, 1.0]. NaN is mapped to [0.0]. *)
+
+val to_float : t -> float
+(** Extract the underlying float for serialization or display.
+    Prefer the combinators below for composition. *)
+
+val zero : t
+(** [make 0.0]. *)
+
+val one : t
+(** [make 1.0]. *)
+
+val combine : t -> t -> t
+(** Geometric mean: [sqrt(a *. b)]. Used to compose independent
+    confidence sources (e.g. verifier × producer). *)
+
+val compare : t -> t -> int
+
+val equal : t -> t -> bool
+
+val to_json : t -> Yojson.Safe.t
+
+val of_json : Yojson.Safe.t -> (t, string) result

--- a/lib/shared_types/dune
+++ b/lib/shared_types/dune
@@ -1,0 +1,6 @@
+(include_subdirs no)
+
+(library
+ (name shared_types)
+ (public_name masc_mcp.shared_types)
+ (libraries unix yojson))

--- a/lib/shared_types/resilience_outcome.ml
+++ b/lib/shared_types/resilience_outcome.ml
@@ -1,0 +1,118 @@
+type full
+type partial
+type graceful
+
+type ('a, 'e) t =
+  | FullSuccess : {
+      value : 'a;
+      confidence : Confidence.t;
+      artifacts : Artifact_id.t list;
+    } -> ('a, 'e) t
+  | PartialSuccess : {
+      value : 'a;
+      completed : Artifact_id.t list;
+      failed : (Artifact_id.t * 'e) list;
+      confidence : Confidence.t;
+      degradation_level : int;
+    } -> ('a, 'e) t
+  | GracefulFailure : {
+      fallback : 'a option;
+      reason : string;
+      recovery_strategy : string;
+      confidence : Confidence.t;
+    } -> ('a, 'e) t
+
+let clamp_level n =
+  if n < 1 then 1
+  else if n > 4 then 4
+  else n
+
+let full ~value ~confidence ~artifacts =
+  FullSuccess { value; confidence; artifacts }
+
+let partial ~value ~completed ~failed ~confidence ~degradation_level =
+  PartialSuccess
+    { value;
+      completed;
+      failed;
+      confidence;
+      degradation_level = clamp_level degradation_level;
+    }
+
+let graceful ?fallback ~reason ~recovery_strategy ~confidence () =
+  GracefulFailure { fallback; reason; recovery_strategy; confidence }
+
+let is_full : type a e. (a, e) t -> bool = function
+  | FullSuccess _ -> true
+  | _ -> false
+
+let is_partial : type a e. (a, e) t -> bool = function
+  | PartialSuccess _ -> true
+  | _ -> false
+
+let is_graceful : type a e. (a, e) t -> bool = function
+  | GracefulFailure _ -> true
+  | _ -> false
+
+let value_opt : type a e. (a, e) t -> a option = function
+  | FullSuccess { value; _ } -> Some value
+  | PartialSuccess { value; _ } -> Some value
+  | GracefulFailure { fallback; _ } -> fallback
+
+let confidence : type a e. (a, e) t -> Confidence.t = function
+  | FullSuccess { confidence; _ } -> confidence
+  | PartialSuccess { confidence; _ } -> confidence
+  | GracefulFailure { confidence; _ } -> confidence
+
+let map : type a b e. (a -> b) -> (a, e) t -> (b, e) t =
+  fun f -> function
+  | FullSuccess { value; confidence; artifacts } ->
+    FullSuccess { value = f value; confidence; artifacts }
+  | PartialSuccess { value; completed; failed; confidence; degradation_level } ->
+    PartialSuccess
+      { value = f value;
+        completed;
+        failed;
+        confidence;
+        degradation_level;
+      }
+  | GracefulFailure { fallback; reason; recovery_strategy; confidence } ->
+    GracefulFailure
+      { fallback = Option.map f fallback;
+        reason;
+        recovery_strategy;
+        confidence;
+      }
+
+let cata :
+  type a e r.
+  full:(a -> Confidence.t -> Artifact_id.t list -> r) ->
+  partial:(a -> Artifact_id.t list -> (Artifact_id.t * e) list ->
+           Confidence.t -> int -> r) ->
+  graceful:(a option -> string -> string -> Confidence.t -> r) ->
+  (a, e) t -> r =
+  fun ~full ~partial ~graceful t ->
+  match t with
+  | FullSuccess { value; confidence; artifacts } ->
+    full value confidence artifacts
+  | PartialSuccess { value; completed; failed; confidence; degradation_level } ->
+    partial value completed failed confidence degradation_level
+  | GracefulFailure { fallback; reason; recovery_strategy; confidence } ->
+    graceful fallback reason recovery_strategy confidence
+
+let lift_result ?confidence ?(artifacts = []) = function
+  | Ok value ->
+    let c = Option.value confidence ~default:Confidence.one in
+    FullSuccess { value; confidence = c; artifacts }
+  | Error _ ->
+    GracefulFailure
+      { fallback = None;
+        reason = "lifted from Error";
+        recovery_strategy = "Abort";
+        confidence = Confidence.zero;
+      }
+
+let class_to_string : type a e. (a, e) t -> string = function
+  | FullSuccess _ -> "FullSuccess"
+  | PartialSuccess _ -> "PartialSuccess"
+  | GracefulFailure _ -> "GracefulFailure"

--- a/lib/shared_types/resilience_outcome.mli
+++ b/lib/shared_types/resilience_outcome.mli
@@ -1,0 +1,141 @@
+(** Resilience_outcome — Ternary outcome GADT (stub).
+
+    Replaces the binary [('a, 'e) result] with a three-class outcome that
+    treats partial success as a first-class citizen, not a silent coercion
+    of [Ok]. This is the type Autonomous returns from [tick] and that
+    Resilience adapters wrap in higher tiers.
+
+    Three classes:
+    - [FullSuccess]: everything completed; all declared artifacts produced.
+    - [PartialSuccess]: primary value usable; some artifacts failed.
+      Carries which succeeded, which failed, and the degradation level.
+    - [GracefulFailure]: operation could not complete, but a fallback or
+      handoff path exists. Optional [fallback] payload.
+
+    {b STUB STATUS (Tier I5, Cycle 19)}: the [recovery_strategy] field of
+    [GracefulFailure] is a placeholder [string] (the strategy name like
+    ["Retry"], ["Fallback"], ["Handoff"], ["Abort"]). The eventual GADT
+    [Recovery.strategy] is introduced in Tier B6. Callers must treat this
+    string as opaque — structural pattern matching on the strategy is
+    deferred. The migration plan: B6 introduces [Recovery.strategy], and
+    a follow-up PR replaces this field's type with no API breakage at
+    the constructor name level.
+
+    INTEGRATED §3.1 Decision 6: Resilience wraps outer outcomes; this
+    type lives in [shared_types] precisely so that Autonomous can return
+    it from day 1 without depending on Resilience itself.
+
+    @stability Evolving (stub)
+    @since 0.18.9 *)
+
+(** {1 Phantom witnesses for outcome classes} *)
+
+type full
+type partial
+type graceful
+
+(** {1 The ternary outcome GADT} *)
+
+type ('a, 'e) t =
+  | FullSuccess : {
+      value : 'a;
+      confidence : Confidence.t;
+      artifacts : Artifact_id.t list;
+    } -> ('a, 'e) t
+    (** All declared artifacts produced. *)
+
+  | PartialSuccess : {
+      value : 'a;
+      completed : Artifact_id.t list;
+      failed : (Artifact_id.t * 'e) list;
+      confidence : Confidence.t;
+      degradation_level : int;
+        (** [1..4] corresponding to L1..L4 (Resilience.Degradation.level
+            in Tier A11). [1] = highest capability, [4] = lowest. *)
+    } -> ('a, 'e) t
+    (** Primary value usable; some artifacts failed. *)
+
+  | GracefulFailure : {
+      fallback : 'a option;
+      reason : string;
+      recovery_strategy : string;
+        (** STUB (I5): placeholder for [Recovery.strategy] (Tier B6).
+            Treat as opaque; common values: ["Retry"], ["Fallback"],
+            ["Degrade"], ["Speculate"], ["Handoff"], ["Abort"]. *)
+      confidence : Confidence.t;
+    } -> ('a, 'e) t
+    (** Operation failed; fallback or handoff available. *)
+
+(** {1 Constructors} *)
+
+val full :
+  value:'a ->
+  confidence:Confidence.t ->
+  artifacts:Artifact_id.t list ->
+  ('a, 'e) t
+
+val partial :
+  value:'a ->
+  completed:Artifact_id.t list ->
+  failed:(Artifact_id.t * 'e) list ->
+  confidence:Confidence.t ->
+  degradation_level:int ->
+  ('a, 'e) t
+(** [degradation_level] is clamped to [[1, 4]] at construction time
+    (defensive normalization mirroring [Confidence.make]). *)
+
+val graceful :
+  ?fallback:'a ->
+  reason:string ->
+  recovery_strategy:string ->
+  confidence:Confidence.t ->
+  unit ->
+  ('a, 'e) t
+
+(** {1 Predicates} *)
+
+val is_full : ('a, 'e) t -> bool
+
+val is_partial : ('a, 'e) t -> bool
+
+val is_graceful : ('a, 'e) t -> bool
+
+(** {1 Extraction} *)
+
+val value_opt : ('a, 'e) t -> 'a option
+(** [Some] for [FullSuccess] and [PartialSuccess].
+    For [GracefulFailure], returns [fallback]. *)
+
+val confidence : ('a, 'e) t -> Confidence.t
+(** Embedded confidence regardless of outcome class. *)
+
+(** {1 Combinators} *)
+
+val map : ('a -> 'b) -> ('a, 'e) t -> ('b, 'e) t
+(** Map the payload. Class is preserved. *)
+
+val cata :
+  full:('a -> Confidence.t -> Artifact_id.t list -> 'r) ->
+  partial:('a -> Artifact_id.t list -> (Artifact_id.t * 'e) list ->
+           Confidence.t -> int -> 'r) ->
+  graceful:('a option -> string -> string -> Confidence.t -> 'r) ->
+  ('a, 'e) t -> 'r
+(** Catamorphism: case-analyze all three constructors with continuations.
+    Useful for serialization or rendering without exposing the GADT. *)
+
+(** {1 Lifting from [result]} *)
+
+val lift_result :
+  ?confidence:Confidence.t ->
+  ?artifacts:Artifact_id.t list ->
+  ('a, 'e) result ->
+  ('a, 'e) t
+(** [Ok v] → [FullSuccess] with the given [confidence] (default
+    [Confidence.one]) and [artifacts] (default [[]]).
+    [Error e] → [GracefulFailure] with no fallback, [reason] = ["lifted from Error"],
+    [recovery_strategy] = ["Abort"], confidence = [Confidence.zero]. *)
+
+(** {1 Class identification} *)
+
+val class_to_string : ('a, 'e) t -> string
+(** ["FullSuccess"], ["PartialSuccess"], or ["GracefulFailure"]. *)

--- a/lib/shared_types/timestamp.ml
+++ b/lib/shared_types/timestamp.ml
@@ -1,0 +1,18 @@
+type t = float
+
+let now () = Unix.gettimeofday ()
+
+let of_float f = f
+
+let to_float t = t
+
+let compare = Float.compare
+
+let equal = Float.equal
+
+let to_json t = `Float t
+
+let of_json = function
+  | `Float f -> Ok f
+  | `Int i -> Ok (float_of_int i)
+  | _ -> Error "Timestamp.of_json: expected float or int"

--- a/lib/shared_types/timestamp.mli
+++ b/lib/shared_types/timestamp.mli
@@ -1,0 +1,31 @@
+(** Timestamp — Unix epoch seconds (UTC).
+
+    Standardized on [float] across all new modules per INTEGRATED §5
+    Decision 2. Multimodal converts to [Ptime.t] internally if needed,
+    but exposes {!t} in its public surface.
+
+    Use [now] sparingly: deterministic cores (Keeper FSM, Autonomous
+    state transitions) must take [now : float] as an explicit argument
+    rather than calling {!now} directly, to preserve testability and
+    TLA+ refinement.
+
+    @stability Evolving
+    @since 0.18.9 *)
+
+type t = float
+(** Unix epoch in seconds (UTC). *)
+
+val now : unit -> t
+(** [Unix.gettimeofday ()]. Side-effecting. Avoid in pure cores. *)
+
+val of_float : float -> t
+
+val to_float : t -> float
+
+val compare : t -> t -> int
+
+val equal : t -> t -> bool
+
+val to_json : t -> Yojson.Safe.t
+
+val of_json : Yojson.Safe.t -> (t, string) result

--- a/ppx_tla/ppx_tla.ml
+++ b/ppx_tla/ppx_tla.ml
@@ -132,15 +132,53 @@ let derive_impl_for_variant ~loc cds =
   else
     [ to_tla; all_symbols ]
 
+(* ── Record-type implementation generators (Cycle 20 / Tier I7) ────
+
+   For record types we emit:
+   - [field_names : string list]   — every field's source name
+   - [field_count : int]           — [List.length field_names]
+
+   These two helpers let TLA+ specs assert structural shape without the
+   deriver having to know how to render arbitrary field values. Future
+   tiers may add a [to_tla_record] combinator that delegates field-value
+   rendering to user-supplied per-field [to_tla] functions. *)
+
+let make_field_names_impl ~loc lds =
+  let exprs =
+    List.map
+      (fun (ld : label_declaration) ->
+        Ast_builder.Default.estring ~loc ld.pld_name.txt)
+      lds
+  in
+  let list_expr = Ast_builder.Default.elist ~loc exprs in
+  let pat = Ast_builder.Default.ppat_var ~loc (Loc.make ~loc "field_names") in
+  let binding =
+    Ast_builder.Default.value_binding ~loc ~pat ~expr:list_expr
+  in
+  Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
+
+let make_field_count_impl ~loc lds =
+  let count = List.length lds in
+  let int_expr = Ast_builder.Default.eint ~loc count in
+  let pat = Ast_builder.Default.ppat_var ~loc (Loc.make ~loc "field_count") in
+  let binding =
+    Ast_builder.Default.value_binding ~loc ~pat ~expr:int_expr
+  in
+  Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
+
+let derive_impl_for_record ~loc lds =
+  [ make_field_names_impl ~loc lds; make_field_count_impl ~loc lds ]
+
 let str_type_decl ~ctxt (_rec_flag, type_decls) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   match type_decls with
   | [ td ] -> (
       match td.ptype_kind with
       | Ptype_variant cds -> derive_impl_for_variant ~loc cds
-      | Ptype_abstract | Ptype_record _ | Ptype_open ->
+      | Ptype_record lds -> derive_impl_for_record ~loc lds
+      | Ptype_abstract | Ptype_open ->
           Location.raise_errorf ~loc
-            "[@@deriving tla]: only variant types are supported")
+            "[@@deriving tla]: only variant and record types are supported")
   | _ ->
       Location.raise_errorf ~loc
         "[@@deriving tla]: a single type declaration is supported per \
@@ -188,6 +226,22 @@ let derive_sig_for_variant ~loc ~type_name cds =
   in
   to_tla_sig :: all_symbols_sig :: all_states_sig_opt
 
+let int_t ~loc =
+  Ast_builder.Default.ptyp_constr ~loc
+    (Loc.make ~loc (Longident.Lident "int"))
+    []
+
+let derive_sig_for_record ~loc lds =
+  let _ = lds in
+  let field_names_sig =
+    make_value_sig ~loc ~name:"field_names"
+      ~type_:(list_t ~loc (string_t ~loc))
+  in
+  let field_count_sig =
+    make_value_sig ~loc ~name:"field_count" ~type_:(int_t ~loc)
+  in
+  [ field_names_sig; field_count_sig ]
+
 let sig_type_decl ~ctxt (_rec_flag, type_decls) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   match type_decls with
@@ -195,9 +249,11 @@ let sig_type_decl ~ctxt (_rec_flag, type_decls) =
       match td.ptype_kind with
       | Ptype_variant cds ->
           derive_sig_for_variant ~loc ~type_name:td.ptype_name.txt cds
-      | Ptype_abstract | Ptype_record _ | Ptype_open ->
+      | Ptype_record lds ->
+          derive_sig_for_record ~loc lds
+      | Ptype_abstract | Ptype_open ->
           Location.raise_errorf ~loc
-            "[@@deriving tla]: only variant types are supported")
+            "[@@deriving tla]: only variant and record types are supported")
   | _ ->
       Location.raise_errorf ~loc
         "[@@deriving tla]: a single type declaration is supported per \

--- a/test/ppx_tla/dune
+++ b/test/ppx_tla/dune
@@ -1,4 +1,4 @@
-(test
- (name test_basic)
+(tests
+ (names test_basic test_records)
  (preprocess
   (pps ppx_tla)))

--- a/test/ppx_tla/test_records.ml
+++ b/test/ppx_tla/test_records.ml
@@ -1,0 +1,71 @@
+(* Cycle 19 / Tier I7 tests for ppx_tla [@@deriving tla] on record types.
+
+   Records emit:
+   - [field_names : string list]: source-order field names
+   - [field_count : int]: [List.length field_names]
+
+   The deriver does NOT inspect or render field values — that is left to
+   future tiers (and to user-supplied per-field combinators). The minimal
+   shape-helper API is sufficient for TLA+ structural-shape assertions
+   that need to enumerate fields without knowing their types.
+
+   Modules below wrap each record type so [field_names] / [field_count]
+   stay namespaced. *)
+
+module Conditions = struct
+  type t = {
+    healthy : bool;
+    overflow : bool;
+    has_pending_compaction : bool;
+    awaiting_approval : bool;
+  }
+  [@@deriving tla]
+end
+
+module Single_field = struct
+  type t = { only : int } [@@deriving tla]
+end
+
+module Mixed_types = struct
+  type t = {
+    name : string;
+    count : int;
+    active : bool;
+    tags : string list;
+  }
+  [@@deriving tla]
+end
+
+let test_conditions_field_names () =
+  assert
+    (Conditions.field_names
+     = [ "healthy"; "overflow"; "has_pending_compaction"; "awaiting_approval" ])
+
+let test_conditions_field_count () =
+  assert (Conditions.field_count = 4)
+
+let test_single_field () =
+  assert (Single_field.field_names = [ "only" ]);
+  assert (Single_field.field_count = 1)
+
+let test_mixed_types () =
+  assert (Mixed_types.field_names = [ "name"; "count"; "active"; "tags" ]);
+  assert (Mixed_types.field_count = 4)
+
+(* Source-order preservation: fields must appear in declaration order,
+   not alphabetical or hash order. The deriver iterates the AST list
+   in order. *)
+let test_source_order_preserved () =
+  let module Ordered = struct
+    type t = { z : int; a : int; m : int } [@@deriving tla]
+  end in
+  assert (Ordered.field_names = [ "z"; "a"; "m" ]);
+  assert (Ordered.field_count = 3)
+
+let () =
+  test_conditions_field_names ();
+  test_conditions_field_count ();
+  test_single_field ();
+  test_mixed_types ();
+  test_source_order_preserved ();
+  print_endline "test_records: all assertions passed"

--- a/test/shared_audit/dune
+++ b/test/shared_audit/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_shared_audit)
+ (libraries alcotest shared_audit yojson unix digestif))

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -1,0 +1,231 @@
+(** Tier I6 — Shared_audit unit tests.
+
+    Verifies envelope hash determinism, JSON round-trip, and store-level
+    chain integrity (append → recent → verify_chain → tampering detection). *)
+
+open Alcotest
+
+module Env = Shared_audit.Envelope
+module Store = Shared_audit.Store
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Helpers                                                       *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let unique_temp_dir prefix =
+  let base = Filename.get_temp_dir_name () in
+  let suffix = Printf.sprintf "%s_%d_%d" prefix (Unix.getpid ()) (Random.bits ()) in
+  let dir = Filename.concat base suffix in
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm_rf path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  try rm_rf dir with _ -> ()
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Envelope                                                      *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let test_envelope_make_basic () =
+  let e = Env.make
+    ~category:"TestCat"
+    ~payload:(`Assoc [ "k", `Int 1 ])
+    ~prev_hash:None
+  in
+  check string "category" "TestCat" e.category;
+  check (option string) "no prev_hash" None e.prev_hash;
+  check bool "id non-empty" true (String.length e.id > 0);
+  check bool "ts > 0" true (e.ts > 0.0)
+
+let test_envelope_canonical_json_deterministic () =
+  let e = Env.make
+    ~category:"X"
+    ~payload:(`String "test")
+    ~prev_hash:(Some "abc123")
+  in
+  let s1 = Env.canonical_json e in
+  let s2 = Env.canonical_json e in
+  check string "deterministic" s1 s2
+
+let test_envelope_compute_hash_deterministic () =
+  let e = Env.make
+    ~category:"X"
+    ~payload:(`Int 42)
+    ~prev_hash:None
+  in
+  let h1 = Env.compute_hash e in
+  let h2 = Env.compute_hash e in
+  check string "hash deterministic" h1 h2;
+  check int "SHA256 hex length" 64 (String.length h1)
+
+let test_envelope_hash_changes_with_payload () =
+  let e1 = { (Env.make ~category:"X" ~payload:(`Int 1) ~prev_hash:None)
+             with ts = 1.0; id = "fixed-id" }
+  in
+  let e2 = { e1 with payload = `Int 2 } in
+  check bool "different payload → different hash" true
+    (Env.compute_hash e1 <> Env.compute_hash e2)
+
+let test_envelope_json_round_trip () =
+  let e = Env.make
+    ~category:"RoundTrip"
+    ~payload:(`Assoc [ "field", `String "value"; "n", `Int 7 ])
+    ~prev_hash:(Some "deadbeef")
+  in
+  let json = Env.to_json e in
+  match Env.of_json json with
+  | Error msg -> fail msg
+  | Ok back ->
+    check string "id preserved" e.id back.id;
+    check (float 1e-6) "ts preserved" e.ts back.ts;
+    check string "category preserved" e.category back.category;
+    check (option string) "prev_hash preserved" e.prev_hash back.prev_hash;
+    check bool "payload equal"
+      true (Yojson.Safe.equal e.payload back.payload)
+
+let test_envelope_of_json_genesis_no_prev_hash_field () =
+  let json = `Assoc [
+    "id", `String "abc";
+    "ts", `Float 1.0;
+    "category", `String "X";
+    "payload", `Null;
+    (* no prev_hash field at all *)
+  ] in
+  match Env.of_json json with
+  | Ok e -> check (option string) "missing prev_hash → None" None e.prev_hash
+  | Error e -> fail e
+
+let test_envelope_of_json_rejects_bad () =
+  match Env.of_json (`Int 42) with
+  | Ok _ -> fail "should reject non-object"
+  | Error _ -> ()
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Store: append + chain                                         *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let test_store_append_chains () =
+  let dir = unique_temp_dir "audit_chain" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let e1 = Store.append store ~category:"A" ~payload:(`Int 1) in
+    let e2 = Store.append store ~category:"B" ~payload:(`Int 2) in
+    let e3 = Store.append store ~category:"C" ~payload:(`Int 3) in
+    check (option string) "first prev_hash None" None e1.prev_hash;
+    check (option string) "second prev_hash = hash of first"
+      (Some (Env.hash_for_chain e1)) e2.prev_hash;
+    check (option string) "third prev_hash = hash of second"
+      (Some (Env.hash_for_chain e2)) e3.prev_hash)
+
+let test_store_recent_returns_n () =
+  let dir = unique_temp_dir "audit_recent" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    for i = 1 to 5 do
+      let _ = Store.append store ~category:"X" ~payload:(`Int i) in ()
+    done;
+    let last3 = Store.recent store ~n:3 in
+    check int "3 entries" 3 (List.length last3);
+    let payloads = List.map (fun (e : Env.t) ->
+      match e.payload with `Int i -> i | _ -> -1) last3
+    in
+    check (list int) "last 3 are 3,4,5" [ 3; 4; 5 ] payloads)
+
+let test_store_since_filters () =
+  let dir = unique_temp_dir "audit_since" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 1) in
+    Unix.sleepf 0.05;
+    let cutoff = Unix.gettimeofday () in
+    Unix.sleepf 0.05;
+    let _ = Store.append store ~category:"X" ~payload:(`Int 2) in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 3) in
+    let after = Store.since store ~ts:cutoff in
+    check int "2 entries after cutoff" 2 (List.length after))
+
+let test_store_verify_chain_intact () =
+  let dir = unique_temp_dir "audit_verify_intact" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    for i = 1 to 4 do
+      let _ = Store.append store ~category:"V" ~payload:(`Int i) in ()
+    done;
+    let all = Store.recent store ~n:100 in
+    match Store.verify_chain all with
+    | Ok () -> ()
+    | Error (idx, reason) ->
+      fail (Printf.sprintf "chain broken at %d: %s" idx reason))
+
+let test_store_verify_chain_detects_tampering () =
+  let dir = unique_temp_dir "audit_verify_tamper" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 1) in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 2) in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 3) in
+    let all = Store.recent store ~n:100 in
+    (* Tamper: replace middle entry's payload, keep its prev_hash *)
+    let tampered = List.mapi (fun i (e : Env.t) ->
+      if i = 1 then { e with payload = `Int 999 } else e) all
+    in
+    match Store.verify_chain tampered with
+    | Ok () -> fail "should detect tampering"
+    | Error (idx, _) ->
+      (* The mismatch surfaces at the entry AFTER the tampered one,
+         because its prev_hash no longer matches. *)
+      check bool "broken link reported" true (idx >= 2))
+
+let test_store_resume_continues_chain () =
+  let dir = unique_temp_dir "audit_resume" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store_a = Store.create ~base_dir:dir in
+    let e1 = Store.append store_a ~category:"X" ~payload:(`Int 1) in
+    (* "Restart": create a fresh store at the same dir. *)
+    let store_b = Store.create ~base_dir:dir in
+    let e2 = Store.append store_b ~category:"X" ~payload:(`Int 2) in
+    check (option string)
+      "resumed chain: e2.prev_hash = hash of e1"
+      (Some (Env.hash_for_chain e1)) e2.prev_hash)
+
+let test_store_base_dir_inspector () =
+  let dir = unique_temp_dir "audit_inspector" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    check string "base_dir reported" dir (Store.base_dir store))
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Suite                                                         *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let () =
+  Random.self_init ();
+  run "Shared_audit" [
+    "Envelope", [
+      test_case "make basic" `Quick test_envelope_make_basic;
+      test_case "canonical_json deterministic" `Quick test_envelope_canonical_json_deterministic;
+      test_case "compute_hash deterministic" `Quick test_envelope_compute_hash_deterministic;
+      test_case "hash changes with payload" `Quick test_envelope_hash_changes_with_payload;
+      test_case "json round-trip" `Quick test_envelope_json_round_trip;
+      test_case "missing prev_hash field accepted" `Quick test_envelope_of_json_genesis_no_prev_hash_field;
+      test_case "rejects non-object" `Quick test_envelope_of_json_rejects_bad;
+    ];
+    "Store", [
+      test_case "append chains prev_hash" `Quick test_store_append_chains;
+      test_case "recent returns N" `Quick test_store_recent_returns_n;
+      test_case "since filters by timestamp" `Quick test_store_since_filters;
+      test_case "verify_chain intact" `Quick test_store_verify_chain_intact;
+      test_case "verify_chain detects tampering" `Quick test_store_verify_chain_detects_tampering;
+      test_case "resume continues chain" `Quick test_store_resume_continues_chain;
+      test_case "base_dir inspector" `Quick test_store_base_dir_inspector;
+    ];
+  ]

--- a/test/shared_types/dune
+++ b/test/shared_types/dune
@@ -1,3 +1,3 @@
-(test
- (name test_shared_types)
+(tests
+ (names test_shared_types test_resilience_outcome)
  (libraries alcotest shared_types yojson unix))

--- a/test/shared_types/dune
+++ b/test/shared_types/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_shared_types)
+ (libraries alcotest shared_types yojson unix))

--- a/test/shared_types/test_resilience_outcome.ml
+++ b/test/shared_types/test_resilience_outcome.ml
@@ -1,0 +1,234 @@
+(** Tier I5 — Resilience_outcome stub GADT unit tests.
+
+    Verifies the three-class outcome contract, defensive level clamping,
+    extraction helpers, and result-lifting. *)
+
+open Alcotest
+
+module RO = Shared_types.Resilience_outcome
+module C = Shared_types.Confidence
+module AID = Shared_types.Artifact_id
+
+(* String error type to satisfy the 'e parameter in tests. *)
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Constructors + predicates                                     *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let test_full_constructor () =
+  let id = AID.generate () in
+  let o = RO.full ~value:42 ~confidence:C.one ~artifacts:[ id ] in
+  check bool "is_full" true (RO.is_full o);
+  check bool "not partial" false (RO.is_partial o);
+  check bool "not graceful" false (RO.is_graceful o);
+  check (option int) "value extracted" (Some 42) (RO.value_opt o)
+
+let test_partial_constructor () =
+  let id_ok = AID.generate () in
+  let id_fail = AID.generate () in
+  let o : (int, string) RO.t =
+    RO.partial
+      ~value:7
+      ~completed:[ id_ok ]
+      ~failed:[ id_fail, "boom" ]
+      ~confidence:(C.make 0.6)
+      ~degradation_level:2
+  in
+  check bool "is_partial" true (RO.is_partial o);
+  check bool "not full" false (RO.is_full o);
+  check (option int) "value extracted" (Some 7) (RO.value_opt o)
+
+let test_graceful_with_fallback () =
+  let o : (int, string) RO.t =
+    RO.graceful
+      ~fallback:99
+      ~reason:"network timeout"
+      ~recovery_strategy:"Retry"
+      ~confidence:(C.make 0.3)
+      ()
+  in
+  check bool "is_graceful" true (RO.is_graceful o);
+  check (option int) "fallback exposed" (Some 99) (RO.value_opt o)
+
+let test_graceful_without_fallback () =
+  let o : (int, string) RO.t =
+    RO.graceful
+      ~reason:"unrecoverable"
+      ~recovery_strategy:"Handoff"
+      ~confidence:C.zero
+      ()
+  in
+  check bool "is_graceful" true (RO.is_graceful o);
+  check (option int) "no fallback" None (RO.value_opt o)
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Defensive degradation_level clamp                             *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let assert_partial_level expected o =
+  match (o : (int, string) RO.t) with
+  | RO.PartialSuccess { degradation_level; _ } ->
+    check int "level clamped" expected degradation_level
+  | _ -> fail "expected PartialSuccess"
+
+let test_partial_clamps_low () =
+  RO.partial ~value:1 ~completed:[] ~failed:[]
+    ~confidence:C.one ~degradation_level:0
+  |> assert_partial_level 1
+
+let test_partial_clamps_high () =
+  RO.partial ~value:1 ~completed:[] ~failed:[]
+    ~confidence:C.one ~degradation_level:9
+  |> assert_partial_level 4
+
+let test_partial_passthrough_in_range () =
+  RO.partial ~value:1 ~completed:[] ~failed:[]
+    ~confidence:C.one ~degradation_level:3
+  |> assert_partial_level 3
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Confidence extraction                                          *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let test_confidence_extraction () =
+  let o_full : (int, string) RO.t =
+    RO.full ~value:1 ~confidence:(C.make 0.9) ~artifacts:[]
+  in
+  let o_partial : (int, string) RO.t =
+    RO.partial ~value:1 ~completed:[] ~failed:[]
+      ~confidence:(C.make 0.5) ~degradation_level:2
+  in
+  let o_graceful : (int, string) RO.t =
+    RO.graceful ~reason:"x" ~recovery_strategy:"Abort"
+      ~confidence:(C.make 0.1) ()
+  in
+  check (float 1e-9) "full confidence" 0.9 (C.to_float (RO.confidence o_full));
+  check (float 1e-9) "partial confidence" 0.5 (C.to_float (RO.confidence o_partial));
+  check (float 1e-9) "graceful confidence" 0.1 (C.to_float (RO.confidence o_graceful))
+
+(* ──────────────────────────────────────────────────────────── *)
+(* map                                                            *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let test_map_full_preserves_class () =
+  let o : (int, string) RO.t = RO.full ~value:3 ~confidence:C.one ~artifacts:[] in
+  let o' = RO.map (fun n -> n * 10) o in
+  check bool "still full" true (RO.is_full o');
+  check (option int) "mapped value" (Some 30) (RO.value_opt o')
+
+let test_map_graceful_maps_fallback () =
+  let o : (int, string) RO.t =
+    RO.graceful ~fallback:5 ~reason:"x" ~recovery_strategy:"Retry"
+      ~confidence:C.zero ()
+  in
+  let o' = RO.map (fun n -> n + 100) o in
+  check bool "still graceful" true (RO.is_graceful o');
+  check (option int) "fallback mapped" (Some 105) (RO.value_opt o')
+
+let test_map_graceful_without_fallback_stays_none () =
+  let o : (int, string) RO.t =
+    RO.graceful ~reason:"x" ~recovery_strategy:"Abort" ~confidence:C.zero ()
+  in
+  let o' = RO.map (fun n -> n * 2) o in
+  check (option int) "no fallback" None (RO.value_opt o')
+
+(* ──────────────────────────────────────────────────────────── *)
+(* cata                                                           *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let test_cata_dispatches_correctly () =
+  let label : (int, string) RO.t -> string =
+    RO.cata
+      ~full:(fun _ _ _ -> "full")
+      ~partial:(fun _ _ _ _ _ -> "partial")
+      ~graceful:(fun _ _ _ _ -> "graceful")
+  in
+  let f : (int, string) RO.t = RO.full ~value:1 ~confidence:C.one ~artifacts:[] in
+  let p : (int, string) RO.t =
+    RO.partial ~value:1 ~completed:[] ~failed:[]
+      ~confidence:C.one ~degradation_level:2
+  in
+  let g : (int, string) RO.t =
+    RO.graceful ~reason:"x" ~recovery_strategy:"Abort" ~confidence:C.zero ()
+  in
+  check string "full" "full" (label f);
+  check string "partial" "partial" (label p);
+  check string "graceful" "graceful" (label g)
+
+(* ──────────────────────────────────────────────────────────── *)
+(* lift_result                                                    *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let test_lift_result_ok () =
+  let o : (int, string) RO.t = RO.lift_result (Ok 42) in
+  check bool "Ok lifts to FullSuccess" true (RO.is_full o);
+  check (option int) "value preserved" (Some 42) (RO.value_opt o);
+  check (float 1e-9) "default confidence 1.0" 1.0 (C.to_float (RO.confidence o))
+
+let test_lift_result_ok_with_confidence () =
+  let o : (int, string) RO.t =
+    RO.lift_result ~confidence:(C.make 0.7) (Ok 1)
+  in
+  check (float 1e-9) "custom confidence" 0.7 (C.to_float (RO.confidence o))
+
+let test_lift_result_error () =
+  let o : (int, string) RO.t = RO.lift_result (Error "boom") in
+  check bool "Error lifts to GracefulFailure" true (RO.is_graceful o);
+  check (option int) "no fallback" None (RO.value_opt o);
+  check (float 1e-9) "zero confidence" 0.0 (C.to_float (RO.confidence o))
+
+(* ──────────────────────────────────────────────────────────── *)
+(* class_to_string                                                *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let test_class_to_string () =
+  let f : (int, string) RO.t = RO.full ~value:1 ~confidence:C.one ~artifacts:[] in
+  let p : (int, string) RO.t =
+    RO.partial ~value:1 ~completed:[] ~failed:[]
+      ~confidence:C.one ~degradation_level:1
+  in
+  let g : (int, string) RO.t =
+    RO.graceful ~reason:"x" ~recovery_strategy:"Abort" ~confidence:C.zero ()
+  in
+  check string "full label" "FullSuccess" (RO.class_to_string f);
+  check string "partial label" "PartialSuccess" (RO.class_to_string p);
+  check string "graceful label" "GracefulFailure" (RO.class_to_string g)
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Suite                                                          *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let () =
+  run "Resilience_outcome (stub)" [
+    "Constructors", [
+      test_case "full" `Quick test_full_constructor;
+      test_case "partial" `Quick test_partial_constructor;
+      test_case "graceful with fallback" `Quick test_graceful_with_fallback;
+      test_case "graceful without fallback" `Quick test_graceful_without_fallback;
+    ];
+    "Defensive level clamp", [
+      test_case "clamps below 1" `Quick test_partial_clamps_low;
+      test_case "clamps above 4" `Quick test_partial_clamps_high;
+      test_case "passthrough in range" `Quick test_partial_passthrough_in_range;
+    ];
+    "Extraction", [
+      test_case "confidence by class" `Quick test_confidence_extraction;
+    ];
+    "map", [
+      test_case "full preserves class" `Quick test_map_full_preserves_class;
+      test_case "graceful maps fallback" `Quick test_map_graceful_maps_fallback;
+      test_case "graceful without fallback stays None" `Quick
+        test_map_graceful_without_fallback_stays_none;
+    ];
+    "cata", [
+      test_case "dispatches correctly" `Quick test_cata_dispatches_correctly;
+    ];
+    "lift_result", [
+      test_case "Ok → FullSuccess" `Quick test_lift_result_ok;
+      test_case "Ok with custom confidence" `Quick test_lift_result_ok_with_confidence;
+      test_case "Error → GracefulFailure" `Quick test_lift_result_error;
+    ];
+    "class_to_string", [
+      test_case "labels all three" `Quick test_class_to_string;
+    ];
+  ]

--- a/test/shared_types/test_shared_types.ml
+++ b/test/shared_types/test_shared_types.ml
@@ -1,0 +1,220 @@
+(** Tier I4 — Shared types unit tests.
+
+    Verifies the abstract-type invariants and JSON round-trips for
+    [Shared_types.{Confidence, Timestamp, Budget, Artifact_id}]. *)
+
+open Alcotest
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Confidence                                                    *)
+(* ──────────────────────────────────────────────────────────── *)
+
+module C = Shared_types.Confidence
+
+let test_confidence_clamps_high () =
+  let c = C.make 1.5 in
+  check (float 0.0) "clamps to 1.0" 1.0 (C.to_float c)
+
+let test_confidence_clamps_low () =
+  let c = C.make (-0.3) in
+  check (float 0.0) "clamps to 0.0" 0.0 (C.to_float c)
+
+let test_confidence_clamps_nan () =
+  let c = C.make Float.nan in
+  check (float 0.0) "NaN → 0.0" 0.0 (C.to_float c)
+
+let test_confidence_passthrough_in_range () =
+  let c = C.make 0.42 in
+  check (float 1e-12) "stays 0.42" 0.42 (C.to_float c)
+
+let test_confidence_combine_geometric_mean () =
+  let a = C.make 0.81 in
+  let b = C.make 0.49 in
+  let g = C.combine a b in
+  (* sqrt(0.81 * 0.49) = sqrt(0.3969) = 0.63 *)
+  check (float 1e-9) "geometric mean" 0.63 (C.to_float g)
+
+let test_confidence_combine_with_zero () =
+  let a = C.make 0.9 in
+  let g = C.combine a C.zero in
+  check (float 1e-12) "0 absorbs" 0.0 (C.to_float g)
+
+let test_confidence_json_round_trip () =
+  let c = C.make 0.73 in
+  let json = C.to_json c in
+  match C.of_json json with
+  | Ok back -> check (float 1e-12) "round-trip" 0.73 (C.to_float back)
+  | Error e -> fail e
+
+let test_confidence_of_json_int () =
+  match C.of_json (`Int 1) with
+  | Ok c -> check (float 0.0) "int 1 → 1.0" 1.0 (C.to_float c)
+  | Error e -> fail e
+
+let test_confidence_of_json_invalid () =
+  match C.of_json (`String "0.5") with
+  | Ok _ -> fail "should reject string"
+  | Error _ -> ()
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Timestamp                                                     *)
+(* ──────────────────────────────────────────────────────────── *)
+
+module T = Shared_types.Timestamp
+
+let test_timestamp_ordering () =
+  let a = T.of_float 1700000000.0 in
+  let b = T.of_float 1700000001.0 in
+  check int "a < b" (-1) (Int.compare (T.compare a b) 0)
+
+let test_timestamp_now_recent () =
+  let n = T.now () in
+  check bool "now > 2026-01-01 epoch" true (n > 1735689600.0)
+
+let test_timestamp_json_round_trip () =
+  let t = T.of_float 1700000123.456 in
+  match T.of_json (T.to_json t) with
+  | Ok back -> check (float 1e-9) "round-trip" 1700000123.456 (T.to_float back)
+  | Error e -> fail e
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Budget                                                        *)
+(* ──────────────────────────────────────────────────────────── *)
+
+module B = Shared_types.Budget
+
+let test_budget_zero_exhausted () =
+  check bool "zero is exhausted" true (B.is_exhausted B.zero)
+
+let test_budget_make_not_exhausted () =
+  let b = B.make ~tokens:100 ~turns:10 ~time_ms:60000 ~cost_usd:1.0 in
+  check bool "fresh budget not exhausted" false (B.is_exhausted b)
+
+let test_budget_sub_tokens_drains () =
+  let b = B.make ~tokens:50 ~turns:10 ~time_ms:60000 ~cost_usd:1.0 in
+  let b' = B.sub_tokens b 50 in
+  check bool "tokens=0 → exhausted" true (B.is_exhausted b')
+
+let test_budget_sub_turns_drains () =
+  let b = B.make ~tokens:100 ~turns:1 ~time_ms:60000 ~cost_usd:1.0 in
+  let b' = B.sub_turns b 1 in
+  check bool "turns=0 → exhausted" true (B.is_exhausted b')
+
+let test_budget_negative_cost_not_exhausted () =
+  (* cost_usd 부호는 gating 아님 — 정보 전용 *)
+  let b = B.make ~tokens:100 ~turns:10 ~time_ms:60000 ~cost_usd:(-5.0) in
+  check bool "negative cost OK" false (B.is_exhausted b)
+
+let test_budget_json_round_trip () =
+  let b = B.make ~tokens:1000 ~turns:50 ~time_ms:300000 ~cost_usd:2.5 in
+  match B.of_json (B.to_json b) with
+  | Ok back -> check bool "round-trip equal" true (B.equal b back)
+  | Error e -> fail e
+
+let test_budget_of_json_missing_field () =
+  let bad = `Assoc [ "tokens", `Int 100 ] in
+  match B.of_json bad with
+  | Ok _ -> fail "should reject missing fields"
+  | Error _ -> ()
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Artifact_id (UUID v7)                                         *)
+(* ──────────────────────────────────────────────────────────── *)
+
+module A = Shared_types.Artifact_id
+
+let test_artifact_id_generate_format () =
+  let id = A.generate () in
+  let s = A.to_string id in
+  check int "36 chars" 36 (String.length s);
+  check char "dash at 8" '-' s.[8];
+  check char "dash at 13" '-' s.[13];
+  check char "dash at 18" '-' s.[18];
+  check char "dash at 23" '-' s.[23];
+  check char "version 7" '7' s.[14]
+
+let test_artifact_id_generate_uniqueness () =
+  let a = A.generate () in
+  let b = A.generate () in
+  check bool "different IDs" false (A.equal a b)
+
+let test_artifact_id_round_trip () =
+  let original = A.generate () in
+  match A.of_string (A.to_string original) with
+  | Ok back -> check bool "parse equals generate" true (A.equal original back)
+  | Error e -> fail e
+
+let test_artifact_id_of_string_too_short () =
+  match A.of_string "short" with
+  | Ok _ -> fail "should reject"
+  | Error _ -> ()
+
+let test_artifact_id_of_string_wrong_version () =
+  let v4 = "01890e2a-4c8e-4b21-9f3c-1234567890ab" in
+  match A.of_string v4 with
+  | Ok _ -> fail "should reject v4"
+  | Error _ -> ()
+
+let test_artifact_id_of_string_missing_dash () =
+  let no_dash = "01890e2a04c8e-7b21-9f3c-1234567890abcd" in
+  match A.of_string no_dash with
+  | Ok _ -> fail "should reject missing dash"
+  | Error _ -> ()
+
+let test_artifact_id_of_string_invalid_variant () =
+  let bad_variant = "01890e2a-4c8e-7b21-2f3c-1234567890ab" in
+  match A.of_string bad_variant with
+  | Ok _ -> fail "should reject variant nibble '2'"
+  | Error _ -> ()
+
+let test_artifact_id_time_ordering () =
+  (* UUID v7 prefix = ms timestamp; sequential generates should sort. *)
+  let a = A.generate () in
+  Unix.sleepf 0.005;
+  let b = A.generate () in
+  let cmp = A.compare a b in
+  check bool "earlier-generated sorts first" true (cmp < 0)
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Suite                                                         *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let () =
+  Random.self_init ();
+  run "Shared_types" [
+    "Confidence", [
+      test_case "clamps high" `Quick test_confidence_clamps_high;
+      test_case "clamps low" `Quick test_confidence_clamps_low;
+      test_case "clamps NaN" `Quick test_confidence_clamps_nan;
+      test_case "passthrough in range" `Quick test_confidence_passthrough_in_range;
+      test_case "combine geometric mean" `Quick test_confidence_combine_geometric_mean;
+      test_case "combine with zero" `Quick test_confidence_combine_with_zero;
+      test_case "json round-trip" `Quick test_confidence_json_round_trip;
+      test_case "of_json int" `Quick test_confidence_of_json_int;
+      test_case "of_json rejects string" `Quick test_confidence_of_json_invalid;
+    ];
+    "Timestamp", [
+      test_case "ordering" `Quick test_timestamp_ordering;
+      test_case "now is recent" `Quick test_timestamp_now_recent;
+      test_case "json round-trip" `Quick test_timestamp_json_round_trip;
+    ];
+    "Budget", [
+      test_case "zero exhausted" `Quick test_budget_zero_exhausted;
+      test_case "fresh not exhausted" `Quick test_budget_make_not_exhausted;
+      test_case "sub_tokens drains" `Quick test_budget_sub_tokens_drains;
+      test_case "sub_turns drains" `Quick test_budget_sub_turns_drains;
+      test_case "negative cost OK" `Quick test_budget_negative_cost_not_exhausted;
+      test_case "json round-trip" `Quick test_budget_json_round_trip;
+      test_case "missing field rejected" `Quick test_budget_of_json_missing_field;
+    ];
+    "Artifact_id", [
+      test_case "generate format" `Quick test_artifact_id_generate_format;
+      test_case "uniqueness" `Quick test_artifact_id_generate_uniqueness;
+      test_case "round-trip" `Quick test_artifact_id_round_trip;
+      test_case "of_string too short" `Quick test_artifact_id_of_string_too_short;
+      test_case "of_string wrong version" `Quick test_artifact_id_of_string_wrong_version;
+      test_case "of_string missing dash" `Quick test_artifact_id_of_string_missing_dash;
+      test_case "of_string invalid variant" `Quick test_artifact_id_of_string_invalid_variant;
+      test_case "time ordering" `Quick test_artifact_id_time_ordering;
+    ];
+  ]


### PR DESCRIPTION
## 요약

Tier I5 — `Resilience_outcome` ternary outcome GADT를 stub 형태로 도입합니다. INTEGRATED §3.1 Decision 6에 따라 Resilience는 outermost wrapper가 되어야 하므로, Autonomous (B4)가 day 1부터 이 타입을 반환할 수 있도록 `lib/shared_types/`에 미리 land합니다.

**Stack PR**: base = `feature/i4-shared-types` (#11550). I4 머지 후 base를 main으로 변경 또는 rebase 예정.

## 변경 내용

3-class GADT: `FullSuccess` / `PartialSuccess` / `GracefulFailure`. PartialSuccess는 first-class citizen으로, `Ok`의 silent coercion이 아닙니다.

| Constructor | 페이로드 |
|-------------|---------|
| `FullSuccess` | `{ value, confidence, artifacts }` |
| `PartialSuccess` | `{ value, completed, failed, confidence, degradation_level }` |
| `GracefulFailure` | `{ fallback?, reason, recovery_strategy, confidence }` |

API: `full`/`partial`/`graceful` constructors, `is_*` predicates, `value_opt` (graceful의 fallback 포함), `confidence` 추출, `map` (class 보존), `cata` (catamorphism), `lift_result` (`Ok→Full` / `Error→Graceful`).

## STUB 명시

- `recovery_strategy : string` 은 placeholder입니다 (Tier B6에서 `Recovery.strategy` GADT 도입 예정).
- 현재 callers는 strategy를 opaque string으로 다뤄야 하며, 일반적인 값: `"Retry"`, `"Fallback"`, `"Degrade"`, `"Speculate"`, `"Handoff"`, `"Abort"`.
- B6 follow-up PR이 type을 교체하되 constructor 이름 / 호출 패턴은 유지하도록 설계되었습니다.
- `.mli` docstring에 STUB STATUS 명시 + commit message에 migration plan.

## 설계 결정

- **`degradation_level` defensive clamp `[1, 4]`**: Confidence와 동일한 패턴 — 타입 시스템과 함께 invariant를 다층 방어.
- **GADT explicit type annotation**: `let is_full : type a e. (a, e) t -> bool = ...` 로 OCaml이 모든 case를 강제 검증하게 만듭니다 (INTEGRATED Risk #5 GADT exhaustiveness decay 대비).
- **Inner module 없이 top-level**: `Shared_types.Resilience_outcome.full` (file-name = module-name 자연스러운 OCaml convention).

## 테스트

`test/shared_types/test_resilience_outcome.ml`: **16 cases, 0.004s**.

| 영역 | 검증 |
|------|------|
| Constructors (4) | full/partial/graceful with-fallback/graceful without-fallback |
| Defensive level clamp (3) | below 1 / above 4 / passthrough in range |
| Extraction (1) | confidence 추출이 모든 class에서 작동 |
| `map` (3) | full preserves class / graceful maps fallback / graceful without fallback stays None |
| `cata` (1) | dispatch 정확성 |
| `lift_result` (3) | Ok / Ok with custom confidence / Error |
| `class_to_string` (1) | 3 class 라벨 |

**누적 sub-library: 43/43 tests GREEN** (27 from I4 + 16 from I5).

## Test plan

- [x] `dune build --root . lib/shared_types/` GREEN
- [x] `dune build --root . test/shared_types/` GREEN (2 binaries)
- [x] `dune runtest --root . test/shared_types/` GREEN (16/16 + 27/27)
- [x] Pre-push race check: 0 conflicting PRs (I4 #11550만 stack base로 매칭)

🤖 Generated with [Claude Code](https://claude.com/claude-code)