### PR TITLE
feat(dashboard_bonsai): Tier F1 — multimodal artifact gallery view (Cycle 27)

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -141,5 +141,7 @@ let () =
   Dashboard_bonsai_lib.Overview_fetch.start_polling ();
   Dashboard_bonsai_lib.Goals_fetch.run ();
   Dashboard_bonsai_lib.Goals_fetch.start_polling ();
+  Dashboard_bonsai_lib.Multimodal_fetch.run ();
+  Dashboard_bonsai_lib.Multimodal_fetch.start_polling ();
   install_moon_clock ()
 ;;

--- a/dashboard_bonsai/src/app.ml
+++ b/dashboard_bonsai/src/app.ml
@@ -23,5 +23,6 @@ let root (graph @ local) =
   | Archive_runs -> Archive_runs_view.component graph
   | Overview -> Overview_view.component graph
   | Goals -> Goals_view.component graph
+  | Multimodal -> Multimodal_view.component graph
   | other -> Placeholder_view.component ~route:other graph
 ;;

--- a/dashboard_bonsai/src/multimodal_fetch.ml
+++ b/dashboard_bonsai/src/multimodal_fetch.ml
@@ -1,0 +1,33 @@
+(** Single-shot fetch of [/api/v1/multimodal/list] + 5 s polling.
+
+    Mirrors [Overview_fetch] / [Logs_fetch] pattern. Failed fetches
+    leave the previously-stored response in [Multimodal_var]. *)
+
+open! Core
+open Brr_io
+
+let endpoint = "/api/v1/multimodal/list"
+
+let parse_and_store (text : Jstr.t) : unit =
+  match Yojson.Safe.from_string (Jstr.to_string text) with
+  | json ->
+    let response = Multimodal_types.response_of_yojson json in
+    Bonsai.Expert.Var.set Multimodal_var.var response
+  | exception _ -> ()
+;;
+
+let run () : unit =
+  let open Fut.Result_syntax in
+  let work =
+    let* response = Fetch.url (Jstr.v endpoint) in
+    Fetch.Body.text (Fetch.Response.as_body response)
+  in
+  Fut.await work (function
+    | Ok text -> parse_and_store text
+    | Error _ -> ())
+;;
+
+let start_polling () : unit =
+  let _id : Brr.G.timer_id = Brr.G.set_interval ~ms:5000 run in
+  ()
+;;

--- a/dashboard_bonsai/src/multimodal_types.ml
+++ b/dashboard_bonsai/src/multimodal_types.ml
@@ -1,0 +1,66 @@
+(** Tier F1 — typed model of [/api/v1/multimodal/list].
+
+    Schema source: [lib/server/server_routes_http_routes_multimodal.ml]
+    [list_response]. Response contains a [count] (int) and an
+    [artifacts] array; each artifact carries [id], [kind], [payload],
+    [metadata], and [provenance].
+
+    F1 only renders id/kind/metadata-summary on cards. [payload] is
+    deliberately ignored here — it can be large and is fetched
+    on-demand via [/api/v1/multimodal/get/<id>] (deferred to F2). *)
+
+open! Core
+
+type artifact =
+  { id : string
+  ; kind : string  (* "code" | "image" | "audio" | "doc" — see lib/multimodal/artifact.ml *)
+  ; metadata_keys : string list  (* short summary: top-level keys of metadata object *)
+  ; created_by : string  (* from provenance.created_by, "" if absent *)
+  }
+
+type response =
+  { count : int
+  ; artifacts : artifact list
+  }
+
+let empty_response : response = { count = 0; artifacts = [] }
+
+let string_field json name : string =
+  match Yojson.Safe.Util.member name json with
+  | `String s -> s
+  | _ -> ""
+;;
+
+let metadata_keys_of json : string list =
+  match json with
+  | `Assoc kv -> List.map kv ~f:fst
+  | _ -> []
+;;
+
+let artifact_of_yojson (json : Yojson.Safe.t) : artifact =
+  let id = string_field json "id" in
+  let kind = string_field json "kind" in
+  let metadata_keys =
+    metadata_keys_of (Yojson.Safe.Util.member "metadata" json)
+  in
+  let created_by =
+    match Yojson.Safe.Util.member "provenance" json with
+    | `Null -> ""
+    | prov -> string_field prov "created_by"
+  in
+  { id; kind; metadata_keys; created_by }
+;;
+
+let response_of_yojson (json : Yojson.Safe.t) : response =
+  let count =
+    match Yojson.Safe.Util.member "count" json with
+    | `Int n -> n
+    | _ -> 0
+  in
+  let artifacts =
+    match Yojson.Safe.Util.member "artifacts" json with
+    | `List xs -> List.map xs ~f:artifact_of_yojson
+    | _ -> []
+  in
+  { count; artifacts }
+;;

--- a/dashboard_bonsai/src/multimodal_var.ml
+++ b/dashboard_bonsai/src/multimodal_var.ml
@@ -1,0 +1,5 @@
+(** Bonsai.Expert.Var holding the current multimodal list response. *)
+
+let var : Multimodal_types.response Bonsai.Expert.Var.t =
+  Bonsai.Expert.Var.create Multimodal_types.empty_response
+;;

--- a/dashboard_bonsai/src/multimodal_view.ml
+++ b/dashboard_bonsai/src/multimodal_view.ml
@@ -1,0 +1,163 @@
+(** Tier F1 — Multimodal artifact gallery.
+
+    Reads [Multimodal_var] (populated by [Multimodal_fetch]) and
+    renders one card per artifact: id (truncated), kind badge,
+    metadata key summary, created_by.
+
+    Empty state ("waiting for tagged tool output") is the common case
+    until [MASC_MULTIMODAL=1] + [MASC_TOOL_EMISSION=1] are both on
+    AND a keeper tool emits a tagged JSON result.
+
+    The view is read-only — interactions (filtering, opening payload)
+    are deferred to F2. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .root {
+    min-height: 100vh;
+    background: var(--color-bg-page);
+    color: var(--color-fg-primary);
+    font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
+    padding: 3rem 4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  .header { display: flex; align-items: baseline; gap: 1rem; }
+  .title {
+    font-family: 'Cinzel', serif;
+    font-weight: 500;
+    font-size: 1.75rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-bright);
+    margin: 0;
+  }
+  .count {
+    font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.85rem;
+    color: var(--color-fg-muted);
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+  }
+  .card {
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    border-radius: 6px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .card_head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .badge {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    border-radius: 3px;
+    background: color-mix(in oklab, var(--accent-blood) 20%, transparent);
+    color: var(--text-bright);
+    border: 1px solid color-mix(in oklab, var(--accent-blood) 40%, transparent);
+  }
+  .id {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.75rem;
+    color: var(--color-fg-muted);
+  }
+  .meta_keys {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.7rem;
+    color: var(--color-fg-primary);
+    word-break: break-all;
+  }
+  .created_by {
+    font-family: 'EB Garamond', Georgia, serif;
+    font-size: 0.85rem;
+    font-style: italic;
+    color: var(--color-fg-muted);
+  }
+  .empty {
+    padding: 2rem;
+    text-align: center;
+    color: var(--color-fg-muted);
+    border: 1px dashed var(--color-border-default);
+    border-radius: 6px;
+  }
+|}]
+
+let truncate_id (s : string) : string =
+  if String.length s <= 8 then s
+  else String.sub s ~pos:0 ~len:8 ^ "…"
+;;
+
+let card (a : Multimodal_types.artifact) : Node.t =
+  Node.div
+    ~attrs:[ Style.card ]
+    [ Node.div
+        ~attrs:[ Style.card_head ]
+        [ Node.span ~attrs:[ Style.badge ] [ Node.text a.kind ]
+        ; Node.span ~attrs:[ Style.id ] [ Node.text (truncate_id a.id) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.meta_keys ]
+        [ Node.text
+            (match a.metadata_keys with
+             | [] -> "(no metadata)"
+             | keys -> "metadata: " ^ String.concat ~sep:", " keys)
+        ]
+    ; (if String.is_empty a.created_by then Node.none
+       else
+         Node.div
+           ~attrs:[ Style.created_by ]
+           [ Node.text ("created by " ^ a.created_by) ])
+    ]
+;;
+
+let empty_state : Node.t =
+  Node.div
+    ~attrs:[ Style.empty ]
+    [ Node.text
+        "waiting for tagged tool output. enable \
+         MASC_TOOL_EMISSION=1 + MASC_MULTIMODAL=1 and have a \
+         keeper tool emit JSON with __multimodal_kind / \
+         __multimodal_id keys."
+    ]
+;;
+
+let view_of_response (r : Multimodal_types.response) : Node.t =
+  Node.div
+    ~attrs:[ Style.root; Attr.role "main"; Attr.create "aria-label" "Multimodal gallery" ]
+    [ Node.div
+        ~attrs:[ Style.header ]
+        [ Node.h1 ~attrs:[ Style.title ] [ Node.text "Multimodal · gallery" ]
+        ; Node.span
+            ~attrs:[ Style.count ]
+            [ Node.text (Printf.sprintf "%d artifacts" r.count) ]
+        ]
+    ; (if List.is_empty r.artifacts then empty_state
+       else
+         Node.div
+           ~attrs:[ Style.grid ]
+           (List.map r.artifacts ~f:card))
+    ]
+;;
+
+let component (_graph @ local) =
+  Bonsai.map (Bonsai.Expert.Var.value Multimodal_var.var) ~f:view_of_response
+;;

--- a/dashboard_bonsai/src/route.ml
+++ b/dashboard_bonsai/src/route.ml
@@ -23,6 +23,7 @@ type t =
   | Social_board
   | Dead_keepers
   | Archive_runs
+  | Multimodal
   | Hello
 [@@deriving sexp, compare, equal]
 
@@ -38,6 +39,7 @@ let slug = function
   | Social_board -> "social-board"
   | Dead_keepers -> "dead-keepers"
   | Archive_runs -> "archive-runs"
+  | Multimodal -> "multimodal"
   | Hello -> "hello"
 ;;
 
@@ -54,6 +56,7 @@ let label = function
   | Social_board -> "social board"
   | Dead_keepers -> "dead keepers"
   | Archive_runs -> "archive runs"
+  | Multimodal -> "multimodal"
   | Hello -> "hello"
 ;;
 
@@ -61,7 +64,7 @@ let path t = Printf.sprintf "/dashboard/b/%s" (slug t)
 
 (* Bonsai로 이식된 탭 목록. 그 외는 placeholder (Phase 2+). *)
 let is_implemented = function
-  | Logs | Hello | Dead_keepers | Keepers | Archive_runs | Overview | Goals -> true
+  | Logs | Hello | Dead_keepers | Keepers | Archive_runs | Overview | Goals | Multimodal -> true
   | Observatory | Intervene | Tools | Sessions | Social_board -> false
 ;;
 
@@ -78,6 +81,7 @@ let all : t list =
   ; Social_board
   ; Dead_keepers
   ; Archive_runs
+  ; Multimodal
   ]
 ;;
 
@@ -109,6 +113,7 @@ let of_path (path_str : string) : t =
   | "social-board" -> Social_board
   | "dead-keepers" -> Dead_keepers
   | "archive-runs" -> Archive_runs
+  | "multimodal" -> Multimodal
   | "hello" -> Hello
   | "" -> Overview (* /dashboard/b/ → Overview *)
   | _ -> Overview (* unknown → Overview *)


### PR DESCRIPTION
## Summary

Adds **`/dashboard/b/multimodal`** — read-only gallery of artifacts living in the process-wide `Multimodal.Workspace_holder`, polled every 5s from `/api/v1/multimodal/list`.

Closes the **visible end** of the K1→K2→K3 production loop. Operators can now see, in the Bonsai dashboard, every artifact that flows through the chain.

## What renders

Empty state is the common case until both env vars are on:

```
┌─────────────────────────────────────┐
│ Multimodal · gallery     0 artifacts│
│                                      │
│  ┌─────────────────────────────┐    │
│  │ waiting for tagged tool     │    │
│  │ output. enable              │    │
│  │ MASC_TOOL_EMISSION=1 +      │    │
│  │ MASC_MULTIMODAL=1 ...       │    │
│  └─────────────────────────────┘    │
└─────────────────────────────────────┘
```

Once tagged results flow through:

```
┌─────────────────────────────────────────────────┐
│ Multimodal · gallery              4 artifacts   │
│                                                  │
│ ┌─────────┐  ┌─────────┐  ┌─────────┐          │
│ │ [code]  │  │ [image] │  │ [audio] │          │
│ │ 01900000│  │ 01900000│  │ 01900000│          │
│ │ metadata│  │ metadata│  │ metadata│          │
│ │ : lang  │  │ : dim   │  │ : dur_ms│          │
│ │created  │  │created  │  │created  │          │
│ │by alice │  │by alice │  │by alice │          │
│ └─────────┘  └─────────┘  └─────────┘          │
└─────────────────────────────────────────────────┘
```

## New modules (`dashboard_bonsai/src/`)

| File | LoC | Role |
|------|-----|------|
| `multimodal_types.ml`  | 64  | typed model — `{count; artifacts[]}` where each artifact = `{id; kind; metadata_keys[]; created_by}` |
| `multimodal_var.ml`    | 5   | `Bonsai.Expert.Var` holder (mirrors `Overview_var`) |
| `multimodal_fetch.ml`  | 30  | single-shot fetch + 5s `setInterval` polling (mirrors `Overview_fetch`) |
| `multimodal_view.ml`   | 161 | ppx_css grid of artifact cards; empty-state hint |

## Wiring

- **`route.ml`** — add `Multimodal` variant + slug/label/path/of_path + nav `all` + `is_implemented = true`.
- **`app.ml`** — dispatch `Multimodal -> Multimodal_view.component graph`.
- **`bin/main.ml`** — `Multimodal_fetch.run () + start_polling ()` in app boot.

## Out of scope (deferred to F2)

- Filters by kind / created_by
- Sort by created_at
- Payload preview (can be large — fetched on-demand via `/api/v1/multimodal/get/<id>`)
- Provenance DAG visualization
- Dark-mode contrast variants

## Build status (honest)

The four new modules typecheck individually in the `bonsai-dashboard` opam switch.

The **full `dashboard_bonsai_lib` build is blocked by pre-existing errors** unrelated to F1:
- `src/logs_view.ml:1488` — type mismatch (`[ \`Error | \`Idle | \`Info | \`Warn ]` vs `int`)
- `src/keepers_directory.ml:437` — `Virtual_dom.Vdom.Event` unbound module

Those belong in separate fix PRs. F1 stays scope-tight.

## Cycle 27 production loop — visible end

```
tool author opt-in (2 reserved JSON keys)
  → K3 Multimodal.Tool_emission           (deterministic detector, MERGED)
  → K4 keeper hook accumulator            (#12135)
  → K1 working_context multimodal_artifacts hydrate  (in main)
  → D1 GET /api/v1/multimodal/list        (in main)
  → F1 Bonsai gallery view                ← this PR
```

## Test plan

- [ ] dashboard_bonsai pre-existing blocker fixes merge
- [ ] `dune build` GREEN under `bonsai-dashboard` switch
- [ ] manual: `/dashboard/b/multimodal` route loads (empty state)
- [ ] manual: enable both env flags + run a keeper tool that emits tagged JSON → cards appear within 5s
- [ ] F2 PR adds detail view + provenance graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)