### PR TITLE
specs(cascade): adopt [@@deriving tla] on cascade_strategy.kind

### DIFF
--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -154,13 +154,14 @@ let backoff_ms policy ~cycle =
     min policy.backoff_cap_ms raw
 
 type kind =
-  | Failover
-  | Capacity_aware
-  | Weighted_random
-  | Circuit_breaker_cycling
-  | Priority_tier
-  | Sticky
-  | Round_robin
+  | Failover [@tla.symbol "failover"]
+  | Capacity_aware [@tla.symbol "capacity_aware"]
+  | Weighted_random [@tla.symbol "weighted_random"]
+  | Circuit_breaker_cycling [@tla.symbol "circuit_breaker_cycling"]
+  | Priority_tier [@tla.symbol "priority_tier"]
+  | Sticky [@tla.symbol "sticky"]
+  | Round_robin [@tla.symbol "round_robin"]
+[@@deriving tla]
 
 let kind_to_string = function
   | Failover -> "failover"

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -172,6 +172,11 @@ type kind =
         single cycle, the rotated order is preserved (Failover
         within); cross-call fairness comes from the cursor.
         @since 0.9.7 *)
+[@@deriving tla]
+(** [@@deriving tla] generates [to_tla_symbol] (kind -> string),
+    [all_symbols] (string list), and [all_states] (kind list) so
+    [specs/boundary/CascadeStrategy.tla] string literals stay
+    drift-free with the OCaml type. PPX adoption per Cycle 18. *)
 
 val kind_to_string : kind -> string
 


### PR DESCRIPTION
## Summary

Second `[@@deriving tla]` adoption per Cycle 14 audit (#12143). The first was resilience (#12150). PR #12149 §3.1 identified `cascade_strategy.kind` as the prime boundary-domain mappable candidate.

## Changes

```ocaml
(* lib/cascade/cascade_strategy.ml *)
type kind =
  | Failover [@tla.symbol "failover"]
  | Capacity_aware [@tla.symbol "capacity_aware"]
  | Weighted_random [@tla.symbol "weighted_random"]
  | Circuit_breaker_cycling [@tla.symbol "circuit_breaker_cycling"]
  | Priority_tier [@tla.symbol "priority_tier"]
  | Sticky [@tla.symbol "sticky"]
  | Round_robin [@tla.symbol "round_robin"]
[@@deriving tla]
```

`[@tla.symbol]` overrides match the snake_case convention used by `cascade_strategy_trace` and the corresponding TLA spec literals.

No `dune` change needed — main `lib/dune` already has `ppx_tla` in its preprocess pps list.

## What's preserved

Hand-written `kind_to_string` and `all_kinds` remain. The PPX adds new `to_tla_symbol`, `all_symbols`, `all_states` helpers without colliding.

## Coverage growth

`ppx_deriving_tla_modules`: 4 → **5** (autonomous, keeper, multimodal, resilience #12150, +cascade)

## Test plan

- [x] `dune build --root . lib/` exit 0 (warnings unrelated, pre-existing)
- [x] `[@tla.symbol]` strings match `cascade_strategy_trace` symbol convention
- [ ] CI runs full test suite

## References

- PR #12143 — Cycle 14 audit (parent)
- PR #12150 — first adoption (resilience)
- PR #12149 — boundary spot-check identified this candidate
- `specs/boundary/CascadeStrategy.tla` — TLA spec this links to

🤖 Generated with [Claude Code](https://claude.com/claude-code)
