### PR TITLE
feat(headless-preact): RFC 0005 useMenu adapter

### DIFF
--- a/dashboard/design-system/headless-preact/use-menu.test.ts
+++ b/dashboard/design-system/headless-preact/use-menu.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import type { MenuItemDescriptor } from '../headless-core/menu'
+import { useMenu } from './use-menu'
+
+function flushEffects(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 16))
+}
+
+let container: HTMLElement
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.append(container)
+})
+
+afterEach(() => {
+  render(null, container)
+  container.remove()
+})
+
+const items: ReadonlyArray<MenuItemDescriptor> = [
+  { id: 'open', kind: 'action', label: 'Open' },
+  { id: 'save', kind: 'action', label: 'Save' },
+  { id: 'sep', kind: 'separator' },
+  { id: 'quit', kind: 'action', label: 'Quit' },
+]
+
+describe('useMenu', () => {
+  it('starts closed', async () => {
+    let captured!: ReturnType<typeof useMenu>
+    function Probe(): unknown {
+      captured = useMenu({ id: 'm1', items })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.isOpen).toBe(false)
+  })
+
+  it('open() flips isOpen and re-renders', async () => {
+    let captured!: ReturnType<typeof useMenu>
+    function Probe(): unknown {
+      captured = useMenu({ id: 'm1', items })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    captured.open()
+    await flushEffects()
+    expect(captured.isOpen).toBe(true)
+  })
+
+  it('toggle flips state', async () => {
+    let captured!: ReturnType<typeof useMenu>
+    function Probe(): unknown {
+      captured = useMenu({ id: 'm1', items })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    captured.toggle()
+    await flushEffects()
+    expect(captured.isOpen).toBe(true)
+    captured.toggle()
+    await flushEffects()
+    expect(captured.isOpen).toBe(false)
+  })
+
+  it('getTriggerProps reports aria-haspopup=menu', async () => {
+    let captured!: ReturnType<typeof useMenu>
+    function Probe(): unknown {
+      captured = useMenu({ id: 'm1', items })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.getTriggerProps()['aria-haspopup']).toBe('menu')
+  })
+
+  it('getMenuProps role=menu', async () => {
+    let captured!: ReturnType<typeof useMenu>
+    function Probe(): unknown {
+      captured = useMenu({ id: 'm1', items })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.getMenuProps().role).toBe('menu')
+  })
+
+  it('select fires onSelect handler', async () => {
+    const calls: ReadonlyArray<string>[] = []
+    let captured!: ReturnType<typeof useMenu>
+    function Probe(): unknown {
+      captured = useMenu({
+        id: 'm1',
+        items,
+        onSelect: (id, path) => calls.push([id, ...path]),
+      })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    captured.open()
+    captured.select('save')
+    await flushEffects()
+    expect(calls.length).toBe(1)
+    expect(calls[0]![0]).toBe('save')
+  })
+})

--- a/dashboard/design-system/headless-preact/use-menu.ts
+++ b/dashboard/design-system/headless-preact/use-menu.ts
@@ -1,0 +1,84 @@
+/**
+ * useMenu — Preact adapter over headless-core/Menu (RFC 0005 §3.3).
+ *
+ * Cached controller via useRef, subscribe → bumpState. Optional
+ * triggerRef enables future placement / focus restoration; current
+ * implementation forwards triggerProps and lets the consumer attach
+ * the ref directly.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import type { RefObject } from 'preact'
+import {
+  createMenu,
+  type MenuController,
+  type MenuItemProps,
+  type MenuOptions,
+  type MenuProps,
+  type MenuTriggerProps,
+} from '../headless-core/menu'
+
+export interface UseMenuArgs extends MenuOptions {
+  triggerRef?: RefObject<HTMLElement>
+}
+
+export interface UseMenuResult {
+  readonly isOpen: boolean
+  readonly activeId: string | null
+  open(): void
+  close(): void
+  toggle(): void
+  focus(itemId: string): void
+  select(itemId: string): void
+  getTriggerProps(): MenuTriggerProps
+  getMenuProps(): MenuProps
+  getItemProps(itemId: string): MenuItemProps
+}
+
+export function useMenu(args: UseMenuArgs): UseMenuResult {
+  const controllerRef = useRef<MenuController | null>(null)
+  const [, bump] = useState(0)
+
+  if (controllerRef.current === null) {
+    const { triggerRef: _ignored, ...opts } = args
+    controllerRef.current = createMenu(opts)
+  }
+
+  useEffect(() => {
+    const c = controllerRef.current
+    if (c === null) return undefined
+    return c.subscribe(() => bump((n) => n + 1))
+  }, [])
+
+  // Restore focus to trigger when menu closes (best-effort).
+  const wasOpenRef = useRef(false)
+  useEffect(() => {
+    const c = controllerRef.current
+    if (c === null) return
+    const open = c.isOpen
+    if (wasOpenRef.current && !open && args.triggerRef?.current) {
+      args.triggerRef.current.focus()
+    }
+    wasOpenRef.current = open
+  })
+
+  return useMemo<UseMenuResult>(() => {
+    const c = controllerRef.current!
+    return {
+      get isOpen() {
+        return c.isOpen
+      },
+      get activeId() {
+        return c.activeId
+      },
+      open: () => c.open(),
+      close: () => c.close(),
+      toggle: () => c.toggle(),
+      focus: (id) => c.focus(id),
+      select: (id) => c.select(id),
+      getTriggerProps: () => c.getTriggerProps(),
+      getMenuProps: () => c.getMenuProps(),
+      getItemProps: (id) => c.getItemProps(id),
+    }
+  }, [])
+}


### PR DESCRIPTION
RFC 0005 §3.3 Preact adapter over createMenu. Cached controller via useRef + subscribe→bumpState. Optional triggerRef restores focus on close. 6/6 tests pass, typecheck clean.