### PR TITLE
specs(multimodal): add MultimodalHydrator Bug Model (RFC-Q2-5)

### DIFF
--- a/specs/multimodal/MultimodalHydrator-buggy.cfg
+++ b/specs/multimodal/MultimodalHydrator-buggy.cfg
@@ -1,0 +1,20 @@
+\* Buggy model: hydrator add_edge accepts self-loops (from_id /=
+\* to_id check dropped). Expected: NoSelfLoop VIOLATED in 1 step
+\* after first AddSelfLoop fires.
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    Nodes = {a1, a2, a3}
+    MaxEdges = 3
+
+CONSTRAINT
+    BoundedEdges
+
+INVARIANTS
+    TypeOK
+    NoSelfLoop
+    NoCycleBounded
+    DedupeIdempotent
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/multimodal/MultimodalHydrator.tla
+++ b/specs/multimodal/MultimodalHydrator.tla
@@ -102,6 +102,26 @@ Spec == Init /\ [][Next]_vars
 
 BoundedEdges == Cardinality(edges) <= MaxEdges
 
+\* ── Bug model (RFC-Q2-5) ────────────────────────────────────────
+\*
+\* Models the bug class where the hydrator's add_edge precondition
+\* check on from_id /= to_id is bypassed (the spec header notes
+\* the runtime is more permissive than the spec forbids; a
+\* refactor that loses the production-side guard reproduces the
+\* bug). NoSelfLoop catches this on the first reflexive edge.
+
+AddSelfLoop(node) ==
+    /\ <<node, node>> \notin edges
+    /\ Cardinality(edges) < MaxEdges
+    \* deliberately omitted: from_id /= to_id check
+    /\ edges' = edges \cup { <<node, node>> }
+
+NextBuggy ==
+    \/ Next
+    \/ \E node \in Nodes : AddSelfLoop(node)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
 THEOREM Spec => []TypeOK
 THEOREM Spec => []NoSelfLoop
 THEOREM Spec => []NoCycleBounded


### PR DESCRIPTION
## Summary

Sixth Phase 3 RFC stub implementation. Adds Bug Model to `specs/multimodal/MultimodalHydrator.tla`.

## Phase 3 reclassification

Phase 3 §3 originally classified RFC-Q2-5 as **"needs prereq"** (NoSelfLoop addition to clean cfg). Verified during implementation: **NoSelfLoop is already in the clean cfg INVARIANTS list**. Phase 3's classification was conservative — actual case is strong-invariant.

This mirrors the same audit conservative-bias pattern as Q-P0-2 Phase 2 (21 tautology candidates → 0 actual). Audit chains favour over-classifying as "needs work" rather than missing real gaps; follow-up implementation cycles surface the false positives.

## Bug class

The spec header itself notes:

> "The hydrator's actual add_edge is more permissive (it would accept a self-loop if both endpoints exist), but the spec forbids them as an invariant — production code must reject."

A refactor losing the production-side guard reproduces the bug. Action `AddSelfLoop` drops the `from_id /= to_id` check.

## Domain coverage

multimodal **2/2** (both MultimodalArtifact RFC-Q2-4 #12167 and MultimodalHydrator RFC-Q2-5 covered).

## References

- PR #12137 — Phase 3 RFC stubs (parent, RFC-Q2-5 source)
- PR #12132 §6 — Q-P0-2 audit chain Phase 2 (same conservative-bias correction pattern)
- `lib/multimodal/multimodal_hydrator.{ml,mli}` — runtime side (`add_edge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
