### PR TITLE
Surface resolved goal verification evidence

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -258,6 +258,7 @@ describe('dashboard goals decoding', () => {
     expect(result.tree[0]?.verification_summary).toEqual({
       effective_policy: null,
       open_request: null,
+      latest_request: null,
       approve_count: 0,
       reject_count: 0,
       remaining_possible: 0,
@@ -287,9 +288,72 @@ describe('dashboard goals decoding', () => {
     expect(result.goal.verification_summary).toEqual({
       effective_policy: null,
       open_request: null,
+      latest_request: null,
       approve_count: 0,
       reject_count: 0,
       remaining_possible: 0,
+    })
+  })
+
+  it('decodes resolved goal verification evidence on tree payloads', async () => {
+    const rawResponse = {
+      tree: [
+        makeRawGoalNode({
+          verification_summary: {
+            effective_policy: null,
+            open_request: null,
+            latest_request: {
+              id: 'gvr-1',
+              goal_id: 'goal-1',
+              target_phase: 'completed',
+              requested_by: { kind: 'operator', id: 'planner' },
+              policy_snapshot: {
+                principals: [{ kind: 'keeper', id: 'keeper-alpha' }],
+                eligible_principals: [{ kind: 'keeper', id: 'keeper-alpha' }],
+                required_verdicts: 1,
+              },
+              votes: [
+                {
+                  principal: { kind: 'keeper', id: 'keeper-alpha', display_name: 'keeper-alpha' },
+                  decision: 'approve',
+                  note: 'checked receipt and tests',
+                  evidence_refs: ['receipt:keeper-alpha:turn-7', 'test:test_goal_tools'],
+                  submitted_at: '2026-04-23T01:00:00Z',
+                },
+              ],
+              status: 'approved',
+              created_at: '2026-04-23T00:55:00Z',
+              resolved_at: '2026-04-23T01:00:00Z',
+            },
+            approve_count: 1,
+            reject_count: 0,
+            remaining_possible: 0,
+          },
+        }),
+      ],
+      summary: {},
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardGoalsTree()
+
+    expect(result.tree[0]?.verification_summary.latest_request).toMatchObject({
+      id: 'gvr-1',
+      status: 'approved',
+      votes: [
+        {
+          decision: 'approve',
+          note: 'checked receipt and tests',
+          evidence_refs: ['receipt:keeper-alpha:turn-7', 'test:test_goal_tools'],
+        },
+      ],
     })
   })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -920,6 +920,7 @@ function decodeGoalVerificationSummary(raw: unknown): GoalVerificationSummary {
     return {
       effective_policy: null,
       open_request: null,
+      latest_request: null,
       approve_count: 0,
       reject_count: 0,
       remaining_possible: 0,
@@ -928,6 +929,7 @@ function decodeGoalVerificationSummary(raw: unknown): GoalVerificationSummary {
   return {
     effective_policy: decodeGoalVerificationPolicySnapshot(raw.effective_policy),
     open_request: decodeGoalVerificationRequest(raw.open_request),
+    latest_request: decodeGoalVerificationRequest(raw.latest_request),
     approve_count: asInt(raw.approve_count) ?? 0,
     reject_count: asInt(raw.reject_count) ?? 0,
     remaining_possible: asInt(raw.remaining_possible) ?? 0,

--- a/dashboard/src/components/activity-heatmap-draw.ts
+++ b/dashboard/src/components/activity-heatmap-draw.ts
@@ -10,13 +10,15 @@ export const LEFT_MARGIN = 28
 export const TOP_PAD = 20
 export const LEGEND_HEIGHT = 32
 
-const COLORS = [
+const COLORS: readonly [string, string, string, string, string] = [
   'var(--slate-800)',
   '#0e4a5c',
   '#0e6e7e',
   '#14919b',
   'var(--cyan)',
 ]
+
+type HeatmapCanvasContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
 
 export function intensityColor(count: number, max: number): string {
   if (count === 0) return COLORS[0]
@@ -43,7 +45,7 @@ export interface HeatmapCell {
 }
 
 export function drawHeatmap(
-  ctx: CanvasRenderingContext2D,
+  ctx: HeatmapCanvasContext,
   matrix: number[][],
   max: number,
 ) {
@@ -93,7 +95,7 @@ export function drawHeatmap(
   const legendStartX = LEFT_MARGIN + 28
   for (let i = 0; i < COLORS.length; i++) {
     const lx = legendStartX + i * (CELL + 2)
-    ctx.fillStyle = COLORS[i]!
+    ctx.fillStyle = COLORS[i] ?? COLORS[0]
     ctx.beginPath()
     ctx.roundRect(lx, legendY, CELL, 12, 2)
     ctx.fill()

--- a/dashboard/src/components/common/virtual-list.ts
+++ b/dashboard/src/components/common/virtual-list.ts
@@ -34,7 +34,8 @@ function binarySearchOffset(offsets: number[], target: number): number {
   let hi = offsets.length - 1
   while (lo < hi) {
     const mid = Math.floor((lo + hi) / 2)
-    if (offsets[mid] < target) {
+    const midOffset = offsets[mid] ?? 0
+    if (midOffset < target) {
       lo = mid + 1
     } else {
       hi = mid
@@ -77,8 +78,10 @@ export function VirtualList<T>({
     const acc: number[] = new Array(items.length + 1)
     acc[0] = 0
     for (let i = 0; i < items.length; i++) {
-      const h = heightsRef.current.get(getKey(items[i])) ?? estimatedItemHeight
-      acc[i + 1] = acc[i] + h
+      const item = items[i]
+      if (item === undefined) continue
+      const h = heightsRef.current.get(getKey(item)) ?? estimatedItemHeight
+      acc[i + 1] = (acc[i] ?? 0) + h
     }
     return acc
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -45,6 +45,7 @@ function makeNode(overrides: Partial<GoalTreeNode> = {}): GoalTreeNode {
     verification_summary: {
       effective_policy: null,
       open_request: null,
+      latest_request: null,
       approve_count: 0,
       reject_count: 0,
       remaining_possible: 0,

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -27,6 +27,7 @@ import type {
   GoalTreeNode,
   GoalTreeTask,
   GoalTreeSummary,
+  GoalVerificationRequest,
   GoalVerificationSummary,
 } from '../../types'
 import {
@@ -257,9 +258,127 @@ let detailRequestSeq = 0
 const EMPTY_GOAL_VERIFICATION_SUMMARY: GoalVerificationSummary = {
   effective_policy: null,
   open_request: null,
+  latest_request: null,
   approve_count: 0,
   reject_count: 0,
   remaining_possible: 0,
+}
+
+function verificationPrincipalLabel(principal: GoalVerificationRequest['requested_by']) {
+  return `${principal.kind}:${principal.display_name ?? principal.id}`
+}
+
+function verificationStatusLabel(
+  request: GoalVerificationRequest | null,
+  isOpen: boolean,
+) {
+  if (!request) return '정책 설정됨'
+  if (isOpen) return '확인 대기'
+  switch (request.status) {
+    case 'approved': return '확인됨'
+    case 'rejected': return '반려됨'
+    case 'cancelled': return '취소됨'
+    default: return request.status
+  }
+}
+
+function verificationStatusClass(
+  request: GoalVerificationRequest | null,
+  isOpen: boolean,
+) {
+  if (!request) return 'border-card-border/60 bg-[var(--white-4)] text-text-muted'
+  if (isOpen) return 'border-amber-400/25 bg-amber-400/10 text-amber-100'
+  switch (request.status) {
+    case 'approved': return 'border-ok/25 bg-ok/10 text-ok'
+    case 'rejected': return 'border-bad/25 bg-bad/10 text-bad'
+    case 'cancelled': return 'border-warn/25 bg-warn/10 text-warn'
+    default: return 'border-card-border/60 bg-[var(--white-4)] text-text-body'
+  }
+}
+
+function GoalVerificationEvidencePanel({
+  summary,
+  compact = false,
+}: {
+  summary: GoalVerificationSummary
+  compact?: boolean
+}) {
+  const request = summary.open_request ?? summary.latest_request ?? null
+  const isOpen = Boolean(summary.open_request)
+  const policy = request?.policy_snapshot ?? summary.effective_policy ?? null
+  if (!policy && !request) return null
+
+  const requiredVerdicts = policy?.required_verdicts ?? 0
+  const statusClass = verificationStatusClass(request, isOpen)
+  const votes = request?.votes ?? []
+  const panelClass = compact
+    ? 'ml-6 rounded border border-amber-400/20 bg-amber-400/8 p-2 text-xs text-amber-100'
+    : 'rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4'
+
+  return html`
+    <div class=${panelClass}>
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div class="text-2xs font-semibold uppercase tracking-widest text-text-muted">AI 확인</div>
+        <span class="rounded border px-2 py-0.5 text-3xs font-semibold ${statusClass}">
+          ${verificationStatusLabel(request, isOpen)}
+        </span>
+      </div>
+      <div class="mt-2 flex flex-wrap items-center gap-2 text-xs text-text-body">
+        <span class="rounded border border-amber-400/20 bg-amber-400/8 px-2 py-1 text-amber-100">
+          quorum ${summary.approve_count}/${requiredVerdicts}
+        </span>
+        <span>reject ${summary.reject_count}</span>
+        <span>remaining ${summary.remaining_possible}</span>
+      </div>
+      ${request ? html`
+        <div class="mt-2 flex flex-wrap gap-2 text-3xs text-text-muted">
+          <span>request ${request.id}</span>
+          <span>target ${request.target_phase}</span>
+          <span>opened <${TimeAgo} timestamp=${request.created_at} /></span>
+          ${request.resolved_at ? html`
+            <span>resolved <${TimeAgo} timestamp=${request.resolved_at} /></span>
+          ` : null}
+        </div>
+      ` : null}
+      ${policy && policy.eligible_principals.length > 0 ? html`
+        <div class="mt-3 flex flex-wrap gap-1.5">
+          ${policy.eligible_principals.map(principal => html`
+            <span key=${`${principal.kind}:${principal.id}`} class="rounded border border-card-border/60 bg-[var(--white-4)] px-2 py-0.5 text-3xs font-medium text-text-body">
+              ${verificationPrincipalLabel(principal)}
+            </span>
+          `)}
+        </div>
+      ` : null}
+      ${votes.length > 0 ? html`
+        <div class="mt-3 flex flex-col gap-2">
+          ${votes.map(vote => {
+            const evidenceRefs = vote.evidence_refs ?? []
+            return html`
+              <div key=${`${vote.principal.kind}:${vote.principal.id}:${vote.submitted_at}`} class="rounded border border-card-border/50 bg-[var(--white-3)] p-2 text-xs text-text-body">
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="font-semibold text-text-strong">${verificationPrincipalLabel(vote.principal)}</span>
+                  <span class="rounded border border-card-border/60 bg-[var(--white-4)] px-1.5 py-0.5 text-3xs uppercase tracking-wider text-text-muted">${vote.decision}</span>
+                  <span class="text-3xs text-text-dim"><${TimeAgo} timestamp=${vote.submitted_at} /></span>
+                </div>
+                ${vote.note ? html`
+                  <div class="mt-1 leading-relaxed text-text-muted">${vote.note}</div>
+                ` : null}
+                ${evidenceRefs.length > 0 ? html`
+                  <div class="mt-2 flex flex-wrap gap-1">
+                    ${evidenceRefs.map(ref => html`
+                      <code key=${ref} class="rounded border border-card-border/60 bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-text-secondary">${ref}</code>
+                    `)}
+                  </div>
+                ` : null}
+              </div>
+            `
+          })}
+        </div>
+      ` : request ? html`
+        <div class="mt-3 text-xs text-text-muted">verifier vote 없음</div>
+      ` : null}
+    </div>
+  `
 }
 
 function toggleNode(id: string) {
@@ -573,17 +692,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
 
       ${isExpanded ? html`
         <div class="mt-1.5 flex flex-col gap-1.5">
-          ${verificationSummary.open_request ? html`
-            <div class="ml-6 rounded border border-amber-400/20 bg-amber-400/8 p-2 text-xs text-amber-100">
-              <div class="mb-1 text-3xs font-semibold uppercase tracking-widest text-amber-200/80">목표 검증</div>
-              <div>request ${verificationSummary.open_request.id}</div>
-              <div>
-                quorum ${verificationSummary.approve_count}/${verificationSummary.open_request.policy_snapshot.required_verdicts},
-                reject ${verificationSummary.reject_count},
-                remaining ${verificationSummary.remaining_possible}
-              </div>
-            </div>
-          ` : null}
+          <${GoalVerificationEvidencePanel} summary=${verificationSummary} compact />
           ${node.tasks.length > 0 ? html`
             <div class="ml-6 flex flex-col gap-1 rounded border border-card-border/40 bg-[rgba(5,9,16,0.6)] p-2">
               <div class="mb-1 text-3xs font-semibold uppercase tracking-widest text-text-dim">연결된 태스크</div>
@@ -859,31 +968,7 @@ function GoalDetailPanel({
           <${DetailMetric} label="최근 활동" value=${selectedNode.stagnation_seconds > 0 ? `${Math.floor(selectedNode.stagnation_seconds / 3600)}h idle` : 'now'} tone=${selectedNode.badges.includes('stalled') ? 'warn' : 'default'} />
         </div>
 
-        ${verificationSummary.effective_policy ? html`
-          <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
-            <div class="mb-2 text-2xs font-semibold uppercase tracking-widest text-text-muted">목표 검증</div>
-            <div class="flex flex-wrap items-center gap-2 text-xs text-text-body">
-              <span class="rounded border border-amber-400/20 bg-amber-400/8 px-2 py-1 text-amber-100">
-                quorum ${verificationSummary.approve_count}/${verificationSummary.effective_policy.required_verdicts}
-              </span>
-              <span>reject ${verificationSummary.reject_count}</span>
-              <span>remaining ${verificationSummary.remaining_possible}</span>
-            </div>
-            <div class="mt-3 flex flex-wrap gap-1.5">
-              ${verificationSummary.effective_policy.eligible_principals.map(principal => html`
-                <span key=${`${principal.kind}:${principal.id}`} class="rounded border border-card-border/60 bg-[var(--white-4)] px-2 py-0.5 text-3xs font-medium text-text-body">
-                  ${principal.kind}:${principal.display_name ?? principal.id}
-                </span>
-              `)}
-            </div>
-            ${verificationSummary.open_request ? html`
-              <div class="mt-3 rounded border border-amber-400/20 bg-amber-400/8 p-3 text-xs text-amber-100">
-                <div>request ${verificationSummary.open_request.id}</div>
-                <div class="mt-1">status ${verificationSummary.open_request.status}</div>
-              </div>
-            ` : null}
-          </div>
-        ` : null}
+        <${GoalVerificationEvidencePanel} summary=${verificationSummary} />
 
         ${selectedNode.badges.length > 0 ? html`
           <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
@@ -918,6 +1003,8 @@ function GoalDetailPanel({
       ${activeTab === 'evidence' ? html`
         <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
           <div class="flex flex-col gap-4">
+            <${GoalVerificationEvidencePanel} summary=${verificationSummary} />
+
             <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
               <div class="mb-3 text-2xs font-semibold uppercase tracking-widest text-text-muted">키퍼 준비 상태</div>
               ${detail ? (

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -563,6 +563,7 @@ export interface GoalVerificationRequest {
 export interface GoalVerificationSummary {
   effective_policy?: GoalVerificationRequest['policy_snapshot'] | null
   open_request?: GoalVerificationRequest | null
+  latest_request?: GoalVerificationRequest | null
   approve_count: number
   reject_count: number
   remaining_possible: number

--- a/dashboard/src/workers/activity-heatmap.worker.ts
+++ b/dashboard/src/workers/activity-heatmap.worker.ts
@@ -6,7 +6,12 @@ interface HeatmapJob {
   dpr: number
 }
 
-self.onmessage = (event: MessageEvent<HeatmapJob>) => {
+const workerSelf = self as unknown as {
+  onmessage: ((event: MessageEvent<HeatmapJob>) => void) | null
+  postMessage: (message: unknown, transfer?: Transferable[]) => void
+}
+
+workerSelf.onmessage = (event: MessageEvent<HeatmapJob>) => {
   const { matrix, max, dpr } = event.data
 
   const w = canvasWidth()
@@ -14,12 +19,12 @@ self.onmessage = (event: MessageEvent<HeatmapJob>) => {
   const canvas = new OffscreenCanvas(w * dpr, h * dpr)
   const ctx = canvas.getContext('2d')
   if (!ctx) {
-    self.postMessage({ bitmap: null })
+    workerSelf.postMessage({ bitmap: null })
     return
   }
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
   drawHeatmap(ctx, matrix, max)
 
   const bitmap = canvas.transferToImageBitmap()
-  self.postMessage({ bitmap }, [bitmap as unknown as Transferable])
+  workerSelf.postMessage({ bitmap }, [bitmap as unknown as Transferable])
 }

--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -295,9 +295,14 @@ let goal_policy_nodes goals =
       })
     goals
 
-let verification_summary_json (goal : Goal_store.goal)
+let verification_summary_json ?latest_request (goal : Goal_store.goal)
     (effective_policy : Goal_verification.policy_snapshot option)
     (open_request : Goal_verification.goal_verification_request option) =
+  let latest_request =
+    match latest_request with
+    | Some request -> Some request
+    | None -> open_request
+  in
   let effective_policy_json =
     match effective_policy with
     | None -> `Null
@@ -308,8 +313,18 @@ let verification_summary_json (goal : Goal_store.goal)
     | None -> `Null
     | Some request -> Goal_verification.goal_verification_request_to_yojson request
   in
+  let latest_request_json =
+    match latest_request with
+    | None -> `Null
+    | Some request -> Goal_verification.goal_verification_request_to_yojson request
+  in
   let approve_count, reject_count, remaining_possible =
-    match open_request with
+    let summary_request =
+      match open_request with
+      | Some request -> Some request
+      | None -> latest_request
+    in
+    match summary_request with
     | None -> (0, 0, 0)
     | Some request ->
         ( Goal_verification.count_votes ~decision:Goal_verification.Approve request,
@@ -321,6 +336,7 @@ let verification_summary_json (goal : Goal_store.goal)
       ("phase", Goal_phase.to_yojson goal.phase);
       ("effective_policy", effective_policy_json);
       ("open_request", open_request_json);
+      ("latest_request", latest_request_json);
       ("approve_count", `Int approve_count);
       ("reject_count", `Int reject_count);
       ("remaining_possible", `Int remaining_possible);
@@ -754,7 +770,8 @@ let handle_goal_verify (ctx : context) args =
                               Goal_verification.goal_verification_request_to_yojson
                                 request );
                             ( "verification_summary",
-                              verification_summary_json updated_goal
+                              verification_summary_json ~latest_request:request
+                                updated_goal
                                 effective_policy
                                 (if updated_goal.phase = Goal_phase.Awaiting_verification then
                                    Some request

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -747,6 +747,10 @@ let build_goal_verification_projection ~(config : Coord.config) goals =
   in
   let effective_policy_table = Hashtbl.create (max 16 (List.length goals)) in
   let request_table = Hashtbl.create (max 16 (List.length requests)) in
+  let latest_request_table :
+      (string, Goal_verification.goal_verification_request) Hashtbl.t =
+    Hashtbl.create (max 16 (List.length requests))
+  in
   let goal_events =
     let path = Goal_verification.events_path config in
     if Coord.path_exists config path then
@@ -767,6 +771,13 @@ let build_goal_verification_projection ~(config : Coord.config) goals =
     goals;
   List.iter
     (fun (request : Goal_verification.goal_verification_request) ->
+      let should_replace_latest =
+        match Hashtbl.find_opt latest_request_table request.goal_id with
+        | None -> true
+        | Some existing -> String.compare request.created_at existing.created_at >= 0
+      in
+      if should_replace_latest then
+        Hashtbl.replace latest_request_table request.goal_id request;
       if request.status = Goal_verification.Open then
         Hashtbl.replace request_table request.goal_id request)
     requests;
@@ -784,17 +795,25 @@ let build_goal_verification_projection ~(config : Coord.config) goals =
       Option.value (Hashtbl.find_opt effective_policy_table goal_id)
         ~default:None),
     (fun goal_id -> Hashtbl.find_opt request_table goal_id),
+    (fun goal_id -> Hashtbl.find_opt latest_request_table goal_id),
     (fun goal_id ->
       Option.value (Hashtbl.find_opt events_table goal_id) ~default:[]) )
 
 let rec tree_node_to_json ?(effective_policy_for_goal = fun _ -> None)
-    ?(open_request_for_goal = fun _ -> None) ?(events_for_goal = fun _ -> [])
+    ?(open_request_for_goal = fun _ -> None)
+    ?(latest_request_for_goal = fun _ -> None) ?(events_for_goal = fun _ -> [])
     node =
   let goal = node.goal in
   let effective_policy = effective_policy_for_goal goal.id in
   let open_request = open_request_for_goal goal.id in
-  let approve_count, reject_count, remaining_possible =
+  let latest_request = latest_request_for_goal goal.id in
+  let summary_request =
     match open_request with
+    | Some request -> Some request
+    | None -> latest_request
+  in
+  let approve_count, reject_count, remaining_possible =
+    match summary_request with
     | None -> (0, 0, 0)
     | Some request ->
         ( Goal_verification.count_votes ~decision:Goal_verification.Approve request,
@@ -847,6 +866,11 @@ let rec tree_node_to_json ?(effective_policy_for_goal = fun _ -> None)
               | Some request ->
                   Goal_verification.goal_verification_request_to_yojson request
               | None -> `Null );
+            ( "latest_request",
+              match latest_request with
+              | Some request ->
+                  Goal_verification.goal_verification_request_to_yojson request
+              | None -> `Null );
             ("approve_count", `Int approve_count);
             ("reject_count", `Int reject_count);
             ("remaining_possible", `Int remaining_possible);
@@ -865,7 +889,7 @@ let rec tree_node_to_json ?(effective_policy_for_goal = fun _ -> None)
         `List
           (List.map
              (tree_node_to_json ~effective_policy_for_goal ~open_request_for_goal
-                ~events_for_goal)
+                ~latest_request_for_goal ~events_for_goal)
              node.children) );
       ("child_count", `Int (List.length node.children));
       ("last_activity_at", `String node.last_activity_at);
@@ -963,22 +987,27 @@ let timeline_event_json ~ts ~kind ~lane ~title ~summary ~severity =
       ("severity", `String severity);
     ]
 
+let json_member_or_null field = function
+  | `Assoc _ as json -> member field json
+  | _ -> `Null
+
 let goal_event_timeline_json event =
   let event_type =
     event |> member "event_type" |> to_string_option
     |> Option.value ~default:"goal_event"
   in
   let payload = event |> member "payload" in
+  let payload_field field = json_member_or_null field payload in
   let ts = event |> member "ts" |> to_string_option |> Option.value ~default:"" in
   let title, summary, severity =
     match event_type with
     | "goal_phase" ->
         let phase =
-          payload |> member "phase" |> to_string_option
+          payload_field "phase" |> to_string_option
           |> Option.value ~default:"unknown"
         in
         let actor =
-          payload |> member "actor" |> member "id" |> to_string_option
+          payload_field "actor" |> json_member_or_null "id" |> to_string_option
         in
         ( "Goal Phase",
           (match actor with
@@ -989,13 +1018,14 @@ let goal_event_timeline_json event =
           | "awaiting_verification" | "awaiting_approval" | "paused" -> "warn"
           | _ -> "ok") )
     | "goal_verification_opened" ->
+        let request = payload_field "request" in
         let request_id =
-          payload |> member "request" |> member "id" |> to_string_option
+          request |> json_member_or_null "id" |> to_string_option
           |> Option.value ~default:"request"
         in
         let required =
-          payload |> member "request" |> member "policy_snapshot"
-          |> member "required_verdicts" |> to_int_option
+          request |> json_member_or_null "policy_snapshot"
+          |> json_member_or_null "required_verdicts" |> to_int_option
         in
         ( "Goal Verification Opened",
           (match required with
@@ -1003,13 +1033,14 @@ let goal_event_timeline_json event =
           | None -> Printf.sprintf "request %s opened" request_id),
           "warn" )
     | "goal_vote" ->
-        let vote = payload |> member "vote" in
+        let vote = payload_field "vote" in
         let decision =
-          vote |> member "decision" |> to_string_option
+          vote |> json_member_or_null "decision" |> to_string_option
           |> Option.value ~default:"unknown"
         in
         let principal =
-          vote |> member "principal" |> member "id" |> to_string_option
+          vote |> json_member_or_null "principal" |> json_member_or_null "id"
+          |> to_string_option
           |> Option.value ~default:"principal"
         in
         ( "Goal Vote",
@@ -1017,7 +1048,7 @@ let goal_event_timeline_json event =
           if String.equal decision "reject" then "bad" else "ok" )
     | "goal_verification_resolved" ->
         let status =
-          payload |> member "status" |> to_string_option
+          payload_field "status" |> to_string_option
           |> Option.value ~default:"unknown"
         in
         ( "Goal Verification Resolved",
@@ -1027,7 +1058,7 @@ let goal_event_timeline_json event =
           | "rejected" -> "bad"
           | _ -> "warn") )
     | "goal_approval_opened" ->
-        let request_id = payload |> member "request_id" |> to_string_option in
+        let request_id = payload_field "request_id" |> to_string_option in
         ( "Goal Approval Opened",
           (match request_id with
           | Some id -> Printf.sprintf "request %s is awaiting operator approval" id
@@ -1035,7 +1066,7 @@ let goal_event_timeline_json event =
           "warn" )
     | "goal_approval_resolved" ->
         let decision =
-          payload |> member "decision" |> to_string_option
+          payload_field "decision" |> to_string_option
           |> Option.value ~default:"unknown"
         in
         ( "Goal Approval Resolved",
@@ -1151,7 +1182,10 @@ let goal_detail_json ~(config : Coord.config) ~goal_id :
     (Yojson.Safe.t, string) result =
   let goals = Goal_store.list_goals config () in
   let tasks = Coord.get_tasks_safe config in
-  let effective_policy_for_goal, open_request_for_goal, events_for_goal =
+  let ( effective_policy_for_goal,
+        open_request_for_goal,
+        latest_request_for_goal,
+        events_for_goal ) =
     build_goal_verification_projection ~config goals
   in
   let forest = build_forest ~config ~goals ~tasks in
@@ -1195,7 +1229,7 @@ let goal_detail_json ~(config : Coord.config) ~goal_id :
             ("generated_at", `String (Types.now_iso ()));
             ( "goal",
               tree_node_to_json ~effective_policy_for_goal ~open_request_for_goal
-                ~events_for_goal node );
+                ~latest_request_for_goal ~events_for_goal node );
             ("linked_tasks", `List (List.map task_to_tree_json node.tasks));
             ("linked_keepers", `List (List.map goal_detail_keeper_json keeper_details));
             ("approvals", `List approvals);
@@ -1208,7 +1242,10 @@ let goal_detail_json ~(config : Coord.config) ~goal_id :
 let dashboard_goals_tree_json ~(config : Coord.config) : Yojson.Safe.t =
   let goals = Goal_store.list_goals config () in
   let tasks = Coord.get_tasks_safe config in
-  let effective_policy_for_goal, open_request_for_goal, events_for_goal =
+  let ( effective_policy_for_goal,
+        open_request_for_goal,
+        latest_request_for_goal,
+        events_for_goal ) =
     build_goal_verification_projection ~config goals
   in
   let forest = build_forest ~config ~goals ~tasks in
@@ -1260,7 +1297,7 @@ let dashboard_goals_tree_json ~(config : Coord.config) : Yojson.Safe.t =
         `List
           (List.map
              (tree_node_to_json ~effective_policy_for_goal ~open_request_for_goal
-                ~events_for_goal)
+                ~latest_request_for_goal ~events_for_goal)
              forest) );
       ( "summary",
         `Assoc

--- a/lib/dashboard/dashboard_goals.mli
+++ b/lib/dashboard/dashboard_goals.mli
@@ -84,12 +84,14 @@ val tree_node_to_json :
     (string -> Goal_verification.policy_snapshot option) ->
   ?open_request_for_goal:
     (string -> Goal_verification.goal_verification_request option) ->
+  ?latest_request_for_goal:
+    (string -> Goal_verification.goal_verification_request option) ->
   ?events_for_goal:(string -> Yojson.Safe.t list) ->
   tree_node ->
   Yojson.Safe.t
 (** Renders a single {!tree_node} as JSON.  Optional
     callbacks supply per-goal verification policy /
-    open-request / event-timeline projections; defaults
+    open-request / latest-request / event-timeline projections; defaults
     return [None] / [\[\]] so callers that don't need
     verification context can pass the bare node. *)
 

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -29,6 +29,43 @@ let with_room f =
       ignore (Coord.init config ~agent_name:(Some "planner"));
       f config)
 
+let coord_ctx config : Tool_coord.context =
+  { Tool_coord.config; agent_name = "planner" }
+
+let parse_json_result = function
+  | true, body -> Yojson.Safe.from_string body
+  | false, body -> fail body
+
+let principal_json ~kind ~id =
+  `Assoc [ ("kind", `String kind); ("id", `String id) ]
+
+let create_done_task config ~goal_id ~title =
+  ignore
+    (Coord_task.add_task ~goal_id config ~title ~priority:3
+       ~description:"done task fixture");
+  let task_id =
+    Coord.get_tasks_raw config
+    |> List.find_map (fun (task : Types.task) ->
+           if String.equal task.title title then Some task.id else None)
+    |> function
+    | Some task_id -> task_id
+    | None -> fail ("task not found: " ^ title)
+  in
+  let step action notes =
+    match
+      Coord.transition_task_r config ~agent_name:"planner" ~task_id ~action
+        ~notes ()
+    with
+    | Ok _ -> ()
+    | Error err -> fail (Types.masc_error_to_string err)
+  in
+  step Types.Claim "test fixture claim";
+  step Types.Start "test fixture start";
+  step Types.Done_action "test fixture done"
+
+let string_list_field json field =
+  json |> member field |> to_list |> List.map to_string
+
 let make_keeper_meta ~name ~goal_id =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -118,6 +155,101 @@ let root_node json =
   match json |> member "tree" |> to_list with
   | node :: _ -> node
   | [] -> fail "expected one goal in tree"
+
+let test_goal_tree_surfaces_resolved_verification_evidence () =
+  with_room @@ fun config ->
+  let verifier_policy =
+    {
+      Goal_verification.inherit_mode = Goal_verification.Extend;
+      principals =
+        [
+          {
+            kind = Goal_verification.Keeper;
+            id = "keeper-alpha";
+            display_name = Some "keeper-alpha";
+          };
+        ];
+      required_verdicts = Some 1;
+    }
+  in
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal config ~title:"Resolved verification evidence"
+        ~verifier_policy ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Resolved done task";
+  let transitioned =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("action", `String "request_complete");
+            ("actor", principal_json ~kind:"operator" ~id:"planner");
+          ])
+  in
+  let request_id =
+    match transitioned with
+    | Some result ->
+        parse_json_result result
+        |> member "verification_request"
+        |> fun json -> json |> member "id" |> to_string
+    | None -> fail "masc_goal_transition not handled"
+  in
+  let verified =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_verify"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("request_id", `String request_id);
+            ("principal", principal_json ~kind:"keeper" ~id:"keeper-alpha");
+            ("decision", `String "approve");
+            ("note", `String "checked receipt and tests");
+            ( "evidence_refs",
+              `List
+                [
+                  `String "receipt:keeper-alpha:turn-7";
+                  `String "test:test_dashboard_goals";
+                ] );
+          ])
+  in
+  (match verified with
+  | Some result -> ignore (parse_json_result result)
+  | None -> fail "masc_goal_verify not handled");
+  let node = Dashboard_goals.dashboard_goals_tree_json ~config |> root_node in
+  let summary = node |> member "verification_summary" in
+  check bool "open request cleared in dashboard tree" true
+    (summary |> member "open_request" = `Null);
+  let latest_request = summary |> member "latest_request" in
+  check string "latest request id retained in dashboard tree" request_id
+    (latest_request |> member "id" |> to_string);
+  check string "latest request approved in dashboard tree" "approved"
+    (latest_request |> member "status" |> to_string);
+  let vote =
+    match latest_request |> member "votes" |> to_list with
+    | vote :: _ -> vote
+    | [] -> fail "expected dashboard verification vote"
+  in
+  check string "vote note surfaced in dashboard tree" "checked receipt and tests"
+    (vote |> member "note" |> to_string);
+  check (list string) "vote evidence surfaced in dashboard tree"
+    [ "receipt:keeper-alpha:turn-7"; "test:test_dashboard_goals" ]
+    (string_list_field vote "evidence_refs");
+  match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
+  | Error msg -> fail msg
+  | Ok detail_json ->
+      let detail_latest =
+        detail_json
+        |> member "goal"
+        |> member "verification_summary"
+        |> member "latest_request"
+      in
+      check string "latest request retained in goal detail" request_id
+        (detail_latest |> member "id" |> to_string)
 
 let test_empty_executing_goal_is_at_risk () =
   with_room @@ fun config ->
@@ -367,6 +499,8 @@ let () =
     [
       ( "tree",
         [
+          test_case "resolved goal verification evidence is surfaced" `Quick
+            test_goal_tree_surfaces_resolved_verification_evidence;
           test_case "empty executing goal is at risk" `Quick
             test_empty_executing_goal_is_at_risk;
           test_case "open task without keeper is at risk" `Quick

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -45,6 +45,15 @@ let get_string_field json field =
   | `String value -> value
   | _ -> fail (field ^ " missing")
 
+let get_string_list_field json field =
+  Yojson.Safe.Util.member field json
+  |> Yojson.Safe.Util.to_list
+  |> List.map Yojson.Safe.Util.to_string
+
+let json_is_null = function
+  | `Null -> true
+  | _ -> false
+
 let contains_substring s needle =
   let s_len = String.length s in
   let n_len = String.length needle in
@@ -283,6 +292,13 @@ let test_goal_transition_verification_to_completion () =
     Yojson.Safe.Util.member "verification_request" transitioned_json
   in
   let request_id = get_string_field request_json "id" in
+  let transitioned_summary =
+    Yojson.Safe.Util.member "verification_summary" transitioned_json
+  in
+  check string "latest request visible while open" request_id
+    (transitioned_summary
+    |> Yojson.Safe.Util.member "latest_request"
+    |> fun json -> get_string_field json "id");
   let verified =
     Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_verify"
       ~args:
@@ -292,6 +308,13 @@ let test_goal_transition_verification_to_completion () =
             ("request_id", `String request_id);
             ("principal", principal_json ~kind:"keeper" ~id:"keeper-alpha");
             ("decision", `String "approve");
+            ("note", `String "checked receipt and tests");
+            ( "evidence_refs",
+              `List
+                [
+                  `String "receipt:keeper-alpha:turn-7";
+                  `String "test:test_goal_tools";
+                ] );
           ])
   in
   let verified_json =
@@ -301,7 +324,118 @@ let test_goal_transition_verification_to_completion () =
   in
   let verified_goal = Yojson.Safe.Util.member "goal" verified_json in
   check string "phase moved to completed" "completed"
-    (get_string_field verified_goal "phase")
+    (get_string_field verified_goal "phase");
+  let verified_summary =
+    Yojson.Safe.Util.member "verification_summary" verified_json
+  in
+  check bool "open request cleared after approve" true
+    (verified_summary |> Yojson.Safe.Util.member "open_request" |> json_is_null);
+  check int "approve count follows latest request" 1
+    (verified_summary |> Yojson.Safe.Util.member "approve_count"
+    |> Yojson.Safe.Util.to_int);
+  let latest_request =
+    Yojson.Safe.Util.member "latest_request" verified_summary
+  in
+  check string "approved latest request retained" request_id
+    (get_string_field latest_request "id");
+  check string "latest request status approved" "approved"
+    (get_string_field latest_request "status");
+  let vote =
+    match latest_request |> Yojson.Safe.Util.member "votes" |> Yojson.Safe.Util.to_list with
+    | vote :: _ -> vote
+    | [] -> fail "expected verification vote"
+  in
+  check string "vote note retained" "checked receipt and tests"
+    (get_string_field vote "note");
+  check (list string) "vote evidence refs retained"
+    [ "receipt:keeper-alpha:turn-7"; "test:test_goal_tools" ]
+    (get_string_list_field vote "evidence_refs")
+
+let test_goal_transition_rejected_verification_retains_evidence () =
+  with_room @@ fun config ->
+  let verifier_policy =
+    {
+      Goal_verification.inherit_mode = Goal_verification.Extend;
+      principals =
+        [
+          {
+            kind = Goal_verification.Keeper;
+            id = "keeper-alpha";
+            display_name = Some "keeper-alpha";
+          };
+        ];
+      required_verdicts = Some 1;
+    }
+  in
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Reject me" ~verifier_policy () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Reject done task";
+  let transitioned =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("action", `String "request_complete");
+            ("actor", principal_json ~kind:"operator" ~id:"planner");
+          ])
+  in
+  let transitioned_json =
+    match transitioned with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_transition not handled"
+  in
+  let request_id =
+    transitioned_json
+    |> Yojson.Safe.Util.member "verification_request"
+    |> fun json -> get_string_field json "id"
+  in
+  let rejected =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_verify"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("request_id", `String request_id);
+            ("principal", principal_json ~kind:"keeper" ~id:"keeper-alpha");
+            ("decision", `String "reject");
+            ("note", `String "receipt did not prove completion");
+            ("evidence_refs", `List [ `String "receipt:keeper-alpha:turn-7" ]);
+          ])
+  in
+  let rejected_json =
+    match rejected with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_verify not handled"
+  in
+  check string "phase moved back to executing" "executing"
+    (rejected_json |> Yojson.Safe.Util.member "goal" |> fun json ->
+     get_string_field json "phase");
+  let latest_request =
+    rejected_json
+    |> Yojson.Safe.Util.member "verification_summary"
+    |> Yojson.Safe.Util.member "latest_request"
+  in
+  check int "reject count follows latest request" 1
+    (rejected_json
+    |> Yojson.Safe.Util.member "verification_summary"
+    |> Yojson.Safe.Util.member "reject_count"
+    |> Yojson.Safe.Util.to_int);
+  check string "latest request status rejected" "rejected"
+    (get_string_field latest_request "status");
+  let vote =
+    match latest_request |> Yojson.Safe.Util.member "votes" |> Yojson.Safe.Util.to_list with
+    | vote :: _ -> vote
+    | [] -> fail "expected reject vote"
+  in
+  check string "reject note retained" "receipt did not prove completion"
+    (get_string_field vote "note");
+  check (list string) "reject evidence retained"
+    [ "receipt:keeper-alpha:turn-7" ]
+    (get_string_list_field vote "evidence_refs")
 
 let test_goal_transition_approval_gate () =
   with_room @@ fun config ->
@@ -574,6 +708,8 @@ let () =
           test_case "review updates status" `Quick test_goal_review_updates_status;
           test_case "transition verify complete" `Quick
             test_goal_transition_verification_to_completion;
+          test_case "rejected verification retains evidence" `Quick
+            test_goal_transition_rejected_verification_retains_evidence;
           test_case "approval gate" `Quick
             test_goal_transition_approval_gate;
           test_case "review done compatibility" `Quick


### PR DESCRIPTION
## Summary
- add verification_summary.latest_request so resolved goal verification requests remain visible after the open request clears
- surface AI confirmation status, verifier votes, notes, and evidence refs in the goal tree/detail UI
- harden goal timeline rendering against sparse goal-event payloads
- fix latest-main dashboard typecheck drift in activity heatmap, virtual list, and worker message typing

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_goal_tools.exe test/test_dashboard_goals.exe
- ALCOTEST_QUICK_TESTS=false _build/default/test/test_goal_tools.exe
- ALCOTEST_QUICK_TESTS=false _build/default/test/test_dashboard_goals.exe
- pnpm typecheck
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts -t "dashboard goals decoding"
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/components/goals/goal-tree.test.ts

## Notes
- A broad local dashboard.test.ts run in this sandbox repeatedly attempted localhost:3000 and was stopped; the touched dashboard decoding tests were run with a focused Vitest filter. CI Dashboard runs the full typecheck on Linux and this branch includes the strictness fixes needed on the latest base.