### PR TITLE
chore(board): add board.mli — top-level cascade facade pin (cycle 199)

### DIFF
--- a/lib/board.mli
+++ b/lib/board.mli
@@ -1,0 +1,24 @@
+(** Board — top-level public facade for the board store.
+
+    The .ml is a single line: [include Board_votes].  This
+    .mli mirrors the cascade with [include module type of
+    struct include Board_votes end] so type identity is
+    preserved end-to-end across the four-hop chain
+    {!Board_types} → {!Board_core_classify} →
+    {!Board_core_payload} (cascaded inside {!Board_core}) →
+    {!Board_core} → {!Board_votes} → {!Board}.
+
+    Callers reach the entire board surface — store /
+    persistence / classification / payload normalisation /
+    voting / karma / flair — through {!Board.X} unqualified
+    after [open Masc_mcp].  478 dotted [Board.X] call sites
+    in lib + bin + test all resolve through this cascade.
+
+    No locally-defined surface; this facade has no
+    behavioural code of its own.  Every entry visible from
+    {!Board} traces back to one of the four upstream
+    modules. *)
+
+include module type of struct
+  include Board_votes
+end


### PR DESCRIPTION
## Summary
- Add `lib/board.mli` — 1-line cascade-include over `Board_votes`.
- 4-hop chain complete: `Board_types` → `Board_core_classify` → `Board_core_payload` (cascaded inside `Board_core`) → `Board_core` (cycle 197) → `Board_votes` (cycle 198) → `Board` (this PR).

## Surface
- Cascade-include `Board_votes` via `include module type of struct include M end` form so type identity propagates end-to-end (cycle 187 rationale).
- 478 dotted `Board.X` call sites in lib + bin + test all resolve through this cascade — no locally-defined surface.

## Verification
- `dune build lib/ test/` clean (new default workflow per cycle 198 amend lesson — module-alias grep miss prevention).
- 0 `module [A-Z]+ = ...Board` aliases in test/ (no test-alias risk).

## Test plan
- [x] `dune build lib/ test/` clean
- [ ] required CI checks