### PR TITLE
feat(perf): PR-0.2.G k6 dashboard WS load harness

### DIFF
--- a/.github/workflows/dashboard-ws-load.yml
+++ b/.github/workflows/dashboard-ws-load.yml
@@ -1,0 +1,77 @@
+name: PR-0.2.G — Dashboard WS Load (k6)
+
+# k6 100-VU WebSocket load harness against the masc-mcp dashboard endpoint.
+# Sibling of:
+#   - .github/workflows/perf-baseline.yml          (PR-0.2.F)
+#   - lib/transport_metrics.ml WS histogram        (PR-0.2.B, #12015 MERGED)
+#   - scripts/oas-hung-keeper-dump.sh              (#11071, ops sibling)
+#
+# CI mode: smoke. The script targets a live server at :8937; in CI no
+# server is running, so the WS connect fails fast and the harness exits
+# with a non-zero status. We mark the run as continue-on-error so the
+# job does not fail the PR — the captured summary is still useful for
+# verifying:
+#   - k6 binary present, script parses
+#   - workflow YAML syntax valid
+#   - PR-0.2.G threshold definitions in scope
+#
+# This continue-on-error is scoped to the harness *test* step; build /
+# typecheck steps in this repo never use continue-on-error
+# (memory: feedback_ci_build_step_continue_on_error_masks_compile_break).
+#
+# Real 100-VU measurement runs on a dedicated runner with the dashboard
+# server live, scoped to a separate operations PR (PR-0.2.H or runbook).
+# Until then this workflow is intentionally a syntax + smoke check only.
+#
+# References:
+#   - dashboard/test/load/ws-100vu.js
+#   - .github/workflows/perf-baseline.yml          (mirror schedule pattern)
+#   - knowledge/research/2026-04-masc-ide-strategy/IMPLEMENTATION-QUEUE.md Q-P1-7
+
+on:
+  pull_request:
+    paths:
+      - 'dashboard/test/load/**'
+      - '.github/workflows/dashboard-ws-load.yml'
+  workflow_dispatch:
+    inputs:
+      vus:
+        description: 'Virtual users (default 100; CI smoke uses 5)'
+        default: '100'
+      duration:
+        description: 'Scenario duration (default 30s; CI smoke uses 5s)'
+        default: '30s'
+      target_url:
+        description: 'WS URL (default ws://127.0.0.1:8937/dashboard/ws)'
+        default: 'ws://127.0.0.1:8937/dashboard/ws'
+
+permissions:
+  contents: read
+
+jobs:
+  k6-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run k6 smoke (server unreachable in CI is expected)
+        uses: grafana/k6-action@v0.3.1
+        continue-on-error: true
+        with:
+          filename: dashboard/test/load/ws-100vu.js
+          flags: --summary-export=k6-summary.json
+        env:
+          MASC_DASHBOARD_WS_URL: ${{ inputs.target_url || 'ws://127.0.0.1:8937/dashboard/ws' }}
+          K6_VUS: ${{ inputs.vus || '5' }}
+          K6_DURATION: ${{ inputs.duration || '5s' }}
+          K6_HOLD_MS: '3000'
+
+      - name: Upload k6 summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-summary-${{ github.run_id }}
+          path: k6-summary.json
+          retention-days: 30
+          if-no-files-found: ignore

--- a/dashboard/test/load/ws-100vu.js
+++ b/dashboard/test/load/ws-100vu.js
@@ -1,0 +1,105 @@
+// k6 WebSocket load harness — masc-mcp dashboard
+//
+// Tracks: PR-0.2.G (sibling of PR-0.2.B WS histogram #12015, PR-0.2.F
+// perf-baseline.yml). IMPLEMENTATION-QUEUE Q-P1-7 (Track C C-5).
+//
+// Targets the dashboard WebSocket endpoint at port 8937. Default scenario
+// holds 100 sustained virtual users for 30 seconds. CI runs a 5-VU 5-second
+// smoke variant; real 100-VU measurement runs on a dedicated production
+// runner per docs/design/perf-baseline-protocol.md scope.
+//
+// Thresholds (Track A line 1063 / IMPLEMENTATION-QUEUE Phase 1 SLO):
+//   - ws_connecting     p(95) < 500ms  (initial network handshake)
+//   - sync_latency_ms   p(95) < 100ms  (broadcast → recv application-level)
+//   - msg-received rate > 99%
+//
+// Configurable via env:
+//   MASC_DASHBOARD_WS_URL  (default ws://127.0.0.1:8937/dashboard/ws)
+//   K6_VUS                 (default 100)
+//   K6_DURATION            (default 30s)
+//   K6_HOLD_MS             (default 20000 — connection hold per VU)
+
+import ws from 'k6/ws'
+import { check, sleep } from 'k6'
+import { Trend } from 'k6/metrics'
+
+const syncLatency = new Trend('sync_latency_ms')
+
+const targetUrl =
+  __ENV.MASC_DASHBOARD_WS_URL || 'ws://127.0.0.1:8937/dashboard/ws'
+const vus = parseInt(__ENV.K6_VUS || '100', 10)
+const duration = __ENV.K6_DURATION || '30s'
+const holdMs = parseInt(__ENV.K6_HOLD_MS || '20000', 10)
+
+export const options = {
+  scenarios: {
+    sustained: {
+      executor: 'constant-vus',
+      vus,
+      duration,
+    },
+  },
+  thresholds: {
+    ws_connecting: ['p(95)<500'],
+    sync_latency_ms: ['p(95)<100'],
+    'checks{type:msg-received}': ['rate>0.99'],
+    'checks{type:connect}': ['rate>0.99'],
+  },
+  // Tag every metric so threshold groups stay narrow.
+  tags: {
+    harness: 'ws-100vu',
+    track: 'PR-0.2.G',
+  },
+}
+
+export default function () {
+  const sentAt = new Map() // request-id -> ts (ms)
+
+  const res = ws.connect(targetUrl, {}, function (socket) {
+    socket.on('open', function () {
+      const helloId = `hello-${__VU}-${Date.now()}`
+      sentAt.set(helloId, Date.now())
+      socket.send(
+        JSON.stringify({ type: 'hello', client: 'k6-load-vu', id: helloId })
+      )
+    })
+
+    socket.on('message', function (data) {
+      // Application-level latency: time since *some* outbound message.
+      // For broadcast frames we have no request-id round-trip, so we use
+      // Date.now() - sentAt(any) as a coarse upper bound.
+      const anySentAt = Math.min(...sentAt.values())
+      if (Number.isFinite(anySentAt)) {
+        syncLatency.add(Date.now() - anySentAt)
+      }
+      check(
+        data,
+        {
+          'message received': (d) =>
+            typeof d === 'string' && d.length > 0,
+        },
+        { type: 'msg-received' }
+      )
+    })
+
+    socket.on('error', function (e) {
+      // CI runs without a live server; expected to fail at WS connect or
+      // immediately after. Real measurement runs on a dedicated runner.
+      console.warn(`ws error (expected in CI): ${e.error()}`)
+    })
+
+    socket.setTimeout(function () {
+      socket.close()
+    }, holdMs)
+  })
+
+  check(
+    res,
+    {
+      'connect status 101': (r) => r && r.status === 101,
+    },
+    { type: 'connect' }
+  )
+
+  sleep(1)
+}


### PR DESCRIPTION
## Summary

k6 100-VU sustained WebSocket load harness for the dashboard endpoint on port 8937, plus a CI smoke workflow. Sibling of PR-0.2.B/E/F under the perf baseline track.

## Why now

External multi-agent IDE analysis (Track C, line 2399-2469) recommends k6 + WebSocket harness for the dashboard fan-out path. This PR delivers the harness scaffold (script + workflow); real measurement requires a separate operations PR with a dedicated runner where the dashboard server is live.

## Files

- ``dashboard/test/load/ws-100vu.js`` — k6 script, sustained-VU executor, ``sync_latency_ms`` Trend metric, env-driven config, threshold groups for connect/recv
- ``.github/workflows/dashboard-ws-load.yml`` — pull_request trigger scoped to harness paths + manual workflow_dispatch with vus/duration/target_url inputs

## Thresholds

| Metric | p(95) | Source |
|---|---|---|
| ``ws_connecting`` | < 500 ms | network handshake |
| ``sync_latency_ms`` | < 100 ms | Track A line 1063, IMPLEMENTATION-QUEUE Phase 1 SLO |
| ``msg-received`` rate | > 99% | smoke check |

## CI safety

``continue-on-error`` is scoped exclusively to the harness *test* step; build / typecheck steps never use it (memory: ``feedback_ci_build_step_continue_on_error_masks_compile_break``).

The CI run is expected to fail at WS connect because no dashboard server is live in CI. The captured k6 summary exercises the script parser and threshold definitions. The job is marked ``continue-on-error: true`` so the harness check does not fail unrelated PRs.

Real 100-VU measurement is scoped to a follow-up PR (PR-0.2.H or ops runbook) with a dedicated runner.

## Race-check

``gh pr list --search "PR-0.2.G OR k6-ws-load OR dashboard-ws-load OR ws-100vu"`` returned 0 open k6 PRs at push time. Other "harness"-keyword matches (eval_harness, tool_call_replay_harness) are different domains.

## Related

- PR #12015 — PR-0.2.B WS message_bytes histogram (MERGED)
- PR #12010 — PR-0.2.E IO-wait sampler RFC (MERGED)
- ``.github/workflows/perf-baseline.yml`` — PR-0.2.F sibling
- PR #12026 — RFC 0017 OCaml↔CRDT Boundary (Cycle 2 sibling output)
- PR #12034 — LICENSE Audit + ENTERPRISE Candidates (Cycle 3 sibling output, MERGED)

## Test plan

- [ ] k6 action installs successfully
- [ ] Script syntax check passes
- [ ] Workflow YAML lint passes
- [ ] ``continue-on-error`` confirmed scoped to test step only (not build/typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)