### PR TITLE
docs(legal): LICENSE audit + ENTERPRISE separation candidates

### DIFF
--- a/docs/legal/ENTERPRISE-CANDIDATES.md
+++ b/docs/legal/ENTERPRISE-CANDIDATES.md
@@ -1,0 +1,119 @@
+# ENTERPRISE Edition — Module Separation Candidates
+
+> Status: Candidate identification (코드 변경 0). **본 문서는 분리 결정이 아니다.**
+> Author: Vincent (jeong-sik)
+> Created: 2026-04-29
+> Related: `docs/legal/LICENSE-AUDIT-2026-04.md`, IMPLEMENTATION-QUEUE Q-P0-5
+> Source 자료: 외부 multi-agent IDE 분석 (`multiagent-ide-deep-analysis.md` Track D §1, line 3294-3458) Open Core 권고
+
+---
+
+## 1. Purpose
+
+Open Core 분리 시 EE(Enterprise Edition) tier로 이동 가능한 모듈을 *식별*한다. 본 문서는 식별만 다루며, 분리 결정은 별도 (CLA 선행 + 모든 contributor 동의 + 비즈니스 결정 후).
+
+분리 *반대 의견*도 §4에 기록한다 — anti-hype: 분리는 항상 옳지 않다.
+
+---
+
+## 2. Candidate Modules (식별)
+
+### 2.1 Auth Suite
+
+| 모듈 | EE 적합성 근거 |
+|---|---|
+| `lib/auth.ml` + `.mli` | 인증 핵심. EE는 *확장*만 (SAML2/SCIM/SSO) |
+| `lib/auth_doctor.ml` + `.mli` | auth 진단 도구. compliance 시나리오에서 EE 차별화 가능 |
+| `lib/auth_login.ml` + `.mli` | login 흐름 |
+| `lib/auth_resolve.ml` + `.mli` | identity 해소 |
+| `lib/auth_strict_mode.ml` + `.mli` | strict mode (compliance) — Enterprise compliance 요구에 부합 |
+| `lib/auth_error_kind.ml` + `.mli` | error variant (분리 무관, OSS 유지 권고) |
+
+**평가**:
+- ✅ Enterprise 차별화 가능 (SSO/SAML2/SCIM/OIDC 확장은 typical EE)
+- ⚠️ 핵심 기능 — Open Core 사용자가 인증 *없이* 동작해야 함 → core auth는 OSS에 *유지*, EE는 *추가 확장만*
+- 다음 작업: 코드 sweep으로 *core*(필수)와 *enterprise*(SAML2/SCIM/audit) 경계 식별
+
+**분리 반대 의견**: auth는 보안 핵심. EE 분리 시 OSS 사용자의 *security audit* 가능 영역이 줄어듦 → 신뢰 저하 위험. *추가 확장만 EE*로 한정.
+
+### 2.2 Sandbox
+
+| 모듈 | 근거 |
+|---|---|
+| `lib/task_sandbox.ml` + `.mli` | task 격리. gVisor/Firecracker 도입 시 EE 후보 (외부 분석 §1, line 3437) |
+
+**평가**:
+- ✅ Enterprise 차별화 (강한 격리 = compliance 요구)
+- ❌ 현재 구현이 *Tier 1 부분 구현* (ch1 S6: "sandbox path leak 잔존, gVisor/Firecracker rg 0 hits")
+- → EE 분리 *prerequisite 미충족*. sandbox 완성 후 결정.
+
+### 2.3 Credential Provider
+
+| 모듈 | 근거 |
+|---|---|
+| `lib/credential_provider/*` (RFC 0008 기반) | 자격 증명 수명주기. 외부 IdP 연동 (Okta, Auth0) EE 후보 |
+
+**평가**:
+- ⚠️ RFC 0008 진행 중 — spec 안정화 prerequisite
+- 분리 결정은 RFC 0008 머지 + production usage 확보 후
+
+### 2.4 향후 후보 (현재 미구현)
+
+| 영역 | 외부 분석 인용 | 구현 여부 |
+|---|---|---|
+| SSO / SAML2 / OIDC 확장 | line 3437-3458 (SOC2/GDPR DPO) | 미구현 |
+| Multi-tenancy / Tenant isolation | line 3326 Enterprise Tier | 미구현 |
+| Audit log + compliance reporting | line 3437-3458 | 부분 (`metric_*` 카운터 일부) |
+| Quantum-resistant encryption (Ed25519 → CRYSTALS-Kyber) | line 3431+ | 미구현 |
+| Bring-Your-Own-Agent (BYOA) marketplace | line 3424-3428 | 미구현 |
+
+위 5건은 *모두 미구현 영역* — EE 후보 식별이라기보다 *EE 차별화 후보 영역*. 구현 자체가 prerequisite.
+
+---
+
+## 3. 분리 의사결정 Prerequisites
+
+분리 PR을 만들기 전 만족해야 할 조건:
+
+- [ ] CLA / DCO 도입 (LICENSE-AUDIT §4)
+- [ ] 모든 contributor 동의 (git blame sweep + outreach)
+- [ ] 분리 후 OSS / EE 양쪽의 build/test 검증 인프라 (CI 분기, monorepo vs 별도 repo)
+- [ ] 비즈니스 결정 (Vincent 단독 또는 법인 전환 후)
+- [ ] EE 라이선스 모델 결정 (proprietary, AGPL, Apache 2.0 + commercial 듀얼, …)
+- [ ] 외부 의견 — 기존 contributor + early users 의견 수렴
+
+---
+
+## 4. 분리 반대 의견 (anti-hype)
+
+분리는 항상 옳지 않다. 다음 위험을 명시:
+
+1. **OSS 신뢰 저하**: 핵심 기능을 EE로 보내면 OSS 사용자가 "fully usable" 상태가 아님 → adoption 저하
+2. **유지비 분산**: monorepo vs 별도 repo 결정 따라 CI/test 비용 2배
+3. **Premature optimization**: 현재 12 keeper 환경에서 Enterprise tier 수요 검증 안 됨 → 시기상조
+4. **License 전환 cost**: MIT → Apache+Commercial 등 전환 시 모든 contributor 동의 필요 → 실패 시 forking 위험
+5. **External 분석의 시장 수치 신뢰도**: $526억 시장 (Insight 6) Confidence L — investor pitch 외 내부 결정에 사용 비권장 (Track D §4 참조)
+
+→ 결정: **본 cycle에서는 분리 결정 보류**. 식별만 진행. 6개월 후 (2026 Q4) 재평가 일정.
+
+---
+
+## 5. Open Questions
+
+- 분리 시 monorepo vs 별도 repo? (외부 분석 §1.2 Open Core, line 3300)
+- EE 코드의 publish 위치 (private GitHub org? GitLab? self-hosted?)
+- 분리 시 기존 contributor의 EE 코드 contribute 가능성 (CLA 동의 + access)
+- "free tier 3 agent / 100 credits" (line 3326-3327)와 OSS 무제한의 관계
+- BYOA(Bring Your Own Agent, line 3424) 도입 시 EE/OSS 경계
+
+---
+
+## 6. References
+
+- 외부 분석: `multiagent-ide-deep-analysis.md` Track D §1 (line 3294-3458), §4 (Insight 6)
+- LICENSE-AUDIT: `docs/legal/LICENSE-AUDIT-2026-04.md` §4 (CLA prerequisite)
+- IMPLEMENTATION-QUEUE: Q-P0-5
+- ch1 진단: `ch1_diagnosis_mapping.md` S6 (sandbox path leak)
+- RFC 0008: `docs/rfc/RFC-0008-credential-provider.md`
+
+*작성: 2026-04-29 / 분리 결정은 별도, 본 문서는 식별만*

--- a/docs/legal/LICENSE-AUDIT-2026-04.md
+++ b/docs/legal/LICENSE-AUDIT-2026-04.md
@@ -1,0 +1,93 @@
+# LICENSE Audit — 2026-04-29
+
+> Status: First-pass audit. Subsequent revisions track CLA, license header coverage, and dependency license drift.
+> Author: Vincent (jeong-sik)
+> Last verified: 2026-04-29
+> Source 자료: 외부 multi-agent IDE 분석(`multiagent-ide-deep-analysis.md` Track D §1, line 3294-3317) Open Core 권고
+
+---
+
+## 1. Current License State
+
+| 항목 | 상태 |
+|---|---|
+| Top-level `LICENSE` | **MIT License**, Copyright (c) 2024-2025 MASC Contributors |
+| `LICENSE.md` (markdown variant) | 부재 |
+| `ENTERPRISE.md` (top-level) | 부재 |
+| `docs/legal/` | 부재 → 본 PR로 신설 |
+| `CLA.md` / `DCO` / contributor agreement | **부재** |
+| SPDX header coverage | 미점검 (§2 후속 작업) |
+| 의존성 license 인벤토리 | 미점검 (§3 후속 작업) |
+
+**현 단계 결론**: license 텍스트 자체는 MIT으로 명확. Open Core / Enterprise Edition 분리(외부 분석 §1) 진입 전 prerequisite이 *contributor 동의 절차* + *header coverage 자동화* + *의존성 license 인벤토리* 3건 미충족.
+
+---
+
+## 2. License Header Coverage
+
+후속 작업 (별도 PR):
+
+```bash
+# 모든 OCaml 소스에 SPDX-License-Identifier 헤더 누락 여부 점검
+find lib bin specs -name '*.ml' -o -name '*.mli' | \
+  xargs grep -L 'SPDX-License-Identifier' | head -20
+```
+
+수동 점검은 sample 검사만 했고, 자동 sweep + ratchet 도입 후속 PR.
+
+---
+
+## 3. Third-party Dependencies (의존성 라이선스)
+
+후속 작업 (별도 PR):
+
+- `dune-project`의 `depends` 영역 enumerate (~30 packages)
+- `opam list --installed` + `opam show <pkg> | grep -i license` 자동 수집
+- license 호환성 매트릭스 (MIT/Apache 2.0/BSD/LGPL/AGPL 분류)
+- copyleft (LGPL/AGPL) 의존성 발견 시 별도 평가
+
+현재까지 spot-check (수동)로 발견된 license 종류:
+- MIT (대부분)
+- Apache 2.0 (`yojson`, `eio` 등 추정)
+- BSD (`menhir` 추정)
+
+자동 수집 후 본 문서 §3 갱신.
+
+---
+
+## 4. Contributor Agreement
+
+| 항목 | 상태 | 위험 |
+|---|---|---|
+| DCO | 부재 (`.github/CONTRIBUTING.md` 없음) | 향후 license 전환 시 *모든 contributor 개별 동의* 필요 |
+| CLA | 부재 | 동일 |
+| `git blame` contributor 수 | (미수집) | sweep 후 §4 갱신 |
+
+**권고**: contributor 수 증가 전 DCO 도입 (lightweight, CLA 대비 진입 장벽 낮음). Open Core 분리 시점에는 CLA 도입 검토.
+
+---
+
+## 5. Open Core 분리 후보
+
+별도 문서 `docs/legal/ENTERPRISE-CANDIDATES.md` 참조. 본 문서는 license 측면만 다룬다.
+
+---
+
+## 6. Action Items
+
+- [ ] **License header SPDX sweep** (별도 PR) — `find ... -name '*.ml' | xargs grep -L 'SPDX-License-Identifier'` ratchet 도입
+- [ ] **opam 의존성 license 수집** (별도 PR) — `opam show <pkg>` 자동 enumerate, 호환성 매트릭스
+- [ ] **DCO 도입 결정** (별도 PR) — `.github/CONTRIBUTING.md` + DCO/CLA-bot 통합
+- [ ] **Contributor 식별** — `git log --format='%aE' | sort -u` + contact list
+- [ ] **EE 분리 결정** (사용자 결정 영역, prerequisite 충족 후)
+
+---
+
+## 7. References
+
+- `LICENSE` (top-level, MIT)
+- 외부 분석: `multiagent-ide-deep-analysis.md` (2026-04-29) Track D §1 (line 3294-3458)
+- IMPLEMENTATION-QUEUE: Q-P0-5 (research worktree)
+- 본 PR: `feature/license-audit-2026-04`
+
+*작성: 2026-04-29*


### PR DESCRIPTION
## Summary

First-pass legal review under the Open Core path proposed in the external multi-agent IDE analysis (2026-04-29 Track D §1). Two new docs added under ``docs/legal/``. Code: 0 files changed.

## Why now

External analysis recommends Open Core + 3-Tier billing (Free/Pro/Enterprise) as Phase 1+ product strategy. Before any license transition or module separation, three prerequisites must be in place:

- SPDX header sweep (currently absent)
- Dependency license inventory (currently spot-checked only)
- DCO/CLA + contributor consent surface (currently absent)

This PR introduces the audit doc that names those prerequisites explicitly, and a separate ``ENTERPRISE-CANDIDATES.md`` that identifies — but **does not decide** — which modules might move to an EE tier later.

## Scope

- ``docs/legal/LICENSE-AUDIT-2026-04.md`` — current LICENSE state (MIT confirmed) + missing artefacts + 5 follow-up actions
- ``docs/legal/ENTERPRISE-CANDIDATES.md`` — candidate modules (``auth.*``, ``task_sandbox``, ``credential_provider``) + 5 anti-hype counter-arguments + decision deferred to 2026 Q4

## Anti-hype guard

§4 of ``ENTERPRISE-CANDIDATES.md`` records explicit counter-arguments against separation: OSS trust degradation, premature optimisation under 12-keeper scale, license-transition contributor risk, and the external analysis's own market-size claim ($526B, Insight 6) being Confidence-L (single source). Decision is deferred to 2026 Q4 review.

## Test plan

- [ ] Doc review (no code changes to verify).
- [ ] Confirm path placement (``docs/legal/`` is new — keep here, or relocate to top-level ``ENTERPRISE.md``?).
- [ ] Cross-check candidate module list against in-flight RFC 0008 (credential provider) progress.

## Related

- RFC 0017 (PR #12026) — OCaml↔CRDT Boundary, sibling cycle output
- External analysis: ``multiagent-ide-deep-analysis.md`` Track D
- ch1 diagnostic: ``ch1_diagnosis_mapping.md`` S6 (sandbox path leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)