### PR TITLE
feat(relation): add relation_materializer.mli — narrow lifecycle hook surface (cycle 51)

### DIFF
--- a/lib/relation_materializer.mli
+++ b/lib/relation_materializer.mli
@@ -1,0 +1,33 @@
+(** Relation_materializer — record agent collaboration edges to
+    Neo4j (via GraphQL) when MASC lifecycle events fire.
+
+    Both entry points dispatch a single batched GraphQL mutation
+    (alias-batched: 20 peers = 1 HTTP request) and detach into an
+    Eio fiber when an Eio runtime is available. They never block
+    the caller and never raise — failures are logged via
+    [Log.Misc.error] and dropped.
+
+    Internal helpers ([log_err], [build_batch_mutation],
+    [record_collaborations_async]) are hidden — callers consume
+    only the two lifecycle hooks below, which {!Coord_hooks} wires
+    in via [Atomic.set] in [Coord]'s init.
+
+    @since 2.112.0 *)
+
+val on_agent_leave :
+  leaving_agent:string ->
+  active_agents:string list ->
+  unit
+(** When an agent leaves a MASC room, record [COLLABORATED_WITH]
+    edges between [leaving_agent] and every other member of
+    [active_agents] (the leaver itself is filtered out). No-op
+    when no peers remain. *)
+
+val on_task_done :
+  assignee:string ->
+  active_agents:string list ->
+  unit
+(** When a task completes, record collaboration edges between the
+    [assignee] and every other member of [active_agents]
+    (the assignee itself is filtered out). No-op when no peers
+    remain. *)


### PR DESCRIPTION
## Summary

Cycle 51 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/relation_materializer.ml` (85 lines).

Surface (2 bindings only):
- `on_agent_leave ~leaving_agent ~active_agents : unit`
- `on_task_done   ~assignee      ~active_agents : unit`

Hidden internals:
- `log_err`
- `build_batch_mutation` (GraphQL alias-batch builder)
- `record_collaborations_async` (Eio fiber dispatcher)

## Why narrow surface

Both Coord wirings (`lib/coord.ml`) consume the module exclusively
via `Atomic.set Coord_hooks.relation_on_leave_fn` /
`relation_on_task_done_fn`. The callbacks reference *only* the two
hook signatures — not the GraphQL builder or fiber dispatcher.
Exposing the helpers would leak the alias-batching strategy and
Eio runtime detection as part of the public contract; hiding them
keeps refactoring room (e.g. swapping from `Eio.Fiber.fork_daemon`
to a job queue) without breaking callers.

## Caller audit (`rg "Relation_materializer\."`)
- `lib/coord.ml` — `Atomic.set` on `relation_on_leave_fn` /
  `relation_on_task_done_fn` (both exposed)
- `lib/coord/coord_hooks.ml` — doc comments only
No internal helper is referenced externally.

## Contract notes (in the .mli doc)
- Hooks return immediately: `Eio.Fiber.fork_daemon` when an Eio
  runtime is present (`Eio_context.get_switch_opt` Some), else
  synchronous best-effort.
- Both filter the actor itself before issuing edges.
- Failures are logged via `Log.Misc.error` and dropped — never
  raised.

## Test plan
- [x] `dune build @check` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
