### PR TITLE
chore(dashboard): add dashboard_tool_host_events.mli (cycle 84)

### DIFF
--- a/lib/dashboard_tool_host_events.mli
+++ b/lib/dashboard_tool_host_events.mli
@@ -1,0 +1,101 @@
+(** Dashboard_tool_host_events — typed surface for the
+    `client_tool_host_failure` HTTP report and the matching
+    `tool_assigned` lifecycle event.
+
+    The dashboard exposes a small POST endpoint where MCP clients
+    (codex / claude / kimi / gemini) self-report tool-host failures
+    they observed locally — connection drops, timeouts, schema-mismatch
+    rejections.  This module parses those JSON payloads, fans them out
+    to {!Log}, {!Audit_log}, and {!Telemetry_eio}, and records the
+    matching tool-assignment events for the dashboard's tool-quality
+    surface card. *)
+
+(** {1 Tool-host failure report}
+
+    Concrete record because two consumers construct it field-by-field
+    (test fixtures + the future "synthetic report" injection paths).
+    The record is the operator's grep contract — every field name
+    appears verbatim in audit-log JSON / dashboard cards / telemetry
+    rows, so a future "let's rename agent_name to actor_name" change
+    must touch this contract explicitly. *)
+type report = {
+  agent_name : string;
+  client_name : string;
+  tool_name : string;
+  transport : string;
+  phase : string option;
+  message : string;
+  request_id : string option;
+  session_id : string option;
+  trace_id : string option;
+  timeout_ms : int option;
+}
+
+val report_of_yojson :
+  ?fallback_agent:string -> Yojson.Safe.t -> (report, string) result
+(** [report_of_yojson ?fallback_agent json] parses a tool-host failure
+    JSON payload.  Required fields: [tool_name], [message] (both
+    extracted via stringish coercion — `String / `Int / `Intlit /
+    `Float all map to a string).
+
+    Optional fields default with operator-visible literals:
+    - [client_name]: [fallback_agent] (trimmed) or "tool-host"
+    - [agent_name]: explicit [agent_name] field, then [fallback_agent],
+      then [client_name].  The three-level fallback is deliberate so a
+      single-keeper deployment never reports an empty agent_name in
+      audit logs.
+    - [transport]: "mcp_http"
+
+    Returns [Error] for non-object payloads ("request body must be a
+    JSON object") and missing required fields ("missing required
+    field: <name>") — the wording is part of the HTTP 400 response
+    body and operator runbooks grep on it. *)
+
+val details_json : report -> Yojson.Safe.t
+(** [details_json report] returns the JSON object suitable for
+    {!Log.client_tool_host_error} `~details`.  The payload combines
+    {!Failure_envelope.tool_host_failure} with a flat [`Assoc] of the
+    optional fields (only present when set, never as `Null), so the
+    dashboard JSON consumers can rely on "field present ⟺ field set". *)
+
+val record :
+  ?fs:'fs ->
+  Coord_utils.config ->
+  report ->
+  unit
+(** [record ?fs config report] is the fan-out side-effect:
+    1. [Log.client_tool_host_error] (file ring + stderr)
+    2. [Audit_log.log_client_tool_host_failure] (durable JSONL)
+    3. {!Telemetry_eio.track_error} when [fs] is provided
+
+    The [fs] parameter is the Eio filesystem capability;
+    {!Telemetry_eio.track_error} is skipped when [fs = None] because
+    the telemetry pipeline writes to disk.  Operators who want
+    telemetry must thread the capability through — silently skipping
+    is the only correct behaviour at boot before the runtime is up. *)
+
+(** {1 Tool-assignment lifecycle event}
+
+    Snapshot the dashboard records when a profile/preset is assigned
+    to an agent.  Concrete record for the same reason as {!report}. *)
+type assignment_snapshot = {
+  agent_name : string;
+  profile : string;
+  preset : string option;
+  tool_count : int;
+  assignment_id : string;
+}
+
+val record_assignment :
+  ?fs:'fs ->
+  Coord_utils.config ->
+  assignment_snapshot ->
+  unit
+(** [record_assignment ?fs config snapshot] forwards to
+    {!Telemetry_eio.track_tool_assigned}.  No callers today, but the
+    surface is exposed because the dashboard tool-assignment card is a
+    documented adjacent feature (see the dashboard runbook entry on
+    "tool-assigned vs tool-host-failure correlation").  Hiding it
+    would force a future "wire up the assignment event" PR to either
+    re-implement the telemetry call or to first reopen the surface —
+    same calculus as cycle 82 (dashboard_tool_source_freshness). *)


### PR DESCRIPTION
## Summary

Cycle 84 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/dashboard_tool_host_events.ml`
(152 lines).

Surface (6 entries, 5 hide):

- `type report` (concrete record, 10 fields)
- `val report_of_yojson : ?fallback_agent:string -> Yojson.Safe.t ->
    (report, string) result`
- `val details_json : report -> Yojson.Safe.t`
- `val record : ?fs:'fs -> Coord_utils.config -> report -> unit`
- `type assignment_snapshot` (concrete record, 5 fields)
- `val record_assignment :
    ?fs:'fs -> Coord_utils.config -> assignment_snapshot -> unit`

Hidden internals:
- `val trim_to_option` (also exists in `Dashboard_utils` —
  hiding prevents drift between two near-identical helpers)
- `val stringish_member_opt` (`String/`Int/`Intlit/`Float coercion)
- `val required_member` (Error wording is operator-visible but the
  helper itself is internal)
- `val parse_timeout_ms` (`Intlit string fallback)
- `val ring_message` (log line formatter)

## Why concrete records

`type report` and `type assignment_snapshot` stay concrete because
`test/test_dashboard_tool_host_events.ml` and
`test/test_operator_control_snapshot.ml` construct them
field-by-field. Hiding would break the test fixture contract — same
calculus as cycle 65 (`tool_autoresearch_context.mli`) and cycle 81
(`discovery_cache.mli`'s test-visible state).

## report_of_yojson three-level agent_name fallback

Pinned at the contract seam:

| Source (in order) | Used when |
|---|---|
| Explicit `agent_name` field | Present and non-empty after trim |
| `fallback_agent` argument (trimmed) | No explicit field |
| `client_name` (resolved separately) | Both above missing |

Operator runbooks rely on never seeing an empty `agent_name` in
audit logs — pinning the cascade explicitly so a future
"simplify the fallback" change must touch this contract.

## Required-field error wording pinned

The HTTP 400 response body uses these strings verbatim:
- `"missing required field: %s"` — for `tool_name` / `message`
- `"request body must be a JSON object"` — for non-`Assoc payload

Operator runbooks grep on the literal wording, so the .mli pins it.

## record fs-None -> skip telemetry asymmetry

`record ?fs config report` calls `Telemetry_eio.track_error` only
when `fs` is provided. Telemetry writes to disk and cannot run
pre-runtime; silently skipping is the only correct boot-time
behaviour. Documented at the contract seam so a future
"always emit telemetry" change must promote `fs` to required first.

## Why expose `record_assignment` (no caller today)

`record_assignment` and `assignment_snapshot` have no external
callers today, but the dashboard tool-assignment card is a
documented adjacent feature. Hiding them would force a future
"wire up the assignment event" PR to either re-implement the
`Telemetry_eio.track_tool_assigned` call or to first reopen the
surface — same calculus as cycle 82
(`dashboard_tool_source_freshness.mli`'s full kit exposure).

## Caller audit (`rg "Dashboard_tool_host_events\\."`)
- `lib/server/server_routes_http_routes_dashboard.ml` —
  `report_of_yojson` + `record` (HTTP POST handler at the
  `/dashboard/tool-host-events` route)
- `test/test_operator_control_snapshot.ml` — `record` + record
  field access (fixture)
- `test/test_dashboard_tool_host_events.ml` — `report_of_yojson`
  + `record` + `details_json` + record field access (unit test)

No external reference to the 5 hidden helpers.

## Test plan
- [x] `dune build --root . lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
