### PR TITLE
test(dashboard): a11y batch 2 — collapsible/confirm-dialog

### DIFF
--- a/dashboard/src/components/common/collapsible.a11y.test.ts
+++ b/dashboard/src/components/common/collapsible.a11y.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for CollapsibleSection. The component delegates
+// disclosure semantics to native <details>/<summary>, so axe primarily
+// guards: (1) heading-text-not-empty in the summary slot, (2)
+// content-inside-disclosure-region landmark/role conformance, and
+// (3) badges (extra summary content) not breaking the summary's
+// accessible name.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { CollapsibleSection } from './collapsible'
+
+describe('CollapsibleSection a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('closed by default with text title passes axe', async () => {
+    render(
+      html`<${CollapsibleSection} title="Advanced settings">
+        <p>panel content</p>
+      <//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('open state passes axe', async () => {
+    render(
+      html`<${CollapsibleSection} title="Advanced settings" open=${true}>
+        <p>panel content</p>
+      <//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with badge in the summary slot still has an accessible name', async () => {
+    render(
+      html`<${CollapsibleSection}
+        title="Filters"
+        badge=${html`<span aria-hidden="true">·5</span>`}
+      >
+        <p>filter content</p>
+      <//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('mountWhenOpen=true closed state still passes axe (children not yet mounted)', async () => {
+    render(
+      html`<${CollapsibleSection}
+        title="Lazy panel"
+        mountWhenOpen=${true}
+      >
+        <p>expensive content</p>
+      <//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/confirm-dialog.a11y.test.ts
+++ b/dashboard/src/components/common/confirm-dialog.a11y.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for ConfirmDialogOverlay. Dialog patterns are the
+// densest a11y surface in the dashboard: aria-modal, aria-labelledby
+// on the panel, focus-trap, ESC handler. axe primarily verifies the
+// labelling and role wiring; focus-trap behavior is left to the
+// FocusScope unit tests (#11697).
+//
+// The component is signal-driven (requestConfirm sets a module-scope
+// signal). Each test triggers requestConfirm, renders the overlay,
+// runs axe, then clicks Cancel to reset the signal — otherwise state
+// would leak across tests in the same suite.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import {
+  ConfirmDialogOverlay,
+  requestConfirm,
+} from './confirm-dialog'
+
+async function dismiss(container: HTMLElement, pendingPromise: Promise<boolean>): Promise<void> {
+  const cancelBtn = container.querySelector<HTMLButtonElement>('button')
+  cancelBtn?.click()
+  // Settle the requestConfirm promise so the next test starts clean.
+  await pendingPromise.catch(() => undefined)
+  // Force a no-op render to flush the closed signal.
+  render(null, container)
+}
+
+describe('ConfirmDialogOverlay a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('closed state renders nothing (trivially accessible)', async () => {
+    render(html`<${ConfirmDialogOverlay} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('open warning dialog passes axe (default tone)', async () => {
+    const pending = requestConfirm({
+      title: 'Discard changes?',
+      message: 'Unsaved edits will be lost.',
+    })
+    render(html`<${ConfirmDialogOverlay} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+    await dismiss(container, pending)
+  })
+
+  it('open danger dialog passes axe', async () => {
+    const pending = requestConfirm({
+      title: 'Delete project?',
+      message: 'This action cannot be undone.',
+      tone: 'danger',
+      confirmText: 'Delete',
+    })
+    render(html`<${ConfirmDialogOverlay} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+    await dismiss(container, pending)
+  })
+
+  it('open info dialog passes axe', async () => {
+    const pending = requestConfirm({
+      title: 'Heads up',
+      message: 'A new version is available.',
+      tone: 'info',
+    })
+    render(html`<${ConfirmDialogOverlay} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+    await dismiss(container, pending)
+  })
+})


### PR DESCRIPTION
## Summary

Second a11y test batch (after #11703). Two atoms representing distinct a11y patterns:

| Atom | Pattern | Cases | Notes |
|------|---------|-------|-------|
| **CollapsibleSection** | disclosure (\`<details>\`/\`<summary>\`) | 4 | closed/open + badge slot + mountWhenOpen lazy-render |
| **ConfirmDialogOverlay** | modal dialog (signal-driven) | 4 | closed null + warning/danger/info open with cleanup |

8 cases, all pass.

## Changed from prior revision

Originally included DashedNotice but dropped after rebase: PR #11704 (\"Iter 5\") covers it. Conflict was add/add on \`dashed-notice.a11y.test.ts\`. Their 2-case version is in main; we yielded.

Net new atom coverage from this PR: collapsible + confirm-dialog (+8 cases).
Cumulative a11y test count after merge: button (4) + #11703 batch 1 (13) + #11704 Iter 5 (8) + this PR (8) = **33 tests**.

## Why these picks

- **Disclosure**: native \`<details>\` is the cleanest a11y pattern but composing extra summary content (badges) is a known regression vector.
- **Modal dialog**: highest-density a11y surface in the dashboard. \`aria-modal\`, \`aria-labelledby\`, focus-trap. Focus-trap behavior validated separately by FocusScope (#11697); this PR validates labelling/role wiring.

## Signal-leak guard (ConfirmDialog)

\`requestConfirm()\` writes to a module-scope signal. The local \`dismiss(container, pending)\` helper clicks Cancel + awaits the Promise so each test starts with isOpen=false. Without this, the second open-state test would inherit stale signal and assert against the wrong tone.

## Verification

- [x] \`pnpm vitest run src/components/common/{collapsible,confirm-dialog}.a11y.test.ts\` → 8/8 pass
- [x] Rebase clean against latest main
- [ ] CI checks (this PR)

## Related

- Depends on (merged): #11676 jest-axe wiring
- Sibling PRs: #11703 batch 1 (merged), #11704 Iter 5 (merged)
- Spec: design_system_v2 §6.3 (automated a11y testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)