### PR TITLE
[codex] enforce keeper turn FSM contract edges

### DIFF
--- a/docs/observability/keeper-turn-fsm-metrics.md
+++ b/docs/observability/keeper-turn-fsm-metrics.md
@@ -37,8 +37,8 @@ Bumped exactly once per `Keeper_turn_fsm.emit_transition` call.
 
 | Label | Values |
 |-------|--------|
-| `from` | `idle`, `phase_gating`, `cascade_routing`, `awaiting_provider`, `streaming`, `awaiting_tool_result`, `completing`, plus `-` when no `?prev` was supplied |
-| `to` | one of `turn_state_label` outputs: `idle`, `phase_gating`, `cascade_routing`, `awaiting_provider`, `streaming`, `awaiting_tool_result`, `completing`, `done`, `failed:<reason>`, `cancelled:<reason>` |
+| `from` | `idle`, `phase_gating`, `cascade_routing`, `awaiting_provider`, `streaming`, `awaiting_tool`, `completing`, plus `-` when no `?prev` was supplied |
+| `to` | one of `turn_state_label` outputs: `idle`, `phase_gating`, `cascade_routing`, `awaiting_provider`, `streaming`, `awaiting_tool`, `completing`, `done`, `failed:<reason>`, `cancelled:<reason>` |
 | `keeper` | keeper name (e.g. `nick0cave`, `alice`) |
 
 `failed:` reasons (`failure_reason_label`):
@@ -97,6 +97,12 @@ Format:
 Emitted via `Log.Keeper.info` with the `keeper_name` and `turn_id` structured fields wired in Step 0a (#11154 / #11156 / #11159). A missing `?prev` renders as `-`.
 
 The line text is stable and pinned by the `test_keeper_turn_fsm_emit` sentinel — a label rename or signature drift fails the build.
+
+`emit_transition` also classifies every `(prev, next)` pair against the
+runtime image of `KeeperTurnFSM.tla` `Next`. An edge outside the contract
+increments `masc_fsm_guard_violation_total{action="KeeperTurnFSM.Next", ...}`
+and logs `[fsm:transition:violation]`; with `MASC_FSM_GUARD_ASSERT=1` the same
+violation raises during tests/CI.
 
 ## Pulling a single turn back out
 

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -51,18 +51,11 @@ let failure_reason_label = function
   | Failure_unexpected_exception _ -> "unexpected_exception"
 
 let turn_state_label = function
-  | Idle -> "idle"
-  | Phase_gating -> "phase_gating"
-  | Cascade_routing -> "cascade_routing"
-  | Awaiting_provider -> "awaiting_provider"
-  | Streaming -> "streaming"
-  | Awaiting_tool_result -> "awaiting_tool_result"
-  | Completing -> "completing"
-  | Done -> "done"
   | Failed reason ->
-      "failed:" ^ failure_reason_label reason
+      to_tla_symbol (Failed reason) ^ ":" ^ failure_reason_label reason
   | Cancelled reason ->
-      "cancelled:" ^ cancel_reason_label reason
+      to_tla_symbol (Cancelled reason) ^ ":" ^ cancel_reason_label reason
+  | state -> to_tla_symbol state
 
 let pp_cancel_reason fmt r =
   Format.pp_print_string fmt (cancel_reason_label r)
@@ -90,12 +83,118 @@ let pp_failure_reason fmt = function
 let pp_turn_state fmt s =
   Format.pp_print_string fmt (turn_state_label s)
 
+type transition_action =
+  | StartTurn
+  | PhaseGateSkip
+  | PhaseGateOk
+  | CascadeRouted
+  | CascadeUnavailable
+  | ProviderResponded
+  | ProviderTimeout
+  | StreamYieldsTool
+  | ToolReturned
+  | StreamComplete
+  | ContractOk
+  | ContractViolation
+  | ReceiptLost
+  | GenericFail
+  | SupervisorRequestsStop
+  | HonorStopSignal
+  | TerminalStutter
+
+let transition_action_label = function
+  | StartTurn -> "StartTurn"
+  | PhaseGateSkip -> "PhaseGateSkip"
+  | PhaseGateOk -> "PhaseGateOk"
+  | CascadeRouted -> "CascadeRouted"
+  | CascadeUnavailable -> "CascadeUnavailable"
+  | ProviderResponded -> "ProviderResponded"
+  | ProviderTimeout -> "ProviderTimeout"
+  | StreamYieldsTool -> "StreamYieldsTool"
+  | ToolReturned -> "ToolReturned"
+  | StreamComplete -> "StreamComplete"
+  | ContractOk -> "ContractOk"
+  | ContractViolation -> "ContractViolation"
+  | ReceiptLost -> "ReceiptLost"
+  | GenericFail -> "GenericFail"
+  | SupervisorRequestsStop -> "SupervisorRequestsStop"
+  | HonorStopSignal -> "HonorStopSignal"
+  | TerminalStutter -> "TerminalStutter"
+
+type transition_violation = {
+  from_state : string;
+  to_state : string;
+  reason : string;
+}
+
+let same_tla_state a b =
+  String.equal (to_tla_symbol a) (to_tla_symbol b)
+
+let same_observable_state a b =
+  String.equal (turn_state_label a) (turn_state_label b)
+
+let classify_transition ~from_state ~to_state =
+  match from_state, to_state with
+  | Idle, Phase_gating -> Some StartTurn
+  | Phase_gating, Done -> Some PhaseGateSkip
+  | Phase_gating, Cascade_routing -> Some PhaseGateOk
+  | Cascade_routing, Awaiting_provider -> Some CascadeRouted
+  | Cascade_routing, Failed (Failure_cascade_unavailable _) ->
+      Some CascadeUnavailable
+  | Awaiting_provider, Streaming -> Some ProviderResponded
+  | Awaiting_provider, Cancelled Cancelled_provider_timeout ->
+      Some ProviderTimeout
+  | Streaming, Awaiting_tool_result -> Some StreamYieldsTool
+  | Awaiting_tool_result, Streaming -> Some ToolReturned
+  | Streaming, Completing -> Some StreamComplete
+  | Completing, Done -> Some ContractOk
+  | Completing, Failed (Failure_tool_contract_violation _) ->
+      Some ContractViolation
+  | Completing, Failed (Failure_receipt_lost _) -> Some ReceiptLost
+  | _, Failed _ when is_active from_state -> Some GenericFail
+  | _, Cancelled _ when is_active from_state -> Some HonorStopSignal
+  | _, _ when is_active from_state && same_tla_state from_state to_state ->
+      Some SupervisorRequestsStop
+  | _, _
+    when is_terminal from_state && is_terminal to_state
+         && same_observable_state from_state to_state ->
+      Some TerminalStutter
+  | _ -> None
+
+let assert_transition_allowed ~from_state ~to_state =
+  match classify_transition ~from_state ~to_state with
+  | Some action -> Ok action
+  | None ->
+      Error
+        {
+          from_state = to_tla_symbol from_state;
+          to_state = to_tla_symbol to_state;
+          reason = "not_in_keeper_turn_fsm_next";
+        }
+
+let guard_transition ~keeper_name ~turn_id ~from_state ~to_state =
+  match assert_transition_allowed ~from_state ~to_state with
+  | Ok _ -> ()
+  | Error violation ->
+      let stage = violation.from_state ^ "->" ^ violation.to_state in
+      Keeper_fsm_guard_runtime.wrap_unit
+        ~action:"KeeperTurnFSM.Next"
+        ~stage
+        (fun () -> assert false);
+      Log.Keeper.warn ~keeper_name ~turn_id
+        "[fsm:transition:violation] %s -> %s (%s)"
+        violation.from_state violation.to_state violation.reason
+
 let emit_transition ~keeper_name ~turn_id ?prev state =
   let prev_label =
     match prev with
     | Some s -> turn_state_label s
     | None -> "-"
   in
+  (match prev with
+   | Some from_state ->
+       guard_transition ~keeper_name ~turn_id ~from_state ~to_state:state
+   | None -> ());
   let state_label = turn_state_label state in
   Log.Keeper.info ~keeper_name ~turn_id
     "[fsm:transition] %s -> %s" prev_label state_label;

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -75,6 +75,50 @@ val pp_cancel_reason : Format.formatter -> cancel_reason -> unit
 val pp_failure_reason : Format.formatter -> failure_reason -> unit
 val pp_turn_state : Format.formatter -> turn_state -> unit
 
+type transition_action =
+  | StartTurn
+  | PhaseGateSkip
+  | PhaseGateOk
+  | CascadeRouted
+  | CascadeUnavailable
+  | ProviderResponded
+  | ProviderTimeout
+  | StreamYieldsTool
+  | ToolReturned
+  | StreamComplete
+  | ContractOk
+  | ContractViolation
+  | ReceiptLost
+  | GenericFail
+  | SupervisorRequestsStop
+  | HonorStopSignal
+  | TerminalStutter
+(** Runtime image of [KeeperTurnFSM.tla] [Next] actions.
+
+    [GenericFail] is the OCaml-side structured-failure extension for
+    active-state failures whose carrier is more specific than the compact
+    TLA projection. *)
+
+val transition_action_label : transition_action -> string
+
+type transition_violation = {
+  from_state : string;
+  to_state : string;
+  reason : string;
+}
+
+val classify_transition :
+  from_state:turn_state ->
+  to_state:turn_state ->
+  transition_action option
+(** Return the TLA+ action represented by an OCaml state edge, if the
+    edge is allowed by the keeper-turn FSM contract. *)
+
+val assert_transition_allowed :
+  from_state:turn_state ->
+  to_state:turn_state ->
+  (transition_action, transition_violation) result
+
 val require_active_state : turn_state -> turn_state
 (** Identity on [s]; runtime-asserts that [s] is not a terminal state
     ([Done], [Failed _], [Cancelled _]).

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -298,8 +298,9 @@ val metric_keeper_turn_fsm_transitions : string
 
     Labels: [action, stage]. [action] is the spec-action name
     ([WakeupSignal], [HeartbeatTick], [TurnComplete],
-    [SubmitTask], [AssignTask], [EmptyQueueSleep]). [stage] is
-    [pre] or [post].
+    [SubmitTask], [AssignTask], [EmptyQueueSleep]) or a runtime
+    contract surface such as [KeeperTurnFSM.Next]. [stage] is [pre],
+    [post], or a compact contract edge such as [streaming->done].
 
     Operator signal: a non-zero value on any [action,stage] pair
     indicates the OCaml runtime drifted from the

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -22,102 +22,188 @@ let test_emit_transition_signature_stable () =
   (* Pass concrete values so a signature drift (e.g. removing
      [?prev], or moving [keeper_name] off labelled args) fails
      to type-check. *)
-  F.emit_transition ~keeper_name:"alice" ~turn_id:42
+  F.emit_transition
+    ~keeper_name:"alice"
+    ~turn_id:42
     ~prev:F.Phase_gating
     (F.Cancelled F.Cancelled_phase_gate_close);
-  F.emit_transition ~keeper_name:"bob" ~turn_id:0
+  F.emit_transition
+    ~keeper_name:"bob"
+    ~turn_id:0
     (F.Failed (F.Failure_runtime_error "noop"));
-  F.emit_transition ~keeper_name:"carol" ~turn_id:1
-    F.Idle;
+  F.emit_transition ~keeper_name:"carol" ~turn_id:1 F.Idle;
   Alcotest.(check bool)
     "emit_transition accepts ?prev / labelled args / int turn_id"
-    true true
+    true
+    true
+;;
 
 (* ── Label coverage ────────────────────────────────────────── *)
 
 let test_turn_state_labels_cover_every_variant () =
   let pairs : (F.turn_state * string) list =
-    [
-      (F.Idle, "idle");
-      (F.Phase_gating, "phase_gating");
-      (F.Cascade_routing, "cascade_routing");
-      (F.Awaiting_provider, "awaiting_provider");
-      (F.Streaming, "streaming");
-      (F.Awaiting_tool_result, "awaiting_tool_result");
-      (F.Completing, "completing");
-      (F.Done, "done");
-      ( F.Failed (F.Failure_runtime_error "x"),
-        "failed:runtime_error" );
-      ( F.Cancelled F.Cancelled_phase_gate_close,
-        "cancelled:phase_gate_close" );
+    [ F.Idle, "idle"
+    ; F.Phase_gating, "phase_gating"
+    ; F.Cascade_routing, "cascade_routing"
+    ; F.Awaiting_provider, "awaiting_provider"
+    ; F.Streaming, "streaming"
+    ; F.Awaiting_tool_result, "awaiting_tool"
+    ; F.Completing, "completing"
+    ; F.Done, "done"
+    ; F.Failed (F.Failure_runtime_error "x"), "failed:runtime_error"
+    ; F.Cancelled F.Cancelled_phase_gate_close, "cancelled:phase_gate_close"
     ]
   in
   List.iter
     (fun (s, expected) ->
-      Alcotest.(check string)
-        ("turn_state_label " ^ expected)
-        expected (F.turn_state_label s))
+       Alcotest.(check string)
+         ("turn_state_label " ^ expected)
+         expected
+         (F.turn_state_label s))
     pairs
+;;
+
+let check_action expected ~from_state ~to_state =
+  match F.classify_transition ~from_state ~to_state with
+  | Some actual ->
+    Alcotest.(check string)
+      ("transition action " ^ F.transition_action_label expected)
+      (F.transition_action_label expected)
+      (F.transition_action_label actual)
+  | None ->
+    Alcotest.failf
+      "expected transition action %s for %s -> %s"
+      (F.transition_action_label expected)
+      (F.turn_state_label from_state)
+      (F.turn_state_label to_state)
+;;
+
+let test_transition_actions_cover_tla_next () =
+  check_action F.StartTurn ~from_state:F.Idle ~to_state:F.Phase_gating;
+  check_action F.PhaseGateSkip ~from_state:F.Phase_gating ~to_state:F.Done;
+  check_action F.PhaseGateOk ~from_state:F.Phase_gating ~to_state:F.Cascade_routing;
+  check_action F.CascadeRouted ~from_state:F.Cascade_routing ~to_state:F.Awaiting_provider;
+  check_action
+    F.CascadeUnavailable
+    ~from_state:F.Cascade_routing
+    ~to_state:
+      (F.Failed (F.Failure_cascade_unavailable { base = "ollama"; resolved = None }));
+  check_action F.ProviderResponded ~from_state:F.Awaiting_provider ~to_state:F.Streaming;
+  check_action
+    F.ProviderTimeout
+    ~from_state:F.Awaiting_provider
+    ~to_state:(F.Cancelled F.Cancelled_provider_timeout);
+  check_action F.StreamYieldsTool ~from_state:F.Streaming ~to_state:F.Awaiting_tool_result;
+  check_action F.ToolReturned ~from_state:F.Awaiting_tool_result ~to_state:F.Streaming;
+  check_action F.StreamComplete ~from_state:F.Streaming ~to_state:F.Completing;
+  check_action F.ContractOk ~from_state:F.Completing ~to_state:F.Done;
+  check_action
+    F.ContractViolation
+    ~from_state:F.Completing
+    ~to_state:
+      (F.Failed (F.Failure_tool_contract_violation { reason_code = "passive_only" }));
+  check_action
+    F.ReceiptLost
+    ~from_state:F.Completing
+    ~to_state:
+      (F.Failed (F.Failure_receipt_lost { primary_error = "io"; fallback_path = None }));
+  check_action
+    F.GenericFail
+    ~from_state:F.Streaming
+    ~to_state:(F.Failed (F.Failure_runtime_error "boom"));
+  check_action F.SupervisorRequestsStop ~from_state:F.Streaming ~to_state:F.Streaming;
+  check_action
+    F.HonorStopSignal
+    ~from_state:F.Streaming
+    ~to_state:(F.Cancelled F.Cancelled_supervisor_stop);
+  check_action F.TerminalStutter ~from_state:F.Done ~to_state:F.Done
+;;
+
+let test_invalid_transition_rejected () =
+  match F.assert_transition_allowed ~from_state:F.Idle ~to_state:F.Done with
+  | Error violation ->
+    Alcotest.(check string) "invalid edge from state" "idle" violation.from_state;
+    Alcotest.(check string) "invalid edge to state" "done" violation.to_state;
+    Alcotest.(check string)
+      "invalid edge reason"
+      "not_in_keeper_turn_fsm_next"
+      violation.reason
+  | Ok action ->
+    Alcotest.failf
+      "Idle -> Done unexpectedly classified as %s"
+      (F.transition_action_label action)
+;;
 
 let test_cancel_reason_labels_documented () =
   let pairs : (F.cancel_reason * string) list =
-    [
-      (F.Cancelled_supervisor_stop, "supervisor_stop");
-      (F.Cancelled_phase_gate_close, "phase_gate_close");
-      (F.Cancelled_provider_timeout, "provider_timeout");
-      (F.Cancelled_fleet_shutdown, "fleet_shutdown");
+    [ F.Cancelled_supervisor_stop, "supervisor_stop"
+    ; F.Cancelled_phase_gate_close, "phase_gate_close"
+    ; F.Cancelled_provider_timeout, "provider_timeout"
+    ; F.Cancelled_fleet_shutdown, "fleet_shutdown"
     ]
   in
   List.iter
     (fun (r, expected) ->
-      Alcotest.(check string)
-        ("cancel_reason " ^ expected)
-        expected (F.cancel_reason_label r))
+       Alcotest.(check string)
+         ("cancel_reason " ^ expected)
+         expected
+         (F.cancel_reason_label r))
     pairs
+;;
 
 let test_failure_reason_labels_documented () =
   let pairs : (F.failure_reason * string) list =
-    [
-      ( F.Failure_cascade_unavailable
-          { base = "ollama:7b"; resolved = None },
-        "cascade_unavailable" );
-      ( F.Failure_provider_error { kind = "k"; detail = "d" },
-        "provider_error" );
-      ( F.Failure_tool_contract_violation { reason_code = "rc" },
-        "tool_contract_violation" );
-      ( F.Failure_receipt_lost
-          { primary_error = "e"; fallback_path = None },
-        "receipt_lost" );
-      ( F.Failure_turn_livelock_blocked { reason = "stuck_after_sec" },
-        "turn_livelock_blocked" );
-      (F.Failure_runtime_error "msg", "runtime_error");
-      ( F.Failure_unexpected_exception
-          { exn = "Boom"; backtrace = None },
-        "unexpected_exception" );
+    [ ( F.Failure_cascade_unavailable { base = "ollama:7b"; resolved = None }
+      , "cascade_unavailable" )
+    ; F.Failure_provider_error { kind = "k"; detail = "d" }, "provider_error"
+    ; F.Failure_tool_contract_violation { reason_code = "rc" }, "tool_contract_violation"
+    ; F.Failure_receipt_lost { primary_error = "e"; fallback_path = None }, "receipt_lost"
+    ; ( F.Failure_turn_livelock_blocked { reason = "stuck_after_sec" }
+      , "turn_livelock_blocked" )
+    ; F.Failure_runtime_error "msg", "runtime_error"
+    ; ( F.Failure_unexpected_exception { exn = "Boom"; backtrace = None }
+      , "unexpected_exception" )
     ]
   in
   List.iter
     (fun (r, expected) ->
-      Alcotest.(check string)
-        ("failure_reason " ^ expected)
-        expected (F.failure_reason_label r))
+       Alcotest.(check string)
+         ("failure_reason " ^ expected)
+         expected
+         (F.failure_reason_label r))
     pairs
+;;
 
 let () =
-  Alcotest.run "keeper_turn_fsm_emit"
-    [
-      ( "signature_anchor",
-        [
-          Alcotest.test_case "emit_transition surface stable"
-            `Quick test_emit_transition_signature_stable;
-        ] );
-      ( "labels",
-        [
-          Alcotest.test_case "turn_state covers every variant"
-            `Quick test_turn_state_labels_cover_every_variant;
-          Alcotest.test_case "cancel_reason labels match docs"
-            `Quick test_cancel_reason_labels_documented;
-          Alcotest.test_case "failure_reason labels match docs"
-            `Quick test_failure_reason_labels_documented;
-        ] );
+  Alcotest.run
+    "keeper_turn_fsm_emit"
+    [ ( "signature_anchor"
+      , [ Alcotest.test_case
+            "emit_transition surface stable"
+            `Quick
+            test_emit_transition_signature_stable
+        ] )
+    ; ( "labels"
+      , [ Alcotest.test_case
+            "turn_state covers every variant"
+            `Quick
+            test_turn_state_labels_cover_every_variant
+        ; Alcotest.test_case
+            "transition actions cover TLA Next"
+            `Quick
+            test_transition_actions_cover_tla_next
+        ; Alcotest.test_case
+            "invalid transition rejected"
+            `Quick
+            test_invalid_transition_rejected
+        ; Alcotest.test_case
+            "cancel_reason labels match docs"
+            `Quick
+            test_cancel_reason_labels_documented
+        ; Alcotest.test_case
+            "failure_reason labels match docs"
+            `Quick
+            test_failure_reason_labels_documented
+        ] )
     ]
+;;


### PR DESCRIPTION
## Summary

- classify keeper turn `(prev, next)` edges through a runtime image of `KeeperTurnFSM.tla` `Next`
- reject out-of-contract edges via `masc_fsm_guard_violation_total{action="KeeperTurnFSM.Next", stage="<from>-><to>"}` and `MASC_FSM_GUARD_ASSERT=1`
- align `Awaiting_tool_result` operator labels with the TLA symbol `awaiting_tool`
- document the transition guard in the keeper turn FSM observability surface

## Why this matters

The AST/PPX contract should not stop at generated labels. The runtime now checks the actual keeper turn edge being emitted against the typed contract surface, so drift becomes an observable guard violation instead of a silent log/metric mismatch.

This deliberately keeps the implementation concrete: no synthetic provider behavior, no fake receipt writes, and no string-only routing layer. The guard is tied to the typed `turn_state` ADT, the generated TLA labels, and the existing `Keeper_fsm_guard_runtime` assertion/counter path.

## Validation

- `scripts/dune-local.sh build ppx_tla test/ppx_tla/test_basic.exe test/test_keeper_turn_fsm_emit.exe test/test_keeper_turn_fsm_tla_parity.exe test/test_keeper_typed_labels.exe test/test_keeper_receipt_outcome_tla_parity.exe test/test_keeper_receipt_authoritative.exe test/test_keeper_receipt_authoritative_matrix.exe`
- `_build/default/test/ppx_tla/test_basic.exe`
- `_build/default/test/test_keeper_turn_fsm_emit.exe`
- `_build/default/test/test_keeper_turn_fsm_tla_parity.exe`
- `_build/default/test/test_keeper_receipt_outcome_tla_parity.exe`
- `_build/default/test/test_keeper_typed_labels.exe`
- `_build/default/test/test_keeper_receipt_authoritative.exe`
- `_build/default/test/test_keeper_receipt_authoritative_matrix.exe`
- `git diff --check --cached`
