### PR TITLE
feat(multimodal): Tier A7 — Create factories + Workspace registry (Cycle 24-25)

### DIFF
--- a/lib/multimodal/create.ml
+++ b/lib/multimodal/create.ml
@@ -1,0 +1,47 @@
+(* Create — Cycle 24-25 / Tier A7 first half.
+   See create.mli for design rationale. *)
+
+let provenance_of ?(origins = []) ~created_by ~created_at () : Provenance_stub.t =
+  { Provenance_stub.origin_artifact_ids = origins; created_by; created_at }
+
+let make_artifact (type a) ~(id : Shared_types.Artifact_id.t)
+    ~(kind : a Artifact.kind) ~(payload : Payload.t)
+    ?(metadata = `Null) ?origins ~created_by ~created_at () : a Artifact.t =
+  {
+    Artifact.id;
+    kind;
+    payload;
+    metadata;
+    provenance = provenance_of ?origins ~created_by ~created_at ();
+  }
+
+let create_code ~id ~payload ?metadata ?origins ~created_by ~created_at () =
+  make_artifact ~id ~kind:Artifact.Code ~payload ?metadata ?origins
+    ~created_by ~created_at ()
+
+let create_image ~id ~payload ?metadata ?origins ~created_by ~created_at () =
+  make_artifact ~id ~kind:Artifact.Image ~payload ?metadata ?origins
+    ~created_by ~created_at ()
+
+let create_audio ~id ~payload ?metadata ?origins ~created_by ~created_at () =
+  make_artifact ~id ~kind:Artifact.Audio ~payload ?metadata ?origins
+    ~created_by ~created_at ()
+
+let create_doc ~id ~payload ?metadata ?origins ~created_by ~created_at () =
+  make_artifact ~id ~kind:Artifact.Doc ~payload ?metadata ?origins
+    ~created_by ~created_at ()
+
+let create_with_blob_ref ~kind ~id ~blob_ref ?metadata ?origins
+    ~created_by ~created_at () =
+  make_artifact ~id ~kind ~payload:(Payload.Blob_ref blob_ref) ?metadata
+    ?origins ~created_by ~created_at ()
+
+let create_with_streaming ~kind ~id ~bytes_so_far ?metadata ?origins
+    ~created_by ~created_at () =
+  make_artifact ~id ~kind ~payload:(Payload.Streaming bytes_so_far) ?metadata
+    ?origins ~created_by ~created_at ()
+
+let create_with_lazy_payload ~kind ~id ~thunk ?metadata ?origins
+    ~created_by ~created_at () =
+  make_artifact ~id ~kind ~payload:(Payload.Lazy_payload thunk) ?metadata
+    ?origins ~created_by ~created_at ()

--- a/lib/multimodal/create.mli
+++ b/lib/multimodal/create.mli
@@ -1,0 +1,115 @@
+(** Create — factory constructors for {!Artifact.t} values.
+
+    Cycle 24-25 / Tier A7 (first half).
+
+    {1 What this module is}
+
+    Convenience constructors for the four artifact kinds, plus
+    payload-shape shortcuts. Each kind has a dedicated factory
+    that narrows the phantom witness on the returned
+    {!Artifact.t}, so handlers downstream can take advantage of
+    compile-time kind discrimination without manually
+    constructing the record.
+
+    Tier A7's second half (workspace + dashboard route) builds
+    on this module to register artifacts into the {!Workspace}
+    registry; the dashboard `/api/v1/artifacts/*` route lands
+    in a subsequent PR.
+
+    {1 Provenance defaults}
+
+    Every constructor accepts an optional [?origins] list and a
+    required [~created_by] / [~created_at] pair. When [origins]
+    is omitted, the artifact is treated as the start of a new
+    creation chain (no predecessors) and {!Provenance_stub.empty}
+    is used.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+(** {1 Code artifact} *)
+
+val create_code :
+  id:Shared_types.Artifact_id.t ->
+  payload:Payload.t ->
+  ?metadata:Yojson.Safe.t ->
+  ?origins:Shared_types.Artifact_id.t list ->
+  created_by:string ->
+  created_at:float ->
+  unit ->
+  Artifact.code Artifact.t
+
+(** {1 Image artifact} *)
+
+val create_image :
+  id:Shared_types.Artifact_id.t ->
+  payload:Payload.t ->
+  ?metadata:Yojson.Safe.t ->
+  ?origins:Shared_types.Artifact_id.t list ->
+  created_by:string ->
+  created_at:float ->
+  unit ->
+  Artifact.image Artifact.t
+
+(** {1 Audio artifact} *)
+
+val create_audio :
+  id:Shared_types.Artifact_id.t ->
+  payload:Payload.t ->
+  ?metadata:Yojson.Safe.t ->
+  ?origins:Shared_types.Artifact_id.t list ->
+  created_by:string ->
+  created_at:float ->
+  unit ->
+  Artifact.audio Artifact.t
+
+(** {1 Doc artifact} *)
+
+val create_doc :
+  id:Shared_types.Artifact_id.t ->
+  payload:Payload.t ->
+  ?metadata:Yojson.Safe.t ->
+  ?origins:Shared_types.Artifact_id.t list ->
+  created_by:string ->
+  created_at:float ->
+  unit ->
+  Artifact.doc Artifact.t
+
+(** {1 Payload-shape shortcuts}
+
+    Each shortcut wraps a payload constructor + the kind factory
+    above so callers do not need to manually construct
+    {!Payload.t}. *)
+
+val create_with_blob_ref :
+  kind:'a Artifact.kind ->
+  id:Shared_types.Artifact_id.t ->
+  blob_ref:string ->
+  ?metadata:Yojson.Safe.t ->
+  ?origins:Shared_types.Artifact_id.t list ->
+  created_by:string ->
+  created_at:float ->
+  unit ->
+  'a Artifact.t
+
+val create_with_streaming :
+  kind:'a Artifact.kind ->
+  id:Shared_types.Artifact_id.t ->
+  bytes_so_far:int ->
+  ?metadata:Yojson.Safe.t ->
+  ?origins:Shared_types.Artifact_id.t list ->
+  created_by:string ->
+  created_at:float ->
+  unit ->
+  'a Artifact.t
+
+val create_with_lazy_payload :
+  kind:'a Artifact.kind ->
+  id:Shared_types.Artifact_id.t ->
+  thunk:(unit -> string) ->
+  ?metadata:Yojson.Safe.t ->
+  ?origins:Shared_types.Artifact_id.t list ->
+  created_by:string ->
+  created_at:float ->
+  unit ->
+  'a Artifact.t

--- a/lib/multimodal/workspace.ml
+++ b/lib/multimodal/workspace.ml
@@ -1,0 +1,91 @@
+(* Workspace — Cycle 24-25 / Tier A7 first half.
+   See workspace.mli for design rationale. *)
+
+module Aid = Shared_types.Artifact_id
+
+type t = {
+  artifacts : (Aid.t * Artifact.any) list;
+      (* keyed assoc; latest add replaces existing key *)
+  dag : Multimodal_hydrator.provenance_dag;
+}
+
+let empty = { artifacts = []; dag = Multimodal_hydrator.empty_dag }
+
+let add ws (artifact : Artifact.any) =
+  let id = Artifact.any_id artifact in
+  let without =
+    List.filter (fun (k, _) -> not (Aid.equal k id)) ws.artifacts
+  in
+  { ws with artifacts = without @ [ (id, artifact) ] }
+
+let has_id ws id =
+  List.exists (fun (k, _) -> Aid.equal k id) ws.artifacts
+
+let add_edge ws ~from_id ~to_id =
+  if (not (has_id ws from_id)) || not (has_id ws to_id) then ws
+  else
+    {
+      ws with
+      dag = Multimodal_hydrator.add_edge ws.dag ~from_id ~to_id;
+    }
+
+let remove ws id =
+  let filtered =
+    List.filter (fun (k, _) -> not (Aid.equal k id)) ws.artifacts
+  in
+  { ws with artifacts = filtered }
+
+let find_by_id ws id =
+  List.find_map
+    (fun (k, v) -> if Aid.equal k id then Some v else None)
+    ws.artifacts
+
+let all ws =
+  List.sort
+    (fun (a, _) (b, _) -> Aid.compare a b)
+    ws.artifacts
+  |> List.map snd
+
+let size ws = List.length ws.artifacts
+
+let list_by_kind_tag ws tag =
+  List.filter_map
+    (fun (_, any) ->
+      let any_kind = Artifact.any_kind_of any in
+      if Artifact.any_kind_to_tag any_kind = tag then Some any
+      else None)
+    ws.artifacts
+
+let timeline ws =
+  let with_ts =
+    List.map
+      (fun (_, any) ->
+        let (Artifact.Any a) = any in
+        (a.Artifact.provenance.Provenance_stub.created_at, any))
+      ws.artifacts
+  in
+  List.sort (fun (a, _) (b, _) -> Float.compare a b) with_ts
+  |> List.map snd
+
+let search_metadata_key ws key =
+  List.filter_map
+    (fun (_, any) ->
+      let (Artifact.Any a) = any in
+      match a.Artifact.metadata with
+      | `Assoc kv when List.mem_assoc key kv -> Some any
+      | _ -> None)
+    ws.artifacts
+
+let provenance_dag ws = ws.dag
+
+let origins_of ws id = Multimodal_hydrator.origins_of ws.dag id
+
+let descendants_of ws id = Multimodal_hydrator.descendants_of ws.dag id
+
+let to_json ws =
+  `Assoc
+    [
+      ( "artifacts",
+        `List (List.map (fun (_, any) -> Artifact.any_to_json any) ws.artifacts) );
+      ("dag", Multimodal_hydrator.dag_to_json ws.dag);
+    ]

--- a/lib/multimodal/workspace.mli
+++ b/lib/multimodal/workspace.mli
@@ -1,0 +1,105 @@
+(** Workspace — multimodal artifact registry + gallery.
+
+    Cycle 24-25 / Tier A7 (first half).
+
+    {1 What this module is}
+
+    A persistent registry binding {!Artifact_id.t} → {!Artifact.any},
+    bundled with a {!Multimodal_hydrator.provenance_dag} and
+    queryable views (timeline by creation time, filter by kind,
+    metadata-key search). The runtime backbone of the
+    "workspace gallery" surface; the dashboard
+    `/api/v1/artifacts/*` route in the A7 second-half PR
+    consumes this registry without modifying it.
+
+    {1 Persistence semantics}
+
+    Workspace values are immutable — every mutation
+    ({!add}, {!add_edge}, {!remove}) returns a new value with
+    the same id-key contract. Callers that need a long-lived
+    workspace store the value behind a ref or atomic.
+
+    {1 Why not just use a [Hashtbl]?}
+
+    The dashboard route + tests need a deterministic snapshot.
+    A [Hashtbl] surfaces insertion-order or hash-derived
+    iteration order across OCaml versions; the immutable
+    record here uses an association list keyed on
+    {!Artifact_id.t} (UUID v7 is monotonic) so {!timeline}
+    returns the same order regardless of host.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+(** {1 Workspace value} *)
+
+type t
+
+val empty : t
+(** A workspace with zero artifacts and an empty
+    {!Multimodal_hydrator.provenance_dag}. *)
+
+(** {1 Mutators (return new value)} *)
+
+val add : t -> Artifact.any -> t
+(** [add ws artifact] inserts (or replaces) the artifact
+    keyed by its id. *)
+
+val add_edge :
+  t ->
+  from_id:Shared_types.Artifact_id.t ->
+  to_id:Shared_types.Artifact_id.t ->
+  t
+(** Append a provenance edge to the workspace's DAG. Both
+    endpoints must already be present — [add_edge] is a
+    no-op (returns the workspace unchanged) when either is
+    missing, mirroring the
+    {!Multimodal_hydrator.add_edge} dedupe semantics. *)
+
+val remove : t -> Shared_types.Artifact_id.t -> t
+(** [remove ws id] drops the artifact at [id] (no-op if
+    absent). DAG edges referencing the dropped id are
+    {b not} pruned — Tier A10 may add a verification helper
+    that flags orphan edges. *)
+
+(** {1 Queries} *)
+
+val find_by_id :
+  t -> Shared_types.Artifact_id.t -> Artifact.any option
+
+val all : t -> Artifact.any list
+(** All artifacts in id order (UUID v7 ⇒ creation-time
+    monotonic). *)
+
+val size : t -> int
+
+val list_by_kind_tag :
+  t -> Artifact.kind_tag -> Artifact.any list
+(** Artifacts whose kind matches the supplied tag. *)
+
+val timeline : t -> Artifact.any list
+(** Artifacts sorted by [provenance.created_at] ascending. *)
+
+val search_metadata_key : t -> string -> Artifact.any list
+(** Artifacts whose [metadata] is an [`Assoc] containing the
+    given key. *)
+
+val provenance_dag : t -> Multimodal_hydrator.provenance_dag
+(** Direct access to the DAG (for use with
+    {!Multimodal_hydrator.hydrate}). *)
+
+val origins_of :
+  t ->
+  Shared_types.Artifact_id.t ->
+  Shared_types.Artifact_id.t list
+
+val descendants_of :
+  t ->
+  Shared_types.Artifact_id.t ->
+  Shared_types.Artifact_id.t list
+
+(** {1 JSON} *)
+
+val to_json : t -> Yojson.Safe.t
+(** Encodes the registry as
+    [\{ "artifacts": [ ... ], "dag": {...} \}]. *)

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_artifact test_multimodal_hydrator)
+ (names test_artifact test_multimodal_hydrator test_create test_workspace)
  (libraries multimodal shared_types yojson))

--- a/test/multimodal/test_create.ml
+++ b/test/multimodal/test_create.ml
@@ -1,0 +1,126 @@
+(* Cycle 24-25 / Tier A7 — Multimodal.Create tests. *)
+
+module C = Multimodal.Create
+module A = Multimodal.Artifact
+module P = Multimodal.Payload
+module Pr = Multimodal.Provenance_stub
+module Aid = Shared_types.Artifact_id
+
+(* ─── kind-specific factories ─────────────────────────────────── *)
+
+let test_create_code_returns_code_kind () =
+  let id = Aid.generate () in
+  let a =
+    C.create_code ~id ~payload:(P.Blob_ref "code-blob") ~created_by:"executor"
+      ~created_at:1.0 ()
+  in
+  match a.A.kind with A.Code -> () | _ -> assert false
+
+let test_create_image_returns_image_kind () =
+  let id = Aid.generate () in
+  let a =
+    C.create_image ~id ~payload:(P.Streaming 512) ~created_by:"executor"
+      ~created_at:2.0 ()
+  in
+  match a.A.kind with A.Image -> () | _ -> assert false
+
+let test_create_audio_returns_audio_kind () =
+  let id = Aid.generate () in
+  let a =
+    C.create_audio ~id
+      ~payload:(P.Lazy_payload (fun () -> ""))
+      ~created_by:"scholar" ~created_at:3.0 ()
+  in
+  match a.A.kind with A.Audio -> () | _ -> assert false
+
+let test_create_doc_returns_doc_kind () =
+  let id = Aid.generate () in
+  let a =
+    C.create_doc ~id ~payload:(P.Blob_ref "doc-blob") ~created_by:"verifier"
+      ~created_at:4.0 ()
+  in
+  match a.A.kind with A.Doc -> () | _ -> assert false
+
+(* ─── Provenance defaults ─────────────────────────────────────── *)
+
+let test_origins_default_to_empty_list () =
+  let id = Aid.generate () in
+  let a =
+    C.create_code ~id ~payload:(P.Blob_ref "x") ~created_by:"executor"
+      ~created_at:1.0 ()
+  in
+  assert (a.A.provenance.Pr.origin_artifact_ids = [])
+
+let test_origins_when_supplied () =
+  let parent = Aid.generate () in
+  let id = Aid.generate () in
+  let a =
+    C.create_code ~id ~payload:(P.Blob_ref "x") ~origins:[ parent ]
+      ~created_by:"executor" ~created_at:1.0 ()
+  in
+  assert (List.length a.A.provenance.Pr.origin_artifact_ids = 1);
+  assert (Aid.equal (List.hd a.A.provenance.Pr.origin_artifact_ids) parent)
+
+let test_metadata_default_is_null () =
+  let id = Aid.generate () in
+  let a =
+    C.create_code ~id ~payload:(P.Blob_ref "x") ~created_by:"executor"
+      ~created_at:1.0 ()
+  in
+  assert (a.A.metadata = `Null)
+
+let test_metadata_when_supplied () =
+  let id = Aid.generate () in
+  let meta = `Assoc [ ("lang", `String "ocaml") ] in
+  let a =
+    C.create_code ~id ~payload:(P.Blob_ref "x") ~metadata:meta
+      ~created_by:"executor" ~created_at:1.0 ()
+  in
+  assert (a.A.metadata = meta)
+
+(* ─── Payload-shape shortcuts ─────────────────────────────────── *)
+
+let test_create_with_blob_ref () =
+  let id = Aid.generate () in
+  let a =
+    C.create_with_blob_ref ~kind:A.Image ~id ~blob_ref:"blob-x"
+      ~created_by:"executor" ~created_at:1.0 ()
+  in
+  match a.A.payload with
+  | P.Blob_ref s -> assert (s = "blob-x")
+  | _ -> assert false
+
+let test_create_with_streaming () =
+  let id = Aid.generate () in
+  let a =
+    C.create_with_streaming ~kind:A.Audio ~id ~bytes_so_far:1024
+      ~created_by:"executor" ~created_at:1.0 ()
+  in
+  match a.A.payload with
+  | P.Streaming n -> assert (n = 1024)
+  | _ -> assert false
+
+let test_create_with_lazy_payload () =
+  let id = Aid.generate () in
+  let a =
+    C.create_with_lazy_payload ~kind:A.Code ~id
+      ~thunk:(fun () -> "thunked")
+      ~created_by:"executor" ~created_at:1.0 ()
+  in
+  match a.A.payload with
+  | P.Lazy_payload f -> assert (f () = "thunked")
+  | _ -> assert false
+
+let () =
+  test_create_code_returns_code_kind ();
+  test_create_image_returns_image_kind ();
+  test_create_audio_returns_audio_kind ();
+  test_create_doc_returns_doc_kind ();
+  test_origins_default_to_empty_list ();
+  test_origins_when_supplied ();
+  test_metadata_default_is_null ();
+  test_metadata_when_supplied ();
+  test_create_with_blob_ref ();
+  test_create_with_streaming ();
+  test_create_with_lazy_payload ();
+  print_endline "test_create: all assertions passed"

--- a/test/multimodal/test_workspace.ml
+++ b/test/multimodal/test_workspace.ml
@@ -1,0 +1,148 @@
+(* Cycle 24-25 / Tier A7 — Multimodal.Workspace tests. *)
+
+module W = Multimodal.Workspace
+module C = Multimodal.Create
+module A = Multimodal.Artifact
+module P = Multimodal.Payload
+module Aid = Shared_types.Artifact_id
+
+let make_doc id ts =
+  C.create_doc ~id ~payload:(P.Blob_ref (Aid.to_string id))
+    ~metadata:(`Assoc [ ("title", `String ("doc-" ^ Aid.to_string id)) ])
+    ~created_by:"executor" ~created_at:ts ()
+
+let make_image id ts =
+  C.create_image ~id ~payload:(P.Streaming 0) ~created_by:"executor"
+    ~created_at:ts ()
+
+(* ─── empty / size / add ──────────────────────────────────────── *)
+
+let test_empty () =
+  assert (W.size W.empty = 0);
+  assert (W.all W.empty = [])
+
+let test_add_increments_size () =
+  let id = Aid.generate () in
+  let ws = W.add W.empty (A.Any (make_doc id 1.0)) in
+  assert (W.size ws = 1)
+
+let test_add_replaces_existing_id () =
+  let id = Aid.generate () in
+  let ws0 = W.add W.empty (A.Any (make_doc id 1.0)) in
+  let ws = W.add ws0 (A.Any (make_doc id 2.0)) in
+  assert (W.size ws = 1)
+
+(* ─── find / remove ───────────────────────────────────────────── *)
+
+let test_find_by_id_present () =
+  let id = Aid.generate () in
+  let ws = W.add W.empty (A.Any (make_doc id 1.0)) in
+  match W.find_by_id ws id with
+  | Some _ -> ()
+  | None -> assert false
+
+let test_find_by_id_missing () =
+  let missing = Aid.generate () in
+  assert (W.find_by_id W.empty missing = None)
+
+let test_remove () =
+  let id = Aid.generate () in
+  let ws0 = W.add W.empty (A.Any (make_doc id 1.0)) in
+  let ws = W.remove ws0 id in
+  assert (W.size ws = 0);
+  assert (W.find_by_id ws id = None)
+
+let test_remove_missing_is_noop () =
+  let id = Aid.generate () in
+  let missing = Aid.generate () in
+  let ws = W.add W.empty (A.Any (make_doc id 1.0)) in
+  let ws' = W.remove ws missing in
+  assert (W.size ws' = 1)
+
+(* ─── list_by_kind_tag ────────────────────────────────────────── *)
+
+let test_list_by_kind_tag () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let id3 = Aid.generate () in
+  let ws0 = W.add W.empty (A.Any (make_doc id1 1.0)) in
+  let ws1 = W.add ws0 (A.Any (make_image id2 2.0)) in
+  let ws = W.add ws1 (A.Any (make_doc id3 3.0)) in
+  assert (List.length (W.list_by_kind_tag ws A.Tag_doc) = 2);
+  assert (List.length (W.list_by_kind_tag ws A.Tag_image) = 1);
+  assert (List.length (W.list_by_kind_tag ws A.Tag_code) = 0)
+
+(* ─── timeline ────────────────────────────────────────────────── *)
+
+let test_timeline_sorts_by_created_at () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let id3 = Aid.generate () in
+  let ws0 = W.add W.empty (A.Any (make_doc id3 30.0)) in
+  let ws1 = W.add ws0 (A.Any (make_doc id1 10.0)) in
+  let ws = W.add ws1 (A.Any (make_doc id2 20.0)) in
+  let line = W.timeline ws in
+  assert (List.length line = 3);
+  let first = List.nth line 0 in
+  let last = List.nth line 2 in
+  assert (Aid.equal (A.any_id first) id1);
+  assert (Aid.equal (A.any_id last) id3)
+
+(* ─── search_metadata_key ─────────────────────────────────────── *)
+
+let test_search_metadata_key_matches () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let ws0 = W.add W.empty (A.Any (make_doc id1 1.0)) in
+  let ws = W.add ws0 (A.Any (make_image id2 2.0)) in
+  assert (List.length (W.search_metadata_key ws "title") = 1);
+  assert (List.length (W.search_metadata_key ws "nonexistent_key") = 0)
+
+(* ─── DAG integration ─────────────────────────────────────────── *)
+
+let test_add_edge_with_both_present () =
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let ws0 = W.add W.empty (A.Any (make_doc id1 1.0)) in
+  let ws1 = W.add ws0 (A.Any (make_doc id2 2.0)) in
+  let ws = W.add_edge ws1 ~from_id:id1 ~to_id:id2 in
+  assert (W.origins_of ws id2 = [ id1 ]);
+  assert (W.descendants_of ws id1 = [ id2 ])
+
+let test_add_edge_missing_endpoint_is_noop () =
+  let id1 = Aid.generate () in
+  let id_missing = Aid.generate () in
+  let ws0 = W.add W.empty (A.Any (make_doc id1 1.0)) in
+  let ws = W.add_edge ws0 ~from_id:id1 ~to_id:id_missing in
+  (* edge not added because id_missing is not present *)
+  assert (W.descendants_of ws id1 = [])
+
+(* ─── JSON ────────────────────────────────────────────────────── *)
+
+let test_to_json_shape () =
+  let id1 = Aid.generate () in
+  let ws = W.add W.empty (A.Any (make_doc id1 1.0)) in
+  match W.to_json ws with
+  | `Assoc kv ->
+      assert (List.mem_assoc "artifacts" kv);
+      assert (List.mem_assoc "dag" kv);
+      (match List.assoc "artifacts" kv with
+       | `List xs -> assert (List.length xs = 1)
+       | _ -> assert false)
+  | _ -> assert false
+
+let () =
+  test_empty ();
+  test_add_increments_size ();
+  test_add_replaces_existing_id ();
+  test_find_by_id_present ();
+  test_find_by_id_missing ();
+  test_remove ();
+  test_remove_missing_is_noop ();
+  test_list_by_kind_tag ();
+  test_timeline_sorts_by_created_at ();
+  test_search_metadata_key_matches ();
+  test_add_edge_with_both_present ();
+  test_add_edge_missing_endpoint_is_noop ();
+  test_to_json_shape ();
+  print_endline "test_workspace: all assertions passed"


### PR DESCRIPTION
## Summary

Tier A7 first half — type-discriminated artifact factories plus an immutable workspace registry. The dashboard `/api/v1/artifacts/*` route is deferred to the A7.2 follow-up PR.

## Modules

| Module | Surface |
|--------|---------|
| `Create` | `create_code` / `create_image` / `create_audio` / `create_doc` per-kind factories returning phantom-narrowed `'a Artifact.t`. Payload-shape shortcuts: `create_with_blob_ref` / `create_with_streaming` / `create_with_lazy_payload`. |
| `Workspace` | Immutable registry: `add` / `add_edge` / `remove` mutators (return new value). Queries: `find_by_id`, `all` (id-sorted), `list_by_kind_tag`, `timeline` (created_at-sorted), `search_metadata_key`, `origins_of` / `descendants_of`. JSON encoding `{ "artifacts": [...], "dag": {...} }`. |

## Why immutable + assoc list (not `Hashtbl`)

The dashboard route + tests need deterministic ordering across OCaml versions. `Hashtbl` surfaces insertion-order or hash-derived iteration order. The assoc list keyed on `Artifact_id.t` (UUID v7 ⇒ monotonic) gives stable ordering for the gallery view.

## `add_edge` semantics

`add_edge ws ~from_id ~to_id` is a no-op (returns `ws` unchanged) when either endpoint is absent — preserving the `Multimodal_hydrator.add_edge` dedupe contract. Tier A10 may add a verification helper that flags orphan edges left after `remove`.

## Plan §2.2 reference

| Tier | LoC | Risk |
|------|-----|------|
| **A7** (first half) | 614 / 7 files | Medium (dashboard route deferred to A7.2) |

base=main (`281317a0a6`).

## Test plan

- [x] `dune build --root . lib/multimodal test/multimodal` GREEN
- [x] `dune runtest --root . test/multimodal --force` GREEN — 26 new assertions
  - `test_create` (11): kind-specific factory output, origins default + supplied, metadata default + supplied, payload-shape shortcuts for blob_ref / streaming / lazy_payload
  - `test_workspace` (15): empty/size/add, add replaces existing id, find_by_id present + missing, remove + remove-missing-noop, list_by_kind_tag for 3 kinds, timeline sort, search_metadata_key match + miss, add_edge both-present + missing-endpoint no-op, to_json shape
- [x] Race check `gh pr list --search "multimodal_create OR multimodal_workspace OR ..."` → 0 open
- [ ] CI Build and Test green after push

## Related

- A7.2 (dashboard `/api/v1/artifacts/*` route + Tool_set `Creative` preset wiring) lands separately.
- B8 (✅), B9 (✅) merged.
- A10 (consensus + audit + Multimodal Review bridge) waits on A9.2 (deliberation driver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)