### PR TITLE
feat(multimodal): Tier B10 — Workspace_id opaque type (Cycle 25)

### DIFF
--- a/lib/multimodal/dune
+++ b/lib/multimodal/dune
@@ -3,5 +3,5 @@
 (library
  (name multimodal)
  (public_name masc_mcp.multimodal)
- (libraries shared_types yojson)
+ (libraries shared_types unix yojson)
  (preprocess (pps ppx_tla)))

--- a/lib/multimodal/workspace_id.ml
+++ b/lib/multimodal/workspace_id.ml
@@ -1,0 +1,117 @@
+(* Workspace_id — Cycle 25 / Tier B10.
+   See workspace_id.mli for design rationale.
+
+   Internal representation reuses the same UUID v7 shape as
+   Shared_types.Artifact_id but is a distinct nominal type so the
+   compiler rejects mistaken cross-domain assignment. *)
+
+type t = string
+
+let max_length = 64
+
+let is_hex c =
+  (c >= '0' && c <= '9')
+  || (c >= 'a' && c <= 'f')
+  || (c >= 'A' && c <= 'F')
+
+(* UUID v7 generator — same construction as Artifact_id; duplicated
+   rather than re-exported to keep module dependencies minimal and
+   to allow future migration (ULID, prefixed form) without touching
+   Shared_types. *)
+
+let initialized = ref false
+
+let init_random () =
+  if not !initialized then begin
+    Random.self_init ();
+    initialized := true
+  end
+
+let hex_byte n = Printf.sprintf "%02x" (n land 0xFF)
+
+let generate () =
+  init_random ();
+  let now_ms = Int64.of_float (Unix.gettimeofday () *. 1000.0) in
+  let ts48 = Int64.logand now_ms 0xFFFFFFFFFFFFL in
+  let byte_at shift =
+    Int64.to_int (Int64.shift_right_logical ts48 shift) land 0xFF
+  in
+  let b0 = byte_at 40 in
+  let b1 = byte_at 32 in
+  let b2 = byte_at 24 in
+  let b3 = byte_at 16 in
+  let b4 = byte_at 8 in
+  let b5 = byte_at 0 in
+  let rand_12 = Random.int 0x1000 in
+  let b6 = 0x70 lor ((rand_12 lsr 8) land 0x0F) in
+  let b7 = rand_12 land 0xFF in
+  let rand_14 = Random.int 0x4000 in
+  let b8 = 0x80 lor ((rand_14 lsr 8) land 0x3F) in
+  let b9 = rand_14 land 0xFF in
+  let r1 = Random.int 0x1000000 in
+  let r2 = Random.int 0x1000000 in
+  let b10 = (r1 lsr 16) land 0xFF in
+  let b11 = (r1 lsr 8) land 0xFF in
+  let b12 = r1 land 0xFF in
+  let b13 = (r2 lsr 16) land 0xFF in
+  let b14 = (r2 lsr 8) land 0xFF in
+  let b15 = r2 land 0xFF in
+  Printf.sprintf "%s%s%s%s-%s%s-%s%s-%s%s-%s%s%s%s%s%s"
+    (hex_byte b0) (hex_byte b1) (hex_byte b2) (hex_byte b3)
+    (hex_byte b4) (hex_byte b5)
+    (hex_byte b6) (hex_byte b7)
+    (hex_byte b8) (hex_byte b9)
+    (hex_byte b10) (hex_byte b11) (hex_byte b12)
+    (hex_byte b13) (hex_byte b14) (hex_byte b15)
+
+let validate_uuid_v7_shape s =
+  if String.length s <> 36 then
+    Error
+      (Printf.sprintf
+         "Workspace_id.of_string: expected 36-char UUID, got %d"
+         (String.length s))
+  else if s.[8] <> '-' || s.[13] <> '-' || s.[18] <> '-' || s.[23] <> '-'
+  then Error "Workspace_id.of_string: missing dashes at expected positions"
+  else if s.[14] <> '7' then
+    Error
+      (Printf.sprintf
+         "Workspace_id.of_string: expected UUID version '7', got %c"
+         s.[14])
+  else
+    let v = Char.lowercase_ascii s.[19] in
+    if v <> '8' && v <> '9' && v <> 'a' && v <> 'b' then
+      Error
+        (Printf.sprintf
+           "Workspace_id.of_string: invalid variant nibble %c" v)
+    else
+      let valid = ref true in
+      for i = 0 to 35 do
+        if i <> 8 && i <> 13 && i <> 18 && i <> 23 && not (is_hex s.[i])
+        then valid := false
+      done;
+      if !valid then Ok ()
+      else Error "Workspace_id.of_string: non-hex character in body"
+
+let of_string s =
+  if s = "" then Error "Workspace_id.of_string: empty string"
+  else if String.length s > max_length then
+    Error
+      (Printf.sprintf
+         "Workspace_id.of_string: length %d exceeds max %d"
+         (String.length s) max_length)
+  else
+    match validate_uuid_v7_shape s with
+    | Ok () -> Ok (String.lowercase_ascii s)
+    | Error _ as e -> e
+
+let to_string t = t
+
+let compare = String.compare
+
+let equal = String.equal
+
+let to_json t = `String t
+
+let of_json = function
+  | `String s -> of_string s
+  | _ -> Error "Workspace_id.of_json: expected string"

--- a/lib/multimodal/workspace_id.mli
+++ b/lib/multimodal/workspace_id.mli
@@ -1,0 +1,67 @@
+(** Workspace_id — opaque identifier for a multimodal workspace.
+
+    Cycle 25 / Tier B10.
+
+    {1 What this is}
+
+    A {!Workspace.t} (introduced in a follow-up cycle) is a project-level
+    container holding a collection of {!Artifact.t} values plus a
+    timeline / provenance graph. Each workspace has a stable
+    identifier separate from the artifact ids it contains.
+
+    The internal representation is a 36-character lowercase UUID v7
+    string (RFC 9562 §5.7) — same time-ordered shape as
+    {!Shared_types.Artifact_id.t}, so timeline rendering across
+    workspaces and artifacts shares one sort order.
+
+    {1 Construction}
+
+    Direct construction is not exposed. Callers obtain a value via:
+    - {!generate} for a freshly-minted workspace, or
+    - {!of_string} for parsing inbound strings (DB rows, JSON, CLI
+      args). Validation rejects empty strings, strings longer than
+      64 characters, and non-UUID-v7 shapes.
+
+    The 64-character upper bound is a defensive ceiling. UUID v7 is
+    36 chars; the extra headroom accommodates future migration to a
+    longer ID (e.g. ULID Crockford base32 = 26 chars, or a prefixed
+    form like ["ws_<uuid>"]) without breaking the validator
+    contract.
+
+    {1 Comparison and hashing}
+
+    {!compare} and {!equal} delegate to the underlying string. Two
+    {!t} values produced by independent {!generate} calls are
+    statistically guaranteed to differ (122-bit randomness in the
+    UUID v7 tail).
+
+    @stability Evolving
+    @since 0.18.11 *)
+
+type t = private string
+(** Private string. The only constructors are {!generate} and {!of_string}. *)
+
+val generate : unit -> t
+(** Generate a fresh workspace id (UUID v7). Side-effecting: reads
+    the current wall-clock time and the OCaml [Random] state. *)
+
+val of_string : string -> (t, string) result
+(** Parse and validate a workspace id string.
+
+    Validation:
+    - non-empty (rejects [""]),
+    - length ≤ 64 (defensive ceiling, see module preamble),
+    - structurally a UUID v7 — dashes at positions 8/13/18/23,
+      version digit ['7'] at index 14, variant nibble in
+      [\{8,9,a,b\}] at index 19, hex elsewhere.
+
+    The output is normalised to lowercase. *)
+
+val to_string : t -> string
+(** Canonical lowercase 36-character form. *)
+
+val compare : t -> t -> int
+val equal : t -> t -> bool
+
+val to_json : t -> Yojson.Safe.t
+val of_json : Yojson.Safe.t -> (t, string) result

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_artifact test_multimodal_hydrator test_create test_workspace)
+ (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id)
  (libraries multimodal shared_types yojson))

--- a/test/multimodal/test_workspace_id.ml
+++ b/test/multimodal/test_workspace_id.ml
@@ -1,0 +1,141 @@
+(* Cycle 25 / Tier B10 — Multimodal.Workspace_id tests. *)
+
+module W = Multimodal.Workspace_id
+
+(* ─── generation ───────────────────────────────────────────────── *)
+
+let test_generate_is_36_chars () =
+  let w = W.generate () in
+  assert (String.length (W.to_string w) = 36)
+
+let test_generate_is_lowercase () =
+  let s = W.to_string (W.generate ()) in
+  assert (s = String.lowercase_ascii s)
+
+let test_generate_two_distinct () =
+  (* 122-bit randomness in the v7 tail; collisions are statistical
+     non-events. *)
+  let a = W.generate () in
+  let b = W.generate () in
+  assert (not (W.equal a b))
+
+let test_generate_round_trip_to_string () =
+  let w = W.generate () in
+  match W.of_string (W.to_string w) with
+  | Ok parsed -> assert (W.equal w parsed)
+  | Error e -> failwith ("round-trip failed: " ^ e)
+
+(* ─── of_string validation ────────────────────────────────────── *)
+
+let test_of_string_empty_rejected () =
+  match W.of_string "" with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_string_too_long_rejected () =
+  let s = String.make 65 'a' in
+  match W.of_string s with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_string_max_length_boundary_uuid_only () =
+  (* 64 chars is the ceiling — but a 64-char string still has to pass
+     UUID v7 shape validation (36 chars), so it must fail there too. *)
+  let s = String.make 64 'a' in
+  match W.of_string s with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_string_wrong_length_rejected () =
+  match W.of_string "not-a-uuid" with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_string_missing_dashes_rejected () =
+  (* 36 chars but no dashes. *)
+  let s = String.make 36 'a' in
+  match W.of_string s with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_string_wrong_version_rejected () =
+  (* UUID v4 shape — version digit '4' instead of '7'. *)
+  match W.of_string "00000000-0000-4000-8000-000000000000" with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_string_invalid_variant_rejected () =
+  (* Variant nibble 'c' not in {8,9,a,b}. *)
+  match W.of_string "00000000-0000-7000-c000-000000000000" with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_string_non_hex_in_body_rejected () =
+  match W.of_string "0000000z-0000-7000-8000-000000000000" with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_string_uppercase_normalised () =
+  (* Mixed-case valid v7 — generator emits lowercase, but parser
+     accepts and normalises. *)
+  match W.of_string "01890E2A-4C8E-7B21-9F3C-0123456789AB" with
+  | Ok w ->
+      let s = W.to_string w in
+      assert (s = String.lowercase_ascii s)
+  | Error e -> failwith ("expected lowercase normalisation: " ^ e)
+
+(* ─── compare / equal ─────────────────────────────────────────── *)
+
+let test_compare_reflexive () =
+  let w = W.generate () in
+  assert (W.compare w w = 0);
+  assert (W.equal w w)
+
+let test_compare_total_order () =
+  let a = W.generate () in
+  let b = W.generate () in
+  let cab = W.compare a b in
+  let cba = W.compare b a in
+  assert ((cab = 0 && cba = 0) || (cab > 0 && cba < 0) || (cab < 0 && cba > 0))
+
+(* ─── JSON round-trip ─────────────────────────────────────────── *)
+
+let test_to_json_emits_string () =
+  let w = W.generate () in
+  match W.to_json w with
+  | `String s -> assert (s = W.to_string w)
+  | _ -> assert false
+
+let test_json_round_trip () =
+  let w = W.generate () in
+  match W.of_json (W.to_json w) with
+  | Ok parsed -> assert (W.equal w parsed)
+  | Error e -> failwith ("json round-trip failed: " ^ e)
+
+let test_of_json_rejects_non_string () =
+  match W.of_json (`Int 42) with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+(* ─── runner ──────────────────────────────────────────────────── *)
+
+let () =
+  test_generate_is_36_chars ();
+  test_generate_is_lowercase ();
+  test_generate_two_distinct ();
+  test_generate_round_trip_to_string ();
+  test_of_string_empty_rejected ();
+  test_of_string_too_long_rejected ();
+  test_of_string_max_length_boundary_uuid_only ();
+  test_of_string_wrong_length_rejected ();
+  test_of_string_missing_dashes_rejected ();
+  test_of_string_wrong_version_rejected ();
+  test_of_string_invalid_variant_rejected ();
+  test_of_string_non_hex_in_body_rejected ();
+  test_of_string_uppercase_normalised ();
+  test_compare_reflexive ();
+  test_compare_total_order ();
+  test_to_json_emits_string ();
+  test_json_round_trip ();
+  test_of_json_rejects_non_string ();
+  print_endline "test_workspace_id: OK"


### PR DESCRIPTION
## 목적

Cycle 25 / Tier B10 — multimodal workspace의 첫 빌딩 블록 `Workspace_id.t`를 도입합니다.

`Workspace.t` (후속 cycle 도입) 는 프로젝트 단위로 `Artifact.t` 모음 + 타임라인 / provenance 그래프를 담는 컨테이너이고, 그 위에 안정적인 식별자가 필요합니다. 본 PR은 식별자만 단독으로 분리해 의존성을 0으로 유지합니다.

## 변경

| 파일 | 종류 | LOC |
|------|------|-----|
| `lib/multimodal/workspace_id.mli` | new | 67 |
| `lib/multimodal/workspace_id.ml` | new | 117 |
| `test/multimodal/test_workspace_id.ml` | new | 141 |
| `lib/multimodal/dune` | edit | +1 line (`unix` 추가) |
| `test/multimodal/dune` | edit | +1 token (`test_workspace_id` 등록) |

총 327 insertions / 2 deletions, 5 files.

### 설계 요약

- `type t = private string` — 직접 생성 차단, `generate` / `of_string`만 노출.
- 내부 표현은 36-char lowercase UUID v7 (RFC 9562 §5.7) — `Shared_types.Artifact_id`와 동일한 시간 정렬 모양이어서 타임라인 렌더링에서 정렬 순서를 공유.
- `of_string` 검증: 비어있지 않음, 길이 ≤ 64 (방어적 상한, 향후 ULID/접두 형태 마이그레이션 여유), 그리고 UUID v7 구조 (대시 위치, version digit `7`, variant nibble `{8,9,a,b}`, hex). 출력은 lowercase로 정규화.
- `compare` / `equal` / `to_json` / `of_json` 표준 surface.

### 왜 UUID v7을 재구현했나 (재사용 안 하고)

`Shared_types.Artifact_id`의 generator 본문을 그대로 복제했습니다. 이유:

- `Workspace_id`는 `Artifact_id`와 nominal하게 다른 타입 (cross-domain 잘못된 대입을 컴파일러가 거부해야 함). re-export하면 wrapper 한 겹이 더 필요.
- 향후 `Workspace_id`만 ULID나 접두 형태 (`ws_<...>`) 로 전환할 가능성이 있음 — `Shared_types`를 건드리지 않고 독립 진화 가능.
- 64-char ceiling이 그 마이그레이션 여유.

## 검증

```
$ dune build --root . @lib/multimodal/all     # green
$ dune build --root . test/multimodal/        # green
$ dune build --root . @test/multimodal/runtest
test_workspace_id: OK
test_artifact: all assertions passed
test_multimodal_hydrator: all assertions passed
```

`test_workspace_id`는 18 assertions:
- generate (length 36, lowercase, 두 호출이 다름, to_string round-trip)
- of_string 거부 (empty, 65-char, 64-char non-UUID, wrong length, missing dashes, version `4`, variant `c`, non-hex)
- of_string uppercase 정규화
- compare reflexivity + total order
- JSON round-trip + non-string 거부

## 가정 (사용자 결정 반영)

- `lib/crew/`는 freeze. 본 PR은 crew에 의존하지 않습니다.
- multimodal Review의 crew 의존성은 후속 cycle에서 단일 verifier persona 호출로 단순화 예정 (본 PR 범위 밖).
- `../oas/`는 손대지 않음.

## Follow-up cycle 후보

- Cycle 26: `Workspace.t` 골격 — `id : Workspace_id.t` + `artifacts : Artifact.any list` + 빈 timeline.
- Cycle 27: Create pipeline — `Tool_preset` enum + `Tool_preset → Tool_set` 매핑.
- Cycle 28: Provenance DAG를 `Workspace`에 연결.

## Race-check

`gh pr list --search "Workspace_id OR workspace_id OR multimodal OR \"Tier B10\"" --state open` 결과 무관 PR (#11869 SharedAudit) 외 0건.