### PR TITLE
feat(dashboard): record OAS response telemetry samples

### DIFF
--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -54,6 +54,68 @@ let record_with_time ~now (s : sample) =
 
 let record (s : sample) = record_with_time ~now:(Unix.gettimeofday ()) s
 
+let duration_from_response ?total_duration_ms
+    (response : Oas.Types.api_response) =
+  match total_duration_ms, response.telemetry with
+  | Some ms, _ when ms > 0.0 -> ms
+  | _, Some telemetry when telemetry.request_latency_ms > 0 ->
+      Float.of_int telemetry.request_latency_ms
+  | _ -> 0.0
+
+let ttfb_from_response (response : Oas.Types.api_response) =
+  match response.telemetry with
+  | Some { timings = Some { prompt_ms = Some ms; _ }; _ } when ms > 0.0 ->
+      ms
+  | _ -> 0.0
+
+let cache_hit_from_response ~(usage : Oas.Types.api_usage)
+    (response : Oas.Types.api_response) =
+  usage.cache_read_input_tokens > 0
+  ||
+  match response.telemetry with
+  | Some { timings = Some { cache_n = Some n; _ }; _ } -> n > 0
+  | _ -> false
+
+let throughput_from_response ~(usage : Oas.Types.api_usage) ~ttfb_ms
+    ~total_duration_ms (response : Oas.Types.api_response) =
+  match response.telemetry with
+  | Some { timings = Some { predicted_per_second = Some v; _ }; _ }
+    when v > 0.0 -> v
+  | _ ->
+      if usage.output_tokens <= 0 then 0.0
+      else
+        let decode_ms = Float.max 1.0 (total_duration_ms -. ttfb_ms) in
+        Float.of_int usage.output_tokens /. (decode_ms /. 1000.0)
+
+let sample_of_response ~provider_id ~model_id ?total_duration_ms
+    ?(retry_count = 0) ~status (response : Oas.Types.api_response) =
+  let usage = Oas_response.usage_or_zero response in
+  let total_duration_ms =
+    duration_from_response ?total_duration_ms response
+  in
+  let ttfb_ms = ttfb_from_response response in
+  {
+    provider_id;
+    model_id;
+    ttfb_ms;
+    total_duration_ms;
+    serialization_ms = 0.0;
+    input_tokens = usage.input_tokens;
+    output_tokens = usage.output_tokens;
+    throughput_tokens_per_s =
+      throughput_from_response ~usage ~ttfb_ms ~total_duration_ms response;
+    cost_usd = Option.value ~default:0.0 usage.cost_usd;
+    cache_hit = cache_hit_from_response ~usage response;
+    status;
+    retry_count;
+  }
+
+let record_response ~provider_id ~model_id ?total_duration_ms ?retry_count
+    ~status response =
+  record
+    (sample_of_response ~provider_id ~model_id ?total_duration_ms
+       ?retry_count ~status response)
+
 let snapshot_provider provider =
   with_lock (fun () ->
       match Hashtbl.find_opt table provider with

--- a/lib/dashboard/dashboard_oas_bridge.mli
+++ b/lib/dashboard/dashboard_oas_bridge.mli
@@ -68,6 +68,37 @@ val record : sample -> unit
 (** [record s] appends [s] to its provider's ring. Thread-safe.
     When the per-provider cap is reached, the oldest entry is dropped. *)
 
+val sample_of_response :
+  provider_id:string ->
+  model_id:string ->
+  ?total_duration_ms:float ->
+  ?retry_count:int ->
+  status:status ->
+  Oas.Types.api_response ->
+  sample
+(** [sample_of_response ~provider_id ~model_id ?total_duration_ms response]
+    projects an OAS [api_response] into the twelve-signal bridge sample.
+
+    - [usage] fields become token, cost, and cache-hit signals.
+    - [response.telemetry.request_latency_ms] is used as duration when the
+      caller does not provide [total_duration_ms].
+    - native decode throughput is preferred when OAS telemetry exposes it;
+      otherwise wall-clock throughput is derived from output tokens and
+      duration.
+
+    Missing OAS usage or telemetry is represented as zero-valued additive
+    data rather than dropping the sample, so coverage gaps stay visible. *)
+
+val record_response :
+  provider_id:string ->
+  model_id:string ->
+  ?total_duration_ms:float ->
+  ?retry_count:int ->
+  status:status ->
+  Oas.Types.api_response ->
+  unit
+(** Convert an OAS response with {!sample_of_response}, then {!record} it. *)
+
 val recent :
   ?provider:string -> ?limit:int -> unit -> (sample * float) list
 (** [recent ?provider ?limit ()] returns up to [limit] most recent samples,

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -258,6 +258,32 @@ let build
 let enrich_idle_detail =
   Oas_worker_exec_checkpoint.enrich_idle_detail
 
+let run_duration_ms_since started_at =
+  Float.max 0.0 ((Unix.gettimeofday () -. started_at) *. 1000.0)
+
+let dashboard_status_of_stop_reason = function
+  | Completed -> Dashboard_oas_bridge.Success
+  | TurnBudgetExhausted _ -> Dashboard_oas_bridge.Timeout
+  | MutationBoundaryReached _ ->
+      Dashboard_oas_bridge.Cancelled { reason = "mutation_boundary_reached" }
+
+let record_dashboard_oas_response ~config ~total_duration_ms ~status
+    (response : Oas.Types.api_response) =
+  try
+    let provider_id = Provider_adapter.provider_label_of_config config.provider_cfg in
+    let model_id =
+      let response_model = String.trim response.model in
+      if response_model = "" then config.model_id else response_model
+    in
+    Dashboard_oas_bridge.record_response ~provider_id ~model_id
+      ~total_duration_ms ~status response
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+      Log.Misc.warn
+        "oas_worker %s: dashboard_oas_bridge record failed: %s"
+        config.name (Printexc.to_string exn)
+
 (* ================================================================ *)
 (* Resume from checkpoint                                            *)
 (* ================================================================ *)
@@ -368,6 +394,7 @@ let run
   | Ok agent ->
   (match agent_ref with Some r -> r := Some agent | None -> ());
   let effective_contract = match contract with Some c -> Some c | None -> config.contract in
+  let run_started_at = Unix.gettimeofday () in
   (try
     let result, proof = match effective_contract with
       | Some c ->
@@ -380,6 +407,7 @@ let run
         in
         (r, None)
     in
+    let run_total_duration_ms = run_duration_ms_since run_started_at in
     (match proof_ref with Some ref_ -> ref_ := proof | None -> ());
     let checkpoint =
       let ckpt =
@@ -425,6 +453,9 @@ let run
     in
     (match result with
     | Ok response ->
+      record_dashboard_oas_response ~config
+        ~total_duration_ms:run_total_duration_ms
+        ~status:Dashboard_oas_bridge.Success response;
       Ok
         {
           response;
@@ -445,6 +476,9 @@ let run
           ~text:(Printf.sprintf
             "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)
       in
+      record_dashboard_oas_response ~config
+        ~total_duration_ms:run_total_duration_ms
+        ~status:Dashboard_oas_bridge.Timeout partial_response;
       Ok
         {
           response = partial_response;
@@ -472,6 +506,10 @@ let run
             ~model_id:config.model_id
             ~text:response_text
         in
+        record_dashboard_oas_response ~config
+          ~total_duration_ms:run_total_duration_ms
+          ~status:(dashboard_status_of_stop_reason stop_reason)
+          partial_response;
         Ok
           {
             response = partial_response;
@@ -491,6 +529,14 @@ let run
       let detail =
         enrich_idle_detail detail (Oas.Agent.state agent).messages
       in
+      let error_response =
+        partial_response_of_stop ~session_id ~model_id:config.model_id
+          ~text:detail
+      in
+      record_dashboard_oas_response ~config
+        ~total_duration_ms:run_total_duration_ms
+        ~status:(Dashboard_oas_bridge.Error { transient = false })
+        error_response;
       (* Demoted from WARN to DEBUG (task-239): this fires once per tier,
          but a cascade caller (Oas_worker_named.run_named) retries on the
          next provider.  Emitting WARN/ERROR here creates noise on
@@ -511,6 +557,17 @@ let run
     let bt = Printexc.get_backtrace () in
     (try Oas.Agent.close agent with close_exn ->
       Log.Misc.warn "agent close failed during cleanup: %s" (Printexc.to_string close_exn));
+    let detail =
+      Printf.sprintf "execution exception: %s" (Printexc.to_string exn)
+    in
+    let error_response =
+      partial_response_of_stop ~session_id ~model_id:config.model_id
+        ~text:detail
+    in
+    record_dashboard_oas_response ~config
+      ~total_duration_ms:(run_duration_ms_since run_started_at)
+      ~status:(Dashboard_oas_bridge.Error { transient = false })
+      error_response;
     Log.Misc.error "oas_worker %s: execution exception: %s\nBacktrace: %s"
       config.name (Printexc.to_string exn) bt;
     Error (Oas.Error.Internal (Printf.sprintf "execution exception: %s" (Printexc.to_string exn))))

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -5,6 +5,7 @@
     the nearest-rank percentile in {!Dashboard_oas_bridge.summary}. *)
 
 module DOB = Masc_mcp.Dashboard_oas_bridge
+module Oas = Masc_mcp.Oas
 
 let make_sample
     ?(provider = "anthropic")
@@ -36,6 +37,42 @@ let make_sample
   }
 
 let setup () = DOB.clear ()
+
+let make_usage ?cost ?(cache_creation = 0) ?(cache_read = 0) ~input
+    ~output () : Oas.Types.api_usage =
+  {
+    input_tokens = input;
+    output_tokens = output;
+    cache_creation_input_tokens = cache_creation;
+    cache_read_input_tokens = cache_read;
+    cost_usd = cost;
+  }
+
+let make_telemetry ?timings ?(request_latency_ms = 0) ()
+    : Oas.Types.inference_telemetry =
+  {
+    system_fingerprint = None;
+    timings;
+    reasoning_tokens = None;
+    request_latency_ms;
+    peak_memory_gb = None;
+    provider_kind = None;
+    reasoning_effort = None;
+    canonical_model_id = None;
+    effective_context_window = None;
+    provider_internal_action_count = None;
+  }
+
+let make_response ?usage ?telemetry ?(model = "claude-opus-4-7") ()
+    : Oas.Types.api_response =
+  {
+    id = "resp-1";
+    model;
+    stop_reason = Oas.Types.EndTurn;
+    content = [];
+    usage;
+    telemetry;
+  }
 
 (* --- record + recent --- *)
 
@@ -117,6 +154,72 @@ let test_clear_provider () =
   Alcotest.(check int) "ollama remains" 1
     (List.length (DOB.recent ~provider:"ollama" ()))
 
+(* --- OAS response projection --- *)
+
+let test_sample_of_response_uses_usage_and_native_telemetry () =
+  let usage =
+    make_usage ~input:11 ~output:5 ~cache_read:7 ~cost:0.12 ()
+  in
+  let timings : Oas.Types.inference_timings =
+    {
+      prompt_n = Some 11;
+      prompt_ms = Some 510.0;
+      prompt_per_second = Some 21.55;
+      predicted_n = Some 5;
+      predicted_ms = Some 61.3;
+      predicted_per_second = Some 81.56;
+      cache_n = Some 7;
+    }
+  in
+  let telemetry = make_telemetry ~timings ~request_latency_ms:620 () in
+  let response = make_response ~usage ~telemetry ~model:"gpt-4" () in
+  let sample =
+    DOB.sample_of_response ~provider_id:"openai_compat" ~model_id:"gpt-4"
+      ~status:DOB.Success response
+  in
+  Alcotest.(check string) "provider" "openai_compat" sample.provider_id;
+  Alcotest.(check string) "model" "gpt-4" sample.model_id;
+  Alcotest.(check int) "input tokens" 11 sample.input_tokens;
+  Alcotest.(check int) "output tokens" 5 sample.output_tokens;
+  Alcotest.(check (float 1e-9)) "ttfb" 510.0 sample.ttfb_ms;
+  Alcotest.(check (float 1e-9)) "duration" 620.0
+    sample.total_duration_ms;
+  Alcotest.(check (float 1e-9)) "native throughput" 81.56
+    sample.throughput_tokens_per_s;
+  Alcotest.(check (float 1e-9)) "cost" 0.12 sample.cost_usd;
+  Alcotest.(check bool) "cache hit" true sample.cache_hit
+
+let test_sample_of_response_derives_wall_throughput () =
+  let usage = make_usage ~input:100 ~output:50 () in
+  let telemetry = make_telemetry ~request_latency_ms:250 () in
+  let response = make_response ~usage ~telemetry ~model:"ollama:qwen" () in
+  let sample =
+    DOB.sample_of_response ~provider_id:"ollama" ~model_id:"ollama:qwen"
+      ~status:DOB.Success response
+  in
+  Alcotest.(check (float 1e-9)) "duration" 250.0
+    sample.total_duration_ms;
+  Alcotest.(check (float 1e-9)) "wall throughput" 200.0
+    sample.throughput_tokens_per_s
+
+let test_record_response_records_missing_usage_as_zero_sample () =
+  setup ();
+  let response =
+    make_response ~telemetry:(make_telemetry ~request_latency_ms:33 ())
+      ~model:"kimi-for-coding" ()
+  in
+  DOB.record_response ~provider_id:"kimi_cli" ~model_id:"kimi-for-coding"
+    ~status:(DOB.Error { transient = false }) response;
+  match DOB.recent ~provider:"kimi_cli" () with
+  | [ (sample, _) ] ->
+      Alcotest.(check int) "input tokens" 0 sample.input_tokens;
+      Alcotest.(check int) "output tokens" 0 sample.output_tokens;
+      Alcotest.(check (float 1e-9)) "duration" 33.0
+        sample.total_duration_ms;
+      Alcotest.(check bool) "cache hit" false sample.cache_hit
+  | xs ->
+      Alcotest.failf "expected one sample, got %d" (List.length xs)
+
 let () =
   Alcotest.run "Dashboard_oas_bridge"
     [
@@ -139,4 +242,13 @@ let () =
         ] );
       ( "clear",
         [ Alcotest.test_case "clear provider" `Quick test_clear_provider ] );
+      ( "oas_response",
+        [
+          Alcotest.test_case "usage + native telemetry" `Quick
+            test_sample_of_response_uses_usage_and_native_telemetry;
+          Alcotest.test_case "wall throughput fallback" `Quick
+            test_sample_of_response_derives_wall_throughput;
+          Alcotest.test_case "missing usage records zero sample" `Quick
+            test_record_response_records_missing_usage_as_zero_sample;
+        ] );
     ]


### PR DESCRIPTION
## Summary
- Project OAS `api_response` usage and inference telemetry into `Dashboard_oas_bridge.sample`.
- Record additive dashboard OAS samples at the `Oas_worker_exec.run` success, stop, and error boundary.
- Extend `test_dashboard_oas_bridge` with response projection coverage for native telemetry, wall throughput fallback, and missing usage.

## Product impact
- Advances #11924 from collector skeleton into live per-run telemetry ingestion.
- Keeps existing keeper Prometheus/cost paths unchanged while giving the dashboard bridge typed samples for duration, tokens, cost, cache-hit, throughput, and outcome status.

## Evidence
- `scripts/dune-local.sh build lib/dashboard/dashboard_oas_bridge.{ml,mli} lib/oas_worker_exec.ml test/test_dashboard_oas_bridge.exe`
- `scripts/dune-local.sh exec test/test_dashboard_oas_bridge.exe` - 11 tests passed.
- `git diff --check HEAD~1..HEAD`
- `git show --check --stat --oneline HEAD`

## Review evidence
- Recording failures are isolated behind a warn-only guard so OAS execution results are not changed by dashboard telemetry failures.
- Missing OAS usage or telemetry is recorded as zero-valued additive sample data instead of dropping coverage gaps.
- Existing metrics and keeper hook emission paths are untouched.

## Linked issue
- Refs #11924
