### PR TITLE
feat(eio): add masc_eio_env.mli — typed runtime-env capture surface (cycle 60)

### DIFF
--- a/lib/masc_eio_env.mli
+++ b/lib/masc_eio_env.mli
@@ -1,0 +1,49 @@
+(** Masc_eio_env — module-level Eio environment for OAS HTTP
+    calls.
+
+    The OAS provider completions use [cohttp-eio] for HTTP
+    transport, which needs an Eio switch and net handle.
+    {!init} is called once at server startup (in
+    [server_runtime_bootstrap]); every consumer that needs to
+    issue an HTTP call later reaches the captured handles via
+    {!get} or {!get_opt}.
+
+    Internal storage (the [Atomic.t t option] slot) is hidden —
+    callers consume only the {!type-t} record and the three
+    accessors. *)
+
+type t = {
+  sw : Eio.Switch.t;
+  net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
+  clock : float Eio.Time.clock_ty Eio.Resource.t option;
+}
+(** Captured Eio handles. [clock] is optional because some
+    callers (e.g. tests, stdio mode) initialise without one;
+    components that strictly require a clock should pattern
+    match on [Some] and fail loudly rather than substitute a
+    fallback. *)
+
+val init :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  unit ->
+  unit
+(** Capture the runtime handles. Last-writer-wins on
+    [Atomic.set]; intended to be called exactly once at server
+    startup but a re-init is permitted (used by the harness
+    test suite). *)
+
+val get : unit -> t
+(** Read the captured environment.
+
+    @raise Invalid_argument when {!init} has not yet run.
+    Callers in the boot path that may legitimately fire before
+    {!init} should use {!get_opt} instead. *)
+
+val get_opt : unit -> t option
+(** Read the captured environment without raising. Returns
+    [None] when {!init} has not run — used by tests and by
+    code paths that must degrade gracefully (cascade catalog
+    runtime, masc_oas_bridge fallback, local-runtime probes,
+    oas_worker_named scheduler). *)


### PR DESCRIPTION
## Summary

Cycle 60 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/masc_eio_env.ml` (24 lines).

Surface (1 record type + 3 accessors):
- `type t = { sw; net; clock = float Eio.Time.clock_ty Eio.Resource.t option }`
- `init  : ~sw -> ~net -> ?clock -> unit -> unit`
- `get   : unit -> t` (raises `Invalid_argument` when uninit)
- `get_opt : unit -> t option`

Hidden internals:
- `env` — `Atomic.t (t option)` storage slot

## Why typed surface

The asymmetric `get` vs `get_opt` contract is operationally
important. Boot-time consumers in
- `lib/cascade/cascade_catalog_runtime.ml`
- `lib/masc_oas_bridge.ml`
- `lib/tool_local_runtime_verify.ml`
- `lib/tool_local_runtime_bench.ml`
- `lib/oas_worker_named.ml`

can legitimately fire before `init` and **must degrade
gracefully**. They use `get_opt`. Conversely `keeper_llm_bridge`
runs deep enough into the request path that an uninitialised
env is a programming error — it uses `get` and expects the
`Invalid_argument` to surface.

A future "let's just always use `get`" refactor would crash the
boot path on cold-start; pinning which accessor each caller
class uses at the contract seam makes that refactor fail loudly
during type-check rather than at runtime under load.

`clock` optionality is documented at the type seam: tests and
stdio mode initialise without one. Components that strictly need
a clock should pattern match on `Some` and fail loudly — not
substitute a fallback. The class of drift bug this avoids is
#6663-style "value silently provided where None was the signal".

## Caller audit (`rg "Masc_eio_env\\."`)
- `lib/server/server_runtime_bootstrap.ml` — `init`
- `lib/keeper/keeper_llm_bridge.ml` —
  `(Masc_eio_env.get ()).clock`
- 5 lib/ callers using `get_opt` (graceful degrade)
- `test/test_tool_task_coverage.ml` — `get_opt` precondition
  assert

No external reference to `env`.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
