### PR TITLE
feat(headless-solid): RFC 0001 usePortal adapter

### DIFF
--- a/dashboard/design-system/headless-solid/use-portal.test.ts
+++ b/dashboard/design-system/headless-solid/use-portal.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+//
+// Tests for headless-solid/use-portal. Mirrors Preact adapter coverage:
+// register/deregister lifecycle, z-index resolution, isolation between
+// consumers via the swappable default manager.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createRoot } from 'solid-js'
+import { createPortalManager, PORTAL_Z_INDEX } from '../headless-core/portal-manager'
+import { getPortalManager, setPortalManager, usePortal } from './use-portal'
+
+let dispose: (() => void) | undefined
+
+beforeEach(() => {
+  setPortalManager(createPortalManager())
+  dispose = undefined
+})
+
+afterEach(() => {
+  dispose?.()
+})
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((d) => {
+    dispose = d
+    return fn()
+  })
+}
+
+describe('usePortal — z-index resolution', () => {
+  it('returns layer default z-index when no override is given', () => {
+    const result = withRoot(() => usePortal({ layer: 'toast' }))
+    expect(result.zIndex).toBe(PORTAL_Z_INDEX.toast)
+  })
+
+  it('honors explicit zIndex override', () => {
+    const result = withRoot(() => usePortal({ layer: 'toast', zIndex: 9999 }))
+    expect(result.zIndex).toBe(9999)
+  })
+})
+
+describe('usePortal — registration lifecycle', () => {
+  it('registers on mount and includes layer in topmost()', () => {
+    withRoot(() => usePortal({ layer: 'tooltip' }))
+    const top = getPortalManager().topmost()
+    expect(top).not.toBeNull()
+    expect(top?.layer).toBe('tooltip')
+  })
+
+  it('deregisters when root disposes', () => {
+    const localDispose = createRoot((d) => {
+      usePortal({ layer: 'modal' })
+      return d
+    })
+    expect(getPortalManager().layers().length).toBe(1)
+    localDispose()
+    expect(getPortalManager().layers().length).toBe(0)
+  })
+
+  it('skips registration when enabled=false', () => {
+    withRoot(() => usePortal({ layer: 'tooltip', enabled: false }))
+    expect(getPortalManager().layers().length).toBe(0)
+  })
+
+  it('multiple usePortal calls coexist with correct stack order', () => {
+    withRoot(() => {
+      usePortal({ layer: 'toast' })
+      usePortal({ layer: 'tooltip' })
+    })
+    const layers = getPortalManager().layers()
+    expect(layers.length).toBe(2)
+    expect(layers[0]!.layer).toBe('toast')
+    expect(layers[1]!.layer).toBe('tooltip')
+  })
+})
+
+describe('usePortal — portalId', () => {
+  it('returns a stable string id', () => {
+    const a = withRoot(() => usePortal({ layer: 'toast' }))
+    expect(typeof a.portalId).toBe('string')
+    expect(a.portalId.length).toBeGreaterThan(0)
+  })
+
+  it('different hook calls produce different ids', () => {
+    const ids = withRoot(() => {
+      const a = usePortal({ layer: 'toast' })
+      const b = usePortal({ layer: 'tooltip' })
+      return [a.portalId, b.portalId]
+    })
+    expect(ids[0]).not.toBe(ids[1])
+  })
+})
+
+describe('setPortalManager isolation', () => {
+  it('swapping the manager isolates state between consumers', () => {
+    const a = createPortalManager()
+    setPortalManager(a)
+    withRoot(() => usePortal({ layer: 'toast' }))
+    expect(a.layers().length).toBe(1)
+
+    const b = createPortalManager()
+    setPortalManager(b)
+    withRoot(() => usePortal({ layer: 'tooltip' }))
+    expect(b.layers().length).toBe(1)
+    // The first manager still has its registration alive (not disposed).
+    expect(a.layers().length).toBe(1)
+  })
+})

--- a/dashboard/design-system/headless-solid/use-portal.ts
+++ b/dashboard/design-system/headless-solid/use-portal.ts
@@ -1,0 +1,75 @@
+/**
+ * usePortal — SolidJS adapter over headless-core/PortalManager
+ * (RFC 0001 §"directory layout", RFC 0017 PR #2.2).
+ *
+ * Registers a portal layer with the shared manager on mount, deregisters
+ * on root dispose, and returns the resolved z-index + a stable id for
+ * aria-* wiring.
+ *
+ * Render strategy is the caller's choice — this hook does NOT call
+ * Solid's `<Portal>`. Consumers can render in-place, into a `<Portal>`,
+ * or via their own root.
+ *
+ * Module-scoped default manager keeps stack ordering consistent across
+ * all consumers in a single page. Tests swap it via `setPortalManager()`.
+ */
+
+import { createUniqueId, onCleanup } from 'solid-js'
+import {
+  createPortalManager,
+  PORTAL_Z_INDEX,
+  type ActivePortalLayer,
+  type PortalLayerKind,
+  type PortalManager,
+} from '../headless-core/portal-manager'
+
+let defaultManager: PortalManager = createPortalManager()
+
+/** Test-only: replaces the module-scoped manager for isolation. */
+export function setPortalManager(manager: PortalManager): void {
+  defaultManager = manager
+}
+
+/** Mostly useful for tests inspecting topmost() / layers(). */
+export function getPortalManager(): PortalManager {
+  return defaultManager
+}
+
+export interface UsePortalOptions {
+  /** Layer kind — picks default z-index from PORTAL_Z_INDEX. */
+  layer: PortalLayerKind
+  /** Optional z-index override (e.g. tooltip pinned above toast). */
+  zIndex?: number
+  /**
+   * Skip register side effect when false. Mirrors Preact adapter's
+   * temporary-suppression pattern. Default: true.
+   * Note: this is read once at hook call time. Consumers needing
+   * dynamic toggling should wrap the hook call in `<Show when={...}>`
+   * (Solid idiom for conditional mounting).
+   */
+  enabled?: boolean
+}
+
+export interface UsePortalResult {
+  /** Resolved z-index (override or PORTAL_Z_INDEX[layer] default). */
+  readonly zIndex: number
+  /** Stable id assigned to this portal instance for aria-* wiring. */
+  readonly portalId: string
+}
+
+export function usePortal(options: UsePortalOptions): UsePortalResult {
+  const { layer, zIndex, enabled = true } = options
+  const portalId = createUniqueId()
+  const resolvedZ = zIndex ?? PORTAL_Z_INDEX[layer]
+
+  if (enabled) {
+    const active: ActivePortalLayer = defaultManager.push({
+      id: portalId,
+      layer,
+      zIndex,
+    })
+    onCleanup(() => defaultManager.pop(active.id))
+  }
+
+  return { zIndex: resolvedZ, portalId }
+}


### PR DESCRIPTION
PR #2.2 of SolidJS migration sequence. Solid adapter for PortalManager. usePortal(options) registers layer on mount, deregisters on root dispose via onCleanup. portalId via createUniqueId(). 9/9 tests pass, typecheck clean. Production touch 0. Sequential after #12200.