### PR TITLE
refactor(keeper): type gate decision labels

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -136,9 +136,23 @@ let extract_command_from_input (input : Yojson.Safe.t) : string =
 (* Telemetry                                                       *)
 (* -------------------------------------------------------------- *)
 
+type gate_decision =
+  | Gate_override
+  | Gate_continue
+  | Gate_approval_required
+
+let gate_decision_to_string = function
+  | Gate_override -> "override"
+  | Gate_continue -> "continue"
+  | Gate_approval_required -> "approval_required"
+
+let gate_decision_is_rejection = function
+  | Gate_override | Gate_approval_required -> true
+  | Gate_continue -> false
+
 type gate_decision_event = {
   stage : string;
-  decision : string;
+  decision : gate_decision;
   reason_code : string;
   reason_text : string;
   tool_name : string;
@@ -173,11 +187,11 @@ let notify_gate_decision on_gate_decision (event : gate_decision_event) =
     - [reason_text]         human-readable detail
     - [source]              "hook" (distinguishes from legacy paths) *)
 (* Spec mapping: GateRejected action — KeeperTurnCycle.tla lines 189-200.
-   The two-arm match below routes "override" | "approval_required" to
+   The two-arm match below routes Gate_override | Gate_approval_required to
    Keeper_registry.mark_turn_gate_rejected_by_name, which fires the
    decision_stage = "gate_rejected" / turn_phase = "finalizing" transition.
-   The "continue" branch (and any unknown decision string) skips the spec
-   action entirely and only emits the Event_bus Custom event below.
+   The Gate_continue branch skips the spec action entirely and only emits
+   the Event_bus Custom event below.
 
    Cycle 49 observability addition: when the gate rejects, the turn
    becomes terminal WITHOUT any cascade tier ever being attempted.  A
@@ -217,11 +231,8 @@ let emit_gate_event
     ~stage ~decision ~reason_code
     ~tool_name ~agent_name ~turn
     ~accumulated_cost_usd ~stage_latency_ms ~reason_text =
-  let is_gate_rejection =
-    match decision with
-    | "override" | "approval_required" -> true
-    | _ -> false
-  in
+  let decision_label = gate_decision_to_string decision in
+  let is_gate_rejection = gate_decision_is_rejection decision in
   if is_gate_rejection then begin
     Keeper_registry.mark_turn_gate_rejected_by_name agent_name;
     Prometheus.inc_counter gate_rejected_terminal_metric
@@ -229,19 +240,19 @@ let emit_gate_event
         ("keeper", agent_name);
         ("tool", tool_name);
         ("reason", reason_code);
-        ("decision", decision);
+        ("decision", decision_label);
       ] ();
     Log.Keeper.info
       "keeper:%s tool:%s decision=%s reason_code=%s cascade=none \
        (gate rejected before cascade attempt)"
-      agent_name tool_name decision reason_code
+      agent_name tool_name decision_label reason_code
   end;
   match Masc_event_bus.get () with
   | None -> ()
   | Some bus ->
     let payload = `Assoc [
       ("stage", `String stage);
-      ("decision", `String decision);
+      ("decision", `String decision_label);
       ("reason_code", `String reason_code);
       ("tool_name", `String tool_name);
       ("agent_name", `String agent_name);
@@ -344,7 +355,7 @@ let custom_guard
          broadcast_tool_skipped
            ~keeper_name ~tool_name ~reason_code:"pre_tool_use_guard";
          report_gate_decision on_gate_decision
-           ~stage:"pre_tool_use_guard" ~decision:"override"
+           ~stage:"pre_tool_use_guard" ~decision:Gate_override
            ~reason_code:"pre_tool_use_guard" ~reason_text:reason
            ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
            ~stage_latency_ms:latency_ms;
@@ -390,7 +401,7 @@ let streak_guard
         broadcast_tool_skipped
           ~keeper_name ~tool_name ~reason_code:"streak_gate";
         report_gate_decision on_gate_decision
-          ~stage:"streak_gate" ~decision:"override"
+          ~stage:"streak_gate" ~decision:Gate_override
           ~reason_code:"streak_gate" ~reason_text
           ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
           ~stage_latency_ms:latency_ms;
@@ -422,7 +433,7 @@ let deny_guard
         broadcast_tool_skipped
           ~keeper_name ~tool_name ~reason_code:"keeper_deny";
         report_gate_decision on_gate_decision
-          ~stage:"keeper_deny" ~decision:"override"
+          ~stage:"keeper_deny" ~decision:Gate_override
           ~reason_code:"keeper_deny" ~reason_text
           ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
           ~stage_latency_ms:latency_ms;
@@ -460,7 +471,7 @@ let cost_guard
          broadcast_tool_skipped
            ~keeper_name ~tool_name ~reason_code:"cost_gate";
          report_gate_decision on_gate_decision
-           ~stage:"cost_gate" ~decision:"override"
+           ~stage:"cost_gate" ~decision:Gate_override
            ~reason_code:"cost_gate" ~reason_text
            ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
            ~stage_latency_ms:latency_ms;
@@ -502,7 +513,7 @@ let destructive_guard
            broadcast_tool_skipped
              ~keeper_name ~tool_name ~reason_code:"destructive_guard";
            report_gate_decision on_gate_decision
-             ~stage:"destructive_guard" ~decision:"override"
+             ~stage:"destructive_guard" ~decision:Gate_override
              ~reason_code:"destructive_guard" ~reason_text
              ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
              ~stage_latency_ms:latency_ms;
@@ -538,7 +549,7 @@ let governance_approval_guard
       if needs_approval then begin
         let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
         report_gate_decision on_gate_decision
-          ~stage:"governance_approval" ~decision:"approval_required"
+          ~stage:"governance_approval" ~decision:Gate_approval_required
           ~reason_code:"governance_approval"
           ~reason_text:"risk threshold reached; operator approval required"
           ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd

--- a/lib/keeper/keeper_guards.mli
+++ b/lib/keeper/keeper_guards.mli
@@ -38,10 +38,22 @@ val broadcast_tool_skipped :
     [command]/[cmd]/[content] string for screening guards. *)
 val extract_command_from_input : Yojson.Safe.t -> string
 
+(** Typed gate decision vocabulary. JSON/log/metric labels must pass
+    through {!gate_decision_to_string}; internal branching should match this
+    variant exhaustively. *)
+type gate_decision =
+  | Gate_override
+  | Gate_continue
+  | Gate_approval_required
+
+val gate_decision_to_string : gate_decision -> string
+
+val gate_decision_is_rejection : gate_decision -> bool
+
 (** Telemetry payload reported to the gate observer. *)
 type gate_decision_event =
   { stage : string
-  ; decision : string
+  ; decision : gate_decision
   ; reason_code : string
   ; reason_text : string
   ; tool_name : string
@@ -64,7 +76,7 @@ val notify_gate_decision :
     [override] / [approval_required] decisions. *)
 val emit_gate_event :
   stage:string ->
-  decision:string ->
+  decision:gate_decision ->
   reason_code:string ->
   tool_name:string ->
   agent_name:string ->
@@ -79,7 +91,7 @@ val emit_gate_event :
 val report_gate_decision :
   (gate_decision_event -> unit) ->
   stage:string ->
-  decision:string ->
+  decision:gate_decision ->
   reason_code:string ->
   reason_text:string ->
   tool_name:string ->

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -65,7 +65,7 @@ let current_keeper_model meta =
   if m = "" then meta.Keeper_types.cascade_name else m
 
 let render_pre_tool_gate_output (event : Keeper_guards.gate_decision_event) =
-  if String.equal event.decision "approval_required" then
+  if event.decision = Keeper_guards.Gate_approval_required then
     Printf.sprintf
       "[tool_approval_required] tool=%s source=keeper_hook code=%s reason=%s"
       (Keeper_guards.escape_field event.tool_name)
@@ -78,8 +78,9 @@ let render_pre_tool_gate_output (event : Keeper_guards.gate_decision_event) =
       ~reason_text:event.reason_text
 
 let pre_tool_gate_error (event : Keeper_guards.gate_decision_event) =
+  let decision = Keeper_guards.gate_decision_to_string event.decision in
   Printf.sprintf "%s:%s: %s"
-    event.decision event.reason_code event.reason_text
+    decision event.reason_code event.reason_text
 
 let record_pre_tool_gate_attempt
     ~(meta_ref : Keeper_types.keeper_meta ref)

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -115,6 +115,20 @@ let test_render_inline_skip_reason () =
   check bool "contains source=keeper_hook" true
     (contains_substring s "source=keeper_hook")
 
+let test_gate_decision_vocabulary () =
+  check string "override" "override"
+    (KG.gate_decision_to_string KG.Gate_override);
+  check string "continue" "continue"
+    (KG.gate_decision_to_string KG.Gate_continue);
+  check string "approval_required" "approval_required"
+    (KG.gate_decision_to_string KG.Gate_approval_required);
+  check bool "override rejects" true
+    (KG.gate_decision_is_rejection KG.Gate_override);
+  check bool "continue does not reject" false
+    (KG.gate_decision_is_rejection KG.Gate_continue);
+  check bool "approval rejects" true
+    (KG.gate_decision_is_rejection KG.Gate_approval_required)
+
 (* ----------------------------------------------------------------- *)
 (* Individual guard tests                                              *)
 (* ----------------------------------------------------------------- *)
@@ -148,7 +162,8 @@ let test_deny_guard_notifies_gate_observer () =
   match !observed with
   | [ event ] ->
     check string "stage" "keeper_deny" event.KG.stage;
-    check string "decision" "override" event.KG.decision;
+    check string "decision" "override"
+      (KG.gate_decision_to_string event.KG.decision);
     check string "reason_code" "keeper_deny" event.KG.reason_code;
     check string "tool_name" "dangerous_tool" event.KG.tool_name;
     check int "turn" 4 event.KG.turn;
@@ -300,7 +315,8 @@ let test_governance_approval_notifies_gate_observer () =
     match !observed with
     | [ event ] ->
       check string "stage" "governance_approval" event.KG.stage;
-      check string "decision" "approval_required" event.KG.decision;
+      check string "decision" "approval_required"
+        (KG.gate_decision_to_string event.KG.decision);
       check string "reason_code" "governance_approval" event.KG.reason_code;
       check string "tool_name" "keeper_fs_edit" event.KG.tool_name
     | events ->
@@ -396,6 +412,7 @@ let () = run "Keeper_guards" [
   "utilities", [
     test_case "extract_command_from_input" `Quick test_extract_command_from_input;
     test_case "render_inline_skip_reason" `Quick test_render_inline_skip_reason;
+    test_case "gate decision vocabulary" `Quick test_gate_decision_vocabulary;
   ];
   "deny_guard", [
     test_case "blocks denied tool" `Quick test_deny_guard_blocks;


### PR DESCRIPTION
## Summary
- Add typed `Keeper_guards.gate_decision` vocabulary for keeper pre-tool gate decisions.
- Preserve existing JSON, log, and Prometheus labels through `gate_decision_to_string`.
- Update keeper OAS hook rendering and focused guard tests to use the typed decision.

## Product impact
- Advances #11926 C-T7.1 by removing the `decision : string` surface from the keeper gate observer family.
- Replaces the previous unknown-string fallback with exhaustive variant matching for `override`, `continue`, and `approval_required`.
- Keeps external dashboard/event payload compatibility unchanged.

## Evidence
- `scripts/dune-local.sh build lib/keeper/keeper_guards.{ml,mli} lib/keeper/keeper_hooks_oas.{ml,mli} test/test_keeper_guards.exe`
- `scripts/dune-local.sh exec test/test_keeper_guards.exe` - 22 tests passed.
- `git diff --check HEAD~1..HEAD`
- `git show --check --stat --oneline HEAD`

## Review evidence
- `rg 'decision\s*:\s*string' lib test -g '*.ml' -g '*.mli'` no longer reports `keeper_guards`; count is reduced from 17 to 14.
- JSON/event labels still render as `override`, `continue`, and `approval_required`.

## Linked issue
- Refs #11926
