### PR TITLE
specs(autonomous): add AutonomousPhase Bug Model (RFC-Q2-2)

### DIFF
--- a/specs/autonomous/AutonomousPhase-buggy.cfg
+++ b/specs/autonomous/AutonomousPhase-buggy.cfg
@@ -1,0 +1,17 @@
+\* Buggy model: GADT type-level constraint bypassed (e.g. via
+\* Obj.magic or serialisation round-trip), allowing illegal phase
+\* transition. Expected: OnlyLegalTransitions VIOLATED in 1 step
+\* after Init.
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxHistory = 4
+
+CONSTRAINT
+    BoundedHistory
+
+INVARIANTS
+    TypeOK
+    StartedAtIdle
+    CurrentMatchesHead
+    OnlyLegalTransitions

--- a/specs/autonomous/AutonomousPhase.tla
+++ b/specs/autonomous/AutonomousPhase.tla
@@ -87,6 +87,28 @@ Spec == Init /\ [][Next]_vars
 
 BoundedHistory == Len(history) <= MaxHistory
 
+\* ── Bug model (RFC-Q2-2) ────────────────────────────────────────
+\*
+\* Models the bug class where an illegal phase transition slips past
+\* the OCaml-side GADT guard and reaches the runtime history. The
+\* GADT in [Autonomous_phase.Transition.t : ('from, 'to_) t] makes
+\* this unconstructible at the type level, but the spec verifies
+\* that even if the constraint were lifted (e.g. via Obj.magic or a
+\* serialisation round-trip), [OnlyLegalTransitions] catches it.
+
+IllegalStep(next_phase) ==
+    /\ next_phase \in Phases
+    /\ next_phase /= current  \* skip the trivial self-loop case
+    /\ <<current, next_phase>> \notin LegalTransitions
+    /\ current' = next_phase
+    /\ history' = Append(history, next_phase)
+
+NextBuggy ==
+    \/ Next
+    \/ \E next_phase \in Phases : IllegalStep(next_phase)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
 THEOREM Spec => []TypeOK
 THEOREM Spec => []StartedAtIdle
 THEOREM Spec => []CurrentMatchesHead


### PR DESCRIPTION
## Summary

First Phase 3 RFC stub implementation (PR #12137 §RFC-Q2-2). Adds Bug Model to `specs/autonomous/AutonomousPhase.tla`.

## Bug class

Models the case where the GADT type-level constraint `[Autonomous_phase.Transition.t : ('from, 'to_) t]` is bypassed (e.g. via `Obj.magic` or a serialisation round-trip), allowing an illegal phase transition to reach the runtime history.

## Changes

```tla
IllegalStep(next_phase) ==
    /\ next_phase \in Phases
    /\ next_phase /= current
    /\ <<current, next_phase>> \notin LegalTransitions
    /\ current' = next_phase
    /\ history' = Append(history, next_phase)

NextBuggy ==
    \/ Next
    \/ \E next_phase \in Phases : IllegalStep(next_phase)

SpecBuggy == Init /\ [][NextBuggy]_vars
```

`AutonomousPhase-buggy.cfg` declares `SPECIFICATION SpecBuggy` with the same invariants as the clean cfg.

## Expected TLC behaviour

- **Clean cfg**: passes `OnlyLegalTransitions` (current state)
- **Buggy cfg**: violates `OnlyLegalTransitions` in 1 step after Init

If both pass or both fail, the spec is broken (per CLAUDE.md `TLA+ Bug Model 패턴`). CI's TLA+ Model Checking job is the definitive verification.

## Phase 3 progress

Reduces zero-Bug-Model coverage domains: 5 → **4** (autonomous still has 1 remaining: AutonomousLoop / RFC-Q2-1).

This is the **strong-invariant case** (per PR #12137 §3): `OnlyLegalTransitions` was already declared in the clean cfg, so no prerequisite invariant strengthening was needed.

## Naming

Uses canonical `NextBuggy` / `SpecBuggy` (per Cycle 13 unification, PR #12138).

## Test plan

- [x] `IllegalStep` excludes self-loop (`next_phase /= current`) to avoid trivial violations
- [x] `NextBuggy` extends `Next`, not replaces (clean transitions still allowed)
- [x] Buggy cfg uses same invariants as clean
- [ ] TLC clean: passes (`make check-clean` — runs in CI)
- [ ] TLC buggy: violates `OnlyLegalTransitions` (`make check-buggy` — runs in CI)

## References

- PR #12137 — Phase 3 RFC stubs (parent, RFC-Q2-2 source)
- PR #12138 — NextBuggy/SpecBuggy naming unification
- `lib/autonomous/autonomous_phase.{ml,mli}` — runtime side (GADT `Transition.t`)
- CLAUDE.md `TLA+ Bug Model 패턴`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
