### PR TITLE
fix(dashboard): race-cancel immediate recompute + faster proactive recovery

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -207,14 +207,20 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
         | exception exn ->
           (match exn with
            | Compute_timeout _ -> ()
-           | _ when is_internal_race_cancel exn -> ()
+           | _ when is_internal_race_cancel exn ->
+               Log.Dashboard.debug "cache bg-revalidate race-cancel for %s, scheduling early retry" key
            | _ -> Log.Dashboard.warn "cache bg-revalidate failed (%s): %s" key (Printexc.to_string exn));
           atomic_update table (fun map ->
             match SMap.find_opt key map with
             | Some (Computing { token = c; _ }) when c = token ->
               let ts = now () in
               let backoff_grace = stale_grace *. bg_revalidate_backoff_factor in
-              ((), SMap.add key (Ready { value = stale_value; expires_at = ts; stale_until = ts +. backoff_grace }) map)
+              (* After race-cancel, set expires_at = ts so the next lookup
+                 immediately triggers recompute instead of returning stale. *)
+              let expires_at =
+                if is_internal_race_cancel exn then ts else ts +. backoff_grace
+              in
+              ((), SMap.add key (Ready { value = stale_value; expires_at; stale_until = ts +. backoff_grace }) map)
             | _ -> ((), map)
           )
       and restore_stale_ready () =

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -20,8 +20,8 @@ let default_config ~label ~interval_s =
   {
     label;
     interval_s;
-    max_backoff_s = 120.0;
-    failure_threshold = 5;
+    max_backoff_s = 60.0;
+    failure_threshold = 3;
     timeout_s = 10.0;
     on_error = None;
     health_check = None;


### PR DESCRIPTION
## Summary
- Dashboard cache bg-revalidate race-cancel (`Fiber.Not_first`) no longer silently swallowed.
- After race-cancel, sets `expires_at = now` so the next lookup immediately triggers recompute instead of returning stale data.
- Reduces proactive_refresh defaults for faster recovery:
  - `max_backoff_s`: 120 → 60
  - `failure_threshold`: 5 → 3

## Why
Race-cancel in background revalidation was leaving stale data with a long backoff grace, causing persistent "reconnecting"/"no signal" UI states.

## Test plan
- [ ] CI build/lint passes
- [ ] Verify dashboard cache tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)