### PR TITLE
feat(activity-graph): add activity_graph_registry.mli — typed SSE registry surface (cycle 74)

### DIFF
--- a/lib/activity_graph/activity_graph_registry.mli
+++ b/lib/activity_graph/activity_graph_registry.mli
@@ -1,0 +1,78 @@
+(** Activity_graph_registry — SSE client registry guarded by an
+    [Eio.Mutex].
+
+    {!Activity_graph} re-exports the public surface via
+    [include Activity_graph_registry] so it can iterate
+    {!clients} and {!client_matches} from inside its event
+    fan-out without re-introducing the cycle this split was
+    extracted to break.
+
+    Internal storage (the [registry_mutex] handle, the
+    [client_count_atomic] counter, and the [client_id_counter]
+    monotonic id source) is hidden — callers consume only the
+    locked accessors and the lifecycle entry points. *)
+
+open Activity_graph_types
+
+type client = {
+  client_id : int;
+  push : string -> unit;
+  kind_filters : string list;
+  mutable last_seq : int;
+  created_at : float;
+}
+(** A registered SSE client. The record is exposed concretely
+    because {!Activity_graph} reads / mutates [last_seq] from
+    inside the fan-out and reads [kind_filters] via
+    {!client_matches}; hiding the layout would force getter
+    pairs without making the abstraction any richer. *)
+
+val clients : (string, client) Hashtbl.t
+(** Live session-id → client table. {!Activity_graph} iterates
+    this Hashtbl from its broadcast loop under
+    {!with_registry_ro}; mutations must go through {!register} /
+    {!unregister} / {!unregister_if_current}. *)
+
+val with_registry_rw :
+  (unit -> 'a) -> 'a
+(** Run [f ()] under a read-write lock on {!clients}. When the
+    Eio runtime is not yet ready ([Eio_guard.is_ready () = false],
+    e.g. during boot), [f ()] runs unlocked — the registry has
+    no readers / writers at that point.
+    [Eio.Cancel.Cancelled] propagates unchanged. *)
+
+val with_registry_ro :
+  (unit -> 'a) -> 'a
+(** Read-only variant of {!with_registry_rw}. Same boot-time
+    fast path. *)
+
+val client_matches : client -> event -> bool
+(** [true] when [client.kind_filters] is empty (subscribe-all)
+    or when [event.kind] is in the filter list. *)
+
+val register :
+  string ->
+  push:(string -> unit) ->
+  last_seq:int ->
+  ?kind_filters:string list ->
+  unit ->
+  int
+(** Register or replace the client for [session_id] and return
+    the freshly-allocated [client_id] (monotonic, never reused).
+    A re-register with the same [session_id] preserves the
+    counter — only new sessions increment {!client_count}. *)
+
+val unregister : string -> unit
+(** Drop the client for [session_id] unconditionally. No-op when
+    no client is registered. *)
+
+val unregister_if_current : string -> int -> unit
+(** Drop the client for [session_id] iff its current
+    [client_id] equals the given one. Used to avoid a TOCTOU
+    where a slow disconnect handler removes a client another
+    fiber has already replaced via {!register}. *)
+
+val client_count : unit -> int
+(** Number of distinct [session_id]s currently registered.
+    Backed by an [Atomic.t] so the read does not take the
+    registry lock. *)


### PR DESCRIPTION
## Summary

Cycle 74 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for
`lib/activity_graph/activity_graph_registry.ml` (69 lines).

Surface (1 record + 8 entries):
- `type client = { client_id; push; kind_filters;
                   mutable last_seq; created_at }`
- `val clients : (string, client) Hashtbl.t`
- `val with_registry_rw : (unit -> 'a) -> 'a`
- `val with_registry_ro : (unit -> 'a) -> 'a`
- `val client_matches : client -> event -> bool`
- `val register :
    string -> push:(string -> unit) -> last_seq:int ->
    ?kind_filters:string list -> unit -> int`
- `val unregister : string -> unit`
- `val unregister_if_current : string -> int -> unit`
- `val client_count : unit -> int`

Hidden internals:
- `val registry_mutex` — `Eio.Mutex.t` (exposed only via the
  `with_registry_*` wrappers)
- `val client_count_atomic` — `int Atomic.t` (read via
  `client_count`)
- `val client_id_counter` — used only by `register` allocation

## Why expose the record + Hashtbl concretely

`activity_graph.ml` does `include Activity_graph_registry` and
iterates the `clients` Hashtbl from inside its event fan-out
loop, reading and mutating `client.last_seq`. Hiding the
Hashtbl behind an iterator helper would force the fan-out into
a callback shape without making the abstraction any richer —
the fan-out *is* the contract, and `last_seq` mutation per
event is the throughput-critical operation.

## Boot-time fast path

The `with_registry_rw` / `with_registry_ro` wrappers detect
`Eio_guard.is_ready () = false` (e.g. during boot) and run `f`
unlocked — the registry has no readers / writers at that point.
The .mli pins this contract so a future "always lock" refactor
sees the boot-time invariant before deadlocking the bootstrap.

## TOCTOU contract for unregister_if_current

Pinned at the seam: drop the client iff its current
`client_id` equals the supplied one. Without this, a slow
disconnect handler can remove a client another fiber has
already replaced via `register`, dropping a live SSE stream.

## Caller audit
- `lib/activity_graph/activity_graph.ml` — `include
  Activity_graph_registry`; `with_registry_ro` + Hashtbl
  iteration + `client_matches` inside the event fan-out
- `lib/server/server_activity_http.ml` — `register` +
  `unregister_if_current` (2 sites)
- `test/test_activity_graph.ml` — `register` + `unregister`

No external reference to the 3 hidden internals.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
