### PR TITLE
feat(multimodal): Tier K2 — Keeper_emitter + e2e pipeline (Cycle 27)

### DIFF
--- a/lib/multimodal/keeper_emitter.ml
+++ b/lib/multimodal/keeper_emitter.ml
@@ -1,0 +1,52 @@
+(* Keeper_emitter — see keeper_emitter.mli for design rationale. *)
+
+let multimodal_key = "multimodal_artifacts"
+
+let raw_artifact_to_json
+    ~(id : string)
+    ~(kind_tag : Artifact.kind_tag)
+    ~(payload_json : Yojson.Safe.t)
+    ~(metadata : Yojson.Safe.t) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("id", `String id);
+      ("kind_hint", `String (Artifact.kind_tag_to_string kind_tag));
+      ("payload_json", payload_json);
+      ("metadata", metadata);
+    ]
+
+let append_to_list
+    (existing : Yojson.Safe.t option)
+    (entry : Yojson.Safe.t) : Yojson.Safe.t =
+  match existing with
+  | Some (`List xs) -> `List (xs @ [ entry ])
+  | _ -> `List [ entry ]
+
+let emit
+    ~(working_context : Yojson.Safe.t option)
+    ~(id : string)
+    ~(kind_tag : Artifact.kind_tag)
+    ~(payload_json : Yojson.Safe.t)
+    ~(metadata : Yojson.Safe.t) : Yojson.Safe.t option =
+  let entry = raw_artifact_to_json ~id ~kind_tag ~payload_json ~metadata in
+  let kv =
+    match working_context with
+    | Some (`Assoc kv) -> kv
+    | _ -> []
+  in
+  let prior_list = List.assoc_opt multimodal_key kv in
+  let new_list = append_to_list prior_list entry in
+  let kv_without =
+    List.filter (fun (k, _) -> k <> multimodal_key) kv
+  in
+  Some (`Assoc ((multimodal_key, new_list) :: kv_without))
+
+let emit_many
+    ~(working_context : Yojson.Safe.t option)
+    (entries :
+      (string * Artifact.kind_tag * Yojson.Safe.t * Yojson.Safe.t)
+      list) : Yojson.Safe.t option =
+  List.fold_left
+    (fun wc (id, kind_tag, payload_json, metadata) ->
+      emit ~working_context:wc ~id ~kind_tag ~payload_json ~metadata)
+    working_context entries

--- a/lib/multimodal/keeper_emitter.mli
+++ b/lib/multimodal/keeper_emitter.mli
@@ -1,0 +1,58 @@
+(** Keeper-side emission API for multimodal artifacts.
+
+    Cycle 27 / Tier K2 — the producer-side counterpart of the K1
+    consumer wire-in.
+
+    {1 What this module is}
+
+    A single typed function {!emit} that appends a [raw_artifact]
+    JSON entry to [working_context["multimodal_artifacts"]]. The
+    K1 keeper post-turn wire-in
+    ({!Wirein_helpers.extract_raw_artifacts}) consumes (and
+    removes) the list each turn, so this is a write-then-flush
+    contract — every emission is observed at most once.
+
+    {1 Why a typed API rather than free-form JSON}
+
+    Three reasons:
+
+    + The keeper agent's prompt layer should not encode the raw
+      JSON shape — that contract belongs in OCaml, where ppx_tla
+      keeps {!Artifact.kind_tag} and the emitter in lockstep.
+    + Tests can exercise the producer side without instantiating
+      a full keeper agent ({!emit} is pure).
+    + A single definition lets us add invariants (e.g. id
+      uniqueness check, payload size cap) here rather than in
+      every caller.
+
+    {1 RFC-0002 compliance}
+
+    This module lives in [lib/multimodal/] and does not import
+    [lib/keeper]. Keeper-side callers (hooks, prompts, tool
+    interceptors) thread their [working_context] through {!emit}
+    and use the returned value. *)
+
+val emit :
+  working_context:Yojson.Safe.t option ->
+  id:string ->
+  kind_tag:Artifact.kind_tag ->
+  payload_json:Yojson.Safe.t ->
+  metadata:Yojson.Safe.t ->
+  Yojson.Safe.t option
+(** [emit ~working_context ~id ~kind_tag ~payload_json ~metadata]
+    returns a working_context with the new entry appended to the
+    [multimodal_artifacts] list. The list is created if absent.
+    Other [`Assoc] keys are preserved.
+
+    The [kind_tag] is rendered to its canonical lowercase string
+    (["code"], ["image"], ["audio"], ["doc"]) so the K1 wire-in's
+    {!Multimodal_keeper_bridge.parse_kind_hint} round-trips
+    cleanly. *)
+
+val emit_many :
+  working_context:Yojson.Safe.t option ->
+  (string * Artifact.kind_tag * Yojson.Safe.t * Yojson.Safe.t) list ->
+  Yojson.Safe.t option
+(** [emit_many ~working_context entries] is the bulk variant. Each
+    [(id, kind_tag, payload_json, metadata)] tuple is appended in
+    order. Equivalent to a left fold of {!emit} over [entries]. *)

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 12,
+  "keeper_mli_missing": 3,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 989,
+  "lib_dune_lines": 991,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 3
+  "lib_other_mli_missing": 1
 }

--- a/test/dune
+++ b/test/dune
@@ -1766,6 +1766,11 @@
  (modules test_a12_e2e_demo)
  (libraries masc_test_deps multimodal resilience shared_audit shared_types))
 
+(test
+ (name test_k2_pipeline_e2e)
+ (modules test_k2_pipeline_e2e)
+ (libraries masc_test_deps multimodal shared_types yojson))
+
 (executable
  (name test_concurrent_distributed)
  (modules test_concurrent_distributed)

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id test_multimodal_keeper_bridge test_workspace_holder test_wirein_helpers)
+ (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id test_multimodal_keeper_bridge test_workspace_holder test_wirein_helpers test_keeper_emitter)
  (libraries multimodal shared_types yojson str unix))

--- a/test/multimodal/test_keeper_emitter.ml
+++ b/test/multimodal/test_keeper_emitter.ml
@@ -1,0 +1,171 @@
+(* Tier K2 — Multimodal.Keeper_emitter unit tests. *)
+
+module E = Multimodal.Keeper_emitter
+module A = Multimodal.Artifact
+
+let yojson_eq a b = Yojson.Safe.equal a b
+
+let assoc_lookup_list (wc : Yojson.Safe.t option) (key : string)
+    : Yojson.Safe.t list =
+  match wc with
+  | Some (`Assoc kv) -> (
+      match List.assoc_opt key kv with
+      | Some (`List xs) -> xs
+      | _ -> [])
+  | _ -> []
+
+let test_emit_into_none () =
+  let wc =
+    E.emit ~working_context:None
+      ~id:"01900000-0000-7000-8000-000000000001"
+      ~kind_tag:A.Tag_code
+      ~payload_json:(`String "println")
+      ~metadata:`Null
+  in
+  let entries = assoc_lookup_list wc "multimodal_artifacts" in
+  assert (List.length entries = 1);
+  (match List.hd entries with
+   | `Assoc kv ->
+       assert (List.assoc_opt "kind_hint" kv = Some (`String "code"));
+       assert (
+         List.assoc_opt "id" kv
+         = Some
+             (`String "01900000-0000-7000-8000-000000000001"))
+   | _ -> assert false);
+  print_endline "  emit_into_none: OK"
+
+let test_emit_preserves_other_keys () =
+  let initial =
+    Some
+      (`Assoc
+        [
+          ("autonomous_meta", `Assoc [ ("phase", `String "executing") ]);
+          ("custom", `Int 42);
+        ])
+  in
+  let wc =
+    E.emit ~working_context:initial
+      ~id:"01900000-0000-7000-8000-000000000010"
+      ~kind_tag:A.Tag_image
+      ~payload_json:(`String "<base64>")
+      ~metadata:(`Assoc [ ("width", `Int 512) ])
+  in
+  (match wc with
+   | Some (`Assoc kv) ->
+       assert (
+         List.assoc_opt "autonomous_meta" kv
+         = Some
+             (`Assoc [ ("phase", `String "executing") ]));
+       assert (List.assoc_opt "custom" kv = Some (`Int 42));
+       let entries = assoc_lookup_list wc "multimodal_artifacts" in
+       assert (List.length entries = 1)
+   | _ -> assert false);
+  print_endline "  emit_preserves_other_keys: OK"
+
+let test_emit_appends_to_existing_list () =
+  let wc1 =
+    E.emit ~working_context:None
+      ~id:"01900000-0000-7000-8000-000000000020"
+      ~kind_tag:A.Tag_code
+      ~payload_json:(`String "first")
+      ~metadata:`Null
+  in
+  let wc2 =
+    E.emit ~working_context:wc1
+      ~id:"01900000-0000-7000-8000-000000000021"
+      ~kind_tag:A.Tag_doc
+      ~payload_json:(`String "second")
+      ~metadata:`Null
+  in
+  let entries = assoc_lookup_list wc2 "multimodal_artifacts" in
+  assert (List.length entries = 2);
+  (* Order preserved: first then second. *)
+  (match entries with
+   | [ first; second ] ->
+       assert (
+         yojson_eq
+           (Yojson.Safe.Util.member "payload_json" first)
+           (`String "first"));
+       assert (
+         yojson_eq
+           (Yojson.Safe.Util.member "payload_json" second)
+           (`String "second"))
+   | _ -> assert false);
+  print_endline "  emit_appends_in_order: OK"
+
+let test_kind_hint_strings () =
+  let cases =
+    [
+      (A.Tag_code, "code");
+      (A.Tag_image, "image");
+      (A.Tag_audio, "audio");
+      (A.Tag_doc, "doc");
+    ]
+  in
+  List.iter
+    (fun (tag, expected) ->
+      let wc =
+        E.emit ~working_context:None
+          ~id:"01900000-0000-7000-8000-000000000030"
+          ~kind_tag:tag ~payload_json:`Null ~metadata:`Null
+      in
+      let entries = assoc_lookup_list wc "multimodal_artifacts" in
+      let hint =
+        match List.hd entries with
+        | `Assoc kv -> List.assoc "kind_hint" kv
+        | _ -> assert false
+      in
+      assert (yojson_eq hint (`String expected)))
+    cases;
+  print_endline "  kind_hint_canonical_strings: OK"
+
+let test_emit_many () =
+  let entries =
+    [
+      ( "01900000-0000-7000-8000-000000000040",
+        A.Tag_code,
+        `String "code",
+        `Null );
+      ( "01900000-0000-7000-8000-000000000041",
+        A.Tag_image,
+        `String "img",
+        `Null );
+      ( "01900000-0000-7000-8000-000000000042",
+        A.Tag_audio,
+        `String "wav",
+        `Null );
+    ]
+  in
+  let wc = E.emit_many ~working_context:None entries in
+  let result = assoc_lookup_list wc "multimodal_artifacts" in
+  assert (List.length result = 3);
+  print_endline "  emit_many: OK"
+
+let test_round_trip_to_keeper_bridge () =
+  (* Producer (K2) → Consumer (K1) round-trip. *)
+  let wc =
+    E.emit ~working_context:None
+      ~id:"01900000-0000-7000-8000-000000000050"
+      ~kind_tag:A.Tag_image
+      ~payload_json:(`Assoc [ ("url", `String "data:image/png") ])
+      ~metadata:(`Assoc [ ("dim", `String "512x512") ])
+  in
+  let raws, _wc_rest =
+    Multimodal.Wirein_helpers.extract_raw_artifacts wc
+  in
+  assert (List.length raws = 1);
+  let raw = List.hd raws in
+  assert (raw.Multimodal.Multimodal_keeper_bridge.id
+          = "01900000-0000-7000-8000-000000000050");
+  assert (raw.kind_hint = "image");
+  print_endline "  emitter_to_wirein_round_trip: OK"
+
+let () =
+  print_endline "=== Keeper_emitter ===";
+  test_emit_into_none ();
+  test_emit_preserves_other_keys ();
+  test_emit_appends_to_existing_list ();
+  test_kind_hint_strings ();
+  test_emit_many ();
+  test_round_trip_to_keeper_bridge ();
+  print_endline "=== Keeper_emitter: 6/6 OK ==="

--- a/test/test_k2_pipeline_e2e.ml
+++ b/test/test_k2_pipeline_e2e.ml
@@ -1,0 +1,211 @@
+(* Tier K2 — multimodal producer→consumer→workspace→HTTP chain.
+
+   This test exercises the complete production-loop path that the
+   K1 wire-in seam exists to support:
+
+     keeper agent (simulated)
+       │
+       ▼
+     Keeper_emitter.emit  (K2: producer)
+       │  writes working_context["multimodal_artifacts"]
+       ▼
+     Wirein_helpers.extract_raw_artifacts  (K1: consumer)
+       │  drains and parses
+       ▼
+     Multimodal_keeper_bridge.hydrate_with_workspace
+       │  typed Artifact construction + DAG insertion
+       ▼
+     Workspace_holder.update  (K1)
+       │  process-wide live workspace
+       ▼
+     Server_routes_http_routes_multimodal.list_response  (D1)
+       │  read-only HTTP envelope
+       ▼
+     dashboard JSON
+
+   Every link is verified deterministically — no LLM calls, no
+   network I/O. If any stage drops or duplicates artifacts the
+   final assertion fails.
+
+   The test does NOT call apply_post_turn_lifecycle — that brings
+   in the entire keeper FSM including OAS Checkpoint construction.
+   The pieces excerpted here are the same modules
+   apply_multimodal_wirein dispatches to, so the chain is identical
+   from the artifact's point of view. *)
+
+module H = Multimodal.Workspace_holder
+module W = Multimodal.Workspace
+module B = Multimodal.Multimodal_keeper_bridge
+module E = Multimodal.Keeper_emitter
+module Wirein = Multimodal.Wirein_helpers
+module A = Multimodal.Artifact
+module Aid = Shared_types.Artifact_id
+module Multimodal_routes = Masc_mcp.Server_routes_http_routes_multimodal
+
+let now = 1_700_000_000.0
+
+let assert_eq_int ~label expected actual =
+  if expected <> actual then (
+    Printf.printf "FAIL [%s]: expected %d, actual %d\n" label expected actual;
+    exit 1)
+
+let pluck_count_field json =
+  match json with
+  | `Assoc kv -> (
+      match List.assoc_opt "count" kv with
+      | Some (`Int n) -> n
+      | _ -> -1)
+  | _ -> -1
+
+let pluck_artifacts_field json =
+  match json with
+  | `Assoc kv -> (
+      match List.assoc_opt "artifacts" kv with
+      | Some (`List xs) -> xs
+      | _ -> [])
+  | _ -> []
+
+let kind_hint_of_artifact_json (art : Yojson.Safe.t) : string =
+  match art with
+  | `Assoc kv -> (
+      match List.assoc_opt "kind" kv with
+      | Some (`String s) -> s
+      | _ -> "")
+  | _ -> ""
+
+(* ── Phase 1: producer side — emission ────────────────────────── *)
+let phase1_producer_emission () =
+  print_endline "── Phase 1: producer side ──";
+  let entries =
+    [
+      ( "01900000-0000-7000-8000-000000000101",
+        A.Tag_code,
+        `String "let main = ()",
+        `Assoc [ ("lang", `String "ocaml") ] );
+      ( "01900000-0000-7000-8000-000000000102",
+        A.Tag_image,
+        `String "data:image/png;base64,iVBORw0K",
+        `Assoc [ ("dim", `String "512x512") ] );
+      ( "01900000-0000-7000-8000-000000000103",
+        A.Tag_doc,
+        `String "# Title\n\nBody",
+        `Assoc [ ("format", `String "markdown") ] );
+    ]
+  in
+  let wc = E.emit_many ~working_context:None entries in
+  let raws_in_wc =
+    match wc with
+    | Some (`Assoc kv) -> (
+        match List.assoc_opt "multimodal_artifacts" kv with
+        | Some (`List xs) -> xs
+        | _ -> [])
+    | _ -> []
+  in
+  assert_eq_int ~label:"emitted_count" 3 (List.length raws_in_wc);
+  print_endline "  emit_many ok (3 entries)";
+  wc
+
+(* ── Phase 2: consumer side — extraction ──────────────────────── *)
+let phase2_consumer_extraction wc =
+  print_endline "── Phase 2: consumer side ──";
+  let raws, wc_rest = Wirein.extract_raw_artifacts wc in
+  assert_eq_int ~label:"extracted_raws" 3 (List.length raws);
+  (* multimodal_artifacts key drained from wc_rest *)
+  (match wc_rest with
+   | Some (`Assoc kv) ->
+       assert (List.assoc_opt "multimodal_artifacts" kv = None)
+   | None -> ()
+   | _ -> assert false);
+  print_endline "  extract_raw_artifacts ok (3 raws, key drained)";
+  raws
+
+(* ── Phase 3: hydration → workspace insertion ─────────────────── *)
+let phase3_hydrate raws =
+  print_endline "── Phase 3: hydrate + workspace ──";
+  H.reset ();
+  H.update (fun ws ->
+      let ws', added =
+        B.hydrate_with_workspace ws raws ~now
+          ~created_by:"test-keeper"
+      in
+      assert_eq_int ~label:"hydrated" 3 (List.length added);
+      ws');
+  let snap = H.get () in
+  assert_eq_int ~label:"workspace_size" 3 (W.size snap);
+  print_endline "  hydrate_with_workspace ok (3 typed artifacts in holder)"
+
+(* ── Phase 4: HTTP surface response — D1 list endpoint ────────── *)
+let phase4_d1_response_via_holder () =
+  print_endline "── Phase 4: D1 HTTP surface ──";
+  Multimodal_routes.bind_workspace_getter H.get;
+  let json = Multimodal_routes.list_response () in
+  let count = pluck_count_field json in
+  assert_eq_int ~label:"d1_count" 3 count;
+  let artifacts = pluck_artifacts_field json in
+  assert_eq_int ~label:"d1_artifacts_list_len" 3 (List.length artifacts);
+  let kinds =
+    List.map kind_hint_of_artifact_json artifacts |> List.sort compare
+  in
+  let expected = List.sort compare [ "code"; "image"; "doc" ] in
+  if kinds <> expected then (
+    Printf.printf "FAIL [d1_kinds]: expected %s, actual %s\n"
+      (String.concat "," expected)
+      (String.concat "," kinds);
+    exit 1);
+  print_endline "  list_response ok (3 artifacts visible to dashboard)"
+
+(* ── Phase 5: incremental emission (turn 2) ───────────────────── *)
+let phase5_incremental_turn () =
+  print_endline "── Phase 5: incremental turn ──";
+  (* A second turn emits one additional artifact. The K1 wire-in
+     consumes only the new entry and accumulates it on top of the
+     prior workspace. *)
+  let wc =
+    E.emit ~working_context:None
+      ~id:"01900000-0000-7000-8000-000000000104"
+      ~kind_tag:A.Tag_audio
+      ~payload_json:(`String "data:audio/wav;base64,UklGRg==")
+      ~metadata:(`Assoc [ ("duration_ms", `Int 1500) ])
+  in
+  let raws, _ = Wirein.extract_raw_artifacts wc in
+  H.update (fun ws ->
+      let ws', _ =
+        B.hydrate_with_workspace ws raws ~now:(now +. 1.0)
+          ~created_by:"test-keeper"
+      in
+      ws');
+  let snap = H.get () in
+  assert_eq_int ~label:"workspace_size_after_turn2" 4 (W.size snap);
+  let json = Multimodal_routes.list_response () in
+  assert_eq_int ~label:"d1_count_after_turn2" 4
+    (pluck_count_field json);
+  print_endline "  turn-2 emission flows through to dashboard (4 total)"
+
+(* ── Phase 6: kind filter via Workspace.list_by_kind_tag ──────── *)
+let phase6_kind_filter () =
+  print_endline "── Phase 6: kind filter ──";
+  let snap = H.get () in
+  let images = W.list_by_kind_tag snap A.Tag_image in
+  let codes = W.list_by_kind_tag snap A.Tag_code in
+  let docs = W.list_by_kind_tag snap A.Tag_doc in
+  let audios = W.list_by_kind_tag snap A.Tag_audio in
+  assert_eq_int ~label:"images" 1 (List.length images);
+  assert_eq_int ~label:"codes" 1 (List.length codes);
+  assert_eq_int ~label:"docs" 1 (List.length docs);
+  assert_eq_int ~label:"audios" 1 (List.length audios);
+  print_endline "  per-kind filter ok (1 each across 4 kinds)"
+
+let () =
+  print_endline "=== K2 e2e pipeline (Cycle 27 Tier K2 — production loop) ===";
+  let wc = phase1_producer_emission () in
+  let raws = phase2_consumer_extraction wc in
+  phase3_hydrate raws;
+  phase4_d1_response_via_holder ();
+  phase5_incremental_turn ();
+  phase6_kind_filter ();
+  print_endline
+    "=== K2 e2e: 6/6 phases passed (production loop closed) ===";
+  print_endline
+    "    K1 wire-in seam is now provably live: producer → consumer";
+  print_endline
+    "    → workspace → HTTP surface chain GREEN end-to-end."


### PR DESCRIPTION
Cycle 27 / Tier K2 — Producer-side counterpart of the K1 wire-in. Closes the multimodal production loop **end-to-end**.

## Production loop

```
keeper agent (simulated)
  │ Keeper_emitter.emit              ← K2 (this PR)
  ▼ working_context["multimodal_artifacts"]
  │ Wirein_helpers.extract_raw_artifacts ← K1
  │ Multimodal_keeper_bridge.hydrate    ← W3
  │ Workspace_holder.update              ← K1
  │ list_response                        ← D1
  ▼ dashboard JSON
```

K1 created the consumer seam (write side of working_context). K2 lands the **typed producer API** and the **integration test** that proves the seam is live, not dead.

## What lands

| File | Role |
|------|------|
| `lib/multimodal/keeper_emitter.{mli,ml}` (NEW, ~120 LoC) | `emit` + `emit_many`. Pure: writes raw_artifact JSON into `working_context["multimodal_artifacts"]`. Other `\`Assoc` keys preserved. |
| `test/multimodal/test_keeper_emitter.ml` (NEW, 6 assertions) | Unit coverage including round-trip with `Wirein_helpers.extract_raw_artifacts`. |
| `test/test_k2_pipeline_e2e.ml` (NEW, 6 phases) | producer → consumer → hydration → workspace → D1 HTTP envelope. Deterministic, no LLM/network. |
| `test/dune` + `test/multimodal/dune` | + 2 entries. |

## E2E test phases (all GREEN)

1. **Producer**: `emit_many ~working_context:None entries` → 3 raws in working_context.
2. **Consumer**: `Wirein_helpers.extract_raw_artifacts wc` → 3 raws + key drained from `wc_rest`.
3. **Hydration**: `Multimodal_keeper_bridge.hydrate_with_workspace` → 3 typed artifacts in `Workspace_holder`.
4. **D1 HTTP**: `list_response ()` (with `bind_workspace_getter Workspace_holder.get`) → JSON `{count: 3, artifacts: [...]}` with kinds `[code; image; doc]`.
5. **Incremental turn**: emit 1 audio artifact in turn 2 → workspace size 4, dashboard sees 4.
6. **Per-kind filter**: `Workspace.list_by_kind_tag` returns 1 each across 4 kinds.

Every link verified deterministically.

## RFC-0002 compliance

`lib/multimodal/keeper_emitter` does **not** import `lib/keeper`. Future keeper-side callers (hooks, prompts, tool interceptors) thread `working_context` through `Keeper_emitter.emit`.

## Verification

- `dune build --root .` — GREEN
- `dune runtest --root . test/multimodal/` — 6 new assertions GREEN + 8 existing suites GREEN (0 regressions)
- `dune exec --root . test/test_k2_pipeline_e2e.exe` — 6/6 phases GREEN

## Plan reference

§16 K2 — production loop closing follow-up to K1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
