### PR TITLE
feat(design-system): Iter 2 — migrate AuthPopover to useFocusScope

### DIFF
--- a/dashboard/design-system/RFC/0002-migration-playbook.md
+++ b/dashboard/design-system/RFC/0002-migration-playbook.md
@@ -46,6 +46,12 @@ Components are migrated bottom-up (atom → molecule → organism → page). Ear
 
 Iter 1 is the canonical reference. Each later iter follows the same shape.
 
+> **Reality-check (2026-04-29)**: Production-Preact migrations diverge
+> from the table above, which targets `ui_kits/cockpit` (React reference
+> UI Kit, not a Preact migration target). Actual: Iter 1 = DialogOverlay
+> (PR #11827, merged), Iter 2 = AuthPopover (`auth-status.ts`, in
+> progress). Table refresh follows in a separate RFC update.
+
 ## Per-iter PR shape
 
 Every migration PR must include exactly these parts:

--- a/dashboard/design-system/migration-bridge.css
+++ b/dashboard/design-system/migration-bridge.css
@@ -1,0 +1,27 @@
+/* migration-bridge.css — Strangler Fig migration bridge.
+ *
+ * Appended to per iter (RFC 0002 §"Per-iter PR shape" §5). Bridges
+ * legacy CSS hooks (e.g. .is-open) to the new data-attributes (e.g.
+ * data-state="open") so consumers can migrate one at a time without
+ * breaking the visual contract. Removed entirely in the cleanup PR
+ * once every consumer has migrated.
+ *
+ * Status (2026-04-29): owns Iter 2 (AuthPopover). Iter 1 (DialogOverlay,
+ * PR #11827) used Tailwind v4 data-[state=…]: variants directly and
+ * did not require a bridge entry.
+ */
+
+/* Iter 2 — AuthPopover (auth-status.ts)
+ *
+ * AuthPopover is conditionally mounted by Preact (the consumer renders
+ * `${popoverOpen.value ? html`<${AuthPopover} … />` : null}`), so the
+ * `data-state="open"` selector exists today as a stable anchor for the
+ * cleanup PR's eventual transition rules. Visual contract preserved:
+ * the panel is a native <div> with default `display: block`, so this
+ * declaration is a no-op today and a hook for future CSS-driven
+ * visibility (e.g. animated open/close without conditional mount).
+ */
+.auth-popover[data-state='open'],
+.auth-popover.is-open {
+  display: block;
+}

--- a/dashboard/src/components/auth-status.a11y.test.ts
+++ b/dashboard/src/components/auth-status.a11y.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for AuthStatus popover (RFC 0002 Iter 2). Locks the
+// aria-expanded / aria-haspopup / aria-controls / aria-labelledby wiring
+// + role="dialog" + sr-only label so future migrations land as
+// zero-regression. axe verifies the trigger↔panel id wiring is sound.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+
+vi.mock('../store', () => ({
+  shellAuthSummary: { value: null },
+  refreshShell: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../api/core', () => ({
+  clearStoredToken: vi.fn(),
+  currentDashboardActor: vi.fn().mockReturnValue('test'),
+  isRemoteAccess: vi.fn().mockReturnValue(false),
+  setStoredToken: vi.fn(),
+}))
+vi.mock('../api/mcp', () => ({ resetMcpClientState: vi.fn() }))
+vi.mock('../lib/dashboard-auth-access', () => ({
+  dashboardAuthAccess: vi.fn().mockReturnValue({ allowed: true, reason: null }),
+}))
+vi.mock('../lib/dashboard-actor', () => ({
+  hasDashboardActorQueryParam: vi.fn().mockReturnValue(false),
+  readStoredDashboardActorName: vi.fn().mockReturnValue('test'),
+  resolveDashboardActorName: vi.fn().mockReturnValue('test'),
+  syncDashboardActorName: vi.fn((s: string) => s),
+}))
+vi.mock('./common/toast', () => ({ showToast: vi.fn() }))
+
+import { AuthStatus, __resetForTests } from './auth-status'
+
+const flushUi = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 30))
+
+describe('AuthStatus a11y (Iter 2)', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    __resetForTests()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+    __resetForTests()
+  })
+
+  it('trigger collapsed passes axe', async () => {
+    render(html`<${AuthStatus} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('popover open passes axe (aria-expanded + aria-controls + role=dialog wiring)', async () => {
+    render(html`<${AuthStatus} />`, container)
+    const trigger = container.querySelector('button[aria-haspopup]') as HTMLButtonElement
+    trigger.click()
+    await flushUi()
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/auth-status.test.ts
+++ b/dashboard/src/components/auth-status.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+//
+// Behavior tests for AuthStatus's popover (RFC 0002 Iter 2 — useFocusScope
+// migration). Locks the user-observable contract: trigger toggles open/
+// closed, data-state surfaces the state, focus moves into the panel on
+// open and restores on close, ESC closes the popover.
+//
+// These tests run on the migrated (post-Cycle 1) AuthStatus and verify
+// that the inline focus management replacement (useFocusScope) preserves
+// the popover lifecycle while introducing focus trap + ESC capabilities.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+
+vi.mock('../store', () => ({
+  shellAuthSummary: { value: null },
+  refreshShell: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../api/core', () => ({
+  clearStoredToken: vi.fn(),
+  currentDashboardActor: vi.fn().mockReturnValue('test'),
+  isRemoteAccess: vi.fn().mockReturnValue(false),
+  setStoredToken: vi.fn(),
+}))
+vi.mock('../api/mcp', () => ({ resetMcpClientState: vi.fn() }))
+vi.mock('../lib/dashboard-auth-access', () => ({
+  dashboardAuthAccess: vi.fn().mockReturnValue({ allowed: true, reason: null }),
+}))
+vi.mock('../lib/dashboard-actor', () => ({
+  hasDashboardActorQueryParam: vi.fn().mockReturnValue(false),
+  readStoredDashboardActorName: vi.fn().mockReturnValue('test'),
+  resolveDashboardActorName: vi.fn().mockReturnValue('test'),
+  syncDashboardActorName: vi.fn((s: string) => s),
+}))
+vi.mock('./common/toast', () => ({ showToast: vi.fn() }))
+
+import { AuthStatus, __resetForTests } from './auth-status'
+
+const flushUi = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 30))
+
+describe('AuthStatus popover behavior (Iter 2)', () => {
+  let container: HTMLElement
+  let outsideButton: HTMLButtonElement
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    __resetForTests()
+
+    outsideButton = document.createElement('button')
+    outsideButton.id = 'outside'
+    outsideButton.textContent = 'outside'
+    document.body.appendChild(outsideButton)
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.innerHTML = ''
+    __resetForTests()
+  })
+
+  it('renders the trigger collapsed (popover closed) by default', () => {
+    render(html`<${AuthStatus} />`, container)
+    const trigger = container.querySelector('button[aria-haspopup]')
+    expect(trigger).not.toBeNull()
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('clicking the trigger opens the popover with data-state="open" and aria wiring', async () => {
+    render(html`<${AuthStatus} />`, container)
+    const trigger = container.querySelector('button[aria-haspopup]') as HTMLButtonElement
+    trigger.click()
+    await flushUi()
+
+    const panel = container.querySelector('[role="dialog"]')
+    expect(panel).not.toBeNull()
+    expect(panel?.getAttribute('data-state')).toBe('open')
+
+    const labelledBy = panel?.getAttribute('aria-labelledby') ?? ''
+    expect(labelledBy).not.toBe('')
+    expect(panel?.querySelector(`#${CSS.escape(labelledBy)}`)).not.toBeNull()
+
+    const ariaControls = trigger.getAttribute('aria-controls') ?? ''
+    expect(ariaControls).toBe(panel?.id ?? '__missing__')
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('opening the popover moves focus into the panel (focus trap activate)', async () => {
+    outsideButton.focus()
+    expect(document.activeElement?.id).toBe('outside')
+
+    render(html`<${AuthStatus} />`, container)
+    const trigger = container.querySelector('button[aria-haspopup]') as HTMLButtonElement
+    trigger.click()
+    await flushUi()
+
+    const panel = container.querySelector('[role="dialog"]')
+    expect(panel).not.toBeNull()
+    // First tabbable inside the panel is whatever Tabbable filter picked
+    // — the precise element depends on actorOverrideLocked branch — but
+    // the focus must have left `outside` and landed inside the panel.
+    expect(document.activeElement).not.toBe(outsideButton)
+    expect(panel?.contains(document.activeElement)).toBe(true)
+  })
+
+  it('Escape key closes the popover and restores focus to the trigger', async () => {
+    render(html`<${AuthStatus} />`, container)
+    const trigger = container.querySelector('button[aria-haspopup]') as HTMLButtonElement
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    trigger.click()
+    await flushUi()
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull()
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    )
+    await flushUi()
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -27,6 +27,15 @@ const tokenInput = signal('')
 const actorInput = signal('')
 const bannerDismissed = signal(false)
 
+// Test-only helper. Resets module-level signals so *.test.ts files can
+// guarantee isolation in `beforeEach`. Mirrors use-id.ts:50 pattern.
+export function __resetForTests(): void {
+  popoverOpen.value = false
+  tokenInput.value = ''
+  actorInput.value = ''
+  bannerDismissed.value = false
+}
+
 function cleanErrorMessage(value: string | null | undefined): string | null {
   if (!value) return null
   return value.replace(/^[^\w가-힣@]+/u, '').trim() || null

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -1,5 +1,8 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { useEffect, useRef } from 'preact/hooks'
+import { useFocusScope } from '../../design-system/headless-preact/use-focus-scope'
+import { useId } from '../../design-system/headless-preact/use-id'
 import {
   clearStoredToken,
   currentDashboardActor,
@@ -131,6 +134,8 @@ function openPopover(): void {
 }
 
 export function AuthStatus() {
+  const popoverId = useId()
+  const labelId = useId()
   const { dotColor, label } = authBadgeSummary()
 
   return html`
@@ -139,6 +144,7 @@ export function AuthStatus() {
         class="flex items-center gap-1.5 text-2xs py-1 px-2 rounded border border-solid border-[var(--color-border-default)] bg-[var(--white-4)] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[var(--white-8)] text-[var(--color-fg-muted)]"
         aria-expanded=${popoverOpen.value}
         aria-haspopup="true"
+        aria-controls=${popoverId}
         onClick=${() => { popoverOpen.value ? (popoverOpen.value = false) : openPopover() }}
         title="인증 상태"
         aria-label="인증 상태"
@@ -146,12 +152,45 @@ export function AuthStatus() {
         <span class="size-[7px] rounded-sm inline-block ${dotColor}"></span>
         <span>${label}</span>
       </button>
-      ${popoverOpen.value ? html`<${AuthPopover} />` : null}
+      ${popoverOpen.value ? html`<${AuthPopover} popoverId=${popoverId} labelId=${labelId} />` : null}
     </div>
   `
 }
 
-function AuthPopover() {
+interface AuthPopoverProps {
+  popoverId: string
+  labelId: string
+}
+
+function AuthPopover({ popoverId, labelId }: AuthPopoverProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Focus trap + restore: delegated to headless-core via useFocusScope.
+  // RFC 0002 Iter 2 — Iter 1 (DialogOverlay PR #11827) is the canonical
+  // reference; same shape as dialog.ts:48-55. AuthPopover is conditionally
+  // mounted, so `active: true` while the component lives is sufficient —
+  // unmount triggers the hook's cleanup which restores focus to the
+  // element that was focused before the popover opened (the trigger button).
+  useFocusScope({
+    containerRef: panelRef,
+    active: true,
+    initialFocus: 'first',
+  })
+
+  // ESC closes the popover. Out of useFocusScope's scope per RFC 0001
+  // §"out of scope" — handled inline so each popover can opt in/out of
+  // close-on-ESC behavior independently.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        popoverOpen.value = false
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [])
+
   const summary = shellAuthSummary.value
   const storedActor = readStoredDashboardActorName()
   const requestedActor = summary?.requested_agent ?? resolveDashboardActorName() ?? 'dashboard'
@@ -164,7 +203,15 @@ function AuthPopover() {
   const actorOverrideLocked = authenticated
 
   return html`
-    <div class="absolute right-0 top-full mt-1.5 w-80 rounded border border-[var(--color-border-default)] bg-[rgba(10,18,34,0.97)] shadow-sm backdrop-blur-sm p-3 z-50">
+    <div
+      ref=${panelRef}
+      id=${popoverId}
+      role="dialog"
+      aria-labelledby=${labelId}
+      data-state="open"
+      class="auth-popover absolute right-0 top-full mt-1.5 w-80 rounded border border-[var(--color-border-default)] bg-[rgba(10,18,34,0.97)] shadow-sm backdrop-blur-sm p-3 z-50"
+    >
+      <h2 id=${labelId} class="sr-only">인증 상태 패널</h2>
       <div class="flex flex-col gap-3">
         <div class="flex flex-col text-2xs">
           <${KvRow} label="stored actor" value=${storedActor ? `@${storedActor}` : '-'} wrap=${true} />
@@ -259,9 +306,9 @@ export function RemoteWarningBanner() {
         >인증 열기</button>
         <button type="button"
           class="text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] cursor-pointer text-2xs transition-colors"
-          aria-label="\uc778\uc99d \ubc30\ub108 \ub2eb\uae30"
+          aria-label="인증 배너 닫기"
           onClick=${() => { bannerDismissed.value = true }}
-        >\u2715</button>
+        >✕</button>
       </div>
     </div>
   `

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -36,6 +36,12 @@
 @import "./responsive.css";
 @import "./a11y.css"; /* after feature styles so reduced-motion overrides win */
 
+/* Strangler Fig migration bridge — bridges legacy CSS hooks to
+ * data-attributes during in-progress component migrations. Per-iter
+ * blocks are appended here; the entire file is removed in the cleanup
+ * PR once every consumer has migrated. RFC 0002 §"Per-iter PR shape" §5. */
+@import "../../design-system/migration-bridge.css";
+
 /* ── Card / Section / Headline base styles ─────────────────────
    Shared across the dashboard. Every card, title, headline, and
    badge gets consistent depth, 8px-grid spacing, and hierarchy.


### PR DESCRIPTION
## Migration: AuthPopover (Iter 2)

`dashboard/src/components/auth-status.ts`의 `AuthPopover`를 RFC 0002 Iter 2로 마이그레이션합니다. inline focus 처리 부재(focus trap, ESC, focus restore)를 `useFocusScope` + `useId` 기반 Headless 패턴으로 정리합니다. Iter 1 (`DialogOverlay`, PR #11827)이 reference 패턴.

### Reality-check (RFC 0002 본문 vs production)

RFC 0002 본문은 Iter 1 = "Topbar branch popover"로 정의하지만 Topbar는 `ui_kits/cockpit` (React reference UI Kit, Preact 비호환)에만 존재합니다. 실제 production에서 Iter 1 = `dialog.ts` (PR #11827 머지), 본 PR의 `AuthPopover`가 Iter 2 — production-Preact dashboard의 첫 popover migration입니다. RFC 본문 ordering 본격 갱신은 후속 PR.

## Changes

| Cycle | 변경 | 파일 |
|-------|------|------|
| 1 (b2878f2898) | useFocusScope + useId + data-state + ESC handler | `auth-status.ts` (+52/-5) |
| 2 (0988576370) | 4 behavior + 2 jest-axe 테스트 + `__resetForTests` helper | `auth-status.test.ts`, `auth-status.a11y.test.ts`, `auth-status.ts` |
| 3 (377ce54e77) | `migration-bridge.css` 신규 + `global.css` import | `design-system/migration-bridge.css`, `src/styles/global.css` |
| 4 (65c25aa318) | RFC 0002 1줄 reality-check 노트 | `design-system/RFC/0002-migration-playbook.md` |

### Migration delta

- **Before**: `popoverOpen` signal + 조건부 마운트만. focus trap / ESC / focus restore 모두 부재. `aria-expanded` / `aria-haspopup`만 (PR #11021로 추가).
- **After**: `useFocusScope({ containerRef: panelRef, active: true, initialFocus: 'first' })` (dialog.ts:48-55 mirror) + ESC handler (RFC 0001 §"out of scope" 명시) + `data-state="open"` (Tailwind v4 `data-[state=open]:` variants 가능) + `useId()` 기반 `aria-controls` (trigger ↔ panel) + `aria-labelledby` (panel ↔ sr-only `<h2>`).
- **시각 영향**: 0px. attribute / sr-only label / no-op CSS 추가만 — 시각 contract 보존.

## Verification

- `pnpm tsc --noEmit` — clean (TSC_EXIT=0)
- `pnpm vitest run src/components/auth-status` — **6 tests pass (1.36s)**
- `pnpm vitest run` (전체) — 4756/4757 pass. 단 1 fail은 `feedback-state.test.ts > ErrorFatal > uses the danger variant button (background tint)` — PR #11887 cycle 34 ActionButton component-level token aliases 도입 후 test expectation 미갱신으로 인한 pre-existing drift. 본 PR 변경 path와 dependency 분리되어 회귀 아님 (auth-status / migration-bridge.css / global.css → button.ts 의존 없음).
- `./node_modules/.bin/eslint src` — 0 errors / 0 warnings
- 수동 visual diff: 0px (open/closed 두 상태 모두)

## Rollback

Single `git revert` of this PR. Headless primitives (`headless-core`, `headless-preact`), RFC 0002 본문, `migration-bridge.css` skeleton은 main에 잔류.

## Out of scope (후속 PR)

- click-outside (현재 부재 — RFC 0002 §"Non-goals" feature-add 분리 원칙)
- `usePortal` (현재 absolute positioning, z-index 충돌 발생 시)
- RFC 0002 본문 Iter ordering 본격 수정
- `feedback-state.test.ts` ↔ ActionButton token alias drift fix

## Refs

- RFC 0001 (#11670) — Headless Foundation
- RFC 0002 (#11760) — Strangler Fig Migration Playbook
- PR #11827 — Iter 1: DialogOverlay → useFocusScope
- PR #11021 — auth-status a11y aria-expanded/haspopup (round-6 split 2/N)

🤖 Generated with [Claude Code](https://claude.com/claude-code)