### PR TITLE
keeper: file-scope pragma + parser sweep (Track 1B step 2)

### DIFF
--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -5,6 +5,12 @@
     multi-line).
     Enough to express all keeper_profile_defaults fields. *)
 
+(* tla-lint: file-scope: parser local state — TOML lexer accumulators
+   (line buffer, multiline-string buffer, current_table, key/value list)
+   are confined to a single parse_lines call and never observed as
+   keeper FSM state. Every [:=] / [<-] in this file mutates parser-
+   internal scaffolding, not state-machine state. *)
+
 type toml_value =
   | Toml_string of string
   | Toml_int of int

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -5,6 +5,11 @@
     total (every internal name has a defined behavior) and
     [to_internal] partial (only Anthropic-Code cognates resolve). *)
 
+(* tla-lint: file-scope: parser local state — argument-key remappers
+   (e.g. file_path -> path, command -> cmd) all build a fresh assoc
+   list via local [out] refs scoped to the function body. None of
+   these mutations escape; none observe or mutate keeper FSM state. *)
+
 (* (public_name, internal_name).
    Keep alphabetical by public name to make diffs reviewable. *)
 let aliases : (string * string) list =

--- a/scripts/tla-mutation-lint-baseline.json
+++ b/scripts/tla-mutation-lint-baseline.json
@@ -4,5 +4,5 @@
   "_comment_3": "Reduce by either: (a) refactoring the site away from mutation, or (b) annotating with (* tla-lint: allow-mutation: <reason> *).",
   "_comment_4": "After reducing, run scripts/tla-mutation-lint-ratchet.sh --regenerate to rewrite this file. Increases require a paired follow-up issue.",
   "_comment_5": "Reference: planning/claude-plans/greedy-sleeping-blossom.md (Track 1A).",
-  "keeper_mutation_sites_max": 238
+  "keeper_mutation_sites_max": 195
 }

--- a/scripts/tla-mutation-lint.sh
+++ b/scripts/tla-mutation-lint.sh
@@ -15,11 +15,23 @@
 #   2. Pexp_setfield (record-field assign)         X.f <- v   /   X.f := v
 #   3. Pexp_apply  ( := ) for ref cells           X := v
 #
-# Escape: a line whose previous non-blank source line contains the
-# tag [tla-lint: allow-mutation:] is excluded from the count. Example:
+# Escapes (two granularities):
 #
-#   (* tla-lint: allow-mutation: heartbeat counter, not FSM state *)
-#   Atomic.set tick_count (n + 1)
+#   1. Per-line: a line whose previous non-blank source line (within
+#      5 lines) contains the tag [tla-lint: allow-mutation:] is
+#      excluded. Example:
+#
+#        (* tla-lint: allow-mutation: heartbeat counter, not FSM state *)
+#        Atomic.set tick_count (n + 1)
+#
+#   2. Per-file: a file whose first 30 lines contain the tag
+#      [tla-lint: file-scope:] is treated as entirely non-FSM, so
+#      every mutation in it is exempt. Use this for parsers,
+#      remappers, and config loaders where 40+ local-accumulator
+#      mutations make per-line annotation noise. Example:
+#
+#        (* tla-lint: file-scope: parser local state — TOML lexer
+#           accumulators are not keeper FSM state *)
 #
 # The intent is to make the audit budget visible: every unmasked
 # mutation in lib/keeper/ is potentially a TLA+ Next-set drift
@@ -66,7 +78,8 @@ PATTERNS=(
 
 VIOLATIONS=0
 TMPFILE="$(mktemp)"
-trap 'rm -f "$TMPFILE"' EXIT
+FILESCOPED_FILES="$(mktemp)"
+trap 'rm -f "$TMPFILE" "$FILESCOPED_FILES"' EXIT
 
 # Scan lib/keeper/ recursively. Skip .mli (declarations only,
 # no mutations). Skip generated files under _build/.
@@ -76,8 +89,31 @@ rg --no-heading --line-number --type ocaml "${PATTERNS[@]}" \
    --glob '!_build/**' \
    2>/dev/null > "$TMPFILE" || true
 
+# Pre-scan for file-scope exemption pragma. A file whose first 30
+# lines contain [tla-lint: file-scope: <reason>] is treated as
+# entirely non-FSM (e.g. a parser, a remapper, a config loader).
+# Use this when per-line annotation would be noisy (40+ sites in a
+# single utility file).
+#
+# The 30-line limit prevents accidentally exempting a file by
+# embedding the pragma deep in the body — a documentation comment
+# next to a mutation would still need the per-line tag.
+while IFS= read -r ml_file; do
+  [ -z "$ml_file" ] && continue
+  if head -n 30 "$ml_file" 2>/dev/null \
+     | grep -q 'tla-lint:[[:space:]]*file-scope:'; then
+    echo "$ml_file" >> "$FILESCOPED_FILES"
+  fi
+done < <(find "$KEEPER_DIR" -name '*.ml' -type f \
+           -not -path '*/_build/*' 2>/dev/null)
+
 while IFS=: read -r file lineno line; do
   [ -z "$file" ] && continue
+
+  # File-scope pragma exempts the whole file.
+  if grep -qFx "$file" "$FILESCOPED_FILES" 2>/dev/null; then
+    continue
+  fi
 
   # Strip leading whitespace from the matched line for false-positive
   # filtering. We exclude:

--- a/test/test_tla_mutation_lint.sh
+++ b/test/test_tla_mutation_lint.sh
@@ -78,5 +78,44 @@ if [ "$got" != "0" ]; then
 fi
 echo "ok case 3 — comment lines containing := are not flagged"
 
+# Case 4: file-scope pragma exempts the entire file.
+cat > "$TMP/lib/keeper/test_fixture.ml" <<'OCAML'
+(* Synthetic parser file with many local-accumulator mutations. *)
+
+(* tla-lint: file-scope: parser local state — accumulators only *)
+
+let counter = ref 0
+
+let many_mutations () =
+  counter := !counter + 1;
+  counter := !counter + 1;
+  counter := !counter + 1;
+  let a = Atomic.make 0 in
+  Atomic.set a 1;
+  Atomic.set a 2
+OCAML
+got="$(TLA_LINT_KEEPER_DIR="$TMP/lib/keeper" bash "$DETECTOR" --count)"
+if [ "$got" != "0" ]; then
+  echo "FAIL case 4: file-scope pragma should exempt all mutations, got $got" >&2
+  TLA_LINT_KEEPER_DIR="$TMP/lib/keeper" bash "$DETECTOR" >&2 || true
+  exit 1
+fi
+echo "ok case 4 — file-scope pragma exempts all mutations in the file"
+
+# Case 5: file-scope pragma must appear in the first 30 lines.
+{
+  for _ in $(seq 1 35); do echo "(* padding *)"; done
+  echo "(* tla-lint: file-scope: too-late pragma should not exempt *)"
+  echo "let counter = ref 0"
+  echo "let mut () = counter := !counter + 1"
+} > "$TMP/lib/keeper/test_fixture.ml"
+got="$(TLA_LINT_KEEPER_DIR="$TMP/lib/keeper" bash "$DETECTOR" --count)"
+if [ "$got" != "1" ]; then
+  echo "FAIL case 5: late pragma should NOT exempt; expected 1, got $got" >&2
+  TLA_LINT_KEEPER_DIR="$TMP/lib/keeper" bash "$DETECTOR" >&2 || true
+  exit 1
+fi
+echo "ok case 5 — pragma after line 30 does not exempt"
+
 echo ""
-echo "[tla-mutation-lint test] PASS — 3/3 cases"
+echo "[tla-mutation-lint test] PASS — 5/5 cases"


### PR DESCRIPTION
## Summary

Second reduction PR for the mutation-lint ratchet. Adds a **file-scope pragma** to the detector and applies it to the two largest non-FSM mutation hotspots — TOML config parser (28 sites) and tool-name argument remapper (15 sites). Lowers `scripts/tla-mutation-lint-baseline.json` from **238 → 195** (43-site decrease, 18% of the post-step-1 surface).

**Net signal**: 43 mutation sites exempted with **2 file-scope comments** instead of 43 line annotations. Demonstrates the audit-budget principle — exempt by rationale once, not by line.

## What changes

### Detector (`scripts/tla-mutation-lint.sh`, +46/-7)

New escape granularity. The detector now supports **two** ways to mark a mutation as non-FSM:

1. **Per-line** (existing, from PR #12247): `(* tla-lint: allow-mutation: <reason> *)` immediately above a single mutation. Lookback window is 5 lines.
2. **Per-file** (new): `(* tla-lint: file-scope: <reason> *)` within the **first 30 lines** of a `.ml` file exempts every mutation in that file.

The 30-line cap prevents accidental file-scope exemption via a pragma embedded deep in the body — a body comment must still use the per-line tag.

Detector implementation: a pre-scan loop walks every `lib/keeper/*.ml` file, inspects `head -n 30`, and records files whose header contains `tla-lint:[[:space:]]*file-scope:` as filescoped. The main violation loop skips filescoped files before the per-line escape check.

### Pragmas applied (2 files)

- **`lib/keeper/keeper_toml_loader.ml`** — TOML config parser, 28 sites. Pragma rationale: "parser local state — TOML lexer accumulators (line buffer, multiline-string buffer, current_table, key/value list) are confined to a single `parse_lines` call and never observed as keeper FSM state."
- **`lib/keeper/keeper_tool_alias.ml`** — argument-key remapper, 15 sites. Pragma rationale: "parser local state — argument-key remappers (e.g. `file_path -> path`, `command -> cmd`) all build a fresh assoc list via local `out` refs scoped to the function body."

### Test cases extended (3 → 5)

`test/test_tla_mutation_lint.sh` gains:
- **case 4**: file-scope pragma exempts all mutations in a file (synthetic 5-mutation fixture, expected count 0)
- **case 5**: pragma after line 30 does NOT exempt (35 lines of padding + pragma + 1 mutation, expected count 1)

## Diff stat

```
 lib/keeper/keeper_toml_loader.ml        |  6 +++++
 lib/keeper/keeper_tool_alias.ml         |  5 ++++
 scripts/tla-mutation-lint-baseline.json |  2 +-
 scripts/tla-mutation-lint.sh            | 46 +++++++++++++++++++++++++++++----
 test/test_tla_mutation_lint.sh          | 41 ++++++++++++++++++++++++++++-
 5 files changed, 93 insertions(+), 7 deletions(-)
```

## Why these two files first

Per `~/me/planning/claude-plans/track-1b-mutation-categorization.md`, these are the two largest mutation contributors after Categories B/D were swept in #12259. Both are pure utility code:
- `keeper_toml_loader` is a TOML lexer-parser; mutations are line buffers, multiline-string accumulators, current-table tracking. None observe or mutate FSM state.
- `keeper_tool_alias` rewrites argument keys (`file_path → path`, etc.); mutations are local assoc-list accumulators. Pure data transformation.

The categorization doc estimated 43 sites in these two files; observed 43 sites. Estimate held.

## Test plan

- [x] `bash scripts/tla-mutation-lint.sh --count` → `195` (was `238`)
- [x] `bash scripts/tla-mutation-lint-ratchet.sh` → `OK — mutations at floor (195)`
- [x] `bash test/test_tla_mutation_lint.sh` → `PASS — 5/5 cases`
- [x] `dune build --root .` → exit 0 (no compile error from the OCaml comments)
- [ ] CI: lint, OCaml structure ratchet (will run on push)

## What is NOT in this PR

- No actual code refactor — all changes are comments and a small detector enhancement.
- No CI hookup for the ratchet (sister scripts `tla-ppx-ratchet.sh` and `lint-cancel-guard.sh` also lack hooks; a single CI workflow change can wire all three later).
- No changes to PR #12256 (RFC-0018 — terminal_outcome boundary) which awaits user review.

## After this PR

195 mutation sites remaining. Next moves are:
- **Category C** (~25 sites): set-once caches in keeper modules. Refactor candidates for `Lazy.t` / `Atomic.t`. Small follow-up PRs.
- **Category E** (~30-50 sites): the lint's *primary* target — actual FSM state mutation. Per-site analysis required.

## Context

Part of the "PPX rigor track" gap-fill from the 2026-04-28 Kimi keeper FSM audit. Companion to #12242 (Track 3 — fsm_guard alerting, **MERGED**), #12247 (Track 1A — detector + ratchet, **MERGED**), #12259 (Track 1B step 1 — Cat B/D sweep, **MERGED**), and #12256 (RFC-0018 — Track 2 alternative design, awaiting review).

Plan: `~/me/planning/claude-plans/greedy-sleeping-blossom.md` + `~/me/planning/claude-plans/track-1b-mutation-categorization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
