### PR TITLE
Type tool assignment error kinds

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -770,8 +770,8 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
    | Some aid ->
        let error_kind =
          if not success then
-           if !timeout_hit then Some "timeout"
-           else Some "tool_failure"
+           let kind = if !timeout_hit then "timeout" else "tool_failure" in
+           Some (Tool_assignment_telemetry.error_kind_of_string kind)
          else None
        in
        Tool_assignment_telemetry.emit_completed

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -4,6 +4,12 @@
 
 type assignment_id = string
 
+type error_kind = Error_kind of string
+
+let error_kind_of_string value = Error_kind value
+
+let error_kind_to_string (Error_kind value) = value
+
 type tool_event =
   | Assigned of {
       assignment_id : assignment_id;
@@ -29,7 +35,7 @@ type tool_event =
       tool_name : string;
       success : bool;
       duration_ms : float;
-      error_kind : string option;
+      error_kind : error_kind option;
       timestamp : float;
     }
 
@@ -71,7 +77,9 @@ let event_to_json = function
         ; ("success", `Bool success)
         ; ("duration_ms", `Float duration_ms)
         ; ( "error_kind"
-          , match error_kind with Some e -> `String e | None -> `Null )
+          , match error_kind with
+            | Some e -> `String (error_kind_to_string e)
+            | None -> `Null )
         ; ("timestamp", `Float timestamp)
         ]
 
@@ -117,7 +125,7 @@ let event_of_json json : (tool_event, string) result =
         let error_kind =
           match json |> member "error_kind" with
           | `Null -> None
-          | `String s -> Some s
+          | `String s -> Some (error_kind_of_string s)
           | _ -> None
         in
         Ok

--- a/lib/tool_assignment_telemetry.mli
+++ b/lib/tool_assignment_telemetry.mli
@@ -15,6 +15,15 @@
 
 type assignment_id = string
 
+type error_kind = private Error_kind of string
+(** Coarse tool completion error family. *)
+
+val error_kind_of_string : string -> error_kind
+(** Convert a wire/log label into an internal error-kind value. *)
+
+val error_kind_to_string : error_kind -> string
+(** Convert an internal error-kind value back to the public wire label. *)
+
 type tool_event =
   | Assigned of {
       assignment_id : assignment_id;
@@ -40,7 +49,7 @@ type tool_event =
       tool_name : string;
       success : bool;
       duration_ms : float;
-      error_kind : string option;
+      error_kind : error_kind option;
       timestamp : float;
     }
 
@@ -81,7 +90,7 @@ val emit_completed :
   tool_name:string ->
   success:bool ->
   duration_ms:float ->
-  ?error_kind:string ->
+  ?error_kind:error_kind ->
   unit ->
   unit
 

--- a/test/test_tool_assignment_telemetry.ml
+++ b/test/test_tool_assignment_telemetry.ml
@@ -117,6 +117,33 @@ let test_completed_temporal_ordering () =
     check bool "assigned before called" true (t0 <= t1);
     check bool "called before completed" true (t1 <= t2))
 
+let test_completed_error_kind_round_trip () =
+  with_eio_temp_base_path (fun () ->
+    Tool_assignment_telemetry.reset_for_testing ();
+    let assignment_id =
+      Tool_assignment_telemetry.emit_assigned
+        ~agent_id:"agent-3b"
+        ~profile:"Managed_agent"
+        ~tool_list:[ "read" ]
+        ()
+    in
+    Tool_assignment_telemetry.emit_completed
+      ~assignment_id
+      ~tool_name:"read"
+      ~success:false
+      ~duration_ms:7.0
+      ~error_kind:(Tool_assignment_telemetry.error_kind_of_string "timeout")
+      ();
+    match Tool_assignment_telemetry.read_recent ~n:1 with
+    | Error msg -> fail ("read_recent failed: " ^ msg)
+    | Ok [ Completed ev ] -> (
+        match ev.error_kind with
+        | Some kind ->
+            check string "error kind" "timeout"
+              (Tool_assignment_telemetry.error_kind_to_string kind)
+        | None -> fail "expected error_kind")
+    | Ok _ -> fail "expected one Completed event")
+
 (* --- Test 4: Config hash format validation --- *)
 
 let test_config_hash_format () =
@@ -197,6 +224,8 @@ let () =
             test_called_links_to_assignment_id;
           test_case "completed temporal ordering" `Quick
             test_completed_temporal_ordering;
+          test_case "completed error kind round-trip" `Quick
+            test_completed_error_kind_round_trip;
           test_case "config hash format" `Quick test_config_hash_format;
           test_case "read_recent newest first" `Quick
             test_read_recent_newest_first;


### PR DESCRIPTION
## Summary
- Add a private `Tool_assignment_telemetry.error_kind` wrapper for Completed events.
- Preserve the `error_kind` JSON wire label through explicit conversion helpers.
- Update the MCP tool completion telemetry call site and add a round-trip test.

## Validation
- `scripts/dune-local.sh build test/test_tool_assignment_telemetry.exe`
- `_build/default/test/test_tool_assignment_telemetry.exe`
- `git diff --check`
- `rg -n "error_kind\s*:\s*string option|\?error_kind:string" lib/tool_assignment_telemetry.ml lib/tool_assignment_telemetry.mli lib/mcp_server_eio_call_tool.ml test/test_tool_assignment_telemetry.ml` (0 matches)

Part of #11926.