### PR TITLE
chore(tool): add tool_agent_timeline.mli — per-agent activity timeline (cycle 170)

### DIFF
--- a/lib/tool_agent_timeline.mli
+++ b/lib/tool_agent_timeline.mli
@@ -1,0 +1,85 @@
+(** Tool_agent_timeline — Per-agent activity timeline + summary.
+
+    Implements the [masc_agent_timeline] MCP tool plus the
+    [/api/dashboard/agent/<name>/timeline] HTTP route.  Aggregates
+    6 event sources for a single agent ([agent_events],
+    [task_events], [message_events], [tool_call_events],
+    [keeper_cdal_events], [turn_completed_events]), filters by
+    [since_hours] cutoff, sorts chronologically, truncates to
+    [limit] (most recent), and emits a JSON summary with
+    cardinality counts + token/cost rollups.
+
+    Internal: 11 helpers + 1 type stay private —
+    \[parse_iso_timestamp] (Scanf-based ISO8601 parser),
+    [timeline_event] type + [event_to_json], the 6 source
+    extractors ([agent_events], [task_events], [message_events],
+    [tool_call_events], [keeper_cdal_events],
+    [turn_completed_events]), and [handle_agent_timeline] (the
+    dispatch handler that reaches {!build_timeline}).  All
+    consumed only inside {!build_timeline} or {!dispatch}. *)
+
+(** {1 Tool result + context} *)
+
+type tool_result = bool * string
+(** [(success, message)] dispatch return shape. *)
+
+type context = {
+  config : Coord.config;
+  agent_name : string;
+}
+(** Per-call context.  Concrete record because callers
+    construct it field-by-field at the dispatch site
+    ([{ Tool_agent_timeline.config; agent_name }]). *)
+
+(** {1 Timeline construction} *)
+
+val build_timeline :
+  Coord.config ->
+  agent_name:string ->
+  since_hours:float ->
+  limit:int ->
+  include_tasks:bool ->
+  include_board:bool ->
+  include_tool_calls:bool ->
+  Yojson.Safe.t
+(** [build_timeline config ~agent_name ~since_hours ~limit
+      ~include_tasks ~include_board ~include_tool_calls] returns a
+    JSON object with two keys:
+
+    - [events] — the truncated, chronologically-sorted event
+      list (most recent [limit] events).
+    - [summary] — cardinality counts ([tasks_completed],
+      [tasks_claimed], [messages_sent], [tool_calls],
+      [turns_completed], [total_events]) plus token/cost
+      rollups ([total_input_tokens], [total_output_tokens],
+      [total_cost_usd]) and [active_duration_minutes].
+
+    The 6 event sources are gathered unconditionally except:
+
+    - [include_tasks = false] -> [task_events] is skipped.
+    - [include_tool_calls = false] -> [tool_call_events] is
+      skipped.
+    - [include_board] is currently unused (reserved for future
+      board-event integration).
+
+    Per-source internal limits are pinned at 200 events
+    ([message_events], [tool_call_events], [keeper_cdal_events],
+    [turn_completed_events]); the [~limit] argument applies to
+    the merged sorted list. *)
+
+(** {1 Dispatch + schemas} *)
+
+val dispatch :
+  context ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  tool_result option
+(** [dispatch ctx ~name ~args] routes by tool name.  Returns
+    [None] when [name] is not [masc_agent_timeline] — caller
+    treats that as "not my tool". *)
+
+val schemas : Types.tool_schema list
+(** [schemas] is the [Types.tool_schema list] registered with the
+    MCP catalog (consumed by {!Config.visible_tool_schemas}).
+    Used by the side-effect block at module load via
+    {!Tool_spec.register}. *)


### PR DESCRIPTION
## Summary

Pin the public surface of `lib/tool_agent_timeline.ml` — the per-agent activity timeline module backing both the `masc_agent_timeline` MCP tool and the `/api/dashboard/agent/<name>/timeline` HTTP route.

## Surface (2 types + 3 entries)

- `tool_result = bool * string`
- `context` — concrete record (`config: Coord.config; agent_name: string`); callers construct via `{ Tool_agent_timeline.config; agent_name }` at the dispatch site.
- `build_timeline` — 6-event-source aggregator with cutoff filter + chronological sort + limit truncation.
- `dispatch` — router for the `masc_agent_timeline` tool.
- `schemas : Types.tool_schema list` — MCP catalog registration.

## Hidden (11 helpers + 1 type — 4:1 hide ratio on 648 lines)

`parse_iso_timestamp`, `timeline_event` type + `event_to_json`, the 6 source extractors (`agent_events`, `task_events`, `message_events`, `tool_call_events`, `keeper_cdal_events`, `turn_completed_events`), and `handle_agent_timeline` (dispatch handler that reaches `build_timeline`).

## Contract pinning

- **`build_timeline.include_board` documented as currently unused (reserved for future board-event integration)** — drift to a "remove unused param" PR would silently break the caller's signature contract.
- **Per-source internal limits pinned at 200 events** for `message_events`, `tool_call_events`, `keeper_cdal_events`, `turn_completed_events`. The caller's `~limit` parameter applies to the **merged sorted list**, NOT per source — drift would silently expand or shrink memory budget.

## Surface confirmed via caller grep

- `lib/mcp_server_eio_execute.ml` — `dispatch` + context field construction
- `lib/keeper/keeper_tag_dispatch.ml` — `dispatch` + context field construction
- `lib/server/server_dashboard_http_agent_api.ml` — `build_timeline`
- `lib/config.ml` — `schemas`

## Test plan

- [x] `dune build --root . lib/` green on first try
- [ ] CI: dune build + ratchet (`lib_other_mli_missing` decrement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)