### PR TITLE
chore(operator): add operator_control_action.mli (cycle 126)

### DIFF
--- a/lib/operator/operator_control_action.mli
+++ b/lib/operator/operator_control_action.mli
@@ -1,0 +1,158 @@
+(** Operator_control_action — operator action / judgment helpers.
+
+    Layered between {!Operator_control_snapshot} (state-readonly) and
+    {!Operator_control} (exposed dispatcher).  Adds:
+
+    - Judgment surface validation + write/latest JSON dispatchers.
+    - {!action_request} record + parsers from raw JSON args.
+    - {!generate_confirm_token} (collision-retry with exponential
+      backoff).
+    - {!preview_of_action} for UI confirmation panes.
+
+    {b Include cascade:} starts with [include Operator_control_snapshot]
+    so {!Operator_control}'s [include] propagates the snapshot
+    surface (notably the [\\'a context] type) through.  Internal
+    helpers ([judgment_surface_enums], [normalize_judgment_*],
+    [default_fresh_ttl_sec], [normalize_action_target_type],
+    [default_target_type_for], [require_payload_field]) stay
+    private. *)
+
+include module type of struct
+  include Operator_control_snapshot
+end
+
+(** {1 Judgment dispatchers} *)
+
+val judgment_write_json :
+  'a context -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+(** [judgment_write_json ctx args] records an
+    {!Operator_judgment} entry parsed from [args].  Required fields:
+
+    - [surface]: ["command.namespace"] or ["intervene"].
+    - [target_type]: any root alias (see
+      {!Operator_digest_types.is_root_alias}).
+    - [summary] (non-empty after trim).
+
+    Optional: [target_id], [fresh_ttl_sec] (default 60s for
+    command.namespace, 300s for intervene, 120s otherwise; floored
+    at 1), [confidence] (default 0.5), [keeper_name],
+    [evidence_refs] (string list), [recommended_action] (object),
+    [model_name], [runtime_name], [fallback_used] (bool, default
+    false), [disagreement_with_truth] (bool, default false).
+
+    Returns [Ok \`Assoc \[("status", "ok"); ("judgment", ...)\]] on
+    success, [Error msg] on validation failure. *)
+
+val judgment_latest_json :
+  'a context -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+(** [judgment_latest_json ctx args] reads the most-recent active
+    judgment matching [(surface, target_type, target_id)].  Required
+    fields: [surface], [target_type].  Optional: [target_id],
+    [require_fresh] (default [true]).  When [require_fresh = true],
+    judgments past their [fresh_until] window are filtered to [None]. *)
+
+(** {1 Action request} *)
+
+type action_request = {
+  actor : string;
+  action_type : string;
+  target_type : string;
+  target_id : string option;
+  payload : Yojson.Safe.t;
+}
+(** Parsed operator action — output of {!action_request_of_args}. *)
+
+val canonical_action_type : string -> string
+(** [canonical_action_type t] applies the operator action-type alias
+    table:
+
+    | Input | Output |
+    | --- | --- |
+    | [autonomy_tick] | [social_sweep] |
+    | [room_pause] / [namespace_pause] | [namespace_pause] |
+    | [room_resume] / [namespace_resume] | [namespace_resume] |
+    | [keeper_msg] / [keeper_message] | [keeper_message] |
+    | other | passthrough |
+
+    Pinned at the contract seam — the [keeper_msg] -> [keeper_message]
+    rename and [autonomy_tick] -> [social_sweep] are the long-lived
+    operator-API legacy paths. *)
+
+val generate_confirm_token :
+  clock:_ Eio.Time.clock -> Coord.config -> (string, string) result
+(** [generate_confirm_token ~clock config] returns a 36-char token
+    of the form ["opc_" ^ <32-char-token-suffix>].  Handles
+    collisions:
+
+    - 10 retry attempts.
+    - Exponential backoff: 1ms -> 2ms -> 4ms -> ... -> ~512ms.
+    - On exhaustion: [Error "failed to generate unique confirm token
+      after 10 attempts (...)"] including the current pending-confirm
+      count (operator-actionable diagnostic). *)
+
+val resolved_actor_for_args :
+  ?actor_hint:string ->
+  'a context ->
+  Yojson.Safe.t ->
+  (string, string) result
+(** [resolved_actor_for_args ?actor_hint ctx args] picks the actor
+    string in priority order: [actor_hint] (trimmed) -> [args.actor]
+    (trimmed) -> {!normalized_actor} fallback to [ctx.agent_name].
+    Always returns [Ok _]; [string result] is for caller chaining
+    via {!Result.Syntax}. *)
+
+val action_request_of_args :
+  ?actor_hint:string ->
+  'a context ->
+  Yojson.Safe.t ->
+  (action_request, string) result
+(** [action_request_of_args ?actor_hint ctx args] parses an
+    [action_request] from raw JSON.  Applies
+    {!canonical_action_type} to [action_type] and falls back to the
+    type-specific default target_type (see internal
+    [default_target_type_for]) when [args.target_type] is missing. *)
+
+val normalize_request_target_type :
+  action_request -> (action_request, string) result
+(** [normalize_request_target_type r] returns [r] with [target_type]
+    validated against the allowed set ([root] / [keeper] / [""]).
+    Empty [target_type] is replaced by the action-type default.
+    Returns [Error "target_type must be root or keeper"] on invalid
+    inputs. *)
+
+val delegated_tool_for : string -> string
+(** [delegated_tool_for action_type] returns the tool name for an
+    action_type by lookup into
+    {!Operator_pending_confirm.available_actions}; returns
+    ["unknown"] when no match exists.  Used for confirm-step routing
+    so the JSON contract knows which tool will receive the call. *)
+
+val confirm_required : string -> bool
+(** Re-export of {!Operator_approval.confirm_required}.  Pinned here
+    to keep the action contract surface in one place. *)
+
+val preview_of_action : action_request -> Yojson.Safe.t
+(** [preview_of_action r] renders a JSON preview for UI
+    confirmation panes.  Schema:
+
+    {[
+      {
+        "actor": <string>,
+        "action_type": <string>,
+        "target_type": <string>,
+        "target_id": <string|null>,
+        "payload": <object>  (* empty when payload is not [`Assoc] *)
+      }
+    ]} *)
+
+val validate_target_type :
+  string -> action_request -> (unit, string) result
+(** [validate_target_type expected r] returns [Ok ()] iff
+    [r.target_type = expected]; otherwise
+    [Error "invalid target_type for <action_type> (expected
+    <expected>)"]. *)
+
+val require_target_id : action_request -> (string, string) result
+(** [require_target_id r] returns [Ok id] iff
+    [r.target_id = Some id]; otherwise
+    [Error "target_id is required"]. *)


### PR DESCRIPTION
## Summary

Cycle 126 — adds an explicit interface for
\`lib/operator/operator_control_action.ml\` (250 lines).

## Surface (14 entries + include cascade, 7 hide)

\`\`\`ocaml
include module type of struct include Operator_control_snapshot end

val judgment_write_json / judgment_latest_json
type action_request (5 fields)
val canonical_action_type
val generate_confirm_token  (~clock + Coord.config)
val resolved_actor_for_args
val action_request_of_args
val normalize_request_target_type
val delegated_tool_for
val confirm_required  (re-export)
val preview_of_action
val validate_target_type
val require_target_id
\`\`\`

Hidden 7: \`judgment_surface_enums\`, 3 \`normalize_judgment_*\` /
\`default_fresh_ttl_sec\` helpers (judgment_*_json internals),
\`normalize_action_target_type\` /
\`default_target_type_for\` (action_request internals),
\`require_payload_field\` (no caller).

## include cascade pinning

\`Operator_control\` does [\`include Operator_control_action\`] —
every public symbol must remain visible. \`Operator_control.mli\`
exists and re-exposes \`judgment_write_json\` /
\`judgment_latest_json\` directly, so those entries are mandatory
in this .mli too.

\`include module type of struct include Operator_control_snapshot end\`
(struct form) preserves the [\`'a context\`] type identity through
the cascade.

## canonical_action_type alias table

| Input | Canonical |
|---|---|
| \`autonomy_tick\` | \`social_sweep\` |
| \`room_pause\` / \`namespace_pause\` | \`namespace_pause\` |
| \`room_resume\` / \`namespace_resume\` | \`namespace_resume\` |
| \`keeper_msg\` / \`keeper_message\` | \`keeper_message\` |
| \`social_sweep\` | \`social_sweep\` |
| anything else | passthrough |

The \`keeper_msg\` -> \`keeper_message\` rename and \`autonomy_tick\`
-> \`social_sweep\` are long-lived operator-API legacy paths —
pinning at the contract seam prevents drift.

## generate_confirm_token retry contract

| Aspect | Value |
|---|---|
| Format | \`opc_<32-char-suffix>\` (36 chars total) |
| Max attempts | 10 |
| Backoff | 1ms -> 2ms -> 4ms -> ... -> ~512ms (capped) |
| Error on exhaustion | \`failed to generate unique confirm token after 10 attempts (token space may be exhausted; <N> pending confirms)\` |

The pending-confirm count in the error message is operator-actionable
— operators see whether token-space saturation or PRNG flakiness is
the root.

## judgment_write_json fresh_ttl_sec defaults

| Surface | Default |
|---|---|
| \`command.namespace\` | 60 sec |
| \`intervene\` | 300 sec |
| anything else | 120 sec |

Floored at 1 (operator cannot pass [\`fresh_ttl_sec=0\`] to disable
freshness gating).

## preview_of_action JSON shape

\`\`\`json
{
  "actor": "<string>",
  "action_type": "<string>",
  "target_type": "<string>",
  "target_id": "<string|null>",
  "payload": { ... }
}
\`\`\`

\`payload\` is always an object: \`\\\`Assoc fields\` when
\`request.payload\` is \`\\\`Assoc\`, else empty object.

## Caller audit
- \`lib/operator/operator_control.ml\` — include cascade + 11 bare
  symbols
- \`lib/operator/operator_control.mli\` — \`judgment_write_json\` +
  \`judgment_latest_json\` re-exposed

No external direct caller (\`Operator_control_action.X\` grep = 0).
All access goes through the \`Operator_control\` include cascade.

## Test plan
- [x] \`dune build --root . lib\` — clean
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)