### PR TITLE
feat(headless): RFC 0009 TaskQueue implementation

### DIFF
--- a/dashboard/design-system/headless-core/task-queue.test.ts
+++ b/dashboard/design-system/headless-core/task-queue.test.ts
@@ -1,0 +1,275 @@
+// Pure TS unit tests for TaskQueue. No DOM.
+import { describe, it, expect } from 'vitest'
+import {
+  createTaskQueueManager,
+  type Task,
+  type TaskDescriptor,
+} from './task-queue'
+
+let clock = 0
+function nextTime(): string {
+  clock += 1
+  // ISO format with monotonic millisecond increment so localCompare is FIFO.
+  return new Date(2026, 0, 1, 0, 0, 0, clock).toISOString()
+}
+
+function reset(): void {
+  clock = 0
+}
+
+function task(id: string, patch: Partial<TaskDescriptor> = {}): TaskDescriptor {
+  return {
+    id,
+    agentId: patch.agentId ?? 'a1',
+    title: patch.title ?? `Task ${id}`,
+    priority: patch.priority ?? 5,
+    state: patch.state ?? 'queued',
+    ...patch,
+  }
+}
+
+describe('createTaskQueueManager — add / get', () => {
+  it('add() inserts task and subscribers fire once', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    let fires = 0
+    let captured: ReadonlyArray<Task> = []
+    m.subscribe((s) => {
+      fires += 1
+      captured = s
+    })
+    m.add(task('t1'))
+    expect(fires).toBe(1)
+    expect(captured.map((t) => t.id)).toEqual(['t1'])
+    expect(m.getAll().length).toBe(1)
+  })
+
+  it('add() is idempotent on duplicate id', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('t1'))
+    m.add(task('t1', { title: 'Different title' }))
+    expect(m.getAll().length).toBe(1)
+    expect(m.getAll()[0]!.title).toBe('Task t1')
+  })
+
+  it('initialTasks seed via constructor', () => {
+    reset()
+    const m = createTaskQueueManager({
+      now: nextTime,
+      initialTasks: [task('a'), task('b')],
+    })
+    expect(m.getAll().map((t) => t.id)).toEqual(['a', 'b'])
+  })
+})
+
+describe('createTaskQueueManager — update / state transitions', () => {
+  it('update state: running → completed sets snapshot', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('t1', { state: 'running' }))
+    let fired: Task | null = null
+    m.subscribeTask('t1', (t) => {
+      fired = t
+    })
+    m.update('t1', { state: 'completed', completedAt: '2026-01-01T00:00:01Z' })
+    expect(fired).not.toBeNull()
+    expect((fired as unknown as Task).state).toBe('completed')
+  })
+
+  it('announceStateChange: queued → running emits "started"', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('t1', { title: 'Build', state: 'queued' }))
+    m.update('t1', { state: 'running' })
+    const a = m.announceStateChange('t1', 'queued')
+    expect(a.text).toBe('Build started')
+    expect(a.assertive).toBe(false)
+  })
+
+  it('announceStateChange: running → failed is assertive with errorMessage', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('t1', { title: 'Deploy', state: 'running' }))
+    m.update('t1', { state: 'failed', errorMessage: 'auth refused' })
+    const a = m.announceStateChange('t1', 'running')
+    expect(a.text).toBe('Deploy failed: auth refused')
+    expect(a.assertive).toBe(true)
+  })
+
+  it('announceStateChange: running → paused / paused → running', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('t1', { title: 'Sync', state: 'running' }))
+    m.update('t1', { state: 'paused' })
+    expect(m.announceStateChange('t1', 'running').text).toBe('Sync paused')
+    m.update('t1', { state: 'running' })
+    expect(m.announceStateChange('t1', 'paused').text).toBe('Sync resumed')
+  })
+
+  it('announceStateChange: → queued is silent', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('t1', { title: 'X', state: 'running' }))
+    // Forced reset: directly transition to queued (RFC retry case).
+    m.update('t1', { state: 'queued' })
+    expect(m.announceStateChange('t1', 'running').text).toBe('')
+  })
+})
+
+describe('createTaskQueueManager — byPriority ordering', () => {
+  it('priority desc, then FIFO at same priority', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('a', { priority: 5 })) // createdAt earliest among prio-5
+    m.add(task('b', { priority: 10 })) // priority 10
+    m.add(task('c', { priority: 5 })) // createdAt later than a
+    const ord = m.byPriority().map((t) => t.id)
+    expect(ord).toEqual(['b', 'a', 'c'])
+  })
+
+  it('running before queued at same priority', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('q1', { priority: 5, state: 'queued' }))
+    m.add(task('r1', { priority: 5, state: 'running' }))
+    const ord = m.byPriority().map((t) => t.id)
+    expect(ord).toEqual(['r1', 'q1'])
+  })
+
+  it('reorder() override survives until next priority/state change', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('a', { priority: 10 }))
+    m.add(task('b', { priority: 5 }))
+    m.add(task('c', { priority: 1 }))
+    expect(m.byPriority().map((t) => t.id)).toEqual(['a', 'b', 'c'])
+    m.reorder(['c', 'a', 'b'])
+    expect(m.byPriority().map((t) => t.id)).toEqual(['c', 'a', 'b'])
+    // Update non-state, non-priority field — override survives.
+    m.update('a', { description: 'note' })
+    expect(m.byPriority().map((t) => t.id)).toEqual(['c', 'a', 'b'])
+    // State change clears override.
+    m.update('a', { state: 'running' })
+    expect(m.byPriority().map((t) => t.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('byPriority excludes terminal states', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('a', { state: 'completed' }))
+    m.add(task('b', { state: 'running' }))
+    m.add(task('c', { state: 'failed' }))
+    expect(m.byPriority().map((t) => t.id)).toEqual(['b'])
+  })
+})
+
+describe('createTaskQueueManager — query views', () => {
+  it('byState filters', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('a', { state: 'running' }))
+    m.add(task('b', { state: 'queued' }))
+    m.add(task('c', { state: 'running' }))
+    expect(m.byState('running').map((t) => t.id)).toEqual(['a', 'c'])
+    expect(m.byState('queued').map((t) => t.id)).toEqual(['b'])
+  })
+
+  it('byAgent filters', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('a', { agentId: 'k1' }))
+    m.add(task('b', { agentId: 'k2' }))
+    m.add(task('c', { agentId: 'k1' }))
+    expect(m.byAgent('k1').map((t) => t.id)).toEqual(['a', 'c'])
+    expect(m.byAgent('k2').map((t) => t.id)).toEqual(['b'])
+  })
+})
+
+describe('createTaskQueueManager — retention', () => {
+  it('maxRetention evicts oldest terminal task; active never evicted', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime, maxRetention: 2 })
+    m.add(task('c1', { state: 'completed' }))
+    m.add(task('c2', { state: 'completed' }))
+    m.add(task('a1', { state: 'running' }))
+    // 3 tasks, 2 terminal, retention 2 → at limit, no evict yet.
+    expect(m.getAll().length).toBe(3)
+    m.add(task('c3', { state: 'completed' }))
+    // 3 terminal > 2 → oldest terminal (c1) evicted.
+    expect(m.getAll().map((t) => t.id)).toEqual(['c2', 'a1', 'c3'])
+  })
+
+  it('update to terminal triggers eviction', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime, maxRetention: 1 })
+    m.add(task('c1', { state: 'completed' }))
+    m.add(task('r1', { state: 'running' }))
+    // 1 terminal at limit. Now flip r1 to completed → 2 terminal,
+    // c1 (oldest) evicts.
+    m.update('r1', { state: 'completed' })
+    expect(m.getAll().map((t) => t.id)).toEqual(['r1'])
+  })
+})
+
+describe('createTaskQueueManager — subscriptions', () => {
+  it('subscribeTask isolates by id', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('t1'))
+    m.add(task('t2'))
+    let t1Fires = 0
+    let t2Fires = 0
+    m.subscribeTask('t1', () => {
+      t1Fires += 1
+    })
+    m.subscribeTask('t2', () => {
+      t2Fires += 1
+    })
+    m.update('t1', { state: 'running' })
+    expect(t1Fires).toBe(1)
+    expect(t2Fires).toBe(0)
+  })
+
+  it('100 sequential update() calls produce 100 emits (no batching)', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('t1', { state: 'running', progress: 0 }))
+    let fires = 0
+    m.subscribe(() => {
+      fires += 1
+    })
+    for (let i = 1; i <= 100; i += 1) {
+      m.update('t1', { progress: i })
+    }
+    expect(fires).toBe(100)
+  })
+
+  it('subscribe leak — unsubscribe stops fires', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    let fires = 0
+    const dispose = m.subscribe(() => {
+      fires += 1
+    })
+    m.add(task('t1'))
+    expect(fires).toBe(1)
+    dispose()
+    m.add(task('t2'))
+    expect(fires).toBe(1)
+  })
+})
+
+describe('createTaskQueueManager — remove', () => {
+  it('remove() drops task and clears reorder mention', () => {
+    reset()
+    const m = createTaskQueueManager({ now: nextTime })
+    m.add(task('a'))
+    m.add(task('b'))
+    m.add(task('c'))
+    m.reorder(['c', 'a', 'b'])
+    m.remove('a')
+    expect(m.getAll().map((t) => t.id)).toEqual(['b', 'c'])
+    expect(m.byPriority().map((t) => t.id)).toEqual(['c', 'b'])
+  })
+})

--- a/dashboard/design-system/headless-core/task-queue.ts
+++ b/dashboard/design-system/headless-core/task-queue.ts
@@ -1,0 +1,295 @@
+/**
+ * TaskQueue — framework-agnostic queue manager for MASC tasks (RFC 0009).
+ *
+ * Mirrors MASC's task storage; never authors. Owns canonical task list,
+ * answers priority/state/agent queries, and emits SR announcements with
+ * the right urgency for each transition. Sister to Toast (RFC 0007) —
+ * both are append-only event surfaces, but Task is structured + queryable
+ * while Toast is ephemeral.
+ *
+ * MVP scope (RFC 0009 §3, §4, §5, §6, §7):
+ *   - Five states: queued / running / paused / completed / failed
+ *   - byPriority order: priority desc, running > paused > queued at same
+ *     priority, FIFO within remainder
+ *   - reorder(ids) explicit override; cleared on next priority/state change
+ *   - announceStateChange(id, prev) emits text + assertive flag matching
+ *     RFC §4 transition table; failed → assertive=true
+ *   - maxRetention default 200; evicts oldest completed/failed only
+ *
+ * Out of scope (deferred per RFC 0009 §11):
+ *   - Multi-assignee tasks
+ *   - localStorage persistence of reorder override
+ *   - Failed → queued retry as new task vs same id (caller decides)
+ */
+
+export type TaskState = 'queued' | 'running' | 'paused' | 'completed' | 'failed'
+
+export interface TaskDescriptor {
+  readonly id: string
+  readonly agentId: string
+  readonly title: string
+  readonly description?: string
+  readonly priority: number
+  readonly state: TaskState
+  readonly progress?: number
+  readonly startedAt?: string
+  readonly completedAt?: string
+  readonly errorMessage?: string
+}
+
+export interface Task extends TaskDescriptor {
+  readonly createdAt: string
+}
+
+export interface TaskQueueOptions {
+  initialTasks?: ReadonlyArray<TaskDescriptor>
+  maxRetention?: number
+  /** Override creation timestamp generator (testing). */
+  now?: () => string
+}
+
+export interface StateAnnouncement {
+  readonly text: string
+  readonly assertive: boolean
+}
+
+export interface TaskQueueManager {
+  add(task: TaskDescriptor): void
+  remove(id: string): void
+  update(id: string, patch: Partial<Omit<TaskDescriptor, 'id'>>): void
+  reorder(ids: ReadonlyArray<string>): void
+
+  getAll(): ReadonlyArray<Task>
+  byState(state: TaskState): ReadonlyArray<Task>
+  byAgent(agentId: string): ReadonlyArray<Task>
+  byPriority(): ReadonlyArray<Task>
+
+  subscribe(listener: (tasks: ReadonlyArray<Task>) => void): () => void
+  subscribeTask(id: string, listener: (task: Task) => void): () => void
+
+  announceStateChange(id: string, prev: TaskState): StateAnnouncement
+}
+
+const DEFAULT_RETENTION = 200
+
+function isActive(state: TaskState): boolean {
+  return state === 'queued' || state === 'running' || state === 'paused'
+}
+
+function isTerminal(state: TaskState): boolean {
+  return state === 'completed' || state === 'failed'
+}
+
+function activeStateRank(state: TaskState): number {
+  if (state === 'running') return 0
+  if (state === 'paused') return 1
+  if (state === 'queued') return 2
+  return 3
+}
+
+export function createTaskQueueManager(opts?: TaskQueueOptions): TaskQueueManager {
+  const maxRetention = opts?.maxRetention ?? DEFAULT_RETENTION
+  const now = opts?.now ?? (() => new Date().toISOString())
+
+  const tasks = new Map<string, Task>()
+  const insertionOrder: string[] = []
+  let reorderOverride: ReadonlyArray<string> | null = null
+
+  const listeners = new Set<(tasks: ReadonlyArray<Task>) => void>()
+  const taskListeners = new Map<string, Set<(task: Task) => void>>()
+
+  function snapshot(): ReadonlyArray<Task> {
+    return Object.freeze(insertionOrder.map((id) => tasks.get(id)!).filter(Boolean))
+  }
+
+  function emit(): void {
+    const s = snapshot()
+    for (const l of listeners) l(s)
+  }
+
+  function emitTask(t: Task): void {
+    const set = taskListeners.get(t.id)
+    if (set === undefined) return
+    for (const l of set) l(t)
+  }
+
+  function evictIfOverflow(): void {
+    let nonActive = 0
+    for (const t of tasks.values()) {
+      if (isTerminal(t.state)) nonActive += 1
+    }
+    while (nonActive > maxRetention) {
+      // Find oldest terminal task in insertion order.
+      for (const id of insertionOrder) {
+        const t = tasks.get(id)
+        if (t !== undefined && isTerminal(t.state)) {
+          tasks.delete(id)
+          const idx = insertionOrder.indexOf(id)
+          if (idx >= 0) insertionOrder.splice(idx, 1)
+          break
+        }
+      }
+      nonActive -= 1
+    }
+  }
+
+  function add(descriptor: TaskDescriptor): void {
+    if (tasks.has(descriptor.id)) return
+    const t: Task = Object.freeze({
+      ...descriptor,
+      createdAt: now(),
+    })
+    tasks.set(t.id, t)
+    insertionOrder.push(t.id)
+    evictIfOverflow()
+    emit()
+    emitTask(t)
+  }
+
+  function remove(id: string): void {
+    if (!tasks.has(id)) return
+    tasks.delete(id)
+    const idx = insertionOrder.indexOf(id)
+    if (idx >= 0) insertionOrder.splice(idx, 1)
+    if (reorderOverride !== null) {
+      reorderOverride = reorderOverride.filter((x) => x !== id)
+    }
+    emit()
+  }
+
+  function update(id: string, patch: Partial<Omit<TaskDescriptor, 'id'>>): void {
+    const cur = tasks.get(id)
+    if (cur === undefined) return
+    const next: Task = Object.freeze({ ...cur, ...patch })
+    tasks.set(id, next)
+    // Drop reorder override on priority or state change so byPriority
+    // returns to natural ordering until consumer reorders again.
+    if (
+      ('priority' in patch && patch.priority !== cur.priority) ||
+      ('state' in patch && patch.state !== cur.state)
+    ) {
+      reorderOverride = null
+    }
+    if ('state' in patch && isTerminal(next.state) && !isTerminal(cur.state)) {
+      evictIfOverflow()
+    }
+    emit()
+    emitTask(next)
+  }
+
+  function reorder(ids: ReadonlyArray<string>): void {
+    // Validate: all ids exist and are active.
+    for (const id of ids) {
+      const t = tasks.get(id)
+      if (t === undefined || !isActive(t.state)) return
+    }
+    reorderOverride = Object.freeze([...ids])
+    emit()
+  }
+
+  function getAll(): ReadonlyArray<Task> {
+    return snapshot()
+  }
+
+  function byState(state: TaskState): ReadonlyArray<Task> {
+    return Object.freeze(snapshot().filter((t) => t.state === state))
+  }
+
+  function byAgent(agentId: string): ReadonlyArray<Task> {
+    return Object.freeze(snapshot().filter((t) => t.agentId === agentId))
+  }
+
+  function byPriority(): ReadonlyArray<Task> {
+    const active = snapshot().filter((t) => isActive(t.state))
+    if (reorderOverride !== null) {
+      const map = new Map(active.map((t) => [t.id, t]))
+      const out: Task[] = []
+      for (const id of reorderOverride) {
+        const t = map.get(id)
+        if (t !== undefined) out.push(t)
+      }
+      return Object.freeze(out)
+    }
+    return Object.freeze(
+      [...active].sort((a, b) => {
+        if (a.priority !== b.priority) return b.priority - a.priority
+        const sa = activeStateRank(a.state)
+        const sb = activeStateRank(b.state)
+        if (sa !== sb) return sa - sb
+        return a.createdAt.localeCompare(b.createdAt)
+      }),
+    )
+  }
+
+  function subscribe(listener: (tasks: ReadonlyArray<Task>) => void): () => void {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  }
+
+  function subscribeTask(id: string, listener: (task: Task) => void): () => void {
+    let set = taskListeners.get(id)
+    if (set === undefined) {
+      set = new Set()
+      taskListeners.set(id, set)
+    }
+    set.add(listener)
+    return () => {
+      set!.delete(listener)
+      if (set!.size === 0) taskListeners.delete(id)
+    }
+  }
+
+  function announceStateChange(id: string, prev: TaskState): StateAnnouncement {
+    const cur = tasks.get(id)
+    if (cur === undefined) {
+      return Object.freeze({ text: '', assertive: false })
+    }
+    const next = cur.state
+    if (next === prev) return Object.freeze({ text: '', assertive: false })
+
+    if (next === 'queued') {
+      return Object.freeze({ text: '', assertive: false })
+    }
+    if (next === 'running' && prev === 'paused') {
+      return Object.freeze({ text: `${cur.title} resumed`, assertive: false })
+    }
+    if (next === 'running') {
+      // queued → running OR direct ?→running (RFC §4 last row "skipping queued")
+      return Object.freeze({ text: `${cur.title} started`, assertive: false })
+    }
+    if (next === 'paused' && prev === 'running') {
+      return Object.freeze({ text: `${cur.title} paused`, assertive: false })
+    }
+    if (next === 'completed') {
+      return Object.freeze({ text: `${cur.title} completed`, assertive: false })
+    }
+    if (next === 'failed') {
+      const msg = cur.errorMessage !== undefined && cur.errorMessage.length > 0
+        ? `${cur.title} failed: ${cur.errorMessage}`
+        : `${cur.title} failed`
+      return Object.freeze({ text: msg, assertive: true })
+    }
+    return Object.freeze({ text: '', assertive: false })
+  }
+
+  // Seed initial roster.
+  if (opts?.initialTasks !== undefined) {
+    for (const d of opts.initialTasks) add(d)
+  }
+
+  return {
+    add,
+    remove,
+    update,
+    reorder,
+    getAll,
+    byState,
+    byAgent,
+    byPriority,
+    subscribe,
+    subscribeTask,
+    announceStateChange,
+  }
+}


### PR DESCRIPTION
## Summary

Implements `createTaskQueueManager` per RFC 0009 (`dashboard/design-system/RFC/0009-task-queue.md`).

- 5-state lifecycle: queued / running / paused / completed / failed
- `byPriority`: priority desc → active states (running > paused > queued) → FIFO tail
- `reorder(ids)` explicit override; cleared on next priority/state change
- Retention eviction (default 200): oldest terminal task first; active never evicted
- `announceStateChange(id, prev)` returns frozen `{ text, assertive }` per RFC §4 transition table — failed → assertive=true
- `subscribeTask(id)` isolation; 100 sequential updates → 100 subscriber fires (no batching)

## Verification

- `pnpm typecheck` — clean (strict mode)
- `pnpm test design-system/headless-core/task-queue` — 20/20 pass
- No external deps — pure framework-agnostic primitive

## Out of scope (RFC §11)

- Multi-assignee tasks
- localStorage persistence of reorder override
- Failed → queued retry (caller decides)