### PR TITLE
spike(dashboard): KpiStripIsland sync-mount variant — useEffect overhead eliminated (RFC 0017 §7d)

### DIFF
--- a/dashboard/design-system/RFC/0017-solidjs-migration-measurement.md
+++ b/dashboard/design-system/RFC/0017-solidjs-migration-measurement.md
@@ -125,13 +125,46 @@ The Solid path consumes roughly twice the main-thread budget for the same stream
 - The update measurement re-renders the entire tree each round (worst case for Preact). Solid's *targeted* signal updates (changing a single cell value through a stored ref) would be faster, but our caller pattern always re-renders from scratch on prop change because `cells` is a fresh array literal each parent render. Refactoring callers to keep persistent stores would shift the comparison, but is itself a non-trivial migration.
 - The 30 ms overhead is dominated by `useEffect` scheduling. A different mounting strategy (e.g. `solidRender` called synchronously in the Preact component body during the first render) could close most of this gap, but would break the eventual-consistency model the test shim relies on, and require a redesign of `KpiStripIsland`.
 
+## Synchronous-mount spike (RFC 0017 §7d, added 2026-04-30)
+
+Recommendation 4 below proposed investigating a sync-mount strategy. That spike is now done: `kpi-strip-island-sync.ts` moves the Solid mount into a Preact ref callback (commit-phase synchronous) and the prop sync into `useLayoutEffect` (synchronous, before paint). Both shift the work out of task tier.
+
+Numbers at n=16 (warm cache, headless Chromium):
+
+```
+Mount → DOM:
+  Preact KpiStrip:          16.50 ms
+  Solid useEffect island:   32.80 ms   ← shipping wrapper
+  Solid sync-mount island:  16.80 ms   ← spike variant (kpi-strip-island-sync.ts)
+    delta vs useEffect:     16.00 ms saved
+    delta vs Preact:         0.30 ms slower
+
+Update burst (60 sequential re-renders):
+  Preact KpiStrip:          total= 991 ms, mean=16.51 ms
+  Solid useEffect island:   total=1999 ms, mean=33.32 ms   ← shipping (~half throughput)
+  Solid sync-mount island:  total=1008 ms, mean=16.80 ms   ← spike (parity with Preact)
+
+  throughput sync/Preact:    1.02   (1.0 = parity)
+  throughput sync/useEffect: 0.50   (sync mount is 2× the useEffect path)
+```
+
+The `useEffect` overhead is **eliminated** by the ref-callback approach. Sync-mount island reaches **parity with Preact** at our production scale.
+
+**But parity is not a win.** This spike removes the latency *regression* the shipping wrapper introduces, but the original RFC 0017 promise — that Solid would be *faster* — is still unrealised. The reason: at small N with full prop replacement on every parent render, both Preact's diff and Solid's per-cell render do similar amounts of work. Solid's fine-grained reactivity advantage only surfaces when individual cells subscribe to their own signals and the parent doesn't recreate the `cells` array on every event.
+
+For the RFC 0017 trajectory this means:
+
+1. **Sync-mount can be promoted to production** as a low-risk improvement: removes the 30 ms regression on every page using a migrated caller, no API change, identical DOM contract.
+2. **Phase 2 / Phase 3 islands stay paused** until the per-cell signal redesign (separate larger RFC) is done. Adding more sync-mount islands at parity gives no win, just larger frame budget consumption with no benefit.
+
 ## Recommendations
 
 1. **Do not roll back blindly.** Bundle isolation (9.3 KB amortised after first caller, 0 B per subsequent caller), type safety, and the test-shim infrastructure are all clean wins; reverting them costs more than the latency we'd recover.
-2. **Amend RFC 0017 §4.** The krausest citation does not generalise to our app shape. Replace it with these measured numbers and an explicit note that the migration was not justified by user-perceived latency.
-3. **Skip RFC 0017 §6 (Lifeline/Ticker islands) for now.** Per these numbers, more islands have no performance justification unless those components have N>200 cells. They do not. **The sustained-load numbers strengthen this**: at n=16 Solid throughput is half of Preact's, so adding more islands to a streaming dashboard makes the SSE back-pressure problem worse, not better.
-4. **Investigate a synchronous mount strategy** as a future spike. If the 30 ms `useEffect` overhead can be eliminated, the cross-over point shifts down toward our actual usage and the migration becomes a real win. This is worth a separate, scoped RFC.
-5. **Keep the current migration as deliberate code organisation.** The Solid island gives us framework-agnostic primitives, a clean migration boundary, and a reusable test pattern (`vi.doMock` shim). Those are the actual wins to report — performance is not.
+2. **Amend RFC 0017 §4.** The krausest citation does not generalise to our app shape. Replace it with these measured numbers and an explicit note that the migration was not justified by user-perceived latency *unless paired with a per-cell signal API*.
+3. **Skip RFC 0017 §6 (Lifeline/Ticker islands) for now.** Per these numbers, more islands have no performance justification unless those components have N>200 cells (they do not) or use fine-grained signals (current API does not).
+4. **Promote `KpiStripIslandSync` to the shipping wrapper** as a separate small PR. Spike result is unambiguous: removes the 30 ms regression, achieves parity with Preact. Risk is bounded — the wrapper is a thin Preact component, the Solid factory it imports is unchanged, and the existing test shim still works (it bypasses the wrapper entirely with `vi.doMock`).
+5. **Per-cell signal API redesign** as a separate, larger RFC if real perf wins are needed. This would change `KpiStripIslandData` from `cells: ReadonlyArray<KpiCellProps>` to `cellSignals: ReadonlyArray<Accessor<KpiCellProps>>`, allowing callers to mutate one cell without recreating the array. Costly: every caller refactors its data flow.
+6. **Keep the current migration as deliberate code organisation.** The Solid island gives us framework-agnostic primitives, a clean migration boundary, and a reusable test pattern (`vi.doMock` shim). Those are the actual wins to report — performance was not, until the sync-mount spike, which now gives us parity.
 
 ## Reproduction
 

--- a/dashboard/design-system/RFC/0017-solidjs-migration.md
+++ b/dashboard/design-system/RFC/0017-solidjs-migration.md
@@ -119,6 +119,22 @@ The single-shot 3-sample numbers above don't tell us what happens when the dashb
 
 The krausest figures in §1 do not generalise to our usage shape (small N, but high update rate from SSE). The companion measurement document records what we actually observed and recommends Phase 2 (Lifeline) and Phase 3 (Ticker) be paused pending a synchronous-mount spike that could close the 30 ms `useEffect` gap.
 
+### 7d. Synchronous-mount spike (added 2026-04-30 — same-day follow-up)
+
+`kpi-strip-island-sync.ts` is a spike variant that moves the Solid mount into a Preact ref callback (commit-phase synchronous) and the prop sync into `useLayoutEffect`. Both shift the work out of task tier, eliminating the bulk of the 30 ms `useEffect` gap.
+
+| Workload (n=16) | Preact | Solid useEffect | Solid sync-mount |
+|-----------------|--------|-----------------|------------------|
+| Mount → DOM | 16.50 ms | 32.80 ms | **16.80 ms** (parity) |
+| Update burst (60 samples), total | 991 ms | 1999 ms | **1008 ms** (parity) |
+| Throughput vs Preact | 1.00 | 0.50 | **1.02** |
+
+The spike's hypothesis holds — useEffect overhead is eliminated. **But parity is not a win.** The original §1 promise that Solid would be *faster* is still unrealised at small N because both renderers do similar work when callers replace the entire `cells` prop on every parent render. The fine-grained-signal advantage only surfaces if callers stop recreating the array.
+
+**Production action**: promote `KpiStripIslandSync` to the shipping wrapper as a separate small PR (no API change, identical DOM contract). This removes the 30 ms regression on every page that uses a migrated caller, returning the existing trajectory to neutral.
+
+**Phase 2 / Phase 3 stay paused** until a per-cell signal API redesign is done — that's a separate larger RFC.
+
 ## 8. Rollback Criteria
 
 This RFC is rolled back (and PR #N reverted) if:

--- a/dashboard/design-system/preview/bench-kpi.html
+++ b/dashboard/design-system/preview/bench-kpi.html
@@ -83,6 +83,7 @@
       <button id="run-suite">Full suite (mount + 3× update)</button>
       <button id="run-sustained">Sustained 5s (n=16, 30 updates/sec target)</button>
       <button id="run-keeper-shape">Keeper-shape spike (n=16, 60 updates burst)</button>
+      <button id="run-spike-sync">Sync-mount spike (n=16, useEffect vs ref callback)</button>
     </div>
 
     <pre class="results" id="results">(no measurements yet)</pre>
@@ -97,6 +98,9 @@
         <div id="island-host"></div>
       </div>
     </div>
+
+    <h2 style="font-size:14px; margin-top:24px">Sync-mount spike host (RFC 0017 §7d)</h2>
+    <div id="sync-host"></div>
   </div>
 
   <script type="module" src="bench-kpi.ts"></script>

--- a/dashboard/design-system/preview/bench-kpi.ts
+++ b/dashboard/design-system/preview/bench-kpi.ts
@@ -21,6 +21,7 @@ import {
   KpiStripIsland,
   type KpiStripIslandData,
 } from '../../src/components/kpi-strip-island'
+import { KpiStripIslandSync } from '../../src/components/kpi-strip-island-sync'
 
 interface SeedRow {
   total: number
@@ -492,6 +493,154 @@ document.getElementById('run-keeper-shape')?.addEventListener('click', async () 
     `=== keeper-shape spike (n=${n}, ${burstUpdates} updates each side) ===`,
     `Preact: total ${ps.reduce((a, b) => a + b, 0).toFixed(0)}ms, mean ${(ps.reduce((a, b) => a + b, 0) / ps.length).toFixed(2)}ms, p95 ${p95(ps).toFixed(2)}ms, max ${Math.max(...ps).toFixed(2)}ms`,
     `Solid:  total ${is_.reduce((a, b) => a + b, 0).toFixed(0)}ms, mean ${(is_.reduce((a, b) => a + b, 0) / is_.length).toFixed(2)}ms, p95 ${p95(is_).toFixed(2)}ms, max ${Math.max(...is_).toFixed(2)}ms`,
+    '',
+  ]
+  resultsEl.textContent = block.join('\n') + '\n'
+  console.log(block.join('\n'))
+})
+
+// ── Sync-mount spike (RFC 0017 §7d) ──
+//
+// Compares the shipping island wrapper (useEffect-based) against
+// `KpiStripIslandSync`, which moves the Solid mount into a Preact ref
+// callback (commit-phase synchronous) and the prop sync into
+// `useLayoutEffect`. If the spike's hypothesis holds, the ~30 ms
+// useEffect overhead disappears and the variant beats the shipping
+// island at the same n.
+
+const syncHost = document.getElementById('sync-host') as HTMLElement
+
+async function timeSyncRender(
+  rows: SeedRow[],
+  cellsPerStrip: number,
+  expectedSentinels: ReadonlyArray<string>,
+): Promise<number> {
+  return timeUpdateToDom(
+    () => {
+      render(
+        html`<div>${rows.map((r) => html`
+          <${KpiStripIslandSync} ariaLabel="bench" cols=${cellsPerStrip} cells=${rowToCells(r, cellsPerStrip)} />
+        `)}</div>`,
+        syncHost,
+      )
+    },
+    syncHost,
+    expectedSentinels,
+  )
+}
+
+document.getElementById('run-spike-sync')?.addEventListener('click', async () => {
+  resultsEl.textContent = 'sync-mount spike: warmup...\n'
+  const n = 16
+  const cellsPerStrip = Number(cellsInput.value)
+  const burstUpdates = 60
+
+  // Warmup
+  for (let i = 0; i < 3; i += 1) {
+    await runMount(n, cellsPerStrip)
+    render(null, syncHost)
+  }
+
+  resultsEl.textContent = ''
+
+  // ─── Mount comparison ───
+  const rows = makeSeed(n)
+  const expected = n * cellsPerStrip
+
+  render(null, preactHost)
+  const preactMountMs = await timeRenderToDom(
+    () => render(
+      html`<div>${rows.map((r) => html`
+        <${KpiStrip} ariaLabel="bench" cols=${cellsPerStrip}>
+          ${rowToCells(r, cellsPerStrip).map((cell) => html`<${KpiCell} ...${cell} />`)}
+        <//>
+      `)}</div>`,
+      preactHost,
+    ),
+    preactHost,
+    expected,
+  )
+
+  render(null, islandHost)
+  const islandMountMs = await timeRenderToDom(
+    () => render(
+      html`<div>${rows.map((r) => html`
+        <${KpiStripIsland} ariaLabel="bench" cols=${cellsPerStrip} cells=${rowToCells(r, cellsPerStrip)} />
+      `)}</div>`,
+      islandHost,
+    ),
+    islandHost,
+    expected,
+  )
+
+  render(null, syncHost)
+  const syncMountMs = await timeRenderToDom(
+    () => render(
+      html`<div>${rows.map((r) => html`
+        <${KpiStripIslandSync} ariaLabel="bench" cols=${cellsPerStrip} cells=${rowToCells(r, cellsPerStrip)} />
+      `)}</div>`,
+      syncHost,
+    ),
+    syncHost,
+    expected,
+  )
+
+  // ─── Burst update comparison (60 sequential re-renders) ───
+  const preactSamples: number[] = []
+  const islandSamples: number[] = []
+  const syncSamples: number[] = []
+  for (let i = 0; i < burstUpdates; i += 1) {
+    for (const r of rows) r.total += 1
+    const sentinels = rows.map((r) => String(r.total))
+
+    preactSamples.push(await timeUpdateToDom(
+      () => render(
+        html`<div>${rows.map((r) => html`
+          <${KpiStrip} ariaLabel="bench" cols=${cellsPerStrip}>
+            ${rowToCells(r, cellsPerStrip).map((cell) => html`<${KpiCell} ...${cell} />`)}
+          <//>
+        `)}</div>`,
+        preactHost,
+      ),
+      preactHost,
+      sentinels,
+    ))
+
+    islandSamples.push(await timeUpdateToDom(
+      () => render(
+        html`<div>${rows.map((r) => html`
+          <${KpiStripIsland} ariaLabel="bench" cols=${cellsPerStrip} cells=${rowToCells(r, cellsPerStrip)} />
+        `)}</div>`,
+        islandHost,
+      ),
+      islandHost,
+      sentinels,
+    ))
+
+    syncSamples.push(await timeSyncRender(rows, cellsPerStrip, sentinels))
+  }
+
+  const summary = (samples: number[]): string => {
+    const total = samples.reduce((a, b) => a + b, 0)
+    const mean = total / samples.length
+    return `total=${total.toFixed(0)}ms mean=${mean.toFixed(2)}ms p95=${p95(samples).toFixed(2)}ms max=${Math.max(...samples).toFixed(2)}ms`
+  }
+
+  const block = [
+    `=== sync-mount spike (n=${n}, ${burstUpdates} updates) ===`,
+    `Mount→DOM:`,
+    `  Preact KpiStrip:           ${preactMountMs.toFixed(2)} ms`,
+    `  Solid useEffect island:    ${islandMountMs.toFixed(2)} ms`,
+    `  Solid sync-mount island:   ${syncMountMs.toFixed(2)} ms`,
+    `  delta sync vs useEffect:   ${(islandMountMs - syncMountMs).toFixed(2)} ms saved`,
+    `  delta sync vs Preact:      ${(syncMountMs - preactMountMs).toFixed(2)} ms (positive = sync slower than Preact)`,
+    ``,
+    `Update→DOM (${burstUpdates} samples):`,
+    `  Preact KpiStrip:           ${summary(preactSamples)}`,
+    `  Solid useEffect island:    ${summary(islandSamples)}`,
+    `  Solid sync-mount island:   ${summary(syncSamples)}`,
+    `  throughput sync/Preact:    ${(syncSamples.reduce((a, b) => a + b, 0) / preactSamples.reduce((a, b) => a + b, 0)).toFixed(2)} (1.0 = parity)`,
+    `  throughput sync/useEffect: ${(syncSamples.reduce((a, b) => a + b, 0) / islandSamples.reduce((a, b) => a + b, 0)).toFixed(2)}`,
     '',
   ]
   resultsEl.textContent = block.join('\n') + '\n'

--- a/dashboard/src/components/kpi-strip-island-sync.ts
+++ b/dashboard/src/components/kpi-strip-island-sync.ts
@@ -1,0 +1,70 @@
+// Synchronous-mount variant of KpiStripIsland — RFC 0017 §7d spike.
+//
+// The shipping `KpiStripIsland` (kpi-strip-island.ts) wires its Solid
+// subtree through `useEffect`, which fires at task tier. Headless
+// Chromium measurement at n=16 (PR #12280) showed this adds ~30 ms of
+// fixed overhead per mount and per update — large enough that island
+// throughput is half of the Preact original at production scale.
+//
+// This variant moves the Solid mount/dispose into a Preact ref callback
+// (fires synchronously during the commit phase) and the prop sync into
+// `useLayoutEffect` (fires synchronously before paint). Both shift the
+// work out of task tier, eliminating the bulk of the ~30 ms gap.
+//
+// Tradeoff: Preact's ref callback fires synchronously in the same tick
+// as the surrounding render. Calling `solidRender` inside it nests one
+// renderer inside another; experimentally this works because Solid's
+// render is itself synchronous and does not yield. We retain the
+// caller's prop reference identity by reading `props` directly inside
+// the layout-effect, so each parent re-render pushes the latest data.
+//
+// Used only by the bench page for now; the production wrapper stays on
+// the well-tested useEffect path until this spike's measurement is
+// reviewed.
+
+import { useLayoutEffect, useRef } from 'preact/hooks'
+import { render as solidRender } from 'solid-js/web'
+import type { Setter } from 'solid-js'
+import type { VNode } from 'preact'
+import { html } from 'htm/preact'
+import {
+  createKpiStripIsland,
+  type KpiStripIslandData,
+} from './kpi-strip-island-solid.solid'
+
+export type { KpiStripIslandData } from './kpi-strip-island-solid.solid'
+
+interface MountedIsland {
+  dispose: () => void
+  setState: Setter<KpiStripIslandData>
+}
+
+export function KpiStripIslandSync(props: KpiStripIslandData): VNode {
+  const handleRef = useRef<MountedIsland | null>(null)
+
+  // Mount/unmount via ref callback. Preact invokes this synchronously
+  // during commit when the host `<div>` is attached (or detached). The
+  // Solid render is also synchronous, so by the time the surrounding
+  // commit returns, the cells are already in the DOM.
+  const mount = (el: HTMLDivElement | null): void => {
+    if (el !== null && handleRef.current === null) {
+      const island = createKpiStripIsland(props)
+      const dispose = solidRender(island.jsx, el)
+      handleRef.current = { dispose, setState: island.setState }
+      return
+    }
+    if (el === null && handleRef.current !== null) {
+      handleRef.current.dispose()
+      handleRef.current = null
+    }
+  }
+
+  // Push prop changes to the Solid signal in useLayoutEffect — fires
+  // synchronously after the DOM commits but before the browser paints.
+  // No task-tier hop, so the update reaches Solid in the same frame.
+  useLayoutEffect(() => {
+    handleRef.current?.setState(props)
+  })
+
+  return html`<div ref=${mount} />`
+}


### PR DESCRIPTION
## Spike result

The 30 ms \`useEffect\` overhead the shipping \`KpiStripIsland\` adds (PR #12274 / #12280) is **entirely attributable to task-tier scheduling** and is eliminated by moving the Solid mount into a Preact ref callback (commit-phase synchronous) and the prop sync into \`useLayoutEffect\` (pre-paint synchronous).

| Workload (n=16) | Preact | Solid useEffect | Solid sync-mount |
|-----------------|--------|-----------------|------------------|
| Mount → DOM | 16.50 ms | 32.80 ms | **16.80 ms** (parity) |
| Update burst, total (60 samples) | 991 ms | 1999 ms | **1008 ms** (parity) |
| Throughput vs Preact | 1.00 | 0.50 | **1.02** |

## What lands (spike-only, not promoted to production)

| File | Purpose |
|------|---------|
| \`src/components/kpi-strip-island-sync.ts\` | \`KpiStripIslandSync\` — same prop surface as the shipping wrapper, ref callback + useLayoutEffect internals |
| \`design-system/preview/bench-kpi.{html,ts}\` | Three-way comparison (Preact / Solid useEffect / Solid sync-mount) with a "Sync-mount spike" button |
| \`design-system/RFC/0017-solidjs-migration{,-measurement}.md\` §7d | Write-up of the spike, raw numbers, recommendations |

## Reading

The spike's hypothesis holds — useEffect overhead is gone. **But parity is not a win.** The original §1 promise that Solid would be faster than Preact at small N is still unrealised; both renderers do similar work when callers replace the entire \`cells\` prop on every parent render. The fine-grained-signal advantage only surfaces when individual cells subscribe to their own signals and the parent doesn't recreate the array.

## Updated recommendations

| Original (PR #12274) | Updated (this PR) |
|----------------------|-------------------|
| Investigate sync-mount as a future spike | **Done** — useEffect overhead eliminated |
| Phase 2 / Phase 3 islands paused | **Still paused** — parity ≠ win, no perf justification for more islands |
| Future per-cell signal RFC | **Still future** — explicit recommendation in §7d |
| (n/a) | **Promote \`KpiStripIslandSync\` to shipping wrapper** as a separate small PR. Removes the 30 ms regression for the 5 already-migrated callers in one shot. |

## Why this PR doesn't already promote the sync wrapper

Production swap is a non-trivial decision (changes how every existing island mounts) and the spike is best reviewed independently of the swap. The promotion PR will follow once this spike is reviewed and the numbers are accepted.

## Verification

| Step | Result |
|------|--------|
| \`pnpm typecheck\` | green |
| \`vitest --config vitest.solid.config.ts\` | 128/128 pass |
| \`pnpm build\` | success |
| Headless Chromium bench run via puppeteer | numbers above |

## Companion

PR #12287 (\`feature/ds-v2-rfc0017-eslint-guard\`) adds a lint-time guard that points new callers at \`KpiStripIsland\` and the §7c measurement explanation. Both PRs are in flight — they're independent and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)