### PR TITLE
Type admission queue cascade names

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -10,7 +10,7 @@
 
 type waiter_info = {
   keeper_name : string;
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
   enqueue_ts : float;
   priority : Llm_provider.Request_priority.t;
 }
@@ -137,9 +137,7 @@ let check_host_resources ~keeper_name =
     Ok ()
 
 let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
-  (* SSOT: every admission_queue entry point canonicalizes cascade_name
-     so metrics/structs never see drift values. *)
-  let cascade_name = Keeper_cascade_profile.canonicalize cascade_name in
+  let cascade_name = Keeper_cascade_profile.runtime_name_to_string cascade_name in
   match check_host_resources ~keeper_name with
   | Error _ as e -> e
   | Ok () ->
@@ -159,6 +157,7 @@ let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
         raise exn
 
 let try_with_permit ~priority:_ ~keeper_name ~cascade_name f =
+  let cascade_name = Keeper_cascade_profile.runtime_name_to_string cascade_name in
   match check_host_resources ~keeper_name with
   | Error _ -> None
   | Ok () ->
@@ -190,7 +189,8 @@ let snapshot_json () =
     ("waiters", `List (List.map (fun (w : waiter_info) ->
       `Assoc [
         ("keeper_name", `String w.keeper_name);
-        ("cascade_name", `String w.cascade_name);
+        ( "cascade_name",
+          `String (Keeper_cascade_profile.runtime_name_to_string w.cascade_name) );
         ("priority", `String (Llm_provider.Request_priority.to_string w.priority));
         ("wait_seconds", `Float (now -. w.enqueue_ts));
       ]) s.waiters));

--- a/lib/admission_queue.mli
+++ b/lib/admission_queue.mli
@@ -15,7 +15,7 @@
 (** Metadata carried per waiter — for observability, not scheduling. *)
 type waiter_info = {
   keeper_name : string;
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
   enqueue_ts : float;
   priority : Llm_provider.Request_priority.t;
 }
@@ -40,7 +40,7 @@ val with_permit :
   ?wait_timeout_sec:float ->
   priority:Llm_provider.Request_priority.t ->
   keeper_name:string ->
-  cascade_name:string ->
+  cascade_name:Keeper_cascade_profile.runtime_name ->
   (unit -> 'a) ->
   ('a, [> `Host_resource_saturated of string ]) result
 (** Acquire a permit, run [f], release permit on exit (normal or exception).
@@ -53,7 +53,7 @@ val with_permit :
 val try_with_permit :
   priority:Llm_provider.Request_priority.t ->
   keeper_name:string ->
-  cascade_name:string ->
+  cascade_name:Keeper_cascade_profile.runtime_name ->
   (unit -> 'a) ->
   'a option
 (** Non-blocking variant. Returns [None] if host resources are saturated. *)

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -30,6 +30,10 @@ let known_cascades = List.map to_string all
 let default = Big_three
 let default_name = to_string default
 
+type runtime_name = Runtime_name of string
+
+let runtime_name_to_string (Runtime_name value) = value
+
 let of_string_opt (raw : string) : t option =
   match String.trim raw |> String.lowercase_ascii with
   | "" -> Some default
@@ -266,6 +270,8 @@ let resolve_live ?config_path raw =
 
 let canonicalize (raw : string) : string =
   canonicalize_with_catalog ~catalog:(catalog_names ()) raw
+
+let runtime_name_of_string raw = Runtime_name (canonicalize raw)
 
 let models_key_t t = to_string t ^ "_models"
 let temperature_key_t t = to_string t ^ "_temperature"

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -50,6 +50,16 @@ val known_cascades : string list
 (** [known_cascades = List.map to_string all]. Provided for consumers
     that still operate on strings; new code should take {!t} directly. *)
 
+type runtime_name = Runtime_name of string
+(** Catalog-aware cascade name after point-of-use runtime normalization.
+    Unlike {!t}, this can carry dynamic cascade catalog names. *)
+
+val runtime_name_to_string : runtime_name -> string
+val runtime_name_of_string : string -> runtime_name
+(** Canonicalizes legacy aliases and live catalog names for runtime
+    telemetry/admission labels. Unknown nonblank values fall back to
+    {!default_name}, matching {!canonicalize}. *)
+
 val catalog_names : ?config_path:string -> unit -> string list
 (** Live profile catalog discovered from the active [cascade.json].
     When the file cannot be read, returns [[]]. *)

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -871,8 +871,11 @@ let run_named
          do_backoff (n + 1);
          cycle_loop (n + 1))
   in
+  let admission_cascade_name =
+    Keeper_cascade_profile.runtime_name_of_string cascade_name
+  in
   match Admission_queue.with_permit ?wait_timeout_sec
-    ~priority:queue_priority ~keeper_name:name ~cascade_name
+    ~priority:queue_priority ~keeper_name:name ~cascade_name:admission_cascade_name
     (fun () -> cycle_loop 0) with
   | Ok result -> result
   | Error (`Host_resource_saturated reason) ->
@@ -929,10 +932,13 @@ let run_model_by_label
       in
       let config = { config with transport = transport_resolved } in
       match
+        let admission_cascade_name =
+          Keeper_cascade_profile.runtime_name_of_string model_label
+        in
         Admission_queue.with_permit ?wait_timeout_sec
           ~priority:Llm_provider.Request_priority.Proactive
           ~keeper_name:"oas-label-model"
-          ~cascade_name:model_label
+          ~cascade_name:admission_cascade_name
           (fun () ->
             with_codex_cli_preflight
               ~scope:(Printf.sprintf "model_label:%s" model_label)
@@ -1056,10 +1062,13 @@ let run_model_with_masc_tools
       in
       let config = { config with raw_trace; transport = transport_resolved } in
       match
+        let admission_cascade_name =
+          Keeper_cascade_profile.runtime_name_of_string model_label
+        in
         Admission_queue.with_permit ?wait_timeout_sec
           ~priority:Llm_provider.Request_priority.Proactive
           ~keeper_name:"oas-explicit-model"
-          ~cascade_name:model_label
+          ~cascade_name:admission_cascade_name
           (fun () ->
             with_codex_cli_preflight
               ~scope:(Printf.sprintf "explicit_model:%s" model_label)

--- a/test/test_admission_queue_coverage.ml
+++ b/test/test_admission_queue_coverage.ml
@@ -9,6 +9,8 @@ open Alcotest
 
 module AQ = Masc_mcp.Admission_queue
 
+let cascade_name raw = Masc_mcp.Keeper_cascade_profile.runtime_name_of_string raw
+
 (* ============================================================
    Passthrough Contract
    ============================================================ *)
@@ -16,7 +18,7 @@ module AQ = Masc_mcp.Admission_queue
 let test_with_permit_runs () =
   Eio_main.run (fun _env ->
     match AQ.with_permit ~priority:Interactive
-      ~keeper_name:"test" ~cascade_name:"test" (fun () -> 42) with
+      ~keeper_name:"test" ~cascade_name:(cascade_name "test") (fun () -> 42) with
     | Ok result -> check int "runs and returns" 42 result
     | Error _ -> fail "unexpected error")
 
@@ -24,7 +26,7 @@ let test_with_permit_propagates_exception () =
   Eio_main.run (fun _env ->
     match
       AQ.with_permit ~priority:Interactive
-        ~keeper_name:"test" ~cascade_name:"test"
+        ~keeper_name:"test" ~cascade_name:(cascade_name "test")
         (fun () -> failwith "boom")
     with
     | Ok _ -> fail "should raise"
@@ -34,7 +36,7 @@ let test_with_permit_propagates_exception () =
 let test_try_always_succeeds () =
   Eio_main.run (fun _env ->
     let result = AQ.try_with_permit ~priority:Interactive
-      ~keeper_name:"test" ~cascade_name:"test" (fun () -> 42) in
+      ~keeper_name:"test" ~cascade_name:(cascade_name "test") (fun () -> 42) in
     check (option int) "always Some" (Some 42) result)
 
 let test_concurrent_all_run () =
@@ -42,7 +44,7 @@ let test_concurrent_all_run () =
     let count = Atomic.make 0 in
     let run_one name =
       match AQ.with_permit ~priority:Proactive
-        ~keeper_name:name ~cascade_name:"test"
+        ~keeper_name:name ~cascade_name:(cascade_name "test")
         (fun () ->
           ignore (Atomic.fetch_and_add count 1);
           Eio.Fiber.yield ())
@@ -91,7 +93,7 @@ let test_wait_timeout_passthrough_no_leak () =
     AQ.reset_for_test ~max_slots:1;
     let ran = ref false in
     (match AQ.with_permit ~wait_timeout_sec:0.01 ~priority:Background
-      ~keeper_name:"timed-out" ~cascade_name:"test"
+      ~keeper_name:"timed-out" ~cascade_name:(cascade_name "test")
       (fun () -> ran := true)
     with
     | Ok () -> check bool "wait timeout ignored in passthrough" true !ran
@@ -160,7 +162,7 @@ let test_with_permit_releases_inflight_gauge () =
         "masc_inference_queue_inflight" ()
     in
     (match AQ.with_permit ~priority:Interactive
-      ~keeper_name:"metric-test" ~cascade_name:"test"
+      ~keeper_name:"metric-test" ~cascade_name:(cascade_name "test")
       (fun () -> ())
     with
     | Ok () -> ()
@@ -178,8 +180,8 @@ let test_with_permit_releases_on_exception () =
         "masc_inference_queue_inflight" ()
     in
     (match
-       AQ.with_permit ~priority:Interactive
-         ~keeper_name:"metric-test-exn" ~cascade_name:"test"
+         AQ.with_permit ~priority:Interactive
+         ~keeper_name:"metric-test-exn" ~cascade_name:(cascade_name "test")
          (fun () -> failwith "boom")
      with
      | Ok _ -> fail "should raise"
@@ -198,7 +200,7 @@ let test_with_permit_increments_acquired_counter () =
         "masc_inference_queue_acquired_total" ()
     in
     (match AQ.with_permit ~priority:Interactive
-      ~keeper_name:"counter-test" ~cascade_name:"test"
+      ~keeper_name:"counter-test" ~cascade_name:(cascade_name "test")
       (fun () -> ())
     with
     | Ok () -> ()
@@ -216,7 +218,7 @@ let test_try_with_permit_releases_inflight_gauge () =
         "masc_inference_queue_inflight" ()
     in
     let _ : int option = AQ.try_with_permit ~priority:Interactive
-      ~keeper_name:"try-metric" ~cascade_name:"test"
+      ~keeper_name:"try-metric" ~cascade_name:(cascade_name "test")
       (fun () -> 1)
     in
     let after =


### PR DESCRIPTION
## Summary

- Add `Keeper_cascade_profile.runtime_name` as a catalog-aware cascade-name wrapper for dynamic runtime labels.
- Move `Admission_queue` public `cascade_name` parameters and waiter metadata off raw `string`.
- Convert `Oas_worker_named` admission calls and admission queue tests at the API boundary.

## Issue

Part of #11926 C-T7.2 (`cascade_name:string` family).

This is the first cascade-name slice after C-T7.1 completed. It keeps JSON/metrics labels as strings via `runtime_name_to_string`, but requires callers entering the admission queue to make cascade-name normalization explicit.

## Validation

- PASS: `scripts/dune-local.sh build test/test_admission_queue_coverage.exe`
- PASS: `git diff --check`
- PASS: `rg -n "cascade_name\\s*:\\s*string|\\?cascade_name:string" lib/admission_queue.ml lib/admission_queue.mli lib/oas_worker_named.ml test/test_admission_queue_coverage.ml`
  - Result: no matches in the touched admission queue slice.
- SKIPPED: `scripts/dune-local.sh exec test/test_admission_queue_coverage.exe`
  - The test process remained queued behind the shared `/tmp/me-dune-local.lock` held by other concurrent Dune jobs; I stopped the waiting process after the focused build had passed.
