### PR TITLE
feat(dashboard): migrate safe-autonomy KpiStrip to Solid island (RFC 0017 PR #5)

### DIFF
--- a/dashboard/src/components/safe-autonomy.ts
+++ b/dashboard/src/components/safe-autonomy.ts
@@ -7,8 +7,7 @@ import { Card } from './common/card'
 import { JsonViewerCard } from './common/json-viewer'
 import { EmptyState } from './common/empty-state'
 import { KeeperBadge } from './keeper-badge'
-import { KpiCell } from './kpi-cell'
-import { KpiStrip } from './kpi-strip'
+import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
 import { formatTimeAgo } from '../lib/format-time'
 import {
   asBoolean,
@@ -265,14 +264,18 @@ function KeeperCard({ item }: { item: KeeperItem }) {
             : null}
         </div>
         <div class="text-xs lg:min-w-[220px]">
-          <${KpiStrip} ariaLabel="domain 통계" cols=${2}>
-            <${KpiCell} variant="stacked" label="score" value=${item.score.toFixed(1)} />
-            <${KpiCell} variant="stacked" label="approvals" value=${item.approval_pending_count} />
-            <${KpiCell} variant="stacked" label="turns" value=${item.total_turns} />
-            <${KpiCell} variant="stacked" label="activity" value=${item.recent_activity_count} />
-            <${KpiCell} variant="stacked" label="history" value=${item.trace_history_count} />
-            <${KpiCell} variant="stacked" label="task" value=${item.current_task_id ?? 'none'} />
-          <//>
+          <${KpiStripIsland}
+            ariaLabel="domain 통계"
+            cols=${2}
+            cells=${[
+              { variant: 'stacked', label: 'score', value: item.score.toFixed(1) },
+              { variant: 'stacked', label: 'approvals', value: item.approval_pending_count },
+              { variant: 'stacked', label: 'turns', value: item.total_turns },
+              { variant: 'stacked', label: 'activity', value: item.recent_activity_count },
+              { variant: 'stacked', label: 'history', value: item.trace_history_count },
+              { variant: 'stacked', label: 'task', value: item.current_task_id ?? 'none' },
+            ] satisfies KpiStripIslandData['cells']}
+          />
         </div>
       </div>
     </div>
@@ -407,14 +410,18 @@ export function SafeAutonomyPanel() {
                       generated ${data.generated_at ? formatTimeAgo(data.generated_at) : '정보 없음'}
                     </div>
                   </div>
-                  <${KpiStrip} ariaLabel="safe-autonomy 요약" cols=${4}>
-                    <${KpiCell} variant="stacked" label="keepers" value=${data.summary.keeper_count} />
-                    <${KpiCell} variant="stacked" label="active goals" value=${data.summary.active_goal_count} />
-                    <${KpiCell} variant="stacked" label="findings" value=${data.summary.findings_total} />
-                    <${KpiCell} variant="stacked" label="human queue" value=${data.summary.human_action_required_count} />
-                    <${KpiCell} variant="stacked" label="with task" value=${data.summary.keepers_with_current_task} />
-                    <${KpiCell} variant="stacked" label="approval depth" value=${data.summary.approval_queue_depth} />
-                  <//>
+                  <${KpiStripIsland}
+                    ariaLabel="safe-autonomy 요약"
+                    cols=${4}
+                    cells=${[
+                      { variant: 'stacked', label: 'keepers', value: data.summary.keeper_count },
+                      { variant: 'stacked', label: 'active goals', value: data.summary.active_goal_count },
+                      { variant: 'stacked', label: 'findings', value: data.summary.findings_total },
+                      { variant: 'stacked', label: 'human queue', value: data.summary.human_action_required_count },
+                      { variant: 'stacked', label: 'with task', value: data.summary.keepers_with_current_task },
+                      { variant: 'stacked', label: 'approval depth', value: data.summary.approval_queue_depth },
+                    ] satisfies KpiStripIslandData['cells']}
+                  />
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary

RFC 0017 PR #5 — second production caller migration. \`safe-autonomy.ts\` now uses \`KpiStripIsland\` for both of its KPI strips. **Validates PR #4's amortisation claim**: the solid chunk size doesn't grow between PR #4 and PR #5.

## What lands

| Location | Before | After |
|----------|--------|-------|
| DomainCard inner strip (cols=2, 6 cells, rendered N×) | \`<\${KpiStrip}><\${KpiCell}>...\` | \`<\${KpiStripIsland} cells=\${[...]} />\` |
| Top-level summary strip (cols=4, 6 cells, ×1) | \`<\${KpiStrip}><\${KpiCell}>...\` | \`<\${KpiStripIsland} cells=\${[...]} />\` |
| Imports | \`KpiCell\`, \`KpiStrip\` | \`KpiStripIsland\`, \`KpiStripIslandData\` |

## Bundle delta

| Chunk | PR #4 (main) | PR #5 | Δ |
|-------|--------------|-------|---|
| \`solid-*.js\` | **9.3 KB** | **9.3 KB** | **0 B** |
| \`safe-autonomy-*.js\` | (~unchanged) | 12 KB | wrapper import only |
| \`index-*.js\` | 200 KB | 200 KB | 0 |

Confirms RFC 0017 §7 amortisation: solid runtime + KpiStrip/Cell/Bar are paid once in PR #4. Each additional caller pays only the small Preact wrapper import in its own route chunk.

## Why no new tests

\`safe-autonomy.ts\` has no existing test coverage to mirror. The migration is verified by:
- \`pnpm typecheck\` green
- \`KpiStripIsland\` integration tests (already merged in PR #4) — same wrapper exercised
- \`pnpm build\` success
- Manual visual smoke: pending dev-server pass before un-Drafting

## List iteration first proof

DomainCard renders one Solid island **per domain row**. \`data.domains.map(item => html\`<\${DomainCard} item=\${item} />\`)\` therefore mounts and disposes multiple Solid roots within a single Preact list. This is the first production exercise of that lifecycle pattern. Build success + typecheck green is the static evidence; runtime correctness is covered by PR #4's integration tests (mount, prop sync, unmount disposal).

## Verification

| Step | Result |
|------|--------|
| \`pnpm typecheck\` | green |
| \`vitest --config vitest.solid.config.ts\` | **128/128 pass** |
| \`pnpm build\` | success; bundle table above |
| \`vitest --config vitest.config.ts\` | 5132/5134 pass; 2 fail in \`auth-status.test.ts\` focus-trap (passes in isolation, **pre-existing happy-dom flake unrelated to KpiStrip**) |

## Out of scope (next PRs)

- governance.ts (9 KpiStrip/Cell refs)
- harness-health.ts (15 refs, 3 nested strips)
- connector-status.ts (7 refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)