### PR TITLE
[codex] Surface Track 5 live collaboration view

### DIFF
--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -18,11 +18,10 @@ export function Live({ variant = 'full' }: LiveProps) {
   return html`
     <div class="flex flex-col gap-5">
       ${!observatoryMode ? html`
-        <section class="contain-content monitor-surface-card monitor-surface-card-strong px-5 py-4" aria-label="라이브 모니터 소개">
+        <section class="contain-content monitor-surface-card monitor-surface-card-strong px-5 py-4" aria-label="라이브 협업 상태">
           <div class="flex flex-col gap-2">
             <div class="flex flex-col gap-2">
-              <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--color-fg-secondary)]">라이브 모니터</h2>
-              <p class="m-0 text-sm leading-paragraph text-[var(--color-fg-primary)]">실시간 이벤트 흐름과 활성 에이전트 상태를 한 화면에서 봅니다.</p>
+              <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--color-fg-secondary)]">라이브 협업</h2>
             </div>
           </div>
         </section>

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -51,7 +51,7 @@ export function ActivityStream() {
         <span class="text-xs text-[var(--color-fg-muted)]">${totalEvents.value} 수신 · ${entries.length} 표시</span>
       </div>
       <${FilterBar} />
-      <div class="activity-stream-list grid max-h-[52vh] min-h-0 content-start gap-2 overflow-y-auto pr-1">
+      <div class="activity-stream-list grid max-h-[52vh] min-h-0 content-start gap-2 overflow-y-auto pr-1" role="log" aria-live="polite" aria-label="활동 스트림 이벤트">
         ${entries.length === 0
           ? !connected.value
             ? html`<${ErrorState} message="실시간 연결이 끊겨있습니다. 서버 상태를 확인하세요." />`

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -1,5 +1,5 @@
 // MASC Dashboard — Status Surface (Phase 2+4: fleet-health + runtime unified)
-// Read-only observability surfaces: observatory, journey, agents, runtime,
+// Read-only observability surfaces: live, observatory, journey, agents, runtime,
 // fleet-health (FilterChips unified panel), memory-subsystems.
 
 import { html } from 'htm/preact'
@@ -8,7 +8,7 @@ import { route } from '../router'
 import { LoadingState } from './common/feedback-state'
 
 type StatusSection =
-  | 'observatory' | 'journey' | 'git-graph' | 'agents' | 'runtime' | 'fleet-health'
+  | 'live' | 'observatory' | 'journey' | 'git-graph' | 'agents' | 'runtime' | 'fleet-health'
   | 'safe-autonomy'
   | 'memory-subsystems' | 'attribution'
   | 'cost'
@@ -27,6 +27,9 @@ const LazyFleetHealthPanel = lazy(async () => ({
 }))
 const LazyObservatory = lazy(async () => ({
   default: (await import('./observatory/observatory')).Observatory,
+}))
+const LazyLive = lazy(async () => ({
+  default: (await import('./live')).Live,
 }))
 const LazyAttributionPanel = lazy(async () => ({
   default: (await import('./attribution-panel')).AttributionPanel,
@@ -50,6 +53,8 @@ function sectionFallback(label: string) {
 
 function sectionLabel(section: StatusSection): string {
   switch (section) {
+    case 'live':
+      return '라이브 협업'
     case 'observatory':
       return '관찰소'
     case 'journey':
@@ -75,6 +80,8 @@ function sectionLabel(section: StatusSection): string {
 
 function renderSection(section: StatusSection) {
   switch (section) {
+    case 'live':
+      return html`<${LazyLive} />`
     case 'observatory':
       return html`<${LazyObservatory} />`
     case 'journey':
@@ -102,6 +109,7 @@ function currentSection(): StatusSection {
   const section = route.value.params.section
   if (
     section === 'observatory'
+    || section === 'live'
     || section === 'journey'
     || section === 'git-graph'
     || section === 'runtime'

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -75,6 +75,7 @@ describe('monitoring navigation labels', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     const labelFor = (id: string) => sections.find(item => item.id === id)?.label
 
+    expect(labelFor('live')).toBe('라이브 협업')
     expect(labelFor('observatory')).toBe('관찰소 (beta)')
     expect(labelFor('journey')).toBe('여정 맵')
     expect(labelFor('fleet-health')).toBe('플릿 텔레메트리')
@@ -99,6 +100,7 @@ describe('monitoring navigation labels', () => {
     const ids = sections.map(item => item.id)
 
     expect(ids).toContain('journey')
+    expect(ids).toContain('live')
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('safe-autonomy')
     expect(ids).toContain('runtime')
@@ -112,10 +114,11 @@ describe('monitoring navigation labels', () => {
     expect(ids).not.toContain('governance')
   })
 
-  it('puts journey first so the integrated flow map is the clearest monitoring entry point', () => {
+  it('puts live collaboration first before slower analysis surfaces', () => {
     const sections = visibleSectionItemsForTab('monitoring')
-    expect(sections[0]?.id).toBe('journey')
-    expect(sections[1]?.id).toBe('observatory')
+    expect(sections[0]?.id).toBe('live')
+    expect(sections[1]?.id).toBe('journey')
+    expect(sections[2]?.id).toBe('observatory')
   })
 
   it('monitoring sidebar labels are unique (no overloaded term like "런타임")', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -3,6 +3,7 @@ import type { RouteState, TabId } from '../types'
 type SurfaceId = TabId
 type SurfaceSectionId =
   // monitoring
+  | 'live'
   | 'observatory'
   | 'journey'
   | 'git-graph'
@@ -134,6 +135,12 @@ export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = DASHBOARD_SURFACES.map(su
 
 export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavItem[]> = {
   monitoring: [
+    {
+      id: 'live',
+      label: '라이브 협업',
+      description: '현재 에이전트 펄스, 활동 스트림, Keeper 상태를 함께 봅니다.',
+      params: { section: 'live' },
+    },
     {
       id: 'journey',
       label: '여정 맵',

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -67,6 +67,11 @@ describe('refreshPlanForRoute', () => {
   it('uses the current monitoring sections', () => {
     expect(refreshPlanForRoute({
       tab: 'monitoring',
+      params: { section: 'live' },
+    })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot'])
+
+    expect(refreshPlanForRoute({
+      tab: 'monitoring',
       params: { section: 'agents' },
     })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot'])
 

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -74,6 +74,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       if (routeState.params.section === 'observatory') {
         return ['namespaceTruth', 'execution', 'missionSnapshot', 'observatory', 'activityGraph']
       }
+      if (routeState.params.section === 'live') {
+        return ['namespaceTruth', 'execution', 'missionSnapshot']
+      }
       if (routeState.params.section === 'journey') {
         return ['execution', 'missionSnapshot']
       }


### PR DESCRIPTION
## Summary
- expose the existing Live monitor as a first-class Monitoring section for Track 5 live collaboration
- route `monitoring?section=live` through the dashboard status surface and hydrate namespace/execution/mission data on navigation
- add polite live-region semantics to the activity stream and remove the introductory copy block from the standalone Live view

## Why
Track 5 calls out multi-agent presence, activity, and focus visibility as a core UI/UX surface. MASC already had the pulse strip, activity stream, and focus sidebar behind Observatory; this PR makes that live collaboration surface directly reachable without inventing a new backend contract.

## Validation
- `pnpm install --offline`
- `pnpm typecheck`
- `pnpm exec vitest run src/tab-refresh.test.ts src/config/navigation.test.ts src/components/live/pulse-strip.a11y.test.ts src/components/live/keeper-health-strip.a11y.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm build`
- `git diff --check`

Note: Vitest emitted the existing sandbox localhost:3000 `EPERM` warning, but all 51 selected tests passed.
