### PR TITLE
feat(keeper): K4c crash-path teardown — drop accumulator on supervisor unregisters

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -569,6 +569,7 @@ let cleanup_dead_tombstone (ctx : _ context)
               false
       in
       Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
+      Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
       if persisted_paused then begin
         publish_lifecycle
           ~event:(Keeper_lifecycle_events.Custom_event
@@ -584,6 +585,7 @@ let cleanup_dead_tombstone (ctx : _ context)
       end
   | Ok None ->
       Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
+      Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
       publish_lifecycle
         ~event:(Keeper_lifecycle_events.Custom_event
                   { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
@@ -591,6 +593,7 @@ let cleanup_dead_tombstone (ctx : _ context)
       Log.Keeper.warn "%s: dead tombstone unregistered (meta missing)" entry.name
   | Error err ->
       Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
+      Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
       publish_lifecycle
         ~event:(Keeper_lifecycle_events.Custom_event
                   { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
@@ -911,7 +914,10 @@ let sweep_and_recover (ctx : _ context) =
                end))
   ) entries;
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
-    Keeper_registry.unregister ~base_path entry.name
+    Keeper_registry.unregister ~base_path entry.name;
+    (* K4c — restart-budget exhaustion: keeper is permanently
+       removed (no respawn), so reclaim its accumulator slot. *)
+    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name
   ) !to_unregister;
   List.iter (fun ((entry : Keeper_registry.registry_entry), msg) ->
     (* RFC-0002: dispatch budget exhaustion before marking dead *)
@@ -997,7 +1003,9 @@ let sweep_and_recover (ctx : _ context) =
     | _ ->
         Log.Keeper.error "%s: cannot read meta for restart, removing"
           old_entry.name;
-        Keeper_registry.unregister ~base_path old_entry.name
+        Keeper_registry.unregister ~base_path old_entry.name;
+        (* K4c — restart-meta read failure: keeper abandoned, drop. *)
+        Keeper_tool_emission_hook.drop_keeper_accumulator old_entry.name
   ) restart_list;
   (* Phase 2: restore paused reconcile gates whose approval queue was lost
      on restart. The queue itself is in-memory, but paused keeper meta is


### PR DESCRIPTION
## Summary

Wires `Keeper_tool_emission_hook.drop_keeper_accumulator` into the 5 non-lifecycle keeper-removal sites in `keeper_supervisor.ml` so the K4c per-keeper accumulator registry does not leak slots across crashes, budget exhaustion, or meta-read failures.

## Why this PR exists

PR #12275 wired teardown into the operator-driven path (`handle_keeper_down` with `remove_meta=true`). But keepers also disappear from the registry without going through that handler — when crashes accumulate, when restart budget is exhausted, or when meta becomes unreadable. Without this PR, those paths leak accumulator slots until process exit.

## Sites covered (5, all permanent removal)

| File:line | Trigger | Type |
|-----------|---------|------|
| `keeper_supervisor.ml:572` | `cleanup_dead_tombstone` — paused write OK | dead, no respawn |
| `keeper_supervisor.ml:587` | `cleanup_dead_tombstone` — meta missing | dead, no respawn |
| `keeper_supervisor.ml:594` | `cleanup_dead_tombstone` — meta error | dead, no respawn |
| `keeper_supervisor.ml:917` | restart-budget exhaustion (`to_unregister`) | budget burned |
| `keeper_supervisor.ml:1004` | restart-list meta-read failure | abandoned |

## Sites deliberately NOT touched (immediate respawn)

| File:line | Why skip |
|-----------|----------|
| `keeper_supervisor.ml:430` | `unregister` → immediately followed by `supervise_keepalive` (respawn under same name) |
| `keeper_keepalive.ml:544` | `unregister` → new keeper takes over same name |

For respawn cases the slot stays useful for the new instance; dropping there would discard items captured by the previous fiber that the new fiber's first-turn drain would have reaped.

## Coverage gap closed

With this PR + #12275, all 7 keeper-disappearance paths surveyed by the audit are accounted for:
- 5 permanent (this PR) → drop
- 2 respawn → keep
- 1 operator (#12275) → drop

## Test plan

- [x] `dune build --root .` GREEN
- [x] `test_keeper_tool_emission_hook` 14/14 GREEN (no regression)
- [ ] Live: forcibly crash a keeper, confirm `registered_keeper_names()` shrinks (cannot exercise without running supervisor; the surface contract is the same one PR #12275 tested)