### PR TITLE
feat(http): add http_protocol_detect.mli — typed h2c preface peek surface (cycle 57)

### DIFF
--- a/lib/http_protocol_detect.mli
+++ b/lib/http_protocol_detect.mli
@@ -1,0 +1,51 @@
+(** Http_protocol_detect — branch a freshly-accepted TCP socket
+    between HTTP/1.1 and HTTP/2 (h2c, prior-knowledge) by peeking
+    the connection preface.
+
+    HTTP/2 clients using prior knowledge open with the 24-byte
+    preface starting [PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n]. The
+    detector reads the first 14 bytes via [Unix.recv MSG_PEEK]
+    so the data stays in the kernel buffer and the chosen
+    backend (httpun-eio or h2-eio) reads it normally afterwards.
+
+    Internal helpers (the [h2_preface_prefix] string constant
+    and the [h2_preface_len] derived integer) are hidden —
+    callers consume only the [protocol] variant, the two
+    detector entry points, and the printable converter. *)
+
+type protocol =
+  | Http1
+  | Http2
+
+val detect_from_fd :
+  Unix.file_descr ->
+  (protocol, string) result
+(** [detect_from_fd fd] peeks the first bytes of [fd] using
+    [MSG_PEEK] and classifies the protocol.
+
+    Returns [Ok Http2] when the peek matches the H2 preface
+    prefix, [Ok Http1] for any other observed bytes (including
+    a partial read shorter than the preface — any valid H2
+    client sends the full preface immediately).
+
+    [Ok Http1] is also returned for [EAGAIN] / [EWOULDBLOCK]
+    on a non-blocking socket — an in-flight HTTP/1.1 request
+    is the most likely cause.
+
+    Returns [Error msg] for [recv = 0] (peer closed before
+    sending) and for any other [Unix.Unix_error]
+    (formatted via [Unix.error_message]). *)
+
+val detect :
+  _ Eio.Net.stream_socket ->
+  (protocol, string) result
+(** Eio adapter around {!detect_from_fd}: extracts the underlying
+    [Unix.file_descr] via [Eio_unix.Resource.fd_opt] and runs the
+    peek under [Eio_unix.Fd.use_exn "protocol_detect"].
+
+    Returns [Error "no Unix FD available on this socket"] when
+    the flow has no Unix FD (e.g. an in-memory transport). *)
+
+val protocol_to_string : protocol -> string
+(** ["HTTP/1.1"] / ["HTTP/2"] — printable form for log lines and
+    metric labels. *)


### PR DESCRIPTION
## Summary

Cycle 57 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/http_protocol_detect.ml` (64 lines).

Surface:
- `type protocol = Http1 | Http2`
- `detect_from_fd : Unix.file_descr -> (protocol, string) result`
- `detect : _ Eio.Net.stream_socket -> (protocol, string) result`
- `protocol_to_string : protocol -> string`

Hidden internals:
- `h2_preface_prefix` — `"PRI * HTTP/2.0"` 14-byte sentinel
- `h2_preface_len` — derived `String.length`

## Why this module needs a typed surface

The detector branches every TCP connection between
`httpun-eio` (HTTP/1.1) and `h2-eio` (HTTP/2 prior knowledge).
Edge-case behaviour is operationally load-bearing — a silent
mis-classification breaks the connection or downgrades a
client. The `.mli` pins four observable rules at the contract
seam so future refactors fail here, not on production traffic:

1. **Partial peek (< 14 bytes)** → `Ok Http1`
2. **`EAGAIN` / `EWOULDBLOCK`** on non-blocking sockets →
   `Ok Http1`
3. **`recv = 0`** → `Error "connection closed before protocol
   detection"`
4. **Other `Unix_error`** → `Error` formatted via
   `Unix.error_message`

Pinning the variant as `Http1 | Http2` (not exposed as a poly
variant or open variant) means a future "classify gRPC too"
refactor must extend the type — failing every match site rather
than silently widening behaviour.

## Caller audit (`rg "Http_protocol_detect"`)
- `lib/server/server_bootstrap_http.ml` — `detect` + pattern
  matches on `Http1` / `Http2`
- `test/test_http_protocol_detect.ml` — `detect_from_fd` +
  variant matches across socket-pair fixtures

No external reference to `h2_preface_prefix` /
`h2_preface_len`.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI) — `test_http_protocol_detect`
      exercises both variants and the partial-peek path
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
