### PR TITLE
fix(keeper): classify actionable signals structurally

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -50,6 +50,7 @@ let run_turn
          base_system_prompt:string -> messages:Oas.Types.message list -> turn_prompt)
       ~(user_message : string)
       ~(cascade_name : string)
+      ?structured_world_observation
       ?(turn_affordances = [])
       ?provider_filter
       ~(generation : int)
@@ -671,36 +672,8 @@ let run_turn
              ~history_messages
              ~actual_input_tokens:usage.input_tokens
          in
-         let has_positive_count_after_marker haystack marker =
-           let haystack = String.lowercase_ascii haystack in
-           let marker = String.lowercase_ascii marker in
-           let hay_len = String.length haystack in
-           let marker_len = String.length marker in
-           let is_digit c = c >= '0' && c <= '9' in
-           let rec parse_digits idx acc =
-             if idx >= hay_len || not (is_digit haystack.[idx]) then acc
-             else
-               parse_digits (idx + 1)
-                 ((acc * 10) + Char.code haystack.[idx] - Char.code '0')
-           in
-           let rec skip_to_digit start idx =
-             if idx >= hay_len || idx - start > 32 then false
-             else if is_digit haystack.[idx] then
-               parse_digits idx 0 > 0
-             else
-               skip_to_digit start (idx + 1)
-           in
-           let rec search idx =
-             if marker_len = 0 || idx + marker_len > hay_len then false
-             else if String.sub haystack idx marker_len = marker then
-               skip_to_digit (idx + marker_len) (idx + marker_len)
-             else
-               search (idx + 1)
-           in
-           search 0
-         in
          (* Classify the most-specific actionable signal observed in the
-            prompt body, applying the P1 affordance-tool intersection so
+            structured world snapshot, applying the P1 affordance-tool intersection so
             keepers without the corresponding action tool degrade to
             [No_actionable_signal] (cf. [keeper_contract_classifier.mli]
             precedence: unclaimed > board > discovered).
@@ -708,31 +681,13 @@ let run_turn
             The boolean [actionable_signal_context] is derived from the
             kind for backward compatibility with downstream callers; the
             kind itself flows into violation log/metric labels so
-            operators can see *which* signal class the LLM failed on
-            (issue #11266 Track 2c, Step 6b caller rewrite). *)
+            operators can see *which* signal class the LLM failed on. *)
          let actionable_signal_kind : Keeper_contract_classifier.actionable_signal =
-           let haystack = user_message ^ "\n" ^ dynamic_context in
-           let has_any_tool tools =
-             List.exists (fun t -> List.mem t all_tool_names) tools
-           in
-           if has_positive_count_after_marker haystack "Unclaimed tasks"
-              && has_any_tool
-                   [ "keeper_task_claim"; "masc_claim_next";
-                     "masc_claim_task" ]
-           then Has_unclaimed_tasks
-           else if has_positive_count_after_marker haystack "### Board Activity"
-                   && has_any_tool
-                        [ "keeper_board_post"; "keeper_board_comment";
-                          "masc_broadcast"; "masc_keeper_msg" ]
-           then Has_board_activity
-           else if String_util.contains_substring_ci haystack "## Discovered Work"
-                   && has_any_tool
-                        [ "keeper_task_claim"; "masc_claim_next";
-                          "masc_claim_task";
-                          "keeper_board_post"; "masc_add_task";
-                          "keeper_tasks_audit" ]
-           then Has_discovered_work
-           else No_actionable_signal
+           match structured_world_observation with
+           | Some observation ->
+             Keeper_contract_classifier.classify_actionable_signal_with_allowed_tools
+               ~allowed_tool_names:all_tool_names observation
+           | None -> No_actionable_signal
          in
          let actionable_signal_context =
            Keeper_agent_tool_surface

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -208,6 +208,9 @@ val adaptive_thinking_budget :
            and checkpoint message history, returns the final turn system prompt
     @param user_message The user's message to the keeper
     @param cascade_name Cascade profile name for model selection
+    @param structured_world_observation Structured world signal used by
+           required-tool contract checks. When omitted, the contract gate
+           does not infer world state from prompt text.
     @param provider_filter Optional provider restriction
     @param generation Current generation counter
     @param max_turns Maximum agent turns (default from env config)
@@ -236,6 +239,7 @@ val run_turn :
         -> turn_prompt)
   -> user_message:string
   -> cascade_name:string
+  -> ?structured_world_observation:Keeper_contract_classifier.world_observation
   -> ?turn_affordances:string list
   -> ?provider_filter:string list
   -> generation:int

--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -46,6 +46,26 @@ let classify_actionable_signal o =
   else if o.has_discovered_work_section then Has_discovered_work
   else No_actionable_signal
 
+let classify_actionable_signal_with_allowed_tools ~allowed_tool_names o =
+  let has_any_tool names =
+    List.exists (fun name -> List.mem name allowed_tool_names) names
+  in
+  if o.unclaimed_task_count > 0
+     && has_any_tool
+          [ "keeper_task_claim"; "masc_claim_next"; "masc_claim_task" ]
+  then Has_unclaimed_tasks
+  else if o.board_activity_count > 0
+          && has_any_tool
+               [ "keeper_board_post"; "keeper_board_comment"; "masc_broadcast";
+                 "masc_keeper_msg" ]
+  then Has_board_activity
+  else if o.has_discovered_work_section
+          && has_any_tool
+               [ "keeper_task_claim"; "masc_claim_next"; "masc_claim_task";
+                 "keeper_board_post"; "masc_add_task"; "keeper_tasks_audit" ]
+  then Has_discovered_work
+  else No_actionable_signal
+
 let is_actionable = function
   | No_actionable_signal -> false
   | Has_unclaimed_tasks | Has_board_activity | Has_discovered_work -> true

--- a/lib/keeper/keeper_contract_classifier.mli
+++ b/lib/keeper/keeper_contract_classifier.mli
@@ -1,10 +1,4 @@
-(** Typed classifier for keeper turn completion contract.
-
-    Step 6a of the bloodflow restoration plan introduces only the
-    type vocabulary; the call-site rewrite that replaces the
-    [String_util.contains_substring_ci haystack ...] heuristic in
-    [keeper_agent_run.ml:2285-2298] is left to a follow-up stack
-    so the type surface lands additively first. *)
+(** Typed classifier for keeper turn completion contract. *)
 
 type actionable_signal =
   | Has_unclaimed_tasks
@@ -28,12 +22,9 @@ val contract_status_label : contract_status -> string
 val pp_contract_status : Format.formatter -> contract_status -> unit
 
 (** Structured per-turn world snapshot consumed by
-    [classify_actionable_signal]. Mirrors the three substring markers
-    that [keeper_agent_run.ml:2285-2298] currently scrapes from the
-    rendered prompt body — the upstream code already knows these as
-    counts and a boolean before formatting them into the string, so
-    Step 6b's caller rewrite will populate this record at the source
-    instead of re-parsing the prompt. *)
+    [classify_actionable_signal].  These values are observed before prompt
+    rendering so the completion-contract gate does not infer world state
+    from rendered prose. *)
 type world_observation = {
   unclaimed_task_count : int;
       (** Number of unclaimed tasks in the keeper's queue.
@@ -65,6 +56,16 @@ type world_observation = {
     is the structured equivalent of the existing
     [actionable_signal_context = true]. *)
 val classify_actionable_signal : world_observation -> actionable_signal
+
+(** Like [classify_actionable_signal], but skips a candidate signal when
+    the active tool surface has no tool capable of acting on that signal.
+
+    This preserves the documented precedence while avoiding unwinnable
+    contract violations. Example: if unclaimed tasks exist but the keeper
+    cannot see a claim tool, board activity can still become the selected
+    actionable signal when board tools are visible. *)
+val classify_actionable_signal_with_allowed_tools :
+  allowed_tool_names:string list -> world_observation -> actionable_signal
 
 (** [is_actionable s] is [false] iff [s = No_actionable_signal].
     Provided so callers comparing the structured signal against the

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -397,6 +397,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let turn_affordances =
         Keeper_unified_metrics.observed_affordances_of_observation ~meta observation
       in
+      let structured_world_observation :
+          Keeper_contract_classifier.world_observation =
+        {
+          unclaimed_task_count = observation.unclaimed_task_count;
+          board_activity_count = List.length observation.pending_board_events;
+          has_discovered_work_section = observation.work_discovery_due;
+        }
+      in
       (* 5. Run via OAS Agent.run() with transient-error retry *)
       (* Track whether side-effecting tool calls have been executed.
          If a board_post/comment/shell/file edit succeeded and then a
@@ -702,6 +710,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
                     ~max_context:execution.max_context ~build_turn_prompt
                     ~user_message ~cascade_name:execution.cascade_name
+                    ~structured_world_observation
                     ~turn_affordances
                     ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
                     ~generation:run_generation

--- a/test/test_keeper_classifier_helper.ml
+++ b/test/test_keeper_classifier_helper.ml
@@ -1,6 +1,5 @@
-(** test_keeper_classifier_helper — coverage for the structured
-    [classify_actionable_signal] introduced as the precursor to Step 6b
-    caller adoption. *)
+(** test_keeper_classifier_helper — coverage for the structured actionable
+    signal classifier used by the required-tool contract gate. *)
 
 open Masc_mcp
 module C = Keeper_contract_classifier
@@ -42,6 +41,35 @@ let test_discovered_only_when_no_other () =
   Alcotest.check s "discovered alone"
     C.Has_discovered_work
     (C.classify_actionable_signal (obs ~discovered:true ()))
+
+let test_allowed_tools_preserve_fallback_precedence () =
+  Alcotest.check s "board wins when claim tools are hidden"
+    C.Has_board_activity
+    (C.classify_actionable_signal_with_allowed_tools
+       ~allowed_tool_names:[ "keeper_board_post" ]
+       (obs ~tasks:2 ~board:1 ()));
+  Alcotest.check s "discovered wins when claim and board tools are hidden"
+    C.Has_discovered_work
+    (C.classify_actionable_signal_with_allowed_tools
+       ~allowed_tool_names:[ "keeper_tasks_audit" ]
+       (obs ~tasks:2 ~board:1 ~discovered:true ()));
+  Alcotest.check s "no unwinnable signal without action tools"
+    C.No_actionable_signal
+    (C.classify_actionable_signal_with_allowed_tools
+       ~allowed_tool_names:[ "keeper_tasks_list"; "masc_status" ]
+       (obs ~tasks:2 ~board:1 ~discovered:true ()))
+
+let test_allowed_tools_keep_top_priority_when_actionable () =
+  Alcotest.check s "unclaimed wins with claim tool visible"
+    C.Has_unclaimed_tasks
+    (C.classify_actionable_signal_with_allowed_tools
+       ~allowed_tool_names:[ "keeper_task_claim"; "keeper_board_post" ]
+       (obs ~tasks:2 ~board:1 ~discovered:true ()));
+  Alcotest.check s "board wins over discovered with board tool visible"
+    C.Has_board_activity
+    (C.classify_actionable_signal_with_allowed_tools
+       ~allowed_tool_names:[ "keeper_board_comment"; "keeper_tasks_audit" ]
+       (obs ~board:1 ~discovered:true ()))
 
 let test_zero_counts_are_inactive () =
   (* count = 0 must NOT promote to *_activity (boundary check on ">0"). *)
@@ -106,6 +134,10 @@ let () =
             test_board_takes_second_priority;
           Alcotest.test_case "discovered alone" `Quick
             test_discovered_only_when_no_other;
+          Alcotest.test_case "allowed tools preserve fallback precedence" `Quick
+            test_allowed_tools_preserve_fallback_precedence;
+          Alcotest.test_case "allowed tools keep top actionable priority" `Quick
+            test_allowed_tools_keep_top_priority_when_actionable;
           Alcotest.test_case "zero counts are inactive" `Quick
             test_zero_counts_are_inactive;
           Alcotest.test_case "negative counts are inactive" `Quick


### PR DESCRIPTION
## Summary
- replaces prompt-body marker scraping in keeper completion-contract classification with a structured world observation passed from Keeper_world_observation
- keeps signal precedence typed and gates each signal by visible action tools so keepers are not blamed for unwinnable turns
- adds classifier coverage for fallback precedence and hidden-tool cases

## Why it matters
This removes another string-match layer from keeper autonomy. The turn gate now follows typed world state instead of guessing from rendered prompt text, which makes the A -> B -> C path explainable and auditable.

## Verification
- env DUNE_JOBS=1 DUNE_BUILD_DIR=_build-structured-actionable scripts/dune-local.sh build test/test_keeper_classifier_helper.exe
- _build-structured-actionable/default/test/test_keeper_classifier_helper.exe
- git diff --check origin/main...HEAD
- rg "has_positive_count_after_marker|Unclaimed tasks|Board Activity|Discovered Work|contains_substring_ci haystack" lib/keeper/keeper_agent_run.ml