### PR TITLE
feat(headless-solid): RFC 0014 useTreeView adapter

### DIFF
--- a/dashboard/design-system/headless-solid/use-tree-view.test.ts
+++ b/dashboard/design-system/headless-solid/use-tree-view.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createRoot } from 'solid-js'
+import type { TreeNode } from '../headless-core/tree-view'
+import { useTreeView } from './use-tree-view'
+
+let dispose: (() => void) | undefined
+
+beforeEach(() => {
+  dispose = undefined
+})
+
+afterEach(() => {
+  dispose?.()
+})
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((d) => {
+    dispose = d
+    return fn()
+  })
+}
+
+const tree: ReadonlyArray<TreeNode<{ kind: string }>> = [
+  { id: 'root', label: 'Root', parentId: null, hasChildren: true },
+  { id: 'a', label: 'A', parentId: 'root', hasChildren: false, data: { kind: 'file' } },
+  { id: 'b', label: 'B', parentId: 'root', hasChildren: true },
+  { id: 'b1', label: 'B1', parentId: 'b', hasChildren: false, data: { kind: 'file' } },
+]
+
+describe('useTreeView', () => {
+  it('initial visible reflects defaultExpanded', () => {
+    const { visible } = withRoot(() =>
+      useTreeView({
+        nodes: tree,
+        selectionMode: 'single',
+        defaultExpanded: ['root'],
+      }),
+    )
+    const ids = visible().map((n) => n.id)
+    expect(ids).toContain('root')
+    expect(ids).toContain('a')
+    expect(ids).toContain('b')
+    expect(ids).not.toContain('b1')
+  })
+
+  it('expand re-renders accessor with children', async () => {
+    const { visible, expand } = withRoot(() =>
+      useTreeView({
+        nodes: tree,
+        selectionMode: 'single',
+        defaultExpanded: ['root'],
+      }),
+    )
+    await expand('b')
+    expect(visible().map((n) => n.id)).toContain('b1')
+  })
+
+  it('select stores id in selected accessor', () => {
+    const { selected, select } = withRoot(() =>
+      useTreeView({
+        nodes: tree,
+        selectionMode: 'single',
+        defaultExpanded: ['root'],
+      }),
+    )
+    select('a')
+    expect(selected().has('a')).toBe(true)
+  })
+
+  it('clearSelection empties selected', () => {
+    const { selected, select, clearSelection } = withRoot(() =>
+      useTreeView({
+        nodes: tree,
+        selectionMode: 'single',
+        defaultExpanded: ['root'],
+      }),
+    )
+    select('a')
+    expect(selected().size).toBe(1)
+    clearSelection()
+    expect(selected().size).toBe(0)
+  })
+
+  it('getRootProps returns role=tree', () => {
+    const { getRootProps } = withRoot(() =>
+      useTreeView({ nodes: tree, selectionMode: 'single' }),
+    )
+    expect(getRootProps().role).toBe('tree')
+  })
+
+  it('getAriaLevel reports 1-indexed depth', () => {
+    const { getAriaLevel } = withRoot(() =>
+      useTreeView({
+        nodes: tree,
+        selectionMode: 'single',
+        defaultExpanded: ['root', 'b'],
+      }),
+    )
+    expect(getAriaLevel('root')).toBe(1)
+    expect(getAriaLevel('b')).toBe(2)
+    expect(getAriaLevel('b1')).toBe(3)
+  })
+
+  it('expanded accessor reflects expand/collapse', () => {
+    const { expanded, collapse } = withRoot(() =>
+      useTreeView({
+        nodes: tree,
+        selectionMode: 'single',
+        defaultExpanded: ['root'],
+      }),
+    )
+    expect(expanded().has('root')).toBe(true)
+    collapse('root')
+    expect(expanded().has('root')).toBe(false)
+  })
+})

--- a/dashboard/design-system/headless-solid/use-tree-view.ts
+++ b/dashboard/design-system/headless-solid/use-tree-view.ts
@@ -1,0 +1,77 @@
+/**
+ * useTreeView — SolidJS adapter over headless-core/TreeView
+ * (RFC 0014 §3.2, RFC 0017 PR #2.9).
+ *
+ * Multi-field reactive accessors (visible/nodes/expanded/selected/activeId).
+ * expand/toggleExpand return Promise to forward async onLoadChildren.
+ */
+
+import { createSignal, onCleanup, type Accessor } from 'solid-js'
+import {
+  createTreeView,
+  type TreeNode,
+  type TreeNodeProps,
+  type TreeRootProps,
+  type TreeViewController,
+  type TreeViewOptions,
+} from '../headless-core/tree-view'
+
+export interface UseTreeViewResult<T = unknown> {
+  readonly visible: Accessor<ReadonlyArray<TreeNode<T>>>
+  readonly nodes: Accessor<ReadonlyArray<TreeNode<T>>>
+  readonly expanded: Accessor<ReadonlySet<string>>
+  readonly selected: Accessor<ReadonlySet<string>>
+  readonly activeId: Accessor<string | null>
+  readonly controller: TreeViewController<T>
+  getRootProps(): TreeRootProps
+  getNodeProps(id: string): TreeNodeProps
+  expand(id: string): Promise<void>
+  collapse(id: string): void
+  toggleExpand(id: string): Promise<void>
+  select(
+    id: string,
+    opts?: { readonly extend?: boolean; readonly toggle?: boolean },
+  ): void
+  clearSelection(): void
+  getAriaLevel(id: string): number
+}
+
+export function useTreeView<T = unknown>(
+  opts: TreeViewOptions<T>,
+): UseTreeViewResult<T> {
+  const controller = createTreeView<T>(opts)
+
+  const [visible, setVisible] = createSignal<ReadonlyArray<TreeNode<T>>>(
+    controller.getVisible(),
+  )
+  const [nodes, setNodes] = createSignal<ReadonlyArray<TreeNode<T>>>(controller.nodes)
+  const [expanded, setExpanded] = createSignal<ReadonlySet<string>>(controller.expanded)
+  const [selected, setSelected] = createSignal<ReadonlySet<string>>(controller.selected)
+  const [activeId, setActiveId] = createSignal<string | null>(controller.activeId)
+
+  const dispose = controller.subscribe(() => {
+    setVisible(controller.getVisible())
+    setNodes(controller.nodes)
+    setExpanded(controller.expanded)
+    setSelected(controller.selected)
+    setActiveId(controller.activeId)
+  })
+  onCleanup(dispose)
+
+  return {
+    visible,
+    nodes,
+    expanded,
+    selected,
+    activeId,
+    controller,
+    getRootProps: () => controller.getRootProps(),
+    getNodeProps: (id) => controller.getNodeProps(id),
+    expand: (id) => controller.expand(id),
+    collapse: (id) => controller.collapse(id),
+    toggleExpand: (id) => controller.toggleExpand(id),
+    select: (id, o) => controller.select(id, o),
+    clearSelection: () => controller.clearSelection(),
+    getAriaLevel: (id) => controller.getAriaLevel(id),
+  }
+}


### PR DESCRIPTION
PR #2.9 of SolidJS migration sequence. Solid adapter for TreeView. 5 reactive accessors. expand/toggleExpand return Promise. 7/7 tests pass, typecheck clean. Production touch 0. Sequential after #12226.