### PR TITLE
feat(keeper): turn_sandbox_runtime factory closure (PR-3b, #11611 part 1)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -466,6 +466,7 @@
    keeper_alerting_path
    keeper_sandbox_containment
    keeper_sandbox_runtime
+   keeper_sandbox_factory
    keeper_turn_sandbox_runtime
    keeper_docker_read
    keeper_timing

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -95,20 +95,23 @@ let container_name_of meta =
     (Unix.getpid ())
     (int_of_float (Unix.gettimeofday () *. 1000.0))
 
-let run_command_in_container_with_status ?turn_sandbox_runtime
+let run_command_in_container_with_status ?turn_sandbox_factory
     ?(ok_exit_codes = [ 0 ])
     ~config ~(meta : keeper_meta)
     ~(command_argv : string list) ~(max_bytes : int)
     ~(timeout_sec : float) () : (Unix.process_status * string, string) result =
+  let cwd = host_playground_root ~config ~meta in
+  let runtime_opt =
+    Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd
+  in
   let image = Env_config_keeper.KeeperSandbox.docker_image () in
-  if Option.is_none turn_sandbox_runtime && String.trim image = "" then
+  if Option.is_none runtime_opt && String.trim image = "" then
     Error "keeper sandbox docker image is not configured"
   else if command_argv = [] then
     Error "run_command_in_container_with_status: command_argv is empty"
   else
-    match turn_sandbox_runtime with
+    match runtime_opt with
     | Some runtime ->
-      let cwd = host_playground_root ~config ~meta in
       Keeper_turn_sandbox_runtime.run_command_with_status
         ~ok_exit_codes runtime ~cwd ~command_argv ~max_bytes ~timeout_sec ()
     | None ->
@@ -153,21 +156,21 @@ let run_command_in_container_with_status ?turn_sandbox_runtime
            Error
              (Printf.sprintf "docker_%s_stopped: signal=%d" head_program n))
 
-let run_command_in_container ?turn_sandbox_runtime ?(ok_exit_codes = [ 0 ]) ~config ~meta
+let run_command_in_container ?turn_sandbox_factory ?(ok_exit_codes = [ 0 ]) ~config ~meta
     ~command_argv ~max_bytes ~timeout_sec () =
   match
-    run_command_in_container_with_status ?turn_sandbox_runtime
+    run_command_in_container_with_status ?turn_sandbox_factory
       ~ok_exit_codes ~config ~meta
       ~command_argv ~max_bytes ~timeout_sec ()
   with
   | Error _ as err -> err
   | Ok (_st, out) -> Ok out
 
-let read_file_in_container ?turn_sandbox_runtime ~config ~(meta : keeper_meta) ~host_path
+let read_file_in_container ?turn_sandbox_factory ~config ~(meta : keeper_meta) ~host_path
     ~(max_bytes : int) ~(timeout_sec : float) () : (string, string) result =
   match container_path_of_host ~config ~meta ~host_path with
   | Error _ as e -> e
   | Ok container_path ->
-    run_command_in_container ?turn_sandbox_runtime ~config ~meta
+    run_command_in_container ?turn_sandbox_factory ~config ~meta
       ~command_argv:[ "cat"; container_path ]
       ~max_bytes ~timeout_sec ()

--- a/lib/keeper/keeper_docker_read.mli
+++ b/lib/keeper/keeper_docker_read.mli
@@ -34,7 +34,7 @@ val container_path_of_host :
     Errors include image misconfiguration, docker exit non-zero, or
     the input not being inside the playground. *)
 val read_file_in_container :
-  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
+  ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   host_path:string ->
@@ -62,7 +62,7 @@ val read_file_in_container :
     the program name (e.g. [docker_rg_failed], [docker_cat_failed])
     for caller log forensics. *)
 val run_command_in_container_with_status :
-  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
+  ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
   ?ok_exit_codes:int list ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
@@ -77,7 +77,7 @@ val run_command_in_container_with_status :
     [run_command_in_container_with_status] that drops the returned
     process status and keeps only the captured stdout bytes. *)
 val run_command_in_container :
-  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
+  ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
   ?ok_exit_codes:int list ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -51,7 +51,7 @@ let is_missing_read_path_error (e : string) =
   || String.starts_with ~prefix:"path_not_found_under_allowed_roots:" e
 
 let handle_keeper_fs_read
-      ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
+      ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
@@ -87,7 +87,7 @@ let handle_keeper_fs_read
     if Keeper_docker_read.should_route_read ~meta then
       let timeout_sec = 30.0 in
       match
-        Keeper_docker_read.read_file_in_container ?turn_sandbox_runtime ~config ~meta
+        Keeper_docker_read.read_file_in_container ?turn_sandbox_factory ~config ~meta
           ~host_path:target ~max_bytes ~timeout_sec ()
       with
       | Error msg ->
@@ -184,13 +184,13 @@ let validate_write_target ~config ~meta ~target =
   | Error e -> Error (error_json ~fields:[ "path", `String target ] e)
 
 let handle_keeper_fs_edit
-      ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
+      ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
   =
   let via_field =
-    match turn_sandbox_runtime with
+    match turn_sandbox_factory with
     | Some _ -> [ ("via", `String "docker") ]
     | None -> []
   in
@@ -242,7 +242,10 @@ let handle_keeper_fs_edit
                 error_json ~fields:[ "path", `String target ] msg
               | Ok (updated, occurrences) ->
                 let write_result =
-                  match turn_sandbox_runtime with
+                  match
+                    Keeper_sandbox_factory.resolve_opt
+                      turn_sandbox_factory ~cwd:target
+                  with
                   | Some runtime ->
                     Keeper_turn_sandbox_runtime.overwrite_file runtime
                       ~host_path:target ~content:updated
@@ -290,7 +293,10 @@ let handle_keeper_fs_edit
      | Ok () ->
     (try
        let write_result =
-         match turn_sandbox_runtime with
+         match
+           Keeper_sandbox_factory.resolve_opt
+             turn_sandbox_factory ~cwd:target
+         with
          | Some runtime ->
            (match mode with
             | Append ->

--- a/lib/keeper/keeper_exec_fs.mli
+++ b/lib/keeper/keeper_exec_fs.mli
@@ -11,14 +11,14 @@ val all_fs_write_modes : fs_write_mode list
 val valid_fs_write_mode_strings : string list
 
 val handle_keeper_fs_read :
-  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+  turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->
   string
 
 val handle_keeper_fs_edit :
-  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+  turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -593,8 +593,8 @@ let run_docker_with_git_bash = Keeper_shell_docker.run_docker_with_git_bash
 let run_docker_hardened_bash = Keeper_shell_docker.run_docker_hardened_bash
 
 let handle_keeper_bash
-      ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
-      ~(turn_sandbox_runtime_git : Keeper_turn_sandbox_runtime.t option)
+      ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
+      ~(turn_sandbox_factory_git : Keeper_sandbox_factory.t option)
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -774,14 +774,18 @@ let handle_keeper_bash
         ~labels:[ ("keeper", meta.name); ("detected_tool", detected_tool) ]
         ();
       run_docker_with_git_bash
-        ~turn_sandbox_runtime:turn_sandbox_runtime_git
+        ~turn_sandbox_runtime:
+          (Keeper_sandbox_factory.resolve_opt
+             turn_sandbox_factory_git ~cwd)
         ~config ~meta ~cwd ~timeout_sec ~cmd ())
     else if sandbox_profile = Docker then (
       Log.Keeper.info
         "DOCKER_EXEC: keeper=%s cwd=%s cmd=%s network=%s"
         meta.name cwd cmd_for_log (network_mode_to_string sandbox_network_mode);
       run_docker_hardened_bash
-        ~turn_sandbox_runtime
+        ~turn_sandbox_runtime:
+          (Keeper_sandbox_factory.resolve_opt
+             turn_sandbox_factory ~cwd)
         ~config ~meta ~cwd ~timeout_sec ~cmd
         ~network_mode:sandbox_network_mode)
     else
@@ -1296,7 +1300,7 @@ let gh_repo_context_error_json = Keeper_shell_gh_context.gh_repo_context_error_j
 let resolve_gh_repo_context = Keeper_shell_gh_context.resolve_gh_repo_context
 
 let handle_keeper_shell
-      ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
+      ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -1473,7 +1477,7 @@ let handle_keeper_shell
       | Ok cpath -> (
           match
             Keeper_docker_read.run_command_in_container_with_status
-              ?turn_sandbox_runtime
+              ?turn_sandbox_factory
               ~ok_exit_codes ~config ~meta ~command_argv:(command_argv cpath)
               ~max_bytes ~timeout_sec ()
           with
@@ -1489,7 +1493,7 @@ let handle_keeper_shell
   in
   let run_in_turn_runtime ?(ok_exit_codes = [ 0 ]) ~cwd ~cmd ~command_argv
       ~max_bytes ~timeout_sec ?(map_output = fun out -> out) ?(extra = []) () =
-    match turn_sandbox_runtime with
+    match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
     | Some runtime ->
       (match
          Keeper_turn_sandbox_runtime.run_command_with_status
@@ -1598,7 +1602,7 @@ let handle_keeper_shell
           | Ok cpath ->
             (match
                Keeper_docker_read.run_command_in_container
-                 ?turn_sandbox_runtime ~config ~meta
+                 ?turn_sandbox_factory ~config ~meta
                  ~command_argv:[ "ls"; "-la"; cpath ]
                  ~max_bytes:1_000_000
                  ~timeout_sec:io_timeout_sec
@@ -1643,7 +1647,7 @@ let handle_keeper_shell
        if Keeper_docker_read.should_route_read ~meta then
          (match
             Keeper_docker_read.read_file_in_container
-              ?turn_sandbox_runtime ~config ~meta
+              ?turn_sandbox_factory ~config ~meta
               ~host_path:target ~max_bytes
               ~timeout_sec:read_timeout_sec
               ()
@@ -1793,7 +1797,7 @@ let handle_keeper_shell
              Printf.sprintf "-%d" count ]
          in
          let argv = if file_path <> "" then base_argv @ [ "--"; file_path ] else base_argv in
-         (match turn_sandbox_runtime with
+         (match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
           | Some runtime ->
             let argv =
               let base_argv =
@@ -2100,7 +2104,7 @@ let handle_keeper_shell
         | Error e -> path_error e
         | Ok cwd ->
           let wt_out_result =
-            match turn_sandbox_runtime with
+            match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
             | Some runtime ->
               Keeper_turn_sandbox_runtime.run_command runtime
                 ~cwd
@@ -2203,7 +2207,7 @@ let handle_keeper_shell
            (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd_str with
             | Error e -> path_error e
             | Ok () ->
-              (* PR #11080 sibling sweep: when [turn_sandbox_runtime]
+              (* PR #11080 sibling sweep: when [turn_sandbox_factory]
                  is bound the bash exec runs inside the keeper's
                  container, so the LLM-facing [cwd] field must hold
                  the in-container path.  When the runtime is absent
@@ -2211,7 +2215,7 @@ let handle_keeper_shell
                  keeper sees and the [Local] variant passes it
                  through unchanged. *)
               let cwd_response =
-                match turn_sandbox_runtime with
+                match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
                 | Some runtime ->
                   Keeper_cwd_response.docker ~host_cwd:cwd
                     ~container_cwd:
@@ -2250,7 +2254,7 @@ let handle_keeper_shell
                   | None ->
                     let t0 = Unix.gettimeofday () in
                     let st, out =
-                      match turn_sandbox_runtime with
+                      match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
                       | Some runtime ->
                         (match
                            Keeper_turn_sandbox_runtime.run_bash_with_status runtime
@@ -2308,7 +2312,7 @@ let handle_keeper_shell
                            ()))
                | None ->
                  let st, out =
-                   match turn_sandbox_runtime with
+                   match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
                    | Some runtime ->
                      (match
                         Keeper_turn_sandbox_runtime.run_bash_with_status runtime

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -49,8 +49,8 @@ val cmd_targets_git_or_gh : string -> bool
     for unit testing. *)
 
 val handle_keeper_bash :
-  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
-  turn_sandbox_runtime_git:Keeper_turn_sandbox_runtime.t option ->
+  turn_sandbox_factory:Keeper_sandbox_factory.t option ->
+  turn_sandbox_factory_git:Keeper_sandbox_factory.t option ->
   exec_cache:Masc_exec.Exec_cache.t option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
@@ -75,7 +75,7 @@ val handle_keeper_bash_kill :
     (SIGTERM → grace → SIGKILL). Idempotent. *)
 
 val handle_keeper_shell :
-  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+  turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   exec_cache:Masc_exec.Exec_cache.t option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -116,8 +116,8 @@ let execute_keeper_tool_call_with_outcome
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(ctx_work : working_context)
-      ?turn_sandbox_runtime
-      ?turn_sandbox_runtime_git
+      ?turn_sandbox_factory
+      ?turn_sandbox_factory_git
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
       ~(name : string)
@@ -243,14 +243,14 @@ let execute_keeper_tool_call_with_outcome
       else failure_tool_result (error_json msg)
     | "keeper_fs_read" ->
       make_executed_tool_result
-        (Keeper_exec_fs.handle_keeper_fs_read ~turn_sandbox_runtime ~config ~meta ~args)
+        (Keeper_exec_fs.handle_keeper_fs_read ~turn_sandbox_factory ~config ~meta ~args)
     | "keeper_fs_edit" ->
       make_executed_tool_result
-        (Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime ~config ~meta ~args)
+        (Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory ~config ~meta ~args)
     | "keeper_bash" ->
       make_executed_tool_result
         (Keeper_exec_shell.handle_keeper_bash
-           ~turn_sandbox_runtime ~turn_sandbox_runtime_git ~exec_cache ~config ~meta ~args
+           ~turn_sandbox_factory ~turn_sandbox_factory_git ~exec_cache ~config ~meta ~args
            ())
     | "keeper_bash_output" ->
       make_executed_tool_result
@@ -260,7 +260,7 @@ let execute_keeper_tool_call_with_outcome
         (Keeper_exec_shell.handle_keeper_bash_kill ~config ~meta ~args)
     | "keeper_shell" ->
       make_executed_tool_result
-        (Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime ~exec_cache ~config ~meta ~args)
+        (Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory ~exec_cache ~config ~meta ~args)
     | "keeper_voice_speak"
     | "keeper_voice_listen"
     | "keeper_voice_agent"
@@ -358,8 +358,8 @@ let execute_keeper_tool_call
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(ctx_work : working_context)
-      ?turn_sandbox_runtime
-      ?turn_sandbox_runtime_git
+      ?turn_sandbox_factory
+      ?turn_sandbox_factory_git
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
       ~(name : string)
@@ -369,7 +369,7 @@ let execute_keeper_tool_call
   =
   let result =
     execute_keeper_tool_call_with_outcome
-      ~config ~meta ~ctx_work ?turn_sandbox_runtime ?turn_sandbox_runtime_git
+      ~config ~meta ~ctx_work ?turn_sandbox_factory ?turn_sandbox_factory_git
       ~exec_cache ?search_fn ~name ~input ()
   in
   result.raw_output

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -156,8 +156,8 @@ val execute_keeper_tool_call_with_outcome :
   config:Coord.config ->
   meta:keeper_meta ->
   ctx_work:working_context ->
-  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
-  ?turn_sandbox_runtime_git:Keeper_turn_sandbox_runtime.t ->
+  ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+  ?turn_sandbox_factory_git:Keeper_sandbox_factory.t ->
   exec_cache:Masc_exec.Exec_cache.t option ->
   ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
   name:string ->
@@ -169,8 +169,8 @@ val execute_keeper_tool_call :
   config:Coord.config ->
   meta:keeper_meta ->
   ctx_work:working_context ->
-  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
-  ?turn_sandbox_runtime_git:Keeper_turn_sandbox_runtime.t ->
+  ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+  ?turn_sandbox_factory_git:Keeper_sandbox_factory.t ->
   exec_cache:Masc_exec.Exec_cache.t option ->
   ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
   name:string ->

--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -1,0 +1,50 @@
+type t = {
+  config : Coord.config;
+  meta : Keeper_types.keeper_meta;
+  cache : ((bool * string), Keeper_turn_sandbox_runtime.t) Hashtbl.t;
+  mutex : Mutex.t;
+}
+
+let create ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) =
+  {
+    config;
+    meta;
+    cache = Hashtbl.create 4;
+    mutex = Mutex.create ();
+  }
+
+let with_lock (t : t) f =
+  Mutex.lock t.mutex;
+  Fun.protect
+    ~finally:(fun () -> try Mutex.unlock t.mutex with _ -> ())
+    f
+
+let resolve (t : t) ~in_playground ~cwd =
+  with_lock t (fun () ->
+    let key = (in_playground, cwd) in
+    match Hashtbl.find_opt t.cache key with
+    | Some r -> Some r
+    | None ->
+      let (effective_profile, effective_network) =
+        Keeper_shell_docker.effective_sandbox_profile
+          ~meta:t.meta ~in_playground
+      in
+      (match effective_profile with
+       | Keeper_types.Docker ->
+         let r =
+           Keeper_turn_sandbox_runtime.create
+             ~config:t.config
+             ~meta:t.meta
+             ~network_mode:effective_network
+             ()
+         in
+         Hashtbl.add t.cache key r;
+         Some r
+       | Keeper_types.Local -> None))
+
+let cleanup (t : t) =
+  with_lock t (fun () ->
+    Hashtbl.iter
+      (fun _ r -> Keeper_turn_sandbox_runtime.cleanup r)
+      t.cache;
+    Hashtbl.reset t.cache)

--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -1,14 +1,18 @@
 type t = {
   config : Coord.config;
   meta : Keeper_types.keeper_meta;
-  cache : ((bool * string), Keeper_turn_sandbox_runtime.t) Hashtbl.t;
+  default_network_override : Keeper_types.network_mode option;
+  cache :
+    ((bool * string), Keeper_turn_sandbox_runtime.t) Hashtbl.t;
   mutex : Mutex.t;
 }
 
-let create ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) =
+let create ?default_network_override
+    ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) () =
   {
     config;
     meta;
+    default_network_override;
     cache = Hashtbl.create 4;
     mutex = Mutex.create ();
   }
@@ -19,9 +23,31 @@ let with_lock (t : t) f =
     ~finally:(fun () -> try Mutex.unlock t.mutex with _ -> ())
     f
 
-let resolve (t : t) ~in_playground ~cwd =
+let strip_trailing_slashes path =
+  let rec loop i =
+    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
+  in
+  let len = loop (String.length path) in
+  if len = String.length path then path else String.sub path 0 len
+
+let normalize p =
+  Keeper_alerting_path.normalize_path_for_check p
+  |> strip_trailing_slashes
+
+let in_playground_of_cwd (t : t) ~cwd =
+  let host_root =
+    Keeper_sandbox.host_root_abs_of_meta ~config:t.config t.meta
+    |> normalize
+  in
+  let cwd_norm = normalize cwd in
+  String.equal cwd_norm host_root
+  || String.starts_with ~prefix:(host_root ^ "/") cwd_norm
+
+let resolve (t : t) ~cwd =
   with_lock t (fun () ->
-    let key = (in_playground, cwd) in
+    let in_playground = in_playground_of_cwd t ~cwd in
+    let cwd_norm = normalize cwd in
+    let key = (in_playground, cwd_norm) in
     match Hashtbl.find_opt t.cache key with
     | Some r -> Some r
     | None ->
@@ -29,18 +55,24 @@ let resolve (t : t) ~in_playground ~cwd =
         Keeper_shell_docker.effective_sandbox_profile
           ~meta:t.meta ~in_playground
       in
+      let actual_network =
+        Option.value t.default_network_override ~default:effective_network
+      in
       (match effective_profile with
        | Keeper_types.Docker ->
          let r =
            Keeper_turn_sandbox_runtime.create
              ~config:t.config
              ~meta:t.meta
-             ~network_mode:effective_network
+             ~network_mode:actual_network
              ()
          in
          Hashtbl.add t.cache key r;
          Some r
        | Keeper_types.Local -> None))
+
+let resolve_opt t_opt ~cwd =
+  Option.bind t_opt (fun t -> resolve t ~cwd)
 
 let cleanup (t : t) =
   with_lock t (fun () ->

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -1,0 +1,40 @@
+(** Turn-scoped factory for {!Keeper_turn_sandbox_runtime.t}.
+
+    A single keeper turn may dispatch tool calls from different cwds,
+    each implying a different [in_playground] state.  The factory
+    centralizes the {!Keeper_shell_docker.effective_sandbox_profile}
+    invariant and memoizes one runtime per [(in_playground, cwd)] so a
+    Docker container is created at most once per distinct dispatch
+    context.
+
+    Background: pre-PR-3b, [keeper_tools_oas.make_tool_bundle]
+    inspected [meta.sandbox_profile] eagerly at turn-start and produced
+    [None] for [Local], silently bypassing the
+    [DockerPlayground.enabled + in_playground=true → Docker upgrade]
+    path that PR-3 (#11610) wired into [effective_sandbox_profile].
+    With the factory the invariant is evaluated per call site, never
+    at turn-start.
+
+    The dependency on {!Keeper_shell_docker} stays acyclic:
+    [keeper_shell_docker] only consumes [Keeper_turn_sandbox_runtime.t]
+    as a parameter and never constructs one itself. *)
+
+type t
+
+val create :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  t
+
+val resolve :
+  t ->
+  in_playground:bool ->
+  cwd:string ->
+  Keeper_turn_sandbox_runtime.t option
+(** Returns [Some runtime] when {!Keeper_shell_docker.effective_sandbox_profile}
+    yields [Docker]; [None] when [Local].  Memoizes per
+    [(in_playground, cwd)] so subsequent calls reuse the same
+    container. *)
+
+val cleanup : t -> unit
+(** Tears down every runtime created via {!resolve}.  Idempotent. *)

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -3,17 +3,19 @@
     A single keeper turn may dispatch tool calls from different cwds,
     each implying a different [in_playground] state.  The factory
     centralizes the {!Keeper_shell_docker.effective_sandbox_profile}
-    invariant and memoizes one runtime per [(in_playground, cwd)] so a
-    Docker container is created at most once per distinct dispatch
-    context.
+    invariant, evaluates [in_playground] from the call-site [cwd], and
+    memoizes one runtime per [(in_playground, cwd)] so a Docker
+    container is created at most once per distinct dispatch context
+    within a turn.
 
-    Background: pre-PR-3b, [keeper_tools_oas.make_tool_bundle]
-    inspected [meta.sandbox_profile] eagerly at turn-start and produced
-    [None] for [Local], silently bypassing the
-    [DockerPlayground.enabled + in_playground=true → Docker upgrade]
-    path that PR-3 (#11610) wired into [effective_sandbox_profile].
-    With the factory the invariant is evaluated per call site, never
-    at turn-start.
+    Background: pre-PR-3b, [keeper_tools_oas.make_tool_bundle] inspected
+    [meta.sandbox_profile] eagerly at turn-start and produced [None]
+    for [Local], silently bypassing the [DockerPlayground.enabled +
+    in_playground=true → Docker upgrade] path that PR-3 (#11610) wired
+    into [effective_sandbox_profile].  With the factory the invariant
+    is evaluated per call site, never at turn-start, and the memo
+    prevents the cold-start-every-call pattern that lingered after
+    PR-3.
 
     The dependency on {!Keeper_shell_docker} stays acyclic:
     [keeper_shell_docker] only consumes [Keeper_turn_sandbox_runtime.t]
@@ -22,19 +24,33 @@
 type t
 
 val create :
+  ?default_network_override:Keeper_types.network_mode ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
+  unit ->
   t
+(** Create an empty factory.  [default_network_override], when supplied,
+    is applied to every runtime created via {!resolve} (used by the git
+    variant which always inherits the host network). *)
 
 val resolve :
   t ->
-  in_playground:bool ->
   cwd:string ->
   Keeper_turn_sandbox_runtime.t option
 (** Returns [Some runtime] when {!Keeper_shell_docker.effective_sandbox_profile}
-    yields [Docker]; [None] when [Local].  Memoizes per
+    yields [Docker] (with [in_playground] derived from [cwd] vs the
+    keeper's playground root); [None] when [Local].  Memoizes per
     [(in_playground, cwd)] so subsequent calls reuse the same
     container. *)
+
+val resolve_opt :
+  t option ->
+  cwd:string ->
+  Keeper_turn_sandbox_runtime.t option
+(** Convenience wrapper: [None] when [t option] is [None], otherwise
+    delegates to {!resolve}.  Lets call sites that previously matched
+    on [Keeper_turn_sandbox_runtime.t option] keep the same shape after
+    the factory rewrite. *)
 
 val cleanup : t -> unit
 (** Tears down every runtime created via {!resolve}.  Idempotent. *)

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -157,8 +157,8 @@ let make_keeper_tool_handler
     ~(config : Coord.config)
     ~(meta : Keeper_types.keeper_meta)
     ~(ctx_snapshot : Keeper_types.working_context)
-    ?turn_sandbox_runtime
-    ?turn_sandbox_runtime_git
+    ?turn_sandbox_factory
+    ?turn_sandbox_factory_git
     ~(exec_cache : Masc_exec.Exec_cache.t option)
     ?search_fn
     ?on_tool_called
@@ -191,8 +191,8 @@ let make_keeper_tool_handler
           Inference_utils.timed (fun () ->
             Keeper_exec_tools.execute_keeper_tool_call_with_outcome
               ~config ~meta ~ctx_work:ctx_snapshot
-              ?turn_sandbox_runtime
-              ?turn_sandbox_runtime_git
+              ?turn_sandbox_factory
+              ?turn_sandbox_factory_git
               ~exec_cache
               ?search_fn
               ~name ~input ())
@@ -428,20 +428,25 @@ let make_tool_bundle
     ?on_tool_called
     ()
   : tool_bundle =
-  let turn_sandbox_runtime =
-    match meta.sandbox_profile with
-    | Keeper_types.Docker ->
-      Some (Keeper_turn_sandbox_runtime.create ~config ~meta ~network_mode:meta.network_mode ())
-    | Keeper_types.Local -> None
+  (* PR-3b (#11611 part 1): replace eager [Keeper_turn_sandbox_runtime]
+     instances with a factory.  in_playground/cwd are unknown at
+     turn-start, so the factory defers
+     [Keeper_shell_docker.effective_sandbox_profile] resolution until
+     each tool call site that already knows its [cwd].  The git variant
+     stays gated by [hard_mode]; when off, it carries a
+     [default_network_override] so resolved runtimes always inherit the
+     host network. *)
+  let turn_sandbox_factory =
+    Some (Keeper_sandbox_factory.create ~config ~meta ())
   in
-  let turn_sandbox_runtime_git =
-    match meta.sandbox_profile with
-    | Keeper_types.Docker ->
-      if Env_config_keeper.KeeperSandbox.hard_mode () then
-        None
-      else
-        Some (Keeper_turn_sandbox_runtime.create ~config ~meta ~network_mode:Network_inherit ())
-    | Keeper_types.Local -> None
+  let turn_sandbox_factory_git =
+    if Env_config_keeper.KeeperSandbox.hard_mode () then
+      None
+    else
+      Some
+        (Keeper_sandbox_factory.create
+           ~default_network_override:Network_inherit
+           ~config ~meta ())
   in
   let exec_cache = Some (Masc_exec.Exec_cache.create ()) in
   (* Build Tool.t for the full universe so BM25 and Tool_op can
@@ -483,8 +488,8 @@ let make_tool_bundle
           ~description:td.description
           ~input_schema:td.input_schema
           (make_keeper_tool_handler ~name:td.name ~config ~meta ~ctx_snapshot
-             ?turn_sandbox_runtime
-             ?turn_sandbox_runtime_git
+             ?turn_sandbox_factory
+             ?turn_sandbox_factory_git
              ~exec_cache
              ?search_fn ?on_tool_called ~failure_counts ()))
       else None
@@ -515,8 +520,8 @@ let make_tool_bundle
             ~description:internal_def.description
             ~input_schema
             (make_keeper_tool_handler ~name:internal ~config ~meta ~ctx_snapshot
-               ?turn_sandbox_runtime
-               ?turn_sandbox_runtime_git
+               ?turn_sandbox_factory
+               ?turn_sandbox_factory_git
                ~exec_cache
                ?search_fn ?on_tool_called
                ~translate_input:(fun j ->
@@ -528,12 +533,8 @@ let make_tool_bundle
     tools = internal_tools @ alias_tools;
     cleanup =
       (fun () ->
-        (match turn_sandbox_runtime with
-        | Some runtime -> Keeper_turn_sandbox_runtime.cleanup runtime
-        | None -> ());
-        (match turn_sandbox_runtime_git with
-        | Some runtime -> Keeper_turn_sandbox_runtime.cleanup runtime
-        | None -> ()));
+        Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory;
+        Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory_git);
   }
 
 let make_tools

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -61,8 +61,8 @@ val make_keeper_tool_handler :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   ctx_snapshot:Keeper_types.working_context ->
-  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
-  ?turn_sandbox_runtime_git:Keeper_turn_sandbox_runtime.t ->
+  ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+  ?turn_sandbox_factory_git:Keeper_sandbox_factory.t ->
   exec_cache:Masc_exec.Exec_cache.t option ->
   ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
   ?on_tool_called:(string -> unit) ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -850,32 +850,24 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
               Keeper_exec_context.create ~system_prompt:""
                 ~max_tokens:(Keeper_config.keeper_unified_max_tokens ())
             in
-            let turn_sandbox_runtime =
-              match meta.Keeper_types.sandbox_profile with
-              | Keeper_types.Docker ->
-                  Some
-                    (Keeper_turn_sandbox_runtime.create ~config ~meta
-                       ~network_mode:meta.network_mode ())
-              | Keeper_types.Local -> None
+            (* PR-3b (#11611 part 1): factory replaces eager
+               Keeper_turn_sandbox_runtime here too. *)
+            let turn_sandbox_factory =
+              Some (Keeper_sandbox_factory.create ~config ~meta ())
             in
-            let turn_sandbox_runtime_git =
-              match meta.Keeper_types.sandbox_profile with
-              | Keeper_types.Docker ->
-                  if Env_config_keeper.KeeperSandbox.hard_mode () then
-                    None
-                  else
-                    Some
-                      (Keeper_turn_sandbox_runtime.create ~config ~meta
-                         ~network_mode:Keeper_types.Network_inherit ())
-              | Keeper_types.Local -> None
+            let turn_sandbox_factory_git =
+              if Env_config_keeper.KeeperSandbox.hard_mode () then
+                None
+              else
+                Some
+                  (Keeper_sandbox_factory.create
+                     ~default_network_override:Keeper_types.Network_inherit
+                     ~config ~meta ())
             in
             let cleanup () =
-              (match turn_sandbox_runtime with
-               | Some runtime -> Keeper_turn_sandbox_runtime.cleanup runtime
-               | None -> ());
-              match turn_sandbox_runtime_git with
-              | Some runtime -> Keeper_turn_sandbox_runtime.cleanup runtime
-              | None -> ()
+              Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory;
+              Option.iter
+                Keeper_sandbox_factory.cleanup turn_sandbox_factory_git
             in
             let exec_cache = Some (Masc_exec.Exec_cache.create ()) in
             let result =
@@ -883,8 +875,8 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
                 ~finally:cleanup
                 (fun () ->
                   Keeper_exec_tools.execute_keeper_tool_call_with_outcome
-                    ~config ~meta ~ctx_work ?turn_sandbox_runtime
-                    ?turn_sandbox_runtime_git ~exec_cache ~name
+                    ~config ~meta ~ctx_work ?turn_sandbox_factory
+                    ?turn_sandbox_factory_git ~exec_cache ~name
                     ~input:coerced_args ())
             in
             let success =


### PR DESCRIPTION
## Why

Issue [#11611](https://github.com/jeong-sik/masc-mcp/issues/11611) part 1.  Pre-PR-3b, `keeper_tools_oas.make_tool_bundle` and `mcp_server_eio_execute.dispatch_internal_keeper_runtime_tool` produced a `Keeper_turn_sandbox_runtime.t option` eagerly at turn-start by inspecting `meta.sandbox_profile` directly.  That bypassed the [`effective_sandbox_profile`](https://github.com/jeong-sik/masc-mcp/blob/main/lib/keeper/keeper_shell_docker.ml#L133) invariant wired by [PR-3 (#11610)](https://github.com/jeong-sik/masc-mcp/pull/11610) for the `Local + DockerPlayground.enabled + in_playground=true → Docker upgrade` branch — and it cold-started a new container on every tool call when the upgrade did kick in.

## What

Introduces `Keeper_sandbox_factory` — a turn-scoped factory that:

1. Derives `in_playground` from the *call-site* `cwd` (vs the keeper's playground root).
2. Invokes `Keeper_shell_docker.effective_sandbox_profile` per call so the PR-3 invariant covers every dispatch path, not just the bash route.
3. Memoizes one `Keeper_turn_sandbox_runtime.t` per `(in_playground, cwd)` so subsequent calls inside the same dispatch context reuse the container.
4. Carries an optional `default_network_override` for the git variant (always inherits host network when hard-mode is off).
5. Runs `cleanup` on every cached runtime in one shot (idempotent).

`keeper_shell_docker` stays `Keeper_turn_sandbox_runtime.t`-typed — it is the low-level layer.  Callers (`keeper_exec_shell`, `keeper_exec_fs`, `keeper_docker_read`, `keeper_exec_tools`, `keeper_tools_oas`, `mcp_server_eio_execute`) hold the factory and call `Keeper_sandbox_factory.resolve_opt … ~cwd` immediately before forwarding the resolved runtime down.

## Files

- `lib/keeper/keeper_sandbox_factory.{ml,mli}` (new, 87 LoC)
- `lib/keeper/keeper_tools_oas.{ml,mli}` — `make_tool_bundle` + `make_keeper_tool_handler` rewired
- `lib/keeper/keeper_exec_tools.{ml,mli}` — forward parameters renamed
- `lib/keeper/keeper_exec_fs.{ml,mli}` — two write paths use `resolve_opt ~cwd:target`
- `lib/keeper/keeper_exec_shell.{ml,mli}` — six call sites use `resolve_opt ~cwd`
- `lib/keeper/keeper_docker_read.{ml,mli}` — `run_command_in_container_with_status` resolves with `cwd = host_playground_root`
- `lib/mcp_server_eio_execute.ml` — `dispatch_internal_keeper_runtime_tool` switched to factory + `cleanup` via `Keeper_sandbox_factory.cleanup`
- `lib/dune` — module list registers `keeper_sandbox_factory`

`lib/keeper/keeper_shell_docker.{ml,mli}` deliberately untouched: callers resolve before forwarding so the dependency graph stays acyclic (`keeper_sandbox_factory → keeper_shell_docker`, never the reverse).

## Verification

- `dune build lib` — clean.
- Plan SSOT: `planning/claude-plans/30m-users-dancer-downloads-kimi-agent-greedy-pebble.md` (PR-3b row).
- Memory: factory closure is the architectural answer the analysis converged on; the eager fix is blocked by `working_context = { checkpoint; max_tokens }` not carrying `cwd`.

## Test plan

- [x] `dune build lib` clean
- [ ] `dune runtest` (CI)
- [ ] Lint, OCaml Structure Ratchet, TLA+, Keeper Cwd Leak Gate (CI)
- [ ] Manual: 5 docker keepers (sojin/verdict/analyst/janitor/poe) → `keeper_bash 'cat /etc/hostname'` returns container hostname (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)