### PR TITLE
feat(resilience): Tier A11 — Degradation level GADT + Speculative scaffolding (Cycle 27)

### DIFF
--- a/lib/resilience/degradation.ml
+++ b/lib/resilience/degradation.ml
@@ -1,0 +1,110 @@
+(* Degradation — Cycle 27 / Tier A11 (degradation half).
+   See degradation.mli for design rationale. *)
+
+(* ── Phantom witnesses ────────────────────────────────────────── *)
+
+type full_capability = |
+type reduced_capability = |
+type skeleton_capability = |
+type fallback_capability = |
+
+(* ── Level GADT ───────────────────────────────────────────────── *)
+
+type _ level =
+  | L1 : full_capability level
+  | L2 : reduced_capability level
+  | L3 : skeleton_capability level
+  | L4 : fallback_capability level
+
+type any_level = Any_level : 'a level -> any_level
+
+(* ── Tag mirror ───────────────────────────────────────────────── *)
+
+type level_tag = Tag_l1 | Tag_l2 | Tag_l3 | Tag_l4
+
+let all_level_tags = [ Tag_l1; Tag_l2; Tag_l3; Tag_l4 ]
+
+let level_tag_to_string = function
+  | Tag_l1 -> "L1"
+  | Tag_l2 -> "L2"
+  | Tag_l3 -> "L3"
+  | Tag_l4 -> "L4"
+
+let level_to_tag : type a. a level -> level_tag = function
+  | L1 -> Tag_l1
+  | L2 -> Tag_l2
+  | L3 -> Tag_l3
+  | L4 -> Tag_l4
+
+let any_level_to_tag (Any_level l) = level_to_tag l
+
+let level_to_string : type a. a level -> string =
+ fun l -> level_tag_to_string (level_to_tag l)
+
+(* ── Numeric mapping ──────────────────────────────────────────── *)
+
+let to_int : type a. a level -> int = function
+  | L1 -> 1
+  | L2 -> 2
+  | L3 -> 3
+  | L4 -> 4
+
+let any_to_int (Any_level l) = to_int l
+
+let of_int_opt = function
+  | 1 -> Some (Any_level L1)
+  | 2 -> Some (Any_level L2)
+  | 3 -> Some (Any_level L3)
+  | 4 -> Some (Any_level L4)
+  | _ -> None
+
+(* ── Authorization (stub) ─────────────────────────────────────── *)
+
+let authorize_transition ~from:_ ~to_:_ = Ok ()
+
+(* ── Strategy adjustment ──────────────────────────────────────── *)
+
+let error_mode_kind_label (mode : Recovery.error_mode) : string =
+  match mode with
+  | Recovery.TransientError _ -> "Transient"
+  | Recovery.PermanentError _ -> "Permanent"
+  | Recovery.ResourceExhausted _ -> "ResourceExhausted"
+  | Recovery.AmbiguityError _ -> "Ambiguity"
+  | Recovery.ConsensusError _ -> "Consensus"
+  | Recovery.DegradationRequired _ -> "DegradationRequired"
+
+let apply_level_to_strategy : type a.
+    a level ->
+    Recovery.error_mode ->
+    [ `Retry | `Fallback | `Handoff | `Abort ] Recovery.strategy =
+ fun lvl mode ->
+  match lvl with
+  | L1 -> Recovery.default_strategy mode
+  | L2 -> (
+      (* Reduced capability: a Retry that would otherwise drive
+         the same failing path becomes a Fallback substitution. *)
+      match Recovery.default_strategy mode with
+      | Recovery.Retry _ ->
+          Recovery.Fallback
+            { fallback_value = "<degraded:L2>"; degrade_confidence_by = 0.3 }
+      | other -> other)
+  | L3 ->
+      Recovery.Handoff
+        {
+          operator_message =
+            Printf.sprintf
+              "Degradation L3 (skeleton): tool use disabled. Original \
+               error mode: %s"
+              (error_mode_kind_label mode);
+          preserve_state = true;
+        }
+  | L4 ->
+      Recovery.Abort
+        {
+          reason =
+            Printf.sprintf
+              "Degradation L4 (fallback): canned response only. \
+               Original error mode: %s"
+              (error_mode_kind_label mode);
+          cleanup = (fun () -> ());
+        }

--- a/lib/resilience/degradation.mli
+++ b/lib/resilience/degradation.mli
@@ -1,0 +1,113 @@
+(** Degradation — tiered capability levels for resilience.
+
+    Cycle 27 / Tier A11 (partial — degradation only; speculative
+    in companion module {!Speculative}).
+
+    {1 What this module is}
+
+    A 4-level capability lattice the resilience layer steps through
+    when {!Recovery.default_strategy} is insufficient (escalate)
+    or excessive (de-escalate). The {!level} GADT is phantom-tagged
+    so legitimate transitions are encoded at the type level.
+
+    {1 The level lattice}
+
+    - {!L1}: full capability — all tools, all branches, no caps
+      applied beyond the keeper's normal budget.
+    - {!L2}: reduced — drops creative/external tools (image
+      generation, network fetch); core reasoning + read tools
+      remain.
+    - {!L3}: skeleton — drops all tool use; the agent emits
+      plan-only / schema-only artifacts.
+    - {!L4}: fallback — drops the agent entirely; static
+      pre-canned response.
+
+    Each level carries an empty phantom witness type so the GADT's
+    type parameter narrows specifically per-constructor; the
+    structural mirror {!level_tag} provides a derivable variant
+    for ppx_tla and runtime indexing.
+
+    {1 Numeric mapping}
+
+    The companion stub field [Resilience_outcome.PartialSuccess.degradation_level]
+    carries an [int] in [\[1, 4\]]. {!to_int} and {!of_int_opt} are
+    the canonical bridges; the integer encoding is the lattice
+    ordinal (lower = higher capability).
+
+    {1 Policy lineage (placeholder)}
+
+    {!authorize_transition} returns [Ok ()] unconditionally in
+    this PR; the real OAS [Policy.evaluate_with_lineage] integration
+    lands in a follow-up tier (A11b) without renaming the function.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+(** {1 Phantom witnesses}
+
+    Empty-variant declarations (no inhabitants). Internal use is
+    purely type-level — no value of these types is ever
+    constructed. *)
+
+type full_capability
+type reduced_capability
+type skeleton_capability
+type fallback_capability
+
+(** {1 Level GADT} *)
+
+type _ level =
+  | L1 : full_capability level
+  | L2 : reduced_capability level
+  | L3 : skeleton_capability level
+  | L4 : fallback_capability level
+
+(** Existential capture for storing levels of mixed capability
+    in homogeneous lists or APIs that defer dispatch to runtime. *)
+type any_level = Any_level : 'a level -> any_level
+
+(** {1 Tag mirror} *)
+
+type level_tag = Tag_l1 | Tag_l2 | Tag_l3 | Tag_l4
+
+val all_level_tags : level_tag list
+
+val level_tag_to_string : level_tag -> string
+
+val level_to_tag : 'a level -> level_tag
+
+val any_level_to_tag : any_level -> level_tag
+
+val level_to_string : 'a level -> string
+
+(** {1 Numeric mapping} *)
+
+val to_int : 'a level -> int
+
+val any_to_int : any_level -> int
+
+val of_int_opt : int -> any_level option
+(** [Some] for [1..4], [None] otherwise. *)
+
+(** {1 Authorization (stub)} *)
+
+val authorize_transition :
+  from:any_level -> to_:any_level -> (unit, string) result
+(** Stub: returns [Ok ()] for any pair. Tier A11b wires real
+    OAS Policy lineage. *)
+
+(** {1 Strategy adjustment} *)
+
+val apply_level_to_strategy :
+  'a level ->
+  Recovery.error_mode ->
+  [ `Retry | `Fallback | `Handoff | `Abort ] Recovery.strategy
+(** Given a failure mode and a target level, return a policy-
+    adjusted recovery strategy:
+    - [L1] returns the canonical {!Recovery.default_strategy}.
+    - [L2] downgrades [Retry] to [Fallback]; preserves others.
+    - [L3] forces a [Handoff] regardless of mode.
+    - [L4] forces an [Abort].
+    Higher levels are progressively more conservative — once
+    skeleton or fallback is required, retrying or substituting
+    is no longer appropriate. *)

--- a/lib/resilience/speculative.ml
+++ b/lib/resilience/speculative.ml
@@ -1,0 +1,82 @@
+(* Speculative — Cycle 27 / Tier A11 (sequential simulator).
+   See speculative.mli for design rationale and the Eio deferral. *)
+
+type budget_policy = {
+  time_cap_ms : int;
+  tokens_cap : int option;
+  branches_max : int;
+}
+
+let default_budget =
+  { time_cap_ms = 30_000; tokens_cap = None; branches_max = 4 }
+
+type 'a branch = unit -> ('a, string) result
+
+type 'a selection = {
+  winner_index : int option;
+  attempted : int;
+  errors : string list;
+}
+[@@warning "-69"]
+
+let take_n n xs =
+  let rec aux k = function
+    | [] -> []
+    | _ when k <= 0 -> []
+    | x :: rest -> x :: aux (k - 1) rest
+  in
+  aux (max 0 n) xs
+
+let execute ~(budget : budget_policy) (branches : 'a branch list) :
+    ('a, string) Shared_types.Resilience_outcome.t * 'a selection =
+  let limited = take_n budget.branches_max branches in
+  match limited with
+  | [] ->
+      let outcome =
+        Shared_types.Resilience_outcome.graceful
+          ~reason:"no_branches"
+          ~recovery_strategy:"Speculate"
+          ~confidence:Shared_types.Confidence.zero
+          ()
+      in
+      let selection =
+        { winner_index = None; attempted = 0; errors = [] }
+      in
+      (outcome, selection)
+  | _ ->
+      let rec try_each idx errors_rev = function
+        | [] ->
+            let outcome =
+              Shared_types.Resilience_outcome.graceful
+                ~reason:"all_branches_failed"
+                ~recovery_strategy:"Speculate"
+                ~confidence:Shared_types.Confidence.zero
+                ()
+            in
+            let selection =
+              {
+                winner_index = None;
+                attempted = idx;
+                errors = List.rev errors_rev;
+              }
+            in
+            (outcome, selection)
+        | f :: rest -> (
+            match f () with
+            | Ok value ->
+                let outcome =
+                  Shared_types.Resilience_outcome.full ~value
+                    ~confidence:Shared_types.Confidence.one
+                    ~artifacts:[]
+                in
+                let selection =
+                  {
+                    winner_index = Some idx;
+                    attempted = idx + 1;
+                    errors = List.rev errors_rev;
+                  }
+                in
+                (outcome, selection)
+            | Error e -> try_each (idx + 1) (e :: errors_rev) rest)
+      in
+      try_each 0 [] limited

--- a/lib/resilience/speculative.mli
+++ b/lib/resilience/speculative.mli
@@ -1,0 +1,101 @@
+(** Speculative — branch-execution scaffolding.
+
+    Cycle 27 / Tier A11 (partial — types + sequential simulator;
+    parallel race in companion follow-up A11b).
+
+    {1 What this module is}
+
+    A scaffolding for speculative execution: try several candidate
+    branches, pick the first that succeeds within budget, abort
+    the rest. Lifts the keeper out of strictly-sequential planning
+    when several plausible paths exist (per the
+    [Recovery.AmbiguityError] mode and the design doc's
+    "Speculate" recovery strategy slot).
+
+    {b STUB STATUS (Tier A11 first PR)}: the {!execute} below is
+    a sequential simulator. Real Eio.Switch-based parallel race
+    + abort lands in Tier A11b — that PR adds the [eio] dependency
+    to [lib/resilience/dune] and integrates with the keeper's
+    structured-concurrency entry point. The signatures here are
+    deliberately aligned with the future parallel implementation
+    so the swap is API-compatible.
+
+    {1 Why a sequential simulator first}
+
+    A standalone Eio dependency on [lib/resilience] would expand
+    the build closure for every consumer of [Recovery] /
+    [Confidence]. Keeping A11's first PR Eio-free preserves the
+    file-disjoint property declared in plan §16, and lets type
+    machinery + selection contract land independently of Eio
+    integration concerns.
+
+    @stability Evolving (stub)
+    @since 0.18.10 *)
+
+(** {1 Budget policy}
+
+    Caps applied to a single {!execute} invocation. *)
+
+type budget_policy = {
+  time_cap_ms : int;
+      (** Hard ceiling on wall-clock time per invocation. The
+          sequential simulator does not enforce this; the future
+          parallel implementation will. *)
+  tokens_cap : int option;
+      (** Optional token budget; [None] is unbounded. The simulator
+          does not enforce; informs callers that hold the budget
+          on the keeper side. *)
+  branches_max : int;
+      (** Maximum number of branches to try. {!execute} truncates
+          the branch list to this length before iterating. Set
+          to [0] to short-circuit (returns [GracefulFailure]
+          with empty [errors]). *)
+}
+
+val default_budget : budget_policy
+(** [{ time_cap_ms = 30_000; tokens_cap = None; branches_max = 4 }]. *)
+
+(** {1 Branch}
+
+    A branch is a thunk that produces a value or an error string.
+    The first branch to return [Ok _] wins. *)
+
+type 'a branch = unit -> ('a, string) result
+
+(** {1 Selection diagnostics}
+
+    Always returned alongside the outcome so callers can render
+    which branch won, how many were attempted, and what the
+    failing-branch errors were. *)
+
+type 'a selection = {
+  winner_index : int option;
+      (** [Some i] when branch at index [i] returned [Ok _].
+          [None] when no branch succeeded within budget. *)
+  attempted : int;
+      (** Number of branches actually evaluated (≤
+          [budget.branches_max]). *)
+  errors : string list;
+      (** Errors from non-winning branches in evaluation order. *)
+}
+[@@warning "-69"]
+
+(** {1 Execute}
+
+    Run branches under budget. STUB: sequential, first-success
+    wins. Future tier replaces with Eio.Switch-based race + abort.
+
+    Outcome semantics:
+    - First branch to return [Ok value] →
+      [FullSuccess { value; confidence = full; artifacts = [] }].
+    - All branches fail →
+      [GracefulFailure { fallback = None; reason = "all_branches_failed";
+                          recovery_strategy = "Speculate";
+                          confidence = zero }].
+    - Empty branch list (or [branches_max = 0]) →
+      [GracefulFailure { ... reason = "no_branches"; ... }]. *)
+
+val execute :
+  budget:budget_policy ->
+  'a branch list ->
+  ('a, string) Shared_types.Resilience_outcome.t * 'a selection

--- a/test/resilience/dune
+++ b/test/resilience/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_confidence test_recovery test_keeper_bridge)
+ (names test_confidence test_recovery test_keeper_bridge test_degradation test_speculative)
  (libraries resilience shared_types shared_audit yojson unix))

--- a/test/resilience/test_degradation.ml
+++ b/test/resilience/test_degradation.ml
@@ -1,0 +1,112 @@
+(* Cycle 27 / Tier A11 — Resilience.Degradation tests. *)
+
+module D = Resilience.Degradation
+module R = Resilience.Recovery
+
+(* ─── Tag mirror + numeric mapping ────────────────────────────── *)
+
+let test_all_level_tags () =
+  assert (List.length D.all_level_tags = 4);
+  let strs = List.map D.level_tag_to_string D.all_level_tags in
+  assert (strs = [ "L1"; "L2"; "L3"; "L4" ])
+
+let test_level_to_tag_round_trip () =
+  assert (D.level_to_tag D.L1 = D.Tag_l1);
+  assert (D.level_to_tag D.L2 = D.Tag_l2);
+  assert (D.level_to_tag D.L3 = D.Tag_l3);
+  assert (D.level_to_tag D.L4 = D.Tag_l4)
+
+let test_any_level_to_tag () =
+  assert (D.any_level_to_tag (D.Any_level D.L1) = D.Tag_l1);
+  assert (D.any_level_to_tag (D.Any_level D.L4) = D.Tag_l4)
+
+let test_level_to_string () =
+  assert (D.level_to_string D.L2 = "L2");
+  assert (D.level_to_string D.L3 = "L3")
+
+let test_to_int () =
+  assert (D.to_int D.L1 = 1);
+  assert (D.to_int D.L4 = 4);
+  assert (D.any_to_int (D.Any_level D.L3) = 3)
+
+let test_of_int_opt () =
+  (match D.of_int_opt 2 with
+   | Some (D.Any_level D.L2) -> ()
+   | _ -> assert false);
+  assert (D.of_int_opt 5 = None);
+  assert (D.of_int_opt 0 = None);
+  assert (D.of_int_opt (-1) = None)
+
+(* ─── authorize_transition (stub) ─────────────────────────────── *)
+
+let test_authorize_transition_stub_always_ok () =
+  let res =
+    D.authorize_transition ~from:(D.Any_level D.L1) ~to_:(D.Any_level D.L4)
+  in
+  assert (res = Ok ());
+  let res2 =
+    D.authorize_transition ~from:(D.Any_level D.L4) ~to_:(D.Any_level D.L1)
+  in
+  assert (res2 = Ok ())
+
+(* ─── apply_level_to_strategy ─────────────────────────────────── *)
+
+let transient_mode () = R.transient ~detail:"net" ~max_retries:3 ()
+let permanent_handoff_mode () =
+  R.permanent ~detail:"401" ~fallback:(R.HumanHandoff "rotate key")
+let resource_mode () =
+  R.resource_exhausted ~resource:`Tokens ~consumed:1.0 ~limit:1.0
+
+let test_l1_returns_canonical_for_transient () =
+  match D.apply_level_to_strategy D.L1 (transient_mode ()) with
+  | R.Retry _ -> ()
+  | _ -> assert false
+
+let test_l1_returns_canonical_for_permanent_handoff () =
+  match D.apply_level_to_strategy D.L1 (permanent_handoff_mode ()) with
+  | R.Handoff _ -> ()
+  | _ -> assert false
+
+let test_l2_downgrades_retry_to_fallback () =
+  match D.apply_level_to_strategy D.L2 (transient_mode ()) with
+  | R.Fallback { fallback_value; degrade_confidence_by } ->
+      assert (fallback_value = "<degraded:L2>");
+      assert (Float.abs (degrade_confidence_by -. 0.3) < 1e-9)
+  | _ -> assert false
+
+let test_l2_preserves_handoff_for_permanent () =
+  match D.apply_level_to_strategy D.L2 (permanent_handoff_mode ()) with
+  | R.Handoff _ -> ()
+  | _ -> assert false
+
+let test_l3_forces_handoff_regardless () =
+  (match D.apply_level_to_strategy D.L3 (transient_mode ()) with
+   | R.Handoff _ -> ()
+   | _ -> assert false);
+  match D.apply_level_to_strategy D.L3 (resource_mode ()) with
+  | R.Handoff _ -> ()
+  | _ -> assert false
+
+let test_l4_forces_abort_regardless () =
+  (match D.apply_level_to_strategy D.L4 (transient_mode ()) with
+   | R.Abort _ -> ()
+   | _ -> assert false);
+  match D.apply_level_to_strategy D.L4 (permanent_handoff_mode ()) with
+  | R.Abort _ -> ()
+  | _ -> assert false
+
+let () =
+  test_all_level_tags ();
+  test_level_to_tag_round_trip ();
+  test_any_level_to_tag ();
+  test_level_to_string ();
+  test_to_int ();
+  test_of_int_opt ();
+  test_authorize_transition_stub_always_ok ();
+  test_l1_returns_canonical_for_transient ();
+  test_l1_returns_canonical_for_permanent_handoff ();
+  test_l2_downgrades_retry_to_fallback ();
+  test_l2_preserves_handoff_for_permanent ();
+  test_l3_forces_handoff_regardless ();
+  test_l4_forces_abort_regardless ();
+  print_endline "test_degradation: all assertions passed"

--- a/test/resilience/test_speculative.ml
+++ b/test/resilience/test_speculative.ml
@@ -1,0 +1,106 @@
+(* Cycle 27 / Tier A11 — Resilience.Speculative tests. *)
+
+module S = Resilience.Speculative
+module R_outcome = Shared_types.Resilience_outcome
+
+(* ─── budget_policy ───────────────────────────────────────────── *)
+
+let test_default_budget () =
+  let b = S.default_budget in
+  assert (b.time_cap_ms = 30_000);
+  assert (b.tokens_cap = None);
+  assert (b.branches_max = 4)
+
+(* ─── execute: no-branch / first-success / all-fail / cap ─────── *)
+
+let test_execute_empty_branches () =
+  let _outcome, selection =
+    S.execute ~budget:S.default_budget []
+  in
+  assert (selection.winner_index = None);
+  assert (selection.attempted = 0);
+  assert (selection.errors = [])
+
+let test_execute_first_branch_wins () =
+  let branches : int S.branch list =
+    [ (fun () -> Ok 42); (fun () -> Ok 99) ]
+  in
+  let outcome, selection = S.execute ~budget:S.default_budget branches in
+  assert (selection.winner_index = Some 0);
+  assert (selection.attempted = 1);
+  assert (selection.errors = []);
+  match R_outcome.value_opt outcome with
+  | Some 42 -> ()
+  | _ -> assert false
+
+let test_execute_second_branch_wins_after_first_fails () =
+  let branches : string S.branch list =
+    [ (fun () -> Error "transport"); (fun () -> Ok "ok-from-2") ]
+  in
+  let outcome, selection = S.execute ~budget:S.default_budget branches in
+  assert (selection.winner_index = Some 1);
+  assert (selection.attempted = 2);
+  assert (selection.errors = [ "transport" ]);
+  match R_outcome.value_opt outcome with
+  | Some "ok-from-2" -> ()
+  | _ -> assert false
+
+let test_execute_all_branches_fail () =
+  let branches : int S.branch list =
+    [
+      (fun () -> Error "e1");
+      (fun () -> Error "e2");
+      (fun () -> Error "e3");
+    ]
+  in
+  let outcome, selection = S.execute ~budget:S.default_budget branches in
+  assert (selection.winner_index = None);
+  assert (selection.attempted = 3);
+  assert (selection.errors = [ "e1"; "e2"; "e3" ]);
+  assert (R_outcome.is_graceful outcome)
+
+let test_execute_branches_max_truncates () =
+  let counter = ref 0 in
+  let f i () =
+    incr counter;
+    Error (Printf.sprintf "fail-%d" i)
+  in
+  let branches : int S.branch list =
+    [ f 0; f 1; f 2; f 3; f 4 ]
+  in
+  let budget = { S.default_budget with branches_max = 2 } in
+  let _outcome, selection = S.execute ~budget branches in
+  assert (selection.attempted = 2);
+  assert (!counter = 2);
+  assert (selection.errors = [ "fail-0"; "fail-1" ])
+
+let test_execute_branches_max_zero () =
+  let counter = ref 0 in
+  let branches : int S.branch list =
+    [
+      (fun () ->
+        incr counter;
+        Ok 1);
+    ]
+  in
+  let budget = { S.default_budget with branches_max = 0 } in
+  let _outcome, selection = S.execute ~budget branches in
+  assert (selection.attempted = 0);
+  assert (!counter = 0);
+  assert (selection.errors = [])
+
+let test_execute_full_success_sets_outcome_class () =
+  let branches : int S.branch list = [ (fun () -> Ok 7) ] in
+  let outcome, _ = S.execute ~budget:S.default_budget branches in
+  assert (R_outcome.is_full outcome)
+
+let () =
+  test_default_budget ();
+  test_execute_empty_branches ();
+  test_execute_first_branch_wins ();
+  test_execute_second_branch_wins_after_first_fails ();
+  test_execute_all_branches_fail ();
+  test_execute_branches_max_truncates ();
+  test_execute_branches_max_zero ();
+  test_execute_full_success_sets_outcome_class ();
+  print_endline "test_speculative: all assertions passed"


### PR DESCRIPTION
## Summary

Tier A11 — first PR covering type machinery + the sequential-simulator branch of the speculative executor. Opens Cycle 27 (Speculative + Dashboard) per plan §16. Eio.Switch-based parallel race + abort is deferred to a companion follow-up (A11b) so this PR keeps `lib/resilience/dune` unchanged and stays file-disjoint with the parallel A6 PR.

## Modules

| Module | Surface |
|--------|---------|
| `Degradation` | 4-level capability lattice with phantom-tagged GADT (L1/L2/L3/L4 + 4 empty witness types) + structural mirror `level_tag`. Numeric bridge `to_int`/`of_int_opt` aligns with the I5 stub field `Resilience_outcome.PartialSuccess.degradation_level`. |
| `Speculative` | `budget_policy` + `'a branch` + `'a selection` types and `execute ~budget branches` sequential simulator. Same signature shape as the future Eio.Switch race — A11b swaps without API change. |

## Strategy mapping (`apply_level_to_strategy`)

| Level | Behaviour |
|-------|-----------|
| `L1` | Returns canonical `Recovery.default_strategy` |
| `L2` | Downgrades `Retry` → `Fallback`; preserves other classes |
| `L3` | Forces `Handoff` regardless of mode (skeleton: tool use disabled) |
| `L4` | Forces `Abort` regardless of mode (canned response only) |

## Why split (Eio deferral)

A standalone Eio dependency on `lib/resilience` would expand the build closure for every consumer of `Recovery` / `Confidence`. Keeping A11's first PR Eio-free preserves the file-disjoint property declared in plan §16 and lets type machinery + selection contract land independently of Eio integration concerns. The sequential simulator's signature is intentionally aligned with the future parallel implementation — consumers call `execute ~budget branches` today and gain parallelism transparently.

## Plan §16 reference

| Tier | LoC | Risk |
|------|-----|------|
| **A11** (first PR) | ~580 / 7 files | Medium (sequential simulator + GADT lattice; Eio deferred) |

3-PR parallel entry confirmed by user. base=main, no stack PR.

## Test plan

- [x] `dune build --root . lib/resilience test/resilience` GREEN
- [x] `dune runtest --root . test/resilience --force` GREEN — 21 new assertions across `test_degradation` (13) + `test_speculative` (8)
- [x] Race check `gh pr list --search "degradation OR speculative OR Tier A11"` → 0 directly overlapping
- [ ] CI Build and Test green after push

## Related

- Cycle 27 entry. Tier A11b will add Eio.Switch parallel race + budget guard. Tier A12 (E2E demo) follows.
- `Recovery.error_mode.DegradationRequired.recommended_level: int` retype to `Degradation.level` deferred to a separate cleanup PR (A11b or its companion).
- Cycle 23 closing (A6) and Cycle 24 entry (B8) entered in parallel — independent file scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)