### PR TITLE
Type operator review decisions

### DIFF
--- a/lib/operator/operator_review_state.ml
+++ b/lib/operator/operator_review_state.ml
@@ -2,10 +2,15 @@ module U = Yojson.Safe.Util
 
 open Operator_pending_confirm
 
+type review_decision_value = Review_decision_value of string
+
+let review_decision_value_to_string (Review_decision_value value) = value
+let review_decision_value_of_string value = Review_decision_value value
+
 type review_decision = {
   item_id : string;
   fingerprint : string;
-  decision : string;
+  decision : review_decision_value;
   actor : string;
   reason : string;
   at : string;
@@ -22,7 +27,7 @@ let review_decision_to_yojson (entry : review_decision) =
     [
       ("item_id", `String entry.item_id);
       ("fingerprint", `String entry.fingerprint);
-      ("decision", `String entry.decision);
+      ("decision", `String (review_decision_value_to_string entry.decision));
       ("actor", `String entry.actor);
       ("reason", `String entry.reason);
       ("at", `String entry.at);
@@ -38,7 +43,9 @@ let review_decision_of_yojson json =
       {
         item_id = json |> U.member "item_id" |> U.to_string;
         fingerprint = json |> U.member "fingerprint" |> U.to_string;
-        decision = json |> U.member "decision" |> U.to_string;
+        decision =
+          json |> U.member "decision" |> U.to_string
+          |> review_decision_value_of_string;
         actor = json |> U.member "actor" |> U.to_string;
         reason = json |> U.member "reason" |> U.to_string;
         at = json |> U.member "at" |> U.to_string;

--- a/lib/operator/operator_review_state.mli
+++ b/lib/operator/operator_review_state.mli
@@ -7,10 +7,15 @@
 
 (** {1 Types} *)
 
+type review_decision_value = Review_decision_value of string
+
+val review_decision_value_to_string : review_decision_value -> string
+val review_decision_value_of_string : string -> review_decision_value
+
 type review_decision = {
   item_id : string;
   fingerprint : string;
-  decision : string;
+  decision : review_decision_value;
   actor : string;
   reason : string;
   at : string;


### PR DESCRIPTION
## Summary

- Add `Operator_review_state.review_decision_value` as a typed wrapper for persisted operator review decisions.
- Keep `review_state.json` wire format unchanged by rendering/parsing the value at the JSON boundary.
- Reduce the exact `decision : string` sweep from 7 remaining sites to 5 on latest `main`.

## Product impact

- Promise affected: `ops visibility`
- User-visible change: no dashboard/API JSON shape change; this narrows backend operator review records so review decisions are no longer passed as an untyped string field internally.

## Evidence

- `scripts/dune-local.sh build test/test_operator_control.exe` passed.
- `rg -n "decision\\s*:\\s*string" lib test -g '*.ml' -g '*.mli'` reports 5 remaining exact sites.
- `git diff --check` passed.
- `scripts/dune-local.sh exec test/test_operator_control.exe` was started and showed operator tests 0-24 passing, then produced no further output for over 6 minutes; stopped to avoid leaving a hung local test process.

## Review evidence

- Local focused build verification only. Cross-model review not run for this narrow typed-wrapper slice.

## Linked issue

- Relates #11926
