### PR TITLE
specs(tla): unify BugAction naming to NextBuggy / SpecBuggy

### DIFF
--- a/specs/bug-models/AtomicFileWrite-buggy.cfg
+++ b/specs/bug-models/AtomicFileWrite-buggy.cfg
@@ -1,5 +1,5 @@
 \* Buggy model: unsafe writer (truncate-then-write).
 \* Expected: ReaderNeverSeesEmpty VIOLATED in 3 steps.
-SPECIFICATION SpecUnsafe
+SPECIFICATION SpecBuggy
 INVARIANT ReaderNeverSeesEmpty
 CHECK_DEADLOCK FALSE

--- a/specs/bug-models/AtomicFileWrite.tla
+++ b/specs/bug-models/AtomicFileWrite.tla
@@ -66,12 +66,12 @@ Read ==
 
 \* ── Unsafe Next (bug model) ───────────────────────────
 
-NextUnsafe ==
+NextBuggy ==
     \/ UnsafeTruncate
     \/ UnsafeWrite
     \/ Read
 
-SpecUnsafe == Init /\ [][NextUnsafe]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
 
 \* ── Safe Next (fixed model) ───────────────────────────
 

--- a/specs/bug-models/HebbianLearning.tla
+++ b/specs/bug-models/HebbianLearning.tla
@@ -194,12 +194,12 @@ NextSafe ==
     \/ SafeStrAcquire \/ SafeStrCompute \/ SafeStrSave \/ SafeStrReset
     \/ SafeConAcquire \/ SafeConCompute \/ SafeConSave \/ SafeConReset
 
-NextUnsafe ==
+NextBuggy ==
     \/ UnsafeStrLoad \/ UnsafeStrCompute \/ UnsafeStrSave \/ UnsafeStrReset
     \/ UnsafeConLoad \/ UnsafeConCompute \/ UnsafeConSave \/ UnsafeConReset
 
 Spec == Init /\ [][NextSafe]_vars
-SpecBuggy == Init /\ [][NextUnsafe]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
 
 \* ── Safety Invariants ─────────────────────────────────
 


### PR DESCRIPTION
## Summary

Resolves the BugAction naming drift surfaced by Phase 2 §6 (PR #12132). Two specs in `specs/bug-models/` used non-canonical names; this PR unifies them to `NextBuggy` / `SpecBuggy`.

| Spec | Before | After |
|---|---|---|
| `specs/bug-models/HebbianLearning.tla` | `NextUnsafe`, `SpecBuggy` (mixed) | `NextBuggy`, `SpecBuggy` |
| `specs/bug-models/AtomicFileWrite.tla` | `NextUnsafe`, `SpecUnsafe` | `NextBuggy`, `SpecBuggy` |
| `specs/bug-models/AtomicFileWrite-buggy.cfg` | `SPECIFICATION SpecUnsafe` | `SPECIFICATION SpecBuggy` |

Canonical name `NextBuggy` / `SpecBuggy` is used by ~21 specs across `boundary/`, `bug-models/`, `admission-queue/`, `auth/`. The `*Unsafe` variant was used by only 2 specs.

## Why

Phase 2 §6 of the TLA+ specs gap audit (PR #12132) surfaced 3 BugAction synthesis styles:
- `NextBuggy` (most common)
- `NextUnsafe` (2 specs in bug-models/)
- inline `\/ Next \/ <BugAction>`

Picking a single canonical style makes future audit ratchets simpler (a `gen-tla-index.sh` lint can warn on non-`NextBuggy` names). Surgical rename only — no semantic change.

## Test plan

- [x] `rg "NextUnsafe|SpecUnsafe" specs/` → 0 matches after edit
- [x] `AtomicFileWrite-buggy.cfg` SPECIFICATION updated to match renamed spec
- [x] No external references to old names (only the historical Phase 2 doc, which is intentionally unchanged as historical record)
- [ ] TLC verification (will run as part of CI's TLA+ Model Checking job)

## References

- PR #12132 — Phase 2 §6 surfaced this drift
- `specs/keeper-state-machine/KeeperOASAdvanced.tla` — canonical
- CLAUDE.md `TLA+ Bug Model 패턴`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
