### PR TITLE
feat(headless-solid): RFC 0001 useFocusScope adapter

### DIFF
--- a/dashboard/design-system/headless-solid/use-focus-scope.test.ts
+++ b/dashboard/design-system/headless-solid/use-focus-scope.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createRoot, createSignal } from 'solid-js'
+import { useFocusScope } from './use-focus-scope'
+
+let dispose: (() => void) | undefined
+let container: HTMLElement
+
+beforeEach(() => {
+  dispose = undefined
+  container = document.createElement('div')
+  container.innerHTML = '<button id="a">A</button><button id="b">B</button>'
+  document.body.append(container)
+})
+
+afterEach(() => {
+  dispose?.()
+  container.remove()
+})
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((d) => {
+    dispose = d
+    return fn()
+  })
+}
+
+describe('useFocusScope', () => {
+  it('returns the underlying scope handle', () => {
+    const { scope } = withRoot(() =>
+      useFocusScope({ containerRef: () => container }),
+    )
+    expect(typeof scope.activate).toBe('function')
+    expect(typeof scope.deactivate).toBe('function')
+  })
+
+  it('activates focus on mount when active=true (default)', () => {
+    withRoot(() => useFocusScope({ containerRef: () => container }))
+    const a = container.querySelector('#a') as HTMLButtonElement
+    expect(document.activeElement).toBe(a)
+  })
+
+  it('does not activate when active=false', () => {
+    const before = document.activeElement
+    withRoot(() => useFocusScope({ containerRef: () => container, active: false }))
+    expect(document.activeElement).toBe(before)
+  })
+
+  it('reactive active toggle activates and deactivates', () => {
+    const [active, setActive] = createSignal(false)
+    withRoot(() =>
+      useFocusScope({ containerRef: () => container, active }),
+    )
+    const a = container.querySelector('#a') as HTMLButtonElement
+    expect(document.activeElement).not.toBe(a)
+    setActive(true)
+    expect(document.activeElement).toBe(a)
+    setActive(false)
+    // After deactivate, focus is no longer trapped to a.
+    expect(document.activeElement).not.toBe(a)
+  })
+
+  it('initialFocus function selects custom element', () => {
+    withRoot(() =>
+      useFocusScope({
+        containerRef: () => container,
+        initialFocus: () => container.querySelector('#b'),
+      }),
+    )
+    const b = container.querySelector('#b') as HTMLButtonElement
+    expect(document.activeElement).toBe(b)
+  })
+
+  it('createRoot dispose deactivates the scope', () => {
+    const localDispose = createRoot((d) => {
+      useFocusScope({ containerRef: () => container })
+      return d
+    })
+    const a = container.querySelector('#a') as HTMLButtonElement
+    expect(document.activeElement).toBe(a)
+    localDispose()
+    // After dispose, no longer trapping. Focus may move.
+    expect(document.activeElement).not.toBe(null)
+  })
+})

--- a/dashboard/design-system/headless-solid/use-focus-scope.ts
+++ b/dashboard/design-system/headless-solid/use-focus-scope.ts
@@ -1,0 +1,79 @@
+/**
+ * useFocusScope — SolidJS adapter over headless-core/FocusScope
+ * (RFC 0001 §"directory layout", RFC 0017 PR #2.6).
+ *
+ * Activates a focus trap + restore scope around a container element
+ * while the `active` accessor returns true. On deactivation (or root
+ * dispose), restores focus to whatever was focused before the scope
+ * took over.
+ *
+ * Solid convention: instead of a Preact RefObject, the caller passes a
+ * getter `() => HTMLElement | null`. Solid's `let el!: HTMLElement; <div ref={el} />`
+ * pattern naturally yields a getter via closure.
+ *
+ * Activation is reactive: pass `active: () => boolean` to flip via a
+ * signal. Plain boolean works too (read once at hook call).
+ */
+
+import { createEffect, createMemo, onCleanup } from 'solid-js'
+import {
+  createFocusScope,
+  type FocusScope,
+  type InitialFocus,
+} from '../headless-core/focus-scope'
+
+export interface UseFocusScopeOptions {
+  /**
+   * Getter for the container element. Returning null is safe — the
+   * scope no-ops until the element appears.
+   */
+  containerRef: () => HTMLElement | null
+  /**
+   * Activation flag. Pass an Accessor (getter) for reactive toggling,
+   * or a plain boolean for static activation. Default true.
+   */
+  active?: boolean | (() => boolean)
+  /** Tab cycles within the container. Default true. */
+  loop?: boolean
+  /** Restore focus to the previously focused element on deactivate. Default true. */
+  restoreFocus?: boolean
+  /** Where to land focus on activate. Default 'first'. */
+  initialFocus?: InitialFocus
+}
+
+export interface UseFocusScopeResult {
+  readonly scope: FocusScope
+}
+
+export function useFocusScope(options: UseFocusScopeOptions): UseFocusScopeResult {
+  const {
+    containerRef,
+    active = true,
+    loop = true,
+    restoreFocus = true,
+    initialFocus = 'first',
+  } = options
+
+  const scope = createFocusScope({
+    containerRef,
+    loop,
+    restoreFocus,
+    initialFocus,
+  })
+
+  const isActive = typeof active === 'function'
+    ? createMemo(active)
+    : (): boolean => active
+
+  createEffect(() => {
+    if (isActive()) {
+      scope.activate()
+    } else {
+      scope.deactivate()
+    }
+  })
+
+  onCleanup(() => scope.deactivate())
+
+  return { scope }
+}


### PR DESCRIPTION
PR #2.6 of SolidJS migration sequence. Solid adapter for FocusScope. containerRef as getter (Solid convention). active accepts bool or Accessor<bool> for reactive toggling. createEffect drives activate/deactivate. 6/6 tests pass, typecheck clean. Production touch 0. Sequential after #12211.