### PR TITLE
feat(headless-preact): RFC 0014 useTreeView adapter

### DIFF
--- a/dashboard/design-system/headless-preact/use-tree-view.test.ts
+++ b/dashboard/design-system/headless-preact/use-tree-view.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import type { TreeNode } from '../headless-core/tree-view'
+import { useTreeView } from './use-tree-view'
+
+function flushEffects(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 16))
+}
+
+let container: HTMLElement
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.append(container)
+})
+
+afterEach(() => {
+  render(null, container)
+  container.remove()
+})
+
+const tree: ReadonlyArray<TreeNode<{ kind: string }>> = [
+  { id: 'root', label: 'Root', parentId: null, hasChildren: true },
+  { id: 'a', label: 'A', parentId: 'root', hasChildren: false, data: { kind: 'file' } },
+  { id: 'b', label: 'B', parentId: 'root', hasChildren: true },
+  { id: 'b1', label: 'B1', parentId: 'b', hasChildren: false, data: { kind: 'file' } },
+]
+
+describe('useTreeView', () => {
+  it('initial visible reflects defaultExpanded', async () => {
+    let captured!: ReturnType<typeof useTreeView>
+    function Probe(): unknown {
+      captured = useTreeView({
+        nodes: tree,
+        selectionMode: 'single',
+        defaultExpanded: ['root'],
+      })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    const ids = captured.visible.map((n) => n.id)
+    expect(ids).toContain('root')
+    expect(ids).toContain('a')
+    expect(ids).toContain('b')
+    expect(ids).not.toContain('b1')
+  })
+
+  it('expand re-renders and includes children', async () => {
+    let captured!: ReturnType<typeof useTreeView>
+    function Probe(): unknown {
+      captured = useTreeView({
+        nodes: tree,
+        selectionMode: 'single',
+        defaultExpanded: ['root'],
+      })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    await captured.expand('b')
+    await flushEffects()
+    expect(captured.visible.map((n) => n.id)).toContain('b1')
+  })
+
+  it('select stores id in selected set', async () => {
+    let captured!: ReturnType<typeof useTreeView>
+    function Probe(): unknown {
+      captured = useTreeView({
+        nodes: tree,
+        selectionMode: 'single',
+        defaultExpanded: ['root'],
+      })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    captured.select('a')
+    await flushEffects()
+    expect(captured.selected.has('a')).toBe(true)
+  })
+
+  it('getRootProps returns role=tree', async () => {
+    let captured!: ReturnType<typeof useTreeView>
+    function Probe(): unknown {
+      captured = useTreeView({ nodes: tree, selectionMode: 'single' })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.getRootProps().role).toBe('tree')
+  })
+
+  it('getAriaLevel reports depth', async () => {
+    let captured!: ReturnType<typeof useTreeView>
+    function Probe(): unknown {
+      captured = useTreeView({
+        nodes: tree,
+        selectionMode: 'single',
+        defaultExpanded: ['root', 'b'],
+      })
+      return null
+    }
+    render(html`<${Probe} />`, container)
+    await flushEffects()
+    expect(captured.getAriaLevel('root')).toBe(1)
+    expect(captured.getAriaLevel('b')).toBe(2)
+    expect(captured.getAriaLevel('b1')).toBe(3)
+  })
+})

--- a/dashboard/design-system/headless-preact/use-tree-view.ts
+++ b/dashboard/design-system/headless-preact/use-tree-view.ts
@@ -1,0 +1,81 @@
+/**
+ * useTreeView — Preact adapter over headless-core/TreeView (RFC 0014 §3.2).
+ *
+ * Cached controller via useRef, subscribe → bumpState for re-render.
+ * expand returns a Promise so consumers can await async children load.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import {
+  createTreeView,
+  type TreeNode,
+  type TreeNodeProps,
+  type TreeRootProps,
+  type TreeViewController,
+  type TreeViewOptions,
+} from '../headless-core/tree-view'
+
+export interface UseTreeViewResult<T = unknown> {
+  readonly visible: ReadonlyArray<TreeNode<T>>
+  readonly nodes: ReadonlyArray<TreeNode<T>>
+  readonly expanded: ReadonlySet<string>
+  readonly selected: ReadonlySet<string>
+  readonly activeId: string | null
+  getRootProps(): TreeRootProps
+  getNodeProps(id: string): TreeNodeProps
+  expand(id: string): Promise<void>
+  collapse(id: string): void
+  toggleExpand(id: string): Promise<void>
+  select(
+    id: string,
+    opts?: { readonly extend?: boolean; readonly toggle?: boolean },
+  ): void
+  clearSelection(): void
+  getAriaLevel(id: string): number
+}
+
+export function useTreeView<T = unknown>(
+  opts: TreeViewOptions<T>,
+): UseTreeViewResult<T> {
+  const controllerRef = useRef<TreeViewController<T> | null>(null)
+  const [, bump] = useState(0)
+
+  if (controllerRef.current === null) {
+    controllerRef.current = createTreeView(opts)
+  }
+
+  useEffect(() => {
+    const c = controllerRef.current
+    if (c === null) return undefined
+    return c.subscribe(() => bump((n) => n + 1))
+  }, [])
+
+  return useMemo<UseTreeViewResult<T>>(() => {
+    const c = controllerRef.current!
+    return {
+      get visible() {
+        return c.getVisible()
+      },
+      get nodes() {
+        return c.nodes
+      },
+      get expanded() {
+        return c.expanded
+      },
+      get selected() {
+        return c.selected
+      },
+      get activeId() {
+        return c.activeId
+      },
+      getRootProps: () => c.getRootProps(),
+      getNodeProps: (id) => c.getNodeProps(id),
+      expand: (id) => c.expand(id),
+      collapse: (id) => c.collapse(id),
+      toggleExpand: (id) => c.toggleExpand(id),
+      select: (id, o) => c.select(id, o),
+      clearSelection: () => c.clearSelection(),
+      getAriaLevel: (id) => c.getAriaLevel(id),
+    }
+  }, [])
+}


### PR DESCRIPTION
RFC 0014 §3.2 Preact adapter over createTreeView. Cached controller via useRef + subscribe→bumpState. expand/toggleExpand return Promise (async onLoadChildren). Forwards getRootProps/getNodeProps/getAriaLevel + select/clearSelection/collapse. 5/5 tests pass, typecheck clean.