### PR TITLE
fix: coord_worktree.validate_clone_origin_url SSOT (PR #11951 follow-up)

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -180,9 +180,21 @@ let extract_github_org url =
 
 let validate_clone_origin_url ~base_path url =
   let allowed_orgs, denied_repos = load_git_clone_policy ~base_path in
+  let denied_check () =
+    match extract_github_org_repo url with
+    | Some org_repo when List.mem org_repo denied_repos ->
+        Error (Printf.sprintf "Repository '%s' is in the denied list" org_repo)
+    | _ -> Ok ()
+  in
   if allowed_orgs = [] then
-    Error
-      "No allowed orgs configured for git clone (git_clone.allowed_orgs in tool_policy.toml)"
+    (* Empty allowed_orgs = skip org check. Per config/tool_policy.toml,
+       this matches operator intent: the keeper may clone any repo
+       reachable through the operator's gh credential, subject to
+       denied_repos. SSOT alignment with [Tool_code_write.validate_clone_url]
+       (#11951) and [Gh_command_validation.validate_gh_command] which
+       both treat [allowed_orgs = []] as "policy not configured / skip".
+       Follow-up to #11830 — second site that PR #11951 missed. *)
+    denied_check ()
   else
     match extract_github_org url with
     | None ->
@@ -192,11 +204,7 @@ let validate_clone_origin_url ~base_path url =
           (Printf.sprintf
              "GitHub org '%s' not in allowed list: %s. Use the actual GitHub owner from the clone URL; do not infer an org from local workspace path segments."
              org (String.concat ", " allowed_orgs))
-    | Some _ -> (
-        match extract_github_org_repo url with
-        | Some org_repo when List.mem org_repo denied_repos ->
-            Error (Printf.sprintf "Repository '%s' is in the denied list" org_repo)
-        | _ -> Ok ())
+    | Some _ -> denied_check ()
 
 (** Check if directory is a git repository - delegates to Coord_git *)
 let is_git_repo config =


### PR DESCRIPTION
## 배경

**Wiring 누락 발견**. PR #11951 (#11830 fix) 가 \`Tool_code_write.validate_clone_url\` 의 \`allowed_orgs = []\` permissive 처리를 정정했지만, **동일한 패턴이 inline-replicated 된 두 번째 site \`Coord_worktree.validate_clone_origin_url\` 를 sweep 안 함**.

## 누락된 site

\`lib/coord/coord_worktree.ml:181-185\`:

\`\`\`ocaml
let validate_clone_origin_url ~base_path url =
  let allowed_orgs, denied_repos = load_git_clone_policy ~base_path in
  if allowed_orgs = [] then
    Error "No allowed orgs configured for git clone (git_clone.allowed_orgs in tool_policy.toml)"
\`\`\`

\`Tool_code_write.validate_clone_url\` 와 의미 동일. 같은 SSOT (\`config/tool_policy.toml\` \`allowed_orgs\`) 의 해석이 두 site 에 inline 복제됨.

## 영향

caller \`coord_worktree.ml:628 auto_provision_clone\`:

\`\`\`ocaml
match validate_clone_origin_url ~base_path:config.base_path origin_url with
| Error err ->
    Error (IoError (Printf.sprintf "auto_provision_clone_failed: origin %s rejected by clone policy: %s" origin_url err))
| Ok () -> git clone ...
\`\`\`

worktree auto-provision (sandbox 자동 생성) 시 모든 origin clone 이 \`allowed_orgs = []\` (default) 환경에서 silently 차단됨. PR #11951 머지 후 \`tool_code_write\` 경로는 unblock 됐지만 sandbox auto-provision 경로는 여전히 깨진 상태.

## 변경

\`Coord_worktree.validate_clone_origin_url\` 도 PR #11951 와 동일한 형태로 정정:

- \`allowed_orgs = []\` → org check skip, denied_repos 만 검사
- \`denied_check ()\` helper 로 중복 제거
- 코멘트에 SSOT 정렬 (Tool_code_write + Gh_command_validation) 명시

## 검증

\`No allowed orgs configured\` 문자열이 lib/ 에서 **0 건** sweep 완료:

\`\`\`bash
$ rg -n 'No allowed orgs configured' lib/
(no matches)
\`\`\`

## 메모리 패턴

- *SSOT inline copy bypasses concurrent root fix* — 정확히 이 사례
- *AI 페어 상호작용 검증* — 2번째 fix 시 근본 sweep 강제. 본 PR 이 그 sweep

## 참고

- PR #11951 (#11830 1st site fix, merged)
- Issue #11830 / #11710 (원본 tracker — 이번 PR 로 SSOT 완전 정렬)

🤖 Generated with [Claude Code](https://claude.com/claude-code)