### PR TITLE
spec(shared): add SharedAudit.tla — I6 catch-up Merkle chain integrity

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -206,6 +206,9 @@ run_tlc "$REPO_ROOT/specs/multimodal" "MultimodalArtifact.tla"
 # Cycle 19 — Resilience_outcome ternary lattice (Tier I5 catch-up).
 run_tlc "$REPO_ROOT/specs/resilience" "ResilienceOutcome.tla"
 
+# Cycle 19 — Shared_audit Merkle chain integrity (Tier I6 catch-up).
+run_tlc "$REPO_ROOT/specs/shared" "SharedAudit.tla"
+
 # Optional: run TraceSpec if --trace flag provided
 if [ "${1:-}" = "--trace" ]; then
   TRACE_SPEC="$REPO_ROOT/specs/keeper-state-machine/KeeperTraceSpec.tla"

--- a/specs/shared/SharedAudit.cfg
+++ b/specs/shared/SharedAudit.cfg
@@ -1,0 +1,14 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Ids = {id1, id2, id3, id4}
+    Categories = {RecoveryAttempted, DegradationTriggered}
+
+CONSTRAINT
+    BoundedEntries
+
+INVARIANTS
+    TypeOK
+    IdsUnique
+    ChainIntegrity
+    EntryIdMinted

--- a/specs/shared/SharedAudit.tla
+++ b/specs/shared/SharedAudit.tla
@@ -1,0 +1,119 @@
+---- MODULE SharedAudit ----
+\* Cycle 19 / Tier I6 catch-up spec.
+\*
+\* Models the Merkle-chained immutable audit log exposed by
+\* lib/shared_audit/{envelope,store}.{mli,ml}. Each entry
+\* carries an id, timestamp, category, payload, and the SHA256
+\* digest (prev_hash) of the previous entry's canonical JSON.
+\* The chain ensures tamper detection: any modification to an
+\* entry breaks the prev_hash field of the next entry, surfaced
+\* via Store.verify_chain.
+\*
+\* The hash function is abstracted here as identity over the id
+\* field — that is, hash(entry) == entry.id. This is sufficient
+\* to model the chain integrity invariants because:
+\*
+\*   - Envelope.make generates a fresh unique id per entry, so
+\*     equality of ids implies equality of entries.
+\*   - The runtime SHA256 digest is collision-resistant; modelling
+\*     hash via id-equality preserves chain integrity reasoning
+\*     while keeping the state space small enough for TLC.
+\*
+\* OCaml <-> TLA+ mapping:
+\*
+\*   variable                 | OCaml site
+\*   -------------------------+--------------------------------------------
+\*   entries                  | Store.t internal append-only list
+\*   entries[i].id            | Envelope.t.id (ULID-shaped)
+\*   entries[i].prev_hash     | Envelope.t.prev_hash (None for genesis,
+\*                            | Some (hash_for_chain entries[i-1]) otherwise)
+\*   entries[i].category      | Envelope.t.category (e.g. "RecoveryAttempted",
+\*                            | "DegradationTriggered", "DeliberationTransition")
+
+EXTENDS TLC, Naturals, Sequences, FiniteSets
+
+CONSTANTS
+    Ids,            \* finite universe of envelope ids
+    Categories      \* finite universe of category strings
+
+\* Sentinel for the genesis entry's prev_hash field — encoded as
+\* a string so the [prev_hash] type stays homogeneous.
+GenesisHash == "__genesis__"
+
+Envelope == [
+    id : Ids,
+    category : Categories,
+    prev_hash : Ids \cup {GenesisHash}
+]
+
+VARIABLES
+    entries,        \* finite sequence of Envelope values
+    used_ids        \* set of ids already minted (Envelope.make freshness)
+
+vars == <<entries, used_ids>>
+
+(* The canonical hash of an envelope is, in this model, its id.
+   The runtime computes a SHA256 over canonical JSON; we abstract
+   to id-equality because that is the property the chain
+   integrity invariant depends on. *)
+HashOf(env) == env.id
+
+\* ── Type invariant ───────────────────────────────────────────────
+TypeOK ==
+    /\ \A i \in 1..Len(entries) : entries[i] \in Envelope
+    /\ used_ids \subseteq Ids
+
+\* Every minted id must appear in used_ids and at most once in
+\* entries — Envelope.make guarantees freshness.
+IdsUnique ==
+    \A i \in 1..Len(entries) :
+        \A j \in 1..Len(entries) :
+            i # j => entries[i].id # entries[j].id
+
+\* The genesis entry (entries[1]) has prev_hash = GenesisHash.
+\* All later entries chain from the previous via HashOf.
+ChainIntegrity ==
+    /\ Len(entries) > 0 => entries[1].prev_hash = GenesisHash
+    /\ \A i \in 2..Len(entries) :
+            entries[i].prev_hash = HashOf(entries[i-1])
+
+\* Every entry's id must already be in used_ids — minted before
+\* (or at the moment of) appending.
+EntryIdMinted ==
+    \A i \in 1..Len(entries) :
+        entries[i].id \in used_ids
+
+\* ── Init / Next ──────────────────────────────────────────────────
+Init ==
+    /\ entries = << >>
+    /\ used_ids = {}
+
+\* Append a fresh entry with the chain-derived prev_hash.
+AppendEntry(new_id, cat) ==
+    /\ new_id \notin used_ids
+    /\ used_ids' = used_ids \cup {new_id}
+    /\ LET prev == IF Len(entries) = 0
+                   THEN GenesisHash
+                   ELSE HashOf(entries[Len(entries)])
+       IN entries' =
+            Append(entries,
+                   [ id |-> new_id,
+                     category |-> cat,
+                     prev_hash |-> prev ])
+
+Next ==
+    \E new_id \in Ids, cat \in Categories :
+        AppendEntry(new_id, cat)
+
+Spec == Init /\ [][Next]_vars
+
+\* State-space bound for TLC: keep the chain short enough to
+\* enumerate exhaustively. Wired in via the .cfg CONSTRAINT.
+BoundedEntries == Len(entries) <= 3
+
+THEOREM Spec => []TypeOK
+THEOREM Spec => []IdsUnique
+THEOREM Spec => []ChainIntegrity
+THEOREM Spec => []EntryIdMinted
+
+====


### PR DESCRIPTION
## Summary

Tier I6 (Shared_audit envelope + store) shipped to main without the companion TLA+ spec required by plan §5. This catch-up PR adds the spec + cfg + `tla-check.sh` wire-up — companion of the I5 ResilienceOutcome (#11868) and B8 MultimodalArtifact (✅ #11849) catch-ups.

## Spec model

Models the Merkle-chained immutable audit log:

```
entries : Seq(Envelope)
Envelope == [ id : Ids, category : Categories, prev_hash : Ids ∪ {GenesisHash} ]
```

The hash function is abstracted as identity over the id field. `Envelope.make` guarantees fresh unique ids (so equality of ids implies equality of entries), and the runtime SHA256 digest is collision-resistant. Modelling hash via id-equality preserves chain integrity reasoning while keeping the state space small enough for TLC.

## Invariants

| Invariant | Statement |
|-----------|-----------|
| `TypeOK` | every entry conforms to the Envelope shape; `used_ids ⊆ Ids` |
| `IdsUnique` | no two entries share the same id (`Envelope.make` freshness) |
| `ChainIntegrity` | `entries[1].prev_hash = GenesisHash` and `entries[i].prev_hash = HashOf(entries[i-1])` for `i ≥ 2` |
| `EntryIdMinted` | every entry's id is in `used_ids` — minted before (or at the moment of) appending |

## State-space bound

`BoundedEntries == Len(entries) <= 3` wired via `.cfg CONSTRAINT`. Same operator-via-cfg pattern as the ResilienceOutcome catch-up.

## Local verification

```
$ java -cp ~/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC \
    -config specs/shared/SharedAudit.cfg \
    -workers auto -deadlock specs/shared/SharedAudit.tla
…
Model checking completed. No error has been found.
633 states generated, 249 distinct states found, 0 states left on queue.
The depth of the complete state graph search is 4.
Finished in 03s
```

`cfg`: `Ids = {id1, id2, id3, id4}`, `Categories = {RecoveryAttempted, DegradationTriggered}`, `BoundedEntries ≤ 3`.

## Plan §5 reference

| Spec file | Tier | Refines |
|-----------|------|---------|
| `specs/shared/SharedAudit.tla` | **I6** | (independent — Merkle chain invariant) |

## Test plan

- [x] Local TLC GREEN — 249 distinct states, depth 4, no error.
- [x] `scripts/tla-check.sh` wire-up: 1 line under the Multimodal entry.
- [x] Race check `gh pr list --search "SharedAudit OR ..."` → 0 directly overlapping (only #11868 ResilienceOutcome is sibling, distinct file).
- [ ] CI tla-check green after push

## Related

- Companion of MultimodalArtifact (✅ #11849) and ResilienceOutcome (#11868) catch-ups. Same 3-piece pattern (spec + cfg + tla-check wire-up) and operator-via-cfg CONSTRAINT.
- Cycle 27 follow-up specs (`ResilienceDegradation`, `MultimodalHydrator`, `CrewDeliberation`, `AutonomousPhase`, `AutonomousLoop`) deferred to subsequent catch-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)