### PR TITLE
feat(multimodal): Tier K3 — Tool_emission deterministic detector (Cycle 27)

### DIFF
--- a/lib/multimodal/tool_emission.ml
+++ b/lib/multimodal/tool_emission.ml
@@ -1,0 +1,66 @@
+(* Tool_emission — see tool_emission.mli for design. *)
+
+let multimodal_kind_key = "__multimodal_kind"
+let multimodal_id_key = "__multimodal_id"
+let multimodal_metadata_key = "__multimodal_metadata"
+
+let lookup_string (result : Yojson.Safe.t) (key : string) : string option =
+  match result with
+  | `Assoc kv -> (
+      match List.assoc_opt key kv with
+      | Some (`String s) -> Some s
+      | _ -> None)
+  | _ -> None
+
+let lookup_field (result : Yojson.Safe.t) (key : string)
+    : Yojson.Safe.t option =
+  match result with
+  | `Assoc kv -> List.assoc_opt key kv
+  | _ -> None
+
+let extract_kind_from_result (result : Yojson.Safe.t)
+    : Artifact.kind_tag option =
+  match lookup_string result multimodal_kind_key with
+  | Some s -> Multimodal_keeper_bridge.parse_kind_hint s
+  | None -> None
+
+let extract_id_from_result (result : Yojson.Safe.t) : string option =
+  lookup_string result multimodal_id_key
+
+let strip_reserved_keys (result : Yojson.Safe.t) : Yojson.Safe.t =
+  match result with
+  | `Assoc kv ->
+      let reserved =
+        [
+          multimodal_kind_key;
+          multimodal_id_key;
+          multimodal_metadata_key;
+        ]
+      in
+      `Assoc (List.filter (fun (k, _) -> not (List.mem k reserved)) kv)
+  | other -> other
+
+let emit_from_tool_result
+    ~(working_context : Yojson.Safe.t option)
+    ~(result : Yojson.Safe.t) : Yojson.Safe.t option =
+  match extract_kind_from_result result with
+  | None -> working_context
+  | Some kind_tag -> (
+      match extract_id_from_result result with
+      | None -> working_context
+      | Some id ->
+          let metadata =
+            match lookup_field result multimodal_metadata_key with
+            | Some (`Assoc _ as m) -> m
+            | _ -> `Assoc []
+          in
+          let payload_json = strip_reserved_keys result in
+          Keeper_emitter.emit ~working_context ~id ~kind_tag
+            ~payload_json ~metadata)
+
+let emit_from_tool_results
+    ~(working_context : Yojson.Safe.t option)
+    (results : Yojson.Safe.t list) : Yojson.Safe.t option =
+  List.fold_left
+    (fun wc result -> emit_from_tool_result ~working_context:wc ~result)
+    working_context results

--- a/lib/multimodal/tool_emission.mli
+++ b/lib/multimodal/tool_emission.mli
@@ -1,0 +1,95 @@
+(** Tool-result → multimodal emission.
+
+    Cycle 27 / Tier K3 — the next layer above {!Keeper_emitter}.
+
+    {1 What this module is}
+
+    A pure converter from a single tool-call result to (optionally)
+    one [working_context] update with a new
+    {!Multimodal_keeper_bridge.raw_artifact} entry, gated by an
+    {b explicit} tag on the tool result.
+
+    The contract: a tool wishing to register a multimodal artifact
+    sets two reserved fields on its JSON output —
+
+    {[
+      {
+        "__multimodal_kind": "code" | "image" | "audio" | "doc",
+        "__multimodal_id": "<uuid v7 string>",
+        "...rest of the tool's regular output..."
+      }
+    ]}
+
+    No tag → the tool result is opaque to the multimodal pipeline.
+
+    {1 Why explicit tagging instead of heuristics}
+
+    Tool name regex (e.g. ["matches /image/i"]) silently drifts
+    when tool surfaces are renamed and silently mis-classifies new
+    tools that happen to match. The explicit-tag protocol is
+    deterministic: a tool either opts in or it does not.
+
+    Reference: [feedback_no-string-matching-classification.md].
+
+    {1 Scope of this PR}
+
+    - {!extract_kind_from_result}: lookup
+      [__multimodal_kind] and parse via
+      {!Multimodal_keeper_bridge.parse_kind_hint}. Returns [None]
+      on missing key, malformed payload, or unknown kind.
+    - {!emit_from_tool_result}: detector + emitter chain. When the
+      result carries no tag, returns the [working_context]
+      unchanged.
+    - {!emit_from_tool_results}: bulk variant.
+
+    The tag-emission contract on the tool side is left to
+    follow-up PRs (tool surface adapters). *)
+
+val multimodal_kind_key : string
+(** ["__multimodal_kind"] — the reserved JSON key carrying the
+    artifact kind hint. Exposed so tool authors can use the same
+    constant. *)
+
+val multimodal_id_key : string
+(** ["__multimodal_id"] — the reserved JSON key carrying the
+    artifact id. *)
+
+val multimodal_metadata_key : string
+(** ["__multimodal_metadata"] — optional reserved key. When
+    present its [`Assoc] value is forwarded as the artifact's
+    metadata; otherwise an empty assoc is used. *)
+
+val extract_kind_from_result :
+  Yojson.Safe.t -> Artifact.kind_tag option
+(** [extract_kind_from_result result] reads
+    [result[multimodal_kind_key]] and parses it via
+    {!Multimodal_keeper_bridge.parse_kind_hint}. Returns [None]
+    when the key is absent, the value is not a string, or the
+    string is not one of [code]/[image]/[audio]/[doc]. *)
+
+val extract_id_from_result : Yojson.Safe.t -> string option
+(** [extract_id_from_result result] reads
+    [result[multimodal_id_key]]. Returns [None] when the key is
+    absent or the value is not a string. *)
+
+val emit_from_tool_result :
+  working_context:Yojson.Safe.t option ->
+  result:Yojson.Safe.t ->
+  Yojson.Safe.t option
+(** [emit_from_tool_result ~working_context ~result] is the chain:
+
+    + extract [__multimodal_kind] (else return [working_context]);
+    + extract [__multimodal_id] (else return [working_context]);
+    + read optional [__multimodal_metadata];
+    + call {!Keeper_emitter.emit} with the tool result {b minus}
+      the reserved keys as the payload.
+
+    The reserved-key strip ensures the artifact's
+    [payload_json] does not duplicate the kind/id/metadata
+    already stored in dedicated [raw_artifact] fields. *)
+
+val emit_from_tool_results :
+  working_context:Yojson.Safe.t option ->
+  Yojson.Safe.t list ->
+  Yojson.Safe.t option
+(** Bulk variant — folds {!emit_from_tool_result} over the list. *)

--- a/test/dune
+++ b/test/dune
@@ -1773,6 +1773,11 @@
  (modules test_k2_pipeline_e2e)
  (libraries masc_test_deps multimodal shared_types yojson))
 
+(test
+ (name test_k3_tool_pipeline_e2e)
+ (modules test_k3_tool_pipeline_e2e)
+ (libraries masc_test_deps multimodal shared_types yojson))
+
 (executable
  (name test_concurrent_distributed)
  (modules test_concurrent_distributed)

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id test_multimodal_keeper_bridge test_workspace_holder test_wirein_helpers test_keeper_emitter)
+ (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id test_multimodal_keeper_bridge test_workspace_holder test_wirein_helpers test_keeper_emitter test_tool_emission)
  (libraries multimodal shared_types yojson str unix))

--- a/test/multimodal/test_tool_emission.ml
+++ b/test/multimodal/test_tool_emission.ml
@@ -1,0 +1,163 @@
+(* Tier K3 — Multimodal.Tool_emission unit tests. *)
+
+module T = Multimodal.Tool_emission
+module A = Multimodal.Artifact
+
+let test_extract_kind_present () =
+  let result =
+    `Assoc
+      [
+        (T.multimodal_kind_key, `String "image");
+        ("other", `String "x");
+      ]
+  in
+  assert (T.extract_kind_from_result result = Some A.Tag_image);
+  print_endline "  extract_kind_present: OK"
+
+let test_extract_kind_absent () =
+  let result = `Assoc [ ("other", `String "x") ] in
+  assert (T.extract_kind_from_result result = None);
+  print_endline "  extract_kind_absent: OK"
+
+let test_extract_kind_unknown_string () =
+  let result =
+    `Assoc [ (T.multimodal_kind_key, `String "video") ]
+  in
+  assert (T.extract_kind_from_result result = None);
+  print_endline "  extract_kind_unknown_string: OK"
+
+let test_extract_kind_non_string () =
+  let result = `Assoc [ (T.multimodal_kind_key, `Int 1) ] in
+  assert (T.extract_kind_from_result result = None);
+  print_endline "  extract_kind_non_string: OK"
+
+let test_extract_kind_non_assoc () =
+  assert (T.extract_kind_from_result (`String "image") = None);
+  assert (T.extract_kind_from_result `Null = None);
+  print_endline "  extract_kind_non_assoc: OK"
+
+let test_extract_id () =
+  let result =
+    `Assoc [ (T.multimodal_id_key, `String "01900000-0000-7000-8000-000000000001") ]
+  in
+  assert (
+    T.extract_id_from_result result
+    = Some "01900000-0000-7000-8000-000000000001");
+  print_endline "  extract_id: OK"
+
+let test_emit_no_tag_returns_unchanged () =
+  let initial = Some (`Assoc [ ("preserve", `String "yes") ]) in
+  let result =
+    `Assoc
+      [
+        ("just_data", `String "regular tool output");
+        ("count", `Int 42);
+      ]
+  in
+  let wc = T.emit_from_tool_result ~working_context:initial ~result in
+  assert (wc = initial);
+  print_endline "  emit_no_tag_returns_unchanged: OK"
+
+let test_emit_missing_id_returns_unchanged () =
+  let initial = None in
+  let result =
+    `Assoc [ (T.multimodal_kind_key, `String "code") ]
+  in
+  let wc = T.emit_from_tool_result ~working_context:initial ~result in
+  assert (wc = initial);
+  print_endline "  emit_missing_id_returns_unchanged: OK"
+
+let test_emit_strips_reserved_keys_from_payload () =
+  let result =
+    `Assoc
+      [
+        (T.multimodal_kind_key, `String "code");
+        (T.multimodal_id_key, `String "01900000-0000-7000-8000-000000000010");
+        (T.multimodal_metadata_key, `Assoc [ ("lang", `String "ml") ]);
+        ("source", `String "let x = 1");
+      ]
+  in
+  let wc =
+    T.emit_from_tool_result ~working_context:None ~result
+  in
+  let raws, _ = Multimodal.Wirein_helpers.extract_raw_artifacts wc in
+  assert (List.length raws = 1);
+  let raw = List.hd raws in
+  assert (raw.Multimodal.Multimodal_keeper_bridge.kind_hint = "code");
+  (* payload_json should contain only "source", reserved keys stripped. *)
+  (match raw.payload_json with
+   | `Assoc kv ->
+       assert (List.assoc_opt "source" kv = Some (`String "let x = 1"));
+       assert (List.assoc_opt T.multimodal_kind_key kv = None);
+       assert (List.assoc_opt T.multimodal_id_key kv = None);
+       assert (List.assoc_opt T.multimodal_metadata_key kv = None)
+   | _ -> assert false);
+  (* metadata forwarded from __multimodal_metadata. *)
+  (match raw.metadata with
+   | `Assoc kv ->
+       assert (List.assoc_opt "lang" kv = Some (`String "ml"))
+   | _ -> assert false);
+  print_endline "  emit_strips_reserved_keys: OK"
+
+let test_emit_metadata_default_when_absent () =
+  let result =
+    `Assoc
+      [
+        (T.multimodal_kind_key, `String "doc");
+        (T.multimodal_id_key, `String "01900000-0000-7000-8000-000000000020");
+        ("body", `String "# Title");
+      ]
+  in
+  let wc =
+    T.emit_from_tool_result ~working_context:None ~result
+  in
+  let raws, _ = Multimodal.Wirein_helpers.extract_raw_artifacts wc in
+  let raw = List.hd raws in
+  assert (raw.metadata = `Assoc []);
+  print_endline "  emit_metadata_defaults_to_empty_assoc: OK"
+
+let test_emit_from_tool_results_bulk () =
+  let r1 =
+    `Assoc
+      [
+        (T.multimodal_kind_key, `String "code");
+        (T.multimodal_id_key, `String "01900000-0000-7000-8000-000000000030");
+      ]
+  in
+  let r2 =
+    `Assoc
+      [
+        (T.multimodal_kind_key, `String "image");
+        (T.multimodal_id_key, `String "01900000-0000-7000-8000-000000000031");
+      ]
+  in
+  (* untagged result — should be ignored *)
+  let r3 = `Assoc [ ("regular", `String "data") ] in
+  let r4 =
+    `Assoc
+      [
+        (T.multimodal_kind_key, `String "audio");
+        (T.multimodal_id_key, `String "01900000-0000-7000-8000-000000000032");
+      ]
+  in
+  let wc =
+    T.emit_from_tool_results ~working_context:None [ r1; r2; r3; r4 ]
+  in
+  let raws, _ = Multimodal.Wirein_helpers.extract_raw_artifacts wc in
+  assert (List.length raws = 3);
+  print_endline "  emit_bulk_skips_untagged: OK"
+
+let () =
+  print_endline "=== Tool_emission ===";
+  test_extract_kind_present ();
+  test_extract_kind_absent ();
+  test_extract_kind_unknown_string ();
+  test_extract_kind_non_string ();
+  test_extract_kind_non_assoc ();
+  test_extract_id ();
+  test_emit_no_tag_returns_unchanged ();
+  test_emit_missing_id_returns_unchanged ();
+  test_emit_strips_reserved_keys_from_payload ();
+  test_emit_metadata_default_when_absent ();
+  test_emit_from_tool_results_bulk ();
+  print_endline "=== Tool_emission: 11/11 OK ==="

--- a/test/test_k3_tool_pipeline_e2e.ml
+++ b/test/test_k3_tool_pipeline_e2e.ml
@@ -1,0 +1,193 @@
+(* Tier K3 — tool-result → multimodal pipeline e2e.
+
+   Layer above K2: K2 proved the producer/consumer chain works
+   when something explicitly calls Keeper_emitter.emit. K3 proves
+   that {b tool authors do not need to know about Keeper_emitter}
+   — they only need to mark their JSON output with two reserved
+   keys, and Tool_emission turns the result into the same chain.
+
+   Pipeline:
+
+     tool surface
+       │
+       │ emits result_json with __multimodal_kind / __multimodal_id
+       ▼
+     Tool_emission.emit_from_tool_results  ← K3 (this PR)
+       │
+       ▼ working_context["multimodal_artifacts"]
+       │
+       │ Wirein_helpers.extract_raw_artifacts ← K1
+       │ Multimodal_keeper_bridge.hydrate    ← W3
+       │ Workspace_holder.update              ← K1
+       │ list_response                        ← D1
+       ▼ dashboard JSON
+
+   The test mixes 4 tagged tool results with 2 untagged ones to
+   verify that the detector ignores untagged outputs. *)
+
+module H = Multimodal.Workspace_holder
+module W = Multimodal.Workspace
+module B = Multimodal.Multimodal_keeper_bridge
+module Wirein = Multimodal.Wirein_helpers
+module T = Multimodal.Tool_emission
+module Routes = Masc_mcp.Server_routes_http_routes_multimodal
+
+let now = 1_700_001_000.0
+
+let assert_eq_int ~label expected actual =
+  if expected <> actual then (
+    Printf.printf "FAIL [%s]: expected %d, actual %d\n" label expected actual;
+    exit 1)
+
+let pluck_count_field json =
+  match json with
+  | `Assoc kv -> (
+      match List.assoc_opt "count" kv with
+      | Some (`Int n) -> n
+      | _ -> -1)
+  | _ -> -1
+
+let pluck_artifacts_field json =
+  match json with
+  | `Assoc kv -> (
+      match List.assoc_opt "artifacts" kv with
+      | Some (`List xs) -> xs
+      | _ -> [])
+  | _ -> []
+
+let make_tagged ~kind ~id ~payload_extra ~metadata : Yojson.Safe.t =
+  `Assoc
+    ([
+       (T.multimodal_kind_key, `String kind);
+       (T.multimodal_id_key, `String id);
+       (T.multimodal_metadata_key, metadata);
+     ]
+    @ payload_extra)
+
+let make_untagged (key : string) (value : string) : Yojson.Safe.t =
+  `Assoc [ (key, `String value); ("ts", `Int 12345) ]
+
+(* ── Phase 1: simulated tool surface emits 6 results ─────────── *)
+let phase1_tool_surface_emits () =
+  print_endline "── Phase 1: tool surface emits 6 results ──";
+  let results =
+    [
+      (* Tagged — should flow through *)
+      make_tagged ~kind:"code"
+        ~id:"01900000-0000-7000-8000-000000000201"
+        ~payload_extra:[ ("source", `String "let x = 1") ]
+        ~metadata:(`Assoc [ ("lang", `String "ml") ]);
+      make_tagged ~kind:"image"
+        ~id:"01900000-0000-7000-8000-000000000202"
+        ~payload_extra:[ ("data_url", `String "data:image/png") ]
+        ~metadata:(`Assoc [ ("dim", `String "1024x768") ]);
+      (* Untagged — should be ignored *)
+      make_untagged "echoed_text" "tool returned plain string";
+      make_tagged ~kind:"audio"
+        ~id:"01900000-0000-7000-8000-000000000203"
+        ~payload_extra:[ ("wav_b64", `String "RIFF...") ]
+        ~metadata:(`Assoc [ ("dur_ms", `Int 800) ]);
+      (* Untagged — should be ignored *)
+      make_untagged "search_hits" "no multimodal tag here";
+      make_tagged ~kind:"doc"
+        ~id:"01900000-0000-7000-8000-000000000204"
+        ~payload_extra:[ ("body", `String "# Title\n") ]
+        ~metadata:(`Assoc [ ("format", `String "md") ]);
+    ]
+  in
+  let wc = T.emit_from_tool_results ~working_context:None results in
+  let raws_in_wc =
+    match wc with
+    | Some (`Assoc kv) -> (
+        match List.assoc_opt "multimodal_artifacts" kv with
+        | Some (`List xs) -> xs
+        | _ -> [])
+    | _ -> []
+  in
+  assert_eq_int ~label:"emitted_count" 4 (List.length raws_in_wc);
+  print_endline "  6 results in, 4 emitted (2 untagged ignored)";
+  wc
+
+(* ── Phase 2: K1 wirein consumes ──────────────────────────────── *)
+let phase2_consumer wc =
+  print_endline "── Phase 2: K1 wirein consumes ──";
+  let raws, wc_rest = Wirein.extract_raw_artifacts wc in
+  assert_eq_int ~label:"extracted" 4 (List.length raws);
+  (match wc_rest with
+   | Some (`Assoc kv) ->
+       assert (List.assoc_opt "multimodal_artifacts" kv = None)
+   | _ -> ());
+  print_endline "  4 raws extracted, key drained";
+  raws
+
+(* ── Phase 3: hydrate + workspace_holder ─────────────────────── *)
+let phase3_hydrate raws =
+  print_endline "── Phase 3: hydrate + workspace_holder ──";
+  H.reset ();
+  H.update (fun ws ->
+      let ws', added =
+        B.hydrate_with_workspace ws raws ~now ~created_by:"k3-test"
+      in
+      assert_eq_int ~label:"hydrated" 4 (List.length added);
+      ws');
+  let snap = H.get () in
+  assert_eq_int ~label:"workspace_size" 4 (W.size snap);
+  print_endline "  4 typed artifacts in workspace_holder"
+
+(* ── Phase 4: D1 HTTP envelope ────────────────────────────────── *)
+let phase4_dashboard () =
+  print_endline "── Phase 4: D1 HTTP envelope ──";
+  Routes.bind_workspace_getter H.get;
+  let json = Routes.list_response () in
+  assert_eq_int ~label:"d1_count" 4 (pluck_count_field json);
+  let arts = pluck_artifacts_field json in
+  assert_eq_int ~label:"d1_arts_len" 4 (List.length arts);
+  print_endline "  dashboard sees 4 artifacts"
+
+(* ── Phase 5: payload_json reserved-key strip verification ───── *)
+let phase5_payload_strip_verification () =
+  print_endline "── Phase 5: payload_json reserved-key strip ──";
+  let snap = H.get () in
+  let arts = W.all snap in
+  List.iter
+    (fun (any : Multimodal.Artifact.any) ->
+      let json = Multimodal.Artifact.any_to_json any in
+      let payload =
+        match json with
+        | `Assoc kv -> (
+            match List.assoc_opt "payload" kv with
+            | Some p -> p
+            | None -> `Null)
+        | _ -> `Null
+      in
+      let payload_json =
+        match payload with
+        | `Assoc pkv -> (
+            match List.assoc_opt "lazy" pkv with
+            | Some j -> j
+            | None -> payload)
+        | other -> other
+      in
+      (match payload_json with
+       | `Assoc kv ->
+           assert (
+             List.assoc_opt T.multimodal_kind_key kv = None);
+           assert (List.assoc_opt T.multimodal_id_key kv = None);
+           assert (
+             List.assoc_opt T.multimodal_metadata_key kv = None)
+       | _ -> ()))
+    arts;
+  print_endline "  no reserved keys leak into hydrated payload"
+
+let () =
+  print_endline "=== K3 e2e tool pipeline (Cycle 27 — tool author seam) ===";
+  let wc = phase1_tool_surface_emits () in
+  let raws = phase2_consumer wc in
+  phase3_hydrate raws;
+  phase4_dashboard ();
+  phase5_payload_strip_verification ();
+  print_endline "=== K3 e2e: 5/5 phases passed ===";
+  print_endline
+    "    Tool authors only need to set 2 reserved keys —";
+  print_endline
+    "    Tool_emission converts to typed artifacts deterministically."


### PR DESCRIPTION
Cycle 27 / Tier K3 — Layer above K2. Lets **tool surfaces opt into the multimodal pipeline by setting two reserved JSON keys**, with no heuristics on tool names.

## Production loop with K3

```
tool surface
  │ emits result with __multimodal_kind / __multimodal_id
  ▼
Tool_emission.emit_from_tool_results  ← K3 (this PR)
  │ working_context["multimodal_artifacts"]
  │ Wirein_helpers.extract_raw_artifacts ← K1
  │ Multimodal_keeper_bridge.hydrate    ← W3
  │ Workspace_holder.update              ← K1
  │ list_response                        ← D1
  ▼ dashboard JSON
```

## Why explicit tagging, not regex

Tool-name regex (e.g. `matches /image/i`) silently drifts when tools are renamed and silently mis-classifies new tools that happen to match. The explicit-tag protocol is deterministic: a tool either opts in or it does not.

Reference: `feedback_no-string-matching-classification.md`.

## Reserved-key contract

```json
{
  "__multimodal_kind": "code|image|audio|doc",
  "__multimodal_id":   "<uuid v7 string>",
  "__multimodal_metadata": { ... },
  "...regular tool output..."
}
```

Reserved keys are **stripped** from `payload_json` after extraction, so the hydrated artifact does not duplicate kind/id/metadata.

## What lands

| File | Role |
|------|------|
| `lib/multimodal/tool_emission.{mli,ml}` (NEW, ~110 LoC) | `extract_kind_from_result`, `extract_id_from_result`, `emit_from_tool_result`, `emit_from_tool_results`. |
| `test/multimodal/test_tool_emission.ml` (NEW, 11 assertions) | Detector edge cases (absent/unknown/non-string/non-assoc) + reserved-key strip + metadata default + bulk-skip-untagged. |
| `test/test_k3_tool_pipeline_e2e.ml` (NEW, 5 phases) | 6 tool results (4 tagged + 2 untagged) → 4 emitted → hydrated → dashboard sees 4 → no reserved-key leak in payload. |
| `test/dune` + `test/multimodal/dune` | + 2 entries. |

## Verification

- `dune build --root .` — GREEN
- `dune runtest --root . test/multimodal/` — 11 new + 19 existing GREEN, 0 regressions
- `dune exec --root . test/test_k3_tool_pipeline_e2e.exe` — 5/5 phases GREEN

## RFC-0002 compliance

`lib/multimodal/tool_emission` does **not** import `lib/keeper`. Tool surface adapters thread `working_context` through `emit_from_tool_result`.

## Plan reference

§16 K3 — tool author seam follow-up to K2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
