### PR TITLE
chore: bump version to 0.18.11

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc_mcp)
-(version 0.18.10)
+(version 0.18.11)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Summary
- Bump `dune-project` version from `0.18.10` → `0.18.11`

## Test plan
- [x] `dune build` passes (single-line version string change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)