### PR TITLE
feat(ppx-tla): Tier I7 — [@@deriving tla] records support (Cycle 20)

### DIFF
--- a/lib/shared_audit/dune
+++ b/lib/shared_audit/dune
@@ -1,0 +1,6 @@
+(include_subdirs no)
+
+(library
+ (name shared_audit)
+ (public_name masc_mcp.shared_audit)
+ (libraries unix yojson digestif digestif.c))

--- a/lib/shared_audit/envelope.ml
+++ b/lib/shared_audit/envelope.ml
@@ -1,0 +1,110 @@
+type t = {
+  id : string;
+  ts : float;
+  category : string;
+  payload : Yojson.Safe.t;
+  prev_hash : string option;
+}
+
+let initialized = ref false
+
+let init_random () =
+  if not !initialized then begin
+    Random.self_init ();
+    initialized := true
+  end
+
+(* ULID-lite: 16 hex chars timestamp-ms + "-" + 26 hex chars random. *)
+let generate_id () =
+  init_random ();
+  let now_ms = Int64.of_float (Unix.gettimeofday () *. 1000.0) in
+  let ts_hex = Printf.sprintf "%016Lx" now_ms in
+  let r1 = Random.int64 0x100000000L in
+  let r2 = Random.int64 0x100000000L in
+  let r3 = Random.int64 0x10000L in
+  let r_hex = Printf.sprintf "%08Lx%08Lx%04Lx" r1 r2 r3 in
+  ts_hex ^ "-" ^ r_hex
+
+let make ~category ~payload ~prev_hash =
+  { id = generate_id ();
+    ts = Unix.gettimeofday ();
+    category;
+    payload;
+    prev_hash;
+  }
+
+let canonical_json t =
+  let prev =
+    match t.prev_hash with
+    | None -> `Null
+    | Some h -> `String h
+  in
+  let fields = [
+    "id", `String t.id;
+    "ts", `Float t.ts;
+    "category", `String t.category;
+    "payload", t.payload;
+    "prev_hash", prev;
+  ] in
+  Yojson.Safe.to_string (`Assoc fields)
+
+let compute_hash t =
+  let s = canonical_json t in
+  Digestif.SHA256.digest_string s |> Digestif.SHA256.to_hex
+
+let hash_for_chain = compute_hash
+
+let to_json t =
+  let prev =
+    match t.prev_hash with
+    | None -> `Null
+    | Some h -> `String h
+  in
+  `Assoc [
+    "id", `String t.id;
+    "ts", `Float t.ts;
+    "category", `String t.category;
+    "payload", t.payload;
+    "prev_hash", prev;
+  ]
+
+let of_json = function
+  | `Assoc fields ->
+    let get_string k =
+      match List.assoc_opt k fields with
+      | Some (`String s) -> Ok s
+      | _ -> Error (Printf.sprintf "Envelope.of_json: missing or bad %s" k)
+    in
+    let get_float k =
+      match List.assoc_opt k fields with
+      | Some (`Float f) -> Ok f
+      | Some (`Int i) -> Ok (float_of_int i)
+      | _ -> Error (Printf.sprintf "Envelope.of_json: missing or bad %s" k)
+    in
+    let get_payload () =
+      match List.assoc_opt "payload" fields with
+      | Some v -> Ok v
+      | None -> Error "Envelope.of_json: missing payload"
+    in
+    let get_prev_hash () =
+      match List.assoc_opt "prev_hash" fields with
+      | Some `Null -> Ok None
+      | Some (`String s) -> Ok (Some s)
+      | None -> Ok None
+      | _ -> Error "Envelope.of_json: bad prev_hash"
+    in
+    (match
+       get_string "id",
+       get_float "ts",
+       get_string "category",
+       get_payload (),
+       get_prev_hash ()
+     with
+     | Ok id, Ok ts, Ok category, Ok payload, Ok prev_hash ->
+       Ok { id; ts; category; payload; prev_hash }
+     | Error e, _, _, _, _
+     | _, Error e, _, _, _
+     | _, _, Error e, _, _
+     | _, _, _, Error e, _
+     | _, _, _, _, Error e -> Error e)
+  | _ -> Error "Envelope.of_json: expected object"

--- a/lib/shared_audit/envelope.mli
+++ b/lib/shared_audit/envelope.mli
@@ -1,0 +1,56 @@
+(** Shared_audit envelope — Merkle-chained immutable audit entry.
+
+    Each entry carries:
+    - [id]: ULID-like identifier (timestamp prefix + random hex)
+    - [ts]: Unix epoch seconds (UTC)
+    - [category]: domain-specific string. CREW uses
+      ["DeliberationTransition"]; Resilience uses ["DegradationTriggered"],
+      ["RecoveryAttempted"], etc. The shared envelope leaves category
+      meaning to each domain.
+    - [payload]: arbitrary JSON sub-tree
+    - [prev_hash]: SHA256 of previous entry's canonical JSON, or [None]
+      for the genesis entry.
+
+    The hash chain ensures tamper detection: any modification to an
+    entry breaks the [prev_hash] field of the next entry, surfaced via
+    {!Store.verify_chain}.
+
+    {b Canonical JSON} is computed with deterministic field order
+    ([id; ts; category; payload; prev_hash]) so that equivalent entries
+    hash to the same digest regardless of input order. The shared
+    envelope is the unifying storage backend per INTEGRATED §3.2.
+
+    @stability Evolving
+    @since 0.18.9 *)
+
+type t = {
+  id : string;
+  ts : float;
+  category : string;
+  payload : Yojson.Safe.t;
+  prev_hash : string option;
+}
+
+val make :
+  category:string ->
+  payload:Yojson.Safe.t ->
+  prev_hash:string option ->
+  t
+(** Construct a fresh entry. Generates a new [id] and uses the current
+    wall-clock time as [ts]. *)
+
+val canonical_json : t -> string
+(** Deterministic JSON serialization (canonical field order). This is
+    the input to the hash function. *)
+
+val compute_hash : t -> string
+(** SHA256 hex-digest of {!canonical_json}. *)
+
+val hash_for_chain : t -> string
+(** Hash of this entry, suitable as the [prev_hash] of the next entry.
+    Currently identical to {!compute_hash}; named separately to allow
+    a future Merkle-tree variant without API breakage. *)
+
+val to_json : t -> Yojson.Safe.t
+
+val of_json : Yojson.Safe.t -> (t, string) result

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -1,0 +1,144 @@
+type t = {
+  base_dir : string;
+  mutable latest_hash : string option;
+}
+
+let format_path ~base_dir ~ts =
+  let tm = Unix.gmtime ts in
+  let yyyy_mm = Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900)
+                  (tm.Unix.tm_mon + 1)
+  in
+  let dd = Printf.sprintf "%02d" tm.Unix.tm_mday in
+  Filename.concat (Filename.concat base_dir yyyy_mm) (dd ^ ".jsonl")
+
+let rec mkdir_p dir =
+  if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    try Unix.mkdir dir 0o755
+    with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+  end
+
+let ensure_dir_exists path = mkdir_p (Filename.dirname path)
+
+let read_jsonl_file path =
+  let ic = open_in path in
+  let entries = ref [] in
+  (try
+     while true do
+       let line = input_line ic in
+       if String.length line > 0 then
+         match Yojson.Safe.from_string line |> Envelope.of_json with
+         | Ok env -> entries := env :: !entries
+         | Error _ -> ()  (* Skip malformed lines silently. *)
+     done
+   with End_of_file -> close_in ic);
+  List.rev !entries
+
+let load_latest_hash ~base_dir =
+  if not (Sys.file_exists base_dir) then None
+  else if not (Sys.is_directory base_dir) then None
+  else
+    let months =
+      Sys.readdir base_dir
+      |> Array.to_list
+      |> List.filter (fun s -> String.length s = 7 && s.[4] = '-')
+      |> List.sort (fun a b -> String.compare b a)
+    in
+    let rec find_in_months = function
+      | [] -> None
+      | m :: rest ->
+        let m_dir = Filename.concat base_dir m in
+        if not (Sys.is_directory m_dir) then find_in_months rest
+        else
+          let days =
+            Sys.readdir m_dir
+            |> Array.to_list
+            |> List.filter (fun s -> Filename.check_suffix s ".jsonl")
+            |> List.sort (fun a b -> String.compare b a)
+          in
+          (match days with
+           | [] -> find_in_months rest
+           | d :: _ ->
+             let path = Filename.concat m_dir d in
+             let entries = read_jsonl_file path in
+             (match List.rev entries with
+              | last :: _ -> Some (Envelope.hash_for_chain last)
+              | [] -> find_in_months rest))
+    in
+    find_in_months months
+
+let create ~base_dir =
+  if not (Sys.file_exists base_dir) then mkdir_p base_dir;
+  let latest_hash = load_latest_hash ~base_dir in
+  { base_dir; latest_hash }
+
+let base_dir t = t.base_dir
+
+let append t ~category ~payload =
+  let entry = Envelope.make ~category ~payload ~prev_hash:t.latest_hash in
+  let path = format_path ~base_dir:t.base_dir ~ts:entry.ts in
+  ensure_dir_exists path;
+  let oc = open_out_gen [Open_append; Open_creat; Open_wronly] 0o644 path in
+  output_string oc (Yojson.Safe.to_string (Envelope.to_json entry));
+  output_char oc '\n';
+  close_out oc;
+  t.latest_hash <- Some (Envelope.hash_for_chain entry);
+  entry
+
+let read_all_entries t =
+  if not (Sys.file_exists t.base_dir) then []
+  else if not (Sys.is_directory t.base_dir) then []
+  else
+    let entries = ref [] in
+    let months =
+      Sys.readdir t.base_dir
+      |> Array.to_list
+      |> List.filter (fun s -> String.length s = 7 && s.[4] = '-')
+      |> List.sort String.compare
+    in
+    List.iter (fun m ->
+      let m_dir = Filename.concat t.base_dir m in
+      if Sys.is_directory m_dir then begin
+        let days =
+          Sys.readdir m_dir
+          |> Array.to_list
+          |> List.filter (fun s -> Filename.check_suffix s ".jsonl")
+          |> List.sort String.compare
+        in
+        List.iter (fun d ->
+          let path = Filename.concat m_dir d in
+          List.iter (fun e -> entries := e :: !entries) (read_jsonl_file path)
+        ) days
+      end
+    ) months;
+    List.rev !entries
+
+let recent t ~n =
+  let all = read_all_entries t in
+  let len = List.length all in
+  if len <= n then all
+  else
+    let rec drop k l =
+      if k <= 0 then l
+      else match l with
+        | [] -> []
+        | _ :: r -> drop (k - 1) r
+    in
+    drop (len - n) all
+
+let since t ~ts =
+  read_all_entries t
+  |> List.filter (fun (e : Envelope.t) -> e.ts >= ts)
+
+let verify_chain entries =
+  let rec check idx prev = function
+    | [] -> Ok ()
+    | (e : Envelope.t) :: rest ->
+      if e.prev_hash <> prev then
+        Error (idx, Printf.sprintf "prev_hash mismatch at index %d" idx)
+      else
+        let h = Envelope.hash_for_chain e in
+        check (idx + 1) (Some h) rest
+  in
+  check 0 None entries

--- a/lib/shared_audit/store.mli
+++ b/lib/shared_audit/store.mli
@@ -1,0 +1,52 @@
+(** Shared_audit store — dated JSONL append-only store.
+
+    Mirrors the storage pattern from [keeper_approval_queue.ml] and
+    [keeper_crash_persistence.ml]. Entries are appended to
+    [<base_dir>/YYYY-MM/DD.jsonl], one JSON object per line. The
+    YYYY-MM/DD partitioning keeps individual files manageable and
+    enables date-range queries via filesystem listing.
+
+    The store maintains in-memory state for the latest entry's hash
+    so [append] can chain automatically without re-reading the
+    full log on each call. On creation, the latest hash is loaded
+    from the most recent JSONL file (if any) so sessions that resume
+    an existing audit log continue the chain correctly.
+
+    {b Single-process design}: this implementation does not coordinate
+    across processes. For multi-process audit (e.g., concurrent keepers
+    writing to the same log), a follow-up PR will add file-locking
+    or a single-writer dispatcher.
+
+    @stability Evolving
+    @since 0.18.9 *)
+
+type t
+
+val create : base_dir:string -> t
+(** Create or open a store rooted at [base_dir]. The directory is
+    created (with parents) if it does not exist. The latest entry's
+    hash is loaded from the most recent JSONL file in [base_dir],
+    so [append] continues the chain across sessions. *)
+
+val append :
+  t ->
+  category:string ->
+  payload:Yojson.Safe.t ->
+  Envelope.t
+(** Append a new entry with [prev_hash] computed from the latest
+    on-disk entry. Returns the appended entry. *)
+
+val recent : t -> n:int -> Envelope.t list
+(** Read the most recent [n] entries (chronologically increasing). *)
+
+val since : t -> ts:float -> Envelope.t list
+(** Read all entries whose [ts] is >= the given timestamp. *)
+
+val verify_chain : Envelope.t list -> (unit, int * string) result
+(** Verify the [prev_hash] chain over a list of entries assumed in
+    chronological order. Returns [Ok ()] if the chain is intact;
+    [Error (idx, reason)] at the first broken link. The first entry
+    must have [prev_hash = None]. *)
+
+val base_dir : t -> string
+(** Inspector for the base directory (mainly for tests). *)

--- a/ppx_tla/ppx_tla.ml
+++ b/ppx_tla/ppx_tla.ml
@@ -132,15 +132,53 @@ let derive_impl_for_variant ~loc cds =
   else
     [ to_tla; all_symbols ]
 
+(* ── Record-type implementation generators (Cycle 20 / Tier I7) ────
+
+   For record types we emit:
+   - [field_names : string list]   — every field's source name
+   - [field_count : int]           — [List.length field_names]
+
+   These two helpers let TLA+ specs assert structural shape without the
+   deriver having to know how to render arbitrary field values. Future
+   tiers may add a [to_tla_record] combinator that delegates field-value
+   rendering to user-supplied per-field [to_tla] functions. *)
+
+let make_field_names_impl ~loc lds =
+  let exprs =
+    List.map
+      (fun (ld : label_declaration) ->
+        Ast_builder.Default.estring ~loc ld.pld_name.txt)
+      lds
+  in
+  let list_expr = Ast_builder.Default.elist ~loc exprs in
+  let pat = Ast_builder.Default.ppat_var ~loc (Loc.make ~loc "field_names") in
+  let binding =
+    Ast_builder.Default.value_binding ~loc ~pat ~expr:list_expr
+  in
+  Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
+
+let make_field_count_impl ~loc lds =
+  let count = List.length lds in
+  let int_expr = Ast_builder.Default.eint ~loc count in
+  let pat = Ast_builder.Default.ppat_var ~loc (Loc.make ~loc "field_count") in
+  let binding =
+    Ast_builder.Default.value_binding ~loc ~pat ~expr:int_expr
+  in
+  Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
+
+let derive_impl_for_record ~loc lds =
+  [ make_field_names_impl ~loc lds; make_field_count_impl ~loc lds ]
+
 let str_type_decl ~ctxt (_rec_flag, type_decls) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   match type_decls with
   | [ td ] -> (
       match td.ptype_kind with
       | Ptype_variant cds -> derive_impl_for_variant ~loc cds
-      | Ptype_abstract | Ptype_record _ | Ptype_open ->
+      | Ptype_record lds -> derive_impl_for_record ~loc lds
+      | Ptype_abstract | Ptype_open ->
           Location.raise_errorf ~loc
-            "[@@deriving tla]: only variant types are supported")
+            "[@@deriving tla]: only variant and record types are supported")
   | _ ->
       Location.raise_errorf ~loc
         "[@@deriving tla]: a single type declaration is supported per \
@@ -188,6 +226,22 @@ let derive_sig_for_variant ~loc ~type_name cds =
   in
   to_tla_sig :: all_symbols_sig :: all_states_sig_opt
 
+let int_t ~loc =
+  Ast_builder.Default.ptyp_constr ~loc
+    (Loc.make ~loc (Longident.Lident "int"))
+    []
+
+let derive_sig_for_record ~loc lds =
+  let _ = lds in
+  let field_names_sig =
+    make_value_sig ~loc ~name:"field_names"
+      ~type_:(list_t ~loc (string_t ~loc))
+  in
+  let field_count_sig =
+    make_value_sig ~loc ~name:"field_count" ~type_:(int_t ~loc)
+  in
+  [ field_names_sig; field_count_sig ]
+
 let sig_type_decl ~ctxt (_rec_flag, type_decls) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   match type_decls with
@@ -195,9 +249,11 @@ let sig_type_decl ~ctxt (_rec_flag, type_decls) =
       match td.ptype_kind with
       | Ptype_variant cds ->
           derive_sig_for_variant ~loc ~type_name:td.ptype_name.txt cds
-      | Ptype_abstract | Ptype_record _ | Ptype_open ->
+      | Ptype_record lds ->
+          derive_sig_for_record ~loc lds
+      | Ptype_abstract | Ptype_open ->
           Location.raise_errorf ~loc
-            "[@@deriving tla]: only variant types are supported")
+            "[@@deriving tla]: only variant and record types are supported")
   | _ ->
       Location.raise_errorf ~loc
         "[@@deriving tla]: a single type declaration is supported per \

--- a/test/ppx_tla/dune
+++ b/test/ppx_tla/dune
@@ -1,4 +1,4 @@
-(test
- (name test_basic)
+(tests
+ (names test_basic test_records)
  (preprocess
   (pps ppx_tla)))

--- a/test/ppx_tla/test_records.ml
+++ b/test/ppx_tla/test_records.ml
@@ -1,0 +1,71 @@
+(* Cycle 19 / Tier I7 tests for ppx_tla [@@deriving tla] on record types.
+
+   Records emit:
+   - [field_names : string list]: source-order field names
+   - [field_count : int]: [List.length field_names]
+
+   The deriver does NOT inspect or render field values — that is left to
+   future tiers (and to user-supplied per-field combinators). The minimal
+   shape-helper API is sufficient for TLA+ structural-shape assertions
+   that need to enumerate fields without knowing their types.
+
+   Modules below wrap each record type so [field_names] / [field_count]
+   stay namespaced. *)
+
+module Conditions = struct
+  type t = {
+    healthy : bool;
+    overflow : bool;
+    has_pending_compaction : bool;
+    awaiting_approval : bool;
+  }
+  [@@deriving tla]
+end
+
+module Single_field = struct
+  type t = { only : int } [@@deriving tla]
+end
+
+module Mixed_types = struct
+  type t = {
+    name : string;
+    count : int;
+    active : bool;
+    tags : string list;
+  }
+  [@@deriving tla]
+end
+
+let test_conditions_field_names () =
+  assert
+    (Conditions.field_names
+     = [ "healthy"; "overflow"; "has_pending_compaction"; "awaiting_approval" ])
+
+let test_conditions_field_count () =
+  assert (Conditions.field_count = 4)
+
+let test_single_field () =
+  assert (Single_field.field_names = [ "only" ]);
+  assert (Single_field.field_count = 1)
+
+let test_mixed_types () =
+  assert (Mixed_types.field_names = [ "name"; "count"; "active"; "tags" ]);
+  assert (Mixed_types.field_count = 4)
+
+(* Source-order preservation: fields must appear in declaration order,
+   not alphabetical or hash order. The deriver iterates the AST list
+   in order. *)
+let test_source_order_preserved () =
+  let module Ordered = struct
+    type t = { z : int; a : int; m : int } [@@deriving tla]
+  end in
+  assert (Ordered.field_names = [ "z"; "a"; "m" ]);
+  assert (Ordered.field_count = 3)
+
+let () =
+  test_conditions_field_names ();
+  test_conditions_field_count ();
+  test_single_field ();
+  test_mixed_types ();
+  test_source_order_preserved ();
+  print_endline "test_records: all assertions passed"

--- a/test/shared_audit/dune
+++ b/test/shared_audit/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_shared_audit)
+ (libraries alcotest shared_audit yojson unix digestif))

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -1,0 +1,231 @@
+(** Tier I6 — Shared_audit unit tests.
+
+    Verifies envelope hash determinism, JSON round-trip, and store-level
+    chain integrity (append → recent → verify_chain → tampering detection). *)
+
+open Alcotest
+
+module Env = Shared_audit.Envelope
+module Store = Shared_audit.Store
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Helpers                                                       *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let unique_temp_dir prefix =
+  let base = Filename.get_temp_dir_name () in
+  let suffix = Printf.sprintf "%s_%d_%d" prefix (Unix.getpid ()) (Random.bits ()) in
+  let dir = Filename.concat base suffix in
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm_rf path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  try rm_rf dir with _ -> ()
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Envelope                                                      *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let test_envelope_make_basic () =
+  let e = Env.make
+    ~category:"TestCat"
+    ~payload:(`Assoc [ "k", `Int 1 ])
+    ~prev_hash:None
+  in
+  check string "category" "TestCat" e.category;
+  check (option string) "no prev_hash" None e.prev_hash;
+  check bool "id non-empty" true (String.length e.id > 0);
+  check bool "ts > 0" true (e.ts > 0.0)
+
+let test_envelope_canonical_json_deterministic () =
+  let e = Env.make
+    ~category:"X"
+    ~payload:(`String "test")
+    ~prev_hash:(Some "abc123")
+  in
+  let s1 = Env.canonical_json e in
+  let s2 = Env.canonical_json e in
+  check string "deterministic" s1 s2
+
+let test_envelope_compute_hash_deterministic () =
+  let e = Env.make
+    ~category:"X"
+    ~payload:(`Int 42)
+    ~prev_hash:None
+  in
+  let h1 = Env.compute_hash e in
+  let h2 = Env.compute_hash e in
+  check string "hash deterministic" h1 h2;
+  check int "SHA256 hex length" 64 (String.length h1)
+
+let test_envelope_hash_changes_with_payload () =
+  let e1 = { (Env.make ~category:"X" ~payload:(`Int 1) ~prev_hash:None)
+             with ts = 1.0; id = "fixed-id" }
+  in
+  let e2 = { e1 with payload = `Int 2 } in
+  check bool "different payload → different hash" true
+    (Env.compute_hash e1 <> Env.compute_hash e2)
+
+let test_envelope_json_round_trip () =
+  let e = Env.make
+    ~category:"RoundTrip"
+    ~payload:(`Assoc [ "field", `String "value"; "n", `Int 7 ])
+    ~prev_hash:(Some "deadbeef")
+  in
+  let json = Env.to_json e in
+  match Env.of_json json with
+  | Error msg -> fail msg
+  | Ok back ->
+    check string "id preserved" e.id back.id;
+    check (float 1e-6) "ts preserved" e.ts back.ts;
+    check string "category preserved" e.category back.category;
+    check (option string) "prev_hash preserved" e.prev_hash back.prev_hash;
+    check bool "payload equal"
+      true (Yojson.Safe.equal e.payload back.payload)
+
+let test_envelope_of_json_genesis_no_prev_hash_field () =
+  let json = `Assoc [
+    "id", `String "abc";
+    "ts", `Float 1.0;
+    "category", `String "X";
+    "payload", `Null;
+    (* no prev_hash field at all *)
+  ] in
+  match Env.of_json json with
+  | Ok e -> check (option string) "missing prev_hash → None" None e.prev_hash
+  | Error e -> fail e
+
+let test_envelope_of_json_rejects_bad () =
+  match Env.of_json (`Int 42) with
+  | Ok _ -> fail "should reject non-object"
+  | Error _ -> ()
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Store: append + chain                                         *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let test_store_append_chains () =
+  let dir = unique_temp_dir "audit_chain" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let e1 = Store.append store ~category:"A" ~payload:(`Int 1) in
+    let e2 = Store.append store ~category:"B" ~payload:(`Int 2) in
+    let e3 = Store.append store ~category:"C" ~payload:(`Int 3) in
+    check (option string) "first prev_hash None" None e1.prev_hash;
+    check (option string) "second prev_hash = hash of first"
+      (Some (Env.hash_for_chain e1)) e2.prev_hash;
+    check (option string) "third prev_hash = hash of second"
+      (Some (Env.hash_for_chain e2)) e3.prev_hash)
+
+let test_store_recent_returns_n () =
+  let dir = unique_temp_dir "audit_recent" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    for i = 1 to 5 do
+      let _ = Store.append store ~category:"X" ~payload:(`Int i) in ()
+    done;
+    let last3 = Store.recent store ~n:3 in
+    check int "3 entries" 3 (List.length last3);
+    let payloads = List.map (fun (e : Env.t) ->
+      match e.payload with `Int i -> i | _ -> -1) last3
+    in
+    check (list int) "last 3 are 3,4,5" [ 3; 4; 5 ] payloads)
+
+let test_store_since_filters () =
+  let dir = unique_temp_dir "audit_since" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 1) in
+    Unix.sleepf 0.05;
+    let cutoff = Unix.gettimeofday () in
+    Unix.sleepf 0.05;
+    let _ = Store.append store ~category:"X" ~payload:(`Int 2) in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 3) in
+    let after = Store.since store ~ts:cutoff in
+    check int "2 entries after cutoff" 2 (List.length after))
+
+let test_store_verify_chain_intact () =
+  let dir = unique_temp_dir "audit_verify_intact" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    for i = 1 to 4 do
+      let _ = Store.append store ~category:"V" ~payload:(`Int i) in ()
+    done;
+    let all = Store.recent store ~n:100 in
+    match Store.verify_chain all with
+    | Ok () -> ()
+    | Error (idx, reason) ->
+      fail (Printf.sprintf "chain broken at %d: %s" idx reason))
+
+let test_store_verify_chain_detects_tampering () =
+  let dir = unique_temp_dir "audit_verify_tamper" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 1) in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 2) in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 3) in
+    let all = Store.recent store ~n:100 in
+    (* Tamper: replace middle entry's payload, keep its prev_hash *)
+    let tampered = List.mapi (fun i (e : Env.t) ->
+      if i = 1 then { e with payload = `Int 999 } else e) all
+    in
+    match Store.verify_chain tampered with
+    | Ok () -> fail "should detect tampering"
+    | Error (idx, _) ->
+      (* The mismatch surfaces at the entry AFTER the tampered one,
+         because its prev_hash no longer matches. *)
+      check bool "broken link reported" true (idx >= 2))
+
+let test_store_resume_continues_chain () =
+  let dir = unique_temp_dir "audit_resume" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store_a = Store.create ~base_dir:dir in
+    let e1 = Store.append store_a ~category:"X" ~payload:(`Int 1) in
+    (* "Restart": create a fresh store at the same dir. *)
+    let store_b = Store.create ~base_dir:dir in
+    let e2 = Store.append store_b ~category:"X" ~payload:(`Int 2) in
+    check (option string)
+      "resumed chain: e2.prev_hash = hash of e1"
+      (Some (Env.hash_for_chain e1)) e2.prev_hash)
+
+let test_store_base_dir_inspector () =
+  let dir = unique_temp_dir "audit_inspector" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    check string "base_dir reported" dir (Store.base_dir store))
+
+(* ──────────────────────────────────────────────────────────── *)
+(* Suite                                                         *)
+(* ──────────────────────────────────────────────────────────── *)
+
+let () =
+  Random.self_init ();
+  run "Shared_audit" [
+    "Envelope", [
+      test_case "make basic" `Quick test_envelope_make_basic;
+      test_case "canonical_json deterministic" `Quick test_envelope_canonical_json_deterministic;
+      test_case "compute_hash deterministic" `Quick test_envelope_compute_hash_deterministic;
+      test_case "hash changes with payload" `Quick test_envelope_hash_changes_with_payload;
+      test_case "json round-trip" `Quick test_envelope_json_round_trip;
+      test_case "missing prev_hash field accepted" `Quick test_envelope_of_json_genesis_no_prev_hash_field;
+      test_case "rejects non-object" `Quick test_envelope_of_json_rejects_bad;
+    ];
+    "Store", [
+      test_case "append chains prev_hash" `Quick test_store_append_chains;
+      test_case "recent returns N" `Quick test_store_recent_returns_n;
+      test_case "since filters by timestamp" `Quick test_store_since_filters;
+      test_case "verify_chain intact" `Quick test_store_verify_chain_intact;
+      test_case "verify_chain detects tampering" `Quick test_store_verify_chain_detects_tampering;
+      test_case "resume continues chain" `Quick test_store_resume_continues_chain;
+      test_case "base_dir inspector" `Quick test_store_base_dir_inspector;
+    ];
+  ]


### PR DESCRIPTION
## 요약

Tier I7 — `ppx_tla`를 record 타입까지 확장합니다. variant 지원(Cycle 2 nullary, Cycle 3 parameterised + `[@tla.symbol]` override)는 그대로 유지되고, records 케이스만 raise → derive로 교체합니다.

**Stack PR 4-deep**: I7 → #11559 (I6) → #11554 (I5) → #11550 (I4) → main. Cycle 20의 첫 PR.

## 변경 내용

records가 `[@@deriving tla]`를 만나면 다음 두 helper를 emit합니다:

| 생성 함수 | 시그니처 | 의미 |
|----------|---------|------|
| `field_names` | `string list` | 소스 순서대로 모든 필드 이름 |
| `field_count` | `int` | `List.length field_names` |

이 두 helper는 TLA+ structural-shape 검증에 충분합니다. 필드 값 렌더링은 후속 tier (`to_tla_record` combinator)로 미루며, deriver가 임의 필드 타입을 알 필요가 없습니다.

## 설계 결정

- **Surgical change**: `Ptype_record _` 케이스 두 개의 `raise_errorf`를 `derive_*_for_record`로 교체. variant 코드 변경 0.
- **Source order preservation**: PPX가 AST list를 그대로 순회. `{ z; a; m }` → `["z"; "a"; "m"]` (alphabetical 아님). 검증은 `test_source_order_preserved`로.
- **Field 값은 emit 안 함**: deriver가 임의 필드 type을 모르기 때문에 값 렌더링은 user-supplied per-field combinator에 위임 (Tier I8 GADT 작업과 묶이는 follow-up).
- **변경된 raise message**: `"only variant types are supported"` → `"only variant and record types are supported"`.

## I7이 unblock하는 후속 작업

- **Tier I8**: GADT existential support (`Autonomous_phase.any` smoke).
- **Tier B3+**: `Stimulus.t` (record), `Intent.t` (record), `Goal_dag.node` (record), `Resource_budget.snapshot` (record), `Confidence.t` 보유 record 등에 직접 `[@@deriving tla]` 부착 가능.

## 테스트

`test/ppx_tla/test_records.ml`: 5 assertions, 모두 통과.

| 테스트 | 검증 |
|-------|------|
| `Conditions` (4-bool record) | conditions-style record. `field_names = ["healthy"; "overflow"; "has_pending_compaction"; "awaiting_approval"]`, `field_count = 4` |
| `Single_field` | boundary 1-field record |
| `Mixed_types` (string/int/bool/list) | 다양한 필드 타입 |
| `Source order preserved` | `{ z; a; m }` → `["z"; "a"; "m"]` (alphabetical 아님) |

기존 `test_basic` (Cycle 2 + 3 + 12 tests): **회귀 0**. variant 지원 변경 없음.

## Test plan

- [x] `dune build --root . ppx_tla/` GREEN
- [x] `dune build --root . test/ppx_tla/` GREEN (test_basic + test_records)
- [x] `dune runtest --root . test/ppx_tla/` GREEN
  - `test_records: all assertions passed`
  - `ppx_tla cycle 2 + 3 + 12 tests: PASS`
- [x] Pre-push race check: 0 conflicting PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)