### PR TITLE
test(a11y): batch 12 — filter-chips, section-cap, error-panel (cycle 33)

### DIFF
--- a/dashboard/src/components/common/error-panel.a11y.test.ts
+++ b/dashboard/src/components/common/error-panel.a11y.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for ErrorPanel — dropdown listing unacknowledged
+// errors. role="alert" on the wrapper (so AT announces when the
+// panel opens with content) and per-row icon-color + severity badge.
+// Tests pin both empty and populated states across severities.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { ErrorPanel } from './error-panel'
+import { errors } from './error-notification-state'
+import type { DashboardError } from '../../types/error'
+
+function makeError(overrides: Partial<DashboardError> = {}): DashboardError {
+  const now = Date.now()
+  return {
+    id: 'test-id',
+    fingerprint: 'fp',
+    agentName: 'sigma',
+    taskId: null,
+    message: 'Test error',
+    errorCode: 'internal_error',
+    severity: 'critical',
+    timestamp: now,
+    acknowledged: false,
+    count: 1,
+    lastSeen: now,
+    ...overrides,
+  }
+}
+
+describe('ErrorPanel a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    errors.value = []
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+    errors.value = []
+  })
+
+  it('empty state passes axe', async () => {
+    render(html`<${ErrorPanel} onClose=${() => {}} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('single critical error passes axe', async () => {
+    errors.value = [makeError({ severity: 'critical', message: 'Connection refused' })]
+    render(html`<${ErrorPanel} onClose=${() => {}} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('mixed severities (critical + warning + info) pass axe', async () => {
+    errors.value = [
+      makeError({ id: 'a', severity: 'critical', errorCode: 'internal_error', message: 'Boom' }),
+      makeError({ id: 'b', severity: 'warning', errorCode: 'rate_limited', message: 'Slow down' }),
+      makeError({ id: 'c', severity: 'info', errorCode: 'not_found', message: 'Missing' }),
+    ]
+    render(html`<${ErrorPanel} onClose=${() => {}} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('error with taskId + count > 1 passes axe', async () => {
+    errors.value = [makeError({
+      taskId: 'task-42',
+      count: 3,
+      message: 'Repeated timeout',
+      errorCode: 'timeout',
+      severity: 'warning',
+    })]
+    render(html`<${ErrorPanel} onClose=${() => {}} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/filter-chips.a11y.test.ts
+++ b/dashboard/src/components/common/filter-chips.a11y.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for FilterChips. role="tablist" wrapper + role="tab"
+// children + aria-selected on the active chip — this is the WAI-ARIA
+// tabs pattern. Tests pin uncontrolled (value+onChange) and signal
+// (active=Signal<T>) APIs both axe-clean across both tones and sizes.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { signal } from '@preact/signals'
+import { FilterChips } from './filter-chips'
+
+describe('FilterChips a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  const chips = [
+    { key: 'all', label: 'All' },
+    { key: 'active', label: 'Active', count: 12 },
+    { key: 'idle', label: 'Idle', count: 3 },
+  ] as const
+
+  it('value + onChange (uncontrolled-ish) passes axe', async () => {
+    render(
+      html`<${FilterChips}
+        chips=${chips}
+        value="active"
+        onChange=${() => {}}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('signal-driven (active=Signal<T>) passes axe', async () => {
+    const active = signal<'all' | 'active' | 'idle'>('all')
+    render(
+      html`<${FilterChips} chips=${chips} active=${active} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('size=md + tone=accent passes axe', async () => {
+    render(
+      html`<${FilterChips}
+        chips=${chips}
+        value="idle"
+        onChange=${() => {}}
+        size="md"
+        tone="accent"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('chip with title attribute passes axe', async () => {
+    const chipsWithTitle = [
+      { key: 'all', label: 'All', title: 'Show every keeper' },
+      { key: 'live', label: 'Live', title: 'Currently active only' },
+    ] as const
+    render(
+      html`<${FilterChips}
+        chips=${chipsWithTitle}
+        value="live"
+        onChange=${() => {}}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/section-cap.a11y.test.ts
+++ b/dashboard/src/components/common/section-cap.a11y.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for SectionCap. Tiny uppercase tracking-wider
+// section heading. Renders as <div> (not <h*>) by design — section
+// caps are labels, not document outline. axe should still report 0
+// violations across all tone/weight combinations.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { SectionCap } from './section-cap'
+
+describe('SectionCap a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default (muted + normal) passes axe', async () => {
+    render(html`<${SectionCap}>Recent activity</${SectionCap}>`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('tone=dim variant passes axe', async () => {
+    render(
+      html`<${SectionCap} tone="dim">Telemetry</${SectionCap}>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('weight=semibold variant passes axe', async () => {
+    render(
+      html`<${SectionCap} weight="semibold">Allowlist</${SectionCap}>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('caller-supplied extra class passes axe', async () => {
+    render(
+      html`<${SectionCap} class="mb-2 border-b border-[var(--white-5)]">
+        Diagnostics
+      </${SectionCap}>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

Lane C batch 12 — 3 dashboard atoms gain jest-axe coverage (12 cases).

## Atoms

| Atom | Cases | Coverage focus |
|------|-------|----------------|
| `FilterChips` | 4 | WAI-ARIA tabs pattern (role=tablist + role=tab + aria-selected); uncontrolled + signal-driven APIs; size/tone matrix; chip title |
| `SectionCap` | 4 | tone (muted/dim) × weight (normal/semibold) + extra class; renders as `<div>` not `<h*>` (section labels, not outline) |
| `ErrorPanel` | 4 | empty state, single critical, mixed severities, error with taskId + count > 1 (grouping) |

## Verification

- `pnpm test` (vitest happy-dom) → **12/12 passing**, 6.93s
- jest-axe + axe-core report 0 violations

## Pattern

Same as batches 1-11. ErrorPanel uses module-scoped `errors` signal directly — `beforeEach` / `afterEach` reset to `[]` so cases don't bleed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)