### PR TITLE
chore(tool): add tool_misc_admin.mli (cycle 137)

### DIFF
--- a/lib/tool_misc_admin.mli
+++ b/lib/tool_misc_admin.mli
@@ -1,0 +1,100 @@
+(** Tool_misc_admin — auth, config, tool inventory, and feature
+    flag handlers.
+
+    Extracted from {!Tool_misc} to reduce god-file size.  Contains
+    administrative tool handlers for the dashboard:
+
+    - {!handle_config} (auth config snapshot for the operator UI)
+    - {!handle_tool_admin_snapshot} (tool inventory + permissions)
+    - {!handle_tool_admin_update} (write a section's auth config)
+    - {!handle_feature_flags} (feature flag inventory)
+    - {!tool_inventory_json} (catalog-driven schema list)
+
+    @since 2.187.0 — God file decomposition Phase 1.
+
+    Internal: \[U\] (Yojson.Safe.Util alias), \[json_string_option\],
+    \[bool_arg_opt\], \[int_arg_opt\] (3 local args helpers
+    duplicated from Tool_misc to avoid circular deps),
+    \[permission_to_json\], \[auth_snapshot_json\],
+    \[enforcement_summary_json\], \[handle_feature_flags\] stay
+    private — none are referenced outside this file. *)
+
+(** {1 Types} *)
+
+type tool_result = bool * string
+(** Standard MCP tool return shape: [(success, body_or_error)].
+    [body_or_error] is the JSON string serialised body on success,
+    or a plain error message on failure. *)
+
+type context = {
+  config : Coord.config;
+  agent_name : string;
+}
+(** Per-call context.  Concrete record because callers
+    (notably {!Tool_misc}) construct it field-by-field. *)
+
+(** {1 SSOT} *)
+
+val valid_admin_section_strings : string list
+(** [\["auth"\]] — canonical section values accepted by
+    [masc_tool_admin_update].
+
+    Adding a new section requires {b three} synchronised changes:
+    + A new branch in {!handle_tool_admin_update}.
+    + This list gains the new string.
+    + {!Tool_schemas_misc.admin_section_enum_strings} mirror.
+
+    Sync test in [test_types.ml :: admin_section_ssot] catches
+    drift between the three.
+
+    {b History}: schema once advertised
+    [\["auth"; "unit_policy"\]] but the handler only implemented
+    [auth] (#8546) — fictional sections were removed and pinned
+    here. *)
+
+(** {1 Read-only inventory} *)
+
+val tool_inventory_json :
+  _ ->
+  include_hidden:bool ->
+  include_deprecated:bool ->
+  Yojson.Safe.t
+(** [tool_inventory_json _ctx ~include_hidden ~include_deprecated]
+    returns the tool catalog snapshot.
+
+    [enabled_in_current_mode] is reported as [false] because this
+    is the dashboard context (no keeper) — pinned at the contract
+    seam to prevent operator dashboards from incorrectly showing
+    keeper-only tools as active. *)
+
+(** {1 Tool handlers}
+
+    All four handlers take [args : Yojson.Safe.t] (the JSON-RPC
+    [params] object) and return {!tool_result}.  [ctx] is required
+    for the snapshot/update handlers because they read from the
+    base path. *)
+
+val handle_config : Yojson.Safe.t -> tool_result
+(** [handle_config args] returns the auth-config snapshot filtered
+    by [args.category] (optional string).  Read-only. *)
+
+val handle_tool_admin_snapshot : context -> Yojson.Safe.t -> tool_result
+(** [handle_tool_admin_snapshot ctx args] returns the tool
+    inventory + auth config + feature-flag summary for the admin
+    dashboard.  Optional args:
+
+    - [include_hidden] (bool, default [true]).
+    - [include_deprecated] (bool, default [true]). *)
+
+val handle_tool_admin_update :
+  context -> Yojson.Safe.t -> tool_result
+(** [handle_tool_admin_update ctx args] writes a new auth config.
+    Required args:
+
+    - [section] (string) — must be in {!valid_admin_section_strings}.
+    - [updates] (object) — section-specific payload.
+
+    Returns [(false, "section must be one of: auth")] when the
+    section is invalid.  The "must be one of" message is
+    operator-actionable and pinned at the contract seam — drift
+    breaks the admin UI's error-handling. *)


### PR DESCRIPTION
## Summary

Cycle 137 — adds an explicit interface for
\`lib/tool_misc_admin.ml\` (329 lines).  Admin handlers
extracted from \`tool_misc.ml\` for god-file decomposition.

## Surface (7 entries, 8 hide)

\`\`\`ocaml
type tool_result = bool * string
type context = { config; agent_name }

val valid_admin_section_strings : string list
val tool_inventory_json : _ -> include_hidden:bool -> include_deprecated:bool -> Yojson.Safe.t
val handle_config : Yojson.Safe.t -> tool_result
val handle_tool_admin_snapshot : context -> Yojson.Safe.t -> tool_result
val handle_tool_admin_update : context -> Yojson.Safe.t -> tool_result
\`\`\`

Hidden 8: \`U\` alias, 3 local args helpers
(\`json_string_option\` / \`bool_arg_opt\` / \`int_arg_opt\`),
\`permission_to_json\`, \`auth_snapshot_json\`,
\`enforcement_summary_json\`, \`handle_feature_flags\` (zero
external callers).

## valid_admin_section_strings SSOT pinned

\`\`\`ocaml
val valid_admin_section_strings : string list  (* = ["auth"] *)
\`\`\`

Adding a new section requires **3 synchronized changes**:
1. New branch in \`handle_tool_admin_update\` dispatch.
2. This list gains the new string.
3. \`Tool_schemas_misc.admin_section_enum_strings\` mirror.

Sync test in \`test_types.ml::admin_section_ssot\` catches drift.

**History**: #8546 — schema once advertised
\`["auth"; "unit_policy"]\` but only \`auth\` was implemented.
Fictional section removed and pinned here.

## handle_tool_admin_update error format pinned

\`\`\`
(false, "section must be one of: auth")
\`\`\`

The "must be one of" prefix is **operator-actionable** and the
admin UI parses for it.  Format drift would break error display.

## tool_inventory_json dashboard context

\`enabled_in_current_mode\` is reported as **false** in this
function (dashboard context — no keeper present).  Pinning at
the docstring prevents operator dashboards from incorrectly
showing keeper-only tools as active.

## Why \`handle_feature_flags\` hidden

Zero external callers.  Function exists in the .ml but is unused
outside the module (likely orphan from a refactor).  Future
"expose feature-flag handler" PR can reopen explicitly with
intent.

## Why 3 args helpers duplicated from Tool_misc

Comment in the .ml: "duplicated from tool_misc to avoid circular
deps".  \`Tool_misc\` would otherwise depend on
\`Tool_misc_admin\` and vice versa.  Hidden because all three
helpers (\`json_string_option\`, \`bool_arg_opt\`, \`int_arg_opt\`)
are pure JSON-args helpers — future "extract to Tool_args" PR
can deduplicate without touching this module's surface.

## Caller audit
- \`lib/tool_misc.ml\` — \`context\`, \`handle_config\`,
  \`handle_tool_admin_snapshot\`, \`handle_tool_admin_update\`,
  \`tool_inventory_json\`
- \`lib/tool_schemas/tool_schemas_misc.ml\` —
  \`valid_admin_section_strings\`
- \`test/test_types.ml\` — \`valid_admin_section_strings\` (SSOT
  drift test)

No external reference to the 8 hidden helpers /
\`handle_feature_flags\`.

## Test plan
- [x] \`dune build --root . lib\` — clean (first iteration)
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)