### PR TITLE
feat(crew): Tier A8 — persona_contract GADT + crew_types + 4 static contracts (Cycle 25)

### DIFF
--- a/lib/crew/crew_types.ml
+++ b/lib/crew/crew_types.ml
@@ -1,0 +1,87 @@
+(* Crew_types — Cycle 25 / Tier A8.
+   See crew_types.mli for design rationale. *)
+
+(* ── Persona kind ─────────────────────────────────────────────── *)
+
+type persona_kind =
+  | Analyst [@tla.symbol "analyst"]
+  | Executor [@tla.symbol "executor"]
+  | Scholar [@tla.symbol "scholar"]
+  | Verifier [@tla.symbol "verifier"]
+[@@deriving tla]
+
+let all_persona_kinds = [ Analyst; Executor; Scholar; Verifier ]
+
+let persona_kind_to_string = to_tla_symbol
+
+let persona_kind_of_string_opt s =
+  match String.lowercase_ascii s with
+  | "analyst" -> Some Analyst
+  | "executor" -> Some Executor
+  | "scholar" -> Some Scholar
+  | "verifier" -> Some Verifier
+  | _ -> None
+
+let persona_kind_to_json p = `String (persona_kind_to_string p)
+
+let persona_kind_of_json = function
+  | `String s -> (
+      match persona_kind_of_string_opt s with
+      | Some p -> Ok p
+      | None -> Error (Printf.sprintf "unknown persona_kind: %s" s))
+  | _ -> Error "persona_kind must be a JSON string"
+
+(* ── Vote ─────────────────────────────────────────────────────── *)
+
+type vote =
+  | Approve
+  | Dissent of string
+  | Abstain
+
+let vote_label = function
+  | Approve -> "approve"
+  | Dissent _ -> "dissent"
+  | Abstain -> "abstain"
+
+let vote_to_json = function
+  | Approve -> `Assoc [ ("kind", `String "approve") ]
+  | Dissent r ->
+      `Assoc [ ("kind", `String "dissent"); ("reason", `String r) ]
+  | Abstain -> `Assoc [ ("kind", `String "abstain") ]
+
+let vote_of_json = function
+  | `Assoc kv -> (
+      match List.assoc_opt "kind" kv with
+      | Some (`String "approve") -> Ok Approve
+      | Some (`String "abstain") -> Ok Abstain
+      | Some (`String "dissent") -> (
+          match List.assoc_opt "reason" kv with
+          | Some (`String r) -> Ok (Dissent r)
+          | _ -> Error "dissent vote missing 'reason' string field")
+      | Some (`String other) ->
+          Error (Printf.sprintf "unknown vote kind: %s" other)
+      | _ -> Error "vote missing 'kind' string field")
+  | _ -> Error "vote must be a JSON object"
+
+(* ── Council identifier ───────────────────────────────────────── *)
+
+type council_id = string
+
+let council_id_of_string s =
+  let len = String.length s in
+  if len = 0 then Error "council_id must be non-empty"
+  else if len > 64 then
+    Error
+      (Printf.sprintf "council_id too long (%d > 64 chars)" len)
+  else Ok s
+
+let council_id_to_string s = s
+
+let council_id_to_json s = `String s
+
+let council_id_of_json = function
+  | `String s -> council_id_of_string s
+  | _ -> Error "council_id must be a JSON string"
+
+let council_id_compare = String.compare
+let council_id_equal = String.equal

--- a/lib/crew/crew_types.mli
+++ b/lib/crew/crew_types.mli
@@ -1,0 +1,98 @@
+(** Crew_types — common types for the CREW deliberation framework.
+
+    Cycle 25 / Tier A8.
+
+    {1 What this module is}
+
+    Shared types used across the CREW family of modules
+    (persona_contract, council, deliberation, consensus, audit).
+    Lives separately from {!Persona_contract} so that downstream
+    modules in subsequent tiers can depend on these enums and
+    identifier types without pulling in the contract record
+    payloads.
+
+    {1 Persona kind}
+
+    {!persona_kind} is the four-way tag that bridges
+    {!Persona_contract.contract} GADT (compile-time
+    discrimination) and runtime indexing (e.g. when reading a
+    persona name from a JSON config or persisting a vote
+    keyed by persona). The structural mirror has [\[@tla.symbol\]]
+    overrides so {!persona_kind_to_string} round-trips through
+    the canonical lowercase form ([analyst] / [executor] /
+    [scholar] / [verifier]) used in [config/personas/*/profile.json].
+
+    {1 Vote}
+
+    {!vote} encodes the trinary outcome of a single persona's
+    judgement during a deliberation phase: {!Approve},
+    {!Dissent} (with reason string), or {!Abstain}. Tier A9's
+    council_state machine consumes this enum directly.
+
+    {1 Council identifier}
+
+    {!council_id} is an opaque string-newtype carrying a unique
+    council instance identifier (typically ULID-shaped,
+    constructed by the caller). This module does not generate
+    identifiers — it only validates length on {!of_string}.
+    Tier A9 wires real ULID generation alongside the council
+    state machine.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+(** {1 Persona kind} *)
+
+type persona_kind =
+  | Analyst
+  | Executor
+  | Scholar
+  | Verifier
+
+val all_persona_kinds : persona_kind list
+
+val persona_kind_to_string : persona_kind -> string
+(** Lowercase canonical name. {!Analyst} → ["analyst"], etc. *)
+
+val persona_kind_of_string_opt : string -> persona_kind option
+(** Inverse of {!persona_kind_to_string}. Case-insensitive on
+    input. Returns [None] for unknown strings. *)
+
+val persona_kind_to_json : persona_kind -> Yojson.Safe.t
+
+val persona_kind_of_json : Yojson.Safe.t -> (persona_kind, string) result
+
+(** {1 Vote} *)
+
+type vote =
+  | Approve
+  | Dissent of string
+      (** Reason for dissent. The follow-up Tier A10 (consensus)
+          inspects this string when computing whether dissent
+          carries an override flag. *)
+  | Abstain
+
+val vote_to_json : vote -> Yojson.Safe.t
+
+val vote_of_json : Yojson.Safe.t -> (vote, string) result
+
+val vote_label : vote -> string
+(** ["approve"] / ["dissent"] / ["abstain"]. Reason text is
+    not included — this is the discriminator only. *)
+
+(** {1 Council identifier} *)
+
+type council_id = private string
+
+val council_id_of_string : string -> (council_id, string) result
+(** Validates the string is non-empty and ≤ 64 chars. *)
+
+val council_id_to_string : council_id -> string
+
+val council_id_to_json : council_id -> Yojson.Safe.t
+
+val council_id_of_json : Yojson.Safe.t -> (council_id, string) result
+
+val council_id_compare : council_id -> council_id -> int
+
+val council_id_equal : council_id -> council_id -> bool

--- a/lib/crew/dune
+++ b/lib/crew/dune
@@ -1,0 +1,7 @@
+(include_subdirs no)
+
+(library
+ (name crew)
+ (public_name masc_mcp.crew)
+ (libraries shared_types yojson)
+ (preprocess (pps ppx_tla)))

--- a/lib/crew/persona_contract.ml
+++ b/lib/crew/persona_contract.ml
@@ -1,0 +1,134 @@
+(* Persona_contract — Cycle 25 / Tier A8.
+   See persona_contract.mli for design rationale. *)
+
+(* ── Phantom witnesses ────────────────────────────────────────── *)
+
+type analyst = |
+type executor = |
+type scholar = |
+type verifier = |
+
+(* ── Contract record ──────────────────────────────────────────── *)
+
+(* The phantom 'a parameter is unused at the value level — it
+   lives purely in the type. Each constructor below narrows it
+   to a specific witness so handler functions specialised on
+   one persona cannot be misapplied. *)
+type 'a contract = {
+  name : string;
+  description : string;
+  core_responsibilities : string list;
+  forbidden_tools : string list;
+  kind : Crew_types.persona_kind;
+}
+
+(* ── Static contract values ───────────────────────────────────── *)
+
+let analyst_contract : analyst contract =
+  {
+    name = "analyst";
+    description =
+      "Critical analyser. Surfaces hidden assumptions, decomposes \
+       problems into checkable claims, flags rationalization \
+       patterns in prior reasoning.";
+    core_responsibilities =
+      [
+        "decompose claim into atomic checkable statements";
+        "surface unstated assumption";
+        "flag motivated reasoning";
+        "name the trade-off explicitly";
+      ];
+    forbidden_tools = [ "external_api_call"; "shell_write" ];
+    kind = Crew_types.Analyst;
+  }
+
+let executor_contract : executor contract =
+  {
+    name = "executor";
+    description =
+      "Action-taker. Carries out concrete edits, shell commands, \
+       and tool calls per a plan handed down by analyst or \
+       scholar. Owns the side-effecting tool surface.";
+    core_responsibilities =
+      [
+        "execute approved plan steps";
+        "report exit status + diff per step";
+        "stop and ask when plan diverges from observed reality";
+      ];
+    forbidden_tools = [];
+    kind = Crew_types.Executor;
+  }
+
+let scholar_contract : scholar contract =
+  {
+    name = "scholar";
+    description =
+      "Researcher. Pulls prior art, fetches documentation, \
+       synthesises option lists. Read-only on the world; never \
+       writes side effects.";
+    core_responsibilities =
+      [
+        "retrieve canonical documentation";
+        "summarise option space with trade-offs";
+        "cite source for any factual claim";
+      ];
+    forbidden_tools = [ "shell_write"; "file_write"; "git_push" ];
+    kind = Crew_types.Scholar;
+  }
+
+let verifier_contract : verifier contract =
+  {
+    name = "verifier";
+    description =
+      "Reviewer. Inspects artifacts produced by other personas, \
+       runs evals, asserts correctness. Read + test-run; no \
+       write side effects.";
+    core_responsibilities =
+      [
+        "run declared eval gate";
+        "diff against expected output";
+        "produce verdict with evidence";
+      ];
+    forbidden_tools = [ "shell_write"; "file_write"; "git_push" ];
+    kind = Crew_types.Verifier;
+  }
+
+(* ── Existential capture ──────────────────────────────────────── *)
+
+type any_persona = Any_persona : 'a contract -> any_persona
+
+let all_personas =
+  [
+    Any_persona analyst_contract;
+    Any_persona executor_contract;
+    Any_persona scholar_contract;
+    Any_persona verifier_contract;
+  ]
+
+(* ── Accessors ────────────────────────────────────────────────── *)
+
+let name c = c.name
+let description c = c.description
+let core_responsibilities c = c.core_responsibilities
+let forbidden_tools c = c.forbidden_tools
+let persona_kind c = c.kind
+
+let any_persona_kind (Any_persona c) = c.kind
+let any_name (Any_persona c) = c.name
+let any_description (Any_persona c) = c.description
+
+(* ── JSON ─────────────────────────────────────────────────────── *)
+
+let to_json c =
+  `Assoc
+    [
+      ("name", `String c.name);
+      ("kind", Crew_types.persona_kind_to_json c.kind);
+      ("description", `String c.description);
+      ( "core_responsibilities",
+        `List (List.map (fun s -> `String s) c.core_responsibilities) );
+      ( "forbidden_tools",
+        `List (List.map (fun s -> `String s) c.forbidden_tools) );
+    ]
+
+let any_to_json (Any_persona c) = to_json c

--- a/lib/crew/persona_contract.mli
+++ b/lib/crew/persona_contract.mli
@@ -1,0 +1,112 @@
+(** Persona_contract — phantom-tagged contract record per CREW persona.
+
+    Cycle 25 / Tier A8.
+
+    {1 What this module is}
+
+    A static, type-discriminated contract for each of the four
+    base personas (analyst / executor / scholar / verifier). The
+    contract records carry the persona's core responsibilities,
+    a freeform description, and a forbidden-tools list.
+    Compile-time discrimination via the phantom-tagged
+    {!contract} record excludes mismatched
+    [Analyst-handler over Executor-contract] at the type level.
+
+    {1 Provenance of the contract values}
+
+    A8 hard-codes the four contract values in this module. Tier
+    A8b (deferred follow-up) will replace these with a loader
+    over [config/personas/<kind>/profile.json] without breaking
+    the [analyst_contract] / [executor_contract] / etc. names —
+    the values are addressable in the same form whether sourced
+    from constants or from disk.
+
+    {1 Phantom witness pattern}
+
+    Each persona has an empty witness type ({!analyst},
+    {!executor}, {!scholar}, {!verifier}). The {!contract} record
+    carries a phantom parameter that the constructor narrows to
+    the correct witness, so a function specialised on
+    [analyst contract] cannot be applied to an
+    [executor contract]. The {!any_persona} existential lets
+    callers pack a heterogeneous list when runtime dispatch is
+    appropriate; {!any_persona_kind} extracts the runtime tag.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+(** {1 Phantom witnesses}
+
+    Empty-variant declarations (no inhabitants). External call
+    sites see them as abstract; internal use is purely type-level. *)
+
+type analyst
+type executor
+type scholar
+type verifier
+
+(** {1 Contract record} *)
+
+(** Phantom-tagged contract for one persona. The phantom
+    parameter ['a] is one of the four witness types above and is
+    the compile-time discriminator. The payload is read-only;
+    callers do not construct values directly. *)
+type 'a contract
+
+(** {1 Static contract values} *)
+
+val analyst_contract : analyst contract
+(** The analyst persona contract. Surfaces hidden assumptions,
+    decomposes problems into checkable claims, and flags
+    rationalization patterns. Forbidden from external API calls. *)
+
+val executor_contract : executor contract
+(** The executor persona contract. Carries out concrete actions
+    (file edits, shell commands, tool calls) per a plan handed
+    down by analyst or scholar. Permitted to use the full
+    tool surface. *)
+
+val scholar_contract : scholar contract
+(** The scholar persona contract. Researches prior art, retrieves
+    documentation, and synthesises options. Permitted to use
+    read-only tools (web search, doc fetch); forbidden from
+    write side effects. *)
+
+val verifier_contract : verifier contract
+(** The verifier persona contract. Reviews artifacts produced
+    by other personas, runs evals, asserts correctness. Permitted
+    to read and run tests; forbidden from write side effects. *)
+
+(** {1 Existential capture} *)
+
+type any_persona = Any_persona : 'a contract -> any_persona
+
+val all_personas : any_persona list
+(** All four personas in canonical declaration order
+    [\[Analyst; Executor; Scholar; Verifier\]]. *)
+
+(** {1 Accessors} *)
+
+val name : 'a contract -> string
+(** Lowercase canonical name (matches
+    [Crew_types.persona_kind_to_string] of {!persona_kind}). *)
+
+val description : 'a contract -> string
+
+val core_responsibilities : 'a contract -> string list
+
+val forbidden_tools : 'a contract -> string list
+
+val persona_kind : 'a contract -> Crew_types.persona_kind
+
+val any_persona_kind : any_persona -> Crew_types.persona_kind
+
+val any_name : any_persona -> string
+
+val any_description : any_persona -> string
+
+(** {1 JSON} *)
+
+val to_json : 'a contract -> Yojson.Safe.t
+
+val any_to_json : any_persona -> Yojson.Safe.t

--- a/lib/dune
+++ b/lib/dune
@@ -960,6 +960,8 @@
    masc_mcp.resilience
    ;; Multimodal artifact GADT sub-library (Tier B8) — Code/Image/Audio/Doc + Payload + Provenance
    masc_mcp.multimodal
+   ;; CREW persona contract sub-library (Tier A8) — analyst / executor / scholar / verifier
+   masc_mcp.crew
    )
  (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_let ppx_tla))
  (instrumentation (backend bisect_ppx)))

--- a/test/crew/dune
+++ b/test/crew/dune
@@ -1,0 +1,3 @@
+(tests
+ (names test_crew_types test_persona_contract)
+ (libraries crew shared_types yojson))

--- a/test/crew/test_crew_types.ml
+++ b/test/crew/test_crew_types.ml
@@ -1,0 +1,125 @@
+(* Cycle 25 / Tier A8 — Crew_types tests. *)
+
+module C = Crew.Crew_types
+
+(* ─── persona_kind ────────────────────────────────────────────── *)
+
+let test_all_persona_kinds () =
+  assert (List.length C.all_persona_kinds = 4);
+  assert (C.all_persona_kinds = [ C.Analyst; C.Executor; C.Scholar; C.Verifier ])
+
+let test_persona_kind_to_string () =
+  assert (C.persona_kind_to_string C.Analyst = "analyst");
+  assert (C.persona_kind_to_string C.Executor = "executor");
+  assert (C.persona_kind_to_string C.Scholar = "scholar");
+  assert (C.persona_kind_to_string C.Verifier = "verifier")
+
+let test_persona_kind_of_string_opt_known () =
+  assert (C.persona_kind_of_string_opt "analyst" = Some C.Analyst);
+  assert (C.persona_kind_of_string_opt "Executor" = Some C.Executor);
+  assert (C.persona_kind_of_string_opt "SCHOLAR" = Some C.Scholar)
+
+let test_persona_kind_of_string_opt_unknown () =
+  assert (C.persona_kind_of_string_opt "wizard" = None);
+  assert (C.persona_kind_of_string_opt "" = None)
+
+let test_persona_kind_json_round_trip () =
+  List.iter
+    (fun k ->
+      let json = C.persona_kind_to_json k in
+      match C.persona_kind_of_json json with
+      | Ok back -> assert (back = k)
+      | Error _ -> assert false)
+    C.all_persona_kinds
+
+let test_persona_kind_of_json_rejects_non_string () =
+  match C.persona_kind_of_json (`Int 42) with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+(* ─── vote ────────────────────────────────────────────────────── *)
+
+let test_vote_label () =
+  assert (C.vote_label C.Approve = "approve");
+  assert (C.vote_label (C.Dissent "blocked on X") = "dissent");
+  assert (C.vote_label C.Abstain = "abstain")
+
+let test_vote_round_trip_approve () =
+  match C.vote_of_json (C.vote_to_json C.Approve) with
+  | Ok C.Approve -> ()
+  | _ -> assert false
+
+let test_vote_round_trip_dissent_with_reason () =
+  let v = C.Dissent "tool surface unsafe" in
+  match C.vote_of_json (C.vote_to_json v) with
+  | Ok (C.Dissent r) -> assert (r = "tool surface unsafe")
+  | _ -> assert false
+
+let test_vote_round_trip_abstain () =
+  match C.vote_of_json (C.vote_to_json C.Abstain) with
+  | Ok C.Abstain -> ()
+  | _ -> assert false
+
+let test_vote_dissent_missing_reason_rejected () =
+  let bogus = `Assoc [ ("kind", `String "dissent") ] in
+  match C.vote_of_json bogus with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+(* ─── council_id ──────────────────────────────────────────────── *)
+
+let test_council_id_valid () =
+  match C.council_id_of_string "council-001" with
+  | Ok id ->
+      assert (C.council_id_to_string id = "council-001");
+      assert (C.council_id_to_json id = `String "council-001")
+  | Error _ -> assert false
+
+let test_council_id_empty_rejected () =
+  match C.council_id_of_string "" with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_council_id_too_long_rejected () =
+  let long_s = String.make 65 'a' in
+  match C.council_id_of_string long_s with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_council_id_at_max_length () =
+  let s = String.make 64 'b' in
+  match C.council_id_of_string s with
+  | Ok _ -> ()
+  | Error _ -> assert false
+
+let test_council_id_json_round_trip () =
+  let id = Result.get_ok (C.council_id_of_string "council-roundtrip") in
+  match C.council_id_of_json (C.council_id_to_json id) with
+  | Ok back -> assert (C.council_id_equal back id)
+  | Error _ -> assert false
+
+let test_council_id_compare () =
+  let a = Result.get_ok (C.council_id_of_string "abc") in
+  let b = Result.get_ok (C.council_id_of_string "abd") in
+  assert (C.council_id_compare a b < 0);
+  assert (C.council_id_compare a a = 0)
+
+let () =
+  test_all_persona_kinds ();
+  test_persona_kind_to_string ();
+  test_persona_kind_of_string_opt_known ();
+  test_persona_kind_of_string_opt_unknown ();
+  test_persona_kind_json_round_trip ();
+  test_persona_kind_of_json_rejects_non_string ();
+  test_vote_label ();
+  test_vote_round_trip_approve ();
+  test_vote_round_trip_dissent_with_reason ();
+  test_vote_round_trip_abstain ();
+  test_vote_dissent_missing_reason_rejected ();
+  test_council_id_valid ();
+  test_council_id_empty_rejected ();
+  test_council_id_too_long_rejected ();
+  test_council_id_at_max_length ();
+  test_council_id_json_round_trip ();
+  test_council_id_compare ();
+  print_endline "test_crew_types: all assertions passed"

--- a/test/crew/test_persona_contract.ml
+++ b/test/crew/test_persona_contract.ml
@@ -1,0 +1,139 @@
+(* Cycle 25 / Tier A8 — Persona_contract tests. *)
+
+module P = Crew.Persona_contract
+module C = Crew.Crew_types
+
+(* ─── Static contract values ──────────────────────────────────── *)
+
+let test_analyst_contract_kind () =
+  assert (P.persona_kind P.analyst_contract = C.Analyst);
+  assert (P.name P.analyst_contract = "analyst")
+
+let test_executor_contract_kind () =
+  assert (P.persona_kind P.executor_contract = C.Executor);
+  assert (P.name P.executor_contract = "executor")
+
+let test_scholar_contract_kind () =
+  assert (P.persona_kind P.scholar_contract = C.Scholar);
+  assert (P.name P.scholar_contract = "scholar")
+
+let test_verifier_contract_kind () =
+  assert (P.persona_kind P.verifier_contract = C.Verifier);
+  assert (P.name P.verifier_contract = "verifier")
+
+let test_descriptions_non_empty () =
+  List.iter
+    (fun any ->
+      let d = P.any_description any in
+      assert (String.length d > 0))
+    P.all_personas
+
+let test_responsibilities_non_empty () =
+  let counts =
+    List.map
+      (fun (P.Any_persona c) -> List.length (P.core_responsibilities c))
+      P.all_personas
+  in
+  List.iter (fun n -> assert (n > 0)) counts
+
+(* ─── Forbidden tools follow design intent ────────────────────── *)
+
+let test_executor_has_no_forbidden_tools () =
+  assert (P.forbidden_tools P.executor_contract = [])
+
+let test_scholar_forbids_writes () =
+  let forbidden = P.forbidden_tools P.scholar_contract in
+  assert (List.mem "shell_write" forbidden);
+  assert (List.mem "file_write" forbidden)
+
+let test_verifier_forbids_writes () =
+  let forbidden = P.forbidden_tools P.verifier_contract in
+  assert (List.mem "shell_write" forbidden);
+  assert (List.mem "file_write" forbidden)
+
+let test_analyst_forbids_external_api () =
+  assert (List.mem "external_api_call" (P.forbidden_tools P.analyst_contract))
+
+(* ─── Existential capture ────────────────────────────────────── *)
+
+let test_all_personas_count () =
+  assert (List.length P.all_personas = 4)
+
+let test_all_personas_kinds_in_order () =
+  let kinds = List.map P.any_persona_kind P.all_personas in
+  assert (kinds = [ C.Analyst; C.Executor; C.Scholar; C.Verifier ])
+
+let test_any_persona_round_trip_via_kind () =
+  let names_via_any = List.map P.any_name P.all_personas in
+  let canonical =
+    List.map C.persona_kind_to_string
+      [ C.Analyst; C.Executor; C.Scholar; C.Verifier ]
+  in
+  assert (names_via_any = canonical)
+
+(* ─── JSON ────────────────────────────────────────────────────── *)
+
+let test_to_json_shape () =
+  let j = P.to_json P.analyst_contract in
+  match j with
+  | `Assoc kv ->
+      assert (List.assoc "name" kv = `String "analyst");
+      assert (List.mem_assoc "kind" kv);
+      assert (List.mem_assoc "description" kv);
+      assert (List.mem_assoc "core_responsibilities" kv);
+      assert (List.mem_assoc "forbidden_tools" kv)
+  | _ -> assert false
+
+let test_to_json_kind_round_trip () =
+  let j = P.to_json P.scholar_contract in
+  match j with
+  | `Assoc kv -> (
+      let k_json = List.assoc "kind" kv in
+      match C.persona_kind_of_json k_json with
+      | Ok C.Scholar -> ()
+      | _ -> assert false)
+  | _ -> assert false
+
+let test_any_to_json_matches_to_json () =
+  let direct = P.to_json P.executor_contract in
+  let via_any = P.any_to_json (P.Any_persona P.executor_contract) in
+  assert (direct = via_any)
+
+(* ─── Compile-time discrimination smoke (compiles → passes) ──── *)
+
+(* The following functions exist purely for the compiler to check
+   that contract values cannot be cross-applied between personas.
+   If P.analyst contract and P.executor contract were the same
+   type, the body of [accept_analyst] would compile with
+   [P.executor_contract], breaking type discipline. *)
+
+let _accept_analyst (_c : P.analyst P.contract) = ()
+let _accept_executor (_c : P.executor P.contract) = ()
+let _accept_scholar (_c : P.scholar P.contract) = ()
+let _accept_verifier (_c : P.verifier P.contract) = ()
+
+let test_compile_time_discrimination () =
+  _accept_analyst P.analyst_contract;
+  _accept_executor P.executor_contract;
+  _accept_scholar P.scholar_contract;
+  _accept_verifier P.verifier_contract
+
+let () =
+  test_analyst_contract_kind ();
+  test_executor_contract_kind ();
+  test_scholar_contract_kind ();
+  test_verifier_contract_kind ();
+  test_descriptions_non_empty ();
+  test_responsibilities_non_empty ();
+  test_executor_has_no_forbidden_tools ();
+  test_scholar_forbids_writes ();
+  test_verifier_forbids_writes ();
+  test_analyst_forbids_external_api ();
+  test_all_personas_count ();
+  test_all_personas_kinds_in_order ();
+  test_any_persona_round_trip_via_kind ();
+  test_to_json_shape ();
+  test_to_json_kind_round_trip ();
+  test_any_to_json_matches_to_json ();
+  test_compile_time_discrimination ();
+  print_endline "test_persona_contract: all assertions passed"


### PR DESCRIPTION
## Summary

Tier A8 — greenfield `lib/crew/` sub-library opening Cycle 25 (CREW deliberation framework foundation). Provides the type machinery that A9 (council + 6-phase deliberation) and A10 (consensus + audit + Multimodal Review bridge) build on.

## Modules

| Module | Surface |
|--------|---------|
| `Crew_types` | `persona_kind` variant (ppx_tla derived) + `vote` trinary + `council_id` private string-newtype with length [1, 64] |
| `Persona_contract` | 4 phantom witnesses (`analyst`, `executor`, `scholar`, `verifier`) + `'a contract` record + 4 hard-coded contract values + `any_persona` existential + `all_personas` |

## Forbidden-tools encoding

| Persona | Forbidden |
|---------|-----------|
| `analyst` | `external_api_call`, `shell_write` |
| `executor` | (none — full tool surface) |
| `scholar` | `shell_write`, `file_write`, `git_push` (read + research only) |
| `verifier` | `shell_write`, `file_write`, `git_push` (read + test-run only) |

## Why phantom-tagged contracts (compile-time discrimination)

Each `'a contract` value narrows the phantom to a specific witness, so a handler specialised on `analyst contract` cannot be applied to an `executor contract`. The empty witness types are unconstructible, so misuse fails to type-check at the consumer site rather than surfacing as a runtime tag mismatch. The `any_persona` existential lets callers pack a heterogeneous list when runtime dispatch is appropriate.

The static contract values are hard-coded in this PR. **Tier A8b** (deferred) will swap the source to `config/personas/<kind>/profile.json` without renaming `analyst_contract` / `executor_contract` / etc. — same address, different source.

## Plan §2.2 reference

| Tier | LoC | Risk |
|------|-----|------|
| **A8** | 590 / 9 files | Low (file-disjoint greenfield) |

base=main (latest, `f4f13e999d`), no stack PR.

## Test plan

- [x] `dune build --root . lib/crew test/crew` GREEN
- [x] `dune runtest --root . test/crew --force` GREEN — 34 new assertions
- [x] Race check `gh pr list --search "crew OR persona_contract OR ..."` → 0 open
- [ ] CI Build and Test green after push

## Related

- Cycle 25 entry. Tier A9 (council + 6-phase GADT machine + timeout) follows. Tier A10 (consensus + audit + Multimodal `Review.evaluate` ↔ `Crew_critique` bridge functor) closes Cycle 26.
- Cycle 23 (A6 ✅), Cycle 24 (B8 ✅), Cycle 27 entry (A11 ✅) all merged before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)