### PR TITLE
specs(multimodal): add MultimodalArtifact Bug Model (RFC-Q2-4)

### DIFF
--- a/specs/multimodal/MultimodalArtifact-buggy.cfg
+++ b/specs/multimodal/MultimodalArtifact-buggy.cfg
@@ -1,0 +1,19 @@
+\* Buggy model: hydrator AddEdge bypasses artifact presence checks,
+\* allowing edges into non-present artifacts. Expected:
+\* DAGRefIntegrity VIOLATED in 1 step after first edge.
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    ArtifactIds = {a1, a2}
+    Personas = {executor}
+
+INVARIANTS
+    TypeOK
+    ArtifactIdMatchesKey
+    DAGRefIntegrity
+    NoSelfLoops
+    DAGAcyclic
+    ProvenanceOriginsLive
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/multimodal/MultimodalArtifact.tla
+++ b/specs/multimodal/MultimodalArtifact.tla
@@ -194,6 +194,31 @@ Next ==
 
 Spec == Init /\ [][Next]_vars
 
+\* ── Bug model (RFC-Q2-4) ────────────────────────────────────────
+\*
+\* Models the bug class where the hydrator's [add_edge] precondition
+\* check on artifact presence is bypassed (e.g. a callsite passes a
+\* placeholder Artifact_id.t that has not yet been realised via
+\* CreateArtifact). The resulting DAG references a non-present
+\* artifact, violating DAGRefIntegrity.
+
+AddEdgeWithDeadEndpoint(from_id, to_id) ==
+    /\ from_id # to_id
+    /\ <<from_id, to_id>> \notin dag
+    /\ DAGAcyclicIn(dag \cup {<<from_id, to_id>>})
+    \* deliberately omitted: artifacts[<id>].present checks
+    /\ \/ ~artifacts[from_id].present
+       \/ ~artifacts[to_id].present
+    /\ dag' = dag \cup {<<from_id, to_id>>}
+    /\ UNCHANGED artifacts
+
+NextBuggy ==
+    \/ Next
+    \/ \E from_id \in ArtifactIds, to_id \in ArtifactIds :
+            AddEdgeWithDeadEndpoint(from_id, to_id)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
 THEOREM Spec => []TypeOK
 THEOREM Spec => []ArtifactIdMatchesKey
 THEOREM Spec => []DAGRefIntegrity


### PR DESCRIPTION
## Summary

Second Phase 3 RFC stub implementation (RFC-Q2-2 was AutonomousPhase in #12160). Adds Bug Model to `specs/multimodal/MultimodalArtifact.tla`.

## Bug class

Models the case where the hydrator's `add_edge` precondition check on artifact presence is bypassed (e.g. callsite passes a placeholder `Artifact_id.t` that has not yet been realised via `CreateArtifact`). The resulting DAG references a non-present artifact.

```tla
AddEdgeWithDeadEndpoint(from_id, to_id) ==
    /\ from_id # to_id
    /\ <<from_id, to_id>> \notin dag
    /\ DAGAcyclicIn(dag \cup {<<from_id, to_id>>})
    \* deliberately omitted: artifacts[<id>].present checks
    /\ \/ ~artifacts[from_id].present
       \/ ~artifacts[to_id].present
    /\ dag' = dag \cup {<<from_id, to_id>>}
    /\ UNCHANGED artifacts
```

The `~present` requirement forces the bug to actually fire (not just "skip the check" but also "produce an invalid edge").

## Expected TLC

- **Clean cfg**: passes `DAGRefIntegrity`
- **Buggy cfg**: violates `DAGRefIntegrity` in 1 step after first `AddEdgeWithDeadEndpoint`

## Phase 3 progress

Reduces zero-Bug-Model coverage domains: multimodal **0/2 → 1/2** (MultimodalHydrator still needs RFC-Q2-5 — that one is "needs prereq" per Phase 3 §3, requires `NoSelfLoop` cfg-level invariant first).

Naming follows Cycle 13 unification (`NextBuggy` / `SpecBuggy`).

## Test plan

- [x] `IllegalStep` ensures the bug actually triggers (`~present` requirement)
- [x] `NextBuggy` extends `Next`, not replaces (clean transitions remain)
- [x] Same invariant set in clean and buggy cfg (per CLAUDE.md pattern)
- [ ] TLC verification via `make check-clean` / `make check-buggy` (CI runs)

## References

- PR #12137 — Phase 3 RFC stubs (parent, RFC-Q2-4 source)
- PR #12138, #12160 — same Bug Model pattern
- `lib/multimodal/multimodal_hydrator.{ml,mli}` — runtime side (`add_edge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
