### PR TITLE
feat(dashboard): governance KpiStrip → Solid island + test shim (RFC 0017 PR #6)

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -4,6 +4,8 @@ import { act } from 'preact/test-utils'
 import * as Vitest from 'vitest'
 import type { DashboardGovernanceResponse, GovernanceCaseBundle, KeeperApprovalQueueItem } from '../types'
 import { filterApprovalQueue } from './governance'
+import { KpiStrip } from './kpi-strip'
+import { KpiCell } from './kpi-cell'
 
 const { afterEach, beforeEach, describe, expect, it, vi } = Vitest
 
@@ -58,6 +60,28 @@ async function loadComponentWithApi(api: {
   Vitest.vi.doMock('../api', () => api)
   Vitest.vi.doMock('../sse-store', () => ({
     registerGovernanceRefresh: Vitest.vi.fn(),
+  }))
+  // KpiStripIsland mounts its Solid subtree inside `useEffect`, so the
+  // first synchronous render produces an empty `<div>` and the assertions
+  // on cell text would fire before mount. Substitute a synchronous Preact
+  // shim that renders the same cells via the original KpiStrip + KpiCell.
+  // Production behaviour stays as the real island; this shim only exists
+  // for the Preact-side test config (vitest.config.ts).
+  Vitest.vi.doMock('./kpi-strip-island', () => ({
+    KpiStripIsland: (props: {
+      ariaLabel: string
+      variant?: 'standard' | 'compact' | 'stacked'
+      cols?: number
+      cells: ReadonlyArray<Record<string, unknown>>
+    }) => html`
+      <${KpiStrip}
+        ariaLabel=${props.ariaLabel}
+        variant=${props.variant}
+        cols=${props.cols}
+      >
+        ${props.cells.map((cell) => html`<${KpiCell} ...${cell} />`)}
+      <//>
+    `,
   }))
   return import('./governance')
 }

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -6,8 +6,8 @@ import type { GovernanceJudgeSummary, KeeperApprovalQueueItem, KeeperApprovalRul
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { Card } from './common/card'
-import { KpiCell, type KpiCellKind } from './kpi-cell'
-import { KpiStrip } from './kpi-strip'
+import type { KpiCellKind } from './kpi-cell'
+import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
 import { TimeAgo } from './common/time-ago'
 import { EmptyState } from './common/empty-state'
 import { StatusDot } from './common/status-dot'
@@ -121,34 +121,38 @@ function GovernanceSummaryStrip() {
       </div>
     </div>
     <div class="mb-5">
-      <${KpiStrip} ariaLabel="governance 요약" cols=${4}>
-        <${KpiCell}
-          variant="stacked"
-          label="Judge 상태"
-          value=${liveJudgeState}
-          caption=${judge?.keeper_name?.trim() || '실시간 judge'}
-          kind=${(judgeUnhealthy ? 'warn' : (judgeHealthy ? 'ok' : undefined)) as KpiCellKind | undefined}
-        />
-        <${KpiCell}
-          variant="stacked"
-          label="Judge 모델"
-          value=${liveJudgeModel}
-          caption=${judge?.model_used?.trim() ? '런타임 보고' : '알 수 없음'}
-        />
-        <${KpiCell}
-          variant="stacked"
-          label="최근 판단"
-          value=${judgmentCount}
-          caption="실시간"
-        />
-        <${KpiCell}
-          variant="stacked"
-          label="관리자 승인 대기"
-          value=${approvalCount}
-          caption=${approvalCount > 0 ? '검토 필요' : (judgeHealthy ? '정상' : 'live')}
-          kind=${(approvalCount > 0 ? 'warn' : (judgeHealthy ? 'ok' : undefined)) as KpiCellKind | undefined}
-        />
-      <//>
+      <${KpiStripIsland}
+        ariaLabel="governance 요약"
+        cols=${4}
+        cells=${[
+          {
+            variant: 'stacked',
+            label: 'Judge 상태',
+            value: liveJudgeState,
+            caption: judge?.keeper_name?.trim() || '실시간 judge',
+            kind: (judgeUnhealthy ? 'warn' : (judgeHealthy ? 'ok' : undefined)) as KpiCellKind | undefined,
+          },
+          {
+            variant: 'stacked',
+            label: 'Judge 모델',
+            value: liveJudgeModel,
+            caption: judge?.model_used?.trim() ? '런타임 보고' : '알 수 없음',
+          },
+          {
+            variant: 'stacked',
+            label: '최근 판단',
+            value: judgmentCount,
+            caption: '실시간',
+          },
+          {
+            variant: 'stacked',
+            label: '관리자 승인 대기',
+            value: approvalCount,
+            caption: approvalCount > 0 ? '검토 필요' : (judgeHealthy ? '정상' : 'live'),
+            kind: (approvalCount > 0 ? 'warn' : (judgeHealthy ? 'ok' : undefined)) as KpiCellKind | undefined,
+          },
+        ] satisfies KpiStripIslandData['cells']}
+      />
     </div>
     <${JudgeStatusBar} />
     ${governanceError.value ? html`<div class="mb-5 rounded border border-[var(--bad-30)] bg-[var(--bad-8)] p-2.5 text-xs text-[#f7b6b6]">${governanceError.value}</div>` : null}

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -3,9 +3,17 @@ import preact from '@preact/preset-vite'
 
 export default defineConfig({
   // Keep Vitest on the Preact transform pipeline. vite-plugin-solid has
-  // global test-mode side effects that break existing Preact hook tests even
-  // when its transform include filter is path-scoped. Solid tests run through
-  // vitest.solid.config.ts so their resolver/runtime conditions stay isolated.
+  // global test-mode side effects that break existing Preact hook tests
+  // (Preact hooks dispatcher gets clobbered → "Cannot read properties of
+  // undefined (reading '__H')" during render) even when its transform
+  // include filter is path-scoped to /\.solid\.tsx$/. Confirmed PR #6
+  // 2026-04-30 with vite-plugin-solid 2.11.12 — same failure mode as
+  // documented earlier.
+  //
+  // Instead, vitest-setup.ts substitutes KpiStripIsland with a
+  // synchronous Preact shim so caller tests can keep asserting KpiCell
+  // cell content immediately after render. The real island ships in
+  // production and is exercised under vitest.solid.config.ts.
   plugins: [preact()],
   test: {
     environment: 'happy-dom',


### PR DESCRIPTION
## Summary

RFC 0017 PR #6 — third caller migrated, plus the **test infrastructure pattern** for callers whose tests assert KpiCell text content.

## What lands

| File | Change |
|------|--------|
| \`src/components/governance.ts\` | Single strip (cols=4, 4 cells) → \`KpiStripIsland\`. First caller with conditional \`caption\`/\`kind\` ternaries in the cells data array; \`satisfies\` narrows the type without explicit cast. |
| \`src/components/governance.test.ts\` | \`loadComponentWithApi\` now registers \`vi.doMock('./kpi-strip-island', ...)\` returning a synchronous Preact shim. Cell text appears immediately after \`render()\`. |
| \`vitest.config.ts\` | Comment block updated to document the architectural decision. No plugin changes. |

## Why a test shim

| Approach | Result |
|----------|--------|
| Just migrate code, run tests | 10/20 governance fail. \`expect(textContent).toContain('Judge 상태')\` runs before the island's \`useEffect\` mounts the Solid subtree. |
| Wait for flushUi (4× microtask + setTimeout 0) | Same fail — the Solid runtime can't render under the Preact-only test config (\`solid-js/web\` resolves to SSR mode → "Client-only API called on the server side"). |
| Add \`resolve.conditions: ['browser']\` | Fixes the SSR error but exposes the next layer: \`.solid.tsx\` files don't get a JSX transform → "jsxDEV is not a function". |
| Add \`vite-plugin-solid\` with \`/\\.solid\\.tsx$/\` include | Solid plugin clobbers Preact hooks dispatcher globally → "Cannot read properties of undefined (reading '__H')" during render. PR #1's warning still applies to vite-plugin-solid 2.11.12. |
| **\`vi.doMock('./kpi-strip-island', ...)\`** ← chosen | Preact tests see a synchronous shim that renders the same cells via original KpiStrip + KpiCell. Production behaviour stays as the real Solid island. Solid integration tests still cover the real wrapper under \`vitest.solid.config.ts\`. |

The shim only exists for the Preact-side test runner. The real island ships to the browser. Real island integration tests (mount, prop sync, unmount) live in \`kpi-strip-island.solid.test.ts\` (already merged, 6 cases).

## Bundle delta (vs PR #5 main)

| Chunk | Δ |
|-------|---|
| \`solid-*.js\` | 9.3 KB → 9.3 KB (third caller, **0 B growth**) |
| \`index-*.js\` (main) | 200 KB stable |

Three caller migrations confirm RFC 0017 §7 amortisation: cost is paid once in PR #4.

## Verification

| Step | Result |
|------|--------|
| \`pnpm typecheck\` | green |
| \`vitest --config vitest.solid.config.ts\` | **128/128 pass** |
| \`vitest --config vitest.config.ts\` | **5134/5134 pass** (governance: 20/20 with shim, even the previously flaky auth-status focus-trap test passes this run) |
| \`pnpm build\` | success |

## Out of scope (next PRs)

- harness-health.ts (15 refs, 3 strips). Tests don't assert KpiCell text, so no shim required.
- connector-status.ts (7 refs). Same — tests don't assert KpiCell text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)