### PR TITLE
fix(test): docker keeper factory wiring + sandbox-boundary predicate (Issue #11710)

### DIFF
--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -527,8 +527,14 @@ let test_keeper_shell_gh_without_current_task_uses_sandbox_context () =
   with_repo_context_test_env @@ fun ~base:_ ~config ~repo_dir ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   let meta = make_meta ~sandbox_profile:Keeper_types.Docker () in
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -11,6 +11,7 @@ module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_id = Masc_mcp.Keeper_id
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
+module Keeper_sandbox_factory = Masc_mcp.Keeper_sandbox_factory
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Fs_compat = Fs_compat
@@ -204,6 +205,31 @@ let blocked_by_symmetric_sandbox raw =
       let len = String.length needle in
       String.length err >= len && String.sub err 0 len = needle
 
+(* Docker-keeper boundary enforcement landed in two phases:
+   - B-1.5 (early): [symmetric_sandbox_blocked], emitted by
+     [Keeper_sandbox_containment.check_read_target] AFTER the resolver
+     allowed the host path through.
+   - PR-3b (2026-04-28+): the resolver itself rejects out-of-sandbox
+     reads with [path_outside_sandbox], so the symmetric check is not
+     reached for the canonical "outside playground" case.  Both labels
+     observably mean "Docker keeper read blocked by playground
+     boundary".  Use this looser predicate for Docker-keeper tests so
+     the semantic stays "is it blocked" instead of pinning to the
+     1st-stage label.  Legacy [blocked_by_symmetric_sandbox] stays
+     strict so [test_legacy_keeper_unaffected] continues to assert
+     "this code path didn't fire" rather than the broader "blocked or
+     not". *)
+let blocked_by_sandbox_boundary raw =
+  match parse_field raw "error" with
+  | None -> false
+  | Some err ->
+      let starts_with prefix s =
+        let pl = String.length prefix in
+        String.length s >= pl && String.sub s 0 pl = prefix
+      in
+      starts_with "symmetric_sandbox_blocked" err
+      || starts_with "path_outside_sandbox" err
+
 let test_legacy_keeper_unaffected () =
   setup ~keeper_name:"alice" ~sandbox:Keeper_types.Local
   @@ fun ~base ~config ~meta ~playground:_ ->
@@ -212,6 +238,11 @@ let test_legacy_keeper_unaffected () =
     Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
+  (* Strict predicate: this test specifically asserts the symmetric
+     containment layer doesn't fire for Local keepers.  PR-3b's resolver
+     tightening also blocks Local with [path_outside_sandbox], but that
+     is the resolver layer, not the symmetric containment layer this
+     test was written to characterise. *)
   Alcotest.(check bool) "legacy bypasses symmetric containment" false
     (blocked_by_symmetric_sandbox raw)
 
@@ -220,24 +251,36 @@ let test_docker_keeper_blocks_ls_outside () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc [ ("op", `String "ls"); ("path", `String outside_dir) ])
   in
   Alcotest.(check bool) "ls outside playground blocked" true
-    (blocked_by_symmetric_sandbox raw)
+    (blocked_by_sandbox_boundary raw)
 
 let test_docker_keeper_blocks_cat_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "host_secret.txt" in
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "cat outside playground blocked" true
-    (blocked_by_symmetric_sandbox raw)
+    (blocked_by_sandbox_boundary raw)
 
 let test_docker_keeper_blocks_rg_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
@@ -248,8 +291,14 @@ let test_docker_keeper_blocks_rg_outside () =
     (Fs_compat.save_file_atomic
        (Filename.concat outside_dir "leak.txt")
        "secret-token");
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -259,15 +308,21 @@ let test_docker_keeper_blocks_rg_outside () =
           ])
   in
   Alcotest.(check bool) "rg outside playground blocked" true
-    (blocked_by_symmetric_sandbox raw)
+    (blocked_by_sandbox_boundary raw)
 
 let test_docker_keeper_blocks_find_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -277,7 +332,7 @@ let test_docker_keeper_blocks_find_outside () =
           ])
   in
   Alcotest.(check bool) "find outside playground blocked" true
-    (blocked_by_symmetric_sandbox raw)
+    (blocked_by_sandbox_boundary raw)
 
 let test_docker_keeper_allows_inside_playground () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
@@ -292,18 +347,24 @@ let test_docker_keeper_allows_inside_playground () =
      /bin/cat availability; we only assert the symmetric_sandbox guard
      is silent. *)
   Alcotest.(check bool) "playground-internal cat not blocked" false
-    (blocked_by_symmetric_sandbox raw)
+    (blocked_by_sandbox_boundary raw)
 
 let test_docker_git_creds_contained () =
   setup ~keeper_name:"poe" ~sandbox:Keeper_types.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "git_secret.txt" in
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "docker git-creds also contained" true
-    (blocked_by_symmetric_sandbox raw)
+    (blocked_by_sandbox_boundary raw)
 
 let test_gh_binds_repo_from_active_task_worktree () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Local

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -12,6 +12,7 @@ module Coord = Masc_mcp.Coord
 module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
+module Keeper_sandbox_factory = Masc_mcp.Keeper_sandbox_factory
 module Keeper_shell_docker = Masc_mcp.Keeper_shell_docker
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
@@ -347,8 +348,14 @@ let test_git_clone_routes_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -372,8 +379,14 @@ let test_hard_mode_git_clone_uses_brokered_route () =
   with_env "MASC_KEEPER_SANDBOX_RELAX_FS" "false" @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -607,8 +620,14 @@ let test_git_clone_repairs_existing_docker_clone_checkout () =
   clear_checkout_but_keep_git_dir clone_path;
   Alcotest.(check bool) "checkout file removed before repair" false
     (Sys.file_exists restored_readme);
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [


### PR DESCRIPTION
## 배경

Issue **#11710** 의 9개 docker-keeper test failures 처리. PR-3b 시리즈(#11679 factory introduction + #11695 resolver tightening)의 잠재 부채.

본 PR 은 **PR #11825 (main blocker fix) 위에 stack** 됩니다 — base merged 되면 자동 origin/main 으로 rebase.

## 변경 요약

### 1. Predicate split — semantic 분리 (test_keeper_shell_containment.ml)

PR-3b 가 docker keeper boundary 를 두 layer 로 enforce:
- B-1.5 (early): `Keeper_sandbox_containment.check_read_target` → `symmetric_sandbox_blocked` (resolver 통과 후 fire)
- PR-3b (2026-04-28+): resolver 자체가 outside path 거부 → `path_outside_sandbox` (symmetric layer 도달 안 함)

기존 predicate `blocked_by_symmetric_sandbox` 는 B-1.5 라벨만 매칭. 5 docker keeper test 는 "blocked" 의도였으나 새 라벨로 fire 되어 false negative 발생.

| Predicate | 매칭 | 용도 |
|-----------|------|------|
| `blocked_by_symmetric_sandbox` (strict) | `symmetric_sandbox_blocked` 만 | `test_legacy_keeper_unaffected` (Local keeper, "이 layer 가 fire 안 함" 단언) |
| `blocked_by_sandbox_boundary` (broad) | 둘 다 | 5 Docker keeper "blocks X outside" tests |

### 2. Factory wiring — 9개 함수 (3 파일)

PR #11679 가 production 시그니처를 `~turn_sandbox_factory: option` 으로 옮긴 뒤, 테스트는 `None` 만 사용. resolve_opt None → docker route 발화 안 함. 9 함수에 `Keeper_sandbox_factory.create ~config ~meta ()` + `Fun.protect ... cleanup` + `~turn_sandbox_factory:(Some factory)` 적용.

수정 함수 목록:
- `test_docker_keeper_blocks_{ls,cat,rg,find}_outside` (containment)
- `test_docker_git_creds_contained` (containment)
- `test_git_clone_routes_through_docker` (docker_route)
- `test_hard_mode_git_clone_uses_brokered_route` (docker_route)
- `test_git_clone_repairs_existing_docker_clone_checkout` (docker_route)
- `test_keeper_shell_gh_without_current_task_uses_sandbox_context` (github_read_only)

Module alias 추가: `Keeper_sandbox_factory` in 두 파일. github_read_only 는 기존 `open Masc_mcp` 로 도달.

## 검증

| Test file | 결과 (9 originally failing → 이번 fix 후) |
|-----------|------|
| `test_keeper_shell_containment` | ✅ **9/9 PASS** (5 newly fixed) |
| `test_keeper_shell_docker_route` | ⚠️ **12/15 PASS** (3 git_clone 잔여 실패 — 별개 회귀) |
| `test_keeper_github_read_only` | ⚠️ **28/29 PASS** (1 gh op 잔여 실패 — 별개 회귀) |

총 **5 / 9 fix**. factory wiring 은 architecturally 옳지만 4 잔여 케이스는 다른 layer 의 회귀가 docker route 도달 전 차단.

## 잔여 4개 실패 — 별개 회귀로 분리 (follow-up issue 권장)

### 3 git_clone 테스트
- 경로: `tool_code_write.ml` / `coord_worktree.ml` 의 `allowed_orgs = []` allowlist
- 응답: `{"error":"clone_blocked","reason":"No allowed orgs configured for git clone (git_clone.allowed_orgs in tool_policy.toml)"}`
- **Comment vs code drift**: `config/tool_policy.toml` 주석은 *Empty list = skip check* 명시하지만 실제 코드는 `if allowed = [] then Error "..."` (block all)
- Test expects `via=docker`; receives `error=clone_blocked` (docker route 도달 전 차단)

### 1 gh 테스트 (`test_keeper_shell_gh_without_current_task_uses_sandbox_context`)
- 응답: `Yojson__Safe.Util.Type_error("Expected bool, got null")` — `ok` 필드가 null
- gh op 응답 shape 변경. factory wiring 과 무관한 다른 code path 변경.

## 의존 관계 / Stack PR

- **Base**: `fix/main-blocker-unified-turn-printexc` (PR **#11825**) — 머지 후 자동 origin/main rebase.
- **이번 PR**: `fix/docker-keeper-factory-stack`
- 머지 순서: #11825 → #11823 (cascade hard_quota) → 본 PR.

## 참고

- Issue **#11710**: 9 docker keeper semantic regressions tracker.
- PR **#11679** (PR-3b part 1): factory 도입.
- PR **#11695**: resilience tier A6 (간접 영향, main blocker 트리거).
- PR **#11705**: turn_sandbox_factory cascade rename — 빌드 fix 부분.

메모리 패턴:
- *Surgical Changes*: 9 함수 mechanical edit, setup helper 보존.
- *Don't add features beyond what the task requires*: predicate split 만 수정, 다른 layer 회귀는 별개 PR.
- *Issue Discovery*: 잔여 4 실패는 별도 follow-up issue 로 추적.
