### PR TITLE
test(dashboard): a11y coverage for badge/checkbox/copy-id-button

### DIFF
--- a/dashboard/src/components/common/badge.a11y.test.ts
+++ b/dashboard/src/components/common/badge.a11y.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for CountBadge — display-only atom with no
+// interaction surface. The exhaustive tone sweep guards against a
+// future tone palette change accidentally introducing low-contrast
+// or color-only-information violations.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { CountBadge } from './badge'
+
+describe('CountBadge a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default tone renders accessibly', async () => {
+    render(html`<${CountBadge}>12<//>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('warn tone renders accessibly', async () => {
+    render(html`<${CountBadge} tone="warn">3<//>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('ok tone renders accessibly', async () => {
+    render(html`<${CountBadge} tone="ok">8<//>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('bad tone renders accessibly', async () => {
+    render(html`<${CountBadge} tone="bad">5<//>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('accent tone renders accessibly', async () => {
+    render(html`<${CountBadge} tone="accent">21<//>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/checkbox.a11y.test.ts
+++ b/dashboard/src/components/common/checkbox.a11y.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for Checkbox — form input atom. Critical because
+// a checkbox without an accessible name is a WCAG 2.1 violation
+// (4.1.2 Name, Role, Value), and the component's own JSDoc warns that
+// dropping the `ariaLabel` / `id` props is a known regression source.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { Checkbox } from './checkbox'
+
+describe('Checkbox a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with ariaLabel passes axe (icon-style standalone)', async () => {
+    render(html`<${Checkbox} ariaLabel="Subscribe to newsletter" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with id + external <label for=""> passes axe', async () => {
+    render(
+      html`<div>
+        <label for="agree">Agree to terms</label>
+        <${Checkbox} id="agree" />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with ariaLabelledby pointing at sibling element passes axe', async () => {
+    render(
+      html`<div>
+        <span id="opt-label">Notify me</span>
+        <${Checkbox} ariaLabelledby="opt-label" />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('disabled + ariaLabel passes axe', async () => {
+    render(
+      html`<${Checkbox} ariaLabel="Locked option" disabled=${true} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('checked + ariaLabel passes axe', async () => {
+    render(
+      html`<${Checkbox} ariaLabel="Active filter" checked=${true} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/copy-id-button.a11y.test.ts
+++ b/dashboard/src/components/common/copy-id-button.a11y.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for CopyIdButton — icon-only button. Tests guard
+// the accessible-name fallback chain (ariaLabel || `${label} 복사` ||
+// '복사'); a regression that drops both label and ariaLabel would yield
+// a button with only an SVG icon and no name (WCAG 4.1.2).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { CopyIdButton } from './copy-id-button'
+
+describe('CopyIdButton a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default render uses fallback aria-label "복사"', async () => {
+    render(html`<${CopyIdButton} value="abc-123" />`, container)
+    const btn = container.querySelector('button')!
+    expect(btn.getAttribute('aria-label')).toBe('복사')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with `label` derives "<label> 복사" aria-label', async () => {
+    render(html`<${CopyIdButton} value="abc-123" label="Session ID" />`, container)
+    const btn = container.querySelector('button')!
+    expect(btn.getAttribute('aria-label')).toBe('Session ID 복사')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('explicit `ariaLabel` overrides the derived label', async () => {
+    render(
+      html`<${CopyIdButton} value="abc" label="Session ID" ariaLabel="Copy session id" />`,
+      container,
+    )
+    const btn = container.querySelector('button')!
+    expect(btn.getAttribute('aria-label')).toBe('Copy session id')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

Extends the jest-axe baseline (#11676 — merged) to three additional atoms, each on a different a11y surface:

| Atom | Type | Cases | Why |
|------|------|-------|-----|
| **CountBadge** | display | 5 (one per tone) | Tone palette change → axe catches contrast/color-only-info regressions |
| **Checkbox** | form input | 5 (ariaLabel / id+\`<label>\` / ariaLabelledby / disabled / checked) | Component's own JSDoc warns that dropping accessible-name props is a known regression — let axe enforce it |
| **CopyIdButton** | icon-only action | 3 (default fallback / derived from \`label\` / explicit override) | Guards the \`ariaLabel \|\| \`\\\`\${label} 복사\\\` \|\| '복사'\` fallback chain. Also asserts the resolved aria-label literal so renames don't silently break |

13 cases, all pass. Total dashboard a11y test count: 4 → 17.

## Pattern reuse

Every file follows the existing \`button.a11y.test.ts\` style:

\`\`\`ts
preact render → happy-dom container → beforeEach/afterEach → axe(container) → toHaveNoViolations()
\`\`\`

No new test helpers introduced. Future atoms can drop a sibling \`*.a11y.test.ts\` next to their existing \`*.test.ts\` using the same template.

## Verification

- [x] \`pnpm vitest run src/components/common/{badge,checkbox,copy-id-button}.a11y.test.ts\` → 13/13 pass
- [x] \`pnpm tsc --noEmit\` clean
- [ ] CI checks (this PR)

## Related

- Depends on (now merged): #11676 jest-axe wiring
- Spec: design_system_v2 §6 (Accessibility v2.0)
- Migration: migration_guide_sec01 Phase 0 (a11y baseline before component migration)

## Note on main blockers

Same \`Health\` / \`CI Gate\` / \`Meta Guards\` checks fail on main and other open PRs (root: OCaml \`-warn-error +a\` in unrelated backend code). This PR is dashboard-only TS — Build/Test/Dashboard/Lint pass cleanly. Will unblock once the main fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)