### PR TITLE
fix(test): complete turn_sandbox_runtime → turn_sandbox_factory cascade (PR-3b residual)

### DIFF
--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -320,8 +320,8 @@ let test_docker_blocks_nested_docker_command () =
   let meta = make_docker_meta "docker-nested" in
   let raw =
     Keeper_exec_shell.handle_keeper_bash
-      ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~exec_cache:None
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "docker run --rm alpine true") ]) ()
   in
@@ -341,8 +341,8 @@ let test_docker_blocks_docker_socket_reference () =
   let meta = make_docker_meta "docker-sock" in
   let raw =
     Keeper_exec_shell.handle_keeper_bash
-      ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~exec_cache:None
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "cat /var/run/docker.sock") ]) ()
   in
@@ -365,8 +365,8 @@ let test_docker_missing_seccomp_profile_fails_closed () =
     (fun () ->
       let raw =
         Keeper_exec_shell.handle_keeper_bash
-          ~turn_sandbox_runtime:None
-          ~turn_sandbox_runtime_git:None ~exec_cache:None
+          ~turn_sandbox_factory:None
+          ~turn_sandbox_factory_git:None ~exec_cache:None
           ~config ~meta
           ~args:(`Assoc [ ("cmd", `String "pwd") ]) ()
       in
@@ -440,7 +440,7 @@ let test_keeper_shell_ls_recovers_doubled_playground_prefix () =
   in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
-      ~turn_sandbox_runtime:None ~exec_cache:None
+      ~turn_sandbox_factory:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "ls");
@@ -463,7 +463,7 @@ let test_readonly_chaining_hint_lists_subops () =
   let meta = make_readonly_meta "chain-hint" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
-      ~turn_sandbox_runtime:None ~exec_cache:None
+      ~turn_sandbox_factory:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "bash");
@@ -492,7 +492,7 @@ let test_readonly_redirect_hint_points_at_fs_edit () =
   let meta = make_readonly_meta "redirect-hint" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
-      ~turn_sandbox_runtime:None ~exec_cache:None
+      ~turn_sandbox_factory:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "bash");
@@ -563,8 +563,8 @@ let test_bash_missing_cmd_field () =
   let meta = make_docker_meta "missing-cmd" in
   let raw =
     Keeper_exec_shell.handle_keeper_bash
-      ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~exec_cache:None
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [ ("run_in_background", `Bool false) ]) ()
   in
@@ -583,7 +583,7 @@ let test_shell_missing_op_field () =
   let meta = make_readonly_meta "missing-op" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
-      ~turn_sandbox_runtime:None ~exec_cache:None
+      ~turn_sandbox_factory:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [ ("path", `String "/some/path") ])
   in
@@ -602,7 +602,7 @@ let test_shell_unsupported_op () =
   let meta = make_readonly_meta "bad-op" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
-      ~turn_sandbox_runtime:None ~exec_cache:None
+      ~turn_sandbox_factory:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "definitely_not_a_real_op");

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -9,6 +9,7 @@
 module Coord = Masc_mcp.Coord
 module Keeper_docker_read = Masc_mcp.Keeper_docker_read
 module Keeper_turn_sandbox_runtime = Masc_mcp.Keeper_turn_sandbox_runtime
+module Keeper_sandbox_factory = Masc_mcp.Keeper_sandbox_factory
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
@@ -629,14 +630,14 @@ let test_turn_runtime_reuses_single_container () =
   let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir host_root;
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
-  let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta () in
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
   Fun.protect ~finally:(fun () ->
-    Keeper_turn_sandbox_runtime.cleanup runtime;
+    Keeper_sandbox_factory.cleanup factory;
     cleanup_dir base) @@ fun () ->
   let run_once () =
     match
       Keeper_docker_read.run_command_in_container_with_status
-        ~turn_sandbox_runtime:runtime
+        ~turn_sandbox_factory:factory
         ~config ~meta
         ~command_argv:[ "cat"; "/home/keeper/playground/minjae/mind/demo.txt" ]
         ~max_bytes:4096 ~timeout_sec:5.0 ()
@@ -653,7 +654,7 @@ let test_turn_runtime_reuses_single_container () =
   in
   run_once ();
   run_once ();
-  Keeper_turn_sandbox_runtime.cleanup runtime;
+  Keeper_sandbox_factory.cleanup factory;
   let lines =
     read_file log_path
     |> String.split_on_char '\n'
@@ -814,20 +815,20 @@ let test_turn_runtime_relaxed_fs_omits_readonly_and_noexec () =
   let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir host_root;
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
-  let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta () in
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
   Fun.protect ~finally:(fun () ->
-    Keeper_turn_sandbox_runtime.cleanup runtime;
+    Keeper_sandbox_factory.cleanup factory;
     cleanup_dir base) @@ fun () ->
   (match
      Keeper_docker_read.run_command_in_container_with_status
-       ~turn_sandbox_runtime:runtime
+       ~turn_sandbox_factory:factory
        ~config ~meta
        ~command_argv:[ "cat"; "/home/keeper/playground/minjae/mind/demo.txt" ]
        ~max_bytes:4096 ~timeout_sec:5.0 ()
    with
    | Error msg -> Alcotest.failf "expected turn runtime command success, got %s" msg
    | Ok _ -> ());
-  Keeper_turn_sandbox_runtime.cleanup runtime;
+  Keeper_sandbox_factory.cleanup factory;
   let run_line =
     read_file log_path
     |> String.split_on_char '\n'

--- a/test/test_keeper_exec_shell_cwd_response.ml
+++ b/test/test_keeper_exec_shell_cwd_response.ml
@@ -117,7 +117,7 @@ let test_git_log_runtime_branch_uses_cwd_response () =
     (* The git_log runtime branch builds its own cwd_response.
        Verify at least 2 distinct [cwd_response = Keeper_cwd_response.docker]
        constructions in the file (render_docker + git_log; the
-       op="bash" arm uses [match turn_sandbox_runtime] form
+       op="bash" arm uses [match turn_sandbox_factory] form
        which differs). *)
     let docker_ctor_uses =
       count_substring src "Keeper_cwd_response.docker ~host_cwd:cwd"

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -99,7 +99,7 @@ let test_patch_unique_match () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\nlet y = 2\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -121,7 +121,7 @@ let test_patch_no_match_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -151,7 +151,7 @@ let test_patch_multiple_matches_without_replace_all_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -171,7 +171,7 @@ let test_patch_replace_all () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -193,7 +193,7 @@ let test_patch_empty_old_string_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -211,7 +211,7 @@ let test_patch_missing_file_errors () =
   setup @@ fun ~config ~meta ~playground ->
   let path = Filename.concat playground "ghost.ml" in
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -228,7 +228,7 @@ let test_patch_delete_via_empty_new_string () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "keep me\nDELETE_ME\nkeep me too\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -247,7 +247,7 @@ let test_overwrite_unchanged_by_patch_addition () =
   setup @@ fun ~config ~meta ~playground ->
   let path = Filename.concat playground "new.txt" in
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~meta
       ~args:
         (`Assoc
           [

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -528,7 +528,7 @@ let test_keeper_shell_gh_without_current_task_uses_sandbox_context () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   let meta = make_meta ~sandbox_profile:Keeper_types.Docker () in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -209,7 +209,7 @@ let test_legacy_keeper_unaffected () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "secret.txt" in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "legacy bypasses symmetric containment" false
@@ -221,7 +221,7 @@ let test_docker_keeper_blocks_ls_outside () =
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc [ ("op", `String "ls"); ("path", `String outside_dir) ])
   in
@@ -233,7 +233,7 @@ let test_docker_keeper_blocks_cat_outside () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "host_secret.txt" in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "cat outside playground blocked" true
@@ -249,7 +249,7 @@ let test_docker_keeper_blocks_rg_outside () =
        (Filename.concat outside_dir "leak.txt")
        "secret-token");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -267,7 +267,7 @@ let test_docker_keeper_blocks_find_outside () =
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -285,7 +285,7 @@ let test_docker_keeper_allows_inside_playground () =
   let demo = Filename.concat playground "demo.txt" in
   ignore (Fs_compat.save_file_atomic demo "hello inside playground");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String demo) ])
   in
   (* Goal: containment did not block. Whether `cat` succeeds depends on
@@ -299,7 +299,7 @@ let test_docker_git_creds_contained () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "git_secret.txt" in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "docker git-creds also contained" true
@@ -338,7 +338,7 @@ let test_gh_binds_repo_from_active_task_worktree () =
   with_env "GH_PWD_FILE" gh_pwd_file @@ fun () ->
   with_env "PATH" (bin_dir ^ ":" ^ existing_path ()) @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -379,7 +379,7 @@ let test_gh_missing_worktree_returns_typed_error () =
   in
   let meta = { meta with current_task_id = Some current_task_id } in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "gh"); ("cmd", `String "pr list") ])
   in
   Alcotest.(check (option string)) "typed gh error"

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -261,7 +261,7 @@ let assert_docker_route_fires ~config ~meta ~playground =
   List.iter
     (fun (op, args) ->
       let raw =
-        Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta ~args
+        Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta ~args
       in
       Alcotest.(check bool)
         (Printf.sprintf "%s surfaces docker image config error (docker route fired)" op)
@@ -285,7 +285,7 @@ let test_cat_legacy_keeper_skips_docker () =
   ensure_dir (Filename.dirname host_path);
   ignore (Fs_compat.save_file_atomic host_path "matrix");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String host_path) ])
   in
   Alcotest.(check bool)
@@ -326,7 +326,7 @@ let test_rg_no_match_remains_successful_in_docker_route () =
   ensure_dir (Filename.dirname host_path);
   ignore (Fs_compat.save_file_atomic host_path "alpha\nbeta\ngamma\n");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
             [
@@ -348,7 +348,7 @@ let test_git_clone_routes_through_docker () =
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -373,7 +373,7 @@ let test_hard_mode_git_clone_uses_brokered_route () =
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -397,8 +397,8 @@ let test_bash_routes_through_docker () =
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "echo hello"); ("cwd", `String playground) ])
       ()
   in
@@ -414,8 +414,8 @@ let test_bash_legacy_skips_docker () =
   let outside_cwd = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir outside_cwd) @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "echo hello"); ("cwd", `String outside_cwd) ])
       ()
   in
@@ -429,8 +429,8 @@ let test_bash_git_creds_routes_through_docker () =
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "git status"); ("cwd", `String playground) ])
       ()
   in
@@ -444,8 +444,8 @@ let test_hard_mode_blocks_raw_gh_bash () =
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground:_ ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "gh pr list") ])
       ()
   in
@@ -608,7 +608,7 @@ let test_git_clone_repairs_existing_docker_clone_checkout () =
   Alcotest.(check bool) "checkout file removed before repair" false
     (Sys.file_exists restored_readme);
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -632,8 +632,8 @@ let test_bash_fake_docker_executes () =
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "echo hello"); ("cwd", `String playground) ])
       ()
   in

--- a/test/test_keeper_shell_via_field.ml
+++ b/test/test_keeper_shell_via_field.ml
@@ -88,7 +88,7 @@ let assert_via_host ~op raw =
         "op=%s missing [via] discriminator in host-branch JSON; raw=%s" op raw
 
 let invoke ~config ~meta args =
-  Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None
+  Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None
     ~exec_cache:None ~config ~meta ~args
 
 let test_ls_host_includes_via () =


### PR DESCRIPTION
## Why

PR-3b ([#11679](https://github.com/jeong-sik/masc-mcp/pull/11679)) renamed the keeper exec API parameter `?turn_sandbox_runtime` → `?turn_sandbox_factory` but only swept `lib/`.  The 8 test fixtures below kept the stale label and broke `dune build` workspace-wide.  PR [#11698](https://github.com/jeong-sik/masc-mcp/pull/11698) caught one of them; this PR closes the rest.

User reproduced the failure on `main` ~2026-04-29 02:07 KST:

```
File "test/test_keeper_bash_safety.ml", line 323, characters 28-32:
323 |       ~turn_sandbox_runtime:None
                                  ^^^^
Error: This argument cannot be applied with label ~turn_sandbox_runtime
[+ 7 similar errors]
```

## How

Two patterns:

1. **Label-only rename (7 files, 51 sites)** — `~turn_sandbox_runtime:None` → `~turn_sandbox_factory:None` and the `_git` variant.  `None` stays `None` on the option parameter.  Word-boundary perl prevents any module-name corruption (`Keeper_turn_sandbox_runtime` is preserved).  Files: `test_keeper_bash_safety`, `test_keeper_fs_edit_patch`, `test_keeper_shell_via_field`, `test_keeper_shell_docker_route`, `test_keeper_github_read_only`, `test_keeper_shell_containment`, `test_keeper_exec_shell_cwd_response`.

2. **Manual factory wrap (`test_keeper_docker_read.ml`, 2 test bodies)** — both built a `Keeper_turn_sandbox_runtime.t` directly and passed it as `~turn_sandbox_runtime:runtime`.  Replaced with `Keeper_sandbox_factory.{create, cleanup}`; the factory memoizes the runtime internally so the test still exercises the same dispatch path.

The pre-existing `Keeper_turn_sandbox_runtime` module alias stays — harmless and used by other cleanup-only fixtures.

## Out of scope (separate triage)

The same workspace build surfaces two unrelated `main` errors that were not caused by PR-3b and do not regress with this fix:

- `Resilience.Keeper_bridge` unbound (link error, masc_mcp lib)
- `KGR.goal_title_of_purpose` unbound (`test_keeper_goal_repair.ml`)

Will file separately if not already tracked.

## Test plan

- [x] `dune build test/` clean for the 8 cascade files (verified locally).
- [ ] CI Build and Test green (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)