### PR TITLE
config(cascade): raise ollama-only token cap

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -46,7 +46,7 @@
   "_comment_ollama_only": "Keeper-assignable ollama-only profile for local-only agents. Conservative output/context defaults avoid qwen3.6 27B timeout loops on local runtimes.",
   "ollama_only_models": [ "ollama:auto" ],
   "ollama_only_temperature": 0.7,
-  "ollama_only_max_tokens": 4096,
+  "ollama_only_max_tokens": 8192,
   "ollama_only_keep_alive": "-1",
   "ollama_only_num_ctx": 32768,
   "ollama_only_keeper_assignable": true,

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -65,7 +65,7 @@ models = [
   "ollama:auto",
 ]
 temperature = 0.7
-max_tokens = 4096
+max_tokens = 8192
 keep_alive = "-1"
 num_ctx = 32768
 keeper_assignable = true


### PR DESCRIPTION
## Summary
- raise ollama_only max_tokens from 4096 to 8192 in cascade TOML/JSON seeds
- keep num_ctx at 32768 and keep_alive at -1 from the root-loop fix

## Why
4096 is a low output cap for coding keepers: it is enough for small answers, but it forces more continuation turns for non-trivial patches and can amplify local qwen timeout pressure. 8192 keeps the runtime conservative while making coding turns practical.

## Validation
- scripts/dune-local.sh build test/test_cascade_toml_materialization.exe
- env MASC_CASCADE_TOML_PATH=config/cascade.toml MASC_CASCADE_JSON_PATH=config/cascade.json ./_build/default/test/test_cascade_toml_materialization.exe
- git diff --check