### PR TITLE
chore(types): add .mli for 12 decomposition sub-modules + oas facade

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -1,0 +1,121 @@
+open Keeper_types
+
+val effective_keepalive_meta :
+  base_path:string ->
+  fallback:keeper_meta ->
+  disk_meta_opt:keeper_meta option ->
+  keeper_meta
+
+val keeper_agent_status : keeper_meta -> Types.agent_status
+
+val sync_keeper_presence :
+  ctx:'a context ->
+  meta_current:keeper_meta ->
+  t_presence_start:float ->
+  consecutive_failures:int ref ->
+  last_successful_heartbeat_ts:float ref ->
+  work_as_hb:(unit -> bool) ->
+  max_silence:(unit -> float) ->
+  keeper_meta
+
+val collect_keepalive_board_events :
+  ctx:'a context ->
+  meta_current:keeper_meta ->
+  proactive_warmup_elapsed:bool ->
+  Keeper_world_observation.keepalive_event list * keeper_meta
+
+val in_turn_liveness_pulse_interval_sec : unit -> float
+
+val with_in_turn_liveness_pulse_for_test :
+  sw:Eio.Switch.t ->
+  clock:'a Eio.Time.clock ->
+  interval_sec:float ->
+  tick:(unit -> unit) ->
+  (unit -> 'b) ->
+  'b
+
+val emit_in_turn_liveness_pulse :
+  ctx:'a context -> meta:keeper_meta -> unit
+
+val with_in_turn_liveness_pulse :
+  ctx:'a context ->
+  meta:keeper_meta ->
+  stop:bool Atomic.t ->
+  (unit -> 'b) -> 'b
+
+val run_keepalive_unified_turn :
+  ctx:'a context ->
+  meta_after_triage:keeper_meta ->
+  pending_board_events:Keeper_world_observation.keepalive_event list ->
+  stop:bool Atomic.t ->
+  proactive_warmup_elapsed:bool ->
+  shared_context:Oas.Context.t ->
+  keeper_meta
+
+val refresh_work_as_heartbeat :
+  ctx:'a context ->
+  meta_after_proactive:keeper_meta ->
+  proactive_warmup_elapsed:bool ->
+  work_as_hb:(unit -> bool) ->
+  last_successful_heartbeat_ts:float ref ->
+  consecutive_failures:int ref ->
+  unit
+
+val dispatch_recurring_keepalive :
+  ctx:'a context ->
+  meta_after_proactive:keeper_meta ->
+  now_ts:float ->
+  int
+
+(** Pure: whether a [Heartbeat_smart] decision should allow the keepalive
+    cycle (presence/snapshot/board/turn/recurring) to run.
+
+    Contract: [Skip_busy] -> [true] (cycle continues).
+    [Skip_idle] -> [false] (keeper idle, back off).
+    [Emit] -> [true]. *)
+val smart_heartbeat_cycle_continues : Heartbeat_smart.decision -> bool
+
+val run_smart_heartbeat_gate :
+  clock:'a Eio.Time.clock ->
+  stop:bool Atomic.t ->
+  wakeup:bool Atomic.t ->
+  meta_current:keeper_meta ->
+  smart_hb_enabled:(unit -> bool) ->
+  smart_hb_config:Heartbeat_smart.config ->
+  last_successful_heartbeat_ts:float ref ->
+  last_heartbeat_cycle_ts:float ref ->
+  bool
+
+val maybe_write_heartbeat_snapshot :
+  ctx:'a context ->
+  meta_current:keeper_meta ->
+  now_ts:float ->
+  consecutive_hb_failures:int ->
+  last_snapshot_ts:float ref ->
+  snapshot_interval_sec:int ->
+  timing_ring:Keeper_keepalive_signal.stage_timing array ->
+  timing_filled:int ->
+  unit
+
+val record_keepalive_stage_timing :
+  timing_ring:Keeper_keepalive_signal.stage_timing array ->
+  timing_cursor:int ref ->
+  timing_filled:int ref ->
+  ring_sz:int ->
+  t_presence_start:float ->
+  t_presence_end:float ->
+  t_snapshot_start:float ->
+  t_snapshot_end:float ->
+  t_board_start:float ->
+  t_board_end:float ->
+  t_turn_start:float ->
+  t_turn_end:float ->
+  t_recurring_start:float ->
+  t_recurring_end:float ->
+  unit
+
+(** The heartbeat loop body, extracted for reuse by the supervisor.
+    Runs synchronously in the calling fiber until [stop] becomes true. *)
+val run_heartbeat_loop :
+  proactive_warmup_sec:int -> 'a context -> keeper_meta -> bool Atomic.t ->
+  wakeup:bool Atomic.t -> unit

--- a/lib/keeper/keeper_heartbeat_snapshot.mli
+++ b/lib/keeper/keeper_heartbeat_snapshot.mli
@@ -1,0 +1,24 @@
+(** Canonical metric name for proactive-scheduler skip reasons.
+    Labels: [("keeper", <name>); ("reason", <skip_reason>)]. *)
+val proactive_skip_reason_metric : string
+
+val keepalive_interval_sec : unit -> int
+
+(** Heartbeat history fallback read limits. *)
+val max_history_read_bytes : int
+val max_history_read_lines : int
+
+(** Usage payload for heartbeat/status metrics rows. *)
+val status_tick_usage_json : unit -> Yojson.Safe.t
+
+val max_consecutive_heartbeat_failures : unit -> int
+val max_consecutive_turn_failures : unit -> int
+
+val write_heartbeat_snapshot :
+  ctx:'a Keeper_types.context ->
+  meta_current:Keeper_types.keeper_meta ->
+  now_ts:float ->
+  consecutive_hb_failures:int ->
+  timing_ring:Keeper_keepalive_signal.stage_timing array ->
+  timing_filled:int ->
+  unit

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -1,0 +1,69 @@
+open Keeper_types
+
+(** Optional gRPC client + env — WORM Atomic: set at server bootstrap
+    when [MASC_AGENT_TRANSPORT=grpc]. *)
+val grpc_client_ref : Masc_grpc_client.t option Atomic.t
+val grpc_env_ref : Eio_unix.Stdenv.base option Atomic.t
+
+val set_grpc_client : ?env:Eio_unix.Stdenv.base -> Masc_grpc_client.t -> unit
+
+(** FSM guard identity helpers (Cycle 43).
+    Wrapped by [Keeper_fsm_guard_runtime.wrap_unit] at call sites. *)
+val pre_turn_complete_heartbeat : turn_running:bool ref -> unit
+val post_turn_complete_heartbeat : turn_running:bool ref -> unit
+val post_wakeup_signal : wakeup:bool Atomic.t -> unit
+val post_submit_task : meta:keeper_meta -> task_id:Keeper_id.Task_id.t -> unit
+val post_heartbeat_tick : wakeup:bool Atomic.t -> unit
+
+(** Sleep in short chunks so [stop_keepalive] or [wakeup_keeper] takes
+    effect within ~chunk_sec instead of waiting for the full interval. *)
+val interruptible_sleep :
+  clock:'a Eio.Time.clock -> stop:bool Atomic.t -> wakeup:bool Atomic.t ->
+  float -> unit
+
+(** Wake up a specific keeper immediately. *)
+val wakeup_keeper : ?base_path:string -> string -> unit
+
+(** Wake up all running keepers. [None] preserves legacy global wakeup. *)
+val wakeup_all_keepers : ?base_path:string -> unit -> unit
+
+(** Board-reactive debounce interval (seconds), from runtime config. *)
+val board_reactive_debounce_sec : float
+
+val board_reactive_wakeup_allowed :
+  base_path:string -> keeper_name:string -> post_id:string -> bool
+
+val wakeup_relevant_keeper_for_board_signal :
+  config:Coord.config -> Board_dispatch.keeper_board_signal -> unit
+
+(** Per-stage timing accumulator for Phase 0 profiling. *)
+type stage_timing = {
+  presence_ms : float;
+  snapshot_ms : float;
+  board_ms : float;
+  turn_ms : float;
+  recurring_ms : float;
+}
+
+val stage_timing_ring_size : unit -> int
+
+val percentile : float array -> float -> float
+
+val stage_timing_to_json :
+  ring:stage_timing array -> count:int -> [> `Null | `Assoc of (string * [> `Assoc of (string * [> `Float | `Int ]) list ]) list ]
+
+val format_since_last_scheduled_autonomous : int option -> string
+
+val keepalive_entry_accepts_late_event :
+  ctx:'a context -> keeper_name:string -> bool
+
+val dispatch_keepalive_event :
+  ctx:'a context -> keeper_name:string ->
+  Keeper_state_machine.event -> unit
+
+val dispatch_keepalive_event_with_audit :
+  ctx:'a context -> keeper_name:string ->
+  snapshot:Keeper_measurement.measurement ->
+  events_fired:Keeper_guard.event list ->
+  selected_event:Keeper_guard.event option ->
+  Keeper_state_machine.event -> unit

--- a/lib/keeper/keeper_shell_bash.mli
+++ b/lib/keeper/keeper_shell_bash.mli
@@ -1,0 +1,14 @@
+(* Keeper_shell_bash — bash execution pipeline for keeper_bash tool.
+
+   Private sub-module included by [Keeper_exec_shell]. Only exposes what the
+   facade needs. *)
+
+val handle_keeper_bash :
+  turn_sandbox_factory:Keeper_sandbox_factory.t option ->
+  turn_sandbox_factory_git:Keeper_sandbox_factory.t option ->
+  exec_cache:Masc_exec.Exec_cache.t option ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  unit ->
+  string

--- a/lib/keeper/keeper_shell_ops.mli
+++ b/lib/keeper/keeper_shell_ops.mli
@@ -1,0 +1,12 @@
+(* Keeper_shell_ops — structured shell op dispatch for keeper_shell tool.
+
+   Private sub-module included by [Keeper_exec_shell]. Only exposes what the
+   facade needs. *)
+
+val handle_keeper_shell :
+  turn_sandbox_factory:Keeper_sandbox_factory.t option ->
+  exec_cache:Masc_exec.Exec_cache.t option ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -1,0 +1,183 @@
+(* Keeper_turn_cascade_budget — cascade execution types, fail-open rotation,
+   OAS timeout budget resolution, context overflow recovery, keeper pause/resume
+   sync, partial-commit continue gate, and context budget resolution.
+
+   Public sub-module included by [Keeper_unified_turn]. *)
+
+open Keeper_types
+open Keeper_exec_context
+module EC = Keeper_error_classify
+
+type cascade_execution = {
+  cascade_name : string;
+  max_context_resolution : max_context_resolution;
+  max_context : int;
+  temperature : float;
+  max_tokens : int;
+}
+
+val fail_open_rotation_cascades_from_catalog :
+  catalog_names:string list ->
+  keeper_assignable:string list ->
+  string list option
+
+val active_fail_open_rotation_cascades : unit -> string list option
+
+val next_fail_open_cascade_for_turn :
+  ?rotation_cascades:string list ->
+  base_cascade:string ->
+  effective_cascade:string ->
+  tool_requirement:string ->
+  attempted_cascades:string list ->
+  Oas.Error.sdk_error ->
+  EC.degraded_retry option
+
+val record_turn_failure_stress :
+  meta:keeper_meta ->
+  is_auto_recoverable:bool ->
+  consecutive:int ->
+  threshold:int ->
+  err:Oas.Error.sdk_error ->
+  unit
+
+val oas_timeout_guard_sec : float
+(** Retry guard floor (seconds). *)
+
+val min_oas_timeout_budget_sec : float
+(** Minimum OAS timeout budget (seconds). *)
+
+type oas_timeout_budget_resolution = {
+  effective_timeout_sec : float;
+  adaptive_timeout_sec : float;
+  keeper_turn_timeout_sec : float;
+  remaining_turn_budget_sec : float;
+  estimated_input_tokens : int;
+  max_turns : int;
+  source : string;
+}
+
+val oas_timeout_budget_resolution_to_yojson :
+  oas_timeout_budget_resolution -> Yojson.Safe.t
+
+val resolve_bounded_oas_timeout_budget_with_turn_budget :
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  oas_timeout_budget_resolution option
+
+val bounded_oas_timeout_for_turn_budget_with_turn_budget :
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  float option
+
+val bounded_oas_timeout_for_turn_budget :
+  estimated_input_tokens:int ->
+  remaining_turn_budget_s:float ->
+  float option
+
+val oas_retry_budget_available_for_turn :
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  bool
+
+val reclassify_oas_timeout_for_attempt :
+  timeout_budget:oas_timeout_budget_resolution option ->
+  Oas.Error.sdk_error ->
+  Oas.Error.sdk_error
+
+type degraded_retry_budget_decision =
+  | No_degraded_retry
+  | Degraded_retry_budget_exhausted of EC.degraded_retry
+  | Degraded_retry_allowed of EC.degraded_retry
+
+val next_fail_open_cascade_for_turn_with_budget :
+  ?rotation_cascades:string list ->
+  base_cascade:string ->
+  effective_cascade:string ->
+  tool_requirement:string ->
+  attempted_cascades:string list ->
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  Oas.Error.sdk_error ->
+  degraded_retry_budget_decision
+
+type overflow_retry_plan = {
+  retry_max_context : int;
+  retry_generation : int;
+  compaction : compaction_event;
+}
+
+type turn_event_bus_overflow = {
+  estimated_tokens : int;
+  limit_tokens : int;
+}
+
+type turn_event_bus_summary = {
+  correlation_id : string option;
+  overflow_imminent : turn_event_bus_overflow option;
+}
+
+val empty_turn_event_bus_summary : turn_event_bus_summary
+
+val merge_turn_event_bus_summary :
+  turn_event_bus_summary -> turn_event_bus_summary -> turn_event_bus_summary
+
+val recover_context_overflow_retry :
+  meta:keeper_meta ->
+  base_dir:string ->
+  max_cascade_context:int ->
+  error:Oas.Error.sdk_error ->
+  overflow_retry_plan option
+
+val summarize_turn_event_bus :
+  Oas.Event_bus.event list -> turn_event_bus_summary
+
+val context_overflow_event_of_error :
+  fallback_tokens:int ->
+  ?turn_event_bus:turn_event_bus_summary ->
+  Oas.Error.sdk_error ->
+  Keeper_state_machine.event
+
+val pause_keeper_for_overflow :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  reason:string ->
+  keeper_meta
+(** Pause a keeper after unresolved context overflow. Writes meta with merge-CAS
+    and dispatches [Compact_retry_exhausted] then [Operator_pause]. Returns the
+    paused meta. *)
+
+val sync_keeper_paused_state :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  paused:bool ->
+  (keeper_meta, string) result
+(** Persist paused/resumed state before mutating the live registry/phase.
+    Returns [Error] when disk sync fails so callers can surface the failure
+    instead of silently diverging runtime vs persisted state. *)
+
+val current_keeper_meta :
+  config:Coord.config ->
+  fallback_meta:keeper_meta ->
+  keeper_meta
+(** Read the latest meta from the registry, falling back to the given
+    [fallback_meta] when the registry entry is missing. *)
+
+val enqueue_partial_commit_continue_gate :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  failure_reason:Keeper_registry.failure_reason ->
+  committed_tools:string list ->
+  error_detail:string ->
+  string
+
+val resolved_max_context_for_turn :
+  meta:keeper_meta ->
+  string list ->
+  int
+(** Resolve the initial keeper turn context budget. Uses the first available
+    model in the cascade rather than the largest fallback model, so lifecycle
+    context math matches the provider that will receive the first request. *)

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -1,0 +1,89 @@
+(* Keeper_turn_helpers — string matching, event reporting, trajectory/receipt
+   helpers, FSM guard post-actions, and local discovery readiness.
+
+   Public sub-module included by [Keeper_unified_turn]. *)
+
+open Keeper_types
+open Keeper_exec_context
+
+(** Interval (seconds) for the per-turn background fiber that drains the
+    [keeper_turn] subscription on the OAS event bus. *)
+val default_turn_event_bus_drain_interval_sec : float
+
+val turn_event_bus_drain_interval_sec : unit -> float
+
+val substring_matches_at : needle:string -> string -> int -> bool
+(** [substring_matches_at ~needle haystack start_idx] checks whether
+    [needle] occurs in [haystack] starting at [start_idx]. *)
+
+val string_contains_substring : needle:string -> string -> bool
+(** Case-sensitive substring test. *)
+
+val string_contains_substring_ci : needle:string -> string -> bool
+(** Case-insensitive substring test. *)
+
+val report_keeper_cycle_side_effect_issue :
+  config:Coord.config ->
+  keeper_name:string ->
+  side_effect:string ->
+  ?severity:[> `Warn | `Error ] ->
+  string -> unit
+(** Log and record a side-effect failure for a keeper cycle. *)
+
+val dispatch_keeper_phase_event_checked :
+  config:Coord.config ->
+  keeper_name:string ->
+  side_effect:string ->
+  Keeper_state_machine.event -> unit
+(** Dispatch a phase event and log on error instead of raising. *)
+
+val finalize_trajectory_acc :
+  config:Coord.config ->
+  keeper_name:string ->
+  Trajectory.accumulator ->
+  Trajectory.trajectory_outcome -> unit
+(** Finalize a trajectory accumulator with the given outcome. Logs errors
+    rather than raising (except cancellation). *)
+
+val record_execution_receipt_gap :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  stale_reason:string ->
+  error:string ->
+  unit -> unit
+(** Record a coverage gap when an execution receipt could not be appended. *)
+
+val post_assign_task : any_pending:bool -> channel:string -> unit
+(** FSM guard post-action for [AssignTask]. *)
+
+val post_empty_queue_sleep : any_pending:bool -> channel:string -> unit
+(** FSM guard post-action for [EmptyQueueSleep]. *)
+
+val post_turn_complete_task : cycle_completed:bool ref -> unit
+(** FSM guard post-action for [TurnComplete]. *)
+
+val pre_dispatch_tool_surface : Keeper_execution_receipt.tool_surface
+(** Default tool surface for pre-dispatch receipts (no tools dispatched). *)
+
+val record_pre_dispatch_terminal_observation :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  generation:int ->
+  cascade_name:string ->
+  outcome:string ->
+  terminal_reason_code:string ->
+  activity_kind:string ->
+  trajectory_outcome:Trajectory.trajectory_outcome ->
+  ?error_kind:string ->
+  ?error_message:string ->
+  ?keeper_turn_id:string ->
+  unit -> unit
+(** Record a terminal observation (receipt + activity graph event) for a
+    pre-dispatch failure or early exit. *)
+
+val ensure_local_discovery_ready :
+  ?refresh:(string list -> bool) ->
+  string list ->
+  (unit, string) result
+(** Ensure local-provider discovery is refreshed before a turn when the
+    selected labels depend on runtime discovery. *)

--- a/lib/keeper/keeper_turn_liveness.mli
+++ b/lib/keeper/keeper_turn_liveness.mli
@@ -1,0 +1,67 @@
+(* Keeper_turn_liveness — local-only cascade liveness decisions, ollama
+   saturation pre-skip, and turn liveload configuration.
+
+   Public sub-module included by [Keeper_unified_turn]. *)
+
+open Keeper_types
+
+(** Deterministic decision for the local-only phase fallback boundary. This
+    does not probe runtime liveness; it only decides whether the selected
+    labels warrant an Ollama liveness check before preserving [local_only]. *)
+type local_only_liveness_decision =
+  | Keep_effective_cascade of string
+  | Probe_local_only_urls of {
+      effective_cascade : string;
+      fallback_cascade : string;
+      ollama_base_urls : string list;
+    }
+
+val decide_local_only_liveness :
+  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
+  base_cascade:string ->
+  effective_cascade:string ->
+  string list ->
+  local_only_liveness_decision
+
+val fail_open_local_only_when_unavailable :
+  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
+  ?probe_ollama_base_url:(string -> bool) ->
+  base_cascade:string ->
+  effective_cascade:string ->
+  string list ->
+  string
+(** When phase routing temporarily forces [local_only], fail open to the
+    keeper's configured base cascade if the local Ollama endpoint is
+    unavailable. Explicit [local_only] keepers are preserved. *)
+
+val resolve_ollama_only_base_url :
+  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
+  string list ->
+  string option
+(** PR-B: when every label in the resolved cascade points at the
+    same ollama [base_url] return [Some url], else [None]. Purely
+    structural: does not probe the network. *)
+
+val is_ollama_saturated :
+  ?capacity_lookup:(string -> Cascade_throttle.capacity_info option) ->
+  string ->
+  bool
+(** Read the [Cascade_ollama_probe] cache and report whether the endpoint
+    is saturated (no available slots while at least one request is active
+    or queued). No cache / failed probe returns [false] (fail-open) so a
+    flaky probe never starves the keeper. *)
+
+val saturation_skip_backoff_sec : float
+(** Backoff sleep applied after a saturation skip (seconds). *)
+
+val saturation_skip_jitter_factor : float
+(** Jitter factor for saturation skip sleep. *)
+
+val saturation_skip_sleep_duration : unit -> float
+(** Compute a jittered sleep duration for saturation skip. *)
+
+val turn_livelock_max_attempts : unit -> int
+(** Configurable livelock detection max attempts. *)
+
+val turn_livelock_stuck_after_sec : unit -> float
+(** Configurable livelock detection stuck threshold (seconds). *)

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -1,0 +1,64 @@
+exception Semaphore_wait_timeout of float
+
+(** Global turn slot cap. Safety ceiling for ALL keeper turns. *)
+val keeper_turn_throttle_limit : int
+
+val turn_semaphore : int Eio.Semaphore.t
+val autonomous_turn_semaphore : int Eio.Semaphore.t
+
+(** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper
+    turn slot. Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. *)
+val semaphore_wait_timeout_sec : float
+
+type autonomous_waiter = {
+  ticket : int;
+  keeper_name : string;
+}
+
+(** Test-only reset for the autonomous FIFO wait queue. *)
+val reset_autonomous_turn_queue_for_test : unit -> unit
+
+(** Test-only snapshot of keeper names currently queued for an autonomous turn. *)
+val autonomous_waiter_snapshot_for_test : unit -> string list
+
+(** Test-only snapshots of the current semaphore availability. *)
+val turn_semaphore_value_for_test : unit -> int
+val autonomous_turn_semaphore_value_for_test : unit -> int
+
+(** Test-only FIFO queue primitives for autonomous fairness regression tests. *)
+val enqueue_autonomous_waiter_for_test : string -> int
+val drop_autonomous_waiter_for_test : int -> unit
+
+(** Pure computation: seconds keeper should yield before re-entering queue
+    at time [now].  0.0 = no yield needed. *)
+val fairness_delay_sec_at : now:float -> keeper_name:string -> float
+
+(** Test-only: stamp a completion time directly (bypasses [Time_compat.now]). *)
+val record_autonomous_completion_at_for_test : keeper_name:string -> ts:float -> unit
+
+(** Test-only: clear all per-keeper completion timestamps. *)
+val reset_autonomous_completion_for_test : unit -> unit
+
+(** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
+    per keeper. Promoted to [Keeper_fiber_crash] at this limit. *)
+val oas_timeout_budget_strike_limit : int
+
+val bump_budget_exhaustion : keeper_name:string -> int
+val reset_budget_exhaustion : keeper_name:string -> unit
+val peek_budget_exhaustion_for_test : keeper_name:string -> int
+val set_budget_exhaustion_for_test : keeper_name:string -> strikes:int -> unit
+
+type keeper_turn_slot_state
+
+val with_keeper_turn_slot :
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of float ]) result
+
+(** Test-only wrapper around the keeper turn slot acquisition path. *)
+val with_keeper_turn_slot_for_test :
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of float ]) result

--- a/lib/oas_worker_named.mli
+++ b/lib/oas_worker_named.mli
@@ -1,0 +1,181 @@
+(** Oas_worker_named — MASC named-cascade and model-label execution entry points.
+
+    Public API for running OAS agents through MASC-managed named cascade
+    profiles ([run_named]) or explicit model label ([run_model_by_label]),
+    with optional MASC tool bridging variants.
+
+    The facade [include]s the three sub-modules:
+    - {!Oas_worker_named_cascade} — Eio context, cascade resolution, runtime MCP policy
+    - {!Oas_worker_named_error} — masc_internal_error type, error conversion, codex CLI preflight
+    - {!Oas_worker_named_fsm} — SDK error to FSM outcome, session/resumption analysis
+
+    @since God file decomposition — extracted from oas_worker.ml *)
+
+include module type of Oas_worker_named_cascade
+include module type of Oas_worker_named_error
+include module type of Oas_worker_named_fsm
+
+(** {1 Named cascade execution} *)
+
+val run_named :
+  cascade_name:string ->
+  ?keeper_name:string ->
+  ?model_strings:string list ->
+  goal:string ->
+  ?provider_filter:(Llm_provider.Provider_config.t -> bool) ->
+  ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
+  ?priority:Llm_provider.Request_priority.t ->
+  ?session_id:string ->
+  ?system_prompt:string ->
+  ?tools:Oas.Tool.t list ->
+  ?initial_messages:Oas.Types.message list ->
+  ?max_turns:int ->
+  ?max_idle_turns:int ->
+  ?stream_idle_timeout_s:float ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?max_input_tokens:int option ->
+  ?max_cost_usd:float option ->
+  ?wait_timeout_sec:float ->
+  ?accept:(Oas_response.api_response -> bool) ->
+  ?guardrails:Oas.Guardrails.t ->
+  ?hooks:Oas.Hooks.t ->
+  ?context_reducer:Oas.Context_reducer.t ->
+  ?memory:Oas.Memory.t ->
+  ?tool_retry_policy:Oas.Tool_retry.t ->
+  ?required_tool_satisfaction:Oas.Completion_contract.tool_satisfaction ->
+  ?raw_trace:Oas.Types.raw_trace ->
+  ?on_event:(Oas.Types.event -> unit) ->
+  ?on_yield:(Oas_response.api_response -> unit) ->
+  ?on_resume:(unit -> unit) ->
+  ?agent_ref:Oas.Agent.t option ref ->
+  ?proof_ref:string option ref ->
+  ?contract:Oas.Completion_contract.t ->
+  ?transport:Masc_grpc_transport.t ->
+  ?cli_transport_overrides:Oas_worker_exec.cli_transport_overrides ->
+  ?allowed_paths:string list ->
+  ?checkpoint_sidecar:string option ref ->
+  ?cache_system_prompt:bool ->
+  ?yield_on_tool:bool ->
+  ?compact_ratio:float ->
+  ?checkpoint_dir:string ->
+  ?context_injector:Oas.Context_injector.t ->
+  ?context:Oas.Types.context ->
+  ?slot_id:string ->
+  ?enable_thinking:bool ->
+  ?approval:Oas.Approval.t ->
+  ?exit_condition:Oas.Types.exit_condition ->
+  ?exit_condition_result:(Oas_response.api_response -> Oas.Types.exit_condition_result option) ->
+  ?summarizer:(Oas.Types.message list -> string) ->
+  ?oas_checkpoint:Oas.Checkpoint.t ->
+  ?event_bus:Oas.Event_bus.t ->
+  ?sw:Eio.Switch.t ->
+  ?net:Eio.Net.t ->
+  ?per_provider_timeout_s:float ->
+  unit ->
+  (Oas_worker_exec.run_result, Oas.Error.sdk_error) result
+(** Run a single [Agent.run] call with MASC-driven cascade model fallback.
+    MASC drives the cascade FSM directly: resolves cascade providers,
+    tries each with OAS, and uses [Cascade_fsm.decide] on failure.
+    The cascade loop runs inside an admission queue permit. *)
+
+(** {1 Model-label execution} *)
+
+val run_model_by_label :
+  model_label:string ->
+  goal:string ->
+  ?system_prompt:string ->
+  ?tools:Oas.Tool.t list ->
+  ?max_turns:int ->
+  ?max_idle_turns:int ->
+  ?stream_idle_timeout_s:float ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?max_input_tokens:int option ->
+  ?max_cost_usd:float option ->
+  ?wait_timeout_sec:float ->
+  ?accept:(Oas_response.api_response -> bool) ->
+  ?guardrails:Oas.Guardrails.t ->
+  ?hooks:Oas.Hooks.t ->
+  ?context_reducer:Oas.Context_reducer.t ->
+  ?memory:Oas.Memory.t ->
+  ?tool_retry_policy:Oas.Tool_retry.t ->
+  ?enable_thinking:bool ->
+  ?compact_ratio:float ->
+  ?contract:Oas.Completion_contract.t ->
+  ?on_event:(Oas.Types.event -> unit) ->
+  ?transport:Masc_grpc_transport.t ->
+  ?sw:Eio.Switch.t ->
+  ?net:Eio.Net.t ->
+  unit ->
+  (Oas_worker_exec.run_result, Oas.Error.sdk_error) result
+(** Run a single [Agent.run] using a model label string
+    (e.g. ["llama:qwen3.5"]).  Validates the label before execution. *)
+
+(** {1 MASC tool bridging} *)
+
+val run_named_with_masc_tools :
+  cascade_name:string ->
+  goal:string ->
+  ?priority:Llm_provider.Request_priority.t ->
+  ?system_prompt:string ->
+  masc_tools:Types.tool_schema list ->
+  dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->
+  ?max_turns:int ->
+  ?stream_idle_timeout_s:float ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?max_input_tokens:int option ->
+  ?max_cost_usd:float option ->
+  ?wait_timeout_sec:float ->
+  ?guardrails:Oas.Guardrails.t ->
+  ?hooks:Oas.Hooks.t ->
+  ?memory:Oas.Memory.t ->
+  ?tool_retry_policy:Oas.Tool_retry.t ->
+  ?required_tool_satisfaction:Oas.Completion_contract.tool_satisfaction ->
+  ?raw_trace:Oas.Types.raw_trace ->
+  ?on_event:(Oas.Types.event -> unit) ->
+  ?on_yield:(Oas_response.api_response -> unit) ->
+  ?on_resume:(unit -> unit) ->
+  ?proof_ref:string option ref ->
+  ?contract:Oas.Completion_contract.t ->
+  ?transport:Masc_grpc_transport.t ->
+  ?yield_on_tool:bool ->
+  ?compact_ratio:float ->
+  ?approval:Oas.Approval.t ->
+  ?sw:Eio.Switch.t ->
+  ?net:Eio.Net.t ->
+  unit ->
+  (Oas_worker_exec.run_result, Oas.Error.sdk_error) result
+(** [run_named] variant that bridges MASC tool schemas into OAS tools
+    via {!Tool_bridge.oas_tool_of_masc}. *)
+
+val run_model_with_masc_tools :
+  model_label:string ->
+  goal:string ->
+  ?system_prompt:string ->
+  masc_tools:Types.tool_schema list ->
+  dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->
+  ?max_turns:int ->
+  ?stream_idle_timeout_s:float ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?max_input_tokens:int option ->
+  ?max_cost_usd:float option ->
+  ?wait_timeout_sec:float ->
+  ?guardrails:Oas.Guardrails.t ->
+  ?hooks:Oas.Hooks.t ->
+  ?memory:Oas.Memory.t ->
+  ?tool_retry_policy:Oas.Tool_retry.t ->
+  ?enable_thinking:bool ->
+  ?compact_ratio:float ->
+  ?contract:Oas.Completion_contract.t ->
+  ?raw_trace:Oas.Types.raw_trace ->
+  ?on_event:(Oas.Types.event -> unit) ->
+  ?transport:Masc_grpc_transport.t ->
+  ?sw:Eio.Switch.t ->
+  ?net:Eio.Net.t ->
+  unit ->
+  (Oas_worker_exec.run_result, Oas.Error.sdk_error) result
+(** [run_model_by_label] variant that bridges MASC tool schemas into OAS tools. *)

--- a/lib/oas_worker_named_cascade.mli
+++ b/lib/oas_worker_named_cascade.mli
@@ -1,0 +1,130 @@
+(** Oas_worker_named_cascade — Eio context, cascade resolution, runtime MCP policy.
+
+    Extracted from oas_worker_named.ml (God file decomposition).
+    Provides cascade profile defaults, Eio context validation,
+    provider resolution, tool-support filtering, and cross-cascade fallback.
+
+    This module is [include]d by {!Oas_worker_named}; all bindings are
+    re-exported by the facade.  @since God file decomposition *)
+
+(** {1 Cascade profile defaults} *)
+
+val default_config_path : unit -> string option
+(** Alias for [Cascade_runtime.cascade_config_path]. *)
+
+val default_model_strings : string list
+(** Alias for [Cascade_runtime.default_model_strings]. *)
+
+(** {1 Eio context validation} *)
+
+val require_eio :
+  ?sw:Eio.Switch.t -> ?net:Eio.Net.t -> unit ->
+  (Eio.Switch.t * Eio.Net.t, string) result
+(** Validate that an Eio switch and network are available in the current
+    context.  Returns [Ok (sw, net)] when both are present, or [Error msg]
+    when running outside a server context. *)
+
+val eio_context_error_to_sdk_error : string -> Oas.Error.sdk_error
+(** Lift a context-missing diagnostic string into an [Oas.Error.Config]
+    error with field ["eio_context"]. *)
+
+val cascade_catalog_error_to_sdk_error : string -> Oas.Error.sdk_error
+(** Lift a cascade-catalog diagnostic into an [Oas.Error.Config]
+    error with field ["cascade_name"]. *)
+
+(** {1 Provider resolution} *)
+
+val resolve_cascade_providers :
+  ?provider_filter:(Llm_provider.Provider_config.t -> bool) ->
+  ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  cascade_name:string -> unit ->
+  (Llm_provider.Provider_config.t list, string) result
+(** Resolve cascade provider configs via MASC Cascade_config. *)
+
+val resolve_providers_from_model_strings :
+  ?provider_filter:(Llm_provider.Provider_config.t -> bool) ->
+  ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  string list ->
+  (Llm_provider.Provider_config.t list, string) result
+(** Resolve from an explicit model string list (user-declared in keeper TOML). *)
+
+val keeper_agent_name_opt : string -> string option
+(** Derive the agent name from a keeper name; [None] when the name is empty. *)
+
+val runtime_mcp_policy_for_tools :
+  keeper_name:string -> Oas.Tool.t list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+(** Build a runtime MCP policy from the tool list, honouring public MCP tools
+    and keeper-internal surface classifications. *)
+
+val runtime_mcp_policy_for_provider :
+  keeper_name:string ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+(** Normalise a runtime MCP policy for a specific provider, injecting the
+    keeper's agent name when applicable. *)
+
+val codex_cli_cannot_carry_keeper_bound_runtime_mcp :
+  keeper_name:string ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  bool
+(** [true] when the provider is codex_cli and the policy includes tools that
+    require a bound-actor (keeper-scoped) runtime MCP — codex_cli cannot
+    carry these across its CLI subprocess boundary. *)
+
+(** {1 Provider filter rejection classification} *)
+
+type filter_rejection_reason =
+  | Codex_keeper_bound_actor_required
+  | Tool_lane_unsupported
+  | Required_tool_use of Provider_tool_support.rejection_reason
+(** Why a provider was rejected by the cascade filter.  Order mirrors the
+    filter's short-circuit priority. *)
+
+val filter_rejection_reason_label : filter_rejection_reason -> string
+
+val classify_filter_rejection :
+  keeper_name:string ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  ?tools:Oas.Tool.t list ->
+  require_tool_choice_support:bool ->
+  require_tool_support:bool ->
+  Llm_provider.Provider_config.t ->
+  filter_rejection_reason option
+(** Classify why a single provider would be rejected by the tool-use gate. *)
+
+val filter_candidate_providers_for_tool_support :
+  keeper_name:string ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  ?tools:Oas.Tool.t list ->
+  require_tool_choice_support:bool ->
+  require_tool_support:bool ->
+  label:string ->
+  Llm_provider.Provider_config.t list ->
+  Llm_provider.Provider_config.t list
+(** Filter provider candidates through the tool-use gate.  When the gate
+    empties the list, emits a deduplicated diagnostic (ERROR on first
+    occurrence per signature, DEBUG on repeats). *)
+
+(** {1 Cross-cascade fallback} *)
+
+val resolve_tool_capable_provider_across_cascades :
+  sw:Eio.Switch.t ->
+  net:Eio.Net.t ->
+  keeper_name:string ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  ?tools:Oas.Tool.t list ->
+  require_tool_choice_support:bool ->
+  require_tool_support:bool ->
+  exclude_cascade:string ->
+  unit ->
+  (string * Llm_provider.Provider_config.t) option
+(** Search all other cascades for a healthy tool-capable provider when the
+    current cascade has none after filtering.  Returns the source cascade
+    name and provider config, or [None].  Depth: 1 level only. *)

--- a/lib/oas_worker_named_error.mli
+++ b/lib/oas_worker_named_error.mli
@@ -1,0 +1,138 @@
+(** Oas_worker_named_error — masc_internal_error type, error conversion, codex CLI preflight.
+
+    Extracted from oas_worker_named.ml (God file decomposition).
+    Defines the [masc_internal_error] variant type, JSON serialization,
+    SDK error conversion, error classification, and codex CLI prompt
+    preflight checks.
+
+    This module is [include]d by {!Oas_worker_named}; all bindings are
+    re-exported by the facade.  @since God file decomposition *)
+
+(** {1 MASC internal error type} *)
+
+type masc_internal_error =
+  | Cascade_exhausted of {
+      cascade_name : string;
+      reason : Keeper_types.cascade_exhaustion_reason;
+    }
+  | Resumable_cli_session of {
+      cascade_name : string;
+      detail : string;
+      exit_code : int option;
+    }
+  | No_tool_capable_provider of {
+      cascade_name : string;
+      configured_labels : string list;
+    }
+  | Accept_rejected of {
+      scope : string;
+      model : string option;
+      reason : string;
+    }
+  | Admission_queue_timeout of {
+      keeper_name : string;
+      cascade_name : string;
+      wait_sec : float;
+    }
+  | Admission_queue_rejected of {
+      keeper_name : string;
+      reason : string;
+    }
+  | Turn_timeout of {
+      elapsed_sec : float;
+    }
+  | Oas_timeout_budget of {
+      budget_sec : float;
+      keeper_turn_timeout_sec : float;
+      estimated_input_tokens : int;
+      source : string;
+    }
+  | Ambiguous_post_commit of {
+      is_timeout : bool;
+      tools : string list;
+      original_error : string;
+    }
+
+val masc_internal_error_to_json : masc_internal_error -> Yojson.Safe.t
+
+val sdk_error_of_masc_internal_error : masc_internal_error -> Oas.Error.sdk_error
+(** Convert a [masc_internal_error] to an SDK error, bumping the
+    [masc_oas_error_total] Prometheus counter with [kind] and
+    [cascade_name] labels. *)
+
+val classify_masc_internal_error :
+  Oas.Error.sdk_error -> masc_internal_error option
+(** Parse an SDK error back into a [masc_internal_error] when it was
+    originally produced by [sdk_error_of_masc_internal_error].  Returns
+    [None] for errors that do not carry the [masc_oas_error] prefix. *)
+
+val kind_of_masc_internal_error : masc_internal_error -> string
+(** Short label for each variant, used as the [kind] Prometheus label. *)
+
+val cascade_name_of_masc_internal_error : masc_internal_error -> string
+(** Cascade name from the error payload, or ["unknown"] for variants that
+    fire outside cascade context. *)
+
+val admission_wait_timeout_error :
+  keeper_name:string ->
+  cascade_name:string ->
+  priority:Llm_provider.Request_priority.t ->
+  int ->
+  (string, Oas.Error.sdk_error) result
+(** Build an [Admission_queue_timeout] error from a wait duration in ms. *)
+
+(** {1 Config construction} *)
+
+val config_for_label :
+  name:string ->
+  model_label:string ->
+  system_prompt:string ->
+  tools:Oas.Tool.t list ->
+  max_turns:int ->
+  max_tokens:int ->
+  ?max_input_tokens:int option ->
+  ?max_cost_usd:float option ->
+  temperature:float ->
+  ?max_idle_turns:int ->
+  ?stream_idle_timeout_s:float ->
+  ?guardrails:Oas.Guardrails.t ->
+  ?hooks:Oas.Hooks.t ->
+  ?context_reducer:Oas.Context_reducer.t ->
+  ?memory:Oas.Memory.t ->
+  ?tool_retry_policy:Oas.Tool_retry.t ->
+  ?enable_thinking:bool ->
+  ?compact_ratio:float ->
+  ?contract:Oas.Completion_contract.t ->
+  ?approval:Oas.Approval.t ->
+  description:string option ->
+  unit ->
+  (Oas_worker_exec.config, Oas.Error.sdk_error) result
+(** Build an [Oas_worker_exec.config] from a model label string.  Resolves
+    the provider config and fills in defaults. *)
+
+(** {1 Codex CLI preflight} *)
+
+type codex_cli_prompt_preflight = {
+  prompt_bytes : int;
+  prompt_tokens : int;
+  context_window_tokens : int;
+  retry_limit_tokens : int;
+  hits_argv_limit : bool;
+  hits_context_window : bool;
+}
+
+val codex_cli_prompt_preflight :
+  config:Oas_worker_exec.config -> goal:string -> codex_cli_prompt_preflight option
+(** Check whether a codex_cli invocation would exceed the argv or context
+    window limit.  Returns [Some] when limits are hit, [None] when safe
+    (or when the provider is not codex_cli). *)
+
+val with_codex_cli_preflight :
+  scope:string ->
+  config:Oas_worker_exec.config ->
+  goal:string ->
+  (unit -> ('a, Oas.Error.sdk_error) result) ->
+  ('a, Oas.Error.sdk_error) result
+(** Wrap an execution with a codex_cli preflight check.  If the prompt
+    exceeds limits, returns [Error] immediately without calling [run].
+    Otherwise delegates to [run]. *)

--- a/lib/oas_worker_named_fsm.mli
+++ b/lib/oas_worker_named_fsm.mli
@@ -1,0 +1,85 @@
+(** Oas_worker_named_fsm — SDK error to FSM outcome, session/resumption analysis.
+
+    Extracted from oas_worker_named.ml (God file decomposition).
+    Converts OAS SDK errors into Cascade_fsm provider outcomes,
+    classifies CLI-wrapped error patterns (hard quota, max turns,
+    resumable sessions), and enriches errors with provider-specific hints.
+
+    This module is [include]d by {!Oas_worker_named}; all bindings are
+    re-exported by the facade.  @since God file decomposition *)
+
+(** {1 Cascade outcome classification} *)
+
+val sdk_error_to_cascade_outcome :
+  Oas.Error.sdk_error -> Cascade_fsm.provider_outcome option
+(** Convert an SDK error into a cascade FSM provider outcome.
+    API-level errors and model-capability-dependent agent errors are
+    cascadeable.  Structural agent errors (budget, idle, exit) are not. *)
+
+(** {1 Error enrichment} *)
+
+val enrich_sdk_error :
+  cascade_name:string ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  Oas.Error.sdk_error -> Oas.Error.sdk_error
+(** Enrich an SDK error with provider-specific diagnostic hints
+    (e.g. Moonshot auth, OpenAI-compat 404). *)
+
+(** {1 CLI-wrapped error pattern classification} *)
+
+val message_looks_like_cli_wrapped_hard_quota : string -> bool
+(** Detect hard-quota indicators in CLI-wrapped error messages. *)
+
+val message_looks_like_cli_wrapped_max_turns : string -> bool
+(** Detect max-turns indicators in CLI-wrapped error messages. *)
+
+val message_looks_like_resumable_cli_session : string -> bool
+(** Detect resumable-session indicators in CLI-wrapped error messages. *)
+
+val cli_wrapped_hard_quota_indicators : string list
+(** List of substring indicators for CLI-wrapped hard quota. *)
+
+val cli_wrapped_max_turns_indicators : string list
+(** List of substring indicators for CLI-wrapped max turns. *)
+
+(** {1 Resumable CLI session helpers} *)
+
+val resumable_cli_session_detail : string -> string
+
+val resumable_cli_session_exit_code : string -> int option
+
+val exit_code_of_message : string -> int option
+(** Extract an exit code from a CLI error message string. *)
+
+val retry_message_looks_like_not_found : string -> bool
+(** Detect "not found" / 404 patterns in retry error messages. *)
+
+(** {1 SDK error predicates} *)
+
+val sdk_error_to_resumable_cli_session :
+  cascade_name:string -> Oas.Error.sdk_error -> Oas.Error.sdk_error option
+(** If the error looks like a resumable CLI session, convert it into the
+    structured [Resumable_cli_session] form. *)
+
+val sdk_error_is_resumable_cli_session : Oas.Error.sdk_error -> bool
+
+val sdk_error_is_hard_quota : Oas.Error.sdk_error -> bool
+(** [true] when the error represents a hard usage quota that will not
+    recover within the cascade turn budget. *)
+
+val sdk_error_soft_rate_limited :
+  Oas.Error.sdk_error -> float option option
+(** [Some (Some retry_after)] for non-quota 429 responses with a parsed
+    [retry_after].  [Some None] when [retry_after] is absent.
+    [None] for non-429 or hard-quota-429 errors. *)
+
+val sdk_error_is_max_turns_exceeded : Oas.Error.sdk_error -> bool
+
+(** {1 Moonshot / Kimi helpers} *)
+
+val is_moonshot_provider : Llm_provider.Provider_config.t -> bool
+
+val resolve_kimi_api_key_env_name : cascade_name:string -> string
+
+val moonshot_auth_hint_marker : string
+val openai_compat_not_found_hint_marker : string


### PR DESCRIPTION
## Summary
- Add .mli interface files for all 12 sub-modules extracted in PR #11996 god file decomposition
- Also adds oas_worker_named.mli (facade) which was missing before decomposition
- Reduces ratchet `keeper_mli_missing` from 12 to 0

## Files (13 total, +1177 lines)
**keeper/** (9): keeper_keepalive_signal, keeper_turn_slot, keeper_heartbeat_snapshot, keeper_heartbeat_loop, keeper_turn_helpers, keeper_turn_liveness, keeper_turn_cascade_budget, keeper_shell_bash, keeper_shell_ops
**oas/** (4): oas_worker_named (facade), oas_worker_named_cascade, oas_worker_named_error, oas_worker_named_fsm

## Verification
- `dune build @install` passes locally in worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)