### PR TITLE
test: wire TLA literal parity across domains

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -8,13 +8,13 @@ include Keeper_config
 let keeper_debug = Env_config.KeeperRuntime.debug
 
 type sandbox_profile =
-  | Local [@tla.symbol "Local"]
+  | Local
     (** Host-process execution. Filesystem scope is bound to
         [~/me/.masc/playground/<keeper>/] (see [Playground_paths]).
         Network inherits the server's namespace. Intended for keepers
         whose work stays on local files and does not need container-grade
         isolation. *)
-  | Docker [@tla.symbol "Docker"]
+  | Docker
     (** Containerized execution with hardened defaults: cap-drop,
         no-new-privs, read-only rootfs, tmpfs, pids/memory limits.
         Network defaults to [Network_none]; the internal git/gh
@@ -22,9 +22,17 @@ type sandbox_profile =
         uses network egress plus read-only mounts from the selected
         root/keeper GitHub identity bundle for the duration of a git/gh
         command. *)
-[@@deriving tla]
-(** [@@deriving tla] generates [to_tla_symbol] / [all_symbols] /
-    [all_states] matching the [ProfileSet] string set declared in
+
+module Sandbox_profile_tla = struct
+  type t = sandbox_profile =
+    | Local [@tla.symbol "Local"]
+    | Docker [@tla.symbol "Docker"]
+  [@@deriving tla]
+end
+(** TLA+ dispatch symbols for {!sandbox_profile}. Kept in a submodule
+    so the generated [to_tla_symbol] / [all_symbols] / [all_states]
+    names cannot be shadowed by the separate [network_mode] deriver
+    below. Matches [ProfileSet] in
     [specs/boundary/SandboxDispatch.tla]. *)
 
 type network_mode =

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -36,6 +36,35 @@ type _ strategy =
   | Abort : { reason : string; cleanup : unit -> unit }
       -> [> `Abort ] strategy
 
+(* TLA+ taxonomy mirrors for specs/resilience/ResilienceDegradation.tla.
+   Payload-bearing constructors cannot use ppx_tla's [all_states], so
+   the exhaustive functions below are the typed contract and the lists
+   are the set surface consumed by parity tests. *)
+let error_mode_to_tla_symbol = function
+  | TransientError _ -> "Transient"
+  | PermanentError _ -> "Permanent"
+  | ResourceExhausted _ -> "ResourceExhausted"
+  | AmbiguityError _ -> "Ambiguity"
+  | ConsensusError _ -> "Consensus"
+  | DegradationRequired _ -> "Degradation"
+
+let all_error_mode_tla_symbols =
+  [ "Transient";
+    "Permanent";
+    "ResourceExhausted";
+    "Ambiguity";
+    "Consensus";
+    "Degradation";
+  ]
+
+let strategy_to_tla_symbol : type a. a strategy -> string = function
+  | Retry _ -> "Retry"
+  | Fallback _ -> "Fallback"
+  | Handoff _ -> "Handoff"
+  | Abort _ -> "Abort"
+
+let all_strategy_tla_symbols = [ "Retry"; "Fallback"; "Handoff"; "Abort" ]
+
 (* ── Convenience constructors ─────────────────────────────────── *)
 
 let transient ~detail ?(max_retries = 3) ?(backoff_ms = 200) () =

--- a/lib/resilience/recovery.mli
+++ b/lib/resilience/recovery.mli
@@ -116,6 +116,21 @@ type _ strategy =
   | Abort : { reason : string; cleanup : unit -> unit }
       -> [> `Abort ] strategy
 
+(** TLA+ symbol for {!error_mode}, matching
+    [specs/resilience/ResilienceDegradation.tla] [ErrorModes]. *)
+val error_mode_to_tla_symbol : error_mode -> string
+
+(** Complete TLA+ [ErrorModes] mirror for payload-bearing
+    {!error_mode} constructors. *)
+val all_error_mode_tla_symbols : string list
+
+(** TLA+ symbol for {!strategy}, matching
+    [specs/resilience/ResilienceDegradation.tla] [Strategies]. *)
+val strategy_to_tla_symbol : 'a strategy -> string
+
+(** Complete TLA+ [Strategies] mirror for {!strategy}. *)
+val all_strategy_tla_symbols : string list
+
 (** {1 Heuristic classification} *)
 
 val classify_string : string -> error_mode

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-04-30T09:32:44Z (HEAD: f975e0f4bd)
+Generated: 2026-04-30T10:05:39Z (HEAD: 54b91fd4e9)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -54,7 +54,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | Cancellation.tla | Cancellation | manual | 2 | 1 | clean={inv:TypeOK, inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} buggy={inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} | 834dcb495e5a |
 | CascadeKeeperRecovery.tla | CascadeKeeperRecovery | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 370581910533 |
 | CascadeResolver.tla | CascadeResolver | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:NeverRouteToDown} | e0c5a7d1d999 |
-| CascadeStrategy.tla | CascadeStrategy | manual | 2 | 1 | clean={inv:Safety} buggy={inv:BoundedCycle} | fecb35cea4e9 |
+| CascadeStrategy.tla | CascadeStrategy | manual | 2 | 1 | clean={inv:Safety} buggy={inv:BoundedCycle} | 004523df4adf |
 | CascadeStrategyStateful.tla | CascadeStrategyStateful | manual | 2 | 1 | clean={inv:TypeOK, inv:StickyDomainBounded, inv:StickyMembersAreCandidates, inv:RRBounded, inv:NoExpiredEntriesUsable, prop:StickyEventuallyEvicts} buggy={inv:TypeOK, inv:StickyDomainBounded, inv:StickyMembersAreCandidates, inv:RRBounded, inv:NoExpiredEntriesUsable, prop:StickyEventuallyEvicts} | 3e154032b46f |
 | KeeperContinueGate.tla | KeeperContinueGate | manual | 2 | 1 | clean={inv:Safety, prop:PendingEventuallyResolves} buggy={inv:ApprovedResolutionClearsFailure} | 7f71fad0d4cb |
 | KeeperContractViolated.tla | KeeperContractViolated | manual | 2 | 1 | clean={inv:Safety} buggy={inv:Safety} | 65324331c483 |

--- a/specs/boundary/CascadeStrategy.tla
+++ b/specs/boundary/CascadeStrategy.tla
@@ -45,6 +45,13 @@ VARIABLES
 vars == << cycle, attempted, outcome, accepted_provider >>
 
 OutcomeSet == {"in_progress", "accepted", "exhausted"}
+\* Runtime strategy taxonomy mirror pinned by the OCaml/TLA parity
+\* test. The model below abstracts over candidate ordering, but the
+\* exported strategy kind set still must not drift from
+\* lib/cascade/cascade_strategy.ml.
+StrategyKindSet == {"failover", "capacity_aware", "weighted_random",
+                    "circuit_breaker_cycling", "priority_tier",
+                    "sticky", "round_robin"}
 NoneProvider == "_none_"
 ASSUME NoneProvider \notin Candidates
 

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -75,3 +75,96 @@ let find_project_root () =
         walk parent
   in
   walk start_dir
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let n = in_channel_length ic in
+      really_input_string ic n)
+
+let tla_quoted_strings content =
+  let re = Str.regexp "\"\\([^\"]*\\)\"" in
+  let acc = ref [] in
+  let pos = ref 0 in
+  let keep_scanning = ref true in
+  while !keep_scanning do
+    match Str.search_forward re content !pos with
+    | exception Not_found -> keep_scanning := false
+    | _ ->
+        acc := Str.matched_group 1 content :: !acc;
+        pos := Str.match_end ()
+  done;
+  List.rev !acc
+
+let tla_find_quoted_set ~symbol content =
+  let header = symbol ^ " ==" in
+  let len = String.length content in
+  let hlen = String.length header in
+  let rec find_header i =
+    if i + hlen > len then None
+    else if String.sub content i hlen = header then Some (i + hlen)
+    else find_header (i + 1)
+  in
+  let rec find_matching_brace depth i =
+    if i >= len then None
+    else
+      match content.[i] with
+      | '{' -> find_matching_brace (depth + 1) (i + 1)
+      | '}' ->
+          let depth = depth - 1 in
+          if depth = 0 then Some i else find_matching_brace depth (i + 1)
+      | _ -> find_matching_brace depth (i + 1)
+  in
+  match find_header 0 with
+  | None -> None
+  | Some after_header -> (
+      match String.index_from_opt content after_header '{' with
+      | None -> None
+      | Some open_brace -> (
+          match find_matching_brace 0 open_brace with
+          | None -> None
+          | Some close_brace ->
+              let body =
+                String.sub content open_brace
+                  (close_brace - open_brace + 1)
+              in
+              Some (tla_quoted_strings body)))
+
+let tla_quoted_set_exn ?(source = "<tla>") ~symbol content =
+  match tla_find_quoted_set ~symbol content with
+  | Some values -> values
+  | None ->
+      failwith
+        (Printf.sprintf
+           "%s not found in %s; set definition may have moved or been \
+            renamed."
+           symbol source)
+
+let tla_quoted_set_from_repo_file_exn ~relpath ~symbol =
+  let path = Filename.concat (find_project_root ()) relpath in
+  tla_quoted_set_exn ~source:relpath ~symbol (read_file path)
+
+let sorted_strings = List.sort String.compare
+
+let assert_same_string_set ~label ~expected ~actual =
+  let expected = sorted_strings expected in
+  let actual = sorted_strings actual in
+  if actual <> expected then begin
+    Printf.printf "Expected %s : [%s]\n" label
+      (String.concat "; " expected);
+    Printf.printf "Actual   %s : [%s]\n" label
+      (String.concat "; " actual);
+    let only_expected =
+      List.filter (fun s -> not (List.mem s actual)) expected
+    in
+    let only_actual =
+      List.filter (fun s -> not (List.mem s expected)) actual
+    in
+    Printf.printf "Only expected : [%s]\n"
+      (String.concat "; " only_expected);
+    Printf.printf "Only actual   : [%s]\n"
+      (String.concat "; " only_actual);
+    failwith (label ^ " differs")
+  end

--- a/test/dune
+++ b/test/dune
@@ -441,6 +441,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_tla_literal_parity)
+ (modules test_tla_literal_parity)
+ (libraries masc_test_deps autonomous resilience))
+
+(test
  (name test_keeper_receipt_authoritative)
  (modules test_keeper_receipt_authoritative)
  (libraries masc_test_deps))

--- a/test/test_keeper_receipt_outcome_tla_parity.ml
+++ b/test/test_keeper_receipt_outcome_tla_parity.ml
@@ -12,95 +12,17 @@
 
 (* ── TLA+ spec parsing ───────────────────────────────────────
 
-   Read [ReceiptOutcomeSet] directly out of [KeeperTurnFSM.tla].
-   Removes the previous hand-maintained copy (which carried the
-   TODO "a future cycle may parse the .tla file directly so this
-   list is no longer a second source of truth"). Same parser
-   pattern as [test_keeper_state_machine_correspondence] for
-   KeeperStateMachine. *)
-
-let rec find_repo_root dir =
-  let candidate =
-    Filename.concat dir "specs/keeper-turn-fsm/KeeperTurnFSM.tla"
-  in
-  if Sys.file_exists candidate then dir
-  else
-    let parent = Filename.dirname dir in
-    if String.equal parent dir then
-      failwith "could not find repo root for KeeperTurnFSM.tla"
-    else find_repo_root parent
-
-let project_root () =
-  match Sys.getenv_opt "DUNE_SOURCEROOT" with
-  | Some root -> root
-  | None -> find_repo_root (Filename.dirname Sys.executable_name)
-
-let read_file path =
-  let ic = open_in path in
-  let n = in_channel_length ic in
-  let s = really_input_string ic n in
-  close_in ic;
-  s
-
-(** Locate [Name == { "...", "...", ... }] set literal in TLA+ text
-    and extract every quoted-string element. Walks from the opening
-    brace to the next closing brace, then collects all
-    [Str.regexp "\"\\([^\"]*\\)\""] hits. Returns [None] if absent. *)
-let find_quoted_set ~symbol content =
-  let header = symbol ^ " ==" in
-  let len = String.length content in
-  let hlen = String.length header in
-  let rec idx i =
-    if i + hlen > len then None
-    else if String.sub content i hlen = header then Some (i + hlen)
-    else idx (i + 1)
-  in
-  match idx 0 with
-  | None -> None
-  | Some after_header ->
-      (match String.index_from_opt content after_header '{' with
-       | None -> None
-       | Some open_brace ->
-           (match String.index_from_opt content open_brace '}' with
-            | None -> None
-            | Some close_brace ->
-                let body =
-                  String.sub content open_brace
-                    (close_brace - open_brace + 1)
-                in
-                let re = Str.regexp "\"\\([^\"]*\\)\"" in
-                let acc = ref [] in
-                let pos = ref 0 in
-                let go = ref true in
-                while !go do
-                  match Str.search_forward re body !pos with
-                  | exception Not_found -> go := false
-                  | _ ->
-                      acc := Str.matched_group 1 body :: !acc;
-                      pos := Str.match_end ()
-                done;
-                Some (List.rev !acc)))
+   Read [ReceiptOutcomeSet] directly out of [KeeperTurnFSM.tla],
+   using the shared parser from [Masc_test_deps]. *)
 
 (** Mechanically extract [ReceiptOutcomeSet] from the spec, then drop
     ["receipt_unset"] — initial-state-only marker, not representable
     on a terminal receipt per [EveryTurnHasTerminalReceipt]. *)
 let spec_terminal_outcome_set : string list =
-  let path =
-    Filename.concat
-      (project_root ())
-      "specs/keeper-turn-fsm/KeeperTurnFSM.tla"
-  in
-  let content = read_file path in
-  match find_quoted_set ~symbol:"ReceiptOutcomeSet" content with
-  | None ->
-      failwith
-        "ReceiptOutcomeSet not found in \
-         specs/keeper-turn-fsm/KeeperTurnFSM.tla — set definition may \
-         have moved or been renamed."
-  | Some outcomes ->
-      List.filter
-        (fun s -> not (String.equal s "receipt_unset"))
-        outcomes
+  Masc_test_deps.tla_quoted_set_from_repo_file_exn
+    ~relpath:"specs/keeper-turn-fsm/KeeperTurnFSM.tla"
+    ~symbol:"ReceiptOutcomeSet"
+  |> List.filter (fun s -> not (String.equal s "receipt_unset"))
 
 (* The four [outcome_kind] terminal variants mapped to their TLA+
    receipt symbols.  This is not a blind prefix: the JSON boundary keeps
@@ -111,7 +33,7 @@ let ocaml_terminal_outcome_set =
     Masc_mcp.Keeper_execution_receipt.outcome_kind_to_tla_receipt
     [ `Ok; `Skipped; `Error; `Cancelled ]
 
-let sort = List.sort String.compare
+let sort = Masc_test_deps.sorted_strings
 
 let test_terminal_set_parity () =
   let ocaml = sort ocaml_terminal_outcome_set in

--- a/test/test_keeper_turn_fsm_tla_parity.ml
+++ b/test/test_keeper_turn_fsm_tla_parity.ml
@@ -15,109 +15,23 @@
 
 (* ── TLA+ spec parsing ───────────────────────────────────────
 
-   Read [TurnStateSet] directly out of [KeeperTurnFSM.tla]. Removes
-   the previous hand-maintained copy (which carried the TODO
-   "Cycle 3+ may parse the .tla file directly so this list is no
-   longer a second source of truth"). Same parser pattern as
-   [test_keeper_receipt_outcome_tla_parity] for the sibling
-   [ReceiptOutcomeSet]. *)
-
-let rec find_repo_root dir =
-  let candidate =
-    Filename.concat dir "specs/keeper-turn-fsm/KeeperTurnFSM.tla"
-  in
-  if Sys.file_exists candidate then dir
-  else
-    let parent = Filename.dirname dir in
-    if String.equal parent dir then
-      failwith "could not find repo root for KeeperTurnFSM.tla"
-    else find_repo_root parent
-
-let project_root () =
-  match Sys.getenv_opt "DUNE_SOURCEROOT" with
-  | Some root -> root
-  | None -> find_repo_root (Filename.dirname Sys.executable_name)
-
-let read_file path =
-  let ic = open_in path in
-  let n = in_channel_length ic in
-  let s = really_input_string ic n in
-  close_in ic;
-  s
-
-(** Locate [Name == { "...", "...", ... }] set literal in TLA+ text
-    and extract every quoted-string element. Walks from the opening
-    brace to the next closing brace, then collects every
-    [Str.regexp "\"\\([^\"]*\\)\""] hit. Returns [None] if absent. *)
-let find_quoted_set ~symbol content =
-  let header = symbol ^ " ==" in
-  let len = String.length content in
-  let hlen = String.length header in
-  let rec idx i =
-    if i + hlen > len then None
-    else if String.sub content i hlen = header then Some (i + hlen)
-    else idx (i + 1)
-  in
-  match idx 0 with
-  | None -> None
-  | Some after_header ->
-      (match String.index_from_opt content after_header '{' with
-       | None -> None
-       | Some open_brace ->
-           (match String.index_from_opt content open_brace '}' with
-            | None -> None
-            | Some close_brace ->
-                let body =
-                  String.sub content open_brace
-                    (close_brace - open_brace + 1)
-                in
-                let re = Str.regexp "\"\\([^\"]*\\)\"" in
-                let acc = ref [] in
-                let pos = ref 0 in
-                let go = ref true in
-                while !go do
-                  match Str.search_forward re body !pos with
-                  | exception Not_found -> go := false
-                  | _ ->
-                      acc := Str.matched_group 1 body :: !acc;
-                      pos := Str.match_end ()
-                done;
-                Some (List.rev !acc)))
+   Read state sets directly out of [KeeperTurnFSM.tla], using the
+   shared test helper so every parity test has the same set parser. *)
 
 let spec_turn_state_set : string list =
-  let path =
-    Filename.concat
-      (project_root ())
-      "specs/keeper-turn-fsm/KeeperTurnFSM.tla"
-  in
-  let content = read_file path in
-  match find_quoted_set ~symbol:"TurnStateSet" content with
-  | None ->
-      failwith
-        "TurnStateSet not found in \
-         specs/keeper-turn-fsm/KeeperTurnFSM.tla — set definition may \
-         have moved or been renamed."
-  | Some states -> states
+  Masc_test_deps.tla_quoted_set_from_repo_file_exn
+    ~relpath:"specs/keeper-turn-fsm/KeeperTurnFSM.tla"
+    ~symbol:"TurnStateSet"
 
 let spec_quoted_set symbol : string list =
-  let path =
-    Filename.concat
-      (project_root ())
-      "specs/keeper-turn-fsm/KeeperTurnFSM.tla"
-  in
-  let content = read_file path in
-  match find_quoted_set ~symbol content with
-  | None ->
-      failwith
-        (symbol
-        ^ " not found in specs/keeper-turn-fsm/KeeperTurnFSM.tla — set \
-           definition may have moved or been renamed.")
-  | Some states -> states
+  Masc_test_deps.tla_quoted_set_from_repo_file_exn
+    ~relpath:"specs/keeper-turn-fsm/KeeperTurnFSM.tla"
+    ~symbol
 
 let spec_active_state_set = spec_quoted_set "ActiveStateSet"
 let spec_terminal_state_set = spec_quoted_set "TerminalStateSet"
 
-let sort = List.sort String.compare
+let sort = Masc_test_deps.sorted_strings
 
 let test_all_symbols_match_spec () =
   let ocaml = sort Masc_mcp.Keeper_turn_fsm.all_symbols in
@@ -140,13 +54,8 @@ let test_all_symbols_match_spec () =
   end
 
 let check_symbol_set ~label ~ocaml ~spec =
-  let ocaml = sort ocaml in
-  let spec = sort spec in
-  if ocaml <> spec then begin
-    Printf.printf "OCaml %s : [%s]\n" label (String.concat "; " ocaml);
-    Printf.printf "Spec  %s : [%s]\n" label (String.concat "; " spec);
-    failwith ("Keeper_turn_fsm " ^ label ^ " differs from TLA+ spec")
-  end
+  Masc_test_deps.assert_same_string_set
+    ~label:("Keeper_turn_fsm " ^ label) ~expected:spec ~actual:ocaml
 
 let test_classified_symbols_match_spec () =
   check_symbol_set ~label:"active_symbols"

--- a/test/test_tla_literal_parity.ml
+++ b/test/test_tla_literal_parity.ml
@@ -1,0 +1,108 @@
+(* Cross-domain TLA literal parity.
+
+   These checks pin TLA+ string sets to the OCaml symbol surfaces that
+   own the corresponding runtime taxonomy. A constructor or spec literal
+   added on only one side should fail here before it becomes operator
+   documentation drift. *)
+
+module T = Masc_test_deps
+
+let set relpath symbol =
+  T.tla_quoted_set_from_repo_file_exn ~relpath ~symbol
+
+let assert_set ~label ~expected ~actual =
+  T.assert_same_string_set ~label ~expected ~actual
+
+let test_multimodal_artifact () =
+  assert_set ~label:"MultimodalArtifact.Kinds"
+    ~expected:
+      (set "specs/multimodal/MultimodalArtifact.tla" "Kinds")
+    ~actual:
+      (List.map Multimodal.Artifact.kind_tag_to_string
+         Multimodal.Artifact.all_kind_tags)
+
+let payload_kind = function
+  | `Assoc fields -> (
+      match List.assoc_opt "kind" fields with
+      | Some (`String kind) -> kind
+      | Some _ | None -> failwith "payload JSON missing string kind field")
+  | _ -> failwith "payload JSON is not an object"
+
+let test_multimodal_payload () =
+  let actual =
+    [ Multimodal.Payload.Lazy_payload (fun () -> "lazy");
+      Multimodal.Payload.Blob_ref "blob://probe";
+      Multimodal.Payload.Streaming 42;
+    ]
+    |> List.map (fun payload -> payload_kind (Multimodal.Payload.to_json payload))
+  in
+  assert_set ~label:"MultimodalArtifact.PayloadKinds"
+    ~expected:
+      (set "specs/multimodal/MultimodalArtifact.tla" "PayloadKinds")
+    ~actual
+
+let test_resilience_degradation () =
+  assert_set ~label:"ResilienceDegradation.Levels"
+    ~expected:(set "specs/resilience/ResilienceDegradation.tla" "Levels")
+    ~actual:Resilience.Degradation.all_symbols;
+  assert_set ~label:"ResilienceDegradation.TerminalLevels"
+    ~expected:[ "L4" ]
+    ~actual:Resilience.Degradation.terminal_symbols;
+  assert_set ~label:"ResilienceDegradation.ErrorModes"
+    ~expected:
+      (set "specs/resilience/ResilienceDegradation.tla" "ErrorModes")
+    ~actual:Resilience.Recovery.all_error_mode_tla_symbols;
+  assert_set ~label:"ResilienceDegradation.Strategies"
+    ~expected:
+      (set "specs/resilience/ResilienceDegradation.tla" "Strategies")
+    ~actual:Resilience.Recovery.all_strategy_tla_symbols
+
+let test_autonomous_phase () =
+  assert_set ~label:"AutonomousPhase.Phases"
+    ~expected:(set "specs/autonomous/AutonomousPhase.tla" "Phases")
+    ~actual:Autonomous.Autonomous_phase.all_symbols;
+  assert_set ~label:"AutonomousLoop.AutoPhases"
+    ~expected:(set "specs/autonomous/AutonomousLoop.tla" "AutoPhases")
+    ~actual:Autonomous.Autonomous_phase.all_symbols
+
+let pairs_to_transition_symbols values =
+  let rec loop acc = function
+    | from_ :: to_ :: rest -> loop ((from_ ^ "->" ^ to_) :: acc) rest
+    | [] -> List.rev acc
+    | [ dangling ] ->
+        failwith
+          (Printf.sprintf
+             "LegalTransitions has an odd quoted-string count; dangling %S"
+             dangling)
+  in
+  loop [] values
+
+let test_autonomous_transitions () =
+  let expected =
+    set "specs/autonomous/AutonomousPhase.tla" "LegalTransitions"
+    |> pairs_to_transition_symbols
+  in
+  assert_set ~label:"AutonomousPhase.LegalTransitions"
+    ~expected
+    ~actual:Autonomous.Autonomous_phase.Transition.all_symbols
+
+let test_cascade_strategy () =
+  assert_set ~label:"CascadeStrategy.StrategyKindSet"
+    ~expected:
+      (set "specs/boundary/CascadeStrategy.tla" "StrategyKindSet")
+    ~actual:Masc_mcp.Cascade_strategy.all_symbols
+
+let test_sandbox_dispatch_profile () =
+  assert_set ~label:"SandboxDispatch.ProfileSet"
+    ~expected:(set "specs/boundary/SandboxDispatch.tla" "ProfileSet")
+    ~actual:Masc_mcp.Keeper_types_profile.Sandbox_profile_tla.all_symbols
+
+let () =
+  test_multimodal_artifact ();
+  test_multimodal_payload ();
+  test_resilience_degradation ();
+  test_autonomous_phase ();
+  test_autonomous_transitions ();
+  test_cascade_strategy ();
+  test_sandbox_dispatch_profile ();
+  print_endline "test_tla_literal_parity: OK"


### PR DESCRIPTION
## Summary

- Add a shared TLA quoted-set parser to `Masc_test_deps` and reuse it in existing keeper parity tests.
- Add `test_tla_literal_parity` to pin multimodal, resilience, autonomous, cascade, and sandbox TLA literal sets to the OCaml symbol surfaces.
- Move `sandbox_profile` TLA symbols into `Sandbox_profile_tla` to avoid generated helper shadowing by `network_mode`.
- Add `CascadeStrategy.StrategyKindSet` plus resilience TLA taxonomy helpers for payload-bearing error/strategy types.

## Product impact

This makes the TLA specs less decorative: drift in key operator-facing taxonomies now fails in Dune instead of surviving as stale comments or manual literals.

## Evidence

- `scripts/dune-local.sh exec ./test/test_tla_literal_parity.exe`
- `scripts/dune-local.sh exec ./test/test_keeper_turn_fsm_tla_parity.exe`
- `scripts/dune-local.sh exec ./test/test_keeper_receipt_outcome_tla_parity.exe`
- `scripts/dune-local.sh exec ./test/resilience/test_recovery.exe`
- `scripts/dune-local.sh exec ./test/resilience/test_degradation.exe`
- `scripts/tla-ppx-ratchet.sh --print`
- `scripts/ci/check-tla-variant-sync.sh`
- `bash scripts/ci/check-tla-harness-coverage.sh`
- `env TLA2TOOLS=/Users/dancer/me/tools/tla2tools.jar make -C specs check-boundary`
- `scripts/gen-tla-index.sh > /tmp/INDEX...` + diff against committed `specs/INDEX.md` ignoring `Generated:`

## Review evidence

Focus review on whether each TLA set is owned by the right runtime symbol surface, especially `Sandbox_profile_tla`, `Recovery.*_tla_symbols`, and the new `StrategyKindSet`.

## Linked issue

None.
