### PR TITLE
chore(release): sync 0.18.13 release truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,34 @@
 # Changelog
 
 
+## [0.18.13] - 2026-04-30
+
+Aggregate of 389 commits since v0.18.9 (147 feat / 74 chore / 54 fix / 26 docs / 25 test / 20 refactor / 8 spec / 3 ci, plus filename-scoped surface pins). No breaking API changes.
+
+This is a release-truth catch-up for the 0.18.10-0.18.13 stabilization train. The headline thread is keeper/OAS boundary hardening after budget-loop and local Ollama timeout failures, plus dashboard/runtime visibility cleanup and CI/release hygiene.
+
+### Added
+
+- OAS provider error variant contract, metric export, and dashboard telemetry samples for provider/cascade diagnosis.
+- Resolved-goal verification evidence and expanded dashboard/runtime surfaces for operator truth.
+- Performance and reliability instrumentation, including dashboard WS load harness, cache hit/miss counters, GC quick-stat sampling, and cold/warm tool-call labels.
+
+### Fixed
+
+- Keeper OAS timeout behavior: fallback budget reservation, repeated `oas_timeout_budget` auto-pause, hard-quota fail-fast handling, and local Ollama token-cap tuning.
+- Docker-backed keeper execution: `HOME=/tmp` coverage for run/exec/shell paths and runtime contract visibility fixes.
+- Dashboard CI/typecheck stability, provider cascade clarity, fleet idle recovery false positives, and stale TLA/spec-line references.
+
+### Changed
+
+- OAS pin metadata refreshed through the reachable `0.184.0` SDK line and downstream version truth synced to `0.18.13`.
+- Keeper tool preset UI compatibility removed after the runtime-facing preset model moved to typed gate decisions.
+- TLA deadlock checking narrowed for `AutonomousLoop` terminal-state behavior so CI tracks the intended invariant surface.
+
+### Deprecated
+
+- None.
+
 ## [0.18.9] - 2026-04-28 — patch: spec ↔ code bidirectional identity infrastructure (Cycle 24-44 autonomous series) + 234 operational commits
 
 Aggregate of 254 commits since v0.18.8 (109 feat / 33 fix / 37 docs+spec / 36 chore / 34 refactor / 3 test / 1 quality / 1 ci). No breaking API changes. Patch bump (per #11388 narrow-scope precedent); a minor bump (`0.19.0`) is also defensible given the 109 `feat` commits and is a release-manager call.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # masc-mcp Roadmap
 
 > Current package version: v0.18.13
-> Latest release: v0.18.9 (2026-04-28)
-> Updated: 2026-04-28
+> Latest release: v0.18.13 (2026-04-30)
+> Updated: 2026-04-30
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.
 For the product promise and GitHub operating model, see [docs/PRODUCT-OPERATING-PLAN.md](docs/PRODUCT-OPERATING-PLAN.md).

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -10,8 +10,8 @@ code_refs:
 # Product Operating Plan
 
 > Current package version: v0.18.13
-> Latest release: v0.18.9 (2026-04-28)
-> Updated: 2026-04-28
+> Latest release: v0.18.13 (2026-04-30)
+> Updated: 2026-04-30
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 
 Execution companion for capsule-only coordination hardening:

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -10,7 +10,7 @@ code_refs:
 
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
-> Last Updated: 2026-04-28
+> Last Updated: 2026-04-30
 > Snapshot baseline: `dune-project` version `0.18.13`
 
 MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Claude, Gemini, Codex, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, dashboard/operator read visibility를 제공하며, MCP JSON-RPC 프로토콜을 통해 주요 AI IDE/CLI와 통합된다. Historical compatibility lane과 internal orchestration reference는 migration context로만 남긴다.


### PR DESCRIPTION
## Summary
- add a filled 0.18.13 changelog entry for the v0.18.9..HEAD release-truth catch-up
- sync roadmap and product-plan latest-release metadata to 2026-04-30
- update spec index verification date without widening the release train

## Verification
- scripts/check-version-truth.sh
- bash scripts/check-release-train-guard.sh --base origin/main --head HEAD
- git diff --check HEAD~1..HEAD