### PR TITLE
feat(dashboard): KpiStrip Solid island, first caller migration (RFC 0017 PR #4)

### DIFF
--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -11,8 +11,7 @@ import { Card } from './common/card'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { SectionCap } from './common/section-cap'
-import { KpiCell } from './kpi-cell'
-import { KpiStrip } from './kpi-strip'
+import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
 
 type FeatureStatus = 'healthy' | 'warning' | 'inactive' | 'deprecated'
 type StatusFilter = FeatureStatus | 'all'
@@ -229,14 +228,18 @@ export function FeatureHealth() {
                   </div>
 
                   <div class="mt-4">
-                    <${KpiStrip} ariaLabel="기능 상태 요약" variant="standard">
-                      <${KpiCell} variant="stacked" label="총 기능" value=${overview.total_features} />
-                      <${KpiCell} variant="stacked" label="활성화" value=${overview.enabled_count} />
-                      <${KpiCell} variant="stacked" label="정상" value=${overview.healthy_count} kind="ok" />
-                      <${KpiCell} variant="stacked" label="실험적" value=${overview.warning_count} kind="warn" />
-                      <${KpiCell} variant="stacked" label="비활성" value=${overview.inactive_count} />
-                      <${KpiCell} variant="stacked" label="폐기 예정" value=${overview.deprecated_count} kind="err" />
-                    <//>
+                    <${KpiStripIsland}
+                      ariaLabel="기능 상태 요약"
+                      variant="standard"
+                      cells=${[
+                        { variant: 'stacked', label: '총 기능', value: overview.total_features },
+                        { variant: 'stacked', label: '활성화', value: overview.enabled_count },
+                        { variant: 'stacked', label: '정상', value: overview.healthy_count, kind: 'ok' },
+                        { variant: 'stacked', label: '실험적', value: overview.warning_count, kind: 'warn' },
+                        { variant: 'stacked', label: '비활성', value: overview.inactive_count },
+                        { variant: 'stacked', label: '폐기 예정', value: overview.deprecated_count, kind: 'err' },
+                      ] satisfies KpiStripIslandData['cells']}
+                    />
                   </div>
 
                   <div class="mt-4 text-xs text-[var(--color-fg-disabled)]">

--- a/dashboard/src/components/kpi-strip-island-solid.solid.tsx
+++ b/dashboard/src/components/kpi-strip-island-solid.solid.tsx
@@ -1,0 +1,47 @@
+/** @jsxImportSource solid-js */
+//
+// Solid renderer factory for the KpiStrip island. Pairs with
+// `kpi-strip-island.ts` (Preact wrapper) — the Preact side mounts a
+// host `<div>`, calls `createKpiStripIsland(initial)` to get a JSX
+// closure + state setter, then hands the closure to `solid-js/web`
+// `render` and feeds prop changes into the setter on every Preact
+// re-render.
+//
+// Why split into two files: a single .tsx with both Preact hooks and
+// Solid JSX would force one transformer (Preact or Solid) to claim
+// the file and silently mis-compile the other side. Physical file
+// boundary = transform boundary; the Solid plugin's include regex
+// captures `*.solid.tsx`, the rest stays on Preact.
+
+import { For, createSignal, type JSX, type Setter } from 'solid-js'
+import { KpiStrip, type KpiStripVariant } from './kpi-strip.solid'
+import { KpiCell, type KpiCellProps } from './kpi-cell.solid'
+
+export interface KpiStripIslandData {
+  ariaLabel: string
+  variant?: KpiStripVariant
+  cols?: number
+  cells: ReadonlyArray<KpiCellProps>
+}
+
+export interface KpiStripIslandHandle {
+  /** JSX closure to hand to `solid-js/web` `render`. */
+  jsx: () => JSX.Element
+  /** Replace the entire state object — Solid diffs internally and only
+   *  re-renders the cells whose props changed. */
+  setState: Setter<KpiStripIslandData>
+}
+
+export function createKpiStripIsland(initial: KpiStripIslandData): KpiStripIslandHandle {
+  const [state, setState] = createSignal<KpiStripIslandData>(initial)
+  const jsx = (): JSX.Element => (
+    <KpiStrip
+      ariaLabel={state().ariaLabel}
+      variant={state().variant}
+      cols={state().cols}
+    >
+      <For each={state().cells}>{(cell) => <KpiCell {...cell} />}</For>
+    </KpiStrip>
+  )
+  return { jsx, setState }
+}

--- a/dashboard/src/components/kpi-strip-island.solid.test.ts
+++ b/dashboard/src/components/kpi-strip-island.solid.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+//
+// Integration test for the Preact→Solid island bridge. Verifies:
+//   1. Initial mount produces the Solid subtree (role=list + cells).
+//   2. Re-rendering the Preact parent with new `cells` prop reaches
+//      the Solid signal and updates only changed cells (no re-mount).
+//   3. Unmounting the Preact parent disposes the Solid root cleanly.
+//
+// These three scenarios are the contract that PR #4 promises: a Preact
+// parent can keep its render cycle while a Solid child stays
+// reactive without any cross-framework bridge code at the call site.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
+
+describe('KpiStripIsland (Preact→Solid bridge)', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  // Preact's useEffect schedules at task tier (setTimeout-style), not
+  // microtask. The first test in a freshly-loaded happy-dom can hit
+  // additional cold-start latency before the Preact reconciler commits
+  // refs, so we flush twice with a short delay to be safe — once for
+  // Preact's commit + ref assignment, once more so the second useEffect
+  // (prop sync) gets a chance to run before assertions.
+  function flush(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 10))
+      .then(() => new Promise((resolve) => setTimeout(resolve, 10)))
+  }
+
+  it('mounts a Solid KpiStrip subtree inside the Preact host', async () => {
+    const cells: KpiStripIslandData['cells'] = [
+      { variant: 'stacked', label: 'A', value: 1 },
+      { variant: 'stacked', label: 'B', value: 2 },
+    ]
+    render(html`<${KpiStripIsland} ariaLabel="x" cells=${cells} />`, container)
+    await flush()
+    const strip = container.querySelector('[role="list"]') as HTMLElement
+    expect(strip).toBeTruthy()
+    expect(strip.getAttribute('aria-label')).toBe('x')
+    expect(container.querySelectorAll('[role="listitem"]').length).toBe(2)
+  })
+
+  it('forwards variant and cols to the Solid KpiStrip', async () => {
+    const cells: KpiStripIslandData['cells'] = [
+      { variant: 'stacked', label: 'A', value: 1 },
+    ]
+    render(
+      html`<${KpiStripIsland} ariaLabel="x" variant="stacked" cols=${5} cells=${cells} />`,
+      container,
+    )
+    await flush()
+    const strip = container.querySelector('[role="list"]') as HTMLElement
+    expect(strip.getAttribute('data-variant')).toBe('stacked')
+    expect(strip.getAttribute('data-cols')).toBe('5')
+  })
+
+  it('reactively updates cells when the Preact parent re-renders', async () => {
+    const initial: KpiStripIslandData['cells'] = [
+      { variant: 'stacked', label: 'A', value: 1 },
+      { variant: 'stacked', label: 'B', value: 2 },
+    ]
+    render(html`<${KpiStripIsland} ariaLabel="x" cells=${initial} />`, container)
+    await flush()
+    const stripBefore = container.querySelector('[role="list"]') as HTMLElement
+    expect(container.textContent).toContain('A')
+    expect(container.textContent).toContain('1')
+
+    const next: KpiStripIslandData['cells'] = [
+      { variant: 'stacked', label: 'A', value: 99 },
+      { variant: 'stacked', label: 'B', value: 2 },
+    ]
+    render(html`<${KpiStripIsland} ariaLabel="x" cells=${next} />`, container)
+    await flush()
+    const stripAfter = container.querySelector('[role="list"]') as HTMLElement
+    expect(container.textContent).toContain('99')
+    // Same Solid root → same DOM container reference (not re-mounted).
+    expect(stripAfter).toBe(stripBefore)
+  })
+
+  it('grows and shrinks the cells array', async () => {
+    const small: KpiStripIslandData['cells'] = [
+      { variant: 'stacked', label: 'A', value: 1 },
+    ]
+    render(html`<${KpiStripIsland} ariaLabel="x" cells=${small} />`, container)
+    await flush()
+    expect(container.querySelectorAll('[role="listitem"]').length).toBe(1)
+
+    const large: KpiStripIslandData['cells'] = [
+      { variant: 'stacked', label: 'A', value: 1 },
+      { variant: 'stacked', label: 'B', value: 2 },
+      { variant: 'stacked', label: 'C', value: 3 },
+    ]
+    render(html`<${KpiStripIsland} ariaLabel="x" cells=${large} />`, container)
+    await flush()
+    expect(container.querySelectorAll('[role="listitem"]').length).toBe(3)
+
+    const empty: KpiStripIslandData['cells'] = []
+    render(html`<${KpiStripIsland} ariaLabel="x" cells=${empty} />`, container)
+    await flush()
+    expect(container.querySelectorAll('[role="listitem"]').length).toBe(0)
+  })
+
+  it('disposes the Solid root cleanly when the Preact host unmounts', async () => {
+    const cells: KpiStripIslandData['cells'] = [
+      { variant: 'stacked', label: 'A', value: 1 },
+    ]
+    render(html`<${KpiStripIsland} ariaLabel="x" cells=${cells} />`, container)
+    await flush()
+    expect(container.querySelector('[role="list"]')).toBeTruthy()
+
+    render(null, container)
+    await flush()
+    expect(container.querySelector('[role="list"]')).toBeNull()
+    expect(container.querySelectorAll('[role="listitem"]').length).toBe(0)
+  })
+
+  it('forwards kind and progress through to the Solid cell', async () => {
+    const cells: KpiStripIslandData['cells'] = [
+      { variant: 'stacked', label: 'CTX', value: '40k', kind: 'warn', progress: 73 },
+    ]
+    render(html`<${KpiStripIsland} ariaLabel="x" cells=${cells} />`, container)
+    await flush()
+    const cell = container.querySelector('[role="listitem"]') as HTMLElement
+    expect(cell.getAttribute('aria-label')).toContain('progress 73%')
+    expect(cell.getAttribute('aria-label')).toContain('(warning)')
+    // The Bar primitive renders inside the cell, kind tints the fill.
+    expect(cell.innerHTML).toContain('var(--color-status-warn)')
+    expect(cell.innerHTML).toContain('width: 73%')
+  })
+})

--- a/dashboard/src/components/kpi-strip-island.ts
+++ b/dashboard/src/components/kpi-strip-island.ts
@@ -1,0 +1,59 @@
+// Preact wrapper that mounts the Solid `KpiStrip` subtree as an island.
+//
+// Usage from a Preact caller (data-driven, no children):
+//
+//   <${KpiStripIsland}
+//     ariaLabel="기능 상태 요약"
+//     variant="standard"
+//     cells=${[
+//       { variant: 'stacked', label: '총 기능', value: total },
+//       { variant: 'stacked', label: '정상', value: ok, kind: 'ok' },
+//       ...
+//     ]}
+//   />
+//
+// Lifecycle:
+//   - mount: useEffect creates a Solid signal seeded with the props,
+//     hands the JSX closure to `solid-js/web` render, stores the setter.
+//   - re-render: the second useEffect (no deps) fires every Preact
+//     render and pushes the latest props through `setState`. Solid
+//     diffs the signal value and re-renders only what actually changed.
+//   - unmount: dispose the Solid root + null the setter.
+
+import { useEffect, useRef } from 'preact/hooks'
+import { render as solidRender } from 'solid-js/web'
+import type { Setter } from 'solid-js'
+import type { VNode } from 'preact'
+import { html } from 'htm/preact'
+import {
+  createKpiStripIsland,
+  type KpiStripIslandData,
+} from './kpi-strip-island-solid.solid'
+
+export type { KpiStripIslandData } from './kpi-strip-island-solid.solid'
+
+export function KpiStripIsland(props: KpiStripIslandData): VNode {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const setStateRef = useRef<Setter<KpiStripIslandData> | null>(null)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return undefined
+    const island = createKpiStripIsland(props)
+    setStateRef.current = island.setState
+    const dispose = solidRender(island.jsx, el)
+    return () => {
+      dispose()
+      setStateRef.current = null
+    }
+    // Mount-once intentional: Solid owns its own reactivity after the
+    // initial mount. Prop sync runs in the second useEffect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    setStateRef.current?.(props)
+  })
+
+  return html`<div ref=${containerRef} />`
+}


### PR DESCRIPTION
## Summary

RFC 0017 PR #4 — first **production caller** migration to a SolidJS island. \`feature-health.ts\`'s overview KPI strip now mounts a Solid subtree (KpiStrip + 6 KpiCells) inside the existing Preact tree via a small wrapper component.

## What lands

| File | Role |
|------|------|
| \`dashboard/src/components/kpi-strip-island-solid.solid.tsx\` | Solid renderer factory. Owns the \`createSignal\` of strip data, exports a JSX closure + setter |
| \`dashboard/src/components/kpi-strip-island.ts\` | Preact wrapper. Mounts host \`<div>\`, calls \`solid-js/web\` \`render\`, syncs props on every re-render, disposes on unmount |
| \`dashboard/src/components/kpi-strip-island.solid.test.ts\` | 6 integration scenarios (mount, sync, grow/shrink, unmount, kind+progress forwarding) |
| \`dashboard/src/components/feature-health.ts\` | Replaced \`<\${KpiStrip}>...children...</\${KpiStrip}>\` with \`<\${KpiStripIsland} cells=\${[...]} />\` |

## Bundle delta (production build)

| Chunk | Before | After | Delta |
|-------|--------|-------|-------|
| \`solid-*.js\` | **1 B** | **9.3 KB** | +9.3 KB (solid-js runtime + KpiStrip/Cell/Bar Solid mirrors land) |
| \`index-*.js\` (Preact main) | 200 KB | 200 KB | 0 |
| \`feature-health-*.js\` | (n/a) | 13 KB | +Preact-side wrapper import |

The 9.3 KB is the **one-time cost** of enabling Solid in the dashboard. Subsequent islands amortise this baseline. Per RFC 0017 §7 verification this is the first measurable production datapoint of the migration.

## Why two files (transform boundary = file boundary)

A single \`.tsx\` mixing Preact \`useEffect\`/\`useRef\` with Solid \`<For>\` JSX would force one transformer (\`@preact/preset-vite\` or \`vite-plugin-solid\`) to claim the file and silently mis-compile the other side. Splitting:
- \`*.solid.tsx\` — owns Solid JSX. Solid plugin transforms.
- \`.ts\` — owns Preact hooks + htm tagged templates. Preact plugin handles, no JSX transform needed (htm parses at runtime).

## Caller migration shape

Children pattern (Preact, 8 lines of nested htm):
\`\`\`js
<\${KpiStrip} ariaLabel=\"기능 상태 요약\" variant=\"standard\">
  <\${KpiCell} variant=\"stacked\" label=\"총 기능\" value=\${overview.total_features} />
  <\${KpiCell} variant=\"stacked\" label=\"활성화\" value=\${overview.enabled_count} />
  ...
<//>
\`\`\`

becomes data pattern (island, 8 lines of array):
\`\`\`js
<\${KpiStripIsland}
  ariaLabel=\"기능 상태 요약\"
  variant=\"standard\"
  cells=\${[
    { variant: 'stacked', label: '총 기능', value: overview.total_features },
    { variant: 'stacked', label: '활성화', value: overview.enabled_count },
    ...
  ] satisfies KpiStripIslandData['cells']}
/>
\`\`\`

DOM contract identical (\`role=list\`, \`role=listitem\`, aria-labels, surface styles).

## Verification

| Step | Result |
|------|--------|
| \`pnpm typecheck\` | green |
| \`pnpm test\` (Preact suite) | **5134/5134 pass** |
| \`vitest --config vitest.solid.config.ts\` | **128/128 pass** (was 122 + 6 new island scenarios) |
| \`pnpm build\` | success; bundle delta documented above |

## Trade-offs / known issues

- Test \`flush()\` helper waits 2× \`setTimeout(10)\` because Preact's first \`useEffect\` commit can hit cold-start latency in happy-dom. Documented inline.
- Caller migration switches the call shape from children → data prop. This is a deliberate API consequence of crossing a framework boundary; remaining 4 callers (governance, harness-health, safe-autonomy, connector-status) will get the same treatment in PR #5+.

## Trajectory (next)

PR #5 candidate: migrate \`safe-autonomy.ts\` (16 KpiCell refs across nested strips) — biggest caller, will surface any island composition issues before they spread to the smaller 9-ref callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)