### PR TITLE
fix(server): whitelist multimodal dashboard reads as public_read

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -625,6 +625,16 @@ let is_public_read_path path =
   || String.starts_with ~prefix:"/dashboard/" path
   || String.starts_with ~prefix:"/static/" path
   || String.starts_with ~prefix:"/graphiql/" path
+  (* Tier F2 dashboard reads — multimodal artifact gallery + detail
+     panel. The Bonsai dashboard issues these via [Brr_io.Fetch.url]
+     with no credentials, mirroring the rest of the dashboard's
+     read-only surface. Routes themselves are wrapped in
+     [with_public_read] in [server_routes_http_routes_multimodal];
+     this whitelist entry is what makes that wrapper actually
+     public when [http_auth_strict_enabled] is on. *)
+  || String.starts_with ~prefix:"/api/v1/multimodal/list" path
+  || String.starts_with ~prefix:"/api/v1/multimodal/get/" path
+  || String.starts_with ~prefix:"/api/v1/multimodal/provenance/" path
 
 let resolve_agent_name_for_auth ~base_path request ~token :
     (string option, Types.masc_error) result =

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -815,6 +815,30 @@ let test_public_read_path_rejects_generic_connector_unbind () =
   check bool "generic connector unbind is not public read" false
     (SA.is_public_read_path "/api/v1/gate/connector/unbind")
 
+(* Tier F2 — multimodal dashboard reads are public *)
+let test_public_read_path_allows_multimodal_list () =
+  let module SA = Masc_mcp.Server_auth in
+  check bool "multimodal list is public read" true
+    (SA.is_public_read_path "/api/v1/multimodal/list")
+
+let test_public_read_path_allows_multimodal_get () =
+  let module SA = Masc_mcp.Server_auth in
+  check bool "multimodal get/<id> is public read" true
+    (SA.is_public_read_path "/api/v1/multimodal/get/01900000-0000-7000-8000-000000000001")
+
+let test_public_read_path_allows_multimodal_provenance () =
+  let module SA = Masc_mcp.Server_auth in
+  check bool "multimodal provenance/<id> is public read" true
+    (SA.is_public_read_path "/api/v1/multimodal/provenance/01900000-0000-7000-8000-000000000001")
+
+let test_public_read_path_rejects_unrelated_multimodal_subpath () =
+  let module SA = Masc_mcp.Server_auth in
+  (* If a future write endpoint lands under /api/v1/multimodal/, the
+     prefix entries above must NOT cover it. Only the three known
+     read paths are public; anything else stays auth-required. *)
+  check bool "multimodal create (hypothetical) is NOT public read" false
+    (SA.is_public_read_path "/api/v1/multimodal/create")
+
 let test_permission_for_tool_unknown () =
   match Auth.permission_for_tool "unknown_tool_xyz" with
   | None -> ()
@@ -1226,5 +1250,13 @@ let () =
         test_public_read_path_rejects_generic_connector_bind;
       test_case "generic connector unbind is not public read" `Quick
         test_public_read_path_rejects_generic_connector_unbind;
+      test_case "multimodal list is public read" `Quick
+        test_public_read_path_allows_multimodal_list;
+      test_case "multimodal get is public read" `Quick
+        test_public_read_path_allows_multimodal_get;
+      test_case "multimodal provenance is public read" `Quick
+        test_public_read_path_allows_multimodal_provenance;
+      test_case "unrelated multimodal subpath stays auth-required" `Quick
+        test_public_read_path_rejects_unrelated_multimodal_subpath;
     ];
   ]


### PR DESCRIPTION
## Summary

Adds the three F2 dashboard read endpoints to the strict-mode public-read whitelist:
- `/api/v1/multimodal/list`
- `/api/v1/multimodal/get/<id>`
- `/api/v1/multimodal/provenance/<id>`

## Problem (D2 audit finding)

F2 (PR #12269, already merged) wires gallery cards to fetch detail + provenance in parallel via `Brr_io.Fetch.url`. The Bonsai dashboard does not pass auth credentials, mirroring the rest of its read-only surface (`/health`, `/dashboard/*`, `/static/*`, etc.).

But `/api/v1/multimodal/*` was missing from `is_public_read_path`. With `http_auth_strict_enabled` on, the routes wrapped in `with_public_read` fall through to `with_read_auth`, which 401s a no-credential request. F2's parser collapses the 401 envelope into the same `None` state as a 404 — so the panel sticks at "loading…" forever with no distinction.

This is a non-issue in non-strict deployments; it bites operators running strict mode.

## Why prefix match

Only the read paths are whitelisted. The `get/` and `provenance/` entries use prefix because the `<id>` segment is variable. A negative test pins the boundary: a hypothetical `/api/v1/multimodal/create` write endpoint stays auth-required.

## Tests

- [x] `multimodal list is public read` (positive)
- [x] `multimodal get is public read` (positive)
- [x] `multimodal provenance is public read` (positive)
- [x] `unrelated multimodal subpath stays auth-required` (boundary)
- [x] All 108 tests in `test_auth_coverage` GREEN
- [x] `dune build --root .` GREEN

## Out of scope

- Distinguishing 401 vs 404 vs network-error in F2 itself — that's the F2 UX states follow-up (Idle/Loading/Loaded/NotFound/Error variant), separate PR.