### PR TITLE
specs(keeper): adopt [@@deriving tla] on network_mode

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -24,8 +24,9 @@ type sandbox_profile =
         for the duration of a git/gh command. *)
 
 type network_mode =
-  | Network_none
-  | Network_inherit
+  | Network_none [@tla.symbol "Network_none"]
+  | Network_inherit [@tla.symbol "Network_inherit"]
+[@@deriving tla]
 
 type shared_memory_scope =
   | Shared_memory_disabled


### PR DESCRIPTION
## Summary

Eleventh `[@@deriving tla]` adoption. Sibling to `sandbox_profile` (#12187) — same module, same dune setup.

```ocaml
type network_mode =
  | Network_none [@tla.symbol "Network_none"]
  | Network_inherit [@tla.symbol "Network_inherit"]
[@@deriving tla]
```

`network_mode` is the second axis of the keeper sandbox dispatch contract (alongside `sandbox_profile`). The boundary spec `SandboxDispatch.tla` mentions both; PPX makes both type families drift-free.

## Coverage growth

`ppx_deriving_tla_modules`: 13 → **14**.

## Test plan

- [x] `dune build --root . @lib/check` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
