### PR TITLE
feat(autoresearch): add tool_autoresearch_context.mli — typed handler-env record (cycle 65)

### DIFF
--- a/lib/tool_autoresearch_context.mli
+++ b/lib/tool_autoresearch_context.mli
@@ -1,0 +1,34 @@
+(** Tool_autoresearch_context — shared environment record passed
+    into autoresearch tool handlers.
+
+    All fields except [base_path] are optional and represent
+    optional integration points: [agent_name] is set when a
+    handler runs on behalf of a specific agent (used to scope
+    Hebbian / journal writes); [start_operation] is the OAS
+    bridge that actually launches a research run; [config] /
+    [sw] / [clock] expose the Eio runtime handles a handler
+    needs only when it persists state or sleeps.
+
+    The record is exposed concretely (not as an abstract type)
+    because the test suite constructs it directly across 6
+    fixtures in [test_autoresearch_target_score] and
+    [test_autoresearch_oas_primitives]; hiding the shape would
+    force the tests through factory helpers without making the
+    abstraction any richer.
+
+    [Tool_autoresearch] re-exports this type as
+    [Tool_autoresearch.context] for the public tool surface;
+    [Tool_autoresearch_cycle] consumes it directly. *)
+
+type t = {
+  base_path : string;
+  agent_name : string option;
+  start_operation :
+    (goal:string ->
+     target_file:string ->
+     (Yojson.Safe.t, string) result)
+    option;
+  config : Coord.config option;
+  sw : Eio.Switch.t option;
+  clock : float Eio.Time.clock_ty Eio.Resource.t option;
+}


### PR DESCRIPTION
## Summary

Cycle 65 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/tool_autoresearch_context.ml`
(14 lines).

Surface (single concrete record):
- `type t = { base_path; agent_name; start_operation; config;
              sw; clock }`

## Why concrete record (not abstract)

The record is constructed directly by 6 test fixtures across
`test_autoresearch_target_score` (3 cases) and
`test_autoresearch_oas_primitives` (3 cases). Hiding the shape
would force the tests through factory helpers without making
the abstraction any richer — the fields are *semantically*
distinct and tests need to control each one.

The optional-field convention is documented in the docstring:
- `base_path` is mandatory (always set, no fallback)
- `agent_name = None` → no agent scope (anonymous Hebbian /
  journal writes go to a shared bucket)
- `start_operation = None` → OAS bridge unavailable (tests
  inject deterministic stand-ins via `custom_generators` in
  the registry)
- `config` / `sw` / `clock = None` → handler runs in degraded
  mode (no persistence, no sleep)

A future "let's make this abstract" refactor would need to
re-architect the test fixtures *and* the degraded-mode logic;
surfacing the field semantics here keeps that intent visible.

## Caller audit (`rg "Tool_autoresearch_context"`)
- `lib/tool_autoresearch.ml` —
  `type context = Tool_autoresearch_context.t` re-export
- `lib/tool_autoresearch_cycle.ml` — typed parameter on
  `make_loop_memory` and friends
- `test/test_autoresearch_target_score.ml` — 3 fixture
  constructors
- `test/test_autoresearch_oas_primitives.ml` — 3 fixture
  constructors

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI) — both fixture suites exercise every
      field combination
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
