### PR TITLE
spec(keeper): derive_phase OCaml → TLA+ navigation anchors (C1 Phase 0)

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -308,6 +308,66 @@ let can_execute_turn = function
 
 (* ── derive_phase ──────────────────────────────────────── *)
 
+(* Spec navigation (OCaml priority -> TLA+ line) — plan §3 Tier C1 Phase 0
+   anchor. Authoritative spec mirror is KeeperReconcileLiveness.tla:88-101
+   (DerivePhase operator). The priority cascade below is preserved
+   verbatim; this block adds OCaml -> spec citations so drift is
+   grep-discoverable from this side too.
+
+     Priority | Spec citation
+     ---------+----------------------------------------------------------
+       1      | KeeperReconcileLiveness.tla:89-90 (Stopped: drain_complete
+              |   AND ~compaction_active AND ~handoff_active)
+       2      | (no spec — see Note A: launch_pending is pre-FSM)
+       3a-c   | KeeperReconcileLiveness.tla:91-93 (Dead/Restarting/Crashed)
+              |   boundary/KeeperRecoveryOrchestration.tla:53-57 (recovery)
+       4      | KeeperReconcileLiveness.tla:94 (Draining)
+       5      | KeeperReconcileLiveness.tla:95 (Failing — guardrail)
+       6      | KeeperReconcileLiveness.tla:96 (Paused — operator_paused;
+              |   compact_retry_exhausted clause is OCaml-stricter, see
+              |   Note B below — refinement, not drift)
+       7a     | KeeperReconcileLiveness.tla:97 (HandingOff)
+              |   KeeperConditionsGovernPhase.tla:96-100 (Transition action)
+       7b     | KeeperReconcileLiveness.tla:98 (Compacting)
+              |   KeeperCompactionLifecycle.tla:171-184 (Compacting cycle)
+       7c     | KeeperCompactionLifecycle.tla:154 (Overflowed) — partition
+              |   (KeeperReconcileLiveness omits Overflowed; coverage by
+              |    sibling spec is intentional, see Note C)
+       8      | KeeperReconcileLiveness.tla:99 (Failing — health degraded)
+       9      | KeeperReconcileLiveness.tla:100 (Running)
+              |   KeeperCoreTriad.tla:147,316 (turn_healthy=true -> Running)
+      10      | KeeperReconcileLiveness.tla:101 (Offline fallback)
+
+   Reverse direction (spec -> this function) anchors:
+     KeeperReconcileLiveness.tla:86      "matching OCaml derive_phase"
+     KeeperConditionsGovernPhase.tla:44  cites line 351 (HandingOff)
+     KeeperCoreTriad.tla:147,316         cites Running mirror
+     bug-models/KeeperPhaseRace.tla:7-10 cites this function entry
+
+   Classification (plan §1 4-way):
+     Note A — Drift candidate. Priority 2 Offline (launch_pending AND
+       ~fiber_alive) has no phase-derivation spec model. C1 follow-up:
+       either add KeeperLaunchPending.tla or document the pre-FSM
+       lifecycle as intentional scope projection. Until then: drift.
+     Note B — Refinement (acknowledged). Priority 6 OCaml clause
+       `context_overflow AND compact_retry_exhausted -> Paused` is
+       stricter than spec line 96 (operator_paused only). Without it
+       Overflowed -> Compacting loops indefinitely when retries are
+       exhausted; KeeperReconcileLiveness scope deliberately excludes
+       compact retry semantics, which live in KeeperCompactionLifecycle.
+     Note C — Partition (acknowledged). Overflowed phase derivation
+       lives in KeeperCompactionLifecycle.tla; KeeperReconcileLiveness
+       omits it because reconcile liveness is independent of overflow.
+       Multi-spec coverage by design, not drift.
+
+   C1 follow-up scope (plan §3, sequenced):
+     - Phase 1 (per-priority): convert each branch to `let try_<action>
+       state` mirroring the corresponding TLA+ Next-action enablement.
+     - Phase 2 (compile-time): exhaustiveness ratchet — every spec
+       action has exactly one OCaml try_ counterpart.
+     - Phase 3 (optional, plan §11.1 not adopted by default): runtime
+       gate `emit_phase_transition` — review hook only, not production. *)
+
 let derive_phase (c : conditions) : phase =
   (* Priority order: first match wins.
 


### PR DESCRIPTION
## Summary

First narrow PR of plan §3 **Tier C1 — `derive_phase` 사양화** (formalized incompleteness, β1).

Adds a 60-line spec navigation block immediately above `derive_phase` (`lib/keeper/keeper_state_machine.ml:309`) that:

1. **Maps every priority branch** of the 10-step cascade to its TLA+ citation (authoritative mirror is `KeeperReconcileLiveness.tla:88-101 DerivePhase`).
2. **Classifies three known divergences** under plan §1's 4-way taxonomy (Safety / Liveness / Refinement / Drift):
   - **Note A — Drift**: Priority 2 Offline (`launch_pending && ~fiber_alive`) has no phase-derivation spec model. C1 follow-up: add `KeeperLaunchPending.tla` or document as intentional pre-FSM scope projection.
   - **Note B — Refinement (acknowledged)**: Priority 6's `context_overflow && compact_retry_exhausted ⇒ Paused` clause is OCaml-stricter than `KeeperReconcileLiveness:96` (operator_paused only). Prevents the `Overflowed → Compacting` infinite loop when retries exhaust. Spec-side fix would require importing compact retry semantics into Reconcile, which is intentionally out of scope (KeeperCompactionLifecycle owns that).
   - **Note C — Partition (acknowledged)**: Priority 7c `Overflowed` lives in `KeeperCompactionLifecycle.tla:154`, not `KeeperReconcileLiveness`. Multi-spec coverage by design.

## Why this is the first PR

Reverse-direction anchors already exist spec-side:
- `KeeperReconcileLiveness.tla:86` — "matching OCaml derive_phase"
- `KeeperConditionsGovernPhase.tla:44` — cites line 351 (HandingOff)
- `KeeperCoreTriad.tla:147,316` — Running mirror
- `bug-models/KeeperPhaseRace.tla:7-10` — function entry

Only the OCaml → spec direction was missing. Adding it is **zero-behavior**, allowing C1 Phase 1 (per-priority `let try_<action> state` rewrite) and Phase 2 (compile-time exhaustiveness ratchet) to land as separate PRs each anchored to a verified spec line.

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_state_machine.ml`) |
| Lines | +60 / -0 |
| Behavior change | none (comment-only) |
| Body of `derive_phase` | unchanged |
| Build | `dune build --root . lib/keeper/` ✅ |

## Follow-up sequence (plan §3)

- **C1 Phase 1**: Convert each priority branch to `let try_<action> state` mirroring the corresponding TLA+ Next-action enablement. One PR per priority (or grouped as `try_recovery`, `try_buffer`, `try_health`, ...).
- **C1 Phase 2**: Compile-time exhaustiveness — every spec action has exactly one OCaml `try_` counterpart, enforced by a ratchet test or pattern match.
- **C1 Phase 3 (deferred, plan §11.1 not adopted by default)**: Runtime gate `emit_phase_transition`. Review hook only — the cost-acknowledgment in plan §11.1 explicitly excludes adopting this for production.

## Plan reference

`/Users/dancer/me/planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md`:
- §1 — formalized incompleteness 4-way classification
- §3 Tier C1 — derive_phase 사양화 (large surface, sequenced)
- §13.2 β1 — entry condition (user signal "C1 진행", 2026-04-28)