### PR TITLE
test(a11y): batch 11 — status-chip, sparkline, route-link (cycle 30)

### DIFF
--- a/dashboard/src/components/common/route-link.a11y.test.ts
+++ b/dashboard/src/components/common/route-link.a11y.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for RouteLink. Anchor element with hash href +
+// modifier-key passthrough (cmd+click opens in new tab). Tests pin
+// that aria-current=page and the focus ring don't introduce axe
+// violations across the navigation tab variants.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { RouteLink } from './route-link'
+
+describe('RouteLink a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default link passes axe', async () => {
+    render(
+      html`<${RouteLink} tab="overview">Overview</${RouteLink}>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('aria-current=page passes axe', async () => {
+    render(
+      html`<${RouteLink} tab="monitoring" ariaCurrent="page">Monitoring</${RouteLink}>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with title attribute passes axe', async () => {
+    render(
+      html`<${RouteLink}
+        tab="logs"
+        title="Open the system logs view"
+      >Logs</${RouteLink}>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('link with params passes axe', async () => {
+    render(
+      html`<${RouteLink}
+        tab="command"
+        params=${{ keeper: 'sigma' }}
+      >Command sigma</${RouteLink}>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/sparkline.a11y.test.ts
+++ b/dashboard/src/components/common/sparkline.a11y.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for Sparkline. Canvas-based chart — accessible
+// name comes from auto-generated aria-label OR caller override OR
+// aria-hidden=true (when an adjacent numeric label already announces
+// the value). Tests pin all three modes axe-clean.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { Sparkline } from './sparkline'
+
+describe('Sparkline a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default auto-aria-label passes axe', async () => {
+    render(
+      html`<${Sparkline} values=${[10, 12, 14, 13, 15, 18]} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('caller-supplied ariaLabel passes axe', async () => {
+    render(
+      html`<${Sparkline}
+        values=${[1, 2, 3, 4, 5]}
+        ariaLabel="Latency trend rising"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('decorative (ariaHidden=true) sparkline passes axe', async () => {
+    render(
+      html`<div>
+        <span>42</span>
+        <${Sparkline} values=${[40, 41, 42]} ariaHidden=${true} />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('insufficient data (< 2 points) renders accessibly', async () => {
+    render(html`<${Sparkline} values=${[5]} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/status-chip.a11y.test.ts
+++ b/dashboard/src/components/common/status-chip.a11y.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for StatusChip — pill renders status verdicts
+// across the dashboard. Two API surfaces (legacy `label` prop + modern
+// `children`) plus tone palette + uppercase toggle. Tests guard that
+// every combination remains axe-clean (no aria-prohibited-attr from
+// span chips and no contrast issues at the chip level).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { StatusChip } from './status-chip'
+
+describe('StatusChip a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('legacy label prop passes axe', async () => {
+    render(html`<${StatusChip} label="OK" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('children API passes axe', async () => {
+    render(html`<${StatusChip}>Active</${StatusChip}>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('tone variants (semantic enum + raw Tailwind) pass axe', async () => {
+    render(
+      html`<div>
+        <${StatusChip} label="OK" tone="ok" />
+        <${StatusChip} label="WARN" tone="warn" />
+        <${StatusChip} label="ERR" tone="err" />
+        <${StatusChip} label="custom" tone="bg-[var(--accent-12)] text-white" />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('uppercase=false (plain pill) passes axe', async () => {
+    render(
+      html`<${StatusChip} uppercase=${false}>file/path.ts</${StatusChip}>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

Lane C batch 11 — 3 dashboard atoms gain jest-axe coverage (12 cases).

## Atoms

| Atom | Cases | Coverage focus |
|------|-------|----------------|
| `StatusChip` | 4 | legacy `label` vs modern `children` API; tone palette (semantic enum + raw Tailwind); uppercase=true/false |
| `Sparkline` | 4 | auto-generated aria-label, caller override, decorative (ariaHidden=true), insufficient-data (< 2 points) |
| `RouteLink` | 4 | default anchor, aria-current=page, title attr, params object |

## Verification

- `pnpm test` (vitest happy-dom) → **12/12 passing**, 1.67s
- jest-axe + axe-core report 0 violations for every case

## Pattern

Same as batches 1-10: `<vitest-environment happy-dom>` + Preact `render` + `htm/preact` + `axe(container).toHaveNoViolations()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)