### PR TITLE
feat(dashboard_bonsai): Tier F2 — multimodal artifact detail panel

### DIFF
--- a/dashboard_bonsai/src/multimodal_detail_fetch.ml
+++ b/dashboard_bonsai/src/multimodal_detail_fetch.ml
@@ -1,0 +1,72 @@
+(** Tier F2 — single-shot fetch of artifact detail + provenance.
+
+    Triggered by [Multimodal_view] card on_click; not polling. The
+    detail and provenance vars are reset to [None] before the fetch
+    starts so the panel can render a "loading" state. Both endpoints
+    are fetched in parallel and each callback writes only its own
+    var (no shared peek).
+
+    Failed fetches leave the corresponding var at [None]. *)
+
+open! Core
+open Brr_io
+
+let detail_endpoint id = Printf.sprintf "/api/v1/multimodal/get/%s" id
+let provenance_endpoint id =
+  Printf.sprintf "/api/v1/multimodal/provenance/%s" id
+;;
+
+let parse_json_or_error (text : Jstr.t) : Yojson.Safe.t option =
+  match Yojson.Safe.from_string (Jstr.to_string text) with
+  | json ->
+    (* Server returns a top-level error envelope on lookup failure;
+       reject those by checking for an "error" field at the top
+       level (artifact_response and provenance_response shapes never
+       carry one). *)
+    (match Yojson.Safe.Util.member "error" json with
+     | `String _ -> None
+     | _ -> Some json)
+  | exception _ -> None
+;;
+
+let parse_detail (text : Jstr.t) : Multimodal_detail_types.detail option =
+  Option.map (parse_json_or_error text) ~f:Multimodal_detail_types.detail_of_yojson
+;;
+
+let parse_provenance (text : Jstr.t)
+  : Multimodal_detail_types.provenance option
+  =
+  Option.map (parse_json_or_error text)
+    ~f:Multimodal_detail_types.provenance_of_yojson
+;;
+
+let fetch_text url =
+  let open Fut.Result_syntax in
+  let* response = Fetch.url (Jstr.v url) in
+  Fetch.Body.text (Fetch.Response.as_body response)
+;;
+
+let fetch ~id : unit =
+  Bonsai.Expert.Var.set
+    Multimodal_detail_var.selected_id_var (Some id);
+  Bonsai.Expert.Var.set Multimodal_detail_var.detail_var None;
+  Bonsai.Expert.Var.set Multimodal_detail_var.provenance_var None;
+  Fut.await (fetch_text (detail_endpoint id)) (function
+    | Ok text ->
+      Bonsai.Expert.Var.set
+        Multimodal_detail_var.detail_var
+        (parse_detail text)
+    | Error _ -> ());
+  Fut.await (fetch_text (provenance_endpoint id)) (function
+    | Ok text ->
+      Bonsai.Expert.Var.set
+        Multimodal_detail_var.provenance_var
+        (parse_provenance text)
+    | Error _ -> ())
+;;
+
+let clear () : unit =
+  Bonsai.Expert.Var.set Multimodal_detail_var.selected_id_var None;
+  Bonsai.Expert.Var.set Multimodal_detail_var.detail_var None;
+  Bonsai.Expert.Var.set Multimodal_detail_var.provenance_var None
+;;

--- a/dashboard_bonsai/src/multimodal_detail_types.ml
+++ b/dashboard_bonsai/src/multimodal_detail_types.ml
@@ -1,0 +1,77 @@
+(** Tier F2 — typed model of [/api/v1/multimodal/get/<id>] and
+    [/api/v1/multimodal/provenance/<id>].
+
+    Schema source: [lib/server/server_routes_http_routes_multimodal.ml]
+    [artifact_response] (full artifact JSON) and [provenance_response]
+    ([{id, origins[], descendants[]}]).
+
+    F2 renders a detail panel when an artifact is selected: payload
+    pretty-print, metadata, origins/descendants list. Lists are
+    flat string ids; F2 does not yet render a provenance DAG. *)
+
+open! Core
+
+type detail =
+  { id : string
+  ; kind : string
+  ; payload_pretty : string
+      (* Whole [payload] sub-tree pretty-printed as JSON. Server
+         returns this verbatim (lazy-decoded blobs are stringified
+         server-side); F2 does not interpret kind-specific shapes. *)
+  ; metadata_pretty : string
+      (* Whole [metadata] sub-tree pretty-printed as JSON for
+         operator inspection. *)
+  ; created_by : string
+  }
+
+type provenance =
+  { origins : string list
+  ; descendants : string list
+  }
+
+let pretty_of json =
+  Yojson.Safe.pretty_to_string ~std:true json
+
+let detail_of_yojson (json : Yojson.Safe.t) : detail =
+  let string_field name =
+    match Yojson.Safe.Util.member name json with
+    | `String s -> s
+    | _ -> ""
+  in
+  let payload_pretty =
+    pretty_of (Yojson.Safe.Util.member "payload" json)
+  in
+  let metadata_pretty =
+    pretty_of (Yojson.Safe.Util.member "metadata" json)
+  in
+  let created_by =
+    match Yojson.Safe.Util.member "provenance" json with
+    | `Null -> ""
+    | prov ->
+      (match Yojson.Safe.Util.member "created_by" prov with
+       | `String s -> s
+       | _ -> "")
+  in
+  { id = string_field "id"
+  ; kind = string_field "kind"
+  ; payload_pretty
+  ; metadata_pretty
+  ; created_by
+  }
+;;
+
+let string_list_of_yojson_member (json : Yojson.Safe.t) (name : string)
+    : string list =
+  match Yojson.Safe.Util.member name json with
+  | `List xs ->
+    List.filter_map xs ~f:(function
+      | `String s -> Some s
+      | _ -> None)
+  | _ -> []
+;;
+
+let provenance_of_yojson (json : Yojson.Safe.t) : provenance =
+  { origins = string_list_of_yojson_member json "origins"
+  ; descendants = string_list_of_yojson_member json "descendants"
+  }
+;;

--- a/dashboard_bonsai/src/multimodal_detail_var.ml
+++ b/dashboard_bonsai/src/multimodal_detail_var.ml
@@ -1,0 +1,20 @@
+(** Tier F2 — Bonsai.Expert.Var holders for the detail panel.
+
+    Three independent vars instead of one merged record so each
+    parallel fetch ([/get] + [/provenance]) writes only its own slot
+    without needing a synchronous peek of the other slot. The view
+    reads all three reactively via [Bonsai.Expert.Var.value]. *)
+
+let selected_id_var : string option Bonsai.Expert.Var.t =
+  Bonsai.Expert.Var.create None
+;;
+
+let detail_var : Multimodal_detail_types.detail option Bonsai.Expert.Var.t =
+  Bonsai.Expert.Var.create None
+;;
+
+let provenance_var
+  : Multimodal_detail_types.provenance option Bonsai.Expert.Var.t
+  =
+  Bonsai.Expert.Var.create None
+;;

--- a/dashboard_bonsai/src/multimodal_detail_view.ml
+++ b/dashboard_bonsai/src/multimodal_detail_view.ml
@@ -1,0 +1,231 @@
+(** Tier F2 — detail panel for the currently-selected artifact.
+
+    Renders below the gallery grid when [selected_id_var] is [Some _].
+    Reads three vars reactively:
+    - [selected_id_var] : [string option]   (controls visibility + close)
+    - [detail_var]      : [detail option]   ([/get] result)
+    - [provenance_var]  : [provenance option] ([/provenance] result)
+
+    A close button clears all three vars via [Multimodal_detail_fetch.clear].
+    No payload-kind-specific rendering — payload + metadata are
+    pretty-printed JSON for operator inspection. Provenance is a flat
+    list of origin/descendant ids; F2 does not yet render a DAG. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .panel {
+    margin-top: 1.5rem;
+    padding: 1.5rem;
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    border-radius: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+  }
+  .head_left { display: flex; align-items: baseline; gap: 0.75rem; }
+  .head_title {
+    font-family: 'Cinzel', serif;
+    font-weight: 500;
+    font-size: 1rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-bright);
+    margin: 0;
+  }
+  .head_id {
+    font-family: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+    font-size: 0.8rem;
+    color: var(--color-fg-muted);
+  }
+  .close_btn {
+    background: transparent;
+    border: 1px solid var(--color-border-default);
+    color: var(--color-fg-muted);
+    border-radius: 3px;
+    padding: 4px 10px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    cursor: pointer;
+    letter-spacing: 0.08em;
+  }
+  .close_btn:hover { color: var(--text-bright); }
+  .section_title {
+    font-family: 'Cinzel', serif;
+    font-size: 0.75rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-fg-muted);
+    margin: 0 0 0.4rem 0;
+  }
+  .json {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.75rem;
+    color: var(--color-fg-primary);
+    background: color-mix(in oklab, var(--color-bg-page) 50%, transparent);
+    padding: 0.75rem;
+    border-radius: 4px;
+    border: 1px solid color-mix(in oklab, var(--color-border-default) 60%, transparent);
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-height: 320px;
+    overflow: auto;
+    margin: 0;
+  }
+  .prov_grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+  .prov_list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: var(--color-fg-primary);
+  }
+  .prov_list li {
+    padding: 2px 0;
+    border-bottom: 1px solid color-mix(in oklab, var(--color-border-default) 30%, transparent);
+  }
+  .prov_empty {
+    font-family: 'EB Garamond', Georgia, serif;
+    font-style: italic;
+    color: var(--color-fg-muted);
+    font-size: 0.85rem;
+  }
+  .loading {
+    font-family: 'EB Garamond', Georgia, serif;
+    font-style: italic;
+    color: var(--color-fg-muted);
+  }
+  .created_by {
+    font-family: 'EB Garamond', Georgia, serif;
+    font-style: italic;
+    color: var(--color-fg-muted);
+    font-size: 0.85rem;
+  }
+|}]
+
+let close_button : Node.t =
+  Node.button
+    ~attrs:
+      [ Style.close_btn
+      ; Attr.on_click (fun _ ->
+            Multimodal_detail_fetch.clear ();
+            Effect.Ignore)
+      ]
+    [ Node.text "close" ]
+;;
+
+let render_detail (d : Multimodal_detail_types.detail) : Node.t list =
+  [ Node.div
+      ~attrs:[ Style.head ]
+      [ Node.div
+          ~attrs:[ Style.head_left ]
+          [ Node.h2 ~attrs:[ Style.head_title ] [ Node.text d.kind ]
+          ; Node.span ~attrs:[ Style.head_id ] [ Node.text d.id ]
+          ]
+      ; close_button
+      ]
+  ; (if String.is_empty d.created_by then Node.none
+     else
+       Node.div
+         ~attrs:[ Style.created_by ]
+         [ Node.text ("created by " ^ d.created_by) ])
+  ; Node.div
+      [ Node.h3 ~attrs:[ Style.section_title ] [ Node.text "payload" ]
+      ; Node.pre ~attrs:[ Style.json ] [ Node.text d.payload_pretty ]
+      ]
+  ; Node.div
+      [ Node.h3 ~attrs:[ Style.section_title ] [ Node.text "metadata" ]
+      ; Node.pre ~attrs:[ Style.json ] [ Node.text d.metadata_pretty ]
+      ]
+  ]
+;;
+
+let render_id_list (ids : string list) : Node.t =
+  if List.is_empty ids
+  then Node.span ~attrs:[ Style.prov_empty ] [ Node.text "(none)" ]
+  else
+    Node.ul
+      ~attrs:[ Style.prov_list ]
+      (List.map ids ~f:(fun id -> Node.li [ Node.text id ]))
+;;
+
+let render_provenance (p : Multimodal_detail_types.provenance) : Node.t =
+  Node.div
+    [ Node.h3 ~attrs:[ Style.section_title ] [ Node.text "provenance" ]
+    ; Node.div
+        ~attrs:[ Style.prov_grid ]
+        [ Node.div
+            [ Node.div ~attrs:[ Style.section_title ] [ Node.text "origins" ]
+            ; render_id_list p.origins
+            ]
+        ; Node.div
+            [ Node.div ~attrs:[ Style.section_title ] [ Node.text "descendants" ]
+            ; render_id_list p.descendants
+            ]
+        ]
+    ]
+;;
+
+let view_of_state
+    ~(selected_id : string option)
+    ~(detail : Multimodal_detail_types.detail option)
+    ~(provenance : Multimodal_detail_types.provenance option)
+    : Node.t
+  =
+  match selected_id with
+  | None -> Node.none
+  | Some id ->
+    let header_when_loading =
+      Node.div
+        ~attrs:[ Style.head ]
+        [ Node.div
+            ~attrs:[ Style.head_left ]
+            [ Node.span ~attrs:[ Style.head_id ] [ Node.text id ] ]
+        ; close_button
+        ]
+    in
+    let body =
+      match detail with
+      | None ->
+        [ header_when_loading
+        ; Node.div ~attrs:[ Style.loading ] [ Node.text "loading detail…" ]
+        ]
+      | Some d -> render_detail d
+    in
+    let prov_section =
+      match provenance with
+      | None ->
+        Node.div
+          ~attrs:[ Style.loading ]
+          [ Node.text "loading provenance…" ]
+      | Some p -> render_provenance p
+    in
+    Node.div ~attrs:[ Style.panel ] (body @ [ prov_section ])
+;;
+
+let component (_graph @ local) =
+  let%map.Bonsai selected_id =
+    Bonsai.Expert.Var.value Multimodal_detail_var.selected_id_var
+  and detail = Bonsai.Expert.Var.value Multimodal_detail_var.detail_var
+  and provenance =
+    Bonsai.Expert.Var.value Multimodal_detail_var.provenance_var
+  in
+  view_of_state ~selected_id ~detail ~provenance
+;;

--- a/dashboard_bonsai/src/multimodal_view.ml
+++ b/dashboard_bonsai/src/multimodal_view.ml
@@ -8,8 +8,10 @@
     until [MASC_MULTIMODAL=1] + [MASC_TOOL_EMISSION=1] are both on
     AND a keeper tool emits a tagged JSON result.
 
-    The view is read-only — interactions (filtering, opening payload)
-    are deferred to F2. *)
+    Cards are clickable: click triggers parallel fetches against
+    [/api/v1/multimodal/get/<id>] + [/api/v1/multimodal/provenance/<id>]
+    via [Multimodal_detail_fetch.fetch], and the detail panel
+    ([Multimodal_detail_view]) renders below the grid. *)
 
 open! Core
 open! Bonsai_web
@@ -58,6 +60,11 @@ stylesheet
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    cursor: pointer;
+    transition: border-color 120ms ease;
+  }
+  .card:hover {
+    border-color: color-mix(in oklab, var(--accent-blood) 50%, var(--color-border-default));
   }
   .card_head {
     display: flex;
@@ -108,7 +115,15 @@ let truncate_id (s : string) : string =
 
 let card (a : Multimodal_types.artifact) : Node.t =
   Node.div
-    ~attrs:[ Style.card ]
+    ~attrs:
+      [ Style.card
+      ; Attr.role "button"
+      ; Attr.create "tabindex" "0"
+      ; Attr.create "aria-label" ("Open artifact " ^ a.id)
+      ; Attr.on_click (fun _ ->
+            Multimodal_detail_fetch.fetch ~id:a.id;
+            Effect.Ignore)
+      ]
     [ Node.div
         ~attrs:[ Style.card_head ]
         [ Node.span ~attrs:[ Style.badge ] [ Node.text a.kind ]
@@ -140,7 +155,11 @@ let empty_state : Node.t =
     ]
 ;;
 
-let view_of_response (r : Multimodal_types.response) : Node.t =
+let view_of_response
+    ~(detail_panel : Node.t)
+    (r : Multimodal_types.response)
+    : Node.t
+  =
   Node.div
     ~attrs:[ Style.root; Attr.role "main"; Attr.create "aria-label" "Multimodal gallery" ]
     [ Node.div
@@ -155,9 +174,12 @@ let view_of_response (r : Multimodal_types.response) : Node.t =
          Node.div
            ~attrs:[ Style.grid ]
            (List.map r.artifacts ~f:card))
+    ; detail_panel
     ]
 ;;
 
-let component (_graph @ local) =
-  Bonsai.map (Bonsai.Expert.Var.value Multimodal_var.var) ~f:view_of_response
+let component (graph @ local) =
+  let%map.Bonsai response = Bonsai.Expert.Var.value Multimodal_var.var
+  and detail_panel = Multimodal_detail_view.component graph in
+  view_of_response ~detail_panel response
 ;;


### PR DESCRIPTION
## Summary

Wires F1 gallery cards to a clickable detail panel that fetches `/api/v1/multimodal/get/<id>` + `/api/v1/multimodal/provenance/<id>` in parallel and renders payload/metadata as pretty-printed JSON plus origins/descendants id lists. Closes the loop K1→K2→K3→K4→K4b→K1 hydrate→D1 HTTP→F1 gallery→**F2 detail** for operator inspection.

## Design highlights

- **3 independent Bonsai.Expert.Var holders** (`selected_id_var`, `detail_var`, `provenance_var`) so each parallel fetch writes only its own slot — eliminates the sync-read-then-merge anti-pattern.
- **Reactive let%map** in `Multimodal_detail_view.component` reads all three vars, so partial states render `loading detail…` / `loading provenance…` without any synchronous peek of var contents.
- **a11y**: card gains `role="button"`, `tabindex="0"`, `aria-label`. Close button on the panel.
- **No payload-kind-specific rendering** — F2 stays operator-grade JSON inspection. DAG layout of provenance chains and filtering are deferred.

## Files

| File | Purpose |
|------|---------|
| `dashboard_bonsai/src/multimodal_detail_types.ml` | `detail` / `provenance` records + JSON parsers |
| `dashboard_bonsai/src/multimodal_detail_var.ml` | 3 Bonsai.Expert.Var holders |
| `dashboard_bonsai/src/multimodal_detail_fetch.ml` | parallel fetch via `Brr_io.Fetch` |
| `dashboard_bonsai/src/multimodal_detail_view.ml` | reactive panel component |
| `dashboard_bonsai/src/multimodal_view.ml` | gallery card `on_click` + panel insertion |

## Test plan

- [x] `dune build --root dashboard_bonsai` GREEN under bonsai-dashboard switch
- [x] js_of_ocaml emits `_build/default/bin/main.bc.js` (~64 MB, parity with main)
- [ ] Live keeper smoke: enable `MASC_TOOL_EMISSION=1` + `MASC_MULTIMODAL=1`, emit a tagged tool result, click a card in the dashboard, observe payload/metadata JSON + origins/descendants populate

## Out of scope

- Provenance DAG visualization (flat lists for now)
- Filter/search bar over the gallery
- Kind-specific payload renderers (image previews, audio players, etc.)