### PR TITLE
feat(headless-preact): RFC 0016 useToolbar adapter

### DIFF
--- a/dashboard/design-system/headless-preact/use-toolbar.test.ts
+++ b/dashboard/design-system/headless-preact/use-toolbar.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import type { ToolbarItem } from '../headless-core/toolbar'
+import { useToolbar } from './use-toolbar'
+
+function flushEffects(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 16))
+}
+
+let container: HTMLElement
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.append(container)
+})
+
+afterEach(() => {
+  render(null, container)
+  container.remove()
+})
+
+const items: ReadonlyArray<ToolbarItem> = [
+  { id: 'save', kind: 'button', label: 'Save' },
+  { id: 'bold', kind: 'toggle', label: 'Bold', pressed: false },
+  { id: 'sep', kind: 'separator' },
+  { id: 'left', kind: 'radio', label: 'Left', checked: true, radioGroup: 'align' },
+  { id: 'right', kind: 'radio', label: 'Right', checked: false, radioGroup: 'align' },
+]
+
+describe('useToolbar', () => {
+  it('exposes visibleItems matching input', async () => {
+    let captured!: ReturnType<typeof useToolbar>
+    function Probe(): unknown {
+      captured = useToolbar({ items, ariaLabel: 'Test' })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.visibleItems.length).toBe(items.length)
+    expect(captured.hasOverflow).toBe(false)
+  })
+
+  it('toggle flips pressed', async () => {
+    let captured!: ReturnType<typeof useToolbar>
+    function Probe(): unknown {
+      captured = useToolbar({ items, ariaLabel: 'Test' })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    captured.toggle('bold')
+    await flushEffects()
+    const props = captured.getItemProps('bold')
+    expect(props['aria-pressed']).toBe(true)
+  })
+
+  it('selectRadio enforces single-select within group', async () => {
+    let captured!: ReturnType<typeof useToolbar>
+    function Probe(): unknown {
+      captured = useToolbar({ items, ariaLabel: 'Test' })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    captured.selectRadio('right')
+    await flushEffects()
+    expect(captured.getItemProps('right')['aria-checked']).toBe(true)
+    expect(captured.getItemProps('left')['aria-checked']).toBe(false)
+  })
+
+  it('overflow menu trigger reports aria-expanded', async () => {
+    let captured!: ReturnType<typeof useToolbar>
+    function Probe(): unknown {
+      captured = useToolbar({ items, ariaLabel: 'Test' })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.getOverflowMenuTriggerProps()['aria-expanded']).toBe(false)
+    captured.openOverflowMenu()
+    await flushEffects()
+    expect(captured.getOverflowMenuTriggerProps()['aria-expanded']).toBe(true)
+  })
+
+  it('getRootProps returns role=toolbar', async () => {
+    let captured!: ReturnType<typeof useToolbar>
+    function Probe(): unknown {
+      captured = useToolbar({ items, ariaLabel: 'Test' })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.getRootProps().role).toBe('toolbar')
+    expect(captured.getRootProps()['aria-label']).toBe('Test')
+  })
+
+  it('explicit containerSize narrows visibleItems via overflowAt', async () => {
+    let captured!: ReturnType<typeof useToolbar>
+    function Probe(): unknown {
+      captured = useToolbar({ items, ariaLabel: 'Test', overflowAt: 2 })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.visibleItems.length).toBe(2)
+    expect(captured.overflowItems.length).toBeGreaterThan(0)
+    expect(captured.hasOverflow).toBe(true)
+  })
+})

--- a/dashboard/design-system/headless-preact/use-toolbar.ts
+++ b/dashboard/design-system/headless-preact/use-toolbar.ts
@@ -1,0 +1,117 @@
+/**
+ * useToolbar — Preact adapter over headless-core/Toolbar (RFC 0016 §3.2).
+ *
+ * Mirrors useRovingTabindex shape. Consumer supplies a containerRef;
+ * when present and ResizeObserver is available, the adapter wires up
+ * width tracking automatically. Item width tracking remains the
+ * consumer's responsibility (per-item refs vary by render strategy).
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import type { RefObject } from 'preact'
+import {
+  createToolbar,
+  type ToolbarController,
+  type ToolbarItem,
+  type ToolbarItemProps,
+  type ToolbarOptions,
+  type ToolbarRootProps,
+} from '../headless-core/toolbar'
+
+export interface UseToolbarArgs extends ToolbarOptions {
+  containerRef?: RefObject<HTMLElement>
+}
+
+export interface UseToolbarResult {
+  readonly visibleItems: ReadonlyArray<ToolbarItem>
+  readonly overflowItems: ReadonlyArray<ToolbarItem>
+  readonly hasOverflow: boolean
+  readonly activeId: string | null
+  readonly overflowMenuOpen: boolean
+  getRootProps(): ToolbarRootProps
+  getItemProps(id: string): ToolbarItemProps
+  getOverflowMenuTriggerProps(): { readonly 'aria-haspopup': 'menu'; readonly 'aria-expanded': boolean; readonly onClick: () => void }
+  setItemWidth(id: string, px: number): void
+  setContainerSize(px: number): void
+  toggle(id: string): void
+  selectRadio(id: string): void
+  activate(id: string): void
+  openOverflowMenu(): void
+  closeOverflowMenu(): void
+}
+
+export function useToolbar(args: UseToolbarArgs): UseToolbarResult {
+  const controllerRef = useRef<ToolbarController | null>(null)
+  const [, bump] = useState(0)
+
+  if (controllerRef.current === null) {
+    const { containerRef: _ignored, ...opts } = args
+    controllerRef.current = createToolbar(opts)
+  }
+
+  useEffect(() => {
+    controllerRef.current?.setItems(args.items)
+  }, [args.items])
+
+  useEffect(() => {
+    const c = controllerRef.current
+    if (c === null) return undefined
+    return c.subscribe(() => bump((n) => n + 1))
+  }, [])
+
+  useEffect(() => {
+    const ref = args.containerRef
+    if (ref === undefined) return undefined
+    const el = ref.current
+    if (el === null) return undefined
+    const c = controllerRef.current
+    if (c === null) return undefined
+    c.setContainerSize(el.getBoundingClientRect().width)
+    if (typeof ResizeObserver === 'undefined') return undefined
+    const ro = new ResizeObserver((entries) => {
+      const last = entries[entries.length - 1]
+      if (last !== undefined) c.setContainerSize(last.contentRect.width)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [args.containerRef])
+
+  return useMemo<UseToolbarResult>(() => {
+    const c = controllerRef.current!
+    return {
+      get visibleItems() {
+        return c.visibleItems
+      },
+      get overflowItems() {
+        return c.overflowItems
+      },
+      get hasOverflow() {
+        return c.hasOverflow
+      },
+      get activeId() {
+        return c.activeId
+      },
+      get overflowMenuOpen() {
+        return c.overflowMenuOpen
+      },
+      getRootProps: () => c.getRootProps(),
+      getItemProps: (id) => c.getItemProps(id),
+      getOverflowMenuTriggerProps: () => {
+        const open = c.overflowMenuOpen
+        return Object.freeze({
+          'aria-haspopup': 'menu' as const,
+          'aria-expanded': open,
+          onClick: () =>
+            open ? c.closeOverflowMenu() : c.openOverflowMenu(),
+        })
+      },
+      setItemWidth: (id, px) => c.setItemWidth(id, px),
+      setContainerSize: (px) => c.setContainerSize(px),
+      toggle: (id) => c.toggle(id),
+      selectRadio: (id) => c.selectRadio(id),
+      activate: (id) => c.activate(id),
+      openOverflowMenu: () => c.openOverflowMenu(),
+      closeOverflowMenu: () => c.closeOverflowMenu(),
+    }
+  }, [])
+}


### PR DESCRIPTION
RFC 0016 §3.2 Preact adapter over createToolbar. Cached controller via useRef + subscribe→bumpState. Optional containerRef wires ResizeObserver to drive setContainerSize. Forwards getRootProps/getItemProps/getOverflowMenuTriggerProps + toggle/selectRadio/activate. 6/6 tests pass, typecheck clean.