### PR TITLE
feat(mcp): add mcp_server_eio_governance.mli — typed governance/session surface (cycle 80)

### DIFF
--- a/lib/mcp_server_eio_governance.mli
+++ b/lib/mcp_server_eio_governance.mli
@@ -1,0 +1,109 @@
+(** Mcp_server_eio_governance — governance configuration and
+    MCP session helpers.
+
+    Extracted from [mcp_server_eio.ml] to reduce file size and
+    enable reuse from {!Tool_inline_dispatch} without
+    re-introducing the dependency cycle the split was designed
+    to break. {!Mcp_server_eio} re-exports the two record types
+    via [type t = Mcp_server_eio_governance.t = { … }] and
+    forwards [governance_defaults] /
+    [mcp_session_{to,of}_json] as top-level lets.
+
+    Internal helpers (the [governance_path] / [mcp_sessions_path]
+    path joiners and the [ensure_masc_dir] mkdir helper) are
+    hidden — callers go through [load_*] / [save_*] which call
+    them on every read / write. The auto-derived
+    [mcp_session_record_to_yojson] /
+    [mcp_session_record_of_yojson] are also hidden; the
+    [mcp_session_{to,of}_json] aliases are the canonical names. *)
+
+(** {1 Governance} *)
+
+type governance_config = {
+  level : string;
+  audit_enabled : bool;
+  anomaly_detection : bool;
+}
+(** Process-wide governance posture. The fields are public so
+    {!Mcp_server_eio} can rebind the type via the [type … = … =
+    { … }] equality pattern; tests in
+    [test_governance_yojson_roundtrip] also construct the record
+    directly. *)
+
+val governance_config_to_yojson : governance_config -> Yojson.Safe.t
+(** [@@deriving yojson]-generated encoder. Exposed because the
+    round-trip test suite asserts on the output and
+    {!save_governance} composes the result with an
+    [updated_at] field before persisting. *)
+
+val governance_config_of_yojson :
+  Yojson.Safe.t -> (governance_config, string) result
+(** [@@deriving yojson { strict = false }]-generated decoder.
+    Strict-false: unknown fields are tolerated to keep older
+    [governance.json] payloads readable across upgrades. *)
+
+val governance_defaults : string -> governance_config
+(** Resolve a {!governance_config} from a level name (case
+    insensitive). The level is canonicalised to lowercase in
+    [level], and the two boolean fields are derived:
+
+    - [audit_enabled = true] iff [level] is
+      ["production"] / ["enterprise"] / ["paranoid"]
+    - [anomaly_detection = true] iff [level] is
+      ["enterprise"] / ["paranoid"]
+
+    Every other level (including ["development"], the implicit
+    fallback) leaves both flags [false]. *)
+
+val load_governance : Coord.config -> governance_config
+(** Read [governance.json] under [config]'s [.masc/] root. When
+    the file is absent, returns
+    [governance_defaults "development"]. Per-field fallback to
+    {!governance_defaults} of the JSON's [level] is applied so a
+    partial file does not bring the boolean flags to their
+    [false] defaults. *)
+
+val save_governance :
+  Coord.config -> governance_config -> unit
+(** Persist [g] to [governance.json] under [config]'s [.masc/]
+    root. The [updated_at] field is appended (current
+    [Types.now_iso ()]) when the encoder produces an [`Assoc].
+    Creates the [.masc/] directory if absent. *)
+
+(** {1 MCP sessions} *)
+
+type mcp_session_record = {
+  id : string;
+  agent_name : string option;
+  created_at : float;
+  last_seen : float;
+}
+(** A single persisted MCP session row. [agent_name] defaults to
+    [None] when absent in JSON via the [@default None] derive
+    attribute. *)
+
+val mcp_session_to_json : mcp_session_record -> Yojson.Safe.t
+(** Canonical encoder name used by callers; aliases the
+    auto-derived [mcp_session_record_to_yojson] which is hidden
+    to keep the surface stable across PPX renames. *)
+
+val mcp_session_of_json :
+  Yojson.Safe.t -> mcp_session_record option
+(** Canonical decoder name. Returns [None] on any decode
+    failure (the auto-derived
+    [mcp_session_record_of_yojson]'s [Result.t] is collapsed
+    via [Result.to_option] because callers always treat decode
+    failure as "skip this row"). *)
+
+val load_mcp_sessions : Coord.config -> mcp_session_record list
+(** Read [mcp-sessions.json] under [config]'s [.masc/] root.
+    Returns [[]] when the file is absent or when the top-level
+    JSON is not a [`List]. Individual rows that fail to decode
+    are silently dropped — callers must not rely on a complete
+    list across schema migrations. *)
+
+val save_mcp_sessions :
+  Coord.config -> mcp_session_record list -> unit
+(** Persist [sessions] as a [`List] to [mcp-sessions.json] under
+    [config]'s [.masc/] root. Creates the [.masc/] directory if
+    absent. *)


### PR DESCRIPTION
## Summary

Cycle 80 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/mcp_server_eio_governance.ml`
(97 lines).

Surface (2 records + 9 entries):
- `type governance_config = { level; audit_enabled;
                                 anomaly_detection }`
- `val governance_config_to_yojson / _of_yojson` (PPX-derived)
- `val governance_defaults : string -> governance_config`
- `val load_governance / save_governance`
- `type mcp_session_record = { id; agent_name; created_at;
                                  last_seen }`
- `val mcp_session_to_json / _of_json` (canonical aliases)
- `val load_mcp_sessions / save_mcp_sessions`

Hidden internals:
- `governance_path` / `mcp_sessions_path` — path joiners called
  only by `load_*` / `save_*`
- `ensure_masc_dir` — directory creator called by `save_*`
- `mcp_session_record_to_yojson` / `_of_yojson` — auto-derived
  PPX names shadowed by canonical aliases

## Why concrete records (not abstract)

Both records are exposed concretely because:
1. `mcp_server_eio.ml` re-exports the types via the
   `type t = … = { … }` equality pattern so the rest of the
   codebase keeps using bare names; abstract types break the
   re-export.
2. `test_governance_yojson_roundtrip` constructs both records
   directly across multiple fixtures.

## Strict-false JSON decode contract

`governance_config_of_yojson` is `[@@deriving yojson { strict =
false }]`-derived: **unknown fields are tolerated** to keep
older `governance.json` payloads readable across upgrades. The
`.mli` docstring documents this so a future "let's tighten
validation" refactor does not silently break in-place upgrade
paths. Same applies to `mcp_session_record_of_yojson`.

## Per-field fallback in `load_governance`

A partial `governance.json` with only `level` set falls back
to `governance_defaults level` for the boolean flags rather
than collapsing them to `false`. Pinning this contract
prevents a future "simpler decoder" refactor from silently
flipping `audit_enabled` to `false` on partial config files
(which would silently disable audit logging in production).

## `mcp_session_of_json` collapse semantic

Returns `option` (not `Result.t`) because callers in
`load_mcp_sessions` always treat decode failure as
"skip this row" via `List.filter_map`. The `.mli` docstring
documents this so callers don't expect a structured error
explanation — and a future caller that does need it must
introduce a new strict variant rather than tighten this one.

## Caller audit
- `lib/mcp_server_eio.ml` — type re-exports +
  `governance_defaults` + `mcp_session_to_json` / `_of_json`
- `lib/mcp_server_eio_execute.ml` — `save_governance`,
  `load_mcp_sessions`, `save_mcp_sessions` (DI table)
- `lib/tool_inline_dispatch{,_types}.ml` — `mcp_session_record`
  / `governance_config` types in DI signatures
- `test/test_governance_yojson_roundtrip.ml` — round-trip
  tests exercising `governance_config_to_yojson` / `_of_yojson`
  + `mcp_session_to_json` / `_of_json` directly

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI) — `test_governance_yojson_roundtrip`
      exercises every PPX-derived encoder / decoder
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
