### PR TITLE
specs(resilience): add ResilienceDegradation Bug Model (RFC-Q2-6)

### DIFF
--- a/specs/resilience/ResilienceDegradation-buggy.cfg
+++ b/specs/resilience/ResilienceDegradation-buggy.cfg
@@ -1,0 +1,17 @@
+\* Buggy model: lattice monotonicity bypassed. Any level
+\* transition allowed, including L4 -> L1 regression. Expected:
+\* MonotonicDegradation VIOLATED in 2 steps (escalate to L4,
+\* then regress to any lower level).
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxDecisions = 3
+
+CONSTRAINT
+    BoundedDecisions
+
+INVARIANTS
+    TypeOK
+    MonotonicDegradation
+    NoRetryAtL4Permanent
+    NoRetryAtL4Exhausted

--- a/specs/resilience/ResilienceDegradation.tla
+++ b/specs/resilience/ResilienceDegradation.tla
@@ -152,6 +152,29 @@ Spec == Init /\ [][Next]_vars
 
 BoundedDecisions == Len(decisions) <= MaxDecisions
 
+\* ── Bug model (RFC-Q2-6) ────────────────────────────────────────
+\*
+\* Models the bug class where the lattice monotonicity is broken —
+\* operator-authorised L4 transparently drops back to L1 without
+\* an explicit recovery action. The clean EscalateLevel only allows
+\* level transitions where the level index increases (or holds).
+\* The bug action drops that constraint, allowing arbitrary
+\* lattice regression.
+
+LatticeRegress(new_level) ==
+    /\ new_level \in Levels
+    /\ new_level # level
+    \* deliberately omitted: the EscalateLevel monotonicity check.
+    \* Any transition is allowed, including L4 -> L1 regression.
+    /\ level' = new_level
+    /\ UNCHANGED decisions
+
+NextBuggy ==
+    \/ Next
+    \/ \E new_level \in Levels : LatticeRegress(new_level)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
 THEOREM Spec => []TypeOK
 THEOREM Spec => []MonotonicDegradation
 THEOREM Spec => []NoRetryAtL4Permanent


### PR DESCRIPTION
## Summary

Fifth Phase 3 RFC stub implementation. Adds Bug Model to `specs/resilience/ResilienceDegradation.tla`.

## Bug class

Lattice monotonicity bypassed — operator-authorised L4 transparently drops back to L1 (or any other lower level) without an explicit recovery action.

```tla
LatticeRegress(new_level) ==
    /\ new_level \in Levels
    /\ new_level # level
    \* deliberately omitted: the EscalateLevel monotonicity check.
    \* Any transition is allowed, including L4 -> L1 regression.
    /\ level' = new_level
    /\ UNCHANGED decisions
```

## Domain coverage

resilience **2/2** (both ResilienceDegradation RFC-Q2-6 and ResilienceOutcome RFC-Q2-7 #12168 covered).

Combined with Cycle 24 sibling: **0%-coverage domains 4 → 2** (only masc-ecosystem and shared remain).

## Expected TLC

- **Clean cfg**: passes `MonotonicDegradation`
- **Buggy cfg**: violates `MonotonicDegradation` in 2 steps (escalate to L4, regress to lower level)

## References

- PR #12137 — Phase 3 RFC stubs (parent, RFC-Q2-6 source)
- PR #12168 — sibling resilience Bug Model (ResilienceOutcome)
- `lib/resilience/degradation.{ml,mli}` — runtime side (4-level lattice)
- `feedback_no-string-matching-classification` — variant-based classification preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)
