### PR TITLE
specs(masc-ecosystem): add MASCEcosystem Bug Model + AtMostOneAgentPerTask (RFC-Q2-3, closes Phase 3)

### DIFF
--- a/specs/masc-ecosystem/MASCEcosystem-buggy.cfg
+++ b/specs/masc-ecosystem/MASCEcosystem-buggy.cfg
@@ -1,0 +1,17 @@
+\* Buggy model: AgentClaimsTask race — two agents end up claiming
+\* the same task because the [tasks_status = Pending] precondition
+\* was dropped in a refactor. Expected: AtMostOneAgentPerTask
+\* VIOLATED in 2 steps after both agents are in the room and one
+\* claim already happened.
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    Agents = {"A1", "A2"}
+    Keepers = {"K1", "K2"}
+    Tasks = {"T1"}
+    MaxContext = 100
+
+INVARIANTS
+    NoContextOverflow
+    SingleTaskPerAgent
+    AtMostOneAgentPerTask

--- a/specs/masc-ecosystem/MASCEcosystem.cfg
+++ b/specs/masc-ecosystem/MASCEcosystem.cfg
@@ -10,6 +10,7 @@ CONSTANTS
 INVARIANTS
     NoContextOverflow
     SingleTaskPerAgent
+    AtMostOneAgentPerTask
 
 \* Liveness properties remain temporal.
 PROPERTIES

--- a/specs/masc-ecosystem/MASCEcosystem.tla
+++ b/specs/masc-ecosystem/MASCEcosystem.tla
@@ -109,6 +109,37 @@ NoContextOverflow == \A k \in Keepers: keeper_context[k] <= MaxContext
 \* 2. A normal Agent can only have one task at a time
 SingleTaskPerAgent == \A a \in Agents: agent_tasks[a] = "None" \/ agent_tasks[a] \in Tasks
 
+\* 3. A task is claimed by at most one agent at any moment.
+\*    SingleTaskPerAgent constrains the per-agent side; this
+\*    constrains the per-task side. Required as the prereq for the
+\*    DoubleClaim Bug Model (RFC-Q2-3).
+AtMostOneAgentPerTask ==
+    \A t \in Tasks :
+        Cardinality({a \in Agents : agent_tasks[a] = t}) <= 1
+
+\* ── Bug model (RFC-Q2-3) ────────────────────────────────────────
+\*
+\* Models the bug class where two agents end up claiming the same
+\* task — e.g. a race in agent_tasks update without a CAS guard,
+\* or a refactor that loses the [tasks_status[t] = "Pending"]
+\* check. The clean AgentClaimsTask enforces the precondition;
+\* the buggy variant drops it.
+
+DoubleClaim(a, t) ==
+    /\ a \in room_agents
+    /\ agent_tasks[a] = "None"
+    \* deliberately omitted: tasks_status[t] = "Pending"
+    /\ \E other \in Agents : agent_tasks[other] = t  \* force overlap
+    /\ agent_tasks' = [agent_tasks EXCEPT ![a] = t]
+    /\ UNCHANGED <<room_agents, tasks_status, keeper_context,
+                   keeper_gen, board_posts>>
+
+NextBuggy ==
+    \/ Next
+    \/ \E a \in Agents, t \in Tasks : DoubleClaim(a, t)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars /\ Fairness
+
 \* ── Liveness Properties ───────────────────────────────────
 
 \* 3. A Task is eventually completed by an Agent


### PR DESCRIPTION
## Summary

Eighth and final Phase 3 RFC stub implementation. Adds Bug Model + prereq invariant to `specs/masc-ecosystem/MASCEcosystem.tla`. **Closes Phase 3 RFC stub queue (8/8)**.

## Prereq invariant added

```tla
\* 3. A task is claimed by at most one agent at any moment.
\*    SingleTaskPerAgent constrains the per-agent side; this
\*    constrains the per-task side. Required as the prereq for the
\*    DoubleClaim Bug Model.
AtMostOneAgentPerTask ==
    \A t \in Tasks :
        Cardinality({a \in Agents : agent_tasks[a] = t}) <= 1
```

The clean Spec satisfies it because `AgentClaimsTask` requires `tasks_status[t] = "Pending"` and transitions to `"InProgress"`, preventing concurrent claims.

## Bug class

`AgentClaimsTask` race — two agents end up claiming the same task because the `tasks_status = Pending` precondition was dropped (e.g. CAS guard lost in a refactor).

```tla
DoubleClaim(a, t) ==
    /\ a \in room_agents
    /\ agent_tasks[a] = "None"
    \* deliberately omitted: tasks_status[t] = "Pending"
    /\ \E other \in Agents : agent_tasks[other] = t
    /\ agent_tasks' = [agent_tasks EXCEPT ![a] = t]
    ...
```

## Phase 3 closure stats

- **8/8 RFC stubs implemented** (Q2-1 through Q2-8)
- 0%-coverage domains: 5 → 0 after this PR merges
- Phase 3 prereq classification accuracy: 1/3 (33%). Q2-3 (this PR) was the only true prereq; Q2-5 and Q2-8 were false positives. Same conservative-bias pattern as Q-P0-2 Phase 2 tautology candidates (21 → 0).

See sibling Cycle 32 doc PR for closure summary.

## References

- PR #12137 — Phase 3 RFC stubs (parent, RFC-Q2-3 source — only true prereq)
- PR #12174, #12160, #12167, #12168, #12175, #12178, #12180 — sibling 7 implementations
- `lib/coord/` — runtime side (agent task claim race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
