### PR TITLE
chore(http): add masc_http_client.mli (cycle 131)

### DIFF
--- a/lib/masc_http_client/masc_http_client.mli
+++ b/lib/masc_http_client/masc_http_client.mli
@@ -1,0 +1,126 @@
+(** Masc_http_client — cohttp-eio wrapper with explicit socket close.
+
+    cohttp-eio 6.1.1 does not reliably close the underlying TCP
+    socket fd when the {!Eio.Switch} exits (observed on macOS).
+    This module intercepts the connection factory via
+    [Cohttp_eio.Client.make_generic] to capture the raw socket and
+    close it explicitly on switch release.
+
+    All MASC code that makes outbound HTTP requests should use this
+    module instead of {!Cohttp_eio.Client.make} directly.  See
+    {{:https://github.com/jeong-sik/masc-mcp/issues/3221} #3221}.
+
+    Internal helper {!with_optional_timeout} stays private — every
+    public entry point exposes [?clock ?timeout_sec] directly so
+    callers do not see the timeout-fiber-race scaffolding. *)
+
+(** {1 Connection factory} *)
+
+val make_closing_client :
+  sw:Eio.Switch.t ->
+  net:[> `Network | `Platform of [> `Generic ] ] Eio.Resource.t ->
+  https:
+    (Uri.t ->
+     [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t ->
+     [> `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+    option ->
+  Cohttp_eio.Client.t
+(** [make_closing_client ~sw ~net ~https] builds a
+    {!Cohttp_eio.Client.t} that:
+
+    + Resolves the URI hostname via {!Eio.Net.getaddrinfo_stream}
+      (raises [Invalid_argument] when no result).
+    + Connects raw via {!Eio.Net.connect}.
+    + For [https://] URIs, calls [https = Some wrap] with [(uri,
+      sock)] to layer TLS; raises [Invalid_argument] when [https =
+      None] but the URI is HTTPS.
+    + Tracks every connection in an internal flow list and registers
+      an {!Eio.Switch.on_release} hook to close all flows when the
+      switch exits.
+
+    The polymorphic [net] / [https] arguments accept any
+    Eio.Net.t-compatible resource and any TLS wrapper that returns
+    a flow-shaped resource — kept abstract so callers can plug in
+    their own TLS stack. *)
+
+(** {1 Response payload} *)
+
+type response = {
+  status : int;
+  headers : (string * string) list;
+  body : string;
+}
+(** Structured response returned by {!get_response_sync}.  Body is
+    fully read into memory; size capped at 8 MB
+    (see {!post_sync} / {!get_response_sync} for the cap details). *)
+
+(** {1 Synchronous request helpers}
+
+    All three helpers:
+    - Run inside {!Eio.Switch.run}, so connection cleanup is
+      guaranteed regardless of success or exception.
+    - Add [Connection: close] to the request headers so the
+      cohttp-eio reader stops at end-of-stream.
+    - Cap the response body at 8 MB; oversize bodies surface
+      [Error "masc_http_client: body size exceeds 8 MB"].
+    - Convert [Eio.Cancel.Cancelled] re-raises (cancellation
+      propagates), wrap any other exception as
+      [Error (Printexc.to_string exn)].
+    - When [?clock] {b and} [?timeout_sec > 0.0] are both supplied,
+      race the request against an {!Eio.Time.sleep} fiber.  On
+      timeout, return [Error "timeout after %.1fs"]. *)
+
+val post_sync :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  net:[> `Network | `Platform of [> `Generic ] ] Eio.Resource.t ->
+  ?https:
+    (Uri.t ->
+     [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t ->
+     [> `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+    option ->
+  url:string ->
+  headers:(string * string) list ->
+  body:string ->
+  unit ->
+  ((int * string), string) result
+(** [post_sync ?clock ?timeout_sec ~net ?https ~url ~headers ~body
+      ()] performs a [POST url] with [Content-Type] honored from
+    [headers].  Returns [Ok (status_code, body_string)] on success.
+    Connection-level errors (DNS, TLS, I/O) are caught and surfaced
+    as [Error _] rather than propagating as exceptions. *)
+
+val get_response_sync :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  net:[> `Network | `Platform of [> `Generic ] ] Eio.Resource.t ->
+  ?https:
+    (Uri.t ->
+     [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t ->
+     [> `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+    option ->
+  url:string ->
+  headers:(string * string) list ->
+  unit ->
+  (response, string) result
+(** [get_response_sync ?clock ?timeout_sec ~net ?https ~url
+      ~headers ()] performs a [GET url].  Returns [Ok response] with
+    full status / headers / body for callers that need to inspect
+    response headers (e.g. link-preview redirect handling). *)
+
+val get_sync :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  net:[> `Network | `Platform of [> `Generic ] ] Eio.Resource.t ->
+  ?https:
+    (Uri.t ->
+     [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t ->
+     [> `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+    option ->
+  url:string ->
+  headers:(string * string) list ->
+  unit ->
+  ((int * string), string) result
+(** [get_sync] is {!get_response_sync} with the response headers
+    discarded — returns [Ok (status_code, body_string)] for callers
+    that only care about status + body. *)


### PR DESCRIPTION
## Summary

Cycle 131 — adds an explicit interface for
\`lib/masc_http_client/masc_http_client.ml\` (190 lines).

## Surface (5 entries, 1 hide)

\`\`\`ocaml
val make_closing_client
  ~sw:Eio.Switch.t
  ~net:[> \`Network | \`Platform of [> \`Generic ] ] Eio.Resource.t
  ~https:(Uri.t -> sock -> wrapped_sock) option
  -> Cohttp_eio.Client.t

type response = { status; headers; body }

val post_sync ?clock ?timeout_sec ~net ?https ~url ~headers ~body ()
val get_response_sync ?clock ?timeout_sec ~net ?https ~url ~headers ()
val get_sync ?clock ?timeout_sec ~net ?https ~url ~headers ()
\`\`\`

Hidden 1: \`with_optional_timeout\` (internal Eio.Fiber.first race
for [?clock ?timeout_sec] semantics).

## Why hide \`with_optional_timeout\`

Every public entry exposes [\`?clock ?timeout_sec\`] directly —
callers don't see the timeout-fiber-race scaffolding.  Pinned at
the .mli seam: future refactors of the race mechanism (e.g. switch
to \`Eio.Time.with_timeout\` once polymorphic-variant compat is
fixed) won't change the public contract.

## Connection-close discipline (#3221)

cohttp-eio 6.1.1 does NOT reliably close the TCP socket fd when
\`Eio.Switch\` exits on macOS.  \`make_closing_client\`:

1. Intercepts the connection factory via
   \`Cohttp_eio.Client.make_generic\`.
2. Tracks every flow in an internal list.
3. Registers \`Eio.Switch.on_release\` to close all flows when the
   switch exits.

**All MASC outbound HTTP must use this module** instead of
\`Cohttp_eio.Client.make\` directly.

## Synchronous helper invariants (pinned at the contract seam)

| Invariant | Detail |
|---|---|
| Switch scope | Run inside \`Eio.Switch.run\` — cleanup guaranteed |
| Connection close | Auto-prepend \`Connection: close\` to request headers |
| Body cap | 8 MB; oversize -> \`Error "body size exceeds 8 MB"\` |
| Cancellation | \`Eio.Cancel.Cancelled\` re-raised; other exns -> \`Error _\` |
| Timeout race | \`?clock\` + \`?timeout_sec > 0.0\` -> \`Eio.Fiber.first\` |
| Timeout error | \`Error "timeout after %.1fs"\` |

## Polymorphic Eio types

Pinned exactly to .ml inferred type:

\`\`\`
net : [> \`Network | \`Platform of [> \`Generic ] ] Eio.Resource.t
https : (Uri.t
         -> [ \`Generic ] Eio.Net.stream_socket_ty Eio.Resource.t
         -> [> \`Close | \`Flow | \`R | \`Shutdown | \`W ] Eio.Resource.t) option
clock : [> float Eio.Time.clock_ty ] Eio.Resource.t
\`\`\`

Closed [\`Generic\`] on the input socket / open [> ...] on the
output (TLS layer can extend).  Caller can plug in their own TLS
stack — kept abstract.

## Why 3 sync helpers (post / get / get_response)?

| Helper | Returns | Use case |
|---|---|---|
| \`post_sync\` | \`(int * string)\` | POST with status + body |
| \`get_sync\` | \`(int * string)\` | GET with status + body only |
| \`get_response_sync\` | \`response\` (full record) | GET when caller needs response headers (link-preview redirect handling) |

\`get_sync\` is implemented as \`get_response_sync\` + drop headers.

## Caller audit
- \`lib/auto_responder.ml\` — \`post_sync\`
- \`lib/cascade/cascade_ollama_probe.ml\` — \`get_sync\`
- \`lib/graphql_client.ml\` — \`post_sync\`
- \`lib/local/worker_container_types.ml\` — \`post_sync\`
- \`lib/opentelemetry_client_cohttp_eio.ml\` — \`make_closing_client\`
- \`lib/server/server_dashboard_http_link_preview.ml\` —
  \`get_response_sync\`
- \`lib/voice/voice_bridge_core.ml\` — \`make_closing_client\`
- \`test/http_client/test_masc_http_client.ml\` —
  \`make_closing_client\`
- \`test/test_ci_hardening_source.ml\` — \`make_closing_client\`

No external reference to \`with_optional_timeout\`.

## Test plan
- [x] \`dune build --root . lib\` — clean
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)