### PR TITLE
refactor(design-system): lift cyan/purple short-name aliases (Iter 2c-4)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.generated.css
+++ b/dashboard/design-system/source_styles/tokens.generated.css
@@ -167,6 +167,8 @@
   --rose: #f43f5e;  /* Tailwind rose-500 alias */
   --rose-fg: #fecdd3;  /* Tailwind rose-200 alias */
   --rose-light: #fb7185;  /* Tailwind rose-400 alias */
+  --cyan: #22d3ee;  /* Tailwind cyan-400 alias (kept short name) */
+  --purple: #a78bfa;  /* Tailwind purple-400 alias (kept short name) */
 }
 
 :root {

--- a/dashboard/design-system/tokens/build/tokens.json
+++ b/dashboard/design-system/tokens/build/tokens.json
@@ -722,6 +722,16 @@
       "$type": "color",
       "$value": "#fb7185",
       "$description": "Tailwind rose-400 alias"
+    },
+    "cyan": {
+      "$type": "color",
+      "$value": "#22d3ee",
+      "$description": "Tailwind cyan-400 alias (kept short name)"
+    },
+    "purple": {
+      "$type": "color",
+      "$value": "#a78bfa",
+      "$description": "Tailwind purple-400 alias (kept short name)"
     }
   },
   "semantic": {

--- a/dashboard/design-system/tokens/source.ts
+++ b/dashboard/design-system/tokens/source.ts
@@ -327,6 +327,12 @@ export const raw: ReadonlyArray<TokenBase> = (() => {
   out.push(t("rose-fg",        "#fecdd3", "raw", "color", "Tailwind rose-200 alias"));
   out.push(t("rose-light",     "#fb7185", "raw", "color", "Tailwind rose-400 alias"));
 
+  // Iter 2c-4: cyan/purple short names. Companion alpha variants
+  // (--cyan-12, --cyan-16, --purple-12, --purple-24, --purple-50) stay
+  // hand-authored in variables.css per the companion alpha policy.
+  out.push(t("cyan",           "#22d3ee", "raw", "color", "Tailwind cyan-400 alias (kept short name)"));
+  out.push(t("purple",         "#a78bfa", "raw", "color", "Tailwind purple-400 alias (kept short name)"));
+
   return Object.freeze(out);
 })();
 

--- a/dashboard/src/styles/tokens.generated.css
+++ b/dashboard/src/styles/tokens.generated.css
@@ -166,6 +166,8 @@
   --color-rose: #f43f5e;
   --color-rose-fg: #fecdd3;
   --color-rose-light: #fb7185;
+  --color-cyan: #22d3ee;
+  --color-purple: #a78bfa;
   --color-ok-soft: rgb(107 158 107 / .10);
   --color-ok-fg: #8ebc8e;
   --color-ok-border: rgb(107 158 107 / .35);

--- a/dashboard/src/styles/tokens.generated.ts
+++ b/dashboard/src/styles/tokens.generated.ts
@@ -166,6 +166,8 @@ export const TOKENS = {
   "rose": { name: "--rose", value: "#f43f5e", tier: "raw", kind: "color" },
   "roseFg": { name: "--rose-fg", value: "#fecdd3", tier: "raw", kind: "color" },
   "roseLight": { name: "--rose-light", value: "#fb7185", tier: "raw", kind: "color" },
+  "cyan": { name: "--cyan", value: "#22d3ee", tier: "raw", kind: "color" },
+  "purple": { name: "--purple", value: "#a78bfa", tier: "raw", kind: "color" },
   "okSoft": { name: "--ok-soft", value: "rgb(107 158 107 / .10)", tier: "semantic", kind: "color" },
   "okFg": { name: "--ok-fg", value: "#8ebc8e", tier: "semantic", kind: "color" },
   "okBorder": { name: "--ok-border", value: "rgb(107 158 107 / .35)", tier: "semantic", kind: "color" },

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -308,10 +308,9 @@
   --fs-lg: var(--font-size-lg);
 
   /* Extended palette */
-  --cyan: #22d3ee;
+  /* --cyan, --purple base hex lifted to source.ts (Iter 2c-4); alpha companions retained */
   --cyan-12: rgba(34, 211, 238, 0.12);
   --cyan-16: rgba(34, 211, 238, 0.16);
-  --purple: #a78bfa;
   --text-slate: #b0bfd4;
   --text-slate-light: #cbd5e1;
   --text-near-white: #f8fafc;

--- a/dashboard_bonsai/src/tokens.ml
+++ b/dashboard_bonsai/src/tokens.ml
@@ -167,6 +167,8 @@ type semantic =
   | `Rose
   | `Rose_fg
   | `Rose_light
+  | `Cyan
+  | `Purple
   | `Ok_soft
   | `Ok_fg
   | `Ok_border
@@ -561,6 +563,8 @@ let name_of = function
   | `Rose -> "rose"
   | `Rose_fg -> "rose-fg"
   | `Rose_light -> "rose-light"
+  | `Cyan -> "cyan"
+  | `Purple -> "purple"
   | `Ok_soft -> "ok-soft"
   | `Ok_fg -> "ok-fg"
   | `Ok_border -> "ok-border"

--- a/dashboard_bonsai/src/tokens.mli
+++ b/dashboard_bonsai/src/tokens.mli
@@ -178,6 +178,8 @@ type semantic =
   | `Rose
   | `Rose_fg
   | `Rose_light
+  | `Cyan
+  | `Purple
   | `Ok_soft
   | `Ok_fg
   | `Ok_border


### PR DESCRIPTION
## Iter 2c-4 — cyan/purple short-name lift

**Ratchet**: 42 → 39 (Iter 2c-3) → **37** (this).
**Cumulative**: 57 → 37 = **-20 hex (35% absorbed)**.

### Tokens added (`source.ts`)

```ts
out.push(t("cyan",   "#22d3ee", "raw", "color", "Tailwind cyan-400 alias (kept short name)"));
out.push(t("purple", "#a78bfa", "raw", "color", "Tailwind purple-400 alias (kept short name)"));
```

### Removed (`variables.css`)

- `--cyan: #22d3ee;`
- `--purple: #a78bfa;`

### Retained (companion alpha policy)

- `--cyan-12`, `--cyan-16` (rgba)
- `--purple-12`, `--purple-24`, `--purple-50` (rgba)

### Verification (local)

- `pnpm tokens:build` ✓
- `pnpm tokens:check` ✓ (status canon + ΔE keeper palette)
- `pnpm typecheck` ✓

### Lift wave context

| Iter | tokens | ratchet | cumulative |
|---|---:|---|---|
| 2c-1 (#11652) | 10 | 57→47 | 18% |
| 2c-2 (#11661) | 5 | 47→42 | 26% |
| 2c-3 (#11664) | 3 | 42→39 | 32% |
| **2c-4 (this)** | **2** | **39→37** | **35%** |

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
