### PR TITLE
test(dashboard): a11y batch 8 — progress-bar/select/live-pulse-dot

### DIFF
--- a/dashboard/src/components/common/live-pulse-dot.a11y.test.ts
+++ b/dashboard/src/components/common/live-pulse-dot.a11y.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for LivePulseDot — pulsing dot indicating polling
+// liveness. Tests pin all 3 states (live/stale/idle) and verify the
+// component's accessible-name strategy (title + aria-label combine to
+// give the dot a descriptive name beyond color-only signaling).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { LivePulseDot } from './live-pulse-dot'
+
+describe('LivePulseDot a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('live state (recent tick) passes axe', async () => {
+    const recentTick = new Date().toISOString()
+    render(
+      html`<${LivePulseDot} lastTickAt=${recentTick} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('stale state (older tick) passes axe', async () => {
+    const oldTick = new Date(Date.now() - 60_000).toISOString()
+    render(
+      html`<${LivePulseDot} lastTickAt=${oldTick} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('idle state (null tick — never sampled) passes axe', async () => {
+    render(html`<${LivePulseDot} lastTickAt=${null} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/progress-bar.a11y.test.ts
+++ b/dashboard/src/components/common/progress-bar.a11y.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for ProgressBar — single-value progress indicator.
+// axe primarily verifies: (1) progressbar role + aria-valuenow/min/max
+// wiring is intact, and (2) the tone palette stays above WCAG AA
+// contrast across all 8 tones.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { ProgressBar } from './progress-bar'
+
+describe('ProgressBar a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default render with pct passes axe', async () => {
+    render(html`<${ProgressBar} pct=${42} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with ariaLabel passes axe', async () => {
+    render(
+      html`<${ProgressBar} pct=${75} ariaLabel="Build progress" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('all 4 status tones (accent/ok/warn/bad) pass axe', async () => {
+    render(
+      html`<div>
+        <${ProgressBar} pct=${30} tone="accent" ariaLabel="Accent" />
+        <${ProgressBar} pct=${85} tone="ok" ariaLabel="Ok" />
+        <${ProgressBar} pct=${60} tone="warn" ariaLabel="Warn" />
+        <${ProgressBar} pct=${15} tone="bad" ariaLabel="Bad" />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('extended tone palette (emerald/amber/rose/sky) passes axe', async () => {
+    render(
+      html`<div>
+        <${ProgressBar} pct=${50} tone="emerald" ariaLabel="Emerald" />
+        <${ProgressBar} pct=${50} tone="amber" ariaLabel="Amber" />
+        <${ProgressBar} pct=${50} tone="rose" ariaLabel="Rose" />
+        <${ProgressBar} pct=${50} tone="sky" ariaLabel="Sky" />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('pct=0 and pct=100 boundary cases pass axe', async () => {
+    render(
+      html`<div>
+        <${ProgressBar} pct=${0} ariaLabel="Empty" />
+        <${ProgressBar} pct=${100} ariaLabel="Full" />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/select.a11y.test.ts
+++ b/dashboard/src/components/common/select.a11y.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for Select — native <select> form input. The
+// component's JSDoc warns that dropping `id` / `ariaLabel` is a
+// known regression; this suite makes axe enforce the contract.
+// Mirrors the checkbox/input batches.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { Select } from './select'
+
+const STRING_OPTIONS = ['Apple', 'Banana', 'Cherry']
+const OBJECT_OPTIONS = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+]
+
+describe('Select a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with ariaLabel + string options passes axe', async () => {
+    render(
+      html`<${Select} options=${STRING_OPTIONS} ariaLabel="Fruit" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with id + external <label for=""> + object options passes axe', async () => {
+    render(
+      html`<div>
+        <label for="grade">Grade</label>
+        <${Select} id="grade" options=${OBJECT_OPTIONS} />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with placeholder + ariaLabel passes axe', async () => {
+    render(
+      html`<${Select}
+        ariaLabel="Pick one"
+        placeholder="Choose…"
+        options=${STRING_OPTIONS}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('disabled + ariaLabel passes axe', async () => {
+    render(
+      html`<${Select}
+        ariaLabel="Locked field"
+        options=${STRING_OPTIONS}
+        disabled=${true}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with value preselected passes axe', async () => {
+    render(
+      html`<${Select}
+        ariaLabel="Pre-filled"
+        options=${OBJECT_OPTIONS}
+        value="b"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

Eighth a11y test batch. Three orthogonal patterns:

| Atom | Pattern | Cases |
|------|---------|-------|
| **ProgressBar** | progressbar role + 8-tone palette | 5 |
| **Select** | native form input (label-resolution + states) | 5 |
| **LivePulseDot** | tri-state status indicator (live/stale/idle) | 3 |

13 cases, all pass. \`tsc --noEmit\` clean.

## Why these picks

- **ProgressBar** — wide tone palette (8 tones across 2 families: status + extended) means contrast regression risk. Boundary cases (0%, 100%) verify edge-render.
- **Select** — same JSDoc warning as Input/Checkbox: dropping accessible-name props is a known regression. axe contract now locked.
- **LivePulseDot** — color-only indicator becomes a11y trap if title/aria-label drop. 3 states verify each tone path.

## Verification

- [x] \`pnpm vitest run src/components/common/{progress-bar,select,live-pulse-dot}.a11y.test.ts\` → **13/13 pass**
- [x] \`pnpm tsc --noEmit\` clean
- [ ] CI checks (this PR)

## Cumulative coverage

21 atoms in main + 9 pending atoms across #11815, #11818, **this PR** = **~30 atoms / ~110 cases** once all pending land.

## Related

- Depends on (merged): #11676 jest-axe wiring
- Sibling pending: #11815 batch 6, #11818 batch 7
- Spec: design_system_v2 §6.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)