### PR TITLE
chore: regenerate OCaml structure baseline after #11994

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 1,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 968,
+  "lib_dune_lines": 969,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 8
+  "lib_other_mli_missing": 7
 }


### PR DESCRIPTION
## Context

PR #11994 registered `server_routes_http_routes_multimodal` in `lib/dune`,
increasing `lib_dune_lines` from 968 to 969.

## Changes

- `scripts/ocaml-structure-baseline.json`: update `lib_dune_lines` 968 → 969.
- Also captures `lib_other_mli_missing` drift 8 → 7 from prior merged work.

## Verification

```bash
scripts/ocaml-structure-ratchet.sh --print
# All metrics current == baseline
```