### PR TITLE
chore(tool): add tool_coord.mli — coord MCP dispatcher surface (cycle 178)

### DIFF
--- a/lib/tool_coord.mli
+++ b/lib/tool_coord.mli
@@ -1,0 +1,93 @@
+(** Tool_coord — Coord management MCP tools (status / reset /
+    init / workflow_guide / check / assertion).
+
+    Note: [join] / [leave] / [set_room] / [who] require state +
+    registry and remain in [mcp_server_eio.ml] — those tools are
+    NOT routed through this module's {!dispatch}.
+
+    Type re-exports preserve identity with the source modules:
+    - {!tool_result} = {!Coord_types.tool_result}
+    - {!context} = {!Coord_types.context}
+    - {!assertion_kind} = {!Coord_assertions.assertion_kind}
+
+    Callers can interleave these types freely with the source
+    modules' types.
+
+    Internal: ~50+ helpers stay private — text-cache primitives
+    (\[text_cache] type, \[make_text_cache], \[_status_cache],
+    \[cache_ttl_seconds], \[status_cache_ttl_s],
+    \[invalidate_status_cache], \[cached_text_by_key]),
+    \[take_items], \[effective_cluster_name],
+    \[lifecycle_tools] / \[is_lifecycle_tool],
+    \[unique_strings], \[credential_state],
+    \[status_worktree_active] / \[safe_resolve_agent_name] /
+    \[safe_current_task] / \[safe_get_agents] /
+    \[safe_is_zombie_agent], the deliverable-conflict scanners
+    (\[todo_task_has_completed_deliverable_conflict],
+    \[todo_completed_deliverable_conflicts]),
+    \[resolve_current_binding], \[planning_context_state],
+    \[coordination_fsm_attention_items], \[assertion_kind_to_string],
+    \[all_assertion_kinds], plus per-tool handlers
+    ([handle_status], [handle_reset], [handle_init],
+    [handle_workflow_guide], [handle_check], [handle_assertion]).
+    All consumed only inside {!dispatch}'s pipeline. *)
+
+(** {1 Tool result + context} *)
+
+type tool_result = Coord_types.tool_result
+(** Alias for [bool * string] — re-export of
+    {!Coord_types.tool_result}. *)
+
+type context = Coord_types.context = {
+  config : Coord.config;
+  agent_name : string;
+}
+(** Per-call context.  Concrete record — callers construct via
+    [{ Tool_coord.config; agent_name }] at the dispatch site. *)
+
+(** {1 Assertion kinds} *)
+
+(** Coordinator-state assertion targets used by the
+    [masc_assert] tool.  Re-export of
+    {!Coord_assertions.assertion_kind} — type identity
+    preserved.  Adding a constructor requires update in
+    {!Coord_assertions} (the SSOT) and propagates here
+    automatically. *)
+type assertion_kind = Coord_assertions.assertion_kind =
+  | Room_set
+  | Joined
+  | Task_claimed
+  | Current_task_set
+  | Worktree_active
+
+val valid_assertion_strings : string list
+(** [valid_assertion_strings] is the canonical list of
+    assertion kind labels (one per constructor).  Used by error
+    messages + the [masc_assert] schema [enum] field — adding a
+    constructor automatically updates this list. *)
+
+val assertion_kind_of_string_lenient :
+  string -> assertion_kind option
+(** [assertion_kind_of_string_lenient s] parses a permissive
+    label form (case-insensitive, allows variants like
+    ["room_set"] / ["roomSet"] / ["room"]).  Returns [None] on
+    unknown.  Lenient parsing is intentional for human-typed
+    governance commands; drift to strict matching would break
+    operator UX. *)
+
+(** {1 Dispatch} *)
+
+val dispatch :
+  context ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  tool_result option
+(** [dispatch ctx ~name ~args] routes [name] to the appropriate
+    private handler ([handle_status], [handle_reset],
+    [handle_init], [handle_workflow_guide], [handle_check],
+    [handle_assertion]).  Returns [None] when [name] is not a
+    coord tool — caller treats as "not my tool".
+
+    Status results are cached for ~2 seconds via the internal
+    text-cache to absorb repeated dashboard polls; cache
+    invalidates on coord state mutations. *)


### PR DESCRIPTION
## Summary

Pin the public surface of `lib/tool_coord.ml` — the coord-management MCP tool dispatcher (status / reset / init / workflow_guide / check / assert).

**Important**: `join` / `leave` / `set_room` / `who` need state + registry and remain in `mcp_server_eio.ml` — those tools are NOT routed through this module's `dispatch`.

## Surface (3 types + 3 entries)

- `tool_result` — alias to `Coord_types.tool_result`
- `context` — re-export of `Coord_types.context` (concrete record for `{ Tool_coord.config; agent_name }` destructure at call sites)
- `assertion_kind` — re-export of `Coord_assertions.assertion_kind` with 5 constructors (`Room_set`, `Joined`, `Task_claimed`, `Current_task_set`, `Worktree_active`)
- `valid_assertion_strings`
- `assertion_kind_of_string_lenient`
- `dispatch`

## Hidden (~50+ helpers + 7 internal types)

Status caching primitives (`text_cache`, `make_text_cache`, `_status_cache`, `cache_ttl_seconds`, `status_cache_ttl_s`, `invalidate_status_cache`, `cached_text_by_key`), 6 per-tool handlers (`handle_status`, `handle_reset`, `handle_init`, `handle_workflow_guide`, `handle_check`, `handle_assertion`), and ~30 internal helpers (`take_items`, `effective_cluster_name`, lifecycle classifiers, credential probes, deliverable-conflict scanners, `resolve_current_binding`, `planning_context_state`, `coordination_fsm_attention_items`, etc.).

## Contract pinning

- **Module docstring pins layered architecture**: `join`/`leave`/`set_room`/`who` are NOT routed here — they need state + registry and stay in `mcp_server_eio.ml`. Drift to "include join here" would break the layer separation.
- **Type re-exports use identity preservation** (`= ...` form) — callers pass values between `Tool_coord.X` and `Coord_types.X` / `Coord_assertions.X` freely.
- **`assertion_kind_of_string_lenient` permissive parsing pinned** (case-insensitive + variants like `room_set`/`roomSet`/`room`) — drift to strict matching would break human-typed governance commands.
- **dispatch ~2 second status cache TTL pinned** in docstring — drift would change dashboard polling cost.

## Surface confirmed via caller grep

6 dotted accesses across `lib/mcp_server_eio_execute.ml` (`Mod_room` route), `lib/keeper/keeper_tag_dispatch.ml`, `lib/server/server_bootstrap_loops.ml` + tests.

## Test plan

- [x] `dune build --root . lib/` green on first try
- [ ] CI: dune build + ratchet (`lib_other_mli_missing` decrement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)