### PR TITLE
feat(meta-cognition): add meta_cognition_digest.mli — typed digest accessor surface (cycle 76)

### DIFF
--- a/lib/meta_cognition_digest.mli
+++ b/lib/meta_cognition_digest.mli
@@ -1,0 +1,47 @@
+(** Meta_cognition_digest — board digest management.
+
+    Manages meta-cognition digest posts on the board, including
+    signature-based deduplication and latest-digest lookup.
+    Pulled out of [meta_cognition.ml] as part of the god-file
+    split; {!Meta_cognition} re-exports the public surface via
+    [include Meta_cognition_digest], so callers reach
+    {!latest_digest_json} either as
+    [Meta_cognition.latest_digest_json] (the dashboard's
+    namespace-truth path) or directly via this module.
+
+    Internal helpers ([digest_hearth] / [digest_source] string
+    constants, the [post_digest_key] meta extractor, and the
+    [latest_digest_post] intermediate that returns
+    [(post * digest_key)] tuples) are hidden — callers consume
+    only the typed reference accessor and the JSON projection.
+
+    @since God file decomposition — extracted from
+    meta_cognition.ml *)
+
+val latest_digest_ref :
+  ?summary:Meta_cognition_types.summary ->
+  unit ->
+  Meta_cognition_types.digest_ref option
+(** Look up the most recent digest post on the
+    ["meta-cognition"] hearth (Automation_post,
+    [Recent]-sorted, top-20 window) whose meta JSON has
+    [source = "meta_cognition_digest"]. Returns [None] when no
+    matching post exists.
+
+    When [summary] is supplied, [matches_summary] in the result
+    record is set iff the post's [digest_key] equals
+    {!Meta_cognition_interpret.summary_signature} of the
+    summary; otherwise [matches_summary] is [false]. *)
+
+val latest_digest_json :
+  ?summary:Meta_cognition_types.summary ->
+  unit ->
+  Yojson.Safe.t
+(** {!latest_digest_ref} projected to a JSON object with the
+    fields [post_id] / [title] / [created_at] / [updated_at] /
+    [hearth] / [digest_key] / [matches_summary] / [provenance].
+    [provenance] is always [`String "board"] so dashboard
+    consumers can attribute the digest to its source surface;
+    [updated_at] / [hearth] render as [`Null] when absent on
+    the underlying post. Returns [`Null] when no digest post
+    matches. *)


### PR DESCRIPTION
## Summary

Cycle 76 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/meta_cognition_digest.ml` (71 lines).

Surface (typed accessor + JSON projection):
- `val latest_digest_ref :
    ?summary:Meta_cognition_types.summary -> unit ->
    Meta_cognition_types.digest_ref option`
- `val latest_digest_json :
    ?summary:Meta_cognition_types.summary -> unit ->
    Yojson.Safe.t`

Hidden internals:
- `val digest_hearth` — `"meta-cognition"` string constant
- `val digest_source` — `"meta_cognition_digest"` string
  constant
- `val post_digest_key` — `post -> string option` meta
  extractor
- `val latest_digest_post` — `(post * digest_key)` tuple
  intermediate

## Why hide the string constants

Hiding `digest_hearth` / `digest_source` prevents a future
caller from bypassing the canonical spelling (e.g. accepting
`"meta_cog"` as a source alternative). The matcher is internal
to the digest pipeline; callers should query through
`latest_digest_*` rather than reproduce the lookup.

## Board-side filter contract pinned at the seam

- hearth = `"meta-cognition"`
- post_kind = `Automation_post`
- sort = `Recent`
- window = top 20
- meta JSON: `source` must equal `"meta_cognition_digest"`
  after `trim` + `lowercase`

A future "let's also scan Human_post" or "expand the window to
50" refactor must touch this file as part of an explicit
contract change.

## Null-vs-missing semantic preserved (cycle 69 pattern)

The JSON projection renders absent `updated_at` / `hearth` as
`` `Null `` rather than empty strings, matching the
`telemetry_coverage_gap` pattern documented in cycle 69.
Dashboard consumers rely on this to distinguish "deliberately
absent" from "deliberately blank".

`provenance` is always `` `String "board" `` so dashboard
consumers can attribute the digest to its source surface — a
future "memory" or "vector-store" provenance is a contract
extension, not an emergent regression.

## `matches_summary` semantics

- summary supplied + signature equals `digest_key` → `true`
- summary omitted, or signature mismatch → `false`

`Meta_cognition_interpret.summary_signature` is the canonical
hash function; pinning the equality contract here prevents a
future "let's normalise whitespace before hashing" change from
silently flipping the boolean across every namespace-truth
panel.

## Caller audit (`rg "Meta_cognition_digest|latest_digest_json"`)
- `lib/meta_cognition.ml` — `include Meta_cognition_digest`
- `lib/server/server_dashboard_http_namespace_truth_support.ml`
  — `Meta_cognition.latest_digest_json` (`?summary`)

No external reference to `digest_hearth` / `digest_source` /
`post_digest_key` / `latest_digest_post`.

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
