### PR TITLE
[codex] Fix Track 6 dashboard presence typing

### DIFF
--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -78,6 +78,7 @@ const SseOuterSchema = object({
 interface SseSection {
   sessions_observer: number
   sessions_coordinator: number
+  sessions_presence: number
   sessions_total: number
   external_subscribers: number
   broadcast_avg_seconds: number
@@ -270,6 +271,7 @@ export function parseTransportHealthData(data: unknown): TransportHealthData {
     sse: {
       sessions_observer: outer.sse.sessions_observer,
       sessions_coordinator: outer.sse.sessions_coordinator,
+      sessions_presence: outer.sse.sessions_presence,
       sessions_total: outer.sse.sessions_total,
       external_subscribers: outer.sse.external_subscribers,
       broadcast_avg_seconds: outer.sse.broadcast_avg_seconds,


### PR DESCRIPTION
## What changed

- Added `sessions_presence` to the `SseSection` TypeScript interface.
- Preserved `outer.sse.sessions_presence` in `parseTransportHealthData`.

## Why

Follow-up for https://github.com/jeong-sik/masc-mcp/pull/12129. The backend and Valibot schema added the presence SSE count, but the hand-shaped TypeScript return type omitted that field, causing the Dashboard typecheck to fail after the Track 6 presence channel merged.

## Validation

- `git diff origin/main...HEAD --check`
- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/api/transport-health.test.ts src/components/transport-health.test.ts`
