### PR TITLE
fix(dashboard): resolve CSS vars for cytoscape + cap retry log + drop unsupported shadow-*

### DIFF
--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -29,25 +29,55 @@ export interface FsmGraphSpec {
   direction?: 'TB' | 'LR'
 }
 
-// Color palette matching dashboard dark theme
-const NODE_COLORS: Record<FsmNode['type'], { bg: string; border: string; text: string }> = {
-  state:    { bg: 'var(--slate-800)', border: 'var(--slate-600)', text: 'var(--frost-100)' },
-  active:   { bg: '#065f46', border: 'var(--emerald)', text: 'var(--white-pure)' },
-  buffer:   { bg: '#78350f', border: 'var(--amber-bright)', text: 'var(--white-pure)' },
-  terminal: { bg: '#7f1d1d', border: 'var(--color-status-err)', text: 'var(--white-pure)' },
-  start:    { bg: 'var(--slate-800)', border: '#6366f1', text: '#c7d2fe' },
-  end:      { bg: 'var(--slate-800)', border: '#6b7280', text: '#9ca3af' },
-  ok:       { bg: '#065f46', border: 'var(--emerald)', text: 'var(--white-pure)' },
-  warn:     { bg: '#78350f', border: 'var(--amber-bright)', text: 'var(--white-pure)' },
-  err:      { bg: '#7f1d1d', border: 'var(--color-status-err)', text: 'var(--white-pure)' },
-  dim:      { bg: 'var(--slate-800)', border: '#374151', text: '#6b7280' },
+// Cytoscape's style parser does not resolve CSS variables — `var(--x)`
+// strings are rejected. Resolve once per render against `:root` and
+// pass literal hex/rgb values into the stylesheet.
+const TOKEN_FALLBACKS: Record<string, string> = {
+  '--slate-800': '#1e293b',
+  '--slate-600': '#475569',
+  '--slate-500': '#64748b',
+  '--slate-400': '#94a3b8',
+  '--frost-100': '#e2e8f0',
+  '--emerald': '#22c55e',
+  '--amber-bright': '#f59e0b',
+  '--color-status-err': '#ef4444',
+  '--white-pure': '#ffffff',
+  '--panel-dark': '#0f172a',
 }
 
-const EDGE_COLORS: Record<string, string> = {
-  normal: 'var(--slate-500)',
-  error: 'var(--color-status-err)',
-  recovery: 'var(--emerald)',
-  cascade: 'var(--amber-bright)',
+function resolveCssVar(token: string): string {
+  // token may be the bare name "--frost-100" or a "var(--frost-100)" wrapper.
+  const m = token.match(/^var\((--[a-z0-9-]+)\)$/i)
+  const name = m ? m[1] : token.startsWith('--') ? token : null
+  if (!name) return token
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return TOKEN_FALLBACKS[name] ?? token
+  }
+  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+  return v || TOKEN_FALLBACKS[name] || token
+}
+
+// Color palette matching dashboard dark theme. Values are resolved
+// lazily inside buildStylesheet/buildNodeColors so that token changes
+// (theme switch) propagate on next render.
+const NODE_COLOR_TOKENS: Record<FsmNode['type'], { bg: string; border: string; text: string }> = {
+  state:    { bg: '--slate-800', border: '--slate-600', text: '--frost-100' },
+  active:   { bg: '#065f46',     border: '--emerald',   text: '--white-pure' },
+  buffer:   { bg: '#78350f',     border: '--amber-bright', text: '--white-pure' },
+  terminal: { bg: '#7f1d1d',     border: '--color-status-err', text: '--white-pure' },
+  start:    { bg: '--slate-800', border: '#6366f1',     text: '#c7d2fe' },
+  end:      { bg: '--slate-800', border: '#6b7280',     text: '#9ca3af' },
+  ok:       { bg: '#065f46',     border: '--emerald',   text: '--white-pure' },
+  warn:     { bg: '#78350f',     border: '--amber-bright', text: '--white-pure' },
+  err:      { bg: '#7f1d1d',     border: '--color-status-err', text: '--white-pure' },
+  dim:      { bg: '--slate-800', border: '#374151',     text: '#6b7280' },
+}
+
+const EDGE_COLOR_TOKENS: Record<string, string> = {
+  normal: '--slate-500',
+  error: '--color-status-err',
+  recovery: '--emerald',
+  cascade: '--amber-bright',
 }
 
 interface CytoscapeFsmProps {
@@ -101,10 +131,10 @@ function buildStylesheet() {
         'text-halign': 'center',
         'font-size': '11px',
         'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
-        color: 'var(--frost-100)',
-        'background-color': 'var(--slate-800)',
+        color: resolveCssVar('--frost-100'),
+        'background-color': resolveCssVar('--slate-800'),
         'border-width': 2,
-        'border-color': 'var(--slate-600)',
+        'border-color': resolveCssVar('--slate-600'),
         shape: 'roundrectangle',
         width: 'label',
         height: 'label',
@@ -118,16 +148,16 @@ function buildStylesheet() {
       style: {
         'curve-style': 'bezier',
         'target-arrow-shape': 'triangle',
-        'target-arrow-color': 'var(--slate-500)',
-        'line-color': 'var(--slate-500)',
+        'target-arrow-color': resolveCssVar('--slate-500'),
+        'line-color': resolveCssVar('--slate-500'),
         width: 1.5,
         label: 'data(label)',
         'font-size': '9px',
         'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
-        color: 'var(--slate-400)',
+        color: resolveCssVar('--slate-400'),
         'text-rotation': 'autorotate',
         'text-margin-y': -8,
-        'text-background-color': 'var(--panel-dark)',
+        'text-background-color': resolveCssVar('--panel-dark'),
         'text-background-opacity': 0.85,
         'text-background-padding': '2px',
         'text-background-shape': 'roundrectangle',
@@ -136,7 +166,7 @@ function buildStylesheet() {
     {
       selector: ':parent',
       style: {
-        'background-color': 'var(--panel-dark)',
+        'background-color': resolveCssVar('--panel-dark'),
         'border-color': '#334155',
         'border-width': 1,
         'border-style': 'dashed',
@@ -144,38 +174,39 @@ function buildStylesheet() {
         'text-halign': 'center',
         padding: '16px',
         'font-size': '10px',
-        color: 'var(--slate-500)',
+        color: resolveCssVar('--slate-500'),
       },
     },
   ]
 
   // Node type-specific styles
-  for (const [type, colors] of Object.entries(NODE_COLORS)) {
+  for (const [type, tokens] of Object.entries(NODE_COLOR_TOKENS)) {
     styles.push({
       selector: `node[nodeType="${type}"]`,
       style: {
-        'background-color': colors.bg,
-        'border-color': colors.border,
-        color: colors.text,
+        'background-color': resolveCssVar(tokens.bg),
+        'border-color': resolveCssVar(tokens.border),
+        color: resolveCssVar(tokens.text),
       },
     })
   }
 
-  // Active node glow effect
+  // Active node emphasis. Cytoscape has no `shadow-*` node properties
+  // (only `text-shadow-*`); use the supported `overlay-*` family plus
+  // a thicker border to convey "active" without warnings.
   styles.push({
     selector: 'node[nodeType="active"]',
     style: {
-      'border-width': 3,
-      'shadow-blur': 12,
-      'shadow-color': 'var(--emerald)',
-      'shadow-opacity': 0.6,
-      'shadow-offset-x': 0,
-      'shadow-offset-y': 0,
+      'border-width': 4,
+      'overlay-color': resolveCssVar('--emerald'),
+      'overlay-opacity': 0.18,
+      'overlay-padding': 6,
     },
   })
 
   // Edge type styles
-  for (const [type, color] of Object.entries(EDGE_COLORS)) {
+  for (const [type, token] of Object.entries(EDGE_COLOR_TOKENS)) {
+    const color = resolveCssVar(token)
     styles.push({
       selector: `edge[edgeType="${type}"]`,
       style: {

--- a/dashboard/src/namespace-truth-actions.ts
+++ b/dashboard/src/namespace-truth-actions.ts
@@ -53,7 +53,6 @@ async function doFetchNamespaceTruth(): Promise<void> {
 
 function scheduleNamespaceWarmRetry(): void {
   warmRetryAttempt++
-  console.debug(`[project-snapshot] warm-up retry ${warmRetryAttempt}/${WARM_MAX_RETRIES}`)
   if (warmRetryAttempt > WARM_MAX_RETRIES) {
     namespaceTruthInitializing.value = false
     namespaceTruthError.value = 'Server warm-up timed out. Try refreshing.'
@@ -61,6 +60,7 @@ function scheduleNamespaceWarmRetry(): void {
     warmRetryAttempt = 0
     return
   }
+  console.debug(`[project-snapshot] warm-up retry ${warmRetryAttempt}/${WARM_MAX_RETRIES}`)
   if (warmRetryTimer) clearTimeout(warmRetryTimer)
   warmRetryTimer = setTimeout(() => {
     warmRetryTimer = null


### PR DESCRIPTION
## 증상 (브라우저 콘솔, 2026-04-29)

대시보드 로드 시 콘솔에 세 종류 이슈 동시 발생.

### 1. cytoscape의 \`var(--*)\` 거부
cytoscape의 스타일 파서는 CSS 변수를 해석하지 않고 리터럴 색만 받습니다. \`'var(--frost-100)'\` 같은 값을 그대로 넘기면 매 렌더 ~30개의 \`The style property color: var(--frost-100) is invalid\` 경고가 찍히고 폴백 색이 적용됩니다.

### 2. 미지원 \`shadow-*\` 속성
cytoscape의 노드 스타일 spec에는 \`shadow-blur/shadow-color/shadow-opacity/shadow-offset-*\`가 **없습니다** (\`text-shadow-*\`만 존재). 활성 노드마다 6개 경고.

### 3. retry 로그 \`11/10\` off-by-one
\`namespace-truth-actions.ts\`의 \`scheduleNamespaceWarmRetry\`가 cap 체크 전에 로그를 찍어서, give-up 직전에 \`warm-up retry 11/10\`이 한 번 인쇄됩니다.

## 변경

### \`dashboard/src/components/common/cytoscape-fsm.ts\`
- \`resolveCssVar(token)\` 추가. \`var(--x)\` 또는 \`--x\` 둘 다 받아서 \`getComputedStyle(documentElement).getPropertyValue\`로 해석. SSR/조기-페인트 대비 정적 폴백 테이블 동봉.
- \`NODE_COLORS\` → \`NODE_COLOR_TOKENS\`로 이름 변경, 값에는 토큰명만 보관. \`buildStylesheet\` 안에서 일괄 \`resolveCssVar\` 적용.
- 활성 노드 글로우: 지원 안 되는 \`shadow-*\` 블록 → cytoscape 지원 \`overlay-color/opacity/padding\` + \`border-width: 4\`로 교체. 시각 효과 유지, 경고 0.

### \`dashboard/src/namespace-truth-actions.ts\`
- \`console.debug\` 로그를 cap 체크 **다음**으로 이동. give-up 시 \`11/10\`은 더 이상 안 찍힘.

## 검증

- \`pnpm typecheck\` clean
- \`pnpm lint\` clean
- \`pnpm build\` success (1m 37s)

## 범위 밖 (별도 트랙)

- \`width: 'label'\` / \`height: 'label'\` deprecation: cytoscape API 마이그레이션 별도 작업.
- 서버 \`/api/v1/dashboard/project-snapshot\` 첫 응답 30s+: 서버 init pipeline 조사 필요. retry 폴링은 클라가 우아하게 견디므로 분리.

## Test plan

- [ ] CI green
- [ ] 머지 후 대시보드에서 활성 노드 시각 효과 확인 (외곽 글로우 → 오버레이로 시각적 동등)
- [ ] 콘솔에 \`The style property ... is invalid\` 경고 사라지는지 확인
- [ ] init 시점에 \`warm-up retry N/10\`만 N=1..10 범위 내로 찍히는지 확인