### PR TITLE
keeper: annotate test-hook + fiber-signal mutations (Track 1B step 1)

### DIFF
--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -305,6 +305,7 @@ let resolution_event_of_json json =
 
 let read_window_entries (config : Coord_query.config) =
   (match !window_read_count_for_testing_ref with
+  (* tla-lint: allow-mutation: test hook — opt-in counter for window-read assertions *)
   | Some count -> window_read_count_for_testing_ref := Some (count + 1)
   | None -> ());
   let now = Time_compat.now () in
@@ -957,9 +958,11 @@ let accountability_summary_json (config : Coord_query.config) ~keeper_name
   accountability_summary_lookup config ~keeper_name ~agent_name
 
 let enable_window_read_count_for_testing () =
+  (* tla-lint: allow-mutation: test hook — initialise opt-in counter from test setup *)
   window_read_count_for_testing_ref := Some 0
 
 let disable_window_read_count_for_testing () =
+  (* tla-lint: allow-mutation: test hook — clear opt-in counter from test teardown *)
   window_read_count_for_testing_ref := None
 
 let window_read_count_for_testing () =

--- a/lib/keeper/keeper_fsm_guard_runtime.ml
+++ b/lib/keeper/keeper_fsm_guard_runtime.ml
@@ -17,6 +17,7 @@ let assert_mode () =
       policy_assert_mode := Some v;
       v
 
+(* tla-lint: allow-mutation: test hook — reset env-cached policy between tests *)
 let refresh_policy_for_test () = policy_assert_mode := None
 let assert_mode_for_test () = assert_mode ()
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -123,6 +123,7 @@ let set_keeper_paused_state ~agent_name paused =
              then Keeper_state_machine.Operator_pause
              else Keeper_state_machine.Operator_resume));
        if not paused then begin
+         (* tla-lint: allow-mutation: fiber signal — Atomic flag wakes the keeper from Eio.Promise.await *)
          Atomic.set entry.fiber_wakeup true;
          (* Cycle 43: KeeperHeartbeat.tla WakeupSignal post-condition. *)
          Keeper_fsm_guard_runtime.wrap_unit
@@ -642,6 +643,7 @@ let stop_keepalive ?base_path name =
   in
   List.iter
     (fun (entry : Keeper_registry.registry_entry) ->
+       (* tla-lint: allow-mutation: fiber signal — stop+wakeup pair triggers cooperative shutdown *)
        Atomic.set entry.fiber_stop true;
        Atomic.set entry.fiber_wakeup true;
        (* Cycle 43: KeeperHeartbeat.tla WakeupSignal post-condition fires

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -681,6 +681,7 @@ let mark_turn_finished ~base_path name =
      [interruptible_sleep]'s CAS, but an explicit reset here guarantees the
      flag is clean regardless of whether the heartbeat loop's sleep path ran. *)
   (match get ~base_path name with
+   (* tla-lint: allow-mutation: fiber signal — clear stale wakeup flag, paired with [interruptible_sleep] CAS *)
    | Some entry -> Atomic.set entry.fiber_wakeup false
    | None -> ());
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
@@ -752,6 +753,7 @@ let spawn_slots_available () =
 
 let wakeup ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
+  (* tla-lint: allow-mutation: fiber signal — public wakeup API for a single keeper *)
   | Some entry -> Atomic.set entry.fiber_wakeup true
   | None -> ()
 
@@ -759,6 +761,7 @@ let wakeup_all ?base_path () =
   StringMap.iter (fun _k entry ->
     (match base_path with
      | Some expected when not (String.equal expected entry.base_path) -> ()
+     (* tla-lint: allow-mutation: fiber signal — bulk wakeup for Running keepers under base_path filter *)
      | _ -> if entry.phase = Running then Atomic.set entry.fiber_wakeup true)
   ) (Atomic.get registry)
 
@@ -1234,6 +1237,7 @@ let dispatch_event ~base_path name event =
 let prepare_fiber_launch ~base_path name =
   (match get ~base_path name with
    | Some entry ->
+       (* tla-lint: allow-mutation: fiber signal — initialise per-fiber Atomic flags before keeper launch *)
        Atomic.set entry.fiber_stop false;
        Atomic.set entry.fiber_wakeup false;
        Atomic.set entry.waiting_for_inference false

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -327,6 +327,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                in
                Keeper_registry.set_failure_reason ~base_path meta.name
                  (Some (Keeper_registry.Stale_turn_timeout kill_class));
+               (* tla-lint: allow-mutation: fiber signal — stop the wedged keeper after stale-turn classification *)
                Atomic.set reg.fiber_stop true;
                let window_count = record_stale_termination meta.name now in
                Prometheus.inc_counter

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -424,6 +424,7 @@ let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
        resumed_meta.name Keeper_state_machine.Operator_resume);
   match Keeper_registry.get ~base_path:ctx.config.base_path resumed_meta.name with
   | Some entry when Option.is_none (Eio.Promise.peek entry.done_p) ->
+      (* tla-lint: allow-mutation: fiber signal — wake the keeper after operator resume *)
       Atomic.set entry.fiber_wakeup true
   | Some _ ->
       Keeper_registry.unregister ~base_path:ctx.config.base_path

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -520,6 +520,7 @@ let sync_keeper_paused_state
          else Keeper_state_machine.Operator_resume);
       (if not paused then
          match Keeper_registry.get ~base_path:config.base_path meta.name with
+         (* tla-lint: allow-mutation: fiber signal — wake on resume from cascade budget gate *)
          | Some entry -> Atomic.set entry.fiber_wakeup true
          | None ->
              Keeper_turn_helpers.report_keeper_cycle_side_effect_issue

--- a/scripts/tla-mutation-lint-baseline.json
+++ b/scripts/tla-mutation-lint-baseline.json
@@ -4,5 +4,5 @@
   "_comment_3": "Reduce by either: (a) refactoring the site away from mutation, or (b) annotating with (* tla-lint: allow-mutation: <reason> *).",
   "_comment_4": "After reducing, run scripts/tla-mutation-lint-ratchet.sh --regenerate to rewrite this file. Increases require a paired follow-up issue.",
   "_comment_5": "Reference: planning/claude-plans/greedy-sleeping-blossom.md (Track 1A).",
-  "keeper_mutation_sites_max": 254
+  "keeper_mutation_sites_max": 238
 }


### PR DESCRIPTION
## Summary

First reduction PR for the mutation-lint ratchet shipped in #12247. Lowers `scripts/tla-mutation-lint-baseline.json` from **254 → 238** (16-site decrease, ~6% of the keeper mutation surface) by annotating the two cleanest non-FSM categories with the `(* tla-lint: allow-mutation: <reason> *)` escape comment.

Pure comments. No code-behavior change. Touched `.ml` files type-check unchanged (`dune build --root . — clean`).

## What changes

| Category | Sites | Files | Reason annotation |
|---|---|---|---|
| **B — Test hooks** | 4 | `keeper_fsm_guard_runtime.ml`, `keeper_accountability.ml` | "test hook — opt-in counter / test reset" |
| **D — Fiber signals** | 12 | `keeper_keepalive.ml`, `keeper_supervisor.ml`, `keeper_stale_watchdog.ml`, `keeper_turn_cascade_budget.ml`, `keeper_registry.ml` | "fiber signal — Atomic flag coordinating Eio fibers" |

Each annotation names *why* the site is non-FSM. Test hooks are opt-in counters/resets that test code mutates deliberately; fiber signals are `Atomic` flags for inter-fiber coordination (`fiber_wakeup`, `fiber_stop`, `waiting_for_inference`) — these are correct uses of `Atomic` for thread-safety, not state-machine state.

## Diff stat

```
 lib/keeper/keeper_accountability.ml      | 3 +++
 lib/keeper/keeper_fsm_guard_runtime.ml   | 1 +
 lib/keeper/keeper_keepalive.ml           | 2 ++
 lib/keeper/keeper_registry.ml            | 4 ++++
 lib/keeper/keeper_stale_watchdog.ml      | 1 +
 lib/keeper/keeper_supervisor.ml          | 1 +
 lib/keeper/keeper_turn_cascade_budget.ml | 1 +
 scripts/tla-mutation-lint-baseline.json  | 2 +-
 8 files changed, 14 insertions(+), 1 deletion(-)
```

## Why category-by-category, not file-by-file

Each PR sweeps one **classification rationale**, not one file or directory. Mixing test hooks with FSM-state refactors would conflate "annotate this is fine" with "this needs design work." See `~/me/planning/claude-plans/track-1b-mutation-categorization.md` for the 5-category breakdown:

- **A — Local accumulator** (~80 sites): `out := (k, v) :: !out` in folds. Pure local state. Annotate. Low priority.
- **B — Test hook** (~10 sites): `*_for_testing_ref` mutations. **This PR.**
- **C — Module init / set-once** (~20-30 sites): `Lazy.t` / `Atomic.t` refactor candidates.
- **D — Fiber signal** (~10 sites): inter-fiber `Atomic` flags. **This PR.**
- **E — Actual FSM state** (~30-50 sites): the lint's primary target. Needs per-site analysis.

After this PR: 238 sites remaining. Next moves are Category A (the 28+15 sites in `keeper_toml_loader.ml` + `keeper_tool_alias.ml` are pure parser-state — quick wins) and Category C (refactor candidates — small follow-up PRs).

## Test plan

- [x] `bash scripts/tla-mutation-lint.sh --count` → `238` (was `254`)
- [x] `bash scripts/tla-mutation-lint-ratchet.sh` → `OK — mutations at floor (238)`
- [x] `bash test/test_tla_mutation_lint.sh` → `PASS — 3/3 cases` (escape, zero-mutation, comment-only false-positive)
- [x] `dune build --root .` → exit 0 (no compile error from the new comments)
- [ ] CI: lint, OCaml structure ratchet, etc. (will run on push)

## Sites annotated

**Test hooks:**
- `keeper_fsm_guard_runtime.ml:20` — `refresh_policy_for_test`
- `keeper_accountability.ml:308` — `window_read_count_for_testing_ref` bump in `read_window_entries`
- `keeper_accountability.ml:960` — `enable_window_read_count_for_testing`
- `keeper_accountability.ml:963` — `disable_window_read_count_for_testing`

**Fiber signals:**
- `keeper_keepalive.ml:126` — post-resume wakeup
- `keeper_keepalive.ml:646-647` — stop+wakeup pair (fleet shutdown)
- `keeper_supervisor.ml:427` — wakeup after operator resume
- `keeper_stale_watchdog.ml:330` — stop after stale-turn timeout
- `keeper_turn_cascade_budget.ml:523` — wakeup from cascade gate
- `keeper_registry.ml:684` — clear stale wakeup flag
- `keeper_registry.ml:755` — public wakeup API
- `keeper_registry.ml:762` — bulk wakeup (`wakeup_all`)
- `keeper_registry.ml:1237-1239` — `prepare_fiber_launch` (3-flag init)

## Context

Part of the "PPX rigor track" gap-fill from the 2026-04-28 Kimi keeper FSM audit. Companion to #12242 (Track 3 — fsm_guard alerting), #12247 (Track 1A — mutation lint detector + ratchet baseline 254), and #12256 (RFC-0018 — Track 2 alternative design).

Plan: `~/me/planning/claude-plans/greedy-sleeping-blossom.md` + `~/me/planning/claude-plans/track-1b-mutation-categorization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
