### PR TITLE
fix(test): correct tool_schedule construction in K4 hook test

### DIFF
--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -33,6 +33,14 @@ let with_env_unset name f =
   in
   Fun.protect ~finally:restore f
 
+let stub_schedule : THooks.tool_schedule =
+  { planned_index = 0
+  ; batch_index = 0
+  ; batch_size = 1
+  ; concurrency_class = "test"
+  ; batch_kind = "test"
+  }
+
 let make_post_tool_use ~content : THooks.hook_event =
   THooks.PostToolUse
     { tool_use_id = "tu-1"
@@ -41,7 +49,7 @@ let make_post_tool_use ~content : THooks.hook_event =
     ; output = Ok ({ TT.content } : TT.tool_output)
     ; result_bytes = String.length content
     ; duration_ms = 1.0
-    ; schedule = THooks.Now
+    ; schedule = stub_schedule
     }
 
 let make_pre_tool_use () : THooks.hook_event =
@@ -51,7 +59,7 @@ let make_pre_tool_use () : THooks.hook_event =
     ; input = `Assoc []
     ; accumulated_cost_usd = 0.0
     ; turn = 1
-    ; schedule = THooks.Now
+    ; schedule = stub_schedule
     }
 
 let make_post_tool_use_error () : THooks.hook_event =
@@ -67,7 +75,7 @@ let make_post_tool_use_error () : THooks.hook_event =
            } : TT.tool_error)
     ; result_bytes = 0
     ; duration_ms = 0.5
-    ; schedule = THooks.Now
+    ; schedule = stub_schedule
     }
 
 let assert_eq_int ~label expected actual =


### PR DESCRIPTION
## Summary

K4 PR #12135 merged with a test that wrote `schedule = THooks.Now` (a non-existent constructor). `Agent_sdk.Hooks.tool_schedule` is a record, not a variant. The test compiled in K4's worktree only because the wider lib build was already failing on a different main blocker (`ProviderFailure` exhaustiveness, addressed in #12153) — the test never reached the type checker.

## Fix

Introduce a `stub_schedule` record literal and use it in all 3 event-construction helpers in `test/test_keeper_tool_emission_hook.ml`. No behavioural change in the hook itself.

## Relationship to #12153

This is the test counterpart to #12153 (provider-failure exhaustiveness fix). Both are needed for K4 test to compile:
- #12153 fixes lib partial-match warnings (6 lib files)
- This PR fixes test record construction (1 test file)

Either can land first; together they unblock `dune runtest test/test_keeper_tool_emission_hook.exe` (9/9 assertions).

## Test plan

- [ ] #12153 + this PR both merge
- [ ] `dune build test/test_keeper_tool_emission_hook.exe` GREEN
- [ ] `dune runtest test/test_keeper_tool_emission_hook.exe` 9/9 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)