### PR TITLE
Fix shared test dependency for keeper tool emission hook

### DIFF
--- a/test/deps/dune
+++ b/test/deps/dune
@@ -51,6 +51,7 @@
    (re_export mirage-crypto)
    (re_export mirage-crypto-rng)
    (re_export mirage-crypto-rng.unix)
+   (re_export multimodal)
    (re_export ocaml-protoc-plugin)
    (re_export ocaml-webrtc)
    (re_export qcheck-alcotest)


### PR DESCRIPTION
## Summary
- add `multimodal` to the shared `masc_test_deps` re-export list
- keep `test_keeper_tool_emission_hook` compiling after the Agent SDK schedule record update already present on main

## Context
- ProviderFailure handling and related CI cleanups landed on main via #12182 while this PR was in flight.
- This PR is now reduced to the remaining shared test dependency gap.

## Validation
- git diff --check
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_keeper_tool_emission_hook.exe
- ./_build/default/test/test_keeper_tool_emission_hook.exe