### PR TITLE
feat(perf): add baseline measurement infrastructure (scripts + protocol + template)

### DIFF
--- a/docs/design/perf-baseline-protocol.md
+++ b/docs/design/perf-baseline-protocol.md
@@ -1,0 +1,200 @@
+# Performance Baseline 측정 프로토콜 (RFC PR-0.2)
+
+masc-mcp v0.18.11 (OCaml 5.4 + Eio) 의 14 일 baseline 측정 인프라
+정의. 본 문서는 향후 모든 최적화 PR (캐시, GC, WebSocket, MCP
+latency 등) 의 머지 조건이 되는 baseline 계측 방법을 한 곳에 모은
+SSOT 다.
+
+본 PR 의 산출물:
+
+- `scripts/perf-baseline.sh` — daily snapshot 수집 스크립트
+- `reports/perf-baseline-template.md` — before/after 보고 템플릿
+- `docs/design/perf-baseline-protocol.md` — 본 문서
+
+코드 (`lib/`) 변경은 0. 신규 의존성 0.
+
+## 1. 배경과 결정 사항
+
+### 1.1 왜 본 PR 인가
+
+외부 전략 문서가 권고한 ROI 수치 (캐시 41x, GC 18% 향상 등) 는 모두
+**fictitious** 이다. 측정값이 0 인 상태에서 산출된 추정으로,
+검증 가능한 baseline 없이 받아들이면 잘못된 우선순위로 인프라가
+변형될 수 있다. 따라서 어떠한 최적화 PR 도 머지 전에:
+
+1. 기존 baseline 표를 보여야 하고,
+2. 그 표의 특정 행(들) 을 개선했음을 같은 단위로 증명해야 한다.
+
+이를 강제하려면 **baseline 자체가 먼저 존재해야 한다**. 본 PR 은
+"측정 자산만" 추가한다. 코드는 건드리지 않으며, 측정 결과를 어떤
+임계값으로 강제하지도 않는다.
+
+### 1.2 사용자 답변 (운영 전제)
+
+| 항목 | 값 | 근거 |
+|------|-----|------|
+| 운영 keeper 수 | 12+ | 사용자 확인 |
+| 50+ keeper | aspirational, baseline 가정 아님 | 사용자 확인 |
+| 인프라 | 단일 Railway 인스턴스 | 사용자 확인 |
+| 기존 prometheus | 존재 (`lib/prometheus.ml`, `/metrics`) | 코드 확인 |
+| Runtime_events | 존재 (`lib/core/masc_runtime_events.ml`) | 코드 확인 |
+
+본 baseline 은 12+ keeper 의 **현재 동작** 을 sample 하여 기록하는
+것이지, 50+ keeper 의 가설적 동작을 기록하지 않는다.
+
+## 2. 측정 대상 metric
+
+다섯 영역 모두 `scripts/perf-baseline.sh` 가 한 번에 수집하며,
+같은 보고 파일에 같은 timestamp 로 append 된다.
+
+### 2.1 캐시 hit ratio
+
+| metric | 출처 | 수집 방법 | 비고 |
+|--------|------|----------|------|
+| WS parse cache hit ratio | `masc_ws_parse_cache_{hits,misses}_total` | `/metrics` 카운터 합산 | 이미 export 됨 |
+| WS bytes cache hit ratio | `masc_ws_bytes_cache_{hits,misses}_total` | `/metrics` 카운터 합산 | 이미 export 됨 |
+| in-process caches | `lib/cache_eio.ml`, `lib/dashboard/dashboard_cache.ml` | **미export** | Phase 0.2.A |
+
+`cache_eio` / `dashboard_cache` 는 hit/miss 카운터가 prometheus 에
+등록되어 있지 않다. 사후 sampling (시점별 cache size 기록) 은
+의미 없는 숫자가 되므로, **이 두 모듈에 카운터를 추가하는 것을
+별도 PR (Phase 0.2.A) 로 명시하고**, 본 baseline 보고서에는 "not
+exported" 로 기록한다. 추정 hit ratio 를 만들지 않는다.
+
+### 2.2 WebSocket message size 분포 (P50/P95/P99) 와 RTT
+
+| metric | 출처 | 수집 방법 | 비고 |
+|--------|------|----------|------|
+| total bytes sent | `masc_ws_bytes_sent_total` | counter | 이미 export 됨 |
+| sessions total | `masc_ws_sessions_total` | counter | 이미 export 됨 |
+| client buffered bytes | `masc_ws_client_buffered_bytes` | gauge | 이미 export 됨 |
+| throttled deliveries | `masc_ws_throttled_deliveries_total` | counter | 이미 export 됨 |
+| 메시지 size P50/P95/P99 | `masc_ws_message_bytes` (histogram) | **미정의** | Phase 0.2.B |
+| RTT P50/P95/P99 | `masc_ws_rtt_seconds` (histogram) | **미정의** | Phase 0.2.B |
+
+현재 export 는 평균 size 를 도출할 수 있는 수준 (`bytes_sent /
+sessions`) 까지만 가능하다. percentile 분포를 baseline 에 넣으려면
+histogram bucket 등록이 선행되어야 한다. 본 PR 은 그 사실을
+보고서에 표시하고, 추정 percentile 을 만들어 적지 않는다.
+
+### 2.3 MCP tool call latency (cold vs warm)
+
+| metric | 출처 | 수집 방법 | 비고 |
+|--------|------|----------|------|
+| tool call count | `masc_tool_call_total` | counter | 이미 export 됨 |
+| tool call duration histogram | `masc_tool_call_duration_seconds` | histogram | 이미 export 됨 |
+| keeper tool call duration | `masc_keeper_tool_call_duration_seconds` | histogram | 이미 export 됨 |
+| cold vs warm 분리 | `phase=cold|warm` label | **미부착** | Phase 0.2.C |
+
+`benchmarks/quick-bench.sh` 와 `benchmarks/benchmark.sh` 가 lane
+분리 (session/read/coordination/runtime/a2a/lock) 를 이미 한다.
+이 lane 들은 cold vs warm 의 proxy 로 쓸 수 있지만, **dispatcher
+레벨에서 phase label 이 붙은 histogram 이 더 정확하다**. 본
+baseline 은 lane 별 percentile 을 quick-bench 출력으로 보존하고,
+phase label 도입은 0.2.C 로 분리한다.
+
+### 2.4 GC minor pause P99, major pause P99, RSS
+
+| metric | 출처 | 수집 방법 | 비고 |
+|--------|------|----------|------|
+| host RSS (kB) | `/proc/<pid>/status` (Linux) / `ps -o rss=` | shell 호출 | placeholder |
+| process open fds | `masc_process_open_fds` | gauge | 이미 export 됨 |
+| GC minor pause P99 | `Gc.quick_stat` 주기 sampler | **미등록** | Phase 0.2.D |
+| GC major pause P99 | 동일 | 동일 | 동일 |
+| heap_words / live_words | 동일 | 동일 | 동일 |
+
+OCaml 의 `Gc.quick_stat` 은 정량 정보가 풍부하지만 prometheus
+gauge 로 export 되지 않은 상태다. 외부 권고 ("GC 18% 향상") 의
+검증은 이 sampler 가 들어오기 전까지는 불가능하다. 본 PR 은 그
+사실을 명시한다.
+
+### 2.5 Eio fiber 활성 수, IO wait 분포
+
+| metric | 출처 | 수집 방법 | 비고 |
+|--------|------|----------|------|
+| active agents | `masc_active_agents` | gauge | 이미 export 됨 |
+| keeper turn span | `Masc_runtime_events.ev_turn` | runtime_events ring | OCAMLRUNPARAM=e 필요 |
+| 활성 fiber 수 | runtime_events 신규 span | **미정의** | Phase 0.2.E |
+| IO wait P95 | runtime_events 신규 span | **미정의** | Phase 0.2.E |
+
+`Masc_runtime_events` 는 turn 단위 span 만 emit 한다. fiber 활성
+수와 IO wait 분포는 별도의 span 또는 tracing 기반이 필요하므로
+본 baseline 은 turn span 의 개수와 평균 길이만 보고한다 (olly 가
+설치되어 있고 `OLLY_TRACE=1` 인 경우).
+
+## 3. 수집 워크플로
+
+### 3.1 단일 스냅샷
+
+```bash
+# server 가 :8935 에서 동작 중이어야 함
+bash scripts/perf-baseline.sh
+# → reports/perf-baseline-YYYY-MM-DD.md 에 append
+```
+
+`--dry-run` 은 의존성과 endpoint 가용성만 검증하고 종료한다.
+의존성: `curl`, `awk`, `date`, `mkdir`, `tee`. `jq`, `olly` 는
+선택. 모두 macOS / Linux 표준.
+
+### 3.2 14 일 baseline
+
+운영 환경 (Railway 단일 인스턴스, 12+ keeper) 에서 매일 1 회
+실행을 14 일 누적한다. 실행 시각은 일 단위 동일 시각을 권장
+(예: UTC 03:00). 결과는 `reports/perf-baseline-YYYY-MM-DD.md`
+파일 14 개로 남는다. 14 일 평균과 분산은 향후 0.2.F 단계에서
+스크립트로 계산한다.
+
+### 3.3 cron 등록 (선택)
+
+```cron
+# 매일 03:00 UTC, OCAMLRUNPARAM=e 로 서버가 실행 중일 때
+0 3 * * * cd /path/to/masc-mcp && \
+  OLLY_TRACE=0 bash scripts/perf-baseline.sh \
+  >> /var/log/masc-mcp/perf-baseline.cron.log 2>&1
+```
+
+`OLLY_TRACE=1` 은 30 초 동안 olly 가 마스터 process 에 attach
+하므로, 운영 환경에서는 기본 0 을 권장한다.
+
+## 4. PR 머지 조건 (향후 최적화 PR 에 적용)
+
+`reports/perf-baseline-template.md` 의 **2 절 "Required metric
+table"** 을 PR 본문에 그대로 복사하고, baseline / after / delta /
+source 칸을 모두 채워야 한다. 비어 있는 셀은 `not exported` 로
+표기하고 follow-up phase (0.2.A ~ 0.2.E) 를 명시한다.
+
+머지 가능성은 reviewer 판단으로 강제한다. 본 PR 단계에서 CI 자동
+diff 는 wiring 하지 않는다 (Phase 0.2.F).
+
+### 4.1 강제하지 않는 것
+
+- 절대 임계값 (예: P95 < 80ms) 강제. baseline 이 있어야 임계값을
+  도출할 수 있고, 임계값 없이 baseline 만 먼저 쌓는다.
+- 외부 전략 문서의 ROI 수치 (41x, 18% 등). 본 baseline 의 표만이
+  유효한 비교 단위다.
+
+## 5. 본 PR 이후의 단계 (참고)
+
+| Phase | 산출물 | 선행 조건 |
+|-------|--------|----------|
+| 0.2.A | `cache_eio` / `dashboard_cache` 에 hit/miss 카운터 등록 | 본 PR 머지 |
+| 0.2.B | `masc_ws_message_bytes`, `masc_ws_rtt_seconds` histogram | 본 PR 머지 |
+| 0.2.C | tool call dispatcher 에 `phase=cold|warm` label | 본 PR 머지 |
+| 0.2.D | `Gc.quick_stat` 주기 sampler → gauge family | 본 PR 머지 |
+| 0.2.E | `Masc_runtime_events` 에 io-wait span 추가 | 본 PR 머지 |
+| 0.2.F | CI 가 PR 본문의 baseline 표 형식을 검사하고 daily 보고서를 diff | 0.2.A~E 일부 머지 |
+
+각 phase 는 별도 PR 로 분리한다. 본 PR 은 그 어느 phase 의 코드도
+포함하지 않는다.
+
+## 6. 한계
+
+- 본 baseline 은 **단일 Railway 인스턴스 + 12+ keeper** 의 측정
+  값만 보고한다. 환경이 다르면 (다중 region, 50+ keeper) 새 baseline
+  을 다시 14 일 쌓아야 한다.
+- prometheus counter 는 server restart 시 0 으로 초기화된다.
+  daily 보고서는 누적이 아니라 **순간 snapshot** 이며, rate 는
+  14 일 분량에서 계산한다.
+- macOS 와 Linux 의 RSS 측정 경로가 다르다 (`ps` vs `/proc`). 두
+  환경 모두 지원하지만, 비교 단위로는 같은 OS 안에서만 의미가
+  있다.

--- a/reports/perf-baseline-template.md
+++ b/reports/perf-baseline-template.md
@@ -1,0 +1,117 @@
+# masc-mcp performance baseline — report template
+
+This template is the **canonical layout** that `scripts/perf-baseline.sh`
+emits and that every optimisation PR (RFC PR-0.2 follow-ups: cache,
+GC, WebSocket framing, MCP latency) must reuse for its before/after
+table. Copy it verbatim, fill the values, and link the source dump.
+
+> **Operating context** (RFC PR-0.2 Q&A)
+> - 12+ keepers on a single Railway instance.
+> - 50+ keepers is aspirational, not the target.
+> - All threshold rationale must reference the **measured** baseline,
+>   not the strategy doc's fictitious estimates (cache 41x, GC 18%, etc.).
+
+## 1. Run metadata
+
+| field | value |
+|-------|-------|
+| date (UTC) | `YYYY-MM-DD` |
+| timestamp (UTC) | `YYYY-MM-DDThh:mm:ssZ` |
+| git sha | `<12-char>` |
+| label | `default` \| `cold` \| `warm` \| `<custom>` |
+| host | `railway-prod` \| `local-mac-m3` |
+| keeper count (live) | `<int>` |
+| process uptime | `<duration>` |
+| OCAMLRUNPARAM | e.g. `e=1` (runtime_events on?) |
+
+## 2. Required metric table
+
+Every PR submission must populate **all rows below**. Cells that
+cannot be measured yet must read `not exported` plus a link to the
+follow-up issue, never `0` or `n/a` without justification.
+
+### 2.1 Cache hit ratio
+
+| metric | baseline | after | delta | source |
+|--------|---------:|------:|------:|--------|
+| `masc_ws_parse_cache_hits_total / (hits+misses)` |  |  |  | `/metrics` |
+| `masc_ws_bytes_cache_hits_total / (hits+misses)` |  |  |  | `/metrics` |
+| `dashboard_cache_*` (Phase 0.2.A) | not exported | | | `lib/dashboard/dashboard_cache.ml` |
+| `cache_eio_*` (Phase 0.2.A) | not exported | | | `lib/cache_eio.ml` |
+
+### 2.2 WebSocket framing
+
+| metric | baseline | after | delta | source |
+|--------|---------:|------:|------:|--------|
+| `masc_ws_sessions_total` |  |  |  | counter |
+| `masc_ws_bytes_sent_total` |  |  |  | counter (bytes) |
+| `masc_ws_client_buffered_bytes` |  |  |  | gauge |
+| `masc_ws_throttled_deliveries_total` |  |  |  | counter |
+| message size P50/P95/P99 (Phase 0.2.B) | not histogrammed | | | `masc_ws_message_bytes` |
+| RTT P50/P95/P99 (Phase 0.2.B) | not histogrammed | | | `masc_ws_rtt_seconds` |
+
+### 2.3 MCP tool-call latency
+
+| metric | baseline | after | delta | source |
+|--------|---------:|------:|------:|--------|
+| `masc_tool_call_total` |  |  |  | counter |
+| `masc_tool_call_duration_seconds` P50 |  |  |  | histogram |
+| `masc_tool_call_duration_seconds` P95 |  |  |  | histogram |
+| `masc_tool_call_duration_seconds` P99 |  |  |  | histogram |
+| cold-call P95 (Phase 0.2.C) | not labelled | | | needs `phase=cold` |
+| warm-call P95 (Phase 0.2.C) | not labelled | | | needs `phase=warm` |
+
+### 2.4 GC pauses and RSS
+
+| metric | baseline | after | delta | source |
+|--------|---------:|------:|------:|--------|
+| host RSS (kB) |  |  |  | `/proc/<pid>/status` or `ps -o rss=` |
+| `masc_process_open_fds` |  |  |  | gauge |
+| GC minor pause P99 (Phase 0.2.D) | not exported | | | `Gc.quick_stat` sampler |
+| GC major pause P99 (Phase 0.2.D) | not exported | | | `Gc.quick_stat` sampler |
+| heap_words (Phase 0.2.D) | not exported | | | `Gc.quick_stat` sampler |
+| live_words (Phase 0.2.D) | not exported | | | `Gc.quick_stat` sampler |
+
+### 2.5 Eio runtime / fibers
+
+| metric | baseline | after | delta | source |
+|--------|---------:|------:|------:|--------|
+| `masc_active_agents` |  |  |  | gauge |
+| `masc_keeper_alive_total` |  |  |  | counter |
+| `masc_keeper_turns_total` |  |  |  | counter |
+| active-fiber count (Phase 0.2.E) | not exported | | | needs runtime_events extension |
+| io-wait P95 (Phase 0.2.E) | not exported | | | needs runtime_events extension |
+
+## 3. Acceptance gate (template wording for follow-up PRs)
+
+A follow-up optimisation PR is mergeable only if **every claim in the
+PR description is backed by the table above**. The expected wording:
+
+> Baseline (sha `<12>`, label=`default`, ${N} keepers): `<row>` =
+> `<value>`. After: `<value>`. Delta: `<absolute>` (`<percent>`).
+> Source dump: `reports/perf-baseline-YYYY-MM-DD.md`.
+
+PRs that cite the strategy-doc estimates (cache 41x, GC 18% etc.)
+without a concrete row from this table fail the gate. The gate is
+enforced by reviewer judgement; no CI check is wired yet (Phase
+0.2.F).
+
+## 4. Known measurement gaps (as of 2026-04)
+
+| area | gap | follow-up phase |
+|------|-----|----------------|
+| cache | only WS parse/bytes caches export hit/miss; in-process caches do not | 0.2.A |
+| websocket | only counters; no message-size or RTT histograms | 0.2.B |
+| mcp latency | no cold-vs-warm split | 0.2.C |
+| gc | OCaml `Gc.quick_stat` not exported as gauge family | 0.2.D |
+| eio | runtime_events emits turn span only; no io-wait or fiber-count span | 0.2.E |
+| ci | no automatic baseline diff in PR check | 0.2.F |
+
+## 5. Reading the daily file
+
+`scripts/perf-baseline.sh` appends one snapshot block per run to
+`reports/perf-baseline-YYYY-MM-DD.md`. To compare two snapshots
+(e.g. before/after a PR landed), use the index table at the top of
+the daily file plus the section headers (`## Cache hit ratios
+(<ts>, label=<l>, sha=<sha>)`). The 14-day window means the latest
+14 daily files form the rolling baseline; older files may be archived.

--- a/scripts/perf-baseline.sh
+++ b/scripts/perf-baseline.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# perf-baseline.sh
+#
+# RFC PR-0.2 — 14-day performance baseline collector for masc-mcp.
+#
+# Single-shot snapshot of the metrics that future optimization PRs
+# (cache, GC, WebSocket framing, MCP latency) must beat to merge. Run
+# manually or under cron once per day; output is appended to a daily
+# Markdown report under reports/perf-baseline-YYYY-MM-DD.md.
+#
+# Operating context (per RFC PR-0.2 Q&A):
+#   - 12+ keepers on a single Railway instance.
+#   - 50+ keepers is aspirational, not the baseline target.
+#   - Prometheus scrape is local to this script (curl /metrics);
+#     external Prometheus/Grafana wiring is out of scope.
+#
+# Sources:
+#   - lib/prometheus.ml + /metrics endpoint  (counters/gauges/histograms)
+#   - lib/core/masc_runtime_events.ml        (turn span events for olly)
+#   - benchmarks/quick-bench.sh              (MCP latency lanes)
+#
+# Usage:
+#   bash scripts/perf-baseline.sh                    # full snapshot
+#   bash scripts/perf-baseline.sh --dry-run          # validate env, no writes
+#   OLLY_TRACE=1 bash scripts/perf-baseline.sh       # opt-in olly capture
+#   PERF_BASELINE_LABEL=warm bash scripts/perf-baseline.sh
+#
+# Exit codes:
+#   0 success, 1 generic failure, 2 dependency missing,
+#   3 server unreachable, 64 usage error.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help)
+      sed -n '3,30p' "$0"; exit 0 ;;
+    *)
+      echo "perf-baseline.sh: unknown arg: $arg" >&2
+      echo "usage: $0 [--dry-run]" >&2
+      exit 64 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Paths and environment
+# ---------------------------------------------------------------------------
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+REPO_ROOT="$(cd "${HERE}/.." && pwd)"
+TODAY="$(date -u +%Y-%m-%d)"
+TIMESTAMP_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+LABEL="${PERF_BASELINE_LABEL:-default}"
+
+REPORTS_DIR="${REPO_ROOT}/reports"
+TMP_DIR="${REPO_ROOT}/.tmp/perf-baseline"
+REPORT_FILE="${REPORTS_DIR}/perf-baseline-${TODAY}.md"
+METRICS_DUMP="${TMP_DIR}/metrics-${TODAY}-${LABEL}.txt"
+
+MASC_HOST="${MASC_HOST:-127.0.0.1}"
+MASC_PORT="${MASC_PORT:-8935}"
+MASC_BASE_URL="${MASC_BASE_URL:-http://${MASC_HOST}:${MASC_PORT}}"
+METRICS_URL="${MASC_BASE_URL}/metrics"
+DASHBOARD_STATUS_URL="${MASC_BASE_URL}/api/v1/dashboard/status"
+
+OLLY_TRACE="${OLLY_TRACE:-0}"
+OLLY_DURATION_SEC="${OLLY_DURATION_SEC:-30}"
+
+# ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "perf-baseline.sh: missing dependency: ${cmd}" >&2
+    return 2
+  fi
+}
+
+check_deps() {
+  local missing=0
+  for cmd in curl awk date mkdir tee; do
+    require_cmd "$cmd" || missing=1
+  done
+  # jq is preferred but optional; fall back to awk if absent.
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "perf-baseline.sh: jq not found — JSON sections will be raw text" >&2
+  fi
+  if [[ "$OLLY_TRACE" = "1" ]] && ! command -v olly >/dev/null 2>&1; then
+    echo "perf-baseline.sh: OLLY_TRACE=1 but 'olly' not on PATH (skipping trace)" >&2
+    OLLY_TRACE=0
+  fi
+  if (( missing == 1 )); then
+    return 2
+  fi
+}
+
+server_reachable() {
+  curl -fsS -m 3 "$DASHBOARD_STATUS_URL" >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Prometheus helpers
+# ---------------------------------------------------------------------------
+
+# fetch_metrics: dump /metrics to a file. Aborts on HTTP failure.
+fetch_metrics() {
+  local out="$1"
+  curl -fsS -m 10 "$METRICS_URL" -o "$out"
+}
+
+# metric_value <dump-file> <metric-name> [<label-substring>]
+# Returns the first matching counter/gauge value, or 0 if absent.
+# Histograms are queried via metric_histogram_bucket.
+metric_value() {
+  local file="$1" name="$2" label_filter="${3:-}"
+  if [[ -z "$label_filter" ]]; then
+    awk -v n="$name" '
+      $0 !~ /^#/ && index($0, n)==1 {
+        # Match either "name " (no labels) or "name{...}".
+        line=$0
+        sub(/^[^ ]+ /,"",line)
+        print line
+        exit
+      }
+    ' "$file"
+  else
+    awk -v n="$name" -v lf="$label_filter" '
+      $0 !~ /^#/ && index($0, n)==1 && index($0, lf)>0 {
+        line=$0
+        sub(/^[^ ]+ /,"",line)
+        print line
+        exit
+      }
+    ' "$file"
+  fi
+}
+
+# Sum every label-permutation of a counter family.
+metric_sum() {
+  local file="$1" name="$2"
+  awk -v n="$name" '
+    $0 !~ /^#/ && index($0, n)==1 {
+      line=$0
+      sub(/^[^ ]+ /,"",line)
+      sum += line + 0
+    }
+    END { printf "%g", sum+0 }
+  ' "$file"
+}
+
+# Compute hit_ratio = hits / (hits + misses), or "n/a" if denom == 0.
+hit_ratio() {
+  local file="$1" hits_metric="$2" misses_metric="$3"
+  local h m denom
+  h="$(metric_sum "$file" "$hits_metric")"
+  m="$(metric_sum "$file" "$misses_metric")"
+  denom=$(awk -v a="$h" -v b="$m" 'BEGIN{print a+b}')
+  if [[ "$denom" = "0" ]]; then
+    echo "n/a"
+  else
+    awk -v a="$h" -v d="$denom" 'BEGIN{printf "%.4f", a/d}'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Olly capture (opt-in)
+# ---------------------------------------------------------------------------
+# Requires the masc-mcp server process to have OCAMLRUNPARAM=e
+# (Runtime_events ring buffer enabled). When OLLY_TRACE=1, we run a
+# fixed-duration capture and append the summary to the report. We do
+# NOT auto-attach to a running process — the operator should set
+# OCAMLRUNPARAM=e at server start. If olly cannot attach, we record
+# the failure rather than aborting the whole snapshot.
+olly_capture() {
+  local out="$1"
+  if [[ "$OLLY_TRACE" != "1" ]]; then
+    return 0
+  fi
+  local pid
+  pid="$(pgrep -f 'masc_mcp_server' | head -n 1 || true)"
+  if [[ -z "$pid" ]]; then
+    echo "(olly) masc_mcp_server pid not found — skipping" >"$out"
+    return 0
+  fi
+  # olly trace-format is version-dependent; we just capture stdout and
+  # let the report show whatever the user's olly produces.
+  if ! olly trace --pid "$pid" --duration "${OLLY_DURATION_SEC}s" >"$out" 2>&1; then
+    echo "(olly) capture failed: see $out" >&2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Report rendering
+# ---------------------------------------------------------------------------
+write_header() {
+  local file="$1"
+  if [[ -f "$file" ]]; then
+    return 0
+  fi
+  cat >"$file" <<EOF
+# masc-mcp performance baseline — ${TODAY}
+
+Generated by \`scripts/perf-baseline.sh\`. One row per snapshot;
+each run appends. Operating target: 12+ keepers on a single Railway
+instance. 50+ keepers is aspirational, not assumed in any threshold.
+
+| ts (UTC) | label | git sha | section |
+|----------|-------|---------|---------|
+EOF
+}
+
+git_sha() {
+  (cd "$REPO_ROOT" && git rev-parse --short=12 HEAD 2>/dev/null) || echo "unknown"
+}
+
+render_section() {
+  local title="$1"; shift
+  echo
+  echo "## ${title} (${TIMESTAMP_UTC}, label=${LABEL}, sha=$(git_sha))"
+  echo
+  cat
+}
+
+render_index_row() {
+  local section="$1"
+  printf "| %s | %s | %s | %s |\n" \
+    "$TIMESTAMP_UTC" "$LABEL" "$(git_sha)" "$section"
+}
+
+# ---------------------------------------------------------------------------
+# Metric extraction blocks
+# ---------------------------------------------------------------------------
+
+# 1. Cache hit ratio
+section_cache() {
+  local file="$1"
+  local ws_parse_ratio ws_bytes_ratio
+  ws_parse_ratio="$(hit_ratio "$file" \
+    masc_ws_parse_cache_hits_total masc_ws_parse_cache_misses_total)"
+  ws_bytes_ratio="$(hit_ratio "$file" \
+    masc_ws_bytes_cache_hits_total masc_ws_bytes_cache_misses_total)"
+
+  cat <<EOF
+| metric | source | value |
+|--------|--------|-------|
+| ws_parse_cache_hit_ratio | masc_ws_parse_cache_{hits,misses}_total | ${ws_parse_ratio} |
+| ws_bytes_cache_hit_ratio | masc_ws_bytes_cache_{hits,misses}_total | ${ws_bytes_ratio} |
+| ws_parse_cache_hits_total  | counter (sum across labels) | $(metric_sum "$file" masc_ws_parse_cache_hits_total) |
+| ws_parse_cache_misses_total| counter (sum across labels) | $(metric_sum "$file" masc_ws_parse_cache_misses_total) |
+| ws_bytes_cache_hits_total  | counter (sum across labels) | $(metric_sum "$file" masc_ws_bytes_cache_hits_total) |
+| ws_bytes_cache_misses_total| counter (sum across labels) | $(metric_sum "$file" masc_ws_bytes_cache_misses_total) |
+
+Caches outside WS framing (\`lib/cache_eio.ml\`, \`lib/dashboard/dashboard_cache.ml\`)
+have no exported counters yet. **Phase 0.2.A: add hit/miss counters** is a
+prerequisite for the broader cache-effectiveness baseline; this report
+records them as missing rather than synthesising them.
+EOF
+}
+
+# 2. WebSocket framing
+section_websocket() {
+  local file="$1"
+  cat <<EOF
+| metric | source | value |
+|--------|--------|-------|
+| ws_sessions_total       | masc_ws_sessions_total       | $(metric_sum "$file" masc_ws_sessions_total) |
+| ws_bytes_sent_total     | masc_ws_bytes_sent_total     | $(metric_sum "$file" masc_ws_bytes_sent_total) |
+| ws_client_buffered_bytes| masc_ws_client_buffered_bytes (gauge) | $(metric_value "$file" masc_ws_client_buffered_bytes) |
+| ws_throttled_deliveries | masc_ws_throttled_deliveries_total | $(metric_sum "$file" masc_ws_throttled_deliveries_total) |
+| ws_slice_fanout_skipped | masc_ws_slice_fanout_skipped_total | $(metric_sum "$file" masc_ws_slice_fanout_skipped_total) |
+| ws_delta_built_total    | masc_ws_delta_built_total    | $(metric_sum "$file" masc_ws_delta_built_total) |
+
+P50/P95/P99 message-size and RTT distributions are **not yet
+histogrammed** — \`masc_ws_bytes_sent_total\` is a counter, not a
+histogram. Phase 0.2.B: introduce \`masc_ws_message_bytes\` and
+\`masc_ws_rtt_seconds\` histograms before claiming size/RTT baselines.
+EOF
+}
+
+# 3. MCP tool call latency
+section_mcp_latency() {
+  local file="$1"
+  local hist_lines
+  hist_lines="$(awk '
+    $0 ~ /^masc_tool_call_duration_seconds_bucket/ ||
+    $0 ~ /^masc_tool_call_duration_seconds_sum/   ||
+    $0 ~ /^masc_tool_call_duration_seconds_count/ { print }
+  ' "$file" || true)"
+
+  cat <<EOF
+| metric | source | value |
+|--------|--------|-------|
+| tool_call_total       | masc_tool_call_total (sum) | $(metric_sum "$file" masc_tool_call_total) |
+| tool_call_duration_count | masc_tool_call_duration_seconds_count | $(metric_sum "$file" masc_tool_call_duration_seconds_count) |
+| tool_call_duration_sum   | masc_tool_call_duration_seconds_sum   | $(metric_sum "$file" masc_tool_call_duration_seconds_sum) |
+| keeper_tool_call_duration_count | masc_keeper_tool_call_duration_seconds_count | $(metric_sum "$file" masc_keeper_tool_call_duration_seconds_count) |
+
+Histogram buckets (raw):
+
+\`\`\`
+${hist_lines:-(no buckets exported — verify register_histogram fired)}
+\`\`\`
+
+Cold-vs-warm split: this snapshot does not separate first-call from
+steady-state. Phase 0.2.C: tag the histogram with a \`phase\` label
+(cold|warm) inside the dispatcher to make the cold-path baseline
+measurable.
+EOF
+}
+
+# 4. GC / RSS
+section_gc_rss() {
+  local file="$1"
+  # OCaml-level Gc.* metrics are not exported via /metrics today.
+  # Capture the host view via /proc (Linux) or ps (macOS) to keep the
+  # baseline self-contained, then flag the gap.
+  local pid rss_kb
+  pid="$(pgrep -f 'masc_mcp_server' | head -n 1 || true)"
+  if [[ -n "$pid" ]]; then
+    if [[ "$(uname)" = "Linux" ]] && [[ -r "/proc/$pid/status" ]]; then
+      rss_kb="$(awk '/^VmRSS:/ {print $2}' "/proc/$pid/status")"
+    else
+      rss_kb="$(ps -o rss= -p "$pid" 2>/dev/null | awk '{print $1}')"
+    fi
+  else
+    rss_kb=""
+  fi
+
+  cat <<EOF
+| metric | source | value |
+|--------|--------|-------|
+| process_open_fds | masc_process_open_fds (gauge) | $(metric_value "$file" masc_process_open_fds) |
+| process_fd_warn_threshold | masc_process_fd_warn_threshold (gauge) | $(metric_value "$file" masc_process_fd_warn_threshold) |
+| process_timeout_total | masc_process_timeout_total | $(metric_sum "$file" masc_process_timeout_total) |
+| host_rss_kb (pid=${pid:-?}) | ps/proc | ${rss_kb:-unavailable} |
+
+OCaml GC stats (minor pause P99, major pause P99, heap_words,
+live_words) are **not registered** in \`lib/prometheus.ml\` today.
+Phase 0.2.D: wire \`Gc.quick_stat\` into a periodic gauge sampler so
+that minor/major pause distributions become first-class metrics.
+Until then, treat host RSS as a coarse placeholder.
+EOF
+}
+
+# 5. Eio fiber / runtime events
+section_eio_runtime() {
+  local file="$1"
+  cat <<EOF
+| metric | source | value |
+|--------|--------|-------|
+| active_agents | masc_active_agents (gauge) | $(metric_value "$file" masc_active_agents) |
+| keeper_count (alive)| masc_keeper_alive_total (counter) | $(metric_sum "$file" masc_keeper_alive_total) |
+| keeper_turns_total  | masc_keeper_turns_total | $(metric_sum "$file" masc_keeper_turns_total) |
+| keeper_turn_starts  | masc_keeper_turn_starts_total | $(metric_sum "$file" masc_keeper_turn_starts_total) |
+
+Active-fiber count and per-fiber IO-wait distribution are NOT
+exported. Source for these will be \`Masc_runtime_events\` plus
+olly:
+
+  - lib/core/masc_runtime_events.ml registers a turn span event.
+  - With OCAMLRUNPARAM=e and OLLY_TRACE=1, this script attaches olly
+    for ${OLLY_DURATION_SEC}s and dumps the trace to .tmp/perf-baseline/.
+  - Phase 0.2.E: extend masc_runtime_events to emit an io-wait span
+    so the IO distribution can be aggregated without a sampling
+    profiler.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Main flow
+# ---------------------------------------------------------------------------
+
+main() {
+  check_deps || exit 2
+
+  if (( DRY_RUN == 1 )); then
+    echo "perf-baseline.sh: --dry-run"
+    echo "  repo_root      = ${REPO_ROOT}"
+    echo "  reports_dir    = ${REPORTS_DIR}"
+    echo "  metrics_url    = ${METRICS_URL}"
+    echo "  status_url     = ${DASHBOARD_STATUS_URL}"
+    echo "  report_file    = ${REPORT_FILE}"
+    echo "  metrics_dump   = ${METRICS_DUMP}"
+    echo "  olly_trace     = ${OLLY_TRACE}"
+    if server_reachable; then
+      echo "  server         = reachable"
+    else
+      echo "  server         = NOT reachable (would exit 3 on real run)"
+    fi
+    exit 0
+  fi
+
+  if ! server_reachable; then
+    echo "perf-baseline.sh: masc-mcp not reachable at ${MASC_BASE_URL}" >&2
+    echo "  start with: dune exec masc_mcp_server -- --foreground" >&2
+    exit 3
+  fi
+
+  mkdir -p "$REPORTS_DIR" "$TMP_DIR"
+  fetch_metrics "$METRICS_DUMP"
+  write_header "$REPORT_FILE"
+
+  {
+    render_index_row "snapshot"
+
+    section_cache "$METRICS_DUMP"     | render_section "Cache hit ratios"
+    section_websocket "$METRICS_DUMP" | render_section "WebSocket framing"
+    section_mcp_latency "$METRICS_DUMP" | render_section "MCP tool-call latency"
+    section_gc_rss "$METRICS_DUMP"    | render_section "GC pause and RSS"
+    section_eio_runtime "$METRICS_DUMP" | render_section "Eio runtime / fibers"
+
+    if [[ "$OLLY_TRACE" = "1" ]]; then
+      local olly_out="${TMP_DIR}/olly-${TODAY}-${LABEL}.txt"
+      olly_capture "$olly_out"
+      {
+        echo "Captured for ${OLLY_DURATION_SEC}s. Raw trace at: ${olly_out}"
+        echo
+        echo '```'
+        head -c 4096 "$olly_out" 2>/dev/null || true
+        echo
+        echo '```'
+      } | render_section "olly trace (head)"
+    fi
+  } >>"$REPORT_FILE"
+
+  echo "perf-baseline.sh: appended snapshot to ${REPORT_FILE}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Adds operator-facing tooling to capture a 14-day baseline before any optimization PR lands.
- Discovers that masc-mcp already has prometheus + /metrics infra; this PR fills the *capture* gap, not the *export* gap.

## Files
- `scripts/perf-baseline.sh` (434 lines, executable, `--dry-run` supported).
- `reports/perf-baseline-template.md` (117 lines).
- `docs/design/perf-baseline-protocol.md` (200 lines, Korean).

## Why
External strategy docs cite ROI numbers (caching 41x, GC 18%, INP 52%) measured in other environments. Without a masc-mcp baseline (12+ keeper, single Railway instance), all such citations are fictitious. This PR makes future optimization PRs **prove** their effect with same-unit before/after rows.

## Follow-ups (separate PRs)
- PR-0.2.A: register cache hit/miss counters in `cache_eio` / `dashboard_cache`.
- PR-0.2.B: WS message-bytes / RTT histograms.
- PR-0.2.C: cold/warm phase label on tool_call_duration.
- PR-0.2.D: `Gc.quick_stat` gauge sampler.
- PR-0.2.E: runtime_events IO-wait span.
- PR-0.2.F: CI baseline-row checker.

## Test plan
- [x] `bash scripts/perf-baseline.sh --dry-run` exits 0; missing endpoint exits 3; unknown arg exits 64.
- [x] `bash -n scripts/perf-baseline.sh` passes.
- [ ] Reviewers verify the metric list against `lib/prometheus.ml` registrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)