### PR TITLE
feat(design-system): IdGenerator — RFC 0001 impl-1 (headless-core)

### DIFF
--- a/dashboard/design-system/headless-core/id-generator.test.ts
+++ b/dashboard/design-system/headless-core/id-generator.test.ts
@@ -1,0 +1,64 @@
+// Pure TS unit tests for IdGenerator. No DOM, no Preact runtime.
+import { describe, it, expect } from 'vitest'
+import { createIdGenerator } from './id-generator'
+
+describe('createIdGenerator', () => {
+  it('produces a monotonic sequence starting at 1', () => {
+    const gen = createIdGenerator()
+    expect(gen.next()).toBe('id-1')
+    expect(gen.next()).toBe('id-2')
+    expect(gen.next()).toBe('id-3')
+  })
+
+  it('uses the supplied seed as the default prefix', () => {
+    const gen = createIdGenerator('drawer')
+    expect(gen.next()).toBe('drawer-1')
+    expect(gen.next()).toBe('drawer-2')
+  })
+
+  it('per-call prefix overrides the seed for that call only', () => {
+    const gen = createIdGenerator('drawer')
+    expect(gen.next('trigger')).toBe('trigger-1')
+    expect(gen.next('content')).toBe('content-2')
+    // back to default seed on the next call
+    expect(gen.next()).toBe('drawer-3')
+  })
+
+  it('reset() returns the counter to 0 so the next id starts at 1', () => {
+    const gen = createIdGenerator()
+    gen.next()
+    gen.next()
+    gen.next()
+    gen.reset()
+    expect(gen.next()).toBe('id-1')
+  })
+
+  it('two instances are independent: their counters do not share state', () => {
+    const a = createIdGenerator('a')
+    const b = createIdGenerator('b')
+    expect(a.next()).toBe('a-1')
+    expect(b.next()).toBe('b-1')
+    expect(a.next()).toBe('a-2')
+    expect(b.next()).toBe('b-2')
+  })
+
+  it('two instances with the same seed produce identical sequences (SSR determinism)', () => {
+    const a = createIdGenerator('drawer')
+    const b = createIdGenerator('drawer')
+    expect(a.next()).toBe(b.next())
+    expect(a.next('trigger')).toBe(b.next('trigger'))
+    expect(a.next()).toBe(b.next())
+  })
+
+  it('undefined seed falls back to the default "id" prefix', () => {
+    const gen = createIdGenerator(undefined)
+    expect(gen.next()).toBe('id-1')
+  })
+
+  it('empty string seed falls back to the default prefix (CSS-escape sharp edge)', () => {
+    const gen = createIdGenerator('')
+    expect(gen.next()).toBe('id-1')
+    // per-call prefix override still works after empty-string seed
+    expect(gen.next('explicit')).toBe('explicit-2')
+  })
+})

--- a/dashboard/design-system/headless-core/id-generator.ts
+++ b/dashboard/design-system/headless-core/id-generator.ts
@@ -1,0 +1,59 @@
+/**
+ * IdGenerator — framework-agnostic, deterministic ID generator.
+ *
+ * Replaces ad-hoc `Math.random()` ID patterns in interactive primitives
+ * (Drawer/Popover/Dialog) where the trigger and content need a stable
+ * shared id for `aria-labelledby` / `aria-controls` wiring.
+ *
+ * Design (RFC 0001 §"First 3 primitives"):
+ *   - Per-instance monotonic counter
+ *   - Caller may supply a seed prefix (defaults to `"id"`); each `next()`
+ *     call may also override the prefix at the call site
+ *   - `reset()` zeroes the counter (for hydration boundaries / SSR replay)
+ *   - Two independent generators with the same seed produce identical
+ *     id sequences — sufficient for the SSR/hydration determinism the
+ *     RFC sketches as a future requirement
+ *
+ * Out of scope (will land later if/when the dashboard adopts SSR):
+ *   - Tree-aware id allocation (Preact useId is the right primitive there)
+ *   - Web crypto seeded UUIDs
+ *
+ * No external dependencies. Pure TS. Safe to import from headless-preact
+ * adapter or any other framework adapter.
+ */
+
+export interface IdGenerator {
+  /**
+   * Returns the next id in sequence, formatted as `<prefix>-<n>` where
+   * `n` increments monotonically from 1. The optional `prefix` argument
+   * overrides the seed for this call only.
+   */
+  next(prefix?: string): string
+
+  /** Resets the counter to 0. Subsequent `next()` returns `<prefix>-1`. */
+  reset(): void
+}
+
+const DEFAULT_SEED = 'id'
+
+/**
+ * Creates an IdGenerator. `seed` is the default prefix used when
+ * `next()` is called with no argument; defaults to `"id"`.
+ */
+export function createIdGenerator(seed?: string): IdGenerator {
+  // Empty string seed falls back to the default — `-1` style ids are
+  // legal HTML5 but require CSS-selector escaping (`\-1`), which is a
+  // sharp edge a caller almost never wants. Treat `""` as "not supplied".
+  const defaultPrefix = seed && seed.length > 0 ? seed : DEFAULT_SEED
+  let counter = 0
+
+  return {
+    next(prefix?: string): string {
+      counter += 1
+      return `${prefix ?? defaultPrefix}-${counter}`
+    },
+    reset(): void {
+      counter = 0
+    },
+  }
+}

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -21,5 +21,5 @@
     "noUncheckedIndexedAccess": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"]
+  "include": ["src", "design-system/headless-core"]
 }

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [preact()],
   test: {
     environment: 'happy-dom',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'design-system/**/*.test.ts'],
     globals: true,
     setupFiles: ['./vitest-setup.ts'],
   },


### PR DESCRIPTION
## Summary

First framework-agnostic primitive from **RFC 0001 Headless Foundation** (#11670). Pure TS, no Preact import — usable from any future framework adapter.

- `design-system/headless-core/id-generator.ts` — ~50 LoC
- `design-system/headless-core/id-generator.test.ts` — 8 cases, all pass
- `vitest.config.ts` + `tsconfig.json` updated to include the new directory

## API

```ts
const gen = createIdGenerator('drawer')
gen.next()           // 'drawer-1'
gen.next('trigger')  // 'trigger-2'  (per-call override)
gen.reset()
gen.next()           // 'drawer-1'   (counter reset)
```

## Design notes

- **SSR determinism foundation**: two instances with the same seed produce identical id sequences. Future Preact `useId` adapter (`headless-preact/use-id.ts`) will leverage this for hydration parity. Tree-aware allocation is YAGNI today (dashboard is SPA).
- **Empty-string seed falls back to default**. `-1` style ids are legal HTML5 but require CSS-selector escape (`\-1`). Treat `""` as "not supplied" — fail-closed for unknown→permissive default ([memory feedback_keeper_runtime_fail_closed_for_unknown_permissive_default]).
- **No external dependencies.** Will be importable from `headless-preact/`, future Bonsai adapter, or test harnesses.

## Verification

- [x] `pnpm vitest run design-system/headless-core/id-generator.test.ts` → 8/8 pass
- [x] `pnpm vitest run src/components/common/button.test.ts` → 20/20 pass (no regression)
- [x] `pnpm tsc --noEmit` clean
- [ ] CI checks (this PR)

## Scope

In: IdGenerator only.
Out: PortalManager (impl-2), FocusScope (impl-3), Preact `useId` adapter, Web Crypto UUIDs, tree-aware allocation.

## Related

- RFC: #11670 (Headless Foundation, defines the API shape this PR implements)
- Companion: #11676 (a11y test infra — jest-axe wiring)
- Spec: design_system_v2 §1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)