### PR TITLE
Type audit approval decisions

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -18,6 +18,15 @@ type outcome =
   | Success
   | Failure of string
 
+type governance_audit_decision =
+  | Governance_allow
+  | Governance_require_confirm
+  | Governance_deny
+  | Governance_confirm
+  | Governance_expired
+  | Governance_unauthorized
+  | Governance_other of string
+
 type action =
   | Join
   | Leave
@@ -34,7 +43,7 @@ type action =
   | CircuitOpen
   | CircuitClose
   | SearchRefinement
-  | GovernanceDecision of string
+  | GovernanceDecision of governance_audit_decision
   | Custom of string
 
 type audit_entry = {
@@ -58,6 +67,24 @@ let preview ?(max_len = 200) (value : string) =
 
 (** {1 Serialization} *)
 
+let governance_audit_decision_to_string = function
+  | Governance_allow -> "allow"
+  | Governance_require_confirm -> "require_confirm"
+  | Governance_deny -> "deny"
+  | Governance_confirm -> "confirm"
+  | Governance_expired -> "expired"
+  | Governance_unauthorized -> "unauthorized"
+  | Governance_other value -> value
+
+let governance_audit_decision_of_string = function
+  | "allow" -> Governance_allow
+  | "require_confirm" -> Governance_require_confirm
+  | "deny" -> Governance_deny
+  | "confirm" -> Governance_confirm
+  | "expired" -> Governance_expired
+  | "unauthorized" -> Governance_unauthorized
+  | value -> Governance_other value
+
 let action_to_string = function
   | Join -> "join"
   | Leave -> "leave"
@@ -74,7 +101,8 @@ let action_to_string = function
   | CircuitOpen -> "circuit_open"
   | CircuitClose -> "circuit_close"
   | SearchRefinement -> "search_refinement"
-  | GovernanceDecision decision -> "governance_decision:" ^ decision
+  | GovernanceDecision decision ->
+      "governance_decision:" ^ governance_audit_decision_to_string decision
   | Custom name -> "custom:" ^ name
 
 let string_to_action = function
@@ -95,7 +123,8 @@ let string_to_action = function
   | s when String.length s > 10 && String.starts_with ~prefix:"tool_call:" s ->
       ToolCall (String.sub s 10 (String.length s - 10))
   | s when String.length s > 20 && String.starts_with ~prefix:"governance_decision:" s ->
-      GovernanceDecision (String.sub s 20 (String.length s - 20))
+      let raw = String.sub s 20 (String.length s - 20) in
+      GovernanceDecision (governance_audit_decision_of_string raw)
   | s when String.length s > 7 && String.starts_with ~prefix:"custom:" s ->
       Custom (String.sub s 7 (String.length s - 7))
   | s -> Custom s

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -30,6 +30,15 @@ type outcome =
   | Success
   | Failure of string
 
+type governance_audit_decision =
+  | Governance_allow
+  | Governance_require_confirm
+  | Governance_deny
+  | Governance_confirm
+  | Governance_expired
+  | Governance_unauthorized
+  | Governance_other of string
+
 type action =
   | Join
   | Leave
@@ -46,7 +55,7 @@ type action =
   | CircuitOpen
   | CircuitClose
   | SearchRefinement
-  | GovernanceDecision of string
+  | GovernanceDecision of governance_audit_decision
   | Custom of string
 
 type audit_entry = {
@@ -67,6 +76,12 @@ val action_to_string : action -> string
 (** Stable serialisation; round-tripped by the legacy reader. The
     parametric variants ([ToolCall] / [GovernanceDecision] /
     [Custom]) are encoded as ["<tag>:<arg>"]. *)
+
+val governance_audit_decision_to_string :
+  governance_audit_decision -> string
+
+val governance_audit_decision_of_string :
+  string -> governance_audit_decision
 
 val entry_to_json : audit_entry -> Yojson.Safe.t
 
@@ -232,7 +247,7 @@ val log_governance_decision :
   config ->
   agent_id:string ->
   trace_id:string ->
-  decision:string ->
+  decision:governance_audit_decision ->
   action_type:string ->
   confirmation_state:string ->
   unit -> unit

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -90,16 +90,16 @@ let should_audit ~governance_level risk =
   | None -> false
 
 let audit_decision (config : Coord.config) (decision : governance_decision) =
-  let action_str =
+  let audit_decision, action_str =
     match decision.action with
-    | `Allow -> "allow"
-    | `Require_confirm _ -> "require_confirm"
-    | `Deny _ -> "deny"
+    | `Allow -> Audit_log.Governance_allow, "allow"
+    | `Require_confirm _ -> Audit_log.Governance_require_confirm, "require_confirm"
+    | `Deny _ -> Audit_log.Governance_deny, "deny"
   in
   Audit_log.log_governance_decision config
     ~agent_id:"governance-pipeline"
     ~trace_id:decision.trace_id
-    ~decision:action_str
+    ~decision:audit_decision
     ~action_type:(risk_level_to_string decision.risk)
     ~confirmation_state:action_str
     ()

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -75,6 +75,10 @@ type pending_approval = {
 
 type decision = Oas.Hooks.approval_decision
 
+type approval_audit_decision =
+  | Approval_resolved of decision
+  | Approval_expired of string
+
 type approval_rule = {
   id : string;
   keeper_name : string;
@@ -118,6 +122,15 @@ let risk_level_of_string = function
   | "high" -> Some High
   | "critical" -> Some Critical
   | _ -> None
+
+let approval_decision_to_string = function
+  | Oas.Hooks.Approve -> "approve"
+  | Oas.Hooks.Reject reason -> "reject:" ^ reason
+  | Oas.Hooks.Edit _ -> "edit"
+
+let approval_audit_decision_to_string = function
+  | Approval_resolved decision -> approval_decision_to_string decision
+  | Approval_expired reason -> "reject:" ^ reason
 
 let string_opt_of_json = function
   | `String value ->
@@ -456,7 +469,12 @@ let get_audit_store ?base_path () =
 let audit_approval_event ?base_path ~event_type ~id ~keeper_name ~tool_name
     ~risk_level ?turn_id ?task_id ?goal_id ?(goal_ids = [])
     ?runtime_contract ?selected_model ?disposition ?disposition_reason
-    ?rule_match ?source_approval_id ?auto_approved ?(decision = "") () =
+    ?rule_match ?source_approval_id ?auto_approved ?decision () =
+  let decision =
+    decision
+    |> Option.map approval_audit_decision_to_string
+    |> Option.value ~default:""
+  in
   match get_audit_store ?base_path () with
   | None -> ()
   | Some store ->
@@ -696,11 +714,7 @@ let record_pending (entry : pending_approval) =
   broadcast_pending entry
 
 let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
-  let decision_str = match decision with
-    | Oas.Hooks.Approve -> "approve"
-    | Oas.Hooks.Reject reason -> "reject:" ^ reason
-    | Oas.Hooks.Edit _ -> "edit"
-  in
+  let decision_str = approval_decision_to_string decision in
   Log.Keeper.info
     "HITL_APPROVAL_RESOLVED: id=%s keeper=%s tool=%s decision=%s"
     entry.id entry.keeper_name entry.tool_name decision_str;
@@ -710,7 +724,8 @@ let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
     ?goal_id:entry.goal_id ~goal_ids:entry.goal_ids
     ?runtime_contract:entry.runtime_contract
     ?selected_model:entry.selected_model ?disposition:entry.disposition
-    ?disposition_reason:entry.disposition_reason ~decision:decision_str ();
+    ?disposition_reason:entry.disposition_reason
+    ~decision:(Approval_resolved decision) ();
   (match entry.resolver with
    | Some resolver -> Eio.Promise.resolve resolver decision
    | None -> ());
@@ -998,7 +1013,7 @@ let expire_stale ~max_wait_s =
       ~goal_ids:entry.goal_ids ?runtime_contract:entry.runtime_contract
       ?selected_model:entry.selected_model ?disposition:entry.disposition
       ?disposition_reason:entry.disposition_reason
-      ~decision:("reject:" ^ reason) ();
+      ~decision:(Approval_expired reason) ();
     (match entry.resolver with
      | Some resolver ->
        Eio.Promise.resolve resolver (Oas.Hooks.Reject reason)

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -17,6 +17,10 @@ type risk_level =
 (** [Oas.Hooks.approval_decision] alias used as the resolver type. *)
 type decision = Oas.Hooks.approval_decision
 
+type approval_audit_decision =
+  | Approval_resolved of decision
+  | Approval_expired of string
+
 (** Pending approval entry — the suspended-fiber side of the
     Eio.Promise rendez-vous. *)
 type pending_approval =
@@ -81,6 +85,8 @@ val resolve_error_to_string : resolve_error -> string
 val risk_level_to_string : risk_level -> string
 val risk_level_to_int : risk_level -> int
 val risk_level_of_string : string -> risk_level option
+val approval_decision_to_string : decision -> string
+val approval_audit_decision_to_string : approval_audit_decision -> string
 
 (** {1 Rule store (persisted)} *)
 
@@ -147,7 +153,7 @@ val audit_approval_event :
   ?rule_match:rule_match ->
   ?source_approval_id:string ->
   ?auto_approved:bool ->
-  ?decision:string ->
+  ?decision:approval_audit_decision ->
   unit ->
   unit
 

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -634,7 +634,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
             };
           Audit_log.log_governance_decision ctx.config
             ~agent_id:actor ~trace_id:entry.trace_id
-            ~decision:"expired" ~action_type:entry.action_type
+            ~decision:Audit_log.Governance_expired ~action_type:entry.action_type
             ~confirmation_state:(confirmation_state_to_string Expired) ();
           Error "pending confirmation expired"
       | Some entry when not (String.equal actor entry.actor) ->
@@ -655,7 +655,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
             };
           Audit_log.log_governance_decision ctx.config
             ~agent_id:actor ~trace_id:entry.trace_id
-            ~decision:"unauthorized" ~action_type:entry.action_type
+            ~decision:Audit_log.Governance_unauthorized ~action_type:entry.action_type
             ~confirmation_state:(confirmation_state_to_string Denied) ();
           Error "actor is not allowed to confirm this action"
       | Some entry ->
@@ -678,7 +678,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               };
             Audit_log.log_governance_decision ctx.config
               ~agent_id:actor ~trace_id:entry.trace_id
-              ~decision:"deny" ~action_type:entry.action_type
+              ~decision:Audit_log.Governance_deny ~action_type:entry.action_type
               ~confirmation_state:(confirmation_state_to_string Denied) ();
             Ok
               (json_ok
@@ -719,7 +719,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               };
             Audit_log.log_governance_decision ctx.config
               ~agent_id:entry.actor ~trace_id:entry.trace_id
-              ~decision:"confirm" ~action_type:entry.action_type
+              ~decision:Audit_log.Governance_confirm ~action_type:entry.action_type
               ~confirmation_state:(confirmation_state_to_string Confirmed) ();
             Ok
               (json_ok

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -966,13 +966,13 @@ let test_read_recent_audit_filters_after_wide_scan () =
   let keeper_name = "audit-target-keeper" in
   AQ.audit_approval_event ~event_type:"resolved" ~id:"target-audit"
     ~keeper_name ~tool_name:"keeper_shell" ~risk_level:AQ.Medium
-    ~decision:"approve" ();
+    ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ();
   for i = 1 to 32 do
     AQ.audit_approval_event ~event_type:"resolved"
       ~id:(Printf.sprintf "other-audit-%02d" i)
       ~keeper_name:(Printf.sprintf "busy-keeper-%02d" i)
       ~tool_name:"keeper_shell" ~risk_level:AQ.Medium
-      ~decision:"approve" ()
+      ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ()
   done;
   match AQ.read_recent_audit ~keeper_name ~n:1 () with
   | [ json ] ->


### PR DESCRIPTION
## Summary

- Add typed `Audit_log.governance_audit_decision` for governance audit entries.
- Add typed `Keeper_approval_queue.approval_audit_decision` for approval audit entries.
- Keep existing JSONL/dashboard `"decision"` strings stable by rendering through explicit `*_to_string` helpers.

## Issue

Part of #11926 `[OAS] I7 String elimination first sweep (decision/cascade_name/error_kind)`.

This slice removes the remaining approval/audit API boundary signatures:

- `lib/audit_log.mli: decision:string`
- `lib/keeper/keeper_approval_queue.mli: ?decision:string`

On this branch the remaining exact matches are the operator review state and compaction runtime fields already covered by draft PRs #12085 and #12086.

## Validation

- PASS: `scripts/dune-local.sh build test/test_hitl_approval.exe`
- PASS: `git diff --check`
- PASS: `rg -n "decision\\s*:\\s*string|\\?decision:string" lib test -g '*.ml' -g '*.mli'`
  - Result: 5 remaining exact matches, all in file families covered by #12085/#12086.
- EXISTING TEST GAP: `scripts/dune-local.sh exec test/test_hitl_approval.exe`
  - Without an explicit temp base path, it fails on the existing prod-base-path guard.
  - With `MASC_BASE_PATH=/tmp/masc-hitl-approval-test-codex-11926`, the early approval queue cases pass, then existing approval queue tests fail.
  - Base `main` reproduces `approval_queue 17` with `expected one target audit, got 0`, so that failure is not introduced by this slice.
