### PR TITLE
fix(test): update turn_sandbox_runtime → turn_sandbox_factory label

### DIFF
--- a/test/test_keeper_fs_write_containment.ml
+++ b/test/test_keeper_fs_write_containment.ml
@@ -114,7 +114,7 @@ let test_docker_write_blocks_project_root_even_if_allowlisted () =
   let path = Filename.concat config.base_path "root-write.txt" in
   let raw =
     Keeper_exec_fs.handle_keeper_fs_edit
-      ~turn_sandbox_runtime:None
+      ~turn_sandbox_factory:None
       ~config
       ~meta
       ~args:
@@ -142,7 +142,7 @@ let test_docker_write_allows_playground () =
   ensure_dir (Filename.dirname path);
   let raw =
     Keeper_exec_fs.handle_keeper_fs_edit
-      ~turn_sandbox_runtime:None
+      ~turn_sandbox_factory:None
       ~config
       ~meta
       ~args:


### PR DESCRIPTION
## Summary
- `handle_keeper_fs_edit` signature renamed `~turn_sandbox_runtime` → `~turn_sandbox_factory` but `test_keeper_fs_write_containment.ml` was not updated
- 2 occurrences fixed

## Test plan
- [x] `dune build --root . test/test_keeper_fs_write_containment.exe` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)