### PR TITLE
monitoring: alert + dashboard for masc_fsm_guard_violation_total

### DIFF
--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -25,6 +25,8 @@ Tracks cascade-routing decisions inside `Oas_worker_named.cycle_loop`. Counters:
 
 Tracks the typed turn-state ADT inside `run_keeper_cycle`. Counter: `masc_keeper_turn_fsm_transitions_total{from,to,keeper}`. State vocabulary: 10 typed states with `failure_reason` / `cancel_reason` carriers (TLA+ `KeeperTurnFSM`).
 
+`keeper-turn-fsm-alerts.yml` also carries the **fsm_guard violation** alerts (group `masc_keeper_fsm_guard`). Counter: `masc_fsm_guard_violation_total{action,stage}` — incremented when a `[@@fsm_guard "<expr>"]`-injected runtime assertion catches a TLA+ Next-set violation in counter mode (production default `MASC_FSM_GUARD_ASSERT=0`). The dashboard surfaces this counter in the bottom row of `grafana-keeper-turn-fsm-dashboard.json`.
+
 The two domains overlap *only* at `cascade_routing` — when the keeper FSM enters cascade routing, the cascade subsystem takes over until a provider is selected (or exhausted). Both surfaces emit independently; an operator chasing a turn that died at cascade exhaustion sees:
 
 - `masc_keeper_turn_fsm_transitions_total{to="failed:cascade_unavailable",keeper=...}` — keeper view

--- a/infrastructure/monitoring/grafana-keeper-turn-fsm-dashboard.json
+++ b/infrastructure/monitoring/grafana-keeper-turn-fsm-dashboard.json
@@ -140,6 +140,61 @@
       "options": {
         "legend": { "displayMode": "table", "placement": "right", "showLegend": true }
       }
+    },
+    {
+      "type": "timeseries",
+      "title": "FSM guard violations by (action, stage) — rate / 5m",
+      "gridPos": { "x": 0, "y": 24, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Per-(action, stage) rate of [@@fsm_guard]-injected assertion failures. Production default (MASC_FSM_GUARD_ASSERT=0) catches Assert_failure and bumps this counter silently — any non-zero rate here is spec drift that escaped the parity test gate. See lib/keeper/keeper_fsm_guard_runtime.mli.",
+      "targets": [
+        {
+          "expr": "sum by (action, stage) (rate(masc_fsm_guard_violation_total[5m]))",
+          "legendFormat": "{{action}} / {{stage}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "FSM guard violations — lifetime total",
+      "gridPos": { "x": 12, "y": 24, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Cumulative [@@fsm_guard] violations since process start, broken down by (action, stage). Non-zero on a fresh process means the very first heartbeat already drifted from spec; investigate before trusting any other panel on this dashboard.",
+      "targets": [
+        {
+          "expr": "sum by (action, stage) (masc_fsm_guard_violation_total)",
+          "legendFormat": "{{action}} / {{stage}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 100 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
     }
   ],
   "refresh": "30s",

--- a/infrastructure/monitoring/keeper-turn-fsm-alerts.yml
+++ b/infrastructure/monitoring/keeper-turn-fsm-alerts.yml
@@ -132,3 +132,95 @@ groups:
               - cascade exhaustion specific to this keeper's cascade
               - livelock guard re-rejecting (see KeeperTurnLivelockBurst)
             Drill: bin/masc-trace <base> {{ $labels.keeper }} <recent_turn_id>
+
+  # PPX [@@fsm_guard "<expr>"] runtime assertion violations.
+  # Counter: masc_fsm_guard_violation_total{action,stage}
+  #   - Defined: lib/prometheus.ml:645
+  #   - Bumped:  lib/keeper/keeper_fsm_guard_runtime.ml:24
+  #   - Wired:   12 hot-path call sites (heartbeat_loop, keepalive,
+  #              unified_turn, turn_helpers)
+  #
+  # Default production policy is counter mode (MASC_FSM_GUARD_ASSERT=0):
+  # Assert_failure is caught and the counter increments silently. Any
+  # non-zero rate here is a TLA+ Next-set violation that escaped the
+  # parity test gate; treat as spec drift, not "noise".
+  #
+  # Hard mode (MASC_FSM_GUARD_ASSERT=1) is for tests / smoke / CI and
+  # raises Assert_failure instead of bumping the counter. So a positive
+  # rate here implies production is in counter mode.
+  - name: masc_keeper_fsm_guard
+    interval: 30s
+    rules:
+
+      # Any violation is signal -- counter mode swallows the
+      # Assert_failure, so the metric is the only operator-visible
+      # surface. for: 5m debounces transient single-tick blips that
+      # could happen during compaction or cancel storms.
+      - alert: KeeperFsmGuardViolation
+        expr: |
+          rate(masc_fsm_guard_violation_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: keeper
+          subsystem: fsm_guard
+        annotations:
+          summary: "Keeper FSM guard violation in {{ $labels.action }} ({{ $labels.stage }})"
+          description: |
+            A [@@fsm_guard]-injected assertion failed in
+            {{ $labels.action }} at stage {{ $labels.stage }} at rate
+            {{ $value }}/s for 5m. This means an OCaml hot-path took
+            a state transition that the corresponding TLA+ Next set
+            does not enable.
+
+            Common causes:
+              - Spec change merged but OCaml call site not migrated
+              - New emit site landed without [@@deriving tla] / [@@fsm_guard]
+              - PPX guard expression is stale relative to refactored
+                state shape
+
+            Drill:
+              1. Identify the offending action: {{ $labels.action }}
+              2. Find the [@@fsm_guard] attribute carrying that label:
+                 rg '@@fsm_guard.*"{{ $labels.action }}"' lib/keeper/
+              3. Compare to specs/keeper-turn-fsm/KeeperTurnFSM.tla
+                 (or sibling .tla in specs/keeper-state-machine/)
+                 for the matching action's enablement condition.
+              4. Re-run the call site under MASC_FSM_GUARD_ASSERT=1
+                 to capture the Assert_failure stack.
+              5. Either: fix the OCaml call site, update the PPX guard
+                 expression, or correct the spec -- whichever is wrong.
+
+            Reference: docs/observability/keeper-turn-fsm-metrics.md
+            Reference: lib/keeper/keeper_fsm_guard_runtime.mli (contract)
+
+      # Burst: rate > 0.5/s over 1m sustained for 2m means a keeper
+      # is taking the bad transition every couple of cycles, not
+      # once. Page rather than warn.
+      - alert: KeeperFsmGuardViolationBurst
+        expr: |
+          rate(masc_fsm_guard_violation_total[1m]) > 0.5
+        for: 2m
+        labels:
+          severity: critical
+          component: keeper
+          subsystem: fsm_guard
+        annotations:
+          summary: "Keeper FSM guard burst -- {{ $labels.action }} firing > 0.5/s"
+          description: |
+            [@@fsm_guard] for {{ $labels.action }} is failing at
+            > 0.5/s sustained for 2m. A repeat-rate this high
+            indicates a keeper is wedged on a single transition that
+            is now spec-illegal. counter-mode default means the
+            keeper is still "running" but every relevant tick is a
+            silent invariant violation.
+
+            Immediate action:
+              - Set MASC_FSM_GUARD_ASSERT=1 on the affected keeper
+                to fail-fast and surface the Assert_failure.
+              - Check whether the same keeper is also producing
+                masc_keeper_invariant_violations_total ticks
+                (KeeperCompositeInvariantSingleKeeperStuck).
+              - If the offending {{ $labels.action }} matches a recent
+                spec change, consider reverting the [@@fsm_guard]
+                expression update until the call sites are migrated.


### PR DESCRIPTION
## Summary

Closes the operator-visibility gap for `masc_fsm_guard_violation_total`. The PPX `[@@fsm_guard "<expr>"]` runtime wrapper increments this counter on every caught `Assert_failure` in the default counter-mode (`MASC_FSM_GUARD_ASSERT=0`) production policy. Until now nothing alerted on it — spec drift was silently absorbed by the counter.

This PR is **YAML + JSON only**. No OCaml changes. The counter, Slack/Alertmanager fanout, and dashboard scaffold all pre-exist.

## What changes

### `infrastructure/monitoring/keeper-turn-fsm-alerts.yml` (+92)
New group `masc_keeper_fsm_guard`:
- **`KeeperFsmGuardViolation`** — `rate(masc_fsm_guard_violation_total[5m]) > 0` for `5m`, severity `warning`. Any violation is signal in counter mode; the 5m window debounces single-tick blips.
- **`KeeperFsmGuardViolationBurst`** — `rate(...[1m]) > 0.5` for `2m`, severity `critical`. Repeat-rate this high implies a wedged keeper on a spec-illegal transition.

Both annotations carry a drill section: identify the `[@@fsm_guard]` attribute → compare to the matching `.tla` action's enablement condition → `MASC_FSM_GUARD_ASSERT=1` to capture the `Assert_failure` stack.

### `infrastructure/monitoring/grafana-keeper-turn-fsm-dashboard.json` (+55)
Bottom row (y=24) gains two panels:
- timeseries: `sum by (action, stage) (rate(masc_fsm_guard_violation_total[5m]))`
- stat: lifetime total with green / yellow / red thresholds at 0 / 1 / 100

### `infrastructure/monitoring/README.md` (+2)
Documents that `keeper-turn-fsm-alerts.yml` now also covers fsm_guard violations under group `masc_keeper_fsm_guard`.

## Why this design

- **`rate > 0`, not `> N/s`**: counter mode is silent; a single increment IS the signal. The `for: 5m` already absorbs transient blips.
- **`KeeperFsmGuardViolationBurst` separate from the warning alert**: matches the `cascade-alerts.yml:146` precedent (`KeeperCompositeInvariantViolationBurst`) — warn vs page split by sustained rate.
- **No direct OCaml → Slack call**: existing Alertmanager fanout reused. `keeper_alerting.ml` is reserved for LLM-context signals, not operator paging.

## Test plan

- [x] `promtool check rules infrastructure/monitoring/keeper-turn-fsm-alerts.yml` → `SUCCESS: 6 rules found` (4 existing + 2 new)
- [x] `jq empty infrastructure/monitoring/grafana-keeper-turn-fsm-dashboard.json` → exits 0
- [x] `jq '.panels | length'` → 6 (was 4)
- [ ] Manual smoke (post-merge): run keeper with `MASC_FSM_GUARD_ASSERT=0` + a synthetic `[@@fsm_guard "false"]`, observe `curl localhost:8935/metrics | grep masc_fsm_guard_violation` non-zero, observe Alertmanager → Slack within ~5m.

## Context

Part of the "PPX rigor track" gap-fill from the 2026-04-28 Kimi keeper FSM audit report (cross-referenced with the AST·PPX 계약 report). This is PR 1 of 4 — the others (receipt-as-mandatory-field on terminal `turn_state`, `ppx_tla_lint` detect-only, then enforcement) follow in separate PRs.

Plan: `~/me/planning/claude-plans/greedy-sleeping-blossom.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
