### PR TITLE
chore(meta-cognition): add meta_cognition_parse.mli (cycle 96)

### DIFF
--- a/lib/meta_cognition_parse.mli
+++ b/lib/meta_cognition_parse.mli
@@ -1,0 +1,55 @@
+(** Meta_cognition_parse — JSON parsing for summary data.
+
+    Parses the compact summary JSON produced by
+    [Meta_cognition_format.summary_json] back into typed OCaml
+    records for programmatic interpretation.
+
+    {!Meta_cognition} re-exports {!parse_summary} via
+    [include Meta_cognition_parse], so the parent module's .mli
+    declares it.  Hiding {!parse_summary} would break the parent
+    contract — same calculus as cycle 76 / 89.
+
+    All other helpers (per-sub-summary parsers,
+    [`String / `Int / `Float / `Bool / `List` extractors]) stay
+    private.  Hiding the extractors specifically is a fence:
+    operator-visible JSON parsing must always go through
+    {!parse_summary}, never through ad-hoc per-field re-implementations
+    that could drift on the empty-string-as-None convention.
+
+    @since God file decomposition — extracted from
+    meta_cognition.ml *)
+
+val parse_summary :
+  Yojson.Safe.t ->
+  (Meta_cognition_types.summary_input, string) result
+(** [parse_summary json] decodes the summary JSON object into a
+    {!Meta_cognition_types.summary_input}.
+
+    {2 Required fields}
+
+    Top-level integer fields are required; missing or non-integer
+    triggers an error:
+    - [belief_count] -> ["summary.belief_count missing or invalid"]
+    - [contested_belief_count] ->
+      ["summary.contested_belief_count missing or invalid"]
+
+    {2 Optional fields}
+
+    [stagnation_score] defaults to [0.0] when absent or non-numeric
+    (intentional — older snapshots predate the field).  The three
+    sub-summaries ([dominant_belief], [top_tension], [top_desire])
+    each accept [`Null] (returns the all-[None] / empty-list
+    record) or an [`Assoc _] object; any other shape returns
+    [Error] with the per-summary error wording (e.g.
+    ["dominant_belief must be an object"]).
+
+    {2 Empty-string-as-None convention}
+
+    Every string field is parsed through a trim-then-empty-check
+    pass: an empty string after trimming is read as [None].  This
+    matches the cross-module Null-vs-missing pattern (cycle 69
+    [telemetry_coverage_gap], cycle 76 [meta_cognition_digest],
+    cycle 81 [discovery_cache], cycle 82
+    [dashboard_tool_source_freshness]).  A future "let's preserve
+    empty strings" change must touch this contract explicitly so
+    dashboard consumers stay consistent. *)


### PR DESCRIPTION
## Summary

Cycle 96 — adds an explicit interface for
`lib/meta_cognition_parse.ml` (163 lines).

Completes the meta-cognition .mli trio (digest cycle 76,
interpret cycle 89, parse cycle 96).

## Surface (1 entry, 9 hide)

```ocaml
val parse_summary :
  Yojson.Safe.t ->
  (Meta_cognition_types.summary_input, string) result
```

Hidden internals (9):
- `json_string_opt` — `String trim → empty-as-None
- `json_int_opt` — `Int + `Intlit
- `json_float_opt` — `Float + `Int + `Intlit
- `json_bool_opt` — `Bool only
- `json_string_list_opt` — `List filter_map + unique_non_empty
- `parse_belief_summary`, `parse_tension_summary`,
  `parse_desire_summary` — per-sub-summary parsers
- `parse_optional_summary` — parse-or-Null wrapper

## Why parse_summary must stay exposed

`lib/meta_cognition.ml` does `include Meta_cognition_parse` and
`lib/meta_cognition.mli` declares `parse_summary`. Hiding would
break the parent contract — same calculus as cycle 76 (#11656)
and cycle 89.

## Why hide all 5 JSON extractors

The hidden 5 JSON extractors are an intentional fence: operator-
visible JSON parsing must always go through `parse_summary`,
never through ad-hoc per-field re-implementations that could
drift on the **empty-string-as-None** convention.

## Required-field error wording pinned

| Trigger | Error message |
|---|---|
| `belief_count` missing or non-int | `summary.belief_count missing or invalid` |
| `contested_belief_count` missing or non-int | `summary.contested_belief_count missing or invalid` |
| `dominant_belief` neither Assoc nor Null | `dominant_belief must be an object` |
| `top_tension` neither Assoc nor Null | `top_tension must be an object` |
| `top_desire` neither Assoc nor Null | `top_desire must be an object` |

## stagnation_score default

Defaults to `0.0` when absent or non-numeric. **Intentional** —
older snapshots predate the field, and treating them as
non-stagnant is the correct backward-compat behaviour.

## Cross-module Null-vs-missing convention

Empty-string-as-None preserves the pattern established in
cycle 69 (`telemetry_coverage_gap`), cycle 76
(`meta_cognition_digest`), cycle 81 (`discovery_cache`), and
cycle 82 (`dashboard_tool_source_freshness`). A future "preserve
empty strings" change must touch this contract explicitly so
dashboard consumers stay consistent.

## Caller audit
- `lib/meta_cognition.ml` — `include Meta_cognition_parse`
- `lib/meta_cognition.mli` — declares `parse_summary`
- (no direct `Meta_cognition_parse.X` callers — all flow through
  `Meta_cognition.parse_summary` via the include)

No external reference to the 9 hidden helpers.

## Test plan
- [x] `dune build --root . lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
