### PR TITLE
test(dashboard): a11y batch 6 — json-viewer/heartbeat-streak/heartbeat-uptime

### DIFF
--- a/dashboard/src/components/common/heartbeat-streak-chip.a11y.test.ts
+++ b/dashboard/src/components/common/heartbeat-streak-chip.a11y.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for HeartbeatStreakChip — tiny status badge
+// answering "how long has this connector been in its current state?".
+// axe guards: tone palette (up/down/unknown) maintains WCAG AA
+// contrast; the chip's text content carries enough information for
+// AT users (no color-only signal).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { HeartbeatStreakChip } from './heartbeat-streak-chip'
+import type { HeartbeatState } from '../../lib/heartbeat-history'
+
+const upHistory: HeartbeatState[] = Array<HeartbeatState>(22).fill('up')
+const downHistory: HeartbeatState[] = Array<HeartbeatState>(3).fill('down')
+const unknownHistory: HeartbeatState[] = Array<HeartbeatState>(1).fill('unknown')
+
+describe('HeartbeatStreakChip a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('up streak passes axe (operational tone)', async () => {
+    render(
+      html`<${HeartbeatStreakChip} history=${upHistory} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('down streak passes axe (failure tone)', async () => {
+    render(
+      html`<${HeartbeatStreakChip} history=${downHistory} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('unknown streak passes axe (muted tone)', async () => {
+    render(
+      html`<${HeartbeatStreakChip} history=${unknownHistory} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('empty history (no data) renders nothing accessibly', async () => {
+    render(html`<${HeartbeatStreakChip} history=${[]} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/heartbeat-uptime-chip.a11y.test.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.a11y.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for HeartbeatUptimeChip — rolling uptime % badge.
+// Pairs with HeartbeatStreakChip; both share the operational/degraded/
+// unhealthy tone palette so axe verifies all 3 tones independently.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { HeartbeatUptimeChip } from './heartbeat-uptime-chip'
+import type { HeartbeatState } from '../../lib/heartbeat-history'
+
+function history(up: number, down: number, unknown: number): HeartbeatState[] {
+  return [
+    ...Array<HeartbeatState>(up).fill('up'),
+    ...Array<HeartbeatState>(down).fill('down'),
+    ...Array<HeartbeatState>(unknown).fill('unknown'),
+  ]
+}
+
+describe('HeartbeatUptimeChip a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('operational (>=99%) passes axe', async () => {
+    render(
+      html`<${HeartbeatUptimeChip} history=${history(100, 0, 0)} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('degraded (95-99%) passes axe', async () => {
+    render(
+      html`<${HeartbeatUptimeChip} history=${history(96, 4, 0)} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('unhealthy (<95%) passes axe', async () => {
+    render(
+      html`<${HeartbeatUptimeChip} history=${history(80, 20, 0)} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('all unknown (returns null) renders nothing accessibly', async () => {
+    render(
+      html`<${HeartbeatUptimeChip} history=${history(0, 0, 5)} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/json-viewer.a11y.test.ts
+++ b/dashboard/src/components/common/json-viewer.a11y.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for JsonViewer / JsonViewerCard. Tree-style
+// data display. axe primarily guards: (1) the recursive nested
+// `<details>` / `<summary>` structure (when collapsible) keeps a
+// proper accessibility tree, and (2) the colored type-tagged spans
+// (string/number/boolean) maintain WCAG AA contrast.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { JsonViewer, JsonViewerCard } from './json-viewer'
+
+describe('JsonViewer a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('flat object passes axe', async () => {
+    render(
+      html`<${JsonViewer} data=${{ name: 'masc', version: 1 }} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('nested object + array passes axe', async () => {
+    render(
+      html`<${JsonViewer}
+        data=${{
+          agents: ['a', 'b'],
+          status: { ok: true, count: 12 },
+        }}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with label passes axe', async () => {
+    render(
+      html`<${JsonViewer} data=${[1, 2, 3]} label="numbers" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('initialCollapsed=true passes axe', async () => {
+    render(
+      html`<${JsonViewer}
+        data=${{ a: 1, b: 2 }}
+        initialCollapsed=${true}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('null + boolean + string mix passes axe (type-tag color sweep)', async () => {
+    render(
+      html`<${JsonViewer}
+        data=${{ s: 'text', n: 42, b: true, nil: null, arr: [] }}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('JsonViewerCard a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with title passes axe', async () => {
+    render(
+      html`<${JsonViewerCard}
+        title="Run summary"
+        data=${{ ok: 12, err: 0 }}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

Sixth a11y test batch. Three different patterns:

| Atom | Pattern | Cases |
|------|---------|-------|
| **JsonViewer / JsonViewerCard** | recursive data tree | 6 |
| **HeartbeatStreakChip** | status-streak badge (up/down/unknown) | 4 |
| **HeartbeatUptimeChip** | uptime % badge (operational/degraded/unhealthy) | 4 |

14 cases, all pass. \`tsc --noEmit\` clean.

## Why these picks

- **JsonViewer** — recursive nested rendering with type-tagged spans. Without an a11y guard, the recursive collapse/expand structure could regress to a div-soup that breaks the accessibility tree.
- **Heartbeat chips (streak + uptime)** — both share the operational/degraded/unhealthy tone palette and are commonly displayed side-by-side. Locking both with axe ensures palette changes propagate consistently.

## Honest mid-PR API correction

Initial draft passed \`streak\` / \`summary\` prop objects, but the components actually take \`history: HeartbeatState[]\` and compute streak/summary internally. 4 test failures surfaced the wrong assumption; fix was constructing history arrays of the right state composition. **Good signal that the test coverage catches API drift, not just behavior drift.**

## Verification

- [x] \`pnpm vitest run src/components/common/{json-viewer,heartbeat-streak-chip,heartbeat-uptime-chip}.a11y.test.ts\` → 14/14 pass
- [x] \`pnpm tsc --noEmit\` clean
- [ ] CI checks (this PR)

## Cumulative coverage

18 atoms in main (after #11703, #11704, #11707, #11720) + 6 pending atoms across #11754 / #11773 / **this PR** = **~24 atoms / ~85 cases** once all pending land.

## Related

- Depends on (merged): #11676 jest-axe wiring
- Sibling pending: #11754 batch 4, #11773 batch 5, #11732 SegmentedBar fix
- Spec: design_system_v2 §6.3 (automated a11y testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)