### PR TITLE
fix(test-build): expose 4 board_votes helpers in mli

### DIFF
--- a/lib/board_votes.mli
+++ b/lib/board_votes.mli
@@ -51,6 +51,18 @@ val valid_vote_direction_strings : string list
     JSON Schema generator for the [direction] enum field
     in the vote MCP tool. *)
 
+val all_vote_directions : vote_direction list
+(** Witness list — one entry per {!vote_direction}
+    constructor, in declaration order. *)
+
+val vote_direction_of_string_opt : string -> vote_direction option
+(** Sound partial parser: case-insensitive, trims whitespace.
+    [""] is accepted as [Some Up] for back-compat with
+    [tool_board.ml] which defaults to ["up"] when the field
+    is missing.  Unknown input returns [None] (no silent
+    permissive fallback).  Pinned for behaviour-tests under
+    {!test/test_types}. *)
+
 (** {1 Vote log path} *)
 
 val vote_log_path : unit -> string
@@ -198,3 +210,21 @@ val post_to_yojson_with_karma :
     [classification_reason], extracted [flair], and a
     pre-computed [score = votes_up - votes_down] so the
     client does not have to derive it. *)
+
+(** {1 Fixture-voter quarantine (#9886)} *)
+
+val is_fixture_voter_target : string -> bool
+(** Returns [true] when [target] (a [room:agent] tuple or bare
+    agent name) refers to a fixture / synthetic / test voter.
+    Matches the [hot-voter-] / [synthetic-voter-] /
+    [test-voter-] prefixes that production traffic never uses.
+    Pinned for behaviour-tests under
+    {!test/test_board_fixture_detector}. *)
+
+val quarantine_enabled : unit -> bool
+(** Reads [MASC_BOARD_VOTE_QUARANTINE] (default [true] —
+    production-ledger #9886 measured 100% fixture-pattern votes
+    orphaning ranking).  Returns [false] only when the env is
+    explicitly set to [0] / [false] / [off] / empty.  Pinned
+    for behaviour-tests under
+    {!test/test_board_vote_quarantine}. *)


### PR DESCRIPTION
## 증상

`origin/main` (HEAD `281317a0a6`) 에서 `dune build` 가 3개 cascade 에러로 실패:

```
File "test/test_board_vote_quarantine.ml", line 26:
  Error: Unbound value BV.quarantine_enabled
File "test/test_board_fixture_detector.ml", line 23:
  Error: Unbound value BV.is_fixture_voter_target
File "test/test_types.ml", line 722:
  Error: Unbound value B.vote_direction_of_string_opt
```

## 근본 원인

PR #11860 (Cycle 198 — "add board_votes.mli — voting + karma + flair pin") 가 새 `.mli` 추가하면서 voting / karma / flair surface 만 expose 하고 4개 test-referenced helper 노출 누락:

- `vote_direction_of_string_opt` (sound partial parser, fail-closed)
- `all_vote_directions` (witness list)
- `is_fixture_voter_target` (#9886 fixture-voter detection)
- `quarantine_enabled` (#9886 env-driven quarantine flag)

이전엔 `.mli` 부재로 inferred signature 가 자동 노출했는데, scaffold PR 이 surface 좁히면서 silent 회귀.

## 변경

순수 additive — `.ml` / test 미변경. `.mli` 에 4 개 `val` 추가.

| 파일 | 노출 심볼 |
|------|---------|
| lib/board_votes.mli | all_vote_directions, vote_direction_of_string_opt, is_fixture_voter_target, quarantine_enabled |

총 **1 file, +30 lines, -0 lines**.

## 검증

```
$ dune build --root .   # before: 3 cascaded errors. after: PASS (exit 0).
```

## 패턴 누적 (4시간 내 3건)

같은 \"cycle-based mli scaffold misses test-referenced symbol\" 패턴이 4시간 내 3 번째 발생:

| PR | Scaffold | Missing | Fix PR |
|----|----------|---------|--------|
| #11763 (cycle 132) | tool_local_runtime.mli + 9 others | 14 helpers | #11856 |
| #11853 (cycle 194) | institution_eio.mli | 3 helpers | #11859 |
| #11860 (cycle 198) | board_votes.mli | 4 helpers | (this PR) |

Followup 권장: cycle scaffold 자동화에 \"이 모듈이 test/ 에서 호출하는 symbol 자동 expose\" 가드 추가. 예: `rg \"<Module>\\.\" test/ | extract symbols` → 누락 시 scaffold PR 자체 fail.

## 회귀 가능성

- `.ml` / test 미변경 → semantic drift 0.
- 추가된 `val` 시그니처는 모두 `.ml` 의 inferred 시그니처와 verbatim 매치.