### PR TITLE
refactor(gate): type channel error kinds

### DIFF
--- a/lib/gate/channel_gate_metrics.ml
+++ b/lib/gate/channel_gate_metrics.ml
@@ -9,6 +9,11 @@ type outcome =
   | Dispatch_unavailable
   | Internal_error of string
 
+type error_kind = Error_kind of string
+
+let error_kind_of_string value = Error_kind value
+let error_kind_to_string (Error_kind value) = value
+
 type channel_stats = {
   channel : string;
   message_count : int;
@@ -25,7 +30,7 @@ type channel_stats = {
   last_keeper : string;
   last_room_id : string;
   last_error : string;
-  last_error_kind : string;
+  last_error_kind : error_kind;
   last_outcome : string;
   total_duration_ms : int;
   timed_count : int;
@@ -46,7 +51,7 @@ type binding_stats = {
   last_success_ts : float;
   last_error_ts : float;
   last_error : string;
-  last_error_kind : string;
+  last_error_kind : error_kind;
   last_outcome : string;
   total_duration_ms : int;
   timed_count : int;
@@ -60,7 +65,7 @@ type gate_event = {
   room_id : string;
   keeper : string;
   outcome : string;
-  error_kind : string;
+  error_kind : error_kind;
   error : string;
   duration_ms : int;
 }
@@ -75,7 +80,7 @@ type binding_acc = {
   mutable last_error_ts : float;
   mutable keeper : string;
   mutable last_error : string;
-  mutable last_error_kind : string;
+  mutable last_error_kind : error_kind;
   mutable last_outcome : string;
   mutable total_dur_ms : int;
   mutable timed_count : int;
@@ -97,7 +102,7 @@ type stats_acc = {
   mutable last_keeper : string;
   mutable last_room_id : string;
   mutable last_error : string;
-  mutable last_error_kind : string;
+  mutable last_error_kind : error_kind;
   mutable last_outcome : string;
   mutable total_dur_ms : int;
   mutable timed_count : int;
@@ -125,7 +130,7 @@ let make_binding_acc () =
     last_error_ts = 0.0;
     keeper = "";
     last_error = "";
-    last_error_kind = "";
+    last_error_kind = error_kind_of_string "";
     last_outcome = "idle";
     total_dur_ms = 0;
     timed_count = 0;
@@ -148,7 +153,7 @@ let make_acc () =
     last_keeper = "";
     last_room_id = "";
     last_error = "";
-    last_error_kind = "";
+    last_error_kind = error_kind_of_string "";
     last_outcome = "idle";
     total_dur_ms = 0;
     timed_count = 0;
@@ -228,11 +233,12 @@ let get_or_create_binding acc room_id =
       binding
 
 let outcome_error_details = function
-  | Validation_error message -> ("validation", message)
-  | Keeper_error message -> ("keeper", message)
-  | Dispatch_unavailable -> ("dispatch_unavailable", "keeper dispatch unavailable")
-  | Internal_error message -> ("internal", message)
-  | Success | Duplicate -> ("", "")
+  | Validation_error message -> (error_kind_of_string "validation", message)
+  | Keeper_error message -> (error_kind_of_string "keeper", message)
+  | Dispatch_unavailable ->
+      (error_kind_of_string "dispatch_unavailable", "keeper dispatch unavailable")
+  | Internal_error message -> (error_kind_of_string "internal", message)
+  | Success | Duplicate -> (error_kind_of_string "", "")
 
 let append_event ~channel ~room_id ~keeper ~duration_ms outcome ~timestamp =
   let error_kind, error = outcome_error_details outcome in
@@ -308,35 +314,41 @@ let record_attempt ~channel ~room_id ~keeper ~duration_ms outcome =
            | None -> ())
       | Validation_error message ->
           acc.validation_error_count <- acc.validation_error_count + 1;
-          update_error_fields acc ~now ~kind:"validation" ~message;
+          update_error_fields acc ~now
+            ~kind:(error_kind_of_string "validation") ~message;
           (match binding with
            | Some binding ->
-               update_binding_error_fields binding ~now ~kind:"validation"
-                 ~message
+               update_binding_error_fields binding ~now
+                 ~kind:(error_kind_of_string "validation") ~message
            | None -> ())
       | Keeper_error message ->
           acc.keeper_error_count <- acc.keeper_error_count + 1;
-          update_error_fields acc ~now ~kind:"keeper" ~message;
+          update_error_fields acc ~now ~kind:(error_kind_of_string "keeper")
+            ~message;
           (match binding with
            | Some binding ->
-               update_binding_error_fields binding ~now ~kind:"keeper" ~message
+               update_binding_error_fields binding ~now
+                 ~kind:(error_kind_of_string "keeper") ~message
            | None -> ())
       | Dispatch_unavailable ->
           acc.dispatch_unavailable_count <- acc.dispatch_unavailable_count + 1;
-          update_error_fields acc ~now ~kind:"dispatch_unavailable"
+          update_error_fields acc ~now
+            ~kind:(error_kind_of_string "dispatch_unavailable")
             ~message:"keeper dispatch unavailable";
           (match binding with
            | Some binding ->
-               update_binding_error_fields binding ~now ~kind:"dispatch_unavailable"
+               update_binding_error_fields binding ~now
+                 ~kind:(error_kind_of_string "dispatch_unavailable")
                  ~message:"keeper dispatch unavailable"
            | None -> ())
       | Internal_error message ->
           acc.internal_error_count <- acc.internal_error_count + 1;
-          update_error_fields acc ~now ~kind:"internal" ~message;
+          update_error_fields acc ~now ~kind:(error_kind_of_string "internal")
+            ~message;
           (match binding with
            | Some binding ->
-               update_binding_error_fields binding ~now ~kind:"internal"
-                 ~message
+               update_binding_error_fields binding ~now
+                 ~kind:(error_kind_of_string "internal") ~message
            | None -> ()));
       append_event ~channel:channel_key ~room_id:trimmed_room ~keeper:trimmed_keeper
         ~duration_ms outcome ~timestamp:now)
@@ -533,7 +545,7 @@ let gate_event_to_json (event : gate_event) =
       ("room_id", `String event.room_id);
       ("keeper", `String event.keeper);
       ("outcome", `String event.outcome);
-      ("error_kind", `String event.error_kind);
+      ("error_kind", `String (error_kind_to_string event.error_kind));
       ("error", `String event.error);
       ("duration_ms", `Int event.duration_ms);
     ]
@@ -656,7 +668,7 @@ let snapshot_json () =
         ("last_keeper", `String stats.last_keeper);
         ("last_room_id", `String stats.last_room_id);
         ("last_error", `String stats.last_error);
-        ("last_error_kind", `String stats.last_error_kind);
+        ("last_error_kind", `String (error_kind_to_string stats.last_error_kind));
         ("last_outcome", `String stats.last_outcome);
         ("avg_duration_ms", `Int avg_dur);
         ("max_duration_ms", `Int stats.max_duration_ms);
@@ -685,7 +697,7 @@ let snapshot_json () =
         ("last_success", `String (iso_of_ts stats.last_success_ts));
         ("last_error_at", `String (iso_of_ts stats.last_error_ts));
         ("last_error", `String stats.last_error);
-        ("last_error_kind", `String stats.last_error_kind);
+        ("last_error_kind", `String (error_kind_to_string stats.last_error_kind));
         ("last_outcome", `String stats.last_outcome);
         ("avg_duration_ms", `Int avg_dur);
         ("max_duration_ms", `Int stats.max_duration_ms);

--- a/lib/gate/channel_gate_metrics.mli
+++ b/lib/gate/channel_gate_metrics.mli
@@ -15,6 +15,13 @@ type outcome =
   | Dispatch_unavailable
   | Internal_error of string
 
+(** Closed wrapper for connector error-kind labels. JSON/status surfaces
+    continue to render the stable snake_case string labels. *)
+type error_kind = private Error_kind of string
+
+val error_kind_of_string : string -> error_kind
+val error_kind_to_string : error_kind -> string
+
 (** Per-channel statistics snapshot (immutable). *)
 type channel_stats = {
   channel : string;
@@ -32,7 +39,7 @@ type channel_stats = {
   last_keeper : string;
   last_room_id : string;
   last_error : string;
-  last_error_kind : string;
+  last_error_kind : error_kind;
   last_outcome : string;
   total_duration_ms : int;
   timed_count : int;
@@ -54,7 +61,7 @@ type binding_stats = {
   last_success_ts : float;
   last_error_ts : float;
   last_error : string;
-  last_error_kind : string;
+  last_error_kind : error_kind;
   last_outcome : string;
   total_duration_ms : int;
   timed_count : int;
@@ -69,7 +76,7 @@ type gate_event = {
   room_id : string;
   keeper : string;
   outcome : string;
-  error_kind : string;
+  error_kind : error_kind;
   error : string;
   duration_ms : int;
 }

--- a/test/test_channel_gate_metrics.ml
+++ b/test/test_channel_gate_metrics.ml
@@ -20,6 +20,13 @@ let find_channel_json channel json =
   |> List.find (fun item ->
          String.equal (item |> U.member "channel" |> U.to_string) channel)
 
+let check_error_kind name expected actual =
+  check string name expected (Metrics.error_kind_to_string actual)
+
+let test_error_kind_round_trip () =
+  let kind = Metrics.error_kind_of_string "validation" in
+  check_error_kind "round trip" "validation" kind
+
 let test_record_attempt_tracks_connector_diagnostics () =
   with_eio (fun () ->
       let channel = unique_channel "discord-metrics" in
@@ -42,7 +49,7 @@ let test_record_attempt_tracks_connector_diagnostics () =
       check int "validation_error_count" 1 stats.validation_error_count;
       check int "room_count counts unique rooms" 2 stats.room_count;
       check string "last_keeper trimmed" "luna" stats.last_keeper;
-      check string "last_error_kind" "validation" stats.last_error_kind;
+      check_error_kind "last_error_kind" "validation" stats.last_error_kind;
       check string "last_outcome" "duplicate" stats.last_outcome;
       check string "last_room_id" "room-b" stats.last_room_id)
 
@@ -65,7 +72,7 @@ let test_record_internal_error_exn_tracks_internal_failures () =
       check int "internal_error_count" 1 stats.internal_error_count;
       check string "last_keeper trimmed" "sangsu" stats.last_keeper;
       check string "last_error redacted" "internal error" stats.last_error;
-      check string "last_error_kind" "internal" stats.last_error_kind;
+      check_error_kind "last_error_kind" "internal" stats.last_error_kind;
       check string "last_outcome" "internal_error" stats.last_outcome)
 
 let test_record_validation_error_metric_tracks_request_metadata () =
@@ -221,6 +228,7 @@ let () =
     [
       ( "metrics",
         [
+          test_case "error kind round trip" `Quick test_error_kind_round_trip;
           test_case "records connector diagnostics" `Quick
             test_record_attempt_tracks_connector_diagnostics;
           test_case "records internal exception diagnostics" `Quick


### PR DESCRIPTION
Refs #11926

## Summary
- Add `Channel_gate_metrics.error_kind` as a private typed wrapper.
- Move channel/binding/event `last_error_kind` fields off raw `string` while preserving JSON/status string labels.
- Add focused round-trip coverage and keep existing channel gate metrics behavior intact.

## Validation
- `scripts/dune-local.sh build lib/gate/channel_gate_metrics.ml lib/gate/channel_gate_metrics.mli test/test_channel_gate_metrics.exe`
- `./_build/default/test/test_channel_gate_metrics.exe` - 9 tests passed
- `git diff --check HEAD~1`
- `rg -n "last_error_kind\\s*:\\s*string|error_kind\\s*:\\s*string" lib/gate/channel_gate_metrics.ml lib/gate/channel_gate_metrics.mli` - 0 matches