### PR TITLE
fix(keeper): Skip_idle wake closes MissedWakeup gap (sibling of #10078)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -646,6 +646,14 @@ let smart_heartbeat_cycle_continues (d : Heartbeat_smart.decision) : bool =
   | Heartbeat_smart.Skip_idle _ -> false
 ;;
 
+let cycle_continues_after_wake
+      (d : Heartbeat_smart.decision)
+      (outcome : Keeper_keepalive_signal.sleep_outcome) : bool =
+  match d, outcome with
+  | Heartbeat_smart.Skip_idle _, Keeper_keepalive_signal.Woken -> true
+  | _, _ -> smart_heartbeat_cycle_continues d
+;;
+
 let run_smart_heartbeat_gate
       ~(clock : _ Eio.Time.clock)
       ~(stop : bool Atomic.t)
@@ -669,24 +677,44 @@ let run_smart_heartbeat_gate
     else Heartbeat_smart.Emit
   in
   (* Run side-effects (idle sleep, cycle-timestamp update) per the
-     decision, then use [smart_heartbeat_cycle_continues] (pure, see
-     .mli) as the authoritative gate answer. This split exists so the
-     regression guard lives in a pure function that unit tests can
-     exercise without an Eio runtime. *)
-  (match smart_hb_decision with
-   | Heartbeat_smart.Skip_busy ->
-     Log.Keeper.debug
-       "smart heartbeat: busy (task=%s) — cycle continues, broadcast may be debounced"
-       (match meta_current.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "?");
-     last_heartbeat_cycle_ts := Time_compat.now ()
-   | Heartbeat_smart.Skip_idle next_time ->
-     let wait = Float.max 1.0 (next_time -. Time_compat.now ()) in
-     Log.Keeper.debug "smart heartbeat: skip (idle, next in %.1fs)" wait;
-     let jitter = wait *. 0.1 *. Random.float 1.0 in
-     Keeper_keepalive_signal.interruptible_sleep ~clock ~stop ~wakeup (wait +. jitter)
-   | Heartbeat_smart.Emit ->
-     last_heartbeat_cycle_ts := Time_compat.now ());
-  smart_heartbeat_cycle_continues smart_hb_decision
+     decision, then delegate the gate answer to [cycle_continues_after_wake]
+     so the [Skip_idle + Woken] case can promote to [true] (closing the
+     [MissedWakeup] gap in KeeperHeartbeat.tla — sibling of #10078). The
+     pure helpers stay testable without an Eio runtime. *)
+  let sleep_outcome =
+    match smart_hb_decision with
+    | Heartbeat_smart.Skip_busy ->
+      Log.Keeper.debug
+        "smart heartbeat: busy (task=%s) — cycle continues, broadcast may be debounced"
+        (match meta_current.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "?");
+      last_heartbeat_cycle_ts := Time_compat.now ();
+      Keeper_keepalive_signal.Timeout
+    | Heartbeat_smart.Skip_idle next_time ->
+      let wait = Float.max 1.0 (next_time -. Time_compat.now ()) in
+      Log.Keeper.debug "smart heartbeat: skip (idle, next in %.1fs)" wait;
+      let jitter = wait *. 0.1 *. Random.float 1.0 in
+      let outcome =
+        Keeper_keepalive_signal.interruptible_sleep
+          ~clock ~stop ~wakeup (wait +. jitter)
+      in
+      (match outcome with
+       | Keeper_keepalive_signal.Woken ->
+         (* External wakeup arrived during idle backoff: the keeper is
+            no longer idle. Stamp the cycle timestamp so the next
+            [should_emit] does not immediately re-classify as Skip_idle,
+            and let the cycle proceed (presence/board/turn dispatch).
+            Spec: KeeperHeartbeat.tla HeartbeatTick — turn_state must
+            transition to "running". *)
+         Log.Keeper.info
+           "smart heartbeat: idle wake — cycle resumed (post=consumed)";
+         last_heartbeat_cycle_ts := Time_compat.now ()
+       | Keeper_keepalive_signal.Stopped | Keeper_keepalive_signal.Timeout -> ());
+      outcome
+    | Heartbeat_smart.Emit ->
+      last_heartbeat_cycle_ts := Time_compat.now ();
+      Keeper_keepalive_signal.Timeout
+  in
+  cycle_continues_after_wake smart_hb_decision sleep_outcome
 ;;
 
 let maybe_write_heartbeat_snapshot
@@ -1027,7 +1055,9 @@ let run_heartbeat_loop
         let jitter =
           base *. Env_config.KeeperKeepalive.jitter_factor *. Random.float 1.0
         in
-        Keeper_keepalive_signal.interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (base +. jitter));
+        ignore (Keeper_keepalive_signal.interruptible_sleep
+                  ~clock:ctx.clock ~stop ~wakeup (base +. jitter)
+                : Keeper_keepalive_signal.sleep_outcome));
       if Atomic.get stop then () else loop ())
   in
   loop ()

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -81,6 +81,25 @@ val dispatch_recurring_keepalive :
     [Emit] -> [true]. *)
 val smart_heartbeat_cycle_continues : Heartbeat_smart.decision -> bool
 
+(** Pure: post-sleep refinement of [smart_heartbeat_cycle_continues] that
+    closes the [MissedWakeup] gap in [KeeperHeartbeat.tla].
+
+    The base helper is computed before the idle sleep, but during a
+    [Skip_idle] sleep an external [wakeup_keeper] / board signal can
+    flip the wakeup atomic — [interruptible_sleep] returns [Woken] in
+    that case. The spec's honest [HeartbeatTick] action requires
+    [turn_state' = "running"] when wakeup is consumed, so the cycle
+    must continue even though the original decision was [Skip_idle].
+    This sibling of #10078 (which lifted the same restriction for
+    [Skip_busy]) closes the [Skip_idle] half intentionally left open
+    by that fix.
+
+    Contract: returns the base decision unchanged for [Skip_busy] and
+    [Emit]; for [Skip_idle], promotes to [true] iff the sleep ended
+    with [Woken] (not [Timeout] / [Stopped]). *)
+val cycle_continues_after_wake :
+  Heartbeat_smart.decision -> Keeper_keepalive_signal.sleep_outcome -> bool
+
 val run_smart_heartbeat_gate :
   clock:'a Eio.Time.clock ->
   stop:bool Atomic.t ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -243,7 +243,8 @@ let run_grpc_heartbeat_stream
       if not (Atomic.get stop || Atomic.get close_ref)
       then (
         let no_wakeup = Atomic.make false in
-        interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec;
+        ignore (interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec
+                : Keeper_keepalive_signal.sleep_outcome);
         tick ()))
   in
   tick ()

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -81,6 +81,12 @@ val fairness_delay_sec_at : now:float -> keeper_name:string -> float
     ever running a turn. *)
 val smart_heartbeat_cycle_continues : Heartbeat_smart.decision -> bool
 
+(** Pure: post-sleep refinement. Promotes [Skip_idle] to [true] iff the
+    sleep ended with [Woken]. Closes the [MissedWakeup] gap in
+    KeeperHeartbeat.tla left open by sibling fix #10078. *)
+val cycle_continues_after_wake :
+  Heartbeat_smart.decision -> Keeper_keepalive_signal.sleep_outcome -> bool
+
 val status_tick_usage_json : unit -> Yojson.Safe.t
 (** Usage payload for heartbeat/status metrics rows.  Status ticks are not
     LLM calls, so all per-turn token counters are explicit zeroes while

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -82,28 +82,34 @@ let post_submit_task ~(meta : keeper_meta) ~(task_id : Keeper_id.Task_id.t) =
 let post_heartbeat_tick ~(wakeup : bool Atomic.t) = ignore wakeup
   [@@fsm_guard "Atomic.get wakeup = false"]
 
+type sleep_outcome =
+  | Stopped
+  | Woken
+  | Timeout
+
 (** Sleep in short chunks so [stop_keepalive] or [wakeup_keeper] takes
     effect within ~chunk_sec instead of waiting for the full interval. *)
-let interruptible_sleep ~clock ~stop ~wakeup duration =
+let interruptible_sleep ~clock ~stop ~wakeup duration : sleep_outcome =
   let chunk_sec = Env_config.KeeperKeepalive.sleep_chunk_sec in
   let rec wait remaining =
     if Atomic.get stop
-    then ()
+    then Stopped
     else if (* Spec: KeeperHeartbeat.tla HeartbeatTick action — wakeup is
               consumed (TRUE -> FALSE) and the caller proceeds to dispatch.
-              MissedWakeup bug-action would have this compare_and_set
-              succeed without a follow-up turn; structural invariant is
-              that this branch returns immediately so the surrounding
-              loop can re-enter and dispatch on next tick. *)
+              Returning [Woken] lets [run_smart_heartbeat_gate] honour
+              the spec's [turn_state' = "running"] postcondition; without
+              the discriminator the [Skip_idle] branch would consume the
+              CAS and then skip the cycle (the [MissedWakeup] bug-action). *)
             Atomic.compare_and_set wakeup true false
-    then
+    then (
       (* Cycle 43: post-action guard mirrors the spec's [wakeup_signaled =
          FALSE] postcondition. Counter-mode by default. *)
       Keeper_fsm_guard_runtime.wrap_unit
         ~action:"HeartbeatTick" ~stage:"post"
-        (fun () -> post_heartbeat_tick ~wakeup)
+        (fun () -> post_heartbeat_tick ~wakeup);
+      Woken)
     else if remaining <= 0.0
-    then ()
+    then Timeout
     else (
       let chunk = Float.min chunk_sec remaining in
       Eio.Time.sleep clock chunk;

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -15,11 +15,27 @@ val post_wakeup_signal : wakeup:bool Atomic.t -> unit
 val post_submit_task : meta:keeper_meta -> task_id:Keeper_id.Task_id.t -> unit
 val post_heartbeat_tick : wakeup:bool Atomic.t -> unit
 
+(** Outcome of an [interruptible_sleep] call. Mirrors the three terminal
+    branches of the polling loop, so callers can react to "woken by an
+    external signal" distinctly from "slept the full duration".
+
+    Closing the [Skip_idle] half of the [MissedWakeup] gap (see
+    [specs/keeper-state-machine/KeeperHeartbeat.tla]) requires
+    discriminating [`Woken`] from [`Timeout`] at the call site — sibling
+    fix #10078 covered [Skip_busy] without exposing this distinction. *)
+type sleep_outcome =
+  | Stopped   (** [stop] atomic was observed [true] before the duration
+                  elapsed. *)
+  | Woken     (** [wakeup] atomic transitioned [true -> false] via CAS;
+                  the caller should treat this as a [HeartbeatTick]
+                  spec-action and dispatch a turn. *)
+  | Timeout   (** Full [duration] elapsed without [stop] or [wakeup]. *)
+
 (** Sleep in short chunks so [stop_keepalive] or [wakeup_keeper] takes
     effect within ~chunk_sec instead of waiting for the full interval. *)
 val interruptible_sleep :
   clock:'a Eio.Time.clock -> stop:bool Atomic.t -> wakeup:bool Atomic.t ->
-  float -> unit
+  float -> sleep_outcome
 
 (** Wake up a specific keeper immediately. *)
 val wakeup_keeper : ?base_path:string -> string -> unit

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -144,6 +144,47 @@ let test_cycle_pauses_on_skip_idle () =
   check bool "Skip_idle pauses cycle" false
     (KK.smart_heartbeat_cycle_continues (HS.Skip_idle next))
 
+(* ── MissedWakeup gap regression guard (KeeperHeartbeat.tla) ───────
+   Skip_idle + Woken must promote the gate to [true]. Without this,
+   external wakeup_keeper / board_signal calls that fire during a
+   Skip_idle backoff sleep are silently absorbed: the CAS clears the
+   atomic, the loop returns, but the cycle is skipped — the spec's
+   MissedWakeup bug-action (line 104, KeeperHeartbeat.tla) made
+   concrete. Sibling of #10078 which closed the same hole for
+   Skip_busy. *)
+
+module KKS = Masc_mcp.Keeper_keepalive_signal
+
+let test_after_wake_idle_woken_continues () =
+  let next = Unix.gettimeofday () +. 60.0 in
+  check bool "Skip_idle + Woken -> cycle resumes" true
+    (KK.cycle_continues_after_wake (HS.Skip_idle next) KKS.Woken)
+
+let test_after_wake_idle_timeout_pauses () =
+  let next = Unix.gettimeofday () +. 60.0 in
+  check bool "Skip_idle + Timeout -> cycle still paused" false
+    (KK.cycle_continues_after_wake (HS.Skip_idle next) KKS.Timeout)
+
+let test_after_wake_idle_stopped_pauses () =
+  let next = Unix.gettimeofday () +. 60.0 in
+  check bool "Skip_idle + Stopped -> cycle paused (shutdown path)" false
+    (KK.cycle_continues_after_wake (HS.Skip_idle next) KKS.Stopped)
+
+let test_after_wake_busy_unchanged () =
+  (* Skip_busy already continues per #10078; outcome must not regress
+     that decision regardless of the sleep outcome (this branch never
+     sleeps in practice, but the helper is total). *)
+  check bool "Skip_busy + Woken -> still continues" true
+    (KK.cycle_continues_after_wake HS.Skip_busy KKS.Woken);
+  check bool "Skip_busy + Timeout -> still continues" true
+    (KK.cycle_continues_after_wake HS.Skip_busy KKS.Timeout)
+
+let test_after_wake_emit_unchanged () =
+  check bool "Emit + Timeout -> continues" true
+    (KK.cycle_continues_after_wake HS.Emit KKS.Timeout);
+  check bool "Emit + Woken -> continues" true
+    (KK.cycle_continues_after_wake HS.Emit KKS.Woken)
+
 let test_status_tick_usage_json_includes_cache_fields () =
   let usage = KK.status_tick_usage_json () in
   let int_member key =
@@ -193,6 +234,18 @@ let () =
         `Quick test_cycle_continues_on_skip_busy;
       test_case "Emit -> cycle continues" `Quick test_cycle_continues_on_emit;
       test_case "Skip_idle -> cycle pauses" `Quick test_cycle_pauses_on_skip_idle;
+    ];
+    "missed_wakeup_gap", [
+      test_case "Skip_idle + Woken -> resumes (MissedWakeup spec gap)"
+        `Quick test_after_wake_idle_woken_continues;
+      test_case "Skip_idle + Timeout -> still paused"
+        `Quick test_after_wake_idle_timeout_pauses;
+      test_case "Skip_idle + Stopped -> paused (shutdown)"
+        `Quick test_after_wake_idle_stopped_pauses;
+      test_case "Skip_busy outcome-agnostic"
+        `Quick test_after_wake_busy_unchanged;
+      test_case "Emit outcome-agnostic"
+        `Quick test_after_wake_emit_unchanged;
     ];
     "status_tick_usage", [
       test_case "status tick usage preserves cache fields" `Quick


### PR DESCRIPTION
## Summary

`run_smart_heartbeat_gate` computed the Skip/Emit decision once before `interruptible_sleep`, then returned that decision unchanged regardless of how the sleep ended. When an external `wakeup_keeper` (board signal, @mention) flipped the wakeup atomic during a `Skip_idle` backoff, the CAS consumed it and the sleep returned — but the gate still emitted `cycle_continues = false`. The wakeup was absorbed and the cycle skipped: the `MissedWakeup` bug-action modelled in `specs/keeper-state-machine/KeeperHeartbeat.tla:104`.

`last_successful_heartbeat_ts` was never refreshed by the consumed wakeup, so the next iteration re-classified as `Skip_idle` and slept again. Each new board post triggered another wakeup, all absorbed the same way — keeper appeared alive yet ran no turn for the full extended-idle interval (`idle_threshold_s × idle_multiplier`, default 900s).

## Root cause vs. #10078

#10078 (2026-04-24) lifted the same restriction for `Skip_busy`: *"only `Skip_idle` pauses the cycle"*. The author left `Skip_idle` intentionally — idle keepers should back off to save tokens. But `Skip_idle + Woken` is not idle: an external producer just signalled. This PR closes the half left open by #10078 without weakening its token-saving intent.

| Decision | Outcome | Pre-PR | Post-PR |
|---|---|---|---|
| `Skip_idle` | (no wakeup) | pause ✓ | pause ✓ (token save preserved) |
| `Skip_idle` | `Woken` | pause ✗ (MissedWakeup) | **resume ✓** |
| `Skip_busy` | any | continues ✓ (#10078) | continues ✓ |
| `Emit` | any | continues ✓ | continues ✓ |

## Fix

- `interruptible_sleep` returns `Stopped | Woken | Timeout` instead of `unit`, exposing how the sleep ended.
- New pure helper `cycle_continues_after_wake` promotes `(Skip_idle, Woken) -> true`; all other combinations defer to `smart_heartbeat_cycle_continues` (unchanged contract).
- `run_smart_heartbeat_gate` updates `last_heartbeat_cycle_ts` on Woken so the next `should_emit` does not immediately re-loop into Skip_idle.

## Spec alignment

`KeeperHeartbeat.tla` honest `HeartbeatTick` action (line 77-82) requires `wakeup_signaled = TRUE -> turn_state' = \"running\"`. The previous runtime satisfied only the first conjunct and left `turn_state = \"idle\"` — exactly the `MissedWakeup` shape (line 104-109). After this fix the Woken outcome lets the cycle proceed to turn dispatch, matching the spec's honest action.

## Test plan

- [x] `dune build @check --root .` — pass
- [x] `dune exec test/test_smart_heartbeat_keepalive.exe --root .` — **23/23 pass** (18 existing + 5 new under `missed_wakeup_gap` group)
- [x] `dune exec test/test_keeper_registry.exe --root . -- test basic` — 27/27 pass (covers `wakeup_relevant_keeper_for_board_signal`)
- [x] `bash scripts/tla-check.sh` — pass
- [ ] CI green
- [ ] Post-merge live verification: idle keeper receives board signal → \`smart heartbeat: idle wake — cycle resumed\` log appears within ~2s, followed by \`keepalive turn scheduled\`

## Blast radius

- **Type-level**: `interruptible_sleep` return type changed (was `unit`). Two fire-and-forget callers (recurring loop sleep at heartbeat_loop:1058, gRPC tick sleep at keepalive:246) updated to `ignore (... : sleep_outcome)`. No external surface changes.
- **Behaviour delta**: a keeper idle past `idle_threshold_s` (default 300s) that receives a board signal now resumes its full keepalive cycle on the next chunk (≤ 2s) instead of waiting up to ~90s for the Skip_idle window to expire.
- **Token cost**: bounded by the existing 60s per-`post_id` board debounce (`board_reactive_wakeup_allowed`) — unchanged. The wakeup-aware path can run at most once per (keeper, post_id, 60s) window.

## Rollback

Single commit, 7 files, no schema or persistence changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)