### PR TITLE
docs(keeper): add OperatorPauseBroadcast.tla anchor in keeper_stale_watchdog (Cycle 37)

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -15,6 +15,50 @@
 
     @since PR #10670 — extracted from Keeper_supervisor. *)
 
+(* Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern.  Sibling
+   to PR 11618 (Cycle 35, keeper_execution_receipt.ml).  Authoritative
+   spec mirror is
+   specs/keeper-state-machine/OperatorPauseBroadcast.tla.
+
+   Spec line 20-21 cite "lib/keeper/keeper_supervisor.ml: stale
+   watchdog fiber forks under ctx.sw and calls
+   emit_stale_keeper_broadcast".  That citation pre-dates PR 10670
+   which extracted this module from Keeper_supervisor to break a
+   circular dependency.  After the extraction:
+
+     keeper_supervisor.ml line ~118    fork_stale_watchdog wrapper
+                                       (re-exports the function below)
+     keeper_stale_watchdog.ml          actual fiber logic + emit
+                                       (this file)
+     keeper_execution_receipt.ml       emit_stale_keeper_broadcast
+                                       definition (called at line 287
+                                       of this file)
+
+   Spec citation drift: the spec module string still says
+   "keeper_supervisor.ml" but the true post-extraction location of
+   the watchdog logic is here.  Spec-side cleanup is deferred — when
+   the spec is next regenerated it should point at this module
+   directly.
+
+   Spec semantics modelled (TLA+ -> OCaml):
+     phase = StaleRunning      reached when this watchdog detects a
+                               stall (idle or failure-loop) and sets
+                               fiber_stop.
+     OperatorBroadcast emit    line 287 below calls
+                               Keeper_execution_receipt.emit_stale_keeper_broadcast
+                               unconditionally on detection (inside a
+                               try block — clean Spec model).
+     Eventually-emit liveness  satisfied because every detection path
+                               feeds into the same emit call;
+                               last_broadcast_ts (line 99) only
+                               throttles repeated emissions, it does
+                               not silently skip.
+
+   Bug model the spec catches: a refactor that wrapped the line 287
+   emit in a conditional that could silently skip would re-create
+   the original fleet-stall regression class.  The spec's bug-action
+   would silently drop emits and violate the leads-to property. *)
+
 open Keeper_types
 
 (* Process-global termination history per keeper.  Survives keeper


### PR DESCRIPTION
## Summary

**Closes the OperatorPauseBroadcast pair (2/2)**.  Sibling to **#11618** (Cycle 35, `keeper_execution_receipt.ml`).

Pre-PR grep for `Spec:` or `OperatorPauseBroadcast` in `keeper_stale_watchdog.ml` returned **zero hits**.

## Spec citation drift discovered

`OperatorPauseBroadcast.tla:20-21` cites:
> `lib/keeper/keeper_supervisor.ml: stale watchdog fiber forks under ctx.sw and calls emit_stale_keeper_broadcast`

That citation **pre-dates PR #10670** which extracted the watchdog logic from `Keeper_supervisor` to break a circular dependency with `Keeper_keepalive`.

Current actual location:

| Module | Role |
|--------|------|
| `keeper_supervisor.ml` (~line 118) | `fork_stale_watchdog` wrapper (re-exports the function below) |
| `keeper_stale_watchdog.ml` | actual fiber logic + emit (this file) |
| `keeper_execution_receipt.ml` (line ~411) | `emit_stale_keeper_broadcast` definition (anchored separately in #11618) |

Anchor placed in `keeper_stale_watchdog.ml` (the **true location** of the watchdog fiber) rather than the wrapper, so future drift between the watchdog and the spec is grep-discoverable from the actual implementation.

Spec-side citation cleanup is deferred — when the spec is next regenerated it should point at this module directly.

## What changed

Regular `(* ... *)` comment added after the existing module docstring (Cycle 36 lessons-learned formatting — no docstring extension to avoid ocamldoc lexer surprises):

| Spec semantic | OCaml mapping |
|---------------|---------------|
| `StaleRunning` phase | watchdog detection (idle stall ≥ 300s OR failure-loop count ≥ 3) sets `fiber_stop` |
| `OperatorBroadcast` emit | line 287 calls `Keeper_execution_receipt.emit_stale_keeper_broadcast` unconditionally inside a `try` |
| Eventually-emit liveness | every detection path feeds into the same emit; `last_broadcast_ts` only throttles, does not silently skip |
| Bug model | conditional that could silently skip emit would re-create the original `#fleet-stall` regression class |

## OperatorPauseBroadcast pair status (closed)

| Aspect | OCaml | Anchor PR |
|--------|-------|-----------|
| Receipt-side broadcast hook (`needs_operator_broadcast` + `emit_operator_broadcast`) | `keeper_execution_receipt.ml` | #11618 (Cycle 35) ✅ |
| Watchdog-side detection + emit | `keeper_stale_watchdog.ml` | This PR (Cycle 37) |

After both merge: bidirectional discoverability for OperatorPauseBroadcast across receipt and watchdog sides.

## Scope

| Aspect | Value |
|--------|-------|
| Files | 1 (`lib/keeper/keeper_stale_watchdog.ml`, 331 lines) |
| Lines | +44 / -0 (comment-only, regular multi-line comment) |
| Behavior change | none |
| Build | `dune build --root . lib/keeper/` ✅ |

## Pattern reuse trail (14 PRs total)

24-36 derive_phase / LaunchPending / Note A / B1 / B2 / B3 / CircuitBreaker / Rollover / PostTurn / Types / MemoryPolicy / OperatorPauseBroadcast 1/2 / MemoryBank / **37 OperatorPauseBroadcast 2/2 (this PR)**