### PR TITLE
feat(keeper): gate rejection observability — counter + log + cascade_attempted (Cycle 49)

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -177,15 +177,65 @@ let notify_gate_decision on_gate_decision (event : gate_decision_event) =
    Keeper_registry.mark_turn_gate_rejected_by_name, which fires the
    decision_stage = "gate_rejected" / turn_phase = "finalizing" transition.
    The "continue" branch (and any unknown decision string) skips the spec
-   action entirely and only emits the Event_bus Custom event below. *)
+   action entirely and only emits the Event_bus Custom event below.
+
+   Cycle 49 observability addition: when the gate rejects, the turn
+   becomes terminal WITHOUT any cascade tier ever being attempted.  A
+   dashboard reading only the final outcome ("Turn_gate_rejected") cannot
+   distinguish "all gates rejected, cascade=none" from "all cascades
+   exhausted" — both surface as terminal failure.  We add a Prometheus
+   counter, an INFO log line, and a [cascade_attempted] payload field so
+   the narrative is observable. *)
+
+(** Prometheus metric: turns terminated by a pre_tool_use gate rejection
+    (Override or ApprovalRequired) without ever attempting a cascade
+    tier.  See [emit_gate_event] for the firing site.
+
+    Labels stay bounded:
+    - [keeper]   ∈ keeper agent names (finite per fleet)
+    - [tool]     ∈ tool names (finite, registry-controlled)
+    - [reason]   ∈ guard reason_code strings (finite, defined by guards)
+    - [decision] ∈ {override, approval_required} *)
+let gate_rejected_terminal_metric =
+  "masc_keeper_turn_gate_rejected_terminal_total"
+
+let () =
+  Prometheus.register_counter
+    ~name:gate_rejected_terminal_metric
+    ~help:
+      "Total turns terminated by a pre_tool_use gate rejection \
+       (Override or ApprovalRequired) without ever attempting a \
+       cascade tier.  A non-zero rate on a keeper indicates \
+       pre_tool_use guards short-circuit before the cascade ever \
+       runs — useful for distinguishing 'all gates rejected, \
+       cascade=none' from 'all cascades exhausted' in the keeper \
+       terminal taxonomy.  Emitted with labels: keeper, tool, reason, \
+       decision."
+    ()
+
 let emit_gate_event
     ~stage ~decision ~reason_code
     ~tool_name ~agent_name ~turn
     ~accumulated_cost_usd ~stage_latency_ms ~reason_text =
-  (match decision with
-   | "override" | "approval_required" ->
-       Keeper_registry.mark_turn_gate_rejected_by_name agent_name
-   | _ -> ());
+  let is_gate_rejection =
+    match decision with
+    | "override" | "approval_required" -> true
+    | _ -> false
+  in
+  if is_gate_rejection then begin
+    Keeper_registry.mark_turn_gate_rejected_by_name agent_name;
+    Prometheus.inc_counter gate_rejected_terminal_metric
+      ~labels:[
+        ("keeper", agent_name);
+        ("tool", tool_name);
+        ("reason", reason_code);
+        ("decision", decision);
+      ] ();
+    Log.Keeper.info
+      "keeper:%s tool:%s decision=%s reason_code=%s cascade=none \
+       (gate rejected before cascade attempt)"
+      agent_name tool_name decision reason_code
+  end;
   match Masc_event_bus.get () with
   | None -> ()
   | Some bus ->
@@ -200,6 +250,7 @@ let emit_gate_event
       ("stage_latency_ms", `Float stage_latency_ms);
       ("reason_text", `String reason_text);
       ("source", `String "hook");
+      ("cascade_attempted", `Bool (not is_gate_rejection));
     ] in
     (try
       Oas_bus_instrument.publish bus


### PR DESCRIPTION
## Summary

`emit_gate_event`이 gate rejection (Override / ApprovalRequired) branch에서 (a) Prometheus counter, (b) INFO log, (c) Event_bus payload `cascade_attempted=false` 필드를 emit하도록 보강합니다. Plan §20.5 P2 (Cycle 49) — keeper "바보 상태" silent-failure path observability 시리즈의 두 번째 PR.

## Why (P2 — Cycle 49)

Cycle 48 P1 (OAS PR #1246, SSE keepalive idle deadline preservation)가 streaming hang 진단의 root cause 한 갈래였다면, P2는 **gate rejection narrative gap**입니다.

현재 동작 (Pre-PR):
- Gate가 reject (Override / ApprovalRequired) → `mark_turn_gate_rejected_by_name` → turn `Decision_gate_rejected` terminal
- **Cascade는 한 번도 시도되지 않음** (gate가 cascade 실행 전에 short-circuit)
- Dashboard는 `Turn_gate_rejected`만 보임 — "all gates rejected, cascade=none" vs "cascade attempted but all rejected"를 구분 불가

이번 PR이 추가하는 것:
- `masc_keeper_turn_gate_rejected_terminal_total` counter — keeper별 gate rejection 빈도 가시화
- INFO log line — "gate rejected before cascade attempt" narrative
- Event_bus payload `cascade_attempted: bool` — downstream consumer가 stream 필터 가능

## What changed

`lib/keeper/keeper_guards.ml` — `emit_gate_event` 함수만 (1 파일, +56/-5):

| 변경 | 위치 | 형태 |
|------|------|------|
| Prometheus counter 등록 | top-level `let () = Prometheus.register_counter ...` | `keeper_accountability.ml:114-122` 패턴 재사용 |
| Counter 등록 docstring | 위 등록 위 | label set (`keeper, tool, reason, decision`) 명시 |
| `is_gate_rejection` 추출 | `emit_gate_event` 시작 | match로 boolean 결정 |
| `inc_counter` + `Log.info` | gate rejection branch | label dict 4 fields |
| Event_bus payload | 모든 branch | `cascade_attempted` 필드 추가 |

## Verification

```bash
# Lib build (clean)
dune build --root <worktree> lib/keeper/                  # ✓ OK

# Existing test_keeper_guards build is BLOCKED by main self-blocker:
#   Error: Unbound module Resilience.Keeper_bridge
# Cross-check on origin/main confirms same error WITHOUT this branch's changes.
# Per memory rule `feedback_main_blockers_check_unrelated_pr_check_fails`,
# this is not introduced by this PR.
```

**Production verification**: 머지 후 Prometheus dashboard에서 `masc_keeper_turn_gate_rejected_terminal_total{keeper=*}` counter가 non-zero인 keeper를 확인. 만약 0이면 해당 keeper는 gate rejection 경로를 한 번도 안 탔다는 뜻.

## Risk

- **낮음** — 변경은 관찰만 (counter + log + payload 필드 추가). 기존 control flow 0 변경
- 기존 Event_bus consumer가 `cascade_attempted` 필드를 모르면 무시 (Yojson `Assoc`는 extra 필드 허용)
- Counter label cardinality는 bounded (keeper / tool / reason / decision 모두 finite set)

## Companion PR

Plan §20 P1/P2/P3 시리즈:
- P1: jeong-sik/oas#1246 — SSE keepalive idle deadline preservation (Draft)
- **P2: 이 PR** — gate rejection observability
- P3 (planned): watchdog soft threshold counters

P2/P3는 OAS 의존성 0이라 P1 머지 대기 없이 병렬 진행.

## Test plan

- [x] `dune build lib/keeper/` clean
- [x] Race check (`gh pr list --search "gate_rejection OR keeper_guards"`) — 0건
- [x] Cross-check main self-blocker (Resilience.Keeper_bridge)
- [ ] Reviewer 검토
- [ ] (post-merge) Production dashboard에서 counter non-zero 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
