### PR TITLE
refactor(dialog): migrate consumers to dialog-* aliases (cycle 50)

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -246,7 +246,7 @@ export function AgentDetailOverlay() {
       labelledBy=${titleId}
       onClose=${closeAgentDetail}
       initialFocusRef=${closeButtonRef}
-      overlayClass="agent-detail-overlay fixed inset-0 z-[60] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-[var(--t-med)]"
+      overlayClass="agent-detail-overlay fixed inset-0 z-[60] bg-[var(--dialog-overlay-bg)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-[var(--t-med)]"
       panelClass="w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded border border-card-border bg-bg-1/95 backdrop-blur-sm shadow-sm shadow-black/50 ring-1 ring-white/5"
     >
       <div class="p-6 flex flex-col gap-5">

--- a/dashboard/src/components/common/confirm-dialog.ts
+++ b/dashboard/src/components/common/confirm-dialog.ts
@@ -89,7 +89,7 @@ export function ConfirmDialogOverlay() {
       labelledBy="confirm-dialog-title"
       onClose=${handleClose}
       overlayClass="fixed inset-0 z-[100] flex items-center justify-center p-4"
-      panelClass="w-full max-w-100 bg-[rgba(13,21,38,0.98)] rounded-md border border-[var(--color-border-default)] shadow-[0_24px_64px_rgba(0,0,0,0.6)] overflow-hidden"
+      panelClass="w-full max-w-100 bg-[var(--dialog-panel-bg)] rounded-md border border-[var(--dialog-panel-border)] shadow-[0_24px_64px_rgba(0,0,0,0.6)] overflow-hidden"
     >
       <div class="p-5">
         <div class="flex items-start gap-4">

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -415,8 +415,8 @@ export function TaskDetailOverlay() {
       labelledBy=${titleId}
       onClose=${closeTaskDetail}
       initialFocusRef=${closeButtonRef}
-      overlayClass="fixed inset-0 z-[60] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-200"
-      panelClass="w-full max-w-[900px] max-h-[90vh] overflow-y-auto bg-[var(--color-bg-surface)] rounded border border-[var(--color-border-default)] shadow-[0_24px_64px_var(--black-50)]"
+      overlayClass="fixed inset-0 z-[60] bg-[var(--dialog-overlay-bg)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-[var(--t-med)]"
+      panelClass="w-full max-w-[900px] max-h-[90vh] overflow-y-auto bg-[var(--color-bg-surface)] rounded border border-[var(--dialog-panel-border)] shadow-[0_24px_64px_var(--black-50)]"
     >
       ${'' /* Sticky Header */}
       <div class="sticky top-0 z-10 flex items-center justify-between gap-4 px-6 py-4 border-b border-[var(--color-border-default)] bg-[rgba(13,21,38,0.97)] backdrop-blur-sm rounded-t-2xl">

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -510,8 +510,8 @@ function KeeperClearContextDialog({
       describedBy=${descId}
       onClose=${pending ? () => {} : onClose}
       initialFocusRef=${reasonRef}
-      overlayClass="fixed inset-0 z-[80] bg-[var(--white-5)]/70 backdrop-blur-sm isolate flex items-center justify-center p-4"
-      panelClass="w-full max-w-130 rounded border border-[var(--bad-30)] bg-[rgba(13,21,38,0.98)] shadow-[0_24px_64px_rgba(0,0,0,0.6)]"
+      overlayClass="fixed inset-0 z-[80] bg-[var(--dialog-overlay-bg)]/70 backdrop-blur-sm isolate flex items-center justify-center p-4"
+      panelClass="w-full max-w-130 rounded border border-[var(--bad-30)] bg-[var(--dialog-panel-bg)] shadow-[0_24px_64px_rgba(0,0,0,0.6)]"
     >
       <div class="p-5 flex flex-col gap-4">
         <div class="flex flex-col gap-1">


### PR DESCRIPTION
First consumer of dialog-* tokens (#11905). 7 swaps across 4 dialog consumer files (confirm-dialog, keeper-detail, task-detail-overlay, agent-detail). Two consumers keep original panel bg to avoid visual drift — separate alignment PR after eyeballing. 14/14 dialog tests pass.