### PR TITLE
fix(oas_event_bridge): kind-only fallback for unmigrated payload variants (#10584)

### DIFF
--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -134,11 +134,26 @@ let wrap_event ~ts ~correlation_id ~run_id ~event_type ~payload
 
 (** Serialize an OAS event to JSON for SSE relay + durable storage.
     Reads envelope metadata ([correlation_id], [run_id], [ts]) from
-    [evt.meta] and includes them in every emitted JSON object. *)
+    [evt.meta] and includes them in every emitted JSON object.
+
+    The match below intentionally combines explicit per-variant arms
+    with a final [other] catch-all that produces a kind-only fallback
+    via [Oas.Event_bus.payload_kind].  The catch-all is "redundant" at
+    every individual snapshot of the OAS variant set (warning 11), but
+    it is a deliberate future-proof against the OAS pin-bump P0 class
+    (#10490, #10574, #10584).  Without the catch-all, every new
+    upstream variant breaks main with [-warn-error +8] until the
+    consumer is migrated; with it, the relay degrades to a
+    kind-labelled placeholder + a warn log signal until an explicit
+    arm is added.
+
+    Suppressing warning 11 ([@warning "-11"]) is therefore the entire
+    point of this function's shape — do not remove it without also
+    removing the catch-all. *)
 let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
   let { Oas.Event_bus.correlation_id; run_id; ts; _ } = evt.meta in
   let wrap = wrap_event ~ts ~correlation_id ~run_id in
-  match evt.payload with
+  match[@warning "-11"] evt.payload with
   | Oas.Event_bus.AgentStarted { agent_name; task_id } ->
       let payload =
         `Assoc
@@ -355,6 +370,38 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          payload aggregate. Skip the relay to avoid flooding SSE
          consumers with high-frequency low-value events. *)
       None
+  | other ->
+      (* Graceful fallback for OAS variants that ship before this consumer
+         is migrated to an explicit shape (#10584).  Pre-fix, the match
+         above was exhaustive and the OAS pin bump that introduced
+         [InferenceTelemetry] (#10490) and [Stale_turn_timeout] (#10574)
+         broke main with [-warn-error +8] partial-match errors.
+
+         [Oas.Event_bus.payload_kind] is co-located with the [payload]
+         variant in OAS — adding a new variant upstream forces an
+         entry there in the same patch, so the snake_case label is
+         always accurate.  Emit a kind-only SSE event so subscribers
+         see *something happened* (with stable [event_type] for
+         filtering) instead of having the whole stream fail to parse.
+
+         [note] flags the partial-data shape so dashboards can render
+         it as a placeholder rather than treating it as a complete
+         payload.  The warn log gives operators a per-process signal
+         that an OAS variant has shipped without a masc-mcp consumer
+         migration; downstream PRs should then move the variant out
+         of this catch-all into an explicit arm. *)
+      let kind = Oas.Event_bus.payload_kind other in
+      Log.Misc.warn
+        "oas_event_bridge: kind-only fallback for unmigrated payload \
+         variant kind=%s correlation_id=%s run_id=%s"
+        kind correlation_id run_id;
+      let payload =
+        `Assoc [
+          ("kind", `String kind);
+          ("note", `String "kind-only fallback; consumer not yet migrated");
+        ]
+      in
+      Some (wrap ~event_type:kind ~payload ())
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -773,6 +773,67 @@ let test_oas_event_bridge_logs_tool_completed_with_agent_name () =
           raise Exit)
       with Exit -> ())
 
+(* #10584 — kind-only fallback regression pins.
+
+   The catch-all [other -> ...] arm in [native_event_to_json] sits AFTER
+   the explicit [InferenceTelemetry _ -> None].  Variant ordering matters:
+   moving the catch-all above [InferenceTelemetry] would silently start
+   relaying per-token telemetry over SSE (high-frequency flood path that
+   was deliberately suppressed in #10590).  Pin both invariants. *)
+
+let test_inference_telemetry_stays_none_after_fallback () =
+  let evt : Event_bus.event =
+    Event_bus.mk_event
+      ~correlation_id:"test-corr"
+      ~run_id:"test-run"
+      (Event_bus.InferenceTelemetry
+         {
+           agent_name = "test-agent";
+           turn = 1;
+           provider = "test-provider";
+           model = "test-model";
+           prompt_tokens = Some 10;
+           completion_tokens = Some 20;
+           prompt_ms = Some 5.0;
+           decode_ms = Some 50.0;
+           decode_tok_s = Some 100.0;
+         })
+  in
+  match Oas_event_bridge.native_event_to_json evt with
+  | None -> ()
+  | Some _ ->
+      Alcotest.fail
+        "InferenceTelemetry must remain None — catch-all fallback \
+         must not absorb the high-frequency suppression case"
+
+let test_payload_kind_labels_match_envelope_event_type () =
+  (* For the explicit-arm path, the [event_type] embedded in the wrap
+     envelope must remain a valid [Event_bus.payload_kind] result so
+     dashboards can union explicit-arm and fallback events on a single
+     [event_type] axis.  Probe one representative variant. *)
+  let evt : Event_bus.event =
+    Event_bus.mk_event
+      ~correlation_id:"test-corr"
+      ~run_id:"test-run"
+      (Event_bus.AgentStarted
+         { agent_name = "probe-agent"; task_id = "probe-task" })
+  in
+  let kind = Event_bus.payload_kind evt.payload in
+  Alcotest.(check string) "kind label" "agent_started" kind;
+  match Oas_event_bridge.native_event_to_json evt with
+  | Some (`Assoc fields) ->
+      let event_type =
+        match List.assoc_opt "event_type" fields with
+        | Some (`String value) -> value
+        | _ -> ""
+      in
+      Alcotest.(check string)
+        "envelope event_type matches payload_kind"
+        kind event_type
+  | _ ->
+      Alcotest.fail
+        "expected Some `Assoc — explicit-arm AgentStarted serialization"
+
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -811,6 +872,10 @@ let () =
         test_oas_event_bridge_logs_turn_completed_with_agent_name;
       Alcotest.test_case "sse bridge logs tool completed with agent name" `Quick
         test_oas_event_bridge_logs_tool_completed_with_agent_name;
+      Alcotest.test_case "inference telemetry stays None after fallback added (#10584)" `Quick
+        test_inference_telemetry_stays_none_after_fallback;
+      Alcotest.test_case "payload_kind labels match wrap envelope event_type" `Quick
+        test_payload_kind_labels_match_envelope_event_type;
     ];
     "message_conversion", [
       Alcotest.test_case "message roundtrip" `Quick test_message_roundtrip;


### PR DESCRIPTION
## 컨텍스트

#10584 — exhaustive match on cross-module variant breaks main on variant addition.
이슈 본문이 두 P0 victim 으로 #10490 (`InferenceTelemetry`) 과 #10574 (`Stale_turn_timeout`) 을 인용. Option B (SSOT helper) + Option C (audit script) 는 이미 land:
- `payload_kind` SSOT helper: oas#1205 MERGED (2026-04-27)
- `cohort_key` SSOT migration: #10618 MERGED
- audit script: #10989 MERGED

**잔존 부분**: `lib/oas_event_bridge.ml` 의 `native_event_to_json` 이 여전히 exhaustive — 다음 OAS variant 가 ship 되면 같은 P0 클래스 재발.

## 변경

`native_event_to_json` 끝에 `other` catch-all 추가:

```ocaml
match[@warning "-11"] evt.payload with
| (* … 14 explicit arms … *)
| Oas.Event_bus.InferenceTelemetry _ -> None  (* 명시적 SSE flood 억제 *)
| other ->
    let kind = Oas.Event_bus.payload_kind other in
    Log.Misc.warn "oas_event_bridge: kind-only fallback for unmigrated \
                   payload variant kind=%s correlation_id=%s run_id=%s"
      kind correlation_id run_id;
    let payload =
      `Assoc [
        ("kind", `String kind);
        ("note", `String "kind-only fallback; consumer not yet migrated");
      ]
    in
    Some (wrap ~event_type:kind ~payload ())
```

핵심 결정:
- **`[@warning "-11"]` 명시 suppress**: catch-all 은 현재 variant set 에 대해 unused. 의도된 future-proofing — annotation 제거 시 빌드 깨지므로 다음 작업자가 catch-all 도 같이 제거하도록 강제.
- **`payload_kind` SSOT 활용**: oas 에서 새 variant ship 시 `payload_kind` 함수 본문에 entry 추가가 강제 (warn-error +8). 따라서 fallback 의 kind label 은 항상 정확.
- **`Log.Misc.warn` per-call**: operator visibility. 미래에 high-frequency variant 가 fallback 으로 떨어지면 dedup PR 검토 필요 (out of scope).

## 의도된 trade-off

| 접근 | Pros | Cons |
|------|------|------|
| **현재 (Option B+A 하이브리드)** | 빌드 안전, kind-label 가시성, warn signal | catch-all 이 future variant 의 partial 동작 허용 (의도된 graceful degradation) |
| 대안: 그대로 exhaustive | 새 variant 강제 명시 (compile-time) | 다음 pin bump 마다 P0 |
| 대안: `_ -> "unknown"` (issue Option A) | 빌드 안전 | telemetry 데이터 silent drop, 가장 위험 |

issue 본문이 권고한 그대로의 형태.

## Pinned 테스트

`test/test_oas_integration.ml` 추가:
1. **InferenceTelemetry 가 None 유지** — `other` 가 `InferenceTelemetry _ -> None` 위에 들어가지 않는지 핀. 순서 뒤집으면 per-token telemetry 가 SSE flood (#10590 회귀).
2. **payload_kind ↔ envelope event_type 매치** — explicit-arm 인 `AgentStarted` 가 `payload_kind` 와 같은 label 을 envelope `event_type` 에 emit. 미래 fallback 채널이 explicit 채널과 동일 axis 에서 dashboard union 가능.

## 검증

- `dune build --root .` exit 0
- 새 테스트 2개 OK
- 기존 `oas_events` 테스트 16/19 OK (실패 9, 12 는 main pre-existing flake — `agent_completed` usage assertion 과 `sse retries append failure` eio cancel timing, 본 변경 무관)

## Cross-ref

- #10584 (Recurring P0 — issue)
- #10490 (P0: InferenceTelemetry build break)
- #10574 (P0: Stale_turn_timeout build break)
- #10618 (Option B: cohort_key SSOT migration — MERGED)
- #10989 (Option C: cross-module exhaustive-match audit script — MERGED)
- oas#1205 (payload_kind SSOT helper — MERGED 2026-04-27)
- MEMORY: `feedback_variant-add-partial-match-cascade.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
