### PR TITLE
refactor(keeper): type receipt cascade names

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1251,7 +1251,8 @@ let run_turn
         network_mode = Keeper_types.network_mode_to_string meta.network_mode;
         approval_profile = acc.tool_surface.approval_mode_effective;
         approval_profile_derived = acc.tool_surface.approval_mode_derived;
-        cascade_name;
+        cascade_name =
+          Keeper_execution_receipt.cascade_name_of_string cascade_name;
         cascade_selected_model =
           Option.bind cascade_observation (fun obs -> obs.selected_model);
         cascade_attempt_count =
@@ -1265,7 +1266,9 @@ let run_turn
         cascade_outcome =
           cascade_outcome_of_observation cascade_observation;
         degraded_retry_applied;
-        degraded_retry_cascade;
+        degraded_retry_cascade =
+          Option.map Keeper_execution_receipt.cascade_name_of_string
+            degraded_retry_cascade;
         fallback_reason;
         cascade_rotation_attempts;
         stop_reason = !receipt_stop_reason_ref;

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -37,6 +37,11 @@ type error_kind = Error_kind of string
 let error_kind_of_string value = Error_kind value
 let error_kind_to_string (Error_kind value) = value
 
+type cascade_name = Keeper_cascade_profile.runtime_name
+
+let cascade_name_of_string = Keeper_cascade_profile.runtime_name_of_string
+let cascade_name_to_string = Keeper_cascade_profile.runtime_name_to_string
+
 (* TLA+ ReceiptIsAuthoritative invariant
    (specs/keeper-turn-fsm/KeeperTurnFSM.tla:336):
      receipt_outcome = "receipt_done" => turn_state = "done"
@@ -72,8 +77,8 @@ type tool_surface =
   }
 
 type cascade_rotation_attempt =
-  { from_cascade : string
-  ; to_cascade : string
+  { from_cascade : cascade_name
+  ; to_cascade : cascade_name
   ; reason : string
   ; outcome : string
   ; error_kind : error_kind option
@@ -106,13 +111,13 @@ type t =
   ; network_mode : string
   ; approval_profile : string option
   ; approval_profile_derived : bool
-  ; cascade_name : string
+  ; cascade_name : cascade_name
   ; cascade_selected_model : string option
   ; cascade_attempt_count : int
   ; cascade_fallback_applied : bool
   ; cascade_outcome : string
   ; degraded_retry_applied : bool
-  ; degraded_retry_cascade : string option
+  ; degraded_retry_cascade : cascade_name option
   ; fallback_reason : string option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
   ; stop_reason : string option
@@ -171,8 +176,8 @@ let last_tool_name receipt =
 let cascade_rotation_attempt_to_json attempt =
   `Assoc
     [
-      ("from_cascade", `String attempt.from_cascade);
-      ("to_cascade", `String attempt.to_cascade);
+      ("from_cascade", `String (cascade_name_to_string attempt.from_cascade));
+      ("to_cascade", `String (cascade_name_to_string attempt.to_cascade));
       ("reason", `String attempt.reason);
       ("outcome", `String attempt.outcome);
       ( "error_kind",
@@ -381,7 +386,7 @@ let to_json (receipt : t) =
       ~required_tools:receipt.tool_surface.required_tools
       ~missing_required_tools:receipt.tool_surface.missing_required_tools
       ?model:receipt.model_used
-      ~cascade_profile:receipt.cascade_name
+      ~cascade_profile:(cascade_name_to_string receipt.cascade_name)
       ()
   in
   let action_radius =
@@ -474,7 +479,7 @@ let to_json (receipt : t) =
       ( "cascade",
         `Assoc
           [
-            ("name", `String receipt.cascade_name);
+            ("name", `String (cascade_name_to_string receipt.cascade_name));
             ( "selected_model",
               match receipt.cascade_selected_model with
               | Some value -> `String value
@@ -485,7 +490,7 @@ let to_json (receipt : t) =
             ("degraded_retry_applied", `Bool receipt.degraded_retry_applied);
             ( "degraded_retry_cascade",
               match receipt.degraded_retry_cascade with
-              | Some value -> `String value
+              | Some value -> `String (cascade_name_to_string value)
               | None -> `Null );
             ( "fallback_reason",
               match receipt.fallback_reason with
@@ -574,7 +579,7 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
         | None -> `Null )
     ; "goal_ids", list_json receipt.goal_ids
     ; "response_text_present", `Bool receipt.response_text_present
-    ; "cascade_name", `String receipt.cascade_name
+    ; "cascade_name", `String (cascade_name_to_string receipt.cascade_name)
     ; "cascade_outcome", `String receipt.cascade_outcome
     ; "tool_contract_result", `String receipt.tool_contract_result
     ; ( "last_tool_name",
@@ -658,12 +663,13 @@ let append (config : Coord.config) (receipt : t) =
 let emit_stale_keeper_broadcast config
     ~keeper_name ~agent_name ~cascade_name ~trace_id ~generation
     ~stale_seconds ~last_turn_ts =
+  let cascade_name_string = cascade_name_to_string cascade_name in
   let payload =
     `Assoc
       [ "schema", `String "keeper.operator_broadcast_required.v1"
       ; "keeper_name", `String keeper_name
       ; "agent_name", `String agent_name
-      ; "cascade_name", `String cascade_name
+      ; "cascade_name", `String cascade_name_string
       ; "trace_id", `String trace_id
       ; "generation", `Int generation
       ; "disposition", `String "stalled"
@@ -683,7 +689,7 @@ let emit_stale_keeper_broadcast config
   in
   Log.Keeper.error
     "%s: stale_keeper_broadcast emitted last_turn=%.0fs ago cascade=%s seq=%d"
-    keeper_name stale_seconds cascade_name event.seq
+    keeper_name stale_seconds cascade_name_string event.seq
 
 let latest_json (config : Coord.config) keeper_name =
   let store =

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -39,6 +39,14 @@ type error_kind = private Error_kind of string
 val error_kind_of_string : string -> error_kind
 val error_kind_to_string : error_kind -> string
 
+type cascade_name = Keeper_cascade_profile.runtime_name
+(** Runtime cascade profile name as stored by execution receipts. Dynamic
+    catalog names stay possible, but receipt construction must cross this
+    typed boundary before persistence. *)
+
+val cascade_name_of_string : string -> cascade_name
+val cascade_name_to_string : cascade_name -> string
+
 type receipt_authority_violation = {
   outcome : string;
   turn_state : string;
@@ -85,8 +93,8 @@ type tool_surface =
   }
 
 type cascade_rotation_attempt =
-  { from_cascade : string
-  ; to_cascade : string
+  { from_cascade : cascade_name
+  ; to_cascade : cascade_name
   ; reason : string
   ; outcome : string
   ; error_kind : error_kind option
@@ -119,13 +127,13 @@ type t =
   ; network_mode : string
   ; approval_profile : string option
   ; approval_profile_derived : bool
-  ; cascade_name : string
+  ; cascade_name : cascade_name
   ; cascade_selected_model : string option
   ; cascade_attempt_count : int
   ; cascade_fallback_applied : bool
   ; cascade_outcome : string
   ; degraded_retry_applied : bool
-  ; degraded_retry_cascade : string option
+  ; degraded_retry_cascade : cascade_name option
   ; fallback_reason : string option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
   ; stop_reason : string option
@@ -167,7 +175,7 @@ val emit_stale_keeper_broadcast :
   Coord.config ->
   keeper_name:string ->
   agent_name:string ->
-  cascade_name:string ->
+  cascade_name:cascade_name ->
   trace_id:string ->
   generation:int ->
   stale_seconds:float ->

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -392,7 +392,9 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                     ctx.config
                     ~keeper_name:meta.name
                     ~agent_name:meta.agent_name
-                    ~cascade_name:meta.cascade_name
+                    ~cascade_name:
+                      (Keeper_execution_receipt.cascade_name_of_string
+                         meta.cascade_name)
                     ~trace_id:
                       (Keeper_id.Trace_id.to_string
                          entry.meta.runtime.trace_id)

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -185,7 +185,7 @@ let record_pre_dispatch_terminal_observation
     ~(config : Coord.config)
     ~(meta : keeper_meta)
     ~(generation : int)
-    ~(cascade_name : string)
+    ~(cascade_name : Keeper_execution_receipt.cascade_name)
     ~(outcome : string)
     ~(terminal_reason_code : string)
     ~(activity_kind : string)
@@ -194,6 +194,9 @@ let record_pre_dispatch_terminal_observation
     ?error_message
     ?keeper_turn_id
     () : unit =
+  let cascade_name_string =
+    Keeper_execution_receipt.cascade_name_to_string cascade_name
+  in
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   let started_at = now_iso () in
   let masc_root = Coord.masc_root_dir config in
@@ -277,7 +280,7 @@ let record_pre_dispatch_terminal_observation
                 ("trace_id", `String trace_id);
                 ("outcome", `String outcome);
                 ("terminal_reason_code", `String terminal_reason_code);
-                ("cascade_name", `String cascade_name);
+                ("cascade_name", `String cascade_name_string);
               ])
          ()
      in

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -69,7 +69,7 @@ val record_pre_dispatch_terminal_observation :
   config:Coord.config ->
   meta:keeper_meta ->
   generation:int ->
-  cascade_name:string ->
+  cascade_name:Keeper_execution_receipt.cascade_name ->
   outcome:string ->
   terminal_reason_code:string ->
   activity_kind:string ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -90,7 +90,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~config
         ~meta
         ~generation
-        ~cascade_name:meta.cascade_name
+        ~cascade_name:
+          (Keeper_execution_receipt.cascade_name_of_string meta.cascade_name)
         ~outcome:"skipped"
         ~terminal_reason_code
         ~activity_kind:"keeper.turn_skipped"
@@ -202,7 +203,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 ~config
                 ~meta
                 ~generation
-                ~cascade_name:effective_cascade_name
+                ~cascade_name:
+                  (Keeper_execution_receipt.cascade_name_of_string
+                     effective_cascade_name)
                 ~outcome:"error"
                 ~terminal_reason_code:"ollama_saturated"
                 ~activity_kind:"keeper.turn_failed"
@@ -289,7 +292,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~config
             ~meta
             ~generation
-            ~cascade_name:effective_cascade_name
+            ~cascade_name:
+              (Keeper_execution_receipt.cascade_name_of_string
+                 effective_cascade_name)
             ~outcome:"error"
             ~terminal_reason_code
             ~activity_kind:"keeper.turn_blocked"
@@ -334,7 +339,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              ~config
              ~meta
              ~generation
-             ~cascade_name:initial_execution.cascade_name
+             ~cascade_name:
+               (Keeper_execution_receipt.cascade_name_of_string
+                  initial_execution.cascade_name)
              (* β6: "blocked" was not in outcome_kind quad-state
                 (ok/skipped/error/cancelled), causing operator_disposition
                 to classify livelock-blocked turns as "unknown".  Map to
@@ -608,8 +615,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           (err : Oas.Error.sdk_error) =
         let attempt : Keeper_execution_receipt.cascade_rotation_attempt =
           {
-            from_cascade;
-            to_cascade = retry.next_cascade;
+            from_cascade =
+              Keeper_execution_receipt.cascade_name_of_string from_cascade;
+            to_cascade =
+              Keeper_execution_receipt.cascade_name_of_string retry.next_cascade;
             reason = retry.fallback_reason;
             outcome;
             error_kind =
@@ -753,7 +762,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     ~config
                     ~meta:run_meta
                     ~generation:run_generation
-                    ~cascade_name:execution.cascade_name
+                    ~cascade_name:
+                      (Keeper_execution_receipt.cascade_name_of_string
+                         execution.cascade_name)
                     ~outcome:"cancelled"
                     ~terminal_reason_code:"external_cancel"
                     ~activity_kind:"keeper.turn_cancelled"

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -465,19 +465,27 @@ let append_execution_receipt config ~keeper_name =
       network_mode = Lib.Keeper_types.network_mode_to_string meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
-      cascade_name = meta.cascade_name;
+      cascade_name =
+        Lib.Keeper_execution_receipt.cascade_name_of_string meta.cascade_name;
       cascade_selected_model = Some "custom:mock";
       cascade_attempt_count = 2;
       cascade_fallback_applied = true;
       cascade_outcome = "passed_to_next_model";
       degraded_retry_applied = true;
-      degraded_retry_cascade = Some Lib.Keeper_config.local_recovery_cascade_name;
+      degraded_retry_cascade =
+        Some
+          (Lib.Keeper_execution_receipt.cascade_name_of_string
+             Lib.Keeper_config.local_recovery_cascade_name);
       fallback_reason = Some "turn_timeout";
       cascade_rotation_attempts =
         [
           {
-            from_cascade = Lib.Keeper_config.default_cascade_name;
-            to_cascade = Lib.Keeper_config.local_recovery_cascade_name;
+            from_cascade =
+              Lib.Keeper_execution_receipt.cascade_name_of_string
+                Lib.Keeper_config.default_cascade_name;
+            to_cascade =
+              Lib.Keeper_execution_receipt.cascade_name_of_string
+                Lib.Keeper_config.local_recovery_cascade_name;
             reason = "turn_timeout";
             outcome = "retry_scheduled";
             error_kind =

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -130,7 +130,8 @@ let append_keeper_receipt ?(outcome = "ok")
       network_mode = Keeper_types.network_mode_to_string meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
-      cascade_name = meta.cascade_name;
+      cascade_name =
+        Keeper_execution_receipt.cascade_name_of_string meta.cascade_name;
       cascade_selected_model = Some "openai:gpt-5.4";
       cascade_attempt_count = 1;
       cascade_fallback_applied = false;

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -639,21 +639,29 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
         Masc_mcp.Keeper_types.network_mode_to_string meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
-      cascade_name = meta.cascade_name;
+      cascade_name =
+        Masc_mcp.Keeper_execution_receipt.cascade_name_of_string
+          meta.cascade_name;
       cascade_selected_model = Some "custom:mock";
       cascade_attempt_count = 2;
       cascade_fallback_applied;
       cascade_outcome;
       degraded_retry_applied;
-      degraded_retry_cascade;
+      degraded_retry_cascade =
+        Option.map Masc_mcp.Keeper_execution_receipt.cascade_name_of_string
+          degraded_retry_cascade;
       fallback_reason;
       cascade_rotation_attempts =
         (match degraded_retry_cascade, fallback_reason with
          | Some retry_cascade, Some reason ->
            [
              {
-               from_cascade = meta.cascade_name;
-               to_cascade = retry_cascade;
+               from_cascade =
+                 Masc_mcp.Keeper_execution_receipt.cascade_name_of_string
+                   meta.cascade_name;
+               to_cascade =
+                 Masc_mcp.Keeper_execution_receipt.cascade_name_of_string
+                   retry_cascade;
                reason;
                outcome = "retry_scheduled";
                error_kind =

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -73,7 +73,7 @@ let mk_receipt
     network_mode = "offline";
     approval_profile = None;
     approval_profile_derived = false;
-    cascade_name = "default";
+    cascade_name = R.cascade_name_of_string "default";
     cascade_selected_model = None;
     cascade_attempt_count = 1;
     cascade_fallback_applied;


### PR DESCRIPTION
## Summary

Refs #11926.

- Add a local `Keeper_execution_receipt.cascade_name` typed boundary backed by `Keeper_cascade_profile.runtime_name`.
- Type execution receipt `cascade_name`, `degraded_retry_cascade`, rotation `from_cascade` / `to_cascade`, pre-dispatch receipt ingress, and stale watchdog broadcast ingress.
- Preserve existing JSON/dashboard/operator-broadcast wire strings through `cascade_name_to_string`.
- Update receipt/dashboard tests to construct typed receipt cascade names explicitly.

## Product impact

Execution receipts now preserve dynamic runtime cascade labels while forcing receipt writers through a typed boundary before persistence. This reduces the C-T7.2 `cascade_name:string` surface without changing stored JSON or dashboard payload shape.

## Evidence

- `scripts/dune-local.sh build lib/keeper/keeper_execution_receipt.ml lib/keeper/keeper_execution_receipt.mli lib/keeper/keeper_turn_helpers.ml lib/keeper/keeper_turn_helpers.mli lib/keeper/keeper_agent_run.ml lib/keeper/keeper_unified_turn.ml lib/keeper/keeper_stale_watchdog.ml test/test_keeper_pause_broadcast.exe test/test_dashboard_keeper_routes.exe test/test_dashboard_goals.exe test/test_dashboard_execution.exe test/test_observability_provider_contracts.exe`
- `./_build/default/test/test_keeper_pause_broadcast.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 ./_build/default/test/test_dashboard_keeper_routes.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 ./_build/default/test/test_dashboard_goals.exe`
- `./_build/default/test/test_observability_provider_contracts.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 ./_build/default/test/test_dashboard_execution.exe`
- `scripts/stringly-boundary-ratchet.sh --print`
- `git diff --check HEAD~1 HEAD`

## Review evidence

- `raw_cascade_name_string_signatures` moved from 81 to 76 on this branch.
- Targeted grep over touched receipt/helper/test files no longer reports `cascade_name:string` signatures.
- `test_dashboard_execution.exe` mutates `config/cascade.json` as a test side effect locally; the generated change was restored and is not part of this PR.

## Linked issue

- #11926
