### PR TITLE
fix(keeper): classify provider metrics through registry

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -192,9 +192,7 @@ let label_or_unknown raw =
 
 let provider_kind_of_model_used raw =
   let model_used = label_or_unknown raw in
-  match String.index_opt model_used ':' with
-  | Some idx when idx > 0 -> String.sub model_used 0 idx
-  | _ -> "unknown"
+  Provider_adapter.provider_of_model_label model_used
 
 let record_turn_latency_by_model_bucket
     ~(keeper : string)

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -123,9 +123,9 @@ val record_turn_latency_bucket :
   keeper:string -> latency_ms:int -> unit
 
 val provider_kind_of_model_used : string -> string
-(** Derive the bounded provider label from a keeper [model_used]
-    surface such as [claude_code:auto] or [kimi_cli:kimi-for-coding].
-    Empty or unprefixed values collapse to [unknown]. *)
+(** Derive the bounded provider label from a keeper [model_used] surface via
+    the provider adapter registry. Empty, unprefixed, or unregistered
+    provider prefixes collapse to [unknown]. *)
 
 val record_turn_latency_by_model_bucket :
   keeper:string ->

--- a/test/test_keeper_long_turn_9943.ml
+++ b/test/test_keeper_long_turn_9943.ml
@@ -164,6 +164,12 @@ let test_provider_kind_of_model_used () =
     "claude_code" (M.provider_kind_of_model_used "claude_code:auto");
   Alcotest.(check string) "kimi_cli label"
     "kimi_cli" (M.provider_kind_of_model_used " kimi_cli:kimi-for-coding ");
+  Alcotest.(check string) "direct api prefix stays distinct from cli"
+    "claude" (M.provider_kind_of_model_used "claude:auto");
+  Alcotest.(check string) "unknown prefixed label is not trusted"
+    "unknown" (M.provider_kind_of_model_used "pretend_provider:model");
+  Alcotest.(check string) "custom endpoint label remains bounded"
+    "custom" (M.provider_kind_of_model_used "custom:model@https://example.test/v1");
   Alcotest.(check string) "unprefixed"
     "unknown" (M.provider_kind_of_model_used "gpt-5.4");
   Alcotest.(check string) "empty"


### PR DESCRIPTION
## Summary
- route keeper provider metric labels through Provider_adapter.provider_of_model_label instead of slicing model_used at ':'
- keep CLI/API prefixes distinct, and collapse unregistered provider prefixes to unknown
- add regression coverage for direct API prefix, custom labels, and fake provider prefixes

## Validation
- env DUNE_JOBS=1 DUNE_BUILD_DIR=_build-provider-metrics scripts/dune-local.sh build test/test_keeper_long_turn_9943.exe
- _build-provider-metrics/default/test/test_keeper_long_turn_9943.exe
- git diff --check origin/main...HEAD