### PR TITLE
feat(autoresearch): add autoresearch_lineage.mli — typed actor/tag contract surface (cycle 66)

### DIFF
--- a/lib/autoresearch_lineage.mli
+++ b/lib/autoresearch_lineage.mli
@@ -1,0 +1,47 @@
+(** Autoresearch_lineage — shared actor names and tag contract
+    for autoresearch feedback artifacts.
+
+    Lesson and finding records produced across the autoresearch
+    loop need to describe the same lineage consistently: which
+    internal actor generated the record, which loop actor
+    participated, and which baseline tags make the record
+    discoverable from search.
+
+    Internal helpers (the [actor] variant, the [actor_name]
+    derivation, and the [normalize_tag] string trimmer) are
+    hidden — callers consume only the materialised string
+    constants and the {!finding_tags} composer. *)
+
+val lesson_reviewer_actor_name : string
+(** ["autoresearch-reviewer"] — the agent name attributed to
+    lesson-review writes. Pinned at the contract seam because
+    the dashboard / search index depend on the exact spelling. *)
+
+val cycle_runner_actor_name : string
+(** ["autoresearch_cycle"] — the agent name attributed to
+    cycle-runner writes. Different shape (underscore, no
+    "reviewer" suffix) is intentional and historic; do not
+    "harmonise" without an explicit migration. *)
+
+val cycle_failure_participants : string list
+(** [[lesson_reviewer_actor_name; cycle_runner_actor_name]] —
+    the canonical participant list embedded in
+    cycle-failure lessons so retrospective queries can match
+    either actor. *)
+
+val domain_tag : string
+(** ["autoresearch"] — the always-present root tag in
+    {!finding_tags} output. *)
+
+val finding_tags :
+  target_file:string ->
+  extra:string list ->
+  string list
+(** Compose a deduplicated tag list for a finding record.
+
+    Order: {!domain_tag} first, then [target_file] (when
+    non-empty after trim), then each member of [extra] in input
+    order. Empty / whitespace-only entries are dropped via the
+    internal [normalize_tag]; duplicates are filtered with
+    first-occurrence wins so the result is stable across
+    re-renders of the same finding. *)


### PR DESCRIPTION
## Summary

Cycle 66 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/autoresearch_lineage.ml` (40 lines).

Surface (4 string constants + 1 composer):
- `val lesson_reviewer_actor_name : string`
- `val cycle_runner_actor_name    : string`
- `val cycle_failure_participants : string list`
- `val domain_tag                 : string`
- `val finding_tags : target_file:string -> extra:string list ->
                        string list`

Hidden internals:
- `type actor = Lesson_reviewer | Cycle_runner`
- `val actor_name` — variant-to-string derivation
- `val normalize_tag` — whitespace trimmer

## Why hide the variant

Callers (`tool_autoresearch_cycle`, dashboard, search index)
need only the materialised strings. Hiding the `actor` variant
and `actor_name` derivation prevents a future caller from
pattern-matching on `Lesson_reviewer | Cycle_runner` and
bypassing the canonical spelling — the variant is an
implementation detail of how the strings are derived, not part
of the contract.

The naming asymmetry between
`"autoresearch-reviewer"` (hyphen) and `"autoresearch_cycle"`
(underscore) is intentional and historic; the docstring tells
future maintainers not to "harmonise" without an explicit
migration of every persisted lesson record.

`finding_tags` composes a deduplicated, ordered tag list:
1. `domain_tag` first
2. `target_file` (when non-empty after trim)
3. each `extra` member in input order
…with first-occurrence-wins dedup. The order is documented at
the contract seam because the search index relies on it being
deterministic per finding.

## Caller audit (`rg "Autoresearch_lineage\\."`)
- `lib/tool_autoresearch_cycle.ml` —
  `lesson_reviewer_actor_name` (2 sites)
- `test/test_autoresearch_oas_primitives.ml` —
  `lesson_reviewer_actor_name` + `domain_tag`
- `test/test_autoresearch_knowledge.ml` — all four constants +
  `finding_tags`

No external reference to `actor` / `actor_name` /
`normalize_tag`.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI) — `test_autoresearch_knowledge`
      exercises the dedup contract for `finding_tags`
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
