### PR TITLE
feat(keeper): Tier K1 — Multimodal post-turn wire-in (Cycle 27)

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -205,6 +205,85 @@ let apply_resilience_wirein
             lifecycle.updated_meta.name (Printexc.to_string exn);
           lifecycle)
 
+(* ── Tier K1: multimodal post-turn wire-in (Cycle 27) ─────────────
+   Feature-flag-gated wire-in that runs after the A5/A6 pair. Reads
+   raw multimodal artifacts the keeper agent dropped into
+   [working_context["multimodal_artifacts"]], hydrates them via
+   [Multimodal_keeper_bridge.hydrate_one], and accumulates them into
+   the process-wide [Multimodal.Workspace_holder].
+
+   When [MASC_MULTIMODAL] is off (default), the wire-in is a pure
+   pass-through. When on, it consumes the artifact bag and replaces
+   it with a [workspace_meta] summary so the next turn does not
+   re-process the same entries.
+
+   Failures inside the wire-in do not propagate — they are logged
+   and the unmodified lifecycle result is returned, preserving the
+   keeper's primary turn outcome. *)
+
+let apply_multimodal_wirein
+    ~(now : float)
+    (lifecycle : post_turn_lifecycle) : post_turn_lifecycle =
+  if not (Multimodal.Wirein_helpers.masc_multimodal_enabled ()) then
+    lifecycle
+  else
+    match lifecycle.checkpoint with
+    | None -> lifecycle
+    | Some cp -> (
+        try
+          let raws, wc_rest =
+            Multimodal.Wirein_helpers.extract_raw_artifacts
+              cp.Oas.Checkpoint.working_context
+          in
+          let added_count = ref 0 in
+          let last_id = ref None in
+          Multimodal.Workspace_holder.update (fun ws ->
+              let ws', added =
+                Multimodal.Multimodal_keeper_bridge
+                .hydrate_with_workspace ws raws
+                  ~now
+                  ~created_by:lifecycle.updated_meta.name
+              in
+              added_count := List.length added;
+              (match List.rev added with
+               | [] -> ()
+               | last :: _ ->
+                   last_id :=
+                     Some
+                       (Shared_types.Artifact_id.to_string
+                          (Multimodal.Artifact.any_id last)));
+              ws')
+          ;
+          let workspace_size =
+            Multimodal.Workspace.size
+              (Multimodal.Workspace_holder.get ())
+          in
+          let meta =
+            `Assoc
+              [
+                ("added_this_turn", `Int !added_count);
+                ("workspace_size", `Int workspace_size);
+                ( "last_artifact_id",
+                  match !last_id with
+                  | Some s -> `String s
+                  | None -> `Null );
+                ("at", `Float now);
+              ]
+          in
+          let new_wc =
+            Multimodal.Wirein_helpers.upsert_workspace_meta wc_rest
+              meta
+          in
+          let new_cp =
+            { cp with Oas.Checkpoint.working_context = new_wc }
+          in
+          { lifecycle with checkpoint = Some new_cp }
+        with exn ->
+          Log.Keeper.warn
+            "keeper:%s multimodal wire-in failed: %s"
+            lifecycle.updated_meta.name (Printexc.to_string exn);
+          lifecycle)
+
 let apply_post_turn_lifecycle
     ~(on_compaction_started : unit -> unit)
     ~(on_handoff_started : unit -> unit)
@@ -458,10 +537,14 @@ let apply_post_turn_lifecycle
         message_count = rollover.message_count;
       }
   in
-  (* Strict ordering: autonomous tick → resilience classification.
-     Do not reorder — A6 PR pinned this sequence. *)
+  (* Strict ordering: autonomous tick → resilience classification
+     → multimodal hydration. Do not reorder — A6/K1 pinned this
+     sequence. The multimodal pass runs last because it persists a
+     [workspace_meta] summary that depends on whether prior passes
+     have already mutated [working_context]. *)
   let body = apply_autonomous_wirein ~now:now_ts body in
-  apply_resilience_wirein ~now:now_ts body
+  let body = apply_resilience_wirein ~now:now_ts body in
+  apply_multimodal_wirein ~now:now_ts body
 
 let forced_overflow_retry_meta
     (meta : keeper_meta)

--- a/lib/multimodal/wirein_helpers.ml
+++ b/lib/multimodal/wirein_helpers.ml
@@ -1,0 +1,81 @@
+(* Wirein_helpers — see wirein_helpers.mli for design rationale. *)
+
+let masc_multimodal_enabled () =
+  match Sys.getenv_opt "MASC_MULTIMODAL" with
+  | Some ("1" | "true" | "yes" | "on") -> true
+  | _ -> false
+
+let multimodal_key = "multimodal_artifacts"
+
+let parse_raw_artifact (json : Yojson.Safe.t)
+    : Multimodal_keeper_bridge.raw_artifact option =
+  match json with
+  | `Assoc kv ->
+      let lookup k =
+        try Some (List.assoc k kv) with Not_found -> None
+      in
+      let id =
+        match lookup "id" with Some (`String s) -> Some s | _ -> None
+      in
+      let kind_hint =
+        match lookup "kind_hint" with
+        | Some (`String s) -> Some s
+        | _ -> None
+      in
+      let payload_json =
+        match lookup "payload_json" with
+        | Some j -> j
+        | None -> `Null
+      in
+      let metadata =
+        match lookup "metadata" with
+        | Some j -> j
+        | None -> `Null
+      in
+      (match (id, kind_hint) with
+       | Some id, Some kind_hint ->
+           Some
+             {
+               Multimodal_keeper_bridge.id;
+               kind_hint;
+               payload_json;
+               metadata;
+             }
+       | _ -> None)
+  | _ -> None
+
+let extract_raw_artifacts
+    (working_context : Yojson.Safe.t option)
+    : Multimodal_keeper_bridge.raw_artifact list * Yojson.Safe.t option =
+  match working_context with
+  | Some (`Assoc kv) ->
+      let raws_json, kv_rest =
+        List.partition (fun (k, _) -> k = multimodal_key) kv
+      in
+      let raws =
+        match raws_json with
+        | [ (_, `List entries) ] ->
+            List.filter_map parse_raw_artifact entries
+        | _ -> []
+      in
+      let next_wc =
+        if raws_json = [] then working_context
+        else Some (`Assoc kv_rest)
+      in
+      (raws, next_wc)
+  | _ -> ([], working_context)
+
+let upsert_workspace_meta
+    (working_context : Yojson.Safe.t option)
+    (workspace_meta : Yojson.Safe.t) : Yojson.Safe.t option =
+  let updated_kv =
+    match working_context with
+    | None -> [ ("workspace_meta", workspace_meta) ]
+    | Some (`Assoc kv) ->
+        let kv_without =
+          List.filter (fun (k, _) -> k <> "workspace_meta") kv
+        in
+        ("workspace_meta", workspace_meta) :: kv_without
+    | Some _ -> [ ("workspace_meta", workspace_meta) ]
+  in
+  Some (`Assoc updated_kv)

--- a/lib/multimodal/wirein_helpers.mli
+++ b/lib/multimodal/wirein_helpers.mli
@@ -1,0 +1,66 @@
+(** Wirein_helpers — pure helpers for the Tier K1 keeper post-turn
+    multimodal wire-in.
+
+    Cycle 27 / Tier K1.
+
+    {1 What this module does}
+
+    Provides three functions used by [Keeper_post_turn]:
+
+    - {!masc_multimodal_enabled} — env flag gate.
+    - {!extract_raw_artifacts} — pull raw artifact JSON from a
+      [working_context] bag.
+    - {!upsert_workspace_meta} — record a workspace summary into
+      the OAS Checkpoint working_context.
+
+    The wire-in body lives directly inside [Keeper_post_turn] (see
+    [apply_multimodal_wirein] there) so we mirror the A5/A6 layout.
+    These helpers are pure and unit-testable without dragging the
+    full [masc_mcp] library into the test closure.
+
+    {1 Convention for raw artifact extraction}
+
+    The keeper agent loop signals "I produced an artifact this
+    turn" by appending a JSON object to a [`List] under the
+    ["multimodal_artifacts"] key of [working_context]. Each entry
+    has the same shape as
+    {!Multimodal_keeper_bridge.raw_artifact}:
+
+    {[
+      {
+        "id": "<uuid v7 string>",
+        "kind_hint": "code" | "image" | "audio" | "doc",
+        "payload_json": <opaque>,
+        "metadata": <opaque>
+      }
+    ]}
+
+    The wire-in consumes (and removes) these entries each turn so
+    they are not double-counted. *)
+
+val masc_multimodal_enabled : unit -> bool
+(** [true] iff [MASC_MULTIMODAL] is set to one of ["1"], ["true"],
+    ["yes"], or ["on"]. Default ([false]) keeps the wire-in inert. *)
+
+val extract_raw_artifacts :
+  Yojson.Safe.t option ->
+  Multimodal_keeper_bridge.raw_artifact list * Yojson.Safe.t option
+(** [extract_raw_artifacts wc] returns
+    [(raws, wc_without_multimodal_key)]:
+
+    - [raws] = parsed [raw_artifact] values from
+      [wc.multimodal_artifacts]. Malformed entries are silently
+      skipped; the function never raises.
+    - [wc_without_multimodal_key] = the same working_context with
+      the consumed key dropped (so the next turn does not
+      re-process them).
+
+    [wc = None] or non-[`Assoc] payload → [([], wc)]. *)
+
+val upsert_workspace_meta :
+  Yojson.Safe.t option -> Yojson.Safe.t -> Yojson.Safe.t option
+(** [upsert_workspace_meta wc meta] stores [meta] under the
+    ["workspace_meta"] key of an [`Assoc] working_context. Same
+    semantics as
+    {!Autonomous.Wirein_helpers.upsert_autonomous_meta} for the
+    autonomous_meta key. *)

--- a/lib/multimodal/workspace_holder.ml
+++ b/lib/multimodal/workspace_holder.ml
@@ -1,0 +1,29 @@
+(* Workspace_holder — see workspace_holder.mli for design. *)
+
+let mutex = Mutex.create ()
+
+let workspace_ref = ref Workspace.empty
+
+let get () =
+  Mutex.lock mutex;
+  let snap = !workspace_ref in
+  Mutex.unlock mutex;
+  snap
+
+let replace ws =
+  Mutex.lock mutex;
+  workspace_ref := ws;
+  Mutex.unlock mutex
+
+let update f =
+  Mutex.lock mutex;
+  let next =
+    try f !workspace_ref
+    with exn ->
+      Mutex.unlock mutex;
+      raise exn
+  in
+  workspace_ref := next;
+  Mutex.unlock mutex
+
+let reset () = replace Workspace.empty

--- a/lib/multimodal/workspace_holder.mli
+++ b/lib/multimodal/workspace_holder.mli
@@ -1,0 +1,50 @@
+(** Workspace_holder — long-lived [Workspace.t] reference shared
+    across keeper turn life-cycles and the dashboard HTTP surface.
+
+    Cycle 27 / Tier K1.
+
+    {1 What this module is}
+
+    A process-wide store for the live [Workspace.t]. The keeper
+    post-turn wire-in updates it via {!update}; the dashboard
+    HTTP route (D1) reads it via {!get} through a callback bound
+    in {!Server_routes_http_routes_multimodal.bind_workspace_getter}.
+
+    {1 Why a separate module}
+
+    Three callers need one consistent [Workspace.t] view:
+    - {!Wirein_helpers.apply_multimodal_wirein} (keeper turn tail)
+    - {!Server_routes_http_routes_multimodal.list_response} (HTTP read)
+    - integration tests that exercise both halves
+
+    Threading the workspace through every callsite is intrusive
+    and breaks RFC-0002 (the keeper FSM cannot grow new fields).
+    A module-level ref guarded by a mutex is the smallest seam
+    that satisfies all three.
+
+    {1 Concurrency}
+
+    The ref is protected by an internal {!Stdlib.Mutex} (not
+    {!Eio.Mutex}) so that updates from any context — pre-Eio
+    init, an Eio fiber, a unit-test main thread — work uniformly.
+    Reads ({!get}) snapshot the workspace under the lock and
+    return the immutable value; updates ({!update}) compose a
+    function under the lock. There is no recursion or blocking
+    I/O inside the critical section, so the mutex never becomes
+    a contention hotspot. *)
+
+val get : unit -> Workspace.t
+(** Snapshot the current workspace value. *)
+
+val update : (Workspace.t -> Workspace.t) -> unit
+(** [update f] atomically replaces the held workspace with
+    [f current]. The function should be pure — exceptions thrown
+    inside [f] propagate and the workspace is left unchanged. *)
+
+val replace : Workspace.t -> unit
+(** Replace the held workspace value entirely. Primarily for
+    test setup; production code should prefer {!update}. *)
+
+val reset : unit -> unit
+(** Reset to {!Workspace.empty}. Test helper; equivalent to
+    [replace Workspace.empty]. *)

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -10,6 +10,12 @@ let make_routes ~port ~host ~sw ~clock =
   (* Register connectors before routes are wired up *)
   Channel_gate_connector.register (module Channel_gate_discord_state);
   Channel_gate_connector.register (module Channel_gate_imessage_state);
+  (* Tier K1: bind the multimodal workspace getter so the dashboard
+     reads the live keeper-side workspace instead of [Workspace.empty].
+     Idempotent — calling [bind_workspace_getter] twice just replaces
+     the callback. *)
+  Server_routes_http_routes_multimodal.bind_workspace_getter
+    Multimodal.Workspace_holder.get;
   Http.Router.empty
   |> Server_routes_http_routes_frontend.add_routes ~port ~host
   |> Server_routes_http_routes_room.add_routes

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id test_multimodal_keeper_bridge)
- (libraries multimodal shared_types yojson str))
+ (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id test_multimodal_keeper_bridge test_workspace_holder test_wirein_helpers)
+ (libraries multimodal shared_types yojson str unix))

--- a/test/multimodal/test_wirein_helpers.ml
+++ b/test/multimodal/test_wirein_helpers.ml
@@ -1,0 +1,139 @@
+(* Tier K1 — Multimodal.Wirein_helpers unit tests. *)
+
+module H = Multimodal.Wirein_helpers
+module B = Multimodal.Multimodal_keeper_bridge
+
+let test_disabled_by_default () =
+  Unix.putenv "MASC_MULTIMODAL" "";
+  assert (not (H.masc_multimodal_enabled ()));
+  print_endline "  disabled_by_default: OK"
+
+let test_enabled_with_flag () =
+  Unix.putenv "MASC_MULTIMODAL" "1";
+  assert (H.masc_multimodal_enabled ());
+  Unix.putenv "MASC_MULTIMODAL" "true";
+  assert (H.masc_multimodal_enabled ());
+  Unix.putenv "MASC_MULTIMODAL" "yes";
+  assert (H.masc_multimodal_enabled ());
+  Unix.putenv "MASC_MULTIMODAL" "on";
+  assert (H.masc_multimodal_enabled ());
+  Unix.putenv "MASC_MULTIMODAL" "";
+  print_endline "  enabled_with_flag: OK"
+
+let test_extract_none () =
+  let raws, wc = H.extract_raw_artifacts None in
+  assert (raws = []);
+  assert (wc = None);
+  print_endline "  extract_none: OK"
+
+let test_extract_no_key () =
+  let wc = Some (`Assoc [ ("other_key", `String "value") ]) in
+  let raws, wc' = H.extract_raw_artifacts wc in
+  assert (raws = []);
+  assert (wc = wc');
+  print_endline "  extract_no_key: OK"
+
+let test_extract_well_formed () =
+  let wc =
+    Some
+      (`Assoc
+        [
+          ( "multimodal_artifacts",
+            `List
+              [
+                `Assoc
+                  [
+                    ( "id",
+                      `String "01900000-0000-7000-8000-000000000010" );
+                    ("kind_hint", `String "code");
+                    ("payload_json", `String "println");
+                    ("metadata", `Null);
+                  ];
+                `Assoc
+                  [
+                    ( "id",
+                      `String "01900000-0000-7000-8000-000000000011" );
+                    ("kind_hint", `String "image");
+                    ("payload_json", `Null);
+                    ("metadata", `Null);
+                  ];
+              ] );
+          ("other_key", `String "preserved");
+        ])
+  in
+  let raws, wc' = H.extract_raw_artifacts wc in
+  assert (List.length raws = 2);
+  let first = List.nth raws 0 in
+  assert (first.B.kind_hint = "code");
+  (match wc' with
+   | Some (`Assoc kv) ->
+       assert (List.assoc_opt "multimodal_artifacts" kv = None);
+       assert (List.assoc_opt "other_key" kv = Some (`String "preserved"))
+   | _ -> assert false);
+  print_endline "  extract_well_formed: OK"
+
+let test_extract_skips_malformed () =
+  let wc =
+    Some
+      (`Assoc
+        [
+          ( "multimodal_artifacts",
+            `List
+              [
+                `Assoc
+                  [
+                    ("id", `String "01900000-0000-7000-8000-000000000020");
+                    ("kind_hint", `String "doc");
+                    ("payload_json", `Null);
+                    ("metadata", `Null);
+                  ];
+                `Assoc [ ("kind_hint", `String "image") ]
+                (* missing id *);
+                `String "not an object";
+              ] );
+        ])
+  in
+  let raws, _ = H.extract_raw_artifacts wc in
+  assert (List.length raws = 1);
+  print_endline "  extract_skips_malformed: OK"
+
+let test_upsert_workspace_meta_none () =
+  let meta = `Assoc [ ("workspace_size", `Int 3) ] in
+  let wc = H.upsert_workspace_meta None meta in
+  (match wc with
+   | Some (`Assoc kv) ->
+       assert (List.assoc_opt "workspace_meta" kv = Some meta)
+   | _ -> assert false);
+  print_endline "  upsert_meta_none_input: OK"
+
+let test_upsert_workspace_meta_replaces () =
+  let prev =
+    Some
+      (`Assoc
+        [
+          ("workspace_meta", `Assoc [ ("workspace_size", `Int 0) ]);
+          ("autonomous_meta", `Assoc [ ("phase", `String "idle") ]);
+        ])
+  in
+  let new_meta = `Assoc [ ("workspace_size", `Int 5) ] in
+  let wc = H.upsert_workspace_meta prev new_meta in
+  (match wc with
+   | Some (`Assoc kv) ->
+       assert (List.assoc_opt "workspace_meta" kv = Some new_meta);
+       assert (
+         List.assoc_opt "autonomous_meta" kv
+         = Some (`Assoc [ ("phase", `String "idle") ]))
+   | _ -> assert false);
+  print_endline "  upsert_meta_replaces_preserves_other_keys: OK"
+
+let () =
+  print_endline "=== Wirein_helpers ===";
+  test_disabled_by_default ();
+  test_enabled_with_flag ();
+  test_extract_none ();
+  test_extract_no_key ();
+  test_extract_well_formed ();
+  test_extract_skips_malformed ();
+  test_upsert_workspace_meta_none ();
+  test_upsert_workspace_meta_replaces ();
+  print_endline "=== Wirein_helpers: 8/8 OK ==="

--- a/test/multimodal/test_workspace_holder.ml
+++ b/test/multimodal/test_workspace_holder.ml
@@ -1,0 +1,99 @@
+(* Tier K1 — Multimodal.Workspace_holder unit tests. *)
+
+module H = Multimodal.Workspace_holder
+module W = Multimodal.Workspace
+module A = Multimodal.Artifact
+
+let make_artifact ~id_str ~kind ~now : A.any =
+  match Shared_types.Artifact_id.of_string id_str with
+  | Ok id ->
+      let provenance =
+        {
+          Multimodal.Provenance_stub.origin_artifact_ids = [];
+          created_by = "test";
+          created_at = now;
+        }
+      in
+      let artifact =
+        {
+          A.id;
+          kind;
+          payload = Multimodal.Payload.Lazy_payload (fun () -> "");
+          metadata = `Null;
+          provenance;
+        }
+      in
+      A.Any artifact
+  | Error msg ->
+      failwith ("test fixture id parse failed: " ^ msg)
+
+let test_initial_empty () =
+  H.reset ();
+  let ws = H.get () in
+  assert (W.size ws = 0);
+  print_endline "  initial_empty: OK"
+
+let test_replace () =
+  H.reset ();
+  let ws = W.empty in
+  let a =
+    make_artifact
+      ~id_str:"01900000-0000-7000-8000-000000000001"
+      ~kind:A.Code ~now:1.0
+  in
+  let ws = W.add ws a in
+  H.replace ws;
+  let snap = H.get () in
+  assert (W.size snap = 1);
+  print_endline "  replace: OK"
+
+let test_update_atomic () =
+  H.reset ();
+  let a =
+    make_artifact
+      ~id_str:"01900000-0000-7000-8000-000000000002"
+      ~kind:A.Image ~now:2.0
+  in
+  H.update (fun ws -> W.add ws a);
+  let snap = H.get () in
+  assert (W.size snap = 1);
+  print_endline "  update_atomic: OK"
+
+let test_update_propagates_exception () =
+  H.reset ();
+  let a =
+    make_artifact
+      ~id_str:"01900000-0000-7000-8000-000000000003"
+      ~kind:A.Doc ~now:3.0
+  in
+  H.update (fun ws -> W.add ws a);
+  let raised = ref false in
+  (try
+     H.update (fun _ -> failwith "boom")
+   with Failure _ -> raised := true);
+  assert !raised;
+  let snap = H.get () in
+  assert (W.size snap = 1);
+  print_endline "  update_exception_keeps_state: OK"
+
+let test_reset () =
+  H.reset ();
+  let a =
+    make_artifact
+      ~id_str:"01900000-0000-7000-8000-000000000004"
+      ~kind:A.Audio ~now:4.0
+  in
+  H.update (fun ws -> W.add ws a);
+  assert (W.size (H.get ()) = 1);
+  H.reset ();
+  assert (W.size (H.get ()) = 0);
+  print_endline "  reset: OK"
+
+let () =
+  print_endline "=== Workspace_holder ===";
+  test_initial_empty ();
+  test_replace ();
+  test_update_atomic ();
+  test_update_propagates_exception ();
+  test_reset ();
+  print_endline "=== Workspace_holder: 5/5 OK ==="


### PR DESCRIPTION
Cycle 27 / Tier K1. Bridges the keeper turn lifecycle to the live multimodal workspace exposed at `/api/v1/multimodal/*` (D1).

## What lands

Three new files + two existing files updated:

| File | Role |
|------|------|
| `lib/multimodal/workspace_holder.{mli,ml}` (NEW) | Process-wide `Workspace.t` ref guarded by `Stdlib.Mutex`. Get/replace/update/reset. |
| `lib/multimodal/wirein_helpers.{mli,ml}` (NEW) | Pure: `MASC_MULTIMODAL` env flag, `extract_raw_artifacts` (skips malformed silently), `upsert_workspace_meta`. |
| `lib/keeper/keeper_post_turn.ml` | New `apply_multimodal_wirein` runs **after** A5 + A6 in `apply_post_turn_lifecycle`. Off by default. |
| `lib/server/server_routes_http.ml` | `make_routes` now calls `bind_workspace_getter Workspace_holder.get`. |
| `test/multimodal/{test_workspace_holder,test_wirein_helpers}.ml` (NEW, 13 assertions) | Coverage for new modules. |

## Wire-in ordering (pinned)

```
apply_post_turn_lifecycle:
  body
  |> apply_autonomous_wirein   (A5)
  |> apply_resilience_wirein   (A6)
  |> apply_multimodal_wirein   (K1) ← new, runs last
```

K1 must run after A6 because it persists `workspace_meta` derived from the post-A6 `working_context` and consumes the `multimodal_artifacts` key from it.

## Convention for raw artifact production

The keeper agent loop drops a JSON list under `working_context["multimodal_artifacts"]`:

```json
{
  "id": "<uuid v7 string>",
  "kind_hint": "code|image|audio|doc",
  "payload_json": <opaque>,
  "metadata": <opaque>
}
```

The wire-in consumes (and removes) these entries each turn so the next turn does not double-count. Real candidate-detection (turn output → raw_artifact production) is left to the keeper-agent prompt layer; this PR ships the seam.

## Failure isolation

All wire-in exceptions are caught and logged. The unmodified lifecycle result is returned, preserving the keeper's primary turn outcome — same pattern as A5/A6.

## Verification

- `dune build --root .` — GREEN
- `dune runtest --root . test/multimodal/` — 13 new assertions GREEN, 8 existing suites GREEN (0 regressions)
- File-disjoint with all open PRs (race check returned `[]`)

## Plan reference

§16 K1 — keeper integration follow-up to **W1+W2+W3+D1** (all merged in the previous batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
