### PR TITLE
docs(keeper): add KeeperGenerationLineage.tla anchor in keeper_post_turn (Cycle 32)

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -11,7 +11,42 @@
     - memory bank / episodes: [Keeper_agent_run] tail after [Agent.run]
     - hebbian: task lifecycle in [Coord_task]
 
-    Extracted from Keeper_exec_context as part of #4955 god-file split. *)
+    Extracted from Keeper_exec_context as part of #4955 god-file split.
+
+    Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern.  Sibling
+    to #11612 (Cycle 31, [keeper_rollover.ml]).  Authoritative spec
+    mirror is [specs/keeper-state-machine/KeeperGenerationLineage.tla].
+
+    Spec lines 10-13 already cite this module as one of three modeled
+    OCaml sources:
+      - lib/keeper/keeper_post_turn.ml   (this file — post-turn pipeline)
+      - lib/keeper/keeper_rollover.ml    (rollover semantics — anchored
+                                          in #11612)
+      - lib/keeper/keeper_types.mli      (type lineage — anchor deferred)
+
+    This block is the reverse-direction citation so code search for
+    "KeeperGenerationLineage" lands here.
+
+    Post-turn -> spec mapping:
+      Compaction phase    feeds into [keeper_phase] = "running" while
+                          the in-flight turn is still resolving.
+      Handoff rollover    delegates to [Keeper_rollover.attempt] and
+                          increments [meta.generation] — spec's
+                          generation variable.  The new trace_id and
+                          trace_history append happen there.
+      Continuity summary  refreshes the [meta.continuity_summary] /
+                          checkpoint pair after rollover, preserving
+                          the spec's [ckpt_valid] / [ckpt_generation]
+                          parity invariant.
+
+    Spec scope (line 4-8): same identity across generations,
+    trace_id replacement, append-only ancestry, checkpoint lineage
+    parity once back to idle.
+
+    Spec out-of-scope (line 15-18 in spec): compaction strategy
+    selection (KeeperCompactionLifecycle), Agent.run turn loop,
+    long-term memory recall.  This module *triggers* compaction but
+    does not *select* the strategy. *)
 
 open Keeper_types
 open Keeper_memory


### PR DESCRIPTION
## Summary

Sibling to **#11612** (Cycle 31, `keeper_rollover.ml`).  `KeeperGenerationLineage.tla` cites three modeled OCaml sources; this PR adds the second of three reverse-direction anchors.

Pre-PR grep for `Spec:` or `KeeperGenerationLineage` in `lib/keeper/keeper_post_turn.ml` returned **zero hits**.

## What changed

Module docstring extended (lines 1-14 → 1-58, comment-only):

| Post-turn pipeline phase | Spec mapping |
|--------------------------|--------------|
| Compaction phase | feeds into `keeper_phase = "running"` while in-flight turn resolves |
| Handoff rollover | delegates to `Keeper_rollover.attempt`, increments `meta.generation` (spec's `generation` variable) |
| Continuity summary | refreshes `meta.continuity_summary` / checkpoint pair, preserving `ckpt_valid` / `ckpt_generation` parity |

## Triangulation noted in anchor block

- **post_turn** *triggers* compaction; **selects strategy**: `KeeperCompactionLifecycle`
- **post_turn** delegates rollover semantics to `Keeper_rollover` (anchored in #11612)
- **post_turn** updates continuity which preserves spec's checkpoint parity

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_post_turn.ml`, 513 lines) |
| Lines | +36 / -1 (comment-only, docstring extension) |
| Behavior change | none |
| Build | `dune build --root . lib/keeper/` ✅ |

## Pattern reuse trail (8 + 1 PRs)

- Cycle 24-31: derive_phase, KeeperLaunchPending spec, Note A resolved, B1/B2/B3 trio, CircuitBreaker, GenerationLineage 1/3
- **Cycle 32 (this PR)**: GenerationLineage 2/3 (post_turn)

Third sibling (`keeper_types.mli`, 404 lines) deferred to a separate cycle — the mli is type-definition surface that deserves its own narrow PR.

## Plan reference

`/Users/dancer/me/planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md` §19.12 anchor pattern continuation.