### PR TITLE
chore(tool): add tool_local_runtime_http.mli (cycle 129)

### DIFF
--- a/lib/tool_local_runtime_http.mli
+++ b/lib/tool_local_runtime_http.mli
@@ -1,0 +1,115 @@
+(** Tool_local_runtime_http — curl-shelled HTTP helpers for local
+    runtime probing.
+
+    All requests:
+    - Force HTTP/1.1 ([--http1.1]) — keeps curl off proxies that
+      mishandle HTTP/2.
+    - Pass through {!Masc_exec.Exec_gate.run_argv_with_status} so
+      tool exec policy / timeouts / audit logging stay consistent.
+    - Append [\\n%\{http_code\}] to capture the status code as the
+      last line of the body (parsed by
+      {!split_http_body_and_status}).
+
+    {b Include cascade:} starts with [include Tool_local_runtime_core]
+    so siblings ({!Tool_local_runtime_bench},
+    {!Tool_local_runtime_verify}, {!Tool_local_runtime_probe})
+    receive the core surface transitively via
+    [include Tool_local_runtime_http].
+
+    Internal helpers ([split_http_body_and_status],
+    [append_headers]) stay private. *)
+
+include module type of struct
+  include Tool_local_runtime_core
+end
+
+(** {1 String / JSON helpers} *)
+
+val trim_to_option : string -> string option
+(** [trim_to_option raw] returns [Some s] iff [s = String.trim raw]
+    is non-empty, else [None].  Used for "treat empty string as
+    missing" semantics on JSON / shell inputs. *)
+
+val int_member : Yojson.Safe.t -> string -> int option
+(** [int_member json key] reads [json.key] as an int.  Accepts both
+    [\`Int n] and [\`Intlit s] (parsed via [parse_int_opt]).  Returns
+    [None] when the field is missing, the wrong type, or
+    [Intlit] failed to parse. *)
+
+val string_member : Yojson.Safe.t -> string -> string option
+(** [string_member json key] reads [json.key] as a non-empty string.
+    Returns [None] when the field is missing, not a string, or the
+    string is empty after trimming. *)
+
+(** {1 GET helpers} *)
+
+val http_get_text_with_status_with_headers :
+  ?timeout_sec:int ->
+  ?headers:(string * string) list ->
+  string ->
+  ((int option * string), string) result
+(** [http_get_text_with_status_with_headers ?timeout_sec ?headers url]
+    issues a [GET url] via curl.  Returns
+    [Ok (http_status_opt, body)] on curl exit 0, where:
+
+    - [http_status_opt = Some n] when curl emitted a status line, or
+      [None] when the body lacked a trailing status line.
+    - [body] is the response body with the status-code suffix stripped.
+
+    [timeout_sec] defaults to 10 (floored at 1).
+    [headers] defaults to [\[\]]; appended in left-to-right order
+    (each pair becomes [-H "name: value"]).
+
+    Errors include curl exit code, signals, and stop reasons. *)
+
+val http_get_text_with_status :
+  ?timeout_sec:int ->
+  string ->
+  ((int option * string), string) result
+(** [http_get_text_with_status] is
+    {!http_get_text_with_status_with_headers} with no extra headers. *)
+
+val http_get_json_with_status :
+  ?timeout_sec:int ->
+  string ->
+  ((int option * Yojson.Safe.t), string) result
+(** [http_get_json_with_status ?timeout_sec url] composes
+    {!http_get_text_with_status} + [Yojson.Safe.from_string].  Returns
+    [Error "invalid json from <url>: <msg>"] on parse failure. *)
+
+(** {1 POST helpers} *)
+
+val http_post_json_text_with_status_with_headers :
+  timeout_sec:int ->
+  ?headers:(string * string) list ->
+  url:string ->
+  body_json:string ->
+  unit ->
+  ((int option * string), string) result
+(** [http_post_json_text_with_status_with_headers ~timeout_sec
+      ?headers ~url ~body_json ()] issues a [POST url] with
+    [Content-Type: application/json] and [body_json] as the request
+    body.  Returns [Ok (http_status_opt, body_text)] on curl exit 0.
+
+    [timeout_sec] is required (no default — caller must commit to a
+    bound).  [headers] defaults to [\[\]] and is appended after the
+    built-in [Content-Type] header. *)
+
+val http_post_json_text_with_status :
+  timeout_sec:int ->
+  url:string ->
+  body_json:string ->
+  ((int option * string), string) result
+(** [http_post_json_text_with_status] is
+    {!http_post_json_text_with_status_with_headers} with no extra
+    headers. *)
+
+val http_post_json_with_status :
+  timeout_sec:int ->
+  url:string ->
+  body_json:string ->
+  ((int option * Yojson.Safe.t), string) result
+(** [http_post_json_with_status ~timeout_sec ~url ~body_json] composes
+    {!http_post_json_text_with_status} + [Yojson.Safe.from_string].
+    Returns [Error "invalid json from <url>: <msg>"] on parse
+    failure. *)


### PR DESCRIPTION
## Summary

Cycle 129 — adds an explicit interface for
\`lib/tool_local_runtime_http.ml\` (133 lines).

## Surface (9 entries + Tool_local_runtime_core cascade, 2 hide)

\`\`\`ocaml
include module type of struct include Tool_local_runtime_core end

(* JSON / string helpers *)
val trim_to_option / int_member / string_member

(* GET *)
val http_get_text_with_status / _with_headers
val http_get_json_with_status

(* POST *)
val http_post_json_text_with_status / _with_headers
val http_post_json_with_status
\`\`\`

Hidden 2: \`split_http_body_and_status\` (status-line parser),
\`append_headers\` (curl argv builder).

## include cascade (3 siblings)

\`\`\`
Tool_local_runtime_core
        |
        v
[Tool_local_runtime_http] (this PR)
        |
        +--> Tool_local_runtime_bench    [include]
        +--> Tool_local_runtime_verify   [include]
        +--> Tool_local_runtime_probe    [include]
\`\`\`

Used \`include module type of struct include Tool_local_runtime_core end\`
(struct form) to preserve type identity through both layers of the
cascade.

## HTTP request contract pinned

All requests:
1. Force **HTTP/1.1** (\`--http1.1\`) — keeps curl off proxies that
   mishandle HTTP/2.
2. Pass through \`Masc_exec.Exec_gate.run_argv_with_status\` —
   tool exec policy + timeout + audit logging stay consistent.
3. Append \`\\n%\{http_code\}\` to capture status as the last body
   line (parsed by the hidden \`split_http_body_and_status\`).

## Defaults / required args

| Function | timeout_sec | headers |
|---|---|---|
| \`http_get_text_with_status\` | optional, default 10 | (none) |
| \`http_get_text_with_status_with_headers\` | optional, default 10 | optional, default \`\[\]\` |
| \`http_get_json_with_status\` | optional, default 10 | (none) |
| \`http_post_json_text_with_status\` | **required** | (none) |
| \`http_post_json_text_with_status_with_headers\` | **required** | optional, default \`\[\]\` |
| \`http_post_json_with_status\` | **required** | (none) |

POST helpers force the caller to commit to a timeout — no implicit
fallback.  GET helpers floor at 1s.

## Return type contract

All HTTP helpers return
\`((int option * <body>), string) result\` where \`int option\`:
- \`Some n\` — curl emitted a status line.
- \`None\` — body lacked a trailing status line (server returned
  empty body, or proxy stripped the suffix).

JSON variants compose with \`Yojson.Safe.from_string\` and surface
\`Error "invalid json from <url>: <msg>"\` on parse failure.

## int_member / string_member edge cases

| Input | \`int_member\` | \`string_member\` |
|---|---|---|
| \`{key: 42}\` | \`Some 42\` | \`None\` |
| \`{key: "42"}\` | \`None\` | \`Some "42"\` |
| \`{key: 9999999999999}\` (Intlit) | \`Some _\` (parse_int_opt) | \`None\` |
| \`{key: ""}\` | \`None\` | \`None\` (empty after trim) |
| \`{key: "  "}\` | \`None\` | \`None\` (empty after trim) |
| \`{}\` (missing) | \`None\` | \`None\` |

## Caller audit
- \`lib/tool_misc_web_search.ml\` —
  \`http_get_text_with_status\`,
  \`http_get_text_with_status_with_headers\`,
  \`http_post_json_text_with_status_with_headers\`
- \`lib/tool_local_runtime_bench.ml\` (via include) —
  \`http_get_text_with_status\`
- \`lib/tool_local_runtime_verify.ml\` (via include) — 6 entries
- \`lib/tool_local_runtime_probe.ml\` (via include) — 5 entries

No external reference to \`split_http_body_and_status\` /
\`append_headers\`.

## Test plan
- [x] \`dune build --root . lib\` — clean
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)