### PR TITLE
feat(server): add subsystem_health.mli — typed alive/dead registry surface (cycle 54)

### DIFF
--- a/lib/subsystem_health.mli
+++ b/lib/subsystem_health.mli
@@ -1,0 +1,30 @@
+(** Subsystem_health — process-wide registry of forked subsystems
+    and their alive/dead state.
+
+    Module-level [Hashtbl] guarded by [Stdlib.Mutex] (cross-domain:
+    /health handler may run on a different domain than the fork
+    callers, ruling out [Eio.Mutex]). Available from process start
+    with no init timing dependency.
+
+    Internal helpers (the [registry] table, [registry_mu] mutex,
+    and [with_lock] critical-section wrapper) are hidden — callers
+    consume only the three lifecycle entry points below. *)
+
+val register : string -> unit
+(** Mark [name] as alive in the registry. Called from
+    [fork_subsystem] in [server_bootstrap_loops] when a subsystem
+    fiber is forked. Idempotent — re-registers as alive with no
+    crash time even if the entry already exists. *)
+
+val mark_dead : string -> unit
+(** Mark [name] as dead and stamp its crash time
+    ([Time_compat.now ()]). Called from the supervisor fiber
+    when it observes a crash. Idempotent — overwrites any prior
+    entry with the new crash timestamp. *)
+
+val to_yojson : unit -> Yojson.Safe.t
+(** Render the registry as a JSON object keyed by subsystem name,
+    sorted alphabetically. Each value is
+    [\{ "status": "alive" | "dead", "crashed_at"?: float \}].
+    Consumed by the HTTP [/health] handler in
+    [server_routes_http_runtime]. *)


### PR DESCRIPTION
## Summary

Cycle 54 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/subsystem_health.ml` (44 lines).

Surface (3 lifecycle entries):
- `register   : string -> unit`
- `mark_dead  : string -> unit`
- `to_yojson  : unit -> Yojson.Safe.t`

Hidden internals:
- `registry` — `(string, bool * float option) Hashtbl.t`
- `registry_mu` — `Stdlib.Mutex.t`
- `with_lock` — critical-section helper

## Why narrow surface

The registry is process-wide state; exposing the table type
would publish the encoding `(alive, crash_time_opt)` as part of
the public contract. A future swap to per-subsystem records or
to `Atomic.t`-keyed storage should not have to break callers.
The three lifecycle entries are the only thing consumers need.

`Stdlib.Mutex` (not `Eio.Mutex`) is intentional: the `/health`
HTTP handler may run on a different domain than the fork
callers, ruling out `Eio.Mutex`. The `.mli` documents this
constraint at the contract seam.

## Caller audit (`rg "Subsystem_health\\."`)
- `lib/server/server_bootstrap_loops.ml` — `register` /
  `mark_dead` on fork and supervisor observation
- `lib/server/server_routes_http_runtime.ml` — `to_yojson`
  under the `"subsystems"` key on the `/health` JSON response

No external reference to `registry` / `registry_mu` /
`with_lock`.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
