### PR TITLE
chore(server): add server_mcp_transport_http_headers.mli (cycle 95)

### DIFF
--- a/lib/server/server_mcp_transport_http_headers.mli
+++ b/lib/server/server_mcp_transport_http_headers.mli
@@ -1,0 +1,184 @@
+(** Server_mcp_transport_http_headers — HTTP header builders, accept
+    negotiation, body-method classifier, and SSE constants for the
+    MCP transport.
+
+    Re-exported piecemeal by {!Server_mcp_transport_http} via
+    [let X = Server_mcp_transport_http_headers.X] bindings, so this
+    surface is the SSOT for header literals (mcp-session-id /
+    mcp-protocol-version / cookie format) and SSE constants
+    (retry-ms / ping interval).  Operator runbooks grep on these
+    literals. *)
+
+type deps = Server_mcp_transport_http_types.deps
+
+(** {1 JSON-RPC body classification} *)
+
+val is_http_error_response : Yojson.Safe.t -> bool
+(** [is_http_error_response json] returns [true] when [json] is a
+    JSON-RPC 2.0 response object with [id = null] AND [error.code]
+    in [-32700] (Parse error) / [-32600] (Invalid Request).  Used
+    to distinguish "request the server could not parse" from
+    business-logic errors when deciding whether to attach a
+    legacy-accept warning header. *)
+
+val request_runtime_result : deps -> (Server_mcp_transport_http_types.runtime, string) result
+(** [request_runtime_result deps] is a thin wrapper for
+    [deps.get_runtime_result ()] — kept as a binding so the call
+    site is greppable across the transport. *)
+
+val body_jsonrpc_method : string -> (string * bool) option
+(** [body_jsonrpc_method body_str] parses [body_str] as JSON and
+    returns [Some (method_, has_id)] when it is an [`Assoc] with a
+    [method] string field, [None] otherwise (parse failure or
+    non-object body).  [has_id] reports whether the [id] field is
+    present (used to distinguish notifications from requests). *)
+
+val is_notification_method : string -> bool
+(** [is_notification_method m] tests whether [m] starts with the
+    literal prefix [["notifications/"]].  Notifications must have
+    [has_id = false] in the JSON-RPC envelope. *)
+
+val is_initialize_method : string -> bool
+(** [is_initialize_method m] tests whether [m] equals the literal
+    [["initialize"]].  The initialize handshake must always go over
+    plain JSON, never SSE. *)
+
+(** {1 Accept-header classification}
+
+    The MCP spec mandates [Accept: application/json, text/event-stream]
+    for streamable transports.  Two opt-outs:
+
+    - [allow_legacy_accept] env flag accepts the older single-type
+      Accept headers ([application/json] alone or [text/event-stream]
+      alone).
+    - The [x-masc-force-json] request header overrides the Accept
+      negotiation entirely. *)
+
+val allow_legacy_accept : bool
+(** Cached at module-init from the [MASC_ALLOW_LEGACY_ACCEPT]
+    environment flag.  Truthy values: [1] / [true] / [yes] / [on]
+    (case-insensitive, trimmed).  Anything else is [false]. *)
+
+val classify_mcp_accept :
+  Httpun.Request.t ->
+  Mcp_transport_protocol.Http_negotiation.accept_mode
+(** [classify_mcp_accept request] reads the [accept] header and
+    returns the negotiation classification, honouring
+    {!allow_legacy_accept}. *)
+
+val classify_mcp_accept_for_body :
+  Httpun.Request.t ->
+  string ->
+  Mcp_transport_protocol.Http_negotiation.accept_mode
+(** Same as {!classify_mcp_accept} but with one upgrade path: when
+    the Accept header alone classifies as [Rejected] AND the body
+    is a notification (method starts with [notifications/], no id),
+    promote the classification to [Legacy_accepted] so notifications
+    can land even from clients that omit the streamable Accept set.
+    Notification-only relaxation, never for request-id'd calls. *)
+
+val should_use_sse_for_body :
+  Httpun.Request.t ->
+  string ->
+  Mcp_transport_protocol.Http_negotiation.accept_mode ->
+  bool
+(** [should_use_sse_for_body request body_str accept_mode] returns
+    [true] iff the response should stream over SSE.  Two
+    short-circuits to plain JSON: the body is the [initialize]
+    handshake (always JSON) OR [accept_mode <> Streamable] OR the
+    Accept header does not include [text/event-stream]. *)
+
+val request_accepts_json : Httpun.Request.t -> bool
+(** [request_accepts_json request] returns [true] iff the Accept
+    header advertises [application/json] (or wildcard). *)
+
+val request_force_json_response : Httpun.Request.t -> bool
+(** [request_force_json_response request] returns [true] iff the
+    [x-masc-force-json] header is set to a truthy value
+    ([1]/[true]/[yes]/[on], case-insensitive, trimmed).  Header
+    overrides Accept negotiation. *)
+
+val force_json_response : bool
+(** Module-init cache of [MASC_FORCE_JSON_RESPONSE] OR
+    [MCP_FORCE_JSON_RESPONSE] env flags (truthy semantics matching
+    {!allow_legacy_accept}).  Either flag forces every response to
+    plain JSON regardless of Accept negotiation. *)
+
+(** {1 Header builders} *)
+
+val mcp_headers : string -> string -> (string * string) list
+(** [mcp_headers session_id protocol_version] returns the two MCP
+    envelope headers ([mcp-session-id], [mcp-protocol-version]) in
+    fixed order for grep stability in operator dumps. *)
+
+val session_cookie_header : string -> string * string
+(** [session_cookie_header session_id] returns
+    [("set-cookie", "mcp-session-id=<id>; Path=/; Max-Age=<day>; SameSite=Lax")].
+    [Max-Age] is one day (from {!Masc_time_constants.day_int}) —
+    operators relying on shorter sessions must reset cookies via
+    a separate path. *)
+
+val sse_headers :
+  deps:deps -> string -> string -> string -> (string * string) list
+(** [sse_headers ~deps session_id protocol_version origin] returns
+    SSE response headers: [content-type] (from
+    {!Http_negotiation.sse_content_type}), {!session_cookie_header},
+    {!mcp_headers} pair, plus [deps.cors_headers origin].  Used by
+    the one-shot SSE response path. *)
+
+val sse_stream_headers :
+  deps:deps -> string -> string -> string -> (string * string) list
+(** [sse_stream_headers ~deps session_id protocol_version origin] is
+    {!sse_headers} plus [cache-control: no-cache] and
+    [connection: keep-alive].  Used for long-lived SSE streams (the
+    AG-UI bridge and the per-session event stream). *)
+
+val json_headers :
+  deps:deps -> string -> string -> string -> (string * string) list
+(** [json_headers ~deps session_id protocol_version origin] returns
+    [content-type: application/json] + {!mcp_headers} pair +
+    [deps.cors_headers origin].  The canonical "JSON response"
+    builder used by every JSON-bodied response in the transport. *)
+
+val legacy_accept_warning_headers :
+  Mcp_transport_protocol.Http_negotiation.accept_mode ->
+  (string * string) list
+(** [legacy_accept_warning_headers classification] returns a
+    [warning: 299 - "..."] + [x-masc-legacy-accept: 1] pair when the
+    classification is [Legacy_accepted], empty list otherwise.
+    The warning code 299 is RFC 7234's "miscellaneous persistent
+    warning"; the literal text steers operators to upgrade the
+    client's Accept header. *)
+
+val legacy_transport_deprecation_headers : (string * string) list
+(** Static three-header set ([deprecation: true],
+    [warning: 299 - "..."], [link: </mcp>; rel="successor-version"])
+    for the legacy SSE endpoints ([/sse], [/messages]) which are
+    being phased out in favour of the unified [/mcp] path. *)
+
+(** {1 SSE constants} *)
+
+val sse_retry_ms : int
+(** Pinned at [3000] (3 seconds).  The [retry:] field in SSE prime
+    events tells the EventSource client how long to wait before
+    reconnecting after a transport error.  3 s balances transient-
+    glitch recovery against tight-loop reconnect storms. *)
+
+val sse_prime_event : unit -> string
+(** [sse_prime_event ()] returns the SSE prime frame
+    [["retry: <sse_retry_ms>\nid: <next>\n\n"]] with a fresh id
+    from {!Sse.next_id}.  The trailing double-newline is the SSE
+    frame terminator — required by the spec. *)
+
+val sse_ping_interval_s : float
+(** Pinned at [30.0] seconds.  Ping fibers use this interval to
+    write the SSE comment frame [": ping\n\n"] so middleboxes do
+    not idle out the connection.  Matches the same constant
+    duplicated in {!Server_mcp_transport_http_agui} (the duplicate
+    is intentional — see that module's contract). *)
+
+val get_last_event_id : Httpun.Request.t -> int option
+(** [get_last_event_id request] reads the [last-event-id] header
+    and parses it as an integer.  Returns [None] when the header
+    is absent or non-integer.  Used to drive event replay on SSE
+    reconnect. *)


### PR DESCRIPTION
## Summary

Cycle 95 — adds an explicit interface for
`lib/server/server_mcp_transport_http_headers.ml` (156 lines).

## Surface (24 entries, 3 hide)

The module is the SSOT for MCP HTTP transport header literals
and SSE constants. {!Server_mcp_transport_http} re-exports ~10
bindings via `let X = Server_mcp_transport_http_headers.X`,
plus sister modules (`_agui`, `_protocol`, `_respond`) reach
specific helpers directly.

```ocaml
type deps = Server_mcp_transport_http_types.deps

(* Body classification *)
val is_http_error_response, body_jsonrpc_method
val is_notification_method, is_initialize_method
val request_runtime_result

(* Accept negotiation *)
val allow_legacy_accept (env-cached bool)
val classify_mcp_accept, classify_mcp_accept_for_body
val should_use_sse_for_body
val request_accepts_json, request_force_json_response
val force_json_response (env-cached bool)

(* Header builders *)
val mcp_headers, session_cookie_header
val sse_headers, sse_stream_headers, json_headers
val legacy_accept_warning_headers
val legacy_transport_deprecation_headers

(* SSE constants *)
val sse_retry_ms (= 3000)
val sse_prime_event
val sse_ping_interval_s (= 30.0)
val get_last_event_id
```

Hidden: `module Http`, `module Http_negotiation` (internal
aliases), `env_flag`, `header_truthy_value` (truthy parsers).

## Operator-visible literals pinned

| Literal | Used by |
|---|---|
| `mcp-session-id` / `mcp-protocol-version` (fixed order) | Every response |
| `mcp-session-id=<id>; Path=/; Max-Age=<day>; SameSite=Lax` | Cookie header |
| Warning code `299` | RFC 7234 misc-persistent (legacy-accept) |
| `deprecation: true` + `link: </mcp>; rel="successor-version"` | `/sse` + `/messages` legacy paths |
| `sse_retry_ms = 3000` (3 s) | Transient-recovery vs reconnect-storm balance |
| `sse_ping_interval_s = 30.0` | Matches duplicate in `_agui` (intentional) |

## classify_mcp_accept_for_body upgrade path

When Accept alone classifies as `Rejected` AND the body is a
**notification** (method starts with `notifications/`, no `id`),
the classification is promoted to `Legacy_accepted` so
notifications can land even from clients that omit the
streamable Accept set. Notification-only relaxation, never for
request-id'd calls.

## should_use_sse_for_body short-circuits

| Condition | Result |
|---|---|
| Body is `initialize` handshake | Plain JSON (always) |
| `accept_mode <> Streamable` | Plain JSON |
| Accept lacks `text/event-stream` | Plain JSON |
| Otherwise | SSE |

## Caller audit
- `lib/server/server_mcp_transport_http.ml` — 9 re-exported bindings
- `lib/server/server_mcp_transport_http_agui.ml` — `sse_stream_headers`
- `lib/server/server_mcp_transport_http_protocol.ml` —
  `is_http_error_response`
- `lib/server/server_mcp_transport_http_respond.ml` —
  `json_headers` / `mcp_headers`

No external reference to `Http` / `Http_negotiation` modules or
`env_flag` / `header_truthy_value` helpers.

## Test plan
- [x] `dune build --root . lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
