### PR TITLE
docs(keeper): add KeeperCircuitBreaker.tla anchor in keeper_failure_circuit_breaker (Cycle 30)

### DIFF
--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -8,7 +8,33 @@
 
     Error classes are coarse categories (path_not_found, cwd_not_directory,
     path_not_in_allowed_paths/path_outside_sandbox) — not exact error strings. This prevents
-    near-miss variants from resetting the counter. *)
+    near-miss variants from resetting the counter.
+
+    Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern applied
+    to circuit breaker.  Authoritative spec mirror is
+    [specs/keeper-state-machine/KeeperCircuitBreaker.tla] (#8642 family).
+
+    Spec lines 9-13 already cite this module field-by-field:
+      Threshold     -> [let threshold = 3]
+      count         -> [mutable consecutive_count : int]
+      currentClass  -> [mutable consecutive_class : error_class]
+      tripped       -> [record_failure] return value
+      ErrorClasses  -> [type error_class] (this file, ~line 17)
+
+    This block is the reverse-direction citation so code search for
+    "KeeperCircuitBreaker" lands in this module.
+
+    Scope projection (already documented in spec lines 15-22):
+      OCaml has 5 error classes (Path_not_found, Path_not_allowed,
+      Cwd_not_directory, Shell_exit_nonzero, Other); spec models 3
+      (path_not_found, path_not_allowed, other).  The two extra OCaml
+      classes fold into the spec's "other" partition.  This is
+      Refinement (acknowledged), not Drift — adding a new OCaml class
+      does NOT require spec update unless it violates ClassIsolation.
+
+    Bug-Model contract: clean cfg verifies SafetyInvariant +
+    ClassIsolation; buggy cfg removes the per-class reset and the
+    ClassIsolation property is violated. *)
 
 (* ================================================================ *)
 (* Error classification                                             *)


### PR DESCRIPTION
## Summary

Continues the spec → code anchor closure pattern established by **Cycles 27-29** (B1/B2/B3 trio, #11596 / #11597 / #11599).

Pre-PR grep for `KeeperCircuitBreaker` or `Spec:` in `lib/keeper/keeper_failure_circuit_breaker.ml` returned **zero hits**, even though `KeeperCircuitBreaker.tla:9-13` already cited this module field-by-field.

## What changed

Single anchor block added to the module docstring (lines 1-11 → 1-44, comment-only):

| Spec entity | OCaml field |
|-------------|-------------|
| `Threshold` | `let threshold = 3` |
| `count` | `mutable consecutive_count : int` |
| `currentClass` | `mutable consecutive_class : error_class` |
| `tripped` | `record_failure` return value |
| `ErrorClasses` | `type error_class` (this file, ~line 17) |

## Refinement / Drift classification

The spec already documents **scope projection** at lines 15-22: OCaml has 5 error classes (`Path_not_found / Path_not_allowed / Cwd_not_directory / Shell_exit_nonzero / Other`), spec models 3 (`path_not_found / path_not_allowed / other`).  The two extras fold into the spec's "other" partition.

This is **Refinement (acknowledged)**, not Drift, per plan §1 4-way classification.  Adding a new OCaml class does NOT require spec update unless it violates `ClassIsolation`.

## Spec line citation accuracy

All five citations are **accurate** with current code — no line drift correction needed (unlike #11596 / B1's +13 line drift in `KeeperHeartbeat.tla`).

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_failure_circuit_breaker.ml`, 358 lines total) |
| Lines | +27 / -1 (comment-only, docstring extension) |
| Behavior change | none |
| Build | `dune build --root . lib/keeper/` ✅ |

## Plan reference

`/Users/dancer/me/planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md`:
- §19 anchor pattern (Option A continuation beyond B1/B2/B3 trio)
- §1 — Refinement vs Drift 4-way classification

## Pattern reuse trail

Same closure form from Cycle 24 onward:
- **Cycle 24** (#11565): C1 Phase 0 `derive_phase` navigation block
- **Cycle 25** (#11583): N1 spec `KeeperLaunchPending.tla`
- **Cycle 26** (#11584): N2 Note A "drift → resolved" comment
- **Cycle 27** (#11596): B1 `KeeperHeartbeat` anchor
- **Cycle 28** (#11597): B2 `KeeperTaskAcquisition` anchor
- **Cycle 29** (#11599): B3 `KeeperApprovalQueue` anchor
- **Cycle 30** (this PR): `KeeperCircuitBreaker` anchor