### PR TITLE
feat(perf): cache hit/miss counters (PR-0.2.A)

### DIFF
--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -345,19 +345,27 @@ let get config ~key : (cache_entry option, string) result =
           | Some entry -> Some (legacy_path, entry, true)
           | None -> None
   in
+  (* PR-0.2.A: cache hit/miss observation only (no logic change). *)
+  let cache_label = [("cache", "eio")] in
   match located with
   | None ->
+    Prometheus.inc_counter Prometheus.metric_cache_misses_total
+      ~labels:cache_label ();
     (* Trigger batch eviction check even on miss *)
     let _evicted = maybe_evict_expired config in
     Ok None
   | Some (path, entry, from_legacy) ->
       try
         if is_expired entry then begin
+          Prometheus.inc_counter Prometheus.metric_cache_misses_total
+            ~labels:cache_label ();
           (* Auto-delete expired entries *)
           if remove_file_if_exists path then decrement_cached_entry_count ();
           let _evicted = maybe_evict_expired config in
           Ok None
         end else begin
+          Prometheus.inc_counter Prometheus.metric_cache_hits_total
+            ~labels:cache_label ();
           if from_legacy then maybe_migrate_legacy_entry config ~key entry;
           let _evicted = maybe_evict_expired config in
           Ok (Some entry)

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -130,6 +130,18 @@ let timeout_json ~key ~timeout_sec ~timeout_kind =
 let max_wait_sec = 130.0
 let wait_poll_interval_sec = 0.25
 
+(** PR-0.2.A: dashboard cache hit/miss observation labels.  Pure
+    instrumentation — never branches on these counters. *)
+let cache_metric_label = [("cache", "dashboard")]
+
+let inc_cache_hit () =
+  Prometheus.inc_counter Prometheus.metric_cache_hits_total
+    ~labels:cache_metric_label ()
+
+let inc_cache_miss () =
+  Prometheus.inc_counter Prometheus.metric_cache_misses_total
+    ~labels:cache_metric_label ()
+
 (** Eio path: per-key locking with stampede protection + stale-while-revalidate.
 
     Three cases on cache lookup:
@@ -186,12 +198,18 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
         (`Compute token, SMap.add key (Computing { token; started_at = now (); stale = None }) map)
     ) in
     match action with
-    | `Hit v -> v
+    | `Hit v ->
+      (* PR-0.2.A: cache hit observation (no logic change). *)
+      inc_cache_hit ();
+      v
     | `Timed_out -> raise (Compute_timeout (key, true))
     | `Wait token ->
       Time_compat.sleep wait_poll_interval_sec;
       try_get ~waited:(waited +. wait_poll_interval_sec) ~watching_token:(Some token)
     | `Stale (stale_value, token) ->
+      (* PR-0.2.A: stale-served-from-cache counts as a hit (caller gets
+         data without blocking on compute; bg recompute is incidental). *)
+      inc_cache_hit ();
       let do_bg_compute () =
         match compute () with
         | value ->
@@ -253,6 +271,8 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
            do_bg_compute ());
       stale_value
     | `Compute token ->
+      (* PR-0.2.A: cache miss observation (this fiber must compute). *)
+      inc_cache_miss ();
       let result_ref = ref None in
       let run_compute () =
         try result_ref := Some (Ok (compute ()))
@@ -348,8 +368,13 @@ let get_or_compute_simple key ~ttl compute =
       let token = next_token () in
       (`Compute token, SMap.add key (Computing { token; started_at = ts; stale = None }) map)
   ) with
-  | `Hit v -> v
+  | `Hit v ->
+    (* PR-0.2.A: cache hit observation. *)
+    inc_cache_hit ();
+    v
   | `Compute token ->
+    (* PR-0.2.A: cache miss observation. *)
+    inc_cache_miss ();
     (match compute () with
      | value ->
        let ts_after = now () in

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -522,6 +522,13 @@ let metric_ws_parse_cache_hits = "masc_ws_parse_cache_hits_total"
 let metric_ws_parse_cache_misses = "masc_ws_parse_cache_misses_total"
 let metric_ws_bytes_cache_hits = "masc_ws_bytes_cache_hits_total"
 let metric_ws_bytes_cache_misses = "masc_ws_bytes_cache_misses_total"
+(* PR-0.2.A (RFC 2026-04-masc-ide-strategy): generic cache hit/miss
+   counters, labelled by [cache] = "eio" | "dashboard".  Distinct from
+   the WS-specific parse/bytes cache counters above; these track the
+   filesystem-backed [Cache_eio] and the dashboard in-memory
+   stale-while-revalidate cache. *)
+let metric_cache_hits_total = "masc_cache_hits_total"
+let metric_cache_misses_total = "masc_cache_misses_total"
 let metric_ws_client_buffered_bytes = "masc_ws_client_buffered_bytes"
 let metric_ws_client_acks = "masc_ws_client_acks_total"
 let metric_ws_throttled_deliveries = "masc_ws_throttled_deliveries_total"
@@ -1200,6 +1207,16 @@ let init () =
     Counter;
   add metric_ws_bytes_cache_misses
     "WS raw-SSE-forward Bytes cache misses (fresh allocation required)"
+    Counter;
+  (* PR-0.2.A: generic cache hit/miss counters.  Labels: cache=eio|dashboard.
+     [eio] tracks Cache_eio.get; [dashboard] tracks Dashboard_cache.get_or_compute.
+     Per-label series are auto-created on first inc_counter call. *)
+  add metric_cache_hits_total
+    "Cache lookup hits. Labels: cache=eio|dashboard. \
+     hit_ratio = hits / (hits + misses) per cache label."
+    Counter;
+  add metric_cache_misses_total
+    "Cache lookup misses (compute required). Labels: cache=eio|dashboard."
     Counter;
   register_histogram ~name:metric_ws_client_buffered_bytes
     ~help:"Dashboard client WebSocket.bufferedAmount reported on each ack" ();

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -456,6 +456,19 @@ val metric_ws_parse_cache_hits : string
 val metric_ws_parse_cache_misses : string
 val metric_ws_bytes_cache_hits : string
 val metric_ws_bytes_cache_misses : string
+
+(** PR-0.2.A (RFC 2026-04-masc-ide-strategy): cache lookup hit/miss
+    counters. Labels: [cache] with values
+    - ["eio"]      — [Cache_eio.get] (filesystem-backed key/value cache).
+    - ["dashboard"] — [Dashboard_cache.get_or_compute] (in-memory
+                     stale-while-revalidate cache for dashboard responses).
+    Operator query: [hit_ratio = hits / (hits + misses)] per [cache] label
+    quantifies cache effectiveness. Pure observation — registering or
+    incrementing these counters never changes cache logic. *)
+val metric_cache_hits_total : string
+
+val metric_cache_misses_total : string
+(** Companion to {!metric_cache_hits_total}; same [cache] label values. *)
 val metric_ws_client_buffered_bytes : string
 val metric_ws_client_acks : string
 val metric_ws_throttled_deliveries : string


### PR DESCRIPTION
## Summary
- Add Prometheus counters: masc_cache_hits_total, masc_cache_misses_total
- Labels: cache=eio | dashboard
- Logic 영향: 0 (관측만)
- RFC: knowledge/research/2026-04-masc-ide-strategy/IMPLEMENTATION-PLAN.md PR-0.2.A

## Test plan
- [x] dune build lib/ 통과
- [ ] curl /metrics 출력에서 masc_cache_*_total 시리즈 확인