### PR TITLE
feat(autonomous): Tier W1 — Autonomous_executor (Tool_call → Multimodal artifact)

### DIFF
--- a/lib/autonomous/autonomous_executor.ml
+++ b/lib/autonomous/autonomous_executor.ml
@@ -1,0 +1,106 @@
+(* Autonomous_executor — Cycle 27 / Tier W1.
+   See autonomous_executor.mli for design rationale. *)
+
+module A = Multimodal.Artifact
+module P = Multimodal.Payload
+module Pv = Multimodal.Provenance_stub
+module W = Multimodal.Workspace
+
+type tool_call = {
+  name : string;
+  args : Yojson.Safe.t;
+}
+
+let prefix_of name =
+  match String.index_opt name '_' with
+  | Some i -> Some (String.sub name 0 i)
+  | None -> Some name
+
+let classify_tool name =
+  match prefix_of name with
+  | Some "code" -> Some A.Tag_code
+  | Some "image" -> Some A.Tag_image
+  | Some "audio" -> Some A.Tag_audio
+  | Some "doc" -> Some A.Tag_doc
+  | _ -> None
+
+let payload_of_args args =
+  let lazy_text () = Yojson.Safe.to_string args in
+  P.Lazy_payload lazy_text
+
+let metadata_of_call name args =
+  `Assoc
+    [
+      ("tool_name", `String name);
+      ("args", args);
+    ]
+
+let provenance_for ~now ~created_by =
+  {
+    Pv.origin_artifact_ids = [];
+    created_by;
+    created_at = now;
+  }
+
+let translate tc ~now ~created_by =
+  match classify_tool tc.name with
+  | None -> None
+  | Some Tag_code ->
+      let id = Shared_types.Artifact_id.generate () in
+      let art : A.code A.t =
+        {
+          id;
+          kind = A.Code;
+          payload = payload_of_args tc.args;
+          metadata = metadata_of_call tc.name tc.args;
+          provenance = provenance_for ~now ~created_by;
+        }
+      in
+      Some (A.Any art)
+  | Some Tag_image ->
+      let id = Shared_types.Artifact_id.generate () in
+      let art : A.image A.t =
+        {
+          id;
+          kind = A.Image;
+          payload = payload_of_args tc.args;
+          metadata = metadata_of_call tc.name tc.args;
+          provenance = provenance_for ~now ~created_by;
+        }
+      in
+      Some (A.Any art)
+  | Some Tag_audio ->
+      let id = Shared_types.Artifact_id.generate () in
+      let art : A.audio A.t =
+        {
+          id;
+          kind = A.Audio;
+          payload = payload_of_args tc.args;
+          metadata = metadata_of_call tc.name tc.args;
+          provenance = provenance_for ~now ~created_by;
+        }
+      in
+      Some (A.Any art)
+  | Some Tag_doc ->
+      let id = Shared_types.Artifact_id.generate () in
+      let art : A.doc A.t =
+        {
+          id;
+          kind = A.Doc;
+          payload = payload_of_args tc.args;
+          metadata = metadata_of_call tc.name tc.args;
+          provenance = provenance_for ~now ~created_by;
+        }
+      in
+      Some (A.Any art)
+
+let accumulate ws calls ~now ~created_by =
+  List.fold_left
+    (fun (ws_acc, arts_acc) tc ->
+      match translate tc ~now ~created_by with
+      | None -> (ws_acc, arts_acc)
+      | Some any ->
+          let ws_acc' = W.add ws_acc any in
+          (ws_acc', any :: arts_acc))
+    (ws, []) calls
+  |> fun (ws_final, arts_rev) -> (ws_final, List.rev arts_rev)

--- a/lib/autonomous/autonomous_executor.mli
+++ b/lib/autonomous/autonomous_executor.mli
@@ -1,0 +1,67 @@
+(** Autonomous_executor — Tool_call → Multimodal artifact translator.
+
+    Cycle 27 / Tier W1. Wire-in path that converts the keeper's
+    turn-output Tool_calls into typed
+    {!Multimodal.Artifact.any} values for accumulation in a
+    {!Multimodal.Workspace}.
+
+    {1 Why this module}
+
+    The autonomous loop's [Executing] phase emits Tool_calls
+    (pairs of tool name + JSON args). Without this translator,
+    multimodal artifacts produced by tools like [code_write] or
+    [image_generate] live in the keeper's raw turn log only —
+    invisible to the workspace registry, the dashboard, and any
+    downstream resilience/audit consumers.
+
+    {1 Scope of this PR}
+
+    - Heuristic classifier: tool-name prefix → {!Artifact.kind_tag}
+      (e.g. [code_write] → [Tag_code]).
+    - {!translate}: single tool_call → optional
+      {!Multimodal.Artifact.any}.
+    - {!accumulate}: bulk tool_calls into a workspace, returning
+      the new workspace plus the artifacts inserted.
+
+    {1 Deferred}
+
+    - Real provenance edges from upstream tool_calls — {!translate}
+      currently produces empty [origin_artifact_ids]. Tier W3
+      (multimodal_keeper_bridge) adds provenance hydration.
+    - Lazy / Streaming payload selection — currently always
+      [Lazy_payload]. Future PR may select based on byte size
+      or content-type. *)
+
+type tool_call = {
+  name : string;
+  args : Yojson.Safe.t;
+}
+
+val classify_tool : string -> Multimodal.Artifact.kind_tag option
+(** Heuristic prefix-based classification.
+    [code_*]   → [Some Tag_code]
+    [image_*]  → [Some Tag_image]
+    [audio_*]  → [Some Tag_audio]
+    [doc_*]    → [Some Tag_doc]
+    Other → [None]. *)
+
+val translate :
+  tool_call ->
+  now:float ->
+  created_by:string ->
+  Multimodal.Artifact.any option
+(** Translate one tool_call into an artifact, if its name maps
+    to a known multimodal kind. The artifact's payload field
+    captures the [args] JSON as a [Lazy_payload]; metadata
+    records the tool name. *)
+
+val accumulate :
+  Multimodal.Workspace.t ->
+  tool_call list ->
+  now:float ->
+  created_by:string ->
+  Multimodal.Workspace.t * Multimodal.Artifact.any list
+(** Bulk: process tool_calls in order, inserting each translated
+    artifact into the workspace. Returns the new workspace plus
+    the list of artifacts that were translated and inserted
+    (skipping non-multimodal tool_calls). *)

--- a/lib/autonomous/dune
+++ b/lib/autonomous/dune
@@ -3,6 +3,6 @@
 (library
  (name autonomous)
  (public_name masc_mcp.autonomous)
- (libraries shared_types yojson)
+ (libraries shared_types multimodal yojson)
  (preprocess
   (pps ppx_tla)))

--- a/test/autonomous/dune
+++ b/test/autonomous/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_autonomous_phase test_autonomous_state test_transition test_autonomous_bridge test_autonomous_wirein test_autonomous_stimulus)
- (libraries autonomous shared_types yojson unix))
+ (names test_autonomous_phase test_autonomous_state test_transition test_autonomous_bridge test_autonomous_wirein test_autonomous_stimulus test_autonomous_executor)
+ (libraries autonomous multimodal shared_types yojson unix))

--- a/test/autonomous/test_autonomous_executor.ml
+++ b/test/autonomous/test_autonomous_executor.ml
@@ -1,0 +1,142 @@
+(* Tier W1 — Autonomous_executor tests. *)
+
+module E = Autonomous.Autonomous_executor
+module A = Multimodal.Artifact
+module W = Multimodal.Workspace
+
+let check_bool label b =
+  if not b then failwith (Printf.sprintf "%s: false" label)
+
+let check_int label expected actual =
+  if expected <> actual then
+    failwith
+      (Printf.sprintf "%s: expected %d, got %d" label expected actual)
+
+(* ── classify_tool ──────────────────────────────────────────── *)
+
+let test_classify_code () =
+  check_bool "code_write → Tag_code"
+    (E.classify_tool "code_write" = Some A.Tag_code)
+
+let test_classify_image () =
+  check_bool "image_generate → Tag_image"
+    (E.classify_tool "image_generate" = Some A.Tag_image)
+
+let test_classify_audio () =
+  check_bool "audio_synth → Tag_audio"
+    (E.classify_tool "audio_synth" = Some A.Tag_audio)
+
+let test_classify_doc () =
+  check_bool "doc_compose → Tag_doc"
+    (E.classify_tool "doc_compose" = Some A.Tag_doc)
+
+let test_classify_unknown () =
+  check_bool "shell_exec → None"
+    (E.classify_tool "shell_exec" = None);
+  check_bool "no_underscore → None"
+    (E.classify_tool "ping" = None)
+
+(* ── translate ──────────────────────────────────────────────── *)
+
+let test_translate_code () =
+  let tc : E.tool_call =
+    { name = "code_write"; args = `Assoc [ ("path", `String "x.ml") ] }
+  in
+  match E.translate tc ~now:1.0 ~created_by:"executor" with
+  | None -> failwith "expected Some artifact"
+  | Some (A.Any art) ->
+      check_bool "kind tag = Tag_code"
+        (A.kind_to_tag art.kind = A.Tag_code)
+
+let test_translate_unknown_returns_none () =
+  let tc : E.tool_call =
+    { name = "shell_exec"; args = `Assoc [] }
+  in
+  check_bool "shell_exec → None"
+    (E.translate tc ~now:1.0 ~created_by:"executor" = None)
+
+let test_translate_metadata_carries_tool_name () =
+  let tc : E.tool_call =
+    { name = "image_generate"; args = `Assoc [] }
+  in
+  match E.translate tc ~now:2.0 ~created_by:"executor" with
+  | Some (A.Any art) -> (
+      match art.metadata with
+      | `Assoc kv ->
+          check_bool "tool_name field present"
+            (List.mem_assoc "tool_name" kv);
+          let tn = List.assoc "tool_name" kv in
+          check_bool "tool_name = image_generate"
+            (tn = `String "image_generate")
+      | _ -> failwith "metadata not object")
+  | None -> failwith "expected Some"
+
+(* ── accumulate ─────────────────────────────────────────────── *)
+
+let test_accumulate_mixed () =
+  let calls : E.tool_call list =
+    [
+      { name = "code_write"; args = `Null };
+      { name = "shell_exec"; args = `Null };
+      { name = "image_generate"; args = `Null };
+      { name = "audio_synth"; args = `Null };
+      { name = "doc_compose"; args = `Null };
+      { name = "ping"; args = `Null };
+    ]
+  in
+  let ws0 = W.empty in
+  let ws, arts =
+    E.accumulate ws0 calls ~now:1.0 ~created_by:"executor"
+  in
+  check_int "4 multimodal artifacts produced" 4 (List.length arts);
+  check_int "workspace size = 4" 4 (W.size ws)
+
+let test_accumulate_empty () =
+  let ws0 = W.empty in
+  let ws, arts = E.accumulate ws0 [] ~now:1.0 ~created_by:"executor" in
+  check_int "empty list → 0 artifacts" 0 (List.length arts);
+  check_int "workspace empty" 0 (W.size ws)
+
+let test_accumulate_only_unknown () =
+  let calls : E.tool_call list =
+    [
+      { name = "shell_exec"; args = `Null };
+      { name = "ping"; args = `Null };
+    ]
+  in
+  let ws, arts =
+    E.accumulate W.empty calls ~now:1.0 ~created_by:"executor"
+  in
+  check_int "no multimodal calls → 0 artifacts" 0
+    (List.length arts);
+  check_int "workspace empty" 0 (W.size ws)
+
+(* ── Driver ─────────────────────────────────────────────────── *)
+
+let () =
+  let cases =
+    [
+      ("classify_code", test_classify_code);
+      ("classify_image", test_classify_image);
+      ("classify_audio", test_classify_audio);
+      ("classify_doc", test_classify_doc);
+      ("classify_unknown", test_classify_unknown);
+      ("translate_code", test_translate_code);
+      ( "translate_unknown_returns_none",
+        test_translate_unknown_returns_none );
+      ( "translate_metadata_carries_tool_name",
+        test_translate_metadata_carries_tool_name );
+      ("accumulate_mixed", test_accumulate_mixed);
+      ("accumulate_empty", test_accumulate_empty);
+      ("accumulate_only_unknown", test_accumulate_only_unknown);
+    ]
+  in
+  List.iter
+    (fun (name, f) ->
+      try f ()
+      with e ->
+        Printf.printf "FAIL %s: %s\n" name (Printexc.to_string e);
+        exit 1)
+    cases;
+  Printf.printf "test_autonomous_executor: %d cases OK\n"
+    (List.length cases)


### PR DESCRIPTION
Cycle 27 first wire-in. Heuristic prefix-based classification of tool_calls into Multimodal artifacts.

## Files
- `lib/autonomous/autonomous_executor.{mli,ml}` (NEW, ~150 LoC)
- `lib/autonomous/dune`: + multimodal lib
- `test/autonomous/test_autonomous_executor.ml`: 11 assertions

## Verification
- `dune build --root . lib/autonomous test/autonomous` — GREEN
- `dune runtest` — 11 new + 6 existing GREEN, 0 regression
- file-disjoint with W2/W3, all open PRs

## Plan reference
§2.2 W1 wire-in chain. lib/keeper integration deferred to follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
