### PR TITLE
feat(tool): add tool_shard_limits.mli — SSOT byte-budget surface (cycle 67)

### DIFF
--- a/lib/tool_shard_limits.mli
+++ b/lib/tool_shard_limits.mli
@@ -1,0 +1,25 @@
+(** Tool_shard_limits — SSOT integer constants shared between
+    [Tool_shard] (the MCP tool surface) and [Keeper_exec_fs]
+    (the runtime handler).
+
+    Lives in a leaf module with no dependencies so both sides can
+    import the same value without forming the
+    [Tool_shard ↔ Keeper_exec_fs] dependency cycle that motivated
+    the extraction in the first place. *)
+
+val keeper_fs_read_default_max_bytes : int
+(** Default byte budget for [keeper_fs_read] when the caller
+    omits [max_bytes]. Currently 20_000.
+
+    Pinned at the contract seam because the value appears in
+    two unrelated places: the JSON schema for [keeper_fs_read]'s
+    [max_bytes] parameter (where it is rendered into the
+    [description] string for the LLM) and the runtime guard in
+    [Keeper_exec_fs]. Surfacing it here keeps both consumers
+    locked to the same number. *)
+
+val keeper_fs_read_default_max_bytes_string : string
+(** [string_of_int keeper_fs_read_default_max_bytes]. Pre-rendered
+    so the schema description string can include it without a
+    per-schema-render allocation, and so the schema stays a
+    structural constant rather than a function call result. *)


### PR DESCRIPTION
## Summary

Cycle 67 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/tool_shard_limits.ml` (9 lines).

Surface (2 leaf constants):
- `val keeper_fs_read_default_max_bytes : int`
- `val keeper_fs_read_default_max_bytes_string : string`

No internals to hide — the module body is two top-level `let`s.

## Why typed surface (despite tiny module)

The value `20_000` appears in **two unrelated places**:
1. `lib/tool_shard.ml` — the JSON schema description for
   `keeper_fs_read`'s `max_bytes` parameter, rendered into the
   LLM-facing string.
2. `lib/keeper/keeper_exec_fs.ml` — the runtime byte-budget
   guard.

Pinning both the integer and its pre-rendered string variant in
the `.mli` keeps the schema description and runtime guard
locked to the same number. A future bump (e.g. 20_000 →
40_000) must touch this single file.

The pre-rendered string exists so the schema description does
not pay a per-render `string_of_int` and so the schema stays a
structural constant rather than a function-call result.

## Why the module exists at all

`tool_shard_limits.ml` is a leaf with no dependencies because
it broke a `Tool_shard ↔ Keeper_exec_fs` import cycle. The
`.mli` docstring records this load-bearing constraint so a
future "let's just inline these" refactor sees what it would
re-introduce.

## Skipped this cycle

`lib/board.ml` (`include Board_votes`) and
`lib/oas_model_resolve.ml` (`include Cascade_runtime`) — both
are facade-wrapper modules where an explicit `.mli` would force
`include module type of …` and create sync burden every time
the underlying lib changes. Same calculus as `lib/oas.ml`
(skipped previously).

## Caller audit (`rg "Tool_shard_limits\\."`)
- `lib/tool_shard.ml` — `keeper_fs_read_default_max_bytes_string`
- `lib/keeper/keeper_exec_fs.ml` —
  `keeper_fs_read_default_max_bytes` + a docstring reference

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
