### PR TITLE
dashboard: align composite FSM flowchart with KSM Zombie state

### DIFF
--- a/dashboard/src/components/composite-fsm-flowchart.test.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.test.ts
@@ -23,15 +23,22 @@ describe('buildCompositeFsmMermaid', () => {
     expect(src).toContain('kcl_idle["idle"]')
   })
 
-  it('covers the full KSM state surface (12 phases)', () => {
+  it('covers the full KSM state surface (13 phases)', () => {
     const ksm = [
       'Offline', 'Running', 'Failing', 'Overflowed', 'Compacting',
       'HandingOff', 'Draining', 'Paused', 'Stopped', 'Crashed',
-      'Restarting', 'Dead',
+      'Restarting', 'Dead', 'Zombie',
     ]
     for (const label of ksm) {
       expect(src).toContain(`"${label}"`)
     }
+  })
+
+  it('tags Zombie as a terminal state alongside Stopped and Dead', () => {
+    // Zombie is a terminal phase reached when terminal_failure_latched
+    // is asserted (KeeperStateMachine.tla:77 TerminalPhases).
+    expect(src).toContain('ksm_zombie["Zombie"]')
+    expect(src).toMatch(/class .*ksm_zombie.*terminal/)
   })
 
   it('does not emit duplicate top-level node ids (no un-prefixed collisions)', () => {

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -18,6 +18,7 @@
  *   specs/keeper-state-machine/KeeperDecisionPipeline.tla
  *   specs/keeper-state-machine/KeeperCascadeLifecycle.tla
  *   specs/keeper-state-machine/KeeperCompactionLifecycle.tla
+ *   specs/keeper-state-machine/KeeperCircuitBreaker.tla
  *
  * Only the common-case edges are rendered — a full enumeration of
  * every guarded transition would be unreadable and is what the TLA+
@@ -33,7 +34,7 @@ import { MermaidGraph } from './common/mermaid-graph'
 // does not collapse e.g. two "idle" nodes (KTC and KCL both have one).
 // Labels displayed to the operator stay bare for readability.
 const MERMAID_COMPOSITE: string = `flowchart TB
-  %% ─ KSM (Lifecycle, 12 states) ──────────────────────────
+  %% ─ KSM (Lifecycle, 13 states) ──────────────────────────
   subgraph KSM ["라이프사이클 · KSM"]
     direction LR
     ksm_offline["Offline"] --> ksm_running["Running"]
@@ -53,6 +54,11 @@ const MERMAID_COMPOSITE: string = `flowchart TB
     ksm_crashed --> ksm_restarting["Restarting"]
     ksm_restarting --> ksm_running
     ksm_restarting --> ksm_dead
+    %% Zombie is reached via TerminalFailureDetected from any non-terminal
+    %% phase (derive_phase ELSE-IF branch on terminal_failure_latched=TRUE).
+    %% Failing is the most common upstream phase; the dashed edge marks
+    %% the trigger as a guarded condition rather than a direct transition.
+    ksm_failing -.-> ksm_zombie["Zombie"]
   end
 
   %% ─ KTC (Turn cycle, 5 states) ──────────────────────────
@@ -112,7 +118,7 @@ const MERMAID_COMPOSITE: string = `flowchart TB
   classDef motion   fill:#1a1305,stroke:#a16207,color:#fde68a
   classDef error    fill:#1e0a0a,stroke:#b91c1c,color:#fca5a5
 
-  class ksm_stopped,ksm_dead terminal
+  class ksm_stopped,ksm_dead,ksm_zombie terminal
   class ksm_running,ksm_paused,ktc_idle,kcl_idle,kmc_accumulating,kcb_clean stable
   class ksm_compacting,ksm_handingoff,ksm_overflowed,ksm_draining,ksm_restarting,ktc_prompting,ktc_executing,ktc_compacting,ktc_finalizing,kcl_selecting,kcl_trying,kmc_compacting,kcb_warning motion
   class ksm_failing,ksm_crashed,kdp_gate_rejected,kcl_exhausted error

--- a/docs/observability/composite-fsm-matrix-design.md
+++ b/docs/observability/composite-fsm-matrix-design.md
@@ -1,6 +1,6 @@
 ---
 status: reference
-last_verified: 2026-04-17
+last_verified: 2026-04-30
 code_refs:
   - lib/keeper/keeper_composite_observer.ml
   - lib/keeper/keeper_state_machine.ml
@@ -22,7 +22,7 @@ The keeper runtime exposes **6 orthogonal FSM axes** per entity and a **4-invari
 
 | Axis | Code site                           | States                                                                    | TLA+ spec                              |
 | ---- | ----------------------------------- | ------------------------------------------------------------------------- | -------------------------------------- |
-| KSM  | `keeper_state_machine.mli` (phase)  | Offline / Running / Failing / Overflowed / Compacting / HandingOff / Paused / Draining / Stopped / Crashed / Restarting / Dead | `KeeperStateMachine.tla`               |
+| KSM  | `keeper_state_machine.mli` (phase)  | Offline / Running / Failing / Overflowed / Compacting / HandingOff / Paused / Draining / Stopped / Crashed / Restarting / Dead / Zombie | `KeeperStateMachine.tla`               |
 | KTC  | `keeper_registry.mli:turn_phase`    | idle / prompting / executing / compacting / finalizing                    | `KeeperTurnCycle.tla`                  |
 | KDP  | `keeper_registry.mli:decision_stage`| undecided / guard_ok / gate_rejected / tool_policy_selected               | `KeeperDecisionPipeline.tla`           |
 | KCL  | `keeper_registry.mli:cascade_state` | idle / selecting / trying / done / exhausted                              | `KeeperCascadeLifecycle.tla`           |


### PR DESCRIPTION
## Summary

PR #12114 (`feat(keeper): ZOMBIE state + TLA+ spec alignment for architecture resilience`, merged 2026-04-30 02:51) added the Zombie terminal phase to `KeeperStateMachine.tla`:

```
TerminalPhases == {"Stopped", "Dead", "Zombie"}
TypeOK Phase \in {..., "Dead", "Zombie"}  (13 entries)
```

The composite FSM dashboard panel and the matrix design doc still rendered 12 KSM phases. This PR aligns both with the spec.

## Why this is the right shape

`Zombie` is reachable from **any** non-terminal phase via `derive_phase`'s `ELSE IF terminal_failure_latched THEN "Zombie"` branch. A direct edge from every non-terminal node would clutter the diagram — the panel header already commits to *common-case edges only*, with exhaustive enumeration delegated to TLC. The chosen rendering is:

- **One dashed edge** from `Failing` to `Zombie`. `Failing` is the most common upstream phase under terminal-failure latching, and the dashed style matches the existing `kcb_warning -.-> kcb_cooling` convention for "transition exists but is guarded by a condition observed inside the mutator's read-modify-write".
- **Terminal classDef** for `ksm_zombie` (red), matching `ksm_stopped` and `ksm_dead`.

## Changes

| File | Change |
|------|--------|
| `dashboard/src/components/composite-fsm-flowchart.ts` | Add `ksm_zombie` node + dashed edge `ksm_failing -.-> ksm_zombie`. Tag `ksm_zombie` with `terminal` classDef. Update KSM subgraph header `12 → 13`. Add `KeeperCircuitBreaker.tla` to the spec source list (KCB was already rendered but missing from the comment). |
| `dashboard/src/components/composite-fsm-flowchart.test.ts` | KSM phase enumeration `12 → 13` with `Zombie` added. New test: Zombie carries the terminal classDef. |
| `docs/observability/composite-fsm-matrix-design.md` | KSM states `12 → 13` (add Zombie). Bump `last_verified` to 2026-04-30. |

## Verification

- `pnpm test src/components/composite-fsm-flowchart.test.ts` — **11/11 pass** (10 existing + 1 new Zombie terminal-tag test)
- Mermaid src invariants verified: axis count (6), prefix collision check, KCB tripped-omission, classDef hex literal — all green

## Out of scope

- `lib/keeper/keeper_state_machine.ml` and `test/test_keeper_state_machine*.ml` reference `terminal_failure_latched` as a record field. After PR #12114 merge there are pre-existing build errors on main (`Unbound record field SM.terminal_failure_latched`) — those are part of the same ZOMBIE family and will be fixed by separate PRs in that family. Not in scope here; this PR only touches the dashboard rendering and the design doc.
- The four joint invariants (`phase_turn_alignment` etc.) and their dashboard strip are untouched. `terminal_failure_latched` is a per-keeper condition, not a joint invariant — it does not need to appear in the LT-13 violation counter.

## References

- Spec: `specs/keeper-state-machine/KeeperStateMachine.tla:77` (TerminalPhases), `:597` (TypeOK)
- Upstream PR: #12114 (ZOMBIE state alignment)
- Related design doc: `docs/observability/composite-fsm-matrix-design.md`
