### PR TITLE
docs(keeper): add KeeperTurnCycle.tla anchor in keeper_guards (Cycle 39)

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -22,6 +22,44 @@
 
     @since T1-A — pre_tool_use guard decomposition *)
 
+(* ─────────────────────────────────────────────────────────────────── *)
+(* Spec navigation (OCaml -> TLA+) — KeeperTurnCycle composite anchor. *)
+(* ─────────────────────────────────────────────────────────────────── *)
+(*                                                                     *)
+(* Authoritative spec mirror is                                        *)
+(*   specs/keeper-state-machine/KeeperTurnCycle.tla                    *)
+(* (3-axis composite — turn_phase x decision_stage x cascade_state).   *)
+(*                                                                     *)
+(* This module is one of FOUR cooperating write points; siblings are   *)
+(* keeper_registry.ml (raw setters), keeper_unified_turn.ml (top-level *)
+(* orchestration), and keeper_agent_run.ml (policy selection).         *)
+(* keeper_guards.ml owns a SINGLE spec action:                         *)
+(*                                                                     *)
+(*   GateRejected — spec line 192-200                                  *)
+(*     pre_tool_use override / approval_required short-circuit.        *)
+(*     turn_phase: executing -> finalizing                             *)
+(*     decision_stage: tool_policy_selected -> gate_rejected           *)
+(*     cascade_state preserved at "trying" (UNCHANGED in spec).        *)
+(*                                                                     *)
+(* Spec inline citation at KeeperTurnCycle.tla:58 says "line 120" —    *)
+(* current actual call site of                                         *)
+(*   Keeper_registry.mark_turn_gate_rejected_by_name                   *)
+(* is line 143 inside [emit_gate_event] (drift +23 since spec was      *)
+(* written; spec citation list is module-coarse and survives line      *)
+(* shifts within the same function).                                   *)
+(*                                                                     *)
+(* Cross-axis invariants (KeeperTurnCycle.tla:115-123) most relevant   *)
+(* to this file:                                                       *)
+(*   - GateRejectedRequiresFinalizing                                  *)
+(*       (decision_stage = "gate_rejected" => turn_phase = "finalizing")*)
+(*   - TerminalCascadeRequiresFinalizing                               *)
+(*                                                                     *)
+(* These cross-axis invariants are why KeeperTurnCycle exists          *)
+(* alongside the single-axis siblings (KeeperDecisionPipeline,         *)
+(* KeeperCascadeLifecycle, KeeperConditionsGovernPhase): no single     *)
+(* axis can express the conjunction across phase x decision x cascade. *)
+(* ─────────────────────────────────────────────────────────────────── *)
+
 (* -------------------------------------------------------------- *)
 (* Shared utilities previously inline in [keeper_hooks_oas]        *)
 (* -------------------------------------------------------------- *)
@@ -134,6 +172,12 @@ let notify_gate_decision on_gate_decision (event : gate_decision_event) =
     - [stage_latency_ms]    measured duration of this guard
     - [reason_text]         human-readable detail
     - [source]              "hook" (distinguishes from legacy paths) *)
+(* Spec mapping: GateRejected action — KeeperTurnCycle.tla lines 189-200.
+   The two-arm match below routes "override" | "approval_required" to
+   Keeper_registry.mark_turn_gate_rejected_by_name, which fires the
+   decision_stage = "gate_rejected" / turn_phase = "finalizing" transition.
+   The "continue" branch (and any unknown decision string) skips the spec
+   action entirely and only emits the Event_bus Custom event below. *)
 let emit_gate_event
     ~stage ~decision ~reason_code
     ~tool_name ~agent_name ~turn


### PR DESCRIPTION
## Summary

OCaml ↔ TLA+ bidirectional anchor for the **keeper_guards.ml** write
point of \`KeeperTurnCycle.tla\` (single \`GateRejected\` action).

This is part of the Cycle 24+ anchor sweep to close the
\"spec → code citation rich, code → spec citation absent\" gap that the
user identified as the lifecycle \"discoverability black box.\"

## What changes

\`lib/keeper/keeper_guards.ml\` (+44 / -0)
- **Module-level navigation block** (after the existing module
  docstring): names this file as 1 of 4 cooperating write points for
  the 3-axis composite (siblings: keeper_registry,
  keeper_unified_turn, keeper_agent_run). Identifies the **single
  owned spec action**: \`GateRejected\` (KeeperTurnCycle.tla:189-200).
- **Inline anchor** on \`emit_gate_event\` (where the spec action
  fires): documents the two-arm match —
  \`override | approval_required → mark_turn_gate_rejected_by_name\`
  (spec action), \`continue\` (and unknown decision) skips the spec
  action.
- Records **spec citation drift**: KeeperTurnCycle.tla:58 cites
  \`keeper_guards.ml line 120\`. Current actual call site is line 143
  inside \`emit_gate_event\` (drift +23 within the same function).
  The function-level anchor survives the line shift.

No semantic change. Comments only.

## Why this file matters

Of the 4 write-point siblings, \`keeper_guards.ml\` is the **narrowest
footprint** — single spec action vs multi-action role for the
others. The narrowness is exactly why this file is hard to find via
spec → code; you need to know the action name to land here.

## Cross-axis context

Cited cross-axis invariants in the anchor block:
- \`GateRejectedRequiresFinalizing\` — \`decision_stage = "gate_rejected"\` ⇒ \`turn_phase = "finalizing"\`
- \`TerminalCascadeRequiresFinalizing\`

These cross-axis invariants exist precisely because no single-axis
sibling spec (KeeperDecisionPipeline, KeeperCascadeLifecycle,
KeeperConditionsGovernPhase) can express conjunctions across
turn_phase × decision_stage × cascade_state.

## Verification

- \`dune build --root . lib/keeper/\` — clean
- Race window check (immediately before push): no overlapping OPEN PR
  in keeper_guards / KeeperTurnCycle scope
- Worktree path: \`.worktrees/spec-keeper-guards-turn-cycle-anchor\`
- diff stat: 1 file, +44/-0

## Plan ref

Plan §19 (Cycle 39, post-Cycle 38 ROI decay autonomous extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)