### PR TITLE
feat(multimodal): Tier B8 — Artifact GADT + Payload + Provenance_stub (Cycle 24)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -958,6 +958,8 @@
    masc_mcp.shared_types
    ;; Resilience sub-library (Tier B6-B7) used by Keeper post-turn wire-in (Tier A6)
    masc_mcp.resilience
+   ;; Multimodal artifact GADT sub-library (Tier B8) — Code/Image/Audio/Doc + Payload + Provenance
+   masc_mcp.multimodal
    )
  (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_let ppx_tla))
  (instrumentation (backend bisect_ppx)))

--- a/lib/multimodal/artifact.ml
+++ b/lib/multimodal/artifact.ml
@@ -1,0 +1,73 @@
+(* Artifact — Cycle 24 / Tier B8.
+   See artifact.mli for design rationale. *)
+
+(* ── Phantom witnesses ────────────────────────────────────────── *)
+
+type code = |
+type image = |
+type audio = |
+type doc = |
+
+(* ── Kind GADT ────────────────────────────────────────────────── *)
+
+type _ kind =
+  | Code : code kind
+  | Image : image kind
+  | Audio : audio kind
+  | Doc : doc kind
+
+type any_kind = Any_kind : 'a kind -> any_kind
+
+(* ── Kind tag (structural mirror) ─────────────────────────────── *)
+
+type kind_tag =
+  | Tag_code [@tla.symbol "code"]
+  | Tag_image [@tla.symbol "image"]
+  | Tag_audio [@tla.symbol "audio"]
+  | Tag_doc [@tla.symbol "doc"]
+[@@deriving tla]
+
+let all_kind_tags = [ Tag_code; Tag_image; Tag_audio; Tag_doc ]
+
+let kind_tag_to_string = to_tla_symbol
+
+let kind_to_tag : type a. a kind -> kind_tag = function
+  | Code -> Tag_code
+  | Image -> Tag_image
+  | Audio -> Tag_audio
+  | Doc -> Tag_doc
+
+let any_kind_to_tag (Any_kind k) = kind_to_tag k
+
+let kind_to_string : type a. a kind -> string =
+ fun k -> kind_tag_to_string (kind_to_tag k)
+
+let any_kind_to_string (Any_kind k) = kind_to_string k
+
+(* ── Artifact record + existential ────────────────────────────── *)
+
+type 'a t = {
+  id : Shared_types.Artifact_id.t;
+  kind : 'a kind;
+  payload : Payload.t;
+  metadata : Yojson.Safe.t;
+  provenance : Provenance_stub.t;
+}
+
+type any = Any : 'a t -> any
+
+let any_id (Any a) = a.id
+let any_kind_of (Any a) = Any_kind a.kind
+
+let to_json : type a. a t -> Yojson.Safe.t =
+ fun a ->
+  `Assoc
+    [
+      ("id", Shared_types.Artifact_id.to_json a.id);
+      ("kind", `String (kind_to_string a.kind));
+      ("payload", Payload.to_json a.payload);
+      ("metadata", a.metadata);
+      ("provenance", Provenance_stub.to_json a.provenance);
+    ]
+
+let any_to_json (Any a) = to_json a

--- a/lib/multimodal/artifact.mli
+++ b/lib/multimodal/artifact.mli
@@ -1,0 +1,112 @@
+(** Artifact — phantom-tagged multimodal artifact GADT.
+
+    Cycle 24 / Tier B8.
+
+    {1 What this module is}
+
+    A first-class multimodal artifact carrying:
+    - an opaque {!Shared_types.Artifact_id.t} (UUID v7),
+    - a phantom-tagged {!kind} (Code/Image/Audio/Doc),
+    - a {!Payload.t} (lazy / blob_ref / streaming),
+    - free-form JSON metadata,
+    - a {!Provenance_stub.t} record.
+
+    The phantom-tag pattern excludes mismatched
+    [Code-kind handler over Image-kind artifact] at compile time.
+    Existential capture via {!any_kind} and {!any} permits
+    homogeneous lists when callers must defer kind dispatch to
+    runtime.
+
+    {1 Tag mirror pattern (per B3 / B5)}
+
+    The [\`a kind] GADT cannot be derived directly by [ppx_tla] —
+    each constructor specialises ['a] to a distinct phantom
+    witness. Tier I8/I9 cover only the 0-param GADT case and
+    phantom-only ['a] indices that are caller tags, neither of
+    which applies here. Instead, we maintain a regular variant
+    {!kind_tag} as a structural mirror with [\[@tla.symbol\]]
+    overrides and derive [tla] from it. The hand-written
+    {!kind_to_tag} is the SSOT lookup, and OCaml's exhaustiveness
+    check catches drift if {!kind_tag} grows but {!kind_to_tag}
+    does not.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+(** {1 Kind phantom witnesses}
+
+    Empty-variant declarations (no inhabitants). External call
+    sites see them as abstract. Internal use is purely type-level
+    — no value of these types is ever constructed. *)
+
+type code
+type image
+type audio
+type doc
+
+(** {1 Kind GADT} *)
+
+type _ kind =
+  | Code : code kind
+  | Image : image kind
+  | Audio : audio kind
+  | Doc : doc kind
+
+(** Existential capture so callers can store mixed-kind values
+    in a homogeneous list. *)
+type any_kind = Any_kind : 'a kind -> any_kind
+
+(** {1 Kind tag (structural mirror, ppx-derivable)}
+
+    The deriver emits [to_tla_symbol], [all_symbols], and
+    [all_states] over this type; the GADT projects to the tag via
+    {!kind_to_tag}. *)
+
+type kind_tag =
+  | Tag_code
+  | Tag_image
+  | Tag_audio
+  | Tag_doc
+
+val all_kind_tags : kind_tag list
+(** All four constructors in declaration order. *)
+
+val kind_tag_to_string : kind_tag -> string
+(** Lowercase symbol name — [Tag_code → "code"] etc. Mirrors the
+    [\[@tla.symbol\]] override layer. *)
+
+val kind_to_tag : 'a kind -> kind_tag
+(** Hand-written 1:1 lookup. Compile-time exhaustiveness keeps
+    this aligned with {!kind_tag}. *)
+
+val any_kind_to_tag : any_kind -> kind_tag
+
+val kind_to_string : 'a kind -> string
+
+val any_kind_to_string : any_kind -> string
+
+(** {1 Artifact record} *)
+
+type 'a t = {
+  id : Shared_types.Artifact_id.t;
+  kind : 'a kind;
+  payload : Payload.t;
+  metadata : Yojson.Safe.t;
+  provenance : Provenance_stub.t;
+}
+
+(** Existential wrapper. Callers that need to operate over a
+    list of artifacts of mixed kinds use this to pack each
+    {!t} value. *)
+type any = Any : 'a t -> any
+
+val any_id : any -> Shared_types.Artifact_id.t
+
+val any_kind_of : any -> any_kind
+
+val to_json : 'a t -> Yojson.Safe.t
+(** Encodes [id], [kind] (as the {!kind_tag} symbol), [payload],
+    [metadata], [provenance]. The kind discriminator round-trips
+    through {!kind_tag_to_string}. *)
+
+val any_to_json : any -> Yojson.Safe.t

--- a/lib/multimodal/dune
+++ b/lib/multimodal/dune
@@ -1,0 +1,7 @@
+(include_subdirs no)
+
+(library
+ (name multimodal)
+ (public_name masc_mcp.multimodal)
+ (libraries shared_types yojson)
+ (preprocess (pps ppx_tla)))

--- a/lib/multimodal/payload.ml
+++ b/lib/multimodal/payload.ml
@@ -1,0 +1,31 @@
+(* Payload — Cycle 24 / Tier B8.
+   See payload.mli for design rationale. *)
+
+type t =
+  | Lazy_payload of (unit -> string)
+  | Blob_ref of string
+  | Streaming of int
+
+let to_json = function
+  | Lazy_payload _ -> `Assoc [ ("kind", `String "lazy") ]
+  | Blob_ref s ->
+      `Assoc [ ("kind", `String "blob_ref"); ("ref", `String s) ]
+  | Streaming n ->
+      `Assoc [ ("kind", `String "streaming"); ("bytes", `Int n) ]
+
+let of_json = function
+  | `Assoc kv -> (
+      match List.assoc_opt "kind" kv with
+      | Some (`String "lazy") -> Ok (Lazy_payload (fun () -> ""))
+      | Some (`String "blob_ref") -> (
+          match List.assoc_opt "ref" kv with
+          | Some (`String s) -> Ok (Blob_ref s)
+          | _ -> Error "blob_ref payload missing 'ref' string field")
+      | Some (`String "streaming") -> (
+          match List.assoc_opt "bytes" kv with
+          | Some (`Int n) -> Ok (Streaming n)
+          | _ -> Error "streaming payload missing 'bytes' int field")
+      | Some (`String other) ->
+          Error (Printf.sprintf "unknown payload kind: %s" other)
+      | _ -> Error "payload missing 'kind' string field")
+  | _ -> Error "payload must be a JSON object"

--- a/lib/multimodal/payload.mli
+++ b/lib/multimodal/payload.mli
@@ -1,0 +1,42 @@
+(** Payload — multimodal artifact payload representation.
+
+    Cycle 24 / Tier B8.
+
+    Three variants:
+    - {!Lazy_payload}: deferred string materialisation. The closure
+      captures whatever computation the producer wants delayed (e.g.
+      reading from disk, decoding, decompression). Round-tripping
+      through {!of_json} loses the original closure — see below.
+    - {!Blob_ref}: an opaque reference into an external blob store.
+      The string is treated as an arbitrary identifier; this module
+      does not interpret its structure.
+    - {!Streaming}: byte-count-only handle for in-progress streams.
+      The integer is the bytes-so-far counter at the moment of
+      capture; consumers should treat it as a hint, not authoritative.
+
+    Tier B9 (Multimodal_hydrator) will wrap these with the existing
+    [keeper_artifact_hydrator] so its consumers see a uniform surface.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+type t =
+  | Lazy_payload of (unit -> string)
+  | Blob_ref of string
+  | Streaming of int
+
+val to_json : t -> Yojson.Safe.t
+(** JSON encoding:
+    - [Lazy_payload _ → \{ "kind": "lazy" \}]. The closure is not
+      serialised — only the discriminator survives.
+    - [Blob_ref s → \{ "kind": "blob_ref", "ref": s \}].
+    - [Streaming n → \{ "kind": "streaming", "bytes": n \}]. *)
+
+val of_json : Yojson.Safe.t -> (t, string) result
+(** Parse the {!to_json} shape.
+
+    [Lazy_payload] reconstructs a closure that always returns the
+    empty string ([fun () -> ""]) — the original closure cannot be
+    serialised, so deserialisation is lossy by construction.
+    Callers needing the original payload must keep the in-memory
+    artifact value, not round-trip through JSON. *)

--- a/lib/multimodal/provenance_stub.ml
+++ b/lib/multimodal/provenance_stub.ml
@@ -1,0 +1,58 @@
+(* Provenance_stub — Cycle 24 / Tier B8. *)
+
+type t = {
+  origin_artifact_ids : Shared_types.Artifact_id.t list;
+  created_by : string;
+  created_at : float;
+}
+
+let empty ~created_by ~created_at =
+  { origin_artifact_ids = []; created_by; created_at }
+
+let to_json p =
+  `Assoc
+    [
+      ( "origin_artifact_ids",
+        `List
+          (List.map Shared_types.Artifact_id.to_json p.origin_artifact_ids)
+      );
+      ("created_by", `String p.created_by);
+      ("created_at", `Float p.created_at);
+    ]
+
+let of_json = function
+  | `Assoc kv ->
+      let origin_result =
+        match List.assoc_opt "origin_artifact_ids" kv with
+        | Some (`List xs) ->
+            List.fold_right
+              (fun j acc ->
+                match (Shared_types.Artifact_id.of_json j, acc) with
+                | Ok id, Ok rest -> Ok (id :: rest)
+                | Error e, _ -> Error e
+                | _, Error e -> Error e)
+              xs (Ok [])
+        | None -> Ok []
+        | _ -> Error "origin_artifact_ids must be a JSON list"
+      in
+      let created_by_result =
+        match List.assoc_opt "created_by" kv with
+        | Some (`String s) -> Ok s
+        | _ -> Error "created_by must be a JSON string"
+      in
+      let created_at_result =
+        match List.assoc_opt "created_at" kv with
+        | Some (`Float f) -> Ok f
+        | Some (`Int i) -> Ok (float_of_int i)
+        | _ -> Error "created_at must be a JSON number"
+      in
+      (match origin_result, created_by_result, created_at_result with
+       | Ok ids, Ok name, Ok ts ->
+           Ok
+             {
+               origin_artifact_ids = ids;
+               created_by = name;
+               created_at = ts;
+             }
+       | Error e, _, _ | _, Error e, _ | _, _, Error e -> Error e)
+  | _ -> Error "provenance_stub must be a JSON object"

--- a/lib/multimodal/provenance_stub.mli
+++ b/lib/multimodal/provenance_stub.mli
@@ -1,0 +1,30 @@
+(** Provenance_stub — minimal artifact provenance record.
+
+    Cycle 24 / Tier B8.
+
+    Stub form: a flat record carrying the originating artifact ids,
+    the producer name, and the creation timestamp. The follow-up
+    Tier B9 (Multimodal_hydrator) will extend this into a Provenance
+    DAG capturing transformation lineage between artifacts.
+
+    Stored on every {!Artifact.t}. The stub is sufficient for B8's
+    JSON round-trip, downstream filtering, and timeline rendering;
+    the DAG arrives in B9 without renaming the existing fields.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+type t = {
+  origin_artifact_ids : Shared_types.Artifact_id.t list;
+  created_by : string;
+  created_at : float;
+}
+
+val empty : created_by:string -> created_at:float -> t
+(** [empty ~created_by ~created_at] constructs a provenance with no
+    origin artifacts. Useful when an artifact is the start of a new
+    creation chain (no predecessors). *)
+
+val to_json : t -> Yojson.Safe.t
+
+val of_json : Yojson.Safe.t -> (t, string) result

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -1,0 +1,3 @@
+(tests
+ (names test_artifact)
+ (libraries multimodal shared_types yojson))

--- a/test/multimodal/test_artifact.ml
+++ b/test/multimodal/test_artifact.ml
@@ -1,0 +1,165 @@
+(* Cycle 24 / Tier B8 — Multimodal.Artifact tests. *)
+
+module A = Multimodal.Artifact
+module P = Multimodal.Payload
+module Pr = Multimodal.Provenance_stub
+module Aid = Shared_types.Artifact_id
+
+(* ─── kind / kind_tag mirror ──────────────────────────────────── *)
+
+let test_kind_tag_symbols () =
+  assert (A.kind_tag_to_string A.Tag_code = "code");
+  assert (A.kind_tag_to_string A.Tag_image = "image");
+  assert (A.kind_tag_to_string A.Tag_audio = "audio");
+  assert (A.kind_tag_to_string A.Tag_doc = "doc")
+
+let test_all_kind_tags () =
+  assert (List.length A.all_kind_tags = 4);
+  let symbols = List.map A.kind_tag_to_string A.all_kind_tags in
+  assert (symbols = [ "code"; "image"; "audio"; "doc" ])
+
+let test_kind_to_tag_round_trip () =
+  assert (A.kind_to_tag A.Code = A.Tag_code);
+  assert (A.kind_to_tag A.Image = A.Tag_image);
+  assert (A.kind_to_tag A.Audio = A.Tag_audio);
+  assert (A.kind_to_tag A.Doc = A.Tag_doc)
+
+let test_any_kind_to_tag () =
+  assert (A.any_kind_to_tag (A.Any_kind A.Code) = A.Tag_code);
+  assert (A.any_kind_to_tag (A.Any_kind A.Image) = A.Tag_image);
+  assert (A.any_kind_to_tag (A.Any_kind A.Audio) = A.Tag_audio);
+  assert (A.any_kind_to_tag (A.Any_kind A.Doc) = A.Tag_doc)
+
+let test_kind_to_string () =
+  assert (A.kind_to_string A.Code = "code");
+  assert (A.any_kind_to_string (A.Any_kind A.Image) = "image")
+
+(* ─── Payload variant ─────────────────────────────────────────── *)
+
+let test_payload_blob_ref_round_trip () =
+  let p = P.Blob_ref "blob-abc" in
+  let json = P.to_json p in
+  match P.of_json json with
+  | Ok (P.Blob_ref s) -> assert (s = "blob-abc")
+  | _ -> assert false
+
+let test_payload_streaming_round_trip () =
+  let p = P.Streaming 4096 in
+  match P.of_json (P.to_json p) with
+  | Ok (P.Streaming n) -> assert (n = 4096)
+  | _ -> assert false
+
+let test_payload_lazy_lossy_round_trip () =
+  let p = P.Lazy_payload (fun () -> "hello") in
+  match P.of_json (P.to_json p) with
+  | Ok (P.Lazy_payload f) ->
+      (* Round-trip is lossy by construction — closure rebuilt. *)
+      assert (f () = "")
+  | _ -> assert false
+
+let test_payload_unknown_kind_rejected () =
+  let bogus = `Assoc [ ("kind", `String "magic") ] in
+  match P.of_json bogus with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+(* ─── Provenance_stub ─────────────────────────────────────────── *)
+
+let test_provenance_empty_round_trip () =
+  let pr = Pr.empty ~created_by:"vincent" ~created_at:1234.5 in
+  match Pr.of_json (Pr.to_json pr) with
+  | Ok p ->
+      assert (p.Pr.origin_artifact_ids = []);
+      assert (p.created_by = "vincent");
+      assert (Float.abs (p.created_at -. 1234.5) < 1e-6)
+  | Error _ -> assert false
+
+let test_provenance_with_origins_round_trip () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let pr =
+    {
+      Pr.origin_artifact_ids = [ id1; id2 ];
+      created_by = "executor";
+      created_at = 9999.0;
+    }
+  in
+  match Pr.of_json (Pr.to_json pr) with
+  | Ok p ->
+      assert (List.length p.Pr.origin_artifact_ids = 2);
+      assert (
+        Aid.equal (List.hd p.origin_artifact_ids) id1)
+  | Error _ -> assert false
+
+(* ─── Artifact record ─────────────────────────────────────────── *)
+
+let make_image_artifact () : A.image A.t =
+  let id = Aid.generate () in
+  {
+    A.id;
+    kind = A.Image;
+    payload = P.Blob_ref "img-blob-1";
+    metadata = `Assoc [ ("width", `Int 800); ("height", `Int 600) ];
+    provenance = Pr.empty ~created_by:"executor" ~created_at:1.0;
+  }
+[@@warning "-37"]
+
+let test_artifact_to_json () =
+  let a = make_image_artifact () in
+  let json = A.to_json a in
+  match json with
+  | `Assoc kv ->
+      let kind = List.assoc "kind" kv in
+      assert (kind = `String "image");
+      assert (List.mem_assoc "id" kv);
+      assert (List.mem_assoc "payload" kv);
+      assert (List.mem_assoc "metadata" kv);
+      assert (List.mem_assoc "provenance" kv)
+  | _ -> assert false
+
+let test_any_artifact_existential () =
+  let a = make_image_artifact () in
+  let any = A.Any a in
+  assert (A.any_kind_of any = A.Any_kind A.Image);
+  let id_back = A.any_id any in
+  assert (Aid.equal id_back a.A.id);
+  let json = A.any_to_json any in
+  let json_b = A.to_json a in
+  assert (json = json_b)
+
+let test_homogeneous_list_of_any () =
+  let a_img = make_image_artifact () in
+  let a_code : A.code A.t =
+    let id = Aid.generate () in
+    {
+      A.id;
+      kind = A.Code;
+      payload = P.Streaming 0;
+      metadata = `Null;
+      provenance = Pr.empty ~created_by:"executor" ~created_at:2.0;
+    }
+  in
+  let xs = [ A.Any a_img; A.Any a_code ] in
+  let kinds = List.map A.any_kind_of xs in
+  assert (kinds = [ A.Any_kind A.Image; A.Any_kind A.Code ]);
+  let symbols =
+    List.map (fun a -> A.any_kind_to_string (A.any_kind_of a)) xs
+  in
+  assert (symbols = [ "image"; "code" ])
+
+let () =
+  test_kind_tag_symbols ();
+  test_all_kind_tags ();
+  test_kind_to_tag_round_trip ();
+  test_any_kind_to_tag ();
+  test_kind_to_string ();
+  test_payload_blob_ref_round_trip ();
+  test_payload_streaming_round_trip ();
+  test_payload_lazy_lossy_round_trip ();
+  test_payload_unknown_kind_rejected ();
+  test_provenance_empty_round_trip ();
+  test_provenance_with_origins_round_trip ();
+  test_artifact_to_json ();
+  test_any_artifact_existential ();
+  test_homogeneous_list_of_any ();
+  print_endline "test_artifact: all assertions passed"


### PR DESCRIPTION
## Summary

Tier B8 — greenfield `lib/multimodal/` sub-library opening Cycle 24 (multimodal core). Phantom-tagged artifact GADT enables compile-time exclusion of kind-mismatched handlers, with existential capture for homogeneous mixed-kind lists.

## Modules

| Module | Surface |
|--------|---------|
| `Artifact` | `'a kind` GADT (Code/Image/Audio/Doc) + 4 phantom witnesses + `kind_tag` mirror with `[@tla.symbol]` overrides (B3/B5 pattern) + existential `any_kind` / `any` |
| `Payload` | `Lazy_payload of (unit -> string)` \| `Blob_ref of string` \| `Streaming of int`. JSON round-trip lossy for Lazy_payload (closure cannot be serialised). |
| `Provenance_stub` | `{ origin_artifact_ids; created_by; created_at }`. B9 extends into Provenance DAG. |

## Tag mirror pattern (per B3 / B5)

The `'a kind` GADT cannot be derived directly by `ppx_tla` — each constructor specialises `'a` to a distinct phantom witness (Tier I8/I9 cover only 0-param GADT and phantom-only `'a` indices). Instead a regular variant `kind_tag` mirrors the GADT structurally with `[@tla.symbol]` overrides; the hand-written `kind_to_tag` is the SSOT projection, and OCaml exhaustiveness catches drift.

## Plan §16 reference

| Tier | LoC | Risk |
|------|-----|------|
| **B8** | 484 / 9 files | Low (file-disjoint greenfield) |

3-PR parallel entry confirmed by user. base=main, no stack PR.

## Test plan

- [x] `dune build --root . lib/multimodal test/multimodal` GREEN
- [x] `dune runtest --root . test/multimodal` GREEN — 14 new assertions
- [x] Race check `gh pr list --search "multimodal_artifact OR ..."` → 0 open
- [ ] CI Build and Test green after push

## Related

- Cycle 24 entry. Tier B9 (Multimodal_hydrator) wraps `keeper_artifact_hydrator` non-invasively. Tier A7 adds Tool_set integration + Workspace + Dashboard routes.
- Cycle 23 closing (A6) and Cycle 27 (A11) entered in parallel — independent file scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)