### PR TITLE
chore(keeper): add keeper_goal_repair.mli (cycle 91)

### DIFF
--- a/lib/keeper/keeper_goal_repair.mli
+++ b/lib/keeper/keeper_goal_repair.mli
@@ -1,0 +1,88 @@
+(** Keeper_goal_repair — detect and repair empty [active_goal_ids].
+
+    When a keeper's [active_goal_ids] is empty, the task filter accepts
+    ALL tasks equally, causing claim/release loops.  This module:
+
+    1. Detects keepers with empty [active_goal_ids].
+    2. Creates a goal from the keeper's [goal] field (purpose statement).
+    3. Assigns the new goal id to [active_goal_ids].
+
+    Two entry points: {!dry_run} (no side effects, returns the audit
+    only) and {!run} (actually creates goals + writes meta).  Internal
+    helpers (find / repair / title-derivation / empty-result constant)
+    stay private.
+
+    @since 2.237.0 *)
+
+type repair_action = {
+  keeper_name : string;
+  goal_id : string;
+  goal_title : string;
+}
+(** One repair entry.  [goal_id] is ["(dry-run)"] for {!dry_run}
+    actions and the actual goal id for {!run}. *)
+
+type repair_result = {
+  actions : repair_action list;
+  skipped : (string * string) list;
+        (** [(keeper_name, reason)] — keeper had a non-empty
+            [active_goal_ids] or the meta was missing in a way the
+            audit pass classified as benign. *)
+  errors : (string * string) list;
+        (** [(keeper_name, error_message)] — read/write/upsert
+            failures.  Do not contain the substring
+            ["already has active_"] (that classifies as
+            {!field-skipped}). *)
+}
+(** Concrete record because {!Tool_keeper} field-accesses the lists
+    when projecting to the dashboard JSON.  Lists are returned in
+    keeper-name order (stable scan order from the [.json] directory
+    listing reversed back). *)
+
+val repair_result_to_yojson : repair_result -> Yojson.Safe.t
+(** [repair_result_to_yojson r] renders the result as
+    {[
+      `Assoc [
+        ("repaired", `Int <count>);
+        ("skipped", `Int <count>);
+        ("errors", `Int <count>);
+        ("actions", `List [<repair_action>...]);
+        ("skipped_details", `List [<{name, reason}>...]);
+        ("error_details", `List [<{name, error}>...]);
+      ]
+    ]}
+    The triple count + per-list detail shape is the dashboard
+    contract — operator runbooks read these field names verbatim. *)
+
+val dry_run : Coord.config -> repair_result
+(** [dry_run config] scans every keeper meta under
+    [<masc_dir>/keepers/*.json] and returns the audit without
+    creating any goals or writing any meta.  [actions[i].goal_id] is
+    always ["(dry-run)"].  Useful for confirming the repair scope
+    before committing.  Read-only on disk. *)
+
+val run : Coord.config -> repair_result
+(** [run config] scans every keeper meta under
+    [<masc_dir>/keepers/*.json] and, for each keeper with empty
+    [active_goal_ids]:
+
+    1. Derives a title from the keeper's purpose statement
+       (truncated to 115 chars + ["… (auto)"] suffix; falls back to
+       ["(unnamed keeper)"] when the purpose is empty).
+    2. Calls {!Goal_store.upsert_goal} which must report [`created]
+       (an [`updated] response is treated as an error — repair
+       expects fresh-goal creation, not an existing-goal collision).
+    3. Writes the keeper meta with the new goal id assigned to
+       [active_goal_ids].
+
+    Side-effects:
+    - Creates one goal record per repaired keeper.
+    - Mutates one keeper meta file per repair.
+    - Logs at the [Log.Keeper] level (via the goal-store / meta
+      writers).
+
+    Error classification: failures whose message starts with
+    ["already has active_"] (literal 18-char prefix) are reported
+    in {!field-skipped}, not {!field-errors}.  This is a contract
+    so operator runbooks distinguish "no-op due to race" from "real
+    failure".  Other failures land in {!field-errors}. *)


### PR DESCRIPTION
## Summary

Cycle 91 — adds an explicit interface for
`lib/keeper/keeper_goal_repair.ml` (123 lines).

## Surface (5 entries, 4 hide)

```ocaml
type repair_action = {
  keeper_name : string;
  goal_id : string;
  goal_title : string;
}

type repair_result = {
  actions : repair_action list;
  skipped : (string * string) list;
  errors : (string * string) list;
}

val repair_result_to_yojson : repair_result -> Yojson.Safe.t
val dry_run : Coord.config -> repair_result
val run : Coord.config -> repair_result
```

Hidden: `empty_result`, `goal_title_of_purpose`,
`find_empty_goal_keepers`, `repair_keeper`.

## Error classification contract

`run` reports failures whose message starts with the literal
18-char prefix `"already has active_"` in `skipped`, not
`errors`. Operator runbooks distinguish "no-op due to race"
from "real failure" on this exact prefix — pinning at the
contract seam.

## dry_run vs run asymmetry

| Function | Side effect | `goal_id` |
|---|---|---|
| `dry_run` | Read-only on disk | Literal `"(dry-run)"` |
| `run` | Creates goal + writes meta | Real id from `Goal_store.upsert_goal` |

Dashboards can render the planned action without mistaking the
placeholder for a real id.

## Caller audit
- `lib/tool_keeper.ml:1016-1017` — `dry_run` / `run` dispatch
- `lib/tool_keeper.ml:1046` — `repair_result_to_yojson`
- `lib/keeper/keeper_schema.ml:313/318` — schema descriptions
  reference the public functions

## Test plan
- [x] `dune build --root . lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
