### PR TITLE
fix(dashboard): isolate Solid Vitest config

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "vitest run --no-file-parallelism --maxWorkers=1",
+    "test": "vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 && vitest run --config vitest.solid.config.ts --no-file-parallelism --maxWorkers=1",
     "test:serial": "pnpm test",
     "test:watch": "vitest",
     "tokens:build": "tsx design-system/tokens/build.ts",

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -1,23 +1,16 @@
 import { defineConfig } from 'vitest/config'
 import preact from '@preact/preset-vite'
-import solid from 'vite-plugin-solid'
 
 export default defineConfig({
-  plugins: [
-    // SolidJS plugin must run before Preact's so it claims its files
-    // first. `include` restricts the JSX transform to PoC paths so
-    // non-Solid Preact tests are unaffected. Mirrors vite.config.ts.
-    solid({
-      include: [
-        /design-system\/headless-solid\//,
-        /design-system\/preview\/solid-.*/,
-      ],
-    }),
-    preact(),
-  ],
+  // Keep Vitest on the Preact transform pipeline. vite-plugin-solid has
+  // global test-mode side effects that break existing Preact hook tests even
+  // when its transform include filter is path-scoped. Solid tests run through
+  // vitest.solid.config.ts so their resolver/runtime conditions stay isolated.
+  plugins: [preact()],
   test: {
     environment: 'happy-dom',
     include: ['src/**/*.test.ts', 'design-system/**/*.test.ts'],
+    exclude: ['design-system/headless-solid/**/*.test.ts'],
     globals: true,
     setupFiles: ['./vitest-setup.ts'],
   },

--- a/dashboard/vitest.solid.config.ts
+++ b/dashboard/vitest.solid.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import solid from 'vite-plugin-solid'
+
+export default defineConfig({
+  plugins: [
+    solid({
+      include: ['design-system/headless-solid/**/*.{ts,tsx}'],
+    }),
+  ],
+  test: {
+    environment: 'happy-dom',
+    include: ['design-system/headless-solid/**/*.test.ts'],
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary

- split dashboard Vitest into isolated Preact and Solid configs
- keep existing Preact suites on `@preact/preset-vite` only
- run the SolidJS PoC headless tests through `vitest.solid.config.ts`

## Why

PR #12162 registered `vite-plugin-solid` in the default Vitest config. Even with a scoped transform include filter, the plugin applies test-mode resolver/runtime side effects globally and breaks existing Preact hook tests with `__H` / `__$f` errors. Separating the suites keeps the Solid PoC covered without contaminating the Preact runtime.

Closes #12185

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/fleet-telemetry-panel.test.ts`
- `pnpm exec vitest run --config vitest.solid.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 --reporter=json --outputFile=/tmp/vitest-preact-12185.json` (5134/5134 passed)
- `scripts/dashboard-drift-check.sh`

Note: full local `pnpm test` with default reporter produced noisy sandbox `localhost:3000` EPERM warnings; the same preact suite completed successfully with JSON reporter, and the Solid suite completed separately.
