### PR TITLE
fix(dashboard): add 'cost' to SurfaceSectionId type union

### DIFF
--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -9,6 +9,7 @@ type SurfaceSectionId =
   | 'runtime'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
   | 'safe-autonomy'
+  | 'cost'           // O4 cost/latency dashboard zone (#11542); use-site existed without type entry
   | 'memory-subsystems'
   | 'attribution'     // Layer 4 gate-chain observation (per-gate outcome + recent events)
   // command


### PR DESCRIPTION
## Summary

Surgical 1-line fix to a pre-existing typecheck regression in main. Unblocks the Dashboard CI check on all v2 design-system pivot PRs (#11642 Iter 1 1b and #11652 Iter 2c-1 both merged with this failure visible — the gate didn't block them, but it should be green going forward).

## What changed

\`dashboard/src/config/navigation.ts\` — added \`'cost'\` to the \`SurfaceSectionId\` union after \`'safe-autonomy'\`.

\`\`\`diff
   | 'safe-autonomy'
+  | 'cost'           // O4 cost/latency dashboard zone (#11542); use-site existed without type entry
   | 'memory-subsystems'
\`\`\`

## Why

#11542 (cost / latency dashboard zone, O4) added the use-site (\`id: 'cost'\`, line ~175) but did not extend the \`SurfaceSectionId\` type union. Result: \`tsc --noEmit\` fails with

\`\`\`
src/config/navigation.ts(171,7): error TS2322:
  Type '"cost"' is not assignable to type 'SurfaceSectionId'.
\`\`\`

This typecheck error has been showing up as the Dashboard check failure on multiple PRs branching off main — independent of the PR's actual changes. Identified during v2 design-system pivot Iter 0 audit (#11590) follow-up loop fire #9.

## Verification

\`\`\`
$ cd dashboard
$ pnpm typecheck
> tsc --noEmit
(no output — clean)
\`\`\`

## Test plan

- [x] Local \`pnpm typecheck\` passes (was failing before).
- [ ] CI Dashboard check turns green on this PR.
- [ ] Future v2 design-system pivot PRs (e.g., Iter 2c-2, Iter 2d, Iter 2a once \`/bg-X\` answered) see green Dashboard check.

## Cross-reference

- Origin: #11542 (introduced the use-site without type extension)
- Discovered during: #11590 v2 audit follow-up, fire #9 (#11652 Iter 2c-1 verification)
- Independent of: v2 design-system token absorption (this fix is pure type plumbing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)