### PR TITLE
fix(tla): disable deadlock check for AutonomousLoop terminal state

### DIFF
--- a/specs/autonomous/AutonomousLoop.cfg
+++ b/specs/autonomous/AutonomousLoop.cfg
@@ -7,6 +7,9 @@ CONSTANTS
 CONSTRAINT
     BoundedSteps
 
+CHECK_DEADLOCK
+    FALSE
+
 INVARIANTS
     TypeOK
     MetaPersistedAfterTick


### PR DESCRIPTION
## Problem

TLC model checker reports deadlock (exit 11) for `AutonomousLoop` because the `\"terminated\"` keeper phase is an intentional terminal state with no further enabled actions.

This is a pre-existing failure also visible on main (run 25115790011).

## Change

Add `CHECK_DEADLOCK FALSE` to `specs/autonomous/AutonomousLoop.cfg` so TLC accepts the terminal state as valid.

## Verification

- [x] `scripts/tla-check.sh` passes locally for `AutonomousLoop`