### PR TITLE
[codex] Fix fleet FSM idle recovery false positive

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -697,7 +697,8 @@ let composite_recommended_actions_json ~keeper_name ~snapshot ~execution =
     is_live && composite_snapshot_is_idle snapshot && stale_long_enough
   in
   let blocked = composite_execution_blocked execution in
-  let needs_attention = blocked || (not is_live) || idle_attention in
+  let stale_without_live_turn = (not is_live) && stale_long_enough in
+  let needs_attention = blocked || stale_without_live_turn || idle_attention in
   let reason =
     match json_string "operator_disposition_reason" execution with
     | Some value when String.trim value <> "" -> value
@@ -705,7 +706,7 @@ let composite_recommended_actions_json ~keeper_name ~snapshot ~execution =
         match json_string "terminal_reason_code" execution with
         | Some value when String.trim value <> "" -> value
         | _ when idle_attention -> "idle_composite"
-        | _ when not is_live -> "not_live"
+        | _ when stale_without_live_turn -> "not_live"
         | _ -> "runtime_attention" )
   in
   let make action_type severity reason suggested_payload =

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -586,7 +586,13 @@ let seed_agent_file ?(agent_type = "worker") ?(capabilities = []) config agent_n
 ;;
 
 let append_execution_receipt ?(tool_contract_result = "satisfied")
-    ?(tools_used = [ "keeper_fs_read" ]) config ~keeper_name =
+    ?(tools_used = [ "keeper_fs_read" ])
+    ?(cascade_fallback_applied = true)
+    ?(cascade_outcome = "passed_to_next_model")
+    ?(degraded_retry_applied = true)
+    ?(degraded_retry_cascade =
+      Some Masc_mcp.Keeper_config.local_recovery_cascade_name)
+    ?(fallback_reason = Some "turn_timeout") config ~keeper_name =
   let meta =
     match Masc_mcp.Keeper_types.read_meta config keeper_name with
     | Ok (Some meta) -> meta
@@ -636,24 +642,26 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
       cascade_name = meta.cascade_name;
       cascade_selected_model = Some "custom:mock";
       cascade_attempt_count = 2;
-      cascade_fallback_applied = true;
-      cascade_outcome = "passed_to_next_model";
-      degraded_retry_applied = true;
-      degraded_retry_cascade =
-        Some Masc_mcp.Keeper_config.local_recovery_cascade_name;
-      fallback_reason = Some "turn_timeout";
+      cascade_fallback_applied;
+      cascade_outcome;
+      degraded_retry_applied;
+      degraded_retry_cascade;
+      fallback_reason;
       cascade_rotation_attempts =
-        [
-          {
-            from_cascade = meta.cascade_name;
-            to_cascade = Masc_mcp.Keeper_config.local_recovery_cascade_name;
-            reason = "turn_timeout";
-            outcome = "retry_scheduled";
-            error_kind = Some "internal";
-            error_message = Some "turn timeout";
-            recorded_at = ended_at;
-          };
-        ];
+        (match degraded_retry_cascade, fallback_reason with
+         | Some retry_cascade, Some reason ->
+           [
+             {
+               from_cascade = meta.cascade_name;
+               to_cascade = retry_cascade;
+               reason;
+               outcome = "retry_scheduled";
+               error_kind = Some "internal";
+               error_message = Some "turn timeout";
+               recorded_at = ended_at;
+             };
+           ]
+         | _ -> []);
       stop_reason = Some "completed";
       error_kind = None;
       error_message = None;
@@ -1298,6 +1306,35 @@ let test_composite_routes_surface_runtime_recommended_actions () =
        actions)
 ;;
 
+let test_composite_routes_skip_recent_successful_idle_recovery () =
+  with_seeded_server
+  @@ fun ~port ~config ~admin_token ~keeper_name ->
+  let boot_path = Printf.sprintf "/api/v1/keepers/%s/boot" keeper_name in
+  let boot_result =
+    run_curl_post ~body:"{}" ~token:admin_token ~port ~path:boot_path ()
+  in
+  require_status "boot route registers keeper before composite read" 200 boot_result;
+  append_execution_receipt ~tool_contract_result:"satisfied_execution"
+    ~tools_used:[ "keeper_fs_read" ]
+    ~cascade_fallback_applied:false
+    ~cascade_outcome:"completed"
+    ~degraded_retry_applied:false
+    ~degraded_retry_cascade:None
+    ~fallback_reason:None config ~keeper_name;
+  let path = Printf.sprintf "/api/v1/keepers/%s/composite" keeper_name in
+  let result = run_curl_get ~port ~path () in
+  require_status "per-keeper composite GET returns 200" 200 result;
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string result.body in
+  check bool "seeded keeper is not in a live turn" false
+    (json |> member "is_live" |> to_bool);
+  let execution = json |> member "execution" in
+  check string "receipt is healthy" "healthy"
+    (execution |> member "operator_disposition_reason" |> to_string);
+  check int "recent successful idle keeper has no runtime action" 0
+    (json |> member "recommended_actions" |> to_list |> List.length)
+;;
+
 let test_tool_calls_route_surfaces_coverage_gap_health () =
   with_seeded_server
   @@ fun ~port ~config ~admin_token:_ ~keeper_name ->
@@ -1519,6 +1556,10 @@ let () =
             "composite routes surface runtime recommended actions"
             `Slow
             test_composite_routes_surface_runtime_recommended_actions
+        ; test_case
+            "composite routes skip recent successful idle recovery"
+            `Slow
+            test_composite_routes_skip_recent_successful_idle_recovery
         ; test_case
             "tool calls route surfaces coverage gap health"
             `Slow


### PR DESCRIPTION
## Summary
- Prevent keeper composite recommended actions from treating every non-live idle snapshot as a recovery condition.
- Only classify `not_live` as attention-worthy after the existing stale threshold has elapsed.
- Add a route regression test for a recent successful idle keeper with an empty `recommended_actions` list.

## Root Cause
`/api/v1/keepers/:name/composite` used `blocked || (not is_live) || idle_attention` to decide whether a keeper needed operator action. That made normal idle keepers with fresh healthy receipts look like runtime stalls because `is_live=false` is expected when no turn is currently running.

## Operator Impact
The Fleet FSM / AI diagnosis surface should stop recommending probe/recover for recently successful idle keepers like the healthy `qa-king`/`ramarama`/`ollama-local` pattern, while preserving tool-contract blocker recommendations for real `tool_required_unsatisfied` states.

## Validation
- `git diff --check -- lib/server/server_dashboard_http.ml test/test_dashboard_keeper_routes.ml`
- `scripts/dune-local.sh build bin/main_eio.exe test/test_dashboard_keeper_routes.exe`
- `ALCOTEST_QUICK_TESTS=false _build/default/test/test_dashboard_keeper_routes.exe test --show-errors dashboard_keeper_routes 11`
- `ALCOTEST_QUICK_TESTS=false _build/default/test/test_dashboard_keeper_routes.exe test --show-errors dashboard_keeper_routes 10`