### PR TITLE
fix(main): cover keeper docker HOME and metric export drift

### DIFF
--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -68,6 +68,8 @@ let build_docker_argv ~image ~container_name ~host_root ~croot
       "-i";
       "--user";
       Printf.sprintf "%d:%d" uid gid;
+      "--env";
+      "HOME=/tmp";
     ]
   @ Keeper_sandbox_runtime.docker_nofile_args ()
   @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -132,6 +132,8 @@ let start_managed_container
                     @ [
                       "--user";
                       Printf.sprintf "%d:%d" uid gid;
+                      "--env";
+                      "HOME=/tmp";
                     ]
                     @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
                     @ [

--- a/lib/oas_worker_named_error.mli
+++ b/lib/oas_worker_named_error.mli
@@ -86,10 +86,6 @@ val admission_wait_timeout_error :
 
 val cross_cascade_fallback_metric : string
 
-val masc_oas_error_total_metric : string
-(** Canonical Prometheus counter name used by
-    [sdk_error_of_masc_internal_error]. *)
-
 (** {1 Config construction} *)
 
 val config_for_label :


### PR DESCRIPTION
## Summary
- Follow-up to #12036/#12045: applies `--env HOME=/tmp` to the remaining docker run paths that were missed in the initial sweep:
  - `keeper_docker_read.ml` (docker run)
  - `keeper_sandbox_control.ml` (docker run)
- Without this, containers started with `--user <uid>:<gid>` fail with "No user exists for uid" when the UID has no /etc/passwd entry.

## Test plan
- [x] `dune build --root . @check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)