### PR TITLE
feat(headless): RFC 0004 SplitPane implementation + Preact adapter

### DIFF
--- a/dashboard/design-system/headless-core/split-pane.test.ts
+++ b/dashboard/design-system/headless-core/split-pane.test.ts
@@ -1,0 +1,220 @@
+// Pure TS unit tests for SplitPane. No DOM.
+import { describe, it, expect } from 'vitest'
+import {
+  createSplitPane,
+  type SplitKeyEvent,
+  type SplitStorage,
+} from './split-pane'
+
+function memoryStorage(initial?: Record<string, string>): SplitStorage & {
+  readonly map: Map<string, string>
+} {
+  const map = new Map<string, string>(Object.entries(initial ?? {}))
+  return {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value)
+    },
+    map,
+  }
+}
+
+function makeKey(key: string, shiftKey?: boolean): SplitKeyEvent & {
+  _prevented: boolean
+} {
+  let prevented = false
+  return {
+    key,
+    shiftKey,
+    preventDefault() {
+      prevented = true
+    },
+    get _prevented() {
+      return prevented
+    },
+  } as SplitKeyEvent & { _prevented: boolean }
+}
+
+describe('createSplitPane — defaults + persistence', () => {
+  it('default ratio is 0.5; storage untouched on construct', () => {
+    const storage = memoryStorage()
+    const sp = createSplitPane({ direction: 'horizontal', persistKey: 'k', storage })
+    expect(sp.getRatio()).toBe(0.5)
+    expect(storage.map.size).toBe(0)
+  })
+
+  it('persists on setRatio + reads back on next construct', () => {
+    const storage = memoryStorage()
+    const sp1 = createSplitPane({ direction: 'horizontal', persistKey: 'k', storage })
+    sp1.setRatio(0.42)
+    expect(storage.map.get('k')).toBe('0.42')
+    const sp2 = createSplitPane({ direction: 'horizontal', persistKey: 'k', storage })
+    expect(sp2.getRatio()).toBe(0.42)
+  })
+
+  it('corrupted persisted value falls back to defaultRatio', () => {
+    const storage = memoryStorage({ k: 'NaN' })
+    const sp = createSplitPane({
+      direction: 'horizontal',
+      persistKey: 'k',
+      defaultRatio: 0.3,
+      storage,
+    })
+    expect(sp.getRatio()).toBe(0.3)
+  })
+
+  it('out-of-range persisted value falls back to defaultRatio', () => {
+    const storage = memoryStorage({ k: '2.0' })
+    const sp = createSplitPane({
+      direction: 'horizontal',
+      persistKey: 'k',
+      defaultRatio: 0.6,
+      storage,
+    })
+    expect(sp.getRatio()).toBe(0.6)
+  })
+})
+
+describe('createSplitPane — pointer drag (horizontal)', () => {
+  it('drag right by 200px on 800px container increases ratio by 0.25', () => {
+    const sp = createSplitPane({ direction: 'horizontal', defaultRatio: 0.5 })
+    sp.setContainerSize(800)
+    sp.handlePointerDown({ clientX: 100, clientY: 0 })
+    sp.handlePointerMove({ clientX: 300, clientY: 0 })
+    expect(sp.getRatio()).toBeCloseTo(0.75, 5)
+  })
+
+  it('clamps at maxRatio during drag', () => {
+    const sp = createSplitPane({ direction: 'horizontal', defaultRatio: 0.85 })
+    sp.setContainerSize(800)
+    sp.handlePointerDown({ clientX: 100, clientY: 0 })
+    sp.handlePointerMove({ clientX: 1000, clientY: 0 })
+    expect(sp.getRatio()).toBe(0.9)
+  })
+})
+
+describe('createSplitPane — pointer drag (vertical)', () => {
+  it('drag down increases ratio (top pane widens)', () => {
+    const sp = createSplitPane({ direction: 'vertical', defaultRatio: 0.5 })
+    sp.setContainerSize(400)
+    sp.handlePointerDown({ clientX: 0, clientY: 100 })
+    sp.handlePointerMove({ clientX: 0, clientY: 200 })
+    expect(sp.getRatio()).toBeCloseTo(0.75, 5)
+  })
+})
+
+describe('createSplitPane — pointer up persists', () => {
+  it('drag end writes localStorage', () => {
+    const storage = memoryStorage()
+    const sp = createSplitPane({
+      direction: 'horizontal',
+      persistKey: 'k',
+      storage,
+    })
+    sp.setContainerSize(1000)
+    sp.handlePointerDown({ clientX: 0, clientY: 0 })
+    sp.handlePointerMove({ clientX: 100, clientY: 0 })
+    expect(storage.map.has('k')).toBe(false)
+    sp.handlePointerUp()
+    expect(storage.map.get('k')).toBe('0.6')
+  })
+
+  it('pointer up without down is no-op', () => {
+    const storage = memoryStorage()
+    const sp = createSplitPane({
+      direction: 'horizontal',
+      persistKey: 'k',
+      storage,
+    })
+    sp.handlePointerUp()
+    expect(storage.map.size).toBe(0)
+  })
+})
+
+describe('createSplitPane — keyboard step', () => {
+  it('ArrowRight on horizontal advances by 0.02', () => {
+    const sp = createSplitPane({ direction: 'horizontal', defaultRatio: 0.5 })
+    sp.handleKeyDown(makeKey('ArrowRight'))
+    expect(sp.getRatio()).toBeCloseTo(0.52, 5)
+  })
+
+  it('Shift+ArrowRight advances by 0.10 (coarse)', () => {
+    const sp = createSplitPane({ direction: 'horizontal', defaultRatio: 0.5 })
+    sp.handleKeyDown(makeKey('ArrowRight', true))
+    expect(sp.getRatio()).toBeCloseTo(0.6, 5)
+  })
+
+  it('off-axis arrow keys are no-op', () => {
+    const sp = createSplitPane({ direction: 'horizontal', defaultRatio: 0.5 })
+    sp.handleKeyDown(makeKey('ArrowUp'))
+    expect(sp.getRatio()).toBe(0.5)
+  })
+})
+
+describe('createSplitPane — Home / End', () => {
+  it('Home clamps to minRatio, End to maxRatio; both persist', () => {
+    const storage = memoryStorage()
+    const sp = createSplitPane({
+      direction: 'horizontal',
+      defaultRatio: 0.5,
+      persistKey: 'k',
+      storage,
+    })
+    sp.handleKeyDown(makeKey('Home'))
+    expect(sp.getRatio()).toBe(0.1)
+    expect(storage.map.get('k')).toBe('0.1')
+    sp.handleKeyDown(makeKey('End'))
+    expect(sp.getRatio()).toBe(0.9)
+    expect(storage.map.get('k')).toBe('0.9')
+  })
+})
+
+describe('createSplitPane — Enter toggle collapse', () => {
+  it('Enter from default position collapses to second; Enter again expands', () => {
+    const sp = createSplitPane({ direction: 'horizontal', defaultRatio: 0.5 })
+    sp.handleKeyDown(makeKey('Enter'))
+    // ratio 0.5 vs midpoint (0.1+0.9)/2=0.5 → not less; collapse to 'second'
+    expect(sp.isCollapsed()).toBe(true)
+    expect(sp.getRatio()).toBe(0.9)
+    sp.handleKeyDown(makeKey('Enter'))
+    expect(sp.isCollapsed()).toBe(false)
+    expect(sp.getRatio()).toBeCloseTo(0.5, 5)
+  })
+
+  it('collapse from low ratio targets first side', () => {
+    const sp = createSplitPane({ direction: 'horizontal', defaultRatio: 0.2 })
+    sp.handleKeyDown(makeKey('Enter'))
+    expect(sp.isCollapsed()).toBe(true)
+    expect(sp.getRatio()).toBe(0.1)
+  })
+})
+
+describe('createSplitPane — splitter ARIA props', () => {
+  it('aria-valuenow is integer percent of ratio', () => {
+    const sp = createSplitPane({ direction: 'horizontal', defaultRatio: 0.42 })
+    const props = sp.getSplitterProps()
+    expect(props['aria-valuenow']).toBe(42)
+    expect(props['aria-valuemin']).toBe(10)
+    expect(props['aria-valuemax']).toBe(90)
+    expect(props['aria-orientation']).toBe('horizontal')
+    expect(props.tabIndex).toBe(0)
+    expect(props.role).toBe('separator')
+  })
+})
+
+describe('createSplitPane — subscribe', () => {
+  it('subscriber fires on every ratio change including drag', () => {
+    const sp = createSplitPane({ direction: 'horizontal', defaultRatio: 0.5 })
+    sp.setContainerSize(1000)
+    const calls: number[] = []
+    const dispose = sp.subscribe((r) => calls.push(r))
+    sp.handlePointerDown({ clientX: 0, clientY: 0 })
+    sp.handlePointerMove({ clientX: 50, clientY: 0 })
+    sp.handlePointerMove({ clientX: 100, clientY: 0 })
+    sp.handlePointerUp()
+    expect(calls.length).toBe(2) // two move events fired
+    dispose()
+    sp.handleKeyDown(makeKey('ArrowRight'))
+    expect(calls.length).toBe(2) // unsubscribed
+  })
+})

--- a/dashboard/design-system/headless-core/split-pane.ts
+++ b/dashboard/design-system/headless-core/split-pane.ts
@@ -1,0 +1,283 @@
+/**
+ * SplitPane — framework-agnostic resizable splitter (RFC 0004).
+ *
+ * Implements the headless splitter that IdePlane (Stage 5),
+ * Inspector resize, and Drawer width-snap consume. Pointer + keyboard
+ * driven; persists to localStorage; exposes role=separator with
+ * aria-valuenow/min/max as integer percent.
+ *
+ * MVP scope (RFC 0004 §3, §4, §5):
+ *   - direction horizontal / vertical
+ *   - clamped ratio in [minRatio, maxRatio] (defaults 0.1, 0.9, 0.5)
+ *   - localStorage persistKey: read on construct, write on
+ *     pointerUp / keyDown / setRatio
+ *   - splitter ARIA props: role=separator + aria-orientation +
+ *     aria-valuenow/min/max as integer percent
+ *   - keyboard: Arrow step 0.02, Shift+Arrow coarse 0.10, Home/End
+ *     clamp, Enter toggle collapse with prevRatio restoration
+ *   - subscribe with leak-safe disposers
+ *
+ * Out of scope (RFC 0004 §10):
+ *   - 3-pane = consumer composes two SplitPanes
+ *   - touch / pen / mouse-button distinctions (single pointer stream)
+ *   - render markup
+ */
+
+export type SplitDirection = 'horizontal' | 'vertical'
+
+export interface SplitPaneOptions {
+  direction: SplitDirection
+  defaultRatio?: number
+  minRatio?: number
+  maxRatio?: number
+  /** localStorage key. Convention: "masc.split-pane.<id>". */
+  persistKey?: string
+  onResize?: (ratio: number) => void
+  ariaLabel?: string
+  /** Storage adapter — defaults to global localStorage when present.
+   *  Tests inject a mock to keep the suite environment-independent. */
+  storage?: SplitStorage
+}
+
+export interface SplitStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+export interface SplitterProps {
+  readonly role: 'separator'
+  readonly 'aria-label': string
+  readonly 'aria-orientation': SplitDirection
+  readonly 'aria-valuenow': number
+  readonly 'aria-valuemin': number
+  readonly 'aria-valuemax': number
+  readonly tabIndex: 0
+}
+
+export interface SplitKeyEvent {
+  readonly key: string
+  readonly shiftKey?: boolean
+  preventDefault(): void
+}
+
+export interface SplitPointerEvent {
+  readonly clientX: number
+  readonly clientY: number
+}
+
+export interface SplitPane {
+  getRatio(): number
+  setRatio(value: number): void
+  isCollapsed(): boolean
+  collapse(side: 'first' | 'second'): void
+  expand(): void
+
+  getSplitterProps(): SplitterProps
+
+  setContainerSize(px: number): void
+
+  handlePointerDown(event: SplitPointerEvent): void
+  handlePointerMove(event: SplitPointerEvent): void
+  handlePointerUp(): void
+  handleKeyDown(event: SplitKeyEvent): void
+
+  subscribe(listener: (ratio: number, collapsed: boolean) => void): () => void
+}
+
+const DEFAULT_DEFAULT_RATIO = 0.5
+const DEFAULT_MIN_RATIO = 0.1
+const DEFAULT_MAX_RATIO = 0.9
+const STEP = 0.02
+const COARSE_STEP = 0.1
+
+function inferStorage(): SplitStorage | null {
+  try {
+    if (typeof globalThis.localStorage !== 'undefined') {
+      return globalThis.localStorage as SplitStorage
+    }
+  } catch {
+    // SSR / sandbox — no storage available.
+  }
+  return null
+}
+
+export function createSplitPane(opts: SplitPaneOptions): SplitPane {
+  const direction = opts.direction
+  const minRatio = opts.minRatio ?? DEFAULT_MIN_RATIO
+  const maxRatio = opts.maxRatio ?? DEFAULT_MAX_RATIO
+  const ariaLabel = opts.ariaLabel ?? 'Panel resize handle'
+  const storage = opts.storage ?? inferStorage()
+  const persistKey = opts.persistKey
+
+  function clamp(v: number): number {
+    if (Number.isNaN(v)) return DEFAULT_DEFAULT_RATIO
+    return Math.max(minRatio, Math.min(maxRatio, v))
+  }
+
+  // Read persisted value.
+  let initialRatio = opts.defaultRatio ?? DEFAULT_DEFAULT_RATIO
+  if (storage !== null && persistKey !== undefined) {
+    const raw = storage.getItem(persistKey)
+    if (raw !== null) {
+      const parsed = Number.parseFloat(raw)
+      if (!Number.isNaN(parsed) && parsed >= minRatio && parsed <= maxRatio) {
+        initialRatio = parsed
+      }
+    }
+  }
+
+  let ratio = clamp(initialRatio)
+  let prevRatio = ratio
+  let collapsed = false
+  let containerSize = 0
+  let dragging = false
+  let dragStartClient = 0
+  let dragStartRatio = 0
+
+  const listeners = new Set<(ratio: number, collapsed: boolean) => void>()
+
+  function emit(): void {
+    for (const l of listeners) l(ratio, collapsed)
+    if (opts.onResize !== undefined) opts.onResize(ratio)
+  }
+
+  function persist(): void {
+    if (storage === null || persistKey === undefined) return
+    storage.setItem(persistKey, String(ratio))
+  }
+
+  function setRatioInternal(v: number, opts?: { persist?: boolean }): void {
+    const next = clamp(v)
+    if (next === ratio) return
+    ratio = next
+    if (opts?.persist === true) persist()
+    emit()
+  }
+
+  return {
+    getRatio() {
+      return ratio
+    },
+
+    setRatio(v: number) {
+      setRatioInternal(v, { persist: true })
+    },
+
+    isCollapsed() {
+      return collapsed
+    },
+
+    collapse(side: 'first' | 'second') {
+      if (!collapsed) prevRatio = ratio
+      collapsed = true
+      ratio = side === 'first' ? minRatio : maxRatio
+      emit()
+    },
+
+    expand() {
+      if (!collapsed) return
+      collapsed = false
+      ratio = clamp(prevRatio)
+      persist()
+      emit()
+    },
+
+    getSplitterProps(): SplitterProps {
+      return Object.freeze({
+        role: 'separator' as const,
+        'aria-label': ariaLabel,
+        'aria-orientation': direction,
+        'aria-valuenow': Math.round(ratio * 100),
+        'aria-valuemin': Math.round(minRatio * 100),
+        'aria-valuemax': Math.round(maxRatio * 100),
+        tabIndex: 0 as const,
+      })
+    },
+
+    setContainerSize(px: number) {
+      containerSize = px
+    },
+
+    handlePointerDown(event: SplitPointerEvent) {
+      dragging = true
+      dragStartClient = direction === 'horizontal' ? event.clientX : event.clientY
+      dragStartRatio = ratio
+    },
+
+    handlePointerMove(event: SplitPointerEvent) {
+      if (!dragging) return
+      if (containerSize <= 0) return
+      const client = direction === 'horizontal' ? event.clientX : event.clientY
+      const delta = (client - dragStartClient) / containerSize
+      // For horizontal, increasing client.x widens the FIRST pane.
+      // For vertical, increasing client.y widens the FIRST pane (top).
+      setRatioInternal(dragStartRatio + delta)
+    },
+
+    handlePointerUp() {
+      if (!dragging) return
+      dragging = false
+      persist()
+    },
+
+    handleKeyDown(event: SplitKeyEvent) {
+      const step = event.shiftKey === true ? COARSE_STEP : STEP
+      const isHorizontal = direction === 'horizontal'
+      switch (event.key) {
+        case 'ArrowRight':
+          if (isHorizontal) {
+            event.preventDefault()
+            setRatioInternal(ratio + step, { persist: true })
+          }
+          return
+        case 'ArrowLeft':
+          if (isHorizontal) {
+            event.preventDefault()
+            setRatioInternal(ratio - step, { persist: true })
+          }
+          return
+        case 'ArrowDown':
+          if (!isHorizontal) {
+            event.preventDefault()
+            setRatioInternal(ratio + step, { persist: true })
+          }
+          return
+        case 'ArrowUp':
+          if (!isHorizontal) {
+            event.preventDefault()
+            setRatioInternal(ratio - step, { persist: true })
+          }
+          return
+        case 'Home':
+          event.preventDefault()
+          setRatioInternal(minRatio, { persist: true })
+          return
+        case 'End':
+          event.preventDefault()
+          setRatioInternal(maxRatio, { persist: true })
+          return
+        case 'Enter':
+        case ' ':
+          event.preventDefault()
+          // RFC 0004 §10.2 tie-break: collapse to whichever side is
+          // closer. ratio < (min+max)/2 -> collapse first; else second.
+          if (collapsed) {
+            this.expand()
+          } else {
+            const midpoint = (minRatio + maxRatio) / 2
+            this.collapse(ratio < midpoint ? 'first' : 'second')
+          }
+          return
+        default:
+          return
+      }
+    },
+
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}

--- a/dashboard/design-system/headless-preact/use-split-pane.ts
+++ b/dashboard/design-system/headless-preact/use-split-pane.ts
@@ -1,0 +1,116 @@
+/**
+ * useSplitPane — Preact adapter over headless-core/SplitPane.
+ *
+ * Per RFC 0004 §3.2. Owns a ResizeObserver on the container ref to
+ * feed setContainerSize, subscribes to ratio changes, and exposes
+ * splitter prop bundle + first/second pane flex-basis style helpers.
+ */
+
+import type { RefObject } from 'preact'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import {
+  createSplitPane,
+  type SplitDirection,
+  type SplitPane,
+  type SplitterProps,
+  type SplitKeyEvent,
+  type SplitPointerEvent,
+  type SplitStorage,
+} from '../headless-core/split-pane'
+
+export interface UseSplitPaneArgs {
+  containerRef: RefObject<HTMLElement | null>
+  direction: SplitDirection
+  defaultRatio?: number
+  minRatio?: number
+  maxRatio?: number
+  persistKey?: string
+  storage?: SplitStorage
+  onResize?: (ratio: number) => void
+  ariaLabel?: string
+}
+
+export interface UseSplitPaneResult {
+  readonly ratio: number
+  readonly collapsed: boolean
+  setRatio(value: number): void
+  collapse(side: 'first' | 'second'): void
+  expand(): void
+  splitterProps: SplitterProps & {
+    readonly onPointerDown: (e: SplitPointerEvent) => void
+    readonly onPointerMove: (e: SplitPointerEvent) => void
+    readonly onPointerUp: () => void
+    readonly onKeyDown: (e: SplitKeyEvent) => void
+  }
+  readonly firstPaneStyle: { readonly flexBasis: string }
+  readonly secondPaneStyle: { readonly flexBasis: string }
+}
+
+export function useSplitPane(args: UseSplitPaneArgs): UseSplitPaneResult {
+  const splitRef = useRef<SplitPane | null>(null)
+  const [ratio, setRatio] = useState<number>(() => args.defaultRatio ?? 0.5)
+  const [collapsed, setCollapsed] = useState<boolean>(false)
+
+  if (splitRef.current === null) {
+    splitRef.current = createSplitPane({
+      direction: args.direction,
+      defaultRatio: args.defaultRatio,
+      minRatio: args.minRatio,
+      maxRatio: args.maxRatio,
+      persistKey: args.persistKey,
+      storage: args.storage,
+      onResize: args.onResize,
+      ariaLabel: args.ariaLabel,
+    })
+    setRatio(splitRef.current.getRatio())
+  }
+
+  useEffect(() => {
+    const sp = splitRef.current
+    if (sp === null) return undefined
+    const dispose = sp.subscribe((r, c) => {
+      setRatio(r)
+      setCollapsed(c)
+    })
+    return dispose
+  }, [])
+
+  // ResizeObserver wiring.
+  useEffect(() => {
+    const sp = splitRef.current
+    const el = args.containerRef.current
+    if (sp === null || el === null) return undefined
+    if (typeof ResizeObserver === 'undefined') return undefined
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry === undefined) return
+      const px =
+        args.direction === 'horizontal'
+          ? entry.contentRect.width
+          : entry.contentRect.height
+      sp.setContainerSize(px)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [args.containerRef, args.direction])
+
+  return useMemo<UseSplitPaneResult>(() => {
+    const sp = splitRef.current!
+    return {
+      ratio,
+      collapsed,
+      setRatio: (v: number) => sp.setRatio(v),
+      collapse: (side: 'first' | 'second') => sp.collapse(side),
+      expand: () => sp.expand(),
+      splitterProps: {
+        ...sp.getSplitterProps(),
+        onPointerDown: (e: SplitPointerEvent) => sp.handlePointerDown(e),
+        onPointerMove: (e: SplitPointerEvent) => sp.handlePointerMove(e),
+        onPointerUp: () => sp.handlePointerUp(),
+        onKeyDown: (e: SplitKeyEvent) => sp.handleKeyDown(e),
+      },
+      firstPaneStyle: { flexBasis: `${Math.round(ratio * 100)}%` },
+      secondPaneStyle: { flexBasis: `${Math.round((1 - ratio) * 100)}%` },
+    }
+  }, [ratio, collapsed])
+}


### PR DESCRIPTION
## Summary

Implements RFC 0004 (#11952, merged) — the resizable splitter that **IdePlane (Stage 5)**, **Inspector resize**, and **Drawer width-snap** all consume. Pointer + keyboard driven, role=separator with integer-percent ARIA values, optional localStorage persistence.

## What lands

- `headless-core/split-pane.ts` (~225 lines)
- `headless-core/split-pane.test.ts` (17 cases, **all passing**)
- `headless-preact/use-split-pane.ts` — adapter with `ResizeObserver` wiring + `flexBasis` style helpers

## Test results

```
Test Files  1 passed (1)
     Tests  17 passed (17)
```

## Highlights

- **Pluggable `SplitStorage`** interface — tests inject a memory adapter; production uses global `localStorage` via `inferStorage()` SSR-safe guard.
- **Persisted value validation** — corrupted (`NaN`) or out-of-range (`-1` / `2.0`) values fall back to `defaultRatio`. No crash, no silent data corruption.
- **Pointer math** — clientX/Y delta normalized by `containerSize`. Clamped at `[minRatio, maxRatio]` during drag.
- **Keyboard model** — Arrow step `0.02`, `Shift+Arrow` coarse `0.10`. Home/End clamp to min/max with persist. Off-axis arrow keys no-op.
- **Enter collapse tie-break** — ratio < `(min+max)/2` → collapse `'first'`, else `'second'`. Expand restores `prevRatio`.
- **Splitter ARIA** — `aria-valuenow` rounds to integer percent. `aria-orientation` matches direction. `tabIndex: 0`.

## Adapter usage

```tsx
const ref = useRef<HTMLDivElement>(null)
const { ratio, splitterProps, firstPaneStyle, secondPaneStyle } = useSplitPane({
  containerRef: ref,
  direction: 'horizontal',
  persistKey: 'masc.split-pane.ide-tree',
  defaultRatio: 0.25,
  minRatio: 0.15,
  maxRatio: 0.5,
})

return (
  <div ref={ref} style={{ display: 'flex' }}>
    <aside style={firstPaneStyle}>tree</aside>
    <div {...splitterProps} class="splitter" />
    <main style={secondPaneStyle}>editor</main>
  </div>
)
```

`ResizeObserver` is wired automatically; SSR-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)