### PR TITLE
fix(keeper): suppress stale watchdog during semaphore waits

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -285,6 +285,28 @@ let with_in_turn_liveness_pulse
     f
 ;;
 
+type semaphore_wait_observation_kind =
+  | Semaphore_wait_pending
+  | Semaphore_wait_timeout
+
+let semaphore_wait_observation_reasons ~kind ~channel =
+  let kind_reason =
+    match kind with
+    | Semaphore_wait_pending -> "semaphore_wait_pending"
+    | Semaphore_wait_timeout -> "semaphore_wait_timeout"
+  in
+  [
+    kind_reason;
+    "peers_holding_slot";
+    "channel_" ^ Keeper_world_observation.channel_to_string channel;
+  ]
+
+let record_semaphore_wait_observation ~base_path ~keeper_name ~channel ~kind =
+  Keeper_registry.record_skip_reasons
+    ~base_path
+    keeper_name
+    ~reasons:(semaphore_wait_observation_reasons ~kind ~channel)
+
 let run_keepalive_unified_turn
       ~(ctx : _ context)
       ~(meta_after_triage : keeper_meta)
@@ -437,6 +459,14 @@ let run_keepalive_unified_turn
       then meta_after_triage
       else if should_run_turn
       then (
+        (* Admission wait happens before [mark_turn_started], so the stale
+           watchdog would otherwise see an idle keeper while the fiber is
+           legitimately blocked behind turn-capacity backpressure. *)
+        record_semaphore_wait_observation
+          ~base_path:ctx.config.base_path
+          ~keeper_name:meta_after_triage.name
+          ~channel:turn_decision.channel
+          ~kind:Semaphore_wait_pending;
         match
           Keeper_turn_slot.with_keeper_turn_slot ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel (fun ~semaphore_wait_ms ->
@@ -541,6 +571,11 @@ let run_keepalive_unified_turn
              keeper failure. Skip this cycle and let the next heartbeat retry
              once a slot opens up. Meta is left untouched so failure counters
              do not tick. *)
+          record_semaphore_wait_observation
+            ~base_path:ctx.config.base_path
+            ~keeper_name:meta_after_triage.name
+            ~channel:turn_decision.channel
+            ~kind:Semaphore_wait_timeout;
           let auto_avail = Eio.Semaphore.get_value Keeper_turn_slot.autonomous_turn_semaphore in
           let turn_avail = Eio.Semaphore.get_value Keeper_turn_slot.turn_semaphore in
           Log.Keeper.warn

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -49,6 +49,22 @@ val with_in_turn_liveness_pulse :
   stop:bool Atomic.t ->
   (unit -> 'b) -> 'b
 
+type semaphore_wait_observation_kind =
+  | Semaphore_wait_pending
+  | Semaphore_wait_timeout
+
+val semaphore_wait_observation_reasons :
+  kind:semaphore_wait_observation_kind ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  string list
+
+val record_semaphore_wait_observation :
+  base_path:string ->
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  kind:semaphore_wait_observation_kind ->
+  unit
+
 val run_keepalive_unified_turn :
   ctx:'a context ->
   meta_after_triage:keeper_meta ->

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -18,6 +18,18 @@ let counter_for ~keeper ~channel =
     ]
     ()
 
+let make_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc [
+         ("name", `String name);
+         ("agent_name", `String name);
+         ("trace_id", `String ("trace-" ^ name));
+       ])
+  with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
+
 let test_metric_name_stable () =
   Alcotest.(check string)
     "semaphore wait timeout canonical metric name"
@@ -70,6 +82,51 @@ let test_channel_isolation () =
     before_turn
     (counter_for ~keeper ~channel:"turn")
 
+let test_wait_observation_reason_labels () =
+  Alcotest.(check (list string))
+    "pending reactive reasons"
+    [ "semaphore_wait_pending"; "peers_holding_slot"; "channel_reactive" ]
+    (Masc_mcp.Keeper_heartbeat_loop.semaphore_wait_observation_reasons
+       ~kind:Masc_mcp.Keeper_heartbeat_loop.Semaphore_wait_pending
+       ~channel:Masc_mcp.Keeper_world_observation.Reactive);
+  Alcotest.(check (list string))
+    "timeout scheduled autonomous reasons"
+    [
+      "semaphore_wait_timeout";
+      "peers_holding_slot";
+      "channel_scheduled_autonomous";
+    ]
+    (Masc_mcp.Keeper_heartbeat_loop.semaphore_wait_observation_reasons
+       ~kind:Masc_mcp.Keeper_heartbeat_loop.Semaphore_wait_timeout
+       ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous)
+
+let test_wait_observation_updates_registry_skip_stamp () =
+  let base_path =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-semaphore-wait-observation-%d" (Unix.getpid ()))
+  in
+  let keeper = "wait-observation-9771" in
+  Masc_mcp.Keeper_registry.unregister ~base_path keeper;
+  let meta = make_meta keeper in
+  ignore (Masc_mcp.Keeper_registry.register ~base_path keeper meta);
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_registry.unregister ~base_path keeper)
+    (fun () ->
+      Masc_mcp.Keeper_heartbeat_loop.record_semaphore_wait_observation
+        ~base_path
+        ~keeper_name:keeper
+        ~channel:Masc_mcp.Keeper_world_observation.Reactive
+        ~kind:Masc_mcp.Keeper_heartbeat_loop.Semaphore_wait_pending;
+      match Masc_mcp.Keeper_registry.get ~base_path keeper with
+      | Some { Masc_mcp.Keeper_registry.last_skip_observation = Some (_, reasons); _ } ->
+        Alcotest.(check (list string))
+          "pending wait stamped for watchdog suppression"
+          [ "semaphore_wait_pending"; "peers_holding_slot"; "channel_reactive" ]
+          reasons
+      | Some _ -> Alcotest.fail "last_skip_observation was not stamped"
+      | None -> Alcotest.fail "registered keeper missing")
+
 let () =
   Alcotest.run "keeper_semaphore_wait_counter_9771" [
     "metric_name", [
@@ -83,5 +140,11 @@ let () =
     "isolation", [
       Alcotest.test_case "keepers isolated" `Quick test_keeper_isolation;
       Alcotest.test_case "channels isolated" `Quick test_channel_isolation;
+    ];
+    "watchdog_observation", [
+      Alcotest.test_case "reason labels are stable" `Quick
+        test_wait_observation_reason_labels;
+      Alcotest.test_case "registry skip stamp is updated" `Quick
+        test_wait_observation_updates_registry_skip_stamp;
     ];
   ]


### PR DESCRIPTION
## Summary

- Record a keeper semaphore-wait observation before turn-slot admission blocks.
- Refresh that observation as `semaphore_wait_timeout` when admission times out and the turn is intentionally skipped.
- Pin the reason labels and registry stamp with `test_keeper_semaphore_wait_counter`.

## Product impact

This prevents the stale watchdog from killing a keeper that is alive but waiting behind fleet turn-capacity backpressure. In the live failure, `executor` was killed as `idle 327s` while nearby keepers were repeatedly logging `turn_available=0` and `semaphore wait > 60s`; that should be surfaced as slot pressure, not treated as a wedged keeper fiber.

## Evidence

- Live log, 2026-04-30T11:35:48Z: `executor: stale watchdog terminating fiber (idle 327s)`.
- Live log, same window: repeated `semaphore_wait: turn semaphore wait exceeded 60s` and `turn_available=0`.
- Local test: `env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh exec ./test/test_keeper_semaphore_wait_counter.exe`.

## Review evidence

- `test_keeper_semaphore_wait_counter_9771`: 6 tests passed after rebase onto `origin/main`.
- `git diff --check`: passed.

## Linked issue

- None. Filed from live keeper runtime evidence on 2026-04-30.
