### PR TITLE
env_config_snapshot.mli: pin masc_config snapshot boundary (3 entries)

### DIFF
--- a/lib/config/env_config_snapshot.mli
+++ b/lib/config/env_config_snapshot.mli
@@ -1,0 +1,52 @@
+(** Env_config_snapshot — runtime config snapshot for the
+    [masc_config] dashboard tool: per-category entry list
+    + per-entry source provenance.
+
+    External surface (3 entries) — every dotted caller
+    reaches one of these and nothing else:
+    - {!valid_config_category_strings} consumed by
+      [tool_schemas_misc] when generating the
+      [masc_config] tool enum + by
+      [test/test_types].
+    - {!all_categories} consumed by
+      [env_config_introspect] +
+      [test/test_types].
+    - {!to_json} consumed by [env_config] (the
+      facade) + [env_config_introspect].
+
+    Internal helpers stay private at this boundary
+    (~71 internal lets — [entry] /
+    [source_provenance] record types, [entry] /
+    [default_provenance] / [is_sensitive_name]
+    constructors, [category] tuple builder,
+    [server_entries] / [path_entries] / every other
+    per-domain entry list, [read_entry] /
+    [read_with_provenance] / [redact_value] / every
+    JSON sub-renderer). *)
+
+val valid_config_category_strings : string list
+(** Wire forms accepted by the [masc_config] tool's
+    [category] enum.  Mirrored into the OCaml category
+    table inside the .ml so adding a category
+    automatically updates both the parser and the
+    schema's user-visible catalogue (#8493). *)
+
+val all_categories : unit -> (string * Yojson.Safe.t) list
+(** Returns the per-category entry list as
+    [\[(category_name, `List entries)\]] tuples.
+    Computed on demand from the per-domain entry
+    declarations inside the .ml. *)
+
+val to_json :
+  ?server_meta:Yojson.Safe.t ->
+  ?generated_at:string ->
+  ?cat:string ->
+  unit ->
+  Yojson.Safe.t
+(** Renders the full config snapshot envelope.  When
+    [?cat] is provided and matches a known category, the
+    response is narrowed to that single section; an
+    unknown name collapses to an empty
+    [`Assoc \[\]] for the categories field rather than
+    raising.  [?server_meta] / [?generated_at] are
+    threaded into the envelope when present. *)

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -6,5 +6,5 @@
   "godsplit_count": 0,
   "lib_dune_lines": 968,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 11
+  "lib_other_mli_missing": 10
 }


### PR DESCRIPTION
## Summary

`lib/config/env_config_snapshot.ml` (1129 lines) .mli 추가. 3 entries — `masc_config` 대시보드 도구의 config snapshot.

## Surface (3 entries)

\`\`\`ocaml
val valid_config_category_strings : string list
val all_categories : unit -> (string * Yojson.Safe.t) list
val to_json :
  ?server_meta:Yojson.Safe.t ->
  ?generated_at:string ->
  ?cat:string ->
  unit ->
  Yojson.Safe.t
\`\`\`

5 dotted callers — `env_config` (facade), `env_config_introspect`, `tool_schemas_misc`, plus `test_types`. No cascade-include.

## Pre-flight cascade check

74 top-level decls. Pre-flight grep confirmed only 3 externally reachable. False-positive matches (`category` / `to_json` in sister files) were either documentation strings or already counted as dotted access.

## Internal helpers (~71 private)

`entry` / `source_provenance` record types, `entry` / `default_provenance` / `is_sensitive_name` constructors, `category` tuple builder, `server_entries` / `path_entries` / 도메인별 entry 리스트, `read_entry` / `read_with_provenance` / `redact_value` / 각 JSON sub-renderer.

## Ratchet

`lib_other_mli_missing` 11 → 10 baseline lowered.

## Test plan
- [x] `dune build --root . --cache=disabled` clean (1 iteration)
- [x] `bash scripts/ocaml-structure-ratchet.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)