### PR TITLE
chore(tool): add tool_local_runtime_verify.mli — runtime contract verify (cycle 176)

### DIFF
--- a/lib/tool_local_runtime_verify.mli
+++ b/lib/tool_local_runtime_verify.mli
@@ -1,0 +1,85 @@
+(** Tool_local_runtime_verify — Runtime contract verification for
+    local LLM runtime pools (llama.cpp / Ollama).
+
+    Exposes 3 verification entries.  The .ml does
+    [include Tool_local_runtime_http] for internal access to HTTP
+    helpers ([trim_to_option], discovery resolution, etc.); those
+    helpers are intentionally hidden from external callers via
+    this .mli — verify is the contract layer, http is the
+    implementation layer.
+
+    Internal: ~25 helpers stay private —
+    \[runtime_snapshots_for_pool], \[safe_discovery_endpoints],
+    \[discovery_endpoints_for_pool], \[active_slots_of_json],
+    \[slot_count_of_json], the 4 [endpoint_*] field projectors,
+    \[first_endpoint_url], \[error_message_of_http_error],
+    \[probe_chat_completion_compatible], \[chat_contract_probe_body],
+    \[chat_contract_reachable], \[chat_contract_status],
+    \[runtime_verify_json_from_discovery] /
+    \[runtime_verify_json_legacy] (the two backends behind
+    {!runtime_verify_json}).  Plus the 3 [Oas_types] alias
+    + the [include Tool_local_runtime_http] cascade.  All
+    consumed only inside {!runtime_verify_json}'s pipeline. *)
+
+val provider_health_reachable :
+  status:int option -> body:string option -> bool
+(** [provider_health_reachable ~status ~body] is [true] iff
+    [status = Some 200].  [body] is currently ignored — the
+    health endpoint is a status-code-only check.  Drift to
+    body-content validation would change "what counts as
+    reachable" and need a coordinated update with the
+    health-check probe. *)
+
+val classify_runtime_blocker :
+  provider_reachable:bool ->
+  slot_reachable:bool ->
+  chat_contract_status:string ->
+  expected_model:string option ->
+  actual_model_id:string option ->
+  expected_slots:int option ->
+  actual_slots_total:int ->
+  expected_ctx:int option ->
+  actual_ctx:int option ->
+  chat_completion_compatible:bool ->
+  string option * string option
+(** [classify_runtime_blocker ~provider_reachable ~slot_reachable
+      ~chat_contract_status ~expected_model ~actual_model_id
+      ~expected_slots ~actual_slots_total ~expected_ctx
+      ~actual_ctx ~chat_completion_compatible] grades a runtime
+    snapshot through 6 cascading checks.  Returns
+    [(blocker_code, message)]:
+
+    + [(Some "provider_unreachable", _)] when provider or slots
+      endpoint failed.
+    + [(Some "provider_protocol_incompatible", _)] when chat
+      completions probe failed.
+    + [(Some "provider_model_mismatch", _)] when expected_model
+      is set but actual differs (or actual is missing).
+    + [(Some "slot_count_insufficient", _)] when actual slots
+      below expected.
+    + [(Some "ctx_mismatch", _)] when expected_ctx differs from
+      actual.
+    + [(Some "chat_contract_incompatible", _)] when contract
+      status is ["rejected"].
+    + [(None, None)] when all checks pass.
+
+    Pinned blocker codes — operator dashboards parse these
+    strings.  Drift breaks tooltip + alerting downstream. *)
+
+val runtime_verify_json :
+  ?runtime_pool:string ->
+  ?expected_slots:int ->
+  ?expected_ctx:int ->
+  ?expected_model:string ->
+  unit ->
+  Yojson.Safe.t
+(** [runtime_verify_json ?runtime_pool ?expected_slots
+      ?expected_ctx ?expected_model ()] runs the full runtime
+    verification pipeline against either the discovery cache
+    (when an endpoint set is resolvable for [?runtime_pool]) or
+    the legacy single-host probe (fallback).
+
+    Returns a JSON object with health/slot/ctx/model
+    diagnostics + the {!classify_runtime_blocker} verdict.  [?runtime_pool]
+    selects the pool by name; default behaviour is "use the
+    default pool" via {!Local_runtime_pool.default_pool_label}. *)


### PR DESCRIPTION
## Summary

Pin the public surface of `lib/tool_local_runtime_verify.ml` — the runtime contract verification module that grades local LLM runtime pools (llama.cpp / Ollama) through 6 cascading checks and returns operator-readable blocker codes.

## Surface (3 entries — extreme hide ratio for 614 lines)

- `provider_health_reachable : status:int option -> body:string option -> bool` — status-code-only check
- `classify_runtime_blocker` — 6-stage cascade returning `(string option, string option)` (blocker_code, message)
- `runtime_verify_json` — full verification pipeline (discovery-first with legacy fallback)

## Hidden (~25 helpers + `include Tool_local_runtime_http` cascade)

The `.ml` does `include Tool_local_runtime_http` to access HTTP helpers internally. The .mli **shadows the cascade** so external callers cannot reach those helpers via `Tool_local_runtime_verify.X` — verify is the contract layer, http is the implementation layer.

Internal helpers: `runtime_snapshots_for_pool`, `safe_discovery_endpoints`, `discovery_endpoints_for_pool`, `active_slots_of_json`, `slot_count_of_json`, 4 `endpoint_*` field projectors, `first_endpoint_url`, `error_message_of_http_error`, `probe_chat_completion_compatible`, `chat_contract_probe_body`, `chat_contract_reachable`, `chat_contract_status`, `runtime_verify_json_from_discovery`, `runtime_verify_json_legacy`.

## Contract pinning

- **`provider_health_reachable` status-code-only**: drift to body-content validation would change "what counts as reachable" without coordinated probe update.
- **`classify_runtime_blocker` 6 pinned blocker codes** (`"provider_unreachable"`, `"provider_protocol_incompatible"`, `"provider_model_mismatch"`, `"slot_count_insufficient"`, `"ctx_mismatch"`, `"chat_contract_incompatible"`) — operator dashboards parse these literals for tooltip + alerting. Drift breaks downstream UI.
- **Include cascade contract**: verify is contract layer, http is implementation layer; verify.mli shadows http.ml's bindings so external callers cannot reach http helpers via verify.

## Surface confirmed via caller grep

3 distinct dotted accesses (matching `Tool_local_runtime_verify.classify_runtime_blocker / .provider_health_reachable / .runtime_verify_json`).

## Test plan

- [x] `dune build --root . lib/` green on first try (narrow .mli correctly shadows include cascade)
- [ ] CI: dune build + ratchet (`lib_other_mli_missing` decrement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)