### PR TITLE
dashboard: F5 goal progress + F6 cascade inspector

### DIFF
--- a/dashboard/src/components/cascade-inspector.ts
+++ b/dashboard/src/components/cascade-inspector.ts
@@ -1,0 +1,242 @@
+// Cascade Inspector — strategy trace, profile health, and candidate deep-dive.
+// Phase F6: O1 Cascade Inspector surface (monitoring section).
+
+import { html } from 'htm/preact'
+import { signal, computed } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import {
+  fetchCascadeStrategyTrace,
+  fetchCascadeHealth,
+  type CascadeStrategyTraceEvent,
+  type CascadeHealthProvider,
+} from '../api/dashboard-cascade'
+import { LoadingState, ErrorState, EmptyState } from './common/feedback-state'
+import { FilterChips } from './common/filter-chips'
+import { StatusBadge } from './common/status-badge'
+import { TimeAgo } from './common/time-ago'
+
+// -- Local state -------------------------------------------------
+
+const traceLoading = signal<boolean>(false)
+const traceError = signal<string | null>(null)
+const traceEvents = signal<CascadeStrategyTraceEvent[]>([])
+const traceUpdatedAt = signal<string>('')
+const healthLoading = signal<boolean>(false)
+const healthError = signal<string | null>(null)
+const healthProviders = signal<CascadeHealthProvider[]>([])
+const selectedCascade = signal<string>('all')
+
+// -- Derived -----------------------------------------------------
+
+const cascadeNames = computed(() => {
+  const names = new Set<string>()
+  for (const e of traceEvents.value) names.add(e.cascade_name)
+  return [...names].sort()
+})
+
+const filteredEvents = computed(() => {
+  const sel = selectedCascade.value
+  if (sel === 'all') return traceEvents.value
+  return traceEvents.value.filter(e => e.cascade_name === sel)
+})
+
+// -- Data fetching -----------------------------------------------
+
+async function refreshTrace() {
+  traceLoading.value = true
+  traceError.value = null
+  try {
+    const res = await fetchCascadeStrategyTrace({ limit: 200 })
+    traceEvents.value = res.events
+    traceUpdatedAt.value = res.updated_at
+  } catch (err) {
+    traceError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    traceLoading.value = false
+  }
+}
+
+async function refreshHealth() {
+  healthLoading.value = true
+  healthError.value = null
+  try {
+    const res = await fetchCascadeHealth()
+    healthProviders.value = res.providers
+  } catch (err) {
+    healthError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    healthLoading.value = false
+  }
+}
+
+export function refreshCascadeInspector(): void {
+  void refreshTrace()
+  void refreshHealth()
+}
+
+// -- Sub-components ----------------------------------------------
+
+function TraceKindBadge({ kind }: { kind: string }) {
+  const tone: 'ok' | 'warn' | 'bad' =
+    kind === 'ordered' ? 'ok'
+    : kind === 'filtered_empty' ? 'warn'
+    : 'bad'
+  const label =
+    kind === 'ordered' ? '정상'
+    : kind === 'filtered_empty' ? '필터링'
+    : '고갈'
+  return html`<${StatusBadge} tone=${tone}>${label}<//>`
+}
+
+function StrategyTraceTable({ events }: { events: CascadeStrategyTraceEvent[] }) {
+  if (events.length === 0) {
+    return html`<${EmptyState} message="전략 추적 이벤트가 없습니다" compact />`
+  }
+
+  return html`
+    <div class="overflow-x-auto rounded border border-card-border/60">
+      <table class="w-full text-left text-xs">
+        <thead class="bg-[var(--white-3)] text-text-muted">
+          <tr>
+            <th class="px-3 py-2 font-semibold">시간</th>
+            <th class="px-3 py-2 font-semibold">Cascade</th>
+            <th class="px-3 py-2 font-semibold">전략</th>
+            <th class="px-3 py-2 font-semibold text-right">Cycle</th>
+            <th class="px-3 py-2 font-semibold text-right">후보</th>
+            <th class="px-3 py-2 font-semibold text-right">백오프(ms)</th>
+            <th class="px-3 py-2 font-semibold">결과</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-card-border/40">
+          ${events.map(e => html`
+            <tr key=${e.ts + e.cascade_name + e.cycle} class="hover:bg-[var(--white-3)] transition-colors">
+              <td class="px-3 py-2 text-text-body whitespace-nowrap">
+                <${TimeAgo} iso=${new Date(e.ts).toISOString()} />
+              </td>
+              <td class="px-3 py-2 font-medium text-text-strong">${e.cascade_name}</td>
+              <td class="px-3 py-2 text-text-body">${e.strategy}</td>
+              <td class="px-3 py-2 text-right tabular-nums text-text-muted">${e.cycle}</td>
+              <td class="px-3 py-2 text-right tabular-nums text-text-muted">${e.candidates_in}→${e.candidates_out}</td>
+              <td class="px-3 py-2 text-right tabular-nums text-text-muted">${e.backoff_ms}</td>
+              <td class="px-3 py-2">
+                <${TraceKindBadge} kind=${e.kind} />
+              </td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+function ProviderHealthTable({ providers }: { providers: CascadeHealthProvider[] }) {
+  if (providers.length === 0) {
+    return html`<${EmptyState} message="프로바이더 건강 데이터가 없습니다" compact />`
+  }
+
+  return html`
+    <div class="overflow-x-auto rounded border border-card-border/60">
+      <table class="w-full text-left text-xs">
+        <thead class="bg-[var(--white-3)] text-text-muted">
+          <tr>
+            <th class="px-3 py-2 font-semibold">프로바이더</th>
+            <th class="px-3 py-2 font-semibold text-right">성공률</th>
+            <th class="px-3 py-2 font-semibold text-right">연속 실패</th>
+            <th class="px-3 py-2 font-semibold">쿨다운</th>
+            <th class="px-3 py-2 font-semibold text-right">이벤트</th>
+            <th class="px-3 py-2 font-semibold text-right">평균 지연(ms)</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-card-border/40">
+          ${providers.map(p => html`
+            <tr key=${p.provider_key} class="hover:bg-[var(--white-3)] transition-colors">
+              <td class="px-3 py-2 font-medium text-text-strong">${p.provider_key}</td>
+              <td class="px-3 py-2 text-right tabular-nums ${p.success_rate >= 0.9 ? 'text-ok' : p.success_rate >= 0.7 ? 'text-warn' : 'text-bad'}">
+                ${Math.round(p.success_rate * 100)}%
+              </td>
+              <td class="px-3 py-2 text-right tabular-nums ${p.consecutive_failures > 2 ? 'text-bad' : 'text-text-muted'}">
+                ${p.consecutive_failures}
+              </td>
+              <td class="px-3 py-2">
+                ${p.in_cooldown
+                  ? html`<${StatusBadge} tone="warn">잇데이 출다욘 징햊학<///>`
+                  : html`<span class="text-text-muted">-</span>`}
+              </td>
+              <td class="px-3 py-2 text-right tabular-nums text-text-muted">${p.events_in_window}</td>
+              <td class="px-3 py-2 text-right tabular-nums text-text-muted">
+                ${p.avg_latency_ms != null ? Math.round(p.avg_latency_ms) : '-'}
+              </td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+// -- Main component ----------------------------------------------
+
+export function CascadeInspector() {
+  useEffect(() => {
+    refreshCascadeInspector()
+  }, [])
+
+  const names = cascadeNames.value
+  const chips = [
+    { key: 'all', label: '전체' },
+    ...names.map(n => ({ key: n, label: n })),
+  ]
+
+  return html`
+    <div class="flex flex-col gap-5">
+      <section class="rounded border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5" aria-label="Cascade 검사기">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div class="text-2xs font-semibold uppercase tracking-[0.18em] text-text-muted">Cascade 검사기</div>
+            <h3 class="mt-2 text-[22px] font-semibold tracking-[-0.02em] text-text-strong">
+              전략 추적 · 프로바이더 건강도
+            </h3>
+            <p class="mt-2 text-sm leading-relaxed text-text-muted">
+              cascade 의사결정 이력과 프로바이더 상태를 한 화면에서 봅니다.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4" aria-label="전략 추적">
+        <div class="flex flex-wrap items-center justify-between gap-3 mb-3">
+          <div>
+            <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted">전략 추적</div>
+            <h3 class="mt-1 text-md font-semibold text-text-strong">최근 이벤트</h3>
+          </div>
+          ${names.length > 0 ? html`
+            <${FilterChips}
+              chips=${chips}
+              value=${selectedCascade.value}
+              onChange=${(v: string) => { selectedCascade.value = v }}
+            />
+          ` : null}
+        </div>
+        ${traceLoading.value
+          ? html`<${LoadingState}>이벤트 불러오는 중...<//>`
+          : traceError.value
+            ? html`<${ErrorState} message=${traceError.value} onRetry=${refreshTrace} />`
+            : html`<${StrategyTraceTable} events=${filteredEvents.value} />`
+        }
+      </section>
+
+      <section class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4" aria-label="프로바이더 건강도">
+        <div class="mb-3">
+          <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted">프로바이더</div>
+          <h3 class="mt-1 text-md font-semibold text-text-strong">건강도 스냅숏</h3>
+        </div>
+        ${healthLoading.value
+          ? html`<${LoadingState}>건강도 불러오는 중...<//>`
+          : healthError.value
+            ? html`<${ErrorState} message=${healthError.value} onRetry=${refreshHealth} />`
+            : html`<${ProviderHealthTable} providers=${healthProviders.value} />`
+        }
+      </section>
+    </div>
+  `
+}

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -1,5 +1,6 @@
 // Goal-related types, signals, derived data, and helper functions
 
+import { html } from 'htm/preact'
 import { signal, computed } from '@preact/signals'
 import {
   goals,
@@ -169,6 +170,26 @@ export const horizonProgress = computed<Record<'short' | 'mid' | 'long', GoalPro
 export function formatProgressPct(p: GoalProgress): string {
   if (p.total === 0) return '0%'
   return `${Math.round(p.ratio * 100)}%`
+}
+
+export function TaskProgressBar({ done, total, size = 'md' }: { done: number; total: number; size?: 'sm' | 'md' }) {
+  const ratio = total > 0 ? done / total : 0
+  const pct = Math.round(ratio * 100)
+  const barColor =
+    pct >= 80 ? 'var(--color-status-ok)'
+    : pct >= 50 ? 'var(--amber-bright)'
+    : pct >= 20 ? '#fb923c'
+    : 'var(--color-status-err)'
+
+  const h = size === 'sm' ? 'h-1.5' : 'h-2.5'
+  return html`
+    <div class="flex items-center gap-2">
+      <div class="flex-1 ${h} rounded-sm bg-[var(--white-10)] overflow-hidden">
+        <div class="${h} rounded-sm transition-all duration-500" style="width:${pct}%;background:${barColor}"></div>
+      </div>
+      <span class="text-2xs font-semibold tabular-nums text-text-muted w-14 text-right">${done}/${total}</span>
+    </div>
+  `
 }
 
 // -- Helpers -----------------------------------------------------

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -42,6 +42,7 @@ import {
   goalPhaseStatus,
   matchesGoalPhaseFilter,
   phaseFilterLabel,
+  TaskProgressBar,
 } from './goal-helpers'
 
 type GoalDetailTab = 'summary' | 'tasks' | 'evidence'
@@ -599,7 +600,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
           <div class="flex flex-wrap items-center gap-2.5 text-2xs text-text-muted">
             <${HealthBadge} health=${node.health} />
             <${StatusBadge} status=${node.status} />
-            ${node.task_count > 0 ? html`<span>${node.task_done_count}/${node.task_count} 태스크</span>` : null}
+            ${node.task_count > 0 ? html`<div class="w-32"><${TaskProgressBar} done=${node.task_done_count} total=${node.task_count} size="sm" /></div>` : null}
             ${node.metric ? html`
               <span
                 class="rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-1.5 py-0.5 font-mono text-3xs text-text-secondary"

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -17,6 +17,10 @@ import {
   groupedByHorizon,
   horizonProgress,
   formatProgressPct,
+  goalProgressFor,
+  TaskProgressBar,
+  horizonLabel,
+  goalPhaseLabel,
 } from './goal-helpers'
 import { TaskBacklog } from './kanban-components'
 import { TaskStaleAlert } from './task-stale-alert'
@@ -368,6 +372,37 @@ export function Planning() {
                 ` : null}
               </div>
             ` : null}
+            <div class="mt-4 flex flex-col gap-3">
+              ${(['short', 'mid', 'long'] as const).map(h => {
+                const list = grouped[h] ?? []
+                if (list.length === 0) return null
+                return html`
+                  <div key=${h}>
+                    <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted mb-2">
+                      ${horizonLabel(h)} 목표
+                    </div>
+                    <div class="flex flex-col gap-2">
+                      ${list.map(g => {
+                        const p = goalProgressFor(g.id)
+                        return html`
+                          <div key=${g.id} class="flex items-center gap-3 rounded border border-card-border/60 bg-[var(--white-3)] px-3 py-2">
+                            <div class="min-w-0 flex-1">
+                              <div class="flex items-center gap-2">
+                                <span class="text-xs font-medium text-text-strong truncate">${g.title}</span>
+                                <span class="shrink-0 rounded border border-card-border/70 bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-text-muted">${goalPhaseLabel(g.phase)}</span>
+                              </div>
+                            </div>
+                            <div class="w-28">
+                              <${TaskProgressBar} done=${p.done} total=${p.total} size="sm" />
+                            </div>
+                          </div>
+                        `
+                      })}
+                    </div>
+                  </div>
+                `
+              })}
+            </div>
           </div>
         ` : html`
           <p class="mt-2 text-sm text-text-muted">등록된 목표가 없습니다. 목표 트리에서 추가할 수 있습니다.</p>

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -9,6 +9,7 @@ import { LoadingState } from './common/feedback-state'
 
 type StatusSection =
   | 'live' | 'observatory' | 'journey' | 'git-graph' | 'agents' | 'runtime' | 'fleet-health'
+  | 'cascade-inspector'
   | 'safe-autonomy'
   | 'memory-subsystems' | 'attribution'
   | 'cost'
@@ -46,6 +47,9 @@ const LazySafeAutonomyPanel = lazy(async () => ({
 const LazyCostDashboard = lazy(async () => ({
   default: (await import('./cost-dashboard')).CostDashboard,
 }))
+const LazyCascadeInspector = lazy(async () => ({
+  default: (await import('./cascade-inspector')).CascadeInspector,
+}))
 
 function sectionFallback(label: string) {
   return html`<${LoadingState}>${label} 불러오는 중...<//>`
@@ -75,6 +79,8 @@ function sectionLabel(section: StatusSection): string {
       return '에이전트 상태'
     case 'cost':
       return '비용 / 지연'
+    case 'cascade-inspector':
+      return 'Cascade 검사기'
   }
 }
 
@@ -102,6 +108,8 @@ function renderSection(section: StatusSection) {
       return html`<${LazyAgentsUnified} />`
     case 'cost':
       return html`<${LazyCostDashboard} />`
+    case 'cascade-inspector':
+      return html`<${LazyCascadeInspector} />`
   }
 }
 
@@ -118,6 +126,7 @@ function currentSection(): StatusSection {
     || section === 'memory-subsystems'
     || section === 'attribution'
     || section === 'cost'
+    || section === 'cascade-inspector'
   ) return section
   return 'agents'
 }

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -12,6 +12,7 @@ type SurfaceSectionId =
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
   | 'safe-autonomy'
   | 'cost'           // O4 cost/latency dashboard zone (#11542); use-site existed without type entry
+  | 'cascade-inspector' // O1 Cascade Inspector surface (Phase F6)
   | 'memory-subsystems'
   | 'attribution'     // Layer 4 gate-chain observation (per-gate outcome + recent events)
   // command
@@ -170,6 +171,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '캐스케이드',
       description: 'Provider 건강도, 슬롯 용량, 모델 선택 스냅샷을 한 화면에서 봅니다.',
       params: { section: 'runtime' },
+    },
+    {
+      id: 'cascade-inspector',
+      label: 'Cascade 검사기',
+      description: 'Cascade 의사결정 이력과 프로바이더 상태를 한 화면에서 봅니다.',
+      params: { section: 'cascade-inspector' },
     },
     {
       id: 'fleet-health',

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -49,6 +49,11 @@ async function refreshDoctorSurface(): Promise<void> {
   await refreshDoctor()
 }
 
+async function refreshCascadeInspectorSurface(): Promise<void> {
+  const { refreshCascadeInspector } = await import('./components/cascade-inspector')
+  await refreshCascadeInspector()
+}
+
 type RefreshTask =
   | 'shell'
   | 'namespaceTruth'
@@ -63,6 +68,7 @@ type RefreshTask =
   | 'harness'
   | 'toolQuality'
   | 'inspector'
+  | 'cascadeInspector'
   | 'operatorSnapshot'
   | 'operatorRoomDigest'
 
@@ -87,6 +93,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
         return ['namespaceTruth', 'execution', 'missionSnapshot']
       }
       // fleet-health: view-aware refresh (Phase 1 contract from tab-refresh.test.ts)
+      if (routeState.params.section === 'cascade-inspector') {
+        return ['cascadeInspector']
+      }
       if (routeState.params.section === 'fleet-health') {
         const view = routeState.params.view
         if (view === 'tool-quality') return ['toolQuality']
@@ -148,6 +157,7 @@ const REFRESHERS: Record<RefreshTask, (routeState: Pick<RouteState, 'tab' | 'par
     void refreshServerConfigSurface()
     void refreshDoctorSurface()
   },
+  cascadeInspector: () => { void refreshCascadeInspectorSurface() },
   operatorSnapshot: () => { void refreshOperatorSnapshot({ force: true }) },
   operatorRoomDigest: () => { void refreshOperatorRoomDigest({ force: true }) },
 }


### PR DESCRIPTION
## Summary
- F5: Add per-goal progress bars in Planning surface using shared TaskProgressBar component
- F6: Add new Cascade Inspector surface with strategy trace events and provider health snapshot

## Changes
- `goal-helpers.ts`: Extract TaskProgressBar for reuse across goal-tree and planning
- `planning.ts`: Render progress cards for each goal grouped by horizon
- `cascade-inspector.ts`: New component with FilterChips, strategy trace table, provider health table
- `navigation.ts`, `status.ts`, `tab-refresh.ts`: Wire new surface into dashboard shell

## Test plan
- [x] pnpm typecheck passes
- [x] pnpm lint passes
- [ ] Verify TaskProgressBar renders in Planning and GoalTree
- [ ] Verify CascadeInspector loads strategy trace and health data

🤖 Generated with [Claude Code](https://claude.com/claude-code)