### PR TITLE
ci(perf): daily perf baseline workflow (PR-0.2.F)

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -1,0 +1,43 @@
+name: Perf Baseline (Daily)
+
+# Runs scripts/perf-baseline.sh on a daily schedule and records the
+# raw output as an artifact. The script targets a live masc-mcp server
+# at :8935; in CI no server is running, so the run is expected to exit
+# with code 3 ("server unreachable"). The captured artifact is still
+# useful as an audit trail of attempted runs and dependency presence
+# (curl, awk, date, mkdir, tee) on the runner.
+#
+# Real 14-day baseline collection happens on the Railway production
+# host per docs/design/perf-baseline-protocol.md section 3.3. This
+# workflow documents the schedule and leaves a paper trail; the daily
+# production cron is the source of truth for actual numbers.
+#
+# References:
+#   - scripts/perf-baseline.sh        (#11984)
+#   - docs/design/perf-baseline-protocol.md (#11984, section 3.3)
+#   - knowledge/research/2026-04-masc-ide-strategy/IMPLEMENTATION-PLAN.md PR-0.2.F
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # daily 08:00 UTC
+  workflow_dispatch:
+
+jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run perf baseline
+        run: |
+          chmod +x scripts/perf-baseline.sh
+          ./scripts/perf-baseline.sh > baseline-output.txt 2>&1 || echo "exit=$?" >> baseline-output.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-baseline-${{ github.run_id }}
+          path: baseline-output.txt
+          retention-days: 90


### PR DESCRIPTION
## Summary
- Daily cron (08:00 UTC) running `scripts/perf-baseline.sh` from #11984
- Artifact retention 90 days
- `workflow_dispatch` for manual run
- 14일 baseline 측정 protocol (`docs/design/perf-baseline-protocol.md`) 의 자동화

## RFC
- `knowledge/research/2026-04-masc-ide-strategy/IMPLEMENTATION-PLAN.md` PR-0.2.F

## 설계 메모
`scripts/perf-baseline.sh` 는 `:8935` 의 라이브 masc-mcp 서버를 대상으로 한다.
GH Actions 러너에는 서버가 없으므로 daily run 은 exit 3 (`server unreachable`) 로
종료되며, 워크플로는 `|| echo "exit=$?"` 로 흡수해 artifact 만 남긴다.
production 14일 baseline 수집은 Railway 호스트 cron 으로 분리되어 있으며
(`docs/design/perf-baseline-protocol.md` 3.3 절), 본 워크플로는 시도 기록과
의존성 (curl/awk/date/mkdir/tee) 가용 여부의 audit trail 역할만 한다.

## Test plan
- [ ] `workflow_dispatch` 수동 트리거 (1회)
- [ ] artifact 다운로드 후 baseline 데이터 검증

## Cron 충돌 점검
- 기존 cron 스케줄: `tla-index.yml` `17 6 * * 1`, `webrtc-live-interop.yml` `15 3 * * 0`
- 신규: `0 8 * * *` (daily) → 시간/요일 모두 비겹침

코드 변경 0. 신규 의존성 0.