### PR TITLE
feat(perf): WS message_bytes histogram (PR-0.2.B)

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -529,6 +529,7 @@ let metric_ws_slice_fanout_skipped = "masc_ws_slice_fanout_skipped_total"
 let metric_ws_bytes_sent = "masc_ws_bytes_sent_total"
 let metric_grpc_bytes_sent = "masc_grpc_bytes_sent_total"
 let metric_ws_delta_built = "masc_ws_delta_built_total"
+let metric_ws_message_bytes = "masc_ws_message_bytes"
 (* Backlog-replay attribution: every gRPC Subscribe RPC reads
    [.masc/backlog.jsonl] from disk before the live broadcast hook
    takes over.  These two counters separate replay cost from live
@@ -1230,6 +1231,16 @@ let init () =
      allocation + jsonrpc_notification wrap per delta). Divide by \
      broadcast count to estimate fanout amplification."
     Counter;
+  register_histogram ~name:metric_ws_message_bytes
+    ~help:"WebSocket message payload size in bytes (per-frame, wire \
+           boundary). Labelled by direction so send vs recv \
+           distributions can be compared independently."
+    ~labels:[("direction", "send")] ();
+  register_histogram ~name:metric_ws_message_bytes
+    ~help:"WebSocket message payload size in bytes (per-frame, wire \
+           boundary). Labelled by direction so send vs recv \
+           distributions can be compared independently."
+    ~labels:[("direction", "recv")] ();
   add metric_grpc_backlog_replay_lines_scanned
     "Lines walked while replaying .masc/backlog.jsonl on a gRPC \
      Subscribe RPC (every line, including those filtered by \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -464,6 +464,13 @@ val metric_ws_bytes_sent : string
 val metric_grpc_bytes_sent : string
 val metric_ws_delta_built : string
 
+val metric_ws_message_bytes : string
+(** Histogram of WebSocket message payload size in bytes, observed at
+    the wire boundary. Labels: [direction = send | recv]. Complements
+    the [masc_ws_bytes_sent_total] counter by exposing per-message
+    distribution (p50/p95/p99) so operators can distinguish a few
+    large frames from many small frames. *)
+
 val metric_grpc_backlog_replay_lines_scanned : string
 (** Lines walked while replaying [.masc/backlog.jsonl] on a gRPC
     Subscribe RPC, including those filtered out by [since_seq]. *)

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -157,6 +157,7 @@ let send_frame_bytes session bytes ~len =
       Httpun_ws.Wsd.send_bytes session.wsd
         ~kind:`Text bytes ~off:0 ~len;
       Transport_metrics.inc_ws_bytes_sent ~bytes:len;
+      Transport_metrics.observe_ws_message_bytes_sent len;
       true
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -760,6 +761,7 @@ let handle_inbound_text session ~on_message ~is_fin text =
       end
 
 let read_inbound_message_frame session ~on_message ~is_fin ~len payload =
+  Transport_metrics.observe_ws_message_bytes_recv len;
   read_payload_string payload ~len ~on_complete:(fun text ->
       handle_inbound_text session ~on_message ~is_fin text)
 

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -129,6 +129,16 @@ let inc_ws_bytes_sent ~bytes =
     Prometheus.inc_counter Prometheus.metric_ws_bytes_sent
       ~delta:(float_of_int bytes) ()
 
+let observe_ws_message_bytes_sent n =
+  let bytes = float_of_int (max 0 n) in
+  Prometheus.observe_histogram Prometheus.metric_ws_message_bytes
+    ~labels:[("direction", "send")] bytes
+
+let observe_ws_message_bytes_recv n =
+  let bytes = float_of_int (max 0 n) in
+  Prometheus.observe_histogram Prometheus.metric_ws_message_bytes
+    ~labels:[("direction", "recv")] bytes
+
 let inc_grpc_bytes_sent ~bytes =
   if bytes > 0 then
     Prometheus.inc_counter Prometheus.metric_grpc_bytes_sent

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -156,6 +156,18 @@ val inc_ws_bytes_sent : bytes:int -> unit
     [masc_ws_bytes_sent_total] by [bytes].  No-op when
     [bytes <= 0]. *)
 
+val observe_ws_message_bytes_sent : int -> unit
+(** [observe_ws_message_bytes_sent n] records [n] (clamped to
+    [max 0 n]) into [masc_ws_message_bytes{direction="send"}].
+    Paired with {!inc_ws_bytes_sent}: counter for total volume,
+    histogram for per-message distribution. *)
+
+val observe_ws_message_bytes_recv : int -> unit
+(** [observe_ws_message_bytes_recv n] records [n] (clamped to
+    [max 0 n]) into [masc_ws_message_bytes{direction="recv"}].
+    Observed at the inbound frame boundary before message
+    re-assembly. *)
+
 val inc_ws_delta_built : unit -> unit
 (** Increments [masc_ws_delta_built]. *)
 


### PR DESCRIPTION
## Summary

RFC pack `knowledge/research/2026-04-masc-ide-strategy/IMPLEMENTATION-PLAN.md` Phase 0 sub-PR. Adds `masc_ws_message_bytes` histogram with `direction=send|recv` labels, observed at the WebSocket wire boundary. Complements the existing `masc_ws_bytes_sent_total` counter by exposing per-message distribution (p50/p95/p99) so operators can distinguish a few large frames from many small frames.

## Changes

- `lib/prometheus.ml` + `.mli`: new constant `metric_ws_message_bytes = "masc_ws_message_bytes"`. Init pre-registers two histogram rows (`direction=send`, `direction=recv`) so `/metrics` shows zero baselines before first observation, mirroring the pattern used for `metric_sse_broadcast_duration` and `metric_ws_client_buffered_bytes`.
- `lib/transport_metrics.ml` + `.mli`: two helpers `observe_ws_message_bytes_sent` / `observe_ws_message_bytes_recv` that clamp to `max 0 n` and dispatch through `Prometheus.observe_histogram`.
- `lib/server/server_mcp_transport_ws.ml`: 2 call sites
  - `send_frame_bytes` — directly after the existing `inc_ws_bytes_sent ~bytes:len` line. Counter and histogram observe the same `len` so per-message distribution and total volume stay aligned.
  - `read_inbound_message_frame` — at frame entry, observing `~len` (frame payload length) before re-assembly into a full message.

## Logic surface

Zero logic change. Only metric instrumentation added. Send/recv hot paths unchanged: existing `Httpun_ws.Wsd.send_bytes` send and `read_payload_string` recv pipelines untouched apart from the inserted observer call.

## RTT — intentionally omitted

The instrumentation brief allowed adding `masc_ws_rtt_seconds` only if a clear ping/pong (or send→ack) timestamp pattern was already wired. The WS frame handler in `server_mcp_transport_ws.ml` only does `Httpun_ws.Wsd.send_pong wsd` on `\`Ping`, with no timestamp tracking; JSON-RPC request-response correlation is also not centralised in the WS layer. Adding RTT would require either ping send-time tracking or JSON-RPC ID matching — both are logic changes outside the PR-0.2.B "logic 변경 0 + metric 추가만" boundary. RTT can be a follow-up if a ping/pong timestamp pattern is introduced.

## Test plan

- [x] `dune build lib/` green (clean rebuild, full lib).
- [x] Race-check (`gh pr list --search`): 0 conflicting PRs at push time. PR-0.2.A (#11953-equivalent), PR-0.2.C (#12012), PR-0.2.E (#12010), PR-0.2.F (#12009) cover disjoint metric surfaces.
- [x] Rebased on `origin/main` (e40e1905f5).
- [ ] Local smoke: bring server up, open a WS session and send/receive a few frames, confirm `masc_ws_message_bytes_*{direction="send"}` and `{direction="recv"}` rows appear in `/metrics` with non-zero `_count`.
- [ ] Histogram bucketing sanity: confirm small (< 256 B) and large (> 64 KiB) WS broadcasts both land in distinct buckets.

## Notes

- `dune fmt` was intentionally NOT run globally — running it would touch ~2200 unrelated files (matches PR-0.2.C convention). My additions match the existing local style of `prometheus.ml`, `transport_metrics.ml`, and `server_mcp_transport_ws.ml`.
- Histogram pre-registration (one row per direction) mirrors the existing convention so dashboards see zero baselines instead of "missing series" right after a server restart.
- Help text identical between the two registrations because the help string is per-name in Prometheus exposition; only the labels differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)