### PR TITLE
fix(specs): refresh stale spec-line-refs after module relocation

### DIFF
--- a/specs/bug-models/DashboardCacheStampede.tla
+++ b/specs/bug-models/DashboardCacheStampede.tla
@@ -11,7 +11,7 @@
 \* Actual code (verified 2026-04-20):
 \*   lib/dashboard/dashboard_cache.ml:60   let maybe_evict map
 \*   lib/dashboard/dashboard_cache.ml:149  let get_or_compute_eio
-\*   lib/dashboard/dashboard_cache.ml:238  | Eio.Cancel.Cancelled _ as e -> ...
+\*   lib/dashboard/dashboard_cache.ml:244  | Eio.Cancel.Cancelled _ as e -> ...
 \*
 \* (Path drift: lib/dashboard_cache.ml -> lib/dashboard/dashboard_cache.ml.
 \*  Line drift: 265 -> 216. Recorded for cross-reference.)

--- a/specs/bug-models/KeeperPhaseRace.tla
+++ b/specs/bug-models/KeeperPhaseRace.tla
@@ -12,7 +12,7 @@
 \* cannot race a `phase` write.
 \*
 \* The closest live analog — and what this spec now models — is the
-\* fail-cascade contract in lib/keeper/keeper_keepalive.ml:max_consecutive_turn_failures
+\* fail-cascade contract in lib/keeper/keeper_heartbeat_snapshot.ml:max_consecutive_turn_failures
 \* (call site inside run_heartbeat_loop, see `start_keepalive`):
 \*
 \*   let turn_fail_count = (* read consecutive turn failures *) in
@@ -42,7 +42,7 @@
 \*   spec variable          <-> OCaml site
 \*   ----------------------+---------------------------------------------
 \*   turn_fail_count        <-> keeper_keepalive.ml:1566 (let turn_fail_count)
-\*   threshold              <-> keeper_keepalive.ml:510 (max_consecutive_turn_failures)
+\*   threshold              <-> keeper_heartbeat_snapshot.ml:44 (max_consecutive_turn_failures)
 \*   crashed                <-> keeper_keepalive.ml:1584 (raise Keeper_fiber_crash)
 \*   recorded_failure_n     <-> keeper_keepalive.ml:1583 (Turn_consecutive_failures n)
 \*

--- a/specs/keeper-state-machine/KeeperReconcileLiveness.tla
+++ b/specs/keeper-state-machine/KeeperReconcileLiveness.tla
@@ -56,7 +56,7 @@
 \* The liveness property MUST be violated in the buggy variant.
 \*
 \* Mirrors: lib/keeper/keeper_state_machine.ml (update_conditions)
-\*          lib/keeper/keeper_keepalive.ml:write_heartbeat_snapshot (heartbeat recovery)
+\*          lib/keeper/keeper_heartbeat_snapshot.ml:write_heartbeat_snapshot (heartbeat recovery)
 
 EXTENDS Naturals
 
@@ -195,7 +195,7 @@ ManualReconcileCleared ==
                    stop_requested, restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
 
-\* HeartbeatRecovery: the FIXED code path from keeper_keepalive.ml:write_heartbeat_snapshot.
+\* HeartbeatRecovery: the FIXED code path from keeper_heartbeat_snapshot.ml:write_heartbeat_snapshot.
 \* Dispatches Heartbeat_ok + Turn_succeeded + Manual_reconcile_cleared atomically.
 \* In the real code these are 3 sequential dispatch_event calls, but since
 \* Eio is cooperative and no yield point exists between them, the effect is atomic.


### PR DESCRIPTION
## Summary
- 3 spec files updated to track module relocation (`keeper_keepalive.ml` → `keeper_heartbeat_snapshot.ml`) + 1 line drift in `dashboard_cache.ml`
- 5 line/2 deletions, comment-only changes
- **Blocks no merges**: pure spec annotation refresh

## Why
`scripts/lint/spec-line-refs.sh` reports `1 drift, 2 dangling` on main, causing Meta Guards to fail on **every PR that touches lib code**. PRs #12012 #12015 and pending Phase 0.2 sub-PRs are blocked despite touching zero relocated code.

## Local verification
\`\`\`
$ bash scripts/lint/spec-line-refs.sh
spec-line-refs: 85 refs checked (43 line-anchored ok, 42 symbol-anchored ok, 0 drift, 0 dangling, 0 allowlisted)
\`\`\`
Before: 42 + 40, 1 drift, 2 dangling.

## Test plan
- [x] \`bash scripts/lint/spec-line-refs.sh\` exit 0
- [ ] CI Meta Guards pass on this PR
- [ ] Re-trigger #12012 / #12015 / new sub-PRs after merge — Meta Guards should flip green