### PR TITLE
feat(keeper): surface unknown_toml_keys in drift_surface_json

### DIFF
--- a/config/keepers/ramarama.toml
+++ b/config/keepers/ramarama.toml
@@ -1,0 +1,9 @@
+[keeper]
+persona_name = "ramarama"
+sandbox_profile = "docker"
+network_mode = "inherit"
+tool_preset = "social"
+work_discovery_enabled = true
+work_discovery_sources = ["board_posts"]
+github_identity = "anyang-keepers"
+git_identity_mode = "github_identity"

--- a/config/keepers/taskmaster.toml
+++ b/config/keepers/taskmaster.toml
@@ -1,0 +1,9 @@
+[keeper]
+persona_name = "taskmaster"
+sandbox_profile = "docker"
+network_mode = "inherit"
+tool_preset = "delivery"
+work_discovery_enabled = true
+work_discovery_sources = ["unclaimed_tasks", "stale_tasks"]
+github_identity = "anyang-keepers"
+git_identity_mode = "github_identity"

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -98,11 +98,23 @@ tools = ["masc_status", "masc_web_search"]
 # Coordination: external agent coordination tools.
 # Only needed by keepers that manage tasks across agents.
 [masc.coordination]
-tools = ["masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard", "masc_agent_card", "masc_tool_help"]
+tools = [
+  "masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task",
+  "masc_batch_add_tasks", "masc_agents", "masc_dashboard",
+  "masc_agent_card", "masc_tool_help",
+  "masc_join", "masc_leave", "masc_who", "masc_heartbeat",
+  "masc_messages", "masc_broadcast",
+]
 
 # Full core: backward compat alias (essential + coordination).
 [masc.core]
-tools = ["masc_status", "masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard", "masc_agent_card", "masc_tool_help", "masc_web_search"]
+tools = [
+  "masc_status", "masc_tasks", "masc_claim_next", "masc_transition",
+  "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard",
+  "masc_agent_card", "masc_tool_help", "masc_web_search",
+  "masc_join", "masc_leave", "masc_who", "masc_heartbeat",
+  "masc_messages", "masc_broadcast",
+]
 
 [masc.dispatch]
 tools = [

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1476,7 +1476,12 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("cooldown_sec", `Int m.proactive.cooldown_sec);
         ]
       in
-      let drift = drift_surface_json () in
+      let drift =
+        let toml_defaults =
+          Keeper_types_profile.load_keeper_profile_defaults name
+        in
+        drift_surface_json ~unknown_toml_keys:toml_defaults.unknown_toml_keys
+      in
       let handoff =
         `Assoc [
           ("auto", `Bool m.auto_handoff);

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -7,14 +7,11 @@ let string_list_to_json values =
 
 
 
-let drift_surface_json () =
+let drift_surface_json ~unknown_toml_keys =
   `Assoc
     [
-      ("status", `String "unwired");
-      ("enabled", `Null);
-      ("min_turn_gap", `Null);
-      ("count_total", `Null);
-      ("last_reason", `Null);
+      ("unknown_toml_keys", string_list_to_json unknown_toml_keys);
+      ("unknown_toml_keys_count", `Int (List.length unknown_toml_keys));
     ]
 
 let auto_execution_session_surface_json () =

--- a/lib/keeper/keeper_status_bridge.mli
+++ b/lib/keeper/keeper_status_bridge.mli
@@ -36,7 +36,7 @@ val runtime_blocker_surface_opt :
 
 val string_list_to_json : string list -> Yojson.Safe.t
 
-val drift_surface_json : unit -> Yojson.Safe.t
+val drift_surface_json : unknown_toml_keys:string list -> Yojson.Safe.t
 
 val auto_execution_session_surface_json : unit -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1109,7 +1109,12 @@ let handle_keeper_status ctx args : tool_result =
                then `Null
                else `String m.runtime.proactive_rt.last_preview);
            ]);
-           ("drift", drift_surface_json ());
+           ("drift",
+             let toml_defaults =
+               Keeper_types_profile.load_keeper_profile_defaults name
+             in
+             drift_surface_json
+               ~unknown_toml_keys:toml_defaults.unknown_toml_keys);
            ("policy", `Assoc [
              ("voice_tools_available", `Bool (List.mem "keeper_voice_speak" allowed_tools));
              ("sandbox_profile",


### PR DESCRIPTION
PR-A2 for task-109 / task-056.

## Changes
- Replace drift_surface_json placeholder (status=unwired) with actual unknown_toml_keys list + count from Keeper_types_profile defaults
- Update signature in .mli to require ~unknown_toml_keys parameter
- Wire both keeper_status_detail and dashboard_http_keeper call sites
- Add missing MASC coordination tools to presets + missing keeper configs (task-075)

## Verification
- [ ] dune build @check
- [ ] dune runtest test/test_keeper_toml.ml
- [ ] dune runtest test/test_keeper_toml_config_validation.ml

Refs: task-109, task-056, task-075