### PR TITLE
Derive TLA state classifications from ppx_tla

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -23,16 +23,16 @@ type failure_reason =
     }
 
 type turn_state =
-  | Idle
-  | Phase_gating
-  | Cascade_routing
-  | Awaiting_provider
-  | Streaming
-  | Awaiting_tool_result [@tla.symbol "awaiting_tool"]
-  | Completing
-  | Done
-  | Failed of failure_reason
-  | Cancelled of cancel_reason
+  | Idle [@tla.idle]
+  | Phase_gating [@tla.active]
+  | Cascade_routing [@tla.active]
+  | Awaiting_provider [@tla.active]
+  | Streaming [@tla.active]
+  | Awaiting_tool_result [@tla.symbol "awaiting_tool"] [@tla.active]
+  | Completing [@tla.active]
+  | Done [@tla.terminal]
+  | Failed of failure_reason [@tla.terminal]
+  | Cancelled of cancel_reason [@tla.terminal]
 [@@deriving tla]
 
 let cancel_reason_label = function

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -45,22 +45,24 @@ type failure_reason =
     is currently implicit across multiple files and Step 4b will
     introduce explicit transitions. *)
 type turn_state =
-  | Idle
-  | Phase_gating
-  | Cascade_routing
-  | Awaiting_provider
-  | Streaming
-  | Awaiting_tool_result [@tla.symbol "awaiting_tool"]
-  | Completing
-  | Done
-  | Failed of failure_reason
-  | Cancelled of cancel_reason
+  | Idle [@tla.idle]
+  | Phase_gating [@tla.active]
+  | Cascade_routing [@tla.active]
+  | Awaiting_provider [@tla.active]
+  | Streaming [@tla.active]
+  | Awaiting_tool_result [@tla.symbol "awaiting_tool"] [@tla.active]
+  | Completing [@tla.active]
+  | Done [@tla.terminal]
+  | Failed of failure_reason [@tla.terminal]
+  | Cancelled of cancel_reason [@tla.terminal]
 [@@deriving tla]
 (** TLA+ symbol mapping derived by [ppx_tla].
 
-    [to_tla_symbol] / [all_symbols] match [TurnStateSet] in
-    [specs/keeper-turn-fsm/KeeperTurnFSM.tla] (verified by
-    [test_keeper_turn_fsm_tla_parity]).
+    [to_tla_symbol] / [all_symbols] match [TurnStateSet], while
+    [active_symbols] / [terminal_symbols] and the generated
+    [is_active] / [is_terminal] predicates match [ActiveStateSet] and
+    [TerminalStateSet] in [specs/keeper-turn-fsm/KeeperTurnFSM.tla]
+    (verified by [test_keeper_turn_fsm_tla_parity]).
 
     [@tla.symbol "awaiting_tool"] on [Awaiting_tool_result] covers the
     OCaml-vs-TLA+ naming difference without renaming either side. *)

--- a/ppx_tla/ppx_tla.ml
+++ b/ppx_tla/ppx_tla.ml
@@ -27,10 +27,11 @@
      declarations so the type can carry [@@deriving tla] in its public
      interface as well as its implementation.
 
-   Classification attributes ([@tla.terminal] / [@tla.idle] / [@tla.active])
-   that derive [terminal_states] / [idle_states] / [active_states] subsets
-   are intentionally deferred to a follow-up cycle to keep this commit
-   focused on the parity test for the existing TurnStateSet. *)
+   Cycle 21 closes the deferred classification slice:
+   - [@tla.terminal] / [@tla.active] / [@tla.idle] per constructor.
+   - [terminal_symbols] / [active_symbols] / [idle_symbols].
+   - [is_terminal] / [is_active] / [is_idle] predicates that work even
+     when constructors carry payloads. *)
 
 open Ppxlib
 
@@ -46,6 +47,34 @@ let symbol_of_constructor (cd : constructor_declaration) =
   match Attribute.get symbol_attr cd with
   | Some s -> s
   | None -> String.lowercase_ascii cd.pcd_name.txt
+
+(* Constructor classification attributes.
+
+   These mirror TLA+ sets such as [TerminalStateSet] and
+   [ActiveStateSet] without requiring payload-bearing constructors to
+   be enumerated as values. The deriver emits symbol subsets plus
+   predicates, so [Failed _] can still be classified as terminal. *)
+let terminal_attr =
+  Attribute.declare "tla.terminal"
+    Attribute.Context.constructor_declaration
+    Ast_pattern.(pstr nil)
+    ()
+
+let active_attr =
+  Attribute.declare "tla.active"
+    Attribute.Context.constructor_declaration
+    Ast_pattern.(pstr nil)
+    ()
+
+let idle_attr =
+  Attribute.declare "tla.idle"
+    Attribute.Context.constructor_declaration
+    Ast_pattern.(pstr nil)
+    ()
+
+let constructor_is_terminal cd = Attribute.get terminal_attr cd <> None
+let constructor_is_active cd = Attribute.get active_attr cd <> None
+let constructor_is_idle cd = Attribute.get idle_attr cd <> None
 
 (* [@@tla.phantom_param] flag on type declarations (Cycle 20 / Tier I9).
 
@@ -155,13 +184,71 @@ let make_all_states_impl ~loc cds =
   in
   Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
 
+let bool_expr ~loc value =
+  Ast_builder.Default.pexp_construct ~loc
+    (Loc.make ~loc (Longident.Lident (if value then "true" else "false")))
+    None
+
+let make_symbol_subset_impl ~loc ~name ~pred cds =
+  let exprs =
+    cds
+    |> List.filter pred
+    |> List.map (fun cd ->
+           Ast_builder.Default.estring ~loc (symbol_of_constructor cd))
+  in
+  let list_expr = Ast_builder.Default.elist ~loc exprs in
+  let pat = Ast_builder.Default.ppat_var ~loc (Loc.make ~loc name) in
+  let binding =
+    Ast_builder.Default.value_binding ~loc ~pat ~expr:list_expr
+  in
+  Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
+
+let make_constructor_predicate_impl ~loc ~name ~pred cds =
+  let cases =
+    List.map
+      (fun (cd : constructor_declaration) ->
+        let pat = constructor_pattern ~loc cd in
+        let rhs = bool_expr ~loc (pred cd) in
+        Ast_builder.Default.case ~lhs:pat ~guard:None ~rhs)
+      cds
+  in
+  let arg_name = "__tla_arg" in
+  let arg_pat =
+    Ast_builder.Default.ppat_var ~loc (Loc.make ~loc arg_name)
+  in
+  let arg_expr = Ast_builder.Default.evar ~loc arg_name in
+  let match_expr = Ast_builder.Default.pexp_match ~loc arg_expr cases in
+  let func =
+    Ast_builder.Default.pexp_fun ~loc Nolabel None arg_pat match_expr
+  in
+  let pat = Ast_builder.Default.ppat_var ~loc (Loc.make ~loc name) in
+  let binding = Ast_builder.Default.value_binding ~loc ~pat ~expr:func in
+  Ast_builder.Default.pstr_value ~loc Nonrecursive [ binding ]
+
+let make_classification_impls ~loc cds =
+  [
+    make_symbol_subset_impl ~loc ~name:"terminal_symbols"
+      ~pred:constructor_is_terminal cds;
+    make_symbol_subset_impl ~loc ~name:"active_symbols"
+      ~pred:constructor_is_active cds;
+    make_symbol_subset_impl ~loc ~name:"idle_symbols"
+      ~pred:constructor_is_idle cds;
+    make_constructor_predicate_impl ~loc ~name:"is_terminal"
+      ~pred:constructor_is_terminal cds;
+    make_constructor_predicate_impl ~loc ~name:"is_active"
+      ~pred:constructor_is_active cds;
+    make_constructor_predicate_impl ~loc ~name:"is_idle"
+      ~pred:constructor_is_idle cds;
+  ]
+
 let derive_impl_for_variant ~loc cds =
   let to_tla = make_to_tla_symbol_impl ~loc cds in
   let all_symbols = make_all_symbols_impl ~loc cds in
+  let classification = make_classification_impls ~loc cds in
   if List.for_all constructor_is_nullary cds then
-    [ to_tla; all_symbols; make_all_states_impl ~loc cds ]
+    [ to_tla; all_symbols; make_all_states_impl ~loc cds ] @ classification
   else
-    [ to_tla; all_symbols ]
+    [ to_tla; all_symbols ] @ classification
 
 (* ── Record-type implementation generators (Cycle 20 / Tier I7) ────
 
@@ -306,13 +393,14 @@ let make_to_tla_symbol_impl_gadt_one_param ~loc ~type_name cds =
 let derive_impl_for_gadt ~loc ~type_name ~type_params ~is_phantom cds =
   let _ = type_name in
   let all_symbols = make_all_symbols_impl ~loc cds in
+  let classification = make_classification_impls ~loc cds in
   match (type_params, is_phantom) with
   | [], _ ->
     (* GADT with no type params: structurally like ordinary variant but
        all_states is suppressed because GADT constructors with explicit
        result types may not list-construct cleanly without payload. *)
     let to_tla = make_to_tla_symbol_impl ~loc cds in
-    [ to_tla; all_symbols ]
+    [ to_tla; all_symbols ] @ classification
   | _ :: _, true ->
     (* Phantom-parameter GADT (Tier I9): the user has asserted via
        [@@tla.phantom_param] that no constructor specialises any type
@@ -323,7 +411,7 @@ let derive_impl_for_gadt ~loc ~type_name ~type_params ~is_phantom cds =
        enforces the phantom contract: a constructor that specialises
        a parameter triggers a clean type error at the user's call site. *)
     let to_tla = make_to_tla_symbol_impl ~loc cds in
-    [ to_tla; all_symbols ]
+    [ to_tla; all_symbols ] @ classification
   | _ :: _, false ->
     (* Non-phantom 1+ parameter GADT existentials still require the
        three-piece AST trick (ptyp_poly + pexp_newtype + inner
@@ -377,6 +465,11 @@ let list_t ~loc element_t =
     (Loc.make ~loc (Longident.Lident "list"))
     [ element_t ]
 
+let bool_t ~loc =
+  Ast_builder.Default.ptyp_constr ~loc
+    (Loc.make ~loc (Longident.Lident "bool"))
+    []
+
 let make_value_sig ~loc ~name ~type_ =
   Ast_builder.Default.psig_value ~loc
     (Ast_builder.Default.value_description ~loc
@@ -425,7 +518,21 @@ let derive_sig_for_variant ~loc ~type_name ~type_params ~is_phantom cds =
     else
       []
   in
-  to_tla_sig :: all_symbols_sig :: all_states_sig_opt
+  let symbol_list_t = list_t ~loc (string_t ~loc) in
+  let bool_arrow =
+    Ast_builder.Default.ptyp_arrow ~loc Nolabel arg_t (bool_t ~loc)
+  in
+  let classification_sigs =
+    [
+      make_value_sig ~loc ~name:"terminal_symbols" ~type_:symbol_list_t;
+      make_value_sig ~loc ~name:"active_symbols" ~type_:symbol_list_t;
+      make_value_sig ~loc ~name:"idle_symbols" ~type_:symbol_list_t;
+      make_value_sig ~loc ~name:"is_terminal" ~type_:bool_arrow;
+      make_value_sig ~loc ~name:"is_active" ~type_:bool_arrow;
+      make_value_sig ~loc ~name:"is_idle" ~type_:bool_arrow;
+    ]
+  in
+  to_tla_sig :: all_symbols_sig :: all_states_sig_opt @ classification_sigs
 
 let int_t ~loc =
   Ast_builder.Default.ptyp_constr ~loc

--- a/test/ppx_tla/test_basic.ml
+++ b/test/ppx_tla/test_basic.ml
@@ -6,6 +6,8 @@
    - [@tla.symbol "explicit"] override
    - [all_symbols] always generated
    - [all_states] generated only when every constructor is nullary
+   - [@tla.terminal] / [@tla.active] / [@tla.idle] classification
+     emits symbol subsets and payload-safe predicates
 
    Each type is wrapped in its own module because [@@deriving tla]
    generates [to_tla_symbol] / [all_symbols] / [all_states] in the
@@ -38,6 +40,16 @@ module Mixed = struct
     | Awaiting_tool_result [@tla.symbol "awaiting_tool"]
     | Failed of Reason.t
     | Cancelled of Reason.t
+  [@@deriving tla]
+end
+
+module Classified = struct
+  type t =
+    | Idle [@tla.idle]
+    | Running [@tla.active]
+    | Awaiting_tool [@tla.symbol "awaiting_tool"] [@tla.active]
+    | Done [@tla.terminal]
+    | Failed of Reason.t [@tla.terminal]
   [@@deriving tla]
 end
 
@@ -89,6 +101,21 @@ let test_mixed_all_symbols () =
   assert (
     Mixed.all_symbols
     = [ "awaiting_provider"; "awaiting_tool"; "failed"; "cancelled" ])
+
+let test_classified_symbol_subsets () =
+  assert (Classified.idle_symbols = [ "idle" ]);
+  assert (Classified.active_symbols = [ "running"; "awaiting_tool" ]);
+  assert (Classified.terminal_symbols = [ "done"; "failed" ])
+
+let test_classified_predicates () =
+  assert (Classified.is_idle Classified.Idle);
+  assert (not (Classified.is_idle Classified.Running));
+  assert (Classified.is_active Classified.Running);
+  assert (Classified.is_active Classified.Awaiting_tool);
+  assert (not (Classified.is_active Classified.Done));
+  assert (Classified.is_terminal Classified.Done);
+  assert (Classified.is_terminal (Classified.Failed "boom"));
+  assert (not (Classified.is_terminal Classified.Idle))
 
 (* Cycle 12 (PR #11450): [@@fsm_guard "expr"] runtime assertion injection.
    The guard is parsed as an OCaml boolean expression at PPX time and
@@ -143,6 +170,8 @@ let () =
   test_mixed_to_tla_symbol_override ();
   test_mixed_to_tla_symbol_parameterised ();
   test_mixed_all_symbols ();
+  test_classified_symbol_subsets ();
+  test_classified_predicates ();
   test_fsm_guard_pass ();
   test_fsm_guard_fail ();
   test_fsm_guard_curried_pass ();

--- a/test/test_keeper_turn_fsm_tla_parity.ml
+++ b/test/test_keeper_turn_fsm_tla_parity.ml
@@ -1,6 +1,8 @@
 (* Parity test: [Keeper_turn_fsm.all_symbols] (derived by [ppx_tla])
    must match the [TurnStateSet] enumerated in
-   [specs/keeper-turn-fsm/KeeperTurnFSM.tla].
+   [specs/keeper-turn-fsm/KeeperTurnFSM.tla]. The same generated
+   classification contract must also match [ActiveStateSet] and
+   [TerminalStateSet].
 
    This test makes the spec-implementation drift visible at build time.
    When a constructor is added, removed, or renamed in either side, the
@@ -97,6 +99,24 @@ let spec_turn_state_set : string list =
          have moved or been renamed."
   | Some states -> states
 
+let spec_quoted_set symbol : string list =
+  let path =
+    Filename.concat
+      (project_root ())
+      "specs/keeper-turn-fsm/KeeperTurnFSM.tla"
+  in
+  let content = read_file path in
+  match find_quoted_set ~symbol content with
+  | None ->
+      failwith
+        (symbol
+        ^ " not found in specs/keeper-turn-fsm/KeeperTurnFSM.tla — set \
+           definition may have moved or been renamed.")
+  | Some states -> states
+
+let spec_active_state_set = spec_quoted_set "ActiveStateSet"
+let spec_terminal_state_set = spec_quoted_set "TerminalStateSet"
+
 let sort = List.sort String.compare
 
 let test_all_symbols_match_spec () =
@@ -118,6 +138,26 @@ let test_all_symbols_match_spec () =
        update either the OCaml type, the [@tla.symbol] override, or the \
        spec."
   end
+
+let check_symbol_set ~label ~ocaml ~spec =
+  let ocaml = sort ocaml in
+  let spec = sort spec in
+  if ocaml <> spec then begin
+    Printf.printf "OCaml %s : [%s]\n" label (String.concat "; " ocaml);
+    Printf.printf "Spec  %s : [%s]\n" label (String.concat "; " spec);
+    failwith ("Keeper_turn_fsm " ^ label ^ " differs from TLA+ spec")
+  end
+
+let test_classified_symbols_match_spec () =
+  check_symbol_set ~label:"active_symbols"
+    ~ocaml:Masc_mcp.Keeper_turn_fsm.active_symbols
+    ~spec:spec_active_state_set;
+  check_symbol_set ~label:"terminal_symbols"
+    ~ocaml:Masc_mcp.Keeper_turn_fsm.terminal_symbols
+    ~spec:spec_terminal_state_set;
+  check_symbol_set ~label:"idle_symbols"
+    ~ocaml:Masc_mcp.Keeper_turn_fsm.idle_symbols
+    ~spec:[ "idle" ]
 
 let test_to_tla_symbol_for_each_constructor () =
   (* Sanity: every nullary constructor round-trips through to_tla_symbol
@@ -151,7 +191,24 @@ let test_to_tla_symbol_for_each_constructor () =
       (Masc_mcp.Keeper_turn_fsm.Cancelled dummy_cancel)
     = "cancelled")
 
+let test_classification_predicates () =
+  let open Masc_mcp.Keeper_turn_fsm in
+  assert (is_idle Idle);
+  assert (not (is_active Idle));
+  assert (not (is_terminal Idle));
+  assert (is_active Phase_gating);
+  assert (is_active Cascade_routing);
+  assert (is_active Awaiting_provider);
+  assert (is_active Streaming);
+  assert (is_active Awaiting_tool_result);
+  assert (is_active Completing);
+  assert (is_terminal Done);
+  assert (is_terminal (Failed (Failure_runtime_error "probe")));
+  assert (is_terminal (Cancelled Cancelled_supervisor_stop))
+
 let () =
   test_all_symbols_match_spec ();
+  test_classified_symbols_match_spec ();
   test_to_tla_symbol_for_each_constructor ();
+  test_classification_predicates ();
   print_endline "keeper_turn_fsm TLA+ parity test: PASS"


### PR DESCRIPTION
## Summary
- add ppx_tla constructor classification attributes for TLA terminal, active, and idle sets
- generate terminal_symbols, active_symbols, idle_symbols plus is_terminal/is_active/is_idle predicates
- annotate Keeper_turn_fsm turn_state and extend parity tests against KeeperTurnFSM.tla ActiveStateSet and TerminalStateSet

## Why it matters
The AST plan had TurnStateSet parity, but ActiveStateSet and TerminalStateSet were still hand-maintained semantics. This closes that gap so payload-bearing constructors like Failed _ and Cancelled _ can be classified by generated predicates instead of reviewer convention.

## Verification
- scripts/dune-local.sh build ppx_tla test/ppx_tla/test_basic.exe test/test_keeper_turn_fsm_tla_parity.exe
- ./_build/default/test/ppx_tla/test_basic.exe
- ./_build/default/test/test_keeper_turn_fsm_tla_parity.exe
- scripts/dune-local.sh build @test/ppx_tla/runtest
- git diff --check