### PR TITLE
keeper: file-scope pragma on 4 audit/alert utilities (Track 1B step 3)

### DIFF
--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -1,6 +1,10 @@
 (** Keeper_alerting — alert fanout, skill routing, path safety checks,
     and tool-call preparation helpers for keeper execution. *)
 
+(* tla-lint: file-scope: alert score/reason accumulators are local
+   refs scoped to a single compute_alert_score call; output is a
+   computed score+reasons pair, not a stateful FSM transition. *)
+
 open Keeper_types
 open Keeper_memory
 

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -1,6 +1,11 @@
 (** Compaction audit: Event_bus subscriber + paired JSONL persistence.
     See {!Keeper_compact_audit} for API docs. *)
 
+(* tla-lint: file-scope: compaction audit subscriber. The store_ref
+   cache and start/complete pair-grouping accumulators are
+   observability bookkeeping for the JSONL flush layer; no value
+   here feeds back into keeper FSM state. *)
+
 (* ── Types ─────────────────────────────────────────────────────── *)
 
 type trigger =

--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -5,6 +5,12 @@
 
     @since Decision Layer v2 — Phase A2 (#6232) *)
 
+(* tla-lint: file-scope: forensics ring buffer + accumulator. The
+   ring's pos/count/unflushed counters are observability bookkeeping
+   for the JSONL flush, not state-machine state observed by the
+   keeper FSM. The header explicitly notes the abstract record
+   prevents trust calculations from consuming forensics data. *)
+
 (* ================================================================ *)
 (* Feature flag                                                     *)
 (* ================================================================ *)

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -1,5 +1,10 @@
 (** Keeper Transition Audit — Structured audit trail (RFC-0002). *)
 
+(* tla-lint: file-scope: structured audit trail for FSM transitions.
+   The ring buffer (pos/count) and result accumulators here record
+   what the FSM did; they do not influence what it does next.
+   Mutations are bookkeeping for the JSONL flush layer. *)
+
 type transition_record = {
   snapshot : Keeper_measurement.measurement_snapshot option;
   events_fired : Keeper_state_machine.event list;

--- a/scripts/tla-mutation-lint-baseline.json
+++ b/scripts/tla-mutation-lint-baseline.json
@@ -4,5 +4,5 @@
   "_comment_3": "Reduce by either: (a) refactoring the site away from mutation, or (b) annotating with (* tla-lint: allow-mutation: <reason> *).",
   "_comment_4": "After reducing, run scripts/tla-mutation-lint-ratchet.sh --regenerate to rewrite this file. Increases require a paired follow-up issue.",
   "_comment_5": "Reference: planning/claude-plans/greedy-sleeping-blossom.md (Track 1A).",
-  "keeper_mutation_sites_max": 195
+  "keeper_mutation_sites_max": 163
 }


### PR DESCRIPTION
## Summary

Third reduction PR for the mutation-lint ratchet. Stacked originally on #12265, now rebased onto current `main`. Applies the file-scope pragma to four observability/forensics modules whose mutations are bookkeeping for ring buffers, JSONL flush layers, or local score accumulators, not keeper FSM state.

Current main drift means the ratchet floor is now **195 -> 163** after this PR.

## Files annotated

| File | Sites | Rationale |
|---|---:|---|
| `keeper_alerting.ml` | 9 | `compute_alert_score` local refs accumulate bonuses across signal categories; output is a computed pair, not stateful FSM transition. |
| `keeper_decision_audit.ml` | 8 | Ring buffer bookkeeping records forensics data and does not feed trust/FSM transitions. |
| `keeper_transition_audit.ml` | 10 | Structured audit trail records what the FSM did; it does not influence what it does next. |
| `keeper_compact_audit.ml` | 6 | Compaction audit subscriber caches and start/complete pair-grouping feed JSONL flush bookkeeping. |

## Validation

- `bash scripts/tla-mutation-lint.sh --count` -> `163`
- `bash scripts/tla-mutation-lint-ratchet.sh` -> `OK - mutations at floor (163)`
- `bash test/test_tla_mutation_lint.sh` -> `PASS - 5/5 cases`
- `scripts/dune-local.sh build lib/keeper/keeper_alerting.ml lib/keeper/keeper_compact_audit.ml lib/keeper/keeper_decision_audit.ml lib/keeper/keeper_transition_audit.ml`
- `git diff --check origin/main...HEAD`

## Review Focus

Review whether these four file-scope pragmas are correctly limited to observability/forensics bookkeeping, and confirm that the baseline movement is a net decrease from current `main` (`195 -> 163`) rather than a new mutation increase.

## Context

Part of the PPX rigor / Track 1B mutation categorization cleanup. This follows #12247, #12259, and #12265.
