### PR TITLE
refactor(keeper): type execution receipt error kinds

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1190,7 +1190,11 @@ let run_turn
     let error_kind, error_message =
       match turn_result with
       | Ok _ -> None, None
-      | Error err -> Some (sdk_error_kind err), Some (Oas.Error.to_string err)
+      | Error err ->
+        ( Some
+            (Keeper_execution_receipt.error_kind_of_string
+               (sdk_error_kind err)),
+          Some (Oas.Error.to_string err) )
     in
     let tool_contract_result =
       match turn_result with

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -32,6 +32,11 @@ let outcome_kind_is_terminal_success = function
   | `Ok | `Skipped -> true
   | `Error | `Cancelled -> false
 
+type error_kind = Error_kind of string
+
+let error_kind_of_string value = Error_kind value
+let error_kind_to_string (Error_kind value) = value
+
 (* TLA+ ReceiptIsAuthoritative invariant
    (specs/keeper-turn-fsm/KeeperTurnFSM.tla:336):
      receipt_outcome = "receipt_done" => turn_state = "done"
@@ -71,7 +76,7 @@ type cascade_rotation_attempt =
   ; to_cascade : string
   ; reason : string
   ; outcome : string
-  ; error_kind : string option
+  ; error_kind : error_kind option
   ; error_message : string option
   ; recorded_at : string
   }
@@ -111,7 +116,7 @@ type t =
   ; fallback_reason : string option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
   ; stop_reason : string option
-  ; error_kind : string option
+  ; error_kind : error_kind option
   ; error_message : string option
   ; started_at : string
   ; ended_at : string
@@ -170,7 +175,8 @@ let cascade_rotation_attempt_to_json attempt =
       ("to_cascade", `String attempt.to_cascade);
       ("reason", `String attempt.reason);
       ("outcome", `String attempt.outcome);
-      ("error_kind", string_opt_json attempt.error_kind);
+      ( "error_kind",
+        string_opt_json (Option.map error_kind_to_string attempt.error_kind) );
       ("error_message", string_opt_json attempt.error_message);
       ("recorded_at", `String attempt.recorded_at);
     ]
@@ -235,7 +241,9 @@ let operator_disposition (receipt : t) =
     String.lowercase_ascii receipt.tool_contract_result
   in
   let error_kind =
-    Option.map String.lowercase_ascii receipt.error_kind
+    Option.map
+      (fun kind -> String.lowercase_ascii (error_kind_to_string kind))
+      receipt.error_kind
   in
   let provider_runtime_failure =
     String.starts_with ~prefix:"api_error_" terminal_reason
@@ -329,7 +337,9 @@ let operator_disposition (receipt : t) =
          terminal_reason=%s tool_contract_result=%s error_kind=%s) \
          — investigate regression of #11651 silent-path fix"
         receipt.outcome cascade_outcome terminal_reason tool_contract_result
-        (Option.value error_kind ~default:"<none>");
+        (Option.value
+           (Option.map error_kind_to_string receipt.error_kind)
+           ~default:"<none>");
       ("unknown", "unmapped_cascade_state")
 
 let to_json (receipt : t) =
@@ -344,7 +354,7 @@ let to_json (receipt : t) =
         [
           ( "kind",
             match error_kind with
-            | Some value -> `String value
+            | Some value -> `String (error_kind_to_string value)
             | None -> `Null );
           ( "message",
             match error_message with
@@ -599,7 +609,7 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
         | None -> `Null )
     ; ( "error_kind",
         match receipt.error_kind with
-        | Some v -> `String v
+        | Some v -> `String (error_kind_to_string v)
         | None -> `Null )
     ; ( "error_message",
         match receipt.error_message with

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -34,6 +34,11 @@ val outcome_kind_is_terminal_success : outcome_kind -> bool
     Used by dashboard "healthy" classification and action_radius
     success accounting. *)
 
+type error_kind = private Error_kind of string
+
+val error_kind_of_string : string -> error_kind
+val error_kind_to_string : error_kind -> string
+
 type receipt_authority_violation = {
   outcome : string;
   turn_state : string;
@@ -84,7 +89,7 @@ type cascade_rotation_attempt =
   ; to_cascade : string
   ; reason : string
   ; outcome : string
-  ; error_kind : string option
+  ; error_kind : error_kind option
   ; error_message : string option
   ; recorded_at : string
   }
@@ -124,7 +129,7 @@ type t =
   ; fallback_reason : string option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
   ; stop_reason : string option
-  ; error_kind : string option
+  ; error_kind : error_kind option
   ; error_message : string option
   ; started_at : string
   ; ended_at : string

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -74,7 +74,7 @@ val record_pre_dispatch_terminal_observation :
   terminal_reason_code:string ->
   activity_kind:string ->
   trajectory_outcome:Trajectory.trajectory_outcome ->
-  ?error_kind:string ->
+  ?error_kind:Keeper_execution_receipt.error_kind ->
   ?error_message:string ->
   ?keeper_turn_id:int ->
   unit -> unit

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -294,7 +294,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~terminal_reason_code
             ~activity_kind:"keeper.turn_blocked"
             ~trajectory_outcome:(Trajectory.Failed terminal_reason_code)
-            ~error_kind:(sdk_error_kind err)
+            ~error_kind:
+              (Keeper_execution_receipt.error_kind_of_string
+                 (sdk_error_kind err))
             ~error_message
             ~keeper_turn_id
             ();
@@ -610,7 +612,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             to_cascade = retry.next_cascade;
             reason = retry.fallback_reason;
             outcome;
-            error_kind = Some (sdk_error_kind err);
+            error_kind =
+              Some
+                (Keeper_execution_receipt.error_kind_of_string
+                   (sdk_error_kind err));
             error_message = Some (Oas.Error.to_string err);
             recorded_at = now_iso ();
           }

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -480,7 +480,8 @@ let append_execution_receipt config ~keeper_name =
             to_cascade = Lib.Keeper_config.local_recovery_cascade_name;
             reason = "turn_timeout";
             outcome = "retry_scheduled";
-            error_kind = Some "internal";
+            error_kind =
+              Some (Lib.Keeper_execution_receipt.error_kind_of_string "internal");
             error_message = Some "turn timeout";
             recorded_at = ended_at;
           };

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -656,7 +656,10 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
                to_cascade = retry_cascade;
                reason;
                outcome = "retry_scheduled";
-               error_kind = Some "internal";
+               error_kind =
+                 Some
+                   (Masc_mcp.Keeper_execution_receipt.error_kind_of_string
+                      "internal");
                error_message = Some "turn timeout";
                recorded_at = ended_at;
              };
@@ -1177,7 +1180,13 @@ let test_keeper_cascade_assignment_updates_dashboard_projection () =
 let test_execution_trust_route_surfaces_trust_summary_fields () =
   with_seeded_server
   @@ fun ~port ~config ~admin_token:_ ~keeper_name ->
-  append_execution_receipt config ~keeper_name;
+  append_execution_receipt
+    ~cascade_fallback_applied:false
+    ~cascade_outcome:"completed"
+    ~degraded_retry_applied:false
+    ~degraded_retry_cascade:None
+    ~fallback_reason:None
+    config ~keeper_name;
   let result =
     run_curl_get ~port ~path:"/api/v1/dashboard/execution-trust" ()
   in

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -123,7 +123,7 @@ let test_pause_human_when_no_tools_used () =
 let test_provider_failure_not_reported_as_tool_unsatisfied () =
   let r =
     mk_receipt ~tools_used:[] ~terminal_reason_code:"api_error_invalid_request"
-      ~error_kind:(Some "api")
+      ~error_kind:(Some (R.error_kind_of_string "api"))
       ~error_message:
         (Some
            "Invalid request: kimi_cli startup crash while setting process title")
@@ -135,7 +135,7 @@ let test_provider_failure_not_reported_as_tool_unsatisfied () =
 let test_preflight_config_failure_not_reported_as_tool_unsatisfied () =
   let r =
     mk_receipt ~tools_used:[] ~terminal_reason_code:"config_error"
-      ~error_kind:(Some "config")
+      ~error_kind:(Some (R.error_kind_of_string "config"))
       ~error_message:(Some "provider auth/config failed before turn")
       ()
   in


### PR DESCRIPTION
Refs #11926

## Summary
- Add private `Keeper_execution_receipt.error_kind` with string conversion helpers.
- Type `cascade_rotation_attempt.error_kind`, receipt `t.error_kind`, and pre-dispatch terminal observation ingress.
- Convert SDK error-kind strings at receipt ingress in `keeper_unified_turn` and `keeper_agent_run` while preserving existing JSON/dashboard/operator-broadcast wire strings.

## Validation
- `scripts/dune-local.sh build lib/keeper/keeper_execution_receipt.ml lib/keeper/keeper_execution_receipt.mli lib/keeper/keeper_turn_helpers.ml lib/keeper/keeper_turn_helpers.mli lib/keeper/keeper_unified_turn.ml lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run.mli test/test_keeper_pause_broadcast.exe test/test_dashboard_execution.exe test/test_dashboard_keeper_routes.exe test/test_dashboard_goals.exe test/test_observability_provider_contracts.exe`
- `./_build/default/test/test_keeper_pause_broadcast.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 ./_build/default/test/test_dashboard_keeper_routes.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 ./_build/default/test/test_dashboard_goals.exe`
- `./_build/default/test/test_observability_provider_contracts.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 ./_build/default/test/test_dashboard_execution.exe`
- `git diff --check HEAD~1 HEAD`
- raw-string boundary grep for `error_kind:string` and direct `Some "..."` fixture ingress returned no matches in the touched receipt/test files.