### PR TITLE
chore(mcp): add mcp_sdk_adapter_masc.mli (cycle 123)

### DIFF
--- a/lib/mcp_sdk_adapter_masc.mli
+++ b/lib/mcp_sdk_adapter_masc.mli
@@ -1,0 +1,56 @@
+(** Mcp_sdk_adapter_masc — narrow adapter between MASC's local
+    {!Mcp_server} surface and the MCP protocol SDK
+    ({!Mcp_protocol_eio.Handler} / {!Mcp_protocol.Mcp_types}).
+
+    Three external entries — the rest of the module is internal
+    glue (yojson parsers, schema converters, handler builder) that
+    has no caller outside this file.  The narrow surface is
+    deliberate: SDK / MASC type bridging stays here so the protocol
+    layer stays clean. *)
+
+val handles_method : string -> bool
+(** [handles_method m] is [true] iff the SDK adapter dispatches
+    method [m] (currently only ["ping"]).  The protocol router uses
+    this to decide whether to delegate to {!dispatch_request} or
+    fall through to the MASC-native handler. *)
+
+val dispatch_request :
+  handle_call_tool_eio:_ ->
+  state:_ ->
+  profile:_ ->
+  sw:_ ->
+  clock:_ ->
+  ?mcp_session_id:_ ->
+  ?auth_token:_ ->
+  Yojson.Safe.t ->
+  Yojson.Safe.t option
+(** [dispatch_request ~handle_call_tool_eio ~state ~profile ~sw
+      ~clock ?mcp_session_id ?auth_token json] inspects [json] for
+    a JSON-RPC request whose method is in {!handles_method}'s set
+    and returns:
+
+    - [Some response_json] when the method is SDK-owned and was
+      dispatched (currently only ["ping"] -> empty
+      [\{"jsonrpc":"2.0","id":..,"result":\{\}\}]).
+    - [None] when [json] is not a [`Assoc] or the method is not in
+      the SDK-owned set — caller must fall through to the
+      MASC-native handler.
+
+    The capability arguments ([handle_call_tool_eio], [state],
+    [profile], [sw], [clock], [mcp_session_id], [auth_token]) are
+    threaded through for forward compatibility — the current ["ping"]
+    dispatcher ignores them.  Polymorphic types intentional: the
+    adapter does not own the runtime types. *)
+
+val sdk_prompt_of_local :
+  Mcp_prompt_surface.prompt_def -> Mcp_protocol.Mcp_types.prompt
+(** [sdk_prompt_of_local prompt] converts a MASC-side
+    {!Mcp_prompt_surface.prompt_def} into the SDK-side
+    {!Mcp_protocol.Mcp_types.prompt}.  Each
+    {!Mcp_prompt_surface.prompt_argument} maps to a
+    {!Mcp_protocol.Mcp_types} prompt argument with [description]
+    wrapped in [Some] and [required] wrapped in [Some].
+
+    Exposed because {!Mcp_prompt_surface}'s interface references
+    this conversion in its public contract — keeping the bridge in
+    a single .mli avoids duplication. *)


### PR DESCRIPTION
## Summary

Cycle 123 — adds an explicit interface for
\`lib/mcp_sdk_adapter_masc.ml\` (299 lines).

## Surface (3 entries, 17 hide)

\`\`\`ocaml
val handles_method : string -> bool
val dispatch_request : ... -> Yojson.Safe.t -> Yojson.Safe.t option
val sdk_prompt_of_local : Mcp_prompt_surface.prompt_def -> Mcp_protocol.Mcp_types.prompt
\`\`\`

Hidden 17: 3 module aliases, \`tool_profile\` type alias,
\`sdk_owned_methods\`, \`instructions_for_profile\`,
\`jsonrpc_notification\` re-export, \`make_context\`, 5 yojson
helpers, 3 schema converters, \`create_handler\` (90-line internal
builder), \`dispatch_ping\`.

## Why 3 / 17 narrow

Only 2 callers:

| File | Symbols used |
|---|---|
| \`lib/mcp_server_eio_protocol.ml\` | \`handles_method\`, \`dispatch_request\` |
| \`lib/mcp_prompt_surface.mli\` | \`sdk_prompt_of_local\` |

The other 17 toplevels are internal SDK<->MASC type-bridge glue
(yojson parsers, schema converters, Handler.t builder).  Keeping
them hidden enforces the adapter as a single contract seam — future
"expose Handler.t builder" PRs reopen explicitly.

## dispatch_request method routing

| Method | Behavior |
|---|---|
| \`ping\` | \`Some \\\`Assoc [(\"jsonrpc\", \"2.0\"); (\"id\", id); (\"result\", \\\`Assoc [])]\` |
| anything else | \`None\` (caller falls through to MASC-native handler) |

\`sdk_owned_methods = ["ping"]\` is the **single source** for the
SDK-owned method set; \`handles_method\` queries it via \`List.mem\`.

## Polymorphic capability args

\`dispatch_request\` accepts polymorphic
\`handle_call_tool_eio\` / \`state\` / \`profile\` / \`sw\` /
\`clock\` / \`mcp_session_id\` / \`auth_token\` because the adapter
does not own the runtime types.  Current ping dispatcher ignores
them; threaded through for forward compat (future SDK-owned methods
that touch state).

## sdk_prompt_of_local mapping

| MASC field | SDK field |
|---|---|
| \`prompt.name\` | \`name\` |
| \`prompt.description\` | \`description\` |
| \`prompt.arguments[i].description\` | \`Some description\` |
| \`prompt.arguments[i].required\` | \`Some required\` |

Exposed because \`mcp_prompt_surface.mli\` references this conversion
in its own contract — keeping the bridge in one .mli avoids
duplication.

## create_handler hidden

The 90-line \`create_handler\` builds a \`Handler.t\` from
\`tool_schemas_for_profile state profile\`, sorts tools/resources/
templates/prompts by name, and folds them into the handler.  It is
**not called externally** — used only by the (also-hidden)
\`make_context\` and consumed inside this file.  Future "promote
Handler.t to caller" PR reopens.

## Caller audit
- \`lib/mcp_server_eio_protocol.ml\` — \`handles_method\` +
  \`dispatch_request\`
- \`lib/mcp_prompt_surface.mli\` — \`sdk_prompt_of_local\`

No external reference to the 17 hidden helpers.

## Test plan
- [x] \`dune build --root . lib\` — clean
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)