### PR TITLE
feat(keeper-watchdog): kill-class-dimensioned termination counter (Cycle 50)

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -89,6 +89,42 @@ let record_stale_termination keeper_name now : int =
     Hashtbl.replace termination_history keeper_name pruned;
     List.length pruned)
 
+(* Cycle 50 observability: kill-class-dimensioned counter.
+
+   The pre-existing [masc_keeper_stale_termination_total] counter has
+   only the [keeper] label, so a dashboard cannot attribute kills to
+   the typed [stale_kill_class] root cause without re-parsing the
+   reason_desc text.  PR #11292 already typed the class as
+   [Keeper_registry.stale_kill_class] (idle_turn / in_turn_hung /
+   noop_failure_loop); this PR surfaces that class as a Prometheus
+   label so operators can chart "which root cause is dominant?".
+
+   The existing termination counter is preserved unchanged (no label
+   changes, no removal) so existing dashboards / alerts continue to
+   work.  This counter is purely additive. *)
+
+(** Map a [stale_kill_class] to a low-cardinality Prometheus label
+    value.  Keep this distinct from [Keeper_registry.stale_kill_class_to_string]
+    which embeds variable counts (seconds, noop_count) — those would
+    explode counter cardinality. *)
+let stale_kill_class_label (cls : Keeper_registry.stale_kill_class) : string =
+  match cls with
+  | Idle_turn _ -> "idle_turn"
+  | In_turn_hung _ -> "in_turn_hung"
+  | Noop_failure_loop _ -> "noop_failure_loop"
+
+let () =
+  Prometheus.register_counter
+    ~name:"masc_keeper_stale_termination_by_class_total"
+    ~help:
+      "Total stale watchdog terminations broken down by typed kill \
+       class (idle_turn | in_turn_hung | noop_failure_loop).  \
+       Companion to masc_keeper_stale_termination_total which has \
+       only the keeper label — this counter adds the class dimension \
+       so dashboards can attribute kills to root cause without \
+       re-parsing the reason_desc string.  Labels: keeper, class."
+    ()
+
 (* #10765 phase 2: fleet-wide batch termination detection.
 
    Each keeper runs its watchdog as an independent fiber, so the
@@ -280,6 +316,13 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                Prometheus.inc_counter
                  "masc_keeper_stale_termination_total"
                  ~labels:[ ("keeper", meta.name) ]
+                 ();
+               Prometheus.inc_counter
+                 "masc_keeper_stale_termination_by_class_total"
+                 ~labels:[
+                   ("keeper", meta.name);
+                   ("class", stale_kill_class_label kill_class);
+                 ]
                  ();
                Log.Keeper.error
                  "%s: stale watchdog terminating fiber (%s) [cascade=%s window_count=%d/6h]"


### PR DESCRIPTION
## Summary

Stale watchdog의 typed `stale_kill_class` (idle_turn / in_turn_hung / noop_failure_loop)를 Prometheus label로 surface합니다. 신규 counter `masc_keeper_stale_termination_by_class_total{keeper, class}` 추가, 기존 `masc_keeper_stale_termination_total` 그대로 보존. Plan §20.6 P3 (Cycle 50) — keeper "바보 상태" silent-failure observability 시리즈의 세 번째 PR.

## Why (P3 — Cycle 50)

PR #11292이 stale watchdog kill reason을 typed enum (`Keeper_registry.stale_kill_class`)으로 만들었지만, Prometheus counter는 여전히 단일 `masc_keeper_stale_termination_total{keeper}` 형태입니다. Dashboard에서:

- "어느 root cause가 dominant인가?" — 알 수 없음
- `reason_desc` log line 파싱 필요 (high-cardinality strings 포함)
- `stale_kill_class_to_string`은 숫자 (`stall_seconds`, `noop_count`) 포함 → label로 쓰면 cardinality 폭발

이번 PR은 enum-only label `class ∈ {idle_turn, in_turn_hung, noop_failure_loop}` 만 노출하는 별도 counter를 추가해 dashboard PromQL 쿼리로 직접 분리 가능하게 합니다.

## What changed

`lib/keeper/keeper_stale_watchdog.ml` — 1 파일, +37/-0:

| 변경 | 위치 | 내용 |
|------|------|------|
| Helper `stale_kill_class_label` | `record_stale_termination` 옆 | enum tag만 반환 (`idle_turn`/`in_turn_hung`/`noop_failure_loop`) |
| Counter registration | top-level `let () =` | bounded labels 명시 |
| inc_counter 추가 | line 316 옆 | 기존 `masc_keeper_stale_termination_total` 호출 직후 |

## Verification

```bash
# Lib build (clean)
dune build --root <worktree> lib/keeper/                  # ✓ OK

# Test build blocked by main self-blocker (Resilience.Keeper_bridge)
# — cross-check confirms same error WITHOUT this branch's changes.
# Per memory rule `feedback_main_blockers_check_unrelated_pr_check_fails`,
# this is not introduced by this PR.
```

**Production verification**: 머지 후 PromQL 쿼리:

```
sum by (class) (rate(masc_keeper_stale_termination_by_class_total[1h]))
```

가 `{idle_turn, in_turn_hung, noop_failure_loop}` 3 branches로 attribute되어 보임.

## Risk

- **0** — purely additive. 기존 `masc_keeper_stale_termination_total` 그대로 (회귀 0)
- 신규 counter cardinality bounded:
  - keeper labels: 운영 fleet의 keeper 수 (~10s)
  - class labels: 정확히 3 (idle_turn, in_turn_hung, noop_failure_loop)
  - 총 cardinality: ~30 unique time series
- `stale_kill_class_label` helper는 모듈 internal — 외부 영향 없음

## Companion PRs

Plan §20 P1/P2/P3 시리즈:
- P1: jeong-sik/oas#1246 — SSE keepalive idle deadline preservation (Draft)
- P2: jeong-sik/masc-mcp#11708 — gate rejection observability (Draft)
- **P3: 이 PR** — watchdog kill-class counter

세 PR 모두 keeper "바보 상태" 진단의 다른 갈래를 fix/observe합니다.

## Test plan

- [x] `dune build lib/keeper/` clean
- [x] Race check (`gh pr list --search "stale_watchdog OR kill_class OR termination_by_class"`) — 0건
- [x] Cross-check main self-blocker (Resilience.Keeper_bridge)
- [ ] Reviewer 검토
- [ ] (post-merge) Production dashboard에서 class label 분리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
