### PR TITLE
feat(autonomous): Tier B6 — Stimulus taxonomy (Cycle 23)

### DIFF
--- a/lib/autonomous/stimulus.ml
+++ b/lib/autonomous/stimulus.ml
@@ -1,0 +1,134 @@
+(* Stimulus — Cycle 23 / Tier B6.
+   See stimulus.mli for the design rationale. *)
+
+(* ── Source taxonomy ─────────────────────────────────────────────── *)
+
+type source =
+  | User_message [@tla.symbol "user_message"]
+  | Memory_recall [@tla.symbol "memory_recall"]
+  | Discovery_signal [@tla.symbol "discovery_signal"]
+  | Resource_alert [@tla.symbol "resource_alert"]
+  | Goal_phase_change [@tla.symbol "goal_phase_change"]
+  | Priority_shift [@tla.symbol "priority_shift"]
+  | External_event [@tla.symbol "external_event"]
+[@@deriving tla]
+
+(* ── Stimulus value ──────────────────────────────────────────────── *)
+
+type t = {
+  id : string;
+  source : source;
+  payload : Yojson.Safe.t;
+  salience : float;
+  timestamp : float;
+}
+
+(* ── String projection ───────────────────────────────────────────── *)
+
+let source_to_string = to_tla_symbol
+
+let source_of_string = function
+  | "user_message" -> Some User_message
+  | "memory_recall" -> Some Memory_recall
+  | "discovery_signal" -> Some Discovery_signal
+  | "resource_alert" -> Some Resource_alert
+  | "goal_phase_change" -> Some Goal_phase_change
+  | "priority_shift" -> Some Priority_shift
+  | "external_event" -> Some External_event
+  | _ -> None
+
+(* ── Construction ────────────────────────────────────────────────── *)
+
+(* Range check excludes NaN: [Float.is_finite] rejects NaN/Inf, and
+   the bounds are checked separately. We do not coerce out-of-range
+   inputs to a clamped value; that would silently mask emitter bugs
+   and violate the "Unknown → Permissive Default" anti-pattern. *)
+let validate_salience s =
+  if not (Float.is_finite s) then
+    invalid_arg
+      (Printf.sprintf "Stimulus.make: salience not finite (%f)" s);
+  if s < 0.0 || s > 1.0 then
+    invalid_arg
+      (Printf.sprintf "Stimulus.make: salience out of range [0,1]: %f" s)
+
+let validate_id id =
+  if String.length id = 0 then
+    invalid_arg "Stimulus.make: id must be non-empty"
+
+let make ~id ~source ~payload ~salience ~timestamp =
+  validate_id id;
+  validate_salience salience;
+  { id; source; payload; salience; timestamp }
+
+(* ── Scoring ─────────────────────────────────────────────────────── *)
+
+let default_decay = 0.01
+
+let score t ~now =
+  let age = Float.max 0.0 (now -. t.timestamp) in
+  t.salience *. Float.exp (-. default_decay *. age)
+
+(* ── Serialisation ───────────────────────────────────────────────── *)
+
+let to_json t : Yojson.Safe.t =
+  `Assoc
+    [
+      ("id", `String t.id);
+      ("source", `String (source_to_string t.source));
+      ("payload", t.payload);
+      ("salience", `Float t.salience);
+      ("timestamp", `Float t.timestamp);
+    ]
+
+(* Defensive parsing: no exceptions escape — every malformed input
+   maps to [Error msg] with a localised reason. The salience and id
+   validations re-use the construction-time invariants. *)
+let of_json (j : Yojson.Safe.t) : (t, string) result =
+  let ( let* ) = Result.bind in
+  match j with
+  | `Assoc fields ->
+      let lookup k =
+        match List.assoc_opt k fields with
+        | Some v -> Ok v
+        | None -> Error (Printf.sprintf "Stimulus.of_json: missing key %S" k)
+      in
+      let* id_j = lookup "id" in
+      let* id =
+        match id_j with
+        | `String s -> Ok s
+        | _ -> Error "Stimulus.of_json: id must be a string"
+      in
+      let* source_j = lookup "source" in
+      let* source_str =
+        match source_j with
+        | `String s -> Ok s
+        | _ -> Error "Stimulus.of_json: source must be a string"
+      in
+      let* source =
+        match source_of_string source_str with
+        | Some s -> Ok s
+        | None ->
+            Error
+              (Printf.sprintf "Stimulus.of_json: unknown source %S"
+                 source_str)
+      in
+      let* payload = lookup "payload" in
+      let* salience_j = lookup "salience" in
+      let* salience =
+        match salience_j with
+        | `Float f -> Ok f
+        | `Int i -> Ok (float_of_int i)
+        | _ -> Error "Stimulus.of_json: salience must be a number"
+      in
+      let* timestamp_j = lookup "timestamp" in
+      let* timestamp =
+        match timestamp_j with
+        | `Float f -> Ok f
+        | `Int i -> Ok (float_of_int i)
+        | _ -> Error "Stimulus.of_json: timestamp must be a number"
+      in
+      (* Re-run construction-time invariants so [of_json |> to_json]
+         and [make ...] enforce the same range. *)
+      (try Ok (make ~id ~source ~payload ~salience ~timestamp)
+       with Invalid_argument msg -> Error msg)
+  | _ -> Error "Stimulus.of_json: expected JSON object"

--- a/lib/autonomous/stimulus.mli
+++ b/lib/autonomous/stimulus.mli
@@ -1,0 +1,147 @@
+(** Stimulus — a single percept that may trigger autonomous action.
+
+    Cycle 23 / Tier B6 — first cut.
+
+    {1 Scope of this PR}
+
+    - {!source} variant of 7 percept categories with [@@deriving tla]
+      for symbol-table parity with the architecture spec.
+    - {!t} record carrying [id], [source], opaque [payload]
+      ([Yojson.Safe.t]), [salience] in [\[0.0, 1.0\]], and a [timestamp].
+    - {!make} with salience range validation
+      ([Invalid_argument] on violation).
+    - {!score} = [salience * exp(-decay * age)] with default
+      [decay = 0.01], [age = max 0.0 (now - timestamp)].
+    - {!source_to_string} / {!source_of_string} string projections
+      (canonical lowercase, dash-free symbols).
+    - {!to_json} / {!of_json} for deterministic test assertions and
+      future Memory/Checkpoint round-trips. [of_json] returns
+      [Result.t] with a human-readable error string.
+
+    {1 Position in the autonomous loop}
+
+    The Perceive sub-phase aggregates [Stimulus.t] values from
+    upstream channels (user input, episodic recall, discovery, budget,
+    goal lifecycle, priority shifts, opaque external events). The
+    Intend sub-phase consumes them via [Intent_engine.analyze]
+    (Cycle 24 candidate). [Stimulus] itself has no dependency on the
+    rest of the loop — it is a pure value type so it can be unit
+    tested without [Eio_main.run] or any keeper context.
+
+    {1 Rationale}
+
+    {2 Why a record (not an object or first-class module)?}
+
+    A record gives a flat, syntactically uniform shape that maps 1:1
+    to JSON, matches the [autonomous_KEY_INTERFACES.mli] design
+    document, and stays trivially serialisable. The five fields are
+    closed and well-known; adding a new field is a deliberate schema
+    change, not an implicit extension.
+
+    {2 Why [@@deriving tla] on [source] only?}
+
+    [ppx_tla] in this repo derives symbol tables for plain variants
+    (see {!Autonomous_phase.tag}). Records are not currently a
+    supported derive target, so {!t} is hand-serialised in
+    {!to_json} / {!of_json} instead. The architecture spec
+    ([autonomous_KEY_INTERFACES.mli]) places [\[@@deriving tla\]] on
+    both [source] and [t]; we follow the codebase's conservative
+    pattern and only derive on the variant.
+
+    {2 Why [salience] is not a private float type?}
+
+    Range validation happens once at construction in {!make}.
+    Downstream readers can treat [salience] as an opaque
+    [\[0.0, 1.0\]] number; introducing a [Salience.t] private type
+    is a follow-up Tier consideration, not part of B6.
+
+    {1 Deferred}
+
+    - [Stimulus.t] [@@deriving tla] (record support in [ppx_tla]).
+    - Frequency / decay tuning hooks (currently the [decay]
+      parameter is module-private with a single default).
+    - Cross-stimulus de-duplication (responsibility of the Perceive
+      pipeline, not the value type itself). *)
+
+(** {1 Source taxonomy} *)
+
+type source =
+  | User_message [@tla.symbol "user_message"]
+      (** New user input in the conversation context. *)
+  | Memory_recall [@tla.symbol "memory_recall"]
+      (** A salient episodic memory has been surfaced. *)
+  | Discovery_signal [@tla.symbol "discovery_signal"]
+      (** [Proactive_discovery] (later Cycle) found something
+          potentially relevant. *)
+  | Resource_alert [@tla.symbol "resource_alert"]
+      (** A [Resource_budget] threshold has been crossed. *)
+  | Goal_phase_change [@tla.symbol "goal_phase_change"]
+      (** A tracked goal changed [Goal_phase]. *)
+  | Priority_shift [@tla.symbol "priority_shift"]
+      (** [Self_priority] re-ranked one or more entries. *)
+  | External_event [@tla.symbol "external_event"]
+      (** Unstructured event handed in by [Autonomous_bridge]. *)
+[@@deriving tla]
+
+(** {1 Stimulus value} *)
+
+type t = {
+  id : string;
+  source : source;
+  payload : Yojson.Safe.t;
+  salience : float;  (** in [\[0.0, 1.0\]] *)
+  timestamp : float;  (** unix seconds when emitted *)
+}
+
+(** {1 Construction} *)
+
+val make :
+  id:string ->
+  source:source ->
+  payload:Yojson.Safe.t ->
+  salience:float ->
+  timestamp:float ->
+  t
+(** [make ~id ~source ~payload ~salience ~timestamp] returns a fresh
+    stimulus.
+
+    @raise Invalid_argument
+      if [salience] is outside [\[0.0, 1.0\]] (NaN included), or if
+      [id] is empty. The other fields are passed through verbatim;
+      payload validation is the emitter's responsibility. *)
+
+(** {1 Scoring} *)
+
+val score : t -> now:float -> float
+(** Time-decayed salience for ranking in the Perceive aggregator.
+
+    [score t ~now = t.salience *. exp (-. decay *. age)] where
+    [decay = 0.01] and [age = max 0.0 (now -. t.timestamp)].
+
+    Properties:
+    - [score t ~now:t.timestamp = t.salience]
+    - [score t ~now] is monotonically non-increasing in [now]
+    - [score t ~now < t.timestamp = t.salience] (no time-travel
+      amplification) *)
+
+(** {1 String projection} *)
+
+val source_to_string : source -> string
+(** Canonical lowercase symbol; equivalent to
+    [to_tla_symbol] on {!source}. *)
+
+val source_of_string : string -> source option
+(** Inverse of {!source_to_string}. Returns [None] for unknown
+    inputs — fail-closed; callers that want
+    string-validation-as-error should match on [None] explicitly. *)
+
+(** {1 Serialisation} *)
+
+val to_json : t -> Yojson.Safe.t
+(** Render to a fixed-shape JSON object. Keys: [id], [source],
+    [payload], [salience], [timestamp]. *)
+
+val of_json : Yojson.Safe.t -> (t, string) result
+(** Parse a [Stimulus.t] from JSON. The error string identifies the
+    first violation (missing key, wrong type, unknown source,
+    out-of-range salience). Symmetric with {!to_json}. *)

--- a/test/autonomous/dune
+++ b/test/autonomous/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_autonomous_phase test_autonomous_state test_transition test_autonomous_bridge test_autonomous_wirein)
+ (names test_autonomous_phase test_autonomous_state test_transition test_autonomous_bridge test_autonomous_wirein test_autonomous_stimulus)
  (libraries autonomous shared_types yojson unix))

--- a/test/autonomous/test_autonomous_stimulus.ml
+++ b/test/autonomous/test_autonomous_stimulus.ml
@@ -1,0 +1,268 @@
+(* Cycle 23 / Tier B6 tests — Stimulus value type.
+
+   Validates:
+   - [source]-level [@@deriving tla] correctness
+   - [source_to_string] / [source_of_string] round-trip
+   - [make] accepts [salience] in [0.0, 1.0]
+   - [make] rejects out-of-range, NaN, and empty id (Invalid_argument)
+   - [score] = salience at [now = timestamp]
+   - [score] decays for [now > timestamp]
+   - [score] does not amplify for [now < timestamp]
+   - [to_json] / [of_json] symmetric round-trip
+   - [of_json] rejects malformed inputs with Error *)
+
+module S = Autonomous.Stimulus
+
+(* ─── Source taxonomy + tla deriver ───────────────────────────── *)
+
+let test_source_to_tla_symbol () =
+  assert (S.to_tla_symbol S.User_message = "user_message");
+  assert (S.to_tla_symbol S.Memory_recall = "memory_recall");
+  assert (S.to_tla_symbol S.Discovery_signal = "discovery_signal");
+  assert (S.to_tla_symbol S.Resource_alert = "resource_alert");
+  assert (S.to_tla_symbol S.Goal_phase_change = "goal_phase_change");
+  assert (S.to_tla_symbol S.Priority_shift = "priority_shift");
+  assert (S.to_tla_symbol S.External_event = "external_event")
+
+let test_all_symbols_count () = assert (List.length S.all_symbols = 7)
+
+let test_all_states_count () = assert (List.length S.all_states = 7)
+
+let test_source_of_string_round_trip () =
+  let all =
+    [
+      S.User_message;
+      S.Memory_recall;
+      S.Discovery_signal;
+      S.Resource_alert;
+      S.Goal_phase_change;
+      S.Priority_shift;
+      S.External_event;
+    ]
+  in
+  List.iter
+    (fun src ->
+      let s = S.source_to_string src in
+      match S.source_of_string s with
+      | Some src' -> assert (src' = src)
+      | None -> assert false)
+    all
+
+let test_source_of_string_unknown_is_none () =
+  assert (S.source_of_string "" = None);
+  assert (S.source_of_string "USER_MESSAGE" = None);
+  assert (S.source_of_string "user-message" = None);
+  assert (S.source_of_string "nope" = None)
+
+(* ─── make: range validation ──────────────────────────────────── *)
+
+let test_make_valid_mid () =
+  let s =
+    S.make
+      ~id:"stim-1"
+      ~source:S.User_message
+      ~payload:`Null
+      ~salience:0.5
+      ~timestamp:1000.0
+  in
+  assert (s.id = "stim-1");
+  assert (s.source = S.User_message);
+  assert (s.salience = 0.5);
+  assert (s.timestamp = 1000.0)
+
+let test_make_valid_boundaries () =
+  let s0 =
+    S.make ~id:"a" ~source:S.User_message ~payload:`Null
+      ~salience:0.0 ~timestamp:0.0
+  in
+  let s1 =
+    S.make ~id:"b" ~source:S.User_message ~payload:`Null
+      ~salience:1.0 ~timestamp:0.0
+  in
+  assert (s0.salience = 0.0);
+  assert (s1.salience = 1.0)
+
+let raises_invalid_argument f =
+  try
+    let _ = f () in
+    false
+  with Invalid_argument _ -> true
+
+let test_make_rejects_above_one () =
+  assert (
+    raises_invalid_argument (fun () ->
+        S.make ~id:"x" ~source:S.User_message ~payload:`Null
+          ~salience:2.0 ~timestamp:0.0))
+
+let test_make_rejects_negative () =
+  assert (
+    raises_invalid_argument (fun () ->
+        S.make ~id:"x" ~source:S.User_message ~payload:`Null
+          ~salience:(-0.001) ~timestamp:0.0))
+
+let test_make_rejects_nan () =
+  assert (
+    raises_invalid_argument (fun () ->
+        S.make ~id:"x" ~source:S.User_message ~payload:`Null
+          ~salience:Float.nan ~timestamp:0.0))
+
+let test_make_rejects_infinity () =
+  assert (
+    raises_invalid_argument (fun () ->
+        S.make ~id:"x" ~source:S.User_message ~payload:`Null
+          ~salience:Float.infinity ~timestamp:0.0))
+
+let test_make_rejects_empty_id () =
+  assert (
+    raises_invalid_argument (fun () ->
+        S.make ~id:"" ~source:S.User_message ~payload:`Null
+          ~salience:0.5 ~timestamp:0.0))
+
+(* ─── score: decay semantics ──────────────────────────────────── *)
+
+let approx_eq a b = Float.abs (a -. b) < 1e-9
+
+let test_score_at_emit_time () =
+  let s =
+    S.make ~id:"x" ~source:S.User_message ~payload:`Null
+      ~salience:0.7 ~timestamp:1000.0
+  in
+  assert (approx_eq (S.score s ~now:1000.0) 0.7)
+
+let test_score_decays_over_time () =
+  let s =
+    S.make ~id:"x" ~source:S.User_message ~payload:`Null
+      ~salience:1.0 ~timestamp:0.0
+  in
+  let s100 = S.score s ~now:100.0 in
+  let s500 = S.score s ~now:500.0 in
+  assert (s100 < 1.0);
+  assert (s500 < s100);
+  (* salience=1.0, decay=0.01, age=100 → exp(-1.0) ≈ 0.3679 *)
+  assert (approx_eq s100 (Float.exp (-1.0)))
+
+let test_score_clamps_negative_age () =
+  let s =
+    S.make ~id:"x" ~source:S.User_message ~payload:`Null
+      ~salience:0.5 ~timestamp:1000.0
+  in
+  (* now < timestamp must NOT amplify above salience *)
+  assert (approx_eq (S.score s ~now:500.0) 0.5)
+
+(* ─── JSON round-trip ─────────────────────────────────────────── *)
+
+let test_to_json_shape () =
+  let s =
+    S.make ~id:"abc" ~source:S.Memory_recall
+      ~payload:(`Assoc [ ("k", `Int 1) ])
+      ~salience:0.3 ~timestamp:42.0
+  in
+  let j = S.to_json s in
+  assert (Yojson.Safe.Util.member "id" j = `String "abc");
+  assert (Yojson.Safe.Util.member "source" j = `String "memory_recall");
+  assert (
+    Yojson.Safe.Util.member "payload" j = `Assoc [ ("k", `Int 1) ]);
+  assert (Yojson.Safe.Util.member "salience" j = `Float 0.3);
+  assert (Yojson.Safe.Util.member "timestamp" j = `Float 42.0)
+
+let test_of_json_round_trip () =
+  let s =
+    S.make ~id:"abc" ~source:S.External_event
+      ~payload:(`String "hello") ~salience:0.9 ~timestamp:7.0
+  in
+  let j = S.to_json s in
+  match S.of_json j with
+  | Ok s' ->
+      assert (s'.id = s.id);
+      assert (s'.source = s.source);
+      assert (s'.payload = s.payload);
+      assert (approx_eq s'.salience s.salience);
+      assert (approx_eq s'.timestamp s.timestamp)
+  | Error e -> failwith ("of_json round-trip failed: " ^ e)
+
+let test_of_json_int_salience_accepted () =
+  (* Yojson may emit `Int for whole-number floats; of_json must accept both. *)
+  let j =
+    `Assoc
+      [
+        ("id", `String "x");
+        ("source", `String "user_message");
+        ("payload", `Null);
+        ("salience", `Int 1);
+        ("timestamp", `Int 0);
+      ]
+  in
+  match S.of_json j with
+  | Ok s ->
+      assert (approx_eq s.salience 1.0);
+      assert (approx_eq s.timestamp 0.0)
+  | Error e -> failwith ("expected Ok, got Error: " ^ e)
+
+let test_of_json_rejects_non_object () =
+  match S.of_json (`String "nope") with
+  | Ok _ -> assert false
+  | Error _ -> ()
+
+let test_of_json_rejects_missing_key () =
+  let j =
+    `Assoc
+      [
+        ("id", `String "x");
+        ("source", `String "user_message");
+        (* payload missing *)
+        ("salience", `Float 0.5);
+        ("timestamp", `Float 0.0);
+      ]
+  in
+  match S.of_json j with Ok _ -> assert false | Error _ -> ()
+
+let test_of_json_rejects_unknown_source () =
+  let j =
+    `Assoc
+      [
+        ("id", `String "x");
+        ("source", `String "made_up");
+        ("payload", `Null);
+        ("salience", `Float 0.5);
+        ("timestamp", `Float 0.0);
+      ]
+  in
+  match S.of_json j with Ok _ -> assert false | Error _ -> ()
+
+let test_of_json_rejects_out_of_range_salience () =
+  let j =
+    `Assoc
+      [
+        ("id", `String "x");
+        ("source", `String "user_message");
+        ("payload", `Null);
+        ("salience", `Float 1.5);
+        ("timestamp", `Float 0.0);
+      ]
+  in
+  match S.of_json j with Ok _ -> assert false | Error _ -> ()
+
+let () =
+  test_source_to_tla_symbol ();
+  test_all_symbols_count ();
+  test_all_states_count ();
+  test_source_of_string_round_trip ();
+  test_source_of_string_unknown_is_none ();
+  test_make_valid_mid ();
+  test_make_valid_boundaries ();
+  test_make_rejects_above_one ();
+  test_make_rejects_negative ();
+  test_make_rejects_nan ();
+  test_make_rejects_infinity ();
+  test_make_rejects_empty_id ();
+  test_score_at_emit_time ();
+  test_score_decays_over_time ();
+  test_score_clamps_negative_age ();
+  test_to_json_shape ();
+  test_of_json_round_trip ();
+  test_of_json_int_salience_accepted ();
+  test_of_json_rejects_non_object ();
+  test_of_json_rejects_missing_key ();
+  test_of_json_rejects_unknown_source ();
+  test_of_json_rejects_out_of_range_salience ();
+  print_endline "test_autonomous_stimulus: all assertions passed"


### PR DESCRIPTION
## 목적

Cycle 23 / Tier B6 — Autonomous loop의 Perceive 입력인 `Stimulus.t` 값 타입을 도입합니다. 7-source 분류 + salience 검증 + 시간 감쇠 score + JSON 직렬화의 작은 가치 객체이며, 향후 `Intent_engine.analyze` (Cycle 24 후보)의 입력이 됩니다.

## 변경

- `lib/autonomous/stimulus.mli` 신설 (147 LOC) — 7-variant `source` (`User_message` ~ `External_event`) + `t` record + `make`/`score`/`source_to/of_string`/`to_json`/`of_json` API와 docstring.
- `lib/autonomous/stimulus.ml` 신설 (134 LOC) — fail-closed 검증(NaN/Inf/range/empty-id), `decay = 0.01` 기본 감쇠, JSON parser는 예외 escape 없이 `Result.t`로 반환.
- `test/autonomous/test_autonomous_stimulus.ml` 신설 (268 LOC) — 22개 assertion 테스트(taxonomy round-trip, 범위 검증, score 단조성, JSON 양방향).
- `test/autonomous/dune` 의 `(names ...)` 에 `test_autonomous_stimulus` 추가.

`lib/autonomous/dune` 은 변경 없음 — wrapped library가 새 `.ml`/`.mli` 를 자동 인식합니다.

## 검증

- `dune build --root .`: 통과 (전체 빌드, 경고 0)
- `dune test --root . --force test/autonomous/`: 6/6 pass (`test_autonomous_phase`, `test_autonomous_state`, `test_transition`, `test_autonomous_bridge`, `test_autonomous_wirein`, `test_autonomous_stimulus`)
- 모든 외부 입력 경로(`make`, `of_json`)에 대해 적어도 하나의 negative test 존재.

## 설계 메모

- `[@@deriving tla]` 는 `source` variant 에만 적용. record `t` 도 `autonomous_KEY_INTERFACES.mli` 사양에는 derive 표기가 있지만, 본 레포의 `ppx_tla` 는 record derive 가 아직 사용처에 없어 hand-written `to_json`/`of_json` 으로 대신했습니다 (Tier I8/I9 지연 정책과 동일).
- `score` 는 `now < timestamp` 일 때 amplification 하지 않도록 `Float.max 0.0 (now -. timestamp)` 로 age 를 clamp 합니다.
- 검증은 fail-closed — NaN/Inf/out-of-range 는 `Invalid_argument` 로 raise. "Unknown → Permissive Default" anti-pattern 회피 (memory/feedback_keeper_runtime_fail_closed_for_unknown_permissive_default).
- 본 PR은 `lib/crew/`, `../oas/`, multimodal/resilience 어느 쪽에도 의존하지 않으며 추가 모듈을 의존성에 넣지 않습니다.

## 가정 (사용자 결정 반영)

- `lib/crew/` 는 freeze 상태로, 본 PR 은 crew/Council 에 의존하지 않습니다.
- 후속 Tier (Intent_engine, Goal_dag, Self_priority, Resource_budget) 는 별도 cycle PR 로 분리.

## Follow-up cycle 후보

- Cycle 24: `Intent.mli` + `Intent_engine` 골격 (Stimulus list → Intent.t option).
- Cycle 25: `Resource_budget` + `Self_priority` skeleton.
- Tier I-track: `ppx_tla` 의 record derive 지원이 추가되면 `t` 에도 `[@@deriving tla]` 부착.