### PR TITLE
feat(headless-preact): RFC 0010 useCollaboration adapter

### DIFF
--- a/dashboard/design-system/headless-preact/use-collaboration.test.ts
+++ b/dashboard/design-system/headless-preact/use-collaboration.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+//
+// Tests for headless-preact/use-collaboration. Verifies file-scoped
+// reactivity over the headless CollaborationManager.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { createAgentPresenceManager } from '../headless-core/agent-presence'
+import { createCollaborationManager } from '../headless-core/collaboration'
+import { useFileConflicts, useFileCursors } from './use-collaboration'
+
+function flushEffects(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 16))
+}
+
+let container: HTMLElement
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.append(container)
+})
+
+afterEach(() => {
+  render(null, container)
+  container.remove()
+})
+
+function setupTwo(): {
+  presence: ReturnType<typeof createAgentPresenceManager>
+  collab: ReturnType<typeof createCollaborationManager>
+} {
+  const presence = createAgentPresenceManager({
+    initialAgents: [
+      {
+        id: 'a',
+        name: 'Alice',
+        sigil: { text: 'A' },
+        colorSlot: 1,
+      },
+      {
+        id: 'b',
+        name: 'Bob',
+        sigil: { text: 'B' },
+        colorSlot: 2,
+      },
+    ],
+  })
+  const collab = createCollaborationManager({ presence })
+  return { presence, collab }
+}
+
+describe('useFileCursors', () => {
+  it('initial snapshot has cursors that already exist', async () => {
+    const { presence, collab } = setupTwo()
+    presence.updateCursor('a', 'src/foo.ts', 10, 1)
+    let captured: ReadonlyArray<{ file: string }> = []
+    function Probe(): unknown {
+      captured = useFileCursors(collab, 'src/foo.ts')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.length).toBe(1)
+    expect(captured[0]!.file).toBe('src/foo.ts')
+  })
+
+  it('re-renders on cursor add in subscribed file', async () => {
+    const { presence, collab } = setupTwo()
+    let captured: ReadonlyArray<unknown> = []
+    function Probe(): unknown {
+      captured = useFileCursors(collab, 'src/foo.ts')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.length).toBe(0)
+    presence.updateCursor('a', 'src/foo.ts', 5, 1)
+    await flushEffects()
+    expect(captured.length).toBe(1)
+  })
+
+  it('does not re-render on changes in unrelated file', async () => {
+    const { presence, collab } = setupTwo()
+    let renders = 0
+    function Probe(): unknown {
+      renders += 1
+      useFileCursors(collab, 'src/foo.ts')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    const before = renders
+    presence.updateCursor('a', 'src/bar.ts', 5, 1)
+    await flushEffects()
+    expect(renders).toBe(before)
+  })
+})
+
+describe('useFileConflicts', () => {
+  it('returns conflicts only for subscribed file', async () => {
+    const { presence, collab } = setupTwo()
+    let captured: ReadonlyArray<{ file: string }> = []
+    function Probe(): unknown {
+      captured = useFileConflicts(collab, 'src/foo.ts')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.length).toBe(0)
+    presence.updateCursor('a', 'src/foo.ts', 10, 1)
+    presence.updateCursor('b', 'src/foo.ts', 10, 5)
+    await flushEffects()
+    expect(captured.length).toBe(1)
+    expect(captured[0]!.file).toBe('src/foo.ts')
+  })
+
+  it('ignores conflicts in other files', async () => {
+    const { presence, collab } = setupTwo()
+    let captured: ReadonlyArray<unknown> = []
+    function Probe(): unknown {
+      captured = useFileConflicts(collab, 'src/foo.ts')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    presence.updateCursor('a', 'src/other.ts', 10, 1)
+    presence.updateCursor('b', 'src/other.ts', 10, 5)
+    await flushEffects()
+    expect(captured.length).toBe(0)
+  })
+})

--- a/dashboard/design-system/headless-preact/use-collaboration.ts
+++ b/dashboard/design-system/headless-preact/use-collaboration.ts
@@ -1,0 +1,47 @@
+/**
+ * useCollaboration — Preact adapter over headless-core/CollaborationManager
+ * (RFC 0010 §3.3).
+ *
+ * Hooks for file-scoped cursor and conflict subscriptions. The
+ * manager is provided externally so multiple editor surfaces share
+ * the same conflict state.
+ */
+
+import { useEffect, useState } from 'preact/hooks'
+import type {
+  AgentCursor,
+  CollaborationManager,
+  FileConflict,
+} from '../headless-core/collaboration'
+
+export function useFileCursors(
+  manager: CollaborationManager,
+  file: string,
+): ReadonlyArray<AgentCursor> {
+  const [cursors, setCursors] = useState<ReadonlyArray<AgentCursor>>(() =>
+    manager.activeAgentsInFile(file),
+  )
+  useEffect(() => {
+    setCursors(manager.activeAgentsInFile(file))
+    const dispose = manager.subscribeFile(file, (cs) => setCursors(cs))
+    return dispose
+  }, [manager, file])
+  return cursors
+}
+
+export function useFileConflicts(
+  manager: CollaborationManager,
+  file: string,
+): ReadonlyArray<FileConflict> {
+  const [conflicts, setConflicts] = useState<ReadonlyArray<FileConflict>>(() =>
+    manager.conflictsInFile(file),
+  )
+  useEffect(() => {
+    setConflicts(manager.conflictsInFile(file))
+    const dispose = manager.subscribeConflicts((all) => {
+      setConflicts(all.filter((c) => c.file === file))
+    })
+    return dispose
+  }, [manager, file])
+  return conflicts
+}


### PR DESCRIPTION
## Summary

Implements RFC 0010 §3.3 Preact adapter over the merged `CollaborationManager` (#12111).

- `useFileCursors(manager, file)` — per-file cursor list, subscribes to `subscribeFile`
- `useFileConflicts(manager, file)` — filters `subscribeConflicts` (which emits all conflicts) to the watched file

## Verification

- `pnpm typecheck` — clean
- `pnpm test design-system/headless-preact/use-collaboration` — 5/5 pass (happy-dom)
- Confirmed file isolation: subscribers in unrelated files do not re-render

## Pattern

`subscribeConflicts` emits the entire conflict set; the adapter narrows to `c.file === file` so consumers only re-render on relevant changes.