### PR TITLE
chore(prompt-registry): add prompt_registry.mli — versioned prompt store pin (cycle 202)

### DIFF
--- a/lib/prompt_registry/prompt_registry.mli
+++ b/lib/prompt_registry/prompt_registry.mli
@@ -1,0 +1,214 @@
+(** Prompt_registry — versioned prompt template store
+    with file overrides and runtime resolution.
+
+    Three resolution sources, in priority order:
+    - {b Override}: in-memory key→string set via
+      {!set_override} (validated against [meta_tbl]).
+    - {b File}: markdown file at
+      [<markdown_dir>/<key>.md] (frontmatter stripped via
+      [parse_frontmatter]).
+    - {b Default}: registered template registered through
+      {!register_default} during plugin init.
+
+    Persistence: {!persist_overrides} writes the override
+    map to [.masc/prompt_overrides.json];
+    {!restore_overrides} reapplies it through the same
+    validation as {!set_override} so manually-edited
+    entries are dropped with a warn instead of silently
+    accepted.
+
+    Concurrency: every state mutation goes through the
+    [with_mutex] guard around
+    {!Prompt_registry_store.t.mutex}.  File reads
+    ({!resolve_prompt}, {!list_prompts},
+    {!validate_prompt_templates}) snapshot under the lock,
+    release it, then read disk so concurrent readers do
+    not serialize on I/O.
+
+    Internal helpers stay private at this boundary
+    ([parse_frontmatter], [parse_list_value],
+    [extract_variables], [store],
+    [version_index], [meta_tbl], [prompts_dir],
+    [markdown_dir], [make_key], [is_valid_prompt_key],
+    [prompt_markdown_path], [read_file_if_exists],
+    [get_versions], [list_all], [list_ids], [exists],
+    [unregister], [deprecate], [update_metrics],
+    [unresolved_var_re], [replace_substring_all],
+    [render_template], [stats], [count], [count_unique],
+    [to_json], [of_json], [default_prompt_value_unlocked],
+    [build_resolved_from_snapshot], [resolved_of_snapshot],
+    [unexpected_template_variables],
+    [prompt_item_json_of_resolved], [compare_prompt_items],
+    [register_prompt], [register_default],
+    [apply_override_validated], [prompt_snapshot] type,
+    [register], [init], [render]). *)
+
+(** {1 Type re-exports} *)
+
+module Types = Prompt_registry_types
+(** Re-export of the type-only sub-module so callers reach
+    record / variant types via [Prompt_registry.Types.X]
+    after [open Masc_mcp].
+    [test/test_prompt_registry_pbt.ml] uses this alias. *)
+
+type prompt_metrics = Prompt_registry_types.prompt_metrics = {
+  usage_count : int;
+  avg_score : float;
+  last_used : float;
+}
+
+val prompt_metrics_to_yojson : prompt_metrics -> Yojson.Safe.t
+val prompt_metrics_of_yojson :
+  Yojson.Safe.t -> (prompt_metrics, string) result
+
+type prompt_entry = Prompt_registry_types.prompt_entry = {
+  id : string;
+  template : string;
+  version : string;
+  variables : string list;
+  metrics : prompt_metrics option;
+  created_at : float;
+  deprecated : bool;
+}
+
+val prompt_entry_to_yojson : prompt_entry -> Yojson.Safe.t
+val prompt_entry_of_yojson :
+  Yojson.Safe.t -> (prompt_entry, string) result
+
+type registry_stats = Prompt_registry_types.registry_stats = {
+  total_prompts : int;
+  active_prompts : int;
+  deprecated_prompts : int;
+  most_used : string option;
+  avg_usage : float;
+}
+
+type prompt_meta = Prompt_registry_types.prompt_meta = {
+  description : string;
+  category : string;
+  required_file : bool;
+  template_variables : string list;
+}
+
+type prompt_resolution = Prompt_registry_types.prompt_resolution = {
+  effective : string;
+  source : string;
+  file_value : string option;
+  override_value : string option;
+  default_value : string option;
+  file_path : string option;
+  file_exists : bool;
+  has_override : bool;
+}
+
+(** {1 Markdown directory} *)
+
+val set_markdown_dir : string -> unit
+(** Pins the directory the file-based resolution path
+    looks under for [<key>.md]. *)
+
+val get_markdown_dir : unit -> string option
+(** Returns the currently-pinned markdown dir, [None] if
+    {!set_markdown_dir} was never called. *)
+
+val load_prompts_from_directory : string -> unit
+(** Auto-discovers [*.md] files under [dir], parses YAML
+    frontmatter, and registers each as a known prompt
+    via the internal [register_prompt] helper.  Files
+    without frontmatter (or without a [description]) are
+    skipped — those require explicit registration. *)
+
+(** {1 Resolution} *)
+
+val resolve_prompt : string -> prompt_resolution
+(** Reads the markdown file (outside the mutex) then
+    looks up override / default under the lock and
+    returns the full {!prompt_resolution} record.  Used
+    by the dashboard HTTP route to surface every source's
+    contribution side-by-side. *)
+
+val get_prompt : string -> string
+(** Convenience accessor for [(resolve_prompt key).effective].
+    Returns the empty string when [key] is missing from
+    every source. *)
+
+val prompt_source : string -> string
+(** [(resolve_prompt key).source]: ["override"] /
+    ["file"] / ["default"] / ["missing"]. *)
+
+(** {1 Rendering} *)
+
+val render_prompt_template :
+  string -> (string * string) list -> (string, string) result
+(** Renders the prompt at [key] with the variable
+    substitutions from the assoc list.  Errors when the
+    prompt is missing (empty after trim) or when the
+    template references an unresolved variable not in the
+    assoc list. *)
+
+(** {1 Override lifecycle} *)
+
+val set_override : string -> string -> (unit, string) result
+(** Validates and installs an override.  Rejects invalid
+    keys, empty / oversized (>10000 chars) values, and
+    unexpected template variables (a variable in the
+    template that the registered [meta_tbl] entry does
+    not declare).  Validation + write happen inside a
+    single [with_mutex] block to prevent a concurrent
+    [register_prompt] from invalidating the decision
+    after validation but before the write. *)
+
+val clear_prompt_override : string -> unit
+(** Removes the override for [key] (no-op when absent).
+    Falls back to file → default on next resolution. *)
+
+val persist_overrides : string -> unit
+(** Writes the current override table to
+    [<base_path>/.masc/prompt_overrides.json].  Idempotent. *)
+
+val restore_overrides : string -> unit
+(** Reads
+    [<base_path>/.masc/prompt_overrides.json] and reapplies
+    every entry through {!set_override}'s validation.
+    Stale or manually-edited entries are skipped with a
+    [Log.Misc.warn] instead of being silently accepted. *)
+
+(** {1 Listing + JSON export} *)
+
+val list_prompts : unit -> Yojson.Safe.t list
+(** Returns one JSON entry per registered prompt.
+    Snapshots key / meta / override / default under the
+    mutex, releases the lock, then reads the markdown
+    files and builds the [resolved] record outside the
+    lock so concurrent callers no longer serialize on
+    disk I/O.  Sorted by [(category, key)]. *)
+
+val prompts_json : unit -> Yojson.Safe.t
+(** [`Assoc [("prompts", `List (list_prompts ()))]] —
+    canonical envelope for the dashboard prompt route. *)
+
+(** {1 Validation} *)
+
+val validate_required_prompt_files : unit -> (string * string) list
+(** Returns [(key, path)] for every prompt whose meta
+    declares [required_file = true] but whose markdown
+    file is missing or unreadable.  [path] is the
+    expected location, or ["<invalid-key>"] when the
+    markdown dir is unset. *)
+
+val validate_prompt_templates : unit -> (string * string) list
+(** Returns [(key, variable)] pairs for every template
+    that references a variable not declared in the
+    registered [meta_tbl] entry's [template_variables]
+    list.  Empty / missing prompts are skipped (only
+    rendered prompts can have unexpected variables). *)
+
+(** {1 Test isolation} *)
+
+val clear : unit -> unit
+(** Drops every entry from the registry / version index /
+    override table / meta table and unsets the persisted
+    directory.  Pinned at this boundary because
+    [test/test_prompt_registry_defaults.ml] calls it
+    between cases for isolation; production code paths
+    do not need it. *)


### PR DESCRIPTION
## Summary
- Add `lib/prompt_registry/prompt_registry.mli` pinning the runtime prompt template registry surface (970 LOC).
- 15 functions + Types module re-export + 5 type re-exports + 4 yojson encoder/decoder pairs.

## Surface
- **Type-only access**: `Types` module re-export of `Prompt_registry_types` (used by `test_prompt_registry_pbt.ml` via `module Types = Prompt_registry.Types`).
- **Concrete record types** (re-exported from Types so callers pattern-match fields): `prompt_metrics`, `prompt_entry`, `registry_stats`, `prompt_meta`, `prompt_resolution`.
- **Yojson**: `prompt_metrics_to_yojson`, `prompt_metrics_of_yojson`, `prompt_entry_to_yojson`, `prompt_entry_of_yojson`.
- **Markdown directory**: `set_markdown_dir`, `get_markdown_dir`, `load_prompts_from_directory`.
- **Resolution**: `resolve_prompt`, `get_prompt`, `prompt_source`.
- **Rendering**: `render_prompt_template`.
- **Override lifecycle**: `set_override`, `clear_prompt_override`, `persist_overrides`, `restore_overrides`.
- **Listing / JSON export**: `list_prompts`, `prompts_json`.
- **Validation**: `validate_required_prompt_files`, `validate_prompt_templates`.
- **Test isolation**: `clear` (used by `test/test_prompt_registry_defaults.ml`).

## Resolution priority
override → file (`<markdown_dir>/<key>.md`) → registered default → empty.

## Internal helpers (private at this boundary)
- `parse_frontmatter`, `parse_list_value`, `extract_variables`.
- `make_key`, `is_valid_prompt_key`, `prompt_markdown_path`, `read_file_if_exists`.
- `get`, `get_versions`, `list_all`, `list_ids`, `exists`, `unregister`, `deprecate`, `update_metrics`.
- Render helpers: `unresolved_var_re`, `replace_substring_all`, `render_template`.
- Stats / counts / json: `stats`, `count`, `count_unique`, `to_json`, `of_json`.
- Internal resolution: `default_prompt_value_unlocked`, `build_resolved_from_snapshot`, `resolved_of_snapshot`, `unexpected_template_variables`.
- Output helpers: `prompt_item_json_of_resolved`, `compare_prompt_items`.
- Register helpers: `register_prompt`, `register_default`, `apply_override_validated`, `register`, `init`, `render`.

## Build feedback iteration
First build caught one `prompt_metrics` field name mistake (`total_uses` vs actual `usage_count`).  Fixed in the same iteration.

## Test plan
- [x] `dune build --root .` clean (lib + test + bin)
- [ ] required CI checks