### PR TITLE
fix(dashboard): silence cytoscape style warnings (var, label, shadow, wheel)

### DIFF
--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -6,6 +6,28 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import type cytoscape from 'cytoscape'
 import { InlineSpinner } from './inline-spinner'
 
+// Cytoscape's style language doesn't accept CSS custom properties directly —
+// it parses `var(--x)` as an unknown literal and silently drops the property.
+// Resolve to the actual computed color at stylesheet-build time.
+function resolveCssVar(value: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback
+  const match = /^var\((--[^)]+)\)$/.exec(value.trim())
+  const name = match?.[1]
+  if (!name) return value
+  const computed = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim()
+  return computed || fallback
+}
+
+function resolveNodeColor(c: { bg: string; border: string; text: string }) {
+  return {
+    bg: resolveCssVar(c.bg, '#1e293b'),
+    border: resolveCssVar(c.border, '#475569'),
+    text: resolveCssVar(c.text, '#f1f5f9'),
+  }
+}
+
 // Types for graph spec (consumed by all 3 FSM builders)
 export interface FsmNode {
   id: string
@@ -101,13 +123,14 @@ function buildStylesheet() {
         'text-halign': 'center',
         'font-size': '11px',
         'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
-        color: 'var(--frost-100)',
-        'background-color': 'var(--slate-800)',
+        color: resolveCssVar('var(--frost-100)', '#cbd5e1'),
+        'background-color': resolveCssVar('var(--slate-800)', '#1e293b'),
         'border-width': 2,
-        'border-color': 'var(--slate-600)',
+        'border-color': resolveCssVar('var(--slate-600)', '#475569'),
         shape: 'roundrectangle',
-        width: 'label',
-        height: 'label',
+        // 'auto' sizes the node to its label bbox; 'label' was deprecated.
+        width: 'auto',
+        height: 'auto',
         padding: '10px',
         'text-wrap': 'wrap',
         'text-max-width': '120px',
@@ -118,16 +141,16 @@ function buildStylesheet() {
       style: {
         'curve-style': 'bezier',
         'target-arrow-shape': 'triangle',
-        'target-arrow-color': 'var(--slate-500)',
-        'line-color': 'var(--slate-500)',
+        'target-arrow-color': resolveCssVar('var(--slate-500)', '#64748b'),
+        'line-color': resolveCssVar('var(--slate-500)', '#64748b'),
         width: 1.5,
         label: 'data(label)',
         'font-size': '9px',
         'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
-        color: 'var(--slate-400)',
+        color: resolveCssVar('var(--slate-400)', '#94a3b8'),
         'text-rotation': 'autorotate',
         'text-margin-y': -8,
-        'text-background-color': 'var(--panel-dark)',
+        'text-background-color': resolveCssVar('var(--panel-dark)', '#0f172a'),
         'text-background-opacity': 0.85,
         'text-background-padding': '2px',
         'text-background-shape': 'roundrectangle',
@@ -136,7 +159,7 @@ function buildStylesheet() {
     {
       selector: ':parent',
       style: {
-        'background-color': 'var(--panel-dark)',
+        'background-color': resolveCssVar('var(--panel-dark)', '#0f172a'),
         'border-color': '#334155',
         'border-width': 1,
         'border-style': 'dashed',
@@ -144,13 +167,14 @@ function buildStylesheet() {
         'text-halign': 'center',
         padding: '16px',
         'font-size': '10px',
-        color: 'var(--slate-500)',
+        color: resolveCssVar('var(--slate-500)', '#64748b'),
       },
     },
   ]
 
   // Node type-specific styles
-  for (const [type, colors] of Object.entries(NODE_COLORS)) {
+  for (const [type, raw] of Object.entries(NODE_COLORS)) {
+    const colors = resolveNodeColor(raw)
     styles.push({
       selector: `node[nodeType="${type}"]`,
       style: {
@@ -161,21 +185,19 @@ function buildStylesheet() {
     })
   }
 
-  // Active node glow effect
+  // Active node emphasis. Cytoscape core has no `shadow-*` properties — they
+  // were silently dropped before. Use a thicker border instead, which is
+  // visually unambiguous and survives layout/zoom without canvas overhead.
   styles.push({
     selector: 'node[nodeType="active"]',
     style: {
-      'border-width': 3,
-      'shadow-blur': 12,
-      'shadow-color': 'var(--emerald)',
-      'shadow-opacity': 0.6,
-      'shadow-offset-x': 0,
-      'shadow-offset-y': 0,
+      'border-width': 4,
     },
   })
 
   // Edge type styles
-  for (const [type, color] of Object.entries(EDGE_COLORS)) {
+  for (const [type, raw] of Object.entries(EDGE_COLORS)) {
+    const color = resolveCssVar(raw, '#64748b')
     styles.push({
       selector: `edge[edgeType="${type}"]`,
       style: {
@@ -218,7 +240,10 @@ export function CytoscapeFsm({ spec, height = '280px', class: className = '' }: 
           } as cytoscape.LayoutOptions,
           minZoom: 0.3,
           maxZoom: 3,
-          wheelSensitivity: 0.3,
+          // wheelSensitivity intentionally left at default (1).
+          // Cytoscape warns against custom values because zoom feel
+          // depends on hardware (mouse vs trackpad) and OS scroll
+          // settings; the previous 0.3 made trackpads feel sluggish.
           boxSelectionEnabled: false,
           selectionType: 'single',
           userPanningEnabled: true,


### PR DESCRIPTION
## 증상

FSM 패널 (KSM/KTC/KDP/KCL/KMC + memory tier + pipeline) 마운트할 때마다 브라우저 콘솔에 ~30개 경고 발생:

```
The style property `color: var(--frost-100)` is invalid
The style property `background-color: var(--slate-800)` is invalid
The style value of `label` is deprecated for `width`
The style property `shadow-blur: 12` is invalid
You have set a custom wheel sensitivity. ...
```

## 근본 원인 (4 종)

1. **CSS var passthrough** — Cytoscape 스타일 언어는 자체 parser. `var(--frost-100)` 같은 CSS custom property를 그대로 던지면 unknown literal 로 파싱 → 그 속성 통째로 silent drop. 가장 큰 batch (~25 경고).
2. **`width/height: 'label'`** — Cytoscape 3.x 에서 `'auto'` + `text-max-width` 패턴으로 deprecated.
3. **`shadow-*` properties** — Cytoscape core 스타일 vocabulary 에 없음. Active-node glow effect 가 이미 silent drop 중.
4. **`wheelSensitivity: 0.3`** — Cytoscape 자체가 \"하드웨어 의존적이라 custom 값 권장 안 함\" 경고. Trackpad 사용자에겐 sluggish 한 느낌만 줌.

## 변경

단일 파일 (`dashboard/src/components/common/cytoscape-fsm.ts`):

| Before | After | 이유 |
|--------|-------|------|
| `'background-color': 'var(--slate-800)'` | `resolveCssVar('var(--slate-800)', '#1e293b')` | CSS var 런타임 해결 |
| `width: 'label', height: 'label'` | `width: 'auto', height: 'auto'` | API deprecation |
| `'shadow-blur': 12, 'shadow-color': ..., ...` | `'border-width': 4` | shadow 미지원 → border 강조로 대체 |
| `wheelSensitivity: 0.3` | (removed, defaults to 1) | hardware-dependent 경고 제거 |

총 **1 file, +46 lines, -21 lines**.

### Helper 도입

```ts
function resolveCssVar(value: string, fallback: string): string {
  if (typeof window === 'undefined') return fallback
  const match = /^var\\((--[^)]+)\\)\$/.exec(value.trim())
  const name = match?.[1]
  if (!name) return value
  const computed = getComputedStyle(document.documentElement)
    .getPropertyValue(name)
    .trim()
  return computed || fallback
}
```

NODE_COLORS / EDGE_COLORS literal 은 SSOT 토큰 가독성을 위해 그대로 유지하고, stylesheet 빌드 시점에 일괄 해결. SSR 안전 가드 (`typeof window`) 포함.

## 영향 범위

`cytoscape-fsm.ts` 단독. 다른 cytoscape consumer 들 (`keeper-state-diagram`, `keeper-memory-tier-panel`, `fsm-hub-pipeline-panels`) 은 `var(--…)` 를 Tailwind arbitrary-value class string 안에서만 사용 — CSS 문법으로 정상 처리되므로 무관.

## 검증

- `pnpm typecheck` — pass.
- `pnpm lint` — pass.
- `pnpm build` — pass (1m 19s).
- 콘솔 경고: 30 → 1 (남은 1건은 unrelated extension).

## Trade-offs

- **CSS var resolver 비용**: 컴포넌트 init 시 `getComputedStyle` 약 30 회 호출. Panel-level 컴포넌트라 acceptable. memoised resolver 는 premature optimization 으로 판단.
- **Active-node glow downgrade**: 초록색 halo 사라지고 border-width 만 두꺼워짐. 운영자 가시성 차이가 문제면 후속 PR 에서 `border-color` 애니메이션 레이어 추가 가능.

## 회귀 가능성

- Behavior 변화: 4 가지 모두 \"현재 silent drop 되던 속성을 정상 적용\" 또는 \"deprecated 경고 제거\". 시각적 차이는 (1) var 해결로 색이 정상 적용 (이전엔 무지정 → 검정 fallback) (2) shadow 제거 (이전에도 안 보이던 효과). 두 변화 모두 \"의도된 디자인 복구\" 방향.
- Hardware-dependent zoom 은 user-facing 변화. 이전 `0.3` 에 익숙해진 운영자가 \"줌이 빨라졌다\" 보고할 가능성 있음. Cytoscape 권장이 default 사용.
