### PR TITLE
feat(dashboard): expose safe-autonomy history trend (F1)

### DIFF
--- a/dashboard/src/components/safe-autonomy.ts
+++ b/dashboard/src/components/safe-autonomy.ts
@@ -85,6 +85,7 @@ interface SafeAutonomyData {
   findings: FindingItem[]
   timeline: TimelineItem[]
   artifacts: Record<string, unknown>
+  history: number[]
 }
 
 const safeAutonomy: AsyncResource<SafeAutonomyData> = createAsyncResource()
@@ -186,6 +187,10 @@ function normalizeTimelineItem(value: unknown): TimelineItem {
 
 function normalizePayload(raw: unknown): SafeAutonomyData {
   const data = isRecord(raw) ? raw : {}
+  const historyRaw = Array.isArray(data.history) ? data.history : []
+  const history = historyRaw
+    .map((v) => (typeof v === 'number' ? v : undefined))
+    .filter((v): v is number => v !== undefined)
   return {
     generated_at: asString(data.generated_at, ''),
     summary: normalizeSummary(data.summary),
@@ -194,6 +199,7 @@ function normalizePayload(raw: unknown): SafeAutonomyData {
     findings: asRecordArray(data.findings).map(normalizeFinding),
     timeline: asRecordArray(data.timeline).map(normalizeTimelineItem),
     artifacts: isRecord(data.artifacts) ? data.artifacts : {},
+    history,
   }
 }
 
@@ -305,6 +311,40 @@ function FindingsList({ findings }: { findings: FindingItem[] }) {
   `
 }
 
+function SafeAutonomyTrend({ history }: { history: number[] }) {
+  if (history.length === 0) {
+    return html`<${EmptyState} message="충분한 history가 쌓이면 trend가 표시됩니다." compact />`
+  }
+  const min = Math.min(...history)
+  const max = Math.max(...history)
+  const range = max - min || 1
+  const threshold = 78
+  return html`
+    <div class="space-y-2">
+      <div class="flex items-end gap-1 h-16">
+        ${history.map((score) => {
+          const pct = Math.max(0, Math.min(100, ((score - min) / range) * 100))
+          const belowThreshold = score < threshold
+          return html`
+            <div
+              class="flex-1 rounded-sm ${belowThreshold
+                ? 'bg-[var(--bad-30)]'
+                : 'bg-[var(--ok-30)]'}"
+              style=${`height: ${pct}%`}
+              title=${`score: ${score.toFixed(1)}`}
+            />
+          `
+        })}
+      </div>
+      <div class="flex items-center justify-between text-3xs text-[var(--color-fg-muted)]">
+        <span>min ${min.toFixed(1)}</span>
+        <span class="font-semibold text-[var(--color-fg-secondary)]">current ${history[history.length - 1]!.toFixed(1)}</span>
+        <span>max ${max.toFixed(1)}</span>
+      </div>
+    </div>
+  `
+}
+
 function TimelineList({ timeline }: { timeline: TimelineItem[] }) {
   if (timeline.length === 0) {
     return html`<${EmptyState} message="최근 타임라인 이벤트가 없습니다." compact />`
@@ -388,6 +428,10 @@ export function SafeAutonomyPanel() {
                     ? html`<${EmptyState} message="표시할 keeper snapshot이 없습니다." compact />`
                     : data.per_keeper.map(item => html`<${KeeperCard} key=${item.name} item=${item} />`)}
                 </div>
+              <//>
+
+              <${Card} title="글로벌 스코어 트렌드" class="section">
+                <${SafeAutonomyTrend} history=${data.history} />
               <//>
 
               <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -1031,6 +1031,36 @@ let write_artifacts ~(config : Coord.config) payload =
   if history_appended then Fs_compat.append_jsonl history_path payload;
   { latest_path; history_path; fingerprint; history_appended }
 
+let read_history_scores ~(config : Coord.config) : float list =
+  let _dir, _latest_path, history_path = artifact_paths config in
+  if not (Fs_compat.file_exists history_path) then []
+  else
+    let entries = Fs_compat.load_jsonl history_path in
+    let scores =
+      List.filter_map
+        (fun json ->
+           match json with
+           | `Assoc fields ->
+               (match List.assoc_opt "summary" fields with
+                | Some (`Assoc summary_fields) ->
+                    (match List.assoc_opt "global_score" summary_fields with
+                     | Some (`Float f) -> Some f
+                     | Some (`Int i) -> Some (float_of_int i)
+                     | _ -> None)
+                | _ -> None)
+           | _ -> None)
+        entries
+    in
+    let len = List.length scores in
+    if len <= 15 then scores
+    else
+      let rec drop n = function
+        | [] -> []
+        | _ :: xs when n > 0 -> drop (n - 1) xs
+        | xs -> xs
+      in
+      drop (len - 15) scores
+
 let global_status_of_score ~has_fail score =
   if has_fail || score < 60.0 then Fail
   else if score < 85.0 then Warn
@@ -1150,6 +1180,7 @@ let json ~(config : Coord.config) () =
     timeline_entries_json ~alias_to_keeper ~activity_items ~approval_by_keeper
       ~keepers:keeper_snapshots
   in
+  let history_scores = read_history_scores ~config in
   let payload =
     `Assoc
       [
@@ -1195,6 +1226,7 @@ let json ~(config : Coord.config) () =
                 (base_evidence_ref "route" "metrics" "/metrics");
             ] );
         ("tool_quality_live", live_tool_payload);
+        ("history", `List (List.map (fun s -> `Float s) history_scores));
       ]
   in
   let artifacts = write_artifacts ~config payload in


### PR DESCRIPTION
## Summary
- Backend: `read_history_scores` reads last 15 `global_score` values from `history.jsonl` artifact and exposes them in the safe-autonomy JSON payload.
- Frontend: `SafeAutonomyTrend` renders a 15-run bar chart with min/max/current labels and threshold-based color coding (below 78 = red).

Closes gap F1 from ds-v2 phase-2 implementation audit.

## Changes
- `lib/dashboard/dashboard_safe_autonomy.ml`: add `read_history_scores` helper, wire into `json` payload
- `dashboard/src/components/safe-autonomy.ts`: add `SafeAutonomyTrend` component, add `history` field to `SafeAutonomyData`

## Test plan
- [x] `dune build --root=.` compiles
- [x] `pnpm typecheck` compiles
- [x] `pnpm build` compiles

## Related
- Design system audit: `dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)