### PR TITLE
feat(headless): RFC 0008 AgentPresenceManager implementation + Preact adapter

### DIFF
--- a/dashboard/design-system/headless-core/agent-presence.test.ts
+++ b/dashboard/design-system/headless-core/agent-presence.test.ts
@@ -1,0 +1,259 @@
+// Pure TS unit tests for AgentPresenceManager. No DOM.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  createAgentPresenceManager,
+  deriveSigil,
+  kSlot,
+  type AgentDescriptor,
+} from './agent-presence'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-04-29T00:00:00Z'))
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+const nick: AgentDescriptor = Object.freeze({
+  id: 'nick0cave',
+  name: 'nick0cave',
+  sigil: { text: 'NC' },
+  colorSlot: 1,
+})
+
+const sangsu: AgentDescriptor = Object.freeze({
+  id: 'sangsu',
+  name: 'sangsu',
+  sigil: { text: 'SS' },
+  colorSlot: 5,
+})
+
+describe('createAgentPresenceManager — register / unregister', () => {
+  it('register adds the agent; has flips true; subscribers fire', () => {
+    const m = createAgentPresenceManager()
+    const calls: number[] = []
+    m.subscribe((snap) => calls.push(snap.length))
+    m.register(nick)
+    expect(m.has('nick0cave')).toBe(true)
+    expect(calls).toEqual([1])
+  })
+
+  it('unregister removes; has flips false; per-agent listeners cleaned', () => {
+    const m = createAgentPresenceManager()
+    m.register(nick)
+    m.unregister('nick0cave')
+    expect(m.has('nick0cave')).toBe(false)
+  })
+})
+
+describe('createAgentPresenceManager — updateState', () => {
+  it('flips state, updates stateChangedAt, fires subscribers', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick] })
+    const calls: string[] = []
+    m.subscribe(() => calls.push('snap'))
+    vi.advanceTimersByTime(1000)
+    m.updateState('nick0cave', 'working')
+    const agent = m.agents.get('nick0cave')!
+    expect(agent.state).toBe('working')
+    expect(agent.stateChangedAt).toBe(new Date('2026-04-29T00:00:01Z').toISOString())
+    expect(calls).toEqual(['snap'])
+  })
+
+  it('no-op on unknown id', () => {
+    const m = createAgentPresenceManager()
+    let fired = 0
+    m.subscribe(() => {
+      fired += 1
+    })
+    m.updateState('not-there', 'working')
+    expect(fired).toBe(0)
+  })
+
+  it('no-op when state matches current', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick] })
+    let fired = 0
+    m.subscribe(() => {
+      fired += 1
+    })
+    m.updateState('nick0cave', 'idle')
+    expect(fired).toBe(0)
+  })
+})
+
+describe('createAgentPresenceManager — announceStateChange', () => {
+  it('working -> polite "is now working"', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick] })
+    m.updateState('nick0cave', 'working')
+    const ann = m.announceStateChange('nick0cave', 'idle')
+    expect(ann).not.toBeNull()
+    expect(ann!.text).toBe('nick0cave is now working')
+    expect(ann!.assertive).toBe(false)
+  })
+
+  it('error -> ASSERTIVE "reported an error"', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick] })
+    m.updateState('nick0cave', 'error')
+    const ann = m.announceStateChange('nick0cave', 'working')
+    expect(ann!.text).toBe('nick0cave reported an error')
+    expect(ann!.assertive).toBe(true)
+  })
+
+  it('idle / thinking -> null (silent)', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick] })
+    m.updateState('nick0cave', 'thinking')
+    expect(m.announceStateChange('nick0cave', 'working')).toBeNull()
+  })
+})
+
+describe('createAgentPresenceManager — subscribe / subscribeAgent', () => {
+  it('subscribeAgent listener fires only for matching id', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick, sangsu] })
+    const nickFires: string[] = []
+    const sangsuFires: string[] = []
+    m.subscribeAgent('nick0cave', (a) => nickFires.push(a.state))
+    m.subscribeAgent('sangsu', (a) => sangsuFires.push(a.state))
+    m.updateState('nick0cave', 'working')
+    m.updateState('sangsu', 'error')
+    expect(nickFires).toEqual(['working'])
+    expect(sangsuFires).toEqual(['error'])
+  })
+
+  it('subscribe / unsubscribe is leak-safe', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick] })
+    let fired = 0
+    const dispose = m.subscribe(() => {
+      fired += 1
+    })
+    m.updateState('nick0cave', 'working')
+    expect(fired).toBe(1)
+    dispose()
+    m.updateState('nick0cave', 'idle')
+    expect(fired).toBe(1)
+  })
+})
+
+describe('createAgentPresenceManager — byState / withinFile', () => {
+  it('byState filters', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick, sangsu] })
+    m.updateState('nick0cave', 'working')
+    expect(m.byState('working').map((a) => a.id)).toEqual(['nick0cave'])
+    expect(m.byState('idle').map((a) => a.id)).toEqual(['sangsu'])
+  })
+
+  it('withinFile filters by currentFile', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick, sangsu] })
+    m.updateCursor('nick0cave', 'app.ts', 10, 5)
+    expect(m.withinFile('app.ts').map((a) => a.id)).toEqual(['nick0cave'])
+    expect(m.withinFile('other.ts')).toHaveLength(0)
+  })
+})
+
+describe('createAgentPresenceManager — cursor + heartbeat', () => {
+  it('updateCursor sets currentFile + line/column', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick] })
+    m.updateCursor('nick0cave', 'main.ts', 42, 7)
+    const a = m.agents.get('nick0cave')!
+    expect(a.currentFile).toBe('main.ts')
+    expect(a.cursor).toEqual({ line: 42, column: 7 })
+  })
+
+  it('clearCursor unsets cursor + currentFile', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick] })
+    m.updateCursor('nick0cave', 'main.ts', 42, 7)
+    m.clearCursor('nick0cave')
+    const a = m.agents.get('nick0cave')!
+    expect(a.cursor).toBeUndefined()
+    expect(a.currentFile).toBeUndefined()
+  })
+
+  it('heartbeat resets idleMs to 0', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick] })
+    m.heartbeat('nick0cave')
+    expect(m.agents.get('nick0cave')!.idleMs).toBe(0)
+  })
+})
+
+describe('deriveSigil + kSlot', () => {
+  it('deriveSigil takes first 2 alpha chars uppercase', () => {
+    expect(deriveSigil('nick0cave').text).toBe('NI')
+    expect(deriveSigil('alice').text).toBe('AL')
+    expect(deriveSigil('Q').text).toBe('Q?')
+  })
+
+  it('kSlot is deterministic for same id', () => {
+    expect(kSlot('nick0cave')).toBe(kSlot('nick0cave'))
+    expect(kSlot('sangsu')).toBe(kSlot('sangsu'))
+  })
+
+  it('kSlot returns a slot in 1..12', () => {
+    for (const id of ['a', 'b', 'foo', 'nick0cave', 'sangsu', 'rama']) {
+      const slot = kSlot(id)
+      expect(slot).toBeGreaterThanOrEqual(1)
+      expect(slot).toBeLessThanOrEqual(12)
+    }
+  })
+})
+
+describe('createAgentPresenceManager — sigil disambiguation', () => {
+  it('default policy adds superscript digit suffix on collision', () => {
+    const m = createAgentPresenceManager()
+    m.register({ id: 'a', name: 'nick0cave', sigil: { text: 'NC' }, colorSlot: 1 })
+    m.register({ id: 'b', name: 'nicolas-cage', sigil: { text: 'NC' }, colorSlot: 2 })
+    m.register({ id: 'c', name: 'northcat', sigil: { text: 'NC' }, colorSlot: 3 })
+    expect(m.agents.get('a')!.sigil).toEqual({ text: 'NC' })
+    expect(m.agents.get('b')!.sigil.suffix).toBe('²')
+    expect(m.agents.get('c')!.sigil.suffix).toBe('³')
+  })
+
+  it('custom policy overrides default', () => {
+    const m = createAgentPresenceManager({
+      sigilDisambiguate: (cand) => ({ text: cand.text, suffix: '!' }),
+    })
+    m.register({ id: 'a', name: 'a', sigil: { text: 'XX' }, colorSlot: 1 })
+    m.register({ id: 'b', name: 'b', sigil: { text: 'XX' }, colorSlot: 2 })
+    expect(m.agents.get('a')!.sigil.suffix).toBe('!')
+    expect(m.agents.get('b')!.sigil.suffix).toBe('!')
+  })
+})
+
+describe('createAgentPresenceManager — reducedMotion getter', () => {
+  it('reducedMotion returns the configured fn result', () => {
+    let flag = false
+    const m = createAgentPresenceManager({ reducedMotion: () => flag })
+    expect(m.reducedMotion()).toBe(false)
+    flag = true
+    expect(m.reducedMotion()).toBe(true)
+  })
+})
+
+describe('createAgentPresenceManager — high-throughput correctness', () => {
+  it('genuine state transitions emit; same-state updates do not (no-op)', () => {
+    const m = createAgentPresenceManager()
+    for (let i = 0; i < 12; i += 1) {
+      m.register({
+        id: `k${i}`,
+        name: `keeper-${i}`,
+        sigil: { text: `K${i}` },
+        colorSlot: ((i % 12) + 1) as never,
+      })
+    }
+    let fires = 0
+    const dispose = m.subscribe(() => {
+      fires += 1
+    })
+    // 12 agents start as 'idle'. Each toggle alternates between
+    // 'working' and 'idle' for the agent — every call genuinely
+    // changes state, so every call should emit.
+    const states = ['working', 'idle', 'working', 'idle', 'working'] as const
+    for (let pass = 0; pass < states.length; pass += 1) {
+      for (let agent = 0; agent < 12; agent += 1) {
+        m.updateState(`k${agent}`, states[pass])
+      }
+    }
+    expect(fires).toBe(12 * states.length)
+    dispose()
+    m.updateState('k0', 'thinking')
+    expect(fires).toBe(12 * states.length)
+  })
+})

--- a/dashboard/design-system/headless-core/agent-presence.test.ts
+++ b/dashboard/design-system/headless-core/agent-presence.test.ts
@@ -246,9 +246,9 @@ describe('createAgentPresenceManager — high-throughput correctness', () => {
     // 'working' and 'idle' for the agent — every call genuinely
     // changes state, so every call should emit.
     const states = ['working', 'idle', 'working', 'idle', 'working'] as const
-    for (let pass = 0; pass < states.length; pass += 1) {
+    for (const next of states) {
       for (let agent = 0; agent < 12; agent += 1) {
-        m.updateState(`k${agent}`, states[pass])
+        m.updateState(`k${agent}`, next)
       }
     }
     expect(fires).toBe(12 * states.length)

--- a/dashboard/design-system/headless-core/agent-presence.ts
+++ b/dashboard/design-system/headless-core/agent-presence.ts
@@ -1,0 +1,342 @@
+/**
+ * AgentPresenceManager — canonical agent registry (RFC 0008).
+ *
+ * Replaces today's drift across keeper-card / agent-monitor / lifeline /
+ * composer mention popover where each surface owns its own roster cache.
+ * One manager owns id / name / sigil / colorSlot / state / cursor /
+ * heartbeat for every agent; consumers subscribe and render.
+ *
+ * MVP scope (RFC 0008 §3, §4, §5):
+ *   - 6-state model (idle/working/thinking/waiting_for_human/error/completed)
+ *   - register / unregister / has / updateState / updateCursor /
+ *     clearCursor / heartbeat
+ *   - byState / withinFile queries
+ *   - subscribe (snapshot) and subscribeAgent (per-agent listener)
+ *   - announceStateChange returning SR text per transition (assertive
+ *     for *->error, polite otherwise)
+ *   - deriveSigil with collision suffix policy (NC / NC² / NC³ via
+ *     superscript digits)
+ *   - kSlot deterministic FNV-1a mod 12 mapping
+ *   - reducedMotion getter (consumer keys off animation; primitive is
+ *     animation-agnostic)
+ *
+ * Out of scope (RFC 0008 §10):
+ *   - Network sync (consumer adapter calls update*)
+ *   - RBAC / permission filtering
+ *   - Stale heartbeat -> synthetic 'stalled' state (consumer-side
+ *     based on idleMs)
+ */
+
+export type AgentState =
+  | 'idle'
+  | 'working'
+  | 'thinking'
+  | 'waiting_for_human'
+  | 'error'
+  | 'completed'
+
+export type AgentColorSlot =
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+
+export interface AgentSigil {
+  readonly text: string
+  readonly suffix?: string
+}
+
+export interface AgentDescriptor {
+  readonly id: string
+  readonly name: string
+  readonly sigil: AgentSigil
+  readonly colorSlot: AgentColorSlot
+}
+
+export interface AgentRuntimeState {
+  readonly state: AgentState
+  readonly currentFile?: string
+  readonly cursor?: { readonly line: number; readonly column: number }
+  readonly stateChangedAt: string
+  readonly idleMs?: number
+}
+
+export interface Agent extends AgentDescriptor, AgentRuntimeState {}
+
+export interface AgentPresenceOptions {
+  initialAgents?: ReadonlyArray<AgentDescriptor>
+  reducedMotion?: () => boolean
+  sigilDisambiguate?: (
+    candidate: AgentSigil,
+    existing: ReadonlyArray<AgentSigil>,
+  ) => AgentSigil
+}
+
+export interface StateChangeAnnouncement {
+  readonly text: string
+  readonly assertive: boolean
+}
+
+export interface AgentPresenceManager {
+  readonly agents: ReadonlyMap<string, Agent>
+
+  register(agent: AgentDescriptor): void
+  unregister(id: string): void
+  has(id: string): boolean
+
+  updateState(id: string, state: AgentState): void
+  updateCursor(id: string, file: string, line: number, column: number): void
+  clearCursor(id: string): void
+  heartbeat(id: string): void
+
+  byState(state: AgentState): ReadonlyArray<Agent>
+  withinFile(file: string): ReadonlyArray<Agent>
+
+  subscribe(listener: (snapshot: ReadonlyArray<Agent>) => void): () => void
+  subscribeAgent(id: string, listener: (agent: Agent) => void): () => void
+
+  announceStateChange(id: string, prevState: AgentState): StateChangeAnnouncement | null
+
+  reducedMotion(): boolean
+}
+
+const SUPERSCRIPT_DIGITS = ['¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹']
+
+function defaultDisambiguate(
+  candidate: AgentSigil,
+  existing: ReadonlyArray<AgentSigil>,
+): AgentSigil {
+  let count = 0
+  for (const e of existing) {
+    if (e.text === candidate.text) count += 1
+  }
+  if (count === 0) return candidate
+  // Use superscript digit per RFC 0008 §6 default.
+  const suffix = SUPERSCRIPT_DIGITS[count] ?? `^${count + 1}`
+  return Object.freeze({ text: candidate.text, suffix })
+}
+
+/** FNV-1a hash mod 12, slots numbered 1..12. */
+export function kSlot(id: string): AgentColorSlot {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < id.length; i += 1) {
+    hash ^= id.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  // imul keeps it i32; coerce to unsigned via >>> 0
+  const unsigned = hash >>> 0
+  const slot = (unsigned % 12) + 1
+  return slot as AgentColorSlot
+}
+
+export function deriveSigil(name: string): AgentSigil {
+  const cleaned = name.replace(/[^A-Za-z]/g, '').toUpperCase()
+  const text = cleaned.length >= 2 ? cleaned.slice(0, 2) : cleaned.padEnd(2, '?')
+  return Object.freeze({ text })
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+export function createAgentPresenceManager(
+  opts?: AgentPresenceOptions,
+): AgentPresenceManager {
+  const reducedMotionFn = opts?.reducedMotion ?? (() => false)
+  const disambiguate = opts?.sigilDisambiguate ?? defaultDisambiguate
+
+  const map = new Map<string, Agent>()
+  const listeners = new Set<(snapshot: ReadonlyArray<Agent>) => void>()
+  const perAgent = new Map<string, Set<(agent: Agent) => void>>()
+
+  function snapshot(): ReadonlyArray<Agent> {
+    return Object.freeze([...map.values()])
+  }
+
+  function emit(): void {
+    const snap = snapshot()
+    for (const listener of listeners) listener(snap)
+  }
+
+  function emitAgent(id: string): void {
+    const agent = map.get(id)
+    if (agent === undefined) return
+    const set = perAgent.get(id)
+    if (set === undefined) return
+    for (const listener of set) listener(agent)
+  }
+
+  function existingSigils(excludeId?: string): ReadonlyArray<AgentSigil> {
+    const out: AgentSigil[] = []
+    for (const a of map.values()) {
+      if (a.id === excludeId) continue
+      out.push(a.sigil)
+    }
+    return out
+  }
+
+  function setAgent(next: Agent): void {
+    map.set(next.id, next)
+    emit()
+    emitAgent(next.id)
+  }
+
+  // Bootstrap initial roster.
+  if (opts?.initialAgents !== undefined) {
+    for (const desc of opts.initialAgents) {
+      const sigil = disambiguate(desc.sigil, existingSigils(desc.id))
+      const agent: Agent = Object.freeze({
+        ...desc,
+        sigil,
+        state: 'idle',
+        stateChangedAt: nowIso(),
+      })
+      map.set(agent.id, agent)
+    }
+  }
+
+  return {
+    get agents() {
+      return map as ReadonlyMap<string, Agent>
+    },
+
+    register(desc: AgentDescriptor): void {
+      const sigil = disambiguate(desc.sigil, existingSigils(desc.id))
+      const prior = map.get(desc.id)
+      const agent: Agent = Object.freeze({
+        ...desc,
+        sigil,
+        state: prior?.state ?? 'idle',
+        currentFile: prior?.currentFile,
+        cursor: prior?.cursor,
+        stateChangedAt: prior?.stateChangedAt ?? nowIso(),
+        idleMs: prior?.idleMs,
+      })
+      setAgent(agent)
+    },
+
+    unregister(id: string): void {
+      if (!map.has(id)) return
+      map.delete(id)
+      perAgent.delete(id)
+      emit()
+    },
+
+    has(id: string): boolean {
+      return map.has(id)
+    },
+
+    updateState(id: string, state: AgentState): void {
+      const prior = map.get(id)
+      if (prior === undefined) return
+      if (prior.state === state) return
+      const next: Agent = Object.freeze({
+        ...prior,
+        state,
+        stateChangedAt: nowIso(),
+      })
+      setAgent(next)
+    },
+
+    updateCursor(id: string, file: string, line: number, column: number): void {
+      const prior = map.get(id)
+      if (prior === undefined) return
+      const next: Agent = Object.freeze({
+        ...prior,
+        currentFile: file,
+        cursor: Object.freeze({ line, column }),
+      })
+      setAgent(next)
+    },
+
+    clearCursor(id: string): void {
+      const prior = map.get(id)
+      if (prior === undefined) return
+      // omit currentFile / cursor by destructuring
+      const { currentFile: _f, cursor: _c, ...rest } = prior
+      const next = Object.freeze({ ...rest } as Agent)
+      setAgent(next)
+    },
+
+    heartbeat(id: string): void {
+      const prior = map.get(id)
+      if (prior === undefined) return
+      const next: Agent = Object.freeze({ ...prior, idleMs: 0 })
+      setAgent(next)
+    },
+
+    byState(state: AgentState): ReadonlyArray<Agent> {
+      const out: Agent[] = []
+      for (const a of map.values()) {
+        if (a.state === state) out.push(a)
+      }
+      return Object.freeze(out)
+    },
+
+    withinFile(file: string): ReadonlyArray<Agent> {
+      const out: Agent[] = []
+      for (const a of map.values()) {
+        if (a.currentFile === file) out.push(a)
+      }
+      return Object.freeze(out)
+    },
+
+    subscribe(listener: (snapshot: ReadonlyArray<Agent>) => void): () => void {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+
+    subscribeAgent(id: string, listener: (agent: Agent) => void): () => void {
+      let set = perAgent.get(id)
+      if (set === undefined) {
+        set = new Set()
+        perAgent.set(id, set)
+      }
+      set.add(listener)
+      return () => {
+        const s = perAgent.get(id)
+        if (s !== undefined) s.delete(listener)
+      }
+    },
+
+    announceStateChange(
+      id: string,
+      _prevState: AgentState,
+    ): StateChangeAnnouncement | null {
+      const agent = map.get(id)
+      if (agent === undefined) return null
+      const name = agent.name
+      switch (agent.state) {
+        case 'working':
+          return Object.freeze({ text: `${name} is now working`, assertive: false })
+        case 'waiting_for_human':
+          return Object.freeze({
+            text: `${name} is waiting for your input`,
+            assertive: false,
+          })
+        case 'error':
+          return Object.freeze({ text: `${name} reported an error`, assertive: true })
+        case 'completed':
+          return Object.freeze({ text: `${name} completed`, assertive: false })
+        case 'thinking':
+        case 'idle':
+        default:
+          return null
+      }
+    },
+
+    reducedMotion(): boolean {
+      return reducedMotionFn()
+    },
+  }
+}

--- a/dashboard/design-system/headless-preact/use-agent-presence.ts
+++ b/dashboard/design-system/headless-preact/use-agent-presence.ts
@@ -1,0 +1,56 @@
+/**
+ * useAgentPresence — Preact adapter over headless-core/AgentPresenceManager.
+ *
+ * Per RFC 0008 §3.4. Hooks for whole-snapshot, per-agent, and
+ * by-state subscriptions. The manager is provided externally
+ * (typically via Preact context allocated at app boot) so multiple
+ * surfaces share one canonical roster.
+ */
+
+import { useEffect, useState } from 'preact/hooks'
+import type {
+  Agent,
+  AgentPresenceManager,
+  AgentState,
+} from '../headless-core/agent-presence'
+
+export function useAgentPresence(manager: AgentPresenceManager): {
+  readonly agents: ReadonlyArray<Agent>
+} {
+  const [snapshot, setSnapshot] = useState<ReadonlyArray<Agent>>(() => [
+    ...manager.agents.values(),
+  ])
+  useEffect(() => {
+    const dispose = manager.subscribe((s) => setSnapshot(s))
+    return dispose
+  }, [manager])
+  return { agents: snapshot }
+}
+
+export function useAgent(
+  manager: AgentPresenceManager,
+  id: string,
+): Agent | undefined {
+  const [agent, setAgent] = useState<Agent | undefined>(() => manager.agents.get(id))
+  useEffect(() => {
+    setAgent(manager.agents.get(id))
+    const dispose = manager.subscribeAgent(id, (a) => setAgent(a))
+    return dispose
+  }, [manager, id])
+  return agent
+}
+
+export function useAgentsByState(
+  manager: AgentPresenceManager,
+  state: AgentState,
+): ReadonlyArray<Agent> {
+  const [agents, setAgents] = useState<ReadonlyArray<Agent>>(() =>
+    manager.byState(state),
+  )
+  useEffect(() => {
+    setAgents(manager.byState(state))
+    const dispose = manager.subscribe(() => setAgents(manager.byState(state)))
+    return dispose
+  }, [manager, state])
+  return agents
+}


### PR DESCRIPTION
## Summary

Implements RFC 0008 (#11961, merged) — the canonical agent registry that fixes today's drift across **keeper-card** / **agent-monitor** / **lifeline** / **composer mention dropdown**. Each surface owns its own roster cache today and races on SSE deliveries; this manager is the single source of truth.

## What lands

- `headless-core/agent-presence.ts` (~310 lines)
- `headless-core/agent-presence.test.ts` (22 cases, **all passing**)
- `headless-preact/use-agent-presence.ts` — 3 hooks: `useAgentPresence`, `useAgent`, `useAgentsByState`

## Test results

```
Test Files  1 passed (1)
     Tests  22 passed (22)
```

## Highlights

- **6-state model** with announce-text + assertive-flag mapping (error → assertive, others polite, idle/thinking silent).
- **`deriveSigil`** + **`kSlot`** helpers exported. FNV-1a mod 12 via `Math.imul` for 32-bit deterministic hashing.
- **Sigil collision policy** uses superscript digits (NC / NC² / NC³); pluggable via `opts.sigilDisambiguate`.
- **`reducedMotion()` getter**. Primitive itself is animation-agnostic — consumer keys off `agent.state` and the flag.
- **Subscribe leak-safety**: per-agent listeners cleaned on `unregister`; whole-snapshot listeners cleanly disposed.

## Unblocks

RFC 0009 (TaskQueue), RFC 0010 (CollaborationCursor), RFC 0011 (InlineSuggestion) — all cross-reference `Agent` from this RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)