### PR TITLE
fix(dashboard): refuse stale-keeper fallback when registry is loaded (closes #12283)

### DIFF
--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -5,7 +5,7 @@ import { fetchCascadeProfiles, updateKeeperCascade } from '../api/dashboard'
 import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
 import type { Keeper } from '../types'
-import { refreshDashboard } from '../store'
+import { refreshDashboard, keepers } from '../store'
 import { KeeperPhaseAndStage } from './keeper-phase-indicator'
 import { formatDuration } from '../lib/format-time'
 import {
@@ -127,13 +127,24 @@ export function KeeperDetailMissingState({
   keeperName: string
   onClose: () => void
 }) {
+  // #12283: split the message by registry state. If [keepers.value] is empty
+  // we are likely in a refresh transition (data still loading); if it has
+  // entries but our target is missing, the keeper is genuinely absent — most
+  // commonly a stale-watchdog kill (KeeperHeartbeat.tla idle_turn class) or
+  // an operator stop. Naming the cause lets the operator decide between
+  // "wait for refresh" and "filter is pointing at a dead keeper".
+  const liveCount = keepers.value.length
+  const isLikelyDead = liveCount > 0
+  const explanation = isLikelyDead
+    ? `현재 fleet에 ${keeperName}이(가) 없습니다 (live ${liveCount}명). watchdog 종료 또는 operator stop 가능성이 높습니다 — masc_keeper_stale_termination_total{keeper=\"${keeperName}\"} 에서 종료 시각을 확인하세요.`
+    : '레지스트리가 아직 로드되지 않았습니다. 잠시 후 자동 갱신됩니다.'
   return html`
     <div class="mx-auto flex w-full max-w-[1100px] flex-col gap-4">
       <div class="rounded-[28px] border border-[var(--color-border-default)] bg-[rgba(9,14,24,0.92)] px-6 py-6 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
         <div class="text-3xs font-semibold uppercase tracking-[0.18em] text-[var(--color-fg-muted)]">키퍼 상세</div>
         <h2 class="m-0 mt-2 text-xl font-semibold text-[var(--text-strong)]">${keeperName}</h2>
         <p class="m-0 mt-2 text-sm leading-relaxed text-[var(--text-secondary)]">
-          현재 스냅샷에서 keeper를 찾지 못했습니다. 목록으로 돌아가서 다시 선택하거나, 최신 dashboard refresh 이후 다시 열어 보세요.
+          ${explanation}
         </p>
         <div class="mt-4">
           <button

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -275,3 +275,4 @@ describe('lineageTransitionLabel', () => {
     expect(lineageTransitionLabel(4, 5)).toBe('gen 4 -> gen 5')
   })
 })
+

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -29,11 +29,12 @@ import { TimeAgo } from './common/time-ago'
 import { Checkbox } from './common/checkbox'
 import { TextArea } from './common/input'
 import type { Keeper } from '../types'
-import { invalidateDashboardCache, refreshDashboard } from '../store'
+import { invalidateDashboardCache, refreshDashboard, keepers } from '../store'
 import { hydrateKeeperStatus, selectKeeper } from '../keeper-runtime'
 import { activeKeeperName, keeperStatusDetails } from '../keeper-state'
 import { registerKeeperTurnRefresh } from '../sse-store'
 import { findKeeper } from '../lib/keeper-utils'
+import { resolveKeeperForDetail } from '../lib/keeper-detail-resolution'
 import {
   KeeperConversationPanel,
   KeeperDiagnosticSummary,
@@ -795,9 +796,13 @@ export function KeeperDetailPage() {
       : ''
   if (!keeperName) return null
 
-  const fallback = selectedKeeper.value
-  const keeper = findKeeper(keeperName)
-    ?? (fallback && (fallback.name === keeperName || fallback.agent_name === keeperName) ? fallback : null)
+  // Resolve the active keeper. See [resolveKeeperForDetail] for semantics.
+  const keeper = resolveKeeperForDetail(
+    keeperName,
+    findKeeper(keeperName),
+    selectedKeeper.value,
+    keepers.value.length,
+  )
   if (!keeper) {
     return html`<${KeeperDetailMissingState} keeperName=${keeperName} onClose=${closeKeeperDetail} />`
   }

--- a/dashboard/src/lib/keeper-detail-resolution.test.ts
+++ b/dashboard/src/lib/keeper-detail-resolution.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Keeper } from '../types'
+import { resolveKeeperForDetail } from './keeper-detail-resolution'
+
+// #12283: dead-keeper resolution. Pre-fix, the panel kept rendering a
+// stale [selectedKeeper.value] after the live registry had dropped it
+// (e.g. stale-watchdog kill), causing "insertBefore parameter 1 is not
+// of type 'Node'" downstream. The resolver now refuses the fallback
+// when the registry is non-empty AND the target is missing.
+//
+// Pure unit tests — no React render, no signal harness. Lives in
+// [src/lib/] to dodge the [src/components/keeper-detail.test.ts] mock
+// chain that breaks on lucide-preact during setup.
+describe('resolveKeeperForDetail (#12283)', () => {
+  const live: Keeper = { name: 'sangsu', agent_name: 'sangsu' } as unknown as Keeper
+  const stale: Keeper = { name: 'sangsu', agent_name: 'sangsu' } as unknown as Keeper
+
+  it('prefers the live registry hit', () => {
+    expect(resolveKeeperForDetail('sangsu', live, stale, 11)).toBe(live)
+  })
+
+  it('returns null when registry is loaded but target is absent (regression guard)', () => {
+    // Pre-fix returned the stale fallback here, leading to crash. Post-fix
+    // returns null so the caller renders the missing-state.
+    expect(resolveKeeperForDetail('sangsu', null, stale, 11)).toBeNull()
+  })
+
+  it('honors fallback during registry-empty transition', () => {
+    // Registry count = 0 means the snapshot has not loaded yet — keep
+    // the cached pin so operators do not see a flash of "missing".
+    expect(resolveKeeperForDetail('sangsu', null, stale, 0)).toBe(stale)
+  })
+
+  it('rejects fallback whose name does not match the requested keeper', () => {
+    const other: Keeper = { name: 'qa-king', agent_name: 'qa-king' } as unknown as Keeper
+    expect(resolveKeeperForDetail('sangsu', null, other, 0)).toBeNull()
+  })
+
+  it('matches fallback by agent_name', () => {
+    const aliased: Keeper = { name: 'sangsu', agent_name: 'sangsu_v2' } as unknown as Keeper
+    expect(resolveKeeperForDetail('sangsu_v2', null, aliased, 0)).toBe(aliased)
+  })
+
+  it('returns null when both live and fallback are absent', () => {
+    expect(resolveKeeperForDetail('sangsu', null, null, 11)).toBeNull()
+    expect(resolveKeeperForDetail('sangsu', null, null, 0)).toBeNull()
+  })
+})

--- a/dashboard/src/lib/keeper-detail-resolution.ts
+++ b/dashboard/src/lib/keeper-detail-resolution.ts
@@ -1,0 +1,45 @@
+// Pure resolution helper for the keeper-detail page. Extracted so unit
+// tests can exercise the logic without pulling in the React component
+// import graph (which transitively reaches lucide-preact mocks).
+//
+// Issue #12283 background: see [resolveKeeperForDetail].
+
+import type { Keeper } from '../types'
+
+/**
+ * Resolve which Keeper object to render in the detail panel.
+ *
+ * Pre-fix behavior trusted [selectedKeeper.value] (the cached pin)
+ * whenever the live registry lookup returned null. That worked across
+ * registry refresh transitions, but it also kept the panel rendering
+ * a *dead* keeper after the live registry had already dropped it (e.g.
+ * stale-watchdog kill — KeeperHeartbeat.tla idle_turn class, fixed
+ * runtime-side by #12271). Downstream panels then ran field accesses
+ * against a stale shape, eventually producing
+ * "Failed to execute 'insertBefore' on 'Node': parameter 1 is not of
+ * type 'Node'".
+ *
+ * Resolution rule:
+ * - Live registry hit wins.
+ * - The cached fallback is only honored when the live registry is empty
+ *   (likely a refresh transition); when the registry has keepers but
+ *   our target is absent, the absence is treated as real and the caller
+ *   should render the missing-state.
+ *
+ * Pure for testability — takes the live count rather than reading
+ * [keepers.value] internally so unit tests don't need a signal harness.
+ */
+export function resolveKeeperForDetail(
+  keeperName: string,
+  liveMatch: Keeper | null,
+  fallback: Keeper | null,
+  liveRegistryCount: number,
+): Keeper | null {
+  if (liveMatch) return liveMatch
+  if (fallback == null) return null
+  const fallbackMatchesName =
+    fallback.name === keeperName || fallback.agent_name === keeperName
+  if (!fallbackMatchesName) return null
+  // Trust the cached fallback only during registry-empty transitions.
+  return liveRegistryCount === 0 ? fallback : null
+}


### PR DESCRIPTION
Closes #12283.

## Summary

\`KeeperDetailPage\` previously always trusted \`selectedKeeper.value\` (the cached pin) when \`findKeeper\` returned null. That bridged brief registry-refresh transitions, but it also kept the panel open when a keeper was *genuinely gone* — the most common cause being a stale-watchdog kill (\`KeeperHeartbeat.tla\` \`idle_turn\` class, root-cause fixed by #12271).

Rendering with stale data triggered downstream field accesses against an absent shape and eventually:

> Failed to execute 'insertBefore' on 'Node': parameter 1 is not of type 'Node'.

Witnessed live 2026-04-30: 5 keepers killed by stale watchdog 19:49–19:53 KST (\`taskmaster\`, \`qa-king\`, \`executor\`, \`issue_king\`, \`sangsu\`). Filter chip in URL still pointed at sangsu, so opening the agent directory blew up the whole page.

## Fix

- Extract resolution into pure helper \`resolveKeeperForDetail\` in \`dashboard/src/lib/keeper-detail-resolution.ts\` (testable without a signal harness or React render).
- New rule: trust the cached fallback **only** when the live registry is empty (\`keepers.value.length === 0\`). When the registry has entries but our target is missing, render the missing-state instead.
- \`KeeperDetailMissingState\` now splits its message by registry state:
  - \`live > 0\` (real absence): \`현재 fleet에 X이(가) 없습니다 (live N명). watchdog 종료 또는 operator stop 가능성이 높습니다 — masc_keeper_stale_termination_total{keeper=\"X\"} 에서 종료 시각을 확인하세요.\`
  - \`live === 0\` (refresh transition): \`레지스트리가 아직 로드되지 않았습니다. 잠시 후 자동 갱신됩니다.\`

| State | Pre-fix | Post-fix |
|---|---|---|
| live registry has target | render detail | render detail |
| live registry empty, fallback matches | render fallback (stale) | render fallback (transition) |
| live registry has entries, target missing, fallback matches | **render fallback (CRASH)** | **render missing-state** |
| no fallback, target missing | render missing-state | render missing-state |

## Why split the file?

The dedicated \`lib/keeper-detail-resolution.test.ts\` lives under \`src/lib\` to bypass the existing \`src/components/keeper-detail.test.ts\` setup chain that crashes on \`lucide-preact\` mocks (pre-existing issue, the whole test file fails at suite-load before any of its tests run — verified by \`git stash && vitest run\` on main). The pure resolver has no UI imports, so its tests don't need the broken setup. The component-level test file remains untouched.

## Test plan

- [x] \`npm run typecheck\` — pass
- [x] \`npx vitest run src/lib/keeper-detail-resolution.test.ts\` — **6/6 pass** (live preferred · dead drops fallback · empty registry keeps fallback · agent_name match · two no-match rejections)
- [ ] CI green
- [ ] Live: filter to a keeper, kill it (or pick a known-dead one), reload — page renders missing-state with \`stale_termination\` metric reference instead of error overlay.

## Related

- #12271 (merged): closed the runtime \`MissedWakeup\` that produced the watchdog kills the dashboard then mishandled
- #12282 (in flight): adds \`masc_keeper_skip_idle_wake_resumed_total\` positive counter — the missing-state copy in this PR points operators there for kill-time evidence

## Blast radius

- One pure helper extraction + one resolver call site change
- Missing-state component now reads \`keepers.value\` directly to discriminate message
- No public API / schema / dependency changes
- No removal of existing behaviour outside the documented fallback rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)