### PR TITLE
ci(tokens-drift): Gate 2 fail-fast on missing prerequisites (Iter 1 1b)

### DIFF
--- a/.github/workflows/tokens-drift.yml
+++ b/.github/workflows/tokens-drift.yml
@@ -12,13 +12,16 @@ name: tokens-drift
 #   Gate 2 (reference equivalence) - generated CSS lost a token name
 #       the legacy hand-written stylesheets exposed, or the keeper
 #       OkLCH triple drifted past the perceptual threshold.
-#       (Conditional: skipped when the equivalence script is absent.)
 #   Gate 3 (tier integrity) - generated artifacts changed without the
 #       authoring SSOT (source.ts) changing in the same PR. This is a
 #       structural lock against direct edits of @generated files.
 #
-# Branch protection registration is the user's call. Until then this
-# workflow advises only; it does NOT block merges automatically.
+# All three gates are mandatory. If the equivalence script or its
+# package.json entry are missing, Gate 2 fails — that is the point of a
+# required check. The script was removed by #11250 and restored by
+# #11330; this gate ensures any future regression is loud, not silent.
+# Branch protection registration to mark this workflow required is the
+# user's separate admin step.
 
 on:
   pull_request:
@@ -109,22 +112,22 @@ jobs:
       # ── Gate 2 ──────────────────────────────────────────────────────
       # Equivalence check. The script
       #   dashboard/design-system/tokens/scripts/check-equivalence.mjs
-      # is referenced in the Wave 2 design notes but currently does
-      # not exist in main (it was removed by #11250). Until it lands,
-      # this step is conditional and only runs when the script + the
-      # `tokens:check` package script are both present.
-      - name: Gate 2 - reference equivalence (conditional)
+      # was restored by #11330 (status canon + keeper ΔE) after #11250
+      # had removed it. The gate is now mandatory: a missing script or
+      # missing `tokens:check` package script is a regression that must
+      # block merge, not be silently skipped.
+      - name: Gate 2 - reference equivalence (mandatory)
         working-directory: dashboard
         run: |
           set -euo pipefail
           script="design-system/tokens/scripts/check-equivalence.mjs"
           if [ ! -f "$script" ]; then
-            echo "::notice::skipping Gate 2: $script not present in tree"
-            exit 0
+            echo "::error::Gate 2 prerequisite missing: $script. Restore the script (see #11330) or revert the change that removed it."
+            exit 1
           fi
           if ! node -e "const p=require('./package.json');process.exit(p.scripts && p.scripts['tokens:check']?0:1)"; then
-            echo "::notice::skipping Gate 2: package.json has no 'tokens:check' script"
-            exit 0
+            echo "::error::Gate 2 prerequisite missing: dashboard/package.json has no 'tokens:check' script. Restore the entry (see #11330)."
+            exit 1
           fi
           pnpm tokens:check
 


### PR DESCRIPTION
## Summary

v2 design-system pivot **Iter 1 1b** per [\`~/me/planning/claude-plans/20m-keen-giraffe.md\`](https://github.com/jeong-sik/masc-mcp). Closes the silent-skip path in Gate 2 of the \`tokens-drift\` workflow. Strict-safer no-op for current main.

Triggered by user \`go on\` on Iter 0 audit PR #11590 fire #5 decision point.

## What changed

\`.github/workflows/tokens-drift.yml\` — two \`exit 0\` early returns in Gate 2 → \`exit 1\` with explicit error messages. Header comment block updated to document new semantics and #11330 history.

\`\`\`diff
- if [ ! -f "$script" ]; then
-   echo "::notice::skipping Gate 2: $script not present in tree"
-   exit 0
+ if [ ! -f "$script" ]; then
+   echo "::error::Gate 2 prerequisite missing: $script. Restore the script (see #11330) or revert the change that removed it."
+   exit 1
\`\`\`

(Same flip on the \`tokens:check\` package script absence path.)

## Why this is safe today

The script (\`dashboard/design-system/tokens/scripts/check-equivalence.mjs\`) and the \`tokens:check\` entry in \`dashboard/package.json\` both **already exist in main** — restored by #11330 after #11250 had removed them. So:

- On current main: both gate prerequisites pass → \`pnpm tokens:check\` runs → no behavioral change for any current PR that triggers this workflow.
- On a hypothetical future PR that removes the script or the entry: this workflow now fails loudly instead of silently passing.

## Why this matters for v2

Per the audit (PR #11590), the workflow file's own header comment said:

> Branch protection registration is the user's call. Until then this workflow advises only; it does NOT block merges automatically.
> ... (Conditional: skipped when the equivalence script is absent.)

The combination — required check + silent skip — meant a PR that accidentally removed the equivalence script could pass CI invisibly. v1-§5 P0 / v2-§7 calls this exact pattern out as a behavioral discipline gap. This PR closes the silent-skip half of it.

## Out of scope (Iter 1 1a)

Branch protection registration on \`main\` to mark this workflow required is the user's separate admin step. Possible via:

\`\`\`bash
gh api -X PUT repos/jeong-sik/masc-mcp/branches/main/protection \\
  -F required_status_checks.contexts[]='Tokens drift (build + equivalence)' \\
  -F required_status_checks.contexts[]='Tier integrity (no hand-edit of generated)' \\
  -F required_status_checks.strict=true
\`\`\`

(or via Settings → Branches UI).

The workflow has a \`paths:\` filter, so it does not run on PRs that don't touch token files. GitHub treats a non-running required check as "not yet completed" and blocks merge — so registering it as required does NOT brick non-token PRs as long as branch protection is configured to allow that. This is documented in the v2 plan §"Iter 1 readiness" but flagged for the admin step.

## Test plan

- [x] Local \`yamllint\` (visual review) — diff is +15/-12, semantically equivalent on existing main.
- [ ] CI green on this PR (the workflow itself runs against this PR — meta-validation).
- [ ] After merge: tokens-drift workflow continues to pass for all PRs that don't touch tokens (because of \`paths:\` filter); passes for PRs that touch tokens cleanly; fails (loudly) for PRs that remove the equivalence script.

## Cross-reference

- Iter 0 audit (this PR's source): #11590 (merged \`1059c1975c\`)
- #11250 (removed the equivalence script)
- #11330 (restored it — \`feat(design-system): restore tokens:check (status canon + keeper ΔE)\`)
- v2 plan: \`~/me/planning/claude-plans/20m-keen-giraffe.md\` §"20분 청크" Iter 1
- Source corpus: v1-§5 / v2-§7 — token gate mandatory enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)