### PR TITLE
chore(goal): add goal_store.mli — goal lifecycle store pin (cycle 196)

### DIFF
--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -1,0 +1,276 @@
+(** Goal_store — shared planning goals with a dedicated
+    lifecycle phase.
+
+    Persists goals under [<base>/.masc/goals.json] with an
+    integer [version] counter and an ISO-8601 [updated_at]
+    stamp.  Each goal carries:
+
+    - a {!Goal_phase.t} (canonical lifecycle: [Executing] /
+      [Awaiting_verification] / [Blocked] / [Completed] /
+      [Paused] / [Dropped]),
+    - a legacy {!goal_status} kept for backward-compat with
+      consumers that have not migrated to phases yet
+      (derived from phase on write, inferred on read for
+      old rows),
+    - a {!horizon} ([Short] / [Mid] / [Long]) used by the
+      refresh / snapshot scheduler to decide which cohort
+      to scan,
+    - an optional {!Goal_verification.goal_verifier_policy}
+      that gates entry into [Goal_phase.Completed].
+
+    Every type is exposed concretely because external
+    callers ([test/test_dashboard_goals], [test_goal_janitor],
+    [test_keeper_task_dispatch],
+    [test_coordination_product], [lib/coord_goals],
+    [lib/server/server_dashboard_http]) construct goal records
+    by literal, pattern-match on every variant constructor,
+    and access record fields ([.id], [.phase],
+    [.updated_at], [.horizon], [.title], …) directly.
+
+    Internal helpers stay private at this boundary
+    ([refresh_mode], [snapshot_mode], [snapshot] type +
+    function, [refresh_result], [refresh],
+    [parse_refresh_mode], [parse_snapshot_mode],
+    [snapshot_mode_of_refresh_mode], [normalize_lower],
+    [now_ms], [gen_goal_id], [find_goal], [replace_goal],
+    [update_state], [normalize_goal], [sort_goals],
+    [parse_yyyy_mm_dd], [days_until],
+    [should_refresh_goal], [reprioritize], [active_goals],
+    [has_scheduler_state], [scheduler_state_path],
+    [snapshots_dir], [ensure_dirs], [default_state],
+    [clamp_priority]). *)
+
+(** {1 Status / horizon / review variants} *)
+
+type goal_status =
+  | Active
+  | Paused
+  | Done
+  | Dropped
+  (** Legacy lifecycle status.  Persisted alongside
+      {!Goal_phase.t} for backward-compat; derived from the
+      phase on write via {!goal_status_of_phase} and
+      inferred on read for old rows.  New code paths should
+      branch on [.phase] instead of [.status]. *)
+
+val goal_status_to_yojson : goal_status -> Yojson.Safe.t
+val goal_status_of_yojson :
+  Yojson.Safe.t -> (goal_status, string) result
+
+type horizon =
+  | Short
+  | Mid
+  | Long
+  (** Time-bucket the goal belongs to.  Used by the
+      refresh scheduler ([Daily] → [Short], [Weekly] →
+      [Mid], [Monthly] → [Long]) to decide which cohort to
+      reprioritise. *)
+
+val horizon_to_yojson : horizon -> Yojson.Safe.t
+
+type review_outcome =
+  | ReviewDone
+  | ReviewProgress
+  | ReviewBlocked
+  | ReviewDropped
+  (** Outcome supplied to {!review_goal}.  Each outcome
+      maps to a deterministic [(phase, priority_delta)]
+      transition: [ReviewDone] → [Completed],
+      [ReviewProgress] → [Executing] with priority bumped
+      up (lower number), [ReviewBlocked] → [Blocked] with
+      priority bumped down, [ReviewDropped] → [Dropped]. *)
+
+(** {1 Parsers (string → variant option)} *)
+
+val parse_horizon : string option -> horizon option
+(** Case-insensitive, trim-tolerant.  [None]/empty string
+    pass through as [None]. *)
+
+val parse_goal_status : string option -> goal_status option
+(** Same shape as {!parse_horizon}. *)
+
+val parse_goal_phase : string option -> Goal_phase.t option
+(** Delegates to {!Goal_phase.parse}.  [None] passes
+    through. *)
+
+val parse_review_outcome : string -> review_outcome option
+(** Case-insensitive, trim-tolerant.  Mandatory string
+    (no option wrap) — call sites already gated on
+    presence. *)
+
+(** {1 Phase ↔ legacy status bridge} *)
+
+val goal_status_of_phase : Goal_phase.t -> goal_status
+(** Forward derivation used on write.  Maps every phase to
+    its canonical legacy status:
+    - [Executing] / [Awaiting_verification] → [Active]
+    - [Paused] → [Paused]
+    - [Completed] → [Done]
+    - [Blocked] / [Dropped] → [Dropped] *)
+
+val phase_of_goal_status : goal_status -> Goal_phase.t
+(** Reverse inference used on read for rows persisted
+    before phases existed.  Maps [Active] → [Executing],
+    [Paused] → [Paused], [Done] → [Completed], [Dropped] →
+    [Dropped]. *)
+
+(** {1 Goal record} *)
+
+type goal = {
+  id : string;
+  horizon : horizon;
+  title : string;
+  metric : string option;
+  target_value : string option;
+  due_date : string option;
+  priority : int;
+  status : goal_status;
+  phase : Goal_phase.t;
+  verifier_policy : Goal_verification.goal_verifier_policy option;
+  require_completion_approval : bool;
+  active_verification_request_id : string option;
+  parent_goal_id : string option;
+  last_review_note : string option;
+  last_review_at : string option;
+  created_at : string;
+  updated_at : string;
+}
+(** A single goal entry.  [priority] is clamped to [1..5]
+    on every write through the internal [normalize_goal]
+    pass.  [active_verification_request_id] tracks an open
+    {!Goal_verification.goal_verification_request} when the
+    phase is [Awaiting_verification]; cleared on every
+    phase transition out of the verification path. *)
+
+val goal_to_yojson : goal -> Yojson.Safe.t
+
+(** {1 State} *)
+
+type state = {
+  version : int;
+  updated_at : string;
+  goals : goal list;
+}
+(** On-disk shape persisted to {!goals_path}.  [version]
+    increments on every write so concurrent readers detect
+    drift. *)
+
+(** {1 Rollup} *)
+
+type rollup = {
+  short_count : int;
+  mid_count : int;
+  long_count : int;
+  active_count : int;
+  paused_count : int;
+  done_count : int;
+  dropped_count : int;
+}
+(** Aggregate counts produced by {!compute_rollup}.
+    Consumed by [coord_goals.ml] and the dashboard HTTP
+    endpoint to render the goal-tree summary. *)
+
+val rollup_to_yojson : rollup -> Yojson.Safe.t
+
+val compute_rollup : goal list -> rollup
+(** Field-wise count of goals per horizon and per legacy
+    status.  Single pass; no allocation beyond the result
+    record. *)
+
+(** {1 Persistence paths} *)
+
+val goals_path : Coord.config -> string
+(** [{!Coord.masc_dir} / "goals.json"]. *)
+
+(** {1 State I/O} *)
+
+val read_state : Coord.config -> state
+(** Reads {!goals_path}; returns an empty default state on
+    missing file or parse failure.  Goals loaded from disk
+    are passed through the internal normaliser ([priority]
+    clamp + phase/status reconciliation). *)
+
+val write_state : Coord.config -> state -> unit
+(** Atomic write of the canonical state to {!goals_path}.
+    Caller is responsible for serialising concurrent
+    writes — the internal mutators ({!update_goal},
+    {!delete_goal}, {!upsert_goal}, {!review_goal}) all
+    hold the file lock around their read-modify-write
+    block; raw users of {!write_state} (the test harness
+    only) should not race against them. *)
+
+(** {1 Single-goal operations} *)
+
+val get_goal : Coord.config -> goal_id:string -> goal option
+
+val update_goal :
+  Coord.config ->
+  goal_id:string ->
+  (goal -> goal) ->
+  (goal, string) result
+(** Locks the state file, applies [f] to the matched goal
+    (with [updated_at] pre-stamped), normalises the result,
+    and writes back.  Errors when the [goal_id] is unknown. *)
+
+val delete_goal :
+  Coord.config -> goal_id:string -> (unit, string) result
+(** Removes the goal whose [.id] matches.  Errors when the
+    id is unknown. *)
+
+(** {1 List + upsert} *)
+
+val list_goals :
+  Coord.config ->
+  ?horizon:horizon ->
+  ?status:goal_status ->
+  ?phase:Goal_phase.t ->
+  unit ->
+  goal list
+(** Reads the state, applies optional filters, then sorts
+    by [(horizon, priority, updated_at desc)]. *)
+
+val upsert_goal :
+  Coord.config ->
+  ?id:string ->
+  ?horizon:horizon ->
+  ?title:string ->
+  ?metric:string ->
+  ?target_value:string ->
+  ?due_date:string ->
+  ?priority:int ->
+  ?status:goal_status ->
+  ?phase:Goal_phase.t ->
+  ?parent_goal_id:string ->
+  ?verifier_policy:Goal_verification.goal_verifier_policy ->
+  ?require_completion_approval:bool ->
+  unit ->
+  (goal * [ `created | `updated ], string) result
+(** Creates a new goal when [id] is omitted (mints
+    [goal-<ms>-<4 hex digits>] internally), updates the
+    matched row otherwise.  Returns the resolved goal
+    paired with [`created] / [`updated] so callers can
+    branch on the outcome.
+
+    Errors:
+    - [title] required for new goals (omit / empty string
+      on a new goal id).
+    - [phase] and legacy [status] disagree (when both are
+      supplied and {!phase_of_goal_status} of [status] does
+      not equal [phase]). *)
+
+(** {1 Review workflow} *)
+
+val review_goal :
+  Coord.config ->
+  goal_id:string ->
+  outcome:review_outcome ->
+  ?new_horizon:horizon ->
+  ?note:string ->
+  unit ->
+  (goal, string) result
+(** Applies the [(phase, priority_delta)] transition from
+    {!review_outcome}, optionally moves the goal across
+    horizons, and records the note + timestamp into
+    [last_review_note] / [last_review_at].  Clears
+    [active_verification_request_id] except when the new
+    phase is [Awaiting_verification]. *)


### PR DESCRIPTION
## Summary
- Add `lib/goal/goal_store.mli` pinning the shared planning-goal store surface (759 LOC).
- 36 externally-consumed symbols (variants + types + functions + field accesses).
- Sister of `goal_verification.mli` (cycle 192a).

## Surface
- **Variant constructors** (used externally): `Active`, `Paused`, `Done`, `Dropped`, `Short`, `Mid`, `Long`, `ReviewDone`, `ReviewProgress`, `ReviewBlocked`, `ReviewDropped`.
- **Types (concrete records)**: `goal_status`, `horizon`, `review_outcome`, `goal`, `state`, `rollup`.
- **Parsers**: `parse_horizon`, `parse_goal_status`, `parse_goal_phase`, `parse_review_outcome`.
- **Phase ↔ legacy status bridge**: `goal_status_of_phase`, `phase_of_goal_status`.
- **State I/O**: `goals_path`, `read_state`, `write_state`.
- **Single-goal ops**: `get_goal`, `update_goal`, `delete_goal`.
- **List / upsert**: `list_goals`, `upsert_goal` returns `(goal * [`created | `updated], string) result`.
- **Review workflow**: `review_goal`.
- **Rollup**: `compute_rollup`, `rollup_to_yojson`.
- **Yojson encoders**: `goal_status_to_yojson`, `goal_status_of_yojson`, `horizon_to_yojson`, `goal_to_yojson`.

## Internal helpers (private at this boundary)
- `refresh_mode`, `snapshot_mode`, `snapshot` (type + function), `refresh_result`, `refresh`, `parse_refresh_mode`, `parse_snapshot_mode`, `snapshot_mode_of_refresh_mode`.
- `normalize_goal`, `sort_goals`, `gen_goal_id`, `find_goal`, `replace_goal`, `update_state`, `clamp_priority`, `normalize_lower`, `now_ms`.
- `parse_yyyy_mm_dd`, `days_until`, `should_refresh_goal`, `reprioritize`.
- `active_goals`, `has_scheduler_state`, `scheduler_state_path`, `snapshots_dir`, `ensure_dirs`, `default_state`.

## Test plan
- [x] `dune build lib/` clean
- [ ] required CI checks