### PR TITLE
env_config_core.mli: pin MASC env-config prelude (84 entries, cycle 233)

### DIFF
--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -1,0 +1,176 @@
+(** Env_config_core — MASC environment configuration prelude.
+
+    All env vars use the [MASC_*] prefix. Functions ending in
+    [_result] return [(string, string) result] for structured error
+    handling; convenience variants without the suffix raise
+    {!Config_error} on missing/invalid values.
+
+    {b Cascade chain}: surface re-exposed via
+    [include module type of Env_config_core] in
+    {!Env_config}, which sibling sub-modules
+    ({!Env_config_runtime}, {!Env_config_governance},
+    {!Env_config_keeper}) extend.  Sibling sub-modules also reach
+    the helper getters here ([get_int], [get_float], [get_bool],
+    [trim_opt], [raw_value_opt]) unqualified through the prelude
+    pattern, so this boundary's surface flows through to every
+    config consumer. *)
+
+(** {1 Exception} *)
+
+exception Config_error of string
+(** Raised by convenience functions ([sb_path],
+    [masc_http_base_url]) when a required environment variable is
+    missing.  Prefer the [_result] variants for structured error
+    handling. *)
+
+(** {1 Raw env-var access} *)
+
+val raw_value_opt : string -> string option
+(** Read [name] via {!Sys.getenv_opt}, falling back to
+    {!Config_boot_overrides} when the parent process did not export
+    the variable.  Returns [None] when neither source has it. *)
+
+(** {1 Typed getters with defaults} *)
+
+val get_string : default:string -> string -> string
+val get_int : default:int -> string -> int
+val get_float : default:float -> string -> float
+val get_bool : default:bool -> string -> bool
+
+(** {1 String / path helpers} *)
+
+val trim_opt : string option -> string option
+(** [Some s] with whitespace trimmed; [None] when [s] is empty
+    after trim or already [None]. *)
+
+val strip_trailing_slashes : string -> string
+val strip_path_trailing_slashes : string -> string
+val expand_home_prefix : string -> string
+val normalize_path_lexically : string -> string
+val normalize_masc_base_path_input : string -> string
+val existing_dir : string -> bool
+val existing_file : string -> bool
+val home_dir_opt : unit -> string option
+
+(** {1 Deprecation warnings + fallback getters} *)
+
+val deprecation_warned : (string, bool) Hashtbl.t
+(** Internal once-per-key cache for {!warn_deprecated}.  Exposed
+    only because the cascade chain re-exports the prelude verbatim. *)
+
+val warn_deprecated : old_name:string -> new_name:string -> unit
+
+val deprecated_opt :
+  old_name:string -> new_name:string -> string option
+
+val resolve_deprecated :
+  primary:string -> deprecated:string -> string option
+
+val get_float_deprecated :
+  default:float -> primary:string -> deprecated:string -> float
+
+val get_int_deprecated :
+  default:int -> primary:string -> deprecated:string -> int
+
+val get_bool_deprecated :
+  default:bool -> primary:string -> deprecated:string -> bool
+
+(** {1 HTTP host + port (SSOT for issue 8352)} *)
+
+val default_http_port : string
+val default_http_port_int : int
+val host_env_key : string
+val http_port_env_key : string
+val masc_http_port : unit -> string
+val masc_http_port_int : unit -> int
+val masc_host_opt : unit -> string option
+val default_host : string
+val masc_host : unit -> string
+
+(** {1 Assets / cluster name} *)
+
+val assets_dir_opt : unit -> string option
+val cluster_name_opt : unit -> string option
+val cluster_name : unit -> string
+
+(** {1 HTTP base URL} *)
+
+val http_base_url_env_key : string
+val mcp_url_env_key : string
+val masc_http_base_url : unit -> string
+val masc_http_base_url_result : unit -> (string, string) result
+
+(** {1 Port helper} *)
+
+val get_port : default:int -> string -> int
+(** Read a TCP port from [name], validated to [\[1, 65535\]].
+    Returns [default] on missing, empty, out-of-range, or
+    non-integer values. *)
+
+(** {1 Base path / storage} *)
+
+val base_path_env_key : string
+val base_path_input_env_key : string
+val base_path_source_opt : unit -> (string * string) option
+val base_path_raw_opt : unit -> string option
+val base_path_opt : unit -> string option
+val running_under_test_executable : unit -> bool
+val test_allow_home_base_path_env : string
+val base_path_prod_guard : string -> string
+val base_path : unit -> string
+val sb_path_opt : unit -> string option
+val sb_path_result : unit -> (string, string) result
+val sb_path : unit -> string
+val storage_type_env_key : string
+val orchestrator_enabled_env_key : string
+val storage_type : unit -> string
+
+(** {1 Config / personas / data dir} *)
+
+val config_dir_env_key : string
+val personas_dir_env_key : string
+val config_dir_opt : unit -> string option
+val personas_dir_opt : unit -> string option
+val data_dir_env_key : string
+val data_dir_opt : unit -> string option
+
+(** {1 Relay calibration} *)
+
+val relay_calibration_enabled : unit -> bool
+
+(** {1 Auth} *)
+
+val admin_token_env_key : string
+val tool_auth_strict_env_key : string
+val admin_token_opt : unit -> string option
+val tool_auth_strict : unit -> bool
+
+(** {1 Git} *)
+
+val git_fetch_timeout_sec_env_key : string
+val git_fetch_timeout_sec : unit -> float
+
+(** {1 Logging / telemetry} *)
+
+val log_level_env_key : string
+val telemetry_enabled_env_key : string
+val parse_warn_env_key : string
+val governance_level_env_key : string
+val log_level_opt : unit -> string option
+val telemetry_enabled : unit -> bool
+val parse_warn_enabled : unit -> bool
+val governance_level : unit -> string
+
+(** {1 Build identity / auto respond / pubsub} *)
+
+val build_git_commit_opt : unit -> string option
+val auto_respond_opt : unit -> string option
+val pubsub_max_messages : unit -> int
+
+(** {1 Keeper defaults} *)
+
+val keeper_social_model : unit -> string
+val keeper_will : unit -> string
+val keeper_needs : unit -> string
+val keeper_desires : unit -> string
+val keeper_default_sandbox_profile_raw : unit -> string

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -6,5 +6,5 @@
   "godsplit_count": 0,
   "lib_dune_lines": 989,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 7
+  "lib_other_mli_missing": 6
 }


### PR DESCRIPTION
## Summary
- Adds `.mli` for `lib/config/env_config_core.ml` (536 LOC, 1 exception + 83 vals).
- Surface flows through `include module type of Env_config_core` cascade in `env_config.mli` → reaches 90 consumer files (254 unqualified `Env_config.X` references).
- Sibling sub-modules (env_config_runtime/governance/keeper) reach helpers unqualified: `get_int` 60×, `get_float` 120×, `get_bool` 34×, `trim_opt` 19×, `raw_value_opt` 2×.

## Strategy
Per `feedback_mli_exposure_strategy_by_module_size`: 536 LOC at ≤500 boundary + heavy cascade reach → **exhaustive expose** for safety. All top-level lets enumerated as `val`, even apparently-internal helpers (`deprecation_warned` Hashtbl, `strip_*_slashes`, `warn_deprecated`) since the cascade contract has been inferring them.

## Ratchet
`lib_other_mli_missing` 7 → 6.

## Test plan
- [x] `dune build --root . --cache=disabled` clean (clean exit, no signature mismatch)
- [x] Race check (gh pr list "env_config_core" / "env-core-pin") = 0 hits before push
- [x] Baseline diff is one-line tighten only (no main regression silent absorb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)