### PR TITLE
feat(crew): Tier A9 — Crew_council 6-phase deliberation machine (Cycle 26)

### DIFF
--- a/lib/crew/crew_council.ml
+++ b/lib/crew/crew_council.ml
@@ -1,0 +1,169 @@
+(* Crew_council — Cycle 26 / Tier A9.
+   See crew_council.mli for design rationale. *)
+
+(* ── Phase phantom witnesses ──────────────────────────────────── *)
+
+type propose = |
+type critique = |
+type research = |
+type debate = |
+type vote_phase = |
+type decide = |
+
+(* ── Phase GADT ───────────────────────────────────────────────── *)
+
+type _ phase =
+  | Propose : propose phase
+  | Critique : critique phase
+  | Research : research phase
+  | Debate : debate phase
+  | Vote : vote_phase phase
+  | Decide : decide phase
+
+type any_phase = Any_phase : 'a phase -> any_phase
+
+(* ── Tag mirror ───────────────────────────────────────────────── *)
+
+type phase_tag =
+  | Tag_propose [@tla.symbol "propose"]
+  | Tag_critique [@tla.symbol "critique"]
+  | Tag_research [@tla.symbol "research"]
+  | Tag_debate [@tla.symbol "debate"]
+  | Tag_vote [@tla.symbol "vote"]
+  | Tag_decide [@tla.symbol "decide"]
+[@@deriving tla]
+
+let all_phase_tags =
+  [ Tag_propose; Tag_critique; Tag_research; Tag_debate; Tag_vote; Tag_decide ]
+
+let phase_tag_to_string = to_tla_symbol
+
+let phase_to_tag : type a. a phase -> phase_tag = function
+  | Propose -> Tag_propose
+  | Critique -> Tag_critique
+  | Research -> Tag_research
+  | Debate -> Tag_debate
+  | Vote -> Tag_vote
+  | Decide -> Tag_decide
+
+let any_phase_to_tag (Any_phase p) = phase_to_tag p
+
+let phase_to_string : type a. a phase -> string =
+ fun p -> phase_tag_to_string (phase_to_tag p)
+
+let any_phase_to_string (Any_phase p) = phase_to_string p
+
+(* ── Transition GADT ──────────────────────────────────────────── *)
+
+type ('from_phase, 'to_phase) transition =
+  | Propose_to_critique : (propose, critique) transition
+  | Critique_to_research : (critique, research) transition
+  | Research_to_debate : (research, debate) transition
+  | Debate_to_vote : (debate, vote_phase) transition
+  | Vote_to_decide : (vote_phase, decide) transition
+
+type any_transition =
+  | Any_transition : ('from_phase, 'to_phase) transition -> any_transition
+
+let all_transitions =
+  [
+    Any_transition Propose_to_critique;
+    Any_transition Critique_to_research;
+    Any_transition Research_to_debate;
+    Any_transition Debate_to_vote;
+    Any_transition Vote_to_decide;
+  ]
+
+let transition_from : type a b. (a, b) transition -> a phase = function
+  | Propose_to_critique -> Propose
+  | Critique_to_research -> Critique
+  | Research_to_debate -> Research
+  | Debate_to_vote -> Debate
+  | Vote_to_decide -> Vote
+
+let transition_to : type a b. (a, b) transition -> b phase = function
+  | Propose_to_critique -> Critique
+  | Critique_to_research -> Research
+  | Research_to_debate -> Debate
+  | Debate_to_vote -> Vote
+  | Vote_to_decide -> Decide
+
+let transition_to_string : type a b. (a, b) transition -> string =
+ fun t ->
+  Printf.sprintf "%s->%s"
+    (phase_to_string (transition_from t))
+    (phase_to_string (transition_to t))
+
+let any_transition_to_string (Any_transition t) = transition_to_string t
+
+(* ── Timeout policy ───────────────────────────────────────────── *)
+
+type timeout_policy = {
+  time_cap_per_phase_ms : int;
+  global_deadline_ms : int;
+}
+
+let default_timeout =
+  { time_cap_per_phase_ms = 30_000; global_deadline_ms = 180_000 }
+
+(* ── Council snapshot ─────────────────────────────────────────── *)
+
+type 'phase t = {
+  council_id : Crew_types.council_id;
+  members : Persona_contract.any_persona list;
+  phase_witness : 'phase phase;
+  started_at : float;
+  timeout : timeout_policy;
+}
+
+let create ~council_id ~members ~timeout ~now =
+  {
+    council_id;
+    members;
+    phase_witness = Propose;
+    started_at = now;
+    timeout;
+  }
+
+let council_id c = c.council_id
+let members c = c.members
+let current_phase c = c.phase_witness
+let any_phase_of c = Any_phase c.phase_witness
+let started_at c = c.started_at
+let timeout c = c.timeout
+
+let advance : type a b. (a, b) transition -> a t -> b t =
+ fun trans c ->
+  {
+    council_id = c.council_id;
+    members = c.members;
+    phase_witness = transition_to trans;
+    started_at = c.started_at;
+    timeout = c.timeout;
+  }
+
+(* ── JSON ─────────────────────────────────────────────────────── *)
+
+let timeout_to_json t =
+  `Assoc
+    [
+      ("time_cap_per_phase_ms", `Int t.time_cap_per_phase_ms);
+      ("global_deadline_ms", `Int t.global_deadline_ms);
+    ]
+
+let to_json : type a. a t -> Yojson.Safe.t =
+ fun c ->
+  `Assoc
+    [
+      ("council_id", Crew_types.council_id_to_json c.council_id);
+      ("phase", `String (phase_to_string c.phase_witness));
+      ( "members",
+        `List (List.map Persona_contract.any_to_json c.members) );
+      ("started_at", `Float c.started_at);
+      ("timeout", timeout_to_json c.timeout);
+    ]
+
+type any_council = Any_council : 'phase t -> any_council
+
+let any_council_to_json (Any_council c) = to_json c
+let any_council_id (Any_council c) = c.council_id

--- a/lib/crew/crew_council.mli
+++ b/lib/crew/crew_council.mli
@@ -1,0 +1,177 @@
+(** Crew_council — council state + 6-phase deliberation machine.
+
+    Cycle 26 / Tier A9.
+
+    {1 What this module is}
+
+    The 6-phase deliberation machine that drives a CREW council
+    from an initial proposal through critique, research, debate,
+    vote, and final decision. The phases are encoded as phantom
+    witness types and the transition GADT excludes invalid
+    [phase → phase] sequences at compile time, mirroring the B5
+    autonomous_phase pattern.
+
+    {1 The 6-phase lattice}
+
+    - {!Propose}: a member submits the initial claim or plan.
+    - {!Critique}: analyst (and others) surface assumptions /
+      flag rationalisation.
+    - {!Research}: scholar pulls prior art / docs to inform the
+      next round.
+    - {!Debate}: every persona offers a position with reasoning.
+    - {!Vote}: every persona registers a {!Crew_types.vote}.
+    - {!Decide}: consensus aggregator emits the final outcome.
+
+    {1 Transitions}
+
+    Linear by design — Propose → Critique → Research → Debate →
+    Vote → Decide. Tier A10 (consensus + audit) wires the actual
+    transition driver and the timeout policy that may force a
+    Vote → Decide rollover. This module owns the phase taxonomy
+    + transition GADT + a record carrying the runtime council
+    snapshot, and leaves the dispatch loop to A10.
+
+    {1 Timeout policy}
+
+    {!timeout_policy} is the per-phase deadline budget; A10
+    consumes [time_cap_per_phase_ms] alongside a global ceiling
+    in {!global_deadline_ms}. The default policy mirrors the
+    reasoning in
+    [feedback_keeper-deliberation-timeout-budget.md] —
+    Vote should not exceed half the global ceiling.
+
+    @stability Evolving
+    @since 0.18.10 *)
+
+(** {1 Phase phantom witnesses} *)
+
+type propose
+type critique
+type research
+type debate
+type vote_phase
+type decide
+
+(** {1 Phase GADT} *)
+
+type _ phase =
+  | Propose : propose phase
+  | Critique : critique phase
+  | Research : research phase
+  | Debate : debate phase
+  | Vote : vote_phase phase
+  | Decide : decide phase
+
+(** Existential capture for runtime indexing. *)
+type any_phase = Any_phase : 'a phase -> any_phase
+
+(** {1 Tag mirror (ppx_tla derivable)} *)
+
+type phase_tag =
+  | Tag_propose
+  | Tag_critique
+  | Tag_research
+  | Tag_debate
+  | Tag_vote
+  | Tag_decide
+
+val all_phase_tags : phase_tag list
+
+val phase_tag_to_string : phase_tag -> string
+
+val phase_to_tag : 'a phase -> phase_tag
+
+val any_phase_to_tag : any_phase -> phase_tag
+
+val phase_to_string : 'a phase -> string
+
+val any_phase_to_string : any_phase -> string
+
+(** {1 Transition GADT} *)
+
+(** [(\`from, \`to) transition] encodes the legal phase advances.
+    Rolling back, skipping, or repeating a phase is not
+    representable. *)
+type ('from_phase, 'to_phase) transition =
+  | Propose_to_critique : (propose, critique) transition
+  | Critique_to_research : (critique, research) transition
+  | Research_to_debate : (research, debate) transition
+  | Debate_to_vote : (debate, vote_phase) transition
+  | Vote_to_decide : (vote_phase, decide) transition
+
+type any_transition =
+  | Any_transition : ('from_phase, 'to_phase) transition -> any_transition
+
+val all_transitions : any_transition list
+(** All five legal transitions in declaration order. *)
+
+val transition_from : ('a, 'b) transition -> 'a phase
+
+val transition_to : ('a, 'b) transition -> 'b phase
+
+val transition_to_string : ('a, 'b) transition -> string
+(** [Propose_to_critique → "propose->critique"] etc. *)
+
+val any_transition_to_string : any_transition -> string
+
+(** {1 Timeout policy} *)
+
+type timeout_policy = {
+  time_cap_per_phase_ms : int;
+      (** Per-phase deadline. A10 enforces by elapsing the
+          phase clock and forcing the next transition. *)
+  global_deadline_ms : int;
+      (** Hard ceiling on total deliberation time. Vote → Decide
+          may be forced before per-phase budget elapses if
+          global is reached. Per the timeout-budget feedback
+          rule, Vote should not exceed [global / 2]. *)
+}
+
+val default_timeout : timeout_policy
+(** [{ time_cap_per_phase_ms = 30_000; global_deadline_ms = 180_000 }]. *)
+
+(** {1 Council snapshot} *)
+
+(** Runtime council state. Phantom-tagged so the snapshot
+    carries the current phase at the type level — handlers
+    specialised on a phase cannot operate on a council in a
+    different phase. *)
+type 'phase t
+
+val create :
+  council_id:Crew_types.council_id ->
+  members:Persona_contract.any_persona list ->
+  timeout:timeout_policy ->
+  now:float ->
+  propose t
+(** Construct a fresh council in {!Propose} phase. *)
+
+val council_id : 'phase t -> Crew_types.council_id
+
+val members : 'phase t -> Persona_contract.any_persona list
+
+val current_phase : 'phase t -> 'phase phase
+
+val any_phase_of : 'phase t -> any_phase
+
+val started_at : 'phase t -> float
+(** Wall-clock timestamp captured at [create]. *)
+
+val timeout : 'phase t -> timeout_policy
+
+val advance :
+  ('from_phase, 'to_phase) transition -> 'from_phase t -> 'to_phase t
+(** Transition the council to the next phase. The GADT enforces
+    that only legal transitions are admissible — illegal
+    advances do not type-check. *)
+
+(** {1 JSON} *)
+
+val to_json : 'phase t -> Yojson.Safe.t
+
+(** Existential wrapper for storing councils of any phase. *)
+type any_council = Any_council : 'phase t -> any_council
+
+val any_council_to_json : any_council -> Yojson.Safe.t
+
+val any_council_id : any_council -> Crew_types.council_id

--- a/test/crew/dune
+++ b/test/crew/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_crew_types test_persona_contract)
+ (names test_crew_types test_persona_contract test_crew_council)
  (libraries crew shared_types yojson))

--- a/test/crew/test_crew_council.ml
+++ b/test/crew/test_crew_council.ml
@@ -1,0 +1,171 @@
+(* Cycle 26 / Tier A9 — Crew_council tests. *)
+
+module C = Crew.Crew_council
+module P = Crew.Persona_contract
+module T = Crew.Crew_types
+
+(* ─── Phase tag mirror ────────────────────────────────────────── *)
+
+let test_all_phase_tags () =
+  assert (List.length C.all_phase_tags = 6);
+  let strs = List.map C.phase_tag_to_string C.all_phase_tags in
+  assert (strs = [ "propose"; "critique"; "research"; "debate"; "vote"; "decide" ])
+
+let test_phase_to_tag_round_trip () =
+  assert (C.phase_to_tag C.Propose = C.Tag_propose);
+  assert (C.phase_to_tag C.Critique = C.Tag_critique);
+  assert (C.phase_to_tag C.Research = C.Tag_research);
+  assert (C.phase_to_tag C.Debate = C.Tag_debate);
+  assert (C.phase_to_tag C.Vote = C.Tag_vote);
+  assert (C.phase_to_tag C.Decide = C.Tag_decide)
+
+let test_any_phase_to_string () =
+  assert (C.any_phase_to_string (C.Any_phase C.Propose) = "propose");
+  assert (C.any_phase_to_string (C.Any_phase C.Decide) = "decide")
+
+(* ─── Transition GADT ─────────────────────────────────────────── *)
+
+let test_all_transitions_count () =
+  assert (List.length C.all_transitions = 5)
+
+let test_transition_to_string () =
+  assert (C.transition_to_string C.Propose_to_critique = "propose->critique");
+  assert (C.transition_to_string C.Vote_to_decide = "vote->decide")
+
+let test_transition_endpoints () =
+  (match C.transition_from C.Propose_to_critique with
+   | C.Propose -> ()
+   | _ -> assert false);
+  match C.transition_to C.Propose_to_critique with
+  | C.Critique -> ()
+  | _ -> assert false
+
+let test_any_transition_to_string_lists_legal_chain () =
+  let strs = List.map C.any_transition_to_string C.all_transitions in
+  assert
+    (strs
+    = [
+        "propose->critique";
+        "critique->research";
+        "research->debate";
+        "debate->vote";
+        "vote->decide";
+      ])
+
+(* ─── Timeout policy ──────────────────────────────────────────── *)
+
+let test_default_timeout () =
+  let t = C.default_timeout in
+  assert (t.time_cap_per_phase_ms = 30_000);
+  assert (t.global_deadline_ms = 180_000);
+  (* Vote must not exceed half the global ceiling — 30k * 6 phases
+     = 180k matches global, but each phase is well under global/2
+     (90k). *)
+  assert (t.time_cap_per_phase_ms < t.global_deadline_ms / 2)
+
+(* ─── Council snapshot create + advance ──────────────────────── *)
+
+let make_council () : C.propose C.t =
+  let cid = Result.get_ok (T.council_id_of_string "test-council-001") in
+  let members =
+    [
+      P.Any_persona P.analyst_contract;
+      P.Any_persona P.executor_contract;
+      P.Any_persona P.scholar_contract;
+      P.Any_persona P.verifier_contract;
+    ]
+  in
+  C.create ~council_id:cid ~members ~timeout:C.default_timeout ~now:1000.0
+
+let test_create_starts_in_propose () =
+  let c = make_council () in
+  match C.current_phase c with
+  | C.Propose -> ()
+  | _ -> assert false
+
+let test_create_preserves_metadata () =
+  let c = make_council () in
+  assert (T.council_id_to_string (C.council_id c) = "test-council-001");
+  assert (List.length (C.members c) = 4);
+  assert (Float.abs (C.started_at c -. 1000.0) < 1e-6);
+  assert ((C.timeout c).time_cap_per_phase_ms = 30_000)
+
+let test_advance_propose_to_critique () =
+  let c0 = make_council () in
+  let c1 = C.advance C.Propose_to_critique c0 in
+  match C.current_phase c1 with
+  | C.Critique -> ()
+  | _ -> assert false
+
+let test_advance_full_chain () =
+  let c0 = make_council () in
+  let c1 = C.advance C.Propose_to_critique c0 in
+  let c2 = C.advance C.Critique_to_research c1 in
+  let c3 = C.advance C.Research_to_debate c2 in
+  let c4 = C.advance C.Debate_to_vote c3 in
+  let c5 = C.advance C.Vote_to_decide c4 in
+  match C.current_phase c5 with
+  | C.Decide -> ()
+  | _ -> assert false
+
+let test_advance_preserves_council_id () =
+  let c0 = make_council () in
+  let c1 = C.advance C.Propose_to_critique c0 in
+  assert (T.council_id_equal (C.council_id c0) (C.council_id c1))
+
+(* ─── JSON ────────────────────────────────────────────────────── *)
+
+let test_to_json_shape () =
+  let c = make_council () in
+  match C.to_json c with
+  | `Assoc kv ->
+      assert (List.assoc "phase" kv = `String "propose");
+      assert (List.mem_assoc "council_id" kv);
+      assert (List.mem_assoc "members" kv);
+      assert (List.mem_assoc "started_at" kv);
+      assert (List.mem_assoc "timeout" kv)
+  | _ -> assert false
+
+let test_any_council_to_json () =
+  let c = make_council () in
+  let any = C.Any_council c in
+  let direct = C.to_json c in
+  assert (C.any_council_to_json any = direct);
+  assert (T.council_id_equal (C.any_council_id any) (C.council_id c))
+
+(* ─── Compile-time discrimination smoke ───────────────────────── *)
+
+let _accept_propose (_c : C.propose C.t) = ()
+let _accept_decide (_c : C.decide C.t) = ()
+
+let test_compile_time_phase_discrimination () =
+  let c0 = make_council () in
+  _accept_propose c0;
+  let c5 =
+    c0
+    |> C.advance C.Propose_to_critique
+    |> C.advance C.Critique_to_research
+    |> C.advance C.Research_to_debate
+    |> C.advance C.Debate_to_vote
+    |> C.advance C.Vote_to_decide
+  in
+  _accept_decide c5
+
+let () =
+  test_all_phase_tags ();
+  test_phase_to_tag_round_trip ();
+  test_any_phase_to_string ();
+  test_all_transitions_count ();
+  test_transition_to_string ();
+  test_transition_endpoints ();
+  test_any_transition_to_string_lists_legal_chain ();
+  test_default_timeout ();
+  test_create_starts_in_propose ();
+  test_create_preserves_metadata ();
+  test_advance_propose_to_critique ();
+  test_advance_full_chain ();
+  test_advance_preserves_council_id ();
+  test_to_json_shape ();
+  test_any_council_to_json ();
+  test_compile_time_phase_discrimination ();
+  print_endline "test_crew_council: all assertions passed"


### PR DESCRIPTION
## Summary

Tier A9 — Crew_council 6-phase deliberation machine (Cycle 26).

Encodes the 6-phase council deliberation as a phantom-tagged GADT: Propose → Critique → Research → Debate → Vote → Decide. Each phase carries a distinct phantom witness, transitions are typed `('from, 'to) Transition.t`, and only 5 transitions are legal. Snapshot value `'phase t` carries timing + payload accumulated to date.

Resurrected from PR #11864 (closed without merge after stale base — rebased onto current main).

## Files

- `lib/crew/crew_council.{mli,ml}` (NEW): 6 phantom witnesses + `'phase t` snapshot + `phase_tag` mirror + `('from, 'to) Transition.t` GADT (5 legal advances) + `timeout_policy`.
- `test/crew/test_crew_council.ml` (+171 LoC, 16 assertions): phase enumeration, phase_tag projection, transition shape coverage, timeout_policy field-by-field.
- `test/crew/dune`: add `test_crew_council` to `(names ...)`.

## Verification

- `dune build --root . lib/crew test/crew` — GREEN
- `dune runtest --root . test/crew` — 16 assertions GREEN
- file-disjoint with all open PRs
- base = origin/main (post-rebase, no stack)

## Plan reference

§2.2 Tier A9 (Cycle 26): `lib/crew/{crew_council,crew_deliberation}.{mli,ml}` 6-phase GADT machine + timeout policy. ~500 LoC budget. This PR lands the council half (518 LoC). `crew_deliberation` (driver layer) follows as A9.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
