### PR TITLE
docs(keeper): add KeeperHeartbeat.tla anchor in keeper_keepalive (Cycle 27 / B1)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -586,7 +586,13 @@ let interruptible_sleep ~clock ~stop ~wakeup duration =
   let rec wait remaining =
     if Atomic.get stop
     then ()
-    else if Atomic.compare_and_set wakeup true false
+    else if (* Spec: KeeperHeartbeat.tla HeartbeatTick action — wakeup is
+              consumed (TRUE -> FALSE) and the caller proceeds to dispatch.
+              MissedWakeup bug-action would have this compare_and_set
+              succeed without a follow-up turn; structural invariant is
+              that this branch returns immediately so the surrounding
+              loop can re-enter and dispatch on next tick. *)
+            Atomic.compare_and_set wakeup true false
     then ()
     else if remaining <= 0.0
     then ()
@@ -1824,6 +1830,36 @@ let record_keepalive_stage_timing
   timing_cursor := (!timing_cursor + 1) mod ring_sz;
   if !timing_filled < ring_sz then incr timing_filled
 ;;
+
+(* Spec navigation (OCaml -> TLA+) — plan §19 Cycle 27 anchor for
+   B1 (Heartbeat).  Authoritative spec mirror is
+   specs/keeper-state-machine/KeeperHeartbeat.tla (Cycle 7 / Tier B1,
+   PR #11408).
+
+   Spec line 4 cites this function "at line 1815"; the actual current
+   line is 1828 (drift of +13 since spec was authored, due to upstream
+   changes in this module).  Future spec PRs may re-anchor; until
+   then this comment is the authoritative reverse-direction citation.
+
+   Action mapping (TLA+ -> OCaml):
+     WakeupSignal     external code sets [wakeup] Atomic to true
+                      (e.g., wakeup_keeper / operator_resume).
+     HeartbeatTick    [interruptible_sleep] consumes the wakeup via
+                      [Atomic.compare_and_set wakeup true false] at
+                      this file line 589, then the loop body services
+                      the pending event.
+     TurnComplete     turn body finishes; loop returns to next sleep
+                      cycle.
+     MissedWakeup     bug action — the wakeup is observed and cleared
+                      but the loop fails to start a turn.  In OCaml
+                      this would be a regression where the
+                      compare_and_set succeeds but the surrounding
+                      branch returns early without dispatching.  The
+                      spec's NoMissedSignals invariant catches that
+                      drift; in code, the structural invariant is
+                      that every successful compare_and_set is
+                      followed by the dispatch path on the same loop
+                      iteration. *)
 
 let run_heartbeat_loop
       ~proactive_warmup_sec


### PR DESCRIPTION
## Summary

User assessment 2026-04-28 identified the Lifecycle category at **30-40% complete** with heartbeat / task acquisition / approval expiry as three "black box" areas.  Investigation showed the asymmetry root cause: spec → OCaml citation exists, but **OCaml → spec citation does not**.

Code search for `KeeperHeartbeat` or `Spec:` in `lib/keeper/keeper_keepalive.ml` returned **zero hits** before this PR.

This is the first of three sibling PRs (Option A from plan §19.4) that close the discoverability gap by adding reverse-direction anchor comments.  Comment-only — no semantic change.

## What changed

| Anchor | Location | Content |
|--------|----------|---------|
| Navigation block | `keeper_keepalive.ml:1828` (above `run_heartbeat_loop`) | Maps the four spec actions (`WakeupSignal` / `HeartbeatTick` / `TurnComplete` / `MissedWakeup`) to OCaml locations, explains the structural invariant that catches `MissedWakeup` |
| Inline citation | `keeper_keepalive.ml:589` (`Atomic.compare_and_set wakeup true false`) | The exact OCaml line the spec's `HeartbeatTick` action mirrors |

## Spec line drift correction

`KeeperHeartbeat.tla:4` cites `run_heartbeat_loop at line 1815`; current actual line is **1828** (drift of +13 since the spec was authored at Cycle 7).  The drift is now recorded in the OCaml navigation block so future readers know the spec citation is stale and where the function actually lives.  Spec-side line update is deferred (cosmetic; would conflict with future spec PRs).

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_keepalive.ml`) |
| Lines | +37 / -1 (comment-only) |
| Behavior change | none |
| Build | `dune build --root . lib/keeper/` ✅ |

## Plan reference

`/Users/dancer/me/planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md`:
- §19.5 Cycle 27 (B1 anchor)
- §19.4 Option A (3 sibling PR, user signal 2026-04-28)
- §19.2 — sibling specs already merged: B1 #11408, B2 #11412, B3 #11417

## Sibling PRs (Cycle 28 / 29 to follow)

- **Cycle 28 (B2)**: `lib/keeper/keeper_unified_turn.ml` ↔ `KeeperTaskAcquisition.tla`
- **Cycle 29 (B3)**: `lib/keeper/keeper_approval_queue.ml` ↔ `KeeperApprovalQueue.tla`