### PR TITLE
fix(keeper): reject active task silence as progress

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -227,6 +227,12 @@ let is_completion_tool_name name =
   in
   List.mem canonical_name completion_tool_names
 
+let is_stay_silent_tool_name name =
+  let name = canonical_tool_name name in
+  match Tool_name.of_string name with
+  | Some (Keeper Stay_silent) -> true
+  | _ -> false
+
 let tool_name_can_satisfy_required_contract name =
   let name = canonical_tool_name name in
   (* Completion tools (stay_silent, release, done, etc.) intentionally
@@ -279,6 +285,13 @@ let classify_tool_progress name =
   then Execution
   else Passive_status
 
+let is_owned_task_progress_tool_name name =
+  if is_stay_silent_tool_name name then false
+  else
+    match classify_tool_progress name with
+    | Execution | Completion -> true
+    | Passive_status | Claim_context -> false
+
 let is_passive_status_tool_name name =
   match classify_tool_progress name with
   | Passive_status -> true
@@ -322,6 +335,13 @@ let actionable_tool_contract_violation_reason
     | [] ->
       Some
         "actionable keeper signal was present, but the model called no keeper tools"
+    | names
+      when (not claim_context_allowed)
+           && not (List.exists is_owned_task_progress_tool_name names) ->
+      Some
+        (Printf.sprintf
+           "actionable keeper signal was present for an owned active task, but the model only used passive/claim/stay_silent tools without execution progress: %s"
+           (String.concat ", " names))
     | names
       when List.for_all
              (fun name ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5164,6 +5164,32 @@ let test_actionable_tool_contract_rejects_claim_context_when_already_claimed () 
        ~actionable_signal_context:true
        ~tool_names:[ "keeper_task_claim" ])
 
+let test_actionable_tool_contract_rejects_stay_silent_when_already_claimed () =
+  let check_violation label tool_names =
+    match
+      KTD.actionable_tool_contract_violation_reason
+        ~claim_context_allowed:false
+        ~actionable_signal_context:true
+        ~tool_names
+    with
+    | Some reason ->
+        check bool (label ^ " mentions owned active task") true
+          (contains_substring reason "owned active task");
+        check bool (label ^ " mentions execution progress") true
+          (contains_substring reason "without execution progress")
+    | None -> fail (label ^ ": expected owned-task silence violation")
+  in
+  check_violation "stay_silent alone" [ "keeper_stay_silent" ];
+  check_violation "stay_silent plus passive"
+    [ "keeper_stay_silent"; "keeper_tasks_list"; "masc_status" ];
+  check_violation "claim plus passive"
+    [ "keeper_task_claim"; "keeper_tasks_list" ];
+  check (option string) "task completion still satisfies owned task" None
+    (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:false
+       ~actionable_signal_context:true
+       ~tool_names:[ "keeper_task_done" ])
+
 let test_claim_tool_classification_covers_masc_claim_task () =
   check bool "keeper claim is claim tool" true
     (KTD.is_claim_tool_name "keeper_task_claim");
@@ -6538,6 +6564,10 @@ let () =
             "actionable signal rejects claim context after ownership"
             `Quick
             test_actionable_tool_contract_rejects_claim_context_when_already_claimed;
+          test_case
+            "actionable signal rejects stay_silent after ownership"
+            `Quick
+            test_actionable_tool_contract_rejects_stay_silent_when_already_claimed;
           test_case "claim tool classification covers masc claim task" `Quick
             test_claim_tool_classification_covers_masc_claim_task;
           test_case "actionable signal allows execution tools" `Quick


### PR DESCRIPTION
## Summary
- keep idle/no-fit keeper_stay_silent allowed before ownership
- reject stay_silent, passive reads, and claim-only mixtures when the keeper already owns an active task and the turn has an actionable signal
- add regression coverage that task completion still satisfies owned active work

## Validation
- git diff --check origin/main...HEAD
- env DUNE_JOBS=1 DUNE_BUILD_DIR=_build-active-task-silence scripts/dune-local.sh build lib/.masc_mcp.objs/byte/masc_mcp__Keeper_tool_disclosure.cmo
- attempted env DUNE_JOBS=1 DUNE_BUILD_DIR=_build-active-task-silence scripts/dune-local.sh build test/test_keeper_unified.exe; blocked by local agent_sdk/OAS pin drift after main bump: missing llm_provider.cmi / inconsistent Agent_sdk__Tool. CI is the reliable full-suite check here.