### PR TITLE
feat(crew): Tier A10a — Crew_consensus tally + outcome GADT (Cycle 26)

### DIFF
--- a/lib/crew/crew_consensus.ml
+++ b/lib/crew/crew_consensus.ml
@@ -1,0 +1,138 @@
+(* Crew_consensus — Cycle 26 / Tier A10a.
+   See crew_consensus.mli for design rationale. *)
+
+(* ── Tally ──────────────────────────────────────────────────────── *)
+
+type tally = {
+  approve : int;
+  dissent : int;
+  abstain : int;
+}
+
+let empty_tally = { approve = 0; dissent = 0; abstain = 0 }
+
+let tally_of_votes votes =
+  List.fold_left
+    (fun acc v ->
+      match v with
+      | Crew_types.Approve -> { acc with approve = acc.approve + 1 }
+      | Crew_types.Dissent _ -> { acc with dissent = acc.dissent + 1 }
+      | Crew_types.Abstain -> { acc with abstain = acc.abstain + 1 })
+    empty_tally votes
+
+let tally_total t = t.approve + t.dissent + t.abstain
+
+(* ── Quorum policy ──────────────────────────────────────────────── *)
+
+type quorum_policy = {
+  min_voters : int;
+  approve_threshold : float;
+}
+
+let default_policy = { min_voters = 1; approve_threshold = 0.5 }
+
+(* ── Outcome ────────────────────────────────────────────────────── *)
+
+type deadlock_kind =
+  | Tied [@tla.symbol "tied"]
+  | Below_quorum [@tla.symbol "below_quorum"]
+  | All_abstain [@tla.symbol "all_abstain"]
+[@@deriving tla]
+
+let all_deadlock_kinds = [ Tied; Below_quorum; All_abstain ]
+
+type approved = |
+type rejected = |
+type stalemate = |
+
+type 'state outcome =
+  | Approved : tally -> approved outcome
+  | Rejected : { tally : tally; reasons : string list } -> rejected outcome
+  | Stalemate : { tally : tally; kind : deadlock_kind } -> stalemate outcome
+
+type any_outcome = Any_outcome : 'a outcome -> any_outcome
+
+(* ── Tag mirror ─────────────────────────────────────────────────── *)
+
+type outcome_tag =
+  | Approved_tag [@tla.symbol "approved"]
+  | Rejected_tag [@tla.symbol "rejected"]
+  | Stalemate_tag [@tla.symbol "stalemate"]
+[@@deriving tla]
+
+let all_outcome_tags = [ Approved_tag; Rejected_tag; Stalemate_tag ]
+
+let outcome_to_tag : type a. a outcome -> outcome_tag = function
+  | Approved _ -> Approved_tag
+  | Rejected _ -> Rejected_tag
+  | Stalemate _ -> Stalemate_tag
+
+let any_outcome_to_tag (Any_outcome o) = outcome_to_tag o
+
+(* ── JSON serialisation ─────────────────────────────────────────── *)
+
+let tally_to_json t =
+  `Assoc
+    [
+      ("approve", `Int t.approve);
+      ("dissent", `Int t.dissent);
+      ("abstain", `Int t.abstain);
+    ]
+
+let deadlock_kind_to_string = function
+  | Tied -> "tied"
+  | Below_quorum -> "below_quorum"
+  | All_abstain -> "all_abstain"
+
+let outcome_to_json : type a. a outcome -> Yojson.Safe.t = function
+  | Approved tally ->
+      `Assoc
+        [
+          ("kind", `String "approved");
+          ("tally", tally_to_json tally);
+        ]
+  | Rejected { tally; reasons } ->
+      `Assoc
+        [
+          ("kind", `String "rejected");
+          ("tally", tally_to_json tally);
+          ( "dissent_reasons",
+            `List (List.map (fun r -> `String r) reasons) );
+        ]
+  | Stalemate { tally; kind } ->
+      `Assoc
+        [
+          ("kind", `String "stalemate");
+          ("deadlock_kind", `String (deadlock_kind_to_string kind));
+          ("tally", tally_to_json tally);
+        ]
+
+let any_outcome_to_json (Any_outcome o) = outcome_to_json o
+
+(* ── Evaluation ─────────────────────────────────────────────────── *)
+
+let collect_dissent_reasons votes =
+  List.filter_map
+    (function Crew_types.Dissent r -> Some r | _ -> None)
+    votes
+
+let evaluate ~policy votes =
+  let tally = tally_of_votes votes in
+  let total = tally_total tally in
+  if total < policy.min_voters then
+    Any_outcome (Stalemate { tally; kind = Below_quorum })
+  else if tally.approve = 0 && tally.dissent = 0 then
+    Any_outcome (Stalemate { tally; kind = All_abstain })
+  else if tally.approve = tally.dissent && tally.approve > 0 then
+    Any_outcome (Stalemate { tally; kind = Tied })
+  else
+    let active = tally.approve + tally.dissent in
+    let approve_frac =
+      if active = 0 then 0.0
+      else float_of_int tally.approve /. float_of_int active
+    in
+    if approve_frac >= policy.approve_threshold then
+      Any_outcome (Approved tally)
+    else
+      let reasons = collect_dissent_reasons votes in
+      Any_outcome (Rejected { tally; reasons })

--- a/lib/crew/crew_consensus.mli
+++ b/lib/crew/crew_consensus.mli
@@ -1,0 +1,110 @@
+(** Crew consensus — Cycle 26 / Tier A10a.
+
+    Tally a list of [Crew_types.vote]s against a [quorum_policy]
+    and derive a phantom-tagged [outcome] capturing the council's
+    collective decision.
+
+    A10 plan §2.2 splits this work into three pieces:
+      - A10a: this module (vote tally + outcome GADT, A9-independent)
+      - A10b: Multimodal review record (artifact evaluation contract)
+      - A10c: crew_audit + Crew_critique bridge functor (A9-dependent)
+
+    A10a depends on [Crew_types.vote] only and is buildable on any
+    main HEAD that has Tier A8 (#11838) merged. *)
+
+(* ── Tally ──────────────────────────────────────────────────────── *)
+
+type tally = {
+  approve : int;
+  dissent : int;
+  abstain : int;
+}
+
+val empty_tally : tally
+
+val tally_of_votes : Crew_types.vote list -> tally
+
+val tally_total : tally -> int
+
+(* ── Quorum policy ──────────────────────────────────────────────── *)
+
+type quorum_policy = {
+  min_voters : int;
+      (** Minimum number of total ballots (incl. abstain) required
+          before any positive verdict is permitted. *)
+  approve_threshold : float;
+      (** Approval fraction over non-abstaining ballots required for
+          [Approved]. Must be in [0.0, 1.0]. *)
+}
+
+val default_policy : quorum_policy
+(** [{ min_voters = 1; approve_threshold = 0.5 }]. *)
+
+(* ── Outcome ────────────────────────────────────────────────────── *)
+
+type deadlock_kind =
+  | Tied [@tla.symbol "tied"]
+  | Below_quorum [@tla.symbol "below_quorum"]
+  | All_abstain [@tla.symbol "all_abstain"]
+[@@deriving tla]
+
+val all_deadlock_kinds : deadlock_kind list
+
+(** Phantom witnesses for outcome states. *)
+type approved = |
+type rejected = |
+type stalemate = |
+
+(** GADT-tagged consensus outcome. [Approved] carries only the tally;
+    [Rejected] also collects dissent reasons; [Stalemate] explains
+    the deadlock kind. *)
+type 'state outcome =
+  | Approved : tally -> approved outcome
+  | Rejected : { tally : tally; reasons : string list } -> rejected outcome
+  | Stalemate : { tally : tally; kind : deadlock_kind } -> stalemate outcome
+
+(** Existential capture for storing heterogeneous outcomes
+    (e.g. council_audit log entries). *)
+type any_outcome = Any_outcome : 'a outcome -> any_outcome
+
+(* ── Tag mirror ─────────────────────────────────────────────────── *)
+
+(** Plain variant mirror of [outcome] for ppx_tla derivation. The
+    GADT constructors specialise their [outcome] type parameter, so
+    ppx_tla cannot derive directly on [outcome]; we mirror the three
+    branches as a flat enum and project via [outcome_to_tag]. *)
+type outcome_tag =
+  | Approved_tag [@tla.symbol "approved"]
+  | Rejected_tag [@tla.symbol "rejected"]
+  | Stalemate_tag [@tla.symbol "stalemate"]
+[@@deriving tla]
+
+val all_outcome_tags : outcome_tag list
+
+val outcome_to_tag : 'a outcome -> outcome_tag
+
+val any_outcome_to_tag : any_outcome -> outcome_tag
+
+(* ── JSON serialisation ─────────────────────────────────────────── *)
+
+val tally_to_json : tally -> Yojson.Safe.t
+
+val outcome_to_json : 'a outcome -> Yojson.Safe.t
+
+val any_outcome_to_json : any_outcome -> Yojson.Safe.t
+
+(* ── Evaluation ─────────────────────────────────────────────────── *)
+
+val evaluate :
+  policy:quorum_policy -> Crew_types.vote list -> any_outcome
+(** [evaluate ~policy votes] derives the consensus [outcome]:
+
+    - [tally_total < policy.min_voters] → [Stalemate Below_quorum]
+    - All votes are [Abstain] → [Stalemate All_abstain]
+    - [tally.approve = tally.dissent] (both non-zero) → [Stalemate Tied]
+    - approve fraction (over non-abstain ballots) ≥ [approve_threshold]
+      → [Approved tally]
+    - otherwise → [Rejected] with collected dissent reasons.
+
+    Order matters: [Below_quorum] is checked first to avoid a
+    deceptive "Approved with one vote" verdict. *)

--- a/test/crew/dune
+++ b/test/crew/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_crew_types test_persona_contract)
+ (names test_crew_types test_persona_contract test_crew_consensus)
  (libraries crew shared_types yojson))

--- a/test/crew/test_crew_consensus.ml
+++ b/test/crew/test_crew_consensus.ml
@@ -1,0 +1,249 @@
+(* Tier A10a — Crew_consensus tally + outcome evaluation. *)
+
+module C = Crew.Crew_consensus
+module T = Crew.Crew_types
+
+let check_int label expected actual =
+  if expected <> actual then
+    failwith
+      (Printf.sprintf "%s: expected %d, got %d" label expected actual)
+
+let check_str label expected actual =
+  if not (String.equal expected actual) then
+    failwith
+      (Printf.sprintf "%s: expected %S, got %S" label expected actual)
+
+let check_bool label b =
+  if not b then failwith (Printf.sprintf "%s: false" label)
+
+let assoc_string key json =
+  match json with
+  | `Assoc kv -> (
+      match List.assoc_opt key kv with
+      | Some (`String s) -> s
+      | _ ->
+          failwith
+            (Printf.sprintf "expected string field %S in %s" key
+               (Yojson.Safe.to_string json)))
+  | _ -> failwith "expected JSON object"
+
+let assoc_int key json =
+  match json with
+  | `Assoc kv -> (
+      match List.assoc_opt key kv with
+      | Some (`Int n) -> n
+      | _ ->
+          failwith
+            (Printf.sprintf "expected int field %S in %s" key
+               (Yojson.Safe.to_string json)))
+  | _ -> failwith "expected JSON object"
+
+(* ── Tally ──────────────────────────────────────────────────────── *)
+
+let test_empty_tally () =
+  let t = C.empty_tally in
+  check_int "empty.approve" 0 t.approve;
+  check_int "empty.dissent" 0 t.dissent;
+  check_int "empty.abstain" 0 t.abstain;
+  check_int "empty.total" 0 (C.tally_total t)
+
+let test_tally_of_votes_mixed () =
+  let votes =
+    [ T.Approve; T.Dissent "policy unclear"; T.Abstain; T.Approve ]
+  in
+  let t = C.tally_of_votes votes in
+  check_int "approve count" 2 t.approve;
+  check_int "dissent count" 1 t.dissent;
+  check_int "abstain count" 1 t.abstain;
+  check_int "total" 4 (C.tally_total t)
+
+let test_tally_of_empty_list () =
+  let t = C.tally_of_votes [] in
+  check_int "empty list approve" 0 t.approve;
+  check_int "empty list total" 0 (C.tally_total t)
+
+(* ── Evaluation: deadlock branches ──────────────────────────────── *)
+
+let test_evaluate_below_quorum () =
+  let policy = { C.min_voters = 3; approve_threshold = 0.5 } in
+  let outcome = C.evaluate ~policy [ T.Approve; T.Approve ] in
+  let tag = C.any_outcome_to_tag outcome in
+  check_bool "below_quorum → Stalemate_tag"
+    (tag = C.Stalemate_tag);
+  let json = C.any_outcome_to_json outcome in
+  check_str "stalemate deadlock_kind" "below_quorum"
+    (assoc_string "deadlock_kind" json)
+
+let test_evaluate_all_abstain () =
+  let outcome =
+    C.evaluate ~policy:C.default_policy [ T.Abstain; T.Abstain ]
+  in
+  let tag = C.any_outcome_to_tag outcome in
+  check_bool "all_abstain → Stalemate_tag"
+    (tag = C.Stalemate_tag);
+  let json = C.any_outcome_to_json outcome in
+  check_str "all_abstain deadlock_kind" "all_abstain"
+    (assoc_string "deadlock_kind" json)
+
+let test_evaluate_tied () =
+  let outcome =
+    C.evaluate ~policy:C.default_policy
+      [ T.Approve; T.Dissent "no" ]
+  in
+  let tag = C.any_outcome_to_tag outcome in
+  check_bool "tied → Stalemate_tag" (tag = C.Stalemate_tag);
+  let json = C.any_outcome_to_json outcome in
+  check_str "tied deadlock_kind" "tied"
+    (assoc_string "deadlock_kind" json)
+
+(* ── Evaluation: positive verdicts ──────────────────────────────── *)
+
+let test_evaluate_approved_majority () =
+  let outcome =
+    C.evaluate ~policy:C.default_policy
+      [ T.Approve; T.Approve; T.Dissent "edge case" ]
+  in
+  let tag = C.any_outcome_to_tag outcome in
+  check_bool "majority approve → Approved_tag"
+    (tag = C.Approved_tag);
+  let json = C.any_outcome_to_json outcome in
+  check_str "approved kind" "approved" (assoc_string "kind" json);
+  check_int "approved tally.approve" 2
+    (assoc_int "approve"
+       (match json with
+       | `Assoc kv -> List.assoc "tally" kv
+       | _ -> failwith "no tally"))
+
+let test_evaluate_unanimous_single () =
+  let outcome =
+    C.evaluate ~policy:C.default_policy [ T.Approve ]
+  in
+  check_bool "single approve → Approved_tag"
+    (C.any_outcome_to_tag outcome = C.Approved_tag)
+
+let test_evaluate_rejected_minority () =
+  let outcome =
+    C.evaluate ~policy:C.default_policy
+      [ T.Approve; T.Dissent "x"; T.Dissent "y" ]
+  in
+  let tag = C.any_outcome_to_tag outcome in
+  check_bool "minority approve → Rejected_tag"
+    (tag = C.Rejected_tag);
+  let json = C.any_outcome_to_json outcome in
+  check_str "rejected kind" "rejected" (assoc_string "kind" json);
+  match json with
+  | `Assoc kv -> (
+      match List.assoc_opt "dissent_reasons" kv with
+      | Some (`List reasons) ->
+          check_int "rejected dissent_reasons length" 2
+            (List.length reasons)
+      | _ -> failwith "missing dissent_reasons")
+  | _ -> failwith "expected object"
+
+(* ── Custom policy thresholds ───────────────────────────────────── *)
+
+let test_evaluate_threshold_boundary () =
+  let policy = { C.min_voters = 1; approve_threshold = 0.66 } in
+  (* 2 approve / 3 active = 66.67% — passes 0.66 *)
+  let pass =
+    C.evaluate ~policy
+      [ T.Approve; T.Approve; T.Dissent "x" ]
+  in
+  check_bool "0.6667 ≥ 0.66 → Approved"
+    (C.any_outcome_to_tag pass = C.Approved_tag);
+  (* 2 approve / 3 active = 66.67% — fails 0.67 *)
+  let policy_strict =
+    { C.min_voters = 1; approve_threshold = 0.67 }
+  in
+  let fail =
+    C.evaluate ~policy:policy_strict
+      [ T.Approve; T.Approve; T.Dissent "x" ]
+  in
+  check_bool "0.6667 < 0.67 → Rejected"
+    (C.any_outcome_to_tag fail = C.Rejected_tag)
+
+(* ── Tag enumerations ───────────────────────────────────────────── *)
+
+let test_all_outcome_tags () =
+  check_int "outcome_tag count" 3 (List.length C.all_outcome_tags);
+  check_bool "Approved_tag in list"
+    (List.mem C.Approved_tag C.all_outcome_tags);
+  check_bool "Rejected_tag in list"
+    (List.mem C.Rejected_tag C.all_outcome_tags);
+  check_bool "Stalemate_tag in list"
+    (List.mem C.Stalemate_tag C.all_outcome_tags)
+
+let test_all_deadlock_kinds () =
+  check_int "deadlock_kind count" 3
+    (List.length C.all_deadlock_kinds);
+  check_bool "Tied in list" (List.mem C.Tied C.all_deadlock_kinds);
+  check_bool "Below_quorum in list"
+    (List.mem C.Below_quorum C.all_deadlock_kinds);
+  check_bool "All_abstain in list"
+    (List.mem C.All_abstain C.all_deadlock_kinds)
+
+(* ── outcome_to_tag exhaustiveness ──────────────────────────────── *)
+
+let test_outcome_to_tag_projection () =
+  let approved : C.approved C.outcome =
+    C.Approved C.empty_tally
+  in
+  check_bool "Approved → Approved_tag"
+    (C.outcome_to_tag approved = C.Approved_tag);
+  let rejected : C.rejected C.outcome =
+    C.Rejected { tally = C.empty_tally; reasons = [] }
+  in
+  check_bool "Rejected → Rejected_tag"
+    (C.outcome_to_tag rejected = C.Rejected_tag);
+  let stalemate : C.stalemate C.outcome =
+    C.Stalemate { tally = C.empty_tally; kind = C.Tied }
+  in
+  check_bool "Stalemate → Stalemate_tag"
+    (C.outcome_to_tag stalemate = C.Stalemate_tag)
+
+(* ── JSON ───────────────────────────────────────────────────────── *)
+
+let test_tally_json_roundtrip () =
+  let t = { C.approve = 5; dissent = 2; abstain = 1 } in
+  let json = C.tally_to_json t in
+  check_int "json approve" 5 (assoc_int "approve" json);
+  check_int "json dissent" 2 (assoc_int "dissent" json);
+  check_int "json abstain" 1 (assoc_int "abstain" json)
+
+let test_default_policy_values () =
+  let p = C.default_policy in
+  check_int "default min_voters" 1 p.min_voters;
+  check_bool "default approve_threshold = 0.5"
+    (Float.equal p.approve_threshold 0.5)
+
+(* ── Driver ─────────────────────────────────────────────────────── *)
+
+let () =
+  let cases =
+    [
+      ("empty_tally", test_empty_tally);
+      ("tally_of_votes_mixed", test_tally_of_votes_mixed);
+      ("tally_of_empty_list", test_tally_of_empty_list);
+      ("evaluate_below_quorum", test_evaluate_below_quorum);
+      ("evaluate_all_abstain", test_evaluate_all_abstain);
+      ("evaluate_tied", test_evaluate_tied);
+      ("evaluate_approved_majority", test_evaluate_approved_majority);
+      ("evaluate_unanimous_single", test_evaluate_unanimous_single);
+      ("evaluate_rejected_minority", test_evaluate_rejected_minority);
+      ("evaluate_threshold_boundary", test_evaluate_threshold_boundary);
+      ("all_outcome_tags", test_all_outcome_tags);
+      ("all_deadlock_kinds", test_all_deadlock_kinds);
+      ("outcome_to_tag_projection", test_outcome_to_tag_projection);
+      ("tally_json_roundtrip", test_tally_json_roundtrip);
+      ("default_policy_values", test_default_policy_values);
+    ]
+  in
+  List.iter
+    (fun (name, f) ->
+      try f ()
+      with e ->
+        Printf.printf "FAIL %s: %s\n" name (Printexc.to_string e);
+        exit 1)
+    cases;
+  Printf.printf "test_crew_consensus: %d cases OK\n"
+    (List.length cases)


### PR DESCRIPTION
## Summary

Tier A10a — `Crew_consensus` vote tally + outcome GADT (Cycle 26).

Plan §2.2 splits A10 (~400 LoC) into three file-disjoint pieces. This PR lands the **A9-independent half**:

- `Crew_consensus.tally` — count Approve/Dissent/Abstain ballots
- `quorum_policy` — `{ min_voters; approve_threshold }` with safe defaults (1 / 0.5)
- `'state outcome` GADT — phantom witnesses Approved / Rejected / Stalemate
- `deadlock_kind` — Tied / Below_quorum / All_abstain (ppx_tla derived)
- `outcome_tag` mirror — flat enum for ppx_tla TLA+ symbol derivation
- `any_outcome = Any_outcome : 'a outcome -> any_outcome` existential
- `evaluate ~policy votes : any_outcome` — strict order (quorum → all-abstain → tied → fraction)

A10b (`Multimodal.Review` artifact evaluation record) lands in parallel — multimodal-only deps.
A10c (`Crew_audit` + `Review`↔`Crew_critique` bridge functor) blocks on A9 (#11893) merging.

## Files

- `lib/crew/crew_consensus.{mli,ml}` (NEW, ~150 LoC)
- `test/crew/test_crew_consensus.ml` (NEW, 15 assertions)
- `test/crew/dune` (+ test name)

## Verification

- `dune build --root . lib/crew test/crew` — GREEN
- `dune runtest --root . test/crew` — 15 new + 19 existing + 34 persona = all GREEN, 0 regression
- `lib/crew/dune` unchanged (no new transitive dep, ppx_tla preprocess inherited)
- file-disjoint with #11893 (A9 council), main (A8 contracts), all open PRs (race-check 0 hits)

## Plan reference

§2.2 Tier A10 (Cycle 26): `lib/crew/{crew_consensus,crew_audit}.{mli,ml}` + Multimodal `Review.evaluate` ↔ `Crew_critique` bridge functor. Total ~400 LoC.

This PR (~150 LoC) is the A10a slice — vote tally + outcome derivation. The remaining ~250 LoC split into A10b (Multimodal review record) and A10c (council audit + bridge) for parallel flow control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
