### PR TITLE
[codex] fix keeper docker runtime tool execution

### DIFF
--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -38,6 +38,15 @@ val rewrite_turn_runtime_paths_to_host :
     turn-scoped sandbox responses that must preserve host-path contracts
     for follow-up tool calls. *)
 
+val rewrite_docker_host_paths_to_container :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  string ->
+  string
+(** Rewrites host playground root occurrences in keeper-issued Docker
+    commands to the corresponding in-container playground root before
+    execution. *)
+
 val cmd_targets_git_or_gh : string -> bool
 (** Docker git-credentials per-command dispatch predicate. True when
     the trimmed command's first whitespace-separated word is exactly

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -214,6 +214,81 @@ let docker_nofile_args () =
   let limit = Env_config_keeper.KeeperSandbox.nofile_limit () in
   [ "--ulimit"; Printf.sprintf "nofile=%d:%d" limit limit ]
 
+let docker_user_env_args () =
+  [
+    "--env"; "HOME=/tmp";
+    "--env"; "USER=keeper";
+    "--env"; "LOGNAME=keeper";
+    "--env"; "SHELL=/bin/sh";
+  ]
+
+let docker_identity_dir ~host_root =
+  Filename.concat host_root ".docker-identity"
+
+let docker_user_identity_mount_args ~host_root ~uid ~gid =
+  let dir = docker_identity_dir ~host_root in
+  let passwd_path = Filename.concat dir "passwd" in
+  let group_path = Filename.concat dir "group" in
+  let passwd =
+    Printf.sprintf
+      "root:x:0:0:root:/root:/bin/sh\nkeeper:x:%d:%d:MASC Keeper:/tmp:/bin/sh\n"
+      uid gid
+  in
+  let group =
+    Printf.sprintf "root:x:0:\nkeeper:x:%d:\n" gid
+  in
+  try
+    Fs_compat.mkdir_p dir;
+    match Fs_compat.save_file_atomic passwd_path passwd with
+    | Error err ->
+        Error (Printf.sprintf "failed to write docker passwd file: %s" err)
+    | Ok () ->
+      (match Fs_compat.save_file_atomic group_path group with
+       | Error err ->
+           Error (Printf.sprintf "failed to write docker group file: %s" err)
+       | Ok () ->
+           Ok
+             [
+               "-v"; passwd_path ^ ":/etc/passwd:ro";
+               "-v"; group_path ^ ":/etc/group:ro";
+             ])
+  with
+  | Sys_error err | Unix.Unix_error (_, _, err) ->
+      Error (Printf.sprintf "failed to prepare docker user identity: %s" err)
+
+let is_path_boundary_after text idx =
+  idx >= String.length text
+  ||
+  match text.[idx] with
+  | '/' | '\'' | '"' | ' ' | '\t' | '\n' | '\r' | ';' | '&' | '|'
+  | ')' | '(' | ':' ->
+      true
+  | _ -> false
+
+let rewrite_host_root_to_container_root ~host_root ~container_root text =
+  let host_root = strip_trailing_slashes host_root in
+  let container_root = strip_trailing_slashes container_root in
+  let needle_len = String.length host_root in
+  if needle_len = 0 || not (String_util.contains_substring text host_root)
+  then text
+  else
+    let text_len = String.length text in
+    let buf = Buffer.create text_len in
+    let rec loop i =
+      if i >= text_len then ()
+      else if i + needle_len <= text_len
+              && String.sub text i needle_len = host_root
+              && is_path_boundary_after text (i + needle_len)
+      then (
+        Buffer.add_string buf container_root;
+        loop (i + needle_len))
+      else (
+        Buffer.add_char buf text.[i];
+        loop (i + 1))
+    in
+    loop 0;
+    Buffer.contents buf
+
 type inspected_container =
   {
     owner_pid : int option;

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -95,6 +95,20 @@ val docker_nofile_args : unit -> string list
 (** Docker [--ulimit nofile=<soft>:<hard>] argv fragment for keeper
     sandbox containers. *)
 
+val docker_user_env_args : unit -> string list
+(** Docker [--env ...] argv fragment for the numeric keeper user. *)
+
+val docker_user_identity_mount_args :
+  host_root:string -> uid:int -> gid:int -> (string list, string) result
+(** Docker [-v ...] argv fragment that supplies passwd/group entries for
+    the numeric host uid/gid used inside the keeper container. *)
+
+val rewrite_host_root_to_container_root :
+  host_root:string -> container_root:string -> string -> string
+(** Rewrite occurrences of [host_root] as a path prefix to
+    [container_root]. This is intentionally path-boundary aware so
+    sibling paths such as [/root2] are left untouched. *)
+
 val list_containers :
   ?keeper_name:string ->
   ?container_kind:string ->

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -120,6 +120,27 @@ let docker_private_workspace_cwd ~(config : Coord.config) ~(meta : keeper_meta)
   else
     container_root
 
+let rewrite_docker_command_paths ~(config : Coord.config) ~(meta : keeper_meta)
+    cmd =
+  let raw_host_root =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let normalized_host_root =
+    raw_host_root
+    |> Keeper_alerting_path.normalize_path_for_check
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let container_root = keeper_private_container_root meta in
+  let rewritten =
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:raw_host_root ~container_root cmd
+  in
+  if String.equal raw_host_root normalized_host_root then rewritten
+  else
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:normalized_host_root ~container_root rewritten
+
 (* ── Profile resolution ────────────────────────────────── *)
 
 (* Invariant (root-fix family 2/3, 2026-04-28):
@@ -301,7 +322,9 @@ let run_docker_shell_command_with_status
   else if git_creds_enabled && Env_config_keeper.KeeperSandbox.hard_mode () then
     sandbox_error
       "sandbox hard mode forbids Docker git credential dispatch; use keeper_shell op=git_clone or op=gh so git/gh egress is brokered outside the container"
-  else if command_uses_nested_container_runtime cmd then
+  else
+    let cmd = rewrite_docker_command_paths ~config ~meta cmd in
+  if command_uses_nested_container_runtime cmd then
     sandbox_error
       (if git_creds_enabled then
          "sandbox_profile=docker+git_creds blocks nested container runtimes and host socket references"
@@ -401,6 +424,12 @@ let run_docker_shell_command_with_status
       let container_cwd = docker_private_workspace_cwd ~config ~meta cwd in
       let uid = Unix.getuid () in
       let gid = Unix.getgid () in
+      match
+        Keeper_sandbox_runtime.docker_user_identity_mount_args
+          ~host_root ~uid ~gid
+      with
+      | Error err -> sandbox_error err
+      | Ok identity_mounts ->
       let network_args, network_label =
         if git_creds_enabled then
           ([ "--network"; "bridge" ], "bridge")
@@ -489,9 +518,8 @@ let run_docker_shell_command_with_status
           "-i";
           "--user";
           Printf.sprintf "%d:%d" uid gid;
-          "--env";
-          "HOME=/tmp";
         ]
+        @ Keeper_sandbox_runtime.docker_user_env_args ()
         @ Keeper_sandbox_runtime.docker_nofile_args ()
         @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
         @ [
@@ -518,6 +546,7 @@ let run_docker_shell_command_with_status
         @ ssh_auth_mount
         @ ssh_auth_env
         @ token_env
+        @ identity_mounts
         @ [ image; "bash"; "-lc"; cmd ]
       in
       (try

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -312,8 +312,37 @@ let rewrite_turn_runtime_paths_to_host
   =
   replace_all_substrings
     ~needle:(Keeper_sandbox.container_root meta.name)
-    ~replacement:(Keeper_sandbox.host_root_abs_of_meta ~config meta)
+    ~replacement:
+      (Keeper_sandbox.host_root_abs_of_meta ~config meta
+       |> Keeper_alerting_path.strip_trailing_slashes)
     text
+
+let rewrite_docker_host_paths_to_container
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      text
+  =
+  let raw_host_root =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let normalized_host_root =
+    raw_host_root
+    |> Keeper_alerting_path.normalize_path_for_check
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let container_root =
+    Keeper_sandbox.container_root meta.name
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let rewritten =
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:raw_host_root ~container_root text
+  in
+  if String.equal raw_host_root normalized_host_root then rewritten
+  else
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:normalized_host_root ~container_root rewritten
 
 let run_argv_with_status_retry_eintr ?cwd ~timeout_sec argv =
   let max_eintr_retries = 8 in

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -146,6 +146,12 @@ let start_container (t : t) ~(timeout_sec : float) =
         let network_args, network_label =
           Keeper_sandbox_runtime.docker_network_args t.network_mode
         in
+        match
+          Keeper_sandbox_runtime.docker_user_identity_mount_args
+            ~host_root:t.host_root ~uid:t.uid ~gid:t.gid
+        with
+        | Error _ as err -> err
+        | Ok identity_mounts ->
         let argv =
           Keeper_sandbox_runtime.docker_command_argv ()
           @ [
@@ -163,9 +169,8 @@ let start_container (t : t) ~(timeout_sec : float) =
           @ [
             "--user";
             Printf.sprintf "%d:%d" t.uid t.gid;
-            "--env";
-            "HOME=/tmp";
           ]
+          @ Keeper_sandbox_runtime.docker_user_env_args ()
           @ Keeper_sandbox_runtime.docker_nofile_args ()
           @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
           @ [
@@ -186,6 +191,7 @@ let start_container (t : t) ~(timeout_sec : float) =
               "--workdir";
               t.container_root;
             ]
+          @ identity_mounts
           @ network_args
           @ [
               image;
@@ -225,11 +231,10 @@ let run_exec_with_status_once
             "exec";
             "--user";
             Printf.sprintf "%d:%d" t.uid t.gid;
-            "--env";
-            "HOME=/tmp";
             "-w";
             container_cwd;
           ]
+        @ Keeper_sandbox_runtime.docker_user_env_args ()
         @ (match stdin_content with Some _ -> [ "-i" ] | None -> [])
         @ (container_name :: command_argv)
       in
@@ -288,6 +293,10 @@ let run_command ?(ok_exit_codes = [ 0 ]) t ~cwd ~command_argv
 
 let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string)
     ~(timeout_sec : float) () =
+  let cmd =
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:t.host_root ~container_root:t.container_root cmd
+  in
   run_exec_with_status t ~timeout_sec ~cwd
     ~command_argv:[ "bash"; "-lc"; cmd ^ " 2>&1" ]
 

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -531,7 +531,10 @@ let test_rewrite_turn_runtime_paths_to_host () =
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   let meta = make_docker_meta "minjae" in
   let container_root = Keeper_sandbox.container_root meta.name in
-  let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+  let host_root =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
+    |> Masc_mcp.Keeper_alerting_path.strip_trailing_slashes
+  in
   let input =
     Printf.sprintf "worktree %s/repos/masc-mcp\npwd=%s/repos/masc-mcp\n"
       container_root container_root
@@ -552,6 +555,29 @@ let test_rewrite_turn_runtime_paths_to_host_is_noop_without_container_path () =
   let input = "worktree /tmp/other\n" in
   Alcotest.(check string) "unrelated paths untouched" input
     (Keeper_exec_shell.rewrite_turn_runtime_paths_to_host ~config ~meta input)
+
+let test_rewrite_docker_host_paths_to_container () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  let meta = make_docker_meta "minjae" in
+  let host_root =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
+    |> Masc_mcp.Keeper_alerting_path.strip_trailing_slashes
+  in
+  let container_root = Keeper_sandbox.container_root meta.name in
+  let input =
+    Printf.sprintf "cd %s/repos/masc-mcp && test -d %s2\n"
+      host_root host_root
+  in
+  let rewritten =
+    Keeper_exec_shell.rewrite_docker_host_paths_to_container
+      ~config ~meta input
+  in
+  Alcotest.(check string) "host root rewritten only on path boundary"
+    (Printf.sprintf "cd %s/repos/masc-mcp && test -d %s2\n"
+       container_root host_root)
+    rewritten
 
 (* ── Negative / error-path tests (task-034) ──────────────────────── *)
 
@@ -669,6 +695,8 @@ let () =
         test_rewrite_turn_runtime_paths_to_host;
       Alcotest.test_case "unrelated paths remain unchanged" `Quick
         test_rewrite_turn_runtime_paths_to_host_is_noop_without_container_path;
+      Alcotest.test_case "docker commands rewrite host paths to container paths" `Quick
+        test_rewrite_docker_host_paths_to_container;
     ]);
     ("negative_path", [
       Alcotest.test_case "missing cmd field" `Quick test_bash_missing_cmd_field;

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -563,6 +563,30 @@ let test_git_creds_inherit_network_omits_invalid_network_flag () =
   Alcotest.(check bool) "network inherit never uses invalid flag value" false
     (contains_substring line "--network inherit")
 
+let test_git_creds_mounts_numeric_user_identity () =
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  let line =
+    run_git_creds_docker_shell ~config ~meta ~playground ~log_path
+  in
+  let identity_dir = Filename.concat playground ".docker-identity" in
+  let passwd_path = Filename.concat identity_dir "passwd" in
+  let group_path = Filename.concat identity_dir "group" in
+  Alcotest.(check bool) "passwd file mounted" true
+    (contains_substring line (passwd_path ^ ":/etc/passwd:ro"));
+  Alcotest.(check bool) "group file mounted" true
+    (contains_substring line (group_path ^ ":/etc/group:ro"));
+  Alcotest.(check bool) "USER env forwarded" true
+    (contains_substring line "USER=keeper");
+  Alcotest.(check bool) "passwd maps host uid" true
+    (contains_substring (read_file passwd_path)
+       (Printf.sprintf "keeper:x:%d:%d:" (Unix.getuid ()) (Unix.getgid ())));
+  Alcotest.(check bool) "group maps host gid" true
+    (contains_substring (read_file group_path)
+       (Printf.sprintf "keeper:x:%d:" (Unix.getgid ())))
+
 let test_git_creds_respects_keeper_alias_identity_mode () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
@@ -663,6 +687,34 @@ let test_bash_fake_docker_executes () =
   Alcotest.(check bool) "bash output includes fake docker stdout" true
     (response_mentions raw "output" "stdout:")
 
+let test_bash_rewrites_host_path_command_for_docker () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let container_root = Keeper_sandbox.container_root meta.name in
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ( "cmd",
+              `String
+                (Printf.sprintf "cd %s/repos/masc-mcp && pwd"
+                   (Keeper_alerting_path.strip_trailing_slashes playground)) );
+            ("cwd", `String playground);
+          ])
+      ()
+  in
+  Alcotest.(check (option bool)) "bash via fake docker is ok" (Some true)
+    (parse_bool_field raw "ok");
+  Alcotest.(check bool) "command uses container path" true
+    (response_mentions raw "output"
+       (Filename.concat container_root "repos/masc-mcp"));
+  Alcotest.(check bool) "command no longer leaks host playground path" false
+    (response_mentions raw "output" playground)
+
 let () =
   Alcotest.run "Keeper_shell_docker_route"
     [
@@ -683,6 +735,9 @@ let () =
           Alcotest.test_case
             "docker keeper bash executes through fake docker"
             `Quick test_bash_fake_docker_executes;
+          Alcotest.test_case
+            "docker keeper bash rewrites host paths before exec"
+            `Quick test_bash_rewrites_host_path_command_for_docker;
         ] );
       ( "docker_route_skipped",
         [
@@ -703,6 +758,9 @@ let () =
           Alcotest.test_case
             "git-creds inherit network omits invalid docker flag"
             `Quick test_git_creds_inherit_network_omits_invalid_network_flag;
+          Alcotest.test_case
+            "git-creds mounts passwd entry for numeric uid"
+            `Quick test_git_creds_mounts_numeric_user_identity;
           Alcotest.test_case
             "git-creds respects keeper_alias git identity mode"
             `Quick test_git_creds_respects_keeper_alias_identity_mode;


### PR DESCRIPTION

## Summary

This fixes the keeper Docker execution failures visible in the 2026-04-30 operator logs.

- Rewrite host playground paths such as `/Users/dancer/me/.masc/playground/docker/executor/...` to the in-container keeper playground root before Docker execution.
- Mount generated passwd/group files for the host numeric uid/gid so Docker git/ssh commands no longer fail with `No user exists for uid 502`.
- Normalize turn-runtime path rewriting so reported host paths do not gain doubled separators.
- Add focused tests for keeper bash path rewriting and Docker git credential route identity mounting.

## Operator impact

The executor no longer fails valid commands just because the model used the host playground path while the command is actually running inside `/home/keeper/playground/<keeper>`. Git-backed Docker commands also get a valid identity inside the container, which addresses the observed remote/git failure before the command had a chance to authenticate normally.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_bash_safety.exe test/test_keeper_shell_docker_route.exe`
- `./_build/default/test/test_keeper_bash_safety.exe` - 29 tests successful
- `./_build/default/test/test_keeper_shell_docker_route.exe` - 17 tests successful
