### PR TITLE
chore(benchmark): add tool_call_quality_benchmark_summary.mli (cycle 139)

### DIFF
--- a/lib/tool_call_quality_benchmark_summary.mli
+++ b/lib/tool_call_quality_benchmark_summary.mli
@@ -1,0 +1,63 @@
+(** Tool_call_quality_benchmark_summary — aggregate evidence runs
+    + case scores into a {!benchmark_summary}.
+
+    Single external entry: {!summarize}.  All percentile / averaging
+    / dedup / grouping helpers are private — the .mli pins the
+    output type, not the plumbing.
+
+    {b Family}: complements
+    {!Tool_call_quality_benchmark_loader} (raw evidence I/O),
+    {!Tool_call_quality_benchmark_scoring} (per-run scoring), and
+    {!Tool_call_quality_benchmark} (the facade that wires all
+    three together).
+
+    Internal: 19 helpers stay private (\[avg_float\],
+    \[avg_int_option\], \[avg_float_option\],
+    \[percentile95_int_option\], \[dedupe_keep_order\],
+    \[normalize_string_list\], \[model_label\],
+    \[normalize_filter_set\], \[keep_run\],
+    \[group_scores_by_case\], \[modal_ratio\], \[tool_sequence\],
+    \[summary_key_of_run\], \[summary_key_of_score\],
+    \[repeated_metrics_for_view\], \[collapse_repeated_metrics\],
+    \[build_summary_rows\]). *)
+
+val summarize :
+  cases:Tool_call_quality_benchmark_types.benchmark_case list ->
+  runs:Tool_call_quality_benchmark_types.evidence_run list ->
+  ?model_filters:string list ->
+  ?keeper_filters:string list ->
+  unit ->
+  Tool_call_quality_benchmark_types.benchmark_summary
+(** [summarize ~cases ~runs ?model_filters ?keeper_filters ()]
+    returns the aggregated summary.
+
+    {b Filter contract}: when [model_filters = Some \[\]] or
+    [None], all runs pass the model filter; same for
+    [keeper_filters].  Non-empty filters match against:
+
+    - [model_filters]: ["<provider>:<model>"] composite key.
+    - [keeper_filters]: keeper profile string.
+
+    Filter strings are normalised (trim + lowercase) before
+    comparison.
+
+    {b Status counters} ({!benchmark_summary.unsupported_runs} /
+    {!benchmark_summary.runtime_unreachable_runs} /
+    {!benchmark_summary.unknown_case_runs}) reflect filtered runs:
+
+    - [unsupported_runs]: [run.status = Run_unsupported].
+    - [runtime_unreachable_runs]: [run.status = Run_runtime_unreachable].
+    - [unknown_case_runs]: [run.status = Run_ok] AND
+      [run.case_id] not in [cases].
+
+    {b Three groupings produced} (always all three, not selectable):
+
+    - [grouped_by_provider_model_keeper] — most-specific
+      grouping; one row per ["<provider>:<model>:<keeper>"] tuple.
+    - [grouped_by_provider_model] — collapses keeper variations.
+    - [grouped_by_keeper_profile] — collapses provider/model
+      variations.
+
+    Rows in each list are sorted by descending [composite_score],
+    breaking ties by descending [cases_total] (more evidence
+    wins). *)


### PR DESCRIPTION
## Summary

Cycle 139 — adds an explicit interface for
\`lib/tool_call_quality_benchmark_summary.ml\` (330 lines).
Single-entry minimal surface.

## Surface (1 entry, 19 hide)

\`\`\`ocaml
val summarize :
  cases:Tool_call_quality_benchmark_types.benchmark_case list ->
  runs:Tool_call_quality_benchmark_types.evidence_run list ->
  ?model_filters:string list ->
  ?keeper_filters:string list ->
  unit ->
  Tool_call_quality_benchmark_types.benchmark_summary
\`\`\`

Hidden 19: averaging (\`avg_float\` / \`avg_int_option\` /
\`avg_float_option\`), \`percentile95_int_option\`, list helpers
(\`dedupe_keep_order\` / \`normalize_string_list\`), filter
normalization (\`model_label\` / \`normalize_filter_set\` /
\`keep_run\`), grouping (\`group_scores_by_case\` / \`modal_ratio\`
/ \`tool_sequence\` / \`summary_key_of_run\` / \`summary_key_of_score\`
/ \`repeated_metrics_for_view\` / \`collapse_repeated_metrics\` /
\`build_summary_rows\`).

## Family context

\`\`\`
Tool_call_quality_benchmark_types     (data types, has .mli already)
        |
        +--> Tool_call_quality_benchmark_loader   (cycle 108 — PR #11734)
        +--> Tool_call_quality_benchmark_scoring  (cycle 111 — PR #11737)
        +--> [Tool_call_quality_benchmark_summary]   (this PR)
        |
        v
Tool_call_quality_benchmark            (facade — wires all four)
\`\`\`

## Filter contract pinned

| Filter input | Behavior |
|---|---|
| \`Some []\` or \`None\` | All runs pass |
| \`Some \[..\]\` (non-empty) | Match against composite key |

Match keys:
- \`model_filters\`: \`<provider>:<model>\` composite key
- \`keeper_filters\`: keeper profile string

Strings are **normalised** (trim + lowercase) before comparison.

## Status counter semantics

| Counter | Definition |
|---|---|
| \`unsupported_runs\` | \`run.status = Run_unsupported\` |
| \`runtime_unreachable_runs\` | \`run.status = Run_runtime_unreachable\` |
| \`unknown_case_runs\` | \`run.status = Run_ok\` **AND** \`run.case_id\` not in \`cases\` |

\`unknown_case_runs\` is the diagnostic for case-id drift —
operator sees that runs reference cases no longer in the catalog.

## Three groupings always produced

| Grouping | Collapses |
|---|---|
| \`grouped_by_provider_model_keeper\` | nothing — most specific |
| \`grouped_by_provider_model\` | keeper profile |
| \`grouped_by_keeper_profile\` | provider + model |

All three are produced by every \`summarize\` call (not
selectable).  Caller picks the relevant view in the UI.

## Row sort order

Primary: descending \`composite_score\`.
Tie-break: descending \`cases_total\` (more evidence wins).

Pinned at the contract seam — UI tables depend on this exact
ordering for "best provider" rendering.

## Caller audit
- \`lib/tool_call_quality_benchmark.ml\` — \`summarize\`

No external reference to the 19 hidden helpers.

## Test plan
- [x] \`dune build --root . lib\` — clean (first iteration)
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)