### PR TITLE
refactor: duration-300 → t-slow token sweep across 2 fill-bar atoms (cycle 44)

### DIFF
--- a/dashboard/src/components/common/distribution-bars.ts
+++ b/dashboard/src/components/common/distribution-bars.ts
@@ -104,7 +104,7 @@ export function DistributionBars({
                     </div>
                     <div class="h-2 overflow-hidden rounded-sm bg-[var(--white-5)]">
                       <div
-                        class="h-full rounded-sm transition-[width] duration-300"
+                        class="h-full rounded-sm transition-[width] duration-[var(--t-slow)]"
                         style=${`width:${Math.min(width, 100)}%;background:${palette.fill};opacity:0.8;`}
                       ></div>
                     </div>

--- a/dashboard/src/components/common/progress-bar.ts
+++ b/dashboard/src/components/common/progress-bar.ts
@@ -92,7 +92,7 @@ interface ProgressBarProps {
 }
 
 const TRACK_BASE = 'w-full overflow-hidden rounded-sm'
-const FILL_BASE = 'h-full rounded-sm transition-[width] duration-300 ease-in-out'
+const FILL_BASE = 'h-full rounded-sm transition-[width] duration-[var(--t-slow)] ease-in-out'
 
 export function ProgressBar({
   pct,


### PR DESCRIPTION
## Summary

Sweeps the remaining `duration-300` magic numbers in `dashboard/src/components/common/` to the `--t-slow` token (360ms).

## Files changed (2, 2 occurrences)

| File | Context |
|------|---------|
| `distribution-bars.ts:107` | bar segment `transition-[width] duration-300` |
| `progress-bar.ts:95` | FILL_BASE `transition-[width] duration-300 ease-in-out` |

Both → `duration-[var(--t-slow)]`.

## Cosmetic delta

300ms → 360ms is a **60ms shift** in fill-bar perception territory. The fill-bar is the user's "I see it progressing" channel — 60ms more lingers slightly but stays within the fill-perception window (200-500ms range).

If a callsite genuinely needs to feel snappier (e.g. an instant ack bar), it can opt into `duration-[var(--t-med)]` (200ms) explicitly.

## Verification

- `pnpm test` → **37/37 passing** across the 2 affected components + their existing test files
- `rg duration-300 dashboard/src/components/common/*.ts` → empty after PR

## Pattern

Same approach as #11900 (`duration-150` → `t-fast`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)