### PR TITLE
feat(dashboard): add dashboard_http_tool_quality.mli — 2-fn endpoint surface (cycle 46)

### DIFF
--- a/lib/dashboard/dashboard_http_tool_quality.mli
+++ b/lib/dashboard/dashboard_http_tool_quality.mli
@@ -1,0 +1,32 @@
+(** Dashboard_http_tool_quality — operator-facing tool-quality
+    aggregation endpoint.
+
+    Reads the keeper tool-call log, classifies failure outputs into
+    canonical reason codes, and emits per-tool / per-keeper /
+    per-thinking-mode / per-hour rate tables for the
+    [/api/v1/dashboard/tool-quality] surface.
+
+    Internal helpers (the [normalize_failure_text] /
+    [classify_process_status] text classifiers, the
+    [bucket_key] / [thinking_mode_of_record] / [hour_key_of_record]
+    record projectors, the [update_rate_table] / [render_rate_table]
+    aggregation primitives, the [dashboard_surface] /
+    [source_metadata_fields] / [empty_summary] payload builders) are
+    hidden — callers consume the entry points only. *)
+
+val classify_failure_output : string -> string
+(** Map a raw tool-call failure output (which may carry an
+    [error: ] / [tool_error: ] prefix and a JSON envelope) to a
+    canonical reason code. Recognises the
+    ["command_blocked_readonly:<category>"] form and falls back to a
+    normalised free-text classification or to ["parse_error"] /
+    ["unknown_error"] / ["empty_output"] when nothing matches. *)
+
+val aggregate :
+  ?n:int -> ?window_hours:float -> unit -> Yojson.Safe.t
+(** Build the dashboard payload from the most recent [n] keeper
+    tool-call log records (default [5000]), optionally narrowed to
+    the last [window_hours] hours. The payload includes per-tool /
+    per-keeper / per-thinking-mode / per-hour rate tables plus the
+    source-metadata envelope and the canonical
+    [dashboard_surface] tag. *)


### PR DESCRIPTION
## Summary

- \`lib/dashboard/dashboard_http_tool_quality.mli\` 신규 (428줄 모듈, 2 surface 노출 / ~13 internal 숨김).
- \`/api/v1/dashboard/tool-quality\` endpoint surface 명확히 고정 (4 caller, 2 symbol).

## Hidden (~13)

- 텍스트 분류기 내부: \`normalize_failure_text\`, \`classify_process_status\`
- Record projector 3: \`bucket_key\`, \`thinking_mode_of_record\`, \`hour_key_of_record\`
- Rate-table primitives 2: \`update_rate_table\`, \`render_rate_table\`
- Payload builder 3: \`dashboard_surface\` (상수), \`source_metadata_fields\`, \`empty_summary\`

## Exposed (2)

- \`classify_failure_output : string -> string\` — test_tool_quality_classify
- \`aggregate : ?n:int -> ?window_hours:float -> unit -> Yojson.Safe.t\` — dashboard_safe_autonomy + server_routes_http_routes_dashboard + test_keeper_tool_call_log

## Caller audit

4 caller file (test 2 + lib 2). \`include\` re-export 없음 → narrow 안전. propagation chain 0.

## Cycle progression note

처음 \`dashboard_execution_helpers\` (484줄) 시도했으나 3 sibling 모듈이 \`include\` 한다 → cascade 위험. 같은 sub-dir 내 단일-caller-graph 모듈 (\`dashboard_http_tool_quality\`) 로 변경 → first try clean.

## First-try-clean

\`dune build --root . @check\` 첫 시도 통과.

## Memory rule applied

\`feedback_ocaml_docstring_escape_quote_lexer_trap\` 워크플로 룰 사전 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)