### PR TITLE
docs(audit): TLA+ specs gap audit Phase 2 (Q-P0-2 follow-up)

### DIFF
--- a/docs/audit/TLA-SPECS-GAP-AUDIT-2026-04-PHASE2.md
+++ b/docs/audit/TLA-SPECS-GAP-AUDIT-2026-04-PHASE2.md
@@ -1,0 +1,141 @@
+# TLA+ Specs Gap Audit — Phase 2 (tautology triage)
+
+> Status: Phase 2 of N. Triages the 21 tautology candidates from Phase 1 §3.2.
+> Author: Vincent (jeong-sik) with Claude
+> Created: 2026-04-30
+> Tracks: Q-P0-2 follow-up
+> Related: PR #12123 (Phase 1, MERGED)
+
+---
+
+## 1. Why Phase 2 sweeps Phase 1's candidate list
+
+Phase 1 §3.2 surfaced **21 specs** where `INDEX.md` shows the clean and buggy invariant sets are textually identical. The framing was:
+
+> This may still be valid: the buggy cfg can override the Spec/Init/Next action (e.g. via a separate SpecBuggy definition that includes BugAction) while keeping the same invariants — that *is* the CLAUDE.md pattern. […] The point is structural: INDEX.md reveals 21 candidate-tautology rows that warrant per-spec inspection, not that all 21 are wrong.
+
+A spot-check on `auth/AuthIdentityFSM` confirmed `Spec` vs `SpecBuggy` distinction. Phase 2 runs the same check across all 21.
+
+## 2. Method
+
+```bash
+# /tmp/cycle11-tautology-sweep.sh — for each candidate:
+clean_spec=$(grep -E "^SPECIFICATION" "$clean_cfg" | awk '{print $2}')
+buggy_spec=$(grep -E "^SPECIFICATION" "$buggy_cfg" | awk '{print $2}')
+[[ "$clean_spec" == "$buggy_spec" ]] && verdict="TAUTOLOGY" || verdict="VALID"
+```
+
+Necessary condition: different `SPECIFICATION` name. Sufficient confirmation: spot-check that `SpecBuggy` definition introduces a different `Next` relation (i.e. extends with `BugAction` or names a `NextBuggy` / `NextUnsafe`).
+
+## 3. Sweep results
+
+| Candidate | Clean SPEC | Buggy SPEC | Verdict |
+|---|---|---|---|
+| admission-queue/AdmissionQueue | Spec | SpecBuggy | **VALID** |
+| auth/AuthIdentityFSM | Spec | SpecBuggy | **VALID** |
+| boundary/CascadeKeeperRecovery | Spec | SpecBuggy | **VALID** |
+| boundary/CascadeStrategyStateful | Spec | SpecBuggy | **VALID** |
+| boundary/KeeperContractViolated | Spec | SpecBuggy | **VALID** |
+| boundary/KeeperEmptyToolUniverse | Spec | SpecBuggy | **VALID** |
+| boundary/KeeperRecoveryOrchestration | Spec | SpecBuggy | **VALID** |
+| boundary/KeeperStaleKilled | Spec | SpecBuggy | **VALID** |
+| boundary/KeeperTurnScheduler | Spec | SpecBuggy | **VALID** |
+| boundary/KeeperTurnTerminal | Spec | SpecBuggy | **VALID** |
+| bug-models/AuthIdentityFSM | Spec | SpecBuggy | **VALID** |
+| bug-models/DashboardCacheStampede | SpecClean | SpecBuggy | **VALID** |
+| bug-models/DiscoveryCacheTTL | SpecClean | SpecBuggy | **VALID** |
+| bug-models/DispatchCoverage | Spec | SpecBuggy | **VALID** |
+| bug-models/FileLockStarvation | SpecClean | SpecBuggy | **VALID** |
+| bug-models/HebbianLearning | Spec | SpecBuggy | **VALID** |
+| bug-models/KeepalivePhaseConsistency | Spec | SpecBuggy | **VALID** |
+| bug-models/KeeperPhaseRace | Spec | SpecBuggy | **VALID** |
+| bug-models/MemoryCompaction | Spec | SpecBuggy | **VALID** |
+| bug-models/SSEBroadcastBlock | SpecClean | SpecBuggy | **VALID** |
+| bug-models/SessionRegistryGhost | SpecClean | SpecBuggy | **VALID** |
+
+**21/21 VALID. Zero true tautologies.**
+
+## 4. Spot-check confirmation (sample of 4)
+
+The "different SPECIFICATION name" criterion is necessary but not sufficient — the buggy `Spec` must actually exercise a different `Next` relation. Verified on a representative sample:
+
+```bash
+$ rg "^SpecBuggy|^NextBuggy|^NextUnsafe" specs/...
+```
+
+| Spec | Buggy `Spec` definition | BugAction synthesis |
+|---|---|---|
+| `auth/AuthIdentityFSM.tla` | `SpecBuggy == Init /\ [][NextBuggy]_vars` | (separate `NextBuggy` action) |
+| `boundary/KeeperContractViolated.tla` | `SpecBuggy == Init /\ [][NextBuggy]_vars` | (separate `NextBuggy` action) |
+| `bug-models/HebbianLearning.tla` | `SpecBuggy == Init /\ [][NextUnsafe]_vars` | renamed `NextUnsafe` |
+| `admission-queue/AdmissionQueue.tla` | `SpecBuggy == Init /\ [][NextBuggy]_vars` | `NextBuggy == \/ Next \/ FdGuardSkip \/ ReleaseSkipped` (extends `Next`) |
+
+All four use the CLAUDE.md `Next \/ BugAction` recipe with one cosmetic divergence: **three different names** for the bug-extended transition relation (`NextBuggy`, `NextUnsafe`, occasionally inline). This is style drift, not correctness — addressed in §6.
+
+## 5. Phase 1 verdict revision
+
+Phase 1's "Tautology candidate" row in §4 ranked Medium severity with count 21. Phase 2 reduces this to **Medium severity, count 0**. The audit's working-list of pending hygiene items shrinks accordingly:
+
+| Class | Phase 1 count | Phase 2 count | Notes |
+|---|---|---|---|
+| 0% Bug Model coverage | 8 specs | 8 specs | unchanged — needs domain-specific BugAction per spec |
+| Tautology | 21 candidates | **0** | resolved in this Phase |
+| Split-pair `*Bug.tla` style | 3 specs | 3 specs | unchanged |
+| `specs/states/` artifact | 1 dir | 1 dir | unchanged |
+| **NEW: BugAction naming drift** | — | 3 styles | uncovered in §4 spot-check |
+
+The total surface is now **1 high-severity item (8 specs) + 3 low-severity hygiene items**, down from a fuzzy "29-item" appearance in Phase 1.
+
+## 6. New finding: BugAction naming drift
+
+Three names in use for the bug-extended transition:
+
+- `NextBuggy` (most boundary/, most bug-models/, admission-queue)
+- `NextUnsafe` (HebbianLearning)
+- inline `\/ Next \/ <BugAction>` directly in `SpecBuggy` (rarer)
+
+`KeeperOASAdvanced.tla` (the canonical example referenced in CLAUDE.md) uses `CancelledNeverAbsorbed` invariant + `CancelledAbsorbed` BugAction directly inside `Next`. So even the "canonical" spec doesn't follow a single naming convention.
+
+This is a hygiene finding worth tracking, not blocking. A follow-up could:
+1. Pick `NextBuggy` as canonical (most-used)
+2. Migrate `NextUnsafe` (1 case) and inline cases (~few) in a single sweep PR
+3. Add a `gen-tla-index.sh` lint that warns on non-`NextBuggy` names
+
+Defer until a separate Phase or skip if the cost outweighs the value.
+
+## 7. Updated phase plan
+
+| Phase | Scope | Status |
+|---|---|---|
+| 1 | Initial gap survey, taxonomy | PR #12123 (MERGED) |
+| **2 (this PR)** | **21-candidate tautology sweep** | **this PR** |
+| 3 | 8-spec zero-coverage Bug Model triage; per-spec RFC index | next |
+| 4 | Coverage ratchet (descriptive metric) wired into CI | after Phase 3 baseline |
+
+Phase 3 will not write the buggy cfgs (each needs domain expertise) — it will *enumerate* per-spec RFC stubs so the work can fan out across follow-up PRs.
+
+## 8. Ratchet note
+
+Adding `candidate_tautology_specs` as a descriptive ratchet metric (Phase 1 §6) is no longer useful — the count is 0 and stays 0 unless `INDEX.md` regenerates with new identical rows that turn out to be valid. The ratchet would produce noise rather than signal. **Withdrawn.**
+
+The other proposed metric, `domains_without_bug_model`, remains worth tracking. Its current floor is 5; goal is monotonic decrease.
+
+## 9. Closing observation: candidate vs verdict discipline
+
+Phase 1 spent care framing the 21 specs as *candidates* and refused to call them violations. Phase 2 confirms the framing was correct: zero of 21 are actual violations. Had Phase 1 over-claimed ("21 weak Bug Models"), Phase 2 would now be a full retraction.
+
+The discipline mirrors the OAS chain: Phase 1 there flagged Layer C as `NEEDS SWEEP` (count 200+ raw references); Phase 2 refined the verdict to PASS via C1–C4 taxonomy. **In both audits the second phase narrows or zeroes out an over-broad first-phase signal.** This is a property of survey-style audits — wide net first, structural classification second, fixes only after the classification stabilizes.
+
+For future audits in this style, expect the second pass to delete more than it adds.
+
+## 10. References
+
+- `docs/audit/TLA-SPECS-GAP-AUDIT-2026-04.md` — Phase 1 (MERGED in #12123)
+- `specs/INDEX.md` — auto-generated, source for Phase 1 §3.2 candidate list
+- `/tmp/cycle11-tautology-sweep.sh` — sweep script (output reproduced in §3)
+- `specs/keeper-state-machine/KeeperOASAdvanced.tla` — canonical Bug Model example referenced in CLAUDE.md
+- `docs/audit/OAS-MASC-BOUNDARY-AUDIT-2026-04-PHASE2.md` — sister audit's Phase 2 (NEEDS SWEEP→PASS via C1–C4 taxonomy)
+- CLAUDE.md `TLA+ Bug Model 패턴` section
+- Memory: `feedback_self_confession_comments_must_be_measured` (don't trust prose alone — measure)
+
+*Audit date: 2026-04-30 / Phase 2 of 4 / docs-only / verifies Phase 1 framing*


### PR DESCRIPTION
## Summary

Phase 2 of TLA+ specs gap audit (Q-P0-2). Triages the 21 tautology candidates from Phase 1 §3.2 (PR #12123 MERGED).

**Result: 21/21 VALID. Zero true tautologies.**

Sweep methodology (per `/tmp/cycle11-tautology-sweep.sh`): for each candidate, diff the `SPECIFICATION` line of clean cfg vs `-buggy.cfg`. Different name (`Spec`/`SpecBuggy` or `SpecClean`/`SpecBuggy`) implies the buggy variant introduces a different `Next` relation. All 21 satisfy this.

Spot-checked 4 specs to confirm `SpecBuggy` actually introduces `NextBuggy` or `NextUnsafe` with extended actions:

| Spec | Buggy form |
|---|---|
| auth/AuthIdentityFSM | `SpecBuggy == Init /\ [][NextBuggy]_vars` |
| boundary/KeeperContractViolated | same pattern |
| bug-models/HebbianLearning | `[][NextUnsafe]_vars` (renamed) |
| admission-queue/AdmissionQueue | `NextBuggy == \/ Next \/ FdGuardSkip \/ ReleaseSkipped` (extends) |

## Phase 1 verdict revision

| Class | Phase 1 count | Phase 2 count |
|---|---|---|
| 0% Bug Model coverage | 8 specs | 8 specs (unchanged) |
| Tautology | 21 candidates | **0** |
| Split-pair `*Bug.tla` | 3 specs | 3 specs (unchanged) |
| `specs/states/` artifact | 1 dir | 1 dir (unchanged) |
| **NEW: BugAction naming drift** | — | 3 styles (low) |

Phase 1 §6 ratchet proposal `candidate_tautology_specs` **withdrawn** — count is 0, would produce noise. `domains_without_bug_model` retained.

## Why this matters

Same self-correcting pattern as the OAS audit chain (Q-P0-3, MERGED): Phase 1 there flagged Layer C as `NEEDS SWEEP` from raw counts; Phase 2 refined the verdict to PASS via C1–C4 taxonomy. **In both audits, the second phase narrows or zeroes out an over-broad first-phase signal.** Phase 1's candidate framing was correct discipline — refusing to call the 21 specs "weak" without evidence avoided a 21-item false alarm.

## Test plan

- [x] Sweep script reproduces on 21 candidates → all VALID
- [x] Spot-check 4 sample specs → confirms `SpecBuggy` extends `Next` with bug actions
- [x] Phase 1 §3.2 quote confirms framing was deliberate ("not that all 21 are wrong")
- [ ] Phase 3: per-spec RFC index for the 8 zero-coverage specs (out of scope)
- [ ] Phase 4: ratchet wire-up after Phase 3 baseline (out of scope)

## References

- PR #12123 — Phase 1 (MERGED)
- `docs/audit/OAS-MASC-BOUNDARY-AUDIT-2026-04-PHASE2.md` — sister chain Phase 2
- `specs/INDEX.md` — auto-generated source for candidate list
- `specs/keeper-state-machine/KeeperOASAdvanced.tla` — canonical Bug Model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
