### PR TITLE
feat(headless-solid): RFC 0006 useTooltip adapter

### DIFF
--- a/dashboard/design-system/headless-solid/use-tooltip.test.ts
+++ b/dashboard/design-system/headless-solid/use-tooltip.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+//
+// Tests for headless-solid/use-tooltip. Covers initial state, show/hide
+// transitions, prop bundle invariants, and createUniqueId fallback id.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createComputed, createRoot } from 'solid-js'
+import { useTooltip } from './use-tooltip'
+
+let dispose: (() => void) | undefined
+
+beforeEach(() => {
+  dispose = undefined
+})
+
+afterEach(() => {
+  dispose?.()
+})
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((d) => {
+    dispose = d
+    return fn()
+  })
+}
+
+describe('useTooltip', () => {
+  it('starts closed by default', () => {
+    const { isOpen } = withRoot(() => useTooltip())
+    expect(isOpen()).toBe(false)
+  })
+
+  it('show() opens, hide() closes — accessor reflects state', () => {
+    const { isOpen, show, hide } = withRoot(() => useTooltip({ showDelay: 0, hideDelay: 0 }))
+    show()
+    expect(isOpen()).toBe(true)
+    hide()
+    expect(isOpen()).toBe(false)
+  })
+
+  it('aria-describedby accessor flips with isOpen', () => {
+    const { triggerProps, show } = withRoot(() => useTooltip({ id: 'tip-x', showDelay: 0 }))
+    expect(triggerProps['aria-describedby']()).toBeUndefined()
+    show()
+    expect(triggerProps['aria-describedby']()).toBe('tip-x')
+  })
+
+  it('contentProps id matches tooltip id', () => {
+    const { contentProps, id } = withRoot(() => useTooltip({ id: 'tip-y' }))
+    expect(contentProps.id).toBe('tip-y')
+    expect(id).toBe('tip-y')
+  })
+
+  it('contentProps data-state reflects isOpen', () => {
+    const { contentProps, show, hide } = withRoot(() =>
+      useTooltip({ showDelay: 0, hideDelay: 0 }),
+    )
+    expect(contentProps['data-state']()).toBe('closed')
+    show()
+    expect(contentProps['data-state']()).toBe('open')
+    hide()
+    expect(contentProps['data-state']()).toBe('closed')
+  })
+
+  it('contentProps role=tooltip', () => {
+    const { contentProps } = withRoot(() => useTooltip())
+    expect(contentProps.role).toBe('tooltip')
+  })
+
+  it('placement defaults to top, accepts override', () => {
+    const a = withRoot(() => useTooltip())
+    expect(a.placement).toBe('top')
+    dispose?.()
+    dispose = undefined
+    const b = withRoot(() => useTooltip({ placement: 'bottom' }))
+    expect(b.placement).toBe('bottom')
+    expect(b.contentProps['data-placement']).toBe('bottom')
+  })
+
+  it('createUniqueId fallback when no id supplied', () => {
+    const a = withRoot(() => useTooltip())
+    expect(a.id).toMatch(/^tip-/)
+    expect(a.id.length).toBeGreaterThan(4)
+  })
+
+  it('createComputed re-runs on show()', () => {
+    let runs = 0
+    let last: boolean | undefined
+    withRoot(() => {
+      const { isOpen, show } = useTooltip({ showDelay: 0 })
+      createComputed(() => {
+        last = isOpen()
+        runs += 1
+      })
+      show()
+    })
+    expect(runs).toBeGreaterThan(1)
+    expect(last).toBe(true)
+  })
+})

--- a/dashboard/design-system/headless-solid/use-tooltip.ts
+++ b/dashboard/design-system/headless-solid/use-tooltip.ts
@@ -1,0 +1,108 @@
+/**
+ * useTooltip — SolidJS adapter over headless-core/Tooltip + TooltipManager
+ * (RFC 0006 §3.3, RFC 0017 PR #2.4).
+ *
+ * Returns prop bundles for trigger + content elements plus an `isOpen`
+ * accessor. Lifecycle:
+ *   - Controller created in the hook body (inside createRoot scope)
+ *   - subscribe → setSignal on open/close changes
+ *   - onCleanup releases subscription AND calls controller.destroy()
+ *     (clears timers, unregisters from manager)
+ *
+ * Consumer renders the tooltip body inside a `usePortal({ layer:
+ * 'dropdown' })` tree.
+ */
+
+import { createSignal, createUniqueId, onCleanup, type Accessor } from 'solid-js'
+import {
+  createTooltip,
+  type TooltipKeyEvent,
+  type TooltipPlacement,
+} from '../headless-core/tooltip'
+import type { TooltipManager } from '../headless-core/tooltip-manager'
+
+export interface UseTooltipArgs {
+  /** Stable id for aria-describedby. If omitted, allocated via createUniqueId. */
+  id?: string
+  showDelay?: number
+  hideDelay?: number
+  placement?: TooltipPlacement
+  /** Optional one-at-a-time manager; typically passed via Solid context. */
+  manager?: TooltipManager
+  /** Controlled mode: parent owns open. */
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+export interface UseTooltipResult {
+  readonly isOpen: Accessor<boolean>
+  readonly id: string
+  readonly placement: TooltipPlacement
+  /** Spread onto the trigger element (button, link, etc.). */
+  triggerProps: {
+    readonly 'aria-describedby': Accessor<string | undefined>
+    readonly onMouseEnter: () => void
+    readonly onMouseLeave: () => void
+    readonly onFocus: () => void
+    readonly onBlur: () => void
+    readonly onKeyDown: (e: TooltipKeyEvent) => void
+  }
+  /** Spread onto the content / bubble element. */
+  contentProps: {
+    readonly id: string
+    readonly role: 'tooltip'
+    readonly 'data-placement': TooltipPlacement
+    readonly 'data-state': Accessor<'open' | 'closed'>
+    readonly onMouseEnter: () => void
+    readonly onMouseLeave: () => void
+  }
+  show: () => void
+  hide: () => void
+}
+
+export function useTooltip(args: UseTooltipArgs = {}): UseTooltipResult {
+  const fallbackId = createUniqueId()
+  const id = args.id ?? `tip-${fallbackId}`
+  const placement = args.placement ?? 'top'
+
+  const controller = createTooltip({
+    id,
+    showDelay: args.showDelay,
+    hideDelay: args.hideDelay,
+    placement,
+    manager: args.manager,
+    open: args.open,
+    onOpenChange: args.onOpenChange,
+  })
+
+  const [isOpen, setIsOpen] = createSignal<boolean>(controller.isOpen)
+  const dispose = controller.subscribe(() => setIsOpen(controller.isOpen))
+  onCleanup(() => {
+    dispose()
+    controller.destroy()
+  })
+
+  return {
+    isOpen,
+    id,
+    placement,
+    triggerProps: {
+      'aria-describedby': () => (isOpen() ? id : undefined),
+      onMouseEnter: () => controller.handleTriggerMouseEnter(),
+      onMouseLeave: () => controller.handleTriggerMouseLeave(),
+      onFocus: () => controller.handleTriggerFocus(),
+      onBlur: () => controller.handleTriggerBlur(),
+      onKeyDown: (e: TooltipKeyEvent) => controller.handleTriggerKeyDown(e),
+    },
+    contentProps: {
+      id,
+      role: 'tooltip',
+      'data-placement': placement,
+      'data-state': () => (isOpen() ? 'open' : 'closed'),
+      onMouseEnter: () => controller.handleContentMouseEnter(),
+      onMouseLeave: () => controller.handleContentMouseLeave(),
+    },
+    show: () => controller.show(),
+    hide: () => controller.hide(),
+  }
+}


### PR DESCRIPTION
PR #2.4 of SolidJS migration sequence. useTooltip returns Accessor isOpen + trigger/content prop bundles. aria-describedby + data-state are Accessor. onCleanup runs controller.destroy() (clears timers + unregisters from manager). 9/9 tests pass. Production touch 0. Sequential after #12205.