### PR TITLE
feat(worker): add worker_execution_backend.mli — typed runtime variant + codec surface (cycle 63)

### DIFF
--- a/lib/worker_execution_backend.mli
+++ b/lib/worker_execution_backend.mli
@@ -1,0 +1,35 @@
+(** Worker_execution_backend — closed variant naming the
+    container runtime a worker executes against, with
+    JSON / string codecs.
+
+    Used by [Worker_container_types.runtime_backend] (the field
+    every worker spec carries) and dispatched on by
+    [Worker_container_runners] to pick between in-process
+    [Local_playground] execution and a real [Docker] container.
+
+    The variant is intentionally closed: a future "k8s" or
+    "podman" backend must extend the type, failing every
+    pattern-match site at compile time rather than silently
+    routing to one of the existing arms. *)
+
+type t =
+  | Local_playground
+  | Docker
+
+val to_string : t -> string
+(** ["local_playground"] / ["docker"] — canonical lower-snake
+    form used in JSONL persistence and operator output. *)
+
+val of_string : string -> t option
+(** Inverse of {!to_string}, accepting an extra ["local"] alias
+    for [Local_playground] and trimming / lowercasing the input.
+    Returns [None] for any unknown value (no silent fallback). *)
+
+val to_yojson : t -> Yojson.Safe.t
+(** Wraps {!to_string} as [`String _]. *)
+
+val of_yojson : Yojson.Safe.t -> (t, string) result
+(** Strict JSON decoder — only [`String s] is accepted, with
+    [s] forwarded to {!of_string}. Returns [Error] for unknown
+    string values and for non-string JSON, with the value
+    surfaced in the error message for debuggability. *)


### PR DESCRIPTION
## Summary

Cycle 63 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/worker_execution_backend.ml`
(25 lines).

Surface (1 closed variant + 4 codec entries — exhaustive,
no internals to hide):
- `type t = Local_playground | Docker`
- `to_string : t -> string`
- `of_string : string -> t option`
- `to_yojson : t -> Yojson.Safe.t`
- `of_yojson : Yojson.Safe.t -> (t, string) result`

## Why typed surface

The variant is closed by intent — a future "k8s" / "podman"
backend must extend the type, failing every pattern-match site
at compile time rather than silently routing to one of the
existing arms. `lib/local/worker_container_runners.ml` already
matches exhaustively on `Local_playground | Docker`; pinning
the type via `.mli` prevents a refactor from widening to a
polymorphic variant or open type without surfacing breakage.

Codec contracts:
- `of_string` accepts an extra `"local"` alias for
  `Local_playground` and trims / lowercases input; returns
  `None` for any unknown value (no silent fallback).
- `of_yojson` is strict — `Error` for both non-string JSON and
  unknown string values, with the offending value surfaced for
  debugging.

Both rules are documented at the contract seam to prevent a
"be lenient and default to local" refactor that would silently
route Docker workloads to in-process execution.

## Caller audit (`rg "Worker_execution_backend"`)
- `lib/local/worker_container_types.ml` — `runtime_backend`
  field of every worker spec
- `lib/local/worker_container_runners.ml` — exhaustive match
  over `Local_playground` / `Docker`
- `test/test_worker_runtime.ml` — `to_string` + the
  `Local_playground` constructor in fixtures

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
