### PR TITLE
ci: PR-scoped concurrency + merged-PR guard for pr-automation/tokens-drift

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -17,10 +17,22 @@ permissions:
   issues: write
   pull-requests: write
 
+# Cancel superseded PR-Automation runs for the same PR. Multiple
+# labeled/unlabeled/synchronize events on the same PR otherwise stack
+# into duplicate runs (observed 2026-04-29: feature/board-core-mli,
+# feature/ds-v2-dialog-anim-wiring, fix/ir3-checkpoint-error).
+concurrency:
+  group: pr-automation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   draft-automerge-guard:
     name: Draft Auto-Merge Guard
     runs-on: ubuntu-latest
+    # Skip when the PR is already closed/merged. labeled/unlabeled
+    # events on pull_request_target can fire after merge (post-merge
+    # automation removing labels), causing wasted runs.
+    if: ${{ github.event.pull_request.state != 'closed' && github.event.pull_request.merged != true }}
     steps:
       - name: Keep draft PRs draft-only unless explicitly approved
         uses: actions/github-script@v9
@@ -342,7 +354,7 @@ jobs:
   label-and-review:
     runs-on: ubuntu-latest
     needs: draft-automerge-guard
-    if: ${{ !cancelled() && needs.draft-automerge-guard.result == 'success' && contains(fromJSON('["opened","reopened","synchronize","ready_for_review"]'), github.event.action) }}
+    if: ${{ !cancelled() && needs.draft-automerge-guard.result == 'success' && contains(fromJSON('["opened","reopened","synchronize","ready_for_review"]'), github.event.action) && github.event.pull_request.state != 'closed' && github.event.pull_request.merged != true }}
     steps:
       - name: Auto label and optional reviewer request
         uses: actions/github-script@v9

--- a/.github/workflows/tokens-drift.yml
+++ b/.github/workflows/tokens-drift.yml
@@ -41,6 +41,11 @@ permissions:
   contents: read
   pull-requests: read
 
+# Cancel in-flight runs when a new commit is pushed to the same PR.
+concurrency:
+  group: tokens-drift-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Generated artifact paths kept here as a single list for re-use across
 # the diff and tier-integrity gates. Update this list together with
 # build.ts OUT entries.


### PR DESCRIPTION
## 목적

`pr-automation.yml`, `tokens-drift.yml`에 PR번호 기준 concurrency를 추가하고, `pr-automation.yml`에는 머지/클로즈된 PR에서의 후발화 가드를 더해 GitHub Actions 낭비를 줄입니다.

## 근거 (실측, 2026-04-29 ~30분 window)

`gh run list --limit 30` 기준 동일 브랜치에서 같은 워크플로가 짧은 간격으로 중복 큐잉된 사례:

| 브랜치 | 워크플로 | 간격 | 사유 추정 |
|---|---|---|---|
| `feature/board-core-mli` | PR Automation | 34s | labeled → synchronize |
| `feature/ds-v2-dialog-anim-wiring` | PR Automation | 129s | 동상 |
| `fix/ir3-checkpoint-error` | PR Automation | 32s | 동상 |

`ci.yml`은 이미 `cancel-in-progress: PR-only` 패턴이라 이 문제 없음 → 손대지 않습니다.

## 변경

### `.github/workflows/pr-automation.yml`
1. 파일 상단 `concurrency` 블록 추가
   - `group: pr-automation-${{ github.event.pull_request.number }}`
   - `cancel-in-progress: true`
   - 다른 PR끼리는 직렬화되지 않음 (PR번호 기준 분리)
2. 두 job(`draft-automerge-guard`, `label-and-review`)에 가드 추가
   - `github.event.pull_request.state != 'closed' && github.event.pull_request.merged != true`
   - `pull_request_target`의 `labeled/unlabeled`가 머지 후 post-merge label 정리 시 발화하는 케이스 차단

### `.github/workflows/tokens-drift.yml`
- 동일한 PR-scoped concurrency 추가. 경로 필터로 빈도가 낮지만 cancel-on-superseded는 무비용.

## 영향 추정

- pr-automation 런 수 약 30~40% 감소 (위 표 기준)
- tokens-drift는 작음 (경로 필터가 이미 대부분 차단)
- 잘못된 동시성 그룹으로 다른 PR이 막힐 가능성: 없음 (PR번호 분리)

## 적용 시점 주의

`pull_request_target`은 **base branch 버전의 워크플로**가 실행되므로, 이 변경은 **main 머지 이후 새로 트리거되는 이벤트부터 효과**가 있습니다. 기존 큐잉된 런에는 영향 없습니다.

## 건드리지 않은 것

- `ci.yml` 858줄 (이미 `cancel-in-progress: PR-only` + surface-detect로 절제됨)
- `release.yml`, `deploy-railway.yml` (이미 concurrency 있음)
- `webrtc-live-interop.yml` (주 1회 cron, 영향 미미)
- 모든 job 로직

## Test plan

- [ ] CI Gate green
- [ ] 머지 후 다음 PR 사이클에서 `gh run list`로 중복 pr-automation 런 사라지는지 확인
- [ ] 동일 PR에서 빠르게 두 번 push했을 때 첫 런이 cancelled로 마무리되는지 확인