### PR TITLE
fix(keeper): reserve fallback budget for OAS timeouts

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -112,6 +112,10 @@ let oas_timeout_guard_sec = 15.0
 
 let min_oas_timeout_budget_sec = 15.0
 
+(* Profiles with a declared fallback must not spend the whole turn on the
+   first provider. Keep half of the usable budget for the degraded retry. *)
+let degraded_retry_budget_reserve_fraction = 0.5
+
 type oas_timeout_budget_resolution = {
   effective_timeout_sec : float;
   adaptive_timeout_sec : float;
@@ -136,6 +140,7 @@ let oas_timeout_budget_resolution_to_yojson
     ]
 
 let resolve_bounded_oas_timeout_budget_with_turn_budget
+    ~(reserve_degraded_retry_budget : bool)
     ~(estimated_input_tokens : int) ~(max_turns : int)
     ~(remaining_turn_budget_s : float) : oas_timeout_budget_resolution option =
   let usable_budget = remaining_turn_budget_s -. oas_timeout_guard_sec in
@@ -148,17 +153,43 @@ let resolve_bounded_oas_timeout_budget_with_turn_budget
       .oas_timeout_for_estimated_input_tokens_with_turn_budget
         ~estimated_input_tokens ~max_turns
     in
-    let effective_timeout_sec =
+    let turn_capped_timeout_sec =
       Float.min adaptive_timeout_sec usable_budget
     in
+    let retry_capped_timeout_sec =
+      if reserve_degraded_retry_budget then
+        let retry_reserved_cap =
+          usable_budget *. degraded_retry_budget_reserve_fraction
+        in
+        if retry_reserved_cap >= min_oas_timeout_budget_sec
+        then Float.min turn_capped_timeout_sec retry_reserved_cap
+        else turn_capped_timeout_sec
+      else turn_capped_timeout_sec
+    in
+    let effective_timeout_sec = retry_capped_timeout_sec in
+    let capped_by_turn_budget =
+      turn_capped_timeout_sec < adaptive_timeout_sec
+    in
+    let capped_by_degraded_retry_budget =
+      retry_capped_timeout_sec < turn_capped_timeout_sec
+    in
     let source =
-      match runtime.oas_timeout_override_sec.value with
-      | Some _ when effective_timeout_sec < adaptive_timeout_sec ->
+      match
+        ( runtime.oas_timeout_override_sec.value,
+          capped_by_turn_budget,
+          capped_by_degraded_retry_budget )
+      with
+      | Some _, _, true -> "override_capped_by_degraded_retry_budget"
+      | Some _, true, false ->
           "override_capped_by_turn_budget"
-      | Some _ -> "override"
-      | None when effective_timeout_sec < adaptive_timeout_sec ->
+      | Some _, false, false -> "override"
+      | None, true, true ->
+          "adaptive_estimated_input_tokens_capped_by_turn_budget_and_degraded_retry_budget"
+      | None, false, true ->
+          "adaptive_estimated_input_tokens_capped_by_degraded_retry_budget"
+      | None, true, false ->
           "adaptive_estimated_input_tokens_capped_by_turn_budget"
-      | None -> "adaptive_estimated_input_tokens"
+      | None, false, false -> "adaptive_estimated_input_tokens"
     in
     Some
       {
@@ -177,7 +208,8 @@ let bounded_oas_timeout_for_turn_budget_with_turn_budget
   Option.map
     (fun (budget : oas_timeout_budget_resolution) -> budget.effective_timeout_sec)
     (resolve_bounded_oas_timeout_budget_with_turn_budget
-       ~estimated_input_tokens ~max_turns ~remaining_turn_budget_s)
+       ~reserve_degraded_retry_budget:false ~estimated_input_tokens ~max_turns
+       ~remaining_turn_budget_s)
 
 let bounded_oas_timeout_for_turn_budget ~(estimated_input_tokens : int)
     ~(remaining_turn_budget_s : float) : float option =
@@ -189,7 +221,8 @@ let oas_retry_budget_available_for_turn ~(estimated_input_tokens : int)
     ~(max_turns : int) ~(remaining_turn_budget_s : float) : bool =
   Option.is_some
     (resolve_bounded_oas_timeout_budget_with_turn_budget
-       ~estimated_input_tokens ~max_turns ~remaining_turn_budget_s)
+       ~reserve_degraded_retry_budget:false ~estimated_input_tokens ~max_turns
+       ~remaining_turn_budget_s)
 
 let reclassify_oas_timeout_for_attempt
     ~(timeout_budget : oas_timeout_budget_resolution option)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -819,8 +819,18 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     keeper_profile
             in
             let attempt_result =
+              let reserve_degraded_retry_budget =
+                match
+                  Keeper_cascade_profile.fallback_cascade_for
+                    execution.cascade_name
+                with
+                | Some fallback_cascade ->
+                    not (String.equal fallback_cascade execution.cascade_name)
+                | None -> false
+              in
               match
                 resolve_bounded_oas_timeout_budget_with_turn_budget
+                  ~reserve_degraded_retry_budget
                   ~max_turns
                   ~estimated_input_tokens:prompt_timeout_estimate_tokens
                   ~remaining_turn_budget_s:(remaining_turn_budget_s ())

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -50,6 +50,7 @@ type oas_timeout_budget_resolution = {
 }
 
 val resolve_bounded_oas_timeout_budget_with_turn_budget :
+  reserve_degraded_retry_budget:bool ->
   estimated_input_tokens:int ->
   max_turns:int ->
   remaining_turn_budget_s:float ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4596,11 +4596,11 @@ let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
       ~estimated_input_tokens ~remaining_turn_budget_s:1200.0
   with
   | Some timeout_s ->
-      (* The bounded variant subtracts a ~30s finalization guard
+      (* The bounded variant subtracts a 15s finalization guard
          from [remaining_turn_budget_s] and caps at the adaptive
          raw.  With #10008 fm2 the adaptive raw equals
          [turn_timeout_sec] (1200), so the finalization guard path
-         dominates: returned value is [remaining - 30]. *)
+         dominates: returned value is [remaining - 15]. *)
       check bool "bounded timeout at or below adaptive raw"
         true (timeout_s <= expected);
       check bool "bounded leaves positive finalization guard"
@@ -4631,7 +4631,8 @@ let test_bounded_oas_timeout_caps_to_remaining_turn_budget () =
       ~estimated_input_tokens:2_000 ~remaining_turn_budget_s:235.7
   with
   | Some timeout_s ->
-      check (float 0.01) "remaining budget cap leaves finalization guard" 205.7 timeout_s
+      check (float 0.01) "remaining budget cap leaves finalization guard"
+        220.7 timeout_s
   | None -> fail "expected bounded timeout"
 
 let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
@@ -4650,7 +4651,7 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
   with
   | Some timeout_s ->
       (* #10008 fm2: raw formula no longer depends on max_turns;
-         bounded variant still subtracts the ~30s finalization
+         bounded variant still subtracts the 15s finalization
          guard from [remaining_turn_budget_s] and caps at the
          raw.  Verify the cap was applied ([<=] raw) and the
          guard reserved a positive amount. *)
@@ -4658,6 +4659,23 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
         true (timeout_s <= raw);
       check bool "finalization guard reserves positive delta"
         true (timeout_s <= 1200.0 && timeout_s > 1100.0)
+  | None -> fail "expected bounded timeout"
+
+let test_bounded_oas_timeout_reserves_degraded_retry_budget () =
+  match
+    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~reserve_degraded_retry_budget:true ~estimated_input_tokens:2_000
+      ~max_turns:4 ~remaining_turn_budget_s:1200.0
+  with
+  | Some budget ->
+      check (float 0.01)
+        "first attempt keeps half the usable turn budget for fallback"
+        592.5 budget.effective_timeout_sec;
+      check (float 0.01) "remaining budget records post-guard usable budget"
+        1185.0 budget.remaining_turn_budget_sec;
+      check string "source records retry reserve"
+        "adaptive_estimated_input_tokens_capped_by_turn_budget_and_degraded_retry_budget"
+        budget.source
   | None -> fail "expected bounded timeout"
 
 let test_bounded_oas_timeout_refuses_too_little_budget () =
@@ -4672,7 +4690,8 @@ let test_oas_timeout_reclassifies_only_current_attempt_budget () =
   in
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
-      ~estimated_input_tokens:2_000 ~max_turns:4
+      ~reserve_degraded_retry_budget:false ~estimated_input_tokens:2_000
+      ~max_turns:4
       ~remaining_turn_budget_s:1200.0
   with
   | None -> fail "expected timeout budget"
@@ -6624,6 +6643,8 @@ let () =
             test_bounded_oas_timeout_caps_to_remaining_turn_budget;
           test_case "bounded OAS timeout respects channel turn budget override" `Quick
             test_bounded_oas_timeout_uses_channel_turn_budget_override;
+          test_case "bounded OAS timeout reserves degraded retry budget" `Quick
+            test_bounded_oas_timeout_reserves_degraded_retry_budget;
           test_case "bounded OAS timeout refuses too little remaining budget" `Quick
             test_bounded_oas_timeout_refuses_too_little_budget;
           test_case "OAS timeout classification uses current attempt budget" `Quick


### PR DESCRIPTION
## Summary
- reserve half of usable keeper turn budget for degraded retry when a cascade profile declares a fallback cascade
- keep existing budget behavior for callers that do not opt into degraded-retry reservation
- update keeper timeout tests for the current 15s guard and add fallback-budget coverage

## Operator impact
This prevents local fallback profiles such as local_qwen3_27b_only from spending almost the entire 1800s turn budget on the first Ollama provider. On oas_timeout_budget, the keeper should now have enough remaining wall-clock budget to rotate to the declared fallback cascade instead of ending the cycle exhausted.

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_keeper_unified.exe
- _build/default/test/test_keeper_unified.exe test --show-errors transient_network_error 44
- _build/default/test/test_keeper_unified.exe test --compact --show-errors transient_network_error 40-49