### PR TITLE
refactor(button): migrate ActionButton to component-level token aliases (cycle 34)

### DIFF
--- a/dashboard/src/components/common/button.test.ts
+++ b/dashboard/src/components/common/button.test.ts
@@ -34,9 +34,12 @@ describe('ActionButton', () => {
     expect(cn).toContain('accent')
   })
 
-  it('variant=danger includes the bad-state token classes', () => {
+  it('variant=danger includes the danger token classes', () => {
     render(html`<${ActionButton} variant="danger">x<//>`, container)
-    expect(container.querySelector('button')!.className).toContain('bad')
+    // After cycle 34 the inline `bad-*` literals were swapped for the
+    // `--button-danger-*` component-level aliases; var() chain resolves
+    // to the same hex (zero visual drift).
+    expect(container.querySelector('button')!.className).toContain('button-danger')
   })
 
   it('size=sm uses the smaller padding tier', () => {
@@ -119,8 +122,11 @@ describe('ActionButton', () => {
     expect(container.querySelector('button')!.hasAttribute('aria-pressed')).toBe(false)
   })
 
-  it('pressed=true with ghost variant overrides bg to accent-12 (visual selected state)', () => {
+  it('pressed=true with ghost variant swaps bg to ghost-pressed slot (visual selected state)', () => {
     render(html`<${ActionButton} variant="ghost" pressed=${true}>Active<//>`, container)
-    expect(container.querySelector('button')!.className).toContain('bg-[var(--accent-12)]')
+    // After cycle 34 the inline accent-12 literal moved into the
+    // --button-ghost-bg-pressed component slot (which itself resolves
+    // to var(--accent-12) via the token chain).
+    expect(container.querySelector('button')!.className).toContain('button-ghost-bg-pressed')
   })
 })

--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -23,12 +23,20 @@ const SIZE_CLASSES: Record<ButtonSize, string> = {
   lg: 'py-2 px-4 text-sm',
 }
 
+// Component-level token slots (button-{variant}-bg/fg/border/bg-hover/bg-pressed).
+// Defined in dashboard/design-system/tokens/source.ts §"Component-level role
+// tokens". Each alias resolves to the same hex via var() chain; swapping
+// the slot at the token layer (e.g. shipping a brand re-skin) propagates
+// here without touching this file.
+//
+// subtle/warn keep inline literals — their token slots haven't been
+// authored yet (see #11876 follow-up). When they land, swap inline.
 const VARIANT_CLASSES: Record<ButtonVariant, string> = {
-  primary: 'border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--color-fg-secondary)] hover:bg-[var(--accent-20)]',
-  ghost: 'border border-solid border-[var(--color-border-default)] bg-[var(--white-4)] text-[var(--color-fg-primary)] hover:bg-[var(--white-8)]',
-  danger: 'border border-solid border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-20)]',
+  primary: 'border border-solid border-[var(--button-primary-border)] bg-[var(--button-primary-bg)] text-[var(--button-primary-fg)] hover:bg-[var(--button-primary-bg-hover)]',
+  ghost: 'border border-solid border-[var(--button-ghost-border)] bg-[var(--button-ghost-bg)] text-[var(--button-ghost-fg)] hover:bg-[var(--button-ghost-bg-hover)]',
+  danger: 'border border-solid border-[var(--button-danger-border)] bg-[var(--button-danger-bg)] text-[var(--button-danger-fg)] hover:bg-[var(--button-danger-bg-hover)]',
   subtle: 'border-none bg-transparent text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] hover:bg-[var(--white-6)]',
-  ok: 'border border-solid border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)] hover:bg-[var(--ok-20)]',
+  ok: 'border border-solid border-[var(--button-ok-border)] bg-[var(--button-ok-bg)] text-[var(--button-ok-fg)] hover:bg-[var(--button-ok-bg-hover)]',
   warn: 'border-none bg-[var(--warn-14)] text-[var(--color-status-warn)] hover:bg-[var(--warn-24)]',
 }
 
@@ -37,12 +45,16 @@ const VARIANT_CLASSES: Record<ButtonVariant, string> = {
 // state that aria-pressed announces to assistive tech. Without this the
 // button can be aria-pressed but visually identical to unpressed, which
 // is a confusing mismatch.
+//
+// ghost pressed deliberately swaps its border/fg to the primary slots —
+// the active state borrows primary's affordance so the user reads it
+// as "selected" instead of "still neutral".
 const PRESSED_CLASSES: Record<ButtonVariant, string> = {
-  primary: 'bg-[var(--accent-20)]',
-  ghost: 'bg-[var(--accent-12)] border-[var(--accent-30)] text-[var(--color-fg-secondary)]',
-  danger: 'bg-[var(--bad-20)]',
+  primary: 'bg-[var(--button-primary-bg-pressed)]',
+  ghost: 'bg-[var(--button-ghost-bg-pressed)] border-[var(--button-primary-border)] text-[var(--button-primary-fg)]',
+  danger: 'bg-[var(--button-danger-bg-pressed)]',
   subtle: 'bg-[var(--white-6)] text-[var(--color-fg-primary)]',
-  ok: 'bg-[var(--ok-20)]',
+  ok: 'bg-[var(--button-ok-bg-pressed)]',
   warn: 'bg-[var(--warn-24)]',
 }
 


### PR DESCRIPTION
## Summary

**The first real consumer of the button-* token slots.** Token PRs (#11839 primary, #11847 ghost, #11855 danger, #11876 ok) authored 20 component-level slots over 4 cycles; this PR finally swaps the inline `var(--accent-12)` etc literals in `button.ts` for those aliases.

## What changes

| Variant | Inline literal | Component-level alias |
|---------|----------------|------------------------|
| primary bg | `var(--accent-12)` | `var(--button-primary-bg)` |
| primary border | `var(--accent-30)` | `var(--button-primary-border)` |
| primary fg | `var(--color-fg-secondary)` | `var(--button-primary-fg)` |
| primary hover | `var(--accent-20)` | `var(--button-primary-bg-hover)` |
| primary pressed | `var(--accent-20)` | `var(--button-primary-bg-pressed)` |

Same 5-slot swap for **ghost**, **danger**, **ok**.

`subtle` and `warn` retain inline literals for now — their token slots haven't been authored yet (#11876 follow-up). When those land, this file gets a same-shape swap.

## Why now

Tokens that no consumer reads are dead weight. Until this PR the component-level slots existed only in CSS output and tokens.json. Now `ActionButton` actually consumes them, so future palette retunes (e.g. dark/light, brand re-skin, motion-reduced) propagate from the token layer with zero callsite edits.

## Value drift: 0

Every alias resolves to the same hex via the `var()` chain (the alias *is* a `var(--upstream)` reference). Visual regression risk is zero.

## Ghost pressed special case

Ghost's pressed state deliberately swaps its border/fg to the **primary** slot family. The active state borrows primary's affordance so users read it as "selected" instead of "still neutral". Captured in code comment.

## Test impact

2 `button.test.ts` assertions previously checked the old inline literals (`'bad'`, `'bg-[var(--accent-12)]'`). Updated to assert on the alias slot names instead. **24/24 button tests passing.**

## Out of scope

- `subtle` / `warn` variant token slots (subsequent PR)
- Other ActionButton consumers (none — VARIANT_CLASSES is the single source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)