### PR TITLE
feat(server): D3 — server-side filter for /api/v1/multimodal/list

### DIFF
--- a/lib/server/server_routes_http_routes_multimodal.ml
+++ b/lib/server/server_routes_http_routes_multimodal.ml
@@ -12,13 +12,98 @@ let workspace_getter : (unit -> W.t) ref = ref (fun () -> W.empty)
 
 let bind_workspace_getter f = workspace_getter := f
 
-let list_response () =
+(* Tier D3 — server-side filter helpers for /api/v1/multimodal/list.
+
+   Mirrors the client-side filter in [Multimodal_filter_view] so
+   F4-driven UI and direct API consumers (curl, scripts) see the
+   same matching semantics. The filter operates on the post-
+   serialization JSON rather than the typed [Artifact.any]
+   existential because [created_by]/metadata-keys access from
+   outside the [Multimodal] module would require new accessors;
+   the JSON representation already carries every field we need. *)
+
+let lower (s : string) = String.lowercase_ascii s
+
+let case_contains ~(haystack : string) ~(needle : string) : bool =
+  if needle = "" then true
+  else
+    let h = lower haystack in
+    let n = lower needle in
+    let lh = String.length h in
+    let ln = String.length n in
+    if ln > lh then false
+    else
+      let rec loop i =
+        if i + ln > lh then false
+        else if String.sub h i ln = n then true
+        else loop (i + 1)
+      in
+      loop 0
+
+let json_string_field (json : Yojson.Safe.t) (field : string) : string =
+  match Yojson.Safe.Util.member field json with
+  | `String s -> s
+  | _ -> ""
+
+let json_created_by (json : Yojson.Safe.t) : string =
+  match Yojson.Safe.Util.member "provenance" json with
+  | `Null -> ""
+  | prov -> json_string_field prov "created_by"
+
+let json_metadata_keys (json : Yojson.Safe.t) : string list =
+  match Yojson.Safe.Util.member "metadata" json with
+  | `Assoc kv -> List.map fst kv
+  | _ -> []
+
+let artifact_passes
+    ~(kind_filter : string option)
+    ~(created_by_filter : string option)
+    ~(query : string option)
+    (json : Yojson.Safe.t)
+    : bool
+  =
+  let kind_ok =
+    match kind_filter with
+    | None -> true
+    | Some k -> json_string_field json "kind" = k
+  in
+  let created_by_ok =
+    match created_by_filter with
+    | None -> true
+    | Some cb -> json_created_by json = cb
+  in
+  let q_ok =
+    match query with
+    | None -> true
+    | Some "" -> true
+    | Some q ->
+      case_contains ~haystack:(json_string_field json "id") ~needle:q
+      || case_contains ~haystack:(json_string_field json "kind") ~needle:q
+      || case_contains ~haystack:(json_created_by json) ~needle:q
+      || List.exists
+           (fun k -> case_contains ~haystack:k ~needle:q)
+           (json_metadata_keys json)
+  in
+  kind_ok && created_by_ok && q_ok
+
+let list_response ?kind_filter ?created_by_filter ?query () =
   let ws = !workspace_getter () in
   let arts = W.all ws in
+  let json_arts = List.map A.any_to_json arts in
+  let filtered =
+    if kind_filter = None && created_by_filter = None && query = None
+    then json_arts
+    else
+      List.filter
+        (artifact_passes ~kind_filter ~created_by_filter ~query)
+        json_arts
+  in
   `Assoc
     [
-      ("count", `Int (List.length arts));
-      ("artifacts", `List (List.map A.any_to_json arts));
+      ("count", `Int (List.length filtered));
+      (* Pre-filter total — lets the F4 client show "N of M". *)
+      ("total", `Int (List.length json_arts));
+      ("artifacts", `List filtered);
     ]
 
 let parse_id id_str = Aid.of_string id_str
@@ -76,7 +161,16 @@ let add_routes router =
        (fun request reqd ->
          with_public_read
            (fun _state _req reqd ->
-             let json = list_response () in
+             let kind_filter =
+               Server_utils.query_param request "kind"
+             in
+             let created_by_filter =
+               Server_utils.query_param request "created_by"
+             in
+             let query = Server_utils.query_param request "q" in
+             let json =
+               list_response ?kind_filter ?created_by_filter ?query ()
+             in
              respond_public_read_json ~status:`OK request reqd
                (Yojson.Safe.to_string json))
            request reqd)

--- a/lib/server/server_routes_http_routes_multimodal.mli
+++ b/lib/server/server_routes_http_routes_multimodal.mli
@@ -33,9 +33,24 @@ val bind_workspace_getter :
     integration follow-up to wire keeper-side state into the
     HTTP surface. *)
 
-val list_response : unit -> Yojson.Safe.t
-(** [{ "count": n, "artifacts": [...] }] envelope listing
-    every artifact currently in the workspace. *)
+val list_response :
+  ?kind_filter:string ->
+  ?created_by_filter:string ->
+  ?query:string ->
+  unit ->
+  Yojson.Safe.t
+(** Tier D3 — server-side filtered list envelope.
+
+    Returns [{ "count": filtered_n, "total": pre_filter_n,
+    "artifacts": [...] }]. When all three filter args are absent,
+    [count = total] and the artifact list is unfiltered (mirrors
+    the pre-D3 behavior).
+
+    Filter semantics (mirrored in dashboard's [Multimodal_filter_view]):
+    - [kind_filter]: exact-match against artifact's [kind] field
+    - [created_by_filter]: exact-match against [provenance.created_by]
+    - [query]: case-insensitive substring against [id], [kind],
+      [created_by], and [metadata]'s top-level keys *)
 
 val artifact_response :
   id_str:string -> Yojson.Safe.t * Httpun.Status.t


### PR DESCRIPTION
## Summary

Adds query-param-driven filter to the F1 list endpoint, mirroring the F4 client-side filter so UI and direct API consumers (curl, scripts) share semantics.

## Query params

| Param | Semantics |
|-------|-----------|
| \`?kind=<exact>\` | exact-match against \`artifact.kind\` |
| \`?created_by=<exact>\` | exact-match against \`provenance.created_by\` |
| \`?q=<substring>\` | case-insensitive substring against id / kind / created_by / metadata top-level keys |

## Response shape change

Adds \`"total": <pre_filter_n>\` so F4 client can show "N of M". Existing F1 client only reads \`count\` and \`artifacts\` — backwards compatible.

## Why JSON-level filter

\`Artifact.any\` is an existential GADT; \`created_by\` / metadata-keys access from outside \`Multimodal\` would require new public accessors. \`any_to_json\` already carries every field — small extra cost (one field walk per artifact) that doesn't matter at current scale (10s–100s artifacts).

## Coordinated with F4 (#12286 merged) and F5 (#12298)

F4 client-side filter still works (server returns full list when no params present). When F4 evolves to push filters as URL params, this PR is the receiver.

## Test plan

- [x] dune build GREEN
- [ ] Live: \`curl /api/v1/multimodal/list?kind=image\` returns only image artifacts; \`?q=foo\` substring matches; missing params → unfiltered list