### PR TITLE
fix(meta-cognition): correct meta_cognition_digest.mli — main blocker from #11632

### DIFF
--- a/lib/meta_cognition_digest.mli
+++ b/lib/meta_cognition_digest.mli
@@ -9,17 +9,35 @@
     [Meta_cognition.latest_digest_json] (the dashboard's
     namespace-truth path) or directly via this module.
 
-    Internal helpers ([digest_hearth] / [digest_source] string
-    constants, the [post_digest_key] meta extractor, and the
+    The [digest_hearth] / [digest_source] string constants and the
+    [post_digest_key] meta extractor are exposed because
+    {!Meta_cognition} (which does [include Meta_cognition_digest])
+    re-exports them at the dashboard's namespace-truth path; the
     [latest_digest_post] intermediate that returns
-    [(post * digest_key)] tuples) are hidden — callers consume
-    only the typed reference accessor and the JSON projection.
+    [(post * digest_key)] tuples stays hidden — callers consume the
+    typed reference accessor and the JSON projection.
 
     @since God file decomposition — extracted from
     meta_cognition.ml *)
 
+val digest_hearth : string
+(** Pinned to ["meta-cognition"] — the board hearth namespace
+    digest posts live under. Operator runbooks grep on the literal
+    string. *)
+
+val digest_source : string
+(** Pinned to ["meta_cognition_digest"] — the [meta.source] field
+    value used to identify digest posts on the board. *)
+
+val post_digest_key : Board.post -> string option
+(** [post_digest_key post] returns [Some key] when the post has a
+    [meta.source] equal (case-insensitive trim) to
+    {!digest_source} and a [meta.digest_key] string field; [None]
+    otherwise. Used by {!latest_digest_ref} to pick the most recent
+    post-with-key on the digest hearth. *)
+
 val latest_digest_ref :
-  ?summary:Meta_cognition_types.summary ->
+  ?summary:Meta_cognition_types.summary_input ->
   unit ->
   Meta_cognition_types.digest_ref option
 (** Look up the most recent digest post on the
@@ -34,7 +52,7 @@ val latest_digest_ref :
     summary; otherwise [matches_summary] is [false]. *)
 
 val latest_digest_json :
-  ?summary:Meta_cognition_types.summary ->
+  ?summary:Meta_cognition_types.summary_input ->
   unit ->
   Yojson.Safe.t
 (** {!latest_digest_ref} projected to a JSON object with the


### PR DESCRIPTION
## Summary

**Main blocker fix.** PR #11632 (cycle 76) introduced two
regressions in `lib/meta_cognition_digest.mli` that cause
`dune build lib` to fail on `origin/main`. This unblocks every
in-flight `lib_other_mli_missing` PR.

## Issues

### 1. Wrong type alias

```
Error: Unbound type constructor Meta_cognition_types.summary
```

The .mli used `Meta_cognition_types.summary` but the actual type
defined in `lib/meta_cognition_types.ml` is `summary_input`.

### 2. Hidden re-exports break `meta_cognition.mli`

`lib/meta_cognition.ml` does `include Meta_cognition_digest`, and
`lib/meta_cognition.mli` (line 80–82) declares:

```
val digest_hearth : string
val digest_source : string
val post_digest_key : Board.post -> string option
```

The cycle 76 .mli hid all three as "internal helpers", so the
parent module fails to satisfy its interface:

```
The value digest_hearth is required but not provided
The value digest_source is required but not provided
The value post_digest_key is required but not provided
```

## Fix

- Replace `Meta_cognition_types.summary` with
  `Meta_cognition_types.summary_input` on both `latest_digest_ref`
  and `latest_digest_json`.
- Expose `digest_hearth` / `digest_source` / `post_digest_key`
  with docstrings pinning the literal hearth name
  (`"meta-cognition"`) and source-field value
  (`"meta_cognition_digest"`) since operator runbooks grep on
  those strings.

## Why CI did not catch this

The `lib_other_mli_missing` ratchet script counts `.mli` files
but does not invoke `dune build`; the file's existence was
sufficient to decrement the ratchet. A future hardening change
should add `dune build lib` to the ratchet job — out of scope
here, separate follow-up.

## Test plan
- [x] `dune build --root . lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Unblocks every open `lib_other_mli_missing` PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
