### PR TITLE
specs(sse): adopt [@@deriving tla] on session_kind

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -37,9 +37,10 @@ let run_test_hook hook =
   | None -> ()
 
 type session_kind =
-  | Observer     (** Dashboard / read-only viewers *)
-  | Coordinator  (** MCP agent connections *)
-  | Presence     (** Ephemeral liveness / awareness channel *)
+  | Observer [@tla.symbol "observer"]    (** Dashboard / read-only viewers *)
+  | Coordinator [@tla.symbol "coordinator"] (** MCP agent connections *)
+  | Presence [@tla.symbol "presence"]    (** Ephemeral liveness / awareness channel *)
+[@@deriving tla]
 
 (** Broadcast targeting selector. *)
 type broadcast_target =

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -13,6 +13,7 @@ type session_kind =
   | Observer
   | Coordinator
   | Presence
+[@@deriving tla]
 
 type broadcast_target =
   | All


### PR DESCRIPTION
## Summary

Tenth `[@@deriving tla]` adoption. 3-variant ADT.

```ocaml
type session_kind =
  | Observer [@tla.symbol "observer"]
  | Coordinator [@tla.symbol "coordinator"]
  | Presence [@tla.symbol "presence"]
[@@deriving tla]
```

`sse.session_kind` drives broadcast targeting in the SSE hub. PPX adoption makes the target-set string mapping drift-free.

## Coverage growth

`ppx_deriving_tla_modules`: 12 → **13**.

**Achievement**: 13 modules — over 3× growth from Cycle 14 audit baseline of 4 modules. Ratchet floor (#12151) absorbs each new adoption monotonically.

## Test plan

- [x] `dune build --root . @lib/check` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
