### PR TITLE
chore(tool-schemas): add tool_schemas_misc.mli — SSOT mirror surface (cycle 189)

### DIFF
--- a/lib/tool_schemas/tool_schemas_misc.mli
+++ b/lib/tool_schemas/tool_schemas_misc.mli
@@ -1,0 +1,63 @@
+(** Tool_schemas_misc — Tool schemas for [Tool_misc],
+    separated to break the [Config] dependency cycle.
+
+    All 4 entries are SSOT mirrors of producer-side string
+    lists.  Adding / removing values requires coordinated
+    updates at the SSOT (which lives in a downstream module
+    that cannot be referenced here without re-introducing the
+    cycle).  Three test invariants keep the mirrors aligned:
+
+    - [test_types.ml :: dashboard_scope_ssot] —
+      {!dashboard_scope_enum_strings} vs
+      [Dashboard.valid_scope_strings]
+    - [test_types.ml :: config_category_ssot] —
+      {!config_category_enum_strings} vs
+      [Env_config_snapshot.valid_config_category_strings]
+    - Issue #8546 — {!admin_section_enum_strings} vs
+      [Tool_misc_admin.valid_admin_section_strings] *)
+
+(** {1 Enum string mirrors (SSOT)} *)
+
+val admin_section_enum_strings : string list
+(** Mirror of [Tool_misc_admin.valid_admin_section_strings]
+    (issue #8546).  Currently [\["auth"\]] — drift would
+    re-introduce the schema-vs-handler mismatch where the
+    schema advertised values the handler did not implement,
+    causing [section must be one of: auth] errors for LLM
+    clients following the schema.  Pinned at the contract
+    seam — same cycle pattern as #8484 / #8490 / #8493. *)
+
+val dashboard_scope_enum_strings : string list
+(** Mirror of [Dashboard.valid_scope_strings] (issue #8592).
+    Currently [\["all"; "current"\]] — adding a 3rd scope
+    constructor must fail [scope_to_string] compilation AND
+    the [dashboard_scope_ssot] test, instead of silently
+    dropping from the JSON Schema.  Hand-mirrored because
+    [Tool_schemas_misc] is upstream of [Dashboard] in the
+    dependency graph. *)
+
+val config_category_enum_strings : string list
+(** Mirror of [Env_config_snapshot.valid_config_category_strings]
+    (issue #8493).  20 categories pinned: ["server"], ["auth"],
+    ["transport"], ["storage"], ["runtime"],
+    ["rate_limiting"], ["inference"], ["keeper"],
+    ["keeper_execution"], ["keeper_guardrails"], ["autonomy"],
+    ["level2"], ["dashboard"], ["economy"], ["governance"],
+    ["channel"], ["process"], ["worker"], ["web_search"],
+    ["session"].  Hand-mirrored because [Tool_schemas_misc]
+    depends only on [masc_types] — adding [masc_config] as a
+    direct dep would reintroduce the cycle this split avoids.
+    The [config_category_ssot] test keeps this aligned with
+    the producer-side SSOT. *)
+
+(** {1 Tool schema list} *)
+
+val schemas : Types.tool_schema list
+(** [schemas] is the [Types.tool_schema list] for the
+    [masc_config], [masc_dashboard], and [masc_misc_admin]
+    tools.  Consumed by {!Config.visible_tool_schemas} via
+    {!Tools.schemas}.  The schema [enum] fields derive from
+    {!admin_section_enum_strings} /
+    {!dashboard_scope_enum_strings} /
+    {!config_category_enum_strings} so adding a value updates
+    the schema automatically. *)


### PR DESCRIPTION
## Summary

Pin the public surface of `lib/tool_schemas/tool_schemas_misc.ml` — tool schemas module that mirrors 3 producer-side enum string lists to break the `Config` dependency cycle.

## Surface (4 entries — all SSOT mirrors with test invariants)

- `admin_section_enum_strings` — mirror of `Tool_misc_admin.valid_admin_section_strings` (issue #8546)
- `dashboard_scope_enum_strings` — mirror of `Dashboard.valid_scope_strings` (issue #8592)
- `config_category_enum_strings` — mirror of `Env_config_snapshot.valid_config_category_strings` (issue #8493)
- `schemas : Types.tool_schema list` — schema `enum` fields derive from above mirrors

## Contract pinning

3 SSOT mirror invariants pinned in module docstring with cross-references to test invariants:
- `test_types.ml :: dashboard_scope_ssot`
- `test_types.ml :: config_category_ssot`
- Issue #8546 schema-vs-handler mismatch context

Pinned literal sets:
- `admin_section_enum_strings = ["auth"]` — drift re-introduces the `section must be one of: auth` error pattern from #8546
- `dashboard_scope_enum_strings = ["all"; "current"]` — 3rd constructor must fail `scope_to_string` compilation AND the SSOT test, not silently drop from JSON Schema
- `config_category_enum_strings = 20-entry pinned list` — cycle constraint prevents direct `masc_config` dependency

## Surface confirmed via caller grep

4 dotted accesses across `test/test_types.ml` (3 SSOT tests) + `lib/config.ml` (schemas consumption).

## Test plan

- [x] `dune build --root . lib/` cmi rebuilt fresh
- [x] All 4 entries match producer-side SSOT contracts (test invariants enforce on regression)
- [ ] CI: dune build + ratchet (`tool_schemas_mli_missing` decrement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)