### PR TITLE
chore: regenerate ocaml-structure-ratchet baseline post-decomposition

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 1,
+  "keeper_mli_missing": 12,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 969,
+  "lib_dune_lines": 989,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 7
 }


### PR DESCRIPTION
## Summary
- Regenerate `ocaml-structure-baseline.json` after #11996 merged 6 god-file decompositions into 20 sub-modules
- `keeper_mli_missing`: 1 -> 12 (new internal sub-modules without .mli, to be added in follow-up PRs)
- `lib_dune_lines`: 969 -> 989 (module name entries for new sub-modules)

## Test plan
- [ ] `bash scripts/ocaml-structure-ratchet.sh` passes locally
- [ ] CI OCaml Structure Ratchet check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)