### PR TITLE
fix(keeper): remove Docker→Local silent fallback in effective_sandbox_profile (sandbox root-fix 2/3)

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -122,16 +122,29 @@ let docker_private_workspace_cwd ~(config : Coord.config) ~(meta : keeper_meta)
 
 (* ── Profile resolution ────────────────────────────────── *)
 
+(* Invariant (root-fix family 2/3, 2026-04-28):
+   When [meta.sandbox_profile = Docker], the effective profile is ALWAYS
+   Docker, regardless of [in_playground]. The historical behavior of
+   silently dropping back to Local when the cwd was outside the playground
+   was the proximate cause of the host-fallback bypass reported in the
+   2026-04-28 sandbox audit. The Local→Docker upgrade path stays gated on
+   [in_playground] because that branch is opt-in via DockerPlayground —
+   only the down-conversion (Docker→Local) is removed. *)
 let effective_sandbox_profile ~(meta : keeper_meta) ~in_playground =
   if Env_config_keeper.KeeperSandbox.hard_mode () then
     (meta.sandbox_profile, meta.network_mode)
-  else if meta.sandbox_profile = Local
-     && Env_config_keeper.DockerPlayground.enabled
-     && in_playground
-  then
-    (Docker, Network_inherit)
   else
-    (meta.sandbox_profile, meta.network_mode)
+    match meta.sandbox_profile with
+    | Docker ->
+        (* Invariant: meta=Docker → effective=Docker. No silent host fallback. *)
+        (Docker, meta.network_mode)
+    | Local
+      when Env_config_keeper.DockerPlayground.enabled && in_playground ->
+        (* Opt-in upgrade: Local→Docker only when the playground feature is
+           enabled and the cwd is inside the playground root. *)
+        (Docker, Network_inherit)
+    | Local ->
+        (Local, meta.network_mode)
 
 (* ── Nested runtime detection ──────────────────────────── *)
 


### PR DESCRIPTION
## Why

Family **2/3** of the 2026-04-28 sandbox bypass root-fix series.

- PR-1 (#11594, merged): defect B (persistence). Strict parser + migration.
- **This PR**: defect C (logic). `effective_sandbox_profile` no longer downgrades a `Docker`-configured keeper to `Local` when the cwd happens to fall outside the playground root. That silent down-conversion was the proximate cause of `keeper_bash 'ls /Users/...'` running on the host for Docker-profile keepers.

## What changes

`lib/keeper/keeper_shell_docker.ml:125-148`:

- `meta.sandbox_profile = Docker` → invariant: effective `(Docker, meta.network_mode)`.
- `meta.sandbox_profile = Local` + `DockerPlayground.enabled` + `in_playground` → opt-in upgrade `(Docker, Network_inherit)` (unchanged).
- `meta.sandbox_profile = Local` (default) → `(Local, meta.network_mode)`.

The diff is +19/−6 across one file.

## What does NOT change (deferred)

1. `keeper_tools_oas.ml:431-444` `turn_sandbox_runtime` still reads `meta.sandbox_profile` directly. The factory-closure refactor that threads `effective_sandbox_profile ~in_playground` through the bundle is **PR-3b** (~24 cascade sites). The invariant change in this PR is sufficient on its own to close the silent-fallback path because `effective_sandbox_profile` is the SSOT consulted by `keeper_exec_shell.handle_keeper_bash` — once that returns `Docker`, the dispatch goes through `run_docker_hardened_bash` regardless of how the runtime was created.
2. TLA invariant. `specs/boundary/ToolCallContract.tla` is a telemetry boundary spec and does not model host-fallback as a possible `outcome`. A purpose-built `SandboxDispatch.tla` would be the right home for `DockerImpliesDockerVia`. Opening as a follow-up issue rather than retrofitting `ToolCallContract`.

## Verification

- `dune build @all` exit 0.
- 9/9 in-flight keepers verified valid post-#11594. The new invariant is preventative — it does not alter observed behavior on the current set; it removes the path that silently routed Docker-configured keepers to host on cwd-outside-playground.
- Reproducer (manual, post-merge):
  ```
  # Docker keeper, cwd outside playground:
  # AS-WAS: silent host fork/exec
  # AS-IS:  Docker container dispatch via run_docker_hardened_bash
  ```

## Coordination

- No new env flag (Hard cutover per user direction).
- Race-window: clean (no other open PR on `keeper_shell_docker.ml` / `effective_sandbox_profile`).
- Plan SSOT: `planning/claude-plans/30m-users-dancer-downloads-kimi-agent-greedy-pebble.md`

## Follow-up

- **PR-3b**: factory closure for `turn_sandbox_runtime` to honor `effective_sandbox_profile` at call time (in_playground sensitive). ~24 cascade sites in `keeper_tools_oas.ml`, `keeper_exec_tools.ml`, `keeper_exec_shell.ml`.
- **PR-2**: structural — `Shell_ir.simple` + `Sandbox_target.t` IR + `exec_dispatch` Docker route.
- **Issue**: TLA spec `SandboxDispatch.tla` for `DockerImpliesDockerVia` invariant + `BugAction_HostFallback`.