### PR TITLE
feat(config): add env_config_introspect.mli — typed root-runtime metadata surface (cycle 61)

### DIFF
--- a/lib/env_config_introspect.mli
+++ b/lib/env_config_introspect.mli
@@ -1,0 +1,31 @@
+(** Env_config_introspect — root-level config introspection
+    wrapper.
+
+    The canonical category definitions, masking rules, and source
+    attribution live in [Env_config_snapshot] inside the
+    [masc_config] sub-library. This wrapper adds root-runtime
+    metadata that is only available from the main server library
+    ([Version.version], [Server_startup_state.elapsed_since_start],
+    [Sys.ocaml_version], the live PID, and [MASC_BUILD_GIT_COMMIT]).
+
+    Internal helper [server_meta] is hidden — callers consume only
+    the two JSON entry points. *)
+
+val to_json : unit -> Yojson.Safe.t
+(** Render the full snapshot as a JSON object with the
+    [server] / [generated_at] / [categories] top-level keys.
+    [generated_at] is the ISO-8601 timestamp at call time;
+    [server] embeds version / git_commit / ocaml_version /
+    uptime_seconds / pid; [categories] is the full
+    {!Env_config_snapshot.all_categories} table. *)
+
+val to_json_filtered :
+  ?cat:string ->
+  unit ->
+  Yojson.Safe.t
+(** Like {!to_json} but restricts the [categories] table to the
+    single entry whose key equals [cat] (case-sensitive). When
+    [cat] is omitted or names a missing category, the [categories]
+    object is empty for the latter case and unchanged from
+    {!to_json} for the former. Used by [tool_misc_admin] for the
+    operator [/admin/config?cat=...] endpoint. *)


### PR DESCRIPTION
## Summary

Cycle 61 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/env_config_introspect.ml` (29 lines).

Surface (2 entries):
- `to_json : unit -> Yojson.Safe.t`
- `to_json_filtered : ?cat:string -> unit -> Yojson.Safe.t`

Hidden internals:
- `server_meta` — private builder for the
  version/git/ocaml/uptime/pid block

## Why typed surface

The split between this wrapper and `Env_config_snapshot` is
operationally important and otherwise invisible: the canonical
category / masking rules live in `masc_config` (sub-library), and
the root-only runtime metadata (`Version.version`,
`Server_startup_state.elapsed_since_start`, `Sys.ocaml_version`,
`Unix.getpid`, `MASC_BUILD_GIT_COMMIT`) lives in the main lib
because it depends on `masc_mcp.config`'s subset.

A future "let's move the masking rules out" refactor must extend
either this contract or the snapshot one — the seam is explicit
in the docstring. Pinning the return as `Yojson.Safe.t` (not a
typed record) preserves the consumers' freedom to add fields
without breaking the `categories` shape — the JSON is the
boundary.

## Caller audit (`rg "Env_config_introspect\\."`)
- `lib/server/server_h2_gateway.ml` — `to_json` (dashboard route)
- `lib/server/server_routes_http_routes_dashboard.ml` —
  `to_json`
- `lib/tool_misc_admin.ml` — `to_json_filtered` (admin
  `/config?cat=`)

No external reference to `server_meta`.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
