### PR TITLE
feat(perf): cold/warm phase label on tool_call_duration (PR-0.2.C)

### DIFF
--- a/lib/otel/otel_dispatch_hook.ml
+++ b/lib/otel/otel_dispatch_hook.ml
@@ -18,11 +18,24 @@
 
 module OT = Opentelemetry
 
+(** PR-0.2.C: process startup timestamp captured at module load. Used to
+    classify tool calls into [phase=cold] (within first
+    [cold_phase_seconds] after startup) or [phase=warm] (after).
+    Cold/warm split lets dashboards distinguish first-call overhead
+    (provider warmup, JIT, prefix-cache miss) from steady-state cost
+    without changing the histogram's underlying observation. *)
+let startup_time = Unix.gettimeofday ()
+let cold_phase_seconds = 60.0
+let cold_warm_phase () =
+  if Unix.gettimeofday () -. startup_time < cold_phase_seconds then "cold"
+  else "warm"
+
 (** Record a tool call as an OTel span and Prometheus histogram observation. *)
 let on_tool_result (result : Tool_result.t) : Tool_result.t =
   (* Prometheus histogram: always active regardless of MASC_OTEL_ENABLED *)
   Prometheus.observe_histogram "masc_tool_call_duration_seconds"
-    ~labels:[("tool_name", result.tool_name)]
+    ~labels:[("tool_name", result.tool_name);
+             ("phase", cold_warm_phase ())]
     (result.duration_ms /. 1000.0);
   (* OTel span: only when enabled *)
   if Otel_config.enabled then begin

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -873,8 +873,16 @@ let init () =
     "Total provider prefix cache read tokens (Anthropic)" Counter;
   add metric_tool_call
     "Total keeper tool calls labeled by provider, tool, and outcome" Counter;
+  (* PR-0.2.C: pre-register cold/warm phase rows so /metrics shows a
+     zero-value baseline before the first observation. The phase label
+     is decided at observe-site in [Otel_dispatch_hook] based on a
+     module-level startup time threshold. *)
   register_histogram ~name:metric_tool_call_duration
-    ~help:"Tool call latency in seconds" ();
+    ~help:"Tool call latency in seconds (phase=cold|warm)"
+    ~labels:[("phase", "cold")] ();
+  register_histogram ~name:metric_tool_call_duration
+    ~help:"Tool call latency in seconds (phase=cold|warm)"
+    ~labels:[("phase", "warm")] ();
   (* Inference admission queue metrics *)
   add metric_inference_queue_inflight
     "Concurrent inference calls holding an admission permit" Gauge;


### PR DESCRIPTION
## Summary

RFC pack `knowledge/research/2026-04-masc-ide-strategy/IMPLEMENTATION-PLAN.md` Phase 0 sub-PR. Adds `phase=cold|warm` label to `masc_tool_call_duration_seconds` histogram so dashboards can split first-call overhead (provider warmup, JIT, prefix-cache miss) from steady-state cost without a separate metric.

## Changes

- `lib/prometheus.ml` (init): pre-register two histogram rows (`phase=cold`, `phase=warm`) so `/metrics` shows zero baselines before first observation.
- `lib/otel/otel_dispatch_hook.ml`: capture `startup_time` at module load. `cold_warm_phase ()` returns `cold` if elapsed < 60s, else `warm`. Existing `tool_name` label preserved; phase added.

## Logic surface

Phase classifier is the only logic added (~5 lines: `startup_time`, `cold_phase_seconds`, `cold_warm_phase`). Tool execution path, OTel span emission, and histogram observation primitive untouched.

## Test plan

- [x] `dune build lib/` green (lib-only compile, full lib).
- [ ] Local smoke: bring server up, invoke a tool within first 60s → confirm `masc_tool_call_duration_seconds{...,phase="cold"}` row in `/metrics`. Wait > 60s → next call lands in `phase="warm"`.
- [ ] Dashboard query updated separately (out of PR-0.2.C scope per IMPLEMENTATION-PLAN.md).

## Notes

- Cold threshold is a module-level constant (`cold_phase_seconds = 60.0`); not exposed as env. If we need to tune later, follow `feedback_no-hyperparameter-as-env-knob` and either keep as code constant or introduce a single boolean kill switch.
- `dune fmt` was intentionally NOT run globally — running it would touch ~2200 unrelated files (project not currently fmt-clean, see existing main format). My additions match the existing local style of both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)