### PR TITLE
fix(keeper,ocaml): mli exposure + remaining docker HOME=/tmp

### DIFF
--- a/lib/oas_worker_named_error.mli
+++ b/lib/oas_worker_named_error.mli
@@ -83,6 +83,10 @@ val admission_wait_timeout_error :
 
 val cross_cascade_fallback_metric : string
 
+val masc_oas_error_total_metric : string
+(** Canonical Prometheus counter name used by
+    [sdk_error_of_masc_internal_error]. *)
+
 (** {1 Config construction} *)
 
 val config_for_label :


### PR DESCRIPTION
## Summary
- Fixes main branch build failure: `Unbound value OWN.masc_oas_error_total_metric` in `test/test_oas_error_kind_counter.ml`
  - Root cause: `masc_oas_error_total_metric` defined in `.ml` but missing from `.mli`
- Fixes remaining docker run paths missing `--env HOME=/tmp` for UID mismatch:
  - `keeper_docker_read.ml`
  - `keeper_sandbox_control.ml`
  - These were missed in the initial sweep (#12036, #12045)

## Test plan
- [x] `dune build --root . @check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)