### PR TITLE
specs(audit_log): adopt [@@deriving tla] on action

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -29,23 +29,24 @@ type governance_audit_decision =
   | Governance_other of string
 
 type action =
-  | Join
-  | Leave
-  | ClaimTask
-  | StartTask
-  | DoneTask
-  | CancelTask
-  | ReleaseTask
-  | Broadcast
-  | Suspend
-  | ToolCall of string
-  | AuthSuccess
-  | AuthFailure
-  | CircuitOpen
-  | CircuitClose
-  | SearchRefinement
-  | GovernanceDecision of governance_audit_decision
-  | Custom of string
+  | Join [@tla.symbol "join"]
+  | Leave [@tla.symbol "leave"]
+  | ClaimTask [@tla.symbol "claim_task"]
+  | StartTask [@tla.symbol "start_task"]
+  | DoneTask [@tla.symbol "done_task"]
+  | CancelTask [@tla.symbol "cancel_task"]
+  | ReleaseTask [@tla.symbol "release_task"]
+  | Broadcast [@tla.symbol "broadcast"]
+  | Suspend [@tla.symbol "suspend"]
+  | ToolCall of string [@tla.symbol "tool_call"]
+  | AuthSuccess [@tla.symbol "auth_success"]
+  | AuthFailure [@tla.symbol "auth_failure"]
+  | CircuitOpen [@tla.symbol "circuit_open"]
+  | CircuitClose [@tla.symbol "circuit_close"]
+  | SearchRefinement [@tla.symbol "search_refinement"]
+  | GovernanceDecision of governance_audit_decision [@tla.symbol "governance_decision"]
+  | Custom of string [@tla.symbol "custom"]
+[@@deriving tla]
 
 type audit_entry = {
   timestamp: float;

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -58,6 +58,7 @@ type action =
   | SearchRefinement
   | GovernanceDecision of governance_audit_decision
   | Custom of string
+[@@deriving tla]
 
 type audit_entry = {
   timestamp : float;


### PR DESCRIPTION
## Summary

Fourth `[@@deriving tla]` adoption. Boundary 18-spec full sweep (#12159) §3 priority 2 candidate. Largest single adoption to date — 17 variants vs 8 for cascade_strategy.kind (#12158).

```ocaml
type action =
  | Join [@tla.symbol "join"]
  | Leave [@tla.symbol "leave"]
  ... (12 nullary + 5 payload-bearing) ...
  | Custom of string [@tla.symbol "custom"]
[@@deriving tla]
```

`[@tla.symbol]` overrides applied to ALL 17 constructors with snake_case convention matching MASC audit category strings.

## Coverage growth

`ppx_deriving_tla_modules`: 6 → **7**.

## Spec linkage

`specs/boundary/AuditLog.tla` literal set is now drift-free with the OCaml type. Adding a new audit category regenerates symbols automatically; the audit log envelope's `Envelope.t.category` field consumers can use `to_tla_symbol` or `all_symbols` for switch-case generation.

## Test plan

- [x] `dune build --root . @lib/check` exit 0 (warnings unrelated, pre-existing)
- [x] `[@tla.symbol]` snake_case follows `governance_decision` precedent
- [x] All 17 constructors annotated (nullary + payload-bearing)
- [ ] Downstream consumers of `kind_to_string` etc. continue to work (out of scope)

## References

- PR #12150, #12158, #12166 — sibling adoptions (resilience, cascade, audit_log.outcome)
- PR #12159 — boundary sweep ranked this candidate at priority 2
- `lib/audit_log.{ml,mli}` — adoption site

🤖 Generated with [Claude Code](https://claude.com/claude-code)
