### PR TITLE
feat(telemetry): add telemetry_coverage_gap.mli — typed durable-gap surface (cycle 69)

### DIFF
--- a/lib/telemetry_coverage_gap.mli
+++ b/lib/telemetry_coverage_gap.mli
@@ -1,0 +1,48 @@
+(** Telemetry_coverage_gap — durable record of telemetry write-path
+    failures.
+
+    A "coverage gap" is a moment when one telemetry lane wrote
+    successfully but another did not, leaving the dashboards
+    showing stale data even though the producer is healthy.
+    {!record} stamps both a Prometheus counter
+    ([metric_telemetry_coverage_gap]) and a JSONL row under
+    [<masc_root>/telemetry-coverage-gaps/] so unified telemetry
+    can surface the gap on its next read.
+
+    Internal helpers (the [store_dir] path joiner and the
+    [string_opt_json] None-vs-empty serialiser) are hidden —
+    callers consume only the recorder and the reader. *)
+
+val record :
+  masc_root:string ->
+  source:string ->
+  producer:string ->
+  durable_store:string ->
+  dashboard_surface:string ->
+  stale_reason:string ->
+  ?keeper_name:string ->
+  ?trace_id:string ->
+  ?error:string ->
+  unit ->
+  unit
+(** Append one [masc.telemetry_coverage_gap.v1] JSONL row to the
+    durable store and bump
+    [Prometheus.metric_telemetry_coverage_gap] with the
+    ([source] / [producer] / [dashboard_surface] / [stale_reason])
+    label tuple.
+
+    [keeper_name] / [trace_id] / [error] are optional contextual
+    fields — when omitted (or empty after trim) the JSON value
+    is rendered as [`Null] rather than the empty string so
+    downstream consumers can distinguish "missing" from
+    "deliberately blank". *)
+
+val read_recent :
+  masc_root:string ->
+  n:int ->
+  Yojson.Safe.t list
+(** Return the most recent [n] JSON rows from the coverage-gap
+    store. Newest-first ordering matches
+    [Dated_jsonl.read_recent]. Returns the empty list when
+    [n <= 0] or when the store directory does not yet exist
+    (no rows have been recorded for this [masc_root]). *)


### PR DESCRIPTION
## Summary

Cycle 69 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/telemetry_coverage_gap.ml`
(48 lines).

Surface:
- `val record : masc_root:string -> source:string ->
                producer:string -> durable_store:string ->
                dashboard_surface:string -> stale_reason:string ->
                ?keeper_name:string -> ?trace_id:string ->
                ?error:string -> unit -> unit`
- `val read_recent : masc_root:string -> n:int ->
                       Yojson.Safe.t list`

Hidden internals:
- `val store_dir` — `<masc_root>/telemetry-coverage-gaps/`
  path joiner
- `val string_opt_json` — None-vs-empty serialiser

## Why typed surface

The module produces both a Prometheus counter and a JSONL
durable record per gap event; six different consumers
(`tool_usage_log`, `mcp_server_eio_call_tool`,
`telemetry_unified`, two dashboard handlers, the freshness
probe) read it back. The contract surface is operationally
load-bearing — the dashboards cross-reference the gap rows
against telemetry rows to decide whether a stale lane is "no
data yet" or "write-path failure".

The `Null`-vs-empty distinction is documented at the seam:
when `keeper_name` / `trace_id` / `error` are omitted or empty
after trim, the JSON value renders as `` `Null `` rather than
`` `String "" ``. Downstream consumers rely on this to
distinguish "missing" from "deliberately blank"; pinning it
in the `.mli` prevents a future "let's normalise to empty
string" refactor from silently changing dashboard semantics.

The schema string (`"masc.telemetry_coverage_gap.v1"`) is **not**
exposed — it is part of the persisted JSONL contract, not the
OCaml call surface; consumers parse it from the row rather than
comparing against this module's literal.

## Caller audit (`rg "Telemetry_coverage_gap\\."`)

`record`:
- `lib/tool_usage_log.ml`
- `lib/mcp_server_eio_call_tool.ml`
- `test/test_dashboard_tools.ml`

`read_recent`:
- `lib/tool_usage_log.ml` (n=50)
- `lib/telemetry_unified.ml` (n=50)
- `lib/server/server_dashboard_http_keeper_api.ml` (2 sites, n=32)
- `lib/dashboard_tool_source_freshness.ml` (n=50)
- `lib/dashboard/dashboard_http_keeper.ml`
- `test/test_dashboard_tools.ml`

No external reference to `store_dir` / `string_opt_json`.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI) — `test_dashboard_tools` exercises
      record + read_recent round-trip
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
