### PR TITLE
chore(a2a): remove dead masc_a2a_* from advertised tool lists

### DIFF
--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -228,7 +228,6 @@ let core_remote_operation_names =
         "masc_agents";
         "masc_agent_update";
         "masc_messages";
-        "masc_a2a_subscribe";
         "masc_plan_init";
         "masc_plan_get";
         "masc_plan_update";

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -349,8 +349,6 @@ module Rest = struct
         [
           "masc_broadcast";
           "masc_messages";
-          "masc_a2a_delegate";
-          "masc_a2a_subscribe";
         ] );
       ( "decision",
         [


### PR DESCRIPTION
## Summary

A2A MCP tool surface decision halted (issue #10864, closed `not planned` 2026-04-30). This PR removes the false advertisement of `masc_a2a_subscribe` and `masc_a2a_delegate` from advertised tool lists.

## Why

- `Tool_inline_dispatch.*` string match for `"masc_a2a_*"`: **0**
- `A2a_tools.subscribe` / `A2a_tools.poll_events` direct caller (lib/, bin/, test/): **0**
- PR #7184 (2026-04-15, "prune dead tool registry — 65 tools removed") rationale: 0-call tools removed. Same standard applied here to two surface entries that escaped that prune.

The internal `A2a_tools` API (`notify_event` / `cleanup_*` / `latest_heartbeat_*` / `default_a2a_version`) remains active in 9 lib files for background coord and dashboard data — explicitly out of scope.

## Scope

3 lines, 2 files:

| File | Lines | Change |
|------|-------|--------|
| `lib/transport.ml` | 352-353 | remove `"masc_a2a_delegate"`, `"masc_a2a_subscribe"` from `messaging` category |
| `lib/sdk_tool_contract.ml` | 231 | remove `"masc_a2a_subscribe"` from `core_remote_operation_names` |

Variant types (`Tool_name.A2a_subscribe`, `Tool_name.A2a_delegate`) are intentionally kept to avoid OCaml type-cascade across `tool_name.ml` / `tool_name.mli` / `tool_catalog.ml` / `mcp_server_eio_tool_profile.ml`. A separate full-sunset PR can prune them if/when complete sunset is decided.

## Verification

- Diff is type-stable: removing string literal elements from a `string list`. No type signatures change.
- No other references to the removed advertised strings in the modified files.
- Diff size: `2 files changed, 3 deletions(-)`.

## Main blockers (out of scope)

`main` currently has unrelated build errors that are not introduced by this PR:

- `lib/` partial-match: `Some (ProviderFailure _)` not handled
- `test/test_keeper_state_machine*.ml`: `terminal_failure_latched` field unbound (test side stale after PR #12114 merge 2026-04-30 02:51)

These will be fixed by separate PRs (likely the same ZOMBIE/terminal_failure_latched alignment family). This PR's CI may show these failures; they are pre-existing main blockers.

## References

- Issue #10864 — closed `not planned`, full halt rationale + 6 analysis comments
- PR #7184 — prior prune precedent
- Memory: `project_a2a_surface_halt_2026_04_30`
