### PR TITLE
docs(start): refresh stale GC comment to point at runtime bootstrap SSOT

### DIFF
--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -6,9 +6,18 @@
 
 set -e
 
-# OCaml GC: use defaults. Large minor heap (s=4194304) caused 10GB+ RSS
-# because Eio fibers share the domain heap and 360 tools + 12 keepers
-# amplify allocation pressure. The default 256KB minor heap is sufficient.
+# OCaml GC tuning is applied programmatically in
+# lib/server/server_runtime_bootstrap.ml (minor_heap=16MB / space_overhead=200 /
+# max_overhead=500), only when OCAMLRUNPARAM is unset.
+#
+# Historical context: an earlier 4MB minor heap (OCAMLRUNPARAM=s=4194304)
+# produced 10GB+ RSS under shared-fiber workloads with many tools/keepers. A
+# 2026-04 root-cause analysis traced the symptom to MADV_FREE page faults
+# during aggressive major GC slices on macOS, which blocked the Eio event
+# loop. The current settings reduce major GC frequency to absorb bursty
+# dashboard allocations without thrashing — they do not shrink the minor heap.
+#
+# To override at launch, set OCAMLRUNPARAM before invoking this script.
 
 # Optional: load OPAM environment if available (must never be fatal for MCP startup)
 if command -v opam >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Refresh the `start-masc-mcp.sh` GC comment that was 10 days stale (2026-03-24) and misleadingly contradicted the actual runtime decision in `lib/server/server_runtime_bootstrap.ml:259-277` (2026-04-03/04).
- No code changes; comment only (-3 / +12 lines).

## Why
`git blame` shows the bootstrap module's GC tuning landed on 2026-04-03/04 (commits `a8458cb1b4d` / `a84e4a51562`) with `minor_heap=16MB` and `space_overhead=200`, applied only when `OCAMLRUNPARAM` is unset. The script-level comment from 2026-03-24 still warned against large minor heaps based on the pre-MADV-FREE diagnosis, which now misleads the next reader who sees the script comment but not the runtime tuning.

## Changes
The stale "use defaults" comment is replaced with a description that:
- Names the SSOT module (`lib/server/server_runtime_bootstrap.ml`) so readers can find the live decision.
- Preserves the historical context (4MB minor heap caused 10GB+ RSS pre-MADV-FREE diagnosis) so future operators understand why the trade-off looks the way it does.
- Explains the current trade-off (reduce major GC frequency to absorb bursty 2GB+ dashboard allocations, not shrink minor heap).
- Notes that operators can override via `OCAMLRUNPARAM`.

## Test plan
- [x] Comment-only change, no behavior delta.
- [ ] Reviewers verify the wording matches `lib/server/server_runtime_bootstrap.ml:259-277` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)