### PR TITLE
feat(resilience): Tier A12 — Resilience_audit category + envelope wrap (Cycle 28)

### DIFF
--- a/lib/resilience/audit.ml
+++ b/lib/resilience/audit.ml
@@ -1,0 +1,85 @@
+(* Resilience_audit — Cycle 28 / Tier A12.
+
+   Typed category enum lifted onto Shared_audit.Envelope. The shared
+   envelope stays the single Merkle-chained record; this module only
+   pins the category surface and threads keeper_name / session_id into
+   the payload. *)
+
+type category =
+  | OutcomeRecorded
+  | ConfidenceEvaluated
+  | DegradationTriggered
+  | DegradationRecovered
+  | SpeculativeBranchStarted
+  | SpeculativeBranchCompleted
+  | SpeculativeWinnerSelected
+  | RecoveryAttempted
+  | RecoverySucceeded
+  | RecoveryFailed
+  | BudgetChecked
+  | BudgetExceeded
+
+let category_to_string = function
+  | OutcomeRecorded -> "OutcomeRecorded"
+  | ConfidenceEvaluated -> "ConfidenceEvaluated"
+  | DegradationTriggered -> "DegradationTriggered"
+  | DegradationRecovered -> "DegradationRecovered"
+  | SpeculativeBranchStarted -> "SpeculativeBranchStarted"
+  | SpeculativeBranchCompleted -> "SpeculativeBranchCompleted"
+  | SpeculativeWinnerSelected -> "SpeculativeWinnerSelected"
+  | RecoveryAttempted -> "RecoveryAttempted"
+  | RecoverySucceeded -> "RecoverySucceeded"
+  | RecoveryFailed -> "RecoveryFailed"
+  | BudgetChecked -> "BudgetChecked"
+  | BudgetExceeded -> "BudgetExceeded"
+
+let category_of_string = function
+  | "OutcomeRecorded" -> Some OutcomeRecorded
+  | "ConfidenceEvaluated" -> Some ConfidenceEvaluated
+  | "DegradationTriggered" -> Some DegradationTriggered
+  | "DegradationRecovered" -> Some DegradationRecovered
+  | "SpeculativeBranchStarted" -> Some SpeculativeBranchStarted
+  | "SpeculativeBranchCompleted" -> Some SpeculativeBranchCompleted
+  | "SpeculativeWinnerSelected" -> Some SpeculativeWinnerSelected
+  | "RecoveryAttempted" -> Some RecoveryAttempted
+  | "RecoverySucceeded" -> Some RecoverySucceeded
+  | "RecoveryFailed" -> Some RecoveryFailed
+  | "BudgetChecked" -> Some BudgetChecked
+  | "BudgetExceeded" -> Some BudgetExceeded
+  | _ -> None
+
+let category_to_json c : Yojson.Safe.t = `String (category_to_string c)
+
+(* Wrap [payload] into a JSON object that carries optional [keeper_name]
+   and [session_id] alongside the caller's payload. The shared envelope
+   has no such fields, so we thread them through the payload sub-tree. *)
+let wrap_payload ?keeper_name ?session_id ~payload () : Yojson.Safe.t =
+  let base_assoc =
+    match payload with
+    | `Assoc kvs -> kvs
+    | other -> [ "payload", other ]
+  in
+  let with_keeper =
+    match keeper_name with
+    | None -> base_assoc
+    | Some k -> ("_keeper_name", `String k) :: base_assoc
+  in
+  let with_session =
+    match session_id with
+    | None -> with_keeper
+    | Some s -> ("_session_id", `String s) :: with_keeper
+  in
+  `Assoc with_session
+
+let make_entry ~category ?keeper_name ?session_id ~payload ~prev_hash () =
+  let wrapped = wrap_payload ?keeper_name ?session_id ~payload () in
+  Shared_audit.Envelope.make
+    ~category:(category_to_string category)
+    ~payload:wrapped
+    ~prev_hash
+
+let entry_to_json = Shared_audit.Envelope.to_json
+let entry_of_json = Shared_audit.Envelope.of_json
+
+let category_of_entry (e : Shared_audit.Envelope.t) =
+  category_of_string e.category

--- a/lib/resilience/audit.mli
+++ b/lib/resilience/audit.mli
@@ -1,0 +1,139 @@
+(** Resilience_audit — typed category enum lifted onto Shared_audit.Envelope.
+
+    Cycle 28 / Tier A12 — first cut.
+
+    {1 What this module is}
+
+    A thin resilience-specific layer on top of {!Shared_audit.Envelope}.
+    The shared envelope leaves [category] as a free string; this module
+    pins the resilience domain to a closed variant ({!category}) so
+    that:
+
+    - producers cannot emit a typo'd category by accident,
+    - downstream consumers (filters, dashboards, replay) can pattern-match
+      exhaustively, and
+    - the canonical string form is the {b only} string allowed to land
+      in the underlying envelope.
+
+    The Merkle [prev_hash] chain, [id] generation, [ts], and canonical
+    JSON serialization are entirely delegated to {!Shared_audit.Envelope}.
+    No separate entry record is introduced.
+
+    {1 Scope of this PR}
+
+    - {!category} variant: 12 resilience categories from the design doc
+      (resilience_KEY_INTERFACES.mli §6 Audit) covering outcomes,
+      confidence, degradation, speculative branches, recovery, and
+      budget events.
+    - {!category_to_string} / {!category_of_string}: total ⇄ partial
+      string bijection; unknown strings yield [None].
+    - {!category_to_json}: convenience for embedding the category as
+      a JSON string node in payloads.
+    - {!make_entry}: build a {!Shared_audit.Envelope.t} from a typed
+      category plus optional [keeper_name] / [session_id] (which are
+      threaded into the payload, not the envelope, since the shared
+      envelope has no such fields).
+    - {!entry_to_json} / {!entry_of_json}: lossless round-trip through
+      JSON via [Envelope.to_json] / [Envelope.of_json]. Re-parsing
+      preserves the typed category iff the wire string is recognised.
+    - {!category_of_entry}: lift the envelope's [category : string]
+      back to a typed {!category}.
+
+    {1 Deferred to follow-up Tiers}
+
+    - {b Cycle 29}: in-memory queue + dated JSONL drain (built on
+      {!Shared_audit.Store}, gated by category filter).
+    - {b Cycle 30}: live SSE stream + [verify_chain] integrity check
+      surfaced through dashboard.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+(** {1 Resilience audit categories} *)
+
+(** Closed variant of resilience-specific audit categories.
+
+    Mapped 1:1 with the design doc (resilience_KEY_INTERFACES.mli §6
+    Audit). The string form (see {!category_to_string}) is the
+    canonical wire representation that lands in
+    [Shared_audit.Envelope.category]. *)
+type category =
+  | OutcomeRecorded
+      (** A {!Shared_types.Resilience_outcome.t} was emitted by a
+          keeper turn (FullSuccess / PartialSuccess / GracefulFailure). *)
+  | ConfidenceEvaluated
+      (** A composite confidence score was computed for an artifact. *)
+  | DegradationTriggered
+      (** Capability level was lowered (e.g. L1 → L2). *)
+  | DegradationRecovered
+      (** Capability level was restored upward. *)
+  | SpeculativeBranchStarted
+      (** A speculative branch was forked. *)
+  | SpeculativeBranchCompleted
+      (** A speculative branch finished (won, lost, or aborted). *)
+  | SpeculativeWinnerSelected
+      (** A winning branch was committed and losers reaped. *)
+  | RecoveryAttempted
+      (** A {!Recovery.strategy} was selected and dispatched. *)
+  | RecoverySucceeded
+      (** The dispatched strategy resolved successfully. *)
+  | RecoveryFailed
+      (** The dispatched strategy itself failed. *)
+  | BudgetChecked
+      (** A budget probe was issued (no exhaustion yet). *)
+  | BudgetExceeded
+      (** A budget threshold was crossed. *)
+
+val category_to_string : category -> string
+(** Canonical wire string. The shared envelope stores this. *)
+
+val category_of_string : string -> category option
+(** Inverse of {!category_to_string}. Returns [None] for unrecognised
+    strings (including legacy / cross-domain categories such as
+    CREW's [["DeliberationTransition"]]). *)
+
+val category_to_json : category -> Yojson.Safe.t
+(** [`String (category_to_string c)]. Convenience for embedding the
+    category inside a payload sub-tree. *)
+
+(** {1 Entry construction (envelope wrap)} *)
+
+val make_entry :
+  category:category ->
+  ?keeper_name:string ->
+  ?session_id:string ->
+  payload:Yojson.Safe.t ->
+  prev_hash:string option ->
+  unit ->
+  Shared_audit.Envelope.t
+(** Build a {!Shared_audit.Envelope.t} for a resilience event.
+
+    [keeper_name] and [session_id], if provided, are wrapped into the
+    final payload as [_keeper_name] / [_session_id] sibling fields
+    next to the caller's [payload]. This keeps the envelope schema
+    untouched while letting resilience-specific consumers filter on
+    these dimensions.
+
+    If [payload] is not a JSON object, it is wrapped under a
+    [["payload"]] field so the envelope receives a well-formed
+    [`Assoc].
+
+    [ts] is taken from {!Shared_audit.Envelope.make}'s wall clock
+    (no override exposed; tests can compare round-trip semantics
+    instead of literal timestamps). *)
+
+val entry_to_json : Shared_audit.Envelope.t -> Yojson.Safe.t
+(** Alias of {!Shared_audit.Envelope.to_json}, exposed so resilience
+    callers do not have to reach across the [Shared_audit] module
+    boundary for a trivial passthrough. *)
+
+val entry_of_json :
+  Yojson.Safe.t -> (Shared_audit.Envelope.t, string) result
+(** Alias of {!Shared_audit.Envelope.of_json}. The resulting envelope
+    keeps [category] as a string; use {!category_of_entry} to lift
+    it back to a typed {!category}. *)
+
+val category_of_entry : Shared_audit.Envelope.t -> category option
+(** Read [envelope.category] back into the typed variant. Returns
+    [None] when the envelope was emitted by a different domain or
+    contains an unknown category string. *)

--- a/test/resilience/dune
+++ b/test/resilience/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_confidence test_recovery test_keeper_bridge test_degradation test_speculative)
+ (names test_confidence test_recovery test_keeper_bridge test_degradation test_speculative test_audit)
  (libraries resilience shared_types shared_audit yojson unix))

--- a/test/resilience/test_audit.ml
+++ b/test/resilience/test_audit.ml
@@ -1,0 +1,196 @@
+(* Cycle 28 / Tier A12 tests — Resilience.Audit category enum + envelope wrap. *)
+
+module A = Resilience.Audit
+module E = Shared_audit.Envelope
+
+(* ─── Category string round-trip ──────────────────────────────── *)
+
+let all_categories : A.category list =
+  [
+    OutcomeRecorded;
+    ConfidenceEvaluated;
+    DegradationTriggered;
+    DegradationRecovered;
+    SpeculativeBranchStarted;
+    SpeculativeBranchCompleted;
+    SpeculativeWinnerSelected;
+    RecoveryAttempted;
+    RecoverySucceeded;
+    RecoveryFailed;
+    BudgetChecked;
+    BudgetExceeded;
+  ]
+
+let test_category_roundtrip_total () =
+  (* of_string ∘ to_string = Some on every variant. *)
+  List.iter
+    (fun c ->
+      let s = A.category_to_string c in
+      match A.category_of_string s with
+      | Some c' -> assert (c' = c)
+      | None ->
+          Printf.eprintf "category_of_string failed for %s\n" s;
+          assert false)
+    all_categories
+
+let test_category_of_string_unknown () =
+  assert (A.category_of_string "" = None);
+  assert (A.category_of_string "Unknown" = None);
+  (* CREW's category should not collide with resilience's surface. *)
+  assert (A.category_of_string "DeliberationTransition" = None)
+
+let test_category_strings_all_distinct () =
+  let strings = List.map A.category_to_string all_categories in
+  let unique = List.sort_uniq String.compare strings in
+  assert (List.length unique = List.length all_categories)
+
+let test_category_to_json () =
+  match A.category_to_json A.RecoveryAttempted with
+  | `String "RecoveryAttempted" -> ()
+  | _ -> assert false
+
+(* ─── make_entry / envelope schema ────────────────────────────── *)
+
+let test_make_entry_minimal () =
+  let e =
+    A.make_entry
+      ~category:A.OutcomeRecorded
+      ~payload:(`Assoc [ "outcome", `String "FullSuccess" ])
+      ~prev_hash:None
+      ()
+  in
+  assert (e.E.category = "OutcomeRecorded");
+  assert (e.E.prev_hash = None);
+  (* Payload Assoc preserved — no wrapping when keeper_name/session_id absent. *)
+  match e.E.payload with
+  | `Assoc kvs ->
+      (match List.assoc_opt "outcome" kvs with
+       | Some (`String "FullSuccess") -> ()
+       | _ -> assert false);
+      assert (List.assoc_opt "_keeper_name" kvs = None);
+      assert (List.assoc_opt "_session_id" kvs = None)
+  | _ -> assert false
+
+let test_make_entry_with_keeper_and_session () =
+  let e =
+    A.make_entry
+      ~category:A.RecoveryAttempted
+      ~keeper_name:"dreamer"
+      ~session_id:"sess-001"
+      ~payload:(`Assoc [ "strategy", `String "Retry" ])
+      ~prev_hash:(Some "abc123")
+      ()
+  in
+  assert (e.E.category = "RecoveryAttempted");
+  assert (e.E.prev_hash = Some "abc123");
+  match e.E.payload with
+  | `Assoc kvs ->
+      (match List.assoc_opt "_keeper_name" kvs with
+       | Some (`String "dreamer") -> ()
+       | _ -> assert false);
+      (match List.assoc_opt "_session_id" kvs with
+       | Some (`String "sess-001") -> ()
+       | _ -> assert false);
+      (match List.assoc_opt "strategy" kvs with
+       | Some (`String "Retry") -> ()
+       | _ -> assert false)
+  | _ -> assert false
+
+let test_make_entry_non_assoc_payload_wrapped () =
+  (* A scalar payload must be wrapped under "payload" so the envelope
+     receives a well-formed Assoc. *)
+  let e =
+    A.make_entry
+      ~category:A.BudgetChecked
+      ~payload:(`Int 42)
+      ~prev_hash:None
+      ()
+  in
+  match e.E.payload with
+  | `Assoc kvs ->
+      (match List.assoc_opt "payload" kvs with
+       | Some (`Int 42) -> ()
+       | _ -> assert false)
+  | _ -> assert false
+
+let test_make_entry_id_and_ts_set () =
+  let e =
+    A.make_entry
+      ~category:A.ConfidenceEvaluated
+      ~payload:(`Assoc [])
+      ~prev_hash:None
+      ()
+  in
+  assert (String.length e.E.id > 0);
+  assert (e.E.ts > 0.0)
+
+(* ─── JSON round-trip via envelope ────────────────────────────── *)
+
+let test_entry_json_roundtrip () =
+  let e =
+    A.make_entry
+      ~category:A.SpeculativeWinnerSelected
+      ~keeper_name:"k1"
+      ~payload:(`Assoc [ "winner", `String "branch-2" ])
+      ~prev_hash:(Some "deadbeef")
+      ()
+  in
+  let json = A.entry_to_json e in
+  match A.entry_of_json json with
+  | Ok e' ->
+      assert (e'.E.id = e.E.id);
+      assert (e'.E.ts = e.E.ts);
+      assert (e'.E.category = e.E.category);
+      assert (e'.E.prev_hash = e.E.prev_hash);
+      (* category_of_entry must lift the wire string back. *)
+      (match A.category_of_entry e' with
+       | Some A.SpeculativeWinnerSelected -> ()
+       | _ -> assert false)
+  | Error msg ->
+      Printf.eprintf "entry_of_json: %s\n" msg;
+      assert false
+
+let test_category_of_entry_unknown_domain () =
+  (* An envelope from a different domain should not lift to a typed
+     resilience category. *)
+  let foreign =
+    Shared_audit.Envelope.make
+      ~category:"DeliberationTransition"
+      ~payload:(`Assoc [])
+      ~prev_hash:None
+  in
+  assert (A.category_of_entry foreign = None)
+
+(* ─── Hash chain still works through make_entry ───────────────── *)
+
+let test_chain_continuity () =
+  let e1 =
+    A.make_entry
+      ~category:A.OutcomeRecorded
+      ~payload:(`Assoc [ "step", `Int 1 ])
+      ~prev_hash:None
+      ()
+  in
+  let h1 = E.hash_for_chain e1 in
+  let e2 =
+    A.make_entry
+      ~category:A.OutcomeRecorded
+      ~payload:(`Assoc [ "step", `Int 2 ])
+      ~prev_hash:(Some h1)
+      ()
+  in
+  assert (e2.E.prev_hash = Some h1)
+
+let () =
+  test_category_roundtrip_total ();
+  test_category_of_string_unknown ();
+  test_category_strings_all_distinct ();
+  test_category_to_json ();
+  test_make_entry_minimal ();
+  test_make_entry_with_keeper_and_session ();
+  test_make_entry_non_assoc_payload_wrapped ();
+  test_make_entry_id_and_ts_set ();
+  test_entry_json_roundtrip ();
+  test_category_of_entry_unknown_domain ();
+  test_chain_continuity ();
+  print_endline "test_audit: all assertions passed"


### PR DESCRIPTION
## 목적

Cycle 28 / Tier A12 — resilience-specific audit category enum과 entry envelope 래퍼를 도입했습니다. `shared_audit/envelope` 위에 12종 category를 lift하여 typo 없는 emit과 exhaustive consumer pattern-match를 가능하게 합니다.

## 변경

| 파일 | 변경 | LOC |
|------|------|-----|
| `lib/resilience/audit.mli` | 신설 | 139 |
| `lib/resilience/audit.ml`  | 신설 | 85 |
| `test/resilience/test_audit.ml` | 신설 | 196 |
| `test/resilience/dune` | `+test_audit` | 1 |

총 +421 / -1.

## 검증

- `dune build --root .` — 통과 (경고 0)
- `dune build --root . @test/resilience/runtest` — 6/6 pass:
  - `test_confidence`, `test_recovery`, `test_keeper_bridge`, `test_degradation`, `test_speculative` 기존 모두 OK
  - `test_audit` 신규 — all assertions pass

## 설계 결정

1. **별도 entry 타입 없이 envelope wrap**: Merkle `prev_hash`, `id`, `ts`, JSON 직렬화는 모두 `Shared_audit.Envelope`에 위임. 재구현 X.
2. **Closed variant 12 카테고리**: `OutcomeRecorded`, `ConfidenceEvaluated`, `DegradationTriggered`, `DegradationRecovered`, `SpeculativeBranchStarted/Completed`, `SpeculativeWinnerSelected`, `RecoveryAttempted/Succeeded/Failed`, `BudgetChecked/Exceeded`. 설계 문서 `resilience_KEY_INTERFACES.mli §6 Audit`와 1:1 매핑.
3. **`category_of_string` fail-closed**: 알 수 없는 wire string은 `None` (CREW의 `DeliberationTransition` 등 cross-domain 카테고리는 자연스럽게 거부).
4. **Optional keeper/session payload nesting**: `keeper_name` / `session_id`를 envelope schema에 추가하지 않고 payload 내부 `_keeper_name` / `_session_id` 필드로 wrap.

## 가정 (사용자 결정 반영)

- `lib/crew/`는 freeze 상태로, 본 PR은 crew/Council에 의존하지 않습니다.
- `../oas/` 변경 없음.

## Follow-up cycle 후보

- **Cycle 29**: in-memory queue + dated JSONL drain (built on `Shared_audit.Store`, gated by category filter)
- **Cycle 30**: live SSE stream + `verify_chain` integrity check, dashboard 노출

## 참고

origin/main HEAD `80606a8fa1` 기반. main이 매우 활발한 시간대라 push 직전 race-check 수행 (`resilience_audit`, `resilience-audit`, `Cycle 28`, `Tier A12` 키워드 dash/underscore 변형 모두 검색 — 동일 영역 PR 0건). 인접 PR #11869 SharedAudit는 `specs/shared/SharedAudit.tla`만 변경하여 본 PR과 영역 무관.