### PR TITLE
fix(meta-cognition): correct broken .mli type references from god-file split

### DIFF
--- a/lib/meta_cognition.mli
+++ b/lib/meta_cognition.mli
@@ -78,8 +78,5 @@ val interpret : summary_input -> interpretation
 val interpretation_to_json : interpretation -> Yojson.Safe.t
 val salience_to_string : salience -> string
 val summary_signature : summary_input -> string
-val digest_hearth : string
-val digest_source : string
-val post_digest_key : Board.post -> string option
 val latest_digest_ref : ?summary:summary_input -> unit -> digest_ref option
 val latest_digest_json : ?summary:summary_input -> unit -> Yojson.Safe.t

--- a/lib/meta_cognition_digest.mli
+++ b/lib/meta_cognition_digest.mli
@@ -19,7 +19,7 @@
     meta_cognition.ml *)
 
 val latest_digest_ref :
-  ?summary:Meta_cognition_types.summary ->
+  ?summary:Meta_cognition_types.summary_input ->
   unit ->
   Meta_cognition_types.digest_ref option
 (** Look up the most recent digest post on the
@@ -34,7 +34,7 @@ val latest_digest_ref :
     summary; otherwise [matches_summary] is [false]. *)
 
 val latest_digest_json :
-  ?summary:Meta_cognition_types.summary ->
+  ?summary:Meta_cognition_types.summary_input ->
   unit ->
   Yojson.Safe.t
 (** {!latest_digest_ref} projected to a JSON object with the


### PR DESCRIPTION
## Summary
- `meta_cognition_digest.mli` referenced `Meta_cognition_types.summary` which doesn't exist — fixed to `summary_input`
- Removed stale `val` declarations (`digest_hearth`, `digest_source`, `post_digest_key`) from `meta_cognition.mli` that were hidden during god-file decomposition

## Root Cause
PR #11632 (god-file split) introduced `meta_cognition_digest.mli` with a forward reference to a non-existent type, and `meta_cognition.mli` still listed internal values that the digest module's own `.mli` hides.

## Test Plan
- [x] `dune build` passes (was failing before)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)