### PR TITLE
feat(resilience): Tier B7 — Confidence composite scoring (Cycle 23)

### DIFF
--- a/lib/resilience/confidence.ml
+++ b/lib/resilience/confidence.ml
@@ -1,0 +1,196 @@
+(* Confidence — Cycle 23 / Tier B7.
+   See confidence.mli for the design rationale. *)
+
+module C = Shared_types.Confidence
+
+type factor =
+  | Artifact of { producer : string; raw_score : float }
+  | Verification of {
+      verifier : string;
+      score : float;
+      evidence : string;
+    }
+  | Degradation of { level : int; penalty : float }
+  | Consensus of {
+      agree_count : int;
+      total_count : int;
+      method_ : string;
+    }
+
+type recommendation =
+  | NoAction
+  | RequestVerification of { who : string; why : string }
+  | Degrade of { target_level : int; why : string }
+  | Handoff of { reason : string }
+
+type report = {
+  final : C.t;
+  factors : factor list;
+  threshold : float;
+  below_threshold : bool;
+  recommendation : recommendation option;
+}
+
+(* ── Convenience constructors ──────────────────────────────────── *)
+
+let artifact ~producer ~score = Artifact { producer; raw_score = score }
+
+let verification ~verifier ~score ~evidence =
+  Verification { verifier; score; evidence }
+
+let degradation ~level ~penalty = Degradation { level; penalty }
+
+let consensus ~agree_count ~total_count ~method_ =
+  Consensus { agree_count; total_count; method_ }
+
+(* ── Score extraction ──────────────────────────────────────────── *)
+
+let clamp_unit f =
+  if Float.is_nan f then 0.0
+  else if f < 0.0 then 0.0
+  else if f > 1.0 then 1.0
+  else f
+
+let weight_score = function
+  | Artifact { raw_score; _ } -> Some (clamp_unit raw_score)
+  | Verification { score; _ } -> Some (clamp_unit score)
+  | Consensus { agree_count; total_count; _ } ->
+      if total_count <= 0 then Some 0.0
+      else
+        Some
+          (clamp_unit
+             (float_of_int agree_count /. float_of_int total_count))
+  | Degradation _ -> None
+
+let degradation_penalty = function
+  | Degradation { penalty; _ } -> Some (clamp_unit penalty)
+  | _ -> None
+
+let max_degradation_level factors =
+  List.fold_left
+    (fun acc f ->
+      match f with
+      | Degradation { level; _ } -> max acc level
+      | _ -> acc)
+    0 factors
+
+(* ── Composition: geometric mean × penalties ──────────────────── *)
+
+let geometric_mean scores =
+  match scores with
+  | [] -> 0.0
+  | _ ->
+      let n = List.length scores in
+      let log_sum =
+        List.fold_left
+          (fun acc s ->
+            (* Treat exact 0 as a hard zero of the geometric mean.
+               Otherwise log(0) = -inf would propagate; this is the
+               desired semantics — any single factor at 0 forces the
+               composite to 0. *)
+            if s <= 0.0 then Float.neg_infinity
+            else acc +. Float.log s)
+          0.0 scores
+      in
+      if Float.is_finite log_sum then
+        Float.exp (log_sum /. float_of_int n)
+      else 0.0
+
+let compose_score factors =
+  let weight_scores = List.filter_map weight_score factors in
+  let penalties = List.filter_map degradation_penalty factors in
+  let base = geometric_mean weight_scores in
+  List.fold_left ( *. ) base penalties
+
+(* ── Recommendation selection ──────────────────────────────────── *)
+
+let select_recommendation
+    ~final_float ~threshold ~factors : recommendation option =
+  if final_float >= threshold then None
+  else
+    let very_low = final_float <= threshold *. 0.5 in
+    let has_degradation =
+      List.exists (function Degradation _ -> true | _ -> false) factors
+    in
+    if very_low then
+      Some
+        (Handoff
+           {
+             reason =
+               Printf.sprintf
+                 "confidence %.3f far below threshold %.3f"
+                 final_float threshold;
+           })
+    else if has_degradation then
+      Some
+        (Degrade
+           {
+             target_level = max_degradation_level factors + 1;
+             why =
+               Printf.sprintf
+                 "composite %.3f under threshold %.3f despite \
+                  Degradation factors present"
+                 final_float threshold;
+           })
+    else
+      let weakest_verifier =
+        List.find_map
+          (function
+            | Verification { verifier; _ } -> Some verifier
+            | _ -> None)
+          factors
+      in
+      Some
+        (RequestVerification
+           {
+             who = Option.value weakest_verifier ~default:"any-verifier";
+             why =
+               Printf.sprintf
+                 "composite %.3f under threshold %.3f; request \
+                  additional verification"
+                 final_float threshold;
+           })
+
+(* ── Public API ────────────────────────────────────────────────── *)
+
+let evaluate ~factors ~threshold =
+  let final_float = compose_score factors in
+  let final = C.make final_float in
+  let below_threshold = final_float < threshold in
+  let recommendation =
+    select_recommendation ~final_float ~threshold ~factors
+  in
+  { final; factors; threshold; below_threshold; recommendation }
+
+let is_acceptable r =
+  (not r.below_threshold) && r.recommendation = None
+
+let worst_factor r =
+  let value_of f =
+    match f with
+    | Artifact { raw_score; _ } -> Some (clamp_unit raw_score)
+    | Verification { score; _ } -> Some (clamp_unit score)
+    | Degradation { penalty; _ } -> Some (clamp_unit penalty)
+    | Consensus { agree_count; total_count; _ } ->
+        if total_count <= 0 then Some 0.0
+        else
+          Some
+            (clamp_unit
+               (float_of_int agree_count /. float_of_int total_count))
+  in
+  match r.factors with
+  | [] -> None
+  | first :: rest ->
+      let init_score =
+        Option.value (value_of first) ~default:1.0
+      in
+      let _, worst =
+        List.fold_left
+          (fun (best_score, best_f) f ->
+            match value_of f with
+            | None -> (best_score, best_f)
+            | Some s ->
+                if s < best_score then (s, f) else (best_score, best_f))
+          (init_score, first) rest
+      in
+      Some worst

--- a/lib/resilience/confidence.mli
+++ b/lib/resilience/confidence.mli
@@ -1,0 +1,141 @@
+(** Confidence — composite confidence scoring with factor decomposition.
+
+    Cycle 23 / Tier B7 — first cut.
+
+    {1 What this module is}
+
+    Confidence is not a single scalar; it is a composite metric
+    derived from {b artifact quality}, {b verification depth},
+    {b degradation penalty}, and {b consensus agreement}. The
+    autonomous engine and CREW deliberation produce confidence
+    factors during execution; this module combines them into a
+    final score, compares against a policy threshold, and
+    surfaces an actionable recommendation when the score is low.
+
+    {1 Scope of this PR}
+
+    - {!factor} variant: four contribution kinds.
+    - {!report} record: composite score (via
+      {!Shared_types.Confidence.t}), the factor decomposition,
+      the threshold, the [below_threshold] flag, and an optional
+      {!recommendation}.
+    - {!evaluate}: geometric mean of factor scores combined with
+      the multiplicative {!Degradation} penalty (when present);
+      compared to the threshold to populate the report.
+    - {!is_acceptable}: predicate combining threshold + recommendation.
+    - {!worst_factor}: identify the single factor that most
+      reduced the composite score — useful for targeted recovery.
+
+    {1 Deferred to follow-up Tiers}
+
+    - [factor_of_verifications]: bridge to OAS
+      [Verified_output.verification_result]. Requires importing the
+      OAS verification surface, deferred to keep this PR's
+      dependency footprint bounded.
+    - [apply_policy]: bridge to OAS [Policy.t]. Same deferral.
+    - The {!recommendation.Degrade} variant carries a [target_level]
+      [int]; Tier A11 introduces [Resilience.Degradation.level] which
+      will retype this field with no constructor renaming. *)
+
+(** {1 Factors} *)
+
+(** A single factor contributing to the final confidence score. *)
+type factor =
+  | Artifact of { producer : string; raw_score : float }
+      (** Confidence contributed by the artifact producer itself.
+          [raw_score] is in [\[0.0, 1.0\]]; values outside that
+          range are clamped by {!evaluate}. *)
+  | Verification of {
+      verifier : string;
+      score : float;
+      evidence : string;
+    }
+      (** Confidence contributed by an independent verifier
+          (e.g. CREW peer review or [Verified_output] cross-check). *)
+  | Degradation of { level : int; penalty : float }
+      (** Multiplicative penalty applied because the system is
+          running at a reduced level (L2..L4). [penalty] in
+          [\[0.0, 1.0\]]; lower means stronger penalty. *)
+  | Consensus of {
+      agree_count : int;
+      total_count : int;
+      method_ : string;
+    }
+      (** Confidence derived from multi-persona consensus
+          (e.g. 5 of 6 CREW personas agree). *)
+
+(** {1 Recommendations} *)
+
+(** Recommended action when confidence falls below the threshold. *)
+type recommendation =
+  | NoAction
+  | RequestVerification of { who : string; why : string }
+      (** Ask an independent verifier to re-check the primary artifact. *)
+  | Degrade of { target_level : int; why : string }
+      (** Drop to a lower degradation level. [target_level] is an
+          [int] for now; Tier A11 introduces a typed level. *)
+  | Handoff of { reason : string }
+      (** Escalate to a human operator; autonomy cannot proceed safely. *)
+
+(** {1 Reports} *)
+
+(** A complete confidence report with actionable recommendation. *)
+type report = {
+  final : Shared_types.Confidence.t;
+      (** The composite confidence score, clamped via
+          {!Shared_types.Confidence.make}. *)
+  factors : factor list;
+      (** Decomposition of how [final] was derived. *)
+  threshold : float;
+      (** The policy threshold that [final] was compared against. *)
+  below_threshold : bool;
+      (** [true] iff [Shared_types.Confidence.to_float final
+          < threshold]. *)
+  recommendation : recommendation option;
+      (** Recommendation populated when [below_threshold = true]. *)
+}
+
+(** {1 Construction} *)
+
+val evaluate : factors:factor list -> threshold:float -> report
+(** [evaluate ~factors ~threshold] computes [final] as the
+    geometric mean of {b non-Degradation} factor scores, then
+    multiplies by every {!Degradation} factor's [penalty]. The
+    result is clamped to [\[0.0, 1.0\]] via
+    {!Shared_types.Confidence.make}.
+
+    When [factors = []] (or only contains Degradation entries with
+    no other factor to weight), [final] is taken to be [0.0] —
+    the absence of any positive evidence cannot ground confidence.
+
+    The recommendation is selected as follows:
+    - [final >= threshold]                 → [None]
+    - [final < threshold] + Verification only is weak →
+      [Some (RequestVerification { ... })]
+    - [final < threshold] + Degradation present →
+      [Some (Degrade { target_level = max_level + 1; ... })]
+    - [final << threshold] (≤ 50% of threshold)        →
+      [Some (Handoff { reason = ... })]
+    - otherwise                            → [Some NoAction]
+      (caller may override). *)
+
+(** {1 Queries} *)
+
+val is_acceptable : report -> bool
+(** [true] iff [report.below_threshold = false] AND [recommendation
+    = None]. Either flag tripping yields [false]. *)
+
+val worst_factor : report -> factor option
+(** Return the factor whose individual contribution most reduced
+    the composite score, or [None] when [factors = []]. The
+    "contribution" of each factor is its raw score (or its penalty
+    for [Degradation]); the worst is the one with the lowest such
+    value. Useful for targeted recovery. *)
+
+(** {1 Convenience constructors} *)
+
+val artifact : producer:string -> score:float -> factor
+val verification : verifier:string -> score:float -> evidence:string -> factor
+val degradation : level:int -> penalty:float -> factor
+val consensus :
+  agree_count:int -> total_count:int -> method_:string -> factor

--- a/lib/resilience/dune
+++ b/lib/resilience/dune
@@ -1,0 +1,6 @@
+(include_subdirs no)
+
+(library
+ (name resilience)
+ (public_name masc_mcp.resilience)
+ (libraries shared_types))

--- a/test/resilience/dune
+++ b/test/resilience/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_confidence)
+ (libraries resilience shared_types))

--- a/test/resilience/test_confidence.ml
+++ b/test/resilience/test_confidence.ml
@@ -1,0 +1,185 @@
+(* Cycle 23 / Tier B7 tests — Resilience.Confidence composite scoring. *)
+
+module C = Shared_types.Confidence
+module Conf = Resilience.Confidence
+
+let approx_eq ?(eps = 1e-6) a b = Float.abs (a -. b) < eps
+
+(* ─── Convenience constructors ────────────────────────────────── *)
+
+let test_constructors_match_variants () =
+  let a = Conf.artifact ~producer:"executor" ~score:0.8 in
+  let v = Conf.verification ~verifier:"verifier" ~score:0.9 ~evidence:"ok" in
+  let d = Conf.degradation ~level:2 ~penalty:0.7 in
+  let cs = Conf.consensus ~agree_count:5 ~total_count:6 ~method_:"vote" in
+  (match a with
+   | Conf.Artifact { producer; raw_score } ->
+       assert (producer = "executor");
+       assert (raw_score = 0.8)
+   | _ -> assert false);
+  (match v with
+   | Conf.Verification { verifier; score; evidence } ->
+       assert (verifier = "verifier");
+       assert (score = 0.9);
+       assert (evidence = "ok")
+   | _ -> assert false);
+  (match d with
+   | Conf.Degradation { level; penalty } ->
+       assert (level = 2);
+       assert (penalty = 0.7)
+   | _ -> assert false);
+  match cs with
+  | Conf.Consensus { agree_count; total_count; method_ } ->
+      assert (agree_count = 5);
+      assert (total_count = 6);
+      assert (method_ = "vote")
+  | _ -> assert false
+
+(* ─── evaluate composition ────────────────────────────────────── *)
+
+let test_evaluate_geometric_mean () =
+  let report =
+    Conf.evaluate
+      ~factors:
+        [ Conf.artifact ~producer:"p1" ~score:0.6;
+          Conf.artifact ~producer:"p2" ~score:0.8;
+        ]
+      ~threshold:0.5
+  in
+  let final = C.to_float report.final in
+  assert (approx_eq final (Float.sqrt 0.48));
+  assert (not report.below_threshold);
+  assert (report.recommendation = None)
+
+let test_evaluate_with_degradation_penalty () =
+  let report =
+    Conf.evaluate
+      ~factors:
+        [ Conf.artifact ~producer:"p" ~score:0.9;
+          Conf.degradation ~level:3 ~penalty:0.5;
+        ]
+      ~threshold:0.5
+  in
+  let final = C.to_float report.final in
+  assert (approx_eq final 0.45);
+  assert report.below_threshold;
+  match report.recommendation with
+  | Some (Conf.Degrade { target_level; _ }) -> assert (target_level = 4)
+  | _ -> assert false
+
+let test_evaluate_empty_factors () =
+  let report = Conf.evaluate ~factors:[] ~threshold:0.5 in
+  let final = C.to_float report.final in
+  assert (approx_eq final 0.0);
+  assert report.below_threshold
+
+let test_evaluate_only_degradation_zeroes () =
+  let report =
+    Conf.evaluate
+      ~factors:[ Conf.degradation ~level:2 ~penalty:0.7 ]
+      ~threshold:0.5
+  in
+  let final = C.to_float report.final in
+  assert (approx_eq final 0.0)
+
+let test_evaluate_consensus_factor () =
+  let report =
+    Conf.evaluate
+      ~factors:[ Conf.consensus ~agree_count:4 ~total_count:5 ~method_:"vote" ]
+      ~threshold:0.5
+  in
+  let final = C.to_float report.final in
+  assert (approx_eq final 0.8);
+  assert (not report.below_threshold)
+
+(* ─── is_acceptable predicate ─────────────────────────────────── *)
+
+let test_is_acceptable_above_threshold () =
+  let report =
+    Conf.evaluate
+      ~factors:[ Conf.artifact ~producer:"p" ~score:0.9 ]
+      ~threshold:0.5
+  in
+  assert (Conf.is_acceptable report)
+
+let test_is_acceptable_below_threshold () =
+  let report =
+    Conf.evaluate
+      ~factors:[ Conf.artifact ~producer:"p" ~score:0.3 ]
+      ~threshold:0.5
+  in
+  assert (not (Conf.is_acceptable report))
+
+(* ─── Recommendation ladder ──────────────────────────────────── *)
+
+let test_recommendation_handoff_when_far_below () =
+  let report =
+    Conf.evaluate
+      ~factors:[ Conf.artifact ~producer:"p" ~score:0.2 ]
+      ~threshold:0.5
+  in
+  match report.recommendation with
+  | Some (Conf.Handoff _) -> ()
+  | _ -> assert false
+
+let test_recommendation_request_verification_default () =
+  let report =
+    Conf.evaluate
+      ~factors:[ Conf.artifact ~producer:"p" ~score:0.4 ]
+      ~threshold:0.5
+  in
+  match report.recommendation with
+  | Some (Conf.RequestVerification _) -> ()
+  | _ -> assert false
+
+(* ─── worst_factor ────────────────────────────────────────────── *)
+
+let test_worst_factor_picks_lowest_score () =
+  let report =
+    Conf.evaluate
+      ~factors:
+        [ Conf.artifact ~producer:"p1" ~score:0.9;
+          Conf.artifact ~producer:"p2" ~score:0.3;
+          Conf.verification ~verifier:"v" ~score:0.7 ~evidence:"e";
+        ]
+      ~threshold:0.1
+  in
+  match Conf.worst_factor report with
+  | Some (Conf.Artifact { producer; raw_score }) ->
+      assert (producer = "p2");
+      assert (approx_eq raw_score 0.3)
+  | _ -> assert false
+
+let test_worst_factor_empty_returns_none () =
+  let report = Conf.evaluate ~factors:[] ~threshold:0.5 in
+  assert (Conf.worst_factor report = None)
+
+(* ─── Clamping ───────────────────────────────────────────────── *)
+
+let test_evaluate_clamps_out_of_range_inputs () =
+  let report =
+    Conf.evaluate
+      ~factors:
+        [ Conf.artifact ~producer:"high" ~score:1.5;
+          Conf.artifact ~producer:"neg" ~score:(-0.3);
+        ]
+      ~threshold:0.5
+  in
+  let final = C.to_float report.final in
+  assert (approx_eq final 0.0)
+
+let () =
+  test_constructors_match_variants ();
+  test_evaluate_geometric_mean ();
+  test_evaluate_with_degradation_penalty ();
+  test_evaluate_empty_factors ();
+  test_evaluate_only_degradation_zeroes ();
+  test_evaluate_consensus_factor ();
+  test_is_acceptable_above_threshold ();
+  test_is_acceptable_below_threshold ();
+  test_recommendation_handoff_when_far_below ();
+  test_recommendation_request_verification_default ();
+  test_worst_factor_picks_lowest_score ();
+  test_worst_factor_empty_returns_none ();
+  test_evaluate_clamps_out_of_range_inputs ();
+  print_endline "test_confidence: all assertions passed"


### PR DESCRIPTION
## Summary

Cycle 23 first PR — greenfield `lib/resilience/` sub-library opens with composite confidence scoring. The autonomous engine and CREW deliberation produce confidence factors during execution; this module combines them into a final score, compares against a policy threshold, and surfaces an actionable recommendation when the score is low.

## Module surface (`lib/resilience/confidence.{mli,ml}`)

- **`factor` variant** (4 contribution kinds): `Artifact`, `Verification`, `Degradation` (multiplicative penalty), `Consensus`.
- **`recommendation` variant**: `NoAction`, `RequestVerification`, `Degrade`, `Handoff`. Selected automatically by `evaluate` when below threshold.
- **`report` record** using `Shared_types.Confidence.t` for the clamped final score. Carries factors / threshold / below_threshold / recommendation.
- **`evaluate ~factors ~threshold`**:
  - Geometric mean of non-Degradation factor scores (clamped to [0, 1]).
  - Multiplied by every Degradation factor's penalty.
  - Hard-zero semantics: any single factor at exactly 0 forces composite to 0.
  - Recommendation ladder: above threshold → None; ≤ 50% of threshold → Handoff; below + Degradation present → Degrade; otherwise → RequestVerification.
- **Convenience constructors**: `artifact`, `verification`, `degradation`, `consensus`.
- **Queries**: `is_acceptable`, `worst_factor`.

## Test plan
- [x] `dune build --root . lib/resilience/` GREEN
- [x] `dune build --root . test/resilience/` GREEN
- [x] `dune runtest --root . test/resilience/ --force` — 13 cases GREEN:
  - Constructor variant matching (4 kinds)
  - Geometric mean composition (sqrt(0.48))
  - Degradation penalty multiplication (0.9 × 0.5 = 0.45)
  - Empty factors → 0.0
  - Degradation-only → 0.0 (no positive evidence)
  - Consensus factor: 4/5 = 0.8
  - is_acceptable above/below threshold
  - Recommendation Handoff when far below threshold
  - Recommendation RequestVerification default
  - worst_factor identifies lowest score
  - worst_factor on empty returns None
  - Clamping out-of-range inputs (1.5 → 1.0, -0.3 → 0.0)
- [x] No regression: `shared_types` 43 tests GREEN

## Out of scope (deferred)
- `factor_of_verifications`: bridge to OAS `Verified_output.verification_result`. Requires OAS verification surface; deferred to keep this PR's dependency footprint bounded to `shared_types` alone.
- `apply_policy`: bridge to OAS `Policy.t`. Same deferral.
- Tier A11 introduces typed `Resilience.Degradation.level` which will retype the `recommendation.Degrade.target_level` field with no constructor renaming.

## Plan reference
`planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-temporal-stream.md` §2.2 Tier B7 — opens Cycle 23 by establishing the resilience sub-library skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)