### PR TITLE
refactor(oas): type structured error cascade names

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1573,7 +1573,10 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
    | Some err ->
        (match Oas_worker_named.classify_masc_internal_error err with
         | Some (Oas_worker_named.No_tool_capable_provider
-                  { cascade_name; _ }) ->
+	                  { cascade_name; _ }) ->
+            let cascade_name =
+              Oas_worker_named.cascade_name_to_string cascade_name
+            in
             Prometheus.inc_counter
               Prometheus.metric_keeper_no_tool_provider
               ~labels:

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -97,6 +97,7 @@ let run_named
     if Option.is_some model_strings && trimmed <> "" then trimmed
     else Keeper_cascade_profile.normalize_declared_name cascade_name
   in
+  let error_cascade_name = cascade_name_of_string cascade_name in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~keeper_name tools in
   let configured_labels_result, candidate_cfgs_result =
     match model_strings with
@@ -173,10 +174,13 @@ let run_named
         (sdk_error_of_masc_internal_error
            (if require_tool_choice_support then
               No_tool_capable_provider
-                { cascade_name; configured_labels }
+                { cascade_name = error_cascade_name; configured_labels }
             else
               Cascade_exhausted
-                { cascade_name; reason = Keeper_types.No_providers_available }))
+                {
+                  cascade_name = error_cascade_name;
+                  reason = Keeper_types.No_providers_available;
+                }))
   | _ ->
   let capture, _metrics =
     Oas_worker_cascade.cascade_metrics_for_candidates ~candidate_cfgs ()
@@ -391,7 +395,7 @@ let run_named
             sdk_error_of_masc_internal_error
               (Resumable_cli_session
                  {
-                   cascade_name;
+                   cascade_name = error_cascade_name;
                    detail = resumable_cli_session_detail message;
                    exit_code = resumable_cli_session_exit_code message;
                  })
@@ -400,7 +404,7 @@ let run_named
             sdk_error_of_masc_internal_error
               (Resumable_cli_session
                  {
-                   cascade_name;
+                   cascade_name = error_cascade_name;
                    detail = resumable_cli_session_detail reason;
                    exit_code = resumable_cli_session_exit_code reason;
                  })
@@ -408,7 +412,7 @@ let run_named
             sdk_error_of_masc_internal_error
               (Cascade_exhausted
                  {
-                   cascade_name;
+                   cascade_name = error_cascade_name;
                    reason;
                  })
       in
@@ -827,7 +831,11 @@ let run_named
       ~outcome:`Failure ~observation:(Some observation) ();
     Error
       (sdk_error_of_masc_internal_error
-         (Cascade_exhausted { cascade_name; reason = Keeper_types.Candidates_filtered_after_cycles }))
+         (Cascade_exhausted
+            {
+              cascade_name = error_cascade_name;
+              reason = Keeper_types.Candidates_filtered_after_cycles;
+            }))
   in
   let record_trace ~cycle ~candidates_out ~backoff_ms ~kind =
     Cascade_strategy_trace.record {

--- a/lib/oas_worker_named_error.ml
+++ b/lib/oas_worker_named_error.ml
@@ -9,18 +9,23 @@
 
 open Result.Syntax
 
+type cascade_name = Keeper_cascade_profile.runtime_name
+
+let cascade_name_of_string raw = Keeper_cascade_profile.Runtime_name raw
+let cascade_name_to_string = Keeper_cascade_profile.runtime_name_to_string
+
 type masc_internal_error =
   | Cascade_exhausted of {
-      cascade_name : string;
+      cascade_name : cascade_name;
       reason : Keeper_types.cascade_exhaustion_reason;
     }
   | Resumable_cli_session of {
-      cascade_name : string;
+      cascade_name : cascade_name;
       detail : string;
       exit_code : int option;
     }
   | No_tool_capable_provider of {
-      cascade_name : string;
+      cascade_name : cascade_name;
       configured_labels : string list;
     }
   | Accept_rejected of {
@@ -30,7 +35,7 @@ type masc_internal_error =
     }
   | Admission_queue_timeout of {
       keeper_name : string;
-      cascade_name : string;
+      cascade_name : cascade_name;
       wait_sec : float;
     }
   | Admission_queue_rejected of {
@@ -63,6 +68,7 @@ let string_opt_of_assoc key = function
 
 let masc_internal_error_to_json = function
   | Cascade_exhausted { cascade_name; reason } ->
+    let cascade_name = cascade_name_to_string cascade_name in
     `Assoc
       [
         ("kind", `String "cascade_exhausted");
@@ -70,6 +76,7 @@ let masc_internal_error_to_json = function
         ("reason", Keeper_types.cascade_exhaustion_reason_to_json reason);
       ]
   | Resumable_cli_session { cascade_name; detail; exit_code } ->
+    let cascade_name = cascade_name_to_string cascade_name in
     `Assoc
       [
         ("kind", `String "resumable_cli_session");
@@ -78,6 +85,7 @@ let masc_internal_error_to_json = function
         ("exit_code", Json_util.int_opt_to_json exit_code);
       ]
   | No_tool_capable_provider { cascade_name; configured_labels } ->
+    let cascade_name = cascade_name_to_string cascade_name in
     `Assoc
       [
         ("kind", `String "no_tool_capable_provider");
@@ -94,6 +102,7 @@ let masc_internal_error_to_json = function
         ("reason", `String reason);
       ]
   | Admission_queue_timeout { keeper_name; cascade_name; wait_sec } ->
+    let cascade_name = cascade_name_to_string cascade_name in
     `Assoc
       [
         ("kind", `String "admission_queue_timeout");
@@ -192,6 +201,7 @@ let cascade_name_of_masc_internal_error = function
   | Resumable_cli_session { cascade_name; _ }
   | No_tool_capable_provider { cascade_name; _ }
   | Admission_queue_timeout { cascade_name; _ } ->
+      let cascade_name = cascade_name_to_string cascade_name in
       if String.equal (String.trim cascade_name) "" then "unknown"
       else cascade_name
   | Accept_rejected _
@@ -213,14 +223,15 @@ let sdk_error_of_masc_internal_error err =
 
 let admission_wait_timeout_error
     ~(keeper_name : string)
-    ~(cascade_name : string)
+    ~(cascade_name : cascade_name)
     ~(priority : Llm_provider.Request_priority.t)
     (wait_ms : int) =
   let wait_sec = float_of_int wait_ms /. 1000.0 in
+  let cascade_name_string = cascade_name_to_string cascade_name in
   let msg =
     Printf.sprintf
       "Admission queue wait timeout after %.1fs (wait_ms=%d, keeper=%s, cascade=%s, priority=%s)"
-      wait_sec wait_ms keeper_name cascade_name
+      wait_sec wait_ms keeper_name cascade_name_string
       (Llm_provider.Request_priority.to_string priority)
   in
   Log.Misc.warn "%s" msg;
@@ -263,7 +274,7 @@ let classify_masc_internal_error (err : Oas.Error.sdk_error) :
                  Some
                    (Cascade_exhausted
                       {
-                        cascade_name;
+                        cascade_name = cascade_name_of_string cascade_name;
                         reason;
                       })
                | None -> None)
@@ -273,7 +284,7 @@ let classify_masc_internal_error (err : Oas.Error.sdk_error) :
                  Some
                    (Resumable_cli_session
                       {
-                        cascade_name;
+                        cascade_name = cascade_name_of_string cascade_name;
                         detail;
                         exit_code = int_opt_of_assoc "exit_code" json;
                       })
@@ -296,7 +307,7 @@ let classify_masc_internal_error (err : Oas.Error.sdk_error) :
                  Some
                    (No_tool_capable_provider
                       {
-                        cascade_name;
+                        cascade_name = cascade_name_of_string cascade_name;
                         configured_labels;
                       })
                | None -> None)
@@ -324,7 +335,13 @@ let classify_masc_internal_error (err : Oas.Error.sdk_error) :
                        | _ -> 0.0)
                    | _ -> 0.0
                  in
-                 Some (Admission_queue_timeout { keeper_name; cascade_name; wait_sec })
+                 Some
+                   (Admission_queue_timeout
+                      {
+                        keeper_name;
+                        cascade_name = cascade_name_of_string cascade_name;
+                        wait_sec;
+                      })
                | _ -> None)
            | Some (`String "admission_queue_rejected") -> (
                match string_opt_of_assoc "keeper_name" json,

--- a/lib/oas_worker_named_error.mli
+++ b/lib/oas_worker_named_error.mli
@@ -10,18 +10,23 @@
 
 (** {1 MASC internal error type} *)
 
+type cascade_name = Keeper_cascade_profile.runtime_name
+
+val cascade_name_of_string : string -> cascade_name
+val cascade_name_to_string : cascade_name -> string
+
 type masc_internal_error =
   | Cascade_exhausted of {
-      cascade_name : string;
+      cascade_name : cascade_name;
       reason : Keeper_types.cascade_exhaustion_reason;
     }
   | Resumable_cli_session of {
-      cascade_name : string;
+      cascade_name : cascade_name;
       detail : string;
       exit_code : int option;
     }
   | No_tool_capable_provider of {
-      cascade_name : string;
+      cascade_name : cascade_name;
       configured_labels : string list;
     }
   | Accept_rejected of {
@@ -31,7 +36,7 @@ type masc_internal_error =
     }
   | Admission_queue_timeout of {
       keeper_name : string;
-      cascade_name : string;
+      cascade_name : cascade_name;
       wait_sec : float;
     }
   | Admission_queue_rejected of {
@@ -78,7 +83,7 @@ val masc_oas_error_total_metric : string
 
 val admission_wait_timeout_error :
   keeper_name:string ->
-  cascade_name:string ->
+  cascade_name:cascade_name ->
   priority:Llm_provider.Request_priority.t ->
   int ->
   (string, Oas.Error.sdk_error) result

--- a/lib/oas_worker_named_fsm.ml
+++ b/lib/oas_worker_named_fsm.ml
@@ -245,7 +245,8 @@ let sdk_error_to_resumable_cli_session ~cascade_name
           (Oas_worker_named_error.sdk_error_of_masc_internal_error
              (Oas_worker_named_error.Resumable_cli_session
                 {
-                  cascade_name;
+                  cascade_name =
+                    Oas_worker_named_error.cascade_name_of_string cascade_name;
                   detail = resumable_cli_session_detail message;
                   exit_code = resumable_cli_session_exit_code message;
                 }))

--- a/test/test_keeper_cascade_auto_pause_task074.ml
+++ b/test/test_keeper_cascade_auto_pause_task074.ml
@@ -30,17 +30,19 @@ module Owne = Masc_mcp.Oas_worker_named
 module KT = Masc_mcp.Keeper_types
 module Regime = Masc_mcp.Keeper_behavioral_regime
 
+let cascade_name raw = Owne.cascade_name_of_string raw
+
 (* --- 1. is_cascade_exhausted_error covers the variants auto-pause cares about --- *)
 
 let mk_cascade_exhausted () =
   Owne.sdk_error_of_masc_internal_error
     (Owne.Cascade_exhausted
-       { cascade_name = "test"; reason = KT.All_providers_failed })
+       { cascade_name = cascade_name "test"; reason = KT.All_providers_failed })
 
 let mk_no_tool_capable () =
   Owne.sdk_error_of_masc_internal_error
     (Owne.No_tool_capable_provider
-       { cascade_name = "test"; configured_labels = [] })
+       { cascade_name = cascade_name "test"; configured_labels = [] })
 
 let mk_accept_rejected () =
   Owne.sdk_error_of_masc_internal_error
@@ -49,7 +51,7 @@ let mk_accept_rejected () =
 let mk_resumable_cli_session () =
   Owne.sdk_error_of_masc_internal_error
     (Owne.Resumable_cli_session
-       { cascade_name = "test";
+       { cascade_name = cascade_name "test";
          detail = "rollout-thread-not-found";
          exit_code = Some 1 })
 
@@ -83,7 +85,7 @@ let mk_admission_queue_timeout () =
   Owne.sdk_error_of_masc_internal_error
     (Owne.Admission_queue_timeout
        { keeper_name = "test_keeper";
-         cascade_name = "test";
+         cascade_name = cascade_name "test";
          wait_sec = 5.0 })
 
 let test_pause_does_not_fire_on_transient () =

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -14,14 +14,17 @@ module KEC = Masc_mcp.Keeper_error_classify
 module Owne = Masc_mcp.Oas_worker_named
 module KT = Masc_mcp.Keeper_types
 
+let cascade_name raw = Owne.cascade_name_of_string raw
+
 let make_cascade_exhausted reason =
   Owne.sdk_error_of_masc_internal_error
-    (Owne.Cascade_exhausted { cascade_name = "test_cascade"; reason })
+    (Owne.Cascade_exhausted
+       { cascade_name = cascade_name "test_cascade"; reason })
 
 let make_no_tool_capable () =
   Owne.sdk_error_of_masc_internal_error
     (Owne.No_tool_capable_provider
-       { cascade_name = "test_cascade"; configured_labels = [] })
+       { cascade_name = cascade_name "test_cascade"; configured_labels = [] })
 
 let make_accept_rejected () =
   Owne.sdk_error_of_masc_internal_error

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -21,6 +21,8 @@ module OMR = Masc_mcp.Oas_model_resolve
 module AQ = Masc_mcp.Keeper_approval_queue
 module Keeper_types = Masc_mcp.Keeper_types
 
+let oas_error_cascade_name = Masc_mcp.Oas_worker_named.cascade_name_of_string
+
 let has_prompt_root path =
   Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
 
@@ -3646,7 +3648,8 @@ let wrapped_cascade_max_turns_error () =
   Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
     (Masc_mcp.Oas_worker_named.Cascade_exhausted
        {
-         cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+         cascade_name =
+           oas_error_cascade_name Masc_mcp.Keeper_config.default_cascade_name;
          reason = Keeper_types.Other_detail wrapped_claude_max_turns_message;
        })
 
@@ -3683,7 +3686,7 @@ let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumabl
       (Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
          (Masc_mcp.Oas_worker_named.Resumable_cli_session
             {
-              cascade_name = "kimi_cli_keeper";
+              cascade_name = oas_error_cascade_name "kimi_cli_keeper";
               detail =
                 "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc";
               exit_code = Some 75;
@@ -3701,7 +3704,7 @@ let test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout
          (Masc_mcp.Oas_worker_named.Admission_queue_timeout
             {
               keeper_name = "nick0cave";
-              cascade_name = "big_three";
+              cascade_name = oas_error_cascade_name "big_three";
               wait_sec = 90.0;
             }))
   in
@@ -4286,7 +4289,7 @@ let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
     Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
       (Masc_mcp.Oas_worker_named.Resumable_cli_session
          {
-           cascade_name = "kimi_cli_keeper";
+           cascade_name = oas_error_cascade_name "kimi_cli_keeper";
            detail = canonical_detail;
            exit_code = Some 75;
          })
@@ -4684,7 +4687,8 @@ let test_cascade_exhausted_error_detected_from_structured_internal_error () =
     Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
       (Masc_mcp.Oas_worker_named.Cascade_exhausted
          {
-           cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+           cascade_name =
+             oas_error_cascade_name Masc_mcp.Keeper_config.default_cascade_name;
            reason = Masc_mcp.Keeper_types.All_providers_failed;
          })
   in
@@ -4725,7 +4729,8 @@ let test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quo
     Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
       (Masc_mcp.Oas_worker_named.Cascade_exhausted
          {
-           cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+           cascade_name =
+             oas_error_cascade_name Masc_mcp.Keeper_config.default_cascade_name;
            reason =
              Keeper_types.Other_detail
                "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
@@ -4743,7 +4748,8 @@ let test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaus
     Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
       (Masc_mcp.Oas_worker_named.Cascade_exhausted
          {
-           cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+           cascade_name =
+             oas_error_cascade_name Masc_mcp.Keeper_config.default_cascade_name;
            reason = Keeper_types.Candidates_filtered_after_cycles;
          })
   in
@@ -4755,7 +4761,7 @@ let test_auto_recoverable_turn_error_includes_resumable_cli_session_error () =
     Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
       (Masc_mcp.Oas_worker_named.Resumable_cli_session
          {
-           cascade_name = "kimi_cli_keeper";
+           cascade_name = oas_error_cascade_name "kimi_cli_keeper";
            detail =
              Masc_mcp.Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail;
            exit_code = Some 75;
@@ -4769,7 +4775,7 @@ let test_cascade_exhausted_error_includes_resumable_cli_session_error () =
     Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
       (Masc_mcp.Oas_worker_named.Resumable_cli_session
          {
-           cascade_name = "kimi_cli_keeper";
+           cascade_name = oas_error_cascade_name "kimi_cli_keeper";
            detail =
              Masc_mcp.Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail;
            exit_code = Some 75;

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -10,6 +10,8 @@
 module OWN = Masc_mcp.Oas_worker_named
 module Prom = Masc_mcp.Prometheus
 
+let typed_cascade_name = OWN.cascade_name_of_string
+
 (* #10285: cascade_name label was added.  Query [(kind, cascade_name)]
    pair.  Tests that only care about kind regardless of cascade pass
    the expected cascade_name explicitly so assertions stay exact. *)
@@ -63,7 +65,7 @@ let test_cascade_exhausted_kind () =
     OWN.sdk_error_of_masc_internal_error
       (OWN.Cascade_exhausted
          {
-           cascade_name;
+           cascade_name = typed_cascade_name cascade_name;
            reason =
              Masc_mcp.Keeper_types.Other_detail "all providers tried";
          })
@@ -81,7 +83,7 @@ let test_resumable_cli_session_kind () =
     OWN.sdk_error_of_masc_internal_error
       (OWN.Resumable_cli_session
          {
-           cascade_name;
+           cascade_name = typed_cascade_name cascade_name;
            detail = "session resumable";
            exit_code = Some 130;
          })
@@ -99,7 +101,7 @@ let test_no_tool_capable_provider_kind () =
     OWN.sdk_error_of_masc_internal_error
       (OWN.No_tool_capable_provider
          {
-           cascade_name;
+           cascade_name = typed_cascade_name cascade_name;
            configured_labels = [ "openai"; "anthropic" ];
          })
   in
@@ -132,7 +134,11 @@ let test_admission_queue_timeout_kind () =
   let _ =
     OWN.sdk_error_of_masc_internal_error
       (OWN.Admission_queue_timeout
-         { keeper_name = "keeper-alpha"; cascade_name; wait_sec = 30.0 })
+         {
+           keeper_name = "keeper-alpha";
+           cascade_name = typed_cascade_name cascade_name;
+           wait_sec = 30.0;
+         })
   in
   Alcotest.(check (float 0.0001))
     "admission_queue_timeout{cascade_name=big_three} counter +1"
@@ -200,7 +206,11 @@ let test_resumable_cli_session_per_cascade_isolation () =
   let _ =
     OWN.sdk_error_of_masc_internal_error
       (OWN.Resumable_cli_session
-         { cascade_name = cascade_a; detail = "exit 1"; exit_code = Some 1 })
+         {
+           cascade_name = typed_cascade_name cascade_a;
+           detail = "exit 1";
+           exit_code = Some 1;
+         })
   in
   Alcotest.(check (float 0.0001))
     "governance_judge counter advanced"
@@ -222,7 +232,11 @@ let test_empty_cascade_name_collapses_to_unknown () =
   let _ =
     OWN.sdk_error_of_masc_internal_error
       (OWN.Resumable_cli_session
-         { cascade_name = "  "; detail = "exit 1"; exit_code = Some 1 })
+         {
+           cascade_name = typed_cascade_name "  ";
+           detail = "exit 1";
+           exit_code = Some 1;
+         })
   in
   Alcotest.(check (float 0.0001))
     "blank cascade_name routes to 'unknown'"

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -10,6 +10,9 @@ open Masc_mcp
 
 module Oas = Agent_sdk
 
+let internal_cascade_name = Oas_worker_named.cascade_name_of_string
+let internal_cascade_name_to_string = Oas_worker_named.cascade_name_to_string
+
 let ctx_messages = Keeper_exec_context.messages_of_context
 let ctx_system_prompt = Keeper_exec_context.system_prompt_of_context
 
@@ -895,7 +898,7 @@ let test_sdk_error_is_resumable_cli_session_detects_structured_error () =
     Oas_worker_named.sdk_error_of_masc_internal_error
       (Oas_worker_named.Resumable_cli_session
          {
-           cascade_name = "governance_judge";
+           cascade_name = internal_cascade_name "governance_judge";
            detail =
              "kimi_cli reported a resumable CLI session (exit 1). \
               Resumable session available via -r.";
@@ -1544,13 +1547,16 @@ let test_classify_masc_internal_error_roundtrip () =
     Oas_worker_named.sdk_error_of_masc_internal_error
       (Oas_worker_named.Cascade_exhausted
          {
-           cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+           cascade_name =
+             internal_cascade_name Masc_mcp.Keeper_config.default_cascade_name;
            reason = Keeper_types.All_providers_failed;
          })
   in
   (match Oas_worker_named.classify_masc_internal_error cascade_err with
    | Some (Oas_worker_named.Cascade_exhausted { cascade_name; reason }) ->
-       Alcotest.(check string) "cascade name" Masc_mcp.Keeper_config.default_cascade_name cascade_name;
+       Alcotest.(check string) "cascade name"
+         Masc_mcp.Keeper_config.default_cascade_name
+         (internal_cascade_name_to_string cascade_name);
        Alcotest.(check string) "cascade reason"
          (Keeper_types.cascade_exhaustion_summary Keeper_types.All_providers_failed)
          (Keeper_types.cascade_exhaustion_summary reason)
@@ -1576,14 +1582,15 @@ let test_classify_masc_internal_error_roundtrip () =
     Oas_worker_named.sdk_error_of_masc_internal_error
       (Oas_worker_named.Resumable_cli_session
          {
-           cascade_name = "kimi_cli_keeper";
+           cascade_name = internal_cascade_name "kimi_cli_keeper";
            detail = Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail;
            exit_code = Some 75;
          })
   in
   match Oas_worker_named.classify_masc_internal_error resumable_err with
   | Some (Oas_worker_named.Resumable_cli_session { cascade_name; detail; exit_code }) ->
-      Alcotest.(check string) "resumable cascade" "kimi_cli_keeper" cascade_name;
+      Alcotest.(check string) "resumable cascade" "kimi_cli_keeper"
+        (internal_cascade_name_to_string cascade_name);
       Alcotest.(check string) "resumable detail redacted"
         Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail
         detail;
@@ -2565,7 +2572,8 @@ let test_kimi_cli_resumable_invalid_request_reclassifies_as_structured () =
       | Some
           (Oas_worker_named.Resumable_cli_session
              { cascade_name; detail = structured_detail; exit_code }) ->
-          Alcotest.(check string) "cascade" "kimi_cli_keeper" cascade_name;
+          Alcotest.(check string) "cascade" "kimi_cli_keeper"
+            (internal_cascade_name_to_string cascade_name);
           Alcotest.(check string) "detail" detail structured_detail;
           Alcotest.(check (option int)) "exit code" (Some 1) exit_code
       | _ -> Alcotest.fail "expected structured resumable CLI session")


### PR DESCRIPTION
## Summary
- Refs #11926.
- Add typed `Oas_worker_named_error.cascade_name` backed by `Keeper_cascade_profile.runtime_name`.
- Type structured MASC OAS error variants that carry cascade labels, including the admission timeout helper.
- Preserve JSON, Prometheus, and operator-facing labels by rendering only at the boundary.

## Product impact
Structured OAS internal errors now carry cascade labels through a typed boundary while keeping existing wire payloads and metrics labels stable. This reduces the C-T7.2 `cascade_name` string surface without changing runtime-facing output.

## Validation
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_oas_error_kind_counter.exe test/test_oas_worker.exe test/test_keeper_error_classify_recoverable.exe test/test_keeper_cascade_auto_pause_task074.exe`
- `git diff --check HEAD~1 HEAD`
- `scripts/stringly-boundary-ratchet.sh` -> `cascade_name 66 / 81` (down from 76 / 81 on main before this slice)
- `./_build/default/test/test_oas_error_kind_counter.exe`
- `./_build/default/test/test_keeper_error_classify_recoverable.exe`
- `./_build/default/test/test_keeper_cascade_auto_pause_task074.exe`
- `./_build/default/test/test_oas_worker.exe test resume_config 17,51-53`
- `./_build/default/test/test_keeper_unified.exe test phase_gate 20-22`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 29-30`
- `./_build/default/test/test_keeper_unified.exe test transient_network_error 31,35-39`

## Notes
A full direct `./_build/default/test/test_oas_worker.exe` run was stopped after it sat without further output; the focused build and targeted relevant resume_config cases passed.