### PR TITLE
ci: update OCaml structure baseline after keeper prompt split

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 2,
+  "keeper_mli_missing": 1,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 993,
+  "lib_dune_lines": 994,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 1
 }


### PR DESCRIPTION
## Summary
- regenerate OCaml structure baseline after #12277 landed on main
- record keeper_mli_missing improvement 2 -> 1 and intentional lib_dune_lines 993 -> 994
- pair the lib/dune growth with existing follow-up #11702

## Verification
- scripts/ocaml-structure-ratchet.sh
- scripts/stringly-boundary-ratchet.sh
- scripts/oas-boundary-ratchet.sh

Ratchet-Follow-Up: #11702