### PR TITLE
specs(provider_adapter): adopt [@@deriving tla] on runtime_kind

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1,7 +1,8 @@
 type runtime_kind =
-  | Local
-  | Cli_agent
-  | Direct_api
+  | Local [@tla.symbol "local"]
+  | Cli_agent [@tla.symbol "cli_agent"]
+  | Direct_api [@tla.symbol "direct_api"]
+[@@deriving tla]
 
 type auth_mode =
   | No_auth

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -12,6 +12,7 @@ type runtime_kind =
   | Local
   | Cli_agent
   | Direct_api
+[@@deriving tla]
 
 type auth_mode =
   | No_auth


### PR DESCRIPTION
## Summary

Seventh `[@@deriving tla]` adoption. Cycle 14 audit (#12143) flagged `provider_adapter.runtime_kind` among the candidates.

```ocaml
type runtime_kind =
  | Local [@tla.symbol "local"]
  | Cli_agent [@tla.symbol "cli_agent"]
  | Direct_api [@tla.symbol "direct_api"]
[@@deriving tla]
```

The runtime kind is the cascade-layer routing primitive distinguishing whether a provider dispatches as a local subprocess, an external CLI agent (codex/claude/etc.), or a Direct API HTTP call.

## Coverage growth

`ppx_deriving_tla_modules`: 9 → **10**. Achievement: double-digit module count.

## Test plan

- [x] `dune build --root . @lib/check` exit 0
- [x] `[@tla.symbol]` snake_case convention follows existing pattern
- [x] Hand-written code (provider_adapter functions) unaffected

## References

- PR #12143 — Cycle 14 audit (parent)
- PR #12150, #12158, #12166, #12176, #12179, #12187 — sibling adoptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
