### PR TITLE
fix(keeper): add HOME=/tmp to shell docker run for UID mismatch

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -489,6 +489,8 @@ let run_docker_shell_command_with_status
           "-i";
           "--user";
           Printf.sprintf "%d:%d" uid gid;
+          "--env";
+          "HOME=/tmp";
         ]
         @ Keeper_sandbox_runtime.docker_nofile_args ()
         @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -163,6 +163,8 @@ let start_container (t : t) ~(timeout_sec : float) =
           @ [
             "--user";
             Printf.sprintf "%d:%d" t.uid t.gid;
+            "--env";
+            "HOME=/tmp";
           ]
           @ Keeper_sandbox_runtime.docker_nofile_args ()
           @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
@@ -223,6 +225,8 @@ let run_exec_with_status_once
             "exec";
             "--user";
             Printf.sprintf "%d:%d" t.uid t.gid;
+            "--env";
+            "HOME=/tmp";
             "-w";
             container_cwd;
           ]

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -674,6 +674,25 @@ and handle_transition ?agent_tool_names ctx args =
         else
           List.filter (fun (k, _) -> not (String.equal k "to") || not (has "action")) kvs
       in
+      let kvs =
+        match List.find_opt (fun (k, _) -> String.equal k "pr_url") kvs with
+        | Some (_, `String pr_url) when pr_url <> "" ->
+            let kvs = List.filter (fun (k, _) -> not (String.equal k "pr_url")) kvs in
+            let kvs =
+              match List.find_opt (fun (k, _) -> String.equal k "notes") kvs with
+              | Some (_, `String notes) ->
+                  List.map
+                    (fun (k, v) ->
+                      if String.equal k "notes"
+                      then ("notes", `String (notes ^ "\nPR: " ^ pr_url))
+                      else (k, v))
+                    kvs
+              | _ -> kvs @ [ ("notes", `String ("PR: " ^ pr_url)) ]
+            in
+            kvs
+        | Some _ -> List.filter (fun (k, _) -> not (String.equal k "pr_url")) kvs
+        | None -> kvs
+      in
       `Assoc kvs
     | other -> other
   in


### PR DESCRIPTION
## Summary

Follow-up to #12036. The oneshot shell docker path in `keeper_shell_docker.ml` also passes `--user` with the host UID, which fails when the UID has no `/etc/passwd` entry inside the sandbox image.

Fix: add `--env HOME=/tmp` to the `docker run` argv so git/SSH operations inside the shell container have a writable home directory.

## Related

- #12036 (turn sandbox runtime + tool_task fixes)