### PR TITLE
feat(keeper): K5 — Prometheus gauge for K4c accumulator registry size

### DIFF
--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -87,16 +87,28 @@ let global_accumulator = create_accumulator ()
 let registry : (string, accumulator) Hashtbl.t = Hashtbl.create 16
 let registry_mutex : Stdlib.Mutex.t = Stdlib.Mutex.create ()
 
+(* Tier K5 — emit registry size gauge after every register/drop so
+   operators can alert on divergence from the active keeper count.
+   Caller MUST already hold [registry_mutex]; we read the size
+   under the same lock that mutated the table. No labels. *)
+let emit_registry_size_gauge_holding_lock () : unit =
+  let n = Hashtbl.length registry in
+  Prometheus.set_gauge
+    Prometheus.metric_keeper_tool_emission_registry_size
+    ~labels:[]
+    (float_of_int n)
+
 let accumulator_for_keeper (keeper_name : string) : accumulator =
   Stdlib.Mutex.lock registry_mutex;
-  let acc =
+  let acc, grew =
     match Hashtbl.find_opt registry keeper_name with
-    | Some a -> a
+    | Some a -> a, false
     | None ->
         let a = create_accumulator () in
         Hashtbl.add registry keeper_name a;
-        a
+        a, true
   in
+  if grew then emit_registry_size_gauge_holding_lock ();
   Stdlib.Mutex.unlock registry_mutex;
   acc
 
@@ -108,5 +120,7 @@ let registered_keeper_names () : string list =
 
 let drop_keeper_accumulator (keeper_name : string) : unit =
   Stdlib.Mutex.lock registry_mutex;
+  let was_present = Hashtbl.mem registry keeper_name in
   Hashtbl.remove registry keeper_name;
+  if was_present then emit_registry_size_gauge_holding_lock ();
   Stdlib.Mutex.unlock registry_mutex

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -372,6 +372,14 @@ let metric_keeper_operator_clear = "masc_keeper_operator_clear_total"
 let metric_keeper_compaction_noop =
   "masc_keeper_compaction_noop_total"
 
+(* Tier K5 — observability over the K4c per-keeper tool-emission
+   accumulator registry. The registry is process-local; this gauge
+   exposes its size so operators can alert on divergence from the
+   active keeper count (a leak symptom would be registry size >
+   live keeper count without trending down on teardown). *)
+let metric_keeper_tool_emission_registry_size =
+  "masc_keeper_tool_emission_registry_size"
+
 (* #10349: keeper FS path rejection counter.  Pre-fix the
    user-facing read-path rejection strings carried the resolver's
    view of allowed sandbox roots (for example [(roots=[<list>])]
@@ -906,6 +914,12 @@ let init () =
      after_tokens > 0 (compaction triggered but produced no \
      savings; labels: keeper, trigger)"
     Counter;
+  (* K5: per-keeper tool-emission accumulator registry size.
+     Updated by Keeper_tool_emission_hook on register/drop. *)
+  add metric_keeper_tool_emission_registry_size
+    "Number of keepers with a registered tool-emission \
+     accumulator (Tier K4c per-keeper isolation registry size)"
+    Gauge;
   (* Operator-initiated overflow recovery — emitted by tool_keeper.ml *)
   add metric_keeper_operator_compact
     "Total operator-invoked masc_keeper_compact calls (labels: result=ok|no_checkpoint|precondition|not_found)" Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -139,6 +139,13 @@ val metric_keeper_compaction_saved_tokens : string
     triggers rather than savings.  Labels: [keeper, trigger]. *)
 val metric_keeper_compaction_noop : string
 
+(** Tier K5 — registry size for the per-keeper tool-emission
+    accumulator (Tier K4c). Operators can alert on divergence from
+    the active keeper count — a steady-state leak shows up as the
+    gauge climbing past live keeper count without trending back
+    down on keeper_down / supervisor cleanup. No labels. *)
+val metric_keeper_tool_emission_registry_size : string
+
 val metric_keeper_operator_compact : string
 val metric_keeper_operator_clear : string
 


### PR DESCRIPTION
## Summary

Adds `masc_keeper_tool_emission_registry_size` (Gauge, no labels) emitted by `Keeper_tool_emission_hook` every time the K4c per-keeper accumulator registry mutates:

- `accumulator_for_keeper` when it lazily creates a new entry
- `drop_keeper_accumulator` when an entry is actually removed

## Operator alert pattern

The gauge climbing past **live keeper count** without trending back down on `keeper_down` / supervisor cleanup is a **leak symptom**. Couple this with `Keeper_registry` size (already exposed) for divergence alerting.

## Why no `keeper` label

The registry is process-global. Labeling per-keeper would create gauge cardinality proportional to the keeper population — but the value is the same gauge for every keeper. Per-keeper visibility comes from `registered_keeper_names` (diagnostics endpoint), not Prometheus.

## Implementation note

`emit_registry_size_gauge_holding_lock` is called **under** `registry_mutex` so the size we read is the size we just established. Releasing the lock first would race against another thread's mutation and emit a stale value.

## Files

| File | Change |
|------|--------|
| `lib/prometheus.ml` | Define `metric_keeper_tool_emission_registry_size`; register as Gauge in `default_metrics` |
| `lib/prometheus.mli` | Export |
| `lib/keeper/keeper_tool_emission_hook.ml` | Helper `emit_registry_size_gauge_holding_lock`; called from `accumulator_for_keeper` (when entry is newly created) and `drop_keeper_accumulator` (when entry was actually present) |

## Test plan

- [x] `dune build --root .` GREEN
- [x] `test_keeper_tool_emission_hook` 14/14 GREEN (no regression)
- [ ] Live: spawn N keepers → gauge = N; keeper_down k → gauge = N-1