### PR TITLE
test(dashboard): a11y batch 3 — distribution-bars/error-boundary/input

### DIFF
--- a/dashboard/src/components/common/distribution-bars.a11y.test.ts
+++ b/dashboard/src/components/common/distribution-bars.a11y.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for DistributionBars + SegmentedBar — data-viz
+// atoms. axe primarily guards: (1) the bars convey their data via
+// text labels (numeric + label) not color-alone, and (2) the tone
+// palette doesn't introduce contrast-against-bg violations on any
+// of the 5 tone slots.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import {
+  DistributionBars,
+  type DistributionItem,
+} from './distribution-bars'
+
+const items: DistributionItem[] = [
+  { label: 'Active', value: 12, tone: 'ok' },
+  { label: 'Idle', value: 5, tone: 'muted' },
+  { label: 'Errored', value: 2, tone: 'bad' },
+]
+
+describe('DistributionBars a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('basic items render accessibly', async () => {
+    render(html`<${DistributionBars} items=${items} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with detail strings on each item passes axe', async () => {
+    const detailed = items.map((i) => ({ ...i, detail: `${i.value} keepers` }))
+    render(html`<${DistributionBars} items=${detailed} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('all 5 tones at once passes axe (tone-palette sweep)', async () => {
+    const allTones: DistributionItem[] = [
+      { label: 'A', value: 1, tone: 'accent' },
+      { label: 'O', value: 2, tone: 'ok' },
+      { label: 'W', value: 3, tone: 'warn' },
+      { label: 'B', value: 4, tone: 'bad' },
+      { label: 'M', value: 5, tone: 'muted' },
+    ]
+    render(html`<${DistributionBars} items=${allTones} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+// SegmentedBar a11y test deliberately omitted from this PR.
+//
+// First-run revealed a real production violation: distribution-bars.ts
+// renders `<div aria-label="...">` without a `role`. axe rule
+// `aria-prohibited-attr` rejects this — aria-label requires a valid
+// role on non-semantic elements. Same pattern at lines 152-156 (bar
+// segments) and 164-170 (chip pills).
+//
+// Treating it under Issue Discovery Protocol (instructions/workflow.md):
+// scope of this PR is *adding* a11y coverage, not fixing components.
+// Mixing the fix in would silently expand surgical change scope.
+//
+// Followup: SegmentedBar should either add role="img" + aria-label OR
+// drop aria-label and rely on the visible label rendered alongside.
+// Tracking via PR description (this PR's body); upgrade to GitHub issue
+// if the fix doesn't land in the next iter.

--- a/dashboard/src/components/common/error-boundary.a11y.test.ts
+++ b/dashboard/src/components/common/error-boundary.a11y.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for ErrorBoundary. Two surfaces:
+//   1. Happy path: children render unchanged → axe just verifies the
+//      passthrough doesn't introduce wrapping issues.
+//   2. Error path: a child throws on render → boundary catches and
+//      shows the fatal/recoverable banner with retry (+reload for
+//      fatal). axe verifies the banner's own a11y (heading hierarchy,
+//      button labels, alert role).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { ErrorBoundary } from './error-boundary'
+
+function Boom(): unknown {
+  throw new Error('boom')
+}
+
+describe('ErrorBoundary a11y', () => {
+  let container: HTMLElement
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    // Preact prints the caught error to console.error during render —
+    // silence the noise so test output stays readable.
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+    errorSpy.mockRestore()
+  })
+
+  it('happy path: children render passes axe', async () => {
+    render(
+      html`<${ErrorBoundary}>
+        <button type="button" aria-label="ok">ok</button>
+      <//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('error path with default fatal severity passes axe', async () => {
+    render(
+      html`<${ErrorBoundary} label="Test"><${Boom} /><//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('error path with recoverable severity passes axe', async () => {
+    render(
+      html`<${ErrorBoundary} label="Test" severity="recoverable">
+        <${Boom} />
+      <//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('custom fallback render passes axe when caller provides one', async () => {
+    const fallback = (err: Error) =>
+      html`<div role="alert" aria-live="assertive">
+        <p>Custom: ${err.message}</p>
+      </div>`
+    render(
+      html`<${ErrorBoundary} fallback=${fallback}>
+        <${Boom} />
+      <//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/input.a11y.test.ts
+++ b/dashboard/src/components/common/input.a11y.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for TextInput + TextArea. Form inputs need an
+// accessible name; the component's JSDoc explicitly warns that
+// dropping `id` (for external <label for="">) or `ariaLabel` is a
+// known regression. Tests pin both labelling strategies, plus disabled
+// + required + placeholder-only (an axe-violation negative — caught
+// by NOT including a placeholder-only test).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { TextInput, TextArea } from './input'
+
+describe('TextInput a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with ariaLabel passes axe', async () => {
+    render(html`<${TextInput} ariaLabel="Project name" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with id + external <label for=""> passes axe', async () => {
+    render(
+      html`<div>
+        <label for="proj">Project</label>
+        <${TextInput} id="proj" />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('disabled + ariaLabel passes axe', async () => {
+    render(
+      html`<${TextInput} ariaLabel="Locked field" disabled=${true} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('required + ariaLabel passes axe', async () => {
+    render(
+      html`<${TextInput} ariaLabel="Email" required=${true} type="email" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('TextArea a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with ariaLabel passes axe', async () => {
+    render(html`<${TextArea} ariaLabel="Description" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with id + external <label for=""> passes axe', async () => {
+    render(
+      html`<div>
+        <label for="desc">Description</label>
+        <${TextArea} id="desc" />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

Third a11y test batch. Three different a11y patterns:

| Atom | Pattern | Cases | Notes |
|------|---------|-------|-------|
| **DistributionBars** | data viz | 3 | items + per-item detail + 5-tone palette sweep |
| **ErrorBoundary** | state-driven panel | 4 | happy path + fatal + recoverable + custom fallback |
| **TextInput / TextArea** | form input | 6 | mirrors checkbox batch 1 pattern (ariaLabel + id+\`<label>\` + disabled/required/type) |

13 cases, all pass. \`tsc --noEmit\` clean.

## ⚠️ Production a11y bug discovered (not fixed here)

While writing the SegmentedBar a11y test, axe surfaced a real violation in \`distribution-bars.ts\`:

- Lines **152–156** — bar segments use \`<div aria-label=\"...\">\` without a \`role\` attribute.
- Lines **164–170** — chip pills use \`<span aria-label=\"...\">\` without a \`role\` attribute.

axe rule \`aria-prohibited-attr\`: aria-label requires a valid role on non-semantic elements.

**Issue Discovery Protocol applied** (instructions/workflow.md): scope of this PR is *adding* a11y coverage, not *fixing* components. Mixing the fix in would silently expand surgical change scope. SegmentedBar a11y test deliberately **omitted** with an inline comment pointing at the violation. Followup options:
1. Add \`role=\"img\"\` + keep aria-label
2. Drop aria-label and rely on the visible label rendered alongside

If not fixed in the next iter, upgrade this footnote to a tracked GitHub issue.

## Verification

- [x] \`pnpm vitest run src/components/common/{distribution-bars,error-boundary,input}.a11y.test.ts\` → 13/13 pass
- [x] \`pnpm tsc --noEmit\` clean
- [ ] CI checks (this PR)

## Cumulative coverage

button (4) + #11703 (13) + #11704 (8) + #11707 (8 after rebase) + **this PR (13)** = **46 a11y cases** across 12 atoms once this lands.

## Related

- Depends on (merged): #11676 jest-axe wiring
- Sibling PRs: #11703 (merged), #11704 (merged), #11707 (Draft, rebased)
- Spec: design_system_v2 §6.3 (automated a11y testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)