### PR TITLE
fix: register multimodal routes + expose missing test surfaces

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -143,6 +143,7 @@
    server_routes_http_routes_attribution
    server_routes_http_routes_activity
    server_routes_http_routes_artifacts
+   server_routes_http_routes_multimodal
    server_routes_http_routes_legendary_bash
    server_routes_http_routes_channel_gate
    server_routes_http_routes_sidecar

--- a/lib/server/server_dashboard_http_execution_surfaces.mli
+++ b/lib/server/server_dashboard_http_execution_surfaces.mli
@@ -188,3 +188,15 @@ val pipeline_stage_of_lifecycle_event :
   string -> string option
 
 val paused_of_lifecycle_event : string -> bool option
+
+val seed_execution_cache_for_test : unit -> unit
+
+val patch_surface_json_for_running_keepers :
+  Coord.config -> Yojson.Safe.t -> Yojson.Safe.t
+
+val patch_keeper_row :
+  keeper_name:string ->
+  event:string ->
+  keepalive_running:bool ->
+  Yojson.Safe.t ->
+  Yojson.Safe.t


### PR DESCRIPTION
## Problem

Main branch `dune build` fails with three categories of errors after recent PR merges:

1. **Unbound module** `Server_routes_http_routes_multimodal` — file exists but missing from `lib/dune` modules list (PR #11983).
2. **Unbound value** `Lib.Server_dashboard_http.patch_surface_json_for_running_keepers` — defined in `server_dashboard_http_execution_surfaces.ml` but not exposed in `.mli` (PR #11979).
3. **Unbound value** `Lib.Server_dashboard_http.seed_execution_cache_for_test` — same root cause as #2.
4. **Unbound value** `Lib.Server_dashboard_http.patch_keeper_row` — same root cause as #2.

## Changes

- `lib/dune`: add `server_routes_http_routes_multimodal` to modules list.
- `lib/server/server_dashboard_http_execution_surfaces.mli`: expose `seed_execution_cache_for_test`, `patch_surface_json_for_running_keepers`, and `patch_keeper_row`.

## Verification

```
dune build --root . @all
```

Build passes with no errors.