### PR TITLE
feat(keeper): Tier K4b — wire tool-emission accumulator into runtime (Cycle 27)

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -221,6 +221,46 @@ let apply_resilience_wirein
    and the unmodified lifecycle result is returned, preserving the
    keeper's primary turn outcome. *)
 
+(* ── Tier K4b: tool-emission drain (Cycle 27) ──────────────────────
+   Drains the K4 hook accumulator (parsed JSONs captured by
+   [Keeper_tool_emission_hook.make_post_tool_use_hook] during
+   Agent.run) into [working_context["multimodal_artifacts"]] so the
+   K1 wirein below picks them up.
+
+   Strict ordering: this MUST run BEFORE [apply_multimodal_wirein].
+   K4b emit + K1 hydrate is a producer/consumer pair on the same
+   working_context bag.
+
+   Feature flag: [MASC_TOOL_EMISSION] (default off). When off, the
+   drain is a no-op (the hook itself is also a no-op when the flag
+   is off, so the accumulator is empty). *)
+let apply_tool_emission_wirein
+    ~(now : float)
+    (lifecycle : post_turn_lifecycle) : post_turn_lifecycle =
+  let _ = now in
+  if not (Keeper_tool_emission_hook.masc_tool_emission_enabled ()) then
+    lifecycle
+  else
+    match lifecycle.checkpoint with
+    | None -> lifecycle
+    | Some cp -> (
+        try
+          let new_wc =
+            Keeper_tool_emission_hook.drain_into_working_context
+              Keeper_tool_emission_hook.global_accumulator
+              ~working_context:cp.Oas.Checkpoint.working_context
+          in
+          let new_cp =
+            { cp with Oas.Checkpoint.working_context = new_wc }
+          in
+          { lifecycle with checkpoint = Some new_cp }
+        with exn ->
+          Log.Keeper.warn
+            "keeper:%s tool emission drain failed: %s"
+            lifecycle.updated_meta.name
+            (Printexc.to_string exn);
+          lifecycle)
+
 let apply_multimodal_wirein
     ~(now : float)
     (lifecycle : post_turn_lifecycle) : post_turn_lifecycle =
@@ -544,12 +584,16 @@ let apply_post_turn_lifecycle
       }
   in
   (* Strict ordering: autonomous tick → resilience classification
-     → multimodal hydration. Do not reorder — A6/K1 pinned this
-     sequence. The multimodal pass runs last because it persists a
-     [workspace_meta] summary that depends on whether prior passes
-     have already mutated [working_context]. *)
+     → tool emission drain (K4b) → multimodal hydration (K1). Do
+     not reorder — A6/K1 pinned the autonomous→resilience→multimodal
+     sequence; K4b inserts between resilience and multimodal because
+     it is the producer that K1 consumes. The multimodal pass runs
+     last because it persists a [workspace_meta] summary that
+     depends on whether prior passes have already mutated
+     [working_context]. *)
   let body = apply_autonomous_wirein ~now:now_ts body in
   let body = apply_resilience_wirein ~now:now_ts body in
+  let body = apply_tool_emission_wirein ~now:now_ts body in
   apply_multimodal_wirein ~now:now_ts body
 
 let forced_overflow_retry_meta

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1282,6 +1282,17 @@ let prepare_agent_setup
     in
     Oas.Hooks.compose ~outer:mem_hooks ~inner:hooks
   in
+  (* Tier K4b: install the tool-emission PostToolUse hook so tagged
+     tool results flow into the K4 process-wide accumulator during
+     Agent.run. The drain happens in keeper_post_turn.ml
+     [apply_tool_emission_wirein] BEFORE [apply_multimodal_wirein].
+     When [MASC_TOOL_EMISSION] is off the hook is a no-op (see
+     [Keeper_tool_emission_hook] for the gating). *)
+  let hooks =
+    Keeper_tool_emission_hook.install_into_hooks
+      Keeper_tool_emission_hook.global_accumulator
+      hooks
+  in
   let reducer =
     let hydrator_steps =
       match Keeper_artifact_hydrator.reducer_from_env () with

--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -75,3 +75,5 @@ let drain_into_working_context acc ~(working_context : Yojson.Safe.t option)
     else
       Multimodal.Tool_emission.emit_from_tool_results
         ~working_context items
+
+let global_accumulator = create_accumulator ()

--- a/lib/keeper/keeper_tool_emission_hook.mli
+++ b/lib/keeper/keeper_tool_emission_hook.mli
@@ -90,3 +90,13 @@ val drain_into_working_context :
 (** Number of items currently held in the accumulator. Useful for
     tests and metrics. *)
 val accumulator_size : accumulator -> int
+
+(** Process-wide singleton accumulator used by K4b runtime wire-up
+    (see [Keeper_run_tools] hook installation +
+    [Keeper_post_turn.apply_tool_emission_wirein]). All keepers share
+    this accumulator; cross-keeper attribution is acceptable because
+    [Multimodal.Workspace_holder] is itself process-wide.
+
+    Tests and other call sites that need an isolated accumulator
+    should use [create_accumulator] instead. *)
+val global_accumulator : accumulator


### PR DESCRIPTION
## Summary

Follow-up to **K4 #12135** (deterministic core module, MERGED 2026-04-30). K4b plugs the accumulator into the keeper turn lifecycle so tool authors who set the two reserved JSON keys (`__multimodal_kind` / `__multimodal_id`) get end-to-end auto-pipeline without writing keeper-side glue.

## Pipeline (full runtime path now closed)

```
tool author opt-in (2 reserved JSON keys)
  → Agent.run fires PostToolUse hook
  → K4 hook parses output.content, pushes into global_accumulator   ← K4 (in main)
  → Agent.run completes
  → keeper_post_turn.apply_post_turn_lifecycle:
      autonomous_wirein → resilience_wirein
      → apply_tool_emission_wirein  (drains accumulator)            ← K4b (this PR)
      → apply_multimodal_wirein     (hydrates into Workspace_holder) ← K1 (in main)
  → Multimodal.Workspace_holder updated
  → GET /api/v1/multimodal/list                                     ← D1 (in main)
  → /dashboard/b/multimodal Bonsai gallery                          ← F1 (in main)
```

## Changes

### 1. `lib/keeper/keeper_tool_emission_hook.{mli,ml}` — add singleton

```ocaml
val global_accumulator : accumulator
```

Process-wide singleton used by the runtime wire-up. Tests still use `create_accumulator` for isolated bags. Cross-keeper attribution is acceptable because `Multimodal.Workspace_holder` is itself process-wide.

### 2. `lib/keeper/keeper_run_tools.ml` (`prepare_agent_setup`) — install hook

```ocaml
let hooks =
  Keeper_tool_emission_hook.install_into_hooks
    Keeper_tool_emission_hook.global_accumulator
    hooks
in
```

Wraps the `post_tool_use` hook chain after `mem_hooks` compose. When `MASC_TOOL_EMISSION=0` (default) the hook is a no-op and does not touch accumulator state.

### 3. `lib/keeper/keeper_post_turn.ml` (`apply_post_turn_lifecycle`) — drain step

New helper `apply_tool_emission_wirein` drains `global_accumulator` into `working_context["multimodal_artifacts"]` via `drain_into_working_context` → `Tool_emission.emit_from_tool_results`.

**Strict ordering** (hard-coded in the lifecycle body):

```
autonomous → resilience → tool_emission_drain → multimodal hydration
                          ^^^^^^^^^^^^^^^^^^^^
                          K4b — producer for K1
```

The new step MUST run before `apply_multimodal_wirein` because K4b is the producer that K1 consumes on the same `working_context["multimodal_artifacts"]` bag.

Failures inside the drain are caught and logged, never propagating to the keeper's primary outcome (mirrors existing autonomous/resilience/multimodal wirein patterns).

## Feature flag

`MASC_TOOL_EMISSION=1` to activate. Default off — no behavioural change for existing operators. Independent of `MASC_MULTIMODAL` (K1) — both must be on for the full chain.

## Build status (honest)

All 3 touched modules typecheck clean: `cmi` / `cmx` GREEN for `Keeper_post_turn`, `Keeper_run_tools`, `Keeper_tool_emission_hook`.

`dune build lib/` is currently blocked by the pre-existing `ProviderFailure` exhaustiveness main blocker. Fix is in flight at:
- **#12153** — lib partial-match arms (6 files)
- **#12154** — K4 test `tool_schedule` record construction

Both must merge for K4 + K4b to fully validate. K4b itself does not introduce any new build issues.

## Test plan

- [ ] #12153 + #12154 merge → main builds clean
- [ ] this PR rebases onto green main
- [ ] `dune runtest test/test_keeper_tool_emission_hook.exe` 9/9 GREEN
- [ ] manual: `MASC_TOOL_EMISSION=1 MASC_MULTIMODAL=1` + keeper agent runs a tool whose output JSON has `__multimodal_kind` + `__multimodal_id` → artifact appears in `/api/v1/multimodal/list` within one turn
- [ ] gallery: F1 view (`/dashboard/b/multimodal`) shows the artifact within 5s of next poll

## Cross-keeper attribution caveat (deferred)

The `global_accumulator` is shared across all keepers. If keeper A's turn drains items emitted during keeper B's PostToolUse, attribution `created_by` will be assigned to A. In practice this is rare (heartbeat scheduling serialises most keeper turns) and acceptable for the initial production-loop wire-up. A future PR can add per-keeper accumulators if observation shows attribution drift in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)