### PR TITLE
feat(dashboard): finish KpiStrip Solid island migration (RFC 0017 PR #7)

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -2,6 +2,8 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { KpiStrip } from './kpi-strip'
+import { KpiCell } from './kpi-cell'
 
 // 90s window absorbs cold-build transform overhead (observed 60-140s on
 // the first run) for the first/heaviest test in this file — render of a
@@ -198,6 +200,30 @@ async function loadComponentWithApi(api: {
   }))
   vi.doMock('./common/toast', () => ({
     showToast: api.showToast ?? vi.fn(),
+  }))
+  // Synchronous Preact shim — KpiStripIsland's real implementation
+  // imports solid-js/web. Under vitest.config.ts (no Solid plugin and
+  // no `browser` resolver condition) that resolves to the SSR build,
+  // whose `render` throws "Client-only API called on the server side"
+  // from inside the wrapper's useEffect. The shim short-circuits the
+  // chain — Solid is never loaded — and renders the same cells via
+  // the original Preact KpiStrip + KpiCell. Production keeps the real
+  // island; this swap exists only for the Preact-side test runner.
+  vi.doMock('./kpi-strip-island', () => ({
+    KpiStripIsland: (props: {
+      ariaLabel: string
+      variant?: 'standard' | 'compact' | 'stacked'
+      cols?: number
+      cells: ReadonlyArray<Record<string, unknown>>
+    }) => html`
+      <${KpiStrip}
+        ariaLabel=${props.ariaLabel}
+        variant=${props.variant}
+        cols=${props.cols}
+      >
+        ${props.cells.map((cell) => html`<${KpiCell} ...${cell} />`)}
+      <//>
+    `,
   }))
   const module = await import('./connector-status')
   module.resetConnectorStatusState()

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -23,8 +23,7 @@ import { formatElapsedCompact, formatTimeAgoEn } from '../lib/format-time'
 import { ErrorState } from './common/feedback-state'
 import { ConnectorOverviewSkeleton } from './connector-overview-skeleton'
 import { lastEvent } from '../sse'
-import { KpiCell } from './kpi-cell'
-import { KpiStrip } from './kpi-strip'
+import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { showToast } from './common/toast'
@@ -1522,12 +1521,16 @@ function GateAnalyticsSection({
         : html`
             <div>
               <div class="mb-3">
-                <${KpiStrip} ariaLabel="connector gate 통계" cols=${4}>
-                  <${KpiCell} variant="stacked" label="메시지" value=${gate.total_messages} />
-                  <${KpiCell} variant="stacked" label="성공" value=${gate.total_success} />
-                  <${KpiCell} variant="stacked" label="오류" value=${gate.total_errors} />
-                  <${KpiCell} variant="stacked" label="중복 제거 키" value=${gate.dedup_table_size} />
-                <//>
+                <${KpiStripIsland}
+                  ariaLabel="connector gate 통계"
+                  cols=${4}
+                  cells=${[
+                    { variant: 'stacked', label: '메시지', value: gate.total_messages },
+                    { variant: 'stacked', label: '성공', value: gate.total_success },
+                    { variant: 'stacked', label: '오류', value: gate.total_errors },
+                    { variant: 'stacked', label: '중복 제거 키', value: gate.dedup_table_size },
+                  ] satisfies KpiStripIslandData['cells']}
+                />
               </div>
 
               <div class="mb-4 grid grid-cols-2 gap-2 text-2xs text-[var(--color-fg-disabled)] max-[720px]:grid-cols-1">

--- a/dashboard/src/components/harness-health.test.ts
+++ b/dashboard/src/components/harness-health.test.ts
@@ -3,6 +3,8 @@ import { render } from 'preact'
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { escapeMermaidLabel, flowStatusClass } from './harness-health'
+import { KpiStrip } from './kpi-strip'
+import { KpiCell } from './kpi-cell'
 
 // ── Pure function tests ──
 
@@ -189,6 +191,27 @@ async function loadComponentWithApi(api: {
   }))
   vi.doMock('../router', () => ({
     navigate: api.navigate ?? vi.fn(),
+  }))
+  // Synchronous Preact shim — KpiStripIsland mounts its Solid subtree
+  // inside useEffect, so cell text would only appear after a flush. The
+  // existing assertions on '9세대' etc. fire immediately. Production
+  // ships the real island; this shim is test-config-only. Real island
+  // integration tests live in kpi-strip-island.solid.test.ts.
+  vi.doMock('./kpi-strip-island', () => ({
+    KpiStripIsland: (props: {
+      ariaLabel: string
+      variant?: 'standard' | 'compact' | 'stacked'
+      cols?: number
+      cells: ReadonlyArray<Record<string, unknown>>
+    }) => html`
+      <${KpiStrip}
+        ariaLabel=${props.ariaLabel}
+        variant=${props.variant}
+        cols=${props.cols}
+      >
+        ${props.cells.map((cell) => html`<${KpiCell} ...${cell} />`)}
+      <//>
+    `,
   }))
   vi.doMock('./common/mermaid-graph', () => ({
     MermaidGraph: ({ source, fallbackText }: { source: string; fallbackText?: string }) => html`

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -6,8 +6,7 @@ import { navigate } from '../router'
 import { Card } from './common/card'
 import { SectionCap } from './common/section-cap'
 import { MermaidGraph } from './common/mermaid-graph'
-import { KpiCell } from './kpi-cell'
-import { KpiStrip } from './kpi-strip'
+import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
 import {
   harness,
   loadHarnessHealth,
@@ -345,17 +344,21 @@ export function HarnessHealth() {
               </div>
             ` : null}
 
-            <${KpiStrip} ariaLabel="calibration 요약" cols=${4}>
-              <${KpiCell} variant="stacked" label="총 판정" value=${cal.total_verdicts} />
-              <${KpiCell} variant="stacked" label="거부율" value="${rejectRate}%" />
-              <${KpiCell} variant="stacked" label="대체 처리율" value="${fallbackPct}%" />
-              <${KpiCell}
-                variant="stacked"
-                label="일치율"
-                value="${agreementPct}%"
-                caption="FP:${cal.false_positive_count} FN:${cal.false_negative_count}"
-              />
-            <//>
+            <${KpiStripIsland}
+              ariaLabel="calibration 요약"
+              cols=${4}
+              cells=${[
+                { variant: 'stacked', label: '총 판정', value: cal.total_verdicts },
+                { variant: 'stacked', label: '거부율', value: `${rejectRate}%` },
+                { variant: 'stacked', label: '대체 처리율', value: `${fallbackPct}%` },
+                {
+                  variant: 'stacked',
+                  label: '일치율',
+                  value: `${agreementPct}%`,
+                  caption: `FP:${cal.false_positive_count} FN:${cal.false_negative_count}`,
+                },
+              ] satisfies KpiStripIslandData['cells']}
+            />
 
             <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-3 text-xs leading-loose text-[var(--color-fg-muted)]">
               인간 라벨 ${cal.labeled_count}건이 calibration ground truth입니다. 값이 0이면 runtime health는 볼 수 있어도 evaluator accuracy는 아직 검증되지 않았습니다.
@@ -385,24 +388,30 @@ export function HarnessHealth() {
               status=${data.pre_compact.status}
               lastEventAt=${data.pre_compact.last_event_at}
             />
-            <${KpiStrip} ariaLabel="압축 전 상태 요약" variant="stacked">
-              <${KpiCell}
-                variant="stacked"
-                label="최근 컨텍스트 사용률"
-                value=${data.overview.latest_pre_compact_ratio != null ? `${Math.round(data.overview.latest_pre_compact_ratio * 100)}%` : '-'}
-                caption=${`최근 ${data.pre_compact.total_recent}건`}
-              />
-              <${KpiCell}
-                variant="stacked"
-                label="최근 신호"
-                value=${freshnessLabel(data.pre_compact.last_event_at)}
-              />
-              <${KpiCell}
-                variant="stacked"
-                label="상태"
-                value=${railStatusLabel(data.pre_compact.status)}
-              />
-            <//>
+            <${KpiStripIsland}
+              ariaLabel="압축 전 상태 요약"
+              variant="stacked"
+              cells=${[
+                {
+                  variant: 'stacked',
+                  label: '최근 컨텍스트 사용률',
+                  value: data.overview.latest_pre_compact_ratio != null
+                    ? `${Math.round(data.overview.latest_pre_compact_ratio * 100)}%`
+                    : '-',
+                  caption: `최근 ${data.pre_compact.total_recent}건`,
+                },
+                {
+                  variant: 'stacked',
+                  label: '최근 신호',
+                  value: freshnessLabel(data.pre_compact.last_event_at),
+                },
+                {
+                  variant: 'stacked',
+                  label: '상태',
+                  value: railStatusLabel(data.pre_compact.status),
+                },
+              ] satisfies KpiStripIslandData['cells']}
+            />
             <${PreCompactList} section=${data.pre_compact} />
           </div>
         `}
@@ -419,24 +428,30 @@ export function HarnessHealth() {
               status=${data.recent_handoffs.status}
               lastEventAt=${data.recent_handoffs.last_event_at}
             />
-            <${KpiStrip} ariaLabel="세대 교체 요약" variant="stacked">
-              <${KpiCell}
-                variant="stacked"
-                label="최근 세대"
-                value=${data.overview.latest_handoff_generation != null ? `${data.overview.latest_handoff_generation}세대` : '-'}
-                caption=${`최근 ${data.recent_handoffs.total_recent}건`}
-              />
-              <${KpiCell}
-                variant="stacked"
-                label="최근 신호"
-                value=${freshnessLabel(data.recent_handoffs.last_event_at)}
-              />
-              <${KpiCell}
-                variant="stacked"
-                label="상태"
-                value=${railStatusLabel(data.recent_handoffs.status)}
-              />
-            <//>
+            <${KpiStripIsland}
+              ariaLabel="세대 교체 요약"
+              variant="stacked"
+              cells=${[
+                {
+                  variant: 'stacked',
+                  label: '최근 세대',
+                  value: data.overview.latest_handoff_generation != null
+                    ? `${data.overview.latest_handoff_generation}세대`
+                    : '-',
+                  caption: `최근 ${data.recent_handoffs.total_recent}건`,
+                },
+                {
+                  variant: 'stacked',
+                  label: '최근 신호',
+                  value: freshnessLabel(data.recent_handoffs.last_event_at),
+                },
+                {
+                  variant: 'stacked',
+                  label: '상태',
+                  value: railStatusLabel(data.recent_handoffs.status),
+                },
+              ] satisfies KpiStripIslandData['cells']}
+            />
             <${HandoffList} section=${data.recent_handoffs} />
           </div>
         `}


### PR DESCRIPTION
## Summary

RFC 0017 PR #7 — final caller batch. After this PR, **no production code imports the original Preact KpiStrip / KpiCell directly** (kpi-strip.ts and kpi-cell.ts remain only as the test-shim re-import path).

## What lands

| File | Change |
|------|--------|
| \`harness-health.ts\` | 3 strips (calibration cols=4 + pre-compact stacked + handoff stacked, **10 cells**) → \`KpiStripIsland\`. First module with multiple strips. |
| \`connector-status.ts\` | 1 strip (cols=4, 4 cells) → \`KpiStripIsland\`. |
| \`harness-health.test.ts\` | Adds \`vi.doMock('./kpi-strip-island', ...)\` shim because tests assert '9세대' (handoff strip cell value). |
| \`connector-status.test.ts\` | Same shim, preventive — without it the real island's useEffect throws "Client-only API called on the server side" on every render (passes as unhandled error but pollutes CI logs). |

## Architectural note

| Approach | Result |
|----------|--------|
| Add shim to every caller test importing KpiStripIsland | ✅ Chosen. Brittle but simple — pattern is identical, ~25 lines per test file. |
| \`resolve.conditions: ['browser', 'development']\` | ❌ Fixes SSR error but flips Preact itself to a different export condition → \`__H\` hooks dispatcher dies globally. |
| \`vite-plugin-solid\` with \`/\\.solid\\.tsx$/\` include | ❌ Clobbers Preact hooks dispatcher globally even with strict path scope (PR #6 confirmed for plugin 2.11.12). |

## Bundle delta — full RFC 0017 §7 amortisation table

| PR | Caller(s) | solid chunk | Δ |
|----|-----------|-------------|---|
| PR #4 | feature-health (1st) | 1 B → **9.3 KB** | +9.3 KB baseline |
| PR #5 | safe-autonomy | 9.3 KB → 9.3 KB | **0 B** |
| PR #6 | governance | 9.3 KB → 9.3 KB | **0 B** |
| PR #7 | harness-health + connector-status | 9.3 KB → 9.3 KB | **0 B** |

Five callers migrated. Total dashboard cost = 9.3 KB one-time runtime + per-caller route chunks unchanged. **Amortisation hypothesis confirmed across the entire migration.**

## Verification

| Step | Result |
|------|--------|
| \`pnpm typecheck\` | green |
| \`vitest --config vitest.solid.config.ts\` | **128/128 pass** |
| \`vitest --config vitest.config.ts\` | **5155/5155 pass** (incl. harness-health 30/30 and connector-status 16/16 with shims) |
| \`pnpm build\` | success |

## Trajectory closure

RFC 0017 trajectory PR #4 → PR #7 complete. Subsequent steps (Lifeline/Ticker islands, full-page Solid components) follow as separate RFC items if performance numbers from production justify them. The migration toolkit (KpiStripIsland, vi.doMock shim pattern, headless-solid adapters) is reusable for any future Preact → Solid bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)