### PR TITLE
feat(dashboard): eslint guard for direct KpiStrip/KpiCell imports (RFC 0017 §7c)

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -91,4 +91,71 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-member-access': 'off',
     },
   },
+  // RFC 0017 — KpiStrip island guard.
+  //
+  // Direct imports of `./kpi-strip` and `./kpi-cell` are reserved for the
+  // wrapper itself and the test shim path. Production code must reach
+  // them through `KpiStripIsland`. The guard exists because the
+  // sustained-load measurement (RFC 0017 §7c, 2026-04-30) showed that
+  // KpiStripIsland is roughly 2× slower than the Preact original at our
+  // production scale (n≈16, ~30 ms `useEffect` overhead per island)
+  // — adding more direct callers would *worsen* SSE back-pressure on
+  // streaming dashboards, while adding more island callers also worsens
+  // it. Until a synchronous-mount spike eliminates the `useEffect`
+  // delay, neither path should grow without explicit owner sign-off.
+  {
+    // Scope intentionally narrow: only `src/components/**/*.ts(x)` reach
+    // for KpiStrip / KpiCell. Restricting the block keeps unrelated
+    // files (workers, lib helpers with their own react-hooks disable
+    // comments) untouched by this guard's parser configuration.
+    files: ['src/components/**/*.{ts,tsx}'],
+    ignores: [
+      // The originals themselves.
+      'src/components/kpi-strip.ts',
+      'src/components/kpi-cell.ts',
+      // The Preact wrapper re-exports them and the Solid factory does
+      // not import them.
+      'src/components/kpi-strip-island.ts',
+      'src/components/kpi-strip-island-solid.solid.tsx',
+      // Caller tests register a `vi.doMock('./kpi-strip-island', ...)`
+      // shim factory built from the original Preact KpiStrip + KpiCell.
+      'src/components/*.test.ts',
+      'src/components/*.test.tsx',
+    ],
+    languageOptions: {
+      parser: tseslint.parser,
+    },
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+      // Plugin loaded (rules off by default) so existing
+      // `// eslint-disable-next-line react-hooks/exhaustive-deps`
+      // comments in components/common/virtual-list.ts and
+      // components/fsm-hub.ts (outside TARGET_FILES) don't surface as
+      // "Definition for rule was not found".
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      // `@typescript-eslint/no-restricted-imports` over the core rule
+      // because we want `allowTypeImports` — the existing
+      // `import type { KpiCellKind } from './kpi-cell'` in
+      // `governance.ts` is harmless (no runtime), only runtime imports
+      // need the guard.
+      '@typescript-eslint/no-restricted-imports': ['error', {
+        paths: [
+          {
+            name: './kpi-strip',
+            message:
+              'Use KpiStripIsland from ./kpi-strip-island instead. Direct KpiStrip imports are reserved for the wrapper and the test shim path. See RFC 0017 §7c — measurement (2026-04-30) showed island throughput is ~half of Preact at n=16, so do not assume migration is a perf win.',
+            allowTypeImports: true,
+          },
+          {
+            name: './kpi-cell',
+            message:
+              'Use KpiStripIsland from ./kpi-strip-island instead. Direct KpiCell imports are reserved for the wrapper and the test shim path. See RFC 0017 §7c.',
+            allowTypeImports: true,
+          },
+        ],
+      }],
+    },
+  },
 )


### PR DESCRIPTION
## Why

After PR #12280 measured KpiStripIsland at ~2× slower throughput than the Preact original at n=16, we should keep both paths intentional rather than letting either grow silently. This adds a lint-time guard that points new callers at RFC 0017 §7c instead of the wrong default.

## The rule

\`@typescript-eslint/no-restricted-imports\` (chosen over the core rule for \`allowTypeImports\`):

| | |
|---|---|
| Scope | \`src/components/**/*.{ts,tsx}\` |
| Allowlist | \`kpi-strip.ts\`, \`kpi-cell.ts\`, \`kpi-strip-island.ts\`, \`kpi-strip-island-solid.solid.tsx\`, \`*.test.{ts,tsx}\` |
| Blocked | runtime imports of \`./kpi-strip\` and \`./kpi-cell\` |
| Allowed | \`import type ...\` (governance.ts still imports \`KpiCellKind\` as type) |

Tests register \`vi.doMock('./kpi-strip-island', ...)\` shims built from the original Preact components, so the test allowlist is necessary for the existing test pattern.

The block also loads \`react-hooks\` (rules off by default) so existing \`// eslint-disable-next-line react-hooks/exhaustive-deps\` comments in two non-TARGET_FILES (\`virtual-list.ts\`, \`fsm-hub.ts\`) don't surface as "Definition for rule was not found" once the new block parses them.

## Verification

| Step | Result |
|------|--------|
| \`pnpm lint\` | exit 0, only the 3 pre-existing unused-eslint-disable warnings |
| Negative test (temp file with runtime \`./kpi-strip\` + \`./kpi-cell\` imports) | both flagged with full RFC 0017 §7c message |
| Type-only import (\`import type { KpiCellKind } from './kpi-cell'\`) | not flagged |
| \`pnpm typecheck\` | green |
| \`vitest --config vitest.solid.config.ts\` | 128/128 pass |
| \`pnpm build\` | success |

## Sample error message

```
'./kpi-strip' import is restricted from being used.
Use KpiStripIsland from ./kpi-strip-island instead. Direct KpiStrip imports are reserved for the wrapper and the test shim path. See RFC 0017 §7c — measurement (2026-04-30) showed island throughput is ~half of Preact at n=16, so do not assume migration is a perf win
  @typescript-eslint/no-restricted-imports
```

## Companion work

Spike on a synchronous-mount strategy that could eliminate the 30 ms \`useEffect\` overhead is in [feature/ds-v2-rfc0017-sync-mount-spike](https://github.com/jeong-sik/masc-mcp/tree/feature/ds-v2-rfc0017-sync-mount-spike) (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)