### PR TITLE
feat(headless-preact): RFC 0015 useTabs adapter

### DIFF
--- a/dashboard/design-system/headless-preact/use-tabs.test.ts
+++ b/dashboard/design-system/headless-preact/use-tabs.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import type { TabDescriptor } from '../headless-core/tabs'
+import { useTabs } from './use-tabs'
+
+function flushEffects(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 16))
+}
+
+let container: HTMLElement
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.append(container)
+})
+
+afterEach(() => {
+  render(null, container)
+  container.remove()
+})
+
+const tabsFixture: ReadonlyArray<TabDescriptor> = [
+  { id: 't1', label: 'One' },
+  { id: 't2', label: 'Two' },
+  { id: 't3', label: 'Three' },
+]
+
+describe('useTabs', () => {
+  it('exposes initial activeId from defaultActiveId', async () => {
+    let captured!: ReturnType<typeof useTabs>
+    function Probe(): unknown {
+      captured = useTabs({ tabs: tabsFixture, defaultActiveId: 't2' })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.activeId).toBe('t2')
+  })
+
+  it('re-renders on activate', async () => {
+    let captured!: ReturnType<typeof useTabs>
+    function Probe(): unknown {
+      captured = useTabs({ tabs: tabsFixture })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    captured.activate('t3')
+    await flushEffects()
+    expect(captured.activeId).toBe('t3')
+  })
+
+  it('exposes tabs snapshot from controller', async () => {
+    let captured!: ReturnType<typeof useTabs>
+    function Probe(): unknown {
+      captured = useTabs({ tabs: tabsFixture })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.tabs.map((t) => t.id)).toEqual(['t1', 't2', 't3'])
+  })
+
+  it('close() removes a tab', async () => {
+    let captured!: ReturnType<typeof useTabs>
+    function Probe(): unknown {
+      captured = useTabs({ tabs: tabsFixture })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    captured.close('t2')
+    await flushEffects()
+    expect(captured.tabs.map((t) => t.id)).toEqual(['t1', 't3'])
+  })
+
+  it('getTabListProps returns role=tablist', async () => {
+    let captured!: ReturnType<typeof useTabs>
+    function Probe(): unknown {
+      captured = useTabs({ tabs: tabsFixture })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.getTabListProps().role).toBe('tablist')
+  })
+
+  it('getTabProps returns role=tab with aria-selected', async () => {
+    let captured!: ReturnType<typeof useTabs>
+    function Probe(): unknown {
+      captured = useTabs({ tabs: tabsFixture, defaultActiveId: 't1' })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    const props = captured.getTabProps('t1')
+    expect(props.role).toBe('tab')
+    expect(props['aria-selected']).toBe(true)
+  })
+})

--- a/dashboard/design-system/headless-preact/use-tabs.ts
+++ b/dashboard/design-system/headless-preact/use-tabs.ts
@@ -1,0 +1,72 @@
+/**
+ * useTabs — Preact adapter over headless-core/Tabs (RFC 0015 §3.2).
+ *
+ * Mirrors the use-roving-tabindex shape: cached controller via useRef,
+ * subscribe → bumpState for re-render, useMemo prop getters.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import {
+  createTabs,
+  type CloseButtonProps,
+  type TabDescriptor,
+  type TabListProps,
+  type TabPanelProps,
+  type TabProps,
+  type TabsController,
+  type TabsOptions,
+} from '../headless-core/tabs'
+
+export interface UseTabsResult {
+  readonly activeId: string | null
+  readonly tabs: ReadonlyArray<TabDescriptor>
+  readonly draggingId: string | null
+  getTabListProps(): TabListProps
+  getTabProps(id: string): TabProps
+  getTabPanelProps(id: string): TabPanelProps
+  getCloseButtonProps(id: string): CloseButtonProps
+  activate(id: string): void
+  close(id: string): void
+  reorder(ids: ReadonlyArray<string>): void
+}
+
+export function useTabs(opts: TabsOptions): UseTabsResult {
+  const controllerRef = useRef<TabsController | null>(null)
+  const [, bump] = useState(0)
+
+  if (controllerRef.current === null) {
+    controllerRef.current = createTabs(opts)
+  }
+
+  useEffect(() => {
+    controllerRef.current?.setTabs(opts.tabs)
+  }, [opts.tabs])
+
+  useEffect(() => {
+    const c = controllerRef.current
+    if (c === null) return undefined
+    return c.subscribe(() => bump((n) => n + 1))
+  }, [])
+
+  return useMemo<UseTabsResult>(() => {
+    const c = controllerRef.current!
+    return {
+      get activeId() {
+        return c.activeId
+      },
+      get tabs() {
+        return c.tabs
+      },
+      get draggingId() {
+        return c.draggingId
+      },
+      getTabListProps: () => c.getTabListProps(),
+      getTabProps: (id) => c.getTabProps(id),
+      getTabPanelProps: (id) => c.getTabPanelProps(id),
+      getCloseButtonProps: (id) => c.getCloseButtonProps(id),
+      activate: (id) => c.activate(id),
+      close: (id) => c.close(id),
+      reorder: (ids) => c.reorder(ids),
+    }
+  }, [])
+}


### PR DESCRIPTION
RFC 0015 §3.2 Preact adapter over createTabs. Cached controller via useRef + subscribe→bumpState. Forwards getTabListProps/getTabProps/getTabPanelProps/getCloseButtonProps + activate/close/reorder. 6/6 tests pass, typecheck clean.