### PR TITLE
[codex] fix MCP per-client auth identities

### DIFF
--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -134,7 +134,34 @@ projection before retrying OAuth login:
 Every required config stage should be `pass`; `codex_oauth_login` is expected
 to be `skip` because MASC uses bearer-token auth.
 
-## 5. Supported Local Start
+## 5. Claude / Gemini MCP Bearers
+
+Claude and Gemini must not reuse the Codex bearer. Mint each local MCP client
+as its own worker identity, then sync the shared client config:
+
+```bash
+BASE_PATH="${MASC_BASE_PATH:-$HOME/me}"
+
+./_build/default/bin/main_eio.exe login \
+  --base-path "$BASE_PATH" \
+  --agent claude \
+  --role worker \
+  --shell
+
+./_build/default/bin/main_eio.exe login \
+  --base-path "$BASE_PATH" \
+  --agent gemini \
+  --role worker \
+  --shell
+
+~/me/scripts/mcp-sync.sh
+```
+
+`doctor auth --json` exposes `.mcp_clients[]`; `claude` should use
+`MASC_CLAUDE_MCP_TOKEN` / `X-MASC-Agent: claude`, and `gemini` should use
+`MASC_GEMINI_MCP_TOKEN` / `X-MASC-Agent: gemini`.
+
+## 6. Supported Local Start
 
 When running from a worktree but using a shared local coordination root, start the server with an explicit base path:
 
@@ -149,7 +176,7 @@ MASC_BASE_PATH="$BASE_PATH" \
 
 Then run `./_build/default/bin/main_eio.exe doctor --base-path "$BASE_PATH"` and re-check `/health` to confirm the effective base path is the path you intended.
 
-## 6. Bootstrap an Admin Bearer
+## 7. Bootstrap an Admin Bearer
 
 If you already have an admin bearer, skip to step 7.
 
@@ -235,7 +262,7 @@ Notes:
 - keep the raw bearer outside the repo
 - this is for trusted local operator use, not a remote/public bootstrap path
 
-## 7. Open the Dashboard as Admin
+## 8. Open the Dashboard as Admin
 
 Pass the token once via query string. The dashboard moves it into `sessionStorage` and removes it from the URL.
 
@@ -260,7 +287,7 @@ Expected:
 - `effective_agent="codex-tool-matrix"`
 - `effective_role="admin"`
 
-## 8. Verify Admin-Only Routes
+## 9. Verify Admin-Only Routes
 
 Use a low-risk keeper first.
 
@@ -310,7 +337,7 @@ curl -sS http://127.0.0.1:8935/api/v1/dashboard/execution \
   | jq '.keepers[] | select(.name=="<keeper>") | {name,status,paused,trace_id,active_model}'
 ```
 
-## 9. Rollback
+## 10. Rollback
 
 If you need to go back to anonymous loopback behavior:
 

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -795,15 +795,21 @@ let record_bearer_token_mismatch ~expected_agent ~actual_agent =
     ]
     ()
 
+let bearer_token_owner_mismatch_message ~requested_agent ~token_owner =
+  Printf.sprintf
+    "No credential found for %s (bearer token belongs to %s). MCP identity \
+     mismatch: mint/sync a bearer for %s (`masc-mcp login --agent %s --role \
+     worker --shell`, then `sb mcp sync`) or send the token owner's identity."
+    requested_agent token_owner requested_agent requested_agent
+
 let missing_credential_error config ~agent_name ~token : masc_error =
   match find_credential_by_token config ~token with
   | Ok owner when owner.agent_name <> agent_name ->
       record_bearer_token_mismatch
         ~expected_agent:agent_name ~actual_agent:owner.agent_name;
       Unauthorized
-        (Printf.sprintf
-           "No credential found for %s (bearer token belongs to %s)"
-           agent_name owner.agent_name)
+        (bearer_token_owner_mismatch_message ~requested_agent:agent_name
+           ~token_owner:owner.agent_name)
   | _ -> Unauthorized ("No credential found for " ^ agent_name)
 
 (** Verify a token.
@@ -831,9 +837,8 @@ let verify_token_owner_alias config ~agent_name ~token =
         ~expected_agent:agent_name ~actual_agent:owner.agent_name;
       Error
         (Unauthorized
-           (Printf.sprintf
-              "No credential found for %s (bearer token belongs to %s)"
-              agent_name owner.agent_name))
+           (bearer_token_owner_mismatch_message ~requested_agent:agent_name
+              ~token_owner:owner.agent_name))
   | Error e -> Error e
 
 let verify_token config ~agent_name ~token : (agent_credential, masc_error) result =

--- a/lib/auth_doctor.ml
+++ b/lib/auth_doctor.ml
@@ -28,6 +28,22 @@ type codex_mcp = {
   config : Codex_mcp_config_doctor.t;
 }
 
+type mcp_client = {
+  client_name : string;
+  agent_name : string;
+  token_env_var : string;
+  token_file_path : string;
+  credential_present : bool;
+  credential_role : string option;
+  raw_token_file_present : bool;
+  token_source : string;
+  token_status : string;
+  token_agent : string option;
+  token_role : string option;
+  token_can_read_state : bool option;
+  identity_ready : bool;
+}
+
 type t = {
   status : status;
   base_path : string;
@@ -52,6 +68,7 @@ type t = {
   role_counts : (string * int) list;
   watched_agents : watched_agent list;
   codex_mcp : codex_mcp;
+  mcp_clients : mcp_client list;
   warnings : string list;
   next_actions : string list;
 }
@@ -71,6 +88,31 @@ let codex_mcp_token_env_var = "MASC_MCP_TOKEN"
 
 let codex_mcp_login_note =
   "`codex mcp login` is OAuth-only; masc-mcp uses bearer token auth."
+
+type mcp_client_spec = {
+  client_name : string;
+  agent_name : string;
+  token_env_var : string;
+}
+
+let mcp_client_specs =
+  [
+    {
+      client_name = "codex";
+      agent_name = "codex-mcp-client";
+      token_env_var = codex_mcp_token_env_var;
+    };
+    {
+      client_name = "claude";
+      agent_name = "claude";
+      token_env_var = "MASC_CLAUDE_MCP_TOKEN";
+    };
+    {
+      client_name = "gemini";
+      agent_name = "gemini";
+      token_env_var = "MASC_GEMINI_MCP_TOKEN";
+    };
+  ]
 
 let canonicalize_path path =
   try Unix.realpath path with
@@ -265,6 +307,81 @@ let codex_mcp_report ~base_path =
             config;
           })
 
+let mcp_client_report ~base_path ~auth_dir
+    ({ client_name; agent_name; token_env_var } : mcp_client_spec) =
+  let token_file_path = raw_token_file_path ~auth_dir agent_name in
+  let credential_opt = Auth.load_credential base_path agent_name in
+  let raw_token_file_present = file_exists token_file_path in
+  let token_source, raw_token =
+    match Sys.getenv_opt token_env_var |> Env_config_core.trim_opt with
+    | Some value -> ("env", Some value)
+    | None -> (
+        match read_nonempty_text_file token_file_path with
+        | Some value -> ("token_file", Some value)
+        | None -> ("missing", None))
+  in
+  let token_status, token_agent, token_role, token_can_read_state =
+    match raw_token with
+    | None -> ("missing", None, None, None)
+    | Some token -> (
+        match Auth.find_credential_by_token base_path ~token with
+        | Ok cred ->
+            let status =
+              if String.equal cred.agent_name agent_name then
+                "live"
+              else
+                "wrong_agent"
+            in
+            ( status,
+              Some cred.agent_name,
+              Some (agent_role_to_string cred.role),
+              Some (has_permission cred.role CanReadState) )
+        | Error _ -> ("invalid_or_expired", None, None, None))
+  in
+  let identity_ready =
+    Option.is_some credential_opt && String.equal token_status "live"
+  in
+  {
+    client_name;
+    agent_name;
+    token_env_var;
+    token_file_path;
+    credential_present = Option.is_some credential_opt;
+    credential_role = Option.map (fun (cred : agent_credential) -> agent_role_to_string cred.role) credential_opt;
+    raw_token_file_present;
+    token_source;
+    token_status;
+    token_agent;
+    token_role;
+    token_can_read_state;
+    identity_ready;
+  }
+
+let mcp_client_warning (client : mcp_client) =
+  match client.token_status with
+  | "wrong_agent" ->
+      Some
+        (Printf.sprintf
+           "%s MCP bearer resolves to %s instead of %s; rerun `masc-mcp login --agent %s --role worker --shell` and `sb mcp sync`."
+           client.client_name
+           (Option.value ~default:"(unknown)" client.token_agent)
+           client.agent_name client.agent_name)
+  | "invalid_or_expired" ->
+      Some
+        (Printf.sprintf
+           "%s MCP bearer from %s is invalid or expired; rerun `masc-mcp login --agent %s --role worker --shell` and `sb mcp sync`."
+           client.client_name client.token_source client.agent_name)
+  | _ -> None
+
+let mcp_client_next_action (client : mcp_client) =
+  if client.identity_ready then
+    None
+  else
+    Some
+      (Printf.sprintf
+         "For %s MCP, run `masc-mcp login --agent %s --role worker --shell`, then `sb mcp sync` so its bearer and X-MASC-Agent match."
+         client.client_name client.agent_name)
+
 let analyze ~base_path_input ~default_base_path () =
   let normalized_base_path =
     Env_config_core.normalize_masc_base_path_input base_path_input
@@ -300,6 +417,9 @@ let analyze ~base_path_input ~default_base_path () =
       ~dashboard_dev_token_available ~admin_token_env_state credentials
   in
   let codex_mcp = codex_mcp_report ~base_path in
+  let mcp_clients =
+    List.map (mcp_client_report ~base_path ~auth_dir) mcp_client_specs
+  in
   let token_bound_admin_http_ready =
     auth_cfg.enabled && auth_cfg.require_token && admin_bearer_sources <> []
   in
@@ -381,7 +501,10 @@ let analyze ~base_path_input ~default_base_path () =
          None);
     ]
     |> List.filter_map Fun.id
-    |> (fun values -> values @ Codex_mcp_config_doctor.warnings codex_mcp.config)
+    |> (fun values ->
+         values
+         @ List.filter_map mcp_client_warning mcp_clients
+         @ Codex_mcp_config_doctor.warnings codex_mcp.config)
     |> dedupe_keep_order
   in
   let next_actions =
@@ -430,7 +553,10 @@ let analyze ~base_path_input ~default_base_path () =
       Some "Rerun `masc-mcp doctor auth` after editing auth files or rotating tokens.";
     ]
     |> List.filter_map Fun.id
-    |> (fun values -> values @ Codex_mcp_config_doctor.next_actions codex_mcp.config)
+    |> (fun values ->
+         values
+         @ List.filter_map mcp_client_next_action mcp_clients
+         @ Codex_mcp_config_doctor.next_actions codex_mcp.config)
     |> dedupe_keep_order
   in
   let status =
@@ -466,11 +592,12 @@ let analyze ~base_path_input ~default_base_path () =
     role_counts = role_counts_of_credentials credentials;
     watched_agents;
     codex_mcp;
+    mcp_clients;
     warnings;
     next_actions;
   }
 
-let watched_agent_to_yojson agent =
+let watched_agent_to_yojson (agent : watched_agent) =
   `Assoc
     [
       ("agent_name", `String agent.agent_name);
@@ -501,6 +628,27 @@ let codex_mcp_to_yojson codex_mcp =
       ("login_supported", `Bool codex_mcp.login_supported);
       ("login_note", `String codex_mcp.login_note);
       ("config", Codex_mcp_config_doctor.to_yojson codex_mcp.config);
+    ]
+
+let mcp_client_to_yojson (client : mcp_client) =
+  `Assoc
+    [
+      ("client_name", `String client.client_name);
+      ("agent_name", `String client.agent_name);
+      ("token_env_var", `String client.token_env_var);
+      ("token_file_path", `String client.token_file_path);
+      ("credential_present", `Bool client.credential_present);
+      (option_field "credential_role" client.credential_role);
+      ("raw_token_file_present", `Bool client.raw_token_file_present);
+      ("token_source", `String client.token_source);
+      ("token_status", `String client.token_status);
+      (option_field "token_agent" client.token_agent);
+      (option_field "token_role" client.token_role);
+      ( "token_can_read_state",
+        match client.token_can_read_state with
+        | Some value -> `Bool value
+        | None -> `Null );
+      ("identity_ready", `Bool client.identity_ready);
     ]
 
 let to_yojson (report : t) =
@@ -543,6 +691,8 @@ let to_yojson (report : t) =
       ( "watched_agents",
         `List (List.map watched_agent_to_yojson report.watched_agents) );
       ("codex_mcp", codex_mcp_to_yojson report.codex_mcp);
+      ( "mcp_clients",
+        `List (List.map mcp_client_to_yojson report.mcp_clients) );
       ("warnings", `List (List.map (fun value -> `String value) report.warnings));
       ("next_actions", `List (List.map (fun value -> `String value) report.next_actions));
     ]
@@ -606,7 +756,7 @@ let render_text (report : t) =
   add_line "";
   add_line "watched_agents:";
   List.iter
-    (fun agent ->
+    (fun (agent : watched_agent) ->
       add_line
         (Printf.sprintf
            "- %s: credential=%s role=%s can_admin=%s raw_token_file=%s expires_at=%s"
@@ -669,6 +819,20 @@ let render_text (report : t) =
            (Codex_mcp_config_doctor.stage_status_to_string stage.status)
            stage.detail))
     report.codex_mcp.config.stages;
+  add_line "";
+  add_line "mcp_clients:";
+  List.iter
+    (fun (client : mcp_client) ->
+      add_line
+        (Printf.sprintf
+           "- %s: agent=%s env=%s token_file=%s credential=%s token_source=%s token_status=%s token_agent=%s identity_ready=%s"
+           client.client_name client.agent_name client.token_env_var
+           client.token_file_path
+           (yes_no client.credential_present)
+           client.token_source client.token_status
+           (option_value client.token_agent)
+           (yes_no client.identity_ready)))
+    report.mcp_clients;
   if report.warnings <> [] then begin
     add_line "";
     add_line "warnings:";

--- a/lib/auth_doctor.mli
+++ b/lib/auth_doctor.mli
@@ -1,6 +1,6 @@
 (** Auth_doctor — Server-side authentication health diagnostic.
 
-    Inspects the resolved auth directory + Codex MCP wiring +
+    Inspects the resolved auth directory + MCP client wiring +
     admin-token sources and produces a structured {!t} report
     that is rendered as JSON ({!to_yojson}) or human text
     ({!render_text}) and graded by {!exit_code} for CLI use.
@@ -14,7 +14,7 @@
     [watched_agent_names], [admin_token_env_state],
     [admin_token_env_fields], [role_counts_of_credentials],
     [live_admin_token_file_source], [admin_bearer_sources],
-    [codex_mcp_report], plus the per-record yojson encoders
+    [codex_mcp_report], MCP client identity checks, plus the per-record yojson encoders
     ([watched_agent_to_yojson], [codex_mcp_to_yojson]).
     All consumed only inside {!analyze} / {!to_yojson} /
     {!render_text}. *)
@@ -31,7 +31,7 @@ val status_to_string : status -> string
     ["ok"] / ["warn"] / ["error"].  Pinned literal — drift would
     break tooling that parses the auth-doctor JSON. *)
 
-(** {1 Per-agent + Codex MCP records} *)
+(** {1 Per-agent + MCP records} *)
 
 type watched_agent = {
   agent_name : string;
@@ -61,6 +61,26 @@ type codex_mcp = {
     [codex mcp login] is OAuth-only while masc-mcp uses bearer
     token auth — pinned at the contract seam. *)
 
+type mcp_client = {
+  client_name : string;
+  agent_name : string;
+  token_env_var : string;
+  token_file_path : string;
+  credential_present : bool;
+  credential_role : string option;
+  raw_token_file_present : bool;
+  token_source : string;
+  token_status : string;
+  token_agent : string option;
+  token_role : string option;
+  token_can_read_state : bool option;
+  identity_ready : bool;
+}
+(** Per-client MCP identity readiness for local Codex/Claude/Gemini
+    bearer-token wiring.  [token_source] is ["env"], ["token_file"],
+    or ["missing"]; [token_status] is ["live"], ["wrong_agent"],
+    ["invalid_or_expired"], or ["missing"]. *)
+
 (** {1 Aggregate report} *)
 
 type t = {
@@ -87,6 +107,7 @@ type t = {
   role_counts : (string * int) list;
   watched_agents : watched_agent list;
   codex_mcp : codex_mcp;
+  mcp_clients : mcp_client list;
   warnings : string list;
   next_actions : string list;
 }
@@ -111,7 +132,8 @@ val analyze :
     + Each registered agent credential -> {!watched_agent} row.
     + Admin-token env-var status + admin-bearer source
       enumeration ([admin_bearer_sources]).
-    + Codex MCP wiring via {!Codex_mcp_config_doctor}.
+    + Codex MCP config via {!Codex_mcp_config_doctor}.
+    + Local MCP client identities for Codex, Claude, and Gemini.
 
     Side-effecting (file reads); pure with respect to the
     process registry — does not mutate auth state. *)

--- a/lib/auth_login.ml
+++ b/lib/auth_login.ml
@@ -15,6 +15,7 @@ type t = {
   raw_token_file : string;
   dashboard_url : string;
   mcp_url : string;
+  mcp_token_env_var : string;
   codex_server_name : string;
   codex_token_env_var : string;
   codex_login_supported : bool;
@@ -23,6 +24,12 @@ type t = {
 let codex_server_name = "masc"
 
 let codex_token_env_var = "MASC_MCP_TOKEN"
+
+let mcp_token_env_var_for_agent = function
+  | "claude" -> "MASC_CLAUDE_MCP_TOKEN"
+  | "gemini" -> "MASC_GEMINI_MCP_TOKEN"
+  | "codex" | "codex-mcp-client" -> codex_token_env_var
+  | _ -> codex_token_env_var
 
 let rng_initialized = Atomic.make false
 
@@ -106,6 +113,7 @@ let mint ~base_path ~host ~port ~agent_name ~role () =
               raw_token_file;
               dashboard_url;
               mcp_url;
+              mcp_token_env_var = mcp_token_env_var_for_agent cred.agent_name;
               codex_server_name;
               codex_token_env_var;
               codex_login_supported = false;
@@ -124,6 +132,14 @@ let to_yojson report =
       ("raw_token_file", `String report.raw_token_file);
       ("dashboard_url", `String report.dashboard_url);
       ("mcp_url", `String report.mcp_url);
+      ( "mcp_client",
+        `Assoc
+          [
+            ("server_name", `String report.codex_server_name);
+            ("agent_name", `String report.agent_name);
+            ("auth_model", `String "bearer_token_env");
+            ("token_env_var", `String report.mcp_token_env_var);
+          ] );
       ( "codex_mcp",
         `Assoc
           [
@@ -144,7 +160,7 @@ let render_shell report =
         (single_quote_shell report.agent_name);
       Printf.sprintf "export MASC_OPERATOR_TOKEN=%s"
         (single_quote_shell report.bearer_token);
-      Printf.sprintf "export %s=%s" report.codex_token_env_var
+      Printf.sprintf "export %s=%s" report.mcp_token_env_var
         (single_quote_shell report.bearer_token);
       Printf.sprintf "export MASC_DASHBOARD_URL=%s"
         (single_quote_shell report.dashboard_url);
@@ -167,6 +183,12 @@ let render_text report =
       "";
       "exports:";
       render_shell report;
+      "";
+      "mcp_client:";
+      Printf.sprintf "- server_name: %s" report.codex_server_name;
+      Printf.sprintf "- agent_name: %s" report.agent_name;
+      Printf.sprintf "- token_env_var: %s" report.mcp_token_env_var;
+      "- auth_model: bearer_token_env";
       "";
       "codex_mcp:";
       Printf.sprintf "- server_name: %s" report.codex_server_name;

--- a/lib/auth_login.mli
+++ b/lib/auth_login.mli
@@ -41,6 +41,7 @@ type t = {
   raw_token_file : string;
   dashboard_url : string;
   mcp_url : string;
+  mcp_token_env_var : string;
   codex_server_name : string;
   codex_token_env_var : string;
   codex_login_supported : bool;
@@ -54,6 +55,10 @@ type t = {
       written to [raw_token_file] (operator-readable, mode 0600).
     - [dashboard_url] always carries [agent] + [token] query params,
       both URL-encoded.
+    - [mcp_token_env_var] is the client-specific bearer env var for
+      known MCP clients ([claude] -> [MASC_CLAUDE_MCP_TOKEN],
+      [gemini] -> [MASC_GEMINI_MCP_TOKEN], Codex ->
+      [MASC_MCP_TOKEN]).
     - [codex_server_name] is the constant [["masc"]] and
       [codex_token_env_var] is [["MASC_MCP_TOKEN"]]; both pinned at
       this level so the operator runbook for `codex` integration
@@ -106,7 +111,8 @@ val to_yojson : t -> Yojson.Safe.t
 (** [to_yojson report] renders the canonical JSON-RPC result
     object with fields [status: "ok"] / [base_path] / [auth_config_path]
     / [auth_change] / [agent_name] / [role] / [bearer_token] /
-    [raw_token_file] / [dashboard_url] / [mcp_url] / [codex_mcp].
+    [raw_token_file] / [dashboard_url] / [mcp_url] / [mcp_client] /
+    [codex_mcp].
 
     The [codex_mcp] sub-object pins five fields: [server_name],
     [auth_model: "bearer_token_env"], [token_env_var],
@@ -121,7 +127,7 @@ val render_shell : t -> string
 
     - [MASC_OPERATOR_AGENT]
     - [MASC_OPERATOR_TOKEN]
-    - [<codex_token_env_var>] (currently [MASC_MCP_TOKEN])
+    - [<mcp_token_env_var>] (client-specific for Claude/Gemini/Codex)
     - [MASC_DASHBOARD_URL]
 
     All values are POSIX-quoted (single-quoted with embedded
@@ -133,8 +139,8 @@ val render_text : t -> string
     suitable for terminal display: status / base_path /
     auth_config_path / auth_change / agent_name / role /
     raw_token_file / dashboard_url / mcp_url, then the shell
-    [exports:] block (from {!render_shell}), then the [codex_mcp:]
-    block describing the bearer-token-env auth model.
+    [exports:] block (from {!render_shell}), then [mcp_client:] and
+    [codex_mcp:] blocks describing the bearer-token-env auth model.
 
     The bearer token itself is intentionally NOT included as a
     standalone line in the text output — it appears only inside

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -641,10 +641,17 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     | None -> `Null
   in
 
-  (* Resolve agent_name: session identity > arguments > fallback *)
+  (* Resolve agent_name for telemetry.  HTTP auth injects [_agent_name] as
+     the canonical caller; legacy [agent_name] may be a tool-domain target. *)
   let agent_name =
-    let from_args = Safe_ops.json_string ~default:"" "agent_name" arguments in
-    if from_args <> "" then from_args
+    let from_transport =
+      Safe_ops.json_string ~default:"" "_agent_name" arguments
+    in
+    let from_legacy =
+      Safe_ops.json_string ~default:"" "agent_name" arguments
+    in
+    if from_transport <> "" then from_transport
+    else if from_legacy <> "" then from_legacy
     else
       let identity =
         Agent_registry_eio.get_or_create_identity ?mcp_session_id arguments

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -76,6 +76,21 @@ let silent_auth_token_error_kind = function
 let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =
   (not has_explicit_agent_name) && is_ephemeral_agent_name agent_name
 
+let caller_agent_name_from_arguments arguments =
+  let nonempty_nonunknown key =
+    match Safe_ops.json_string_opt key arguments with
+    | Some value ->
+        let value = String.trim value in
+        if value <> "" && value <> "unknown" then
+          Some value
+        else
+          None
+    | None -> None
+  in
+  match nonempty_nonunknown "_agent_name" with
+  | Some _ as value -> value
+  | None -> nonempty_nonunknown "agent_name"
+
 let direct_call_block_message name =
   if Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name then
     let replacement_hint =
@@ -158,18 +173,18 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
   in
 
   (* Helper to get values from JSON arguments - delegates to Safe_ops *)
-  let arg_get_string key default =
-    Safe_ops.json_string ~default key arguments
-  in
   let arg_get_string_opt key =
     match Safe_ops.json_string_opt key arguments with
     | Some "" -> None
     | other -> other
   in
 
-  (* Resolve agent_name via Agent Identity system (primary) with legacy fallback. *)
-  let raw_agent_name = arg_get_string "agent_name" "" in
-  let has_explicit_agent_name = raw_agent_name <> "" && raw_agent_name <> "unknown" in
+  (* Resolve caller identity.  HTTP auth injects [_agent_name] from the
+     bearer-token owner; legacy [agent_name] is still accepted for direct
+     callers and for older MCP clients that have not moved to the internal
+     marker yet. *)
+  let explicit_agent_name = caller_agent_name_from_arguments arguments in
+  let has_explicit_agent_name = Option.is_some explicit_agent_name in
   let identity_session_prefix =
     let len = min 8 (String.length identity.session_key) in
     if len = 0 then "anon" else String.sub identity.session_key 0 len
@@ -179,30 +194,39 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
   in
   let agent_name =
     (* Fix 4: Use cached resolved name to skip legacy /tmp file reads *)
-    if has_explicit_agent_name then
-      raw_agent_name
-    else match cached_resolved_agent with
-    | Some cached -> cached
+    match explicit_agent_name with
+    | Some agent_name -> agent_name
     | None ->
-    if identity.Agent_identity.agent_name <> "" then
-      identity.Agent_identity.agent_name
-    else
-      match read_mcp_session_agent () with
-      | Some name -> name
-      | None ->
-          if Option.is_some mcp_session_id then
-            generated_fallback_agent_name
-          else
-            let term_session_id = Option.value ~default:"" (Sys.getenv_opt "TERM_SESSION_ID") in
-            let term_file = Printf.sprintf "/tmp/.masc_agent_%s" term_session_id in
-            (match Safe_ops.protect ~default:None (fun () ->
-               let name = Fs_compat.load_file term_file |> String.trim in
-               if name <> "" then Some name else None)
-             with
-             | Some name ->
-                 Log.Mcp.warn "[deprecated] agent name resolved via /tmp TERM file — migrate to Agent_identity";
-                 name
-             | None -> generated_fallback_agent_name)
+        (match cached_resolved_agent with
+         | Some cached -> cached
+         | None ->
+             if identity.Agent_identity.agent_name <> "" then
+               identity.Agent_identity.agent_name
+             else
+               match read_mcp_session_agent () with
+               | Some name -> name
+               | None ->
+                   if Option.is_some mcp_session_id then
+                     generated_fallback_agent_name
+                   else
+                     let term_session_id =
+                       Option.value ~default:"" (Sys.getenv_opt "TERM_SESSION_ID")
+                     in
+                     let term_file =
+                       Printf.sprintf "/tmp/.masc_agent_%s" term_session_id
+                     in
+                     (match
+                        Safe_ops.protect ~default:None (fun () ->
+                            let name =
+                              Fs_compat.load_file term_file |> String.trim
+                            in
+                            if name <> "" then Some name else None)
+                      with
+                      | Some name ->
+                          Log.Mcp.warn
+                            "[deprecated] agent name resolved via /tmp TERM file — migrate to Agent_identity";
+                          name
+                      | None -> generated_fallback_agent_name))
   in
 
   let token =

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -2,12 +2,15 @@
     plus the join-state resolver shared with the keeper
     onboarding path.
 
-    The .ml is 919 lines.  Only 4 entries reach callers:
+    The .ml is 919 lines.  Only a small set of entries reach callers:
     - {!resolve_join_state} and
       {!should_read_legacy_persisted_agent_name} —
       [test/test_mcp_server_eio.ml] exercises both to
       verify the join-required + ephemeral-name fallback
       decisions stay consistent across refactors.
+    - {!caller_agent_name_from_arguments} — isolates the
+      HTTP [_agent_name] vs legacy [agent_name] precedence
+      contract without running the full dispatcher.
     - {!execute_tool_eio} — invoked by
       [lib/server/server_runtime_bootstrap.ml] and threaded
       through {!Mcp_server_eio_call_tool.handle_call_tool_eio}
@@ -65,6 +68,13 @@ val should_read_legacy_persisted_agent_name :
     {b ephemeral} class ([_ephemeral_*] / unknown
     sentinels).  Tested directly to keep the legacy /
     explicit path split honest. *)
+
+val caller_agent_name_from_arguments : Yojson.Safe.t -> string option
+(** Returns the explicit caller identity carried in [tools/call]
+    arguments.  The internal HTTP-auth marker [_agent_name] wins
+    over legacy [agent_name]; legacy [agent_name] remains the fallback
+    for direct callers and old MCP clients.  Blank and ["unknown"]
+    values are ignored. *)
 
 (** {1 [tools/call] inner dispatcher} *)
 

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -48,6 +48,24 @@ let with_env name value f =
      | None -> Unix.putenv name "");
     raise exn
 
+let contains_substring text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  if needle_len = 0 then
+    true
+  else if needle_len > text_len then
+    false
+  else
+    let rec loop i =
+      if i + needle_len > text_len then
+        false
+      else if String.sub text i needle_len = needle then
+        true
+      else
+        loop (i + 1)
+    in
+    loop 0
+
 let with_eio_runtime f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -247,9 +265,13 @@ let test_verify_token_reports_token_owner_on_agent_mismatch () =
   cleanup_test_room dir;
   match create_result, verify_result with
   | Ok _, Error (Types.Unauthorized msg) ->
-      check string "mismatch message"
-        "🔐 Unauthorized: No credential found for gemini (bearer token belongs to codex)"
-        (Types.masc_error_to_string (Types.Unauthorized msg))
+      let rendered = Types.masc_error_to_string (Types.Unauthorized msg) in
+      check bool "mismatch message names token owner" true
+        (String.contains rendered '('
+         && contains_substring rendered "bearer token belongs to codex");
+      check bool "mismatch message explains fix" true
+        (contains_substring rendered
+           "masc-mcp login --agent gemini --role worker --shell")
   | Ok _, Ok _ ->
       fail "verify_token should fail when token owner and requested agent differ"
   | Ok _, Error e ->

--- a/test/test_auth_doctor.ml
+++ b/test/test_auth_doctor.ml
@@ -92,6 +92,16 @@ let save_credential_or_fail base_path ~agent_name ~role ~raw_token =
 let raw_token_file base_path agent_name =
   Filename.concat (Auth.auth_dir base_path) (agent_name ^ ".token")
 
+let find_mcp_client report client_name =
+  match
+    List.find_opt
+      (fun (client : Auth_doctor.mcp_client) ->
+        String.equal client.client_name client_name)
+      (report : Auth_doctor.t).mcp_clients
+  with
+  | Some client -> client
+  | None -> failf "missing mcp client report for %s" client_name
+
 let test_warns_for_codex_worker_admin_route_mismatch () =
   with_temp_dir "auth-doctor-warn" @@ fun base_path ->
   let auth_cfg =
@@ -262,6 +272,59 @@ let test_reports_codex_mcp_bearer_env () =
     (list_contains_substring ~needle:"codex mcp login"
        report.warnings)
 
+let test_reports_claude_and_gemini_mcp_client_identities () =
+  with_temp_dir "auth-doctor-mcp-clients" @@ fun base_path ->
+  let auth_cfg =
+    Types.
+      {
+        enabled = true;
+        room_secret_hash = None;
+        require_token = true;
+        token_expiry_hours = 24;
+      }
+  in
+  Auth.save_auth_config base_path auth_cfg;
+  save_credential_or_fail base_path ~agent_name:"admin" ~role:Types.Admin
+    ~raw_token:"admin-token";
+  Auth.save_private_text_file (raw_token_file base_path "admin")
+    "admin-token";
+  save_credential_or_fail base_path ~agent_name:"claude"
+    ~role:Types.Worker ~raw_token:"claude-token";
+  Auth.save_private_text_file (raw_token_file base_path "claude")
+    "claude-token";
+  save_credential_or_fail base_path ~agent_name:"gemini"
+    ~role:Types.Worker ~raw_token:"gemini-token";
+  Auth.save_private_text_file (raw_token_file base_path "gemini")
+    "gemini-token";
+  with_env "MASC_HOST" "127.0.0.1" @@ fun () ->
+  with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
+  with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_env "MASC_CLAUDE_MCP_TOKEN" "" @@ fun () ->
+  with_env "MASC_GEMINI_MCP_TOKEN" "" @@ fun () ->
+  with_valid_codex_config base_path @@ fun () ->
+  let report =
+    Auth_doctor.analyze ~base_path_input:base_path
+      ~default_base_path:base_path ()
+  in
+  let claude = find_mcp_client report "claude" in
+  check string "claude agent" "claude" claude.agent_name;
+  check string "claude env" "MASC_CLAUDE_MCP_TOKEN"
+    claude.token_env_var;
+  check string "claude token source" "token_file" claude.token_source;
+  check string "claude token status" "live" claude.token_status;
+  check bool "claude identity ready" true claude.identity_ready;
+  let gemini = find_mcp_client report "gemini" in
+  check string "gemini env" "MASC_GEMINI_MCP_TOKEN"
+    gemini.token_env_var;
+  check bool "gemini identity ready" true gemini.identity_ready;
+  check bool "json exposes mcp clients" true
+    (contains_substring ~needle:"\"mcp_clients\""
+       (Auth_doctor.to_yojson report |> Yojson.Safe.to_string));
+  check bool "text names claude env" true
+    (contains_substring ~needle:"MASC_CLAUDE_MCP_TOKEN"
+       (Auth_doctor.render_text report))
+
 let test_reports_codex_config_pipeline_stages () =
   with_temp_dir "auth-doctor-codex-config-ok" @@ fun base_path ->
   let auth_cfg =
@@ -412,6 +475,8 @@ let () =
             test_ignores_stale_admin_raw_token_file;
           test_case "reports Codex MCP bearer env" `Quick
             test_reports_codex_mcp_bearer_env;
+          test_case "reports Claude and Gemini MCP client identities" `Quick
+            test_reports_claude_and_gemini_mcp_client_identities;
           test_case "reports Codex MCP config pipeline stages" `Quick
             test_reports_codex_config_pipeline_stages;
           test_case "reports stable Codex MCP config stages when file missing"

--- a/test/test_auth_login.ml
+++ b/test/test_auth_login.ml
@@ -48,6 +48,8 @@ let test_login_enables_bearer_auth_and_prints_codex_exports () =
         (Types.agent_role_to_string report.role);
       check string "codex env" "MASC_MCP_TOKEN"
         report.codex_token_env_var;
+      check string "client env" "MASC_MCP_TOKEN"
+        report.mcp_token_env_var;
       check bool "codex login unsupported" false
         report.codex_login_supported;
       check bool "raw token file exists" true
@@ -76,6 +78,32 @@ let test_login_enables_bearer_auth_and_prints_codex_exports () =
         (Yojson.Safe.Util.member "status" json
         |> Yojson.Safe.Util.to_string)
 
+let test_login_prints_claude_client_env () =
+  with_temp_dir "auth-login-claude" @@ fun base_path ->
+  match
+    Auth_login.mint ~base_path ~host:"127.0.0.1" ~port:8935
+      ~agent_name:"claude" ~role:Types.Worker ()
+  with
+  | Error err ->
+      failf "login mint failed: %s" (Types.masc_error_to_string err)
+  | Ok report ->
+      check string "agent" "claude" report.agent_name;
+      check string "client env" "MASC_CLAUDE_MCP_TOKEN"
+        report.mcp_token_env_var;
+      check string "codex env remains pinned" "MASC_MCP_TOKEN"
+        report.codex_token_env_var;
+      let shell = Auth_login.render_shell report in
+      check bool "shell exports claude token" true
+        (contains_substring ~needle:"export MASC_CLAUDE_MCP_TOKEN="
+           shell);
+      check bool "shell does not export codex token for claude login" false
+        (contains_substring ~needle:"export MASC_MCP_TOKEN=" shell);
+      let json = Auth_login.to_yojson report in
+      check string "json client env" "MASC_CLAUDE_MCP_TOKEN"
+        (Yojson.Safe.Util.member "mcp_client" json
+         |> Yojson.Safe.Util.member "token_env_var"
+         |> Yojson.Safe.Util.to_string)
+
 let () =
   run "auth_login"
     [
@@ -83,5 +111,7 @@ let () =
         [
           test_case "enables bearer auth and prints Codex exports" `Quick
             test_login_enables_bearer_auth_and_prints_codex_exports;
+          test_case "prints Claude client env" `Quick
+            test_login_prints_claude_client_env;
         ] );
     ]

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1650,6 +1650,33 @@ let test_execute_tool_generated_agent_name_uses_token_identity () =
 
   cleanup_dir base_path
 
+let test_execute_tool_internal_agent_name_overrides_legacy_arg () =
+  let resolve args =
+    Masc_mcp.Mcp_server_eio_execute.caller_agent_name_from_arguments args
+  in
+  Alcotest.(check (option string))
+    "_agent_name wins over legacy agent_name"
+    (Some "stable-admin")
+    (resolve
+       (`Assoc
+         [
+           ("_agent_name", `String "stable-admin");
+           ("agent_name", `String "claude");
+         ]));
+  Alcotest.(check (option string))
+    "legacy agent_name remains fallback"
+    (Some "claude")
+    (resolve (`Assoc [ ("agent_name", `String "claude") ]));
+  Alcotest.(check (option string))
+    "unknown internal marker falls back to legacy"
+    (Some "claude")
+    (resolve
+       (`Assoc
+         [
+           ("_agent_name", `String "unknown");
+           ("agent_name", `String "claude");
+         ]))
+
 let check_task_still_todo config task_id =
   match
     Masc_mcp.Coord.get_tasks_raw config
@@ -3155,6 +3182,8 @@ let eio_tests = [
   "explicit alias reuses joined nickname", `Quick, test_execute_tool_explicit_alias_reuses_joined_nickname;
   "generated agent_name uses token identity", `Quick,
     test_execute_tool_generated_agent_name_uses_token_identity;
+  "internal _agent_name overrides legacy agent_name", `Quick,
+    test_execute_tool_internal_agent_name_overrides_legacy_arg;
   "explicit generated alias claim_next not rewritten by token", `Quick,
     test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token;
   "explicit generated alias transition not rewritten by token", `Quick,


### PR DESCRIPTION
## Summary

- Makes HTTP MCP execution prefer `_agent_name` over legacy `agent_name` for caller identity.
- Keeps legacy `agent_name` as the fallback for direct/older clients and domain arguments.
- Adds client-specific login export support for Claude/Gemini/Codex.
- Extends `doctor auth` with `mcp_clients[]` readiness for Codex, Claude, and Gemini.
- Improves bearer-owner mismatch errors with the exact mint/sync remediation.

## Root Cause / Impact

The HTTP transport already injected `_agent_name` from the bearer token owner, but the execution and telemetry paths still preferred legacy `agent_name`. That let a tool-domain/caller argument like `agent_name="claude"` override a Codex-owned bearer identity and generated repeated `No credential found for claude (bearer token belongs to codex-mcp-client)` failures.

The new contract treats `_agent_name` as the authenticated caller identity and makes per-client readiness visible in `doctor auth`.

## Validation

- `OCAMLPARAM='_,warn-error=-8' MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_auth_login.exe test/test_auth_doctor.exe test/test_mcp_server_eio.exe`
- `_build/default/test/test_auth_login.exe` -> 2 tests passed
- `_build/default/test/test_auth_doctor.exe` -> 9 tests passed
- `_build/default/test/test_auth.exe test credentials 4 --quick-tests --show-errors` -> passed
- `_build/default/test/test_mcp_server_eio.exe test eio 49 --quick-tests --show-errors` -> passed
- Live `doctor auth --base-path /Users/dancer/me --json` showed `codex`, `claude`, and `gemini` all `identity_ready=true`

Note: full default warning-as-error builds currently surface unrelated OAS `ProviderFailure` partial-match warnings in existing files, so focused validation used `warn-error=-8` to avoid mixing that provider drift into this PR.