### PR TITLE
feat(keeper): Tier K4c — per-keeper tool-emission accumulator registry

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -245,9 +245,17 @@ let apply_tool_emission_wirein
     | None -> lifecycle
     | Some cp -> (
         try
+          let acc =
+            (* Tier K4c — pull THIS keeper's accumulator. Producer
+               side ([Keeper_run_tools]) registered it under the
+               same name pre-Agent.run, so the items captured during
+               this turn drain into this turn's working_context. *)
+            Keeper_tool_emission_hook.accumulator_for_keeper
+              lifecycle.updated_meta.name
+          in
           let new_wc =
             Keeper_tool_emission_hook.drain_into_working_context
-              Keeper_tool_emission_hook.global_accumulator
+              acc
               ~working_context:cp.Oas.Checkpoint.working_context
           in
           let new_cp =

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1293,16 +1293,18 @@ let prepare_agent_setup
     in
     Oas.Hooks.compose ~outer:mem_hooks ~inner:hooks
   in
-  (* Tier K4b: install the tool-emission PostToolUse hook so tagged
-     tool results flow into the K4 process-wide accumulator during
-     Agent.run. The drain happens in keeper_post_turn.ml
-     [apply_tool_emission_wirein] BEFORE [apply_multimodal_wirein].
+  (* Tier K4b/K4c: install the tool-emission PostToolUse hook so
+     tagged tool results flow into this keeper's own accumulator
+     during Agent.run. The drain happens in keeper_post_turn.ml
+     [apply_tool_emission_wirein] BEFORE [apply_multimodal_wirein],
+     keyed by the SAME keeper name (stable across turns).
      When [MASC_TOOL_EMISSION] is off the hook is a no-op (see
      [Keeper_tool_emission_hook] for the gating). *)
   let hooks =
-    Keeper_tool_emission_hook.install_into_hooks
-      Keeper_tool_emission_hook.global_accumulator
-      hooks
+    let acc =
+      Keeper_tool_emission_hook.accumulator_for_keeper agent_name
+    in
+    Keeper_tool_emission_hook.install_into_hooks acc hooks
   in
   let reducer =
     let hydrator_steps =

--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -77,3 +77,36 @@ let drain_into_working_context acc ~(working_context : Yojson.Safe.t option)
         ~working_context items
 
 let global_accumulator = create_accumulator ()
+
+(* Tier K4c — per-keeper registry. Each keeper gets its own
+   accumulator so concurrent multi-keeper tool emissions cannot
+   bleed across attribution boundaries. The registry itself is
+   guarded by [registry_mutex] for the get-or-create path; each
+   accumulator value carries its own mutex for push/drain (see
+   [push] / [drain]). *)
+let registry : (string, accumulator) Hashtbl.t = Hashtbl.create 16
+let registry_mutex : Stdlib.Mutex.t = Stdlib.Mutex.create ()
+
+let accumulator_for_keeper (keeper_name : string) : accumulator =
+  Stdlib.Mutex.lock registry_mutex;
+  let acc =
+    match Hashtbl.find_opt registry keeper_name with
+    | Some a -> a
+    | None ->
+        let a = create_accumulator () in
+        Hashtbl.add registry keeper_name a;
+        a
+  in
+  Stdlib.Mutex.unlock registry_mutex;
+  acc
+
+let registered_keeper_names () : string list =
+  Stdlib.Mutex.lock registry_mutex;
+  let names = Hashtbl.fold (fun k _ acc -> k :: acc) registry [] in
+  Stdlib.Mutex.unlock registry_mutex;
+  List.sort String.compare names
+
+let drop_keeper_accumulator (keeper_name : string) : unit =
+  Stdlib.Mutex.lock registry_mutex;
+  Hashtbl.remove registry keeper_name;
+  Stdlib.Mutex.unlock registry_mutex

--- a/lib/keeper/keeper_tool_emission_hook.mli
+++ b/lib/keeper/keeper_tool_emission_hook.mli
@@ -91,12 +91,37 @@ val drain_into_working_context :
     tests and metrics. *)
 val accumulator_size : accumulator -> int
 
-(** Process-wide singleton accumulator used by K4b runtime wire-up
-    (see [Keeper_run_tools] hook installation +
-    [Keeper_post_turn.apply_tool_emission_wirein]). All keepers share
-    this accumulator; cross-keeper attribution is acceptable because
-    [Multimodal.Workspace_holder] is itself process-wide.
+(** Process-wide singleton accumulator. Retained for backwards
+    compatibility with callers that pre-date Tier K4c per-keeper
+    isolation. Production wire-up (K4b) now uses
+    [accumulator_for_keeper] instead so concurrent multi-keeper tool
+    emissions do not bleed across attribution boundaries.
 
     Tests and other call sites that need an isolated accumulator
     should use [create_accumulator] instead. *)
 val global_accumulator : accumulator
+
+(** Tier K4c — per-keeper accumulator registry.
+
+    Look up (or lazily create) the accumulator owned by [keeper_name].
+    Both the producer side ([Keeper_run_tools.install_into_hooks]
+    pre-Agent.run) and the consumer side
+    ([Keeper_post_turn.apply_tool_emission_wirein] post-Agent.run) MUST
+    pass the same [keeper_name] so the in-flight items captured during
+    a turn drain back into the same working_context.
+
+    The keeper name is the canonical identifier (
+    [Keeper_metadata.t.name] / [lifecycle.updated_meta.name]) — stable
+    across turns. Trace ids rotate per turn and are NOT suitable here.
+
+    Thread-safe; safe for concurrent calls from multiple keeper fibers. *)
+val accumulator_for_keeper : string -> accumulator
+
+(** Snapshot of keeper names with a registered accumulator, in
+    ascending order. Useful for metrics/diagnostics. *)
+val registered_keeper_names : unit -> string list
+
+(** Remove a keeper's accumulator entry from the registry. Intended
+    for keeper teardown paths (process shutdown, keeper down/repair).
+    Safe to call on a name that was never registered (no-op). *)
+val drop_keeper_accumulator : string -> unit

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -242,6 +242,70 @@ let test_install_no_existing_hook () =
         (H.accumulator_size acc));
   print_endline "  install_no_existing_hook: OK"
 
+(* ── Tier K4c — per-keeper accumulator registry ────────────────── *)
+
+let test_registry_get_or_create_idempotent () =
+  let unique = Printf.sprintf "k4c-test-idem-%d" (Unix.getpid ()) in
+  H.drop_keeper_accumulator unique;
+  let a1 = H.accumulator_for_keeper unique in
+  let a2 = H.accumulator_for_keeper unique in
+  (* Physical equality: get-or-create returns the same instance. *)
+  assert (a1 == a2);
+  H.drop_keeper_accumulator unique;
+  print_endline "  registry_get_or_create_idempotent: OK"
+
+let test_registry_isolates_two_keepers () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let alpha = Printf.sprintf "k4c-test-alpha-%d" (Unix.getpid ()) in
+      let beta = Printf.sprintf "k4c-test-beta-%d" (Unix.getpid ()) in
+      H.drop_keeper_accumulator alpha;
+      H.drop_keeper_accumulator beta;
+      let acc_a = H.accumulator_for_keeper alpha in
+      let acc_b = H.accumulator_for_keeper beta in
+      assert (not (acc_a == acc_b));
+      let hook_a = H.make_post_tool_use_hook acc_a in
+      let _ : THooks.hook_decision =
+        hook_a
+          (make_post_tool_use
+             ~content:
+               {|{"__multimodal_kind":"code","__multimodal_id":"01900000-0000-7000-8000-0000000000a1"}|})
+      in
+      assert_eq_int ~label:"alpha_capture" 1 (H.accumulator_size acc_a);
+      assert_eq_int ~label:"beta_isolated" 0 (H.accumulator_size acc_b);
+      H.drop_keeper_accumulator alpha;
+      H.drop_keeper_accumulator beta);
+  print_endline "  registry_isolates_two_keepers: OK"
+
+let test_registry_registered_names_sorted () =
+  let pid = Unix.getpid () in
+  let names =
+    [ Printf.sprintf "k4c-test-zeta-%d" pid
+    ; Printf.sprintf "k4c-test-alpha-%d" pid
+    ; Printf.sprintf "k4c-test-mu-%d" pid
+    ]
+  in
+  List.iter H.drop_keeper_accumulator names;
+  List.iter (fun n -> ignore (H.accumulator_for_keeper n)) names;
+  let listed = H.registered_keeper_names () in
+  let listed_subset =
+    List.for_all (fun n -> List.mem n listed) names
+  in
+  assert listed_subset;
+  let rec is_sorted = function
+    | [] | [ _ ] -> true
+    | a :: b :: rest -> String.compare a b <= 0 && is_sorted (b :: rest)
+  in
+  assert (is_sorted listed);
+  List.iter H.drop_keeper_accumulator names;
+  print_endline "  registry_registered_names_sorted: OK"
+
+let test_registry_drop_keeper_unknown_name_ok () =
+  let unique = Printf.sprintf "k4c-test-never-%d" (Unix.getpid ()) in
+  (* Drop on a never-registered name must not raise. *)
+  H.drop_keeper_accumulator unique;
+  H.drop_keeper_accumulator unique;
+  print_endline "  registry_drop_keeper_unknown_name_ok: OK"
+
 let () =
   print_endline "=== Keeper_tool_emission_hook ===";
   test_disabled_no_op ();
@@ -253,4 +317,8 @@ let () =
   test_drain_skips_untagged ();
   test_install_chain_preserves_decision ();
   test_install_no_existing_hook ();
-  print_endline "=== Keeper_tool_emission_hook: 9/9 OK ==="
+  test_registry_get_or_create_idempotent ();
+  test_registry_isolates_two_keepers ();
+  test_registry_registered_names_sorted ();
+  test_registry_drop_keeper_unknown_name_ok ();
+  print_endline "=== Keeper_tool_emission_hook: 13/13 OK ==="


### PR DESCRIPTION
## Summary

Replaces the process-wide singleton accumulator used by K4b runtime wire-up with a **per-keeper registry** keyed by stable `keeper_name`. Producer (`Keeper_run_tools`) and consumer (`Keeper_post_turn.apply_tool_emission_wirein`) both look up the same keeper name so concurrent multi-keeper tool emissions cannot bleed across attribution boundaries.

## Why now

`global_accumulator` was acceptable when only one keeper ran at a time. Cycle 27 production loop now allows multiple keepers to run concurrently — under that regime, keeper A's tool result could drain into keeper B's `working_context["multimodal_artifacts"]` because both shared one accumulator. K4c closes that gap before the loop sees real multi-keeper traffic.

## Design

| Decision | Rationale |
|----------|-----------|
| **Key = `keeper_name`** | Stable across turns. `trace_id` rotates per turn → would lose accumulator state mid-flight |
| **Get-or-create lazy registry** | First call from either side allocates; second call (drain) returns the same instance |
| **Two mutex layers** | `registry_mutex` guards the Hashtbl; each accumulator's own mutex guards push/drain |
| **`global_accumulator` retained in mli** | Backwards compat with any pre-K4c callers; production wire-up no longer uses it |
| **`drop_keeper_accumulator` idempotent on unknown names** | Safe for keeper teardown paths (process shutdown, repair) |

## Surface delta

```
+ val accumulator_for_keeper : string -> accumulator
+ val registered_keeper_names : unit -> string list
+ val drop_keeper_accumulator : string -> unit
  val global_accumulator : accumulator   (* doc updated, kept for compat *)
```

## Test plan (4 new, 13 total GREEN)

- [x] `registry_get_or_create_idempotent` — physical equality across two calls
- [x] `registry_isolates_two_keepers` — alpha hook fires, alpha=1 / beta=0
- [x] `registry_registered_names_sorted` — subset + sort invariant
- [x] `registry_drop_keeper_unknown_name_ok` — no exception
- [x] all 9 pre-K4c tests still GREEN
- [x] `dune build --root .` GREEN

## Out of scope

- **Registry GC** — accumulators survive for the process lifetime. Per-keeper teardown could call `drop_keeper_accumulator` but the call sites for keeper down/repair are not wired in this PR.
- **Per-trace_id sub-bucketing** — if turn-level isolation is ever needed (e.g., overlapping turns from one keeper), that's a follow-up. Today, post-turn drain runs synchronously between turns within a single keeper.