### PR TITLE
feat(keeper): Tier K4 — tool-emission hook accumulator (Cycle 27)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -527,6 +527,7 @@
    keeper_compact_audit
    keeper_rollover
    keeper_post_turn
+   keeper_tool_emission_hook
    keeper_artifact_hydrator
    keeper_exec_context
    keeper_tools_oas

--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -1,0 +1,77 @@
+(* Tier K4 — keeper-side tool-emission hook implementation. *)
+
+type accumulator = {
+  mutable items : Yojson.Safe.t list;
+  mutex : Stdlib.Mutex.t;
+}
+
+let create_accumulator () =
+  { items = []; mutex = Stdlib.Mutex.create () }
+
+let masc_tool_emission_enabled () =
+  match Sys.getenv_opt "MASC_TOOL_EMISSION" with
+  | Some ("1" | "true" | "TRUE") -> true
+  | _ -> false
+
+let push acc (json : Yojson.Safe.t) : unit =
+  Stdlib.Mutex.lock acc.mutex;
+  acc.items <- json :: acc.items;
+  Stdlib.Mutex.unlock acc.mutex
+
+let drain acc : Yojson.Safe.t list =
+  Stdlib.Mutex.lock acc.mutex;
+  let items = List.rev acc.items in
+  acc.items <- [];
+  Stdlib.Mutex.unlock acc.mutex;
+  items
+
+let accumulator_size acc =
+  Stdlib.Mutex.lock acc.mutex;
+  let n = List.length acc.items in
+  Stdlib.Mutex.unlock acc.mutex;
+  n
+
+let try_parse (s : string) : Yojson.Safe.t option =
+  try Some (Yojson.Safe.from_string s) with _ -> None
+
+let make_post_tool_use_hook (acc : accumulator) : Oas.Hooks.hook =
+  fun event ->
+    (if masc_tool_emission_enabled () then
+       match event with
+       | Oas.Hooks.PostToolUse { output; _ } -> (
+           match output with
+           | Ok { content } -> (
+               match try_parse content with
+               | Some json -> push acc json
+               | None -> ())
+           | Error _ -> ())
+       | _ -> ());
+    Oas.Hooks.Continue
+
+let install_into_hooks (acc : accumulator) (hooks : Oas.Hooks.hooks)
+    : Oas.Hooks.hooks =
+  let k4_hook = make_post_tool_use_hook acc in
+  let combined : Oas.Hooks.hook =
+    match hooks.post_tool_use with
+    | None -> k4_hook
+    | Some original ->
+        fun event ->
+          (* K4 hook is observational and always returns Continue;
+             we run it for its side effect, then defer the decision
+             to the original hook. *)
+          let _ : Oas.Hooks.hook_decision = k4_hook event in
+          original event
+  in
+  { hooks with post_tool_use = Some combined }
+
+let drain_into_working_context acc ~(working_context : Yojson.Safe.t option)
+    : Yojson.Safe.t option =
+  if not (masc_tool_emission_enabled ()) then
+    let _ : Yojson.Safe.t list = drain acc in
+    working_context
+  else
+    let items = drain acc in
+    if items = [] then working_context
+    else
+      Multimodal.Tool_emission.emit_from_tool_results
+        ~working_context items

--- a/lib/keeper/keeper_tool_emission_hook.mli
+++ b/lib/keeper/keeper_tool_emission_hook.mli
@@ -1,0 +1,92 @@
+(** Tier K4 — keeper-side capture of tagged tool results into the
+    multimodal pipeline (Cycle 27).
+
+    Layer above K3: K3 ([Multimodal.Tool_emission]) provides the
+    deterministic detector + emitter that turns a single tagged JSON
+    result into the [working_context["multimodal_artifacts"]] bag.
+    K4 wires that detector into the live keeper turn so tool authors
+    do not need to write any keeper-side glue — they only set the
+    two reserved JSON keys (see [Multimodal.Tool_emission]) and the
+    rest happens automatically.
+
+    Pipeline:
+
+      keeper agent runs                  ← Agent.run
+        │
+        │ each PostToolUse event
+        ▼
+      [accumulator]                      ← K4 (this module)
+        │
+        │ post_turn_lifecycle
+        ▼
+      drain_into_working_context         ← K4
+        │
+        │ Multimodal.Tool_emission.emit_from_tool_results
+        ▼
+      working_context["multimodal_artifacts"]
+        │
+        │ apply_multimodal_wirein        ← K1 (already wired)
+        ▼
+      Multimodal.Workspace_holder
+
+    Feature flag: [MASC_TOOL_EMISSION] (default off). When off,
+    [make_post_tool_use_hook] still installs but is a no-op, and
+    [drain_into_working_context] returns the working_context
+    unchanged. Independent of [MASC_MULTIMODAL] (K1) — both must be
+    on for the full chain. *)
+
+(** Per-turn mutable accumulator. Holds parsed
+    [Yojson.Safe.t] results captured during Agent.run. Thread-safe
+    via [Stdlib.Mutex] (PostToolUse hooks may fire from worker
+    fibers). *)
+type accumulator
+
+(** Allocate a fresh empty accumulator. *)
+val create_accumulator : unit -> accumulator
+
+(** Reads the [MASC_TOOL_EMISSION] env var. Returns [true] for
+    [1], [true], [TRUE]; [false] otherwise (including unset). *)
+val masc_tool_emission_enabled : unit -> bool
+
+(** Build a [PostToolUse] hook handler that captures tool output
+    content as JSON into the accumulator.
+
+    The handler is a no-op when [masc_tool_emission_enabled ()] is
+    [false]. Parse failures (non-JSON tool output) are silently
+    ignored — only valid JSON enters the accumulator.
+
+    All hook events return [Continue]. The hook is purely
+    observational: it never aborts a tool call, never adjusts
+    params, never elicits input. *)
+val make_post_tool_use_hook : accumulator -> Oas.Hooks.hook
+
+(** Wrap an existing [Oas.Hooks.hooks] record so that
+    [post_tool_use] also routes through the K4 accumulator hook.
+
+    If the record already has a [post_tool_use] hook, both hooks
+    fire in sequence; the original hook's decision is preserved
+    (the K4 hook's [Continue] is overridden by the original's
+    decision). If the record has no [post_tool_use] hook, only the
+    K4 hook is installed. *)
+val install_into_hooks :
+  accumulator ->
+  Oas.Hooks.hooks ->
+  Oas.Hooks.hooks
+
+(** Drain the accumulator and merge any tagged tool results into
+    [working_context["multimodal_artifacts"]] via
+    [Multimodal.Tool_emission.emit_from_tool_results].
+
+    After draining, the accumulator is empty (so subsequent turns
+    start fresh).
+
+    When [masc_tool_emission_enabled ()] is [false] OR the
+    accumulator is empty, returns [working_context] unchanged. *)
+val drain_into_working_context :
+  accumulator ->
+  working_context:Yojson.Safe.t option ->
+  Yojson.Safe.t option
+
+(** Number of items currently held in the accumulator. Useful for
+    tests and metrics. *)
+val accumulator_size : accumulator -> int

--- a/test/dune
+++ b/test/dune
@@ -214,7 +214,8 @@
         test_provider_capability_matrix
         test_provider_error
         test_keeper_synthetic_marker
-        test_keeper_turn_fsm_wired_sites)
+        test_keeper_turn_fsm_wired_sites
+        test_keeper_tool_emission_hook)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_sse_presence test_cancellation test_graphql_api
@@ -399,6 +400,7 @@
           test_provider_error
           test_keeper_synthetic_marker
           test_keeper_turn_fsm_wired_sites
+          test_keeper_tool_emission_hook
           )
  (libraries masc_test_deps))
 

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -1,0 +1,248 @@
+(* Tier K4 — Keeper_tool_emission_hook unit tests.
+
+   Coverage:
+   - feature flag respected (off → no-op, on → captures)
+   - PostToolUse: Ok content parses → accumulator grows
+   - PostToolUse: Error tool_result → ignored
+   - non-JSON content → silently ignored (no exception)
+   - non-PostToolUse events → ignored
+   - drain empties accumulator
+   - install_into_hooks chain preserves original decision *)
+
+module H = Masc_mcp.Keeper_tool_emission_hook
+module THooks = Agent_sdk.Hooks
+module TT = Agent_sdk.Types
+
+let with_env_set name value f =
+  let prev = Sys.getenv_opt name in
+  Unix.putenv name value;
+  let restore () =
+    match prev with
+    | Some v -> Unix.putenv name v
+    | None -> Unix.putenv name ""
+  in
+  Fun.protect ~finally:restore f
+
+let with_env_unset name f =
+  let prev = Sys.getenv_opt name in
+  Unix.putenv name "";
+  let restore () =
+    match prev with
+    | Some v -> Unix.putenv name v
+    | None -> ()
+  in
+  Fun.protect ~finally:restore f
+
+let make_post_tool_use ~content : THooks.hook_event =
+  THooks.PostToolUse
+    { tool_use_id = "tu-1"
+    ; tool_name = "fake_tool"
+    ; input = `Assoc []
+    ; output = Ok ({ TT.content } : TT.tool_output)
+    ; result_bytes = String.length content
+    ; duration_ms = 1.0
+    ; schedule = THooks.Now
+    }
+
+let make_pre_tool_use () : THooks.hook_event =
+  THooks.PreToolUse
+    { tool_use_id = "tu-1"
+    ; tool_name = "fake_tool"
+    ; input = `Assoc []
+    ; accumulated_cost_usd = 0.0
+    ; turn = 1
+    ; schedule = THooks.Now
+    }
+
+let make_post_tool_use_error () : THooks.hook_event =
+  THooks.PostToolUse
+    { tool_use_id = "tu-2"
+    ; tool_name = "broken_tool"
+    ; input = `Assoc []
+    ; output =
+        Error
+          ({ TT.message = "boom"
+           ; recoverable = true
+           ; error_class = None
+           } : TT.tool_error)
+    ; result_bytes = 0
+    ; duration_ms = 0.5
+    ; schedule = THooks.Now
+    }
+
+let assert_eq_int ~label expected actual =
+  if expected <> actual then (
+    Printf.printf "FAIL [%s]: expected %d actual %d\n" label
+      expected actual;
+    exit 1)
+
+let test_disabled_no_op () =
+  with_env_unset "MASC_TOOL_EMISSION" (fun () ->
+      assert (not (H.masc_tool_emission_enabled ()));
+      let acc = H.create_accumulator () in
+      let hook = H.make_post_tool_use_hook acc in
+      let event =
+        make_post_tool_use
+          ~content:
+            {|{"__multimodal_kind":"code","__multimodal_id":"01900000-0000-7000-8000-000000000001","source":"x"}|}
+      in
+      let _ : THooks.hook_decision = hook event in
+      assert_eq_int ~label:"disabled_no_capture" 0
+        (H.accumulator_size acc));
+  print_endline "  disabled_no_op: OK"
+
+let test_enabled_captures_post_tool_use () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      assert (H.masc_tool_emission_enabled ());
+      let acc = H.create_accumulator () in
+      let hook = H.make_post_tool_use_hook acc in
+      let event =
+        make_post_tool_use
+          ~content:
+            {|{"__multimodal_kind":"code","__multimodal_id":"01900000-0000-7000-8000-000000000001","source":"x"}|}
+      in
+      let _ : THooks.hook_decision = hook event in
+      assert_eq_int ~label:"enabled_capture" 1
+        (H.accumulator_size acc));
+  print_endline "  enabled_captures_post_tool_use: OK"
+
+let test_error_tool_result_ignored () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let acc = H.create_accumulator () in
+      let hook = H.make_post_tool_use_hook acc in
+      let _ : THooks.hook_decision =
+        hook (make_post_tool_use_error ())
+      in
+      assert_eq_int ~label:"error_ignored" 0
+        (H.accumulator_size acc));
+  print_endline "  error_tool_result_ignored: OK"
+
+let test_non_json_content_ignored () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let acc = H.create_accumulator () in
+      let hook = H.make_post_tool_use_hook acc in
+      let event =
+        make_post_tool_use ~content:"not actually json {{{"
+      in
+      let _ : THooks.hook_decision = hook event in
+      assert_eq_int ~label:"non_json_ignored" 0
+        (H.accumulator_size acc));
+  print_endline "  non_json_content_ignored: OK"
+
+let test_other_events_ignored () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let acc = H.create_accumulator () in
+      let hook = H.make_post_tool_use_hook acc in
+      let _ : THooks.hook_decision = hook (make_pre_tool_use ()) in
+      assert_eq_int ~label:"pre_tool_use_ignored" 0
+        (H.accumulator_size acc));
+  print_endline "  other_events_ignored: OK"
+
+let test_drain_empties_accumulator () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let acc = H.create_accumulator () in
+      let hook = H.make_post_tool_use_hook acc in
+      let _ : THooks.hook_decision =
+        hook
+          (make_post_tool_use
+             ~content:
+               {|{"__multimodal_kind":"code","__multimodal_id":"01900000-0000-7000-8000-000000000010","source":"x"}|})
+      in
+      let _ : THooks.hook_decision =
+        hook
+          (make_post_tool_use
+             ~content:
+               {|{"__multimodal_kind":"image","__multimodal_id":"01900000-0000-7000-8000-000000000011","data_url":"data:..."}|})
+      in
+      assert_eq_int ~label:"size_before_drain" 2
+        (H.accumulator_size acc);
+      let new_wc =
+        H.drain_into_working_context acc ~working_context:None
+      in
+      (* Both items had reserved keys → both flow through. *)
+      let raws, _ =
+        Multimodal.Wirein_helpers.extract_raw_artifacts new_wc
+      in
+      assert_eq_int ~label:"emitted_raws" 2 (List.length raws);
+      assert_eq_int ~label:"size_after_drain" 0
+        (H.accumulator_size acc));
+  print_endline "  drain_empties_accumulator: OK"
+
+let test_drain_skips_untagged () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let acc = H.create_accumulator () in
+      let hook = H.make_post_tool_use_hook acc in
+      (* tagged *)
+      let _ : THooks.hook_decision =
+        hook
+          (make_post_tool_use
+             ~content:
+               {|{"__multimodal_kind":"doc","__multimodal_id":"01900000-0000-7000-8000-000000000020","body":"# t"}|})
+      in
+      (* untagged — captured but skipped by Tool_emission *)
+      let _ : THooks.hook_decision =
+        hook
+          (make_post_tool_use
+             ~content:{|{"echo":"hello","ts":12345}|})
+      in
+      let new_wc =
+        H.drain_into_working_context acc ~working_context:None
+      in
+      let raws, _ =
+        Multimodal.Wirein_helpers.extract_raw_artifacts new_wc
+      in
+      assert_eq_int ~label:"only_tagged_emitted" 1
+        (List.length raws));
+  print_endline "  drain_skips_untagged: OK"
+
+let test_install_chain_preserves_decision () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let acc = H.create_accumulator () in
+      (* original hook returns Skip; chain must surface Skip. *)
+      let original : THooks.hook =
+        fun _ -> THooks.Skip
+      in
+      let hooks = { THooks.empty with post_tool_use = Some original } in
+      let combined = H.install_into_hooks acc hooks in
+      let chained = Option.get combined.post_tool_use in
+      let event =
+        make_post_tool_use
+          ~content:
+            {|{"__multimodal_kind":"code","__multimodal_id":"01900000-0000-7000-8000-000000000030","source":"x"}|}
+      in
+      let decision = chained event in
+      assert (decision = THooks.Skip);
+      (* side effect: K4 hook must still capture into accumulator. *)
+      assert_eq_int ~label:"chained_capture" 1
+        (H.accumulator_size acc));
+  print_endline "  install_chain_preserves_decision: OK"
+
+let test_install_no_existing_hook () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let acc = H.create_accumulator () in
+      let hooks = THooks.empty in
+      let combined = H.install_into_hooks acc hooks in
+      let chained = Option.get combined.post_tool_use in
+      let event =
+        make_post_tool_use
+          ~content:
+            {|{"__multimodal_kind":"audio","__multimodal_id":"01900000-0000-7000-8000-000000000040","wav":"r"}|}
+      in
+      let decision = chained event in
+      assert (decision = THooks.Continue);
+      assert_eq_int ~label:"installed_capture" 1
+        (H.accumulator_size acc));
+  print_endline "  install_no_existing_hook: OK"
+
+let () =
+  print_endline "=== Keeper_tool_emission_hook ===";
+  test_disabled_no_op ();
+  test_enabled_captures_post_tool_use ();
+  test_error_tool_result_ignored ();
+  test_non_json_content_ignored ();
+  test_other_events_ignored ();
+  test_drain_empties_accumulator ();
+  test_drain_skips_untagged ();
+  test_install_chain_preserves_decision ();
+  test_install_no_existing_hook ();
+  print_endline "=== Keeper_tool_emission_hook: 9/9 OK ==="


### PR DESCRIPTION
## Summary

Layer above [K3 #12105](https://github.com/jeong-sik/masc-mcp/pull/12105) (`Multimodal.Tool_emission` deterministic detector, MERGED 2026-04-30). K4 wires the detector into the live keeper turn so tool authors do not need to write keeper-side glue — they only set the two reserved JSON keys (`__multimodal_kind` / `__multimodal_id`) and the rest happens automatically.

## Pipeline

```
keeper agent runs (Agent.run)
  │
  │ each PostToolUse hook event
  ▼
[K4 accumulator]                    ← this PR
  │
  │ post_turn lifecycle (K4b follow-up)
  ▼
drain_into_working_context          ← Tool_emission.emit_from_tool_results
  │
  ▼
working_context["multimodal_artifacts"]
  │
  │ apply_multimodal_wirein         ← K1 (in main)
  ▼
Multimodal.Workspace_holder
```

## Module surface

`lib/keeper/keeper_tool_emission_hook.{mli,ml}`:

- `type accumulator` — `Stdlib.Mutex`-protected mutable bag of parsed `Yojson.Safe.t` results
- `create_accumulator`, `accumulator_size`
- `masc_tool_emission_enabled : unit -> bool` — reads `MASC_TOOL_EMISSION`
- `make_post_tool_use_hook` — observational `PostToolUse` handler. Parses `output.content` as JSON, pushes onto accumulator. Always returns `Continue` (never aborts a tool call). Parse failures silently ignored.
- `install_into_hooks` — wraps existing `Oas.Hooks.hooks` so `post_tool_use` chains through K4 first (capture), then defers to any existing hook for the actual decision.
- `drain_into_working_context` — drains accumulator, feeds items to `Multimodal.Tool_emission.emit_from_tool_results`, returns updated `working_context`.

Feature flag: `MASC_TOOL_EMISSION` (default off). Independent of `MASC_MULTIMODAL` (K1) — both must be on for the full chain.

## Test coverage

`test/test_keeper_tool_emission_hook.ml` — 9/9 assertions:

1. `disabled_no_op` — flag off, no capture
2. `enabled_captures_post_tool_use` — happy path
3. `error_tool_result_ignored` — `Error _` output skipped
4. `non_json_content_ignored` — parse failure silently dropped
5. `other_events_ignored` — only `PostToolUse` handled
6. `drain_empties_accumulator` — both items emit, size 0 after
7. `drain_skips_untagged` — only tagged JSONs flow to wirein
8. `install_chain_preserves_decision` — original hook's `Skip` surfaces, K4 still captures via side effect
9. `install_no_existing_hook` — `Continue` when no original hook

## K4b follow-up (NOT in this PR)

This PR lands the deterministic core in isolation (mirrors K2 typed-API/e2e split). K4b will wire:
- accumulator creation + `install_into_hooks` in `keeper_run_tools.ml` `prepare_agent_setup`
- `drain_into_working_context` in `keeper_post_turn.ml` `apply_post_turn_lifecycle`, BEFORE `apply_multimodal_wirein`

K4b touches `keeper_run_tools.ml` and `keeper_post_turn.ml` (multi-site invasion); separating it keeps K4 to a single new file.

## Build status (honest)

This PR's module typechecks: `cmi` / `cmx` / `cmo` all green for `Keeper_tool_emission_hook`.

`dune runtest` is **blocked by a pre-existing main blocker** — `Llm_provider.Http_client.ProviderFailure` variant added upstream in `agent_sdk` but not yet handled in:
- `lib/oas_worker_named.ml:341-372`
- `lib/tool_local_runtime_verify.ml:121-142`
- `lib/tool_local_runtime_bench.ml:19-40`

That fix belongs in a **separate family-fix PR** so all open PRs unblock together (memory: `feedback_main_blocker_namespace_rename_family_fix.md`). This PR does not bundle the fix.

## Cycle 27 production loop

```
tool author opt-in (2 reserved keys)
  → K3 Tool_emission.emit_from_tool_result   (deterministic detector, MERGED)
  → K4 keeper-side hook capture + drain      (this PR)
  → K1 working_context["multimodal_artifacts"] hydration  (in main)
  → D1 GET /api/v1/multimodal/list           (live)
```

## Test plan

- [ ] ProviderFailure family fix PR merge → unblocks lib build
- [ ] `dune runtest test/test_keeper_tool_emission_hook.exe` 9/9 GREEN
- [ ] K4b PR wires accumulator into agent_setup + post_turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)