### PR TITLE
fix(config,spec): remove merge conflict marker and TLA+ contradiction

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -385,7 +385,6 @@ module KeeperKeepalive = struct
   let turn_timeout_sec =
     Float.max 60.0 (Float.min timeout_hard_ceiling_sec
       (get_float ~default:3600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
->>>>>>> 8a608170c8 (feat(resilience): bulkhead pattern - ZOMBIE state, terminal_failure_latched, cascade pool)
 
   (** Maximum time a proactive keeper will wait in the MASC admission queue
       before abandoning the current OAS attempt.

--- a/specs/keeper-state-machine/KeeperStateMachine.tla
+++ b/specs/keeper-state-machine/KeeperStateMachine.tla
@@ -376,7 +376,7 @@ TerminalFailureDetected ==
                    stop_requested, restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete,
                    context_overflow, compact_retry_exhausted,
-                   terminal_failure_latched, restart_count>>
+                   restart_count>>
 
 \* ── Overflow Lifecycle Events ─────────────────────────────
 


### PR DESCRIPTION
## Summary

- **lib/config/env_config_keeper.ml**: Remove unresolved merge conflict marker (`>>>>>>> 8a608170c8...`) that was left in main after squash-merged PR #12130. This caused a syntax error breaking dune builds.

- **specs/keeper-state-machine/KeeperStateMachine.tla**: Fix contradiction in `TerminalFailureDetected` action where `terminal_failure_latched` was both primed-assigned (`= TRUE`) and included in the `UNCHANGED` tuple.

## Test plan
- [ ] dune build passes past `lib/config/` (verified locally)
- [ ] TLA+ syntax check passes
- [ ] No semantic changes to runtime behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)