### PR TITLE
feat(operator): add operator_approval.mli — typed action gate surface (cycle 50)

### DIFF
--- a/lib/operator_approval.mli
+++ b/lib/operator_approval.mli
@@ -1,0 +1,53 @@
+(** Operator_approval — OAS Approval pipeline for operator action
+    confirmation.
+
+    Centralises the [confirm_required] logic (previously duplicated
+    in 3 files) into a single OAS [Approval] pipeline with typed
+    risk levels. Callers consume the predicates ([is_allowed] /
+    [confirm_required]), the risk classifier ([risk_of_action]),
+    and the public action lists; the [pipeline] / [evaluate_action]
+    pair surfaces the OAS Approval gate for downstream policy
+    decoders.
+
+    @since OAS integration Phase F *)
+
+(** {1 Action catalogue} *)
+
+val high_risk_actions : string list
+(** Action types that always require operator confirmation. Risk
+    level is [Oas.Approval.High] and {!confirm_required} returns
+    [true] for every member. *)
+
+val allowed_actions : string list
+(** Action types known to the operator surface. Members not in
+    {!high_risk_actions} auto-approve through the pipeline; non-members
+    fall through to the high-risk gate as [Medium]. *)
+
+(** {1 Risk classification} *)
+
+val risk_of_action : string -> Oas.Approval.risk_level
+(** [High] when the action is in {!high_risk_actions}, [Low] when
+    only in {!allowed_actions}, otherwise [Medium]. *)
+
+val is_allowed : string -> bool
+(** [true] iff the action is in {!allowed_actions}. *)
+
+val confirm_required : string -> bool
+(** [true] iff the action is in {!high_risk_actions}. *)
+
+(** {1 OAS approval pipeline} *)
+
+val pipeline : Oas.Approval.t
+(** The composed pipeline: auto-approve allowed non-high-risk
+    actions, then a [high_risk_gate] stage that emits
+    [Reject "requires operator confirmation"] for high-risk
+    actions and [Pass] otherwise. *)
+
+val evaluate_action :
+  action_type:string ->
+  agent_name:string ->
+  turn:int ->
+  Oas.Hooks.approval_decision
+(** Evaluate [action_type] against {!pipeline} with an empty input
+    payload. The [agent_name] / [turn] pair is forwarded to the
+    OAS approval context. *)


### PR DESCRIPTION
## Summary

Cycle 50 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/operator_approval.ml` (51 lines).

Surface (7 bindings):
- `high_risk_actions` / `allowed_actions` — `string list`
- `risk_of_action` — `string -> Oas.Approval.risk_level`
- `is_allowed` / `confirm_required` — string predicates (5 callers)
- `pipeline` — `Oas.Approval.t` (auto-approve + high_risk_gate stages)
- `evaluate_action ~action_type ~agent_name ~turn` →
  `Oas.Hooks.approval_decision`

## Why typed surface vs inferred dump

The module body is small but pulls in `Oas.Approval` and
`Oas.Hooks` transitive types. The inferred-dump form would have
re-leaked `approval_stage` / `approval_decision` shapes — exactly
the pattern the `inferred_dump_headers` ratchet (#11402) was
introduced to prevent. Explicit .mli pins the contract at this
seam so future OAS pin bumps fail here, not at every caller site.

`pipeline` and `evaluate_action` are referenced in RFC-0005 as
the documented future emit path; kept exposed even though no
in-tree caller uses them yet.

## Caller audit (`rg "Operator_approval\."`)
- `lib/operator/operator_pending_confirm.ml` — `confirm_required`
- `lib/operator/operator_control_action.ml` — `confirm_required`
- `lib/operator/operator_digest_types.ml` — `confirm_required`
- `lib/dashboard/dashboard_operator_judge.ml` — `is_allowed`, `confirm_required`

All 5 use sites consume documented bindings; no internal access.

## Test plan
- [x] `dune build lib/operator_approval.cma` — clean
- [x] `dune build @check` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)