### PR TITLE
fix(keeper): β6 outcome_kind alignment — map blocked to error

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1354,7 +1354,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              ~meta
              ~generation
              ~cascade_name:initial_execution.cascade_name
-             ~outcome:"blocked"
+             (* β6: "blocked" was not in outcome_kind quad-state
+                (ok/skipped/error/cancelled), causing operator_disposition
+                to classify livelock-blocked turns as "unknown".  Map to
+                "error" — livelock IS a turn failure; the specific reason
+                is captured in terminal_reason_code. *)
+             ~outcome:"error"
              ~terminal_reason_code
              ~activity_kind:"keeper.turn_blocked"
              ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)


### PR DESCRIPTION
## Summary
- Map `"blocked"` pre-dispatch outcome to `"error"` at `keeper_unified_turn.ml:1357`
- `"blocked"` was not in the `outcome_kind` quad-state (`ok`/`skipped`/`error`/`cancelled`), causing `operator_disposition` to classify livelock-blocked turns as `"unknown"`/`"unmapped_cascade_state"` on the dashboard

## Alignment Sweep Results
All receipt construction sites emit valid outcome_kind values:
- `keeper_unified_turn.ml:1114` → `"cancelled"` ✅
- `keeper_unified_turn.ml:1227` → `"error"` ✅
- `keeper_unified_turn.ml:1314` → `"error"` ✅
- `keeper_unified_turn.ml:1357` → `"blocked"` → **fixed to `"error"`**
- `keeper_unified_turn.ml:1767` → `"cancelled"` ✅
- `keeper_agent_run.ml:2847` → `"ok"`/`"error"` ✅
- `keeper_hooks_oas.ml:479` → `"ok"`/`"error"` ✅

`"skipped"` is spec-only (TLA+ PhaseGateSkip), never emitted at runtime.

## Test plan
- [x] `dune build` passes
- [ ] CI green (Build+Test, Lint, TLA+)
- [ ] Verify no other `"blocked"` or non-quad-state outcome strings exist via `rg '~outcome:"' lib/keeper/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)