### PR TITLE
feat(dashboard_bonsai): F2 UX states — Idle/Loading/Loaded/NotFound/Error

### DIFF
--- a/dashboard_bonsai/src/multimodal_detail_fetch.ml
+++ b/dashboard_bonsai/src/multimodal_detail_fetch.ml
@@ -1,43 +1,41 @@
-(** Tier F2 — single-shot fetch of artifact detail + provenance.
+(** Tier F2-ux — single-shot fetch of artifact detail + provenance
+    with explicit Loading/Loaded/NotFound/Error state transitions.
 
-    Triggered by [Multimodal_view] card on_click; not polling. The
-    detail and provenance vars are reset to [None] before the fetch
-    starts so the panel can render a "loading" state. Both endpoints
-    are fetched in parallel and each callback writes only its own
-    var (no shared peek).
+    Triggered by [Multimodal_view] card on_click; not polling. On
+    each [fetch], both detail/provenance vars start at [Loading].
+    Each parallel fetch independently transitions to [Loaded x],
+    [NotFound] (server error envelope), or [Error msg] (network /
+    parse failure).
 
-    Failed fetches leave the corresponding var at [None]. *)
+    The two responses are independent — operator can see detail
+    arrive while provenance is still loading or vice versa. *)
 
 open! Core
 open Brr_io
+
+module T = Multimodal_detail_types
 
 let detail_endpoint id = Printf.sprintf "/api/v1/multimodal/get/%s" id
 let provenance_endpoint id =
   Printf.sprintf "/api/v1/multimodal/provenance/%s" id
 ;;
 
-let parse_json_or_error (text : Jstr.t) : Yojson.Safe.t option =
+(** Parse one fetch body into a [_ fetch_state]. The deserializer
+    [decode] is applied only when the body classifies as [Ok_json];
+    error envelopes become [NotFound] (most common reason: id not
+    resolvable on the server) and JSON-parse failures become
+    [Error]. *)
+let body_to_state
+    (decode : Yojson.Safe.t -> 'a)
+    (text : Jstr.t)
+    : 'a T.fetch_state
+  =
   match Yojson.Safe.from_string (Jstr.to_string text) with
   | json ->
-    (* Server returns a top-level error envelope on lookup failure;
-       reject those by checking for an "error" field at the top
-       level (artifact_response and provenance_response shapes never
-       carry one). *)
-    (match Yojson.Safe.Util.member "error" json with
-     | `String _ -> None
-     | _ -> Some json)
-  | exception _ -> None
-;;
-
-let parse_detail (text : Jstr.t) : Multimodal_detail_types.detail option =
-  Option.map (parse_json_or_error text) ~f:Multimodal_detail_types.detail_of_yojson
-;;
-
-let parse_provenance (text : Jstr.t)
-  : Multimodal_detail_types.provenance option
-  =
-  Option.map (parse_json_or_error text)
-    ~f:Multimodal_detail_types.provenance_of_yojson
+    (match T.classify_json json with
+     | T.Ok_json j -> T.Loaded (decode j)
+     | T.Error_envelope_msg _ -> T.NotFound)
+  | exception _ -> T.Error "invalid JSON response"
 ;;
 
 let fetch_text url =
@@ -49,24 +47,26 @@ let fetch_text url =
 let fetch ~id : unit =
   Bonsai.Expert.Var.set
     Multimodal_detail_var.selected_id_var (Some id);
-  Bonsai.Expert.Var.set Multimodal_detail_var.detail_var None;
-  Bonsai.Expert.Var.set Multimodal_detail_var.provenance_var None;
-  Fut.await (fetch_text (detail_endpoint id)) (function
-    | Ok text ->
-      Bonsai.Expert.Var.set
-        Multimodal_detail_var.detail_var
-        (parse_detail text)
-    | Error _ -> ());
-  Fut.await (fetch_text (provenance_endpoint id)) (function
-    | Ok text ->
-      Bonsai.Expert.Var.set
-        Multimodal_detail_var.provenance_var
-        (parse_provenance text)
-    | Error _ -> ())
+  Bonsai.Expert.Var.set Multimodal_detail_var.detail_var T.Loading;
+  Bonsai.Expert.Var.set Multimodal_detail_var.provenance_var T.Loading;
+  Fut.await (fetch_text (detail_endpoint id)) (fun result ->
+      let st =
+        match result with
+        | Ok text -> body_to_state T.detail_of_yojson text
+        | Error _ -> T.Error "fetch failed"
+      in
+      Bonsai.Expert.Var.set Multimodal_detail_var.detail_var st);
+  Fut.await (fetch_text (provenance_endpoint id)) (fun result ->
+      let st =
+        match result with
+        | Ok text -> body_to_state T.provenance_of_yojson text
+        | Error _ -> T.Error "fetch failed"
+      in
+      Bonsai.Expert.Var.set Multimodal_detail_var.provenance_var st)
 ;;
 
 let clear () : unit =
   Bonsai.Expert.Var.set Multimodal_detail_var.selected_id_var None;
-  Bonsai.Expert.Var.set Multimodal_detail_var.detail_var None;
-  Bonsai.Expert.Var.set Multimodal_detail_var.provenance_var None
+  Bonsai.Expert.Var.set Multimodal_detail_var.detail_var T.Idle;
+  Bonsai.Expert.Var.set Multimodal_detail_var.provenance_var T.Idle
 ;;

--- a/dashboard_bonsai/src/multimodal_detail_types.ml
+++ b/dashboard_bonsai/src/multimodal_detail_types.ml
@@ -29,8 +29,35 @@ type provenance =
   ; descendants : string list
   }
 
+(** Tier F2-ux — fetch state for the detail/provenance vars.
+
+    [Idle]     : nothing selected; the panel is hidden.
+    [Loading]  : selection set, fetch in flight.
+    [Loaded x] : success, payload available.
+    [NotFound] : server returned an error envelope ([{"error":"..."}]),
+                 most commonly because the id does not resolve.
+    [Error s]  : everything else (network, CORS, JSON parse failure).
+                 [s] is operator-facing; English short string. *)
+type 'a fetch_state =
+  | Idle
+  | Loading
+  | Loaded of 'a
+  | NotFound
+  | Error of string
+
 let pretty_of json =
   Yojson.Safe.pretty_to_string ~std:true json
+
+(** Classify a parsed JSON response: [{"error": ...}] envelope ⇒
+    [Error_envelope_msg]; any other shape ⇒ [Ok_json json]. *)
+type json_classification =
+  | Ok_json of Yojson.Safe.t
+  | Error_envelope_msg of string
+
+let classify_json (json : Yojson.Safe.t) : json_classification =
+  match Yojson.Safe.Util.member "error" json with
+  | `String s -> Error_envelope_msg s
+  | _ -> Ok_json json
 
 let detail_of_yojson (json : Yojson.Safe.t) : detail =
   let string_field name =

--- a/dashboard_bonsai/src/multimodal_detail_var.ml
+++ b/dashboard_bonsai/src/multimodal_detail_var.ml
@@ -1,20 +1,28 @@
-(** Tier F2 — Bonsai.Expert.Var holders for the detail panel.
+(** Tier F2-ux — Bonsai.Expert.Var holders for the detail panel.
 
-    Three independent vars instead of one merged record so each
-    parallel fetch ([/get] + [/provenance]) writes only its own slot
-    without needing a synchronous peek of the other slot. The view
-    reads all three reactively via [Bonsai.Expert.Var.value]. *)
+    Three independent vars; each parallel fetch ([/get] + [/provenance])
+    writes only its own slot. The view reads all three reactively via
+    [Bonsai.Expert.Var.value].
+
+    Detail and provenance are now [_ fetch_state] (Idle/Loading/Loaded/
+    NotFound/Error) so the panel can render distinct UI for each phase
+    instead of collapsing all failure modes into a perpetual loading
+    spinner. *)
 
 let selected_id_var : string option Bonsai.Expert.Var.t =
   Bonsai.Expert.Var.create None
 ;;
 
-let detail_var : Multimodal_detail_types.detail option Bonsai.Expert.Var.t =
-  Bonsai.Expert.Var.create None
+let detail_var
+  : Multimodal_detail_types.detail Multimodal_detail_types.fetch_state
+      Bonsai.Expert.Var.t
+  =
+  Bonsai.Expert.Var.create Multimodal_detail_types.Idle
 ;;
 
 let provenance_var
-  : Multimodal_detail_types.provenance option Bonsai.Expert.Var.t
+  : Multimodal_detail_types.provenance Multimodal_detail_types.fetch_state
+      Bonsai.Expert.Var.t
   =
-  Bonsai.Expert.Var.create None
+  Bonsai.Expert.Var.create Multimodal_detail_types.Idle
 ;;

--- a/dashboard_bonsai/src/multimodal_detail_view.ml
+++ b/dashboard_bonsai/src/multimodal_detail_view.ml
@@ -112,6 +112,23 @@ stylesheet
     font-style: italic;
     color: var(--color-fg-muted);
   }
+  .not_found {
+    font-family: 'EB Garamond', Georgia, serif;
+    color: var(--color-fg-muted);
+    padding: 0.75rem;
+    border: 1px dashed color-mix(in oklab, var(--color-border-default) 70%, transparent);
+    border-radius: 4px;
+    text-align: center;
+  }
+  .error {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--text-bright);
+    background: color-mix(in oklab, var(--accent-blood) 18%, transparent);
+    border: 1px solid color-mix(in oklab, var(--accent-blood) 50%, transparent);
+    padding: 0.6rem 0.75rem;
+    border-radius: 4px;
+  }
   .created_by {
     font-family: 'EB Garamond', Georgia, serif;
     font-style: italic;
@@ -183,40 +200,83 @@ let render_provenance (p : Multimodal_detail_types.provenance) : Node.t =
     ]
 ;;
 
+module T = Multimodal_detail_types
+
+let header_for_id (id : string) : Node.t =
+  Node.div
+    ~attrs:[ Style.head ]
+    [ Node.div
+        ~attrs:[ Style.head_left ]
+        [ Node.span ~attrs:[ Style.head_id ] [ Node.text id ] ]
+    ; close_button
+    ]
+;;
+
+(** Detail-side rendering for each fetch_state. When the state is
+    [Loaded d], we use [render_detail d] which embeds its own header
+    (with kind + id). All other states fall back to a simple
+    id-only header so the close button stays available. *)
+let render_detail_state
+    ~(id : string)
+    (state : T.detail T.fetch_state)
+    : Node.t list
+  =
+  match state with
+  | T.Loaded d -> render_detail d
+  | T.Loading ->
+    [ header_for_id id
+    ; Node.div ~attrs:[ Style.loading ] [ Node.text "loading detail…" ]
+    ]
+  | T.Idle ->
+    (* Defensive — should not occur while selected_id is Some,
+       but render close-able header so the operator can clear. *)
+    [ header_for_id id ]
+  | T.NotFound ->
+    [ header_for_id id
+    ; Node.div
+        ~attrs:[ Style.not_found ]
+        [ Node.text "artifact not found" ]
+    ]
+  | T.Error msg ->
+    [ header_for_id id
+    ; Node.div
+        ~attrs:[ Style.error ]
+        [ Node.text ("detail unavailable: " ^ msg) ]
+    ]
+;;
+
+let render_provenance_state
+    (state : T.provenance T.fetch_state)
+    : Node.t
+  =
+  match state with
+  | T.Loaded p -> render_provenance p
+  | T.Loading ->
+    Node.div
+      ~attrs:[ Style.loading ]
+      [ Node.text "loading provenance…" ]
+  | T.Idle -> Node.none
+  | T.NotFound ->
+    Node.div
+      ~attrs:[ Style.not_found ]
+      [ Node.text "no provenance recorded" ]
+  | T.Error msg ->
+    Node.div
+      ~attrs:[ Style.error ]
+      [ Node.text ("provenance unavailable: " ^ msg) ]
+;;
+
 let view_of_state
     ~(selected_id : string option)
-    ~(detail : Multimodal_detail_types.detail option)
-    ~(provenance : Multimodal_detail_types.provenance option)
+    ~(detail : T.detail T.fetch_state)
+    ~(provenance : T.provenance T.fetch_state)
     : Node.t
   =
   match selected_id with
   | None -> Node.none
   | Some id ->
-    let header_when_loading =
-      Node.div
-        ~attrs:[ Style.head ]
-        [ Node.div
-            ~attrs:[ Style.head_left ]
-            [ Node.span ~attrs:[ Style.head_id ] [ Node.text id ] ]
-        ; close_button
-        ]
-    in
-    let body =
-      match detail with
-      | None ->
-        [ header_when_loading
-        ; Node.div ~attrs:[ Style.loading ] [ Node.text "loading detail…" ]
-        ]
-      | Some d -> render_detail d
-    in
-    let prov_section =
-      match provenance with
-      | None ->
-        Node.div
-          ~attrs:[ Style.loading ]
-          [ Node.text "loading provenance…" ]
-      | Some p -> render_provenance p
-    in
+    let body = render_detail_state ~id detail in
+    let prov_section = render_provenance_state provenance in
     Node.div ~attrs:[ Style.panel ] (body @ [ prov_section ])
 ;;
 


### PR DESCRIPTION
## Summary

Replaces the `_ option` vars in the multimodal detail panel with a generic `_ fetch_state` variant so the panel can render **distinct** UI for each phase instead of collapsing every failure mode into a perpetual "loading…" spinner.

```ocaml
type 'a fetch_state =
  | Idle
  | Loading
  | Loaded of 'a
  | NotFound
  | Error of string
```

## Classification rule

In `body_to_state`:

| Outcome | State |
|---------|-------|
| `Brr_io.Fetch.url` returns `Error _` | `Error "fetch failed"` |
| Body fails `Yojson.from_string` | `Error "invalid JSON response"` |
| Body has top-level `"error"` field | `NotFound` |
| Otherwise | `Loaded (decode body)` |

The error envelope is the server's only failure shape (multimodal routes return `{"error": "..."}` for invalid id / not found / missing param). We collapse all envelope variants to `NotFound` because the operator's actionable question is "is this id resolvable?" — distinguishing 404 vs 400 in the UI was not requested.

## View additions

- **Loading**: italic "loading detail…" / "loading provenance…"
- **NotFound**: dashed-border muted "artifact not found" / "no provenance recorded"
- **Error**: red-tinted box with the operator-facing message
- **Idle**: defensive close-able header (shouldn't occur while `selected_id = Some`, but render close button anyway)

## Files

| File | Change |
|------|--------|
| `multimodal_detail_types.ml` | + `fetch_state` variant, + `classify_json` helper |
| `multimodal_detail_var.ml` | `option` → `fetch_state`; default `Idle` |
| `multimodal_detail_fetch.ml` | `body_to_state` classifier; explicit Loading/Loaded/NotFound/Error transitions |
| `multimodal_detail_view.ml` | `render_detail_state` + `render_provenance_state` 5-arm match; new CSS for `.not_found` and `.error` |

## Test plan

- [x] `dune build --root dashboard_bonsai` GREEN under bonsai-dashboard switch
- [x] JS bundle emit verified
- [ ] Live: card click → Loading; valid id → Loaded; invalid id (or strict-auth 401 if #12279 not merged) → NotFound; offline → Error

## Coordinated with

- **#12279** (server: whitelist multimodal as public_read) — once that lands, strict-mode deployments get `Loaded` instead of `NotFound`. Both PRs are independent in code; either can merge first.