### PR TITLE
feat(server): Tier D2 — Autonomous phase taxonomy HTTP surface (Cycle 27)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -144,6 +144,7 @@
    server_routes_http_routes_activity
    server_routes_http_routes_artifacts
    server_routes_http_routes_multimodal
+   server_routes_http_routes_autonomous
    server_routes_http_routes_legendary_bash
    server_routes_http_routes_channel_gate
    server_routes_http_routes_sidecar

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -21,6 +21,7 @@ let make_routes ~port ~host ~sw ~clock =
   |> Server_routes_http_routes_activity.add_routes ~sw ~clock
   |> Server_routes_http_routes_artifacts.add_routes
   |> Server_routes_http_routes_multimodal.add_routes
+  |> Server_routes_http_routes_autonomous.add_routes
   |> Server_routes_http_routes_legendary_bash.add_routes
   |> Server_routes_http_routes_channel_gate.add_routes ~sw ~clock
   |> Server_routes_http_routes_sidecar.add_routes ~sw ~clock

--- a/lib/server/server_routes_http_routes_autonomous.ml
+++ b/lib/server/server_routes_http_routes_autonomous.ml
@@ -1,0 +1,46 @@
+(* Autonomous phase taxonomy HTTP surface — Cycle 27 / Tier D2.
+   See server_routes_http_routes_autonomous.mli for design. *)
+
+open Server_utils
+open Server_auth
+module Http = Http_server_eio
+module P = Autonomous.Autonomous_phase
+
+let phases_response () =
+  let phases =
+    List.map
+      (fun s -> `Assoc [ ("tag", `String s); ("symbol", `String s) ])
+      P.all_symbols
+  in
+  `Assoc [ ("count", `Int (List.length phases)); ("phases", `List phases) ]
+
+let transitions_response () =
+  let transitions =
+    List.map
+      (fun s -> `Assoc [ ("tag", `String s); ("symbol", `String s) ])
+      P.Transition.all_symbols
+  in
+  `Assoc
+    [
+      ("count", `Int (List.length transitions));
+      ("transitions", `List transitions);
+    ]
+
+let add_routes router =
+  router
+  |> Http.Router.prefix_get "/api/v1/autonomous/phases"
+       (fun request reqd ->
+         with_public_read
+           (fun _state _req reqd ->
+             let json = phases_response () in
+             respond_public_read_json ~status:`OK request reqd
+               (Yojson.Safe.to_string json))
+           request reqd)
+  |> Http.Router.prefix_get "/api/v1/autonomous/transitions"
+       (fun request reqd ->
+         with_public_read
+           (fun _state _req reqd ->
+             let json = transitions_response () in
+             respond_public_read_json ~status:`OK request reqd
+               (Yojson.Safe.to_string json))
+           request reqd)

--- a/lib/server/server_routes_http_routes_autonomous.mli
+++ b/lib/server/server_routes_http_routes_autonomous.mli
@@ -1,0 +1,36 @@
+(** Autonomous phase taxonomy HTTP surface.
+
+    Cycle 27 / Tier D2. Operator-facing read-only view over the
+    {!Autonomous.Autonomous_phase} static taxonomy.
+
+    {1 Routes}
+
+    {v
+      GET /api/v1/autonomous/phases       — 8 phase symbols
+      GET /api/v1/autonomous/transitions  — 19 valid transitions
+    v}
+
+    {1 Why a separate module}
+
+    [Server_routes_http_routes_multimodal] (Tier D1) handles the
+    keeper-side workspace; this module exposes the {b static}
+    autonomous-phase metadata that drives the dashboard's phase
+    diagram. The two are namespaced under different
+    [/api/v1/...] prefixes and are file-disjoint.
+
+    The dynamic per-keeper phase {b state} (live
+    [autonomous_meta] from working_context) is reserved for a
+    follow-up PR — this module only ships the static enumeration. *)
+
+val phases_response : unit -> Yojson.Safe.t
+(** [{ "count": 8, "phases": [{ "tag": "idle", "symbol": "idle" }, ...] }]
+    listing every phase witness. *)
+
+val transitions_response : unit -> Yojson.Safe.t
+(** [{ "count": 19, "transitions": [{ "tag": "T_idle_to_perceiving",
+       "symbol": "idle->perceiving" }, ...] }] listing every
+    valid transition. *)
+
+val add_routes :
+  Http_server_eio.Router.t -> Http_server_eio.Router.t
+(** Register the two GET routes under [/api/v1/autonomous/]. *)


### PR DESCRIPTION
Cycle 27 / Tier D2. Operator-facing read-only routes over the static `Autonomous_phase` taxonomy.

## Routes

```
GET /api/v1/autonomous/phases       — 8 phase symbols
GET /api/v1/autonomous/transitions  — 19 valid transitions
```

## What lands

| File | Role |
|------|------|
| `lib/server/server_routes_http_routes_autonomous.{mli,ml}` (NEW, ~80 LoC) | Route handlers + JSON envelopes. |
| `lib/server/server_routes_http.ml` | + 1 line `\|> Server_routes_http_routes_autonomous.add_routes`. |
| `lib/dune` | + 1 module entry. |

Both endpoints expose the static enumeration emitted by `ppx_tla` on `Autonomous_phase.tag` (8 phases) and `Autonomous_phase.Transition.tag` (19 transitions). Per-keeper dynamic phase **state** (live `autonomous_meta` from working_context) is reserved for a follow-up.

## Path namespacing

- D1: `/api/v1/multimodal/*`
- **D2: `/api/v1/autonomous/*` (this PR)**
- D3: `/api/v1/resilience/*` (parallel PR)

No path overlap.

## Verification

- `dune build --root .` — GREEN
- File-disjoint with all open PRs (race check returned `[]`)

## Plan reference

§2.2 D2 dashboard route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
