### PR TITLE
feat(headless): RFC 0005 Menu + ContextMenu implementation

### DIFF
--- a/dashboard/design-system/headless-core/menu.test.ts
+++ b/dashboard/design-system/headless-core/menu.test.ts
@@ -1,0 +1,307 @@
+// Pure TS unit tests for Menu + ContextMenu. No DOM.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  createMenu,
+  createContextMenu,
+  type MenuKeyEvent,
+  type MenuItemDescriptor,
+} from './menu'
+
+function makeKey(
+  key: string,
+  opts?: Partial<MenuKeyEvent>,
+): MenuKeyEvent & { _prevented: boolean } {
+  let prevented = false
+  return {
+    key,
+    metaKey: opts?.metaKey,
+    ctrlKey: opts?.ctrlKey,
+    shiftKey: opts?.shiftKey,
+    altKey: opts?.altKey,
+    preventDefault() {
+      prevented = true
+    },
+    get _prevented() {
+      return prevented
+    },
+  } as MenuKeyEvent & { _prevented: boolean }
+}
+
+const FLAT: ReadonlyArray<MenuItemDescriptor> = [
+  { id: 'open', label: 'Open' },
+  { id: 'sep', label: '', type: 'separator' },
+  { id: 'rename', label: 'Rename', shortcut: 'F2' },
+  { id: 'delete', label: 'Delete', disabled: true },
+]
+
+const NESTED: ReadonlyArray<MenuItemDescriptor> = [
+  { id: 'view', label: 'View' },
+  {
+    id: 'move',
+    label: 'Move to',
+    items: [
+      { id: 'archive', label: 'Archive' },
+      { id: 'trash', label: 'Trash' },
+    ],
+  },
+  { id: 'rename', label: 'Rename' },
+]
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createMenu — open / close round-trip', () => {
+  it('open() opens; close() closes; trigger reflects via aria-expanded', () => {
+    const m = createMenu({ id: 'm1', items: FLAT })
+    expect(m.isOpen).toBe(false)
+    expect(m.getTriggerProps()['aria-expanded']).toBe(false)
+    m.open()
+    expect(m.isOpen).toBe(true)
+    expect(m.getTriggerProps()['aria-expanded']).toBe(true)
+    m.close()
+    expect(m.isOpen).toBe(false)
+  })
+
+  it('first focus on open lands on first enabled item', () => {
+    const items: ReadonlyArray<MenuItemDescriptor> = [
+      { id: 'a', label: 'A', disabled: true },
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C' },
+    ]
+    const m = createMenu({ id: 'm1', items })
+    m.open()
+    expect(m.activeId).toBe('b')
+  })
+
+  it('keyboard open: Enter / Space / ArrowDown -> open + first focus', () => {
+    const m = createMenu({ id: 'm1', items: FLAT })
+    m.getTriggerProps().onKeyDown(makeKey('Enter'))
+    expect(m.isOpen).toBe(true)
+    m.close()
+    m.getTriggerProps().onKeyDown(makeKey(' '))
+    expect(m.isOpen).toBe(true)
+  })
+
+  it('keyboard open: ArrowUp -> open + last focus', () => {
+    const m = createMenu({ id: 'm1', items: FLAT })
+    m.getTriggerProps().onKeyDown(makeKey('ArrowUp'))
+    expect(m.isOpen).toBe(true)
+    expect(m.activeId).toBe('rename') // 'delete' is disabled, last-enabled
+  })
+})
+
+describe('createMenu — keyboard navigation', () => {
+  it('ArrowDown / ArrowUp move rover; separator skipped', () => {
+    const m = createMenu({ id: 'm1', items: FLAT })
+    m.open()
+    expect(m.activeId).toBe('open')
+    m.getMenuProps().onKeyDown(makeKey('ArrowDown'))
+    expect(m.activeId).toBe('rename') // sep is filtered from rover entirely
+  })
+
+  it('Esc on open menu closes', () => {
+    const m = createMenu({ id: 'm1', items: FLAT })
+    m.open()
+    m.getMenuProps().onKeyDown(makeKey('Escape'))
+    expect(m.isOpen).toBe(false)
+  })
+
+  it('Enter selects + closes', () => {
+    const calls: string[] = []
+    const m = createMenu({
+      id: 'm1',
+      items: FLAT,
+      onSelect: (id) => calls.push(id),
+    })
+    m.open()
+    m.getMenuProps().onKeyDown(makeKey('Enter'))
+    expect(calls).toEqual(['open'])
+    expect(m.isOpen).toBe(false)
+  })
+
+  it('disabled items are skipped by rover; click is no-op', () => {
+    const calls: string[] = []
+    const m = createMenu({
+      id: 'm1',
+      items: FLAT,
+      onSelect: (id) => calls.push(id),
+    })
+    m.open()
+    m.getItemProps('delete').onClick()
+    expect(calls).toEqual([])
+  })
+})
+
+describe('createMenu — submenu lifecycle', () => {
+  it('ArrowRight on item with children opens submenu', () => {
+    const m = createMenu({ id: 'm1', items: NESTED })
+    const snaps: Array<{ openPath: ReadonlyArray<string> }> = []
+    m.subscribe((s) => snaps.push({ openPath: s.openPath }))
+    m.open()
+    m.getMenuProps().onKeyDown(makeKey('ArrowDown')) // focus 'move'
+    expect(m.activeId).toBe('move')
+    m.getMenuProps().onKeyDown(makeKey('ArrowRight'))
+    // After ArrowRight, last snap should reflect openPath=['move'].
+    const last = snaps[snaps.length - 1]
+    expect(last).toBeDefined()
+    expect(last!.openPath).toEqual(['move'])
+  })
+
+  it('ArrowLeft from open submenu closes it', () => {
+    const m = createMenu({ id: 'm1', items: NESTED })
+    const snaps: Array<{ openPath: ReadonlyArray<string> }> = []
+    m.subscribe((s) => snaps.push({ openPath: s.openPath }))
+    m.open()
+    m.getMenuProps().onKeyDown(makeKey('ArrowDown'))
+    m.getMenuProps().onKeyDown(makeKey('ArrowRight')) // open submenu
+    expect(snaps[snaps.length - 1]!.openPath).toEqual(['move'])
+    m.getMenuProps().onKeyDown(makeKey('ArrowLeft'))
+    expect(snaps[snaps.length - 1]!.openPath).toEqual([])
+  })
+
+  it('hover with delay opens submenu', () => {
+    const m = createMenu({ id: 'm1', items: NESTED, submenuOpenDelay: 100 })
+    const snaps: Array<ReadonlyArray<string>> = []
+    m.subscribe((s) => snaps.push(s.openPath))
+    m.open()
+    m.getItemProps('move').onMouseEnter()
+    vi.advanceTimersByTime(99)
+    expect(snaps[snaps.length - 1] ?? []).toEqual([])
+    vi.advanceTimersByTime(2)
+    expect(snaps[snaps.length - 1]).toEqual(['move'])
+  })
+
+  it('Esc on submenu closes only one level', () => {
+    const m = createMenu({ id: 'm1', items: NESTED })
+    m.open()
+    m.getMenuProps().onKeyDown(makeKey('ArrowDown'))
+    m.getMenuProps().onKeyDown(makeKey('ArrowRight')) // open submenu
+    expect(m.isOpen).toBe(true)
+    m.getMenuProps().onKeyDown(makeKey('Escape'))
+    // Submenu closes; root menu still open
+    expect(m.isOpen).toBe(true)
+    m.getMenuProps().onKeyDown(makeKey('Escape'))
+    // Root closes
+    expect(m.isOpen).toBe(false)
+  })
+})
+
+describe('createMenu — getItemProps ARIA', () => {
+  it('aria-haspopup=menu when item has children', () => {
+    const m = createMenu({ id: 'm1', items: NESTED })
+    expect(m.getItemProps('move')['aria-haspopup']).toBe('menu')
+    expect(m.getItemProps('view')['aria-haspopup']).toBeUndefined()
+  })
+
+  it('aria-keyshortcuts surfaces shortcut string', () => {
+    const m = createMenu({ id: 'm1', items: FLAT })
+    expect(m.getItemProps('rename')['aria-keyshortcuts']).toBe('F2')
+  })
+
+  it('separator items render role=separator', () => {
+    const m = createMenu({ id: 'm1', items: FLAT })
+    const props = m.getItemProps('sep')
+    expect(props.role).toBe('separator')
+    expect(props.tabIndex).toBe(-1)
+  })
+
+  it('aria-disabled set on disabled items', () => {
+    const m = createMenu({ id: 'm1', items: FLAT })
+    expect(m.getItemProps('delete')['aria-disabled']).toBe(true)
+    expect(m.getItemProps('open')['aria-disabled']).toBeUndefined()
+  })
+
+  it('aria-expanded reflects submenu open state', () => {
+    const m = createMenu({ id: 'm1', items: NESTED })
+    m.open()
+    expect(m.getItemProps('move')['aria-expanded']).toBe(false)
+    m.getItemProps('move').onClick() // selecting an item with children opens submenu
+    expect(m.getItemProps('move')['aria-expanded']).toBe(true)
+  })
+})
+
+describe('createMenu — trigger ARIA', () => {
+  it('aria-controls = menu id', () => {
+    const m = createMenu({ id: 'menu-x', items: FLAT })
+    expect(m.getTriggerProps()['aria-controls']).toBe('menu-x')
+    expect(m.getMenuProps().id).toBe('menu-x')
+  })
+})
+
+describe('createContextMenu — openAt + viewport flip', () => {
+  it('top-left corner -> bottom-start', () => {
+    const cm = createContextMenu({
+      id: 'ctx',
+      items: FLAT,
+      viewport: { width: 1000, height: 1000 },
+    })
+    cm.openAt({ x: 100, y: 100 })
+    expect(cm.position).toEqual({ x: 100, y: 100 })
+    expect(cm.resolvedPlacement).toBe('bottom-start')
+    expect(cm.isOpen).toBe(true)
+  })
+
+  it('bottom-right corner -> top-end', () => {
+    const cm = createContextMenu({
+      id: 'ctx',
+      items: FLAT,
+      viewport: { width: 1000, height: 1000 },
+    })
+    cm.openAt({ x: 900, y: 900 })
+    expect(cm.resolvedPlacement).toBe('top-end')
+  })
+
+  it('right edge but top -> bottom-end', () => {
+    const cm = createContextMenu({
+      id: 'ctx',
+      items: FLAT,
+      viewport: { width: 1000, height: 1000 },
+    })
+    cm.openAt({ x: 800, y: 100 })
+    expect(cm.resolvedPlacement).toBe('bottom-end')
+  })
+})
+
+describe('createMenu — subscribe', () => {
+  it('listener fires on open / close / submenu open', () => {
+    const m = createMenu({ id: 'm1', items: NESTED })
+    let count = 0
+    const dispose = m.subscribe(() => {
+      count += 1
+    })
+    m.open()
+    m.close()
+    expect(count).toBeGreaterThan(0)
+    const before = count
+    dispose()
+    m.open()
+    expect(count).toBe(before)
+  })
+})
+
+describe('createMenu — onSelect path', () => {
+  it('flat menu select -> path is single id', () => {
+    const calls: ReadonlyArray<string>[] = []
+    const m = createMenu({
+      id: 'm1',
+      items: FLAT,
+      onSelect: (_id, path) => calls.push(path),
+    })
+    m.open()
+    m.select('open')
+    expect(calls).toEqual([['open']])
+  })
+
+  it('toggle: closed -> open, open -> closed', () => {
+    const m = createMenu({ id: 'm1', items: FLAT })
+    expect(m.isOpen).toBe(false)
+    m.toggle()
+    expect(m.isOpen).toBe(true)
+    m.toggle()
+    expect(m.isOpen).toBe(false)
+  })
+})

--- a/dashboard/design-system/headless-core/menu.ts
+++ b/dashboard/design-system/headless-core/menu.ts
@@ -1,0 +1,544 @@
+/**
+ * Menu — framework-agnostic menu / context-menu / submenu primitive
+ * (RFC 0005). Composes RovingTabindex (RFC 0003) for menuitem
+ * keyboard navigation, IdGenerator (RFC 0001) for aria-controls
+ * linkage, and is designed to mount inside PortalManager 'dropdown'
+ * layer (RFC 0001) — the manager itself is consumer-side concern.
+ *
+ * MVP scope (RFC 0005 §3, §4, §5, §7):
+ *   - Action menu, submenu, context menu (createContextMenu wrapper)
+ *   - Trigger: aria-haspopup=menu + aria-expanded + aria-controls,
+ *     keyboard open via Enter/Space/ArrowDown (focus first item) and
+ *     ArrowUp (focus last item)
+ *   - Menu items: role=menuitem, aria-disabled, aria-keyshortcuts,
+ *     data-active rover hook
+ *   - Separator items: role=separator with no rover stop
+ *   - Submenu open/close delays (default 200/300 ms)
+ *   - Submenus = separate createMenu instances chained via openPath
+ *     snapshot; ArrowRight/ArrowLeft navigate the chain
+ *   - Esc closes current level (deepest first); propagates up
+ *
+ * Out of scope (RFC 0005 §11, §6):
+ *   - Menu chrome tokens (Stage 1.4 follow-up — already merged via
+ *     #11965)
+ *   - Hover-tunnel mouse path (Amazon mega-menu pattern); 200/300 ms
+ *     delays approximate the effect
+ *   - Global keyboard shortcut REGISTRATION — manager exposes
+ *     aria-keyshortcuts but does not bind global keys
+ */
+
+import {
+  createRovingTabindex,
+  type RovingTabindexController,
+  type RovingKeyEvent,
+} from './roving-tabindex'
+
+export type MenuPlacement =
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'top-start'
+  | 'top-end'
+  | 'right-start'
+  | 'right-end'
+  | 'left-start'
+  | 'left-end'
+
+export interface MenuItemDescriptor {
+  readonly id: string
+  readonly label: string
+  readonly disabled?: boolean
+  readonly shortcut?: string
+  readonly items?: ReadonlyArray<MenuItemDescriptor>
+  readonly type?: 'item' | 'separator'
+}
+
+export interface MenuOptions {
+  items: ReadonlyArray<MenuItemDescriptor>
+  placement?: MenuPlacement
+  orientation?: 'vertical' | 'horizontal'
+  loop?: boolean
+  submenuOpenDelay?: number
+  submenuCloseDelay?: number
+  /** Stable id seed; consumer typically passes useId() result. */
+  id: string
+  onSelect?: (itemId: string, path: ReadonlyArray<string>) => void
+  onOpenChange?: (open: boolean) => void
+}
+
+export interface MenuKeyEvent {
+  readonly key: string
+  readonly metaKey?: boolean
+  readonly ctrlKey?: boolean
+  readonly shiftKey?: boolean
+  readonly altKey?: boolean
+  preventDefault(): void
+}
+
+export interface MenuTriggerProps {
+  readonly 'aria-haspopup': 'menu'
+  readonly 'aria-expanded': boolean
+  readonly 'aria-controls': string
+  readonly onClick: () => void
+  readonly onKeyDown: (e: MenuKeyEvent) => void
+}
+
+export interface MenuProps {
+  readonly id: string
+  readonly role: 'menu'
+  readonly 'aria-orientation': 'vertical' | 'horizontal'
+  readonly tabIndex: -1
+  readonly onKeyDown: (e: MenuKeyEvent) => void
+}
+
+export interface MenuItemProps {
+  readonly id: string
+  readonly role: 'menuitem' | 'separator'
+  readonly tabIndex: 0 | -1
+  readonly 'aria-disabled'?: true
+  readonly 'aria-haspopup'?: 'menu'
+  readonly 'aria-expanded'?: boolean
+  readonly 'aria-keyshortcuts'?: string
+  readonly 'data-active': '' | undefined
+  readonly onClick: () => void
+  readonly onMouseEnter: () => void
+  readonly onMouseLeave: () => void
+}
+
+export interface MenuSnapshot {
+  readonly isOpen: boolean
+  readonly activeId: string | null
+  readonly openPath: ReadonlyArray<string>
+}
+
+export interface MenuController {
+  readonly isOpen: boolean
+  readonly activeId: string | null
+
+  open(): void
+  close(): void
+  toggle(): void
+
+  focus(itemId: string): void
+  select(itemId: string): void
+
+  getTriggerProps(): MenuTriggerProps
+  getMenuProps(): MenuProps
+  getItemProps(itemId: string): MenuItemProps
+
+  subscribe(listener: (snapshot: MenuSnapshot) => void): () => void
+
+  /** Internal: parent invokes this when its trigger initiates a chain
+   *  open — so child can open without redundant trigger click. */
+  _openImmediate(): void
+  /** Internal: id of the parent item this menu is attached to (for
+   *  submenus). null for root menus. */
+  readonly _parentItemId: string | null
+}
+
+const DEFAULT_OPEN_DELAY = 200
+const DEFAULT_CLOSE_DELAY = 300
+
+interface InternalMenuOptions extends MenuOptions {
+  parentItemId?: string | null
+  onChainSelect?: (path: ReadonlyArray<string>) => void
+}
+
+function createMenuInternal(opts: InternalMenuOptions): MenuController {
+  const orientation = opts.orientation ?? 'vertical'
+  const loop = opts.loop ?? true
+  const openDelay = opts.submenuOpenDelay ?? DEFAULT_OPEN_DELAY
+  const closeDelay = opts.submenuCloseDelay ?? DEFAULT_CLOSE_DELAY
+
+  let isOpen = false
+  let openSubmenuId: string | null = null
+  let openTimer: ReturnType<typeof setTimeout> | null = null
+  let closeTimer: ReturnType<typeof setTimeout> | null = null
+
+  const submenus = new Map<string, MenuController>()
+  // Lazily build child menus for items that have nested items.
+  for (const item of opts.items) {
+    if (item.items !== undefined && item.items.length > 0) {
+      const childId = `${opts.id}-sub-${item.id}`
+      const child: MenuController = createMenuInternal({
+        id: childId,
+        items: item.items,
+        placement: 'right-start',
+        orientation: 'vertical',
+        loop,
+        submenuOpenDelay: openDelay,
+        submenuCloseDelay: closeDelay,
+        onSelect: opts.onSelect,
+        parentItemId: item.id,
+        onChainSelect: opts.onChainSelect,
+      })
+      submenus.set(item.id, child)
+    }
+  }
+
+  const rover: RovingTabindexController = createRovingTabindex({
+    orientation,
+    loop,
+    items: opts.items
+      .filter((i) => i.type !== 'separator')
+      .map((i) => ({ id: i.id, disabled: i.disabled, text: i.label })),
+  })
+
+  const listeners = new Set<(s: MenuSnapshot) => void>()
+
+  function snapshot(): MenuSnapshot {
+    const path: string[] = []
+    if (openSubmenuId !== null) path.push(openSubmenuId)
+    return Object.freeze({
+      isOpen,
+      activeId: rover.activeId,
+      openPath: Object.freeze(path),
+    })
+  }
+
+  function emit(): void {
+    const snap = snapshot()
+    for (const l of listeners) l(snap)
+  }
+
+  function clearOpenTimer(): void {
+    if (openTimer !== null) {
+      clearTimeout(openTimer)
+      openTimer = null
+    }
+  }
+  function clearCloseTimer(): void {
+    if (closeTimer !== null) {
+      clearTimeout(closeTimer)
+      closeTimer = null
+    }
+  }
+
+  function openSubmenu(itemId: string): void {
+    if (openSubmenuId === itemId) return
+    if (openSubmenuId !== null) {
+      submenus.get(openSubmenuId)?.close()
+    }
+    const child = submenus.get(itemId)
+    if (child === undefined) return
+    child._openImmediate()
+    openSubmenuId = itemId
+    emit()
+  }
+
+  function closeSubmenu(): void {
+    if (openSubmenuId === null) return
+    submenus.get(openSubmenuId)?.close()
+    openSubmenuId = null
+    emit()
+  }
+
+  function setOpen(next: boolean): void {
+    if (isOpen === next) return
+    isOpen = next
+    if (!next) {
+      // Cascade: close any open child.
+      closeSubmenu()
+      clearOpenTimer()
+      clearCloseTimer()
+    }
+    if (opts.onOpenChange !== undefined) opts.onOpenChange(next)
+    emit()
+  }
+
+  function selectImpl(itemId: string): void {
+    const item = opts.items.find((i) => i.id === itemId)
+    if (item === undefined || item.disabled === true || item.type === 'separator')
+      return
+    if (item.items !== undefined && item.items.length > 0) {
+      openSubmenu(itemId)
+      return
+    }
+    const path = [...(opts.parentItemId !== null && opts.parentItemId !== undefined
+      ? [opts.parentItemId]
+      : []), itemId]
+    if (opts.onSelect !== undefined) opts.onSelect(itemId, path)
+    if (opts.onChainSelect !== undefined) opts.onChainSelect(path)
+    setOpen(false)
+  }
+
+  function handleTriggerKeyDown(e: MenuKeyEvent): void {
+    if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
+      e.preventDefault()
+      setOpen(true)
+      rover.first()
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setOpen(true)
+      rover.last()
+      return
+    }
+  }
+
+  function handleMenuKeyDown(e: MenuKeyEvent): void {
+    if (!isOpen) return
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      if (openSubmenuId !== null) {
+        closeSubmenu()
+        return
+      }
+      setOpen(false)
+      return
+    }
+    if (e.key === 'ArrowRight') {
+      // Open submenu if the focused item has children.
+      const focusedId = rover.activeId
+      if (focusedId !== null) {
+        const child = submenus.get(focusedId)
+        if (child !== undefined) {
+          e.preventDefault()
+          openSubmenu(focusedId)
+          return
+        }
+      }
+      // Otherwise no-op for vertical menu.
+      return
+    }
+    if (e.key === 'ArrowLeft') {
+      // Close submenu OR (if root) close menu.
+      if (openSubmenuId !== null) {
+        e.preventDefault()
+        closeSubmenu()
+        return
+      }
+      if (opts.parentItemId !== null && opts.parentItemId !== undefined) {
+        e.preventDefault()
+        setOpen(false)
+        return
+      }
+      return
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      if (rover.activeId !== null) selectImpl(rover.activeId)
+      return
+    }
+    // Forward to rover.
+    const adapted: RovingKeyEvent = {
+      key: e.key,
+      shiftKey: e.shiftKey,
+      metaKey: e.metaKey,
+      ctrlKey: e.ctrlKey,
+      altKey: e.altKey,
+      preventDefault: () => e.preventDefault(),
+    }
+    rover.handleKeyDown(adapted)
+  }
+
+  return {
+    get isOpen() {
+      return isOpen
+    },
+    get activeId() {
+      return rover.activeId
+    },
+    get _parentItemId() {
+      return opts.parentItemId ?? null
+    },
+
+    open(): void {
+      setOpen(true)
+      rover.first()
+    },
+
+    close(): void {
+      setOpen(false)
+    },
+
+    toggle(): void {
+      if (isOpen) setOpen(false)
+      else this.open()
+    },
+
+    _openImmediate(): void {
+      setOpen(true)
+      rover.first()
+    },
+
+    focus(itemId: string): void {
+      rover.setActive(itemId)
+    },
+
+    select(itemId: string): void {
+      selectImpl(itemId)
+    },
+
+    getTriggerProps(): MenuTriggerProps {
+      return Object.freeze({
+        'aria-haspopup': 'menu' as const,
+        'aria-expanded': isOpen,
+        'aria-controls': opts.id,
+        onClick: () => this.toggle(),
+        onKeyDown: handleTriggerKeyDown,
+      })
+    },
+
+    getMenuProps(): MenuProps {
+      return Object.freeze({
+        id: opts.id,
+        role: 'menu' as const,
+        'aria-orientation': orientation,
+        tabIndex: -1 as const,
+        onKeyDown: handleMenuKeyDown,
+      })
+    },
+
+    getItemProps(itemId: string): MenuItemProps {
+      const item = opts.items.find((i) => i.id === itemId)
+      if (item === undefined) {
+        return Object.freeze({
+          id: itemId,
+          role: 'menuitem' as const,
+          tabIndex: -1 as const,
+          'data-active': undefined,
+          onClick: () => {},
+          onMouseEnter: () => {},
+          onMouseLeave: () => {},
+        })
+      }
+      if (item.type === 'separator') {
+        return Object.freeze({
+          id: itemId,
+          role: 'separator' as const,
+          tabIndex: -1 as const,
+          'data-active': undefined,
+          onClick: () => {},
+          onMouseEnter: () => {},
+          onMouseLeave: () => {},
+        })
+      }
+      const isActive = rover.activeId === itemId
+      const isDis = item.disabled === true
+      const hasSub = item.items !== undefined && item.items.length > 0
+      const props: MenuItemProps = {
+        id: itemId,
+        role: 'menuitem' as const,
+        tabIndex: isActive ? 0 : -1,
+        'aria-disabled': isDis ? (true as const) : undefined,
+        'aria-haspopup': hasSub ? ('menu' as const) : undefined,
+        'aria-expanded': hasSub ? openSubmenuId === itemId : undefined,
+        'aria-keyshortcuts': item.shortcut,
+        'data-active': isActive ? '' : undefined,
+        onClick: () => {
+          if (isDis) return
+          selectImpl(itemId)
+        },
+        onMouseEnter: () => {
+          if (isDis) return
+          rover.setActive(itemId)
+          if (hasSub) {
+            clearCloseTimer()
+            clearOpenTimer()
+            openTimer = setTimeout(() => {
+              openTimer = null
+              openSubmenu(itemId)
+            }, openDelay)
+          } else if (openSubmenuId !== null) {
+            // Hovering a sibling without children — start close timer.
+            clearCloseTimer()
+            closeTimer = setTimeout(() => {
+              closeTimer = null
+              closeSubmenu()
+            }, closeDelay)
+          }
+        },
+        onMouseLeave: () => {
+          if (openTimer !== null) clearOpenTimer()
+        },
+      }
+      return Object.freeze(props)
+    },
+
+    subscribe(listener: (s: MenuSnapshot) => void): () => void {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}
+
+export function createMenu(opts: MenuOptions): MenuController {
+  return createMenuInternal({ ...opts, parentItemId: null })
+}
+
+// Context menu wrapper — adds openAt(coords) + viewport flip awareness.
+
+export interface ContextMenuOptions extends MenuOptions {
+  viewport?: { readonly width: number; readonly height: number }
+}
+
+export interface ContextMenuController extends MenuController {
+  openAt(coords: { x: number; y: number }): void
+  /** Last-set position; null when never opened or after close. */
+  readonly position: { readonly x: number; readonly y: number } | null
+  /** Resolved placement after viewport flip. */
+  readonly resolvedPlacement: MenuPlacement
+}
+
+export function createContextMenu(opts: ContextMenuOptions): ContextMenuController {
+  const inner = createMenu(opts)
+  let position: { x: number; y: number } | null = null
+  let resolvedPlacement: MenuPlacement = opts.placement ?? 'bottom-start'
+
+  function getViewport(): { width: number; height: number } {
+    if (opts.viewport !== undefined) return opts.viewport
+    if (typeof globalThis.window !== 'undefined') {
+      return {
+        width: globalThis.window.innerWidth,
+        height: globalThis.window.innerHeight,
+      }
+    }
+    return { width: 1024, height: 768 }
+  }
+
+  // Cannot spread `inner` because getters would be evaluated to static
+  // values at spread time, freezing isOpen / activeId. Forward each
+  // member explicitly so the getters stay live against `inner`'s state.
+  const cm: ContextMenuController = {
+    get isOpen() {
+      return inner.isOpen
+    },
+    get activeId() {
+      return inner.activeId
+    },
+    get _parentItemId() {
+      return inner._parentItemId
+    },
+    get position() {
+      return position
+    },
+    get resolvedPlacement() {
+      return resolvedPlacement
+    },
+    open: () => inner.open(),
+    close: () => inner.close(),
+    toggle: () => inner.toggle(),
+    _openImmediate: () => inner._openImmediate(),
+    focus: (id: string) => inner.focus(id),
+    select: (id: string) => inner.select(id),
+    getTriggerProps: () => inner.getTriggerProps(),
+    getMenuProps: () => inner.getMenuProps(),
+    getItemProps: (id: string) => inner.getItemProps(id),
+    subscribe: (listener) => inner.subscribe(listener),
+    openAt(coords: { x: number; y: number }): void {
+      const vp = getViewport()
+      position = { ...coords }
+      const rightHalf = coords.x > vp.width / 2
+      const bottomHalf = coords.y > vp.height / 2
+      if (rightHalf && bottomHalf) resolvedPlacement = 'top-end'
+      else if (rightHalf) resolvedPlacement = 'bottom-end'
+      else if (bottomHalf) resolvedPlacement = 'top-start'
+      else resolvedPlacement = 'bottom-start'
+      inner.open()
+    },
+  }
+  return cm
+}


### PR DESCRIPTION
## Summary

Implements RFC 0005 (#11953, merged) — headless action-menu / context-menu / submenu primitive that **composes the now-merged RovingTabindex** (#11988).

## Test results

```
Tests  24 passed (24)
```

## Highlights

- Submenus = separate `createMenu` instances chained via `openPath` snapshot
- Keyboard: Enter/Space/ArrowDown opens menu + first focus; ArrowUp opens + last focus; ArrowRight on parent → submenu; ArrowLeft closes submenu one level; Esc closes deepest first
- Hover with `submenuOpenDelay` (default 200 ms); pre-timer leave cancels
- Separator items filtered from Roving entirely
- ARIA: `role=menu` + `role=menuitem`/`role=separator` + `aria-haspopup` + `aria-keyshortcuts` + `aria-expanded`
- `createContextMenu(opts)` adds `openAt(coords)` with viewport-flip placement

## Bug fix during implementation

`createContextMenu` cannot use object spread `{ ...inner }` — getters are evaluated to static values at spread time, freezing `isOpen`/`activeId`. Replaced with explicit member forwarding so getters stay live.

## Unblocks

- **Toolbar overflow menu** (RFC 0016)
- **InlineSuggestion multi-suggestion picker** (RFC 0011)

🤖 Generated with [Claude Code](https://claude.com/claude-code)