### PR TITLE
test(handover): exercise trigger_reason mapping via public create_handover API

### DIFF
--- a/test/test_handover_eio_coverage.ml
+++ b/test/test_handover_eio_coverage.ml
@@ -128,27 +128,42 @@ let test_trigger_reason_task_complete () =
   | _ -> fail "expected TaskComplete"
 
 (* ============================================================
-   trigger_reason_to_string Tests
+   trigger_reason → handover_reason Tests
+
+   Verifies the [trigger_reason → string] mapping observed via the
+   public [create_handover] API. The internal helper
+   [Handover_eio.trigger_reason_to_string] (intentionally hidden by
+   the [handover_eio.mli] typed surface, cycle 134) is exercised
+   transitively: [create_handover] sets [handover_reason] to that
+   helper's output, so the resulting record's [handover_reason]
+   field is the canonical observation point for callers.
    ============================================================ *)
 
+let reason_string_for reason =
+  let r =
+    Handover_eio.create_handover
+      ~from_agent:"" ~task_id:"" ~session_id:"" ~reason
+  in
+  r.handover_reason
+
 let test_trigger_reason_to_string_context_limit () =
-  let s = Handover_eio.trigger_reason_to_string (Handover_eio.ContextLimit 85) in
+  let s = reason_string_for (Handover_eio.ContextLimit 85) in
   check string "context_limit" "context_limit_85" s
 
 let test_trigger_reason_to_string_timeout () =
-  let s = Handover_eio.trigger_reason_to_string (Handover_eio.Timeout 600) in
+  let s = reason_string_for (Handover_eio.Timeout 600) in
   check string "timeout" "timeout_600s" s
 
 let test_trigger_reason_to_string_explicit () =
-  let s = Handover_eio.trigger_reason_to_string Handover_eio.Explicit in
+  let s = reason_string_for Handover_eio.Explicit in
   check string "explicit" "explicit" s
 
 let test_trigger_reason_to_string_fatal_error () =
-  let s = Handover_eio.trigger_reason_to_string (Handover_eio.FatalError "Crash") in
+  let s = reason_string_for (Handover_eio.FatalError "Crash") in
   check string "fatal_error" "error: Crash" s
 
 let test_trigger_reason_to_string_task_complete () =
-  let s = Handover_eio.trigger_reason_to_string Handover_eio.TaskComplete in
+  let s = reason_string_for Handover_eio.TaskComplete in
   check string "task_complete" "task_complete" s
 
 (* ============================================================


### PR DESCRIPTION
## Summary

\`test_handover_eio_coverage.ml\`의 5개 \`test_trigger_reason_to_string_*\` 케이스가 \`Handover_eio.trigger_reason_to_string\`을 직접 호출하고 있었지만, PR #11765 (cycle 134)이 \`handover_eio.mli\`를 추가하면서 이 helper를 의도적으로 internal로 숨겼습니다. \`@check\` 빌드가 깨졌습니다:

\`\`\`
Error: Unbound value Handover_eio.trigger_reason_to_string
\`\`\`

## Approach

.mli 경계를 다시 뚫는 대신 같은 behavior를 public API로 검증합니다. .mli가 명시적으로 \`handover_reason = trigger_reason_to_string reason\`을 문서화하므로, \`create_handover\`가 만든 record의 \`handover_reason\` 필드가 caller-side에서 보는 canonical 출력 지점입니다.

\`\`\`ocaml
let reason_string_for reason =
  let r = Handover_eio.create_handover
            ~from_agent:\"\" ~task_id:\"\" ~session_id:\"\" ~reason
  in
  r.handover_reason
\`\`\`

5개 case가 이 helper를 거쳐 같은 mapping을 검증.

## Why this is the right fix

- **테스트는 behavior를 verify해야지 implementation을 verify하면 안 됩니다.** 기존 test가 internal helper를 직접 호출한 건 implementation testing — .mli 추가가 이걸 표면화시킨 셈.
- **.mli 경계 보존.** PR #11765의 typed surface 결정을 존중.
- **검증 범위 동일.** 5개 trigger_reason variant 모두 같은 expected string 검증.

## Test plan

- [x] \`dune build test/test_handover_eio_coverage.exe\` green
- [x] \`dune exec test/test_handover_eio_coverage.exe\` 29/29 pass

## Pattern

같은 .mli 추가 cycle 부산물로 깨진 다른 test 파일들(test_dashboard_namespace_truth.ml, test_voice_config.ml, test_context_compact_oas_coverage.ml 등)도 동일 패턴(internal 호출 → public API rewrite)으로 처리 가능. 이 PR은 한 파일 scope.