### PR TITLE
Add collaboration performance budget contract

### DIFF
--- a/dashboard/src/collab-mvp-contract.test.ts
+++ b/dashboard/src/collab-mvp-contract.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   COLLAB_MVP_STACK,
+  COLLAB_TRACK8_PERFORMANCE_BUDGET,
   buildCollabMvpProjection,
+  evaluateCollabPerformanceBudget,
 } from './collab-mvp-contract'
 import { normalizeTask } from './store-normalizers'
 import type { Agent, Task } from './types'
@@ -18,6 +20,123 @@ describe('COLLAB_MVP_STACK', () => {
       status: 'contract',
       owner: 'masc',
     })
+  })
+})
+
+describe('COLLAB_TRACK8_PERFORMANCE_BUDGET', () => {
+  it('captures the Track 8 dashboard collaboration performance targets', () => {
+    expect(COLLAB_TRACK8_PERFORMANCE_BUDGET).toEqual([
+      expect.objectContaining({
+        id: 'sync_latency_p95_ms',
+        unit: 'ms',
+        target: 100,
+        comparator: 'lt',
+      }),
+      expect.objectContaining({
+        id: 'ws_connect_p95_ms',
+        unit: 'ms',
+        target: 500,
+        comparator: 'lt',
+      }),
+      expect.objectContaining({
+        id: 'checks_rate',
+        unit: 'ratio',
+        target: 0.99,
+        comparator: 'gt',
+      }),
+      expect.objectContaining({
+        id: 'keystroke_latency_ms',
+        unit: 'ms',
+        target: 16,
+        comparator: 'lt',
+      }),
+      expect.objectContaining({
+        id: 'fps',
+        unit: 'fps',
+        target: 55,
+        comparator: 'gte',
+      }),
+      expect.objectContaining({
+        id: 'lcp_ms',
+        unit: 'ms',
+        target: 2500,
+        comparator: 'lt',
+      }),
+      expect.objectContaining({
+        id: 'inp_ms',
+        unit: 'ms',
+        target: 200,
+        comparator: 'lt',
+      }),
+      expect.objectContaining({
+        id: 'document_size_bytes',
+        unit: 'bytes',
+        target: 10 * 1024 * 1024,
+        comparator: 'lt',
+      }),
+      expect.objectContaining({
+        id: 'merge_12_docs_ms',
+        unit: 'ms',
+        target: 100,
+        comparator: 'lt',
+      }),
+      expect.objectContaining({
+        id: 'ops_per_sec',
+        unit: 'ops/sec',
+        target: 1000,
+        comparator: 'gt',
+      }),
+    ])
+    expect(COLLAB_TRACK8_PERFORMANCE_BUDGET.every(metric =>
+      metric.owner === 'masc' && metric.sourceSection === 'multiagent-ide-deep-analysis.md#8'
+    )).toBe(true)
+  })
+})
+
+describe('evaluateCollabPerformanceBudget', () => {
+  it('passes samples that satisfy strict and inclusive Track 8 targets', () => {
+    expect(evaluateCollabPerformanceBudget({
+      sync_latency_p95_ms: 99.9,
+      ws_connect_p95_ms: 499,
+      checks_rate: 0.991,
+      keystroke_latency_ms: 15.9,
+      fps: 55,
+      lcp_ms: 2499,
+      inp_ms: 199,
+      document_size_bytes: 10 * 1024 * 1024 - 1,
+      merge_12_docs_ms: 99,
+      ops_per_sec: 1001,
+    })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'sync_latency_p95_ms', pass: true }),
+      expect.objectContaining({ id: 'fps', pass: true }),
+      expect.objectContaining({ id: 'ops_per_sec', pass: true }),
+    ]))
+  })
+
+  it('fails boundary and non-finite samples that violate the contract', () => {
+    expect(evaluateCollabPerformanceBudget({
+      sync_latency_p95_ms: 100,
+      ws_connect_p95_ms: 500,
+      checks_rate: 0.99,
+      keystroke_latency_ms: 16,
+      fps: 54.99,
+      lcp_ms: 2500,
+      inp_ms: 200,
+      document_size_bytes: 10 * 1024 * 1024,
+      merge_12_docs_ms: 100,
+      ops_per_sec: Number.POSITIVE_INFINITY,
+    })).toEqual([
+      expect.objectContaining({ id: 'sync_latency_p95_ms', pass: false }),
+      expect.objectContaining({ id: 'ws_connect_p95_ms', pass: false }),
+      expect.objectContaining({ id: 'checks_rate', pass: false }),
+      expect.objectContaining({ id: 'keystroke_latency_ms', pass: false }),
+      expect.objectContaining({ id: 'fps', pass: false }),
+      expect.objectContaining({ id: 'lcp_ms', pass: false }),
+      expect.objectContaining({ id: 'inp_ms', pass: false }),
+      expect.objectContaining({ id: 'document_size_bytes', pass: false }),
+      expect.objectContaining({ id: 'merge_12_docs_ms', pass: false }),
+      expect.objectContaining({ id: 'ops_per_sec', pass: false }),
+    ])
   })
 })
 

--- a/dashboard/src/collab-mvp-contract.ts
+++ b/dashboard/src/collab-mvp-contract.ts
@@ -80,6 +80,132 @@ export interface CollabMvpEventSemantic {
   attributes: string[]
 }
 
+export type CollabPerformanceBudgetMetricId =
+  | 'sync_latency_p95_ms'
+  | 'ws_connect_p95_ms'
+  | 'checks_rate'
+  | 'keystroke_latency_ms'
+  | 'fps'
+  | 'lcp_ms'
+  | 'inp_ms'
+  | 'document_size_bytes'
+  | 'merge_12_docs_ms'
+  | 'ops_per_sec'
+
+export type CollabPerformanceBudgetComparator = 'lt' | 'lte' | 'gt' | 'gte'
+export type CollabPerformanceBudgetUnit = 'ms' | 'ratio' | 'fps' | 'bytes' | 'ops/sec'
+
+export interface CollabPerformanceBudgetMetric {
+  id: CollabPerformanceBudgetMetricId
+  label: string
+  unit: CollabPerformanceBudgetUnit
+  target: number
+  comparator: CollabPerformanceBudgetComparator
+  sourceSection: 'multiagent-ide-deep-analysis.md#8'
+  owner: 'masc'
+}
+
+export interface CollabPerformanceBudgetResult {
+  id: CollabPerformanceBudgetMetricId
+  value: number
+  target: number
+  comparator: CollabPerformanceBudgetComparator
+  pass: boolean
+}
+
+export const COLLAB_TRACK8_PERFORMANCE_BUDGET: CollabPerformanceBudgetMetric[] = [
+  {
+    id: 'sync_latency_p95_ms',
+    label: 'Sync latency p95',
+    unit: 'ms',
+    target: 100,
+    comparator: 'lt',
+    sourceSection: 'multiagent-ide-deep-analysis.md#8',
+    owner: 'masc',
+  },
+  {
+    id: 'ws_connect_p95_ms',
+    label: 'WebSocket connect p95',
+    unit: 'ms',
+    target: 500,
+    comparator: 'lt',
+    sourceSection: 'multiagent-ide-deep-analysis.md#8',
+    owner: 'masc',
+  },
+  {
+    id: 'checks_rate',
+    label: 'Checks pass rate',
+    unit: 'ratio',
+    target: 0.99,
+    comparator: 'gt',
+    sourceSection: 'multiagent-ide-deep-analysis.md#8',
+    owner: 'masc',
+  },
+  {
+    id: 'keystroke_latency_ms',
+    label: 'Keystroke latency',
+    unit: 'ms',
+    target: 16,
+    comparator: 'lt',
+    sourceSection: 'multiagent-ide-deep-analysis.md#8',
+    owner: 'masc',
+  },
+  {
+    id: 'fps',
+    label: 'Frame rate',
+    unit: 'fps',
+    target: 55,
+    comparator: 'gte',
+    sourceSection: 'multiagent-ide-deep-analysis.md#8',
+    owner: 'masc',
+  },
+  {
+    id: 'lcp_ms',
+    label: 'Largest Contentful Paint',
+    unit: 'ms',
+    target: 2500,
+    comparator: 'lt',
+    sourceSection: 'multiagent-ide-deep-analysis.md#8',
+    owner: 'masc',
+  },
+  {
+    id: 'inp_ms',
+    label: 'Interaction to Next Paint',
+    unit: 'ms',
+    target: 200,
+    comparator: 'lt',
+    sourceSection: 'multiagent-ide-deep-analysis.md#8',
+    owner: 'masc',
+  },
+  {
+    id: 'document_size_bytes',
+    label: 'Document size',
+    unit: 'bytes',
+    target: 10 * 1024 * 1024,
+    comparator: 'lt',
+    sourceSection: 'multiagent-ide-deep-analysis.md#8',
+    owner: 'masc',
+  },
+  {
+    id: 'merge_12_docs_ms',
+    label: 'Merge 12 docs',
+    unit: 'ms',
+    target: 100,
+    comparator: 'lt',
+    sourceSection: 'multiagent-ide-deep-analysis.md#8',
+    owner: 'masc',
+  },
+  {
+    id: 'ops_per_sec',
+    label: 'CRDT throughput',
+    unit: 'ops/sec',
+    target: 1000,
+    comparator: 'gt',
+    sourceSection: 'multiagent-ide-deep-analysis.md#8',
+    owner: 'masc',
+  },
+]
+
 export const COLLAB_MVP_EVENT_SEMANTICS: CollabMvpEventSemantic[] = [
   {
     name: 'masc.collab.doc.sync',
@@ -127,6 +253,39 @@ export const COLLAB_MVP_EVENT_SEMANTICS: CollabMvpEventSemantic[] = [
     ],
   },
 ]
+
+function passesPerformanceBudget(
+  value: number,
+  target: number,
+  comparator: CollabPerformanceBudgetComparator,
+): boolean {
+  switch (comparator) {
+    case 'lt':
+      return value < target
+    case 'lte':
+      return value <= target
+    case 'gt':
+      return value > target
+    case 'gte':
+      return value >= target
+  }
+}
+
+export function evaluateCollabPerformanceBudget(
+  samples: Partial<Record<CollabPerformanceBudgetMetricId, number>>,
+): CollabPerformanceBudgetResult[] {
+  return COLLAB_TRACK8_PERFORMANCE_BUDGET.flatMap(metric => {
+    const value = samples[metric.id]
+    if (value === undefined) return []
+    return [{
+      id: metric.id,
+      value,
+      target: metric.target,
+      comparator: metric.comparator,
+      pass: Number.isFinite(value) && passesPerformanceBudget(value, metric.target, metric.comparator),
+    }]
+  })
+}
 
 export type TodoClaimState = 'unclaimed' | 'claimed' | 'running' | 'verification' | 'terminal'
 


### PR DESCRIPTION
## Summary

Applies Track 8's performance and monitoring budget slice to the MASC dashboard collaboration contract.

- Adds a typed Track8 budget contract for sync, WebSocket connect, checks, keystroke latency, FPS, Web Vitals, document size, merge latency, and CRDT ops/sec.
- Adds a deterministic evaluator for sampled dashboard metrics, including boundary and non-finite failures.
- Covers the contract with focused dashboard tests without adding heavy k6/Lighthouse/Jepsen runner infrastructure in this slice.

## Validation

- `git diff --check`
- `pnpm exec vitest run --config vitest.config.ts src/collab-mvp-contract.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm typecheck`