### PR TITLE
chore(worker): add worker_container_runners.mli (cycle 158)

### DIFF
--- a/lib/local/worker_container_runners.mli
+++ b/lib/local/worker_container_runners.mli
@@ -1,0 +1,96 @@
+(** Worker_container_runners — OAS-backed and legacy-backed worker
+    spawn entry points.
+
+    Re-exported by {!Worker_runtime} (the public facade) which
+    does \[include module type of Worker_container_runners\] in its
+    .mli.  Callers reach the run helpers + lookup utilities
+    through {!Worker_runtime}.
+
+    {b Cascade chain}: starts with [include Worker_container],
+    transitively bringing the {!Worker_container} +
+    {!Worker_container_types} surfaces into scope (notably
+    [list_masc_tools], [parse_text_tool_calls], [run_result]).
+
+    Internal: 7 helpers stay private — \[resolve_net\],
+    \[default_shell_tool_names\], \[build_execution_spec\],
+    \[workspace_path_of_spec\], \[effective_model_of_resume\],
+    \[dedupe_tools_by_name\], \[create_raw_trace\].  All consumed
+    inside the run / preflight pipelines. *)
+
+include module type of struct
+  include Worker_container
+end
+
+(** {1 OAS-backed run} *)
+
+val run_worker_oas :
+  sw:Eio.Switch.t ->
+  ?net:Eio_context.eio_net ->
+  room_config:Coord.config option ->
+  Worker_execution_spec.t ->
+  unit ->
+  (run_result, string) result
+(** [run_worker_oas ~sw ?net ~room_config spec] returns a thunk
+    that runs (or resumes) the worker via OAS:
+
+    - Resolve net (from [?net] or {!Eio_context}).
+    - Resolve effective model from
+      {!Worker_container.load_worker_meta} when checkpoint
+      exists, otherwise from the spec.
+    - Build MASC + shell tool sets and dedupe by tool name.
+    - Create / open raw trace under
+      [<base_path>/workers/<worker_name>/raw_trace.jsonl].
+    - Dispatch to {!Worker_oas.run_worker_via_oas} (cold start)
+      or {!Worker_oas.resume_worker_via_oas} (when checkpoint
+      present).
+
+    Returns a thunk so callers can defer the run inside their
+    own switch / fiber. *)
+
+(** {1 Preflight (Docker batches)} *)
+
+val preflight_spawn_batch :
+  ?clock_opt:_ ->
+  Worker_execution_spec.t list ->
+  (unit, string) result
+(** [preflight_spawn_batch ?clock_opt specs] runs the per-batch
+    Docker preflight check ({!Worker_runtime_docker.preflight_batch})
+    when {!Worker_runtime_config.backend} is [Docker]; returns
+    [Ok ()] immediately for [Local_playground].  Operator calls
+    once before spawning all workers in the batch — errors
+    short-circuit the whole batch.  See cycle 143
+    ({!Worker_runtime_docker}) for the Docker-side details. *)
+
+(** {1 Backend-dispatching run} *)
+
+val run_worker :
+  sw:Eio.Switch.t ->
+  ?net:Eio_context.eio_net ->
+  runtime_backend:Worker_execution_backend.t ->
+  base_path:string ->
+  worker_name:string ->
+  model_label:string ->
+  room_config:Coord.config option ->
+  ?working_dir:string ->
+  ?thinking_enabled:bool ->
+  ?worker_run_id:string ->
+  role:string option ->
+  selection_note:string option ->
+  prompt:string ->
+  timeout_sec:int ->
+  unit ->
+  (run_result, string) result
+(** [run_worker ~sw ?net ~runtime_backend ~base_path ~worker_name
+      ~model_label ~room_config ?working_dir ?thinking_enabled
+      ?worker_run_id ~role ~selection_note ~prompt ~timeout_sec]
+    builds a {!Worker_execution_spec.t} from the explicit args
+    and dispatches by [runtime_backend]:
+
+    - [Local_playground] -> {!run_worker_oas} with the spec.
+    - [Docker] -> rewrite spec for container via
+      {!Worker_runtime_docker.rewrite_spec_for_container}, then
+      {!Worker_runtime_docker.run_worker_spec}.
+
+    Returns the same thunk shape as {!run_worker_oas}.  Pinned
+    at the contract seam: adding a new backend variant requires
+    extending this match. *)


### PR DESCRIPTION
## Summary

Cycle 158 — adds an explicit interface for
\`lib/local/worker_container_runners.ml\` (170 lines).
**Re-attempt** of a module deferred at cycle 144 due to facade
complexity.

## Surface (3 entries + Worker_container cascade, 7 hide)

\`\`\`ocaml
include module type of struct include Worker_container end

val run_worker_oas
  ~sw ?net ~room_config:Coord.config option
  -> Worker_execution_spec.t -> unit -> (run_result, string) result

val preflight_spawn_batch ?clock_opt
  -> Worker_execution_spec.t list -> (unit, string) result

val run_worker
  ~sw ?net ~runtime_backend ~base_path ~worker_name ~model_label
  ~room_config ?working_dir ?thinking_enabled ?worker_run_id
  ~role ~selection_note ~prompt ~timeout_sec
  -> unit -> (run_result, string) result
\`\`\`

Hidden 7: \`resolve_net\`, \`default_shell_tool_names\`,
\`build_execution_spec\`, \`workspace_path_of_spec\`,
\`effective_model_of_resume\`, \`dedupe_tools_by_name\`,
\`create_raw_trace\`.

## Cascade preservation

\`\`\`
Worker_container_types
       |
       v
Worker_container        (no .mli — inferred surface)
       |
       v
[Worker_container_runners]  (this PR)
       |
       v
Worker_runtime          (.mli does include module type of Worker_container_runners)
\`\`\`

\`Worker_runtime.mli\` uses **non-struct** \`include module type of
Worker_container_runners\`.  My .mli uses struct-form
\`include module type of struct include Worker_container end\` so
the transitive types (\`run_result\`, \`list_masc_tools\`,
\`parse_text_tool_calls\`) propagate correctly through to
\`Worker_runtime\` callers.

## Cycle 144 deferral, cycle 158 re-attempt

Cycle 144 deferred this module due to facade complexity.  Cycle
158 re-attempted with experience from cycle 157
(compiler-driven type discovery).

Two key insights from build errors:

1. \`?net\` is \`Eio_context.eio_net\` (NOT
   \`[ \`Generic | \`Unix ] Eio.Net.ty Eio.Resource.t\` —
   that's the un-aliased form).  This module uses the aliased
   version through \`Eio_context\`.

2. \`~room_config\` is \`Coord.config option\` (NOT just
   \`Coord.config\`).  The optional wrapping comes from the
   \`Coord_utils.config = Coord.config\` chain — caller can pass
   \`None\` when running detached.

Both caught by build error — same pattern as cycle 157's
\`transport\` fix.

## Thunk pattern pinned

\`run_worker_oas\` returns
\`unit -> (run_result, string) result\` so callers can defer the
run inside their own switch / fiber.  Pinning at the docstring
prevents future "simplify by returning result directly"
simplifications that would break the lazy-execution flow.

## run_worker dispatch table

| Backend | Action |
|---|---|
| \`Local_playground\` | \`run_worker_oas\` with the spec |
| \`Docker\` | rewrite spec → \`run_worker_spec\` via \`Worker_runtime_docker\` |

Adding a new backend variant requires extending this match.

## Caller audit
- \`lib/local/worker_runtime.ml\` — include cascade
- \`lib/local/worker_runtime.mli\` —
  [\`include module type of Worker_container_runners\`] (re-export)
- \`bin/masc_worker_run.ml\` — \`Worker_runtime.run_worker_oas\`
- \`test/test_worker_runtime.ml\` — \`run_worker_oas\`,
  \`list_masc_tools\` (cascade)
- \`test/test_worker_container_coverage.ml\` —
  \`parse_text_tool_calls\` (cascade)

No external reference to the 7 hidden helpers.

## Test plan
- [x] \`dune build --root . lib\` — clean (after 2 type fixes)
- [ ] \`dune runtest\` (CI)
- [ ] Ratchet \`lib_other_mli_missing\` decreases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)