### PR TITLE
feat(resilience): Tier A11b — Recovery → Degradation level bridge (Cycle 27)

### DIFF
--- a/lib/resilience/degradation.ml
+++ b/lib/resilience/degradation.ml
@@ -108,3 +108,18 @@ let apply_level_to_strategy : type a.
               (error_mode_kind_label mode);
           cleanup = (fun () -> ());
         }
+
+(* ── Recovery → Degradation bridge ────────────────────────────── *)
+
+let of_recovery_recommended_level (mode : Recovery.error_mode) :
+    any_level option =
+  match mode with
+  | Recovery.DegradationRequired { recommended_level; _ } ->
+      of_int_opt recommended_level
+  | _ -> None
+
+let strategy_for_error_mode (mode : Recovery.error_mode) :
+    [ `Retry | `Fallback | `Handoff | `Abort ] Recovery.strategy =
+  match of_recovery_recommended_level mode with
+  | Some (Any_level level) -> apply_level_to_strategy level mode
+  | None -> Recovery.default_strategy mode

--- a/lib/resilience/degradation.mli
+++ b/lib/resilience/degradation.mli
@@ -111,3 +111,41 @@ val apply_level_to_strategy :
     Higher levels are progressively more conservative — once
     skeleton or fallback is required, retrying or substituting
     is no longer appropriate. *)
+
+(** {1 Recovery → Degradation bridge}
+
+    The B6 [Recovery.error_mode.DegradationRequired] constructor
+    carries [recommended_level : int] (per the I5 stub note
+    pending Tier A11). A direct retype to [Degradation.level]
+    on the B6 side would create a circular dependency:
+    [Recovery → Degradation → Recovery]. Instead the conversion
+    lives here, where [Degradation] already imports
+    [Recovery.error_mode].
+
+    {!of_recovery_recommended_level} interprets the integer as
+    the lattice ordinal ([1..4]); other modes return [None].
+    {!strategy_for_error_mode} composes that lookup with
+    {!apply_level_to_strategy} so callers obtain the level-
+    adjusted strategy in one call. *)
+
+val of_recovery_recommended_level :
+  Recovery.error_mode -> any_level option
+(** [of_recovery_recommended_level mode] returns the
+    {!any_level} encoded by [mode]'s [recommended_level] field
+    when [mode] is [Recovery.DegradationRequired { recommended_level; _ }]
+    and [recommended_level] is in [\[1, 4\]]. Returns [None] for
+    any other failure mode and for out-of-range integers. *)
+
+val strategy_for_error_mode :
+  Recovery.error_mode ->
+  [ `Retry | `Fallback | `Handoff | `Abort ] Recovery.strategy
+(** [strategy_for_error_mode mode] returns:
+    - {!apply_level_to_strategy} of the encoded level when [mode]
+      is [DegradationRequired] with a level in [\[1, 4\]].
+    - {!Recovery.default_strategy} of [mode] otherwise (other
+      failure kinds, and [DegradationRequired] with an
+      out-of-range integer).
+
+    This is the canonical entrypoint for callers that have an
+    [error_mode] in hand and want a strategy without first
+    extracting the level. *)

--- a/test/resilience/test_degradation.ml
+++ b/test/resilience/test_degradation.ml
@@ -95,6 +95,57 @@ let test_l4_forces_abort_regardless () =
   | R.Abort _ -> ()
   | _ -> assert false
 
+(* ─── Recovery → Degradation bridge (A11b) ────────────────────── *)
+
+let test_of_recovery_recommended_level_for_degradation_required () =
+  let mode = R.degradation_required ~detail:"target=2" ~recommended_level:2 in
+  match D.of_recovery_recommended_level mode with
+  | Some (D.Any_level level) -> assert (D.to_int level = 2)
+  | None -> assert false
+
+let test_of_recovery_recommended_level_returns_none_for_other_modes () =
+  assert (D.of_recovery_recommended_level (transient_mode ()) = None);
+  assert (D.of_recovery_recommended_level (permanent_handoff_mode ()) = None);
+  assert (D.of_recovery_recommended_level (resource_mode ()) = None)
+
+let test_of_recovery_recommended_level_returns_none_for_out_of_range () =
+  let mode = R.degradation_required ~detail:"bad" ~recommended_level:0 in
+  assert (D.of_recovery_recommended_level mode = None);
+  let mode2 = R.degradation_required ~detail:"bad" ~recommended_level:5 in
+  assert (D.of_recovery_recommended_level mode2 = None)
+
+let test_strategy_for_error_mode_uses_level_when_present () =
+  (* L1 → canonical (Recovery.default_strategy of DegradationRequired
+     is Handoff per B6 mapping). Verifying L1 path still returns
+     Handoff confirms the mode→level→strategy round-trip. *)
+  let mode_l1 = R.degradation_required ~detail:"x" ~recommended_level:1 in
+  (match D.strategy_for_error_mode mode_l1 with
+   | R.Handoff _ -> ()
+   | _ -> assert false);
+  (* L4 forces Abort regardless of mode. *)
+  let mode_l4 = R.degradation_required ~detail:"x" ~recommended_level:4 in
+  match D.strategy_for_error_mode mode_l4 with
+  | R.Abort _ -> ()
+  | _ -> assert false
+
+let test_strategy_for_error_mode_falls_back_to_default_for_other_modes () =
+  (* Transient → Recovery.default_strategy → Retry. *)
+  (match D.strategy_for_error_mode (transient_mode ()) with
+   | R.Retry _ -> ()
+   | _ -> assert false);
+  (* Permanent handoff → Handoff via canonical default. *)
+  match D.strategy_for_error_mode (permanent_handoff_mode ()) with
+  | R.Handoff _ -> ()
+  | _ -> assert false
+
+let test_strategy_for_error_mode_falls_back_when_level_out_of_range () =
+  (* recommended_level = 99 → of_recovery_recommended_level = None
+     → falls back to canonical default (Handoff for DegradationRequired). *)
+  let mode = R.degradation_required ~detail:"x" ~recommended_level:99 in
+  match D.strategy_for_error_mode mode with
+  | R.Handoff _ -> ()
+  | _ -> assert false
+
 let () =
   test_all_level_tags ();
   test_level_to_tag_round_trip ();
@@ -109,4 +160,10 @@ let () =
   test_l2_preserves_handoff_for_permanent ();
   test_l3_forces_handoff_regardless ();
   test_l4_forces_abort_regardless ();
+  test_of_recovery_recommended_level_for_degradation_required ();
+  test_of_recovery_recommended_level_returns_none_for_other_modes ();
+  test_of_recovery_recommended_level_returns_none_for_out_of_range ();
+  test_strategy_for_error_mode_uses_level_when_present ();
+  test_strategy_for_error_mode_falls_back_to_default_for_other_modes ();
+  test_strategy_for_error_mode_falls_back_when_level_out_of_range ();
   print_endline "test_degradation: all assertions passed"


### PR DESCRIPTION
## Summary

Tier A11b — closes the deferred item from A11 first PR. Adds two helpers to `lib/resilience/degradation` that bridge `Recovery.error_mode` to the `Degradation` lattice without inducing a circular dependency.

## Why on the Degradation side (not Recovery)

A direct retype of `Recovery.DegradationRequired.recommended_level` from `int` → `Degradation.level` would require `Recovery` to import `Degradation`. But `Degradation` already imports `Recovery` (`apply_level_to_strategy : 'a level -> Recovery.error_mode -> ... Recovery.strategy`). Circular dependency.

Putting the bridge on the `Degradation` side preserves the one-way dependency and is the canonical location for callers that hold a `Recovery.error_mode` and want a strategy without first extracting the level.

## New surfaces

| Function | Behaviour |
|----------|-----------|
| `of_recovery_recommended_level : Recovery.error_mode -> any_level option` | `Some (Any_level Lk)` for `DegradationRequired { recommended_level = k; ... }` with `k ∈ [1,4]`; `None` otherwise. |
| `strategy_for_error_mode : Recovery.error_mode -> _ Recovery.strategy` | Composes the lookup with `apply_level_to_strategy` for valid `DegradationRequired` modes. Falls back to `Recovery.default_strategy` for other modes and out-of-range levels. |

## Test plan

- [x] `dune build --root . lib/resilience test/resilience` GREEN
- [x] `dune runtest --root . test/resilience --force` GREEN — 6 new assertions across:
  - `of_recovery_recommended_level` for `DegradationRequired` (round-trip int → level)
  - `None` for non-`DegradationRequired` modes (Transient, Permanent, ResourceExhausted)
  - `None` for out-of-range integers (0, 5)
  - `strategy_for_error_mode` uses level when present (L1 → Handoff via canonical, L4 → Abort forced)
  - `strategy_for_error_mode` falls back to canonical for other modes
  - `strategy_for_error_mode` falls back to canonical when level is out of range
- [x] Race check `gh pr list --search "degradation OR Tier A11b"` → 0 open
- [ ] CI Build and Test green after push

## Plan §16 reference

| Tier | LoC | Risk |
|------|-----|------|
| **A11b** | 110 / 3 files | Low (additive helpers only — no signature change to existing surface) |

base=main (`00a6b8b1bd`).

## Related

- Cycle 27 follow-up. The remaining A11 deferred item (real Eio.Switch parallel race in `Speculative.execute`) lands separately.
- Cycle 23 (A6), Cycle 24 (B8), Cycle 27 entry (A11) all merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)