### PR TITLE
feat(discovery): add discovery_cache.mli — typed TTL-cache surface (cycle 81)

### DIFF
--- a/lib/discovery_cache.mli
+++ b/lib/discovery_cache.mli
@@ -1,0 +1,108 @@
+(** Discovery_cache — TTL-cached wrapper over the OAS provider
+    discovery probe.
+
+    All HTTP probing logic lives in [Llm_provider.Discovery]; this
+    module adds:
+    - 30-second TTL caching keyed off an [Atomic.t] timestamp
+      so the staleness check needs no lock;
+    - convenience queries (any-local-healthy / idle-slot count /
+      busy-slot count);
+    - Eio capability injection via {!set_env} at server init so
+      the cached probe can issue HTTP without threading the
+      runtime through every caller.
+
+    The cache mutex protects the result list only — the HTTP
+    probe itself runs **outside** the lock to keep dashboard /
+    local-runtime consumers from waiting on multi-second network
+    I/O. Two concurrent refreshers may both probe; that is
+    wasteful but correct, and the 30 s TTL narrows the window.
+
+    Test-only mutable state ([cached_endpoints] /
+    [cache_updated_at]) is exposed deliberately —
+    [test_tool_local_runtime_verify] needs to seed and restore
+    the cache before / after exercising consumers. The .mli
+    documents this so a future "make these private" refactor
+    sees the test contract it would break. *)
+
+(** {1 Type aliases} *)
+
+type endpoint_info = Llm_provider.Discovery.endpoint_status
+(** Re-export of [Llm_provider.Discovery.endpoint_status] so
+    callers do not have to spell the long path. *)
+
+(** {1 Capability injection} *)
+
+val set_env :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  unit
+(** Capture the Eio switch and net handle for later HTTP
+    probing. Called once at server init by
+    [server_runtime_bootstrap]; safe to re-call (last-writer-wins
+    on the underlying [Atomic.t]). *)
+
+val set_base_path : string -> unit
+(** Capture the base path used by {!Discovery_history} to
+    persist probe snapshots. When unset, probe persistence is
+    skipped silently — the cache itself works without a base
+    path. *)
+
+(** {1 Cache state (test-visible)} *)
+
+val cached_endpoints : endpoint_info list ref
+(** Current cached probe result. Exposed for the
+    [test_tool_local_runtime_verify] suite which needs to seed
+    a deterministic value and restore the original after the
+    test. Production callers should go through
+    {!get_cached_or_refresh} instead. *)
+
+val cache_updated_at : float Atomic.t
+(** Unix timestamp of the most recent successful refresh. The
+    TTL check in {!get_cached_or_refresh} reads this without
+    taking the cache mutex. Exposed for the same testing
+    reason as {!cached_endpoints}. *)
+
+(** {1 Refresh + read} *)
+
+val refresh_cache : unit -> unit
+(** Run the discovery probe (HTTP, no lock held) and install
+    the result under the cache mutex. Also persists the snapshot
+    to {!Discovery_history} when {!set_base_path} has been called.
+    No-op when {!set_env} has not yet captured the Eio handles. *)
+
+val get_cached_or_refresh : unit -> endpoint_info list
+(** Return the cached endpoint list, refreshing first when:
+    - the TTL has elapsed (30 seconds), or
+    - the cache is still empty (first call after boot).
+
+    The staleness check uses an atomic read so it does not
+    contend with concurrent refreshes. *)
+
+val cache_age_seconds : unit -> float
+(** Wall-clock seconds since the last successful refresh. *)
+
+(** {1 Convenience queries} *)
+
+val any_local_healthy : unit -> bool
+(** [true] iff at least one cached endpoint reports healthy.
+    Implicitly refreshes via {!get_cached_or_refresh}. *)
+
+val idle_slot_count : unit -> int
+(** Sum of [slot.idle] across cached endpoints; endpoints with
+    no slot info contribute 0. Implicitly refreshes via
+    {!get_cached_or_refresh}. *)
+
+val busy_slot_count : unit -> int
+(** Sum of [slot.busy] across cached endpoints; endpoints with
+    no slot info contribute 0. Implicitly refreshes via
+    {!get_cached_or_refresh}. *)
+
+(** {1 JSON projections} *)
+
+val endpoint_to_json : endpoint_info -> Yojson.Safe.t
+(** Re-export of [Llm_provider.Discovery.endpoint_status_to_json]
+    so dashboard consumers do not have to spell the path. *)
+
+val summary_to_json : endpoint_info list -> Yojson.Safe.t
+(** Re-export of [Llm_provider.Discovery.summary_to_json] so
+    dashboard consumers do not have to spell the path. *)


### PR DESCRIPTION
## Summary

Cycle 81 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/discovery_cache.ml` (112 lines).

Surface (1 type alias + 12 entries):
- `type endpoint_info = Llm_provider.Discovery.endpoint_status`
- `val set_env / set_base_path` — Eio capability injection
- `val cached_endpoints / cache_updated_at` — test-visible
  mutable state (deliberate, documented)
- `val refresh_cache / get_cached_or_refresh /
       cache_age_seconds`
- `val any_local_healthy / idle_slot_count / busy_slot_count`
- `val endpoint_to_json / summary_to_json` — JSON projections

Hidden internals:
- `cache_mu` — `Eio.Mutex.t` critical-section guard
- `cache_ttl` — `30.0` second constant
- `sw_ref` / `net_ref` / `base_path_ref` — Atomic option slots
  used by `set_env` / `set_base_path`

## Why test-only state is exposed (not hidden)

`cached_endpoints` (a `ref`) and `cache_updated_at` (an
`Atomic.t`) are reached into by
`test/test_tool_local_runtime_verify.ml`:

```ocaml
let previous = !Discovery_cache.cached_endpoints in
Atomic.set Discovery_cache.cache_updated_at (Time_compat.now ());
…
Discovery_cache.cached_endpoints := previous;
```

This is the **only** way the test can inject a deterministic
cache state before exercising the consumers. Hiding the slots
would force the test through a setter helper that production
callers do not need; same trade-off as cycle 64
(`tool_autoresearch_registry`) and cycle 68
(`prompt_registry_store`).

The `.mli` documents the test contract so a future
"make these private" refactor sees what the test fixture would
need rewritten.

## Cache mutex contract — load-bearing

The HTTP probe runs **outside** `cache_mu` because the probe
is multi-second network I/O and the cache is read by the
dashboard / local-runtime hot path. Two concurrent refreshers
may both probe; wasteful but correct, and the 30 s TTL narrows
the race window.

This pattern was the fix for `prompt_registry _unlocked` drift
(PR #6663). The `.mli` surfaces the rule so a future
"let's just hold the lock through the probe for safety" change
does not silently re-introduce the multi-second lock contention
that broke the dashboard.

## Atomic-read TTL semantics

`get_cached_or_refresh`'s staleness check reads
`cache_updated_at` without taking `cache_mu` so a refresher
in progress does not block readers. A future
"always lock for safety" refactor would silently re-introduce
the contention.

## Probe-snapshot persistence is opt-in

The `Discovery_history.record_probe` call is gated on
`base_path_ref` being set; absent base path → snapshot
silently dropped. Documenting this at the seam prevents a
future caller that forgets `set_base_path` from mysteriously
losing the historical trail.

## Caller audit
- `lib/server/server_runtime_bootstrap.ml` — `set_env` +
  `set_base_path`
- `lib/http_server_eio.ml` — `set_env`
- `lib/dashboard_provider_runs.ml` —
  `get_cached_or_refresh`
- `lib/dashboard/dashboard_http_monitoring.ml` —
  `busy_slot_count` / `idle_slot_count` / `cache_age_seconds` /
  `endpoint_to_json` / `get_cached_or_refresh`
- `lib/keeper/keeper_status_detail.ml` — `endpoint_info` /
  `get_cached_or_refresh`
- `lib/local/local_runtime_pool.ml` — `endpoint_info` /
  `get_cached_or_refresh`
- `lib/tool_local_runtime_verify.ml` — `cache_age_seconds` /
  `endpoint_info` / `get_cached_or_refresh`
- `test/test_tool_local_runtime_verify.ml` —
  `cached_endpoints` / `cache_updated_at` (seed / restore)

## Test plan
- [x] `dune build lib` — clean
- [ ] `dune runtest` (CI) —
      `test_tool_local_runtime_verify` exercises the
      seed / restore contract for the test-visible slots
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
