### PR TITLE
chore(ratchet): naturalize ocaml-structure-baseline — lib_dune 965→969 + downward refresh

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 2,
-  "coord_mli_missing": 1,
+  "keeper_mli_missing": 1,
+  "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 965,
+  "lib_dune_lines": 969,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 56
+  "lib_other_mli_missing": 27
 }


### PR DESCRIPTION
## 목적

OCaml structure ratchet baseline을 main 현재 상태로 자연화. 다수 open cycle PR이 동일 메트릭으로 BLOCKED 상태였음.

## 자연화 결과

| 메트릭 | 이전 baseline | 현재 main | 변화 |
|--------|---------------|-----------|------|
| `keeper_mli_missing` | 2 | 1 | ↓ -1 (downward ratchet) |
| `coord_mli_missing` | 1 | 0 | ↓ -1 (downward ratchet) |
| `godsplit_count` | 0 | 0 | — |
| `lib_dune_lines` | 965 | 969 | ↑ +4 (main 머지 결과) |
| `inferred_dump_headers` | 0 | 0 | — |
| `lib_other_mli_missing` | 56 | 27 | ↓↓ -29 (.mli pin 작업 누적) |

## 트리거

`lib/dune`은 4 라인 증가했지만 ratchet baseline은 미갱신 상태. 동시에 .mli coverage 작업(cycle 192-199 board/goal/institution/local/activity-graph 등)이 누적되어 `lib_other_mli_missing`이 56→27로 절반 떨어졌으나 downward ratchet 기회가 묻혀 있었음.

이는 메모리 룰 `feedback_ratchet-naturalization-after-admin-merge`의 정확한 패턴.

## Unblocks

- #11874 — feat(multimodal): Tier B10 Workspace_id (Cycle 25)
- #11877 — feat(resilience): Tier A12 Audit category (Cycle 28)
- #11880 — chore: bump version 0.18.9 → 0.18.10

## 검증

`scripts/ocaml-structure-ratchet.sh --regenerate` 실행 결과만 commit. 코드 변경 0.