### PR TITLE
fix(keeper): surface tool policy denials in telemetry

### DIFF
--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -100,6 +100,27 @@ let thinking_mode_of_record record =
      | _ -> "unknown")
   | _ -> "unknown"
 
+let bool_field_opt record field =
+  match record with
+  | `Assoc fields ->
+    (match List.assoc_opt field fields with
+     | Some (`Bool value) -> Some value
+     | _ -> None)
+  | _ -> None
+
+let tool_success_of_record record =
+  match bool_field_opt record "semantic_success" with
+  | Some value -> value
+  | None ->
+    (match bool_field_opt record "success" with
+     | Some value -> value
+     | None -> false)
+
+let semantic_outcome_of_record record ~ok =
+  match Safe_ops.json_string_opt "semantic_outcome" record with
+  | Some value when String.trim value <> "" -> value
+  | _ -> if ok then "success" else "tool_failure"
+
 let hour_key_of_record record =
   let hour_of_unix ts =
     let tm = Unix.gmtime ts in
@@ -179,6 +200,7 @@ let empty_summary ~window_hours ~n ~sampling_mode =
     ; ("by_lane", `List [])
     ; ("by_thinking_mode", `List [])
     ; ("by_tool_choice", `List [])
+    ; ("by_semantic_outcome", `List [])
     ; ("failure_categories", `List [])
     ; ("hourly_trend", `List [])
     ])
@@ -221,6 +243,9 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
   let tool_choice_stats : (string, int ref * int ref) Hashtbl.t =
     Hashtbl.create 8
   in
+  let semantic_outcome_stats : (string, int ref * int ref) Hashtbl.t =
+    Hashtbl.create 8
+  in
   (* error category -> count *)
   let failure_cats : (string, int ref) Hashtbl.t = Hashtbl.create 32 in
   List.iter (fun record ->
@@ -233,12 +258,8 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
       Safe_ops.json_string_opt "keeper" record
       |> Option.value ~default:"unknown"
     in
-    let ok = match record with
-      | `Assoc fields ->
-        (match List.assoc_opt "success" fields with
-         | Some (`Bool b) -> b | _ -> false)
-      | _ -> false
-    in
+    let ok = tool_success_of_record record in
+    let semantic_outcome = semantic_outcome_of_record record ~ok in
     let dur = match record with
       | `Assoc fields ->
         (match List.assoc_opt "duration_ms" fields with
@@ -306,6 +327,7 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
     update_rate_table thinking_mode_stats (thinking_mode_of_record record) ok;
     update_rate_table tool_choice_stats
       (bucket_key record "tool_choice" ~default:"unknown") ok;
+    update_rate_table semantic_outcome_stats semantic_outcome ok;
     (* failure category *)
     if not ok then begin
       let output =
@@ -323,7 +345,10 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
            | _ -> "")
         | _ -> ""
       in
-      let cat = classify_failure_output output
+      let cat =
+        match semantic_outcome with
+        | "policy_denied" | "structured_error" -> semantic_outcome
+        | _ -> classify_failure_output output
       in
       let r = match Hashtbl.find_opt failure_cats cat with
         | Some r -> r
@@ -375,6 +400,9 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
   let by_tool_choice =
     render_rate_table ~field:"name" tool_choice_stats
   in
+  let by_semantic_outcome =
+    render_rate_table ~field:"name" semantic_outcome_stats
+  in
   let failure_categories =
     Hashtbl.fold (fun cat r acc ->
       (!r, `Assoc [("category", `String cat); ("count", `Int !r)]) :: acc
@@ -423,6 +451,7 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
     ("by_lane", `List by_lane);
     ("by_thinking_mode", `List by_thinking_mode);
     ("by_tool_choice", `List by_tool_choice);
+    ("by_semantic_outcome", `List by_semantic_outcome);
     ("failure_categories", `List failure_categories);
     ("hourly_trend", `List hourly);
   ])

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -309,6 +309,28 @@ let blob_aware_output_json (output : string) : Yojson.Safe.t =
         ]
   | Tool_output.Inline _ -> `String output
 
+let semantic_outcome_of_output ~success output =
+  match Safe_ops.parse_json_safe
+          ~context:"Keeper_tool_call_log.semantic_outcome"
+          output
+  with
+  | Ok json ->
+      let ok_field = Safe_ops.json_bool_opt "ok" json in
+      let error_field =
+        Safe_ops.json_string_opt "error" json |> Option.map String.trim
+      in
+      (match error_field with
+       | Some "tool_not_allowed" -> (false, "policy_denied")
+       | Some error when error <> "" -> (false, "structured_error")
+       | _ ->
+         (match ok_field with
+          | Some false -> (false, "structured_error")
+          | Some true -> (success, if success then "success" else "tool_failure")
+          | None ->
+            if success then (true, "success") else (false, "tool_failure")))
+  | Error _ ->
+      if success then (true, "success") else (false, "tool_failure")
+
 let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
   (* Per-leaf sentinel-aware truncation. Previously
      [String.sub (Yojson.Safe.to_string input) 0 (max - suffix)] chopped
@@ -519,6 +541,9 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
       let safe_input = input_to_json (Observability_redact.redact_json_value input) in
       let safe_output = Observability_redact.redact_preview ~max_len:max_output_len output_text in
       let output_json = blob_aware_output_json safe_output in
+      let semantic_success, semantic_outcome =
+        semantic_outcome_of_output ~success safe_output
+      in
       let model_opt = optional_model (Some model) in
       let runtime_contract =
         Keeper_runtime_contract.runtime_contract_json_from_fields
@@ -563,6 +588,8 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
            ; ("input", safe_input)
            ; ("output", output_json)
            ; ("success", `Bool success)
+           ; ("semantic_success", `Bool semantic_success)
+           ; ("semantic_outcome", `String semantic_outcome)
            ; ("duration_ms", `Float duration_ms)
            ; ("runtime_contract", runtime_contract)
            ; ("action_radius", action_radius)

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -147,6 +147,29 @@ let runtime_mcp_tool_surface_class allowed_tool_names =
   else
     "mixed"
 
+let runtime_mcp_current_task_required_tools
+    ~(config : Coord.config)
+    (entry : Keeper_registry.registry_entry) =
+  match entry.meta.current_task_id with
+  | None -> []
+  | Some task_id ->
+      let task_id = Keeper_id.Task_id.to_string task_id in
+      let tasks =
+        try Coord.get_tasks_raw config
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+            Log.Keeper.warn
+              "keeper:%s runtime MCP failed to load current task contract for %s: %s"
+              entry.name task_id (Printexc.to_string exn);
+            []
+      in
+      tasks
+      |> List.find_opt (fun (task : Types.task) -> String.equal task.id task_id)
+      |> Option.map Coord.task_required_tools
+      |> Option.value ~default:[]
+      |> Keeper_types.dedupe_keep_order
+
 let runtime_mcp_keeper_log_context_of_entry
     ?mcp_session_id
     (entry : Keeper_registry.registry_entry)
@@ -183,6 +206,12 @@ let runtime_mcp_keeper_log_context_of_entry
       ~phase:entry.phase
       entry.meta
   in
+  let required_tools =
+    runtime_mcp_current_task_required_tools ~config entry
+  in
+  let missing_required_tools =
+    Coord.missing_required_tools ~allowed:allowed_tool_names required_tools
+  in
   let profile_defaults =
     Keeper_types_profile.load_keeper_profile_defaults entry.meta.name
   in
@@ -216,8 +245,8 @@ let runtime_mcp_keeper_log_context_of_entry
     tool_surface_class =
       Some (runtime_mcp_tool_surface_class allowed_tool_names);
     visible_tool_count = Some (List.length allowed_tool_names);
-    required_tools = Some [];
-    missing_required_tools = Some [];
+    required_tools = Some required_tools;
+    missing_required_tools = Some missing_required_tools;
     cascade_profile = Some entry.meta.cascade_name;
   }
 

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -139,6 +139,39 @@ let test_model_field_stored () =
     Alcotest.(check bool) "model field present" true
       (Observability_redact.contains_substring ~sub:"glm-4-9b" entry_str))
 
+let test_policy_denied_structured_error_gets_semantic_failure () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k" ~tool_name:"keeper_fs_read"
+      ~input:(`Assoc [("path", `String "blocked.txt")])
+      ~output_text:
+        {|{"ok":false,"error":"tool_not_allowed","tool":"keeper_fs_read"}|}
+      ~success:true ~duration_ms:1.0 ();
+    let entries = Keeper_tool_call_log.read_recent ~n:1 () in
+    Alcotest.(check int) "one entry" 1 (List.length entries);
+    let entry = List.hd entries in
+    Alcotest.(check bool) "transport success preserved" true
+      (Safe_ops.json_bool ~default:false "success" entry);
+    Alcotest.(check bool) "semantic success is false" false
+      (Safe_ops.json_bool ~default:true "semantic_success" entry);
+    Alcotest.(check (option string)) "semantic outcome"
+      (Some "policy_denied")
+      (Safe_ops.json_string_opt "semantic_outcome" entry);
+    let summary = Dashboard_http_tool_quality.aggregate ~n:10 () in
+    Alcotest.(check int) "dashboard semantic success count" 0
+      (Safe_ops.json_int ~default:(-1) "success" summary);
+    Alcotest.(check int) "dashboard semantic failure count" 1
+      (Safe_ops.json_int ~default:(-1) "failure" summary);
+    let failure_category =
+      summary
+      |> Yojson.Safe.Util.member "failure_categories"
+      |> Yojson.Safe.Util.to_list
+      |> List.hd
+    in
+    Alcotest.(check (option string)) "failure category"
+      (Some "policy_denied")
+      (Safe_ops.json_string_opt "category" failure_category))
+
 let test_turn_context_fields_stored () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.set_turn_context
@@ -619,6 +652,8 @@ let () =
         [ eio_test "denied tool not logged" test_denied_tool_not_logged
         ; eio_test "sensitive input fields redacted" test_sensitive_input_fields_redacted
         ; eio_test "model field stored" test_model_field_stored
+        ; eio_test "policy denied is semantic failure"
+            test_policy_denied_structured_error_gets_semantic_failure
         ; eio_test "turn context fields stored" test_turn_context_fields_stored
         ; eio_test "turn context fields absent without context"
             test_turn_context_fields_absent_without_context

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -21,7 +21,8 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
-let make_keeper_meta ?agent_name ?current_task_id ?(goal_ids = []) name =
+let make_keeper_meta ?agent_name ?current_task_id ?(goal_ids = [])
+    ?tool_access name =
   let agent_name =
     Option.value agent_name
       ~default:(Masc_mcp.Keeper_types.keeper_agent_name name)
@@ -44,10 +45,34 @@ let make_keeper_meta ?agent_name ?current_task_id ?(goal_ids = []) name =
            ( "active_goal_ids",
              `List (List.map (fun goal_id -> `String goal_id) goal_ids) );
          ])
+    @
+    (match tool_access with
+     | Some tool_access ->
+         [
+           ( "tool_access",
+             Masc_mcp.Keeper_types.tool_access_to_json tool_access );
+         ]
+     | None -> [])
   in
   match Masc_test_deps.meta_of_json_fixture (`Assoc fields) with
   | Ok meta -> meta
   | Error err -> fail ("make_keeper_meta failed: " ^ err)
+
+let contract_requiring_tools required_tools : Types.task_contract =
+  {
+    strict = false;
+    completion_contract = [];
+    required_tools;
+    required_evidence = [];
+    inspect_gate_evidence = [];
+    verify_gate_evidence = [];
+    links =
+      {
+        operation_id = None;
+        session_id = None;
+        autoresearch_loop_id = None;
+      };
+  }
 
 let extract_json_from_text text =
   try
@@ -190,6 +215,53 @@ let test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn () =
         (Some []) ctx.missing_required_tools;
       check (option string) "cascade profile" (Some meta.cascade_name)
         ctx.cascade_profile)
+
+let test_runtime_mcp_keeper_log_context_loads_current_task_contract () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir () in
+  let keeper_name = "sangsu-task-contract" in
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some keeper_name));
+  let contract =
+    contract_requiring_tools [ "keeper_bash"; "keeper_fs_edit" ]
+  in
+  ignore
+    (Masc_mcp.Coord.add_task
+       ~contract
+       config
+       ~title:"Needs execution tools"
+       ~priority:1
+       ~description:"exercise runtime MCP required tool logging");
+  let meta =
+    make_keeper_meta
+      ~current_task_id:"task-001"
+      ~tool_access:(Masc_mcp.Keeper_types.Custom [ "keeper_bash" ])
+      keeper_name
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_registry.unregister ~base_path keeper_name;
+      cleanup_dir base_path)
+    (fun () ->
+      ignore
+        (Masc_mcp.Keeper_registry.register_offline ~base_path keeper_name meta);
+      let entry =
+        match Masc_mcp.Keeper_registry.get ~base_path keeper_name with
+        | Some entry -> entry
+        | None -> fail "expected registered keeper entry"
+      in
+      let ctx =
+        Masc_mcp.Mcp_server_eio_call_tool.runtime_mcp_keeper_log_context_of_entry
+          entry
+          ~arguments:(`Assoc [])
+      in
+      check (option (list string)) "runtime mcp required tools"
+        (Some [ "keeper_bash"; "keeper_fs_edit" ])
+        ctx.required_tools;
+      check (option (list string)) "runtime mcp missing required tools"
+        (Some [ "keeper_fs_edit" ])
+        ctx.missing_required_tools)
 
 let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
   Eio_main.run @@ fun env ->
@@ -365,6 +437,8 @@ let () =
           test_case "regular tool keeps default timeout" `Quick test_regular_tool_uses_default_timeout;
           test_case "runtime MCP log context uses keeper trace/current turn" `Quick
             test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn;
+          test_case "runtime MCP log context loads current task contract" `Quick
+            test_runtime_mcp_keeper_log_context_loads_current_task_contract;
           test_case "runtime MCP trace logs and broadcasts" `Quick
             test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts;
         ] );


### PR DESCRIPTION
## Summary
- Load the current task contract into runtime-MCP keeper tool-call context so required_tools and missing_required_tools are no longer always empty.
- Add semantic_success and semantic_outcome to keeper tool-call logs so structured tool_not_allowed payloads no longer look like clean successes.
- Teach the dashboard tool-quality aggregate to prefer semantic_success and expose by_semantic_outcome.

## Product impact
Promise: ops visibility

This is the first bloodflow slice for keeper autonomy debugging: when a keeper is blocked by tool policy or missing required tools, operators can see the exact stop point instead of reading success=true around an ok=false payload.

## Evidence
- env DUNE_JOBS=1 DUNE_BUILD_DIR=_build-bloodflow-check dune build --root . test/test_mcp_server_eio_call_tool.exe test/test_keeper_tool_call_log.exe
- _build-bloodflow-check/default/test/test_mcp_server_eio_call_tool.exe
- _build-bloodflow-check/default/test/test_keeper_tool_call_log.exe

## Review evidence
- Direct GLM review via `sb glm-text --system "You are a strict OCaml PR reviewer..." --temperature 0.2 --max-tokens 1200 ...`: No findings. Reviewer noted the semantic_success / semantic_outcome producer-consumer path is consistent and tests cover both semantic failure and current-task contract loading.

## Linked issue
None. This is the first implementation slice from the live keeper bloodflow diagnosis.