### PR TITLE
feat(prompt): add prompt_defaults.mli — typed bootstrap surface (cycle 55)

### DIFF
--- a/lib/prompt_defaults.mli
+++ b/lib/prompt_defaults.mli
@@ -1,0 +1,49 @@
+(** Prompt_defaults — auto-discover prompt metadata from markdown
+    frontmatter and register it with {!Prompt_registry}.
+
+    [bootstrap_runtime] is called once during server startup; it
+    resolves the prompt markdown directory, points
+    {!Prompt_registry} at it, loads every markdown file with YAML
+    frontmatter ([description] / [category] /
+    [template_variables]), and replays any persisted operator
+    overrides. The signature is memoised so a re-call with the
+    same [(workspace_path, prompt_markdown_dir)] pair is a no-op
+    — useful when the bootstrap is wired into multiple lifecycle
+    points.
+
+    Internal helpers (the [existing_dir] predicate, the
+    [prompt_markdown_dir_candidates] list, and the
+    [bootstrapped_signature] memo ref) are hidden — callers
+    consume only the three entry points below. *)
+
+val init : unit -> unit
+(** Re-scan the currently-configured markdown directory and
+    register all prompts that have YAML frontmatter. Used by
+    tests after a manual [Prompt_registry.set_markdown_dir] call;
+    no-op when no directory is configured. *)
+
+val resolve_prompt_markdown_dir :
+  workspace_path:string ->
+  base_path:string ->
+  string
+(** Pick the prompt markdown directory for a given workspace.
+    Currently always returns [Config_dir_resolver.prompts_dir ()]
+    (both for the resolved candidate and the fallback) — the
+    parameters are accepted for forward compatibility with
+    workspace-scoped overrides and exercised directly by the
+    [test_server_runtime_bootstrap] suite. *)
+
+val bootstrap_runtime :
+  workspace_path:string ->
+  base_path:string ->
+  string
+(** Resolve the markdown directory, point {!Prompt_registry} at
+    it, load every prompt file, and restore persisted operator
+    overrides. Returns the resolved directory path.
+
+    Idempotent on the [(workspace_path, prompt_markdown_dir)]
+    pair — repeated calls with the same arguments skip the
+    registry mutation and override replay. [Eio.Cancel.Cancelled]
+    is propagated; any other exception during override restore
+    is logged via [Log.Misc.error] and swallowed so a corrupt
+    override file cannot bring the boot path down. *)


### PR DESCRIPTION
## Summary

Cycle 55 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/prompt_defaults.ml` (46 lines).

Surface (3 entries):
- `init : unit -> unit`
- `resolve_prompt_markdown_dir
    : workspace_path:string -> base_path:string -> string`
- `bootstrap_runtime
    : workspace_path:string -> base_path:string -> string`

Hidden internals:
- `existing_dir` — filesystem predicate
- `prompt_markdown_dir_candidates` — resolution candidate list
- `bootstrapped_signature` — memo ref

## Why typed surface

`bootstrap_runtime` returns the resolved markdown directory so
the boot path can log it. Pinning the return type to `string`
prevents a future refactor (e.g. returning a richer summary
record) from silently widening the contract. The
`Eio.Cancel.Cancelled` propagation rule (raised through, not
caught) is documented at the contract seam — callers must
understand the restore-override path is interruptible by an
ambient cancel.

## Caller audit (`rg "Prompt_defaults\\."`)
- `lib/server/server_runtime_bootstrap.ml` — `bootstrap_runtime`
- `test/test_server_runtime_bootstrap.ml` — 4 calls to
  `resolve_prompt_markdown_dir`
- `test/test_keeper_unified.ml`, `test_keeper_deliberation.ml`,
  `test_prompt_registry_defaults.ml` — `init`

No external reference to `existing_dir` /
`prompt_markdown_dir_candidates` / `bootstrapped_signature`.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
