### PR TITLE
feat(tools): tlc_test_gen — multi-spec self-validation (Cycle 23)

### DIFF
--- a/tools/tlc_test_gen/sample_outputs/dune
+++ b/tools/tlc_test_gen/sample_outputs/dune
@@ -1,12 +1,18 @@
 ; Self-validating sample outputs.
 ;
-; The (rule) below regenerates sample_inv_runner.ml every time tlc_test_gen
-; or the source fixture changes. The (tests) target then compiles + runs
-; the generated module, so any drift between the tool and the fixture
+; The (rule) blocks regenerate the *_runner.ml files every time tlc_test_gen
+; or the source fixtures change. The (tests) target then compiles + runs
+; each generated module, so any drift between the tool and a fixture
 ; surfaces immediately as a build or test failure.
 ;
 ; This closes the round-trip cycle described in plan §16: TLA+ trace →
 ; tlc_test_gen → OCaml runner → dune test → PASS / FAIL.
+;
+; Coverage:
+;   - sample_inv_runner:    int / string / bool round-trip
+;   - nested_sample_runner: V_raw nested record round-trip
+;       (validates that parser / emitter / runner all preserve embedded
+;        [host |-> "..."] without escaping or de-quoting drift)
 
 (rule
  (target sample_inv_runner.ml)
@@ -14,6 +20,12 @@
        (:gen ../bin/main.exe))
  (action (with-stdout-to %{target} (run %{gen} --runner %{fixture}))))
 
+(rule
+ (target nested_sample_runner.ml)
+ (deps (:fixture ../test/fixtures/nested_record.tla)
+       (:gen ../bin/main.exe))
+ (action (with-stdout-to %{target} (run %{gen} --runner %{fixture}))))
+
 (tests
- (names sample_inv_runner)
+ (names sample_inv_runner nested_sample_runner)
  (libraries tlc_test_gen))


### PR DESCRIPTION
## Summary

Extends `tools/tlc_test_gen/sample_outputs/dune` so the round-trip cycle (TLA+ trace → tlc_test_gen → OCaml runner → dune test → PASS/FAIL) covers **both** fixtures, not just one.

| Runner | Coverage |
|--------|----------|
| `sample_inv_runner` (existing, #11553) | int / string / bool round-trip |
| `nested_sample_runner` (this PR) | `V_raw` nested record round-trip |

V_raw handling is the layer most prone to silent drift — embedded quotes and `\|->` symbols must survive parser → emitter → OCaml string literal → `=` structural equality. Without nested_record under self-validation, any escaping regression in that path passes silently because the existing fixture has no V_raw bindings.

## Verification

```
$ dune test --root . tools/tlc_test_gen --force
PASS                                  (test_ttrace_parser fragment tests)
PASS [SampleInv_TTrace_1700000000]    (int / string / bool)
PASS [NestedSample_TTrace_1700000001] (V_raw nested record)
```

generated `nested_sample_runner.ml` preserves embedded quotes verbatim:

```ocaml
"config", T.V_raw "[host |-> \"init\", port |-> 0]";
```

OCaml compiles + structural compares the same V_raw payload → drift in escaping, de-quoting, or truncation in any of parser / emitter / runner fails the build or test target on next `dune build`.

## Scope

- 1 file: `tools/tlc_test_gen/sample_outputs/dune` (+16 / -4)
- isolated tool dune scope — `lib/` build unaffected
- no PPX, no library dependency change

## Plan

`/Users/dancer/me/planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md` §16.8 (Cycle 22 extension — β2 multi-spec self-validation).