### PR TITLE
feat(keeper): emit Prometheus counter for Skip_idle wake resume (#12271 follow-up)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -704,10 +704,15 @@ let run_smart_heartbeat_gate
             [should_emit] does not immediately re-classify as Skip_idle,
             and let the cycle proceed (presence/board/turn dispatch).
             Spec: KeeperHeartbeat.tla HeartbeatTick — turn_state must
-            transition to "running". *)
+            transition to "running". Prometheus counter is the operator-
+            visible positive signal for the #12271 fix path. *)
          Log.Keeper.info
            "smart heartbeat: idle wake — cycle resumed (post=consumed)";
-         last_heartbeat_cycle_ts := Time_compat.now ()
+         last_heartbeat_cycle_ts := Time_compat.now ();
+         Prometheus.inc_counter
+           Prometheus.metric_keeper_skip_idle_wake_resumed
+           ~labels:[ ("keeper", meta_current.name) ]
+           ()
        | Keeper_keepalive_signal.Stopped | Keeper_keepalive_signal.Timeout -> ());
       outcome
     | Heartbeat_smart.Emit ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -647,6 +647,17 @@ let metric_keeper_lifecycle_callback_failures =
   "masc_keeper_lifecycle_callback_failures_total"
 let metric_keeper_event_bus_drain = "masc_keeper_event_bus_drain_total"
 let metric_keeper_dead_total = "masc_keeper_dead_total"
+(* Positive signal for the Skip_idle + Woken gate-promotion path added
+   by #12271. Increments every time run_smart_heartbeat_gate observes
+   that an external wakeup_keeper call cut a Skip_idle backoff sleep
+   short and the cycle was resumed (KeeperHeartbeat.tla HeartbeatTick
+   action). A zero rate after operator-visible board signals to a Live
+   keeper means the fix path is not firing — either the wakeup never
+   reached the atomic, or a regression silently re-introduced
+   MissedWakeup. Pair with stale_termination_by_class for full
+   positive/negative coverage. Labels: keeper. *)
+let metric_keeper_skip_idle_wake_resumed =
+  "masc_keeper_skip_idle_wake_resumed_total"
 let metric_keeper_near_exhaustion_total = "masc_keeper_near_exhaustion_total"
 (* PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
    per keeper. Counter increments on each strike; a strike at
@@ -968,6 +979,13 @@ let init () =
     "Total keeper transitions to Dead phase after the supervisor exhausts \
      max_restarts. Labeled by keeper and reason. Any rate >0 is operator-\
      actionable: the supervisor will not retry the keeper."
+    Counter;
+  add metric_keeper_skip_idle_wake_resumed
+    "Total cycles where an external wakeup_keeper / board signal cut a \
+     Skip_idle backoff sleep short and the heartbeat cycle was resumed \
+     (cycle_continues_after_wake -> true). Positive signal for the \
+     #12271 fix; pairs with masc_keeper_stale_termination_by_class_total \
+     {class=idle_turn} which should drop in proportion. Labels: keeper."
     Counter;
   add metric_keeper_near_exhaustion_total
     "Total keeper restart attempts at restart_count = max_restarts - 1, \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -333,6 +333,20 @@ val metric_keeper_dead_total : string
     Labeled by [keeper] and [reason]. Operators should alert on any rate >0:
     by construction Dead means the supervisor gave up and no further
     restart will be attempted. *)
+
+val metric_keeper_skip_idle_wake_resumed : string
+(** Positive signal for the #12271 Skip_idle + Woken fix path. Increments
+    each time [run_smart_heartbeat_gate] observes an external [wakeup_keeper]
+    cut a Skip_idle backoff sleep short and the cycle was resumed
+    ([cycle_continues_after_wake] -> [true]). Operator-meaningful pair with
+    [masc_keeper_stale_termination_by_class_total] (class=idle_turn): a
+    healthy fleet should show non-zero rates here proportional to inbound
+    board signals, with the idle_turn kill rate trending toward zero. A
+    zero rate after operator-visible signals suggests either the wakeup
+    never reached the atomic, or a regression silently re-introduced
+    MissedWakeup (KeeperHeartbeat.tla bug action).
+    Labels: [keeper]. *)
+
 val metric_keeper_near_exhaustion_total : string
 (** Total times a keeper restart attempt landed at
     [restart_count = max_restarts - 1], i.e. one attempt away from Dead.

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -185,6 +185,50 @@ let test_after_wake_emit_unchanged () =
   check bool "Emit + Woken -> continues" true
     (KK.cycle_continues_after_wake HS.Emit KKS.Woken)
 
+(* ── Operator telemetry: positive signal counter ───────────────────
+   Sibling to masc_keeper_stale_termination_by_class_total (negative).
+   Operators read these two together: rate(positive) > 0 + rate(negative
+   {class=idle_turn}) trending to 0 = fix is firing. Both metrics must
+   be registered (no dead series), accept a [keeper] label, and increment
+   monotonically. *)
+
+module Prom = Masc_mcp.Prometheus
+
+let test_skip_idle_wake_resumed_metric_registered () =
+  let labels = [ ("keeper", "test_keeper_a") ] in
+  let before =
+    Prom.metric_value_or_zero
+      Prom.metric_keeper_skip_idle_wake_resumed ~labels ()
+  in
+  Prom.inc_counter
+    Prom.metric_keeper_skip_idle_wake_resumed ~labels ();
+  let after =
+    Prom.metric_value_or_zero
+      Prom.metric_keeper_skip_idle_wake_resumed ~labels ()
+  in
+  check (float 0.001) "counter increments by 1" 1.0 (after -. before)
+
+let test_skip_idle_wake_resumed_label_isolation () =
+  (* Per-keeper labels must not bleed: a delta on keeper_a should not
+     show on keeper_b. Otherwise operators cannot attribute the fix
+     activity to specific keepers in fleet dashboards. *)
+  let la = [ ("keeper", "test_keeper_iso_a") ] in
+  let lb = [ ("keeper", "test_keeper_iso_b") ] in
+  let b_before =
+    Prom.metric_value_or_zero
+      Prom.metric_keeper_skip_idle_wake_resumed ~labels:lb ()
+  in
+  Prom.inc_counter
+    Prom.metric_keeper_skip_idle_wake_resumed ~labels:la ();
+  Prom.inc_counter
+    Prom.metric_keeper_skip_idle_wake_resumed ~labels:la ();
+  let b_after =
+    Prom.metric_value_or_zero
+      Prom.metric_keeper_skip_idle_wake_resumed ~labels:lb ()
+  in
+  check (float 0.001) "keeper_b counter unchanged" 0.0
+    (b_after -. b_before)
+
 let test_status_tick_usage_json_includes_cache_fields () =
   let usage = KK.status_tick_usage_json () in
   let int_member key =
@@ -246,6 +290,12 @@ let () =
         `Quick test_after_wake_busy_unchanged;
       test_case "Emit outcome-agnostic"
         `Quick test_after_wake_emit_unchanged;
+    ];
+    "operator_telemetry", [
+      test_case "skip_idle_wake_resumed counter registered"
+        `Quick test_skip_idle_wake_resumed_metric_registered;
+      test_case "per-keeper label isolation"
+        `Quick test_skip_idle_wake_resumed_label_isolation;
     ];
     "status_tick_usage", [
       test_case "status tick usage preserves cache fields" `Quick


### PR DESCRIPTION
## Summary

#12271 closed the MissedWakeup gap — Skip_idle + Woken now resumes the heartbeat cycle instead of absorbing the wakeup. But the runtime had no operator-visible signal that the fix path was actually firing: the only adjacent counter is the negative one (\`masc_keeper_stale_termination_*\`). Without the positive counterpart, an operator looking at a sleepy keeper had no way to distinguish *fix is working, just no signals arriving* from *fix path is dead, MissedWakeup regressed*.

This PR adds the positive counter \`masc_keeper_skip_idle_wake_resumed_total\` with a \`keeper\` label, incremented from \`run_smart_heartbeat_gate\` on every Skip_idle + Woken promotion.

## Operator usage

A healthy fleet should show:

\`\`\`
rate(masc_keeper_skip_idle_wake_resumed_total[5m]) > 0
  (proportional to inbound board signals to Live keepers)

rate(masc_keeper_stale_termination_by_class_total{class=\"idle_turn\"}[5m]) -> 0
  (kills attributed to the bug should drop to zero post-#12271)
\`\`\`

A zero positive rate during operator-visible board activity is the regression signal — wakeup is not reaching the atomic, or \`cycle_continues_after_wake\` was reverted, or the Skip_idle branch is unreachable.

| Signal | Direction | Counter |
|---|---|---|
| Idle keeper resumed by external wakeup | positive | \`masc_keeper_skip_idle_wake_resumed_total\` (NEW) |
| Idle keeper killed by stale watchdog | negative | \`masc_keeper_stale_termination_by_class_total{class=idle_turn}\` (existing) |
| Idle keeper killed during turn (other class) | negative | same metric, \`class=in_turn_hung\` / \`noop_failure_loop\` |

## Changes

- \`lib/prometheus.ml\` / \`.mli\`: register \`masc_keeper_skip_idle_wake_resumed_total{keeper}\` counter with full operator-facing help text.
- \`lib/keeper/keeper_heartbeat_loop.ml\`: increment in the Skip_idle + Woken branch immediately after stamping \`last_heartbeat_cycle_ts\`.
- \`test/test_smart_heartbeat_keepalive.ml\`: two new tests under \`operator_telemetry\` group — counter increment + per-keeper label isolation (regression guard against accidentally dropping the \`keeper\` label, which would collapse the fleet view to one series).

## Test plan

- [x] \`dune build @check --root .\` — pass
- [x] \`dune exec test/test_smart_heartbeat_keepalive.exe --root .\` — **25/25 pass** (23 existing + 2 new under \`operator_telemetry\`)
- [ ] CI green
- [ ] Live: after server restart, scrape \`/metrics\` and confirm \`masc_keeper_skip_idle_wake_resumed_total\` series appears with keeper labels once any board signal hits an idle keeper.

## Blast radius

Pure additive: one new counter, one increment site, no behavioural change. The Prometheus subsystem is already locked under \`with_lock\` so the increment is fiber-safe. No schema or persistence changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)