### PR TITLE
chore(tool-code): add tool_code.mli — code navigation security surface (cycle 172)

### DIFF
--- a/lib/tool_code.mli
+++ b/lib/tool_code.mli
@@ -1,0 +1,130 @@
+(** Tool_code — Code navigation MCP tools (search, symbols, read).
+
+    Phase-1 surface: ripgrep-backed search + ctags-style symbol
+    listing + size-and-binary-gated file reads.  Used by
+    [masc_code_search] / [masc_code_symbols] / [masc_code_read].
+
+    Security model (pinned at module level):
+
+    - {b Git root validation}: every operation must resolve a
+      canonical path inside the repository's git root via
+      {!validate_path}.
+    - {b File size limit}: reads reject files above
+      {!max_file_size} (= 500 KiB).
+    - {b Binary detection}: reads reject files whose extension
+      matches {!is_binary_file} (.so, .wasm, .jpg, etc.).
+    - {b Path traversal prevention}: [normalize_path] +
+      [Unix.realpath] block .. traversal AND symlinks pointing
+      outside the agent's playground bundle.
+
+    Internal: 5 helpers stay private — \[binary_extensions]
+    (the canonical block list backing {!is_binary_file}),
+    \[handle_code_search] / \[handle_code_symbols] /
+    \[handle_code_read] (dispatch handlers reachable only via
+    {!dispatch}), and the side-effect [Tool_spec.register]
+    block at module load. *)
+
+(** {1 Tool result + context} *)
+
+type context = {
+  config : Coord.config;
+  agent_name : string;
+}
+(** Per-call context.  Concrete record because callers
+    construct it field-by-field at the dispatch site. *)
+
+type tool_result = bool * string
+
+(** {1 Security primitives} *)
+
+val is_binary_file : string -> bool
+(** [is_binary_file path] is [true] iff [path] ends with one of
+    the pinned binary extensions (.so, .a, .lib, .dll, .dylib,
+    .wasm, .o, .obj, .jpg, .jpeg, .png, .gif, .bmp, .ico, .webp,
+    .mp3, .mp4, .avi, .mov, .wav, .flac, .zip, .tar, .gz, .bz2,
+    .xz, .7z, .pdf, .doc, .docx, .xls, .xlsx, .ppt, .pptx).  Drift
+    in this list = silent regression in the binary block — pinned
+    in the implementation, mirror in this docstring. *)
+
+val max_file_size : int
+(** [max_file_size = 500 * 1024] (= 500 KiB).  Read operations
+    reject files above this cap.  Pinned literal — drift would
+    silently change tooling memory behaviour and break the
+    "tooling is bounded" contract for keepers. *)
+
+(** {1 Path normalization + validation} *)
+
+val normalize_path : string -> string
+(** [normalize_path path] resolves [.] / [..] segments via
+    string-level traversal.  Does NOT follow symlinks — for
+    symlink-aware containment checks use {!validate_read_path}.
+    Returns an absolute path when [path] starts with [/],
+    otherwise relative. *)
+
+val normalize_agent_relative_path :
+  config:Coord.config ->
+  agent_name:string ->
+  string ->
+  string
+(** [normalize_agent_relative_path ~config ~agent_name raw_path]
+    translates between three path forms:
+
+    + Container-side absolute paths
+      ([/home/keeper/playground/<keeper>/<rest>]) are rewritten
+      to host-side ([<base_path>/.masc/playground/docker/<keeper>/<rest>]).
+    + Bundle-relative paths ([.masc/playground/.../<rest>]) are
+      stripped to [<rest>] when redundant.
+    + Doubled-prefix paths (host bundle absolute + own_bundle_rel
+      again) are collapsed.
+    + Playground-lane relative paths ([mind/...] / [repos/...])
+      are anchored under the agent's own bundle.
+
+    Pure transformation — does NOT validate accessibility. *)
+
+val validate_path :
+  Coord.config -> string -> (string, Masc_error.t) result
+(** [validate_path config path] returns the canonical path on
+    success, or an error variant (typically [IoError]) on:
+
+    - null bytes in [path]
+    - not in a git repository
+    - path traversal outside the git root
+
+    Symlinks are realpath-resolved when they exist; missing
+    targets fall back to string-level [normalize_path]
+    comparison.  Used by both {!validate_read_path} (read gate)
+    and the writable-sandbox checks in [Tool_code_write]. *)
+
+val validate_read_path :
+  agent_name:string ->
+  Coord.config ->
+  string ->
+  (string, Masc_error.t) result
+(** [validate_read_path ~agent_name config path] is the
+    read-side gate: applies {!normalize_agent_relative_path}
+    then {!validate_path}, then realpath-resolves the canonical
+    target and re-checks playground containment so a symlink
+    pointing into another agent's bundle is rejected.
+
+    The realpath check is mandatory and fail-closed — drift
+    would re-open the symlink-bypass that GLM-5.1 caught on
+    PR #6664 (issue #2).  Targets outside the playground tree
+    pass through (shared codebase reads are allowed). *)
+
+(** {1 Dispatch + schemas} *)
+
+val dispatch :
+  context ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  tool_result option
+(** [dispatch ctx ~name ~args] routes by tool name to the
+    private handlers ([handle_code_search],
+    [handle_code_symbols], [handle_code_read]).  Returns [None]
+    when [name] is not a code-tool — caller treats that as
+    "not my tool". *)
+
+val schemas : Types.tool_schema list
+(** [schemas] is the [Types.tool_schema list] consumed by
+    [Tools.schemas] / [Config.visible_tool_schemas].  Used by
+    the side-effect [Tool_spec.register] block at module load. *)


### PR DESCRIPTION
## Summary

Pin the public surface of `lib/tool_code.ml` — the code-navigation MCP tool module (`masc_code_search`, `masc_code_symbols`, `masc_code_read`) including the **security-critical** path validation pipeline.

## Surface (10 entries)

- `type context` — concrete record (`config`, `agent_name`)
- `type tool_result = bool * string`
- `is_binary_file` — binary extension block list checker
- `max_file_size` — `500 * 1024` pinned literal
- `normalize_path` — string-level `.` / `..` resolver, **does NOT follow symlinks**
- `normalize_agent_relative_path` — 4-form path translator (container-side, bundle-relative, doubled-prefix, playground-lane)
- `validate_path` — git-root containment with realpath fallback (returns `(string, Masc_error.t) result`)
- `validate_read_path` — read gate with **mandatory realpath** + playground bypass guard
- `dispatch`
- `schemas`

## Hidden (5 internals)

`binary_extensions` (31-extension data table), `handle_code_search`, `handle_code_symbols`, `handle_code_read` (dispatch-routed only), and the side-effect `Tool_spec.register` block at module load.

## Contract pinning (security-critical)

- **`max_file_size` pinned literal** — drift breaks the "tooling is bounded" contract for keepers.
- **`binary_extensions` data table mirrored in `is_binary_file` docstring** — drift = silent regression in binary block.
- **`validate_read_path` mandatory realpath check** pinned with PR #6664 issue #2 reference (GLM-5.1 review caught a symlink bypass; live test case initially reproduced the bypass) — drift would re-open the bypass.
- **`normalize_path` explicit "does NOT follow symlinks"** pinning — symlink containment is `validate_read_path`'s responsibility, not this string-level helper.
- **`normalize_agent_relative_path` 4-form transformation** documented at the contract seam — Docker container paths translate to host paths, doubled prefixes collapse, playground-lane relative paths anchor under the agent's bundle.

## Surface confirmed via caller grep

- `lib/tool_code_write.ml` — `validate_path`, `normalize_agent_relative_path`
- `lib/mcp_server_eio_execute.ml`, `lib/keeper/keeper_tag_dispatch.ml` — `dispatch` + context
- `lib/config.ml`, `lib/tools.ml` — `schemas`

## Test plan

- [x] `dune build --root . lib/` green on first try (Masc_error.t result type inferred correctly)
- [ ] CI: dune build + ratchet (`lib_other_mli_missing` decrement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)