### PR TITLE
docs(keeper): add KeeperGenerationLineage.tla anchor in keeper_rollover (Cycle 31)

### DIFF
--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -4,7 +4,43 @@
     cooldown has elapsed, creates a new session with the current context
     carried forward to the next generation.
 
-    Extracted from Keeper_exec_context as part of #4955 god-file split. *)
+    Extracted from Keeper_exec_context as part of #4955 god-file split.
+
+    Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern.
+    Authoritative spec mirror is
+    [specs/keeper-state-machine/KeeperGenerationLineage.tla].
+
+    Spec lines 10-13 already cite this module:
+    "Modeled from: lib/keeper/keeper_post_turn.ml, lib/keeper/keeper_rollover.ml,
+    lib/keeper/keeper_types.mli".  This block is the reverse-direction
+    citation so code search for "KeeperGenerationLineage" lands here.
+
+    Spec semantics modelled (TLA+ -> OCaml):
+      keeper_phase                 [meta] phase as observed during
+                                   handoff (idle / running / handing_off).
+      generation                   [meta.generation] field — incremented
+                                   on every successful rollover here.
+      current_trace_id             new trace allocated by the rollover
+                                   path; replaces the previous trace on
+                                   successful handoff.
+      trace_history                append-only ancestry recorded into
+                                   meta when rollover commits.
+      ckpt_valid / ckpt_generation [Keeper_types]'s checkpoint lineage
+                                   parity that the handoff must preserve.
+
+    Spec scope (line 4-8):
+      - same keeper identity across generations
+      - trace_id replacement on successful handoff
+      - trace_history append-only ancestry
+      - checkpoint lineage parity once the keeper returns to idle
+
+    Out of scope (line 15-18):
+      - compaction strategy selection (KeeperCompactionLifecycle)
+      - tool execution / Agent.run turn loop
+      - long-term memory recall semantics
+
+    The spec models "same keeper, new trace" rather than a new child
+    runtime — this is the generation contract the rollover enforces. *)
 
 open Keeper_types
 open Keeper_context_core


### PR DESCRIPTION
## Summary

Continues the spec → code anchor pattern from **Cycles 24-30** (#11565 / #11583 / #11584 / #11596 / #11597 / #11599 / #11608).

Pre-PR grep for `Spec:` or `KeeperGenerationLineage` in `lib/keeper/keeper_rollover.ml` returned **zero hits**, even though `KeeperGenerationLineage.tla:10-13` already cited this module as one of three modeled OCaml sources.

## What changed

Module docstring extended with spec navigation block (no semantic change):

| Spec variable | OCaml meaning |
|---------------|---------------|
| `keeper_phase` | `meta`'s phase during handoff (idle / running / handing_off) |
| `generation` | `meta.generation` field — incremented on every successful rollover here |
| `current_trace_id` | new trace allocated by the rollover path |
| `trace_history` | append-only ancestry recorded into meta when rollover commits |
| `ckpt_valid` / `ckpt_generation` | checkpoint lineage parity that the handoff must preserve |

## Scope projection

Spec scope (line 4-8):
- same keeper identity across generations
- trace_id replacement on successful handoff
- trace_history append-only ancestry
- checkpoint lineage parity once the keeper returns to idle

Spec out-of-scope (line 15-18, **explicitly documented**):
- compaction strategy selection (lives in `KeeperCompactionLifecycle`)
- tool execution / `Agent.run` turn loop
- long-term memory recall semantics

The spec models "same keeper, new trace" rather than a new child runtime — this is the generation contract the rollover enforces.

## Why narrow / why not three files at once

The spec cites three OCaml modules: `keeper_post_turn.ml` (513 lines), `keeper_rollover.ml` (295), `keeper_types.mli` (404).  This PR anchors only `keeper_rollover.ml` because:

1. **Smallest target** — 295 lines, easiest review
2. **Semantic primary** — the spec's "same keeper, new trace" semantic literally lives here
3. **Narrow first PR pattern** — Cycles 27-30 each touched one file; this preserves that

Sibling anchors in `keeper_post_turn.ml` and `keeper_types.mli` are deferred to separate cycles if the user wants full coverage.

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_rollover.ml`) |
| Lines | +37 / -1 (comment-only, docstring extension) |
| Behavior change | none |
| Build | `dune build --root . lib/keeper/` ✅ |

## Plan reference

`/Users/dancer/me/planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md` §19 anchor pattern.

## Pattern reuse trail

- Cycle 24 (#11565) — derive_phase navigation block (C1 Phase 0)
- Cycle 25 (#11583) — N1 KeeperLaunchPending.tla
- Cycle 26 (#11584) — N2 Note A drift→resolved
- Cycle 27 (#11596) — B1 KeeperHeartbeat anchor
- Cycle 28 (#11597) — B2 KeeperTaskAcquisition anchor
- Cycle 29 (#11599) — B3 KeeperApprovalQueue anchor
- Cycle 30 (#11608) — KeeperCircuitBreaker anchor
- **Cycle 31 (this PR)** — KeeperGenerationLineage anchor (rollover only)