### PR TITLE
feat(oas): add provider error variant contract

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events text_similarity string_util list_util)
+ (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util)
  (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events base))

--- a/lib/core/provider_error.ml
+++ b/lib/core/provider_error.ml
@@ -1,0 +1,94 @@
+type capacity_scope = [ `Model | `Provider ]
+
+type provider_error =
+  | RateLimit of {
+      retry_after : float option;
+      provider : string;
+    }
+  | CapacityExhausted of {
+      scope : capacity_scope;
+      affected : string list;
+    }
+  | AuthError of {
+      provider : string;
+    }
+  | ServerError of {
+      code : int;
+      transient : bool;
+    }
+  | InvalidRequest of {
+      provider : string;
+      reason : string;
+    }
+
+type t = provider_error
+
+let scope_to_string = function
+  | `Model -> "model"
+  | `Provider -> "provider"
+
+let to_error_kind = function
+  | RateLimit _ -> "rate_limit"
+  | CapacityExhausted _ -> "capacity_exhausted"
+  | AuthError _ -> "auth_error"
+  | ServerError _ -> "server_error"
+  | InvalidRequest _ -> "invalid_request"
+
+let string_list_to_yojson values =
+  `List (List.map (fun value -> `String value) values)
+
+let float_option_to_yojson = function
+  | Some value -> `Float value
+  | None -> `Null
+
+let to_yojson = function
+  | RateLimit { retry_after; provider } ->
+      `Assoc
+        [
+          ("kind", `String "rate_limit");
+          ("retry_after", float_option_to_yojson retry_after);
+          ("provider", `String provider);
+        ]
+  | CapacityExhausted { scope; affected } ->
+      `Assoc
+        [
+          ("kind", `String "capacity_exhausted");
+          ("scope", `String (scope_to_string scope));
+          ("affected", string_list_to_yojson affected);
+        ]
+  | AuthError { provider } ->
+      `Assoc
+        [
+          ("kind", `String "auth_error");
+          ("provider", `String provider);
+        ]
+  | ServerError { code; transient } ->
+      `Assoc
+        [
+          ("kind", `String "server_error");
+          ("code", `Int code);
+          ("transient", `Bool transient);
+        ]
+  | InvalidRequest { provider; reason } ->
+      `Assoc
+        [
+          ("kind", `String "invalid_request");
+          ("provider", `String provider);
+          ("reason", `String reason);
+        ]
+
+let affected_providers = function
+  | RateLimit { provider; _ }
+  | AuthError { provider }
+  | InvalidRequest { provider; _ } ->
+      [ provider ]
+  | CapacityExhausted { affected; _ } -> affected
+  | ServerError _ -> []
+
+let is_capacity_exhausted = function
+  | CapacityExhausted _ -> true
+  | RateLimit _
+  | AuthError _
+  | ServerError _
+  | InvalidRequest _ ->
+      false

--- a/lib/core/provider_error.mli
+++ b/lib/core/provider_error.mli
@@ -1,0 +1,35 @@
+(** Closed provider error contract for cascade / telemetry handoff.
+
+    This module is additive: callers can emit it beside existing string
+    error labels while later sweeps remove stringly-typed decisions. *)
+
+type capacity_scope = [ `Model | `Provider ]
+
+type provider_error =
+  | RateLimit of {
+      retry_after : float option;
+      provider : string;
+    }
+  | CapacityExhausted of {
+      scope : capacity_scope;
+      affected : string list;
+    }
+  | AuthError of {
+      provider : string;
+    }
+  | ServerError of {
+      code : int;
+      transient : bool;
+    }
+  | InvalidRequest of {
+      provider : string;
+      reason : string;
+    }
+
+type t = provider_error
+
+val scope_to_string : capacity_scope -> string
+val to_error_kind : t -> string
+val to_yojson : t -> Yojson.Safe.t
+val affected_providers : t -> string list
+val is_capacity_exhausted : t -> bool

--- a/lib/oas_worker_named_fsm.ml
+++ b/lib/oas_worker_named_fsm.ml
@@ -297,6 +297,50 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
        false)
   | _ -> false
 
+let provider_label provider =
+  match String.trim provider with
+  | "" -> "unknown"
+  | value -> value
+
+let transient_http_status code =
+  code = 408 || code = 409 || code = 425 || code = 429 || code >= 500
+
+let provider_capacity ?(scope = `Provider) provider =
+  Some (Provider_error.CapacityExhausted { scope; affected = [ provider ] })
+
+let retry_api_error_to_provider_error ~provider ~capacity_exhausted api_error =
+  let provider = provider_label provider in
+  match api_error with
+  | Llm_provider.Retry.RateLimited { retry_after; _ } ->
+      if capacity_exhausted then provider_capacity provider
+      else Some (Provider_error.RateLimit { retry_after; provider })
+  | Llm_provider.Retry.Overloaded _ ->
+      provider_capacity provider
+  | Llm_provider.Retry.ServerError { status; _ } ->
+      Some
+        (Provider_error.ServerError
+           { code = status; transient = transient_http_status status })
+  | Llm_provider.Retry.AuthError _ ->
+      Some (Provider_error.AuthError { provider })
+  | Llm_provider.Retry.InvalidRequest { message } ->
+      if capacity_exhausted then provider_capacity provider
+      else Some (Provider_error.InvalidRequest { provider; reason = message })
+  | Llm_provider.Retry.NotFound { message } ->
+      Some (Provider_error.InvalidRequest { provider; reason = message })
+  | Llm_provider.Retry.ContextOverflow _ ->
+      provider_capacity ~scope:`Model provider
+  | Llm_provider.Retry.NetworkError _
+  | Llm_provider.Retry.Timeout _ ->
+      None
+
+let sdk_error_to_provider_error ~provider err =
+  match err with
+  | Oas.Error.Api api_err ->
+      retry_api_error_to_provider_error ~provider
+        ~capacity_exhausted:(sdk_error_is_hard_quota err)
+        api_err
+  | _ -> None
+
 (* When the SDK surfaces a transient HTTP 429 that is *not* a hard-quota
    in disguise, expose the [retry_after] hint that [Llm_provider.Retry]
    already extracted from the response body.  Used by the cascade error

--- a/lib/oas_worker_named_fsm.mli
+++ b/lib/oas_worker_named_fsm.mli
@@ -67,6 +67,20 @@ val sdk_error_is_hard_quota : Oas.Error.sdk_error -> bool
 (** [true] when the error represents a hard usage quota that will not
     recover within the cascade turn budget. *)
 
+val retry_api_error_to_provider_error :
+  provider:string ->
+  capacity_exhausted:bool ->
+  Llm_provider.Retry.api_error ->
+  Provider_error.t option
+(** Convert an SDK retry error into the additive provider-error contract.
+    [capacity_exhausted] is explicit so the production body classifier
+    stays at this OAS boundary instead of moving into [Provider_error]. *)
+
+val sdk_error_to_provider_error :
+  provider:string -> Oas.Error.sdk_error -> Provider_error.t option
+(** Convert API-level SDK errors into provider errors. Non-API structural
+    errors return [None]. *)
+
 val sdk_error_soft_rate_limited :
   Oas.Error.sdk_error -> float option option
 (** [Some (Some retry_after)] for non-quota 429 responses with a parsed

--- a/test/dune
+++ b/test/dune
@@ -211,6 +211,7 @@
         test_actionable_path_action
         test_stale_kill_class
         test_provider_capability_matrix
+        test_provider_error
         test_keeper_synthetic_marker
         test_keeper_turn_fsm_wired_sites)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
@@ -393,6 +394,7 @@
           test_actionable_path_action
           test_stale_kill_class
           test_provider_capability_matrix
+          test_provider_error
           test_keeper_synthetic_marker
           test_keeper_turn_fsm_wired_sites
           )

--- a/test/test_provider_error.ml
+++ b/test/test_provider_error.ml
@@ -1,0 +1,117 @@
+open Alcotest
+
+module P = Provider_error
+module Oas = Agent_sdk
+module Retry = Llm_provider.Retry
+module OWN = Masc_mcp.Oas_worker_named
+
+let check_json name expected error =
+  check string name expected (Yojson.Safe.to_string (P.to_yojson error))
+
+let expect_some = function
+  | Some value -> value
+  | None -> fail "expected provider_error"
+
+let test_rate_limit_maps_retry_after () =
+  let error =
+    Retry.RateLimited { retry_after = Some 1.5; message = "too many requests" }
+    |> OWN.retry_api_error_to_provider_error ~provider:" anthropic "
+         ~capacity_exhausted:false
+    |> expect_some
+  in
+  match error with
+  | P.RateLimit { retry_after; provider } ->
+      check string "provider normalized" "anthropic" provider;
+      check (option (float 0.001)) "retry_after" (Some 1.5) retry_after;
+      check string "kind" "rate_limit" (P.to_error_kind error);
+      check_json "json"
+        {|{"kind":"rate_limit","retry_after":1.5,"provider":"anthropic"}|}
+        error
+  | _ -> fail "expected RateLimit"
+
+let test_rate_limit_can_be_capacity_exhausted () =
+  let error =
+    Retry.RateLimited { retry_after = None; message = "resource exhausted" }
+    |> OWN.retry_api_error_to_provider_error
+         ~provider:"claude_code:auto" ~capacity_exhausted:true
+    |> expect_some
+  in
+  match error with
+  | P.CapacityExhausted { scope = `Provider; affected } ->
+      check (list string) "affected" [ "claude_code:auto" ] affected;
+      check bool "capacity" true (P.is_capacity_exhausted error);
+      check_json "json"
+        {|{"kind":"capacity_exhausted","scope":"provider","affected":["claude_code:auto"]}|}
+        error
+  | _ -> fail "expected provider CapacityExhausted"
+
+let test_anthropic_invalid_request_specified_limit_body_pins_capacity () =
+  let message =
+    "You have reached your specified API usage limits. You will regain access \
+     on 2026-05-01 at 00:00 UTC."
+  in
+  let api_error = Retry.InvalidRequest { message } in
+  let sdk_error = Oas.Error.Api api_error in
+  check bool "existing OAS hard-quota classifier pins production body" true
+    (OWN.sdk_error_is_hard_quota sdk_error);
+  let error =
+    OWN.sdk_error_to_provider_error ~provider:"anthropic" sdk_error
+    |> expect_some
+  in
+  match error with
+  | P.CapacityExhausted { scope = `Provider; affected } ->
+      check (list string) "affected" [ "anthropic" ] affected
+  | _ -> fail "expected specified-limit InvalidRequest to become capacity"
+
+let test_server_and_auth_errors_are_closed_variants () =
+  let server =
+    Retry.ServerError { status = 503; message = "overloaded" }
+    |> OWN.retry_api_error_to_provider_error ~provider:"openai"
+         ~capacity_exhausted:false
+    |> expect_some
+  in
+  let auth =
+    Retry.AuthError { message = "invalid key" }
+    |> OWN.retry_api_error_to_provider_error ~provider:"kimi"
+         ~capacity_exhausted:false
+    |> expect_some
+  in
+  match server, auth with
+  | P.ServerError { code = 503; transient = true }, P.AuthError { provider } ->
+      check string "auth provider" "kimi" provider;
+      check (list string) "server has no provider owner" []
+        (P.affected_providers server)
+  | _ -> fail "expected ServerError/AuthError"
+
+let test_non_capacity_invalid_request_preserves_reason () =
+  let reason = {|{"detail":"Bad Request"}|} in
+  let error =
+    Retry.InvalidRequest { message = reason }
+    |> OWN.retry_api_error_to_provider_error
+         ~provider:"anthropic" ~capacity_exhausted:false
+    |> expect_some
+  in
+  match error with
+  | P.InvalidRequest { provider; reason = actual } ->
+      check string "provider" "anthropic" provider;
+      check string "reason" reason actual;
+      check bool "not capacity" false (P.is_capacity_exhausted error)
+  | _ -> fail "expected InvalidRequest"
+
+let () =
+  Alcotest.run "provider_error"
+    [
+      ( "mapping",
+        [
+          test_case "rate limit maps retry_after" `Quick
+            test_rate_limit_maps_retry_after;
+          test_case "rate limit can become capacity" `Quick
+            test_rate_limit_can_be_capacity_exhausted;
+          test_case "Anthropic specified-limit body maps to capacity" `Quick
+            test_anthropic_invalid_request_specified_limit_body_pins_capacity;
+          test_case "server and auth closed variants" `Quick
+            test_server_and_auth_errors_are_closed_variants;
+          test_case "invalid request preserves reason" `Quick
+            test_non_capacity_invalid_request_preserves_reason;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Add a closed `Provider_error` contract in `masc_core` for rate limit, capacity exhaustion, auth, server, and invalid-request families.
- Add OAS worker boundary helpers that convert structured SDK retry errors into the new provider-error contract without moving production body parsing into core.
- Add focused tests covering retry-after mapping, hard quota capacity mapping, the Anthropic specified-limit body pin, server/auth variants, and invalid-request reason preservation.

## Product impact
- Creates the additive typed surface needed for #11925 before the larger string-elimination sweeps.
- Keeps existing string classifiers in place while giving follow-up work a compile-time variant to emit beside current labels.

## Evidence
- `scripts/dune-local.sh build lib/core/provider_error.{ml,mli} lib/oas_worker_named_fsm.{ml,mli} test/test_provider_error.exe`
- `scripts/dune-local.sh exec test/test_provider_error.exe` — 5 tests passed.
- `git show --check --stat --oneline HEAD`

## Review evidence
- The first build caught an attempted `masc_core` dependency on `Llm_provider`; the conversion was moved to `Oas_worker_named_fsm` so core stays pure.
- After rebasing onto latest main, a second Dune rerun was queued behind the shared `/tmp/me-dune-local.lock`; CI should be treated as the fresh post-rebase verification surface.

## Linked issue
- Refs #11925
