### PR TITLE
chore: bump version to 0.18.13

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc_mcp)
-(version 0.18.12)
+(version 0.18.13)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Changes
- Remove stale v2.* product tags (v2.265.0, v2.266.0, v2.267.0)
- dune-project version: 0.18.12 → 0.18.13