### PR TITLE
specs(autonomous): add AutonomousLoop Bug Model (RFC-Q2-1)

### DIFF
--- a/specs/autonomous/AutonomousLoop-buggy.cfg
+++ b/specs/autonomous/AutonomousLoop-buggy.cfg
@@ -1,0 +1,20 @@
+\* Buggy model: AutoTick observer becomes invasive — flips
+\* keeper_phase to "draining" while still ticking. Expected:
+\* TickOnlyDuringRunning VIOLATED on the second tick (which fires
+\* while keeper_phase = "draining").
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxKeeperSteps = 3
+    MaxAutoTicks = 3
+
+CONSTRAINT
+    BoundedSteps
+
+CHECK_DEADLOCK
+    FALSE
+
+INVARIANTS
+    TypeOK
+    MetaPersistedAfterTick
+    TickOnlyDuringRunning

--- a/specs/autonomous/AutonomousLoop.tla
+++ b/specs/autonomous/AutonomousLoop.tla
@@ -112,6 +112,31 @@ BoundedSteps ==
     /\ keeper_steps <= MaxKeeperSteps
     /\ auto_ticks <= MaxAutoTicks
 
+\* ── Bug model (RFC-Q2-1) ────────────────────────────────────────
+\*
+\* Models the bug class where the autonomous tick observer becomes
+\* invasive — i.e. a tick mutates keeper_phase in addition to its
+\* own meta update. The OCaml-side guard
+\* [Keeper_post_turn.apply_autonomous_wirein] enforces read-only
+\* access to the keeper FSM; the spec verifies that even if that
+\* constraint were bypassed (e.g. via Obj.magic or a refactor
+\* that loses the guard), TickOnlyDuringRunning catches the next
+\* tick after the keeper has been pushed to draining.
+
+AutoTickFlipsKeeperPhase ==
+    /\ keeper_phase = "running"
+    /\ \E next_auto \in AutoPhases : autonomous_phase' = next_auto
+    /\ meta_present' = TRUE
+    /\ auto_ticks' = auto_ticks + 1
+    /\ keeper_phase' = "draining"   \* INVASIVE: must be preserved
+    /\ keeper_steps' = keeper_steps + 1
+
+NextBuggy ==
+    \/ Next
+    \/ AutoTickFlipsKeeperPhase
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
 THEOREM Spec => []TypeOK
 THEOREM Spec => []MetaPersistedAfterTick
 THEOREM Spec => []TickOnlyDuringRunning


### PR DESCRIPTION
## Summary

Fourth Phase 3 RFC stub implementation. Adds Bug Model to `specs/autonomous/AutonomousLoop.tla`.

## Bug class

The autonomous tick observer becomes invasive — a tick mutates `keeper_phase` in addition to its own meta update. The OCaml-side guard `Keeper_post_turn.apply_autonomous_wirein` enforces read-only access to the keeper FSM; the spec verifies that even if that constraint were bypassed, `TickOnlyDuringRunning` catches the next tick after the keeper has been pushed to draining.

```tla
AutoTickFlipsKeeperPhase ==
    /\ keeper_phase = "running"
    /\ \E next_auto \in AutoPhases : autonomous_phase' = next_auto
    /\ meta_present' = TRUE
    /\ auto_ticks' = auto_ticks + 1
    /\ keeper_phase' = "draining"   \* INVASIVE: must be preserved
    /\ keeper_steps' = keeper_steps + 1
```

## Domain coverage

autonomous **2/2** (both AutonomousLoop RFC-Q2-1 and AutonomousPhase RFC-Q2-2 #12160 covered).

Combined with Cycle 25 sibling (resilience RFC-Q2-6): **0%-coverage domains 4 → 2** (only masc-ecosystem and shared remain).

## References

- PR #12137 — Phase 3 RFC stubs (parent, RFC-Q2-1 source)
- PR #12160, #12167, #12168 — sibling Bug Models
- `lib/keeper/keeper_post_turn.ml` — runtime guard (`apply_autonomous_wirein`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
