### PR TITLE
fix(spec): resolve AdmissionQueue TLA+ cumulative-counter deadlock

### DIFF
--- a/specs/admission-queue/AdmissionQueue.tla
+++ b/specs/admission-queue/AdmissionQueue.tla
@@ -84,17 +84,22 @@ FdMax == FdThreshold + 1
 \* branch without simulating C-style truncation.
 GuardFires == fd_count * FdGuardDen >= FdGuardNum * FdThreshold
 
-\* Counter bound. Strictly larger than [active] so the model can
-\* exercise long-running acquire/release sequences without TypeOK
-\* clipping, while still keeping the state space finite.
+\* Concurrent-slot bound. Limits [active] (the running count of
+\* in-flight work). Small enough to keep the state space manageable.
 CounterMax == 6
+
+\* Cumulative-counter bound. [acquire_count] and [release_count] are
+\* monotonic and can grow without bound if the model runs long enough.
+\* A separate, larger ceiling prevents TypeOK from clipping them while
+\* still bounding the state space.
+CumulativeMax == CounterMax * 2
 
 TypeOK ==
     /\ fd_count \in 0..FdMax
     /\ admission_state \in AdmissionStateSet
     /\ active \in 0..CounterMax
-    /\ acquire_count \in 0..CounterMax
-    /\ release_count \in 0..CounterMax
+    /\ acquire_count \in 0..CumulativeMax
+    /\ release_count \in 0..CumulativeMax
     /\ cascade_input \in CascadeNameSet
     /\ cascade_recorded \in CascadeNameSet
 
@@ -139,7 +144,8 @@ RejectByFdGuard ==
 AcceptAndAcquire ==
     /\ admission_state = "checking"
     /\ ~ GuardFires
-    /\ acquire_count < CounterMax
+    /\ active < CounterMax
+    /\ acquire_count < CumulativeMax
     /\ admission_state' = "accepted"
     /\ active' = active + 1
     /\ acquire_count' = acquire_count + 1
@@ -150,6 +156,7 @@ AcceptAndAcquire ==
 Release ==
     /\ admission_state = "accepted"
     /\ active > 0
+    /\ release_count < CumulativeMax
     /\ admission_state' = "idle"
     /\ active' = active - 1
     /\ release_count' = release_count + 1
@@ -216,7 +223,8 @@ ActiveCounterConsistent ==
 FdGuardSkip ==
     /\ admission_state = "checking"
     /\ GuardFires
-    /\ acquire_count < CounterMax
+    /\ active < CounterMax
+    /\ acquire_count < CumulativeMax
     /\ admission_state' = "accepted"
     /\ active' = active + 1
     /\ acquire_count' = acquire_count + 1


### PR DESCRIPTION
## Summary
- Split `CounterMax` into two bounds: `CounterMax` (concurrent slots, `active`) and `CumulativeMax` (monotonic counters, `acquire_count`/`release_count`)
- `AcceptAndAcquire` guard changed from `acquire_count < CounterMax` to `active < CounterMax` — the old guard deadlocked after CounterMax acquire-release cycles because cumulative counters never decrease
- Add `release_count < CumulativeMax` overflow guard to `Release` for symmetry
- Bug action `FdGuardSkip` updated to match

## Root Cause
TLC exit code 11 (deadlock). After 6 acquire-release cycles, `acquire_count = CounterMax = 6`. System enters `"checking"` but `AcceptAndAcquire` is blocked by `acquire_count < CounterMax` (false), and `RejectByFdGuard` is blocked by `~GuardFires` (fd=0). No action is enabled → deadlock.

## Test plan
- [ ] CI `tla-check.sh` passes for AdmissionQueue (Spec + SpecBuggy)
- [ ] Spec clean: no deadlock, no invariant violation
- [ ] SpecBuggy: invariant violation (FdGuardSkip, ReleaseSkipped, CanonicalizeMissed all still caught)

🤖 Generated with [Claude Code](https://claude.com/claude-code)