### PR TITLE
feat(headless-preact): RFC 0011 useInlineSuggestion adapter

### DIFF
--- a/dashboard/design-system/headless-preact/use-inline-suggestion.test.ts
+++ b/dashboard/design-system/headless-preact/use-inline-suggestion.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+//
+// Tests for headless-preact/use-inline-suggestion. Verifies hook
+// reactivity over the headless InlineSuggestionManager and that
+// useSuggestionController returns sane root/button props.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  createInlineSuggestionManager,
+  type InlineSuggestionInput,
+} from '../headless-core/inline-suggestion'
+import {
+  useFileSuggestions,
+  useSuggestionController,
+  useTopSuggestion,
+} from './use-inline-suggestion'
+
+function flushEffects(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 16))
+}
+
+let container: HTMLElement
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.append(container)
+})
+
+afterEach(() => {
+  render(null, container)
+  container.remove()
+})
+
+function makeInput(overrides: Partial<InlineSuggestionInput> = {}): InlineSuggestionInput {
+  return {
+    agentId: 'a',
+    agentName: 'Alice',
+    agentColorSlot: 1,
+    range: { file: 'src/foo.ts', fromLine: 10, toLine: 12 },
+    before: ['  return null'],
+    after: ['  return undefined'],
+    confidence: 0.9,
+    ...overrides,
+  }
+}
+
+describe('useFileSuggestions', () => {
+  it('returns empty for unknown file', async () => {
+    const manager = createInlineSuggestionManager({ ttlMs: 0 })
+    let captured: ReadonlyArray<unknown> = []
+    function Probe(): unknown {
+      captured = useFileSuggestions(manager, 'src/missing.ts')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured).toEqual([])
+  })
+
+  it('reflects propose / retract for the watched file', async () => {
+    const manager = createInlineSuggestionManager({ ttlMs: 0 })
+    let captured: ReadonlyArray<{ id: string }> = []
+    function Probe(): unknown {
+      captured = useFileSuggestions(manager, 'src/foo.ts')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    const id = manager.propose(makeInput())
+    await flushEffects()
+    expect(captured.map((s) => s.id)).toEqual([id])
+    manager.retract(id)
+    await flushEffects()
+    expect(captured).toEqual([])
+  })
+
+  it('does not re-render on changes in unrelated file', async () => {
+    const manager = createInlineSuggestionManager({ ttlMs: 0 })
+    let renders = 0
+    function Probe(): unknown {
+      renders += 1
+      useFileSuggestions(manager, 'src/foo.ts')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    const before = renders
+    manager.propose(
+      makeInput({ range: { file: 'src/other.ts', fromLine: 1, toLine: 2 } }),
+    )
+    await flushEffects()
+    expect(renders).toBe(before)
+  })
+})
+
+describe('useTopSuggestion', () => {
+  it('returns highest confidence containing line', async () => {
+    const manager = createInlineSuggestionManager({ ttlMs: 0 })
+    manager.propose(makeInput({ confidence: 0.4 }))
+    manager.propose(makeInput({ confidence: 0.95 }))
+    let captured: { confidence: number } | undefined
+    function Probe(): unknown {
+      captured = useTopSuggestion(manager, 'src/foo.ts', 11)
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured?.confidence).toBe(0.95)
+  })
+
+  it('returns undefined when no suggestion contains line', async () => {
+    const manager = createInlineSuggestionManager({ ttlMs: 0 })
+    manager.propose(makeInput())
+    let captured: unknown
+    function Probe(): unknown {
+      captured = useTopSuggestion(manager, 'src/foo.ts', 99)
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured).toBeUndefined()
+  })
+})
+
+describe('useSuggestionController', () => {
+  it('returns controller with root + button props', async () => {
+    const manager = createInlineSuggestionManager({ ttlMs: 0 })
+    const id = manager.propose(makeInput())
+    let captured: ReturnType<typeof useSuggestionController>
+    function Probe(): unknown {
+      captured = useSuggestionController(manager, id)
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured).toBeDefined()
+    const root = captured!.getRootProps()
+    expect(root.role).toBe('region')
+    expect(root['aria-keyshortcuts']).toBe('Tab Escape')
+    expect(root.tabIndex).toBe(0)
+    expect(captured!.getAcceptButtonProps().type).toBe('button')
+    expect(captured!.getRejectButtonProps().type).toBe('button')
+  })
+
+  it('returns undefined for missing id (no throw)', async () => {
+    const manager = createInlineSuggestionManager({ ttlMs: 0 })
+    let captured: unknown = 'placeholder'
+    function Probe(): unknown {
+      captured = useSuggestionController(manager, 'inline-suggestion-missing')
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured).toBeUndefined()
+  })
+})

--- a/dashboard/design-system/headless-preact/use-inline-suggestion.ts
+++ b/dashboard/design-system/headless-preact/use-inline-suggestion.ts
@@ -1,0 +1,56 @@
+/**
+ * useInlineSuggestion — Preact adapter over headless-core/InlineSuggestion
+ * (RFC 0011 §3.4).
+ *
+ * Hooks for file-scoped suggestion lists and per-suggestion
+ * controller props. Manager is provided externally so editor and
+ * preview surfaces share the same state.
+ */
+
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import {
+  createSuggestionController,
+  type InlineSuggestion,
+  type InlineSuggestionManager,
+  type SuggestionController,
+} from '../headless-core/inline-suggestion'
+
+export function useFileSuggestions(
+  manager: InlineSuggestionManager,
+  file: string,
+): ReadonlyArray<InlineSuggestion> {
+  const [list, setList] = useState<ReadonlyArray<InlineSuggestion>>(() =>
+    manager.inFile(file),
+  )
+  useEffect(() => {
+    setList(manager.inFile(file))
+    const dispose = manager.subscribeFile(file, (xs) => setList(xs))
+    return dispose
+  }, [manager, file])
+  return list
+}
+
+export function useTopSuggestion(
+  manager: InlineSuggestionManager,
+  file: string,
+  line: number,
+): InlineSuggestion | undefined {
+  const list = useFileSuggestions(manager, file)
+  return useMemo(() => {
+    void list
+    return manager.topAtLine(file, line)
+  }, [manager, file, line, list])
+}
+
+export function useSuggestionController(
+  manager: InlineSuggestionManager,
+  suggestionId: string,
+): SuggestionController | undefined {
+  return useMemo(() => {
+    try {
+      return createSuggestionController(manager, suggestionId)
+    } catch {
+      return undefined
+    }
+  }, [manager, suggestionId])
+}


### PR DESCRIPTION
## Summary

Implements RFC 0011 §3.4 Preact adapter over the merged `InlineSuggestionManager` (#12113).

- `useFileSuggestions(manager, file)` — list of suggestions in file, subscribes to `subscribeFile`
- `useTopSuggestion(manager, file, line)` — highest-confidence suggestion containing line
- `useSuggestionController(manager, suggestionId)` — wraps `createSuggestionController`; returns `undefined` for missing id (no throw)

## Verification

- `pnpm typecheck` — clean
- `pnpm test design-system/headless-preact/use-inline-suggestion` — 7/7 pass (happy-dom)
- Verified controller props: `role=region`, `aria-keyshortcuts="Tab Escape"`, `tabIndex=0`, type=button buttons

## Pattern

`useSuggestionController` catches the controller factory's "not found" throw to keep hooks rule-stable when suggestions are accepted/retracted under the consumer.