### PR TITLE
feat(sse): introduce Sse_presence module (PR-1.7a-1-α scaffold)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -296,6 +296,7 @@
    shutdown_hooks
    spawn
    sse
+   sse_presence
    streamable_http
    subsystem_health
    subscriptions

--- a/lib/sse_presence.ml
+++ b/lib/sse_presence.ml
@@ -1,0 +1,244 @@
+(** Sse_presence — independent SSE channel for awareness/presence traffic.
+
+    Mirrors the lock-free registry + per-session mailbox + bounded ring
+    buffer pattern from {!Sse}, but owns separate state.  Heartbeat-class
+    publishers in PR-1.7a-2 will dual-emit to both channels; this module
+    is the consumer-side half.  Until the HTTP route in PR-1.7a-1-β
+    wires up actual subscribers, [register] / [broadcast] are exercised
+    only by tests, which is intentional — see RFC sec 4.4 stage 1. *)
+
+module SMap = Map.Make (String)
+
+type client = {
+  id : int;
+  event_stream : string Eio.Stream.t;
+  last_event_id : int Atomic.t;
+  created_at : float;
+  last_seen_at : float Atomic.t;
+}
+
+type client_registry_state = {
+  entries : client SMap.t;
+  count : int;
+}
+
+(** Reuse the same operational caps as {!Sse}.  Presence has lighter
+    payload (heartbeat tick) so a tighter limit is possible later, but
+    matching the main channel keeps capacity-planning predictable. *)
+let max_clients = 200
+
+let stream_capacity = 64
+
+let max_buffer_size = 100
+
+let buffer_ttl_seconds = Env_config.InternalTimers.sse_buffer_ttl_sec
+
+let empty_client_registry_state = { entries = SMap.empty; count = 0 }
+
+let clients : client_registry_state Atomic.t =
+  Atomic.make empty_client_registry_state
+
+let client_id_counter = Atomic.make 0
+
+(** Independent of {!Sse.event_counter}: presence subscribers track
+    their own [Last-Event-Id]. *)
+let event_counter = Atomic.make 0
+
+let event_buffer : (int * string * float) list Atomic.t = Atomic.make []
+
+let take n xs =
+  let rec loop acc remaining items =
+    match (remaining, items) with
+    | remaining, _ when remaining <= 0 -> List.rev acc
+    | _, [] -> List.rev acc
+    | _, x :: rest -> loop (x :: acc) (remaining - 1) rest
+  in
+  loop [] n xs
+
+let buffer_event event_id event_str =
+  Lockfree_atomic.update_with_commit event_buffer (fun lst ->
+      let timestamp = Time_compat.now () in
+      let next = (event_id, event_str, timestamp) :: lst in
+      let trimmed =
+        if List.length next > max_buffer_size then take max_buffer_size next
+        else next
+      in
+      { next_state = trimmed; result = () })
+
+let get_events_after last_id =
+  let lst = Atomic.get event_buffer in
+  List.fold_left
+    (fun acc (id, ev, _ts) -> if id > last_id then ev :: acc else acc)
+    [] lst
+
+let cleanup_expired_events () =
+  let now = Time_compat.now () in
+  Lockfree_atomic.update_with_commit event_buffer (fun lst ->
+      let remaining_oldest_first, evicted =
+        List.fold_left
+          (fun (kept, evicted) (((_id, _ev, ts) as item) : int * string * float) ->
+            if now -. ts > buffer_ttl_seconds then (kept, evicted + 1)
+            else (item :: kept, evicted))
+          ([], 0) lst
+      in
+      { next_state = List.rev remaining_oldest_first; result = evicted })
+
+let current_id () = Atomic.get event_counter
+
+let next_id () = Atomic.fetch_and_add event_counter 1 + 1
+
+let mark_seen (client : client) =
+  Atomic.set client.last_seen_at (Time_compat.now ())
+
+let register session_id ~last_event_id =
+  let client_id = Atomic.fetch_and_add client_id_counter 1 + 1 in
+  let last_event_id = Atomic.make last_event_id in
+  let event_stream = Eio.Stream.create stream_capacity in
+  let base_client =
+    {
+      id = client_id;
+      event_stream;
+      last_event_id;
+      created_at = 0.0;
+      last_seen_at = Atomic.make 0.0;
+    }
+  in
+  let evicted =
+    Lockfree_atomic.update_with_commit clients (fun state ->
+        let evicted =
+          if state.count >= max_clients
+             && not (SMap.mem session_id state.entries)
+          then
+            let oldest =
+              SMap.fold
+                (fun sid existing acc ->
+                  match acc with
+                  | None -> Some (sid, existing)
+                  | Some (_, current_oldest) ->
+                      if existing.created_at < current_oldest.created_at
+                      then Some (sid, existing)
+                      else acc)
+                state.entries None
+            in
+            Option.map fst oldest
+          else None
+        in
+        let entries_after_eviction =
+          match evicted with
+          | Some sid -> SMap.remove sid state.entries
+          | None -> state.entries
+        in
+        let install_time = Time_compat.now () in
+        let client =
+          {
+            base_client with
+            created_at = install_time;
+            last_seen_at = Atomic.make install_time;
+          }
+        in
+        let next_entries =
+          SMap.add session_id client entries_after_eviction
+        in
+        {
+          next_state =
+            {
+              entries = next_entries;
+              count = SMap.cardinal next_entries;
+            };
+          result = evicted;
+        })
+  in
+  (match evicted with
+   | Some sid ->
+       Log.Server.info
+         "Evicting oldest presence client %s (at cap %d)" sid max_clients
+   | None -> ());
+  (client_id, event_stream, evicted)
+
+let unregister session_id =
+  Lockfree_atomic.update_with_commit clients (fun state ->
+      if SMap.mem session_id state.entries then
+        let next_entries = SMap.remove session_id state.entries in
+        {
+          next_state = { entries = next_entries; count = state.count - 1 };
+          result = ();
+        }
+      else { next_state = state; result = () })
+
+let unregister_if_current session_id client_id =
+  Lockfree_atomic.update_with_commit clients (fun state ->
+      match SMap.find_opt session_id state.entries with
+      | Some client when client.id = client_id ->
+          let next_entries = SMap.remove session_id state.entries in
+          {
+            next_state =
+              { entries = next_entries; count = state.count - 1 };
+            result = ();
+          }
+      | _ -> { next_state = state; result = () })
+
+let exists session_id = SMap.mem session_id (Atomic.get clients).entries
+
+let touch session_id =
+  match SMap.find_opt session_id (Atomic.get clients).entries with
+  | Some client -> mark_seen client
+  | None -> ()
+
+let update_last_event_id session_id event_id =
+  match SMap.find_opt session_id (Atomic.get clients).entries with
+  | Some client -> Atomic.set client.last_event_id event_id
+  | None -> ()
+
+let all_session_ids () =
+  SMap.fold
+    (fun sid _client acc -> sid :: acc)
+    (Atomic.get clients).entries []
+
+let client_count () = (Atomic.get clients).count
+
+let close_all_clients () =
+  Lockfree_atomic.update_with_commit clients (fun state ->
+      let count = state.count in
+      { next_state = empty_client_registry_state; result = count })
+
+let broadcast json =
+  let data = Yojson.Safe.to_string json in
+  let current_event_id = next_id () in
+  let event = Sse.format_event ~id:current_event_id ~event_type:"message" data in
+  buffer_event current_event_id event;
+  let clients_entries = (Atomic.get clients).entries in
+  let failed = ref [] in
+  SMap.iter
+    (fun session_id client ->
+      if current_event_id > Atomic.get client.last_event_id then
+        let queue_len = Eio.Stream.length client.event_stream in
+        if queue_len >= stream_capacity then begin
+          Log.Server.warn
+            "Presence broadcast skip: session %s stream full (%d/%d)"
+            session_id queue_len stream_capacity;
+          failed := session_id :: !failed
+        end
+        else
+          try
+            Eio.Stream.add client.event_stream event;
+            Atomic.set client.last_event_id current_event_id;
+            mark_seen client
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | e ->
+              Log.Server.error
+                "Presence broadcast enqueue failed for session %s: %s"
+                session_id (Printexc.to_string e);
+              failed := session_id :: !failed)
+    clients_entries;
+  List.iter (fun sid -> unregister sid) !failed
+
+let pop session_id =
+  match SMap.find_opt session_id (Atomic.get clients).entries with
+  | None -> None
+  | Some client -> Some (Eio.Stream.take client.event_stream)
+
+let try_pop session_id =
+  match SMap.find_opt session_id (Atomic.get clients).entries with
+  | None -> None
+  | Some client -> Eio.Stream.take_nonblocking client.event_stream

--- a/lib/sse_presence.mli
+++ b/lib/sse_presence.mli
@@ -1,0 +1,95 @@
+(** Sse_presence — Independent SSE channel for awareness/presence traffic.
+
+    Implements the server-side half of RFC PR-1.7
+    ([docs/rfc/awareness-channel-split.md]).  This module owns its own
+    client registry and event buffer so that broadcasting heartbeat-class
+    events on the presence channel does not flood the main MCP SSE
+    stream, and vice versa.
+
+    Wire compatibility: events are formatted via {!Sse.format_event} so
+    on-the-wire framing is identical to the main channel.  The two
+    channels diverge in [event_counter] (separate sequences for
+    independent [Last-Event-Id] resumability) and in subscriber set
+    (separate [Atomic.t] registries).
+
+    Caller layering: this module is intentionally minimal — it is the
+    storage + fan-out primitive.  HTTP route wiring (e.g. an
+    [/events/presence] endpoint) and producer-side dual-emit live in
+    follow-on PRs (PR-1.7a-1-β and PR-1.7a-2 respectively).
+
+    @since 0.18.x *)
+
+(** {1 Types} *)
+
+module SMap : Map.S with type key = string
+
+(** Per-session presence subscriber.
+
+    Unlike {!Sse.client}, presence subscribers do not have a
+    [session_kind] — every subscriber is treated equally. *)
+type client = {
+  id : int;
+  event_stream : string Eio.Stream.t;
+  last_event_id : int Atomic.t;
+  created_at : float;
+  last_seen_at : float Atomic.t;
+}
+
+type client_registry_state = {
+  entries : client SMap.t;
+  count : int;
+}
+
+(** {1 Constants} *)
+
+val max_clients : int
+val max_buffer_size : int
+val buffer_ttl_seconds : float
+val stream_capacity : int
+
+(** {1 Session Management} *)
+
+(** [register session_id ~last_event_id] registers a new presence
+    subscriber. Returns [(client_id, event_stream, evicted_session_id_opt)].
+    Same eviction semantics as {!Sse.register}: oldest client is evicted
+    at capacity. *)
+val register :
+  string -> last_event_id:int ->
+  int * string Eio.Stream.t * string option
+
+val unregister : string -> unit
+val unregister_if_current : string -> int -> unit
+val exists : string -> bool
+val touch : string -> unit
+val update_last_event_id : string -> int -> unit
+val all_session_ids : unit -> string list
+val client_count : unit -> int
+val close_all_clients : unit -> int
+
+(** {1 Events} *)
+
+(** Allocate next presence event id (independent of {!Sse.next_id}). *)
+val next_id : unit -> int
+
+val current_id : unit -> int
+
+(** {1 Broadcast} *)
+
+(** Push event to every registered presence subscriber. Wire-format is
+    {!Sse.format_event} with [~event_type:"message"]. *)
+val broadcast : Yojson.Safe.t -> unit
+
+(** Pop the next queued event for a session. Blocks until one arrives.
+    Returns [None] if the session has been unregistered. *)
+val pop : string -> string option
+
+(** Non-blocking pop — returns [None] when the queue is empty. *)
+val try_pop : string -> string option
+
+(** {1 Event Buffer} *)
+
+val clients : client_registry_state Atomic.t
+val event_buffer : (int * string * float) list Atomic.t
+val buffer_event : int -> string -> unit
+val get_events_after : int -> string list
+val cleanup_expired_events : unit -> int

--- a/test/dune
+++ b/test/dune
@@ -33,7 +33,7 @@
 (tests
  (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
         test_attempt_state
-        test_sse test_cancellation test_graphql_api
+        test_sse test_sse_presence test_cancellation test_graphql_api
         test_graphql_endpoint
         test_subscriptions test_session test_progress test_spawn
         test_validation test_response
@@ -216,7 +216,7 @@
         test_keeper_turn_fsm_wired_sites)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
-          test_sse test_cancellation test_graphql_api
+          test_sse test_sse_presence test_cancellation test_graphql_api
           test_graphql_endpoint
           test_subscriptions test_session test_progress test_spawn
           test_validation test_response

--- a/test/test_sse_presence.ml
+++ b/test/test_sse_presence.ml
@@ -1,0 +1,113 @@
+(** Isolation tests for {!Masc_mcp.Sse_presence}.
+
+    These tests anchor the contract that the presence channel and the
+    main SSE channel share *no* runtime state.  RFC PR-1.7 sec 4.4 stage 1
+    explicitly relies on this independence — if a future refactor
+    silently routes presence broadcasts through {!Sse}'s registry the
+    dual-emit story collapses. *)
+
+open Alcotest
+
+let fresh_sid prefix =
+  prefix ^ "_" ^ string_of_int (Random.int 1_000_000_000)
+
+let test_register_does_not_leak_into_main () =
+  let module SP = Masc_mcp.Sse_presence in
+  let module S = Masc_mcp.Sse in
+  let sid = fresh_sid "presence_only" in
+  let main_count_before = S.client_count () in
+  let presence_count_before = SP.client_count () in
+  let (_id, _stream, _evicted) = SP.register sid ~last_event_id:0 in
+  check bool "presence subscriber is visible to presence registry"
+    true (SP.exists sid);
+  check bool "presence subscriber is invisible to main SSE registry"
+    false (S.exists sid);
+  check int "main client count unchanged"
+    main_count_before (S.client_count ());
+  check int "presence client count incremented"
+    (presence_count_before + 1) (SP.client_count ());
+  SP.unregister sid
+
+let test_broadcast_does_not_cross_channels () =
+  let module SP = Masc_mcp.Sse_presence in
+  let module S = Masc_mcp.Sse in
+  let presence_sid = fresh_sid "p" in
+  let main_sid = fresh_sid "m" in
+  let (_pid, presence_stream, _) = SP.register presence_sid ~last_event_id:0 in
+  let (_mid, main_stream, _) = S.register main_sid ~last_event_id:0 in
+  Fun.protect
+    ~finally:(fun () ->
+      SP.unregister presence_sid;
+      S.unregister main_sid)
+    (fun () ->
+      (* Sse_presence.broadcast must NOT reach a main-channel subscriber *)
+      SP.broadcast (`Assoc [ "type", `String "keeper_heartbeat" ]);
+      check int "main subscriber receives no presence broadcast"
+        0 (Eio.Stream.length main_stream);
+      check bool "presence subscriber receives presence broadcast (>=1)"
+        true (Eio.Stream.length presence_stream >= 1);
+
+      (* Sse.broadcast must NOT reach the presence subscriber *)
+      let presence_queue_before = Eio.Stream.length presence_stream in
+      S.broadcast (`Assoc [ "type", `String "masc:broadcast" ]);
+      check int "presence subscriber receives no main broadcast"
+        presence_queue_before (Eio.Stream.length presence_stream))
+
+let test_event_counter_independence () =
+  let module SP = Masc_mcp.Sse_presence in
+  let module S = Masc_mcp.Sse in
+  let main_before = S.current_id () in
+  let presence_before = SP.current_id () in
+  (* Bumping presence must not advance the main counter, and vice versa *)
+  let _ = SP.next_id () in
+  let _ = SP.next_id () in
+  check int "main counter unaffected by presence next_id"
+    main_before (S.current_id ());
+  let _ = S.next_id () in
+  check int "presence counter unaffected by main next_id"
+    (presence_before + 2) (SP.current_id ())
+
+let test_buffer_independence () =
+  let module SP = Masc_mcp.Sse_presence in
+  let module S = Masc_mcp.Sse in
+  (* Anchor on the addresses of the Atomic.t cells: presence and main
+     must not share storage.  If a future refactor unifies them the
+     dual-emit + independent Last-Event-Id story breaks. *)
+  check bool "client registries are distinct atomics"
+    true (SP.clients != Obj.magic S.clients);
+  check bool "event buffers are distinct atomics"
+    true (SP.event_buffer != Obj.magic S.event_buffer)
+
+let test_buffer_replay () =
+  let module SP = Masc_mcp.Sse_presence in
+  let id1 = SP.next_id () in
+  SP.buffer_event id1 "id: 1\nevent: message\ndata: a\n\n";
+  let id2 = SP.next_id () in
+  SP.buffer_event id2 "id: 2\nevent: message\ndata: b\n\n";
+  let replay = SP.get_events_after (id1 - 1) in
+  check int "replay returns 2 events" 2 (List.length replay);
+  let replay_after = SP.get_events_after id2 in
+  check int "replay after newest returns 0" 0 (List.length replay_after)
+
+let () =
+  run "sse_presence"
+    [
+      ("registration",
+        [
+          test_case "presence register does not leak into main SSE"
+            `Quick test_register_does_not_leak_into_main;
+        ]);
+      ("isolation",
+        [
+          test_case "broadcast does not cross channels"
+            `Quick test_broadcast_does_not_cross_channels;
+          test_case "event counters are independent"
+            `Quick test_event_counter_independence;
+          test_case "registries and buffers are distinct atomics"
+            `Quick test_buffer_independence;
+        ]);
+      ("replay",
+        [ test_case "buffer replay by last_event_id"
+            `Quick test_buffer_replay;
+        ]);
+    ]


### PR DESCRIPTION
## What

Storage + fan-out primitive for the new awareness/presence SSE channel proposed in [docs/rfc/awareness-channel-split.md](docs/rfc/awareness-channel-split.md) (PR-1.7).

3 new files, 2 dune updates:

| File | Purpose |
|------|---------|
| `lib/sse_presence.ml` (231 LOC) | Independent SSE registry + buffer + broadcast |
| `lib/sse_presence.mli` (76 LOC) | Public interface |
| `test/test_sse_presence.ml` (115 LOC) | 5 isolation tests |
| `lib/dune` | Add `sse_presence` to module list |
| `test/dune` | Add `test_sse_presence` (2 spots) |

## Why this PR (not the full PR-1.7a)

The full PR-1.7a-1 = module + HTTP route + dune + tests is medium surgery. Splitting into:

- **PR-1.7a-1-α** *(this PR)* — module only. Additive, zero callers. Risk: low.
- **PR-1.7a-1-β** *(next)* — `/events/presence` HTTP endpoint consuming `Sse_presence`.
- **PR-1.7a-2** *(after that)* — heartbeat dual-emit at the 3 publisher sites identified in updated RFC sec 1.3 (`keeper_heartbeat_snapshot.ml:395`, `keeper_heartbeat_loop.ml:253`, `keeper_registry.ml:454`).

Each step independently revertable.

## Design decisions

**Mirror, don't refactor**. `Sse_presence` copies the lock-free pattern from `Sse` (Atomic.t SMap registry + Lockfree_atomic CAS + bounded `Eio.Stream` mailboxes + ring buffer with TTL). Trying to parameterize `Sse` to support multiple channels would be a much larger surgery and is reserved for after PR-1.7c (cleanup) lands.

**Reuse `Sse.format_event` for wire framing**. Payload bytes on the wire stay byte-identical to the main channel. The two channels diverge only in:

- separate client registry (`Sse_presence.clients`)
- separate event buffer (`Sse_presence.event_buffer`)
- separate Last-Event-Id sequence (`Sse_presence.event_counter`)

**No `session_kind` on presence subscribers**. Unlike `Sse.client`, presence subscribers are uniform — no Observer/Coordinator distinction. Heartbeat is presence-class regardless of who consumes it.

## Isolation tests

5 alcotest cases anchor the contract that future refactors cannot silently merge state:

1. `presence register does not leak into main SSE` — checks `Sse.exists` returns `false` for a presence-only sid.
2. `broadcast does not cross channels` — both directions: `Sse_presence.broadcast` does not enqueue into a main subscriber's stream, and vice versa.
3. `event counters are independent` — bumping `Sse_presence.next_id` does not advance `Sse.event_counter`.
4. `registries and buffers are distinct atomics` — physical pointer inequality on `Atomic.t` cells.
5. `buffer replay by last_event_id` — `get_events_after` returns events strictly newer than the cursor.

## Build status

`lib/sse_presence.{cmi,cmo,cmt,cmti}` compile cleanly in isolation (`dune build lib/.masc_mcp.objs/byte/masc_mcp__Sse_presence.cmi`).

Full `dune build` of this branch currently fails on **pre-existing** breakage in main: `Llm_provider.Http_client.ProviderFailure` variant was added without sweeping all match arms (`lib/cascade/cascade_fsm.ml`, `lib/tool_local_runtime_*.ml`, `lib/oas_worker_named.ml`). Fix is already in flight at #12121 (Codex Bump OAS agent SDK pin to 0.186.0). This PR's CI should pass once #12121 lands.

## External consumer audit (downstream evidence)

A focused sub-agent audit of `Sse.subscribe_external` callers identifies 3 external SSE consumers that currently receive heartbeats unfiltered:

- `lib/server/server_ws_standalone.ml:44` (standalone WebSocket)
- `lib/server/server_mcp_transport_ws.ml:821` (HTTP-upgraded WebSocket)
- `lib/grpc/masc_grpc_service.ml:511` (gRPC `Subscribe` RPC)

This PR does not touch them. The audit is recorded for PR-1.7c (broadcast cleanup), which is the actual wire-breaking change.

## Out of scope

- HTTP route (`/events/presence`) — PR-1.7a-1-β
- Producer dual-emit — PR-1.7a-2
- Dashboard `EventSource('/events/presence')` consumer — PR-1.7b
- `dune fmt` of unrelated files (main repo is not ocamlformat-clean; sweep would reformat ~2200 files unrelated to this change)

## Test plan
- [x] `Sse_presence` module compiles in isolation (cmi/cmo/cmt/cmti)
- [x] Race-check `gh pr list --search "sse_presence OR PR-1.7a-1"` → no parallel work
- [x] RFC drift fix (PR-1.7a-0, #12115) merged or in flight before this Ready
- [ ] Full `dune build` passes after #12121 lands
- [ ] `test/test_sse_presence.exe` 5 cases pass
- [ ] Self-review per `@~/me/agents/best-programmer/AGENT.md` before Ready