### PR TITLE
docs(keeper): add KeeperGenerationLineage.tla anchor in keeper_types.mli (Cycle 33)

### DIFF
--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -3,7 +3,46 @@
 
     Re-exports everything from {!Keeper_types_profile} (context, schemas,
     profile defaults, path helpers) and {!Keeper_types_support}
-    (model selection, JSONL helpers, metrics store). *)
+    (model selection, JSONL helpers, metrics store).
+
+    Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern.  Sibling
+    to #11612 (rollover) and #11614 (post_turn).  Authoritative spec
+    mirror is [specs/keeper-state-machine/KeeperGenerationLineage.tla].
+
+    Spec lines 10-13 already cite this module among three modeled
+    OCaml sources:
+      - lib/keeper/keeper_post_turn.ml   (post-turn pipeline,
+                                          anchored in #11614)
+      - lib/keeper/keeper_rollover.ml    (rollover semantics,
+                                          anchored in #11612)
+      - lib/keeper/keeper_types.mli      (this file — type lineage)
+
+    This block is the reverse-direction citation so code search for
+    "KeeperGenerationLineage" lands here too.
+
+    Type lineage covered (TLA+ -> OCaml):
+      generation                 [keeper_meta.generation : int] —
+                                 incremented on rollover.  See
+                                 [Keeper_types_profile] and
+                                 [Keeper_rollover.attempt].
+      current_trace_id           [keeper_meta.trace_id : string] —
+                                 replaced on successful handoff.
+      trace_history              [keeper_meta.trace_history : string list] —
+                                 append-only; most recent is at head
+                                 or tail per the OCaml convention used
+                                 in Keeper_rollover.
+      ckpt_valid / ckpt_generation
+                                 derived from [keeper_meta.checkpoint]
+                                 fields, the parity check
+                                 [keeper_phase = idle => ckpt is
+                                 consistent with current generation]
+                                 lives in [Keeper_post_turn] when the
+                                 turn returns to idle.
+
+    Spec out-of-scope (line 15-18 in spec): compaction strategy
+    selection (KeeperCompactionLifecycle), Agent.run turn loop,
+    long-term memory recall.  This module re-exports policy types
+    only — no behavior. *)
 
 include module type of Keeper_types_profile
 


### PR DESCRIPTION
## Summary

**Closes the GenerationLineage trio** (3/3 anchor coverage).  Sibling to:
- **#11612** (Cycle 31): `keeper_rollover.ml` — rollover semantics (1/3)
- **#11614** (Cycle 32): `keeper_post_turn.ml` — post-turn pipeline (2/3)
- **This PR** (Cycle 33): `keeper_types.mli` — type lineage (3/3)

`KeeperGenerationLineage.tla:10-13` cited three modeled OCaml sources; all three now have reverse-direction anchors.

Pre-PR grep for `Spec:` or `KeeperGenerationLineage` in `keeper_types.mli` returned **zero hits**.

## What changed

Module docstring extended (lines 1-6 → 1-46, comment-only):

| Spec variable | OCaml field | Behavior owner |
|---------------|-------------|----------------|
| `generation` | `keeper_meta.generation : int` | `Keeper_rollover.attempt` (#11612) |
| `current_trace_id` | `keeper_meta.trace_id : string` | `Keeper_rollover` |
| `trace_history` | `keeper_meta.trace_history : string list` | `Keeper_rollover` (append) |
| `ckpt_valid / ckpt_generation` | `keeper_meta.checkpoint` fields | `Keeper_post_turn` (back-to-idle parity check) (#11614) |

Records that this module re-exports policy types only — the **behaviour** lives in the two sibling modules.  mli files are pure interface; anchor-only is the natural form here.

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_types.mli`, 404 lines) |
| Lines | +40 / -1 (comment-only, docstring extension) |
| Behavior change | none (mli-only) |
| Build | `dune build --root . lib/keeper/` ✅ |

## GenerationLineage coverage matrix (closed)

| Spec source line | OCaml file | Anchor PR | Status |
|------------------|-----------|-----------|--------|
| spec:11 | `keeper_post_turn.ml` | #11614 | Cycle 32 ✅ |
| spec:12 | `keeper_rollover.ml` | #11612 | Cycle 31 ✅ |
| spec:13 | `keeper_types.mli` | this PR | Cycle 33 ✅ |

After all three merge, every spec citation has a reverse anchor — bidirectional discoverability for KeeperGenerationLineage.

## Plan reference

`/Users/dancer/me/planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md` §19.12 anchor pattern continuation.