### PR TITLE
chore(coord): add coord_types.mli — type-SSOT for coord cluster (cycle 161)

### DIFF
--- a/lib/coord_types.mli
+++ b/lib/coord_types.mli
@@ -1,0 +1,71 @@
+(** Coord_types — Shared types for coordination modules.
+
+    Type-SSOT for the [tool_coord] / [coord_status_rendering] /
+    [coord_assertions] / [coord_goals] cluster.  Consumers
+    typically [open Coord_types] (4 sites: [tool_coord],
+    [coord_goals], [coord_status_rendering], [coord_assertions])
+    so every type below is part of the cross-module contract.
+
+    All records are concrete because callers construct +
+    destructure them field-by-field at the dispatch site. *)
+
+(** [tool_result] is [(success, message)].  Used by tool dispatch
+    return type before promotion to {!Tool_result.t}. *)
+type tool_result = bool * string
+
+(** Per-call coordination context.  Carries the resolved
+    {!Coord.config} and the agent identifier. *)
+type context = {
+  config : Coord.config;
+  agent_name : string;
+}
+
+(** Credential availability snapshot used by status rendering /
+    cascade gating.  [credential_candidates] enumerates env-var
+    names probed during resolution. *)
+type credential_state = {
+  credential_required : bool;
+  credential_available : bool;
+  credential_candidates : string list;
+}
+
+(** Resolved binding between [current_task] and the assignee /
+    planning state.
+
+    - [assigned_task_ids]: tasks where the calling agent is the
+      active assignee (Claimed / InProgress / AwaitingVerification).
+    - [primary_owned]: single canonical task id (when
+      unambiguous).
+    - [planning_current]: task id resolved from planning state
+      (may differ from [primary_owned] during drift).
+    - [current_is_assigned]: whether the [current_task] coord
+      field is in [assigned_task_ids].
+    - [effective_current]: post-reconciliation task id used by
+      status rendering.
+    - [drift_reason]: human-readable explanation when planning
+      and ownership disagree.
+    - [current_task_set]: whether the coord [current_task] field
+      is non-empty.
+    - [claim_first_suppressed]: whether the "claim_first"
+      suggestion was suppressed (e.g. agent already owns a task). *)
+type current_binding = {
+  assigned_task_ids : string list;
+  primary_owned : string option;
+  planning_current : string option;
+  current_is_assigned : bool;
+  effective_current : string option;
+  drift_reason : string option;
+  current_task_set : bool;
+  claim_first_suppressed : bool;
+}
+
+(** Planning-context anomaly snapshot.
+
+    - [planning_missing_task]: task id referenced by the planning
+      slot but not present in the backlog.
+    - [deliverable_conflict_task]: task id whose deliverable
+      claims completion in conflict with the recorded status. *)
+type planning_context_state = {
+  planning_missing_task : string option;
+  deliverable_conflict_task : string option;
+}


### PR DESCRIPTION
## Summary

Pin the type-SSOT module `lib/coord_types.ml` consumed via `open Coord_types` by 4 callers (`tool_coord`, `coord_goals`, `coord_status_rendering`, `coord_assertions`). Adding the .mli does not change the surface (every binding is already cross-module-visible) but pins the field-level contract via docstrings.

## Surface (5 types — all concrete records / aliases)

- `tool_result = bool * string` — pre-`Tool_result.t` dispatch return.
- `context` — per-call coordination context (`config`, `agent_name`).
- `credential_state` — credential availability snapshot (3 fields).
- `current_binding` — 8-field reconciliation snapshot (assigned_task_ids, primary_owned, planning_current, current_is_assigned, effective_current, drift_reason, current_task_set, claim_first_suppressed).
- `planning_context_state` — planning anomaly snapshot (planning_missing_task, deliverable_conflict_task).

## Why expose every binding?

Memory feedback `mli-exposure-strategy-by-module-size` says type-SSOT modules under 500 lines exhaustively expose. Plus `open Coord_types` cascade makes the choice mechanical — hiding any field would break callers.

## Field-level contract pinning

`current_binding` field semantics drove keeper drift / planning conflict cascades. Pinning at .mli level prevents downstream rename / semantic drift:
- `effective_current` vs `primary_owned` vs `planning_current` distinction.
- `drift_reason` as the human-readable disagreement explanation.
- `claim_first_suppressed` decision pinning.

## Test plan

- [x] `dune build --root . lib/` green on first try
- [ ] CI: dune build + ratchet (`lib_other_mli_missing` decrement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)