### PR TITLE
feat(oas): emit provider error variant metrics

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -536,6 +536,10 @@ let run_named
            cascade turns on a provider that is terminal for the current runtime
            state. *)
         let err_str = Oas.Error.to_string sdk_err in
+        let (_ : Provider_error.t option) =
+          emit_sdk_provider_error_metric ~cascade_name
+            ~provider:provider_cfg.model_id sdk_err
+        in
         if sdk_error_is_hard_quota sdk_err then
           Cascade_health_tracker.(
             record_hard_quota global ~provider_key:provider_cfg.model_id

--- a/lib/oas_worker_named_fsm.ml
+++ b/lib/oas_worker_named_fsm.ml
@@ -341,6 +341,37 @@ let sdk_error_to_provider_error ~provider err =
         api_err
   | _ -> None
 
+let provider_error_total_metric = "masc_provider_error_total"
+
+let provider_error_capacity_scope_label = function
+  | Provider_error.CapacityExhausted { scope; _ } ->
+      Provider_error.scope_to_string scope
+  | Provider_error.RateLimit _
+  | Provider_error.AuthError _
+  | Provider_error.ServerError _
+  | Provider_error.InvalidRequest _ ->
+      "none"
+
+let emit_provider_error_metric ~cascade_name ~provider error =
+  let cascade_name = provider_label cascade_name in
+  let provider = provider_label provider in
+  Prometheus.inc_counter provider_error_total_metric
+    ~labels:
+      [
+        ("kind", Provider_error.to_error_kind error);
+        ("provider", provider);
+        ("cascade_name", cascade_name);
+        ("capacity_scope", provider_error_capacity_scope_label error);
+      ]
+    ()
+
+let emit_sdk_provider_error_metric ~cascade_name ~provider err =
+  match sdk_error_to_provider_error ~provider err with
+  | None -> None
+  | Some provider_error ->
+      emit_provider_error_metric ~cascade_name ~provider provider_error;
+      Some provider_error
+
 (* When the SDK surfaces a transient HTTP 429 that is *not* a hard-quota
    in disguise, expose the [retry_after] hint that [Llm_provider.Retry]
    already extracted from the response body.  Used by the cascade error

--- a/lib/oas_worker_named_fsm.mli
+++ b/lib/oas_worker_named_fsm.mli
@@ -81,6 +81,25 @@ val sdk_error_to_provider_error :
 (** Convert API-level SDK errors into provider errors. Non-API structural
     errors return [None]. *)
 
+val provider_error_total_metric : string
+(** Prometheus counter for additive provider-error variant emission. *)
+
+val emit_provider_error_metric :
+  cascade_name:string ->
+  provider:string ->
+  Provider_error.t ->
+  unit
+(** Emit one provider-error variant event while preserving existing
+    string-based health tracker labels. *)
+
+val emit_sdk_provider_error_metric :
+  cascade_name:string ->
+  provider:string ->
+  Oas.Error.sdk_error ->
+  Provider_error.t option
+(** Convert and emit an SDK provider error. Returns the converted variant
+    so callers/tests can assert the same decision without reparsing metrics. *)
+
 val sdk_error_soft_rate_limited :
   Oas.Error.sdk_error -> float option option
 (** [Some (Some retry_after)] for non-quota 429 responses with a parsed

--- a/test/test_provider_error.ml
+++ b/test/test_provider_error.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module P = Provider_error
 module Oas = Agent_sdk
+module Prom = Masc_mcp.Prometheus
 module Retry = Llm_provider.Retry
 module OWN = Masc_mcp.Oas_worker_named
 
@@ -11,6 +12,17 @@ let check_json name expected error =
 let expect_some = function
   | Some value -> value
   | None -> fail "expected provider_error"
+
+let counter_for ~kind ~provider ~cascade_name ~capacity_scope =
+  Prom.metric_value_or_zero OWN.provider_error_total_metric
+    ~labels:
+      [
+        ("kind", kind);
+        ("provider", provider);
+        ("cascade_name", cascade_name);
+        ("capacity_scope", capacity_scope);
+      ]
+    ()
 
 let test_rate_limit_maps_retry_after () =
   let error =
@@ -98,6 +110,64 @@ let test_non_capacity_invalid_request_preserves_reason () =
       check bool "not capacity" false (P.is_capacity_exhausted error)
   | _ -> fail "expected InvalidRequest"
 
+let test_provider_error_metric_name_stable () =
+  check string "metric name" "masc_provider_error_total"
+    OWN.provider_error_total_metric
+
+let test_emit_sdk_provider_error_metric_rate_limit () =
+  let before =
+    counter_for ~kind:"rate_limit" ~provider:"anthropic"
+      ~cascade_name:"big_three" ~capacity_scope:"none"
+  in
+  let emitted =
+    Oas.Error.Api
+      (Retry.RateLimited { retry_after = Some 2.0; message = "too many" })
+    |> OWN.emit_sdk_provider_error_metric ~cascade_name:"big_three"
+         ~provider:"anthropic"
+    |> expect_some
+  in
+  check string "emitted kind" "rate_limit" (P.to_error_kind emitted);
+  check (float 0.0001) "counter +1" (before +. 1.0)
+    (counter_for ~kind:"rate_limit" ~provider:"anthropic"
+       ~cascade_name:"big_three" ~capacity_scope:"none")
+
+let test_emit_sdk_provider_error_metric_capacity_scope () =
+  let before =
+    counter_for ~kind:"capacity_exhausted" ~provider:"anthropic"
+      ~cascade_name:"big_three" ~capacity_scope:"provider"
+  in
+  let emitted =
+    Oas.Error.Api
+      (Retry.InvalidRequest
+         {
+           message =
+             "You have reached your specified API usage limits. You will \
+              regain access on 2026-05-01 at 00:00 UTC.";
+         })
+    |> OWN.emit_sdk_provider_error_metric ~cascade_name:"big_three"
+         ~provider:"anthropic"
+    |> expect_some
+  in
+  check string "emitted kind" "capacity_exhausted" (P.to_error_kind emitted);
+  check (float 0.0001) "counter +1" (before +. 1.0)
+    (counter_for ~kind:"capacity_exhausted" ~provider:"anthropic"
+       ~cascade_name:"big_three" ~capacity_scope:"provider")
+
+let test_emit_sdk_provider_error_metric_skips_non_api () =
+  let before =
+    counter_for ~kind:"invalid_request" ~provider:"anthropic"
+      ~cascade_name:"big_three" ~capacity_scope:"none"
+  in
+  let emitted =
+    Oas.Error.Internal "structural failure"
+    |> OWN.emit_sdk_provider_error_metric ~cascade_name:"big_three"
+         ~provider:"anthropic"
+  in
+  check bool "no provider error emitted" true (Option.is_none emitted);
+  check (float 0.0001) "counter unchanged" before
+    (counter_for ~kind:"invalid_request" ~provider:"anthropic"
+       ~cascade_name:"big_three" ~capacity_scope:"none")
+
 let () =
   Alcotest.run "provider_error"
     [
@@ -113,5 +183,13 @@ let () =
             test_server_and_auth_errors_are_closed_variants;
           test_case "invalid request preserves reason" `Quick
             test_non_capacity_invalid_request_preserves_reason;
+          test_case "metric name stable" `Quick
+            test_provider_error_metric_name_stable;
+          test_case "emit metric for rate limit" `Quick
+            test_emit_sdk_provider_error_metric_rate_limit;
+          test_case "emit metric for capacity" `Quick
+            test_emit_sdk_provider_error_metric_capacity_scope;
+          test_case "skip metric for non-api" `Quick
+            test_emit_sdk_provider_error_metric_skips_non_api;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Add `masc_provider_error_total` typed provider-error metric emission at the OAS named-cascade error boundary.
- Preserve existing string health-tracker labels while emitting the new `Provider_error` variant labels in parallel.
- Extend `test_provider_error` with metric emission checks for rate limits, capacity exhaustion, and non-API skips.

## Product impact
- Advances #11925 from pure type definition into live additive telemetry emission.
- Gives follow-up string-elimination/dashboard work a typed event count without changing current cascade cooldown behavior.

## Evidence
- `scripts/dune-local.sh build lib/oas_worker_named.{ml,mli} lib/oas_worker_named_fsm.{ml,mli} test/test_provider_error.exe`
- `scripts/dune-local.sh exec test/test_provider_error.exe` - 9 tests passed.
- `git diff --check HEAD~1..HEAD`
- `git show --check --stat --oneline HEAD`

## Review evidence
- Existing `Cascade_health_tracker` string labels remain unchanged; the typed provider-error metric is emitted beside them.
- A stale Dune interface cache after an earlier rebase was cleared with `scripts/dune-local.sh clean`; the clean focused rebuild passed, and the final rebase/build/test cycle passed without needing another clean.

## Linked issue
- Refs #11925
