### PR TITLE
fix(institution_eio): fail-closed unknown outcome/mentor strings

### DIFF
--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -123,9 +123,38 @@ let create_institution ~name ~mission () : institution =
 (** {1 Serialization (Helpers)} *)
 
 let outcome_to_string = function `Success -> "success" | `Failure -> "failure" | `Partial -> "partial"
-let outcome_of_string = function "success" -> `Success | "failure" -> `Failure | _ -> `Partial
+
+(* Fail-closed: unknown outcome string surfaces a [Type_error] so a
+   garbage / future-variant payload is rejected at the parse boundary
+   rather than silently coerced to [`Partial].  Callers ([episode_of_json],
+   [load_recent_episodes_jsonl], [load_institution]) already absorb
+   [Yojson.Safe.Util.Type_error] — corrupted entries drop with a warn
+   instead of being treated as healthy [`Partial] data.  Matches the
+   "Unknown -> Permissive Default" anti-pattern flagged across the repo
+   ([agent_status_of_string_r] #10748, fail-closed sweep #11256). *)
+let outcome_of_string = function
+  | "success" -> `Success
+  | "failure" -> `Failure
+  | "partial" -> `Partial
+  | other ->
+      raise
+        (Yojson.Safe.Util.Type_error
+           (Printf.sprintf "unknown institution outcome: %S" other, `String other))
+
 let mentor_to_string = function `Random -> "random" | `Best_fit -> "best_fit" | `Round_robin -> "round_robin"
-let mentor_of_string = function "random" -> `Random | "best_fit" -> `Best_fit | "round_robin" -> `Round_robin | _ -> `Best_fit
+
+(* Fail-closed: see [outcome_of_string] above.  Unknown mentor assignment
+   used to silently collapse to [`Best_fit], merging typo / garbage /
+   future-variant inputs into a single bucket and erasing the diagnostic
+   trail. *)
+let mentor_of_string = function
+  | "random" -> `Random
+  | "best_fit" -> `Best_fit
+  | "round_robin" -> `Round_robin
+  | other ->
+      raise
+        (Yojson.Safe.Util.Type_error
+           (Printf.sprintf "unknown mentor assignment: %S" other, `String other))
 
 (** JSON number → float (handles both JSON Int and Float) *)
 let json_to_float = function

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -156,7 +156,8 @@ let handle_read_resource_eio state id params =
                   let inst = Institution_eio.institution_of_json json in
                   ("text/markdown", Some (Institution_eio.format_for_injection inst))
                 with
-                | Yojson.Json_error _ | Sys_error _ ->
+                | Yojson.Json_error _ | Sys_error _
+                | Yojson.Safe.Util.Type_error _ ->
                   let content = Fs_compat.load_file file in
                   ("application/json", Some content)
               else

--- a/test/dune
+++ b/test/dune
@@ -191,6 +191,7 @@
         test_memory_hooks
         test_agent_stress_timeout_wire_10341
         test_institution_episodes_failure_learnings_10325
+        test_institution_of_string_fail_closed
         test_mid_turn_resume
         test_lockfree_atomic
         test_telemetry_observe
@@ -369,6 +370,7 @@
           test_memory_hooks
           test_agent_stress_timeout_wire_10341
           test_institution_episodes_failure_learnings_10325
+          test_institution_of_string_fail_closed
           test_mid_turn_resume
           test_lockfree_atomic
           test_telemetry_observe

--- a/test/test_institution_of_string_fail_closed.ml
+++ b/test/test_institution_of_string_fail_closed.ml
@@ -1,0 +1,123 @@
+(** Pin fail-closed parsing for [Institution_eio.outcome_of_string] and
+    [mentor_of_string].  Pre-fix both helpers swallowed unknown input
+    via a wildcard branch:
+
+    {[
+      let outcome_of_string = function
+        | "success" -> `Success | "failure" -> `Failure
+        | _ -> `Partial                              (* silent default *)
+
+      let mentor_of_string = function
+        | "random" -> `Random | "best_fit" -> `Best_fit
+        | "round_robin" -> `Round_robin
+        | _ -> `Best_fit                             (* silent default *)
+    ]}
+
+    The "Unknown -> Permissive Default" anti-pattern erases the
+    diagnostic trail: typo, future-variant, or garbage payload all
+    collapse onto a single healthy bucket.  Same class as
+    [agent_status_of_string_r] (#10748) and the keeper runtime
+    fail-closed sweep (#11256).
+
+    Tests pin two contracts:
+
+    1. Known canonical strings continue to parse to the matching
+       polymorphic variant (regression guard).
+    2. Unknown strings raise [Yojson.Safe.Util.Type_error] so callers
+       that already absorb [Type_error] (e.g. [load_institution] at
+       institution_eio.ml:336, [load_recent_episodes_jsonl] at :660,
+       [load_and_format_for_welcome] at :617, and the MCP resource
+       reader after this PR) drop the malformed entry instead of
+       parading it as healthy [`Partial] / [`Best_fit]. *)
+
+open Alcotest
+
+module I = Masc_mcp.Institution_eio
+
+(* --- outcome_of_string --------------------------------------------- *)
+
+let test_outcome_known_success () =
+  check bool "success" true (I.outcome_of_string "success" = `Success)
+
+let test_outcome_known_failure () =
+  check bool "failure" true (I.outcome_of_string "failure" = `Failure)
+
+let test_outcome_known_partial () =
+  check bool "partial" true (I.outcome_of_string "partial" = `Partial)
+
+let test_outcome_unknown_raises () =
+  match I.outcome_of_string "garbage_outcome" with
+  | exception Yojson.Safe.Util.Type_error (msg, _) ->
+      check bool "message references unknown outcome" true
+        (Astring.String.is_infix ~affix:"unknown institution outcome" msg)
+  | _ ->
+      fail "expected Type_error for unknown outcome string"
+
+let test_outcome_empty_raises () =
+  match I.outcome_of_string "" with
+  | exception Yojson.Safe.Util.Type_error _ -> ()
+  | _ -> fail "expected Type_error for empty outcome string"
+
+(* --- mentor_of_string ---------------------------------------------- *)
+
+let test_mentor_known_random () =
+  check bool "random" true (I.mentor_of_string "random" = `Random)
+
+let test_mentor_known_best_fit () =
+  check bool "best_fit" true (I.mentor_of_string "best_fit" = `Best_fit)
+
+let test_mentor_known_round_robin () =
+  check bool "round_robin" true
+    (I.mentor_of_string "round_robin" = `Round_robin)
+
+let test_mentor_unknown_raises () =
+  match I.mentor_of_string "wise_owl" with
+  | exception Yojson.Safe.Util.Type_error (msg, _) ->
+      check bool "message references unknown mentor" true
+        (Astring.String.is_infix ~affix:"unknown mentor assignment" msg)
+  | _ ->
+      fail "expected Type_error for unknown mentor string"
+
+(* --- roundtrip via _to_string ------------------------------------- *)
+
+let test_outcome_roundtrip () =
+  let cases = [`Success; `Failure; `Partial] in
+  List.iter
+    (fun v ->
+      let s = I.outcome_to_string v in
+      check bool ("roundtrip " ^ s) true (I.outcome_of_string s = v))
+    cases
+
+let test_mentor_roundtrip () =
+  let cases = [`Random; `Best_fit; `Round_robin] in
+  List.iter
+    (fun v ->
+      let s = I.mentor_to_string v in
+      check bool ("roundtrip " ^ s) true (I.mentor_of_string s = v))
+    cases
+
+let () =
+  run "institution_of_string_fail_closed"
+    [
+      ( "outcome_of_string",
+        [
+          test_case "known: success" `Quick test_outcome_known_success;
+          test_case "known: failure" `Quick test_outcome_known_failure;
+          test_case "known: partial" `Quick test_outcome_known_partial;
+          test_case "unknown raises Type_error" `Quick
+            test_outcome_unknown_raises;
+          test_case "empty raises Type_error" `Quick
+            test_outcome_empty_raises;
+          test_case "roundtrip" `Quick test_outcome_roundtrip;
+        ] );
+      ( "mentor_of_string",
+        [
+          test_case "known: random" `Quick test_mentor_known_random;
+          test_case "known: best_fit" `Quick test_mentor_known_best_fit;
+          test_case "known: round_robin" `Quick
+            test_mentor_known_round_robin;
+          test_case "unknown raises Type_error" `Quick
+            test_mentor_unknown_raises;
+          test_case "roundtrip" `Quick test_mentor_roundtrip;
+        ] );
+    ]


### PR DESCRIPTION
## 컨텍스트

`lib/institution_eio.ml` 의 `outcome_of_string` / `mentor_of_string` 두 helper 가 wildcard branch 로 unknown 입력을 silent default 에 흡수.

```ocaml
let outcome_of_string = function
  | "success" -> `Success
  | "failure" -> `Failure
  | _ -> `Partial            (* typo / 미래 variant / garbage 모두 같은 bucket *)

let mentor_of_string = function
  | "random" -> `Random
  | "best_fit" -> `Best_fit
  | "round_robin" -> `Round_robin
  | _ -> `Best_fit           (* 같은 패턴 *)
```

MEMORY anti-pattern #2 — Unknown → Permissive Default. 같은 클래스 처리 선례:
- `agent_status_of_string_r` (#10748) — explicit-failure parser 도입
- 키퍼 런타임 fail-closed sweep (#11256)

## 변경

| 파일 | 변경 |
|------|------|
| `lib/institution_eio.ml` | wildcard 를 `raise (Yojson.Safe.Util.Type_error ...)` 로 교체. canonical literal `partial` 도 명시 (이전엔 wildcard 로 흡수되던 것이 이제 매치). |
| `lib/mcp_server_eio_resource.ml` | `institution_of_json` 호출 자리 `with` 절에 `Type_error _` 추가. 다른 caller 와 일관성 (`load_institution` line 336, `load_and_format_for_welcome` line 617 모두 이미 catch). |
| `test/test_institution_of_string_fail_closed.ml` | 신규. 11 alcotest 케이스. canonical 입력 regression + unknown 은 `Type_error` raise + roundtrip. |

## Fail-closed propagation

기존 caller 가 `Type_error` 흡수 경로를 이미 갖고 있어 단순 fail-closed 전환만으로 동작 변화 일관:

| 호출 경로 | Pre-fix | Post-fix |
|----------|---------|----------|
| `episode_of_json` → `load_recent_episodes_jsonl` (line 660) | unknown → `Partial` healthy episode | `Type_error` → 해당 라인 drop + warn |
| `succession_of_json` → `institution_of_json` → `load_institution` (line 336) | unknown → `Best_fit` 가짜 mentor | `Type_error` → return `None` |
| `institution_of_json` from `mcp_server_eio_resource` | (catch 없음) → 예외 propagate | catch 추가, raw JSON content 로 fallback |

## 검증

- 11/11 신규 테스트 OK
- `test_institution_episodes_failure_learnings_10325` regression 통과
- `test_memory_oas_5tier` (`Memory_oas_bridge` 영향) regression 통과
- `dune build --root .` exit 0

## Cross-ref

- MEMORY anti-pattern #2 (Unknown → Permissive Default) — `~/me/CLAUDE.md`
- 같은 fail-closed 가족: #10748 (`agent_status_of_string_r`), #11256 (keeper runtime sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
