### PR TITLE
Fix ProviderFailure OAS compatibility classifiers

### DIFF
--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -61,11 +61,13 @@ let format_exhausted_error last_err =
     | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
       Printf.sprintf "%s provider requires a CLI transport" kind
     | Some (Llm_provider.Http_client.NetworkError { message; _ }) -> message
-    | Some (Llm_provider.Http_client.ProviderTerminal _ as err) ->
+    | Some (Llm_provider.Http_client.ProviderTerminal _ as err)
+    | Some (Llm_provider.Http_client.ProviderFailure _ as err) ->
       (* Mirror the rendering shape used elsewhere on main HEAD
          (tool_local_runtime_bench / verify): "provider terminal:
-         <kind>: <message>". The boundary adapter
-         [Oas_compat.Http_client.error_message] supplies that exact
+         <kind>: <message>" and ProviderFailure's typed formatter.
+         The boundary adapter [Oas_compat.Http_client.error_message] supplies
+         that exact
          format, so future variant additions only break the adapter. *)
       Oas_compat.Http_client.error_message err
     | None -> "No providers available"

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -26,6 +26,7 @@ type cascade_failure_class =
   | Cli_transport_required
   | Network_error
   | Provider_terminal
+  | Provider_failure
 
 let classify_failure err = Oas_compat.Http_client.classify err
 

--- a/lib/cascade/cascade_health_filter.mli
+++ b/lib/cascade/cascade_health_filter.mli
@@ -25,6 +25,7 @@ type cascade_failure_class =
   | Cli_transport_required
   | Network_error
   | Provider_terminal
+  | Provider_failure
 
 val classify_failure :
   Llm_provider.Http_client.http_error -> cascade_failure_class

--- a/lib/cascade/cascade_pool_router.ml
+++ b/lib/cascade/cascade_pool_router.ml
@@ -14,9 +14,6 @@ let create () =
     Cascade_pool.create Cascade_pool.Emergency ~provider_keys:[]
   in
   let pools = [tier1; tier2; emergency] in
-  if pools = [] then
-    failwith "Cascade_pool_router.create: configuration produced an empty pool set"
-  ;
   let keeper_pool_map = Hashtbl.create 64 in
   { pools; keeper_pool_map }
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -385,7 +385,6 @@ module KeeperKeepalive = struct
   let turn_timeout_sec =
     Float.max 60.0 (Float.min timeout_hard_ceiling_sec
       (get_float ~default:3600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
->>>>>>> 8a608170c8 (feat(resilience): bulkhead pattern - ZOMBIE state, terminal_failure_latched, cascade pool)
 
   (** Maximum time a proactive keeper will wait in the MASC admission queue
       before abandoning the current OAS attempt.

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -18,13 +18,23 @@ let severity_to_string = function
   | Warn -> "warn"
   | Bad -> "bad"
 
-let severity_of_code = function
-  | "success" -> Ok
+let known_severity_of_code = function
+  | "success" -> Some Ok
   | "external_cancel"
   | "oas_timeout_budget"
   | "turn_wall_clock_timeout"
-  | "gh_repo_context_missing_worktree" -> Warn
-  | _ -> Bad
+  | "gh_repo_context_missing_worktree" -> Some Warn
+  | "required_tool_use_no_tool_call"
+  | "required_tool_use_unsatisfied"
+  | "post_commit_ambiguous"
+  | "provider_error"
+  | "unknown_error" -> Some Bad
+  | _ -> None
+
+let severity_of_code code =
+  match known_severity_of_code code with
+  | Some severity -> severity
+  | None -> Bad
 
 let summary_of_code = function
   | "success" -> "turn completed"

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -19,6 +19,11 @@ module Http_client = struct
             collapsed here because [should_cascade] only needs the
             terminality bit; consumers wanting the message extract it
             via the original [ProviderTerminal] match. *)
+    | Provider_failure
+        (** OAS [ProviderFailure] — provider/runtime failure classified at
+            the transport edge. Treat as per-provider by default so the
+            cascade can try another provider instead of terminating on
+            one lane's capacity, quota, capability, CLI, or parse failure. *)
 
   (* Case-insensitive substring check, mirroring [cascade_health_filter]. *)
   let contains_ci ?(max_scan = 512) ~haystack ~needle () =
@@ -102,6 +107,8 @@ module Http_client = struct
           Cli_transport_required
       | Llm_provider.Http_client.ProviderTerminal _ ->
           Provider_terminal
+      | Llm_provider.Http_client.ProviderFailure _ ->
+          Provider_failure
       | Llm_provider.Http_client.NetworkError _ -> Network_error
 
   let should_cascade (err : Llm_provider.Http_client.http_error) : bool =
@@ -116,7 +123,8 @@ module Http_client = struct
     | Transient_http _
     | Accept_rejected_capability_mismatch
     | Cli_transport_required
-    | Network_error ->
+    | Network_error
+    | Provider_failure ->
         true
 
   let error_message (err : Llm_provider.Http_client.http_error) : string =
@@ -132,6 +140,8 @@ module Http_client = struct
     | Llm_provider.Http_client.ProviderTerminal
         { kind = Llm_provider.Http_client.Other subtype; message } ->
         Printf.sprintf "provider terminal: %s: %s" subtype message
+    | Llm_provider.Http_client.ProviderFailure { kind; message } ->
+        Llm_provider.Http_client.provider_failure_to_string ~kind ~message
     | Llm_provider.Http_client.HttpError { code; body } -> (
         try
           let json = Yojson.Safe.from_string body in

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -32,6 +32,7 @@ module Http_client : sig
     | Cli_transport_required
     | Network_error
     | Provider_terminal
+    | Provider_failure
 
   val classify : Llm_provider.Http_client.http_error -> cascade_failure_class
   (** Classify an OAS HTTP/client failure into MASC's typed cascade boundary.

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -369,6 +369,9 @@ let run_named
             { kind = Llm_provider.Http_client.Other subtype; message }) ->
             Keeper_types.Other_detail
               (Printf.sprintf "provider terminal %s: %s" subtype message)
+        | Some (Llm_provider.Http_client.ProviderFailure _ as err) ->
+            Keeper_types.Other_detail
+              (Oas_compat.Http_client.error_message err)
         | None -> Keeper_types.No_providers_available
       in
       let observation =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -28,6 +28,8 @@ let error_message_of_http_error = function
   | Llm_provider.Http_client.ProviderTerminal
       { kind = Llm_provider.Http_client.Other subtype; message } ->
       Printf.sprintf "provider terminal: %s: %s" subtype message
+  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
+      Llm_provider.Http_client.provider_failure_to_string ~kind ~message
   | Llm_provider.Http_client.HttpError { code; body } -> (
       try
         let json = Yojson.Safe.from_string body in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -130,6 +130,8 @@ let error_message_of_http_error = function
   | Llm_provider.Http_client.ProviderTerminal
       { kind = Llm_provider.Http_client.Other subtype; message } ->
       Printf.sprintf "provider terminal: %s: %s" subtype message
+  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
+      Llm_provider.Http_client.provider_failure_to_string ~kind ~message
   | Llm_provider.Http_client.HttpError { code; body } -> (
       try
         let json = Yojson.Safe.from_string body in

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 2,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 994,
+  "lib_dune_lines": 998,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 1
 }

--- a/test/dune
+++ b/test/dune
@@ -402,7 +402,7 @@
           test_keeper_turn_fsm_wired_sites
           test_keeper_tool_emission_hook
           )
- (libraries masc_test_deps))
+ (libraries masc_test_deps multimodal))
 
 ; ============================================================
 ; Group 2: Property-based tests (QCheck)

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -13,6 +13,15 @@ module H = Masc_mcp.Keeper_tool_emission_hook
 module THooks = Agent_sdk.Hooks
 module TT = Agent_sdk.Types
 
+let dummy_schedule : THooks.tool_schedule =
+  {
+    planned_index = 0;
+    batch_index = 0;
+    batch_size = 1;
+    concurrency_class = "default";
+    batch_kind = "sequential";
+  }
+
 let with_env_set name value f =
   let prev = Sys.getenv_opt name in
   Unix.putenv name value;
@@ -41,7 +50,7 @@ let make_post_tool_use ~content : THooks.hook_event =
     ; output = Ok ({ TT.content } : TT.tool_output)
     ; result_bytes = String.length content
     ; duration_ms = 1.0
-    ; schedule = THooks.Now
+    ; schedule = dummy_schedule
     }
 
 let make_pre_tool_use () : THooks.hook_event =
@@ -51,7 +60,7 @@ let make_pre_tool_use () : THooks.hook_event =
     ; input = `Assoc []
     ; accumulated_cost_usd = 0.0
     ; turn = 1
-    ; schedule = THooks.Now
+    ; schedule = dummy_schedule
     }
 
 let make_post_tool_use_error () : THooks.hook_event =
@@ -67,7 +76,7 @@ let make_post_tool_use_error () : THooks.hook_event =
            } : TT.tool_error)
     ; result_bytes = 0
     ; duration_ms = 0.5
-    ; schedule = THooks.Now
+    ; schedule = dummy_schedule
     }
 
 let assert_eq_int ~label expected actual =

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -129,6 +129,34 @@ let test_provider_terminal_other () =
     (Astring.String.is_infix ~affix:"structured_terminal_subtype" rendered
      && Astring.String.is_infix ~affix:"provider signalled" rendered)
 
+let test_provider_failure_cascades_and_renders () =
+  let err =
+    Http_client.ProviderFailure
+      {
+        kind =
+          Capacity_exhausted
+            {
+              scope = Failure_scope_model;
+              retry_after = Some 30.0;
+              model = Some "gemini-2.5-pro";
+            };
+        message = "model capacity exhausted";
+      }
+  in
+  Alcotest.(check bool)
+    "ProviderFailure must cascade — typed provider failure is lane-specific"
+    true
+    (Oas_compat.Http_client.should_cascade err);
+  (match Oas_compat.Http_client.classify err with
+   | Provider_failure -> ()
+   | _ -> Alcotest.fail "ProviderFailure must classify as Provider_failure");
+  let rendered = Oas_compat.Http_client.error_message err in
+  Alcotest.(check bool)
+    "error_message renders typed provider failure kind + message"
+    true
+    (Astring.String.is_infix ~affix:"capacity_exhausted:model" rendered
+     && Astring.String.is_infix ~affix:"model capacity exhausted" rendered)
+
 let test_error_message_baseline () =
   (* Smoke check that the new helper preserves existing semantics for
      the variants that already had inline matches at the call sites. *)
@@ -174,6 +202,11 @@ let () =
             `Quick test_provider_terminal_max_turns;
           Alcotest.test_case "Other classify + cascade + message"
             `Quick test_provider_terminal_other;
+        ] );
+      ( "ProviderFailure — typed lane failure cascades",
+        [
+          Alcotest.test_case "classify + cascade + message"
+            `Quick test_provider_failure_cascades_and_renders;
         ] );
       ( "error_message helper baseline",
         [


### PR DESCRIPTION
## Summary
- handle OAS ProviderFailure in MASC cascade classification and error-message rendering
- re-export Provider_failure through cascade_health_filter for typed call sites
- remove a stray env_config_keeper conflict marker discovered while running the issue repro build
- fix inherited #8605-family lint failure in keeper_turn_terminal severity parsing
- update keeper tool emission hook tests for the current OAS hook schedule record shape and link multimodal in the test stanza
- refresh the lib/dune line-count ratchet baseline to current main (tracked by #12077)
- remove the unreachable cascade pool router failwith so the Health lib ratchet stays at zero
- add a ProviderFailure cascade/message regression test

Closes #12122.
Closes #12156.
Closes #12177.
Closes #12191.
Refs #12077.

## Validation
- git diff --check origin/main...HEAD
- bash scripts/lint/no-unknown-permissive-default.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe test/test_dashboard_execution.exe
- scripts/dune-local.sh build @check
- scripts/dune-local.sh exec ./test/test_keeper_terminal_reason.exe
- scripts/dune-local.sh exec ./test/test_keeper_tool_emission_hook.exe
- _build/default/test/test_oas_compat_cascade_fallback.exe
- bash scripts/health_snapshot.sh --json-out /tmp/health-12191.json --baseline-ref origin/main --fail-on-lib-regression
