### PR TITLE
feat(oas-worker): add oas_worker_exec_checkpoint.mli — typed lifecycle/checkpoint surface (cycle 79)

### DIFF
--- a/lib/oas_worker_exec_checkpoint.mli
+++ b/lib/oas_worker_exec_checkpoint.mli
@@ -1,0 +1,89 @@
+(** Oas_worker_exec_checkpoint — lifecycle, checkpoint, and
+    idle-detail helpers extracted from {!Oas_worker_exec}.
+
+    Keeps side-effecting run helpers separate from the main
+    build / resume / run orchestration so the orchestration
+    module stays focused on Eio fiber composition.
+
+    No internal helpers are hidden; the .mli pins each entry
+    point's contract so a future refactor of the OAS Agent
+    surface (Provider / Checkpoint / Types renames) fails here
+    instead of at every call site in {!Oas_worker_exec}. *)
+
+val publish_lifecycle :
+  Oas.Event_bus.t ->
+  name:string ->
+  event:string ->
+  detail:string ->
+  ?error:string ->
+  ?session_id:string ->
+  ?status:string ->
+  unit ->
+  unit
+(** Publish a [Custom "masc.oas_worker.<event>"] event on the
+    process-wide [Masc_event_bus]. The first argument is
+    accepted but **ignored** — the function looks up the bus via
+    [Masc_event_bus.get ()] internally; the parameter is kept
+    for backwards-compatibility with callers that already thread
+    the bus through, and for symmetry with sibling lifecycle
+    publishers that do consume their bus argument.
+
+    Optional [error] / [session_id] / [status] fields are
+    included in the payload only when [Some] and non-empty
+    after trim — empty strings are dropped to keep the JSON
+    payload skinny for downstream SSE consumers. *)
+
+val persist_checkpoint :
+  dir:string ->
+  session_id:string ->
+  Oas.Checkpoint.t ->
+  unit
+(** Serialise [ckpt] via [Oas.Checkpoint.to_string] and write it
+    atomically to [<dir>/<session_id>.json]. The parent [dir]
+    is created via [Fs_compat.mkdir_p] before the write — the
+    function never raises on a missing directory. *)
+
+val build_checkpoint :
+  session_id:string ->
+  ?checkpoint_sidecar:Yojson.Safe.t ->
+  Oas.Agent.t ->
+  Oas.Checkpoint.t
+(** Build an [Oas.Checkpoint.t] for [agent].
+
+    When [checkpoint_sidecar] is omitted, delegates to
+    [Oas.Agent.checkpoint ~session_id agent] (the SDK's own
+    checkpoint capture).
+
+    When [checkpoint_sidecar] is supplied, builds the checkpoint
+    via [Oas.Agent_checkpoint.build_checkpoint] threading the
+    sidecar JSON through as the [working_context]; this path is
+    used when masc-mcp wants to attach extra worker-side state
+    that the SDK's default capture does not include. *)
+
+val partial_response_of_stop :
+  session_id:string ->
+  model_id:string ->
+  text:string ->
+  Oas.Types.api_response
+(** Synthesise an [Oas.Types.api_response] for the early-stop
+    case (e.g. operator-side cancel before the model finishes).
+    [stop_reason = EndTurn], single [Text] content block, no
+    usage / telemetry. The shape lets downstream code treat
+    operator-stop and model-stop uniformly. *)
+
+val enrich_idle_detail :
+  string ->
+  Oas.Types.message list ->
+  string
+(** Enrich an [Oas.Error.to_string] detail string with the name
+    of the most recently called tool when the detail starts
+    with ["Idle detected"]. For all other detail strings the
+    input is returned unchanged.
+
+    The "most recently called tool" is the last
+    [Oas.Types.ToolUse { name }] block in the most recent
+    [Assistant] message; when no such block exists the bare
+    detail is returned.
+
+    Exposed at module level so the test suite can exercise it
+    independently of the network-bound [run] function. *)


### PR DESCRIPTION
## Summary

Cycle 79 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/oas_worker_exec_checkpoint.ml`
(89 lines).

Surface (5 helpers — exhaustive, no internals to hide):
- `val publish_lifecycle :
    Oas.Event_bus.t -> name:string -> event:string ->
    detail:string -> ?error:string -> ?session_id:string ->
    ?status:string -> unit -> unit`
- `val persist_checkpoint :
    dir:string -> session_id:string -> Oas.Checkpoint.t -> unit`
- `val build_checkpoint :
    session_id:string -> ?checkpoint_sidecar:Yojson.Safe.t ->
    Oas.Agent.t -> Oas.Checkpoint.t`
- `val partial_response_of_stop :
    session_id:string -> model_id:string -> text:string ->
    Oas.Types.api_response`
- `val enrich_idle_detail :
    string -> Oas.Types.message list -> string`

## Why typed surface (5 different reasons across 5 functions)

1. **`publish_lifecycle` first argument is *ignored***. The
   function looks up the bus via `Masc_event_bus.get ()`
   internally, but the parameter is kept for
   backwards-compat with callers that already thread the bus
   through and for symmetry with sibling lifecycle
   publishers. The .mli documents this quirk so a future
   "remove the unused param" refactor sees it is a
   compatibility decision, not a forgotten detail.
2. **`persist_checkpoint` never raises** on a missing
   directory — `Fs_compat.mkdir_p` is called before the write.
   Pinning this contract prevents a future "let's just
   `Sys.mkdir`" refactor from silently introducing a raise.
3. **`build_checkpoint` dispatch is split** between
   `Oas.Agent.checkpoint` (no sidecar, SDK default) and
   `Oas.Agent_checkpoint.build_checkpoint` (with sidecar,
   masc-mcp threading extra `working_context`). A future OAS
   pin bump that renames `Agent_checkpoint.build_checkpoint`
   surfaces at this contract seam instead of every call site.
4. **`partial_response_of_stop` shape pinned**:
   `stop_reason = EndTurn`, single `Text` content block, no
   usage / telemetry. This lets downstream code treat
   operator-stop and model-stop uniformly.
5. **`enrich_idle_detail` noop semantics pinned**: only
   `"Idle detected"` prefix triggers enrichment; all other
   detail strings are returned unchanged. A future
   "let's also enrich timeout messages" refactor must extend
   the prefix list explicitly.

## Empty-string-after-trim drop semantic (cycle 69 pattern)

`publish_lifecycle`'s optional `error` / `session_id` /
`status` fields are dropped from the JSON payload when `None`
or empty after trim — same Null-vs-empty pattern as
`telemetry_coverage_gap` (cycle 69) and `meta_cognition_digest`
(cycle 76). Downstream SSE consumers rely on this
distinguishing "missing" from "deliberately blank".

## Caller audit (`rg "Oas_worker_exec_checkpoint\\."`)
- `lib/oas_worker_exec.ml` — top-level `let` rebinds for all
  5 functions

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
