### PR TITLE
feat(voice): expose Voice_config.parse_json + simplify test composition

### DIFF
--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -345,6 +345,14 @@ let parse_local_playback json =
   | `Null -> Ok { enabled = false; agents = [] }
   | _ -> Error "root.local_playback must be an object"
 
+let parse_json json =
+  let open Result in
+  let* tts = parse_tts json in
+  let* stt = parse_stt json in
+  let* session = parse_session json in
+  let* local_playback = parse_local_playback json in
+  Ok { tts; stt; session; local_playback }
+
 let load () =
   let path = config_path () in
   if not (Sys.file_exists path) then
@@ -352,12 +360,7 @@ let load () =
   else
     try
       let json = Safe_ops.read_json_eio path in
-      let open Result in
-      let* tts = parse_tts json in
-      let* stt = parse_stt json in
-      let* session = parse_session json in
-      let* local_playback = parse_local_playback json in
-      Ok { tts; stt; session; local_playback }
+      parse_json json
     with
     | Yojson.Json_error error ->
         Error (Printf.sprintf "invalid voice config json: %s" error)

--- a/lib/voice/voice_config.mli
+++ b/lib/voice/voice_config.mli
@@ -106,6 +106,13 @@ val config_path : unit -> string
 
 (** {1 Loading} *)
 
+val parse_json : Yojson.Safe.t -> (t, string) result
+(** [parse_json json] parses an in-memory JSON value into a [t].
+    Composes the per-section parsers (tts, stt, session,
+    local_playback). Pure — no filesystem access. Used by [load]
+    after IO and by tests that exercise edge cases without a
+    file. *)
+
 val load : unit -> (t, string) result
 (** [load ()] reads + parses the voice config from the first
     existing path in:

--- a/test/test_voice_config.ml
+++ b/test/test_voice_config.ml
@@ -27,13 +27,7 @@ let minimal_config_json ~session_endpoints =
 
 let parse json_str =
   let json = Yojson.Safe.from_string json_str in
-  let open Result in
-  let ( let* ) = bind in
-  let* tts = Vc.parse_tts json in
-  let* stt = Vc.parse_stt json in
-  let* session = Vc.parse_session json in
-  let* local_playback = Vc.parse_local_playback json in
-  Ok { Vc.tts; stt; session; local_playback }
+  Vc.parse_json json
 
 let test_session_empty_endpoints_ok () =
   let json = minimal_config_json ~session_endpoints:"[]" in


### PR DESCRIPTION
## Summary

\`test/test_voice_config.ml\`이 \`Voice_config\`의 4개 internal helper(\`parse_tts\`, \`parse_stt\`, \`parse_session\`, \`parse_local_playback\`)를 직접 composing하고 있었는데, .mli typed surface cycle이 이들을 hide하면서 \`@check\` 빌드가 깨졌습니다.

\`\`\`
Error: Unbound value Vc.parse_tts
\`\`\`

## Fix

\`load\` 함수가 이미 같은 4-step composition을 수행하고 있어, 그 부분을 \`parse_json\`이라는 새 public function으로 추출했습니다.

\`\`\`ocaml
(* lib/voice/voice_config.mli *)
val parse_json : Yojson.Safe.t -> (t, string) result
\`\`\`

- \`load\`는 IO + exception handling 후 \`parse_json\` 호출. 동작 변경 없음.
- \`parse_json\`은 pure — filesystem/exception 무관.
- 테스트의 \`parse\` helper는 한 줄로 축소: \`Vc.parse_json json\`.

## Why this is the right fix

| 측면 | 이전 | 변경 후 |
|---|---|---|
| Public API surface | \`load\` (file-only) | \`load\` + \`parse_json\` (pure) |
| Test 의존성 | 4 internal helpers | 1 public function |
| .mli 경계 | 4 internal hidden, but test broken | 4 internal still hidden, single public entry |
| Edge-case coverage 가능성 | YES (private 호출로) | YES (public API로) |

internal helper들은 그대로 hide 유지 — 새 surface는 single public composition entry point 하나뿐.

## Test plan

- [x] \`dune build test/test_voice_config.exe\` green
- [x] \`dune exec test/test_voice_config.exe\` 5/5 pass
- [x] Race check (\`gh pr list --search\`) 0건

## Pattern series

이 PR은 .mli typed surface cycle 부산물로 깨진 test 파일들을 처리하는 시리즈의 일부입니다:

- **#11844** (MERGED): \`test_handover_eio_coverage\` — public API rewrite (helper 노출 불필요)
- **이 PR**: \`test_voice_config\` — single public composition entry 추가
- 남은 영역: \`test_dashboard_namespace_truth\`, \`test_context_compact_oas_coverage\` 등 (각각 다른 fix mechanism 필요)