### PR TITLE
feat(toast): wire animation tokens to ToastContainer (cycle 32)

### DIFF
--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -173,7 +173,7 @@ export function ToastContainer() {
         <div
           key=${t.id}
           role=${t.type === 'error' ? 'alert' : 'status'}
-          class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-55 max-w-90 rounded border-l-[3px] border-l-solid border border-solid border-[var(--color-border-default)] bg-[rgba(10,18,34,0.96)] shadow-sm animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
+          class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-55 max-w-90 rounded border-l-[3px] border-l-solid border border-solid border-[var(--color-border-default)] bg-[rgba(10,18,34,0.96)] shadow-sm animate-[slideInRight_var(--enter-duration)_var(--enter-easing)] ${BORDER_COLOR[t.type]}"
           onMouseEnter=${() => pauseToastTimer(t.id)}
           onMouseLeave=${() => resumeToastTimer(t.id)}
           onFocusIn=${() => pauseToastTimer(t.id)}


### PR DESCRIPTION
## Summary

Second consumer migration of animation tokens (#11747). After dialog (#11861), toast is now token-driven.

## Change

| Element | Before | After |
|---------|--------|-------|
| Toast slide-in animation | `animate-[slideInRight_0.2s_ease-out]` | `animate-[slideInRight_var(--enter-duration)_var(--enter-easing)]` |

Single line change — Tailwind v4 arbitrary value reads token from CSS variables. The existing `@keyframes slideInRight` (keyframes.css) takes its `duration` + `easing` slots from `--enter-duration` / `--enter-easing`.

## Why this matters

- All 3 toast types (success/warning/error) now share the same enter animation timing source
- Future token re-tune (e.g. for prefers-reduced-motion or accessibility audit) propagates to every toast call site without code edits
- Removes another magic-number `0.2s_ease-out` from the dashboard

## Verification

- `pnpm test` → **23/23 passing** (toast.test.ts + toast.a11y.test.ts)
- 1 file, 1 line changed

## Out of scope

- slideInRight keyframe itself (lives in keyframes.css; wiring it would mean replacing the global @keyframes with token vars — separate PR)
- Toast exit animation (toast unmounts; AnimatePresence-style hold is a Headless follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)