### PR TITLE
feat(keeper): connect cascade thinking_budget to adaptive logic with intent classification

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -122,7 +122,8 @@ let install_snapshot_for_tests ~source_path ~profile_names =
              name;
              weighted_entries = [];
              inference_params = { temperature = None; max_tokens = None;
-                                  keep_alive = None; num_ctx = None };
+                                  keep_alive = None; num_ctx = None;
+                                  thinking_enabled = None; thinking_budget = None };
              api_key_env_overrides = [];
              strategy = Cascade_strategy.failover;
              ollama_max_concurrent = None;

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -24,6 +24,8 @@ type inference_params = Cascade_config_loader.inference_params = {
   max_tokens: int option;
   keep_alive: string option;
   num_ctx: int option;
+  thinking_enabled: bool option;
+  thinking_budget: int option;
 }
 
 let resolve_inference_params = Cascade_config_loader.resolve_inference_params

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -335,6 +335,12 @@ type inference_params = {
   num_ctx: int option;
   (** Ollama [num_ctx] override. Honored only when the resolved
       provider is Ollama. *)
+  thinking_enabled: bool option;
+  thinking_budget: int option;
+  (** [thinking_budget] is a per-turn thinking token budget seed.
+      Keeper adaptive logic may adjust this per turn based on intent
+      classification and error/retry signals.  Provider-specific
+      mapping happens downstream in OAS. *)
 }
 
 (** Resolve inference parameters from cascade.json.

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -165,6 +165,8 @@ let catalog_key_specs =
     ("_sticky_ttl_ms", Schema_field);
     ("_keep_alive", Schema_field);
     ("_num_ctx", Schema_field);
+    ("_thinking_enabled", Schema_field);
+    ("_thinking_budget", Schema_field);
     ("_keeper_assignable", Keeper_assignable_field);
     ("_fallback_cascade", Fallback_cascade_field);
   ]
@@ -286,6 +288,13 @@ type inference_params = {
   num_ctx: int option;
   (** Ollama [num_ctx] override: per-request KV cache allocation in
       tokens. Honored only when the resolved provider is Ollama. *)
+  thinking_enabled: bool option;
+  thinking_budget: int option;
+  (** [thinking_budget] is a per-turn thinking token budget seed.
+      Keeper adaptive logic may adjust this per turn based on intent
+      classification and error/retry signals.  Provider-specific
+      mapping (e.g. to Anthropic [budget_tokens] or DeepSeek
+      [reasoning_effort]) happens downstream in OAS. *)
 }
 
 let read_float_field json key =
@@ -308,6 +317,12 @@ let read_string_field json key =
   | `String s when String.trim s <> "" -> Some (String.trim s)
   | _ -> None
 
+let read_bool_field json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `Bool b -> Some b
+  | _ -> None
+
 let resolve_inference_params ~config_path ~name =
   match load_json config_path with
   | Error msg ->
@@ -315,7 +330,8 @@ let resolve_inference_params ~config_path ~name =
         "[CascadeConfig] resolve_inference_params: %s (name=%s, path=%s)"
         msg name config_path;
       { temperature = None; max_tokens = None;
-        keep_alive = None; num_ctx = None }
+        keep_alive = None; num_ctx = None;
+        thinking_enabled = None; thinking_budget = None }
   | Ok json ->
     let temp =
       match read_float_field json (name ^ "_temperature") with
@@ -340,7 +356,21 @@ let resolve_inference_params ~config_path ~name =
          | Some n when n > 0 -> Some n
          | _ -> None)
     in
-    { temperature = temp; max_tokens = max_tok; keep_alive; num_ctx }
+    let thinking_enabled =
+      match read_bool_field json (name ^ "_thinking_enabled") with
+      | Some _ as v -> v
+      | None -> read_bool_field json "default_thinking_enabled"
+    in
+    let thinking_budget =
+      match read_int_field json (name ^ "_thinking_budget") with
+      | Some n when n > 0 -> Some n
+      | _ ->
+        (match read_int_field json "default_thinking_budget" with
+         | Some n when n > 0 -> Some n
+         | _ -> None)
+    in
+    { temperature = temp; max_tokens = max_tok; keep_alive; num_ctx;
+      thinking_enabled; thinking_budget }
 
 (* ── Per-cascade API key env override ────────────────── *)
 

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -110,15 +110,23 @@ type inference_params = {
   num_ctx: int option;
   (** Ollama [num_ctx] override: per-request KV cache allocation in
       tokens. Honored only when the resolved provider is Ollama. *)
+  thinking_enabled: bool option;
+  thinking_budget: int option;
+  (** [thinking_budget] is a per-turn thinking token budget seed.
+      Keeper adaptive logic may adjust this per turn based on intent
+      classification and error/retry signals.  Provider-specific
+      mapping happens downstream in OAS. *)
 }
 
 (** Resolve inference parameters from cascade.json.
 
     Resolution order:
     1. ["{name}_temperature"] / ["{name}_max_tokens"] /
-       ["{name}_keep_alive"] / ["{name}_num_ctx"]
+       ["{name}_keep_alive"] / ["{name}_num_ctx"] /
+       ["{name}_thinking_enabled"] / ["{name}_thinking_budget"]
     2. ["default_temperature"] / ["default_max_tokens"] /
-       ["default_keep_alive"] / ["default_num_ctx"]
+       ["default_keep_alive"] / ["default_num_ctx"] /
+       ["default_thinking_enabled"] / ["default_thinking_budget"]
     3. [None] (caller uses own defaults) *)
 val resolve_inference_params :
   config_path:string -> name:string -> inference_params

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -15,13 +15,17 @@
 type t = {
   temperature : float option;
   max_tokens : int option;
+  thinking_enabled : bool option;
+  thinking_budget : int option;
 }
 
-let empty = { temperature = None; max_tokens = None }
+let empty = { temperature = None; max_tokens = None;
+              thinking_enabled = None; thinking_budget = None }
 
 (** Convert OAS inference_params to MASC t. *)
 let of_oas (p : Cascade_config.inference_params) : t =
-  { temperature = p.temperature; max_tokens = p.max_tokens }
+  { temperature = p.temperature; max_tokens = p.max_tokens;
+    thinking_enabled = p.thinking_enabled; thinking_budget = p.thinking_budget }
 
 (** Extract inference parameters from a parsed JSON value for a named cascade.
     Exposed for testing without filesystem dependency. *)
@@ -45,7 +49,7 @@ let for_json ~(name : string) (json : Yojson.Safe.t) : t =
     | Some _ as v -> v
     | None -> read_int "default_max_tokens"
   in
-  { temperature; max_tokens }
+  { temperature; max_tokens; thinking_enabled = None; thinking_budget = None }
 
 (** Load inference parameters for a named cascade profile.
     Delegates to MASC [Cascade_config.resolve_inference_params].
@@ -54,7 +58,9 @@ let for_cascade ~(name : string) : t =
   let name = Keeper_cascade_profile.normalize_declared_name name in
   match Cascade_catalog_runtime.resolve_inference_params ~name () with
   | Ok params ->
-      { temperature = params.temperature; max_tokens = params.max_tokens }
+      { temperature = params.temperature; max_tokens = params.max_tokens;
+        thinking_enabled = params.thinking_enabled;
+        thinking_budget = params.thinking_budget }
   | Error detail ->
       Log.warn ~ctx:"cascade"
         "%s: runtime catalog inference lookup failed (%s), using empty defaults"

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -15,6 +15,8 @@
 type t = {
   temperature : float option;
   max_tokens : int option;
+  thinking_enabled : bool option;
+  thinking_budget : int option;
 }
 
 (** No inference parameters specified. *)

--- a/lib/keeper/keeper_agent_prompt_metrics.ml
+++ b/lib/keeper/keeper_agent_prompt_metrics.ml
@@ -7,34 +7,43 @@ let adaptive_thinking_budget
       ~user_message
       ~dynamic_context
       ~current_budget
+      ~intent
   =
   if not enabled
   then current_budget
   else (
-    (* 1) Structured tool errors in last tools -> High thinking *)
-    let had_error =
-      List.exists
-        (fun (r : Oas.Types.tool_result) ->
-           match r with
-           | Error _ -> true
-           | Ok _ -> false)
-        last_tool_results
-    in
-    if is_retry || had_error
-    then Some 1500
-    else (
-      (* 2) Task complexity keywords -> Max thinking *)
-      let haystack = user_message ^ " " ^ dynamic_context in
-      let complex_task =
-        List.exists
-          (fun needle -> String_util.contains_substring_ci haystack needle)
-          [ "분석"; "설계"; "plan"; "architecture"; "complex"; "investigate" ]
-      in
-      if complex_task
-      then Some 2000
-      else
-        (* Otherwise fallback to default or OFF (None) *)
-        current_budget))
+    match intent with
+    | Some Keeper_turn_intent.Mechanical ->
+        (* Mechanical turns do not benefit from structured thinking. *)
+        Some 0
+    | Some Keeper_turn_intent.Cognitive ->
+        (* Cognitive turns use the full cascade seed budget. *)
+        current_budget
+    | None ->
+        (* 1) Structured tool errors in last tools -> High thinking *)
+        let had_error =
+          List.exists
+            (fun (r : Oas.Types.tool_result) ->
+               match r with
+               | Error _ -> true
+               | Ok _ -> false)
+            last_tool_results
+        in
+        if is_retry || had_error
+        then Some 1500
+        else (
+          (* 2) Task complexity keywords -> Max thinking *)
+          let haystack = user_message ^ " " ^ dynamic_context in
+          let complex_task =
+            List.exists
+              (fun needle -> String_util.contains_substring_ci haystack needle)
+              [ "분석"; "설계"; "plan"; "architecture"; "complex"; "investigate" ]
+          in
+          if complex_task
+          then Some 2000
+          else
+            (* Otherwise fallback to default or OFF (None) *)
+            current_budget))
 ;;
 
 (** Structured prompt result from [build_turn_prompt] callback.

--- a/lib/keeper/keeper_agent_prompt_metrics.mli
+++ b/lib/keeper/keeper_agent_prompt_metrics.mli
@@ -9,6 +9,7 @@ val adaptive_thinking_budget :
   user_message:string ->
   dynamic_context:string ->
   current_budget:int option ->
+  intent:Keeper_turn_intent.t option ->
   int option
 
 (** Structured prompt result from [build_turn_prompt] callback.

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -194,6 +194,7 @@ val adaptive_thinking_budget :
   -> user_message:string
   -> dynamic_context:string
   -> current_budget:int option
+  -> intent:Keeper_turn_intent.t option
   -> int option
 
 (** {1 Turn execution} *)

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -938,16 +938,7 @@ let prepare_agent_setup
                  { turn; current_params; messages; last_tool_results; _ } ->
                let hook_t0 = Time_compat.now () in
                current_turn_ref := turn;
-               let adaptive_thinking_budget =
-                 adaptive_thinking_budget
-                   ~enabled:(Keeper_config.keeper_adaptive_thinking_enabled ())
-                   ~is_retry
-                   ~last_tool_results
-                   ~user_message
-                   ~dynamic_context
-                   ~current_budget:current_params.thinking_budget
-               in
-               let adaptive_thinking_override =
+               let intent =
                  if Keeper_config.keeper_adaptive_thinking_mode () then
                    let last_tool_calls =
                      let rev = List.rev messages in
@@ -966,15 +957,35 @@ let prepare_agent_setup
                      scan rev
                    in
                    let retry_count = if is_retry then 1 else 0 in
-                   let intent =
-                     Keeper_turn_intent.classify
-                       ~last_tool_calls
-                       ~last_user_message:(Some user_message)
-                       ~retry_count
-                   in
-                   Some (Keeper_turn_intent.equal intent Keeper_turn_intent.Cognitive)
+                   Some
+                     (Keeper_turn_intent.classify
+                        ~last_tool_calls
+                        ~last_user_message:(Some user_message)
+                        ~retry_count)
                  else
                    None
+               in
+               let cascade_seed = Cascade_inference.for_cascade ~name:cascade_name in
+               let current_budget =
+                 match cascade_seed.thinking_budget with
+                 | Some _ as v -> v
+                 | None -> current_params.thinking_budget
+               in
+               let adaptive_thinking_budget =
+                 adaptive_thinking_budget
+                   ~enabled:(Keeper_config.keeper_adaptive_thinking_enabled ())
+                   ~is_retry
+                   ~last_tool_results
+                   ~user_message
+                   ~dynamic_context
+                   ~current_budget
+                   ~intent
+               in
+               let adaptive_thinking_override =
+                 match intent with
+                 | Some i ->
+                   Some (Keeper_turn_intent.equal i Keeper_turn_intent.Cognitive)
+                 | None -> None
                in
                let current_params =
                  { current_params with

--- a/test/dune
+++ b/test/dune
@@ -215,7 +215,7 @@
         test_provider_error
         test_keeper_synthetic_marker
         test_keeper_turn_fsm_wired_sites
-        test_keeper_tool_emission_hook)
+        )
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
@@ -400,7 +400,6 @@
           test_provider_error
           test_keeper_synthetic_marker
           test_keeper_turn_fsm_wired_sites
-          test_keeper_tool_emission_hook
           )
  (libraries masc_test_deps multimodal))
 
@@ -1786,6 +1785,11 @@
  (name test_k3_tool_pipeline_e2e)
  (modules test_k3_tool_pipeline_e2e)
  (libraries masc_test_deps multimodal shared_types yojson))
+
+(test
+ (name test_keeper_tool_emission_hook)
+ (modules test_keeper_tool_emission_hook)
+ (libraries masc_test_deps multimodal))
 
 (executable
  (name test_concurrent_distributed)

--- a/test/test_keeper_adaptive_thinking.ml
+++ b/test/test_keeper_adaptive_thinking.ml
@@ -9,6 +9,7 @@ let test_adaptive_thinking_disabled () =
       ~user_message:"분석"
       ~dynamic_context:""
       ~current_budget:(Some 100)
+      ~intent:None
   in
   check (option int) "returns current budget when disabled" (Some 100) result
 ;;
@@ -25,6 +26,7 @@ let test_adaptive_thinking_error_or_retry () =
       ~user_message:"hello"
       ~dynamic_context:""
       ~current_budget:None
+      ~intent:None
   in
   check (option int) "high thinking for error" (Some 1500) result1;
   let result2 =
@@ -35,6 +37,7 @@ let test_adaptive_thinking_error_or_retry () =
       ~user_message:"hello"
       ~dynamic_context:""
       ~current_budget:None
+      ~intent:None
   in
   check (option int) "high thinking for retry" (Some 1500) result2
 ;;
@@ -48,6 +51,7 @@ let test_adaptive_thinking_complex_task () =
       ~user_message:"please plan this"
       ~dynamic_context:"some architecture"
       ~current_budget:(Some 100)
+      ~intent:None
   in
   check (option int) "max thinking for complex task keywords" (Some 2000) result
 ;;
@@ -61,8 +65,51 @@ let test_adaptive_thinking_fallback () =
       ~user_message:"simple hello"
       ~dynamic_context:"nothing special"
       ~current_budget:(Some 500)
+      ~intent:None
   in
   check (option int) "fallback to current budget" (Some 500) result
+;;
+
+let test_adaptive_thinking_mechanical () =
+  let result =
+    Masc_mcp.Keeper_agent_run.adaptive_thinking_budget
+      ~enabled:true
+      ~is_retry:false
+      ~last_tool_results:[]
+      ~user_message:"simple hello"
+      ~dynamic_context:""
+      ~current_budget:(Some 500)
+      ~intent:(Some Masc_mcp.Keeper_turn_intent.Mechanical)
+  in
+  check (option int) "mechanical intent minimizes budget" (Some 0) result
+;;
+
+let test_adaptive_thinking_cognitive () =
+  let result =
+    Masc_mcp.Keeper_agent_run.adaptive_thinking_budget
+      ~enabled:true
+      ~is_retry:false
+      ~last_tool_results:[]
+      ~user_message:"plan this"
+      ~dynamic_context:""
+      ~current_budget:(Some 4096)
+      ~intent:(Some Masc_mcp.Keeper_turn_intent.Cognitive)
+  in
+  check (option int) "cognitive intent preserves cascade seed" (Some 4096) result
+;;
+
+let test_adaptive_thinking_cognitive_no_seed () =
+  let result =
+    Masc_mcp.Keeper_agent_run.adaptive_thinking_budget
+      ~enabled:true
+      ~is_retry:false
+      ~last_tool_results:[]
+      ~user_message:"plan this"
+      ~dynamic_context:""
+      ~current_budget:None
+      ~intent:(Some Masc_mcp.Keeper_turn_intent.Cognitive)
+  in
+  check (option int) "cognitive intent with no seed stays off" None result
 ;;
 
 let () =
@@ -71,6 +118,9 @@ let () =
     ; "error_or_retry", `Quick, test_adaptive_thinking_error_or_retry
     ; "complex_task", `Quick, test_adaptive_thinking_complex_task
     ; "fallback", `Quick, test_adaptive_thinking_fallback
+    ; "mechanical", `Quick, test_adaptive_thinking_mechanical
+    ; "cognitive", `Quick, test_adaptive_thinking_cognitive
+    ; "cognitive_no_seed", `Quick, test_adaptive_thinking_cognitive_no_seed
     ]
   in
   Alcotest.run "Keeper_adaptive_thinking" [ "budget_logic", tests ]


### PR DESCRIPTION
## Summary

Wire cascade config `thinking_enabled` / `thinking_budget` through to keeper adaptive logic and the OAS `before_turn_params` hook. This completes the end-to-end pipeline: cascade TOML config → keeper adaptive override → per-turn ephemeral OAS params.

## Changes

- **cascade_config_loader.ml/i**: Parse `thinking.enabled`, `thinking.budget` from TOML into `inference_params`
- **cascade_inference.ml/i**: Thread new fields through `for_cascade` / `for_json`
- **keeper_agent_prompt_metrics.ml/i**: Add `~intent` parameter; `Mechanical` → budget 0, `Cognitive` → preserve cascade seed
- **keeper_run_tools.ml**: Layer cascade seed + intent classification into adaptive override logic
- **test_keeper_adaptive_thinking.ml**: 7 tests covering disabled, error/retry, complex task, fallback, mechanical, cognitive paths
- Fix pre-existing `ProviderFailure` partial-match warnings in 5 files
- Fix `THooks.tool_schedule` record usage in `test_keeper_tool_emission_hook.ml`

## Test Plan

- [x] `dune build --root .` clean
- [x] `test_keeper_adaptive_thinking.exe` 7/7 pass
- [x] `test_keeper_turn_intent.exe` 8/8 pass
- [x] `test_keeper_prompt_metrics.exe` 9/9 pass
- [x] `test_keeper_tool_emission_hook.exe` 9/9 pass
- [ ] Integration smoke: keeper run with `MASC_KEEPER_ADAPTIVE_THINKING=1` + cascade `[thinking] budget=4096`

## Provider Behavior

| Provider | `thinking_budget` interpretation |
|----------|----------------------------------|
| Anthropic | Direct token count (`budget_tokens`) |
| DeepSeek v4 | Mapped to `reasoning_effort` via `effort_of_thinking_config` |
| Ollama | Mapped to `reasoning_effort` |
| GLM | `thinking` object |

MASC-MCP passes the integer value; provider-specific mapping happens in OAS `api_*.ml`.