### PR TITLE
fix(test): align gh sandbox-fallback test with PR #11679 (#11710 B)

### DIFF
--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -524,13 +524,20 @@ done\n\
 printf 'docker-gh-ok workdir=%s cmd=%s\\n' \"$workdir\" \"$*\"\n"
 
 let test_keeper_shell_gh_without_current_task_uses_sandbox_context () =
-  with_repo_context_test_env @@ fun ~base:_ ~config ~repo_dir ->
+  with_repo_context_test_env @@ fun ~base:_ ~config ~repo_dir:_ ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   let meta = make_meta ~sandbox_profile:Keeper_types.Docker () in
   let factory = Keeper_sandbox_factory.create ~config ~meta () in
   Fun.protect
     ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
   @@ fun () ->
+  (* PR #11679 (sandbox factory closure) 이후 path validation 이
+     docker image 검사보다 먼저 실행됨. test 의 의도(`docker image
+     미설정 시 sandbox context 로 fallback`) 를 보존하려면 cwd 를
+     빈 문자열로 두어 [resolve_keeper_shell_read_cwd] 가
+     [keeper_default_read_root] 로 fallback 하게 한다.  외부
+     fixture path([base]/repo) 를 그대로 넘기면 path_outside_sandbox
+     로 cut 되어 docker image 검사에 도달 못 함.  #11710 follow-up. *)
   let raw =
     Keeper_exec_shell.handle_keeper_shell
       ~turn_sandbox_factory:(Some factory)
@@ -539,7 +546,7 @@ let test_keeper_shell_gh_without_current_task_uses_sandbox_context () =
         (`Assoc
           [
             ("op", `String "gh");
-            ("cwd", `String repo_dir);
+            ("cwd", `String "");
             ("cmd", `String "pr list --repo example/project");
           ])
   in
@@ -549,8 +556,6 @@ let test_keeper_shell_gh_without_current_task_uses_sandbox_context () =
     (json |> member "ok" |> to_bool);
   Alcotest.(check string) "sandbox task marker" "(sandbox)"
     (json |> member "task_id" |> to_string);
-  Alcotest.(check string) "cwd preserved" repo_dir
-    (json |> member "cwd" |> to_string);
   Alcotest.(check bool) "repo omitted when sandbox fallback has none" true
     (json |> member "repo" = `Null);
   Alcotest.(check string) "docker image error surfaced"


### PR DESCRIPTION
## 배경

PR #11679 (turn_sandbox_runtime factory closure) 가 sandbox path validation 을 docker image 검사보다 먼저 실행되도록 변경. 기존 `test_keeper_shell_gh_without_current_task_uses_sandbox_context` 는 `cwd: repo_dir` (= `base/repo`, sandbox 외부) 로 호출 후 docker route 가 발화한다고 expect 했지만, PR #11679 이후 `resolve_keeper_shell_read_cwd` 가 `path_outside_sandbox` 로 cut 함.

## 변경

`cwd: repo_dir` → `cwd: ""` (빈 문자열).

`Keeper_exec_shell.resolve_keeper_shell_read_cwd` (line 407) 이 `raw_cwd = ""` 일 때 `keeper_default_read_root ~config ~meta` 로 fallback. 이 root 는 sandbox 안 path 라 path validation 통과 → docker image 검사로 도달 → "image not configured" error 가 surface.

test name (`..._uses_sandbox_context`) 의도와 정확히 일치. `cwd preserved` assertion 만 drop (resolved default root 는 implementation detail, 다른 assertion 으로 cover).

## 영향

#11710 잔여 4건 중 마지막 1건 (B 케이스) close. PR #11829 + #11951 + 본 PR 로 9건 전체 정리.

## 참고

- Issue #11710 (원본 tracker)
- PR #11679 (sandbox factory closure, 의도)
- PR #11829, #11951 (1-3 + 5-9 fix 누적)
