### PR TITLE
feat(button): wire BASE transition to t-med token (cycle 35)

### DIFF
--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -46,7 +46,10 @@ const PRESSED_CLASSES: Record<ButtonVariant, string> = {
   warn: 'bg-[var(--warn-24)]',
 }
 
-const BASE = `rounded cursor-pointer transition-all duration-200 font-medium ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })} active:scale-[0.97] active:opacity-90`
+// `duration-[var(--t-med)]` reads from the design-token duration scale
+// (--t-med = 200ms by default). Token retune (e.g. dampening interaction
+// motion for accessibility) propagates without callsite edits.
+const BASE = `rounded cursor-pointer transition-all duration-[var(--t-med)] font-medium ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })} active:scale-[0.97] active:opacity-90`
 
 interface ActionButtonProps {
   variant?: ButtonVariant


### PR DESCRIPTION
## Summary

Third consumer migration of motion tokens. `button.ts` BASE class swaps `duration-200` for `duration-[var(--t-med)]`.

## Change

| Before | After |
|--------|-------|
| `transition-all duration-200` | `transition-all duration-[var(--t-med)]` |

`--t-med` is the existing 200ms duration slot in `tokens/source.ts` (`t-fast`/`t-med`/`t-slow`/`t-xslow` family). Same numeric value — visual change 0.

## Why

- Removes the third magic-number from a primitive (after #11861 dialog and #11879 toast)
- Token retune (e.g. dampening interaction motion for prefers-reduced-motion or accessibility audit) now propagates to **all 6 ActionButton variants × every callsite** without code edits
- BASE is the universal transition spec for ActionButton — single point of change

## Verification

- `pnpm test` → **24/24 passing** (button.test.ts + button.a11y.test.ts)
- 1 file, 1-line change

## Pattern

Same as #11861 / #11879 — Tailwind v4 arbitrary value reads CSS variable directly. No keyframe edits, no consumer churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)