### PR TITLE
docs(rfc): RFC 0005 — Menu / ContextMenu (draft)

### DIFF
--- a/dashboard/design-system/RFC/0005-menu.md
+++ b/dashboard/design-system/RFC/0005-menu.md
@@ -1,0 +1,382 @@
+# RFC 0005 — Menu / ContextMenu
+
+- **Status**: Draft
+- **Author**: design-system stewardship
+- **Created**: 2026-04-29
+- **Depends on**:
+  - RFC 0001 (Headless Foundation — `FocusScope`, `PortalManager`,
+    `IdGenerator`)
+  - RFC 0003 (Roving Tabindex — for menuitem rover semantics)
+- **Blocks**: spec §5.4 InlineSuggestion (uses Menu for accept/reject
+  command palette), v2 Iter 13 Menu consumer
+
+---
+
+## 1. Motivation
+
+The MASC dashboard currently has no shared Menu primitive. Existing
+needs split across three patterns:
+
+1. **Action menu** (button → dropdown of options). Composer toolbar,
+   keeper card overflow, board comment overflow.
+2. **Context menu** (right-click anywhere). File explorer right-click
+   on a tree node, cytoscape graph right-click, log row right-click.
+3. **Submenu** (menu item → nested menu). Action menu's "Move to →
+   board / archive / trash" pattern.
+
+Each consumer reimplements: portal mount, focus trap, click-outside
+dismissal, ESC handling, keyboard navigation, viewport-edge flip,
+submenu hover-delay. The duplication produces:
+
+- **Inconsistent dismissal**: some menus close on outside click, some
+  on outer scroll, some need explicit close button.
+- **Inconsistent keyboard model**: some support typeahead, some don't;
+  ESC behavior varies (close all vs close one level).
+- **Coupling to Command Palette**: the existing palette UI is the only
+  near-Menu primitive, but it's modal-shaped (not anchored to a
+  trigger), so consumers can't reuse it.
+
+This RFC composes three existing headless primitives (FocusScope +
+PortalManager + RovingTabindex from RFC 0003) into a `createMenu`
+controller and a `createContextMenu` thin wrapper that adds
+right-click + viewport positioning.
+
+## 2. Non-Goals
+
+- Provide rendering markup. Consumer owns DOM, including the
+  menuitem chrome.
+- Replace the Command Palette. The palette is a modal full-text search
+  surface; Menu is anchored and discrete.
+- Keyboard shortcut **registration**. The menu surfaces shortcuts via
+  `aria-keyshortcuts` but does not bind global keys — consumer's
+  responsibility.
+- Theming for menu chrome. Tokens live in a follow-up Stage 1.4 PR
+  (`--menu-bg`, `--menuitem-hover-bg`, etc.) — referenced in §6 of
+  this RFC.
+
+## 3. Public API
+
+### 3.1 Core
+
+```ts
+// headless-core/src/menu.ts
+import type { RovingTabindexController } from "./roving-tabindex.js";
+
+export type MenuPlacement =
+  | "bottom-start" | "bottom-end"
+  | "top-start"    | "top-end"
+  | "right-start"  | "right-end"
+  | "left-start"   | "left-end";
+
+export interface MenuItemDescriptor {
+  readonly id: string;
+  readonly label: string;
+  readonly disabled?: boolean;
+  /** Display string (consumer renders); ALSO bound to `aria-keyshortcuts`. */
+  readonly shortcut?: string;
+  /** Nested menu spec. When present, this item is `aria-haspopup="menu"`. */
+  readonly items?: ReadonlyArray<MenuItemDescriptor>;
+  /** Optional separator marker — rendered as `role="separator"`. */
+  readonly type?: "item" | "separator";
+}
+
+export interface MenuOptions {
+  items: ReadonlyArray<MenuItemDescriptor>;
+  /** Initial placement against trigger; runtime flips on viewport overflow. */
+  placement?: MenuPlacement;
+  /** Default: "vertical". Horizontal menus are rare but supported. */
+  orientation?: "vertical" | "horizontal";
+  /** Loop rover at boundaries. Default: true. */
+  loop?: boolean;
+  /** ms before submenu opens on hover. Default: 200. */
+  submenuOpenDelay?: number;
+  /** ms before submenu closes on leave. Default: 300 (forgiving). */
+  submenuCloseDelay?: number;
+  /** Fires when an item is selected (Enter/Space/click). */
+  onSelect?: (itemId: string, path: ReadonlyArray<string>) => void;
+  /** Fires on open / close. */
+  onOpenChange?: (open: boolean) => void;
+}
+
+export interface MenuController {
+  readonly isOpen: boolean;
+  readonly activeId: string | null;
+
+  open(): void;
+  close(): void;
+  toggle(): void;
+
+  /** Programmatic focus / selection. */
+  focus(itemId: string): void;
+  select(itemId: string): void;
+
+  /** ARIA prop bundles. Consumer spreads onto its DOM. */
+  getTriggerProps(): {
+    readonly "aria-haspopup": "menu";
+    readonly "aria-expanded": boolean;
+    readonly "aria-controls": string;
+    readonly onClick: () => void;
+    readonly onKeyDown: (e: KeyboardEvent) => void;
+  };
+
+  getMenuProps(): {
+    readonly id: string;
+    readonly role: "menu";
+    readonly "aria-orientation": "vertical" | "horizontal";
+    readonly tabIndex: -1;
+    readonly onKeyDown: (e: KeyboardEvent) => void;
+  };
+
+  getItemProps(itemId: string): {
+    readonly id: string;
+    readonly role: "menuitem";
+    readonly tabIndex: 0 | -1;
+    readonly "aria-disabled"?: true;
+    readonly "aria-haspopup"?: "menu";
+    readonly "aria-expanded"?: boolean;
+    readonly "aria-keyshortcuts"?: string;
+    readonly "data-active": "" | undefined;
+    readonly onClick: () => void;
+    readonly onMouseEnter: () => void;
+    readonly onMouseLeave: () => void;
+  };
+
+  /** Subscribe to open / activeId / submenu chain changes. */
+  subscribe(listener: (snapshot: MenuSnapshot) => void): () => void;
+
+  // Internal accessors for testing
+  readonly rover: RovingTabindexController;
+}
+
+export interface MenuSnapshot {
+  readonly isOpen: boolean;
+  readonly activeId: string | null;
+  /** Submenu chain: top-level menu first, deepest open last. */
+  readonly openPath: ReadonlyArray<string>;
+}
+
+export function createMenu(opts: MenuOptions): MenuController;
+```
+
+### 3.2 ContextMenu thin wrapper
+
+```ts
+// headless-core/src/context-menu.ts
+export interface ContextMenuOptions extends MenuOptions {
+  /** Optional viewport bounds; default = window inner size. */
+  viewport?: { readonly width: number; readonly height: number };
+}
+
+export interface ContextMenuController extends MenuController {
+  /** Open at pointer coordinates. Auto-flips against viewport edges. */
+  openAt(coords: { x: number; y: number }): void;
+}
+
+export function createContextMenu(opts: ContextMenuOptions): ContextMenuController;
+```
+
+### 3.3 Preact adapter
+
+```ts
+// headless-preact/src/use-menu.ts
+export interface UseMenuArgs extends MenuOptions {
+  /** Trigger ref; required for placement and focus restore. */
+  triggerRef: RefObject<HTMLElement>;
+}
+
+export function useMenu(args: UseMenuArgs): {
+  isOpen: boolean;
+  activeId: string | null;
+  triggerProps: JSX.HTMLAttributes<HTMLElement>;
+  menuProps: JSX.HTMLAttributes<HTMLElement>;
+  getItemProps: (itemId: string) => JSX.HTMLAttributes<HTMLElement>;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+};
+
+// headless-preact/src/use-context-menu.ts
+export function useContextMenu(args: ContextMenuOptions): {
+  /** Bind to the surface that should accept right-click. */
+  surfaceProps: JSX.HTMLAttributes<HTMLElement>;
+  menuProps: JSX.HTMLAttributes<HTMLElement>;
+  getItemProps: (itemId: string) => JSX.HTMLAttributes<HTMLElement>;
+  isOpen: boolean;
+  position: { x: number; y: number } | null;
+};
+```
+
+## 4. Keyboard contract
+
+### 4.1 Trigger
+
+| Key | Effect |
+|---|---|
+| `Enter` / `Space` / `ArrowDown` | open + focus first enabled item |
+| `ArrowUp` | open + focus last enabled item |
+| `Esc` | (closed: no-op) |
+
+### 4.2 Open menu (rover delegates to RFC 0003)
+
+| Key | `vertical` | `horizontal` |
+|---|---|---|
+| `ArrowDown` | next | (no-op) |
+| `ArrowUp`   | prev | (no-op) |
+| `ArrowRight`| open submenu OR (no-op) | next |
+| `ArrowLeft` | close submenu (this level) OR (no-op if root) | prev |
+| `Home` / `End` | first / last enabled | first / last enabled |
+| `Enter` / `Space` | select + close (or open submenu) | same |
+| `Esc` | close menu, focus trigger | same |
+| Printable char | typeahead | typeahead |
+
+`Esc` from a deep submenu closes only the deepest level (focus moves
+to its parent menuitem). Pressing `Esc` again closes the next level
+up, and so on, ending at the trigger.
+
+### 4.3 ContextMenu surface
+
+`ContextMenu` adds:
+
+| Event | Effect |
+|---|---|
+| `contextmenu` (right-click) | `openAt({x, y})`, suppresses native menu |
+| Outside click | close all open menus |
+| Window scroll | close all open menus (anchored coords go stale) |
+
+## 5. Submenu lifecycle
+
+Submenus are **separate `createMenu` instances** chained via the
+`openPath` snapshot. Hover semantics:
+
+- `mouseenter` on `aria-haspopup` item → start `submenuOpenDelay`
+  timer (default 200 ms). Cancel any pending close timers for that
+  branch.
+- `mouseleave` from the haspopup item → start `submenuCloseDelay`
+  timer (default 300 ms). Cancel if user enters the submenu surface
+  before timer fires.
+- `mouseleave` from the open submenu → start close timer.
+
+Hover delays prevent menus from chasing the cursor diagonally between
+parent menuitem and submenu corner. The 200/300 split is forgiving
+on open and even more forgiving on close (W3C ARIA APG menubar
+recommendation).
+
+## 6. Tokens (deferred to follow-up)
+
+Menu chrome tokens (`--menu-bg`, `--menu-border`, `--menuitem-fg`,
+`--menuitem-hover-bg`, `--menuitem-active-bg`,
+`--menuitem-disabled-fg`, `--menu-separator`, `--menu-shortcut-fg`,
+`--menu-shadow`) are not in this RFC — they belong to a Stage 1.4
+follow-up PR after IDE Chrome tokens (PR
+`feature/ds-v2-ide-chrome-tokens`) lands.
+
+In the meantime, consumers wire visible state through `data-active=""`
+(rover position), `data-disabled=""`, `data-haspopup=""`, and Tailwind
+v4 selectors.
+
+## 7. Composition
+
+```
+trigger button
+  │ aria-haspopup=menu  aria-expanded
+  └─[click]─→ MenuController.open()
+              └─ PortalManager.push(layer="dropdown")
+                    └─ FocusScope.activate(menu surface)
+                          └─ RovingTabindex (orientation=vertical)
+                                ├── menuitem A (tabIndex=0 initially)
+                                ├── menuitem B (tabIndex=-1)
+                                ├── menuitem C aria-haspopup=menu
+                                │     └─[hover/Right]─→ child MenuController
+                                └── separator (role=separator)
+```
+
+Outside-click and window-scroll watchers attach when `isOpen` flips
+to `true` and detach on close. PortalManager dropdown layer (z-index
+`--z-dropdown`) keeps menus above sticky chrome but below modal
+overlays.
+
+## 8. Test plan
+
+`headless-core/src/menu.test.ts`:
+
+1. **Open / close round-trip** — `open()` → `isOpen: true`,
+   `aria-expanded: true` on trigger, focus on first enabled item.
+   `close()` → focus returns to trigger.
+2. **Keyboard open** — `Enter` / `Space` / `ArrowDown` from trigger
+   each open. `ArrowUp` opens with last item focused.
+3. **Disabled items skipped** — first focus on open lands on first
+   *enabled* item.
+4. **Esc closes** — closes one level; submenu chain pops one at a time.
+5. **Submenu open delay** — hover on haspopup item → 200 ms → submenu
+   opens. Pre-timer leave cancels.
+6. **Submenu close delay** — leave open submenu → 300 ms → closes.
+   Re-enter cancels.
+7. **Submenu keyboard** — `ArrowRight` on haspopup → submenu opens with
+   first item focused. `ArrowLeft` from open submenu → closes submenu,
+   parent item refocused.
+8. **`Enter` selects + closes** — fires `onSelect(itemId, path)`,
+   closes menu.
+9. **Typeahead** — printable char focuses next item whose label starts
+   with that char (case-insensitive). Multi-char buffer 500 ms.
+10. **Outside click closes** — synthetic mousedown outside surface
+    closes menu. `onOpenChange(false)` fires.
+11. **`aria-keyshortcuts`** — present on items with `shortcut`,
+    matches the display string.
+12. **Separator role** — `type: "separator"` produces `role="separator"`
+    item with no rover stop.
+
+`headless-core/src/context-menu.test.ts`:
+
+13. **Open at coords** — `openAt({x:100,y:100})` positions menu;
+    snapshot includes `position`.
+14. **Viewport flip** — open near right edge → menu placement flips
+    to `*-end`. Same for bottom edge.
+15. **Right-click suppresses native** — `contextmenu` event default
+    is prevented when surface is bound.
+
+`headless-preact/src/use-menu.test.tsx`:
+
+16. **Trigger ref focus restore** — `useMenu` restores focus to
+    `triggerRef.current` on close.
+17. **`isOpen` reactivity** — Preact re-renders on open/close.
+
+`jest-axe` runs against menu, submenu, and context-menu fixtures.
+
+## 9. Migration path
+
+Consumer migrations (separate PRs):
+
+1. **Composer overflow menu** — replaces inline popover.
+2. **Keeper card overflow** — replaces inline absolute-position div.
+3. **Board comment overflow** — same.
+4. **TreeView right-click context menu** — first ContextMenu consumer.
+5. **Cytoscape graph right-click** — second ContextMenu consumer.
+
+## 10. Merge criteria
+
+- [ ] `headless-core/src/menu.ts` + `context-menu.ts` land
+- [ ] All 17 test cases pass under `vitest --run`
+- [ ] `jest-axe` passes on 3 fixtures (menu / submenu / context-menu)
+- [ ] `headless-preact/src/use-menu.ts` + `use-context-menu.ts` land
+- [ ] One Menu consumer migrates as proof-of-pattern (Composer
+      overflow recommended)
+- [ ] CHANGELOG entry under v0.5
+- [ ] No menu chrome tokens leaked into this PR — token PR is separate
+- [ ] RFC 0003 (Roving Tabindex) implementation merged first
+
+## 11. Open questions
+
+1. **Submenu mouse path tolerance** — the spec calls out the
+   "hover-diagonal-tunnel" pattern (Amazon mega-menu style). For now
+   the 200/300 ms delays approximate the effect without geometric
+   tunneling. Confirm whether tunneling is required.
+2. **Keyboard shortcut conflict with FocusScope traps** — when a Menu
+   is inside a Dialog, the Dialog's FocusScope and the Menu's portal
+   layer both consume `Esc`. Proposal: PortalManager top-of-stack
+   wins; `Esc` closes Menu first, then Dialog. Confirm.
+3. **`aria-activedescendant` vs roving** — RFC 0003 uses roving. ARIA
+   APG also permits `aria-activedescendant`. Roving is simpler and
+   matches Tabs/TreeView; sticking with roving here for consistency.
+
+These do not block draft acceptance but must close before the
+implementation PR opens.


### PR DESCRIPTION
## Summary

Drafts the RFC referenced by `~/Downloads/masc-mcp-design-system-spec.md` §3.2.4 / §5.2.4 / §6 but never written. Menu is the headless action-menu / context-menu / submenu primitive that **Composer overflow**, **Keeper card overflow**, **Board comment overflow**, **TreeView right-click**, and **Cytoscape right-click** all reimplement inline today.

## Composition

Menu does not invent a new primitive. It composes:

- **`FocusScope` (RFC 0001)** — modal trap while menu is open
- **`PortalManager` (RFC 0001)** — `dropdown` layer with proper z-index
- **`IdGenerator` (RFC 0001)** — stable `aria-controls` / `aria-labelledby` linkage
- **`RovingTabindex` (RFC 0003)** — menuitem rover with arrow / typeahead

The compose path is the entire point: every Menu defect today comes from one of these four pieces being reimplemented poorly inline.

## Key decisions captured

- **`createMenu(opts)`** for action menus; **`createContextMenu(opts)`** thin wrapper adds `openAt(coords)` + viewport flip.
- **Submenus = separate `createMenu` instances** chained via `openPath` snapshot. 200 ms open delay + 300 ms close delay (forgiving on close — W3C ARIA APG menubar pattern).
- **ARIA**: `aria-haspopup="menu"`, `aria-expanded`, `aria-keyshortcuts` surfaced via `getItemProps`. Separator items render `role="separator"` with no rover stop.
- **`Esc` closes one level** (deep submenu first) and propagates up across multiple presses, ending at the trigger.
- **Outside-click + window-scroll** close all open menus on the chain.
- **Menu chrome tokens deferred to follow-up Stage 1.4 PR** (`--menu-bg`, `--menuitem-hover-bg`, etc.). Consumers wire visible state via `data-active=""` / `data-disabled=""` for now.

## Companion PRs

- #11948 — IDE Chrome tokens (sister token PR; menu tokens follow later)
- #11949 — RFC 0003 Roving Tabindex (Menu **depends on this**)
- #11950 — Two-Tier SSOT correction memo
- #11951(this) — RFC 0005 Menu

## Open questions for review

1. Submenu mouse-tunnel tolerance (Amazon mega-menu style) — required or 200/300 ms delay sufficient.
2. `Esc` precedence between Menu portal layer and an enclosing Dialog `FocusScope`.
3. Roving vs `aria-activedescendant` — sticking with roving for consistency with Tabs/TreeView.

## Out of scope

- Implementation. RFC only. Implementation lands with Composer overflow consumer migration as proof-of-pattern.
- Menu chrome tokens — follow-up Stage 1.4 PR.
- Global keyboard shortcut registration. `aria-keyshortcuts` displays them; binding is consumer's concern.

## Test plan

- [ ] Reviewer confirms decisions §3 (API), §4 (kbd), §5 (submenu), §7 (composition)
- [ ] Open questions §11 closed before implementation PR opens
- [ ] CHANGELOG entry under v0.5 added with implementation PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)