### PR TITLE
Fix quick-suite advisory regressions

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -38,23 +38,23 @@ let mutex_key base_dir =
   in
   strip_trailing_slashes path
 
-let mutex_for_base_dir ~base_dir ~injected =
+let mutex_for_base_dir ~base_dir =
   let key = mutex_key base_dir in
   Stdlib.Mutex.protect mutex_registry_mu (fun () ->
     match Hashtbl.find_opt mutex_registry key with
     | Some cell -> cell
     | None ->
-        let mutex =
-          match injected with
-          | Some mutex -> mutex
-          | None -> Eio.Mutex.create ()
-        in
+        let mutex = Eio.Mutex.create () in
         let cell = Atomic.make mutex in
         Hashtbl.add mutex_registry key cell;
         cell)
 
 let create ~base_dir ?mutex () =
-  let mutex = mutex_for_base_dir ~base_dir ~injected:mutex in
+  let mutex =
+    match mutex with
+    | Some mutex -> Atomic.make mutex
+    | None -> mutex_for_base_dir ~base_dir
+  in
   { base_dir; mutex }
 
 let base_dir t = t.base_dir
@@ -156,11 +156,9 @@ let load_tail_lines path ~max_lines =
         let chunks = ref [] in
         let total_newlines = ref 0 in
         let pos = ref file_len in
-        let truncated_prefix = ref false in
         while !pos > 0 && !total_newlines <= target_newlines do
           let read_start = max 0 (!pos - chunk_size) in
           let read_len = !pos - read_start in
-          if read_start > 0 then truncated_prefix := true;
           seek_in ic read_start;
           let chunk = Bytes.create read_len in
           really_input ic chunk 0 read_len;
@@ -184,7 +182,7 @@ let load_tail_lines path ~max_lines =
           |> String.split_on_char '\n'
         in
         let raw_lines =
-          if !truncated_prefix then
+          if !pos > 0 then
             match raw_lines with
             | _partial :: rest -> rest
             | [] -> []
@@ -193,13 +191,6 @@ let load_tail_lines path ~max_lines =
         let all_lines =
           raw_lines
           |> List.filter (fun l -> String.trim l <> "")
-        in
-        let all_lines =
-          if !pos > 0 then
-            match all_lines with
-            | _resume_overlap :: rest -> rest
-            | [] -> []
-          else all_lines
         in
         let total = List.length all_lines in
         if total <= max_lines then all_lines
@@ -364,7 +355,7 @@ module For_testing = struct
   let mutex (t : t) = Atomic.get t.mutex
 
   let mutex_for_base_dir base_dir =
-    let cell = mutex_for_base_dir ~base_dir ~injected:None in
+    let cell = mutex_for_base_dir ~base_dir in
     Atomic.get cell
 
   let registry_size () =

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -1,14 +1,16 @@
 (** Date-split JSONL storage.
 
     Organises JSONL records into [base_dir/YYYY-MM/DD.jsonl] files.
-    Each instance carries its own {!Eio.Mutex.t} for concurrent-safe appends. *)
+    Stores rooted at the same [base_dir] share one {!Eio.Mutex.t} for
+    concurrent-safe appends. *)
 
 type t
-(** Opaque handle.  Holds [base_dir] and a per-store mutex. *)
+(** Opaque handle.  Holds [base_dir] and the append mutex. *)
 
 val create : base_dir:string -> ?mutex:Eio.Mutex.t -> unit -> t
 (** [create ~base_dir ()] builds a store rooted at [base_dir].
-    An optional [mutex] can be injected (useful for testing). *)
+    An optional [mutex] can be injected to bypass the shared registry
+    (useful for testing). *)
 
 val base_dir : t -> string
 (** Return the base directory of this store. *)

--- a/lib/exec/path_scope.ml
+++ b/lib/exec/path_scope.ml
@@ -68,9 +68,35 @@ let normalize_cwd cwd =
 let starts_with_dir ~prefix abs =
   abs = prefix || String.starts_with ~prefix:(prefix ^ "/") abs
 
+let lexical_normalize_abs abs =
+  let parts = String.split_on_char '/' abs in
+  let stack = ref [] in
+  List.iter
+    (function
+      | "" | "." -> ()
+      | ".." ->
+          (match !stack with
+           | _ :: rest -> stack := rest
+           | [] -> ())
+      | part -> stack := part :: !stack)
+    parts;
+  "/" ^ String.concat "/" (List.rev !stack)
+
+let lexical_abs ~cwd raw =
+  let abs =
+    if Filename.is_relative raw then Filename.concat cwd raw
+    else raw
+  in
+  lexical_normalize_abs abs
+
 let classify ~raw ~cwd =
   match normalize_path ~cwd raw with
-  | None -> { raw; scope = Absolute_unknown raw }
+  | None ->
+      let abs = lexical_abs ~cwd raw in
+      if starts_with_sandbox abs then
+        { raw; scope = Inside_sandbox abs }
+      else
+        { raw; scope = Absolute_unknown raw }
   | Some abs ->
     if starts_with_sandbox abs then
       { raw; scope = Inside_sandbox abs }

--- a/lib/exec/test/test_exec_types.ml
+++ b/lib/exec/test/test_exec_types.ml
@@ -67,6 +67,16 @@ let test_path_scope_classify_sandbox () =
   | Inside_sandbox _ -> ()
   | _ -> assert false
 
+let test_path_scope_classify_sandbox_escape () =
+  let ps =
+    Path_scope.classify
+      ~raw:"/tmp/masc-keeper-xyz/../../etc/passwd"
+      ~cwd:"/tmp"
+  in
+  match Path_scope.scope ps with
+  | Absolute_unknown _ -> ()
+  | _ -> assert false
+
 let test_path_scope_classify_unresolvable () =
   (* parent dir does not exist on disk → fail-closed. *)
   let ps =
@@ -133,6 +143,7 @@ let () =
   test_parsed_polymorphic ();
   test_path_scope_classify ();
   test_path_scope_classify_sandbox ();
+  test_path_scope_classify_sandbox_escape ();
   test_path_scope_classify_unresolvable ();
   test_verdict_trusted_argv_smart_ctor ();
   test_verdict_four_way ();

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -291,6 +291,9 @@ let run_turn
   in
   ignore (Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta);
   let keeper_sandbox_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+  let keeper_visible_sandbox_root =
+    Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta
+  in
   let effective_allowed_paths = Keeper_alerting_path.effective_allowed_paths ~meta in
   match
     Keeper_alerting_path.absolute_allowed_paths_result
@@ -1298,7 +1301,7 @@ let run_turn
               (!tool_surface_ref).missing_required_tool_names;
           };
         sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta;
-        sandbox_root = Some keeper_sandbox_root;
+        sandbox_root = Some keeper_visible_sandbox_root;
         network_mode = Keeper_types.network_mode_to_string meta.network_mode;
         approval_profile = (!tool_surface_ref).approval_mode_effective;
         approval_profile_derived = (!tool_surface_ref).approval_mode_derived;

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -158,12 +158,11 @@ let normalize_memory_text_key (s : string) : string =
    compiled regex without paying the compile cost on every memory row. *)
 let consensus_default_re = Re.Pcre.re {|\d{6,}ep\+?|} |> Re.compile
 
-(* Eio.Mutex: cache is touched from keeper memory-row evaluation, which
-   runs inside Eio fibers. Stdlib.Mutex with PTHREAD_MUTEX_ERRORCHECK
-   raises EDEADLK on fiber contention (memory: feedback_eio-mutex-vs-stdlib).
-   The "runtime/dashboard domains" comment above predates the realisation
-   that those callers all share the single Eio_main domain. *)
-let consensus_re_mu = Eio.Mutex.create ()
+(* Stdlib.Mutex: this process-global cache is also forced from tests and
+   runtime/dashboard domains outside an Eio context.  The critical section does
+   not perform Eio I/O or yield, so a plain mutex is sufficient and avoids
+   poisoning when first forced by multiple domains. *)
+let consensus_re_mu = Stdlib.Mutex.create ()
 let consensus_re_cached : (string * Re.re) option ref = ref None
 
 let consensus_pattern_key () =
@@ -183,7 +182,7 @@ let compile_consensus_re pattern =
 
 let consensus_re () =
   let pattern = consensus_pattern_key () in
-  Eio.Mutex.use_rw ~protect:true consensus_re_mu (fun () ->
+  Stdlib.Mutex.protect consensus_re_mu (fun () ->
     match !consensus_re_cached with
     | Some (cached_pattern, re) when String.equal cached_pattern pattern ->
         re

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -256,7 +256,7 @@ val normalize_memory_text_key : string -> string
     decided that…" boilerplate so the bank captures actual decisions. *)
 
 val consensus_default_re : Re.re
-val consensus_re_mu : Eio.Mutex.t
+val consensus_re_mu : Stdlib.Mutex.t
 val consensus_re_cached : (string * Re.re) option ref
 val consensus_pattern_key : unit -> string
 val compile_consensus_re : string -> Re.re

--- a/test/dune
+++ b/test/dune
@@ -1651,7 +1651,7 @@
   (setenv MASC_BASE_PATH /tmp/test-phase2
    (setenv MASC_BASE_PATH_INPUT /tmp/test-phase2
     (run %{test}))))
- (libraries masc_mcp masc_mcp.config alcotest eio eio_main unix fs_compat))
+ (libraries masc_test_deps masc_mcp masc_mcp.config alcotest eio eio_main unix fs_compat))
 
 (test
  (name test_heartbeat_integration)
@@ -1660,7 +1660,7 @@
   (setenv MASC_BASE_PATH /tmp/test-heartbeat-integ
    (setenv MASC_BASE_PATH_INPUT /tmp/test-heartbeat-integ
     (run %{test}))))
- (libraries masc_mcp masc_mcp.config fs_compat alcotest eio eio_main unix))
+ (libraries masc_test_deps masc_mcp masc_mcp.config fs_compat alcotest eio eio_main unix))
 
 (test
  (name test_smart_heartbeat_keepalive)

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -669,7 +669,7 @@ let test_activity_surface_contracts () =
        "Activity_graph.emit config");
   check bool "coord task lifecycle emits activity events via hook" true
     (file_contains_pattern "lib/coord/coord_task.ml"
-       "(Atomic.get Coord_hooks.activity_emit_fn)\n      config");
+       "emit_task_activity");
   check bool "coord broadcast emits activity events via hook" true
     (file_contains_pattern "lib/coord/coord_broadcast.ml"
        "(Atomic.get Coord_hooks.activity_emit_fn) config");
@@ -1007,6 +1007,8 @@ let test_masc_dirname_ssot_contracts () =
     "Common.masc_dir_from_base_path";       (* base-rooted helper *)
     "Masc_paths.masc_dir_from_base_path";   (* alias re-export *)
     "Common.masc_dirname";                  (* relative-only constant *)
+    "Common.auth_dir_from_base_path";       (* derived auth root helper *)
+    "Common.agents_dir_from_base_path";     (* derived auth agents helper *)
   ] in
   let file_uses_masc_dir_helper file =
     List.exists (fun p -> file_contains_pattern file p)

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -53,7 +53,7 @@ let make_meta name =
     ("trace_id", `String ("trace-integ-" ^ name));
     ("goal", `String "integration test");
   ] in
-  match KT.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
 

--- a/test/test_keeper_agent_run_sandbox_source.ml
+++ b/test/test_keeper_agent_run_sandbox_source.ml
@@ -62,13 +62,13 @@ let test_cli_transport_cwd_is_keeper_sandbox_root () =
     (count_occurrences ~needle:"cwd = None" src)
 ;;
 
-let test_execution_receipt_reports_same_sandbox_root () =
+let test_execution_receipt_reports_keeper_visible_sandbox_root () =
   let src = load_source target_file in
   check
     bool
-    "receipt reports keeper sandbox root"
+    "receipt reports keeper-visible sandbox root"
     true
-    (contains ~needle:"sandbox_root = Some keeper_sandbox_root" src)
+    (contains ~needle:"sandbox_root = Some keeper_visible_sandbox_root" src)
 ;;
 
 let test_runtime_contract_sandbox_root_is_keeper_visible () =
@@ -106,9 +106,9 @@ let () =
             `Quick
             test_cli_transport_cwd_is_keeper_sandbox_root
         ; test_case
-            "receipt reports same sandbox root"
+            "receipt reports keeper-visible sandbox root"
             `Quick
-            test_execution_receipt_reports_same_sandbox_root
+            test_execution_receipt_reports_keeper_visible_sandbox_root
         ; test_case
             "runtime_contract sandbox_root is keeper-visible"
             `Quick

--- a/test/test_keeper_turn_timeout_default_10456.ml
+++ b/test/test_keeper_turn_timeout_default_10456.ml
@@ -1,13 +1,16 @@
-(** #10456 — pin {!Env_config_keeper.KeeperKeepalive.turn_timeout_sec}
-    SSOT default (3600) and the source literal in
+(** #10456/#10716 — pin {!Env_config_keeper.KeeperKeepalive.turn_timeout_sec}
+    SSOT default (1800) and the source literal in
     {!Keeper_runtime_resolved.turn_timeout_sec_live}.
 
-    Pre-fix drift was:
+    Original pre-fix drift was:
     - env_config_keeper:301 default=3600 (post-#9637)
     - keeper_runtime_resolved:75 default=1200 (stale)
 
     Math: 1200 - 30 (oas_timeout_guard_sec) = 1170s — exact match for
     #10388 cascade ollama timeout walls.
+
+    #10716 later lowered the SSOT default from 3600 to 1800; this test pins
+    the new default while preserving the 1200 drift guard.
 
     This test pins the SSOT and source-level literal so silent
     re-divergence shows up as a test failure. *)
@@ -18,10 +21,10 @@ module E = Env_config_keeper.KeeperKeepalive
 
 let approx = float 0.001
 
-let test_ssot_default_3600 () =
+let test_ssot_default_1800 () =
   check approx
-    "env_config_keeper.KeeperKeepalive.turn_timeout_sec SSOT must stay at 3600 (#9637)"
-    3600.0 E.turn_timeout_sec
+    "env_config_keeper.KeeperKeepalive.turn_timeout_sec SSOT must stay at 1800 (#10716)"
+    1800.0 E.turn_timeout_sec
 
 let resolver_source_path =
   let candidates =
@@ -46,12 +49,15 @@ let test_resolver_default_matches_ssot () =
   | None -> skip ()
   | Some p ->
       let body = read_file p in
-      (* The fix replaces default:1200.0 with default:3600.0 in
+      (* The fix replaces default:1200.0 with default:1800.0 in
          turn_timeout_sec_live. Guard: must NOT contain the stale literal
          on the same line as MASC_KEEPER_TURN_TIMEOUT_SEC. *)
       let stale_pattern = "~default:1200.0 \"MASC_KEEPER_TURN_TIMEOUT_SEC\"" in
-      let canonical_pattern =
+      let stale_3600_pattern =
         "~default:3600.0 \"MASC_KEEPER_TURN_TIMEOUT_SEC\""
+      in
+      let canonical_pattern =
+        "~default:1800.0 \"MASC_KEEPER_TURN_TIMEOUT_SEC\""
       in
       let contains s sub =
         let n = String.length s and m = String.length sub in
@@ -63,9 +69,11 @@ let test_resolver_default_matches_ssot () =
         loop 0
       in
       let has_stale = contains body stale_pattern in
+      let has_stale_3600 = contains body stale_3600_pattern in
       let has_canonical = contains body canonical_pattern in
       check bool "no stale 1200 default in resolver" false has_stale;
-      check bool "canonical 3600 default in resolver" true has_canonical
+      check bool "no stale 3600 default in resolver" false has_stale_3600;
+      check bool "canonical 1800 default in resolver" true has_canonical
 
 let test_resolver_upper_matches_ssot () =
   match resolver_source_path with
@@ -93,8 +101,8 @@ let () =
     [
       ( "ssot-pin",
         [
-          test_case "env_config_keeper SSOT default is 3600 (post-#9637)"
-            `Quick test_ssot_default_3600;
+          test_case "env_config_keeper SSOT default is 1800 (post-#10716)"
+            `Quick test_ssot_default_1800;
         ] );
       ( "resolver-drift-gate",
         [

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -17,7 +17,7 @@ let make_meta name =
     ("trace_id", `String ("trace-test-" ^ name));
     ("goal", `String "test goal");
   ] in
-  match KT.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
 

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -135,7 +135,7 @@ let test_oas_timeout_cap () =
     turn_cap v
 
 let test_turn_timeout_default () =
-  check (float 0.1) "default turn timeout 3600s" 3600.0
+  check (float 0.1) "default turn timeout 1800s" 1800.0
     Cfg.KeeperKeepalive.turn_timeout_sec
 
 let test_max_turns_default () =
@@ -385,7 +385,7 @@ let () =
         test_oas_timeout_zero_uses_wall_clock;
       test_case "budget is token-count independent (#10008 fm2)" `Quick
         test_oas_timeout_is_token_independent;
-      test_case "turn timeout default is 3600" `Quick test_turn_timeout_default;
+      test_case "turn timeout default is 1800" `Quick test_turn_timeout_default;
       test_case "adaptive capped at turn timeout" `Quick test_oas_timeout_cap;
       test_case "max_turns default is 30" `Quick test_max_turns_default;
       test_case "scheduled autonomous max_turns default is 10" `Quick


### PR DESCRIPTION
Addresses part of #12089.

## Scope
- Restores Dated_jsonl tail/read_recent edge cases and explicit mutex override behavior.
- Keeps keeper execution receipts on keeper-visible sandbox roots.
- Updates strict keeper meta fixtures to use the test fixture parser with required sandbox_profile defaults.
- Fixes exec path-scope classification for not-yet-created /tmp/masc-keeper-* sandbox paths without admitting ../ escapes.
- Aligns turn-timeout pin tests with the current 1800s post-#10716 SSOT.
- Restores Keeper_memory_bank consensus regex cache safety across domains by using a Stdlib mutex for the non-yielding global cache.

## Validation
- git diff --check
- scripts/dune-local.sh exec ./test/test_ci_hardening_source.exe
- scripts/dune-local.sh exec ./test/test_keeper_agent_run_sandbox_source.exe
- scripts/dune-local.sh exec ./test/test_phase2_self_preservation.exe
- scripts/dune-local.sh exec ./test/test_heartbeat_integration.exe
- scripts/dune-local.sh exec ./test/test_dated_jsonl.exe
- scripts/dune-local.sh exec ./test/test_dated_jsonl_mutex_registry_10372.exe
- scripts/dune-local.sh exec ./lib/exec/test/test_exec_types.exe
- scripts/dune-local.sh exec ./test/test_work_as_heartbeat.exe
- scripts/dune-local.sh exec ./test/test_keeper_turn_timeout_default_10456.exe
- scripts/dune-local.sh exec ./test/test_keeper_memory_bank_consensus_re_10399.exe

## Notes
- This does not claim to close the transport-harness or contract-harness advisory slices from #12089.
- Local operator-control probe reached early passing cases but was stopped after prolonged no-output; CI remains the authority for that harness behavior.