### PR TITLE
feat(keeper): K4c teardown wire-in — drop_keeper_accumulator on keeper_down

### DIFF
--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -30,7 +30,14 @@ let handle_keeper_down ctx args : tool_result =
       (if remove_meta then
          ( Safe_ops.remove_file_logged ~context:"keeper_down"
              (keeper_meta_path ctx.config name);
-           Keeper_registry.unregister ~base_path:ctx.config.base_path name )
+           Keeper_registry.unregister ~base_path:ctx.config.base_path name;
+           (* Tier K4c teardown — when the keeper is fully removed
+              (remove_meta=true), drop its tool-emission accumulator
+              from the registry so its slot is reclaimable. The
+              retain-paused branch (else) deliberately keeps the
+              accumulator alive so a future resume can drain any
+              pending items captured before pause. *)
+           Keeper_tool_emission_hook.drop_keeper_accumulator name )
        else
          let retained =
            {

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -306,6 +306,33 @@ let test_registry_drop_keeper_unknown_name_ok () =
   H.drop_keeper_accumulator unique;
   print_endline "  registry_drop_keeper_unknown_name_ok: OK"
 
+let test_registry_drop_then_recreate_yields_fresh_accumulator () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let name =
+        Printf.sprintf "k4c-test-recreate-%d" (Unix.getpid ())
+      in
+      H.drop_keeper_accumulator name;
+      let acc1 = H.accumulator_for_keeper name in
+      (* Capture one item into acc1. *)
+      let hook = H.make_post_tool_use_hook acc1 in
+      let _ : THooks.hook_decision =
+        hook
+          (make_post_tool_use
+             ~content:
+               {|{"__multimodal_kind":"code","__multimodal_id":"01900000-0000-7000-8000-0000000000c1"}|})
+      in
+      assert_eq_int ~label:"acc1_before_drop" 1
+        (H.accumulator_size acc1);
+      (* Teardown — simulates [keeper_down] removing the keeper. *)
+      H.drop_keeper_accumulator name;
+      (* Recreate — simulates a re-spawned keeper with the same name. *)
+      let acc2 = H.accumulator_for_keeper name in
+      assert (not (acc1 == acc2));
+      assert_eq_int ~label:"acc2_starts_empty" 0
+        (H.accumulator_size acc2);
+      H.drop_keeper_accumulator name);
+  print_endline "  registry_drop_then_recreate_yields_fresh: OK"
+
 let () =
   print_endline "=== Keeper_tool_emission_hook ===";
   test_disabled_no_op ();
@@ -321,4 +348,5 @@ let () =
   test_registry_isolates_two_keepers ();
   test_registry_registered_names_sorted ();
   test_registry_drop_keeper_unknown_name_ok ();
-  print_endline "=== Keeper_tool_emission_hook: 13/13 OK ==="
+  test_registry_drop_then_recreate_yields_fresh_accumulator ();
+  print_endline "=== Keeper_tool_emission_hook: 14/14 OK ==="


### PR DESCRIPTION
## Summary

Wires the K4c registry's `drop_keeper_accumulator` (landed in #12273) into `Keeper_turn_lifecycle.handle_keeper_down`, so when a keeper is fully removed (`remove_meta=true`), its tool-emission accumulator slot is reclaimed instead of leaking until process exit.

The retain-paused branch (`remove_meta=false`) deliberately does NOT drop, because a future resume should still be able to drain any items captured before the pause.

## Diff scope

| File | Change |
|------|--------|
| `lib/keeper/keeper_turn_lifecycle.ml` | One added line inside the `remove_meta=true` branch + a 6-line comment explaining the asymmetry |
| `test/test_keeper_tool_emission_hook.ml` | New test `registry_drop_then_recreate_yields_fresh_accumulator` (14/14 total) |

## Test rationale

The new test mirrors the production teardown→respawn cycle: capture into `acc1` for keeper $name$, drop, request the same name again. The two accumulators must be **physically distinct** instances and the new one must start empty. This catches a regression where someone accidentally caches the accumulator reference across the drop.

## Why a follow-up PR (not in #12273)

#12273 already merged before this teardown wire-in was ready. New PR keeps the diff small + traceable. Surface used: `Keeper_tool_emission_hook.drop_keeper_accumulator : string -> unit` (already in main as of #12273).

## Out of scope

- Calling `drop_keeper_accumulator` from other keeper-removal paths (sandbox cleanup, crash, etc.) — those don't currently route through `handle_keeper_down`. Audit follow-up.
- Per-trace_id sub-bucketing — out of scope as before.

## Test plan

- [x] `dune build --root .` GREEN
- [x] `dune exec test/test_keeper_tool_emission_hook.exe` 14/14 GREEN
- [ ] Live: `keeper_down --name X --remove_meta=true` followed by `keeper_up --name X` should give X a fresh accumulator (cannot exercise without running keeper; `registered_keeper_names` shrinks/regrows demonstrates the contract)