### PR TITLE
test(dashboard): a11y batch 9 — scroll-to-top/number-input/heartbeat-strip

### DIFF
--- a/dashboard/src/components/common/heartbeat-strip.a11y.test.ts
+++ b/dashboard/src/components/common/heartbeat-strip.a11y.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for HeartbeatStrip — full history bar paired with
+// the streak/uptime chips already covered (#11815). Each strip cell is
+// up/down/unknown coded; tests guard that the strip surface carries
+// enough semantic information for AT (label + per-cell title) and
+// that the tone palette stays above contrast threshold.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { HeartbeatStrip } from './heartbeat-strip'
+import type { HeartbeatState } from '../../lib/heartbeat-history'
+
+const allUp: HeartbeatState[] = Array<HeartbeatState>(60).fill('up')
+const mixed: HeartbeatState[] = [
+  ...Array<HeartbeatState>(40).fill('up'),
+  ...Array<HeartbeatState>(15).fill('down'),
+  ...Array<HeartbeatState>(5).fill('unknown'),
+]
+const allDown: HeartbeatState[] = Array<HeartbeatState>(60).fill('down')
+
+describe('HeartbeatStrip a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('all-up steady state passes axe', async () => {
+    render(html`<${HeartbeatStrip} history=${allUp} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('mixed history (up/down/unknown) passes axe', async () => {
+    render(html`<${HeartbeatStrip} history=${mixed} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('all-down state passes axe (failure tone sweep)', async () => {
+    render(html`<${HeartbeatStrip} history=${allDown} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('empty history renders accessibly', async () => {
+    render(html`<${HeartbeatStrip} history=${[]} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/number-input.a11y.test.ts
+++ b/dashboard/src/components/common/number-input.a11y.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for NumberInput. Form input — same accessible-name
+// strategy as Input/Checkbox/Select. Component's JSDoc warns dropping
+// id/ariaLabel is a known regression; axe enforces it.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { NumberInput } from './number-input'
+
+describe('NumberInput a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('with ariaLabel passes axe', async () => {
+    render(html`<${NumberInput} ariaLabel="Quantity" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with id + external <label for=""> passes axe', async () => {
+    render(
+      html`<div>
+        <label for="qty">Quantity</label>
+        <${NumberInput} id="qty" />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with min/max/step + ariaLabel passes axe', async () => {
+    render(
+      html`<${NumberInput}
+        ariaLabel="Sample size"
+        min=${1}
+        max=${100}
+        step=${1}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('disabled + ariaLabel passes axe', async () => {
+    render(
+      html`<${NumberInput} ariaLabel="Locked" disabled=${true} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('placeholder + ariaLabel passes axe', async () => {
+    render(
+      html`<${NumberInput} ariaLabel="Optional count" placeholder="0" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/scroll-to-top.a11y.test.ts
+++ b/dashboard/src/components/common/scroll-to-top.a11y.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for ScrollToTopButton — floating "back to top"
+// affordance. Icon-only button; tests guard the accessible-name
+// contract (the wrapper button must have an aria-label since the
+// only child is a ChevronUp svg).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { ScrollToTopButton } from './scroll-to-top'
+
+describe('ScrollToTopButton a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    // Mock scroll position so the button renders.
+    Object.defineProperty(window, 'scrollY', {
+      value: 1000,
+      writable: true,
+      configurable: true,
+    })
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly when scroll position triggers visibility', async () => {
+    render(html`<${ScrollToTopButton} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with custom threshold prop passes axe', async () => {
+    render(html`<${ScrollToTopButton} thresholdPx=${200} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

Ninth a11y test batch. Three orthogonal patterns:

| Atom | Pattern | Cases |
|------|---------|-------|
| **ScrollToTopButton** | floating icon button | 2 (visible state + custom threshold) |
| **NumberInput** | numeric form input | 5 (ariaLabel + id+\`<label>\` + min/max/step + disabled + placeholder) |
| **HeartbeatStrip** | history bar (pairs with chips from #11815) | 4 (all-up + mixed + all-down + empty) |

11 cases, all pass. \`tsc --noEmit\` clean.

## Why these picks

- **ScrollToTopButton** — icon-only with no text child. Drops the wrapper button's aria-label = no accessible name regression. Mocks \`window.scrollY\` so the button renders.
- **NumberInput** — third numeric/form input atom (after Input + Checkbox + Select). Same accessible-name strategy; locks the contract.
- **HeartbeatStrip** — completes the heartbeat-* family axe coverage (chips already in #11815). Per-cell tone palette + empty-history null path.

## Pivot rationale (Cycle 25 honest disclosure)

Cycle 25 originally targeted \`button-secondary/ghost/danger\` Lane A extension building on #11839 (button-primary). #11839 is BLOCKED so stacking carried force-push patch-loss risk per memory \`Stack PR base force-push loses patches\`. Pivoted to safe Lane C chunk.

## Verification

- [x] \`pnpm vitest run src/components/common/{scroll-to-top,number-input,heartbeat-strip}.a11y.test.ts\` → 11/11 pass
- [x] \`pnpm tsc --noEmit\` clean
- [ ] CI checks (this PR)

## Cumulative coverage

21 atoms in main + ~12 pending atoms across #11815/#11818/#11836/this PR = **~33 atoms / ~120 cases** once all pending land.

## Related

- Depends on (merged): #11676 jest-axe wiring
- Sibling pending: #11815, #11818, #11836
- Spec: design_system_v2 §6.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)