### PR TITLE
feat(config): add level2_config.mli — typed env-var tuning surface (cycle 53)

### DIFF
--- a/lib/level2_config.mli
+++ b/lib/level2_config.mli
@@ -1,0 +1,78 @@
+(** Level2_config — externalised tuning constants for MASC's
+    Level 2 cognitive subsystems (drift guard, lock contention,
+    Hebbian learning).
+
+    Every value is a thunk that re-reads the corresponding env
+    var at call time; callers should treat reads as cheap but not
+    pinning a value once at startup is intentional — it lets
+    operators change a constant by setting an env var and bouncing
+    the process group without a code patch.
+
+    Recognised env vars:
+    - [MASC_DRIFT_THRESHOLD]            — drift detection threshold (default 0.85)
+    - [MASC_DRIFT_JACCARD_WEIGHT]       — Jaccard weight in similarity blend (default 0.4)
+    - [MASC_DRIFT_COSINE_WEIGHT]        — Cosine weight in similarity blend (default 0.6)
+    - [MASC_LOCK_WARN_MS]               — lock contention warning threshold ms (default 100)
+    - [MASC_HEBBIAN_RATE]               — symmetric Hebbian learning rate (default 0.075)
+    - [MASC_HEBBIAN_DECAY]              — Hebbian decay rate (default 0.01)
+    - [MASC_HEBBIAN_CONSOLIDATION_INTERVAL_S] — consolidation cadence s (default 3600)
+    - [MASC_HEBBIAN_DECAY_AFTER_DAYS]   — synapse decay horizon days (default 14) *)
+
+(** {1 Drift guard} *)
+
+module Drift_guard : sig
+  type weights = { jaccard : float; cosine : float }
+  (** Blend weights for the Jaccard / Cosine similarity combiner. *)
+
+  val default_threshold : unit -> float
+  (** [MASC_DRIFT_THRESHOLD], default 0.85. *)
+
+  val weights : unit -> weights
+  (** [MASC_DRIFT_JACCARD_WEIGHT] / [MASC_DRIFT_COSINE_WEIGHT],
+      defaults 0.4 / 0.6. *)
+end
+
+(** {1 Lock contention} *)
+
+module Lock : sig
+  val warn_threshold_ms : unit -> float
+  (** [MASC_LOCK_WARN_MS], default 100.0 ms. *)
+end
+
+(** {1 Hebbian learning} *)
+
+module Hebbian : sig
+  val learning_rate : unit -> float
+  (** [MASC_HEBBIAN_RATE], default 0.075. Used symmetrically for
+      strengthen / weaken. *)
+
+  val decay_rate : unit -> float
+  (** [MASC_HEBBIAN_DECAY], default 0.01. *)
+
+  val min_weight : unit -> float
+  (** Lower bound on synapse weight, currently 0.05 (constant). *)
+
+  val max_weight : unit -> float
+  (** Upper bound on synapse weight, currently 1.0 (constant). *)
+
+  val consolidation_interval_s : unit -> float
+  (** [MASC_HEBBIAN_CONSOLIDATION_INTERVAL_S], default 3600.0 s.
+      Issue #9876 — cadence kept much shorter than the decay
+      horizon so consolidation never races with active
+      strengthen / weaken traffic (~336 passes per decay window
+      at the defaults). *)
+
+  val decay_after_days : unit -> float
+  (** [MASC_HEBBIAN_DECAY_AFTER_DAYS], default 14.0 days. *)
+end
+
+(** {1 Inspection} *)
+
+val to_json : unit -> Yojson.Safe.t
+(** Snapshot the four headline constants
+    ([drift_threshold] / [lock_warn_ms] / [hebbian_rate] /
+    [hebbian_decay]) as a JSON object for dashboards. *)
+
+val print_config : unit -> unit
+(** Log the headline constants to [Log.Level2.info] for boot-time
+    debugging. *)


### PR DESCRIPTION
## Summary

Cycle 53 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/level2_config.ml` (65 lines).

Surface (3 modules + 2 top-level fns):
- `module Drift_guard`
  - `type weights = { jaccard : float; cosine : float }`
  - `default_threshold` / `weights`
- `module Lock`
  - `warn_threshold_ms`
- `module Hebbian`
  - `learning_rate` / `decay_rate` / `min_weight` / `max_weight`
  - `consolidation_interval_s` / `decay_after_days`
- `to_json` / `print_config`

## Why typed surface

Every binding is a `unit -> float` thunk that re-reads an env
var on each call (intentional — operators tune by setting
`MASC_*` vars and bouncing the process). The `.mli` pins the
arity so a future "let's cache the value" refactor cannot
silently drop the unit arg without failing here at the contract
seam.

`Drift_guard.weights` is also an explicit record type — the
inferred dump would have re-leaked the `{ jaccard; cosine }`
shape as part of the public surface; explicit `.mli` keeps it
documented in one place and ready for any future widening
(e.g. adding a Levenshtein weight) to fail callers cleanly.

## Caller audit (`rg "Level2_config\\."`)

External:
- `lib/drift_guard.ml` — `Drift_guard.{default_threshold, weights}`
- `lib/hebbian_eio.ml`
  - `Hebbian.{learning_rate, decay_rate, min_weight,
    max_weight, consolidation_interval_s, decay_after_days}`
  - `Lock.warn_threshold_ms`
- `test/test_level2_config_coverage.ml` — every getter +
  `to_json`

`print_config` is unused in `lib/` but exposed because it is a
debug-only entry point referenced from boot scripts.

## Test plan
- [x] `dune build @check` — clean
- [ ] `dune runtest` (CI) — `test_level2_config_coverage`
      exercises every getter
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
