### PR TITLE
refactor(design-system): tokenize tools.css raw rgba (--bg-tab-sticky-hover)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.generated.css
+++ b/dashboard/design-system/source_styles/tokens.generated.css
@@ -340,6 +340,7 @@
   --scrim: rgb(0 0 0 / .5);
   --scrim-strong: rgb(0 0 0 / .7);
   --scrim-brass: rgb(var(--brass-glow) / .04);  /* warm wash behind active region */
+  --bg-tab-sticky-hover: rgb(30 41 59 / .95);  /* sticky tab hover backdrop (slate-800 / 95%) */
   --motion-enter: var(--t-med) var(--ease-out);
   --motion-exit: var(--t-fast) var(--ease-in);
   --motion-swap: var(--t-fast) var(--ease);

--- a/dashboard/design-system/tokens/build/tokens.json
+++ b/dashboard/design-system/tokens/build/tokens.json
@@ -1398,6 +1398,11 @@
       "$value": "rgb(var(--brass-glow) / .04)",
       "$description": "warm wash behind active region"
     },
+    "bg-tab-sticky-hover": {
+      "$type": "color",
+      "$value": "rgb(30 41 59 / .95)",
+      "$description": "sticky tab hover backdrop (slate-800 / 95%)"
+    },
     "motion-enter": {
       "$type": "duration",
       "$value": "var(--t-med) var(--ease-out)"

--- a/dashboard/design-system/tokens/source.ts
+++ b/dashboard/design-system/tokens/source.ts
@@ -543,6 +543,8 @@ export const semantic: ReadonlyArray<TokenBase> = (() => {
   out.push(t("scrim-strong", "rgb(0 0 0 / .7)", "role", "color"));
   out.push(t("scrim-brass",  "rgb(var(--brass-glow) / .04)", "role", "color",
     "warm wash behind active region"));
+  out.push(t("bg-tab-sticky-hover", "rgb(30 41 59 / .95)", "role", "color",
+    "sticky tab hover backdrop (slate-800 / 95%)"));
 
   // ── Motion role tokens — bundle duration + easing ──────────────────
   out.push(t("motion-enter",  "var(--t-med) var(--ease-out)", "role", "duration"));

--- a/dashboard/src/styles/tokens.generated.css
+++ b/dashboard/src/styles/tokens.generated.css
@@ -335,6 +335,7 @@
   --color-scrim: rgb(0 0 0 / .5);
   --color-scrim-strong: rgb(0 0 0 / .7);
   --color-scrim-brass: rgb(var(--brass-glow) / .04);
+  --color-bg-tab-sticky-hover: rgb(30 41 59 / .95);
   --motion-enter: var(--t-med) var(--ease-out);
   --motion-exit: var(--t-fast) var(--ease-in);
   --motion-swap: var(--t-fast) var(--ease);

--- a/dashboard/src/styles/tokens.generated.ts
+++ b/dashboard/src/styles/tokens.generated.ts
@@ -335,6 +335,7 @@ export const TOKENS = {
   "scrim": { name: "--scrim", value: "rgb(0 0 0 / .5)", tier: "role", kind: "color" },
   "scrimStrong": { name: "--scrim-strong", value: "rgb(0 0 0 / .7)", tier: "role", kind: "color" },
   "scrimBrass": { name: "--scrim-brass", value: "rgb(var(--brass-glow) / .04)", tier: "role", kind: "color" },
+  "bgTabStickyHover": { name: "--bg-tab-sticky-hover", value: "rgb(30 41 59 / .95)", tier: "role", kind: "color" },
   "motionEnter": { name: "--motion-enter", value: "var(--t-med) var(--ease-out)", tier: "role", kind: "duration" },
   "motionExit": { name: "--motion-exit", value: "var(--t-fast) var(--ease-in)", tier: "role", kind: "duration" },
   "motionSwap": { name: "--motion-swap", value: "var(--t-fast) var(--ease)", tier: "role", kind: "duration" },

--- a/dashboard/src/styles/tools.css
+++ b/dashboard/src/styles/tools.css
@@ -32,7 +32,7 @@
     pointer-events: auto;
   }
   &:hover {
-    background: rgba(30, 41, 59, 0.95);
+    background: var(--color-bg-tab-sticky-hover);
     color: var(--text-near-white);
   }
 }

--- a/dashboard_bonsai/src/tokens.ml
+++ b/dashboard_bonsai/src/tokens.ml
@@ -336,6 +336,7 @@ type semantic =
   | `Scrim
   | `Scrim_strong
   | `Scrim_brass
+  | `Bg_tab_sticky_hover
   | `Motion_enter
   | `Motion_exit
   | `Motion_swap
@@ -711,6 +712,7 @@ let name_of = function
   | `Scrim -> "scrim"
   | `Scrim_strong -> "scrim-strong"
   | `Scrim_brass -> "scrim-brass"
+  | `Bg_tab_sticky_hover -> "bg-tab-sticky-hover"
   | `Motion_enter -> "motion-enter"
   | `Motion_exit -> "motion-exit"
   | `Motion_swap -> "motion-swap"

--- a/dashboard_bonsai/src/tokens.mli
+++ b/dashboard_bonsai/src/tokens.mli
@@ -347,6 +347,7 @@ type semantic =
   | `Scrim
   | `Scrim_strong
   | `Scrim_brass
+  | `Bg_tab_sticky_hover
   | `Motion_enter
   | `Motion_exit
   | `Motion_swap


### PR DESCRIPTION
## Summary

Single-token addition + use-site replacement. Eliminates the only raw
\`rgba(30, 41, 59, 0.95)\` literal in \`tools.css\` (\`tool-back-to-top\`
hover backdrop) by introducing a new role token \`--color-bg-tab-sticky-hover\`
(slate-800 / 95%) in \`source.ts\` and running codegen.

## Why

W11 (Phase 1) audit listed this rgba as one of four \"Phase 2 candidates\"
for tools.css. \`--ok-35\` (#11471), \`--scrim-strong\` + \`--z-overlay-keeper\`
(#11513) already shipped under the same governance pattern; this is the
next small one.

## Pattern

Same as #11513 (Track F single-token PR):

- Define in \`design-system/tokens/source.ts\` (SSOT)
- \`pnpm tokens:build\` regenerates the seven downstream artifacts
- Replace use-site \`rgba(...)\` → \`var(--color-bg-tab-sticky-hover)\`

**Single-SSOT note**: the new token is defined in \`source.ts\` only and
not duplicated into \`variables.css\`. The CSS \`@import\` order in
\`global.css\` is \`tokens.generated.css\` → \`variables.css\`, so the
codegen output is the actual cascade source for any token not
overridden by hand. Adding the token to source.ts only keeps the SSOT
tight — per the Phase 0 finding on second-axis SSOT drift.

## Out of scope

- \`--scrim-strong\` second-axis drift (source.ts: \`.7\` vs variables.css: \`.6\`,
  variables.css winning by import order) — separate concern, will track
  if a fix is warranted.
- variables.css absorption (40+ hex) — large multi-PR migration.

## Test plan

- [x] \`pnpm tokens:check\` — passes (status canon + keeper ΔE)
- [x] \`pnpm lint\` — clean
- [x] \`pnpm build\` — clean
- [ ] Reviewer: confirm \`tool-back-to-top:hover\` backdrop renders
      identically (slate-800 with 95% alpha = unchanged visual)

## Files

- \`dashboard/design-system/tokens/source.ts\` — +2 lines (token + comment)
- \`dashboard/src/styles/tools.css\` — 1 line replaced
- 6 codegen outputs auto-regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)