### PR TITLE
chore(worker): pin worker_dev_tools.mli (PR#9 prep)

### DIFF
--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -1,0 +1,181 @@
+(** Worker_dev_tools — file_read / file_write / shell_exec for Fleet
+    autonomous-coding agents.
+
+    Surface composition:
+
+    - {!Gate_diff_types} re-exported via [include] (line 13 of the .ml).
+      Provides [destructive_class], [legacy_verdict], [shadow_verdict],
+      [gate_diff] + their tag/diff helpers.
+    - {!Gh_command_validation} re-exported via [include] (line 712 of
+      the .ml). Provides [gh_reversibility] + [gh] command validators.
+    - This module's own surface: [block_reason] type, command-validation
+      gates, attribution helper, log-redaction helpers, and the OAS tool
+      factories ({!make_tools}, {!make_readonly_tools}).
+
+    Internal helpers stay hidden: path resolution, character-class
+    classifiers, pipeline tokenization, command-name extraction,
+    URL/credential redaction, [mkdir_p], the underlying file_read/
+    file_write/shell_exec tool builders, parser-reason tag helpers,
+    and the [classify_legacy] / [classify_shadow] private classifiers
+    used by {!diff_command}. *)
+
+include module type of Gate_diff_types
+
+(** {1 Command validation} *)
+
+(** Closed taxonomy of reasons {!validate_command} /
+    {!validate_command_coding} reject a candidate shell command.  The
+    [Command_not_allowed] payload carries the offending command name
+    so the caller can render an actionable hint. *)
+type block_reason =
+  | Empty_command
+  | Chain_or_redirect
+  | Injection
+  | Process_substitution
+  | Unsafe_redirect
+  | Pipes_not_allowed
+  | Command_not_allowed of string
+
+val block_reason_to_string : block_reason -> string
+(** Render a {!block_reason} as the operator-visible error string
+    embedded in tool result payloads.  Wording is pinned (LLM
+    prompt-conditioning depends on the exact alternatives listed for
+    {!Chain_or_redirect}, {!Injection}, etc.). *)
+
+val validate_command : string -> (unit, block_reason) result
+(** Strict (allowlist + no shell metacharacters) validator used by the
+    default [shell_exec] tool.  Rejects empty input, chaining, and any
+    command outside the dev allowlist (rg / grep / dune / git / ...). *)
+
+val validate_command_coding : string -> (unit, block_reason) result
+(** Relaxed validator for Coding/Full preset keepers.  Allows pipes
+    and fd redirects; still blocks shell injection, process
+    substitution, and unsafe redirects.  Validates every segment of
+    the pipeline against the dev allowlist. *)
+
+val validate_command_coding_with_allowlist :
+  ?allow_pipes:bool ->
+  allowed_commands:string list ->
+  string ->
+  (unit, block_reason) result
+(** Customizable variant of {!validate_command_coding} for callers that
+    need a non-default allowlist.  [allow_pipes] defaults to [true];
+    setting it to [false] yields {!Pipes_not_allowed} for any pipeline
+    longer than one segment. *)
+
+val validate_command_paths :
+  ?workdir:string -> string -> (unit, string) result
+(** When [workdir] is supplied, gate every path-bearing token in [cmd]
+    against {!Path_compat.validate_path}.  Returns [Error msg] with the
+    rejected token (or a path-rewrite-syntax reminder) when a token
+    escapes [workdir].  Returns [Ok ()] unconditionally when
+    [workdir = None]. *)
+
+(** {1 Bash safety classifiers} *)
+
+val is_write_operation : string -> bool
+(** [true] iff the command performs a write/mutating operation
+    (git push/commit, dune clean, npm publish, mv, cp, mkdir,
+    chmod, ...).  Read-only commands (git status, dune build, rg)
+    return [false]. *)
+
+val is_git_branch_switch : string -> bool
+(** [true] iff [cmd] is a git branch-switch / branch-mutation command
+    (checkout, switch, branch -c/-m/-D, ...).  Used by the keeper bash
+    sandbox guard to redirect such operations to the explicit worktree
+    flow.  Read-only listing forms are allowed (return [false]). *)
+
+val is_destructive_bash_operation : string -> bool
+(** [true] iff [cmd] is destructive at the bash layer: [rm -rf],
+    forced [git push --force] / [git reset --hard], [git clean -fd],
+    or anything {!Eval_gate.detect_destructive} flags.  Distinct from
+    {!classify_destructive} (Gate_diff_types) which classifies the
+    *kind* of destruction; this returns a boolean for the bash gate. *)
+
+(** {1 Logging redaction} *)
+
+val sanitize_command_for_log : string -> string
+(** Redact embedded credentials before a command is committed to a log
+    line.  Strips [https://user:pw@] URL credentials, inline
+    [token=]/[password=]/[api-key=] assignments, and the value
+    following [--token]/[--password]/[--auth-token]/[--api-key]
+    flags.  The result is suitable for human/log consumption but not
+    for re-execution. *)
+
+val truncate_for_log : ?max_len:int -> string -> string
+(** UTF-8-safe truncation to [max_len] characters (default [240]),
+    appending [...] when truncated. *)
+
+(** {1 Attribution} *)
+
+val attribution_of_validation :
+  cmd:string -> (unit, block_reason) result -> Attribution.t
+(** Convert the result of {!validate_command} (or any validator that
+    yields [block_reason]) into the {!Attribution} envelope consumed by
+    the dashboard.  [Ok ()] yields a [passed] attribution; [Error br]
+    yields a [policy_failed] attribution carrying the block reason tag,
+    the offending command name (when {!Command_not_allowed}), and the
+    operator-visible error string. *)
+
+(** {1 OAS tool factories} *)
+
+(** Per-call observer hook invoked at the end of every tool execution,
+    receiving the tool name, success flag, and elapsed wall-clock
+    duration. *)
+type tool_exec_observer =
+  tool_name:string -> success:bool -> duration_ms:int -> unit
+
+val make_tools :
+  proc_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  ?workdir:string ->
+  ?on_exec:tool_exec_observer ->
+  unit ->
+  Oas.Tool.t list
+(** Build the full Fleet dev toolset: [file_read], [file_write], and
+    [shell_exec].  [shell_exec] uses the strict {!validate_command}
+    gate and the dev allowlist.  All tools resolve paths relative to
+    [workdir] when supplied; absolute paths still pass the
+    in-allowed-directories check. *)
+
+val make_readonly_tools :
+  proc_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  ?workdir:string ->
+  ?on_exec:tool_exec_observer ->
+  unit ->
+  Oas.Tool.t list
+(** Build the read-only subset: [file_read] + a [shell_exec] gated to
+    a smaller read-only command allowlist (rg, grep, ls, cat, ...).
+    [file_write] is intentionally absent. *)
+
+(** {1 Shadow AST gate observability} *)
+
+val shadow_parse_outcome : string -> string
+(** Parse [cmd] with {!Masc_exec_bash_parser.Bash.parse_string} and
+    return a stable, telemetry-suitable tag:
+
+    - ["parsed_simple"] — grammar accepts the command
+    - ["parse_error"] — Menhir/Lex error
+    - ["parse_aborted:<reason>"] — timeout/depth/token-limit
+    - ["too_complex:<reason>"] — recognised-but-unsupported construct
+
+    Never raises; the parser catches every internal exception. *)
+
+val cross_check_command : legacy:'a -> string -> 'a * string
+(** Pair the supplied [legacy] verdict with the {!shadow_parse_outcome}
+    tag for [cmd].  Polymorphic in [legacy] — callers pass either the
+    typed {!legacy_verdict} or the boolean form used by older test
+    sites.  Pure (no side effects); dashboards consume the tuple to
+    spot legacy/shadow drift without two parse passes. *)
+
+val diff_command :
+  string -> gate_diff * legacy_verdict * shadow_verdict
+(** Run both the legacy substring gate and the shadow AST gate on
+    [cmd], returning their reconciliation outcome alongside both
+    verdicts.  Wraps {!classify_legacy} / {!classify_shadow} (private)
+    and {!diff_of_verdicts} (Gate_diff_types). *)
+
+(** {1 Gh CLI cascade} *)
+
+include module type of Gh_command_validation

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 2,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 998,
+  "lib_dune_lines": 993,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 1
 }


### PR DESCRIPTION
## Summary

Pin the public surface of \`Worker_dev_tools\` (1100 LOC) ahead of the
\`lib/oas/\` sub-library split (plan PR#9).

## Surface composition

- \`include module type of Gate_diff_types\` (cascade, line 13 of the .ml):
  \`destructive_class\` + \`classify_destructive\` + legacy/shadow verdicts
  + \`gate_diff\` + \`diff_of_verdicts\` + \`cmd_hash_for_log\` +
  \`shadow_diff_log_enabled\`.
- \`include module type of Gh_command_validation\` (cascade, line 712):
  \`gh_reversibility\` + classify/string helpers + 4 typed validators
  + \`structured_tool_hint_for_r2\`.
- This module's own surface (17 entries):
  - \`block_reason\` variant + \`block_reason_to_string\`
  - 4 command validators: \`validate_command\`, \`validate_command_paths\`,
    \`validate_command_coding\`, \`validate_command_coding_with_allowlist\`
  - Bash safety classifiers: \`is_write_operation\`, \`is_git_branch_switch\`,
    \`is_destructive_bash_operation\`
  - Log redaction: \`sanitize_command_for_log\`, \`truncate_for_log\`
  - \`attribution_of_validation\`
  - Shadow AST gate observability: \`shadow_parse_outcome\`,
    \`cross_check_command\` (kept polymorphic in \`legacy\` — older test
    sites pass \`(unit, _) result\` instead of the typed verdict),
    \`diff_command\`
  - \`tool_exec_observer\` type + \`make_tools\` + \`make_readonly_tools\`

## Internal helpers stay hidden

Path resolution helpers, character-class classifiers, pipeline
tokenization, command-name extraction, URL/credential redaction,
\`mkdir_p\`, the underlying file_read/file_write/shell_exec tool
builders (\`make_file_read\`, \`make_file_write\`, \`make_shell_exec\`,
\`make_shell_exec_readonly\`, \`make_shell_exec_with_allowlist\`),
parser-reason tag helpers, \`classify_legacy\` / \`classify_shadow\`,
\`block_reason_tag\` (private to attribution).

## Verification

- \`dune build @check\` exit 0 (lib + test type-check)
- \`dune build lib/\` exit 0

## Ratchet impact

- \`lib_dune_lines\` baseline 998 → 993 (natural shrink — main reduced
  it between cycles, this PR adopts the smaller floor).
- \`lib_other_mli_missing\` ratchet only counts \`lib/<subdir>/*.ml\`;
  this file is top-level \`lib/*.ml\` so the metric is unchanged at 1.

The value is contract stabilization before sub-library extraction
(plan PR#9), not ratchet reduction.

## Test plan

- [x] \`dune build @check\` (lib + test type-check)
- [x] \`dune build lib/\` (lib full build)
- [ ] CI required checks