### PR TITLE
chore(events): add oas_events.mli (cycle 120)

### DIFF
--- a/lib/oas_events.mli
+++ b/lib/oas_events.mli
@@ -1,0 +1,177 @@
+(** Oas_events — MASC Event_bus publishers for runtime / social
+    events.
+
+    Publishes MASC coordination events (broadcasts, heartbeats,
+    board posts, task transitions, keeper lifecycle, trust /
+    reputation) to the **MASC-owned** Event_bus.  Events follow
+    dot-separated snake_case naming per OAS Custom-name
+    convention: [masc.broadcast], [masc.heartbeat],
+    [masc.keeper.lifecycle], ...
+
+    The [bus] argument is accepted for backward compatibility
+    but ignored — every publish routes to
+    {!Masc_event_bus.get} so the OAS/MASC layer boundary is
+    preserved regardless of the caller's bus reference.  OAS's
+    [event_bus.mli:103-107] explicitly warns against publishing
+    domain events onto OAS's bus.
+
+    Wire format on SSE output keeps colon separators
+    ([masc.broadcast]) for dashboard compatibility — translation
+    is done by the SSE relay, not here.
+
+    @since 2.90.0 (bus-separated since 2.353.0) *)
+
+(** {1 Active publishers} *)
+
+val publish_broadcast :
+  Oas.Event_bus.t -> agent_name:string -> content:string -> unit
+(** Publishes [masc.broadcast] with payload
+    [{agent_name, content, timestamp}]. *)
+
+val publish_heartbeat :
+  Oas.Event_bus.t ->
+  agent_name:string ->
+  turn:int ->
+  context_pct:float ->
+  unit
+(** Publishes [masc.heartbeat] with payload
+    [{agent_name, turn, context_pct, timestamp}]. *)
+
+val publish_task_transition :
+  Oas.Event_bus.t ->
+  agent_name:string ->
+  task_id:string ->
+  transition:Types.task_action ->
+  unit
+(** Publishes [masc.task_transition] with payload
+    [{agent_name, task_id, transition, timestamp}].
+
+    [transition] is the canonical {!Types.task_action} variant
+    (#8605 family) — typos at call sites fail to compile.
+    Wire format ([["claim"]] / [["start"]] / [["done"]] / ...)
+    preserved via {!Types.task_action_to_string}.  Sibling
+    refactor of #8846 (Coord-side hook for the same transition
+    vocabulary). *)
+
+(** {1 Keeper snapshot + lifecycle} *)
+
+val publish_keeper_snapshot :
+  Oas.Event_bus.t ->
+  keeper_name:string ->
+  generation:int ->
+  context_ratio:float ->
+  message_count:int ->
+  unit
+(** Publishes [masc.keeper.snapshot] with payload
+    [{keeper_name, generation, context_ratio, message_count, timestamp}].
+    Emitted alongside SSE broadcast in [keeper_keepalive]. *)
+
+val publish_keeper_lifecycle :
+  Oas.Event_bus.t ->
+  event:Keeper_lifecycle_events.lifecycle_event ->
+  keeper_name:string ->
+  detail:string ->
+  unit ->
+  unit
+(** Publishes [masc.keeper.lifecycle] with payload
+    [{event, keeper_name, phase, detail, timestamp}].
+
+    [event] is the unified
+    {!Keeper_lifecycle_events.lifecycle_event} variant (#8856
+    / #8605 family) — typos at the 16 supervisor / keepalive
+    call sites fail to compile.
+
+    {2 Wire format pinned}
+
+    JSON wire format preserved bit-identically across the
+    variant unification:
+    - [Custom_event { verb; phase = None }] → [event=verb], [phase=null]
+    - [Custom_event { verb; phase = Some p }] → [event=verb], [phase=p]
+    - [Phase_event p] → [event=p], [phase=p]
+
+    Subscribe to {!Keeper_lifecycle_events.all_event_names} to
+    receive the full stream.  Issue #8575: prior docstring
+    listed only five names, so operators silently missed
+    cleanup / self-healing events ([reconciled],
+    [dead_cleaned], [self_preservation], [paused_pruned]) —
+    exactly the events that signal supervisor recovery actions
+    where observability matters most. *)
+
+val publish_keeper_dead :
+  Oas.Event_bus.t ->
+  keeper_name:string ->
+  reason:string ->
+  restart_count:int ->
+  last_failure_reason:string option ->
+  unit ->
+  unit
+(** Publishes [masc.keeper.dead] with payload
+    [{keeper_name, reason, restart_count, last_failure_reason, timestamp}].
+
+    Emitted when {!Keeper_supervisor.sweep_and_recover} gives
+    up on a keeper after [restart_count >= max_restarts].
+    Operators should treat this as actionable: the supervisor
+    will NOT retry the keeper.
+
+    Independent from the [event="dead"] entry on
+    [masc.keeper.lifecycle] (which is unstructured free-form
+    [detail]) so subscribers can filter on a stable topic and
+    pull the structured fields directly. *)
+
+(** {1 Autonomy lifecycle (deprecated — no producer)} *)
+
+val publish_agent_selected :
+  Oas.Event_bus.t ->
+  agent_name:string ->
+  trigger:string ->
+  thompson_score:float ->
+  final_score:float ->
+  unit
+[@@deprecated "Unused since #1060 (no producer wired). Tracked \
+               as 'mark scaffolding' tier of #8857; planned \
+               wiring in Thompson autonomy RFC (open)."]
+
+val publish_agent_decision :
+  Oas.Event_bus.t ->
+  agent_name:string ->
+  action:string ->
+  trigger_reason:string ->
+  unit
+[@@deprecated "Unused since #1060 (no producer wired). Tracked \
+               as 'mark scaffolding' tier of #8857; planned \
+               wiring in Thompson autonomy RFC (open)."]
+
+val publish_agent_action_executed :
+  Oas.Event_bus.t ->
+  agent_name:string ->
+  action:string ->
+  success:bool ->
+  unit
+[@@deprecated "Unused since #1060 (no producer wired). Tracked \
+               as 'mark scaffolding' tier of #8857; planned \
+               wiring in Thompson autonomy RFC (open)."]
+
+(** {1 Phase 4 social (deprecated — no producer)} *)
+
+val publish_trust_updated :
+  Oas.Event_bus.t ->
+  agent_a:string ->
+  agent_b:string ->
+  trust_score:float ->
+  unit
+[@@deprecated "Unused since #1060 (no producer wired). Tracked \
+               as 'mark scaffolding' tier of #8857; planned \
+               wiring with Phase 4 social network feature \
+               (open)."]
+
+val publish_reputation_changed :
+  Oas.Event_bus.t ->
+  agent_name:string ->
+  old_score:float ->
+  new_score:float ->
+  trend:string ->
+  unit
+[@@deprecated "Unused since #1060 (no producer wired). Tracked \
+               as 'mark scaffolding' tier of #8857; planned \
+               wiring with Phase 4 social network feature \
+               (open)."]


### PR DESCRIPTION
## Summary

Cycle 120 — adds an explicit interface for
`lib/oas_events.ml` (249 lines).

## Surface (11 entries, 1 hide)

**Active publishers (6):**

```ocaml
val publish_broadcast / publish_heartbeat / publish_task_transition
val publish_keeper_snapshot / publish_keeper_lifecycle
val publish_keeper_dead
```

**Deprecated publishers (5, all `[@@deprecated]`):**

```ocaml
val publish_agent_selected / publish_agent_decision
val publish_agent_action_executed
val publish_trust_updated / publish_reputation_changed
```

Hidden: `masc_publish` (private route to
`Masc_event_bus.get ()`).

## Layer-boundary contract

The `bus` argument is accepted for backward compatibility but
**ignored**. Every publish routes to
`Masc_event_bus.get ()` so the OAS/MASC boundary is preserved
regardless of caller's bus reference. OAS
`event_bus.mli:103-107` explicitly warns against publishing
domain events onto OAS's shared bus.

## Topic naming pinned

Dot-separated snake_case per OAS Custom-name convention:

| Function | Topic |
|---|---|
| `publish_broadcast` | `masc.broadcast` |
| `publish_heartbeat` | `masc.heartbeat` |
| `publish_task_transition` | `masc.task_transition` |
| `publish_keeper_snapshot` | `masc.keeper.snapshot` |
| `publish_keeper_lifecycle` | `masc.keeper.lifecycle` |
| `publish_keeper_dead` | `masc.keeper.dead` |
| `publish_agent_selected` | `masc.autonomy.agent_selected` |
| `publish_agent_decision` | `masc.autonomy.agent_decision` |
| `publish_agent_action_executed` | `masc.autonomy.agent_action_executed` |
| `publish_trust_updated` | `masc.trust_updated` |
| `publish_reputation_changed` | `masc.reputation_changed` |

## publish_keeper_lifecycle wire format

Variant unification (#8856 / #8605 family) preserves wire
format bit-identically:

| Variant | `event` | `phase` |
|---|---|---|
| `Custom_event { verb; phase = None }` | `verb` | `null` |
| `Custom_event { verb; phase = Some p }` | `verb` | `p` |
| `Phase_event p` | `p` | `p` |

16 supervisor / keepalive call sites compile-time checked.

## Issue #8575 — full event name surface

Prior docstring listed only 5 names → operators silently
missed cleanup / self-healing events
(`reconciled` / `dead_cleaned` / `self_preservation` /
`paused_pruned`) — exactly the events that signal supervisor
recovery actions where observability matters most.

The .mli now points operators at
`Keeper_lifecycle_events.all_event_names` as the SSOT.

## publish_keeper_dead vs lifecycle "dead" asymmetry

| Topic | Shape | Use |
|---|---|---|
| `masc.keeper.dead` | structured (`restart_count`, `last_failure_reason`) | filter on stable topic, pull structured fields directly |
| `masc.keeper.lifecycle` event=`dead` | unstructured free-form `detail` | general lifecycle stream |

Emitted when `Keeper_supervisor.sweep_and_recover` gives up
on a keeper after `restart_count >= max_restarts` —
**actionable**: supervisor will NOT retry.

## @deprecated annotations

5 publishers tagged with `[@@deprecated]` — consumers see
the no-producer signal at compile time when subscribing.
Annotations to be removed when producers land:

- 3 `publish_agent_*` → Thompson autonomy RFC (open)
- 2 social events → Phase 4 social network feature (open)

Tracked as "mark scaffolding" tier of #8857.

## Caller audit
- `lib/keeper/keeper_keepalive.ml` —
  `publish_keeper_snapshot`, `publish_keeper_lifecycle`
  (16 call sites)
- `test/test_oas_integration.ml` — broadcast / heartbeat /
  task_transition / keeper_lifecycle / keeper_snapshot

No external reference to `masc_publish`.

## Test plan
- [x] `dune build --root . lib` — clean
- [ ] `dune runtest` (CI)
- [ ] Ratchet `lib_other_mli_missing` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
