### PR TITLE
Add Track9 quota tier contract

### DIFF
--- a/docs/TRACK9-QUOTA-TIER-CONTRACT.md
+++ b/docs/TRACK9-QUOTA-TIER-CONTRACT.md
@@ -1,0 +1,31 @@
+# Track9 Quota Tier Contract
+
+MASC owns the product/operator quota contract for agent work. OAS stays
+provider-neutral and should not inherit product tier names.
+
+## Default Tier Budget
+
+The default operator budget is `1000 req/min`:
+
+| Tier | Label | Workload | Share | Default |
+| --- | --- | --- | --- | --- |
+| P0 | P0 Critical | Architecture and deploy work | 40% | 400 req/min |
+| P1 | P1 Standard | Feature and test work | 40% | 400 req/min |
+| P2 | P2 Background | Monitoring, cleanup, and docs | 20% | 200 req/min |
+
+The source contract is `Rate_limit.agent_quota_tier_contracts`.
+`Rate_limit.compute_agent_quota_allocations` computes deterministic
+integer allocations for other positive totals and preserves the exact
+sum by assigning rounding remainder in P0, P1, P2 order.
+
+## Control Labels
+
+Track9 control concepts are exposed as labels only:
+
+- `lease-expiry`
+- `backpressure`
+- `adaptive-rate`
+
+This slice does not introduce Redis, Valkey, cloud deployment, or pricing
+logic. Runtime infrastructure can consume these labels later without
+changing the typed tier contract.

--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -25,6 +25,185 @@ type t = {
   mutex: Eio.Mutex.t;
 }
 
+(** {1 Agent Quota Tier Contract} *)
+
+type agent_quota_tier = Rate_limit_types.agent_quota_tier =
+  | P0
+  | P1
+  | P2
+
+type agent_quota_control = Rate_limit_types.agent_quota_control =
+  | LeaseExpiry
+  | Backpressure
+  | AdaptiveRate
+
+type agent_quota_tier_contract =
+  Rate_limit_types.agent_quota_tier_contract = {
+  contract_tier: agent_quota_tier;
+  code: string;
+  label: string;
+  workload_label: string;
+  share_percent: int;
+  default_req_per_min: int;
+}
+
+type agent_quota_allocation = Rate_limit_types.agent_quota_allocation = {
+  allocation_tier: agent_quota_tier;
+  allocation_percent: int;
+  allocation_req_per_min: int;
+}
+
+let default_agent_quota_total_per_min = 1000
+
+let agent_quota_tiers = [P0; P1; P2]
+
+let agent_quota_tier_rank = function
+  | P0 -> 0
+  | P1 -> 1
+  | P2 -> 2
+
+let agent_quota_tier_code = function
+  | P0 -> "P0"
+  | P1 -> "P1"
+  | P2 -> "P2"
+
+let agent_quota_tier_label = function
+  | P0 -> "P0 Critical"
+  | P1 -> "P1 Standard"
+  | P2 -> "P2 Background"
+
+let agent_quota_tier_workload_label = function
+  | P0 -> "architecture-deploy"
+  | P1 -> "feature-test"
+  | P2 -> "monitoring-docs"
+
+let agent_quota_tier_share_percent = function
+  | P0 -> 40
+  | P1 -> 40
+  | P2 -> 20
+
+let agent_quota_control_label = function
+  | LeaseExpiry -> "lease-expiry"
+  | Backpressure -> "backpressure"
+  | AdaptiveRate -> "adaptive-rate"
+
+let agent_quota_control_labels =
+  List.map agent_quota_control_label [LeaseExpiry; Backpressure; AdaptiveRate]
+
+let agent_quota_tier_contract tier =
+  let share_percent = agent_quota_tier_share_percent tier in
+  {
+    contract_tier = tier;
+    code = agent_quota_tier_code tier;
+    label = agent_quota_tier_label tier;
+    workload_label = agent_quota_tier_workload_label tier;
+    share_percent;
+    default_req_per_min =
+      default_agent_quota_total_per_min * share_percent / 100;
+  }
+
+let agent_quota_tier_contracts =
+  List.map agent_quota_tier_contract agent_quota_tiers
+
+let agent_quota_tier_of_task_priority priority =
+  if priority <= 1 then P0
+  else if priority <= 3 then P1
+  else P2
+
+let validate_agent_quota_total ~total_req_per_min =
+  if total_req_per_min <= 0 then
+    Error
+      (Printf.sprintf
+         "agent quota total_req_per_min must be positive, got %d"
+         total_req_per_min)
+  else
+    Ok ()
+
+let sort_agent_quota_allocations allocations =
+  List.sort
+    (fun a b ->
+      compare
+        (agent_quota_tier_rank a.allocation_tier)
+        (agent_quota_tier_rank b.allocation_tier))
+    allocations
+
+let has_exact_agent_quota_tiers allocations =
+  match sort_agent_quota_allocations allocations with
+  | [
+      { allocation_tier = P0; _ };
+      { allocation_tier = P1; _ };
+      { allocation_tier = P2; _ };
+    ] -> true
+  | _ -> false
+
+let validate_agent_quota_allocations ~total_req_per_min allocations =
+  match validate_agent_quota_total ~total_req_per_min with
+  | Error _ as e -> e
+  | Ok () ->
+    if not (has_exact_agent_quota_tiers allocations) then
+      Error "agent quota allocations must include exactly P0, P1, and P2"
+    else
+      match
+        List.find_opt
+          (fun allocation -> allocation.allocation_req_per_min < 0)
+          allocations
+      with
+      | Some allocation ->
+        Error
+          (Printf.sprintf
+             "agent quota allocation for %s must be non-negative, got %d"
+             (agent_quota_tier_code allocation.allocation_tier)
+             allocation.allocation_req_per_min)
+      | None ->
+        let allocated =
+          List.fold_left
+            (fun total allocation -> total + allocation.allocation_req_per_min)
+            0 allocations
+        in
+        if allocated = total_req_per_min then
+          Ok ()
+        else
+          Error
+            (Printf.sprintf
+               "agent quota allocation sum mismatch: expected %d, got %d"
+               total_req_per_min allocated)
+
+let compute_agent_quota_allocations ~total_req_per_min =
+  match validate_agent_quota_total ~total_req_per_min with
+  | Error _ as e -> e
+  | Ok () ->
+    let allocations =
+      List.map
+        (fun tier ->
+          let allocation_percent = agent_quota_tier_share_percent tier in
+          {
+            allocation_tier = tier;
+            allocation_percent;
+            allocation_req_per_min =
+              total_req_per_min * allocation_percent / 100;
+          })
+        agent_quota_tiers
+    in
+    let allocated =
+      List.fold_left
+        (fun total allocation -> total + allocation.allocation_req_per_min)
+        0 allocations
+    in
+    let rec assign_remainder remaining = function
+      | [] -> []
+      | allocation :: rest when remaining > 0 ->
+        {
+          allocation with
+          allocation_req_per_min = allocation.allocation_req_per_min + 1;
+        }
+        :: assign_remainder (remaining - 1) rest
+      | rest -> rest
+    in
+    let allocations = assign_remainder (total_req_per_min - allocated) allocations in
+    match validate_agent_quota_allocations ~total_req_per_min allocations with
+    | Ok () -> Ok allocations
+    | Error _ as e -> e
+
 (** {1 Configuration} *)
 
 let default_rate = 60.0  (* 12+ concurrent keepers need higher throughput *)

--- a/lib/rate_limit.mli
+++ b/lib/rate_limit.mli
@@ -13,6 +13,36 @@
 (** Opaque rate limiter instance. *)
 type t
 
+(** Product-facing agent quota tier. *)
+type agent_quota_tier = Rate_limit_types.agent_quota_tier =
+  | P0
+  | P1
+  | P2
+
+(** Label-only quota-control term. *)
+type agent_quota_control = Rate_limit_types.agent_quota_control =
+  | LeaseExpiry
+  | Backpressure
+  | AdaptiveRate
+
+(** Static operator contract for one quota tier. *)
+type agent_quota_tier_contract =
+  Rate_limit_types.agent_quota_tier_contract = {
+  contract_tier : agent_quota_tier;
+  code : string;
+  label : string;
+  workload_label : string;
+  share_percent : int;
+  default_req_per_min : int;
+}
+
+(** Computed request budget for one quota tier. *)
+type agent_quota_allocation = Rate_limit_types.agent_quota_allocation = {
+  allocation_tier : agent_quota_tier;
+  allocation_percent : int;
+  allocation_req_per_min : int;
+}
+
 (** {1 Limiter Creation} *)
 
 val default_rate : float
@@ -23,6 +53,53 @@ val rate : t -> float
 val burst : t -> int
 val create : ?rate:float -> ?burst:int -> unit -> t
 val create_from_env : unit -> t
+
+(** {1 Agent Quota Tier Contract} *)
+
+val default_agent_quota_total_per_min : int
+(** Default Track9 operator budget: [1000] requests per minute. *)
+
+val agent_quota_tiers : agent_quota_tier list
+(** Stable tier order: P0, P1, P2. *)
+
+val agent_quota_tier_code : agent_quota_tier -> string
+(** ["P0"], ["P1"], or ["P2"]. *)
+
+val agent_quota_tier_label : agent_quota_tier -> string
+(** Operator-facing label, for example ["P0 Critical"]. *)
+
+val agent_quota_tier_workload_label : agent_quota_tier -> string
+(** Workload summary shown to operators. *)
+
+val agent_quota_tier_share_percent : agent_quota_tier -> int
+(** Target percentage of the total request budget. *)
+
+val agent_quota_control_label : agent_quota_control -> string
+(** Stable machine/display label for quota-control terms. *)
+
+val agent_quota_control_labels : string list
+(** Label-only controls: lease expiry, backpressure, adaptive rate. *)
+
+val agent_quota_tier_contract : agent_quota_tier -> agent_quota_tier_contract
+(** Static contract for [tier] using the default total request budget. *)
+
+val agent_quota_tier_contracts : agent_quota_tier_contract list
+(** Static contracts in {!agent_quota_tiers} order. *)
+
+val agent_quota_tier_of_task_priority : int -> agent_quota_tier
+(** Map current MASC task priority to quota tier:
+    [priority <= 1] -> P0, [2..3] -> P1, [>= 4] -> P2. *)
+
+val compute_agent_quota_allocations :
+  total_req_per_min:int -> (agent_quota_allocation list, string) result
+(** Compute P0/P1/P2 request budgets from [total_req_per_min].
+    Positive totals are preserved exactly; rounding remainder is assigned
+    deterministically in P0, P1, P2 order. *)
+
+val validate_agent_quota_allocations :
+  total_req_per_min:int -> agent_quota_allocation list -> (unit, string) result
+(** Validate positive total, exact P0/P1/P2 coverage, non-negative
+    allocation values, and sum preservation. *)
 
 (** {1 Rate Checking} *)
 

--- a/lib/types/rate_limit_types.ml
+++ b/lib/types/rate_limit_types.ml
@@ -25,3 +25,34 @@ type rate_limit_error = {
   wait_seconds: int;
   category: rate_limit_category;
 } [@@deriving show]
+
+(** Product-facing agent quota tiers. *)
+type agent_quota_tier =
+  | P0
+  | P1
+  | P2
+[@@deriving show { with_path = false }]
+
+(** Contract labels for quota-control concepts; no runtime infra here. *)
+type agent_quota_control =
+  | LeaseExpiry
+  | Backpressure
+  | AdaptiveRate
+[@@deriving show { with_path = false }]
+
+(** Static operator contract for one quota tier. *)
+type agent_quota_tier_contract = {
+  contract_tier: agent_quota_tier;
+  code: string;
+  label: string;
+  workload_label: string;
+  share_percent: int;
+  default_req_per_min: int;
+} [@@deriving show]
+
+(** Computed request budget for one quota tier. *)
+type agent_quota_allocation = {
+  allocation_tier: agent_quota_tier;
+  allocation_percent: int;
+  allocation_req_per_min: int;
+} [@@deriving show]

--- a/lib/types/rate_limit_types.mli
+++ b/lib/types/rate_limit_types.mli
@@ -33,3 +33,38 @@ type rate_limit_error = {
   category : rate_limit_category;
 }
 [@@deriving show]
+
+(** Product-facing agent quota tiers.  These are MASC-owned operator
+    terms, not OAS provider vocabulary. *)
+type agent_quota_tier =
+  | P0
+  | P1
+  | P2
+[@@deriving show { with_path = false }]
+
+(** Small labels for future quota controls.  This module only names the
+    contract; it does not implement lease/backpressure infrastructure. *)
+type agent_quota_control =
+  | LeaseExpiry
+  | Backpressure
+  | AdaptiveRate
+[@@deriving show { with_path = false }]
+
+(** Static operator contract for one quota tier. *)
+type agent_quota_tier_contract = {
+  contract_tier : agent_quota_tier;
+  code : string;
+  label : string;
+  workload_label : string;
+  share_percent : int;
+  default_req_per_min : int;
+}
+[@@deriving show]
+
+(** Computed request budget for one quota tier. *)
+type agent_quota_allocation = {
+  allocation_tier : agent_quota_tier;
+  allocation_percent : int;
+  allocation_req_per_min : int;
+}
+[@@deriving show]

--- a/test/test_rate_limit_coverage.ml
+++ b/test/test_rate_limit_coverage.ml
@@ -20,6 +20,126 @@ let test_default_burst () =
   check int "default burst" 150 Rate_limit.default_burst
 
 (* ============================================================
+   Agent Quota Tier Contract Tests
+   ============================================================ *)
+
+let must_allocations total_req_per_min =
+  match Rate_limit.compute_agent_quota_allocations ~total_req_per_min with
+  | Ok allocations -> allocations
+  | Error msg -> fail msg
+
+let allocation_for tier allocations =
+  match
+    List.find_opt
+      (fun allocation ->
+        Rate_limit.agent_quota_tier_code allocation.Rate_limit.allocation_tier
+        = Rate_limit.agent_quota_tier_code tier)
+      allocations
+  with
+  | Some allocation -> allocation
+  | None -> fail ("missing allocation for " ^ Rate_limit.agent_quota_tier_code tier)
+
+let total_allocated allocations =
+  List.fold_left
+    (fun total allocation ->
+      total + allocation.Rate_limit.allocation_req_per_min)
+    0 allocations
+
+let test_agent_quota_default_allocations () =
+  let allocations =
+    must_allocations Rate_limit.default_agent_quota_total_per_min
+  in
+  check int "P0 req/min" 400
+    (allocation_for Rate_limit.P0 allocations).allocation_req_per_min;
+  check int "P1 req/min" 400
+    (allocation_for Rate_limit.P1 allocations).allocation_req_per_min;
+  check int "P2 req/min" 200
+    (allocation_for Rate_limit.P2 allocations).allocation_req_per_min;
+  check int "sum preserved" 1000 (total_allocated allocations)
+
+let test_agent_quota_rounding_preserves_sum () =
+  let allocations = must_allocations 1001 in
+  check int "sum preserved" 1001 (total_allocated allocations);
+  check int "P0 receives first remainder" 401
+    (allocation_for Rate_limit.P0 allocations).allocation_req_per_min;
+  check int "P1 unchanged" 400
+    (allocation_for Rate_limit.P1 allocations).allocation_req_per_min;
+  check int "P2 unchanged" 200
+    (allocation_for Rate_limit.P2 allocations).allocation_req_per_min
+
+let test_agent_quota_invalid_total () =
+  match Rate_limit.compute_agent_quota_allocations ~total_req_per_min:0 with
+  | Ok _ -> fail "expected invalid total to fail"
+  | Error msg ->
+    check bool "mentions positive total" true
+      (String.contains msg 'p')
+
+let test_agent_quota_validate_sum () =
+  let allocations = must_allocations 1000 in
+  (match
+     Rate_limit.validate_agent_quota_allocations
+       ~total_req_per_min:1000 allocations
+   with
+   | Ok () -> ()
+   | Error msg -> fail msg);
+  let bad_allocations =
+    List.map
+      (fun allocation ->
+        if allocation.Rate_limit.allocation_tier = Rate_limit.P2 then
+          {
+            allocation with
+            allocation_req_per_min = allocation.allocation_req_per_min - 1;
+          }
+        else
+          allocation)
+      allocations
+  in
+  match
+    Rate_limit.validate_agent_quota_allocations
+      ~total_req_per_min:1000 bad_allocations
+  with
+  | Ok () -> fail "expected sum mismatch to fail"
+  | Error msg ->
+    check bool "mentions sum mismatch" true
+      (String.contains msg 's')
+
+let test_agent_quota_stable_labels () =
+  check string "P0 code" "P0" (Rate_limit.agent_quota_tier_code Rate_limit.P0);
+  check string "P1 code" "P1" (Rate_limit.agent_quota_tier_code Rate_limit.P1);
+  check string "P2 code" "P2" (Rate_limit.agent_quota_tier_code Rate_limit.P2);
+  check string "P0 label" "P0 Critical"
+    (Rate_limit.agent_quota_tier_label Rate_limit.P0);
+  check string "P1 label" "P1 Standard"
+    (Rate_limit.agent_quota_tier_label Rate_limit.P1);
+  check string "P2 label" "P2 Background"
+    (Rate_limit.agent_quota_tier_label Rate_limit.P2);
+  check (list string) "control labels"
+    ["lease-expiry"; "backpressure"; "adaptive-rate"]
+    Rate_limit.agent_quota_control_labels
+
+let test_agent_quota_contracts () =
+  let contracts = Rate_limit.agent_quota_tier_contracts in
+  check int "three contracts" 3 (List.length contracts);
+  let p0 = List.hd contracts in
+  check string "P0 contract code" "P0" p0.code;
+  check int "P0 share" 40 p0.share_percent;
+  check int "P0 default req/min" 400 p0.default_req_per_min
+
+let test_agent_quota_task_priority_mapping () =
+  check string "priority 1 -> P0" "P0"
+    (Rate_limit.agent_quota_tier_code
+       (Rate_limit.agent_quota_tier_of_task_priority 1));
+  check string "priority 3 -> P1" "P1"
+    (Rate_limit.agent_quota_tier_code
+       (Rate_limit.agent_quota_tier_of_task_priority 3));
+  check string "priority 4 -> P2" "P2"
+    (Rate_limit.agent_quota_tier_code
+       (Rate_limit.agent_quota_tier_of_task_priority 4));
+  check string "priority 0 -> P0" "P0"
+    (Rate_limit.agent_quota_tier_code
+       (Rate_limit.agent_quota_tier_of_task_priority 0))
+
+(* ============================================================
    Create Tests
    ============================================================ *)
 
@@ -226,6 +346,17 @@ let () =
     "constants", [
       test_case "default_rate" `Quick test_default_rate;
       test_case "default_burst" `Quick test_default_burst;
+    ];
+    "agent_quota_tiers", [
+      test_case "default allocations" `Quick test_agent_quota_default_allocations;
+      test_case "rounding preserves sum" `Quick
+        test_agent_quota_rounding_preserves_sum;
+      test_case "invalid total" `Quick test_agent_quota_invalid_total;
+      test_case "validate sum" `Quick test_agent_quota_validate_sum;
+      test_case "stable labels" `Quick test_agent_quota_stable_labels;
+      test_case "contracts" `Quick test_agent_quota_contracts;
+      test_case "task priority mapping" `Quick
+        test_agent_quota_task_priority_mapping;
     ];
     "create", [
       test_case "default" `Quick test_create_default;


### PR DESCRIPTION
## Summary
- Apply the Track9 productization/API slice to MASC as an operator-facing quota-tier contract.
- Add typed P0/P1/P2 agent quota tiers with a 1000 req/min default split of 400/400/200.
- Add deterministic allocation/validation helpers, stable labels, tier contracts, and task-priority mapping.
- Document lease expiry, backpressure, and adaptive-rate controls as contract labels only; this does not add Redis/Valkey, cloud infra, pricing, or billing behavior.

## Validation
- `git diff --check HEAD~1..HEAD`
- `./scripts/dune-local.sh build ./test/test_rate_limit_coverage.exe`
- `./_build/default/test/test_rate_limit_coverage.exe`