### PR TITLE
feat(resilience): Tier B6 — Recovery error_mode + strategy GADT (Cycle 23)

### DIFF
--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -1,0 +1,193 @@
+(* Recovery — Cycle 23 / Tier B6.
+   See recovery.mli for the design rationale. *)
+
+type error_mode =
+  | TransientError of {
+      detail : string;
+      max_retries : int;
+      backoff_ms : int;
+    }
+  | PermanentError of { detail : string; fallback_strategy : fallback }
+  | ResourceExhausted of {
+      resource : [ `Tokens | `Time | `Cost | `Memory | `Disk ];
+      consumed : float;
+      limit : float;
+    }
+  | AmbiguityError of { detail : string; branches : string list }
+  | ConsensusError of { detail : string; dissenters : string list }
+  | DegradationRequired of { detail : string; recommended_level : int }
+
+and fallback =
+  | UseDefaultString of string
+  | UsePlaceholder of string
+  | SkipArtifact of string
+  | HumanHandoff of string
+
+type _ strategy =
+  | Retry : {
+      max_attempts : int;
+      backoff : int -> float;
+    }
+      -> [> `Retry ] strategy
+  | Fallback : { fallback_value : string; degrade_confidence_by : float }
+      -> [> `Fallback ] strategy
+  | Handoff : { operator_message : string; preserve_state : bool }
+      -> [> `Handoff ] strategy
+  | Abort : { reason : string; cleanup : unit -> unit }
+      -> [> `Abort ] strategy
+
+(* ── Convenience constructors ─────────────────────────────────── *)
+
+let transient ~detail ?(max_retries = 3) ?(backoff_ms = 200) () =
+  TransientError { detail; max_retries; backoff_ms }
+
+let permanent ~detail ~fallback =
+  PermanentError { detail; fallback_strategy = fallback }
+
+let resource_exhausted ~resource ~consumed ~limit =
+  ResourceExhausted { resource; consumed; limit }
+
+let ambiguity ~detail ~branches = AmbiguityError { detail; branches }
+
+let consensus_failure ~detail ~dissenters =
+  ConsensusError { detail; dissenters }
+
+let degradation_required ~detail ~recommended_level =
+  DegradationRequired { detail; recommended_level }
+
+(* ── Heuristic classification ─────────────────────────────────── *)
+
+let lowercased_contains haystack needle =
+  let h = String.lowercase_ascii haystack in
+  let n = String.lowercase_ascii needle in
+  let h_len = String.length h in
+  let n_len = String.length n in
+  if n_len = 0 then true
+  else if n_len > h_len then false
+  else
+    let rec loop i =
+      if i + n_len > h_len then false
+      else if String.sub h i n_len = n then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let transient_phrases =
+  [ "timeout";
+    "timed out";
+    "rate limit";
+    "rate-limit";
+    "too many requests";
+    "connection reset";
+    "connection refused";
+    "temporarily unavailable";
+    "temporary";
+    "try again";
+    "transient";
+  ]
+
+let resource_phrases =
+  [ ("token", `Tokens);
+    ("memory", `Memory);
+    ("disk", `Disk);
+    ("budget", `Cost);
+  ]
+
+let classify_string (s : string) : error_mode =
+  if List.exists (fun p -> lowercased_contains s p) transient_phrases then
+    transient ~detail:s ~max_retries:3 ~backoff_ms:250 ()
+  else
+    match
+      List.find_opt
+        (fun (p, _) -> lowercased_contains s p)
+        resource_phrases
+    with
+    | Some (_, resource) ->
+        resource_exhausted ~resource ~consumed:0.0 ~limit:0.0
+    | None -> permanent ~detail:s ~fallback:(HumanHandoff s)
+
+(* ── Default strategy selection ───────────────────────────────── *)
+
+let default_strategy (mode : error_mode) :
+    [ `Retry | `Fallback | `Handoff | `Abort ] strategy =
+  match mode with
+  | TransientError { max_retries; backoff_ms; _ } ->
+      let backoff_seconds = float_of_int backoff_ms /. 1000.0 in
+      Retry
+        {
+          max_attempts = max max_retries 1;
+          backoff = (fun n -> backoff_seconds *. float_of_int (n + 1));
+        }
+  | PermanentError { fallback_strategy; detail } -> (
+      match fallback_strategy with
+      | UseDefaultString v ->
+          Fallback
+            { fallback_value = v; degrade_confidence_by = 0.2 }
+      | UsePlaceholder name ->
+          Fallback
+            {
+              fallback_value = "<placeholder:" ^ name ^ ">";
+              degrade_confidence_by = 0.4;
+            }
+      | SkipArtifact aid ->
+          Fallback
+            {
+              fallback_value = "<skipped:" ^ aid ^ ">";
+              degrade_confidence_by = 0.5;
+            }
+      | HumanHandoff msg ->
+          Handoff
+            {
+              operator_message =
+                Printf.sprintf
+                  "permanent error: %s — handoff requested: %s"
+                  detail msg;
+              preserve_state = true;
+            })
+  | ResourceExhausted { resource; consumed; limit } ->
+      let resource_str =
+        match resource with
+        | `Tokens -> "Tokens"
+        | `Time -> "Time"
+        | `Cost -> "Cost"
+        | `Memory -> "Memory"
+        | `Disk -> "Disk"
+      in
+      Abort
+        {
+          reason =
+            Printf.sprintf
+              "ResourceExhausted: %s consumed=%.2f limit=%.2f"
+              resource_str consumed limit;
+          cleanup = (fun () -> ());
+        }
+  | AmbiguityError { detail; branches } ->
+      Handoff
+        {
+          operator_message =
+            Printf.sprintf
+              "Ambiguity: %s. Branches: %s. (Speculate deferred to A11)"
+              detail
+              (String.concat ", " branches);
+          preserve_state = true;
+        }
+  | ConsensusError { detail; dissenters } ->
+      Handoff
+        {
+          operator_message =
+            Printf.sprintf
+              "Consensus failure: %s. Dissenters: %s."
+              detail
+              (String.concat ", " dissenters);
+          preserve_state = true;
+        }
+  | DegradationRequired { detail; recommended_level } ->
+      Handoff
+        {
+          operator_message =
+            Printf.sprintf
+              "Degrade required (target L%d): %s. (Degrade strategy \
+               deferred to A11)"
+              recommended_level detail;
+          preserve_state = true;
+        }

--- a/lib/resilience/recovery.mli
+++ b/lib/resilience/recovery.mli
@@ -1,0 +1,164 @@
+(** Recovery — failure-mode classification + recovery strategy selection.
+
+    Cycle 23 / Tier B6 — first cut.
+
+    {1 What this module is}
+
+    A resilience-specific layer that maps {b what went wrong} into
+    {b what to do next}. The classifier produces an {!error_mode}
+    that encodes the recovery shape (retry, fallback, handoff,
+    abort) rather than merely the originating fault.
+
+    {1 Scope of this PR}
+
+    - {!error_mode} variant: 6 failure modes with structured
+      payloads (retries hint, fallback choice, resource budget,
+      ambiguity branches, dissenters, recommended degradation level).
+    - {!fallback} variant for the [PermanentError] branch.
+    - {!strategy} GADT: 4 executable strategies in this Tier
+      (Retry, Fallback, Handoff, Abort). [Degrade] and [Speculate]
+      remain {b deferred} until Tier A11 lands the corresponding
+      [Degradation.level] / [Speculative.budget_policy] types.
+    - {!classify_string}: heuristic classifier for arbitrary
+      exception or error strings; the primary fallback path when no
+      structured error is available.
+    - {!default_strategy}: pick the canonical strategy for an
+      [error_mode]. Callers may override with a custom strategy.
+
+    {1 Deferred to follow-up Tiers}
+
+    - [classify_sdk_error]: bridge from OAS [Error.sdk_error] to
+      [error_mode]. Requires importing the OAS error surface;
+      deferred to keep this PR's dependency footprint inside
+      [shared_types]. Tier A6 (resilience keeper_bridge) introduces
+      this bridge as it actually consumes OAS errors at the seam.
+    - [resolve] / [auto_resolve]: Eio-driven execution of the
+      strategy. Deferred until Tier A11 binds [Resilience_audit]
+      and [Speculative.execute].
+    - [Degrade] / [Speculate] strategy constructors and the
+      [DegradationRequired]'s [recommended_level] type are
+      retained as plain ints here; Tier A11 retypes them with no
+      constructor renaming.
+
+    The phantom-tag pattern on {!strategy} (e.g. [\[> `Retry\]
+    strategy]) follows the design doc to enable compile-time
+    discrimination across strategy classes once consumers wire
+    them in. *)
+
+(** {1 Failure-mode classification} *)
+
+(** A resilience-specific failure mode. Richer than OAS errors
+    because it encodes the recovery shape. *)
+type error_mode =
+  | TransientError of {
+      detail : string;
+      max_retries : int;
+      backoff_ms : int;
+    }
+      (** Retryable error: network timeout, rate limit, ephemeral
+          file system issue. *)
+  | PermanentError of { detail : string; fallback_strategy : fallback }
+      (** Unrecoverable for this operation: invalid API key,
+          contract violation, nonexistent file (when the path is
+          known correct). *)
+  | ResourceExhausted of {
+      resource : [ `Tokens | `Time | `Cost | `Memory | `Disk ];
+      consumed : float;
+      limit : float;
+    }
+      (** Budget or capacity exhausted. *)
+  | AmbiguityError of { detail : string; branches : string list }
+      (** Two or more equally plausible interpretations; speculative
+          execution is the recommended response when available. *)
+  | ConsensusError of { detail : string; dissenters : string list }
+      (** CREW personas could not reach agreement. *)
+  | DegradationRequired of {
+      detail : string;
+      recommended_level : int;
+        (** Tier A11 retypes this as [Degradation.level]; for now,
+            an integer in [\[1, 4\]]. *)
+    }
+      (** Current capability level is too ambitious; reduce scope. *)
+
+(** What to do when a [PermanentError] occurs. *)
+and fallback =
+  | UseDefaultString of string
+      (** Use the provided string as the fallback artifact text. *)
+  | UsePlaceholder of string
+      (** Insert a placeholder marker referencing this name. *)
+  | SkipArtifact of string
+      (** Skip the failed artifact id; downstream consumers note
+          its absence. *)
+  | HumanHandoff of string
+      (** Escalate to operator with this message. *)
+
+(** {1 Recovery strategy GADT}
+
+    Phantom-tagged so callers may discriminate at compile time
+    between strategy classes when needed. The current PR exposes
+    Retry / Fallback / Handoff / Abort; Degrade and Speculate
+    arrive in Tier A11. *)
+type _ strategy =
+  | Retry : {
+      max_attempts : int;
+      backoff : int -> float;
+        (** [attempt index → delay seconds]. Caller supplies; the
+            classifier's [TransientError.backoff_ms] is just a hint. *)
+    }
+      -> [> `Retry ] strategy
+  | Fallback : { fallback_value : string; degrade_confidence_by : float }
+      -> [> `Fallback ] strategy
+      (** Substitute a default or placeholder string and reduce
+          confidence. The follow-up Tier may parameterise the value
+          type ('a fallback_value). *)
+  | Handoff : { operator_message : string; preserve_state : bool }
+      -> [> `Handoff ] strategy
+  | Abort : { reason : string; cleanup : unit -> unit }
+      -> [> `Abort ] strategy
+
+(** {1 Heuristic classification} *)
+
+val classify_string : string -> error_mode
+(** Best-effort classification of a free-form exception or error
+    string. Returns [TransientError] for known retryable phrases
+    (timeout, rate limit, connection reset, temporary), and
+    [PermanentError { fallback_strategy = HumanHandoff _ }]
+    otherwise. *)
+
+(** {1 Default strategy selection} *)
+
+val default_strategy : error_mode -> [ `Retry | `Fallback | `Handoff | `Abort ] strategy
+(** Choose the canonical strategy for an [error_mode]:
+
+    - [TransientError]              → [Retry]
+    - [PermanentError { UseDefaultString | UsePlaceholder | SkipArtifact }]
+                                    → [Fallback]
+    - [PermanentError { HumanHandoff }]
+                                    → [Handoff]
+    - [ResourceExhausted]           → [Abort]
+    - [AmbiguityError]              → [Handoff] (Speculate
+                                        deferred until A11)
+    - [ConsensusError]              → [Handoff]
+    - [DegradationRequired]         → [Handoff] (Degrade deferred
+                                        until A11) *)
+
+(** {1 Convenience constructors for [error_mode]} *)
+
+val transient :
+  detail:string -> ?max_retries:int -> ?backoff_ms:int -> unit -> error_mode
+
+val permanent : detail:string -> fallback:fallback -> error_mode
+
+val resource_exhausted :
+  resource:[ `Tokens | `Time | `Cost | `Memory | `Disk ] ->
+  consumed:float ->
+  limit:float ->
+  error_mode
+
+val ambiguity : detail:string -> branches:string list -> error_mode
+
+val consensus_failure :
+  detail:string -> dissenters:string list -> error_mode
+
+val degradation_required :
+  detail:string -> recommended_level:int -> error_mode

--- a/test/resilience/dune
+++ b/test/resilience/dune
@@ -1,3 +1,3 @@
-(test
- (name test_confidence)
+(tests
+ (names test_confidence test_recovery)
  (libraries resilience shared_types))

--- a/test/resilience/test_recovery.ml
+++ b/test/resilience/test_recovery.ml
@@ -1,0 +1,197 @@
+(* Cycle 23 / Tier B6 tests — Resilience.Recovery error_mode + strategy. *)
+
+module R = Resilience.Recovery
+
+(* ─── Convenience constructors ────────────────────────────────── *)
+
+let test_transient_default_args () =
+  let e = R.transient ~detail:"network blip" () in
+  match e with
+  | R.TransientError { detail; max_retries; backoff_ms } ->
+      assert (detail = "network blip");
+      assert (max_retries = 3);
+      assert (backoff_ms = 200)
+  | _ -> assert false
+
+let test_transient_explicit_args () =
+  let e = R.transient ~detail:"x" ~max_retries:5 ~backoff_ms:1000 () in
+  match e with
+  | R.TransientError { max_retries; backoff_ms; _ } ->
+      assert (max_retries = 5);
+      assert (backoff_ms = 1000)
+  | _ -> assert false
+
+let test_permanent_with_handoff () =
+  let e =
+    R.permanent ~detail:"401 unauthorized"
+      ~fallback:(R.HumanHandoff "rotate API key")
+  in
+  match e with
+  | R.PermanentError { detail; fallback_strategy = R.HumanHandoff msg } ->
+      assert (detail = "401 unauthorized");
+      assert (msg = "rotate API key")
+  | _ -> assert false
+
+let test_resource_exhausted () =
+  let e =
+    R.resource_exhausted ~resource:`Tokens ~consumed:1000.0 ~limit:500.0
+  in
+  match e with
+  | R.ResourceExhausted { resource; consumed; limit } ->
+      assert (resource = `Tokens);
+      assert (consumed = 1000.0);
+      assert (limit = 500.0)
+  | _ -> assert false
+
+let test_ambiguity_branches () =
+  let e =
+    R.ambiguity ~detail:"interpretation unclear"
+      ~branches:[ "branch_a"; "branch_b" ]
+  in
+  match e with
+  | R.AmbiguityError { branches; _ } -> assert (List.length branches = 2)
+  | _ -> assert false
+
+let test_consensus_failure_with_dissenters () =
+  let e =
+    R.consensus_failure ~detail:"no agreement"
+      ~dissenters:[ "verifier"; "scholar" ]
+  in
+  match e with
+  | R.ConsensusError { dissenters; _ } -> assert (List.length dissenters = 2)
+  | _ -> assert false
+
+let test_degradation_required_level () =
+  let e =
+    R.degradation_required ~detail:"too aggressive" ~recommended_level:3
+  in
+  match e with
+  | R.DegradationRequired { recommended_level; _ } ->
+      assert (recommended_level = 3)
+  | _ -> assert false
+
+(* ─── classify_string heuristic ───────────────────────────────── *)
+
+let test_classify_transient_timeout () =
+  match R.classify_string "Connection timeout while fetching" with
+  | R.TransientError _ -> ()
+  | _ -> assert false
+
+let test_classify_transient_rate_limit () =
+  match R.classify_string "HTTP 429 rate limit exceeded" with
+  | R.TransientError _ -> ()
+  | _ -> assert false
+
+let test_classify_resource_token () =
+  match R.classify_string "token budget exhausted" with
+  | R.TransientError _ ->
+      (* "exhausted" is not in transient phrases; "token" would
+         match resource. But "budget" matches Cost first depending
+         on iteration order — accept either resource. *)
+      assert false
+  | R.ResourceExhausted _ -> ()
+  | _ -> assert false
+
+let test_classify_permanent_fallback () =
+  match R.classify_string "Some generic error" with
+  | R.PermanentError { fallback_strategy = R.HumanHandoff _; _ } -> ()
+  | _ -> assert false
+
+(* ─── default_strategy mapping ────────────────────────────────── *)
+
+let test_strategy_for_transient_is_retry () =
+  let mode = R.transient ~detail:"x" ~max_retries:5 ~backoff_ms:100 () in
+  match R.default_strategy mode with
+  | R.Retry { max_attempts; backoff } ->
+      assert (max_attempts = 5);
+      let delay = backoff 0 in
+      (* 100ms = 0.1s, attempt 0 → 0.1 * 1 = 0.1 *)
+      assert (Float.abs (delay -. 0.1) < 1e-9)
+  | _ -> assert false
+
+let test_strategy_for_permanent_default_string () =
+  let mode =
+    R.permanent ~detail:"contract violation"
+      ~fallback:(R.UseDefaultString "default-value")
+  in
+  match R.default_strategy mode with
+  | R.Fallback { fallback_value; _ } ->
+      assert (fallback_value = "default-value")
+  | _ -> assert false
+
+let test_strategy_for_permanent_handoff () =
+  let mode =
+    R.permanent ~detail:"401" ~fallback:(R.HumanHandoff "rotate key")
+  in
+  match R.default_strategy mode with
+  | R.Handoff _ -> ()
+  | _ -> assert false
+
+let test_strategy_for_resource_is_abort () =
+  let mode =
+    R.resource_exhausted ~resource:`Memory ~consumed:1000.0 ~limit:500.0
+  in
+  match R.default_strategy mode with
+  | R.Abort _ -> ()
+  | _ -> assert false
+
+let test_strategy_for_ambiguity_is_handoff () =
+  let mode =
+    R.ambiguity ~detail:"two paths" ~branches:[ "a"; "b" ]
+  in
+  match R.default_strategy mode with
+  | R.Handoff _ -> ()
+  | _ -> assert false
+
+let test_strategy_for_consensus_is_handoff () =
+  let mode =
+    R.consensus_failure ~detail:"split" ~dissenters:[ "x" ]
+  in
+  match R.default_strategy mode with
+  | R.Handoff _ -> ()
+  | _ -> assert false
+
+let test_strategy_for_degradation_is_handoff () =
+  let mode =
+    R.degradation_required ~detail:"overrun" ~recommended_level:2
+  in
+  match R.default_strategy mode with
+  | R.Handoff _ -> ()
+  | _ -> assert false
+
+(* ─── Strategy GADT phantom-tag discrimination ────────────────── *)
+
+let test_strategy_phantom_tags_compile () =
+  (* If this compiles, the [> `Retry | `Fallback | ...] return type
+     of default_strategy is correctly polymorphic across the four
+     classes. We do not assert anything here beyond the type-check. *)
+  let _ : [ `Retry | `Fallback | `Handoff | `Abort ] R.strategy =
+    R.default_strategy (R.transient ~detail:"x" ())
+  in
+  let _ : [ `Retry | `Fallback | `Handoff | `Abort ] R.strategy =
+    R.default_strategy
+      (R.resource_exhausted ~resource:`Disk ~consumed:0.0 ~limit:0.0)
+  in
+  ()
+
+let () =
+  test_transient_default_args ();
+  test_transient_explicit_args ();
+  test_permanent_with_handoff ();
+  test_resource_exhausted ();
+  test_ambiguity_branches ();
+  test_consensus_failure_with_dissenters ();
+  test_degradation_required_level ();
+  test_classify_transient_timeout ();
+  test_classify_transient_rate_limit ();
+  test_classify_resource_token ();
+  test_classify_permanent_fallback ();
+  test_strategy_for_transient_is_retry ();
+  test_strategy_for_permanent_default_string ();
+  test_strategy_for_permanent_handoff ();
+  test_strategy_for_resource_is_abort ();
+  test_strategy_for_ambiguity_is_handoff ();
+  test_strategy_for_consensus_is_handoff ();
+  test_strategy_for_degradation_is_handoff ();
+  test_strategy_phantom_tags_compile ();
+  print_endline "test_recovery: all assertions passed"


### PR DESCRIPTION
## Summary

Cycle 23 second PR — adds the failure-mode classifier and recovery-strategy GADT to `lib/resilience/`. Maps "what went wrong" into "what to do next": the strategy GADT encodes the recovery shape (retry, fallback, handoff, abort) rather than merely the originating fault.

## Module surface (`lib/resilience/recovery.{mli,ml}`)

- **`error_mode` variant** (6 failure modes): `TransientError`, `PermanentError`, `ResourceExhausted`, `AmbiguityError`, `ConsensusError`, `DegradationRequired`.
- **`fallback` variant** for `PermanentError`: `UseDefaultString`, `UsePlaceholder`, `SkipArtifact`, `HumanHandoff`. Plain-string typed so this PR has zero OAS dependency surface.
- **`strategy` GADT (4 classes this Tier)**: `Retry`, `Fallback`, `Handoff`, `Abort`. Phantom-tagged (`[> \`Retry] strategy` etc.) for compile-time discrimination. **`Degrade` and `Speculate` deferred to Tier A11**.
- **`classify_string : string -> error_mode`** — heuristic: transient phrases (timeout, rate limit, connection reset, temporary, ...) → `TransientError`, resource phrases (token, memory, disk, budget) → `ResourceExhausted`, otherwise `PermanentError` with `HumanHandoff` fallback. Case-insensitive substring match avoids pulling regex into this layer.
- **`default_strategy : error_mode -> strategy`** — canonical mapping per mode (TransientError→Retry with linear backoff seeded from backoff_ms, PermanentError fallback variants→Fallback/Handoff, ResourceExhausted→Abort, Ambiguity/Consensus/DegradationRequired→Handoff).
- **Convenience constructors**: `transient` (with optional max_retries/backoff_ms), `permanent`, `resource_exhausted`, `ambiguity`, `consensus_failure`, `degradation_required`.

## Test plan
- [x] `dune build --root . lib/resilience/` GREEN
- [x] `dune build --root . test/resilience/` GREEN
- [x] `dune runtest --root . test/resilience/ --force` — 32 assertions across 2 suites GREEN:
  - `test_confidence` (B7, 13): no regression
  - `test_recovery` (B6, 19): all 6 error_mode constructors, classify_string for 4 buckets, default_strategy for all 7 shapes, GADT phantom-tag compile check
- [x] No regression: `shared_types` 43 tests GREEN

## Out of scope (deferred)
- **`classify_sdk_error`**: OAS `Error.sdk_error → error_mode` bridge. Tier A6 (resilience keeper_bridge) introduces it where it actually consumes OAS errors at the seam — keeps this PR's dependency footprint inside `shared_types`.
- **`resolve` / `auto_resolve`**: Eio-driven strategy execution. Deferred until Tier A11 binds `Resilience_audit` + `Speculative.execute`.
- **`Degrade` / `Speculate` strategy constructors**: Tier A11.
- **`DegradationRequired.recommended_level`** retype to `Degradation.level` (currently `int`): Tier A11 with no constructor rename.

## Plan reference
`planning/claude-plans/30m-users-dancer-downloads-kimi-agent-ke-temporal-stream.md` §2.2 Tier B6 — closes Cycle 23 backbone (B6 + B7) and unblocks A6 (Tier A6 needs A5 ✅ + B6 + B7 ✅).

🤖 Generated with [Claude Code](https://claude.com/claude-code)