### PR TITLE
feat(server): Tier D3 — Resilience taxonomy HTTP surface (Cycle 27)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -145,6 +145,7 @@
    server_routes_http_routes_artifacts
    server_routes_http_routes_multimodal
    server_routes_http_routes_autonomous
+   server_routes_http_routes_resilience
    server_routes_http_routes_legendary_bash
    server_routes_http_routes_channel_gate
    server_routes_http_routes_sidecar

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -28,6 +28,7 @@ let make_routes ~port ~host ~sw ~clock =
   |> Server_routes_http_routes_artifacts.add_routes
   |> Server_routes_http_routes_multimodal.add_routes
   |> Server_routes_http_routes_autonomous.add_routes
+  |> Server_routes_http_routes_resilience.add_routes
   |> Server_routes_http_routes_legendary_bash.add_routes
   |> Server_routes_http_routes_channel_gate.add_routes ~sw ~clock
   |> Server_routes_http_routes_sidecar.add_routes ~sw ~clock

--- a/lib/server/server_routes_http_routes_resilience.ml
+++ b/lib/server/server_routes_http_routes_resilience.ml
@@ -1,0 +1,90 @@
+(* Resilience taxonomy HTTP surface — Cycle 27 / Tier D3.
+   See server_routes_http_routes_resilience.mli for design. *)
+
+open Server_utils
+open Server_auth
+module Http = Http_server_eio
+module D = Resilience.Degradation
+
+let level_description = function
+  | D.Tag_l1 ->
+      "L1 — full execution. No degradation."
+  | D.Tag_l2 ->
+      "L2 — reduced quality. Operator notified, confidence \
+       degraded."
+  | D.Tag_l3 ->
+      "L3 — skeleton output. External tools blocked, partial \
+       success only."
+  | D.Tag_l4 ->
+      "L4 — fallback. Permanent failure path, no retry."
+
+let level_rank = function
+  | D.Tag_l1 -> 1
+  | D.Tag_l2 -> 2
+  | D.Tag_l3 -> 3
+  | D.Tag_l4 -> 4
+
+let levels_response () =
+  let entries =
+    List.map
+      (fun tag ->
+        let symbol = D.level_tag_to_string tag in
+        `Assoc
+          [
+            ("tag", `String symbol);
+            ("symbol", `String symbol);
+            ("rank", `Int (level_rank tag));
+            ("description", `String (level_description tag));
+          ])
+      D.all_level_tags
+  in
+  `Assoc
+    [ ("count", `Int (List.length entries)); ("levels", `List entries) ]
+
+let strategies_static =
+  [
+    ( "Retry",
+      "Recoverable error — retry with the same or escalated \
+       parameters." );
+    ( "Fallback",
+      "Permanent error in the primary path — switch to a known \
+       fallback (cache, alternate provider, degraded payload)." );
+    ( "Handoff",
+      "Multi-actor coordination required — escalate to a peer \
+       keeper or operator." );
+    ( "Abort",
+      "Unrecoverable — abandon the turn, surface the failure to \
+       the operator." );
+  ]
+
+let strategies_response () =
+  let entries =
+    List.map
+      (fun (tag, desc) ->
+        `Assoc [ ("tag", `String tag); ("description", `String desc) ])
+      strategies_static
+  in
+  `Assoc
+    [
+      ("count", `Int (List.length entries));
+      ("strategies", `List entries);
+    ]
+
+let add_routes router =
+  router
+  |> Http.Router.prefix_get "/api/v1/resilience/levels"
+       (fun request reqd ->
+         with_public_read
+           (fun _state _req reqd ->
+             let json = levels_response () in
+             respond_public_read_json ~status:`OK request reqd
+               (Yojson.Safe.to_string json))
+           request reqd)
+  |> Http.Router.prefix_get "/api/v1/resilience/strategies"
+       (fun request reqd ->
+         with_public_read
+           (fun _state _req reqd ->
+             let json = strategies_response () in
+             respond_public_read_json ~status:`OK request reqd
+               (Yojson.Safe.to_string json))
+           request reqd)

--- a/lib/server/server_routes_http_routes_resilience.mli
+++ b/lib/server/server_routes_http_routes_resilience.mli
@@ -1,0 +1,35 @@
+(** Resilience taxonomy HTTP surface.
+
+    Cycle 27 / Tier D3. Operator-facing read-only view over the
+    {!Resilience.Degradation} levels and the
+    {!Resilience.Recovery} strategy classes.
+
+    {1 Routes}
+
+    {v
+      GET /api/v1/resilience/levels      — 4 degradation levels
+      GET /api/v1/resilience/strategies  — 4 strategy classes
+    v}
+
+    {1 Why a separate module}
+
+    The static taxonomy is what the dashboard renders as the
+    "resilience legend" panel: which level represents what, which
+    strategy classes the keeper might apply. Per-keeper dynamic
+    [resilience_meta] (live classification timeline) is reserved
+    for a follow-up PR. *)
+
+val levels_response : unit -> Yojson.Safe.t
+(** [{ "count": 4, "levels": [{ "tag": "L1", "symbol": "L1",
+       "rank": 1, "description": "..." }, ...] }] listing every
+    degradation level with its rank ordering and a short
+    operator-facing description. *)
+
+val strategies_response : unit -> Yojson.Safe.t
+(** [{ "count": 4, "strategies": [{ "tag": "Retry",
+       "description": "..." }, ...] }] listing every strategy
+    class produced by {!Resilience.Recovery.default_strategy}. *)
+
+val add_routes :
+  Http_server_eio.Router.t -> Http_server_eio.Router.t
+(** Register the two GET routes under [/api/v1/resilience/]. *)

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 12,
+  "keeper_mli_missing": 3,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 989,
+  "lib_dune_lines": 992,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 3
+  "lib_other_mli_missing": 1
 }


### PR DESCRIPTION
Cycle 27 / Tier D3. Operator-facing read-only routes over the static `Resilience.{Degradation,Recovery}` taxonomy.

## Routes

```
GET /api/v1/resilience/levels      — 4 degradation levels
GET /api/v1/resilience/strategies  — 4 strategy classes
```

## What lands

| File | Role |
|------|------|
| `lib/server/server_routes_http_routes_resilience.{mli,ml}` (NEW, ~95 LoC) | Route handlers + JSON envelopes. |
| `lib/server/server_routes_http.ml` | + 1 line route registration. |
| `lib/dune` | + 1 module entry. |

`levels_response` derives from `Degradation.all_level_tags`, attaching rank ordering (1..4) and operator-facing descriptions. `strategies_response` mirrors the polymorphic-variant return of `Recovery.default_strategy` as a static list — the variant tags `Retry`/`Fallback`/`Handoff`/`Abort` are not directly reflectable.

## Path namespacing

- D1: `/api/v1/multimodal/*`
- D2: `/api/v1/autonomous/*` (parallel PR)
- **D3: `/api/v1/resilience/*` (this PR)**

No path overlap.

## Parallel-merge behaviour

Two single-line additions to `lib/dune` and `lib/server/server_routes_http.ml` overlap with D2. Standard union-merge resolves trivially (autocoder routine; verified locally that both stanzas can co-exist).

## Verification

- `dune build --root .` — GREEN
- File-disjoint at the route-module level (both new `.mli`/`.ml` are unique)

## Plan reference

§2.2 D3 dashboard route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
