### PR TITLE
fix(spec): keep multimodal DAG clean models acyclic

### DIFF
--- a/scripts/gen-tla-index.sh
+++ b/scripts/gen-tla-index.sh
@@ -151,11 +151,12 @@ while IFS= read -r tla; do
   done < <(find "$dir" -maxdepth 1 -type f -name "${base}-*.cfg" 2>/dev/null | sort)
 
   # Aggregate cfg invariants.
-  cfg_count=${#cfgs[@]}
-  TOTAL_CFG=$((TOTAL_CFG + cfg_count))
+  cfg_count=0
   buggy_count=0
   inv_summary=""
-  for c in "${cfgs[@]}"; do
+  for c in "${cfgs[@]:-}"; do
+    [[ -z "$c" ]] && continue
+    cfg_count=$((cfg_count + 1))
     cb="$(basename "$c" .cfg)"
     if [[ "$cb" == *-buggy* ]]; then
       buggy_count=$((buggy_count + 1))
@@ -167,6 +168,7 @@ while IFS= read -r tla; do
       inv_summary+="${label}={${inv}} "
     fi
   done
+  TOTAL_CFG=$((TOTAL_CFG + cfg_count))
   TOTAL_CFG_BUGGY=$((TOTAL_CFG_BUGGY + buggy_count))
   inv_summary="${inv_summary% }"
   [[ -z "$inv_summary" ]] && inv_summary="-"

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -149,7 +149,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Last Modified |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| MultimodalArtifact.tla | MultimodalArtifact | manual | 1 | 0 | clean={inv:TypeOK, inv:ArtifactIdMatchesKey, inv:DAGRefIntegrity, inv:NoSelfLoops, inv:ProvenanceOriginsLive} | 2026-04-29 |
+| MultimodalArtifact.tla | MultimodalArtifact | manual | 1 | 0 | clean={inv:TypeOK, inv:ArtifactIdMatchesKey, inv:DAGRefIntegrity, inv:NoSelfLoops, inv:DAGAcyclic, inv:ProvenanceOriginsLive} | 2026-04-29 |
 | MultimodalHydrator.tla | MultimodalHydrator | manual | 1 | 0 | clean={inv:TypeOK, inv:NoSelfLoop, inv:NoCycleBounded, inv:DedupeIdempotent} | 2026-04-29 |
 
 ### specs/resilience (2 specs)

--- a/specs/multimodal/MultimodalArtifact.cfg
+++ b/specs/multimodal/MultimodalArtifact.cfg
@@ -9,4 +9,5 @@ INVARIANTS
     ArtifactIdMatchesKey
     DAGRefIntegrity
     NoSelfLoops
+    DAGAcyclic
     ProvenanceOriginsLive

--- a/specs/multimodal/MultimodalArtifact.tla
+++ b/specs/multimodal/MultimodalArtifact.tla
@@ -104,6 +104,32 @@ DAGRefIntegrity ==
 NoSelfLoops ==
     \A id \in ArtifactIds : <<id, id>> \notin dag
 
+\* Reachability in the bounded TLC model.  The cfg currently uses two
+\* artifact ids; four hops leaves headroom for small follow-up cfgs
+\* without introducing a recursive transitive-closure operator.
+Reaches1In(edge_set, a, b) == <<a, b>> \in edge_set
+Reaches2In(edge_set, a, b) == \E m \in ArtifactIds :
+    <<a, m>> \in edge_set /\ <<m, b>> \in edge_set
+Reaches3In(edge_set, a, b) == \E m1, m2 \in ArtifactIds :
+    <<a, m1>> \in edge_set /\
+    <<m1, m2>> \in edge_set /\
+    <<m2, b>> \in edge_set
+Reaches4In(edge_set, a, b) == \E m1, m2, m3 \in ArtifactIds :
+    /\ <<a, m1>> \in edge_set
+    /\ <<m1, m2>> \in edge_set
+    /\ <<m2, m3>> \in edge_set
+    /\ <<m3, b>> \in edge_set
+
+DAGAcyclicIn(edge_set) ==
+    \A id \in ArtifactIds :
+        /\ ~Reaches1In(edge_set, id, id)
+        /\ ~Reaches2In(edge_set, id, id)
+        /\ ~Reaches3In(edge_set, id, id)
+        /\ ~Reaches4In(edge_set, id, id)
+
+\* The provenance graph is a DAG, not just a graph without self-loops.
+DAGAcyclic == DAGAcyclicIn(dag)
+
 \* Provenance origin_artifact_ids must reference present artifacts.
 ProvenanceOriginsLive ==
     \A id \in ArtifactIds :
@@ -138,8 +164,25 @@ AddEdge(from_id, to_id) ==
     /\ artifacts[to_id].present
     /\ from_id # to_id
     /\ <<from_id, to_id>> \notin dag
+    /\ DAGAcyclicIn(dag \cup {<<from_id, to_id>>})
     /\ dag' = dag \cup {<<from_id, to_id>>}
     /\ UNCHANGED artifacts
+
+CanCreateArtifact ==
+    \E id \in ArtifactIds : ~artifacts[id].present
+
+CanAddEdge ==
+    \E from_id, to_id \in ArtifactIds :
+        /\ artifacts[from_id].present
+        /\ artifacts[to_id].present
+        /\ from_id # to_id
+        /\ <<from_id, to_id>> \notin dag
+        /\ DAGAcyclicIn(dag \cup {<<from_id, to_id>>})
+
+TerminalStutter ==
+    /\ ~CanCreateArtifact
+    /\ ~CanAddEdge
+    /\ UNCHANGED vars
 
 Next ==
     \/ \E id \in ArtifactIds, k \in Kinds, pk \in PayloadKinds,
@@ -147,6 +190,7 @@ Next ==
             CreateArtifact(id, k, pk, origins, p, t)
     \/ \E from_id \in ArtifactIds, to_id \in ArtifactIds :
             AddEdge(from_id, to_id)
+    \/ TerminalStutter
 
 Spec == Init /\ [][Next]_vars
 
@@ -154,6 +198,7 @@ THEOREM Spec => []TypeOK
 THEOREM Spec => []ArtifactIdMatchesKey
 THEOREM Spec => []DAGRefIntegrity
 THEOREM Spec => []NoSelfLoops
+THEOREM Spec => []DAGAcyclic
 THEOREM Spec => []ProvenanceOriginsLive
 
 ====

--- a/specs/multimodal/MultimodalHydrator.tla
+++ b/specs/multimodal/MultimodalHydrator.tla
@@ -38,26 +38,30 @@ NoSelfLoop ==
     \A e \in edges : e[1] /= e[2]
 
 \* Reachability via 1, 2, 3, ... step paths.
-Reaches1(a, b) == <<a, b>> \in edges
-Reaches2(a, b) == \E m \in Nodes :
-    <<a, m>> \in edges /\ <<m, b>> \in edges
-Reaches3(a, b) == \E m1, m2 \in Nodes :
-    <<a, m1>> \in edges /\ <<m1, m2>> \in edges /\ <<m2, b>> \in edges
-Reaches4(a, b) == \E m1, m2, m3 \in Nodes :
-    /\ <<a, m1>> \in edges
-    /\ <<m1, m2>> \in edges
-    /\ <<m2, m3>> \in edges
-    /\ <<m3, b>> \in edges
+Reaches1In(edge_set, a, b) == <<a, b>> \in edge_set
+Reaches2In(edge_set, a, b) == \E m \in Nodes :
+    <<a, m>> \in edge_set /\ <<m, b>> \in edge_set
+Reaches3In(edge_set, a, b) == \E m1, m2 \in Nodes :
+    <<a, m1>> \in edge_set /\
+    <<m1, m2>> \in edge_set /\
+    <<m2, b>> \in edge_set
+Reaches4In(edge_set, a, b) == \E m1, m2, m3 \in Nodes :
+    /\ <<a, m1>> \in edge_set
+    /\ <<m1, m2>> \in edge_set
+    /\ <<m2, m3>> \in edge_set
+    /\ <<m3, b>> \in edge_set
 
 \* No path from a back to itself within the bounded depth. With
 \* MaxEdges <= 3 and Cardinality(Nodes) <= 4 we cover all cycles
 \* expressible in the state space.
-NoCycleBounded ==
+NoCycleIn(edge_set) ==
     \A a \in Nodes :
-        ~ Reaches1(a, a) /\
-        ~ Reaches2(a, a) /\
-        ~ Reaches3(a, a) /\
-        ~ Reaches4(a, a)
+        /\ ~Reaches1In(edge_set, a, a)
+        /\ ~Reaches2In(edge_set, a, a)
+        /\ ~Reaches3In(edge_set, a, a)
+        /\ ~Reaches4In(edge_set, a, a)
+
+NoCycleBounded == NoCycleIn(edges)
 
 \* The DAG dedupe property: adding an existing edge is a no-op.
 \* edges is a set, so this is automatic in the model.
@@ -73,26 +77,26 @@ Init ==
 \* The hydrator's actual add_edge is more permissive (it would
 \* accept a self-loop if both endpoints exist), but the spec
 \* forbids them as an invariant — production code must reject.
-AddEdge(from_id, to_id) ==
+EdgeAllowed(edge_set, from_id, to_id) ==
     /\ from_id /= to_id
-    /\ <<from_id, to_id>> \notin edges
-    /\ \* no cycle introduced
-       LET edges_after == edges \cup { <<from_id, to_id>> }
-       IN \A a \in Nodes :
-            \* Re-evaluate Reaches with edges_after via inlined
-            \* expansion (1-3 hops since we bound Cardinality).
-            ~ (<<a, a>> \in edges_after)
-            /\ ~ (\E m \in Nodes :
-                   <<a, m>> \in edges_after /\
-                   <<m, a>> \in edges_after)
-            /\ ~ (\E m1, m2 \in Nodes :
-                   /\ <<a, m1>> \in edges_after
-                   /\ <<m1, m2>> \in edges_after
-                   /\ <<m2, a>> \in edges_after)
+    /\ <<from_id, to_id>> \notin edge_set
+    /\ Cardinality(edge_set) < MaxEdges
+    /\ NoCycleIn(edge_set \cup { <<from_id, to_id>> })
+
+AddEdge(from_id, to_id) ==
+    /\ EdgeAllowed(edges, from_id, to_id)
     /\ edges' = edges \cup { <<from_id, to_id>> }
 
+CanAddEdge ==
+    \E from_id, to_id \in Nodes : EdgeAllowed(edges, from_id, to_id)
+
+TerminalStutter ==
+    /\ ~CanAddEdge
+    /\ UNCHANGED edges
+
 Next ==
-    \E from_id, to_id \in Nodes : AddEdge(from_id, to_id)
+    \/ \E from_id, to_id \in Nodes : AddEdge(from_id, to_id)
+    \/ TerminalStutter
 
 Spec == Init /\ [][Next]_vars
 


### PR DESCRIPTION
## Summary

- Add bounded DAG acyclicity to `MultimodalArtifact` and block `AddEdge` transitions that would create a provenance cycle.
- Refactor `MultimodalHydrator` cycle checks to reuse `NoCycleIn`, cap `AddEdge` at `MaxEdges`, and add terminal stutter when no legal edge remains.
- Harden `scripts/gen-tla-index.sh` against empty cfg arrays under `set -u`, then update the multimodal index row for the new invariant.

## Product impact

This repairs issue #12017: clean multimodal TLA+ models no longer fail their own required model check. It restores the intended DAG contract and removes a main CI blocker for downstream PRs inheriting the TLA+ failure.

## Evidence

- `make -C specs TLA2TOOLS=/Users/dancer/me/tools/tla2tools.jar CLEAN_CFGS="./multimodal/MultimodalArtifact.cfg ./multimodal/MultimodalHydrator.cfg" check-clean`
- `bash -n scripts/gen-tla-index.sh`
- `scripts/gen-tla-index.sh > /tmp/masc-tla-index-12017-after-rebase.md`
- `git diff --check origin/main..HEAD`

## Review evidence

Focus on the bounded reachability model and terminal stutter semantics:

- `MultimodalArtifact` now rejects reverse edges that would create a cycle and exposes `DAGAcyclic` as a cfg invariant.
- `MultimodalHydrator` now treats the saturated DAG state as terminal instead of letting TLC report deadlock.
- The index generator change is intentionally narrow: empty cfg-backed specs no longer trip Bash nounset.

## Linked issue

Closes #12017
