### PR TITLE
feat(headless): RFC 0012 KeyboardShortcutManager implementation + Preact adapter

### DIFF
--- a/dashboard/design-system/headless-core/keyboard-shortcuts.test.ts
+++ b/dashboard/design-system/headless-core/keyboard-shortcuts.test.ts
@@ -1,0 +1,315 @@
+// Pure TS unit tests for KeyboardShortcutManager. No DOM.
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createKeyboardShortcutManager,
+  type ShortcutKeyEvent,
+} from './keyboard-shortcuts'
+
+function makeEvent(opts: Partial<ShortcutKeyEvent> & { key: string }): ShortcutKeyEvent {
+  let prevented = false
+  let stopped = false
+  return {
+    key: opts.key,
+    metaKey: opts.metaKey,
+    ctrlKey: opts.ctrlKey,
+    shiftKey: opts.shiftKey,
+    altKey: opts.altKey,
+    target: opts.target ?? null,
+    preventDefault() {
+      prevented = true
+    },
+    stopPropagation() {
+      stopped = true
+    },
+    get _prevented() {
+      return prevented
+    },
+    get _stopped() {
+      return stopped
+    },
+  } as ShortcutKeyEvent & { readonly _prevented: boolean; readonly _stopped: boolean }
+}
+
+describe('createKeyboardShortcutManager — register / unregister', () => {
+  it('register returns dispose; getById round-trips', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    const action = vi.fn()
+    const dispose = m.register({
+      id: 'ide.toggle-sidebar',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: 'toggle sidebar',
+      scope: 'global',
+      action,
+    })
+    expect(m.getById('ide.toggle-sidebar')).toBeDefined()
+    dispose()
+    expect(m.getById('ide.toggle-sidebar')).toBeUndefined()
+  })
+
+  it('unregisterAll(prefix) removes only matching ids', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    m.register({
+      id: 'ide.tab.close',
+      chord: { key: 'w', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      action: () => {},
+    })
+    m.register({
+      id: 'editor.format',
+      chord: { key: 'l', modifiers: ['Mod', 'Shift'] },
+      description: '',
+      scope: 'global',
+      action: () => {},
+    })
+    m.unregisterAll('ide.')
+    expect(m.getById('ide.tab.close')).toBeUndefined()
+    expect(m.getById('editor.format')).toBeDefined()
+  })
+
+  it('duplicate id replaces and warns', () => {
+    const warnings: string[] = []
+    const m = createKeyboardShortcutManager({
+      platform: 'mac',
+      warn: (msg) => warnings.push(msg),
+    })
+    m.register({
+      id: 'x',
+      chord: { key: 'a', modifiers: [] },
+      description: '',
+      scope: 'global',
+      action: () => {},
+    })
+    m.register({
+      id: 'x',
+      chord: { key: 'b', modifiers: [] },
+      description: '',
+      scope: 'global',
+      action: () => {},
+    })
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('already registered')
+  })
+})
+
+describe('createKeyboardShortcutManager — chord matching (mac platform)', () => {
+  it('Meta+B matches Mod+B chord', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    const action = vi.fn()
+    m.register({
+      id: 'sidebar',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      action,
+    })
+    expect(m.dispatch(makeEvent({ key: 'b', metaKey: true }))).toBe(true)
+    expect(action).toHaveBeenCalledOnce()
+  })
+
+  it('Meta+B does NOT match Mod+Shift+B chord (exact modifier match)', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    const action = vi.fn()
+    m.register({
+      id: 'b',
+      chord: { key: 'b', modifiers: ['Mod', 'Shift'] },
+      description: '',
+      scope: 'global',
+      action,
+    })
+    expect(m.dispatch(makeEvent({ key: 'b', metaKey: true }))).toBe(false)
+    expect(action).not.toHaveBeenCalled()
+  })
+
+  it('Ctrl+B does NOT match Mod+B on mac (Mod is Meta there)', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    const action = vi.fn()
+    m.register({
+      id: 'b',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      action,
+    })
+    expect(m.dispatch(makeEvent({ key: 'b', ctrlKey: true }))).toBe(false)
+    expect(action).not.toHaveBeenCalled()
+  })
+
+  it('Ctrl+B matches Mod+B on linux', () => {
+    const m = createKeyboardShortcutManager({ platform: 'linux' })
+    const action = vi.fn()
+    m.register({
+      id: 'b',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      action,
+    })
+    expect(m.dispatch(makeEvent({ key: 'b', ctrlKey: true }))).toBe(true)
+    expect(action).toHaveBeenCalledOnce()
+  })
+})
+
+describe('createKeyboardShortcutManager — preserveInInputs', () => {
+  it('default preserveInInputs=undefined drops shortcuts inside <input>', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    const action = vi.fn()
+    m.register({
+      id: 'x',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      action,
+    })
+    expect(
+      m.dispatch(makeEvent({ key: 'b', metaKey: true, target: { tagName: 'INPUT' } })),
+    ).toBe(false)
+    expect(action).not.toHaveBeenCalled()
+  })
+
+  it('preserveInInputs=true fires inside <input>', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    const action = vi.fn()
+    m.register({
+      id: 'x',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      preserveInInputs: true,
+      action,
+    })
+    expect(
+      m.dispatch(makeEvent({ key: 'b', metaKey: true, target: { tagName: 'INPUT' } })),
+    ).toBe(true)
+    expect(action).toHaveBeenCalledOnce()
+  })
+
+  it('contenteditable counts as input', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    const action = vi.fn()
+    m.register({
+      id: 'x',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      action,
+    })
+    expect(
+      m.dispatch(
+        makeEvent({ key: 'b', metaKey: true, target: { isContentEditable: true } }),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('createKeyboardShortcutManager — formatChord', () => {
+  it('mac uses ⌘ for Mod', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    expect(m.formatChord({ key: 'b', modifiers: ['Mod'] })).toBe('⌘+B')
+  })
+
+  it('win/linux uses Ctrl for Mod', () => {
+    const m = createKeyboardShortcutManager({ platform: 'linux' })
+    expect(m.formatChord({ key: 'b', modifiers: ['Mod'] })).toBe('Ctrl+B')
+  })
+
+  it('platform override per call', () => {
+    const m = createKeyboardShortcutManager({ platform: 'linux' })
+    expect(m.formatChord({ key: 'b', modifiers: ['Mod'] }, 'mac')).toBe('⌘+B')
+  })
+})
+
+describe('createKeyboardShortcutManager — formatAria', () => {
+  it('mac emits Meta+B', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    expect(m.formatAria({ key: 'b', modifiers: ['Mod'] })).toBe('Meta+B')
+  })
+
+  it('linux emits Control+B', () => {
+    const m = createKeyboardShortcutManager({ platform: 'linux' })
+    expect(m.formatAria({ key: 'b', modifiers: ['Mod'] })).toBe('Control+B')
+  })
+
+  it('Mod+Shift+B emits in canonical W3C order', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    expect(m.formatAria({ key: 'b', modifiers: ['Mod', 'Shift'] })).toBe('Meta+Shift+B')
+  })
+})
+
+describe('createKeyboardShortcutManager — priority + last-registered tie-break', () => {
+  it('higher priority wins on conflict', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    const lo = vi.fn()
+    const hi = vi.fn()
+    m.register({
+      id: 'lo',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      priority: 0,
+      action: lo,
+    })
+    m.register({
+      id: 'hi',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      priority: 10,
+      action: hi,
+    })
+    m.dispatch(makeEvent({ key: 'b', metaKey: true }))
+    expect(hi).toHaveBeenCalledOnce()
+    expect(lo).not.toHaveBeenCalled()
+  })
+
+  it('same priority -> last-registered wins', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    const first = vi.fn()
+    const last = vi.fn()
+    m.register({
+      id: 'first',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      action: first,
+    })
+    m.register({
+      id: 'last',
+      chord: { key: 'b', modifiers: ['Mod'] },
+      description: '',
+      scope: 'global',
+      action: last,
+    })
+    m.dispatch(makeEvent({ key: 'b', metaKey: true }))
+    expect(last).toHaveBeenCalledOnce()
+  })
+})
+
+describe('createKeyboardShortcutManager — subscribe', () => {
+  it('subscriber fires on register / unregister', () => {
+    const m = createKeyboardShortcutManager({ platform: 'mac' })
+    let count = 0
+    const dispose = m.subscribe(() => {
+      count += 1
+    })
+    const undo = m.register({
+      id: 'a',
+      chord: { key: 'a', modifiers: [] },
+      description: '',
+      scope: 'global',
+      action: () => {},
+    })
+    expect(count).toBe(1)
+    undo()
+    expect(count).toBe(2)
+    dispose()
+    m.register({
+      id: 'b',
+      chord: { key: 'b', modifiers: [] },
+      description: '',
+      scope: 'global',
+      action: () => {},
+    })
+    expect(count).toBe(2)
+  })
+})

--- a/dashboard/design-system/headless-core/keyboard-shortcuts.ts
+++ b/dashboard/design-system/headless-core/keyboard-shortcuts.ts
@@ -1,0 +1,322 @@
+/**
+ * KeyboardShortcutManager — global IDE shortcut registry (RFC 0012).
+ *
+ * Replaces ad-hoc keydown bindings scattered across the dashboard
+ * (Cmd+K palette, modal Escape, editor shortcuts). One registry owns
+ * chord-to-action bindings, surfaces them via aria-keyshortcuts, and
+ * applies the precedence policy when scopes overlap.
+ *
+ * MVP scope (RFC 0012 §3, §4, §5):
+ *   - Chord matching with Mod modifier (Cmd on macOS, Ctrl elsewhere)
+ *   - Scope: 'global' | { within: () => HTMLElement | null }
+ *   - preserveInInputs default true (Cmd+B fires in name field;
+ *     Tab does NOT steal focus inside text input)
+ *   - Priority tie-break with last-registered wins (with warning)
+ *   - formatChord: platform-aware (⌘ on macOS, Ctrl elsewhere)
+ *   - formatAria: W3C standard tokens (Meta+B / Control+B)
+ *   - subscribe for palette / settings UI
+ *
+ * Out of scope (RFC 0012 §10):
+ *   - Chord sequences (Mod+K Z) — future RFC
+ *   - User-customizable keymaps — register() open for plugins
+ *   - Replace Monaco editor-internal shortcuts
+ */
+
+export type Modifier = 'Mod' | 'Shift' | 'Alt' | 'Ctrl'
+
+export interface Chord {
+  readonly key: string
+  readonly modifiers: ReadonlyArray<Modifier>
+}
+
+export type ScopeWithin = { readonly within: () => HTMLElement | null }
+export type ShortcutScope = 'global' | ScopeWithin
+
+export interface ShortcutDescriptor {
+  readonly id: string
+  readonly chord: Chord
+  readonly description: string
+  readonly scope: ShortcutScope
+  readonly preserveInInputs?: boolean
+  readonly priority?: number
+  readonly action: (e: KeyboardEvent) => void
+}
+
+export interface ShortcutKeyEvent {
+  readonly key: string
+  readonly metaKey?: boolean
+  readonly ctrlKey?: boolean
+  readonly shiftKey?: boolean
+  readonly altKey?: boolean
+  readonly target?: { readonly tagName?: string; readonly isContentEditable?: boolean } | null
+  preventDefault(): void
+  stopPropagation(): void
+}
+
+export type Platform = 'mac' | 'win' | 'linux'
+
+export interface KeyboardShortcutManager {
+  register(s: ShortcutDescriptor): () => void
+  unregisterAll(idPrefix?: string): void
+  getAll(): ReadonlyArray<ShortcutDescriptor>
+  getById(id: string): ShortcutDescriptor | undefined
+
+  formatChord(chord: Chord, platform?: Platform): string
+  formatAria(chord: Chord): string
+
+  /** Manager-side dispatch. Consumer wires a single keydown listener
+   *  at the app root and calls this with each event. */
+  dispatch(event: ShortcutKeyEvent): boolean
+
+  subscribe(listener: (shortcuts: ReadonlyArray<ShortcutDescriptor>) => void): () => void
+}
+
+export interface KeyboardShortcutManagerOptions {
+  /** Override platform detection (test). Default reads navigator.platform. */
+  platform?: Platform
+  /** Sink for diagnostic warnings. Default console.warn. Tests inject
+   *  a spy so we can assert duplicate-registration warnings. */
+  warn?: (message: string) => void
+}
+
+function detectPlatform(): Platform {
+  if (typeof navigator === 'undefined') return 'linux'
+  const p = navigator.platform.toLowerCase()
+  if (p.includes('mac')) return 'mac'
+  if (p.includes('win')) return 'win'
+  return 'linux'
+}
+
+function modKeyForPlatform(platform: Platform): 'meta' | 'ctrl' {
+  return platform === 'mac' ? 'meta' : 'ctrl'
+}
+
+function eventModSet(event: ShortcutKeyEvent): ReadonlySet<Modifier> {
+  const out = new Set<Modifier>()
+  if (event.metaKey === true) out.add('Mod')
+  if (event.ctrlKey === true) {
+    // ctrlKey on mac is Ctrl, not Mod. On other platforms it is Mod.
+    // We can't infer platform from event alone; assume both — chord
+    // matching below normalizes Mod against the active platform.
+    out.add('Ctrl')
+  }
+  if (event.shiftKey === true) out.add('Shift')
+  if (event.altKey === true) out.add('Alt')
+  return out
+}
+
+function chordMatches(
+  chord: Chord,
+  event: ShortcutKeyEvent,
+  platform: Platform,
+): boolean {
+  if (chord.key.toLowerCase() !== event.key.toLowerCase()) return false
+  const eventMods = eventModSet(event)
+  const wantsMod = chord.modifiers.includes('Mod')
+  const wantsShift = chord.modifiers.includes('Shift')
+  const wantsAlt = chord.modifiers.includes('Alt')
+  const wantsCtrl = chord.modifiers.includes('Ctrl')
+
+  // Mod resolution: on mac wants metaKey; elsewhere wants ctrlKey.
+  if (wantsMod) {
+    const modKey = modKeyForPlatform(platform)
+    const has = modKey === 'meta' ? event.metaKey === true : event.ctrlKey === true
+    if (!has) return false
+  }
+  // Mod-only chords don't ALSO require Ctrl on win/linux (Mod IS Ctrl
+  // there). But chords that explicitly want Ctrl on mac must check it.
+  if (wantsCtrl && !wantsMod) {
+    if (event.ctrlKey !== true) return false
+  }
+  if (wantsShift !== (event.shiftKey === true)) return false
+  if (wantsAlt !== (event.altKey === true)) return false
+
+  // Reject extra modifiers that the chord didn't ask for, EXCEPT for
+  // ctrlKey when Mod is wanted on mac (where Mod IS metaKey, ctrlKey
+  // happening to be true alongside is still rejected — RFC 0012 §5
+  // exact match policy).
+  if (!wantsMod && !wantsCtrl) {
+    const modKey = modKeyForPlatform(platform)
+    if (modKey === 'meta' && event.metaKey === true) return false
+    if (modKey === 'ctrl' && event.ctrlKey === true) return false
+  }
+
+  return true
+}
+
+function isInputTarget(target: ShortcutKeyEvent['target']): boolean {
+  if (target === null || target === undefined) return false
+  const tag = target.tagName?.toUpperCase()
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  if (target.isContentEditable === true) return true
+  return false
+}
+
+function isInScope(
+  scope: ShortcutScope,
+  target: ShortcutKeyEvent['target'],
+): boolean {
+  if (scope === 'global') return true
+  // Consumer supplies an HTMLElement check via within(); we approximate
+  // when target lacks contains(). For pure-TS test paths that don't
+  // pass DOM nodes, scoped shortcuts are inert (caller-side concern).
+  const root = scope.within()
+  if (root === null || target === null || target === undefined) return false
+  // duck-type contains
+  const elTarget = target as unknown as Node
+  if (typeof (root as unknown as Node).contains !== 'function') return false
+  return (root as unknown as Node).contains(elTarget)
+}
+
+const PLATFORM_CHORD_MOD_LABEL: Readonly<Record<Platform, string>> = Object.freeze({
+  mac: '⌘',
+  win: 'Ctrl',
+  linux: 'Ctrl',
+})
+
+const PLATFORM_CHORD_LABELS: Readonly<Record<Modifier, string>> = Object.freeze({
+  Mod: '__placeholder__', // resolved per platform in formatChord
+  Shift: 'Shift',
+  Alt: 'Alt',
+  Ctrl: 'Ctrl',
+})
+
+const ARIA_MOD_TOKENS_MAC: Readonly<Record<Modifier, string>> = Object.freeze({
+  Mod: 'Meta',
+  Shift: 'Shift',
+  Alt: 'Alt',
+  Ctrl: 'Control',
+})
+
+const ARIA_MOD_TOKENS_NONMAC: Readonly<Record<Modifier, string>> = Object.freeze({
+  Mod: 'Control',
+  Shift: 'Shift',
+  Alt: 'Alt',
+  Ctrl: 'Control',
+})
+
+export function createKeyboardShortcutManager(
+  opts?: KeyboardShortcutManagerOptions,
+): KeyboardShortcutManager {
+  const platform = opts?.platform ?? detectPlatform()
+  const warn = opts?.warn ?? ((m: string) => console.warn(m))
+
+  const registry = new Map<string, ShortcutDescriptor>()
+  const listeners = new Set<(shortcuts: ReadonlyArray<ShortcutDescriptor>) => void>()
+
+  function emit(): void {
+    const snap = Object.freeze([...registry.values()])
+    for (const l of listeners) l(snap)
+  }
+
+  return {
+    register(s: ShortcutDescriptor): () => void {
+      if (registry.has(s.id)) {
+        warn(`KeyboardShortcutManager: id ${s.id} already registered; replacing`)
+      }
+      registry.set(s.id, s)
+      emit()
+      return () => {
+        if (registry.get(s.id) === s) {
+          registry.delete(s.id)
+          emit()
+        }
+      }
+    },
+
+    unregisterAll(idPrefix?: string): void {
+      if (idPrefix === undefined) {
+        const had = registry.size > 0
+        registry.clear()
+        if (had) emit()
+        return
+      }
+      let removed = false
+      for (const id of [...registry.keys()]) {
+        if (id.startsWith(idPrefix)) {
+          registry.delete(id)
+          removed = true
+        }
+      }
+      if (removed) emit()
+    },
+
+    getAll(): ReadonlyArray<ShortcutDescriptor> {
+      return Object.freeze([...registry.values()])
+    },
+
+    getById(id: string): ShortcutDescriptor | undefined {
+      return registry.get(id)
+    },
+
+    formatChord(chord: Chord, platformOverride?: Platform): string {
+      const p = platformOverride ?? platform
+      const parts: string[] = []
+      for (const m of chord.modifiers) {
+        if (m === 'Mod') {
+          parts.push(PLATFORM_CHORD_MOD_LABEL[p])
+        } else {
+          parts.push(PLATFORM_CHORD_LABELS[m])
+        }
+      }
+      parts.push(chord.key.length === 1 ? chord.key.toUpperCase() : chord.key)
+      // macOS uses no separator in the canonical Cmd+B → "⌘B"; but the
+      // test expectations and most UIs use "+". Use "+".
+      return parts.join('+')
+    },
+
+    formatAria(chord: Chord): string {
+      const map = platform === 'mac' ? ARIA_MOD_TOKENS_MAC : ARIA_MOD_TOKENS_NONMAC
+      const parts: string[] = []
+      for (const m of chord.modifiers) parts.push(map[m])
+      parts.push(chord.key.length === 1 ? chord.key.toUpperCase() : chord.key)
+      return parts.join('+')
+    },
+
+    dispatch(event: ShortcutKeyEvent): boolean {
+      const inInput = isInputTarget(event.target)
+      // Collect candidate matches; pick the highest-priority + scoped-
+      // first, last-registered as final tie-break.
+      const candidates: ShortcutDescriptor[] = []
+      for (const s of registry.values()) {
+        if (!chordMatches(s.chord, event, platform)) continue
+        if (inInput && s.preserveInInputs !== true) continue
+        if (!isInScope(s.scope, event.target)) continue
+        candidates.push(s)
+      }
+      if (candidates.length === 0) return false
+      candidates.sort((a, b) => {
+        // Scoped > global
+        const aScoped = a.scope !== 'global' ? 1 : 0
+        const bScoped = b.scope !== 'global' ? 1 : 0
+        if (aScoped !== bScoped) return bScoped - aScoped
+        const ap = a.priority ?? 0
+        const bp = b.priority ?? 0
+        if (ap !== bp) return bp - ap
+        return 0 // last-registered wins via Map insertion order tie
+      })
+      const winner = candidates[candidates.length === 1 ? 0 : 0]!
+      // For ties (same scoping + same priority) we want last-registered
+      // winner; sort is stable so iterate the original Map order to find
+      // the latest among ties.
+      let best = winner
+      const bestScoped = best.scope !== 'global'
+      const bestPriority = best.priority ?? 0
+      for (const c of candidates) {
+        const cScoped = c.scope !== 'global'
+        if (cScoped !== bestScoped) continue
+        if ((c.priority ?? 0) !== bestPriority) continue
+        best = c // later-registered overrides
+      }
+      best.action(event as unknown as KeyboardEvent)
+      return true
+    },
+
+    subscribe(listener: (shortcuts: ReadonlyArray<ShortcutDescriptor>) => void): () => void {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}

--- a/dashboard/design-system/headless-preact/use-keyboard-shortcut.ts
+++ b/dashboard/design-system/headless-preact/use-keyboard-shortcut.ts
@@ -1,0 +1,75 @@
+/**
+ * useKeyboardShortcut + useKeyboardShortcutHost — Preact adapters
+ * over headless-core/KeyboardShortcutManager.
+ *
+ * Per RFC 0012 §3.2. The host hook binds a single document-level
+ * keydown listener and delegates to manager.dispatch. The per-shortcut
+ * hook registers a chord on mount and disposes on unmount, returning
+ * the human-readable + ARIA chord strings for tooltip / aria-keyshortcuts.
+ */
+
+import { useEffect, useMemo } from 'preact/hooks'
+import type {
+  Chord,
+  KeyboardShortcutManager,
+  ShortcutDescriptor,
+  ShortcutKeyEvent,
+} from '../headless-core/keyboard-shortcuts'
+
+export interface UseKeyboardShortcutResult {
+  readonly display: string
+  readonly aria: string
+}
+
+export function useKeyboardShortcut(
+  manager: KeyboardShortcutManager,
+  descriptor: Omit<ShortcutDescriptor, 'id'>,
+  id: string,
+): UseKeyboardShortcutResult {
+  useEffect(() => {
+    const dispose = manager.register({ id, ...descriptor })
+    return dispose
+  }, [manager, id, descriptor.chord.key, descriptor.chord.modifiers.join(',')])
+
+  return useMemo(
+    () => ({
+      display: manager.formatChord(descriptor.chord),
+      aria: manager.formatAria(descriptor.chord),
+    }),
+    [manager, chordKey(descriptor.chord)],
+  )
+}
+
+function chordKey(chord: Chord): string {
+  return `${chord.modifiers.join('+')}+${chord.key}`
+}
+
+/**
+ * Bind a single global keydown listener. Mount once at the app root.
+ * The listener dispatches every event to the manager; matched shortcuts
+ * fire their action and prevent default; unmatched fall through.
+ */
+export function useKeyboardShortcutHost(manager: KeyboardShortcutManager): void {
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const adapted: ShortcutKeyEvent = {
+        key: event.key,
+        metaKey: event.metaKey,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        target: event.target as ShortcutKeyEvent['target'],
+        preventDefault: () => event.preventDefault(),
+        stopPropagation: () => event.stopPropagation(),
+      }
+      const matched = manager.dispatch(adapted)
+      if (matched) {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+    }
+    if (typeof document === 'undefined') return undefined
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [manager])
+}


### PR DESCRIPTION
## Summary

Implements RFC 0012 (#11969, merged) — the global IDE shortcut registry. Spec §1.3.1 / §5.5.3 listed 15 keyboard E2E scenarios that have no implementation; this PR provides the registry that backs all of them.

## What lands

- `headless-core/keyboard-shortcuts.ts` (~280 lines)
- `headless-core/keyboard-shortcuts.test.ts` (19 cases, **all passing**)
- `headless-preact/use-keyboard-shortcut.ts` — 2 hooks: `useKeyboardShortcut` + `useKeyboardShortcutHost`

## Test results

```
Test Files  1 passed (1)
     Tests  19 passed (19)
```

## Cross-platform `Mod` resolution

| Platform | Chord `Mod+B` matches | `formatChord` | `formatAria` |
|---|---|---|---|
| `mac` | `metaKey + b` | `⌘+B` | `Meta+B` |
| `win` / `linux` | `ctrlKey + b` | `Ctrl+B` | `Control+B` |

Exact-modifier matching: `Mod+B` does NOT match `Mod+Shift+B` and vice versa (W3C ARIA APG conformance).

## `preserveInInputs` policy

Default is **drop shortcuts inside `<input>` / `<textarea>` / `[contenteditable]`** so typing in name fields doesn't trigger global chords. Per-shortcut opt-in via `preserveInInputs: true` for things that should fire anywhere (e.g. `Cmd+S`).

## Adapter usage

```ts
// At app root (mount once)
useKeyboardShortcutHost(manager)

// Per consumer
const { display, aria } = useKeyboardShortcut(manager, {
  chord: { key: 'b', modifiers: ['Mod'] },
  description: 'Toggle sidebar',
  scope: 'global',
  action: () => toggleSidebar(),
}, 'ide.toggle-sidebar')
// → display="⌘+B"  aria="Meta+B"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)