### PR TITLE
feat(multimodal): Tier W3 — Multimodal_keeper_bridge raw → typed hydration (Cycle 27)

### DIFF
--- a/lib/multimodal/multimodal_keeper_bridge.ml
+++ b/lib/multimodal/multimodal_keeper_bridge.ml
@@ -1,0 +1,119 @@
+(* Multimodal_keeper_bridge — Cycle 27 / Tier W3.
+   See multimodal_keeper_bridge.mli for design rationale. *)
+
+module A = Artifact
+
+type raw_artifact = {
+  id : string;
+  kind_hint : string;
+  payload_json : Yojson.Safe.t;
+  metadata : Yojson.Safe.t;
+}
+
+let parse_kind_hint = function
+  | "code" -> Some A.Tag_code
+  | "image" -> Some A.Tag_image
+  | "audio" -> Some A.Tag_audio
+  | "doc" -> Some A.Tag_doc
+  | _ -> None
+
+let resolve_id raw =
+  match Shared_types.Artifact_id.of_string raw.id with
+  | Ok aid -> (aid, raw.metadata)
+  | Error _ ->
+      let fresh = Shared_types.Artifact_id.generate () in
+      let extra =
+        `Assoc
+          [
+            ("original_external_id", `String raw.id);
+            ("regenerated_reason", `String "malformed external id");
+          ]
+      in
+      let merged_metadata =
+        match raw.metadata with
+        | `Assoc kv -> `Assoc (kv @ [ ("hydration_note", extra) ])
+        | other ->
+            `Assoc
+              [
+                ("metadata_original", other);
+                ("hydration_note", extra);
+              ]
+      in
+      (fresh, merged_metadata)
+
+let payload_of_json json =
+  Payload.Lazy_payload (fun () -> Yojson.Safe.to_string json)
+
+let make_provenance ~origin_artifact_ids ~created_by ~now =
+  {
+    Provenance_stub.origin_artifact_ids;
+    created_by;
+    created_at = now;
+  }
+
+let hydrate_one raw ~now ~created_by ~origin_artifact_ids =
+  match parse_kind_hint raw.kind_hint with
+  | None -> None
+  | Some Tag_code ->
+      let id, metadata = resolve_id raw in
+      let art : A.code A.t =
+        {
+          id;
+          kind = A.Code;
+          payload = payload_of_json raw.payload_json;
+          metadata;
+          provenance =
+            make_provenance ~origin_artifact_ids ~created_by ~now;
+        }
+      in
+      Some (A.Any art)
+  | Some Tag_image ->
+      let id, metadata = resolve_id raw in
+      let art : A.image A.t =
+        {
+          id;
+          kind = A.Image;
+          payload = payload_of_json raw.payload_json;
+          metadata;
+          provenance =
+            make_provenance ~origin_artifact_ids ~created_by ~now;
+        }
+      in
+      Some (A.Any art)
+  | Some Tag_audio ->
+      let id, metadata = resolve_id raw in
+      let art : A.audio A.t =
+        {
+          id;
+          kind = A.Audio;
+          payload = payload_of_json raw.payload_json;
+          metadata;
+          provenance =
+            make_provenance ~origin_artifact_ids ~created_by ~now;
+        }
+      in
+      Some (A.Any art)
+  | Some Tag_doc ->
+      let id, metadata = resolve_id raw in
+      let art : A.doc A.t =
+        {
+          id;
+          kind = A.Doc;
+          payload = payload_of_json raw.payload_json;
+          metadata;
+          provenance =
+            make_provenance ~origin_artifact_ids ~created_by ~now;
+        }
+      in
+      Some (A.Any art)
+
+let hydrate_batch raws ~now ~created_by =
+  List.filter_map
+    (fun raw ->
+      hydrate_one raw ~now ~created_by ~origin_artifact_ids:[])
+    raws
+
+let hydrate_with_workspace ws raws ~now ~created_by =
+  let arts = hydrate_batch raws ~now ~created_by in
+  let ws' = List.fold_left Workspace.add ws arts in
+  (ws', arts)

--- a/lib/multimodal/multimodal_keeper_bridge.mli
+++ b/lib/multimodal/multimodal_keeper_bridge.mli
@@ -1,0 +1,85 @@
+(** Multimodal_keeper_bridge — typed hydration of raw artifact JSON.
+
+    Cycle 27 / Tier W3 (B9 follow-up).
+
+    {1 What this module is}
+
+    A pure function [raw_artifact → Multimodal.Artifact.any] that
+    takes a JSON-shaped representation of an artifact (as the
+    keeper or any external producer might emit) and converts it
+    into a typed multimodal artifact. The [kind_hint] field
+    discriminates Code/Image/Audio/Doc; unknown hints yield
+    [None].
+
+    {1 Why this module}
+
+    Tier B9 ({!Multimodal_hydrator}) provides a callback-based
+    DAG builder. This module provides the {b other half}: an
+    actual conversion from raw JSON to typed artifact. Together
+    they form the keeper integration seam — the keeper's
+    [keeper_artifact_hydrator] yields raw JSON via callback,
+    [hydrate_one] converts each entry, and the caller stitches
+    them into a [Workspace] via [hydrate_with_workspace].
+
+    {1 RFC-0002 compliance}
+
+    This module does NOT import [lib/keeper] — keeping the
+    multimodal sub-library independent of the keeper. The
+    keeper-side adapter (which calls [keeper_artifact_hydrator]
+    and feeds [raw_artifact] values into [hydrate_batch]) lives
+    in [lib/keeper] in a follow-up PR.
+
+    {1 Scope of this PR}
+
+    - {!raw_artifact}: input record carrying an opaque id, a
+      [kind_hint] string, payload JSON, and metadata JSON.
+    - {!hydrate_one}: single conversion with provenance hookup.
+    - {!hydrate_batch}: bulk conversion, skipping unknown hints.
+    - {!hydrate_with_workspace}: bulk + Workspace insertion. *)
+
+type raw_artifact = {
+  id : string;
+      (** External id (UUID v7 string). If malformed, a fresh id
+          is generated and the original recorded in metadata. *)
+  kind_hint : string;
+      (** ["code"], ["image"], ["audio"], ["doc"], or any other
+          string. Unknown hints make the entry skip-eligible. *)
+  payload_json : Yojson.Safe.t;
+      (** Wrapped as a [Payload.Lazy_payload] in the produced
+          artifact (lazy so callers do not pay serialization
+          cost upfront). *)
+  metadata : Yojson.Safe.t;
+}
+
+val parse_kind_hint : string -> Artifact.kind_tag option
+(** Map [kind_hint] strings to {!Artifact.kind_tag}. Lowercase,
+    exact match. *)
+
+val hydrate_one :
+  raw_artifact ->
+  now:float ->
+  created_by:string ->
+  origin_artifact_ids:Shared_types.Artifact_id.t list ->
+  Artifact.any option
+(** Convert one raw_artifact. Returns [None] when [kind_hint]
+    is unknown. The artifact's payload is wrapped lazily so
+    consumers that never read the payload pay no overhead. *)
+
+val hydrate_batch :
+  raw_artifact list ->
+  now:float ->
+  created_by:string ->
+  Artifact.any list
+(** Bulk hydrate. Each entry's [origin_artifact_ids] is empty —
+    callers that need provenance edges should use
+    {!hydrate_with_workspace} or call {!hydrate_one} directly. *)
+
+val hydrate_with_workspace :
+  Workspace.t ->
+  raw_artifact list ->
+  now:float ->
+  created_by:string ->
+  Workspace.t * Artifact.any list
+(** Hydrate a batch and insert each artifact into [ws]. The
+    workspace is returned together with the list of artifacts
+    actually inserted (skipping unknown hints). *)

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id)
- (libraries multimodal shared_types yojson))
+ (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id test_multimodal_keeper_bridge)
+ (libraries multimodal shared_types yojson str))

--- a/test/multimodal/test_multimodal_keeper_bridge.ml
+++ b/test/multimodal/test_multimodal_keeper_bridge.ml
@@ -1,0 +1,184 @@
+(* Tier W3 — Multimodal_keeper_bridge tests. *)
+
+module B = Multimodal.Multimodal_keeper_bridge
+module A = Multimodal.Artifact
+module W = Multimodal.Workspace
+module Aid = Shared_types.Artifact_id
+
+let check_bool label b =
+  if not b then failwith (Printf.sprintf "%s: false" label)
+
+let check_int label expected actual =
+  if expected <> actual then
+    failwith
+      (Printf.sprintf "%s: expected %d, got %d" label expected actual)
+
+(* ── parse_kind_hint ────────────────────────────────────────── *)
+
+let test_parse_known_hints () =
+  check_bool "code" (B.parse_kind_hint "code" = Some A.Tag_code);
+  check_bool "image" (B.parse_kind_hint "image" = Some A.Tag_image);
+  check_bool "audio" (B.parse_kind_hint "audio" = Some A.Tag_audio);
+  check_bool "doc" (B.parse_kind_hint "doc" = Some A.Tag_doc)
+
+let test_parse_unknown_hint () =
+  check_bool "unknown" (B.parse_kind_hint "video" = None);
+  check_bool "empty" (B.parse_kind_hint "" = None);
+  check_bool "uppercase" (B.parse_kind_hint "Code" = None)
+
+(* ── hydrate_one ────────────────────────────────────────────── *)
+
+let make_raw kind_hint =
+  let valid_id = Aid.to_string (Aid.generate ()) in
+  {
+    B.id = valid_id;
+    kind_hint;
+    payload_json = `Assoc [ ("body", `String "x") ];
+    metadata = `Assoc [ ("source", `String "test") ];
+  }
+
+let test_hydrate_one_known () =
+  let raw = make_raw "code" in
+  match
+    B.hydrate_one raw ~now:1.0 ~created_by:"test"
+      ~origin_artifact_ids:[]
+  with
+  | None -> failwith "expected Some artifact"
+  | Some (A.Any art) ->
+      check_bool "kind = Tag_code"
+        (A.kind_to_tag art.kind = A.Tag_code)
+
+let test_hydrate_one_unknown () =
+  let raw = make_raw "video" in
+  check_bool "unknown → None"
+    (B.hydrate_one raw ~now:1.0 ~created_by:"test"
+       ~origin_artifact_ids:[]
+    = None)
+
+let test_hydrate_one_malformed_id () =
+  let raw =
+    { (make_raw "image") with id = "not-a-uuid" }
+  in
+  match
+    B.hydrate_one raw ~now:1.0 ~created_by:"test"
+      ~origin_artifact_ids:[]
+  with
+  | None -> failwith "malformed id should still hydrate"
+  | Some (A.Any art) ->
+      (* metadata should record original id *)
+      let md_str = Yojson.Safe.to_string art.metadata in
+      check_bool "metadata records original id"
+        (String.length md_str > 0
+        &&
+        let exists =
+          try
+            let _ = Str.search_forward
+              (Str.regexp_string "original_external_id") md_str 0
+            in
+            true
+          with Not_found -> false
+        in
+        exists)
+
+let test_hydrate_one_provenance () =
+  let parent = Aid.generate () in
+  let raw = make_raw "image" in
+  match
+    B.hydrate_one raw ~now:5.0 ~created_by:"executor"
+      ~origin_artifact_ids:[ parent ]
+  with
+  | None -> failwith "expected hydrate"
+  | Some (A.Any art) ->
+      check_bool "1 origin"
+        (List.length art.provenance.origin_artifact_ids = 1);
+      check_bool "created_by carries through"
+        (String.equal art.provenance.created_by "executor");
+      check_bool "created_at = 5.0"
+        (Float.equal art.provenance.created_at 5.0)
+
+(* ── hydrate_batch ──────────────────────────────────────────── *)
+
+let test_hydrate_batch_skips_unknown () =
+  let raws =
+    [
+      make_raw "code";
+      make_raw "video"; (* skipped *)
+      make_raw "image";
+      make_raw "binary"; (* skipped *)
+      make_raw "audio";
+    ]
+  in
+  let arts = B.hydrate_batch raws ~now:1.0 ~created_by:"test" in
+  check_int "3 known kinds → 3 artifacts" 3 (List.length arts)
+
+let test_hydrate_batch_empty () =
+  let arts = B.hydrate_batch [] ~now:1.0 ~created_by:"test" in
+  check_int "empty → 0" 0 (List.length arts)
+
+(* ── hydrate_with_workspace ─────────────────────────────────── *)
+
+let test_hydrate_with_workspace () =
+  let raws =
+    [
+      make_raw "code";
+      make_raw "image";
+      make_raw "video"; (* skipped *)
+    ]
+  in
+  let ws, arts =
+    B.hydrate_with_workspace W.empty raws ~now:1.0
+      ~created_by:"test"
+  in
+  check_int "2 artifacts inserted" 2 (List.length arts);
+  check_int "workspace size = 2" 2 (W.size ws)
+
+let test_hydrate_preserves_existing_workspace () =
+  let pre_aid = Aid.generate () in
+  let pre_art : A.code A.t =
+    {
+      id = pre_aid;
+      kind = A.Code;
+      payload = Multimodal.Payload.Lazy_payload (fun () -> "x");
+      metadata = `Null;
+      provenance =
+        {
+          origin_artifact_ids = [];
+          created_by = "pre";
+          created_at = 0.0;
+        };
+    }
+  in
+  let ws0 = W.add W.empty (A.Any pre_art) in
+  let ws, _ =
+    B.hydrate_with_workspace ws0 [ make_raw "image" ] ~now:1.0
+      ~created_by:"test"
+  in
+  check_int "size 2 (pre + new)" 2 (W.size ws)
+
+(* ── Driver ─────────────────────────────────────────────────── *)
+
+let () =
+  let cases =
+    [
+      ("parse_known_hints", test_parse_known_hints);
+      ("parse_unknown_hint", test_parse_unknown_hint);
+      ("hydrate_one_known", test_hydrate_one_known);
+      ("hydrate_one_unknown", test_hydrate_one_unknown);
+      ("hydrate_one_malformed_id", test_hydrate_one_malformed_id);
+      ("hydrate_one_provenance", test_hydrate_one_provenance);
+      ("hydrate_batch_skips_unknown", test_hydrate_batch_skips_unknown);
+      ("hydrate_batch_empty", test_hydrate_batch_empty);
+      ("hydrate_with_workspace", test_hydrate_with_workspace);
+      ( "hydrate_preserves_existing_workspace",
+        test_hydrate_preserves_existing_workspace );
+    ]
+  in
+  List.iter
+    (fun (name, f) ->
+      try f ()
+      with e ->
+        Printf.printf "FAIL %s: %s\n" name (Printexc.to_string e);
+        exit 1)
+    cases;
+  Printf.printf "test_multimodal_keeper_bridge: %d cases OK\n"
+    (List.length cases)


### PR DESCRIPTION
Cycle 27 / Tier W3 (B9 follow-up). Pure function `raw_artifact → Multimodal.Artifact.any`. Pairs with B9's callback DAG builder to form the keeper integration seam.

## Files
- `lib/multimodal/multimodal_keeper_bridge.{mli,ml}` (NEW, ~150 LoC)
- `test/multimodal/test_multimodal_keeper_bridge.ml`: 10 assertions
- `test/multimodal/dune`: + test name + str lib

## Verification
- `dune build --root . lib/multimodal test/multimodal` — GREEN
- `dune runtest` — 10 new + 5 existing GREEN, 0 regression
- file-disjoint with W1, W2, all open PRs

## RFC-0002 compliance

No lib/keeper import. Multimodal sub-library remains independent. Keeper-side adapter (calls keeper_artifact_hydrator + feeds via callback) lands in lib/keeper integration follow-up PR.

## Plan reference
§2.2 W3 wire-in chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
