### PR TITLE
fix(oas): expose OAS error metric name

### DIFF
--- a/lib/oas_worker_named_error.mli
+++ b/lib/oas_worker_named_error.mli
@@ -73,6 +73,9 @@ val cascade_name_of_masc_internal_error : masc_internal_error -> string
 (** Cascade name from the error payload, or ["unknown"] for variants that
     fire outside cascade context. *)
 
+val masc_oas_error_total_metric : string
+(** Prometheus counter metric name for structured MASC OAS errors. *)
+
 val admission_wait_timeout_error :
   keeper_name:string ->
   cascade_name:string ->


### PR DESCRIPTION
## What changed

- Export `masc_oas_error_total_metric` from `Oas_worker_named_error.mli`.
- This keeps the public interface aligned with the existing implementation and facade re-export used by `Masc_mcp.Oas_worker_named`.

## Why

`test_oas_error_kind_counter` reads the canonical Prometheus metric name through `Masc_mcp.Oas_worker_named`. The implementation already defines the constant, but the extracted `.mli` did not expose it, so `dune build @all` failed with `Unbound value OWN.masc_oas_error_total_metric`.

## Impact

- Restores build/test visibility for the structured OAS error metric name.
- No runtime behavior change; this is an interface export fix.

## Validation

- `scripts/dune-local.sh clean`
- `scripts/dune-local.sh build @all`
- Rebased on latest `origin/main`
- `scripts/dune-local.sh build @all`
