### PR TITLE
feat(server): add server_routes_http_routes_artifacts.mli — typed blob-store HTTP surface (cycle 77)

### DIFF
--- a/lib/server/server_routes_http_routes_artifacts.mli
+++ b/lib/server/server_routes_http_routes_artifacts.mli
@@ -1,0 +1,55 @@
+(** Server_routes_http_routes_artifacts — HTTP surface for the
+    tool blob store.
+
+    Tool outputs externalised by [Tool_bridge.maybe_externalize]
+    live in [${MASC_BASE_PATH}/.masc/tool_blobs/<sha[0..1]>/<sha>];
+    the dashboard UI displays the sentinel-marker preview by
+    default and lazy-fetches the full bytes via:
+
+    {v GET /api/v1/artifacts/<sha256> v}
+
+    Response (200): JSON envelope
+    {[
+      { "sha256": ..., "bytes": <int>, "mime": "text/plain",
+        "content": "<the bytes>" }
+    ]}
+
+    Errors:
+    - 400 — malformed sha256 (not 64 hex chars)
+    - 404 — sha256 not in store
+    - 503 — base path unresolvable (store unavailable) *)
+
+val is_valid_sha256 : string -> bool
+(** [true] iff [s] is exactly 64 chars long and every char is in
+    the lower / upper hex range ([0-9a-fA-F]). The route handler
+    rejects requests whose path parameter fails this check with
+    400 before touching the blob store, so the validation
+    surfaces as a contract guard for path-traversal and
+    fixed-length sentinels. *)
+
+val blob_response :
+  sha256:string ->
+  Yojson.Safe.t * Httpun.Status.t
+(** Look up [sha256] in the on-disk blob store
+    ([${MASC_BASE_PATH}/.masc/tool_blobs/]) and return the
+    JSON envelope plus the HTTP status code:
+
+    - [`OK] when the blob is present (envelope contains the
+      [content] bytes verbatim);
+    - [`Not_found] when the sha is well-formed but absent
+      from the store;
+    - [`Service_unavailable] when [Env_config_core.base_path_opt]
+      returns [None] (no [MASC_BASE_PATH], no store root).
+
+    The function never raises — every failure path produces a
+    JSON envelope with an [error] field. *)
+
+val add_routes :
+  Http_server_eio.Router.t ->
+  Http_server_eio.Router.t
+(** Register the [GET /api/v1/artifacts/<sha256>] route on
+    [router] using {!Server_auth.with_public_read} (the
+    artifacts endpoint is public-read by design — sentinel
+    sha256 values do not leak in the dashboard's preview, so
+    full-byte fetch needs no auth). Returns the augmented
+    router. *)


### PR DESCRIPTION
## Summary

Cycle 77 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for
`lib/server/server_routes_http_routes_artifacts.ml` (86 lines).

Surface (3 entries — exhaustive, no internals to hide):
- `val is_valid_sha256 : string -> bool`
- `val blob_response :
    sha256:string -> Yojson.Safe.t * Httpun.Status.t`
- `val add_routes :
    Http_server_eio.Router.t -> Http_server_eio.Router.t`

## Skipped this cycle

`lib/server/server_mcp_transport_http_protocol.ml` (75 lines)
— heavy `include Server_mcp_transport_http_session` plus 13
re-exports from `Server_mcp_transport_http_headers`; neither
underlying module has a `.mli`, so an explicit `.mli` here
would force `include module type of …` against an inferred
signature and create sync burden every time the underlying
modules change. Same calculus as `lib/oas.ml` (cycle 57 skip)
and `lib/board.ml` (cycle 67 skip).

## Why typed surface for artifacts

The route handles the dashboard's lazy-fetch endpoint for tool
blob bytes. Three contracts are pinned at the seam:

1. **Path-traversal guard** — `is_valid_sha256` enforces exact
   64 chars + `[0-9a-fA-F]`, rejecting `"."` / `".."` /
   `"../../etc/passwd"` before the request reaches the blob
   store. The function is exposed (not just used internally)
   because `test_tool_output_washing_e2e` exercises it across
   4 cases (valid / length-63 / mixed-class / traversal).
2. **Status code mapping** — `` `OK `` (present) /
   `` `Not_found `` (well-formed but absent) /
   `` `Service_unavailable `` (`MASC_BASE_PATH` unset). A
   future "let's just 404 everywhere for security" refactor
   would silently mask the missing-base-path failure mode.
3. **`never raises`** — every failure path produces a JSON
   envelope with an `error` field rather than an exception.
   The dashboard's lazy-fetch loop relies on this to keep
   rendering even when a blob lookup fails.

## `with_public_read` by design

`add_routes` wraps the handler in `Server_auth.with_public_read`
because sentinel sha256 values do not leak in the dashboard
preview, so a full-byte fetch needs no auth. The docstring
records this rationale so a future "add auth on artifact fetch"
change is an intentional contract revision rather than a silent
security regression.

## Caller audit (`rg "Server_routes_http_routes_artifacts\\."`)
- `lib/server/server_routes_http.ml` — `add_routes` (route
  composition)
- `test/test_tool_output_washing_e2e.ml` — `blob_response`
  (1 site) + `is_valid_sha256` (4 cases)

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI) — `test_tool_output_washing_e2e`
      exercises every exposed binding
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
