### PR TITLE
test(dashboard): expand a11y coverage to 4 atoms (Iter 5)

### DIFF
--- a/dashboard/src/components/common/dashed-notice.a11y.test.ts
+++ b/dashboard/src/components/common/dashed-notice.a11y.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { DashedNotice } from './dashed-notice'
+
+describe('DashedNotice a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default sm/card variant renders accessibly', async () => {
+    render(html`<${DashedNotice}>No events yet<//>`, container)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('md/subtle variant renders accessibly', async () => {
+    render(
+      html`<${DashedNotice} size="md" borderTone="subtle">No deployments in this window<//>`,
+      container,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/section-header.a11y.test.ts
+++ b/dashboard/src/components/common/section-header.a11y.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { SectionHeader } from './section-header'
+
+describe('SectionHeader a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    // SectionHeader renders an <h4>; build a valid h1→h2→h3 chain
+    // above so heading-order axe rule passes when the SectionHeader
+    // appears in the test fragment.
+    container = document.createElement('main')
+    const h1 = document.createElement('h1'); h1.textContent = 'Page'
+    const h2 = document.createElement('h2'); h2.textContent = 'Region'
+    const h3 = document.createElement('h3'); h3.textContent = 'Group'
+    container.append(h1, h2, h3)
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default render passes axe', async () => {
+    const slot = document.createElement('section')
+    container.appendChild(slot)
+    render(html`<${SectionHeader}>Recent activity<//>`, slot)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('with right slot (action) renders accessibly', async () => {
+    const slot = document.createElement('section')
+    container.appendChild(slot)
+    render(
+      html`<${SectionHeader} right=${html`<button type="button">View all</button>`}>Logs<//>`,
+      slot,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/status-badge.a11y.test.ts
+++ b/dashboard/src/components/common/status-badge.a11y.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { StatusBadge } from './status-badge'
+
+describe('StatusBadge a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly for each canonical status', async () => {
+    render(
+      html`<div>
+        <${StatusBadge} status="active" />
+        <${StatusBadge} status="in_progress" />
+        <${StatusBadge} status="error" />
+        <${StatusBadge} status="offline" />
+      </div>`,
+      container,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('explicit label override renders accessibly', async () => {
+    render(html`<${StatusBadge} status="active" label="Online now" />`, container)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/status-dot.a11y.test.ts
+++ b/dashboard/src/components/common/status-dot.a11y.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { StatusDot } from './status-dot'
+
+describe('StatusDot a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default render passes axe (decorative dot, role=presentation expected)', async () => {
+    render(html`<${StatusDot} />`, container)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('all four sizes render accessibly', async () => {
+    render(
+      html`<div>
+        <${StatusDot} size="xs" />
+        <${StatusDot} size="sm" />
+        <${StatusDot} size="md" />
+        <${StatusDot} size="lg" />
+      </div>`,
+      container,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Iter 5 — a11y coverage expansion (4 atoms, 8 cases)

Following PR #11676 (jest-axe wireup + ActionButton baseline), this PR
adds smoke a11y tests for **StatusDot, StatusBadge, SectionHeader,
DashedNotice**.

### Coordination with #11703

This PR coordinates with [#11703](https://github.com/jeong-sik/masc-mcp/pull/11703)
which covers `badge.ts` (different from `status-badge.ts`), Checkbox,
and CopyIdButton. **No path overlap** after rebasing — `checkbox.a11y.test.ts`
removed from this PR to defer to #11703.

### Coverage breakdown

| Atom | Cases | Notes |
|---|---:|---|
| `StatusDot` | 2 | default render + all 4 sizes |
| `StatusBadge` | 2 | canonical statuses + label override |
| `SectionHeader` | 2 | default + with right slot |
| `DashedNotice` | 2 | sm/card + md/subtle variants |
| **Total (this PR)** | **8** | |

### Combined Iter 5 progress

| PR | Atom | Cases |
|---|---|---:|
| #11676 | ActionButton | 4 |
| #11703 | badge / checkbox / copy-id-button | ~6 |
| **#11704 (this)** | StatusDot / StatusBadge / SectionHeader / DashedNotice | 8 |
| **Total** | **8 atoms** | **~18** |

Plan §"Phase 1 Iter 5" target ≥10 met by margin.

### Heading-chain for SectionHeader

`SectionHeader` renders `<h4>` which axe-core flags as out-of-order at
the top of a fragment. The test wrapper builds a valid `h1 → h2 → h3`
chain in `beforeEach` so the rule passes — mirrors real-page usage.

### Verification (local)

- `pnpm vitest run src/components/common/*.a11y.test.ts` ✓ (8/8)
- `pnpm typecheck` ✓

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
