### PR TITLE
refactor(memory): type failed-turn error kinds

### DIFF
--- a/lib/keeper/keeper_agent_memory_episode.ml
+++ b/lib/keeper/keeper_agent_memory_episode.ml
@@ -78,7 +78,9 @@ let record_success
       response failed contract parse — semantically a parse-degraded
       output, not a timeout or hard failure streak). *)
 let stress_kind_of_error_kind error_kind : Agent_stress.stress_kind option =
-  let trimmed = String.trim error_kind in
+  let trimmed =
+    String.trim (Memory_oas_bridge.error_kind_to_string error_kind)
+  in
   let ends_with suffix s =
     let ls = String.length s in
     let lp = String.length suffix in
@@ -111,7 +113,7 @@ let record_failure
     ~(memory : Oas.Memory.t)
     ~(turn : int)
     ~(trace_id : string)
-    ~(error_kind : string)
+    ~(error_kind : Memory_oas_bridge.error_kind)
     ~(error_message : string)
     () : unit =
   try

--- a/lib/keeper/keeper_agent_memory_episode.mli
+++ b/lib/keeper/keeper_agent_memory_episode.mli
@@ -32,7 +32,8 @@ val record_success :
 (** Classify [error_kind] into the matching {!Agent_stress.stress_kind}.
     Returns [None] for kinds that do not map to a pre-existing stress
     dimension. *)
-val stress_kind_of_error_kind : string -> Agent_stress.stress_kind option
+val stress_kind_of_error_kind :
+  Memory_oas_bridge.error_kind -> Agent_stress.stress_kind option
 
 (** Persist a failed-turn episode and surface the failure to
     [Agent_stress] for non-keepalive failure modes. Logs and swallows
@@ -43,7 +44,7 @@ val record_failure :
   memory:Oas.Memory.t ->
   turn:int ->
   trace_id:string ->
-  error_kind:string ->
+  error_kind:Memory_oas_bridge.error_kind ->
   error_message:string ->
   unit ->
   unit

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1185,7 +1185,8 @@ let run_turn
          ~memory
          ~turn
          ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-         ~error_kind:(sdk_error_kind err)
+         ~error_kind:
+           (Memory_oas_bridge.error_kind_of_string (sdk_error_kind err))
          ~error_message:(Oas.Error.to_string err)
          ())
     ;

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -468,12 +468,22 @@ let store_episode_from_snapshot
 
 (** #10341 (#10350): emit Agent_stress Timeout event for timeout-shaped
     error_kind from institution failure path. *)
+type error_kind = Error_kind of string
+
+let error_kind_of_string value = Error_kind value
+let error_kind_to_string (Error_kind value) = value
+
 let timeout_error_kinds =
-  [ "oas_timeout_budget"; "turn_timeout"; "admission_queue_timeout" ]
+  List.map error_kind_of_string
+    [ "oas_timeout_budget"; "turn_timeout"; "admission_queue_timeout" ]
 
 let stress_kind_for_error_kind error_kind =
-  let trimmed = String.trim error_kind in
-  if List.exists (String.equal trimmed) timeout_error_kinds then
+  let trimmed = String.trim (error_kind_to_string error_kind) in
+  if
+    List.exists
+      (fun kind -> String.equal trimmed (error_kind_to_string kind))
+      timeout_error_kinds
+  then
     Some Agent_stress.Timeout
   else None
 
@@ -507,7 +517,7 @@ let () =
     ()
 
 let normalize_error_kind kind =
-  let trimmed = String.trim kind in
+  let trimmed = String.trim (error_kind_to_string kind) in
   if trimmed = "" then "unspecified" else trimmed
 
 let failure_learnings ~error_kind ~error_preview =
@@ -528,7 +538,7 @@ let store_failed_turn_episode
     ~(keeper_name : string)
     ~(turn : int)
     ~(trace_id : string)
-    ~(error_kind : string)
+    ~(error_kind : error_kind)
     ~(error_message : string)
     () : unit =
   let error_preview =
@@ -539,8 +549,9 @@ let store_failed_turn_episode
     String_util.utf8_safe ~max_bytes:4099 ~suffix:"..." error_message
     |> String_util.to_string
   in
+  let error_kind_label = error_kind_to_string error_kind in
   let summary =
-    Printf.sprintf "keeper turn %d failed (%s): %s" turn error_kind
+    Printf.sprintf "keeper turn %d failed (%s): %s" turn error_kind_label
       error_preview
   in
   Prometheus.inc_counter institution_episode_failure_kind_metric
@@ -583,7 +594,7 @@ let store_failed_turn_episode
               [
                 ("trace_id", `String trace_id);
                 ("turn", `String (string_of_int turn));
-                ("error_kind", `String error_kind);
+                ("error_kind", `String error_kind_label);
                 ("error_message", `String error_context);
               ] );
         ];

--- a/lib/memory_oas_bridge.mli
+++ b/lib/memory_oas_bridge.mli
@@ -70,12 +70,19 @@ val store_episode_from_snapshot :
     [keeper_name] / [turn] / [trace_id] metadata, and
     writes via [Oas.Memory.store_episode]. *)
 
+(** Typed wrapper for failed-turn error-kind labels. JSON/status/metric
+    surfaces continue to render the stable string label. *)
+type error_kind = private Error_kind of string
+
+val error_kind_of_string : string -> error_kind
+val error_kind_to_string : error_kind -> string
+
 val store_failed_turn_episode :
   memory:Oas.Memory.t ->
   keeper_name:string ->
   turn:int ->
   trace_id:string ->
-  error_kind:string ->
+  error_kind:error_kind ->
   error_message:string ->
   unit ->
   unit
@@ -90,7 +97,7 @@ val store_failed_turn_episode :
 (** {1 Failure-learning helpers} *)
 
 val failure_learnings :
-  error_kind:string -> error_preview:string -> string list
+  error_kind:error_kind -> error_preview:string -> string list
 (** Builds the canonical [learnings] list for a failed
     episode: [["failure_kind: <normalised>"]] plus, when
     non-empty, ["error_preview: <preview>"].
@@ -194,16 +201,16 @@ val institution_episode_failure_kind_metric : string
     [test/test_institution_episodes_failure_learnings_10325.ml]
     asserts the wire string for telemetry compatibility. *)
 
-val timeout_error_kinds : string list
-(** SSOT list of error-kind strings the
+val timeout_error_kinds : error_kind list
+(** SSOT list of typed error-kind labels the
     {!stress_kind_for_error_kind} mapper treats as
     timeout-class.  Pinned because
     [test/test_agent_stress_timeout_wire_10341.ml] asserts
     its length to keep the catalogue from drifting. *)
 
 val stress_kind_for_error_kind :
-  string -> Agent_stress.stress_kind option
-(** Maps an error kind string onto an
+  error_kind -> Agent_stress.stress_kind option
+(** Maps an error kind label onto an
     {!Agent_stress.kind} when the kind belongs to the
     timeout family ([timeout_error_kinds] internal list).
     Returns [None] for non-timeout errors so the caller

--- a/test/test_agent_stress_emit_10341.ml
+++ b/test/test_agent_stress_emit_10341.ml
@@ -46,7 +46,9 @@ let opt_kind = testable
        | Some x, Some y -> kind_eq x y
        | _ -> false)
 
-let classify = Keeper_agent_memory_episode.stress_kind_of_error_kind
+let classify value =
+  Keeper_agent_memory_episode.stress_kind_of_error_kind
+    (Memory_oas_bridge.error_kind_of_string value)
 
 let test_oas_timeout_budget_to_timeout () =
   check opt_kind "oas_timeout_budget -> Timeout"

--- a/test/test_agent_stress_timeout_wire_10341.ml
+++ b/test/test_agent_stress_timeout_wire_10341.ml
@@ -20,27 +20,30 @@ open Alcotest
 
 module B = Masc_mcp.Memory_oas_bridge
 
+let kind value = B.error_kind_of_string value
+let kind_to_string = B.error_kind_to_string
+
 (* --- timeout kinds map to [Some Timeout] ------------------------ *)
 
 let test_oas_timeout_budget_maps () =
-  match B.stress_kind_for_error_kind "oas_timeout_budget" with
+  match B.stress_kind_for_error_kind (kind "oas_timeout_budget") with
   | Some Masc_mcp.Agent_stress.Timeout -> ()
   | _ -> failf "oas_timeout_budget should map to Timeout"
 
 let test_turn_timeout_maps () =
-  match B.stress_kind_for_error_kind "turn_timeout" with
+  match B.stress_kind_for_error_kind (kind "turn_timeout") with
   | Some Masc_mcp.Agent_stress.Timeout -> ()
   | _ -> failf "turn_timeout should map to Timeout"
 
 let test_admission_queue_timeout_maps () =
-  match B.stress_kind_for_error_kind "admission_queue_timeout" with
+  match B.stress_kind_for_error_kind (kind "admission_queue_timeout") with
   | Some Masc_mcp.Agent_stress.Timeout -> ()
   | _ -> failf "admission_queue_timeout should map to Timeout"
 
 (* --- whitespace tolerance --------------------------------------- *)
 
 let test_trims_whitespace () =
-  match B.stress_kind_for_error_kind "  oas_timeout_budget  " with
+  match B.stress_kind_for_error_kind (kind "  oas_timeout_budget  ") with
   | Some Masc_mcp.Agent_stress.Timeout -> ()
   | _ -> failf "trimmed timeout kind should still map to Timeout"
 
@@ -55,42 +58,42 @@ let test_cascade_exhausted_does_not_map () =
   check (option string)
     "cascade_exhausted intentionally unmapped"
     None
-    (B.stress_kind_for_error_kind "cascade_exhausted"
+    (B.stress_kind_for_error_kind (kind "cascade_exhausted")
      |> Option.map (fun _ -> "mapped"))
 
 let test_resumable_cli_session_does_not_map () =
   check (option string)
     "resumable_cli_session intentionally unmapped"
     None
-    (B.stress_kind_for_error_kind "resumable_cli_session"
+    (B.stress_kind_for_error_kind (kind "resumable_cli_session")
      |> Option.map (fun _ -> "mapped"))
 
 let test_accept_rejected_does_not_map () =
   check (option string)
     "accept_rejected intentionally unmapped"
     None
-    (B.stress_kind_for_error_kind "accept_rejected"
+    (B.stress_kind_for_error_kind (kind "accept_rejected")
      |> Option.map (fun _ -> "mapped"))
 
 let test_no_tool_capable_provider_does_not_map () =
   check (option string)
     "no_tool_capable_provider intentionally unmapped"
     None
-    (B.stress_kind_for_error_kind "no_tool_capable_provider"
+    (B.stress_kind_for_error_kind (kind "no_tool_capable_provider")
      |> Option.map (fun _ -> "mapped"))
 
 let test_unknown_kind_does_not_map () =
   check (option string)
     "unknown free-form kind unmapped"
     None
-    (B.stress_kind_for_error_kind "totally-novel-error-kind-10341"
+    (B.stress_kind_for_error_kind (kind "totally-novel-error-kind-10341")
      |> Option.map (fun _ -> "mapped"))
 
 let test_empty_kind_does_not_map () =
   check (option string)
     "empty kind unmapped (no spurious emit)"
     None
-    (B.stress_kind_for_error_kind ""
+    (B.stress_kind_for_error_kind (kind "")
      |> Option.map (fun _ -> "mapped"))
 
 (* --- timeout_error_kinds list contract -------------------------- *)
@@ -108,7 +111,7 @@ let test_timeout_kinds_list_is_three_items () =
       "turn_timeout";
       "admission_queue_timeout";
     ]
-    B.timeout_error_kinds
+    (List.map kind_to_string B.timeout_error_kinds)
 
 let () =
   run "agent_stress_timeout_wire_10341"

--- a/test/test_failure_learnings_10325.ml
+++ b/test/test_failure_learnings_10325.ml
@@ -6,9 +6,9 @@
     placeholder ("persist failed keeper turns ...").  This defeated the
     institution-memory contract that downstream readers (governance
     judge, anti-rationalization, future keeper turns) consume.  After
-    the fix, [learnings] carries [error_kind:X] and
-    [error_message:Y] tags, or the explicit [NO_LEARNING] sentinel
-    when neither has signal. *)
+    the current contract, [learnings] carries [failure_kind: X] and
+    [error_preview: Y] entries. Blank kinds normalize to the explicit
+    [unspecified] sentinel so rows stay queryable. *)
 
 open Alcotest
 open Masc_mcp
@@ -35,7 +35,9 @@ let extract_failure_learnings ~error_kind ~error_message =
       let memory = Memory_oas_bridge.create_memory ~agent_name:"test" ~base_dir:base () in
       Memory_oas_bridge.store_failed_turn_episode
         ~memory ~keeper_name:"test-keeper" ~turn:1
-        ~trace_id:"trace-1" ~error_kind ~error_message ();
+        ~trace_id:"trace-1"
+        ~error_kind:(Memory_oas_bridge.error_kind_of_string error_kind)
+        ~error_message ();
       let episodes = Oas.Memory.recall_episodes memory ~limit:10 () in
       match episodes with
       | [] -> failwith "no episode persisted"
@@ -70,25 +72,23 @@ let test_kind_and_message_emitted_as_tags () =
   in
   let has_kind =
     List.exists
-      (fun s -> s = "error_kind:oas_timeout_budget")
+      (fun s -> s = "failure_kind: oas_timeout_budget")
       learnings
   in
   let has_message_tag =
     List.exists
-      (fun s ->
-         String.length s > 14
-         && String.equal (String.sub s 0 14) "error_message:")
+      (fun s -> String.starts_with ~prefix:"error_preview:" s)
       learnings
   in
-  check bool "error_kind tag emitted" true has_kind;
-  check bool "error_message tag emitted" true has_message_tag
+  check bool "failure_kind entry emitted" true has_kind;
+  check bool "error_preview entry emitted" true has_message_tag
 
-let test_no_learning_sentinel_when_both_blank () =
+let test_unspecified_kind_when_both_blank () =
   let learnings =
     extract_failure_learnings ~error_kind:"" ~error_message:""
   in
-  check (list string) "explicit absence sentinel"
-    [ "[NO_LEARNING]" ] learnings
+  check (list string) "explicit unspecified sentinel"
+    [ "failure_kind: unspecified" ] learnings
 
 let test_only_kind_when_message_blank () =
   let learnings =
@@ -96,7 +96,7 @@ let test_only_kind_when_message_blank () =
       ~error_kind:"resumable_cli_session" ~error_message:""
   in
   check (list string) "only kind tag emitted"
-    [ "error_kind:resumable_cli_session" ] learnings
+    [ "failure_kind: resumable_cli_session" ] learnings
 
 let () =
   run "failure_learnings_10325"
@@ -106,8 +106,8 @@ let () =
              test_no_generic_boilerplate;
            test_case "kind and message become tag entries" `Quick
              test_kind_and_message_emitted_as_tags;
-           test_case "[NO_LEARNING] sentinel when both blank" `Quick
-             test_no_learning_sentinel_when_both_blank;
+           test_case "unspecified sentinel when both blank" `Quick
+             test_unspecified_kind_when_both_blank;
            test_case "only error_kind when message blank" `Quick
              test_only_kind_when_message_blank;
          ]);

--- a/test/test_institution_episodes_failure_learnings_10325.ml
+++ b/test/test_institution_episodes_failure_learnings_10325.ml
@@ -37,11 +37,13 @@ open Alcotest
 module M = Masc_mcp.Memory_oas_bridge
 module Prom = Masc_mcp.Prometheus
 
+let kind value = M.error_kind_of_string value
+
 (* --- learnings shape -------------------------------------------- *)
 
 let test_learnings_carries_error_kind_first () =
   let learnings =
-    M.failure_learnings ~error_kind:"oas_timeout_budget"
+    M.failure_learnings ~error_kind:(kind "oas_timeout_budget")
       ~error_preview:"Adaptive estimated input tokens exceeded budget"
   in
   check (list string)
@@ -54,7 +56,7 @@ let test_learnings_carries_error_kind_first () =
 
 let test_learnings_omits_empty_preview () =
   let learnings =
-    M.failure_learnings ~error_kind:"resumable_cli_session"
+    M.failure_learnings ~error_kind:(kind "resumable_cli_session")
       ~error_preview:""
   in
   check (list string)
@@ -62,7 +64,7 @@ let test_learnings_omits_empty_preview () =
     [ "failure_kind: resumable_cli_session" ]
     learnings;
   let learnings_ws =
-    M.failure_learnings ~error_kind:"resumable_cli_session"
+    M.failure_learnings ~error_kind:(kind "resumable_cli_session")
       ~error_preview:"   \n  "
   in
   check (list string)
@@ -74,7 +76,7 @@ let test_learnings_omits_empty_preview () =
 
 let test_empty_error_kind_normalises_to_unspecified () =
   let learnings =
-    M.failure_learnings ~error_kind:"" ~error_preview:"some preview"
+    M.failure_learnings ~error_kind:(kind "") ~error_preview:"some preview"
   in
   check (list string)
     "empty error_kind becomes unspecified sentinel"
@@ -86,7 +88,7 @@ let test_empty_error_kind_normalises_to_unspecified () =
 
 let test_whitespace_error_kind_normalises_to_unspecified () =
   let learnings =
-    M.failure_learnings ~error_kind:"  \t " ~error_preview:""
+    M.failure_learnings ~error_kind:(kind "  \t ") ~error_preview:""
   in
   check (list string)
     "whitespace-only error_kind becomes unspecified"

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -489,7 +489,7 @@ let test_failed_turn_episode_flushes_failure_outcome () =
         ~keeper_name:"test-failed-turn"
         ~turn:7
         ~trace_id:"trace-failed-turn"
-        ~error_kind:"provider_timeout"
+        ~error_kind:(Memory_oas_bridge.error_kind_of_string "provider_timeout")
         ~error_message:"provider timed out before producing a tool-using turn"
         ();
       let flushed =


### PR DESCRIPTION
Refs #11926

## Summary
- add a private `Memory_oas_bridge.error_kind` wrapper plus explicit string conversion helpers
- require typed error kinds at failed-turn episode, failure-learning, and timeout stress-classifier boundaries
- convert keeper SDK error strings at the keeper run ingress while preserving JSON and metric wire labels

## Validation
- `scripts/dune-local.sh build lib/memory_oas_bridge.ml lib/memory_oas_bridge.mli lib/keeper/keeper_agent_memory_episode.ml lib/keeper/keeper_agent_memory_episode.mli lib/keeper/keeper_agent_run.ml test/test_agent_stress_timeout_wire_10341.exe test/test_institution_episodes_failure_learnings_10325.exe test/test_agent_stress_emit_10341.exe test/test_memory_oas_5tier.exe test/test_failure_learnings_10325.exe`
- `./_build/default/test/test_failure_learnings_10325.exe`
- `./_build/default/test/test_agent_stress_timeout_wire_10341.exe`
- `./_build/default/test/test_institution_episodes_failure_learnings_10325.exe`
- `./_build/default/test/test_agent_stress_emit_10341.exe`
- `./_build/default/test/test_memory_oas_5tier.exe`
- `git diff --check HEAD~1 HEAD`
- targeted `rg` for `error_kind:string` signatures returned no hits