### PR TITLE
feat(context-compact): expose score_messages + small_local_ctx_floor in mli

### DIFF
--- a/lib/context_compact_oas.mli
+++ b/lib/context_compact_oas.mli
@@ -14,7 +14,7 @@
     [drop_importance_threshold], [summarize_keep_recent]),
     \[tool_output_prune_limit\] env constant, 4 dynamic-context
     thresholds, [first_sentence] / [tool_names_by_id] /
-    [summarize_chunk] / [mask_tool_*] / [score_messages] /
+    [summarize_chunk] / [mask_tool_*] /
     [oas_strategy_of] / [summarize_old_messages] helpers — all
     consumed only inside {!compact}'s pipeline. *)
 
@@ -103,6 +103,27 @@ val observation_summary : observation_context option -> string
     - [None] returns the literal [obs=none].
     - [Some _] returns formatted key=value pairs covering every
       record field. *)
+
+val score_messages :
+  Oas.Types.message list -> (int * float) list
+(** [score_messages msgs] is the SSOT importance scorer used by
+    {!DropLowImportance} and {!SummarizeOld}. Returns a list of
+    [(index, score)] pairs in the same order as [msgs] with
+    [score \in [0.0, 1.0]].
+
+    Composite of recency (quadratic position weight), role
+    (system / user / assistant / tool weights), tool-call
+    presence, and an anchor boost for messages prefixed with
+    \[MEMORY_SUMMARY\] / \[GOAL\] (current + legacy markers).
+    Pure — reads only the cached env-derived weights. *)
+
+val small_local_ctx_floor : int
+(** Context-window threshold below which {!default_dynamic_selector}
+    classifies a local model as "small" and switches to a
+    lightweight strategy set. Mirrors
+    [Env_config.ContextCompact.small_local_floor]; exposed so
+    boundary tests can pin the threshold without duplicating the
+    env lookup. *)
 
 val default_dynamic_selector :
   observation_context -> strategy list


### PR DESCRIPTION
## Summary

\`test/test_context_compact_oas_coverage.ml\`이 22개 case로 검증하던 두 값이 .mli typed-surface cycle에서 hidden되어 \`@check\` 빌드 실패:

\`\`\`
Error: Unbound value Scoring.score_messages
Error: Unbound value Compact.small_local_ctx_floor
\`\`\`

## Why expose (vs. test rewrite)

- **\`score_messages\`**: 테스트 자체 주석이 \"single source of truth\"로 명시. 7개 sticky-marker / role / role-mix edge case가 이 함수의 behavioural spec. SSOT인데 internal로 숨기면 spec verifiability 자체가 깨짐.
- **\`small_local_ctx_floor\`**: pinned threshold (env-derived). boundary test (floor, floor-1)가 정확한 값에 의존. \`Env_config.ContextCompact.small_local_floor\` 직접 참조도 가능하지만, sub-module 의존이 추가되고 mirror 의도가 가려짐.

두 값 모두 **pure** (no side effect, no lifecycle). expose해도 .mli 경계 의도(internal mutable state 보호)와 충돌 없음.

## Diff

| 파일 | 변경 |
|---|---|
| \`lib/context_compact_oas.mli\` | header의 \"Internal\" 리스트에서 \`[score_messages]\` 제거 + 두 \`val\` 추가 (각각 의미 docstring 포함) |

\`lib/context_compact_oas.ml\`은 변경 없음. behaviour 변경 0.

## Test plan

- [x] \`dune build test/test_context_compact_oas_coverage.exe\` green
- [x] \`dune exec test/test_context_compact_oas_coverage.exe\` 22/22 pass
- [x] Race check 0건

## Pattern series

.mli typed surface cycle 부산물 fix 시리즈:

- **#11844** (MERGED): test_handover_eio — public API rewrite
- **#11846**: voice_config — extract+expose composition entry  
- **이 PR**: context_compact_oas — expose pure SSOT value + threshold
- 남은: test_dashboard_namespace_truth, test_transport_metrics (per-agent metric setters의 design call 영역, 별도 처리 필요)