### PR TITLE
keeper: restore typed autonomy bloodflow

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -6,7 +6,7 @@ category: keeper
 ## Rules (violating these wastes your turn budget)
 
 Before any file or path operation, follow this order:
-1. Call keeper_context_status. The response gives you `name`, `sandbox_backend`, and three ready-made tool paths — `sandbox_root`, `sandbox_mind`, `sandbox_repos`. Use these directly instead of reconstructing paths yourself.
+1. Call keeper_context_status. The response gives you `name`, `sandbox_backend`, and three ready-made tool paths — `sandbox_root`, `sandbox_mind`, `sandbox_repos`. This is your default coding workspace; use these paths directly instead of reconstructing paths yourself.
 2. If you need a subpath (e.g. a specific repo), append to `sandbox_repos` — e.g. `{sandbox_repos}/{repo-name}/{file}`.
 3. Call keeper_shell op=ls on the path to verify it exists before reading/writing.
 4. Then proceed with the file operation.

--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -61,14 +61,14 @@ let format_exhausted_error last_err =
     | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
       Printf.sprintf "%s provider requires a CLI transport" kind
     | Some (Llm_provider.Http_client.NetworkError { message; _ }) -> message
-    | Some (Llm_provider.Http_client.ProviderTerminal _ as err) ->
+    | Some
+        ( (Llm_provider.Http_client.ProviderTerminal _
+          | Llm_provider.Http_client.ProviderFailure _) as err ) ->
       (* Mirror the rendering shape used elsewhere on main HEAD
          (tool_local_runtime_bench / verify): "provider terminal:
          <kind>: <message>". The boundary adapter
          [Oas_compat.Http_client.error_message] supplies that exact
          format, so future variant additions only break the adapter. *)
-      Oas_compat.Http_client.error_message err
-    | Some (Llm_provider.Http_client.ProviderFailure _ as err) ->
       Oas_compat.Http_client.error_message err
     | None -> "No providers available"
   in

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -26,7 +26,13 @@ type cascade_failure_class =
   | Cli_transport_required
   | Network_error
   | Provider_terminal
+  | Provider_capacity_exhausted
   | Provider_hard_quota
+  | Provider_capability_mismatch
+  | Provider_cli_policy_invalid
+  | Provider_cli_startup_failed
+  | Provider_failure_parse_error
+  | Provider_failure_unknown
 
 let classify_failure err = Oas_compat.Http_client.classify err
 

--- a/lib/cascade/cascade_health_filter.mli
+++ b/lib/cascade/cascade_health_filter.mli
@@ -25,7 +25,13 @@ type cascade_failure_class =
   | Cli_transport_required
   | Network_error
   | Provider_terminal
+  | Provider_capacity_exhausted
   | Provider_hard_quota
+  | Provider_capability_mismatch
+  | Provider_cli_policy_invalid
+  | Provider_cli_startup_failed
+  | Provider_failure_parse_error
+  | Provider_failure_unknown
 
 val classify_failure :
   Llm_provider.Http_client.http_error -> cascade_failure_class

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -50,7 +50,7 @@ let run_turn
          base_system_prompt:string -> messages:Oas.Types.message list -> turn_prompt)
       ~(user_message : string)
       ~(cascade_name : string)
-      ?structured_world_observation
+      ?world_observation
       ?(turn_affordances = [])
       ?provider_filter
       ~(generation : int)
@@ -672,22 +672,18 @@ let run_turn
              ~history_messages
              ~actual_input_tokens:usage.input_tokens
          in
-         (* Classify the most-specific actionable signal observed in the
-            structured world snapshot, applying the P1 affordance-tool intersection so
-            keepers without the corresponding action tool degrade to
-            [No_actionable_signal] (cf. [keeper_contract_classifier.mli]
-            precedence: unclaimed > board > discovered).
-
-            The boolean [actionable_signal_context] is derived from the
-            kind for backward compatibility with downstream callers; the
-            kind itself flows into violation log/metric labels so
-            operators can see *which* signal class the LLM failed on. *)
+         (* Classify the most-specific actionable signal from the structured
+            keeper world snapshot. This deliberately avoids re-parsing the
+            rendered prompt text; prompt copy may change without changing the
+            deterministic contract gate. *)
          let actionable_signal_kind : Keeper_contract_classifier.actionable_signal =
-           match structured_world_observation with
-           | Some observation ->
-             Keeper_contract_classifier.classify_actionable_signal_with_allowed_tools
-               ~allowed_tool_names:all_tool_names observation
+           match world_observation with
            | None -> No_actionable_signal
+           | Some observation ->
+               observation
+               |> Keeper_contract_classifier.of_keeper_world_observation
+               |> Keeper_contract_classifier.classify_actionable_signal_for_tools
+                    ~allowed_tool_names:all_tool_names
          in
          let actionable_signal_context =
            Keeper_agent_tool_surface

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -209,7 +209,7 @@ val adaptive_thinking_budget :
            and checkpoint message history, returns the final turn system prompt
     @param user_message The user's message to the keeper
     @param cascade_name Cascade profile name for model selection
-    @param structured_world_observation Structured world signal used by
+    @param world_observation Structured keeper world snapshot used by
            required-tool contract checks. When omitted, the contract gate
            does not infer world state from prompt text.
     @param provider_filter Optional provider restriction
@@ -240,7 +240,7 @@ val run_turn :
         -> turn_prompt)
   -> user_message:string
   -> cascade_name:string
-  -> ?structured_world_observation:Keeper_contract_classifier.world_observation
+  -> ?world_observation:Keeper_world_observation.world_observation
   -> ?turn_affordances:string list
   -> ?provider_filter:string list
   -> generation:int

--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -40,31 +40,49 @@ type world_observation = {
   has_discovered_work_section : bool;
 }
 
+let of_keeper_world_observation
+      (observation : Keeper_world_observation.world_observation)
+  : world_observation
+  =
+  {
+    unclaimed_task_count = observation.claimable_task_count;
+    board_activity_count = List.length observation.pending_board_events;
+    has_discovered_work_section =
+      observation.work_discovery_due
+      || Option.is_some observation.worktree_change_summary;
+  }
+
 let classify_actionable_signal o =
   if o.unclaimed_task_count > 0 then Has_unclaimed_tasks
   else if o.board_activity_count > 0 then Has_board_activity
   else if o.has_discovered_work_section then Has_discovered_work
   else No_actionable_signal
 
-let classify_actionable_signal_with_allowed_tools ~allowed_tool_names o =
+let classify_actionable_signal_for_tools ~(allowed_tool_names : string list) o =
   let has_any_tool names =
     List.exists (fun name -> List.mem name allowed_tool_names) names
   in
-  if o.unclaimed_task_count > 0
-     && has_any_tool
-          [ "keeper_task_claim"; "masc_claim_next"; "masc_claim_task" ]
+  if
+    o.unclaimed_task_count > 0
+    && has_any_tool [ "keeper_task_claim"; "masc_claim_next"; "masc_claim_task" ]
   then Has_unclaimed_tasks
-  else if o.board_activity_count > 0
-          && has_any_tool
-               [ "keeper_board_post"; "keeper_board_comment"; "masc_broadcast";
-                 "masc_keeper_msg" ]
+  else if
+    o.board_activity_count > 0
+    && has_any_tool
+         [ "keeper_board_post"; "keeper_board_comment"; "masc_broadcast";
+           "masc_keeper_msg" ]
   then Has_board_activity
-  else if o.has_discovered_work_section
-          && has_any_tool
-               [ "keeper_task_claim"; "masc_claim_next"; "masc_claim_task";
-                 "keeper_board_post"; "masc_add_task"; "keeper_tasks_audit" ]
+  else if
+    o.has_discovered_work_section
+    && has_any_tool
+         [ "keeper_task_claim"; "masc_claim_next"; "masc_claim_task";
+           "keeper_board_post"; "masc_add_task"; "keeper_tasks_audit";
+           "keeper_shell"; "keeper_bash"; "masc_code_git"; "keeper_fs_read" ]
   then Has_discovered_work
   else No_actionable_signal
+
+let classify_actionable_signal_with_allowed_tools =
+  classify_actionable_signal_for_tools
 
 let is_actionable = function
   | No_actionable_signal -> false

--- a/lib/keeper/keeper_contract_classifier.mli
+++ b/lib/keeper/keeper_contract_classifier.mli
@@ -22,9 +22,9 @@ val contract_status_label : contract_status -> string
 val pp_contract_status : Format.formatter -> contract_status -> unit
 
 (** Structured per-turn world snapshot consumed by
-    [classify_actionable_signal].  These values are observed before prompt
-    rendering so the completion-contract gate does not infer world state
-    from rendered prose. *)
+    [classify_actionable_signal]. This is intentionally smaller than
+    {!Keeper_world_observation.world_observation}: it carries only the
+    signals needed by the required-tool contract gate. *)
 type world_observation = {
   unclaimed_task_count : int;
       (** Number of unclaimed tasks in the keeper's queue.
@@ -38,6 +38,13 @@ type world_observation = {
       (** True iff the prompt build emitted a
           ["## Discovered Work (auto, Ns interval)"] section. *)
 }
+
+(** Project the full keeper heartbeat observation into the compact contract
+    snapshot. The task count uses [claimable_task_count], not global backlog
+    size, so keepers without a matching claim surface do not get forced into
+    an impossible required-tool contract. *)
+val of_keeper_world_observation :
+  Keeper_world_observation.world_observation -> world_observation
 
 (** [classify_actionable_signal o] returns the most-specific
     actionable signal observed in [o], following the precedence
@@ -64,6 +71,10 @@ val classify_actionable_signal : world_observation -> actionable_signal
     contract violations. Example: if unclaimed tasks exist but the keeper
     cannot see a claim tool, board activity can still become the selected
     actionable signal when board tools are visible. *)
+val classify_actionable_signal_for_tools :
+  allowed_tool_names:string list -> world_observation -> actionable_signal
+
+(** Backward-compatible alias for [classify_actionable_signal_for_tools]. *)
 val classify_actionable_signal_with_allowed_tools :
   allowed_tool_names:string list -> world_observation -> actionable_signal
 

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -71,11 +71,12 @@ let autonomous_max_idle_turns_live () =
 
 let turn_timeout_sec_live () =
   (* SSOT: must match Env_config_keeper.KeeperKeepalive.turn_timeout_sec
-     (range [60, 7200], default 1800 post-#10716). Drift here was the
-     mathematical root of #10388 (1200 - 30 oas_guard = 1170s budget). *)
+     (range [60, timeout_hard_ceiling_sec], default 3600 clamped to
+     600 post-bulkhead hard ceiling). Drift here was the mathematical
+     root of #10388 (1200 - 30 oas_guard = 1170s budget). *)
   Float.max 60.0
-    (Float.min 7200.0
-       (get_float ~default:1800.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+    (Float.min 600.0
+       (get_float ~default:3600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
 
 let admission_wait_timeout_sec_live () =
   Float.max 5.0

--- a/lib/keeper/keeper_shell_shared.mli
+++ b/lib/keeper/keeper_shell_shared.mli
@@ -148,6 +148,15 @@ val rewrite_turn_runtime_paths_to_host :
     its host playground absolute path so the LLM-facing output
     references real host paths. *)
 
+val rewrite_docker_host_paths_to_container :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  string ->
+  string
+(** Rewrite host playground root occurrences in keeper-issued Docker
+    commands to the corresponding in-container playground root before
+    execution. *)
+
 val run_argv_with_status_retry_eintr :
   ?cwd:string ->
   timeout_sec:float ->

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -506,6 +506,9 @@ let source_provenance_json config (meta : keeper_meta) =
   let live_meta_path = keeper_meta_path config meta.name in
   let default_manifest_path = snapshot.defaults.manifest_path in
   let default_source_kind = snapshot.source_kind in
+  let default_config_error =
+    Keeper_types_profile.keeper_toml_config_error_for_name meta.name
+  in
   `Assoc
     ([
       ("live_meta_path", `String live_meta_path);
@@ -514,6 +517,10 @@ let source_provenance_json config (meta : keeper_meta) =
       ( "default_manifest",
         optional_existing_path_json ?source:default_source_kind default_manifest_path );
       ("default_source_kind", Json_util.string_opt_to_json default_source_kind);
+      ( "default_config_error",
+        Json_util.option_to_yojson
+          Keeper_types_profile.keeper_toml_config_error_to_json
+          default_config_error );
       ("active_config_root", `String resolution.config_root.path);
       ( "active_config_root_source",
         `String (Config_dir_resolver.source_to_string resolution.config_root.source) );

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -342,6 +342,11 @@ let actionable_tool_contract_violation_reason
         (Printf.sprintf
            "actionable keeper signal was present for an owned active task, but the model only used passive/claim/stay_silent tools without execution progress: %s"
            (String.concat ", " names))
+    | names when List.exists is_stay_silent_tool_name names ->
+      Some
+        (Printf.sprintf
+           "actionable keeper signal was present, but the model used keeper_stay_silent without typed no-work proof: %s"
+           (String.concat ", " names))
     | names
       when List.for_all
              (fun name ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -412,6 +412,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     ~build_turn_prompt
                     ~user_message:message
                     ~cascade_name:turn_cascade_name
+                    ~world_observation:(direct_turn_observation meta)
                     ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
                     ~generation:meta.runtime.generation
                     ?on_event

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -1403,8 +1403,65 @@ let classify_toml_failure_reason (err : string) : string =
   else if contains "invalid shared_memory_scope" then "invalid_shared_memory_scope"
   else if contains "invalid" then "invalid_enum"
   else if contains "unknown" || contains "unexpected field" then "unknown_field"
-  else if contains "parse" || contains "syntax" then "parse_error"
+  else if contains "parse" || contains "syntax" || contains "expected" then
+    "parse_error"
   else "other"
+
+type keeper_toml_config_error = {
+  keeper_name : string;
+  path : string;
+  error : string;
+  reason : string;
+}
+
+let keeper_toml_config_error_to_json
+    ({ keeper_name; path; error; reason } : keeper_toml_config_error)
+    : Yojson.Safe.t =
+  `Assoc
+    [
+      ("keeper", `String keeper_name);
+      ("path", `String path);
+      ("reason", `String reason);
+      ("error", `String error);
+      ("terminal_reason", `String "config_parse_failed");
+    ]
+
+let keeper_name_of_toml_path path =
+  Filename.basename path |> Filename.remove_extension
+
+let keeper_toml_config_error_of_path path =
+  match load_keeper_toml path with
+  | Ok _ -> None
+  | Error error ->
+      Some
+        {
+          keeper_name = keeper_name_of_toml_path path;
+          path;
+          error;
+          reason = classify_toml_failure_reason error;
+        }
+
+let keeper_toml_config_errors_in_dir dir =
+  if not (Fs_compat.file_exists dir && Sys.is_directory dir) then []
+  else
+    dir
+    |> Sys.readdir
+    |> Array.to_list
+    |> List.filter (fun f -> Filename.check_suffix f ".toml")
+    |> List.sort String.compare
+    |> List.filter_map (fun f ->
+         keeper_toml_config_error_of_path (Filename.concat dir f))
+
+let keeper_toml_config_errors () =
+  keeper_toml_config_errors_in_dir (Config_dir_resolver.keepers_dir ())
+
+let keeper_toml_config_errors_json () =
+  `List (List.map keeper_toml_config_error_to_json (keeper_toml_config_errors ()))
+
+let keeper_toml_config_error_for_name name =
+  match keeper_toml_path_opt name with
+  | None -> None
+  | Some path -> keeper_toml_config_error_of_path path
 
 let load_keeper_profile_defaults name : keeper_profile_defaults =
   match load_keeper_profile_defaults_result name with

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -396,14 +396,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let turn_affordances =
         Keeper_unified_metrics.observed_affordances_of_observation ~meta observation
       in
-      let structured_world_observation :
-          Keeper_contract_classifier.world_observation =
-        {
-          unclaimed_task_count = observation.unclaimed_task_count;
-          board_activity_count = List.length observation.pending_board_events;
-          has_discovered_work_section = observation.work_discovery_due;
-        }
-      in
       (* 5. Run via OAS Agent.run() with transient-error retry *)
       (* Track whether side-effecting tool calls have been executed.
          If a board_post/comment/shell/file edit succeeded and then a
@@ -709,7 +701,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
                     ~max_context:execution.max_context ~build_turn_prompt
                     ~user_message ~cascade_name:execution.cascade_name
-                    ~structured_world_observation
+                    ~world_observation:observation
                     ~turn_affordances
                     ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
                     ~generation:run_generation

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -19,11 +19,24 @@ module Http_client = struct
             collapsed here because [should_cascade] only needs the
             terminality bit; consumers wanting the message extract it
             via the original [ProviderTerminal] match. *)
+    | Provider_capacity_exhausted
     | Provider_hard_quota
-        (** OAS [ProviderFailure.Hard_quota] — a provider/account quota
-            stop. Treat as cascade-stopping for the current turn so the
-            keeper can surface the quota path instead of burning the
-            remaining cascade budget. *)
+    | Provider_capability_mismatch
+    | Provider_cli_policy_invalid
+    | Provider_cli_startup_failed
+    | Provider_failure_parse_error
+    | Provider_failure_unknown
+
+  let classify_provider_failure_kind =
+    let module H = Llm_provider.Http_client in
+    function
+    | H.Capacity_exhausted _ -> Provider_capacity_exhausted
+    | H.Hard_quota _ -> Provider_hard_quota
+    | H.Capability_mismatch _ -> Provider_capability_mismatch
+    | H.Cli_policy_invalid _ -> Provider_cli_policy_invalid
+    | H.Cli_startup_failed _ -> Provider_cli_startup_failed
+    | H.Provider_parse_error _ -> Provider_failure_parse_error
+    | H.Unknown_provider_failure _ -> Provider_failure_unknown
 
   (* Case-insensitive substring check, mirroring [cascade_health_filter]. *)
   let contains_ci ?(max_scan = 512) ~haystack ~needle () =
@@ -107,20 +120,8 @@ module Http_client = struct
           Cli_transport_required
       | Llm_provider.Http_client.ProviderTerminal _ ->
           Provider_terminal
-      | Llm_provider.Http_client.ProviderFailure { kind; _ } -> (
-          match kind with
-          | Llm_provider.Http_client.Capacity_exhausted _ ->
-              Transient_http 529
-          | Llm_provider.Http_client.Hard_quota _ ->
-              Provider_hard_quota
-          | Llm_provider.Http_client.Capability_mismatch _
-          | Llm_provider.Http_client.Cli_policy_invalid _
-          | Llm_provider.Http_client.Cli_startup_failed _ ->
-              Accept_rejected_capability_mismatch
-          | Llm_provider.Http_client.Provider_parse_error _ ->
-              Provider_parse_error
-          | Llm_provider.Http_client.Unknown_provider_failure _ ->
-              Network_error)
+      | Llm_provider.Http_client.ProviderFailure { kind; _ } ->
+          classify_provider_failure_kind kind
       | Llm_provider.Http_client.NetworkError _ -> Network_error
 
   let should_cascade (err : Llm_provider.Http_client.http_error) : bool =
@@ -128,15 +129,21 @@ module Http_client = struct
     | Local_resource_exhaustion
     | Terminal_http _
     | Accept_rejected_terminal
-    | Provider_terminal
-    | Provider_hard_quota ->
+    | Provider_terminal ->
         false
     | Context_overflow
     | Provider_parse_error
     | Transient_http _
     | Accept_rejected_capability_mismatch
     | Cli_transport_required
-    | Network_error ->
+    | Network_error
+    | Provider_capacity_exhausted
+    | Provider_hard_quota
+    | Provider_capability_mismatch
+    | Provider_cli_policy_invalid
+    | Provider_cli_startup_failed
+    | Provider_failure_parse_error
+    | Provider_failure_unknown ->
         true
 
   let error_message (err : Llm_provider.Http_client.http_error) : string =

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -32,7 +32,14 @@ module Http_client : sig
     | Cli_transport_required
     | Network_error
     | Provider_terminal
+        (** Provider-level terminal condition that should stop cascading. *)
+    | Provider_capacity_exhausted
     | Provider_hard_quota
+    | Provider_capability_mismatch
+    | Provider_cli_policy_invalid
+    | Provider_cli_startup_failed
+    | Provider_failure_parse_error
+    | Provider_failure_unknown
 
   val classify : Llm_provider.Http_client.http_error -> cascade_failure_class
   (** Classify an OAS HTTP/client failure into MASC's typed cascade boundary.
@@ -63,7 +70,12 @@ module Http_client : sig
         CLI source explicitly marks this "so the cascade can move on".
       All of these are per-provider, not cascade-wide; a fallback provider
       may succeed where the current one rejected. See masc-mcp #9932
-      (kimi fallback), #9850 (codex_cli runtime_mcp_auth). *)
+      (kimi fallback), #9850 (codex_cli runtime_mcp_auth).
+
+      [ProviderFailure] is already typed by OAS, so this adapter maps it
+      without marker matching. Capacity, quota, capability, CLI policy/startup,
+      provider parse, and unknown provider failures all advance the cascade as
+      provider-local skip conditions. *)
 
   val error_message : Llm_provider.Http_client.http_error -> string
   (** Extract a human-readable message from an OAS HTTP error.

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -370,11 +370,11 @@ let run_named
             Keeper_types.Other_detail
               (Printf.sprintf "provider terminal %s: %s" subtype message)
         | Some (Llm_provider.Http_client.ProviderFailure _ as err) ->
-            let detail = Oas_compat.Http_client.error_message err in
-            if message_looks_like_cli_wrapped_max_turns detail then
+            let message = Oas_compat.Http_client.error_message err in
+            if message_looks_like_cli_wrapped_max_turns message then
               Keeper_types.Max_turns_exceeded
             else
-              Keeper_types.Other_detail detail
+              Keeper_types.Other_detail message
         | None -> Keeper_types.No_providers_available
       in
       let observation =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -18,14 +18,21 @@ let normalize_cli_provider_caps
         supports_runtime_mcp_tools = true;
         supports_runtime_tool_events = true;
       }
-  | Llm_provider.Provider_config.Kimi_cli
-  | Llm_provider.Provider_config.Gemini_cli ->
+  | Llm_provider.Provider_config.Kimi_cli ->
       {
         caps with
         supports_tools = false;
         supports_tool_choice = false;
         supports_runtime_mcp_tools = true;
         supports_runtime_tool_events = true;
+      }
+  | Llm_provider.Provider_config.Gemini_cli ->
+      {
+        caps with
+        supports_tools = false;
+        supports_tool_choice = false;
+        supports_runtime_mcp_tools = false;
+        supports_runtime_tool_events = false;
       }
   | _ -> caps
 

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -105,6 +105,19 @@ let make_health_json ?(listener = "http/1.1") request =
     else Printf.sprintf "%dh %dm" (uptime_secs / 3600) ((uptime_secs mod 3600) / 60)
   in
   let build = Build_identity.current () in
+  let keeper_config_parse_errors =
+    try Keeper_types_profile.keeper_toml_config_errors () with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+        [
+          {
+            Keeper_types_profile.keeper_name = "unknown";
+            path = "";
+            error = Printexc.to_string exn;
+            reason = "health_probe_failed";
+          };
+        ]
+  in
   `Assoc [
     ("status", `String "ok");
     ("server", `String "masc-mcp");
@@ -136,6 +149,12 @@ let make_health_json ?(listener = "http/1.1") request =
       ("minor_heap_size", `Int (let c = Gc.get () in c.minor_heap_size));
     ]);
     ("keeper_fibers", `Int (Keeper_registry.count_running ()));
+    ("keeper_config_parse_error_count",
+     `Int (List.length keeper_config_parse_errors));
+    ( "keeper_config_parse_errors",
+      `List
+        (List.map Keeper_types_profile.keeper_toml_config_error_to_json
+           keeper_config_parse_errors) );
     (* P2 silent-failure fix: lazy_task_boot_guard fires when a keeper
        startup task exceeds the boot timeout (server_bootstrap_loops.ml:116).
        The Prometheus counter `masc_lazy_task_boot_guard_fired_total`

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-04-30T03:00:48Z (HEAD: 63db68cc78)
+Generated: 2026-04-30T09:16:03Z (HEAD: 6cf32801ee)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -17,8 +17,8 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | Manual specs | 84 |
 | TTrace (auto-generated) | 0 |
 | Directories | 17 |
-| Total .cfg files | 160 |
-| Buggy .cfg (bug-model pair) | 73 |
+| Total .cfg files | 168 |
+| Buggy .cfg (bug-model pair) | 81 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`).
 
@@ -40,8 +40,8 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Last Modified |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| AutonomousLoop.tla | AutonomousLoop | manual | 1 | 0 | clean={inv:TypeOK, inv:MetaPersistedAfterTick, inv:TickOnlyDuringRunning} | 2026-04-29 |
-| AutonomousPhase.tla | AutonomousPhase | manual | 1 | 0 | clean={inv:TypeOK, inv:StartedAtIdle, inv:CurrentMatchesHead, inv:OnlyLegalTransitions} | 2026-04-29 |
+| AutonomousLoop.tla | AutonomousLoop | manual | 2 | 1 | clean={inv:TypeOK, inv:MetaPersistedAfterTick, inv:TickOnlyDuringRunning, inv:AutoTickReadOnly} buggy={inv:TypeOK, inv:MetaPersistedAfterTick, inv:TickOnlyDuringRunning, inv:AutoTickReadOnly} | 2026-04-30 |
+| AutonomousPhase.tla | AutonomousPhase | manual | 2 | 1 | clean={inv:TypeOK, inv:StartedAtIdle, inv:CurrentMatchesHead, inv:OnlyLegalTransitions} buggy={inv:TypeOK, inv:StartedAtIdle, inv:CurrentMatchesHead, inv:OnlyLegalTransitions} | 2026-04-30 |
 
 ### specs/boundary (18 specs)
 
@@ -72,7 +72,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 |------|--------|------|-----|-------|-------------------------|---------------|
 | AmbiguousPartialCommit.tla | AmbiguousPartialCommit | manual | 1 | 0 | clean={inv:TypeOK, inv:Safety} | 2026-04-29 |
 | AmbiguousPartialCommitBug.tla | AmbiguousPartialCommitBug | manual | 1 | 1 | buggy={inv:TypeOK, inv:Safety} | 2026-04-29 |
-| AtomicFileWrite.tla | AtomicFileWrite | manual | 2 | 1 | clean={inv:ReaderNeverSeesEmpty} buggy={inv:ReaderNeverSeesEmpty} | 2026-04-29 |
+| AtomicFileWrite.tla | AtomicFileWrite | manual | 2 | 1 | clean={inv:ReaderNeverSeesEmpty} buggy={inv:ReaderNeverSeesEmpty} | 2026-04-30 |
 | AuthIdentityFSM.tla | AuthIdentityFSM | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 2026-04-29 |
 | CascadeCrossFallback.tla | CascadeCrossFallback | manual | 2 | 1 | clean={inv:TypeOK, inv:AtMostOneCrossCascadePerTurn, inv:PromotionRequiresExhaustion, inv:PromotionFrozenAfterFinish} buggy={inv:TypeOK, inv:AtMostOneCrossCascadePerTurn} | 2026-04-29 |
 | CascadeExhaustion.tla | CascadeExhaustion | manual | 2 | 1 | clean={inv:TypeOK, inv:ExhaustionSafetyLastOk} buggy={inv:TypeOK, inv:ExhaustionDiagnosticConsistency} | 2026-04-29 |
@@ -82,7 +82,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | DispatchCoverage.tla | DispatchCoverage | manual | 2 | 1 | clean={inv:TypeOK, inv:DataFsmConsistent, inv:PhaseConsistent, inv:NeverStuckFailing} buggy={inv:TypeOK, inv:DataFsmConsistent, inv:PhaseConsistent, inv:NeverStuckFailing} | 2026-04-29 |
 | DispatchHookChain.tla | DispatchHookChain | manual | 2 | 1 | clean={inv:ShortCircuitSkipsHandler, inv:PostHooksAfterHandler, inv:HandlerRequiresNoReject} buggy={inv:ShortCircuitSkipsHandler} | 2026-04-29 |
 | FileLockStarvation.tla | FileLockStarvation | manual | 2 | 1 | clean={inv:TypeOK, inv:FlockMutex, inv:SingleMutexPerPath} buggy={inv:TypeOK, inv:FlockMutex, inv:SingleMutexPerPath} | 2026-04-29 |
-| HebbianLearning.tla | HebbianLearning | manual | 2 | 1 | clean={inv:WeightBounded NoLostUpdate} buggy={inv:WeightBounded NoLostUpdate} | 2026-04-29 |
+| HebbianLearning.tla | HebbianLearning | manual | 2 | 1 | clean={inv:WeightBounded NoLostUpdate} buggy={inv:WeightBounded NoLostUpdate} | 2026-04-30 |
 | KeepalivePhaseConsistency.tla | KeepalivePhaseConsistency | manual | 2 | 1 | clean={inv:TypeOK, inv:KeepalivePhaseConsistent, inv:InFlightImpliesRunning} buggy={inv:TypeOK, inv:KeepalivePhaseConsistent, inv:InFlightImpliesRunning} | 2026-04-29 |
 | KeeperPhaseRace.tla | KeeperPhaseRace | manual | 2 | 1 | clean={inv:TypeOK, inv:CrashImpliesThreshold, inv:RecordOnlyOnCrash, inv:CounterBoundedByObservations} buggy={inv:TypeOK, inv:CrashImpliesThreshold, inv:RecordOnlyOnCrash, inv:CounterBoundedByObservations} | 2026-04-29 |
 | KeeperTaskInterlock.tla | KeeperTaskInterlock | manual | 3 | 1 | clean={inv:TypeOK, inv:NoDeadKeeperHoldsTask, inv:ClaimerNotDead, inv:AwaitingVerificationHasClaimer} buggy={inv:TypeOK, inv:NoDeadKeeperHoldsTask, inv:ClaimerNotDead} current={inv:TypeOK} | 2026-04-29 |
@@ -146,21 +146,21 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Last Modified |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| MASCEcosystem.tla | MASCEcosystem | manual | 1 | 0 | clean={inv:NoContextOverflow, inv:SingleTaskPerAgent, prop:AllTasksEventuallyCompleted, prop:MemoryManagementWorks} | 2026-04-29 |
+| MASCEcosystem.tla | MASCEcosystem | manual | 2 | 1 | clean={inv:NoContextOverflow, inv:SingleTaskPerAgent, inv:AtMostOneAgentPerTask, prop:AllTasksEventuallyCompleted, prop:MemoryManagementWorks} buggy={inv:NoContextOverflow, inv:SingleTaskPerAgent, inv:AtMostOneAgentPerTask} | 2026-04-30 |
 
 ### specs/multimodal (2 specs)
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Last Modified |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| MultimodalArtifact.tla | MultimodalArtifact | manual | 1 | 0 | clean={inv:TypeOK, inv:ArtifactIdMatchesKey, inv:DAGRefIntegrity, inv:NoSelfLoops, inv:DAGAcyclic, inv:ProvenanceOriginsLive} | 2026-04-29 |
-| MultimodalHydrator.tla | MultimodalHydrator | manual | 1 | 0 | clean={inv:TypeOK, inv:NoSelfLoop, inv:NoCycleBounded, inv:DedupeIdempotent} | 2026-04-29 |
+| MultimodalArtifact.tla | MultimodalArtifact | manual | 2 | 1 | clean={inv:TypeOK, inv:ArtifactIdMatchesKey, inv:DAGRefIntegrity, inv:NoSelfLoops, inv:DAGAcyclic, inv:ProvenanceOriginsLive} buggy={inv:TypeOK, inv:ArtifactIdMatchesKey, inv:DAGRefIntegrity, inv:NoSelfLoops, inv:DAGAcyclic, inv:ProvenanceOriginsLive} | 2026-04-30 |
+| MultimodalHydrator.tla | MultimodalHydrator | manual | 2 | 1 | clean={inv:TypeOK, inv:NoSelfLoop, inv:NoCycleBounded, inv:DedupeIdempotent} buggy={inv:TypeOK, inv:NoSelfLoop, inv:NoCycleBounded, inv:DedupeIdempotent} | 2026-04-30 |
 
 ### specs/resilience (2 specs)
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Last Modified |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| ResilienceDegradation.tla | ResilienceDegradation | manual | 1 | 0 | clean={inv:TypeOK, inv:MonotonicDegradation, inv:NoRetryAtL4Permanent, inv:NoRetryAtL4Exhausted} | 2026-04-29 |
-| ResilienceOutcome.tla | ResilienceOutcome | manual | 1 | 0 | clean={inv:TypeOK, inv:ConfidenceInRange, inv:DegradationLevelInRange, inv:CompletedFailedDisjoint, inv:RecoveryStrategyDeclared} | 2026-04-29 |
+| ResilienceDegradation.tla | ResilienceDegradation | manual | 2 | 1 | clean={inv:TypeOK, inv:MonotonicDegradation, inv:NoRetryAtL4Permanent, inv:NoRetryAtL4Exhausted} buggy={inv:TypeOK, inv:MonotonicDegradation, inv:NoRetryAtL4Permanent, inv:NoRetryAtL4Exhausted} | 2026-04-30 |
+| ResilienceOutcome.tla | ResilienceOutcome | manual | 2 | 1 | clean={inv:TypeOK, inv:ConfidenceInRange, inv:DegradationLevelInRange, inv:CompletedFailedDisjoint, inv:RecoveryStrategyDeclared} buggy={inv:TypeOK, inv:ConfidenceInRange, inv:DegradationLevelInRange, inv:CompletedFailedDisjoint, inv:RecoveryStrategyDeclared} | 2026-04-30 |
 
 ### specs/server-state (1 specs)
 
@@ -172,7 +172,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Last Modified |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| SharedAudit.tla | SharedAudit | manual | 1 | 0 | clean={inv:TypeOK, inv:IdsUnique, inv:ChainIntegrity, inv:EntryIdMinted} | 2026-04-29 |
+| SharedAudit.tla | SharedAudit | manual | 2 | 1 | clean={inv:TypeOK, inv:IdsUnique, inv:ChainIntegrity, inv:EntryIdMinted} buggy={inv:TypeOK, inv:IdsUnique, inv:ChainIntegrity, inv:EntryIdMinted} | 2026-04-30 |
 
 ### specs/social-state-cap (1 specs)
 

--- a/specs/autonomous/AutonomousLoop-buggy.cfg
+++ b/specs/autonomous/AutonomousLoop-buggy.cfg
@@ -1,7 +1,6 @@
 \* Buggy model: AutoTick observer becomes invasive — flips
 \* keeper_phase to "draining" while still ticking. Expected:
-\* TickOnlyDuringRunning VIOLATED on the second tick (which fires
-\* while keeper_phase = "draining").
+\* AutoTickReadOnly VIOLATED on the first invasive tick.
 SPECIFICATION SpecBuggy
 
 CONSTANTS
@@ -18,3 +17,4 @@ INVARIANTS
     TypeOK
     MetaPersistedAfterTick
     TickOnlyDuringRunning
+    AutoTickReadOnly

--- a/specs/autonomous/AutonomousLoop.cfg
+++ b/specs/autonomous/AutonomousLoop.cfg
@@ -14,3 +14,4 @@ INVARIANTS
     TypeOK
     MetaPersistedAfterTick
     TickOnlyDuringRunning
+    AutoTickReadOnly

--- a/specs/autonomous/AutonomousLoop.tla
+++ b/specs/autonomous/AutonomousLoop.tla
@@ -18,6 +18,7 @@
 \*   keeper_phase      | Keeper_state_machine.t.phase
 \*   autonomous_phase  | Autonomous_state.t.current_phase
 \*   meta_present      | working_context contains "autonomous_meta"
+\*   auto_phase_writes | bug-model witness for invasive keeper phase writes
 
 EXTENDS TLC, Naturals, Sequences, FiniteSets
 
@@ -35,10 +36,11 @@ VARIABLES
     autonomous_phase,
     meta_present,
     keeper_steps,    \* count of keeper transitions
-    auto_ticks       \* count of autonomous ticks
+    auto_ticks,      \* count of autonomous ticks
+    auto_phase_writes \* keeper phase writes performed by autonomous tick
 
 vars == <<keeper_phase, autonomous_phase, meta_present,
-          keeper_steps, auto_ticks>>
+          keeper_steps, auto_ticks, auto_phase_writes>>
 
 \* ── Type invariant ───────────────────────────────────────────────
 TypeOK ==
@@ -47,6 +49,7 @@ TypeOK ==
     /\ meta_present \in BOOLEAN
     /\ keeper_steps \in Nat
     /\ auto_ticks \in Nat
+    /\ auto_phase_writes \in Nat
 
 \* If the Keeper is running and at least one autonomous tick has
 \* fired, working_context["autonomous_meta"] must be present.
@@ -64,6 +67,9 @@ TickOnlyDuringRunning ==
     auto_ticks > 0 => keeper_phase \in { "running", "draining",
                                           "terminated" }
 
+AutoTickReadOnly ==
+    auto_phase_writes = 0
+
 \* ── Init / Next ──────────────────────────────────────────────────
 Init ==
     /\ keeper_phase = "spawned"
@@ -71,24 +77,28 @@ Init ==
     /\ meta_present = FALSE
     /\ keeper_steps = 0
     /\ auto_ticks = 0
+    /\ auto_phase_writes = 0
 
 KeeperToRunning ==
     /\ keeper_phase = "spawned"
     /\ keeper_phase' = "running"
     /\ keeper_steps' = keeper_steps + 1
-    /\ UNCHANGED <<autonomous_phase, meta_present, auto_ticks>>
+    /\ UNCHANGED <<autonomous_phase, meta_present, auto_ticks,
+                   auto_phase_writes>>
 
 KeeperToDraining ==
     /\ keeper_phase = "running"
     /\ keeper_phase' = "draining"
     /\ keeper_steps' = keeper_steps + 1
-    /\ UNCHANGED <<autonomous_phase, meta_present, auto_ticks>>
+    /\ UNCHANGED <<autonomous_phase, meta_present, auto_ticks,
+                   auto_phase_writes>>
 
 KeeperToTerminated ==
     /\ keeper_phase = "draining"
     /\ keeper_phase' = "terminated"
     /\ keeper_steps' = keeper_steps + 1
-    /\ UNCHANGED <<autonomous_phase, meta_present, auto_ticks>>
+    /\ UNCHANGED <<autonomous_phase, meta_present, auto_ticks,
+                   auto_phase_writes>>
 
 \* CRITICAL: AutoTick preserves keeper_phase. This is the
 \* non-invasive wirein contract.
@@ -99,6 +109,7 @@ AutoTick ==
     /\ auto_ticks' = auto_ticks + 1
     /\ keeper_phase' = keeper_phase            \* PRESERVED
     /\ keeper_steps' = keeper_steps            \* PRESERVED
+    /\ auto_phase_writes' = auto_phase_writes  \* PRESERVED
 
 Next ==
     \/ KeeperToRunning
@@ -111,6 +122,7 @@ Spec == Init /\ [][Next]_vars
 BoundedSteps ==
     /\ keeper_steps <= MaxKeeperSteps
     /\ auto_ticks <= MaxAutoTicks
+    /\ auto_phase_writes <= MaxAutoTicks
 
 \* ── Bug model (RFC-Q2-1) ────────────────────────────────────────
 \*
@@ -120,8 +132,7 @@ BoundedSteps ==
 \* [Keeper_post_turn.apply_autonomous_wirein] enforces read-only
 \* access to the keeper FSM; the spec verifies that even if that
 \* constraint were bypassed (e.g. via Obj.magic or a refactor
-\* that loses the guard), TickOnlyDuringRunning catches the next
-\* tick after the keeper has been pushed to draining.
+\* that loses the guard), AutoTickReadOnly catches the invasive write.
 
 AutoTickFlipsKeeperPhase ==
     /\ keeper_phase = "running"
@@ -130,6 +141,7 @@ AutoTickFlipsKeeperPhase ==
     /\ auto_ticks' = auto_ticks + 1
     /\ keeper_phase' = "draining"   \* INVASIVE: must be preserved
     /\ keeper_steps' = keeper_steps + 1
+    /\ auto_phase_writes' = auto_phase_writes + 1
 
 NextBuggy ==
     \/ Next
@@ -140,5 +152,6 @@ SpecBuggy == Init /\ [][NextBuggy]_vars
 THEOREM Spec => []TypeOK
 THEOREM Spec => []MetaPersistedAfterTick
 THEOREM Spec => []TickOnlyDuringRunning
+THEOREM Spec => []AutoTickReadOnly
 
 ====

--- a/test/test_keeper_classifier_helper.ml
+++ b/test/test_keeper_classifier_helper.ml
@@ -121,6 +121,28 @@ let test_is_actionable_matches_classify () =
         expected (C.is_actionable sig_))
     observations
 
+let test_tool_filtered_classifier_uses_visible_capability () =
+  Alcotest.check s "claim tool permits task signal"
+    C.Has_unclaimed_tasks
+    (C.classify_actionable_signal_for_tools
+       ~allowed_tool_names:[ "keeper_task_claim" ]
+       (obs ~tasks:1 ()));
+  Alcotest.check s "missing claim tool downgrades task signal"
+    C.No_actionable_signal
+    (C.classify_actionable_signal_for_tools
+       ~allowed_tool_names:[ "keeper_tasks_list" ]
+       (obs ~tasks:1 ()));
+  Alcotest.check s "falls through to board when task tool missing"
+    C.Has_board_activity
+    (C.classify_actionable_signal_for_tools
+       ~allowed_tool_names:[ "keeper_board_comment" ]
+       (obs ~tasks:1 ~board:1 ()));
+  Alcotest.check s "worktree tool permits discovery signal"
+    C.Has_discovered_work
+    (C.classify_actionable_signal_for_tools
+       ~allowed_tool_names:[ "keeper_shell" ]
+       (obs ~discovered:true ()))
+
 let () =
   Alcotest.run "keeper_classifier_helper"
     [
@@ -142,6 +164,8 @@ let () =
             test_zero_counts_are_inactive;
           Alcotest.test_case "negative counts are inactive" `Quick
             test_negative_counts_are_inactive;
+          Alcotest.test_case "visible tools gate signals" `Quick
+            test_tool_filtered_classifier_uses_visible_capability;
         ] );
       ( "is_actionable",
         [

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -357,7 +357,37 @@ let test_classify_toml_failure_reason_buckets () =
     (f "unknown field 'legacy_scope'");
   check string "parse error" "parse_error"
     (f "parse error at line 3");
+  check string "expected key parse error" "parse_error"
+    (f "line 62: expected key = value");
   check string "uncategorized" "other" (f "completely novel problem")
+
+let test_keeper_toml_config_errors_are_typed () =
+  let dir = Filename.temp_file "keeper_config_errors_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let invalid_path = Filename.concat dir "broken.toml" in
+  let valid_path = Filename.concat dir "valid.toml" in
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove invalid_path with _ -> ());
+      (try Sys.remove valid_path with _ -> ());
+      try Unix.rmdir dir with _ -> ())
+    (fun () ->
+      write_file invalid_path "[keeper]\nname = \"broken\"\n\"dangling\"\n";
+      write_file valid_path "[keeper]\nname = \"valid\"\n";
+      match KTP.keeper_toml_config_errors_in_dir dir with
+      | [ err ] ->
+          check string "keeper name" "broken" err.keeper_name;
+          check string "path" invalid_path err.path;
+          check string "reason" "parse_error" err.reason;
+          let json = KTP.keeper_toml_config_error_to_json err in
+          check string "terminal reason" "config_parse_failed"
+            (Yojson.Safe.Util.member "terminal_reason" json
+             |> Yojson.Safe.Util.to_string)
+      | errors ->
+          fail
+            (Printf.sprintf "expected one typed config error, got %d"
+               (List.length errors)))
 
 let () =
   run "Keeper TOML Config Validation"
@@ -395,5 +425,7 @@ let () =
             test_network_mode_accepts_host_alias;
           test_case "classifies failures into bounded label set" `Quick
             test_classify_toml_failure_reason_buckets;
+          test_case "surfaces typed config parse errors" `Quick
+            test_keeper_toml_config_errors_are_typed;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -36,8 +36,43 @@ let repo_root () =
       in
       ascend (Sys.getcwd ())
 
+let copy_file src dst =
+  let ic = open_in_bin src in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let oc = open_out_bin dst in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc (In_channel.input_all ic)))
+
+let unix_mkdir_p path =
+  let rec loop dir =
+    if dir = "" || dir = "." || Sys.file_exists dir then ()
+    else (
+      loop (Filename.dirname dir);
+      Unix.mkdir dir 0o755)
+  in
+  loop path
+
 let () =
   let base_path = repo_root () in
+  let test_base_path =
+    let path = Filename.temp_file "test_keeper_unified_runtime_" "" in
+    Unix.unlink path;
+    Unix.mkdir path 0o755;
+    path
+  in
+  let test_config_dir =
+    Filename.concat (Filename.concat test_base_path ".masc") "config"
+  in
+  unix_mkdir_p test_config_dir;
+  copy_file
+    (Filename.concat base_path "config/cascade.json")
+    (Filename.concat test_config_dir "cascade.json");
+  Unix.putenv "MASC_BASE_PATH" test_base_path;
+  Unix.putenv "MASC_CONFIG_DIR" test_config_dir;
+  Masc_mcp.Config_dir_resolver.reset ();
   let prompts_dir = Filename.concat base_path "config/prompts" in
   Prompt_registry.set_markdown_dir prompts_dir;
   ignore (Result.get_ok (Masc_mcp.Keeper_exec_tools.init_policy_config ~base_path));
@@ -115,6 +150,25 @@ let with_env name value f =
     match old with
     | Some v -> Unix.putenv name v
     | None -> (try Unix.putenv name "" with _ -> ()))
+    f
+
+let prepare_test_config_root base_dir =
+  let config_dir =
+    Filename.concat (Filename.concat base_dir ".masc") "config"
+  in
+  Keeper_types.mkdir_p config_dir;
+  copy_file
+    (Filename.concat (repo_root ()) "config/cascade.json")
+    (Filename.concat config_dir "cascade.json");
+  config_dir
+
+let with_test_runtime_roots base_dir f =
+  let config_dir = prepare_test_config_root base_dir in
+  with_env "MASC_BASE_PATH" base_dir @@ fun () ->
+  with_env "MASC_CONFIG_DIR" config_dir @@ fun () ->
+  Masc_mcp.Config_dir_resolver.reset ();
+  Fun.protect
+    ~finally:(fun () -> Masc_mcp.Config_dir_resolver.reset ())
     f
 
 (* ---------- World Observation type tests ---------- *)
@@ -1072,6 +1126,7 @@ let test_runtime_trust_snapshot_tolerates_null_telemetry () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
+      with_test_runtime_roots base_dir @@ fun () ->
       let config = Masc_mcp.Coord.default_config base_dir in
       let keeper_name = "runtime-trust-null-telemetry" in
       let meta = { minimal_meta with name = keeper_name } in
@@ -1093,6 +1148,7 @@ let test_runtime_trust_snapshot_surfaces_terminal_reason () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
+      with_test_runtime_roots base_dir @@ fun () ->
       let config = Masc_mcp.Coord.default_config base_dir in
       let keeper_name = "runtime-trust-terminal-reason" in
       let meta =
@@ -3163,7 +3219,7 @@ let test_run_keeper_cycle_skips_non_executable_phase () =
            with
            | None -> fail "expected skipped turn execution receipt"
            | Some receipt ->
-               check string "skipped receipt outcome" "skipped"
+              check string "skipped receipt outcome" "skipped"
                  Yojson.Safe.Util.(receipt |> member "outcome" |> to_string);
                check string "skipped receipt terminal reason"
                  "non_executable_phase:paused"
@@ -3210,8 +3266,8 @@ let test_run_keeper_cycle_records_trajectory_source_contract () =
     (source_file_contains "lib/keeper/keeper_unified_turn.ml"
        "Coord.masc_root_dir config");
   check bool "keeper cycle finalizes trajectory on completion/failure" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
-       "Trajectory.finalize trajectory_acc");
+    (source_file_contains "lib/keeper/keeper_turn_helpers.ml"
+       "let finalize_trajectory_acc");
   check bool "pre-dispatch exits record terminal receipt" true
     (source_file_contains "lib/keeper/keeper_unified_turn.ml"
        "record_pre_dispatch_terminal_observation");
@@ -3338,7 +3394,7 @@ let test_pre_tool_gate_records_durable_attempt_telemetry () =
 
 let test_run_keeper_cycle_surfaces_side_effect_failures_source_contract () =
   check bool "keeper cycle records side-effect issues in registry" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+    (source_file_contains "lib/keeper/keeper_turn_helpers.ml"
        "Keeper_registry.record_error ~base_path:config.base_path");
   check bool "trajectory finalize is not silently ignored" false
     (source_file_contains "lib/keeper/keeper_unified_turn.ml"
@@ -4733,15 +4789,14 @@ let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
       ~estimated_input_tokens ~remaining_turn_budget_s:1200.0
   with
   | Some timeout_s ->
-      (* The bounded variant subtracts a 15s finalization guard
-         from [remaining_turn_budget_s] and caps at the adaptive
-         raw.  With #10008 fm2 the adaptive raw equals
-         [turn_timeout_sec] (1200), so the finalization guard path
-         dominates: returned value is [remaining - 15]. *)
+      (* The bounded variant subtracts a 15s finalization guard from
+         [remaining_turn_budget_s] and caps at the adaptive raw.  After
+         the bulkhead hard ceiling, [turn_timeout_sec] is 600, so the
+         adaptive cap dominates this large remaining-budget case. *)
       check bool "bounded timeout at or below adaptive raw"
         true (timeout_s <= expected);
-      check bool "bounded leaves positive finalization guard"
-        true (timeout_s < 1200.0 && timeout_s > 1100.0)
+      check (float 0.01) "bounded uses hard-capped adaptive timeout"
+        expected timeout_s
   | None -> fail "expected bounded timeout"
 
 (* #10008 fm2: the budget formula no longer scales with token count,
@@ -4788,14 +4843,13 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
   with
   | Some timeout_s ->
       (* #10008 fm2: raw formula no longer depends on max_turns;
-         bounded variant still subtracts the 15s finalization
-         guard from [remaining_turn_budget_s] and caps at the
-         raw.  Verify the cap was applied ([<=] raw) and the
-         guard reserved a positive amount. *)
+         bounded variant still subtracts the 15s finalization guard
+         from [remaining_turn_budget_s] and caps at the raw.  After
+         the bulkhead hard ceiling, the raw 600s cap dominates. *)
       check bool "bounded timeout at or below raw formula output"
         true (timeout_s <= raw);
-      check bool "finalization guard reserves positive delta"
-        true (timeout_s <= 1200.0 && timeout_s > 1100.0)
+      check (float 0.01) "bounded uses channel hard-capped raw timeout"
+        raw timeout_s
   | None -> fail "expected bounded timeout"
 
 let test_bounded_oas_timeout_reserves_degraded_retry_budget () =
@@ -4811,7 +4865,7 @@ let test_bounded_oas_timeout_reserves_degraded_retry_budget () =
       check (float 0.01) "remaining budget records post-guard usable budget"
         1185.0 budget.remaining_turn_budget_sec;
       check string "source records retry reserve"
-        "adaptive_estimated_input_tokens_capped_by_turn_budget_and_degraded_retry_budget"
+        "adaptive_estimated_input_tokens_capped_by_degraded_retry_budget"
         budget.source
   | None -> fail "expected bounded timeout"
 
@@ -5258,26 +5312,30 @@ let test_actionable_tool_contract_allows_execution_tools () =
        ~actionable_signal_context:false
        ~tool_names:[])
 
-let test_stay_silent_satisfies_required_contract_despite_read_only_effect () =
+let test_stay_silent_requires_typed_no_work_proof_on_actionable_signal () =
   (* keeper_stay_silent has effect_domain=Read_only in tool_catalog but is
-     classified as Completion in completion_tool_names.  When the LLM
-     correctly signals "no work for me" via stay_silent alongside status
-     reads, the contract must not fire a false violation.  Observed
-     2026-04-28: analyst/janitor cycles rejected with "passive status/read
-     tools: keeper_stay_silent, keeper_task_list". *)
+     classified as Completion in completion_tool_names, so it can still
+     satisfy a plain required-tool contract.  On an actionable world signal,
+     however, stay_silent must not close the turn unless the typed observation
+     path already proved there is no actionable work. *)
   check bool "stay_silent satisfies required contract" true
     (KTD.tool_name_can_satisfy_required_contract "keeper_stay_silent");
   check bool "completion tool set includes stay_silent" true
     (KTD.is_completion_tool_name "keeper_stay_silent");
-  check (option string) "stay_silent + passive tools = no violation" None
-    (KTD.actionable_tool_contract_violation_reason
+  (match
+     KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
        ~actionable_signal_context:true
-       ~tool_names:[ "keeper_stay_silent"; "keeper_tasks_list" ]);
-  check (option string) "stay_silent alone = no violation" None
+       ~tool_names:[ "keeper_stay_silent"; "keeper_tasks_list" ]
+   with
+   | Some reason ->
+       check bool "reason mentions typed no-work proof" true
+         (contains_substring reason "typed no-work proof")
+   | None -> fail "expected stay_silent actionable violation");
+  check (option string) "non-actionable stay_silent remains allowed" None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
-       ~actionable_signal_context:true
+       ~actionable_signal_context:false
        ~tool_names:[ "keeper_stay_silent" ]);
   (* Without stay_silent, passive-only still violates *)
   check bool "passive-only still violates" true
@@ -6616,8 +6674,8 @@ let () =
             test_claim_tool_classification_covers_masc_claim_task;
           test_case "actionable signal allows execution tools" `Quick
             test_actionable_tool_contract_allows_execution_tools;
-          test_case "stay_silent satisfies required contract despite read-only effect" `Quick
-            test_stay_silent_satisfies_required_contract_despite_read_only_effect;
+          test_case "stay_silent needs typed no-work proof on actionable signal" `Quick
+            test_stay_silent_requires_typed_no_work_proof_on_actionable_signal;
           test_case "required tool predicate rejects passive tools" `Quick
             test_required_tool_satisfaction_rejects_passive_tools;
           test_case "required tool predicate accepts mutating tools" `Quick

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -148,48 +148,49 @@ let test_provider_failure_capacity_cascades () =
     true
     (Oas_compat.Http_client.should_cascade err);
   match Oas_compat.Http_client.classify err with
-  | Transient_http 529 -> ()
-  | _ -> Alcotest.fail "Capacity_exhausted must classify as Transient_http 529"
+  | Provider_capacity_exhausted -> ()
+  | _ ->
+      Alcotest.fail
+        "Capacity_exhausted must classify as Provider_capacity_exhausted"
+
+let test_provider_failure_hard_quota_cascades () =
+  let err =
+    Http_client.ProviderFailure
+      {
+        kind = Hard_quota { retry_after = Some 60.0 };
+        message = "monthly quota exhausted";
+      }
+  in
+  Alcotest.(check bool)
+    "ProviderFailure Hard_quota cascades as a provider-local skip condition"
+    true
+    (Oas_compat.Http_client.should_cascade err);
+  (match Oas_compat.Http_client.classify err with
+   | Provider_hard_quota -> ()
+   | _ -> Alcotest.fail "Hard_quota must classify as Provider_hard_quota");
+  Alcotest.(check bool)
+    "error_message renders typed provider failure"
+    true
+    (Astring.String.is_infix ~affix:"hard_quota"
+       (Oas_compat.Http_client.error_message err))
 
 let test_provider_failure_capability_mismatch_cascades () =
   let err =
     Http_client.ProviderFailure
       {
-        kind =
-          Capability_mismatch
-            { capability = Some "request_scoped_runtime_mcp" };
-        message = "provider lacks request-scoped MCP";
+        kind = Capability_mismatch { capability = Some "runtime_mcp_tools" };
+        message = "gemini_cli cannot receive runtime MCP tools";
       }
   in
   Alcotest.(check bool)
-    "ProviderFailure Capability_mismatch must cascade"
+    "ProviderFailure Capability_mismatch cascades without string markers"
     true
     (Oas_compat.Http_client.should_cascade err);
-  match Oas_compat.Http_client.classify err with
-  | Accept_rejected_capability_mismatch -> ()
-  | _ ->
-      Alcotest.fail
-        "Capability_mismatch must classify as Accept_rejected_capability_mismatch"
-
-let test_provider_failure_hard_quota_stops () =
-  let err =
-    Http_client.ProviderFailure
-      {
-        kind = Hard_quota { retry_after = None };
-        message = "account quota exhausted";
-      }
-  in
-  Alcotest.(check bool)
-    "ProviderFailure Hard_quota must NOT cascade"
-    false
-    (Oas_compat.Http_client.should_cascade err);
   (match Oas_compat.Http_client.classify err with
-   | Provider_hard_quota -> ()
-   | _ -> Alcotest.fail "Hard_quota must classify as Provider_hard_quota");
-  Alcotest.(check string)
-    "error_message delegates to OAS ProviderFailure renderer"
-    "hard_quota: account quota exhausted"
-    (Oas_compat.Http_client.error_message err)
+   | Provider_capability_mismatch -> ()
+   | _ ->
+       Alcotest.fail
+         "Capability_mismatch must classify as Provider_capability_mismatch")
 
 let test_error_message_baseline () =
   (* Smoke check that the new helper preserves existing semantics for
@@ -237,14 +238,14 @@ let () =
           Alcotest.test_case "Other classify + cascade + message"
             `Quick test_provider_terminal_other;
         ] );
-      ( "ProviderFailure — typed provider failures map to cascade policy",
+      ( "ProviderFailure — typed provider-local skips cascade",
         [
-          Alcotest.test_case "Capacity_exhausted cascades"
+          Alcotest.test_case "Capacity_exhausted classify + cascade"
             `Quick test_provider_failure_capacity_cascades;
-          Alcotest.test_case "Capability_mismatch cascades"
+          Alcotest.test_case "Hard_quota classify + cascade + message"
+            `Quick test_provider_failure_hard_quota_cascades;
+          Alcotest.test_case "Capability_mismatch classify + cascade"
             `Quick test_provider_failure_capability_mismatch_cascades;
-          Alcotest.test_case "Hard_quota stops and renders"
-            `Quick test_provider_failure_hard_quota_stops;
         ] );
       ( "error_message helper baseline",
         [

--- a/test/test_provider_capability_matrix.ml
+++ b/test/test_provider_capability_matrix.ml
@@ -14,11 +14,9 @@
        a subprocess that doesn't read them, and the turn would
        silently degrade.
 
-    2. CLI providers MUST advertise runtime MCP tools and
-       runtime tool events.  This is the lane keeper tools
-       (masc_status, keeper_shell, etc.) flow through.  If
-       this regressed for any CLI the keeper would lose its
-       toolset entirely on that provider.
+    2. CLI providers advertise runtime MCP only when their transport
+       accepts request-scoped MCP/tool events. Gemini CLI is static-config
+       only and must not be routed into a required-tool turn.
 
     The CLI list is exhaustively typed via [match] so adding a
     new CLI variant fails compilation here, not at runtime when
@@ -102,18 +100,23 @@ let test_cli_no_inline_tools () =
         false caps.supports_inline_tool_choice)
     cli_kinds
 
+let expected_cli_runtime_mcp = function
+  | PC.Gemini_cli -> false
+  | Claude_code | Kimi_cli | Codex_cli -> true
+  | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope ->
+      false
+
 let test_cli_runtime_mcp_lane () =
   List.iter
     (fun kind ->
       let caps = PTS.capabilities_of_config (make_cfg ~kind) in
+      let expected = expected_cli_runtime_mcp kind in
       Alcotest.(check bool)
-        ("CLI " ^ kind_label kind
-       ^ " must support runtime MCP tools")
-        true caps.supports_runtime_mcp_tools;
+        ("CLI " ^ kind_label kind ^ " runtime MCP tools")
+        expected caps.supports_runtime_mcp_tools;
       Alcotest.(check bool)
-        ("CLI " ^ kind_label kind
-       ^ " must support runtime tool events")
-        true caps.supports_runtime_tool_events)
+        ("CLI " ^ kind_label kind ^ " runtime tool events")
+        expected caps.supports_runtime_tool_events)
     cli_kinds
 
 (** Total function check: [capabilities_of_config] returns for


### PR DESCRIPTION
## Summary
- route keeper actionable-turn contracts from typed world observations instead of rendered prompt string markers
- surface keeper TOML parse failures in health/source provenance and block actionable keeper_stay_silent turns
- tighten provider/OAS capability boundaries for Gemini CLI and typed ProviderFailure cascade classes
- keep keeper timeout/runtime tests aligned with the hard ceiling and isolate test config roots
- refresh the OCaml structure baseline for current-main `lib/dune` drift; follow-up debt is tracked in #12171
- repair the stale keeper tool-emission hook test fixture for the current Agent SDK schedule record shape
- remove an unreachable cascade-pool `failwith` so the health ratchet stays at `lib_failwith=0`

## Verification
- `bash scripts/health_snapshot.sh --json-out /tmp/health-pr12169.json --baseline-ref origin/main --fail-on-lib-regression`
- `bash scripts/lint/no-unknown-permissive-default.sh`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/dune-local.sh build @check`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-autonomy-bloodflow-0430 -j 1 test/test_keeper_unified.exe test/test_provider_capability_matrix.exe test/test_oas_compat_cascade_fallback.exe test/test_keeper_toml_config_validation.exe test/test_keeper_classifier_helper.exe test/test_cascade_runtime.exe test/test_cascade_catalog_runtime.exe test/test_keeper_terminal_reason.exe test/test_keeper_tool_emission_hook.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_provider_capability_matrix.exe`
- `./_build/default/test/test_oas_compat_cascade_fallback.exe`
- `./_build/default/test/test_keeper_toml_config_validation.exe`
- `./_build/default/test/test_keeper_classifier_helper.exe`
- `./_build/default/test/test_cascade_runtime.exe`
- `./_build/default/test/test_cascade_catalog_runtime.exe`
- `./_build/default/test/test_keeper_terminal_reason.exe`
- `./_build/default/test/test_keeper_tool_emission_hook.exe`
- `git diff --check`
