### PR TITLE
fix(pr): mark script-opened drafts as agent PRs

### DIFF
--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -17,7 +17,7 @@ Options:
 Behavior:
   1) push current branch
   2) create draft PR if absent
-  3) auto-label docs/enhancement by changed files
+  3) auto-label agent-pr plus docs/enhancement by changed files
   4) add extra labels
   5) optionally watch checks
 USAGE
@@ -73,6 +73,21 @@ is_doc_path() {
     docs/*|examples/trpg-mvp/*|README.md|*.md) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+ensure_agent_pr_label() {
+  local exists
+
+  exists="$(gh label list --repo "$repo" --search agent-pr --json name --jq 'any(.[]; .name == "agent-pr")' 2>/dev/null || true)"
+  if [[ "$exists" == "true" ]]; then
+    return 0
+  fi
+
+  gh label create agent-pr \
+    --repo "$repo" \
+    --color "5319E7" \
+    --description "Agent-authored draft PR; requires human-approved-ready before ready/merge" \
+    >/dev/null 2>&1 || true
 }
 
 repo=""
@@ -145,6 +160,8 @@ else
   pr_number="$(gh pr view "$pr_url" --repo "$repo" --json number --jq .number)"
 fi
 
+ensure_agent_pr_label
+
 load_changed_files "origin/$base...HEAD"
 if [[ ${#changed_files[@]} -eq 0 ]]; then
   load_changed_files "HEAD~1..HEAD"
@@ -163,7 +180,7 @@ for f in "${changed_files[@]}"; do
   fi
 done
 
-labels=()
+labels=("agent-pr")
 if [[ $has_docs -eq 1 ]]; then
   labels+=("docs")
 fi

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -118,6 +118,16 @@ let test_agent_draft_policy_script () =
        :: base));
   check bool "ready agent PR without bypass fails" true
     (run_agent_draft_policy (("PR_IS_DRAFT", "false") :: base) <> 0);
+  check bool "ready feature PR with agent-pr label fails" true
+    (run_agent_draft_policy
+       [
+         ("GITHUB_EVENT_NAME", "pull_request");
+         ("PR_IS_DRAFT", "false");
+         ("PR_TITLE", "feat: ordinary feature title");
+         ("PR_HEAD_REF", "feature/dashboard-fsm-audit-exposure");
+         ("PR_LABELS", "enhancement,agent-pr");
+       ]
+    <> 0);
   check int "ready agent PR with bypass label passes" 0
     (run_agent_draft_policy
        (("PR_IS_DRAFT", "false")

--- a/test/test_pr_open_script.ml
+++ b/test/test_pr_open_script.ml
@@ -119,6 +119,12 @@ case "${cmd1}:${cmd2}" in
   api:*)
     cat >"$labels_file"
     ;;
+  label:list)
+    printf '[]\n'
+    ;;
+  label:create)
+    exit 0
+    ;;
   pr:checks)
     if [ "${FAKE_GH_ALLOW_CHECKS:-}" = "1" ]; then
       printf 'checks ok\n'
@@ -213,8 +219,12 @@ let test_script_runs_under_system_bash_without_watch () =
       let labels = read_file gh_labels in
       check bool "adds enhancement label for code changes" true
         (contains_substring labels "\"enhancement\"");
+      check bool "adds agent-pr label for draft guard classification" true
+        (contains_substring labels "\"agent-pr\"");
       check bool "does not add docs label for code-only change" false
-        (contains_substring labels "\"docs\""))
+        (contains_substring labels "\"docs\"");
+      check bool "ensures agent-pr label exists" true
+        (contains_substring log "label create"))
 
 let test_script_prints_final_status_after_watch () =
   with_temp_dir "pr-open-script-watch-status" (fun dir ->


### PR DESCRIPTION
## Summary

- Mark every PR opened by `scripts/pr-open.sh` with `agent-pr`.
- Ensure the `agent-pr` label exists before applying the PR labels.
- Add regression coverage that ordinary `feature/*` branches become draft-policy targets when marked `agent-pr`.

## Product impact

Agent-created draft PRs no longer depend on branch naming or title prefixes to enter the draft guard path. This closes the gap observed in #12261 where a script-created draft PR on a normal `feature/*` branch could be treated as non-agent by the CI draft policy.

## Evidence

- `scripts/dune-local.sh build ./test/test_pr_open_script.exe ./test/test_ci_hardening_source.exe`
- `./_build/default/test/test_pr_open_script.exe` (5 tests)
- `./_build/default/test/test_ci_hardening_source.exe` (36 tests)
- `bash -n scripts/pr-open.sh`
- `git diff --check`

## Review evidence

- Review `scripts/pr-open.sh` for label creation/application order.
- Review `test/test_pr_open_script.ml` for script-opened PR label coverage.
- Review `test/test_ci_hardening_source.ml` for the feature-branch `agent-pr` policy regression.

## Linked issue

Fixes #12261.
