### PR TITLE
feat(server): Tier D1 — Multimodal dashboard HTTP surface (Cycle 27)

### DIFF
--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -20,6 +20,7 @@ let make_routes ~port ~host ~sw ~clock =
   |> Server_routes_http_routes_attribution.add_routes
   |> Server_routes_http_routes_activity.add_routes ~sw ~clock
   |> Server_routes_http_routes_artifacts.add_routes
+  |> Server_routes_http_routes_multimodal.add_routes
   |> Server_routes_http_routes_legendary_bash.add_routes
   |> Server_routes_http_routes_channel_gate.add_routes ~sw ~clock
   |> Server_routes_http_routes_sidecar.add_routes ~sw ~clock

--- a/lib/server/server_routes_http_routes_multimodal.ml
+++ b/lib/server/server_routes_http_routes_multimodal.ml
@@ -1,0 +1,130 @@
+(* Multimodal dashboard HTTP surface — Cycle 27 / Tier D1.
+   See server_routes_http_routes_multimodal.mli for design. *)
+
+open Server_utils
+open Server_auth
+module Http = Http_server_eio
+module W = Multimodal.Workspace
+module A = Multimodal.Artifact
+module Aid = Shared_types.Artifact_id
+
+let workspace_getter : (unit -> W.t) ref = ref (fun () -> W.empty)
+
+let bind_workspace_getter f = workspace_getter := f
+
+let list_response () =
+  let ws = !workspace_getter () in
+  let arts = W.all ws in
+  `Assoc
+    [
+      ("count", `Int (List.length arts));
+      ("artifacts", `List (List.map A.any_to_json arts));
+    ]
+
+let parse_id id_str = Aid.of_string id_str
+
+let artifact_response ~id_str =
+  let ws = !workspace_getter () in
+  match parse_id id_str with
+  | Error e ->
+      ( `Assoc
+          [
+            ("error", `String "invalid id");
+            ("reason", `String e);
+            ("id", `String id_str);
+          ],
+        `Bad_request )
+  | Ok aid -> (
+      match W.find_by_id ws aid with
+      | None ->
+          ( `Assoc
+              [
+                ("error", `String "not found");
+                ("id", `String id_str);
+              ],
+            `Not_found )
+      | Some any -> (A.any_to_json any, `OK))
+
+let aid_list_to_json lst =
+  `List (List.map (fun a -> `String (Aid.to_string a)) lst)
+
+let provenance_response ~id_str =
+  let ws = !workspace_getter () in
+  match parse_id id_str with
+  | Error e ->
+      ( `Assoc
+          [
+            ("error", `String "invalid id");
+            ("reason", `String e);
+            ("id", `String id_str);
+          ],
+        `Bad_request )
+  | Ok aid ->
+      let origins = W.origins_of ws aid in
+      let descendants = W.descendants_of ws aid in
+      ( `Assoc
+          [
+            ("id", `String id_str);
+            ("origins", aid_list_to_json origins);
+            ("descendants", aid_list_to_json descendants);
+          ],
+        `OK )
+
+let add_routes router =
+  router
+  |> Http.Router.prefix_get "/api/v1/multimodal/list"
+       (fun request reqd ->
+         with_public_read
+           (fun _state _req reqd ->
+             let json = list_response () in
+             respond_public_read_json ~status:`OK request reqd
+               (Yojson.Safe.to_string json))
+           request reqd)
+  |> Http.Router.prefix_get "/api/v1/multimodal/get/"
+       (fun request reqd ->
+         with_public_read
+           (fun _state _req reqd ->
+             let path = Http.Request.path request in
+             match
+               extract_path_param
+                 ~prefix:"/api/v1/multimodal/get/" path
+             with
+             | None ->
+                 respond_public_read_json ~status:`Bad_request
+                   request reqd
+                   (Yojson.Safe.to_string
+                      (`Assoc
+                        [
+                          ("error", `String "id required");
+                        ]))
+             | Some id_str ->
+                 let json, status =
+                   artifact_response ~id_str
+                 in
+                 respond_public_read_json ~status request reqd
+                   (Yojson.Safe.to_string json))
+           request reqd)
+  |> Http.Router.prefix_get "/api/v1/multimodal/provenance/"
+       (fun request reqd ->
+         with_public_read
+           (fun _state _req reqd ->
+             let path = Http.Request.path request in
+             match
+               extract_path_param
+                 ~prefix:"/api/v1/multimodal/provenance/" path
+             with
+             | None ->
+                 respond_public_read_json ~status:`Bad_request
+                   request reqd
+                   (Yojson.Safe.to_string
+                      (`Assoc
+                        [
+                          ("error", `String "id required");
+                        ]))
+             | Some id_str ->
+                 let json, status =
+                   provenance_response ~id_str
+                 in
+                 respond_public_read_json ~status request reqd
+                   (Yojson.Safe.to_string json))
+           request reqd)

--- a/lib/server/server_routes_http_routes_multimodal.mli
+++ b/lib/server/server_routes_http_routes_multimodal.mli
@@ -1,0 +1,56 @@
+(** Multimodal artifact dashboard HTTP surface.
+
+    Cycle 27 / Tier D1. Operator-facing read-only view over the
+    multimodal workspace.
+
+    {1 Routes}
+
+    {v
+      GET /api/v1/multimodal/list                — all artifacts
+      GET /api/v1/multimodal/get/<id>            — single artifact
+      GET /api/v1/multimodal/provenance/<id>     — DAG neighbors
+    v}
+
+    {1 Workspace source}
+
+    The handler reads the live workspace via a getter callback
+    registered through {!bind_workspace_getter}. Until the keeper
+    integration follow-up lands, the default getter returns
+    [Multimodal.Workspace.empty] — endpoints respond with empty
+    lists, but the surface is exposed.
+
+    {1 Why a separate module}
+
+    [Server_routes_http_routes_artifacts] (existing) handles the
+    Tool blob store under [/api/v1/artifacts/<sha256>]. Despite
+    the path token "artifacts" overlap, the two are different
+    concepts (sha-keyed blob vs id-keyed multimodal). This module
+    namespaces under [/api/v1/multimodal/] to avoid path conflicts. *)
+
+val bind_workspace_getter :
+  (unit -> Multimodal.Workspace.t) -> unit
+(** Override the default workspace getter. Called by the keeper
+    integration follow-up to wire keeper-side state into the
+    HTTP surface. *)
+
+val list_response : unit -> Yojson.Safe.t
+(** [{ "count": n, "artifacts": [...] }] envelope listing
+    every artifact currently in the workspace. *)
+
+val artifact_response :
+  id_str:string -> Yojson.Safe.t * Httpun.Status.t
+(** Single-artifact lookup by string id.
+    - Malformed id → 400 [{error}]
+    - Not found → 404 [{error, id}]
+    - Found → 200 [{...artifact JSON...}]. *)
+
+val provenance_response :
+  id_str:string -> Yojson.Safe.t * Httpun.Status.t
+(** Provenance neighbors:
+    [{ id, origins: [aid...], descendants: [aid...] }].
+    Returns empty arrays if the id is unknown to the workspace. *)
+
+val add_routes :
+  Http_server_eio.Router.t -> Http_server_eio.Router.t
+(** Register the three GET routes under
+    [/api/v1/multimodal/]. Returns the augmented router. *)


### PR DESCRIPTION
Cycle 27 / Tier D1. Operator-facing read-only routes over `Multimodal.Workspace`.

## Routes

```
GET /api/v1/multimodal/list             — all artifacts
GET /api/v1/multimodal/get/<id>         — single artifact
GET /api/v1/multimodal/provenance/<id>  — DAG neighbors
```

## Workspace source

Default = `Multimodal.Workspace.empty` (placeholder until keeper integration follow-up wires keeper-side state via `bind_workspace_getter`).

Path namespacing: `/api/v1/multimodal/*` avoids the existing `/api/v1/artifacts/<sha256>` prefix used for the Tool blob store (different concept — sha-keyed blobs vs id-keyed multimodal).

## Files

- `lib/server/server_routes_http_routes_multimodal.{mli,ml}` (NEW, ~180 LoC)
- `lib/server/server_routes_http.ml`: + 1 line route registration

## Verification
- `dune build --root . lib/server` — GREEN
- file-disjoint with W1, W2, W3, all open PRs

## Plan reference
§2.2 D1 dashboard route. Real workspace data source connection follows in keeper integration PR (after W1+W2+W3 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
