### PR TITLE
fix(test-build): expose 11 internal helpers in mli for behaviour tests

### DIFF
--- a/lib/context_compact_oas.mli
+++ b/lib/context_compact_oas.mli
@@ -118,3 +118,20 @@ val default_dynamic_selector :
     - Low utilization on small local model -> minimal
       ([\[MergeContiguous\]]).
     - Default -> [\[PruneToolOutputs; MergeContiguous\]]. *)
+
+(** {1 Test-visible scoring helper} *)
+
+val score_messages :
+  Oas.Types.message list -> (int * float) list
+(** [score_messages msgs] returns
+    [(message_index, importance_score)] pairs for the input
+    message list.  Importance combines recency (quadratic ramp
+    over the message list) with role / tool weights.  Pinned for
+    behaviour-tests under {!test/test_context_compact_oas_coverage}. *)
+
+val small_local_ctx_floor : int
+(** [small_local_ctx_floor] is the env-driven context-window
+    floor (read once at module init) below which a local-model
+    keeper is treated as "small local" by
+    {!default_dynamic_selector}.  Pinned for behaviour-tests
+    under {!test/test_context_compact_oas_coverage}. *)

--- a/lib/dashboard/dashboard_http_keeper_metrics.mli
+++ b/lib/dashboard/dashboard_http_keeper_metrics.mli
@@ -131,3 +131,21 @@ val get_agent_identity : string -> string * string
     each row.  Kept here so the cascade consumer can call it
     bare via include without opening
     [Dashboard_execution_helpers] separately. *)
+
+(** {1 Test-visible helpers}
+    Pinned for behaviour-tests under {!test/test_dashboard_keeper_metrics_10286}. *)
+
+val contains_ci : string -> string -> bool
+(** [contains_ci haystack needle] is a case-insensitive substring
+    check.  Returns [false] when [needle] is empty or longer than
+    [haystack]. *)
+
+val normalize_similarity_text : string -> string
+(** [normalize_similarity_text s] lowercases ASCII, replaces
+    non-word characters with spaces, collapses whitespace and
+    trims.  Used as the input normaliser for Jaccard similarity. *)
+
+val jaccard_similarity_text : string -> string -> float
+(** [jaccard_similarity_text a b] is the Jaccard index over the
+    token sets of {!normalize_similarity_text} [a] / [b].  Returns
+    [0.0] when either side has no tokens. *)

--- a/lib/dashboard_provider_runs.mli
+++ b/lib/dashboard_provider_runs.mli
@@ -87,3 +87,37 @@ val run_status_json :
     completed runs.  Pinned at the contract seam: drift to
     silent fallbacks would break operator-visible "run
     expired" feedback. *)
+
+(** {1 Provider snapshot inspection (test-visible)}
+    Pinned for behaviour-tests under
+    {!test/test_observability_provider_contracts}. *)
+
+type discovery_info = {
+  discovered_model : string option;
+  ctx_size : int option;
+  total_slots : int option;
+  busy_slots : int option;
+  idle_slots : int option;
+  healthy : bool;
+}
+
+type provider_snapshot = {
+  provider : string;
+  kind : string;
+  runtime_kind : string;
+  auth_kind : string;
+  status : string;
+  available : bool;
+  supports_single_agent_run : bool;
+  default_model : string option;
+  models : string list;
+  source : string;
+  endpoint_url : string option;
+  note : string option;
+  discovery : discovery_info option;
+}
+
+val provider_snapshot_by_name : string -> provider_snapshot option
+(** [provider_snapshot_by_name name] returns the snapshot for the
+    provider with [provider = name], or [None] when no matching
+    provider is registered. *)

--- a/lib/local/worker_container_types.mli
+++ b/lib/local/worker_container_types.mli
@@ -236,6 +236,17 @@ val safe_text_for_followup : string -> string
     bytes after [String.trim] and appends ["...[truncated]"]
     when the input is longer.  Never raises. *)
 
+val parse_text_tool_calls :
+  string -> Oas.Types.content_block list
+(** [parse_text_tool_calls content] extracts inline
+    [mcp__masc__*(...)] tool-call invocations from a free-form
+    text fragment and returns them as [Oas.Types.ToolUse]
+    content blocks.  Returns [\[\]] when no invocations are
+    found.  Pinned for behaviour-tests under
+    {!test/test_worker_container_coverage} — used by the local
+    worker runtime to recover tool calls embedded in model
+    text output. *)
+
 val worker_auth_token :
   base_path:string ->
   worker_name:string ->

--- a/lib/planning_eio.mli
+++ b/lib/planning_eio.mli
@@ -138,3 +138,13 @@ val get_context_markdown : planning_context -> string
 (** [get_context_markdown ctx] renders [ctx] as the Markdown
     document that round-trips through {!load}.  Sections in PDCA
     order with the canonical headings expected by the parser. *)
+
+(** {1 Test-visible helpers}
+    Pinned for behaviour-tests under {!test/test_planning_eio}. *)
+
+val find_substring_from :
+  string -> needle:string -> from:int -> int option
+(** [find_substring_from haystack ~needle ~from] returns
+    [Some i] for the first occurrence of [needle] at offset
+    [i >= from] in [haystack], or [None] when not found.  Returns
+    [None] when [from] exceeds [String.length haystack]. *)

--- a/lib/server/server_dashboard_http_namespace_truth.mli
+++ b/lib/server/server_dashboard_http_namespace_truth.mli
@@ -93,3 +93,25 @@ val broadcast_namespace_truth_snapshot :
     96/min in fresh-server logs).
 
     Safe to call from any fiber — reads cached refs only. *)
+
+(** {1 Test-visible dedup state}
+    Pinned for behaviour-tests under
+    {!test/test_dashboard_namespace_truth} which need to reset the
+    dedup cache between scenarios. *)
+
+val _last_namespace_truth_snapshot_hash :
+  Digestif.SHA256.t option ref
+(** [_last_namespace_truth_snapshot_hash] is the dedup state for
+    {!broadcast_namespace_truth_snapshot}.  Holds the SHA-256 of
+    the most recently broadcast snapshot (with [generated_at]
+    stripped) or [None] when nothing has been broadcast yet.
+    Tests reset to [None] to force re-broadcast in scenarios
+    that exercise the dedup path. *)
+
+val should_broadcast_namespace_truth_snapshot :
+  Yojson.Safe.t -> bool
+(** [should_broadcast_namespace_truth_snapshot snapshot] computes
+    the SHA-256 of the [generated_at]-stripped form of [snapshot]
+    and returns [true] iff it differs from the previously
+    broadcast hash; updates {!_last_namespace_truth_snapshot_hash}
+    as a side effect.  Pinned at the dedup-contract seam. *)

--- a/lib/tool_code_write.mli
+++ b/lib/tool_code_write.mli
@@ -73,6 +73,17 @@ type git_action =
   | Fetch
   | Clone
 
+val git_action_to_string : git_action -> string
+(** [git_action_to_string a] returns the canonical lowercase label
+    for [a] (matches one of {!valid_git_action_strings}).  Pinned
+    for behaviour-tests under {!test/test_types}. *)
+
+val git_action_of_string_opt : string -> git_action option
+(** [git_action_of_string_opt raw] is the inverse of
+    {!git_action_to_string}: trims and lowercases [raw] then
+    matches against the canonical labels.  Returns [None] when
+    [raw] doesn't match a known constructor. *)
+
 val valid_git_action_strings : string list
 (** [valid_git_action_strings] is the canonical lowercase label
     list (one per {!git_action} constructor: ["add"], ["commit"],

--- a/lib/tool_coord.mli
+++ b/lib/tool_coord.mli
@@ -60,6 +60,18 @@ type assertion_kind = Coord_assertions.assertion_kind =
   | Current_task_set
   | Worktree_active
 
+val assertion_kind_to_string : assertion_kind -> string
+(** [assertion_kind_to_string k] returns the canonical lowercase
+    label for [k].  Re-export of
+    {!Coord_assertions.assertion_kind_to_string}; pinned for
+    behaviour-tests under {!test/test_types}. *)
+
+val all_assertion_kinds : assertion_kind list
+(** [all_assertion_kinds] is the canonical witness list — one
+    entry per {!assertion_kind} constructor.  Re-export of
+    {!Coord_assertions.all_assertion_kinds}; pinned for
+    behaviour-tests under {!test/test_types}. *)
+
 val valid_assertion_strings : string list
 (** [valid_assertion_strings] is the canonical list of
     assertion kind labels (one per constructor).  Used by error

--- a/lib/tool_inline_dispatch_extra.mli
+++ b/lib/tool_inline_dispatch_extra.mli
@@ -30,6 +30,23 @@ val ensure_board_post_author :
     same contract, [tool = "masc_board_post"] and
     [field = "author"] pinned. *)
 
+val enforce_caller_identity :
+  tool:string ->
+  field:string ->
+  agent_name:string ->
+  Yojson.Safe.t ->
+  Yojson.Safe.t
+(** [enforce_caller_identity ~tool ~field ~agent_name args]
+    enforces caller-identity contract for arbitrary
+    [(tool, field)] pairs.  When [args.<field>] (after
+    canonicalization) differs from [agent_name]'s canonical form,
+    records the spoof attempt and rewrites the field.  Pinned for
+    behaviour-tests under
+    {!test/test_board_author_identity_10297} which cover all four
+    board entries ([keeper_board_post] / [_comment] / [_vote] /
+    [_comment_vote]).  Prefer {!ensure_board_post_author} for the
+    [masc_board_post]/[author] specialisation. *)
+
 (** {1 Inline dispatch fallback} *)
 
 val dispatch :

--- a/lib/tool_library.mli
+++ b/lib/tool_library.mli
@@ -44,6 +44,12 @@ val source_to_string : library_source -> string
     ["direct_experience"] / ["research"] / ["experiment"] /
     ["observation"]. *)
 
+val all_sources : library_source list
+(** [all_sources] is the canonical witness list — one entry per
+    {!library_source} constructor (in declaration order).  Used
+    by {!valid_source_strings} and by behaviour-tests under
+    {!test/test_types}. *)
+
 val valid_source_strings : string list
 (** [valid_source_strings] is [List.map source_to_string
     all_sources] computed at module init.  Used by handler

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -203,6 +203,20 @@ val ws_listening : unit -> bool
     [ws_enabled () && Atomic.get ws_runtime_listening] —
     AND of env-config and runtime state. *)
 
+(** {1 Agent health gauges (test-visible)} *)
+
+val set_agent_heartbeat_age :
+  agent_name:string -> float -> unit
+(** [set_agent_heartbeat_age ~agent_name age_seconds] writes
+    [age_seconds] to the [masc_agent_heartbeat_age_seconds] gauge
+    labelled by [agent_name].  Pinned for behaviour-tests under
+    {!test/test_transport_metrics}. *)
+
+val inc_agent_stale : unit -> unit
+(** [inc_agent_stale ()] increments the [masc_agent_stale_total]
+    counter.  Pinned for behaviour-tests under
+    {!test/test_transport_metrics}. *)
+
 (** {1 Transport health snapshot} *)
 
 val transport_health_json : config:Coord.config -> Yojson.Safe.t


### PR DESCRIPTION
## 증상

`origin/main` (HEAD `c95a2e7fba`) 에서 `dune build` 가 14개 cascade 에러로 실패:

```
File "test/test_dashboard_keeper_metrics_10286.ml":   Error: Unbound value Metrics.contains_ci
File "test/test_dashboard_namespace_truth.ml":        Error: Unbound value ..._last_namespace_truth_snapshot_hash
File "test/test_planning_eio.ml":                     Error: Unbound value Planning_eio.find_substring_from
File "test/test_transport_metrics.ml":                Error: Unbound value TM.set_agent_heartbeat_age, inc_agent_stale
File "test/test_observability_provider_contracts.ml": Error: Unbound value provider_snapshot_by_name
File "test/test_board_author_identity_10297.ml":      Error: Unbound value D.enforce_caller_identity
File "test/test_context_compact_oas_coverage.ml":     Error: Unbound value Scoring.score_messages, small_local_ctx_floor
File "test/test_worker_container_coverage.ml":        Error: Unbound value Worker_runtime.parse_text_tool_calls
File "test/test_types.ml":                            Error: Unbound value T.git_action_to_string, git_action_of_string_opt, L.all_sources, C.assertion_kind_to_string, all_assertion_kinds
File "test/test_dashboard_namespace_truth.ml":        Error: Unbound value should_broadcast_namespace_truth_snapshot
```

## 근본 원인

1. **Cycle-based mli scaffolding** (#11743, #11763, #11809 등) 이 모듈 경계를 좁혔지만 test-referenced helper 노출 누락.
2. **Admin-merge build bypass** — main의 마지막 successful CI run 은 `2026-04-28T17:06:19Z` (~9 시간 전). 이후 30+ PR이 admin merge로 머지되며 test build 깨짐 누적. 메모리 *Admin merge can bypass build CI* 패턴.
3. 함수는 `.ml` 에 살아있고 contract 도 stable — 단지 `.mli` 의 `val` 선언만 누락.

## 변경

순수 additive — `.ml` 변경 0건, test 변경 0건, behavior shift 0건. 11 `.mli` 파일에 `val` + 필요시 type 추가.

| 파일 | 노출 심볼 |
|------|---------|
| lib/dashboard/dashboard_http_keeper_metrics.mli | contains_ci, normalize_similarity_text, jaccard_similarity_text |
| lib/planning_eio.mli | find_substring_from |
| lib/transport_metrics.mli | set_agent_heartbeat_age, inc_agent_stale |
| lib/context_compact_oas.mli | score_messages, small_local_ctx_floor |
| lib/tool_code_write.mli | git_action_to_string, git_action_of_string_opt |
| lib/dashboard_provider_runs.mli | discovery_info type, provider_snapshot type, provider_snapshot_by_name |
| lib/tool_inline_dispatch_extra.mli | enforce_caller_identity |
| lib/local/worker_container_types.mli | parse_text_tool_calls |
| lib/server/.../server_dashboard_http_namespace_truth.mli | _last_namespace_truth_snapshot_hash, should_broadcast_namespace_truth_snapshot |
| lib/tool_coord.mli | assertion_kind_to_string, all_assertion_kinds |
| lib/tool_library.mli | all_sources |

총 **11 files, +172 lines, -0 lines**.

## 검증

```
$ dune build --root .   # before: 14 errors. after: PASS (exit 0).
```

## Privacy Note

기존 4 개 모듈의 `.mli` docstring 은 이 helper들을 \"Internal: stay private\" 으로 명시:

- `dashboard_http_keeper_metrics.mli`: similarity helpers
- `context_compact_oas.mli`: score_messages
- `dashboard_provider_runs.mli`: provider_snapshot, provider_snapshot_by_name
- `tool_inline_dispatch_extra.mli`: enforce_caller_identity (specialised wrapper `ensure_board_post_author` 만 노출되어 있었음)

이 노출은 **intentional pragmatic trade-off**:

- 테스트가 helper의 동작 (similarity scoring, dedup hash, identity enforcement, provider snapshot inspection) 을 직접 pin 함.
- Public wrapper 가 부분적이거나 (ensure_board_post_author 는 `masc_board_post` 만 커버) 부재함.
- Main blocker 해소가 즉시 우선 (~9시간 동안 30+ PR 의 CI 가 advisory bypass).

테스트를 narrower public surface 로 refactor 하는 작업은 follow-up PR 로 분리 가능 — 본 PR 은 main blocker 해소만 담당.

## 영향

- `origin/main` test build 복구.
- 모든 open PR 의 `dune build` 단계 unblock — admin-merge bypass 의존 해소.
- Behavior 변경 0 건. 새 surface 는 테스트만 사용 (callers 검색 0).

## 회귀 가능성

- `.ml` / 테스트 미변경 → semantic drift 0.
- 추가된 `val` 시그니처는 모두 `.ml` 의 inferred 시그니처와 verbatim 매치 (수동 확인).
- Public surface 확대 외 다른 부수 효과 없음.

## Followup (별도 PR 권장)

- Branch protection: `Build and Test` 를 required check 로 추가 — admin-merge 가 build break 통과하는 사고 재발 방지. 메모리 *Required check must include Lint* 패턴.
- 테스트 4 건 (observability_provider_contracts, board_author_identity_10297, dashboard_keeper_metrics_10286, context_compact_oas_coverage) 의 internal-helper 사용을 narrower public surface 로 refactor 검토.

## 관련 PR

- #11825 (open) — lib/ build 의 별도 main blocker (Printexc + mli wildcard) 처리 중.
- #11844 (merged) — `trigger_reason_to_string` 을 public API 경유 테스트로 대체.
- #11846 (merged) — `parse_tts` 대신 `parse_json` 노출.

본 PR 의 변경은 위 셋과 disjoint. 머지 순서 무관.