### PR TITLE
feat(mcp): add mcp_server_eio_helpers.mli — typed SSE wait/log surface (cycle 56)

### DIFF
--- a/lib/mcp_server_eio_helpers.mli
+++ b/lib/mcp_server_eio_helpers.mli
@@ -1,0 +1,41 @@
+(** Mcp_server_eio_helpers — small utility functions extracted
+    from [mcp_server_eio.ml] so [mcp_server_eio.ml] and
+    [tool_inline_dispatch.ml] can share them without a circular
+    dependency.
+
+    Both helpers re-raise [Eio.Cancel.Cancelled] so an ambient
+    cancel is propagated, then catch and log every other
+    exception so a single bad message cannot bring the SSE loop
+    down. *)
+
+val log_mcp_exn : label:string -> exn -> unit
+(** Log an MCP server error via [Log.Mcp.info]. The line is
+    prefixed with ["[UNEXPECTED] "] for any exception outside the
+    expected set ([Sys_error] / [Failure] / [Not_found] /
+    [End_of_file] / [Yojson.Json_error] /
+    [Yojson.Safe.Util.Type_error]) — the prefix is what
+    operators grep for in production logs to find genuine
+    surprises versus routine I/O / parse failures. *)
+
+val wait_for_message_eio :
+  clock:_ Eio.Time.clock ->
+  Session.registry ->
+  agent_name:string ->
+  timeout:float ->
+  Yojson.Safe.t option
+(** Poll the session registry for a queued message for
+    [agent_name], sleeping [2.0] s between polls via
+    [Eio.Time.sleep], up to [timeout] seconds elapsed.
+
+    Side effects:
+    - Registers the agent's session if absent (failures are
+      logged via {!log_mcp_exn} and swallowed).
+    - Marks the session as listening for the duration of the
+      wait and clears the flag on every exit path
+      (timeout, message, exception, cancel).
+
+    Returns:
+    - [Some msg] when a message arrived before the deadline;
+    - [None] on timeout, on [register]-failure mid-wait, or on a
+      non-cancel exception during the loop;
+    - [Eio.Cancel.Cancelled] is propagated unchanged. *)


### PR DESCRIPTION
## Summary

Cycle 56 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/mcp_server_eio_helpers.ml` (47
lines).

Surface (2 entries — exhaustive, no internals to hide):
- `log_mcp_exn : label:string -> exn -> unit`
- `wait_for_message_eio :
    clock:_ Eio.Time.clock -> Session.registry ->
    agent_name:string -> timeout:float ->
    Yojson.Safe.t option`

## Why typed surface

Two operationally observable behaviours are pinned at the
contract seam:

1. **`[UNEXPECTED] ` prefix semantics** — the prefix is what
   operators grep for in production logs to separate genuine
   surprises from routine I/O / parse failures
   (`Sys_error` / `Failure` / `Not_found` / `End_of_file` /
   `Yojson.Json_error` / `Yojson.Safe.Util.Type_error`). A
   future refactor that adds a level argument or returns a
   structured record would silently break log scrapers.

2. **`Eio.Cancel.Cancelled` propagation** — both helpers
   re-raise `Eio.Cancel.Cancelled` so an ambient cancel keeps
   SSE clients responsive to fiber cancellation. The cancel-vs-
   swallow asymmetry is documented in the docstring so a
   reviewer does not "fix" it into a broad catch.

## Caller audit (`rg "Mcp_server_eio_helpers\\."`)
- `lib/mcp_server_eio_execute.ml` — both bindings re-bound at
  top-level (`let log_mcp_exn = ...` / `let wait_for_message_eio
  = ...`) so the caller surface stays decoupled.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
