### PR TITLE
feat(headless-solid): RFC 0016 useToolbar adapter

### DIFF
--- a/dashboard/design-system/headless-solid/use-toolbar.test.ts
+++ b/dashboard/design-system/headless-solid/use-toolbar.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createRoot } from 'solid-js'
+import type { ToolbarItem } from '../headless-core/toolbar'
+import { useToolbar } from './use-toolbar'
+
+let dispose: (() => void) | undefined
+
+beforeEach(() => {
+  dispose = undefined
+})
+
+afterEach(() => {
+  dispose?.()
+})
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((d) => {
+    dispose = d
+    return fn()
+  })
+}
+
+const items: ReadonlyArray<ToolbarItem> = [
+  { id: 'save', kind: 'button', label: 'Save' },
+  { id: 'bold', kind: 'toggle', label: 'Bold', pressed: false },
+  { id: 'sep', kind: 'separator' },
+  { id: 'left', kind: 'radio', label: 'Left', checked: true, radioGroup: 'align' },
+  { id: 'right', kind: 'radio', label: 'Right', checked: false, radioGroup: 'align' },
+]
+
+describe('useToolbar', () => {
+  it('exposes visibleItems matching input length', () => {
+    const { visibleItems, hasOverflow } = withRoot(() =>
+      useToolbar({ items, ariaLabel: 'Test' }),
+    )
+    expect(visibleItems().length).toBe(items.length)
+    expect(hasOverflow()).toBe(false)
+  })
+
+  it('toggle flips aria-pressed', () => {
+    const { toggle, getItemProps } = withRoot(() =>
+      useToolbar({ items, ariaLabel: 'Test' }),
+    )
+    toggle('bold')
+    expect(getItemProps('bold')['aria-pressed']).toBe(true)
+  })
+
+  it('selectRadio enforces single-select within radio group', () => {
+    const { selectRadio, getItemProps } = withRoot(() =>
+      useToolbar({ items, ariaLabel: 'Test' }),
+    )
+    selectRadio('right')
+    expect(getItemProps('right')['aria-checked']).toBe(true)
+    expect(getItemProps('left')['aria-checked']).toBe(false)
+  })
+
+  it('overflowAt narrows visibleItems', () => {
+    const { visibleItems, overflowItems, hasOverflow } = withRoot(() =>
+      useToolbar({ items, ariaLabel: 'Test', overflowAt: 2 }),
+    )
+    expect(visibleItems().length).toBe(2)
+    expect(overflowItems().length).toBeGreaterThan(0)
+    expect(hasOverflow()).toBe(true)
+  })
+
+  it('openOverflowMenu flips overflowMenuOpen accessor', () => {
+    const { overflowMenuOpen, openOverflowMenu, closeOverflowMenu } = withRoot(() =>
+      useToolbar({ items, ariaLabel: 'Test' }),
+    )
+    expect(overflowMenuOpen()).toBe(false)
+    openOverflowMenu()
+    expect(overflowMenuOpen()).toBe(true)
+    closeOverflowMenu()
+    expect(overflowMenuOpen()).toBe(false)
+  })
+
+  it('getRootProps returns role=toolbar with aria-label', () => {
+    const { getRootProps } = withRoot(() =>
+      useToolbar({ items, ariaLabel: 'My Toolbar' }),
+    )
+    const props = getRootProps()
+    expect(props.role).toBe('toolbar')
+    expect(props['aria-label']).toBe('My Toolbar')
+  })
+
+  it('getOverflowMenuTriggerProps reflects accessor', () => {
+    const { getOverflowMenuTriggerProps, openOverflowMenu } = withRoot(() =>
+      useToolbar({ items, ariaLabel: 'Test' }),
+    )
+    const props = getOverflowMenuTriggerProps()
+    expect(props['aria-haspopup']).toBe('menu')
+    expect(props['aria-expanded']()).toBe(false)
+    openOverflowMenu()
+    expect(props['aria-expanded']()).toBe(true)
+  })
+})

--- a/dashboard/design-system/headless-solid/use-toolbar.ts
+++ b/dashboard/design-system/headless-solid/use-toolbar.ts
@@ -1,0 +1,114 @@
+/**
+ * useToolbar — SolidJS adapter over headless-core/Toolbar
+ * (RFC 0016 §3.2, RFC 0017 PR #2.8).
+ *
+ * Cached controller via createRoot, subscribe → multi-field setSignal
+ * for reactive snapshot reads. Optional containerRef getter wires up
+ * ResizeObserver for width-driven overflow split.
+ */
+
+import { createEffect, createSignal, onCleanup, type Accessor } from 'solid-js'
+import {
+  createToolbar,
+  type ToolbarController,
+  type ToolbarItem,
+  type ToolbarItemProps,
+  type ToolbarOptions,
+  type ToolbarRootProps,
+} from '../headless-core/toolbar'
+
+export interface UseToolbarArgs extends ToolbarOptions {
+  /** Container element getter; pass `() => containerEl` for ResizeObserver wiring. */
+  containerRef?: () => HTMLElement | null
+}
+
+export interface UseToolbarResult {
+  readonly visibleItems: Accessor<ReadonlyArray<ToolbarItem>>
+  readonly overflowItems: Accessor<ReadonlyArray<ToolbarItem>>
+  readonly hasOverflow: Accessor<boolean>
+  readonly activeId: Accessor<string | null>
+  readonly overflowMenuOpen: Accessor<boolean>
+  readonly controller: ToolbarController
+  getRootProps(): ToolbarRootProps
+  getItemProps(id: string): ToolbarItemProps
+  getOverflowMenuTriggerProps(): {
+    readonly 'aria-haspopup': 'menu'
+    readonly 'aria-expanded': Accessor<boolean>
+    readonly onClick: () => void
+  }
+  setItemWidth(id: string, px: number): void
+  setContainerSize(px: number): void
+  toggle(id: string): void
+  selectRadio(id: string): void
+  activate(id: string): void
+  openOverflowMenu(): void
+  closeOverflowMenu(): void
+}
+
+export function useToolbar(args: UseToolbarArgs): UseToolbarResult {
+  const { containerRef: _ignored, ...opts } = args
+  const controller = createToolbar(opts)
+
+  const [visibleItems, setVisibleItems] = createSignal<ReadonlyArray<ToolbarItem>>(
+    controller.visibleItems,
+  )
+  const [overflowItems, setOverflowItems] = createSignal<ReadonlyArray<ToolbarItem>>(
+    controller.overflowItems,
+  )
+  const [hasOverflow, setHasOverflow] = createSignal<boolean>(controller.hasOverflow)
+  const [activeId, setActiveId] = createSignal<string | null>(controller.activeId)
+  const [overflowMenuOpen, setOverflowMenuOpen] = createSignal<boolean>(
+    controller.overflowMenuOpen,
+  )
+
+  const dispose = controller.subscribe(() => {
+    setVisibleItems(controller.visibleItems)
+    setOverflowItems(controller.overflowItems)
+    setHasOverflow(controller.hasOverflow)
+    setActiveId(controller.activeId)
+    setOverflowMenuOpen(controller.overflowMenuOpen)
+  })
+  onCleanup(dispose)
+
+  // ResizeObserver wiring for containerRef.
+  if (args.containerRef !== undefined) {
+    createEffect(() => {
+      const el = args.containerRef!()
+      if (el === null) return
+      controller.setContainerSize(el.getBoundingClientRect().width)
+      if (typeof ResizeObserver === 'undefined') return
+      const ro = new ResizeObserver((entries) => {
+        const last = entries[entries.length - 1]
+        if (last !== undefined) controller.setContainerSize(last.contentRect.width)
+      })
+      ro.observe(el)
+      onCleanup(() => ro.disconnect())
+    })
+  }
+
+  return {
+    visibleItems,
+    overflowItems,
+    hasOverflow,
+    activeId,
+    overflowMenuOpen,
+    controller,
+    getRootProps: () => controller.getRootProps(),
+    getItemProps: (id) => controller.getItemProps(id),
+    getOverflowMenuTriggerProps: () => ({
+      'aria-haspopup': 'menu' as const,
+      'aria-expanded': overflowMenuOpen,
+      onClick: () =>
+        overflowMenuOpen()
+          ? controller.closeOverflowMenu()
+          : controller.openOverflowMenu(),
+    }),
+    setItemWidth: (id, px) => controller.setItemWidth(id, px),
+    setContainerSize: (px) => controller.setContainerSize(px),
+    toggle: (id) => controller.toggle(id),
+    selectRadio: (id) => controller.selectRadio(id),
+    activate: (id) => controller.activate(id),
+    openOverflowMenu: () => controller.openOverflowMenu(),
+    closeOverflowMenu: () => controller.closeOverflowMenu(),
+  }
+}


### PR DESCRIPTION
PR #2.8 of SolidJS migration sequence. Solid adapter for Toolbar. 5 reactive accessors. containerRef getter wires ResizeObserver. getOverflowMenuTriggerProps returns aria-expanded as Accessor. 7/7 tests pass, typecheck clean. Production touch 0. Sequential after #12224.