### PR TITLE
docs(keeper): add KeeperMemoryLifecycle.tla anchor in keeper_memory_bank (Cycle 36)

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -1,5 +1,47 @@
 (** Keeper_memory_bank — memory bank persistence, compaction, and summarization. *)
 
+(* Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern.  Sibling
+   to PR 11617 (Cycle 34, keeper_memory_policy.ml).  Authoritative
+   spec mirror is
+   specs/keeper-state-machine/KeeperMemoryLifecycle.tla.
+
+   Spec lines 22-23 cite this module specifically for two semantic
+   aspects:
+
+     open_short    rows: unresolved short-term notes
+                   (open_question kind).  This module's compaction
+                   and summarization paths must preserve open_short
+                   until they are answered or roll over with the
+                   keeper generation.
+     provenanced   rows: non-empty trace_id and source.  Persistence
+                   here is the authoritative producer of provenance:
+                   no row reaches mid_term or long_term without it.
+
+   This block is the reverse-direction citation so code search for
+   "KeeperMemoryLifecycle" lands in this module too — completing the
+   sibling pair with keeper_memory_policy.ml which carries the
+   horizon-tier and producer anchors (memory_horizon_of_kind_opt
+   and memory_horizon_of_kind).
+
+   Sibling division of labor:
+     keeper_memory_policy.ml   tier vocabulary, producer,
+                               classification.
+     keeper_memory_bank.ml     persistence, compaction,
+                               summarization, provenance enforcement.
+
+   Spec safety goals (line 9-13 in spec):
+     - every persisted note has provenance.  Enforced here by
+       rejecting rows with empty trace_id or source.
+     - overflow and handoff do not silently drop retained notes.
+       Compaction selection paths preserve open_short and
+       provenanced rows; the spec verifies the bound.
+     - handoff clears stale short-term notes.  The generation-handoff
+       path here explicitly clears short_mem that has not been
+       promoted to mid_mem.
+     - each tier stays within its configured bound.
+       select_memory_candidates (this file) walks rows under the
+       tier-specific cap from Keeper_memory_policy.kind_caps. *)
+
 open Keeper_types
 
 include Keeper_memory_policy


### PR DESCRIPTION
## Summary

Closes the **KeeperMemoryLifecycle pair (2/2)**.  Sibling to **#11617** (Cycle 34, `keeper_memory_policy.ml`).

`KeeperMemoryLifecycle.tla:22-23` cited this module for the `open_short` and `provenanced` semantics; pre-PR grep for `Spec:` or `KeeperMemoryLifecycle` in `keeper_memory_bank.ml` returned **zero hits**.

## What changed

Anchor block added as a **regular multi-line comment** (not docstring extension — see lessons learned below):

| Spec aspect | OCaml enforcement |
|-------------|-------------------|
| `open_short` rows | preservation across compaction and summarization |
| `provenanced` rows | non-empty `trace_id` / source enforcement |
| Sibling division | policy = tier vocabulary, bank = persistence |
| Safety goals | all four mapped to OCaml enforcement points (provenance, no-silent-drop, handoff clears stale, tier bounds) |

## Lessons learned (formatting fix)

The first attempt at this PR used the same docstring-extension pattern from #11596/#11597/#11599/#11608/#11612/#11614/#11615/#11617/#11618 — extending the existing `(** ... *)` docstring with ocamldoc-style references like `[memory_horizon_of_kind*]` and `(#11617 anchor)`.

**Build failed**:
```
24 |     Sibling division of labor:
                 ^^^^^^^^
Error: Syntax error
```

OCaml's lexer rejected the `*` wildcard inside a docstring `[...]` reference and the `#11617` PR-number form, treating subsequent text as code.

**Resolution**: keep the original short docstring untouched and place the spec navigation in a regular `(* ... *)` comment.  No ocamldoc references — plain text only.

This is now the safer formatting for any future anchor PR landing on a module with a one-line docstring.

## KeeperMemoryLifecycle pair status

| Aspect | OCaml | Anchor PR |
|--------|-------|-----------|
| Tier vocabulary, producer, classification | `keeper_memory_policy.ml` | #11617 (Cycle 34) ✅ |
| Persistence, compaction, summarization, provenance | `keeper_memory_bank.ml` | This PR (Cycle 36) |

After both merge: bidirectional discoverability for KeeperMemoryLifecycle.

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_memory_bank.ml`, 827 lines) |
| Lines | +42 / -0 (comment-only, regular multi-line comment) |
| Behavior change | none |
| Build | `dune build --root . lib/keeper/` ✅ |

## Pattern reuse trail (13 PRs total)

24-35 derive_phase / LaunchPending / Note A / B1 / B2 / B3 / CircuitBreaker / Rollover / PostTurn / Types / MemoryPolicy / OperatorPauseBroadcast / **36 MemoryBank (this PR, formatting variation)**