### PR TITLE
docs(spec): refresh SocialModelMagenticLedger + EmptyToolUniverse citations (Cycle 43)

### DIFF
--- a/specs/boundary/KeeperEmptyToolUniverse.tla
+++ b/specs/boundary/KeeperEmptyToolUniverse.tla
@@ -4,7 +4,11 @@
 \* Phase A F3 of the bloodflow restoration plan introduced the
 \* observability counter [masc_empty_tool_universe_observed_total] to
 \* surface the volume of the existing [Keeper_tool_surface_empty]
-\* blocker branch in keeper_agent_run (~line 1234) — the keeper turn
+\* blocker branch in keeper_agent_run.ml (line 1235 — entry condition
+\* `tool_gate_requested && all_allowed = []`; the actual blocker raise
+\* is at line 1256, the Phase A F3 counter at line 1245).
+\* Function name [Keeper_tool_surface_empty] is the stable identifier;
+\* lines verified against main 2026-04-28. The keeper turn
 \* enters a tool-required gate but the visible tool surface is empty.
 \* Pre-fix runtime reality: janitor / verifier keepers exhibit
 \* tools_used_count=0 streaks of 14+ turns; a fraction of those land in

--- a/specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
+++ b/specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
@@ -17,8 +17,11 @@
 \*   1. Normal path: [classify_event] (no failure parameter)
 \*      handles progress / signals / idle / quiet.
 \*   2. Failure path: [derive_failure_state] in
-\*      [keeper_social_model_magentic_ledger_v1.ml:202] constructs the
+\*      [keeper_social_model_magentic_ledger_v1.ml:204] constructs the
 \*      [Failure_observed] event directly and bypasses [classify_event].
+\*      (Function name is the stable identifier; line number verified
+\*      against main 2026-04-28 in sibling refresh #11641 / #11645 /
+\*      #11647 / Cycle 43.)
 \*
 \* Both topologies reach [Stalled] on failure, so end-state behaviour
 \* matches.  However, the spec's "failure dominates progress" property is


### PR DESCRIPTION
## Summary

Cluster 2 narrow batch — 4th citation refresh PR following #11641 / #11645 / #11647.

Two narrow `keeper_*` citations across two specs verified stale relative to `main`. Spec-only change, no OCaml impact.

## Drift table

| Spec | Cited function | File | Stale | Actual |
|------|---------------|------|-------|--------|
| `KeeperSocialModelMagenticLedger.tla:20` | `derive_failure_state` | `keeper_social_model_magentic_ledger_v1.ml` | 202 | 204 |
| `boundary/KeeperEmptyToolUniverse.tla:7` | `Keeper_tool_surface_empty` blocker | `keeper_agent_run.ml` | ~1234 | 1235 |

For `KeeperEmptyToolUniverse` the refresh also adds two adjacent anchors that were missing from the original citation: line 1245 (Phase A F3 observability counter) and line 1256 (actual blocker raise site).

## Forward-stability

Both specs receive the same disclaimer pattern as #11641 / #11645 / #11647:

```
\* Function name is the stable identifier; lines verified against main
\* 2026-04-28 in sibling refresh #11641 / #11645 / #11647 / Cycle 43.
```

## Verification

```
java -cp tla2tools.jar tlc2.TLC -config KeeperSocialModelMagenticLedger.cfg \
  KeeperSocialModelMagenticLedger.tla
-> 33 distinct states / no error

java -cp tla2tools.jar tlc2.TLC -config KeeperEmptyToolUniverse.cfg \
  KeeperEmptyToolUniverse.tla
-> 16 distinct states / no error

java -cp tla2tools.jar tlc2.TLC -config KeeperEmptyToolUniverse-buggy.cfg \
  KeeperEmptyToolUniverse.tla
-> SafetyInvariant violated by EmptySilentSkip in 3 steps (buggy preserved)
```

## Scope

- 2 spec files, +9 / -2
- No OCaml impact
- Spec-only

## Pattern note

4th citation refresh PR — ROI decay rule "4회+" 한도 도달. After this PR, autonomous citation-refresh chain naturally winds down. Remaining Cluster 2 specs (KeeperLaunchPending, KeeperConditionsGovernPhase, KeeperOutcomesConservation, MemoryCompaction, etc.) require larger verification surface and overlap with user cascade territory (`dashboard_http_keeper.ml`, `keeper_state_machine.ml`).

## Test plan

- [x] TLC clean run on both specs passes
- [x] EmptyToolUniverse buggy contract still violated by EmptySilentSkip in 3 steps
- [x] `git diff` shows only line digit + disclaimer changes
- [x] Function names unchanged (only digit / paren content changes)