### PR TITLE
refactor: duration-150 → t-fast token sweep across 4 atoms (cycle 38)

### DIFF
--- a/dashboard/src/components/common/filter-chips.ts
+++ b/dashboard/src/components/common/filter-chips.ts
@@ -50,7 +50,7 @@ export function FilterChips<T extends string>({
           title=${chip.title}
           role="tab"
           aria-selected=${activeKey === chip.key}
-          class="${chipClass} cursor-pointer transition-all duration-150 ${activeKey === chip.key
+          class="${chipClass} cursor-pointer transition-all duration-[var(--t-fast)] ${activeKey === chip.key
             ? activeToneClass
             : idleToneClass}"
           onClick=${() => {

--- a/dashboard/src/components/common/json-viewer.ts
+++ b/dashboard/src/components/common/json-viewer.ts
@@ -72,7 +72,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
         aria-expanded=${!collapsed}
         aria-label=${`${collapsed ? 'Expand' : 'Collapse'} ${toggleLabel}`}
       >
-        <span aria-hidden="true" class="text-[var(--color-fg-muted)] shrink-0 w-4 inline-flex justify-center transition-transform duration-150 ${collapsed ? '-rotate-90' : ''}">▼</span>
+        <span aria-hidden="true" class="text-[var(--color-fg-muted)] shrink-0 w-4 inline-flex justify-center transition-transform duration-[var(--t-fast)] ${collapsed ? '-rotate-90' : ''}">▼</span>
         ${label ? html`<span class="text-[var(--color-fg-primary)] font-medium truncate">${label}</span>` : null}
         <span class="text-[var(--color-fg-muted)] text-2xs ml-1 shrink-0">
           ${isArray ? `[${(data as unknown[]).length}]` : `{${entries.length}}`}

--- a/dashboard/src/components/common/scroll-to-top.ts
+++ b/dashboard/src/components/common/scroll-to-top.ts
@@ -71,7 +71,7 @@ export function ScrollToTopButton({
 
   return html`<button
     type="button"
-    class=${`fixed bottom-6 right-6 z-[var(--z-overlay-toast,3070)] flex h-10 w-10 items-center justify-center rounded-sm border border-[var(--white-10)] bg-[var(--color-bg-surface)]/90 text-[var(--color-fg-primary)] shadow-[0_6px_18px_rgba(0,0,0,0.32)] backdrop-blur transition-all duration-150 hover:border-[var(--accent-30)] hover:text-[var(--color-accent-fg)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })} cursor-pointer ${cx ?? ''}`}
+    class=${`fixed bottom-6 right-6 z-[var(--z-overlay-toast,3070)] flex h-10 w-10 items-center justify-center rounded-sm border border-[var(--white-10)] bg-[var(--color-bg-surface)]/90 text-[var(--color-fg-primary)] shadow-[0_6px_18px_rgba(0,0,0,0.32)] backdrop-blur transition-all duration-[var(--t-fast)] hover:border-[var(--accent-30)] hover:text-[var(--color-accent-fg)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })} cursor-pointer ${cx ?? ''}`}
     aria-label="맨 위로"
     title="맨 위로 (Home)"
     data-scroll-to-top

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -185,7 +185,7 @@ export function ToastContainer() {
           ${t.action ? html`
             <button
               type="button"
-              class="shrink-0 text-2xs px-2 py-1 rounded border border-[var(--color-border-default)] bg-[var(--white-5)] text-[var(--color-accent-fg)] hover:bg-[var(--white-10)] cursor-pointer transition-colors duration-150"
+              class="shrink-0 text-2xs px-2 py-1 rounded border border-[var(--color-border-default)] bg-[var(--white-5)] text-[var(--color-accent-fg)] hover:bg-[var(--white-10)] cursor-pointer transition-colors duration-[var(--t-fast)]"
               onClick=${(e: Event) => {
                 e.stopPropagation()
                 t.action!.onClick()
@@ -197,7 +197,7 @@ export function ToastContainer() {
           ` : null}
           <button
             type="button"
-            class="shrink-0 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer p-1 rounded hover:bg-[var(--white-5)] transition-colors duration-150 flex items-center justify-center"
+            class="shrink-0 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer p-1 rounded hover:bg-[var(--white-5)] transition-colors duration-[var(--t-fast)] flex items-center justify-center"
             aria-label="닫기"
             title="닫기"
             onClick=${(e: Event) => {


### PR DESCRIPTION
## Summary

Sweeps the remaining `duration-150` magic numbers in `dashboard/src/components/common/` to the `--t-fast` token (120ms).

## Files changed (4, 5 occurrences)

| File | Context |
|------|---------|
| `filter-chips.ts:53` | chip `transition-all duration-150` |
| `json-viewer.ts:75` | collapse caret `transition-transform duration-150` |
| `scroll-to-top.ts:74` | floating button `transition-all duration-150` |
| `toast.ts:188` | action button `transition-colors duration-150` |
| `toast.ts:200` | close button `transition-colors duration-150` |

All five → `duration-[var(--t-fast)]`.

## Cosmetic delta

150ms → 120ms is a **30ms shift** in micro-interaction perception territory. Within just-noticeable-difference threshold for hover transitions; design system consistency outweighs per-callsite ms accuracy.

If a callsite genuinely needs to stand apart (e.g. an emphasized callout that should feel slower), it can opt into `duration-[var(--t-med)]` (200ms) explicitly.

## Verification

- `pnpm test` → **58/58 passing** across the 4 affected components + their existing test files
- `rg duration-150 dashboard/src/components/common/*.ts` → empty after PR

## Pattern

Same wiring approach as #11861 (DialogOverlay), #11879 (Toast slide), #11890 (button BASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)