### PR TITLE
Type compaction runtime decisions

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -39,13 +39,18 @@ type scheduled_autonomous_cycle_outcome = proactive_cycle_outcome
 
 (* -- Runtime types (moved into agent_runtime_state) -- *)
 
+type compaction_runtime_decision = Compaction_runtime_decision of string
+
+let compaction_runtime_decision_to_string (Compaction_runtime_decision value) = value
+let compaction_runtime_decision_of_string value = Compaction_runtime_decision value
+
 type compaction_runtime =
   { count : int
   ; last_ts : float
   ; last_before_tokens : int
   ; last_after_tokens : int
   ; last_check_ts : float
-  ; last_decision : string
+  ; last_decision : compaction_runtime_decision
   }
 
 type proactive_runtime =

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -69,13 +69,24 @@ type scheduled_autonomous_cycle_outcome = proactive_cycle_outcome
 
 (** {1 Runtime state types} *)
 
+type compaction_runtime_decision = Compaction_runtime_decision of string
+(** Last compaction gate result as persisted in keeper meta.  JSON and
+    dashboard boundaries still use the historical string value via
+    {!compaction_runtime_decision_to_string}. *)
+
+val compaction_runtime_decision_to_string :
+  compaction_runtime_decision -> string
+
+val compaction_runtime_decision_of_string :
+  string -> compaction_runtime_decision
+
 type compaction_runtime = {
   count : int;
   last_ts : float;
   last_before_tokens : int;
   last_after_tokens : int;
   last_check_ts : float;
-  last_decision : string;
+  last_decision : compaction_runtime_decision;
 }
 
 type proactive_runtime = {

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -99,7 +99,9 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "work_discovery_count", `Int rt.proactive_rt.work_discovery_count
     ; "consecutive_noop_count", `Int rt.proactive_rt.consecutive_noop_count
     ; "last_compaction_check_ts", `Float rt.compaction_rt.last_check_ts
-    ; "last_compaction_decision", `String rt.compaction_rt.last_decision
+    ; ( "last_compaction_decision"
+      , `String (compaction_runtime_decision_to_string rt.compaction_rt.last_decision)
+      )
     ; "last_continuity_update_ts", `Float rt.last_continuity_update_ts
     ; "continuity_summary", `String m.continuity_summary
     ; "active_goal_ids", `List (List.map (fun s -> `String s) m.active_goal_ids)

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -388,6 +388,7 @@ let parse_compaction_runtime (json : Yojson.Safe.t) : compaction_runtime =
   ; last_check_ts = Safe_ops.json_float ~default:0.0 "last_compaction_check_ts" json
   ; last_decision =
       Safe_ops.json_string ~default:"uninitialized" "last_compaction_decision" json
+      |> compaction_runtime_decision_of_string
   }
 ;;
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -364,7 +364,8 @@ let apply_post_turn_lifecycle
                   last_check_ts = now_ts;
                   last_decision =
                     Keeper_compact_policy.compaction_decision_to_string
-                      no_checkpoint_decision;
+                      no_checkpoint_decision
+                    |> compaction_runtime_decision_of_string;
                 };
             })
           meta
@@ -496,7 +497,8 @@ let apply_post_turn_lifecycle
                   last_check_ts = now_ts;
                   last_decision =
                     Keeper_compact_policy.compaction_decision_to_string
-                      decision;
+                      decision
+                    |> compaction_runtime_decision_of_string;
                 };
             })
           base_meta

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -200,9 +200,12 @@ let handle_keeper_list ctx args : tool_result =
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);
               ("proactive_visible_count_total", `Int m.runtime.proactive_rt.visible_count_total);
               ("last_compaction_check_ts", `Float m.runtime.compaction_rt.last_check_ts);
-              ("last_compaction_decision",
-                if String.trim m.runtime.compaction_rt.last_decision = "" then `Null
-                else `String m.runtime.compaction_rt.last_decision);
+              ( "last_compaction_decision",
+                let decision =
+                  compaction_runtime_decision_to_string
+                    m.runtime.compaction_rt.last_decision
+                in
+                if String.trim decision = "" then `Null else `String decision );
               ("last_proactive_ts", `Float m.runtime.proactive_rt.last_ts);
               ("last_visible_proactive_ts", `Float m.runtime.proactive_rt.last_visible_ts);
               ("last_visible_proactive_ago_s", `Float last_visible_proactive_ago_s);

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -468,7 +468,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_before_tokens = 0;
             last_after_tokens = 0;
             last_check_ts = now_ts;
-            last_decision = "initialized";
+            last_decision = compaction_runtime_decision_of_string "initialized";
           };
           proactive_rt = {
             count_total = 0;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -98,13 +98,21 @@ val tool_access_default_room_signal_prompt_enabled :
 
 (** {1 Runtime types (embedded in agent_runtime_state)} *)
 
+type compaction_runtime_decision = Compaction_runtime_decision of string
+
+val compaction_runtime_decision_to_string :
+  compaction_runtime_decision -> string
+
+val compaction_runtime_decision_of_string :
+  string -> compaction_runtime_decision
+
 type compaction_runtime = {
   count: int;
   last_ts: float;
   last_before_tokens: int;
   last_after_tokens: int;
   last_check_ts: float;
-  last_decision: string;
+  last_decision: compaction_runtime_decision;
 }
 
 type proactive_runtime = {

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -196,7 +196,8 @@ let test_apply_post_turn_lifecycle_without_checkpoint_records_skip () =
       check string "skip decision" "skipped:no_checkpoint"
         (KEC.compaction_decision_to_string lifecycle.compaction.decision);
       check string "runtime decision persisted" "skipped:no_checkpoint"
-        lifecycle.updated_meta.runtime.compaction_rt.last_decision;
+        (KT.compaction_runtime_decision_to_string
+           lifecycle.updated_meta.runtime.compaction_rt.last_decision);
       check bool "last check ts recorded" true
         (lifecycle.updated_meta.runtime.compaction_rt.last_check_ts > 0.0);
       check int "turn generation unchanged" meta.runtime.generation


### PR DESCRIPTION
## Summary

- Add a `compaction_runtime_decision` wrapper for the persisted keeper runtime `last_compaction_decision` value.
- Keep JSON/dashboard wire output as the existing string while removing the raw `last_decision : string` runtime field.
- Update keeper meta parsing, serialization, status output, turn-up initialization, post-turn writes, and lifecycle assertion conversion.

## Issue

Part of #11926 `[OAS] I7 String elimination first sweep (decision/cascade_name/error_kind)`.

This slice reduces exact `decision : string` / `?decision:string` matches from 5 to 4 on the current branch. The remaining matches are:

- `lib/operator/operator_review_state.ml` and `.mli` on base `main` (covered by #12085)
- `lib/audit_log.mli`
- `lib/keeper/keeper_approval_queue.mli`

## Validation

- PASS: `scripts/dune-local.sh build test/test_keeper_lifecycle.exe`
- PASS: `git diff --check`
- PASS: `rg -n "decision\\s*:\\s*string|\\?decision:string" lib test -g '*.ml' -g '*.mli'`
  - Result: 4 remaining exact matches.
- KNOWN BLOCKER: `scripts/dune-local.sh exec test/test_keeper_lifecycle.exe`
  - Fails on the existing fixture/meta parser blocker: `sandbox_profile required in keeper_meta.json`.
  - The same blocker affects the lifecycle tests before this slice; the build target still compiles successfully.
