### PR TITLE
test(dashboard): align ErrorFatal danger-variant assertion with cycle-34 token migration (main blocker)

### DIFF
--- a/dashboard/src/components/common/feedback-state.test.ts
+++ b/dashboard/src/components/common/feedback-state.test.ts
@@ -123,7 +123,12 @@ describe('ErrorFatal', () => {
   it('uses the danger variant button (background tint)', () => {
     render(html`<${ErrorFatal} title="t" onReload=${() => {}} />`, container)
     const btn = container.querySelector('button')!
-    // ActionButton danger variant maps to bg-[var(--bad-10)] in button.ts.
-    expect(btn.className).toContain('bg-[var(--bad-10)]')
+    // ActionButton danger variant uses the component-level alias
+    // --button-danger-bg, which tokens.generated.ts resolves to
+    // var(--bad-10). Asserting on the literal classname keeps the
+    // test honest about what the component actually outputs (was
+    // missed in the cycle-34 migration to component-level aliases,
+    // commit c8011e3).
+    expect(btn.className).toContain('bg-[var(--button-danger-bg)]')
   })
 })


### PR DESCRIPTION
## 목적: main blocker 해소

\`Dashboard\` CI 잡이 main에서 일관되게 fail 중. 모든 PR에서 같은 단일 테스트 fail이 보이고 admin-merge로 통과시켜오던 패턴 (직전 머지 #11866 / #11872 / #11896 모두 동일).

## 진단

| 항목 | 값 |
|---|---|
| 실패 테스트 | \`src/components/common/feedback-state.test.ts:127\` — \`ErrorFatal > uses the danger variant button (background tint)\` |
| 단언 | \`expect(btn.className).toContain('bg-[var(--bad-10)]')\` |
| 실제 className | \`...bg-[var(--button-danger-bg)] text-[var(--button-danger-fg)]...\` |
| 토큰 alias 정의 | \`tokens.generated.ts:378\` — \`--button-danger-bg → var(--bad-10)\` (색은 동일) |
| 마이그레이션 commit | c8011e3 / PR #11887 (cycle 34, 2026-04-29 14:54 KST) |

c8011e3가 \`button.ts:37\` danger 변형을 component-level alias로 옮길 때 sweep 누락. 색상 결과는 동일(둘 다 \`#...\`)이지만 테스트는 *문자열 className*으로 단언하므로 fail.

## 변경

\`dashboard/src/components/common/feedback-state.test.ts\` 단일 파일.
- \`'bg-[var(--bad-10)]'\` → \`'bg-[var(--button-danger-bg)]'\`
- 코멘트에 alias 간접 참조 + cycle-34 출처 명시.

## 범위 밖 (별도 트랙)

다른 \`--bad-*\` 직접 사용처(handoff-timeline, governance, keeper-detail-history 등)는 컴포넌트 콜사이트지 테스트 단언이 아닙니다. role-alias 마이그레이션 cycle이 그쪽도 다룰 예정 → 이 PR에선 손대지 않음.

## 검증

- \`pnpm vitest run src/components/common/feedback-state.test.ts\` → 11 passed (직전: 1 failed / 10 passed)
- \`pnpm typecheck\` clean
- \`pnpm lint\` clean

## Test plan

- [ ] CI Dashboard 잡 green
- [ ] 다른 워크플로 영향 없음 (테스트 1줄 + 코멘트만 변경)