### PR TITLE
spec(resilience): add ResilienceOutcome.tla — I5 catch-up ternary lattice invariants

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -203,6 +203,9 @@ run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 # Cycle 24 — Multimodal artifact GADT well-formedness (Tier B8 catch-up).
 run_tlc "$REPO_ROOT/specs/multimodal" "MultimodalArtifact.tla"
 
+# Cycle 19 — Resilience_outcome ternary lattice (Tier I5 catch-up).
+run_tlc "$REPO_ROOT/specs/resilience" "ResilienceOutcome.tla"
+
 # Optional: run TraceSpec if --trace flag provided
 if [ "${1:-}" = "--trace" ]; then
   TRACE_SPEC="$REPO_ROOT/specs/keeper-state-machine/KeeperTraceSpec.tla"

--- a/specs/resilience/ResilienceOutcome.cfg
+++ b/specs/resilience/ResilienceOutcome.cfg
@@ -1,0 +1,15 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    ArtifactIds = {a1, a2}
+    Strategies = {Retry, Fallback, Handoff, Abort}
+
+CONSTRAINT
+    BoundedOutcomes
+
+INVARIANTS
+    TypeOK
+    ConfidenceInRange
+    DegradationLevelInRange
+    CompletedFailedDisjoint
+    RecoveryStrategyDeclared

--- a/specs/resilience/ResilienceOutcome.tla
+++ b/specs/resilience/ResilienceOutcome.tla
@@ -1,0 +1,161 @@
+---- MODULE ResilienceOutcome ----
+\* Cycle 19 / Tier I5 catch-up spec.
+\*
+\* Models the ternary outcome GADT exposed by
+\* lib/shared_types/resilience_outcome.{mli,ml}:
+\*
+\*   FullSuccess { value, confidence, artifacts }
+\*   PartialSuccess { value, completed, failed, confidence, degradation_level }
+\*   GracefulFailure { fallback, reason, recovery_strategy, confidence }
+\*
+\* This spec captures the well-formedness invariants that hold
+\* across constructor sites and field updates:
+\*
+\*   - confidence is in [0, 1] (modelled as a denominator / max ratio)
+\*   - degradation_level is in [1, 4] (PartialSuccess only)
+\*   - completed and failed artifact sets are disjoint
+\*   - the recovery_strategy field of GracefulFailure is non-empty
+\*
+\* OCaml <-> TLA+ mapping:
+\*
+\*   variable                | OCaml site
+\*   ------------------------+--------------------------------------------------
+\*   outcomes                | a snapshot list of outcome records that callers
+\*                           | have produced; runtime does not own a registry.
+\*
+\*   record fields (per-class)
+\*     class                 | "full" | "partial" | "graceful"
+\*     confidence_num        | Confidence.to_float * confidence_den
+\*     degradation_level     | Resilience_outcome.PartialSuccess.degradation_level
+\*     completed             | Resilience_outcome.PartialSuccess.completed (artifact ids)
+\*     failed                | keys of Resilience_outcome.PartialSuccess.failed list
+\*     recovery_strategy     | Resilience_outcome.GracefulFailure.recovery_strategy
+
+EXTENDS TLC, Naturals, Sequences, FiniteSets
+
+CONSTANTS
+    ArtifactIds,    \* finite universe of artifact ids
+    Strategies      \* finite universe of recovery_strategy strings (non-empty)
+
+\* Confidence is modelled as confidence_num / confidence_den, with
+\* confidence_den fixed at 100 so the legal range is [0, 100].
+ConfidenceMax == 100
+
+OutcomeClass == {"full", "partial", "graceful"}
+
+Outcome == [
+    class : OutcomeClass,
+    confidence_num : 0..ConfidenceMax,
+    degradation_level : 1..4,
+    completed : SUBSET ArtifactIds,
+    failed : SUBSET ArtifactIds,
+    recovery_strategy : Strategies
+]
+
+VARIABLES
+    outcomes        \* finite sequence of Outcome values produced so far
+
+vars == <<outcomes>>
+
+\* ── Type invariant ───────────────────────────────────────────────
+\* outcomes is a finite sequence (Seq) of Outcome records. We
+\* bound the sequence length via a separate model constant in
+\* the .cfg if needed; here we rely on Init starting empty and
+\* AppendOutcome adding one at a time.
+TypeOK ==
+    \A i \in 1..Len(outcomes) :
+        outcomes[i] \in Outcome
+
+\* ── Per-class well-formedness ────────────────────────────────────
+ConfidenceInRange ==
+    \A i \in 1..Len(outcomes) :
+        outcomes[i].confidence_num >= 0
+        /\ outcomes[i].confidence_num <= ConfidenceMax
+
+DegradationLevelInRange ==
+    \A i \in 1..Len(outcomes) :
+        outcomes[i].degradation_level >= 1
+        /\ outcomes[i].degradation_level <= 4
+
+CompletedFailedDisjoint ==
+    \A i \in 1..Len(outcomes) :
+        outcomes[i].class # "partial" \/
+        outcomes[i].completed \cap outcomes[i].failed = {}
+
+RecoveryStrategyDeclared ==
+    \A i \in 1..Len(outcomes) :
+        outcomes[i].class # "graceful" \/
+        outcomes[i].recovery_strategy \in Strategies
+
+\* ── Init / Next ──────────────────────────────────────────────────
+Init ==
+    outcomes = << >>
+
+(* Construct a candidate outcome with arbitrary chosen field
+   values, gated on the per-class semantics. The spec forbids
+   ill-formed candidates from being appended; runtime enforces
+   the same via constructor-site validation. *)
+AppendFull(conf, arts) ==
+    /\ conf \in 0..ConfidenceMax
+    /\ arts \subseteq ArtifactIds
+    /\ outcomes' =
+        Append(outcomes,
+               [ class |-> "full",
+                 confidence_num |-> conf,
+                 degradation_level |-> 1,
+                 completed |-> arts,
+                 failed |-> {},
+                 recovery_strategy |-> CHOOSE s \in Strategies : TRUE ])
+
+AppendPartial(conf, completed, failed, level) ==
+    /\ conf \in 0..ConfidenceMax
+    /\ completed \subseteq ArtifactIds
+    /\ failed \subseteq ArtifactIds
+    /\ completed \cap failed = {}
+    /\ level \in 1..4
+    /\ outcomes' =
+        Append(outcomes,
+               [ class |-> "partial",
+                 confidence_num |-> conf,
+                 degradation_level |-> level,
+                 completed |-> completed,
+                 failed |-> failed,
+                 recovery_strategy |-> CHOOSE s \in Strategies : TRUE ])
+
+AppendGraceful(conf, strategy) ==
+    /\ conf \in 0..ConfidenceMax
+    /\ strategy \in Strategies
+    /\ outcomes' =
+        Append(outcomes,
+               [ class |-> "graceful",
+                 confidence_num |-> conf,
+                 degradation_level |-> 1,
+                 completed |-> {},
+                 failed |-> {},
+                 recovery_strategy |-> strategy ])
+
+Next ==
+    \/ \E conf \in {0, 50, 100}, arts \in SUBSET ArtifactIds :
+            AppendFull(conf, arts)
+    \/ \E conf \in {0, 50, 100},
+          completed \in SUBSET ArtifactIds,
+          failed \in SUBSET ArtifactIds,
+          level \in 1..4 :
+            AppendPartial(conf, completed, failed, level)
+    \/ \E conf \in {0, 50, 100}, strategy \in Strategies :
+            AppendGraceful(conf, strategy)
+
+Spec == Init /\ [][Next]_vars
+
+\* State-space bound for TLC: keep the outcomes sequence small
+\* enough to enumerate exhaustively. Wired in via the .cfg
+\* CONSTRAINT clause.
+BoundedOutcomes == Len(outcomes) <= 2
+
+THEOREM Spec => []TypeOK
+THEOREM Spec => []ConfidenceInRange
+THEOREM Spec => []DegradationLevelInRange
+THEOREM Spec => []CompletedFailedDisjoint
+THEOREM Spec => []RecoveryStrategyDeclared
+
+====


### PR DESCRIPTION
## Summary

Tier I5 (Resilience_outcome stub GADT) shipped to main without the companion TLA+ spec required by plan §5. This catch-up PR adds the spec + cfg + `tla-check.sh` wire-up. Same 3-piece pattern as the `MultimodalArtifact.tla` catch-up (#11849).

## Spec model

A finite sequence `outcomes` of `Outcome` records, where each record carries `class \in {full, partial, graceful}` plus per-class fields. Three actions (`AppendFull`, `AppendPartial`, `AppendGraceful`) gated on the per-class semantics — ill-formed candidates are not appendable.

## Invariants

| Invariant | Statement |
|-----------|-----------|
| `TypeOK` | every entry has the correct shape and field types |
| `ConfidenceInRange` | `confidence_num \in [0, 100]` (modelled as numerator over fixed denominator 100) |
| `DegradationLevelInRange` | `degradation_level \in [1, 4]` (PartialSuccess only; canonicalised for the other classes) |
| `CompletedFailedDisjoint` | `PartialSuccess.completed \cap PartialSuccess.failed = {}` |
| `RecoveryStrategyDeclared` | `GracefulFailure.recovery_strategy \in Strategies` |

## State-space bound

`BoundedOutcomes == Len(outcomes) <= 2` wired via `.cfg CONSTRAINT` so TLC enumeration finishes deterministically. The first cfg attempt used a literal `Len(outcomes) <= 2` in the CONSTRAINT clause, which TLC rejected (CONSTRAINT must reference a named operator); refactor to a top-level `BoundedOutcomes` operator was the fix.

## Local verification

```
$ java -cp ~/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC \
    -config specs/resilience/ResilienceOutcome.cfg \
    -workers auto -deadlock specs/resilience/ResilienceOutcome.tla
…
Model checking completed. No error has been found.
2317525 states generated, 17557 distinct states found, 0 states left on queue.
The depth of the complete state graph search is 3.
Finished in 06s
```

`cfg`: `ArtifactIds = {a1, a2}`, `Strategies = {Retry, Fallback, Handoff, Abort}`, `BoundedOutcomes ≤ 2`.

## Plan §5 reference

| Spec file | Tier | Refines |
|-----------|------|---------|
| `specs/resilience/ResilienceOutcome.tla` | **I5** | (independent — ternary outcome lattice) |

## Test plan

- [x] Local TLC GREEN — 17557 distinct states, depth 3, no error.
- [x] `scripts/tla-check.sh` wire-up: 1 line under the existing `run_tlc` invocations.
- [x] Race check `gh pr list --search "ResilienceOutcome OR ..."` → 0 open
- [ ] CI tla-check green after push

## Related

- Companion of `MultimodalArtifact.tla` catch-up (✅ #11849).
- Cycle 27 follow-up specs (`ResilienceDegradation`, `MultimodalHydrator`, `CrewDeliberation`, `SharedAudit`, `AutonomousPhase`, `AutonomousLoop`) deferred to subsequent catch-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)