### PR TITLE
specs(resilience): adopt [@@deriving tla] on Degradation.level_tag

### DIFF
--- a/lib/resilience/degradation.ml
+++ b/lib/resilience/degradation.ml
@@ -20,7 +20,12 @@ type any_level = Any_level : 'a level -> any_level
 
 (* ── Tag mirror ───────────────────────────────────────────────── *)
 
-type level_tag = Tag_l1 | Tag_l2 | Tag_l3 | Tag_l4
+type level_tag =
+  | Tag_l1 [@tla.symbol "L1"]
+  | Tag_l2 [@tla.symbol "L2"]
+  | Tag_l3 [@tla.symbol "L3"]
+  | Tag_l4 [@tla.symbol "L4"] [@tla.terminal]
+[@@deriving tla]
 
 let all_level_tags = [ Tag_l1; Tag_l2; Tag_l3; Tag_l4 ]
 

--- a/lib/resilience/degradation.mli
+++ b/lib/resilience/degradation.mli
@@ -69,6 +69,7 @@ type any_level = Any_level : 'a level -> any_level
 (** {1 Tag mirror} *)
 
 type level_tag = Tag_l1 | Tag_l2 | Tag_l3 | Tag_l4
+[@@deriving tla]
 
 val all_level_tags : level_tag list
 

--- a/lib/resilience/dune
+++ b/lib/resilience/dune
@@ -3,4 +3,6 @@
 (library
  (name resilience)
  (public_name masc_mcp.resilience)
- (libraries shared_types shared_audit yojson))
+ (libraries shared_types shared_audit yojson)
+ (preprocess
+  (pps ppx_tla)))


### PR DESCRIPTION
## Summary

First `[@@deriving tla]` adoption per Cycle 14 audit (#12143 §9.2).

`lib/resilience/degradation.{ml,mli}` already documented `level_tag` as the "derivable variant for ppx_tla and runtime indexing" — this PR delivers what the docs promised.

## Changes

```ocaml
(* lib/resilience/degradation.ml *)
type level_tag =
  | Tag_l1 [@tla.symbol "L1"]
  | Tag_l2 [@tla.symbol "L2"]
  | Tag_l3 [@tla.symbol "L3"]
  | Tag_l4 [@tla.symbol "L4"] [@tla.terminal]
[@@deriving tla]
```

`[@tla.symbol]` overrides match the TLA+ `ResilienceDegradation` spec's `Levels == { "L1", "L2", "L3", "L4" }` literal set. `[@tla.terminal]` on `Tag_l4` since L4 is the lattice fallback.

`lib/resilience/dune` gains `(preprocess (pps ppx_tla))`.

## What's preserved

Hand-written `all_level_tags`, `level_tag_to_string`, `level_to_tag` remain. The PPX adds new symbols (`to_tla_symbol`, `all_symbols`, `terminal_symbols`, `is_terminal`) without colliding with manual helpers.

## Test plan

- [x] `dune build --root . lib/resilience/` exits 0
- [x] No collision with hand-written helpers (different names)
- [ ] Downstream callers continue to use the existing helpers (no breakage)

## Coverage growth

`lib_subdirs_with_ppx`: 3 → 4 (autonomous, keeper, multimodal, **+resilience**).

## References

- PR #12143 — Cycle 14 audit
- `specs/resilience/ResilienceDegradation.tla` — TLA spec this links to
- `lib/keeper/keeper_turn_fsm.ml`, `lib/multimodal/artifact.ml` — pattern reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
