### PR TITLE
fix(keeper): wire expire_stale into heartbeat loop (IR-4 / Cycle 31)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1990,6 +1990,10 @@ let run_heartbeat_loop
         end;
         let t_presence_end = Time_compat.now () in
         let now_ts = t_presence_end in
+        (* IR-4 fix: expire stale approval-queue entries every heartbeat cycle.
+           max_wait_s = 600 (10 min) — Critical entries are excluded by
+           expire_stale itself, so only Low/Medium/High are swept. *)
+        Keeper_approval_queue.expire_stale ~max_wait_s:600.0;
         let t_snapshot_start = now_ts in
         maybe_write_heartbeat_snapshot
           ~ctx


### PR DESCRIPTION
## Summary
- Wire `Keeper_approval_queue.expire_stale` into the heartbeat loop at `keeper_keepalive.ml`
- `expire_stale` was fully implemented (resolves stale approval promises with `Reject`) but **never called anywhere** — dead code making `submit_and_await` capable of hanging forever when the resolver fiber dies
- Called every heartbeat cycle with `max_wait_s:600.0` (10 min) after presence sync. Critical entries are excluded by `expire_stale` internally.

## Root Cause (IR-4)
`submit_and_await` at `keeper_approval_queue.ml:751-771` uses bare `Eio.Promise.await` with no timeout. If the resolver fiber crashes or network partitions, the awaiting fiber hangs indefinitely. The fix function `expire_stale` (line 941-984) was designed for exactly this but was never wired in.

## Verification
- `dune build --root . @install` passes
- Change is 1 function call in heartbeat loop — type-safe, no new dependencies

## Test plan
- [ ] CI Build passes
- [ ] CI Lint passes  
- [ ] Manual verification: with a stuck approval promise, next heartbeat cycle should resolve it with Reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)