### PR TITLE
refactor(task-detail-overlay): swap raw hex to var(--color-bg-surface) (cycle 47)

### DIFF
--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -416,7 +416,7 @@ export function TaskDetailOverlay() {
       onClose=${closeTaskDetail}
       initialFocusRef=${closeButtonRef}
       overlayClass="fixed inset-0 z-[60] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-200"
-      panelClass="w-full max-w-[900px] max-h-[90vh] overflow-y-auto bg-[#0d1526] rounded border border-[var(--color-border-default)] shadow-[0_24px_64px_var(--black-50)]"
+      panelClass="w-full max-w-[900px] max-h-[90vh] overflow-y-auto bg-[var(--color-bg-surface)] rounded border border-[var(--color-border-default)] shadow-[0_24px_64px_var(--black-50)]"
     >
       ${'' /* Sticky Header */}
       <div class="sticky top-0 z-10 flex items-center justify-between gap-4 px-6 py-4 border-b border-[var(--color-border-default)] bg-[rgba(13,21,38,0.97)] backdrop-blur-sm rounded-t-2xl">


### PR DESCRIPTION
1-line swap: bg-[#0d1526] → bg-[var(--color-bg-surface)]. Removes the only raw hex literal in dashboard dialog consumers. Sets up dialog-panel-bg consumer migration after #11905 merges. dialog tests pass (10/10).