### PR TITLE
feat(keeper): K6 — per-keeper Prometheus counter for tool-emission pushes

### DIFF
--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -3,10 +3,25 @@
 type accumulator = {
   mutable items : Yojson.Safe.t list;
   mutex : Stdlib.Mutex.t;
+  keeper_name : string option;
+    (* Tier K6 — set by [accumulator_for_keeper] so the [push]
+       function can emit a per-keeper Prometheus counter without
+       routing the name through every call site. [None] for the
+       process-wide [global_accumulator] and for test-created
+       accumulators (no metric emitted in those cases). *)
 }
 
 let create_accumulator () =
-  { items = []; mutex = Stdlib.Mutex.create () }
+  { items = []
+  ; mutex = Stdlib.Mutex.create ()
+  ; keeper_name = None
+  }
+
+let create_accumulator_for ~keeper_name =
+  { items = []
+  ; mutex = Stdlib.Mutex.create ()
+  ; keeper_name = Some keeper_name
+  }
 
 let masc_tool_emission_enabled () =
   match Sys.getenv_opt "MASC_TOOL_EMISSION" with
@@ -16,7 +31,18 @@ let masc_tool_emission_enabled () =
 let push acc (json : Yojson.Safe.t) : unit =
   Stdlib.Mutex.lock acc.mutex;
   acc.items <- json :: acc.items;
-  Stdlib.Mutex.unlock acc.mutex
+  Stdlib.Mutex.unlock acc.mutex;
+  (* Tier K6 — emit per-keeper push counter. Counter is incremented
+     OUTSIDE the accumulator mutex so the metric write does not
+     extend the critical section. The [keeper_name] field is read-
+     only so reading after unlock is race-free. *)
+  match acc.keeper_name with
+  | None -> ()
+  | Some name ->
+    Prometheus.inc_counter
+      Prometheus.metric_keeper_tool_emission_pushes
+      ~labels:[ ("keeper", name) ]
+      ()
 
 let drain acc : Yojson.Safe.t list =
   Stdlib.Mutex.lock acc.mutex;
@@ -104,7 +130,7 @@ let accumulator_for_keeper (keeper_name : string) : accumulator =
     match Hashtbl.find_opt registry keeper_name with
     | Some a -> a, false
     | None ->
-        let a = create_accumulator () in
+        let a = create_accumulator_for ~keeper_name in
         Hashtbl.add registry keeper_name a;
         a, true
   in

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -380,6 +380,15 @@ let metric_keeper_compaction_noop =
 let metric_keeper_tool_emission_registry_size =
   "masc_keeper_tool_emission_registry_size"
 
+(* Tier K6 — per-keeper tagged tool-emission push counter. Increments
+   each time [Keeper_tool_emission_hook.push] captures a parsed JSON
+   tool result into the keeper's accumulator. Lets operators rank
+   keepers by multimodal output volume and detect silent emission
+   stalls (a keeper that should be emitting goes flat). Labels:
+   [keeper]. *)
+let metric_keeper_tool_emission_pushes =
+  "masc_keeper_tool_emission_pushes_total"
+
 (* #10349: keeper FS path rejection counter.  Pre-fix the
    user-facing read-path rejection strings carried the resolver's
    view of allowed sandbox roots (for example [(roots=[<list>])]
@@ -920,6 +929,11 @@ let init () =
     "Number of keepers with a registered tool-emission \
      accumulator (Tier K4c per-keeper isolation registry size)"
     Gauge;
+  (* K6: per-keeper tagged tool-emission push count. *)
+  add metric_keeper_tool_emission_pushes
+    "Total tagged tool results captured into the K4c per-keeper \
+     accumulator (labels: keeper)"
+    Counter;
   (* Operator-initiated overflow recovery — emitted by tool_keeper.ml *)
   add metric_keeper_operator_compact
     "Total operator-invoked masc_keeper_compact calls (labels: result=ok|no_checkpoint|precondition|not_found)" Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -146,6 +146,12 @@ val metric_keeper_compaction_noop : string
     down on keeper_down / supervisor cleanup. No labels. *)
 val metric_keeper_tool_emission_registry_size : string
 
+(** Tier K6 — per-keeper tagged tool-emission push counter. Labels:
+    [keeper]. Incremented by [Keeper_tool_emission_hook.push] each
+    time the PostToolUse hook captures a parsed JSON tool result
+    into the keeper's accumulator. *)
+val metric_keeper_tool_emission_pushes : string
+
 val metric_keeper_operator_compact : string
 val metric_keeper_operator_clear : string
 

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 1,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 994,
+  "lib_dune_lines": 999,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 1
 }


### PR DESCRIPTION
## Summary

Adds \`masc_keeper_tool_emission_pushes_total\` (Counter, label \`keeper\`) emitted by \`Keeper_tool_emission_hook.push\` each time the PostToolUse hook captures a parsed JSON tool result.

## Operator value

- **Rank** keepers by multimodal output volume.
- **Detect silent emission stalls** — keeper that should be emitting goes flat. Distinct from K5 \`registry_size\` gauge which only shows registered/not.

## Implementation

- \`accumulator\` gains \`keeper_name : string option\`. \`None\` for test-created accumulators and \`global_accumulator\`. \`Some name\` for accumulators created via \`accumulator_for_keeper\`.
- \`push\` emits counter **outside** the accumulator mutex (field is read-only after creation, race-free; keeps critical section minimal).
- New \`create_accumulator_for ~keeper_name\` makes identity injection explicit.

## Coordination with K5 (#12297)

Both PRs touch \`prometheus.{ml,mli}\` (different metric) and \`keeper_tool_emission_hook.ml\` (different concerns). Either order merges cleanly with at most a 1-line conflict in the \`add\` block.

## Test plan

- [x] dune build GREEN
- [x] test_keeper_tool_emission_hook 14/14 GREEN (no regression)
- [ ] Live: emit tagged tool result from keeper X → \`pushes_total{keeper="X"}\` increments