### PR TITLE
fix(keeper): export docker path rewrite helper

### DIFF
--- a/lib/keeper/keeper_shell_shared.mli
+++ b/lib/keeper/keeper_shell_shared.mli
@@ -148,6 +148,15 @@ val rewrite_turn_runtime_paths_to_host :
     its host playground absolute path so the LLM-facing output
     references real host paths. *)
 
+val rewrite_docker_host_paths_to_container :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  string ->
+  string
+(** Rewrite host playground root occurrences in keeper-issued Docker
+    commands to the corresponding in-container playground root before
+    execution. *)
+
 val run_argv_with_status_retry_eintr :
   ?cwd:string ->
   timeout_sec:float ->


### PR DESCRIPTION
Closes #12248

## Why
- Current origin/main fails focused OCaml builds because keeper_exec_shell.mli requires rewrite_docker_host_paths_to_container, while keeper_exec_shell.ml only re-exports Keeper_shell_shared and Keeper_shell_shared.mli hides that implemented helper.
- This blocks unrelated PR validation that touches targets depending on keeper_exec_shell.

## Change
- Export the already-implemented rewrite_docker_host_paths_to_container helper from Keeper_shell_shared.mli so Keeper_exec_shell's facade include satisfies its public interface.

## Validation
- env DUNE_JOBS=1 DUNE_BUILD_DIR=.../_build-direct dune build --root ... lib/keeper/keeper_exec_shell.ml lib/keeper/keeper_shell_shared.mli test/test_keeper_bash_safety.exe test/test_keeper_exec_shell_cwd_response.exe
- ./_build-direct/default/test/test_keeper_bash_safety.exe (29 tests)
- ./_build-direct/default/test/test_keeper_exec_shell_cwd_response.exe (4 tests)
- git diff --check