### PR TITLE
feat(dashboard_bonsai): F6 — surface Multimodal in sidebar nav

### DIFF
--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -709,6 +709,7 @@ let nav ~(active : Route.t) =
     ; lnk Tools
     ; lnk Sessions
     ; lnk Social_board
+    ; lnk Multimodal
     ; section "crypt"
     ; lnk Dead_keepers
     ; lnk Archive_runs


### PR DESCRIPTION
## Summary

Adds \`lnk Multimodal\` under the **lab** section of \`shell_view.nav\` so operators can navigate to the gallery from the sidebar instead of typing the URL.

## Drift root cause

\`Route.all\` is currently NOT the SSOT for sidebar order — \`shell_view.nav\` hardcodes the link list. Multimodal was already in \`Route.all\` and marked \`is_implemented = true\` since F1, but never rendered.

This PR fixes the symptom (1-line addition). Tracking the structural fix (make \`shell_view.nav\` iterate \`Route.all\`) separately.