### PR TITLE
fix(headless): drop dead eventModSet helper in keyboard-shortcuts

### DIFF
--- a/dashboard/design-system/headless-core/keyboard-shortcuts.ts
+++ b/dashboard/design-system/headless-core/keyboard-shortcuts.ts
@@ -91,27 +91,12 @@ function modKeyForPlatform(platform: Platform): 'meta' | 'ctrl' {
   return platform === 'mac' ? 'meta' : 'ctrl'
 }
 
-function eventModSet(event: ShortcutKeyEvent): ReadonlySet<Modifier> {
-  const out = new Set<Modifier>()
-  if (event.metaKey === true) out.add('Mod')
-  if (event.ctrlKey === true) {
-    // ctrlKey on mac is Ctrl, not Mod. On other platforms it is Mod.
-    // We can't infer platform from event alone; assume both — chord
-    // matching below normalizes Mod against the active platform.
-    out.add('Ctrl')
-  }
-  if (event.shiftKey === true) out.add('Shift')
-  if (event.altKey === true) out.add('Alt')
-  return out
-}
-
 function chordMatches(
   chord: Chord,
   event: ShortcutKeyEvent,
   platform: Platform,
 ): boolean {
   if (chord.key.toLowerCase() !== event.key.toLowerCase()) return false
-  const eventMods = eventModSet(event)
   const wantsMod = chord.modifiers.includes('Mod')
   const wantsShift = chord.modifiers.includes('Shift')
   const wantsAlt = chord.modifiers.includes('Alt')


### PR DESCRIPTION
## Summary

Follow-up to #12000 (RFC 0012 KeyboardShortcuts, merged).

The merged PR contained a stranded \`eventModSet\` helper and an unused \`eventMods\` local inside \`chordMatches\`. The chord matcher was rewritten earlier to query \`event.metaKey / ctrlKey / shiftKey / altKey\` directly per RFC 0012 §5 exact-match policy, but the helper and its caller were never cleaned up.

\`tsc --noEmit\` fails with **TS6133** on both:

\`\`\`
design-system/headless-core/keyboard-shortcuts.ts(94,10): error TS6133: 'eventModSet' is declared but its value is never read.
design-system/headless-core/keyboard-shortcuts.ts(114,9): error TS6133: 'eventMods' is declared but its value is never read.
\`\`\`

This wasn't caught in #12000's CI because admin-merge bypassed the Dashboard \`typecheck\` step. Subsequent PRs whose Build/Test reads main now fail.

## What's in

- \`dashboard/design-system/headless-core/keyboard-shortcuts.ts\` — delete \`eventModSet\` and the unused \`eventMods\` local. No behavior change (the values were never read).

## Verification

\`\`\`
pnpm typecheck     # clean
pnpm test design-system/headless-core/keyboard-shortcuts
# Test Files 1 passed (1)
# Tests 19 passed (19)
\`\`\`

## Why now

Unblocks #12008 Menu and #12018 Toolbar — both currently mergeable but wait on a clean main typecheck baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)