### PR TITLE
feat(graphql): add graphql_endpoint.mli — typed URL-resolver surface (cycle 59)

### DIFF
--- a/lib/graphql_endpoint.mli
+++ b/lib/graphql_endpoint.mli
@@ -1,0 +1,26 @@
+(** Graphql_endpoint — resolve the GraphQL server URL for the
+    Second Brain stack.
+
+    Resolution order:
+    - [GRAPHQL_URL] env var (operator override; localhost-style
+      hosts get [http://], everything else [https://]);
+    - [RAILWAY_GRAPHQL_URL] env var (always [https://]);
+    - hardcoded fallback
+      [https://second-brain-graphql-production.up.railway.app/graphql].
+
+    Every resolved URL is normalised: scheme prefixed if absent,
+    trailing slash trimmed, [/graphql] path appended if missing.
+    Empty / whitespace-only env var values fall through to the
+    next layer (rather than being treated as "disabled").
+
+    Internal helpers (the [trim_trailing_slash] string trimmer,
+    the [normalize_graphql_url] scheme/path normaliser, the
+    [default_railway_url] constant, the [railway_graphql_url]
+    intermediate, and the [default_scheme_for_override] localhost
+    sniffer) are hidden — callers consume only the resolved URL. *)
+
+val graphql_url : unit -> string
+(** Resolve the GraphQL endpoint URL using the [GRAPHQL_URL] →
+    [RAILWAY_GRAPHQL_URL] → hardcoded fallback chain documented
+    above. Always returns a fully-qualified URL with a scheme
+    and the [/graphql] path; never returns the empty string. *)


### PR DESCRIPTION
## Summary

Cycle 59 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/graphql_endpoint.ml` (54 lines).

Surface (single public binding):
- `graphql_url : unit -> string`

Hidden helpers:
- `trim_trailing_slash`
- `normalize_graphql_url`
- `default_railway_url`
- `railway_graphql_url`
- `default_scheme_for_override`

## Why narrow surface

The 3-layer resolution chain (`GRAPHQL_URL` →
`RAILWAY_GRAPHQL_URL` → hardcoded Railway URL) plus the
empty-string fall-through semantics are operational invariants
that callers in `graphql_client.ml` rely on without ever needing
to introspect the helpers. The module is essentially a
configuration resolver — the public contract is "give me a
working URL", and pinning it as `unit -> string` (never empty)
prevents a future option-typed refactor from silently
surfacing a `None` to every GraphQL consumer.

Localhost-vs-https scheme detection (matches `localhost`,
`127.0.0.1`, `0.0.0.0`, `[::1]`) and trailing-`/graphql` path
guarantee are documented in the docstring so a "we should
support custom paths" refactor is a contract change, not an
emergent regression.

## Caller audit (`rg "Graphql_endpoint\\."`)
- `lib/graphql_client.ml` — `let graphql_url () =
  Graphql_endpoint.graphql_url ()` re-export passthrough
- `test/test_graphql_endpoint.ml` — 4 `graphql_url ()`
  regression cases

No external reference to any of the 5 hidden helpers.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI) — `test_graphql_endpoint`
      exercises env-var precedence and normalisation
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
