### PR TITLE
specs(resilience): add ResilienceOutcome Bug Model (RFC-Q2-7)

### DIFF
--- a/specs/resilience/ResilienceOutcome-buggy.cfg
+++ b/specs/resilience/ResilienceOutcome-buggy.cfg
@@ -1,0 +1,18 @@
+\* Buggy model: caller computes completed/failed sets without
+\* enforcing disjointness. Expected: CompletedFailedDisjoint
+\* VIOLATED in 1 step after first overlap-bearing AppendPartial.
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    ArtifactIds = {a1, a2}
+    Strategies = {Retry, Fallback, Handoff, Abort}
+
+CONSTRAINT
+    BoundedOutcomes
+
+INVARIANTS
+    TypeOK
+    ConfidenceInRange
+    DegradationLevelInRange
+    CompletedFailedDisjoint
+    RecoveryStrategyDeclared

--- a/specs/resilience/ResilienceOutcome.tla
+++ b/specs/resilience/ResilienceOutcome.tla
@@ -147,6 +147,40 @@ Next ==
 
 Spec == Init /\ [][Next]_vars
 
+\* ── Bug model (RFC-Q2-7) ────────────────────────────────────────
+\*
+\* Models the bug class where the caller computes [completed] and
+\* [failed] artifact sets without enforcing disjointness — e.g. a
+\* shared mutable state mutation lets the same artifact id land in
+\* both. The clean AppendPartial enforces completed \cap failed = {}
+\* at the precondition; the bug action drops that check.
+
+AppendPartialNonDisjoint(conf, completed, failed, level) ==
+    /\ conf \in 0..ConfidenceMax
+    /\ completed \subseteq ArtifactIds
+    /\ failed \subseteq ArtifactIds
+    \* deliberately omitted: completed \cap failed = {}
+    /\ completed \cap failed # {}  \* force overlap to actually happen
+    /\ level \in 1..4
+    /\ outcomes' =
+        Append(outcomes,
+               [ class |-> "partial",
+                 confidence_num |-> conf,
+                 degradation_level |-> level,
+                 completed |-> completed,
+                 failed |-> failed,
+                 recovery_strategy |-> CHOOSE s \in Strategies : TRUE ])
+
+NextBuggy ==
+    \/ Next
+    \/ \E conf \in {0, 50, 100},
+          completed \in SUBSET ArtifactIds,
+          failed \in SUBSET ArtifactIds,
+          level \in 1..4 :
+            AppendPartialNonDisjoint(conf, completed, failed, level)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
 \* State-space bound for TLC: keep the outcomes sequence small
 \* enough to enumerate exhaustively. Wired in via the .cfg
 \* CONSTRAINT clause.


### PR DESCRIPTION
## Summary

Third Phase 3 RFC stub implementation. Adds Bug Model to `specs/resilience/ResilienceOutcome.tla`.

## Bug class

Models the case where the caller computes `completed` and `failed` artifact sets without enforcing disjointness — e.g. shared mutable state mutation lets the same artifact id land in both sets.

```tla
AppendPartialNonDisjoint(conf, completed, failed, level) ==
    /\ conf \in 0..ConfidenceMax
    /\ completed \subseteq ArtifactIds
    /\ failed \subseteq ArtifactIds
    \* deliberately omitted: completed \cap failed = {}
    /\ completed \cap failed # {}  \* force overlap
    ...
```

## Pivot from RFC-Q2-7's original BugAction

Phase 3 RFC-Q2-7 originally proposed `FullSuccessWithDegradation` — emit a `class="full"` record with non-empty `degradation_level`. But the existing `DegradationLevelInRange` invariant only checks numeric range (1..4), not class correlation. The cleanest approach would be to first strengthen the invariant to "FullSuccess implies level=1", which is a separate prereq PR.

`AppendPartialNonDisjoint` is a cleaner fit for the invariants the spec **already declares** (`CompletedFailedDisjoint`). This is the discipline encoded in Phase 3 §3 — strong-invariant cases first, prereq cases later.

## Expected TLC

- **Clean cfg**: passes `CompletedFailedDisjoint`
- **Buggy cfg**: violates `CompletedFailedDisjoint` in 1 step

## Phase 3 progress

Reduces zero-Bug-Model coverage domains: resilience **0/2 → 1/2** (ResilienceDegradation RFC-Q2-6 still pending — strong-invariant case, queued).

## References

- PR #12137 — Phase 3 RFC stubs (parent, RFC-Q2-7 source)
- PR #12138, #12160, #12162 (sibling MultimodalArtifact) — same Bug Model pattern
- `lib/resilience/resilience_outcome.{ml,mli}` — runtime side

🤖 Generated with [Claude Code](https://claude.com/claude-code)
