### PR TITLE
fix(dashboard): cytoscape-fsm a11y fixtures — add required FsmNode.type

### DIFF
--- a/dashboard/src/components/common/cytoscape-fsm.a11y.test.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.a11y.test.ts
@@ -13,8 +13,8 @@ import type { FsmGraphSpec } from './cytoscape-fsm'
 
 const trivialSpec: FsmGraphSpec = {
   nodes: [
-    { id: 'idle', label: 'idle' },
-    { id: 'busy', label: 'busy' },
+    { id: 'idle', label: 'idle', type: 'state' },
+    { id: 'busy', label: 'busy', type: 'active' },
   ],
   edges: [
     { source: 'idle', target: 'busy', label: 'start' },
@@ -53,9 +53,9 @@ describe('CytoscapeFsm a11y', () => {
   it('with cascade + error edge types passes axe', async () => {
     const withTypes: FsmGraphSpec = {
       nodes: [
-        { id: 'a', label: 'a' },
-        { id: 'b', label: 'b' },
-        { id: 'c', label: 'c' },
+        { id: 'a', label: 'a', type: 'start' },
+        { id: 'b', label: 'b', type: 'state' },
+        { id: 'c', label: 'c', type: 'end' },
       ],
       edges: [
         { source: 'a', target: 'b', type: 'cascade' },


### PR DESCRIPTION
## 문제

`dashboard/src/components/common/cytoscape-fsm.a11y.test.ts`의 fixture가 `FsmNode.type` 필드를 누락 — Dashboard CI에서 TS2741 에러.

```
Property 'type' is missing in type '{ id: string; label: string; }' but required in type 'FsmNode'.
```

## 근본 원인

- #11913 cycle 42에서 cytoscape-fsm a11y 테스트를 추가했지만 fixture에 `type` 필드 없음.
- `cytoscape-fsm.ts`의 `FsmNode` 인터페이스는 `type: 'state' | 'active' | ...`를 required로 선언.
- Dashboard CI workflow는 path-filtered → dashboard/ 변경 PR에서만 실행 → main에서는 skipped → broken 상태로 머지됨.
- dashboard/를 건드리는 모든 후속 PR이 이 landmine으로 Dashboard 실패. 영향: #11939, #11940, #11905 등.

## 변경

5개 fixture node에 적절한 `type` 리터럴 추가:
- `idle` → `'state'`, `busy` → `'active'` (trivialSpec)
- `a` → `'start'`, `b` → `'state'`, `c` → `'end'` (withTypes)

## 후속 영향

이 PR 머지 후 Dashboard CI가 unblock됨 → autocoder가 #11939, #11940, #11905 자동 머지 가능.

## Test plan

- [ ] CI Dashboard 통과 확인