### PR TITLE
chore(mcp): add mcp_prompt_surface.mli (cycle 86)

### DIFF
--- a/lib/mcp_prompt_surface.mli
+++ b/lib/mcp_prompt_surface.mli
@@ -1,0 +1,100 @@
+(** Mcp_prompt_surface — canonical MCP `prompts/list` + `prompts/get`
+    catalogue.
+
+    Defines the small set of MCP "prompt definitions" the MASC server
+    advertises (currently a single [tool_help] prompt) and the
+    rendering logic that turns a {!prompt_def} + caller-supplied
+    arguments into the JSON-RPC message body.
+
+    The surface is intentionally narrow: callers see the typed
+    catalogue ({!prompt_defs}), the per-prompt JSON projection
+    ({!prompt_json}), and the {!get_json} entry point that the
+    JSON-RPC dispatcher invokes for [prompts/get].  All internal
+    helpers ([lookup], [assoc_string], [message_json], [tool_help_text],
+    [list_json]) stay private — they are stable contract-internal
+    pieces but exposing them would invite duplicate-rendering paths
+    that drift from the canonical {!get_json}. *)
+
+(** {1 Prompt argument schema} *)
+
+type prompt_argument = {
+  name : string;
+  description : string;
+  required : bool;
+}
+(** Concrete record because both consumers
+    ({!Mcp_sdk_adapter_masc} and {!Mcp_server_eio_protocol}) destructure
+    it field-by-field when projecting to the SDK / wire JSON shape.
+    Hiding would break those at the type seam. *)
+
+(** {1 Prompt definition} *)
+
+type prompt_def = {
+  name : string;
+  title : string;
+  description : string;
+  arguments : prompt_argument list;
+  icons : Mcp_server.mcp_icon list;
+}
+(** Concrete record for the same reason as {!prompt_argument} —
+    {!Mcp_sdk_adapter_masc.sdk_prompt_of_local} reads every field.
+
+    The [icons] field is non-optional and currently always populated
+    with a single themed icon; the contract permits an empty list,
+    but UI clients have a degraded fallback that operators dislike
+    so the catalogue convention is "always provide at least one icon". *)
+
+val prompt_defs : prompt_def list
+(** The canonical, ordered prompt catalogue.  Currently contains a
+    single entry, [tool_help] (compose a grounded explanation for a
+    specific MASC MCP tool).  Adding a new prompt requires:
+    1. extending this list,
+    2. extending the [match] in {!get_json} with a new arm,
+    3. updating the operator runbook for the new prompt name.
+
+    The list is the SSOT — both {!Mcp_sdk_adapter_masc} and
+    {!Mcp_server_eio_protocol} consume it to build their respective
+    paginated [prompts/list] responses (sorted by name, paginated
+    independently per transport). *)
+
+val prompt_json : prompt_def -> Yojson.Safe.t
+(** [prompt_json def] returns the canonical JSON object for one
+    prompt definition with fields [name] / [title] / [description] /
+    [icons] / [arguments].  Each argument renders with the same
+    field set ([name] / [description] / [required]) so the wire
+    contract is uniform across prompts. *)
+
+val get_json :
+  config:Coord.config ->
+  name:string ->
+  arguments:Yojson.Safe.t ->
+  Types.tool_schema list ->
+  (Yojson.Safe.t, string) result
+(** [get_json ~config ~name ~arguments schemas] is the JSON-RPC
+    [prompts/get] entry point.
+
+    On success, returns
+    {[
+      `Assoc [
+        ("description", `String prompt.description);
+        ("messages", `List [ <one user message> ]);
+      ]
+    ]}
+    where the message has role ["user"] and content
+    [`Assoc [("type", `String "text"); ("text", `String <body>)]].
+
+    Error wording is operator-visible (returned through the JSON-RPC
+    error envelope by the caller):
+    - [unknown prompt: <name>] — [name] is not in {!prompt_defs}.
+    - [unknown tool: <tool_name>] — [tool_name] is not in [schemas]
+      (only reachable through the [tool_help] prompt).
+    - [tool_name is required] — [arguments] is missing the
+      [tool_name] string.
+    - [unsupported prompt: <name>] — [name] resolved to a
+      {!prompt_def} but {!get_json} has no rendering arm for it (this
+      is a developer error — every prompt in {!prompt_defs} must have
+      a matching [match] arm here).
+
+    The [config] parameter is currently unused but kept in the
+    signature so a future prompt that needs room/agent context can
+    consume it without changing the contract. *)

--- a/lib/meta_cognition_digest.mli
+++ b/lib/meta_cognition_digest.mli
@@ -9,17 +9,35 @@
     [Meta_cognition.latest_digest_json] (the dashboard's
     namespace-truth path) or directly via this module.
 
-    Internal helpers ([digest_hearth] / [digest_source] string
-    constants, the [post_digest_key] meta extractor, and the
+    The [digest_hearth] / [digest_source] string constants and the
+    [post_digest_key] meta extractor are exposed because
+    {!Meta_cognition} (which does [include Meta_cognition_digest])
+    re-exports them at the dashboard's namespace-truth path; the
     [latest_digest_post] intermediate that returns
-    [(post * digest_key)] tuples) are hidden — callers consume
-    only the typed reference accessor and the JSON projection.
+    [(post * digest_key)] tuples stays hidden — callers consume the
+    typed reference accessor and the JSON projection.
 
     @since God file decomposition — extracted from
     meta_cognition.ml *)
 
+val digest_hearth : string
+(** Pinned to ["meta-cognition"] — the board hearth namespace
+    digest posts live under. Operator runbooks grep on the literal
+    string. *)
+
+val digest_source : string
+(** Pinned to ["meta_cognition_digest"] — the [meta.source] field
+    value used to identify digest posts on the board. *)
+
+val post_digest_key : Board.post -> string option
+(** [post_digest_key post] returns [Some key] when the post has a
+    [meta.source] equal (case-insensitive trim) to
+    {!digest_source} and a [meta.digest_key] string field; [None]
+    otherwise. Used by {!latest_digest_ref} to pick the most recent
+    post-with-key on the digest hearth. *)
+
 val latest_digest_ref :
-  ?summary:Meta_cognition_types.summary ->
+  ?summary:Meta_cognition_types.summary_input ->
   unit ->
   Meta_cognition_types.digest_ref option
 (** Look up the most recent digest post on the
@@ -34,7 +52,7 @@ val latest_digest_ref :
     summary; otherwise [matches_summary] is [false]. *)
 
 val latest_digest_json :
-  ?summary:Meta_cognition_types.summary ->
+  ?summary:Meta_cognition_types.summary_input ->
   unit ->
   Yojson.Safe.t
 (** {!latest_digest_ref} projected to a JSON object with the


### PR DESCRIPTION
## Summary

Cycle 86 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/mcp_prompt_surface.ml` (128 lines).

**Stacked on #11656** (main blocker fix) — base will reset to
main automatically once that lands.

## Surface (5 entries, 5 hide)

```ocaml
type prompt_argument = { name : string; description : string; required : bool; }

type prompt_def = {
  name : string;
  title : string;
  description : string;
  arguments : prompt_argument list;
  icons : Mcp_server.mcp_icon list;
}

val prompt_defs : prompt_def list
val prompt_json : prompt_def -> Yojson.Safe.t
val get_json :
  config:Coord.config -> name:string ->
  arguments:Yojson.Safe.t -> Types.tool_schema list ->
  (Yojson.Safe.t, string) result
```

Hidden internals:
- `val lookup`
- `val assoc_string`
- `val message_json`
- `val tool_help_text`
- `val list_json` (no external caller; would create a duplicate
  rendering path that drifts from `prompt_json` + `prompt_defs`)

## Why concrete records

`prompt_argument` and `prompt_def` stay concrete because both
`mcp_sdk_adapter_masc.ml` (`sdk_prompt_of_local`) and
`mcp_server_eio_protocol.ml` (sort comparator + JSON projection)
destructure them field-by-field. Hiding would break the type seam.

## prompt_defs as SSOT

The catalogue is documented at the contract seam as the SSOT.
Extending it requires touching three sites:

1. `prompt_defs` (this module — append the new entry)
2. `get_json` match arm (this module — add a rendering arm)
3. Operator runbook (the new prompt name)

Both transports (`mcp_sdk_adapter_masc` and
`mcp_server_eio_protocol`) consume the same list to build their
respective paginated `prompts/list` responses.

## get_json error wording pinned

| Error | Trigger |
|---|---|
| `unknown prompt: <name>` | `name` not in `prompt_defs` |
| `unknown tool: <tool_name>` | `tool_name` not in `schemas` (only via `tool_help`) |
| `tool_name is required` | missing argument |
| `unsupported prompt: <name>` | match arm missing (developer error — every prompt in `prompt_defs` must have a matching arm) |

The wording is operator-visible through the JSON-RPC error
envelope; the .mli pins it so a future "let's localise these"
change must touch the contract.

## config:Coord.config unused but reserved

The `~config` parameter is currently `~config:_` (ignored) in the
.ml but kept in the signature so a future prompt that needs
room/agent context can consume it without changing the contract.
Documented at the seam so a future "drop unused param" refactor
must explicitly choose between (a) staying ready for future
context-dependent prompts or (b) reopening the surface when one
lands.

## Caller audit (`rg "Mcp_prompt_surface\\."`)
- `lib/mcp_sdk_adapter_masc.ml` — `prompt_def` /
  `prompt_argument` (`sdk_prompt_of_local`), `prompt_defs` (sort),
  `get_json` (dispatch)
- `lib/mcp_server_eio_protocol.ml` — `prompt_def` (sort
  comparator), `prompt_defs`, `prompt_json` (list rendering),
  `get_json` (dispatch)

No external reference to the 5 hidden helpers.

## Test plan
- [x] `dune build --root . lib` — clean (after #11656 fix applied)
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
