### PR TITLE
fix(keeper): unblock canonical seed parse for fail-loud sandbox fields

### DIFF
--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -255,12 +255,19 @@ let fallback_canonical_keeper_meta_key_names =
   ]
 ;;
 
+(* Seed must satisfy every fail-loud field in [meta_of_json]; otherwise the
+   canonical key list silently degrades to [fallback_canonical_keeper_meta_key_names]
+   and [warn_unknown_keeper_meta_keys] floods on every keeper read.
+   #11594 added [parse_sandbox_policy_fields] requiring sandbox_profile +
+   network_mode; keep this seed in sync when adding more required fields. *)
 let canonical_keeper_meta_key_names =
   let seed_json =
     `Assoc
       [ "name", `String "__keeper-meta-key-seed__"
       ; "agent_name", `String "__keeper-meta-key-seed__"
       ; "trace_id", `String "__keeper-meta-key-seed__"
+      ; "sandbox_profile", `String "local"
+      ; "network_mode", `String "none"
       ]
   in
   match meta_of_json seed_json with

--- a/test/dune
+++ b/test/dune
@@ -1675,6 +1675,11 @@
  (libraries masc_mcp masc_test_deps fs_compat alcotest eio eio_main unix))
 
 (test
+ (name test_keeper_meta_canonical_seed)
+ (modules test_keeper_meta_canonical_seed)
+ (libraries masc_mcp alcotest))
+
+(test
  (name test_keeper_paused_cas_retain_9733)
  (modules test_keeper_paused_cas_retain_9733)
  (libraries masc_mcp masc_test_deps fs_compat alcotest eio eio_main unix))

--- a/test/test_keeper_meta_canonical_seed.ml
+++ b/test/test_keeper_meta_canonical_seed.ml
@@ -1,0 +1,66 @@
+(** Drift gate for [canonical_keeper_meta_key_names].
+
+    The reflection-via-roundtrip pattern in [keeper_meta_json.ml] derives the
+    canonical key list by parsing a minimal seed JSON and re-serialising it.
+    If a future change adds a new fail-loud required field to [meta_of_json]
+    without updating the seed, the seed parse fails and the function silently
+    falls back to [fallback_canonical_keeper_meta_key_names] — which floods
+    [warn_unknown_keeper_meta_keys] on every keeper read.
+
+    Regression: PR #11594 (fail-loud sandbox_profile/network_mode parsing,
+    2026-04-28) broke this without test coverage; production logs flooded
+    with "unknown keys" warnings on every reconcile tick (~3000/day). *)
+
+open Masc_mcp
+
+let target_keys =
+  [ "sandbox_profile"
+  ; "network_mode"
+  ; "shared_memory_scope"
+  ; "tool_preset_source"
+  ; "max_checkpoint_messages"
+  ; "always_approve"
+  ; "keeper_id"
+  ; "meta_version"
+  ]
+
+let test_canonical_includes_post_pr11594_keys () =
+  let canonical = Keeper_meta_json.canonical_keeper_meta_key_names in
+  List.iter
+    (fun key ->
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "canonical_keeper_meta_key_names contains %s (seed must satisfy \
+            fail-loud parse)"
+           key)
+        true
+        (List.mem key canonical))
+    target_keys
+
+let test_canonical_disjoint_from_fallback_when_seed_parses () =
+  (* When the seed parses, [canonical_keeper_meta_key_names] should be derived
+     from [meta_to_json], not from [fallback_canonical_keeper_meta_key_names].
+     The static fallback is missing post-PR-11594 keys; if our canonical list
+     equals it byte-for-byte we are silently in fallback mode. *)
+  let canonical = Keeper_meta_json.canonical_keeper_meta_key_names in
+  let fallback = Keeper_meta_json.fallback_canonical_keeper_meta_key_names in
+  Alcotest.(check bool)
+    "canonical list differs from fallback (seed parse must succeed)"
+    true
+    (canonical <> fallback)
+
+let () =
+  Alcotest.run
+    "keeper_meta_canonical_seed"
+    [ ( "drift_gate"
+      , [ Alcotest.test_case
+            "post-PR-11594 keys present"
+            `Quick
+            test_canonical_includes_post_pr11594_keys
+        ; Alcotest.test_case
+            "not collapsed to fallback"
+            `Quick
+            test_canonical_disjoint_from_fallback_when_seed_parses
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 증상

`./.masc/keepers/*.json` 파일 15개 모두에 대해 매 reconcile/watchdog tick (~10초)마다 다음 경고가 발화. 운영 로그(`~/me/.masc/logs/system_log_2026-04-28.jsonl`)에 오늘 하루 **3,111건** 누적.

```
[WARN] [Keeper] keeper meta /Users/dancer/me/.masc/keepers/<name>.json has unknown keys:
  sandbox_profile, network_mode, shared_memory_scope, tool_preset_source,
  max_checkpoint_messages, always_approve, keeper_id, meta_version
```

이 8개 키는 `meta_to_json`(line 30-151)이 항상 emit하는 정상 필드라 절대 unknown이 되어선 안 됨.

## 근본 원인

`canonical_keeper_meta_key_names`(`lib/keeper/keeper_meta_json.ml:258-276`)는 reflection-via-roundtrip 패턴으로 키 목록을 도출:

1. seed JSON(3 필드만) → `meta_of_json` 파싱 → `meta_to_json` 재직렬화 → 키 추출
2. 파싱 실패 시 `fallback_canonical_keeper_meta_key_names`(stale, 8개 키 누락)

PR #11594 (`047b094f65`, "fail-loud sandbox_profile parsing", 2026-04-28)이 `parse_sandbox_policy_fields`(`keeper_meta_json_parse.ml:174-215`)를 추가하며 `sandbox_profile`/`network_mode`를 필수 필드로 만듦. 그러나 seed JSON은 그대로라 파싱이 silent fail → 매번 fallback 사용 → 모든 정상 키가 unknown으로 보고됨.

추가로, fallback 진입 시 `Log.Keeper.warn`은 모듈 초기화 시점에 호출되어 Eio main loop 시작 전이라 JSONL log sink에 도달하지 못함 → silent regression이 운영에서 발견되지 못한 이유.

## 변경

1. `keeper_meta_json.ml` seed JSON에 `sandbox_profile = "local"`, `network_mode = "none"` 추가 + 동기화 필요성을 명시한 주석.
2. `test/test_keeper_meta_canonical_seed.ml` 신규 (drift gate):
   - canonical 리스트에 #11594 이후 추가된 8개 키가 모두 있는지 확인
   - canonical 리스트가 static fallback과 다른지 확인 (silent fallback 진입 차단)

## 검증

```
$ dune build lib/ --root .                         # OK
$ dune build test/test_keeper_meta_canonical_seed.exe --root .  # OK
$ ./_build/default/test/test_keeper_meta_canonical_seed.exe
Testing `keeper_meta_canonical_seed'.
  [OK]  drift_gate  0  post-PR-11594 keys present.
  [OK]  drift_gate  1  not collapsed to fallback.
Test Successful in 0.001s. 2 tests run.
```

## Test plan

- [ ] CI 통과 후 서버 재시작 → `system_log_2026-04-29.jsonl`에서 `has unknown keys` 카운트 0건 확인.
- [ ] (option) `tail -f` 운영 로그에서 watchdog tick이 unknown-key 경고 없이 흐르는지 확인.

## Follow-ups (별도 PR)

- `fallback_canonical_keeper_meta_key_names`에서 누락된 8개 키 추가 (방어선; seed가 정상이면 도달 안 하지만 두 번째 silent fallback 발생 시 출혈 최소화).
- 모듈 초기화 시점의 `Log.Keeper.warn` 사용 ratchet 또는 sink readiness 가드 추가 — 이번처럼 silent regression이 production에서 발견 안 되는 패턴 차단.
- `grace_rem=-30` 키퍼 정체는 별개 이슈 (cascade/OAS budget 영역). 이 PR과 무관.