### PR TITLE
feat(dashboard): expose OAS telemetry bridge

### DIFF
--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -37,7 +37,71 @@ let with_lock f =
   Mutex.lock mu;
   Fun.protect ~finally:(fun () -> Mutex.unlock mu) f
 
+let status_to_yojson = function
+  | Success -> `Assoc [ ("kind", `String "success") ]
+  | Error { transient } ->
+      `Assoc
+        [
+          ("kind", `String "error");
+          ("transient", `Bool transient);
+        ]
+  | Cancelled { reason } ->
+      `Assoc
+        [
+          ("kind", `String "cancelled");
+          ("reason", `String reason);
+        ]
+  | Timeout -> `Assoc [ ("kind", `String "timeout") ]
+
+let sample_to_yojson (s : sample) =
+  `Assoc
+    [
+      ("provider_id", `String s.provider_id);
+      ("model_id", `String s.model_id);
+      ("ttfb_ms", `Float s.ttfb_ms);
+      ("total_duration_ms", `Float s.total_duration_ms);
+      ("serialization_ms", `Float s.serialization_ms);
+      ("input_tokens", `Int s.input_tokens);
+      ("output_tokens", `Int s.output_tokens);
+      ("throughput_tokens_per_s", `Float s.throughput_tokens_per_s);
+      ("cost_usd", `Float s.cost_usd);
+      ("cache_hit", `Bool s.cache_hit);
+      ("status", status_to_yojson s.status);
+      ("retry_count", `Int s.retry_count);
+    ]
+
+let sample_entry_to_yojson (s, recorded_at) =
+  `Assoc
+    [
+      ("sample", sample_to_yojson s);
+      ("recorded_at", `Float recorded_at);
+    ]
+
+let provider_json = function
+  | Some provider -> `String provider
+  | None -> `Null
+
+let broadcast_sample_entry entry =
+  let sample, recorded_at = entry in
+  let json =
+    `Assoc
+      [
+        ("type", `String "oas_telemetry_sample");
+        ("payload", sample_entry_to_yojson entry);
+        ("provider_id", `String sample.provider_id);
+        ("model_id", `String sample.model_id);
+        ("ts_unix", `Float recorded_at);
+      ]
+  in
+  try Sse.broadcast_to Sse.Observers json
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Dashboard.warn "oas telemetry SSE broadcast failed: %s"
+        (Printexc.to_string exn)
+
 let record_with_time ~now (s : sample) =
+  let entry = (s, now) in
   with_lock (fun () ->
       let q =
         match Hashtbl.find_opt table s.provider_id with
@@ -50,7 +114,8 @@ let record_with_time ~now (s : sample) =
       Queue.push (s, now) q;
       while Queue.length q > per_provider_cap do
         ignore (Queue.pop q)
-      done)
+      done);
+  broadcast_sample_entry entry
 
 let record (s : sample) = record_with_time ~now:(Unix.gettimeofday ()) s
 
@@ -234,6 +299,46 @@ let summary ?provider ?limit () =
         error_ratio = float_of_int errors /. float_of_int n;
         cancelled_count = cancels;
       }
+
+let summary_to_yojson (s : summary) =
+  `Assoc
+    [
+      ("sample_count", `Int s.sample_count);
+      ("ttfb_p50_ms", `Float s.ttfb_p50_ms);
+      ("ttfb_p95_ms", `Float s.ttfb_p95_ms);
+      ("total_duration_p50_ms", `Float s.total_duration_p50_ms);
+      ("total_duration_p95_ms", `Float s.total_duration_p95_ms);
+      ("total_duration_p99_ms", `Float s.total_duration_p99_ms);
+      ("cache_hit_ratio", `Float s.cache_hit_ratio);
+      ("total_cost_usd", `Float s.total_cost_usd);
+      ("error_ratio", `Float s.error_ratio);
+      ("cancelled_count", `Int s.cancelled_count);
+    ]
+
+let recent_json ?provider ?limit () =
+  let samples = recent ?provider ?limit () in
+  `Assoc
+    [
+      ("provider", provider_json provider);
+      ( "limit",
+        match limit with
+        | Some limit -> `Int limit
+        | None -> `Null );
+      ("count", `Int (List.length samples));
+      ("samples", `List (List.map sample_entry_to_yojson samples));
+    ]
+
+let summary_json ?provider ?limit () =
+  let summary = summary ?provider ?limit () in
+  `Assoc
+    [
+      ("provider", provider_json provider);
+      ( "limit",
+        match limit with
+        | Some limit -> `Int limit
+        | None -> `Null );
+      ("summary", summary_to_yojson summary);
+    ]
 
 let clear ?provider () =
   with_lock (fun () ->

--- a/lib/dashboard/dashboard_oas_bridge.mli
+++ b/lib/dashboard/dashboard_oas_bridge.mli
@@ -15,7 +15,9 @@
     is O(1) amortized and memory stays bounded regardless of emit volume.
 
     OAS workers call {!record} after each LLM turn (tool path or chat path),
-    and the REST/SSE endpoints read from {!recent} and {!summary}.
+    and the REST/SSE endpoints read from {!recent} and {!summary}. Each
+    recorded sample is also emitted to Observer SSE sessions as an additive
+    [oas_telemetry_sample] dashboard event.
 
     Cross-domain: guarded by [Stdlib.Mutex]. Eio fibers may call these
     functions directly; the critical section is short (queue push or fold)
@@ -141,6 +143,26 @@ val summary : ?provider:string -> ?limit:int -> unit -> summary
     [p], the percentile is the value at index [ceil(p*n) - 1], clamped
     to [\[0, n-1\]]. The choice keeps the dashboard deterministic with
     very small windows (e.g. one sample → p50 = p95 = the only value). *)
+
+val status_to_yojson : status -> Yojson.Safe.t
+(** JSON projection used by the dashboard REST/SSE surface. *)
+
+val sample_to_yojson : sample -> Yojson.Safe.t
+(** JSON projection of the twelve-signal sample fields. *)
+
+val sample_entry_to_yojson : sample * float -> Yojson.Safe.t
+(** JSON projection of [(sample, recorded_at)]. *)
+
+val summary_to_yojson : summary -> Yojson.Safe.t
+(** JSON projection of aggregate fields from {!summary}. *)
+
+val recent_json : ?provider:string -> ?limit:int -> unit -> Yojson.Safe.t
+(** Dashboard payload for
+    [GET /api/v1/dashboard/oas/telemetry/recent?provider=P&limit=N]. *)
+
+val summary_json : ?provider:string -> ?limit:int -> unit -> Yojson.Safe.t
+(** Dashboard payload for
+    [GET /api/v1/dashboard/oas/telemetry/summary?provider=P&limit=N]. *)
 
 val clear : ?provider:string -> unit -> unit
 (** [clear ?provider ()] drops samples. With [provider] only that ring is

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -103,6 +103,21 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
     H2.Body.Writer.close writer
   in
 
+  let trimmed_query_param req key =
+    match Server_utils.query_param req key |> Option.map String.trim with
+    | Some value when value <> "" -> Some value
+    | _ -> None
+  in
+
+  let oas_telemetry_limit_param req =
+    Server_utils.int_query_param req "limit" ~default:50
+    |> Server_utils.clamp ~min_v:1 ~max_v:200
+  in
+
+  let oas_telemetry_provider_param req =
+    trimmed_query_param req "provider"
+  in
+
   (* Read H2 request body asynchronously *)
   let h2_read_body h2_reqd callback =
     let body = H2.Reqd.request_body h2_reqd in
@@ -677,6 +692,20 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           with_server_state h2_reqd (fun state ->
             let json = dashboard_perf_http_json state.Mcp_server.room_config in
             h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/oas/telemetry/recent" ->
+          let provider = oas_telemetry_provider_param httpun_request in
+          let limit = oas_telemetry_limit_param httpun_request in
+          let json = Dashboard_oas_bridge.recent_json ?provider ~limit () in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+            ~extra_headers:cors
+
+      | `GET, "/api/v1/dashboard/oas/telemetry/summary" ->
+          let provider = oas_telemetry_provider_param httpun_request in
+          let limit = oas_telemetry_limit_param httpun_request in
+          let json = Dashboard_oas_bridge.summary_json ?provider ~limit () in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+            ~extra_headers:cors
 
       | `GET, "/api/v1/git/graph" ->
           with_server_state h2_reqd (fun state ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -64,6 +64,17 @@ let telemetry_summary_cache_key ~base_path ~masc_root =
   let digest = Digest.string (base_path ^ "\000" ^ masc_root) |> Digest.to_hex in
   "dashboard:telemetry_summary:" ^ digest
 
+let trimmed_query_param req key =
+  match Server_utils.query_param req key |> Option.map String.trim with
+  | Some value when value <> "" -> Some value
+  | _ -> None
+
+let oas_telemetry_limit_param req =
+  Server_utils.int_query_param req "limit" ~default:50
+  |> Server_utils.clamp ~min_v:1 ~max_v:200
+
+let oas_telemetry_provider_param req = trimmed_query_param req "provider"
+
 let sync_keeper_cascade_meta ~(config : Coord.config) ~(name : string)
     ~(cascade_name : string) : (bool, string) result =
   let updated_at = Keeper_types.now_iso () in
@@ -860,6 +871,22 @@ let rec add_routes ~sw ~clock router =
            Dashboard_cache.get_or_compute cache_key ~ttl:30.0 (fun () ->
                Telemetry_unified.summary_json ~base_path ~masc_root ())
          in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/oas/telemetry/recent" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let provider = oas_telemetry_provider_param req in
+         let limit = oas_telemetry_limit_param req in
+         let json = Dashboard_oas_bridge.recent_json ?provider ~limit () in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/oas/telemetry/summary" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let provider = oas_telemetry_provider_param req in
+         let limit = oas_telemetry_limit_param req in
+         let json = Dashboard_oas_bridge.summary_json ?provider ~limit () in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -6,6 +6,7 @@
 
 module DOB = Masc_mcp.Dashboard_oas_bridge
 module Oas = Masc_mcp.Oas
+module Json = Yojson.Safe.Util
 
 let make_sample
     ?(provider = "anthropic")
@@ -142,6 +143,75 @@ let test_summary_status_counts () =
   Alcotest.(check (float 1e-9)) "error_ratio" 0.5 r.DOB.error_ratio;
   Alcotest.(check int) "cancelled_count" 1 r.DOB.cancelled_count
 
+(* --- dashboard JSON surface --- *)
+
+let test_sample_json_preserves_signal_fields () =
+  let json =
+    DOB.sample_to_yojson
+      (make_sample ~provider:"ollama" ~model:"qwen3" ~ttfb:12.0
+         ~dur:34.0 ~serialization:2.0 ~input:123 ~output:45
+         ~throughput:200.0 ~cost:0.03 ~cache:true
+         ~status:(DOB.Cancelled { reason = "operator" }) ~retry:2 ())
+  in
+  Alcotest.(check string) "provider" "ollama"
+    (json |> Json.member "provider_id" |> Json.to_string);
+  Alcotest.(check string) "model" "qwen3"
+    (json |> Json.member "model_id" |> Json.to_string);
+  Alcotest.(check (float 1e-9)) "ttfb" 12.0
+    (json |> Json.member "ttfb_ms" |> Json.to_float);
+  Alcotest.(check (float 1e-9)) "duration" 34.0
+    (json |> Json.member "total_duration_ms" |> Json.to_float);
+  Alcotest.(check (float 1e-9)) "serialization" 2.0
+    (json |> Json.member "serialization_ms" |> Json.to_float);
+  Alcotest.(check int) "input" 123
+    (json |> Json.member "input_tokens" |> Json.to_int);
+  Alcotest.(check int) "output" 45
+    (json |> Json.member "output_tokens" |> Json.to_int);
+  Alcotest.(check (float 1e-9)) "throughput" 200.0
+    (json |> Json.member "throughput_tokens_per_s" |> Json.to_float);
+  Alcotest.(check (float 1e-9)) "cost" 0.03
+    (json |> Json.member "cost_usd" |> Json.to_float);
+  Alcotest.(check bool) "cache" true
+    (json |> Json.member "cache_hit" |> Json.to_bool);
+  Alcotest.(check string) "status kind" "cancelled"
+    (json |> Json.member "status" |> Json.member "kind" |> Json.to_string);
+  Alcotest.(check string) "status reason" "operator"
+    (json |> Json.member "status" |> Json.member "reason" |> Json.to_string);
+  Alcotest.(check int) "retry" 2
+    (json |> Json.member "retry_count" |> Json.to_int)
+
+let test_recent_json_filters_provider () =
+  setup ();
+  DOB.record (make_sample ~provider:"anthropic" ());
+  DOB.record (make_sample ~provider:"ollama" ~model:"qwen3" ());
+  let json = DOB.recent_json ~provider:"ollama" ~limit:5 () in
+  Alcotest.(check string) "provider" "ollama"
+    (json |> Json.member "provider" |> Json.to_string);
+  Alcotest.(check int) "limit" 5
+    (json |> Json.member "limit" |> Json.to_int);
+  Alcotest.(check int) "count" 1
+    (json |> Json.member "count" |> Json.to_int);
+  match json |> Json.member "samples" |> Json.to_list with
+  | [ entry ] ->
+      Alcotest.(check string) "sample provider" "ollama"
+        (entry |> Json.member "sample" |> Json.member "provider_id"
+       |> Json.to_string)
+  | samples ->
+      Alcotest.failf "expected one sample, got %d" (List.length samples)
+
+let test_summary_json_contains_aggregate () =
+  setup ();
+  DOB.record (make_sample ~cache:true ~status:DOB.Success ());
+  DOB.record (make_sample ~cache:false ~status:DOB.Timeout ());
+  let json = DOB.summary_json ~provider:"anthropic" ~limit:10 () in
+  let summary = json |> Json.member "summary" in
+  Alcotest.(check int) "sample_count" 2
+    (summary |> Json.member "sample_count" |> Json.to_int);
+  Alcotest.(check (float 1e-9)) "cache_hit_ratio" 0.5
+    (summary |> Json.member "cache_hit_ratio" |> Json.to_float);
+  Alcotest.(check (float 1e-9)) "error_ratio" 0.5
+    (summary |> Json.member "error_ratio" |> Json.to_float)
+
 (* --- clear --- *)
 
 let test_clear_provider () =
@@ -239,6 +309,15 @@ let () =
           Alcotest.test_case "cache hit + cost" `Quick
             test_summary_cache_and_cost;
           Alcotest.test_case "status counts" `Quick test_summary_status_counts;
+        ] );
+      ( "json",
+        [
+          Alcotest.test_case "sample fields" `Quick
+            test_sample_json_preserves_signal_fields;
+          Alcotest.test_case "recent filters provider" `Quick
+            test_recent_json_filters_provider;
+          Alcotest.test_case "summary aggregate" `Quick
+            test_summary_json_contains_aggregate;
         ] );
       ( "clear",
         [ Alcotest.test_case "clear provider" `Quick test_clear_provider ] );


### PR DESCRIPTION
## Summary
- add JSON projections for Dashboard_oas_bridge samples and summaries
- expose REST endpoints at /api/v1/dashboard/oas/telemetry/recent and /api/v1/dashboard/oas/telemetry/summary
- emit additive observer SSE events when OAS bridge samples are recorded
- add Dashboard_oas_bridge JSON contract tests

Refs #11924

## Validation
- git diff --check
- scripts/dune-local.sh build lib/dashboard/dashboard_oas_bridge.{ml,mli} lib/server/server_routes_http_routes_dashboard.ml lib/server/server_h2_gateway.ml test/test_dashboard_oas_bridge.exe
- scripts/dune-local.sh exec ./test/test_dashboard_oas_bridge.exe
