### PR TITLE
specs(shared): add SharedAudit Bug Model (RFC-Q2-8)

### DIFF
--- a/specs/shared/SharedAudit-buggy.cfg
+++ b/specs/shared/SharedAudit-buggy.cfg
@@ -1,0 +1,18 @@
+\* Buggy model: Envelope.make computes stale prev_hash (or skips
+\* the chain link entirely after genesis). Expected:
+\* ChainIntegrity VIOLATED in 2 steps (one good entry, then one
+\* with stale GenesisHash).
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    Ids = {id1, id2, id3, id4}
+    Categories = {RecoveryAttempted, DegradationTriggered}
+
+CONSTRAINT
+    BoundedEntries
+
+INVARIANTS
+    TypeOK
+    IdsUnique
+    ChainIntegrity
+    EntryIdMinted

--- a/specs/shared/SharedAudit.tla
+++ b/specs/shared/SharedAudit.tla
@@ -111,6 +111,31 @@ Spec == Init /\ [][Next]_vars
 \* enumerate exhaustively. Wired in via the .cfg CONSTRAINT.
 BoundedEntries == Len(entries) <= 3
 
+\* ── Bug model (RFC-Q2-8) ────────────────────────────────────────
+\*
+\* Models the bug class where Envelope.make computes prev_hash
+\* incorrectly — uses GenesisHash for a non-genesis entry (e.g.
+\* race with a concurrent appender, or a refactor that lost the
+\* chain-link computation). The clean ChainIntegrity invariant
+\* catches this: every i >= 2 must have prev_hash = HashOf(prev).
+
+AppendEntryWithStaleHash(new_id, cat) ==
+    /\ new_id \notin used_ids
+    /\ Len(entries) > 0  \* genesis case is fine; bug is for follow-on entries
+    /\ used_ids' = used_ids \cup {new_id}
+    /\ entries' =
+            Append(entries,
+                   [ id |-> new_id,
+                     category |-> cat,
+                     prev_hash |-> GenesisHash ])  \* stale: should be HashOf(prev)
+
+NextBuggy ==
+    \/ Next
+    \/ \E new_id \in Ids, cat \in Categories :
+            AppendEntryWithStaleHash(new_id, cat)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
 THEOREM Spec => []TypeOK
 THEOREM Spec => []IdsUnique
 THEOREM Spec => []ChainIntegrity


### PR DESCRIPTION
## Summary

Seventh Phase 3 RFC stub implementation. Adds Bug Model to `specs/shared/SharedAudit.tla`.

## Phase 3 reclassification (same as Q2-5)

Phase 3 §3 originally classified RFC-Q2-8 as **"needs prereq"** (ChainIntegrity invariant addition). Verified: **ChainIntegrity is already in the clean cfg INVARIANTS list**. Strong-invariant case after all.

Pattern: 2 of 3 originally-prereq RFCs (Q2-5 multimodal, Q2-8 shared) turned out to be strong-invariant. Q2-3 (MASCEcosystem AtMostOneAgentPerTask) remains the only true prereq case.

## Bug class

Models the case where `Envelope.make` computes `prev_hash` incorrectly — uses `GenesisHash` for a non-genesis entry (race with concurrent appender, or refactor that lost the chain-link computation).

```tla
AppendEntryWithStaleHash(new_id, cat) ==
    /\ new_id \notin used_ids
    /\ Len(entries) > 0  \* genesis case is fine; bug is for follow-on entries
    /\ used_ids' = used_ids \cup {new_id}
    /\ entries' =
            Append(entries,
                   [ id |-> new_id,
                     category |-> cat,
                     prev_hash |-> GenesisHash ])  \* stale: should be HashOf(prev)
```

## Expected TLC

- **Clean cfg**: passes `ChainIntegrity`
- **Buggy cfg**: violates `ChainIntegrity` in 2 steps (one good entry, then one with stale GenesisHash)

## Domain coverage

shared **1/1** (only spec in domain). Combined with sibling Cycle 27, **0%-coverage domains 2 → 0** if we exclude masc-ecosystem (still pending Q2-3 with prereq AtMostOneAgentPerTask invariant).

Actually rephrase: Phase 1 listed 5 zero-coverage domains. After Cycles 20, 22, 23, 24, 25, 27, 29: only **masc-ecosystem** remains.

## References

- PR #12137 — Phase 3 RFC stubs (parent, RFC-Q2-8 source)
- `lib/shared_audit/{envelope,store}.{ml,mli}` — runtime side (Merkle chain)
- Memory: `feedback_self_confession_comments_must_be_measured` — applied here: spec invariant declarations are sound, audit's "needs prereq" was unverified speculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
