### PR TITLE
feat(server): add shutdown_hooks.mli — typed graceful-shutdown surface (cycle 58)

### DIFF
--- a/lib/shutdown_hooks.mli
+++ b/lib/shutdown_hooks.mli
@@ -1,0 +1,42 @@
+(** Shutdown_hooks — centralised graceful shutdown sequencer.
+
+    Wired into the SIGINT / SIGTERM signal handlers in
+    [bin/main_eio] and [bin/main_stdio_eio]; cancels the
+    orchestrator first, then drains SSE / WebSocket sessions,
+    flushes metric / stress buffers, and clears transient A2A and
+    session-identity state. Each step is timed via
+    [Unix.gettimeofday] and logged through [Log.Server.info] so
+    operators can attribute slow shutdowns to a specific stage.
+
+    Internal state (the [cancel_orchestrator_ref] WORM
+    [Atomic.t (unit -> unit) option]) is hidden — callers consume
+    only the registration entry point and the runner.
+
+    @since 0.5.0 *)
+
+val register_cancel_orchestrator : (unit -> unit) -> unit
+(** Stash the orchestrator-cancel function for {!run_all} to
+    invoke first during shutdown. The slot is a single-writer
+    [Atomic.t]; calling [register_cancel_orchestrator] more than
+    once silently overwrites the previous value (last-writer
+    wins), matching the existing single-bootstrap pattern. *)
+
+val run_all : unit -> unit
+(** Run the shutdown sequence in order:
+
+    1. Cancel the registered orchestrator (if any).
+    2. Close every SSE client via [Sse.close_all_clients].
+    3. Close every WebSocket session via
+       [Server_mcp_transport_ws.close_all].
+    4. Flush [Heuristic_metrics] and [Agent_stress] buffers
+       (Eio.Cancel.Cancelled re-raised; any other exception is
+       logged at warn and swallowed so a partial flush failure
+       cannot block shutdown of the rest of the chain).
+    5. Clear [A2a_tools] transient state.
+    6. Clear [Agent_registry_eio] session caches.
+
+    Each step's elapsed time and (where applicable) the count of
+    affected resources are logged. The function never raises
+    except for [Eio.Cancel.Cancelled], which is re-raised with
+    its original backtrace so the parent fiber observes the
+    cancel cleanly. *)


### PR DESCRIPTION
## Summary

Cycle 58 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/shutdown_hooks.ml` (61 lines).

Surface (2 entries):
- `register_cancel_orchestrator : (unit -> unit) -> unit`
- `run_all                      : unit -> unit`

Hidden internals:
- `cancel_orchestrator_ref` — WORM `Atomic.t (unit -> unit) option`

## Why typed surface

The shutdown sequence is operationally load-bearing — its order
determines whether SSE clients receive close frames before the
process exits, whether metric buffers reach disk, and whether
A2A transient state is freed before the final exit. The
docstring pins:

1. **6-step ordering** — orchestrator cancel → SSE close →
   WebSocket close → metric/stress flush → A2A clear → session
   cache clear.
2. **Per-step exception policy** —
   `Eio.Cancel.Cancelled` is re-raised with the original
   backtrace via `Printexc.raise_with_backtrace`; any other
   exception during `Heuristic_metrics.flush` /
   `Agent_stress.flush` / `A2a_tools.clear_transient_state` is
   logged at warn and swallowed so a partial flush failure
   cannot block shutdown of the rest of the chain.
3. **`register_cancel_orchestrator` last-writer-wins** — the
   WORM atomic name suggests "no overwrites", but the actual
   `Atomic.set` in the body permits re-registration. The `.mli`
   documents the behaviour explicitly so operators are not
   surprised mid-incident.

## Caller audit (`rg "Shutdown_hooks\\."`)
- `bin/main_eio.ml` — `Shutdown_hooks.run_all` in the SIGINT
  handler
- `bin/main_stdio_eio.ml` — `Shutdown_hooks.run_all` on EOF
- `lib/server/server_bootstrap_loops.ml` —
  `Shutdown_hooks.register_cancel_orchestrator` after
  orchestrator init

No external reference to `cancel_orchestrator_ref`.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
