### PR TITLE
feat(tool-schemas): add tool_schemas_worktree.mli — worktree-lifecycle schema SSOT (cycle 75)

### DIFF
--- a/lib/tool_schemas/tool_schemas_worktree.mli
+++ b/lib/tool_schemas/tool_schemas_worktree.mli
@@ -1,0 +1,33 @@
+(** Tool_schemas_worktree — SSOT for the three Git-worktree
+    lifecycle tool schemas.
+
+    Surface order:
+    - [masc_worktree_create] — create an isolated Git worktree
+      for a task. Required [task_id]; optional [agent_name],
+      [base_branch] (default ["auto"]), [repo_name].
+    - [masc_worktree_remove] — remove a worktree and its local
+      branch after the work is merged. Required [task_id];
+      optional [agent_name].
+    - [masc_worktree_list] — list active worktrees in the
+      project. No required parameters.
+
+    The schemas are concatenated by four downstream surfaces
+    ([tool_worktree], [tool_shard], [agent_tool_surfaces],
+    [tools]); list length and per-tool [name] strings are part
+    of the public contract because the agent SDK's tool-routing
+    tables grep them at startup. *)
+
+val schemas : Types.tool_schema list
+(** The three worktree-lifecycle schemas in the surface order
+    above. List length and [name] strings are pinned at the
+    contract seam — a future rename of [masc_worktree_remove]
+    must touch this file as part of an explicit migration.
+
+    Note on [repo_name] validation: the schema [pattern]
+    [^[A-Za-z0-9._-]+$] enforces the character class, but the
+    special values ["."] and [".."] match it and are rejected
+    at runtime in [Tool_worktree.handle_worktree_create] and
+    [Coord_worktree.worktree_create_r]. JSON Schema Draft 7
+    (used by most MCP clients) does not support negative
+    lookahead, so the three layers (schema, tool dispatch,
+    coord resolver) must keep the same rule by convention. *)


### PR DESCRIPTION
## Summary

Cycle 75 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/tool_schemas/tool_schemas_worktree.ml`
(78 lines).

Surface (single binding):
- `val schemas : Types.tool_schema list`

No internals to hide.

## Why typed surface

Three MCP tool schemas in surface order:
- `masc_worktree_create` — required `task_id`; optional
  `agent_name`, `base_branch=auto`, `repo_name`
- `masc_worktree_remove` — required `task_id`; optional
  `agent_name`
- `masc_worktree_list` — no required params

List length and per-tool `name` strings are pinned at the
contract seam — four downstream surfaces concat them
(`tool_worktree`, `tool_shard`, `agent_tool_surfaces`, `tools`),
and the agent SDK's tool-routing tables grep the names at
startup. A rename of `masc_worktree_remove` must touch this
file as part of an explicit migration; emergent renames break
production.

## `repo_name` validation contract (load-bearing)

The JSON Schema `pattern` `^[A-Za-z0-9._-]+$` enforces the
character class, but `"."` and `".."` match it and are
rejected at runtime in:
- `Tool_worktree.handle_worktree_create`
- `Coord_worktree.worktree_create_r`

JSON Schema Draft 7 (used by most MCP clients) **does not
support negative lookahead**, so the three layers (schema /
tool dispatch / coord resolver) keep the same rule **by
convention only**. The `.mli` docstring surfaces this
cross-layer constraint so a future "let's tighten the pattern"
refactor sees the convention before silently diverging.

## Caller audit (`rg "Tool_schemas_worktree\\."`)
- `lib/tool_worktree.ml` —
  `let schemas = Tool_schemas_worktree.schemas`
- `lib/tool_shard.ml` — concat into the `tool_shard` surface
- `lib/agent_tool_surfaces.ml` — `schemas`
- `lib/tools.ml` — concat into the master tools list

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
