### PR TITLE
chore(board): add tool_board.mli — board MCP tool family pin (cycle 210)

### DIFF
--- a/lib/tool_board.mli
+++ b/lib/tool_board.mli
@@ -1,0 +1,168 @@
+(** Tool_board — MCP tool family for the internal board.
+
+    Owns:
+    - the {b agent-lookup callback} ({!set_agent_lookup} /
+      {!set_agent_lookup_none} / {!is_agent}) wired at
+      server bootstrap so post-kind classification can ask
+      whether a name is currently joined to the room,
+    - the {b post / comment / vote handlers} routed
+      through {!handle_tool} (one entry per
+      [masc_board_*] tool name),
+    - the {b tools} list advertised to MCP clients
+      (10 schemas: post, list, get, comment, vote, stats,
+      search, comment_vote, profile, hearth_list, delete),
+    - the {b truncated-markdown detector}
+      ({!detect_truncated_markdown} +
+      {!detect_truncated_markdown_with_reason}) used by
+      the post-create path to flag chat-suffix paste
+      accidents,
+    - the {b sort-order parser} ({!parse_sort_order})
+      shared with the dashboard board route.
+
+    Internal helpers stay private at this boundary
+    ([board_list_cache] type + the cache cell, the
+    [cached_board_list] adapter, [strip_state_blocks_text],
+    [tool_result] type alias, [format_ttl_remaining],
+    [agent_lookup_hook] atomic ref,
+    [resolve_board_post_kind], [format_post] /
+    [format_post_compact] / [format_comment] /
+    [format_comment_tree], [assoc_replace],
+    [judgment_arg], [normalize_board_post_meta],
+    [handle_post_create] / [_list_uncached] / [_list] /
+    [_get] / [_comment_add] / [_vote] / [_stats] /
+    [_search] / [_comment_vote] / [_profile] /
+    [_hearth_list] / [_delete] / [_board_cleanup],
+    [board_list_cache_key], [evolution_callback] type,
+    [evolution_hook] atomic ref,
+    [register_evolution_callback], [tool_post_list],
+    [tool_post_get], [tool_comment_add], [tool_vote],
+    [tool_stats], [tool_search], [tool_comment_vote],
+    [tool_profile], [tool_hearth_list], [tool_delete],
+    [tool_board_cleanup], [tool_spec_read_only]). *)
+
+(** {1 Truncated markdown detection} *)
+
+type truncation_signal =
+  | Odd_fence
+      (** odd count of triple-backtick code fences. *)
+  | Odd_inline_tick
+      (** odd count of single backticks outside fences. *)
+  | Unfinished_link
+      (** trailing [\[text\](] with no closing [)]. *)
+  | Unfinished_image
+      (** trailing [\!\[alt\](] with no closing [)]. *)
+  | Odd_double_asterisk
+      (** odd count of [**] outside fences. *)
+
+val truncation_signal_to_string : truncation_signal -> string
+
+val detect_truncated_markdown_with_reason :
+  string -> truncation_signal option
+(** Returns the first {!truncation_signal} that fires for
+    the input, [None] when the markdown looks complete.
+    Used by [handle_post_create] to surface a precise
+    reason in the response when a paste appears
+    truncated. *)
+
+val detect_truncated_markdown : string -> bool
+(** Boolean form — true iff
+    {!detect_truncated_markdown_with_reason} returns a
+    [Some]. *)
+
+(** {1 Sort order} *)
+
+type sort_order = Board_dispatch.sort_order =
+  | Hot
+  | Trending
+  | Recent
+  | Updated
+  | Discussed
+(** Type re-export from {!Board_dispatch.sort_order}.
+    Identity preserved so [Tool_board.sort_order] and
+    [Board_dispatch.sort_order] are interchangeable. *)
+
+val parse_sort_order : string -> (sort_order, string) result
+(** Delegates to
+    {!Board_dispatch.sort_order_of_string_opt} (canonical
+    + documented aliases [new] / [active] / [comments]).
+    Error message lists
+    {!Board_dispatch.valid_sort_order_strings} so adding
+    a constructor automatically updates the user-facing
+    catalogue. *)
+
+(** {1 Display formatting} *)
+
+val format_timestamp_relative : float -> string
+(** Renders a Unix timestamp as a human-readable relative
+    duration (["5s ago"] / ["3h ago"] / ["2d ago"]).
+    Used in board listing prompt blocks. *)
+
+(** {1 Board error rendering} *)
+
+val board_error_to_string : Board.board_error -> string
+(** Renders a {!Board.board_error} with a leading prefix
+    (["Invalid ID:"] / ["Post not found:"] / ...).  Used
+    by the dispatcher to convert [Board.X] errors into
+    user-visible tool response messages. *)
+
+val visibility_of_string : string -> Board.visibility option
+(** Re-export of {!Board.visibility_of_string}.  Pinned at
+    this boundary so callers reach it via
+    [Tool_board.visibility_of_string] without importing
+    {!Board} directly. *)
+
+(** {1 Agent lookup callback} *)
+
+val set_agent_lookup : (string -> bool) -> unit
+(** Wires the [is_agent_joined] check used by the
+    auto-classifier to decide whether a [system_*] author
+    name resolves to a live agent.  Installed once at
+    server bootstrap from [server_state.room_config]. *)
+
+val set_agent_lookup_none : unit -> unit
+(** Clears the previously-installed callback.  Used by
+    test isolation; production paths leave the hook set. *)
+
+val is_agent : string -> bool
+(** Returns the result of the registered hook, [false]
+    when no hook is installed. *)
+
+(** {1 Cache invalidation} *)
+
+val invalidate_board_list_cache : unit -> unit
+(** Drops the cached [masc_board_list] result so the next
+    read sees fresh state.  Called automatically by
+    {!handle_tool} after every mutation tool
+    (post / comment / vote / delete / cleanup). *)
+
+(** {1 Tools advertised to MCP} *)
+
+val tool_post_create : Types.tool_schema
+(** Schema for [masc_board_post].  Pinned at this
+    boundary because the dashboard tool inspector renders
+    the schema directly (other [tool_*] schemas are
+    reached only through {!tools}). *)
+
+val tools : Types.tool_schema list
+(** All 11 board tool schemas in advertisement order:
+    post / list / get / comment / vote / stats / search /
+    comment_vote / profile / hearth_list / delete. *)
+
+(** {1 Tool dispatcher} *)
+
+val handle_tool : string -> Yojson.Safe.t -> bool * string
+(** Routes [name] to the matching internal handler.
+    Mutation tools (post / comment / vote / delete /
+    cleanup) automatically invoke
+    {!invalidate_board_list_cache} on completion so the
+    next [masc_board_list] reads fresh data.  Returns
+    [(success, json_message)] — the wrapper layer
+    composes the final JSON-RPC envelope around it. *)
+
+(** {1 Registry installation} *)
+
+val register : unit -> unit
+(** Installs every tool from {!tools} into the global
+    {!Tool_dispatch} registry and pairs the canonical
+    [masc_board_*] tag with each handler.  Idempotent;
+    second call is a no-op. *)


### PR DESCRIPTION
## Summary
- Add `lib/tool_board.mli` pinning the board MCP tool family surface (1118 LOC).
- 17 external entries collapsed from 62 toplevels.

## Surface
- **Truncated markdown detection**: `truncation_signal` type (5 variants), `truncation_signal_to_string`, `detect_truncated_markdown`, `detect_truncated_markdown_with_reason`.
- **Sort order**: `sort_order` type (re-export from `Board_dispatch.sort_order`, identity preserved), `parse_sort_order`.
- **Display**: `format_timestamp_relative`.
- **Board error rendering**: `board_error_to_string`, `visibility_of_string` (re-export from `Board`).
- **Agent lookup callback**: `set_agent_lookup`, `set_agent_lookup_none`, `is_agent`.
- **Cache**: `invalidate_board_list_cache`.
- **Tools**: `tool_post_create` (single schema pinned — dashboard inspector renders the schema directly; other 10 schemas reach callers only through `tools`), `tools` list, `handle_tool` dispatcher, `register`.

## Internal helpers (private at this boundary)
- Cache plumbing: `board_list_cache` type, `_board_list_cache` cell, `cached_board_list`, `board_list_cache_ttl_s`, `board_list_cache_key`.
- Type alias: `tool_result`.
- TTL formatting: `format_ttl_remaining`.
- Agent lookup state: `agent_lookup_hook` atomic ref.
- Auto-classifier: `resolve_board_post_kind`.
- Display helpers: `format_post`, `format_post_compact`, `format_comment`, `format_comment_tree`.
- Meta plumbing: `assoc_replace`, `judgment_arg`, `normalize_board_post_meta`, `strip_state_blocks_text`.
- 12 internal handlers (`handle_post_create`, `_list`, `_list_uncached`, `_get`, `_comment_add`, `_vote`, `_stats`, `_search`, `_comment_vote`, `_profile`, `_hearth_list`, `_delete`, `_board_cleanup`) — reachable only through `handle_tool`.
- Evolution hook: `evolution_callback` type, `evolution_hook` atomic, `register_evolution_callback`.
- 10 internal `tool_*` schemas (post_list, post_get, comment_add, vote, stats, search, comment_vote, profile, hearth_list, delete, board_cleanup) reach callers via `tools`.
- `tool_spec_read_only`.

## Test plan
- [x] `dune build --root .` clean (lib + test + bin), 1 iteration
- [ ] required CI checks