### PR TITLE
[codex] fix agent directory runtime truth

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -12,6 +12,7 @@ import {
   rosterStateNote,
   uniqueToolNames,
   keeperRuntimeName,
+  isRuntimeBackedKeeper,
   mergeRosterAgent,
   filterAgentRoster,
   countRuntimeKinds,
@@ -328,6 +329,33 @@ describe('keeperRuntimeName', () => {
 })
 
 describe('countRuntimeKinds', () => {
+  it('excludes configured-only paused keepers from live runtime counts', () => {
+    const result = countRuntimeKinds(
+      [],
+      [
+        {
+          name: 'taskmaster',
+          status: 'active',
+          registered: true,
+          keepalive_running: true,
+        } as Keeper,
+        {
+          name: 'verifier',
+          status: 'paused',
+          paused: true,
+          registered: false,
+          keepalive_running: false,
+        } as Keeper,
+      ],
+    )
+
+    expect(result).toEqual({
+      agents: 0,
+      keepers: 1,
+      totalRuntimes: 1,
+    })
+  })
+
   it('collapses keeper-owned generated sub-op aliases when agent meta carries keeper identity', () => {
     const result = countRuntimeKinds(
       [
@@ -405,6 +433,24 @@ describe('countRuntimeKinds', () => {
       keepers: 1,
       totalRuntimes: 2,
     })
+  })
+})
+
+describe('isRuntimeBackedKeeper', () => {
+  it('keeps paused keepers when the supervisor still reports a runtime', () => {
+    expect(isRuntimeBackedKeeper({
+      paused: true,
+      registered: true,
+      keepalive_running: false,
+    })).toBe(true)
+  })
+
+  it('drops paused metas with no registered or keepalive runtime', () => {
+    expect(isRuntimeBackedKeeper({
+      paused: true,
+      registered: false,
+      keepalive_running: false,
+    })).toBe(false)
   })
 })
 

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -179,6 +179,16 @@ function findKeeperRuntimeForAgent(
 
 type KeeperFilterMode = 'all' | 'agent-only' | 'keeper-only'
 
+export function isRuntimeBackedKeeper(keeper: Pick<Keeper, 'paused' | 'registered' | 'keepalive_running'>): boolean {
+  if (keeper.registered === false && keeper.keepalive_running === false) return false
+  if (keeper.paused === true && keeper.registered !== true && keeper.keepalive_running !== true) return false
+  return true
+}
+
+function runtimeBackedKeepers(keeperList: Keeper[]): Keeper[] {
+  return keeperList.filter(isRuntimeBackedKeeper)
+}
+
 function expectedCountForKeeperFilter(
   keeperFilter: KeeperFilterMode,
   counts: ReturnType<typeof resolveRuntimeCounts>,
@@ -397,10 +407,11 @@ export function countRuntimeKinds(
   agentList: Agent[],
   keeperList: Keeper[],
 ): { agents: number; keepers: number; totalRuntimes: number } {
-  const rosterAgents = buildAgentRoster(agentList, keeperList)
-  const keeperLookup = buildKeeperRuntimeLookup(keeperList)
-  const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'keeper-only', keeperLookup).length
-  const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'agent-only', keeperLookup).length
+  const runtimeKeepers = runtimeBackedKeepers(keeperList)
+  const rosterAgents = buildAgentRoster(agentList, runtimeKeepers)
+  const keeperLookup = buildKeeperRuntimeLookup(runtimeKeepers)
+  const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'keeper-only', keeperLookup).length
+  const agentCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'agent-only', keeperLookup).length
 
   return {
     agents: agentCount,
@@ -415,25 +426,29 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
   const agentList = agents.value
   const keeperList = keepers.value
+  const runtimeKeeperList = useMemo(
+    () => runtimeBackedKeepers(keeperList),
+    [keeperList],
+  )
 
   // Memoize roster and lookup Maps — these iterate full keeper/agent arrays.
   // Directory cards are live-only: cached mission briefs are intentionally
   // excluded so one card never mixes multiple freshness levels.
   const rosterAgents = useMemo(
-    () => buildAgentRoster(agentList, keeperList),
-    [agentList, keeperList],
+    () => buildAgentRoster(agentList, runtimeKeeperList),
+    [agentList, runtimeKeeperList],
   )
   const keeperRuntimeLookup = useMemo(
-    () => buildKeeperRuntimeLookup(keeperList),
-    [keeperList],
+    () => buildKeeperRuntimeLookup(runtimeKeeperList),
+    [runtimeKeeperList],
   )
 
   // Derive runtime kind counts from memoized roster (avoids duplicate buildAgentRoster call)
   const liveRuntimeCounts = useMemo(() => {
-    const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'keeper-only', keeperRuntimeLookup).length
-    const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'agent-only', keeperRuntimeLookup).length
+    const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'keeper-only', keeperRuntimeLookup).length
+    const agentCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'agent-only', keeperRuntimeLookup).length
     return { agents: agentCount, keepers: keeperCount, totalRuntimes: rosterAgents.length }
-  }, [rosterAgents, keeperList, keeperRuntimeLookup])
+  }, [rosterAgents, runtimeKeeperList, keeperRuntimeLookup])
 
   const runtimeCounts = resolveRuntimeCounts({
     executionLoaded: executionLoaded.value,
@@ -450,22 +465,22 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const namespaceName = namespaceStatus?.project ?? 'default'
 
   const scopedAgents = useMemo(
-    () => scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperFilter, keeperRuntimeLookup),
-    [rosterAgents, keeperList, keeperFilter, keeperRuntimeLookup],
+    () => scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, keeperFilter, keeperRuntimeLookup),
+    [rosterAgents, runtimeKeeperList, keeperFilter, keeperRuntimeLookup],
   )
   const bandByAgent = useMemo(
     () => new Map(
       scopedAgents.map(agent => [
         agent.name,
         runtimeBandMetaForAgent(
-        agent,
+          agent,
           keeperRuntimeLookup.get(agent.name)
             ?? findKeeperRuntimeForAgent(agent, keeperRuntimeLookup)
-            ?? findKeeperRuntime(agent.name, keeperList),
+            ?? findKeeperRuntime(agent.name, runtimeKeeperList),
         ),
       ] as const),
     ),
-    [scopedAgents, keeperRuntimeLookup, keeperList],
+    [scopedAgents, keeperRuntimeLookup, runtimeKeeperList],
   )
   const normalizedSearch = search.trim().toLowerCase()
   const searchTermsByAgent = useMemo(
@@ -474,7 +489,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         const keeper =
           keeperRuntimeLookup.get(agent.name)
           ?? findKeeperRuntimeForAgent(agent, keeperRuntimeLookup)
-          ?? findKeeperRuntime(agent.name, keeperList)
+          ?? findKeeperRuntime(agent.name, runtimeKeeperList)
         return [
           agent.name,
           keeperIdentitySearchTerms(
@@ -484,7 +499,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         ] as const
       }),
     ),
-    [scopedAgents, keeperRuntimeLookup, keeperList],
+    [scopedAgents, keeperRuntimeLookup, runtimeKeeperList],
   )
   const pageDescription = keeperFilter === 'keeper-only'
     ? 'live runtime 기준으로 주 이름과 현재 상태를 먼저 훑습니다.'
@@ -520,7 +535,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       return a.name.localeCompare(b.name)
     })
 
-  const counts = countAgentsByStatus(scopedAgents, keeperList)
+  const counts = countAgentsByStatus(scopedAgents, runtimeKeeperList)
   const showExecutionFallbackState = shouldShowExecutionFallbackState({
     executionLoaded: executionLoaded.value,
     executionLoading: executionLoading.value,
@@ -554,7 +569,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const configuredKeeperHint =
     keeperFilter === 'agent-only' || runtimeCounts.configuredKeepers <= 0
       ? null
-      : `설정된 keeper ${runtimeCounts.configuredKeepers}개`
+      : runtimeCounts.configuredKeepers > runtimeCounts.keepers
+        ? `설정된 keeper ${runtimeCounts.configuredKeepers}개 · runtime ${runtimeCounts.keepers}개 · 일시정지/미기동 ${runtimeCounts.configuredKeepers - runtimeCounts.keepers}개`
+        : `설정된 keeper ${runtimeCounts.configuredKeepers}개`
   const fallbackStateTitle =
     executionError.value
       ? '상세 상태 불러오기 실패'
@@ -636,7 +653,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           const keeperRuntime =
             keeperRuntimeLookup.get(agent.name)
             ?? findKeeperRuntimeForAgent(agent, keeperRuntimeLookup)
-            ?? findKeeperRuntime(agent.name, keeperList)
+            ?? findKeeperRuntime(agent.name, runtimeKeeperList)
           const band = bandByAgent.get(agent.name) ?? runtimeBandMeta('attention')
           const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime) : null
           const monitoringEvidence = keeperMonitoring ? summarizeMonitoringEvidence(keeperMonitoring) : null

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -67,6 +67,7 @@ export function AgentsUnified() {
   const totalCount = runtimeCounts.totalRuntimes
   const keeperCount = runtimeCounts.keepers
   const agentOnlyCount = runtimeCounts.agents
+  const configuredKeeperDelta = Math.max(0, runtimeCounts.configuredKeepers - keeperCount)
   function chipCount(id: AgentsView): number | null {
     if (id === 'all') return totalCount
     if (id === 'agents') return agentOnlyCount
@@ -92,6 +93,13 @@ export function AgentsUnified() {
         tone="accent"
         class="monitor-muted-panel w-fit p-1.5 shadow-[inset_0_1px_0_var(--white-3)]"
       />
+
+      ${configuredKeeperDelta > 0 ? html`
+        <div class="monitor-muted-panel flex w-fit flex-wrap items-center gap-2 px-3 py-2 text-xs text-[var(--color-fg-muted)]">
+          <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">runtime truth</span>
+          <span>live runtime ${keeperCount} · configured keeper ${runtimeCounts.configuredKeepers} · 일시정지/미기동 ${configuredKeeperDelta}</span>
+        </div>
+      ` : null}
 
       ${currentView !== 'fsm' ? html`
         <div class="monitor-muted-panel flex flex-wrap items-center gap-2 px-4 py-3 text-xs text-[var(--color-fg-muted)]">

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -222,11 +222,26 @@ describe('runtimeAttentionForSnapshot', () => {
     expect(attention.title).toContain('latest activity 10m ago')
   })
 
+  it('keeps recent healthy non-live keepers waiting instead of stale', () => {
+    const snap = snapshot({
+      is_live: false,
+      phase: 'Running',
+      execution: execution({
+        recorded_at: '2026-04-25T07:38:30Z',
+      }),
+    })
+
+    const attention = runtimeAttentionForSnapshot(snap, generatedAt)
+    expect(snap.phase).toBe('Running')
+    expect(attention.level).toBe('ok')
+    expect(attention.label).toBe('대기')
+    expect(attention.reason).toContain('healthy idle')
+  })
+
   it('keeps raw lifecycle separate by flagging stale liveness without changing phase', () => {
     const snap = snapshot({
       is_live: false,
       phase: 'Running',
-      execution: execution(),
     })
 
     const attention = runtimeAttentionForSnapshot(snap, generatedAt)
@@ -268,7 +283,6 @@ describe('runtimeAttentionForSnapshot', () => {
     const stale = snapshot({
       name: 'stale',
       is_live: false,
-      execution: execution(),
     })
     const idle = snapshot({
       name: 'idle',
@@ -300,6 +314,52 @@ describe('runtimeAttentionForSnapshot', () => {
     })
 
     expect(latestRuntimeActivityEpoch(snap)).toBe(generatedAt - 300)
+  })
+
+  it('names missing required keeper tools in blocker cause and next step', () => {
+    const snap = snapshot({
+      is_live: false,
+      execution: execution({
+        outcome: 'error',
+        terminal_reason_code: 'completion_contract_violation:require_tool_use',
+        operator_disposition: 'pause_human',
+        operator_disposition_reason: 'tool_required_unsatisfied',
+        tool_contract_result: 'missing_required_tool_use',
+        tool_surface: {
+          tool_requirement: 'required',
+          tool_gate_enabled: true,
+          missing_required_tools: ['keeper_bash'],
+          required_tools: ['keeper_bash'],
+        },
+      }),
+    })
+
+    const attention = runtimeAttentionForSnapshot(snap, generatedAt)
+    expect(attention.level).toBe('blocked')
+    expect(attention.cause).toContain('missing_required_tool_use (keeper_bash)')
+    expect(attention.nextStep).toContain('keeper_bash')
+  })
+
+  it('routes provider timeout blockers away from generic approval guidance', () => {
+    const snap = snapshot({
+      is_live: true,
+      execution: execution({
+        outcome: 'error',
+        terminal_reason_code: 'api_error_timeout',
+        operator_disposition: 'pause_human',
+        operator_disposition_reason: 'tool_required_unsatisfied',
+        tool_contract_result: 'unknown',
+        error: {
+          kind: 'api',
+          message_preview: 'Timeout after 1785s',
+          message_truncated: false,
+        },
+      }),
+    })
+
+    const attention = runtimeAttentionForSnapshot(snap, generatedAt)
+    expect(attention.level).toBe('blocked')
+    expect(attention.nextStep).toBe('provider timeout budget/cascade lane 확인')
   })
 })
 

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -40,6 +40,7 @@ import {
 
 const POLL_INTERVAL_MS = 10_000
 const LONG_IDLE_SECONDS = 10 * 60
+const STALE_RUNTIME_SECONDS = 30 * 60
 
 /**
  * Time-axis window (LT-16c). 30 snapshots × 10s poll = 5-minute
@@ -287,6 +288,29 @@ function hasBlockingExecutionEvidence(snapshot: KeeperCompositeSnapshot): boolea
   return false
 }
 
+function hasHealthyExecutionEvidence(snapshot: KeeperCompositeSnapshot): boolean {
+  const execution = snapshot.execution
+  if (!execution || hasBlockingExecutionEvidence(snapshot)) return false
+  if (execution.latest_receipt_present !== true) return false
+  if (execution.outcome === 'ok') return true
+  if (execution.terminal_reason_code === 'completed') return true
+  if (execution.tool_contract_result?.startsWith('satisfied')) return true
+  return false
+}
+
+function requiredToolText(snapshot: KeeperCompositeSnapshot): string | null {
+  const surface = snapshot.execution?.tool_surface
+  const missing = surface?.missing_required_tools ?? []
+  const required = surface?.required_tools ?? []
+  const names = missing.length > 0 ? missing : required
+  return names.length > 0 ? names.join(', ') : null
+}
+
+function hasRequireToolUseViolation(snapshot: KeeperCompositeSnapshot): boolean {
+  const code = snapshot.execution?.terminal_reason_code ?? ''
+  return code.includes('require_tool_use')
+}
+
 function blockingCause(snapshot: KeeperCompositeSnapshot): string {
   const execution = snapshot.execution
   if (!execution) return 'blocking execution evidence present'
@@ -299,7 +323,10 @@ function blockingCause(snapshot: KeeperCompositeSnapshot): string {
     )
   }
   if (execution.tool_contract_result === 'missing_required_tool_use') {
-    parts.push('tool contract: missing_required_tool_use')
+    const tools = requiredToolText(snapshot)
+    parts.push(tools ? `tool contract: missing_required_tool_use (${tools})` : 'tool contract: missing_required_tool_use')
+  } else if (hasRequireToolUseViolation(snapshot)) {
+    parts.push('tool contract: actionable signal without keeper tool')
   } else if (execution.tool_contract_result === 'unknown' && execution.error != null) {
     parts.push('tool contract unknown with execution error')
   }
@@ -319,7 +346,19 @@ function blockingNextStep(snapshot: KeeperCompositeSnapshot): string {
   const execution = snapshot.execution
   if (!execution) return 'latest execution receipt 확인'
   if (execution.tool_contract_result === 'missing_required_tool_use') {
-    return '필수 tool contract를 만족시키거나 task/tool 설정 조정'
+    const tools = requiredToolText(snapshot)
+    return tools
+      ? `필수 tool 호출 경로 확인: ${tools}`
+      : '필수 tool contract를 만족시키거나 task/tool 설정 조정'
+  }
+  if (hasRequireToolUseViolation(snapshot)) {
+    return '모델이 keeper tool을 호출하도록 prompt/tool-choice 경로 확인'
+  }
+  if (execution.terminal_reason_code === 'api_error_invalid_request') {
+    return 'provider auth/model/config receipt 확인'
+  }
+  if (execution.terminal_reason_code === 'api_error_timeout') {
+    return 'provider timeout budget/cascade lane 확인'
   }
   if (execution.operator_disposition === 'pause_human') {
     return 'operator gate/approval 상태와 최신 receipt 확인'
@@ -365,6 +404,8 @@ export function buildRuntimeAssistPrompt(
       operator_disposition: snapshot.execution.operator_disposition,
       operator_disposition_reason: snapshot.execution.operator_disposition_reason,
       tool_contract_result: snapshot.execution.tool_contract_result,
+      required_tools: snapshot.execution.tool_surface?.required_tools ?? [],
+      missing_required_tools: snapshot.execution.tool_surface?.missing_required_tools ?? [],
       error_kind: snapshot.execution.error?.kind ?? null,
       error_preview: snapshot.execution.error?.message_preview ?? null,
     })
@@ -484,6 +525,20 @@ export function runtimeAttentionForSnapshot(
     }
   }
   if (!snapshot.is_live) {
+    if (hasHealthyExecutionEvidence(snapshot) && ageSec != null && ageSec < STALE_RUNTIME_SECONDS) {
+      const idleLong = idleComposite && ageSec >= LONG_IDLE_SECONDS
+      const cause = `healthy receipt 이후 live turn 없음 · latest ${ageText}`
+      const nextStep = idleLong ? 'backlog, admission, trigger가 없는지 확인' : '조치 불필요'
+      return {
+        level: idleLong ? 'idle' : 'ok',
+        label: idleLong ? '무전환' : '대기',
+        reason: `healthy idle · latest activity ${ageText}`,
+        cause,
+        nextStep,
+        title: `원인: ${cause} · 다음: ${nextStep} · 증거: ${evidenceText}`,
+        ageSec,
+      }
+    }
     const cause = staleCause(snapshot, ageText)
     const nextStep = staleNextStep(snapshot, latest)
     return {

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -59,6 +59,25 @@ describe('resolveRuntimeCounts', () => {
     })
   })
 
+  it('prefers visible runtime rows over configured fallback counts while execution is still warming', () => {
+    expect(resolveRuntimeCounts({
+      executionLoaded: false,
+      agentsCount: 0,
+      keepersCount: 12,
+      namespaceTruthCounts: { agents: 0, keepers: 14, tasks: 103 },
+      namespaceTruthConfiguredKeepers: 14,
+      shellCounts: { agents: 13, keepers: 12, tasks: 103, total_runtimes: 25 },
+      shellConfiguredKeepers: 14,
+    })).toEqual({
+      agents: 0,
+      keepers: 12,
+      tasks: 0,
+      totalRuntimes: 12,
+      configuredKeepers: 14,
+      source: 'partial',
+    })
+  })
+
   it('keeps fallback truth when execution says loaded but runtime rows are still empty', () => {
     expect(resolveRuntimeCounts({
       executionLoaded: true,

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -84,6 +84,15 @@ export function resolveRuntimeCounts({
     }
   }
 
+  if (liveTotalRuntimes > 0) {
+    return {
+      ...live,
+      totalRuntimes: liveTotalRuntimes,
+      configuredKeepers,
+      source: 'partial',
+    }
+  }
+
   if (namespaceTotalRuntimes > 0) {
     return {
       ...namespace!,

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -5,7 +5,9 @@
     this shared implementation.
 
     Two stall detection modes:
-    1. Idle stall: [last_turn_ts] older than 300s while [Running].
+    1. Idle stall: [last_turn_ts] older than 300s while [Running],
+       with no recent keepalive skip verdict proving the fiber is still
+       evaluating work.
     2. Failure loop: [consecutive_noop_count >= 3] — catches keepers in
        LLM timeout loops where [last_turn_ts] stays fresh because each
        failed turn updates it.
@@ -113,6 +115,13 @@ let stale_kill_class_label (cls : Keeper_registry.stale_kill_class) : string =
   | In_turn_hung _ -> "in_turn_hung"
   | Noop_failure_loop _ -> "noop_failure_loop"
 
+let has_recent_skip_observation ~now ~threshold
+    (entry : Keeper_registry.registry_entry) : bool =
+  match entry.last_skip_observation with
+  | Some (ts, reasons) ->
+      reasons <> [] && now -. ts <= threshold
+  | None -> false
+
 let () =
   Prometheus.register_counter
     ~name:"masc_keeper_stale_termination_by_class_total"
@@ -209,21 +218,27 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                let turn_timeout = Keeper_runtime_resolved.turn_timeout_sec () in
                Float.max turn_timeout threshold
              in
-             let idle_stale, in_turn_stale, in_turn_age =
+             let idle_stale, in_turn_stale, in_turn_age,
+                 idle_skip_suppressed =
                match entry.current_turn_observation with
                | Some obs ->
                  let elapsed = now -. obs.started_at in
                  ( false
                  , elapsed > active_turn_timeout_sec
                    && fiber_age >= grace_period_sec ()
-                 , elapsed )
+                 , elapsed
+                 , false )
                | None ->
+                 let skip_observed =
+                   has_recent_skip_observation ~now ~threshold entry
+                 in
                  let stale =
                    last_turn > 0.0
                    && now -. last_turn > threshold
                    && fiber_age >= grace_period_sec ()
+                   && not skip_observed
                  in
-                 (stale, false, 0.0)
+                 (stale, false, 0.0, skip_observed)
              in
              let noop_count =
                entry.meta.runtime.proactive_rt.consecutive_noop_count
@@ -231,7 +246,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
              let failure_loop = noop_count >= noop_threshold () in
              let stale = idle_stale || in_turn_stale || failure_loop in
              (* #10908: 92% of ticks are
-                [noop=0 idle_stale=false failure_loop=false stale=false]
+               [noop=0 idle_stale=false failure_loop=false stale=false]
                 — every health bool at default.  Logging at INFO drowns
                 actionable ticks (and competing real signals) under
                 ~800 lines/day of identical heartbeat noise.  Same fix
@@ -239,12 +254,13 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                 anything an operator should see (any flag set or any
                 noop accumulated), demote the all-default heartbeat to
                 DEBUG. *)
-             let actionable = stale || noop_count > 0 in
+             let actionable = stale || noop_count > 0 || idle_skip_suppressed in
              let log_line =
                Printf.sprintf
-                 "%s: watchdog tick noop=%d idle_stale=%b in_turn_stale=%b in_turn_age=%.0f failure_loop=%b stale=%b last_turn=%.0f fiber_age=%.0f grace_rem=%.0f"
-                 meta.name noop_count idle_stale in_turn_stale in_turn_age
-                 failure_loop stale last_turn fiber_age grace_remaining
+                 "%s: watchdog tick noop=%d idle_stale=%b idle_skip_suppressed=%b in_turn_stale=%b in_turn_age=%.0f failure_loop=%b stale=%b last_turn=%.0f fiber_age=%.0f grace_rem=%.0f"
+                 meta.name noop_count idle_stale idle_skip_suppressed
+                 in_turn_stale in_turn_age failure_loop stale last_turn
+                 fiber_age grace_remaining
              in
              if actionable
              then Log.Keeper.info "%s" log_line


### PR DESCRIPTION
## Summary
- make Agent Directory counts prefer loaded live runtime rows over configured fallback truth
- keep configured-only paused keepers out of live runtime cards while surfacing the configured/runtime delta
- stop Fleet FSM from labeling recent healthy non-live keepers as stale
- classify tool-contract and provider blockers with concrete next steps
- suppress stale-watchdog idle kills when recent skip evidence proves the keeper fiber is still evaluating work

## Root Cause
The Agent Directory mixed configured keeper totals with live runtime detail rows, so 14 configured keepers could appear as 14 live keepers while the Fleet composite had only 12 runtime rows. Fleet FSM also treated any is_live=false snapshot as stale, even when the latest execution receipt was healthy and recent. Separately, the stale watchdog could terminate a Running keeper after the idle threshold even if the keepalive loop had just recorded a skip verdict.

## Validation
- dashboard: vitest run src/runtime-counts.test.ts
- dashboard: vitest run src/components/agent-roster.test.ts
- dashboard: vitest run src/components/fleet-fsm-matrix.test.ts
- dashboard: tsc --noEmit --pretty
- scripts/dune-local.sh build lib/masc_mcp.cma test/test_keeper_supervisor.exe
- ./_build/default/test/test_keeper_supervisor.exe