### PR TITLE
feat(headless-solid): RFC 0012 useKeyboardShortcut adapter

### DIFF
--- a/dashboard/design-system/headless-solid/use-keyboard-shortcut.test.ts
+++ b/dashboard/design-system/headless-solid/use-keyboard-shortcut.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createRoot } from 'solid-js'
+import { createKeyboardShortcutManager } from '../headless-core/keyboard-shortcuts'
+import { useKeyboardShortcut, useKeyboardShortcutHost } from './use-keyboard-shortcut'
+
+let dispose: (() => void) | undefined
+
+beforeEach(() => {
+  dispose = undefined
+})
+
+afterEach(() => {
+  dispose?.()
+})
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((d) => {
+    dispose = d
+    return fn()
+  })
+}
+
+describe('useKeyboardShortcut', () => {
+  it('registers a chord and returns display + aria strings', () => {
+    const manager = createKeyboardShortcutManager()
+    let triggered = 0
+    const result = withRoot(() =>
+      useKeyboardShortcut(
+        manager,
+        {
+          chord: { key: 'k', modifiers: [] },
+          action: () => { triggered += 1 },
+          description: 'Open command palette',
+          scope: 'global',
+        },
+        'cmd-palette',
+      ),
+    )
+    expect(typeof result.display).toBe('string')
+    expect(typeof result.aria).toBe('string')
+    expect(result.display.length).toBeGreaterThan(0)
+    expect(result.aria.length).toBeGreaterThan(0)
+    // Verify registration is live: dispatch a matching event.
+    const matched = manager.dispatch({
+      key: 'k',
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      target: null,
+      preventDefault: () => {},
+      stopPropagation: () => {},
+    })
+    expect(matched).toBe(true)
+    expect(triggered).toBe(1)
+  })
+
+  it('createRoot dispose unregisters the chord', () => {
+    const manager = createKeyboardShortcutManager()
+    let triggered = 0
+    const localDispose = createRoot((d) => {
+      useKeyboardShortcut(
+        manager,
+        {
+          chord: { key: 'a', modifiers: [] },
+          action: () => { triggered += 1 },
+          description: 'A',
+          scope: 'global',
+        },
+        'a-shortcut',
+      )
+      return d
+    })
+    manager.dispatch({
+      key: 'a', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false,
+      target: null, preventDefault: () => {}, stopPropagation: () => {},
+    })
+    expect(triggered).toBe(1)
+    localDispose()
+    manager.dispatch({
+      key: 'a', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false,
+      target: null, preventDefault: () => {}, stopPropagation: () => {},
+    })
+    expect(triggered).toBe(1)
+  })
+})
+
+describe('useKeyboardShortcutHost', () => {
+  it('binds document keydown and fires registered shortcuts', () => {
+    const manager = createKeyboardShortcutManager()
+    let triggered = 0
+    const localDispose = createRoot((d) => {
+      useKeyboardShortcut(
+        manager,
+        {
+          chord: { key: 'b', modifiers: [] },
+          action: () => { triggered += 1 },
+          description: 'B',
+          scope: 'global',
+        },
+        'b-shortcut',
+      )
+      useKeyboardShortcutHost(manager)
+      return d
+    })
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'b' }))
+    expect(triggered).toBe(1)
+    localDispose()
+  })
+
+  it('unbinds the listener on dispose', () => {
+    const manager = createKeyboardShortcutManager()
+    let triggered = 0
+    const localDispose = createRoot((d) => {
+      useKeyboardShortcut(
+        manager,
+        {
+          chord: { key: 'c', modifiers: [] },
+          action: () => { triggered += 1 },
+          description: 'C',
+          scope: 'global',
+        },
+        'c-shortcut',
+      )
+      useKeyboardShortcutHost(manager)
+      return d
+    })
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'c' }))
+    expect(triggered).toBe(1)
+    localDispose()
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'c' }))
+    expect(triggered).toBe(1)
+  })
+
+  it('unmatched key falls through without throw', () => {
+    const manager = createKeyboardShortcutManager()
+    withRoot(() => useKeyboardShortcutHost(manager))
+    expect(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'q' }))
+    }).not.toThrow()
+  })
+})

--- a/dashboard/design-system/headless-solid/use-keyboard-shortcut.ts
+++ b/dashboard/design-system/headless-solid/use-keyboard-shortcut.ts
@@ -1,0 +1,63 @@
+/**
+ * useKeyboardShortcut + useKeyboardShortcutHost — SolidJS adapters
+ * over headless-core/KeyboardShortcutManager
+ * (RFC 0012 §3.2, RFC 0017 PR #2.5).
+ *
+ * - useKeyboardShortcut registers a chord under its createRoot scope
+ *   and returns the human-readable + ARIA chord strings.
+ * - useKeyboardShortcutHost binds a single document keydown listener
+ *   that dispatches to the manager. Mount once at app root.
+ */
+
+import { onCleanup } from 'solid-js'
+import type {
+  KeyboardShortcutManager,
+  ShortcutDescriptor,
+  ShortcutKeyEvent,
+} from '../headless-core/keyboard-shortcuts'
+
+export interface UseKeyboardShortcutResult {
+  readonly display: string
+  readonly aria: string
+}
+
+export function useKeyboardShortcut(
+  manager: KeyboardShortcutManager,
+  descriptor: Omit<ShortcutDescriptor, 'id'>,
+  id: string,
+): UseKeyboardShortcutResult {
+  const dispose = manager.register({ id, ...descriptor })
+  onCleanup(dispose)
+  return {
+    display: manager.formatChord(descriptor.chord),
+    aria: manager.formatAria(descriptor.chord),
+  }
+}
+
+/**
+ * Bind a single global keydown listener. Mount once at the app root.
+ * Matched shortcuts fire their action and prevent default; unmatched
+ * fall through.
+ */
+export function useKeyboardShortcutHost(manager: KeyboardShortcutManager): void {
+  if (typeof document === 'undefined') return
+  const handler = (event: KeyboardEvent): void => {
+    const adapted: ShortcutKeyEvent = {
+      key: event.key,
+      metaKey: event.metaKey,
+      ctrlKey: event.ctrlKey,
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      target: event.target as ShortcutKeyEvent['target'],
+      preventDefault: () => event.preventDefault(),
+      stopPropagation: () => event.stopPropagation(),
+    }
+    const matched = manager.dispatch(adapted)
+    if (matched) {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+  }
+  document.addEventListener('keydown', handler)
+  onCleanup(() => document.removeEventListener('keydown', handler))
+}


### PR DESCRIPTION
PR #2.5 of SolidJS migration sequence. Solid adapter for KeyboardShortcutManager. useKeyboardShortcut registers chord under createRoot, returns display+aria. useKeyboardShortcutHost binds document keydown. 5/5 tests pass, typecheck clean. Production touch 0. Sequential after #12207.