### PR TITLE
fix(keeper): runtime_contract sandbox_root must be keeper-visible

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1732,7 +1732,8 @@ let run_turn
                 ~goal_ids:meta.active_goal_ids
                 ~sandbox_profile:
                   (Keeper_types.sandbox_profile_to_string meta.sandbox_profile)
-                ~sandbox_root:(Keeper_sandbox.host_root_abs_of_meta ~config meta)
+                ~sandbox_root:
+                  (Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta)
                 ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
                 ~network_mode:
                   (Keeper_types.network_mode_to_string meta.network_mode)

--- a/lib/keeper/keeper_sandbox.ml
+++ b/lib/keeper/keeper_sandbox.ml
@@ -75,6 +75,12 @@ let container_root name =
     Env_config_keeper.DockerPlayground.container_playground_root
     (Playground_paths.sanitize_keeper_name name)
 
+let keeper_visible_root_abs_of_meta ~(config : Coord.config)
+    (meta : Keeper_types.keeper_meta) =
+  match backend_of_profile meta.sandbox_profile with
+  | Local -> host_root_abs_of_meta ~config meta
+  | Docker -> container_root meta.name
+
 let of_meta ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) : t =
   let backend = backend_of_profile meta.sandbox_profile in
   { keeper_name = meta.name

--- a/lib/keeper/keeper_sandbox.mli
+++ b/lib/keeper/keeper_sandbox.mli
@@ -60,6 +60,21 @@ val host_root_abs_of_meta :
     hardened Docker backend. *)
 val container_root : string -> string
 
+(** [keeper_visible_root_abs_of_meta ~config meta] is the absolute
+    sandbox root the keeper LLM should treat as its working root,
+    derived directly from [meta] without building the full record.
+    For Docker keepers this is the in-container path
+    ({!container_root}); for Local keepers this is the host path
+    ({!host_root_abs_of_meta}). Use this in runtime_contract and
+    other LLM-facing surfaces; surfacing the host path to a Docker
+    keeper makes the LLM emit [cd /Users/.../.masc/playground/...]
+    inside the container, which fails because that path does not
+    exist there. *)
+val keeper_visible_root_abs_of_meta :
+  config:Coord.config ->
+  Keeper_types.keeper_meta ->
+  string
+
 (** {1 Construction} *)
 
 (** [of_meta ~config ~meta] derives the full sandbox record from a

--- a/test/test_keeper_agent_run_sandbox_source.ml
+++ b/test/test_keeper_agent_run_sandbox_source.ml
@@ -71,6 +71,32 @@ let test_execution_receipt_reports_same_sandbox_root () =
     (contains ~needle:"sandbox_root = Some keeper_sandbox_root" src)
 ;;
 
+let test_runtime_contract_sandbox_root_is_keeper_visible () =
+  (* Runtime_contract.sandbox_root is consumed by the keeper LLM. Surfacing
+     the host abs path there leaks the abstraction that the keeper lives
+     entirely inside its sandbox; the LLM then emits host-path commands
+     like [cd /Users/.../playground/<keeper>/...] on the next turn, which
+     fail with No such file or directory inside the container.
+     The fix routes the sandbox_root field through
+     [Keeper_sandbox.keeper_visible_root_abs_of_meta] so Docker keepers see
+     [container_root] and Local keepers keep the host path. *)
+  let src = load_source target_file in
+  check
+    bool
+    "runtime_contract sandbox_root routes through keeper_visible_root_abs_of_meta"
+    true
+    (contains
+       ~needle:"Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta"
+       src);
+  check
+    int
+    "runtime_contract sandbox_root no longer calls host_root_abs_of_meta directly"
+    0
+    (count_occurrences
+       ~needle:"~sandbox_root:(Keeper_sandbox.host_root_abs_of_meta"
+       src)
+;;
+
 let () =
   run
     "keeper_agent_run_sandbox_source"
@@ -83,6 +109,10 @@ let () =
             "receipt reports same sandbox root"
             `Quick
             test_execution_receipt_reports_same_sandbox_root
+        ; test_case
+            "runtime_contract sandbox_root is keeper-visible"
+            `Quick
+            test_runtime_contract_sandbox_root_is_keeper_visible
         ] )
     ]
 ;;


### PR DESCRIPTION
## Why

`runtime_contract.sandbox_root` was leaking the host absolute path (`/Users/.../.masc/playground/<keeper>/`)
to the keeper LLM. The LLM then perceived itself as living on the host filesystem and emitted
host-path commands like `cd /Users/...` on the next turn. Inside the Docker sandbox that path
does not exist, so every such command failed with `No such file or directory`.

Operational evidence (2026-04-28, multiple keepers):

```
ls: cannot access '/Users/dancer/me/.masc/playground/docker/issue_king/repos/grpc-direct/lib/': No such file or directory
sandbox docker exec failed (masc-keeper-sandbox:local, exit=2)
```

Response JSON carried `"via":"docker"` while the actual work failed, so from the user's
perspective Docker keepers appeared "not to run on Docker" even though they were entering
the container correctly.

## Root cause

`Keeper_sandbox.keeper_visible_root_abs` (#10650) and `Keeper_cwd_response`'s audience-tagged
path discipline (#11080) were already in place. The runtime_contract builder in
`keeper_agent_run.ml:1735` simply did not use either — it called `host_root_abs_of_meta`
directly. A missed call site, not a missing primitive.

## What

- Add `Keeper_sandbox.keeper_visible_root_abs_of_meta` (a from-meta variant that avoids
  building the full `Keeper_sandbox.t` record).
- Route the runtime_contract `~sandbox_root` argument through it.
- mli docstring describes the leak mechanism and the LLM symptom.
- Source-level guard test (positive + negative) blocks regressions.

## Behavioral change

| Backend | Before | After |
|---|---|---|
| Local  | host abs path | host abs path (no regression — host *is* the environment) |
| Docker | host abs path (leak) | `container_root`, e.g. `/home/keeper/playground/<name>` |

## Out of scope (separate PRs)

- `execution_receipt.sandbox_root` (line 1886/2875) — operator-audit surface, not currently
  fed back into the LLM prompt path.
- `DOCKER_EXEC` info log host_cwd — operator-facing.
- Persona TOML instructions: sandbox-path-only mental-model realignment.

## Test plan

- [x] `dune build --root . @check` (2m12s, exit 0)
- [x] `dune build --root . test/test_keeper_agent_run_sandbox_source.exe`
- [x] 3/3 alcotest cases (2 existing + 1 new source-level guard)
- [ ] CI green
- [ ] Manual follow-up: send a turn to a docker-profile keeper, assert response JSON contains zero `/Users/...` substrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)