### PR TITLE
chore(server): add server_mcp_transport_http_agui.mli (cycle 85)

### DIFF
--- a/lib/meta_cognition_digest.mli
+++ b/lib/meta_cognition_digest.mli
@@ -9,17 +9,35 @@
     [Meta_cognition.latest_digest_json] (the dashboard's
     namespace-truth path) or directly via this module.
 
-    Internal helpers ([digest_hearth] / [digest_source] string
-    constants, the [post_digest_key] meta extractor, and the
+    The [digest_hearth] / [digest_source] string constants and the
+    [post_digest_key] meta extractor are exposed because
+    {!Meta_cognition} (which does [include Meta_cognition_digest])
+    re-exports them at the dashboard's namespace-truth path; the
     [latest_digest_post] intermediate that returns
-    [(post * digest_key)] tuples) are hidden — callers consume
-    only the typed reference accessor and the JSON projection.
+    [(post * digest_key)] tuples stays hidden — callers consume the
+    typed reference accessor and the JSON projection.
 
     @since God file decomposition — extracted from
     meta_cognition.ml *)
 
+val digest_hearth : string
+(** Pinned to ["meta-cognition"] — the board hearth namespace
+    digest posts live under. Operator runbooks grep on the literal
+    string. *)
+
+val digest_source : string
+(** Pinned to ["meta_cognition_digest"] — the [meta.source] field
+    value used to identify digest posts on the board. *)
+
+val post_digest_key : Board.post -> string option
+(** [post_digest_key post] returns [Some key] when the post has a
+    [meta.source] equal (case-insensitive trim) to
+    {!digest_source} and a [meta.digest_key] string field; [None]
+    otherwise. Used by {!latest_digest_ref} to pick the most recent
+    post-with-key on the digest hearth. *)
+
 val latest_digest_ref :
-  ?summary:Meta_cognition_types.summary ->
+  ?summary:Meta_cognition_types.summary_input ->
   unit ->
   Meta_cognition_types.digest_ref option
 (** Look up the most recent digest post on the
@@ -34,7 +52,7 @@ val latest_digest_ref :
     summary; otherwise [matches_summary] is [false]. *)
 
 val latest_digest_json :
-  ?summary:Meta_cognition_types.summary ->
+  ?summary:Meta_cognition_types.summary_input ->
   unit ->
   Yojson.Safe.t
 (** {!latest_digest_ref} projected to a JSON object with the

--- a/lib/server/server_mcp_transport_http_agui.mli
+++ b/lib/server/server_mcp_transport_http_agui.mli
@@ -1,0 +1,72 @@
+(** Server_mcp_transport_http_agui — AG-UI SSE bridge handler.
+
+    Single public entry point: {!handle_ag_ui_events} services
+    [GET /ag-ui/events] by binding a per-session SSE stream to the
+    MASC event bus, converting each MASC event to the AG-UI SSE wire
+    format, and managing two background fibers (drain + ping).
+
+    The internal surface is deliberately narrow.  All helpers
+    (`ag_ui_event_of_masc_event`, `sse_stream_headers` re-export, the
+    local `sse_ping_interval_s` shadow) stay private so the surface
+    stays auditable. *)
+
+val handle_ag_ui_events :
+  deps:Server_mcp_transport_http_types.deps ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  unit
+(** [handle_ag_ui_events ~deps request reqd] handles
+    [GET /ag-ui/events].
+
+    {1 Lifecycle}
+
+    1. Resolve session id from cookie / headers (generates a fresh id
+       when none present — {!Mcp_session.get_or_generate}).
+    2. Resolve protocol version from the per-session table.
+    3. Read [last-event-id] header (replay anchor).
+    4. Run {!check_sse_connect_guard} — on rate-limit reject with
+       {!respond_sse_rate_limited} (HTTP 429) and stop.
+    5. {!stop_sse_session_preserve_guard} on the session id (drops a
+       previous SSE stream for the same session without re-arming the
+       guard).
+    6. Register with {!Sse.register} — receives a per-client event
+       stream and a possibly-evicted prior session id.  Evicted
+       session is fully stopped.
+    7. Send a synthetic AG-UI [Run_started] prime event so the client
+       can observe the connection has settled.
+    8. If [last-event-id] was present, replay missed events via
+       {!Sse.get_events_after}.
+    9. Spawn two fibers under the runtime switch:
+       - drain: pulls from per-session stream, writes raw to client,
+         self-terminates on send failure.
+       - ping: sleeps 30s, writes ": ping\\n\\n" comment frame to
+         keep middleboxes from idling out the connection.
+
+    {1 Cancellation contract}
+
+    Both fibers re-raise [Eio.Cancel.Cancelled] from every level so
+    a switch teardown propagates immediately.  Any other exception
+    is logged at {!Log.Server.error} or {!Log.Server.warn}; the fiber
+    that raised stops the session via
+    {!stop_sse_session_preserve_guard}.  A transient send failure on
+    one fiber does not necessarily kill the other — the second fiber
+    notices [info.stop = true] on its next iteration.
+
+    {1 Boot-time fast path}
+
+    When [deps.get_runtime_result ()] returns [Error] (runtime not
+    yet bootstrapped), the handler skips fiber spawn and logs at
+    {!Log.Server.debug}.  The HTTP response is already in flight at
+    this point — clients see a stream that emits the prime event
+    and any replay events but no live updates.  The client SDK is
+    expected to retry on stream end.
+
+    {1 Ping interval}
+
+    Pinned at 30 seconds (matches
+    {!Server_mcp_transport_http_headers.sse_ping_interval_s}).  The
+    duplicate constant is intentional: the headers module value is
+    the operator-visible constant for HTTP keep-alive negotiation,
+    while this handler uses a local shadow to keep the AG-UI fiber
+    independent of header-module evolution.  A future "let's unify"
+    refactor must touch the duplicate explicitly. *)


### PR DESCRIPTION
## Summary

Cycle 85 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/server/server_mcp_transport_http_agui.ml`
(141 lines).

**Stacked on #11656** (main blocker fix) — base will reset to
main automatically once that lands.

## Surface (1 entry, 3 hide)

```ocaml
val handle_ag_ui_events :
  deps:Server_mcp_transport_http_types.deps ->
  Httpun.Request.t ->
  Httpun.Reqd.t ->
  unit
```

Hidden internals:
- `val ag_ui_event_of_masc_event` — MASC -> AG-UI SSE format
  converter; defined but with no caller anywhere in the repo.
  Hiding closes the dead-code-via-`include` path; future caller
  adds an explicit expose PR.
- `val sse_stream_headers` — re-export from headers module, used
  internally only.
- `val sse_ping_interval_s` — local 30.0 shadow that duplicates
  `Server_mcp_transport_http_headers.sse_ping_interval_s`. Hiding
  the duplicate prevents accidental drift; the headers value
  remains the operator-visible constant.

## handle_ag_ui_events lifecycle pinned

| Step | Action |
|---|---|
| 1 | `Mcp_session.get_or_generate` (session id from cookie/header or fresh) |
| 2 | Read `last-event-id` replay anchor |
| 3 | `check_sse_connect_guard` — 429 on rate-limit and stop |
| 4 | `stop_sse_session_preserve_guard` (drop prior stream without re-arming the guard) |
| 5 | `Sse.register` — per-client event stream + possibly-evicted prior session |
| 6 | Send AG-UI `Run_started` prime event |
| 7 | Replay missed events via `Sse.get_events_after` when last-event-id was present |
| 8 | Spawn drain + ping fibers under runtime switch |

## Cancellation contract

Both fibers re-raise `Eio.Cancel.Cancelled` from every level so a
switch teardown propagates immediately. Any other exception is
logged at `Log.Server.error` or `Log.Server.warn`; the fiber that
raised stops the session via `stop_sse_session_preserve_guard`.

A transient send failure on one fiber does not necessarily kill
the other — the second fiber notices `info.stop = true` on its
next iteration. Documented at the contract seam so a future
"propagate failures aggressively" refactor must touch this
explicitly.

## Boot-time fast path

When `deps.get_runtime_result ()` returns `Error` (runtime not
yet bootstrapped), the handler skips fiber spawn and logs at
`Log.Server.debug`. The HTTP response is already in flight at
this point — clients see the prime event and any replay events
but no live updates. The client SDK is expected to retry on
stream end.

## Ping interval duplicate

Pinned at 30 seconds (matches
`Server_mcp_transport_http_headers.sse_ping_interval_s`). The
duplicate constant is intentional:

- The headers module value is the operator-visible constant for
  HTTP keep-alive negotiation.
- The AG-UI handler uses a local shadow to keep the fiber
  independent of header-module evolution.

Hiding the local shadow in the .mli prevents accidental drift
through the `include` path while preserving the explicit
duplication. A future "let's unify" refactor must touch both
sites explicitly.

## Caller audit (`rg "Server_mcp_transport_http_agui\\."`)
- (none direct) — reached only through
  `include Server_mcp_transport_http_agui` in
  `server_mcp_transport_http.ml`
- `lib/server/server_routes_http_routes_frontend.ml` — binds
  `handle_ag_ui_events` at `GET /ag-ui/events`
- `lib/server/server_routes_http_common.ml` — wraps with deps
- `lib/server/server_mcp_transport_http.ml` — re-exports via
  `include`

No external reference to the 3 hidden helpers.

## Test plan
- [x] `dune build --root . lib` — clean (after #11656 fix applied)
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
