### PR TITLE
fix(dashboard): swallow subscribeDashboardRoute promise rejection in app.ts

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -164,7 +164,12 @@ export function App() {
     // Cancel any pending SSE-triggered refreshes from the previous tab
     // to prevent stale fetch results arriving after navigation (C-4/M-12).
     cancelPendingSSERefreshes()
-    void subscribeDashboardRoute(route.value)
+    // Swallow + log subscribe rejections (timeout / closed socket) here so
+    // they do not surface as Uncaught (in promise) noise in DevTools.  The
+    // ws layer owns reconnect on failure (see dashboard-ws.ts onopen path).
+    subscribeDashboardRoute(route.value).catch(err => {
+      console.warn('[dashboard] subscribeDashboardRoute failed', err)
+    })
     refreshCurrentRoute({ recordVisit: true })
   }, [route.value.tab, route.value.params.section, route.value.params.view, route.value.params.q])
 


### PR DESCRIPTION
## Summary
- Replace `void subscribeDashboardRoute(...)` with explicit `.catch(err => console.warn(...))` so timeout / closed-socket rejections no longer surface as `Uncaught (in promise)` noise in DevTools.

## Reproduction
User reported (2026-04-29):
```
Uncaught (in promise) Error: dashboard websocket rpc timed out: dashboard/subscribe
  at index-CiCwI1O3.js:46:93943
```

## Why `void` was insufficient
`void promise` discards the resolved value but does NOT attach a rejection handler, so an unhandled rejection still bubbles up to `window.onunhandledrejection` and the V8 console reporter. The `void` operator was likely added for the no-await lint rule, not for error handling.

## Recovery semantics unchanged
The ws layer already owns reconnect on failure — see `reconnectAfterCurrentSocketFailure` catch in `dashboard-ws.ts` onopen path (line 398). Dropping the rejection at the `app.ts` call site does not change reconnect behaviour; it just suppresses the user-visible stack trace.

## Scope
- This patch only addresses the **unhandled-rejection symptom** (frontend noise).
- The underlying server-side hang on `dashboard/subscribe` (why the RPC times out in the first place) is tracked separately as a server-side investigation.

## Test plan
- [x] Diff applies cleanly.
- [ ] CI typecheck (this branch contains no `node_modules`, local pnpm typecheck skipped — will rely on CI).
- [ ] Manual: navigate between dashboard tabs while ws is unavailable, verify console shows `[dashboard] subscribeDashboardRoute failed` instead of `Uncaught (in promise)`.