### PR TITLE
feat(keeper): wire [@@fsm_guard] to KeeperHeartbeat actions (Cycle 43)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -549,6 +549,7 @@
    keeper_unified_metrics
    keeper_spec_intf
    keeper_turn_fsm
+   keeper_fsm_guard_runtime
    keeper_turn_livelock
    keeper_stay_silent_loop_detector
    keeper_error_classify

--- a/lib/keeper/keeper_fsm_guard_runtime.ml
+++ b/lib/keeper/keeper_fsm_guard_runtime.ml
@@ -1,0 +1,33 @@
+(* Runtime safety wrapper for [@@fsm_guard]-bearing identity helpers.
+
+   See keeper_fsm_guard_runtime.mli for the contract. *)
+
+let policy_assert_mode = ref None
+
+let read_assert_env () =
+  match Sys.getenv_opt "MASC_FSM_GUARD_ASSERT" with
+  | Some "1" | Some "true" | Some "TRUE" -> true
+  | _ -> false
+
+let assert_mode () =
+  match !policy_assert_mode with
+  | Some v -> v
+  | None ->
+      let v = read_assert_env () in
+      policy_assert_mode := Some v;
+      v
+
+let refresh_policy_for_test () = policy_assert_mode := None
+let assert_mode_for_test () = assert_mode ()
+
+let bump_counter ~action ~stage =
+  Prometheus.inc_counter Prometheus.metric_fsm_guard_violation
+    ~labels:[ ("action", action); ("stage", stage) ]
+    ()
+
+let wrap_unit ~action ~stage thunk =
+  let hard = assert_mode () in
+  try thunk ()
+  with Assert_failure _ as exn ->
+    bump_counter ~action ~stage;
+    if hard then raise exn else ()

--- a/lib/keeper/keeper_fsm_guard_runtime.mli
+++ b/lib/keeper/keeper_fsm_guard_runtime.mli
@@ -1,0 +1,36 @@
+(** Runtime safety wrapper for [@@fsm_guard]-bearing identity helpers.
+
+    Cycle 43 / Tier I3 follow-up to the smoke test at
+    [keeper_turn_fsm.ml:118] (PR #11377 era). The PPX
+    [@@fsm_guard "<bool-expr>"] injects [assert (<bool-expr>);] into
+    the function body. On the heartbeat / task-acquisition hot paths
+    that fire every cycle, raising [Assert_failure] would crash the
+    keeper on a transient drift — undesirable in production but
+    desirable in tests.
+
+    [wrap_unit] runs a [unit -> unit] thunk under that contract:
+    catches [Assert_failure], bumps the
+    [Prometheus.metric_fsm_guard_violation] counter labelled with
+    [action] / [stage], and either swallows the failure (default,
+    "counter mode") or re-raises ([MASC_FSM_GUARD_ASSERT=1], "assert
+    mode" — for tests, smoke runs, and CI).
+
+    The thunk is expected to call an identity helper of return type
+    [unit] (a function whose only purpose is to carry the
+    [@@fsm_guard] attribute). Non-[Assert_failure] exceptions
+    propagate unchanged — only the spec-violation channel is
+    intercepted. *)
+
+val wrap_unit :
+  action:string ->
+  stage:string ->
+  (unit -> unit) ->
+  unit
+
+(** Force a re-read of [MASC_FSM_GUARD_ASSERT] for tests that need to
+    flip the policy mid-run. Production code never calls this. *)
+val refresh_policy_for_test : unit -> unit
+
+(** Inspect the cached policy. [true] iff [MASC_FSM_GUARD_ASSERT=1] at
+    module init or after [refresh_policy_for_test]. *)
+val assert_mode_for_test : unit -> bool

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -579,6 +579,50 @@ let format_since_last_scheduled_autonomous = function
   | Some s -> string_of_int s
   | None -> "-"
 
+(* ── KeeperHeartbeat.tla spec-action runtime guards (Cycle 43) ────────
+
+   Identity helpers carrying [@@fsm_guard] payloads that mirror the
+   honest actions of [specs/keeper-state-machine/KeeperHeartbeat.tla].
+   Each helper is wrapped at the call site by
+   [Keeper_fsm_guard_runtime.wrap_unit], so an [Assert_failure] from a
+   PPX-injected guard becomes a Prometheus counter increment by default
+   (counter mode) and a re-raise when [MASC_FSM_GUARD_ASSERT=1]
+   (assert mode for tests / CI). The bug-action [MissedWakeup] is
+   intentionally NOT instrumented — it is the failure mode these guards
+   are designed to detect, not to enforce. *)
+
+(* Heartbeat turn lifecycle flag, mirroring KeeperHeartbeat.tla's
+   [turn_state] in the {"idle", "running"} alphabet. Read inside
+   identity helpers; written by the caller around [run_heartbeat_loop]
+   and the dispatch sites. Single-fiber by construction — only the
+   keeper's own heartbeat loop touches its [turn_running] ref. *)
+let pre_turn_complete_heartbeat ~(turn_running : bool ref) = ignore turn_running
+  [@@fsm_guard "!turn_running = true"]
+
+let post_turn_complete_heartbeat ~(turn_running : bool ref) = ignore turn_running
+  [@@fsm_guard "!turn_running = false"]
+
+(* WakeupSignal: external code sets the wakeup atomic to TRUE. Spec
+   says the post-condition is [wakeup_signaled = TRUE]. The OCaml
+   [Atomic.set] is idempotent so the assert is trivially true on the
+   honest path; the guard catches a regression where someone replaces
+   [Atomic.set ... true] with [Atomic.set ... false] or forgets the
+   set entirely. *)
+let post_wakeup_signal ~(wakeup : bool Atomic.t) = ignore wakeup
+  [@@fsm_guard "Atomic.get wakeup = true"]
+
+(* HeartbeatTick: the [compare_and_set wakeup true false] in
+   [interruptible_sleep] succeeded — wakeup transitioned TRUE -> FALSE
+   and the sleep returned so the loop can dispatch. Spec post-condition
+   is [wakeup_signaled = FALSE]. False-positive risk: a producer that
+   re-sets the atomic to TRUE between the CAS and this read would make
+   the guard fire. The [interruptible_sleep] body is single-fiber and
+   the only producer is external, so the window is one tick and the
+   counter signal is operationally meaningful — a non-zero count means
+   producers are racing the consumer, which is itself a bug class. *)
+let post_heartbeat_tick ~(wakeup : bool Atomic.t) = ignore wakeup
+  [@@fsm_guard "Atomic.get wakeup = false"]
+
 (** Sleep in short chunks so [stop_keepalive] or [wakeup_keeper] takes
     effect within ~chunk_sec instead of waiting for the full interval. *)
 let interruptible_sleep ~clock ~stop ~wakeup duration =
@@ -593,7 +637,12 @@ let interruptible_sleep ~clock ~stop ~wakeup duration =
               that this branch returns immediately so the surrounding
               loop can re-enter and dispatch on next tick. *)
             Atomic.compare_and_set wakeup true false
-    then ()
+    then
+      (* Cycle 43: post-action guard mirrors the spec's [wakeup_signaled =
+         FALSE] postcondition. Counter-mode by default. *)
+      Keeper_fsm_guard_runtime.wrap_unit
+        ~action:"HeartbeatTick" ~stage:"post"
+        (fun () -> post_heartbeat_tick ~wakeup)
     else if remaining <= 0.0
     then ()
     else (
@@ -1875,6 +1924,9 @@ let run_heartbeat_loop
   in
   let last_snapshot_ts = ref 0.0 in
   let consecutive_failures = ref 0 in
+  (* Cycle 43: KeeperHeartbeat.tla [turn_state] mirror. Single-fiber by
+     construction — only this loop body reads/writes the ref. *)
+  let turn_running = ref false in
   (* Phase 0: per-stage timing ring buffer.
      ring_size is read once at fiber start — mid-flight resize requires
      ring buffer reallocation, so new values apply on next fiber restart. *)
@@ -2018,13 +2070,28 @@ let run_heartbeat_loop
         let t_board_end = Time_compat.now () in
         let t_turn_start = t_board_end in
         let meta_after_proactive =
-          run_keepalive_unified_turn
-            ~ctx
-            ~meta_after_triage
-            ~pending_board_events
-            ~stop
-            ~proactive_warmup_elapsed
-            ~shared_context
+          (* Cycle 43: KeeperHeartbeat.tla TurnComplete bracket — the
+             [turn_running] flag toggles around the dispatch and the
+             pre/post guards mirror the spec's [turn_state] transition
+             "running" -> "idle". *)
+          turn_running := true;
+          let r =
+            run_keepalive_unified_turn
+              ~ctx
+              ~meta_after_triage
+              ~pending_board_events
+              ~stop
+              ~proactive_warmup_elapsed
+              ~shared_context
+          in
+          Keeper_fsm_guard_runtime.wrap_unit
+            ~action:"TurnComplete" ~stage:"pre"
+            (fun () -> pre_turn_complete_heartbeat ~turn_running);
+          turn_running := false;
+          Keeper_fsm_guard_runtime.wrap_unit
+            ~action:"TurnComplete" ~stage:"post"
+            (fun () -> post_turn_complete_heartbeat ~turn_running);
+          r
         in
         (* Turn failure threshold: registry tracks count (via unified_turn),
                  keepalive raises to terminate the fiber for supervisor restart. *)
@@ -2180,7 +2247,13 @@ let set_keeper_paused_state ~agent_name paused =
             (if paused
              then Keeper_state_machine.Operator_pause
              else Keeper_state_machine.Operator_resume));
-       if not paused then Atomic.set entry.fiber_wakeup true)
+       if not paused then begin
+         Atomic.set entry.fiber_wakeup true;
+         (* Cycle 43: KeeperHeartbeat.tla WakeupSignal post-condition. *)
+         Keeper_fsm_guard_runtime.wrap_unit
+           ~action:"WakeupSignal" ~stage:"post"
+           (fun () -> post_wakeup_signal ~wakeup:entry.fiber_wakeup)
+       end)
 ;;
 
 let wakeup_keeper_by_agent_name ~agent_name =
@@ -2682,6 +2755,13 @@ let stop_keepalive ?base_path name =
     (fun (entry : Keeper_registry.registry_entry) ->
        Atomic.set entry.fiber_stop true;
        Atomic.set entry.fiber_wakeup true;
+       (* Cycle 43: KeeperHeartbeat.tla WakeupSignal post-condition fires
+          even on stop_keepalive — the wakeup atomic must be observable
+          as TRUE before the heartbeat fiber consumes its termination
+          signal. *)
+       Keeper_fsm_guard_runtime.wrap_unit
+         ~action:"WakeupSignal" ~stage:"post"
+         (fun () -> post_wakeup_signal ~wakeup:entry.fiber_wakeup);
        (match Atomic.get entry.grpc_close with
        | Some close_fn ->
           (try close_fn () with

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -619,6 +619,7 @@ let metric_keeper_fsm_edge_transitions =
   "masc_keeper_fsm_edge_transitions_total"
 let metric_keeper_turn_fsm_transitions =
   "masc_keeper_turn_fsm_transitions_total"
+let metric_fsm_guard_violation = "masc_fsm_guard_violation_total"
 let metric_keeper_lifecycle_callback_failures =
   "masc_keeper_lifecycle_callback_failures_total"
 let metric_keeper_event_bus_drain = "masc_keeper_event_bus_drain_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -289,6 +289,28 @@ val metric_keeper_fsm_edge_transitions : string
     keepers = ≤ 1600 series; reachable subset is much smaller. *)
 val metric_keeper_turn_fsm_transitions : string
 
+(** Cycle 43 (Tier I3 follow-up to fsm_guard smoke at
+    [keeper_turn_fsm.ml:118]): runtime [@@fsm_guard] assert violations
+    that the [Keeper_fsm_guard_runtime.wrap_unit] caught and recovered
+    from. Bumped by the wrap helper before swallowing
+    [Assert_failure] in counter mode (default), and also bumped before
+    re-raising in assert mode ([MASC_FSM_GUARD_ASSERT=1]).
+
+    Labels: [action, stage]. [action] is the spec-action name
+    ([WakeupSignal], [HeartbeatTick], [TurnComplete],
+    [SubmitTask], [AssignTask], [EmptyQueueSleep]). [stage] is
+    [pre] or [post].
+
+    Operator signal: a non-zero value on any [action,stage] pair
+    indicates the OCaml runtime drifted from the
+    [specs/keeper-state-machine/Keeper{Heartbeat,TaskAcquisition}.tla]
+    contract. The first violation per pair should trigger spec/code
+    reconciliation review.
+
+    Cardinality upper bound: ~7 actions × 2 stages × ~16 keepers
+    ≤ 224 series; fleet-bounded. *)
+val metric_fsm_guard_violation : string
+
 (** PR-J: post-turn lifecycle callbacks raised exceptions that were
     silently swallowed before this counter existed. Labels: [callback]
     with values:

--- a/test/dune
+++ b/test/dune
@@ -106,6 +106,7 @@
         test_decision_pipeline_observer
         test_keeper_composite_observer
         test_keeper_fsm_edges
+        test_keeper_fsm_guard_actions
         test_keeper_callback_hardening
         test_keeper_behavioral_regime
         test_keeper_toml
@@ -284,6 +285,7 @@
           test_decision_pipeline_observer
           test_keeper_composite_observer
           test_keeper_fsm_edges
+          test_keeper_fsm_guard_actions
           test_keeper_callback_hardening
           test_keeper_behavioral_regime
           test_keeper_toml

--- a/test/test_keeper_fsm_guard_actions.ml
+++ b/test/test_keeper_fsm_guard_actions.ml
@@ -1,0 +1,146 @@
+(** test_keeper_fsm_guard_actions — verify the runtime safety wrapper
+    [Keeper_fsm_guard_runtime.wrap_unit] used by KeeperHeartbeat /
+    KeeperTaskAcquisition spec-action guards.
+
+    The PPX [@@fsm_guard] itself is exercised by the smoke test at
+    [keeper_turn_fsm.ml:118] (Cycle 12 / Tier I3); this file pins the
+    surrounding policy contract:
+
+    1. The Prometheus counter constant matches the documented series.
+    2. An honest thunk (no assert raised) leaves the counter alone.
+    3. A buggy thunk (raises [Assert_failure], simulating a PPX-injected
+       guard that observed a spec violation) bumps the counter by one
+       and is swallowed by default (counter mode).
+    4. With [MASC_FSM_GUARD_ASSERT=1], the same buggy thunk re-raises
+       after bumping the counter (assert mode for tests / CI).
+    5. Non-[Assert_failure] exceptions propagate unchanged — only the
+       spec-violation channel is intercepted. *)
+
+module P = Masc_mcp.Prometheus
+module G = Masc_mcp.Keeper_fsm_guard_runtime
+
+let counter_name = P.metric_fsm_guard_violation
+
+let read_count ~action ~stage =
+  P.metric_value_or_zero counter_name
+    ~labels:[ ("action", action); ("stage", stage) ]
+    ()
+
+let test_counter_constant_is_stable () =
+  Alcotest.(check string)
+    "metric name matches the documented Prometheus series"
+    "masc_fsm_guard_violation_total"
+    counter_name
+
+let test_honest_thunk_leaves_counter_alone () =
+  Unix.putenv "MASC_FSM_GUARD_ASSERT" "";
+  G.refresh_policy_for_test ();
+  let action = "TestAction" in
+  let stage = "honest" in
+  let before = read_count ~action ~stage in
+  G.wrap_unit ~action ~stage (fun () -> ());
+  let after = read_count ~action ~stage in
+  Alcotest.(check (float 0.0001))
+    "honest thunk does not bump the counter"
+    before after
+
+let test_buggy_thunk_in_counter_mode_swallows_and_bumps () =
+  Unix.putenv "MASC_FSM_GUARD_ASSERT" "";
+  G.refresh_policy_for_test ();
+  let action = "TestAction" in
+  let stage = "buggy_counter" in
+  let before = read_count ~action ~stage in
+  (* Should not raise — the wrapper catches Assert_failure. *)
+  G.wrap_unit ~action ~stage (fun () -> assert false);
+  let after = read_count ~action ~stage in
+  Alcotest.(check (float 0.0001))
+    "Assert_failure is caught and counter bumped by one"
+    (before +. 1.0) after
+
+let test_buggy_thunk_in_assert_mode_reraises () =
+  Unix.putenv "MASC_FSM_GUARD_ASSERT" "1";
+  G.refresh_policy_for_test ();
+  Alcotest.(check bool)
+    "policy is now assert mode"
+    true (G.assert_mode_for_test ());
+  let action = "TestAction" in
+  let stage = "buggy_assert" in
+  let before = read_count ~action ~stage in
+  (* Should raise — assert mode bumps then re-raises. *)
+  let raised =
+    try
+      G.wrap_unit ~action ~stage (fun () -> assert false);
+      false
+    with Assert_failure _ -> true
+  in
+  let after = read_count ~action ~stage in
+  Alcotest.(check bool)
+    "Assert_failure propagates in assert mode"
+    true raised;
+  Alcotest.(check (float 0.0001))
+    "counter is bumped before re-raise"
+    (before +. 1.0) after;
+  (* Restore counter mode for any subsequent tests. *)
+  Unix.putenv "MASC_FSM_GUARD_ASSERT" "";
+  G.refresh_policy_for_test ()
+
+let test_non_assert_exception_propagates_unchanged () =
+  Unix.putenv "MASC_FSM_GUARD_ASSERT" "";
+  G.refresh_policy_for_test ();
+  let action = "TestAction" in
+  let stage = "non_assert" in
+  let before = read_count ~action ~stage in
+  let raised =
+    try
+      G.wrap_unit ~action ~stage (fun () -> failwith "domain error");
+      false
+    with Failure _ -> true
+  in
+  let after = read_count ~action ~stage in
+  Alcotest.(check bool)
+    "Failure propagates without being swallowed"
+    true raised;
+  Alcotest.(check (float 0.0001))
+    "counter is NOT bumped for non-Assert_failure exceptions"
+    before after
+
+let test_distinct_action_label_isolation () =
+  Unix.putenv "MASC_FSM_GUARD_ASSERT" "";
+  G.refresh_policy_for_test ();
+  let stage = "iso" in
+  let action_a = "ActionA" in
+  let action_b = "ActionB" in
+  let a_before = read_count ~action:action_a ~stage in
+  let b_before = read_count ~action:action_b ~stage in
+  G.wrap_unit ~action:action_a ~stage (fun () -> assert false);
+  let a_after = read_count ~action:action_a ~stage in
+  let b_after = read_count ~action:action_b ~stage in
+  Alcotest.(check (float 0.0001))
+    "action A counter bumped"
+    (a_before +. 1.0) a_after;
+  Alcotest.(check (float 0.0001))
+    "action B counter unchanged when only A is exercised"
+    b_before b_after
+
+let () =
+  let open Alcotest in
+  run "keeper_fsm_guard_actions" [
+    "metric constant", [
+      test_case "name matches documented series" `Quick
+        test_counter_constant_is_stable;
+    ];
+    "counter mode (default)", [
+      test_case "honest thunk does not bump" `Quick
+        test_honest_thunk_leaves_counter_alone;
+      test_case "buggy thunk swallows + bumps" `Quick
+        test_buggy_thunk_in_counter_mode_swallows_and_bumps;
+      test_case "non-assert exception propagates" `Quick
+        test_non_assert_exception_propagates_unchanged;
+      test_case "action label isolation" `Quick
+        test_distinct_action_label_isolation;
+    ];
+    "assert mode (MASC_FSM_GUARD_ASSERT=1)", [
+      test_case "buggy thunk re-raises after bumping" `Quick
+        test_buggy_thunk_in_assert_mode_reraises;
+    ];
+  ]


### PR DESCRIPTION
## 요약

`[@@fsm_guard]` PPX 사용을 `keeper_turn_fsm.ml:118`의 single smoke test에서 **KeeperHeartbeat.tla 4 액션의 honest 3개**(WakeupSignal, HeartbeatTick, TurnComplete)로 확장. spec과 OCaml 런타임 사이의 drift를 자동 감지하기 위함.

Bug-action `MissedWakeup`은 **의도적으로 instrument하지 않음** — 이 guard들이 잡으려는 failure mode이지 enforce하려는 동작이 아님.

## 배경

`specs/keeper-state-machine/KeeperHeartbeat.tla` (Cycle 7 / Tier B1, PR #11408)는 이미 작성·tla-check.sh wired·OCaml anchor 주석 부착됨. 그러나 spec과 코드는 anchor 주석으로만 연결되어 spec drift를 감지할 런타임 신호가 없었음. PR은 그 격차를 메움.

Plan 문서: [`planning/claude-plans/20m-post-merge-improvement-assessment-wise-valiant.md`](https://github.com/jeong-sik/me/blob/main/planning/claude-plans/20m-post-merge-improvement-assessment-wise-valiant.md)

## 설계 결정

**PPX 본체 미변경**. 현재 `[@@fsm_guard "<bool-expr>"]` 단일 boolean expression 지원으로 충분 — 액션마다 **`unit`-반환 identity helper**를 도입해 호출 경계에 `assert (...);`을 박는 패턴.

**Counter-by-default + opt-in assert**. 새 `keeper_fsm_guard_runtime` 모듈이 `Assert_failure`를 try/with로 감싸 `masc_fsm_guard_violation_total{action,stage}` Prometheus counter만 증가시킴 (production 안전). `MASC_FSM_GUARD_ASSERT=1` 환경변수일 때만 re-raise — tests / CI 용.

근거: heartbeat tick은 ~5초마다 호출되므로 transient drift로 production keeper crash는 부적절. 사용자 메모리 `feedback_no-arbitrary-max-tokens-lowering.md` 원칙과 동일 — algo 파라미터가 아닌 단일 boolean kill switch.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/keeper/keeper_fsm_guard_runtime.{ml,mli}` | 신규. `wrap_unit : action:string -> stage:string -> (unit -> unit) -> unit` |
| `lib/keeper/keeper_keepalive.ml` | helper 4개 + wrap 호출처 4곳 (`:589`, `:2183`, `:2643` (turn bracket), `:2684`) |
| `lib/prometheus.{ml,mli}` | `metric_fsm_guard_violation = "masc_fsm_guard_violation_total"` 등록 |
| `lib/dune` | modules 리스트에 `keeper_fsm_guard_runtime` 추가 |
| `test/test_keeper_fsm_guard_actions.ml` | 신규. counter mode / assert mode / non-assert exception / action label isolation 검증 |
| `test/dune` | 두 블록(names, modules) 모두 등록 |

## 검증

- `dune build lib/` green
- 새 unit suite `test_keeper_fsm_guard_actions`: **6/6 pass** (격리된 build dir에서)
- counter-mode swallow + bump 검증
- assert-mode re-raise after bump 검증
- non-`Assert_failure` exception propagation 검증
- action label isolation 검증
- spec 자체는 변경 없음 — `KeeperHeartbeat.tla` / `KeeperTaskAcquisition.tla` 모두 그대로
- CI에서 전체 `tla-check.sh` + `dune runtest` 자동 검증

## 후속

- **PR 2 (Phase B)**: KeeperTaskAcquisition.tla 4 액션 (SubmitTask, AssignTask, TurnComplete, EmptyQueueSleep) wiring. 본 PR의 `keeper_fsm_guard_runtime` 모듈 재사용.
- **PR 3 (Phase C)**: `tla-check.sh`에 `[@@fsm_guard]` 페이로드 parse step + `MASC_FSM_GUARD_ASSERT=1` CI job.

## Operator signal

production에서 1주일간 `metric_fsm_guard_violation{action,stage}` 0 유지를 확인하면 PR 2 진행. 비-0 값은 OCaml 런타임이 spec 의미에서 drift했음을 의미하며 reconciliation review가 필요.

## Out of scope

- PPX `ppx_tla.ml` 본체 확장 (richer payload)
- `try_<action>` 리팩토링 (sitrep "C1 Phase 1 예정")
- 9개 spec → KeeperCompositeLifecycle 통합

🤖 Generated with [Claude Code](https://claude.com/claude-code)