### PR TITLE
docs(rfc): RFC 0015 — Tabs (draft)

### DIFF
--- a/dashboard/design-system/RFC/0015-tabs.md
+++ b/dashboard/design-system/RFC/0015-tabs.md
@@ -1,0 +1,304 @@
+# RFC 0015 — Tabs
+
+- **Status**: Draft
+- **Author**: design-system stewardship
+- **Created**: 2026-04-29
+- **Depends on**:
+  - RFC 0001 (Headless Foundation — `IdGenerator`)
+  - RFC 0003 (Roving Tabindex — `horizontal` orientation, automatic
+    activation supported via `activateOnFocus`)
+- **Consumes**: `--tab-*` tokens (IDE Chrome, #11948).
+- **Blocks**: editor tab strip (Stage 5 IdePlane), Deck mode tabs,
+  keeper inspector tabs, panel switcher tabs.
+
+---
+
+## 1. Motivation
+
+The dashboard has tab-shaped UIs in at least four places, all
+implemented inline:
+
+- **Mode tabs** in the topbar (`Dashboard / Work / Comms / Observe /
+  Cognition / IDE`).
+- **Keeper inspector tabs** (`Activity / Files / Memory / Settings`).
+- **Deck mode tabs** in the cockpit UI Kit (not yet in production).
+- **Settings page section tabs**.
+
+Each binds its own keydown handler, computes its own active index,
+emits its own `aria-selected`. Inconsistencies are visible:
+
+- Some support `Home`/`End`, some don't.
+- "Automatic" activation (`tablist` per W3C — moving the rover
+  immediately activates the tab) is mixed with "manual" activation
+  inconsistently.
+- No standard close-button or drag-reorder behavior.
+- IDE editor tab strip (Stage 5) needs all of those plus overflow.
+
+This RFC defines `createTabs` covering activation modes, close
+buttons, drag-reorder, and overflow scroll. Tab tokens already
+exist (`--tab-bg-active`, `--tab-fg-active`, `--tab-indicator`,
+`--tab-close-hover`) — IDE Chrome PR #11948.
+
+## 2. Non-Goals
+
+- Render markup. Headless. Consumer owns `<ul role="tablist">`,
+  `<li role="tab">`, `<button>` close buttons, drag handles.
+- Persist active tab. Consumer owns persistence (localStorage,
+  routing, etc.).
+- Tab content lazy loading. Consumer renders panels.
+- Multi-row tab wrap. Out of scope; overflow scrolls horizontally.
+
+## 3. Public API
+
+### 3.1 Core
+
+```ts
+// headless-core/src/tabs.ts
+export interface TabDescriptor {
+  readonly id: string;
+  readonly label: string;
+  readonly disabled?: boolean;
+  readonly closeable?: boolean;       // shows × button
+  /** When true, the tab cannot be reordered via drag. */
+  readonly pinned?: boolean;
+}
+
+export type ActivationMode = "automatic" | "manual";
+export type Orientation = "horizontal" | "vertical";
+
+export interface TabsOptions {
+  tabs: ReadonlyArray<TabDescriptor>;
+  activationMode?: ActivationMode;     // default "automatic"
+  orientation?: Orientation;            // default "horizontal"
+  defaultActiveId?: string;
+  onActiveChange?: (id: string) => void;
+  onClose?: (id: string) => void;
+  onReorder?: (ids: ReadonlyArray<string>) => void;
+}
+
+export interface TabsController {
+  readonly activeId: string | null;
+  readonly tabs: ReadonlyArray<TabDescriptor>;
+
+  // Mutations
+  setTabs(tabs: ReadonlyArray<TabDescriptor>): void;
+  activate(id: string): void;
+  close(id: string): void;
+  reorder(ids: ReadonlyArray<string>): void;
+
+  // ARIA prop bundles
+  getTabListProps(): {
+    readonly role: "tablist";
+    readonly "aria-orientation": Orientation;
+    readonly tabIndex: -1;
+    readonly onKeyDown: (e: KeyboardEvent) => void;
+  };
+
+  getTabProps(id: string): {
+    readonly id: string;
+    readonly role: "tab";
+    readonly "aria-selected": boolean;
+    readonly "aria-controls": string;        // panel id
+    readonly "aria-disabled"?: true;
+    readonly tabIndex: 0 | -1;
+    readonly "data-active": "" | undefined;
+    readonly onClick: () => void;
+    readonly onKeyDown: (e: KeyboardEvent) => void;
+  };
+
+  getTabPanelProps(id: string): {
+    readonly id: string;
+    readonly role: "tabpanel";
+    readonly "aria-labelledby": string;       // tab id
+    readonly tabIndex: 0;
+    readonly hidden: boolean;
+  };
+
+  getCloseButtonProps(id: string): {
+    readonly type: "button";
+    readonly "aria-label": string;            // "Close <label>"
+    readonly tabIndex: -1;                    // Tab skips, keep flow on tab
+    readonly onClick: (e: MouseEvent) => void;
+  };
+
+  // Drag reorder (consumer wires HTML5 drag events)
+  handleDragStart(id: string): void;
+  handleDragOver(targetId: string): void;
+  handleDragEnd(): void;
+
+  // Subscriptions
+  subscribe(listener: (state: TabsSnapshot) => void): () => void;
+}
+
+export interface TabsSnapshot {
+  readonly activeId: string | null;
+  readonly tabs: ReadonlyArray<TabDescriptor>;
+  readonly draggingId: string | null;
+}
+
+export function createTabs(opts: TabsOptions): TabsController;
+```
+
+### 3.2 Preact adapter
+
+```ts
+// headless-preact/src/use-tabs.ts
+export function useTabs(opts: TabsOptions): {
+  activeId: string | null;
+  tabs: ReadonlyArray<TabDescriptor>;
+  tabListProps: JSX.HTMLAttributes<HTMLElement>;
+  getTabProps: (id: string) => JSX.HTMLAttributes<HTMLElement>;
+  getTabPanelProps: (id: string) => JSX.HTMLAttributes<HTMLElement>;
+  getCloseButtonProps: (id: string) => JSX.HTMLAttributes<HTMLButtonElement>;
+  activate: (id: string) => void;
+  close: (id: string) => void;
+};
+```
+
+## 4. Activation modes
+
+Per W3C ARIA APG `tablist`:
+
+- **`automatic`**: rover movement (Arrow keys) immediately activates
+  the tab. Used by deck-style content where switching is cheap.
+- **`manual`**: rover moves but tab stays inactive until `Enter` or
+  `Space` selects. Used when activation triggers heavy work
+  (Monaco editor mount, async fetch).
+
+Default `automatic` matches MASC's existing surfaces; editor tabs
+should opt into `manual` because activating means mounting Monaco.
+
+## 5. Keyboard contract
+
+Delegates to RFC 0003 Roving Tabindex (`orientation` matches
+`tablist` `orientation`). Plus tab-specific keys:
+
+| Key | Effect |
+|---|---|
+| `ArrowRight` (horizontal) / `ArrowDown` (vertical) | next |
+| `ArrowLeft` (horizontal) / `ArrowUp` (vertical) | prev |
+| `Home` | first enabled |
+| `End` | last enabled |
+| `Enter` / `Space` (manual mode) | activate focused tab |
+| `Delete` / `Mod+W` (when `closeable`) | close focused tab |
+| typeahead | RFC 0003 |
+
+After close: focus moves to the previous neighbor (or next if no
+previous). If the closed tab was active, the neighbor is also
+activated.
+
+## 6. Close button
+
+`getCloseButtonProps` returns `tabIndex: -1` so Tab traversal goes
+**through the tab itself**, not into the × button. The button is
+mouse-only by default; keyboard close is via `Delete` on the focused
+tab. This matches VS Code and avoids the "Tab Tab Enter" trap.
+
+`onClose` fires after the manager removes the tab from its internal
+list and selects a neighbor. Consumer is then free to unmount the
+panel.
+
+## 7. Drag reorder
+
+HTML5 Drag and Drop is wired by the consumer. The manager tracks
+intent via three handlers:
+
+```
+onDragStart  → manager.handleDragStart(id)
+onDragOver   → manager.handleDragOver(targetId)  // reorders intent
+onDragEnd    → manager.handleDragEnd()           // commits, fires onReorder
+```
+
+Pinned tabs (`pinned: true`) are skipped — `handleDragOver` clamps
+to the rightmost-non-pinned position. Pinned tabs always cluster on
+the left (or top, in vertical orientation).
+
+Visual drag preview is consumer's responsibility — manager tracks
+`draggingId` so consumer can apply `data-dragging=""`.
+
+## 8. Overflow
+
+When `tablist` width < sum of tab widths:
+
+- Tabs render in their natural order with `overflow-x: auto` on the
+  container (consumer CSS).
+- Active tab auto-scrolls into view via `scrollIntoView({ inline:
+  "nearest" })` on activation.
+- Manager exposes `tabs` in DOM order so the consumer can render
+  shadows / fade indicators on either edge (`--tab-overflow-shadow-*`
+  if added in a follow-up tokens PR).
+
+## 9. Test plan
+
+`headless-core/src/tabs.test.ts`:
+
+1. **Activation: automatic** — `ArrowRight` immediately fires
+   `onActiveChange`.
+2. **Activation: manual** — `ArrowRight` moves rover but
+   `onActiveChange` does not fire until `Enter` / `Space`.
+3. **Home / End** — go to first / last enabled.
+4. **Disabled skip** — rover skips disabled; `Home` lands on first
+   enabled.
+5. **Close advances neighbor** — close active id 3 of 5 → id 4
+   becomes active.
+6. **Close last** — close last active → previous becomes active.
+7. **Close all** — `activeId` becomes null after last close.
+8. **`Delete` keyboard close** — fires `onClose` for focused tab.
+9. **Drag reorder** — drag tab 2 over tab 4 → on drag end, order is
+   `[1, 3, 4, 2, 5]`. `onReorder` fires once with new id list.
+10. **Pinned skip** — drag over a pinned target → no reorder, drag
+    end is a no-op for that move.
+11. **`getTabPanelProps.hidden`** — true for non-active panels,
+    false for active.
+12. **`aria-controls` linkage** — tab id ↔ panel id matches.
+13. **Vertical orientation** — `ArrowDown` / `ArrowUp` instead of
+    Left / Right.
+14. **Subscribe / unsubscribe** — listener fires on activate /
+    close / reorder; unsubscribe stops.
+
+`headless-preact/src/use-tabs.test.tsx`:
+
+15. **Hook reactivity** — Preact re-renders on activate / close /
+    reorder.
+16. **`onClick` on tab activates** — fires `onActiveChange`
+    regardless of activation mode.
+
+`jest-axe` against editor-style fixture (5 closeable tabs +
+panels) and a settings-style fixture (3 non-closeable tabs).
+
+## 10. Migration path
+
+Consumer migrations (separate PRs):
+
+1. **Mode tabs** (topbar) — first migration, simplest (no close, no
+   reorder, automatic activation).
+2. **Keeper inspector tabs** — same, automatic activation.
+3. **Editor tab strip** (Stage 5) — manual activation, closeable,
+   reorderable, overflow.
+4. **Deck mode tabs** (cockpit production migration RFC 0013).
+
+## 11. Merge criteria
+
+- [ ] `headless-core/src/tabs.ts` lands
+- [ ] All 14 core + 2 hook tests pass under `vitest --run`
+- [ ] `jest-axe` passes on 2 fixtures
+- [ ] `headless-preact/src/use-tabs.ts` lands
+- [ ] One consumer migrates as proof-of-pattern (Mode tabs
+      recommended — simplest; no close/reorder)
+- [ ] CHANGELOG entry under v0.5
+- [ ] RFC 0003 implementation merged first
+
+## 12. Open questions
+
+1. **Auto-scroll-into-view on activation** — acceptable, or
+   distracting when activation is keyboard-driven? Proposal: yes,
+   always — matches VS Code. Confirm.
+2. **`Delete` vs `Mod+W` for keyboard close** — both? `Mod+W`
+   conflicts with browser tab close; only handle if focus is in
+   tablist. Proposal: bind both, scope to tablist focus. Confirm.
+3. **`--tab-overflow-shadow-*` tokens** — small follow-up PR (2 tokens,
+   left + right edge fade indicators). Defer? Yes — implementation
+   PR can use `linear-gradient` literal until tokens land.
+
+These do not block draft acceptance but must close before the
+implementation PR opens.


### PR DESCRIPTION
## Summary

Drafts the RFC referenced by `~/Downloads/masc-mcp-design-system-spec.md` §3.2.2 / §6.2 but never written. Tabs is the headless tab primitive consolidating today's 4 tab-shaped surfaces — **mode-tabs in topbar**, **keeper-inspector tabs**, **deck-mode tabs**, **settings page tabs** — plus the **Stage 5 editor tab strip**.

## Key decisions captured

- **`createTabs(opts)`** covering activation modes (`automatic` / `manual`), orientation (horizontal / vertical), close, drag-reorder, overflow.
- **W3C ARIA `tablist` + `tab` + `tabpanel`** with `aria-controls` / `aria-labelledby` cross-references.
- **`automatic` activation** matches existing surfaces; **editor tabs opt into `manual`** (Monaco mount is heavy work — defer until Enter/Space).
- **Close button `tabIndex=-1`** so Tab traversal goes through the tab itself (matches VS Code; avoids "Tab Tab Enter" close-button trap). Keyboard close via `Delete` on focused tab + scoped `Mod+W`.
- **Drag reorder** via 3 handlers (`handleDragStart` / `handleDragOver` / `handleDragEnd`). Pinned tabs stay clustered. Visual preview is consumer's concern.
- **Overflow**: container CSS `overflow-x: auto` + active-tab `scrollIntoView({ inline: "nearest" })` on activation.

## Stack context

RFC 0003 (Roving Tabindex) MERGED — rover dependency satisfied.
IDE Chrome tokens (#11948) MERGED — `--tab-*` token surface ready.

## Test plan

- [ ] Reviewer confirms decisions §3 (API), §4 (activation), §5 (kbd), §6 (close), §7 (reorder), §8 (overflow)
- [ ] Open questions §12 closed before implementation PR opens
- [ ] CHANGELOG entry under v0.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)