### PR TITLE
Fix tool dispatch static typed routing

### DIFF
--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -1,9 +1,8 @@
-(** Central Tool Dispatch Registry — O(1) Hashtbl-based dispatch.
+(** Central Tool Dispatch Registry.
 
-    Replaces the 40+ sequential match chain in mcp_server_eio.ml with
-    a single Hashtbl lookup.  Each Tool_X module registers a closure
-    that captures its own context, so the dispatch layer does not need
-    to know about heterogeneous context types.
+    Production MCP tool names route through {!Tool_name} and an exhaustive
+    module-tag match. Mutable registries remain for direct-handler
+    compatibility, schemas, and test/dynamic tools.
 
     Activated by MASC_DISPATCH_V2=1; the legacy match chain is the
     default fallback. *)
@@ -183,12 +182,10 @@ let is_mcp_context_required name =
 let is_destructive name = with_dispatch_ro (fun () -> Hashtbl.mem destructive_set name)
 let is_idempotent name = with_dispatch_ro (fun () -> Hashtbl.mem idempotent_set name)
 
-(** {2 Module Tag Dispatch — O(1) two-level dispatch}
+(** {2 Module Tag Dispatch}
 
-    Maps tool names to module tags at startup (once).
-    At call time, O(1) tag lookup determines which module's context
-    to create lazily. Eliminates per-call 40+ context creation and
-    ~210 Hashtbl.replace ops. *)
+    Known tool names map to module tags through a compile-time match.
+    Runtime registrations remain as a fallback for test/dynamic tools. *)
 
 type module_tag =
   | Mod_plan | Mod_operator
@@ -204,6 +201,105 @@ type module_tag =
   | Mod_inline
   | Mod_autoresearch
   | Mod_shard
+
+let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
+  match tool with
+  | Tool_name.Keeper _ -> Some Mod_shard
+  | Tool_name.Masc_keeper _ -> Some Mod_keeper
+  | Tool_name.Masc m ->
+    let open Tool_name.Masc in
+    match m with
+    | A2a_delegate
+    | Cancel_task
+    | Complete_task
+    | Dispatch_plan
+    | List_tasks
+    | Operation_pause
+    | Operation_start
+    | Operation_status
+    | Operation_stop
+    | Release_task
+    | Set_current_task -> None
+    | Add_task
+    | Batch_add_tasks
+    | Claim_next
+    | Claim_task
+    | Task_history
+    | Tasks
+    | Transition
+    | Update_priority -> Some Mod_task
+    | Agent_card
+    | Agent_fitness
+    | Agent_update
+    | Agents
+    | Collaboration_graph
+    | Get_metrics
+    | Register_capabilities -> Some Mod_agent
+    | Autoresearch_cycle
+    | Autoresearch_inject
+    | Autoresearch_record_finding
+    | Autoresearch_search_findings
+    | Autoresearch_start
+    | Autoresearch_status
+    | Autoresearch_stop -> Some Mod_autoresearch
+    | Board_cleanup
+    | Board_comment
+    | Board_comment_vote
+    | Board_delete
+    | Board_get
+    | Board_hearths
+    | Board_list
+    | Board_post
+    | Board_profile
+    | Board_search
+    | Board_stats
+    | Board_vote
+    | Approval_get
+    | Broadcast
+    | Join
+    | Leave
+    | Mcp_session
+    | Messages
+    | Spawn
+    | Start
+    | Who -> Some Mod_inline
+    | Check
+    | Coord_status
+    | Coordination_fsm_snapshot
+    | Goal_list
+    | Goal_review
+    | Goal_transition
+    | Goal_upsert
+    | Goal_verify
+    | Heartbeat
+    | Reset
+    | Status
+    | Workflow_guide -> Some Mod_room
+    | Code_read | Code_search | Code_symbols -> Some Mod_code
+    | Code_delete | Code_edit | Code_git | Code_shell | Code_write -> Some Mod_code_write
+    | Config
+    | Cleanup_zombies
+    | Dashboard
+    | Gc
+    | Tool_admin_snapshot
+    | Tool_admin_update
+    | Tool_help
+    | Tool_stats
+    | Web_search
+    | Webrtc_answer
+    | Webrtc_offer -> Some Mod_misc
+    | Deliver
+    | Note_add
+    | Plan_clear_task
+    | Plan_get
+    | Plan_get_task
+    | Plan_init
+    | Plan_set_task
+    | Plan_update -> Some Mod_plan
+    | Operator_action | Operator_confirm | Operator_digest | Operator_snapshot -> Some Mod_operator
+    | Pause | Resume -> Some Mod_control
+    | Tool_grant | Tool_list | Tool_revoke -> Some Mod_shard
+    | Worktree_create | Worktree_list | Worktree_remove -> Some Mod_worktree
 
 let tag_registry : (string, module_tag) Hashtbl.t = Hashtbl.create 512
 let tag_registry_initialized = Atomic.make false
@@ -224,7 +320,11 @@ let register_module_tag ~(schemas : Types.tool_schema list) ~tag =
 let register_name_tag ~tool_name ~tag =
   with_dispatch_rw (fun () -> Hashtbl.replace tag_registry tool_name tag)
 
-let lookup_tag name = with_dispatch_ro (fun () -> Hashtbl.find_opt tag_registry name)
+let lookup_tag name =
+  match Tool_name.of_string name with
+  | Some tool -> static_tag_of_tool_name tool
+  | None -> with_dispatch_ro (fun () -> Hashtbl.find_opt tag_registry name)
+
 let lookup_schema name = with_dispatch_ro (fun () -> Hashtbl.find_opt schema_registry name)
 
 let tag_registry_count () = with_dispatch_ro (fun () -> Hashtbl.length tag_registry)
@@ -232,15 +332,18 @@ let tag_registry_count () = with_dispatch_ro (fun () -> Hashtbl.length tag_regis
 let mark_tag_registry_initialized () = with_dispatch_rw (fun () -> Atomic.set tag_registry_initialized true)
 let is_tag_registry_initialized () = with_dispatch_ro (fun () -> Atomic.get tag_registry_initialized)
 
-(** Mint a [Tool_token.t] validated against both registries.
+(** Mint a [Tool_token.t] validated against static routes or registries.
     Protected by dispatch_mu for thread safety (Copilot review).
-    Checks tag_registry (primary) then handler registry (fallback).
+    Checks known typed tool names first, then the runtime tag/handler registries.
     In production both are populated at startup; in test binaries
     only the handler registry may be populated. *)
 let mint_token ~name =
   with_dispatch_ro (fun () ->
     Tool_token.mint_with
-      ~validate:(fun n -> Hashtbl.mem tag_registry n || Hashtbl.mem registry n)
+      ~validate:(fun n ->
+        match Tool_name.of_string n with
+        | Some tool -> Option.is_some (static_tag_of_tool_name tool)
+        | None -> Hashtbl.mem tag_registry n || Hashtbl.mem registry n)
       ~name)
 
 (** Enumerate every tool name registered in either the tag_registry (primary)

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -1,9 +1,8 @@
-(** Central Tool Dispatch Registry - O(1) Hashtbl-based dispatch.
+(** Central Tool Dispatch Registry.
 
-    Replaces the 40+ sequential match chain in mcp_server_eio.ml with
-    a single Hashtbl lookup. Each Tool_X module registers a closure
-    that captures its own context, so the dispatch layer does not need
-    to know about heterogeneous context types. *)
+    Production MCP tool names route through {!Tool_name} and an exhaustive
+    module-tag match. Mutable registries remain for direct-handler
+    compatibility, schemas, and test/dynamic tools. *)
 
 (** Unified handler type: every tool call is [name * args -> tool_result option].
     [None] means "this handler does not know this tool". *)
@@ -99,11 +98,10 @@ val is_mcp_context_required : string -> bool
 val is_destructive : string -> bool
 val is_idempotent : string -> bool
 
-(** {2 Module Tag Dispatch - O(1) two-level dispatch}
+(** {2 Module Tag Dispatch}
 
-    Maps tool names to module tags at startup (once).
-    At call time, O(1) tag lookup determines which module's context
-    to create lazily. *)
+    Known tool names map to module tags through a compile-time match.
+    Runtime registrations remain as a fallback for test/dynamic tools. *)
 
 type module_tag =
   | Mod_plan | Mod_operator

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -95,6 +95,30 @@ let () =
               check bool "count >= 5" true
                 (Tool_dispatch.registered_count () >= 5));
         ] );
+      ( "static_tag_routing",
+        [
+          test_case "known MCP names route through static tags" `Quick (fun () ->
+              check bool "masc_board_delete -> Mod_inline" true
+                (Tool_dispatch.lookup_tag "masc_board_delete"
+                 = Some Tool_dispatch.Mod_inline);
+              check bool "masc_status -> Mod_room" true
+                (Tool_dispatch.lookup_tag "masc_status"
+                 = Some Tool_dispatch.Mod_room);
+              check bool "keeper_bash -> Mod_shard" true
+                (Tool_dispatch.lookup_tag "keeper_bash"
+                 = Some Tool_dispatch.Mod_shard));
+          test_case "mint_token accepts active static tool names" `Quick (fun () ->
+              check bool "masc_status mints" true
+                (Result.is_ok
+                   (Tool_dispatch.mint_token ~name:"masc_status")));
+          test_case "retired typed names do not mint by type alone" `Quick (fun () ->
+              check bool "complete_task has no static route" true
+                (Option.is_none
+                   (Tool_dispatch.lookup_tag "masc_complete_task"));
+              check bool "complete_task mint fails" true
+                (Result.is_error
+                   (Tool_dispatch.mint_token ~name:"masc_complete_task")));
+        ] );
       ( "read_only_set",
         [
           test_case "init and query read_only" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- route known MCP tool names through `Tool_name.of_string` and an exhaustive module-tag match
- keep runtime tag registry as fallback for test/dynamic tools and schemas
- allow tokens for active static typed tools without relying on mutable registration
- add regression coverage for static tag routing and retired typed names

## Issue
- Part of #11926 C-T7.4: replace dict/registry-only tool dispatch routing with typed match routing.

## Validation
- git diff --check origin/main...HEAD
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_tool_dispatch.exe
- ./_build/default/test/test_tool_dispatch.exe