### PR TITLE
feat(tool-schemas): add tool_schemas_run.mli — run-tracking schema SSOT (cycle 78)

### DIFF
--- a/lib/tool_schemas/tool_schemas_run.mli
+++ b/lib/tool_schemas/tool_schemas_run.mli
@@ -1,0 +1,29 @@
+(** Tool_schemas_run — SSOT for the six run-tracking tool
+    schemas.
+
+    Surface order:
+    - [masc_run_init]        — initialise [.masc/runs/<task_id>/]
+      and start tracking; required [task_id], [agent_name].
+    - [masc_run_plan]        — set / update execution plan;
+      required [task_id], [plan].
+    - [masc_run_log]         — append a timestamped note to the
+      run's audit log; required [task_id], [note].
+    - [masc_run_deliverable] — record the final output;
+      required [task_id], [deliverable].
+    - [masc_run_get]         — retrieve plan + logs +
+      deliverables for one run; required [task_id].
+    - [masc_run_list]        — list all runs with status; no
+      required params.
+
+    Concatenated by {!Agent_tool_surfaces} into the
+    process-wide tool surface; list length and per-tool [name]
+    strings are part of the public contract because the agent
+    SDK's tool-routing tables grep them at startup. *)
+
+val schemas : Types.tool_schema list
+(** The six run-tracking schemas in the surface order documented
+    above. List length and [name] strings are pinned at the
+    contract seam — a rename of [masc_run_log] to
+    [masc_run_note] (or any other rebranding) must touch this
+    file as part of an explicit migration so the agent
+    SDK's routing tables stay in sync. *)


### PR DESCRIPTION
## Summary

Cycle 78 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/tool_schemas/tool_schemas_run.ml`
(97 lines).

Surface (single binding):
- `val schemas : Types.tool_schema list`

No internals to hide.

## Why typed surface

Six run-tracking MCP tool schemas in surface order:

| Tool | Required params |
|------|-----------------|
| `masc_run_init`        | `task_id`, `agent_name` |
| `masc_run_plan`        | `task_id`, `plan` |
| `masc_run_log`         | `task_id`, `note` |
| `masc_run_deliverable` | `task_id`, `deliverable` |
| `masc_run_get`         | `task_id` |
| `masc_run_list`        | — |

List length and per-tool `name` strings are pinned at the
contract seam — the agent SDK's tool-routing tables grep them
at startup. A rename of `masc_run_log` to `masc_run_note` (or
any other rebranding) must touch this file as part of an
explicit migration so the routing tables stay in sync.

Same SSOT pattern as cycles 73 (`tool_schemas_code`) and 75
(`tool_schemas_worktree`); the trio collectively forms the
masc-mcp tool surface that `agent_tool_surfaces` concatenates
for discovery.

## Caller audit (`rg "Tool_schemas_run\\."`)
- `lib/agent_tool_surfaces.ml` — `schemas` (concat into the
  process-wide tool surface)

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
