### PR TITLE
test(a11y): batch 13 — async-container, virtual-list, observatory-filter-bar (cycle 36)

### DIFF
--- a/dashboard/src/components/common/async-container.a11y.test.ts
+++ b/dashboard/src/components/common/async-container.a11y.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for AsyncContainer. Switches between LoadingState /
+// ErrorState / EmptyState / render(data) based on signal-driven
+// AsyncState. All 4 branches must axe-clean — the underlying
+// LoadingState/ErrorState/EmptyState already do (batch 5), but the
+// container's switch must not introduce wrapper-level violations.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { signal } from '@preact/signals'
+import { AsyncContainer } from './async-container'
+import type { AsyncState } from '../../lib/async-state'
+
+interface SampleData { items: string[] }
+
+describe('AsyncContainer a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('idle status passes axe', async () => {
+    const state = signal<AsyncState<SampleData>>({ status: 'idle' })
+    render(
+      html`<${AsyncContainer}
+        state=${state}
+        render=${(d: SampleData) => html`<div>${d.items.length}</div>`}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('loading status passes axe', async () => {
+    const state = signal<AsyncState<SampleData>>({ status: 'loading' })
+    render(
+      html`<${AsyncContainer}
+        state=${state}
+        render=${(d: SampleData) => html`<div>${d.items.length}</div>`}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('error status passes axe', async () => {
+    const state = signal<AsyncState<SampleData>>({ status: 'error', message: 'Connection refused' })
+    render(
+      html`<${AsyncContainer}
+        state=${state}
+        render=${(d: SampleData) => html`<div>${d.items.length}</div>`}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('loaded + empty branch passes axe', async () => {
+    const state = signal<AsyncState<SampleData>>({
+      status: 'loaded',
+      data: { items: [] },
+    })
+    render(
+      html`<${AsyncContainer}
+        state=${state}
+        render=${(d: SampleData) => html`<ul>${d.items.map(x => html`<li>${x}</li>`)}</ul>`}
+        emptyWhen=${(d: SampleData) => d.items.length === 0}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('loaded + render branch passes axe', async () => {
+    const state = signal<AsyncState<SampleData>>({
+      status: 'loaded',
+      data: { items: ['alpha', 'beta'] },
+    })
+    render(
+      html`<${AsyncContainer}
+        state=${state}
+        render=${(d: SampleData) => html`<ul>${d.items.map(x => html`<li>${x}</li>`)}</ul>`}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/observatory-filter-bar.a11y.test.ts
+++ b/dashboard/src/components/common/observatory-filter-bar.a11y.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for ObservatoryFilterBar. Renders chips for each
+// active filter with role="region" + aria-label on the wrapper. Each
+// chip's clear button has aria-label. Uses setObservatoryFilter to
+// drive state without mocking — store is module-scoped.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { ObservatoryFilterBar } from './observatory-filter-bar'
+import {
+  setObservatoryFilter,
+  clearObservatoryFilters,
+} from '../../observatory-filter-store'
+
+describe('ObservatoryFilterBar a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    clearObservatoryFilters()
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+    clearObservatoryFilters()
+  })
+
+  it('no active filter (returns null) renders accessibly', async () => {
+    render(html`<${ObservatoryFilterBar} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('keeper filter only passes axe', async () => {
+    setObservatoryFilter({ keeper: 'sigma' })
+    render(html`<${ObservatoryFilterBar} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('all four filters active pass axe', async () => {
+    setObservatoryFilter({
+      keeper: 'sigma',
+      namespace: 'logs',
+      operation: 'fetch',
+      range: '1h',
+    })
+    render(html`<${ObservatoryFilterBar} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('time range filter only passes axe', async () => {
+    setObservatoryFilter({ range: '24h' })
+    render(html`<${ObservatoryFilterBar} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/virtual-list.a11y.test.ts
+++ b/dashboard/src/components/common/virtual-list.a11y.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for VirtualList. Two render paths: below-threshold
+// (≤40 items, no virtualization, plain pass-through) and
+// above-threshold (windowed render with translateY offset). Both
+// must axe-clean — virtualized rendering must not break list semantics
+// for AT (rows still discoverable in the DOM, even if windowed).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { VirtualList } from './virtual-list'
+
+const renderItem = (item: string, _i: number) => html`
+  <div role="listitem">${item}</div>
+`
+
+describe('VirtualList a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('below-threshold (10 items, no virtualization) passes axe', async () => {
+    const items = Array.from({ length: 10 }, (_, i) => `item-${i}`)
+    render(
+      html`<div role="list">
+        <${VirtualList}
+          items=${items}
+          itemHeight=${24}
+          renderItem=${renderItem}
+          getKey=${(x: string) => x}
+        />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('at activation threshold (40 items) passes axe', async () => {
+    const items = Array.from({ length: 40 }, (_, i) => `row-${i}`)
+    render(
+      html`<div role="list">
+        <${VirtualList}
+          items=${items}
+          itemHeight=${20}
+          renderItem=${renderItem}
+          getKey=${(x: string) => x}
+        />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('above-threshold (200 items, virtualized) passes axe', async () => {
+    const items = Array.from({ length: 200 }, (_, i) => `entry-${i}`)
+    render(
+      html`<div role="list">
+        <${VirtualList}
+          items=${items}
+          itemHeight=${24}
+          overscan=${3}
+          renderItem=${renderItem}
+          getKey=${(x: string) => x}
+        />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('empty list (0 items) passes axe', async () => {
+    render(
+      html`<div role="list">
+        <${VirtualList}
+          items=${[]}
+          itemHeight=${24}
+          renderItem=${renderItem}
+          getKey=${(x: string) => x}
+        />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

Lane C batch 13 — 3 dashboard atoms gain jest-axe coverage (13 cases).

## Atoms

| Atom | Cases | Coverage focus |
|------|-------|----------------|
| `AsyncContainer` | 5 | All AsyncState branches (idle/loading/error/loaded-empty/loaded-render) — switch wrapper must not break wrapper-level a11y |
| `VirtualList` | 4 | Below ACTIVATION_THRESHOLD (10), at threshold (40), virtualized (200), empty list — both render paths |
| `ObservatoryFilterBar` | 4 | null-when-no-filter (returns null), single keeper filter, all 4 filters active, time-range-only |

## Verification

- `pnpm test` (vitest happy-dom) → **13/13 passing**, 8.94s
- jest-axe + axe-core report 0 violations

## Pattern

Same as batches 1-12. ObservatoryFilterBar uses module-scoped store directly via `setObservatoryFilter` / `clearObservatoryFilters` — `beforeEach`/`afterEach` reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)