### PR TITLE
fix(spec): add CHECK_DEADLOCK FALSE to multimodal cfgs (#12017 main blocker)

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-04-29T10:52:06Z (HEAD: 8a09618502)
+Generated: 2026-04-29T14:02:34Z (HEAD: 851155b376)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -13,12 +13,12 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | Metric | Value |
 |--------|-------|
-| Total .tla files | 81 |
-| Manual specs | 81 |
+| Total .tla files | 83 |
+| Manual specs | 83 |
 | TTrace (auto-generated) | 0 |
 | Directories | 17 |
-| Total .cfg files | 154 |
-| Buggy .cfg (bug-model pair) | 70 |
+| Total .cfg files | 158 |
+| Buggy .cfg (bug-model pair) | 72 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`).
 
@@ -43,11 +43,13 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | AutonomousLoop.tla | AutonomousLoop | manual | 1 | 0 | clean={inv:TypeOK, inv:MetaPersistedAfterTick, inv:TickOnlyDuringRunning} | 2026-04-29 |
 | AutonomousPhase.tla | AutonomousPhase | manual | 1 | 0 | clean={inv:TypeOK, inv:StartedAtIdle, inv:CurrentMatchesHead, inv:OnlyLegalTransitions} | 2026-04-29 |
 
-### specs/boundary (15 specs)
+### specs/boundary (17 specs)
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Last Modified |
 |------|--------|------|-----|-------|-------------------------|---------------|
 | AuditLog.tla | AuditLog | manual | 2 | 1 | clean={inv:TypeOK, inv:CacheConsistency} buggy={inv:CacheConsistency} | 2026-04-29 |
+| AuditLogAppendOrder.tla | AuditLogAppendOrder | manual | 2 | 1 | clean={inv:TypeOK, inv:MutexExclusion} buggy={inv:MutexExclusion} | 2026-04-29 |
+| AuditLogDurableBeforeAck.tla | AuditLogDurableBeforeAck | manual | 2 | 1 | clean={inv:TypeOK, inv:Durability} buggy={inv:Durability} | 2026-04-29 |
 | Bounded.tla | Bounded | manual | 2 | 1 | clean={inv:TypeOK, inv:Termination, inv:TokenBudget} buggy={inv:Termination, inv:TokenBudget} | 2026-04-28 |
 | Cancellation.tla | Cancellation | manual | 2 | 1 | clean={inv:TypeOK, inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} buggy={inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} | 2026-04-28 |
 | CascadeKeeperRecovery.tla | CascadeKeeperRecovery | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 2026-04-16 |

--- a/specs/multimodal/MultimodalArtifact.cfg
+++ b/specs/multimodal/MultimodalArtifact.cfg
@@ -10,3 +10,6 @@ INVARIANTS
     DAGRefIntegrity
     NoSelfLoops
     ProvenanceOriginsLive
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/multimodal/MultimodalHydrator.cfg
+++ b/specs/multimodal/MultimodalHydrator.cfg
@@ -12,3 +12,6 @@ INVARIANTS
     NoSelfLoop
     NoCycleBounded
     DedupeIdempotent
+
+CHECK_DEADLOCK
+    FALSE


### PR DESCRIPTION
## 배경

#12017 main blocker fix. `MultimodalArtifact.cfg` + `MultimodalHydrator.cfg` 가 CI 의 `make check-clean` 에서 `Error: Deadlock reached` 로 실패해 `TLA+ Model Checking` required check 를 RED 로 만들고 있음.

## 진단

CI 와 동일 flag (`-Xmx2g -Dtlc2.TLC.ide=Github`) 로 로컬 재현:

```
Error: Deadlock reached.
The behavior up to this point is:
State 1: <Initial predicate>
...
State 5: <AddEdge(a1,a2)> -> dag = {<<a1,a2>>, <<a2,a1>>}
```

근본 원인: bounded `ArtifactIds = {a1, a2}` 에서 `CreateArtifact` (2회) + `AddEdge` (2 distinct ordered pair non-self) 모두 소진 후 더 이상 enabled action 없음 → TLC 의 default deadlock check 가 trigger.

invariant 위반이 아님. 종래 trace 만 보고 cycle 형성을 invariant violation 으로 오해하기 쉬웠음 (#12017 issue 본문 권장 옵션 A/B/C 모두 acyclicity 가정한 잘못된 방향).

## 수정

두 cfg 에 `CHECK_DEADLOCK FALSE` 추가:

```
INVARIANTS
    ...

CHECK_DEADLOCK
    FALSE
```

기존 spec 패턴과 일치 — `specs/boundary/AuditLog*.cfg`, `specs/boundary/AuditLogAppendOrder.cfg`, `specs/boundary/AuditLogDurableBeforeAck.cfg` 등 finite-action spec 들이 같은 declaration 사용.

## 검증 (로컬, CI flag)

```bash
java -XX:+UseParallelGC -Xmx2g -Dtlc2.TLC.ide=Github \
  -cp tla2tools-1.8.0.jar tlc2.TLC \
  -workers auto -cleanup -config <cfg> <tla>
```

| Spec | 상태 | states |
|------|------|--------|
| MultimodalArtifact | OK (no error) | 1753 distinct |
| MultimodalHydrator | OK (no error) | 25 distinct |

## 영향

- `TLA+ Model Checking` required check GREEN 회복 → 후속 PR `CI Gate` 자연 unblock
- Spec 의도 변경 없음 (invariant 동일)
- Spec quality 회복: clean variant 가 자기 모델에서 PASS

## Cross-link

- #12017 (main blocker issue, 본 PR 이 close)
- PR #11849 (MultimodalArtifact 도입)
- PR #11959 (MultimodalHydrator 도입)
- Pattern reference: 본 세션 PR #11960/#11982/#11997 (audit_log 3-phase) — 같은 `CHECK_DEADLOCK FALSE` 사용

Closes #12017.
