### PR TITLE
[codex] Expose Track 7 task claim observations

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -284,6 +284,10 @@ let handle_keeper_task_tool
           let matched_goal_id = find_task_goal_id config task_id in
           ( active_goal_scope_json ~meta ?matched_goal_id ()
           , [
+              ( "claim_observation",
+                Tool_task.build_claim_observation_payload
+                  ~now:(Time_compat.now ()) ~agent_name:meta.agent_name
+                  ~task_id );
               ( "claimed_task",
                 `Assoc
                   [

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -20,6 +20,42 @@ let result_to_response = function
   | Ok msg -> (true, msg)
   | Error e -> (false, Types.masc_error_to_string e)
 
+let build_claim_observation_payload ~(now : float) ~(agent_name : string)
+    ~(task_id : string) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("event_type", `String "collaboration.todo.claim_observed");
+      ("observed_at", `Float now);
+      ( "substrate",
+        `Assoc
+          [
+            ("kind", `String "todo_claim");
+            ("provider", `String "masc.coord");
+            ("workspace_id", `Null);
+          ] );
+      ( "actor",
+        `Assoc
+          [
+            ("id", `String agent_name);
+            ("role", `Null);
+            ("display_name", `Null);
+          ] );
+      ( "todo_claim",
+        `Assoc
+          [
+            ("todo_id", `String task_id);
+            ("state", `String "claim_verified");
+            ("claimed_by", `String agent_name);
+            ("winner_actor_id", `String agent_name);
+            ("logical_clock", `Null);
+            ("convergence_delay_ms", `Null);
+          ] );
+    ]
+
+let append_claim_observation message ~now ~agent_name ~task_id =
+  let payload = build_claim_observation_payload ~now ~agent_name ~task_id in
+  message ^ "\nclaim_observation=" ^ Yojson.Safe.to_string payload
+
 let verdict_to_string (result : Anti_rationalization.review_result) =
   match result.verdict with
   | Anti_rationalization.Approve -> "approve"
@@ -533,9 +569,10 @@ let handle_claim_next ?agent_tool_names ctx _args =
     Coord.claim_next_r ctx.config ~agent_name:ctx.agent_name ?agent_tool_names ()
   in
   let message = match result with
-    | Coord.Claim_next_claimed { message; _ } ->
+    | Coord.Claim_next_claimed { message; task_id; _ } ->
         sync_planning_current_task_with_owned_task ctx;
-        message
+        append_claim_observation message ~now:(Time_compat.now ())
+          ~agent_name:ctx.agent_name ~task_id
     | Coord.Claim_next_no_unclaimed -> "📋 No unclaimed tasks available"
     | Coord.Claim_next_no_eligible { excluded_count; _ } ->
         Printf.sprintf "📋 No eligible tasks available (blocked/excluded: %d)" excluded_count

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -42,6 +42,14 @@ val completion_rejection_message : ?allow_force:bool -> string -> string
     [completion_notes_example]. Exposed for regression tests that lock
     in the example substring. *)
 
+(** [build_claim_observation_payload ~now ~agent_name ~task_id] builds the
+    downstream collaboration-observation fragment for a successful
+    [masc_claim_next] write/readback result. MASC uses a central coordination
+    store here, so CRDT-specific [logical_clock] and [convergence_delay_ms]
+    are left null. *)
+val build_claim_observation_payload :
+  now:float -> agent_name:string -> task_id:string -> Yojson.Safe.t
+
 (** [is_cross_model_verdict result] is [true] iff [result] has both
     [generator_cascade = Some g] and [evaluator_cascade] non-empty,
     and [g <> evaluator_cascade].

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -166,7 +166,7 @@ Tip: Look for status='todo' tasks to claim.";
   };
   {
     name = "masc_claim_next";
-    description = "Automatically claim the highest priority unclaimed task. Use this when you want to pick up the most important available work without manually checking the task board. Returns the claimed task details including priority level.";
+    description = "Automatically claim the highest priority unclaimed task. Use this when you want to pick up the most important available work without manually checking the task board. Returns the claimed task details including priority level and a claim_observation fragment for the verified write/readback result.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -167,6 +167,26 @@ let test_claim_returns_result () =
       check bool "claim result non-empty" true (String.length s > 0)
     | _ -> fail "expected result string in claim response")
 
+let test_claim_returns_observation_fragment () =
+  with_room (fun config ->
+    let meta = make_test_meta () in
+    let _ =
+      Coord.add_task config ~title:"Observed task" ~priority:1 ~description:"desc"
+    in
+    let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let json = parse_json result in
+    check string "event type" "collaboration.todo.claim_observed"
+      Yojson.Safe.Util.(
+        json |> member "claim_observation" |> member "event_type" |> to_string);
+    check string "state" "claim_verified"
+      Yojson.Safe.Util.(
+        json |> member "claim_observation" |> member "todo_claim" |> member "state"
+        |> to_string);
+    check string "winner" meta.agent_name
+      Yojson.Safe.Util.(
+        json |> member "claim_observation" |> member "todo_claim"
+        |> member "winner_actor_id" |> to_string))
+
 let test_claim_syncs_keeper_current_task_id () =
   with_room (fun config ->
     let meta = make_test_meta () in
@@ -692,6 +712,8 @@ let () =
   Alcotest.run "Keeper_task_dispatch" [
     "claim", [
       test_case "claim returns result" `Quick test_claim_returns_result;
+      test_case "claim returns observation fragment" `Quick
+        test_claim_returns_observation_fragment;
       test_case "claim syncs keeper current_task_id" `Quick
         test_claim_syncs_keeper_current_task_id;
       test_case "claim empty room" `Quick test_claim_empty_room;

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -71,6 +71,11 @@ let str_contains s substring =
     in
     loop 0
 
+let str_starts_with ~prefix s =
+  let len_s = String.length s in
+  let len_prefix = String.length prefix in
+  len_s >= len_prefix && String.sub s 0 len_prefix = prefix
+
 let contract_requiring_tools tools =
   `Assoc [ ("required_tools", `List (List.map (fun tool -> `String tool) tools)) ]
 
@@ -861,6 +866,38 @@ let () = test "handle_claim_next_sets_planning_current_task" (fun () ->
   let (success, _result) = Tool_task.handle_claim_next ctx (`Assoc []) in
   assert success;
   assert (Planning_eio.get_current_task ctx.config = Some "task-001")
+)
+
+let () = test "handle_claim_next_returns_claim_observation" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Tool_task.handle_add_task ctx (`Assoc [ ("title", `String "Claim observed") ])
+  in
+  let success, result = Tool_task.handle_claim_next ctx (`Assoc []) in
+  if not success then failwith result;
+  let prefix = "claim_observation=" in
+  let line =
+    match
+      List.find_opt
+        (fun line -> str_starts_with ~prefix line)
+        (String.split_on_char '\n' result)
+    with
+    | Some line -> line
+    | None -> failwith ("missing claim observation in result: " ^ result)
+  in
+  let payload =
+    String.sub line (String.length prefix) (String.length line - String.length prefix)
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  assert (payload |> member "event_type" |> to_string
+          = "collaboration.todo.claim_observed");
+  assert (payload |> member "substrate" |> member "kind" |> to_string = "todo_claim");
+  assert (payload |> member "todo_claim" |> member "todo_id" |> to_string = "task-001");
+  assert (payload |> member "todo_claim" |> member "state" |> to_string
+          = "claim_verified");
+  assert (payload |> member "todo_claim" |> member "winner_actor_id" |> to_string
+          = ctx.agent_name)
 )
 
 let () =


### PR DESCRIPTION
## Summary
- append a claim_observation fragment to successful masc_claim_next responses
- include the same observation fragment in keeper_task_claim JSON responses
- repair current OAS ProviderFailure drift in MASC compatibility paths so focused OCaml checks compile
- remove the stray conflict marker and trim lib/dune blank-line drift so existing guards pass

## Why
Track 7 needs claim assignment to be observable as a write/readback result. MASC keeps its central coordination store, but now exposes the actual verified winner in the same todo_claim observation shape used by OAS PR #1267.

## Validation
- git diff --check
- rg -n "^(<<<<<<<|>>>>>>>)|^=======$" lib test docs -g "!_build/**"
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build ./test/test_tool_task_coverage.exe ./test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_tool_task_coverage.exe
- ./_build/default/test/test_keeper_task_dispatch.exe
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/no-unknown-permissive-default.sh
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build ./test/test_oas_compat_cascade_fallback.exe ./test/test_cascade_runtime.exe
- ./_build/default/test/test_oas_compat_cascade_fallback.exe
- ./_build/default/test/test_cascade_runtime.exe
