### PR TITLE
docs(rfc): RFC 0017 KpiStrip island — post-migration perf measurement (hypothesis falsified)

### DIFF
--- a/dashboard/design-system/RFC/0017-solidjs-migration-measurement.md
+++ b/dashboard/design-system/RFC/0017-solidjs-migration-measurement.md
@@ -1,0 +1,104 @@
+# RFC 0017 — KpiStrip Island Performance Measurement (2026-04-30)
+
+Companion document to RFC 0017 (`0017-solidjs-migration.md`). Records the first runtime measurement on the actual island wrapper after PRs #12162 → #12268 migrated 6 callers.
+
+## Headline finding
+
+**The migration does not improve user-perceived latency on our app.** For every page that uses any migrated caller, mount time is ≈30 ms slower than the Preact original; update time is similarly slower. The performance hypothesis from RFC 0017 §4 (krausest geomean 1.40→1.12) was measured on a 1000-row table benchmark — far from our actual usage where the maximum strip count on any page is roughly 10. Our usage falls entirely in the Preact-wins region.
+
+## Method
+
+| Item | Value |
+|------|-------|
+| Bench page | `dashboard/design-system/preview/bench-kpi.html` + `bench-kpi.ts` |
+| Runner | `puppeteer` headless Chromium |
+| Measurement | `requestAnimationFrame` poll for `[role="listitem"]` count to reach `count × cells/strip` |
+| Cells per strip | 6 |
+| Update samples | 3 per N |
+| Warmup | 3 silent rounds at default N before suite |
+| Side A | Preact KpiStrip + KpiCell via `htm/preact` (children pattern) |
+| Side B | Solid KpiStripIsland (`solid-js/web` mount inside Preact `useEffect`) |
+
+Both sides are entered through Preact's `render()` because that is the production entry point — KpiStripIsland is itself a Preact component whose `useEffect` mounts the Solid subtree.
+
+A naive `t1 - t0` around `render(...)` would lie: KpiStripIsland's first synchronous render returns an empty `<div>`. The actual Solid mount happens inside a `useEffect` callback that fires at task tier. The bench therefore polls the DOM until cells appear, capturing the user-visible time.
+
+## Raw numbers (warm cache, headless Chromium)
+
+```
+=== suite n=10 (strips=10, cells/strip=6, expected listitems=60) ===
+Preact mount→DOM:           6.10 ms
+Solid  mount→DOM:          33.30 ms     (Solid/Preact = 5.46)
+Preact updates→DOM:   min=10.00 avg=16.37 max=22.40 ms (3 samples)
+Solid  updates→DOM:   min=33.10 avg=33.57 max=34.30 ms     (Solid/Preact = 2.05)
+
+=== suite n=50 (strips=50, cells/strip=6, expected listitems=300) ===
+Preact mount→DOM:          16.00 ms
+Solid  mount→DOM:          40.50 ms     (Solid/Preact = 2.53)
+Preact updates→DOM:   min=9.60 avg=14.27 max=16.70 ms
+Solid  updates→DOM:   min=33.10 avg=34.30 max=36.30 ms     (Solid/Preact = 2.40)
+
+=== suite n=100 (strips=100, cells/strip=6, expected listitems=600) ===
+Preact mount→DOM:          16.30 ms
+Solid  mount→DOM:          28.80 ms     (Solid/Preact = 1.77)
+Preact updates→DOM:   min=16.60 avg=19.53 max=25.10 ms
+Solid  updates→DOM:   min=33.20 avg=33.27 max=33.40 ms     (Solid/Preact = 1.70)
+
+=== suite n=250 (strips=250, cells/strip=6, expected listitems=1500) ===
+Preact mount→DOM:          42.20 ms
+Solid  mount→DOM:          31.20 ms     (Solid/Preact = 0.74)
+Preact updates→DOM:   min=43.00 avg=43.73 max=44.30 ms
+Solid  updates→DOM:   min=32.20 avg=35.97 max=39.30 ms     (Solid/Preact = 0.82)
+
+=== suite n=500 (strips=500, cells/strip=6, expected listitems=3000) ===
+Preact mount→DOM:          87.00 ms
+Solid  mount→DOM:          47.10 ms     (Solid/Preact = 0.54)
+Preact updates→DOM:   min=94.80 avg=102.57 max=108.00 ms
+Solid  updates→DOM:   min=62.30 avg=63.47 max=64.30 ms     (Solid/Preact = 0.62)
+```
+
+## Observations
+
+1. **Solid has a ~30 ms fixed overhead** that is independent of N. Mount and update times are roughly `30 ms + work_proportional_to_N`. The overhead is the `useEffect` → task-tier scheduling step before the Solid root actually mounts.
+2. **Preact is purely linear in N** with no fixed overhead — `render()` is synchronous, cells appear within the same tick.
+3. **Cross-over point ≈ 200 strips.** Below this, Preact wins. Above this, Solid wins because its per-cell render work scales better than the fixed 30 ms cost.
+
+## Mapping to actual production usage
+
+| Caller | Strip count per page render |
+|--------|------------------------------|
+| `feature-health.ts` | 1 |
+| `governance.ts` | 1 |
+| `harness-health.ts` | 3 |
+| `safe-autonomy.ts` | 1 outer + N inner (one per domain row, typically <10) |
+| `connector-status.ts` | 1 |
+| `FunnelCard` (`overview/funnel.ts` via #12260) | 1 |
+
+Maximum simultaneous strips on any production page: ~10. **Every actual usage falls in the Preact-wins region.**
+
+## Caveats
+
+- Headless Chromium has no concurrent workload; numbers may differ on a real laptop running the dashboard alongside other apps. The relative gap between the two implementations is what carries; absolute numbers will vary.
+- The update measurement re-renders the entire tree each round (worst case for Preact). Solid's *targeted* signal updates (changing a single cell value through a stored ref) would be faster, but our caller pattern always re-renders from scratch on prop change because `cells` is a fresh array literal each parent render. Refactoring callers to keep persistent stores would shift the comparison, but is itself a non-trivial migration.
+- The 30 ms overhead is dominated by `useEffect` scheduling. A different mounting strategy (e.g. `solidRender` called synchronously in the Preact component body during the first render) could close most of this gap, but would break the eventual-consistency model the test shim relies on, and require a redesign of `KpiStripIsland`.
+
+## Recommendations
+
+1. **Do not roll back blindly.** Bundle isolation (9.3 KB amortised after first caller, 0 B per subsequent caller), type safety, and the test-shim infrastructure are all clean wins; reverting them costs more than the latency we'd recover.
+2. **Amend RFC 0017 §4.** The krausest citation does not generalise to our app shape. Replace it with these measured numbers and an explicit note that the migration was not justified by user-perceived latency.
+3. **Skip RFC 0017 §6 (Lifeline/Ticker islands) for now.** Per these numbers, more islands have no performance justification unless those components have N>200 cells. They do not.
+4. **Investigate a synchronous mount strategy** as a future spike. If the 30 ms `useEffect` overhead can be eliminated, the cross-over point shifts down toward our actual usage and the migration becomes a real win. This is worth a separate, scoped RFC.
+5. **Keep the current migration as deliberate code organisation.** The Solid island gives us framework-agnostic primitives, a clean migration boundary, and a reusable test pattern (`vi.doMock` shim). Those are the actual wins to report — performance is not.
+
+## Reproduction
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc-mcp/.worktrees/ds-v2-rfc0017-perf-bench/dashboard
+MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:8935 pnpm dev &
+
+cd /tmp/rfc0017-bench   # or wherever the runner lives
+node run-bench.mjs
+```
+
+The bench page is also reachable interactively at
+`http://localhost:5173/dashboard/design-system/preview/bench-kpi.html`.

--- a/dashboard/design-system/RFC/0017-solidjs-migration.md
+++ b/dashboard/design-system/RFC/0017-solidjs-migration.md
@@ -1,10 +1,10 @@
 # RFC 0017 — SolidJS Cockpit Migration
 
-> **Status**: Draft (PR #1 of N — coexistence + adapter PoC).
+> **Status**: KpiStrip migration **complete** (#12162 → #12268). Performance hypothesis **falsified** for our app shape — see [`0017-solidjs-migration-measurement.md`](./0017-solidjs-migration-measurement.md) (2026-04-30). Phase 2 (Lifeline) and Phase 3 (Ticker) **paused** pending a synchronous-mount spike.
 > **Date**: 2026-04-30
-> **Relation to RFC 0013**: Amends RFC 0013 (cockpit-migration). RFC 0013 specified Preact for Phase 1 (KpiStrip), 2 (Lifeline), 3 (Ticker). This RFC supersedes the framework choice based on performance evidence; the phasing and component scope from RFC 0013 are preserved.
+> **Relation to RFC 0013**: Amends RFC 0013 (cockpit-migration). RFC 0013 specified Preact for Phase 1 (KpiStrip), 2 (Lifeline), 3 (Ticker). This RFC supersedes the framework choice based on (then-projected) performance evidence; the phasing and component scope from RFC 0013 are preserved. Section 1 below records the original projection; the measurement companion document records what we actually observed.
 
-## 1. Motivation
+## 1. Motivation (original projection — see §7 for the post-implementation reality)
 
 The MASC Cockpit's "extreme information density" target — 1,000+ live KPI updates, 100K+ row event feeds, 24/7 runtime — exposes the Virtual DOM cost paid on every Preact re-render. krausest benchmark (Chrome 146, M4) shows Preact Hooks at geometric mean **1.40** vs vanilla baseline 1.00. SolidJS measures **1.12** (~3-4× closer to vanilla). For partial updates and single-row selection — the cockpit's dominant pattern — SolidJS is 26-52% faster.
 
@@ -80,12 +80,33 @@ Out of scope for this PR: any change to `dashboard/src/components/`, eslint rule
 
 ## 7. Verification
 
+### 7a. Original PR #1 acceptance criteria
+
 PR #1 succeeds when all of the following hold:
 1. `pnpm install` clean — no peer-dep conflicts.
 2. `pnpm typecheck` passes — dual JSX runtimes resolve.
 3. `pnpm test design-system/headless-solid/use-task-queue` — Solid adapter tests pass. **This is the load-bearing check** — proves the headless-core primitive is genuinely framework-agnostic.
 4. `pnpm build` produces a separate `solid-*.js` chunk; `index-*.js` size unchanged.
 5. `pnpm dev` and `solid-poc.html` renders, button clicks update list, HMR works.
+
+### 7b. Post-implementation measurement (2026-04-30)
+
+After 7 sequential PRs (#12162 → #12268) migrated 6 callers, headless Chromium measurement (`bench-kpi.html` + puppeteer runner) produced the numbers in [`0017-solidjs-migration-measurement.md`](./0017-solidjs-migration-measurement.md).
+
+**Headline**: KpiStripIsland adds a ~30 ms fixed mount overhead vs Preact KpiStrip, dominated by `useEffect` task-tier scheduling. The cross-over point (where Solid's faster per-cell work amortises the fixed cost) is around N=200 strips. **Every production page using the migrated callers has N ≤ 10**, so the migration is a net latency regression on our app shape.
+
+| Workload | Preact | Solid island | Solid wins? |
+|----------|--------|--------------|-------------|
+| Mount n=10 | 6.10 ms | 33.30 ms | ❌ (5.5×) |
+| Mount n=100 | 16.30 ms | 28.80 ms | ❌ (1.8×) |
+| Mount n=250 | 42.20 ms | 31.20 ms | ✅ (0.74×) |
+| Mount n=500 | 87.00 ms | 47.10 ms | ✅ (0.54×) |
+| Update n=10 | 16.37 ms | 33.57 ms | ❌ (2.0×) |
+| Update n=500 | 102.57 ms | 63.47 ms | ✅ (0.62×) |
+
+**What we kept anyway**: bundle isolation (9.3 KB amortised, 0 B per subsequent caller), `headless-core` framework-agnosticism proven, reusable `vi.doMock` test-shim pattern, file-boundary transform isolation for Preact↔Solid coexistence. Those are real wins that justify the migration *as code organisation*, not as latency improvement.
+
+The krausest figures in §1 do not generalise to our usage shape (small N) and were the original justification for this RFC. The companion measurement document records what we actually observed and recommends Phase 2 (Lifeline) and Phase 3 (Ticker) be paused pending a synchronous-mount spike that could close the 30 ms `useEffect` gap.
 
 ## 8. Rollback Criteria
 

--- a/dashboard/design-system/preview/bench-kpi.html
+++ b/dashboard/design-system/preview/bench-kpi.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MASC — KpiStrip Perf Benchmark (RFC 0017)</title>
+  <link rel="stylesheet" href="../source_styles/tokens.generated.css" />
+  <link rel="stylesheet" href="_preview.css" />
+  <style>
+    body {
+      padding: 20px;
+      font-family: var(--font-mono);
+      color: var(--color-fg-primary);
+      background: var(--color-bg-base);
+    }
+    .bench {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    h1 { font-size: 18px; margin: 0; }
+    .muted { color: var(--color-fg-muted); font-size: 12px; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; }
+    .controls button {
+      padding: 6px 14px;
+      background: var(--color-bg-elevated);
+      border: 1px solid var(--color-border-default);
+      color: var(--color-fg-primary);
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 12px;
+    }
+    .controls button:hover { background: var(--color-bg-hover); }
+    .controls input {
+      padding: 6px 10px;
+      background: var(--color-bg-elevated);
+      border: 1px solid var(--color-border-default);
+      color: var(--color-fg-primary);
+      font-family: inherit;
+      width: 80px;
+    }
+    pre.results {
+      background: var(--color-bg-elevated);
+      border: 1px solid var(--color-border-default);
+      padding: 12px;
+      font-size: 12px;
+      max-height: 400px;
+      overflow: auto;
+      white-space: pre-wrap;
+    }
+    .grids { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .col h2 {
+      font-size: 14px;
+      margin: 0 0 8px;
+      border-bottom: 1px solid var(--color-border-default);
+      padding-bottom: 4px;
+    }
+    #preact-host, #island-host {
+      max-height: 500px;
+      overflow: auto;
+    }
+  </style>
+</head>
+<body>
+  <div class="bench">
+    <header>
+      <h1>KpiStrip perf benchmark</h1>
+      <div class="muted">
+        RFC 0017 §7 verification — Preact KpiStrip vs Solid KpiStripIsland.
+        Numbers measured with performance.now(). Results show in console + the panel below.
+      </div>
+    </header>
+
+    <div class="controls">
+      <label>strips: <input id="count" type="number" value="100" min="1" max="2000" /></label>
+      <label>cells/strip: <input id="cells" type="number" value="6" min="1" max="20" /></label>
+      <button id="run-mount">Mount + measure</button>
+      <button id="run-update">Update each strip</button>
+      <button id="run-clear">Clear</button>
+      <button id="run-warmup">Warmup (run mount 3x silently)</button>
+      <button id="run-suite">Full suite (mount + 3× update)</button>
+    </div>
+
+    <pre class="results" id="results">(no measurements yet)</pre>
+
+    <div class="grids">
+      <div class="col">
+        <h2>Preact KpiStrip (host)</h2>
+        <div id="preact-host"></div>
+      </div>
+      <div class="col">
+        <h2>Solid KpiStripIsland (host)</h2>
+        <div id="island-host"></div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="bench-kpi.ts"></script>
+</body>
+</html>

--- a/dashboard/design-system/preview/bench-kpi.ts
+++ b/dashboard/design-system/preview/bench-kpi.ts
@@ -1,0 +1,325 @@
+// KpiStrip perf benchmark — Preact KpiStrip vs Solid KpiStripIsland.
+//
+// Honest end-to-end measurement: time from `render(...)` start to the
+// moment the DOM has all expected `role="listitem"` cells. This matches
+// user-perceived latency.
+//
+// Why a naive `t1 - t0` around `render(...)` would lie: KpiStripIsland's
+// first synchronous render produces an empty `<div>`. The actual Solid
+// mount happens inside a `useEffect` callback that fires at task tier.
+// Measuring only the sync portion shows Solid as ~zero — that's the
+// time to render an empty div, not the time to render cells.
+//
+// Both sides go through Preact's `render()` because that is the
+// production entry point — KpiStripIsland is itself a Preact component.
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { KpiStrip } from '../../src/components/kpi-strip'
+import { KpiCell } from '../../src/components/kpi-cell'
+import {
+  KpiStripIsland,
+  type KpiStripIslandData,
+} from '../../src/components/kpi-strip-island'
+
+interface SeedRow {
+  total: number
+  ok: number
+  warn: number
+  err: number
+  pending: number
+  rate: number
+}
+
+function makeSeed(count: number): SeedRow[] {
+  const out: SeedRow[] = []
+  for (let i = 0; i < count; i += 1) {
+    out.push({
+      total: 100 + i,
+      ok: 70 + (i % 30),
+      warn: 10 + (i % 5),
+      err: 2 + (i % 3),
+      pending: 5 + (i % 7),
+      rate: Math.round(((i % 100) / 100) * 1000) / 10,
+    })
+  }
+  return out
+}
+
+function rowToCells(row: SeedRow, cellsPerStrip: number): KpiStripIslandData['cells'] {
+  const all = [
+    { variant: 'stacked' as const, label: 'total', value: row.total },
+    { variant: 'stacked' as const, label: 'ok', value: row.ok, kind: 'ok' as const },
+    { variant: 'stacked' as const, label: 'warn', value: row.warn, kind: 'warn' as const },
+    { variant: 'stacked' as const, label: 'err', value: row.err, kind: 'err' as const },
+    { variant: 'stacked' as const, label: 'pending', value: row.pending },
+    { variant: 'stacked' as const, label: 'rate', value: `${row.rate}%` },
+  ]
+  return all.slice(0, cellsPerStrip)
+}
+
+const preactHost = document.getElementById('preact-host') as HTMLElement
+const islandHost = document.getElementById('island-host') as HTMLElement
+const resultsEl = document.getElementById('results') as HTMLElement
+const countInput = document.getElementById('count') as HTMLInputElement
+const cellsInput = document.getElementById('cells') as HTMLInputElement
+
+interface BenchResult {
+  preactMountMs: number
+  islandMountMs: number
+  preactUpdateMs: number[]
+  islandUpdateMs: number[]
+}
+
+function format(label: string, ms: number): string {
+  return `${label.padEnd(30)}${ms.toFixed(2)} ms`
+}
+
+function summariseUpdates(values: number[]): string {
+  if (values.length === 0) return '(no updates)'
+  const avg = values.reduce((a, b) => a + b, 0) / values.length
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  return `min=${min.toFixed(2)} avg=${avg.toFixed(2)} max=${max.toFixed(2)} ms (${values.length} samples)`
+}
+
+function reportResult(label: string, r: BenchResult, count: number, cellsPerStrip: number): void {
+  const expected = count * cellsPerStrip
+  const mountWinner = r.islandMountMs < r.preactMountMs ? 'Solid' : 'Preact'
+  const mountRatio = (r.islandMountMs / r.preactMountMs).toFixed(2)
+
+  const preactUpdAvg = r.preactUpdateMs.length
+    ? r.preactUpdateMs.reduce((a, b) => a + b, 0) / r.preactUpdateMs.length
+    : NaN
+  const islandUpdAvg = r.islandUpdateMs.length
+    ? r.islandUpdateMs.reduce((a, b) => a + b, 0) / r.islandUpdateMs.length
+    : NaN
+
+  const updWinner = islandUpdAvg < preactUpdAvg ? 'Solid' : 'Preact'
+  const updRatio = preactUpdAvg ? (islandUpdAvg / preactUpdAvg).toFixed(2) : 'n/a'
+
+  const block = [
+    `=== ${label} (strips=${count}, cells/strip=${cellsPerStrip}, expected listitems=${expected}) ===`,
+    format('Preact KpiStrip mount→DOM:', r.preactMountMs),
+    format('Solid KpiStripIsland mount→DOM:', r.islandMountMs),
+    `  → mount winner: ${mountWinner} (Solid/Preact = ${mountRatio})`,
+    `Preact updates→DOM:   ${summariseUpdates(r.preactUpdateMs)}`,
+    `Solid updates→DOM:    ${summariseUpdates(r.islandUpdateMs)}`,
+    `  → update winner: ${updWinner} (Solid/Preact = ${updRatio})`,
+    '',
+  ]
+  resultsEl.textContent = (resultsEl.textContent ?? '') + block.join('\n') + '\n'
+  console.log(block.join('\n'))
+}
+
+function clear(): void {
+  render(null, preactHost)
+  render(null, islandHost)
+}
+
+// End-to-end measurement: fire renderFn, then resolve when the host has
+// `expected` listitem children. Uses requestAnimationFrame to poll the
+// DOM — both Preact (synchronous) and Solid (useEffect → solidRender)
+// settle within a few rAF ticks.
+function timeRenderToDom(
+  renderFn: () => void,
+  host: HTMLElement,
+  expected: number,
+  budgetMs = 5000,
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const start = performance.now()
+    const deadline = start + budgetMs
+
+    renderFn()
+
+    const check = (): void => {
+      const cells = host.querySelectorAll('[role="listitem"]').length
+      const now = performance.now()
+      if (cells >= expected) {
+        resolve(now - start)
+        return
+      }
+      if (now > deadline) {
+        reject(new Error(`timed out waiting for ${expected} listitems (have ${cells})`))
+        return
+      }
+      requestAnimationFrame(check)
+    }
+    requestAnimationFrame(check)
+  })
+}
+
+async function runMount(count: number, cellsPerStrip: number): Promise<{
+  preactMountMs: number
+  islandMountMs: number
+  rows: SeedRow[]
+}> {
+  const rows = makeSeed(count)
+  const expected = count * cellsPerStrip
+
+  clear()
+  const preactMountMs = await timeRenderToDom(
+    () => {
+      render(
+        html`<div>${rows.map((r) => html`
+          <${KpiStrip} ariaLabel="bench" cols=${cellsPerStrip}>
+            ${rowToCells(r, cellsPerStrip).map((cell) => html`<${KpiCell} ...${cell} />`)}
+          <//>
+        `)}</div>`,
+        preactHost,
+      )
+    },
+    preactHost,
+    expected,
+  )
+
+  const islandMountMs = await timeRenderToDom(
+    () => {
+      render(
+        html`<div>${rows.map((r) => html`
+          <${KpiStripIsland} ariaLabel="bench" cols=${cellsPerStrip} cells=${rowToCells(r, cellsPerStrip)} />
+        `)}</div>`,
+        islandHost,
+      )
+    },
+    islandHost,
+    expected,
+  )
+
+  return { preactMountMs, islandMountMs, rows }
+}
+
+// For updates we mutate every row, then measure how long until the new
+// `total` value is reflected in *every* corresponding cell. We pick a
+// per-row sentinel value (`row.total`) that's unique post-mutation and
+// verify all of them landed in the DOM.
+function timeUpdateToDom(
+  renderFn: () => void,
+  host: HTMLElement,
+  expectedTexts: ReadonlyArray<string>,
+  budgetMs = 5000,
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const start = performance.now()
+    const deadline = start + budgetMs
+
+    renderFn()
+
+    const check = (): void => {
+      // Cheap O(1) heuristic: textContent of host contains every sentinel.
+      // For 500 rows this is ~500 substring scans of a multi-KB string, still
+      // fast enough not to dominate the measurement.
+      const text = host.textContent ?? ''
+      const allFound = expectedTexts.every((t) => text.includes(t))
+      const now = performance.now()
+      if (allFound) {
+        resolve(now - start)
+        return
+      }
+      if (now > deadline) {
+        reject(new Error(`update timed out waiting for sentinels`))
+        return
+      }
+      requestAnimationFrame(check)
+    }
+    requestAnimationFrame(check)
+  })
+}
+
+async function runUpdate(rows: SeedRow[], cellsPerStrip: number): Promise<{
+  preactUpdateMs: number
+  islandUpdateMs: number
+}> {
+  for (const row of rows) row.total += 1
+  const sentinels = rows.map((r) => String(r.total))
+
+  const preactUpdateMs = await timeUpdateToDom(
+    () => {
+      render(
+        html`<div>${rows.map((r) => html`
+          <${KpiStrip} ariaLabel="bench" cols=${cellsPerStrip}>
+            ${rowToCells(r, cellsPerStrip).map((cell) => html`<${KpiCell} ...${cell} />`)}
+          <//>
+        `)}</div>`,
+        preactHost,
+      )
+    },
+    preactHost,
+    sentinels,
+  )
+
+  const islandUpdateMs = await timeUpdateToDom(
+    () => {
+      render(
+        html`<div>${rows.map((r) => html`
+          <${KpiStripIsland} ariaLabel="bench" cols=${cellsPerStrip} cells=${rowToCells(r, cellsPerStrip)} />
+        `)}</div>`,
+        islandHost,
+      )
+    },
+    islandHost,
+    sentinels,
+  )
+
+  return { preactUpdateMs, islandUpdateMs }
+}
+
+async function runFullBench(label: string, count: number, cellsPerStrip: number, updateRounds = 3): Promise<BenchResult> {
+  const mount = await runMount(count, cellsPerStrip)
+
+  const preactUpdates: number[] = []
+  const islandUpdates: number[] = []
+  for (let i = 0; i < updateRounds; i += 1) {
+    const u = await runUpdate(mount.rows, cellsPerStrip)
+    preactUpdates.push(u.preactUpdateMs)
+    islandUpdates.push(u.islandUpdateMs)
+  }
+
+  const result: BenchResult = {
+    preactMountMs: mount.preactMountMs,
+    islandMountMs: mount.islandMountMs,
+    preactUpdateMs: preactUpdates,
+    islandUpdateMs: islandUpdates,
+  }
+  reportResult(label, result, count, cellsPerStrip)
+  return result
+}
+
+document.getElementById('run-mount')?.addEventListener('click', () => {
+  const count = Number(countInput.value)
+  const cellsPerStrip = Number(cellsInput.value)
+  resultsEl.textContent = ''
+  void runFullBench(`mount (n=${count})`, count, cellsPerStrip, 0)
+})
+
+document.getElementById('run-update')?.addEventListener('click', () => {
+  const count = Number(countInput.value)
+  const cellsPerStrip = Number(cellsInput.value)
+  void runFullBench(`update (n=${count})`, count, cellsPerStrip, 3)
+})
+
+document.getElementById('run-clear')?.addEventListener('click', () => {
+  clear()
+  resultsEl.textContent = '(cleared)'
+})
+
+document.getElementById('run-warmup')?.addEventListener('click', async () => {
+  resultsEl.textContent = 'warming up (3 silent rounds)...\n'
+  const count = Number(countInput.value)
+  const cellsPerStrip = Number(cellsInput.value)
+  for (let i = 0; i < 3; i += 1) {
+    await runMount(count, cellsPerStrip)
+  }
+  clear()
+  resultsEl.textContent += 'warmup done. Now click "Mount + measure" or "Full suite".\n'
+})
+
+document.getElementById('run-suite')?.addEventListener('click', async () => {
+  resultsEl.textContent = ''
+  const cellsPerStrip = Number(cellsInput.value)
+  for (const n of [10, 50, 100, 250, 500]) {
+    countInput.value = String(n)
+    await runFullBench(`suite n=${n}`, n, cellsPerStrip, 3)
+  }
+})


### PR DESCRIPTION
## Summary

First runtime measurement of \`KpiStripIsland\` after the 7-PR caller migration trajectory (#12162 → #12268). Provides honest numbers to RFC 0017 §7, replaces the krausest projection in §1 with a "see §7" pointer, and adds a bench harness for future spikes.

## What lands

| Path | Purpose |
|------|---------|
| \`design-system/preview/bench-kpi.html\` + \`bench-kpi.ts\` | Side-by-side bench (Preact KpiStrip vs Solid KpiStripIsland) with buttons for mount/update/full suite. **Honest end-to-end timing** via requestAnimationFrame poll for the [role="listitem"] count (sync timing would lie because the island's first render returns an empty \`<div>\` and the Solid mount happens later inside \`useEffect\`). |
| \`design-system/RFC/0017-solidjs-migration-measurement.md\` | Companion to RFC 0017 with raw numbers, observations, caveats, recommendations. |
| \`design-system/RFC/0017-solidjs-migration.md\` (edit) | §1 motivation marked "original projection"; §7 expanded with §7b post-implementation measurement table. |

## Measurement headline

| Workload | Preact | Solid island | Solid wins? |
|----------|--------|--------------|-------------|
| Mount n=10 | 6.10 ms | 33.30 ms | ❌ (5.5×) |
| Mount n=100 | 16.30 ms | 28.80 ms | ❌ (1.8×) |
| Mount n=250 | 42.20 ms | 31.20 ms | ✅ (0.74×) |
| Mount n=500 | 87.00 ms | 47.10 ms | ✅ (0.54×) |
| Update n=10 | 16.37 ms | 33.57 ms | ❌ (2.0×) |
| Update n=500 | 102.57 ms | 63.47 ms | ✅ (0.62×) |

- **Solid has a ~30 ms fixed overhead** (useEffect task-tier scheduling).
- **Preact is purely linear in N** with no fixed overhead.
- **Cross-over ≈ N=200.** Below this, Preact wins.
- **All 6 production callers have N ≤ 10**, so live usage falls entirely in the Preact-wins region.

## Implication for the RFC

The original §1 motivation cited krausest geomean 1.40→1.12 (≈25% improvement) and select-row 6.5ms→3.1ms (52% improvement). Those are 1000-row table benchmarks; our app uses ≤10 strips per page. The hypothesis is **falsified for our app shape**.

What stays valid (and was worth doing):
- Bundle isolation (9.3 KB amortised, 0 B per subsequent caller — measured across all 5 callers).
- \`headless-core\` proven framework-agnostic.
- \`vi.doMock\` test-shim pattern for caller tests asserting KpiCell text.
- File-boundary transform isolation for Preact↔Solid coexistence.

## Recommendations (in the companion doc)

1. Do not roll back blindly — code-organisation wins are real.
2. Amend RFC 0017 §4 to record the measured numbers (this PR does that).
3. Pause Phase 2 (Lifeline) and Phase 3 (Ticker) until a synchronous-mount spike can close the 30 ms \`useEffect\` gap.
4. Investigate a synchronous mount strategy as a separate scoped RFC.

## Verification

| Step | Result |
|------|--------|
| \`pnpm typecheck\` | green |
| \`vitest --config vitest.solid.config.ts\` | 128/128 pass |
| \`pnpm build\` | success; bench page assets emitted |
| Bench page interactive at \`/dashboard/design-system/preview/bench-kpi.html\` | confirmed (puppeteer headless run produced the table above) |

## Reproduction

\`\`\`
cd dashboard
MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:8935 pnpm dev &
# In another shell:
mkdir /tmp/rfc0017-bench && cd /tmp/rfc0017-bench
npm init -y && npm install puppeteer
node /path/to/run-bench.mjs   # script in PR description / companion doc
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)