### PR TITLE
fix(main-blockers): coord/resilience rename cascade + KGR mli expose

### DIFF
--- a/lib/keeper/keeper_goal_repair.mli
+++ b/lib/keeper/keeper_goal_repair.mli
@@ -8,9 +8,11 @@
     3. Assigns the new goal id to [active_goal_ids].
 
     Two entry points: {!dry_run} (no side effects, returns the audit
-    only) and {!run} (actually creates goals + writes meta).  Internal
-    helpers (find / repair / title-derivation / empty-result constant)
-    stay private.
+    only) and {!run} (actually creates goals + writes meta).  The
+    title-derivation helper {!goal_title_of_purpose} is exposed for
+    targeted unit-test coverage of its truncation/empty/long
+    branches; other internal helpers (find / repair / empty-result
+    constant) stay private.
 
     @since 2.237.0 *)
 
@@ -38,6 +40,17 @@ type repair_result = {
     when projecting to the dashboard JSON.  Lists are returned in
     keeper-name order (stable scan order from the [.json] directory
     listing reversed back). *)
+
+val goal_title_of_purpose : string -> string
+(** [goal_title_of_purpose purpose] derives the goal title from a
+    keeper's purpose statement:
+    - empty / whitespace-only purpose → ["(unnamed keeper)"]
+    - purpose ≤ 115 chars → ["<purpose> (auto)"]
+    - purpose > 115 chars → first 115 chars + ["… (auto)"]
+
+    The returned string never exceeds 130 chars.  Exposed for direct
+    unit testing of the truncation contract; production code should
+    prefer {!run}/{!dry_run}. *)
 
 val repair_result_to_yojson : repair_result -> Yojson.Safe.t
 (** [repair_result_to_yojson r] renders the result as


### PR DESCRIPTION
## Why

User reproduced two `dune build` failures on main (~2026-04-29 02:07 KST). Both block the workspace build.

### Blocker 1: incomplete coord/resilience rename

PR [#11709](https://github.com/jeong-sik/masc-mcp/pull/11709) renamed `lib/coord/resilience.ml` → `coord_resilience.ml` to stop the unwrapped `Resilience` from shadowing `lib/resilience/` (wrapped library), but missed:

- `lib/coord/resilience.mli` — left in place; .mli without a matching .ml kept dune confused.
- 5 test fixtures still calling `Resilience.{Time, Zombie, ZeroZombie, default_*}` and `module Resilience = Resilience` aliases.

This PR finishes the rename: git-mv the stale .mli, bulk-rename the 5 fixtures to `Coord_resilience.X`, and verify `dune build` clean.

### Blocker 2: KGR.goal_title_of_purpose

`test/test_keeper_goal_repair.ml:6` calls `Keeper_goal_repair.goal_title_of_purpose`, defined in the .ml but hidden by the .mli. Three independent test cases (short, empty, long-truncation) cover its branches — exposing the helper for unit tests is cheaper than scaffolding disk fixtures around `dry_run`/`run`.

## Files (2 commits)

| Commit | Files |
|--------|-------|
| `77c892dbe7` KGR | `lib/keeper/keeper_goal_repair.mli` (3 lines exposed) |
| `88dc9920c2` coord rename | `lib/coord/{resilience,coord_resilience}.mli` (rename) + 5 test files |

## Boundary

The wrapped `lib/resilience/` sub-library and its `test/resilience/*` fixtures (`Resilience.{Keeper_bridge, Recovery, Confidence}`) are untouched — those refer to the wrapped sub-library and are unaffected by the coord rename.

## Test plan

- [x] `dune build` clean on main HEAD `4adc74f959` after both commits
- [ ] CI Build green (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)