### PR TITLE
chore(oas): add oas_model_resolve.mli — facade over Cascade_runtime (cycle 162)

### DIFF
--- a/lib/oas_model_resolve.mli
+++ b/lib/oas_model_resolve.mli
@@ -1,0 +1,18 @@
+(** Oas_model_resolve — compatibility facade over
+    {!Cascade_runtime}.
+
+    Cascade ownership now lives under [lib/cascade/].  This
+    module is a stable name preserved while internal callers
+    migrate.  The facade re-exports {!Cascade_runtime} verbatim
+    via [include module type of] — type identity is preserved,
+    so callers can interleave [Oas_model_resolve.X] and
+    [Cascade_runtime.X] freely.
+
+    External callers (tests + observability contracts) reach
+    {!Cascade_runtime.max_context_of_label},
+    {!Cascade_runtime.provider_name_of_label},
+    {!Cascade_runtime.resolve_primary_max_context} through this
+    facade.  When all callers have migrated, this module can be
+    deleted in one revert-safe commit. *)
+
+include module type of Cascade_runtime


### PR DESCRIPTION
## Summary

Pin the surface of the `Oas_model_resolve` compatibility facade.  The .ml is one functional line (`include Cascade_runtime`); the .mli mirrors via `include module type of Cascade_runtime`.  Type identity is preserved — callers can interleave `Oas_model_resolve.X` and `Cascade_runtime.X` freely.

## Why this is safe

- `Cascade_runtime` already has its own .mli at `lib/cascade/cascade_runtime.mli`, so the include cascade has a known signature ceiling.
- No new types, no new values introduced.
- Adding the .mli does not narrow the surface — it documents that the facade is intentionally identity-with-Cascade_runtime.

## Migration path

This module is a compatibility name preserved during the `lib/cascade/` ownership move. When all callers have migrated to `Cascade_runtime` directly, the module + this .mli can be deleted in one revert-safe commit.

## Surface confirmed via caller grep

- `test/test_observability_provider_contracts.ml` — `max_context_of_label`, `provider_name_of_label`
- `test/test_relay_coverage.ml` — `resolve_primary_max_context` (docstring reference)

All resolve through the include cascade.

## Test plan

- [x] `dune build --root . lib/` green on first try
- [ ] CI: dune build + ratchet (`lib_other_mli_missing` decrement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)