### PR TITLE
fix(ocaml): align split module interfaces

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -6,6 +6,9 @@ val effective_keepalive_meta :
   disk_meta_opt:keeper_meta option ->
   keeper_meta
 
+val repair_identity_drift_for_keepalive :
+  ctx:'a context -> keeper_meta -> keeper_meta option
+
 val keeper_agent_status : keeper_meta -> Types.agent_status
 
 val sync_keeper_presence :
@@ -22,7 +25,7 @@ val collect_keepalive_board_events :
   ctx:'a context ->
   meta_current:keeper_meta ->
   proactive_warmup_elapsed:bool ->
-  Keeper_world_observation.keepalive_event list * keeper_meta
+  Keeper_world_observation.pending_board_event list * keeper_meta
 
 val in_turn_liveness_pulse_interval_sec : unit -> float
 
@@ -46,7 +49,7 @@ val with_in_turn_liveness_pulse :
 val run_keepalive_unified_turn :
   ctx:'a context ->
   meta_after_triage:keeper_meta ->
-  pending_board_events:Keeper_world_observation.keepalive_event list ->
+  pending_board_events:Keeper_world_observation.pending_board_event list ->
   stop:bool Atomic.t ->
   proactive_warmup_elapsed:bool ->
   shared_context:Oas.Context.t ->

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -50,7 +50,13 @@ val stage_timing_ring_size : unit -> int
 val percentile : float array -> float -> float
 
 val stage_timing_to_json :
-  ring:stage_timing array -> count:int -> [> `Null | `Assoc of (string * [> `Assoc of (string * [> `Float | `Int ]) list ]) list ]
+  ring:stage_timing array -> count:int ->
+  [> `Null
+  | `Assoc of
+      (string *
+       [> `Assoc of (string * [> `Float of float | `Int of int ]) list ])
+      list
+  ]
 
 val format_since_last_scheduled_autonomous : int option -> string
 
@@ -63,7 +69,7 @@ val dispatch_keepalive_event :
 
 val dispatch_keepalive_event_with_audit :
   ctx:'a context -> keeper_name:string ->
-  snapshot:Keeper_measurement.measurement ->
-  events_fired:Keeper_guard.event list ->
-  selected_event:Keeper_guard.event option ->
+  snapshot:Keeper_measurement.measurement_snapshot ->
+  events_fired:Keeper_state_machine.event list ->
+  selected_event:Keeper_state_machine.event ->
   Keeper_state_machine.event -> unit

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -32,6 +32,8 @@ val next_fail_open_cascade_for_turn :
   Oas.Error.sdk_error ->
   EC.degraded_retry option
 
+val sdk_error_kind : Oas.Error.sdk_error -> string
+
 val record_turn_failure_stress :
   meta:keeper_meta ->
   is_auto_recoverable:bool ->
@@ -60,6 +62,7 @@ val oas_timeout_budget_resolution_to_yojson :
   oas_timeout_budget_resolution -> Yojson.Safe.t
 
 val resolve_bounded_oas_timeout_budget_with_turn_budget :
+  reserve_degraded_retry_budget:bool ->
   estimated_input_tokens:int ->
   max_turns:int ->
   remaining_turn_budget_s:float ->

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -26,7 +26,7 @@ val report_keeper_cycle_side_effect_issue :
   config:Coord.config ->
   keeper_name:string ->
   side_effect:string ->
-  ?severity:[> `Warn | `Error ] ->
+  ?severity:[< `Warn | `Error > `Warn ] ->
   string -> unit
 (** Log and record a side-effect failure for a keeper cycle. *)
 
@@ -76,7 +76,7 @@ val record_pre_dispatch_terminal_observation :
   trajectory_outcome:Trajectory.trajectory_outcome ->
   ?error_kind:string ->
   ?error_message:string ->
-  ?keeper_turn_id:string ->
+  ?keeper_turn_id:int ->
   unit -> unit
 (** Record a terminal observation (receipt + activity graph event) for a
     pre-dispatch failure or early exit. *)

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -3,8 +3,8 @@ exception Semaphore_wait_timeout of float
 (** Global turn slot cap. Safety ceiling for ALL keeper turns. *)
 val keeper_turn_throttle_limit : int
 
-val turn_semaphore : int Eio.Semaphore.t
-val autonomous_turn_semaphore : int Eio.Semaphore.t
+val turn_semaphore : Eio.Semaphore.t
+val autonomous_turn_semaphore : Eio.Semaphore.t
 
 (** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper
     turn slot. Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. *)

--- a/lib/oas_worker_named.mli
+++ b/lib/oas_worker_named.mli
@@ -22,7 +22,7 @@ val run_named :
   ?keeper_name:string ->
   ?model_strings:string list ->
   goal:string ->
-  ?provider_filter:(Llm_provider.Provider_config.t -> bool) ->
+  ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
   ?require_tool_support:bool ->
   ?priority:Llm_provider.Request_priority.t ->
@@ -35,43 +35,43 @@ val run_named :
   ?stream_idle_timeout_s:float ->
   ?temperature:float ->
   ?max_tokens:int ->
-  ?max_input_tokens:int option ->
-  ?max_cost_usd:float option ->
+  ?max_input_tokens:int ->
+  ?max_cost_usd:float ->
   ?wait_timeout_sec:float ->
   ?accept:(Oas_response.api_response -> bool) ->
   ?guardrails:Oas.Guardrails.t ->
-  ?hooks:Oas.Hooks.t ->
+  ?hooks:Oas.Hooks.hooks ->
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry.t ->
-  ?required_tool_satisfaction:Oas.Completion_contract.tool_satisfaction ->
-  ?raw_trace:Oas.Types.raw_trace ->
-  ?on_event:(Oas.Types.event -> unit) ->
-  ?on_yield:(Oas_response.api_response -> unit) ->
+  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
+  ?required_tool_satisfaction:Oas.Completion_contract.required_tool_satisfaction ->
+  ?raw_trace:Oas.Raw_trace.t ->
+  ?on_event:(Oas.Types.sse_event -> unit) ->
+  ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->
   ?agent_ref:Oas.Agent.t option ref ->
-  ?proof_ref:string option ref ->
-  ?contract:Oas.Completion_contract.t ->
+  ?proof_ref:Oas.Cdal_proof.t option ref ->
+  ?contract:Oas.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
   ?cli_transport_overrides:Oas_worker_exec.cli_transport_overrides ->
   ?allowed_paths:string list ->
-  ?checkpoint_sidecar:string option ref ->
+  ?checkpoint_sidecar:Yojson.Safe.t ->
   ?cache_system_prompt:bool ->
   ?yield_on_tool:bool ->
   ?compact_ratio:float ->
   ?checkpoint_dir:string ->
-  ?context_injector:Oas.Context_injector.t ->
-  ?context:Oas.Types.context ->
-  ?slot_id:string ->
+  ?context_injector:Oas.Hooks.context_injector ->
+  ?context:Oas.Context.t ->
+  ?slot_id:int ->
   ?enable_thinking:bool ->
-  ?approval:Oas.Approval.t ->
-  ?exit_condition:Oas.Types.exit_condition ->
-  ?exit_condition_result:(Oas_response.api_response -> Oas.Types.exit_condition_result option) ->
+  ?approval:Oas.Hooks.approval_callback ->
+  ?exit_condition:(int -> bool) ->
+  ?exit_condition_result:(int -> Oas_worker_exec.stop_reason * string option) ->
   ?summarizer:(Oas.Types.message list -> string) ->
   ?oas_checkpoint:Oas.Checkpoint.t ->
   ?event_bus:Oas.Event_bus.t ->
   ?sw:Eio.Switch.t ->
-  ?net:Eio.Net.t ->
+  ?net:Eio_context.eio_net ->
   ?per_provider_timeout_s:float ->
   unit ->
   (Oas_worker_exec.run_result, Oas.Error.sdk_error) result
@@ -92,22 +92,22 @@ val run_model_by_label :
   ?stream_idle_timeout_s:float ->
   ?temperature:float ->
   ?max_tokens:int ->
-  ?max_input_tokens:int option ->
-  ?max_cost_usd:float option ->
+  ?max_input_tokens:int ->
+  ?max_cost_usd:float ->
   ?wait_timeout_sec:float ->
   ?accept:(Oas_response.api_response -> bool) ->
   ?guardrails:Oas.Guardrails.t ->
-  ?hooks:Oas.Hooks.t ->
+  ?hooks:Oas.Hooks.hooks ->
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry.t ->
+  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
-  ?contract:Oas.Completion_contract.t ->
-  ?on_event:(Oas.Types.event -> unit) ->
+  ?contract:Oas.Risk_contract.t ->
+  ?on_event:(Oas.Types.sse_event -> unit) ->
   ?transport:Masc_grpc_transport.t ->
   ?sw:Eio.Switch.t ->
-  ?net:Eio.Net.t ->
+  ?net:Eio_context.eio_net ->
   unit ->
   (Oas_worker_exec.run_result, Oas.Error.sdk_error) result
 (** Run a single [Agent.run] using a model label string
@@ -126,26 +126,26 @@ val run_named_with_masc_tools :
   ?stream_idle_timeout_s:float ->
   ?temperature:float ->
   ?max_tokens:int ->
-  ?max_input_tokens:int option ->
-  ?max_cost_usd:float option ->
+  ?max_input_tokens:int ->
+  ?max_cost_usd:float ->
   ?wait_timeout_sec:float ->
   ?guardrails:Oas.Guardrails.t ->
-  ?hooks:Oas.Hooks.t ->
+  ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry.t ->
-  ?required_tool_satisfaction:Oas.Completion_contract.tool_satisfaction ->
-  ?raw_trace:Oas.Types.raw_trace ->
-  ?on_event:(Oas.Types.event -> unit) ->
-  ?on_yield:(Oas_response.api_response -> unit) ->
+  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
+  ?required_tool_satisfaction:Oas.Completion_contract.required_tool_satisfaction ->
+  ?raw_trace:Oas.Raw_trace.t ->
+  ?on_event:(Oas.Types.sse_event -> unit) ->
+  ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->
-  ?proof_ref:string option ref ->
-  ?contract:Oas.Completion_contract.t ->
+  ?proof_ref:Oas.Cdal_proof.t option ref ->
+  ?contract:Oas.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
   ?yield_on_tool:bool ->
   ?compact_ratio:float ->
-  ?approval:Oas.Approval.t ->
+  ?approval:Oas.Hooks.approval_callback ->
   ?sw:Eio.Switch.t ->
-  ?net:Eio.Net.t ->
+  ?net:Eio_context.eio_net ->
   unit ->
   (Oas_worker_exec.run_result, Oas.Error.sdk_error) result
 (** [run_named] variant that bridges MASC tool schemas into OAS tools
@@ -161,21 +161,21 @@ val run_model_with_masc_tools :
   ?stream_idle_timeout_s:float ->
   ?temperature:float ->
   ?max_tokens:int ->
-  ?max_input_tokens:int option ->
-  ?max_cost_usd:float option ->
+  ?max_input_tokens:int ->
+  ?max_cost_usd:float ->
   ?wait_timeout_sec:float ->
   ?guardrails:Oas.Guardrails.t ->
-  ?hooks:Oas.Hooks.t ->
+  ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry.t ->
+  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
-  ?contract:Oas.Completion_contract.t ->
-  ?raw_trace:Oas.Types.raw_trace ->
-  ?on_event:(Oas.Types.event -> unit) ->
+  ?contract:Oas.Risk_contract.t ->
+  ?raw_trace:Oas.Raw_trace.t ->
+  ?on_event:(Oas.Types.sse_event -> unit) ->
   ?transport:Masc_grpc_transport.t ->
   ?sw:Eio.Switch.t ->
-  ?net:Eio.Net.t ->
+  ?net:Eio_context.eio_net ->
   unit ->
   (Oas_worker_exec.run_result, Oas.Error.sdk_error) result
 (** [run_model_by_label] variant that bridges MASC tool schemas into OAS tools. *)

--- a/lib/oas_worker_named_cascade.mli
+++ b/lib/oas_worker_named_cascade.mli
@@ -12,14 +12,14 @@
 val default_config_path : unit -> string option
 (** Alias for [Cascade_runtime.cascade_config_path]. *)
 
-val default_model_strings : string list
+val default_model_strings : cascade_name:string -> string list
 (** Alias for [Cascade_runtime.default_model_strings]. *)
 
 (** {1 Eio context validation} *)
 
 val require_eio :
-  ?sw:Eio.Switch.t -> ?net:Eio.Net.t -> unit ->
-  (Eio.Switch.t * Eio.Net.t, string) result
+  ?sw:Eio.Switch.t -> ?net:Eio_context.eio_net -> unit ->
+  (Eio.Switch.t * Eio_context.eio_net, string) result
 (** Validate that an Eio switch and network are available in the current
     context.  Returns [Ok (sw, net)] when both are present, or [Error msg]
     when running outside a server context. *)
@@ -35,7 +35,7 @@ val cascade_catalog_error_to_sdk_error : string -> Oas.Error.sdk_error
 (** {1 Provider resolution} *)
 
 val resolve_cascade_providers :
-  ?provider_filter:(Llm_provider.Provider_config.t -> bool) ->
+  ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
   ?require_tool_support:bool ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
@@ -44,12 +44,12 @@ val resolve_cascade_providers :
 (** Resolve cascade provider configs via MASC Cascade_config. *)
 
 val resolve_providers_from_model_strings :
-  ?provider_filter:(Llm_provider.Provider_config.t -> bool) ->
+  ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
   ?require_tool_support:bool ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
   string list ->
-  (Llm_provider.Provider_config.t list, string) result
+  Llm_provider.Provider_config.t list
 (** Resolve from an explicit model string list (user-declared in keeper TOML). *)
 
 val keeper_agent_name_opt : string -> string option
@@ -116,7 +116,7 @@ val filter_candidate_providers_for_tool_support :
 
 val resolve_tool_capable_provider_across_cascades :
   sw:Eio.Switch.t ->
-  net:Eio.Net.t ->
+  net:Eio_context.eio_net ->
   keeper_name:string ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
   ?tools:Oas.Tool.t list ->

--- a/lib/oas_worker_named_error.mli
+++ b/lib/oas_worker_named_error.mli
@@ -81,6 +81,8 @@ val admission_wait_timeout_error :
   (string, Oas.Error.sdk_error) result
 (** Build an [Admission_queue_timeout] error from a wait duration in ms. *)
 
+val cross_cascade_fallback_metric : string
+
 (** {1 Config construction} *)
 
 val config_for_label :
@@ -90,20 +92,20 @@ val config_for_label :
   tools:Oas.Tool.t list ->
   max_turns:int ->
   max_tokens:int ->
-  ?max_input_tokens:int option ->
-  ?max_cost_usd:float option ->
+  ?max_input_tokens:int ->
+  ?max_cost_usd:float ->
   temperature:float ->
   ?max_idle_turns:int ->
   ?stream_idle_timeout_s:float ->
   ?guardrails:Oas.Guardrails.t ->
-  ?hooks:Oas.Hooks.t ->
+  ?hooks:Oas.Hooks.hooks ->
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry.t ->
+  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
-  ?contract:Oas.Completion_contract.t ->
-  ?approval:Oas.Approval.t ->
+  ?contract:Oas.Risk_contract.t ->
+  ?approval:Oas.Hooks.approval_callback ->
   description:string option ->
   unit ->
   (Oas_worker_exec.config, Oas.Error.sdk_error) result


### PR DESCRIPTION
## Summary
- align recently pinned .mli signatures with the implementations for split keeper/OAS modules
- fix current Eio/OAS type names in public interfaces
- expose helper values that facade modules already depend on

## Why
Current main cannot build `bin/main_eio.exe` locally because split-module interfaces drifted from implementation types. This blocks applying the merged keeper OAS timeout budget fix to the live server.

## Verification
- git diff --check
- scripts/dune-local.sh build bin/main_eio.exe