### PR TITLE
chore(tool): add tool_operator.mli (cycle 140)

### DIFF
--- a/lib/tool_operator.mli
+++ b/lib/tool_operator.mli
@@ -1,0 +1,81 @@
+(** Tool_operator — MCP tools for operator control plane
+    (snapshot / digest / action / confirm / judgment / surface
+    audit).
+
+    Single dispatch entry: {!dispatch}.  Two schema lists exposed
+    so the SDK adapter can advertise the operator-remote subset
+    separately from the full tool catalog.
+
+    Internal: 22 schema-constructor / action-enum / dispatcher
+    helper functions stay private — the .mli pins {!schemas} /
+    {!remote_schemas} list contents at module init, so caller
+    contract is the lists, not the constructors. *)
+
+(** {1 Per-call context} *)
+
+type 'a context = {
+  config : Coord.config;
+  agent_name : string;
+  sw : Eio.Switch.t;
+  clock : 'a Eio.Time.clock;
+  proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
+  net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  mcp_session_id : string option;
+}
+(** Per-tool-call capability bundle.  Concrete record because
+    callers (notably {!Mcp_server_eio_execute}) construct it
+    field-by-field at the dispatch site.  Polymorphic [\\'a] on
+    [clock] propagates Eio's row-typed clock through to
+    {!Operator_control}'s downstream context.  {!dispatch}
+    instantiates [\\'a] to [float Eio.Time.clock_ty] to match
+    {!Operator_control}'s concrete-clock requirement. *)
+
+(** {1 Result} *)
+
+type tool_result = bool * string
+(** Standard MCP tool return: [(success, body_or_error)].
+    [body_or_error] is the JSON-serialised body on success or an
+    error message on failure. *)
+
+(** {1 Dispatch} *)
+
+val dispatch :
+  float Eio.Time.clock_ty context ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  tool_result option
+(** [dispatch ctx ~name ~args] dispatches the named MCP tool call.
+    Returns [None] for unrecognised names so callers can fall
+    through to other dispatchers.
+
+    Recognised names (full catalog — see {!schemas} for the
+    schema bodies):
+    - [masc_operator_snapshot] — read operator state.
+    - [masc_operator_digest] — daily digest.
+    - [masc_operator_action] — schedule an action (requires
+      confirm via separate call).
+    - [masc_operator_confirm] — confirm a pending action.
+    - [masc_operator_judgment_write] — record a judgment (hidden
+      from default catalog).
+    - [masc_operator_judgment_latest] — read latest judgment.
+    - [masc_surface_audit] — operator-only surface drift audit. *)
+
+(** {1 Catalog surfaces}
+
+    The full catalog ({!schemas}, internal) and the operator-remote
+    subset ({!remote_schemas}) advertise different tool sets to
+    different MCP profiles.
+
+    {b Why split}: the operator-remote profile is the externally
+    reachable seam (dashboard / SDK), so it advertises only the
+    safe-to-expose subset.  The full {!schemas} is consumed inside
+    the keeper-bound dispatcher only. *)
+
+val remote_schemas : Types.tool_schema list
+(** Operator-remote tool schemas — the subset advertised to remote
+    MCP clients.  Pinned at the .mli seam so dashboard / SDK
+    consumers see a stable list ordering. *)
+
+val remote_tool_names : string list
+(** [List.map (fun s -> s.name) remote_schemas].  Pre-computed for
+    O(1) membership checks in the auth gate. *)


### PR DESCRIPTION
## Summary

Cycle 140 — adds an explicit interface for
\`lib/tool_operator.ml\` (352 lines).  Operator-control MCP tool
dispatcher (snapshot / digest / action / confirm / judgment /
surface audit).

## Surface (5 entries, 22 hide)

\`\`\`ocaml
type 'a context = {
  config; agent_name; sw; clock;
  proc_mgr; net; mcp_session_id;
}

type tool_result = bool * string

val dispatch :
  float Eio.Time.clock_ty context ->
  name:string ->
  args:Yojson.Safe.t ->
  tool_result option

val remote_schemas : Types.tool_schema list
val remote_tool_names : string list
\`\`\`

Hidden 22: 1 JSON shape helper, 5 enum-string lists, 6 schema
constructors, 1 result-to-yojson helper, full \`schemas\` list,
4 leading-underscore tool-spec metadata lists.

## clock polymorphism asymmetry

\`'a context\` keeps \`clock : 'a Eio.Time.clock\` polymorphic so
the record type propagates to downstream
\`Operator_control.context\` cleanly.  But \`dispatch\` instantiates
\`'a\` to **concrete** \`float Eio.Time.clock_ty\` because
\`Operator_control\`'s downstream functions require concrete-clock
typing.

First build attempt used \`[> float Eio.Time.clock_ty]\` open
variant in the .mli — sub-typing direction check failed.  Concrete
type matches the .ml-inferred type exactly.

## Why two schema lists

| List | Visibility | Used by |
|---|---|---|
| \`schemas\` (hidden) | full catalog | \`Tool_spec.register\` block at module init only |
| \`remote_schemas\` (exposed) | operator-remote subset | dashboard / SDK MCP clients |

The split lets the operator-remote profile (externally reachable)
advertise only safe-to-expose tools, while \`schemas\` stays
keeper-bound (internal).

## Why \`remote_tool_names\` precomputed

\`\`\`ocaml
let remote_tool_names = List.map (fun (s : tool_schema) -> s.name) remote_schemas
\`\`\`

Pre-computed at module init for O(1) membership checks in the
auth gate (vs. recomputing the list on every check call).

## Recognised dispatch names

| Name | Purpose |
|---|---|
| \`masc_operator_snapshot\` | Read operator state |
| \`masc_operator_digest\` | Daily digest |
| \`masc_operator_action\` | Schedule action (requires confirm) |
| \`masc_operator_confirm\` | Confirm a pending action |
| \`masc_operator_judgment_write\` | Record judgment (hidden from default) |
| \`masc_operator_judgment_latest\` | Read latest judgment |
| \`masc_surface_audit\` | Operator-only surface drift audit |

\`dispatch\` returns \`None\` for unrecognised names — caller falls
through to other dispatchers.

## context record fields

| Field | Type |
|---|---|
| \`config\` | \`Coord.config\` |
| \`agent_name\` | \`string\` |
| \`sw\` | \`Eio.Switch.t\` |
| \`clock\` | \`'a Eio.Time.clock\` (polymorphic in record, concrete in dispatch) |
| \`proc_mgr\` | \`Eio_unix.Process.mgr_ty Eio.Resource.t option\` |
| \`net\` | \`[\`Generic | \`Unix] Eio.Net.ty Eio.Resource.t option\` |
| \`mcp_session_id\` | \`string option\` |

## Caller audit
- \`lib/mcp_server_eio_execute.ml\` — \`Tool_operator.config\`
  (record field) + \`Tool_operator.dispatch\`
- \`lib/mcp_server_eio_tool_profile.ml\` —
  \`Tool_operator.remote_schemas\` +
  \`Tool_operator.remote_tool_names\`
- \`test/test_tools_coverage.ml\` — \`Tool_operator.remote_schemas\`

No external reference to \`schemas\` / 6 schema constructors / 5
enum lists / 4 \`_tool_spec_*\` metadata lists.

## Test plan
- [x] \`dune build --root . lib\` — clean (after concrete clock fix)
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)