### PR TITLE
fix(dashboard_bonsai): unblock build under bonsai-dashboard switch

### DIFF
--- a/dashboard_bonsai/src/keepers_directory.ml
+++ b/dashboard_bonsai/src/keepers_directory.ml
@@ -434,8 +434,16 @@ let row_click_effect name =
   let select () = Bonsai.Expert.Var.set selected_name_var (Some name) in
   [ Attr.on_click (fun _ -> Effect.of_sync_fun select ())
   ; Attr.on_keydown (fun ev ->
-      let open Virtual_dom.Vdom.Event.Keyboard in
-      if Key.equal ev.key Key.Enter || Key.equal ev.key (Key.of_string " ")
+      (* Vdom keyboard event API moved out of Virtual_dom.Vdom.Event
+         in newer bonsai_web; read the raw JS [key] field instead.
+         Same activation contract as the click handler. *)
+      let key_str =
+        Js_of_ocaml.Js.Optdef.case
+          ev##.key
+          (fun () -> "")
+          Js_of_ocaml.Js.to_string
+      in
+      if String.equal key_str "Enter" || String.equal key_str " "
       then Effect.of_sync_fun select ()
       else Effect.of_sync_fun (fun () -> ()) ())
   ]

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1485,7 +1485,12 @@ let view_heartbeat ?(entries : Logs_types.entry list = []) () =
     | [] -> heartbeat_bars
     | _ -> heartbeat_bars_of_entries entries
   in
-  let active = List.count ~f:(fun (_, l) -> l <> `Idle) bars in
+  let active =
+    List.count bars ~f:(fun (_, l) ->
+      match l with
+      | `Idle -> false
+      | `Info | `Warn | `Error -> true)
+  in
   let max_height = List.fold bars ~init:0 ~f:(fun acc (h, _) -> Int.max acc h) in
   let aria_desc =
     Printf.sprintf
@@ -1762,7 +1767,7 @@ let render_response
                      (fun el ->
                         el##setAttribute
                           (Js.string "aria-pressed")
-                          (Js.string (if lvl = level then "true" else "false")))
+                          (Js.string (if String.equal lvl level then "true" else "false")))
                  in
                  update "debug"; update "info"; update "warn"; update "error")
                ()
@@ -1772,13 +1777,21 @@ let render_response
                [ Style.chip
                ; Attr.create "data-filter-level" level
                ; Attr.role "button"
-               ; Attr.create "aria-pressed" (if level = "info" then "true" else "false")
+               ; Attr.create "aria-pressed" (if String.equal level "info" then "true" else "false")
                ; Attr.tabindex 0
                ; Attr.on_click (fun _ev -> fire ())
-               ; Attr.on_key_down (fun ev ->
-                   let open Virtual_dom.Vdom.Event.Keyboard in
-                   if Key.equal ev.key Key.Enter
-                      || Key.equal ev.key (Key.of_string " ")
+               ; Attr.on_keydown (fun ev ->
+                   (* Vdom keyboard event API moved out of
+                      Virtual_dom.Vdom.Event in newer bonsai_web.
+                      Read the raw JS [key] field instead. *)
+                   let key_str =
+                     Js_of_ocaml.Js.Optdef.case
+                       ev##.key
+                       (fun () -> "")
+                       Js_of_ocaml.Js.to_string
+                   in
+                   if String.equal key_str "Enter"
+                      || String.equal key_str " "
                    then fire ()
                    else Effect.of_sync_fun (fun () -> ()) ())
                ]
@@ -1938,7 +1951,7 @@ let render_response
                      (fun el ->
                         el##setAttribute
                           (Js.string "aria-pressed")
-                          (Js.string (if n = name then "true" else "false")))
+                          (Js.string (if String.equal n name then "true" else "false")))
                  in
                  update "dark"; update "cyber"; update "term";
                  update "parchment"; update "paper")
@@ -1949,13 +1962,21 @@ let render_response
                [ Style.theme_chip
                ; Attr.create "data-chip-theme" name
                ; Attr.role "button"
-               ; Attr.create "aria-pressed" (if name = "dark" then "true" else "false")
+               ; Attr.create "aria-pressed" (if String.equal name "dark" then "true" else "false")
                ; Attr.tabindex 0
                ; Attr.on_click (fun _ -> fire ())
-               ; Attr.on_key_down (fun ev ->
-                   let open Virtual_dom.Vdom.Event.Keyboard in
-                   if Key.equal ev.key Key.Enter
-                      || Key.equal ev.key (Key.of_string " ")
+               ; Attr.on_keydown (fun ev ->
+                   (* Vdom keyboard event API moved out of
+                      Virtual_dom.Vdom.Event in newer bonsai_web.
+                      Read the raw JS [key] field instead. *)
+                   let key_str =
+                     Js_of_ocaml.Js.Optdef.case
+                       ev##.key
+                       (fun () -> "")
+                       Js_of_ocaml.Js.to_string
+                   in
+                   if String.equal key_str "Enter"
+                      || String.equal key_str " "
                    then fire ()
                    else Effect.of_sync_fun (fun () -> ()) ())
                ]


### PR DESCRIPTION
## Summary

Three pre-existing issues prevented `dashboard_bonsai_lib` from compiling under the current `bonsai-dashboard` opam switch. Discovered while validating F1 #12136 (multimodal gallery view) — F1's own modules typecheck clean, but the surrounding lib failed to link.

## Fixes

### 1. `logs_view.ml:1488` — `List.count` type inference

```ocaml
(* Before: label-first form drove inference toward int return *)
let active = List.count ~f:(fun (_, l) -> l <> `Idle) bars in

(* After: positional-arg-first + explicit variant match *)
let active =
  List.count bars ~f:(fun (_, l) ->
    match l with
    | `Idle -> false
    | `Info | `Warn | `Error -> true)
in
```

Under newer Core/Base with locality annotations, the label-first form drove inference to expect `f : 'a -> int`. Reordering plus an explicit variant match makes the boolean intent unambiguous.

### 2. `Virtual_dom.Vdom.Event.Keyboard` removed (3 sites)

`keepers_directory.ml:437`, `logs_view.ml:1783`, `logs_view.ml:1960` all opened `Virtual_dom.Vdom.Event.Keyboard` which no longer exists. Replaced with direct JS `KeyboardEvent.key` read:

```ocaml
let key_str =
  Js_of_ocaml.Js.Optdef.case
    ev##.key
    (fun () -> "")
    Js_of_ocaml.Js.to_string
in
if String.equal key_str "Enter" || String.equal key_str " "
then fire ()
else Effect.of_sync_fun (fun () -> ()) ()
```

Same Enter / Space activation contract as before. The newer `Vdom_keyboard` library exists but the lighter raw-key approach matches the simple two-key check we actually do.

### 3. Polymorphic `=` on strings (4 sites)

Under `open! Core`, `Stdlib.(=)` is shadowed to int-only equality. Sites:
- `logs_view.ml:1770` — `lvl = level` → `String.equal lvl level`
- `logs_view.ml:1780` — `level = "info"` → `String.equal level "info"`
- `logs_view.ml:1954` — `n = name` → `String.equal n name`
- `logs_view.ml:1965` — `name = "dark"` → `String.equal name "dark"`

### 4. `Attr.on_key_down` → `Attr.on_keydown` (2 sites)

Current attribute name in `Virtual_dom.Vdom.Attr`. Two sites in `logs_view.ml`.

## Build status

`dune build --root .` GREEN under the `bonsai-dashboard` opam switch (5.2.0+ox compiler).

## Relationship to F1 #12136

F1 added the multimodal gallery view (`multimodal_view.ml` + types/var/fetch + route/app/main wiring). F1's 4 new modules typecheck clean individually. This PR fixes the surrounding lib so the full `dashboard_bonsai_lib` (including F1) can build and js_of_ocaml-compile to `main.bc.js`.

After this PR + F1 land, `/dashboard/b/multimodal` actually loads in the running dashboard.

## Test plan

- [ ] `dune build --root .` GREEN under bonsai-dashboard switch
- [ ] `main.bc.js` js_of_ocaml output produced
- [ ] manual: keyboard activation (Enter / Space) on log-level chips + theme chips + keepers-directory rows still works after refactor
- [ ] manual: aria-pressed reflects current selection (the 4 fixed `=` sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)