### PR TITLE
feat(autoresearch): add tool_autoresearch_registry.mli — typed loop/generator registry surface (cycle 64)

### DIFF
--- a/lib/tool_autoresearch_registry.mli
+++ b/lib/tool_autoresearch_registry.mli
@@ -1,0 +1,63 @@
+(** Tool_autoresearch_registry — loop registry, pending hypothesis
+    queue, and per-loop code-generator override state for the
+    autoresearch loop.
+
+    Two of the three Hashtbls ([pending_hypotheses],
+    [custom_generators]) are reached into by the dashboard HTTP
+    handler ([Hashtbl.remove] on cancellation) and by the test
+    suite ([Hashtbl.reset] between cases), so they are exposed
+    by the .mli rather than wrapped in accessor functions —
+    pretending they were private would force every caller into
+    awkward setter/getter pairs without making the storage any
+    more abstract.
+
+    [active_loops] / [latest_loop_id] are re-exports of the
+    {!Autoresearch} state slot so [Tool_autoresearch] (which does
+    [include Tool_autoresearch_registry]) and
+    [Tool_autoresearch_cycle] (which does
+    [open Tool_autoresearch_registry]) can share a single name. *)
+
+val active_loops : (string, Autoresearch.loop_state) Hashtbl.t
+(** Re-export of [Autoresearch.active_loops]. The dashboard's
+    cancellation handler and the cycle runner both mutate this
+    table directly. *)
+
+val latest_loop_id : string option ref
+(** Re-export of [Autoresearch.latest_loop_id]. The dashboard
+    sets this on loop start; consumers read it for the "most
+    recent loop" UI affordance. *)
+
+val pending_hypotheses : (string, string) Hashtbl.t
+(** Per-loop queue of operator-injected hypotheses awaiting the
+    next cycle. Keys are loop ids; values are the hypothesis
+    text. The dashboard's cancellation handler clears entries
+    via [Hashtbl.remove]; the test suite resets the table
+    between cases. *)
+
+(** Per-loop code generator type used by tests to inject a
+    deterministic stand-in for [Autoresearch.generate_code_change].
+    Returns either [Ok (hypothesis, new_code)] or [Error reason]. *)
+type code_generator =
+  goal:string ->
+  baseline:float ->
+  lower_is_better:bool ->
+  history:Autoresearch.cycle_record list ->
+  insights:string list ->
+  target_file:string ->
+  file_content:string ->
+  (string * string, string) result
+
+val custom_generators : (string, code_generator) Hashtbl.t
+(** Per-loop override table. The dashboard's cancellation handler
+    clears entries via [Hashtbl.remove]; the test suite resets
+    the table between cases. *)
+
+val set_generator : string -> code_generator -> unit
+(** Install a custom generator for [loop_id] (last-writer-wins
+    via [Hashtbl.replace]). Used in tests to inject deterministic
+    behaviour. *)
+
+val get_generator : string -> code_generator
+(** Resolve the generator for [loop_id]; falls back to
+    [Autoresearch.generate_code_change] when no override is
+    registered. *)


### PR DESCRIPTION
## Summary

Cycle 64 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/tool_autoresearch_registry.ml`
(33 lines).

Surface (full body — no internals to hide):
- `val active_loops      : (string, Autoresearch.loop_state) Hashtbl.t`
- `val latest_loop_id    : string option ref`
- `val pending_hypotheses : (string, string) Hashtbl.t`
- `type code_generator   = …` (8-arg labelled function type)
- `val custom_generators : (string, code_generator) Hashtbl.t`
- `val set_generator     : string -> code_generator -> unit`
- `val get_generator     : string -> code_generator`

## Why expose the Hashtbls directly

The two override-state Hashtbls (`pending_hypotheses`,
`custom_generators`) are reached into directly by:
- `lib/dashboard/dashboard_http_autoresearch.ml` —
  `Hashtbl.remove` on cancellation
- `test/test_autoresearch_target_score.ml` — `Hashtbl.reset`
  between cases (3 fixtures) + `set_generator` for deterministic
  test injection

Hiding the Hashtbls would force every caller into
setter/getter pairs without making the storage any more
abstract — they still need `remove` and `reset` semantics. The
docstring documents this decision explicitly so a future
"these should be private" refactor sees the surface area it
needs to preserve.

`active_loops` / `latest_loop_id` are passthrough re-exports of
`Autoresearch.*` so `Tool_autoresearch` (which `include`s this
module) and `Tool_autoresearch_cycle` (which `open`s it) share
a single name.

`code_generator` is pinned as a closed 8-arg labelled function
type. A future "add insights_v2 arg" refactor would silently
break the test injection points; the .mli surfaces it at the
seam.

## Caller audit
- `lib/tool_autoresearch.ml` — `include Tool_autoresearch_registry`
- `lib/tool_autoresearch_cycle.ml` —
  `open Tool_autoresearch_registry`
- `lib/dashboard/dashboard_http_autoresearch.ml` —
  `Hashtbl.remove` on both override Hashtbls
- `test/test_autoresearch_target_score.ml` — `Hashtbl.reset` on
  both Hashtbls + `set_generator` across 3 fixtures

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI) — `test_autoresearch_target_score`
      exercises every exposed binding
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
