### PR TITLE
feat(headless-solid): RFC 0007 useToasts adapter

### DIFF
--- a/dashboard/design-system/headless-solid/use-toasts.test.ts
+++ b/dashboard/design-system/headless-solid/use-toasts.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+//
+// Tests for headless-solid/use-toasts. Mirrors Preact adapter scenarios
+// adapted to Solid's accessor + createRoot conventions.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createComputed, createRoot } from 'solid-js'
+import { createToastManager } from '../headless-core/toast-manager'
+import {
+  getRegionPauseHandlers,
+  getToastItemProps,
+  getToastRegionProps,
+  useToasts,
+} from './use-toasts'
+
+let dispose: (() => void) | undefined
+
+beforeEach(() => {
+  dispose = undefined
+})
+
+afterEach(() => {
+  dispose?.()
+})
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((d) => {
+    dispose = d
+    return fn()
+  })
+}
+
+describe('useToasts', () => {
+  it('returns empty initial accessor', () => {
+    const manager = createToastManager()
+    const { toasts } = withRoot(() => useToasts(manager))
+    expect(toasts()).toEqual([])
+  })
+
+  it('notify enqueues, accessor updates synchronously', () => {
+    const manager = createToastManager()
+    const { toasts, notify } = withRoot(() => useToasts(manager))
+    const id = notify({ severity: 'info', message: 'Hello' })
+    expect(toasts().length).toBe(1)
+    expect(toasts()[0]!.id).toBe(id)
+    expect(toasts()[0]!.message).toBe('Hello')
+  })
+
+  it('dismiss removes toast', () => {
+    const manager = createToastManager()
+    const { toasts, notify, dismiss } = withRoot(() => useToasts(manager))
+    const id = notify({ severity: 'info', message: 'Hi' })
+    expect(toasts().length).toBe(1)
+    dismiss(id)
+    expect(toasts().some((t) => t.state === 'dismissed' || t.id !== id)).toBeTruthy()
+  })
+
+  it('createComputed re-runs on signal update', () => {
+    const manager = createToastManager()
+    let runs = 0
+    let lastLen = -1
+    withRoot(() => {
+      const { toasts } = useToasts(manager)
+      createComputed(() => {
+        lastLen = toasts().length
+        runs += 1
+      })
+    })
+    expect(runs).toBe(1)
+    expect(lastLen).toBe(0)
+    manager.notify({ severity: 'info', message: 'A' })
+    expect(runs).toBe(2)
+    expect(lastLen).toBe(1)
+  })
+
+  it('createRoot dispose unsubscribes', () => {
+    const manager = createToastManager()
+    let runs = 0
+    const localDispose = createRoot((d) => {
+      const { toasts } = useToasts(manager)
+      createComputed(() => {
+        void toasts()
+        runs += 1
+      })
+      return d
+    })
+    expect(runs).toBe(1)
+    manager.notify({ severity: 'info', message: 'A' })
+    expect(runs).toBe(2)
+    localDispose()
+    manager.notify({ severity: 'info', message: 'B' })
+    expect(runs).toBe(2)
+  })
+})
+
+describe('getToastRegionProps', () => {
+  it('returns frozen ARIA region attributes', () => {
+    const props = getToastRegionProps()
+    expect(props.role).toBe('region')
+    expect(props['aria-label']).toBe('Notifications')
+    expect(props['aria-live']).toBe('polite')
+    expect(props['aria-atomic']).toBe('false')
+    expect(Object.isFrozen(props)).toBe(true)
+  })
+})
+
+describe('getToastItemProps', () => {
+  it('maps severity to role + aria-live', () => {
+    const manager = createToastManager()
+    manager.notify({ severity: 'error', message: 'Boom' })
+    const t = manager.getQueue()[0]!
+    const props = getToastItemProps(t)
+    expect(props.id).toBe(t.id)
+    expect(props.role).toBe('alert')
+    expect(props['aria-live']).toBe('assertive')
+    expect(props['data-severity']).toBe('error')
+  })
+
+  it('info severity maps to status + polite', () => {
+    const manager = createToastManager()
+    manager.notify({ severity: 'info', message: 'FYI' })
+    const t = manager.getQueue()[0]!
+    const props = getToastItemProps(t)
+    expect(props.role).toBe('status')
+    expect(props['aria-live']).toBe('polite')
+  })
+})
+
+describe('getRegionPauseHandlers', () => {
+  it('mouse enter/leave triggers pauseAll/resumeAll', () => {
+    const manager = createToastManager()
+    let paused = 0
+    let resumed = 0
+    const wrapped: typeof manager = {
+      ...manager,
+      pauseAll: () => { paused += 1 },
+      resumeAll: () => { resumed += 1 },
+    }
+    const handlers = getRegionPauseHandlers(wrapped)
+    handlers.onMouseEnter()
+    handlers.onMouseLeave()
+    handlers.onFocusIn()
+    handlers.onFocusOut()
+    expect(paused).toBe(2)
+    expect(resumed).toBe(2)
+  })
+})

--- a/dashboard/design-system/headless-solid/use-toasts.ts
+++ b/dashboard/design-system/headless-solid/use-toasts.ts
@@ -1,0 +1,97 @@
+/**
+ * useToasts — SolidJS adapter over headless-core/ToastManager
+ * (RFC 0007 §3.3, RFC 0017 PR #2).
+ *
+ * Mirror of headless-preact/use-toasts.ts. Returns the live queue as
+ * a Solid Accessor plus helpers for ARIA props and pause handlers.
+ *
+ * Pattern note: production allocates one ToastManager at app boot.
+ * The Solid app provides it via a `createContext` (introduced when the
+ * first Solid island lands). This hook reads from its argument so it
+ * can be used with any provider strategy.
+ */
+
+import { createSignal, onCleanup, type Accessor } from 'solid-js'
+import {
+  type Toast,
+  type ToastDescriptor,
+  type ToastManager,
+  type ToastSeverity,
+  SEVERITY_TO_ARIA_LIVE,
+  SEVERITY_TO_ROLE,
+} from '../headless-core/toast-manager'
+
+export interface UseToastsResult {
+  readonly toasts: Accessor<ReadonlyArray<Toast>>
+  notify: (descriptor: ToastDescriptor) => string
+  dismiss: (id: string) => void
+}
+
+export function useToasts(manager: ToastManager): UseToastsResult {
+  const [toasts, setToasts] = createSignal<ReadonlyArray<Toast>>(manager.getQueue())
+  const dispose = manager.subscribe((q) => setToasts(q))
+  onCleanup(dispose)
+  return {
+    toasts,
+    notify: (descriptor) => manager.notify(descriptor),
+    dismiss: (id) => manager.dismiss(id),
+  }
+}
+
+/**
+ * Region-level prop bundle. Spread onto the container that wraps all
+ * rendered toasts, mounted inside `usePortal({ layer: 'toast' })` once
+ * a Solid portal adapter ships.
+ */
+export function getToastRegionProps(): {
+  readonly role: 'region'
+  readonly 'aria-label': 'Notifications'
+  readonly 'aria-live': 'polite'
+  readonly 'aria-atomic': 'false'
+} {
+  return Object.freeze({
+    role: 'region' as const,
+    'aria-label': 'Notifications' as const,
+    'aria-live': 'polite' as const,
+    'aria-atomic': 'false' as const,
+  })
+}
+
+/**
+ * Per-toast prop bundle. Severity drives both `role` and `aria-live`
+ * per RFC 0007 §4.
+ */
+export function getToastItemProps(toast: Toast): {
+  readonly id: string
+  readonly role: 'status' | 'alert'
+  readonly 'aria-live': 'polite' | 'assertive'
+  readonly 'data-severity': ToastSeverity
+  readonly 'data-state': 'queued' | 'visible' | 'dismissed'
+} {
+  return Object.freeze({
+    id: toast.id,
+    role: SEVERITY_TO_ROLE[toast.severity],
+    'aria-live': SEVERITY_TO_ARIA_LIVE[toast.severity],
+    'data-severity': toast.severity,
+    'data-state': toast.state,
+  })
+}
+
+/**
+ * Pause/resume handlers for region-level hover/focus. Wire onMouseEnter /
+ * onMouseLeave / onFocusIn / onFocusOut on the region container in Solid
+ * (Solid uses native event names, not Preact's camelCase 'Capture' suffix).
+ */
+export function getRegionPauseHandlers(manager: ToastManager): {
+  readonly onMouseEnter: () => void
+  readonly onMouseLeave: () => void
+  readonly onFocusIn: () => void
+  readonly onFocusOut: () => void
+} {
+  return Object.freeze({
+    onMouseEnter: () => manager.pauseAll(),
+    onMouseLeave: () => manager.resumeAll(),
+    onFocusIn: () => manager.pauseAll(),
+    onFocusOut: () => manager.resumeAll(),
+  })
+}


### PR DESCRIPTION
PR #2.1 of SolidJS migration sequence. Solid adapter mirroring headless-preact/use-toasts.ts. Returns Accessor<Toast[]>; pure helpers (getToastRegionProps/getToastItemProps) ARIA-identical. getRegionPauseHandlers uses Solid native event names. 9/9 tests pass, typecheck clean. Production touch 0. Sequential after #12162 merged.