### PR TITLE
feat(design-system): FocusScope — RFC 0001 impl-3 (headless-core)

### DIFF
--- a/dashboard/design-system/headless-core/focus-scope.test.ts
+++ b/dashboard/design-system/headless-core/focus-scope.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createFocusScope } from './focus-scope'
+
+describe('createFocusScope', () => {
+  let container: HTMLElement
+  let outsideButton: HTMLButtonElement
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    outsideButton = document.createElement('button')
+    outsideButton.textContent = 'outside'
+    outsideButton.id = 'outside'
+    document.body.appendChild(outsideButton)
+
+    container = document.createElement('div')
+    container.id = 'scope'
+    container.tabIndex = -1
+    container.innerHTML = `
+      <button id="b1">first</button>
+      <input id="i1" />
+      <a href="#" id="a1">link</a>
+      <button id="b2" disabled>disabled</button>
+      <button id="b3">last</button>
+    `
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('tabbables() collects focusable descendants in DOM order, skipping disabled', () => {
+    const scope = createFocusScope({ containerRef: () => container })
+    const ids = scope.tabbables().map((el) => el.id)
+    expect(ids).toEqual(['b1', 'i1', 'a1', 'b3'])
+  })
+
+  it('tabbables() skips elements with tabindex="-1"', () => {
+    container.querySelector('#i1')!.setAttribute('tabindex', '-1')
+    const scope = createFocusScope({ containerRef: () => container })
+    expect(scope.tabbables().map((el) => el.id)).toEqual(['b1', 'a1', 'b3'])
+  })
+
+  it('activate() with initialFocus="first" focuses the first tabbable', () => {
+    const scope = createFocusScope({ containerRef: () => container })
+    scope.activate()
+    expect(document.activeElement?.id).toBe('b1')
+  })
+
+  it('activate() with initialFocus="container" focuses the container itself', () => {
+    const scope = createFocusScope({
+      containerRef: () => container,
+      initialFocus: 'container',
+    })
+    scope.activate()
+    expect(document.activeElement?.id).toBe('scope')
+  })
+
+  it('activate() with initialFocus function uses the returned element', () => {
+    const scope = createFocusScope({
+      containerRef: () => container,
+      initialFocus: () => container.querySelector<HTMLElement>('#a1'),
+    })
+    scope.activate()
+    expect(document.activeElement?.id).toBe('a1')
+  })
+
+  it('deactivate() restores focus to the element focused before activate()', () => {
+    outsideButton.focus()
+    expect(document.activeElement?.id).toBe('outside')
+    const scope = createFocusScope({ containerRef: () => container })
+    scope.activate()
+    expect(document.activeElement?.id).toBe('b1')
+    scope.deactivate()
+    expect(document.activeElement?.id).toBe('outside')
+  })
+
+  it('deactivate() with restoreFocus=false leaves focus where it lands', () => {
+    outsideButton.focus()
+    const scope = createFocusScope({
+      containerRef: () => container,
+      restoreFocus: false,
+    })
+    scope.activate()
+    expect(document.activeElement?.id).toBe('b1')
+    scope.deactivate()
+    expect(document.activeElement?.id).toBe('b1') // not restored
+  })
+
+  it('Tab on the last tabbable cycles to the first when loop=true (default)', () => {
+    const scope = createFocusScope({ containerRef: () => container })
+    scope.activate()
+    scope.focusLast()
+    expect(document.activeElement?.id).toBe('b3')
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
+    )
+    expect(document.activeElement?.id).toBe('b1')
+    scope.deactivate()
+  })
+
+  it('Shift+Tab on the first tabbable cycles to the last when loop=true', () => {
+    const scope = createFocusScope({ containerRef: () => container })
+    scope.activate()
+    expect(document.activeElement?.id).toBe('b1')
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }),
+    )
+    expect(document.activeElement?.id).toBe('b3')
+    scope.deactivate()
+  })
+
+  it('loop=false leaves Tab to the browser default (no preventDefault, no manual cycle)', () => {
+    const scope = createFocusScope({
+      containerRef: () => container,
+      loop: false,
+    })
+    scope.activate()
+    scope.focusLast()
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
+    )
+    // Without loop, manual cycle is suppressed; happy-dom won't move focus
+    // to the next tabbable on its own, so focus should remain on b3.
+    expect(document.activeElement?.id).toBe('b3')
+    scope.deactivate()
+  })
+
+  it('contains() reports descendant membership', () => {
+    const scope = createFocusScope({ containerRef: () => container })
+    expect(scope.contains(container.querySelector('#b1')!)).toBe(true)
+    expect(scope.contains(outsideButton)).toBe(false)
+  })
+
+  it('activate() is idempotent (calling twice does not double-install handlers)', () => {
+    const scope = createFocusScope({ containerRef: () => container })
+    scope.activate()
+    scope.activate() // no-op second time
+    scope.deactivate()
+    expect(document.activeElement).not.toBe(container.querySelector('#b1'))
+  })
+
+  it('deactivate() before activate() is a no-op', () => {
+    const scope = createFocusScope({ containerRef: () => container })
+    expect(() => scope.deactivate()).not.toThrow()
+  })
+
+  it('handles a container with zero tabbables: Tab pins focus on container', () => {
+    const empty = document.createElement('div')
+    empty.tabIndex = -1
+    document.body.appendChild(empty)
+    const scope = createFocusScope({
+      containerRef: () => empty,
+      initialFocus: 'container',
+    })
+    scope.activate()
+    expect(document.activeElement).toBe(empty)
+    empty.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
+    )
+    expect(document.activeElement).toBe(empty)
+    scope.deactivate()
+  })
+
+  it('null container ref: activate() is a no-op', () => {
+    const scope = createFocusScope({ containerRef: () => null })
+    expect(() => scope.activate()).not.toThrow()
+    // Nothing should be focused as a side-effect
+    scope.deactivate()
+  })
+})

--- a/dashboard/design-system/headless-core/focus-scope.ts
+++ b/dashboard/design-system/headless-core/focus-scope.ts
@@ -1,0 +1,184 @@
+/**
+ * FocusScope — framework-agnostic focus trap + restore primitive.
+ *
+ * Replaces the inline `useRef + useEffect + document.addEventListener
+ * ("mousedown")` pattern that every Drawer/Popover/Dialog reimplements.
+ * Adapters (headless-preact/use-focus-scope.ts, future Bonsai adapter)
+ * call activate() on mount and deactivate() on unmount.
+ *
+ * MVP scope (RFC 0001 §"createFocusScope"):
+ *   - Tabbable element collector (a, button, input, select, textarea,
+ *     [tabindex] not -1, contenteditable; disabled/hidden filtered out)
+ *   - Tab / Shift+Tab cycling within the container
+ *   - Focus restoration: stash activeElement on activate, restore on
+ *     deactivate
+ *   - initialFocus: 'first' | 'container' | () => HTMLElement | null
+ *
+ * Out of scope (will land later, RFC 0001 §"Open question 1"):
+ *   - Roving Tabindex (tablist, radiogroup, toolbar)
+ *   - Visibility filter beyond `disabled` + `tabindex="-1"`
+ *     (CSS display:none / visibility:hidden / aria-hidden=true detection
+ *     is the second iteration)
+ *   - Focus guard sentinel pair around the container (used when the
+ *     container isn't `position: fixed`); deferred until first consumer
+ *     needs it
+ */
+
+const TABBABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+].join(', ')
+
+export type InitialFocus =
+  | 'first'
+  | 'container'
+  | (() => HTMLElement | null)
+
+export interface FocusScopeOptions {
+  /**
+   * Returns the container element. Function form (not raw element) lets
+   * the caller defer until activate() time, mirroring Preact's nullable
+   * `ref.current` pattern.
+   */
+  containerRef: () => HTMLElement | null
+  /** Tab cycles within the container. Default true. */
+  loop?: boolean
+  /** On deactivate, restore focus to the element focused before activate. Default true. */
+  restoreFocus?: boolean
+  /** Where to land focus on activate. Default 'first'. */
+  initialFocus?: InitialFocus
+}
+
+export interface FocusScope {
+  activate(): void
+  deactivate(): void
+  focusFirst(): void
+  focusLast(): void
+  contains(el: Element): boolean
+  /** Snapshot of currently tabbable descendants (debug / test hook). */
+  tabbables(): HTMLElement[]
+}
+
+function collectTabbables(container: HTMLElement): HTMLElement[] {
+  const matches = container.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR)
+  // Native-focusable elements (<input>, <button>, <a href>) match the
+  // selector even when tabindex="-1" is set on them, because the CSS
+  // `:not([tabindex="-1"])` clause only applies to the [tabindex] term,
+  // not to the named-element terms. JS post-filter handles that case.
+  return Array.from(matches).filter((el) => el.getAttribute('tabindex') !== '-1')
+}
+
+function focusElement(el: HTMLElement | null | undefined): void {
+  if (el && typeof el.focus === 'function') el.focus()
+}
+
+export function createFocusScope(opts: FocusScopeOptions): FocusScope {
+  const loop = opts.loop ?? true
+  const restoreFocus = opts.restoreFocus ?? true
+  const initialFocus: InitialFocus = opts.initialFocus ?? 'first'
+
+  let active = false
+  let priorFocus: HTMLElement | null = null
+  let keydownHandler: ((e: KeyboardEvent) => void) | null = null
+  let attachedTo: HTMLElement | null = null
+
+  function getContainer(): HTMLElement | null {
+    return opts.containerRef()
+  }
+
+  function applyInitialFocus(container: HTMLElement): void {
+    if (typeof initialFocus === 'function') {
+      focusElement(initialFocus())
+      return
+    }
+    if (initialFocus === 'container') {
+      focusElement(container)
+      return
+    }
+    // 'first'
+    const tabbables = collectTabbables(container)
+    focusElement(tabbables[0] ?? container)
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key !== 'Tab') return
+    const container = getContainer()
+    if (!container) return
+    const tabbables = collectTabbables(container)
+    if (tabbables.length === 0) {
+      // Nothing tabbable — pin focus on container itself.
+      e.preventDefault()
+      focusElement(container)
+      return
+    }
+    const first = tabbables[0]!
+    const last = tabbables[tabbables.length - 1]!
+    const activeEl = (container.ownerDocument?.activeElement ?? null) as HTMLElement | null
+
+    if (!loop) return
+
+    if (e.shiftKey && activeEl === first) {
+      e.preventDefault()
+      focusElement(last)
+    } else if (!e.shiftKey && activeEl === last) {
+      e.preventDefault()
+      focusElement(first)
+    }
+  }
+
+  return {
+    activate(): void {
+      if (active) return
+      const container = getContainer()
+      if (!container) return
+      const doc = container.ownerDocument ?? document
+      priorFocus = (doc.activeElement as HTMLElement | null) ?? null
+      keydownHandler = handleKeydown
+      container.addEventListener('keydown', keydownHandler)
+      attachedTo = container
+      applyInitialFocus(container)
+      active = true
+    },
+
+    deactivate(): void {
+      if (!active) return
+      if (attachedTo && keydownHandler) {
+        attachedTo.removeEventListener('keydown', keydownHandler)
+      }
+      keydownHandler = null
+      attachedTo = null
+      if (restoreFocus) focusElement(priorFocus)
+      priorFocus = null
+      active = false
+    },
+
+    focusFirst(): void {
+      const container = getContainer()
+      if (!container) return
+      focusElement(collectTabbables(container)[0])
+    },
+
+    focusLast(): void {
+      const container = getContainer()
+      if (!container) return
+      const tabbables = collectTabbables(container)
+      focusElement(tabbables[tabbables.length - 1])
+    },
+
+    contains(el: Element): boolean {
+      const container = getContainer()
+      return container ? container.contains(el) : false
+    },
+
+    tabbables(): HTMLElement[] {
+      const container = getContainer()
+      return container ? collectTabbables(container) : []
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Third and final framework-agnostic primitive from **RFC 0001 Headless Foundation** (#11670). Replaces the inline \`useRef + useEffect + document.addEventListener(\"mousedown\")\` pattern that every Drawer/Popover/Dialog currently reimplements.

- \`design-system/headless-core/focus-scope.ts\` — ~155 LoC
- \`design-system/headless-core/focus-scope.test.ts\` — 15 cases, all pass

## API

\`\`\`ts
const scope = createFocusScope({
  containerRef: () => dialogEl,
  loop: true,           // default
  restoreFocus: true,   // default
  initialFocus: 'first' // | 'container' | () => HTMLElement | null
})
scope.activate()    // captures activeElement, installs Tab trap, focuses first tabbable
scope.deactivate()  // removes trap, restores prior focus
scope.tabbables()   // debug snapshot
\`\`\`

## Design notes

- **Tabbable collection**: CSS selector covers native focusables (a/button/input/select/textarea/[tabindex]/contenteditable). JS post-filter removes \`tabindex=\"-1\"\` because \`:not([tabindex=\"-1\"])\` in CSS only applies to the bare \`[tabindex]\` term, not to the \`<input>\`/\`<button>\` named-element terms (caught in self-review during test 2).
- **Loop semantics**: Tab on last tabbable → first; Shift+Tab on first → last. \`loop=false\` simply suppresses manual cycling and lets the browser do the default.
- **Restore**: \`activate()\` stashes \`document.activeElement\` BEFORE applying initialFocus, so \`deactivate()\` returns focus to whatever was focused before the scope took over.
- **Idempotency**: \`activate()\` twice is a no-op the second time. \`deactivate()\` before \`activate()\` is a no-op. No exceptions thrown for misuse — adapters can call lifecycle hooks defensively.
- **Null containerRef**: returns gracefully without doing anything. Lets adapters call \`activate()\` before the ref is populated (Preact mount race).

## Verification

- [x] \`pnpm vitest run design-system/headless-core/focus-scope.test.ts\` → 15/15 pass
- [x] \`pnpm vitest run src/components/common/button.test.ts\` → 20/20 pass (no regression)
- [x] \`pnpm tsc --noEmit\` clean
- [ ] CI checks (this PR)

## Scope

In: tabbable collection, focus trap, focus restore, basic init focus modes.

Out (deferred per RFC §"Open question 1"):
- Roving Tabindex (tablist, radiogroup, toolbar) — separate primitive
- Visibility filter beyond \`disabled\` + \`tabindex=\"-1\"\` (CSS \`display:none\` / \`visibility:hidden\` / \`aria-hidden=true\`) — needs computed-style access, second-iteration concern
- Focus guard sentinel pair — only needed when container isn't \`position:fixed\`; revisit when first consumer surfaces
- Preact adapter hook \`use-focus-scope.ts\` — separate PR

## RFC 0001 completion

This PR completes the 3 framework-agnostic primitives sketched in RFC 0001:
- ✅ #11681 IdGenerator (merged)
- ⏳ #11689 PortalManager (Draft)
- ⏳ This PR FocusScope

Once all three land in main, headless-preact adapter PRs (use-id, use-portal, use-focus-scope) can begin.

## Related

- RFC: #11670
- Sibling impl: #11681 (merged), #11689 (Draft)
- Companion infra: #11676 (jest-axe wiring)
- Spec: design_system_v2 §1.3 (Focus Manager utility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)