### PR TITLE
scripts: tla-mutation-lint detector + ratchet (Track 1A)

### DIFF
--- a/scripts/tla-mutation-lint-baseline.json
+++ b/scripts/tla-mutation-lint-baseline.json
@@ -1,0 +1,8 @@
+{
+  "_comment_1": "Mutation-lint ratchet baseline. Floor enforced by scripts/tla-mutation-lint-ratchet.sh.",
+  "_comment_2": "Direction: monotonic DECREASE. current must be <= keeper_mutation_sites_max (we want fewer mutations over time).",
+  "_comment_3": "Reduce by either: (a) refactoring the site away from mutation, or (b) annotating with (* tla-lint: allow-mutation: <reason> *).",
+  "_comment_4": "After reducing, run scripts/tla-mutation-lint-ratchet.sh --regenerate to rewrite this file. Increases require a paired follow-up issue.",
+  "_comment_5": "Reference: planning/claude-plans/greedy-sleeping-blossom.md (Track 1A).",
+  "keeper_mutation_sites_max": 254
+}

--- a/scripts/tla-mutation-lint-ratchet.sh
+++ b/scripts/tla-mutation-lint-ratchet.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Mutation-lint ratchet gate.
+#
+# Runs scripts/tla-mutation-lint.sh --count and compares the output
+# against scripts/tla-mutation-lint-baseline.json. The baseline is a
+# *ceiling*: current_count must be <= keeper_mutation_sites_max.
+#
+# Inversion vs tla-ppx-ratchet.sh: the adoption ratchet enforces a
+# *floor* (current >= baseline) because we want monotonic adoption
+# growth. This ratchet enforces a *ceiling* (current <= baseline)
+# because we want monotonic mutation-site decrease.
+#
+# Reference: planning/claude-plans/greedy-sleeping-blossom.md (Track 1A).
+# Sister script: scripts/tla-ppx-ratchet.sh.
+#
+# Usage:
+#   scripts/tla-mutation-lint-ratchet.sh              # check; exit 0 ok / 2 drift up / 1 error
+#   scripts/tla-mutation-lint-ratchet.sh --regenerate # rewrite baseline from current count
+#   scripts/tla-mutation-lint-ratchet.sh --print      # print current count, no compare
+#
+# CI integration: a job in .github/workflows/ci.yml runs this on
+# every PR; a non-zero exit blocks merge if the check is required.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DETECTOR="${SCRIPT_DIR}/tla-mutation-lint.sh"
+BASELINE_FILE="${SCRIPT_DIR}/tla-mutation-lint-baseline.json"
+
+for tool in bash python3 jq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[tla-mutation-lint-ratchet] required tool missing: $tool" >&2
+    exit 1
+  }
+done
+
+if [ ! -x "$DETECTOR" ]; then
+  echo "[tla-mutation-lint-ratchet] detector not executable: $DETECTOR" >&2
+  exit 1
+fi
+
+current_count() {
+  bash "$DETECTOR" --count
+}
+
+baseline_max() {
+  jq -r '.keeper_mutation_sites_max' "$BASELINE_FILE"
+}
+
+write_baseline() {
+  local count="$1"
+  python3 - "$BASELINE_FILE" "$count" <<'PY'
+import json, sys
+path, count = sys.argv[1], int(sys.argv[2])
+with open(path) as f:
+    data = json.load(f)
+data["keeper_mutation_sites_max"] = count
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PY
+}
+
+MODE="check"
+case "${1:-}" in
+  --regenerate) MODE="regen" ;;
+  --print)      MODE="print" ;;
+  "")           MODE="check" ;;
+  *)
+    echo "[tla-mutation-lint-ratchet] unknown flag: $1" >&2
+    echo "  use --regenerate or --print" >&2
+    exit 1
+    ;;
+esac
+
+current="$(current_count)"
+
+case "$MODE" in
+  print)
+    echo "current=$current"
+    echo "baseline_max=$(baseline_max)"
+    exit 0
+    ;;
+  regen)
+    write_baseline "$current"
+    echo "[tla-mutation-lint-ratchet] regenerated baseline: keeper_mutation_sites_max=$current"
+    exit 0
+    ;;
+esac
+
+baseline="$(baseline_max)"
+
+if [ "$current" -le "$baseline" ]; then
+  if [ "$current" -lt "$baseline" ]; then
+    echo "[tla-mutation-lint-ratchet] OK — mutations decreased from $baseline to $current"
+    echo "[tla-mutation-lint-ratchet] consider running --regenerate in this PR to lower the floor"
+  else
+    echo "[tla-mutation-lint-ratchet] OK — mutations at floor ($current)"
+  fi
+  exit 0
+fi
+
+echo "[tla-mutation-lint-ratchet] FAIL — mutations rose from $baseline to $current" >&2
+echo "" >&2
+echo "Recent additions in lib/keeper/ added new ref-state mutations." >&2
+echo "Either:" >&2
+echo "  (a) Refactor the new site to avoid mutation (preferred)" >&2
+echo "  (b) Annotate with a line comment immediately above the mutation:" >&2
+echo "        (* tla-lint: allow-mutation: <reason> *)" >&2
+echo "" >&2
+echo "If the increase is intentional and unavoidable, run:" >&2
+echo "  bash scripts/tla-mutation-lint-ratchet.sh --regenerate" >&2
+echo "and open a paired follow-up issue documenting the rationale." >&2
+echo "" >&2
+echo "List the new sites with:" >&2
+echo "  bash scripts/tla-mutation-lint.sh" >&2
+exit 2

--- a/scripts/tla-mutation-lint.sh
+++ b/scripts/tla-mutation-lint.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Detect ref-state and Atomic.set mutations in lib/keeper/.
+#
+# This is the detect-only first cut of the ppx_tla_lint track from
+# the Kimi keeper FSM audit (2026-04-28). Surfaces every mutation
+# site so the ratchet (scripts/tla-mutation-lint-ratchet.sh) can
+# enforce monotonic decrease as the team migrates each site to:
+#   (a) a derived state (no mutation), or
+#   (b) marked with a (* tla-lint: allow-mutation: <reason> *) line
+#       comment immediately above, justifying why this site is a
+#       genuine non-FSM mutation (metric counter, fiber signal, etc.).
+#
+# Patterns scanned (lib/keeper/ only):
+#   1. Pexp_apply  Atomic.set X v
+#   2. Pexp_setfield (record-field assign)         X.f <- v   /   X.f := v
+#   3. Pexp_apply  ( := ) for ref cells           X := v
+#
+# Escape: a line whose previous non-blank source line contains the
+# tag [tla-lint: allow-mutation:] is excluded from the count. Example:
+#
+#   (* tla-lint: allow-mutation: heartbeat counter, not FSM state *)
+#   Atomic.set tick_count (n + 1)
+#
+# The intent is to make the audit budget visible: every unmasked
+# mutation in lib/keeper/ is potentially a TLA+ Next-set drift
+# candidate. Future PR (Track 1B) promotes the ratchet to zero and
+# flips this lint to a hard build error via PPX integration.
+#
+# Usage:
+#   scripts/tla-mutation-lint.sh              # print one VIOLATION line per match, count to stderr
+#   scripts/tla-mutation-lint.sh --count      # print the total count only, on stdout
+#
+# Exit code: 0 always (this is the detector — the ratchet decides
+# pass/fail).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Override target dir via env var (used by tests). Default scans the
+# real lib/keeper/ relative to the script's repo.
+KEEPER_DIR="${TLA_LINT_KEEPER_DIR:-${REPO_ROOT}/lib/keeper}"
+
+for tool in rg sed awk wc; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[tla-mutation-lint] required tool missing: $tool" >&2
+    exit 1
+  }
+done
+
+MODE="report"
+if [ "${1:-}" = "--count" ]; then
+  MODE="count"
+fi
+
+# Combined pattern. We use rg with -n for line numbers and -e for
+# multiple expressions. The regex intentionally matches the OCaml
+# surface, not the AST — false positives are filtered by the
+# escape-marker check below.
+PATTERNS=(
+  -e '\bAtomic\.set\b'
+  -e '<\-'                    # record field set: x.f <- v
+  -e ' := '                   # ref cell set:   x := v
+)
+
+VIOLATIONS=0
+TMPFILE="$(mktemp)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Scan lib/keeper/ recursively. Skip .mli (declarations only,
+# no mutations). Skip generated files under _build/.
+rg --no-heading --line-number --type ocaml "${PATTERNS[@]}" \
+   "$KEEPER_DIR" \
+   --glob '!*.mli' \
+   --glob '!_build/**' \
+   2>/dev/null > "$TMPFILE" || true
+
+while IFS=: read -r file lineno line; do
+  [ -z "$file" ] && continue
+
+  # Strip leading whitespace from the matched line for false-positive
+  # filtering. We exclude:
+  #   - String literals containing := (rare but real: e.g. error
+  #     messages like "use := not =")
+  #   - Comment-only lines (* X := Y *)  — pure prose
+  trimmed="$(echo "$line" | sed -E 's/^[[:space:]]+//')"
+  case "$trimmed" in
+    '*'*|'(*'*|'//'*) continue ;;  # comment line
+  esac
+
+  # Look at the previous non-blank line for the allow-mutation tag.
+  start=$((lineno > 5 ? lineno - 5 : 1))
+  end=$((lineno - 1))
+  if [ "$end" -ge "$start" ]; then
+    prev_context="$(sed -n "${start},${end}p" "$file" 2>/dev/null || true)"
+    if echo "$prev_context" | grep -q 'tla-lint:[[:space:]]*allow-mutation:'; then
+      continue
+    fi
+  fi
+
+  VIOLATIONS=$((VIOLATIONS + 1))
+  if [ "$MODE" = "report" ]; then
+    # Strip leading repo root for compact display, falling back to absolute.
+    rel="${file#$REPO_ROOT/}"
+    [ "$rel" = "$file" ] && rel="${file#$KEEPER_DIR/}"
+    echo "VIOLATION: ${rel}:${lineno}: ${trimmed}"
+  fi
+done < "$TMPFILE"
+
+if [ "$MODE" = "count" ]; then
+  echo "$VIOLATIONS"
+else
+  echo "[tla-mutation-lint] mutation sites in lib/keeper/: $VIOLATIONS" >&2
+fi
+exit 0

--- a/test/test_tla_mutation_lint.sh
+++ b/test/test_tla_mutation_lint.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Regression test for scripts/tla-mutation-lint.sh.
+#
+# Builds a synthetic lib/keeper/ tree under a temp dir, runs the
+# detector via the TLA_LINT_KEEPER_DIR override, and asserts the
+# violation count + the escape-hatch behavior.
+#
+# Run: bash test/test_tla_mutation_lint.sh
+# Exit: 0 = all assertions pass, 1 = a case failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DETECTOR="${REPO_ROOT}/scripts/tla-mutation-lint.sh"
+
+[ -x "$DETECTOR" ] || { echo "FAIL: detector not executable: $DETECTOR" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -r "$TMP"' EXIT
+
+mkdir -p "$TMP/lib/keeper"
+
+# Fixture: 4 mutations, 2 masked by escape hatch.
+cat > "$TMP/lib/keeper/test_fixture.ml" <<'OCAML'
+(* Synthetic test fixture for tla-mutation-lint *)
+
+let counter = ref 0
+
+let unmasked_ref () =
+  counter := !counter + 1
+
+let masked_ref () =
+  (* tla-lint: allow-mutation: heartbeat counter *)
+  counter := !counter + 1
+
+let masked_atomic () =
+  let a = Atomic.make 0 in
+  (* tla-lint: allow-mutation: prom counter *)
+  Atomic.set a 1;
+  ignore a
+
+let unmasked_atomic () =
+  let a = Atomic.make 0 in
+  Atomic.set a 1;
+  ignore a
+OCAML
+
+# Case 1: detector reports the right total (2 unmasked).
+got="$(TLA_LINT_KEEPER_DIR="$TMP/lib/keeper" bash "$DETECTOR" --count)"
+if [ "$got" != "2" ]; then
+  echo "FAIL case 1: expected 2 unmasked mutations, got $got" >&2
+  TLA_LINT_KEEPER_DIR="$TMP/lib/keeper" bash "$DETECTOR" >&2 || true
+  exit 1
+fi
+echo "ok case 1 — detector counted 2 unmasked mutations (fixture has 4 total)"
+
+# Case 2: zero-mutation fixture (a constant declaration only).
+echo "let const_only = 42" > "$TMP/lib/keeper/test_fixture.ml"
+got="$(TLA_LINT_KEEPER_DIR="$TMP/lib/keeper" bash "$DETECTOR" --count)"
+if [ "$got" != "0" ]; then
+  echo "FAIL case 2: expected 0 mutations, got $got" >&2
+  exit 1
+fi
+echo "ok case 2 — detector returns 0 on a mutation-free fixture"
+
+# Case 3: comment lines containing := are not mistaken for mutations.
+cat > "$TMP/lib/keeper/test_fixture.ml" <<'OCAML'
+(* The operator := is OCaml's ref assignment. *)
+(* In TLA+ a primed assignment is x' = X, not x := X. *)
+let only_comments = ()
+OCAML
+got="$(TLA_LINT_KEEPER_DIR="$TMP/lib/keeper" bash "$DETECTOR" --count)"
+if [ "$got" != "0" ]; then
+  echo "FAIL case 3: comment-only file should be 0, got $got" >&2
+  TLA_LINT_KEEPER_DIR="$TMP/lib/keeper" bash "$DETECTOR" >&2 || true
+  exit 1
+fi
+echo "ok case 3 — comment lines containing := are not flagged"
+
+echo ""
+echo "[tla-mutation-lint test] PASS — 3/3 cases"


### PR DESCRIPTION
## Summary

Track 1A of the PPX rigor gap-fill — a detect-and-ratchet pair that surfaces every ref-state / `Atomic.set` mutation site in `lib/keeper/` and enforces monotonic decrease over time. Companion to PR #12242 (Track 3 — fsm_guard alerting).

## What changes

Four new files, all under `scripts/` and `test/`. Zero OCaml changes.

- **`scripts/tla-mutation-lint.sh`** (+116) — detector. `rg`-based pattern scan, 5-line escape-marker lookback, env-var override (`TLA_LINT_KEEPER_DIR`) for tests.
- **`scripts/tla-mutation-lint-baseline.json`** (+8) — initial floor: `keeper_mutation_sites_max = 254` (current count at HEAD). Inline comments document the reduction protocol.
- **`scripts/tla-mutation-lint-ratchet.sh`** (+118) — ratchet wrapper. Direction inverted vs `tla-ppx-ratchet.sh` (ceiling, not floor). Modes: `--regenerate` / `--print` / (default) check.
- **`test/test_tla_mutation_lint.sh`** (+82) — 3 regression cases for escape, zero-mutation, and comment-only false-positive avoidance.

Total: **+324 lines, 0 deletions, 4 new files**. No file shared with PR #12242.

## Why scope-reduce from the audit's "ppx_tla_lint PPX library"

The 2026-04-28 audit called for a full `ppx_tla_lint` PPX library that derives the allowlist from TLA+ `Next ==` action-sets. That's ~600 LOC of `ppxlib` integration plus a Menhir-style `.tla` parser. Shipping that as a single PR couples three independently-evolvable pieces (detection mechanics, allowlist source, severity escalation) into one review unit.

This PR ships only the **detection mechanics** + **floor enforcement**, mirroring the established `scripts/lint-cancel-guard.sh` and `scripts/tla-ppx-ratchet.sh` patterns. The TLA-derived allowlist is the natural follow-up — it can be wired in without re-litigating detector or ratchet behavior.

## How the escape hatch works

Any `:=`, `<-`, or `Atomic.set` site is exempt if a comment matching `tla-lint:[[:space:]]*allow-mutation:` appears within 5 lines above:

```ocaml
(* tla-lint: allow-mutation: heartbeat counter, not FSM state *)
counter := !counter + 1
```

The 5-line lookback covers OCaml's typical comment-then-binding spacing. Comment-only lines containing `:=` (e.g. prose explaining the operator) are filtered separately by leading-whitespace check on the matched line itself.

## Direction inversion vs adoption ratchets

| Ratchet | Direction | Goal |
|---|---|---|
| `tla-ppx-ratchet.sh` | floor: current >= baseline | monotonic adoption increase |
| `tla-mutation-lint-ratchet.sh` (new) | ceiling: current <= baseline | monotonic mutation decrease |

`--regenerate` accepts both directions; the gate logic enforces the asymmetric default.

## Test plan

- [x] `bash scripts/tla-mutation-lint.sh --count` → `254`
- [x] `bash scripts/tla-mutation-lint-ratchet.sh` → exit 0 at floor
- [x] Synthetic baseline of 200 → ratchet exits 2 with FAIL message naming the rise (200 → 254)
- [x] `bash scripts/tla-mutation-lint-ratchet.sh --regenerate` → rewrites baseline to current count
- [x] `bash test/test_tla_mutation_lint.sh` → `PASS — 3/3 cases`
- [ ] Manual smoke (post-merge): introduce a mutation in `lib/keeper/keeper_registry.ml`, run `bash scripts/tla-mutation-lint-ratchet.sh`, observe exit 2 with the new mutation listed; revert.

## CI hookup

Intentionally **not** added in this PR. Sister scripts `tla-ppx-ratchet.sh` and `lint-cancel-guard.sh` also currently lack a CI hook — they ship as runnable utilities. A follow-up can wire all three together in one workflow change so the gating rationale lands in one place.

## Context

Part of the "PPX rigor track" gap-fill from the 2026-04-28 Kimi keeper FSM audit (cross-referenced with the AST·PPX 계약 report). PR 3 of 4 in the sequence:

- PR #12242 — Track 3 fsm_guard alerting (in flight)
- This PR — Track 1A mutation lint detect-and-ratchet
- (deferred) Track 1B — promote to error after 1 week of measurement, drive baseline to zero
- (deferred) Track 2 — receipt-as-mandatory-field on terminal `turn_state`. Initial implementation revealed `turn_state` is telemetry-only with 8+ emit sites in `keeper_unified_turn.ml` (not a data product); compile-time enforcement requires a different boundary type at `run_turn`'s return signature, which deserves its own RFC.

Plan: `~/me/planning/claude-plans/greedy-sleeping-blossom.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
