### PR TITLE
fix(mcp): add context to session termination logs

### DIFF
--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -460,11 +460,26 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                              h2_respond_json h2_reqd body ~status:`Bad_request
                                ~extra_headers:(cors @ mcp_headers session_id (get_protocol_version httpun_request))
                          | Ok () ->
+                             let protocol_version =
+                               get_protocol_version httpun_request
+                             in
+                             let sse_active_before_stop =
+                               Server_mcp_transport_http.is_active_sse_session
+                                 session_id
+                             in
                              stop_sse_session session_id;
                              Sse.unregister session_id;
                              forget_mcp_session session_id;
-                             Log.info ~ctx:"h2_gateway" "Session terminated: %s" session_id;
-                             let mcp_hdrs = mcp_headers session_id (get_protocol_version httpun_request) in
+                             Log.info ~ctx:"h2_gateway"
+                               "Session terminated: %s reason=client_delete \
+                                profile=%s protocol_version=%s \
+                                sse_active_before_stop=%b"
+                               session_id
+                               (Server_mcp_transport_http.profile_label profile)
+                               protocol_version sse_active_before_stop;
+                             let mcp_hdrs =
+                               mcp_headers session_id protocol_version
+                             in
                              h2_respond_empty h2_reqd ~extra_headers:mcp_hdrs))
                 | None ->
                     h2_respond_text h2_reqd "Mcp-Session-Id required" ~status:`Bad_request ~extra_headers:cors))

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -802,21 +802,31 @@ let handle_delete_mcp ~deps ?(profile = Full) request reqd =
                   in
                   Httpun.Reqd.respond_with_string reqd response body
               | Ok () ->
+               let protocol_version = get_protocol_version request in
+               let sse_active_before_stop = is_active_sse_session session_id in
                stop_sse_session session_id;
                Sse.unregister session_id;
-               (match request_runtime_result deps with
-               | Ok runtime ->
-                   runtime.clear_resource_subscriptions_for_session session_id
-               | Error msg ->
-                   Log.Server.debug
-                     "skip resource subscription cleanup for session %s: %s"
-                     session_id msg);
+               let resource_cleanup =
+                 match request_runtime_result deps with
+                 | Ok runtime ->
+                     runtime.clear_resource_subscriptions_for_session session_id;
+                     "cleared"
+                 | Error msg ->
+                     Log.Server.debug
+                       "skip resource subscription cleanup for session %s: %s"
+                       session_id msg;
+                     "skipped_runtime_unavailable"
+               in
                forget_mcp_session session_id;
-               Log.info ~ctx:"mcp_transport" "Session terminated: %s" session_id;
+               Log.info ~ctx:"mcp_transport"
+                 "Session terminated: %s reason=client_delete profile=%s \
+                  protocol_version=%s sse_active_before_stop=%b \
+                  resource_cleanup=%s"
+                 session_id (profile_label profile) protocol_version
+                 sse_active_before_stop resource_cleanup;
               let headers =
                 Httpun.Headers.of_list
-                  (("content-length", "0")
-                  :: mcp_headers session_id (get_protocol_version request))
+                  (("content-length", "0") :: mcp_headers session_id protocol_version)
               in
               let response = Httpun.Response.create ~headers `No_content in
               Httpun.Reqd.respond_with_string reqd response ""))

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -38,6 +38,7 @@ val is_valid_protocol_version : string -> bool
 val remember_protocol_version : string -> string -> unit
 val remember_mcp_profile : string -> tool_profile -> unit
 val forget_mcp_session : string -> unit
+val profile_label : tool_profile -> string
 val reap_stale_sessions : is_active_session:(string -> bool) -> int
 val validate_mcp_session_profile :
   profile:tool_profile -> string -> (unit, string) result

--- a/lib/server/server_mcp_transport_http_session.mli
+++ b/lib/server/server_mcp_transport_http_session.mli
@@ -40,6 +40,10 @@ val forget_mcp_session : string -> unit
 (** Removes both the protocol-version and tool-profile entries
     for [session_id]. *)
 
+val profile_label : Server_mcp_transport_http_types.tool_profile -> string
+(** Stable label for the MCP HTTP surface a session belongs to.
+    Used in profile-mismatch errors and termination logs. *)
+
 val reap_stale_sessions :
   is_active_session:(string -> bool) -> int
 (** [reap_stale_sessions ~is_active_session] removes session


### PR DESCRIPTION
## Summary
- include profile, protocol version, and pre-stop SSE state in client DELETE session termination logs
- include resource cleanup outcome on the regular HTTP DELETE path
- expose the stable MCP profile label through the HTTP transport interfaces

## Validation
- env DUNE_JOBS=1 DUNE_BUILD_DIR=_build-mcp-session-term scripts/dune-local.sh build lib/masc_mcp.a
- env DUNE_JOBS=1 DUNE_BUILD_DIR=_build-mcp-session-term scripts/dune-local.sh build lib/.masc_mcp.objs/byte/masc_mcp__Server_mcp_transport_http.cmo lib/.masc_mcp.objs/byte/masc_mcp__Server_h2_gateway.cmo
- git diff --check origin/main...HEAD