### PR TITLE
feat(multimodal): Tier B9 — provenance DAG + callback-driven hydrator (Cycle 24)

### DIFF
--- a/lib/multimodal/multimodal_hydrator.ml
+++ b/lib/multimodal/multimodal_hydrator.ml
@@ -1,0 +1,94 @@
+(* Multimodal_hydrator — Cycle 24 / Tier B9.
+   See multimodal_hydrator.mli for design rationale. *)
+
+module Aid = Shared_types.Artifact_id
+
+type edge = Aid.t * Aid.t
+
+type provenance_dag = { edges : edge list }
+
+let empty_dag = { edges = [] }
+
+let edge_eq (a1, b1) (a2, b2) = Aid.equal a1 a2 && Aid.equal b1 b2
+
+let add_edge dag ~from_id ~to_id =
+  let candidate = (from_id, to_id) in
+  if List.exists (edge_eq candidate) dag.edges then dag
+  else { edges = dag.edges @ [ candidate ] }
+
+let edges dag = dag.edges
+
+let origins_of dag id =
+  List.filter_map
+    (fun (from_id, to_id) ->
+      if Aid.equal to_id id then Some from_id else None)
+    dag.edges
+
+let descendants_of dag id =
+  List.filter_map
+    (fun (from_id, to_id) ->
+      if Aid.equal from_id id then Some to_id else None)
+    dag.edges
+
+let dag_to_json dag =
+  `Assoc
+    [
+      ( "edges",
+        `List
+          (List.map
+             (fun (from_id, to_id) ->
+               `Assoc
+                 [
+                   ("from", Aid.to_json from_id);
+                   ("to", Aid.to_json to_id);
+                 ])
+             dag.edges) );
+    ]
+
+let dag_of_json = function
+  | `Assoc kv -> (
+      match List.assoc_opt "edges" kv with
+      | Some (`List xs) ->
+          let rec loop acc = function
+            | [] -> Ok { edges = List.rev acc }
+            | `Assoc kv :: rest -> (
+                match
+                  ( List.assoc_opt "from" kv,
+                    List.assoc_opt "to" kv )
+                with
+                | Some j_from, Some j_to -> (
+                    match (Aid.of_json j_from, Aid.of_json j_to) with
+                    | Ok from_id, Ok to_id ->
+                        loop ((from_id, to_id) :: acc) rest
+                    | Error e, _ | _, Error e -> Error e)
+                | _ ->
+                    Error
+                      "edge entry must contain 'from' and 'to' fields")
+            | _ -> Error "each edge must be a JSON object"
+          in
+          loop [] xs
+      | None -> Ok { edges = [] }
+      | _ -> Error "'edges' field must be a JSON list")
+  | _ -> Error "provenance_dag must be a JSON object"
+
+(* ── Hydrate ──────────────────────────────────────────────────── *)
+
+type hydrated = {
+  artifact : Artifact.any;
+  origins : Aid.t list;
+  descendants : Aid.t list;
+}
+
+let hydrate ~fetch_artifact ~dag ~ids =
+  List.filter_map
+    (fun id ->
+      match fetch_artifact id with
+      | None -> None
+      | Some artifact ->
+          Some
+            {
+              artifact;
+              origins = origins_of dag id;
+              descendants = descendants_of dag id;
+            })
+    ids

--- a/lib/multimodal/multimodal_hydrator.mli
+++ b/lib/multimodal/multimodal_hydrator.mli
@@ -1,0 +1,100 @@
+(** Multimodal_hydrator — provenance DAG + callback-driven hydration.
+
+    Cycle 24 / Tier B9.
+
+    {1 What this module is}
+
+    A non-invasive layer above {!Artifact.t} that adds:
+    - a {!provenance_dag} value carrying [(from_id → to_id)]
+      edges between artifacts, queryable both directions.
+    - a {!hydrate} routine that, given a [fetch_artifact] callback
+      and a list of artifact ids, produces a list of fully-loaded
+      {!Artifact.any} values along with their provenance neighbours.
+
+    {1 Why a callback (and not a direct keeper_artifact_hydrator wrap)}
+
+    INTEGRATED §A3.2 forbids any modification of
+    [lib/keeper/keeper_artifact_hydrator.\{mli,ml\}] — the existing
+    consumers of that hydrator must continue working unchanged.
+    A direct wrapper inside [lib/multimodal/] would require the
+    multimodal sub-library to import the keeper sub-library, which
+    in turn pulls in [autonomous] / [resilience] / the entire main
+    library, producing a circular dependency.
+
+    Instead this module accepts a [fetch_artifact] callback and
+    leaves wiring to the caller. Tier A7 (which already lives at
+    a level above both [keeper] and [multimodal]) supplies a
+    [fetch_artifact] that delegates to [keeper_artifact_hydrator]
+    on the keeper side, leaving the existing hydrator untouched.
+
+    {1 Provenance DAG}
+
+    The DAG is a flat edge list — no transitive closure cached;
+    queries traverse on demand. Cycles are not enforced absent
+    in {!add_edge} (the keeper does not produce cyclic provenance
+    by construction); future tiers may add a runtime guard if
+    serialised input is admitted.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+(** {1 Provenance DAG} *)
+
+(** [edges = (from_id, to_id)] meaning [to_id] was derived from
+    [from_id]. *)
+type provenance_dag
+
+val empty_dag : provenance_dag
+
+val add_edge :
+  provenance_dag ->
+  from_id:Shared_types.Artifact_id.t ->
+  to_id:Shared_types.Artifact_id.t ->
+  provenance_dag
+(** Append an edge. Duplicates are deduped so the DAG carries at
+    most one edge per [(from_id, to_id)] pair. *)
+
+val edges : provenance_dag -> (Shared_types.Artifact_id.t * Shared_types.Artifact_id.t) list
+(** Edges in insertion order, deduped. *)
+
+val origins_of :
+  provenance_dag ->
+  Shared_types.Artifact_id.t ->
+  Shared_types.Artifact_id.t list
+(** [origins_of dag id] returns all [from_id] for edges
+    [(from_id, id)]. Direct predecessors only — transitive
+    ancestors require iteration. *)
+
+val descendants_of :
+  provenance_dag ->
+  Shared_types.Artifact_id.t ->
+  Shared_types.Artifact_id.t list
+(** [descendants_of dag id] returns all [to_id] for edges
+    [(id, to_id)]. Direct successors only. *)
+
+val dag_to_json : provenance_dag -> Yojson.Safe.t
+
+val dag_of_json : Yojson.Safe.t -> (provenance_dag, string) result
+
+(** {1 Hydrated artifact} *)
+
+(** An {!Artifact.any} bundled with its direct origins and
+    descendants from the [provenance_dag] used for the lookup. *)
+type hydrated = {
+  artifact : Artifact.any;
+  origins : Shared_types.Artifact_id.t list;
+  descendants : Shared_types.Artifact_id.t list;
+}
+
+(** {1 Hydrate}
+
+    Resolve an id list into hydrated artifacts via a caller-
+    supplied [fetch_artifact] callback. Ids that the callback
+    cannot resolve (returns [None]) are skipped silently — the
+    output preserves order of the surviving entries. *)
+
+val hydrate :
+  fetch_artifact:(Shared_types.Artifact_id.t -> Artifact.any option) ->
+  dag:provenance_dag ->
+  ids:Shared_types.Artifact_id.t list ->
+  hydrated list

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_artifact)
+ (names test_artifact test_multimodal_hydrator)
  (libraries multimodal shared_types yojson))

--- a/test/multimodal/test_multimodal_hydrator.ml
+++ b/test/multimodal/test_multimodal_hydrator.ml
@@ -1,0 +1,177 @@
+(* Cycle 24 / Tier B9 — Multimodal_hydrator tests. *)
+
+module H = Multimodal.Multimodal_hydrator
+module A = Multimodal.Artifact
+module P = Multimodal.Payload
+module Pr = Multimodal.Provenance_stub
+module Aid = Shared_types.Artifact_id
+
+(* ─── DAG construction + edge dedupe ──────────────────────────── *)
+
+let test_empty_dag () =
+  assert (H.edges H.empty_dag = [])
+
+let test_add_edge_appends () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let dag = H.add_edge H.empty_dag ~from_id:id1 ~to_id:id2 in
+  let es = H.edges dag in
+  assert (List.length es = 1);
+  match es with
+  | [ (a, b) ] ->
+      assert (Aid.equal a id1);
+      assert (Aid.equal b id2)
+  | _ -> assert false
+
+let test_add_edge_dedupes_same_pair () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let dag =
+    H.empty_dag
+    |> H.add_edge ~from_id:id1 ~to_id:id2
+    |> H.add_edge ~from_id:id1 ~to_id:id2
+  in
+  assert (List.length (H.edges dag) = 1)
+
+let test_add_edge_admits_distinct_pairs () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let id3 = Aid.generate () in
+  let dag =
+    H.empty_dag
+    |> H.add_edge ~from_id:id1 ~to_id:id2
+    |> H.add_edge ~from_id:id2 ~to_id:id3
+    |> H.add_edge ~from_id:id1 ~to_id:id3
+  in
+  assert (List.length (H.edges dag) = 3)
+
+(* ─── DAG queries ─────────────────────────────────────────────── *)
+
+let test_origins_of () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let id3 = Aid.generate () in
+  let dag =
+    H.empty_dag
+    |> H.add_edge ~from_id:id1 ~to_id:id3
+    |> H.add_edge ~from_id:id2 ~to_id:id3
+  in
+  let origins = H.origins_of dag id3 in
+  assert (List.length origins = 2);
+  assert (List.exists (Aid.equal id1) origins);
+  assert (List.exists (Aid.equal id2) origins)
+
+let test_descendants_of () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let id3 = Aid.generate () in
+  let dag =
+    H.empty_dag
+    |> H.add_edge ~from_id:id1 ~to_id:id2
+    |> H.add_edge ~from_id:id1 ~to_id:id3
+  in
+  let descs = H.descendants_of dag id1 in
+  assert (List.length descs = 2);
+  assert (List.exists (Aid.equal id2) descs);
+  assert (List.exists (Aid.equal id3) descs)
+
+let test_origins_of_unknown_returns_empty () =
+  let id = Aid.generate () in
+  assert (H.origins_of H.empty_dag id = []);
+  assert (H.descendants_of H.empty_dag id = [])
+
+(* ─── DAG JSON round-trip ─────────────────────────────────────── *)
+
+let test_dag_json_round_trip () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let dag =
+    H.empty_dag |> H.add_edge ~from_id:id1 ~to_id:id2
+  in
+  match H.dag_of_json (H.dag_to_json dag) with
+  | Ok back ->
+      let es = H.edges back in
+      assert (List.length es = 1);
+      let from_id, to_id = List.hd es in
+      assert (Aid.equal from_id id1);
+      assert (Aid.equal to_id id2)
+  | Error _ -> assert false
+
+let test_dag_of_json_missing_edges_field_ok_empty () =
+  match H.dag_of_json (`Assoc []) with
+  | Ok dag -> assert (H.edges dag = [])
+  | Error _ -> assert false
+
+let test_dag_of_json_malformed_rejected () =
+  match H.dag_of_json (`String "not-an-object") with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+(* ─── Hydrate ─────────────────────────────────────────────────── *)
+
+let make_doc_artifact id : A.doc A.t =
+  {
+    A.id;
+    kind = A.Doc;
+    payload = P.Blob_ref (Aid.to_string id ^ "-blob");
+    metadata = `Null;
+    provenance = Pr.empty ~created_by:"executor" ~created_at:1.0;
+  }
+[@@warning "-37"]
+
+let test_hydrate_resolves_known_ids () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let store = [ (id1, A.Any (make_doc_artifact id1)); (id2, A.Any (make_doc_artifact id2)) ] in
+  let fetch id =
+    List.find_map
+      (fun (k, v) -> if Aid.equal k id then Some v else None)
+      store
+  in
+  let dag = H.add_edge H.empty_dag ~from_id:id1 ~to_id:id2 in
+  let result = H.hydrate ~fetch_artifact:fetch ~dag ~ids:[ id1; id2 ] in
+  assert (List.length result = 2);
+  let h2 = List.nth result 1 in
+  assert (List.length h2.origins = 1);
+  assert (Aid.equal (List.hd h2.origins) id1);
+  assert (h2.descendants = [])
+
+let test_hydrate_skips_unknown_ids () =
+  let id_known = Aid.generate () in
+  let id_missing = Aid.generate () in
+  let fetch id =
+    if Aid.equal id id_known then
+      Some (A.Any (make_doc_artifact id_known))
+    else None
+  in
+  let result =
+    H.hydrate ~fetch_artifact:fetch ~dag:H.empty_dag
+      ~ids:[ id_missing; id_known ]
+  in
+  (* missing was skipped, only known artifact survives. *)
+  assert (List.length result = 1);
+  let h = List.hd result in
+  assert (Aid.equal (A.any_id h.artifact) id_known)
+
+let test_hydrate_empty_input () =
+  let fetch _ = None in
+  let result =
+    H.hydrate ~fetch_artifact:fetch ~dag:H.empty_dag ~ids:[]
+  in
+  assert (result = [])
+
+let () =
+  test_empty_dag ();
+  test_add_edge_appends ();
+  test_add_edge_dedupes_same_pair ();
+  test_add_edge_admits_distinct_pairs ();
+  test_origins_of ();
+  test_descendants_of ();
+  test_origins_of_unknown_returns_empty ();
+  test_dag_json_round_trip ();
+  test_dag_of_json_missing_edges_field_ok_empty ();
+  test_dag_of_json_malformed_rejected ();
+  test_hydrate_resolves_known_ids ();
+  test_hydrate_skips_unknown_ids ();
+  test_hydrate_empty_input ();
+  print_endline "test_multimodal_hydrator: all assertions passed"


### PR DESCRIPTION
## Summary

Tier B9 — adds `Multimodal_hydrator` to `lib/multimodal/`: a non-invasive layer above `Artifact` carrying a **provenance DAG** of artifact-id edges and a **hydrate** routine that resolves an id list through a caller-supplied `fetch_artifact` callback, bundling each resolved artifact with its direct origins/descendants from the DAG.

## Why callback (not direct `keeper_artifact_hydrator` wrap)

INTEGRATED §A3.2 forbids any modification of `lib/keeper/keeper_artifact_hydrator.{mli,ml}`. A direct wrapper inside `lib/multimodal/` would force the multimodal sub-library to import keeper — which transitively pulls `autonomous` / `resilience` / the entire main library — producing a circular dependency.

This module accepts a `fetch_artifact` callback instead, leaving wiring to Tier A7 which already lives at a level above both keeper and multimodal. The existing `keeper_artifact_hydrator` stays untouched as required by the design.

## Surfaces

| Surface | Behaviour |
|---------|-----------|
| `provenance_dag` (opaque) | Flat edge list `(from_id, to_id)` |
| `add_edge` | Dedupes same-pair appends |
| `origins_of` / `descendants_of` | Direct neighbours only — transitive iteration is caller-side |
| `dag_to_json` / `dag_of_json` | Round-trip with malformed-input rejection |
| `hydrate` | Resolves ids through callback; silently skips unknown ids; preserves order of survivors |
| `hydrated` record | `{ artifact; origins; descendants }` per resolved id |

## Plan §2.2 reference

| Tier | LoC | Risk |
|------|-----|------|
| **B9** | 372 / 4 files | Medium (INTEGRATED A3.2 mitigation pattern) |

base=main (`3b4e12f529`, after A11 merge).

## Test plan

- [x] `dune build --root . lib/multimodal test/multimodal` GREEN
- [x] `dune runtest --root . test/multimodal --force` GREEN — 13 new assertions
- [x] Race check `gh pr list --search "multimodal_hydrator OR ..."` → 0 open
- [ ] CI Build and Test green after push

## Related

- Cycle 24 progresses. Tier A7 (Multimodal create + workspace + Tool_set integration + Dashboard `/api/v1/artifacts/*` route) supplies the actual `fetch_artifact` callback that delegates to `keeper_artifact_hydrator` on the keeper side.
- B8 (✅ multimodal artifact GADT) already in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)