### PR TITLE
[codex] fix keeper receipt and checkpoint terminal state

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -209,14 +209,13 @@ groups = ["base", "board_core", "filesystem", "filesystem_write", "library", "sh
 masc_groups = ["essential", "coding"]
 
 # Step 9 (bloodflow restoration plan): the research preset is granted
-# full delivery capabilities so analyst/scholar/verifier-tier keepers
+# delivery-oriented capabilities so analyst/scholar/verifier-tier keepers
 # can do real work -- git clone, PR view/diff, PR create -- instead
-# of only sharing opinions on the board.  The risk-tiered approval
-# gate in [keeper_routine_allowlist.ml] is intentionally kept intact:
-# capability is opened, but High-risk operations (force-push, mass
-# deletion, cross-org repo writes) still queue for operator approval.
+# of only sharing opinions on the board.  Keep raw filesystem edit out
+# of research; code edits should flow through the structured coding tools
+# and the risk-tiered approval gate in [keeper_routine_allowlist.ml].
 [presets.research]
-groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board_core", "autoresearch", "coding_shard", "coding", "github", "github_review"]
+groups = ["base", "filesystem", "library", "shell", "coordination", "board_core", "autoresearch", "coding_shard", "coding", "github", "github_review"]
 masc_groups = ["essential", "coordination", "coding"]
 
 # Delivery preset: research + coding for keepers that need to produce code changes.

--- a/lib/keeper/keeper_agent_checkpoint_hygiene.ml
+++ b/lib/keeper/keeper_agent_checkpoint_hygiene.ml
@@ -54,8 +54,7 @@ let prepare_resume_checkpoint_for_dispatch
     else
       match save_checkpoint compacted_ctx with
       | Ok checkpoint -> (Some checkpoint, None)
-      | Error detail ->
-          (Some (Keeper_exec_context.checkpoint_of_context compacted_ctx), Some detail)
+      | Error detail -> (None, Some detail)
   in
   let context =
     match checkpoint_opt with

--- a/lib/keeper/keeper_agent_checkpoint_hygiene.mli
+++ b/lib/keeper/keeper_agent_checkpoint_hygiene.mli
@@ -51,8 +51,7 @@ val prepare_resume_checkpoint_for_dispatch :
        resolution entirely — the dispatch starts a fresh OAS run.
     4. When checkpoint resolution is required and compaction did
        fire, calls [save_checkpoint] to persist the compacted state.
-       On save failure the result still carries a derived checkpoint
-       so the dispatch is not blocked, and [save_error] surfaces the
-       detail for observability.
+       On save failure the result carries no resume checkpoint, and
+       [save_error] surfaces the detail so the caller can block dispatch.
     5. When no compaction fired, returns the derived checkpoint of
        the unchanged context. *)

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -87,6 +87,16 @@ let terminal_reason_code_of_sdk_error = function
   | Oas.Error.A2a _ -> "a2a_error"
   | Oas.Error.Internal _ -> "internal_error"
 
+let receipt_outcome_kind_of_sdk_error = function
+  | Oas.Error.Api (Oas.Retry.Timeout _) -> `Cancelled
+  | _ -> `Error
+
+let checkpoint_persistence_error ~keeper_name ~detail =
+  Oas.Error.Internal
+    (Printf.sprintf
+       "keeper_checkpoint_persist_failed: keeper=%s detail=%s"
+       keeper_name detail)
+
 let cascade_outcome_of_observation = function
   | Some (obs : Oas_worker.cascade_observation) when obs.fallback_applied ->
     "passed_to_next_model"

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -40,6 +40,18 @@ val api_error_terminal_reason_code : Oas.Error.api_error -> string
     embedding the contract id for completion-contract violations. *)
 val terminal_reason_code_of_sdk_error : Oas.Error.sdk_error -> string
 
+(** Receipt outcome for terminal SDK errors.  Provider timeouts map to
+    [`Cancelled] to match [KeeperTurnFSM.tla] [ProviderTimeout], while
+    all other SDK errors remain ordinary failed receipts. *)
+val receipt_outcome_kind_of_sdk_error :
+  Oas.Error.sdk_error -> Keeper_execution_receipt.outcome_kind
+
+(** Structured internal error for post-turn checkpoint persistence
+    failures.  Used to prevent an otherwise successful keeper turn from
+    returning [Ok] when the replay checkpoint is not durable. *)
+val checkpoint_persistence_error :
+  keeper_name:string -> detail:string -> Oas.Error.sdk_error
+
 (** Map an optional cascade observation to a textual outcome label
     ("passed_to_next_model" / "completed" / "not_observed"). *)
 val cascade_outcome_of_observation :

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -112,6 +112,7 @@ let run_turn
   let ctx_work = ctx.ctx_work in
   let resume_oas_checkpoint = ctx.resume_oas_checkpoint in
   let pre_dispatch_compacted = ctx.pre_dispatch_compacted in
+  let pre_dispatch_checkpoint_error = ctx.pre_dispatch_checkpoint_error in
   let start_turn_count = ctx.start_turn_count in
   let receipt_started_at = ctx.receipt_started_at in
   let config_root = ctx.config_root in
@@ -414,6 +415,9 @@ let run_turn
             meta.name (Printexc.to_string exn)
     in
     let turn_result =
+      match pre_dispatch_checkpoint_error with
+      | Some err -> Error err
+      | None ->
       match !initial_tool_surface_blocker_ref with
       | Some err -> Error err
       | None ->
@@ -943,7 +947,7 @@ let run_turn
            (* Save checkpoint after extracting the replay snapshot so the
                  persisted checkpoint carries scrubbed assistant text plus
                  structured replay metadata on the last assistant message. *)
-           let saved_checkpoint =
+           let saved_checkpoint_result =
              match result.checkpoint with
              | Some checkpoint ->
                let patched =
@@ -956,14 +960,27 @@ let run_turn
                (match
                   Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir patched
                 with
-                | Ok () -> ()
+                | Ok () -> Ok (Some patched)
                 | Error e ->
-                  Log.Keeper.error "keeper:%s cascade=%s OAS checkpoint save failed: %s" meta.name meta.cascade_name e);
-               Some patched
+                  Log.Keeper.error
+                    "keeper:%s cascade=%s OAS checkpoint save failed: %s"
+                    meta.name meta.cascade_name e;
+                  Error
+                    (checkpoint_persistence_error
+                       ~keeper_name:meta.name
+                       ~detail:("OAS checkpoint save failed: " ^ e)))
              | None ->
-               Log.Keeper.error "keeper:%s cascade=%s missing OAS checkpoint after run" meta.name meta.cascade_name;
-               None
+               Log.Keeper.error
+                 "keeper:%s cascade=%s missing OAS checkpoint after run"
+                 meta.name meta.cascade_name;
+               Error
+                 (checkpoint_persistence_error
+                    ~keeper_name:meta.name
+                    ~detail:"missing OAS checkpoint after run")
            in
+           match saved_checkpoint_result with
+           | Error e -> Error e
+           | Ok saved_checkpoint ->
            (match result.proof with
             | Some p ->
               Keeper_turn_telemetry.log_keeper_proof ~keeper_name:meta.name p;
@@ -1252,8 +1269,11 @@ let run_turn
         goal_ids = meta.active_goal_ids;
         outcome =
           (match turn_result with
-           | Ok _ -> "ok"
-           | Error _ -> "error");
+           | Ok _ ->
+             Keeper_execution_receipt.outcome_kind_to_string `Ok
+           | Error err ->
+             Keeper_execution_receipt.outcome_kind_to_string
+               (receipt_outcome_kind_of_sdk_error err));
         terminal_reason_code;
         response_text_present = !receipt_response_text_present_ref;
         model_used = !receipt_model_used_ref;

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -15,6 +15,12 @@ let outcome_kind_to_string = function
   | `Error -> "error"
   | `Cancelled -> "cancelled"
 
+let outcome_kind_to_tla_receipt = function
+  | `Ok -> "receipt_done"
+  | `Skipped -> "receipt_skipped"
+  | `Error -> "receipt_failed"
+  | `Cancelled -> "receipt_cancelled"
+
 let outcome_kind_of_string = function
   | "ok" -> Some `Ok
   | "skipped" -> Some `Skipped

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -18,6 +18,11 @@ val outcome_kind_to_string : outcome_kind -> string
     boundary while the receipt record still stores the legacy string
     form. *)
 
+val outcome_kind_to_tla_receipt : outcome_kind -> string
+(** TLA+ receipt symbol mapping: [`Ok] serializes as ["ok"] in JSON but
+    corresponds to ["receipt_done"] in [KeeperTurnFSM.tla]; [`Error]
+    similarly maps to ["receipt_failed"]. *)
+
 val outcome_kind_of_string : string -> outcome_kind option
 (** Parse the legacy string form. Recognises the four terminal kinds
     and returns [None] for everything else (including ["unset"]) so

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -18,6 +18,7 @@ type run_context =
   ; ctx_work : working_context
   ; resume_oas_checkpoint : Oas.Checkpoint.t option
   ; pre_dispatch_compacted : bool
+  ; pre_dispatch_checkpoint_error : Oas.Error.sdk_error option
   ; start_turn_count : int
   ; receipt_started_at : string
   ; config_root : string
@@ -165,12 +166,18 @@ let prepare_run_context
   let ctx_work = checkpoint_hygiene.context in
   let resume_oas_checkpoint = checkpoint_hygiene.resume_checkpoint in
   let pre_dispatch_compacted = checkpoint_hygiene.compacted in
-  (match checkpoint_hygiene.save_error with
-   | Some detail ->
-       Log.Keeper.error
-         "%s: pre-dispatch checkpoint compaction save failed: %s"
-         meta.name detail
-   | None -> ());
+  let pre_dispatch_checkpoint_error =
+    match checkpoint_hygiene.save_error with
+    | Some detail ->
+      Log.Keeper.error
+        "%s: pre-dispatch checkpoint compaction save failed: %s"
+        meta.name detail;
+      Some
+        (Keeper_agent_error.checkpoint_persistence_error
+           ~keeper_name:meta.name
+           ~detail:("pre-dispatch checkpoint compaction save failed: " ^ detail))
+    | None -> None
+  in
   (if checkpoint_hygiene.applied then
      Log.Keeper.info
        "%s: pre-dispatch compaction %s trigger=%s tokens=%d->%d max_context=%d"
@@ -198,6 +205,7 @@ let prepare_run_context
   ; ctx_work
   ; resume_oas_checkpoint
   ; pre_dispatch_compacted
+  ; pre_dispatch_checkpoint_error
   ; start_turn_count
   ; receipt_started_at
   ; config_root

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -15,6 +15,7 @@ type run_context =
   ; ctx_work : working_context
   ; resume_oas_checkpoint : Oas.Checkpoint.t option
   ; pre_dispatch_compacted : bool
+  ; pre_dispatch_checkpoint_error : Oas.Error.sdk_error option
   ; start_turn_count : int
   ; receipt_started_at : string
   ; config_root : string

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -123,6 +123,8 @@ let make_keeper_meta ?(name = "keeper-lifecycle-test")
           ("trace_id", `String trace_id);
           ("cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name);
           ("last_model_used", `String "llama:auto");
+          ("sandbox_profile", `String "local");
+          ("network_mode", `String "inherit");
         ])
   with
   | Ok meta -> meta
@@ -1922,6 +1924,54 @@ let test_pre_dispatch_resume_checkpoint_saves_compacted_context () =
     !saved_message_count
     (List.length resume_checkpoint.messages)
 
+let test_pre_dispatch_resume_checkpoint_blocks_unsaved_compaction () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let now_ts = 30_000.0 in
+  let base_meta =
+    make_gate_only_meta
+      ~last_continuity_update_ts:now_ts
+      ~cooldown_sec:3600
+      ()
+  in
+  let meta =
+    {
+      base_meta with
+      compaction =
+        {
+          base_meta.compaction with
+          ratio_gate = 0.1;
+        };
+    }
+  in
+  let long_text = String.make emergency_test_text_length 'x' in
+  let ctx =
+    KEC.create ~system_prompt:"sp" ~max_tokens:1000
+    |> fun c -> KEC.append c (Agent_sdk.Types.user_msg long_text)
+    |> fun c -> KEC.append c (Agent_sdk.Types.assistant_msg long_text)
+    |> KEC.sync_oas_context
+  in
+  let checkpoint =
+    {
+      (KEC.checkpoint_of_context ctx) with
+      turn_count = 11;
+      messages = KEC.messages_of_context ctx;
+    }
+  in
+  let ctx = { ctx with checkpoint } in
+  let result =
+    KAR.prepare_resume_checkpoint_for_dispatch
+      ~meta
+      ~now_ts
+      ~loaded_checkpoint_present:true
+      ~save_checkpoint:(fun _ -> Error "disk unavailable")
+      ctx
+  in
+  check bool "pre-dispatch compaction applied" true result.applied;
+  check bool "save error is surfaced" true (Option.is_some result.save_error);
+  check bool "unsaved checkpoint is not used for resume" false
+    (Option.is_some result.resume_checkpoint)
+
 let test_dispatch_keeper_phase_event_uses_room_base_path () =
   let base_dir = temp_dir "keeper_lifecycle_registry_phase" in
   Fun.protect
@@ -2104,6 +2154,8 @@ let () =
             test_pre_dispatch_resume_checkpoint_uses_loaded_working_context;
           test_case "pre-dispatch resume saves compacted context" `Quick
             test_pre_dispatch_resume_checkpoint_saves_compacted_context;
+          test_case "pre-dispatch resume blocks unsaved compaction" `Quick
+            test_pre_dispatch_resume_checkpoint_blocks_unsaved_compaction;
         ] );
       ( "registry_dispatch",
         [

--- a/test/test_keeper_receipt_outcome_tla_parity.ml
+++ b/test/test_keeper_receipt_outcome_tla_parity.ml
@@ -102,13 +102,13 @@ let spec_terminal_outcome_set : string list =
         (fun s -> not (String.equal s "receipt_unset"))
         outcomes
 
-(* The four [outcome_kind] terminal variants prefixed with "receipt_"
-   to align with the TLA+ string form. *)
+(* The four [outcome_kind] terminal variants mapped to their TLA+
+   receipt symbols.  This is not a blind prefix: the JSON boundary keeps
+   legacy ["ok"] / ["error"], while the spec names those terminal
+   receipt outcomes ["receipt_done"] / ["receipt_failed"]. *)
 let ocaml_terminal_outcome_set =
   List.map
-    (fun k ->
-      "receipt_"
-      ^ Masc_mcp.Keeper_execution_receipt.outcome_kind_to_string k)
+    Masc_mcp.Keeper_execution_receipt.outcome_kind_to_tla_receipt
     [ `Ok; `Skipped; `Error; `Cancelled ]
 
 let sort = List.sort String.compare

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -56,6 +56,35 @@ let test_timeout () =
   check string "timeout" "api_error_timeout"
     (code (mk_api (Agent_sdk.Retry.Timeout { message = "x" })))
 
+let outcome_code err =
+  Masc_mcp.Keeper_execution_receipt.outcome_kind_to_string
+    (KAE.receipt_outcome_kind_of_sdk_error err)
+
+let test_timeout_receipt_outcome_is_cancelled () =
+  check string "timeout receipt outcome" "cancelled"
+    (outcome_code
+       (mk_api (Agent_sdk.Retry.Timeout { message = "x" })))
+
+let test_non_timeout_receipt_outcome_is_error () =
+  check string "auth receipt outcome" "error"
+    (outcome_code
+       (mk_api (Agent_sdk.Retry.AuthError { message = "x" })));
+  check string "agent receipt outcome" "error"
+    (outcome_code
+       (Agent_sdk.Error.Agent
+          (Agent_sdk.Error.MaxTurnsExceeded { turns = 1; limit = 1 })))
+
+let test_checkpoint_persistence_error_is_internal_error () =
+  let err =
+    KAE.checkpoint_persistence_error ~keeper_name:"sangsu"
+      ~detail:"missing OAS checkpoint after run"
+  in
+  check string "kind" "internal" (KAE.sdk_error_kind err);
+  check string "terminal reason" "internal_error" (code err);
+  check string "receipt outcome" "error" (outcome_code err);
+  check bool "message carries stable prefix" true
+    (String.contains (Agent_sdk.Error.to_string err) ':')
+
 (* Other variants kept their existing codes — guard against accidental
    churn in adjacent branches. *)
 
@@ -118,6 +147,12 @@ let () =
         ] );
       ( "regression",
         [
+          test_case "provider timeout receipt outcome -> cancelled" `Quick
+            test_timeout_receipt_outcome_is_cancelled;
+          test_case "non-timeout receipt outcome -> error" `Quick
+            test_non_timeout_receipt_outcome_is_error;
+          test_case "checkpoint persistence failure is terminal error" `Quick
+            test_checkpoint_persistence_error_is_internal_error;
           test_case "non-Api variants unchanged" `Quick
             test_other_variants_unchanged;
           test_case "all 9 api codes are pairwise distinct" `Quick

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -219,7 +219,7 @@ let test_concurrent_atomic_writes_never_empty () =
 let test_keeper_mainline_failures_log_at_error () =
   check bool "missing checkpoint after run logs at ERROR" true
     (file_contains_pattern "lib/keeper/keeper_agent_run.ml"
-       {|Log.Keeper.error "keeper:%s missing OAS checkpoint after run"|});
+       {|"keeper:%s cascade=%s missing OAS checkpoint after run"|});
   check bool "memory write failures log at ERROR" true
     (file_contains_pattern "lib/keeper/keeper_agent_run.ml"
        {|"keeper:%s memory_write failed: %s"|});
@@ -228,16 +228,16 @@ let test_keeper_mainline_failures_log_at_error () =
        {|Log.Keeper.warn
                "keeper:%s memory_write failed: %s"|});
   check bool "episode creation failures log at ERROR" true
-    (file_contains_pattern "lib/keeper/keeper_agent_run.ml"
+    (file_contains_pattern "lib/keeper/keeper_agent_memory_episode.ml"
        {|"keeper:%s episode_create failed: %s"|});
   check bool "episode creation failures are no longer WARN" true
-    (file_not_contains_pattern "lib/keeper/keeper_agent_run.ml"
+    (file_not_contains_pattern "lib/keeper/keeper_agent_memory_episode.ml"
        {|Log.Keeper.warn "keeper:%s episode_create failed: %s"|});
   check bool "post-failure read_meta None logs at ERROR" true
-    (file_contains_pattern "lib/keeper/keeper_keepalive.ml"
+    (file_contains_pattern "lib/keeper/keeper_heartbeat_loop.ml"
        {|Log.Keeper.error "keeper:%s read_meta returned None after turn failure, using stale meta"|});
   check bool "post-failure read_meta Error logs at ERROR" true
-    (file_contains_pattern "lib/keeper/keeper_keepalive.ml"
+    (file_contains_pattern "lib/keeper/keeper_heartbeat_loop.ml"
        {|Log.Keeper.error "keeper:%s read_meta failed after turn failure (%s), using stale meta"|})
 
 let test_oas_mainline_warns_are_promoted_in_bridge () =


### PR DESCRIPTION
## Summary

This closes the remaining Keeper FSM/code correspondence gaps from the Kimi Keeper FSM review around receipt outcomes and checkpoint durability.

- Treat provider timeouts as a cancelled receipt outcome instead of collapsing every SDK error to `error`.
- Add an explicit OCaml-to-TLA receipt symbol mapping so `ok/error` JSON labels do not drift from `receipt_done/receipt_failed` spec labels.
- Promote pre-dispatch checkpoint compaction save failures to a terminal internal error before `Agent.run` dispatch, instead of resuming from an unsaved compacted checkpoint.
- Promote post-turn checkpoint save failure or missing checkpoint to a terminal internal error instead of returning a fictitious `Ok` turn.
- Keep research preset delivery-capable while removing raw `keeper_fs_edit`; research code changes should go through structured coding tools.
- Refresh regression tests for sandbox-profile-required fixtures and current log module boundaries.

## Why

The design review identified that KeeperTurnFSM models `receipt_cancelled` and receipt-loss/checkpoint-loss as terminal states, while the OCaml runtime still had paths that either collapsed cancellation to generic error or logged checkpoint persistence failures without changing turn outcome. That made dashboard/replay state look healthier than the durable runtime state.

## Validation

- `scripts/dune-local.sh build test/test_keeper_terminal_reason.exe test/test_keeper_lifecycle.exe test/test_keeper_receipt_outcome_tla_parity.exe test/test_keeper_pause_broadcast.exe test/test_keeper_receipt_authoritative.exe test/test_keeper_receipt_authoritative_matrix.exe test/test_warn_root_causes.exe`
- `_build/default/test/test_keeper_terminal_reason.exe` - 14 tests
- `_build/default/test/test_keeper_lifecycle.exe` - 43 tests
- `_build/default/test/test_keeper_receipt_outcome_tla_parity.exe`
- `_build/default/test/test_keeper_pause_broadcast.exe` - 9 tests
- `_build/default/test/test_keeper_receipt_authoritative.exe`
- `_build/default/test/test_keeper_receipt_authoritative_matrix.exe`
- `_build/default/test/test_warn_root_causes.exe` - 8 tests
- `git diff --check`