### PR TITLE
fix(keeper): expose rewrite_docker_host_paths_to_container in mli

### DIFF
--- a/lib/keeper/keeper_shell_shared.mli
+++ b/lib/keeper/keeper_shell_shared.mli
@@ -148,6 +148,15 @@ val rewrite_turn_runtime_paths_to_host :
     its host playground absolute path so the LLM-facing output
     references real host paths. *)
 
+val rewrite_docker_host_paths_to_container :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  string ->
+  string
+(** Rewrite host playground root occurrences in keeper-issued Docker
+    commands to the corresponding in-container playground root before
+    execution. *)
+
 val run_argv_with_status_retry_eintr :
   ?cwd:string ->
   timeout_sec:float ->


### PR DESCRIPTION
## Summary
- `rewrite_docker_host_paths_to_container` existed in `keeper_shell_shared.ml` but was missing from its `.mli`.
- `keeper_exec_shell.ml` includes `Keeper_shell_shared` and re-exports the value through its own `.mli`, causing a signature mismatch / build break on main.

## Fix
Add the missing `val` declaration to `keeper_shell_shared.mli`.

## Test plan
- [x] `dune build --root .` passes in worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)