### PR TITLE
specs(board): adopt [@@deriving tla] on board_types.post_kind

### DIFF
--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -120,9 +120,10 @@ type visibility =
   | Direct      (* Mentioned agents only *)
 
 type post_kind =
-  | Human_post
-  | Automation_post
-  | System_post
+  | Human_post [@tla.symbol "human_post"]
+  | Automation_post [@tla.symbol "automation_post"]
+  | System_post [@tla.symbol "system_post"]
+[@@deriving tla]
 
 type post = {
   id: Post_id.t;

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -68,6 +68,7 @@ type post_kind =
   | Human_post
   | Automation_post
   | System_post
+[@@deriving tla]
 
 (** {1 Records — Mandatory TTL} *)
 

--- a/lib/board_types/dune
+++ b/lib/board_types/dune
@@ -12,4 +12,4 @@
    eio
    masc_random_id
    masc_mcp.config)
- (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
+ (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_tla)))


### PR DESCRIPTION
## Summary

Eighth `[@@deriving tla]` adoption. 3-variant ADT.

```ocaml
type post_kind =
  | Human_post [@tla.symbol "human_post"]
  | Automation_post [@tla.symbol "automation_post"]
  | System_post [@tla.symbol "system_post"]
[@@deriving tla]
```

## Dune change

`board_types` is a separate library (`masc_mcp.masc_board`) — its dune preprocessor needed `ppx_tla` added (alongside existing `ppx_deriving.show + ppx_deriving.eq`). Same pattern as resilience adoption (#12150).

## Coverage growth

- `ppx_deriving_tla_modules`: 10 → **11**
- `lib_subdirs_with_ppx`: 5 → **6** (autonomous, keeper, multimodal, resilience, cascade, +board_types)

## Test plan

- [x] `dune build --root . lib/board_types/` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
