### PR TITLE
docs(rfc): RFC 0017 — sustained-load bench at n=16 (16-keeper SSE workload)

### DIFF
--- a/dashboard/design-system/RFC/0017-solidjs-migration-measurement.md
+++ b/dashboard/design-system/RFC/0017-solidjs-migration-measurement.md
@@ -76,6 +76,49 @@ Solid  updates→DOM:   min=62.30 avg=63.47 max=64.30 ms     (Solid/Preact = 0.6
 
 Maximum simultaneous strips on any production page: ~10. **Every actual usage falls in the Preact-wins region.**
 
+## Sustained-load measurement (added 2026-04-30, addresses 16-keeper SSE workload)
+
+The single-shot 3-sample suite above leaves a critical question unanswered: what happens when the dashboard is consuming a continuous SSE event stream from many keepers and the parent component re-renders many times per second? The bench was extended with two modes that target this shape — both at **n=16** (= production keeper count).
+
+### Burst — 60 sequential updates at n=16
+
+```
+Preact: total 1019 ms, mean 16.98 ms, p95 20.60 ms, max 25.00 ms
+Solid:  total 1987 ms, mean 33.12 ms, p95 35.80 ms, max 38.90 ms
+```
+
+A 60-update burst (one second of typical 1 Hz/keeper traffic over 16 keepers, compressed) takes Solid **2× longer** to drain. Every individual update is also 2× slower.
+
+### Sustained 5-second window at n=16, target ≈30 Hz
+
+```
+Preact:   296 updates,  frames 296/300 (99%)  mean=16.89 p95=20.60 max=30.30 ms
+Solid:    148 updates,  frames 296/300 (99%)  mean=33.97 p95=40.20 max=53.40 ms
+  → throughput ratio Solid/Preact = 0.50
+```
+
+Preact sustains ~59 updates/sec; Solid sustains ~30 updates/sec. **Solid's throughput is exactly half** of Preact's at our production scale.
+
+Both sides keep 99% frame retention because the rAF poll between updates yields naturally — but the throughput gap means that if SSE event arrival exceeds Solid's drain rate (~30 Hz), the queue grows and the UI shows stale data. Preact has roughly 2× the headroom before the same back-pressure starts.
+
+### Implication for the 16-keeper case
+
+If keepers emit at 1 Hz each (16 events/sec total) and the parent re-renders on every event:
+
+| | Preact | Solid |
+|--|--------|-------|
+| Time to drain one event batch (n=16) | ~17 ms | ~33 ms |
+| Steady-state CPU per second of stream | ~270 ms (27%) | ~530 ms (53%) |
+| Headroom before queue grows | up to ~59 events/sec | up to ~30 events/sec |
+
+The Solid path consumes roughly twice the main-thread budget for the same stream rate. At higher event rates (e.g. burst keeper-startup: 16 keepers × multiple state changes/sec), Solid will start lagging at a rate Preact would still keep up with.
+
+### Caveats specific to sustained mode
+
+- The bench drives both implementations through Preact `render()` at the top, so Preact's sync render cycle and Solid's `useEffect` → solid-root path are both included end-to-end.
+- Headless Chromium with no concurrent workload — a real laptop with other tabs would amplify the absolute numbers but the ratio (Solid 2× slower) is the durable signal.
+- Solid's 33 ms floor is dominated by `useEffect` task-tier scheduling. Targeted signal updates that bypass the parent re-render entirely (e.g. a dedicated keeper-state store the island reads via `createMemo`) would close most of the gap. That refactor is out of scope for the current `KpiStripIsland` shape, which takes a fresh `cells` array literal on every parent render.
+
 ## Caveats
 
 - Headless Chromium has no concurrent workload; numbers may differ on a real laptop running the dashboard alongside other apps. The relative gap between the two implementations is what carries; absolute numbers will vary.
@@ -86,7 +129,7 @@ Maximum simultaneous strips on any production page: ~10. **Every actual usage fa
 
 1. **Do not roll back blindly.** Bundle isolation (9.3 KB amortised after first caller, 0 B per subsequent caller), type safety, and the test-shim infrastructure are all clean wins; reverting them costs more than the latency we'd recover.
 2. **Amend RFC 0017 §4.** The krausest citation does not generalise to our app shape. Replace it with these measured numbers and an explicit note that the migration was not justified by user-perceived latency.
-3. **Skip RFC 0017 §6 (Lifeline/Ticker islands) for now.** Per these numbers, more islands have no performance justification unless those components have N>200 cells. They do not.
+3. **Skip RFC 0017 §6 (Lifeline/Ticker islands) for now.** Per these numbers, more islands have no performance justification unless those components have N>200 cells. They do not. **The sustained-load numbers strengthen this**: at n=16 Solid throughput is half of Preact's, so adding more islands to a streaming dashboard makes the SSE back-pressure problem worse, not better.
 4. **Investigate a synchronous mount strategy** as a future spike. If the 30 ms `useEffect` overhead can be eliminated, the cross-over point shifts down toward our actual usage and the migration becomes a real win. This is worth a separate, scoped RFC.
 5. **Keep the current migration as deliberate code organisation.** The Solid island gives us framework-agnostic primitives, a clean migration boundary, and a reusable test pattern (`vi.doMock` shim). Those are the actual wins to report — performance is not.
 

--- a/dashboard/design-system/RFC/0017-solidjs-migration.md
+++ b/dashboard/design-system/RFC/0017-solidjs-migration.md
@@ -104,9 +104,20 @@ After 7 sequential PRs (#12162 → #12268) migrated 6 callers, headless Chromium
 | Update n=10 | 16.37 ms | 33.57 ms | ❌ (2.0×) |
 | Update n=500 | 102.57 ms | 63.47 ms | ✅ (0.62×) |
 
+### 7c. Sustained-load measurement (16-keeper SSE workload, added later same day)
+
+The single-shot 3-sample numbers above don't tell us what happens when the dashboard is consuming a continuous SSE event stream. Added a sustained-mode bench at **n=16** (= production keeper count):
+
+| Mode | Preact | Solid island |
+|------|--------|--------------|
+| Burst (60 sequential updates @ n=16) | 1019 ms total, mean 16.98 ms/update | 1987 ms total, mean 33.12 ms/update |
+| 5 s sustained window @ n=16 | **296 updates** (~59 Hz), 99% frame retention | **148 updates** (~30 Hz), 99% frame retention |
+
+**Solid throughput is exactly half of Preact's** at our production scale. Frame retention is 99% on both because the rAF poll between updates yields naturally — but the throughput gap means Solid will start lagging the SSE queue at event rates Preact still keeps up with. For a 16-keeper × 1 Hz/keeper stream Preact uses ~27% of a second of main-thread time; Solid uses ~53%.
+
 **What we kept anyway**: bundle isolation (9.3 KB amortised, 0 B per subsequent caller), `headless-core` framework-agnosticism proven, reusable `vi.doMock` test-shim pattern, file-boundary transform isolation for Preact↔Solid coexistence. Those are real wins that justify the migration *as code organisation*, not as latency improvement.
 
-The krausest figures in §1 do not generalise to our usage shape (small N) and were the original justification for this RFC. The companion measurement document records what we actually observed and recommends Phase 2 (Lifeline) and Phase 3 (Ticker) be paused pending a synchronous-mount spike that could close the 30 ms `useEffect` gap.
+The krausest figures in §1 do not generalise to our usage shape (small N, but high update rate from SSE). The companion measurement document records what we actually observed and recommends Phase 2 (Lifeline) and Phase 3 (Ticker) be paused pending a synchronous-mount spike that could close the 30 ms `useEffect` gap.
 
 ## 8. Rollback Criteria
 

--- a/dashboard/design-system/preview/bench-kpi.html
+++ b/dashboard/design-system/preview/bench-kpi.html
@@ -81,6 +81,8 @@
       <button id="run-clear">Clear</button>
       <button id="run-warmup">Warmup (run mount 3x silently)</button>
       <button id="run-suite">Full suite (mount + 3× update)</button>
+      <button id="run-sustained">Sustained 5s (n=16, 30 updates/sec target)</button>
+      <button id="run-keeper-shape">Keeper-shape spike (n=16, 60 updates burst)</button>
     </div>
 
     <pre class="results" id="results">(no measurements yet)</pre>

--- a/dashboard/design-system/preview/bench-kpi.ts
+++ b/dashboard/design-system/preview/bench-kpi.ts
@@ -318,8 +318,182 @@ document.getElementById('run-warmup')?.addEventListener('click', async () => {
 document.getElementById('run-suite')?.addEventListener('click', async () => {
   resultsEl.textContent = ''
   const cellsPerStrip = Number(cellsInput.value)
-  for (const n of [10, 50, 100, 250, 500]) {
+  for (const n of [10, 16, 50, 100, 250, 500]) {
     countInput.value = String(n)
     await runFullBench(`suite n=${n}`, n, cellsPerStrip, 3)
   }
+})
+
+// ── Sustained-update benchmark ──
+//
+// Models the realistic dashboard workload: 16 keepers (or domain rows)
+// each emitting an SSE event burst that triggers a parent re-render.
+// The naive "3 update samples" mode in the suite above misses what
+// happens when update events keep landing while the previous one is
+// still draining. This mode loops re-renders for a fixed window and
+// records:
+//   - throughput (updates/sec actually completed)
+//   - frame budget impact (rAF callbacks observed during the window;
+//     a healthy 60 Hz tab sees ~60 frames/sec → fewer = blocked frames)
+//   - mean / p95 update latency
+//
+// We run the loop on each side **separately** (Preact first, then
+// island) so they don't compete for the main thread. Otherwise the
+// slower side would skew the faster side's measurement.
+
+interface SustainedResult {
+  side: 'preact' | 'island'
+  windowMs: number
+  updates: number
+  framesObserved: number
+  expectedFrames: number
+  meanMs: number
+  p95Ms: number
+  maxMs: number
+}
+
+function frameCounter(windowMs: number): { stop: () => number } {
+  let count = 0
+  let stopped = false
+  const tick = (): void => {
+    if (stopped) return
+    count += 1
+    requestAnimationFrame(tick)
+  }
+  requestAnimationFrame(tick)
+  return {
+    stop: () => {
+      stopped = true
+      return count
+    },
+  }
+}
+
+function p95(values: number[]): number {
+  if (values.length === 0) return NaN
+  const sorted = [...values].sort((a, b) => a - b)
+  const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95))
+  return sorted[idx] ?? NaN
+}
+
+async function runSustainedSide(
+  side: 'preact' | 'island',
+  rows: SeedRow[],
+  cellsPerStrip: number,
+  windowMs: number,
+): Promise<SustainedResult> {
+  const host = side === 'preact' ? preactHost : islandHost
+  const expectedFrames = Math.round((windowMs / 1000) * 60)
+  const fc = frameCounter(windowMs)
+
+  const samples: number[] = []
+  const start = performance.now()
+  const deadline = start + windowMs
+  let updates = 0
+
+  while (performance.now() < deadline) {
+    for (const r of rows) r.total += 1
+    const sentinels = rows.map((r) => String(r.total))
+    const renderFn = side === 'preact'
+      ? () => render(
+          html`<div>${rows.map((r) => html`
+            <${KpiStrip} ariaLabel="bench" cols=${cellsPerStrip}>
+              ${rowToCells(r, cellsPerStrip).map((cell) => html`<${KpiCell} ...${cell} />`)}
+            <//>
+          `)}</div>`,
+          host,
+        )
+      : () => render(
+          html`<div>${rows.map((r) => html`
+            <${KpiStripIsland} ariaLabel="bench" cols=${cellsPerStrip} cells=${rowToCells(r, cellsPerStrip)} />
+          `)}</div>`,
+          host,
+        )
+
+    try {
+      const ms = await timeUpdateToDom(renderFn, host, sentinels, 1000)
+      samples.push(ms)
+      updates += 1
+    } catch {
+      // Drop missed updates; loop will re-render the next iteration.
+      break
+    }
+  }
+
+  const framesObserved = fc.stop()
+  const mean = samples.length ? samples.reduce((a, b) => a + b, 0) / samples.length : NaN
+
+  return {
+    side,
+    windowMs,
+    updates,
+    framesObserved,
+    expectedFrames,
+    meanMs: mean,
+    p95Ms: p95(samples),
+    maxMs: samples.length ? Math.max(...samples) : NaN,
+  }
+}
+
+function reportSustained(label: string, n: number, preactR: SustainedResult, islandR: SustainedResult): void {
+  const block = [
+    `=== ${label} (n=${n} strips, window=${preactR.windowMs}ms) ===`,
+    `Preact:  ${preactR.updates.toString().padStart(4)} updates,  frames ${preactR.framesObserved}/${preactR.expectedFrames}  ` +
+      `mean=${preactR.meanMs.toFixed(2)} p95=${preactR.p95Ms.toFixed(2)} max=${preactR.maxMs.toFixed(2)} ms`,
+    `Solid:   ${islandR.updates.toString().padStart(4)} updates,  frames ${islandR.framesObserved}/${islandR.expectedFrames}  ` +
+      `mean=${islandR.meanMs.toFixed(2)} p95=${islandR.p95Ms.toFixed(2)} max=${islandR.maxMs.toFixed(2)} ms`,
+    `  → throughput ratio Solid/Preact = ${(islandR.updates / Math.max(1, preactR.updates)).toFixed(2)}`,
+    `  → frame retention Preact ${((preactR.framesObserved / preactR.expectedFrames) * 100).toFixed(0)}%, Solid ${((islandR.framesObserved / islandR.expectedFrames) * 100).toFixed(0)}%`,
+    '',
+  ]
+  resultsEl.textContent = (resultsEl.textContent ?? '') + block.join('\n') + '\n'
+  console.log(block.join('\n'))
+}
+
+document.getElementById('run-sustained')?.addEventListener('click', async () => {
+  resultsEl.textContent = 'sustained: warmup mount n=16...\n'
+  const n = 16
+  const cellsPerStrip = Number(cellsInput.value)
+  const mount = await runMount(n, cellsPerStrip)
+
+  // Run each side for 5s separately so the slow one doesn't poison
+  // the fast one's frame counter.
+  const windowMs = 5000
+  resultsEl.textContent += `Running Preact side ${windowMs}ms...\n`
+  const preactR = await runSustainedSide('preact', mount.rows, cellsPerStrip, windowMs)
+  resultsEl.textContent += `Running Solid side ${windowMs}ms...\n`
+  const islandR = await runSustainedSide('island', mount.rows, cellsPerStrip, windowMs)
+
+  reportSustained(`sustained 5s`, n, preactR, islandR)
+})
+
+// "Keeper-shape spike": 16 keepers each emit a burst of ~60 updates
+// (one per second over a minute, compressed). Measures cumulative cost
+// of a typical hour of dashboard idle-watching.
+document.getElementById('run-keeper-shape')?.addEventListener('click', async () => {
+  resultsEl.textContent = ''
+  const n = 16
+  const cellsPerStrip = Number(cellsInput.value)
+  const mount = await runMount(n, cellsPerStrip)
+
+  const burstUpdates = 60
+  const preactSamples: number[] = []
+  const islandSamples: number[] = []
+
+  for (let i = 0; i < burstUpdates; i += 1) {
+    const u = await runUpdate(mount.rows, cellsPerStrip)
+    preactSamples.push(u.preactUpdateMs)
+    islandSamples.push(u.islandUpdateMs)
+  }
+
+  const ps = preactSamples
+  const is_ = islandSamples
+  const block = [
+    `=== keeper-shape spike (n=${n}, ${burstUpdates} updates each side) ===`,
+    `Preact: total ${ps.reduce((a, b) => a + b, 0).toFixed(0)}ms, mean ${(ps.reduce((a, b) => a + b, 0) / ps.length).toFixed(2)}ms, p95 ${p95(ps).toFixed(2)}ms, max ${Math.max(...ps).toFixed(2)}ms`,
+    `Solid:  total ${is_.reduce((a, b) => a + b, 0).toFixed(0)}ms, mean ${(is_.reduce((a, b) => a + b, 0) / is_.length).toFixed(2)}ms, p95 ${p95(is_).toFixed(2)}ms, max ${Math.max(...is_).toFixed(2)}ms`,
+    '',
+  ]
+  resultsEl.textContent = block.join('\n') + '\n'
+  console.log(block.join('\n'))
 })


### PR DESCRIPTION
## Why this PR

Reviewer (Vincent) flagged the previous measurement (PR #12274): the 3-sample suite captures occasional updates, but the realistic dashboard workload is **16 keepers each emitting SSE events**, which translates to many parent re-renders per second. The suite numbers don't tell us whether Solid keeps up under that pressure.

Added two sustained-mode benchmarks at **n=16** (= production keeper count) and ran them through the existing puppeteer runner.

## Headline (warm cache, headless Chromium, n=16)

### Burst — 60 sequential updates

```
Preact  total 1019 ms, mean 16.98 ms/update, p95 20.60 ms, max 25.00 ms
Solid   total 1987 ms, mean 33.12 ms/update, p95 35.80 ms, max 38.90 ms
```

### Sustained 5 s window

```
Preact  296 updates (~59 Hz),  frames 296/300 (99%)  mean=16.89 p95=20.60 max=30.30 ms
Solid   148 updates (~30 Hz),  frames 296/300 (99%)  mean=33.97 p95=40.20 max=53.40 ms
        → throughput Solid/Preact = 0.50
```

**Solid throughput is exactly half of Preact's** at our production scale. Frame retention is 99% on both because rAF naturally yields between updates — the gap shows up as queue depth, not dropped frames. For a 16-keeper × 1 Hz/keeper stream:

| | Preact | Solid |
|--|--------|-------|
| Time to drain one event batch | ~17 ms | ~33 ms |
| Steady-state CPU per second | ~270 ms (27%) | ~530 ms (53%) |
| Headroom before queue grows | up to ~59 events/sec | up to ~30 events/sec |

## What lands

| File | Change |
|------|--------|
| `bench-kpi.html` | Two new buttons: "Sustained 5s (n=16, 30 updates/sec target)" and "Keeper-shape spike (n=16, 60 updates burst)" |
| `bench-kpi.ts` | `runSustainedSide`, `frameCounter`, `p95` helpers + click handlers. Suite size list now includes n=16. |
| `0017-solidjs-migration.md` §7c | Sustained-mode summary added to the §7 verification block |
| `0017-solidjs-migration-measurement.md` | Sustained-load section with raw numbers, headroom math, SSE back-pressure caveat |

## Recommendation strengthens

Previous PR (#12274) recommended:
- Do not roll back; bundle isolation + test infrastructure are real wins.
- Pause Phase 2 (Lifeline) and Phase 3 (Ticker) pending a synchronous-mount spike.

Sustained-mode evidence **strengthens the second point**: adding more islands to a streaming dashboard makes the SSE back-pressure problem **worse**, not better. The 30 ms `useEffect` overhead per island compounds across multiple islands on the same page.

## Verification

| Step | Result |
|------|--------|
| `pnpm typecheck` | green |
| `vitest --config vitest.solid.config.ts` | 128/128 pass |
| `pnpm build` | success |
| Headless Chromium bench run via puppeteer | numbers above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)