### PR TITLE
specs(audit_log): adopt [@@deriving tla] on outcome

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -15,8 +15,9 @@ module StringMap = Map.Make (String)
 (** {1 Types} *)
 
 type outcome =
-  | Success
-  | Failure of string
+  | Success [@tla.symbol "success"]
+  | Failure of string [@tla.symbol "failure"]
+[@@deriving tla]
 
 type governance_audit_decision =
   | Governance_allow

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -29,6 +29,7 @@ type config = Coord_utils.config
 type outcome =
   | Success
   | Failure of string
+[@@deriving tla]
 
 type governance_audit_decision =
   | Governance_allow


### PR DESCRIPTION
## Summary

Third `[@@deriving tla]` adoption (resilience #12150, cascade #12158 preceded). Boundary 18-spec full sweep (#12159) §3 priority 4 candidate — smallest variant set, fastest adoption.

```ocaml
(* lib/audit_log.ml *)
type outcome =
  | Success [@tla.symbol "success"]
  | Failure of string [@tla.symbol "failure"]
[@@deriving tla]
```

Demonstrates `ppx_tla`'s payload-aware `to_tla_symbol` generation — `Failure of string` carries a payload but the symbol mapping is well-defined per `[@tla.symbol]` override. `all_states` cannot be generated (payload-bearing constructor), but `all_symbols` (`string list`) can.

## Coverage growth

`ppx_deriving_tla_modules`: 5 → **6**.

## Why this one first (sweep §5 ordering)

Sweep ranked 4 candidates: (1) CascadeStrategy.kind, (2) AuditLog.action ~20, (3) AuditLog.governance_audit_decision (7), (4) AuditLog.outcome (2). Adopting smallest first de-risks the larger AuditLog.action / governance_audit_decision adoptions — same dune surface, same preprocess setup.

## Test plan

- [x] `dune build --root . @lib/check` exits 0 (warnings unrelated, pre-existing)
- [x] `[@tla.symbol]` overrides applied to both nullary and payload-bearing constructors

## References

- PR #12143 — Cycle 14 audit
- PR #12150, #12158 — sibling adoptions
- PR #12159 — boundary sweep that ranked this candidate
- `lib/audit_log.{ml,mli}` — adoption site

🤖 Generated with [Claude Code](https://claude.com/claude-code)
