### PR TITLE
fix(keeper): enrich operator broadcast diagnostics

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -140,6 +140,29 @@ let string_opt_json = function
   | Some value -> `String value
   | None -> `Null
 
+let last_nonempty values =
+  List.fold_left
+    (fun acc value ->
+      if String.trim value = "" then acc else Some value)
+    None values
+
+let last_tool_name receipt =
+  let rec choose = function
+    | [] -> None
+    | values :: rest -> (
+        match last_nonempty values with
+        | Some _ as value -> value
+        | None -> choose rest)
+  in
+  choose
+    [
+      receipt.observed_tools;
+      receipt.canonical_tools;
+      receipt.tools_used;
+      receipt.reported_tools;
+      receipt.requested_tools;
+    ]
+
 let cascade_rotation_attempt_to_json attempt =
   `Assoc
     [
@@ -492,32 +515,73 @@ let needs_operator_broadcast = function
   | "pause_human" | "alert_exhausted" | "unknown" -> true
   | _ -> false
 
+let operator_broadcast_payload (receipt : t) ~disposition ~reason =
+  `Assoc
+    [ "schema", `String "keeper.operator_broadcast_required.v1"
+    ; "keeper_name", `String receipt.keeper_name
+    ; "agent_name", `String receipt.agent_name
+    ; "trace_id", `String receipt.trace_id
+    ; "generation", `Int receipt.generation
+    ; ( "turn_count",
+        match receipt.turn_count with
+        | Some value -> `Int value
+        | None -> `Null )
+    ; "disposition", `String disposition
+    ; "disposition_reason", `String reason
+    ; "outcome", `String receipt.outcome
+    ; "terminal_reason_code", `String receipt.terminal_reason_code
+    ; ( "current_task_id",
+        match receipt.current_task_id with
+        | Some value -> `String value
+        | None -> `Null )
+    ; "goal_ids", list_json receipt.goal_ids
+    ; "response_text_present", `Bool receipt.response_text_present
+    ; "cascade_name", `String receipt.cascade_name
+    ; "cascade_outcome", `String receipt.cascade_outcome
+    ; "tool_contract_result", `String receipt.tool_contract_result
+    ; ( "last_tool_name",
+        match last_tool_name receipt with
+        | Some value -> `String value
+        | None -> `Null )
+    ; "tools_used", list_json receipt.tools_used
+    ; ( "tool_contract",
+        `Assoc
+          [ "result", `String receipt.tool_contract_result
+          ; "required_tools", list_json receipt.tool_surface.required_tools
+          ; ( "missing_required_tools",
+              list_json receipt.tool_surface.missing_required_tools )
+          ; "visible_tool_count", `Int receipt.tool_surface.visible_tool_count
+          ; "tool_requirement", `String receipt.tool_surface.tool_requirement
+          ; "tool_surface_class", `String receipt.tool_surface.tool_surface_class
+          ; "tool_gate_enabled", `Bool receipt.tool_surface.tool_gate_enabled
+          ] )
+    ; ( "sandbox",
+        `Assoc
+          [ "kind", `String receipt.sandbox_kind
+          ; "sandbox_root", string_opt_json receipt.sandbox_root
+          ; "network_mode", `String receipt.network_mode
+          ] )
+    ; ( "model_used",
+        match receipt.model_used with
+        | Some value -> `String value
+        | None -> `Null )
+    ; ( "stop_reason",
+        match receipt.stop_reason with
+        | Some value -> `String value
+        | None -> `Null )
+    ; ( "error_kind",
+        match receipt.error_kind with
+        | Some v -> `String v
+        | None -> `Null )
+    ; ( "error_message",
+        match receipt.error_message with
+        | Some v -> `String v
+        | None -> `Null )
+    ; "ended_at", `String receipt.ended_at
+    ]
+
 let emit_operator_broadcast config (receipt : t) ~disposition ~reason =
-  let payload =
-    `Assoc
-      [ "schema", `String "keeper.operator_broadcast_required.v1"
-      ; "keeper_name", `String receipt.keeper_name
-      ; "agent_name", `String receipt.agent_name
-      ; "trace_id", `String receipt.trace_id
-      ; "generation", `Int receipt.generation
-      ; "disposition", `String disposition
-      ; "disposition_reason", `String reason
-      ; "outcome", `String receipt.outcome
-      ; "terminal_reason_code", `String receipt.terminal_reason_code
-      ; "cascade_name", `String receipt.cascade_name
-      ; "cascade_outcome", `String receipt.cascade_outcome
-      ; "tool_contract_result", `String receipt.tool_contract_result
-      ; ( "error_kind"
-        , match receipt.error_kind with
-          | Some v -> `String v
-          | None -> `Null )
-      ; ( "error_message"
-        , match receipt.error_message with
-          | Some v -> `String v
-          | None -> `Null )
-      ; "ended_at", `String receipt.ended_at
-      ]
-  in
+  let payload = operator_broadcast_payload receipt ~disposition ~reason in
   let event =
     Activity_graph.emit config
       ~actor:{ Activity_graph.kind = "agent"; id = receipt.agent_name }

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -142,6 +142,12 @@ val operator_disposition : t -> string * string
     indicates a silent dead-end that operators must be notified about. *)
 val needs_operator_broadcast : string -> bool
 
+val operator_broadcast_payload :
+  t -> disposition:string -> reason:string -> Yojson.Safe.t
+(** Structured payload emitted for [keeper.operator_broadcast_required].
+    Exposed so tests can pin the diagnostic fields operators need when a
+    keeper turn pauses or stalls silently. *)
+
 val append : Coord.config -> t -> unit
 val latest_json : Coord.config -> string -> Yojson.Safe.t option
 val latest_json_by_keeper :

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -10,9 +10,11 @@
 open Alcotest
 
 module R = Masc_mcp.Keeper_execution_receipt
+module U = Yojson.Safe.Util
 
 let mk_tool_surface ?(tool_requirement = "required")
-    ?(missing_required_tools = []) () : R.tool_surface =
+    ?(required_tools = []) ?(missing_required_tools = []) () :
+    R.tool_surface =
   {
     turn_lane = "unified";
     tool_surface_class = "post_dispatch";
@@ -20,7 +22,7 @@ let mk_tool_surface ?(tool_requirement = "required")
     visible_tool_count = 1;
     tool_gate_enabled = true;
     tool_surface_fallback_used = false;
-    required_tools = [];
+    required_tools;
     missing_required_tools;
   }
 
@@ -29,8 +31,17 @@ let mk_receipt
     ?(terminal_reason_code = "")
     ?(tool_contract_result = "satisfied")
     ?(tools_used = [ "Read" ])
+    ?(observed_tools = [])
+    ?(canonical_tools = [])
+    ?(reported_tools = [])
+    ?(requested_tools = [])
+    ?(required_tools = [])
+    ?(missing_required_tools = [])
     ?(tool_requirement = "required")
     ?(cascade_outcome = "completed")
+    ?current_task_id
+    ?stop_reason
+    ?(goal_ids = [])
     ?(error_kind = None)
     ?(error_message = None)
     ?(degraded_retry_applied = false)
@@ -42,20 +53,21 @@ let mk_receipt
     trace_id = "trace-test";
     generation = 1;
     turn_count = Some 1;
-    current_task_id = None;
-    goal_ids = [];
+    current_task_id;
+    goal_ids;
     outcome;
     terminal_reason_code;
     response_text_present = true;
     model_used = None;
-    requested_tools = [];
-    reported_tools = [];
-    observed_tools = [];
-    canonical_tools = [];
+    requested_tools;
+    reported_tools;
+    observed_tools;
+    canonical_tools;
     unexpected_tools = [];
     tools_used;
     tool_contract_result;
-    tool_surface = mk_tool_surface ~tool_requirement ();
+    tool_surface =
+      mk_tool_surface ~tool_requirement ~required_tools ~missing_required_tools ();
     sandbox_kind = "local";
     sandbox_root = None;
     network_mode = "offline";
@@ -70,7 +82,7 @@ let mk_receipt
     degraded_retry_cascade = None;
     fallback_reason = None;
     cascade_rotation_attempts = [];
-    stop_reason = None;
+    stop_reason;
     error_kind;
     error_message;
     started_at = "2026-04-26T00:00:00Z";
@@ -183,6 +195,47 @@ let test_each_broadcast_disp_is_reachable () =
   let d3, _ = R.operator_disposition r3 in
   check bool "unknown reachable" true (R.needs_operator_broadcast d3)
 
+let string_list_member name json =
+  json |> U.member name |> U.to_list |> List.map U.to_string
+
+let test_broadcast_payload_carries_turn_diagnostics () =
+  let receipt =
+    mk_receipt
+      ~terminal_reason_code:"completion_contract_violation:require_tool_use"
+      ~tool_contract_result:"missing_required_tool_use"
+      ~tools_used:[ "keeper_tasks_list"; "keeper_stay_silent" ]
+      ~observed_tools:[ "keeper_tasks_list"; "keeper_stay_silent" ]
+      ~required_tools:[ "keeper_shell"; "masc_worktree_create" ]
+      ~missing_required_tools:[ "keeper_shell" ]
+      ~current_task_id:"task-102"
+      ~stop_reason:"completed"
+      ~goal_ids:[ "goal-main" ]
+      ()
+  in
+  let payload =
+    R.operator_broadcast_payload receipt ~disposition:"pause_human"
+      ~reason:"tool_required_unsatisfied"
+  in
+  check string "task id" "task-102"
+    (payload |> U.member "current_task_id" |> U.to_string);
+  check string "last tool" "keeper_stay_silent"
+    (payload |> U.member "last_tool_name" |> U.to_string);
+  check (list string) "goal ids" [ "goal-main" ]
+    (string_list_member "goal_ids" payload);
+  check (list string) "tools used"
+    [ "keeper_tasks_list"; "keeper_stay_silent" ]
+    (string_list_member "tools_used" payload);
+  let contract = payload |> U.member "tool_contract" in
+  check string "contract result" "missing_required_tool_use"
+    (contract |> U.member "result" |> U.to_string);
+  check (list string) "required tools"
+    [ "keeper_shell"; "masc_worktree_create" ]
+    (string_list_member "required_tools" contract);
+  check (list string) "missing required tools" [ "keeper_shell" ]
+    (string_list_member "missing_required_tools" contract);
+  check string "stop reason" "completed"
+    (payload |> U.member "stop_reason" |> U.to_string)
+
 let () =
   run "keeper_pause_broadcast"
     [
@@ -206,5 +259,7 @@ let () =
           test_case "exact predicate" `Quick test_needs_broadcast_predicate;
           test_case "all 3 broadcast paths reachable" `Quick
             test_each_broadcast_disp_is_reachable;
+          test_case "broadcast payload carries turn diagnostics" `Quick
+            test_broadcast_payload_carries_turn_diagnostics;
         ] );
     ]


### PR DESCRIPTION
## Summary
- adds a reusable operator_broadcast_payload helper for keeper broadcast events
- includes turn/task context, last tool, tools used, required tools, missing required tools, sandbox, stop reason, and model fields in keeper.operator_broadcast_required payloads
- pins the payload shape in keeper_pause_broadcast tests

## Why it matters
When keepers pause or stall, operators need to know the exact missing execution lane without reading several receipt/log files by hand. This makes tool_required_unsatisfied broadcasts actionable instead of just saying that a keeper stopped.

## Verification
- env DUNE_JOBS=1 DUNE_BUILD_DIR=_build-keeper-broadcast scripts/dune-local.sh build test/test_keeper_pause_broadcast.exe
- _build-keeper-broadcast/default/test/test_keeper_pause_broadcast.exe
- git diff --check