### PR TITLE
feat(headless-solid): RFC 0015 useTabs adapter

### DIFF
--- a/dashboard/design-system/headless-solid/use-tabs.test.ts
+++ b/dashboard/design-system/headless-solid/use-tabs.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+//
+// Tests for headless-solid/use-tabs. Mirrors the Preact adapter
+// scenarios using Solid's accessor + createRoot conventions.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createComputed, createRoot } from 'solid-js'
+import type { TabDescriptor } from '../headless-core/tabs'
+import { useTabs } from './use-tabs'
+
+let dispose: (() => void) | undefined
+
+beforeEach(() => {
+  dispose = undefined
+})
+
+afterEach(() => {
+  dispose?.()
+})
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((d) => {
+    dispose = d
+    return fn()
+  })
+}
+
+const tabsFixture: ReadonlyArray<TabDescriptor> = [
+  { id: 't1', label: 'One' },
+  { id: 't2', label: 'Two' },
+  { id: 't3', label: 'Three' },
+]
+
+describe('useTabs', () => {
+  it('exposes initial activeId from defaultActiveId', () => {
+    const { activeId } = withRoot(() =>
+      useTabs({ tabs: tabsFixture, defaultActiveId: 't2' }),
+    )
+    expect(activeId()).toBe('t2')
+  })
+
+  it('activate updates accessor', () => {
+    const { activeId, activate } = withRoot(() => useTabs({ tabs: tabsFixture }))
+    activate('t3')
+    expect(activeId()).toBe('t3')
+  })
+
+  it('exposes tabs snapshot', () => {
+    const { tabs } = withRoot(() => useTabs({ tabs: tabsFixture }))
+    expect(tabs().map((t) => t.id)).toEqual(['t1', 't2', 't3'])
+  })
+
+  it('close removes a tab', () => {
+    const { tabs, close } = withRoot(() => useTabs({ tabs: tabsFixture }))
+    close('t2')
+    expect(tabs().map((t) => t.id)).toEqual(['t1', 't3'])
+  })
+
+  it('getTabListProps returns role=tablist', () => {
+    const { getTabListProps } = withRoot(() => useTabs({ tabs: tabsFixture }))
+    expect(getTabListProps().role).toBe('tablist')
+  })
+
+  it('getTabProps returns role=tab with aria-selected', () => {
+    const { getTabProps } = withRoot(() =>
+      useTabs({ tabs: tabsFixture, defaultActiveId: 't1' }),
+    )
+    const props = getTabProps('t1')
+    expect(props.role).toBe('tab')
+    expect(props['aria-selected']).toBe(true)
+  })
+
+  it('createComputed re-runs on activate', () => {
+    let runs = 0
+    let last: string | null = null
+    withRoot(() => {
+      const { activeId, activate } = useTabs({
+        tabs: tabsFixture,
+        defaultActiveId: 't1',
+      })
+      createComputed(() => {
+        last = activeId()
+        runs += 1
+      })
+      activate('t2')
+    })
+    expect(runs).toBeGreaterThan(1)
+    expect(last).toBe('t2')
+  })
+
+  it('reorder mutates tabs accessor', () => {
+    const { tabs, reorder } = withRoot(() => useTabs({ tabs: tabsFixture }))
+    reorder(['t3', 't1', 't2'])
+    expect(tabs().map((t) => t.id)).toEqual(['t3', 't1', 't2'])
+  })
+})

--- a/dashboard/design-system/headless-solid/use-tabs.ts
+++ b/dashboard/design-system/headless-solid/use-tabs.ts
@@ -1,0 +1,63 @@
+/**
+ * useTabs — SolidJS adapter over headless-core/Tabs
+ * (RFC 0015 §3.2, RFC 0017 PR #2.3).
+ *
+ * Mirrors headless-preact/use-tabs.ts. Cached controller via createRoot
+ * lifetime, subscribe → setSignal direct path, accessors expose live
+ * controller state.
+ */
+
+import { createSignal, onCleanup, type Accessor } from 'solid-js'
+import {
+  createTabs,
+  type CloseButtonProps,
+  type TabDescriptor,
+  type TabListProps,
+  type TabPanelProps,
+  type TabProps,
+  type TabsController,
+  type TabsOptions,
+} from '../headless-core/tabs'
+
+export interface UseTabsResult {
+  readonly activeId: Accessor<string | null>
+  readonly tabs: Accessor<ReadonlyArray<TabDescriptor>>
+  readonly draggingId: Accessor<string | null>
+  readonly controller: TabsController
+  getTabListProps(): TabListProps
+  getTabProps(id: string): TabProps
+  getTabPanelProps(id: string): TabPanelProps
+  getCloseButtonProps(id: string): CloseButtonProps
+  activate(id: string): void
+  close(id: string): void
+  reorder(ids: ReadonlyArray<string>): void
+}
+
+export function useTabs(opts: TabsOptions): UseTabsResult {
+  const controller = createTabs(opts)
+
+  const [activeId, setActiveId] = createSignal<string | null>(controller.activeId)
+  const [tabs, setTabs] = createSignal<ReadonlyArray<TabDescriptor>>(controller.tabs)
+  const [draggingId, setDraggingId] = createSignal<string | null>(controller.draggingId)
+
+  const dispose = controller.subscribe((snap) => {
+    setActiveId(snap.activeId)
+    setTabs(snap.tabs)
+    setDraggingId(snap.draggingId)
+  })
+  onCleanup(dispose)
+
+  return {
+    activeId,
+    tabs,
+    draggingId,
+    controller,
+    getTabListProps: () => controller.getTabListProps(),
+    getTabProps: (id) => controller.getTabProps(id),
+    getTabPanelProps: (id) => controller.getTabPanelProps(id),
+    getCloseButtonProps: (id) => controller.getCloseButtonProps(id),
+    activate: (id) => controller.activate(id),
+    close: (id) => controller.close(id),
+    reorder: (ids) => controller.reorder(ids),
+  }
+}


### PR DESCRIPTION
PR #2.3 of SolidJS migration sequence. Solid adapter for tabs controller. useTabs(opts) returns Accessor<activeId/tabs/draggingId> + prop getters. 8/8 tests pass, typecheck clean. Production touch 0. Sequential after #12204.