### PR TITLE
feat: per-keeper Docker image override via sandbox_image

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -746,7 +746,12 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
             if m.sandbox_profile = Keeper_types.Docker
                || (m.sandbox_profile = Keeper_types.Local
                    && Env_config_keeper.DockerPlayground.enabled)
-            then Some (Env_config_keeper.KeeperSandbox.docker_image ())
+            then
+              Some (
+                match m.sandbox_image with
+                | Some img when String.trim img <> "" -> img
+                | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
+              )
             else None
           in
           let sandbox_preflight =
@@ -1610,7 +1615,9 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("credential_fallbacks_disabled",
             `Bool (Env_config_keeper.KeeperSandbox.hard_mode ()));
           ("docker_image",
-            string_or_null (Env_config_keeper.KeeperSandbox.docker_image ()));
+            match effective_sandbox_image with
+            | Some img -> string_or_null img
+            | None -> `Null);
           ("pids_limit", `Int (Env_config_keeper.KeeperSandbox.pids_limit ()));
           ("memory",
             string_or_null (Env_config_keeper.KeeperSandbox.memory ()));

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -106,7 +106,11 @@ let run_command_in_container_with_status ?turn_sandbox_factory
   let runtime_opt =
     Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd
   in
-  let image = Env_config_keeper.KeeperSandbox.docker_image () in
+  let image =
+    match meta.sandbox_image with
+    | Some img when String.trim img <> "" -> img
+    | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
+  in
   if Option.is_none runtime_opt && String.trim image = "" then
     Error "keeper sandbox docker image is not configured"
   else if command_argv = [] then

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -218,6 +218,7 @@ type keeper_meta =
   ; (* -- Policy -- *)
     policy_voice_enabled : bool
   ; sandbox_profile : sandbox_profile
+  ; sandbox_image : string option
   ; network_mode : network_mode
   ; shared_memory_scope : shared_memory_scope
   ; allowed_paths : string list

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -219,6 +219,7 @@ type keeper_meta = {
   (* Policy *)
   policy_voice_enabled : bool;
   sandbox_profile : Keeper_types_profile.sandbox_profile;
+  sandbox_image : string option;
   network_mode : Keeper_types_profile.network_mode;
   shared_memory_scope : Keeper_types_profile.shared_memory_scope;
   allowed_paths : string list;

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -43,6 +43,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
      @ [
       "policy_voice_enabled", `Bool m.policy_voice_enabled
     ; "sandbox_profile", `String (sandbox_profile_to_string m.sandbox_profile)
+    ; "sandbox_image", Json_util.string_opt_to_json m.sandbox_image
     ; "network_mode", `String (network_mode_to_string m.network_mode)
     ; "shared_memory_scope", `String (shared_memory_scope_to_string m.shared_memory_scope)
     ; "allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths)

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -29,6 +29,7 @@ type parsed_keeper_identity =
 type parsed_keeper_policy =
   { pp_policy_voice_enabled : bool
   ; pp_sandbox_profile : sandbox_profile
+  ; pp_sandbox_image : string option
   ; pp_network_mode : network_mode
   ; pp_shared_memory_scope : shared_memory_scope
   ; pp_allowed_paths : string list
@@ -172,7 +173,7 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
    refuse the *missing* and *unparseable* cases, not to second-guess
    legal combinations. *)
 let parse_sandbox_policy_fields (json : Yojson.Safe.t)
-  : (sandbox_profile * network_mode, string) result
+  : (sandbox_profile * string option * network_mode, string) result
   =
   let ( let* ) = Result.bind in
   let* sp_raw =
@@ -193,6 +194,7 @@ let parse_sandbox_policy_fields (json : Yojson.Safe.t)
            sp_raw
            (String.concat ", " valid_sandbox_profile_strings))
   in
+  let si = Safe_ops.json_string_opt "sandbox_image" json in
   let* nm_raw =
     match Safe_ops.json_string_opt "network_mode" json with
     | Some s -> Ok s
@@ -211,7 +213,7 @@ let parse_sandbox_policy_fields (json : Yojson.Safe.t)
            nm_raw
            (String.concat ", " valid_network_mode_strings))
   in
-  Ok (sp, nm)
+  Ok (sp, si, nm)
 ;;
 
 let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
@@ -223,7 +225,7 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
   | Ok pp_tool_access ->
     (match parse_sandbox_policy_fields json with
      | Error msg -> Error ("meta parse error: " ^ msg)
-     | Ok (pp_sandbox_profile, pp_network_mode) ->
+     | Ok (pp_sandbox_profile, pp_sandbox_image, pp_network_mode) ->
     let pp_policy_voice_enabled =
       Safe_ops.json_bool ~default:voice_enabled_default "policy_voice_enabled" json
     in
@@ -331,6 +333,7 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
     Ok
       { pp_policy_voice_enabled
       ; pp_sandbox_profile
+      ; pp_sandbox_image
       ; pp_network_mode
       ; pp_shared_memory_scope
       ; pp_allowed_paths
@@ -588,6 +591,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; instructions = identity.pk_instructions
                    ; policy_voice_enabled = policy.pp_policy_voice_enabled
                    ; sandbox_profile = policy.pp_sandbox_profile
+                   ; sandbox_image = policy.pp_sandbox_image
                    ; network_mode = policy.pp_network_mode
                    ; shared_memory_scope = policy.pp_shared_memory_scope
                    ; allowed_paths = policy.pp_allowed_paths

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -30,6 +30,7 @@ type parsed_keeper_identity =
 type parsed_keeper_policy =
   { pp_policy_voice_enabled : bool
   ; pp_sandbox_profile : sandbox_profile
+  ; pp_sandbox_image : string option
   ; pp_network_mode : network_mode
   ; pp_shared_memory_scope : shared_memory_scope
   ; pp_allowed_paths : string list

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -336,6 +336,8 @@ let ensure_keeper_meta config name =
     (match target_sandbox_profile_result with
      | Error e -> Error e
      | Ok target_sandbox_profile ->
+    let target_sandbox_image =
+      apply_default_opt defaults.sandbox_image meta.sandbox_image in
     let target_network_mode =
       apply_default defaults.network_mode
         (Keeper_types_profile.default_network_mode_for_profile target_sandbox_profile) in
@@ -547,6 +549,7 @@ let ensure_keeper_meta config name =
         tool_access = target_tool_access;
         tool_preset_source = target_tool_preset_source;
         sandbox_profile = target_sandbox_profile;
+        sandbox_image = target_sandbox_image;
         network_mode = target_network_mode;
         shared_memory_scope = target_shared_memory_scope;
         allowed_paths = target_allowed_paths;

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -84,7 +84,11 @@ let start_managed_container
                     Keeper_sandbox_runtime.live_container_to_yojson container);
                  ])
         | None ->
-            let image = Env_config_keeper.KeeperSandbox.docker_image () in
+            let image =
+              match meta.sandbox_image with
+              | Some img when String.trim img <> "" -> img
+              | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
+            in
             if String.trim image = "" then
               Error "keeper sandbox docker image is not configured"
             else

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -313,7 +313,11 @@ let run_docker_shell_command_with_status
     ~(network_mode : network_mode)
   =
   let timeout_sec = max timeout_sec docker_run_min_timeout_sec in
-  let image = Env_config_keeper.KeeperSandbox.docker_image () in
+  let image =
+    match meta.sandbox_image with
+    | Some img when String.trim img <> "" -> img
+    | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
+  in
   let network_mode =
     if Env_config_keeper.KeeperSandbox.hard_mode () then
       Network_none
@@ -578,7 +582,11 @@ let run_docker_with_git_bash
     ~(cwd : string)
     ~(timeout_sec : float)
     ~(cmd : string) () =
-  let image = Env_config_keeper.KeeperSandbox.docker_image () in
+  let image =
+    match meta.sandbox_image with
+    | Some img when String.trim img <> "" -> img
+    | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
+  in
   let sandbox_error_json message =
     Keeper_registry.record_error ~base_path:config.base_path meta.name message;
     error_json message
@@ -669,7 +677,11 @@ let run_docker_hardened_bash
     ~(timeout_sec : float)
     ~(cmd : string)
     ~(network_mode : network_mode) =
-  let image = Env_config_keeper.KeeperSandbox.docker_image () in
+  let image =
+    match meta.sandbox_image with
+    | Some img when String.trim img <> "" -> img
+    | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
+  in
   let sandbox_error_json message =
     Keeper_registry.record_error ~base_path:config.base_path meta.name message;
     error_json message

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -946,7 +946,12 @@ let handle_keeper_status ctx args : tool_result =
            if m.sandbox_profile = Docker
               || (m.sandbox_profile = Local
                   && Env_config_keeper.DockerPlayground.enabled)
-           then Some (Env_config_keeper.KeeperSandbox.docker_image ())
+           then
+             Some (
+               match m.sandbox_image with
+               | Some img when String.trim img <> "" -> img
+               | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
+             )
            else None
          in
          let sandbox_preflight =

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -129,7 +129,11 @@ let run_argv_with_stdin_and_status_retry_eintr ~timeout_sec ~stdin_content argv 
   loop max_eintr_retries
 
 let start_container (t : t) ~(timeout_sec : float) =
-  let image = Env_config_keeper.KeeperSandbox.docker_image () in
+  let image =
+    match t.meta.sandbox_image with
+    | Some img when String.trim img <> "" -> img
+    | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
+  in
   if String.trim image = "" then
     Error "keeper sandbox docker image is not configured"
   else

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -396,6 +396,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         instructions;
         policy_voice_enabled;
         sandbox_profile;
+        sandbox_image = None;
         network_mode;
         shared_memory_scope;
         allowed_paths;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -211,6 +211,7 @@ type keeper_meta = {
   instructions: string;
   policy_voice_enabled: bool;
   sandbox_profile: sandbox_profile;
+  sandbox_image: string option;
   network_mode: network_mode;
   shared_memory_scope: shared_memory_scope;
   allowed_paths: string list;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -285,6 +285,7 @@ type keeper_profile_defaults = {
   shards : string list option;
   allowed_paths : string list option;
   sandbox_profile : sandbox_profile option;
+  sandbox_image : string option;
   network_mode : network_mode option;
   shared_memory_scope : shared_memory_scope option;
   github_identity : string option;
@@ -365,6 +366,7 @@ let empty_keeper_profile_defaults = {
   shards = None;
   allowed_paths = None;
   sandbox_profile = None;
+  sandbox_image = None;
   network_mode = None;
   shared_memory_scope = None;
   github_identity = None;
@@ -786,6 +788,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
           else None;
         sandbox_profile =
           Option.bind (str "sandbox_profile") sandbox_profile_of_string;
+        sandbox_image = str "sandbox_image";
         network_mode =
           Option.bind (str "network_mode") network_mode_of_string;
         shared_memory_scope =
@@ -849,6 +852,7 @@ let parsed_field_key_names =
   ; "shards"
   ; "allowed_paths"
   ; "sandbox_profile"
+  ; "sandbox_image"
   ; "network_mode"
   ; "shared_memory_scope"
   ; "github_identity"
@@ -903,6 +907,7 @@ let canonical_keeper_toml_key_names =
   ; "shards"
   ; "allowed_paths"
   ; "sandbox_profile"
+  ; "sandbox_image"
   ; "network_mode"
   ; "shared_memory_scope"
   ; "github_identity"
@@ -1086,6 +1091,7 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                    Keep these in keeper TOML / runtime config only. *)
                 allowed_paths = None;
                 sandbox_profile = None;
+                sandbox_image = None;
                 network_mode = None;
                 shared_memory_scope = None;
                 github_identity = None;
@@ -1198,6 +1204,7 @@ let merge_keeper_profile_defaults
     shards = prefer overlay.shards base.shards;
     allowed_paths = prefer overlay.allowed_paths base.allowed_paths;
     sandbox_profile = prefer overlay.sandbox_profile base.sandbox_profile;
+    sandbox_image = prefer overlay.sandbox_image base.sandbox_image;
     network_mode = prefer overlay.network_mode base.network_mode;
     shared_memory_scope =
       prefer overlay.shared_memory_scope base.shared_memory_scope;


### PR DESCRIPTION
## Summary

Adds per-keeper Docker image override via a new `sandbox_image : string option` field in the keeper meta pipeline (P3 from Kimi Agent sandbox analysis).

Previously the sandbox Docker image was global-only via `Env_config_keeper.KeeperSandbox.docker_image ()`. This change allows each keeper to specify its own `sandbox_image`, falling back to the global default when absent or empty.

## Changes

- **Type system**: `keeper_meta` gains `sandbox_image : string option` (declared in both `keeper_meta_contract` and `keeper_types`).
- **JSON pipeline**: serialization + deserialization + canonical key list updated.
- **TOML defaults**: `keeper_profile_defaults` parses `sandbox_image`, merged via `apply_default_opt` in `keeper_runtime.ml`.
- **Runtime call sites** (all with `meta` access, per-keeper override applied):
  - `keeper_shell_docker.ml` — 3 locations (shell command, git bash, hardened bash)
  - `keeper_sandbox_control.ml` — managed container start
  - `keeper_turn_sandbox_runtime.ml` — turn sandbox container start
  - `keeper_docker_read.ml` — read-file sandbox container
  - `dashboard_http_keeper.ml` / `keeper_status_detail.ml` — effective image for status reporting
- **Creation path**: `keeper_turn_up_create.ml` initializes `sandbox_image = None`.

## Test plan

- [x] `dune build` compiles cleanly
- [ ] CI checks pass

## Related

Kimi Agent sandbox configuration analysis — P3 defect.