### PR TITLE
[codex] Add Track 6 live presence channel

### DIFF
--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -56,6 +56,7 @@ const SummarySchema = object({
 const SseOuterSchema = object({
   sessions_observer: fallback(number(), 0),
   sessions_coordinator: fallback(number(), 0),
+  sessions_presence: fallback(number(), 0),
   sessions_total: fallback(number(), 0),
   external_subscribers: fallback(number(), 0),
   broadcast_avg_seconds: fallback(number(), 0),
@@ -157,6 +158,7 @@ const WebrtcSchema = object({
 const StreamableHttpSchema = object({
   endpoint: fallback(string(), '/mcp'),
   observer_stream: fallback(string(), '/mcp?sse_kind=observer'),
+  presence_stream: fallback(string(), '/events/presence'),
   managed_endpoint: fallback(string(), '/mcp/managed'),
   operator_endpoint: fallback(string(), '/mcp/operator'),
   delete_endpoint: fallback(string(), '/mcp'),

--- a/dashboard/src/api/transport-health.test.ts
+++ b/dashboard/src/api/transport-health.test.ts
@@ -83,6 +83,7 @@ describe('decodeTransportHealthData', () => {
     expect(result!.summary.external_fanout_targets).toBe(0)
     // sse defaults
     expect(result!.sse.sessions_total).toBe(0)
+    expect(result!.sse.sessions_presence).toBe(0)
     expect(result!.sse.relay_queue_depth).toBe(0)
     expect(result!.sse.relay_retry_total).toBe(0)
     expect(result!.sse.relay_drop_total).toBe(0)
@@ -96,6 +97,7 @@ describe('decodeTransportHealthData', () => {
     expect(result!.webrtc.signaling_mode).toBe('unknown')
     // streamable_http defaults
     expect(result!.streamable_http.default_transport).toBe('unknown')
+    expect(result!.streamable_http.presence_stream).toBe('/events/presence')
     // http2 defaults
     expect(result!.http2.listener_mode).toBe('unknown')
     // cluster defaults
@@ -121,7 +123,8 @@ describe('decodeTransportHealthData', () => {
       sse: {
         sessions_observer: 2,
         sessions_coordinator: 1,
-        sessions_total: 3,
+        sessions_presence: 1,
+        sessions_total: 4,
         external_subscribers: 5,
         broadcast_avg_seconds: 0.5,
         broadcast_count: 100,
@@ -173,6 +176,7 @@ describe('decodeTransportHealthData', () => {
       streamable_http: {
         endpoint: '/mcp',
         observer_stream: '/mcp?sse_kind=observer',
+        presence_stream: '/events/presence',
         managed_endpoint: '/mcp/managed',
         operator_endpoint: '/mcp/operator',
         delete_endpoint: '/mcp',
@@ -204,7 +208,8 @@ describe('decodeTransportHealthData', () => {
     const result = decodeTransportHealthData(raw)
     expect(result!.summary.primary_path).toBe('grpc')
     expect(result!.summary.recent_messages).toBe(42)
-    expect(result!.sse.sessions_total).toBe(3)
+    expect(result!.sse.sessions_total).toBe(4)
+    expect(result!.sse.sessions_presence).toBe(1)
     expect(result!.sse.relay_queue_depth).toBe(4)
     expect(result!.sse.relay_retry_total).toBe(6)
     expect(result!.sse.relay_drop_total).toBe(3)
@@ -216,6 +221,7 @@ describe('decodeTransportHealthData', () => {
     expect(result!.websocket.mode).toBe('relay')
     expect(result!.webrtc.ice_server_count).toBe(2)
     expect(result!.streamable_http.supports_post).toBe(true)
+    expect(result!.streamable_http.presence_stream).toBe('/events/presence')
     expect(result!.http2.multiplex_ready).toBe(true)
     expect(result!.cluster.total_units).toBe(5)
     expect(result!.cluster.live_agents).toBe(3)

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -18,6 +18,7 @@ function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
     sse: {
       sessions_observer: 1,
       sessions_coordinator: 0,
+      sessions_presence: 0,
       sessions_total: 1,
       external_subscribers: 0,
       broadcast_avg_seconds: 0.01,
@@ -78,6 +79,7 @@ function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
     streamable_http: {
       endpoint: '/mcp',
       observer_stream: '/mcp?sse_kind=observer',
+      presence_stream: '/events/presence',
       managed_endpoint: '/mcp/managed',
       operator_endpoint: '/mcp/operator',
       delete_endpoint: '/mcp',
@@ -189,6 +191,8 @@ describe('TransportHealthPanel', () => {
     expect(container.innerHTML).toContain('시그널링 중단')
     expect(container.innerHTML).not.toContain('2 ICE')
     expect(container.textContent).toContain('namespace default')
+    expect(container.textContent).toContain('프레즌스 스트림')
+    expect(container.textContent).toContain('/events/presence')
   })
 
   it('renders namespace chip with cluster prefix for non-default clusters', async () => {
@@ -262,7 +266,8 @@ describe('TransportHealthPanel', () => {
         sse: {
           sessions_observer: 1,
           sessions_coordinator: 0,
-          sessions_total: 1,
+          sessions_presence: 1,
+          sessions_total: 2,
           external_subscribers: 0,
           broadcast_avg_seconds: 0.01,
           broadcast_count: 2,

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -455,6 +455,7 @@ export function TransportHealthPanel() {
             <${SectionCard} title="SSE" status=${sseStatus} eyebrow=${`${data.sse.sessions_total} 활성`}>
               <${MetricRow} label="옵저버" value=${data.sse.sessions_observer} />
               <${MetricRow} label="코디네이터" value=${data.sse.sessions_coordinator} />
+              <${MetricRow} label="프레즌스" value=${data.sse.sessions_presence} />
               <${MetricRow} label="외부 팬아웃" value=${data.sse.external_subscribers} />
               <${MetricRow} label="큐" value=${data.sse.queue_max_depth} sub=${`최대 / 평균 ${formatFloat(data.sse.queue_avg_depth)}`} />
               <${MetricRow} label="릴레이 큐" value=${data.sse.relay_queue_depth} />
@@ -514,6 +515,7 @@ export function TransportHealthPanel() {
             <${SectionCard} title="HTTP" status=${h2Status} eyebrow=${data.http2.listener_mode}>
               <${MetricRow} label="POST" value=${data.streamable_http.endpoint} />
               <${MetricRow} label="옵저버 스트림" value=${data.streamable_http.observer_stream} />
+              <${MetricRow} label="프레즌스 스트림" value=${data.streamable_http.presence_stream} />
               <${MetricRow} label="오퍼레이터 표면" value=${data.streamable_http.operator_endpoint} />
               <${MetricRow} label="레거시" value=${data.streamable_http.legacy_sse_endpoint} sub=${'deprecated'} />
             <//>

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -250,15 +250,18 @@ let emit_in_turn_liveness_pulse ~(ctx : _ context) ~(meta : keeper_meta) =
              meta.name (Printexc.to_string exn));
       let now_ts = Time_compat.now () in
       (try
-         Sse.broadcast
-           (`Assoc
-              [ "type", `String "keeper_heartbeat"
-              ; "name", `String meta.name
-              ; "generation", `Int meta.runtime.generation
-              ; "ts_unix", `Float now_ts
-              ; "phase", `String "turn_running"
-              ; "in_turn", `Bool true
-              ])
+         let json =
+           `Assoc
+             [ "type", `String "keeper_heartbeat"
+             ; "name", `String meta.name
+             ; "generation", `Int meta.runtime.generation
+             ; "ts_unix", `Float now_ts
+             ; "phase", `String "turn_running"
+             ; "in_turn", `Bool true
+             ]
+         in
+         Sse.broadcast json;
+         Sse.broadcast_presence json
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -392,14 +392,17 @@ let write_heartbeat_snapshot
     in
     Dated_jsonl.append metrics_store snapshot;
     (try
-       Sse.broadcast
-         (`Assoc
-             [ "type", `String "keeper_heartbeat"
-             ; "name", `String meta_current.name
-             ; "generation", `Int meta_current.runtime.generation
-             ; "context_ratio", `Float context_ratio_v
-             ; "ts_unix", `Float now_ts
-             ])
+       let json =
+         `Assoc
+           [ "type", `String "keeper_heartbeat"
+           ; "name", `String meta_current.name
+           ; "generation", `Int meta_current.runtime.generation
+           ; "context_ratio", `Float context_ratio_v
+           ; "ts_unix", `Float now_ts
+           ]
+       in
+       Sse.broadcast json;
+       Sse.broadcast_presence json
      with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -449,12 +449,15 @@ let turn_phase_of_cascade_state = function
 
 let broadcast_composite_changed ~name ~ts_unix =
   try
-    Sse.broadcast
-      (`Assoc [
-         "type", `String "keeper_composite_changed";
-         "name", `String name;
-         "ts_unix", `Float ts_unix;
-       ])
+    let json =
+      `Assoc [
+        "type", `String "keeper_composite_changed";
+        "name", `String name;
+        "ts_unix", `Float ts_unix;
+      ]
+    in
+    Sse.broadcast json;
+    Sse.broadcast_presence json
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -440,6 +440,21 @@ let relay_event_type json =
        | Some value -> value
        | None -> "unknown")
 
+let relay_event_is_presence_class json =
+  match relay_event_type json with
+  | "masc:keeper:snapshot" -> true
+  | _ -> false
+
+let broadcast_relay_json json =
+  Sse.broadcast_to All json;
+  if relay_event_is_presence_class json then
+    try Sse.broadcast_presence json
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Misc.warn "oas_event_bridge: presence relay failed: %s"
+          (Printexc.to_string exn)
+
 let update_relay_queue_depth pending =
   Prometheus.set_gauge Prometheus.metric_oas_sse_relay_queue_depth
     (float_of_int (List.length pending))
@@ -564,7 +579,7 @@ let deliver_pending ?store_ref (pending : pending_relay) =
   try
     deliver_pending_with
       ~append_json
-      ~broadcast_json:(Sse.broadcast_to All)
+      ~broadcast_json:broadcast_relay_json
       pending
   with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -92,7 +92,8 @@ let observer_sse_query_token_from_request request =
   in
   match request.Httpun.Request.meth with
   | `GET
-    when observer_stream_requested && String.equal path "/mcp" ->
+    when (observer_stream_requested && String.equal path "/mcp")
+         || String.equal path "/events/presence" ->
       trim_opt (query_param request "token")
   | _ -> None
 
@@ -211,7 +212,7 @@ let verify_mcp_observer_stream_auth ~base_path request =
         | None ->
             Error
               "Authentication required. Use 'Authorization: Bearer <token>' header \
-               or 'token' query param for the observer SSE stream."
+               or 'token' query param for the observer/presence SSE stream."
         | Some token -> (
             match resolve_agent_name_for_auth_raw ~base_path request ~token:(Some token) with
             | Error err -> Error (Types.masc_error_to_string err)

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -67,7 +67,8 @@ val auth_token_from_request : Httpun.Request.t -> string option
 (** Token from [Authorization: Bearer …] on the request. *)
 
 val observer_sse_query_token_from_request : Httpun.Request.t -> string option
-(** Observer SSE allows the token via query string for browser EventSource. *)
+(** Observer/presence SSE allows the token via query string for browser
+    EventSource. *)
 
 val observer_sse_auth_token_from_request : Httpun.Request.t -> string option
 (** Combined header-or-query lookup for the SSE observer endpoint. *)

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -513,7 +513,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
     match profile with
     | Full | Managed_agent ->
         (match sse_kind with
-         | Sse.Observer ->
+         | Sse.Observer | Sse.Presence ->
              deps.verify_mcp_observer_stream_auth ~base_path request
          | Sse.Coordinator ->
              deps.verify_mcp_auth ~base_path request)

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -119,3 +119,5 @@ val handle_delete_mcp :
   unit
 val handle_ag_ui_events :
   deps:deps -> Httpun.Request.t -> Httpun.Reqd.t -> unit
+val handle_presence_events :
+  deps:deps -> Httpun.Request.t -> Httpun.Reqd.t -> unit

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -30,6 +30,21 @@ let ag_ui_event_of_masc_event event =
 
 let sse_ping_interval_s = 30.0
 
+let presence_stream_headers ~deps raw_session_id protocol_version origin =
+  Httpun.Headers.of_list
+    ([
+       ("content-type", Http_negotiation.sse_content_type);
+       ("cache-control", "no-cache");
+       ("connection", "keep-alive");
+       ("x-accel-buffering", "no");
+       Server_mcp_transport_http_headers.session_cookie_header raw_session_id;
+     ]
+    @ Server_mcp_transport_http_headers.mcp_headers raw_session_id
+        protocol_version
+    @ deps.cors_headers origin)
+
+let presence_session_id raw_session_id = "presence:" ^ raw_session_id
+
 let handle_ag_ui_events ~deps request reqd =
   let origin = deps.get_origin request in
   let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
@@ -139,3 +154,114 @@ let handle_ag_ui_events ~deps request reqd =
       | Error msg ->
           Log.Server.debug "ag-ui SSE runtime unavailable for session %s: %s"
             session_id msg)
+
+let handle_presence_events ~deps request reqd =
+  let origin = deps.get_origin request in
+  let raw_session_id = Mcp_session.get_or_generate (get_session_id_any request) in
+  let session_id = presence_session_id raw_session_id in
+  let protocol_version =
+    get_protocol_version_for_session ~session_id:raw_session_id request
+  in
+  let base_path = deps.get_base_path () in
+  match deps.verify_mcp_observer_stream_auth ~base_path request with
+  | Error msg ->
+      respond_mcp_auth_error ~deps request reqd ~session_id:raw_session_id
+        ~protocol_version msg
+  | Ok () -> (
+      match check_sse_connect_guard session_id with
+      | Error (reason, retry_after_s) ->
+          respond_sse_rate_limited ~deps ~origin ~session_id
+            ~protocol_version ~reason ~retry_after_s reqd
+      | Ok () ->
+          stop_sse_session_preserve_guard session_id;
+          let headers =
+            presence_stream_headers ~deps raw_session_id protocol_version origin
+          in
+          let response = Httpun.Response.create ~headers `OK in
+          let writer = Httpun.Reqd.respond_with_streaming reqd response in
+          let mutex = Eio.Mutex.create () in
+          let client_id, event_stream, evicted =
+            Sse.register ~kind:Sse.Presence session_id ~last_event_id:0
+          in
+          (match evicted with
+          | Some evicted_sid -> stop_sse_session evicted_sid
+          | None -> ());
+          let info =
+            {
+              session_id;
+              client_id;
+              writer;
+              mutex;
+              stop = ref false;
+              closed = false;
+            }
+          in
+          register_sse_conn ~session_id ~info;
+          if not (send_raw info ": presence-stream\nretry: 3000\n\n") then
+            Log.Server.debug "presence prime send failed for session %s"
+              info.session_id;
+          match deps.get_runtime_result () with
+          | Ok runtime ->
+              let sw = runtime.sw in
+              let clock = runtime.clock in
+              Eio.Fiber.fork ~sw (fun () ->
+                  let rec drain () =
+                    let event = Eio.Stream.take event_stream in
+                    (try
+                       if not (info.closed || !(info.stop)) then
+                         if not (send_raw info event) then
+                           Log.Server.debug
+                             "presence drain send failed for session %s"
+                             info.session_id
+                     with
+                     | Eio.Cancel.Cancelled _ as e -> raise e
+                     | exn ->
+                         Log.Server.error "presence drain write error: %s"
+                           (Printexc.to_string exn);
+                         stop_sse_session_preserve_guard info.session_id);
+                    if not !(info.stop) then drain ()
+                  in
+                  try drain ()
+                  with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn ->
+                      Log.Server.error "presence drain loop error: %s"
+                        (Printexc.to_string exn));
+              Eio.Fiber.fork ~sw (fun () ->
+                  let rec loop () =
+                    if not !(info.stop) then (
+                      (try Eio.Time.sleep clock sse_ping_interval_s
+                       with
+                       | Eio.Cancel.Cancelled _ as e -> raise e
+                       | exn ->
+                           Log.Server.debug
+                             "presence ping sleep interrupted: %s"
+                             (Printexc.to_string exn));
+                      (try
+                         if info.closed then
+                           stop_sse_session_preserve_guard info.session_id
+                         else if not !(info.stop) then
+                           if not (send_raw info ": ping\n\n") then
+                             Log.Server.debug
+                               "presence ping send failed for session %s"
+                               info.session_id
+                       with
+                       | Eio.Cancel.Cancelled _ as e -> raise e
+                       | exn ->
+                           Log.Server.warn
+                             "presence ping send failed for session %s: %s"
+                             info.session_id (Printexc.to_string exn);
+                           stop_sse_session_preserve_guard info.session_id);
+                      loop ())
+                  in
+                  try loop ()
+                  with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn ->
+                      Log.Server.error
+                        "presence ping loop exited for session %s: %s"
+                        info.session_id (Printexc.to_string exn))
+          | Error msg ->
+              Log.Server.debug
+                "presence SSE runtime unavailable for session %s: %s"
+                session_id msg)

--- a/lib/server/server_mcp_transport_http_agui.mli
+++ b/lib/server/server_mcp_transport_http_agui.mli
@@ -70,3 +70,17 @@ val handle_ag_ui_events :
     while this handler uses a local shadow to keep the AG-UI fiber
     independent of header-module evolution.  A future "let's unify"
     refactor must touch the duplicate explicitly. *)
+
+val handle_presence_events :
+  deps:Server_mcp_transport_http_types.deps ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  unit
+(** [handle_presence_events ~deps request reqd] handles
+    [GET /events/presence].
+
+    The stream registers a {!Sse.Presence} session under a namespaced
+    session id so the dashboard can keep its durable [/mcp] observer
+    stream open while subscribing to live-only presence traffic.
+    Presence events are not replayed from {!Sse.get_events_after};
+    reconnecting clients receive only future liveness/awareness frames. *)

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -268,3 +268,7 @@ let handle_delete_mcp ?(profile = Server_mcp_transport_http.Full) request reqd =
 let handle_ag_ui_events request reqd =
   Server_mcp_transport_http.handle_ag_ui_events ~deps:(mcp_transport_http_deps ())
     request reqd
+
+let handle_presence_events request reqd =
+  Server_mcp_transport_http.handle_presence_events
+    ~deps:(mcp_transport_http_deps ()) request reqd

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -177,6 +177,9 @@ val handle_delete_mcp :
 val handle_ag_ui_events :
   Httpun.Request.t -> Httpun.Reqd.t -> unit
 
+val handle_presence_events :
+  Httpun.Request.t -> Httpun.Reqd.t -> unit
+
 (** {1 Misc helpers} *)
 
 val mcp_transport_http_deps :

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -93,6 +93,7 @@ let add_routes ~port ~host router =
   |> Http.Router.get "/.well-known/agent.json" (serve_agent_card ~host ~port)
   |> Http.Router.get "/.well-known/agent-card.json" (serve_agent_card ~host ~port)
   |> Http.Router.get "/ag-ui/events" handle_ag_ui_events
+  |> Http.Router.get "/events/presence" handle_presence_events
   (* Dashboard sub-routes: must come before the SPA catchall *)
   |> Http.Router.get "/dashboard/credits" (fun request reqd ->
        with_canonical_loopback_host ~port

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -15,8 +15,10 @@
     Session kinds:
     [Observer] sessions receive dashboard snapshots but not agent
     coordination traffic.  [Coordinator] sessions receive heartbeats
-    and task events but not dashboard snapshots.  [broadcast_to All]
-    reaches every session (backward-compatible with the old [broadcast]).
+    and task events but not dashboard snapshots.  [Presence] sessions
+    receive ephemeral liveness/awareness updates through the bufferless
+    presence channel.  [broadcast_to All] reaches every durable session
+    (backward-compatible with the old [broadcast]).
 
     Signal handler safety: registry operations avoid [Eio.Mutex] and rely on
     immutable snapshots plus CAS, so readers can inspect counts without
@@ -37,12 +39,14 @@ let run_test_hook hook =
 type session_kind =
   | Observer     (** Dashboard / read-only viewers *)
   | Coordinator  (** MCP agent connections *)
+  | Presence     (** Ephemeral liveness / awareness channel *)
 
 (** Broadcast targeting selector. *)
 type broadcast_target =
   | All          (** Every connected session (backward-compatible default) *)
   | Observers    (** Only [Observer] sessions *)
   | Coordinators (** Only [Coordinator] sessions *)
+  | Presence_only (** Only [Presence] sessions; never replay-buffered *)
 
 (** Maximum concurrent SSE clients -- prevents connection storm on restart.
     Increased from 50 to 200 to handle Claude.ai MCP client reconnections. *)
@@ -92,6 +96,7 @@ type session_snapshot = {
 let session_kind_to_string = function
   | Observer -> "observer"
   | Coordinator -> "coordinator"
+  | Presence -> "presence"
 
 let take n xs =
   let rec loop acc remaining items =
@@ -115,6 +120,7 @@ let sync_transport_snapshot () =
      compounds with the fan-out itself. *)
   let observer = ref 0 in
   let coordinator = ref 0 in
+  let presence = ref 0 in
   let queue_sum = ref 0 in
   let max_queue_depth = ref 0 in
   let sessions_acc = ref [] in
@@ -125,7 +131,8 @@ let sync_transport_snapshot () =
     max_queue_depth := max !max_queue_depth queue_depth;
     (match client.kind with
      | Observer -> incr observer
-     | Coordinator -> incr coordinator);
+     | Coordinator -> incr coordinator
+     | Presence -> incr presence);
     incr total_sessions_acc;
     sessions_acc :=
       {
@@ -163,6 +170,7 @@ let sync_transport_snapshot () =
   in
   Transport_metrics.set_sse_sessions ~kind:"observer" !observer;
   Transport_metrics.set_sse_sessions ~kind:"coordinator" !coordinator;
+  Transport_metrics.set_sse_sessions ~kind:"presence" !presence;
   Transport_metrics.set_sse_queue_snapshot ~avg_depth
     ~max_depth:!max_queue_depth ~hot_sessions
 
@@ -446,9 +454,10 @@ let push_timeout_s = 5.0
 (** Test whether a client matches a broadcast target. *)
 let client_matches_target target (client : client) =
   match target with
-  | All -> true
+  | All -> client.kind <> Presence
   | Observers -> client.kind = Observer
   | Coordinators -> client.kind = Coordinator
+  | Presence_only -> client.kind = Presence
 
 (** {1 External Subscriber Hook}
 
@@ -650,14 +659,16 @@ let reap_dead_external_subscribers () =
 
     After SSE fan-out, external subscribers (gRPC streams, etc.) are
     also notified with the same formatted event string. *)
-let broadcast_impl target json =
+let broadcast_impl ?(buffer = true) ?(notify_external = true)
+    ?(event_type = "message") target json =
   let t0 = Time_compat.now () in
   let data = Yojson.Safe.to_string json in
   (* Atomically allocate the event id so two concurrent broadcasts
      cannot observe the same peeked counter value and emit duplicates. *)
   let current_event_id = next_id () in
-  let event = format_event ~id:current_event_id ~event_type:"message" data in
-  buffer_event current_event_id event;
+  let event = format_event ~id:current_event_id ~event_type data in
+  if buffer then
+    buffer_event current_event_id event;
   (* The [SMap.t] returned by [Atomic.get] is immutable
      (Lockfree_atomic.update_with_commit replaces it wholesale on
      subscribe/unsubscribe), so we iterate it directly with [SMap.iter].
@@ -667,6 +678,7 @@ let broadcast_impl target json =
     | All -> "all"
     | Observers -> "observers"
     | Coordinators -> "coordinators"
+    | Presence_only -> "presence"
   in
   let clients_entries = (Atomic.get clients).entries in
   let failed = ref [] in
@@ -709,8 +721,10 @@ let broadcast_impl target json =
   let elapsed = Time_compat.now () -. t0 in
   Transport_metrics.observe_broadcast_duration ~target:target_label elapsed;
   sync_transport_snapshot ();
-  (* Notify external subscribers (gRPC streams, etc.) *)
-  notify_external_subscribers event
+  (* Notify external subscribers (gRPC streams, etc.) for durable broadcast
+     traffic only. Presence is intentionally live-only and bufferless. *)
+  if notify_external then
+    notify_external_subscribers event
 
 (** Broadcast event to all connected clients (backward-compatible). *)
 let broadcast json = broadcast_impl All json
@@ -720,6 +734,14 @@ let broadcast json = broadcast_impl All json
     - [Observers]: dashboard / read-only viewers only
     - [Coordinators]: MCP agent sessions only *)
 let broadcast_to target json = broadcast_impl target json
+
+(** Broadcast an ephemeral presence/awareness event. Presence events are live
+    only: they are not replay-buffered and do not fan out through generic
+    external subscribers. Durable consumers continue to receive the caller's
+    normal [broadcast] / [broadcast_to] emission. *)
+let broadcast_presence json =
+  broadcast_impl ~buffer:false ~notify_external:false ~event_type:"presence"
+    Presence_only json
 
 (** Send a JSON-RPC message to a specific session.
     Enqueues the event in the session's stream for asynchronous delivery. *)

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -12,11 +12,13 @@ module SMap : Map.S with type key = string
 type session_kind =
   | Observer
   | Coordinator
+  | Presence
 
 type broadcast_target =
   | All
   | Observers
   | Coordinators
+  | Presence_only
 
 type client = {
   id : int;
@@ -75,6 +77,7 @@ val current_id : unit -> int
 
 val broadcast : Yojson.Safe.t -> unit
 val broadcast_to : broadcast_target -> Yojson.Safe.t -> unit
+val broadcast_presence : Yojson.Safe.t -> unit
 val send_to : string -> Yojson.Safe.t -> unit
 val pop : string -> string option
 val try_pop : string -> string option

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -304,7 +304,8 @@ let transport_health_json ~config =
   in
   let sse_observer = v Prometheus.metric_sse_sessions ~labels:[("kind", "observer")] () in
   let sse_coordinator = v Prometheus.metric_sse_sessions ~labels:[("kind", "coordinator")] () in
-  let sse_total = int_of_float (sse_observer +. sse_coordinator) in
+  let sse_presence = v Prometheus.metric_sse_sessions ~labels:[("kind", "presence")] () in
+  let sse_total = int_of_float (sse_observer +. sse_coordinator +. sse_presence) in
   let sse_external_subscribers =
     int_of_float (v Prometheus.metric_sse_external_subscribers ())
   in
@@ -416,6 +417,7 @@ let transport_health_json ~config =
     ("sse", `Assoc [
       ("sessions_observer", `Int (int_of_float sse_observer));
       ("sessions_coordinator", `Int (int_of_float sse_coordinator));
+      ("sessions_presence", `Int (int_of_float sse_presence));
       ("sessions_total", `Int sse_total);
       ("external_subscribers", `Int sse_external_subscribers);
       ("broadcast_avg_seconds", `Float broadcast_avg);
@@ -496,6 +498,7 @@ let transport_health_json ~config =
     ("streamable_http", `Assoc [
       ("endpoint", `String "/mcp");
       ("observer_stream", `String "/mcp?sse_kind=observer");
+      ("presence_stream", `String "/events/presence");
       ("managed_endpoint", `String "/mcp/managed");
       ("operator_endpoint", `String "/mcp/operator");
       ("delete_endpoint", `String "/mcp");

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -461,6 +461,27 @@ let test_observer_sse_auth_accepts_query_token_fallback () =
       | Ok (Some _cred) -> fail "observer SSE auth should not surface credential details"
       | Error e -> fail e)
 
+let test_presence_sse_auth_accepts_query_token_fallback () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.enable_auth dir ~require_token:true ~agent_name:"bootstrap-admin");
+      let raw_token =
+        match Auth.create_token dir ~agent_name:"stable-admin" ~role:Types.Admin with
+        | Ok (token, _cred) -> token
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      let request =
+        Httpun.Request.create `GET
+          ("/events/presence?session_id=dash_test&token=" ^ raw_token)
+      in
+      match Server_auth.verify_mcp_observer_stream_auth ~base_path:dir request with
+      | Ok None -> ()
+      | Ok (Some _cred) -> fail "presence SSE auth should not surface credential details"
+      | Error e -> fail e)
+
 let test_observer_sse_auth_rejects_query_token_on_non_observer_path () =
   let module Server_auth = Masc_mcp.Server_auth in
   let dir = setup_test_room () in
@@ -1135,6 +1156,8 @@ let () =
         test_http_auth_rejects_query_token_fallback;
       test_case "observer sse accepts query token fallback" `Quick
         test_observer_sse_auth_accepts_query_token_fallback;
+      test_case "presence sse accepts query token fallback" `Quick
+        test_presence_sse_auth_accepts_query_token_fallback;
       test_case "observer sse rejects query token on non-observer path" `Quick
         test_observer_sse_auth_rejects_query_token_on_non_observer_path;
       test_case "verify_mcp_auth accepts valid bearer" `Quick

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -372,7 +372,7 @@ let test_http_write_auth_contracts () =
        {|trim_opt (query_param request "token")|});
   check bool "observer SSE auth error documents scoped query token contract" true
     (file_contains_pattern "lib/server/server_auth.ml"
-       {|or 'token' query param for the observer SSE stream.|});
+       {|or 'token' query param for the observer/presence SSE stream.|});
   check bool "server auth keeps general MCP auth header-only" true
     (file_contains_pattern "lib/server/server_auth.ml"
        {|match auth_token_from_request request with|});

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -160,6 +160,48 @@ let test_broadcast_equals_broadcast_to_all () =
   Sse.unregister "s-eq-obs";
   Sse.unregister "s-eq-coord"
 
+let test_broadcast_all_excludes_presence_sessions () =
+  reset ();
+  ignore (Sse.register ~kind:Presence "s-all-presence" ~last_event_id:0);
+  ignore (Sse.register ~kind:Coordinator "s-all-coord-only" ~last_event_id:0);
+  Sse.broadcast (`Assoc [("durable", `Bool true)]);
+  let got_presence = Sse.try_pop "s-all-presence" in
+  let got_coord = Sse.try_pop "s-all-coord-only" in
+  Alcotest.(check bool) "presence did not get durable all" true
+    (got_presence = None);
+  Alcotest.(check bool) "coordinator got durable all" true (got_coord <> None);
+  Sse.unregister "s-all-presence";
+  Sse.unregister "s-all-coord-only"
+
+let test_broadcast_presence_is_live_only () =
+  reset ();
+  let original_buffer = Atomic.get Sse.event_buffer in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Sse.event_buffer original_buffer;
+      Sse.unregister "s-presence";
+      Sse.unregister "s-observer")
+    (fun () ->
+      Atomic.set Sse.event_buffer [];
+      ignore (Sse.register ~kind:Presence "s-presence" ~last_event_id:0);
+      ignore (Sse.register ~kind:Observer "s-observer" ~last_event_id:0);
+      let before_id = Sse.current_id () in
+      Sse.broadcast_presence (`Assoc [("type", `String "keeper_heartbeat")]);
+      let got_presence = Sse.try_pop "s-presence" in
+      let got_observer = Sse.try_pop "s-observer" in
+      Alcotest.(check bool) "presence got event" true (got_presence <> None);
+      Alcotest.(check bool) "observer did not get presence" true
+        (got_observer = None);
+      (match got_presence with
+       | Some event ->
+           Alcotest.(check bool) "presence event type" true
+             (List.exists
+                (String.equal "event: presence")
+                (String.split_on_char '\n' event))
+       | None -> Alcotest.fail "expected presence event");
+      Alcotest.(check (list string)) "presence not replay buffered" []
+        (Sse.get_events_after before_id))
+
 let test_register_defaults_to_coordinator () =
   reset ();
   (* Register without explicit kind *)
@@ -205,6 +247,8 @@ let () =
           Alcotest.test_case "coordinators only" `Quick test_broadcast_to_coordinators_only;
           Alcotest.test_case "all targets" `Quick test_broadcast_to_all;
           Alcotest.test_case "broadcast = broadcast_to All" `Quick test_broadcast_equals_broadcast_to_all;
+          Alcotest.test_case "broadcast All excludes presence" `Quick test_broadcast_all_excludes_presence_sessions;
+          Alcotest.test_case "presence live-only" `Quick test_broadcast_presence_is_live_only;
           Alcotest.test_case "default kind is Coordinator" `Quick test_register_defaults_to_coordinator;
         ] );
     ]

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -206,6 +206,9 @@ let test_transport_health_json () =
   ignore
     (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Coordinator "coordinator-session"
        ~last_event_id:0);
+  ignore
+    (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Presence "presence-session"
+       ~last_event_id:0);
   TM.set_grpc_active_streams 1;
   TM.set_grpc_subscribers 2;
   Prometheus.set_gauge Prometheus.metric_oas_sse_relay_queue_depth 4.0;
@@ -233,6 +236,8 @@ let test_transport_health_json () =
     (sse_json |> U.member "sessions_observer" |> U.to_int);
   check int "coordinator sessions" 1
     (sse_json |> U.member "sessions_coordinator" |> U.to_int);
+  check int "presence sessions" 1
+    (sse_json |> U.member "sessions_presence" |> U.to_int);
   check bool "queue depth reflects queued event" true
     ((sse_json |> U.member "queue_max_depth" |> U.to_int) > 0);
   check bool "hot sessions are reported" true
@@ -255,6 +260,8 @@ let test_transport_health_json () =
     (match streamable_json |> U.member "auth_policy_present" with
     | `Bool _ -> true
     | _ -> false);
+  check string "presence stream endpoint" "/events/presence"
+    (streamable_json |> U.member "presence_stream" |> U.to_string);
   check int "grpc active streams" 1
     (grpc_json |> U.member "active_streams" |> U.to_int);
   check int "grpc subscribers" 2


### PR DESCRIPTION
## What changed

- Added a live-only `/events/presence` SSE endpoint for ephemeral keeper liveness/awareness traffic.
- Added `Sse.Presence`, `Sse.Presence_only`, and `Sse.broadcast_presence` so presence events do not enter durable replay buffers or generic external fanout.
- Mirrored keeper heartbeat/composite updates and OAS keeper snapshot relay events onto the presence channel while preserving existing durable broadcasts.
- Exposed presence stream metrics and endpoint metadata through transport health and the dashboard panel.
- Added auth/SSE/transport metric/dashboard tests for the new presence surface.

## Stack

Downstream of OAS Track 6 foundation: https://github.com/jeong-sik/oas/pull/1265

## Why

Track 6 needs the runtime side of offline/online sync: durable streams remain replayable, while high-frequency liveness/awareness updates stay bufferless and reconnect-safe. This separates durable operator state from ephemeral presence without changing the existing `/mcp` observer stream contract.

## Validation

- `git diff origin/main...HEAD --check`
- `npm run typecheck` could not run locally because `tsc` is not installed in this worktree.
- `npm test -- --run dashboard/src/api/transport-health.test.ts dashboard/src/components/transport-health.test.ts` could not run locally because `vitest` is not installed in this worktree.
- Focused Dune validation was skipped because the local Dune wrapper was blocked behind existing long-running `/tmp/me-dune-local.lock` work on this host; full compile/test validation is left to CI.

## Notes

Unrelated local provider-failure/OAS-compat edits were intentionally excluded from this PR and preserved in local stashes prefixed `track6-masc-unrelated-`.
