### PR TITLE
feat(tool-schemas): add tool_schemas_code.mli — code-inspection schema SSOT (cycle 73)

### DIFF
--- a/lib/tool_schemas/tool_schemas_code.mli
+++ b/lib/tool_schemas/tool_schemas_code.mli
@@ -1,0 +1,23 @@
+(** Tool_schemas_code — SSOT for code-inspection tool schemas.
+
+    Three MCP tool schemas, in surface order:
+    - [masc_code_search] — ripgrep search with regex support;
+      returns file path / line number / matched content.
+      Required: [query]. Optional: [path], [file_pattern],
+      [case_insensitive], [max_results].
+    - [masc_code_symbols] — extract symbols (functions, types,
+      classes) from a single file via heuristics. Required:
+      [path].
+    - [masc_code_read] — read a file with [offset] / [limit]
+      pagination for large files. Required: [path].
+
+    The schemas are exposed as a [Types.tool_schema list] so the
+    discovery wiring in [agent_tool_surfaces] can concatenate
+    them with the rest of the surface; consumers must not depend
+    on the in-list order beyond the documented surface order
+    above. *)
+
+val schemas : Types.tool_schema list
+(** The three code-inspection schemas. List length and per-tool
+    [name] strings are part of the public contract — the agent
+    SDK's tool-routing tables grep them at startup. *)


### PR DESCRIPTION
## Summary

Cycle 73 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/tool_schemas/tool_schemas_code.ml`
(62 lines).

Surface (single binding):
- `val schemas : Types.tool_schema list`

No internals to hide.

## Why typed surface

The list contains **three MCP tool schemas** in surface order
(`masc_code_search`, `masc_code_symbols`, `masc_code_read`).
Both the list length and the per-tool `name` strings are part
of the public contract — the agent SDK's tool-routing tables
grep them at startup. A future "let's rename `masc_code_read`
to `masc_file_read`" refactor must touch this file as part of
an explicit migration; pinning the surface seam makes that
change visible at the contract level rather than emergent in
the tool-routing tests.

The docstring documents the in-list surface order so a future
"let's alphabetise" reorder is also a contract change with
visible impact rather than an emergent one. (Consumers should
not rely on the order beyond the documented version.)

## Caller audit (`rg "Tool_schemas_code\\."`)
- `lib/agent_tool_surfaces.ml` — `schemas` (concat into the
  process-wide tool surface)

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
