### PR TITLE
feat(headless): RFC 0011 InlineSuggestion implementation

### DIFF
--- a/dashboard/design-system/headless-core/inline-suggestion.test.ts
+++ b/dashboard/design-system/headless-core/inline-suggestion.test.ts
@@ -1,0 +1,317 @@
+// Pure TS unit tests for InlineSuggestion. No DOM.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  createInlineSuggestionManager,
+  createSuggestionController,
+  type InlineSuggestion,
+  type InlineSuggestionInput,
+  type SuggestionKeyEvent,
+} from './inline-suggestion'
+
+function makeKey(
+  key: string,
+  opts?: Partial<SuggestionKeyEvent>,
+): SuggestionKeyEvent & { _prevented: boolean } {
+  let prevented = false
+  return {
+    key,
+    metaKey: opts?.metaKey,
+    ctrlKey: opts?.ctrlKey,
+    shiftKey: opts?.shiftKey,
+    altKey: opts?.altKey,
+    preventDefault() {
+      prevented = true
+    },
+    get _prevented() {
+      return prevented
+    },
+  } as SuggestionKeyEvent & { _prevented: boolean }
+}
+
+function input(
+  patch: Partial<InlineSuggestionInput> = {},
+): InlineSuggestionInput {
+  return {
+    agentId: patch.agentId ?? 'a1',
+    agentName: patch.agentName ?? 'Alice',
+    agentColorSlot: patch.agentColorSlot ?? 1,
+    range: patch.range ?? { file: 'src/x.ts', fromLine: 10, toLine: 12 },
+    before: patch.before ?? ['old'],
+    after: patch.after ?? ['new'],
+    confidence: patch.confidence ?? 0.5,
+    rationale: patch.rationale,
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createInlineSuggestionManager — propose / queries', () => {
+  it('propose returns id formatted by IdGenerator', () => {
+    const m = createInlineSuggestionManager()
+    const id = m.propose(input())
+    expect(id).toMatch(/^inline-suggestion-/)
+    expect(m.getAll().length).toBe(1)
+  })
+
+  it('inFile filters by file', () => {
+    const m = createInlineSuggestionManager()
+    m.propose(input({ range: { file: 'a.ts', fromLine: 1, toLine: 2 } }))
+    m.propose(input({ range: { file: 'b.ts', fromLine: 1, toLine: 2 } }))
+    expect(m.inFile('a.ts').length).toBe(1)
+    expect(m.inFile('b.ts').length).toBe(1)
+  })
+
+  it('inRange returns overlapping suggestions', () => {
+    const m = createInlineSuggestionManager()
+    m.propose(input({ range: { file: 'f', fromLine: 10, toLine: 16 } }))
+    m.propose(input({ range: { file: 'f', fromLine: 13, toLine: 21 } }))
+    m.propose(input({ range: { file: 'f', fromLine: 50, toLine: 52 } }))
+    expect(m.inRange('f', 12, 17).length).toBe(2)
+    expect(m.inRange('f', 50, 51).length).toBe(1)
+  })
+
+  it('topAtLine returns highest-confidence overlap', () => {
+    const m = createInlineSuggestionManager()
+    m.propose(input({ confidence: 0.4, range: { file: 'f', fromLine: 10, toLine: 16 } }))
+    m.propose(input({ confidence: 0.9, range: { file: 'f', fromLine: 12, toLine: 14 } }))
+    m.propose(input({ confidence: 0.6, range: { file: 'f', fromLine: 13, toLine: 15 } }))
+    const top = m.topAtLine('f', 13)
+    expect(top).toBeDefined()
+    expect(top!.confidence).toBe(0.9)
+  })
+
+  it('topAtLine undefined when no overlap', () => {
+    const m = createInlineSuggestionManager()
+    m.propose(input({ range: { file: 'f', fromLine: 10, toLine: 12 } }))
+    expect(m.topAtLine('f', 50)).toBeUndefined()
+    expect(m.topAtLine('other', 11)).toBeUndefined()
+  })
+})
+
+describe('createInlineSuggestionManager — accept / reject lifecycle', () => {
+  it('accept fires onAccept and removes', () => {
+    const accepts: InlineSuggestion[] = []
+    const m = createInlineSuggestionManager({
+      onAccept: (s) => accepts.push(s),
+    })
+    const id = m.propose(input())
+    m.accept(id)
+    expect(accepts.length).toBe(1)
+    expect(m.getAll().length).toBe(0)
+  })
+
+  it('reject fires onReject and removes', () => {
+    const rejects: InlineSuggestion[] = []
+    const m = createInlineSuggestionManager({
+      onReject: (s) => rejects.push(s),
+    })
+    const id = m.propose(input())
+    m.reject(id)
+    expect(rejects.length).toBe(1)
+    expect(m.getAll().length).toBe(0)
+  })
+
+  it('retract removes silently — no onReject fire', () => {
+    const rejects: InlineSuggestion[] = []
+    const m = createInlineSuggestionManager({
+      onReject: (s) => rejects.push(s),
+    })
+    const id = m.propose(input())
+    m.retract(id)
+    expect(rejects.length).toBe(0)
+    expect(m.getAll().length).toBe(0)
+  })
+
+  it('accept on overlapping range auto-rejects others in same file', () => {
+    const rejects: InlineSuggestion[] = []
+    const m = createInlineSuggestionManager({
+      onReject: (s) => rejects.push(s),
+    })
+    const winnerId = m.propose(
+      input({ range: { file: 'f', fromLine: 10, toLine: 15 } }),
+    )
+    m.propose(input({ range: { file: 'f', fromLine: 13, toLine: 18 } }))
+    m.propose(input({ range: { file: 'f', fromLine: 50, toLine: 52 } })) // disjoint
+    m.accept(winnerId)
+    expect(rejects.length).toBe(1)
+    // Disjoint suggestion still alive.
+    expect(m.getAll().length).toBe(1)
+    expect(m.getAll()[0]!.range.fromLine).toBe(50)
+  })
+})
+
+describe('createInlineSuggestionManager — TTL', () => {
+  it('TTL auto-rejects after ttlMs', () => {
+    const rejects: InlineSuggestion[] = []
+    const m = createInlineSuggestionManager({
+      ttlMs: 100,
+      onReject: (s) => rejects.push(s),
+    })
+    m.propose(input())
+    expect(rejects.length).toBe(0)
+    vi.advanceTimersByTime(99)
+    expect(rejects.length).toBe(0)
+    vi.advanceTimersByTime(2)
+    expect(rejects.length).toBe(1)
+    expect(m.getAll().length).toBe(0)
+  })
+
+  it('ttlMs:0 disables auto-rejection', () => {
+    const rejects: InlineSuggestion[] = []
+    const m = createInlineSuggestionManager({
+      ttlMs: 0,
+      onReject: (s) => rejects.push(s),
+    })
+    m.propose(input())
+    vi.advanceTimersByTime(60_000)
+    expect(rejects.length).toBe(0)
+    expect(m.getAll().length).toBe(1)
+  })
+
+  it('accept clears TTL — no double reject after', () => {
+    const rejects: InlineSuggestion[] = []
+    const m = createInlineSuggestionManager({
+      ttlMs: 100,
+      onReject: (s) => rejects.push(s),
+    })
+    const id = m.propose(input())
+    m.accept(id)
+    vi.advanceTimersByTime(200)
+    expect(rejects.length).toBe(0)
+  })
+})
+
+describe('createInlineSuggestionManager — subscribeFile', () => {
+  it('subscribeFile fires on propose / accept / reject within file', () => {
+    const m = createInlineSuggestionManager()
+    let fires = 0
+    m.subscribeFile('f', () => {
+      fires += 1
+    })
+    const id = m.propose(input({ range: { file: 'f', fromLine: 1, toLine: 2 } }))
+    expect(fires).toBe(1)
+    m.accept(id)
+    expect(fires).toBe(2)
+  })
+
+  it('subscribeFile isolates by file', () => {
+    const m = createInlineSuggestionManager()
+    let aFires = 0
+    let bFires = 0
+    m.subscribeFile('a.ts', () => {
+      aFires += 1
+    })
+    m.subscribeFile('b.ts', () => {
+      bFires += 1
+    })
+    m.propose(input({ range: { file: 'a.ts', fromLine: 1, toLine: 2 } }))
+    expect(aFires).toBe(1)
+    expect(bFires).toBe(0)
+  })
+})
+
+describe('createSuggestionController — ARIA props', () => {
+  it('aria-label includes agent + line range + keyboard hint', () => {
+    const m = createInlineSuggestionManager()
+    const id = m.propose(
+      input({
+        agentName: 'Bob',
+        range: { file: 'f', fromLine: 42, toLine: 46 },
+      }),
+    )
+    const c = createSuggestionController(m, id)
+    const root = c.getRootProps()
+    expect(root['aria-label']).toBe(
+      'Suggestion from Bob: replace lines 42-45. Press Tab to accept or Escape to reject.',
+    )
+    expect(root['aria-keyshortcuts']).toBe('Tab Escape')
+    expect(root['data-state']).toBe('suggested')
+    expect(root.role).toBe('region')
+    expect(root.tabIndex).toBe(0)
+  })
+
+  it('data-agent-color matches --k-N', () => {
+    const m = createInlineSuggestionManager()
+    const id = m.propose(input({ agentColorSlot: 7 }))
+    const c = createSuggestionController(m, id)
+    expect(c.getRootProps()['data-agent-color']).toBe('--k-7')
+  })
+
+  it('Tab keydown accepts; Escape rejects', () => {
+    const accepts: InlineSuggestion[] = []
+    const rejects: InlineSuggestion[] = []
+    const m = createInlineSuggestionManager({
+      onAccept: (s) => accepts.push(s),
+      onReject: (s) => rejects.push(s),
+    })
+    const id1 = m.propose(input())
+    const c1 = createSuggestionController(m, id1)
+    c1.getRootProps().onKeyDown(makeKey('Tab'))
+    expect(accepts.length).toBe(1)
+
+    const id2 = m.propose(input())
+    const c2 = createSuggestionController(m, id2)
+    c2.getRootProps().onKeyDown(makeKey('Escape'))
+    expect(rejects.length).toBe(1)
+  })
+
+  it('Shift+Tab does NOT accept (reserved for outer focus reverse)', () => {
+    const accepts: InlineSuggestion[] = []
+    const m = createInlineSuggestionManager({
+      onAccept: (s) => accepts.push(s),
+    })
+    const id = m.propose(input())
+    const c = createSuggestionController(m, id)
+    c.getRootProps().onKeyDown(makeKey('Tab', { shiftKey: true }))
+    expect(accepts.length).toBe(0)
+  })
+
+  it('Mod+Tab does NOT accept', () => {
+    const accepts: InlineSuggestion[] = []
+    const m = createInlineSuggestionManager({
+      onAccept: (s) => accepts.push(s),
+    })
+    const id = m.propose(input())
+    const c = createSuggestionController(m, id)
+    c.getRootProps().onKeyDown(makeKey('Tab', { metaKey: true }))
+    expect(accepts.length).toBe(0)
+  })
+
+  it('button props expose correct labels and shortcuts', () => {
+    const m = createInlineSuggestionManager()
+    const id = m.propose(input({ agentName: 'Carol' }))
+    const c = createSuggestionController(m, id)
+    const accept = c.getAcceptButtonProps()
+    const reject = c.getRejectButtonProps()
+    expect(accept['aria-label']).toBe('Accept suggestion from Carol')
+    expect(accept['aria-keyshortcuts']).toBe('Tab')
+    expect(reject['aria-label']).toBe('Reject suggestion from Carol')
+    expect(reject['aria-keyshortcuts']).toBe('Escape')
+  })
+
+  it('controller throws when suggestion id missing', () => {
+    const m = createInlineSuggestionManager()
+    expect(() => createSuggestionController(m, 'nonexistent')).toThrow()
+  })
+})
+
+describe('createInlineSuggestionManager — single-line label edge case', () => {
+  it('single-line range labels as "line N" (singular)', () => {
+    const m = createInlineSuggestionManager()
+    const id = m.propose(
+      input({
+        agentName: 'Dave',
+        range: { file: 'f', fromLine: 7, toLine: 8 }, // toLine exclusive → 1 line
+      }),
+    )
+    const c = createSuggestionController(m, id)
+    expect(c.getRootProps()['aria-label']).toBe(
+      'Suggestion from Dave: replace line 7. Press Tab to accept or Escape to reject.',
+    )
+  })
+})

--- a/dashboard/design-system/headless-core/inline-suggestion.ts
+++ b/dashboard/design-system/headless-core/inline-suggestion.ts
@@ -1,0 +1,340 @@
+/**
+ * InlineSuggestion — at-the-change-site agent proposal primitive (RFC 0011).
+ *
+ * Manager-plus-controller pair. Manager owns the suggestion roster across
+ * the editor surface and routes accept/reject callbacks. Controller binds
+ * to one suggestion and emits ARIA-correct prop bundles for the editor's
+ * suggestion region. Tab → accept, Escape → reject (RFC §4 keyboard
+ * contract; non-standard Tab override permitted by ARIA APG for
+ * role-specific affordances).
+ *
+ * MVP scope (RFC 0011 §3, §4, §5, §6, §7):
+ *   - propose / retract / accept / reject mutation surface
+ *   - inFile / inRange / topAtLine queries
+ *   - same-range mutual reject on accept (winner takes the slot,
+ *     losers fire onReject)
+ *   - TTL default 30s; ttlMs:0 disables auto-rejection
+ *   - data-agent-color carries `--k-N` for stripe coloring
+ *   - aria-label format: "Suggestion from <name>: replace lines N-M.
+ *     Press Tab to accept or Escape to reject."
+ *
+ * Out of scope (deferred per RFC 0011 §11):
+ *   - LLM streaming partial UI (consumer concern)
+ *   - Suggestion application (consumer writes file in onAccept)
+ *   - Diff rendering (consumer renders before/after lines)
+ *   - Cross-file suggestion bundles
+ */
+
+import { createIdGenerator } from './id-generator'
+
+export interface SuggestionRange {
+  readonly file: string
+  readonly fromLine: number
+  readonly toLine: number
+}
+
+export interface InlineSuggestion {
+  readonly id: string
+  readonly agentId: string
+  readonly agentName: string
+  readonly agentColorSlot: number
+  readonly range: SuggestionRange
+  readonly before: ReadonlyArray<string>
+  readonly after: ReadonlyArray<string>
+  readonly rationale?: string
+  readonly confidence: number
+  readonly createdAt: string
+}
+
+export interface InlineSuggestionInput {
+  readonly agentId: string
+  readonly agentName: string
+  readonly agentColorSlot: number
+  readonly range: SuggestionRange
+  readonly before: ReadonlyArray<string>
+  readonly after: ReadonlyArray<string>
+  readonly rationale?: string
+  readonly confidence: number
+}
+
+export interface InlineSuggestionOptions {
+  onAccept?: (suggestion: InlineSuggestion) => void
+  onReject?: (suggestion: InlineSuggestion) => void
+  /** Auto-reject after Nms with no interaction. 0 = persistent. Default 30000. */
+  ttlMs?: number
+  now?: () => string
+}
+
+export interface InlineSuggestionManager {
+  propose(input: InlineSuggestionInput): string
+  retract(id: string): void
+  accept(id: string): void
+  reject(id: string): void
+
+  getAll(): ReadonlyArray<InlineSuggestion>
+  inFile(file: string): ReadonlyArray<InlineSuggestion>
+  inRange(file: string, fromLine: number, toLine: number): ReadonlyArray<InlineSuggestion>
+  topAtLine(file: string, line: number): InlineSuggestion | undefined
+
+  subscribeFile(
+    file: string,
+    listener: (suggestions: ReadonlyArray<InlineSuggestion>) => void,
+  ): () => void
+}
+
+export interface SuggestionKeyEvent {
+  readonly key: string
+  readonly metaKey?: boolean
+  readonly ctrlKey?: boolean
+  readonly shiftKey?: boolean
+  readonly altKey?: boolean
+  preventDefault(): void
+}
+
+export interface SuggestionRootProps {
+  readonly id: string
+  readonly role: 'region'
+  readonly 'aria-label': string
+  readonly 'aria-keyshortcuts': 'Tab Escape'
+  readonly 'data-state': 'suggested'
+  readonly 'data-agent-color': string
+  readonly tabIndex: 0
+  readonly onKeyDown: (e: SuggestionKeyEvent) => void
+}
+
+export interface SuggestionButtonProps {
+  readonly type: 'button'
+  readonly 'aria-label': string
+  readonly 'aria-keyshortcuts': string
+  readonly onClick: () => void
+}
+
+export interface SuggestionController {
+  readonly suggestion: InlineSuggestion
+  getRootProps(): SuggestionRootProps
+  getAcceptButtonProps(): SuggestionButtonProps
+  getRejectButtonProps(): SuggestionButtonProps
+}
+
+const DEFAULT_TTL_MS = 30000
+
+function rangesOverlap(a: SuggestionRange, b: SuggestionRange): boolean {
+  if (a.file !== b.file) return false
+  // Inclusive fromLine, exclusive toLine per RFC §3.1.
+  return a.fromLine < b.toLine && b.fromLine < a.toLine
+}
+
+export function createInlineSuggestionManager(
+  opts?: InlineSuggestionOptions,
+): InlineSuggestionManager {
+  const ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS
+  const now = opts?.now ?? (() => new Date().toISOString())
+  const idGen = createIdGenerator('inline-suggestion')
+
+  const suggestions = new Map<string, InlineSuggestion>()
+  const ttlTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  const fileListeners = new Map<
+    string,
+    Set<(s: ReadonlyArray<InlineSuggestion>) => void>
+  >()
+
+  function emitFile(file: string): void {
+    const set = fileListeners.get(file)
+    if (set === undefined || set.size === 0) return
+    const listing = inFile(file)
+    for (const l of set) l(listing)
+  }
+
+  function clearTimer(id: string): void {
+    const t = ttlTimers.get(id)
+    if (t !== undefined) {
+      clearTimeout(t)
+      ttlTimers.delete(id)
+    }
+  }
+
+  function inFile(file: string): ReadonlyArray<InlineSuggestion> {
+    const out: InlineSuggestion[] = []
+    for (const s of suggestions.values()) {
+      if (s.range.file === file) out.push(s)
+    }
+    return Object.freeze(out)
+  }
+
+  function propose(input: InlineSuggestionInput): string {
+    const id = idGen.next()
+    const full: InlineSuggestion = Object.freeze({
+      ...input,
+      id,
+      createdAt: now(),
+    })
+    suggestions.set(id, full)
+    if (ttlMs > 0) {
+      const timer = setTimeout(() => {
+        // Only auto-reject if still present.
+        if (suggestions.has(id)) reject(id)
+      }, ttlMs)
+      ttlTimers.set(id, timer)
+    }
+    emitFile(full.range.file)
+    return id
+  }
+
+  function retract(id: string): void {
+    const s = suggestions.get(id)
+    if (s === undefined) return
+    suggestions.delete(id)
+    clearTimer(id)
+    emitFile(s.range.file)
+  }
+
+  function accept(id: string): void {
+    const s = suggestions.get(id)
+    if (s === undefined) return
+    suggestions.delete(id)
+    clearTimer(id)
+    if (opts?.onAccept !== undefined) opts.onAccept(s)
+    // Reject any other suggestion at an overlapping range in the same file.
+    const losers: InlineSuggestion[] = []
+    for (const other of Array.from(suggestions.values())) {
+      if (rangesOverlap(other.range, s.range)) {
+        losers.push(other)
+      }
+    }
+    for (const other of losers) {
+      suggestions.delete(other.id)
+      clearTimer(other.id)
+      if (opts?.onReject !== undefined) opts.onReject(other)
+    }
+    emitFile(s.range.file)
+  }
+
+  function reject(id: string): void {
+    const s = suggestions.get(id)
+    if (s === undefined) return
+    suggestions.delete(id)
+    clearTimer(id)
+    if (opts?.onReject !== undefined) opts.onReject(s)
+    emitFile(s.range.file)
+  }
+
+  return {
+    propose,
+    retract,
+    accept,
+    reject,
+
+    getAll(): ReadonlyArray<InlineSuggestion> {
+      return Object.freeze(Array.from(suggestions.values()))
+    },
+
+    inFile,
+
+    inRange(
+      file: string,
+      fromLine: number,
+      toLine: number,
+    ): ReadonlyArray<InlineSuggestion> {
+      const probe: SuggestionRange = { file, fromLine, toLine }
+      const out: InlineSuggestion[] = []
+      for (const s of suggestions.values()) {
+        if (rangesOverlap(s.range, probe)) out.push(s)
+      }
+      return Object.freeze(out)
+    },
+
+    topAtLine(file: string, line: number): InlineSuggestion | undefined {
+      let best: InlineSuggestion | undefined
+      for (const s of suggestions.values()) {
+        if (s.range.file !== file) continue
+        if (line < s.range.fromLine || line >= s.range.toLine) continue
+        if (best === undefined || s.confidence > best.confidence) {
+          best = s
+        }
+      }
+      return best
+    },
+
+    subscribeFile(
+      file: string,
+      listener: (s: ReadonlyArray<InlineSuggestion>) => void,
+    ): () => void {
+      let set = fileListeners.get(file)
+      if (set === undefined) {
+        set = new Set()
+        fileListeners.set(file, set)
+      }
+      set.add(listener)
+      return () => {
+        set!.delete(listener)
+        if (set!.size === 0) fileListeners.delete(file)
+      }
+    },
+  }
+}
+
+export function createSuggestionController(
+  manager: InlineSuggestionManager,
+  suggestionId: string,
+): SuggestionController {
+  const found = manager.getAll().find((s) => s.id === suggestionId)
+  if (found === undefined) {
+    throw new Error(`InlineSuggestion not found: ${suggestionId}`)
+  }
+  const suggestion: InlineSuggestion = found
+
+  const lineLabel =
+    suggestion.range.fromLine === suggestion.range.toLine - 1
+      ? `line ${suggestion.range.fromLine}`
+      : `lines ${suggestion.range.fromLine}-${suggestion.range.toLine - 1}`
+
+  const baseLabel = `Suggestion from ${suggestion.agentName}: replace ${lineLabel}. Press Tab to accept or Escape to reject.`
+
+  function handleKeyDown(e: SuggestionKeyEvent): void {
+    if (e.metaKey === true || e.ctrlKey === true || e.altKey === true) return
+    if (e.key === 'Tab' && e.shiftKey !== true) {
+      e.preventDefault()
+      manager.accept(suggestionId)
+      return
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      manager.reject(suggestionId)
+    }
+  }
+
+  return Object.freeze({
+    suggestion,
+
+    getRootProps(): SuggestionRootProps {
+      return Object.freeze({
+        id: `suggestion-${suggestion.id}`,
+        role: 'region' as const,
+        'aria-label': baseLabel,
+        'aria-keyshortcuts': 'Tab Escape' as const,
+        'data-state': 'suggested' as const,
+        'data-agent-color': `--k-${suggestion.agentColorSlot}`,
+        tabIndex: 0 as const,
+        onKeyDown: handleKeyDown,
+      })
+    },
+
+    getAcceptButtonProps(): SuggestionButtonProps {
+      return Object.freeze({
+        type: 'button' as const,
+        'aria-label': `Accept suggestion from ${suggestion.agentName}`,
+        'aria-keyshortcuts': 'Tab',
+        onClick: () => manager.accept(suggestionId),
+      })
+    },
+
+    getRejectButtonProps(): SuggestionButtonProps {
+      return Object.freeze({
+        type: 'button' as const,
+        'aria-label': `Reject suggestion from ${suggestion.agentName}`,
+        'aria-keyshortcuts': 'Escape',
+        onClick: () => manager.reject(suggestionId),
+      })
+    },
+  })
+}


### PR DESCRIPTION
## Summary

Implements `createInlineSuggestionManager` + `createSuggestionController` per RFC 0011 (`dashboard/design-system/RFC/0011-inline-suggestion.md`).

- `propose(input)` returns `inline-suggestion-N` id
- TTL via `setTimeout` per suggestion when `ttlMs > 0`; `0` disables; cleared on accept/reject/retract
- `accept(id)` removes target + auto-rejects all suggestions with overlapping range (same file + half-open interval `a.fromLine < b.toLine && b.fromLine < a.toLine`)
- `reject(id)` removes + fires `onReject`
- `retract(id)` silent removal — no callback fire
- `topAtLine(file, line)` returns highest-confidence suggestion containing that line
- `subscribeFile(file, listener)` per-file Set; auto-cleanup when last listener removed

Controller surface:

- `aria-label`: "Suggestion from <agent>: replace <line label>. Press Tab to accept or Escape to reject."
- `data-agent-color`: `--k-${agentColorSlot}`
- `aria-keyshortcuts`: "Tab Escape"
- `onKeyDown`: Tab → accept (calls `preventDefault`); Escape → reject; Shift+Tab / Mod+Tab no-op

## Verification

- `pnpm typecheck` — clean
- `pnpm test design-system/headless-core/inline-suggestion` — 22/22 pass (including TTL fake-timer tests)