### PR TITLE
fix: keep local MCP client bearers alive

### DIFF
--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -97,8 +97,11 @@ If you want structured output for automation:
 authorization endpoint, so `codex mcp login masc` is expected to fail with
 `No authorization support detected`.
 
-For the Codex MCP server, mint a worker bearer and export it as
-`MASC_MCP_TOKEN`:
+For the Codex MCP server, the local startup path maintains a private
+non-expiring worker bearer at
+`$BASE_PATH/.masc/auth/codex-mcp-client.token`. Manual `login` is still useful
+when bootstrapping or rotating the bearer; export the printed value as
+`MASC_MCP_TOKEN` in the shell that starts Codex:
 
 ```bash
 BASE_PATH="${MASC_BASE_PATH:-$HOME}"
@@ -109,8 +112,7 @@ BASE_PATH="${MASC_BASE_PATH:-$HOME}"
   --shell
 ```
 
-Then use the printed `export MASC_MCP_TOKEN=...` in the shell that starts
-Codex. Confirm the Codex-side registration points at the bearer env var:
+Confirm the Codex-side registration points at the bearer env var:
 
 ```bash
 codex mcp get masc
@@ -124,7 +126,7 @@ Bearer Token Env Var: MASC_MCP_TOKEN
 ```
 
 If Codex still reports that `masc` is not logged in, check the pipeline
-projection before retrying OAuth login:
+projection instead of retrying OAuth login:
 
 ```bash
 ./_build/default/bin/main_eio.exe doctor auth --base-path "$BASE_PATH" --json \
@@ -156,6 +158,11 @@ BASE_PATH="${MASC_BASE_PATH:-$HOME/me}"
 
 ~/me/scripts/mcp-sync.sh
 ```
+
+Local startup also self-heals private non-expiring token files for `claude` and
+`gemini`. Manual `login` is for first-time setup or explicit rotation; after
+that, `~/me/scripts/mcp-sync.sh` can project those token files into client
+config.
 
 `doctor auth --json` exposes `.mcp_clients[]`; `claude` should use
 `MASC_CLAUDE_MCP_TOKEN` / `X-MASC-Agent: claude`, and `gemini` should use

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -666,9 +666,8 @@ let expires_at_for_auth_config auth_cfg =
   else
     None
 
-let save_raw_token_credential config ~agent_name ~role ~raw_token :
-    (agent_credential, masc_error) result =
-  let auth_cfg = load_auth_config config in
+let save_raw_token_credential_with_expiry config ~agent_name ~role ~raw_token
+    ~expires_at : (agent_credential, masc_error) result =
   let cred =
     {
       id = None;
@@ -677,7 +676,7 @@ let save_raw_token_credential config ~agent_name ~role ~raw_token :
       token = sha256_hash raw_token;
       role;
       created_at = now_iso ();
-      expires_at = expires_at_for_auth_config auth_cfg;
+      expires_at;
     }
   in
   try
@@ -691,6 +690,17 @@ let save_raw_token_credential config ~agent_name ~role ~raw_token :
     Log.Auth.error "%s" msg;
     Error (IoError msg)
 
+let save_raw_token_credential config ~agent_name ~role ~raw_token :
+    (agent_credential, masc_error) result =
+  let auth_cfg = load_auth_config config in
+  save_raw_token_credential_with_expiry config ~agent_name ~role ~raw_token
+    ~expires_at:(expires_at_for_auth_config auth_cfg)
+
+let save_raw_token_credential_without_expiry config ~agent_name ~role
+    ~raw_token : (agent_credential, masc_error) result =
+  save_raw_token_credential_with_expiry config ~agent_name ~role ~raw_token
+    ~expires_at:None
+
 (* ============================================ *)
 (* Token operations                             *)
 (* ============================================ *)
@@ -699,6 +709,16 @@ let save_raw_token_credential config ~agent_name ~role ~raw_token :
 let create_token config ~agent_name ~role : (string * agent_credential, masc_error) result =
   let raw_token = generate_token () in
   match save_raw_token_credential config ~agent_name ~role ~raw_token with
+  | Ok cred -> Ok (raw_token, cred)
+  | Error e -> Error e
+
+let create_token_without_expiry config ~agent_name ~role :
+    (string * agent_credential, masc_error) result =
+  let raw_token = generate_token () in
+  match
+    save_raw_token_credential_without_expiry config ~agent_name ~role
+      ~raw_token
+  with
   | Ok cred -> Ok (raw_token, cred)
   | Error e -> Error e
 

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -191,6 +191,14 @@ val save_raw_token_credential :
 (** [save_raw_token_credential config ~agent_name ~role ~raw_token] hashes the
     raw token and persists the credential. *)
 
+val save_raw_token_credential_without_expiry :
+  string -> agent_name:string -> role:agent_role -> raw_token:string ->
+  (agent_credential, masc_error) result
+(** [save_raw_token_credential_without_expiry config ~agent_name ~role
+    ~raw_token] persists a credential with [expires_at = None].  Use this for
+    local MCP client bearers backed by private token files, not for
+    operator-issued session tokens. *)
+
 val load_raw_token : string -> agent_name:string -> string option
 (** [load_raw_token base_path ~agent_name] reads the raw bearer token from
     [<base_path>/.masc/auth/<agent_name>.token] if present. Returns [None] if
@@ -232,6 +240,12 @@ val create_token :
   string -> agent_name:string -> role:agent_role ->
   (string * agent_credential, masc_error) result
 (** [create_token config ~agent_name ~role] returns [(raw_token, credential)]. *)
+
+val create_token_without_expiry :
+  string -> agent_name:string -> role:agent_role ->
+  (string * agent_credential, masc_error) result
+(** [create_token_without_expiry config ~agent_name ~role] returns a fresh raw
+    token and non-expiring credential for local MCP client identity sync. *)
 
 val verify_token :
   string -> agent_name:string -> token:string ->

--- a/lib/auth_login.ml
+++ b/lib/auth_login.ml
@@ -31,6 +31,10 @@ let mcp_token_env_var_for_agent = function
   | "codex" | "codex-mcp-client" -> codex_token_env_var
   | _ -> codex_token_env_var
 
+let is_local_mcp_client_agent = function
+  | "claude" | "gemini" | "codex" | "codex-mcp-client" -> true
+  | _ -> false
+
 let rng_initialized = Atomic.make false
 
 let ensure_rng_initialized () =
@@ -89,7 +93,13 @@ let mint ~base_path ~host ~port ~agent_name ~role () =
   match ensure_required_bearer_auth ~base_path ~agent_name with
   | Error err -> Error err
   | Ok auth_change -> (
-      match Auth.create_token base_path ~agent_name ~role with
+      let create_token =
+        if is_local_mcp_client_agent agent_name then
+          Auth.create_token_without_expiry
+        else
+          Auth.create_token
+      in
+      match create_token base_path ~agent_name ~role with
       | Error err -> Error err
       | Ok (bearer_token, cred) ->
           let raw_token_file =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -885,7 +885,7 @@ let codex_mcp_headers_line indent =
 let codex_mcp_bearer_env_line indent =
   Printf.sprintf "%sbearer_token_env_var = \"MASC_MCP_TOKEN\"" indent
 
-let sync_codex_mcp_auth_header_content ~raw_token:_ content =
+let sync_codex_mcp_auth_header_content content =
   let lines, has_trailing_newline =
     split_lines_with_trailing_newline content
   in
@@ -987,7 +987,7 @@ let codex_config_path_opt () =
         (fun home -> Filename.concat home ".codex/config.toml")
         (Env_config_core.home_dir_opt ())
 
-let sync_codex_mcp_config ~base_path ~agent_name =
+let sync_codex_mcp_config ~agent_name =
   if
     not
       (Env_config_core.get_bool ~default:false sync_codex_mcp_config_env_key)
@@ -1004,38 +1004,27 @@ let sync_codex_mcp_config ~base_path ~agent_name =
             "startup skipped Codex MCP config sync: %s does not exist"
             config_path
         else
-          let token_file =
-            Filename.concat (Auth.auth_dir base_path) (agent_name ^ ".token")
-          in
           try
-            let raw_token = String.trim (Fs_compat.load_file token_file) in
-            if String.equal raw_token "" then
-              Log.Server.warn
-                "startup skipped Codex MCP config sync: raw token file is empty at %s"
-                token_file
-            else
-              let content = Fs_compat.load_file config_path in
-              let updated, status =
-                sync_codex_mcp_auth_header_content ~raw_token content
-              in
-              (match status with
-               | Codex_mcp_config_updated ->
-                   Auth.save_private_text_file config_path updated;
-                   Log.Server.warn
-                     "startup synced Codex MCP bearer-token env config for %s in %s"
-                     agent_name config_path
-               | Codex_mcp_config_unchanged ->
-                   Log.Server.info
-                     "startup Codex MCP bearer-token env config already current for %s"
-                     agent_name
-               | Codex_mcp_config_server_missing ->
-                   Log.Server.info
-                     "startup skipped Codex MCP config sync: [mcp_servers.masc] missing in %s"
-                     config_path
-               | Codex_mcp_config_header_missing ->
-                   Log.Server.info
-                     "startup skipped Codex MCP config sync: masc http_headers missing in %s"
-                     config_path)
+            let content = Fs_compat.load_file config_path in
+            let updated, status = sync_codex_mcp_auth_header_content content in
+            (match status with
+             | Codex_mcp_config_updated ->
+                 Auth.save_private_text_file config_path updated;
+                 Log.Server.warn
+                   "startup synced Codex MCP bearer-token env config for %s in %s"
+                   agent_name config_path
+             | Codex_mcp_config_unchanged ->
+                 Log.Server.info
+                   "startup Codex MCP bearer-token env config already current for %s"
+                   agent_name
+             | Codex_mcp_config_server_missing ->
+                 Log.Server.info
+                   "startup skipped Codex MCP config sync: [mcp_servers.masc] missing in %s"
+                   config_path
+             | Codex_mcp_config_header_missing ->
+                 Log.Server.info
+                   "startup skipped Codex MCP config sync: masc http_headers missing in %s"
+                   config_path)
           with
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->
@@ -1047,17 +1036,19 @@ let sync_client_token_file ~base_path ~agent_name ~role =
   let token_file =
     Filename.concat (Auth.auth_dir base_path) (agent_name ^ ".token")
   in
+  let existing_credential = Auth.load_credential base_path agent_name in
   let existing_role =
-    match Auth.load_credential base_path agent_name with
-    | Some cred -> cred.role
-    | None -> role
+    match existing_credential with Some cred -> cred.role | None -> role
   in
   let persist_raw_token raw_token =
     Fs_compat.mkdir_p (Auth.auth_dir base_path);
     Auth.save_private_text_file token_file raw_token
   in
   let create_and_persist ~reason =
-    match Auth.create_token base_path ~agent_name ~role:existing_role with
+    match
+      Auth.create_token_without_expiry base_path ~agent_name
+        ~role:existing_role
+    with
     | Ok (raw_token, _cred) ->
         (try
            persist_raw_token raw_token;
@@ -1075,8 +1066,15 @@ let sync_client_token_file ~base_path ~agent_name ~role =
           "startup failed to mint raw bearer token for %s: %s"
           agent_name (Types.masc_error_to_string err)
   in
-  let normalize_existing raw_token =
+  let normalize_existing raw_token (cred : Types.agent_credential) =
     try
+      (match cred.expires_at with
+       | None -> ()
+       | Some _ ->
+           Auth.save_credential base_path { cred with expires_at = None };
+           Log.Server.warn
+             "startup removed expiry from MCP client bearer credential for %s"
+             agent_name);
       persist_raw_token raw_token;
       Log.Server.info
         "startup verified raw bearer token file for %s at %s"
@@ -1106,10 +1104,25 @@ let sync_client_token_file ~base_path ~agent_name ~role =
   (match current_raw with
    | Some raw_token -> (
        match Auth.verify_token base_path ~agent_name ~token:raw_token with
-       | Ok _ -> normalize_existing raw_token
-       | Error _ -> create_and_persist ~reason:"repaired")
+       | Ok cred -> normalize_existing raw_token cred
+       | Error _ -> (
+           match Auth.load_credential base_path agent_name with
+           | Some (cred : Types.agent_credential)
+             when String.equal cred.token (Auth.sha256_hash raw_token) ->
+               normalize_existing raw_token cred
+           | _ -> create_and_persist ~reason:"repaired"))
    | None -> create_and_persist ~reason:"created");
-  sync_codex_mcp_config ~base_path ~agent_name
+  if String.equal agent_name "codex-mcp-client" then
+    sync_codex_mcp_config ~agent_name
+
+let sync_mcp_client_token_files ~base_path =
+  [
+    ("codex-mcp-client", Types.Worker);
+    ("claude", Types.Worker);
+    ("gemini", Types.Worker);
+  ]
+  |> List.iter (fun (agent_name, role) ->
+         sync_client_token_file ~base_path ~agent_name ~role)
 
 let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
   let base_path = state.Mcp_server.room_config.base_path in
@@ -1512,8 +1525,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       sync_admin_token_env state;
       sync_internal_keeper_token_env state;
       sync_bootable_keeper_credentials state;
-      sync_client_token_file ~base_path ~agent_name:"codex-mcp-client"
-        ~role:Types.Worker;
+      sync_mcp_client_token_files ~base_path;
       let path_diagnostics =
         runtime_path_diagnostics ~input_base_path:base_path state
       in

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -69,7 +69,7 @@ type codex_mcp_config_sync_status =
   | Codex_mcp_config_header_missing
 
 val sync_codex_mcp_auth_header_content :
-  raw_token:string -> string -> string * codex_mcp_config_sync_status
+  string -> string * codex_mcp_config_sync_status
 
 (** {1 Main Entry Point} *)
 

--- a/test/test_auth_login.ml
+++ b/test/test_auth_login.ml
@@ -60,7 +60,9 @@ let test_login_enables_bearer_auth_and_prints_codex_exports () =
        with
        | Ok cred ->
            check string "token owner" "codex-mcp-client"
-             cred.agent_name
+             cred.agent_name;
+           check (option string) "mcp token does not expire" None
+             cred.expires_at
        | Error err ->
            failf "minted token did not verify: %s"
              (Types.masc_error_to_string err));
@@ -90,6 +92,16 @@ let test_login_prints_claude_client_env () =
       check string "agent" "claude" report.agent_name;
       check string "client env" "MASC_CLAUDE_MCP_TOKEN"
         report.mcp_token_env_var;
+      (match
+         Auth.find_credential_by_token base_path
+           ~token:report.bearer_token
+       with
+       | Ok cred ->
+           check (option string) "claude mcp token does not expire" None
+             cred.expires_at
+       | Error err ->
+           failf "minted claude token did not verify: %s"
+             (Types.masc_error_to_string err));
       check string "codex env remains pinned" "MASC_MCP_TOKEN"
         report.codex_token_env_var;
       let shell = Auth_login.render_shell report in

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1618,19 +1618,46 @@ let test_main_eio_self_heals_codex_mcp_token_file () =
           in
           Alcotest.(check bool) "existing role preserved" true
             (credential.role = Types.Worker);
+          Alcotest.(check (option string)) "codex credential does not expire"
+            None credential.expires_at;
           Alcotest.(check string) "raw token hashes to stored credential"
             credential.token (Auth.sha256_hash repaired_raw);
-          match
-            Auth.verify_token dir ~agent_name:"codex-mcp-client"
-              ~token:repaired_raw
-          with
-          | Ok _ -> ()
-          | Error err ->
-              Alcotest.failf "repaired raw token should verify: %s"
-                (Types.masc_error_to_string err)))
+          (match
+             Auth.verify_token dir ~agent_name:"codex-mcp-client"
+               ~token:repaired_raw
+           with
+           | Ok _ -> ()
+           | Error err ->
+               Alcotest.failf "repaired raw token should verify: %s"
+                 (Types.masc_error_to_string err));
+          List.iter
+            (fun agent_name ->
+              let path = Filename.concat auth_dir (agent_name ^ ".token") in
+              Alcotest.(check bool)
+                (agent_name ^ " raw token file exists")
+                true (Sys.file_exists path);
+              let raw = String.trim (read_file path) in
+              let credential =
+                match Auth.load_credential dir agent_name with
+                | Some cred -> cred
+                | None ->
+                    Alcotest.failf "missing %s credential after startup"
+                      agent_name
+              in
+              Alcotest.(check (option string))
+                (agent_name ^ " credential does not expire")
+                None credential.expires_at;
+              Alcotest.(check string)
+                (agent_name ^ " raw token hashes to stored credential")
+                credential.token (Auth.sha256_hash raw);
+              match Auth.verify_token dir ~agent_name ~token:raw with
+              | Ok _ -> ()
+              | Error err ->
+                  Alcotest.failf "%s raw token should verify: %s"
+                    agent_name (Types.masc_error_to_string err))
+            [ "claude"; "gemini" ]))
 
 let test_codex_mcp_config_sync_updates_only_masc_section () =
-  let raw_token = "fresh-\"codex\"\\\\token" in
   let content =
     {|[mcp_servers.other]
 http_headers = { Authorization = "Bearer keep-other" }
@@ -1660,8 +1687,7 @@ http_headers = { Authorization = "Bearer nested-should-stay" }
 |}
   in
   let updated, status =
-    Server_runtime_bootstrap.sync_codex_mcp_auth_header_content ~raw_token
-      content
+    Server_runtime_bootstrap.sync_codex_mcp_auth_header_content content
   in
   Alcotest.(check string) "masc section updated" expected updated;
   Alcotest.(check bool) "reported updated" true
@@ -1682,7 +1708,7 @@ bearer_token_env_var = "MASC_MCP_TOKEN"
   in
   let updated, status =
     Server_runtime_bootstrap.sync_codex_mcp_auth_header_content
-      ~raw_token:"fresh-token" content
+      content
   in
   Alcotest.(check string) "missing config inserted" expected updated;
   Alcotest.(check bool) "reported updated" true


### PR DESCRIPTION
## Summary

- Make local MCP client credentials (`codex-mcp-client`, `claude`, `gemini`) non-expiring when minted through `masc-mcp login` or startup self-heal.
- Extend startup token-file sync to cover Claude and Gemini in addition to Codex, while preserving an existing live raw token and only clearing its credential expiry.
- Remove the unused raw-token dependency from Codex MCP config sync, since Codex now uses `bearer_token_env_var` rather than a hardcoded Authorization header.
- Update the local dashboard auth runbook and regression coverage.

## Root Cause

The local MCP clients were being written with the global default `token_expiry_hours = 24`. Codex then surfaced that bearer-token failure as `The masc MCP server is not logged in. Run codex mcp login masc`, but `codex mcp login` is the wrong path for this server because MASC uses bearer-token MCP auth, not OAuth.

## Operator Impact

After this change, long-running local Codex/Claude/Gemini MCP sessions should stop falling into daily bearer expiry. Startup also repairs older still-valid token files by clearing `expires_at` without rotating the raw token, so current client sessions do not get invalidated unnecessarily.

## Validation

- `MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_auth_login.exe test/test_server_runtime_bootstrap.exe bin/main_eio.exe`
- `./_build/default/test/test_auth_login.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 43..43`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 44-45`
- `git diff --check`

## Live Local Repair

Also repaired this machine's active `/Users/dancer/me/.masc/auth/agents/{codex-mcp-client,claude,gemini}.json` credentials to `expires_at = null`; `doctor auth --base-path /Users/dancer/me --json` reported all three MCP clients `identity_ready=true`, and a real `/mcp initialize` call returned HTTP 200.