### PR TITLE
feat(autoresearch): add tool_autoresearch_broadcast.mli — typed SSE event surface (cycle 62)

### DIFF
--- a/lib/tool_autoresearch_broadcast.mli
+++ b/lib/tool_autoresearch_broadcast.mli
@@ -1,0 +1,31 @@
+(** Tool_autoresearch_broadcast — SSE broadcast for autoresearch
+    loop events.
+
+    Both broadcasters serialise their event as a JSON object and
+    push it via {!Sse.broadcast}. [Eio.Cancel.Cancelled] is
+    re-raised so an ambient cancel propagates; any other
+    exception during [Sse.broadcast] is logged at
+    [Log.Autoresearch.warn] and swallowed so a downstream SSE
+    failure cannot interrupt the autoresearch loop.
+
+    {!Tool_autoresearch} re-exports both bindings via
+    [include Tool_autoresearch_broadcast]; {!Tool_autoresearch_cycle}
+    consumes them directly via [open Tool_autoresearch_broadcast]. *)
+
+val broadcast_cycle_result :
+  Autoresearch.loop_state ->
+  Autoresearch.cycle_record ->
+  unit
+(** Broadcast a per-cycle SSE event with type
+    ["autoresearch_cycle"] containing the cycle number,
+    hypothesis, decision (via {!Autoresearch.decision_to_string}),
+    score before/after, delta, baseline, and best score. *)
+
+val broadcast_loop_lifecycle :
+  string ->
+  Autoresearch.loop_state ->
+  unit
+(** Broadcast a lifecycle SSE event with the caller-supplied
+    [event_type] (e.g. ["autoresearch_started"] /
+    ["autoresearch_stopped"]) and the loop state's id, status,
+    current cycle, best score, and target file. *)


### PR DESCRIPTION
## Summary

Cycle 62 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/tool_autoresearch_broadcast.ml`
(27 lines).

Surface (2 entries — exhaustive, no internals to hide):
- `broadcast_cycle_result :
    Autoresearch.loop_state -> Autoresearch.cycle_record -> unit`
- `broadcast_loop_lifecycle :
    string -> Autoresearch.loop_state -> unit`

## Why typed surface

The module is consumed two different ways and the .mli locks
both shapes simultaneously:

- `lib/tool_autoresearch.ml` does `include
  Tool_autoresearch_broadcast` → re-exports both bindings as
  part of its own public surface
- `lib/tool_autoresearch_cycle.ml` does `open
  Tool_autoresearch_broadcast` → uses both broadcasters
  bare-name in its loop body

A future "return broadcast count" / "return Result.t" refactor
would silently drift the include-based re-export shape and
break every consumer of `Tool_autoresearch.broadcast_*`.
Pinning the unit-arity here makes that refactor fail at the
contract seam.

The Eio.Cancel.Cancelled propagation rule and the Sse.broadcast
exception swallow are documented at the seam: the loop must not
be interrupted by a downstream SSE consumer failure (so a
broken websocket client does not stop autoresearch), but it
must respect ambient fiber cancel (so SIGINT works).

## Caller audit
- `lib/tool_autoresearch.ml` — `include Tool_autoresearch_broadcast`
- `lib/tool_autoresearch_cycle.ml` — `open
  Tool_autoresearch_broadcast` (4 bare-name call sites)

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
