### PR TITLE
docs(keeper): add OperatorPauseBroadcast.tla anchor at broadcast hook (Cycle 35)

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -403,7 +403,45 @@ let to_json (receipt : t) =
    verdict therefore had no transition out: dashboard turned a chip red, but
    no event reached operators and no supervisor handoff fired. We now emit a
    structured "keeper.operator_broadcast_required" activity event so the gate
-   verdict becomes addressable instead of cosmetic. *)
+   verdict becomes addressable instead of cosmetic.
+
+   Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern.
+   Authoritative spec mirror is
+   [specs/keeper-state-machine/OperatorPauseBroadcast.tla].
+
+   Spec lines 17-21 already cite this module:
+     "lib/keeper/keeper_execution_receipt.ml: needs_operator_broadcast +
+      emit_operator_broadcast called from append".
+
+   This block is the reverse-direction citation so code search for
+   "OperatorPauseBroadcast" lands at this hook.
+
+   Spec property under audit (line 11-15):
+     For every keeper that enters PauseHuman or StaleRunning, an
+     OperatorBroadcast event is eventually emitted (leads-to).  The
+     clean Spec satisfies this; the bug model where emit is silently
+     dropped MUST violate it.
+
+   OCaml mapping:
+     PauseHuman / StaleRunning  -> [needs_operator_broadcast]
+                                  returns [true] for "pause_human",
+                                  "alert_exhausted", "unknown".
+     OperatorBroadcast event    -> [emit_operator_broadcast]
+                                  emits "keeper.operator_broadcast_required.v1"
+                                  with structured payload.
+     Eventually-emit liveness   -> [append] (~line 455) calls the
+                                  emit unconditionally when
+                                  [needs_operator_broadcast] is true,
+                                  inside a [try] so a single failure
+                                  does not cascade — the spec's clean
+                                  model.
+
+   Bug model (would be violated if a future refactor wrapped emit
+   in a conditional that could silently skip): an OperatorBroadcast
+   path that requires manual operator dispatch instead of automatic
+   emit would re-create the original #fleet-stall bug.  Sibling
+   anchor in [keeper_supervisor.ml] (StaleRunning watchdog +
+   emit_stale_keeper_broadcast) is deferred to a separate cycle. *)
 let needs_operator_broadcast = function
   | "pause_human" | "alert_exhausted" | "unknown" -> true
   | _ -> false


### PR DESCRIPTION
## Summary

Continues the spec → code anchor pattern from **Cycles 24-34** (11 prior PRs).

The `keeper_execution_receipt` module already carries an anchor for `ReceiptOutcomeSet` (lines 1-9: "Mirrors the TLA+ spec [ReceiptOutcomeSet]…").  **This PR adds a second spec anchor in the same module** — for `OperatorPauseBroadcast` at the existing `#fleet-stall` broadcast hook (line 401-406 → extended).

Pre-PR grep for `OperatorPauseBroadcast` in `keeper_execution_receipt.ml` returned **zero hits**, even though `OperatorPauseBroadcast.tla:17-21` already cited `needs_operator_broadcast` + `emit_operator_broadcast` in this module.

## What changed

Anchor block extended at the existing `#fleet-stall` docstring (lines 401-406 → 401-451, comment-only):

| Spec entity | OCaml mapping |
|-------------|---------------|
| `PauseHuman` / `StaleRunning` | `needs_operator_broadcast` returns `true` for `"pause_human"`, `"alert_exhausted"`, `"unknown"` |
| `OperatorBroadcast` event | `emit_operator_broadcast` emits `"keeper.operator_broadcast_required.v1"` |
| Eventually-emit liveness | `append` (~line 455) calls emit unconditionally inside a `try` — clean Spec model |

## Spec property under audit (recorded in anchor)

> For every keeper that enters PauseHuman or StaleRunning, an OperatorBroadcast event is eventually emitted (leads-to). The clean Spec satisfies this; the bug model where emit is silently dropped MUST violate it.

The anchor block notes the regression pattern: a refactor that wraps emit in a conditional that could silently skip would re-create the original `#fleet-stall` bug — the spec's bug model now catches that pattern.

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_execution_receipt.ml`, 515 lines) |
| Lines | +39 / -1 (comment-only, docstring extension) |
| Behavior change | none |
| Build | `dune build --root . lib/keeper/` ✅ |

## Deferred

Sibling anchor in `keeper_supervisor.ml` (`StaleRunning` watchdog + `emit_stale_keeper_broadcast`, 1011 lines) — separate cycle.

## Plan reference

`/Users/dancer/me/planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-wobbly-shell.md` §19.12 anchor pattern continuation.

## Pattern reuse trail (12 PRs total)

24 derive_phase / 25 LaunchPending / 26 Note A resolved / 27 Heartbeat / 28 TaskAcquisition / 29 ApprovalQueue / 30 CircuitBreaker / 31 Rollover / 32 PostTurn / 33 Types / 34 MemoryPolicy / **35 ExecutionReceipt OperatorPauseBroadcast (this PR)**

## Sub-pattern observation

This is the first PR in the chain where a single OCaml file has **two distinct spec anchors** (`ReceiptOutcomeSet` already + `OperatorPauseBroadcast` now).  Multi-spec coverage of one OCaml module is exactly what plan §1's "honest representation" advocates — each spec owns a distinct property, the OCaml file is the honest implementation surface.