### PR TITLE
feat(autonomous): Tier B3 — Autonomous_phase taxonomy (Cycle 21)

### DIFF
--- a/lib/autonomous/autonomous_phase.ml
+++ b/lib/autonomous/autonomous_phase.ml
@@ -1,0 +1,58 @@
+(* Autonomous_phase — sub-phase taxonomy for the autonomous loop.
+   Cycle 21 / Tier B3.
+
+   See autonomous_phase.mli for the design rationale, especially the
+   note on why [tag] mirrors the phantom witness set. *)
+
+(* ── Phantom witness types ─────────────────────────────────────────
+   Empty-variant declarations (no inhabitants). External call sites
+   see them as abstract. Internal use is purely type-level — no value
+   of these types is ever constructed. *)
+type idle = |
+type perceiving = |
+type intending = |
+type planning = |
+type executing = |
+type verifying = |
+type reflecting = |
+type adapting = |
+
+(* ── Phase tag (runtime mirror) ─────────────────────────────────── *)
+type tag =
+  | Tag_idle [@tla.symbol "idle"]
+  | Tag_perceiving [@tla.symbol "perceiving"]
+  | Tag_intending [@tla.symbol "intending"]
+  | Tag_planning [@tla.symbol "planning"]
+  | Tag_executing [@tla.symbol "executing"]
+  | Tag_verifying [@tla.symbol "verifying"]
+  | Tag_reflecting [@tla.symbol "reflecting"]
+  | Tag_adapting [@tla.symbol "adapting"]
+[@@deriving tla]
+
+(* ── Existential phase wrapper ─────────────────────────────────── *)
+type _ any =
+  | Any_idle : idle any
+  | Any_perceiving : perceiving any
+  | Any_intending : intending any
+  | Any_planning : planning any
+  | Any_executing : executing any
+  | Any_verifying : verifying any
+  | Any_reflecting : reflecting any
+  | Any_adapting : adapting any
+
+(* GADT pattern matching requires the locally-abstract-type
+   annotation [type a.] so each constructor's narrowing of 'a is
+   accepted by the type checker. The body uses no payload, so each
+   arm reduces to a constant tag. *)
+let any_to_tag : type a. a any -> tag = function
+  | Any_idle -> Tag_idle
+  | Any_perceiving -> Tag_perceiving
+  | Any_intending -> Tag_intending
+  | Any_planning -> Tag_planning
+  | Any_executing -> Tag_executing
+  | Any_verifying -> Tag_verifying
+  | Any_reflecting -> Tag_reflecting
+  | Any_adapting -> Tag_adapting
+
+let any_to_string : type a. a any -> string =
+ fun any -> to_tla_symbol (any_to_tag any)

--- a/lib/autonomous/autonomous_phase.mli
+++ b/lib/autonomous/autonomous_phase.mli
@@ -1,0 +1,92 @@
+(** Autonomous_phase — sub-phase taxonomy for the autonomous loop.
+
+    Cycle 21 / Tier B3 — first cut.
+
+    {1 Scope of this PR}
+
+    - 8 phantom witness types ([idle], [perceiving], [intending],
+      [planning], [executing], [verifying], [reflecting], [adapting])
+      that exist purely as compile-time tags carried by the [_ any]
+      GADT and the [Autonomous_state] context indices.
+    - {!tag} regular variant for runtime indexing + ppx_tla derive parity.
+    - {!any} 1-parameter GADT existential wrapping each phantom type.
+    - {!any_to_tag} / {!any_to_string} projections.
+
+    {1 Deferred to Tier B5}
+
+    - The [('from, 'to_) transition] GADT (19 valid-transition witnesses).
+    - Runtime [can_transition] check.
+    - Hand-written [transition_to_string].
+
+    {1 Why a separate [tag] type?}
+
+    The {!any} GADT is a 1-parameter existential whose constructors
+    each specialise the type parameter to a different phantom witness
+    (e.g. [Any_idle : idle any]). The current [ppx_tla] deriver
+    cannot emit [to_tla_symbol] for this shape — Tier I8 deferred
+    1+ parameter non-phantom GADTs, and Tier I9's
+    [\[@@tla.phantom_param\]] only applies when no constructor
+    specialises the parameter.
+
+    Rather than hand-write a parallel [to_tla_symbol_any] that drifts
+    against the phantom type set, we mirror the witnesses as a regular
+    variant {!tag}, derive the symbol mapping there, and project from
+    the GADT to the tag in [any_to_tag]. The single source of truth
+    for phase symbol names is the [\[@tla.symbol\]] override on each
+    {!tag} constructor. *)
+
+(** {1 Phantom witness types}
+
+    These types have no inhabitants — they exist purely as type-level
+    tags. Their abstract status prevents external code from
+    fabricating phase witnesses outside this module. *)
+
+type idle
+type perceiving
+type intending
+type planning
+type executing
+type verifying
+type reflecting
+type adapting
+
+(** {1 Phase tag (runtime mirror of the witness type set)}
+
+    Each phantom witness type has a corresponding {!tag} constructor.
+    The deriver emits [to_tla_symbol], [all_symbols], and [all_states]
+    on this type; the GADT {!any} projects to {!tag} via
+    {!any_to_tag}. *)
+type tag =
+  | Tag_idle [@tla.symbol "idle"]
+  | Tag_perceiving [@tla.symbol "perceiving"]
+  | Tag_intending [@tla.symbol "intending"]
+  | Tag_planning [@tla.symbol "planning"]
+  | Tag_executing [@tla.symbol "executing"]
+  | Tag_verifying [@tla.symbol "verifying"]
+  | Tag_reflecting [@tla.symbol "reflecting"]
+  | Tag_adapting [@tla.symbol "adapting"]
+[@@deriving tla]
+
+(** {1 Existential phase wrapper}
+
+    [_ any] binds a runtime phase value to a compile-time-checked
+    phantom witness. [Autonomous_state.t] (Tier B4) carries values of
+    type ['phase any] to ensure that phase-indexed contexts cannot be
+    mismatched at runtime. *)
+type _ any =
+  | Any_idle : idle any
+  | Any_perceiving : perceiving any
+  | Any_intending : intending any
+  | Any_planning : planning any
+  | Any_executing : executing any
+  | Any_verifying : verifying any
+  | Any_reflecting : reflecting any
+  | Any_adapting : adapting any
+
+val any_to_tag : 'a any -> tag
+(** Project a phase witness to its runtime tag. *)
+
+val any_to_string : 'a any -> string
+(** Canonical lowercase phase name. Equivalent to
+    [to_tla_symbol (any_to_tag x)] — exposed as a convenience and
+    so call sites do not need to know about the {!tag} type. *)

--- a/lib/autonomous/dune
+++ b/lib/autonomous/dune
@@ -1,0 +1,7 @@
+(include_subdirs no)
+
+(library
+ (name autonomous)
+ (public_name masc_mcp.autonomous)
+ (preprocess
+  (pps ppx_tla)))

--- a/test/autonomous/dune
+++ b/test/autonomous/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_autonomous_phase)
+ (libraries autonomous))

--- a/test/autonomous/test_autonomous_phase.ml
+++ b/test/autonomous/test_autonomous_phase.ml
@@ -1,0 +1,92 @@
+(* Cycle 21 / Tier B3 tests — Autonomous_phase tag derivation + any
+   GADT projections.
+
+   Validates:
+   - [tag]-level [@@deriving tla] correctness ([to_tla_symbol],
+     [all_symbols], [all_states])
+   - 8-element completeness of the phase set
+   - [any_to_tag] one-to-one mapping
+   - [any_to_string] equivalence to [to_tla_symbol (any_to_tag _)] *)
+
+open Autonomous.Autonomous_phase
+
+(* ─── Tag-level deriver output (Tier I7 records / I8 GADT independent;
+   exercised here through a regular variant with [@tla.symbol] override) *)
+
+let test_tag_to_tla_symbol () =
+  assert (to_tla_symbol Tag_idle = "idle");
+  assert (to_tla_symbol Tag_perceiving = "perceiving");
+  assert (to_tla_symbol Tag_intending = "intending");
+  assert (to_tla_symbol Tag_planning = "planning");
+  assert (to_tla_symbol Tag_executing = "executing");
+  assert (to_tla_symbol Tag_verifying = "verifying");
+  assert (to_tla_symbol Tag_reflecting = "reflecting");
+  assert (to_tla_symbol Tag_adapting = "adapting")
+
+let test_all_symbols_order () =
+  assert (
+    all_symbols
+    = [ "idle";
+        "perceiving";
+        "intending";
+        "planning";
+        "executing";
+        "verifying";
+        "reflecting";
+        "adapting";
+      ])
+
+let test_all_states_count () = assert (List.length all_states = 8)
+
+let test_all_states_first_and_last () =
+  match all_states with
+  | first :: _ -> assert (first = Tag_idle)
+  | [] -> assert false
+
+(* ─── any GADT projection ─────────────────────────────────────────── *)
+
+let test_any_to_tag () =
+  assert (any_to_tag Any_idle = Tag_idle);
+  assert (any_to_tag Any_perceiving = Tag_perceiving);
+  assert (any_to_tag Any_intending = Tag_intending);
+  assert (any_to_tag Any_planning = Tag_planning);
+  assert (any_to_tag Any_executing = Tag_executing);
+  assert (any_to_tag Any_verifying = Tag_verifying);
+  assert (any_to_tag Any_reflecting = Tag_reflecting);
+  assert (any_to_tag Any_adapting = Tag_adapting)
+
+let test_any_to_string () =
+  assert (any_to_string Any_idle = "idle");
+  assert (any_to_string Any_perceiving = "perceiving");
+  assert (any_to_string Any_intending = "intending");
+  assert (any_to_string Any_planning = "planning");
+  assert (any_to_string Any_executing = "executing");
+  assert (any_to_string Any_verifying = "verifying");
+  assert (any_to_string Any_reflecting = "reflecting");
+  assert (any_to_string Any_adapting = "adapting")
+
+(* ─── Round-trip: any_to_string = to_tla_symbol ∘ any_to_tag ───── *)
+
+let test_any_string_via_tag () =
+  let pairs : (string * tag) list =
+    [ ("idle", Tag_idle);
+      ("perceiving", Tag_perceiving);
+      ("intending", Tag_intending);
+      ("planning", Tag_planning);
+      ("executing", Tag_executing);
+      ("verifying", Tag_verifying);
+      ("reflecting", Tag_reflecting);
+      ("adapting", Tag_adapting);
+    ]
+  in
+  List.iter (fun (sym, tag) -> assert (to_tla_symbol tag = sym)) pairs
+
+let () =
+  test_tag_to_tla_symbol ();
+  test_all_symbols_order ();
+  test_all_states_count ();
+  test_all_states_first_and_last ();
+  test_any_to_tag ();
+  test_any_to_string ();
+  test_any_string_via_tag ();
+  print_endline "test_autonomous_phase: all assertions passed"


### PR DESCRIPTION
## Summary

Cycle 21 first PR — greenfield `lib/autonomous/` sub-library, first cut. Establishes the 8-phase witness-type set, runtime [tag] mirror with [@@deriving tla], and the [_ any] existential GADT wrapper that downstream tiers (B4 Autonomous_state, B5 transition GADT, A4 Autonomous_bridge) build on.

## Module surface

- **8 phantom witness types** (`idle`, `perceiving`, `intending`, `planning`, `executing`, `verifying`, `reflecting`, `adapting`): empty-variant declarations, abstract from outside.
- **`tag` regular variant** mirroring the witness set. Each constructor carries `[@tla.symbol "..."]` so `to_tla_symbol Tag_idle = "idle"` rather than the default `"tag_idle"`. The deriver emits `to_tla_symbol`, `all_symbols`, `all_states`.
- **`_ any` 1-parameter GADT existential** with 8 constructors that each specialise the index to one phantom witness (e.g. `Any_idle : idle any`).
- **Hand-written projections**: `any_to_tag : 'a any -> tag` and `any_to_string : 'a any -> string`.

## Why a separate `tag` type?

The `_ any` GADT is a non-phantom 1+ parameter GADT (each constructor specialises the index), which Tier I8 deferred and Tier I9's `[@@tla.phantom_param]` does not cover. Rather than hand-write a `to_tla_symbol_any` that drifts against the witness set, we mirror the witnesses as a regular variant, derive the symbol mapping there, and project `any -> tag` in `any_to_tag`. The single source of truth for phase symbols is the `[@tla.symbol]` override on each `tag` constructor.

## Test plan
- [x] `dune build --root . lib/autonomous/` GREEN
- [x] `dune build --root . test/autonomous/` GREEN
- [x] `dune runtest --root . test/autonomous/ --force` — 7 assertions GREEN:
  - `to_tla_symbol` correct for all 8 tag constructors
  - `all_symbols` order + 8-element list
  - `all_states` count + first element
  - `any_to_tag` one-to-one across all 8
  - `any_to_string` direct values
  - round-trip equivalence `any_to_string = to_tla_symbol ∘ any_to_tag`
- [x] No regression: shared_types (43 tests) + ppx_tla (4 suites: basic + records + gadt + phantom_param) all GREEN

## Out of scope (deferred per plan §2.2)

- **Tier B4**: `Autonomous_state.t` phase-indexed context record carrying ['phase any] + immutable transition history.
- **Tier B5**: `('from, 'to_) transition` GADT (19 valid-transition witnesses) + hand-written `transition_to_string` + `can_transition` runtime check.

## Plan reference
`planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-temporal-stream.md` §2.2 Tier B3 — opens Cycle 21 by creating the layer that B4/B5/A4 extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)