### PR TITLE
chore(tool): add tool_local_runtime_bench.mli (cycle 133)

### DIFF
--- a/lib/tool_local_runtime_bench.mli
+++ b/lib/tool_local_runtime_bench.mli
@@ -1,0 +1,74 @@
+(** Tool_local_runtime_bench — concurrency benchmark against the
+    local runtime pool.
+
+    {b Include cascade:} starts with [include Tool_local_runtime_http]
+    so the 2-layer chain
+    ([Tool_local_runtime_core] -> [Tool_local_runtime_http] -> here)
+    propagates through {!Tool_local_runtime}.
+
+    Single public entry: {!run_bench}.  Internal helpers
+    ({!pctl} percentile, {!error_message_of_http_error},
+    per-runtime breakdown aggregators, runtime-pool resolution
+    helpers, {!ensure_runtime_reachable}, {!oas_completion_at})
+    stay private — the .mli pins the bench result schema, not the
+    plumbing that produces it. *)
+
+include module type of struct
+  include Tool_local_runtime_http
+end
+
+val run_bench :
+  ?model_id:string ->
+  ?runtime_pool:string ->
+  parallelism:int ->
+  rounds:int ->
+  prompt:string ->
+  max_tokens:int ->
+  timeout_sec:int ->
+  unit ->
+  (Yojson.Safe.t, string) result
+(** [run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt
+      ~max_tokens ~timeout_sec ()] runs a concurrency benchmark.
+
+    {b Reachability gate}: returns [Error _] immediately if
+    {!ensure_runtime_reachable} fails for the requested
+    [runtime_pool].  No samples are taken.
+
+    {b Schedule}: [rounds] sequential rounds, each with
+    [parallelism] concurrent fibers via {!Eio.Fiber.all}.  Total
+    [parallelism * rounds] requests issued.
+
+    {b Per-fiber timeout}: [timeout_sec] enforced via
+    {!Eio.Time.with_timeout_exn}.  Timeouts count as failures with
+    [error = "timeout"].
+
+    {b Result schema} (on [Ok]):
+
+    {[
+      \{
+        "server_url": string,
+        "source": "oas_complete",
+        "model_id": string|null,
+        "runtime_pool": string|null,
+        "parallelism": int,
+        "rounds": int,
+        "total_requests": int,
+        "success_count": int,
+        "failure_count": int,
+        "success_rate": float in \[0.0, 1.0\],
+        "p50_latency_ms": int|null,
+        "p95_latency_ms": int|null,
+        "max_latency_ms": int|null,
+        "configured_max_concurrent_models": int,
+        "configured_capacity": int,
+        "measured_ceiling": int|null,
+        "per_runtime_breakdown": [object],
+        "errors": [string]
+      \}
+    ]}
+
+    [errors] is sorted + deduped via {!List.sort_uniq}.
+    [per_runtime_breakdown] is sorted by [runtime_id] for
+    deterministic output.  Side effect: calls
+    {!Local_runtime_pool.record_measured_ceiling} with the
+    success count so the ceiling carries over to subsequent runs. *)


### PR DESCRIPTION
## Summary

Cycle 133 — adds an explicit interface for
\`lib/tool_local_runtime_bench.ml\` (319 lines).  Single-entry
minimal surface — only \`run_bench\` is external.

## Surface (1 entry + 2-layer cascade, 10 hide)

\`\`\`ocaml
include module type of struct include Tool_local_runtime_http end

val run_bench :
  ?model_id:string ->
  ?runtime_pool:string ->
  parallelism:int ->
  rounds:int ->
  prompt:string ->
  max_tokens:int ->
  timeout_sec:int ->
  unit ->
  (Yojson.Safe.t, string) result
\`\`\`

Hidden 10: \`Oas_types\` alias, \`pctl\`,
\`error_message_of_http_error\`, 3 per-runtime breakdown
aggregators, 4 pool resolution helpers,
\`ensure_runtime_reachable\`, \`oas_completion_at\`.

## 2-layer cascade preserved

\`\`\`
Tool_local_runtime_core
        |
        v
Tool_local_runtime_http      [include]
        |
        v
[Tool_local_runtime_bench]   (this PR)
        |
        v
Tool_local_runtime           [re-exports as run_bench]
\`\`\`

\`include module type of struct include Tool_local_runtime_http end\`
(struct form) preserves type identity through both layers — same
pattern as cycles 129/132.

## run_bench result schema pinned (19 fields)

\`\`\`json
{
  "server_url": "<string>",
  "source": "oas_complete",
  "model_id": "<string|null>",
  "runtime_pool": "<string|null>",
  "parallelism": 4,
  "rounds": 3,
  "total_requests": 12,
  "success_count": 10,
  "failure_count": 2,
  "success_rate": 0.833,
  "p50_latency_ms": 142,
  "p95_latency_ms": 387,
  "max_latency_ms": 412,
  "configured_max_concurrent_models": 4,
  "configured_capacity": 4,
  "measured_ceiling": 10,
  "per_runtime_breakdown": [...],
  "errors": ["timeout", "HTTP 503"]
}
\`\`\`

\`per_runtime_breakdown\` is sorted by \`runtime_id\` for deterministic
output.  \`errors\` is \`List.sort_uniq String.compare\` to dedupe.
Schema drift would silently break dashboard parsers — pinning at
the contract seam prevents drift.

## Bench schedule

| Aspect | Value |
|---|---|
| Rounds | sequential |
| Per-round | \`Eio.Fiber.all\` with [\`parallelism\`] fibers |
| Total requests | \`parallelism * rounds\` |
| Per-fiber timeout | \`Eio.Time.with_timeout_exn\` (sec) |
| Timeout error | \`{ success = false; error = Some "timeout" }\` |
| Reachability gate | \`ensure_runtime_reachable\` runs first; on failure -> \`Error _\` immediately, no samples |

## Side effects documented

\`Local_runtime_pool.record_measured_ceiling success_count\` called
on every successful run.  Pinning at the .mli seam — caller can
expect the ceiling to carry over to subsequent runs.

## Hidden helpers (caller-driven)

\`run_bench\` is the only external API.  All 10 helpers
(percentile, HTTP error formatting, per-runtime aggregation, pool
resolution, reachability probe, single-fiber bench cycle) are
plumbing that future refactors can change without breaking
callers.

## Caller audit
- \`lib/tool_local_runtime.ml\` — \`run_bench\` (forwarded as
  \`Tool_local_runtime.run_bench\`)

No external reference to the 10 hidden helpers.

## Test plan
- [x] \`dune build --root . lib\` — clean (first iteration)
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)