### PR TITLE
fix(exec): Sandbox_target IR + dispatch_simple route via runner closure (sandbox root-fix 3/3)

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -35,6 +35,16 @@ let resolve_env env_bindings =
 
 (* --- simple command execution --- *)
 
+(* Dispatch a simple command via the IR-carried Sandbox_target runner.
+
+   Prior to PR-2 (2026-04-28 root-fix family 3/3) this function called
+   [Process_eio.run_argv_with_status_split] directly, which short-
+   circuited every command to a host fork/exec regardless of the
+   keeper's [sandbox_profile]. The runner closure on the Shell_ir node
+   now carries the sandbox decision: the host case forwards to the
+   same Process_eio call (no behavior change for non-keeper callers),
+   the Docker case is wired up by [lib/keeper] using a closure over
+   [Keeper_turn_sandbox_runtime]. *)
 let dispatch_simple (s : Shell_ir.simple) =
   let bin = Bin.to_string s.bin in
   let argv = bin :: List.map resolve_arg s.args in
@@ -44,8 +54,7 @@ let dispatch_simple (s : Shell_ir.simple) =
     | None -> None
     | Some scope -> Some (Path_scope.raw scope)
   in
-  match Process_eio.run_argv_with_status_split ~timeout_sec:120.0
-          ~env ?cwd argv with
+  match s.sandbox.runner ~argv ~env ~cwd ~timeout_sec:120.0 with
   | exception exn ->
       { status = Unix.WEXITED 1;
         stdout = "";

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -101,7 +101,14 @@ let simple_of_argv ?env ?cwd (argv : string list) =
           (fun dir -> Path_scope.classify ~raw:dir ~cwd:dir)
           cwd
       in
-      Ok { Shell_ir.bin; args; env; cwd; redirects = [] })
+      Ok
+        { Shell_ir.bin
+        ; args
+        ; env
+        ; cwd
+        ; redirects = []
+        ; sandbox = Sandbox_target.host ()
+        })
 
 let verdict_to_string = function
   | Verdict.Allow _ -> "allow"

--- a/lib/exec/parser/bash.ml
+++ b/lib/exec/parser/bash.ml
@@ -17,7 +17,14 @@ let raw_to_simple (bin_str, args_str) : (Shell_ir.simple, Parsed.parse_error) re
     Error { Parsed.pos = Lexing.dummy_pos; token = bin_str; expected = [] }
   | Ok bin ->
     let args = List.map (fun s -> Shell_ir.Lit s) args_str in
-    Ok { Shell_ir.bin; args; env = []; cwd = None; redirects = [] }
+    Ok
+      { Shell_ir.bin
+      ; args
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = Sandbox_target.host ()
+      }
 
 let rec map_stages = function
   | [] -> Ok []

--- a/lib/exec/sandbox_target.ml
+++ b/lib/exec/sandbox_target.ml
@@ -1,0 +1,82 @@
+(* Sandbox target abstraction for Shell_ir dispatch.
+
+   Why this exists
+   ---------------
+   Prior to 2026-04-28, [Exec_dispatch.dispatch_simple] called
+   [Process_eio.run_argv_with_status_split] directly. The Shell_ir record
+   carried no information about *where* the command should run, so every
+   parsed shell command short-circuited to a host-side fork/exec. When a
+   keeper was configured for [sandbox_profile = "docker"], the keeper's
+   bash dispatch path consulted [Keeper_shell_docker.run_docker_*]
+   functions, but any command that flowed through the Shell_ir IR
+   bypassed that branch entirely (defect A in the 2026-04-28 root-fix
+   audit).
+
+   This module introduces a callback-runner abstraction that lets
+   Shell_ir carry the sandbox decision *as data*, while keeping the
+   layering clean: [lib/exec] cannot depend on [lib/keeper], so we do
+   not embed [Keeper_turn_sandbox_runtime.t] in the kind. Instead, the
+   keeper layer constructs a [t] whose [runner] is a closure over its
+   own runtime; [lib/exec] only sees the shape of the closure.
+
+   Usage shape
+   -----------
+   - Host: build via [host ()]; runs the argv in a host process via
+     [Process_eio.run_argv_with_status_split].
+   - Docker: built by [lib/keeper] (e.g.,
+     [Keeper_shell_docker.sandbox_target_of_runtime]) and embedded in
+     the [Shell_ir.simple] record before dispatch. The runner closure
+     adapts the keeper-side Docker call into the same callback shape.
+
+   Status (2026-04-28)
+   -------------------
+   Step 1 of PR-2: this module is introduced ahead of the cascade
+   change in [Shell_ir.simple]. The dispatch path in
+   [Exec_dispatch.dispatch_simple] does not consume the type yet —
+   that wiring lands in step 2 once the cascade sites in tests and
+   library callers are converted. *)
+
+type runner =
+  argv:string list ->
+  env:string array ->
+  cwd:string option ->
+  timeout_sec:float ->
+  Unix.process_status * string * string
+
+(** [kind] is a structural tag for telemetry and logging. The runner
+    closure carries the actual dispatch logic, so this tag does not
+    need to enumerate every concrete runtime — it is a discriminator,
+    not a state machine. *)
+type kind =
+  | Host
+  | Docker of { image : string }
+
+type t = {
+  kind : kind;
+  runner : runner;
+}
+
+(** Default host runner: forwards to [Process_eio.run_argv_with_status_split].
+    Exceptions raised by the underlying runner are propagated unchanged so
+    callers can decide whether to translate them into structured errors.
+    The previous behavior (in [Exec_dispatch.dispatch_simple]) was to
+    catch and surface them via the dispatch result; this preserves the
+    same call shape so wiring step 2 is a structural rename, not a
+    semantic shift. *)
+let host () : t =
+  let runner ~argv ~env ~cwd ~timeout_sec =
+    Process_eio.run_argv_with_status_split ~timeout_sec ~env ?cwd argv
+  in
+  { kind = Host; runner }
+
+(** Build a Docker target from a caller-supplied runner closure. Used by
+    [lib/keeper] to inject [Keeper_turn_sandbox_runtime] without the
+    [lib/exec] layer taking a dependency on [lib/keeper]. *)
+let docker ~image ~runner : t =
+  { kind = Docker { image }; runner }
+
+let kind t = t.kind
+
+let pp_kind fmt = function
+  | Host -> Format.pp_print_string fmt "host"
+  | Docker { image } -> Format.fprintf fmt "docker(%s)" image

--- a/lib/exec/sandbox_target.mli
+++ b/lib/exec/sandbox_target.mli
@@ -1,0 +1,41 @@
+(** Sandbox target abstraction consumed by the Shell_ir dispatch path.
+
+    See [sandbox_target.ml] for the rationale. The short version: this
+    type lets [Shell_ir.simple] carry the sandbox decision as data while
+    keeping [lib/exec] independent of [lib/keeper] (the keeper layer
+    injects its Docker runtime via the [runner] closure). *)
+
+(** A runner closure executes an argv with the given env / cwd / timeout
+    and returns the raw process status plus stdout/stderr buffers.
+    Exceptions are propagated; callers in [Exec_dispatch] catch and
+    translate them into structured dispatch results. *)
+type runner =
+  argv:string list ->
+  env:string array ->
+  cwd:string option ->
+  timeout_sec:float ->
+  Unix.process_status * string * string
+
+(** Discriminator for telemetry. The actual dispatch logic lives in
+    the runner closure, so the kind variant is intentionally narrow. *)
+type kind =
+  | Host
+  | Docker of { image : string }
+
+type t = {
+  kind : kind;
+  runner : runner;
+}
+
+(** Default host runner: forwards directly to
+    [Process_eio.run_argv_with_status_split]. *)
+val host : unit -> t
+
+(** Build a Docker target. The caller (typically [lib/keeper]) supplies
+    the runner closure; this keeps [lib/exec] from having to know about
+    [Keeper_turn_sandbox_runtime] or any other keeper-side construct. *)
+val docker : image:string -> runner:runner -> t
+
+val kind : t -> kind
+
+val pp_kind : Format.formatter -> kind -> unit

--- a/lib/exec/shell_ir.ml
+++ b/lib/exec/shell_ir.ml
@@ -9,6 +9,13 @@ type simple = {
   env : (string * arg) list;
   cwd : Path_scope.t option;
   redirects : Redirect_scope.t list;
+  (* PR-2 root-fix family 3/3 (2026-04-28):
+     [sandbox] carries the dispatch decision through the IR so
+     [Exec_dispatch.dispatch_simple] can route to host or Docker
+     without a separate keeper-only code path. The default
+     [Sandbox_target.host ()] preserves the historical behavior; the
+     keeper layer overrides it when a Docker runtime is available. *)
+  sandbox : Sandbox_target.t;
 }
 
 type t =

--- a/lib/exec/shell_ir.mli
+++ b/lib/exec/shell_ir.mli
@@ -16,6 +16,10 @@ type simple = {
   env : (string * arg) list;      (** [FOO=bar] env prefix on the command *)
   cwd : Path_scope.t option;
   redirects : Redirect_scope.t list;
+  sandbox : Sandbox_target.t;
+  (** Dispatch target — defaults to [Sandbox_target.host ()].  Keeper
+      callers override with a Docker runner closure built from
+      [Keeper_turn_sandbox_runtime]. *)
 }
 
 type t =

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -10,9 +10,10 @@ let bin_ok name =
   (* bin must classify *)
   | Error _ -> assert false
 
-let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = []) bin
+let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = [])
+    ?(sandbox = Sandbox_target.host ()) bin
     : Shell_ir.simple =
-  { bin; args; env; cwd; redirects }
+  { bin; args; env; cwd; redirects; sandbox }
 
 let lit s = Shell_ir.Lit s
 

--- a/lib/exec/test/test_capability_check.ml
+++ b/lib/exec/test/test_capability_check.ml
@@ -11,9 +11,10 @@ let bin_ok name =
   | Ok b -> b
   | Error _ -> assert false
 
-let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = []) bin
+let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = [])
+    ?(sandbox = Sandbox_target.host ()) bin
     : Shell_ir.simple =
-  { bin; args; env; cwd; redirects }
+  { bin; args; env; cwd; redirects; sandbox }
 
 let lit s = Shell_ir.Lit s
 

--- a/lib/exec/test/test_exec_types.ml
+++ b/lib/exec/test/test_exec_types.ml
@@ -64,7 +64,13 @@ let test_verdict_trusted_argv_smart_ctor () =
   | Error _ -> assert false
   | Ok bin ->
       let simple : Shell_ir.simple =
-        { bin; args = []; env = []; cwd = None; redirects = [] }
+        { bin
+        ; args = []
+        ; env = []
+        ; cwd = None
+        ; redirects = []
+        ; sandbox = Sandbox_target.host ()
+        }
       in
       let t = Verdict.trust ~caps:[] simple in
       assert (Verdict.Trusted_argv.bin t = bin);
@@ -82,7 +88,13 @@ let test_verdict_four_way () =
   in
   let bin = match Bin.of_string "ls" with Ok b -> b | Error _ -> assert false in
   let simple : Shell_ir.simple =
-    { bin; args = []; env = []; cwd = None; redirects = [] }
+    { bin
+    ; args = []
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Sandbox_target.host ()
+    }
   in
   let _ =
     Verdict.Suggest_confirm

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -50,7 +50,16 @@ let () =
   with_eio @@ fun () ->
   let open Masc_exec.Shell_ir in
   let bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
-  let ir = Simple { bin; args = [Lit "hello"; Lit "world"]; env = []; cwd = None; redirects = [] } in
+  let ir =
+    Simple
+      { bin
+      ; args = [ Lit "hello"; Lit "world" ]
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = Masc_exec.Sandbox_target.host ()
+      }
+  in
   let result = Masc_exec.Exec_dispatch.dispatch ir in
   let stdout = String.trim result.stdout in
   assert (stdout = "hello world");
@@ -62,7 +71,16 @@ let () =
   with_eio @@ fun () ->
   let open Masc_exec.Shell_ir in
   let bin = Masc_exec.Bin.of_string "cat" |> Result.get_ok in
-  let ir = Simple { bin; args = [Lit "/nonexistent_file_p7_test"]; env = []; cwd = None; redirects = [] } in
+  let ir =
+    Simple
+      { bin
+      ; args = [ Lit "/nonexistent_file_p7_test" ]
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = Masc_exec.Sandbox_target.host ()
+      }
+  in
   let result = Masc_exec.Exec_dispatch.dispatch ir in
   assert (result.status <> Unix.WEXITED 0);
   assert (String.length result.stderr > 0)
@@ -74,9 +92,10 @@ let () =
   let open Masc_exec.Shell_ir in
   let echo_bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
   let tr_bin = Masc_exec.Bin.of_string "tr" |> Result.get_ok in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
   let stages = [
-    Simple { bin = echo_bin; args = [Lit "hello world"]; env = []; cwd = None; redirects = [] };
-    Simple { bin = tr_bin; args = [Lit "a-z"; Lit "A-Z"]; env = []; cwd = None; redirects = [] };
+    Simple { bin = echo_bin; args = [Lit "hello world"]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
+    Simple { bin = tr_bin; args = [Lit "a-z"; Lit "A-Z"]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
   ] in
   let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
   let stdout = String.trim result.stdout in
@@ -90,9 +109,10 @@ let () =
   let open Masc_exec.Shell_ir in
   let echo_bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
   let false_bin = Masc_exec.Bin.of_string "false" |> Result.get_ok in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
   let stages = [
-    Simple { bin = echo_bin; args = [Lit "ok"]; env = []; cwd = None; redirects = [] };
-    Simple { bin = false_bin; args = []; env = []; cwd = None; redirects = [] };
+    Simple { bin = echo_bin; args = [Lit "ok"]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
+    Simple { bin = false_bin; args = []; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
   ] in
   let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
   assert (result.status = Unix.WEXITED 1)


### PR DESCRIPTION
## Why

Family **3/3** of the 2026-04-28 sandbox bypass root-fix series.

- PR-1 (#11594, merged): defect B (persistence) — strict parser + migration script.
- PR-3 (#11610, draft): defect C (logic) — `effective_sandbox_profile` invariant.
- **This PR**: defect A (structural) — `Shell_ir.simple` carries the sandbox decision; `Exec_dispatch.dispatch_simple` routes through a runner closure rather than calling `Process_eio` directly. The historical native-dispatch path that bypassed every keeper-side Docker check is replaced by a single dispatch SSOT.

## Design: callback runner instead of an ADT for Docker

`lib/exec` cannot depend on `lib/keeper` (layering: keeper depends on exec, not vice versa). Embedding `Keeper_turn_sandbox_runtime.t` in `Sandbox_target` would invert that. So `Sandbox_target.t` carries:

```ocaml
type kind  = Host | Docker of { image : string }     (* tag, telemetry-only *)
type runner = argv:.. -> env:.. -> cwd:.. -> timeout_sec:.. -> Unix.process_status * string * string
type t      = { kind : kind; runner : runner }
```

The kind tag is narrow on purpose. Real dispatch logic lives in the `runner` closure, so the keeper layer can inject Docker without `lib/exec` ever importing keeper-side modules.

## Changes (+207 / −16, 11 files)

### New (`lib/exec`)
- `sandbox_target.ml` + `.mli` — runner abstraction with default `host ()` forwarding to `Process_eio.run_argv_with_status_split`.

### Modified (`lib/exec`)
- `shell_ir.ml`/`.mli`: `simple` record gains `sandbox : Sandbox_target.t`.
- `exec_dispatch.ml`: `dispatch_simple` calls `s.sandbox.runner ~argv ~env ~cwd ~timeout_sec`. Pipeline branch unchanged (see deferred item 2 below).
- `exec_gate.ml`, `parser/bash.ml`: construction sites updated.

### Test cascade (8 sites across 4 files)
- `lib/exec/test/test_capability_check.ml`, `test_approval_policy.ml`, `test_exec_types.ml`, `test/test_exec_dispatch.ml` — all default to `Sandbox_target.host ()`.

## What this PR does NOT do (tracked in #11611)

1. **Keeper-side builder.** `lib/keeper` still routes Docker bash through `Keeper_shell_docker.run_docker_*`. Until a follow-up wires `Keeper_turn_sandbox_runtime` into a `Sandbox_target.t` for keeper-built Shell_ir nodes, this PR is structurally complete but functionally idle for keeper callers — host fallback is no longer the only option, but nothing exercises the Docker path through the IR yet.
2. **Pipeline runners.** `dispatch_pipeline` still calls `Process_eio.run_argv_with_stdin_and_status_split`. The runner abstraction does not model stdin; adding it deserves its own PR with stdin-aware test coverage.
3. **`Path_scope.classify`** stays as the original `Absolute_unknown` stub — out of scope here.

## Verification

- `dune build @all` passes (incremental + clean, exit 0).
- 8 cascade sites exhaustively swept; build is silent on the new `sandbox` field.
- Functional verification (Docker keeper → container `ls`) requires the keeper-side builder (PR-2b, see #11611).

## Coordination

- Race-window: clean. The only open PR matching `shell_ir|sandbox_target|exec_dispatch` is PR #11610 (PR-3), which lives in `lib/keeper` only and does not touch `lib/exec`.
- No new env flag (Hard cutover per user direction).
- Plan SSOT: `planning/claude-plans/30m-users-dancer-downloads-kimi-agent-greedy-pebble.md`

## Stack

This PR depends on neither PR-1 (#11594, merged) nor PR-3 (#11610, draft) — it touches `lib/exec` only. Merge order is ergonomic, not structural: PR-3 then PR-2 keeps the audit trail aligned with the audit reports under `Kimi_Agent_샌드박스 설정 문제/`, but either can land first.