### PR TITLE
docs(keeper): add KeeperApprovalQueue.tla anchor in keeper_approval_queue (Cycle 29 / B3)

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -9,6 +9,38 @@
     This replaces the manual "pending_approval" state machine with
     actual execution-level suspension using Eio structured concurrency.
 
+    Spec navigation (OCaml -> TLA+) — plan §19 Cycle 29 anchor for
+    B3 (Approval Queue).  Authoritative spec mirror is
+    [specs/keeper-state-machine/KeeperApprovalQueue.tla] (Cycle 9 /
+    Tier B3, PR #11417).
+
+    Spec lines 5-6 already cite this module:
+    "[submit_and_await] at line 751, [submit_pending] at line 772,
+    [expire_stale] at line 941".  This block is the reverse-direction
+    citation so code search for "KeeperApprovalQueue" lands here.
+
+    Action mapping (TLA+ -> OCaml):
+      Submit                 [submit_and_await] (~line 751) /
+                             [submit_pending] (~line 772) record a
+                             new pending entry and suspend the fiber
+                             on [Eio.Promise.await].
+      Resolve                operator approves/rejects via the HTTP
+                             handler in [server_dashboard_http.ml],
+                             which calls [resolve] on the queue and
+                             wakes the suspended fiber.
+      ExpireStale            [expire_stale] (~line 941) sweeps
+                             timed-out entries and forces
+                             [Eio.Promise.resolve resolver (Reject ...)]
+                             so no fiber is left blocked indefinitely.
+      ExpireStaleNoResolve   bug action — entries are removed from
+                             [pending] without resolving the promise.
+                             Spec invariants SuspensionMatchesPending
+                             and QuiescentImpliesResolved catch this;
+                             in code, the structural invariant is
+                             that every removal from [pending] is
+                             paired with an [Eio.Promise.resolve]
+                             on the same control-flow path.
+
     @since 2.262.0 (#5907) *)
 
 (* ── Types ────────────────────────────────────────────────── *)


### PR DESCRIPTION
## Summary

Sibling to #11596 (B1) and #11597 (B2) — completes the trio of OCaml → spec anchor closures for the **three "black box" lifecycle areas** the user identified at 30-40% in the 2026-04-28 assessment.

Pre-PR grep for `KeeperApprovalQueue` or `Spec:` in `keeper_approval_queue.ml` returned **zero hits**, even though `KeeperApprovalQueue.tla:5-6` already cited the OCaml module by function name and line number.

## What changed

| Anchor | Location | Content |
|--------|----------|---------|
| Module docstring extension | `keeper_approval_queue.ml:1-12` (extended) | Maps four spec actions (`Submit` / `Resolve` / `ExpireStale` / `ExpireStaleNoResolve`) to OCaml locations.  Highlights `SuspensionMatchesPending` and `QuiescentImpliesResolved` invariants — every removal from `pending` must be paired with `Eio.Promise.resolve`. |

## Spec line citation accuracy

All three citations in `KeeperApprovalQueue.tla:5-6` are **accurate** with current code:
- `submit_and_await` line 751 ✅
- `submit_pending` line 772 ✅
- `expire_stale` line 941 ✅

No drift correction needed (unlike #11596 / B1's +13 line drift).

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_approval_queue.ml`) |
| Lines | +32 / -0 (comment-only, docstring extension) |
| Behavior change | none |
| Build | `dune build --root . lib/keeper/` ✅ |

## Plan reference

`/Users/dancer/me/planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md`:
- §19.5 Cycle 29 (B3 anchor) — completes Option A
- §19.10 — after this trio, Lifecycle category 30-40% → 65-80% (discoverability closed)

## Sibling PRs (Option A complete)

- ✅ **Cycle 27 (B1)**: #11596 — `keeper_keepalive.ml` ↔ `KeeperHeartbeat.tla`
- ✅ **Cycle 28 (B2)**: #11597 — `keeper_unified_turn.ml` ↔ `KeeperTaskAcquisition.tla`
- ✅ **Cycle 29 (B3)**: this PR — `keeper_approval_queue.ml` ↔ `KeeperApprovalQueue.tla`

## After all three merge

User assessment's "Lifecycle 30-40%" category should rise to **65-80%** in spec ↔ code identity terms.  Three black-box areas now have bidirectional anchors — every spec action has a code citation, every code path the spec models has a comment pointing at the spec.  The only remaining gap is `try_<action>` style refactor (C1 Phase 1, requires user signal — plan §13.10).