### PR TITLE
[codex] fix keeper stale runtime noise

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -32,7 +32,7 @@ let actionable_path_action_for_class
     | Path_not_allowed ->
       Printf.sprintf "Path is outside your allowed roots. Stay inside %s or use keeper_context_status to see allowed paths." playground
     | Cwd_not_directory ->
-      "The cwd is not a directory. Omit cwd to use your default playground root."
+      "The cwd is not a directory. Omit cwd to use your default playground root, or create/repair the repo worktree first (keeper_shell op=git_clone, then git_worktree/masc_worktree_create for repos/<repo>/.worktrees/<task>)."
     | Shell_exit_nonzero | Other ->
       Printf.sprintf "Check the path. Your playground: %s" playground
 

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -624,6 +624,11 @@ let mark_turn_finished ~base_path name =
   let changed = ref false in
   let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->
+    let had_live_turn =
+      match e.current_turn_observation with
+      | Some _ -> true
+      | None -> false
+    in
     let last_completed_turn =
       match e.current_turn_observation with
       | Some obs ->
@@ -648,7 +653,21 @@ let mark_turn_finished ~base_path name =
             }
       | None -> e.last_completed_turn  (* no live turn → preserve previous *)
     in
+    let meta =
+      if had_live_turn then
+        {
+          e.meta with
+          runtime =
+            {
+              e.meta.runtime with
+              usage =
+                { e.meta.runtime.usage with last_turn_ts = now };
+            };
+        }
+      else e.meta
+    in
     { e with
+      meta;
       current_turn_observation = None;
       last_completed_turn });
   Option.iter

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -314,8 +314,10 @@ val prepare_turn_retry_after_compaction :
 val mark_turn_gate_rejected_by_name : string -> unit
 
 (** Mark the end of a keeper turn. Clears [current_turn_observation]
-    so the composite observer reverts to idle. Idempotent — safe to
-    call in finally blocks even if [mark_turn_started] was not called. *)
+    so the composite observer reverts to idle and stamps
+    [runtime.usage.last_turn_ts] for the completed turn. Idempotent —
+    safe to call in finally blocks even if [mark_turn_started] was not
+    called. *)
 val mark_turn_finished : base_path:string -> string -> unit
 
 (** Record the verdict reasons from a [keeper_cycle_decision] that

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -23,8 +23,15 @@ let docker_exec_failure_message ~image ~status ~output =
   let output_label =
     if String.trim truncated = "" then "<no output>" else truncated
   in
-  Printf.sprintf "sandbox docker exec failed (%s, %s): %s"
-    image (docker_exec_status_label status) output_label
+  let missing_cwd_hint =
+    if String_util.contains_substring output "cd:"
+       && String_util.contains_substring output "No such file or directory"
+    then
+      " hint=cwd_not_directory: create or repair the sandbox repo/worktree first (keeper_shell op=git_clone, then git_worktree/masc_worktree_create for repos/<repo>/.worktrees/<task>)."
+    else ""
+  in
+  Printf.sprintf "sandbox docker exec failed (%s, %s): %s%s"
+    image (docker_exec_status_label status) output_label missing_cwd_hint
 
 (* ── Sandbox GH_TOKEN warn dedup ───────────────────────────
 

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -1,6 +1,58 @@
 open Keeper_types
 open Keeper_exec_shared
 
+let split_once_on_substring s sep =
+  let len = String.length s in
+  let sep_len = String.length sep in
+  if sep_len = 0 then None
+  else
+    let rec loop i =
+      if i + sep_len > len then None
+      else if String.sub s i sep_len = sep then
+        Some
+          ( String.sub s 0 i,
+            String.sub s (i + sep_len) (len - i - sep_len) )
+      else loop (i + 1)
+    in
+    loop 0
+
+let split_shell_chain_for_retry cmd =
+  let rec split_all sep acc s =
+    match split_once_on_substring s sep with
+    | None -> List.rev (String.trim s :: acc)
+    | Some (left, right) -> split_all sep (String.trim left :: acc) right
+  in
+  let commands =
+    if String_util.contains_substring cmd "&&" then split_all "&&" [] cmd
+    else if String_util.contains_substring cmd "||" then split_all "||" [] cmd
+    else if String_util.contains_substring cmd ";" then split_all ";" [] cmd
+    else [ cmd ]
+  in
+  let commands = List.filter (fun s -> String.trim s <> "") commands in
+  match commands with
+  | _ :: _ :: _ when List.length commands <= 8 -> Some commands
+  | _ -> None
+
+let readonly_chain_rewrite_extra ~category cmd =
+  if not (String.equal category "chaining") then []
+  else
+    match split_shell_chain_for_retry cmd with
+    | None -> []
+    | Some commands ->
+        [
+          "rewrite_kind", `String "split_shell_chain";
+          ( "rewrite_hint",
+            `String
+              "Retry each split command as a separate keeper_shell op=bash call in order; keep the same cwd." );
+          "split_commands", `List (List.map (fun c -> `String c) commands);
+          ( "suggested_calls",
+            `List
+              (List.map
+                 (fun c ->
+                   `Assoc [ "op", `String "bash"; "cmd", `String c ])
+                 commands) );
+        ]
+
 let handle_keeper_shell
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(exec_cache : Masc_exec.Exec_cache.t option)
@@ -896,11 +948,12 @@ let handle_keeper_shell
              ~hint
              ~diag:(Keeper_shell_shared.diagnosis_of_readonly_category category)
              ~extra:
-               [
-                 "op", `String op;
-                 "blocked_pattern", `String pat;
-                 "category", `String category;
-               ]
+               ([
+                  "op", `String op;
+                  "blocked_pattern", `String pat;
+                  "category", `String category;
+                ]
+                @ readonly_chain_rewrite_extra ~category cmd_str)
              ())
       | None ->
         (match cwd_target () with

--- a/test/test_actionable_path_action.ml
+++ b/test/test_actionable_path_action.ml
@@ -43,7 +43,7 @@ let test_path_not_allowed () =
 
 let test_cwd_not_directory () =
   r "cwd guidance"
-    "The cwd is not a directory. Omit cwd to use your default playground root."
+    "The cwd is not a directory. Omit cwd to use your default playground root, or create/repair the repo worktree first (keeper_shell op=git_clone, then git_worktree/masc_worktree_create for repos/<repo>/.worktrees/<task>)."
     (actionable_path_action_for_class
        ~playground:pg ~raw_path:"foo" CB.Cwd_not_directory)
 

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -332,6 +332,18 @@ let test_mark_turn_finished_resets_wakeup () =
   check bool "IR-1: wakeup reset after mark_turn_finished" false
     (Atomic.get entry.R.fiber_wakeup)
 
+let test_mark_turn_finished_updates_last_turn_ts () =
+  R.clear ();
+  let keeper_name = "k-last-turn-finish" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_started ~base_path:bp keeper_name;
+  R.mark_turn_finished ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | None -> fail "entry missing after mark_turn_finished"
+  | Some entry ->
+      check bool "last_turn_ts stamped on completed turn" true
+        (entry.R.meta.runtime.usage.last_turn_ts > 0.0)
+
 let test_completed_turns_replay_from_default_store () =
   let base_path = temp_base_path "completed-turn-replay" in
   Fun.protect
@@ -1176,6 +1188,8 @@ let () =
             test_mark_turn_finished_records_completed_turn_outcome_once;
           eio_test "mark_turn_finished resets fiber_wakeup (IR-1)"
             test_mark_turn_finished_resets_wakeup;
+          eio_test "mark_turn_finished updates last_turn_ts"
+            test_mark_turn_finished_updates_last_turn_ts;
           eio_test "completed turns replay from default store"
             test_completed_turns_replay_from_default_store;
           eio_test "unregister" test_unregister;


### PR DESCRIPTION
## Summary

- Stamp `runtime.usage.last_turn_ts` when `Keeper_registry.mark_turn_finished` completes a live turn, so OAS timeout/non-exhaustion terminal turns count as recent liveness instead of being reclassified minutes later as idle stale watchdog kills.
- Add structured `split_shell_chain` retry payloads to readonly `keeper_shell op=bash` chaining blocks, including `split_commands` and `suggested_calls`, so keepers can self-correct `&&`/`;` failures without another opaque loop.
- Add worktree-repair guidance for `cwd_not_directory` and Docker `cd: ... No such file or directory` failures so missing sandbox repo/worktree paths point at `git_clone` plus worktree creation instead of raw container errors.

## Why

The live keeper logs showed mixed runtime symptoms: OAS timeout-budget turns were followed by stale watchdog termination, readonly shell calls failed on chained commands, and Docker sandbox execution surfaced raw missing-worktree `cd` errors. This change keeps those failures classified closer to their real cause and makes the recovery path machine/actionable for the next keeper turn.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_registry.exe test/test_actionable_path_action.exe test/test_keeper_shell_docker_cwd_response.exe`
- `_build/default/test/test_actionable_path_action.exe` (6 tests)
- `_build/default/test/test_keeper_shell_docker_cwd_response.exe` (2 tests)
- `_build/default/test/test_keeper_registry.exe` (66 tests)
