### PR TITLE
fix(dashboard): replace deprecated cytoscape width/height='label' + drop custom wheelSensitivity

### DIFF
--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -121,6 +121,31 @@ function buildElements(spec: FsmGraphSpec) {
   return [...nodes, ...edges]
 }
 
+// Width/height sizing for label-fit nodes. Replaces the deprecated
+// `width: 'label'` / `height: 'label'` (cytoscape 3.33+ emits a
+// per-render warning). Estimates from label length using the node's
+// monospace 11px font and respecting the 120px text-max-width cap.
+const NODE_FONT_PX_PER_CHAR = 7   // 11px ui-monospace ≈ 7px wide
+const NODE_PADDING_PX = 10
+const NODE_TEXT_MAX_WIDTH_PX = 120
+const NODE_LINE_HEIGHT_PX = 16
+const NODE_MIN_WIDTH = 64
+const NODE_MIN_HEIGHT = 36
+
+function nodeWidth(ele: { data: (key: string) => unknown }): number {
+  const label = String(ele.data('label') ?? '')
+  const text = label.length * NODE_FONT_PX_PER_CHAR
+  const fit = Math.min(NODE_TEXT_MAX_WIDTH_PX, text)
+  return Math.max(NODE_MIN_WIDTH, fit + NODE_PADDING_PX * 2)
+}
+
+function nodeHeight(ele: { data: (key: string) => unknown }): number {
+  const label = String(ele.data('label') ?? '')
+  const text = label.length * NODE_FONT_PX_PER_CHAR
+  const lines = Math.max(1, Math.ceil(text / NODE_TEXT_MAX_WIDTH_PX))
+  return Math.max(NODE_MIN_HEIGHT, lines * NODE_LINE_HEIGHT_PX + NODE_PADDING_PX * 2)
+}
+
 function buildStylesheet() {
   const styles: Array<{ selector: string; style: Record<string, unknown> }> = [
     {
@@ -136,11 +161,11 @@ function buildStylesheet() {
         'border-width': 2,
         'border-color': resolveCssVar('--slate-600'),
         shape: 'roundrectangle',
-        width: 'label',
-        height: 'label',
-        padding: '10px',
+        width: nodeWidth,
+        height: nodeHeight,
+        padding: `${NODE_PADDING_PX}px`,
         'text-wrap': 'wrap',
-        'text-max-width': '120px',
+        'text-max-width': `${NODE_TEXT_MAX_WIDTH_PX}px`,
       },
     },
     {
@@ -249,7 +274,11 @@ export function CytoscapeFsm({ spec, height = '280px', class: className = '' }: 
           } as cytoscape.LayoutOptions,
           minZoom: 0.3,
           maxZoom: 3,
-          wheelSensitivity: 0.3,
+          // wheelSensitivity is intentionally left at the cytoscape
+          // default (1). Cytoscape warns against custom values because
+          // the natural zoom feel depends on hardware (mouse vs.
+          // trackpad) and OS scroll settings — the previous 0.3 made
+          // trackpads feel sluggish.
           boxSelectionEnabled: false,
           selectionType: 'single',
           userPanningEnabled: true,


### PR DESCRIPTION
## 목적

#11872 후속으로 남은 cytoscape 콘솔 워닝 두 종류 정리.

1. \`The style value of \`label\` is deprecated for \`width\`/\`height\`\` (per-render, 노드마다)
2. \`You have set a custom wheel sensitivity. This will make your app zoom unnaturally...\` (인스턴스마다 1회)

## 근거

\`node_modules/cytoscape/src/style/properties.mjs:34\`:
\`\`\`
nodeSize: { number: true, min: 0, enums: [ 'label' ] }
\`\`\`

→ width/height에 허용되는 값은 **숫자** 또는 **\`'label'\`** 뿐. \`'auto'\` 같은 다른 문자열은 invalid로 거부되어 silent drop → 기본 30x30px로 떨어짐.

## 변경

\`dashboard/src/components/common/cytoscape-fsm.ts\` 한 파일.

### width/height
- \`'label'\` (deprecated) → 라벨 길이로 픽셀 폭/높이를 계산하는 mapper 함수 (\`nodeWidth\`, \`nodeHeight\`).
- 사이징 상수(폰트 폭, padding, max-width, line-height, min size)를 명명 상수로 분리.

### wheelSensitivity
- \`0.3\` 제거 → cytoscape 기본값 사용. 트랙패드/마우스 휠 자연스러움 확보 + 워닝 제거.

## 검증

- \`pnpm typecheck\` clean
- \`pnpm lint\` clean
- \`pnpm build\` success

## 주의: 평행 PR #11873

같은 영역을 더 넓게 다루는 평행 PR(#11873, 본인 다른 세션, 04:04 생성)이 \`open\` 상태입니다. \`width: 'auto'\`로 가는 접근은 위 spec상 invalid라 노드 사이징이 깨집니다. 이 PR이 superset이므로 #11873은 close 권장 (사용자 판단). 차이점은 #11873 코멘트로 노트했습니다.

## Test plan

- [ ] CI green
- [ ] 머지 후 \`http://127.0.0.1:8935/dashboard\`에서 cytoscape 패널을 띄웠을 때 콘솔에 \`deprecated for width/height\` 워닝 0
- [ ] \`custom wheel sensitivity\` 워닝 0
- [ ] FSM 노드가 라벨 길이에 맞게 적절히 사이징되는지 (긴 라벨도 잘리지 않음)