### PR TITLE
keeper: surface receipt disposition in runtime trust

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -422,6 +422,62 @@ let disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields =
     | Some _, _ -> ("Alert", "critical_block")
     | None, _ -> ("Pass", "healthy")
 
+let operator_disposition_of_display ~disposition ~disposition_reason =
+  match disposition with
+  | "Pass" -> ("pass", disposition_reason)
+  | "Pause" -> ("pause_human", disposition_reason)
+  | "Alert" -> ("alert_exhausted", disposition_reason)
+  | _ -> ("pause_human", disposition_reason)
+
+let display_disposition_of_operator ~operator_disposition
+    ~operator_disposition_reason =
+  let reason default =
+    match String.trim operator_disposition_reason with
+    | "" -> default
+    | value -> value
+  in
+  match String.lowercase_ascii operator_disposition with
+  | "pass" -> ("Pass", "healthy")
+  | "skipped" -> ("Pass", "phase_skipped")
+  | "pass_next_model" -> ("Pass", "cascade_fallback")
+  | "pause_human" -> ("Pause", reason "needs_human_attention")
+  | "fail_open_next_cascade" -> ("Pause", reason "degraded_retry")
+  | "user_cancelled" -> ("Pause", reason "cancelled")
+  | "alert_exhausted" -> ("Alert", reason "cascade_exhausted")
+  | "unknown" -> ("Alert", reason "unmapped_cascade_state")
+  | _ -> ("Alert", reason "unmapped_operator_disposition")
+
+let receipt_operator_disposition receipt =
+  match
+    ( json_string_opt_member "operator_disposition" receipt,
+      json_string_opt_member "operator_disposition_reason" receipt )
+  with
+  | Some disposition, Some reason -> Some (disposition, reason)
+  | Some disposition, None -> Some (disposition, "")
+  | None, _ -> None
+
+let effective_disposition_fields ~fallback_disposition ~fallback_reason
+    latest_receipt =
+  match Option.bind latest_receipt receipt_operator_disposition with
+  | Some (operator_disposition, operator_disposition_reason) ->
+      let disposition, disposition_reason =
+        display_disposition_of_operator ~operator_disposition
+          ~operator_disposition_reason
+      in
+      ( disposition,
+        disposition_reason,
+        operator_disposition,
+        operator_disposition_reason )
+  | None ->
+      let operator_disposition, operator_disposition_reason =
+        operator_disposition_of_display ~disposition:fallback_disposition
+          ~disposition_reason:fallback_reason
+      in
+      ( fallback_disposition,
+        fallback_reason,
+        operator_disposition,
+        operator_disposition_reason )
+
 let disposition_fields_json ~(config : Coord.config) ~(meta : keeper_meta) :
     Yojson.Safe.t =
   let pending_approval_count =
@@ -432,6 +488,11 @@ let disposition_fields_json ~(config : Coord.config) ~(meta : keeper_meta) :
   in
   let disposition, disposition_reason =
     disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields
+  in
+  let latest_receipt = Keeper_execution_receipt.latest_json config meta.name in
+  let disposition, disposition_reason, _, _ =
+    effective_disposition_fields ~fallback_disposition:disposition
+      ~fallback_reason:disposition_reason latest_receipt
   in
   `Assoc
     [
@@ -810,33 +871,18 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   let runtime_contract =
     Keeper_runtime_contract.runtime_contract_json ~config meta
   in
-  let disposition, disposition_reason =
+  let fallback_disposition, fallback_disposition_reason =
     disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields
   in
-  let operator_disposition, operator_disposition_reason =
-    match latest_receipt with
-    | Some receipt -> (
-        let open Yojson.Safe.Util in
-        match
-          ( member "operator_disposition" receipt
-          , member "operator_disposition_reason" receipt )
-        with
-        | `String disposition, `String reason -> (disposition, reason)
-        | _ -> (
-            match disposition with
-            | "Pass" -> ("pass", disposition_reason)
-            | "Pause" -> ("pause_human", disposition_reason)
-            | "Alert" -> ("alert_exhausted", disposition_reason)
-            | _ -> ("pause_human", disposition_reason)))
-    | None -> (
-        match disposition with
-        | "Pass" -> ("pass", disposition_reason)
-        | "Pause" -> ("pause_human", disposition_reason)
-        | "Alert" -> ("alert_exhausted", disposition_reason)
-        | _ -> ("pause_human", disposition_reason))
+  let disposition, disposition_reason, operator_disposition,
+      operator_disposition_reason =
+    effective_disposition_fields ~fallback_disposition
+      ~fallback_reason:fallback_disposition_reason latest_receipt
   in
   let needs_attention =
     assoc_bool_default "needs_attention" ~default:false attention_fields
+    || String.equal disposition "Pause"
+    || String.equal disposition "Alert"
   in
   let attention_reason =
     assoc_string_opt "attention_reason" attention_fields

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -81,7 +81,17 @@ let make_keeper_meta ~name ~goal_id =
   | Ok meta -> { meta with active_goal_ids = [ goal_id ] }
   | Error err -> fail ("meta_of_json failed: " ^ err)
 
-let append_keeper_receipt (config : Coord.config) (meta : Keeper_types.keeper_meta) =
+let append_keeper_receipt ?(outcome = "ok")
+    ?(terminal_reason_code = "completed")
+    ?(requested_tools = [ "keeper_fs_read" ])
+    ?(reported_tools = [ "Read" ])
+    ?(observed_tools = [ "keeper_fs_read" ])
+    ?(canonical_tools = [ "keeper_fs_read" ])
+    ?(tools_used = [ "keeper_fs_read" ])
+    ?(tool_contract_result = "satisfied")
+    ?(tool_requirement = "required")
+    ?(cascade_outcome = "completed") (config : Coord.config)
+    (meta : Keeper_types.keeper_meta) =
   let started_at = Types.now_iso () in
   let ended_at = Types.now_iso () in
   let receipt : Keeper_execution_receipt.t =
@@ -93,22 +103,22 @@ let append_keeper_receipt (config : Coord.config) (meta : Keeper_types.keeper_me
       turn_count = Some 7;
       current_task_id = None;
       goal_ids = meta.active_goal_ids;
-      outcome = "ok";
-      terminal_reason_code = "completed";
+      outcome;
+      terminal_reason_code;
       response_text_present = true;
       model_used = Some "openai:gpt-5.4";
-      requested_tools = [ "keeper_fs_read" ];
-      reported_tools = [ "Read" ];
-      observed_tools = [ "keeper_fs_read" ];
-      canonical_tools = [ "keeper_fs_read" ];
+      requested_tools;
+      reported_tools;
+      observed_tools;
+      canonical_tools;
       unexpected_tools = [];
-      tools_used = [ "keeper_fs_read" ];
-      tool_contract_result = "satisfied";
+      tools_used;
+      tool_contract_result;
       tool_surface =
         {
           turn_lane = "tool";
           tool_surface_class = "mixed";
-          tool_requirement = "required";
+          tool_requirement;
           visible_tool_count = 1;
           tool_gate_enabled = true;
           tool_surface_fallback_used = false;
@@ -124,12 +134,12 @@ let append_keeper_receipt (config : Coord.config) (meta : Keeper_types.keeper_me
       cascade_selected_model = Some "openai:gpt-5.4";
       cascade_attempt_count = 1;
       cascade_fallback_applied = false;
-      cascade_outcome = "completed";
+      cascade_outcome;
       degraded_retry_applied = false;
       degraded_retry_cascade = None;
       fallback_reason = None;
       cascade_rotation_attempts = [];
-      stop_reason = Some "completed";
+      stop_reason = Some terminal_reason_code;
       error_kind = None;
       error_message = None;
       started_at;
@@ -414,6 +424,40 @@ let test_goal_detail_surfaces_keeper_runtime_trust_and_blockers () =
         "execution_receipt"
         (linked_keeper |> member "latest_causal_event" |> member "kind" |> to_string)
 
+let test_goal_detail_uses_receipt_disposition_for_required_tool_failure () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Surface required tool failure" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let meta = make_keeper_meta ~name:"tool-failure-keeper" ~goal_id:goal.id in
+  (match Keeper_types.write_meta ~force:true config meta with
+   | Ok () -> ()
+   | Error err -> fail ("write_meta failed: " ^ err));
+  append_keeper_receipt ~reported_tools:[] ~observed_tools:[] ~canonical_tools:[]
+    ~tools_used:[] ~tool_contract_result:"missing_required_tool_use" config meta;
+  match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
+  | Error msg -> fail msg
+  | Ok json ->
+      let linked_keeper =
+        match json |> member "linked_keepers" |> to_list with
+        | keeper :: _ -> keeper
+        | [] -> fail "expected linked keeper detail"
+      in
+      let runtime_trust = linked_keeper |> member "runtime_trust" in
+      check string "receipt-derived disposition pauses" "Pause"
+        (runtime_trust |> member "disposition" |> to_string);
+      check string "receipt-derived reason surfaced"
+        "tool_required_unsatisfied"
+        (runtime_trust |> member "disposition_reason" |> to_string);
+      check string "operator disposition preserved" "pause_human"
+        (runtime_trust |> member "operator_disposition" |> to_string);
+      check string "operator reason preserved" "tool_required_unsatisfied"
+        (runtime_trust |> member "operator_disposition_reason" |> to_string);
+      check bool "receipt-derived failure needs attention" true
+        (runtime_trust |> member "needs_attention" |> to_bool)
+
 let test_goal_tree_tolerates_null_decision_telemetry () =
   with_room @@ fun config ->
   let goal, _kind =
@@ -514,6 +558,9 @@ let () =
           test_case "goal detail surfaces keeper runtime trust and blockers"
             `Quick
             test_goal_detail_surfaces_keeper_runtime_trust_and_blockers;
+          test_case "goal detail pauses on required tool receipt failure"
+            `Quick
+            test_goal_detail_uses_receipt_disposition_for_required_tool_failure;
           test_case "goal tree tolerates null decision telemetry" `Quick
             test_goal_tree_tolerates_null_decision_telemetry;
           test_case

--- a/test/test_keeper_pause_silent_failure_source.ml
+++ b/test/test_keeper_pause_silent_failure_source.ml
@@ -27,6 +27,8 @@ open Alcotest
 
 let target_file = "lib/server/server_dashboard_http_keeper_api.ml"
 
+let status_detail_file = "lib/keeper/keeper_status_detail.ml"
+
 let metric_name = "metric_keeper_paused_state_persist_errors"
 
 let load_source rel =
@@ -151,6 +153,25 @@ let test_counter_inc_calls () =
        src
      >= 6)
 
+let test_keeper_status_disposition_mirrors_runtime_trust () =
+  let src = load_source status_detail_file in
+  check bool "keeper status builds runtime_trust" true
+    (count_occurrences
+       ~needle:
+         "let runtime_trust =\n           Keeper_runtime_trust_snapshot.snapshot_json"
+       src
+     >= 1);
+  check bool "top-level disposition reads runtime_trust" true
+    (count_occurrences
+       ~needle:"json_string_opt_member runtime_trust \"disposition\""
+       src
+     >= 1);
+  check bool "top-level disposition field is emitted" true
+    (count_occurrences
+       ~needle:"(\"disposition\", Json_util.string_opt_to_json disposition)"
+       src
+     >= 1)
+
 let () =
   run "keeper_pause_silent_failure_source"
     [ ( "issue-8391-high-1"
@@ -163,5 +184,7 @@ let () =
             test_error_branch_observable
         ; test_case "counter inc calls present" `Quick
             test_counter_inc_calls
+        ; test_case "keeper status mirrors runtime-trust disposition" `Quick
+            test_keeper_status_disposition_mirrors_runtime_trust
         ] )
     ]


### PR DESCRIPTION
## Summary
- make latest keeper execution receipts authoritative for runtime-trust display disposition
- map non-forward-progress operator dispositions to visible Pause/Alert states instead of Pass/healthy
- add regression coverage for required-tool failures surfacing as Pause/tool_required_unsatisfied

## Why it matters
Operators were seeing receipt-level failures such as required tool usage violations while higher-level keeper status could still look healthy. This PR makes the failure loud at the runtime-trust layer so silent keeper turns stop hiding behind Pass/healthy.

## Review focus
- receipt-to-display mapping in Keeper_runtime_trust_snapshot
- preserving existing snapshot/blocker behavior when no receipt exists
- regression fixture for tools_used=[] + missing_required_tool_use

## Verification
- git diff --check
- ./_build/default/test/test_keeper_pause_broadcast.exe
- ./_build/default/test/test_dashboard_goals.exe
- rg guard confirmed keeper_status_detail top-level disposition mirrors runtime_trust

## Local verification notes
- A broader focused Dune build was not completed because the shared /tmp/me-dune-local.lock queue was saturated.
- Earlier broader build attempts also exposed unrelated ProviderFailure exhaustiveness errors in untouched OAS/MASC adapter files (for example lib/oas_compat/oas_compat.ml and lib/oas_worker_named.ml). This PR intentionally does not widen into that drift.
