### PR TITLE
feat(prompt): add prompt_registry_store.mli — typed store record + lock surface (cycle 68)

### DIFF
--- a/lib/prompt_registry/prompt_registry_store.mli
+++ b/lib/prompt_registry/prompt_registry_store.mli
@@ -1,0 +1,44 @@
+(** Prompt_registry_store — process-wide prompt registry state +
+    its mutex.
+
+    Owns the four Hashtbls and two refs that {!Prompt_registry}
+    rebinds at the top level so the rest of the codebase can
+    keep using the bare names ([Prompt_registry.registry] /
+    [Prompt_registry.override_tbl] / etc) while the storage
+    layout itself lives in this module.
+
+    The record is exposed concretely because every field is
+    rebound by name in [prompt_registry.ml]; hiding the layout
+    behind an abstract type would force a getter helper for each
+    field without making the abstraction any richer.
+
+    Internal helper [default_state] (the cached singleton) is
+    hidden — callers consume it through the {!default} accessor. *)
+
+type t = {
+  registry : (string, Prompt_registry_types.prompt_entry) Hashtbl.t;
+  version_index : (string, string list) Hashtbl.t;
+  override_tbl : (string, string) Hashtbl.t;
+  meta_tbl : (string, Prompt_registry_types.prompt_meta) Hashtbl.t;
+  prompts_dir : string option ref;
+  markdown_dir : string option ref;
+  mutex : Eio.Mutex.t;
+}
+
+val create : unit -> t
+(** Build a fresh store with empty Hashtbls (capacities matched
+    to historical workload — 64 / 64 / 16 / 32), [None] dir refs,
+    and a fresh [Eio.Mutex.t]. Tests use this to avoid cross-case
+    pollution. *)
+
+val default : unit -> t
+(** Return the process-wide singleton store. Identity-stable
+    across calls; prefer {!create} in tests when isolation is
+    required. *)
+
+val with_lock : t -> (unit -> 'a) -> 'a
+(** Run [f ()] under the store's mutex via
+    [Eio_guard.with_mutex]. The lock is released on every exit
+    path including exceptions and ambient cancel; callers must
+    not block on disk / network I/O inside [f] (the prompt
+    registry mutex is hot-path). *)


### PR DESCRIPTION
## Summary

Cycle 68 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for
`lib/prompt_registry/prompt_registry_store.ml` (29 lines).

Surface (concrete record + 3 entry points):
- `type t = { registry; version_index; override_tbl;
              meta_tbl; prompts_dir; markdown_dir; mutex }`
- `val create   : unit -> t`
- `val default  : unit -> t`
- `val with_lock : t -> (unit -> 'a) -> 'a`

Hidden internals:
- `val default_state` — the cached singleton, exposed via
  `default ()`

## Why concrete record (not abstract)

Every field is rebound by name in
`lib/prompt_registry/prompt_registry.ml`:

```ocaml
let registry = store.registry
let version_index = store.version_index
let override_tbl = store.override_tbl
let meta_tbl = store.meta_tbl
let prompts_dir = store.prompts_dir
let markdown_dir = store.markdown_dir
```

so the rest of the codebase keeps using the bare names
`Prompt_registry.registry` / `Prompt_registry.override_tbl` /
etc. Hiding the layout behind an abstract type would force a
getter helper for each field without making the abstraction any
richer — the storage *is* the contract.

## Why with_lock contract is load-bearing

The docstring documents:
1. Lock released on every exit path including exceptions /
   ambient cancel (via `Eio_guard.with_mutex`).
2. Hot-path warning — callers must not block on disk / network
   I/O inside `f`.

This rule has bitten the codebase before (`prompt_registry
_unlocked` drift, fixed in PR #6663). Making the constraint
explicit at the contract seam is load-bearing — a future
"let's add a slow op inside the lock" refactor sees the rule.

## Caller audit (`rg "Prompt_registry_store"`)
- `lib/prompt_registry/prompt_registry.ml` — `default` +
  `with_lock` + every field rebind

No external reference to `default_state`.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
