### PR TITLE
feat(tokens): input-placeholder + input-border-focus tokens (cycle 49)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.generated.css
+++ b/dashboard/design-system/source_styles/tokens.generated.css
@@ -405,6 +405,8 @@
   --input-border: var(--color-border-default);  /* Form input border */
   --input-bg-hover: var(--white-6);  /* Form input hover bg */
   --input-bg-focus: var(--color-bg-page);  /* Form input :focus-visible bg */
+  --input-placeholder: var(--color-fg-muted);  /* Form input :placeholder text color */
+  --input-border-focus: rgba(71,184,255,0.6);  /* Form input :focus-visible border (accent-tinted, slightly translucent) */
   --dialog-panel-bg: rgba(13,21,38,0.98);  /* DialogOverlay panel surface bg (most-common consumer literal) */
   --dialog-panel-border: var(--color-border-default);  /* DialogOverlay panel border */
   --dialog-overlay-bg: var(--white-5);  /* DialogOverlay scrim base color (pair with /60 or /70 opacity) */

--- a/dashboard/design-system/tokens/build/tokens.json
+++ b/dashboard/design-system/tokens/build/tokens.json
@@ -1764,6 +1764,16 @@
       "$value": "var(--color-bg-page)",
       "$description": "Form input :focus-visible bg"
     },
+    "input-placeholder": {
+      "$type": "color",
+      "$value": "var(--color-fg-muted)",
+      "$description": "Form input :placeholder text color"
+    },
+    "input-border-focus": {
+      "$type": "color",
+      "$value": "rgba(71,184,255,0.6)",
+      "$description": "Form input :focus-visible border (accent-tinted, slightly translucent)"
+    },
     "dialog-panel-bg": {
       "$type": "color",
       "$value": "rgba(13,21,38,0.98)",

--- a/dashboard/design-system/tokens/source.ts
+++ b/dashboard/design-system/tokens/source.ts
@@ -751,6 +751,15 @@ export const semantic: ReadonlyArray<TokenBase> = (() => {
   out.push(t("input-bg-focus",   "var(--color-bg-page)",            "role", "color",
     "Form input :focus-visible bg"));
 
+  // Input family extension — placeholder + focus-visible border. These
+  // are the two remaining inline literals in input.ts INPUT_BASE that
+  // weren't part of the canonical 5-slot shape (#11917). Adding them
+  // closes the input-* family for full consumer migration.
+  out.push(t("input-placeholder", "var(--color-fg-muted)",          "role", "color",
+    "Form input :placeholder text color"));
+  out.push(t("input-border-focus", "rgba(71,184,255,0.6)",          "role", "color",
+    "Form input :focus-visible border (accent-tinted, slightly translucent)"));
+
   // Dialog primitive component-level slots. Existing consumers
   // (confirm-dialog, agent-detail, keeper-detail, task-detail-overlay)
   // each pass a different panel bg literal — `rgba(13,21,38,0.98)`,
@@ -770,6 +779,7 @@ export const semantic: ReadonlyArray<TokenBase> = (() => {
   // retuneable surface (mirror of dialog-* / button-* families).
   out.push(t("toast-bg",         "rgba(10,18,34,0.96)",                "role", "color",
     "ToastContainer surface bg (deep navy with slight transparency for backdrop blend)"));
+
 
 
   // Interactive state roles — explicit hover/selected/pressed semantics

--- a/dashboard/src/styles/tokens.generated.css
+++ b/dashboard/src/styles/tokens.generated.css
@@ -400,6 +400,8 @@
   --color-input-border: var(--color-border-default);
   --color-input-bg-hover: var(--white-6);
   --color-input-bg-focus: var(--color-bg-page);
+  --color-input-placeholder: var(--color-fg-muted);
+  --color-input-border-focus: rgba(71,184,255,0.6);
   --color-dialog-panel-bg: rgba(13,21,38,0.98);
   --color-dialog-panel-border: var(--color-border-default);
   --color-dialog-overlay-bg: var(--white-5);

--- a/dashboard/src/styles/tokens.generated.ts
+++ b/dashboard/src/styles/tokens.generated.ts
@@ -400,6 +400,8 @@ export const TOKENS = {
   "inputBorder": { name: "--input-border", value: "var(--color-border-default)", tier: "role", kind: "color" },
   "inputBgHover": { name: "--input-bg-hover", value: "var(--white-6)", tier: "role", kind: "color" },
   "inputBgFocus": { name: "--input-bg-focus", value: "var(--color-bg-page)", tier: "role", kind: "color" },
+  "inputPlaceholder": { name: "--input-placeholder", value: "var(--color-fg-muted)", tier: "role", kind: "color" },
+  "inputBorderFocus": { name: "--input-border-focus", value: "rgba(71,184,255,0.6)", tier: "role", kind: "color" },
   "dialogPanelBg": { name: "--dialog-panel-bg", value: "rgba(13,21,38,0.98)", tier: "role", kind: "color" },
   "dialogPanelBorder": { name: "--dialog-panel-border", value: "var(--color-border-default)", tier: "role", kind: "color" },
   "dialogOverlayBg": { name: "--dialog-overlay-bg", value: "var(--white-5)", tier: "role", kind: "color" },

--- a/dashboard_bonsai/src/tokens.ml
+++ b/dashboard_bonsai/src/tokens.ml
@@ -401,6 +401,8 @@ type semantic =
   | `Input_border
   | `Input_bg_hover
   | `Input_bg_focus
+  | `Input_placeholder
+  | `Input_border_focus
   | `Dialog_panel_bg
   | `Dialog_panel_border
   | `Dialog_overlay_bg
@@ -892,6 +894,8 @@ let name_of = function
   | `Input_border -> "input-border"
   | `Input_bg_hover -> "input-bg-hover"
   | `Input_bg_focus -> "input-bg-focus"
+  | `Input_placeholder -> "input-placeholder"
+  | `Input_border_focus -> "input-border-focus"
   | `Dialog_panel_bg -> "dialog-panel-bg"
   | `Dialog_panel_border -> "dialog-panel-border"
   | `Dialog_overlay_bg -> "dialog-overlay-bg"

--- a/dashboard_bonsai/src/tokens.mli
+++ b/dashboard_bonsai/src/tokens.mli
@@ -412,6 +412,8 @@ type semantic =
   | `Input_border
   | `Input_bg_hover
   | `Input_bg_focus
+  | `Input_placeholder
+  | `Input_border_focus
   | `Dialog_panel_bg
   | `Dialog_panel_border
   | `Dialog_overlay_bg


### PR DESCRIPTION
Closes input-* family. 2 follow-up slots after canonical 5 (#11917): placeholder color + focus-visible border. Sets up INPUT_BASE zero-inline-literal end-state via consumer-migration follow-up.