### PR TITLE
Type agent stress error kinds

### DIFF
--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -5,6 +5,12 @@
 (* Types                                                            *)
 (* ================================================================ *)
 
+type error_kind = Error_kind of string
+
+let error_kind_of_string value = Error_kind value
+
+let error_kind_to_string (Error_kind value) = value
+
 type stress_kind =
   | Failure_streak of int
   | Turn_failure of turn_failure
@@ -18,7 +24,7 @@ and turn_failure = {
   threshold : int;
   counted_toward_crash : bool;
   recoverable : bool;
-  error_kind : string option;
+  error_kind : error_kind option;
 }
 
 type event = {
@@ -46,7 +52,7 @@ let stress_kind_to_json = function
     let fields =
       match f.error_kind with
       | None -> base
-      | Some kind -> base @ [("error_kind", `String kind)]
+      | Some kind -> base @ [("error_kind", `String (error_kind_to_string kind))]
     in
     `Assoc fields
   | Fallback_approval ->

--- a/lib/agent_stress.mli
+++ b/lib/agent_stress.mli
@@ -9,6 +9,15 @@
 
     @since RFC-0001 Gate A *)
 
+(** Coarse error family attached to turn-failure stress events. *)
+type error_kind = private Error_kind of string
+
+val error_kind_of_string : string -> error_kind
+(** Convert a wire/log label into an internal error-kind value. *)
+
+val error_kind_to_string : error_kind -> string
+(** Convert an internal error-kind value back to the public wire label. *)
+
 (** Stress event kinds -- each maps to a measurable condition. *)
 type stress_kind =
   | Failure_streak of int        (** consecutive failure count *)
@@ -23,7 +32,7 @@ and turn_failure = {
   threshold : int;               (** crash threshold used for the decision *)
   counted_toward_crash : bool;   (** false for auto-recoverable/transient failures *)
   recoverable : bool;            (** whether keeper can continue without crash escalation *)
-  error_kind : string option;    (** coarse sdk error family; never the raw error text *)
+  error_kind : error_kind option; (** coarse sdk error family; never the raw error text *)
 }
 
 (** A single stress observation. *)

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -90,7 +90,7 @@ let record_turn_failure_stress
         threshold;
         counted_toward_crash = not is_auto_recoverable;
         recoverable = is_auto_recoverable;
-        error_kind = Some (sdk_error_kind err);
+        error_kind = Some (Agent_stress.error_kind_of_string (sdk_error_kind err));
       };
     timestamp = Unix.gettimeofday ();
   }

--- a/test/test_agent_stress.ml
+++ b/test/test_agent_stress.ml
@@ -20,7 +20,7 @@ let test_turn_failure_json_contract () =
           threshold = 3;
           counted_toward_crash = true;
           recoverable = false;
-          error_kind = Some "api";
+          error_kind = Some (Stress.error_kind_of_string "api");
         };
       timestamp = 1_777_120_045.0;
     }


### PR DESCRIPTION
## Summary
- Add a private `Agent_stress.error_kind` wrapper for turn-failure stress records.
- Keep the JSON wire field as `error_kind` string via explicit conversion helpers.
- Update the keeper turn-failure stress call site and Agent_stress contract test.

## Validation
- `scripts/dune-local.sh build test/test_agent_stress.exe`
- `_build/default/test/test_agent_stress.exe`
- `git diff --check`
- `rg -n "error_kind\s*:\s*string option|\?error_kind:string" lib/agent_stress.ml lib/agent_stress.mli lib/keeper/keeper_turn_cascade_budget.ml test/test_agent_stress.ml` (0 matches)

Part of #11926.