### PR TITLE
[DS-Impl Phase B] I0-B keeper multi-select + cross-zone filter signal

### DIFF
--- a/dashboard/design-system/audits/2026-04-29-phase-b-i0-backbone.md
+++ b/dashboard/design-system/audits/2026-04-29-phase-b-i0-backbone.md
@@ -1,0 +1,75 @@
+# Phase B · I0 IDE Backbone — partial implementation note (2026-04-29)
+
+The original plan ("Phase B — I0 IDE Backbone") proposed three
+cross-cutting components from `cb-group-i.jsx`:
+
+- I0-A · Branch selector (header bar + branch list)
+- I0-B · Keeper multi-select (chip filter)
+- I0-C · Operator nudge log + compose
+
+This note records what was actually shippable in Phase F scope and what
+is gated on backend work.
+
+## I0-B Keeper Multi-Select — shipped
+
+`dashboard/src/store.ts`:
+- `selectedKeeperFilter: signal<Set<string>>` (empty = "all keepers")
+- `toggleKeeperInFilter(name)` / `clearKeeperFilter()` /
+  `setKeeperFilterToAll(allNames)` mutations
+
+`dashboard/src/components/keeper-multi-select.ts`:
+- `KeeperMultiSelect({ label?, hint? })` chip group consumed by any
+  zone willing to honor `selectedKeeperFilter`.
+
+First use-site: `KeeperTokenStats` (cross-keeper aggregate, originally
+shipped in #11532). The token stats panel now filters by the cross-zone
+selection — empty selection still means "all keepers" so the default
+view is unchanged.
+
+## I0-A Branch Selector — backend-blocked
+
+Spec data shape (`cb-group-i.jsx:14-85`):
+```
+branches[]: { name, tag, status, ahead, behind, head, keepers[] }
+```
+
+Production:
+- No `/api/v1/branches` endpoint
+- No `git`-aware backend service exposed to the dashboard
+- Closest reference: build artifacts know the branch via env vars at
+  CI time, but there is no live "what branches exist on this repo"
+  feed for the operator surface.
+
+A backend endpoint that walks `git for-each-ref refs/heads` and joins
+keeper assignments would be required. Not in Phase F scope.
+
+## I0-C Operator Nudge Log + Compose — partial backend-blocked
+
+Spec data shape (`cb-group-i.jsx:143-194`):
+```
+nudges[]: { id, at, channel, to[], body, ack }
+```
+Plus a compose form for new nudges with channel = hint / approve /
+reject / redirect.
+
+Production:
+- **Compose path exists** — `callMcpTool('masc_broadcast', ...)` in
+  `dashboard/src/api/actions.ts:24` can send broadcast/DM payloads.
+- **Log path missing** — no `nudges.jsonl` API; broadcast events live
+  in transport logs but aren't surfaced as a nudge log.
+
+Could ship compose-only as a stub, but without the log half it would
+not match spec intent. Defer until backend exposes a nudge log feed.
+
+## Phase B status
+
+| Component | Shipped | Reason |
+|-----------|---------|--------|
+| I0-B Keeper Multi-Select | ✅ this PR | data already in `keepers` signal |
+| I0-A Branch Selector | ❌ deferred | no branches API |
+| I0-C Nudge Log + Compose | ⏸ partial | compose works via `masc_broadcast`, log API absent |
+
+Phase B is the last frontend-implementable Phase 2 zone (per the
+remaining-zones audit #11557). With I0-B shipped here, the cross-zone
+filter pattern is in place and any future zone can opt into the
+`selectedKeeperFilter` signal without touching this PR.

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -15,6 +15,7 @@ import { namespaceTruth } from '../namespace-truth-store'
 import { resolveRuntimeCounts } from '../runtime-counts'
 import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
 import { KeeperTokenStats } from './keeper-token-stats'
+import { KeeperMultiSelect } from './keeper-multi-select'
 import { FsmHub } from './fsm-hub'
 import { FleetFsmMatrix } from './fleet-fsm-matrix'
 import { HandoffTimeline } from './handoff-timeline'
@@ -111,7 +112,12 @@ export function AgentsUnified() {
         : html`
           ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
 
-          ${currentView === 'keepers' ? html`<${KeeperTokenStats} />` : null}
+          ${currentView === 'keepers' ? html`
+            <${KeeperMultiSelect}
+              hint="필터를 적용하면 아래 토큰 집계가 선택한 keeper 만 합산합니다. 비어 있으면 전체 합산입니다."
+            />
+            <${KeeperTokenStats} />
+          ` : null}
 
           <${AgentRoster}
             keeperFilter=${currentView === 'keepers' ? 'keeper-only'

--- a/dashboard/src/components/keeper-multi-select.ts
+++ b/dashboard/src/components/keeper-multi-select.ts
@@ -1,0 +1,124 @@
+// MASC Dashboard — I0-B · Cross-zone keeper filter (chip multi-select)
+//
+// Phase 2 spec (`design-system/preview/cb-group-i.jsx:KeeperMultiSelect`)
+// renders a horizontal chip group for selecting a keeper subset that
+// downstream zones (token stats, board, telemetry, etc.) honor as a
+// filter. The cross-cutting nature is the point — this is the IDE
+// backbone's filter affordance.
+//
+// State lives in `selectedKeeperFilter` (store.ts) so other zones can
+// read it without prop-drilling. Empty set = "all keepers" (default
+// unconstrained view).
+//
+// Mount: any zone that benefits from a per-keeper scope. First
+// use-site: cross-keeper TokenStats panel (#11532).
+
+import { html } from 'htm/preact'
+import { computed } from '@preact/signals'
+import {
+  keepers,
+  selectedKeeperFilter,
+  toggleKeeperInFilter,
+  clearKeeperFilter,
+  setKeeperFilterToAll,
+} from '../store'
+
+interface KeeperOption {
+  name: string
+  displayName: string
+  emoji: string
+}
+
+const options = computed<KeeperOption[]>(() => {
+  return keepers.value
+    .map(k => ({
+      name: k.name,
+      displayName: k.koreanName ?? k.name,
+      emoji: k.emoji ?? '',
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+export function KeeperMultiSelect({
+  label = 'keeper filter',
+  hint,
+}: {
+  label?: string
+  hint?: string
+} = {}) {
+  const all = options.value
+  const selected = selectedKeeperFilter.value
+  const allNames = all.map(o => o.name)
+  const selectedCount = selected.size
+  const hasSelection = selectedCount > 0
+  const isAll = !hasSelection
+
+  return html`
+    <section
+      class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3"
+      role="group"
+      aria-label=${label}
+    >
+      <header class="mb-2 flex flex-wrap items-baseline gap-2">
+        <span class="text-2xs font-semibold uppercase tracking-1 text-text-muted">
+          ${label}
+        </span>
+        <span class="text-2xs text-text-disabled" aria-live="polite">
+          ${isAll
+            ? `전체 (${all.length}명)`
+            : `${selectedCount} / ${all.length} 선택`}
+        </span>
+        <div class="ml-auto flex gap-1">
+          <button
+            type="button"
+            class="rounded border border-card-border/40 px-2 py-0.5 text-2xs text-text-muted transition-colors hover:border-card-border/70 hover:text-text-strong"
+            disabled=${!hasSelection}
+            onClick=${() => clearKeeperFilter()}
+          >
+            clear
+          </button>
+          <button
+            type="button"
+            class="rounded border border-card-border/40 px-2 py-0.5 text-2xs text-text-muted transition-colors hover:border-card-border/70 hover:text-text-strong"
+            onClick=${() => setKeeperFilterToAll(allNames)}
+          >
+            all
+          </button>
+        </div>
+      </header>
+      ${all.length === 0 ? html`
+        <p class="text-2xs text-text-disabled">아직 등록된 keeper 가 없습니다.</p>
+      ` : html`
+        <div
+          class="flex flex-wrap gap-1.5"
+          role="group"
+          aria-label=${`${all.length}명 keeper · multi-select`}
+        >
+          ${all.map(o => {
+            const on = selected.has(o.name)
+            return html`
+              <button
+                key=${o.name}
+                type="button"
+                role="checkbox"
+                aria-checked=${on}
+                aria-label=${o.name}
+                class="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-2xs font-mono transition-colors ${on
+                  ? 'border-accent/40 bg-[var(--accent-15)] text-accent'
+                  : 'border-card-border/40 bg-[var(--color-bg-surface)] text-text-muted hover:border-card-border/70 hover:text-text-strong'}"
+                onClick=${() => toggleKeeperInFilter(o.name)}
+              >
+                <span aria-hidden="true">${o.emoji}</span>
+                <span>${o.displayName}</span>
+                <span aria-hidden="true" class="text-text-disabled">${on ? '×' : '+'}</span>
+              </button>
+            `
+          })}
+        </div>
+      `}
+      ${hint ? html`
+        <p class="mt-2 text-2xs text-text-disabled">${hint}</p>
+      ` : null}
+    </section>
+  `
+}

--- a/dashboard/src/components/keeper-token-stats.ts
+++ b/dashboard/src/components/keeper-token-stats.ts
@@ -15,7 +15,7 @@
 
 import { html } from 'htm/preact'
 import { computed } from '@preact/signals'
-import { keepers } from '../store'
+import { keepers, selectedKeeperFilter } from '../store'
 
 interface KeeperTokenRow {
   name: string
@@ -26,7 +26,10 @@ interface KeeperTokenRow {
 }
 
 const rows = computed<KeeperTokenRow[]>(() => {
+  const filter = selectedKeeperFilter.value
+  const isAll = filter.size === 0
   return keepers.value
+    .filter(k => isAll || filter.has(k.name))
     .map(k => ({
       name: k.name,
       displayName: k.koreanName ?? k.name,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -92,6 +92,27 @@ export const executionContinuityBriefs = signal<DashboardExecutionContinuityBrie
 
 export const keeperHeartbeats = signal<Map<string, number>>(new Map())
 
+// --- Cross-zone keeper filter (Phase 2 · I0-B) ---
+// Empty set means "all keepers". Components that consume the filter
+// should treat `size === 0` as the unconstrained case so the default
+// route stays the broadest view. Adding a keeper id narrows the scope.
+export const selectedKeeperFilter = signal<Set<string>>(new Set())
+
+export function toggleKeeperInFilter(name: string): void {
+  const next = new Set(selectedKeeperFilter.value)
+  if (next.has(name)) next.delete(name)
+  else next.add(name)
+  selectedKeeperFilter.value = next
+}
+
+export function clearKeeperFilter(): void {
+  selectedKeeperFilter.value = new Set()
+}
+
+export function setKeeperFilterToAll(allNames: readonly string[]): void {
+  selectedKeeperFilter.value = new Set(allNames)
+}
+
 // --- Board state ---
 
 export const boardPosts = signal<BoardPost[]>([])


### PR DESCRIPTION
## Summary

Final Phase 2 implementation PR. Phase B was originally scoped as the I0 IDE Backbone (Branch selector + Keeper multi-select + Operator nudge log). Of the three, only **I0-B Keeper Multi-Select** is shippable in Phase F scope; I0-A and I0-C are backend-blocked. This PR ships I0-B and documents the deferral.

## Changes

- **`dashboard/src/store.ts`** (+21 lines)
  - \`selectedKeeperFilter: signal<Set<string>>\` (empty = "all keepers")
  - \`toggleKeeperInFilter\` / \`clearKeeperFilter\` / \`setKeeperFilterToAll\`
- **New** \`dashboard/src/components/keeper-multi-select.ts\` (115 LOC)
  - \`KeeperMultiSelect({ label?, hint? })\` chip group
  - chip toggles \`selectedKeeperFilter\` directly; clear / all shortcuts
- **\`dashboard/src/components/keeper-token-stats.ts\`** (+3 / -1)
  - first use-site: filters its aggregate by \`selectedKeeperFilter\`
  - empty selection unchanged → existing \"all keepers\" view preserved
- **\`dashboard/src/components/agents-unified.ts\`** (+5 / -1)
  - mounts \`KeeperMultiSelect\` above \`KeeperTokenStats\` in \`keepers\` view
- **New** audit \`dashboard/design-system/audits/2026-04-29-phase-b-i0-backbone.md\` documenting I0-A / I0-C deferral

## Decisions / Trade-offs

- **Empty set = all keepers.** Matches the original audit's \"unconstrained default\" intent. Adding a keeper narrows scope, removing all returns to broadest view.
- **Cross-zone signal in \`store.ts\`, not prop-drilled.** Future zones (board, telemetry, etc.) can opt in by reading \`selectedKeeperFilter\` without touching this PR.
- **First use-site is TokenStats only.** Adding more use-sites (board / runtime / etc.) would expand surface area; deferred to be additive PRs.
- **I0-A Branch Selector deferred** — no \`/api/v1/branches\` endpoint exists; would require a git-aware backend service that surfaces \`for-each-ref\` + keeper assignment join.
- **I0-C Nudge Log + Compose deferred** — compose path works via \`masc_broadcast\`, but the log half needs a backend feed. Shipping compose-only would not match spec intent.

## Phase 2 status — final

This is the last frontend-implementable Phase 2 zone.

- ✅ K1 100% (BDI #11526 + TokenStats #11532 + ToolAccess #11538)
- ✅ G1 partial (Horizon #11533 + Metric column #11536)
- ✅ G2 partial (Stale + Wall #11534)
- ✅ K4 deprecated (#11524)
- ✅ O4 Cost Dashboard (#11542)
- ✅ G3 ErrorBoundary severity (#11543)
- ✅ C1 / K3 / G3 audited as already covered (#11552 + #11557)
- ✅ **Phase B I0-B Keeper Multi-Select** (this PR)
- 🔴 backend-blocked: K2 / O2 / O3 / O5 / G1-C / I0-A / I0-C
- ⏸ user-deferred: E1-E5
- 🟡 large + multi-PR: O1 Cascade Inspector

## Test plan

- [ ] \`pnpm --filter dashboard typecheck\` (CI)
- [ ] \`pnpm --filter dashboard lint\` (CI)
- [ ] Local: \`monitoring?section=agents&view=keepers\` → multi-select chip group renders above token stats
- [ ] Toggle a chip → token stats filters; toggle again → back to all
- [ ] Clear / all buttons work; counts update aria-live

🤖 Generated with [Claude Code](https://claude.com/claude-code)