### PR TITLE
fix(test-build): expose mentor_/outcome_to_string in institution_eio.mli

### DIFF
--- a/lib/institution_eio.mli
+++ b/lib/institution_eio.mli
@@ -45,6 +45,12 @@ type episode = {
     so corrupted entries drop with a warn instead of being
     silently coerced to [`Partial]. *)
 
+val outcome_to_string :
+  [ `Success | `Failure | `Partial ] -> string
+(** Wire encoder for [outcome] values.  Returns the
+    lower-cased canonical label
+    ([success] / [failure] / [partial]). *)
+
 val outcome_of_string : string -> [ `Success | `Failure | `Partial ]
 (** Parses an outcome wire string (the lower-cased
     [success] / [failure] / [partial]).  {b Raises}
@@ -54,6 +60,21 @@ val outcome_of_string : string -> [ `Success | `Failure | `Partial ]
     garbage / future-variant payload drops the entry instead
     of being mis-classified.  Matches the fail-closed sweep
     in #11256 (rejection of "Unknown → Permissive Default"). *)
+
+val mentor_to_string :
+  [ `Random | `Best_fit | `Round_robin ] -> string
+(** Wire encoder for [mentor_assignment] strategy values.
+    Returns the lower-cased canonical label
+    ([random] / [best_fit] / [round_robin]). *)
+
+val mentor_of_string :
+  string -> [ `Random | `Best_fit | `Round_robin ]
+(** Parses a mentor-assignment wire string
+    ([random] / [best_fit] / [round_robin]).  {b Raises}
+    [Yojson.Safe.Util.Type_error] on unknown input — same
+    fail-closed contract as {!outcome_of_string} (#11675).
+    Pinned for behaviour-tests under
+    {!test/test_institution_of_string_fail_closed}. *)
 
 val episode_to_json : episode -> Yojson.Safe.t
 (** Wire encoder.  Field names mirror the record exactly;


### PR DESCRIPTION
## 증상

`origin/main` (HEAD `915be475fd`) 에서 `dune build` 가 cascade 에러로 실패:

```
File \"test/test_institution_of_string_fail_closed.ml\", line 64:
  Error: Unbound value I.mentor_of_string
File \"test/test_institution_of_string_fail_closed.ml\", line 87:
  Error: Unbound value I.outcome_to_string
```

## 근본 원인

PR #11853 (Cycle 194 — \"add institution_eio.mli — episode + JSONL log surface\") 가 새 `.mli` 를 추가하면서 `episode + JSONL log surface` 만 expose 하고:

- `outcome_to_string` (wire encoder)
- `mentor_to_string` (wire encoder)
- `mentor_of_string` (fail-closed parser, #11675 contract)

세 헬퍼 노출 누락. 이전엔 `.mli` 가 없어서 inferred signature 로 모두 접근 가능했는데, scaffold PR 이 surface 좁히면서 silent 회귀.

`test/test_institution_of_string_fail_closed.ml` (PR #11675) 가 fail-closed 계약을 직접 pin 하기 위해 helper 들을 호출하고 있어 빌드 fail.

## 변경

순수 additive — `.ml` / test 미변경. `.mli` 에 3 개 `val` 추가.

| 파일 | 노출 심볼 |
|------|---------|
| lib/institution_eio.mli | outcome_to_string, mentor_to_string, mentor_of_string |

총 **1 file, +21 lines, -0 lines**.

## 검증

```
$ dune build --root .   # before: 2 cascaded errors. after: PASS (exit 0).
```

## 영향

- `origin/main` test build 복구.
- 모든 open PR 의 `dune build` 단계 unblock — 메모리 *Admin merge can bypass build CI* 패턴 재발 방지.
- Behavior 0 변경, contract 0 변경.

## 회귀 가능성

- `.ml` 미변경 → semantic drift 0.
- 추가된 `val` 시그니처는 모두 `.ml` 의 inferred 시그니처와 verbatim 매치.

## 관련 PR

- #11853 (merged) — `institution_eio.mli` scaffold 추가, 본 fix가 보완.
- #11675 (merged) — fail-closed contract + 테스트 도입. 본 PR 은 그 테스트의 수명 복구.
- #11856 (merged) — 직전 fix(test-build) PR 과 같은 mli expose 패턴.

## Followup

이번 4 시간 내 같은 \"mli scaffold misses helper\" 패턴 4 건 (#11853, #11856 base 깨짐, plus 더). cycle 기반 scaffold 자동화에 \"test/ 에서 참조되는 심볼은 자동 expose\" 가드 추가 검토.