### PR TITLE
feat(multimodal): Tier A10b — Review evaluation record + verdict GADT (Cycle 26)

### DIFF
--- a/lib/multimodal/review.ml
+++ b/lib/multimodal/review.ml
@@ -1,0 +1,165 @@
+(* Review — Cycle 26 / Tier A10b.
+   See review.mli for design rationale. *)
+
+(* ── Score ─────────────────────────────────────────────────────── *)
+
+type score = float
+
+let score_of_float f =
+  if Float.is_nan f then Error "score must not be NaN"
+  else if not (Float.is_finite f) then
+    Error "score must be a finite float"
+  else if f < 0.0 then
+    Error (Printf.sprintf "score %f below 0.0" f)
+  else if f > 1.0 then
+    Error (Printf.sprintf "score %f above 1.0" f)
+  else Ok f
+
+let score_to_float s = s
+
+let score_clip f =
+  if Float.is_nan f then 0.0
+  else if f < 0.0 then 0.0
+  else if f > 1.0 then 1.0
+  else f
+
+let score_zero = 0.0
+
+let score_one = 1.0
+
+(* ── Assessment kind ───────────────────────────────────────────── *)
+
+type assessment_kind =
+  | Quality [@tla.symbol "quality"]
+  | Safety [@tla.symbol "safety"]
+  | Coherence [@tla.symbol "coherence"]
+  | Coverage [@tla.symbol "coverage"]
+[@@deriving tla]
+
+let all_assessment_kinds = [ Quality; Safety; Coherence; Coverage ]
+
+let assessment_kind_to_string = function
+  | Quality -> "quality"
+  | Safety -> "safety"
+  | Coherence -> "coherence"
+  | Coverage -> "coverage"
+
+(* ── Rubric ────────────────────────────────────────────────────── *)
+
+type rubric_score = {
+  kind : assessment_kind;
+  rubric : string;
+  score : score;
+  notes : string option;
+}
+
+let rubric_score_to_json rs =
+  let notes_field =
+    match rs.notes with
+    | Some n -> [ ("notes", `String n) ]
+    | None -> []
+  in
+  `Assoc
+    ([
+       ("kind", `String (assessment_kind_to_string rs.kind));
+       ("rubric", `String rs.rubric);
+       ("score", `Float (score_to_float rs.score));
+     ]
+    @ notes_field)
+
+(* ── Verdict ───────────────────────────────────────────────────── *)
+
+type verdict =
+  | Pass
+  | Fail
+  | Conditional of { conditions : string list }
+
+type verdict_tag =
+  | Pass_tag [@tla.symbol "pass"]
+  | Fail_tag [@tla.symbol "fail"]
+  | Conditional_tag [@tla.symbol "conditional"]
+[@@deriving tla]
+
+let all_verdict_tags = [ Pass_tag; Fail_tag; Conditional_tag ]
+
+let verdict_to_tag = function
+  | Pass -> Pass_tag
+  | Fail -> Fail_tag
+  | Conditional _ -> Conditional_tag
+
+let verdict_to_json = function
+  | Pass -> `Assoc [ ("kind", `String "pass") ]
+  | Fail -> `Assoc [ ("kind", `String "fail") ]
+  | Conditional { conditions } ->
+      `Assoc
+        [
+          ("kind", `String "conditional");
+          ( "conditions",
+            `List (List.map (fun c -> `String c) conditions) );
+        ]
+
+(* ── Review ────────────────────────────────────────────────────── *)
+
+type review = {
+  artifact_id : Shared_types.Artifact_id.t;
+  rubric_scores : rubric_score list;
+  overall : score;
+  verdict : verdict;
+  reviewed_at : float;
+}
+
+let empty_review ~artifact_id ~reviewed_at =
+  {
+    artifact_id;
+    rubric_scores = [];
+    overall = score_zero;
+    verdict = Fail;
+    reviewed_at;
+  }
+
+let add_rubric_score rs r =
+  { r with rubric_scores = rs :: r.rubric_scores }
+
+let with_rubric_scores rss r = { r with rubric_scores = rss }
+
+let mean_score scores =
+  match scores with
+  | [] -> score_zero
+  | _ ->
+      let total =
+        List.fold_left (fun acc s -> acc +. score_to_float s) 0.0 scores
+      in
+      score_clip (total /. float_of_int (List.length scores))
+
+let evaluate ~pass_threshold ~conditional_threshold review =
+  let scores =
+    List.map (fun rs -> rs.score) review.rubric_scores
+  in
+  let overall = mean_score scores in
+  let verdict =
+    if overall >= score_to_float pass_threshold then Pass
+    else if overall >= score_to_float conditional_threshold then
+      let conditions =
+        List.filter_map
+          (fun rs ->
+            if score_to_float rs.score < score_to_float pass_threshold
+            then Some rs.rubric
+            else None)
+          review.rubric_scores
+      in
+      Conditional { conditions }
+    else Fail
+  in
+  { review with overall; verdict }
+
+let review_to_json r =
+  `Assoc
+    [
+      ( "artifact_id",
+        Shared_types.Artifact_id.to_json r.artifact_id );
+      ( "rubric_scores",
+        `List (List.map rubric_score_to_json r.rubric_scores) );
+      ("overall", `Float (score_to_float r.overall));
+      ("verdict", verdict_to_json r.verdict);
+      ("reviewed_at", `Float r.reviewed_at);
+    ]

--- a/lib/multimodal/review.mli
+++ b/lib/multimodal/review.mli
@@ -1,0 +1,125 @@
+(** Multimodal artifact review — Cycle 26 / Tier A10b.
+
+    Anonymous evaluation result for an artifact. The review captures
+    rubric scores across {!assessment_kind}s and derives a verdict
+    against thresholds.
+
+    Reviewer attribution (which persona issued the review) is
+    intentionally NOT a field — it is supplied by the caller in the
+    A10c bridge functor (`Crew_critique`). This keeps the multimodal
+    library free of any [crew] dependency, preserving the layering:
+
+      - lib/multimodal → shared_types, yojson  (this PR)
+      - lib/crew       → shared_types, yojson  (existing)
+      - lib/{crew_audit,crew_critique}  →  multimodal, crew  (A10c)
+
+    A10b plan §2.2: ~150 LoC slice of the ~400 LoC A10 budget. *)
+
+(* ── Score (bounded float in [0.0, 1.0]) ───────────────────────── *)
+
+type score = private float
+
+val score_of_float : float -> (score, string) result
+(** [Error msg] if [f] is NaN, infinite, or outside [0.0, 1.0]. *)
+
+val score_to_float : score -> float
+
+val score_clip : float -> score
+(** Clamp [f] to [0.0, 1.0]. NaN maps to [0.0]. *)
+
+val score_zero : score
+
+val score_one : score
+
+(* ── Assessment dimensions ─────────────────────────────────────── *)
+
+type assessment_kind =
+  | Quality [@tla.symbol "quality"]
+  | Safety [@tla.symbol "safety"]
+  | Coherence [@tla.symbol "coherence"]
+  | Coverage [@tla.symbol "coverage"]
+[@@deriving tla]
+
+val all_assessment_kinds : assessment_kind list
+
+val assessment_kind_to_string : assessment_kind -> string
+
+(* ── Rubric ────────────────────────────────────────────────────── *)
+
+type rubric_score = {
+  kind : assessment_kind;
+  rubric : string;
+  score : score;
+  notes : string option;
+}
+
+val rubric_score_to_json : rubric_score -> Yojson.Safe.t
+
+(* ── Verdict ───────────────────────────────────────────────────── *)
+
+(** [Conditional] carries data, so a tag mirror is needed for
+    ppx_tla derivation. *)
+type verdict =
+  | Pass
+  | Fail
+  | Conditional of { conditions : string list }
+
+type verdict_tag =
+  | Pass_tag [@tla.symbol "pass"]
+  | Fail_tag [@tla.symbol "fail"]
+  | Conditional_tag [@tla.symbol "conditional"]
+[@@deriving tla]
+
+val all_verdict_tags : verdict_tag list
+
+val verdict_to_tag : verdict -> verdict_tag
+
+val verdict_to_json : verdict -> Yojson.Safe.t
+
+(* ── Review ────────────────────────────────────────────────────── *)
+
+type review = {
+  artifact_id : Shared_types.Artifact_id.t;
+  rubric_scores : rubric_score list;
+  overall : score;
+  verdict : verdict;
+  reviewed_at : float;
+      (** Unix epoch seconds. We do not impose [Timestamp.t] here to
+          keep the review module free of additional Shared_types
+          surface. *)
+}
+
+val empty_review :
+  artifact_id:Shared_types.Artifact_id.t ->
+  reviewed_at:float ->
+  review
+(** Empty review — no rubric scores, [overall = score_zero],
+    [verdict = Fail]. Add scores via {!add_rubric_score} and finalise
+    with {!evaluate}. *)
+
+val add_rubric_score : rubric_score -> review -> review
+
+val with_rubric_scores : rubric_score list -> review -> review
+
+(** {1 Evaluation}
+
+    [evaluate ~pass_threshold ~conditional_threshold review] computes:
+
+    - [overall] = mean of [rubric_scores] (or [score_zero] if empty)
+    - if [overall ≥ pass_threshold]            → [Pass]
+    - else if [overall ≥ conditional_threshold] → [Conditional]
+      with each rubric below [pass_threshold] contributing its
+      [rubric] field as a condition string.
+    - else                                       → [Fail]
+
+    Pre-condition: [pass_threshold ≥ conditional_threshold]. If
+    violated the function still returns a well-formed review (the
+    weaker of the two thresholds wins) but the verdict ordering
+    becomes underspecified. *)
+val evaluate :
+  pass_threshold:score ->
+  conditional_threshold:score ->
+  review ->
+  review
+
+val review_to_json : review -> Yojson.Safe.t

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id)
+ (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id test_review)
  (libraries multimodal shared_types yojson))

--- a/test/multimodal/test_review.ml
+++ b/test/multimodal/test_review.ml
@@ -1,0 +1,312 @@
+(* Tier A10b — Multimodal Review evaluation tests. *)
+
+module R = Multimodal.Review
+module Aid = Shared_types.Artifact_id
+
+let check_bool label b =
+  if not b then failwith (Printf.sprintf "%s: false" label)
+
+let check_int label expected actual =
+  if expected <> actual then
+    failwith
+      (Printf.sprintf "%s: expected %d, got %d" label expected actual)
+
+let check_float label expected actual =
+  if not (Float.equal expected actual) then
+    failwith
+      (Printf.sprintf "%s: expected %f, got %f" label expected actual)
+
+let check_str label expected actual =
+  if not (String.equal expected actual) then
+    failwith
+      (Printf.sprintf "%s: expected %S, got %S" label expected actual)
+
+let must = function Ok v -> v | Error e -> failwith e
+
+let make_id _ts = Aid.generate ()
+
+let assoc_string key json =
+  match json with
+  | `Assoc kv -> (
+      match List.assoc_opt key kv with
+      | Some (`String s) -> s
+      | _ -> failwith (Printf.sprintf "no string field %S" key))
+  | _ -> failwith "expected JSON object"
+
+let assoc_float key json =
+  match json with
+  | `Assoc kv -> (
+      match List.assoc_opt key kv with
+      | Some (`Float f) -> f
+      | _ -> failwith (Printf.sprintf "no float field %S" key))
+  | _ -> failwith "expected JSON object"
+
+(* ── Score boundaries ──────────────────────────────────────────── *)
+
+let test_score_clip () =
+  check_float "clip 0.5" 0.5 (R.score_to_float (R.score_clip 0.5));
+  check_float "clip neg → 0" 0.0 (R.score_to_float (R.score_clip (-1.0)));
+  check_float "clip >1 → 1" 1.0 (R.score_to_float (R.score_clip 1.5));
+  check_float "clip nan → 0" 0.0
+    (R.score_to_float (R.score_clip Float.nan))
+
+let test_score_of_float () =
+  let ok = R.score_of_float 0.7 in
+  check_bool "0.7 ok" (Result.is_ok ok);
+  check_bool "1.5 err" (Result.is_error (R.score_of_float 1.5));
+  check_bool "-0.1 err" (Result.is_error (R.score_of_float (-0.1)));
+  check_bool "nan err"
+    (Result.is_error (R.score_of_float Float.nan));
+  check_bool "inf err"
+    (Result.is_error (R.score_of_float Float.infinity))
+
+let test_score_constants () =
+  check_float "score_zero" 0.0 (R.score_to_float R.score_zero);
+  check_float "score_one" 1.0 (R.score_to_float R.score_one)
+
+(* ── Assessment kinds ──────────────────────────────────────────── *)
+
+let test_all_assessment_kinds () =
+  check_int "kind count" 4 (List.length R.all_assessment_kinds);
+  check_str "Quality" "quality"
+    (R.assessment_kind_to_string R.Quality);
+  check_str "Safety" "safety"
+    (R.assessment_kind_to_string R.Safety);
+  check_str "Coherence" "coherence"
+    (R.assessment_kind_to_string R.Coherence);
+  check_str "Coverage" "coverage"
+    (R.assessment_kind_to_string R.Coverage)
+
+(* ── Rubric JSON ───────────────────────────────────────────────── *)
+
+let test_rubric_score_json_with_notes () =
+  let rs : R.rubric_score =
+    {
+      kind = R.Quality;
+      rubric = "design clarity";
+      score = R.score_clip 0.8;
+      notes = Some "minor ambiguity";
+    }
+  in
+  let json = R.rubric_score_to_json rs in
+  check_str "rubric kind json" "quality" (assoc_string "kind" json);
+  check_str "rubric notes json" "minor ambiguity"
+    (assoc_string "notes" json);
+  check_float "rubric score json" 0.8 (assoc_float "score" json)
+
+let test_rubric_score_json_no_notes () =
+  let rs : R.rubric_score =
+    {
+      kind = R.Safety;
+      rubric = "no PII";
+      score = R.score_clip 1.0;
+      notes = None;
+    }
+  in
+  let json = R.rubric_score_to_json rs in
+  match json with
+  | `Assoc kv ->
+      check_bool "no notes field"
+        (not (List.mem_assoc "notes" kv));
+      check_str "kind" "safety" (assoc_string "kind" json)
+  | _ -> failwith "expected object"
+
+(* ── Verdict tag projection ────────────────────────────────────── *)
+
+let test_verdict_to_tag () =
+  check_bool "Pass → Pass_tag"
+    (R.verdict_to_tag R.Pass = R.Pass_tag);
+  check_bool "Fail → Fail_tag"
+    (R.verdict_to_tag R.Fail = R.Fail_tag);
+  check_bool "Conditional → Conditional_tag"
+    (R.verdict_to_tag (R.Conditional { conditions = [ "a" ] })
+    = R.Conditional_tag)
+
+let test_all_verdict_tags () =
+  check_int "verdict_tag count" 3 (List.length R.all_verdict_tags);
+  check_bool "Pass_tag in list"
+    (List.mem R.Pass_tag R.all_verdict_tags);
+  check_bool "Fail_tag in list"
+    (List.mem R.Fail_tag R.all_verdict_tags);
+  check_bool "Conditional_tag in list"
+    (List.mem R.Conditional_tag R.all_verdict_tags)
+
+(* ── Empty review ──────────────────────────────────────────────── *)
+
+let test_empty_review () =
+  let aid = make_id 1.0 in
+  let r = R.empty_review ~artifact_id:aid ~reviewed_at:1.0 in
+  check_int "empty rubric_scores length" 0
+    (List.length r.rubric_scores);
+  check_float "empty overall" 0.0 (R.score_to_float r.overall);
+  check_bool "empty verdict = Fail" (r.verdict = R.Fail);
+  check_float "reviewed_at" 1.0 r.reviewed_at
+
+let test_add_rubric_score () =
+  let aid = make_id 2.0 in
+  let r0 = R.empty_review ~artifact_id:aid ~reviewed_at:2.0 in
+  let rs : R.rubric_score =
+    {
+      kind = R.Quality;
+      rubric = "x";
+      score = R.score_clip 0.9;
+      notes = None;
+    }
+  in
+  let r1 = R.add_rubric_score rs r0 in
+  check_int "after add" 1 (List.length r1.rubric_scores)
+
+(* ── Evaluate verdict branches ────────────────────────────────── *)
+
+let mk_rs k r s =
+  ({
+     R.kind = k;
+     rubric = r;
+     score = R.score_clip s;
+     notes = None;
+   }
+    : R.rubric_score)
+
+let test_evaluate_pass () =
+  let aid = make_id 3.0 in
+  let r =
+    R.empty_review ~artifact_id:aid ~reviewed_at:3.0
+    |> R.with_rubric_scores
+         [
+           mk_rs R.Quality "design" 0.9;
+           mk_rs R.Safety "no PII" 0.95;
+           mk_rs R.Coverage "spec match" 0.85;
+         ]
+  in
+  let r =
+    R.evaluate ~pass_threshold:(R.score_clip 0.8)
+      ~conditional_threshold:(R.score_clip 0.5)
+      r
+  in
+  check_bool "pass" (r.verdict = R.Pass);
+  check_bool "overall ≥ 0.8" (R.score_to_float r.overall >= 0.8)
+
+let test_evaluate_fail () =
+  let aid = make_id 4.0 in
+  let r =
+    R.empty_review ~artifact_id:aid ~reviewed_at:4.0
+    |> R.with_rubric_scores
+         [
+           mk_rs R.Quality "design" 0.2;
+           mk_rs R.Safety "PII leak" 0.1;
+         ]
+  in
+  let r =
+    R.evaluate ~pass_threshold:(R.score_clip 0.8)
+      ~conditional_threshold:(R.score_clip 0.5)
+      r
+  in
+  check_bool "fail" (r.verdict = R.Fail)
+
+let test_evaluate_conditional () =
+  let aid = make_id 5.0 in
+  let r =
+    R.empty_review ~artifact_id:aid ~reviewed_at:5.0
+    |> R.with_rubric_scores
+         [
+           mk_rs R.Quality "design" 0.9;
+           mk_rs R.Safety "PII partial" 0.4;
+           mk_rs R.Coverage "spec gap" 0.5;
+         ]
+  in
+  (* mean = (0.9 + 0.4 + 0.5) / 3 = 0.6 *)
+  let r =
+    R.evaluate ~pass_threshold:(R.score_clip 0.8)
+      ~conditional_threshold:(R.score_clip 0.5)
+      r
+  in
+  match r.verdict with
+  | Conditional { conditions } ->
+      (* Two rubrics below pass_threshold (0.4, 0.5) *)
+      check_int "conditional count" 2 (List.length conditions);
+      check_bool "PII partial in conditions"
+        (List.mem "PII partial" conditions);
+      check_bool "spec gap in conditions"
+        (List.mem "spec gap" conditions)
+  | _ -> failwith "expected Conditional"
+
+let test_evaluate_empty_scores () =
+  let aid = make_id 6.0 in
+  let r0 = R.empty_review ~artifact_id:aid ~reviewed_at:6.0 in
+  let r =
+    R.evaluate ~pass_threshold:(R.score_clip 0.5)
+      ~conditional_threshold:(R.score_clip 0.0)
+      r0
+  in
+  (* mean = 0.0; 0.0 >= conditional_threshold 0.0 → Conditional with 0 conditions *)
+  check_bool "empty → Conditional"
+    (R.verdict_to_tag r.verdict = R.Conditional_tag)
+
+(* ── JSON shape ────────────────────────────────────────────────── *)
+
+let test_review_to_json_shape () =
+  let aid = make_id 7.0 in
+  let r =
+    R.empty_review ~artifact_id:aid ~reviewed_at:7.0
+    |> R.with_rubric_scores
+         [ mk_rs R.Quality "x" 0.9 ]
+    |> R.evaluate ~pass_threshold:(R.score_clip 0.5)
+         ~conditional_threshold:(R.score_clip 0.0)
+  in
+  let json = R.review_to_json r in
+  match json with
+  | `Assoc kv ->
+      check_bool "has artifact_id" (List.mem_assoc "artifact_id" kv);
+      check_bool "has rubric_scores"
+        (List.mem_assoc "rubric_scores" kv);
+      check_bool "has overall" (List.mem_assoc "overall" kv);
+      check_bool "has verdict" (List.mem_assoc "verdict" kv);
+      check_bool "has reviewed_at"
+        (List.mem_assoc "reviewed_at" kv)
+  | _ -> failwith "expected object"
+
+let test_verdict_json () =
+  let _ =
+    R.verdict_to_json (R.Conditional { conditions = [ "a"; "b" ] })
+  in
+  check_str "Pass kind" "pass"
+    (assoc_string "kind" (R.verdict_to_json R.Pass));
+  check_str "Fail kind" "fail"
+    (assoc_string "kind" (R.verdict_to_json R.Fail));
+  check_str "Conditional kind" "conditional"
+    (assoc_string "kind"
+       (R.verdict_to_json
+          (R.Conditional { conditions = [ "x" ] })))
+
+(* ── Driver ─────────────────────────────────────────────────────── *)
+
+let () =
+  let cases =
+    [
+      ("score_clip", test_score_clip);
+      ("score_of_float", test_score_of_float);
+      ("score_constants", test_score_constants);
+      ("all_assessment_kinds", test_all_assessment_kinds);
+      ("rubric_score_json_with_notes", test_rubric_score_json_with_notes);
+      ("rubric_score_json_no_notes", test_rubric_score_json_no_notes);
+      ("verdict_to_tag", test_verdict_to_tag);
+      ("all_verdict_tags", test_all_verdict_tags);
+      ("empty_review", test_empty_review);
+      ("add_rubric_score", test_add_rubric_score);
+      ("evaluate_pass", test_evaluate_pass);
+      ("evaluate_fail", test_evaluate_fail);
+      ("evaluate_conditional", test_evaluate_conditional);
+      ("evaluate_empty_scores", test_evaluate_empty_scores);
+      ("review_to_json_shape", test_review_to_json_shape);
+      ("verdict_json", test_verdict_json);
+    ]
+  in
+  ignore must;
+  List.iter
+    (fun (name, f) ->
+      try f ()
+      with e ->
+        Printf.printf "FAIL %s: %s\n" name (Printexc.to_string e);
+        exit 1)
+    cases;
+  Printf.printf "test_review: %d cases OK\n" (List.length cases)


### PR DESCRIPTION
## Summary

Tier A10b — `Multimodal.Review` evaluation record + verdict GADT (Cycle 26).

Anonymous artifact evaluation result. Captures rubric scores across {Quality, Safety, Coherence, Coverage} dimensions and derives a verdict (Pass/Fail/Conditional) against caller-supplied thresholds.

**Reviewer attribution is intentionally NOT a field.** This preserves the layering invariant:

```
lib/multimodal → shared_types, yojson  ← unchanged
lib/crew       → shared_types, yojson  ← unchanged
lib/{crew_audit,crew_critique} → multimodal, crew  ← future A10c
```

The A10c bridge functor will instantiate `(persona_kind × Review.t)` outside both libraries.

## Files

- `lib/multimodal/review.{mli,ml}` (NEW, ~200 LoC):
  - `score : private float` with `score_of_float` (validating) + `score_clip` (always-valid) + constants
  - `assessment_kind` (Quality/Safety/Coherence/Coverage) — ppx_tla derived
  - `rubric_score` record + JSON
  - `verdict` (Pass/Fail/Conditional) + `verdict_tag` mirror — ppx_tla derived
  - `review` record + `empty_review`/`add_rubric_score`/`with_rubric_scores`
  - `evaluate ~pass_threshold ~conditional_threshold` — mean of rubric scores → verdict
- `test/multimodal/test_review.ml` (NEW, 16 assertions): score clamp, rubric JSON, verdict tag, evaluate branches, threshold boundary, JSON shape
- `test/multimodal/dune` (+ test name)

## Verification

- `dune build --root . lib/multimodal test/multimodal` — GREEN
- `dune runtest --root . test/multimodal` — 16 new + 5 existing all GREEN, 0 regression
- `lib/multimodal/dune` unchanged — review uses only shared_types + yojson (already in deps)
- file-disjoint with #11893 (A9 council), #11932 (A10a consensus), main, all open PRs

## Plan reference

§2.2 Tier A10 (Cycle 26): `lib/crew/{crew_consensus,crew_audit}.{mli,ml}` + Multimodal `Review.evaluate` ↔ `Crew_critique` bridge functor. Total ~400 LoC.

This is the A10b slice (~200 LoC) — `Review.evaluate` half. A10a (#11932) is the `Crew_consensus` half. A10c (council audit + bridge functor) blocks on A9 (#11893) merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
