### PR TITLE
perf(dashboard): Phase 1~3 performance optimizations

### DIFF
--- a/dashboard/src/components/activity-heatmap-draw.ts
+++ b/dashboard/src/components/activity-heatmap-draw.ts
@@ -1,0 +1,119 @@
+// Activity heatmap — pure Canvas 2D drawing functions (no framework deps).
+// Extracted so the same code can run in a Web Worker.
+
+export const DAY_LABELS = ['월', '화', '수', '목', '금', '토', '일'] as const
+export const HOUR_LABELS = [0, 3, 6, 9, 12, 15, 18, 21] as const
+
+export const CELL = 20
+export const GAP = 2
+export const LEFT_MARGIN = 28
+export const TOP_PAD = 20
+export const LEGEND_HEIGHT = 32
+
+const COLORS = [
+  'var(--slate-800)',
+  '#0e4a5c',
+  '#0e6e7e',
+  '#14919b',
+  'var(--cyan)',
+]
+
+export function intensityColor(count: number, max: number): string {
+  if (count === 0) return COLORS[0]
+  if (max === 0) return COLORS[0]
+  const ratio = count / max
+  if (ratio <= 0.25) return COLORS[1]
+  if (ratio <= 0.50) return COLORS[2]
+  if (ratio <= 0.75) return COLORS[3]
+  return COLORS[4]
+}
+
+export function canvasWidth(): number {
+  return LEFT_MARGIN + 24 * (CELL + GAP) - GAP
+}
+
+export function canvasHeight(): number {
+  return TOP_PAD + 7 * (CELL + GAP) - GAP + LEGEND_HEIGHT
+}
+
+export interface HeatmapCell {
+  day: number
+  hour: number
+  count: number
+}
+
+export function drawHeatmap(
+  ctx: CanvasRenderingContext2D,
+  matrix: number[][],
+  max: number,
+) {
+  const w = canvasWidth()
+  const h = canvasHeight()
+
+  // Background
+  ctx.fillStyle = '#0f1117'
+  ctx.fillRect(0, 0, w, h)
+
+  // Hour labels (top)
+  ctx.font = '10px system-ui, sans-serif'
+  ctx.fillStyle = 'var(--slate-500)'
+  ctx.textAlign = 'center'
+  for (const hour of HOUR_LABELS) {
+    const x = LEFT_MARGIN + hour * (CELL + GAP) + CELL / 2
+    ctx.fillText(String(hour), x, TOP_PAD - 6)
+  }
+
+  // Day labels (left) + cells
+  ctx.textAlign = 'right'
+  for (let day = 0; day < 7; day++) {
+    const y = TOP_PAD + day * (CELL + GAP)
+    const label = DAY_LABELS[day]!
+
+    ctx.fillStyle = 'var(--slate-400)'
+    ctx.font = '11px system-ui, sans-serif'
+    ctx.fillText(label, LEFT_MARGIN - 6, y + CELL / 2 + 4)
+
+    for (let hour = 0; hour < 24; hour++) {
+      const count = matrix[day]![hour]!
+      const x = LEFT_MARGIN + hour * (CELL + GAP)
+      ctx.fillStyle = intensityColor(count, max)
+      ctx.beginPath()
+      ctx.roundRect(x, y, CELL, CELL, 3)
+      ctx.fill()
+    }
+  }
+
+  // Legend
+  const legendY = TOP_PAD + 7 * (CELL + GAP) + 8
+  ctx.font = '10px system-ui, sans-serif'
+  ctx.fillStyle = 'var(--slate-500)'
+  ctx.textAlign = 'left'
+  ctx.fillText('적음', LEFT_MARGIN, legendY + 10)
+
+  const legendStartX = LEFT_MARGIN + 28
+  for (let i = 0; i < COLORS.length; i++) {
+    const lx = legendStartX + i * (CELL + 2)
+    ctx.fillStyle = COLORS[i]!
+    ctx.beginPath()
+    ctx.roundRect(lx, legendY, CELL, 12, 2)
+    ctx.fill()
+  }
+
+  ctx.fillStyle = 'var(--slate-500)'
+  ctx.textAlign = 'left'
+  ctx.fillText('많음', legendStartX + COLORS.length * (CELL + 2) + 4, legendY + 10)
+}
+
+export function hitTest(mx: number, my: number): HeatmapCell | null {
+  for (let day = 0; day < 7; day++) {
+    const cy = TOP_PAD + day * (CELL + GAP)
+    if (my < cy || my > cy + CELL) continue
+    for (let hour = 0; hour < 24; hour++) {
+      const cx = LEFT_MARGIN + hour * (CELL + GAP)
+      if (mx >= cx && mx <= cx + CELL) {
+        return { day, hour, count: 0 }
+      }
+    }
+  }
+  return null
+}

--- a/dashboard/src/components/activity-heatmap.ts
+++ b/dashboard/src/components/activity-heatmap.ts
@@ -257,7 +257,7 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
       <div class="mb-2">
         <p class="text-sm text-[var(--color-fg-muted)]">필터링된 전체 이벤트를 기준으로 요일별, 시간대별 활동 밀도를 보여줍니다.</p>
       </div>
-      <div ref=${containerRef} class="relative overflow-x-auto bg-[#0f1117] rounded p-3">
+      <div ref=${containerRef} class="relative overflow-x-auto bg-[#0f1117] rounded p-3 contain-content">
         <canvas ref=${canvasRef} class="block" role="img" aria-label="요일별 시간대별 활동 밀도 히트맵" />
       </div>
     <//>

--- a/dashboard/src/components/activity-heatmap.ts
+++ b/dashboard/src/components/activity-heatmap.ts
@@ -1,168 +1,55 @@
 // Activity heatmap — Canvas 2D day-of-week x hour-of-day density grid.
-// Uses server-projected density from the full filtered event set.
+// PR-4.8: Offloads the static heatmap render to a Web Worker using
+// OffscreenCanvas. The main thread only does a lightweight drawImage()
+// and HTML tooltip overlay. Falls back to main-thread rendering when
+// Worker or OffscreenCanvas are unavailable.
 
 import { html } from 'htm/preact'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { Card } from './common/card'
 import { EmptyState } from './common/feedback-state'
-import { HEATMAP_COLORS } from '../config/constants'
 import type { ActivityGraphResponse } from '../types'
+import {
+  intensityColor,
+  canvasWidth,
+  canvasHeight,
+  drawHeatmap,
+  hitTest,
+  DAY_LABELS,
+} from './activity-heatmap-draw'
 
-const DAY_LABELS = ['월', '화', '수', '목', '금', '토', '일'] as const
-const HOUR_LABELS = [0, 3, 6, 9, 12, 15, 18, 21] as const
-
-const CELL = 20
-const GAP = 2
-const LEFT_MARGIN = 28
-const TOP_PAD = 20
-const LEGEND_HEIGHT = 32
-
-const COLORS = HEATMAP_COLORS
-
-interface HeatmapCell {
-  day: number
-  hour: number
-  count: number
-}
-
-interface TooltipInfo {
-  x: number
-  y: number
-  cell: HeatmapCell
-}
+// Re-export for test consumers that assert on pure functions.
+export { intensityColor, canvasWidth, canvasHeight, hitTest }
 
 interface HeatmapProps {
   data: ActivityGraphResponse
 }
 
-export function intensityColor(count: number, max: number): string {
-  if (count === 0) return COLORS[0]
-  if (max === 0) return COLORS[0]
-  const ratio = count / max
-  if (ratio <= 0.25) return COLORS[1]
-  if (ratio <= 0.50) return COLORS[2]
-  if (ratio <= 0.75) return COLORS[3]
-  return COLORS[4]
+interface TooltipState {
+  x: number
+  y: number
+  text: string
 }
 
-export function canvasWidth(): number {
-  return LEFT_MARGIN + 24 * (CELL + GAP) - GAP
-}
-
-export function canvasHeight(): number {
-  return TOP_PAD + 7 * (CELL + GAP) - GAP + LEGEND_HEIGHT
-}
-
-function drawHeatmap(
-  ctx: CanvasRenderingContext2D,
-  matrix: number[][],
-  max: number,
-  tooltip: TooltipInfo | null,
-) {
-  const w = canvasWidth()
-  const h = canvasHeight()
-
-  // Background
-  ctx.fillStyle = '#0f1117'
-  ctx.fillRect(0, 0, w, h)
-
-  // Hour labels (top)
-  ctx.font = '10px system-ui, sans-serif'
-  ctx.fillStyle = 'var(--slate-500)'
-  ctx.textAlign = 'center'
-  for (const hour of HOUR_LABELS) {
-    const x = LEFT_MARGIN + hour * (CELL + GAP) + CELL / 2
-    ctx.fillText(String(hour), x, TOP_PAD - 6)
+let workerInstance: Worker | null = null
+function getHeatmapWorker(): Worker | null {
+  if (workerInstance) return workerInstance
+  if (typeof Worker === 'undefined' || typeof OffscreenCanvas === 'undefined') return null
+  try {
+    workerInstance = new Worker(
+      new URL('../workers/activity-heatmap.worker.ts', import.meta.url),
+    )
+    return workerInstance
+  } catch {
+    return null
   }
-
-  // Day labels (left) + cells
-  ctx.textAlign = 'right'
-  for (let day = 0; day < 7; day++) {
-    const y = TOP_PAD + day * (CELL + GAP)
-    const label = DAY_LABELS[day]!
-
-    ctx.fillStyle = 'var(--slate-400)'
-    ctx.font = '11px system-ui, sans-serif'
-    ctx.fillText(label, LEFT_MARGIN - 6, y + CELL / 2 + 4)
-
-    for (let hour = 0; hour < 24; hour++) {
-      const count = matrix[day]![hour]!
-      const x = LEFT_MARGIN + hour * (CELL + GAP)
-      ctx.fillStyle = intensityColor(count, max)
-      ctx.beginPath()
-      ctx.roundRect(x, y, CELL, CELL, 3)
-      ctx.fill()
-    }
-  }
-
-  // Legend
-  const legendY = TOP_PAD + 7 * (CELL + GAP) + 8
-  ctx.font = '10px system-ui, sans-serif'
-  ctx.fillStyle = 'var(--slate-500)'
-  ctx.textAlign = 'left'
-  ctx.fillText('적음', LEFT_MARGIN, legendY + 10)
-
-  const legendStartX = LEFT_MARGIN + 28
-  for (let i = 0; i < COLORS.length; i++) {
-    const lx = legendStartX + i * (CELL + 2)
-    ctx.fillStyle = COLORS[i]!
-    ctx.beginPath()
-    ctx.roundRect(lx, legendY, CELL, 12, 2)
-    ctx.fill()
-  }
-
-  ctx.fillStyle = 'var(--slate-500)'
-  ctx.textAlign = 'left'
-  ctx.fillText('많음', legendStartX + COLORS.length * (CELL + 2) + 4, legendY + 10)
-
-  // Tooltip
-  if (tooltip) {
-    const { x, y, cell } = tooltip
-    const dayName = DAY_LABELS[cell.day] ?? '?'
-    const text = `${dayName}요일 ${cell.hour}시 — ${cell.count}건`
-
-    ctx.font = '11px system-ui, sans-serif'
-    const metrics = ctx.measureText(text)
-    const padX = 10
-    const padY = 6
-    const boxW = metrics.width + padX * 2
-    const boxH = 24
-
-    const tx = Math.min(x + 12, w - boxW - 4)
-    const ty = Math.max(y - boxH - 4, 4)
-
-    ctx.fillStyle = 'rgba(15, 23, 42, 0.95)'
-    ctx.beginPath()
-    ctx.roundRect(tx, ty, boxW, boxH, 6)
-    ctx.fill()
-    ctx.strokeStyle = 'rgba(100, 116, 139, 0.3)'
-    ctx.lineWidth = 1
-    ctx.stroke()
-
-    ctx.fillStyle = 'var(--frost-100)'
-    ctx.textAlign = 'left'
-    ctx.fillText(text, tx + padX, ty + padY + 11)
-  }
-}
-
-export function hitTest(mx: number, my: number): HeatmapCell | null {
-  for (let day = 0; day < 7; day++) {
-    const cy = TOP_PAD + day * (CELL + GAP)
-    if (my < cy || my > cy + CELL) continue
-    for (let hour = 0; hour < 24; hour++) {
-      const cx = LEFT_MARGIN + hour * (CELL + GAP)
-      if (mx >= cx && mx <= cx + CELL) {
-        return { day, hour, count: 0 }
-      }
-    }
-  }
-  return null
 }
 
 export function ActivityHeatmap({ data }: HeatmapProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
-  const tooltipRef = useRef<TooltipInfo | null>(null)
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const pendingJobRef = useRef(false)
 
   const matrix = data.heatmap.matrix
   const max = data.heatmap.max
@@ -184,9 +71,33 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
 
     const ctx = canvas.getContext('2d')
     if (!ctx) return
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
 
-    drawHeatmap(ctx, matrix, max, tooltipRef.current)
+    const worker = getHeatmapWorker()
+    if (worker && !pendingJobRef.current) {
+      pendingJobRef.current = true
+      const onMessage = (event: MessageEvent<{ bitmap: ImageBitmap | null }>) => {
+        pendingJobRef.current = false
+        const { bitmap } = event.data
+        if (bitmap) {
+          ctx.save()
+          ctx.setTransform(1, 0, 0, 1, 0, 0)
+          ctx.clearRect(0, 0, canvas.width, canvas.height)
+          ctx.drawImage(bitmap, 0, 0)
+          ctx.restore()
+          bitmap.close()
+        } else {
+          // Worker failed — fallback to main-thread render.
+          ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+          drawHeatmap(ctx, matrix, max)
+        }
+      }
+      worker.addEventListener('message', onMessage, { once: true })
+      worker.postMessage({ matrix, max, dpr })
+    } else {
+      // Worker unavailable or job already in flight — main-thread fallback.
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+      drawHeatmap(ctx, matrix, max)
+    }
 
     function handleMouse(event: MouseEvent) {
       const canvasEl = canvasRef.current
@@ -199,40 +110,25 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
       const my = (event.clientY - rect.top) * scaleY
 
       const hit = hitTest(mx, my)
-      const prev = tooltipRef.current
-
       if (hit) {
         hit.count = matrix[hit.day]![hit.hour]!
-        tooltipRef.current = { x: mx, y: my, cell: hit }
+        const dayName = DAY_LABELS[hit.day] ?? '?'
+        setTooltip({
+          x: event.clientX - rect.left,
+          y: event.clientY - rect.top,
+          text: `${dayName}요일 ${hit.hour}시 — ${hit.count}건`,
+        })
         canvasEl.style.cursor = 'pointer'
       } else {
-        tooltipRef.current = null
+        setTooltip(null)
         canvasEl.style.cursor = 'default'
-      }
-
-      const changed = (hit !== null) !== (prev !== null)
-        || (hit && prev && (hit.day !== prev.cell.day || hit.hour !== prev.cell.hour))
-      if (changed) {
-        const ctx2 = canvasEl.getContext('2d')
-        if (ctx2) {
-          const dpr2 = window.devicePixelRatio || 1
-          ctx2.setTransform(dpr2, 0, 0, dpr2, 0, 0)
-          drawHeatmap(ctx2, matrix, max, tooltipRef.current)
-        }
       }
     }
 
     function handleLeave() {
+      setTooltip(null)
       const canvasEl = canvasRef.current
-      if (!canvasEl) return
-      tooltipRef.current = null
-      const ctx2 = canvasEl.getContext('2d')
-      if (ctx2) {
-        const dpr2 = window.devicePixelRatio || 1
-        ctx2.setTransform(dpr2, 0, 0, dpr2, 0, 0)
-        drawHeatmap(ctx2, matrix, max, null)
-      }
-      canvasEl.style.cursor = 'default'
+      if (canvasEl) canvasEl.style.cursor = 'default'
     }
 
     canvas.addEventListener('mousemove', handleMouse)
@@ -259,6 +155,22 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
       </div>
       <div ref=${containerRef} class="relative overflow-x-auto bg-[#0f1117] rounded p-3 contain-content">
         <canvas ref=${canvasRef} class="block" role="img" aria-label="요일별 시간대별 활동 밀도 히트맵" />
+        ${tooltip
+          ? html`
+            <div
+              class="absolute pointer-events-none z-10 px-2.5 py-1.5 rounded-md text-xs whitespace-nowrap"
+              style=${{
+                left: `${Math.min(tooltip.x + 12, canvasWidth() - 140)}px`,
+                top: `${Math.max(tooltip.y - 32, 4)}px`,
+                background: 'rgba(15, 23, 42, 0.95)',
+                border: '1px solid rgba(100, 116, 139, 0.3)',
+                color: 'var(--frost-100)',
+              }}
+            >
+              ${tooltip.text}
+            </div>
+          `
+          : null}
       </div>
     <//>
   `

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -705,7 +705,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           return html`
             <button type="button"
-              class="monitor-surface-card monitor-surface-card-medium group flex w-full flex-col gap-3.5 rounded-card p-4 text-left transition-all duration-[var(--t-med)] cursor-pointer hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)] hover:-translate-y-0.5"
+              class="monitor-surface-card monitor-surface-card-medium group flex w-full flex-col gap-3.5 rounded-card p-4 text-left transition-all duration-[var(--t-med)] cursor-pointer hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)] hover:-translate-y-0.5 contain-content"
               key=${agent.name}
               aria-label=${detailLabel}
               onClick=${openDetail}

--- a/dashboard/src/components/common/virtual-list.a11y.test.ts
+++ b/dashboard/src/components/common/virtual-list.a11y.test.ts
@@ -89,4 +89,43 @@ describe('VirtualList a11y', () => {
     )
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  describe('dynamic height mode', () => {
+    const dynamicRenderItem = (item: string, _i: number) => html`
+      <div role="listitem" style=${{ height: `${item.length * 10}px` }}>${item}</div>
+    `
+
+    it('below-threshold dynamic mode passes axe', async () => {
+      const items = Array.from({ length: 10 }, (_, i) => `item-${i}`)
+      render(
+        html`<div role="list">
+          <${VirtualList}
+            items=${items}
+            estimatedItemHeight=${24}
+            renderItem=${dynamicRenderItem}
+            getKey=${(x: string) => x}
+          />
+        </div>`,
+        container,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('above-threshold dynamic mode passes axe', async () => {
+      const items = Array.from({ length: 200 }, (_, i) => `entry-${i}`)
+      render(
+        html`<div role="list">
+          <${VirtualList}
+            items=${items}
+            estimatedItemHeight=${20}
+            overscan=${3}
+            renderItem=${dynamicRenderItem}
+            getKey=${(x: string) => x}
+          />
+        </div>`,
+        container,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
 })

--- a/dashboard/src/components/common/virtual-list.ts
+++ b/dashboard/src/components/common/virtual-list.ts
@@ -1,4 +1,4 @@
-// VirtualList — scroll-position based windowing for fixed-height items
+// VirtualList — scroll-position based windowing for fixed and dynamic-height items
 //
 // Only activates above ACTIVATION_THRESHOLD items. Below that, renders all
 // items directly (zero overhead). Uses requestAnimationFrame-throttled scroll
@@ -8,14 +8,16 @@
 // The threshold check only affects the returned markup.
 
 import { html } from 'htm/preact'
-import { useRef, useEffect, useState } from 'preact/hooks'
+import { useRef, useEffect, useState, useMemo } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
+import { onFpsChange } from '../../utils/fps-adaptive'
 
 const ACTIVATION_THRESHOLD = 40
 
 interface VirtualListProps<T> {
   items: T[]
-  itemHeight: number
+  itemHeight?: number
+  estimatedItemHeight?: number
   overscan?: number
   renderItem: (item: T, index: number) => ComponentChildren
   getKey: (item: T) => string
@@ -27,9 +29,24 @@ interface VisibleRange {
   end: number
 }
 
+function binarySearchOffset(offsets: number[], target: number): number {
+  let lo = 0
+  let hi = offsets.length - 1
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2)
+    if (offsets[mid] < target) {
+      lo = mid + 1
+    } else {
+      hi = mid
+    }
+  }
+  return lo
+}
+
 export function VirtualList<T>({
   items,
   itemHeight,
+  estimatedItemHeight = 40,
   overscan = 5,
   renderItem,
   getKey,
@@ -37,8 +54,35 @@ export function VirtualList<T>({
 }: VirtualListProps<T>) {
   // Hooks must be called unconditionally (Rules of Hooks)
   const containerRef = useRef<HTMLDivElement>(null)
+  const heightsRef = useRef<Map<string, number>>(new Map())
   const [range, setRange] = useState<VisibleRange>({ start: 0, end: 30 })
+  const [measureTick, setMeasureTick] = useState(0)
+  const [effectiveOverscan, setEffectiveOverscan] = useState(overscan)
   const virtualize = items.length > ACTIVATION_THRESHOLD
+
+  const dynamicMode = itemHeight === undefined
+
+  // PR-4.9: FPS adaptive quality — shrink overscan when frame rate drops.
+  useEffect(() => {
+    if (!virtualize) return undefined
+    return onFpsChange((fps) => {
+      if (fps < 30) setEffectiveOverscan(1)
+      else if (fps < 45) setEffectiveOverscan(Math.max(2, overscan - 2))
+      else setEffectiveOverscan(overscan)
+    })
+  }, [virtualize, overscan])
+
+  const offsets = useMemo(() => {
+    if (!dynamicMode) return [] as number[]
+    const acc: number[] = new Array(items.length + 1)
+    acc[0] = 0
+    for (let i = 0; i < items.length; i++) {
+      const h = heightsRef.current.get(getKey(items[i])) ?? estimatedItemHeight
+      acc[i + 1] = acc[i] + h
+    }
+    return acc
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dynamicMode, items, measureTick, estimatedItemHeight, getKey])
 
   useEffect(() => {
     if (!virtualize) return
@@ -48,16 +92,30 @@ export function VirtualList<T>({
     let disposed = false
 
     const recompute = () => {
-      const { scrollTop, clientHeight } = el
-      const newStart = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan)
-      const newEnd = Math.min(
-        items.length,
-        Math.ceil((scrollTop + clientHeight) / itemHeight) + overscan,
-      )
-      setRange(prev => {
-        if (prev.start === newStart && prev.end === newEnd) return prev
-        return { start: newStart, end: newEnd }
-      })
+      const os = effectiveOverscan
+      if (dynamicMode) {
+        const { scrollTop, clientHeight } = el
+        const startIdx = binarySearchOffset(offsets, scrollTop)
+        const newStart = Math.max(0, startIdx - os)
+        const endIdx = binarySearchOffset(offsets, scrollTop + clientHeight)
+        const newEnd = Math.min(items.length, endIdx + os)
+        setRange(prev => {
+          if (prev.start === newStart && prev.end === newEnd) return prev
+          return { start: newStart, end: newEnd }
+        })
+      } else {
+        const { scrollTop, clientHeight } = el
+        const ih = itemHeight!
+        const newStart = Math.max(0, Math.floor(scrollTop / ih) - os)
+        const newEnd = Math.min(
+          items.length,
+          Math.ceil((scrollTop + clientHeight) / ih) + os,
+        )
+        setRange(prev => {
+          if (prev.start === newStart && prev.end === newEnd) return prev
+          return { start: newStart, end: newEnd }
+        })
+      }
     }
 
     let ticking = false
@@ -83,7 +141,45 @@ export function VirtualList<T>({
       el.removeEventListener('scroll', onScroll)
       ro.disconnect()
     }
-  }, [virtualize, items.length, itemHeight, overscan])
+  }, [virtualize, items.length, itemHeight, effectiveOverscan, dynamicMode, offsets])
+
+  // Observe child heights in dynamic mode
+  useEffect(() => {
+    if (!virtualize || !dynamicMode) return
+    const el = containerRef.current
+    if (!el) return
+
+    let disposed = false
+    const ro = new ResizeObserver((entries) => {
+      let changed = false
+      for (const entry of entries) {
+        const target = entry.target as HTMLElement
+        const key = target.dataset.vlKey
+        if (!key) continue
+        const h = entry.borderBoxSize?.[0]?.blockSize ?? target.getBoundingClientRect().height
+        const prev = heightsRef.current.get(key)
+        if (prev !== h) {
+          heightsRef.current.set(key, h)
+          changed = true
+        }
+      }
+      if (changed && !disposed) {
+        setMeasureTick(t => t + 1)
+      }
+    })
+
+    const viewport = el.querySelector('.virtual-list-viewport')
+    if (viewport) {
+      for (const child of viewport.children) {
+        ro.observe(child)
+      }
+    }
+
+    return () => {
+      disposed = true
+      ro.disconnect()
+    }
+  }, [virtualize, dynamicMode, range.start, range.end])
 
   // Below threshold: render all items directly, no virtualization
   if (!virtualize) {
@@ -94,8 +190,40 @@ export function VirtualList<T>({
     `
   }
 
-  const totalHeight = items.length * itemHeight
-  const offsetY = range.start * itemHeight
+  // Dynamic height path
+  if (dynamicMode) {
+    const totalHeight = offsets[items.length] ?? items.length * estimatedItemHeight
+    const offsetY = offsets[range.start] ?? range.start * estimatedItemHeight
+    const visible = items.slice(range.start, range.end)
+
+    return html`
+      <div ref=${containerRef} class=${className}>
+        <div class="virtual-list-spacer" style=${{ height: `${totalHeight}px`, position: 'relative' }}>
+          <div
+            class="virtual-list-viewport"
+            style=${{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              willChange: 'transform',
+              transform: `translateY(${offsetY}px)`,
+            }}
+          >
+            ${visible.map((item, i) => {
+              const idx = range.start + i
+              return html`<div key=${getKey(item)} data-vl-key=${getKey(item)}>${renderItem(item, idx)}</div>`
+            })}
+          </div>
+        </div>
+      </div>
+    `
+  }
+
+  // Fixed height path
+  const ih = itemHeight!
+  const totalHeight = items.length * ih
+  const offsetY = range.start * ih
   const visible = items.slice(range.start, range.end)
 
   return html`

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -137,7 +137,7 @@ export function CompositeFsmFlowchart(props: CompositeFsmFlowchartProps = {}) {
   return html`
     <section
       data-testid="composite-fsm-flowchart"
-      class="rounded border border-[var(--white-10)] bg-[var(--white-5)] ${props.class ?? ''}"
+      class="rounded border border-[var(--white-10)] bg-[var(--white-5)] contain-content ${props.class ?? ''}"
       aria-label="복합 FSM 플로우차트"
     >
       <header class="border-b border-[var(--white-10)] p-3">

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1647,7 +1647,7 @@ export function ConnectorStatusPanel() {
     : findKnownConnector(allConnectors, focusedConnectorId) ?? placeholderConnector(focusedConnectorId)
 
   return html`
-    <div>
+    <div class="contain-content">
       <div class="mb-3 flex items-start justify-between gap-3">
         <div>
           <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">${filterId ? CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? '커넥터' : '커넥터'}</h3>

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -839,7 +839,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   return html`
     <section
       data-testid="fleet-fsm-matrix"
-      class="rounded border border-[var(--white-10)] bg-[var(--white-5)]"
+      class="contain-content rounded border border-[var(--white-10)] bg-[var(--white-5)]"
       aria-label="Fleet FSM 통합 상태"
     >
       <header class="flex flex-wrap items-baseline gap-3 border-b border-[var(--white-10)] p-3">

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -61,7 +61,7 @@ export function FleetHealthPanel() {
   const view = activeView.value
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="contain-content flex flex-col gap-4">
         <div class="flex flex-col gap-1">
           <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">운영 신호 묶음</div>
           <p class="m-0 text-xs leading-paragraph text-[var(--color-fg-muted)]">

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -685,7 +685,7 @@ export function FleetTelemetryPanel() {
   const offlineCount = value.rows.length - activeCount
 
   return html`
-    <div class="flex flex-col gap-4 p-4">
+    <div class="contain-content flex flex-col gap-4 p-4">
       <div class="flex items-start justify-between gap-3">
         <div class="flex items-center gap-3">
           <h2 class="text-sm font-medium">Keeper 텔레메트리</h2>

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -513,7 +513,7 @@ export function FsmHub(props: FsmHubProps = {}) {
 
   const rootGap = density === 'compact' ? 'gap-1.5' : 'gap-3'
   return html`
-    <div class=${`flex flex-col ${rootGap}`} data-density=${density}>
+    <div class=${`contain-content flex flex-col ${rootGap}`} data-density=${density}>
       ${/* ── Zone 1: Status Bar ── */ ''}
       <${StatusBar}
         snapshot=${snapshot}

--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -18,7 +18,7 @@ export function Live({ variant = 'full' }: LiveProps) {
   return html`
     <div class="flex flex-col gap-5">
       ${!observatoryMode ? html`
-        <section class="monitor-surface-card monitor-surface-card-strong px-5 py-4" aria-label="라이브 모니터 소개">
+        <section class="contain-content monitor-surface-card monitor-surface-card-strong px-5 py-4" aria-label="라이브 모니터 소개">
           <div class="flex flex-col gap-2">
             <div class="flex flex-col gap-2">
               <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--color-fg-secondary)]">라이브 모니터</h2>
@@ -29,7 +29,7 @@ export function Live({ variant = 'full' }: LiveProps) {
       ` : null}
 
       ${!observatoryMode ? html`
-        <section class="rounded-[var(--radius-xl)] border border-[var(--color-border-divider)] bg-[var(--white-3)] p-4" aria-label="이벤트 펄스 현황">
+        <section class="contain-content rounded-[var(--radius-xl)] border border-[var(--color-border-divider)] bg-[var(--white-3)] p-4" aria-label="이벤트 펄스 현황">
           <${PulseStrip} />
         </section>
       ` : null}
@@ -37,7 +37,7 @@ export function Live({ variant = 'full' }: LiveProps) {
       ${!observatoryMode ? html`<${KeeperHealthStrip} />` : null}
 
       ${observatoryMode ? html`
-        <section class="live-panel-main monitor-surface-card monitor-surface-card-medium p-4" aria-label="활동 스트림">
+        <section class="contain-content live-panel-main monitor-surface-card monitor-surface-card-medium p-4" aria-label="활동 스트림">
           <${ActivityStream} />
         </section>
 
@@ -46,10 +46,10 @@ export function Live({ variant = 'full' }: LiveProps) {
         <//>
       ` : html`
         <div class="live-panels grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
-          <section class="live-panel-main monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-130 p-4" aria-label="활동 스트림">
+          <section class="contain-content live-panel-main monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-130 p-4" aria-label="활동 스트림">
             <${ActivityStream} />
           </section>
-          <section class="live-panel-side monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-130 p-4" aria-label="에이전트 상태 사이드바">
+          <section class="contain-content live-panel-side monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-130 p-4" aria-label="에이전트 상태 사이드바">
             <${FocusSidebar} />
           </section>
         </div>

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -364,7 +364,7 @@ export function LogViewer() {
 
   return html`
     <div class="logs-viewer flex h-full min-h-0 flex-col gap-4">
-      <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-[rgba(138,163,211,0.16)] bg-[rgba(7,13,24,0.86)]" aria-label="로그 뷰어">
+      <section class="contain-content flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-[rgba(138,163,211,0.16)] bg-[rgba(7,13,24,0.86)]" aria-label="로그 뷰어">
         <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[var(--white-5)] px-4 py-4">
           <div class="logs-filters flex flex-wrap gap-2 items-center">
             <${Select}

--- a/dashboard/src/dashboard-ws-parse.ts
+++ b/dashboard/src/dashboard-ws-parse.ts
@@ -1,0 +1,36 @@
+/**
+ * Dashboard WebSocket message parsing — extracted so it can run in a
+ * Web Worker without pulling in the main-thread signal graph.
+ */
+
+export function parseWebSocketSseFrames(data: string): unknown[] {
+  const payloads: unknown[] = []
+  const frames = data.split(/\r?\n\r?\n/)
+  for (const frame of frames) {
+    const dataLines: string[] = []
+    for (const line of frame.split(/\r?\n/)) {
+      if (!line.startsWith('data:')) continue
+      const value = line.slice('data:'.length)
+      dataLines.push(value.startsWith(' ') ? value.slice(1) : value)
+    }
+    if (dataLines.length === 0) continue
+    const body = dataLines.join('\n').trim()
+    if (!body || body === '[DONE]') continue
+    try {
+      payloads.push(JSON.parse(body))
+    } catch (err) {
+      const sample = body.length > 200 ? `${body.slice(0, 200)}…(${body.length} bytes total)` : body
+      // eslint-disable-next-line no-console
+      console.warn('[dashboard-ws] non-JSON SSE frame dropped', { sample, err })
+    }
+  }
+  return payloads
+}
+
+export function parseIncomingPayloads(data: string): unknown[] {
+  try {
+    return [JSON.parse(data)]
+  } catch {
+    return parseWebSocketSseFrames(data)
+  }
+}

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -11,6 +11,7 @@ import {
   connectDashboardWS,
   dashboardSlicesForRoute,
   disconnectDashboardWS,
+  flushPendingInbound,
   parseWebSocketSseFrames,
   subscribeDashboardRoute,
 } from './dashboard-ws'
@@ -63,6 +64,7 @@ class MockWebSocket {
 
   receive(payload: unknown): void {
     this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent)
+    flushPendingInbound()
   }
 }
 
@@ -108,6 +110,17 @@ async function flushPromises(): Promise<void> {
   await Promise.resolve()
   await Promise.resolve()
 }
+
+beforeEach(() => {
+  // Make requestAnimationFrame synchronous so the rAF accumulator
+  // flushes immediately inside the same task.  Tests remain
+  // unchanged and do not need to await microtasks.
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0)
+    return 0
+  })
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+})
 
 afterEach(() => {
   disconnectDashboardWS()

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -41,6 +41,64 @@ let shouldReconnect = true
 let connectGeneration = 0
 const pending = new Map<number, PendingRpc>()
 
+// Phase 2 (PR-4.6): rAF accumulator for inbound WS messages.
+// Instead of processing every WS frame immediately (which can trigger
+// multiple signal writes / renders), we buffer them and flush on the
+// next animation frame.  This bounds update frequency to 60 Hz and
+// lets batch() coalesce all signal mutations in a single frame.
+const pendingInbound: string[] = []
+let flushHandle = 0
+
+function scheduleFlush(): void {
+  if (flushHandle) return
+  if (typeof requestAnimationFrame === 'undefined') {
+    // Fallback for non-browser environments (e.g. vitest with happy-dom).
+    flushHandle = setTimeout(() => {
+      flushHandle = 0
+      flushPending()
+    }, 0) as unknown as number
+    return
+  }
+  flushHandle = requestAnimationFrame(() => {
+    flushHandle = 0
+    flushPending()
+  })
+}
+
+function flushPending(): void {
+  const batchData = pendingInbound.slice()
+  pendingInbound.length = 0
+  for (const data of batchData) {
+    processInboundMessage(data)
+  }
+}
+
+function clearPendingInbound(): void {
+  pendingInbound.length = 0
+  if (flushHandle) {
+    if (typeof cancelAnimationFrame !== 'undefined') {
+      cancelAnimationFrame(flushHandle)
+    } else {
+      clearTimeout(flushHandle)
+    }
+    flushHandle = 0
+  }
+}
+
+/** Test-only helper: synchronously flush any pending inbound messages.
+ *  Production code should never call this — the rAF loop owns timing. */
+export function flushPendingInbound(): void {
+  if (flushHandle) {
+    if (typeof cancelAnimationFrame !== 'undefined') {
+      cancelAnimationFrame(flushHandle)
+    } else {
+      clearTimeout(flushHandle)
+    }
+    flushHandle = 0
+  }
+  flushPending()
+}
+
 function rememberRouteState(routeState: DashboardRouteState): DashboardRouteState {
   desiredRouteState = {
     tab: routeState.tab,
@@ -124,6 +182,7 @@ function closeSocket(): void {
     socket.close()
     socket = null
   }
+  clearPendingInbound()
   rejectPendingRpcs(new Error('dashboard websocket closed'))
 }
 
@@ -306,9 +365,8 @@ export function parseWebSocketSseFrames(data: string): unknown[] {
   return payloads
 }
 
-function handleMessage(data: unknown): void {
+function processInboundMessage(data: string): void {
   batch(() => {
-    if (typeof data !== 'string') return
     let raw: unknown
     try {
       raw = JSON.parse(data)
@@ -324,6 +382,12 @@ function handleMessage(data: unknown): void {
     if (handleNotification(record)) return
     handleRawPush(record)
   })
+}
+
+function handleMessage(data: unknown): void {
+  if (typeof data !== 'string') return
+  pendingInbound.push(data)
+  scheduleFlush()
 }
 
 function reconnectAfterCurrentSocketFailure(ws: WebSocket, err: unknown): void {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -1,6 +1,7 @@
 import type { RouteState, SSEEvent } from './types'
 import { parseSSEMessage } from './schemas/sse'
 import { hydrateDashboardSlice, routeServerPushEvent } from './sse-store'
+import { batch } from '@preact/signals'
 import {
   dashboardWsConnected,
   dashboardWsLastError,
@@ -194,15 +195,17 @@ function handleRpcResponse(raw: JsonObject): boolean {
 }
 
 function applySnapshot(raw: unknown): void {
-  const snapshot = raw as { slices?: unknown; seq?: unknown }
-  if (typeof snapshot.seq === 'number') {
-    dashboardWsLastSeq.value = snapshot.seq
-  }
-  const slices = snapshot.slices as Record<string, unknown> | undefined
-  if (!slices || typeof slices !== 'object') return
-  for (const [slice, payload] of Object.entries(slices)) {
-    hydrateRouteDashboardSlice(slice, payload)
-  }
+  batch(() => {
+    const snapshot = raw as { slices?: unknown; seq?: unknown }
+    if (typeof snapshot.seq === 'number') {
+      dashboardWsLastSeq.value = snapshot.seq
+    }
+    const slices = snapshot.slices as Record<string, unknown> | undefined
+    if (!slices || typeof slices !== 'object') return
+    for (const [slice, payload] of Object.entries(slices)) {
+      hydrateRouteDashboardSlice(slice, payload)
+    }
+  })
 }
 
 function applySubscribeResult(raw: unknown): void {
@@ -211,26 +214,28 @@ function applySubscribeResult(raw: unknown): void {
 }
 
 function applyDelta(raw: unknown): void {
-  const delta = raw as {
-    seq?: unknown
-    slice?: unknown
-    event_type?: unknown
-    payload?: unknown
-  }
-  if (typeof delta.seq === 'number') {
-    dashboardWsLastSeq.value = delta.seq
-    sendNotification('dashboard/ack', {
-      seq: delta.seq,
-      bufferedAmount: socket?.bufferedAmount ?? 0,
-    })
-  }
-  noteDashboardWsEvent()
-  if (typeof delta.slice !== 'string') return
-  hydrateRouteDashboardSlice(
-    delta.slice,
-    delta.payload,
-    typeof delta.event_type === 'string' ? delta.event_type : undefined,
-  )
+  batch(() => {
+    const delta = raw as {
+      seq?: unknown
+      slice?: unknown
+      event_type?: unknown
+      payload?: unknown
+    }
+    if (typeof delta.seq === 'number') {
+      dashboardWsLastSeq.value = delta.seq
+      sendNotification('dashboard/ack', {
+        seq: delta.seq,
+        bufferedAmount: socket?.bufferedAmount ?? 0,
+      })
+    }
+    noteDashboardWsEvent()
+    if (typeof delta.slice !== 'string') return
+    hydrateRouteDashboardSlice(
+      delta.slice,
+      delta.payload,
+      typeof delta.event_type === 'string' ? delta.event_type : undefined,
+    )
+  })
 }
 
 function activeRouteWantsDashboardSlice(slice: string): boolean {
@@ -262,11 +267,13 @@ function unwrapSseCandidate(raw: JsonObject): unknown {
 }
 
 function handleRawPush(raw: unknown): void {
-  if (!raw || typeof raw !== 'object') return
-  const candidate = unwrapSseCandidate(raw as JsonObject)
-  const parsed = parseSSEMessage(candidate)
-  if (!parsed) return
-  routeServerPushEvent(parsed as unknown as SSEEvent)
+  batch(() => {
+    if (!raw || typeof raw !== 'object') return
+    const candidate = unwrapSseCandidate(raw as JsonObject)
+    const parsed = parseSSEMessage(candidate)
+    if (!parsed) return
+    routeServerPushEvent(parsed as unknown as SSEEvent)
+  })
 }
 
 export function parseWebSocketSseFrames(data: string): unknown[] {
@@ -300,28 +307,32 @@ export function parseWebSocketSseFrames(data: string): unknown[] {
 }
 
 function handleMessage(data: unknown): void {
-  if (typeof data !== 'string') return
-  let raw: unknown
-  try {
-    raw = JSON.parse(data)
-  } catch {
-    for (const payload of parseWebSocketSseFrames(data)) {
-      handleRawPush(payload)
+  batch(() => {
+    if (typeof data !== 'string') return
+    let raw: unknown
+    try {
+      raw = JSON.parse(data)
+    } catch {
+      for (const payload of parseWebSocketSseFrames(data)) {
+        handleRawPush(payload)
+      }
+      return
     }
-    return
-  }
-  if (!raw || typeof raw !== 'object') return
-  const record = raw as JsonObject
-  if (handleRpcResponse(record)) return
-  if (handleNotification(record)) return
-  handleRawPush(record)
+    if (!raw || typeof raw !== 'object') return
+    const record = raw as JsonObject
+    if (handleRpcResponse(record)) return
+    if (handleNotification(record)) return
+    handleRawPush(record)
+  })
 }
 
 function reconnectAfterCurrentSocketFailure(ws: WebSocket, err: unknown): void {
   if (socket !== ws) return
-  dashboardWsConnected.value = false
-  dashboardWsReady.value = false
-  dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+  batch(() => {
+    dashboardWsConnected.value = false
+    dashboardWsReady.value = false
+    dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+  })
   lastSubscribeKey = ''
   closeSocket()
   scheduleReconnect()
@@ -362,7 +373,9 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     discovery = await discoverWsUrl()
   } catch (err) {
     if (generation === connectGeneration && shouldReconnect) {
-      dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+      batch(() => {
+        dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+      })
       scheduleReconnect()
     }
     return
@@ -370,7 +383,9 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
   const wsUrl = discovery.wsUrl
   if (!wsUrl) {
     if (generation === connectGeneration && shouldReconnect && discovery.retry) {
-      dashboardWsLastError.value = 'dashboard websocket unavailable'
+      batch(() => {
+        dashboardWsLastError.value = 'dashboard websocket unavailable'
+      })
       scheduleReconnect()
     }
     return
@@ -392,8 +407,10 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     })
       .then(() => {
         if (socket !== ws) return
-        dashboardWsReady.value = true
-        dashboardWsLastError.value = null
+        batch(() => {
+          dashboardWsReady.value = true
+          dashboardWsLastError.value = null
+        })
         if (desiredRouteState) {
           void subscribeDashboardRoute(desiredRouteState)
             .catch(err => reconnectAfterCurrentSocketFailure(ws, err))
@@ -407,12 +424,16 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
   }
   ws.onerror = () => {
     if (socket !== ws) return
-    dashboardWsLastError.value = 'dashboard websocket error'
+    batch(() => {
+      dashboardWsLastError.value = 'dashboard websocket error'
+    })
   }
   ws.onclose = () => {
     if (socket !== ws) return
-    dashboardWsConnected.value = false
-    dashboardWsReady.value = false
+    batch(() => {
+      dashboardWsConnected.value = false
+      dashboardWsReady.value = false
+    })
     lastSubscribeKey = ''
     socket = null
     rejectPendingRpcs(new Error('dashboard websocket closed'))
@@ -424,8 +445,10 @@ export function disconnectDashboardWS(): void {
   shouldReconnect = false
   connectGeneration += 1
   clearReconnectTimer()
-  dashboardWsConnected.value = false
-  dashboardWsReady.value = false
+  batch(() => {
+    dashboardWsConnected.value = false
+    dashboardWsReady.value = false
+  })
   lastSubscribeKey = ''
   desiredRouteState = null
   closeSocket()

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -2,6 +2,10 @@ import type { RouteState, SSEEvent } from './types'
 import { parseSSEMessage } from './schemas/sse'
 import { hydrateDashboardSlice, routeServerPushEvent } from './sse-store'
 import { batch } from '@preact/signals'
+import { parseWebSocketSseFrames as parseWebSocketSseFramesImpl } from './dashboard-ws-parse'
+
+// Re-export for test consumers that assert on frame parsing.
+export const parseWebSocketSseFrames = parseWebSocketSseFramesImpl
 import {
   dashboardWsConnected,
   dashboardWsLastError,
@@ -46,8 +50,38 @@ const pending = new Map<number, PendingRpc>()
 // multiple signal writes / renders), we buffer them and flush on the
 // next animation frame.  This bounds update frequency to 60 Hz and
 // lets batch() coalesce all signal mutations in a single frame.
-const pendingInbound: string[] = []
+const pendingInbound: Array<string | unknown> = []
 let flushHandle = 0
+
+// Phase 2 (PR-4.5): Offload JSON/SSE parsing to a Web Worker so the
+// main thread never blocks on large payloads.
+let parseWorker: Worker | null = null
+let workerJobId = 0
+const workerJobs = new Map<number, (payloads: unknown[]) => void>()
+
+function initParseWorker(): Worker | null {
+  if (parseWorker) return parseWorker
+  if (typeof Worker === 'undefined') return null
+  try {
+    parseWorker = new Worker(
+      new URL('./workers/dashboard-ws.worker.ts', import.meta.url),
+    )
+    parseWorker.onmessage = (event) => {
+      const { id, payloads } = event.data as {
+        id: number
+        payloads: unknown[]
+      }
+      const cb = workerJobs.get(id)
+      if (cb) {
+        cb(payloads)
+        workerJobs.delete(id)
+      }
+    }
+    return parseWorker
+  } catch {
+    return null
+  }
+}
 
 function scheduleFlush(): void {
   if (flushHandle) return
@@ -69,7 +103,11 @@ function flushPending(): void {
   const batchData = pendingInbound.slice()
   pendingInbound.length = 0
   for (const data of batchData) {
-    processInboundMessage(data)
+    if (typeof data === 'string') {
+      processInboundMessage(data)
+    } else {
+      processInboundParsedMessage(data)
+    }
   }
 }
 
@@ -335,34 +373,14 @@ function handleRawPush(raw: unknown): void {
   })
 }
 
-export function parseWebSocketSseFrames(data: string): unknown[] {
-  const payloads: unknown[] = []
-  const frames = data.split(/\r?\n\r?\n/)
-  for (const frame of frames) {
-    const dataLines: string[] = []
-    for (const line of frame.split(/\r?\n/)) {
-      if (!line.startsWith('data:')) continue
-      const value = line.slice('data:'.length)
-      dataLines.push(value.startsWith(' ') ? value.slice(1) : value)
-    }
-    if (dataLines.length === 0) continue
-    const body = dataLines.join('\n').trim()
-    if (!body || body === '[DONE]') continue
-    try {
-      payloads.push(JSON.parse(body))
-    } catch (err) {
-      // P2 silent-failure fix: dashboard pushes are JSON by contract,
-      // so a non-JSON SSE frame here is either a server-side encoding
-      // bug or network corruption.  Previously dropped silently —
-      // operators investigating "stale dashboard" had no signal that
-      // frames were being parsed-but-malformed.  Logging includes a
-      // body sample so the malformed shape is recoverable from
-      // DevTools.  body length is capped to keep the log line bounded.
-      const sample = body.length > 200 ? `${body.slice(0, 200)}…(${body.length} bytes total)` : body
-      console.warn('[dashboard-ws] non-JSON SSE frame dropped', { sample, err })
-    }
-  }
-  return payloads
+function processInboundParsedMessage(raw: unknown): void {
+  batch(() => {
+    if (!raw || typeof raw !== 'object') return
+    const record = raw as JsonObject
+    if (handleRpcResponse(record)) return
+    if (handleNotification(record)) return
+    handleRawPush(record)
+  })
 }
 
 function processInboundMessage(data: string): void {
@@ -371,7 +389,7 @@ function processInboundMessage(data: string): void {
     try {
       raw = JSON.parse(data)
     } catch {
-      for (const payload of parseWebSocketSseFrames(data)) {
+      for (const payload of parseWebSocketSseFramesImpl(data)) {
         handleRawPush(payload)
       }
       return
@@ -386,6 +404,18 @@ function processInboundMessage(data: string): void {
 
 function handleMessage(data: unknown): void {
   if (typeof data !== 'string') return
+  const worker = initParseWorker()
+  if (worker) {
+    const id = ++workerJobId
+    workerJobs.set(id, (payloads) => {
+      for (const p of payloads) {
+        pendingInbound.push(p)
+      }
+      scheduleFlush()
+    })
+    worker.postMessage({ id, data })
+    return
+  }
   pendingInbound.push(data)
   scheduleFlush()
 }

--- a/dashboard/src/lib/performance-monitor.test.ts
+++ b/dashboard/src/lib/performance-monitor.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { PerformanceMonitor, type LoAFEntry } from './performance-monitor'
+
+describe('PerformanceMonitor', () => {
+  let monitor!: PerformanceMonitor
+
+  beforeEach(() => {
+    monitor = new PerformanceMonitor({ maxBufferSize: 5, slowThresholdMs: 50 })
+  })
+
+  afterEach(() => {
+    monitor.stop()
+  })
+
+  it('buffers frames up to maxBufferSize', () => {
+    const base = performance.now()
+    for (let i = 0; i < 10; i++) {
+      monitor['push'](makeEntry(base + i, 10))
+    }
+    expect(monitor.frameCount).toBe(5)
+    expect(monitor.getRecentFrames(1)[0]!.startTime).toBe(base + 9)
+  })
+
+  it('computes average duration over a window', () => {
+    const now = performance.now()
+    monitor['push'](makeEntry(now - 1000, 20))
+    monitor['push'](makeEntry(now - 500, 40))
+    monitor['push'](makeEntry(now - 100, 60))
+
+    expect(monitor.getAverageDuration(2000)).toBeCloseTo(40, 1)
+    expect(monitor.getAverageDuration(300)).toBeCloseTo(60, 1)
+    expect(monitor.getAverageDuration(50)).toBe(0)
+  })
+
+  it('counts slow frames correctly', () => {
+    monitor['push'](makeEntry(0, 30))
+    monitor['push'](makeEntry(1, 60))
+    monitor['push'](makeEntry(2, 50))
+    monitor['push'](makeEntry(3, 90))
+
+    expect(monitor.getSlowFrameCount()).toBe(3)
+    expect(monitor.getSlowFrameCount(40)).toBe(3)
+  })
+
+  it('invokes onSlowFrame callback for slow frames', () => {
+    const onSlowFrame = vi.fn()
+    monitor = new PerformanceMonitor({
+      maxBufferSize: 5,
+      slowThresholdMs: 50,
+      onSlowFrame,
+    })
+
+    monitor['push'](makeEntry(0, 30))
+    expect(onSlowFrame).not.toHaveBeenCalled()
+
+    monitor['push'](makeEntry(1, 70))
+    expect(onSlowFrame).toHaveBeenCalledTimes(1)
+    expect(onSlowFrame).toHaveBeenCalledWith(
+      expect.objectContaining({ duration: 70 })
+    )
+  })
+
+  it('is idempotent on start()', () => {
+    // In happy-dom PerformanceObserver may not exist or throw.
+    // We just verify no exception and idempotency.
+    monitor.start()
+    const obs = monitor['observer']
+    monitor.start()
+    expect(monitor['observer']).toBe(obs)
+  })
+})
+
+function makeEntry(startTime: number, duration: number): LoAFEntry {
+  return {
+    name: 'long-animation-frame',
+    entryType: 'long-animation-frame',
+    startTime,
+    duration,
+    renderStart: startTime,
+    styleAndLayoutStart: startTime,
+    blockingDuration: duration,
+    firstUIEventTimestamp: startTime,
+    scripts: [],
+    toJSON() {
+      return this
+    },
+  } as unknown as LoAFEntry
+}

--- a/dashboard/src/lib/performance-monitor.test.ts
+++ b/dashboard/src/lib/performance-monitor.test.ts
@@ -68,6 +68,32 @@ describe('PerformanceMonitor', () => {
     monitor.start()
     expect(monitor['observer']).toBe(obs)
   })
+
+  it('buffers long tasks up to maxBufferSize', () => {
+    const lt = { name: 'longtask', duration: 120, startTime: 0 } as PerformanceEntry
+    for (let i = 0; i < 10; i++) {
+      monitor['longTaskBuffer'].push(lt)
+      if (monitor['longTaskBuffer'].length > monitor['maxBufferSize']) {
+        monitor['longTaskBuffer'].shift()
+      }
+    }
+    expect(monitor.longTaskCount).toBe(5)
+    expect(monitor.getRecentLongTasks(1)[0]!).toBe(lt)
+  })
+
+  it('returns FPS metrics from history', () => {
+    monitor['fpsHistory'].push(30, 60, 45)
+    expect(monitor.getCurrentFps()).toBe(45)
+    expect(monitor.getAverageFps(3)).toBeCloseTo(45, 1)
+    expect(monitor.getAverageFps(10)).toBeCloseTo(45, 1)
+    expect(monitor.getFpsHistory()).toEqual([30, 60, 45])
+  })
+
+  it('returns zero for empty FPS history', () => {
+    expect(monitor.getCurrentFps()).toBe(0)
+    expect(monitor.getAverageFps()).toBe(0)
+    expect(monitor.getFpsHistory()).toEqual([])
+  })
 })
 
 function makeEntry(startTime: number, duration: number): LoAFEntry {

--- a/dashboard/src/lib/performance-monitor.ts
+++ b/dashboard/src/lib/performance-monitor.ts
@@ -35,6 +35,10 @@ export interface PerformanceMonitorOptions {
   slowThresholdMs?: number
   /** Optional callback invoked for every slow frame. */
   onSlowFrame?: (entry: LoAFEntry) => void
+  /** Enable Long Tasks API observer (default true). */
+  enableLongTasks?: boolean
+  /** Enable FPS monitoring via requestAnimationFrame (default true). */
+  enableFps?: boolean
 }
 
 export class PerformanceMonitor {
@@ -42,16 +46,35 @@ export class PerformanceMonitor {
   private readonly maxBufferSize: number
   private readonly slowThresholdMs: number
   private readonly onSlowFrame?: (entry: LoAFEntry) => void
+  private readonly enableLongTasks: boolean
+  private readonly enableFps: boolean
   private observer?: PerformanceObserver
+  private longTaskObserver?: PerformanceObserver
+  private longTaskBuffer: PerformanceEntry[] = []
+  private fpsHistory: number[] = []
+  private fpsRafId?: number
+  private fpsLastTime?: number
+  private fpsFrameCount = 0
+  private running = false
 
   constructor(options: PerformanceMonitorOptions = {}) {
     this.maxBufferSize = options.maxBufferSize ?? 100
     this.slowThresholdMs = options.slowThresholdMs ?? 100
     this.onSlowFrame = options.onSlowFrame
+    this.enableLongTasks = options.enableLongTasks ?? true
+    this.enableFps = options.enableFps ?? true
   }
 
-  /** Start observing long-animation-frame entries. Idempotent. */
+  /** Start observing performance entries. Idempotent. */
   start(): void {
+    if (this.running) return
+    this.running = true
+    this.startLoAF()
+    if (this.enableLongTasks) this.startLongTasks()
+    if (this.enableFps) this.startFps()
+  }
+
+  private startLoAF(): void {
     if (this.observer) return
     if (typeof PerformanceObserver === 'undefined') return
 
@@ -72,10 +95,63 @@ export class PerformanceMonitor {
     }
   }
 
-  /** Stop observing and clear the internal observer reference. */
+  private startLongTasks(): void {
+    if (this.longTaskObserver) return
+    if (typeof PerformanceObserver === 'undefined') return
+
+    try {
+      this.longTaskObserver = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          this.longTaskBuffer.push(entry)
+          if (this.longTaskBuffer.length > this.maxBufferSize) {
+            this.longTaskBuffer.shift()
+          }
+        }
+      })
+      this.longTaskObserver.observe({ entryTypes: ['longtask'] } as PerformanceObserverInit)
+    } catch {
+      // Long Tasks API unsupported — silently no-op.
+    }
+  }
+
+  private startFps(): void {
+    if (this.fpsRafId) return
+    if (typeof requestAnimationFrame === 'undefined') return
+
+    const tick = (time: number) => {
+      if (!this.running) return
+      if (this.fpsLastTime == null) {
+        this.fpsLastTime = time
+      }
+      const elapsed = time - this.fpsLastTime
+      this.fpsFrameCount++
+      if (elapsed >= 1000) {
+        const fps = Math.round((this.fpsFrameCount * 1000) / elapsed)
+        this.fpsHistory.push(fps)
+        if (this.fpsHistory.length > this.maxBufferSize) {
+          this.fpsHistory.shift()
+        }
+        this.fpsFrameCount = 0
+        this.fpsLastTime = time
+      }
+      this.fpsRafId = requestAnimationFrame(tick)
+    }
+    this.fpsRafId = requestAnimationFrame(tick)
+  }
+
+  /** Stop observing and clear internal observers. */
   stop(): void {
+    this.running = false
     this.observer?.disconnect()
     this.observer = undefined
+    this.longTaskObserver?.disconnect()
+    this.longTaskObserver = undefined
+    if (this.fpsRafId) {
+      cancelAnimationFrame(this.fpsRafId)
+      this.fpsRafId = undefined
+    }
+    this.fpsLastTime = undefined
+    this.fpsFrameCount = 0
   }
 
   /** Return the N most recent frames, oldest first. */
@@ -100,6 +176,34 @@ export class PerformanceMonitor {
   /** Total number of buffered frames. */
   get frameCount(): number {
     return this.buffer.length
+  }
+
+  /** Return the N most recent long-task entries, oldest first. */
+  getRecentLongTasks(count = 10): readonly PerformanceEntry[] {
+    return this.longTaskBuffer.slice(-count)
+  }
+
+  /** Total number of buffered long tasks. */
+  get longTaskCount(): number {
+    return this.longTaskBuffer.length
+  }
+
+  /** Most recent FPS reading, or 0 if none yet. */
+  getCurrentFps(): number {
+    if (this.fpsHistory.length === 0) return 0
+    return this.fpsHistory[this.fpsHistory.length - 1]!
+  }
+
+  /** Average FPS over the last `window` readings. */
+  getAverageFps(window = 10): number {
+    const recent = this.fpsHistory.slice(-window)
+    if (recent.length === 0) return 0
+    return recent.reduce((sum, fps) => sum + fps, 0) / recent.length
+  }
+
+  /** Full FPS history (copy), oldest first. */
+  getFpsHistory(): readonly number[] {
+    return [...this.fpsHistory]
   }
 
   private push(entry: LoAFEntry): void {

--- a/dashboard/src/lib/performance-monitor.ts
+++ b/dashboard/src/lib/performance-monitor.ts
@@ -1,0 +1,126 @@
+/**
+ * Long Animation Frames (LoAF) observer for the MASC dashboard.
+ *
+ * This module instruments the browser's long-animation-frame performance
+ * entries to detect and report slow main-thread frames.  It is pure
+ * observability: no adaptive behavior, no runtime mutation.
+ *
+ * Supported browsers: Chrome 123+, Edge 123+.  On unsupported browsers
+ * the observer constructor throws; we catch and silently disable.
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongAnimationFrameTiming
+ */
+
+export interface LoAFScript {
+  name: string
+  duration: number
+  invoker: string
+  invokerType: string
+  windowAttribution: string
+  executionStart: number
+}
+
+export interface LoAFEntry extends PerformanceEntry {
+  readonly renderStart: number
+  readonly styleAndLayoutStart: number
+  readonly blockingDuration: number
+  readonly firstUIEventTimestamp: number
+  readonly scripts: readonly LoAFScript[]
+}
+
+export interface PerformanceMonitorOptions {
+  /** Maximum number of frames retained in the ring buffer. */
+  maxBufferSize?: number
+  /** Duration threshold (ms) above which a frame is considered "slow". */
+  slowThresholdMs?: number
+  /** Optional callback invoked for every slow frame. */
+  onSlowFrame?: (entry: LoAFEntry) => void
+}
+
+export class PerformanceMonitor {
+  private buffer: LoAFEntry[] = []
+  private readonly maxBufferSize: number
+  private readonly slowThresholdMs: number
+  private readonly onSlowFrame?: (entry: LoAFEntry) => void
+  private observer?: PerformanceObserver
+
+  constructor(options: PerformanceMonitorOptions = {}) {
+    this.maxBufferSize = options.maxBufferSize ?? 100
+    this.slowThresholdMs = options.slowThresholdMs ?? 100
+    this.onSlowFrame = options.onSlowFrame
+  }
+
+  /** Start observing long-animation-frame entries. Idempotent. */
+  start(): void {
+    if (this.observer) return
+    if (typeof PerformanceObserver === 'undefined') return
+
+    try {
+      this.observer = new PerformanceObserver((list) => {
+        for (const raw of list.getEntries()) {
+          const entry = raw as unknown as LoAFEntry
+          this.push(entry)
+        }
+      })
+
+      this.observer.observe({
+        type: 'long-animation-frame',
+        buffered: true,
+      } as PerformanceObserverInit)
+    } catch {
+      // LoAF unsupported on this browser — silently no-op.
+    }
+  }
+
+  /** Stop observing and clear the internal observer reference. */
+  stop(): void {
+    this.observer?.disconnect()
+    this.observer = undefined
+  }
+
+  /** Return the N most recent frames, oldest first. */
+  getRecentFrames(count = 10): readonly LoAFEntry[] {
+    return this.buffer.slice(-count)
+  }
+
+  /** Average frame duration over the last `windowMs` milliseconds. */
+  getAverageDuration(windowMs = 5000): number {
+    const cutoff = performance.now() - windowMs
+    const recent = this.buffer.filter((e) => e.startTime >= cutoff)
+    if (recent.length === 0) return 0
+    return recent.reduce((sum, e) => sum + e.duration, 0) / recent.length
+  }
+
+  /** Count of slow frames (duration >= threshold) in the buffer. */
+  getSlowFrameCount(thresholdMs?: number): number {
+    const t = thresholdMs ?? this.slowThresholdMs
+    return this.buffer.filter((e) => e.duration >= t).length
+  }
+
+  /** Total number of buffered frames. */
+  get frameCount(): number {
+    return this.buffer.length
+  }
+
+  private push(entry: LoAFEntry): void {
+    this.buffer.push(entry)
+    if (this.buffer.length > this.maxBufferSize) {
+      this.buffer.shift()
+    }
+
+    if (entry.duration >= this.slowThresholdMs) {
+      this.onSlowFrame?.(entry)
+      if (import.meta.env?.DEV) {
+        const invokers = entry.scripts.map((s) => s.invoker)
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[PerformanceMonitor] Slow frame ${entry.duration.toFixed(1)}ms`,
+          invokers
+        )
+      }
+    }
+  }
+}
+
+/** Default singleton instance. */
+export const performanceMonitor = new PerformanceMonitor()

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -34,6 +34,7 @@ import { render } from 'preact'
 import { html } from 'htm/preact'
 import { App } from './app'
 import { performanceMonitor } from './lib/performance-monitor'
+import { startWebVitalsCapture } from './utils/performance-metrics'
 
 // Theme resolution precedence: ?theme= URL param (session scoped) >
 // localStorage.dashboardTheme (persistent) > default (unset).
@@ -69,3 +70,7 @@ if (root) {
 // Begin collecting long-animation-frame telemetry.
 // No-op on browsers that do not support LoAF.
 performanceMonitor.start()
+
+// Begin capturing synthetic web-vitals (TTFB, FCP, LCP, CLS, FID).
+// Snapshot available on window.__MASC_WEB_VITALS__ for test/playwright inspection.
+startWebVitalsCapture()

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -33,6 +33,7 @@ import './styles/tools.css'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { App } from './app'
+import { performanceMonitor } from './lib/performance-monitor'
 
 // Theme resolution precedence: ?theme= URL param (session scoped) >
 // localStorage.dashboardTheme (persistent) > default (unset).
@@ -64,3 +65,7 @@ const root = document.getElementById('app')
 if (root) {
   render(html`<${App} />`, root)
 }
+
+// Begin collecting long-animation-frame telemetry.
+// No-op on browsers that do not support LoAF.
+performanceMonitor.start()

--- a/dashboard/src/utils/fps-adaptive.ts
+++ b/dashboard/src/utils/fps-adaptive.ts
@@ -1,0 +1,48 @@
+// FPS adaptive quality — lightweight rAF-based monitor.
+// Reports rolling FPS every ~1 s. Consumers (e.g. VirtualList) can
+// subscribe and lower render quality when FPS is poor.
+
+let rafId = 0
+let lastTime = 0
+let frameCount = 0
+let currentFps = 60
+const listeners = new Set<(fps: number) => void>()
+
+function tick(now: number) {
+  frameCount++
+  if (now - lastTime >= 1000) {
+    currentFps = Math.round((frameCount * 1000) / (now - lastTime))
+    frameCount = 0
+    lastTime = now
+    for (const cb of listeners) cb(currentFps)
+  }
+  rafId = requestAnimationFrame(tick)
+}
+
+function start() {
+  if (rafId) return
+  lastTime = performance.now()
+  frameCount = 0
+  rafId = requestAnimationFrame(tick)
+}
+
+function stop() {
+  if (rafId) {
+    cancelAnimationFrame(rafId)
+    rafId = 0
+  }
+}
+
+export function getFps(): number {
+  return currentFps
+}
+
+/** Subscribe to FPS updates. Returns an unsubscribe function. */
+export function onFpsChange(cb: (fps: number) => void): () => void {
+  listeners.add(cb)
+  start()
+  return () => {
+    listeners.delete(cb)
+    if (listeners.size === 0) stop()
+  }
+}

--- a/dashboard/src/utils/performance-metrics.test.ts
+++ b/dashboard/src/utils/performance-metrics.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  startWebVitalsCapture,
+  getWebVitalsSnapshot,
+  resetWebVitalsSnapshot,
+} from './performance-metrics'
+
+describe('performance-metrics', () => {
+  let observers: Array<{
+    type: string
+    callback: PerformanceObserverCallback
+    entries: PerformanceEntryList
+  }> = []
+
+  beforeEach(() => {
+    resetWebVitalsSnapshot()
+    observers = []
+
+    vi.stubGlobal(
+      'PerformanceObserver',
+      class MockPerformanceObserver {
+        callback: PerformanceObserverCallback
+        constructor(cb: PerformanceObserverCallback) {
+          this.callback = cb
+        }
+        observe(init: PerformanceObserverInit) {
+          const type = (init as Record<string, unknown>).type as string
+          observers.push({ type, callback: this.callback, entries: [] })
+        }
+        disconnect() {
+          observers = observers.filter((o) => o.callback !== this.callback)
+        }
+        takeRecords() {
+          return []
+        }
+      },
+    )
+
+    vi.stubGlobal('performance', {
+      getEntriesByType: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function emitEntry(type: string, entry: PerformanceEntry) {
+    for (const obs of observers) {
+      if (obs.type === type) {
+        obs.entries.push(entry)
+        // Deliver only the new entry to match real PerformanceObserver behavior
+        // (callback receives buffered entries since last invocation).
+        obs.callback({ getEntries: () => [entry] } as PerformanceObserverEntryList, obs as unknown as PerformanceObserver)
+      }
+    }
+  }
+
+  it('captures TTFB from navigation timing', () => {
+    const nav = {
+      startTime: 0,
+      responseStart: 120,
+    } as PerformanceNavigationTiming
+    ;(performance.getEntriesByType as ReturnType<typeof vi.fn>).mockReturnValue([nav])
+
+    startWebVitalsCapture()
+    expect(getWebVitalsSnapshot().ttfb).toBe(120)
+  })
+
+  it('captures FCP from paint observer', () => {
+    ;(performance.getEntriesByType as ReturnType<typeof vi.fn>).mockReturnValue([])
+    startWebVitalsCapture()
+
+    emitEntry('paint', {
+      name: 'first-contentful-paint',
+      startTime: 250,
+    } as PerformanceEntry)
+
+    expect(getWebVitalsSnapshot().fcp).toBe(250)
+  })
+
+  it('captures LCP from largest-contentful-paint observer', () => {
+    ;(performance.getEntriesByType as ReturnType<typeof vi.fn>).mockReturnValue([])
+    startWebVitalsCapture()
+
+    emitEntry('largest-contentful-paint', {
+      startTime: 300,
+    } as PerformanceEntry)
+
+    emitEntry('largest-contentful-paint', {
+      startTime: 600,
+    } as PerformanceEntry)
+
+    expect(getWebVitalsSnapshot().lcp).toBe(600)
+  })
+
+  it('accumulates CLS excluding shifts with recent input', () => {
+    ;(performance.getEntriesByType as ReturnType<typeof vi.fn>).mockReturnValue([])
+    startWebVitalsCapture()
+
+    emitEntry('layout-shift', {
+      startTime: 100,
+      value: 0.05,
+      hadRecentInput: false,
+    } as unknown as PerformanceEntry)
+
+    emitEntry('layout-shift', {
+      startTime: 200,
+      value: 0.03,
+      hadRecentInput: true,
+    } as unknown as PerformanceEntry)
+
+    emitEntry('layout-shift', {
+      startTime: 300,
+      value: 0.02,
+      hadRecentInput: false,
+    } as unknown as PerformanceEntry)
+
+    expect(getWebVitalsSnapshot().cls).toBe(0.07)
+  })
+
+  it('captures FID from first-input observer', () => {
+    ;(performance.getEntriesByType as ReturnType<typeof vi.fn>).mockReturnValue([])
+    startWebVitalsCapture()
+
+    emitEntry('first-input', {
+      startTime: 400,
+      processingStart: 412,
+    } as unknown as PerformanceEntry)
+
+    expect(getWebVitalsSnapshot().fid).toBe(12)
+  })
+
+  it('exposes snapshot on window.__MASC_WEB_VITALS__', () => {
+    ;(performance.getEntriesByType as ReturnType<typeof vi.fn>).mockReturnValue([])
+    startWebVitalsCapture()
+
+    const win = window as unknown as Record<string, unknown>
+    expect(typeof win.__MASC_WEB_VITALS__).toBe('function')
+    expect((win.__MASC_WEB_VITALS__ as () => unknown)()).toEqual(getWebVitalsSnapshot())
+  })
+
+  it('cleanup removes global property and disconnects observers', () => {
+    ;(performance.getEntriesByType as ReturnType<typeof vi.fn>).mockReturnValue([])
+    const cleanup = startWebVitalsCapture()
+
+    expect(observers.length).toBeGreaterThan(0)
+    cleanup()
+
+    const win = window as unknown as Record<string, unknown>
+    expect(win.__MASC_WEB_VITALS__).toBeUndefined()
+    expect(observers.length).toBe(0)
+  })
+
+  it('returns nulls when no data is available', () => {
+    ;(performance.getEntriesByType as ReturnType<typeof vi.fn>).mockReturnValue([])
+    startWebVitalsCapture()
+    const snap = getWebVitalsSnapshot()
+    expect(snap.ttfb).toBeNull()
+    expect(snap.fcp).toBeNull()
+    expect(snap.lcp).toBeNull()
+    expect(snap.cls).toBeNull()
+    expect(snap.fid).toBeNull()
+  })
+})

--- a/dashboard/src/utils/performance-metrics.ts
+++ b/dashboard/src/utils/performance-metrics.ts
@@ -1,0 +1,123 @@
+// Synthetic web-vitals capture using native Performance API.
+// Collects TTFB, FCP, LCP, CLS, and FID without external libraries.
+// Snapshot is exposed on window.__MASC_WEB_VITALS__ for Playwright/vitest consumption.
+
+export interface WebVitalsSnapshot {
+  ttfb: number | null
+  fcp: number | null
+  lcp: number | null
+  cls: number | null
+  fid: number | null
+}
+
+let snapshot: WebVitalsSnapshot = {
+  ttfb: null,
+  fcp: null,
+  lcp: null,
+  cls: null,
+  fid: null,
+}
+
+export function getWebVitalsSnapshot(): WebVitalsSnapshot {
+  return { ...snapshot }
+}
+
+export function resetWebVitalsSnapshot(): void {
+  snapshot = { ttfb: null, fcp: null, lcp: null, cls: null, fid: null }
+}
+
+interface LayoutShiftEntry extends PerformanceEntry {
+  value: number
+  hadRecentInput: boolean
+}
+
+interface FirstInputEntry extends PerformanceEntry {
+  processingStart: number
+}
+
+/** Start capturing web-vitals. Returns a cleanup function. */
+export function startWebVitalsCapture(): () => void {
+  // TTFB from navigation timing
+  try {
+    const navEntries = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[]
+    if (navEntries.length > 0) {
+      const nav = navEntries[0]!
+      snapshot.ttfb = nav.responseStart - nav.startTime
+    }
+  } catch {
+    // Ignore if PerformanceNavigationTiming is unavailable
+  }
+
+  // FCP
+  let paintObserver: PerformanceObserver | null = null
+  try {
+    paintObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (entry.name === 'first-contentful-paint') {
+          snapshot.fcp = entry.startTime
+        }
+      }
+    })
+    paintObserver.observe({ type: 'paint', buffered: true } as PerformanceObserverInit)
+  } catch {
+    // paint type not supported
+  }
+
+  // LCP
+  let lcpObserver: PerformanceObserver | null = null
+  try {
+    lcpObserver = new PerformanceObserver((list) => {
+      const entries = list.getEntries()
+      const last = entries[entries.length - 1]
+      if (last) {
+        snapshot.lcp = last.startTime
+      }
+    })
+    lcpObserver.observe({ type: 'largest-contentful-paint', buffered: true } as PerformanceObserverInit)
+  } catch {
+    // largest-contentful-paint type not supported
+  }
+
+  // CLS
+  let clsObserver: PerformanceObserver | null = null
+  let clsValue = 0
+  try {
+    clsObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        const ls = entry as unknown as LayoutShiftEntry
+        if (!ls.hadRecentInput) {
+          clsValue += ls.value
+        }
+      }
+      snapshot.cls = clsValue
+    })
+    clsObserver.observe({ type: 'layout-shift', buffered: true } as PerformanceObserverInit)
+  } catch {
+    // layout-shift type not supported
+  }
+
+  // FID
+  let fidObserver: PerformanceObserver | null = null
+  try {
+    fidObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        const fi = entry as unknown as FirstInputEntry
+        snapshot.fid = fi.processingStart - fi.startTime
+      }
+    })
+    fidObserver.observe({ type: 'first-input', buffered: true } as PerformanceObserverInit)
+  } catch {
+    // first-input type not supported
+  }
+
+  // Expose globally for test/playwright inspection
+  ;(window as unknown as Record<string, unknown>).__MASC_WEB_VITALS__ = getWebVitalsSnapshot
+
+  return () => {
+    paintObserver?.disconnect()
+    lcpObserver?.disconnect()
+    clsObserver?.disconnect()
+    fidObserver?.disconnect()
+    delete (window as unknown as Record<string, unknown>).__MASC_WEB_VITALS__
+  }
+}

--- a/dashboard/src/workers/activity-heatmap.worker.ts
+++ b/dashboard/src/workers/activity-heatmap.worker.ts
@@ -1,0 +1,25 @@
+import { drawHeatmap, canvasWidth, canvasHeight } from '../components/activity-heatmap-draw'
+
+interface HeatmapJob {
+  matrix: number[][]
+  max: number
+  dpr: number
+}
+
+self.onmessage = (event: MessageEvent<HeatmapJob>) => {
+  const { matrix, max, dpr } = event.data
+
+  const w = canvasWidth()
+  const h = canvasHeight()
+  const canvas = new OffscreenCanvas(w * dpr, h * dpr)
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    self.postMessage({ bitmap: null })
+    return
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  drawHeatmap(ctx, matrix, max)
+
+  const bitmap = canvas.transferToImageBitmap()
+  self.postMessage({ bitmap }, [bitmap as unknown as Transferable])
+}

--- a/dashboard/src/workers/dashboard-ws.worker.ts
+++ b/dashboard/src/workers/dashboard-ws.worker.ts
@@ -1,0 +1,7 @@
+import { parseIncomingPayloads } from '../dashboard-ws-parse'
+
+self.onmessage = (event: MessageEvent<{ id: number; data: string }>) => {
+  const { id, data } = event.data
+  const payloads = parseIncomingPayloads(data)
+  self.postMessage({ id, payloads })
+}


### PR DESCRIPTION
## Summary

Dashboard performance optimization batch covering Phase 1~3 of the MASC IDE strategy report.

### Phase 1 — Containment + Observability
- Add CSS `contain-content` to heavy composite panels (`fleet-health`, `fsm-hub`, `connector-status`, `live`, `logs`).
- Add LoAF (`Long Animation Frame`) monitor via `performanceMonitor.start()`.

### Phase 2 — WS Inbound Pipeline
- Wrap all WebSocket signal writes with `@preact/signals/batch()` to coalesce multiple mutations into a single render.
- Add `requestAnimationFrame` accumulator for inbound WS messages, bounding processing to display refresh rate (60fps cap).
- Offload JSON.parse / SSE frame parsing to a dedicated Web Worker (`dashboard-ws.worker.ts`), with main-thread fallback for tests.

### Phase 3 — Component-Level Optimizations
- **VirtualList** (`virtual-list.ts`):
  - Dual-mode rendering: fixed-height fast path (original) + dynamic-height path with `ResizeObserver` child measurement.
  - Cumulative offset array + `binarySearchOffset` for O(log n) viewport mapping in dynamic mode.
  - FPS-adaptive overscan: shrinks overscan when frame rate drops below 30/45 FPS.
  - Activation threshold (40 items) — renders all items directly below threshold for zero overhead.
- **ActivityHeatmap** (`activity-heatmap.ts`):
  - Offload static Canvas 2D render to an `OffscreenCanvas` Web Worker.
  - Main thread only does `drawImage()` of the transferred `ImageBitmap`.
  - Tooltip converted from canvas-drawn to HTML overlay (`position: absolute` + Preact state), eliminating full bitmap re-renders on mousemove.
  - Extract pure drawing functions to `activity-heatmap-draw.ts` for sharing between main thread and worker.
- **Synthetic Web-Vitals** (`performance-metrics.ts`):
  - Capture TTFB, FCP, LCP, CLS, FID via native `PerformanceObserver`.
  - Expose snapshot on `window.__MASC_WEB_VITALS__` for Playwright / vitest inspection.
  - Wired into `main.ts` on app startup.

## Test plan

- [ ] `npx vitest run src/utils/performance-metrics.test.ts` — 8 passed
- [ ] `npx vitest run src/components/common/virtual-list.a11y.test.ts` — axe passes for fixed + dynamic mode
- [ ] `npx vitest run src/dashboard-ws.test.ts` — WS parsing + rAF flush tests pass
- [ ] Manual: scroll heavy lists (e.g. keeper telemetry) with 1000+ rows — verify smooth 60fps
- [ ] Manual: hover activity heatmap cells — verify tooltip follows cursor without canvas flicker
- [ ] Manual: check `window.__MASC_WEB_VITALS__()` in DevTools console returns non-null snapshot after page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)