### PR TITLE
chore(ratchet): regenerate baseline post PR-3b admin merge

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 10,
-  "coord_mli_missing": 3,
+  "keeper_mli_missing": 3,
+  "coord_mli_missing": 1,
   "godsplit_count": 0,
-  "lib_dune_lines": 958,
-  "inferred_dump_headers": 6,
-  "lib_other_mli_missing": 125
+  "lib_dune_lines": 962,
+  "inferred_dump_headers": 0,
+  "lib_other_mli_missing": 61
 }


### PR DESCRIPTION
## Why

PR-3b ([#11679](https://github.com/jeong-sik/masc-mcp/pull/11679)) admin-merged while OCaml Structure Ratchet was failing — `lib_dune_lines` climbed from 958 to 962 because the new `keeper_sandbox_factory` module added an entry to the modules list.  Main is now in a perpetual ratchet-fail state until the baseline is rewritten.

Memory pattern: *Ratchet 자연화 after admin merge* — when CI fail is admin-overridden, the baseline must be re-pinned to the violation reading in a follow-up so subsequent PRs do not inherit a red main.

## What

Run `scripts/ocaml-structure-ratchet.sh --regenerate` on top of `c60d9de0ab` (PR-3b merge commit).

| metric | before | after |
|--------|--------|-------|
| lib_dune_lines | 958 | **962** (locked to PR-3b reality) |
| keeper_mli_missing | 10 | **3** (downward ratchet) |
| coord_mli_missing | 3 | **1** (downward ratchet) |
| inferred_dump_headers | 6 | **0** (downward ratchet) |
| lib_other_mli_missing | 125 | **61** (downward ratchet) |
| godsplit_count | 0 | 0 |

Only `lib_dune_lines` moves upward; the other four ratchet downward and lock to their lower floors.  Long-term fix for `lib_dune_lines` is to extract `lib/keeper/dune` (the script's own hint), but that is a separate refactor.

## Test plan

- [x] `bash scripts/ocaml-structure-ratchet.sh` clean locally
- [ ] CI Ratchet check green (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)