### PR TITLE
docs(keeper): add KeeperMemoryLifecycle.tla anchor in keeper_memory_policy (Cycle 34)

### DIFF
--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -1,5 +1,44 @@
 (** Keeper_memory — memory-bank paths, reward-model evaluation,
-    state snapshots, recall scoring, and metrics summaries. *)
+    state snapshots, recall scoring, and metrics summaries.
+
+    Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern.
+    Authoritative spec mirror is
+    [specs/keeper-state-machine/KeeperMemoryLifecycle.tla] (#8642 family).
+
+    Spec lines 17-35 already cite this module field-by-field:
+      short_mem / mid_mem / long_mem  -> rows with [horizon] in
+                                         {"short_term", "mid_term",
+                                          "long_term"}, see the
+                                         constants
+                                           [short_term_horizon] (~line 165)
+                                           [mid_term_horizon]   (next)
+                                           [long_term_horizon]  (next)
+      provenanced  -> rows with non-empty trace_id / source
+                      (lives in keeper_memory_bank, not this file).
+      producer     -> [memory_horizon_of_kind_opt] (~line 171, strict)
+                      and [memory_horizon_of_kind] (~line 182,
+                      back-compat wrapper that defaults unknown kinds
+                      to mid_term with a warn — see #8826 drift note).
+
+    This block is the reverse-direction citation so code search for
+    "KeeperMemoryLifecycle" lands here.
+
+    Spec line drift correction:
+      Spec line 19-21 cites "ml:155 / ml:156 / ml:157" for the three
+      horizon constants; current actual line is 165 (+10 drift).  The
+      shift is because new `compaction_outcome` record fields were
+      inserted between the spec citation and the constants.  The
+      function-name citations ([memory_horizon_of_kind_opt],
+      [memory_horizon_of_kind]) remain stable.
+
+    Spec safety goals (line 9-13):
+      - every persisted note has provenance
+      - overflow / handoff do not silently drop retained notes
+      - handoff clears stale short-term notes
+      - each tier stays within its configured bound
+
+    Sibling spec anchors deferred:
+      - keeper_memory_bank.ml (open_short / provenanced semantics) *)
 
 open Keeper_types
 


### PR DESCRIPTION
## Summary

Continues the spec → code anchor pattern from **Cycles 24-33** (10 prior PRs).

Pre-PR grep for `Spec:` or `KeeperMemoryLifecycle` in `lib/keeper/keeper_memory_policy.ml` returned **zero hits**, even though `KeeperMemoryLifecycle.tla:17-35` already cited this module field-by-field.

## What changed

Module docstring extended (lines 1-2 → 1-43, comment-only):

| Spec variable | OCaml entity (function-name citation) |
|---------------|---------------------------------------|
| `short_mem` / `mid_mem` / `long_mem` | rows with `horizon` in {`short_term`, `mid_term`, `long_term`}, see `short_term_horizon` (~line 165) and siblings |
| `provenanced` | rows with non-empty trace_id / source (lives in `keeper_memory_bank.ml`, not this file) |
| `producer` | `memory_horizon_of_kind_opt` (~line 171, strict) and `memory_horizon_of_kind` (~line 182, back-compat wrapper that defaults unknown kinds to `mid_term` with a warn — see #8826 drift note) |

## Spec line drift correction

`KeeperMemoryLifecycle.tla:19-21` cites `ml:155 / ml:156 / ml:157` for the three horizon constants.  Current actual line is **165** (+10 drift), introduced by new `compaction_outcome` record fields inserted earlier in the file.

The anchor block uses **function-name citations** rather than line numbers, so further drift in nearby record fields will not invalidate the citations.

## Spec safety goals (recorded in anchor)

- every persisted note has provenance
- overflow / handoff do not silently drop retained notes
- handoff clears stale short-term notes
- each tier stays within its configured bound

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_memory_policy.ml`, 982 lines) |
| Lines | +40 / -1 (comment-only, docstring extension) |
| Behavior change | none |
| Build | `dune build --root . lib/keeper/` ✅ |

## Deferred

`keeper_memory_bank.ml` (open_short / provenanced semantics) — sibling anchor for the same spec, deferred to a separate cycle.

## Plan reference

`/Users/dancer/me/planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md` §19.12 anchor pattern continuation.

## Pattern reuse trail (11 PRs total)

24 derive_phase / 25 LaunchPending / 26 Note A resolved / 27 Heartbeat / 28 TaskAcquisition / 29 ApprovalQueue / 30 CircuitBreaker / 31 Rollover / 32 PostTurn / 33 Types / **34 MemoryPolicy (this PR)**