### PR TITLE
test(a11y): batch 15 — stat-tile, mermaid-graph, cytoscape-fsm (cycle 42)

### DIFF
--- a/dashboard/src/components/common/cytoscape-fsm.a11y.test.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.a11y.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for CytoscapeFsm wrapper. Cytoscape is lazy-
+// loaded and renders into the host div imperatively — happy-dom
+// can't resolve the dynamic import but the wrapper + loading state
+// must axe-clean across spec variations.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { CytoscapeFsm } from './cytoscape-fsm'
+import type { FsmGraphSpec } from './cytoscape-fsm'
+
+const trivialSpec: FsmGraphSpec = {
+  nodes: [
+    { id: 'idle', label: 'idle' },
+    { id: 'busy', label: 'busy' },
+  ],
+  edges: [
+    { source: 'idle', target: 'busy', label: 'start' },
+    { source: 'busy', target: 'idle', label: 'done', type: 'recovery' },
+  ],
+}
+
+describe('CytoscapeFsm a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default render with simple FSM passes axe', async () => {
+    render(html`<${CytoscapeFsm} spec=${trivialSpec} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with active node + custom height passes axe', async () => {
+    const withActive: FsmGraphSpec = {
+      ...trivialSpec,
+      activeNodeId: 'busy',
+    }
+    render(
+      html`<${CytoscapeFsm} spec=${withActive} height="400px" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with cascade + error edge types passes axe', async () => {
+    const withTypes: FsmGraphSpec = {
+      nodes: [
+        { id: 'a', label: 'a' },
+        { id: 'b', label: 'b' },
+        { id: 'c', label: 'c' },
+      ],
+      edges: [
+        { source: 'a', target: 'b', type: 'cascade' },
+        { source: 'b', target: 'c', type: 'error' },
+      ],
+    }
+    render(html`<${CytoscapeFsm} spec=${withTypes} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/mermaid-graph.a11y.test.ts
+++ b/dashboard/src/components/common/mermaid-graph.a11y.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for MermaidGraph wrapper. The actual graph is
+// rendered async by the lazy-loaded mermaid library; happy-dom won't
+// resolve it but the wrapper element + fallback text path should
+// still axe-clean.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { MermaidGraph } from './mermaid-graph'
+
+describe('MermaidGraph a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('wrapper renders accessibly while mermaid lazy-loads', async () => {
+    const source = 'graph LR;\n  A-->B;\n  B-->C;'
+    render(html`<${MermaidGraph} source=${source} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with fallbackText passes axe', async () => {
+    render(
+      html`<${MermaidGraph}
+        source="graph TD; X-->Y;"
+        fallbackText="Diagram unavailable — see source above."
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('with custom min-height + diagramClass passes axe', async () => {
+    render(
+      html`<${MermaidGraph}
+        source="graph LR; alpha-->beta;"
+        minHeightClass="min-h-60"
+        diagramClass="border border-[var(--white-5)]"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/stat-tile.a11y.test.ts
+++ b/dashboard/src/components/common/stat-tile.a11y.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for StatGrid (StatTile is internal — exposed via the
+// grid). Tests pin all 4 variants (default/gold/accent/warn) + grid
+// columns config + tiles with optional hint.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { StatGrid } from './stat-tile'
+
+describe('StatGrid a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default variant grid passes axe', async () => {
+    render(
+      html`<${StatGrid}
+        items=${[
+          { label: 'Online', value: 12 },
+          { label: 'Idle', value: 3 },
+        ]}
+        cols=${2}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('all 4 variants in one grid pass axe', async () => {
+    render(
+      html`<${StatGrid}
+        items=${[
+          { label: 'Default', value: 10 },
+          { label: 'Gold', value: 20, variant: 'gold' },
+          { label: 'Accent', value: 30, variant: 'accent' },
+          { label: 'Warn', value: 5, variant: 'warn' },
+        ]}
+        cols=${4}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('tiles with hint passes axe', async () => {
+    render(
+      html`<${StatGrid}
+        items=${[
+          { label: 'Throughput', value: '1.2k', hint: 'last 5m' },
+          { label: 'Errors', value: 0, hint: 'all clear', variant: 'gold' },
+        ]}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('single-column dense grid passes axe', async () => {
+    render(
+      html`<${StatGrid}
+        items=${[{ label: 'Total', value: 99 }]}
+        cols=${1}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

Lane C batch 15 — 3 dashboard atoms gain jest-axe coverage (10 cases).

## Atoms

| Atom | Cases | Coverage focus |
|------|-------|----------------|
| `StatGrid` (StatTile internal) | 4 | All 4 variants (default/gold/accent/warn), grid columns, hint optional, single-column dense |
| `MermaidGraph` | 3 | Wrapper accessibility while mermaid lazy-loads; fallbackText; custom minHeight + diagramClass |
| `CytoscapeFsm` | 3 | Trivial 2-node spec, with-active-node, cascade + error edge types |

## Verification

- `pnpm test` (vitest happy-dom) → **10/10 passing**, 4.78s
- jest-axe + axe-core report 0 violations

## Pattern

Same as batches 1-14. Graph atoms (mermaid + cytoscape) verify the wrapper only — happy-dom can't fully resolve their dynamic imports (mirrors batch 14 command-palette / ninja-keys lazy load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)