### PR TITLE
specs(cascade): adopt [@@deriving tla] on source_kind

### DIFF
--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -1,6 +1,7 @@
 type source_kind =
-  | Json
-  | Toml
+  | Json [@tla.symbol "json"]
+  | Toml [@tla.symbol "toml"]
+[@@deriving tla]
 
 type source_info = {
   kind : source_kind;

--- a/lib/cascade/cascade_toml_materializer.mli
+++ b/lib/cascade/cascade_toml_materializer.mli
@@ -26,6 +26,7 @@ type source_kind =
   | Toml
       (** [<config_dir>/cascade.toml] exists; the JSON sibling is a
           derived artifact and not editable in place. *)
+[@@deriving tla]
 
 type source_info = {
   kind : source_kind;


### PR DESCRIPTION
## Summary

Ninth `[@@deriving tla]` adoption. 2-variant nullary ADT — fastest possible adoption shape.

```ocaml
type source_kind =
  | Json [@tla.symbol "json"]
  | Toml [@tla.symbol "toml"]
[@@deriving tla]
```

`cascade_toml_materializer.source_kind` distinguishes whether the cascade config source-of-truth is the editable `cascade.json` or the TOML-derived JSON sibling.

## Coverage growth

`ppx_deriving_tla_modules`: 11 → **12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
