### PR TITLE
[codex] Align phase gate skip contract

### DIFF
--- a/docs/keeper-turn-lifecycle.md
+++ b/docs/keeper-turn-lifecycle.md
@@ -26,16 +26,16 @@ sequenceDiagram
     else phase allows turn
         G->>C: select_cascade
         alt ollama saturated
-            C-->>R: record_pre_dispatch_terminal_observation outcome=skipped
-            R-->>U: Ok meta (skip)
+            C-->>R: record_pre_dispatch_terminal_observation outcome=error
+            R-->>U: Error
         else cascade ok
             C->>A: Keeper_agent_run.run_turn
             alt run_turn returns Error
                 A-->>R: record_pre_dispatch_terminal_observation outcome=error
                 R-->>U: Error
             else turn livelock blocked
-                A-->>R: record_pre_dispatch_terminal_observation outcome=blocked
-                R-->>U: Ok meta (block)
+                A-->>R: record_pre_dispatch_terminal_observation outcome=error
+                R-->>U: Ok meta (terminal failure)
             else turn dispatched
                 A->>T: stream tokens + tool calls
                 T-->>A: results
@@ -58,7 +58,7 @@ stateDiagram-v2
     direction LR
     [*] --> Idle
     Idle --> Phase_gating: heartbeat tick
-    Phase_gating --> Cancelled: phase blocks turn (Cancelled_phase_gate_close)
+    Phase_gating --> Done: phase blocks turn (PhaseGateSkip)
     Phase_gating --> Cascade_routing: phase allows turn
     Cascade_routing --> Failed: cascade unavailable (Failure_cascade_unavailable)
     Cascade_routing --> Failed: cascade build error (Failure_provider_error)
@@ -86,9 +86,9 @@ stateDiagram-v2
 |---|---|---|---|
 | Phase_gating (skip) | phase non-executable | `skipped` | ✓ (#11154) |
 | Cascade_routing | provider selection in flight | (transient) | ✓ |
-| Ollama_saturated (skip) | local provider over budget | `skipped` | ✓ (#11154) |
+| Ollama_saturated | local provider over budget | `error` | ✓ (#11154) |
 | Cascade_error | run_turn returns Error early | `error` | ✓ (#11154) |
-| Turn_livelock (block) | livelock guard caught loop | `blocked` | ✓ (#11154) |
+| Turn_livelock | livelock guard caught loop | `error` | ✓ (#11154) |
 | Streaming | provider yielding tokens | (active) | ✓ |
 | Awaiting_tool_result | tool call in flight | (active) | ✓ |
 | Done | response_text present + receipt ok | `done` | ✓ |

--- a/docs/observability/keeper-turn-fsm-metrics.md
+++ b/docs/observability/keeper-turn-fsm-metrics.md
@@ -69,7 +69,7 @@ The older counter encodes **cross sub-FSM** edges (`ksm_to_kcl_routing`, `kmc_to
 ```promql
 # Phase-gate skip rate per keeper (5m window).
 rate(masc_keeper_turn_fsm_transitions_total{
-  from="phase_gating", to="cancelled:phase_gate_close"
+  from="phase_gating", to="done"
 }[5m])
 
 # Total failure rate by reason.
@@ -112,7 +112,7 @@ violation raises during tests/CI.
 $ masc-trace ~/me alice 42
 2026-04-28T... [receipt 04-28.jsonl] cascade=keeper-default outcome=skipped reason=...
 2026-04-28T... [fsm] alice: [fsm:transition] - -> phase_gating
-2026-04-28T... [fsm] alice: [fsm:transition] phase_gating -> cancelled:phase_gate_close
+2026-04-28T... [fsm] alice: [fsm:transition] phase_gating -> done
 1777248791.071 [tool keeper_tasks_list] ok duration_ms=372
 ```
 
@@ -128,7 +128,7 @@ Source-of-truth cross-reference (after Step 4 caller adoption):
 | Transition | File:line | PR |
 |------------|-----------|-----|
 | `Idle → Phase_gating` (entry) | `keeper_unified_turn.ml:1064` | #11288 |
-| `Phase_gating → Cancelled phase_gate_close` (skip) | `keeper_unified_turn.ml:1086` | #11269 |
+| `Phase_gating → Done` (phase skip) | `keeper_unified_turn.ml:1086` | #11269 |
 | `Phase_gating → Cascade_routing` | `keeper_unified_turn.ml:1095` | #11347 |
 | `Cascade_routing → Failed cascade_unavailable` (ollama) | `keeper_unified_turn.ml:1195` | #11269 |
 | `Cascade_routing → Failed provider_error` (cascade build) | `keeper_unified_turn.ml:1284` | #11340 (variant) + #11269 (site) |

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -91,17 +91,16 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~meta
         ~generation
         ~cascade_name:meta.cascade_name
-        ~outcome:"cancelled"
+        ~outcome:"skipped"
         ~terminal_reason_code
-        ~activity_kind:"keeper.turn_cancelled"
+        ~activity_kind:"keeper.turn_skipped"
         ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
         ~keeper_turn_id
         ();
       Keeper_turn_fsm.emit_transition
         ~keeper_name:meta.name ~turn_id:keeper_turn_id
         ~prev:Keeper_turn_fsm.Phase_gating
-        (Keeper_turn_fsm.Cancelled
-           Keeper_turn_fsm.Cancelled_phase_gate_close);
+        Keeper_turn_fsm.Done;
       Ok meta
   | phase_opt ->
       (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade).

--- a/test/test_keeper_turn_fsm_wired_sites.ml
+++ b/test/test_keeper_turn_fsm_wired_sites.ml
@@ -65,9 +65,9 @@ let count_substring haystack needle =
     | Step | site                                                  | count |
     |------|-------------------------------------------------------|-------|
     | 4c   | run_keeper_cycle entry [Idle -> Phase_gating]         | 1     |
-    | 4b   | phase-gate skip [Phase_gating -> Cancelled]           | 1     |
+    | 4b   | phase-gate skip [Phase_gating -> Done]                | 1     |
     | 4g   | phase pass [Phase_gating -> Cascade_routing]          | 1     |
-    | 4b   | ollama saturated skip                                 | 1     |
+    | 4b   | ollama saturated failure                              | 1     |
     | 4b   | cascade build error                                   | 1     |
     | 4g   | livelock Started [Cascade_routing -> Awaiting_provider] | 1   |
     | 4b   | livelock Blocked                                      | 1     |

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3096,6 +3096,32 @@ let test_run_keeper_cycle_skips_non_executable_phase () =
         (Some "paused")
         (Option.map KP.phase_to_string
            (KR.get_phase ~base_path:base_dir meta.name));
+      let phase_skip_labels =
+        [
+          ("from", "phase_gating");
+          ("to", "done");
+          ("keeper", meta.name);
+        ]
+      in
+      let legacy_phase_cancel_labels =
+        [
+          ("from", "phase_gating");
+          ("to", "cancelled:phase_gate_close");
+          ("keeper", meta.name);
+        ]
+      in
+      let phase_skip_before =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_keeper_turn_fsm_transitions
+          ~labels:phase_skip_labels
+          ()
+      in
+      let legacy_phase_cancel_before =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_keeper_turn_fsm_transitions
+          ~labels:legacy_phase_cancel_labels
+          ()
+      in
       match
         UT.run_keeper_cycle
           ~config
@@ -3109,7 +3135,25 @@ let test_run_keeper_cycle_skips_non_executable_phase () =
             ("expected paused-phase skip, got error: "
             ^ Agent_sdk.Error.to_string err)
       | Ok updated ->
+          let phase_skip_after =
+            Masc_mcp.Prometheus.metric_value_or_zero
+              Masc_mcp.Prometheus.metric_keeper_turn_fsm_transitions
+              ~labels:phase_skip_labels
+              ()
+          in
+          let legacy_phase_cancel_after =
+            Masc_mcp.Prometheus.metric_value_or_zero
+              Masc_mcp.Prometheus.metric_keeper_turn_fsm_transitions
+              ~labels:legacy_phase_cancel_labels
+              ()
+          in
           check string "keeper name preserved" meta.name updated.name;
+          check (float 0.0) "phase skip emits Done transition"
+            (phase_skip_before +. 1.0)
+            phase_skip_after;
+          check (float 0.0) "phase skip does not emit legacy cancel"
+            legacy_phase_cancel_before
+            legacy_phase_cancel_after;
           check (option string) "phase remains paused after skipped turn"
             (Some "paused")
             (Option.map KP.phase_to_string


### PR DESCRIPTION
## Summary

- Align paused/non-executable keeper phase gates with the TLA `PhaseGateSkip` contract: receipt outcome stays `skipped` and the turn FSM now emits `phase_gating -> done` instead of the legacy cancel edge.
- Update keeper lifecycle and FSM metrics docs so operator guidance matches the runtime contract.
- Add a focused regression assertion in `test_keeper_unified` that the new `done` transition increments and the legacy `cancelled:phase_gate_close` edge does not.

## Root Cause

The AST/PPX/TLA contract had already been adopted, but the paused phase-gate runtime path still recorded cancellation semantics. That contradicted `KeeperTurnFSM.tla`, receipt parity expectations, and the existing `test_keeper_unified` expectation that a non-dispatched phase-gated turn is a successful no-op with `receipt_skipped`.

## Operator Impact

Paused keepers now surface phase-gate no-op turns as skipped/done rather than cancelled. Dashboards and PromQL examples should stop treating normal phase gating as a cancellation signal.

## Validation

Local:

- `scripts/check-oas-pin.sh --local-only`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_turn_fsm_emit.exe test/test_keeper_turn_fsm_tla_parity.exe test/test_keeper_receipt_outcome_tla_parity.exe test/test_keeper_receipt_authoritative.exe test/test_keeper_receipt_authoritative_matrix.exe test/ppx_tla/test_basic.exe test/ppx_tla/test_gadt.exe test/test_oas_compat_cascade_fallback.exe`
- `_build/default/test/test_keeper_unified.exe test --color=never --compact --show-errors phase_gate 0`
- `_build/default/test/test_keeper_turn_fsm_emit.exe`
- `_build/default/test/test_keeper_turn_fsm_tla_parity.exe`
- `_build/default/test/test_keeper_receipt_outcome_tla_parity.exe`
- `_build/default/test/test_keeper_receipt_authoritative.exe`
- `_build/default/test/test_keeper_receipt_authoritative_matrix.exe`
- `_build/default/test/ppx_tla/test_basic.exe`
- `_build/default/test/ppx_tla/test_gadt.exe`
- `_build/default/test/test_oas_compat_cascade_fallback.exe`

GitHub Actions on `e30496c16b2de5d56922027274a0042ab0033c5c`:

- `Build and Test` pass
- `CI Gate` pass
- `Health` pass
- `Lint` pass
- `Meta Guards` pass
- `OCaml Structure Ratchet` pass
- `TLA+ Model Checking` pass
- `PR Sync Check` pass
- `Draft Auto-Merge Guard` pass
