### PR TITLE
test(dashboard): a11y batch 4 — card/copyable-code/feedback-state

### DIFF
--- a/dashboard/src/components/common/card.a11y.test.ts
+++ b/dashboard/src/components/common/card.a11y.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for SurfaceCard / SectionCard / Card. Pure
+// container atoms — axe primarily guards landmark-vs-non-landmark
+// usage and that the title-bearing variants surface a real heading
+// rather than a styled <span>.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { SurfaceCard, SectionCard, Card } from './card'
+
+describe('SurfaceCard a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('standard variant renders accessibly', async () => {
+    render(html`<${SurfaceCard}><p>card content</p><//>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('light variant renders accessibly', async () => {
+    render(html`<${SurfaceCard} variant="light"><p>light</p><//>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('compact variant renders accessibly', async () => {
+    render(html`<${SurfaceCard} variant="compact"><p>compact</p><//>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('SectionCard a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with title renders accessibly', async () => {
+    render(
+      html`<${SectionCard} title="Recent activity"><p>...</p><//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('Card a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with title renders accessibly', async () => {
+    render(html`<${Card} title="Header"><p>body</p><//>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/copyable-code.a11y.test.ts
+++ b/dashboard/src/components/common/copyable-code.a11y.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for CopyableCode — single-line shell snippet with
+// a copy button. The button is icon-only by default, so tests guard
+// the accessible-name fallback chain (ariaLabel || `${label} 복사` ||
+// '복사' — same pattern as CopyIdButton).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { CopyableCode } from './copyable-code'
+
+describe('CopyableCode a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default (secondary) variant renders accessibly', async () => {
+    render(html`<${CopyableCode} command="npm install" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('primary variant renders accessibly', async () => {
+    render(
+      html`<${CopyableCode} command="masc deploy" variant="primary" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with label derives accessible name on the copy button', async () => {
+    render(
+      html`<${CopyableCode} command="masc start" label="Start command" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with explicit ariaLabel passes axe', async () => {
+    render(
+      html`<${CopyableCode}
+        command="curl -sSL https://example.com/install.sh | sh"
+        ariaLabel="Copy install command"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/feedback-state.a11y.test.ts
+++ b/dashboard/src/components/common/feedback-state.a11y.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for FeedbackState primitives. EmptyState renders
+// `role="status"` so axe verifies the live-region attribute is on a
+// proper container; ErrorState/Recoverable/Fatal carry retry/reload
+// buttons whose accessible names this test pins.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import {
+  EmptyState,
+  LoadingState,
+  ErrorState,
+  ErrorRecoverable,
+  ErrorFatal,
+} from './feedback-state'
+
+describe('EmptyState a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default render passes axe', async () => {
+    render(html`<${EmptyState} message="No items yet" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('compact + icon passes axe (icon is aria-hidden, message is text)', async () => {
+    render(
+      html`<${EmptyState} icon="📭" message="Inbox is empty" compact=${true} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('LoadingState a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly with default content', async () => {
+    render(html`<${LoadingState}>로딩 중<//>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('ErrorState a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with message passes axe', async () => {
+    render(
+      html`<${ErrorState} message="Network unavailable" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('ErrorRecoverable a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with retry callback passes axe', async () => {
+    render(
+      html`<${ErrorRecoverable}
+        message="Sync failed"
+        onRetry=${() => {}}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('ErrorFatal a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with retry+reload callbacks passes axe', async () => {
+    render(
+      html`<${ErrorFatal}
+        message="Session expired"
+        onRetry=${() => {}}
+        onReload=${() => {}}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

Fourth a11y test batch. Three different surface types:

| Atom group | Pattern | Cases |
|------------|---------|-------|
| **SurfaceCard / SectionCard / Card** | container variants | 5 |
| **CopyableCode** | icon-button code block | 4 |
| **EmptyState / LoadingState / ErrorState / ErrorRecoverable / ErrorFatal** | feedback-state primitives | 6 |

15 cases, all pass. \`tsc --noEmit\` clean.

## Why these picks

- **Cards** (3 export variants) — guards future title→\`<h*>\` migration: a regression that drops the proper heading element would axe-violate \`heading-order\`.
- **CopyableCode** — mirrors the CopyIdButton fallback chain coverage from batch 1 (#11703). Defends the icon-only-button accessible-name contract.
- **FeedbackState primitives** — pins button-name + \`role=\"status\"\` live-region wiring across the 1-tier and 2-tier error families. Specifically guards \`ErrorRecoverable\` (with onRetry) and \`ErrorFatal\` (with onRetry + onReload) — both surface buttons whose Korean labels axe needs to verify reach assistive tech.

## Verification

- [x] \`pnpm vitest run src/components/common/{card,copyable-code,feedback-state}.a11y.test.ts\` → 15/15 pass
- [x] \`pnpm tsc --noEmit\` clean
- [ ] CI checks (this PR)

## Cumulative coverage

button (4) + #11703 (13) + #11704 (8) + #11707 (8) + #11720 (13) + **this PR (15)** = **61 cases** across **16 atoms** once this lands.

\\+4 more once #11732 (SegmentedBar fix) lands and re-enables its commented-out test suite.

## Related

- Depends on (merged): #11676 jest-axe wiring
- Sibling PRs: #11703 (merged), #11704 (merged, other session), #11707 (merged), #11720 (merged), #11732 (Draft)
- Spec: design_system_v2 §6.3 (automated a11y testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)