### PR TITLE
spec(multimodal): add MultimodalArtifact.tla — B8 catch-up well-formedness invariants

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -200,6 +200,9 @@ run_tlc_buggy "$REPO_ROOT/specs/state-product" "CoordinationProduct.tla"
 run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 
+# Cycle 24 — Multimodal artifact GADT well-formedness (Tier B8 catch-up).
+run_tlc "$REPO_ROOT/specs/multimodal" "MultimodalArtifact.tla"
+
 # Optional: run TraceSpec if --trace flag provided
 if [ "${1:-}" = "--trace" ]; then
   TRACE_SPEC="$REPO_ROOT/specs/keeper-state-machine/KeeperTraceSpec.tla"

--- a/specs/multimodal/MultimodalArtifact.cfg
+++ b/specs/multimodal/MultimodalArtifact.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    ArtifactIds = {a1, a2}
+    Personas = {executor}
+
+INVARIANTS
+    TypeOK
+    ArtifactIdMatchesKey
+    DAGRefIntegrity
+    NoSelfLoops
+    ProvenanceOriginsLive

--- a/specs/multimodal/MultimodalArtifact.tla
+++ b/specs/multimodal/MultimodalArtifact.tla
@@ -1,0 +1,159 @@
+---- MODULE MultimodalArtifact ----
+\* Cycle 24 / Tier B8 catch-up spec.
+\*
+\* Mirrors the well-formedness invariants over [Multimodal.Artifact],
+\* [Multimodal.Payload], and [Multimodal.Provenance_stub] from
+\* lib/multimodal/. The runtime artifact carries:
+\*   - an opaque Shared_types.Artifact_id.t (UUID v7),
+\*   - a phantom-tagged kind in {Code, Image, Audio, Doc},
+\*   - a Payload variant in {Lazy_payload, Blob_ref, Streaming},
+\*   - a Provenance_stub record carrying origin artifact ids.
+\*
+\* This spec models a finite ArtifactIds universe and an artifacts
+\* function ArtifactIds -> Artifact, where each artifact carries a
+\* [present : BOOLEAN] field marking whether it has been realised
+\* via CreateArtifact. A separate dag variable carries the directed
+\* (from_id, to_id) edges introduced by Tier B9.
+\*
+\* The [present] field exists for the model only. The runtime
+\* counterpart simply does not have an entry until [CreateArtifact]
+\* is called; we use a present flag here because TLC cannot
+\* fingerprint a state where a function returns heterogeneous types
+\* (record vs sentinel). All present=FALSE artifacts are equivalent
+\* "not yet created" placeholders.
+\*
+\* OCaml <-> TLA+ mapping:
+\*
+\*   variable                 | OCaml site
+\*   -------------------------+---------------------------------------------
+\*   artifacts[id].present    | (modelling artefact only — runtime
+\*                            | tracks via map presence)
+\*   artifacts[id].kind       | Multimodal.Artifact.kind_to_tag
+\*   artifacts[id].payload_kind
+\*                            | Multimodal.Payload.t discriminator
+\*   artifacts[id].provenance | Multimodal.Provenance_stub.t
+\*   dag                      | Multimodal_hydrator.provenance_dag.edges
+\*
+\* Out-of-scope (defer to A7 / B9 follow-ups):
+\*   - Lazy_payload closure semantics / Blob_ref bytes,
+\*   - hydration ordering and concurrency,
+\*   - Tool_set integration (Tier A7).
+
+EXTENDS TLC, Naturals, FiniteSets
+
+CONSTANTS
+    ArtifactIds,    \* finite universe of artifact ids
+    Personas        \* finite universe of creator names
+
+\* The four kind tags exposed by Multimodal.Artifact.kind_tag.
+Kinds == {"code", "image", "audio", "doc"}
+
+\* The three payload discriminators exposed by Multimodal.Payload.t.
+PayloadKinds == {"lazy", "blob_ref", "streaming"}
+
+Provenance == [
+    origin_artifact_ids : SUBSET ArtifactIds,
+    created_by : Personas,
+    created_at : Nat
+]
+
+Artifact == [
+    id : ArtifactIds,
+    kind : Kinds,
+    payload_kind : PayloadKinds,
+    provenance : Provenance,
+    present : BOOLEAN
+]
+
+\* A null-shaped placeholder for ids that have not yet been
+\* CreateArtifact-d. Same record shape as a present artifact so
+\* TLC fingerprinting stays homogeneous.
+DefaultArtifact(i, p, t) == [
+    id |-> i,
+    kind |-> "code",
+    payload_kind |-> "lazy",
+    provenance |-> [ origin_artifact_ids |-> {},
+                     created_by |-> p,
+                     created_at |-> t ],
+    present |-> FALSE
+]
+
+VARIABLES
+    artifacts,
+    dag
+
+vars == <<artifacts, dag>>
+
+\* ── Type invariant ───────────────────────────────────────────────
+TypeOK ==
+    /\ artifacts \in [ArtifactIds -> Artifact]
+    /\ dag \subseteq (ArtifactIds \X ArtifactIds)
+
+\* Every present artifact's id field equals its key in [artifacts].
+ArtifactIdMatchesKey ==
+    \A id \in ArtifactIds :
+        ~artifacts[id].present \/ artifacts[id].id = id
+
+\* No DAG edge points to or from a non-realised artifact.
+DAGRefIntegrity ==
+    \A pair \in dag :
+        /\ artifacts[pair[1]].present
+        /\ artifacts[pair[2]].present
+
+\* No self-loops — an artifact cannot be its own predecessor.
+NoSelfLoops ==
+    \A id \in ArtifactIds : <<id, id>> \notin dag
+
+\* Provenance origin_artifact_ids must reference present artifacts.
+ProvenanceOriginsLive ==
+    \A id \in ArtifactIds :
+        ~artifacts[id].present \/
+        (\A o \in artifacts[id].provenance.origin_artifact_ids :
+            artifacts[o].present)
+
+\* ── Init / Next ──────────────────────────────────────────────────
+\* Pick an arbitrary persona for the placeholder values; it never
+\* matters because [present = FALSE] for every Init artifact.
+InitPersona == CHOOSE p \in Personas : TRUE
+
+Init ==
+    /\ artifacts = [ id \in ArtifactIds |-> DefaultArtifact(id, InitPersona, 0) ]
+    /\ dag = {}
+
+CreateArtifact(id, k, pk, origins, p, t) ==
+    /\ ~artifacts[id].present
+    /\ origins \subseteq { o \in ArtifactIds : artifacts[o].present }
+    /\ artifacts' = [ artifacts EXCEPT ![id] =
+                        [ id |-> id,
+                          kind |-> k,
+                          payload_kind |-> pk,
+                          provenance |-> [ origin_artifact_ids |-> origins,
+                                           created_by |-> p,
+                                           created_at |-> t ],
+                          present |-> TRUE ] ]
+    /\ UNCHANGED dag
+
+AddEdge(from_id, to_id) ==
+    /\ artifacts[from_id].present
+    /\ artifacts[to_id].present
+    /\ from_id # to_id
+    /\ <<from_id, to_id>> \notin dag
+    /\ dag' = dag \cup {<<from_id, to_id>>}
+    /\ UNCHANGED artifacts
+
+Next ==
+    \/ \E id \in ArtifactIds, k \in Kinds, pk \in PayloadKinds,
+          origins \in SUBSET ArtifactIds, p \in Personas, t \in 0..0 :
+            CreateArtifact(id, k, pk, origins, p, t)
+    \/ \E from_id \in ArtifactIds, to_id \in ArtifactIds :
+            AddEdge(from_id, to_id)
+
+Spec == Init /\ [][Next]_vars
+
+THEOREM Spec => []TypeOK
+THEOREM Spec => []ArtifactIdMatchesKey
+THEOREM Spec => []DAGRefIntegrity
+THEOREM Spec => []NoSelfLoops
+THEOREM Spec => []ProvenanceOriginsLive
+
+====


### PR DESCRIPTION
## Summary

Tier B8 (multimodal artifact GADT) shipped to main without the companion TLA+ spec required by plan §5 (each new module PR should land its spec alongside the OCaml). This catch-up PR adds the spec + cfg + `tla-check.sh` wire-up — applies the `feedback_spec_only_pr_ci_gate_failure.md` remediation pattern to avoid CI Gate fail.

## Spec model

A finite `ArtifactIds` universe and an `artifacts` function `ArtifactIds -> Artifact`, with each artifact carrying a `present : BOOLEAN` field marking whether it has been realised via `CreateArtifact`. A separate `dag` variable carries the `(from_id, to_id)` edges introduced by Tier B9 (`Multimodal_hydrator`).

The `present` field exists for the model only. The runtime counterpart simply does not have an entry until `CreateArtifact` is called; we use a present flag here because TLC cannot fingerprint a state where a function returns heterogeneous types (record vs sentinel string) — the first iteration of this spec hit exactly that error.

## Invariants

| Invariant | Statement |
|-----------|-----------|
| `TypeOK` | `artifacts \in [ArtifactIds -> Artifact]` and `dag \subseteq (ArtifactIds × ArtifactIds)` |
| `ArtifactIdMatchesKey` | every present artifact's `id` field equals its key in `artifacts` |
| `DAGRefIntegrity` | no DAG edge points to or from a non-realised artifact |
| `NoSelfLoops` | `\A id : <<id, id>> \notin dag` |
| `ProvenanceOriginsLive` | `provenance.origin_artifact_ids` reference present artifacts |

## Actions

- `CreateArtifact(id, kind, payload_kind, origins, persona, t)` — transitions a not-yet-present artifact to present with chosen fields; `origins` must reference already-present artifacts.
- `AddEdge(from_id, to_id)` — extends `dag` if both endpoints present, no self-loop, no duplicate.

## Local verification

```
$ java -cp ~/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC \
    -config specs/multimodal/MultimodalArtifact.cfg \
    -workers auto -deadlock specs/multimodal/MultimodalArtifact.tla
…
Model checking completed. No error has been found.
2329 states generated, 1753 distinct states found, 0 states left on queue.
The depth of the complete state graph search is 5.
Finished in 01s
```

`cfg`: `ArtifactIds = {a1, a2}`, `Personas = {executor}`, `t \in 0..0`.

## Plan §5 reference

| Spec file | Tier | Refines |
|-----------|------|---------|
| `specs/multimodal/MultimodalArtifact.tla` | **B8** | (independent — kind GADT well-formedness) |

## Test plan

- [x] Local TLC GREEN — 1753 distinct states, depth 5, no error.
- [x] `scripts/tla-check.sh` wire-up: 1 line added under the existing `run_tlc` invocations.
- [x] Race check `gh pr list --search "MultimodalArtifact OR ..."` → 0 open
- [ ] CI tla-check green after push (autocoder gate)

## Related

- B8 (✅ multimodal artifact GADT) already in main.
- Cycle 24/27 follow-up specs (`MultimodalHydrator`, `ResilienceDegradation`) deferred to subsequent catch-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)