### PR TITLE
refactor: duration-200 → t-med sweep across 10 dashboard components (cycle 47)

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -246,7 +246,7 @@ export function AgentDetailOverlay() {
       labelledBy=${titleId}
       onClose=${closeAgentDetail}
       initialFocusRef=${closeButtonRef}
-      overlayClass="agent-detail-overlay fixed inset-0 z-[60] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-200"
+      overlayClass="agent-detail-overlay fixed inset-0 z-[60] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-[var(--t-med)]"
       panelClass="w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded border border-card-border bg-bg-1/95 backdrop-blur-sm shadow-sm shadow-black/50 ring-1 ring-white/5"
     >
       <div class="p-6 flex flex-col gap-5">
@@ -321,7 +321,7 @@ export function AgentDetailOverlay() {
             <button
               ref=${closeButtonRef}
               type="button"
-              class=${`px-4 py-2 text-sm font-semibold rounded border border-transparent bg-[var(--white-10)] text-text-strong hover:bg-[var(--white-20)] transition-colors duration-200 shadow-sm ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`}
+              class=${`px-4 py-2 text-sm font-semibold rounded border border-transparent bg-[var(--white-10)] text-text-strong hover:bg-[var(--white-20)] transition-colors duration-[var(--t-med)] shadow-sm ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`}
               onClick=${closeAgentDetail}
             >
               닫기

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -705,7 +705,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           return html`
             <button type="button"
-              class="monitor-surface-card monitor-surface-card-medium group flex w-full flex-col gap-3.5 rounded-card p-4 text-left transition-all duration-200 cursor-pointer hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)] hover:-translate-y-0.5"
+              class="monitor-surface-card monitor-surface-card-medium group flex w-full flex-col gap-3.5 rounded-card p-4 text-left transition-all duration-[var(--t-med)] cursor-pointer hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)] hover:-translate-y-0.5"
               key=${agent.name}
               aria-label=${detailLabel}
               onClick=${openDetail}

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -75,7 +75,7 @@ export function FleetHealthPanel() {
         size="sm"
         tone="accent"
       />
-      <div class="transition-opacity duration-200">
+      <div class="transition-opacity duration-[var(--t-med)]">
         ${view === 'default'
           ? html`<${DefaultDualPanel} />`
         : view === 'event-log'

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -220,7 +220,7 @@ export function SwimlaneTimeline({
                       data-lane-key=${lane.key}
                       data-lane-index=${laneIndex}
                       data-seg-index=${segIndex}
-                      class=${`${swimlaneSegmentColor(seg.value)} h-full transition-all duration-200 border-r border-[rgba(0,0,0,0.25)] last:border-r-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-fg)] focus-visible:ring-inset ${isHovered ? 'ring-1 ring-[var(--color-accent-fg)] brightness-125' : ''} ${dimmed ? 'opacity-40' : ''}`}
+                      class=${`${swimlaneSegmentColor(seg.value)} h-full transition-all duration-[var(--t-med)] border-r border-[rgba(0,0,0,0.25)] last:border-r-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-fg)] focus-visible:ring-inset ${isHovered ? 'ring-1 ring-[var(--color-accent-fg)] brightness-125' : ''} ${dimmed ? 'opacity-40' : ''}`}
                       style=${`width: ${pct.toFixed(2)}%`}
                       title=${`${lane.label} (${lane.short}) · ${displayState(seg.value)} (${seg.value})\n${fmtAbs(seg.from)} → ${fmtAbs(seg.to)} · ${holdFor}`}
                       aria-label=${ariaLabel}
@@ -283,7 +283,7 @@ export function SwimlaneTimeline({
               const tip = `${fmtAbs(obs.ts)}${changedLanes.length > 0 ? ` · ${changedLanes.join(', ')} changed` : ' · no change'}`
               return html`
                 <div
-                  class=${`absolute top-1/2 -translate-y-1/2 h-1.5 w-1.5 rounded-full ${dotCls} transition-all duration-200`}
+                  class=${`absolute top-1/2 -translate-y-1/2 h-1.5 w-1.5 rounded-full ${dotCls} transition-all duration-[var(--t-med)]`}
                   aria-hidden="true"
                   style=${`left: ${leftPct.toFixed(2)}%`}
                   title=${tip}

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1002,7 +1002,7 @@ function CollapsibleZone({
         aria-controls=${`zone-${id}`}
       >
         <span class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">${zoneTitle}</span>
-        <span class=${`text-3xs text-[var(--color-fg-disabled)] transition-transform duration-200 ${collapsed ? '' : 'rotate-180'}`} aria-hidden="true">▾</span>
+        <span class=${`text-3xs text-[var(--color-fg-disabled)] transition-transform duration-[var(--t-med)] ${collapsed ? '' : 'rotate-180'}`} aria-hidden="true">▾</span>
       </button>
       ${!collapsed ? html`<div id=${`zone-${id}`} class="px-4 pb-3">${children}</div>` : null}
     </div>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -434,7 +434,7 @@ function PromptBlock({
   `
 }
 
-const fieldStyle = 'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded py-2 px-3 font-sans focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-200 shadow-inner'
+const fieldStyle = 'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded py-2 px-3 font-sans focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-[var(--t-med)] shadow-inner'
 
 // ── Inline editing components for runtime config ────────
 

--- a/dashboard/src/components/keeper-detail-layout.ts
+++ b/dashboard/src/components/keeper-detail-layout.ts
@@ -9,7 +9,7 @@ export function KeeperDetailSectionCard({
   children: ComponentChildren
 }) {
   return html`
-    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-sm">
+    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm transition-[border-color,box-shadow] duration-[var(--t-med)] hover:border-accent/30 hover:shadow-sm">
       <div class="text-2xs font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50" aria-hidden="true"></span>
         ${title}

--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -24,7 +24,7 @@ const crashShowAll = signal<boolean>(false)
 
 function SectionCard({ title, children }: { title: string; children: preact.ComponentChildren }) {
   return html`
-    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-sm">
+    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm transition-[border-color,box-shadow] duration-[var(--t-med)] hover:border-accent/30 hover:shadow-sm">
       <div class="text-2xs font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50" aria-hidden="true"></span>
         ${title}

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -236,7 +236,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
   const trimmedQuery = query.trim()
 
   return html`
-    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-sm">
+    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm transition-[border-color,box-shadow] duration-[var(--t-med)] hover:border-accent/30 hover:shadow-sm">
       <div class="text-2xs font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50" aria-hidden="true"></span>
         도구 텔레메트리

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -403,7 +403,7 @@ function PostCard({ post }: { post: BoardPost }) {
   return html`
     <button
       type="button"
-      class=${`board-post group w-full flex gap-3 rounded p-4 border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer text-left ${ringFocusClasses()}`}
+      class=${`board-post group w-full flex gap-3 rounded p-4 border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-[var(--t-med)] cursor-pointer text-left ${ringFocusClasses()}`}
       onClick=${() => navigateToPost(post.id)}
     >
       <!-- Select checkbox -->


### PR DESCRIPTION
## Summary

Mechanical text-replace sweep of `duration-200` to `duration-[var(--t-med)]` across 10 component files, totaling **12 inline magic-number occurrences**.

## Files (instances)

| File | Count |
|------|-------|
| `agent-detail.ts` | 2 |
| `agent-roster.ts` | 1 |
| `fleet-health-panel.ts` | 1 |
| `fsm-hub.ts` | 1 |
| `fsm-hub-timeline-panels.ts` | 2 |
| `keeper-config-panel.ts` | 1 |
| `keeper-detail-layout.ts` | 1 |
| `keeper-tool-telemetry.ts` | 1 |
| `keeper-supervisor-diagnostics.ts` | 1 |
| `memory.ts` | 1 |

## Cosmetic delta

**0ms** — `--t-med` is exactly 200ms in `tokens/source.ts`. Visual change zero; semantic gain only (token-driven, retuneable, drift-resistant).

## Excluded: dashboard-shell.ts

`dashboard-shell.ts` (4 occurrences) is already swapped in **#11930** (open Draft). Merging both PRs cleanly requires excluding it from this sweep — same-file edits would conflict.

## After merge of this PR + #11930

`rg duration-200 dashboard/src/components` → empty. Zero-state for `duration-200` magic numbers across the entire components directory.

## Verification

- `pnpm test` (button.test.ts + button.a11y.test.ts) → **24/24 passing** as a sanity smoke test
- 12 swaps × 1 mechanical pattern (`s/duration-200/duration-[var(--t-med)]/g`) — pure className text replacement with identical render behavior

## Pattern series

- #11890 button BASE (1 swap)
- #11900 t-fast (5 swaps in common/)
- #11920 t-slow (2 swaps in common/)
- #11930 dashboard-shell (4 swaps)
- **this PR** (12 swaps in 10 components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)