### PR TITLE
feat(headless-solid): RFC 0005 useMenu adapter

### DIFF
--- a/dashboard/design-system/headless-solid/use-menu.test.ts
+++ b/dashboard/design-system/headless-solid/use-menu.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createRoot } from 'solid-js'
+import type { MenuItemDescriptor } from '../headless-core/menu'
+import { useMenu } from './use-menu'
+
+let dispose: (() => void) | undefined
+
+beforeEach(() => {
+  dispose = undefined
+})
+
+afterEach(() => {
+  dispose?.()
+})
+
+function withRoot<T>(fn: () => T): T {
+  return createRoot((d) => {
+    dispose = d
+    return fn()
+  })
+}
+
+const items: ReadonlyArray<MenuItemDescriptor> = [
+  { id: 'open', kind: 'action', label: 'Open' },
+  { id: 'save', kind: 'action', label: 'Save' },
+  { id: 'sep', kind: 'separator' },
+  { id: 'quit', kind: 'action', label: 'Quit' },
+]
+
+describe('useMenu', () => {
+  it('starts closed', () => {
+    const { isOpen } = withRoot(() => useMenu({ id: 'm1', items }))
+    expect(isOpen()).toBe(false)
+  })
+
+  it('open() flips isOpen accessor', () => {
+    const { isOpen, open } = withRoot(() => useMenu({ id: 'm1', items }))
+    open()
+    expect(isOpen()).toBe(true)
+  })
+
+  it('toggle() flips state both directions', () => {
+    const { isOpen, toggle } = withRoot(() => useMenu({ id: 'm1', items }))
+    toggle()
+    expect(isOpen()).toBe(true)
+    toggle()
+    expect(isOpen()).toBe(false)
+  })
+
+  it('getTriggerProps reports aria-haspopup=menu', () => {
+    const { getTriggerProps } = withRoot(() => useMenu({ id: 'm1', items }))
+    expect(getTriggerProps()['aria-haspopup']).toBe('menu')
+  })
+
+  it('getMenuProps role=menu', () => {
+    const { getMenuProps } = withRoot(() => useMenu({ id: 'm1', items }))
+    expect(getMenuProps().role).toBe('menu')
+  })
+
+  it('select fires onSelect handler', () => {
+    const calls: ReadonlyArray<string>[] = []
+    const { open, select } = withRoot(() =>
+      useMenu({
+        id: 'm1',
+        items,
+        onSelect: (id, path) => calls.push([id, ...path]),
+      }),
+    )
+    open()
+    select('save')
+    expect(calls.length).toBe(1)
+    expect(calls[0]![0]).toBe('save')
+  })
+
+  it('triggerRef receives focus on close transition', () => {
+    const trigger = document.createElement('button')
+    document.body.append(trigger)
+    const { open, close } = withRoot(() =>
+      useMenu({ id: 'm1', items, triggerRef: () => trigger }),
+    )
+    open()
+    close()
+    expect(document.activeElement).toBe(trigger)
+    trigger.remove()
+  })
+})

--- a/dashboard/design-system/headless-solid/use-menu.ts
+++ b/dashboard/design-system/headless-solid/use-menu.ts
@@ -1,0 +1,73 @@
+/**
+ * useMenu — SolidJS adapter over headless-core/Menu
+ * (RFC 0005 §3.3, RFC 0017 PR #2.10).
+ *
+ * Two reactive accessors (isOpen / activeId). Optional triggerRef is a
+ * getter `() => HTMLElement | null` (Solid convention). On close
+ * transition, focus is restored to the trigger if present.
+ */
+
+import { createEffect, createSignal, onCleanup, type Accessor } from 'solid-js'
+import {
+  createMenu,
+  type MenuItemProps,
+  type MenuOptions,
+  type MenuProps,
+  type MenuTriggerProps,
+} from '../headless-core/menu'
+
+export interface UseMenuArgs extends MenuOptions {
+  /** Trigger element getter for focus restoration on close. */
+  triggerRef?: () => HTMLElement | null
+}
+
+export interface UseMenuResult {
+  readonly isOpen: Accessor<boolean>
+  readonly activeId: Accessor<string | null>
+  open(): void
+  close(): void
+  toggle(): void
+  focus(itemId: string): void
+  select(itemId: string): void
+  getTriggerProps(): MenuTriggerProps
+  getMenuProps(): MenuProps
+  getItemProps(itemId: string): MenuItemProps
+}
+
+export function useMenu(args: UseMenuArgs): UseMenuResult {
+  const { triggerRef, ...opts } = args
+  const controller = createMenu(opts)
+
+  const [isOpen, setIsOpen] = createSignal<boolean>(controller.isOpen)
+  const [activeId, setActiveId] = createSignal<string | null>(controller.activeId)
+
+  const dispose = controller.subscribe(() => {
+    setIsOpen(controller.isOpen)
+    setActiveId(controller.activeId)
+  })
+  onCleanup(dispose)
+
+  // Restore focus to trigger when menu closes (best-effort).
+  let wasOpen = false
+  createEffect(() => {
+    const open = isOpen()
+    if (wasOpen && !open) {
+      const el = triggerRef?.()
+      if (el !== null && el !== undefined) el.focus()
+    }
+    wasOpen = open
+  })
+
+  return {
+    isOpen,
+    activeId,
+    open: () => controller.open(),
+    close: () => controller.close(),
+    toggle: () => controller.toggle(),
+    focus: (id) => controller.focus(id),
+    select: (id) => controller.select(id),
+    getTriggerProps: () => controller.getTriggerProps(),
+    getMenuProps: () => controller.getMenuProps(),
+    getItemProps: (id) => controller.getItemProps(id),
+  }
+}


### PR DESCRIPTION
PR #2.10 of SolidJS migration sequence (final adapter). Solid adapter for Menu. Two reactive accessors (isOpen/activeId). triggerRef as getter for focus restoration on close. createEffect tracks transition. 7/7 tests pass, typecheck clean. Production touch 0. Sequential after #12227.