### PR TITLE
feat(headless): RFC 0007 ToastManager implementation + Preact adapter

### DIFF
--- a/dashboard/design-system/headless-core/toast-manager.test.ts
+++ b/dashboard/design-system/headless-core/toast-manager.test.ts
@@ -1,0 +1,250 @@
+// Pure TS unit tests for ToastManager. No DOM, no Preact runtime.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  createToastManager,
+  SEVERITY_DEFAULT_DURATION_MS,
+  SEVERITY_PRIORITY,
+  SEVERITY_TO_ARIA_LIVE,
+  SEVERITY_TO_ROLE,
+} from './toast-manager'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-04-29T00:00:00Z'))
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createToastManager — notify and visible', () => {
+  it('first notify becomes visible immediately', () => {
+    const m = createToastManager()
+    const id = m.notify({ severity: 'info', message: 'hello' })
+    const queue = m.getQueue()
+    expect(queue).toHaveLength(1)
+    expect(queue[0]!.id).toBe(id)
+    expect(queue[0]!.state).toBe('visible')
+  })
+
+  it('auto-dismiss after duration', () => {
+    const m = createToastManager()
+    m.notify({ severity: 'info', message: 'hi', duration: 1000 })
+    expect(m.getQueue()[0]!.state).toBe('visible')
+    vi.advanceTimersByTime(999)
+    expect(m.getQueue()[0]!.state).toBe('visible')
+    vi.advanceTimersByTime(1)
+    expect(m.getQueue()[0]!.state).toBe('dismissed')
+  })
+
+  it('sticky duration: 0 never auto-dismisses', () => {
+    const m = createToastManager()
+    m.notify({ severity: 'error', message: 'oops' })
+    vi.advanceTimersByTime(60_000)
+    expect(m.getQueue()[0]!.state).toBe('visible')
+  })
+})
+
+describe('createToastManager — dedup', () => {
+  it('replaces in place and resets timer', () => {
+    const m = createToastManager()
+    const id1 = m.notify({ severity: 'info', message: 'one', dedupKey: 'k', duration: 1000 })
+    vi.advanceTimersByTime(800)
+    const id2 = m.notify({ severity: 'info', message: 'two', dedupKey: 'k', duration: 1000 })
+    expect(id1).toBe(id2)
+    const queue = m.getQueue()
+    expect(queue).toHaveLength(1)
+    expect(queue[0]!.message).toBe('two')
+    // Timer reset; original 800ms elapsed shouldn't matter.
+    vi.advanceTimersByTime(900)
+    expect(m.getQueue()[0]!.state).toBe('visible')
+    vi.advanceTimersByTime(100)
+    expect(m.getQueue()[0]!.state).toBe('dismissed')
+  })
+})
+
+describe('createToastManager — priority and ordering', () => {
+  it('error renders before info regardless of arrival order', () => {
+    const m = createToastManager()
+    m.notify({ severity: 'info', message: 'i' })
+    m.notify({ severity: 'error', message: 'e' })
+    const queue = m.getQueue()
+    expect(queue[0]!.severity).toBe('error')
+    expect(queue[1]!.severity).toBe('info')
+  })
+
+  it('FIFO at same priority', () => {
+    const m = createToastManager()
+    m.notify({ severity: 'info', message: 'first' })
+    vi.advanceTimersByTime(10)
+    m.notify({ severity: 'info', message: 'second' })
+    const queue = m.getQueue()
+    expect(queue[0]!.message).toBe('first')
+    expect(queue[1]!.message).toBe('second')
+  })
+})
+
+describe('createToastManager — max visible cap', () => {
+  it('6th notify queues; first dismissal promotes queue head', () => {
+    const m = createToastManager({ maxVisible: 5 })
+    for (let i = 0; i < 5; i += 1) {
+      m.notify({ severity: 'info', message: `v${i}`, duration: 1000 })
+      vi.advanceTimersByTime(1)
+    }
+    const sixthId = m.notify({ severity: 'info', message: 'queued', duration: 1000 })
+    let queue = m.getQueue()
+    const sixth = queue.find((t) => t.id === sixthId)!
+    expect(sixth.state).toBe('queued')
+    // Dismiss one visible → 6th promotes
+    m.dismiss(queue[0]!.id)
+    queue = m.getQueue()
+    const promoted = queue.find((t) => t.id === sixthId)!
+    expect(promoted.state).toBe('visible')
+  })
+})
+
+describe('createToastManager — error preempts low-priority', () => {
+  it('error arriving when 5 info are visible preempts the oldest info', () => {
+    const m = createToastManager({ maxVisible: 5 })
+    const ids: string[] = []
+    for (let i = 0; i < 5; i += 1) {
+      ids.push(m.notify({ severity: 'info', message: `i${i}`, duration: 5000 }))
+      vi.advanceTimersByTime(1)
+    }
+    // All 5 visible
+    for (const id of ids) {
+      expect(m.getQueue().find((t) => t.id === id)!.state).toBe('visible')
+    }
+    m.notify({ severity: 'error', message: 'critical' })
+    // Oldest info should have been preempted (state=dismissed).
+    const queue = m.getQueue()
+    const errorEntry = queue.find((t) => t.severity === 'error')!
+    expect(errorEntry.state).toBe('visible')
+    // First info should now be dismissed.
+    expect(queue.find((t) => t.id === ids[0])!.state).toBe('dismissed')
+  })
+
+  it('error does NOT preempt another error', () => {
+    const m = createToastManager({ maxVisible: 2 })
+    const id1 = m.notify({ severity: 'error', message: 'first' })
+    const id2 = m.notify({ severity: 'error', message: 'second' })
+    expect(m.getQueue().find((t) => t.id === id1)!.state).toBe('visible')
+    expect(m.getQueue().find((t) => t.id === id2)!.state).toBe('visible')
+    const id3 = m.notify({ severity: 'error', message: 'third' })
+    // Third has same priority as the others; cannot preempt.
+    expect(m.getQueue().find((t) => t.id === id3)!.state).toBe('queued')
+  })
+})
+
+describe('createToastManager — pause / resume', () => {
+  it('pause + resume preserves elapsed time', () => {
+    const m = createToastManager()
+    const id = m.notify({ severity: 'info', message: 'p', duration: 1000 })
+    vi.advanceTimersByTime(300)
+    m.pause(id)
+    vi.advanceTimersByTime(5_000) // long pause
+    expect(m.getQueue().find((t) => t.id === id)!.state).toBe('visible')
+    m.resume(id)
+    vi.advanceTimersByTime(699)
+    expect(m.getQueue().find((t) => t.id === id)!.state).toBe('visible')
+    vi.advanceTimersByTime(1)
+    expect(m.getQueue().find((t) => t.id === id)!.state).toBe('dismissed')
+  })
+
+  it('pauseAll / resumeAll affect every visible toast', () => {
+    const m = createToastManager({ maxVisible: 3 })
+    m.notify({ severity: 'info', message: '1', duration: 1000 })
+    m.notify({ severity: 'info', message: '2', duration: 1000 })
+    vi.advanceTimersByTime(500)
+    m.pauseAll()
+    vi.advanceTimersByTime(5000)
+    for (const t of m.getQueue()) {
+      expect(t.state).toBe('visible')
+    }
+    m.resumeAll()
+    vi.advanceTimersByTime(499)
+    for (const t of m.getQueue()) {
+      expect(t.state).toBe('visible')
+    }
+    vi.advanceTimersByTime(1)
+    for (const t of m.getQueue()) {
+      expect(t.state).toBe('dismissed')
+    }
+  })
+})
+
+describe('createToastManager — action button', () => {
+  it('action click dismisses the toast (consumer responsibility — manager exposes action)', () => {
+    const onClick = vi.fn()
+    const m = createToastManager()
+    const id = m.notify({
+      severity: 'info',
+      message: 'undo me',
+      action: { label: 'Undo', onClick },
+    })
+    const t = m.getQueue().find((tt) => tt.id === id)!
+    expect(t.action?.label).toBe('Undo')
+    // Consumer fires action click then explicit dismiss:
+    t.action!.onClick()
+    m.dismiss(id)
+    expect(onClick).toHaveBeenCalledOnce()
+    expect(m.getQueue().find((tt) => tt.id === id)!.state).toBe('dismissed')
+  })
+})
+
+describe('createToastManager — dismissAll', () => {
+  it('flips every visible/queued to dismissed', () => {
+    const m = createToastManager({ maxVisible: 2 })
+    m.notify({ severity: 'info', message: '1' })
+    m.notify({ severity: 'info', message: '2' })
+    m.notify({ severity: 'info', message: '3' }) // queued
+    m.dismissAll()
+    for (const t of m.getQueue()) {
+      expect(t.state).toBe('dismissed')
+    }
+  })
+})
+
+describe('createToastManager — severity static maps', () => {
+  it('SEVERITY_PRIORITY orders error > warning > success > info', () => {
+    expect(SEVERITY_PRIORITY.error).toBeGreaterThan(SEVERITY_PRIORITY.warning)
+    expect(SEVERITY_PRIORITY.warning).toBeGreaterThan(SEVERITY_PRIORITY.success)
+    expect(SEVERITY_PRIORITY.success).toBeGreaterThan(SEVERITY_PRIORITY.info)
+  })
+
+  it('default durations match RFC table', () => {
+    expect(SEVERITY_DEFAULT_DURATION_MS.error).toBe(0)
+    expect(SEVERITY_DEFAULT_DURATION_MS.warning).toBe(8000)
+    expect(SEVERITY_DEFAULT_DURATION_MS.success).toBe(5000)
+    expect(SEVERITY_DEFAULT_DURATION_MS.info).toBe(5000)
+  })
+
+  it('role mapping: error → alert, others → status', () => {
+    expect(SEVERITY_TO_ROLE.error).toBe('alert')
+    expect(SEVERITY_TO_ROLE.warning).toBe('status')
+    expect(SEVERITY_TO_ROLE.success).toBe('status')
+    expect(SEVERITY_TO_ROLE.info).toBe('status')
+  })
+
+  it('aria-live mapping: error → assertive, others → polite', () => {
+    expect(SEVERITY_TO_ARIA_LIVE.error).toBe('assertive')
+    expect(SEVERITY_TO_ARIA_LIVE.warning).toBe('polite')
+    expect(SEVERITY_TO_ARIA_LIVE.success).toBe('polite')
+    expect(SEVERITY_TO_ARIA_LIVE.info).toBe('polite')
+  })
+})
+
+describe('createToastManager — subscribe / unsubscribe', () => {
+  it('subscriber fires on every state change', () => {
+    const m = createToastManager()
+    let calls = 0
+    const dispose = m.subscribe(() => {
+      calls += 1
+    })
+    m.notify({ severity: 'info', message: 'a' })
+    expect(calls).toBeGreaterThan(0)
+    dispose()
+    const before = calls
+    m.notify({ severity: 'info', message: 'b' })
+    expect(calls).toBe(before)
+  })
+})

--- a/dashboard/design-system/headless-core/toast-manager.ts
+++ b/dashboard/design-system/headless-core/toast-manager.ts
@@ -1,0 +1,395 @@
+/**
+ * ToastManager — singleton notification queue (RFC 0007).
+ *
+ * Owns a priority-ordered queue of severity-keyed notifications with
+ * dedup by key, hover/focus/region pause, and automatic dismiss.
+ *
+ * MVP scope (RFC 0007 §3, §4, §5, §6):
+ *   - severity → priority + duration + role + aria-live mapping
+ *     (error=4/sticky/alert/assertive, warning=3/8s, success/info=
+ *     2-1/5s/status/polite)
+ *   - max visible default 5; 6th queues; error preempts oldest
+ *     low-priority visible
+ *   - dedupKey replaces in place + resets timer (cross-component)
+ *   - pause / resume preserve elapsed time (not restart)
+ *   - region pause: pausing one toast pauses all visible timers
+ *   - action button does NOT make error sticky — action IS the
+ *     response signal, default duration applies
+ *
+ * No DOM access. Pure TS. The adapter (use-toasts.ts) wires DOM
+ * pointer-enter/leave + focus events to pause/resume and renders
+ * each toast inside a usePortal({ layer: 'toast' }) tree.
+ */
+
+export type ToastSeverity = 'info' | 'success' | 'warning' | 'error'
+
+export type ToastState = 'queued' | 'visible' | 'dismissed'
+
+export interface ToastAction {
+  readonly label: string
+  readonly onClick: () => void
+}
+
+export interface ToastDescriptor {
+  /** Optional explicit id; auto-generated otherwise. */
+  id?: string
+  readonly severity: ToastSeverity
+  readonly message: string
+  readonly description?: string
+  readonly action?: ToastAction
+  /** ms; 0 = sticky. When omitted, default by severity. */
+  readonly duration?: number
+  /** Cross-component dedup key. */
+  readonly dedupKey?: string
+}
+
+export interface Toast {
+  readonly id: string
+  readonly severity: ToastSeverity
+  readonly message: string
+  readonly description?: string
+  readonly action?: ToastAction
+  readonly duration: number
+  readonly dedupKey?: string
+  readonly priority: number
+  readonly createdAt: number
+  readonly state: ToastState
+}
+
+export interface ToastManagerOptions {
+  /** Max simultaneously visible toasts. Default 5. */
+  maxVisible?: number
+  /** Override default ID generator. */
+  generateId?: () => string
+}
+
+const DEFAULT_MAX_VISIBLE = 5
+
+const SEVERITY_PRIORITY: Readonly<Record<ToastSeverity, number>> = Object.freeze({
+  error: 4,
+  warning: 3,
+  success: 2,
+  info: 1,
+})
+
+const SEVERITY_DEFAULT_DURATION_MS: Readonly<Record<ToastSeverity, number>> = Object.freeze({
+  error: 0, // sticky
+  warning: 8000,
+  success: 5000,
+  info: 5000,
+})
+
+export interface ToastManager {
+  notify(descriptor: ToastDescriptor): string
+  dismiss(id: string): void
+  dismissAll(): void
+  pause(id: string): void
+  resume(id: string): void
+  /** Pause every visible toast (region pause). */
+  pauseAll(): void
+  /** Resume every visible toast. */
+  resumeAll(): void
+
+  getQueue(): ReadonlyArray<Toast>
+
+  subscribe(listener: (queue: ReadonlyArray<Toast>) => void): () => void
+}
+
+interface InternalToast extends Toast {
+  /** State mutation hook keeps the readonly Toast surface clean. */
+  state: ToastState
+  /** ms remaining when paused — null while running. */
+  pausedRemaining: number | null
+  /** Wall-clock ms when current run-segment started. */
+  runStartedAt: number
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+function nextDefaultId(counter: { n: number }): string {
+  counter.n += 1
+  return `toast-${counter.n}`
+}
+
+/** Sort active (queued+visible) toasts in ToastManager render order. */
+function sortToasts(a: Toast, b: Toast): number {
+  if (a.priority !== b.priority) return b.priority - a.priority
+  return a.createdAt - b.createdAt
+}
+
+export function createToastManager(opts?: ToastManagerOptions): ToastManager {
+  const maxVisible = opts?.maxVisible ?? DEFAULT_MAX_VISIBLE
+  const idCounter = { n: 0 }
+  const generateId = opts?.generateId ?? (() => nextDefaultId(idCounter))
+
+  // Internal storage. Keep insertion-time creation order for FIFO at
+  // same priority. State transitions mutate in place; we expose
+  // immutable snapshots via getQueue().
+  const toasts = new Map<string, InternalToast>()
+  const listeners = new Set<(queue: ReadonlyArray<Toast>) => void>()
+
+  function snapshot(): ReadonlyArray<Toast> {
+    // Return *active + dismissed* in priority/created order. State
+    // discriminator carries the lifecycle for the consumer.
+    const arr: Toast[] = []
+    for (const t of toasts.values()) {
+      arr.push({
+        id: t.id,
+        severity: t.severity,
+        message: t.message,
+        description: t.description,
+        action: t.action,
+        duration: t.duration,
+        dedupKey: t.dedupKey,
+        priority: t.priority,
+        createdAt: t.createdAt,
+        state: t.state,
+      })
+    }
+    arr.sort(sortToasts)
+    return Object.freeze(arr)
+  }
+
+  function emit(): void {
+    const snap = snapshot()
+    for (const listener of listeners) listener(snap)
+  }
+
+  function clearTimer(t: InternalToast): void {
+    if (t.timer !== null) {
+      clearTimeout(t.timer)
+      t.timer = null
+    }
+  }
+
+  function startTimer(t: InternalToast, ms: number): void {
+    if (ms <= 0) return
+    t.runStartedAt = Date.now()
+    t.timer = setTimeout(() => {
+      t.timer = null
+      transitionToDismissed(t)
+    }, ms)
+  }
+
+  function transitionToVisible(t: InternalToast): void {
+    if (t.state === 'visible') return
+    t.state = 'visible'
+    if (t.duration > 0) {
+      startTimer(t, t.duration)
+    }
+  }
+
+  function transitionToDismissed(t: InternalToast): void {
+    if (t.state === 'dismissed') return
+    clearTimer(t)
+    t.state = 'dismissed'
+    emit()
+    promoteFromQueue()
+  }
+
+  function visibleCount(): number {
+    let n = 0
+    for (const t of toasts.values()) {
+      if (t.state === 'visible') n += 1
+    }
+    return n
+  }
+
+  function promoteFromQueue(): void {
+    if (visibleCount() >= maxVisible) return
+    const queued: InternalToast[] = []
+    for (const t of toasts.values()) {
+      if (t.state === 'queued') queued.push(t)
+    }
+    queued.sort((a, b) => sortToasts(a, b))
+    while (queued.length > 0 && visibleCount() < maxVisible) {
+      const head = queued.shift()!
+      transitionToVisible(head)
+      emit()
+    }
+  }
+
+  /**
+   * Eviction comparator. Negative when `a` is *more* dismissable than `b`.
+   * Render order (sortToasts) is high-priority + FIFO; eviction order is
+   * inverse for FIFO (oldest dies first) so we can't reuse sortToasts.
+   * Lower priority = more dismissable; at same priority, older = more.
+   */
+  function moreDismissable(a: InternalToast, b: InternalToast): number {
+    if (a.priority !== b.priority) return a.priority - b.priority
+    return a.createdAt - b.createdAt
+  }
+
+  function preemptForError(incomingPriority: number): void {
+    if (visibleCount() < maxVisible) return
+    if (incomingPriority < SEVERITY_PRIORITY.error) return
+    // Find the *most dismissable* visible toast strictly below the
+    // incoming priority. Lowest priority first; oldest at same priority.
+    let victim: InternalToast | null = null
+    for (const t of toasts.values()) {
+      if (t.state !== 'visible') continue
+      if (t.priority >= incomingPriority) continue
+      if (victim === null || moreDismissable(t, victim) < 0) victim = t
+    }
+    if (victim !== null) {
+      transitionToDismissed(victim)
+    }
+  }
+
+  function findByDedupKey(key: string): InternalToast | null {
+    for (const t of toasts.values()) {
+      if (t.dedupKey === key && t.state !== 'dismissed') return t
+    }
+    return null
+  }
+
+  function notifyImpl(descriptor: ToastDescriptor): string {
+    // Dedup: if an active toast carries the same key, replace its
+    // mutable fields in-place and reset its timer.
+    if (descriptor.dedupKey !== undefined) {
+      const existing = findByDedupKey(descriptor.dedupKey)
+      if (existing !== null) {
+        existing.severity = descriptor.severity
+        existing.message = descriptor.message
+        existing.description = descriptor.description
+        existing.action = descriptor.action
+        existing.priority = SEVERITY_PRIORITY[descriptor.severity]
+        existing.duration =
+          descriptor.duration ?? SEVERITY_DEFAULT_DURATION_MS[descriptor.severity]
+        if (existing.state === 'visible') {
+          clearTimer(existing)
+          if (existing.duration > 0) startTimer(existing, existing.duration)
+        }
+        existing.pausedRemaining = null
+        emit()
+        return existing.id
+      }
+    }
+
+    const id = descriptor.id ?? generateId()
+    const priority = SEVERITY_PRIORITY[descriptor.severity]
+    const duration =
+      descriptor.duration ?? SEVERITY_DEFAULT_DURATION_MS[descriptor.severity]
+    const t: InternalToast = {
+      id,
+      severity: descriptor.severity,
+      message: descriptor.message,
+      description: descriptor.description,
+      action: descriptor.action,
+      duration,
+      dedupKey: descriptor.dedupKey,
+      priority,
+      createdAt: Date.now(),
+      state: 'queued',
+      pausedRemaining: null,
+      runStartedAt: 0,
+      timer: null,
+    }
+    toasts.set(id, t)
+
+    // Decide whether to promote immediately or queue.
+    if (priority === SEVERITY_PRIORITY.error) {
+      preemptForError(priority)
+    }
+    if (visibleCount() < maxVisible) {
+      transitionToVisible(t)
+    }
+    emit()
+    return id
+  }
+
+  return {
+    notify(descriptor: ToastDescriptor): string {
+      return notifyImpl(descriptor)
+    },
+
+    dismiss(id: string): void {
+      const t = toasts.get(id)
+      if (t === undefined) return
+      transitionToDismissed(t)
+    },
+
+    dismissAll(): void {
+      for (const t of toasts.values()) {
+        if (t.state !== 'dismissed') {
+          clearTimer(t)
+          t.state = 'dismissed'
+        }
+      }
+      emit()
+    },
+
+    pause(id: string): void {
+      const t = toasts.get(id)
+      if (t === undefined || t.state !== 'visible') return
+      if (t.timer === null) return // already paused or sticky
+      const elapsed = Date.now() - t.runStartedAt
+      t.pausedRemaining = Math.max(0, t.duration - elapsed)
+      clearTimer(t)
+    },
+
+    resume(id: string): void {
+      const t = toasts.get(id)
+      if (t === undefined || t.state !== 'visible') return
+      if (t.pausedRemaining === null) return
+      const remaining = t.pausedRemaining
+      t.pausedRemaining = null
+      if (remaining <= 0) {
+        transitionToDismissed(t)
+        return
+      }
+      startTimer(t, remaining)
+    },
+
+    pauseAll(): void {
+      for (const t of toasts.values()) {
+        if (t.state !== 'visible' || t.timer === null) continue
+        const elapsed = Date.now() - t.runStartedAt
+        t.pausedRemaining = Math.max(0, t.duration - elapsed)
+        clearTimer(t)
+      }
+    },
+
+    resumeAll(): void {
+      for (const t of toasts.values()) {
+        if (t.state !== 'visible' || t.pausedRemaining === null) continue
+        const remaining = t.pausedRemaining
+        t.pausedRemaining = null
+        if (remaining <= 0) {
+          transitionToDismissed(t)
+          continue
+        }
+        startTimer(t, remaining)
+      }
+    },
+
+    getQueue(): ReadonlyArray<Toast> {
+      return snapshot()
+    },
+
+    subscribe(listener: (queue: ReadonlyArray<Toast>) => void): () => void {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}
+
+export const SEVERITY_TO_ROLE: Readonly<Record<ToastSeverity, 'status' | 'alert'>> =
+  Object.freeze({
+    error: 'alert',
+    warning: 'status',
+    success: 'status',
+    info: 'status',
+  })
+
+export const SEVERITY_TO_ARIA_LIVE: Readonly<
+  Record<ToastSeverity, 'polite' | 'assertive'>
+> = Object.freeze({
+  error: 'assertive',
+  warning: 'polite',
+  success: 'polite',
+  info: 'polite',
+})
+
+export { SEVERITY_PRIORITY, SEVERITY_DEFAULT_DURATION_MS }

--- a/dashboard/design-system/headless-preact/use-toasts.ts
+++ b/dashboard/design-system/headless-preact/use-toasts.ts
@@ -1,0 +1,101 @@
+/**
+ * useToasts — Preact adapter over headless-core/ToastManager.
+ *
+ * Per RFC 0007 §3.3. Returns the live queue + helpers for region
+ * / item ARIA props. Subscribes to manager mutations and bumps a
+ * render counter on each change.
+ *
+ * Pattern note: there is no module-level singleton — production
+ * code allocates one ToastManager at app boot and provides it via
+ * Preact context (see `dashboard/src/contexts/toast-context.ts` —
+ * follow-up consumer migration). This hook reads a manager from
+ * its argument so it can be used with any provider strategy.
+ */
+
+import { useEffect, useState } from 'preact/hooks'
+import {
+  type Toast,
+  type ToastDescriptor,
+  type ToastManager,
+  type ToastSeverity,
+  SEVERITY_TO_ARIA_LIVE,
+  SEVERITY_TO_ROLE,
+} from '../headless-core/toast-manager'
+
+export interface UseToastsResult {
+  readonly toasts: ReadonlyArray<Toast>
+  notify: (descriptor: ToastDescriptor) => string
+  dismiss: (id: string) => void
+}
+
+export function useToasts(manager: ToastManager): UseToastsResult {
+  const [snapshot, setSnapshot] = useState<ReadonlyArray<Toast>>(() => manager.getQueue())
+
+  useEffect(() => {
+    const dispose = manager.subscribe((q) => setSnapshot(q))
+    return dispose
+  }, [manager])
+
+  return {
+    toasts: snapshot,
+    notify: (descriptor) => manager.notify(descriptor),
+    dismiss: (id) => manager.dismiss(id),
+  }
+}
+
+/**
+ * Region-level prop bundle. Spread onto the container that wraps
+ * all rendered toasts, mounted inside `usePortal({ layer: 'toast' })`.
+ */
+export function getToastRegionProps(): {
+  readonly role: 'region'
+  readonly 'aria-label': 'Notifications'
+  readonly 'aria-live': 'polite'
+  readonly 'aria-atomic': 'false'
+} {
+  return Object.freeze({
+    role: 'region' as const,
+    'aria-label': 'Notifications' as const,
+    'aria-live': 'polite' as const,
+    'aria-atomic': 'false' as const,
+  })
+}
+
+/**
+ * Per-toast prop bundle. Spread onto each individual toast item.
+ * Severity drives both `role` and `aria-live` per RFC 0007 §4.
+ */
+export function getToastItemProps(toast: Toast): {
+  readonly id: string
+  readonly role: 'status' | 'alert'
+  readonly 'aria-live': 'polite' | 'assertive'
+  readonly 'data-severity': ToastSeverity
+  readonly 'data-state': 'queued' | 'visible' | 'dismissed'
+} {
+  return Object.freeze({
+    id: toast.id,
+    role: SEVERITY_TO_ROLE[toast.severity],
+    'aria-live': SEVERITY_TO_ARIA_LIVE[toast.severity],
+    'data-severity': toast.severity,
+    'data-state': toast.state,
+  })
+}
+
+/**
+ * Convenience: pause/resume handlers for region-level hover/focus.
+ * Wire onPointerEnter / onFocusCapture / onPointerLeave / onBlurCapture
+ * on the region container.
+ */
+export function getRegionPauseHandlers(manager: ToastManager): {
+  readonly onPointerEnter: () => void
+  readonly onPointerLeave: () => void
+  readonly onFocusCapture: () => void
+  readonly onBlurCapture: () => void
+} {
+  return Object.freeze({
+    onPointerEnter: () => manager.pauseAll(),
+    onPointerLeave: () => manager.resumeAll(),
+    onFocusCapture: () => manager.pauseAll(),
+    onBlurCapture: () => manager.resumeAll(),
+  })
+}


### PR DESCRIPTION
## Summary

Third **implementation PR** of the design-system v2 series. Implements RFC 0007 (#11957, merged) — the priority queue notification manager that fixes today's silent-success / silent-failure / inconsistent-dismiss patterns (Composer "sent" badge with no auto-dismiss, keeper spawn failures buried in `console.error`, board comment posts with no feedback).

## What lands

- **`headless-core/toast-manager.ts`** — singleton manager with priority queue, dedup, hover/focus/region pause, severity → role / aria-live mapping (~280 lines)
- **`headless-core/toast-manager.test.ts`** — 18 vitest cases, all passing
- **`headless-preact/use-toasts.ts`** — adapter with `getToastRegionProps`, `getToastItemProps`, `getRegionPauseHandlers` helpers (~95 lines)

## Test results

```
Test Files  1 passed (1)
     Tests  18 passed (18)
```

## Bug fix during implementation

**Eviction comparator was inverted**. The render comparator (`sortToasts`) puts high-priority + FIFO order (oldest renders first); reusing it for eviction produced the wrong victim (newest evicted instead of oldest at same priority). Separated `moreDismissable()` for eviction: lower priority more dismissable; at same priority, **older more dismissable** (FIFO-evict, not FIFO-show). Test `error preempts oldest info` caught the bug.

## Test categories (18 cases)

- **Notify and visible immediately** (state="visible")
- **Auto-dismiss after duration**; **sticky `duration: 0`** never dismisses
- **Dedup by key** replaces in place + resets timer
- **Priority**: error > warning > success > info; FIFO at same priority
- **`maxVisible` cap** (default 5): 6th queues, dismissal promotes head
- **Error preempts oldest visible low-priority** (eviction comparator)
- Error does NOT preempt another error (no priority ladder)
- **pause / resume** preserves elapsed; **pauseAll / resumeAll** covers region
- **action button surface** (consumer dismisses on click)
- **dismissAll** flips every visible+queued to dismissed
- **`SEVERITY_TO_ROLE`** / **`SEVERITY_TO_ARIA_LIVE`** static maps verified
- subscribe / unsubscribe leak-safety

## Adapter helpers

```ts
useToasts(manager)               // returns { toasts, notify, dismiss }
getToastRegionProps()            // role=region + aria-label + aria-live
getToastItemProps(toast)         // role=alert/status + aria-live + data-state
getRegionPauseHandlers(manager)  // onPointerEnter/Leave + onFocusCapture/BlurCapture
```

Region pause-handlers wire Sonner-style "hovering anywhere in region pauses ALL timers" with one spread.

## Stack

- RFC 0007 (#11957) MERGED — design contract
- RFC 0001 `PortalManager` `toast` layer (z-index 100, already in source.ts) — consumer renders region inside `usePortal({ layer: 'toast' })`
- Independent of RFC 0003 / 0005 (no rover, no menu)

## Test plan

- [x] `pnpm test --run design-system/headless-core/toast-manager.test.ts` — **18/18 PASS**
- [x] No DOM dependency
- [ ] CI Dashboard test workflow runs the full headless-core suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)