### PR TITLE
chore(server): add server_dashboard_http_namespace_truth.mli (cycle 127)

### DIFF
--- a/lib/server/server_dashboard_http_namespace_truth.mli
+++ b/lib/server/server_dashboard_http_namespace_truth.mli
@@ -1,0 +1,95 @@
+(** Server_dashboard_http_namespace_truth — namespace-truth read
+    model and SSE snapshot broadcasting.
+
+    Three external surfaces:
+    - {!dashboard_namespace_truth_http_json}: the
+      [/dashboard/namespace-truth] HTTP handler (direct caller:
+      [Server_dashboard_http.dashboard_namespace_truth_http_json]).
+    - {!namespace_truth_snapshot_from_caches}: lightweight cached
+      snapshot used by runtime bootstrap.
+    - {!broadcast_namespace_truth_snapshot}: SSE broadcast to
+      Observer sessions, called from bootstrap loops and proactive
+      refresh hooks.
+
+    Internal: env-default helpers, hash-based dedup state, module
+    aliases (Execution_surfaces / Namespace_truth_support).  All
+    private — the module's effect-free contract is "compose a
+    cached read-model + dedup-broadcast it; everything else is
+    plumbing". *)
+
+val dashboard_namespace_truth_http_json :
+  state:Mcp_server.server_state ->
+  sw:'a ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  'b ->
+  Yojson.Safe.t
+(** [dashboard_namespace_truth_http_json ~state ~sw ~clock request]
+    serves the namespace-truth read model.
+
+    Cold-start fast-path: when the proactive
+    {!Server_dashboard_http_execution_surfaces._execution_cache} has
+    not produced a successful first cycle and the warm-escape window
+    (default 90s = 75s refresh timeout + 15s slack, capped via
+    [MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S]) has not elapsed,
+    returns:
+
+    {[
+      \{"status": "initializing", "generated_at": ..., "message": ...\}
+    ]}
+
+    Warm path: composes shell + execution + command summaries with
+    per-fiber timeouts:
+
+    | Env var | Default | Used for |
+    | --- | --- | --- |
+    | [MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S] | 8.0s | base warm |
+    | [MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S] | 15.0s | base cold |
+    | [MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S] | 12.0s | shell warm cap |
+    | [MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S] | 4.0s | cold shell safety |
+
+    Shell timeout (cold) = max(cold_timeout, shell_fiber + safety) —
+    must exceed the inner cache timeout to avoid the double-timeout
+    race that discards stale data (#5090).
+
+    Graceful degradation: shell falls back to
+    {!Server_dashboard_http_core._last_good_shell} on timeout (61x/day
+    zero-out under I/O contention before the fix). *)
+
+val namespace_truth_snapshot_from_caches :
+  Mcp_server.server_state -> Yojson.Safe.t option
+(** [namespace_truth_snapshot_from_caches state] composes a
+    lightweight namespace-truth snapshot from cached refs only —
+    no PG I/O.
+
+    Returns [None] iff the execution cache has not produced its
+    first successful result (cold start).  Otherwise reads the
+    proactive execution cache + last-good shell + empty command
+    summary and composes via
+    {!Server_dashboard_http_namespace_truth_support.compose_namespace_truth_snapshot}.
+
+    Side effect: updates {!Server_dashboard_http_core._last_good_shell}
+    on a fresh shell read. *)
+
+val broadcast_namespace_truth_snapshot :
+  Mcp_server.server_state -> unit
+(** [broadcast_namespace_truth_snapshot state] dedup-broadcasts the
+    current snapshot to all Observer SSE sessions.
+
+    Three SSE channels emitted per broadcast (snapshot payload
+    identical):
+
+    | [type] field | Stream alias |
+    | --- | --- |
+    | ["project_snapshot"] | canonical |
+    | ["namespace_truth_snapshot"] | alias for namespace dashboards |
+    | ["room_truth_snapshot"] | legacy compatibility |
+
+    Dedup: SHA-256 of the serialized snapshot (with [generated_at]
+    stripped recursively before hashing).  When the hash matches the
+    previous broadcast, skips with a debug log.
+
+    Log demotion: "pushed via SSE" log goes to DEBUG when no Observer
+    is connected (avoids per-minute housekeeping noise; was log-flood
+    96/min in fresh-server logs).
+
+    Safe to call from any fiber — reads cached refs only. *)


### PR DESCRIPTION
## Summary

Cycle 127 — adds an explicit interface for
\`lib/server/server_dashboard_http_namespace_truth.ml\` (253 lines).

## Surface (3 entries, ~7 hide)

\`\`\`ocaml
val dashboard_namespace_truth_http_json   (* HTTP handler *)
val namespace_truth_snapshot_from_caches  (* lightweight cached read *)
val broadcast_namespace_truth_snapshot    (* SSE dedup-broadcast *)
\`\`\`

Hidden: 2 module aliases, \`float_of_env_default_with_legacy\` (no
caller), \`normalize_namespace_truth_snapshot_for_hash\` /
\`should_broadcast_namespace_truth_snapshot\` (broadcast helpers),
\`_last_namespace_truth_snapshot_hash\` / \`_namespace_truth_snapshot_hash_mu\`
(Atomic state with leading \`_\`).

## Why narrow

Module's effect-free contract is "compose a cached read-model +
dedup-broadcast it; everything else is plumbing".  Three external
seams suffice:

| Caller | Symbol | Path |
|---|---|---|
| \`server_dashboard_http.ml\` | \`dashboard_namespace_truth_http_json\` | direct prefix |
| \`server_bootstrap_loops.ml\` | \`broadcast_namespace_truth_snapshot\` | \`Server_dashboard_http.X\` (include cascade) |
| \`server_runtime_bootstrap.ml\` | \`namespace_truth_snapshot_from_caches\` | \`Server_dashboard_http.X\` (include cascade) |

## dashboard_namespace_truth_http_json env knobs

| Env var | Default | Min | Max |
|---|---|---|---|
| \`MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S\` | 8.0s | 1.0 | 120.0 |
| \`MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S\` | 15.0s | 1.0 | 120.0 |
| \`MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S\` | 12.0s | 1.0 | 120.0 |
| \`MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S\` | 4.0s | 0.0 | 60.0 |
| \`MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S\` | 75.0s | 30.0 | 300.0 |

Pinned at the contract seam — operators tune per-fleet.  History:
- #5090: shell timeout double-fire race (cold path needs
  \`max(cold_timeout, shell_fiber + safety)\`).
- #7908: fleet p50 ≈ 17s made the 12s shell cap misfire.

## Cold-start fast-path

Returns \`{"status": "initializing", ...}\` when the proactive
execution cache hasn't produced its first success AND we're inside
the warm-escape window (refresh_timeout + 15s slack).  Frontend
auto-retries every 3s.

## broadcast 3-channel emit

| \`type\` field | Stream alias |
|---|---|
| \`project_snapshot\` | canonical |
| \`namespace_truth_snapshot\` | alias for namespace dashboards |
| \`room_truth_snapshot\` | legacy compat |

Identical payload, separate SSE event types — dashboard subscribers
pick their dialect.

## Dedup contract

SHA-256 of serialized snapshot with \`generated_at\` recursively
stripped before hashing.  Mutex-protected hash ref.  Skip-broadcast
emits a DEBUG log (not info).

## Log demotion

\`"project-snapshot pushed via SSE"\` -> DEBUG when
\`Sse.client_count () = 0\`.  Removes per-minute housekeeping noise
(~96 lines/min in fresh-server logs when nothing is tailing).

## clock concrete type

\`clock:float Eio.Time.clock_ty Eio.Resource.t\` (concrete, not
\`[> float Eio.Time.clock_ty]\`) — \`Eio.Time.with_timeout\` in the
body forces concrete inference.  Polymorphic variant breaks the
.ml<->.mli match (sub-typing direction wrong).

## Caller audit
- \`lib/server/server_dashboard_http.ml\` —
  \`dashboard_namespace_truth_http_json\` + include cascade
- \`lib/server/server_bootstrap_loops.ml\` —
  \`Server_dashboard_http.broadcast_namespace_truth_snapshot\`
- \`lib/server/server_runtime_bootstrap.ml\` —
  \`Server_dashboard_http.namespace_truth_snapshot_from_caches\`

No external reference to the 7 hidden helpers / Atomic state.

## Test plan
- [x] \`dune build --root . lib\` — clean
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)