### PR TITLE
refactor(cascade): type health error kinds

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -256,6 +256,11 @@ type t = {
   mu: Stdlib.Mutex.t;
 }
 
+type error_kind = Error_kind of string
+
+let error_kind_of_string value = Error_kind value
+let error_kind_to_string (Error_kind value) = value
+
 (* ── Constructor ──────────────────────────────── *)
 
 let create () : t = {
@@ -337,7 +342,9 @@ let push_latency state lat_ms =
 let make_fingerprint ?error_kind ?error_reason () =
   let kind =
     match error_kind with
-    | Some k when String.trim k <> "" -> String.trim k
+    | Some k ->
+      let trimmed = String.trim (error_kind_to_string k) in
+      if trimmed = "" then "unclassified" else trimmed
     | _ -> "unclassified"
   in
   match error_reason with

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -81,6 +81,13 @@ val latency_ring_size : int
 (** Opaque health tracker state. *)
 type t
 
+(** Typed wrapper for provider-health error classifications. Dashboard
+    fingerprints and summaries continue to render the stable string label. *)
+type error_kind = private Error_kind of string
+
+val error_kind_of_string : string -> error_kind
+val error_kind_to_string : error_kind -> string
+
 (** Create a new empty tracker. *)
 val create : unit -> t
 
@@ -115,7 +122,7 @@ val record_success :
 val record_failure :
   t ->
   provider_key:string ->
-  ?error_kind:string ->
+  ?error_kind:error_kind ->
   ?error_reason:string ->
   unit ->
   unit
@@ -140,7 +147,7 @@ val record_failure :
 val record_rejected :
   t ->
   provider_key:string ->
-  ?error_kind:string ->
+  ?error_kind:error_kind ->
   ?error_reason:string ->
   unit ->
   unit
@@ -165,7 +172,7 @@ val record_rejected :
 val record_hard_quota :
   t ->
   provider_key:string ->
-  ?error_kind:string ->
+  ?error_kind:error_kind ->
   ?error_reason:string ->
   unit ->
   unit
@@ -181,7 +188,7 @@ val record_hard_quota :
 val record_terminal_failure :
   t ->
   provider_key:string ->
-  ?error_kind:string ->
+  ?error_kind:error_kind ->
   ?error_reason:string ->
   unit ->
   unit
@@ -210,7 +217,7 @@ val record_soft_rate_limited :
   t ->
   provider_key:string ->
   ?retry_after_s:float ->
-  ?error_kind:string ->
+  ?error_kind:error_kind ->
   ?error_reason:string ->
   unit ->
   unit

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -470,7 +470,7 @@ let run_named
            distinguish it from hard errors. *)
         Cascade_health_tracker.(
           record_rejected global ~provider_key:provider_cfg.model_id
-            ~error_kind:"accept_rejected" ());
+            ~error_kind:(error_kind_of_string "accept_rejected") ());
         (* FSM: Accept_rejected → decide *)
         let reason = Printf.sprintf "response rejected by accept (model=%s)" result.response.model in
         let outcome = Cascade_fsm.Accept_rejected
@@ -549,11 +549,13 @@ let run_named
         if sdk_error_is_hard_quota sdk_err then
           Cascade_health_tracker.(
             record_hard_quota global ~provider_key:provider_cfg.model_id
-              ~error_kind:"hard_quota" ~error_reason:err_str ())
+              ~error_kind:(error_kind_of_string "hard_quota")
+              ~error_reason:err_str ())
         else if sdk_error_is_resumable_cli_session sdk_err then
           Cascade_health_tracker.(
             record_terminal_failure global ~provider_key:provider_cfg.model_id
-              ~error_kind:"resumable_cli_session" ~error_reason:err_str ())
+              ~error_kind:(error_kind_of_string "resumable_cli_session")
+              ~error_reason:err_str ())
         else (match sdk_error_soft_rate_limited sdk_err with
         | Some retry_after_opt ->
           (* Transient 429 (not a hard quota in disguise).  Trip an
@@ -567,7 +569,8 @@ let run_named
           Cascade_health_tracker.(
             record_soft_rate_limited global ~provider_key:provider_cfg.model_id
               ?retry_after_s:retry_after_opt
-              ~error_kind:"http_429" ~error_reason:err_str ())
+              ~error_kind:(error_kind_of_string "http_429")
+              ~error_reason:err_str ())
         | None -> (
           (* Classify the err_str into named buckets so Cascade_health_tracker
              fingerprint groups separate codex internal-state corruption
@@ -604,7 +607,8 @@ let run_named
           in
           Cascade_health_tracker.(
             record_failure global ~provider_key:provider_cfg.model_id
-              ~error_kind ~error_reason:err_str ())));
+              ~error_kind:(error_kind_of_string error_kind)
+              ~error_reason:err_str ())));
         (* FSM: Call_err → decide.
            Hard-quota fast-path: a hard quota is permanent for this turn —
            every remaining tier in this cascade (and any cross-cascade

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -7,6 +7,8 @@
 open Alcotest
 module H = Masc_mcp.Cascade_health_tracker
 
+let kind value = H.error_kind_of_string value
+
 let test_record_success_keeps_rate_1 () =
   let t = H.create () in
   H.record_success t ~provider_key:"p" ();
@@ -218,11 +220,11 @@ let info_or_fail t ~provider_key =
 let test_fingerprint_same_classification_accumulates () =
   let t = H.create () in
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"timeout" ~error_reason:"deadline exceeded" ();
+    ~error_kind:(kind "timeout") ~error_reason:"deadline exceeded" ();
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"timeout" ~error_reason:"deadline exceeded" ();
+    ~error_kind:(kind "timeout") ~error_reason:"deadline exceeded" ();
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"timeout" ~error_reason:"deadline exceeded" ();
+    ~error_kind:(kind "timeout") ~error_reason:"deadline exceeded" ();
   let info = info_or_fail t ~provider_key:"p" in
   check int "exactly one fingerprint bucket"
     1 (List.length info.top_fingerprints);
@@ -234,9 +236,9 @@ let test_fingerprint_same_classification_accumulates () =
 let test_fingerprint_distinct_reasons_split () =
   let t = H.create () in
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"failure" ~error_reason:"reason A" ();
+    ~error_kind:(kind "failure") ~error_reason:"reason A" ();
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"failure" ~error_reason:"reason B" ();
+    ~error_kind:(kind "failure") ~error_reason:"reason B" ();
   let info = info_or_fail t ~provider_key:"p" in
   check int "two distinct fingerprints"
     2 (List.length info.top_fingerprints)
@@ -246,7 +248,7 @@ let test_fingerprint_top_3_cap () =
   for i = 1 to 5 do
     let r = Printf.sprintf "reason %d" i in
     H.record_failure t ~provider_key:"p"
-      ~error_kind:"failure" ~error_reason:r ()
+      ~error_kind:(kind "failure") ~error_reason:r ()
   done;
   let info = info_or_fail t ~provider_key:"p" in
   check int "top_fingerprints capped at 3"
@@ -264,7 +266,7 @@ let test_fingerprint_unclassified_when_kind_missing () =
 
 let test_last_failure_at_set_on_failure () =
   let t = H.create () in
-  H.record_failure t ~provider_key:"p" ~error_kind:"failure" ();
+  H.record_failure t ~provider_key:"p" ~error_kind:(kind "failure") ();
   let info_after = info_or_fail t ~provider_key:"p" in
   check bool "last_failure_at populated after failure"
     true (info_after.last_failure_at <> None)
@@ -281,17 +283,17 @@ let test_fingerprint_top_sorted_descending () =
   let t = H.create () in
   (* low: 1, medium: 2, high: 3 *)
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"failure" ~error_reason:"low" ();
+    ~error_kind:(kind "failure") ~error_reason:"low" ();
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"failure" ~error_reason:"medium" ();
+    ~error_kind:(kind "failure") ~error_reason:"medium" ();
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"failure" ~error_reason:"medium" ();
+    ~error_kind:(kind "failure") ~error_reason:"medium" ();
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"failure" ~error_reason:"high" ();
+    ~error_kind:(kind "failure") ~error_reason:"high" ();
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"failure" ~error_reason:"high" ();
+    ~error_kind:(kind "failure") ~error_reason:"high" ();
   H.record_failure t ~provider_key:"p"
-    ~error_kind:"failure" ~error_reason:"high" ();
+    ~error_kind:(kind "failure") ~error_reason:"high" ();
   let info = info_or_fail t ~provider_key:"p" in
   match info.top_fingerprints with
   | (_, c1) :: (_, c2) :: (_, c3) :: _ ->
@@ -355,7 +357,7 @@ let test_terminal_failure_preserves_longer_existing_cooldown () =
 let test_terminal_failure_records_fingerprint () =
   let t = H.create () in
   H.record_terminal_failure t ~provider_key:"kimi-for-coding"
-    ~error_kind:"resumable_cli_session"
+    ~error_kind:(kind "resumable_cli_session")
     ~error_reason:"kimi exited with code 1: session conflict" ();
   let info = info_or_fail t ~provider_key:"kimi-for-coding" in
   match info.top_fingerprints with
@@ -472,7 +474,7 @@ let test_soft_rate_limit_does_not_shorten_hard_quota () =
 let test_soft_rate_limit_records_fingerprint () =
   let t = H.create () in
   H.record_soft_rate_limited t ~provider_key:"claude-cli"
-    ~error_kind:"http_429"
+    ~error_kind:(kind "http_429")
     ~error_reason:"rate limit exceeded for tier" ();
   let info = info_or_fail t ~provider_key:"claude-cli" in
   match info.top_fingerprints with

--- a/test/test_cascade_trust_persist.ml
+++ b/test/test_cascade_trust_persist.ml
@@ -14,6 +14,8 @@ open Alcotest
 module H = Masc_mcp.Cascade_health_tracker
 module P = Masc_mcp.Cascade_trust_persist
 
+let kind value = H.error_kind_of_string value
+
 let temp_base_path () =
   let dir = Filename.temp_file "cascade-trust-persist-" "" in
   Sys.remove dir;
@@ -102,7 +104,7 @@ let test_snapshot_includes_recorded_provider () =
   with_temp_base (fun dir ->
     let key = "test_persist_includes:" ^ string_of_int (Random.bits ()) in
     H.record_failure H.global ~provider_key:key
-      ~error_kind:"failure" ~error_reason:"boom" ();
+      ~error_kind:(kind "failure") ~error_reason:"boom" ();
     P.snapshot_now ~base_path:dir;
     match read_all_jsonl_in dir with
     | [] -> fail "no record"
@@ -122,7 +124,7 @@ let test_snapshot_provider_record_shape () =
   with_temp_base (fun dir ->
     let key = "test_persist_shape:" ^ string_of_int (Random.bits ()) in
     H.record_failure H.global ~provider_key:key
-      ~error_kind:"timeout" ~error_reason:"deadline" ();
+      ~error_kind:(kind "timeout") ~error_reason:"deadline" ();
     P.snapshot_now ~base_path:dir;
     match read_all_jsonl_in dir with
     | [] -> fail "no record"


### PR DESCRIPTION
Refs #11926

## Summary
- add a private `Cascade_health_tracker.error_kind` wrapper plus explicit string conversion helpers
- require typed provider-health error kinds for failure, rejection, hard-quota, terminal-failure, and soft-rate-limit recording
- convert cascade worker classifications at the provider-health boundary while preserving existing fingerprint and dashboard string labels

## Validation
- `scripts/dune-local.sh build lib/cascade/cascade_health_tracker.ml lib/cascade/cascade_health_tracker.mli lib/oas_worker_named.ml test/test_cascade_health_tracker.exe test/test_cascade_trust_persist.exe`
- `./_build/default/test/test_cascade_health_tracker.exe`
- `./_build/default/test/test_cascade_trust_persist.exe`
- `git diff --check HEAD~1 HEAD`
- targeted `rg` for cascade health `?error_kind:string` signatures returned no hits