### PR TITLE
chore(config): add config_doctor.mli — config health diagnostic surface (cycle 179)

### DIFF
--- a/lib/config_doctor.mli
+++ b/lib/config_doctor.mli
@@ -1,0 +1,181 @@
+(** Config_doctor — Configuration health diagnostic for the MASC
+    runtime.
+
+    Inspects the resolved config root + persona overrides + cascade
+    catalog + sandbox preflight and produces structured {!t}
+    reports rendered as JSON ({!to_yojson}) or human text
+    ({!render_text}) and graded by {!exit_code} for CLI use.
+
+    Sister diagnostic to {!Auth_doctor} (cycle 174) — same status
+    grade + exit_code mapping (Ok=0, Warn|Error=1).
+
+    Internal: ~30+ helpers + 4 internal types stay private —
+    \[trim_opt] (re-export of {!Env_config_core.trim_opt}),
+    \[init_state_to_string] (status-side string projection of
+    \[init_state]), \[dedupe_keep_order],
+    \[canonicalize_path], \[runtime_data_root],
+    \[repo_config_seed_path] (path resolvers), \[option_field],
+    \[diagnose_cascade_catalog] /
+    \[cascade_catalog_next_actions] (cascade catalog scanner),
+    \[normalize_tool_preset_opt] / \[non_empty_trimmed_opt]
+    (string normalization), \[persona_tool_preset_conflict_*]
+    helpers (yojson encoder + warning/action message builders),
+    \[discover_persona_tool_preset_conflicts],
+    \[current_inputs] (Eio-aware inputs builder), the [Live_catalog_*]
+    enum used in {!analyze_live}'s status grading, and pure
+    \[analyze] (the lower-level entry behind {!analyze_with} +
+    {!analyze_live}).  All consumed only inside the 5 public
+    entries. *)
+
+(** {1 Init state} *)
+
+type init_state =
+  | Initialized
+  | Missing_init
+  | Invalid_env
+  | Shadowed
+(** Whether the resolved base path is initialized as a MASC
+    runtime directory. *)
+
+(** {1 Status grade} *)
+
+type status =
+  | Ok
+  | Warn
+  | Error
+
+val status_to_string : status -> string
+(** [status_to_string s] returns the canonical lowercase label:
+    ["ok"] / ["warn"] / ["error"].  Pinned literal — drift would
+    break tooling that parses the config-doctor JSON. *)
+
+(** {1 Inputs + report records} *)
+
+type inputs = {
+  cwd : string;
+  executable_name : string;
+  base_path_input : string;
+  env_masc_base_path : string option;
+  env_config_dir : string option;
+  env_personas_dir : string option;
+  resolution_source : string option;
+  repo_config_fallback_enabled : bool;
+}
+(** Inputs to {!analyze_with}.  Concrete record because callers
+    construct via [{ Config_doctor.cwd; ... }] at the dispatch
+    site (notably tests). *)
+
+type t = {
+  status : status;
+  init_state : init_state;
+  base_path : string;
+  active_config_root : string;
+  active_personas_root : string;
+  runtime_data_root : string;
+  config_root_source : string;
+  local_base_config_root : string;
+  local_base_config_initialized : bool;
+  explicit_config_dir : string option;
+  explicit_personas_dir : string option;
+  repo_config_seed_path : string option;
+  repo_fallback_enabled : bool;
+  keeper_runtime_toml_present : bool;
+  warnings : string list;
+  next_actions : string list;
+  persona_tool_preset_conflicts : persona_tool_preset_conflict list;
+  catalog_validation : Yojson.Safe.t option;
+  sandbox_preflight : Yojson.Safe.t option;
+}
+(** Aggregate report.  Concrete record — callers (CLI rendering,
+    tests, dashboard JSON) destructure fields directly.
+    19 fields; new fields go through this contract. *)
+
+and persona_tool_preset_conflict = {
+  keeper_name : string;
+  persona_name : string;
+  toml_path : string;
+  persona_path : string;
+  toml_tool_preset : string;
+  persona_tool_preset : string;
+}
+(** Per-conflict snapshot when keeper config and persona file
+    disagree on the [tool_preset] selector. *)
+
+(** {1 Catalog issue re-exports} *)
+
+type catalog_issue_severity = Cascade_catalog_validator.severity =
+  | Catalog_warn
+  | Catalog_error
+(** Severity grade for cascade catalog issues.  Re-exported with
+    type identity preserved. *)
+
+type catalog_issue = Cascade_catalog_validator.issue = {
+  profile : string option;
+  severity : catalog_issue_severity;
+  message : string;
+}
+(** Cascade catalog validation issue.  Re-exported with type
+    identity preserved. *)
+
+(** {1 Path resolution} *)
+
+val local_base_config_root : base_path:string -> string
+(** [local_base_config_root ~base_path] returns the canonical
+    location of the base config root under [base_path].
+    Pinned at the contract seam — tests + dashboards both
+    derive paths from this. *)
+
+(** {1 Analysis (pure + live)} *)
+
+val analyze_with : inputs -> t
+(** [analyze_with inputs] runs the pure analysis stage
+    (no Eio resources required).  Used by tests + offline
+    diagnostic flows.  Subset of {!analyze_live} — does not
+    inspect the live cascade catalog or sandbox preflight. *)
+
+val analyze_live :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  fs:Eio.Fs.dir_ty Eio.Path.t ->
+  proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t ->
+  base_path_input:string ->
+  default_base_path:string ->
+  unit ->
+  t
+(** [analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
+      ~default_base_path ()] runs the full analysis pipeline:
+
+    + [analyze_with (current_inputs ...)] for the pure stage.
+    + Initialise [Process_eio] with the resolved base path.
+    + Run [Keeper_sandbox_runtime.docker_preflight] (10 s timeout).
+    + Live cascade catalog validation (when reachable).
+    + Combine into a final {!status} via the cascading severity
+      ladder (Invalid_env / Missing_init -> Error; serving stale
+      catalog -> Error; partial catalog -> Warn; etc.).
+
+    Side-effecting (Process_eio init, Docker probe, file reads)
+    but does not mutate persistent state. *)
+
+(** {1 Rendering} *)
+
+val to_yojson : t -> Yojson.Safe.t
+(** [to_yojson report] renders the report as a JSON object for
+    tool output and dashboard consumption. *)
+
+val render_text : t -> string
+(** [render_text report] returns a human-readable multi-line
+    text rendering with section headers and bullet lists.  Used
+    by the CLI [config doctor] subcommand. *)
+
+val exit_code : t -> int
+(** [exit_code report] returns the suggested process exit code:
+
+    - {!Ok} -> [0]
+    - {!Warn} -> [1] (warnings fail CI — same contract as
+      {!Auth_doctor.exit_code})
+    - {!Error} -> [1]
+
+    Pinned at the contract seam: only {!Ok} status returns 0.
+    Drift to permissive Warn=0 would silently swallow config
+    misconfiguration alerts in CI gates. *)


### PR DESCRIPTION
## Summary

Pin the public surface of `lib/config_doctor.ml` — the configuration health diagnostic that inspects the resolved config root + persona overrides + cascade catalog + sandbox preflight.

Sister diagnostic to `Auth_doctor` (cycle 174) — **same status grade + exit_code mapping** (Ok=0, Warn|Error=1).

## Surface (5 types + 6 entries)

- `init_state` — `Initialized | Missing_init | Invalid_env | Shadowed`
- `status` — `Ok | Warn | Error`
- `inputs` — 8 fields, parameter to `analyze_with`
- `t` + `persona_tool_preset_conflict` — mutually recursive records (19 + 6 fields)
- `catalog_issue_severity` / `catalog_issue` — re-exports of `Cascade_catalog_validator.severity` / `Cascade_catalog_validator.issue` with type identity preserved
- `status_to_string`, `local_base_config_root`
- `analyze_with` (pure stage) / `analyze_live` (full pipeline with Eio resources)
- `to_yojson`, `render_text`, `exit_code`

## Hidden (~30+ helpers + 1 internal type)

`trim_opt`, `init_state_to_string`, `dedupe_keep_order`, `canonicalize_path`, `runtime_data_root`, `repo_config_seed_path`, `option_field`, `diagnose_cascade_catalog`, `cascade_catalog_next_actions`, `normalize_tool_preset_opt`, `non_empty_trimmed_opt`, persona_tool_preset_conflict yojson encoder + warning/action message builders, `discover_persona_tool_preset_conflicts`, `current_inputs`, `Live_catalog_*` enum (internal status grading variant), pure `analyze` (lower-level entry).

## Contract pinning

- **`exit_code` mapping pinned** (Ok=0, Warn|Error=1) with explicit reference to `Auth_doctor.exit_code` contract — **same CI gate semantics across both doctors**. Drift would diverge config vs auth gate behaviour.
- **`analyze_live` concrete Eio types** (`[\`Generic | \`Unix] Eio.Net.ty`, `float Eio.Time.clock_ty`, `Eio.Fs.dir_ty Eio.Path.t`, `Eio_unix.Process.mgr_ty`) pinned via **build feedback** — initial `_` polymorphic types failed type check; compiler reported actual types.
- **`analyze_with` (pure) vs `analyze_live` (full pipeline)** separation pinned in docstrings — pure stage usable in tests + offline diagnostics, live stage adds cascade catalog + Docker preflight.
- **`catalog_issue_severity` / `catalog_issue` use type identity preservation** — callers can pass values through the `Cascade_catalog_validator` boundary freely.

## Surface confirmed via caller grep

14 dotted accesses across `test/test_config_doctor.ml`, `test/test_cascade_catalog_runtime.ml`, and CLI usage.

## Test plan

- [x] `dune build --root . lib/` green after Eio type concretization
- [x] Verified concrete Eio types match `.ml` definition
- [ ] CI: dune build + ratchet (`lib_other_mli_missing` decrement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)