### PR TITLE
docs(spec): refresh KeeperHeartbeat.tla keeper_keepalive citations (Cycle 42)

### DIFF
--- a/specs/keeper-state-machine/KeeperHeartbeat.tla
+++ b/specs/keeper-state-machine/KeeperHeartbeat.tla
@@ -1,8 +1,12 @@
 ---- MODULE KeeperHeartbeat ----
 \* Heartbeat loop control flow for [lib/keeper/keeper_keepalive.ml].
 \*
-\* Runtime entities modelled (see [run_heartbeat_loop] at line 1815,
-\* and [Atomic.set entry.fiber_wakeup true] at lines 2130 and 2631):
+\* Function names are stable identifiers; lines drift across edits.
+\* Verified against main as of 2026-04-28 (sibling refresh to #11641,
+\* #11645; see Cycle 27 PR #11596 for the OCaml-side anchor).
+\*
+\* Runtime entities modelled (see [run_heartbeat_loop] at line 1828,
+\* and [Atomic.set entry.fiber_wakeup true] at lines 2143 and 2644):
 \*
 \*   wakeup_signaled  : bool Atomic.t — set by external supervisor /
 \*                      operator code when a keeper should service a


### PR DESCRIPTION
## Summary

Sibling refresh to #11641 (KeeperTurnCycle) and #11645 (Cascade + DecisionPipeline). Three `keeper_keepalive.ml` citations in `KeeperHeartbeat.tla` are stale relative to current `main`.

## Drift

| Function / location | Stale | Actual | Direction |
|--------------------|-------|--------|-----------|
| `run_heartbeat_loop` | 1815 | 1828 | +13 |
| `Atomic.set entry.fiber_wakeup` (tick) | 2130 | 2143 | +13 |
| `Atomic.set entry.fiber_wakeup` (post-turn) | 2631 | 2644 | +13 |

All three drift uniformly — same edit window. Cycle 27 (#11596) added the OCaml-side spec navigation block citing this spec; that PR recorded the +13 drift inline ("spec cites 1815, current 1828"). This PR closes the loop on the spec side.

## Forward-stability

Same disclaimer pattern as #11641 / #11645:

```
\* Function names are stable identifiers; lines drift across edits.
\* Verified against main as of 2026-04-28 (sibling refresh to #11641,
\* #11645; see Cycle 27 PR #11596 for the OCaml-side anchor).
```

## Verification

```
java -cp tla2tools.jar tlc2.TLC -config KeeperHeartbeat.cfg KeeperHeartbeat.tla
-> 4 distinct states / no error (clean unchanged)

java -cp tla2tools.jar tlc2.TLC -config KeeperHeartbeat-buggy.cfg KeeperHeartbeat.tla
-> SafetyInvariant violated by MissedWakeup in 3 steps (buggy unchanged)
```

Both contracts hold (CLAUDE.md software-development.md "TLA+ Bug Model" pattern preserved).

## Scope

- 1 spec file, +6 / -2
- No OCaml impact
- Spec-only

## Pattern

Cluster 2 first PR — same category as #11641 (Cycle 40) and #11645 (Cycle 41) but different OCaml file family. Spec → code citation refresh, not anchor addition.

## Test plan

- [x] TLC clean run passes
- [x] TLC buggy run violates SafetyInvariant in 3 steps
- [x] `git diff` shows only line digit + disclaimer changes
- [x] No OCaml impact