### PR TITLE
keeper: surface terminal turn reasons

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -343,6 +343,10 @@ let keeper_trust_json ?(include_receipt = false)
       ("next_human_action", Yojson.Safe.Util.member "next_human_action" runtime_trust);
       ("approval_state", Yojson.Safe.Util.member "approval" runtime_trust);
       ("execution_summary", Yojson.Safe.Util.member "execution" runtime_trust);
+      ( "latest_terminal_reason",
+        Yojson.Safe.Util.member "latest_terminal_reason" runtime_trust );
+      ( "latest_next_action",
+        Yojson.Safe.Util.member "latest_next_action" runtime_trust );
       ("latest_causal_event", Yojson.Safe.Util.member "latest_causal_event" runtime_trust);
       ( "last_receipt_at",
         match latest_receipt with

--- a/lib/dune
+++ b/lib/dune
@@ -546,6 +546,7 @@
    keeper_agent_tool_surface
    keeper_agent_result
    keeper_agent_error
+   keeper_turn_terminal
    keeper_agent_memory_episode
    keeper_agent_run
    keeper_agent_checkpoint_hygiene

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -111,6 +111,22 @@ let severity_of_decision = function
 
 let severity_of_tool_call success = if success then "ok" else "bad"
 
+let terminal_reason_from_decision json =
+  match json_member "terminal_reason" json with
+  | `Assoc _ as terminal_reason -> Keeper_turn_terminal.of_json terminal_reason
+  | _ -> None
+
+let terminal_reason_from_receipt receipt =
+  match json_string_opt_member "terminal_reason_code" receipt with
+  | Some code ->
+      Some (Keeper_turn_terminal.of_code ~source:"execution_receipt" code)
+  | None -> None
+
+let latest_terminal_reason_opt ~latest_decision ~latest_receipt =
+  match Option.bind latest_decision terminal_reason_from_decision with
+  | Some _ as value -> value
+  | None -> Option.bind latest_receipt terminal_reason_from_receipt
+
 let severity_of_approval_event event decision =
   match event with
   | "pending" -> "warn"
@@ -248,6 +264,56 @@ let decision_timeline_event json =
            ~title:"Turn Decision"
            ~summary
            ~severity:(severity_of_decision turn_verdict) ())
+
+let terminal_reason_timeline_event ~latest_decision ~latest_receipt =
+  let source_json, ts_unix_opt, reason_opt =
+    match latest_decision with
+    | Some decision -> (
+        match terminal_reason_from_decision decision with
+        | Some reason ->
+            ( Some decision,
+              (match json_float_opt_member "ts_unix" decision with
+               | Some _ as value -> value
+               | None -> json_float_opt_member "wall_clock" decision),
+              Some reason )
+        | None -> (None, None, None))
+    | None -> (None, None, None)
+  in
+  let source_json, ts_unix_opt, reason_opt =
+    match reason_opt, latest_receipt with
+    | Some _, _ -> (source_json, ts_unix_opt, reason_opt)
+    | None, Some receipt -> (
+        match terminal_reason_from_receipt receipt with
+        | Some reason ->
+            let ts_unix_opt =
+              match json_string_opt_member "ended_at" receipt with
+              | Some ended_at ->
+                  let ts = Types.parse_iso8601 ~default_time:0.0 ended_at in
+                  if ts > 0.0 then Some ts else None
+              | None -> None
+            in
+            (Some receipt, ts_unix_opt, Some reason)
+        | None -> (None, None, None))
+    | None, None -> (None, None, None)
+  in
+  match source_json, ts_unix_opt, reason_opt with
+  | Some source_json, Some ts_unix, Some reason ->
+      Some
+        (timeline_event_json
+           ?trace_id:(json_string_opt_member "trace_id" source_json)
+           ?keeper_turn_id:(keeper_turn_id_of_json source_json)
+           ?task_id:
+             (match json_string_opt_member "task_id" source_json with
+              | Some _ as value -> value
+              | None -> json_string_opt_member "current_task_id" source_json)
+           ~goal_ids:(goal_ids_of_json source_json)
+           ?next_human_action:reason.next_action
+           ~ts_unix ~kind:"terminal_reason"
+           ~title:"Terminal Reason"
+           ~summary:reason.summary
+           ~severity:(Keeper_turn_terminal.severity_to_string reason.severity)
+           ())
+  | _ -> None
 
 let transition_timeline_event json =
   match json_float_opt_member "wall_clock_at_decision" json with
@@ -724,6 +790,10 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
      | None -> [])
     |> List.filter_map Fun.id
   in
+  let terminal_reason_events =
+    [ terminal_reason_timeline_event ~latest_decision ~latest_receipt ]
+    |> List.filter_map Fun.id
+  in
   let blocker_events =
     let task_id = Keeper_runtime_contract.current_task_id_opt meta in
     let goal_ids = meta.active_goal_ids in
@@ -758,8 +828,8 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
     then acc
     else item :: acc
   in
-  tool_events @ approval_events @ transition_events @ decision_events
-  @ receipt_events @ blocker_events
+  tool_events @ approval_events @ transition_events @ terminal_reason_events
+  @ decision_events @ receipt_events @ blocker_events
   @ (List.filter_map Fun.id [ latest_tool_call_event; latest_approval_event ])
   |> List.fold_left dedupe []
   |> sort_timeline_events
@@ -773,6 +843,17 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   let latest_decision = latest_decision_json ~config ~keeper_name:meta.name in
   let latest_tool_call = latest_tool_call_json ~keeper_name:meta.name in
   let latest_receipt = latest_receipt_json ~config ~keeper_name:meta.name in
+  let latest_terminal_reason =
+    latest_terminal_reason_opt ~latest_decision ~latest_receipt
+  in
+  let latest_terminal_reason_json =
+    latest_terminal_reason
+    |> Option.map Keeper_turn_terminal.to_json
+    |> Option.value ~default:`Null
+  in
+  let latest_next_action =
+    Option.bind latest_terminal_reason (fun reason -> reason.next_action)
+  in
   let latest_approval_audit =
     match
       Keeper_approval_queue.read_recent_audit ~base_path:config.base_path
@@ -889,6 +970,8 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
       ("next_human_action", Json_util.string_opt_to_json next_human_action);
       ("approval", approval_state);
       ("execution", execution_summary);
+      ("latest_terminal_reason", latest_terminal_reason_json);
+      ("latest_next_action", Json_util.string_opt_to_json latest_next_action);
       ("pending_approval_count", `Int pending_approval_count);
       ("pending_approvals", pending_approvals);
       ("latest_decision", Option.value ~default:`Null latest_decision);

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -1,0 +1,175 @@
+(** Structured terminal-reason surface for keeper turn ledgers. *)
+
+type severity =
+  | Ok
+  | Warn
+  | Bad
+
+type t =
+  { code : string
+  ; source : string
+  ; severity : severity
+  ; summary : string
+  ; next_action : string option
+  }
+
+let severity_to_string = function
+  | Ok -> "ok"
+  | Warn -> "warn"
+  | Bad -> "bad"
+
+let severity_of_code = function
+  | "success" -> Ok
+  | "external_cancel"
+  | "oas_timeout_budget"
+  | "turn_wall_clock_timeout"
+  | "gh_repo_context_missing_worktree" -> Warn
+  | _ -> Bad
+
+let summary_of_code = function
+  | "success" -> "turn completed"
+  | "required_tool_use_no_tool_call" ->
+      "required keeper tool use was requested, but the model returned no keeper tool call"
+  | "required_tool_use_unsatisfied" ->
+      "required keeper tool use was requested, but the tool contract was not satisfied"
+  | "gh_repo_context_missing_worktree" ->
+      "GitHub command blocked because the active task has no linked worktree"
+  | "oas_timeout_budget" ->
+      "OAS call was skipped or failed because the turn timeout budget was exhausted"
+  | "turn_wall_clock_timeout" ->
+      "keeper turn hit the wall-clock timeout"
+  | "external_cancel" ->
+      "keeper turn was cancelled before completion"
+  | "post_commit_ambiguous" ->
+      "provider failed after a mutating tool may have committed side effects"
+  | "provider_error" ->
+      "provider or cascade failed"
+  | "unknown_error" ->
+      "keeper turn failed without a classified terminal reason"
+  | code ->
+      Printf.sprintf "keeper turn ended with %s" code
+
+let next_action_of_code = function
+  | "required_tool_use_no_tool_call"
+  | "required_tool_use_unsatisfied" ->
+      Some "inspect_provider_tool_contract"
+  | "gh_repo_context_missing_worktree" ->
+      Some "create_or_link_worktree"
+  | "oas_timeout_budget"
+  | "turn_wall_clock_timeout" ->
+      Some "inspect_timeout_budget"
+  | "external_cancel" ->
+      Some "rerun_if_still_relevant"
+  | "post_commit_ambiguous" ->
+      Some "reconcile_partial_commit"
+  | "provider_error"
+  | "unknown_error" ->
+      Some "inspect_latest_error"
+  | _ -> None
+
+let normalize_code = function
+  | "completed" -> "success"
+  | "completion_contract_violation:require_tool_use" ->
+      "required_tool_use_unsatisfied"
+  | "api_error_timeout" -> "provider_error"
+  | code -> code
+
+let make ?(source = "typed") ?summary ?next_action code =
+  let code = normalize_code code in
+  let summary = Option.value ~default:(summary_of_code code) summary in
+  let next_action =
+    match next_action with
+    | Some _ as value -> value
+    | None -> next_action_of_code code
+  in
+  { code; source; severity = severity_of_code code; summary; next_action }
+
+let success () = make ~source:"turn_result" "success"
+
+let contains_ci text needle =
+  String_util.contains_substring_ci text needle
+
+let contract_code_from_error_text raw_error =
+  if contains_ci raw_error "no ToolUse block"
+     || contains_ci raw_error "called no keeper tools"
+     || contains_ci raw_error "returned no keeper tool"
+  then "required_tool_use_no_tool_call"
+  else "required_tool_use_unsatisfied"
+
+let of_legacy_error_text raw_error =
+  let trimmed = String.trim raw_error in
+  if trimmed = "" then make ~source:"legacy_error_text" "unknown_error"
+  else if contains_ci trimmed "gh_repo_context_missing_worktree" then
+    make ~source:"legacy_error_text" "gh_repo_context_missing_worktree"
+  else if contains_ci trimmed "oas_timeout_budget" then
+    make ~source:"legacy_error_text" "oas_timeout_budget"
+  else if contains_ci trimmed "Turn wall-clock timeout" then
+    make ~source:"legacy_error_text" "turn_wall_clock_timeout"
+  else if contains_ci trimmed "require_tool_use" then
+    make ~source:"legacy_error_text" (contract_code_from_error_text trimmed)
+  else
+    make ~source:"legacy_error_text" "unknown_error"
+
+let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0)
+    ~raw_error err =
+  if post_commit_ambiguous then
+    make ~source:"typed_error" "post_commit_ambiguous"
+  else
+    match Oas_worker_named.classify_masc_internal_error err with
+    | Some (Oas_worker_named.Oas_timeout_budget _) ->
+        make ~source:"typed_error" "oas_timeout_budget"
+    | Some (Oas_worker_named.Turn_timeout _) ->
+        make ~source:"typed_error" "turn_wall_clock_timeout"
+    | _ ->
+        (match err with
+         | Oas.Error.Agent
+             (Oas.Error.CompletionContractViolation
+                { contract = Oas.Completion_contract_id.Require_tool_use; _ }) ->
+             let code =
+               if tool_call_count <= 0 then
+                 contract_code_from_error_text raw_error
+               else
+                 "required_tool_use_unsatisfied"
+             in
+             make ~source:"typed_error" code
+         | _ ->
+             let fallback = of_legacy_error_text raw_error in
+             if String.equal fallback.code "unknown_error" then
+               make ~source:"typed_error"
+                 (Keeper_agent_error.terminal_reason_code_of_sdk_error err)
+             else
+               fallback)
+
+let of_code ?source ?summary ?next_action code =
+  let source = Option.value ~default:"legacy_code" source in
+  make ~source ?summary ?next_action code
+
+let to_json reason =
+  `Assoc
+    [ ("code", `String reason.code)
+    ; ("source", `String reason.source)
+    ; ("severity", `String (severity_to_string reason.severity))
+    ; ("summary", `String reason.summary)
+    ; ( "next_action",
+        match reason.next_action with
+        | Some action -> `String action
+        | None -> `Null )
+    ]
+
+let string_member key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) when String.trim value <> "" -> Some value
+      | _ -> None)
+  | _ -> None
+
+let of_json json =
+  match string_member "code" json with
+  | None -> None
+  | Some code ->
+      let source =
+        string_member "source" json |> Option.value ~default:"decision_log"
+      in
+      let summary = string_member "summary" json in
+      let next_action = string_member "next_action" json in
+      Some (of_code ~source ?summary ?next_action code)

--- a/lib/keeper/keeper_turn_terminal.mli
+++ b/lib/keeper/keeper_turn_terminal.mli
@@ -1,0 +1,33 @@
+(** Structured terminal-reason surface for keeper turn ledgers. *)
+
+type severity =
+  | Ok
+  | Warn
+  | Bad
+
+type t =
+  { code : string
+  ; source : string
+  ; severity : severity
+  ; summary : string
+  ; next_action : string option
+  }
+
+val severity_to_string : severity -> string
+
+val success : unit -> t
+
+val of_code : ?source:string -> ?summary:string -> ?next_action:string -> string -> t
+
+val of_failure :
+  ?post_commit_ambiguous:bool ->
+  ?tool_call_count:int ->
+  raw_error:string ->
+  Oas.Error.sdk_error ->
+  t
+
+val of_legacy_error_text : string -> t
+
+val to_json : t -> Yojson.Safe.t
+
+val of_json : Yojson.Safe.t -> t option

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -497,6 +497,59 @@ let tool_call_detail_to_json
     ; ("latency_ms", `Float detail.latency_ms)
     ]
 
+let provider_context_json ~(meta : keeper_meta)
+    (result : Keeper_agent_run.run_result option) =
+  match result with
+  | Some r ->
+      let cascade_name, selected_model, candidate_models =
+        match r.cascade_observation with
+        | Some observation ->
+            ( observation.cascade_name,
+              observation.selected_model,
+              observation.candidate_models )
+        | None ->
+            ( meta.cascade_name,
+              Some (Keeper_agent_run.surface_model_used r),
+              [] )
+      in
+      `Assoc
+        [ ("cascade_name", `String cascade_name)
+        ; ( "selected_model",
+            Json_util.string_opt_to_json selected_model )
+        ; ( "candidate_models",
+            `List (List.map (fun value -> `String value) candidate_models) )
+        ]
+  | None ->
+      `Assoc
+        [ ("cascade_name", `String meta.cascade_name)
+        ; ("selected_model", `Null)
+        ; ( "candidate_models",
+            `List
+              (List.map
+                 (fun value -> `String value)
+                 (Keeper_model_labels.configured_model_labels_of_meta meta)) )
+        ]
+
+let tool_contract_json ~(tool_call_count : int) ~(tools_used : string list)
+    (result : Keeper_agent_run.run_result option) =
+  let requirement, required_tool_names, missing_required_tool_names =
+    match result with
+    | Some r ->
+        ( r.tool_surface.tool_requirement,
+          r.tool_surface.required_tool_names,
+          r.tool_surface.missing_required_tool_names )
+    | None -> ("unknown", [], [])
+  in
+  `Assoc
+    [ ("requirement", `String requirement)
+    ; ( "required_tool_names",
+        `List (List.map (fun value -> `String value) required_tool_names) )
+    ; ( "missing_required_tool_names",
+        `List (List.map (fun value -> `String value) missing_required_tool_names) )
+    ; ("tool_call_count", `Int tool_call_count)
+    ; ("tools_used", `List (List.map (fun value -> `String value) tools_used))
+    ]
+
 let append_decision_record
     ~(config : Coord.config)
     ~(meta : keeper_meta)
@@ -512,6 +565,7 @@ let append_decision_record
     ?deliberation_execution
     ?(result : Keeper_agent_run.run_result option = None)
     ?error
+    ?terminal_reason
     () : unit =
   let now_ts = Time_compat.now () in
   let trigger_signals = observed_triggers_of_observation ~meta observation in
@@ -615,6 +669,15 @@ let append_decision_record
     | None, Some err -> err
     | None, None -> Option.value ~default:outcome turn_mode_label
   in
+  let terminal_reason =
+    match terminal_reason with
+    | Some reason -> reason
+    | None -> (
+        match outcome, error with
+        | "success", _ -> Keeper_turn_terminal.success ()
+        | _, Some err -> Keeper_turn_terminal.of_legacy_error_text err
+        | _ -> Keeper_turn_terminal.of_code "unknown_error")
+  in
   let json =
     `Assoc
       ([
@@ -631,6 +694,9 @@ let append_decision_record
         ("goal_id", Json_util.string_opt_to_json goal_id);
         ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) goal_ids));
         ("runtime_contract", runtime_contract);
+        ("terminal_reason", Keeper_turn_terminal.to_json terminal_reason);
+        ("provider_context", provider_context_json ~meta result);
+        ("tool_contract", tool_contract_json ~tool_call_count ~tools_used result);
         ("pending_approval_count", `Int pending_approval_count);
         ("approval_mode", Json_util.string_opt_to_json approval_mode);
         ("channel", `String (decision_channel_of_observation observation));

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -197,6 +197,7 @@ val append_decision_record :
   ?deliberation_execution:Keeper_deliberation.execution_result ->
   ?result:Keeper_agent_run.run_result option ->
   ?error:string ->
+  ?terminal_reason:Keeper_turn_terminal.t ->
   unit ->
   unit
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1390,6 +1390,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               (err, updated_meta)
           in
           let e_str = Oas.Error.to_string err in
+          let terminal_reason =
+            Keeper_turn_terminal.of_failure
+              ~post_commit_ambiguous:is_ambiguous_partial
+              ~raw_error:e_str err
+          in
           Keeper_unified_metrics.append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~semaphore_wait_ms
             ~outcome:(if is_ambiguous_partial then "partial" else "error")
@@ -1397,7 +1402,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ?degraded_retry_cascade
             ?fallback_reason
             ~social_state
-            ~error:e_str ();
+            ~error:e_str
+            ~terminal_reason
+            ();
           (* #9769 root fix: heartbeat-field-merge prevents the
              turn-failure retry from clobbering heartbeat-owned fields
              (joined_room_ids, last_seen_seq_by_room), which was the

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -10,9 +10,14 @@
 open Alcotest
 
 module KAE = Masc_mcp.Keeper_agent_error
+module KT = Masc_mcp.Keeper_turn_terminal
 
 let mk_api err = Agent_sdk.Error.Api err
 let code = KAE.terminal_reason_code_of_sdk_error
+
+let terminal_code (reason : KT.t) = reason.code
+let terminal_next_action (reason : KT.t) = reason.next_action
+let terminal_severity (reason : KT.t) = reason.severity
 
 let test_rate_limited () =
   check string "rate_limited" "api_error_rate_limited"
@@ -129,6 +134,61 @@ let test_all_api_codes_distinct () =
   in
   check int "9 variants -> 9 distinct codes" 9 unique
 
+let test_structured_required_tool_no_tool_call () =
+  let err =
+    Agent_sdk.Error.Agent
+      (Agent_sdk.Error.CompletionContractViolation
+         {
+           contract = Agent_sdk.Completion_contract_id.Require_tool_use;
+           reason =
+             "required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block";
+         })
+  in
+  let terminal =
+    KT.of_failure ~raw_error:(Agent_sdk.Error.to_string err) err
+  in
+  check string "code" "required_tool_use_no_tool_call"
+    (terminal_code terminal);
+  check (option string) "next action" (Some "inspect_provider_tool_contract")
+    (terminal_next_action terminal)
+
+let test_structured_oas_timeout_budget () =
+  let err =
+    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+      (Masc_mcp.Oas_worker_named.Oas_timeout_budget
+         {
+           budget_sec = 90.0;
+           keeper_turn_timeout_sec = 1200.0;
+           estimated_input_tokens = 10_000;
+           source = "test";
+         })
+  in
+  let terminal =
+    KT.of_failure ~raw_error:(Agent_sdk.Error.to_string err) err
+  in
+  check string "code" "oas_timeout_budget" (terminal_code terminal);
+  check string "severity" "warn" (KT.severity_to_string (terminal_severity terminal))
+
+let test_structured_turn_wall_clock_timeout () =
+  let err =
+    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+      (Masc_mcp.Oas_worker_named.Turn_timeout { elapsed_sec = 1200.0 })
+  in
+  let terminal =
+    KT.of_failure ~raw_error:(Agent_sdk.Error.to_string err) err
+  in
+  check string "code" "turn_wall_clock_timeout" (terminal_code terminal)
+
+let test_legacy_gh_worktree_text () =
+  let terminal =
+    KT.of_legacy_error_text
+      "keeper_shell failed: gh_repo_context_missing_worktree: active task has no linked worktree"
+  in
+  check string "code" "gh_repo_context_missing_worktree"
+    (terminal_code terminal);
+  check (option string) "next action" (Some "create_or_link_worktree")
+    (terminal_next_action terminal)
+
 let () =
   run "keeper_terminal_reason"
     [
@@ -145,8 +205,8 @@ let () =
           test_case "NetworkError" `Quick test_network_error;
           test_case "Timeout" `Quick test_timeout;
         ] );
-      ( "regression",
-        [
+	      ( "regression",
+	        [
           test_case "provider timeout receipt outcome -> cancelled" `Quick
             test_timeout_receipt_outcome_is_cancelled;
           test_case "non-timeout receipt outcome -> error" `Quick
@@ -155,7 +215,18 @@ let () =
             test_checkpoint_persistence_error_is_internal_error;
           test_case "non-Api variants unchanged" `Quick
             test_other_variants_unchanged;
-          test_case "all 9 api codes are pairwise distinct" `Quick
-            test_all_api_codes_distinct;
-        ] );
-    ]
+	          test_case "all 9 api codes are pairwise distinct" `Quick
+	            test_all_api_codes_distinct;
+	        ] );
+	      ( "structured terminal reason",
+	        [
+	          test_case "required tool no tool call" `Quick
+	            test_structured_required_tool_no_tool_call;
+	          test_case "oas timeout budget" `Quick
+	            test_structured_oas_timeout_budget;
+	          test_case "turn wall-clock timeout" `Quick
+	            test_structured_turn_wall_clock_timeout;
+	          test_case "legacy gh missing worktree text" `Quick
+	            test_legacy_gh_worktree_text;
+	        ] );
+	    ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1066,6 +1066,8 @@ let test_scheduled_turn_decision_runs_immediately_on_fresh_backlog_update () =
      | WO.Skip _ -> false)
 
 let test_runtime_trust_snapshot_tolerates_null_telemetry () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -1081,8 +1083,62 @@ let test_runtime_trust_snapshot_tolerates_null_telemetry () =
       let snapshot =
         Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
       in
-      check bool "selected model stays null" true
-        Yojson.Safe.Util.(snapshot |> member "selected_model" = `Null))
+	      check bool "selected model stays null" true
+	        Yojson.Safe.Util.(snapshot |> member "selected_model" = `Null))
+
+let test_runtime_trust_snapshot_surfaces_terminal_reason () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      let keeper_name = "runtime-trust-terminal-reason" in
+      let meta =
+        {
+          minimal_meta with
+          name = keeper_name;
+          active_goal_ids = [ "goal-terminal-reason" ];
+        }
+      in
+      let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
+      Keeper_types.mkdir_p (Filename.dirname decision_path);
+      Masc_mcp.Keeper_types_support.append_jsonl_line
+        decision_path
+        (`Assoc
+          [
+            ("ts_unix", `Float 1_712_000_000.0);
+            ("trace_id", `String "trace-terminal-reason");
+            ("turn_id", `Int 7);
+            ("task_id", `String "task-terminal-reason");
+            ("goal_ids", `List [ `String "goal-terminal-reason" ]);
+            ( "terminal_reason",
+              `Assoc
+                [
+                  ("code", `String "gh_repo_context_missing_worktree");
+                  ("source", `String "legacy_error_text");
+                  ("severity", `String "warn");
+                  ( "summary",
+                    `String "GitHub command blocked because the active task has no linked worktree" );
+                  ("next_action", `String "create_or_link_worktree");
+                ] );
+          ]);
+      let snapshot =
+        Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+      in
+      let open Yojson.Safe.Util in
+      check string "latest terminal code" "gh_repo_context_missing_worktree"
+        (snapshot |> member "latest_terminal_reason" |> member "code" |> to_string);
+      check string "latest next action" "create_or_link_worktree"
+        (snapshot |> member "latest_next_action" |> to_string);
+      let timeline = snapshot |> member "causal_timeline" |> to_list in
+      check bool "terminal reason event present" true
+        (List.exists
+           (fun event ->
+             event |> member "kind" |> to_string = "terminal_reason"
+             && event |> member "next_human_action" |> to_string = "create_or_link_worktree")
+           timeline))
 
 let test_prompt_contains_identity () =
   let sys, _user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation () in
@@ -2919,10 +2975,18 @@ let test_append_decision_record_persists_tool_calls () =
         Yojson.Safe.Util.(List.nth recorded_tool_calls 0 |> member "tool_name" |> to_string);
       check string "first provider" "codex_cli"
         Yojson.Safe.Util.(List.nth recorded_tool_calls 0 |> member "provider" |> to_string);
-      check string "second outcome" "error"
-        Yojson.Safe.Util.(List.nth recorded_tool_calls 1 |> member "outcome" |> to_string);
-      check (float 0.001) "second latency" 3.0
-        Yojson.Safe.Util.(List.nth recorded_tool_calls 1 |> member "latency_ms" |> to_float))
+	      check string "second outcome" "error"
+	        Yojson.Safe.Util.(List.nth recorded_tool_calls 1 |> member "outcome" |> to_string);
+	      check (float 0.001) "second latency" 3.0
+	        Yojson.Safe.Util.(List.nth recorded_tool_calls 1 |> member "latency_ms" |> to_float);
+	      check string "terminal reason success" "success"
+	        Yojson.Safe.Util.(json |> member "terminal_reason" |> member "code" |> to_string);
+	      check string "provider context selected model" "codex_cli:gpt-5.4"
+	        Yojson.Safe.Util.(json |> member "provider_context" |> member "selected_model" |> to_string);
+	      check string "tool contract requirement" "optional"
+	        Yojson.Safe.Util.(json |> member "tool_contract" |> member "requirement" |> to_string);
+	      check int "tool contract count mirrors tool calls" 2
+	        Yojson.Safe.Util.(json |> member "tool_contract" |> member "tool_call_count" |> to_int))
 
 let test_append_decision_record_nulls_unreported_usage () =
   Eio_main.run @@ fun env ->
@@ -2975,8 +3039,37 @@ let test_append_decision_record_nulls_unreported_usage () =
         (telemetry |> member "telemetry_reported" |> to_bool);
       check string "coverage stage persisted" "oas"
         (telemetry |> member "coverage_stage" |> to_string);
-      check string "coverage reason persisted" "missing_usage_and_inference"
-        (telemetry |> member "coverage_reason" |> to_string))
+	      check string "coverage reason persisted" "missing_usage_and_inference"
+	        (telemetry |> member "coverage_reason" |> to_string))
+
+let test_append_decision_record_classifies_legacy_worktree_error () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      UM.append_decision_record
+        ~config
+        ~meta:minimal_meta
+        ~observation:base_observation
+        ~latency_ms:19
+        ~outcome:"error"
+        ~error:
+          "keeper_shell failed: gh_repo_context_missing_worktree: active task has no linked worktree"
+        ();
+      let json =
+        read_jsonl_line (Keeper_types.keeper_decision_log_path config minimal_meta.name)
+      in
+      let open Yojson.Safe.Util in
+      check string "terminal code" "gh_repo_context_missing_worktree"
+        (json |> member "terminal_reason" |> member "code" |> to_string);
+      check string "next action" "create_or_link_worktree"
+        (json |> member "terminal_reason" |> member "next_action" |> to_string);
+      check string "tool contract unknown for error path" "unknown"
+        (json |> member "tool_contract" |> member "requirement" |> to_string))
 
 let test_run_keeper_cycle_skips_non_executable_phase () =
   Eio_main.run @@ fun env ->
@@ -6262,9 +6355,11 @@ let () =
             test_task_backlog_cooldown_applies_noop_backoff_once;
           test_case "fresh backlog update bypasses cooldown" `Quick
             test_scheduled_turn_decision_runs_immediately_on_fresh_backlog_update;
-          test_case "runtime trust snapshot tolerates null telemetry" `Quick
-            test_runtime_trust_snapshot_tolerates_null_telemetry;
-          test_case "with goals" `Quick test_observation_with_goals;
+	          test_case "runtime trust snapshot tolerates null telemetry" `Quick
+	            test_runtime_trust_snapshot_tolerates_null_telemetry;
+	          test_case "runtime trust snapshot surfaces terminal reason" `Quick
+	            test_runtime_trust_snapshot_surfaces_terminal_reason;
+	          test_case "with goals" `Quick test_observation_with_goals;
           test_case "economic modes" `Quick test_observation_economic_modes;
         ] );
       ( "unified_prompt",
@@ -6397,10 +6492,12 @@ let () =
             test_append_metrics_snapshot_marks_untrusted_usage;
           test_case "decision record persists tool call details" `Quick
             test_append_decision_record_persists_tool_calls;
-          test_case "decision record nulls unreported usage" `Quick
-            test_append_decision_record_nulls_unreported_usage;
-          test_case "social fields" `Quick
-            test_metrics_persist_social_state_fields;
+	          test_case "decision record nulls unreported usage" `Quick
+	            test_append_decision_record_nulls_unreported_usage;
+	          test_case "decision record classifies worktree blocker" `Quick
+	            test_append_decision_record_classifies_legacy_worktree_error;
+	          test_case "social fields" `Quick
+	            test_metrics_persist_social_state_fields;
           test_case "failure response" `Quick test_metrics_failure_response;
           test_case "timeout failure increments proactive backoff" `Quick
             test_metrics_failure_timeout_increments_proactive_backoff;


### PR DESCRIPTION
## Summary
- add structured keeper terminal reasons for decision-log bloodflow visibility
- persist provider/tool-contract context in keeper decision records
- surface latest terminal reason and next action through runtime-trust/dashboard keeper JSON

## Why this matters
Keepers can currently look silent when a turn dies at a provider/tool-contract/worktree boundary. This makes the terminal blocker visible as data instead of requiring log archaeology: required tool with no tool call, missing worktree for gh context, OAS timeout budget, wall-clock timeout, partial commit ambiguity, etc.

## Verification
- scripts/dune-local.sh build test/test_keeper_terminal_reason.exe
- ./_build/default/test/test_keeper_terminal_reason.exe
- scripts/dune-local.sh build test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe test metrics_observation 24-26 --compact --show-errors
- ./_build/default/test/test_keeper_unified.exe test world_observation 36-37 --compact --show-errors
- git diff --check

## Known unrelated blocker
A broader dashboard-target build is blocked by existing ProviderFailure _ exhaustiveness gaps outside this change. Tracked in #12122.