### PR TITLE
feat(headless): RFC 0015 Tabs implementation + Preact-ready API

### DIFF
--- a/dashboard/design-system/headless-core/tabs.test.ts
+++ b/dashboard/design-system/headless-core/tabs.test.ts
@@ -1,5 +1,5 @@
 // Pure TS unit tests for Tabs. No DOM.
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { createTabs, type TabsKeyEvent, type TabDescriptor } from './tabs'
 
 function makeKey(

--- a/dashboard/design-system/headless-core/tabs.test.ts
+++ b/dashboard/design-system/headless-core/tabs.test.ts
@@ -1,0 +1,248 @@
+// Pure TS unit tests for Tabs. No DOM.
+import { describe, it, expect, vi } from 'vitest'
+import { createTabs, type TabsKeyEvent, type TabDescriptor } from './tabs'
+
+function makeKey(
+  key: string,
+  opts?: Partial<TabsKeyEvent>,
+): TabsKeyEvent & { _prevented: boolean } {
+  let prevented = false
+  return {
+    key,
+    metaKey: opts?.metaKey,
+    ctrlKey: opts?.ctrlKey,
+    shiftKey: opts?.shiftKey,
+    altKey: opts?.altKey,
+    preventDefault() {
+      prevented = true
+    },
+    get _prevented() {
+      return prevented
+    },
+  } as TabsKeyEvent & { _prevented: boolean }
+}
+
+const TABS: ReadonlyArray<TabDescriptor> = [
+  { id: 'a', label: 'Alpha' },
+  { id: 'b', label: 'Bravo' },
+  { id: 'c', label: 'Charlie' },
+  { id: 'd', label: 'Delta' },
+  { id: 'e', label: 'Echo' },
+]
+
+describe('createTabs — activation: automatic', () => {
+  it('ArrowRight immediately fires onActiveChange', () => {
+    const calls: string[] = []
+    const t = createTabs({ tabs: TABS, onActiveChange: (id) => calls.push(id) })
+    expect(t.activeId).toBe('a')
+    t.getTabListProps().onKeyDown(makeKey('ArrowRight'))
+    expect(t.activeId).toBe('b')
+    expect(calls).toEqual(['b'])
+  })
+})
+
+describe('createTabs — activation: manual', () => {
+  it('ArrowRight moves rover but does NOT activate; Enter activates', () => {
+    const calls: string[] = []
+    const t = createTabs({
+      tabs: TABS,
+      activationMode: 'manual',
+      onActiveChange: (id) => calls.push(id),
+    })
+    expect(t.activeId).toBe('a')
+    t.getTabListProps().onKeyDown(makeKey('ArrowRight'))
+    // active stays at a; rover advanced to b internally
+    expect(t.activeId).toBe('a')
+    expect(calls).toEqual([])
+    t.getTabListProps().onKeyDown(makeKey('Enter'))
+    expect(t.activeId).toBe('b')
+    expect(calls).toEqual(['b'])
+  })
+
+  it('Space activates focused tab', () => {
+    const t = createTabs({ tabs: TABS, activationMode: 'manual' })
+    t.getTabListProps().onKeyDown(makeKey('ArrowRight'))
+    t.getTabListProps().onKeyDown(makeKey(' '))
+    expect(t.activeId).toBe('b')
+  })
+})
+
+describe('createTabs — Home / End', () => {
+  it('Home goes to first; End goes to last', () => {
+    const t = createTabs({ tabs: TABS })
+    t.activate('c')
+    t.getTabListProps().onKeyDown(makeKey('End'))
+    expect(t.activeId).toBe('e')
+    t.getTabListProps().onKeyDown(makeKey('Home'))
+    expect(t.activeId).toBe('a')
+  })
+})
+
+describe('createTabs — disabled-skip', () => {
+  it('rover skips disabled; first focus lands on first enabled', () => {
+    const tabs: ReadonlyArray<TabDescriptor> = [
+      { id: 'a', label: 'A', disabled: true },
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C' },
+    ]
+    const t = createTabs({ tabs })
+    expect(t.activeId).toBe('b')
+    t.getTabListProps().onKeyDown(makeKey('Home'))
+    expect(t.activeId).toBe('b')
+  })
+})
+
+describe('createTabs — close', () => {
+  it('close active id 3 of 5 -> id 4 becomes active', () => {
+    const t = createTabs({ tabs: TABS })
+    t.activate('c')
+    t.close('c')
+    expect(t.activeId).toBe('b') // previous neighbor
+    expect(t.tabs.map((tt) => tt.id)).toEqual(['a', 'b', 'd', 'e'])
+  })
+
+  it('close last active -> previous becomes active', () => {
+    const t = createTabs({ tabs: TABS })
+    t.activate('e')
+    t.close('e')
+    expect(t.activeId).toBe('d')
+  })
+
+  it('close all -> activeId becomes null', () => {
+    const t = createTabs({ tabs: [{ id: 'only', label: 'O' }] })
+    t.close('only')
+    expect(t.activeId).toBeNull()
+    expect(t.tabs).toHaveLength(0)
+  })
+
+  it('Delete keyboard fires close on closeable tab', () => {
+    const closes: string[] = []
+    const t = createTabs({
+      tabs: [
+        { id: 'a', label: 'A', closeable: true },
+        { id: 'b', label: 'B', closeable: true },
+      ],
+      onClose: (id) => closes.push(id),
+    })
+    t.getTabListProps().onKeyDown(makeKey('Delete'))
+    expect(closes).toEqual(['a'])
+  })
+
+  it('Delete on non-closeable tab is no-op', () => {
+    const closes: string[] = []
+    const t = createTabs({ tabs: TABS, onClose: (id) => closes.push(id) })
+    t.getTabListProps().onKeyDown(makeKey('Delete'))
+    expect(closes).toEqual([])
+    expect(t.tabs).toHaveLength(5)
+  })
+})
+
+describe('createTabs — drag reorder', () => {
+  it('drag tab b over tab d -> order [a, c, b, d, e]; onReorder fires once', () => {
+    const reorders: ReadonlyArray<string>[] = []
+    const t = createTabs({
+      tabs: TABS,
+      onReorder: (ids) => reorders.push(ids),
+    })
+    t.handleDragStart('b')
+    t.handleDragOver('d')
+    t.handleDragEnd()
+    expect(t.tabs.map((tt) => tt.id)).toEqual(['a', 'c', 'b', 'd', 'e'])
+    expect(reorders).toHaveLength(1)
+  })
+
+  it('pinned target is skipped (no reorder)', () => {
+    const tabs: ReadonlyArray<TabDescriptor> = [
+      { id: 'a', label: 'A', pinned: true },
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C' },
+    ]
+    const reorders: ReadonlyArray<string>[] = []
+    const t = createTabs({
+      tabs,
+      onReorder: (ids) => reorders.push(ids),
+    })
+    t.handleDragStart('b')
+    t.handleDragOver('a') // pinned target
+    t.handleDragEnd()
+    expect(t.tabs.map((tt) => tt.id)).toEqual(['a', 'b', 'c'])
+    expect(reorders).toHaveLength(0)
+  })
+
+  it('dragging a pinned source is rejected (no drag started)', () => {
+    const tabs: ReadonlyArray<TabDescriptor> = [
+      { id: 'a', label: 'A', pinned: true },
+      { id: 'b', label: 'B' },
+    ]
+    const t = createTabs({ tabs })
+    t.handleDragStart('a')
+    expect(t.draggingId).toBeNull()
+  })
+})
+
+describe('createTabs — getTabPanelProps.hidden', () => {
+  it('true for non-active panels, false for active', () => {
+    const t = createTabs({ tabs: TABS })
+    t.activate('c')
+    expect(t.getTabPanelProps('a').hidden).toBe(true)
+    expect(t.getTabPanelProps('c').hidden).toBe(false)
+  })
+})
+
+describe('createTabs — aria-controls / aria-labelledby linkage', () => {
+  it('tab id and panel id round-trip through aria attrs', () => {
+    const t = createTabs({ tabs: TABS })
+    const tabProps = t.getTabProps('b')
+    const panelProps = t.getTabPanelProps('b')
+    expect(tabProps['aria-controls']).toBe(panelProps.id)
+    expect(panelProps['aria-labelledby']).toBe(tabProps.id)
+  })
+})
+
+describe('createTabs — vertical orientation', () => {
+  it('ArrowDown / ArrowUp instead of Right / Left', () => {
+    const t = createTabs({ tabs: TABS, orientation: 'vertical' })
+    t.getTabListProps().onKeyDown(makeKey('ArrowDown'))
+    expect(t.activeId).toBe('b')
+    t.getTabListProps().onKeyDown(makeKey('ArrowUp'))
+    expect(t.activeId).toBe('a')
+  })
+})
+
+describe('createTabs — close button props', () => {
+  it('close button has tabIndex -1 and aria-label "Close <label>"', () => {
+    const t = createTabs({
+      tabs: [{ id: 'a', label: 'Alpha', closeable: true }],
+    })
+    const props = t.getCloseButtonProps('a')
+    expect(props.tabIndex).toBe(-1)
+    expect(props['aria-label']).toBe('Close Alpha')
+  })
+
+  it('close button click fires onClose', () => {
+    const closes: string[] = []
+    const t = createTabs({
+      tabs: [{ id: 'a', label: 'A', closeable: true }, { id: 'b', label: 'B' }],
+      onClose: (id) => closes.push(id),
+    })
+    t.getCloseButtonProps('a').onClick()
+    expect(closes).toEqual(['a'])
+  })
+})
+
+describe('createTabs — subscribe', () => {
+  it('listener fires on activate / close / reorder; unsubscribe stops', () => {
+    const t = createTabs({ tabs: TABS })
+    let count = 0
+    const dispose = t.subscribe(() => {
+      count += 1
+    })
+    t.activate('b')
+    t.close('b')
+    expect(count).toBeGreaterThan(0)
+    const before = count
+    dispose()
+    t.activate('c')
+    expect(count).toBe(before)
+  })
+})

--- a/dashboard/design-system/headless-core/tabs.ts
+++ b/dashboard/design-system/headless-core/tabs.ts
@@ -1,0 +1,405 @@
+/**
+ * Tabs — framework-agnostic tablist primitive (RFC 0015).
+ *
+ * Composes RovingTabindex (RFC 0003) for arrow / Home / End / typeahead
+ * navigation, then layers on tab-specific behavior: aria-selected,
+ * aria-controls/aria-labelledby cross-references, automatic vs manual
+ * activation, close button (Delete keyboard), drag reorder.
+ *
+ * MVP scope (RFC 0015 §3, §4, §5):
+ *   - automatic activation (default): rover move = activation
+ *   - manual activation: Enter / Space activates focused tab
+ *   - orientation horizontal (default) / vertical
+ *   - close: Delete on focused tab fires onClose; close button has
+ *     tabIndex=-1 so Tab traversal goes through the tab itself
+ *     (matches VS Code; avoids "Tab Tab Enter" close-button trap)
+ *   - drag reorder via 3 handlers; pinned tabs stay clustered
+ *
+ * Out of scope (RFC 0015 §12):
+ *   - Tab content lazy loading / unmount (consumer concern)
+ *   - Persistence of active tab (consumer owns localStorage / route)
+ *   - Multi-row tab wrap
+ */
+
+import {
+  createRovingTabindex,
+  type RovingTabindexController,
+  type RovingKeyEvent,
+} from './roving-tabindex'
+
+export interface TabDescriptor {
+  readonly id: string
+  readonly label: string
+  readonly disabled?: boolean
+  readonly closeable?: boolean
+  readonly pinned?: boolean
+}
+
+export type ActivationMode = 'automatic' | 'manual'
+export type TabsOrientation = 'horizontal' | 'vertical'
+
+export interface TabsOptions {
+  tabs: ReadonlyArray<TabDescriptor>
+  activationMode?: ActivationMode
+  orientation?: TabsOrientation
+  defaultActiveId?: string
+  onActiveChange?: (id: string) => void
+  onClose?: (id: string) => void
+  onReorder?: (ids: ReadonlyArray<string>) => void
+}
+
+export interface TabsKeyEvent {
+  readonly key: string
+  readonly metaKey?: boolean
+  readonly ctrlKey?: boolean
+  readonly shiftKey?: boolean
+  readonly altKey?: boolean
+  preventDefault(): void
+}
+
+export interface TabListProps {
+  readonly role: 'tablist'
+  readonly 'aria-orientation': TabsOrientation
+  readonly tabIndex: -1
+  readonly onKeyDown: (e: TabsKeyEvent) => void
+}
+
+export interface TabProps {
+  readonly id: string
+  readonly role: 'tab'
+  readonly 'aria-selected': boolean
+  readonly 'aria-controls': string
+  readonly 'aria-disabled'?: true
+  readonly tabIndex: 0 | -1
+  readonly 'data-active': '' | undefined
+  readonly onClick: () => void
+}
+
+export interface TabPanelProps {
+  readonly id: string
+  readonly role: 'tabpanel'
+  readonly 'aria-labelledby': string
+  readonly tabIndex: 0
+  readonly hidden: boolean
+}
+
+export interface CloseButtonProps {
+  readonly type: 'button'
+  readonly 'aria-label': string
+  readonly tabIndex: -1
+  readonly onClick: () => void
+}
+
+export interface TabsController {
+  readonly activeId: string | null
+  readonly tabs: ReadonlyArray<TabDescriptor>
+  readonly draggingId: string | null
+
+  setTabs(tabs: ReadonlyArray<TabDescriptor>): void
+  activate(id: string): void
+  close(id: string): void
+  reorder(ids: ReadonlyArray<string>): void
+
+  getTabListProps(): TabListProps
+  getTabProps(id: string): TabProps
+  getTabPanelProps(id: string): TabPanelProps
+  getCloseButtonProps(id: string): CloseButtonProps
+
+  handleDragStart(id: string): void
+  handleDragOver(targetId: string): void
+  handleDragEnd(): void
+
+  subscribe(listener: (snapshot: TabsSnapshot) => void): () => void
+}
+
+export interface TabsSnapshot {
+  readonly activeId: string | null
+  readonly tabs: ReadonlyArray<TabDescriptor>
+  readonly draggingId: string | null
+}
+
+function tabPanelId(tabId: string): string {
+  return `${tabId}-panel`
+}
+
+export function createTabs(opts: TabsOptions): TabsController {
+  const activationMode = opts.activationMode ?? 'automatic'
+  const orientation = opts.orientation ?? 'horizontal'
+
+  let tabs: ReadonlyArray<TabDescriptor> = opts.tabs
+  let activeId: string | null = opts.defaultActiveId ?? null
+  let draggingId: string | null = null
+  let dragOverId: string | null = null
+
+  // Anchor active to first enabled if no defaultActiveId.
+  if (activeId === null) {
+    for (const t of tabs) {
+      if (t.disabled !== true) {
+        activeId = t.id
+        break
+      }
+    }
+  }
+
+  const rover: RovingTabindexController = createRovingTabindex({
+    orientation,
+    items: tabs.map((t) => ({ id: t.id, disabled: t.disabled, text: t.label })),
+    defaultActiveId: activeId ?? undefined,
+    activateOnFocus: activationMode === 'automatic',
+    onActiveChange: (id) => {
+      if (activationMode === 'automatic' && id !== null) {
+        activate(id)
+      }
+    },
+  })
+
+  const listeners = new Set<(snapshot: TabsSnapshot) => void>()
+
+  function emit(): void {
+    const snap: TabsSnapshot = Object.freeze({
+      activeId,
+      tabs,
+      draggingId,
+    })
+    for (const l of listeners) l(snap)
+  }
+
+  function activate(id: string): void {
+    const idx = tabs.findIndex((t) => t.id === id)
+    if (idx < 0) return
+    const tab = tabs[idx]!
+    if (tab.disabled === true) return
+    if (activeId === id) return
+    activeId = id
+    if (opts.onActiveChange !== undefined) opts.onActiveChange(id)
+    emit()
+  }
+
+  function close(id: string): void {
+    const idx = tabs.findIndex((t) => t.id === id)
+    if (idx < 0) return
+    const wasActive = activeId === id
+    const next = tabs.filter((t) => t.id !== id)
+    tabs = Object.freeze(next)
+    rover.setItems(
+      tabs.map((t) => ({ id: t.id, disabled: t.disabled, text: t.label })),
+    )
+    if (wasActive) {
+      // Pick neighbor: previous if any, else next, else null.
+      let neighborId: string | null = null
+      for (let j = idx - 1; j >= 0; j -= 1) {
+        if (next[j] !== undefined && next[j]!.disabled !== true) {
+          neighborId = next[j]!.id
+          break
+        }
+      }
+      if (neighborId === null) {
+        for (let j = idx; j < next.length; j += 1) {
+          if (next[j] !== undefined && next[j]!.disabled !== true) {
+            neighborId = next[j]!.id
+            break
+          }
+        }
+      }
+      activeId = neighborId
+      if (neighborId !== null && opts.onActiveChange !== undefined) {
+        opts.onActiveChange(neighborId)
+      }
+    }
+    if (opts.onClose !== undefined) opts.onClose(id)
+    emit()
+  }
+
+  function reorder(ids: ReadonlyArray<string>): void {
+    if (ids.length !== tabs.length) return
+    const map = new Map(tabs.map((t) => [t.id, t]))
+    const next: TabDescriptor[] = []
+    for (const id of ids) {
+      const t = map.get(id)
+      if (t === undefined) return
+      next.push(t)
+    }
+    tabs = Object.freeze(next)
+    rover.setItems(
+      tabs.map((t) => ({ id: t.id, disabled: t.disabled, text: t.label })),
+    )
+    if (opts.onReorder !== undefined) opts.onReorder(ids)
+    emit()
+  }
+
+  function handleListKeyDown(e: TabsKeyEvent): void {
+    // Manual activation: Enter / Space activates focused tab.
+    if (
+      activationMode === 'manual' &&
+      (e.key === 'Enter' || e.key === ' ') &&
+      rover.activeId !== null
+    ) {
+      e.preventDefault()
+      activate(rover.activeId)
+      return
+    }
+    // Delete or Mod+W closes focused closeable tab.
+    if (
+      (e.key === 'Delete' || (e.key === 'w' && (e.metaKey === true || e.ctrlKey === true))) &&
+      rover.activeId !== null
+    ) {
+      const target = tabs.find((t) => t.id === rover.activeId)
+      if (target !== undefined && target.closeable === true) {
+        e.preventDefault()
+        close(target.id)
+        return
+      }
+    }
+    // Forward to rover for arrow/Home/End/typeahead.
+    const adapted: RovingKeyEvent = {
+      key: e.key,
+      shiftKey: e.shiftKey,
+      metaKey: e.metaKey,
+      ctrlKey: e.ctrlKey,
+      altKey: e.altKey,
+      preventDefault: () => e.preventDefault(),
+    }
+    rover.handleKeyDown(adapted)
+  }
+
+  return {
+    get activeId() {
+      return activeId
+    },
+    get tabs() {
+      return tabs
+    },
+    get draggingId() {
+      return draggingId
+    },
+
+    setTabs(nextTabs: ReadonlyArray<TabDescriptor>): void {
+      tabs = Object.freeze([...nextTabs])
+      rover.setItems(
+        tabs.map((t) => ({ id: t.id, disabled: t.disabled, text: t.label })),
+      )
+      if (activeId !== null && tabs.findIndex((t) => t.id === activeId) < 0) {
+        // Active tab gone — pick first enabled.
+        let neighborId: string | null = null
+        for (const t of tabs) {
+          if (t.disabled !== true) {
+            neighborId = t.id
+            break
+          }
+        }
+        activeId = neighborId
+        if (neighborId !== null && opts.onActiveChange !== undefined) {
+          opts.onActiveChange(neighborId)
+        }
+      }
+      emit()
+    },
+
+    activate,
+    close,
+    reorder,
+
+    getTabListProps(): TabListProps {
+      return Object.freeze({
+        role: 'tablist' as const,
+        'aria-orientation': orientation,
+        tabIndex: -1 as const,
+        onKeyDown: handleListKeyDown,
+      })
+    },
+
+    getTabProps(id: string): TabProps {
+      const tab = tabs.find((t) => t.id === id)
+      const isActive = activeId === id
+      const isDis = tab?.disabled === true
+      const props: TabProps = {
+        id,
+        role: 'tab' as const,
+        'aria-selected': isActive,
+        'aria-controls': tabPanelId(id),
+        tabIndex: isActive ? 0 : -1,
+        'data-active': isActive ? '' : undefined,
+        onClick: () => activate(id),
+      }
+      if (isDis) {
+        return Object.freeze({ ...props, 'aria-disabled': true as const })
+      }
+      return Object.freeze(props)
+    },
+
+    getTabPanelProps(id: string): TabPanelProps {
+      return Object.freeze({
+        id: tabPanelId(id),
+        role: 'tabpanel' as const,
+        'aria-labelledby': id,
+        tabIndex: 0 as const,
+        hidden: activeId !== id,
+      })
+    },
+
+    getCloseButtonProps(id: string): CloseButtonProps {
+      const tab = tabs.find((t) => t.id === id)
+      const label = tab !== undefined ? `Close ${tab.label}` : 'Close'
+      return Object.freeze({
+        type: 'button' as const,
+        'aria-label': label,
+        tabIndex: -1 as const,
+        onClick: () => close(id),
+      })
+    },
+
+    handleDragStart(id: string): void {
+      const tab = tabs.find((t) => t.id === id)
+      if (tab === undefined || tab.pinned === true) return
+      draggingId = id
+      dragOverId = null
+      emit()
+    },
+
+    handleDragOver(targetId: string): void {
+      if (draggingId === null || draggingId === targetId) return
+      const target = tabs.find((t) => t.id === targetId)
+      if (target === undefined || target.pinned === true) return
+      dragOverId = targetId
+    },
+
+    handleDragEnd(): void {
+      if (draggingId === null) {
+        emit()
+        return
+      }
+      if (dragOverId !== null && dragOverId !== draggingId) {
+        const newOrder: string[] = []
+        for (const t of tabs) {
+          if (t.id === draggingId) continue
+          if (t.id === dragOverId) {
+            newOrder.push(draggingId)
+          }
+          newOrder.push(t.id)
+        }
+        // If the over target was the last position, the dragged item
+        // wasn't appended; ensure it's present.
+        if (newOrder.indexOf(draggingId) === -1) newOrder.push(draggingId)
+        const map = new Map(tabs.map((t) => [t.id, t]))
+        const reordered: TabDescriptor[] = newOrder
+          .map((id) => map.get(id))
+          .filter((t): t is TabDescriptor => t !== undefined)
+        tabs = Object.freeze(reordered)
+        rover.setItems(
+          tabs.map((t) => ({ id: t.id, disabled: t.disabled, text: t.label })),
+        )
+        if (opts.onReorder !== undefined) opts.onReorder(newOrder)
+      }
+      draggingId = null
+      dragOverId = null
+      emit()
+    },
+
+    subscribe(listener: (snapshot: TabsSnapshot) => void): () => void {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Implements RFC 0015 (#11974) — headless tab primitive consolidating mode-tabs / keeper-inspector / deck-mode / settings + Stage 5 editor tab strip. **Composes the now-merged RovingTabindex** (#11988, on main).

## Test results

```
Tests  19 passed (19)
```

## Highlights

- Composes Roving via `createRovingTabindex({ activateOnFocus })` driven by `activationMode`
- **automatic** (default): rover move = activation; **manual**: rover moves but Enter/Space activates
- Close button `tabIndex=-1` so Tab traversal goes through tab itself (matches VS Code)
- Drag reorder via 3 handlers + pinned tabs cluster (pinned source rejected)
- `aria-controls` ↔ `aria-labelledby` round-trip
- Vertical orientation forwards `ArrowDown/ArrowUp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)