### PR TITLE
fix: classify kimi cli startup crashes

### DIFF
--- a/lib/keeper/keeper_agent_checkpoint_hygiene.mli
+++ b/lib/keeper/keeper_agent_checkpoint_hygiene.mli
@@ -44,6 +44,10 @@ val prepare_resume_checkpoint_for_dispatch :
 
     1. Forces a fresh compaction evaluation by overriding
        [meta.compaction.cooldown_sec] to [0].
+       The evaluation is scoped to restored checkpoint/history state.
+       Fresh turn substrate such as the system prompt, tool catalog, and
+       current user assignment is measured by wake-payload telemetry but
+       is not checkpoint history that this function can compact.
     2. Calls {!Keeper_compact_policy.compact_if_needed_typed}; populates
        [before_tokens] / [after_tokens] / [trigger] / [decision] from
        the result.

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -237,11 +237,50 @@ let operator_disposition (receipt : t) =
   let error_kind =
     Option.map String.lowercase_ascii receipt.error_kind
   in
+  let provider_runtime_failure =
+    String.starts_with ~prefix:"api_error_" terminal_reason
+    || String.equal terminal_reason "provider_error"
+    ||
+    (match error_kind with
+     | Some
+         ( "api"
+         | "mcp"
+         | "io"
+         | "orchestration"
+         | "serialization" ) ->
+         true
+     | Some _ | None -> false)
+  in
+  let preflight_config_failure =
+    match error_kind with
+    | Some kind ->
+        string_contains_ci kind "config"
+        || string_contains_ci kind "auth"
+        || string_contains_ci terminal_reason "config"
+        || string_contains_ci terminal_reason "auth"
+    | None ->
+        string_contains_ci terminal_reason "config"
+        || string_contains_ci terminal_reason "auth"
+  in
   if
     String.equal terminal_reason "cascade_exhausted"
     || String.equal cascade_outcome "cascade_exhausted"
     || String.equal cascade_outcome "exhausted"
   then ("alert_exhausted", "cascade_exhausted")
+  else if preflight_config_failure then
+    ("pause_human", "preflight_config_error")
+  else if
+    provider_runtime_failure
+    && (receipt.degraded_retry_applied
+        || Option.is_some receipt.degraded_retry_cascade)
+  then ("fail_open_next_cascade", "degraded_retry")
+  else if
+    provider_runtime_failure
+    && (receipt.cascade_fallback_applied
+        || String.equal cascade_outcome "passed_to_next_model")
+  then ("pass_next_model", "cascade_fallback")
+  else if provider_runtime_failure then
+    ("pause_human", "provider_runtime_error")
   else if
     String.equal receipt.tool_surface.tool_requirement "required"
     && (List.mem tool_contract_result
@@ -257,17 +296,6 @@ let operator_disposition (receipt : t) =
           ]
         || receipt.tools_used = [])
   then ("pause_human", "tool_required_unsatisfied")
-  else if
-    match error_kind with
-    | Some kind ->
-        string_contains_ci kind "config"
-        || string_contains_ci kind "auth"
-        || string_contains_ci terminal_reason "config"
-        || string_contains_ci terminal_reason "auth"
-    | None ->
-        string_contains_ci terminal_reason "config"
-        || string_contains_ci terminal_reason "auth"
-  then ("pause_human", "preflight_config_error")
   else if receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_cascade
   then ("fail_open_next_cascade", "degraded_retry")
   else if

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -178,17 +178,31 @@ let prepare_run_context
            ~detail:("pre-dispatch checkpoint compaction save failed: " ^ detail))
     | None -> None
   in
-  (if checkpoint_hygiene.applied then
+  (let decision =
+     Option.value
+       ~default:
+         (Keeper_compact_policy.compaction_decision_to_string
+            checkpoint_hygiene.decision)
+       checkpoint_hygiene.trigger
+   in
+   let before_ratio =
+     if max_context <= 0 then 0.0
+     else float_of_int checkpoint_hygiene.before_tokens /. float_of_int max_context
+   in
+   if checkpoint_hygiene.applied then
      Log.Keeper.info
-       "%s: pre-dispatch compaction %s trigger=%s tokens=%d->%d max_context=%d"
+       "%s: pre-dispatch compaction %s trigger=%s tokens=%d->%d \
+        max_context=%d ratio=%.4f checkpoint=%b"
        meta.name
        (if checkpoint_hygiene.meaningful_reduction then "applied" else "attempted")
-       (Option.value
-          ~default:
-            (Keeper_compact_policy.compaction_decision_to_string
-               checkpoint_hygiene.decision)
-          checkpoint_hygiene.trigger)
-       checkpoint_hygiene.before_tokens checkpoint_hygiene.after_tokens max_context);
+       decision checkpoint_hygiene.before_tokens checkpoint_hygiene.after_tokens
+       max_context before_ratio loaded_checkpoint_present
+   else
+     Log.Keeper.info
+       "%s: pre-dispatch compaction skipped decision=%s tokens=%d \
+        max_context=%d ratio=%.4f checkpoint=%b"
+       meta.name decision checkpoint_hygiene.before_tokens max_context before_ratio
+       loaded_checkpoint_present);
   let start_turn_count =
     match resume_oas_checkpoint with
     | Some cp -> cp.turn_count

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -69,9 +69,10 @@ module Http_client = struct
          - kimi_cli exit 1: [transport_kimi_cli.ml] labels this
            "permanent auth/config/model error". The auth/config is specific
            to Moonshot; claude/gpt/ollama providers are unaffected.
-         - gemini_cli startup crash: [transport_gemini_cli.ml] explicitly
-           marks the AcceptRejected with "rejecting without retry so the
-           cascade can move on".
+         - gemini_cli startup crash and kimi_cli process-title
+           UnicodeDecodeError: the CLI source explicitly marks the
+           AcceptRejected with "rejecting without retry so the cascade can
+           move on".
      (b) Provider capability mismatches wrapped by MASC's worker layer at
          [oas_worker_named.ml:672-678] (InvalidConfig runtime_mcp_auth /
          tool_support). The detail string is built in

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -66,8 +66,9 @@ module Http_client : sig
         (documented at [oas_worker_named.ml:661-678]).
       - "rejected the request" — kimi_cli exit 1. The auth/config error
         is Moonshot-specific; another provider can succeed.
-      - "startup crash" — gemini_cli top-level await / yoga_wasm. The
-        CLI source explicitly marks this "so the cascade can move on".
+      - "startup crash" — gemini_cli top-level await / yoga_wasm or
+        kimi_cli process-title UnicodeDecodeError. The CLI source
+        explicitly marks this "so the cascade can move on".
       All of these are per-provider, not cascade-wide; a fallback provider
       may succeed where the current one rejected. See masc-mcp #9932
       (kimi fallback), #9850 (codex_cli runtime_mcp_auth).

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -663,7 +663,11 @@ module Kimi_cli_transport_local = struct
       cancel = None;
     }
 
-  let default_prompt_argv_threshold = 512 * 1024
+  (* Kimi CLI imports [setproctitle] on macOS before processing the
+     request.  Long UTF-8 prompts in argv can make setproctitle's
+     import-time [getproctitle()] decode fail before Kimi reads the
+     prompt, so keep argv small and stream keeper prompts via stdin. *)
+  let default_prompt_argv_threshold = 16 * 1024
 
   let prompt_argv_threshold () =
     match Sys.getenv_opt "OAS_KIMI_PROMPT_ARGV_THRESHOLD" with
@@ -997,12 +1001,27 @@ module Kimi_cli_transport_local = struct
     | _ when text_looks_like_resumable_session text -> exit_code_marker_of_text text
     | _ -> None
 
+  let text_looks_like_process_title_unicode_crash text =
+    String_util.contains_substring_ci text "UnicodeDecodeError"
+    && String_util.contains_substring_ci text "setproctitle"
+
   let classify_cli_error = function
     | Error (Llm_provider.Http_client.NetworkError { message; _ }) as err -> (
         if text_looks_like_resumable_session message then
           Error
             (Llm_provider.Http_client.AcceptRejected
                { reason = resumable_session_detail_of_text message })
+        else if text_looks_like_process_title_unicode_crash message then
+          Error
+            (Llm_provider.Http_client.AcceptRejected
+               {
+                 reason =
+                   "kimi_cli startup crash while setting process title \
+                    (UnicodeDecodeError). This is a local CLI/runtime \
+                    failure, not keeper auth or sandbox failure; rejecting \
+                    without retry so the cascade can move on. "
+                   ^ message;
+               })
         else
           match exit_code_of_message message with
         | Some 1 ->

--- a/lib/oas_worker_exec_transport.mli
+++ b/lib/oas_worker_exec_transport.mli
@@ -249,8 +249,9 @@ module Kimi_cli_transport_local : sig
   val resumable_session_exit_code_of_text : string -> int option
 
   (** Reclassify a [NetworkError] from kimi_cli into [AcceptRejected] when
-      the message indicates a permanent error (auth/config/model) or a
-      resumable-session report.  Other variants pass through. *)
+      the message indicates a permanent per-provider error
+      (auth/config/model), a local CLI startup crash, or a resumable-session
+      report.  Other variants pass through. *)
   val classify_cli_error :
     ('a, Llm_provider.Http_client.http_error) result ->
     ('a, Llm_provider.Http_client.http_error) result

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -120,6 +120,28 @@ let test_pause_human_when_no_tools_used () =
   let r = mk_receipt ~tools_used:[] () in
   check_disp "tools_used=[]" r "pause_human" "tool_required_unsatisfied"
 
+let test_provider_failure_not_reported_as_tool_unsatisfied () =
+  let r =
+    mk_receipt ~tools_used:[] ~terminal_reason_code:"api_error_invalid_request"
+      ~error_kind:(Some "api")
+      ~error_message:
+        (Some
+           "Invalid request: kimi_cli startup crash while setting process title")
+      ()
+  in
+  check_disp "provider failure before tool use" r "pause_human"
+    "provider_runtime_error"
+
+let test_preflight_config_failure_not_reported_as_tool_unsatisfied () =
+  let r =
+    mk_receipt ~tools_used:[] ~terminal_reason_code:"config_error"
+      ~error_kind:(Some "config")
+      ~error_message:(Some "provider auth/config failed before turn")
+      ()
+  in
+  check_disp "preflight config before tool use" r "pause_human"
+    "preflight_config_error"
+
 (* === Cascade exhausted always alerts ================================ *)
 
 let test_alert_for_cascade_exhausted () =
@@ -245,6 +267,10 @@ let () =
             test_pause_human_for_each_violation;
           test_case "tools_used=[] -> pause_human" `Quick
             test_pause_human_when_no_tools_used;
+          test_case "provider failure before tool use -> provider_runtime_error" `Quick
+            test_provider_failure_not_reported_as_tool_unsatisfied;
+          test_case "config failure before tool use -> preflight_config_error" `Quick
+            test_preflight_config_failure_not_reported_as_tool_unsatisfied;
           test_case "cascade_exhausted -> alert_exhausted" `Quick
             test_alert_for_cascade_exhausted;
           test_case "unmapped -> unknown" `Quick test_unknown_when_unmapped;

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -42,6 +42,19 @@ let test_gemini_cli_startup_crash_cascades () =
     true
     (Oas_compat.Http_client.should_cascade err)
 
+let test_kimi_cli_startup_crash_cascades () =
+  let reason =
+    "kimi_cli startup crash while setting process title \
+     (UnicodeDecodeError). This is a local CLI/runtime failure, not \
+     keeper auth or sandbox failure; rejecting without retry so the \
+     cascade can move on."
+  in
+  let err = Http_client.AcceptRejected { reason } in
+  Alcotest.(check bool)
+    "kimi_cli startup crash must cascade — next provider may still succeed"
+    true
+    (Oas_compat.Http_client.should_cascade err)
+
 let test_does_not_support_still_cascades () =
   (* Regression pin for #9850: the provider-capability-mismatch marker
      added by codex_cli runtime_mcp_auth / tool_support must keep
@@ -216,6 +229,8 @@ let () =
             `Quick test_kimi_cli_exit_1_cascades;
           Alcotest.test_case "gemini_cli startup crash cascades"
             `Quick test_gemini_cli_startup_crash_cascades;
+          Alcotest.test_case "kimi_cli startup crash cascades"
+            `Quick test_kimi_cli_startup_crash_cascades;
         ] );
       ( "AcceptRejected — capability mismatch still cascades (#9850)",
         [

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2419,6 +2419,19 @@ let test_kimi_cli_build_args_include_runtime_mcp_config () =
        (contains_substring ~needle:"http://127.0.0.1:8947/mcp")
        argv)
 
+let test_kimi_cli_build_args_uses_stdin_for_large_prompt () =
+  let long_prompt = String.make (20 * 1024) 'x' in
+  let argv =
+    Oas_worker_exec.Kimi_cli_transport_local.build_args
+      ~config:Oas_worker_exec.Kimi_cli_transport_local.default_config
+      ~req_config:(make_kimi_cli_provider_cfg ())
+      ~mcp_config_json:[] ~prompt:long_prompt
+  in
+  Alcotest.(check bool) "large prompt is omitted from argv" false
+    (List.mem long_prompt argv);
+  Alcotest.(check bool) "large prompt does not use -p" false
+    (List.mem "-p" argv)
+
 let test_kimi_cli_model_for_provider_keeps_transport_default_on_auto () =
   let provider_cfg = make_kimi_cli_provider_cfg () in
   Alcotest.(check (option string)) "auto uses transport default"
@@ -2581,6 +2594,30 @@ let test_kimi_cli_classify_cli_error_keeps_exit_1_with_error_as_reject () =
       Alcotest.(check bool) "stderr detail preserved" true
         (contains_substring ~needle:"Authentication failed" reason)
   | _ -> Alcotest.fail "expected exit 1 with real stderr to stay rejected"
+
+let test_kimi_cli_classify_cli_error_labels_process_title_unicode_crash () =
+  let raw_message =
+    "kimi exited with code 1: Traceback ... \
+     setproctitle/__init__.py:57 in <module> getproctitle() \
+     UnicodeDecodeError: 'utf-8' codec can't decode byte 0xef"
+  in
+  match
+    Oas_worker_exec.Kimi_cli_transport_local.classify_cli_error
+      (Error
+         (Llm_provider.Http_client.NetworkError
+            {
+              message = raw_message;
+              kind = Llm_provider.Http_client.Unknown;
+            }))
+  with
+  | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
+      Alcotest.(check bool) "startup crash marker" true
+        (contains_substring ~needle:"startup crash" reason);
+      Alcotest.(check bool) "unicode crash detail preserved" true
+        (contains_substring ~needle:"UnicodeDecodeError" reason);
+      Alcotest.(check bool) "not framed as auth/config" false
+        (contains_substring ~needle:"auth/config/model" reason)
+  | _ -> Alcotest.fail "expected setproctitle UnicodeDecodeError to map to AcceptRejected"
 let test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback () =
   let provider_cfg = make_codex_cli_provider_cfg () in
   let config =
@@ -3934,6 +3971,8 @@ let () =
         test_kimi_cli_runtime_mcp_jsons_include_request_policy;
       Alcotest.test_case "kimi argv includes request runtime MCP config" `Quick
         test_kimi_cli_build_args_include_runtime_mcp_config;
+      Alcotest.test_case "kimi large prompt uses stdin, not argv" `Quick
+        test_kimi_cli_build_args_uses_stdin_for_large_prompt;
       Alcotest.test_case "kimi auto model keeps transport default" `Quick
         test_kimi_cli_model_for_provider_keeps_transport_default_on_auto;
       Alcotest.test_case "kimi explicit model is preserved" `Quick
@@ -3950,6 +3989,8 @@ let () =
         test_kimi_cli_resumable_invalid_request_reclassifies_as_structured;
       Alcotest.test_case "kimi exit 1 with stderr remains rejected" `Quick
         test_kimi_cli_classify_cli_error_keeps_exit_1_with_error_as_reject;
+      Alcotest.test_case "kimi setproctitle unicode crash is startup crash" `Quick
+        test_kimi_cli_classify_cli_error_labels_process_title_unicode_crash;
       Alcotest.test_case "worker build_agent installs retry policy" `Quick
         test_worker_build_agent_uses_default_internal_retry_policy;
       Alcotest.test_case "resume config propagates retry policy" `Quick


### PR DESCRIPTION
## Summary

- route large Kimi CLI prompts through stdin so macOS process-title decoding cannot fail before request handling
- classify Kimi process-title startup crashes as provider/runtime failures, allowing cascade fallback instead of terminal operator pause
- keep provider/config startup failures ahead of `tool_required_unsatisfied` in keeper receipt disposition
- log pre-dispatch compaction skipped/applied decisions and document the checkpoint-history boundary

## Root Cause

Kimi CLI 1.37.0 imports `setproctitle` on macOS before reading the request. With a long UTF-8 keeper prompt in argv, import-time `getproctitle()` can raise `UnicodeDecodeError`. That was surfaced as a generic CLI rejection and then misreported as `tool_required_unsatisfied` because the provider crashed before any keeper tool call.

Live `scholar` evidence showed the checkpoint was below compaction thresholds, so compaction was not the trigger. The fix handles the CLI startup failure path directly and makes pre-dispatch compaction decisions visible for future diagnosis.

## Operator Impact

This turns the observed Kimi startup crash into a provider-local failure that the cascade can move past. Operators should see provider/runtime disposition rather than a misleading "required tool contract" pause when the model never got a chance to call tools.

## Validation

- `./scripts/dune-local.sh exec test/test_keeper_lifecycle.exe`
- `./scripts/dune-local.sh exec test/test_keeper_pause_broadcast.exe`
- `./scripts/dune-local.sh exec test/test_oas_compat_cascade_fallback.exe`
- `_build/default/test/test_oas_worker.exe test resume_config 46,55`
- `git diff --check`
