### PR TITLE
refactor(telemetry): type tool-call error kinds

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -756,7 +756,9 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
      [Error_occurred] event for the previously-dead ADT variant. *)
   let telemetry_error_kind =
     if not success then
-      if !timeout_hit then Some "timeout" else Some "tool_failure"
+      Some
+        (Telemetry_eio.error_kind_of_string
+           (if !timeout_hit then "timeout" else "tool_failure"))
     else None
   in
   (* Track tool call in telemetry (controlled by MASC_TELEMETRY_ENABLED) *)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -88,7 +88,8 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
     | Some fs ->
         (try
            let telemetry_error_kind =
-             if success then None else Some "tool_failure"
+             if success then None
+             else Some (Telemetry_eio.error_kind_of_string "tool_failure")
            in
            Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success ~duration_ms
@@ -318,7 +319,8 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
     | Some fs ->
         (try
            let telemetry_error_kind =
-             if success then None else Some "tool_failure"
+             if success then None
+             else Some (Telemetry_eio.error_kind_of_string "tool_failure")
            in
            Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -4,6 +4,25 @@
 (** Config type alias *)
 type config = Coord_utils.config
 
+(** Tool-call error classification labels. *)
+type error_kind = Error_kind of string
+
+let error_kind_of_string value = Error_kind value
+let error_kind_to_string (Error_kind value) = value
+let error_kind_to_yojson kind = `String (error_kind_to_string kind)
+
+let error_kind_of_yojson = function
+  | `String value -> Ok (error_kind_of_string value)
+  | json ->
+      Error
+        (Printf.sprintf "Telemetry_eio.error_kind: expected string, got %s"
+           (Yojson.Safe.to_string json))
+
+let pp_error_kind fmt kind =
+  Format.pp_print_string fmt (error_kind_to_string kind)
+
+let show_error_kind = error_kind_to_string
+
 (** Telemetry event types *)
 type event =
   | Agent_joined of { agent_id: string; capabilities: string list }
@@ -21,7 +40,7 @@ type event =
       session_id: string option [@default None];
       operation_id: string option [@default None];
       worker_run_id: string option [@default None];
-      error_kind: string option [@default None];
+      error_kind: error_kind option [@default None];
       error_message: string option [@default None];
       exit_code: int option [@default None];
       stderr_excerpt: string option [@default None];
@@ -384,10 +403,19 @@ let nonempty_opt value =
       if trimmed = "" then None else Some trimmed
   | None -> None
 
+let nonempty_error_kind_opt value =
+  match value with
+  | Some kind ->
+      let trimmed = String.trim (error_kind_to_string kind) in
+      if trimmed = "" then None else Some (error_kind_of_string trimmed)
+  | None -> None
+
 let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
     ?source ?session_id ?operation_id ?worker_run_id ?error_kind
     ?error_message ?exit_code ?stderr_excerpt () =
-  let error_kind = if success then None else nonempty_opt error_kind in
+  let error_kind =
+    if success then None else nonempty_error_kind_opt error_kind
+  in
   let error_message = if success then None else nonempty_opt error_message in
   let exit_code = if success then None else exit_code in
   let stderr_excerpt =
@@ -412,7 +440,8 @@ let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
   if not success then
     match error_kind with
     | None -> ()
-    | Some trimmed_kind ->
+    | Some kind ->
+          let trimmed_kind = error_kind_to_string kind in
           let message =
             match error_message with
             | Some m -> m

--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -20,6 +20,13 @@ type config = Coord_utils.config
 
 (** {1 Events} *)
 
+(** Typed wrapper for tool-call error classification labels. JSONL rows
+    continue to encode [error_kind] as the stable string label. *)
+type error_kind = private Error_kind of string
+
+val error_kind_of_string : string -> error_kind
+val error_kind_to_string : error_kind -> string
+
 type event =
   | Agent_joined of { agent_id : string; capabilities : string list }
   | Agent_left of { agent_id : string; reason : string }
@@ -48,7 +55,7 @@ type event =
       session_id : string option; [@default None]
       operation_id : string option; [@default None]
       worker_run_id : string option; [@default None]
-      error_kind : string option; [@default None]
+      error_kind : error_kind option; [@default None]
       error_message : string option; [@default None]
       exit_code : int option; [@default None]
       stderr_excerpt : string option; [@default None]
@@ -186,7 +193,7 @@ val track_tool_called :
   ?session_id:string ->
   ?operation_id:string ->
   ?worker_run_id:string ->
-  ?error_kind:string ->
+  ?error_kind:error_kind ->
   ?error_message:string ->
   ?exit_code:int ->
   ?stderr_excerpt:string ->

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -13,6 +13,9 @@ module Telemetry_eio = Masc_mcp.Telemetry_eio
 module Coord = Masc_mcp.Coord
 module Prometheus = Masc_mcp.Prometheus
 
+let error_kind value = Telemetry_eio.error_kind_of_string value
+let error_kind_to_string = Telemetry_eio.error_kind_to_string
+
 let temp_dir () =
   let dir = Filename.temp_file "test_telemetry_eio_" "" in
   Unix.unlink dir;
@@ -111,7 +114,7 @@ let test_event_tool_called () =
     session_id = Some "mcp-session-1";
     operation_id = Some "op-1";
     worker_run_id = Some "run-1";
-    error_kind = Some "timeout";
+    error_kind = Some (error_kind "timeout");
     error_message = Some "timed out after 30s";
     exit_code = None;
     stderr_excerpt = None;
@@ -123,7 +126,8 @@ let test_event_tool_called () =
       check (option string) "session_id" (Some "mcp-session-1") r.session_id;
       check (option string) "operation_id" (Some "op-1") r.operation_id;
       check (option string) "worker_run_id" (Some "run-1") r.worker_run_id;
-      check (option string) "error_kind" (Some "timeout") r.error_kind;
+      check (option string) "error_kind" (Some "timeout")
+        (Option.map error_kind_to_string r.error_kind);
       check (option string) "error_message" (Some "timed out after 30s")
         r.error_message
   | _ -> fail "expected Tool_called"

--- a/test/test_telemetry_eio_pbt.ml
+++ b/test/test_telemetry_eio_pbt.ml
@@ -86,7 +86,7 @@ let gen_event : Telemetry_eio.event QCheck.Gen.t =
              session_id;
              operation_id;
              worker_run_id;
-             error_kind;
+             error_kind = Option.map Telemetry_eio.error_kind_of_string error_kind;
              error_message;
              exit_code;
              stderr_excerpt;
@@ -140,7 +140,7 @@ let saturated_tool_called : Telemetry_eio.event_record =
           session_id = Some "mcp-session";
           operation_id = Some "op-1";
           worker_run_id = Some "wr-1";
-          error_kind = Some "failure";
+          error_kind = Some (Telemetry_eio.error_kind_of_string "failure");
           error_message = Some "boom";
           exit_code = Some 1;
           stderr_excerpt = Some "...";

--- a/test/test_telemetry_error_occurred_wire_10358.ml
+++ b/test/test_telemetry_error_occurred_wire_10358.ml
@@ -35,6 +35,9 @@ open Alcotest
 open Masc_mcp
 module T = Telemetry_eio
 
+let error_kind value = T.error_kind_of_string value
+let error_kind_to_string = T.error_kind_to_string
+
 let make_config () =
   let dir = Filename.temp_file "telem_10358_" "" in
   Sys.remove dir;
@@ -93,7 +96,7 @@ let test_success_true_no_error_emit () =
   with_temp_config @@ fun config ->
   T.track_tool_called config ~tool_name:"masc_status"
     ~success:true ~duration_ms:5
-    ~error_kind:"timeout"
+    ~error_kind:(error_kind "timeout")
     ();
   let kinds = recent_events_kinds config 5 in
   check (list string)
@@ -122,7 +125,7 @@ let test_failure_with_error_kind_pairs () =
     ~agent_id:"keeper-executor-agent"
     ~source:"keeper_internal"
     ~session_id:"sess-10358"
-    ~error_kind:"timeout"
+    ~error_kind:(error_kind "timeout")
     ~error_message:"timeout=1|duration_ms=30000|detail=deadline"
     ();
   let kinds = recent_events_kinds config 5 in
@@ -136,7 +139,7 @@ let test_failure_with_error_kind_pairs () =
   with
   | { T.event = T.Tool_called tool; _ } :: _ ->
       check (option string) "Tool_called.error_kind"
-        (Some "timeout") tool.error_kind;
+        (Some "timeout") (Option.map error_kind_to_string tool.error_kind);
       check (option string) "Tool_called.error_message"
         (Some "timeout=1|duration_ms=30000|detail=deadline")
         tool.error_message
@@ -148,7 +151,7 @@ let test_whitespace_error_kind_no_pair () =
   with_temp_config @@ fun config ->
   T.track_tool_called config ~tool_name:"masc_status"
     ~success:false ~duration_ms:1
-    ~error_kind:"   "
+    ~error_kind:(error_kind "   ")
     ();
   let kinds = recent_events_kinds config 5 in
   check (list string)
@@ -161,7 +164,7 @@ let test_error_message_override_preserved () =
   with_temp_config @@ fun config ->
   T.track_tool_called config ~tool_name:"keeper_edit"
     ~success:false ~duration_ms:42
-    ~error_kind:"tool_failure"
+    ~error_kind:(error_kind "tool_failure")
     ~error_message:"file not found: /tmp/missing.ml"
     ();
   let records = T.read_all_events config in


### PR DESCRIPTION
Refs #11926

## Why
- C-T7.3 leaves telemetry tool-call error_kind as raw strings at the boundary.
- Keep the JSONL/wire value as a string, but type the in-process field so telemetry ingress cannot accidentally widen the raw string surface.

## Change
- Add private Telemetry_eio.error_kind plus conversion helpers.
- Change Tool_called.error_kind and track_tool_called ?error_kind to use the typed value.
- Preserve JSON encoding/decoding as strings for existing telemetry files and downstream consumers.
- Convert dispatch and keeper-stream call sites at telemetry ingress.
- Update telemetry coverage/PBT/wire tests to assert through the typed helper.

## Validation
- scripts/dune-local.sh build lib/telemetry_eio.ml lib/telemetry_eio.mli lib/mcp_server_eio_call_tool.ml lib/server/server_routes_http_keeper_stream.ml lib/local/worker_container.ml test/test_telemetry_eio_coverage.exe test/test_telemetry_error_occurred_wire_10358.exe test/test_telemetry_eio_pbt.exe test/test_worker_dev_tools.exe test/test_observability_provider_contracts.exe
- ./_build/default/test/test_telemetry_eio_coverage.exe (38 tests)
- ./_build/default/test/test_telemetry_error_occurred_wire_10358.exe (5 tests)
- ./_build/default/test/test_telemetry_eio_pbt.exe (3 tests)
- ./_build/default/test/test_worker_dev_tools.exe (120 tests)
- ./_build/default/test/test_observability_provider_contracts.exe (25 tests)
- git diff --check HEAD~1 HEAD
- rg raw error_kind:string signatures in lib/telemetry_eio.ml/.mli: no hits

## Note
- Earlier keeper facade build blocker #12248 is resolved on current origin/main by f45935c86c (#12169), so latest focused local validation now passes.