### PR TITLE
[codex] Surface observation-driven coordination state

### DIFF
--- a/lib/coordination_product.ml
+++ b/lib/coordination_product.ml
@@ -88,6 +88,21 @@ let severity_to_string = function
   | Error -> "error"
 ;;
 
+type observation_principle =
+  | Observable_updates
+  | Deterministic_convergence
+  | Monotonic_progress
+
+let observation_principle_to_string = function
+  | Observable_updates -> "observable_updates"
+  | Deterministic_convergence -> "deterministic_convergence"
+  | Monotonic_progress -> "monotonic_progress"
+;;
+
+let observation_driven_principles =
+  [ Observable_updates; Deterministic_convergence; Monotonic_progress ]
+;;
+
 type ids =
   { goal_id : string option
   ; task_ids : string list
@@ -148,6 +163,91 @@ let task_phase_of_counts statuses =
     if List.for_all (fun status -> task_phase_of_status status = first_phase) rest
     then first_phase
     else Mixed
+;;
+
+type claim_observation =
+  { task_id : string
+  ; owner : string
+  ; phase : task_phase
+  }
+
+type duplicate_active_claim =
+  { task_id : string
+  ; owners : string list
+  }
+
+type turn_queue_entry =
+  { task_id : string
+  ; priority : int
+  ; created_at : string
+  }
+
+let active_owner_of_status = function
+  | Types.Claimed { assignee; _ }
+  | Types.InProgress { assignee; _ }
+  | Types.AwaitingVerification { assignee; _ } -> Some assignee
+  | Types.Todo | Types.Done _ | Types.Cancelled _ -> None
+;;
+
+let active_claim_observation (task : Types.task) =
+  active_owner_of_status task.task_status
+  |> Option.map (fun owner ->
+    { task_id = task.id; owner; phase = task_phase_of_status task.task_status })
+;;
+
+let active_claims tasks = List.filter_map active_claim_observation tasks
+
+let normalize_strings values =
+  values
+  |> List.map String.trim
+  |> List.filter (fun value -> value <> "")
+  |> List.sort_uniq String.compare
+;;
+
+let duplicate_active_claims tasks : duplicate_active_claim list =
+  let owners_by_task_id = Hashtbl.create (List.length tasks) in
+  tasks
+  |> active_claims
+  |> List.iter (fun (observation : claim_observation) ->
+    let owners =
+      match Hashtbl.find_opt owners_by_task_id observation.task_id with
+      | Some owners -> owners
+      | None -> []
+    in
+    Hashtbl.replace owners_by_task_id observation.task_id (observation.owner :: owners));
+  Hashtbl.fold
+    (fun task_id owners acc ->
+       match normalize_strings owners with
+       | _ :: _ :: _ as owners -> ({ task_id; owners } : duplicate_active_claim) :: acc
+       | [] | [ _ ] -> acc)
+    owners_by_task_id
+    []
+  |> List.sort (fun (left : duplicate_active_claim) right ->
+    String.compare left.task_id right.task_id)
+;;
+
+let compare_turn_queue_entry left right =
+  let priority_cmp = Int.compare left.priority right.priority in
+  if priority_cmp <> 0
+  then priority_cmp
+  else (
+    let created_cmp = String.compare left.created_at right.created_at in
+    if created_cmp <> 0 then created_cmp else String.compare left.task_id right.task_id)
+;;
+
+let visible_claim_queue tasks =
+  tasks
+  |> List.filter_map (fun (task : Types.task) ->
+    match task.task_status, task.do_not_reclaim_reason with
+    | Types.Todo, None ->
+      Some { task_id = task.id; priority = task.priority; created_at = task.created_at }
+    | Types.Todo, Some _
+    | Types.Claimed _, _
+    | Types.InProgress _, _
+    | Types.AwaitingVerification _, _
+    | Types.Done _, _
+    | Types.Cancelled _, _ -> None)
+  |> List.sort compare_turn_queue_entry
 ;;
 
 type facts =
@@ -245,6 +345,26 @@ type violation =
   ; message : string
   ; ids : ids
   }
+
+let observation_driven_violations tasks =
+  duplicate_active_claims tasks
+  |> List.map (fun (duplicate : duplicate_active_claim) ->
+    { axis = Task
+    ; code = "duplicate_active_claim_owners"
+    ; severity = Error
+    ; message =
+        Printf.sprintf
+          "Task %s has multiple active owners in the observed shared state: %s."
+          duplicate.task_id
+          (String.concat ", " duplicate.owners)
+    ; ids =
+        { goal_id = None
+        ; task_ids = [ duplicate.task_id ]
+        ; post_ids = []
+        ; agent_name = None
+        }
+    })
+;;
 
 let reward_phase_of_facts
       ~economy_enabled

--- a/lib/coordination_product.mli
+++ b/lib/coordination_product.mli
@@ -52,6 +52,14 @@ type severity =
 
 val severity_to_string : severity -> string
 
+type observation_principle =
+  | Observable_updates
+  | Deterministic_convergence
+  | Monotonic_progress
+
+val observation_principle_to_string : observation_principle -> string
+val observation_driven_principles : observation_principle list
+
 type ids =
   { goal_id : string option
   ; task_ids : string list
@@ -82,6 +90,28 @@ val empty_task_counts : task_counts
 val task_counts_of_statuses : Types.task_status list -> task_counts
 val task_phase_of_counts : Types.task_status list -> task_phase
 val task_counts_to_yojson : task_counts -> Yojson.Safe.t
+
+type claim_observation =
+  { task_id : string
+  ; owner : string
+  ; phase : task_phase
+  }
+
+type duplicate_active_claim =
+  { task_id : string
+  ; owners : string list
+  }
+
+type turn_queue_entry =
+  { task_id : string
+  ; priority : int
+  ; created_at : string
+  }
+
+val active_claim_observation : Types.task -> claim_observation option
+val active_claims : Types.task list -> claim_observation list
+val duplicate_active_claims : Types.task list -> duplicate_active_claim list
+val visible_claim_queue : Types.task list -> turn_queue_entry list
 
 type facts =
   { economy_enabled : bool
@@ -149,6 +179,8 @@ type violation =
   ; message : string
   ; ids : ids
   }
+
+val observation_driven_violations : Types.task list -> violation list
 
 val reward_phase_of_facts
   :  economy_enabled:bool

--- a/lib/coordination_product_snapshot.ml
+++ b/lib/coordination_product_snapshot.ml
@@ -605,7 +605,11 @@ let project state =
         ~persist_errors:state.persist_errors
         ~economy_enabled:state.economy_enabled)
   in
-  Coordination_product.snapshot (goal_products @ unlinked_task_products)
+  let snapshot = Coordination_product.snapshot (goal_products @ unlinked_task_products) in
+  { snapshot with
+    violations =
+      snapshot.violations @ Coordination_product.observation_driven_violations all_tasks
+  }
 ;;
 
 let build config = config |> capture |> project

--- a/test/test_coordination_product.ml
+++ b/test/test_coordination_product.ml
@@ -156,6 +156,63 @@ let test_task_axis_projection () =
     (CP.task_phase_to_string (CP.task_phase_of_counts [ done_status; cancelled_status ]))
 ;;
 
+let test_observation_principles_are_stable () =
+  Alcotest.(check (list string))
+    "principles"
+    [ "observable_updates"; "deterministic_convergence"; "monotonic_progress" ]
+    (List.map CP.observation_principle_to_string CP.observation_driven_principles)
+;;
+
+let test_visible_claim_queue_is_deterministic () =
+  let tasks =
+    [ task ~id:"claimed" ~title:"Claimed" ~task_status:claimed_status ()
+    ; task ~id:"later" ~title:"Later" ()
+    ; task ~id:"earlier" ~title:"Earlier" ()
+    ]
+  in
+  let tasks =
+    List.map
+      (fun (task : Types.task) ->
+         if String.equal task.id "later"
+         then { task with priority = 2; created_at = "2026-04-24T02:00:00Z" }
+         else if String.equal task.id "earlier"
+         then { task with priority = 1; created_at = "2026-04-24T01:00:00Z" }
+         else task)
+      tasks
+  in
+  let queue = CP.visible_claim_queue tasks in
+  Alcotest.(check (list string))
+    "queue"
+    [ "earlier"; "later" ]
+    (List.map (fun (entry : CP.turn_queue_entry) -> entry.task_id) queue)
+;;
+
+let test_duplicate_active_claim_violation () =
+  let tasks =
+    [ task
+        ~id:"task-dup"
+        ~title:"First owner"
+        ~task_status:
+          (Types.Claimed { assignee = "worker-a"; claimed_at = "2026-04-24T00:00:00Z" })
+        ()
+    ; task
+        ~id:"task-dup"
+        ~title:"Second owner"
+        ~task_status:
+          (Types.InProgress { assignee = "worker-b"; started_at = "2026-04-24T00:01:00Z" })
+        ()
+    ; task ~id:"task-open" ~title:"Open" ()
+    ]
+  in
+  let duplicates = CP.duplicate_active_claims tasks in
+  (match duplicates with
+   | [ { CP.task_id = "task-dup"; owners } ] ->
+     Alcotest.(check (list string)) "owners" [ "worker-a"; "worker-b" ] owners
+   | _ -> Alcotest.fail "expected one duplicate active claim");
+  let violations = CP.observation_driven_violations tasks in
+  check_has_code "duplicate_active_claim_owners" violations
+;;
+
 let test_goal_linkage_prefers_structured_goal_id () =
   let explicit =
     task ~id:"task-1" ~title:"Implement product FSM" ~goal_id:"goal-1" ()
@@ -380,7 +437,21 @@ let test_projection_is_deterministic_from_captured_state () =
 let () =
   Alcotest.run
     "Coordination_product"
-    [ "task_axis", [ Alcotest.test_case "projection" `Quick test_task_axis_projection ]
+    [ ( "task_axis"
+      , [ Alcotest.test_case "projection" `Quick test_task_axis_projection
+        ; Alcotest.test_case
+            "observation principles"
+            `Quick
+            test_observation_principles_are_stable
+        ; Alcotest.test_case
+            "visible claim queue"
+            `Quick
+            test_visible_claim_queue_is_deterministic
+        ; Alcotest.test_case
+            "duplicate active claim owners"
+            `Quick
+            test_duplicate_active_claim_violation
+        ] )
     ; ( "goal_linkage"
       , [ Alcotest.test_case
             "structured goal_id matcher"


### PR DESCRIPTION
## Summary

- Add MASC-side Track 3 observation principles for coordination product reporting.
- Project active task claims, visible claim queue entries, and duplicate active claim-owner violations.
- Include duplicate active owner findings in coordination product snapshots.
- Add focused tests for stable principles, deterministic visible queue ordering, and duplicate active claim detection.

## Stack

1. OAS substrate: https://github.com/jeong-sik/oas/pull/1262
2. This PR: MASC product/runtime mapping of Track 3 semantics.

These are different repositories, so this PR cannot use the OAS branch as its GitHub base branch. The review order is still OAS first, then this MASC mapping.

## Impact

Operators get a concrete dashboard/snapshot signal when the observed shared task state has multiple active owners for the same task. The implementation keeps MASC keeper/task semantics in MASC and does not move them into OAS.

## Validation

- `scripts/dune-local.sh build test/test_coordination_product.exe`
- `./_build/default/test/test_coordination_product.exe`