### PR TITLE
specs(keeper): adopt [@@deriving tla] on sandbox_profile

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -8,13 +8,13 @@ include Keeper_config
 let keeper_debug = Env_config.KeeperRuntime.debug
 
 type sandbox_profile =
-  | Local
+  | Local [@tla.symbol "Local"]
     (** Host-process execution. Filesystem scope is bound to
         [~/me/.masc/playground/<keeper>/] (see [Playground_paths]).
         Network inherits the server's namespace. Intended for keepers
         whose work stays on local files and does not need container-grade
         isolation. *)
-  | Docker
+  | Docker [@tla.symbol "Docker"]
     (** Containerized execution with hardened defaults: cap-drop,
         no-new-privs, read-only rootfs, tmpfs, pids/memory limits.
         Network defaults to [Network_none]; the internal git/gh
@@ -22,6 +22,10 @@ type sandbox_profile =
         uses network egress plus read-only mounts from the selected
         root/keeper GitHub identity bundle for the duration of a git/gh
         command. *)
+[@@deriving tla]
+(** [@@deriving tla] generates [to_tla_symbol] / [all_symbols] /
+    [all_states] matching the [ProfileSet] string set declared in
+    [specs/boundary/SandboxDispatch.tla]. *)
 
 type network_mode =
   | Network_none [@tla.symbol "Network_none"]


### PR DESCRIPTION
## Summary

Sixth `[@@deriving tla]` adoption. Boundary 18-spec full sweep (#12159) §3 priority 5 candidate.

```ocaml
(* lib/keeper/keeper_types_profile.ml *)
type sandbox_profile =
  | Local [@tla.symbol "Local"]
    (** Host-process execution... *)
  | Docker [@tla.symbol "Docker"]
    (** Containerized execution... *)
[@@deriving tla]
```

`[@tla.symbol]` overrides match the `ProfileSet` string set in `specs/boundary/SandboxDispatch.tla`:

```tla
ProfileSet == {"Local", "Docker"}
```

## Coverage growth

`ppx_deriving_tla_modules`: 8 → **9**.

## Spec linkage

`SandboxDispatch.tla` already has its own Bug Model (`SpecBuggy` + `RunBashHostFallback`); this adoption complements it on the symbol-mapping side. Adding a new sandbox profile (e.g. `Wasm` or `Firecracker`) regenerates symbols automatically — drift-free with the spec literal set.

## Test plan

- [x] `dune build --root . @lib/check` exit 0
- [x] `[@tla.symbol]` strings match the spec's `ProfileSet`
- [x] Hand-written `sandbox_profile_to_string` continues to work (no name collision)

## References

- PR #12150, #12158, #12166, #12176, #12179 — sibling adoptions
- PR #12159 — boundary sweep ranked this candidate at priority 5
- `lib/keeper/keeper_types_profile.ml` — adoption site
- `specs/boundary/SandboxDispatch.tla` — TLA spec with matching ProfileSet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
