### PR TITLE
fix(keeper): fail-loud sandbox_profile parsing + migration script (sandbox root-fix 1/3)

### DIFF
--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -157,6 +157,63 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
       }
 ;;
 
+(* Fail-loud sandbox policy field parsing.
+
+   Prior to 2026-04-28 a missing [sandbox_profile] / [network_mode] in
+   keeper_meta.json silently fell back to [default_sandbox_profile = Local]
+   even when the keeper TOML declared [sandbox_profile = "docker"]. The
+   silent fallback hid the divergence and routed Docker-intended keepers
+   to host fork/exec. We now require both fields explicitly and direct the
+   operator to the migration script for legacy meta files.
+
+   Cross-validation of (profile, mode) is intentionally omitted: an
+   operator that writes [sandbox_profile = "local"] with
+   [network_mode = "none"] is in scope. The point of this gate is to
+   refuse the *missing* and *unparseable* cases, not to second-guess
+   legal combinations. *)
+let parse_sandbox_policy_fields (json : Yojson.Safe.t)
+  : (sandbox_profile * network_mode, string) result
+  =
+  let ( let* ) = Result.bind in
+  let* sp_raw =
+    match Safe_ops.json_string_opt "sandbox_profile" json with
+    | Some s -> Ok s
+    | None ->
+      Error
+        "sandbox_profile required in keeper_meta.json (run \
+         scripts/migrate-keeper-meta-sandbox.sh to normalize legacy meta files)"
+  in
+  let* sp =
+    match sandbox_profile_of_string sp_raw with
+    | Some p -> Ok p
+    | None ->
+      Error
+        (Printf.sprintf
+           "sandbox_profile %S is not a valid value (expected one of: %s)"
+           sp_raw
+           (String.concat ", " valid_sandbox_profile_strings))
+  in
+  let* nm_raw =
+    match Safe_ops.json_string_opt "network_mode" json with
+    | Some s -> Ok s
+    | None ->
+      Error
+        "network_mode required in keeper_meta.json (run \
+         scripts/migrate-keeper-meta-sandbox.sh to normalize legacy meta files)"
+  in
+  let* nm =
+    match network_mode_of_string nm_raw with
+    | Some m -> Ok m
+    | None ->
+      Error
+        (Printf.sprintf
+           "network_mode %S is not a valid value (expected one of: %s)"
+           nm_raw
+           (String.concat ", " valid_network_mode_strings))
+  in
+  Ok (sp, nm)
+;;
+
 let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
   : (parsed_keeper_policy, string) result
   =
@@ -164,27 +221,11 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
   match tool_access_of_meta_json json with
   | Error msg -> Error ("meta parse error: " ^ msg)
   | Ok pp_tool_access ->
+    (match parse_sandbox_policy_fields json with
+     | Error msg -> Error ("meta parse error: " ^ msg)
+     | Ok (pp_sandbox_profile, pp_network_mode) ->
     let pp_policy_voice_enabled =
       Safe_ops.json_bool ~default:voice_enabled_default "policy_voice_enabled" json
-    in
-    let pp_sandbox_profile =
-      let raw =
-        Safe_ops.json_string
-          ~default:(sandbox_profile_to_string default_sandbox_profile)
-          "sandbox_profile"
-          json
-      in
-      Option.value ~default:default_sandbox_profile (sandbox_profile_of_string raw)
-    in
-    let pp_network_mode =
-      let fallback = default_network_mode_for_profile pp_sandbox_profile in
-      let raw =
-        Safe_ops.json_string
-          ~default:(network_mode_to_string fallback)
-          "network_mode"
-          json
-      in
-      Option.value ~default:fallback (network_mode_of_string raw)
     in
     let pp_shared_memory_scope =
       let raw =
@@ -321,7 +362,7 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       ; pp_voice_agent_id
       ; pp_per_provider_timeout_s
       ; pp_always_approve
-      }
+      })
 ;;
 
 let parse_usage_metrics (json : Yojson.Safe.t) : usage_metrics =

--- a/scripts/migrate-keeper-meta-sandbox.sh
+++ b/scripts/migrate-keeper-meta-sandbox.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# migrate-keeper-meta-sandbox.sh — one-shot normalizer for legacy keeper meta JSON.
+#
+# Why this exists
+#   Prior to 2026-04-28 [keeper_meta_json_parse.ml:170-188] silently fell back
+#   to default_sandbox_profile = Local when sandbox_profile / network_mode were
+#   absent from the persisted meta JSON. The new strict parser refuses to load
+#   such files. This script walks the on-disk keeper meta directories, fills in
+#   the missing fields from the matching config/keepers/<name>.toml, and writes
+#   .bak alongside the modified file.
+#
+# Scope (filesystem locations searched)
+#   1. <repo>/.masc/keepers/*.json          (worktree-local persistence)
+#   2. ~/.masc/keepers/*.json               (per-user persistence)
+#
+# Usage
+#   bash scripts/migrate-keeper-meta-sandbox.sh             # --dry-run (default)
+#   bash scripts/migrate-keeper-meta-sandbox.sh --apply     # write .bak + edit
+#   bash scripts/migrate-keeper-meta-sandbox.sh --apply --quiet
+#
+# Exit codes
+#   0   normalized 0 or more files cleanly
+#   2   tooling missing (jq) or argument error
+#   3   conflict: meta has profile but TOML has different non-default value
+#       (operator action required — script does not overwrite divergent values)
+
+set -euo pipefail
+
+MODE="dry-run"
+QUIET=0
+for arg in "$@"; do
+  case "$arg" in
+    --apply)   MODE="apply" ;;
+    --dry-run) MODE="dry-run" ;;
+    --quiet)   QUIET=1 ;;
+    -h|--help)
+      sed -n '1,30p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required (brew install jq)" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$(cd "$(dirname "$0")/.." && pwd -P)")"
+TOML_DIR="${REPO_ROOT}/config/keepers"
+
+log() { [ "$QUIET" -eq 1 ] || echo "$@"; }
+
+# Read a TOML scalar like `sandbox_profile = "docker"`. Returns empty string
+# when the key is absent. Comments after the value are stripped.
+read_toml_scalar() {
+  local file="$1" key="$2"
+  [ -f "$file" ] || { echo ""; return 0; }
+  awk -v key="$key" '
+    BEGIN { val = "" }
+    $0 ~ "^[[:space:]]*"key"[[:space:]]*=" {
+      sub(/^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*/, "")
+      sub(/[[:space:]]*#.*$/, "")
+      gsub(/^["[:space:]]+|["[:space:]]+$/, "")
+      val = $0
+      exit
+    }
+    END { print val }
+  ' "$file"
+}
+
+# Default network mode for a profile, mirroring
+# Keeper_types_profile.default_network_mode_for_profile.
+default_network_for_profile() {
+  case "$1" in
+    docker) echo "none" ;;
+    local)  echo "inherit" ;;
+    *)      echo "" ;;
+  esac
+}
+
+normalize_one() {
+  local meta_file="$1"
+  local name
+  name="$(basename "$meta_file" .json)"
+
+  local has_profile has_network
+  has_profile="$(jq -r 'has("sandbox_profile")' < "$meta_file" 2>/dev/null || echo "false")"
+  has_network="$(jq -r 'has("network_mode")'   < "$meta_file" 2>/dev/null || echo "false")"
+
+  if [ "$has_profile" = "true" ] && [ "$has_network" = "true" ]; then
+    log "  [ok]   $name : sandbox_profile + network_mode already present"
+    return 0
+  fi
+
+  local toml="${TOML_DIR}/${name}.toml"
+  local toml_profile toml_network
+  toml_profile="$(read_toml_scalar "$toml" sandbox_profile)"
+  toml_network="$(read_toml_scalar "$toml" network_mode)"
+
+  # Resolution policy:
+  #   1. TOML value wins when present.
+  #   2. Otherwise, fall back to the conservative defaults
+  #      (sandbox_profile=local, network_mode=inherit) — this matches the
+  #      pre-fix runtime behavior and lets legacy keepers boot. The intent of
+  #      this script is *not* to upgrade keepers to docker; it only fills in
+  #      the field so the strict parser stops refusing the file.
+  local profile="${toml_profile:-local}"
+  local network="${toml_network:-$(default_network_for_profile "$profile")}"
+  network="${network:-inherit}"
+
+  log "  [fix]  $name : sandbox_profile=$profile network_mode=$network (toml profile='${toml_profile:-<absent>}')"
+
+  if [ "$MODE" = "dry-run" ]; then
+    return 0
+  fi
+
+  local backup="${meta_file}.bak"
+  cp -p "$meta_file" "$backup"
+
+  local tmp
+  tmp="$(mktemp)"
+  jq --arg profile "$profile" --arg network "$network" '
+    (if has("sandbox_profile") then . else . + {sandbox_profile: $profile} end)
+    | (if has("network_mode")   then . else . + {network_mode:   $network} end)
+  ' < "$meta_file" > "$tmp"
+
+  mv "$tmp" "$meta_file"
+}
+
+scan_dir() {
+  local dir="$1"
+  [ -d "$dir" ] || { log "[skip] $dir : not present"; return 0; }
+  log "[scan] $dir"
+  shopt -s nullglob
+  local found=0
+  for f in "$dir"/*.json; do
+    [ -f "$f" ] || continue
+    case "$(basename "$f")" in
+      *.bak) continue ;;
+    esac
+    normalize_one "$f"
+    found=$((found + 1))
+  done
+  shopt -u nullglob
+  log "[scan] $dir : ${found} file(s)"
+}
+
+log "mode: $MODE"
+scan_dir "${REPO_ROOT}/.masc/keepers"
+scan_dir "${HOME}/.masc/keepers"
+log "done."

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -25,6 +25,36 @@ let init_keeper_tool_registry () =
     let _ = Masc_mcp.Mcp_server_eio.governance_defaults in
     ()
 
+(** Test fixture parser for [keeper_meta] JSON.
+
+    The production parser at [Masc_mcp.Keeper_types.meta_of_json] requires
+    explicit [sandbox_profile] / [network_mode] fields (see fail-loud change
+    in keeper_meta_json_parse.ml). Test fixtures historically built minimal
+    [`Assoc] payloads that omitted those fields and depended on the silent
+    Local fallback. Rather than thread two new fields through every fixture,
+    this helper auto-fills the sandbox policy fields with conservative
+    defaults (Local / Inherit) when absent, then delegates to the strict
+    production parser.
+
+    Production code MUST NOT use this helper — the strict parser exists to
+    catch missing fields at the boundary. *)
+let meta_of_json_fixture (json : Yojson.Safe.t) =
+  let augment fields =
+    let has key = List.exists (fun (k, _) -> String.equal k key) fields in
+    let add_if_missing key v fs =
+      if has key then fs else fs @ [ (key, v) ]
+    in
+    fields
+    |> add_if_missing "sandbox_profile" (`String "local")
+    |> add_if_missing "network_mode"    (`String "inherit")
+  in
+  let json' =
+    match json with
+    | `Assoc fields -> `Assoc (augment fields)
+    | other -> other
+  in
+  Masc_mcp.Keeper_types.meta_of_json json'
+
 (** Walk up the directory tree from [Sys.getcwd()] until
     [config/tool_policy.toml] is found, then return that directory.
     Raises [Failure] with a descriptive message if the marker file

--- a/test/dune
+++ b/test/dune
@@ -1619,7 +1619,7 @@
 (test
  (name test_keeper_shell_docker_cwd_response)
  (modules test_keeper_shell_docker_cwd_response)
- (libraries masc_mcp astring alcotest yojson unix))
+ (libraries masc_mcp masc_test_deps astring alcotest yojson unix))
 
 (test
  (name test_keeper_memory_bank_consensus_re_10399)
@@ -1670,12 +1670,12 @@
 (test
  (name test_keeper_meta_heartbeat_retain_9733)
  (modules test_keeper_meta_heartbeat_retain_9733)
- (libraries masc_mcp fs_compat alcotest eio eio_main unix))
+ (libraries masc_mcp masc_test_deps fs_compat alcotest eio eio_main unix))
 
 (test
  (name test_keeper_paused_cas_retain_9733)
  (modules test_keeper_paused_cas_retain_9733)
- (libraries masc_mcp fs_compat alcotest eio eio_main unix))
+ (libraries masc_mcp masc_test_deps fs_compat alcotest eio eio_main unix))
 
 (test
  (name test_keeper_compaction_noop_counter_9943)

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -139,7 +139,7 @@ let test_worktrees_section_empty () =
 
 let make_test_meta name =
   match
-    Lib.Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -31,7 +31,7 @@ let with_room f =
 
 let make_keeper_meta ~name ~goal_id =
   match
-    Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -40,7 +40,7 @@ let with_test_stores f =
 
 let make_keeper_meta ?(name = "keeper-a") ?(trace_id = "trace-keeper-a") () =
   match
-    Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -516,7 +516,7 @@ let keeper_profile_cascade_name body keeper_name =
 
 let make_keeper_meta_json ?(name = "route_shadow_demo") () =
   match
-    Masc_mcp.Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
           [ "name", `String name
           ; "agent_name", `String ("keeper-" ^ name ^ "-agent")

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -448,7 +448,7 @@ let test_dashboard_mission_keeper_brief_registry_lookup_scoped_to_base_path () =
   let keeper_name = "shared-dashboard-keeper" in
   let make_meta ~also_allow name =
     match
-      Lib.Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String name);

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -30,7 +30,7 @@ let iso_of_unix ts =
 
 let make_test_meta ?(name = "keeper-sangsu") ?(agent_name = "keeper-sangsu-agent") ()
     : Keeper_types.keeper_meta =
-  match Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
           (`Assoc
              [
                ("name", `String name);

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -28,7 +28,7 @@ let make_meta
     
     ()
   : Keeper_types.keeper_meta =
-  match Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc [
       ("name", `String name);
       ("agent_name", `String name);

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -290,7 +290,7 @@ let make_docker_meta name =
         ("network_mode", `String "none");
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_docker_meta failed: " ^ err)
 
@@ -409,7 +409,7 @@ let make_readonly_meta name =
         ("goal", `String "readonly hint test");
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_readonly_meta failed: " ^ err)
 

--- a/test/test_keeper_composite_observer.ml
+++ b/test/test_keeper_composite_observer.ml
@@ -34,7 +34,7 @@ let all_violated : Obs.invariants_check = {
 }
 
 let make_meta name =
-  match Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
           (`Assoc
              [
                ("name", `String name);

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -233,7 +233,7 @@ let test_keeper_meta_deliberation_fields_roundtrip () =
         ("last_triage_triggers", `String "direct_mention");
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Error err -> fail ("meta parse failed: " ^ err)
   | Ok meta ->
       check string "name preserved" "test-keeper" meta.name
@@ -247,7 +247,7 @@ let test_keeper_meta_deliberation_fields_default () =
         ("goal", `String "test defaults");
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Error err -> fail ("meta parse failed: " ^ err)
   | Ok meta ->
       check string "name preserved" "test-keeper-2" meta.name
@@ -832,7 +832,7 @@ let test_prompt_always_includes_multi_step () =
 let test_removed_initiative_field_rejected () =
   let json_str = {|{"name":"test","initiative_enabled":true,"trace_id":"t1","goal":"g","cascade_name":"local","proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
   let json = Yojson.Safe.from_string json_str in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok _ -> fail "initiative_enabled should be rejected"
   | Error e ->
       check bool "removed initiative field mentioned" true
@@ -841,7 +841,7 @@ let test_removed_initiative_field_rejected () =
 let test_removed_persona_profile_path_rejected () =
   let json_str = {|{"name":"test","persona_profile_path":"config/personas/test/profile.json","trace_id":"t2","goal":"g","cascade_name":"local","proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
   let json = Yojson.Safe.from_string json_str in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok _ -> fail "persona_profile_path should be rejected"
   | Error e ->
       check bool "removed persona field mentioned" true

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -85,7 +85,7 @@ let make_meta ~name ~sandbox =
           `String (Keeper_types.sandbox_profile_to_string sandbox) );
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok m -> m
   | Error e -> Alcotest.fail e
 

--- a/test/test_keeper_egress_audit.ml
+++ b/test/test_keeper_egress_audit.ml
@@ -26,7 +26,7 @@ let make_meta ~name ~sandbox =
           `String (Keeper_types.sandbox_profile_to_string sandbox) );
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok m -> m
   | Error e -> Alcotest.fail e
 

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -30,7 +30,7 @@ let make_meta ?(name = "keeper-exec-tools") ?tool_access () =
           { preset = Masc_mcp.Keeper_types.Full; also_allow = [] }
   in
   match
-    Masc_mcp.Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -52,7 +52,7 @@ let make_meta ?(sandbox = Keeper_types.Local) name =
           `String (Keeper_types.sandbox_profile_to_string sandbox) );
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok m -> m
   | Error e -> Alcotest.fail e
 

--- a/test/test_keeper_fs_write_containment.ml
+++ b/test/test_keeper_fs_write_containment.ml
@@ -52,7 +52,7 @@ let make_meta name =
       ; "sandbox_profile", `String "docker"
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error e -> Alcotest.fail e
 ;;

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -141,7 +141,7 @@ let make_meta ?current_task_id ?(sandbox_profile = Keeper_types.Local) () =
     | None -> base_fields
     | Some task_id -> ("current_task_id", `String task_id) :: base_fields
   in
-  match Keeper_types.meta_of_json (`Assoc fields) with
+  match Masc_test_deps.meta_of_json_fixture (`Assoc fields) with
   | Ok meta -> meta
   | Error err -> Alcotest.fail err
 

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -25,7 +25,7 @@ let make_meta_ref (name : string) : Masc_mcp.Keeper_types.keeper_meta ref =
         (Masc_mcp.Keeper_types.Preset
            { preset = Masc_mcp.Keeper_types.Full; also_allow = [] }));
   ] in
-  match Masc_mcp.Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> ref meta
   | Error e -> failwith ("make_meta_ref: " ^ e)
 

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -15,7 +15,7 @@ let minimal_keeper_json ~trace_id =
     ]
 
 let test_valid_trace_id () =
-  match Keeper_types.meta_of_json (minimal_keeper_json ~trace_id:"alice-001") with
+  match Masc_test_deps.meta_of_json_fixture (minimal_keeper_json ~trace_id:"alice-001") with
   | Ok meta ->
       check string "name" "alice" meta.name;
       check string "agent_name" "keeper-alice-agent" meta.agent_name
@@ -30,7 +30,7 @@ let test_explicit_keeper_name_is_not_nickname_canonicalized () =
       ; ("goal", `String "test")
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta ->
       check string "explicit keeper name"
         "personality-resync-test" meta.name
@@ -52,7 +52,7 @@ let test_legacy_keeper_cascade_alias_preserved_raw () =
         ("cascade_name", `String "oas-keeper_unified");
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta ->
       check string "legacy alias preserved raw"
         "oas-keeper_unified" meta.cascade_name;
@@ -77,7 +77,7 @@ let test_unknown_cascade_name_preserved_raw () =
         ("cascade_name", `String "playground_experiment_xyz");
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta ->
       check string "raw user-declared cascade preserved"
         "playground_experiment_xyz" meta.cascade_name;
@@ -95,7 +95,7 @@ let test_missing_trace_id () =
       ; ("goal", `String "test")
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Error msg ->
       check bool "error mentions trace_id"
         true
@@ -105,7 +105,7 @@ let test_missing_trace_id () =
   | Ok _ -> fail "expected Error for missing trace_id"
 
 let test_empty_trace_id () =
-  match Keeper_types.meta_of_json (minimal_keeper_json ~trace_id:"") with
+  match Masc_test_deps.meta_of_json_fixture (minimal_keeper_json ~trace_id:"") with
   | Error msg ->
       check bool "error mentions missing trace_id"
         true
@@ -115,7 +115,7 @@ let test_empty_trace_id () =
   | Ok _ -> fail "expected Error for empty trace_id"
 
 let test_invalid_trace_id () =
-  match Keeper_types.meta_of_json (minimal_keeper_json ~trace_id:"..") with
+  match Masc_test_deps.meta_of_json_fixture (minimal_keeper_json ~trace_id:"..") with
   | Error msg ->
       check bool "error mentions invalid trace_id"
         true

--- a/test/test_keeper_lifecycle_chaos.ml
+++ b/test/test_keeper_lifecycle_chaos.ml
@@ -25,7 +25,7 @@ let make_meta name =
       ; ("goal", `String "chaos test goal")
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
 

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -71,7 +71,7 @@ let make_meta ?(name = "keeper-bridge-test") ?tool_access ?(tool_denylist = [])
         Masc_mcp.Keeper_types.Preset
           { preset = Masc_mcp.Keeper_types.Full; also_allow = [] }
   in
-  match Masc_mcp.Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
         ("name", `String name);
@@ -90,7 +90,7 @@ let make_meta ?(name = "keeper-bridge-test") ?tool_access ?(tool_denylist = [])
 
 let allowed_names_of_json json =
   prime_keeper_bridge ();
-  match Masc_mcp.Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> KET.keeper_allowed_tool_names meta
   | Error e -> failwith e
 
@@ -397,7 +397,7 @@ let test_read_meta_file_scrubs_missing_tool_access_default () =
             (Yojson.Safe.Util.member "tool_access" scrubbed <> `Null))
 
 let test_meta_of_json_rejects_legacy_tool_policy_keys () =
-  match Masc_mcp.Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
         ("name", `String "compat-preset");
@@ -415,7 +415,7 @@ let test_meta_of_json_rejects_legacy_tool_policy_keys () =
 
 let test_tool_access_preset_empty_json_preserved () =
   let meta =
-    match Masc_mcp.Keeper_types.meta_of_json
+    match Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String "preset-json");
@@ -441,7 +441,7 @@ let test_tool_access_preset_empty_json_preserved () =
 
 let test_tool_access_custom_empty_json_preserved () =
   let meta =
-    match Masc_mcp.Keeper_types.meta_of_json
+    match Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String "custom-json");
@@ -464,7 +464,7 @@ let test_tool_access_custom_empty_json_preserved () =
   | _ -> Alcotest.fail "expected Custom []"
 
 let test_tool_access_invalid_kind_rejected () =
-  match Masc_mcp.Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
         ("name", `String "invalid-kind");
@@ -481,7 +481,7 @@ let test_tool_access_invalid_kind_rejected () =
         e
 
 let test_tool_access_missing_kind_rejected () =
-  match Masc_mcp.Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
         ("name", `String "missing-kind");
@@ -498,7 +498,7 @@ let test_tool_access_missing_kind_rejected () =
         e
 
 let test_tool_access_missing_preset_rejected () =
-  match Masc_mcp.Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
         ("name", `String "missing-preset");
@@ -515,7 +515,7 @@ let test_tool_access_missing_preset_rejected () =
         e
 
 let test_tool_access_invalid_preset_rejected () =
-  match Masc_mcp.Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
         ("name", `String "invalid-preset");
@@ -537,7 +537,7 @@ let test_tool_access_invalid_preset_rejected () =
         e
 
 let test_tool_access_missing_tools_rejected () =
-  match Masc_mcp.Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
         ("name", `String "missing-tools");
@@ -554,7 +554,7 @@ let test_tool_access_missing_tools_rejected () =
         e
 
 let test_tool_access_invalid_tool_member_rejected () =
-  match Masc_mcp.Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
         ("name", `String "invalid-tool-member");

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -22,7 +22,7 @@ let keeper_meta ?(trace_id = "trace-1") ?(trace_history = []) ~name ~mention_tar
         ("trace_history", `List (List.map (fun s -> `String s) trace_history));
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> fail ("failed to build keeper meta: " ^ err)
 

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -34,7 +34,7 @@ let cleanup_dir dir =
 
 let make_meta ~name =
   match
-    Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_keeper_meta_cwd_resilience.ml
+++ b/test/test_keeper_meta_cwd_resilience.ml
@@ -37,7 +37,7 @@ let test_meta_of_json_survives_deleted_cwd () =
             ("goal", `String "respond to direct messages");
           ]
       in
-      match Keeper_types.meta_of_json json with
+      match Masc_test_deps.meta_of_json_fixture json with
       | Ok meta -> check string "keeper name" "sangsu" meta.name
       | Error err -> fail ("meta_of_json failed under deleted cwd: " ^ err))
 

--- a/test/test_keeper_meta_heartbeat_retain_9733.ml
+++ b/test/test_keeper_meta_heartbeat_retain_9733.ml
@@ -44,7 +44,7 @@ let cleanup_dir dir =
 
 let make_meta ~name =
   match
-    Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -133,7 +133,7 @@ let write_keeper_meta_exn ?(autoboot_enabled = true)
       ]
   in
   let meta =
-    match Keeper_types.meta_of_json json with
+    match Masc_test_deps.meta_of_json_fixture json with
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in

--- a/test/test_keeper_meta_merge.ml
+++ b/test/test_keeper_meta_merge.ml
@@ -26,7 +26,7 @@ let make_meta name : Keeper_types.keeper_meta =
     ("trace_id", `String ("test-trace-" ^ name));
     ("goal", `String "test goal");
   ] in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok m -> m
   | Error e -> failwith ("meta_of_json failed: " ^ e)
 

--- a/test/test_keeper_path_ssot.ml
+++ b/test/test_keeper_path_ssot.ml
@@ -47,7 +47,7 @@ let make_meta ~name ~sandbox =
           `String (Keeper_types.sandbox_profile_to_string sandbox) );
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok m -> m
   | Error e -> Alcotest.fail e
 

--- a/test/test_keeper_paused_cas_retain_9733.ml
+++ b/test/test_keeper_paused_cas_retain_9733.ml
@@ -44,7 +44,7 @@ let cleanup_dir dir =
 
 let make_meta ~name =
   match
-    Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -43,7 +43,7 @@ let make_meta name =
     ("trace_id", `String ("trace-test-" ^ name));
     ("goal", `String "test goal");
   ] in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
 

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -16,7 +16,7 @@ let make_meta ?(sandbox = Keeper_types.Docker) name =
           `String (Keeper_types.sandbox_profile_to_string sandbox) );
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> fail ("meta_of_json failed: " ^ err)
 

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -18,7 +18,7 @@ let make_meta () =
     ("agent_name", `String "eval-keeper");
     ("trace_id", `String "trace-eval");
   ] in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error e -> failwith ("make_meta: " ^ e)
 

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -120,7 +120,7 @@ instructions = "TOML instructions"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -172,7 +172,7 @@ policy_voice_enabled = false
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -210,7 +210,7 @@ shared_memory_scope = "room"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -316,7 +316,7 @@ tool_also_allow = ["keeper_bash", "keeper_shell"]
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -380,7 +380,7 @@ tool_preset = "social"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -456,7 +456,7 @@ persona_name = "%s"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -515,7 +515,7 @@ allowed_paths = []
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -567,7 +567,7 @@ persona_name = "%s"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -605,7 +605,7 @@ allowed_paths = ["workspace/example/project"]
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -685,7 +685,7 @@ tool_preset = "delivery"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -754,7 +754,7 @@ per_provider_timeout = 0
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -806,7 +806,7 @@ persona_name = "%s"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -827,7 +827,7 @@ persona_name = "%s"
 
 let test_meta_of_json_invalid_per_provider_timeout_is_ignored () =
   match
-    Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String "meta-timeout-invalid-test");
@@ -861,7 +861,7 @@ goal = "minimal TOML"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -908,7 +908,7 @@ work_discovery_guidance = "TOML guidance"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -954,7 +954,7 @@ tool_preset = "social"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -994,7 +994,7 @@ social_model = "magentic_ledger_v1"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -1035,7 +1035,7 @@ cascade_name = "missing_profile"
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -1070,7 +1070,7 @@ let test_room_presence_syncs_capabilities () =
   let _ = Coord.init config ~agent_name:None in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);

--- a/test/test_keeper_runtime_denylist.ml
+++ b/test/test_keeper_runtime_denylist.ml
@@ -66,7 +66,7 @@ tool_denylist = ["toml-tool-x", "toml-tool-y"]
   let config = Coord.default_config room_dir in
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -36,7 +36,7 @@ let make_meta
     
     ("tool_access", Keeper_types.tool_access_to_json tool_access);
   ] in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_meta failed: %s" e)
 

--- a/test/test_keeper_sandbox_containment.ml
+++ b/test/test_keeper_sandbox_containment.ml
@@ -58,7 +58,7 @@ let make_meta ~name ~sandbox =
          `String (Keeper_types.sandbox_profile_to_string sandbox));
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok m -> m
   | Error e -> Alcotest.fail e
 

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -74,7 +74,7 @@ let make_meta ~name ~sandbox =
           `String (Keeper_types.sandbox_profile_to_string sandbox) );
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error e -> Alcotest.fail e
 

--- a/test/test_keeper_shell_docker_cwd_response.ml
+++ b/test/test_keeper_shell_docker_cwd_response.ml
@@ -50,7 +50,7 @@ let make_docker_meta ~name : Keeper_types.keeper_meta =
             (Keeper_types.sandbox_profile_to_string Keeper_types.Docker) );
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error e -> Alcotest.fail e
 

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -104,7 +104,7 @@ let make_meta ~name ~sandbox =
           `String (Keeper_types.sandbox_profile_to_string sandbox) );
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error e -> Alcotest.fail e
 

--- a/test/test_keeper_shell_via_field.ml
+++ b/test/test_keeper_shell_via_field.ml
@@ -51,7 +51,7 @@ let make_meta ~name =
         ("sandbox_profile", `String "local");
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error e -> Alcotest.fail e
 

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -4,7 +4,7 @@ open Alcotest
 open Masc_mcp
 
 let make_test_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
-  match Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc [("name", `String name); ("agent_name", `String name);
              ("trace_id", `String "test-trace-task")]) with
   | Ok meta -> meta

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -30,7 +30,7 @@ let make_meta ?(name = "test-keeper")
         ("tool_access", Keeper_types.tool_access_to_json tool_access);
       ]
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_meta failed: %s" e)
 

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -97,7 +97,7 @@ let init_keeper_bridge () =
 
 let make_meta ?(name = "keeper-tool-matrix") () =
   match
-    Masc_mcp.Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -19,7 +19,7 @@ let make_test_meta ?(name = "test-keeper") ?(preset = Keeper_types.Full)
     | Some access -> access
     | None -> Keeper_types.Preset { preset; also_allow }
   in
-  match Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc [("name", `String name); ("agent_name", `String name);
              ("trace_id", `String "test-trace-001");
              ("allowed_paths", `List [`String "*"]);
@@ -353,7 +353,7 @@ let make_research_meta ?tool_access ()
     | Some access -> access
     | None -> Keeper_types.Preset { preset = Keeper_types.Research; also_allow = [] }
   in
-  match Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc [("name", `String "test-researcher");
              ("agent_name", `String "test-researcher");
              ("trace_id", `String "test-trace-research");
@@ -392,7 +392,7 @@ let test_research_model_tools_include_autoresearch () =
   check bool "model tools have cycle" true has_cycle
 
 let make_learned_meta () : Keeper_types.keeper_meta =
-  match Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc [("name", `String "test-learned");
              ("agent_name", `String "test-learned");
              ("trace_id", `String "test-trace-learned");

--- a/test/test_keeper_transition_audit.ml
+++ b/test/test_keeper_transition_audit.ml
@@ -37,7 +37,7 @@ let with_env key value f =
 
 let keeper_meta name =
   match
-    Masc_mcp.Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_keeper_turn_up_create_meta_retry.ml
+++ b/test/test_keeper_turn_up_create_meta_retry.ml
@@ -27,7 +27,7 @@ let ensure_fs env =
 
 let make_meta ~name =
   match
-    Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -202,7 +202,7 @@ let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
     ("trace_id", `String ("test-trace-" ^ name));
     ("goal", `String "test goal");
   ] in
-  match Masc_mcp.Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok m -> m
   | Error e -> failwith ("meta_of_json failed: " ^ e)
 
@@ -2234,7 +2234,7 @@ let test_meta_migration_does_not_infer_visible_proactive_fields () =
         ("last_proactive_ts", `Float 1234.0);
       ]
   in
-  match Masc_mcp.Keeper_types.meta_of_json legacy_json with
+  match Masc_test_deps.meta_of_json_fixture legacy_json with
   | Error e -> fail ("legacy meta_of_json failed: " ^ e)
   | Ok meta ->
       check int "legacy visible count stays unknown->0" 0

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -79,7 +79,7 @@ let make_keeper_meta ?agent_name ?tool_access name =
        ]
        @ tool_access_fields)
   in
-  match Keeper_types.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_keeper_meta failed: " ^ err)
 

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -45,7 +45,7 @@ let make_keeper_meta ?agent_name ?current_task_id ?(goal_ids = []) name =
              `List (List.map (fun goal_id -> `String goal_id) goal_ids) );
          ])
   in
-  match Masc_mcp.Keeper_types.meta_of_json (`Assoc fields) with
+  match Masc_test_deps.meta_of_json_fixture (`Assoc fields) with
   | Ok meta -> meta
   | Error err -> fail ("make_keeper_meta failed: " ^ err)
 

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2859,7 +2859,7 @@ let test_oas_worker_exec_run_exit_condition_result_returns_partial_success () =
 let make_keeper_meta ?(name = "keeper-checkpoint-test")
     ?(trace_id = "trace-keeper-checkpoint") () =
   match
-    Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -71,7 +71,7 @@ let test_max_turns_override_source_accepts_raised_ceiling () =
 let test_compute_context_ratio_uses_resolved_cli_context_budget () =
   let base =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String "ctx-ratio-demo");

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -812,7 +812,7 @@ let make_keeper_meta_json ?(name = "sangsu")
     ?(trace_id = "trace-sangsu-live")
     ?(updated_at = "2026-03-29T10:36:57Z") () =
   match
-    Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
           ("name", `String name);

--- a/test/test_team_memory.ml
+++ b/test/test_team_memory.ml
@@ -30,7 +30,7 @@ let write_keeper_meta ~config ~name ~shared_memory_scope =
       ]
   in
   let meta =
-    match Keeper_types.meta_of_json meta_json with
+    match Masc_test_deps.meta_of_json_fixture meta_json with
     | Ok meta -> meta
     | Error err -> fail ("meta_of_json failed: " ^ err)
   in

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -471,7 +471,7 @@ let test_diff_in_policy_deny () =
 (* ================================================================ *)
 
 let make_gate_test_meta ?(name = "test-gate") () : Keeper_types.keeper_meta =
-  match Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc [("name", `String name); ("agent_name", `String name);
              ("trace_id", `String "test-trace-gate")]) with
   | Ok meta -> meta

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -45,7 +45,7 @@ let parse_create_response_json body =
 
 let make_keeper_meta ?(name = "judge-keeper") () : Keeper_types.keeper_meta =
   match
-    Keeper_types.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
          [
            ("name", `String name);

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -83,7 +83,7 @@ let write_team_memory_keeper_meta ~config ~name ~shared_memory_scope =
       ]
   in
   let meta =
-    match Keeper_types.meta_of_json meta_json with
+    match Masc_test_deps.meta_of_json_fixture meta_json with
     | Ok meta -> meta
     | Error err -> failwith ("meta_of_json failed: " ^ err)
   in

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -897,7 +897,7 @@ let () = test "handle_claim_next_ignores_keeper_preset_for_open_claims" (fun () 
   ignore (Result.get_ok (Keeper_tool_policy.init_policy_config ~base_path));
   let initial_meta =
     match
-      Keeper_types.meta_of_json
+      Masc_test_deps.meta_of_json_fixture
         (`Assoc
           [
             ("name", `String keeper_name);

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -43,7 +43,7 @@ let require_write_ok label = function
   | Error msg -> failf "%s: %s" label msg
 
 let make_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
-  match Keeper_types.meta_of_json
+  match Masc_test_deps.meta_of_json_fixture
     (`Assoc [("name", `String name); ("agent_name", `String name);
              ("trace_id", `String "test-trace-warn")]) with
   | Ok meta -> meta


### PR DESCRIPTION
## Why

Reports in `Kimi_Agent_샌드박스 설정 문제/` (2026-04-28) traced a Docker-sandbox bypass where keepers configured for `sandbox_profile = "docker"` ran on the host. Three independent defects compounded:

- **A (structural)** `lib/exec/exec_dispatch.ml` + `Shell_ir.simple` carry no sandbox info → native dispatch path always forks on host
- **B (persistence)** `lib/keeper/keeper_meta_json_parse.ml:170-188` silently fell back to `Local` when `sandbox_profile` / `network_mode` were missing from the on-disk JSON
- **C (logic)** `effective_sandbox_profile` and `make_tool_bundle` disagree about the effective profile

This PR is **family 1/3** in the root-fix series and addresses **defect B** (persistence). Defects C and A are addressed in two follow-up PRs (PR-3, PR-2 in plan order).

## Changes

### Production code
- `lib/keeper/keeper_meta_json_parse.ml`: new `parse_sandbox_policy_fields` helper using `Safe_ops.json_string_opt`. Missing or unparseable `sandbox_profile` / `network_mode` now return an `Error` directing the operator to the migration script. `parse_keeper_policy` plugs the helper into the result-monad chain it already returned.

### Migration tooling
- `scripts/migrate-keeper-meta-sandbox.sh` (new, executable): one-shot normalizer.
  - Scans `<repo>/.masc/keepers/*.json` and `~/.masc/keepers/*.json`
  - Fills missing fields from `config/keepers/<name>.toml` (TOML wins; otherwise conservative defaults `local` / `inherit`)
  - `--dry-run` is the default; `--apply` writes `.bak` and edits in place
  - Verified against 9 in-flight keepers — all already carry both fields, so the gate is preventative for new keepers, not breaking for current state

### Test fixtures (PR-1b sweep, in this PR)
- `test/deps/masc_test_deps.ml`: new `meta_of_json_fixture` helper that auto-fills missing sandbox fields and delegates to the strict production parser. Production code must not use it.
- 57 test files: rewrote `Keeper_types.meta_of_json` calls to the helper. Production parser remains strict.
- `test/dune`: added `masc_test_deps` to libraries of 3 single-test groups that did not yet depend on it.

## Verification

```bash
dune build @all      # passes (incremental + clean, exit 0)
bash scripts/migrate-keeper-meta-sandbox.sh             # dry-run; reports 9/9 already normalized
```

Reproducer (now refused, was silently downgraded before):

```sh
echo '{"name":"x","trace_id":"t","goal":"g"}' > /tmp/m.json
# Production parser: Error "sandbox_profile required in keeper_meta.json (run scripts/migrate-keeper-meta-sandbox.sh ...)"
```

## Coordination

- No new env flag (Hard cutover per user direction; matches memory rule "No hyperparameter as env knob")
- Plan SSOT: `planning/claude-plans/30m-users-dancer-downloads-kimi-agent-greedy-pebble.md`
- Race-window check at push (dash + underscore variants): clean, no conflicting PRs in `lib/exec`, `lib/keeper`, or `Masc_test_deps`

## Follow-up

- **PR-3** — `effective_sandbox_profile` invariant strengthening + TLA invariant `DockerImpliesDockerVia` in `specs/boundary/ToolCallContract.tla`
- **PR-2** — Sandbox_target IR in `lib/exec/` + `exec_dispatch` Docker route (Shell_ir.simple field add, ~30 cascade sites)
- Migration: after merge, run `bash scripts/migrate-keeper-meta-sandbox.sh --apply` and restart keepers