### PR TITLE
feat(tokens): toast-bg component-level role token (cycle 47)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.generated.css
+++ b/dashboard/design-system/source_styles/tokens.generated.css
@@ -408,6 +408,7 @@
   --dialog-panel-bg: rgba(13,21,38,0.98);  /* DialogOverlay panel surface bg (most-common consumer literal) */
   --dialog-panel-border: var(--color-border-default);  /* DialogOverlay panel border */
   --dialog-overlay-bg: var(--white-5);  /* DialogOverlay scrim base color (pair with /60 or /70 opacity) */
+  --toast-bg: rgba(10,18,34,0.96);  /* ToastContainer surface bg (deep navy with slight transparency for backdrop blend) */
   --state-hover-bg: var(--bg-3);
   --state-hover-fg: var(--fg-1);
   --state-hover-border: var(--line-2);

--- a/dashboard/design-system/tokens/build/tokens.json
+++ b/dashboard/design-system/tokens/build/tokens.json
@@ -1779,6 +1779,11 @@
       "$value": "var(--white-5)",
       "$description": "DialogOverlay scrim base color (pair with /60 or /70 opacity)"
     },
+    "toast-bg": {
+      "$type": "color",
+      "$value": "rgba(10,18,34,0.96)",
+      "$description": "ToastContainer surface bg (deep navy with slight transparency for backdrop blend)"
+    },
     "state-hover-bg": {
       "$type": "color",
       "$value": "var(--bg-3)"

--- a/dashboard/design-system/tokens/source.ts
+++ b/dashboard/design-system/tokens/source.ts
@@ -764,6 +764,14 @@ export const semantic: ReadonlyArray<TokenBase> = (() => {
   out.push(t("dialog-overlay-bg",   "var(--white-5)",               "role", "color",
     "DialogOverlay scrim base color (pair with /60 or /70 opacity)"));
 
+  // Toast primitive component-level slot. ToastContainer inlines
+  // `rgba(10,18,34,0.96)` for its surface bg — converging it on a
+  // single token slot makes the ~5 visible toast types share a
+  // retuneable surface (mirror of dialog-* / button-* families).
+  out.push(t("toast-bg",         "rgba(10,18,34,0.96)",                "role", "color",
+    "ToastContainer surface bg (deep navy with slight transparency for backdrop blend)"));
+
+
   // Interactive state roles — explicit hover/selected/pressed semantics
   out.push(t("state-hover-bg",       "var(--bg-3)",   "role", "color"));
   out.push(t("state-hover-fg",       "var(--fg-1)",   "role", "color"));

--- a/dashboard/src/styles/tokens.generated.css
+++ b/dashboard/src/styles/tokens.generated.css
@@ -403,6 +403,7 @@
   --color-dialog-panel-bg: rgba(13,21,38,0.98);
   --color-dialog-panel-border: var(--color-border-default);
   --color-dialog-overlay-bg: var(--white-5);
+  --color-toast-bg: rgba(10,18,34,0.96);
   --color-state-hover-bg: var(--bg-3);
   --color-state-hover-fg: var(--fg-1);
   --color-state-hover-border: var(--line-2);

--- a/dashboard/src/styles/tokens.generated.ts
+++ b/dashboard/src/styles/tokens.generated.ts
@@ -403,6 +403,7 @@ export const TOKENS = {
   "dialogPanelBg": { name: "--dialog-panel-bg", value: "rgba(13,21,38,0.98)", tier: "role", kind: "color" },
   "dialogPanelBorder": { name: "--dialog-panel-border", value: "var(--color-border-default)", tier: "role", kind: "color" },
   "dialogOverlayBg": { name: "--dialog-overlay-bg", value: "var(--white-5)", tier: "role", kind: "color" },
+  "toastBg": { name: "--toast-bg", value: "rgba(10,18,34,0.96)", tier: "role", kind: "color" },
   "stateHoverBg": { name: "--state-hover-bg", value: "var(--bg-3)", tier: "role", kind: "color" },
   "stateHoverFg": { name: "--state-hover-fg", value: "var(--fg-1)", tier: "role", kind: "color" },
   "stateHoverBorder": { name: "--state-hover-border", value: "var(--line-2)", tier: "role", kind: "color" },

--- a/dashboard_bonsai/src/tokens.ml
+++ b/dashboard_bonsai/src/tokens.ml
@@ -404,6 +404,7 @@ type semantic =
   | `Dialog_panel_bg
   | `Dialog_panel_border
   | `Dialog_overlay_bg
+  | `Toast_bg
   | `State_hover_bg
   | `State_hover_fg
   | `State_hover_border
@@ -869,6 +870,7 @@ let name_of = function
   | `Dialog_panel_bg -> "dialog-panel-bg"
   | `Dialog_panel_border -> "dialog-panel-border"
   | `Dialog_overlay_bg -> "dialog-overlay-bg"
+  | `Toast_bg -> "toast-bg"
   | `State_hover_bg -> "state-hover-bg"
   | `State_hover_fg -> "state-hover-fg"
   | `State_hover_border -> "state-hover-border"

--- a/dashboard_bonsai/src/tokens.mli
+++ b/dashboard_bonsai/src/tokens.mli
@@ -415,6 +415,7 @@ type semantic =
   | `Dialog_panel_bg
   | `Dialog_panel_border
   | `Dialog_overlay_bg
+  | `Toast_bg
   | `State_hover_bg
   | `State_hover_fg
   | `State_hover_border

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 1,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 967,
+  "lib_dune_lines": 968,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 14
+  "lib_other_mli_missing": 12
 }


### PR DESCRIPTION
Adds --toast-bg slot (rgba(10,18,34,0.96)) for ToastContainer. Mirror of button-* / dialog-* / input-* token families. Consumer migration in toast.ts is a 1-line follow-up PR.