### PR TITLE
chore(benchmark): add tool_call_quality_benchmark_render.mli (cycle 90)

### DIFF
--- a/lib/tool_call_quality_benchmark_render.mli
+++ b/lib/tool_call_quality_benchmark_render.mli
@@ -1,0 +1,96 @@
+(** Tool_call_quality_benchmark_render — JSON / CSV rendering for the
+    tool-call quality benchmark.
+
+    Five public renderers for the four benchmark types declared in
+    {!Tool_call_quality_benchmark_types}: per-case score, per-check
+    JSON spec, per-group summary row, and the aggregate benchmark
+    summary.  CSV output is one shape per {!summary_view}, sharing the
+    same column header set across views.
+
+    The four [..._to_yojson] renderers are the SSOT for the on-disk
+    benchmark artefact format — the file emitted by
+    [tool_call_quality_benchmark.ml] and consumed by external
+    dashboards / spreadsheets must round-trip exactly through these
+    functions.  Field names and ordering are part of that contract. *)
+
+val case_score_to_yojson :
+  Tool_call_quality_benchmark_types.case_score -> Yojson.Safe.t
+(** [case_score_to_yojson score] renders a single benchmark case
+    result.  Field set (18 fields, fixed order):
+
+    [case_id] / [provider] / [model] / [keeper_profile] / [passed] /
+    [task_pass] / [tool_selection] / [arg_validity] / [recovery] /
+    [efficiency] / [unnecessary_tool_rate] / [composite_score] /
+    [tool_call_count] / [latency_ms] / [input_tokens] / [output_tokens]
+    / [cost_usd] / [prompt_fingerprint] / [tool_sequence].
+
+    Optional fields render as [`Null] when [None] (NOT as the string
+    ["null"] or the empty array) — preserving the
+    "deliberately absent" vs "deliberately blank" distinction
+    consumers rely on.  See cycle 69
+    ({!Telemetry_coverage_gap}) for the cross-module convention. *)
+
+val json_check_to_yojson :
+  Tool_call_quality_benchmark_types.json_check -> Yojson.Safe.t
+(** [json_check_to_yojson check] renders one path-expectation check.
+    Field set: [path] / [equals] / [contains] / [min_int] /
+    [present].  [equals] retains its original [Yojson.Safe.t] shape
+    (any JSON value is permitted as a comparand). *)
+
+val summary_row_to_yojson :
+  Tool_call_quality_benchmark_types.summary_row -> Yojson.Safe.t
+(** [summary_row_to_yojson row] renders one aggregate row.  22
+    fields:
+
+    [provider] / [model] / [keeper_profile] (group key triple) +
+    [cases_total] / [cases_passed] (count pair) +
+    [task_pass_rate] / [correct_tool_rate] / [arg_valid_rate] /
+    [recovery_rate] / [unnecessary_tool_rate] / [avg_tool_calls] /
+    [p95_latency_ms] / [avg_input_tokens] / [avg_output_tokens] /
+    [avg_cost_usd] / [composite_score] (per-row metrics) +
+    [unsupported_runs] / [runtime_unreachable_runs] (failure
+    classification) + [stability_score] /
+    [tool_sequence_consistency_rate] /
+    [prompt_fingerprint_consistency_rate] / [pass_consistency_rate]
+    (consistency metrics, optional) + [repeated_case_groups]. *)
+
+val benchmark_summary_to_yojson :
+  Tool_call_quality_benchmark_types.benchmark_summary -> Yojson.Safe.t
+(** [benchmark_summary_to_yojson summary] renders the top-level
+    aggregate.  Field set: 6 scalar counts + 3 grouped lists
+    ([grouped_by_provider_model_keeper] / [grouped_by_provider_model]
+    / [grouped_by_keeper_profile]). *)
+
+val summary_rows_to_csv :
+  view:Tool_call_quality_benchmark_types.summary_view ->
+  Tool_call_quality_benchmark_types.benchmark_summary ->
+  string
+(** [summary_rows_to_csv ~view summary] renders a CSV with a fixed
+    23-column header set, regardless of which {!summary_view} is
+    selected.  The header row is identical across views so a
+    spreadsheet template can be reused.
+
+    {2 CSV escaping}
+
+    Values containing comma, double-quote, or newline are wrapped
+    in double quotes with embedded double-quotes doubled (RFC 4180
+    minimal subset).  Any other character is passed through.
+
+    {2 Numeric precision (pinned)}
+
+    Operator-visible spreadsheet contracts depend on these widths:
+
+    - rates (task / tool / arg / recovery / unnecessary): [%.4f]
+    - tool-call counts (avg): [%.4f]
+    - latency / token averages: [%.1f]
+    - cost: [%.6f]
+    - composite score: [%.2f]
+    - optional consistency metrics: [%.4f] when [Some], empty when [None]
+
+    {2 Empty-string vs missing}
+
+    Optional [string]/[float]/[int] columns render as the empty
+    string when [None] (NOT as ["null"] or ["NaN"]).  CSV consumers
+    that distinguish empty from zero rely on this convention.
+
+    Output is terminated with a final newline. *)


### PR DESCRIPTION
## Summary

Cycle 90 of the lib_other_mli_missing ratchet sweep. Adds an
explicit interface for `lib/tool_call_quality_benchmark_render.ml`
(170 lines).

(Skipped `lib/tool_local_runtime_http.ml` — facade with
`include Tool_local_runtime_core` whose underlying .ml has no
.mli; would require duplicating the full core surface or adding
core .mli first.  Deferred until the core gets its own
interface.)

## Surface (5 entries, 4 hide)

```ocaml
val case_score_to_yojson :
  Tool_call_quality_benchmark_types.case_score -> Yojson.Safe.t
val json_check_to_yojson :
  Tool_call_quality_benchmark_types.json_check -> Yojson.Safe.t
val summary_row_to_yojson :
  Tool_call_quality_benchmark_types.summary_row -> Yojson.Safe.t
val benchmark_summary_to_yojson :
  Tool_call_quality_benchmark_types.benchmark_summary -> Yojson.Safe.t
val summary_rows_to_csv :
  view:Tool_call_quality_benchmark_types.summary_view ->
  Tool_call_quality_benchmark_types.benchmark_summary -> string
```

Hidden internals (4):
- `val csv_escape` (RFC 4180 minimal escape)
- `val value_or_empty` (`string option` flatten)
- `val string_of_float_option` (`%.4f` with `""` default)
- `val rows_for_view` (`summary_view -> summary_row list` selector)

## SSOT contract

The four `..._to_yojson` renderers are the SSOT for the on-disk
benchmark artefact format. Field names and ordering are part of
the contract — external dashboards / spreadsheets round-trip
through these functions.

## Null-vs-empty convention

Optional JSON fields render as `` `Null `` when `None` (NOT as
the string `"null"` or the empty array). Preserves the cycle 69
(`telemetry_coverage_gap`) Null-vs-empty distinction across
modules.

## CSV column set is fixed across views

The 23-column header is identical regardless of which
`summary_view` is selected. A spreadsheet template works across
`By_provider_model_keeper` / `By_provider_model` /
`By_keeper_profile` without per-view adjustment.

## Numeric precision pinned

| Field family | Format | Rationale |
|---|---|---|
| Rates (task/tool/arg/recovery/unnecessary) | `%.4f` | 0.0001 resolution for fine-grained comparison |
| Avg tool calls | `%.4f` | Matches rate precision |
| Latency / token averages | `%.1f` | Whole-number scale dominates noise |
| Cost (USD) | `%.6f` | Per-call costs as low as $0.000001 must remain visible |
| Composite score | `%.2f` | Top-line summary, two-decimal display |
| Optional consistency metrics | `%.4f` when Some, `""` when None | Empty preserves missing-vs-zero |

A future "let's normalize to `%.4f` everywhere" refactor must
coordinate with downstream spreadsheet templates.

## Empty-string vs missing in CSV

Optional columns render as `""` (empty cell) when `None` —
NOT as `"null"` or `"NaN"`. CSV consumers that distinguish
empty from zero rely on this convention.

## Caller audit
- `lib/tool_call_quality_benchmark.ml` — re-exports all 5
  public functions via simple `let` bindings

No external reference to the 4 hidden helpers.

## Test plan
- [x] `dune build --root . lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1
- [ ] No new `inferred_dump_headers` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
