### PR TITLE
test(a11y): batch 16 + AgentAvatar role fix (cycle 45)

### DIFF
--- a/dashboard/src/components/live/keeper-health-strip.a11y.test.ts
+++ b/dashboard/src/components/live/keeper-health-strip.a11y.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for KeeperHealthStrip. With totalCount=0 the
+// component returns null (no render), which axe should treat as a
+// valid clean container. Populated state requires seeding live-store
+// from SSE input — out of scope for atom a11y.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { KeeperHealthStrip } from './keeper-health-strip'
+
+describe('KeeperHealthStrip a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('empty state (totalCount=0 → null render) passes axe', async () => {
+    render(html`<${KeeperHealthStrip} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/live/pulse-strip.a11y.test.ts
+++ b/dashboard/src/components/live/pulse-strip.a11y.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for PulseStrip — empty state. Populated state
+// derives from a live-store computed signal driven by SSE input;
+// covering it would require seeding the SSE source. Empty state is
+// the more common boot-time path and exercises the same wrapper.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { PulseStrip } from './pulse-strip'
+
+describe('PulseStrip a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('empty state (no agents connected) passes axe', async () => {
+    render(html`<${PulseStrip} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/overview/agent-avatar.a11y.test.ts
+++ b/dashboard/src/components/overview/agent-avatar.a11y.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+//
+// jest-axe coverage for AgentAvatar — pixel-art avatar with name +
+// status + activity ring. Tests pin renderings across size variants,
+// activity-age states, blocker indicator, and the showName toggle.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { AgentAvatar } from './agent-avatar'
+
+describe('AgentAvatar a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default avatar passes axe', async () => {
+    render(html`<${AgentAvatar} name="sigma" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('avatar with name + status + traits passes axe', async () => {
+    render(
+      html`<${AgentAvatar}
+        name="alpha"
+        status="working"
+        traits=${['curious', 'fast']}
+        showName=${true}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('avatar with onClick (interactive) passes axe', async () => {
+    render(
+      html`<${AgentAvatar}
+        name="omega"
+        onClick=${() => {}}
+        size="lg"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('avatar with operational overlays (work + activityAge + blocker + ring) passes axe', async () => {
+    render(
+      html`<${AgentAvatar}
+        name="theta"
+        size="xl"
+        showName=${true}
+        currentWork="processing telemetry batch"
+        activityAge=${30}
+        hasBlocker=${true}
+        signalTruth="live"
+        alwaysShowBubble=${true}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('stale + archived signal variants pass axe', async () => {
+    render(
+      html`<div>
+        <${AgentAvatar} name="rho" signalTruth="stale" activityAge=${600} />
+        <${AgentAvatar} name="phi" signalTruth="archived" activityAge=${3600} />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/overview/agent-avatar.ts
+++ b/dashboard/src/components/overview/agent-avatar.ts
@@ -125,6 +125,7 @@ export function AgentAvatar({
       ${cells}
       <span
         class="pixel-avatar__activity-dot ${dotClass}"
+        role=${activityDotLabel(activityAge ?? null) ? 'img' : undefined}
         aria-label=${activityDotLabel(activityAge ?? null)}
       />
       ${bubbleText ? html`


### PR DESCRIPTION
## Summary

Lane C batch 16 — first batch beyond `common/`. Extends the a11y test pattern to `overview/` and `live/` dirs. **3rd real production a11y violation surfaced and fixed in the same PR**: AgentAvatar's activity-dot span carried `aria-label` without a role.

## Atoms + production fix

| Atom | Cases | Notes |
|------|-------|-------|
| `AgentAvatar` (overview) | 5 | Default, name+status+traits, onClick interactive, operational overlays, stale + archived signal variants. **Production fix included.** |
| `PulseStrip` (live) | 1 | Empty state. Populated state requires SSE signal seeding (out of scope for atom a11y). |
| `KeeperHealthStrip` (live) | 1 | Empty state (totalCount=0 → null render). |

## Production fix detail

Before:
```ts
<span class="pixel-avatar__activity-dot ${dotClass}" aria-label=${activityDotLabel(...)} />
```

axe verdict: **"aria-label attribute cannot be used on a span with no valid role attribute"**.

After: Add `role="img"` when `aria-label` is present.
```ts
<span class="..." role=${activityDotLabel(...) ? 'img' : undefined} aria-label=${...} />
```

`role="img"` is the canonical WAI-ARIA role for decorative-but-meaningful graphical elements (per axe documentation).

## Issue Discovery pattern

Following memory `Issue Discovery: fix 범위 넘는 이슈 → GitHub Issue > MASC task > memory`. Fix is a 1-line change; bundling with the test PR keeps review burden low.

## Verification

- `pnpm test` → **7/7 passing**, 16.18s
- jest-axe + axe-core report 0 violations after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)