### PR TITLE
ci: wire config-doctor as soft drift gate in build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,6 +515,17 @@ jobs:
           echo "::notice::dune build is hard-required (blocks merge via CI Gate); test execution failures are advisory and summarized below"
           echo "::notice::Optional env-gated suites not run here: PostgreSQL tests, live ICE/STUN/TURN/browser interop, viewer-local-e2e-check, swarm/team-session workload harnesses"
 
+      - name: Config doctor drift report
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        continue-on-error: true
+        run: |
+          if [ -f _build/default/bin/main_eio.exe ]; then
+            echo "::group::Config doctor report"
+            _build/default/bin/main_eio.exe doctor config --json || true
+            echo "::endgroup::"
+          else
+            echo "::notice::main_eio.exe not found, skipping config-doctor"
+          fi
       - name: Summarize advisory build status
         if: ${{ always() }}
         id: build_advisory_status


### PR DESCRIPTION
Wires bin/main_eio.exe doctor config --json into the CI build job as a soft drift gate (continue-on-error). Config drift becomes visible in PR checks without blocking merge.

- Runs only when dune build succeeds
- Outputs JSON report grouped in CI logs
- Falls back gracefully if binary is missing

See .masc/TODO.md entry dated 2026-04-28 for original proposal.

🤖 Generated with [Claude Code](https://claude.com/code)