### PR TITLE
chore(server): add server_mcp_transport_http_sse.mli — SSE wrapper cascade (cycle 188)

### DIFF
--- a/lib/server/server_mcp_transport_http_sse.mli
+++ b/lib/server/server_mcp_transport_http_sse.mli
@@ -1,0 +1,50 @@
+(** Server_mcp_transport_http_sse — Thin compatibility wrapper
+    over the HTTP SSE connection registry.
+
+    Historical context: cleanup loops read this module while
+    request handlers mutated
+    {!Server_mcp_transport_http_conn}.  This wrapper re-exports
+    the conn implementation so both paths observe the same
+    registry + guard tables.  Drift in either direction would
+    re-introduce the registry split that previously caused
+    cleanup-vs-mutation race conditions.
+
+    The .ml is 13 lines:
+    - [type deps = Server_mcp_transport_http_types.deps] alias
+    - [include Server_mcp_transport_http_conn]
+    - [respond_sse_rate_limited] re-export from
+      {!Server_mcp_transport_http_respond}.
+
+    This .mli mirrors with type-identity-preserving cascade
+    (see cycle 187 [coord_utils.mli] for the [module type of
+    struct include M end] pattern rationale). *)
+
+type deps = Server_mcp_transport_http_types.deps
+(** Per-request dependency bundle.  Aliased from
+    {!Server_mcp_transport_http_types.deps} — type identity
+    preserved so callers can interleave the two names. *)
+
+include module type of struct
+  include Server_mcp_transport_http_conn
+end
+(** Re-exposes the entire connection registry surface
+    (registry / guard / session tracking) used by both cleanup
+    loops and request handlers.  Type identity preserved end-
+    to-end via the [struct include M end] form. *)
+
+val respond_sse_rate_limited :
+  deps:Server_mcp_transport_http_types.deps ->
+  origin:string ->
+  session_id:string ->
+  protocol_version:string ->
+  reason:string ->
+  retry_after_s:float ->
+  Httpun.Reqd.t ->
+  unit
+(** Pinned alias of
+    {!Server_mcp_transport_http_respond.respond_sse_rate_limited}
+    at the SSE wrapper boundary so call-sites that historically
+    reached the helper through this module continue to work
+    without import churn.  Signature mirrors the source mli
+    exactly — labeled args [~deps], [~origin], [~session_id],
+    [~protocol_version], [~reason], [~retry_after_s]. *)


### PR DESCRIPTION
## Summary

Pin the public surface of `lib/server/server_mcp_transport_http_sse.ml` — a 13-line thin SSE compatibility wrapper that re-exports the connection registry from `Server_mcp_transport_http_conn`.

## Surface (1 type alias + cascade + 1 entry)

- `type deps = Server_mcp_transport_http_types.deps` — alias preserving type identity
- `include module type of struct include Server_mcp_transport_http_conn end` — full registry cascade with type identity preserved end-to-end
- `respond_sse_rate_limited` — pinned alias of `Server_mcp_transport_http_respond.respond_sse_rate_limited`

## Historical contract pinning

Cleanup loops and request handlers historically observed the **same registry** through this wrapper. Drift in either direction (removing the `include`, splitting the registry) would re-introduce the cleanup-vs-mutation race that this wrapper was designed to prevent. Pinned in module docstring.

## Build feedback iteration

**1st build**: my draft used a positional `Httpun.Reqd.t` arg signature for `respond_sse_rate_limited`. **Actual signature** uses 6 labeled args (`~deps`, `~origin`, `~session_id`, `~protocol_version`, `~reason`, `~retry_after_s`). Mirrored exactly from the source mli.

Cascade pattern matches **cycle 187 `coord_utils`** — uses `module type of struct include M end` form to preserve type identity end-to-end (plain `module type of M` would create nominally distinct copies, breaking caller compatibility).

Pre-existing main errors in `tool_local_runtime.mli:81` + `keeper_unified_turn.ml:1861` are unrelated (same as cycles 182-187).

## Test plan

- [x] `dune build --root . lib/` cmi rebuilt fresh after labeled-arg signature fix
- [x] All sub-modules (conn, types, respond) have .mli files
- [ ] CI: dune build + ratchet (`server_mli_missing` or equivalent decrement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)