### PR TITLE
fix(spawn): remove --yolo flag from gemini keeper invocation

### DIFF
--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -178,7 +178,7 @@ let spawn_config_of_key key =
   | "gemini" ->
       Some {
         agent_name = "gemini";
-        command = "gemini --yolo --output-format json";
+        command = "gemini --output-format json";
         timeout_seconds;
         working_dir = None;
         mcp_tools = masc_mcp_tools;


### PR DESCRIPTION
## Problem
The Gemini keeper was launched with `--yolo`, which auto-approves all tool calls and bypasses the policy gate entirely.

## Fix
Remove `--yolo` from the Gemini CLI command in `spawn_config_of_key` so policy rules in `~/.gemini/policies/auto-saved.toml` are actually enforced.

## Verification
- `rg --yolo lib/spawn.ml` returns no matches.
- Local `dune build lib/spawn.ml` succeeds.