### PR TITLE
feat(autonomous): Tier B4 — Autonomous_state pure value + tick stub (Cycle 21)

### DIFF
--- a/lib/autonomous/autonomous_state.ml
+++ b/lib/autonomous/autonomous_state.ml
@@ -1,0 +1,108 @@
+(* Autonomous_state — pure state value for the autonomous loop.
+   Cycle 21 / Tier B4. See autonomous_state.mli for the design rationale. *)
+
+module Phase = Autonomous_phase
+module Outcome = Shared_types.Resilience_outcome
+module Confidence = Shared_types.Confidence
+
+(* ── Phase-indexed context ──────────────────────────────────────── *)
+
+type 'phase ctx =
+  | Idle_ctx : {
+      created_at : float;
+      meta : Yojson.Safe.t;
+    }
+      -> Phase.idle ctx
+  | Perceiving_ctx : Phase.perceiving ctx
+  | Intending_ctx : Phase.intending ctx
+  | Planning_ctx : Phase.planning ctx
+  | Executing_ctx : Phase.executing ctx
+  | Verifying_ctx : Phase.verifying ctx
+  | Reflecting_ctx : Phase.reflecting ctx
+  | Adapting_ctx : Phase.adapting ctx
+
+(* ── Existential packings ──────────────────────────────────────── *)
+
+type phase_packed = Packed_phase : 'a Phase.any -> phase_packed
+
+type ctx_packed = Packed_ctx : 'a ctx -> ctx_packed
+
+(* ── The state record ──────────────────────────────────────────── *)
+
+type t = {
+  phase : phase_packed;
+  ctx : ctx_packed;
+  iteration_count : int;
+  created_at : float;
+  last_tick_at : float;
+}
+
+(* ── Construction ──────────────────────────────────────────────── *)
+
+let init ?(meta = `Null) ~now () =
+  let idle_ctx = Idle_ctx { created_at = now; meta } in
+  {
+    phase = Packed_phase Phase.Any_idle;
+    ctx = Packed_ctx idle_ctx;
+    iteration_count = 0;
+    created_at = now;
+    last_tick_at = now;
+  }
+
+(* ── Inspection ────────────────────────────────────────────────── *)
+
+let current_phase t =
+  match t.phase with Packed_phase any -> Phase.any_to_tag any
+
+let current_phase_string t =
+  match t.phase with Packed_phase any -> Phase.any_to_string any
+
+let iteration_count t = t.iteration_count
+let created_at t = t.created_at
+let last_tick_at t = t.last_tick_at
+
+(* ── Lifecycle ─────────────────────────────────────────────────── *)
+
+let tick t ~now =
+  let advanced =
+    {
+      t with
+      iteration_count = t.iteration_count + 1;
+      last_tick_at = now;
+    }
+  in
+  Outcome.full
+    ~value:advanced
+    ~confidence:(Confidence.make 1.0)
+    ~artifacts:[]
+
+(* ── Serialisation ─────────────────────────────────────────────── *)
+
+(* Project the existential ctx to its JSON representation. Only
+   Idle_ctx carries actual payload at this Tier; the other seven
+   stub constructors render as the empty object. The [type a.]
+   annotation is required so the GADT match accepts the eight
+   different phantom indices uniformly. *)
+let ctx_to_json : type a. a ctx -> Yojson.Safe.t = function
+  | Idle_ctx { created_at; meta } ->
+      `Assoc
+        [ ("created_at", `Float created_at); ("meta", meta) ]
+  | Perceiving_ctx -> `Assoc []
+  | Intending_ctx -> `Assoc []
+  | Planning_ctx -> `Assoc []
+  | Executing_ctx -> `Assoc []
+  | Verifying_ctx -> `Assoc []
+  | Reflecting_ctx -> `Assoc []
+  | Adapting_ctx -> `Assoc []
+
+let to_json t =
+  let ctx_json =
+    match t.ctx with Packed_ctx c -> ctx_to_json c
+  in
+  `Assoc
+    [ ("phase", `String (current_phase_string t));
+      ("iteration_count", `Int t.iteration_count);
+      ("created_at", `Float t.created_at);
+      ("last_tick_at", `Float t.last_tick_at);
+      ("ctx", ctx_json);
+    ]

--- a/lib/autonomous/autonomous_state.mli
+++ b/lib/autonomous/autonomous_state.mli
@@ -1,0 +1,130 @@
+(** Autonomous_state — pure state value for the autonomous loop.
+
+    Cycle 21 / Tier B4 — first cut.
+
+    {1 Scope of this PR}
+
+    - {!ctx} GADT type with 8 constructors, one per phase. Only
+      {!Idle_ctx} is fully defined (carries [created_at] and a
+      placeholder [meta] JSON payload). The other 7 are stub
+      variants with no payload, to be filled in by later Tiers when
+      the upstream modules land (Stimulus, Intent, Plan,
+      Orchestrator, etc.). The phase-indexed types still mirror
+      {!Autonomous_phase}'s 8 phantom witnesses.
+    - {!t} record carrying an existential phase witness, an
+      existential ctx, and bookkeeping ([iteration_count],
+      [created_at], [last_tick_at]).
+    - {!init} returning an Idle state.
+    - {!tick} that always returns
+      [Resilience_outcome.FullSuccess]; concrete sub-phase
+      transition logic is deferred to Tier A4
+      ([Autonomous_bridge.tick]).
+    - {!to_json} for deterministic test assertions.
+
+    {1 Why existential packing inside the record?}
+
+    OCaml records cannot have universally polymorphic fields like
+    [phase_any : 'a. 'a Autonomous_phase.any]; the only way to
+    carry a value whose phantom type is hidden behind an
+    existential is to wrap it in another GADT constructor that
+    erases the type parameter ({!phase_packed} and {!ctx_packed}).
+    Pattern matching on those wrappers re-introduces the unknown
+    [type a.] locally where needed, which is how the mli/ml
+    boundary stays honest about the heterogeneity.
+
+    {1 Deferred (later Tiers)}
+
+    - Full {!Idle_ctx} fields: [Resource_budget.snapshot],
+      [Goal_dag.t], [Self_priority.t]. Requires those modules,
+      which arrive in later Cycles.
+    - Other ctx constructors' payloads (Stimulus list, Intent.t
+      option, Plan.t, etc.).
+    - [apply_transition] — Tier B5 introduces the transition GADT.
+    - [of_json] — paired with the schema settling (Idle_ctx
+      gaining real fields).
+    - Memory/Checkpoint integration — Tier A5. *)
+
+(** {1 Phase-indexed context}
+
+    Each constructor narrows the phase index ['phase] to a specific
+    {!Autonomous_phase} witness. Only [Idle_ctx] is fully
+    populated at this Tier; the other seven are stub markers
+    reserved for the type system. *)
+type 'phase ctx =
+  | Idle_ctx : {
+      created_at : float;
+      meta : Yojson.Safe.t;
+        (** Placeholder for budget / goals / priority payload until
+            those modules land. *)
+    }
+      -> Autonomous_phase.idle ctx
+  | Perceiving_ctx : Autonomous_phase.perceiving ctx
+  | Intending_ctx : Autonomous_phase.intending ctx
+  | Planning_ctx : Autonomous_phase.planning ctx
+  | Executing_ctx : Autonomous_phase.executing ctx
+  | Verifying_ctx : Autonomous_phase.verifying ctx
+  | Reflecting_ctx : Autonomous_phase.reflecting ctx
+  | Adapting_ctx : Autonomous_phase.adapting ctx
+
+(** {1 Existential packings for record-level erasure} *)
+
+(** Packs an [_ Autonomous_phase.any] witness, hiding the phantom
+    index. Used inside {!t} where universal-polymorphic fields are
+    not expressible. *)
+type phase_packed =
+  | Packed_phase : 'a Autonomous_phase.any -> phase_packed
+
+(** Packs a {!ctx} value, hiding the phantom index. *)
+type ctx_packed = Packed_ctx : 'a ctx -> ctx_packed
+
+(** {1 The state record} *)
+
+type t = {
+  phase : phase_packed;
+  ctx : ctx_packed;
+  iteration_count : int;
+  created_at : float;
+  last_tick_at : float;
+}
+
+(** {1 Construction and inspection} *)
+
+val init : ?meta:Yojson.Safe.t -> now:float -> unit -> t
+(** Create an initial state in the [Idle] phase. [meta] defaults
+    to [`Null] and is reserved for future budget/goals/priority
+    payloads. *)
+
+val current_phase : t -> Autonomous_phase.tag
+(** The phase tag of the current state. *)
+
+val current_phase_string : t -> string
+(** [Autonomous_phase.to_tla_symbol (current_phase t)]. *)
+
+val iteration_count : t -> int
+val created_at : t -> float
+val last_tick_at : t -> float
+
+(** {1 Lifecycle} *)
+
+val tick :
+  t -> now:float -> (t, string) Shared_types.Resilience_outcome.t
+(** Advance the loop by one iteration.
+
+    {b Stub}: the current implementation increments
+    [iteration_count], updates [last_tick_at] to [now], and returns
+    [FullSuccess] with full confidence and no artifacts. Real
+    sub-phase progression (Idle → Perceiving → ...) is deferred to
+    Tier A4 ([Autonomous_bridge.tick]) which wires this into the
+    Keeper observer pipeline.
+
+    The error type is fixed to [string] for now — Tier B6
+    introduces [Recovery.strategy] which will be re-targeted by a
+    follow-up PR with no constructor renaming. *)
+
+(** {1 Serialisation} *)
+
+val to_json : t -> Yojson.Safe.t
+(** Render the state to JSON. The current phase is serialised via
+    {!Autonomous_phase.to_tla_symbol}. The [Idle_ctx] [meta]
+    payload, when present, is included verbatim under
+    ["ctx_meta"]. *)

--- a/lib/autonomous/dune
+++ b/lib/autonomous/dune
@@ -3,5 +3,6 @@
 (library
  (name autonomous)
  (public_name masc_mcp.autonomous)
+ (libraries shared_types yojson)
  (preprocess
   (pps ppx_tla)))

--- a/test/autonomous/dune
+++ b/test/autonomous/dune
@@ -1,3 +1,3 @@
-(test
- (name test_autonomous_phase)
- (libraries autonomous))
+(tests
+ (names test_autonomous_phase test_autonomous_state)
+ (libraries autonomous shared_types yojson))

--- a/test/autonomous/test_autonomous_state.ml
+++ b/test/autonomous/test_autonomous_state.ml
@@ -1,0 +1,105 @@
+(* Cycle 21 / Tier B4 tests — Autonomous_state initial Idle state,
+   tick stub, and JSON projection.
+
+   Validates:
+   - [init] produces an Idle phase with iteration_count = 0
+   - [current_phase] / [current_phase_string] reflect the packed any
+   - [tick] returns FullSuccess with iteration_count incremented and
+     last_tick_at advanced
+   - [tick]'s value preserves [created_at]
+   - [to_json] keys + Idle_ctx [meta] passthrough
+   - Default [meta] is [`Null]
+   - Custom [meta] is round-tripped via JSON *)
+
+module S = Autonomous.Autonomous_state
+module P = Autonomous.Autonomous_phase
+module Outcome = Shared_types.Resilience_outcome
+module Confidence = Shared_types.Confidence
+
+let test_init_creates_idle () =
+  let s = S.init ~now:1000.0 () in
+  assert (S.current_phase_string s = "idle");
+  assert (S.current_phase s = P.Tag_idle);
+  assert (S.iteration_count s = 0);
+  assert (S.last_tick_at s = 1000.0);
+  assert (S.created_at s = 1000.0)
+
+let test_init_default_meta_null () =
+  let s = S.init ~now:0.0 () in
+  let json = S.to_json s in
+  let ctx = Yojson.Safe.Util.member "ctx" json in
+  let meta = Yojson.Safe.Util.member "meta" ctx in
+  assert (meta = `Null)
+
+let test_init_custom_meta_passthrough () =
+  let meta = `Assoc [ ("role", `String "analyst"); ("budget", `Int 100) ] in
+  let s = S.init ~meta ~now:0.0 () in
+  let json = S.to_json s in
+  let ctx = Yojson.Safe.Util.member "ctx" json in
+  let meta_back = Yojson.Safe.Util.member "meta" ctx in
+  assert (meta_back = meta)
+
+let test_tick_returns_full_success () =
+  let s = S.init ~now:1000.0 () in
+  let outcome = S.tick s ~now:1500.0 in
+  match outcome with
+  | Outcome.FullSuccess { value; confidence; artifacts } ->
+      assert (S.last_tick_at value = 1500.0);
+      assert (S.iteration_count value = 1);
+      assert (S.created_at value = 1000.0);
+      assert (Confidence.to_float confidence = 1.0);
+      assert (artifacts = [])
+  | Outcome.PartialSuccess _ -> assert false
+  | Outcome.GracefulFailure _ -> assert false
+
+let test_tick_chain_increments () =
+  let s0 = S.init ~now:0.0 () in
+  let s1 =
+    match S.tick s0 ~now:1.0 with
+    | Outcome.FullSuccess { value; _ } -> value
+    | _ -> assert false
+  in
+  let s2 =
+    match S.tick s1 ~now:2.0 with
+    | Outcome.FullSuccess { value; _ } -> value
+    | _ -> assert false
+  in
+  assert (S.iteration_count s2 = 2);
+  assert (S.last_tick_at s2 = 2.0);
+  assert (S.created_at s2 = 0.0)
+
+let test_to_json_shape () =
+  let s = S.init ~now:1000.0 () in
+  let json = S.to_json s in
+  let assoc = Yojson.Safe.Util.to_assoc json in
+  let keys = List.map fst assoc in
+  assert (List.mem "phase" keys);
+  assert (List.mem "iteration_count" keys);
+  assert (List.mem "created_at" keys);
+  assert (List.mem "last_tick_at" keys);
+  assert (List.mem "ctx" keys);
+  assert (Yojson.Safe.Util.member "phase" json = `String "idle");
+  assert (Yojson.Safe.Util.member "iteration_count" json = `Int 0)
+
+let test_to_json_phase_after_tick () =
+  let s = S.init ~now:0.0 () in
+  let s' =
+    match S.tick s ~now:1.0 with
+    | Outcome.FullSuccess { value; _ } -> value
+    | _ -> assert false
+  in
+  let json = S.to_json s' in
+  (* Tick is a stub — phase remains Idle until A4 wires real transitions. *)
+  assert (Yojson.Safe.Util.member "phase" json = `String "idle");
+  assert (Yojson.Safe.Util.member "iteration_count" json = `Int 1);
+  assert (Yojson.Safe.Util.member "last_tick_at" json = `Float 1.0)
+
+let () =
+  test_init_creates_idle ();
+  test_init_default_meta_null ();
+  test_init_custom_meta_passthrough ();
+  test_tick_returns_full_success ();
+  test_tick_chain_increments ();
+  test_to_json_shape ();
+  test_to_json_phase_after_tick ();
+  print_endline "test_autonomous_state: all assertions passed"


### PR DESCRIPTION
## Summary

Cycle 21 second PR — introduces the immutable state value for the autonomous loop. Builds on B3's `Autonomous_phase` taxonomy (now in main, PR #11591) and I5's `Resilience_outcome` (in main since #11567). The `tick` function returns `Resilience_outcome.t` from day 1 (Decision 6, INTEGRATED §3.1) so `PartialSuccess` is never a silent coercion of `Ok`.

## Module surface (`lib/autonomous/autonomous_state.{mli,ml}`)

- **`'phase ctx` GADT** (8 constructors, one per phase). `Idle_ctx` fully defined with `[created_at; meta : Yojson.Safe.t]` placeholder payload; the other 7 are stub variants reserved for later Tiers when their upstream modules land (Stimulus list, Intent.t option, Plan.t, Orchestrator.task_result, etc.).

- **`phase_packed` / `ctx_packed` existential wrappers**. OCaml records cannot have universally polymorphic fields like `phase_any : 'a. 'a Autonomous_phase.any`, so we erase the phantom index via `Packed_phase : 'a Autonomous_phase.any -> phase_packed` and `Packed_ctx : 'a ctx -> ctx_packed`. Pattern matching on these wrappers re-introduces the unknown `type a.` locally where needed.

- **Record `t = { phase; ctx; iteration_count; created_at; last_tick_at }`**. No `[@@deriving tla]` on the record because the packed fields are GADTs that the deriver doesn't know how to project.

- **`init ?meta ~now ()`** constructs an Idle state.

- **`tick t ~now`** returns `(t, string) Shared_types.Resilience_outcome.t`. Stub: always `FullSuccess` with confidence 1.0, no artifacts, iteration_count + last_tick_at advanced. Real sub-phase progression is deferred to Tier A4. Error type fixed to `string`; Tier B6 introduces `Recovery.strategy` with no constructor renaming.

- **`to_json`** serialises phase + bookkeeping + Idle_ctx meta. Stub ctx variants render as empty objects under `"ctx"`.

- **Accessors**: `current_phase`, `current_phase_string`, `iteration_count`, `created_at`, `last_tick_at`.

## Test plan
- [x] `dune build --root . lib/autonomous/` GREEN
- [x] `dune build --root . test/autonomous/` GREEN
- [x] `dune runtest --root . test/autonomous/ --force` — 14 assertions across 2 suites GREEN:
  - `test_autonomous_state`: 7 cases (init Idle, default/custom meta, tick FullSuccess, tick chain, to_json shape, to_json after tick)
  - `test_autonomous_phase` (B3): 7 cases pass without regression
- [x] No regression: `shared_types` 27 tests + `ppx_tla` 4 suites GREEN

## Out of scope (deferred per plan)
- **Tier B5**: `('from, 'to_) transition` GADT (19 ctors) + `apply_transition` + `can_transition`.
- **Tier A4-A5**: `Autonomous_bridge`, `running_valid` witness, Keeper post-turn lifecycle wire-in (★ first e2e slice).
- Full `Idle_ctx` fields (`Resource_budget.snapshot`, `Goal_dag.t`, `Self_priority.t`) — those modules arrive in later Cycles.
- `of_json` (paired with the schema settling).

## Plan reference
`planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-temporal-stream.md` §2.2 Tier B4 — second of three Cycle 21 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)