### PR TITLE
F2: Extract KeeperBDIPanel with goal horizons

### DIFF
--- a/dashboard/src/components/keeper-bdi-panel.ts
+++ b/dashboard/src/components/keeper-bdi-panel.ts
@@ -1,0 +1,85 @@
+import { html } from 'htm/preact'
+import { KeeperDetailSectionCard } from './keeper-detail-layout'
+
+function ProfileField({ label, value, color }: { label: string; value: string; color: string }) {
+  return html`
+    <div class="flex items-start gap-2 text-xs text-[var(--color-fg-muted)]">
+      <span class="flex-shrink-0">${label}:</span>
+      <span class="font-medium leading-relaxed" style="color: ${color}">${value}</span>
+    </div>
+  `
+}
+
+function GoalHorizonRow({
+  horizon,
+  value,
+}: {
+  horizon: string
+  value: string | null | undefined
+}) {
+  if (!value) return null
+  return html`
+    <div class="flex items-start gap-2 text-xs text-[var(--color-fg-muted)]">
+      <span class="flex-shrink-0 rounded border border-[var(--white-10)] bg-[var(--white-6)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wide">${horizon}</span>
+      <span class="font-medium leading-relaxed text-[var(--color-fg-secondary)]">${value}</span>
+    </div>
+  `
+}
+
+export interface KeeperBDIPanelProps {
+  will?: string | null
+  needs?: string | null
+  desires?: string | null
+  short_goal?: string | null
+  mid_goal?: string | null
+  long_goal?: string | null
+  goal_horizons?: {
+    short?: string | null
+    mid?: string | null
+    long?: string | null
+  } | null
+}
+
+export function KeeperBDIPanel({
+  will,
+  needs,
+  desires,
+  short_goal,
+  mid_goal,
+  long_goal,
+  goal_horizons,
+}: KeeperBDIPanelProps) {
+  const hasBdi = will || needs || desires
+  const s = short_goal ?? goal_horizons?.short
+  const m = mid_goal ?? goal_horizons?.mid
+  const l = long_goal ?? goal_horizons?.long
+  const hasGoals = s || m || l
+
+  if (!hasBdi && !hasGoals) return null
+
+  return html`
+    <${KeeperDetailSectionCard} title="BDI & Horizons">
+      <div class="flex flex-col gap-3">
+        ${hasBdi
+          ? html`
+              <div class="flex flex-col gap-1.5">
+                ${will ? html`<${ProfileField} label="의지" value=${will} color="var(--cyan)" />` : null}
+                ${needs ? html`<${ProfileField} label="필요" value=${needs} color="var(--color-status-warn)" />` : null}
+                ${desires ? html`<${ProfileField} label="염망" value=${desires} color="var(--purple)" />` : null}
+              </div>
+            `
+          : null}
+        ${hasGoals
+          ? html`
+              <div class="flex flex-col gap-1.5">
+                <div class="text-2xs font-semibold uppercase tracking-wide text-[var(--color-fg-muted)] mb-0.5">goal horizons</div>
+                <${GoalHorizonRow} horizon="short" value=${s} />
+                <${GoalHorizonRow} horizon="mid" value=${m} />
+                <${GoalHorizonRow} horizon="long" value=${l} />
+              </div>
+            `
+          : null}
+      </div>
+    <//>
+  `
+}

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -76,6 +76,7 @@ import { KeeperToolTelemetry } from './keeper-tool-telemetry'
 import { KeeperToolCallInspector } from './keeper-tool-call-inspector'
 import { SupervisorDiagnosticsPanel } from './keeper-supervisor-diagnostics'
 import { KeeperEvalQualityPanel } from './keeper-eval-quality'
+import { KeeperBDIPanel } from './keeper-bdi-panel'
 import { KeeperDetailSectionCard as SectionCard } from './keeper-detail-layout'
 import {
   KeeperDetailHeaderInfo,
@@ -670,39 +671,6 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
   `
 }
 
-// ── Profile field (label + value inline) ────────────────
-
-function ProfileField({ label, value, color }: { label: string; value: string; color: string }) {
-  return html`
-    <div class="flex items-start gap-2 text-xs text-[var(--color-fg-muted)]">
-      <span class="flex-shrink-0">${label}:</span>
-      <span class="font-medium leading-relaxed" style="color: ${color}">${value}</span>
-    </div>
-  `
-}
-
-// ── BDI panel (will / needs / desires) ──────────────────
-// Preview spec K1 BDI variant — extraction of inline fragments.
-// Returns null when all three identity fields are absent so callers
-// can place this unconditionally without an outer guard.
-function BdiSection({
-  will,
-  needs,
-  desires,
-}: {
-  will: string | null | undefined
-  needs: string | null | undefined
-  desires: string | null | undefined
-}) {
-  if (!will && !needs && !desires) return null
-  return html`
-    <div class="mt-3 flex flex-col gap-1.5">
-      ${will ? html`<${ProfileField} label="의지" value=${will} color="var(--cyan)" />` : null}
-      ${needs ? html`<${ProfileField} label="필요" value=${needs} color="var(--color-status-warn)" />` : null}
-      ${desires ? html`<${ProfileField} label="열망" value=${desires} color="var(--purple)" />` : null}
-    </div>
-  `
-}
 
 // ── Playground Repos Panel ──────────────────────────────
 
@@ -1173,9 +1141,15 @@ export function KeeperDetailPage() {
               ? html`<div class="text-2xs text-[var(--color-fg-muted)] mt-1 leading-relaxed">${keeper.skill_reason}</div>`
               : null}
 
-            ${'' /* ── Identity: will / needs / desires (extracted to BdiSection) ── */}
-            <${BdiSection} will=${keeper.will} needs=${keeper.needs} desires=${keeper.desires} />
-              <//>
+            <${KeeperBDIPanel}
+              will=${keeper.will}
+              needs=${keeper.needs}
+              desires=${keeper.desires}
+              short_goal=${keeper.short_goal}
+              mid_goal=${keeper.mid_goal}
+              long_goal=${keeper.long_goal}
+              goal_horizons=${keeper.goal_horizons}
+            />
 
           ${keeper.inventory && keeper.inventory.length > 0
             ? html`


### PR DESCRIPTION
## Summary
Phase 2 Implementation Gap Audit — F2 (K1 BDI variant).

- Extract `BdiSection` + `ProfileField` inline fragments from `keeper-detail.ts`
- Create standalone `keeper-bdi-panel.ts` using `KeeperDetailSectionCard`
- Add `short_goal` / `mid_goal` / `long_goal` rendering with `goal_horizons` fallback
- Null-safe: returns `null` when both BDI and horizon data are absent

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [ ] Visual regression check in keeper detail page

## Gap reference
`dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md` — F2