### PR TITLE
specs(audit_log): adopt [@@deriving tla] on governance_audit_decision

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -20,13 +20,14 @@ type outcome =
 [@@deriving tla]
 
 type governance_audit_decision =
-  | Governance_allow
-  | Governance_require_confirm
-  | Governance_deny
-  | Governance_confirm
-  | Governance_expired
-  | Governance_unauthorized
-  | Governance_other of string
+  | Governance_allow [@tla.symbol "governance_allow"]
+  | Governance_require_confirm [@tla.symbol "governance_require_confirm"]
+  | Governance_deny [@tla.symbol "governance_deny"]
+  | Governance_confirm [@tla.symbol "governance_confirm"]
+  | Governance_expired [@tla.symbol "governance_expired"]
+  | Governance_unauthorized [@tla.symbol "governance_unauthorized"]
+  | Governance_other of string [@tla.symbol "governance_other"]
+[@@deriving tla]
 
 type action =
   | Join

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -39,6 +39,7 @@ type governance_audit_decision =
   | Governance_expired
   | Governance_unauthorized
   | Governance_other of string
+[@@deriving tla]
 
 type action =
   | Join


### PR DESCRIPTION
## Summary

Fifth `[@@deriving tla]` adoption. Boundary 18-spec full sweep (#12159) §3 priority 3 candidate. 7-variant ADT (6 nullary + 1 payload-bearing).

```ocaml
type governance_audit_decision =
  | Governance_allow [@tla.symbol "governance_allow"]
  | Governance_require_confirm [@tla.symbol "governance_require_confirm"]
  | Governance_deny [@tla.symbol "governance_deny"]
  | Governance_confirm [@tla.symbol "governance_confirm"]
  | Governance_expired [@tla.symbol "governance_expired"]
  | Governance_unauthorized [@tla.symbol "governance_unauthorized"]
  | Governance_other of string [@tla.symbol "governance_other"]
[@@deriving tla]
```

## Coverage growth

`ppx_deriving_tla_modules`: 7 → **8**.

## AuditLog ADT family completion

This adoption completes the AuditLog ADT family hookup: `outcome` (#12166), `action` (#12176), and now `governance_audit_decision`. The `action` ADT carries `GovernanceDecision of governance_audit_decision`; this PR makes the nested type itself drift-free with the spec literal set.

## References

- PR #12150, #12158, #12166, #12176 — sibling adoptions
- PR #12159 — boundary sweep ranked this candidate at priority 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
