### PR TITLE
feat(headless-solid): RFC 0003 useRovingTabindex adapter

### DIFF
--- a/dashboard/design-system/headless-solid/use-roving-tabindex.test.ts
+++ b/dashboard/design-system/headless-solid/use-roving-tabindex.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createRoot, createSignal } from 'solid-js'
+import type { RovingItemDescriptor } from '../headless-core/roving-tabindex'
+import { useRovingTabindex } from './use-roving-tabindex'
+
+let dispose: (() => void) | undefined
+
+beforeEach(() => {
+  dispose = undefined
+})
+
+afterEach(() => {
+  dispose?.()
+})
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((d) => {
+    dispose = d
+    return fn()
+  })
+}
+
+const fixture: ReadonlyArray<RovingItemDescriptor> = [
+  { id: 'a' },
+  { id: 'b' },
+  { id: 'c' },
+]
+
+describe('useRovingTabindex', () => {
+  it('initial activeId is first item', () => {
+    const { activeId } = withRoot(() =>
+      useRovingTabindex({ items: fixture, orientation: 'horizontal' }),
+    )
+    expect(activeId()).toBe('a')
+  })
+
+  it('defaultActiveId honored', () => {
+    const { activeId } = withRoot(() =>
+      useRovingTabindex({
+        items: fixture,
+        orientation: 'horizontal',
+        defaultActiveId: 'b',
+      }),
+    )
+    expect(activeId()).toBe('b')
+  })
+
+  it('next/prev cycle through items', () => {
+    const { activeId, next, prev } = withRoot(() =>
+      useRovingTabindex({ items: fixture, orientation: 'horizontal' }),
+    )
+    next()
+    expect(activeId()).toBe('b')
+    next()
+    expect(activeId()).toBe('c')
+    prev()
+    expect(activeId()).toBe('b')
+  })
+
+  it('setActive moves rover', () => {
+    const { activeId, setActive } = withRoot(() =>
+      useRovingTabindex({ items: fixture, orientation: 'horizontal' }),
+    )
+    setActive('c')
+    expect(activeId()).toBe('c')
+  })
+
+  it('first/last jump endpoints', () => {
+    const { activeId, last, first } = withRoot(() =>
+      useRovingTabindex({ items: fixture, orientation: 'horizontal' }),
+    )
+    last()
+    expect(activeId()).toBe('c')
+    first()
+    expect(activeId()).toBe('a')
+  })
+
+  it('reactive items accessor — controller resyncs', () => {
+    const [items, setItems] = createSignal<ReadonlyArray<RovingItemDescriptor>>(fixture)
+    const { activeId, items: itemsOut } = withRoot(() =>
+      useRovingTabindex({ items, orientation: 'horizontal' }),
+    )
+    expect(itemsOut().length).toBe(3)
+    setItems([{ id: 'x' }, { id: 'y' }])
+    expect(itemsOut().length).toBe(2)
+    // Active id may shift to first valid id after items shrink.
+    expect(['x', 'y', null]).toContain(activeId())
+  })
+
+  it('getContainerProps + getItemProps return ARIA-correct shapes', () => {
+    const { getContainerProps, getItemProps } = withRoot(() =>
+      useRovingTabindex({ items: fixture, orientation: 'horizontal' }),
+    )
+    const c = getContainerProps()
+    expect(typeof c.onKeyDown).toBe('function')
+    const a = getItemProps('a')
+    expect(a.tabIndex).toBe(0)
+    const b = getItemProps('b')
+    expect(b.tabIndex).toBe(-1)
+  })
+
+  it('onActiveChange fires when rover moves', () => {
+    let lastId: string | null = '?'
+    const { next } = withRoot(() =>
+      useRovingTabindex({
+        items: fixture,
+        orientation: 'horizontal',
+        onActiveChange: (id) => { lastId = id },
+      }),
+    )
+    next()
+    expect(lastId).toBe('b')
+  })
+})

--- a/dashboard/design-system/headless-solid/use-roving-tabindex.ts
+++ b/dashboard/design-system/headless-solid/use-roving-tabindex.ts
@@ -1,0 +1,90 @@
+/**
+ * useRovingTabindex — SolidJS adapter over headless-core/RovingTabindex
+ * (RFC 0003 §3.2, RFC 0017 PR #2.7).
+ *
+ * Replaces ad-hoc keydown + tabindex shuffling. Consumer supplies the
+ * item list (as an Accessor for reactive updates) and binds the
+ * returned prop bundles onto container + item elements.
+ *
+ * - Controller created in the hook body (inside createRoot scope).
+ * - createEffect syncs items() to controller.setItems() on each change.
+ * - subscribe → setSignal on activeId change for reactive reads.
+ * - onCleanup releases the subscription.
+ */
+
+import { createEffect, createSignal, onCleanup, type Accessor } from 'solid-js'
+import {
+  createRovingTabindex,
+  type Orientation,
+  type RovingContainerProps,
+  type RovingItemDescriptor,
+  type RovingItemProps,
+  type RovingKeyEvent,
+  type RovingTabindexController,
+} from '../headless-core/roving-tabindex'
+
+export interface UseRovingTabindexArgs<T extends RovingItemDescriptor> {
+  /** Items getter — pass an Accessor for reactive updates. */
+  items: Accessor<ReadonlyArray<T>> | ReadonlyArray<T>
+  orientation: Orientation
+  loop?: boolean
+  activateOnFocus?: boolean
+  defaultActiveId?: string
+  typeaheadResetMs?: number
+  onActiveChange?: (id: string | null) => void
+}
+
+export interface UseRovingTabindexResult<T extends RovingItemDescriptor> {
+  readonly activeId: Accessor<string | null>
+  readonly items: Accessor<ReadonlyArray<T>>
+  getContainerProps(): RovingContainerProps
+  getItemProps(id: string): RovingItemProps
+  setActive(id: string): void
+  next(): void
+  prev(): void
+  first(): void
+  last(): void
+}
+
+export function useRovingTabindex<T extends RovingItemDescriptor>(
+  args: UseRovingTabindexArgs<T>,
+): UseRovingTabindexResult<T> {
+  const itemsAccessor: Accessor<ReadonlyArray<T>> =
+    typeof args.items === 'function'
+      ? (args.items as Accessor<ReadonlyArray<T>>)
+      : () => args.items as ReadonlyArray<T>
+
+  const controller: RovingTabindexController = createRovingTabindex({
+    orientation: args.orientation,
+    loop: args.loop,
+    activateOnFocus: args.activateOnFocus,
+    defaultActiveId: args.defaultActiveId,
+    typeaheadResetMs: args.typeaheadResetMs,
+    items: itemsAccessor(),
+    onActiveChange: args.onActiveChange,
+  })
+
+  const [activeId, setActiveId] = createSignal<string | null>(controller.activeId)
+
+  createEffect(() => {
+    controller.setItems(itemsAccessor())
+  })
+
+  const dispose = controller.subscribe(() => setActiveId(controller.activeId))
+  onCleanup(dispose)
+
+  return {
+    activeId,
+    items: itemsAccessor,
+    getContainerProps: () => ({
+      ...controller.getContainerProps(),
+      onKeyDown: (e: RovingKeyEvent) => controller.handleKeyDown(e),
+    }),
+    getItemProps: (id: string) => controller.getItemProps(id),
+    setActive: (id) => controller.setActive(id),
+    next: () => controller.next(),
+    prev: () => controller.prev(),
+    first: () => controller.first(),
+    last: () => controller.last(),
+  }
+}


### PR DESCRIPTION
PR #2.7 of SolidJS migration sequence. Solid adapter for RovingTabindex. items accepts Accessor<T[]> OR static array. createEffect resyncs on items() change. Forwards next/prev/first/last/setActive + getContainerProps/getItemProps. 8/8 tests pass, typecheck clean. Production touch 0. Sequential after #12221.