### PR TITLE
fix(dashboard): restore strict typecheck on main

### DIFF
--- a/dashboard/src/components/activity-heatmap-draw.ts
+++ b/dashboard/src/components/activity-heatmap-draw.ts
@@ -16,7 +16,7 @@ const COLORS: readonly [string, string, string, string, string] = [
   '#0e6e7e',
   '#14919b',
   'var(--cyan)',
-]
+] as const
 
 type HeatmapCanvasContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
 


### PR DESCRIPTION
## Summary
- keep the heatmap color palette typed as a fixed tuple after the latest dashboard changes
- restores strict TypeScript inference for intensityColor on current main

## Verification
- pnpm --dir dashboard typecheck
- git diff --check origin/main...HEAD