### PR TITLE
refactor(observability): type cascade labels at metric boundaries

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -137,7 +137,6 @@ let check_host_resources ~keeper_name =
     Ok ()
 
 let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
-  let cascade_name = Keeper_cascade_profile.runtime_name_to_string cascade_name in
   match check_host_resources ~keeper_name with
   | Error _ as e -> e
   | Ok () ->
@@ -157,7 +156,6 @@ let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
         raise exn
 
 let try_with_permit ~priority:_ ~keeper_name ~cascade_name f =
-  let cascade_name = Keeper_cascade_profile.runtime_name_to_string cascade_name in
   match check_host_resources ~keeper_name with
   | Error _ -> None
   | Ok () ->

--- a/lib/admission_queue_metrics.mli
+++ b/lib/admission_queue_metrics.mli
@@ -5,11 +5,16 @@
 
     @since 3.0.0 *)
 
-val on_acquire : keeper_name:string -> cascade_name:string -> wait_ms:int -> unit
+val on_acquire :
+  keeper_name:string ->
+  cascade_name:Keeper_cascade_profile.runtime_name ->
+  wait_ms:int ->
+  unit
 (** Called after successful acquire. Increments inflight gauge,
     records wait time histogram. *)
 
-val on_release : keeper_name:string -> cascade_name:string -> unit
+val on_release :
+  keeper_name:string -> cascade_name:Keeper_cascade_profile.runtime_name -> unit
 (** Called on release. Decrements inflight gauge. *)
 
 val set_max_concurrent : int -> unit

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -695,7 +695,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             Otel_genai.with_keeper_turn_span
               ~keeper_name:run_meta.name
               ~agent_name:run_meta.agent_name
-              ~cascade_name:execution.cascade_name
+              ~cascade_name:
+                (Keeper_cascade_profile.Runtime_name execution.cascade_name)
               ~trace_id:(Keeper_id.Trace_id.to_string run_meta.runtime.trace_id)
               ~generation:run_generation
               ~max_context:execution.max_context

--- a/lib/otel/otel_genai.ml
+++ b/lib/otel/otel_genai.ml
@@ -21,6 +21,7 @@ let keeper_turn_attrs
       ~is_retry
       ~current_task_id
   =
+  let cascade_name = Keeper_cascade_profile.runtime_name_to_string cascade_name in
   let optional_attrs =
     match current_task_id with
     | None -> []

--- a/lib/otel/otel_genai.mli
+++ b/lib/otel/otel_genai.mli
@@ -7,7 +7,7 @@ val keeper_turn_span_name : keeper_name:string -> string
 val keeper_turn_attrs
   :  keeper_name:string
   -> agent_name:string
-  -> cascade_name:string
+  -> cascade_name:Keeper_cascade_profile.runtime_name
   -> trace_id:string
   -> generation:int
   -> max_context:int
@@ -21,7 +21,7 @@ val keeper_turn_attrs
 val with_keeper_turn_span
   :  keeper_name:string
   -> agent_name:string
-  -> cascade_name:string
+  -> cascade_name:Keeper_cascade_profile.runtime_name
   -> trace_id:string
   -> generation:int
   -> max_context:int

--- a/test/test_otel_genai.ml
+++ b/test/test_otel_genai.ml
@@ -2,6 +2,7 @@ module Lib = Masc_mcp
 open Alcotest
 
 let assoc key attrs = List.assoc_opt key attrs
+let cascade_name raw = Lib.Keeper_cascade_profile.Runtime_name raw
 
 let test_keeper_turn_span_name () =
   check
@@ -16,7 +17,7 @@ let test_keeper_turn_attrs_dual_emit () =
     Lib.Otel_genai.keeper_turn_attrs
       ~keeper_name:"ani1999"
       ~agent_name:"ani1999"
-      ~cascade_name:"research"
+      ~cascade_name:(cascade_name "research")
       ~trace_id:"trace-123"
       ~generation:7
       ~max_context:120000
@@ -87,7 +88,7 @@ let test_keeper_turn_attrs_omit_missing_task () =
     Lib.Otel_genai.keeper_turn_attrs
       ~keeper_name:"ani1999"
       ~agent_name:"ani1999"
-      ~cascade_name:"research"
+      ~cascade_name:(cascade_name "research")
       ~trace_id:"trace-123"
       ~generation:7
       ~max_context:120000


### PR DESCRIPTION
## Summary
- Refs #11926.
- Type admission queue metric cascade labels as `Keeper_cascade_profile.runtime_name`.
- Type OTel GenAI keeper-turn cascade labels and render to string only at the span attribute boundary.
- Preserve existing operator labels by wrapping the selected execution cascade as `Runtime_name raw` instead of canonicalizing it during observability emission.

## Product impact
Admission queue metrics and OTel keeper spans now receive typed cascade labels at the API boundary while keeping Prometheus/OTel output strings stable. This continues the C-T7.2 cascade_name string-surface reduction.

## Validation
- `scripts/dune-local.sh build test/test_admission_queue_coverage.exe test/test_otel_genai.exe test/test_keeper_unified.exe` passed before final rebase on the same patch.
- `./_build/default/test/test_admission_queue_coverage.exe` passed: 17 tests.
- `./_build/default/test/test_otel_genai.exe` passed: 3 tests.
- Post-rebase `git diff --check HEAD~1 HEAD` passed.
- Post-rebase `scripts/stringly-boundary-ratchet.sh` passed: `cascade_name 62 / 81`.

## Notes
After rebasing onto the latest `origin/main`, a focused Dune rebuild retry was stopped while waiting on the shared `/tmp/me-dune-local.lock`; CI should be the post-rebase build authority for this draft.