### PR TITLE
[codex] Add Track 2 sync boundary policy

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -390,7 +390,7 @@
    transport
    transport_bridge
    transport_read_model
-   transport_metrics
+   transport_metrics track2_sync_boundary
    ;; gRPC coordination transport (grpc-direct)
    masc_grpc_types
    masc_grpc_service

--- a/lib/track2_sync_boundary.ml
+++ b/lib/track2_sync_boundary.ml
@@ -1,0 +1,107 @@
+type layer =
+  | Authority
+  | Projection
+  | Ephemeral
+
+type writer =
+  | Ocaml_authority
+  | Sync_sidecar
+  | Dashboard_client
+
+type rejection =
+  | Not_authoritative
+  | Projection_is_read_only
+  | Ephemeral_only
+
+type admission =
+  | Accepted
+  | Rejected of rejection
+
+let layer_name = function
+  | Authority -> "authority"
+  | Projection -> "projection"
+  | Ephemeral -> "ephemeral"
+;;
+
+let writer_name = function
+  | Ocaml_authority -> "ocaml_authority"
+  | Sync_sidecar -> "sync_sidecar"
+  | Dashboard_client -> "dashboard_client"
+;;
+
+let rejection_name = function
+  | Not_authoritative -> "not_authoritative"
+  | Projection_is_read_only -> "projection_is_read_only"
+  | Ephemeral_only -> "ephemeral_only"
+;;
+
+let admit_write layer writer =
+  match layer, writer with
+  | Authority, Ocaml_authority -> Accepted
+  | Authority, (Sync_sidecar | Dashboard_client) -> Rejected Not_authoritative
+  | Projection, Ocaml_authority -> Accepted
+  | Projection, (Sync_sidecar | Dashboard_client) -> Rejected Projection_is_read_only
+  | Ephemeral, Dashboard_client -> Accepted
+  | Ephemeral, Sync_sidecar -> Accepted
+  | Ephemeral, Ocaml_authority -> Rejected Ephemeral_only
+;;
+
+let can_write layer writer =
+  match admit_write layer writer with
+  | Accepted -> true
+  | Rejected _ -> false
+;;
+
+let cluster_sizes active_agents =
+  if active_agents <= 0
+  then []
+  else if active_agents <= 5
+  then [ active_agents ]
+  else (
+    let cells = (active_agents + 4) / 5 in
+    let base = active_agents / cells in
+    let extra = active_agents mod cells in
+    List.init cells (fun index -> if index < extra then base + 1 else base))
+;;
+
+let plan_clusters agents =
+  let rec take_n n acc rest =
+    if n <= 0
+    then List.rev acc, rest
+    else (
+      match rest with
+      | [] -> List.rev acc, []
+      | head :: tail -> take_n (n - 1) (head :: acc) tail)
+  in
+  let rec loop sizes rest acc =
+    match sizes with
+    | [] -> List.rev acc
+    | size :: more ->
+      let group, rest = take_n size [] rest in
+      loop more rest (group :: acc)
+  in
+  loop (cluster_sizes (List.length agents)) agents []
+;;
+
+type frame_codec =
+  | Json_text
+  | Opaque_binary_frame
+  | Native_binary_protocol
+
+type frame_contract =
+  { codec : frame_codec
+  ; text_fallback : bool
+  ; version_negotiated : bool
+  ; semantics_preserved : bool
+  ; collaboration_specific : bool
+  }
+
+let admits_frame_contract contract =
+  contract.semantics_preserved
+  && (not contract.collaboration_specific)
+  &&
+  match contract.codec with
+  | Json_text -> true
+  | Opaque_binary_frame -> contract.text_fallback
+  | Native_binary_protocol -> contract.text_fallback && contract.version_negotiated
+;;

--- a/lib/track2_sync_boundary.mli
+++ b/lib/track2_sync_boundary.mli
@@ -1,0 +1,56 @@
+(** Track 2 synchronization boundary policy.
+
+    This module captures the small, typed contract for applying the
+    multi-agent IDE Track 2 plan without changing transport or CRDT
+    implementation code in the same slice. OCaml remains authoritative;
+    CRDT/binary layers are admitted only as projections or transport
+    envelopes. *)
+
+type layer =
+  | Authority
+  | Projection
+  | Ephemeral
+
+type writer =
+  | Ocaml_authority
+  | Sync_sidecar
+  | Dashboard_client
+
+type rejection =
+  | Not_authoritative
+  | Projection_is_read_only
+  | Ephemeral_only
+
+type admission =
+  | Accepted
+  | Rejected of rejection
+
+val layer_name : layer -> string
+val writer_name : writer -> string
+val rejection_name : rejection -> string
+val admit_write : layer -> writer -> admission
+val can_write : layer -> writer -> bool
+
+(** Track 2 local collaboration cells target three to five active agents.
+    For one or two agents, the single partial cell is preserved instead of
+    padding with synthetic participants. *)
+val cluster_sizes : int -> int list
+
+(** [plan_clusters agents] preserves input ordering and partitions the list
+    into deterministic Track 2 cells. *)
+val plan_clusters : string list -> string list list
+
+type frame_codec =
+  | Json_text
+  | Opaque_binary_frame
+  | Native_binary_protocol
+
+type frame_contract =
+  { codec : frame_codec
+  ; text_fallback : bool
+  ; version_negotiated : bool
+  ; semantics_preserved : bool
+  ; collaboration_specific : bool
+  }
+
+val admits_frame_contract : frame_contract -> bool

--- a/test/dune
+++ b/test/dune
@@ -418,6 +418,11 @@
 ; Focused single-module tests
 ; ============================================================
 (test
+ (name test_track2_sync_boundary)
+ (modules test_track2_sync_boundary)
+ (libraries masc_test_deps))
+
+(test
  (name test_meta_cognition_snapshot)
  (modules test_meta_cognition_snapshot)
  (libraries masc_test_deps))

--- a/test/test_track2_sync_boundary.ml
+++ b/test/test_track2_sync_boundary.ml
@@ -1,0 +1,128 @@
+open Alcotest
+module Boundary = Masc_mcp.Track2_sync_boundary
+
+let check_admission name expected layer writer =
+  check bool name expected (Boundary.can_write layer writer)
+;;
+
+let test_writer_admission () =
+  check_admission
+    "authority accepts OCaml writer"
+    true
+    Boundary.Authority
+    Boundary.Ocaml_authority;
+  check_admission
+    "authority rejects dashboard writer"
+    false
+    Boundary.Authority
+    Boundary.Dashboard_client;
+  check
+    string
+    "dashboard rejection reason"
+    "not_authoritative"
+    (Boundary.rejection_name
+       (match Boundary.admit_write Boundary.Authority Boundary.Dashboard_client with
+        | Boundary.Accepted -> failwith "unexpected accepted write"
+        | Boundary.Rejected reason -> reason));
+  check_admission
+    "projection is server authored"
+    true
+    Boundary.Projection
+    Boundary.Ocaml_authority;
+  check_admission
+    "projection rejects sidecar writes"
+    false
+    Boundary.Projection
+    Boundary.Sync_sidecar;
+  check_admission
+    "ephemeral accepts dashboard writes"
+    true
+    Boundary.Ephemeral
+    Boundary.Dashboard_client;
+  check_admission
+    "ephemeral rejects authoritative state writes"
+    false
+    Boundary.Ephemeral
+    Boundary.Ocaml_authority
+;;
+
+let test_cluster_sizes () =
+  check (list int) "no agents" [] (Boundary.cluster_sizes 0);
+  check (list int) "partial pair" [ 2 ] (Boundary.cluster_sizes 2);
+  check (list int) "single full cell" [ 5 ] (Boundary.cluster_sizes 5);
+  check (list int) "avoid singleton remainder" [ 3; 3 ] (Boundary.cluster_sizes 6);
+  check (list int) "balanced cells" [ 4; 4; 3 ] (Boundary.cluster_sizes 11);
+  check (list int) "twelve agent cells" [ 4; 4; 4 ] (Boundary.cluster_sizes 12)
+;;
+
+let test_plan_clusters_preserves_order () =
+  let agents = [ "a"; "b"; "c"; "d"; "e"; "f"; "g"; "h"; "i"; "j"; "k"; "l" ] in
+  check
+    (list (list string))
+    "stable 12-agent partition"
+    [ [ "a"; "b"; "c"; "d" ]; [ "e"; "f"; "g"; "h" ]; [ "i"; "j"; "k"; "l" ] ]
+    (Boundary.plan_clusters agents)
+;;
+
+let contract
+      ?(codec = Boundary.Json_text)
+      ?(text_fallback = true)
+      ?(version_negotiated = true)
+      ?(semantics_preserved = true)
+      ?(collaboration_specific = false)
+      ()
+  =
+  { Boundary.codec
+  ; text_fallback
+  ; version_negotiated
+  ; semantics_preserved
+  ; collaboration_specific
+  }
+;;
+
+let test_frame_contract () =
+  check
+    bool
+    "json text remains admitted"
+    true
+    (Boundary.admits_frame_contract (contract ()));
+  check
+    bool
+    "opaque binary requires fallback"
+    false
+    (Boundary.admits_frame_contract
+       (contract ~codec:Boundary.Opaque_binary_frame ~text_fallback:false ()));
+  check
+    bool
+    "native binary requires version negotiation"
+    false
+    (Boundary.admits_frame_contract
+       (contract ~codec:Boundary.Native_binary_protocol ~version_negotiated:false ()));
+  check
+    bool
+    "semantic drift blocks frame"
+    false
+    (Boundary.admits_frame_contract (contract ~semantics_preserved:false ()));
+  check
+    bool
+    "collaboration-specific codec stays out of boundary"
+    false
+    (Boundary.admits_frame_contract (contract ~collaboration_specific:true ()))
+;;
+
+let () =
+  run
+    "Track2_sync_boundary"
+    [ ( "writes"
+      , [ test_case "admits only layer-owned writers" `Quick test_writer_admission ] )
+    ; ( "clusters"
+      , [ test_case "sizes stay within Track 2 cells" `Quick test_cluster_sizes
+        ; test_case
+            "partitions are deterministic"
+            `Quick
+            test_plan_clusters_preserves_order
+        ] )
+    ; ( "frames"
+      , [ test_case "binary readiness is conservative" `Quick test_frame_contract ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- Add a typed Track 2 sync-boundary policy module for MASC-owned coordination state.
- Cover authority/projection/ephemeral write admission, deterministic 3-5 active-agent clustering, and binary-frame readiness contracts.
- Add focused Alcotest coverage and wire the module/test into Dune.

## Why

Track 2 from the multi-agent IDE analysis needs a concrete MASC-side boundary before any CRDT, Eg-walker-style sync, or MessagePack transport work lands. This keeps authoritative coordination state in OCaml/MASC while allowing future sync sidecars or dashboard projections to be admitted only through explicit typed contracts.

## Stack / Dependency Shape

Not stacked. This PR is independent of the OAS Track 2 boundary PR: MASC owns coordination policy, while OAS remains a domain-neutral runtime SDK.

## Bump / Pin Hygiene

- No OAS dependency bump is included in this PR.
- `scripts/check-oas-pin.sh` verified the current pinned OAS API fingerprint still matches.
- The script also warned that OAS `main` has drifted past the pinned commit; this Track 2 change does not require updating the pin because it does not consume new OAS API.

## Validation

- `ocamlformat --check lib/track2_sync_boundary.ml lib/track2_sync_boundary.mli test/test_track2_sync_boundary.ml`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/dune-local.sh runtest test/test_track2_sync_boundary.exe`
- `scripts/check-oas-pin.sh`
