### PR TITLE
fix(spec): DashboardCacheStampede.tla line refs drift

### DIFF
--- a/specs/bug-models/DashboardCacheStampede.tla
+++ b/specs/bug-models/DashboardCacheStampede.tla
@@ -10,11 +10,11 @@
 \*
 \* Actual code (verified 2026-04-20):
 \*   lib/dashboard/dashboard_cache.ml:60   let maybe_evict map
-\*   lib/dashboard/dashboard_cache.ml:149  let get_or_compute_eio
-\*   lib/dashboard/dashboard_cache.ml:244  | Eio.Cancel.Cancelled _ as e -> ...
+\*   lib/dashboard/dashboard_cache.ml:161  let get_or_compute_eio
+\*   lib/dashboard/dashboard_cache.ml:262  | Eio.Cancel.Cancelled _ as e -> ...
 \*
 \* (Path drift: lib/dashboard_cache.ml -> lib/dashboard/dashboard_cache.ml.
-\*  Line drift: 265 -> 216. Recorded for cross-reference.)
+\*  Line drift: 265 -> 216 -> 161/262. Recorded for cross-reference.)
 
 EXTENDS Naturals
 


### PR DESCRIPTION
## Summary
- Fix 2 spec-line-refs drift in DashboardCacheStampede.tla after autocoder mass-merge advanced main ~20 commits
- `get_or_compute_eio`: 149 → 161
- `Cancelled` pattern: 244 → 262

## Context
Main moved significantly from autocoder merging #12036, #12038, #12039, #12022 in quick succession. The `dashboard_cache.ml` function positions shifted, causing Meta Guards to fail on all subsequent PRs.

Unblocks #12037 (Draft) Meta Guards.

## Test plan
- [x] Local: `bash scripts/lint/spec-line-refs.sh` → 85 refs, 0 drift, 0 dangling
- [ ] CI Meta Guards pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)