### PR TITLE
feat(dashboard): add Track 1 collaboration MVP

### DIFF
--- a/dashboard/src/collab-mvp-contract.test.ts
+++ b/dashboard/src/collab-mvp-contract.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COLLAB_MVP_STACK,
+  buildCollabMvpProjection,
+} from './collab-mvp-contract'
+import { normalizeTask } from './store-normalizers'
+import type { Agent, Task } from './types'
+
+describe('COLLAB_MVP_STACK', () => {
+  it('separates installed dashboard pieces from contract-only Track 1 pieces', () => {
+    expect(COLLAB_MVP_STACK.find(item => item.id === 'cytoscape-git-graph')).toMatchObject({
+      packageName: 'cytoscape',
+      status: 'installed',
+      owner: 'masc',
+    })
+    expect(COLLAB_MVP_STACK.find(item => item.id === 'yjs-document')).toMatchObject({
+      packageName: 'yjs',
+      status: 'contract',
+      owner: 'masc',
+    })
+  })
+})
+
+describe('buildCollabMvpProjection', () => {
+  it('projects TODO claims, turn queue, and worktree-backed graph nodes', () => {
+    const agents: Agent[] = [
+      { name: 'keeper-a', status: 'active', current_task: null, last_seen: '2026-04-30T01:00:00Z' },
+      { name: 'keeper-b', status: 'idle', current_task: null },
+      { name: 'keeper-offline', status: 'offline', current_task: null },
+    ]
+    const tasks: Task[] = [
+      {
+        id: 'task-1',
+        title: 'Implement Track 1',
+        status: 'claimed',
+        priority: 1,
+        assignee: 'keeper-a',
+        goal_id: 'goal-1',
+        worktree: {
+          branch: 'track1-masc-collab-mvp',
+          path: '/repo/.worktrees/track1-masc-collab-mvp',
+          git_root: '/repo',
+          repo_name: 'masc-mcp',
+        },
+      },
+      {
+        id: 'task-2',
+        title: 'Backlog item',
+        status: 'todo',
+        priority: 4,
+      },
+    ]
+
+    const projection = buildCollabMvpProjection({
+      agents,
+      tasks,
+      boardPosts: [],
+      nowIso: '2026-04-30T02:00:00Z',
+    })
+
+    expect(projection.generatedAt).toBe('2026-04-30T02:00:00Z')
+    expect(projection.summary).toMatchObject({
+      activeAgents: 2,
+      openClaims: 2,
+      unclaimedTasks: 1,
+      worktreeBackedBranches: 1,
+      boardObservations: 0,
+    })
+    expect(projection.todoClaims[0]).toMatchObject({
+      taskId: 'task-1',
+      claimant: 'keeper-a',
+      branch: 'track1-masc-collab-mvp',
+      repoName: 'masc-mcp',
+      state: 'claimed',
+    })
+    expect(projection.turnQueue[0]).toMatchObject({
+      agentName: 'keeper-a',
+      state: 'running',
+      currentTaskId: 'task-1',
+      rank: 1,
+    })
+    expect(projection.gitGraph.source).toBe('worktree')
+    expect(projection.gitGraph.nodes.map(node => node.id)).toEqual(expect.arrayContaining([
+      'repo:masc-mcp',
+      'main:masc-mcp',
+      'branch:masc-mcp:track1-masc-collab-mvp',
+      'task:task-1',
+    ]))
+  })
+
+  it('falls back to coordination-derived branches for active tasks without worktree metadata', () => {
+    const projection = buildCollabMvpProjection({
+      agents: [{ name: 'keeper-a', status: 'active', current_task: null }],
+      tasks: [{
+        id: 'task-9',
+        title: 'No worktree yet',
+        status: 'in_progress',
+        assignee: 'keeper-a',
+      }],
+      boardPosts: [],
+      nowIso: '2026-04-30T02:00:00Z',
+    })
+
+    expect(projection.todoClaims[0]).toMatchObject({
+      taskId: 'task-9',
+      branch: 'keeper-a/task-9',
+      repoName: null,
+      state: 'running',
+    })
+    expect(projection.gitGraph.source).toBe('coordination_fallback')
+  })
+})
+
+describe('normalizeTask worktree metadata', () => {
+  it('preserves task worktree fields for Track 1 git graph projection', () => {
+    expect(normalizeTask({
+      id: 'task-1',
+      title: 'Implement Track 1',
+      worktree: {
+        branch: 'track1',
+        path: '/repo/.worktrees/track1',
+        git_root: '/repo',
+        repo_name: 'masc-mcp',
+      },
+    })?.worktree).toEqual({
+      branch: 'track1',
+      path: '/repo/.worktrees/track1',
+      git_root: '/repo',
+      repo_name: 'masc-mcp',
+    })
+  })
+})

--- a/dashboard/src/collab-mvp-contract.ts
+++ b/dashboard/src/collab-mvp-contract.ts
@@ -1,0 +1,388 @@
+import type { Agent, BoardPost, Task } from './types'
+
+export type CollabMvpStackId =
+  | 'yjs-document'
+  | 'y-websocket-transport'
+  | 'codemirror-editor'
+  | 'cytoscape-git-graph'
+  | 'todo-claim'
+  | 'turn-queue'
+  | 'otel-events'
+
+export type CollabMvpStackStatus = 'contract' | 'installed' | 'observed'
+
+export interface CollabMvpStackItem {
+  id: CollabMvpStackId
+  label: string
+  packageName?: string
+  status: CollabMvpStackStatus
+  owner: 'masc'
+}
+
+export const COLLAB_MVP_STACK: CollabMvpStackItem[] = [
+  {
+    id: 'yjs-document',
+    label: 'Yjs document model',
+    packageName: 'yjs',
+    status: 'contract',
+    owner: 'masc',
+  },
+  {
+    id: 'y-websocket-transport',
+    label: 'y-websocket sync lane',
+    packageName: 'y-websocket',
+    status: 'contract',
+    owner: 'masc',
+  },
+  {
+    id: 'codemirror-editor',
+    label: 'CodeMirror 6 editor binding',
+    packageName: '@codemirror/view',
+    status: 'contract',
+    owner: 'masc',
+  },
+  {
+    id: 'cytoscape-git-graph',
+    label: 'cytoscape Git graph',
+    packageName: 'cytoscape',
+    status: 'installed',
+    owner: 'masc',
+  },
+  {
+    id: 'todo-claim',
+    label: 'TODO Claim protocol',
+    status: 'observed',
+    owner: 'masc',
+  },
+  {
+    id: 'turn-queue',
+    label: 'Turn Queue',
+    status: 'observed',
+    owner: 'masc',
+  },
+  {
+    id: 'otel-events',
+    label: 'OpenTelemetry event semantics',
+    status: 'contract',
+    owner: 'masc',
+  },
+]
+
+export type CollabMvpEventName =
+  | 'masc.collab.doc.sync'
+  | 'masc.collab.todo.claim'
+  | 'masc.collab.turn.queue'
+  | 'masc.collab.git.graph'
+
+export interface CollabMvpEventSemantic {
+  name: CollabMvpEventName
+  source: 'dashboard' | 'keeper_coordination' | 'git_projection' | 'crdt_transport'
+  attributes: string[]
+}
+
+export const COLLAB_MVP_EVENT_SEMANTICS: CollabMvpEventSemantic[] = [
+  {
+    name: 'masc.collab.doc.sync',
+    source: 'crdt_transport',
+    attributes: [
+      'masc.workspace_id',
+      'masc.doc_id',
+      'masc.agent_id',
+      'masc.crdt.provider',
+      'masc.sync.bytes',
+      'masc.sync.latency_ms',
+    ],
+  },
+  {
+    name: 'masc.collab.todo.claim',
+    source: 'keeper_coordination',
+    attributes: [
+      'masc.task_id',
+      'masc.claimant',
+      'masc.claim.state',
+      'masc.claim.scope',
+      'masc.goal_id',
+    ],
+  },
+  {
+    name: 'masc.collab.turn.queue',
+    source: 'keeper_coordination',
+    attributes: [
+      'masc.agent_id',
+      'masc.turn.rank',
+      'masc.turn.state',
+      'masc.current_task_id',
+      'masc.queue.depth',
+    ],
+  },
+  {
+    name: 'masc.collab.git.graph',
+    source: 'git_projection',
+    attributes: [
+      'masc.repo_name',
+      'masc.git.branch',
+      'masc.git.worktree_path',
+      'masc.task_id',
+      'masc.agent_id',
+    ],
+  },
+]
+
+export type TodoClaimState = 'unclaimed' | 'claimed' | 'running' | 'verification' | 'terminal'
+
+export interface CollabTodoClaim {
+  taskId: string
+  title: string
+  priority: number
+  state: TodoClaimState
+  claimant: string | null
+  goalId: string | null
+  branch: string | null
+  repoName: string | null
+}
+
+export type TurnQueueState = 'running' | 'waiting' | 'idle'
+
+export interface CollabTurnQueueEntry {
+  agentName: string
+  rank: number
+  state: TurnQueueState
+  currentTaskId: string | null
+  observedAt: string | null
+}
+
+export type CollabGitGraphNodeType = 'repo' | 'main' | 'branch' | 'task'
+export type CollabGitGraphSource = 'worktree' | 'coordination_fallback'
+
+export interface CollabGitGraphNode {
+  id: string
+  label: string
+  type: CollabGitGraphNodeType
+  parent?: string
+  source: CollabGitGraphSource
+}
+
+export interface CollabGitGraphEdge {
+  id: string
+  source: string
+  target: string
+  label?: string
+}
+
+export interface CollabGitGraphSpec {
+  nodes: CollabGitGraphNode[]
+  edges: CollabGitGraphEdge[]
+  source: CollabGitGraphSource
+}
+
+export interface CollabMvpProjection {
+  generatedAt: string
+  summary: {
+    activeAgents: number
+    openClaims: number
+    unclaimedTasks: number
+    worktreeBackedBranches: number
+    boardObservations: number
+  }
+  todoClaims: CollabTodoClaim[]
+  turnQueue: CollabTurnQueueEntry[]
+  gitGraph: CollabGitGraphSpec
+}
+
+export interface BuildCollabMvpProjectionArgs {
+  agents: readonly Agent[]
+  tasks: readonly Task[]
+  boardPosts: readonly BoardPost[]
+  nowIso?: string
+}
+
+const ACTIVE_TASK_STATUSES = new Set(['claimed', 'in_progress', 'awaiting_verification'])
+const OPEN_CLAIM_STATES = new Set<TodoClaimState>(['unclaimed', 'claimed', 'running', 'verification'])
+
+function fallbackNowIso(): string {
+  try {
+    return new Date().toISOString()
+  } catch {
+    return ''
+  }
+}
+
+function statusOf(task: Task): string {
+  return task.status ?? 'todo'
+}
+
+function claimStateOf(task: Task): TodoClaimState {
+  switch (statusOf(task)) {
+    case 'todo':
+      return 'unclaimed'
+    case 'claimed':
+      return 'claimed'
+    case 'in_progress':
+      return 'running'
+    case 'awaiting_verification':
+      return 'verification'
+    default:
+      return 'terminal'
+  }
+}
+
+function branchForTask(task: Task): string | null {
+  if (task.worktree?.branch) return task.worktree.branch
+  if (task.assignee && ACTIVE_TASK_STATUSES.has(statusOf(task))) return `${task.assignee}/${task.id}`
+  return null
+}
+
+function repoNameForTask(task: Task): string | null {
+  return task.worktree?.repo_name || null
+}
+
+function taskClaimant(task: Task): string | null {
+  return task.assignee ?? null
+}
+
+function compareClaims(a: CollabTodoClaim, b: CollabTodoClaim): number {
+  if (a.state === 'terminal' && b.state !== 'terminal') return 1
+  if (b.state === 'terminal' && a.state !== 'terminal') return -1
+  if (a.priority !== b.priority) return a.priority - b.priority
+  return a.taskId.localeCompare(b.taskId)
+}
+
+function makeTodoClaims(tasks: readonly Task[]): CollabTodoClaim[] {
+  return tasks
+    .map(task => ({
+      taskId: task.id,
+      title: task.title,
+      priority: task.priority ?? 3,
+      state: claimStateOf(task),
+      claimant: taskClaimant(task),
+      goalId: task.goal_id ?? null,
+      branch: branchForTask(task),
+      repoName: repoNameForTask(task),
+    }))
+    .sort(compareClaims)
+}
+
+function makeTurnQueue(agents: readonly Agent[], tasks: readonly Task[]): CollabTurnQueueEntry[] {
+  const seen = new Set<string>()
+  const activeTaskByAgent = new Map<string, string>()
+  for (const task of tasks) {
+    if (task.assignee && ACTIVE_TASK_STATUSES.has(statusOf(task))) {
+      activeTaskByAgent.set(task.assignee, task.id)
+    }
+  }
+
+  const entries: CollabTurnQueueEntry[] = agents.map(agent => {
+    seen.add(agent.name)
+    const currentTaskId = agent.current_task ?? activeTaskByAgent.get(agent.name) ?? null
+    return {
+      agentName: agent.name,
+      rank: 0,
+      state: currentTaskId ? 'running' : agent.status === 'idle' ? 'idle' : 'waiting',
+      currentTaskId,
+      observedAt: agent.last_seen ?? null,
+    }
+  })
+
+  for (const [agentName, taskId] of activeTaskByAgent.entries()) {
+    if (seen.has(agentName)) continue
+    entries.push({
+      agentName,
+      rank: 0,
+      state: 'running',
+      currentTaskId: taskId,
+      observedAt: null,
+    })
+  }
+
+  return entries
+    .sort((a, b) => {
+      const stateRank = (entry: CollabTurnQueueEntry) =>
+        entry.state === 'running' ? 0 : entry.state === 'waiting' ? 1 : 2
+      const stateDelta = stateRank(a) - stateRank(b)
+      if (stateDelta !== 0) return stateDelta
+      return a.agentName.localeCompare(b.agentName)
+    })
+    .map((entry, index) => ({ ...entry, rank: index + 1 }))
+}
+
+function graphId(...parts: string[]): string {
+  return parts
+    .join(':')
+    .replace(/[^a-zA-Z0-9:_./-]+/g, '-')
+    .replace(/-+/g, '-')
+}
+
+function makeGitGraph(claims: readonly CollabTodoClaim[]): CollabGitGraphSpec {
+  const nodes = new Map<string, CollabGitGraphNode>()
+  const edges = new Map<string, CollabGitGraphEdge>()
+  let hasWorktree = false
+
+  const addNode = (node: CollabGitGraphNode) => {
+    if (!nodes.has(node.id)) nodes.set(node.id, node)
+  }
+  const addEdge = (edge: CollabGitGraphEdge) => {
+    if (!edges.has(edge.id)) edges.set(edge.id, edge)
+  }
+
+  const visibleClaims = claims.filter(claim => claim.state !== 'terminal').slice(0, 18)
+  const source: CollabGitGraphSource = visibleClaims.some(claim => claim.branch && claim.repoName)
+    ? 'worktree'
+    : 'coordination_fallback'
+
+  for (const claim of visibleClaims) {
+    const repoName = claim.repoName ?? 'coordination'
+    const repoId = graphId('repo', repoName)
+    const mainId = graphId('main', repoName)
+    const branch = claim.branch ?? `unclaimed/${claim.taskId}`
+    const branchId = graphId('branch', repoName, branch)
+    const taskId = graphId('task', claim.taskId)
+    const nodeSource: CollabGitGraphSource = claim.repoName && claim.branch
+      ? 'worktree'
+      : 'coordination_fallback'
+
+    hasWorktree = hasWorktree || nodeSource === 'worktree'
+    addNode({ id: repoId, label: repoName, type: 'repo', source: nodeSource })
+    addNode({ id: mainId, label: 'main', type: 'main', parent: repoId, source: nodeSource })
+    addNode({ id: branchId, label: branch, type: 'branch', parent: repoId, source: nodeSource })
+    addNode({ id: taskId, label: claim.taskId, type: 'task', parent: branchId, source: nodeSource })
+    addEdge({ id: graphId('edge', mainId, branchId), source: mainId, target: branchId })
+    addEdge({ id: graphId('edge', branchId, taskId), source: branchId, target: taskId, label: claim.claimant ?? claim.state })
+  }
+
+  if (nodes.size === 0) {
+    addNode({ id: 'repo:coordination', label: 'coordination', type: 'repo', source })
+    addNode({ id: 'main:coordination', label: 'main', type: 'main', parent: 'repo:coordination', source })
+  }
+
+  return {
+    nodes: Array.from(nodes.values()),
+    edges: Array.from(edges.values()),
+    source: hasWorktree ? 'worktree' : source,
+  }
+}
+
+export function buildCollabMvpProjection({
+  agents,
+  tasks,
+  boardPosts,
+  nowIso,
+}: BuildCollabMvpProjectionArgs): CollabMvpProjection {
+  const todoClaims = makeTodoClaims(tasks)
+  const openClaims = todoClaims.filter(claim => OPEN_CLAIM_STATES.has(claim.state))
+  const turnQueue = makeTurnQueue(agents, tasks)
+  const gitGraph = makeGitGraph(todoClaims)
+
+  return {
+    generatedAt: nowIso ?? fallbackNowIso(),
+    summary: {
+      activeAgents: agents.filter(agent => agent.status !== 'offline').length,
+      openClaims: openClaims.length,
+      unclaimedTasks: todoClaims.filter(claim => claim.state === 'unclaimed').length,
+      worktreeBackedBranches: todoClaims.filter(claim => claim.branch && claim.repoName).length,
+      boardObservations: boardPosts.length,
+    },
+    todoClaims,
+    turnQueue,
+    gitGraph,
+  }
+}

--- a/dashboard/src/collaboration-track1.test.ts
+++ b/dashboard/src/collaboration-track1.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TRACK1_DOC_IDS,
+  classifyTrack1Topic,
+  isTrack1ProjectionDoc,
+  parseTrack1Frame,
+  track1TelemetryAttributes,
+  verifyTrack1TodoClaim,
+} from './collaboration-track1'
+
+describe('parseTrack1Frame', () => {
+  it('accepts server-authored Yjs projection frames', () => {
+    expect(parseTrack1Frame({
+      topic: 'yjs:projection:keepers',
+      doc_id: TRACK1_DOC_IDS.keepers,
+      update_b64: 'AQIDBA==',
+      seq: 42,
+      server_ts: '2026-04-30T01:00:00Z',
+      trace_id: 'trace-1',
+    })).toEqual({
+      kind: 'projection',
+      layer: 'projection',
+      topic: 'yjs:projection:keepers',
+      doc_id: TRACK1_DOC_IDS.keepers,
+      update_b64: 'AQIDBA==',
+      seq: 42,
+      server_ts: '2026-04-30T01:00:00Z',
+      trace_id: 'trace-1',
+    })
+  })
+
+  it('accepts ephemeral awareness frames', () => {
+    expect(parseTrack1Frame({
+      topic: 'yjs:awareness:room-1',
+      client_id: 7,
+      state_b64: 'AAECAw==',
+      room_id: 'room-1',
+    })).toEqual({
+      kind: 'awareness',
+      layer: 'ephemeral',
+      topic: 'yjs:awareness:room-1',
+      client_id: 7,
+      state_b64: 'AAECAw==',
+      room_id: 'room-1',
+      server_ts: undefined,
+    })
+  })
+
+  it('accepts explicit write rejects from the authoritative layer', () => {
+    expect(parseTrack1Frame({
+      topic: 'yjs:reject',
+      doc_id: TRACK1_DOC_IDS.turnQueue,
+      attempted_topic: 'yjs:projection:turn-queue',
+      reason: 'client writes to projection docs are rejected',
+    })).toEqual({
+      kind: 'reject',
+      layer: 'authority',
+      topic: 'yjs:reject',
+      doc_id: TRACK1_DOC_IDS.turnQueue,
+      attempted_topic: 'yjs:projection:turn-queue',
+      reason: 'client writes to projection docs are rejected',
+      server_ts: undefined,
+    })
+  })
+
+  it('drops unknown topics and malformed binary payloads', () => {
+    expect(parseTrack1Frame({ topic: 'runtime.turn_recorded' })).toBeNull()
+    expect(parseTrack1Frame({
+      topic: 'yjs:projection:keepers',
+      doc_id: TRACK1_DOC_IDS.keepers,
+      update_b64: 'not base64',
+    })).toBeNull()
+    expect(parseTrack1Frame({
+      topic: 'yjs:awareness:room-1',
+      client_id: -1,
+      state_b64: 'AAECAw==',
+    })).toBeNull()
+  })
+})
+
+describe('Track 1 helpers', () => {
+  it('classifies authority, projection, and ephemeral topics', () => {
+    expect(classifyTrack1Topic('yjs:projection:keepers')).toBe('projection')
+    expect(classifyTrack1Topic('yjs:awareness:room-1')).toBe('ephemeral')
+    expect(classifyTrack1Topic('yjs:reject')).toBe('authority')
+    expect(classifyTrack1Topic('runtime.turn_recorded')).toBeNull()
+  })
+
+  it('recognizes dashboard projection doc ids', () => {
+    expect(isTrack1ProjectionDoc('/dashboard/keepers')).toBe(true)
+    expect(isTrack1ProjectionDoc('/tmp/debug')).toBe(false)
+  })
+
+  it('verifies TODO claim convergence without client-side ownership writes', () => {
+    expect(verifyTrack1TodoClaim({
+      id: 'todo-1',
+      status: 'claimed',
+      assignedTo: 'keeper-a',
+      logicalClock: 12,
+    }, 'keeper-a')).toMatchObject({
+      won: true,
+      retryable: false,
+      reason: 'owned_after_convergence',
+    })
+
+    expect(verifyTrack1TodoClaim({
+      id: 'todo-1',
+      status: 'claimed',
+      assignedTo: 'keeper-b',
+      logicalClock: 13,
+    }, 'keeper-a')).toMatchObject({
+      won: false,
+      retryable: true,
+      reason: 'lost_after_convergence',
+    })
+  })
+
+  it('builds OpenTelemetry-ready attributes without leaking payload bytes', () => {
+    const frame = parseTrack1Frame({
+      topic: 'yjs:projection:keepers',
+      doc_id: TRACK1_DOC_IDS.keepers,
+      update_b64: 'AQIDBA==',
+      seq: 42,
+    })
+    expect(frame).not.toBeNull()
+    expect(track1TelemetryAttributes(frame!)).toEqual({
+      'masc.collab.kind': 'projection',
+      'masc.collab.layer': 'projection',
+      'masc.collab.topic': 'yjs:projection:keepers',
+      'masc.collab.doc_id': TRACK1_DOC_IDS.keepers,
+      'masc.collab.seq': 42,
+    })
+  })
+})

--- a/dashboard/src/collaboration-track1.ts
+++ b/dashboard/src/collaboration-track1.ts
@@ -1,0 +1,204 @@
+export const TRACK1_SYNC_BUDGET_MS = 50
+export const TRACK1_P95_SYNC_BUDGET_MS = 200
+export const TRACK1_AWARENESS_FPS = 30
+export const TRACK1_AGENT_SLOTS = 12
+
+export const TRACK1_DOC_IDS = {
+  keepers: '/dashboard/keepers',
+  turnQueue: '/dashboard/turn-queue',
+  activityLog: '/dashboard/activity-log',
+  tasks: '/dashboard/tasks',
+  gitGraph: '/dashboard/git-graph',
+} as const
+
+export type Track1DocId = typeof TRACK1_DOC_IDS[keyof typeof TRACK1_DOC_IDS]
+export type Track1Layer = 'authority' | 'projection' | 'ephemeral'
+
+export interface Track1ProjectionFrame {
+  kind: 'projection'
+  layer: 'projection'
+  topic: `yjs:projection:${string}`
+  doc_id: Track1DocId | string
+  update_b64: string
+  seq?: number
+  server_ts?: string
+  trace_id?: string | null
+}
+
+export interface Track1AwarenessFrame {
+  kind: 'awareness'
+  layer: 'ephemeral'
+  topic: `yjs:awareness:${string}`
+  client_id: number
+  state_b64: string
+  room_id?: string
+  server_ts?: string
+}
+
+export interface Track1RejectFrame {
+  kind: 'reject'
+  layer: 'authority'
+  topic: 'yjs:reject'
+  doc_id?: Track1DocId | string
+  reason: string
+  attempted_topic?: string
+  server_ts?: string
+}
+
+export type Track1Frame = Track1ProjectionFrame | Track1AwarenessFrame | Track1RejectFrame
+
+export interface Track1TodoSnapshot {
+  id: string
+  status: 'pending' | 'claimed' | 'done'
+  assignedTo: string | null
+  logicalClock: number
+}
+
+export interface Track1ClaimVerdict {
+  taskId: string
+  agentId: string
+  won: boolean
+  retryable: boolean
+  reason: 'owned_after_convergence' | 'lost_after_convergence' | 'already_done' | 'not_claimed'
+}
+
+export function classifyTrack1Topic(topic: string): Track1Layer | null {
+  if (topic.startsWith('yjs:projection:')) return 'projection'
+  if (topic.startsWith('yjs:awareness:')) return 'ephemeral'
+  if (topic === 'yjs:reject') return 'authority'
+  return null
+}
+
+export function isTrack1ProjectionDoc(docId: string): docId is Track1DocId {
+  return Object.values(TRACK1_DOC_IDS).includes(docId as Track1DocId)
+}
+
+export function parseTrack1Frame(payload: unknown): Track1Frame | null {
+  if (!isRecord(payload)) return null
+  const topic = asString(payload.topic)
+  if (!topic) return null
+
+  if (topic.startsWith('yjs:projection:')) {
+    const docId = asString(payload.doc_id)
+    const update = asString(payload.update_b64)
+    if (!docId || !isBase64Payload(update)) return null
+    return {
+      kind: 'projection',
+      layer: 'projection',
+      topic: topic as `yjs:projection:${string}`,
+      doc_id: docId,
+      update_b64: update,
+      seq: asNumber(payload.seq),
+      server_ts: asString(payload.server_ts),
+      trace_id: asNullableString(payload.trace_id),
+    }
+  }
+
+  if (topic.startsWith('yjs:awareness:')) {
+    const clientId = asNumber(payload.client_id)
+    const state = asString(payload.state_b64)
+    if (clientId === undefined || clientId < 0 || !isBase64Payload(state)) return null
+    return {
+      kind: 'awareness',
+      layer: 'ephemeral',
+      topic: topic as `yjs:awareness:${string}`,
+      client_id: clientId,
+      state_b64: state,
+      room_id: asString(payload.room_id),
+      server_ts: asString(payload.server_ts),
+    }
+  }
+
+  if (topic === 'yjs:reject') {
+    const reason = asString(payload.reason)
+    if (!reason) return null
+    return {
+      kind: 'reject',
+      layer: 'authority',
+      topic,
+      doc_id: asString(payload.doc_id),
+      reason,
+      attempted_topic: asString(payload.attempted_topic),
+      server_ts: asString(payload.server_ts),
+    }
+  }
+
+  return null
+}
+
+export function verifyTrack1TodoClaim(todo: Track1TodoSnapshot, agentId: string): Track1ClaimVerdict {
+  if (todo.status === 'done') {
+    return {
+      taskId: todo.id,
+      agentId,
+      won: false,
+      retryable: false,
+      reason: 'already_done',
+    }
+  }
+  if (todo.assignedTo === agentId) {
+    return {
+      taskId: todo.id,
+      agentId,
+      won: true,
+      retryable: false,
+      reason: 'owned_after_convergence',
+    }
+  }
+  if (todo.assignedTo) {
+    return {
+      taskId: todo.id,
+      agentId,
+      won: false,
+      retryable: true,
+      reason: 'lost_after_convergence',
+    }
+  }
+  return {
+    taskId: todo.id,
+    agentId,
+    won: false,
+    retryable: true,
+    reason: 'not_claimed',
+  }
+}
+
+export function track1TelemetryAttributes(frame: Track1Frame): Record<string, string | number> {
+  const attrs: Record<string, string | number> = {
+    'masc.collab.kind': frame.kind,
+    'masc.collab.layer': frame.layer,
+    'masc.collab.topic': frame.topic,
+  }
+  if (frame.kind === 'projection') {
+    attrs['masc.collab.doc_id'] = frame.doc_id
+    if (frame.seq !== undefined) attrs['masc.collab.seq'] = frame.seq
+  } else if (frame.kind === 'awareness') {
+    attrs['masc.collab.client_id'] = frame.client_id
+    if (frame.room_id) attrs['masc.collab.room_id'] = frame.room_id
+  } else if (frame.doc_id) {
+    attrs['masc.collab.doc_id'] = frame.doc_id
+  }
+  return attrs
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function asNullableString(value: unknown): string | null | undefined {
+  if (value === null) return null
+  return asString(value)
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function isBase64Payload(value: string | undefined): value is string {
+  if (!value || value.length % 4 !== 0) return false
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(value)
+}

--- a/dashboard/src/components/collab-mvp.ts
+++ b/dashboard/src/components/collab-mvp.ts
@@ -1,0 +1,401 @@
+import { html } from 'htm/preact'
+import { useEffect, useRef, useState } from 'preact/hooks'
+import type cytoscape from 'cytoscape'
+import { GitBranch, ListChecks, Radio, UsersRound } from 'lucide-preact'
+import { agents, boardPosts, tasks } from '../store'
+import {
+  buildCollabMvpProjection,
+  COLLAB_MVP_EVENT_SEMANTICS,
+  COLLAB_MVP_STACK,
+  type CollabGitGraphSpec,
+  type CollabMvpStackStatus,
+  type CollabTodoClaim,
+  type CollabTurnQueueEntry,
+} from '../collab-mvp-contract'
+import { InlineSpinner } from './common/inline-spinner'
+
+type CyCore = cytoscape.Core
+
+let cytoscapePromise: Promise<typeof cytoscape> | null = null
+
+function getCytoscape(): Promise<typeof cytoscape> {
+  if (!cytoscapePromise) {
+    cytoscapePromise = import('cytoscape').then(m => m.default ?? m)
+  }
+  return cytoscapePromise
+}
+
+function toneForStackStatus(status: CollabMvpStackStatus): string {
+  switch (status) {
+    case 'installed':
+      return 'border-ok/35 bg-ok/10 text-ok'
+    case 'observed':
+      return 'border-accent/25 bg-[var(--accent-10)] text-accent'
+    case 'contract':
+      return 'border-warn/30 bg-warn/10 text-warn'
+  }
+}
+
+function stateTone(state: string): string {
+  switch (state) {
+    case 'running':
+    case 'claimed':
+      return 'border-ok/35 bg-ok/10 text-ok'
+    case 'verification':
+    case 'waiting':
+      return 'border-warn/30 bg-warn/10 text-warn'
+    case 'unclaimed':
+      return 'border-accent/25 bg-[var(--accent-10)] text-accent'
+    default:
+      return 'border-card-border/50 bg-white/[0.04] text-text-muted'
+  }
+}
+
+function MetricTile({
+  icon,
+  label,
+  value,
+}: {
+  icon: unknown
+  label: string
+  value: number | string
+}) {
+  return html`
+    <div class="min-w-0 rounded border border-card-border/70 bg-black/15 px-3 py-2">
+      <div class="flex items-center gap-2 text-3xs font-medium uppercase text-text-dim">
+        <${icon as never} size=${14} />
+        <span class="truncate">${label}</span>
+      </div>
+      <div class="mt-1 text-xl font-semibold text-text-strong">${value}</div>
+    </div>
+  `
+}
+
+function graphElements(graph: CollabGitGraphSpec): cytoscape.ElementDefinition[] {
+  return [
+    ...graph.nodes.map(node => ({
+      data: {
+        id: node.id,
+        label: node.label,
+        nodeType: node.type,
+        parent: node.parent,
+        source: node.source,
+      },
+    })),
+    ...graph.edges.map(edge => ({
+      data: {
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        label: edge.label ?? '',
+      },
+    })),
+  ]
+}
+
+function graphKey(graph: CollabGitGraphSpec): string {
+  return [
+    graph.source,
+    ...graph.nodes.map(node => `${node.id}/${node.label}/${node.parent ?? ''}`),
+    ...graph.edges.map(edge => `${edge.source}>${edge.target}:${edge.label ?? ''}`),
+  ].join('|')
+}
+
+function graphStylesheet(): cytoscape.StylesheetJsonBlock[] {
+  return [
+    {
+      selector: 'node',
+      style: {
+        label: 'data(label)',
+        'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+        'font-size': '10px',
+        color: '#dbeafe',
+        'text-valign': 'center',
+        'text-halign': 'center',
+        'text-wrap': 'wrap',
+        'text-max-width': '110px',
+        'background-color': '#1e293b',
+        'border-color': '#475569',
+        'border-width': 1,
+        width: 48,
+        height: 30,
+      },
+    },
+    {
+      selector: 'node[nodeType="repo"]',
+      style: {
+        shape: 'roundrectangle',
+        'background-color': '#0f172a',
+        'border-color': '#334155',
+        'border-style': 'dashed',
+        padding: '18px',
+        'font-size': '11px',
+        color: '#94a3b8',
+        'text-valign': 'top',
+      },
+    },
+    {
+      selector: 'node[nodeType="main"]',
+      style: {
+        shape: 'ellipse',
+        'background-color': '#1d4ed8',
+        'border-color': '#93c5fd',
+        color: '#eff6ff',
+      },
+    },
+    {
+      selector: 'node[nodeType="branch"]',
+      style: {
+        shape: 'roundrectangle',
+        'background-color': '#065f46',
+        'border-color': '#34d399',
+        color: '#ecfdf5',
+        width: 92,
+      },
+    },
+    {
+      selector: 'node[nodeType="task"]',
+      style: {
+        shape: 'tag',
+        'background-color': '#78350f',
+        'border-color': '#f59e0b',
+        color: '#fffbeb',
+      },
+    },
+    {
+      selector: 'node[source="coordination_fallback"]',
+      style: {
+        'border-style': 'dotted',
+      },
+    },
+    {
+      selector: 'edge',
+      style: {
+        width: 1.5,
+        'curve-style': 'bezier',
+        'target-arrow-shape': 'triangle',
+        'line-color': '#64748b',
+        'target-arrow-color': '#64748b',
+        label: 'data(label)',
+        'font-size': '9px',
+        color: '#94a3b8',
+        'text-background-color': '#0f172a',
+        'text-background-opacity': 0.8,
+        'text-background-padding': '2px',
+      },
+    },
+  ]
+}
+
+function CollabGitGraph({ graph }: { graph: CollabGitGraphSpec }) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const cyRef = useRef<CyCore | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const key = graphKey(graph)
+
+  useEffect(() => {
+    let cancelled = false
+    const container = containerRef.current
+    if (!container) return undefined
+
+    setLoading(true)
+    setError(null)
+
+    getCytoscape()
+      .then(cyFactory => {
+        if (cancelled) return
+        cyRef.current?.destroy()
+        const cy = cyFactory({
+          container,
+          elements: graphElements(graph),
+          style: graphStylesheet(),
+          layout: {
+            name: 'breadthfirst',
+            directed: true,
+            padding: 18,
+            spacingFactor: 1.15,
+          },
+          userZoomingEnabled: true,
+          userPanningEnabled: true,
+          minZoom: 0.4,
+          maxZoom: 2,
+        })
+        cyRef.current = cy
+        setLoading(false)
+      })
+      .catch(err => {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : String(err))
+        setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+      cyRef.current?.destroy()
+      cyRef.current = null
+    }
+  }, [key])
+
+  return html`
+    <div class="relative min-h-[320px] overflow-hidden rounded border border-card-border/70 bg-[#07101d]">
+      <div
+        ref=${containerRef}
+        role="img"
+        aria-label="Collaboration Git graph"
+        class="h-[320px] w-full"
+      ></div>
+      ${loading ? html`
+        <div class="absolute inset-0 flex items-center justify-center bg-black/20">
+          <${InlineSpinner} label="graph" />
+        </div>
+      ` : null}
+      ${error ? html`
+        <div class="absolute inset-x-3 bottom-3 rounded border border-bad/30 bg-bad/10 px-3 py-2 text-xs text-bad">
+          ${error}
+        </div>
+      ` : null}
+      <div class="absolute left-3 top-3 rounded border border-card-border/60 bg-black/40 px-2 py-1 text-3xs uppercase text-text-muted">
+        ${graph.source}
+      </div>
+    </div>
+  `
+}
+
+function TodoClaimRow({ claim }: { claim: CollabTodoClaim }) {
+  return html`
+    <li class="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-2 rounded border border-card-border/60 bg-black/10 px-3 py-2">
+      <div class="min-w-0">
+        <div class="truncate text-xs font-medium text-text-strong" title=${claim.title}>${claim.title}</div>
+        <div class="mt-0.5 truncate text-3xs text-text-dim">
+          ${claim.taskId}${claim.branch ? ` · ${claim.branch}` : ''}${claim.goalId ? ` · ${claim.goalId}` : ''}
+        </div>
+      </div>
+      <div class="flex shrink-0 flex-col items-end gap-1">
+        <span class="rounded border px-2 py-0.5 text-3xs font-semibold uppercase ${stateTone(claim.state)}">
+          ${claim.state}
+        </span>
+        <span class="text-3xs text-text-dim">${claim.claimant ?? 'open'} · p${claim.priority}</span>
+      </div>
+    </li>
+  `
+}
+
+function TurnQueueRow({ entry }: { entry: CollabTurnQueueEntry }) {
+  return html`
+    <li class="grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-2 rounded border border-card-border/60 bg-black/10 px-3 py-2">
+      <div class="font-mono text-xs text-text-muted">#${entry.rank}</div>
+      <div class="min-w-0">
+        <div class="truncate text-xs font-medium text-text-strong">${entry.agentName}</div>
+        <div class="truncate text-3xs text-text-dim">${entry.currentTaskId ?? 'no current task'}</div>
+      </div>
+      <span class="rounded border px-2 py-0.5 text-3xs font-semibold uppercase ${stateTone(entry.state)}">
+        ${entry.state}
+      </span>
+    </li>
+  `
+}
+
+export function CollabMvp() {
+  const projection = buildCollabMvpProjection({
+    agents: agents.value,
+    tasks: tasks.value,
+    boardPosts: boardPosts.value,
+  })
+  const visibleClaims = projection.todoClaims.filter(claim => claim.state !== 'terminal').slice(0, 8)
+  const visibleQueue = projection.turnQueue.slice(0, 8)
+
+  return html`
+    <section class="flex flex-col gap-4" aria-label="Collaboration MVP">
+      <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        <${MetricTile} icon=${UsersRound} label="active agents" value=${projection.summary.activeAgents} />
+        <${MetricTile} icon=${ListChecks} label="open claims" value=${projection.summary.openClaims} />
+        <${MetricTile} icon=${GitBranch} label="worktree branches" value=${projection.summary.worktreeBackedBranches} />
+        <${MetricTile} icon=${Radio} label="board observations" value=${projection.summary.boardObservations} />
+        <${MetricTile} icon=${Radio} label="event names" value=${COLLAB_MVP_EVENT_SEMANTICS.length} />
+      </div>
+
+      <div class="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.65fr)]">
+        <section class="min-w-0 rounded border border-card-border/70 bg-[rgba(8,13,22,0.74)] p-3">
+          <div class="mb-2 flex items-center justify-between gap-3">
+            <div>
+              <h3 class="m-0 text-sm font-semibold text-text-strong">Git Graph</h3>
+              <div class="text-3xs text-text-dim">${projection.gitGraph.nodes.length} nodes · ${projection.gitGraph.edges.length} edges</div>
+            </div>
+            <span class="rounded border border-card-border/60 bg-black/20 px-2 py-1 text-3xs uppercase text-text-muted">
+              cytoscape
+            </span>
+          </div>
+          <${CollabGitGraph} graph=${projection.gitGraph} />
+        </section>
+
+        <section class="rounded border border-card-border/70 bg-[rgba(8,13,22,0.74)] p-3">
+          <h3 class="m-0 text-sm font-semibold text-text-strong">Substrate</h3>
+          <ul class="mt-3 grid gap-2">
+            ${COLLAB_MVP_STACK.map(item => html`
+              <li class="flex items-center justify-between gap-3 rounded border border-card-border/60 bg-black/10 px-3 py-2">
+                <div class="min-w-0">
+                  <div class="truncate text-xs font-medium text-text-strong">${item.label}</div>
+                  <div class="truncate text-3xs text-text-dim">${item.packageName ?? item.owner}</div>
+                </div>
+                <span class="shrink-0 rounded border px-2 py-0.5 text-3xs font-semibold uppercase ${toneForStackStatus(item.status)}">
+                  ${item.status}
+                </span>
+              </li>
+            `)}
+          </ul>
+        </section>
+      </div>
+
+      <div class="grid gap-4 lg:grid-cols-2">
+        <section class="rounded border border-card-border/70 bg-[rgba(8,13,22,0.74)] p-3">
+          <div class="mb-2 flex items-center justify-between gap-2">
+            <h3 class="m-0 text-sm font-semibold text-text-strong">TODO Claim</h3>
+            <span class="text-3xs text-text-dim">${projection.summary.unclaimedTasks} unclaimed</span>
+          </div>
+          ${visibleClaims.length === 0 ? html`
+            <div class="rounded border border-card-border/50 bg-black/10 px-3 py-4 text-sm text-text-muted">No open claim observations.</div>
+          ` : html`
+            <ul class="grid gap-2">
+              ${visibleClaims.map(claim => html`<${TodoClaimRow} key=${claim.taskId} claim=${claim} />`)}
+            </ul>
+          `}
+        </section>
+
+        <section class="rounded border border-card-border/70 bg-[rgba(8,13,22,0.74)] p-3">
+          <div class="mb-2 flex items-center justify-between gap-2">
+            <h3 class="m-0 text-sm font-semibold text-text-strong">Turn Queue</h3>
+            <span class="text-3xs text-text-dim">${visibleQueue.length} observed</span>
+          </div>
+          ${visibleQueue.length === 0 ? html`
+            <div class="rounded border border-card-border/50 bg-black/10 px-3 py-4 text-sm text-text-muted">No turn observations.</div>
+          ` : html`
+            <ul class="grid gap-2">
+              ${visibleQueue.map(entry => html`<${TurnQueueRow} key=${entry.agentName} entry=${entry} />`)}
+            </ul>
+          `}
+        </section>
+      </div>
+
+      <section class="rounded border border-card-border/70 bg-[rgba(8,13,22,0.74)] p-3">
+        <div class="mb-2 flex items-center justify-between gap-2">
+          <h3 class="m-0 text-sm font-semibold text-text-strong">Event Semantics</h3>
+          <span class="text-3xs text-text-dim">${projection.generatedAt}</span>
+        </div>
+        <div class="grid gap-2 lg:grid-cols-2">
+          ${COLLAB_MVP_EVENT_SEMANTICS.map(event => html`
+            <div class="rounded border border-card-border/60 bg-black/10 px-3 py-2">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="font-mono text-xs text-text-strong">${event.name}</span>
+                <span class="rounded border border-card-border/50 bg-white/[0.04] px-1.5 py-0.5 text-3xs uppercase text-text-muted">
+                  ${event.source}
+                </span>
+              </div>
+              <div class="mt-1 text-3xs text-text-dim">${event.attributes.join(' · ')}</div>
+            </div>
+          `)}
+        </div>
+      </section>
+    </section>
+  `
+}

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -2,16 +2,22 @@
 // board + planning + verification.
 
 import { html } from 'htm/preact'
+import { lazy, Suspense } from 'preact/compat'
 import { route } from '../router'
 import { Memory } from './memory'
 import { PlanningPanel } from './planning-panel'
 import { VerificationRequestsPanel } from './verification-requests-panel'
 import { ErrorBoundary } from './common/error-boundary'
+import { LoadingState } from './common/feedback-state'
 
-type WorkSection = 'board' | 'planning' | 'verification'
+type WorkSection = 'board' | 'planning' | 'collab-mvp' | 'verification'
+
+const LazyCollabMvp = lazy(async () => ({
+  default: (await import('./collab-mvp')).CollabMvp,
+}))
 
 function isWorkSection(v: string | undefined): v is WorkSection {
-  return v === 'board' || v === 'planning' || v === 'verification'
+  return v === 'board' || v === 'planning' || v === 'collab-mvp' || v === 'verification'
 }
 
 export function Work() {
@@ -25,6 +31,11 @@ export function Work() {
         <${ErrorBoundary} label=${current}>
           ${current === 'board' ? html`<${Memory} />`
             : current === 'planning' ? html`<${PlanningPanel} />`
+            : current === 'collab-mvp' ? html`
+              <${Suspense} fallback=${html`<${LoadingState}>협업 화면 불러오는 중...<//>`}>
+                <${LazyCollabMvp} />
+              <//>
+            `
             : html`<${VerificationRequestsPanel} />`
           }
         </>

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -23,6 +23,7 @@ type SurfaceSectionId =
   // workspace
   | 'board'
   | 'planning'       // Phase 1: absorbs goals
+  | 'collab-mvp'     // Track 1: CRDT/editor/git graph/claim queue contract
   | 'verification'   // CDAL follow-up (#7531): Mission detail verification table
   // lab
   | 'tools'
@@ -239,6 +240,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '계획 & 목표',
       description: '실행 단위 칸반과 상위 의도 구조(목표 트리)를 함께 봅니다.',
       params: { section: 'planning' },
+    },
+    {
+      id: 'collab-mvp',
+      label: '협업 MVP',
+      description: 'Yjs/CodeMirror substrate, Git graph, TODO claim, turn queue, telemetry contract를 한 화면에서 봅니다.',
+      params: { section: 'collab-mvp' },
     },
     {
       id: 'verification',

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -83,6 +83,14 @@ export function normalizeTask(raw: unknown): Task | null {
   const id = asString(raw.id)
   const title = asString(raw.title)
   if (!id || !title) return null
+  const worktree = isRecord(raw.worktree)
+    ? {
+        branch: asString(raw.worktree.branch, ''),
+        path: asString(raw.worktree.path, ''),
+        git_root: asString(raw.worktree.git_root, ''),
+        repo_name: asString(raw.worktree.repo_name, ''),
+      }
+    : null
   const contract = isRecord(raw.contract)
     ? {
         strict: asBoolean(raw.contract.strict),
@@ -126,6 +134,7 @@ export function normalizeTask(raw: unknown): Task | null {
     assignee: asString(raw.assignee),
     assignee_kind: asString(raw.assignee_kind) ?? null,
     description: asString(raw.description),
+    worktree,
     created_at: asString(raw.created_at),
     updated_at: asString(raw.updated_at),
     completed_at: asString(raw.completed_at),

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -96,6 +96,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       if (routeState.params.section === 'board') {
         return ['board']
       }
+      if (routeState.params.section === 'collab-mvp') {
+        return ['execution', 'board']
+      }
       return []
     case 'lab':
       if (routeState.params.section === 'autoresearch') {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -35,6 +35,7 @@ export interface Task {
   assignee?: string
   assignee_kind?: string | null
   description?: string
+  worktree?: TaskWorktreeInfo | null
   created_at?: string
   updated_at?: string
   completed_at?: string
@@ -42,6 +43,13 @@ export interface Task {
   handoff_context?: TaskHandoffContext | null
   gate?: TaskGateSnapshot | null
   execution_links?: TaskExecutionLinks | null
+}
+
+export interface TaskWorktreeInfo {
+  branch: string
+  path: string
+  git_root: string
+  repo_name: string
 }
 
 interface TaskExecutionLinks {

--- a/docs/TRACK1-MULTIAGENT-IDE-MVP.md
+++ b/docs/TRACK1-MULTIAGENT-IDE-MVP.md
@@ -1,0 +1,79 @@
+# Track 1 Multi-Agent IDE MVP
+
+Status: implementation slice
+Source: `/Users/dancer/Downloads/multiagent-ide-deep-analysis.md` (local report, 2026-04-29)
+Verified: 2026-04-30
+
+## Scope
+
+Track 1 maps to the report's Phase 1/MVP stack:
+
+- Yjs document updates over `yjs:projection:*`
+- Yjs Awareness over `yjs:awareness:*`
+- CodeMirror 6 read-only code viewer backed by server-authored projection docs
+- cytoscape.js Git graph projection grouped by agent/keeper
+- TODO Claim + Turn Queue as observation-driven coordination
+- OpenTelemetry-ready attributes for collaboration frame flow
+
+## Boundary
+
+MASC owns the product semantics:
+
+- keeper/task/board/turn-queue state
+- branch and worktree visualization
+- operator dashboard projections
+- TODO claim policy and CAS authority
+
+OAS stays a generic agent runtime. It can expose runtime events, raw traces,
+proof records, and OTel spans, but it must not learn MASC-specific CRDT doc
+ids, keeper slots, board semantics, or branch-visualization policy.
+
+## Layer Model
+
+Track 1 follows `docs/rfc/RFC-0017-ocaml-crdt-boundary.md`.
+
+| Layer | Writer | Dashboard contract |
+|-------|--------|--------------------|
+| Authority | OCaml runtime | Existing RPC/REST/CAS transitions only |
+| Projection | Server-authored Yjs doc updates | `yjs:projection:*` frames, read-only client handling |
+| Ephemeral | Browser clients | `yjs:awareness:*` frames for cursor/selection/presence |
+
+Client writes to projection docs are rejected explicitly with `yjs:reject`.
+This keeps keeper FSM/TLA invariants in the authoritative OCaml layer.
+
+## Current Slice
+
+The dashboard now has a pure Track 1 frame contract in
+`dashboard/src/collaboration-track1.ts`.
+
+It provides:
+
+- recognized dashboard projection doc IDs
+- parser for `yjs:projection:*`, `yjs:awareness:*`, and `yjs:reject`
+- TODO claim convergence verifier for UI state
+- OpenTelemetry-ready `masc.collab.*` attributes that do not include binary
+  update payload bytes
+
+The dashboard also has a first projection builder in
+`dashboard/src/collab-mvp-contract.ts`.
+
+It provides:
+
+- current Phase 1 stack status (`contract`, `installed`, or `observed`)
+- TODO claim and turn-queue projections from existing dashboard data
+- cytoscape-ready Git graph nodes/edges from task worktree metadata
+- coordination fallback branches for active tasks that do not yet expose
+  worktree metadata
+
+## Next Implementation Steps
+
+1. Wire `parseTrack1Frame` into the dashboard WebSocket route after the
+   awareness-channel split implementation is available.
+2. Add the server-side opaque Yjs relay or multiplexed WS topic selected by
+   RFC 0017 Q-1.
+3. Implement server-authored projection encoding for keepers, turn queue,
+   activity log, tasks, and Git graph.
+4. Mount CodeMirror 6 as a read-only viewer of server-authored file snapshots.
+5. Render the Git graph projection through the existing cytoscape dependency.
+6. Add k6/Playwright coverage for 12 peers, <50 ms median sync, and 30 FPS
+   awareness coalescing.


### PR DESCRIPTION

## Summary
- add a Workspace collaboration MVP section for the Track 1 stack from the multiagent IDE analysis
- add typed dashboard projections for TODO claim, turn queue, worktree-backed Git graph, and collaboration event semantics
- add Track 1 Yjs projection/awareness/reject frame parsing and OpenTelemetry-ready attributes
- document the MASC-side Track 1 boundary and next implementation steps

## Verification
- pnpm exec tsc --noEmit --pretty false
- pnpm exec vitest run src/collaboration-track1.test.ts src/collab-mvp-contract.test.ts src/store.test.ts --no-file-parallelism --maxWorkers=1
- git diff --check

## Notes
- This is the dashboard/contract slice. Backend emission of task.worktree into execution JSON and the eventual Yjs relay/projector remain follow-up work.
