### PR TITLE
fix(design-system): DTCG cubicBezier $value as 4-number array

### DIFF
--- a/dashboard/design-system/tokens/build.ts
+++ b/dashboard/design-system/tokens/build.ts
@@ -294,11 +294,29 @@ function dtcgKindToType(kind: TokenBase["kind"]): string {
     case "color": return "color";
     case "dimension": return "dimension";
     case "duration": return "duration";
-    case "easing": return "cubicBezier"; // DTCG uses cubicBezier; we pass through string for cubic-bezier()
+    case "easing": return "cubicBezier";
     case "shadow": return "shadow";
     case "typography": return "fontFamily";
     case "number": return "number";
   }
+}
+
+/**
+ * DTCG cubicBezier $value is required to be a 4-number array (P1x, P1y,
+ * P2x, P2y). For raw easing tokens defined as `cubic-bezier(a,b,c,d)`
+ * we parse the args and emit `[a, b, c, d]`. For role-tier easing
+ * tokens whose value is a `var(--…)` reference (e.g.
+ * `--enter-easing` → `var(--ease-out)`), we pass the string through:
+ * DTCG references are still strings, just resolved to arrays at the
+ * raw-tier definition site.
+ */
+function dtcgValue(tk: TokenBase): unknown {
+  if (tk.kind !== "easing") return tk.value;
+  const m = tk.value.trim().match(
+    /^cubic-bezier\(\s*(-?\d*\.?\d+)\s*,\s*(-?\d*\.?\d+)\s*,\s*(-?\d*\.?\d+)\s*,\s*(-?\d*\.?\d+)\s*\)$/,
+  );
+  if (m === null) return tk.value;
+  return [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
 }
 
 function buildDtcgJson(): string {
@@ -313,7 +331,7 @@ function buildDtcgJson(): string {
     for (const tk of toks) {
       g[tk.name] = {
         $type: dtcgKindToType(tk.kind),
-        $value: tk.value,
+        $value: dtcgValue(tk),
         $description: tk.description ?? undefined,
       };
     }
@@ -325,7 +343,7 @@ function buildDtcgJson(): string {
     for (const tk of theme.tokens) {
       g[tk.name] = {
         $type: dtcgKindToType(tk.kind),
-        $value: tk.value,
+        $value: dtcgValue(tk),
         $description: tk.description ?? undefined,
       };
     }

--- a/dashboard/design-system/tokens/build/tokens.json
+++ b/dashboard/design-system/tokens/build/tokens.json
@@ -415,23 +415,48 @@
     },
     "ease": {
       "$type": "cubicBezier",
-      "$value": "cubic-bezier(.2, .7, .2, 1)"
+      "$value": [
+        0.2,
+        0.7,
+        0.2,
+        1
+      ]
     },
     "ease-out": {
       "$type": "cubicBezier",
-      "$value": "cubic-bezier(.16, 1, .3, 1)"
+      "$value": [
+        0.16,
+        1,
+        0.3,
+        1
+      ]
     },
     "ease-in": {
       "$type": "cubicBezier",
-      "$value": "cubic-bezier(.7, 0, .84, 0)"
+      "$value": [
+        0.7,
+        0,
+        0.84,
+        0
+      ]
     },
     "ease-inout": {
       "$type": "cubicBezier",
-      "$value": "cubic-bezier(.65, 0, .35, 1)"
+      "$value": [
+        0.65,
+        0,
+        0.35,
+        1
+      ]
     },
     "ease-spring": {
       "$type": "cubicBezier",
-      "$value": "cubic-bezier(.34, 1.56, .64, 1)"
+      "$value": [
+        0.34,
+        1.56,
+        0.64,
+        1
+      ]
     },
     "space-1": {
       "$type": "dimension",


### PR DESCRIPTION
## Summary

v2 spec §4.1.2 requires "9 DTCG types completely supported". Easing tokens already had \`\$type: \"cubicBezier\"\` but \`\$value\` was emitted as the **literal CSS string** \`\"cubic-bezier(.16, 1, .3, 1)\"\`. Per DTCG 2025.10 format spec, cubicBezier \`\$value\` MUST be a **4-number array** \`[P1x, P1y, P2x, P2y]\`.

This PR closes the long-standing comment on \`build.ts:297\` ("DTCG uses cubicBezier; we pass through string for cubic-bezier()").

## Change

- New \`dtcgValue(tk)\` helper. For easing tokens whose value is a literal \`cubic-bezier(a,b,c,d)\`, parse and emit \`[a, b, c, d]\`.
- Role-tier easing tokens with \`var(--ease-out)\` references stay as strings — DTCG resolves references per-tier; only the raw definition site needs the array form.
- **CSS output unchanged**: \`--ease-out: cubic-bezier(.16, 1, .3, 1)\` still emits identically. Fix is JSON-output-only.

## Diff sample

Before:
\`\`\`json
"ease-out": { "\$type": "cubicBezier", "\$value": "cubic-bezier(.16, 1, .3, 1)" }
\`\`\`

After:
\`\`\`json
"ease-out": { "\$type": "cubicBezier", "\$value": [0.16, 1, 0.3, 1] }
"ease-in":      { "\$value": [0.7, 0, 0.84, 0] }
"ease-inout":   { "\$value": [0.65, 0, 0.35, 1] }
"ease-spring":  { "\$value": [0.34, 1.56, 0.64, 1] }
"ease":         { "\$value": [0.2, 0.7, 0.2, 1] }
\`\`\`

## Why this matters

Tokens consumers that follow DTCG (Style Dictionary, Specify, Token Studio, etc.) **reject the string form**. The dashboard ecosystem doesn't currently consume \`tokens.json\` externally, so this fix has zero runtime impact — but it unblocks future consumers (e.g. the \`@masc/design-tokens\` npm package proposed in design_system_v2 §8.4.1).

## Verification

- [x] \`pnpm tokens:build\` → wrote 7 outputs (only \`build.ts\` + \`tokens.json\` files actually changed)
- [x] \`pnpm tokens:check\` → status canon + keeper palette ΔE checks pass
- [x] \`pnpm tsc --noEmit\` clean
- [ ] CI checks (this PR)

## Scope

In: easing kind → cubicBezier number array.

Out:
- DTCG \`transition\` \$type for composite \`motion-*\` tokens (those still emit as \`duration\` strings)
- \`shadow\` $type as DTCG shadow object form

Both deferred — current consumers don't need them, and the changes are independent of this fix.

## Related

- Spec: design_system_v2 §4.1.2 (DTCG types)
- DTCG 2025.10: design-tokens.github.io/community-group/format
- Companion: #11741 interaction tokens, #11747 animation tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)