### PR TITLE
chore: bump agent_sdk to 0.184.0, masc_mcp to 0.18.12

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc_mcp)
-(version 0.18.11)
+(version 0.18.12)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)
@@ -41,7 +41,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.183.0))
+  (agent_sdk (>= 0.184.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))


### PR DESCRIPTION
## Summary
- Bump `agent_sdk` dependency from `>= 0.183.0` to `>= 0.184.0`
- Bump `masc_mcp` version from `0.18.11` to `0.18.12`

OAS 0.184.0 includes the SSE keepalive idle timer fix (jeong-sik/oas#1246).

## Test plan
- [ ] `dune build` passes with new agent_sdk pin
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)