### PR TITLE
feat(dashboard): expose FSM audit surfaces

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -7,6 +7,7 @@ import {
   fetchDashboardTools,
   fetchKeeperConfig,
   fetchRuntimeModelMetrics,
+  fetchTlcResults,
   fetchToolQuality,
 } from './dashboard'
 
@@ -77,6 +78,30 @@ describe('fetchDashboardShell', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/shell?light=true')
+  })
+})
+
+describe('fetchTlcResults', () => {
+  it('uses the TLC verification results endpoint', async () => {
+    const rawResponse = {
+      updated_at: '2026-04-30T00:00:00Z',
+      results_dir: null,
+      count: 0,
+      entries: [],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchTlcResults()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/verification/tlc-results')
+    expect(result).toEqual(rawResponse)
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2480,3 +2480,39 @@ export function fetchTlaSpecs(
     signal: opts?.signal,
   })
 }
+
+export type TlcResultStatus =
+  | 'passed'
+  | 'violated'
+  | 'running'
+  | 'queued'
+  | 'error'
+  | 'not_run'
+
+export interface TlcResultEntry {
+  spec_name: string
+  cfg_name: string
+  category: TlaSpecCategory
+  status: TlcResultStatus
+  states_explored: number | null
+  distinct_states: number | null
+  diameter: number | null
+  last_run_at: string | null
+  violation: string | null
+  log_path: string | null
+}
+
+export interface TlcResultsResponse {
+  updated_at: string
+  results_dir: string | null
+  count: number
+  entries: TlcResultEntry[]
+}
+
+export function fetchTlcResults(
+  opts?: AbortableRequestOptions,
+): Promise<TlcResultsResponse> {
+  return get<TlcResultsResponse>('/api/v1/verification/tlc-results', {
+    signal: opts?.signal,
+  })
+}

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -29,6 +29,8 @@ export type {
   KeeperCompositeMeasurement,
   KeeperLastOutcome,
   KeeperCompositeExecution,
+  KeeperPhaseDiagnosis,
+  KeeperPhaseDiagnosisRow,
   KeeperCompositePhase,
   KeeperCompositeTurnPhase,
   KeeperCompositeDecisionStage,
@@ -493,7 +495,7 @@ export interface MemoryKindUsageEntry {
   priority: number
 }
 
-interface KeeperStateDiagramResponse {
+export interface KeeperStateDiagramResponse {
   keeper: string
   current_phase: string
   mermaid: string

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -77,6 +77,42 @@ const KeeperCompositeInvariantsSchema = object({
   event_priority_monotone: boolean(),
 })
 
+const KeeperPhaseDiagnosisRowSchema = object({
+  key: string(),
+  label: string(),
+  priority: number(),
+  value: boolean(),
+  phase: string(),
+  determining: boolean(),
+})
+
+const KeeperPhaseDiagnosisSchema = object({
+  current_phase: string(),
+  derived_phase: string(),
+  can_execute_turn: boolean(),
+  conditions: object({
+    launch_pending: boolean(),
+    fiber_alive: boolean(),
+    heartbeat_healthy: boolean(),
+    turn_healthy: boolean(),
+    context_within_budget: boolean(),
+    context_handoff_needed: boolean(),
+    compaction_active: boolean(),
+    handoff_active: boolean(),
+    operator_paused: boolean(),
+    stop_requested: boolean(),
+    restart_budget_remaining: boolean(),
+    backoff_elapsed: boolean(),
+    guardrail_triggered: boolean(),
+    drain_complete: boolean(),
+    context_overflow: boolean(),
+    compact_retry_exhausted: boolean(),
+    terminal_failure_latched: boolean(),
+  }),
+  determining_condition: nullable(string()),
+  rows: array(KeeperPhaseDiagnosisRowSchema),
+})
+
 const KeeperLastOutcomeSchema = object({
   turn_id: number(),
   ended_at: number(),
@@ -161,6 +197,7 @@ export const KeeperCompositeSnapshotSchema = object({
   ),
   measurement: KeeperCompositeMeasurementSchema,
   invariants: KeeperCompositeInvariantsSchema,
+  phase_diagnosis: optional(KeeperPhaseDiagnosisSchema),
   is_live: boolean(),
   last_outcome: nullable(KeeperLastOutcomeSchema),
   execution: optional(KeeperCompositeExecutionSchema),
@@ -172,6 +209,8 @@ export const KeeperCompositeSnapshotSchema = object({
 export type KeeperCompositeSnapshot = InferOutput<typeof KeeperCompositeSnapshotSchema>
 export type KeeperCompositeInvariants = InferOutput<typeof KeeperCompositeInvariantsSchema>
 export type KeeperCompositeMeasurement = InferOutput<typeof KeeperCompositeMeasurementSchema>
+export type KeeperPhaseDiagnosis = InferOutput<typeof KeeperPhaseDiagnosisSchema>
+export type KeeperPhaseDiagnosisRow = InferOutput<typeof KeeperPhaseDiagnosisRowSchema>
 export type KeeperLastOutcome = InferOutput<typeof KeeperLastOutcomeSchema>
 export type KeeperCompositeExecution = InferOutput<typeof KeeperCompositeExecutionSchema>
 export type KeeperCompositePhase = InferOutput<typeof KeeperCompositePhaseSchema>

--- a/dashboard/src/components/keeper-fsm-specs.test.ts
+++ b/dashboard/src/components/keeper-fsm-specs.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect } from 'vitest'
 import {
   buildCompositeFsmSpec,
   buildCompactionSpec,
+  buildTurnFsmSpec,
+  normalizeTurnFsmState,
+  turnFsmTlaSymbol,
+  TURN_FSM_STATES,
 } from './keeper-fsm-specs'
 
 describe('buildCompositeFsmSpec', () => {
@@ -240,5 +244,72 @@ describe('buildCompactionSpec', () => {
     const edge = spec.edges.find(e => e.source === 'compacting' && e.target === 'accumulating')
     expect(edge).toBeTruthy()
     expect(edge!.type).toBe('error')
+  })
+})
+
+// ================================================================
+// buildTurnFsmSpec
+// ================================================================
+
+describe('buildTurnFsmSpec', () => {
+  it('creates one node per keeper_turn_fsm state', () => {
+    const spec = buildTurnFsmSpec('streaming')
+    expect(spec.nodes.map(n => n.id)).toEqual([...TURN_FSM_STATES])
+  })
+
+  it('marks the projected current state active', () => {
+    const spec = buildTurnFsmSpec('streaming')
+    const streaming = spec.nodes.find(n => n.id === 'streaming')
+    expect(streaming!.type).toBe('active')
+    expect(spec.activeNodeId).toBe('streaming')
+  })
+
+  it('maps legacy prompting to phase_gating', () => {
+    expect(normalizeTurnFsmState('prompting')).toBe('phase_gating')
+    const spec = buildTurnFsmSpec('prompting')
+    expect(spec.activeNodeId).toBe('phase_gating')
+  })
+
+  it('maps legacy executing to streaming', () => {
+    expect(normalizeTurnFsmState('executing')).toBe('streaming')
+  })
+
+  it('maps legacy finalizing and compacting to completing', () => {
+    expect(normalizeTurnFsmState('finalizing')).toBe('completing')
+    expect(normalizeTurnFsmState('compacting')).toBe('completing')
+  })
+
+  it('maps the TLA awaiting_tool symbol to the UI awaiting_tool_result state', () => {
+    expect(normalizeTurnFsmState('awaiting_tool')).toBe('awaiting_tool_result')
+    expect(turnFsmTlaSymbol('awaiting_tool_result')).toBe('awaiting_tool')
+  })
+
+  it('keeps failed and cancelled terminal states visible', () => {
+    const failedSpec = buildTurnFsmSpec('failed')
+    const failed = failedSpec.nodes.find(n => n.id === 'failed')
+    const cancelled = failedSpec.nodes.find(n => n.id === 'cancelled')
+    expect(failed!.type).toBe('err')
+    expect(cancelled!.type).toBe('warn')
+  })
+
+  it('returns no active node for unknown turn phases', () => {
+    const spec = buildTurnFsmSpec('mystery')
+    expect(spec.activeNodeId).toBeNull()
+  })
+
+  it('includes the provider/tool/receipt terminal edges', () => {
+    const spec = buildTurnFsmSpec('streaming')
+    expect(spec.edges).toContainEqual({
+      source: 'streaming',
+      target: 'awaiting_tool_result',
+      label: 'StreamYieldsTool',
+      type: 'cascade',
+    })
+    expect(spec.edges).toContainEqual({
+      source: 'completing',
+      target: 'failed',
+      label: 'ReceiptLost',
+      type: 'error',
+    })
   })
 })

--- a/dashboard/src/components/keeper-fsm-specs.ts
+++ b/dashboard/src/components/keeper-fsm-specs.ts
@@ -30,6 +30,64 @@ const KDP_STATES = ['undecided', 'guard_ok', 'gate_rejected', 'tool_policy_selec
 const KCL_STATES = ['idle', 'selecting', 'trying', 'done', 'exhausted']
 const KMC_STATES = ['accumulating', 'compacting', 'done']
 
+export const TURN_FSM_STATES = [
+  'idle',
+  'phase_gating',
+  'cascade_routing',
+  'awaiting_provider',
+  'streaming',
+  'awaiting_tool_result',
+  'completing',
+  'done',
+  'failed',
+  'cancelled',
+] as const
+
+export type KeeperTurnFsmState = (typeof TURN_FSM_STATES)[number]
+
+const TURN_FSM_TLA_SYMBOLS: Record<KeeperTurnFsmState, string> = {
+  idle: 'idle',
+  phase_gating: 'phase_gating',
+  cascade_routing: 'cascade_routing',
+  awaiting_provider: 'awaiting_provider',
+  streaming: 'streaming',
+  awaiting_tool_result: 'awaiting_tool',
+  completing: 'completing',
+  done: 'done',
+  failed: 'failed',
+  cancelled: 'cancelled',
+}
+
+const LEGACY_TURN_PHASE_MAP: Record<string, KeeperTurnFsmState> = {
+  idle: 'idle',
+  prompting: 'phase_gating',
+  executing: 'streaming',
+  compacting: 'completing',
+  finalizing: 'completing',
+  awaiting_tool: 'awaiting_tool_result',
+}
+
+const TURN_FSM_EDGES: FsmEdge[] = [
+  { source: 'idle', target: 'phase_gating', label: 'StartTurn' },
+  { source: 'phase_gating', target: 'done', label: 'PhaseGateSkip', type: 'recovery' },
+  { source: 'phase_gating', target: 'cascade_routing', label: 'PhaseGateOk' },
+  { source: 'cascade_routing', target: 'awaiting_provider', label: 'CascadeRouted', type: 'cascade' },
+  { source: 'cascade_routing', target: 'failed', label: 'CascadeUnavailable', type: 'error' },
+  { source: 'awaiting_provider', target: 'streaming', label: 'ProviderResponded' },
+  { source: 'awaiting_provider', target: 'cancelled', label: 'ProviderTimeout', type: 'error' },
+  { source: 'streaming', target: 'awaiting_tool_result', label: 'StreamYieldsTool', type: 'cascade' },
+  { source: 'awaiting_tool_result', target: 'streaming', label: 'ToolReturned', type: 'recovery' },
+  { source: 'streaming', target: 'completing', label: 'StreamComplete' },
+  { source: 'completing', target: 'done', label: 'ContractOk', type: 'recovery' },
+  { source: 'completing', target: 'failed', label: 'ContractViolation', type: 'error' },
+  { source: 'completing', target: 'failed', label: 'ReceiptLost', type: 'error' },
+  { source: 'phase_gating', target: 'cancelled', label: 'HonorStopSignal', type: 'error' },
+  { source: 'cascade_routing', target: 'cancelled', label: 'HonorStopSignal', type: 'error' },
+  { source: 'streaming', target: 'cancelled', label: 'HonorStopSignal', type: 'error' },
+  { source: 'awaiting_tool_result', target: 'cancelled', label: 'HonorStopSignal', type: 'error' },
+  { source: 'completing', target: 'cancelled', label: 'HonorStopSignal', type: 'error' },
+]
+
 function nodeType(stateId: string, activeId: string, tone: 'active' | 'warn' | 'err'): FsmNode['type'] {
   return stateId === activeId ? tone : 'dim'
 }
@@ -113,6 +171,55 @@ export function buildCompactionSpec(
       { source: 'compacting', target: 'accumulating', label: 'Compaction_failed', type: 'error' },
     ],
     activeNodeId: activeStage,
+    layout: 'breadthfirst',
+    direction: 'LR',
+  }
+}
+
+export function normalizeTurnFsmState(turnPhase: string | null | undefined): KeeperTurnFsmState | null {
+  if (!turnPhase) return null
+  const normalized = turnPhase.trim().toLowerCase()
+  if (!normalized) return null
+  if ((TURN_FSM_STATES as readonly string[]).includes(normalized)) {
+    return normalized as KeeperTurnFsmState
+  }
+  return LEGACY_TURN_PHASE_MAP[normalized] ?? null
+}
+
+export function turnFsmTlaSymbol(state: KeeperTurnFsmState): string {
+  return TURN_FSM_TLA_SYMBOLS[state]
+}
+
+function turnNodeType(state: KeeperTurnFsmState, activeState: KeeperTurnFsmState | null): FsmNode['type'] {
+  if (state === activeState) {
+    if (state === 'failed') return 'err'
+    if (state === 'cancelled') return 'warn'
+    if (state === 'done') return 'ok'
+    return 'active'
+  }
+
+  switch (state) {
+    case 'done':
+      return 'ok'
+    case 'failed':
+      return 'err'
+    case 'cancelled':
+      return 'warn'
+    default:
+      return 'state'
+  }
+}
+
+export function buildTurnFsmSpec(turnPhase: string | null | undefined): FsmGraphSpec {
+  const activeState = normalizeTurnFsmState(turnPhase)
+  return {
+    nodes: TURN_FSM_STATES.map(state => ({
+      id: state,
+      label: state,
+      type: turnNodeType(state, activeState),
+    })),
+    edges: TURN_FSM_EDGES,
+    activeNodeId: activeState,
     layout: 'breadthfirst',
     direction: 'LR',
   }

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -3,14 +3,24 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 
 import {
   fetchKeeperComposite,
+  fetchKeeperStateDiagram,
   fetchKeeperTransitions,
   type KeeperCompositeSnapshot,
+  type KeeperStateDiagramResponse,
   type KeeperTransition,
 } from '../api/keeper'
+import { isRecord } from './common/normalize'
 import { EmptyState } from './common/empty-state'
 import { InlineSpinner } from './common/inline-spinner'
 import { CytoscapeFsm } from './common/cytoscape-fsm'
+import { MermaidGraph } from './common/mermaid-graph'
+import { FilterChips } from './common/filter-chips'
 import { buildCompositeFsmSpec } from './keeper-fsm-specs'
+import { TurnFsmDetailPanel } from './turn-fsm-detail-panel'
+import {
+  normalizePhaseDiagnosis,
+  PhaseConditionsPanel,
+} from './phase-conditions-panel'
 import type { KeeperPhase } from '../types'
 
 interface KeeperStateDiagramProps {
@@ -50,6 +60,13 @@ const INVARIANT_LABELS: Array<[keyof KeeperCompositeSnapshot['invariants'], stri
   ['no_cascade_before_measurement', 'Cascade 순서'],
   ['compaction_atomicity', '압축 원자성'],
   ['event_priority_monotone', '이벤트 우선순위'],
+]
+
+type DiagramView = 'cytoscape' | 'mermaid'
+
+const DIAGRAM_VIEW_CHIPS: Array<{ key: DiagramView; label: string; title: string }> = [
+  { key: 'cytoscape', label: 'Cytoscape', title: 'Composite lifecycle graph' },
+  { key: 'mermaid', label: 'Mermaid', title: 'Backend-generated phase diagram' },
 ]
 
 function normalizePhase(phase: string | null | undefined): string | null {
@@ -96,22 +113,32 @@ function badgeTone(ok: boolean): string {
     : 'border-[rgba(239,68,68,0.24)] bg-[var(--bad-10)] text-[var(--color-status-err)]'
 }
 
+function snapshotPhaseDiagnosis(snapshot: KeeperCompositeSnapshot): unknown {
+  return isRecord(snapshot) ? snapshot.phase_diagnosis : undefined
+}
+
 export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStateDiagramProps) {
   const [snapshot, setSnapshot] = useState<KeeperCompositeSnapshot | null>(null)
+  const [stateDiagram, setStateDiagram] = useState<KeeperStateDiagramResponse | null>(null)
   const [transitions, setTransitions] = useState<KeeperTransition[]>([])
   const [error, setError] = useState<string | null>(null)
+  const [diagramError, setDiagramError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [diagramView, setDiagramView] = useState<DiagramView>('cytoscape')
 
   useEffect(() => {
     const controller = new AbortController()
     setLoading(true)
     setError(null)
+    setDiagramError(null)
+    setStateDiagram(null)
 
     Promise.allSettled([
       fetchKeeperComposite(keeperName, { signal: controller.signal }),
+      fetchKeeperStateDiagram(keeperName, { signal: controller.signal }),
       fetchKeeperTransitions(keeperName, 5, { signal: controller.signal }),
     ])
-      .then(([snapshotResult, transitionsResult]) => {
+      .then(([snapshotResult, stateDiagramResult, transitionsResult]) => {
         if (controller.signal.aborted) return
 
         if (snapshotResult.status === 'fulfilled') {
@@ -119,6 +146,17 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
         } else {
           setSnapshot(null)
           setError(snapshotResult.reason instanceof Error ? snapshotResult.reason.message : 'composite fetch failed')
+        }
+
+        if (stateDiagramResult.status === 'fulfilled') {
+          setStateDiagram(stateDiagramResult.value)
+        } else {
+          setStateDiagram(null)
+          setDiagramError(
+            stateDiagramResult.reason instanceof Error
+              ? stateDiagramResult.reason.message
+              : 'state-diagram fetch failed',
+          )
         }
 
         if (transitionsResult.status === 'fulfilled') {
@@ -141,6 +179,11 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
   const keeperPhase = normalizePhase(currentPhase)
   const compositePhase = normalizePhase(snapshot?.phase)
   const phaseMismatch = Boolean(keeperPhase && compositePhase && keeperPhase !== compositePhase)
+  const phaseDiagnosis = useMemo(
+    () => snapshot ? normalizePhaseDiagnosis(snapshotPhaseDiagnosis(snapshot)) : null,
+    [snapshot],
+  )
+  const mermaidSource = stateDiagram?.mermaid?.trim() ?? ''
 
   const compositeSpec = useMemo(
     () => snapshot
@@ -205,9 +248,54 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
       ` : null}
 
       <div>
-        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)] mb-2">통합 라이프사이클 (KSM · KTC · KDP · KCL · KMC)</div>
-        <${CytoscapeFsm} spec=${compositeSpec} height="320px" />
+        <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
+          <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
+            통합 라이프사이클 (KSM · KTC · KDP · KCL · KMC)
+          </div>
+          <${FilterChips}
+            chips=${DIAGRAM_VIEW_CHIPS}
+            value=${diagramView}
+            onChange=${setDiagramView}
+            tone="accent"
+          />
+        </div>
+        ${diagramView === 'cytoscape' ? html`
+          <div role="tabpanel" aria-label="Composite lifecycle Cytoscape graph">
+            <${CytoscapeFsm} spec=${compositeSpec} height="320px" />
+          </div>
+        ` : html`
+          <div role="tabpanel" aria-label="Backend-generated Mermaid phase diagram">
+            ${diagramError ? html`
+              <${EmptyState} message=${diagramError} compact />
+            ` : mermaidSource ? html`
+              <div class="grid gap-2">
+                <${MermaidGraph}
+                  source=${mermaidSource}
+                  prefix=${`keeper-phase-${keeperName}`}
+                  minHeightClass="min-h-72"
+                  fallbackText=${mermaidSource}
+                />
+                <div class="flex flex-wrap items-center gap-1.5 text-3xs text-[var(--color-fg-disabled)]">
+                  <span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">
+                    backend phase ${stateDiagram?.current_phase ?? 'unknown'}
+                  </span>
+                  <span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">
+                    response.mermaid
+                  </span>
+                </div>
+              </div>
+            ` : html`
+              <${EmptyState} message="backend Mermaid diagram 없음" compact />
+            `}
+          </div>
+        `}
       </div>
+
+      <${TurnFsmDetailPanel} snapshot=${snapshot} />
+
+      ${phaseDiagnosis ? html`
+        <${PhaseConditionsPanel} diagnosis=${phaseDiagnosis} />
+      ` : null}
 
       <div class="grid gap-2 md:grid-cols-2">
         ${INVARIANT_LABELS.map(([key, label]) => {
@@ -222,7 +310,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
       </div>
 
       ${transitions.length > 0 ? html`
-        <div class="grid gap-2">
+        <div class="grid gap-2" role="log" aria-live="polite" aria-label="관측된 전이">
           <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">관측된 전이</div>
           ${transitions.map(transition => html`
             <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-normal text-[var(--color-fg-primary)]">

--- a/dashboard/src/components/phase-conditions-panel.test.ts
+++ b/dashboard/src/components/phase-conditions-panel.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizePhaseDiagnosis } from './phase-conditions-panel'
+
+describe('normalizePhaseDiagnosis', () => {
+  it('normalizes and sorts backend phase diagnosis rows by priority', () => {
+    const diagnosis = normalizePhaseDiagnosis({
+      current_phase: 'Running',
+      derived_phase: 'Failing',
+      can_execute_turn: true,
+      determining_condition: 'failing_unhealthy',
+      rows: [
+        {
+          key: 'running_fiber_alive',
+          label: 'Running: fiber alive',
+          priority: 14,
+          value: true,
+          phase: 'Running',
+          determining: false,
+        },
+        {
+          key: 'failing_unhealthy',
+          label: 'Failing: heartbeat or turn unhealthy',
+          priority: 13,
+          value: true,
+          phase: 'Failing',
+          determining: true,
+        },
+      ],
+    })
+
+    expect(diagnosis).not.toBeNull()
+    expect(diagnosis!.currentPhase).toBe('Running')
+    expect(diagnosis!.derivedPhase).toBe('Failing')
+    expect(diagnosis!.canExecuteTurn).toBe(true)
+    expect(diagnosis!.rows.map(row => row.key)).toEqual([
+      'failing_unhealthy',
+      'running_fiber_alive',
+    ])
+    expect(diagnosis!.rows[0]!.determining).toBe(true)
+  })
+
+  it('infers the determining row from determining_condition when row flag is absent', () => {
+    const diagnosis = normalizePhaseDiagnosis({
+      determining_condition: 'offline_fallback',
+      rows: [
+        {
+          key: 'offline_fallback',
+          label: 'Offline: fallback',
+          priority: 15,
+          value: true,
+          phase: 'Offline',
+        },
+      ],
+    })
+
+    expect(diagnosis!.rows[0]!.determining).toBe(true)
+  })
+
+  it('returns null for missing optional backend field', () => {
+    expect(normalizePhaseDiagnosis(undefined)).toBeNull()
+    expect(normalizePhaseDiagnosis({ rows: [] })).toBeNull()
+  })
+})

--- a/dashboard/src/components/phase-conditions-panel.ts
+++ b/dashboard/src/components/phase-conditions-panel.ts
@@ -1,0 +1,149 @@
+import { html } from 'htm/preact'
+
+import {
+  asBoolean,
+  asInt,
+  asRecordArray,
+  asString,
+  isRecord,
+} from './common/normalize'
+
+export interface PhaseConditionRow {
+  key: string
+  label: string
+  priority: number
+  value: boolean
+  phase: string
+  determining: boolean
+}
+
+export interface PhaseDiagnosis {
+  currentPhase: string | null
+  derivedPhase: string | null
+  canExecuteTurn: boolean | null
+  determiningCondition: string | null
+  rows: PhaseConditionRow[]
+}
+
+export function normalizePhaseDiagnosis(input: unknown): PhaseDiagnosis | null {
+  if (!isRecord(input)) return null
+  const rowRecords = asRecordArray(input.rows)
+  if (rowRecords.length === 0) return null
+
+  const determiningCondition = asString(input.determining_condition) ?? null
+  const rows = rowRecords
+    .map((row, index): PhaseConditionRow => {
+      const key = asString(row.key) ?? `condition_${index + 1}`
+      const priority = asInt(row.priority) ?? index + 1
+      const determining = asBoolean(row.determining) ?? key === determiningCondition
+      return {
+        key,
+        label: asString(row.label) ?? key,
+        priority,
+        value: asBoolean(row.value, false),
+        phase: asString(row.phase) ?? 'unknown',
+        determining,
+      }
+    })
+    .sort((left, right) => left.priority - right.priority)
+
+  return {
+    currentPhase: asString(input.current_phase) ?? null,
+    derivedPhase: asString(input.derived_phase) ?? null,
+    canExecuteTurn: asBoolean(input.can_execute_turn) ?? null,
+    determiningCondition,
+    rows,
+  }
+}
+
+function rowClass(row: PhaseConditionRow): string {
+  if (row.determining) {
+    return 'border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-fg-primary)]'
+  }
+  if (row.value) {
+    return 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--color-fg-primary)]'
+  }
+  return 'border-[var(--white-8)] bg-[var(--white-3)] text-[var(--color-fg-disabled)]'
+}
+
+function chipClass(tone: 'accent' | 'neutral' | 'ok' | 'warn'): string {
+  switch (tone) {
+    case 'accent':
+      return 'border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]'
+    case 'ok':
+      return 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--color-status-ok)]'
+    case 'warn':
+      return 'border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--color-status-warn)]'
+    case 'neutral':
+    default:
+      return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--color-fg-muted)]'
+  }
+}
+
+export function PhaseConditionsPanel({ diagnosis }: { diagnosis: PhaseDiagnosis }) {
+  const executableTone = diagnosis.canExecuteTurn === true
+    ? 'ok'
+    : diagnosis.canExecuteTurn === false
+      ? 'warn'
+      : 'neutral'
+
+  return html`
+    <section
+      class="grid gap-3"
+      role="region"
+      aria-labelledby="phase-conditions-title"
+    >
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <div id="phase-conditions-title" class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
+            Phase conditions
+          </div>
+          <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">
+            derive_phase priority order; first true condition determines the phase
+          </div>
+        </div>
+        <div class="flex flex-wrap items-center gap-1.5 text-3xs">
+          ${diagnosis.currentPhase ? html`
+            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass('neutral')}`}>
+              current ${diagnosis.currentPhase}
+            </span>
+          ` : null}
+          ${diagnosis.derivedPhase ? html`
+            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass('accent')}`}>
+              derived ${diagnosis.derivedPhase}
+            </span>
+          ` : null}
+          <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 ${chipClass(executableTone)}`}>
+            turn ${diagnosis.canExecuteTurn === null ? 'unknown' : diagnosis.canExecuteTurn ? 'executable' : 'blocked'}
+          </span>
+        </div>
+      </div>
+
+      <ol class="grid gap-1.5" role="list" aria-label="phase condition priority order">
+        ${diagnosis.rows.map(row => html`
+          <li
+            key=${row.key}
+            class=${`rounded border px-3 py-2 text-2xs leading-normal ${rowClass(row)}`}
+            aria-current=${row.determining ? 'step' : undefined}
+          >
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="inline-flex min-w-7 items-center justify-center rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-1.5 py-0.5 font-mono text-3xs tabular-nums">
+                P${row.priority}
+              </span>
+              <span class="font-semibold">${row.label}</span>
+              <span class="font-mono text-[var(--color-fg-muted)]">→ ${row.phase}</span>
+              <span class=${`rounded-sm border px-1.5 py-0.5 font-mono text-3xs ${chipClass(row.value ? 'ok' : 'neutral')}`}>
+                ${row.value ? 'true' : 'false'}
+              </span>
+              ${row.determining ? html`
+                <span class=${`rounded-sm border px-1.5 py-0.5 text-3xs ${chipClass('accent')}`}>
+                  determining
+                </span>
+              ` : null}
+            </div>
+          </li>
+        `)}
+      </ol>
+    </section>
+  `
+}

--- a/dashboard/src/components/tlc-results-panel.test.ts
+++ b/dashboard/src/components/tlc-results-panel.test.ts
@@ -1,0 +1,232 @@
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  TlcResultEntry,
+  TlcResultsResponse,
+} from '../api/dashboard'
+
+const mockState = signal({
+  loading: false,
+  error: null as string | null,
+  data: null as TlcResultsResponse | null,
+})
+const mockLoad = vi.fn()
+const mockCancel = vi.fn()
+
+vi.mock('../lib/async-state', () => ({
+  createManagedAsyncResource: () => ({
+    state: mockState,
+    load: mockLoad,
+    cancel: mockCancel,
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('../api/dashboard', () => ({
+  fetchTlcResults: vi.fn(),
+}))
+
+vi.mock('./btn', () => ({
+  Btn: ({ children, onClick }: any) => html`
+    <button type="button" onClick=${onClick}>${children}</button>
+  `,
+}))
+
+vi.mock('./common/card', () => ({
+  Card: ({ title, children }: any) => html`
+    <section data-testid="card"><h3>${title}</h3>${children}</section>
+  `,
+}))
+
+vi.mock('./common/empty-state', () => ({
+  EmptyState: ({ message, children }: any) => html`
+    <div data-testid="empty-state">${children ?? message}</div>
+  `,
+}))
+
+vi.mock('./common/feedback-state', () => ({
+  ErrorState: ({ message }: any) => html`
+    <div data-testid="error-state">${message}</div>
+  `,
+  LoadingState: ({ children }: any) => html`
+    <div data-testid="loading-state">${children}</div>
+  `,
+}))
+
+vi.mock('./common/status-chip', () => ({
+  StatusChip: ({ tone, label, children }: any) => html`
+    <span data-testid="status-chip" data-tone=${tone}>${children ?? label}</span>
+  `,
+}))
+
+vi.mock('./common/filter-chips', () => ({
+  FilterChips: ({ chips, active }: any) => html`
+    <div data-testid="filter-chips">
+      ${chips.map((chip: any) => html`
+        <button
+          type="button"
+          key=${chip.key}
+          data-testid=${`filter-chip-${chip.key}`}
+          data-active=${active?.value === chip.key}
+          onClick=${() => { if (active) active.value = chip.key }}
+        >
+          ${chip.label}${chip.count != null ? ` (${chip.count})` : ''}
+        </button>
+      `)}
+    </div>
+  `,
+}))
+
+import {
+  __resetTlcResultsPanelForTest,
+  filterTlcEntries,
+  formatTlcMetric,
+  formatTlcTimestamp,
+  hasTlcEvidence,
+  TlcResultsPanel,
+  tlcStatusLabel,
+  tlcStatusTone,
+} from './tlc-results-panel'
+
+function makeEntry(overrides: Partial<TlcResultEntry> = {}): TlcResultEntry {
+  return {
+    spec_name: 'KeeperTurnFSM',
+    cfg_name: 'KeeperTurnFSM.cfg',
+    category: 'boundary',
+    status: 'passed',
+    states_explored: 1234,
+    distinct_states: 512,
+    diameter: 17,
+    last_run_at: '2026-04-30T00:00:00Z',
+    violation: null,
+    log_path: '/tmp/tlc.log',
+    ...overrides,
+  }
+}
+
+function setData(entries: TlcResultEntry[], overrides: Partial<TlcResultsResponse> = {}) {
+  mockState.value = {
+    loading: false,
+    error: null,
+    data: {
+      updated_at: '2026-04-30T00:01:00Z',
+      results_dir: null,
+      count: entries.length,
+      entries,
+      ...overrides,
+    },
+  }
+}
+
+describe('TLC result helpers', () => {
+  it('labels every TLC status', () => {
+    expect(tlcStatusLabel('passed')).toBe('통과')
+    expect(tlcStatusLabel('violated')).toBe('위반')
+    expect(tlcStatusLabel('running')).toBe('실행 중')
+    expect(tlcStatusLabel('queued')).toBe('대기')
+    expect(tlcStatusLabel('error')).toBe('오류')
+    expect(tlcStatusLabel('not_run')).toBe('미실행')
+  })
+
+  it('maps TLC statuses to semantic tones', () => {
+    expect(tlcStatusTone('passed')).toBe('ok')
+    expect(tlcStatusTone('violated')).toBe('bad')
+    expect(tlcStatusTone('running')).toBe('info')
+    expect(tlcStatusTone('queued')).toBe('neutral')
+    expect(tlcStatusTone('error')).toBe('warn')
+    expect(tlcStatusTone('not_run')).toBe('neutral')
+  })
+
+  it('formats nullable TLC metrics and timestamps', () => {
+    expect(formatTlcMetric(1234567)).toBe('1,234,567')
+    expect(formatTlcMetric(null)).toBe('-')
+    expect(formatTlcTimestamp('2026-04-30T00:00:00Z')).toBe('2026-04-30 00:00:00')
+    expect(formatTlcTimestamp(null)).toBe('기록 없음')
+  })
+
+  it('treats all-null not_run rows as absent evidence', () => {
+    const notRun = makeEntry({
+      status: 'not_run',
+      states_explored: null,
+      distinct_states: null,
+      diameter: null,
+      last_run_at: null,
+      violation: null,
+      log_path: null,
+    })
+    expect(hasTlcEvidence(notRun)).toBe(false)
+    expect(hasTlcEvidence({ ...notRun, log_path: '/tmp/tlc.log' })).toBe(true)
+    expect(hasTlcEvidence(makeEntry({ status: 'passed' }))).toBe(true)
+  })
+
+  it('filters by status and sorts newest evidence first', () => {
+    const older = makeEntry({ spec_name: 'Older', status: 'passed', last_run_at: '2026-04-29T00:00:00Z' })
+    const newer = makeEntry({ spec_name: 'Newer', status: 'passed', last_run_at: '2026-04-30T00:00:00Z' })
+    const queued = makeEntry({ spec_name: 'Queued', status: 'queued', last_run_at: null })
+
+    expect(filterTlcEntries([older, queued, newer], 'passed').map((entry) => entry.spec_name))
+      .toEqual(['Newer', 'Older'])
+  })
+})
+
+describe('TlcResultsPanel', () => {
+  beforeEach(() => {
+    mockState.value = { loading: false, error: null, data: null }
+    mockLoad.mockReset()
+    mockCancel.mockReset()
+    __resetTlcResultsPanelForTest()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows an explicit empty state when no TLC rows exist', () => {
+    setData([])
+    render(html`<${TlcResultsPanel} />`)
+
+    expect(screen.getByTestId('empty-state').textContent).toContain('TLC 결과 항목이 없습니다')
+  })
+
+  it('shows absent-evidence warning for only not_run rows', () => {
+    setData([
+      makeEntry({
+        status: 'not_run',
+        states_explored: null,
+        distinct_states: null,
+        diameter: null,
+        last_run_at: null,
+        violation: null,
+        log_path: null,
+      }),
+    ])
+    render(html`<${TlcResultsPanel} />`)
+
+    expect(screen.getByText(/TLC 실행 증거 없음/)).toBeTruthy()
+    expect(screen.getByText('미실행')).toBeTruthy()
+    expect(screen.getByText('기록 없음')).toBeTruthy()
+  })
+
+  it('filters rendered rows by status chip', () => {
+    setData([
+      makeEntry({ spec_name: 'PassingSpec', status: 'passed' }),
+      makeEntry({
+        spec_name: 'QueuedSpec',
+        status: 'queued',
+        states_explored: null,
+        distinct_states: null,
+        diameter: null,
+        last_run_at: null,
+      }),
+    ])
+    render(html`<${TlcResultsPanel} />`)
+
+    fireEvent.click(screen.getByTestId('filter-chip-queued'))
+    const card = screen.getByTestId('card')
+    expect(card.textContent).toContain('QueuedSpec')
+    expect(card.textContent).not.toContain('PassingSpec')
+  })
+})

--- a/dashboard/src/components/tlc-results-panel.ts
+++ b/dashboard/src/components/tlc-results-panel.ts
@@ -1,0 +1,286 @@
+// TlcResultsPanel — surfaces last-known TLC model-checking evidence.
+//
+// Consumes:
+//   GET /api/v1/verification/tlc-results
+//
+// The backend may legitimately have no TLC output yet. This panel keeps that
+// absence visible so operators can distinguish "not checked" from "passed".
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import {
+  fetchTlcResults,
+  type TlaSpecCategory,
+  type TlcResultEntry,
+  type TlcResultsResponse,
+  type TlcResultStatus,
+} from '../api/dashboard'
+import { Btn } from './btn'
+import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
+import { ErrorState, LoadingState } from './common/feedback-state'
+import { FilterChips } from './common/filter-chips'
+import { StatusChip } from './common/status-chip'
+import type { ManagedAsyncResource } from '../lib/async-state'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+
+type StatusFilter = 'all' | TlcResultStatus
+
+const statusFilter = signal<StatusFilter>('all')
+
+const STATUS_ORDER: TlcResultStatus[] = [
+  'violated',
+  'error',
+  'running',
+  'queued',
+  'not_run',
+  'passed',
+]
+
+async function loadTlcResults(resource: ManagedAsyncResource<TlcResultsResponse>) {
+  await resource.load(async (signal) => fetchTlcResults({ signal }))
+}
+
+function categoryLabel(cat: TlaSpecCategory): string {
+  switch (cat) {
+    case 'boundary':
+      return '경계'
+    case 'bug-models':
+      return '버그 모델'
+    default:
+      return '기타'
+  }
+}
+
+function categoryTone(cat: TlaSpecCategory): 'ok' | 'warn' | 'neutral' {
+  switch (cat) {
+    case 'boundary':
+      return 'ok'
+    case 'bug-models':
+      return 'warn'
+    default:
+      return 'neutral'
+  }
+}
+
+export function tlcStatusLabel(status: TlcResultStatus): string {
+  switch (status) {
+    case 'passed':
+      return '통과'
+    case 'violated':
+      return '위반'
+    case 'running':
+      return '실행 중'
+    case 'queued':
+      return '대기'
+    case 'error':
+      return '오류'
+    case 'not_run':
+      return '미실행'
+  }
+}
+
+export function tlcStatusTone(status: TlcResultStatus): 'ok' | 'warn' | 'bad' | 'info' | 'neutral' {
+  switch (status) {
+    case 'passed':
+      return 'ok'
+    case 'violated':
+      return 'bad'
+    case 'running':
+      return 'info'
+    case 'error':
+      return 'warn'
+    case 'queued':
+    case 'not_run':
+      return 'neutral'
+  }
+}
+
+export function formatTlcMetric(value: number | null): string {
+  return value == null ? '-' : value.toLocaleString('ko-KR')
+}
+
+export function formatTlcTimestamp(value: string | null): string {
+  return value ? value.slice(0, 19).replace('T', ' ') : '기록 없음'
+}
+
+export function hasTlcEvidence(entry: TlcResultEntry): boolean {
+  return entry.status !== 'not_run'
+    || entry.last_run_at != null
+    || entry.states_explored != null
+    || entry.distinct_states != null
+    || entry.diameter != null
+    || entry.violation != null
+    || entry.log_path != null
+}
+
+export function filterTlcEntries(entries: TlcResultEntry[], filter: StatusFilter): TlcResultEntry[] {
+  const filtered = filter === 'all'
+    ? entries
+    : entries.filter((entry) => entry.status === filter)
+  return [...filtered].sort((a, b) => {
+    const at = a.last_run_at ?? ''
+    const bt = b.last_run_at ?? ''
+    if (at !== bt) return bt.localeCompare(at)
+    return `${a.spec_name}/${a.cfg_name}`.localeCompare(`${b.spec_name}/${b.cfg_name}`)
+  })
+}
+
+export function __resetTlcResultsPanelForTest(): void {
+  statusFilter.value = 'all'
+}
+
+function EvidenceCell({ entry }: { entry: TlcResultEntry }) {
+  if (entry.violation) {
+    return html`
+      <span
+        class="block max-w-[22rem] truncate text-[var(--bad-light)]"
+        title=${entry.violation}
+      >
+        ${entry.violation}
+      </span>
+    `
+  }
+  if (entry.log_path) {
+    return html`
+      <span
+        class="block max-w-[22rem] truncate font-mono text-[var(--color-fg-muted)]"
+        title=${entry.log_path}
+      >
+        ${entry.log_path}
+      </span>
+    `
+  }
+  return html`<span class="text-[var(--color-fg-disabled)]">증거 없음</span>`
+}
+
+function ResultsTable({ entries }: { entries: TlcResultEntry[] }) {
+  return html`
+    <div class="overflow-x-auto">
+      <table class="w-full text-xs tabular-nums" aria-label="TLC 실행 결과">
+        <thead class="text-left text-[var(--color-fg-muted)]">
+          <tr>
+            <th scope="col" class="py-1 pr-4">사양</th>
+            <th scope="col" class="py-1 pr-4">Cfg</th>
+            <th scope="col" class="py-1 pr-4">분류</th>
+            <th scope="col" class="py-1 pr-4">상태</th>
+            <th scope="col" class="py-1 pr-4 text-right">States</th>
+            <th scope="col" class="py-1 pr-4 text-right">Distinct</th>
+            <th scope="col" class="py-1 pr-4 text-right">Diameter</th>
+            <th scope="col" class="py-1 pr-4">마지막 실행</th>
+            <th scope="col" class="py-1">증거</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${entries.map((entry) => html`
+            <tr class="border-t border-[var(--white-10)]">
+              <td class="py-1 pr-4 font-medium text-[var(--color-fg-primary)]">${entry.spec_name}</td>
+              <td class="py-1 pr-4 font-mono text-[var(--color-fg-muted)]">${entry.cfg_name}</td>
+              <td class="py-1 pr-4">
+                <${StatusChip} tone=${categoryTone(entry.category)} label=${categoryLabel(entry.category)} />
+              </td>
+              <td class="py-1 pr-4">
+                <${StatusChip} tone=${tlcStatusTone(entry.status)} label=${tlcStatusLabel(entry.status)} />
+              </td>
+              <td class="py-1 pr-4 text-right text-[var(--color-fg-secondary)]">${formatTlcMetric(entry.states_explored)}</td>
+              <td class="py-1 pr-4 text-right text-[var(--color-fg-secondary)]">${formatTlcMetric(entry.distinct_states)}</td>
+              <td class="py-1 pr-4 text-right text-[var(--color-fg-secondary)]">${formatTlcMetric(entry.diameter)}</td>
+              <td class="py-1 pr-4 text-[var(--color-fg-muted)]">${formatTlcTimestamp(entry.last_run_at)}</td>
+              <td class="py-1"><${EvidenceCell} entry=${entry} /></td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+export function TlcResultsPanel() {
+  const resource = useManagedAsyncResource<TlcResultsResponse>()
+
+  useEffect(() => {
+    void loadTlcResults(resource)
+    const id = setInterval(() => void loadTlcResults(resource), 60_000)
+    return () => { clearInterval(id); resource.cancel() }
+  }, [resource])
+
+  const current = resource.state.value
+  const data = current.data
+  const allEntries = data?.entries ?? []
+  const filtered = filterTlcEntries(allEntries, statusFilter.value)
+  const resultsDir = data?.results_dir ?? '(not configured)'
+  const hasAnyEvidence = allEntries.some(hasTlcEvidence)
+
+  const statusCounts = new Map<TlcResultStatus, number>()
+  for (const status of STATUS_ORDER) statusCounts.set(status, 0)
+  for (const entry of allEntries) {
+    statusCounts.set(entry.status, (statusCounts.get(entry.status) ?? 0) + 1)
+  }
+
+  return html`
+    <${Card} title="TLC 결과">
+      <div class="flex flex-col gap-3">
+        <div class="flex items-center gap-3 flex-wrap">
+          <${Btn} onClick=${() => void loadTlcResults(resource)}>
+            새로고침
+          <//>
+          ${current.loading ? html`<span class="text-xs text-[var(--color-fg-muted)]" role="status">로딩 중...</span>` : null}
+          ${data?.updated_at
+            ? html`<span class="text-xs text-[var(--color-fg-muted)]">tlc · ${data.updated_at}</span>`
+            : null}
+          ${data
+            ? html`<span class="text-xs text-[var(--color-fg-muted)]">
+                ${statusFilter.value === 'all'
+                  ? `총 ${data.count}건`
+                  : `${filtered.length} / ${data.count}건`}
+              </span>`
+            : null}
+        </div>
+
+        <div class="text-xs text-[var(--color-fg-muted)]">
+          <span class="font-mono">${resultsDir}</span>
+        </div>
+
+        <${FilterChips}
+          chips=${[
+            { key: 'all' as StatusFilter, label: '전체', count: allEntries.length },
+            ...STATUS_ORDER.map((status) => ({
+              key: status as StatusFilter,
+              label: tlcStatusLabel(status),
+              count: statusCounts.get(status) ?? 0,
+            })),
+          ]}
+          active=${statusFilter}
+          size="sm"
+          tone="accent"
+        />
+
+        ${current.error ? html`<${ErrorState} message=${current.error} />` : null}
+
+        ${current.loading && !data
+          ? html`<${LoadingState}>TLC 결과 불러오는 중...<//>`
+          : null}
+
+        ${data && allEntries.length > 0 && !hasAnyEvidence
+          ? html`
+            <div
+              class="rounded border border-[var(--warn-20)] bg-[var(--warn-soft)] px-3 py-2 text-xs text-[var(--warn-bright)]"
+              role="status"
+            >
+              TLC 실행 증거 없음: 등록된 항목은 있지만 마지막 실행, 상태 공간, 로그 경로가 아직 없습니다.
+            </div>
+          `
+          : null}
+
+        ${!current.loading && data && allEntries.length === 0
+          ? html`<${EmptyState} compact message="TLC 결과 항목이 없습니다 (results_dir 미설정 또는 아직 수집 전)." />`
+          : filtered.length === 0 && data
+            ? html`<${EmptyState} compact message="선택한 상태의 TLC 결과가 없습니다." />`
+            : filtered.length > 0
+              ? html`<${ResultsTable} entries=${filtered} />`
+              : null}
+      </div>
+    <//>
+  `
+}

--- a/dashboard/src/components/turn-fsm-detail-panel.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.ts
@@ -1,0 +1,124 @@
+import { html } from 'htm/preact'
+import { useMemo } from 'preact/hooks'
+
+import type { KeeperCompositeSnapshot } from '../api/keeper'
+import { CytoscapeFsm } from './common/cytoscape-fsm'
+import {
+  buildTurnFsmSpec,
+  normalizeTurnFsmState,
+  turnFsmTlaSymbol,
+} from './keeper-fsm-specs'
+
+function chipClass(tone: 'accent' | 'neutral' | 'warn' | 'err' | 'ok'): string {
+  switch (tone) {
+    case 'accent':
+      return 'border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]'
+    case 'warn':
+      return 'border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--color-status-warn)]'
+    case 'err':
+      return 'border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--color-status-err)]'
+    case 'ok':
+      return 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--color-status-ok)]'
+    case 'neutral':
+    default:
+      return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--color-fg-muted)]'
+  }
+}
+
+function terminalTone(outcome: string | null | undefined): 'neutral' | 'ok' | 'warn' | 'err' {
+  switch (outcome) {
+    case 'done':
+    case 'skipped':
+      return 'ok'
+    case 'cancelled':
+      return 'warn'
+    case 'failed':
+    case 'error':
+      return 'err'
+    default:
+      return 'neutral'
+  }
+}
+
+function isExactTurnProjection(rawTurnPhase: string, projected: string | null): boolean {
+  const normalized = rawTurnPhase.trim().toLowerCase()
+  return normalized === projected || (normalized === 'awaiting_tool' && projected === 'awaiting_tool_result')
+}
+
+export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
+  const spec = useMemo(
+    () => buildTurnFsmSpec(snapshot.turn_phase),
+    [snapshot.turn_phase],
+  )
+  const projectedState = normalizeTurnFsmState(snapshot.turn_phase)
+  const tlaSymbol = projectedState ? turnFsmTlaSymbol(projectedState) : null
+  const isCoarse = projectedState ? !isExactTurnProjection(snapshot.turn_phase, projectedState) : false
+  const execution = snapshot.execution
+  const terminalReason =
+    execution?.terminal_reason_code
+    ?? execution?.stop_reason
+    ?? execution?.error?.kind
+    ?? null
+
+  return html`
+    <section
+      class="grid gap-3"
+      role="region"
+      aria-labelledby="turn-fsm-detail-title"
+    >
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <div id="turn-fsm-detail-title" class="text-3xs font-semibold uppercase tracking-1 text-[var(--color-fg-muted)]">
+            Turn FSM detail
+          </div>
+          <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">
+            keeper_turn_fsm projection from current composite turn_phase
+          </div>
+        </div>
+        <div class="flex flex-wrap items-center gap-1.5 text-3xs">
+          <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass(projectedState ? 'accent' : 'warn')}`}>
+            ${projectedState ?? 'unmapped'}
+          </span>
+          <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass('neutral')}`}>
+            KTC ${snapshot.turn_phase}
+          </span>
+          ${isCoarse ? html`
+            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 ${chipClass('warn')}`}>
+              coarse legacy map
+            </span>
+          ` : null}
+          ${tlaSymbol ? html`
+            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass('neutral')}`}>
+              TLA ${tlaSymbol}
+            </span>
+          ` : null}
+        </div>
+      </div>
+
+      <${CytoscapeFsm} spec=${spec} height="300px" />
+
+      ${execution ? html`
+        <div class="flex flex-wrap items-center gap-1.5 text-3xs" aria-label="latest turn receipt summary">
+          <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 ${chipClass(terminalTone(execution.outcome))}`}>
+            receipt ${execution.outcome ?? 'unknown'}
+          </span>
+          ${terminalReason ? html`
+            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass(terminalTone(execution.outcome))}`}>
+              reason ${terminalReason}
+            </span>
+          ` : null}
+          ${execution.tool_contract_result ? html`
+            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass(execution.tool_contract_result === 'violated' ? 'err' : 'neutral')}`}>
+              tool ${execution.tool_contract_result}
+            </span>
+          ` : null}
+          ${execution.model_used ? html`
+            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass('neutral')}`}>
+              model ${execution.model_used}
+            </span>
+          ` : null}
+        </div>
+      ` : null}
+    </section>
+  `
+}

--- a/dashboard/src/components/verification-specs-panel.ts
+++ b/dashboard/src/components/verification-specs-panel.ts
@@ -26,6 +26,7 @@ import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import type { ManagedAsyncResource } from '../lib/async-state'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+import { TlcResultsPanel } from './tlc-results-panel'
 
 type CategoryFilter = 'all' | TlaSpecCategory
 const categoryFilter = signal<CategoryFilter>('all')
@@ -195,6 +196,8 @@ export function VerificationSpecsPanel() {
               : '조건에 맞는 스펙이 없습니다.'} />`
           : html`<${SpecsTable} entries=${filtered} />`}
       <//>
+
+      <${TlcResultsPanel} />
     </div>
   `
 }

--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -7,10 +7,36 @@ type spec_entry = {
   mtime : float;
 }
 
+type tlc_status =
+  | Tlc_passed
+  | Tlc_violated
+  | Tlc_running
+  | Tlc_queued
+  | Tlc_error
+  | Tlc_not_run
+
+type tlc_result_entry = {
+  spec_name : string;
+  cfg_name : string;
+  category : string;
+  status : tlc_status;
+  states_explored : int option;
+  distinct_states : int option;
+  diameter : int option;
+  last_run_at : float option;
+  violation : string option;
+  log_path : string option;
+}
+
 let specs_dir () =
   match Sys.getenv_opt "MASC_SPECS_DIR" with
   | Some p when p <> "" -> p
   | _ -> "specs"
+
+let tlc_results_dir () =
+  match Sys.getenv_opt "MASC_TLC_RESULTS_DIR" with
+  | Some p when p <> "" -> p
+  | _ -> Filename.get_temp_dir_name ()
 
 let category_of_subdir = function
   | "boundary" -> "boundary"
@@ -61,7 +87,7 @@ let list_specs () =
   else
     readdir_safe root
     |> List.concat_map (fun sub -> scan_subdir ~root sub)
-    |> List.sort (fun a b ->
+    |> List.sort (fun (a : spec_entry) (b : spec_entry) ->
       match String.compare a.category b.category with
       | 0 -> String.compare a.name b.name
       | c -> c)
@@ -97,4 +123,200 @@ let specs_json () : Yojson.Safe.t =
     "specs_dir", specs_dir_json root;
     "count", `Int (List.length entries);
     "entries", `List (List.map entry_to_json entries);
+  ]
+
+let read_file_safe path =
+  try
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let len = in_channel_length ic in
+         really_input_string ic len)
+    |> fun contents -> Some contents
+  with Sys_error _ | End_of_file -> None
+
+let normalize_int s =
+  String.to_seq s
+  |> Seq.filter (fun c -> c <> ',')
+  |> String.of_seq
+  |> int_of_string_opt
+
+let contains_substring needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0 then true
+  else if needle_len > haystack_len then false
+  else
+    let rec loop i =
+      i + needle_len <= haystack_len
+      && (String.sub haystack i needle_len = needle || loop (i + 1))
+    in
+    loop 0
+
+let split_lines text =
+  String.split_on_char '\n' text |> List.map String.trim
+
+let digit_token_to_int token =
+  let cleaned =
+    token
+    |> String.to_seq
+    |> Seq.filter (function
+         | '0' .. '9' | ',' -> true
+         | _ -> false)
+    |> String.of_seq
+  in
+  if cleaned = "" then None else normalize_int cleaned
+
+let ints_in_line line =
+  line
+  |> String.split_on_char ' '
+  |> List.filter_map digit_token_to_int
+
+let violation_line text =
+  split_lines text
+  |> List.find_opt (fun line ->
+       contains_substring " is violated" line
+       || contains_substring "Temporal properties were violated" line
+       || contains_substring "Invariant " line
+          && contains_substring "violated" line)
+  |> Option.map String.trim
+
+let status_of_log text =
+  if contains_substring "Model checking completed. No error has been found." text
+  then Tlc_passed
+  else if Option.is_some (violation_line text)
+  then Tlc_violated
+  else if contains_substring "Error:" text
+          || contains_substring "Exception" text
+          || contains_substring "Parsing failed" text
+  then Tlc_error
+  else Tlc_running
+
+let tlc_status_to_string = function
+  | Tlc_passed -> "passed"
+  | Tlc_violated -> "violated"
+  | Tlc_running -> "running"
+  | Tlc_queued -> "queued"
+  | Tlc_error -> "error"
+  | Tlc_not_run -> "not_run"
+
+let metrics_of_log text =
+  let state_pair =
+    split_lines text
+    |> List.find_map (fun line ->
+         if contains_substring "states generated" line
+            && contains_substring "distinct states" line
+         then
+           match ints_in_line line with
+           | a :: b :: _ -> Some (a, b)
+           | _ -> None
+         else None)
+  in
+  let states_explored, distinct_states =
+    match state_pair with
+    | Some (a, b) -> Some a, Some b
+    | None -> None, None
+  in
+  let diameter =
+    split_lines text
+    |> List.find_map (fun line ->
+         if contains_substring "depth of the complete state graph search" line
+         then
+           match ints_in_line line with
+           | value :: _ -> Some value
+           | [] -> None
+         else None)
+  in
+  states_explored, distinct_states, diameter
+
+let cfg_entries_for_spec (entry : spec_entry) =
+  let clean =
+    if entry.has_clean_cfg then
+      [ (entry.name ^ ".cfg", entry.name) ]
+    else []
+  in
+  let buggy =
+    if entry.has_buggy_cfg then
+      [ (entry.name ^ "-buggy.cfg", entry.name ^ "-buggy") ]
+    else []
+  in
+  clean @ buggy
+
+let result_for_cfg ~results_dir (spec : spec_entry) (cfg_name, cfg_stem) =
+  let log_path = Filename.concat results_dir ("tlc-" ^ cfg_stem ^ ".log") in
+  match read_file_safe log_path with
+  | None ->
+      {
+        spec_name = spec.name;
+        cfg_name;
+        category = spec.category;
+        status = Tlc_not_run;
+        states_explored = None;
+        distinct_states = None;
+        diameter = None;
+        last_run_at = None;
+        violation = None;
+        log_path = None;
+      }
+  | Some text ->
+      let states_explored, distinct_states, diameter = metrics_of_log text in
+      {
+        spec_name = spec.name;
+        cfg_name;
+        category = spec.category;
+        status = status_of_log text;
+        states_explored;
+        distinct_states;
+        diameter;
+        last_run_at = Some (safe_stat_mtime log_path);
+        violation = violation_line text;
+        log_path = Some log_path;
+      }
+
+let list_tlc_results () =
+  let results_dir = tlc_results_dir () in
+  list_specs ()
+  |> List.concat_map (fun spec ->
+       cfg_entries_for_spec spec
+       |> List.map (result_for_cfg ~results_dir spec))
+
+let option_int_json = function
+  | Some v -> `Int v
+  | None -> `Null
+
+let option_string_json = function
+  | Some v -> `String v
+  | None -> `Null
+
+let option_time_json = function
+  | Some v -> `String (iso_of_unix_time v)
+  | None -> `Null
+
+let tlc_entry_to_json e : Yojson.Safe.t =
+  `Assoc [
+    "spec_name", `String e.spec_name;
+    "cfg_name", `String e.cfg_name;
+    "category", `String e.category;
+    "status", `String (tlc_status_to_string e.status);
+    "states_explored", option_int_json e.states_explored;
+    "distinct_states", option_int_json e.distinct_states;
+    "diameter", option_int_json e.diameter;
+    "last_run_at", option_time_json e.last_run_at;
+    "violation", option_string_json e.violation;
+    "log_path", option_string_json e.log_path;
+  ]
+
+let tlc_results_json () : Yojson.Safe.t =
+  let results_dir = tlc_results_dir () in
+  let entries = list_tlc_results () in
+  `Assoc [
+    "updated_at", `String (iso_of_unix_time (Unix.gettimeofday ()));
+    "results_dir",
+      (if is_directory_safe results_dir then
+         try `String (Unix.realpath results_dir)
+         with Unix.Unix_error _ -> `String results_dir
+       else `Null);
+    "count", `Int (List.length entries);
+    "entries", `List (List.map tlc_entry_to_json entries);
   ]

--- a/lib/dashboard_tla_specs.mli
+++ b/lib/dashboard_tla_specs.mli
@@ -51,3 +51,36 @@ val specs_json : unit -> Yojson.Safe.t
       }
     ]}
 *)
+
+type tlc_status =
+  | Tlc_passed
+  | Tlc_violated
+  | Tlc_running
+  | Tlc_queued
+  | Tlc_error
+  | Tlc_not_run
+
+type tlc_result_entry = {
+  spec_name : string;
+  cfg_name : string;
+  category : string;
+  status : tlc_status;
+  states_explored : int option;
+  distinct_states : int option;
+  diameter : int option;
+  last_run_at : float option;
+  violation : string option;
+  log_path : string option;
+}
+
+val tlc_results_dir : unit -> string
+(** Directory containing TLC logs. Reads [MASC_TLC_RESULTS_DIR], falling back
+    to the host temporary directory. This matches [specs/Makefile], which
+    writes logs as [tlc-<cfg-stem>.log]. *)
+
+val list_tlc_results : unit -> tlc_result_entry list
+(** Project every discovered clean / buggy cfg to its last observed TLC result.
+    Missing logs are reported as [Tlc_not_run]; this function never runs TLC. *)
+
+val tlc_results_json : unit -> Yojson.Safe.t
+(** JSON bundle suitable for [/api/v1/verification/tlc-results]. *)

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -108,6 +108,7 @@ type snapshot = {
   run_id : string;
   ts : float;
   ksm_phase : ksm_phase;
+  raw_phase : Keeper_state_machine.phase;
   collapsed_from : Keeper_state_machine.phase option;
   ktc_turn_phase : turn_phase;
   kdp_decision : decision_stage;
@@ -116,6 +117,7 @@ type snapshot = {
   kcb_state : Keeper_failure_circuit_breaker.display_state;
   shared_measurement : Keeper_state_machine.auto_rule_summary option;
   invariants : invariants_check;
+  conditions : Keeper_state_machine.conditions;
   is_live : bool;
   last_outcome : last_outcome option;
   fiber_stop_flag : bool;
@@ -443,6 +445,7 @@ let observe
     run_id;
     ts;
     ksm_phase;
+    raw_phase = entry.phase;
     collapsed_from;
     ktc_turn_phase = turn_phase;
     kdp_decision = decision_stage;
@@ -451,6 +454,7 @@ let observe
     kcb_state;
     shared_measurement = measurement;
     invariants;
+    conditions = entry.conditions;
     is_live;
     last_outcome =
       (match entry.last_completed_turn with
@@ -505,6 +509,102 @@ let measurement_to_json (m : Keeper_state_machine.auto_rule_summary) : Yojson.Sa
       "goal_drift", `Float m.goal_drift;
     ]
 
+type phase_condition_row = {
+  key : string;
+  label : string;
+  priority : int;
+  value : bool;
+  phase : Keeper_state_machine.phase;
+}
+
+let phase_condition_rows (c : Keeper_state_machine.conditions) : phase_condition_row list =
+  let row key label priority value phase =
+    { key; label; priority; value; phase }
+  in
+  [
+    row "stopped_clean_drain" "Stopped: clean drain complete" 1
+      (c.stop_requested && c.drain_complete
+       && not c.compaction_active && not c.handoff_active)
+      Keeper_state_machine.Stopped;
+    row "offline_launch_pending" "Offline: launch pending without fiber" 2
+      (c.launch_pending && not c.fiber_alive)
+      Keeper_state_machine.Offline;
+    row "zombie_terminal_failure" "Zombie: terminal failure latched" 3
+      c.terminal_failure_latched
+      Keeper_state_machine.Zombie;
+    row "dead_no_fiber_no_budget" "Dead: fiber down and restart budget exhausted" 4
+      ((not c.fiber_alive) && not c.restart_budget_remaining)
+      Keeper_state_machine.Dead;
+    row "restarting_backoff_elapsed" "Restarting: fiber down with elapsed backoff" 5
+      ((not c.fiber_alive) && c.restart_budget_remaining && c.backoff_elapsed)
+      Keeper_state_machine.Restarting;
+    row "crashed_restart_budget" "Crashed: fiber down with restart budget" 6
+      ((not c.fiber_alive) && c.restart_budget_remaining)
+      Keeper_state_machine.Crashed;
+    row "draining_stop_requested" "Draining: stop requested" 7
+      c.stop_requested
+      Keeper_state_machine.Draining;
+    row "failing_guardrail" "Failing: guardrail triggered" 8
+      c.guardrail_triggered
+      Keeper_state_machine.Failing;
+    row "paused_operator_or_retry_exhausted" "Paused: operator pause or compact retry exhausted" 9
+      (c.operator_paused || (c.context_overflow && c.compact_retry_exhausted))
+      Keeper_state_machine.Paused;
+    row "handing_off_active" "HandingOff: handoff active" 10
+      c.handoff_active
+      Keeper_state_machine.HandingOff;
+    row "compacting_active" "Compacting: compaction active" 11
+      c.compaction_active
+      Keeper_state_machine.Compacting;
+    row "overflowed_context" "Overflowed: context overflow awaiting compaction" 12
+      c.context_overflow
+      Keeper_state_machine.Overflowed;
+    row "failing_unhealthy" "Failing: heartbeat or turn unhealthy" 13
+      ((not c.heartbeat_healthy) || not c.turn_healthy)
+      Keeper_state_machine.Failing;
+    row "running_fiber_alive" "Running: fiber alive" 14
+      c.fiber_alive
+      Keeper_state_machine.Running;
+    row "offline_fallback" "Offline: fallback" 15
+      true
+      Keeper_state_machine.Offline;
+  ]
+
+let phase_diagnosis_to_json
+    ~(current_phase : Keeper_state_machine.phase)
+    (conditions : Keeper_state_machine.conditions)
+    : Yojson.Safe.t =
+  let derived_phase = Keeper_state_machine.derive_phase conditions in
+  let rows = phase_condition_rows conditions in
+  let determining =
+    rows
+    |> List.find_opt (fun row -> row.value)
+    |> Option.map (fun row -> row.key)
+  in
+  `Assoc [
+    "current_phase", `String (Keeper_state_machine.phase_to_string current_phase);
+    "derived_phase", `String (Keeper_state_machine.phase_to_string derived_phase);
+    "can_execute_turn", `Bool (Keeper_state_machine.can_execute_turn derived_phase);
+    "conditions", Keeper_state_machine.conditions_to_json conditions;
+    "determining_condition",
+      (match determining with
+       | Some key -> `String key
+       | None -> `Null);
+    "rows",
+      `List
+        (List.map
+           (fun row ->
+              `Assoc [
+                "key", `String row.key;
+                "label", `String row.label;
+                "priority", `Int row.priority;
+                "value", `Bool row.value;
+                "phase", `String (Keeper_state_machine.phase_to_string row.phase);
+                "determining", `Bool (Some row.key = determining);
+              ])
+           rows);
+  ]
+
 let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
   `Assoc [
     "keeper", `String s.keeper_name;
@@ -541,6 +641,8 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
           "captured", `Bool false;
         ]);
     "invariants", invariants_to_json s.invariants;
+    "phase_diagnosis", phase_diagnosis_to_json
+      ~current_phase:s.raw_phase s.conditions;
     "is_live", `Bool s.is_live;
     "last_outcome", (match s.last_outcome with
       | Some lo -> `Assoc [

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -173,6 +173,10 @@ type snapshot = {
   run_id : string;
   ts : float;
   ksm_phase : ksm_phase;
+  raw_phase : Keeper_state_machine.phase;
+      (** Full 12-state keeper phase before the composite 12->7 collapse.
+          Dashboard diagnostics use this to explain why [derive_phase]
+          selected the current runtime phase. *)
   collapsed_from : Keeper_state_machine.phase option;
       (** Raw keeper phase collapsed into [Ksm_stable], when applicable.
           [None] for active composite phases or older payload readers.
@@ -189,6 +193,10 @@ type snapshot = {
           {!Keeper_failure_circuit_breaker.display_state}. *)
   shared_measurement : Keeper_state_machine.auto_rule_summary option;
   invariants : invariants_check;
+  conditions : Keeper_state_machine.conditions;
+      (** Raw observable conditions that derive [raw_phase]. Exposed for
+          dashboard diagnostics; callers should not infer composite state from
+          this when the dedicated axes above are present. *)
   is_live : bool;
       (** [true] when [current_turn_observation] is [Some] — a turn is
           actively executing and the live sub-FSM fields reflect its

--- a/lib/server/server_routes_http_routes_verification.ml
+++ b/lib/server/server_routes_http_routes_verification.ml
@@ -12,6 +12,8 @@
       paging the full request list.
     - [GET /api/v1/verification/specs] — TLA+ spec index with clean / buggy
       cfg coverage (see {!Dashboard_tla_specs}).
+    - [GET /api/v1/verification/tlc-results] — latest observed TLC log
+      projection for each clean / buggy cfg.
     - [POST /api/v1/verification/resolve] — dashboard-initiated approve/reject
       for a pending verification request. Requires bearer token auth; the
       verifier identity is derived from the authenticated dashboard actor
@@ -70,6 +72,12 @@ let add_routes router =
   |> Http.Router.get "/api/v1/verification/specs" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Dashboard_tla_specs.specs_json () in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/verification/tlc-results" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = Dashboard_tla_specs.tlc_results_json () in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_verification.mli
+++ b/lib/server/server_routes_http_routes_verification.mli
@@ -5,6 +5,8 @@
       rejected verification requests.
     - [GET /api/v1/verification/summary] — bucket counts.
     - [GET /api/v1/verification/specs] — TLA+ spec index.
+    - [GET /api/v1/verification/tlc-results] — latest observed TLC
+      log projection.
     - [POST /api/v1/verification/resolve] — dashboard-initiated
       approve/reject (bearer token required). *)
 

--- a/test/test_dashboard_tla_specs.ml
+++ b/test/test_dashboard_tla_specs.ml
@@ -2,6 +2,11 @@
 
 open Alcotest
 
+let write_file path contents =
+  let oc = open_out path in
+  output_string oc contents;
+  close_out oc
+
 let make_fixture_dir () =
   let root = Filename.temp_file "masc-specs-" "" in
   Unix.unlink root;
@@ -10,17 +15,12 @@ let make_fixture_dir () =
   let bugs = Filename.concat root "bug-models" in
   Unix.mkdir boundary 0o755;
   Unix.mkdir bugs 0o755;
-  let write path contents =
-    let oc = open_out path in
-    output_string oc contents;
-    close_out oc
-  in
-  write (Filename.concat boundary "CascadeStrategy.tla") "MODULE CascadeStrategy\n";
-  write (Filename.concat boundary "CascadeStrategy.cfg") "SPECIFICATION Spec\n";
-  write (Filename.concat boundary "CascadeStrategy-buggy.cfg") "SPECIFICATION SpecBuggy\n";
-  write (Filename.concat boundary "ZOnlyTla.tla") "MODULE ZOnlyTla\n";
-  write (Filename.concat bugs "Overflow.tla") "MODULE Overflow\n";
-  write (Filename.concat bugs "Overflow.cfg") "SPECIFICATION Spec\n";
+  write_file (Filename.concat boundary "CascadeStrategy.tla") "MODULE CascadeStrategy\n";
+  write_file (Filename.concat boundary "CascadeStrategy.cfg") "SPECIFICATION Spec\n";
+  write_file (Filename.concat boundary "CascadeStrategy-buggy.cfg") "SPECIFICATION SpecBuggy\n";
+  write_file (Filename.concat boundary "ZOnlyTla.tla") "MODULE ZOnlyTla\n";
+  write_file (Filename.concat bugs "Overflow.tla") "MODULE Overflow\n";
+  write_file (Filename.concat bugs "Overflow.cfg") "SPECIFICATION Spec\n";
   root
 
 let cleanup root =
@@ -40,6 +40,16 @@ let with_specs_dir root f =
       match saved with
       | Some v -> Unix.putenv "MASC_SPECS_DIR" v
       | None -> Unix.putenv "MASC_SPECS_DIR" "")
+    f
+
+let with_tlc_results_dir root f =
+  let saved = Sys.getenv_opt "MASC_TLC_RESULTS_DIR" in
+  Unix.putenv "MASC_TLC_RESULTS_DIR" root;
+  Fun.protect
+    ~finally:(fun () ->
+      match saved with
+      | Some v -> Unix.putenv "MASC_TLC_RESULTS_DIR" v
+      | None -> Unix.putenv "MASC_TLC_RESULTS_DIR" "")
     f
 
 let test_list_specs_basic () =
@@ -117,6 +127,85 @@ let test_json_shape () =
          | _ -> fail "entries should be list")
       | _ -> fail "expected assoc"))
 
+let test_tlc_results_from_logs () =
+  let specs_root = make_fixture_dir () in
+  let logs_root = Filename.temp_file "masc-tlc-results-" "" in
+  Unix.unlink logs_root;
+  Unix.mkdir logs_root 0o755;
+  Fun.protect
+    ~finally:(fun () -> cleanup specs_root; cleanup logs_root)
+    (fun () ->
+      write_file
+        (Filename.concat logs_root "tlc-CascadeStrategy.log")
+        "Model checking completed. No error has been found.\n334 states generated, 334 distinct states found, 0 states left on queue.\nThe depth of the complete state graph search is 14.\n";
+      write_file
+        (Filename.concat logs_root "tlc-CascadeStrategy-buggy.log")
+        "Error: Invariant SafetyInvariant is violated.\n99 states generated, 42 distinct states found, 0 states left on queue.\n";
+      with_specs_dir specs_root (fun () ->
+        with_tlc_results_dir logs_root (fun () ->
+          let entries = Masc_mcp.Dashboard_tla_specs.list_tlc_results () in
+          check int "cfg-backed results" 3 (List.length entries);
+          let cascade =
+            List.find
+              (fun (e : Masc_mcp.Dashboard_tla_specs.tlc_result_entry) ->
+                 e.cfg_name = "CascadeStrategy.cfg")
+              entries
+          in
+          check string "clean spec name" "CascadeStrategy" cascade.spec_name;
+          check bool "clean log path present" true (Option.is_some cascade.log_path);
+          check (option int) "states generated" (Some 334) cascade.states_explored;
+          check (option int) "distinct states" (Some 334) cascade.distinct_states;
+          check (option int) "diameter" (Some 14) cascade.diameter;
+          check bool "clean passed" true
+            (match cascade.status with
+             | Masc_mcp.Dashboard_tla_specs.Tlc_passed -> true
+             | _ -> false);
+          let buggy =
+            List.find
+              (fun (e : Masc_mcp.Dashboard_tla_specs.tlc_result_entry) ->
+                 e.cfg_name = "CascadeStrategy-buggy.cfg")
+              entries
+          in
+          check bool "buggy violated" true
+            (match buggy.status with
+             | Masc_mcp.Dashboard_tla_specs.Tlc_violated -> true
+             | _ -> false);
+          check (option string) "violation line"
+            (Some "Error: Invariant SafetyInvariant is violated.")
+            buggy.violation;
+          let overflow =
+            List.find
+              (fun (e : Masc_mcp.Dashboard_tla_specs.tlc_result_entry) ->
+                 e.cfg_name = "Overflow.cfg")
+              entries
+          in
+          check bool "missing log is not_run" true
+            (match overflow.status with
+             | Masc_mcp.Dashboard_tla_specs.Tlc_not_run -> true
+             | _ -> false))))
+
+let test_tlc_results_json_shape () =
+  let root = make_fixture_dir () in
+  let logs_root = Filename.temp_file "masc-tlc-json-" "" in
+  Unix.unlink logs_root;
+  Unix.mkdir logs_root 0o755;
+  Fun.protect
+    ~finally:(fun () -> cleanup root; cleanup logs_root)
+    (fun () ->
+      with_specs_dir root (fun () ->
+        with_tlc_results_dir logs_root (fun () ->
+          let json = Masc_mcp.Dashboard_tla_specs.tlc_results_json () in
+          match json with
+          | `Assoc fields ->
+            check bool "has updated_at" true (List.mem_assoc "updated_at" fields);
+            check bool "has results_dir" true (List.mem_assoc "results_dir" fields);
+            check bool "has count" true (List.mem_assoc "count" fields);
+            check bool "has entries" true (List.mem_assoc "entries" fields);
+            (match List.assoc "count" fields with
+             | `Int 3 -> ()
+             | _ -> fail "count should be 3")
+          | _ -> fail "expected assoc")))
+
 let () =
   run "dashboard_tla_specs"
     [
@@ -128,5 +217,9 @@ let () =
       ];
       "json", [
         test_case "shape" `Quick test_json_shape;
+      ];
+      "tlc_results", [
+        test_case "reads latest logs" `Quick test_tlc_results_from_logs;
+        test_case "json shape" `Quick test_tlc_results_json_shape;
       ];
     ]

--- a/test/test_keeper_composite_observer.ml
+++ b/test/test_keeper_composite_observer.ml
@@ -187,6 +187,40 @@ let test_snapshot_reports_keeper_identity () =
       (Some keeper_name)
       (Json.member "keeper" snapshot |> Json.to_string_option))
 
+let test_snapshot_reports_phase_diagnosis () =
+  with_registry (fun () ->
+    let base_path = "/tmp/keeper-composite-phase-diagnosis" in
+    let keeper_name = "phase-diagnosis" in
+    ignore (Reg.register ~base_path keeper_name (make_meta keeper_name));
+    ignore (Reg.dispatch_event ~base_path keeper_name Ksm.Operator_pause);
+    let entry =
+      match Reg.get ~base_path keeper_name with
+      | Some entry -> entry
+      | None -> fail "expected paused keeper entry"
+    in
+    let snapshot = Obs.observe entry |> Obs.snapshot_to_json in
+    let diagnosis = Json.member "phase_diagnosis" snapshot in
+    check (option string) "current phase is raw keeper phase"
+      (Some "paused")
+      (Json.member "current_phase" diagnosis |> Json.to_string_option);
+    check (option string) "derived phase matches conditions"
+      (Some "paused")
+      (Json.member "derived_phase" diagnosis |> Json.to_string_option);
+    check bool "paused cannot execute turn"
+      false
+      (Json.member "can_execute_turn" diagnosis |> Json.to_bool);
+    check (option string) "operator pause wins"
+      (Some "paused_operator_or_retry_exhausted")
+      (Json.member "determining_condition" diagnosis |> Json.to_string_option);
+    let rows = Json.member "rows" diagnosis |> Json.to_list in
+    check int "priority rows include fallback" 15 (List.length rows);
+    let determining =
+      rows
+      |> List.filter (fun row ->
+           Json.member "determining" row |> Json.to_bool)
+    in
+    check int "exactly one determining row" 1 (List.length determining))
+
 let test_direct_turn_mutations_emit_composite_changed () =
   with_registry (fun () ->
     let base_path = "/tmp/keeper-composite-turn-ticks" in
@@ -221,6 +255,7 @@ let () =
     [ test_case "stable phase exposes collapsed_from" `Quick test_snapshot_reports_collapsed_from_for_stable_phase
     ; test_case "active phase leaves collapsed_from null" `Quick test_snapshot_omits_collapsed_from_for_active_phase
     ; test_case "snapshot exposes keeper identity" `Quick test_snapshot_reports_keeper_identity
+    ; test_case "snapshot exposes phase diagnosis" `Quick test_snapshot_reports_phase_diagnosis
     ];
     "composite change signals",
     [ test_case "direct turn mutations emit composite tick" `Quick test_direct_turn_mutations_emit_composite_changed ];


### PR DESCRIPTION
## Summary

- Add `/api/v1/verification/tlc-results` so the dashboard can show latest TLC evidence without running TLC from the request path.
- Project keeper composite phase diagnosis from the backend, including raw phase, derived phase, determining condition, and executable condition rows.
- Surface the audit gaps in the dashboard with TLC results, phase conditions, backend Mermaid, and Turn FSM detail panels.

## Product impact

Operators can now distinguish "not run", "passed", and "failed" TLC evidence, inspect why a keeper is blocked or executable, and compare backend-generated FSM state with dashboard-side Turn FSM detail. This closes the audit gap where FSM truth existed in backend/test artifacts but was not visible enough in the operator UI.

## Evidence

- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build ./test/test_dashboard_tla_specs.exe ./test/test_keeper_composite_observer.exe`
- `./_build/default/test/test_dashboard_tla_specs.exe` (7 tests)
- `./_build/default/test/test_keeper_composite_observer.exe` (10 tests)
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/api/keeper.test.ts src/api/keeper-composite-schema.test.ts src/components/keeper-fsm-specs.test.ts src/components/phase-conditions-panel.test.ts src/components/tlc-results-panel.test.ts src/components/verification-specs-panel.test.ts --no-file-parallelism --maxWorkers=1` (6 files / 102 tests)
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard lint`

## Review evidence

- Review backend contract shape in `lib/dashboard_tla_specs.ml`, `lib/keeper/keeper_composite_observer.ml`, and `lib/server/server_routes_http_routes_verification.ml`.
- Review dashboard schema/normalization and no-evidence states in `dashboard/src/components/tlc-results-panel.ts` and `dashboard/src/components/phase-conditions-panel.ts`.
- Review state-diagram UI behavior in `dashboard/src/components/keeper-state-diagram.ts`.

## Linked issue

None. Follow-up implementation from local audit artifact `/Users/dancer/Downloads/DASHBOARD_FSM_AUDIT.md`.
