### PR TITLE
chore(oas): refresh boundary surface fingerprint

### DIFF
--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -47,7 +47,8 @@ let payload_agent_name payload =
      keeper-specific key (e.g. [masc:keeper:snapshot],
      [masc:keeper:lifecycle]).  Without this fallback the top-level
      envelope [agent_name] is Null for 9%+ of daily events, breaking
-     per-agent filters on [.masc/oas-events/*.jsonl].  See #7827. *)
+     per-agent filters over the Dated_jsonl store under [.masc/oas-events/].
+     See #7827. *)
   match payload_string_opt "agent_name" payload with
   | Some _ as value -> value
   | None ->

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "db5473163d08bc25d4c7c60cf6419fbaad487c26",
-  "pinned_version": "v0.181.0",
+  "pinned_sha": "91b7c130e79e7e34ab633db8cddbc1de31299df8",
+  "pinned_version": "v0.184.0",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -166,8 +166,9 @@ let test_keeper_snapshot_envelope_agent_name () =
   (* #7827: publish_keeper_snapshot stores the keeper's identity as
      [keeper_name] inside the Custom payload.  native_event_to_json must
      still populate the top-level envelope [agent_name] so that
-     [.masc/oas-events/*.jsonl] consumers can filter/group by agent
-     instead of silently dropping 9%+ of daily events. *)
+     consumers of the Dated_jsonl store under [.masc/oas-events/] can
+     filter/group by agent instead of silently dropping 9%+ of daily
+     events. *)
   Eio_main.run @@ fun _env ->
   let bus = Event_bus.create () in
   Masc_event_bus.set bus;


### PR DESCRIPTION
## Summary

- Refresh `scripts/oas-api-surface.json` metadata to the current pinned OAS commit/version.
- Clarify OAS event bridge comments to describe the actual `Dated_jsonl` store under `.masc/oas-events/`.

## Why

The OAS public surface itself had no added or removed variants/fields, but the committed fingerprint still pointed at an older OAS pin. That kept the boundary drift check noisy even though the adapter surface was unchanged.

The live runtime check also confirmed that OAS events are stored in the date-partitioned `Dated_jsonl` layout under `.masc/oas-events/`, not as root-level `*.jsonl` files.

## Validation

- `bash scripts/oas-drift-check.sh`
- `bash scripts/check-oas-pin.sh --local-only`
- `AGENT_SDK_LOCAL_REPO=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/boundary-independence-comments MASC_STRICT_OAS_INDEPENDENCE=1 bash scripts/ci/check-masc-oas-boundary.sh`
- `git diff --check`

Focused Dune build was started, but local Dune was blocked behind another session's long-running `@all` build lock.
