### PR TITLE
chore(coord): add coord_assertions.mli (cycle 93)

### DIFF
--- a/lib/coord_assertions.mli
+++ b/lib/coord_assertions.mli
@@ -1,0 +1,114 @@
+(** Coord_assertions — state inspection and assertion-based
+    verification.
+
+    Defines the boolean snapshot of agent state ({!agent_state}),
+    the closed variant of supported assertions ({!assertion_kind}),
+    and the {!handle_check} entry point that the [masc_check] tool
+    invokes via JSON-RPC.
+
+    The {!assertion_kind} variant is the SSOT for the assertion
+    taxonomy.  Adding a new assertion requires:
+    1. Extending {!assertion_kind} (forces every match site to
+       compile).
+    2. Adding the canonical name to {!assertion_kind_to_string}.
+    3. Adding the lenient-parse aliases to
+       {!assertion_kind_of_string_lenient}.
+    4. Adding the operator runbook entry referenced by the
+       fix-hint.
+
+    All of step 2-4 are wired through this module's hidden helpers
+    so the .mli surfaces the cascade explicitly. *)
+
+(** {1 State snapshot} *)
+
+type agent_state = {
+  room_set : bool;
+  joined : bool;
+  task_claimed : bool;
+  current_task_set : bool;
+  worktree_active : bool;
+}
+(** Concrete record because {!Tool_coord} field-constructs it
+    when projecting an inspected context to the assertion engine
+    ([Coord_assertions.room_set = s.room_set]).  Hiding would
+    break the type seam. *)
+
+(** {1 Assertion taxonomy} *)
+
+type assertion_kind =
+  | Room_set         (** Project root configured (legacy aliases: [namespace_ready], [project_ready]). *)
+  | Joined           (** Agent has joined the project namespace. *)
+  | Task_claimed     (** Agent owns at least one claimed task. *)
+  | Current_task_set (** [current_task] is set, fresh, and unambiguous. *)
+  | Worktree_active  (** Agent is in an isolated branch worktree. *)
+(** Closed variant — every match site must update on extension.
+    [Tool_coord] type-aliases this exact shape with the same five
+    constructors, so the cross-module re-export is structurally
+    pinned. *)
+
+val assertion_kind_to_string : assertion_kind -> string
+(** [assertion_kind_to_string k] returns the canonical snake_case
+    tag (e.g. [Room_set -> "room_set"]).  This is the operator-
+    visible name in JSON output — runbook commands grep on these
+    literals. *)
+
+val all_assertion_kinds : assertion_kind list
+(** Canonical declaration order: [Room_set; Joined; Task_claimed;
+    Current_task_set; Worktree_active].  Used by
+    {!handle_check}'s default-list fallback when callers omit the
+    [assertions] argument. *)
+
+val valid_assertion_strings : string list
+(** [List.map assertion_kind_to_string all_assertion_kinds].
+    Used in the "Unknown assertion: ... (expected one of: ...)"
+    error message so operators see the exact accepted values. *)
+
+val assertion_kind_of_string_lenient : string -> assertion_kind option
+(** [assertion_kind_of_string_lenient s] parses an assertion
+    name leniently: in addition to the canonical
+    [assertion_kind_to_string] outputs, it accepts the legacy
+    aliases [namespace_ready] / [project_ready] (both -> [Room_set]).
+
+    Returns [None] for any other input — the {!handle_check}
+    handler reports unknown assertions as a passing failure with
+    a fix hint listing {!valid_assertion_strings}.
+
+    Adding a new alias requires touching this function explicitly;
+    .mli hides the alias set on purpose so a future "be more
+    lenient" PR must extend the contract. *)
+
+(** {1 Tool entry point} *)
+
+val handle_check :
+  inspect_state:(Coord_types.context -> agent_state) ->
+  Coord_types.context ->
+  Yojson.Safe.t ->
+  bool * string
+(** [handle_check ~inspect_state ctx args] is the [masc_check]
+    JSON-RPC entry point.
+
+    {2 Arguments}
+    - [inspect_state ctx] resolves the current {!agent_state}.
+      Caller-supplied so the handler is testable without a real
+      context.
+    - [args] is the raw JSON-RPC params.  Recognises an optional
+      [assertions: [<string>...]] array; missing or non-list values
+      fall back to the canonical defaults (the five
+      [project_ready / joined / task_claimed / current_task_set /
+      worktree_active] strings — note [project_ready] is the legacy
+      alias for [room_set]).  An empty list also falls back to
+      defaults so callers cannot accidentally pass nothing.
+
+    {2 Return value}
+    [(true, json_string)] — the boolean is always [true] (the
+    handler does not use it to signal failure; failure is encoded
+    inside the JSON body).  The JSON body has shape:
+    {[
+      `Assoc [
+        ("assertions", `List [<per-assertion result>...]);
+        ("all_passed", `Bool <all assertions passed>);
+        ("fix_hint", `String | `Null);
+      ]
+    ]}
+    [fix_hint] is the first failing assertion's hint; when all
+    pass, [fix_hint] is [`Null]. *)


### PR DESCRIPTION
## Summary

Cycle 93 — adds an explicit interface for
`lib/coord_assertions.ml` (129 lines).

## Surface (7 entries, 4 hide)

```ocaml
type agent_state = {
  room_set : bool; joined : bool;
  task_claimed : bool; current_task_set : bool;
  worktree_active : bool;
}

type assertion_kind =
  | Room_set | Joined | Task_claimed
  | Current_task_set | Worktree_active

val assertion_kind_to_string : assertion_kind -> string
val all_assertion_kinds : assertion_kind list
val valid_assertion_strings : string list
val assertion_kind_of_string_lenient : string -> assertion_kind option

val handle_check :
  inspect_state:(Coord_types.context -> agent_state) ->
  Coord_types.context ->
  Yojson.Safe.t ->
  bool * string
```

Hidden: `assertion_fix_hint`, `assertion_passes`,
`check_assertion`, `state_to_json`.

## Closed variant cascade

`assertion_kind` is closed. Adding a 6th case requires:

1. Extending `assertion_kind` (forces match-site updates)
2. Adding a canonical name to `assertion_kind_to_string`
3. Adding lenient-parse aliases to
   `assertion_kind_of_string_lenient`
4. Adding the operator runbook entry referenced by the fix-hint
5. Tool_coord must update its type alias
   (`type assertion_kind = Coord_assertions.assertion_kind = ...`)

The 5-step cascade is explicit at the contract seam.

## Legacy aliases pinned

`assertion_kind_of_string_lenient` accepts:
- `room_set` (canonical)
- `namespace_ready` (legacy alias → `Room_set`)
- `project_ready` (legacy alias → `Room_set`)
- the four other canonical names

A future "drop legacy" change must touch this contract — the
legacy aliases are part of the operator-visible API even though
they map to the same canonical kind.

## handle_check default-list contract

When `args` omits `assertions` or passes a non-list / empty
list, the handler falls back to the canonical 5-name default.
Empty list also falls back so callers cannot accidentally pass
nothing.

Return shape: `(true, json_string)` — boolean is always `true`
(failure encoded inside the JSON body, not in the tuple).

## Caller audit
- `lib/tool_coord.ml:17-28` — type alias + 4 fn re-exports
- `lib/tool_coord.ml:646` — `agent_state` field construction
- `lib/tool_coord.ml:653` — `handle_check` dispatch

No external reference to the 4 hidden helpers.

## Test plan
- [x] `dune build --root . lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
