### PR TITLE
chore(coord): add coord_resilience.mli (cycle 100)

### DIFF
--- a/lib/coord/coord_resilience.mli
+++ b/lib/coord/coord_resilience.mli
@@ -1,0 +1,152 @@
+(** Coord_resilience — single source of truth for failure handling.
+
+    Three sub-modules organise the resilience helpers:
+
+    - {!Time}: monotonic-clock + ISO 8601 parsing.
+    - {!Zombie}: agent-staleness detection with per-class thresholds
+      (regular vs keeper agents).
+    - {!ZeroZombie}: cleanup-loop bookkeeping for the zero-zombie
+      protocol that runs in the background.
+
+    Renamed from [Resilience] (cycle 100 / fix #11709) so the module
+    name does not shadow the [masc_mcp.resilience] sub-library that
+    PR #11695 started using via [Resilience.Keeper_bridge].
+
+    @since Single source of truth — failure handling consolidation *)
+
+val default_zombie_threshold : float
+(** Reads [Env_config_runtime.Zombie.threshold_seconds].
+    Default: 300.0 (5 minutes).  Operator override:
+    [MASC_ZOMBIE_THRESHOLD_SEC]. *)
+
+val default_warning_threshold : float
+(** [120.0] (2 minutes).  Pinned at the contract seam — a future
+    "let's tune the inactivity warning" change must touch this
+    constant explicitly so dashboard "agent inactive" copy stays in
+    sync. *)
+
+(** {1 Time helpers} *)
+
+module Time : sig
+  val now : unit -> float
+  (** [now ()] returns the current monotonic Unix-epoch seconds via
+      {!Time_compat.now}. *)
+
+  val parse_iso8601_opt : string -> float option
+  (** [parse_iso8601_opt s] parses an ISO 8601 UTC timestamp.
+      Delegates to {!Types_core.parse_iso8601_opt}.  On parse
+      failure logs at {!Log.Misc.error} and returns [None] —
+      operator runbooks grep on "parse_iso8601_opt failed for:"
+      to detect malformed [last_seen] timestamps in agent state. *)
+
+  val is_stale : ?threshold:float -> string -> bool
+  (** [is_stale ?threshold timestamp_str] returns [true] iff
+      [now () - parse(timestamp_str)] exceeds [threshold]
+      (default {!default_zombie_threshold}).
+
+      {b Important}: malformed timestamps return [true] (treated
+      as stale/zombie).  This is fail-loud — silent acceptance of
+      bad timestamps would let agents avoid eviction by writing
+      garbage.  A future "tolerate parse errors" change would
+      reopen the eviction-bypass class. *)
+end
+
+(** {1 Zombie detection} *)
+
+module Zombie : sig
+  val is_keeper_name : string -> bool
+  (** [is_keeper_name name] tests whether [name] matches the
+      keeper convention [keeper-*-agent] (case-insensitive,
+      trimmed).  Used to apply the longer keeper threshold. *)
+
+  val is_zombie : ?threshold:float -> string -> bool
+  (** [is_zombie ?threshold last_seen_iso] is a thin alias for
+      {!Time.is_stale}. *)
+
+  val is_keeper :
+    name:string -> agent_type:string -> bool
+  (** [is_keeper ~name ~agent_type] returns [true] when EITHER:
+      - [name] matches the keeper-name convention, OR
+      - [agent_type] equals ["keeper"] (case-insensitive, trimmed)
+
+      Name-only matching is insufficient because any agent named
+      [keeper-*-agent] would otherwise get the extended 7-day
+      threshold without the type field check. *)
+
+  val is_zombie_for_agent :
+    agent_name:string -> string -> bool
+  (** [is_zombie_for_agent ~agent_name last_seen_iso] uses
+      {!Env_config_runtime.Zombie.keeper_threshold_seconds} when
+      [agent_name] matches {!is_keeper_name}, otherwise falls
+      back to {!default_zombie_threshold}.  This is the canonical
+      "should I evict this agent" predicate for the gc loop. *)
+end
+
+(** {1 Zero-Zombie protocol}
+
+    Background cleanup loop that runs periodically, invoking a
+    caller-supplied [cleanup_fn] and recording stats.  Used by the
+    bootstrap code to ensure stale agents do not accumulate. *)
+
+module ZeroZombie : sig
+  type stats = {
+    mutable total_cleanups : int;
+    mutable last_cleanup_ts : float;
+    mutable last_cleaned_agents : string list;
+  }
+  (** Concrete record because the global [global_stats] is exposed
+      and dashboards mutate it in place.  All fields are mutable
+      to avoid allocation in the cleanup hot path. *)
+
+  val global_stats : stats
+  (** Singleton stats record updated by every {!cleanup} call.
+      Operators inspect this through the dashboard's
+      "zero-zombie protocol" surface card. *)
+
+  val cleanup : cleanup_fn:(unit -> string list) -> string list
+  (** [cleanup ~cleanup_fn] runs [cleanup_fn ()].  When the result
+      is non-empty:
+      - increments [global_stats.total_cleanups],
+      - sets [last_cleanup_ts] to current time,
+      - replaces [last_cleaned_agents] with the result.
+
+      Returns the cleaned-agents list verbatim. *)
+
+  val is_benign_error : exn -> bool
+  (** [is_benign_error exn] returns [true] for two transient
+      patterns operators expect at startup:
+      - [Invalid_argument("MASC...")] — MASC not initialized yet.
+      - [Sys_error("No such file...")] — transient race during
+        directory creation.
+
+      The two prefixes are pinned at 20 / 14 chars respectively;
+      the prefix-match approach is intentional so a future
+      exception-message tweak does not reopen the noisy-warning
+      surface. *)
+
+  val run_loop :
+    ?interval:float ->
+    clock:_ Eio.Time.clock ->
+    cleanup_fn:(unit -> string list) ->
+    unit ->
+    unit
+  (** [run_loop ?interval ~clock ~cleanup_fn ()] is the long-lived
+      background fiber: sleep [interval] seconds (default
+      [60.0]), call {!cleanup}, repeat.
+
+      {2 Cancellation}
+
+      [Eio.Cancel.Cancelled] is re-raised from every nesting
+      level so a switch teardown propagates immediately.
+
+      {2 Error policy}
+
+      Sleep failures are logged at {!Log.Misc.error} but the loop
+      continues.  Cleanup failures are split:
+      - {!is_benign_error} → silently ignored (no log noise)
+      - other → {!Log.Misc.error} but the loop continues
+
+      The "loop continues despite errors" stance is deliberate:
+      the zero-zombie cleanup is best-effort, not strict — a
+      transient FS race must not stop the cycle. *)
+end


### PR DESCRIPTION
## Summary

Cycle 100 — adds an explicit interface for
`lib/coord/coord_resilience.ml` (126 lines).

Locks in the new namespace from fix #11709 (renamed from
`lib/coord/resilience.ml` to break the shadow with the
`masc_mcp.resilience` sub-library).

## Surface (8 entries, 0 hide)

```ocaml
val default_zombie_threshold : float    (* env-cached *)
val default_warning_threshold : float   (* = 120.0 *)

module Time : sig
  val now : unit -> float
  val parse_iso8601_opt : string -> float option
  val is_stale : ?threshold:float -> string -> bool
end

module Zombie : sig
  val is_keeper_name : string -> bool
  val is_zombie : ?threshold:float -> string -> bool
  val is_keeper : name:string -> agent_type:string -> bool
  val is_zombie_for_agent : agent_name:string -> string -> bool
end

module ZeroZombie : sig
  type stats = {
    mutable total_cleanups : int;
    mutable last_cleanup_ts : float;
    mutable last_cleaned_agents : string list;
  }
  val global_stats : stats
  val cleanup : cleanup_fn:(unit -> string list) -> string list
  val is_benign_error : exn -> bool
  val run_loop :
    ?interval:float -> clock:_ Eio.Time.clock ->
    cleanup_fn:(unit -> string list) -> unit -> unit
end
```

No hidden helpers — 11 callers across orchestrator / coord_state
/ coord_task / coord_gc / dashboard / operator / keeper /
server / voice / session use these symbols directly.

## Time.parse_iso8601_opt fail-loud contract

Malformed timestamps return `None` and log at
`Log.Misc.error "parse_iso8601_opt failed for: %S"`. Downstream
`Time.is_stale` treats `None` as **stale (returns true)** —
silent acceptance of bad timestamps would let agents avoid
eviction by writing garbage. Pinning at the contract seam.

## Zombie threshold cascade

| `is_keeper_name agent_name` | Threshold |
|---|---|
| `true` | `Env_config_runtime.Zombie.keeper_threshold_seconds` |
| `false` | `default_zombie_threshold` |

Name-only matching is insufficient for `is_keeper` (any
agent literally named `keeper-*-agent` would otherwise inherit
the longer threshold) — the `agent_type:"keeper"` field check
is required.

## ZeroZombie.is_benign_error pattern set

| Pattern | Length | Meaning |
|---|---|---|
| `Invalid_argument("MASC...` | 20 chars | MASC not initialized |
| `Sys_error("No such file...` | 14 chars | Transient FS race |

Pinning the prefixes prevents a future "tweak the exception
wording" change from reopening the noisy-warning surface.

## run_loop best-effort stance

Loop continues despite errors. Cleanup failures split:
- `is_benign_error` → silently ignored
- other → `Log.Misc.error` but loop continues

Zero-zombie cleanup is best-effort, not strict — a transient FS
race must not stop the cycle.

## Caller audit
- `lib/orchestrator.ml` — `Zombie` + `ZeroZombie`
- `lib/operator/operator_control_snapshot.ml` —
  `Time.parse_iso8601_opt`
- `lib/coord/coord_task.ml` — `Zombie.is_keeper_name`
- `lib/coord/coord_state.ml` — `default_zombie_threshold` +
  `Time` + `Zombie`
- `lib/coord/coord_gc.ml` — `Zombie.is_keeper`
- `lib/server/server_runtime_bootstrap.ml` —
  `Time.parse_iso8601_opt`
- `lib/voice/voice_session_manager.ml` + `.mli` —
  `default_zombie_threshold` + `Time`
- `lib/session.ml` — `default_warning_threshold`

## Test plan
- [x] `dune build --root . lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
