### PR TITLE
feat(headless-preact): RFC 0009 useTaskQueue adapter

### DIFF
--- a/dashboard/design-system/headless-preact/use-task-queue.test.ts
+++ b/dashboard/design-system/headless-preact/use-task-queue.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+//
+// Tests for headless-preact/use-task-queue. Verifies that hooks
+// react to manager updates via Preact re-render cycle.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { createTaskQueueManager } from '../headless-core/task-queue'
+import {
+  useTask,
+  useTaskQueue,
+  useTasksByPriority,
+  useTasksByState,
+  useTasksForAgent,
+} from './use-task-queue'
+
+function flushEffects(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 16))
+}
+
+let container: HTMLElement
+let mounted = 0
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.append(container)
+  mounted = 0
+})
+
+afterEach(() => {
+  render(null, container)
+  container.remove()
+})
+
+describe('useTaskQueue', () => {
+  it('reads initial snapshot synchronously on mount', async () => {
+    const manager = createTaskQueueManager({
+      initialTasks: [
+        { id: 't1', agentId: 'a', title: 'first', priority: 1, state: 'queued' },
+      ],
+    })
+    let captured: ReadonlyArray<{ id: string }> = []
+    function Probe(): unknown {
+      const { tasks } = useTaskQueue(manager)
+      captured = tasks
+      mounted += 1
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('re-renders on add', async () => {
+    const manager = createTaskQueueManager()
+    let captured: ReadonlyArray<{ id: string }> = []
+    function Probe(): unknown {
+      const { tasks } = useTaskQueue(manager)
+      captured = tasks
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    manager.add({ id: 't1', agentId: 'a', title: 'x', priority: 1, state: 'queued' })
+    await flushEffects()
+    expect(captured.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('byState exposes manager.byState', async () => {
+    const manager = createTaskQueueManager({
+      initialTasks: [
+        { id: 't1', agentId: 'a', title: 'r', priority: 1, state: 'running' },
+        { id: 't2', agentId: 'a', title: 'q', priority: 1, state: 'queued' },
+      ],
+    })
+    let api!: ReturnType<typeof useTaskQueue>
+    function Probe(): unknown {
+      api = useTaskQueue(manager)
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(api.byState('running').map((t) => t.id)).toEqual(['t1'])
+    expect(api.byState('queued').map((t) => t.id)).toEqual(['t2'])
+  })
+})
+
+describe('useTask', () => {
+  it('returns undefined for unknown id (no throw)', async () => {
+    const manager = createTaskQueueManager()
+    let captured: { id: string } | undefined = { id: 'placeholder' }
+    function Probe(): unknown {
+      captured = useTask(manager, 'missing')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured).toBeUndefined()
+  })
+
+  it('re-renders only on per-task changes', async () => {
+    const manager = createTaskQueueManager({
+      initialTasks: [
+        { id: 't1', agentId: 'a', title: 'one', priority: 1, state: 'queued' },
+        { id: 't2', agentId: 'a', title: 'two', priority: 1, state: 'queued' },
+      ],
+    })
+    let renders = 0
+    let last: { state: string } | undefined
+    function Probe(): unknown {
+      renders += 1
+      last = useTask(manager, 't1')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    const before = renders
+    manager.update('t2', { state: 'running' })
+    await flushEffects()
+    expect(renders).toBe(before)
+    manager.update('t1', { state: 'running' })
+    await flushEffects()
+    expect(last?.state).toBe('running')
+    expect(renders).toBeGreaterThan(before)
+  })
+})
+
+describe('useTasksForAgent', () => {
+  it('filters to agentId and updates on add', async () => {
+    const manager = createTaskQueueManager({
+      initialTasks: [
+        { id: 't1', agentId: 'alice', title: 'a1', priority: 1, state: 'queued' },
+        { id: 't2', agentId: 'bob', title: 'b1', priority: 1, state: 'queued' },
+      ],
+    })
+    let captured: ReadonlyArray<{ id: string }> = []
+    function Probe(): unknown {
+      captured = useTasksForAgent(manager, 'alice')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.map((t) => t.id)).toEqual(['t1'])
+    manager.add({ id: 't3', agentId: 'alice', title: 'a2', priority: 1, state: 'queued' })
+    await flushEffects()
+    expect(captured.map((t) => t.id).sort()).toEqual(['t1', 't3'])
+  })
+})
+
+describe('useTasksByState', () => {
+  it('returns only matching state tasks and updates on transition', async () => {
+    const manager = createTaskQueueManager({
+      initialTasks: [
+        { id: 't1', agentId: 'a', title: 'r', priority: 1, state: 'running' },
+        { id: 't2', agentId: 'a', title: 'q', priority: 1, state: 'queued' },
+      ],
+    })
+    let captured: ReadonlyArray<{ id: string }> = []
+    function Probe(): unknown {
+      captured = useTasksByState(manager, 'running')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.map((t) => t.id)).toEqual(['t1'])
+    manager.update('t2', { state: 'running' })
+    await flushEffects()
+    expect(captured.map((t) => t.id).sort()).toEqual(['t1', 't2'])
+  })
+})
+
+describe('useTasksByPriority', () => {
+  it('returns priority-ordered tasks', async () => {
+    const manager = createTaskQueueManager({
+      initialTasks: [
+        { id: 'lo', agentId: 'a', title: 'l', priority: 1, state: 'queued' },
+        { id: 'hi', agentId: 'a', title: 'h', priority: 5, state: 'queued' },
+      ],
+    })
+    let captured: ReadonlyArray<{ id: string }> = []
+    function Probe(): unknown {
+      captured = useTasksByPriority(manager)
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.map((t) => t.id)).toEqual(['hi', 'lo'])
+  })
+})

--- a/dashboard/design-system/headless-preact/use-task-queue.ts
+++ b/dashboard/design-system/headless-preact/use-task-queue.ts
@@ -1,0 +1,96 @@
+/**
+ * useTaskQueue — Preact adapter over headless-core/TaskQueueManager
+ * (RFC 0009 §3.3).
+ *
+ * Hooks for whole-snapshot, per-task, and per-agent subscriptions.
+ * The manager is provided externally so multiple surfaces (rail,
+ * keeper card, activity feed) share one canonical task list.
+ */
+
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import type {
+  Task,
+  TaskQueueManager,
+  TaskState,
+} from '../headless-core/task-queue'
+
+export function useTaskQueue(manager: TaskQueueManager): {
+  readonly tasks: ReadonlyArray<Task>
+  readonly byState: (state: TaskState) => ReadonlyArray<Task>
+} {
+  const [tasks, setTasks] = useState<ReadonlyArray<Task>>(() => manager.getAll())
+  useEffect(() => {
+    setTasks(manager.getAll())
+    const dispose = manager.subscribe((s) => setTasks(s))
+    return dispose
+  }, [manager])
+  const api = useMemo(
+    () => ({
+      tasks,
+      byState: (state: TaskState) => manager.byState(state),
+    }),
+    [manager, tasks],
+  )
+  return api
+}
+
+export function useTask(
+  manager: TaskQueueManager,
+  id: string,
+): Task | undefined {
+  const initial = useMemo(
+    () => manager.getAll().find((t) => t.id === id),
+    [manager, id],
+  )
+  const [task, setTask] = useState<Task | undefined>(initial)
+  useEffect(() => {
+    setTask(manager.getAll().find((t) => t.id === id))
+    const dispose = manager.subscribeTask(id, (t) => setTask(t))
+    return dispose
+  }, [manager, id])
+  return task
+}
+
+export function useTasksForAgent(
+  manager: TaskQueueManager,
+  agentId: string,
+): ReadonlyArray<Task> {
+  const [tasks, setTasks] = useState<ReadonlyArray<Task>>(() =>
+    manager.byAgent(agentId),
+  )
+  useEffect(() => {
+    setTasks(manager.byAgent(agentId))
+    const dispose = manager.subscribe(() => setTasks(manager.byAgent(agentId)))
+    return dispose
+  }, [manager, agentId])
+  return tasks
+}
+
+export function useTasksByState(
+  manager: TaskQueueManager,
+  state: TaskState,
+): ReadonlyArray<Task> {
+  const [tasks, setTasks] = useState<ReadonlyArray<Task>>(() =>
+    manager.byState(state),
+  )
+  useEffect(() => {
+    setTasks(manager.byState(state))
+    const dispose = manager.subscribe(() => setTasks(manager.byState(state)))
+    return dispose
+  }, [manager, state])
+  return tasks
+}
+
+export function useTasksByPriority(
+  manager: TaskQueueManager,
+): ReadonlyArray<Task> {
+  const [tasks, setTasks] = useState<ReadonlyArray<Task>>(() =>
+    manager.byPriority(),
+  )
+  useEffect(() => {
+    setTasks(manager.byPriority())
+    const dispose = manager.subscribe(() => setTasks(manager.byPriority()))
+    return dispose
+  }, [manager])
+  return tasks
+}


### PR DESCRIPTION
## Summary

Implements RFC 0009 §3.3 Preact adapter over the merged `TaskQueueManager` (#12110).

- `useTaskQueue(manager)` — snapshot + `byState()` helper
- `useTask(manager, id)` — per-task subscribe; returns `undefined` for unknown id (no throw)
- `useTasksForAgent(manager, agentId)`
- `useTasksByState(manager, state)`
- `useTasksByPriority(manager)` — priority-ordered

## Verification

- `pnpm typecheck` — clean
- `pnpm test design-system/headless-preact/use-task-queue` — 8/8 pass (happy-dom)

## Pattern

Mirrors `use-agent-presence.ts`: lazy initial state from manager, `useEffect` subscribes with manager dep, returns dispose. Per-task hook re-renders only on its own task changes (verified in test).