### PR TITLE
chore(dashboard): add dashboard_execution_sessions.mli (cycle 149)

### DIFF
--- a/lib/dashboard/dashboard_execution_sessions.mli
+++ b/lib/dashboard/dashboard_execution_sessions.mli
@@ -1,0 +1,68 @@
+(** Dashboard_execution_sessions — session-context aggregation
+    for the execution dashboard.
+
+    {b Cascade chain}: starts with
+    [include Dashboard_execution_helpers], so
+    {!Dashboard_execution_builders} (which does
+    [include Dashboard_execution_sessions]) re-exports the full
+    helpers + this module surface upward to
+    {!Dashboard_execution}.
+
+    Internal: 14 functions stay private.  Only
+    {!related_session_for_member} (used by
+    {!Dashboard_execution_builders}) and
+    {!build_execution_queue} (used by {!Dashboard_execution}) are
+    cascade-visible.  The remaining helpers are keeper-internal
+    and refactor-free:
+
+    - 9 JSON field accessors ([session_payload_json],
+      [session_meta_json], [session_summary_json],
+      [session_team_health_json],
+      [session_communication_json],
+      [session_status_string],
+      [session_recent_events],
+      [event_detail_json],
+      [event_summary]).
+    - [session_severity] (severity classification).
+    - [build_session_seed] / [session_operation_links] /
+      [build_session_contexts] (session aggregation).
+    - [queue_summary_of_session] (queue helper consumed by
+      {!build_execution_queue}).
+
+    Future "expose builder pipeline" PR can reopen these
+    explicitly with intent. *)
+
+include module type of struct
+  include Dashboard_execution_helpers
+end
+
+(** {1 Member -> session lookup (cascade-visible)} *)
+
+val related_session_for_member :
+  session_context list -> string -> session_context option
+(** [related_session_for_member contexts name] returns the first
+    {!session_context} from [contexts] whose normalised
+    member-name list contains [name] (lowercased + trimmed before
+    comparison).  Returns [None] when no member matches.
+
+    Used by {!Dashboard_execution_builders} to resolve
+    agent / keeper member -> session relationships during brief
+    aggregation.  Pinned at the contract seam — agent-name
+    normalisation rules (lowercase + trim) must stay consistent
+    across cascade consumers. *)
+
+(** {1 Execution queue (cascade-visible)} *)
+
+val build_execution_queue :
+  session_context list ->
+  operation_context list ->
+  queue_context list
+(** [build_execution_queue session_contexts operation_contexts]
+    aggregates the dashboard execution queue: blocked / pending
+    sessions plus their linked operation contexts, sorted by
+    severity (descending) then by [last_seen_ts] (descending).
+    Returns a list of structurally-typed queue-item records (each
+    has at minimum [severity_rank: int] and
+    [last_seen_ts: float]).  {!Dashboard_execution} consumes the
+    list bare via include cascade and applies a [take 10] cap
+    before serialisation. *)


### PR DESCRIPTION
## Summary

Cycle 149 — adds an explicit interface for
\`lib/dashboard/dashboard_execution_sessions.ml\` (427 lines).
Session aggregation for the execution dashboard.

## Surface (2 entries + Dashboard_execution_helpers cascade, 14 hide)

\`\`\`ocaml
include module type of struct include Dashboard_execution_helpers end

val related_session_for_member :
  session_context list -> string -> session_context option

val build_execution_queue :
  session_context list -> operation_context list -> queue_context list
\`\`\`

Hidden 14: 9 JSON field accessors (session_*_json + 2 event
helpers), \`session_severity\`, 3 session aggregation builders,
\`queue_summary_of_session\` queue helper.

## Cascade chain

\`\`\`
Dashboard_execution_helpers       (no .mli — inferred)
       |
       v
[Dashboard_execution_sessions]    (this PR)
       |
       v
Dashboard_execution_builders      (include cascade)
       |
       v
Dashboard_execution               (include cascade)
\`\`\`

Two cascade-visible symbols emerge from bare-symbol grep across
both consumers:
- \`related_session_for_member\` used by builders for
  agent / keeper -> session resolution.
- \`build_execution_queue\` used by Dashboard_execution
  (with [take 10] applied before serialisation).

## Initial draft mistakes (lessons)

**Lesson 1**: bare-symbol grep on direct consumer only.  Initial
grep targeted \`Dashboard_execution_builders.ml\` and missed
\`Dashboard_execution.ml\`'s use of \`build_execution_queue\`.
Build error caught the omission.  Reinforces: grep ALL cascade
levels, not just the immediate include consumer.

**Lesson 2**: function name guessed return type wrong.  Initial
\`build_execution_queue\` signature used \`Yojson.Safe.t\`
(assumed it built JSON), but actual return is
\`queue_context list\` (Dashboard_execution caller does \`take 10\`
before serialisation).  Compiler told the truth.

## build_execution_queue sort order pinned

Sort order: \`severity_rank\` descending, then \`last_seen_ts\`
descending (ties).  Pinning prevents future "sort by created_at"
simplification that would change dashboard ordering.

\`queue_context\` type itself is in
\`Dashboard_execution_helpers\` and cascade-visible via the
struct-form include — no additional surface needed.

## Why hide the 9 JSON accessors

\`session_payload_json\` / \`session_meta_json\` / etc. are pure
field-access helpers consumed only inside this module's session
builder pipeline.  Future "expose JSON accessors" PR can reopen
explicitly with intent.

## Caller audit
- \`lib/dashboard/dashboard_execution_builders.ml\` — bare access
  via cascade — \`related_session_for_member\` (3 sites)
- \`lib/dashboard/dashboard_execution.ml\` — bare access via
  cascade through builders — \`build_execution_queue\` (1 site)

No external reference to the 14 hidden JSON helpers / session
builders / queue helper.

## Test plan
- [x] \`dune build --root . lib\` — clean (after 2 sig fixes)
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)