### PR TITLE
[codex] Add Track 5 multi-agent presence primitives

### DIFF
--- a/dashboard/design-system/headless-core/agent-presence.test.ts
+++ b/dashboard/design-system/headless-core/agent-presence.test.ts
@@ -1,9 +1,16 @@
 // Pure TS unit tests for AgentPresenceManager. No DOM.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
+  AGENT_COLOR_PALETTE,
+  activityAnnouncement,
+  assignAgentColorSlot,
+  colorForSlot,
   createAgentPresenceManager,
+  createPresenceUpdateCoalescer,
   deriveSigil,
   kSlot,
+  summarizeActivityEvents,
+  type AgentPaletteSlot,
   type AgentDescriptor,
 } from './agent-presence'
 
@@ -172,6 +179,25 @@ describe('createAgentPresenceManager — cursor + heartbeat', () => {
     m.heartbeat('nick0cave')
     expect(m.agents.get('nick0cave')!.idleMs).toBe(0)
   })
+
+  it('updatePresence stores ephemeral role/task/selection/focus metadata', () => {
+    const m = createAgentPresenceManager({ initialAgents: [nick] })
+    m.updatePresence('nick0cave', {
+      role: 'Refactor',
+      currentTask: 'Tighten auth boundary',
+      selection: {
+        file: 'auth.ts',
+        anchor: { line: 10, column: 1 },
+        focus: { line: 12, column: 8 },
+      },
+      focus: { kind: 'symbol', id: 'auth.verify', label: 'verify' },
+    })
+    expect(m.agents.get('nick0cave')!.presence).toMatchObject({
+      role: 'Refactor',
+      currentTask: 'Tighten auth boundary',
+      updatedAt: '2026-04-29T00:00:00.000Z',
+    })
+  })
 })
 
 describe('deriveSigil + kSlot', () => {
@@ -186,12 +212,29 @@ describe('deriveSigil + kSlot', () => {
     expect(kSlot('sangsu')).toBe(kSlot('sangsu'))
   })
 
-  it('kSlot returns a slot in 1..12', () => {
+  it('kSlot stays compatible with existing 1..12 keeper CSS slots', () => {
     for (const id of ['a', 'b', 'foo', 'nick0cave', 'sangsu', 'rama']) {
       const slot = kSlot(id)
       expect(slot).toBeGreaterThanOrEqual(1)
       expect(slot).toBeLessThanOrEqual(12)
     }
+  })
+
+  it('color helpers expose the 12 keeper + 3 reserve palette', () => {
+    expect(AGENT_COLOR_PALETTE).toHaveLength(15)
+    expect(colorForSlot(1)).toBe('#E74C3C')
+    expect(colorForSlot(15)).toBe('#FF5722')
+  })
+
+  it('assignAgentColorSlot fills unused slots before falling back to hash', () => {
+    const existing = new Map<string, AgentPaletteSlot>()
+    for (let i = 1; i <= 14; i += 1) {
+      existing.set(`k${i}`, i as AgentPaletteSlot)
+    }
+    expect(assignAgentColorSlot('reserve', existing)).toBe(15)
+    existing.set('reserve', 15)
+    expect(assignAgentColorSlot('reserve', existing)).toBe(15)
+    expect(assignAgentColorSlot('overflow', existing)).toBe(kSlot('overflow'))
   })
 })
 
@@ -255,5 +298,98 @@ describe('createAgentPresenceManager — high-throughput correctness', () => {
     dispose()
     m.updateState('k0', 'thinking')
     expect(fires).toBe(12 * states.length)
+  })
+})
+
+describe('createPresenceUpdateCoalescer', () => {
+  it('coalesces many updates to latest per agent around a 33ms interval', () => {
+    const applied: string[] = []
+    const coalescer = createPresenceUpdateCoalescer((update) => {
+      applied.push(`${update.id}:${update.cursor?.line}:${update.currentTask}`)
+    })
+    coalescer.enqueue({ id: 'nick0cave', file: 'a.ts', cursor: { line: 1, column: 1 } })
+    coalescer.enqueue({
+      id: 'nick0cave',
+      file: 'a.ts',
+      cursor: { line: 2, column: 4 },
+      currentTask: 'editing',
+    })
+    coalescer.enqueue({ id: 'sangsu', file: 'b.ts', cursor: { line: 9, column: 1 } })
+    expect(applied).toEqual([])
+    vi.advanceTimersByTime(32)
+    expect(applied).toEqual([])
+    vi.advanceTimersByTime(1)
+    expect(applied).toEqual(['nick0cave:2:editing', 'sangsu:9:undefined'])
+  })
+
+  it('cancel drops pending updates', () => {
+    const applied: string[] = []
+    const coalescer = createPresenceUpdateCoalescer((update) => applied.push(update.id))
+    coalescer.enqueue({ id: 'nick0cave', currentTask: 'editing' })
+    coalescer.cancel()
+    vi.advanceTimersByTime(33)
+    expect(applied).toEqual([])
+  })
+})
+
+describe('activity primitives', () => {
+  it('summarizes activity events in five second buckets', () => {
+    const summaries = summarizeActivityEvents([
+      {
+        id: '1',
+        type: 'edit.started',
+        agentId: 'nick0cave',
+        agentName: 'nick0cave',
+        file: 'core.ts',
+        timestampMs: 1000,
+      },
+      {
+        id: '2',
+        type: 'edit.started',
+        agentId: 'nick0cave',
+        agentName: 'nick0cave',
+        file: 'core.ts',
+        timestampMs: 3200,
+      },
+      {
+        id: '3',
+        type: 'conflict.detected',
+        file: 'core.ts',
+        timestampMs: 5100,
+      },
+    ])
+    expect(summaries).toHaveLength(2)
+    expect(summaries[0]).toMatchObject({
+      type: 'edit.started',
+      count: 2,
+      agentIds: ['nick0cave'],
+      files: ['core.ts'],
+      severity: 'low',
+    })
+    expect(summaries[1]).toMatchObject({
+      type: 'conflict.detected',
+      severity: 'critical',
+    })
+  })
+
+  it('announces only screen-reader-worthy activity events', () => {
+    expect(activityAnnouncement({
+      id: '1',
+      type: 'edit.started',
+      agentId: 'nick0cave',
+      timestampMs: 0,
+    })).toBeNull()
+    expect(activityAnnouncement({
+      id: '2',
+      type: 'conflict.detected',
+      file: 'core.ts',
+      timestampMs: 0,
+    })).toEqual({ text: 'Conflict detected in core.ts', assertive: true })
+    expect(activityAnnouncement({
+      id: '3',
+      type: 'agent.completed',
+      agentName: 'sangsu',
+      timestampMs: 0,
+    })).toEqual({ text: 'sangsu completed', assertive: false })
   })
 })

--- a/dashboard/design-system/headless-core/agent-presence.ts
+++ b/dashboard/design-system/headless-core/agent-presence.ts
@@ -8,6 +8,9 @@
  *
  * MVP scope (RFC 0008 §3, §4, §5):
  *   - 6-state model (idle/working/thinking/waiting_for_human/error/completed)
+ *   - 15 color slots (12 keeper + 3 reserve)
+ *   - Ephemeral role/task/selection/focus metadata
+ *   - Latest-per-agent coalescing helper for ~30Hz cursor/presence updates
  *   - register / unregister / has / updateState / updateCursor /
  *     clearCursor / heartbeat
  *   - byState / withinFile queries
@@ -49,6 +52,50 @@ export type AgentColorSlot =
   | 11
   | 12
 
+export type AgentPaletteSlot =
+  | AgentColorSlot
+  | 13
+  | 14
+  | 15
+
+export const AGENT_COLOR_PALETTE = Object.freeze([
+  '#E74C3C',
+  '#3498DB',
+  '#2ECC71',
+  '#F39C12',
+  '#9B59B6',
+  '#1ABC9C',
+  '#E91E63',
+  '#00BCD4',
+  '#8BC34A',
+  '#FF9800',
+  '#673AB7',
+  '#795548',
+  '#607D8B',
+  '#CDDC39',
+  '#FF5722',
+] as const)
+
+export interface AgentSelectionRange {
+  readonly file: string
+  readonly anchor: { readonly line: number; readonly column: number }
+  readonly focus: { readonly line: number; readonly column: number }
+}
+
+export interface AgentFocusTarget {
+  readonly kind: 'file' | 'symbol' | 'task' | 'panel'
+  readonly id: string
+  readonly label?: string
+}
+
+export interface AgentEphemeralPresence {
+  readonly role?: string
+  readonly currentTask?: string
+  readonly selection?: AgentSelectionRange
+  readonly focus?: AgentFocusTarget
+  readonly updatedAt: string
+}
+
 export interface AgentSigil {
   readonly text: string
   readonly suffix?: string
@@ -65,6 +112,7 @@ export interface AgentRuntimeState {
   readonly state: AgentState
   readonly currentFile?: string
   readonly cursor?: { readonly line: number; readonly column: number }
+  readonly presence?: AgentEphemeralPresence
   readonly stateChangedAt: string
   readonly idleMs?: number
 }
@@ -94,6 +142,7 @@ export interface AgentPresenceManager {
 
   updateState(id: string, state: AgentState): void
   updateCursor(id: string, file: string, line: number, column: number): void
+  updatePresence(id: string, presence: AgentPresenceUpdate): void
   clearCursor(id: string): void
   heartbeat(id: string): void
 
@@ -106,6 +155,61 @@ export interface AgentPresenceManager {
   announceStateChange(id: string, prevState: AgentState): StateChangeAnnouncement | null
 
   reducedMotion(): boolean
+}
+
+export type AgentPresenceUpdate = Omit<Partial<AgentEphemeralPresence>, 'updatedAt'> & {
+  readonly updatedAt?: string
+}
+
+export interface CoalescedPresenceUpdate extends AgentPresenceUpdate {
+  readonly id: string
+  readonly file?: string
+  readonly cursor?: { readonly line: number; readonly column: number }
+}
+
+export interface PresenceUpdateCoalescer {
+  readonly intervalMs: number
+  enqueue(update: CoalescedPresenceUpdate): void
+  flush(): void
+  cancel(): void
+}
+
+export type AgentActivityEventType =
+  | 'agent.started'
+  | 'agent.completed'
+  | 'agent.error'
+  | 'conflict.detected'
+  | 'conflict.resolved'
+  | 'pr.merged'
+  | 'edit.started'
+  | 'file.locked'
+  | 'file.unlocked'
+  | 'commit.created'
+  | 'pr.opened'
+
+export type AgentActivitySeverity = 'critical' | 'high' | 'normal' | 'low'
+
+export interface AgentActivityEvent {
+  readonly id: string
+  readonly type: AgentActivityEventType
+  readonly agentId?: string
+  readonly agentName?: string
+  readonly file?: string
+  readonly message?: string
+  readonly severity?: AgentActivitySeverity
+  readonly timestampMs: number
+}
+
+export interface AgentActivitySummary {
+  readonly key: string
+  readonly type: AgentActivityEventType
+  readonly count: number
+  readonly agentIds: ReadonlyArray<string>
+  readonly files: ReadonlyArray<string>
+  readonly severity: AgentActivitySeverity
+  readonly startedAtMs: number
+  readonly endedAtMs: number
+  readonly message: string
 }
 
 const SUPERSCRIPT_DIGITS = ['¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹']
@@ -124,7 +228,7 @@ function defaultDisambiguate(
   return Object.freeze({ text: candidate.text, suffix })
 }
 
-/** FNV-1a hash mod 12, slots numbered 1..12. */
+/** FNV-1a hash mod 12, slots numbered 1..12 for existing --k-N tokens. */
 export function kSlot(id: string): AgentColorSlot {
   let hash = 0x811c9dc5
   for (let i = 0; i < id.length; i += 1) {
@@ -137,6 +241,23 @@ export function kSlot(id: string): AgentColorSlot {
   return slot as AgentColorSlot
 }
 
+export function colorForSlot(slot: AgentPaletteSlot): string {
+  return AGENT_COLOR_PALETTE[slot - 1]!
+}
+
+export function assignAgentColorSlot(
+  agentId: string,
+  existing: ReadonlyMap<string, AgentPaletteSlot>,
+): AgentPaletteSlot {
+  const current = existing.get(agentId)
+  if (current !== undefined) return current
+  const used = new Set(existing.values())
+  for (let slot = 1; slot <= AGENT_COLOR_PALETTE.length; slot += 1) {
+    if (!used.has(slot as AgentPaletteSlot)) return slot as AgentPaletteSlot
+  }
+  return kSlot(agentId)
+}
+
 export function deriveSigil(name: string): AgentSigil {
   const cleaned = name.replace(/[^A-Za-z]/g, '').toUpperCase()
   const text = cleaned.length >= 2 ? cleaned.slice(0, 2) : cleaned.padEnd(2, '?')
@@ -145,6 +266,17 @@ export function deriveSigil(name: string): AgentSigil {
 
 function nowIso(): string {
   return new Date().toISOString()
+}
+
+function freezePresence(update: AgentPresenceUpdate): AgentEphemeralPresence {
+  const updatedAt = update.updatedAt ?? nowIso()
+  return Object.freeze({
+    role: update.role,
+    currentTask: update.currentTask,
+    selection: update.selection,
+    focus: update.focus,
+    updatedAt,
+  })
 }
 
 export function createAgentPresenceManager(
@@ -217,6 +349,7 @@ export function createAgentPresenceManager(
         state: prior?.state ?? 'idle',
         currentFile: prior?.currentFile,
         cursor: prior?.cursor,
+        presence: prior?.presence,
         stateChangedAt: prior?.stateChangedAt ?? nowIso(),
         idleMs: prior?.idleMs,
       })
@@ -253,6 +386,22 @@ export function createAgentPresenceManager(
         ...prior,
         currentFile: file,
         cursor: Object.freeze({ line, column }),
+      })
+      setAgent(next)
+    },
+
+    updatePresence(id: string, presence: AgentPresenceUpdate): void {
+      const prior = map.get(id)
+      if (prior === undefined) return
+      const next: Agent = Object.freeze({
+        ...prior,
+        presence: freezePresence({
+          role: presence.role ?? prior.presence?.role,
+          currentTask: presence.currentTask ?? prior.presence?.currentTask,
+          selection: presence.selection ?? prior.presence?.selection,
+          focus: presence.focus ?? prior.presence?.focus,
+          updatedAt: presence.updatedAt,
+        }),
       })
       setAgent(next)
     },
@@ -338,5 +487,161 @@ export function createAgentPresenceManager(
     reducedMotion(): boolean {
       return reducedMotionFn()
     },
+  }
+}
+
+export function createPresenceUpdateCoalescer(
+  apply: (update: CoalescedPresenceUpdate) => void,
+  opts?: {
+    readonly intervalMs?: number
+    readonly setTimeout?: (fn: () => void, ms: number) => unknown
+    readonly clearTimeout?: (handle: unknown) => void
+  },
+): PresenceUpdateCoalescer {
+  const intervalMs = opts?.intervalMs ?? 33
+  const setTimer = opts?.setTimeout ?? ((fn, ms) => globalThis.setTimeout(fn, ms))
+  const clearTimer = opts?.clearTimeout ?? ((handle) => globalThis.clearTimeout(handle as never))
+  const pending = new Map<string, CoalescedPresenceUpdate>()
+  let timer: unknown | undefined
+
+  function schedule(): void {
+    if (timer !== undefined) return
+    timer = setTimer(() => {
+      timer = undefined
+      coalescer.flush()
+    }, intervalMs)
+  }
+
+  const coalescer: PresenceUpdateCoalescer = {
+    intervalMs,
+
+    enqueue(update: CoalescedPresenceUpdate): void {
+      pending.set(update.id, Object.freeze({ ...pending.get(update.id), ...update }))
+      schedule()
+    },
+
+    flush(): void {
+      if (timer !== undefined) {
+        clearTimer(timer)
+        timer = undefined
+      }
+      const updates = [...pending.values()]
+      pending.clear()
+      for (const update of updates) apply(update)
+    },
+
+    cancel(): void {
+      if (timer !== undefined) {
+        clearTimer(timer)
+        timer = undefined
+      }
+      pending.clear()
+    },
+  }
+
+  return coalescer
+}
+
+const SEVERITY_RANK: Record<AgentActivitySeverity, number> = {
+  low: 0,
+  normal: 1,
+  high: 2,
+  critical: 3,
+}
+
+function maxSeverity(events: ReadonlyArray<AgentActivityEvent>): AgentActivitySeverity {
+  let best: AgentActivitySeverity = 'low'
+  for (const event of events) {
+    const next = event.severity ?? defaultSeverity(event.type)
+    if (SEVERITY_RANK[next] > SEVERITY_RANK[best]) best = next
+  }
+  return best
+}
+
+function defaultSeverity(type: AgentActivityEventType): AgentActivitySeverity {
+  switch (type) {
+    case 'agent.error':
+    case 'conflict.detected':
+      return 'critical'
+    case 'conflict.resolved':
+    case 'pr.merged':
+      return 'high'
+    case 'agent.started':
+    case 'agent.completed':
+      return 'normal'
+    default:
+      return 'low'
+  }
+}
+
+export function summarizeActivityEvents(
+  events: ReadonlyArray<AgentActivityEvent>,
+  opts?: { readonly windowMs?: number },
+): ReadonlyArray<AgentActivitySummary> {
+  const windowMs = opts?.windowMs ?? 5000
+  const buckets = new Map<string, AgentActivityEvent[]>()
+  for (const event of events) {
+    const windowStart = Math.floor(event.timestampMs / windowMs) * windowMs
+    const key = `${windowStart}:${event.agentId ?? '*'}:${event.type}:${event.file ?? '*'}`
+    const bucket = buckets.get(key)
+    if (bucket === undefined) buckets.set(key, [event])
+    else bucket.push(event)
+  }
+
+  const summaries: AgentActivitySummary[] = []
+  for (const [key, bucket] of buckets) {
+    const sorted = [...bucket].sort((a, b) => a.timestampMs - b.timestampMs)
+    const first = sorted[0]
+    const last = sorted[sorted.length - 1]
+    if (first === undefined || last === undefined) continue
+    const agentIds = [...new Set(sorted.flatMap((e) => (e.agentId === undefined ? [] : [e.agentId])))]
+    const files = [...new Set(sorted.flatMap((e) => (e.file === undefined ? [] : [e.file])))]
+    const count = sorted.length
+    const actor = first.agentName ?? first.agentId ?? 'System'
+    const target = files.length === 0 ? '' : ` in ${files.join(', ')}`
+    const message = count === 1
+      ? first.message ?? `${actor} ${first.type}${target}`
+      : `${actor} ${first.type} x${count}${target}`
+    summaries.push(Object.freeze({
+      key,
+      type: first.type,
+      count,
+      agentIds: Object.freeze(agentIds),
+      files: Object.freeze(files),
+      severity: maxSeverity(sorted),
+      startedAtMs: first.timestampMs,
+      endedAtMs: last.timestampMs,
+      message,
+    }))
+  }
+
+  return Object.freeze(summaries.sort((a, b) => a.startedAtMs - b.startedAtMs))
+}
+
+export function activityAnnouncement(
+  event: AgentActivityEvent,
+): StateChangeAnnouncement | null {
+  const name = event.agentName ?? event.agentId ?? 'Agent'
+  switch (event.type) {
+    case 'agent.started':
+      return Object.freeze({ text: `${name} started`, assertive: false })
+    case 'agent.completed':
+      return Object.freeze({ text: `${name} completed`, assertive: false })
+    case 'agent.error':
+      return Object.freeze({ text: `${name} reported an error`, assertive: true })
+    case 'conflict.detected':
+      return Object.freeze({
+        text: `Conflict detected${event.file === undefined ? '' : ` in ${event.file}`}`,
+        assertive: true,
+      })
+    case 'conflict.resolved':
+      return Object.freeze({
+        text: `Conflict resolved${event.file === undefined ? '' : ` in ${event.file}`}`,
+        assertive: false,
+      })
+    case 'pr.merged':
+      return Object.freeze({ text: event.message ?? 'Pull request merged', assertive: false })
+    default:
+      return null
   }
 }


### PR DESCRIPTION
## Summary

- extend dashboard headless agent presence with ephemeral role, task, selection, focus, and timestamp metadata
- add a latest-per-agent presence update coalescer for roughly 30Hz cursor/presence traffic
- add Track 5 activity primitives: 5s aggregation summaries, severity defaults, and screen-reader announcement filtering
- expose a 15-color palette while keeping existing `kSlot()` compatibility with the current 1..12 keeper CSS token contract

## Why

Track 5 calls for multi-agent IDE/cockpit primitives: presence, activity feed aggregation, collision/conflict surfacing, and accessible announcements. This PR keeps the first MASC slice in the design-system headless layer so dashboard surfaces can consume it without hardwiring a specific panel layout yet.

## Stack

Builds downstream of the generic OAS collaboration projection foundation in https://github.com/jeong-sik/oas/pull/1260. The repos are separate, so this is a logical stack rather than a Git branch stack.

## Validation

- `pnpm exec vitest run --no-file-parallelism --maxWorkers=1 design-system/headless-core/agent-presence.test.ts`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`