### PR TITLE
chore(keeper): demote noisy routine logs

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -495,7 +495,7 @@ let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
 let reconcile_keepalive_keepers (ctx : _ context) =
   let base_path = ctx.config.base_path in
   let names = Keeper_types.keepalive_keeper_names ctx.config in
-  Log.Keeper.info "reconcile_keepalive_keepers: started (candidates=%d)"
+  Log.Keeper.debug "reconcile_keepalive_keepers: started (candidates=%d)"
     (List.length names);
   let t0 = Time_compat.now () in
   List.iter (fun name ->
@@ -534,7 +534,7 @@ let reconcile_keepalive_keepers (ctx : _ context) =
          | Error err ->
              Log.Keeper.debug "reconcile: read_meta failed for %s: %s" name err)
     names;
-  Log.Keeper.info "reconcile_keepalive_keepers: completed (elapsed_ms=%d)"
+  Log.Keeper.debug "reconcile_keepalive_keepers: completed (elapsed_ms=%d)"
     (int_of_float ((Time_compat.now () -. t0) *. 1000.0))
 
 let cleanup_dead_tombstone (ctx : _ context)

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -382,10 +382,10 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
           Eio.Semaphore.acquire sem);
         Ok ()
       with Eio.Time.Timeout ->
-        (* INFO not WARN: see commentary above — keeper skips this turn
-           and the next heartbeat re-queues it. Per-event noise hurts
-           operator signal more than it helps. *)
-        Log.Keeper.info
+        (* DEBUG not WARN: the keeper-specific heartbeat loop already
+           emits the operator-facing skip warning with owner/cascade
+           context, while the metric below preserves attribution. *)
+        Log.Keeper.debug
           "semaphore_wait: %s semaphore wait exceeded %.0fs (channel=%s), \
            skipping turn"
           label semaphore_wait_timeout_sec

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -186,11 +186,11 @@ let register_pre_hook () =
     match hook ~name ~args:compat_args with
     | Oas.Tool_middleware.Pass
       when not (Yojson.Safe.equal compat_args args) ->
-      Log.info "tool_input_validation coerced args for %s" name;
+      Log.debug "tool_input_validation coerced args for %s" name;
       Proceed compat_args
     | Oas.Tool_middleware.Pass -> Pass
     | Oas.Tool_middleware.Proceed coerced ->
-      Log.info "tool_input_validation coerced args for %s" name;
+      Log.debug "tool_input_validation coerced args for %s" name;
       Proceed coerced
     | Oas.Tool_middleware.Reject { message; _ } ->
       let augmented = augment_missing_param_hint ~args:compat_args message in


### PR DESCRIPTION
## Summary

Demote routine keeper/runtime log lines that were showing up as operator-facing `Info` noise:

- successful `tool_input_validation coerced args` messages now log at `Debug`
- generic semaphore wait timeout messages now log at `Debug`, leaving the keeper-specific `WARN ... skipping turn` line and Prometheus counter as the operator signal
- periodic `reconcile_keepalive_keepers` start/completed messages now log at `Debug`, while actual durable keeper reconciliation remains `Info`

## Why

The pasted runtime logs mixed actionable keeper starvation/stale-fiber signals with high-volume success and sweep bookkeeping logs. This keeps warnings, lifecycle events, metrics, and actual reconciliation visible while removing repeated non-actionable lines from normal operator logs.

## Validation

- `git diff --check`
- attempted focused `scripts/dune-local.sh build lib/keeper/keeper_supervisor.ml lib/keeper/keeper_turn_slot.ml lib/tool_input_validation.ml`, but stopped after waiting on the shared Dune lock for over 90 seconds due concurrent local builds

## Runtime note

The live server checked on `127.0.0.1:8935` was running build commit `61dba36f28`, which does not contain `f090bf207c fix(keeper): suppress stale watchdog during semaphore waits (#12288)`. The stale watchdog terminations seen during semaphore wait should be rechecked after restarting onto current main or this branch.