### PR TITLE
fix(checkpoint): promote persist_checkpoint errors to Result (IR-3)

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -388,10 +388,10 @@ let run
       in
       (match config.checkpoint_dir with
        | Some dir ->
-         (try persist_checkpoint ~dir ~session_id ckpt
-          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-            Log.Misc.error "oas_worker: Checkpoint save failed: %s"
-              (Printexc.to_string exn))
+         (match persist_checkpoint ~dir ~session_id ckpt with
+          | Ok () -> ()
+          | Error err ->
+            Log.Misc.error "oas_worker: %s" err)
        | None -> ());
       Some ckpt
     in

--- a/lib/oas_worker_exec_checkpoint.ml
+++ b/lib/oas_worker_exec_checkpoint.ml
@@ -25,10 +25,20 @@ let publish_lifecycle _bus ~name ~event ~detail ?error ?session_id ?status () =
                    @ optional_string_field "session_id" session_id
                    @ optional_string_field "status" status) )))
 
-let persist_checkpoint ~dir ~session_id (ckpt : Oas.Checkpoint.t) =
+let persist_checkpoint ~dir ~session_id (ckpt : Oas.Checkpoint.t)
+    : (unit, string) result =
   let path = Filename.concat dir (session_id ^ ".json") in
-  Fs_compat.mkdir_p dir;
-  Fs_compat.save_file path (Oas.Checkpoint.to_string ckpt)
+  try
+    Fs_compat.mkdir_p dir;
+    Result.map_error
+      (fun err ->
+         Printf.sprintf "checkpoint persist failed for %s: %s" session_id err)
+      (Fs_compat.save_file_atomic path (Oas.Checkpoint.to_string ckpt))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Error (Printf.sprintf "checkpoint persist failed for %s: %s"
+             session_id (Printexc.to_string exn))
 
 let build_checkpoint ~session_id ?checkpoint_sidecar (agent : Oas.Agent.t) =
   match checkpoint_sidecar with

--- a/lib/oas_worker_exec_checkpoint.mli
+++ b/lib/oas_worker_exec_checkpoint.mli
@@ -37,11 +37,12 @@ val persist_checkpoint :
   dir:string ->
   session_id:string ->
   Oas.Checkpoint.t ->
-  unit
+  (unit, string) result
 (** Serialise [ckpt] via [Oas.Checkpoint.to_string] and write it
-    atomically to [<dir>/<session_id>.json]. The parent [dir]
-    is created via [Fs_compat.mkdir_p] before the write — the
-    function never raises on a missing directory. *)
+    atomically (tmp → fsync → rename) to [<dir>/<session_id>.json].
+    Returns [Error msg] on I/O failure instead of raising.
+    The parent [dir] is created via [Fs_compat.mkdir_p] before
+    the write. *)
 
 val build_checkpoint :
   session_id:string ->

--- a/test/dune
+++ b/test/dune
@@ -1917,3 +1917,9 @@
  (name test_process_eio_default_timeout)
  (modules test_process_eio_default_timeout)
  (libraries masc_test_deps))
+
+; IR-3: checkpoint save error promotion
+(test
+ (name test_oas_worker_exec_checkpoint)
+ (modules test_oas_worker_exec_checkpoint)
+ (libraries masc_test_deps))

--- a/test/test_oas_worker_exec_checkpoint.ml
+++ b/test/test_oas_worker_exec_checkpoint.ml
@@ -1,0 +1,95 @@
+(** IR-3 — checkpoint save error promotion.
+
+    [persist_checkpoint] now returns [(unit, string) result] instead of
+    raising.  This test pins:
+    1. A successful write returns [Ok ()] and the file exists on disk.
+    2. A write to a read-only directory returns [Error _], not an
+       exception. *)
+
+open Masc_mcp
+open Alcotest
+
+module CP = Oas_worker_exec_checkpoint
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      try Unix.rmdir path with Sys_error _ -> ())
+    else
+      try Unix.unlink path with Sys_error _ -> ()
+
+let with_tmp_dir f =
+  let dir =
+    Filename.get_temp_dir_name () ^ "/ir3-test-" ^ string_of_int (Random.int 1000000)
+  in
+  Fs_compat.mkdir_p dir;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let dummy_checkpoint : Oas.Checkpoint.t =
+  {
+    Oas.Checkpoint.version = Oas.Checkpoint.checkpoint_version;
+    session_id = "ir3-test";
+    agent_name = "test-worker";
+    model = "";
+    system_prompt = None;
+    messages = [];
+    usage = Oas.Types.empty_usage;
+    turn_count = 0;
+    created_at = 0.0;
+    tools = [];
+    tool_choice = None;
+    disable_parallel_tool_use = false;
+    temperature = None;
+    top_p = None;
+    top_k = None;
+    min_p = None;
+    enable_thinking = None;
+    response_format = Oas.Types.Off;
+    thinking_budget = None;
+    cache_system_prompt = false;
+    max_input_tokens = None;
+    max_total_tokens = None;
+    context = Oas.Context.create ();
+    mcp_sessions = [];
+    working_context = None;
+  }
+
+let test_persist_checkpoint_ok () =
+  with_tmp_dir (fun dir ->
+    let result = CP.persist_checkpoint ~dir ~session_id:"s1" dummy_checkpoint in
+    check bool "persist returns Ok" true (Result.is_ok result);
+    let path = Filename.concat dir "s1.json" in
+    check bool "file exists on disk" true (Sys.file_exists path))
+
+let test_persist_checkpoint_error_on_readonly () =
+  let dir =
+    Filename.get_temp_dir_name () ^ "/ir3-ro-" ^ string_of_int (Random.int 1000000)
+  in
+  Fs_compat.mkdir_p dir;
+  Unix.chmod dir 0o444;
+  let result =
+    try CP.persist_checkpoint ~dir ~session_id:"s2" dummy_checkpoint
+    with exn ->
+      Unix.chmod dir 0o755;
+      rm_rf dir;
+      failf "persist_checkpoint raised unexpectedly: %s" (Printexc.to_string exn)
+  in
+  Unix.chmod dir 0o755;
+  rm_rf dir;
+  check bool "persist returns Error on read-only dir" true (Result.is_error result);
+  let err = Result.get_error result in
+  check bool "error message mentions session" true
+    (try ignore (Str.search_forward (Str.regexp "s2") err 0); true
+     with Not_found -> false)
+
+let () =
+  run "oas_worker_exec_checkpoint"
+    [
+      ( "persist_checkpoint",
+        [
+          test_case "Ok on writable dir" `Quick test_persist_checkpoint_ok;
+          test_case "Error on read-only dir (IR-3)"
+            `Quick test_persist_checkpoint_error_on_readonly;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- `persist_checkpoint` returned `unit` and raised on I/O failure — callers caught exceptions but only logged them, making checkpoint save failures silent
- On resume, a stale/missing checkpoint could corrupt agent state
- Switch to `save_file_atomic` (returns `(unit, string) result`) with outer `try/with` to also catch `Filename.temp_file` exceptions that escape `save_file_atomic`'s own handler
- Caller in `oas_worker_exec.ml` now uses `match` on `Result` instead of `try...with`

## Test plan

- [x] `test_persist_checkpoint_ok` — writable dir returns `Ok ()`, file exists on disk
- [x] `test_persist_checkpoint_error_on_readonly` — read-only dir returns `Error`, not exception
- [x] `dune build` passes
- [x] `dune runtest` for new test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)