### PR TITLE
feat(ppx-tla): Tier I9 — [@@tla.phantom_param] opt-out for phantom GADT existentials (Cycle 20)

### DIFF
--- a/ppx_tla/ppx_tla.ml
+++ b/ppx_tla/ppx_tla.ml
@@ -47,6 +47,37 @@ let symbol_of_constructor (cd : constructor_declaration) =
   | Some s -> s
   | None -> String.lowercase_ascii cd.pcd_name.txt
 
+(* [@@tla.phantom_param] flag on type declarations (Cycle 20 / Tier I9).
+
+   Marks every type parameter of the annotated type as phantom — i.e.
+   not specialised in any constructor body — so that the deriver can
+   emit [to_tla_symbol] / [all_symbols] for a 1+ type-parameter GADT
+   existential as if it had no type parameters at all.
+
+   Motivating use case: phase-encoded state machines such as
+     type 'a perceiving =
+       | P_observe : 'a perceiving
+       | P_wait    : 'a perceiving
+     [@@deriving tla] [@@tla.phantom_param]
+   where 'a is used purely as a type-level tag and never narrowed by a
+   constructor's payload.
+
+   Type safety: if the user lies about phantom-ness (a constructor
+   does specialise 'a, e.g. [P_count : int -> int perceiving]), the
+   emitted match desugars to a regular [match e with ...] without the
+   locally-abstract-type wrapper, and OCaml's type-checker rejects the
+   pattern with an unambiguous error. The attribute is therefore an
+   advisory contract — the deriver trusts it but the compiler enforces
+   the underlying invariant. *)
+let phantom_param_attr =
+  Attribute.declare "tla.phantom_param"
+    Attribute.Context.type_declaration
+    Ast_pattern.(pstr nil)
+    ()
+
+let has_phantom_param_attr (td : type_declaration) =
+  Attribute.get phantom_param_attr td <> None
+
 let lid_of_constructor ~loc (cd : constructor_declaration) =
   Loc.make ~loc (Longident.Lident cd.pcd_name.txt)
 
@@ -272,30 +303,39 @@ let make_to_tla_symbol_impl_gadt_one_param ~loc ~type_name cds =
   in
   Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
 
-let derive_impl_for_gadt ~loc ~type_name ~type_params cds =
+let derive_impl_for_gadt ~loc ~type_name ~type_params ~is_phantom cds =
   let _ = type_name in
   let all_symbols = make_all_symbols_impl ~loc cds in
-  match type_params with
-  | [] ->
+  match (type_params, is_phantom) with
+  | [], _ ->
     (* GADT with no type params: structurally like ordinary variant but
        all_states is suppressed because GADT constructors with explicit
        result types may not list-construct cleanly without payload. *)
     let to_tla = make_to_tla_symbol_impl ~loc cds in
     [ to_tla; all_symbols ]
-  | _ :: _ ->
-    (* Deferred: 1+ type parameter GADT existentials require emitting
-       [let foo : type a. a t -> string = function ...] which has a
-       three-piece AST (ptyp_poly + pexp_newtype + inner pexp_constraint)
-       whose ppxlib-builder reproduction empirically conflicts with the
-       OCaml 5.4 type-checker's scoped-type rules. Tracked for follow-up
-       Tier (I8b / I9) — for now, hand-write [to_tla_symbol_any] for the
-       few known GADT existentials in lib/autonomous/ rather than rely
-       on the deriver. *)
+  | _ :: _, true ->
+    (* Phantom-parameter GADT (Tier I9): the user has asserted via
+       [@@tla.phantom_param] that no constructor specialises any type
+       parameter. The emitted [to_tla_symbol] is structurally identical
+       to the regular-variant case — OCaml's type checker accepts the
+       match because every arm returns the same uniform type [string],
+       so no locally-abstract-type scoping is required. The compiler
+       enforces the phantom contract: a constructor that specialises
+       a parameter triggers a clean type error at the user's call site. *)
+    let to_tla = make_to_tla_symbol_impl ~loc cds in
+    [ to_tla; all_symbols ]
+  | _ :: _, false ->
+    (* Non-phantom 1+ parameter GADT existentials still require the
+       three-piece AST trick (ptyp_poly + pexp_newtype + inner
+       pexp_constraint) whose ppxlib-builder reproduction empirically
+       conflicts with OCaml 5.4 scoped-type rules. Workaround paths:
+       - If parameters are phantom, add [@@tla.phantom_param] (Tier I9).
+       - Otherwise, hand-write [to_tla_symbol_any] for this type. *)
     Location.raise_errorf ~loc
       "[@@deriving tla]: GADT existential with type parameters is not \
-       yet supported. Tier I8 lands GADT detection + 0-param emission; \
-       1+ parameter GADT existentials are deferred to a follow-up tier. \
-       Workaround: hand-write to_tla_symbol_any for this type."
+       yet supported. Add [@@tla.phantom_param] if the type parameters \
+       are phantom (not specialised in constructor bodies). Otherwise, \
+       hand-write to_tla_symbol_any for this type."
 
 let str_type_decl ~ctxt (_rec_flag, type_decls) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
@@ -307,6 +347,7 @@ let str_type_decl ~ctxt (_rec_flag, type_decls) =
             derive_impl_for_gadt ~loc
               ~type_name:td.ptype_name.txt
               ~type_params:td.ptype_params
+              ~is_phantom:(has_phantom_param_attr td)
               cds
           else
             derive_impl_for_variant ~loc cds
@@ -341,16 +382,29 @@ let make_value_sig ~loc ~name ~type_ =
     (Ast_builder.Default.value_description ~loc
        ~name:(Loc.make ~loc name) ~type_ ~prim:[])
 
-let derive_sig_for_variant ~loc ~type_name ~type_params cds =
+let derive_sig_for_variant ~loc ~type_name ~type_params ~is_phantom cds =
   let is_gadt = any_gadt_constructor cds in
   let arg_t =
     if is_gadt then
-      match type_params with
-      | [] -> type_t ~loc ~type_name
-      | _ :: _ ->
+      match (type_params, is_phantom) with
+      | [], _ -> type_t ~loc ~type_name
+      | _ :: _, true ->
+        (* Phantom GADT (Tier I9): apply the original type parameters so
+           the emitted signature reads e.g. [val to_tla_symbol :
+           'a perceiving -> string]. Free type variables in a value
+           description are implicitly universally quantified, which is
+           the correct semantics here — the function works for any
+           instantiation of the phantom parameters. *)
+        let type_args = List.map (fun (ct, _vi) -> ct) type_params in
+        Ast_builder.Default.ptyp_constr ~loc
+          (Loc.make ~loc (Longident.Lident type_name))
+          type_args
+      | _ :: _, false ->
         Location.raise_errorf ~loc
           "[@@deriving tla]: GADT existential with type parameters is \
-           not yet supported in signatures (Tier I8 covers 0-param GADT)."
+           not yet supported in signatures. Add [@@tla.phantom_param] if \
+           the type parameters are phantom (not specialised in \
+           constructor bodies)."
     else
       type_t ~loc ~type_name
   in
@@ -398,6 +452,7 @@ let sig_type_decl ~ctxt (_rec_flag, type_decls) =
           derive_sig_for_variant ~loc
             ~type_name:td.ptype_name.txt
             ~type_params:td.ptype_params
+            ~is_phantom:(has_phantom_param_attr td)
             cds
       | Ptype_record lds ->
           derive_sig_for_record ~loc lds

--- a/test/ppx_tla/dune
+++ b/test/ppx_tla/dune
@@ -1,4 +1,4 @@
 (tests
- (names test_basic test_records test_gadt)
+ (names test_basic test_records test_gadt test_phantom_param)
  (preprocess
   (pps ppx_tla)))

--- a/test/ppx_tla/test_phantom_param.ml
+++ b/test/ppx_tla/test_phantom_param.ml
@@ -1,0 +1,117 @@
+(* Cycle 20 / Tier I9 tests — [@@tla.phantom_param] for GADT existentials
+   with phantom type parameters.
+
+   Tier I9 scope: extends the deriver to accept 1+ type-parameter GADTs
+   when the user marks the type with [@@tla.phantom_param], asserting
+   that no constructor specialises any parameter in its body. The
+   deriver then emits [to_tla_symbol] / [all_symbols] structurally
+   identical to the 0-param GADT case (Tier I8). The user's contract is
+   enforced by the OCaml type-checker — a constructor that lies about
+   phantom-ness produces a clean compile error at the call site. *)
+
+(* ─── 1-parameter phantom GADT (Tier I9 core case) ────────────────── *)
+
+module Phantom_perceiving = struct
+  type 'a perceiving =
+    | P_observe : 'a perceiving
+    | P_wait : 'a perceiving
+  [@@deriving tla] [@@tla.phantom_param]
+end
+
+let test_phantom_perceiving_to_tla_symbol () =
+  let observe : unit Phantom_perceiving.perceiving =
+    Phantom_perceiving.P_observe
+  in
+  let wait : int Phantom_perceiving.perceiving =
+    Phantom_perceiving.P_wait
+  in
+  assert (Phantom_perceiving.to_tla_symbol observe = "p_observe");
+  assert (Phantom_perceiving.to_tla_symbol wait = "p_wait")
+
+let test_phantom_perceiving_all_symbols () =
+  assert (Phantom_perceiving.all_symbols = [ "p_observe"; "p_wait" ])
+
+(* ─── Phantom GADT with [@tla.symbol] override ─────────────────────── *)
+
+module Phantom_with_override = struct
+  type 'a action =
+    | A_run : 'a action [@tla.symbol "execute"]
+    | A_skip : 'a action
+    | A_halt : 'a action [@tla.symbol "stop"]
+  [@@deriving tla] [@@tla.phantom_param]
+end
+
+let test_phantom_with_override () =
+  let run : unit Phantom_with_override.action = Phantom_with_override.A_run in
+  let skip : int Phantom_with_override.action = Phantom_with_override.A_skip in
+  let halt : string Phantom_with_override.action =
+    Phantom_with_override.A_halt
+  in
+  assert (Phantom_with_override.to_tla_symbol run = "execute");
+  assert (Phantom_with_override.to_tla_symbol skip = "a_skip");
+  assert (Phantom_with_override.to_tla_symbol halt = "stop");
+  assert
+    (Phantom_with_override.all_symbols = [ "execute"; "a_skip"; "stop" ])
+
+(* ─── Phantom GADT in module signature (sig_type_decl path) ─────────
+   This validates that derive_sig_for_variant emits
+   [val to_tla_symbol : 'a Phase.t -> string] — i.e. the type
+   parameters are applied to the type name in the signature, free
+   type variables remaining implicitly universally quantified. *)
+
+module Phase : sig
+  type 'a t =
+    | Idle : 'a t
+    | Active : 'a t
+    | Done : 'a t
+  [@@deriving tla] [@@tla.phantom_param]
+end = struct
+  type 'a t =
+    | Idle : 'a t
+    | Active : 'a t
+    | Done : 'a t
+  [@@deriving tla] [@@tla.phantom_param]
+end
+
+let test_phase_signature () =
+  let idle : unit Phase.t = Phase.Idle in
+  let active : int Phase.t = Phase.Active in
+  let dn : string Phase.t = Phase.Done in
+  assert (Phase.to_tla_symbol idle = "idle");
+  assert (Phase.to_tla_symbol active = "active");
+  assert (Phase.to_tla_symbol dn = "done");
+  assert (Phase.all_symbols = [ "idle"; "active"; "done" ])
+
+(* ─── 2-parameter phantom GADT (e.g. ('from, 'to_) transition shape) ──
+   Models the eventual Tier B5 transition GADT shape, where both
+   parameters are phantom and the deriver must emit
+   [val to_tla_symbol : ('a, 'b) bridge -> string]. *)
+
+module Multi_param_phantom = struct
+  type ('a, 'b) bridge =
+    | B_pending : ('a, 'b) bridge
+    | B_active : ('a, 'b) bridge
+    | B_closed : ('a, 'b) bridge
+  [@@deriving tla] [@@tla.phantom_param]
+end
+
+let test_multi_param_phantom () =
+  let p : (unit, int) Multi_param_phantom.bridge =
+    Multi_param_phantom.B_pending
+  in
+  let a : (string, bool) Multi_param_phantom.bridge =
+    Multi_param_phantom.B_active
+  in
+  assert (Multi_param_phantom.to_tla_symbol p = "b_pending");
+  assert (Multi_param_phantom.to_tla_symbol a = "b_active");
+  assert
+    (Multi_param_phantom.all_symbols
+     = [ "b_pending"; "b_active"; "b_closed" ])
+
+let () =
+  test_phantom_perceiving_to_tla_symbol ();
+  test_phantom_perceiving_all_symbols ();
+  test_phantom_with_override ();
+  test_phase_signature ();
+  test_multi_param_phantom ();
+  print_endline "test_phantom_param: all assertions passed"


### PR DESCRIPTION
## Summary

Cycle 20 third PR — completes the ppx_tla extension by accepting 1+ type-parameter GADTs when the user marks the type with `[@@tla.phantom_param]`. The deriver then emits `to_tla_symbol` / `all_symbols` structurally identical to the 0-param GADT case (Tier I8). The OCaml type-checker enforces the phantom contract: a constructor that lies about phantom-ness produces a clean compile error at the user's declaration site.

## Changes

- **`ppx_tla/ppx_tla.ml`** (+95 / -21):
  - New `phantom_param_attr` declared on `type_declaration` context (flag-only, `Ast_pattern.(pstr nil)`).
  - `derive_impl_for_gadt` dispatches on `(type_params, is_phantom)` pair — `[]` (0-param) and `_::_, true` (phantom 1+ param) reuse the regular variant emit; `_::_, false` raises an informative error pointing the user to either `[@@tla.phantom_param]` or a hand-written `to_tla_symbol_any` workaround.
  - `derive_sig_for_variant` applies the original type parameters to the type name when emitting a phantom GADT signature, so the value description reads e.g. `val to_tla_symbol : 'a perceiving -> string` (free type variables implicitly universally quantified).

- **`test/ppx_tla/test_phantom_param.ml`** (new, 113 LoC, 5 cases all GREEN):
  - 1-param phantom GADT (`'a perceiving = P_observe : 'a perceiving | P_wait : 'a perceiving`)
  - 1-param phantom GADT with `[@tla.symbol]` override (3 constructors)
  - Module signature path (`Phase : sig ... end = struct ... end`) exercising `sig_type_decl`
  - 2-parameter phantom GADT (`('a, 'b) bridge`) — models the eventual Tier B5 `('from, 'to) transition` shape

- **`test/ppx_tla/dune`** (+1 / -1): register `test_phantom_param`.

## Test plan
- [x] `dune build --root . ppx_tla/` — GREEN
- [x] `dune build --root . test/ppx_tla/` — GREEN
- [x] `dune runtest --root . test/ppx_tla/ --force` — all four suites pass:
  - `ppx_tla cycle 2 + 3 + 12 tests: PASS`
  - `test_records: all assertions passed`
  - `test_gadt: all assertions passed`
  - `test_phantom_param: all assertions passed`
- [x] No regression in I7 (records) or I8 (0-param GADT) paths

## Out of scope
1+ parameter non-phantom GADT existentials (e.g. `type 'a t = | T_int : int t | T_str : string t`) where constructors specialise the parameter remain deferred. The error message now distinguishes the phantom case (point user to `[@@tla.phantom_param]`) from the genuine specialisation case (point user to hand-written `to_tla_symbol_any`).

## Plan reference
`planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-temporal-stream.md` §2.2 Tier I9 — closes Cycle 20 PPX extension cycle, unblocks Tier B3+ phantom-tagged transition GADTs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)