### PR TITLE
feat: multi-repository architecture

### DIFF
--- a/dashboard/src/components/add-repo-dialog.ts
+++ b/dashboard/src/components/add-repo-dialog.ts
@@ -1,0 +1,296 @@
+// Add Repository Dialog — modal for registering a new repository.
+// POST /api/v1/repositories on submit.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { post } from '../api/core'
+import { showToast } from './common/toast'
+import { fetchRepositories, showAddRepoDialog } from './repo-sidebar'
+import { X } from 'lucide-preact'
+
+// ── Types ────────────────────────────────────────────────
+
+export interface CredentialOption {
+  id: string
+  name: string
+}
+
+// ── Form state ───────────────────────────────────────────
+
+const formName = signal('')
+const formUrl = signal('')
+const formLocalPath = signal('')
+const formDefaultBranch = signal('main')
+const formCredentialId = signal('')
+const formAutoSync = signal(true)
+const formSyncInterval = signal(300)
+const formSubmitting = signal(false)
+const formError = signal<string | null>(null)
+const credentialsResource = signal<CredentialOption[]>([])
+const credentialsLoading = signal(false)
+
+function resetForm(): void {
+  formName.value = ''
+  formUrl.value = ''
+  formLocalPath.value = ''
+  formDefaultBranch.value = 'main'
+  formCredentialId.value = ''
+  formAutoSync.value = true
+  formSyncInterval.value = 300
+  formError.value = null
+}
+
+export function openAddRepoDialog(): void {
+  resetForm()
+  showAddRepoDialog.value = true
+  void loadCredentials()
+}
+
+export function closeAddRepoDialog(): void {
+  showAddRepoDialog.value = false
+  resetForm()
+}
+
+// ── API ──────────────────────────────────────────────────
+
+async function loadCredentials(): Promise<void> {
+  credentialsLoading.value = true
+  try {
+    const raw = await post<unknown[]>('/api/v1/credentials/list', {})
+    const options: CredentialOption[] = raw
+      .filter((item): item is Record<string, unknown> =>
+        item !== null && typeof item === 'object',
+      )
+      .map(item => ({
+        id: typeof item.id === 'string' ? item.id : '',
+        name: typeof item.name === 'string' ? item.name : '',
+      }))
+      .filter(opt => opt.id && opt.name)
+    credentialsResource.value = options
+  } catch (err) {
+    console.warn('[add-repo-dialog] credentials load failed', err)
+    credentialsResource.value = []
+  } finally {
+    credentialsLoading.value = false
+  }
+}
+
+async function submitAddRepo(): Promise<void> {
+  if (formSubmitting.value) return
+
+  const name = formName.value.trim()
+  const url = formUrl.value.trim()
+  const localPath = formLocalPath.value.trim()
+  const defaultBranch = formDefaultBranch.value.trim() || 'main'
+
+  if (!name) {
+    formError.value = '저장소 이름을 입력하세요.'
+    return
+  }
+  if (!url) {
+    formError.value = '저장소 URL을 입력하세요.'
+    return
+  }
+  if (!localPath) {
+    formError.value = '로컬 경로를 입력하세요.'
+    return
+  }
+
+  formSubmitting.value = true
+  formError.value = null
+
+  try {
+    await post('/api/v1/repositories', {
+      name,
+      url,
+      local_path: localPath,
+      default_branch: defaultBranch,
+      credential_id: formCredentialId.value || null,
+      auto_sync: formAutoSync.value,
+      sync_interval: Math.max(60, formSyncInterval.value),
+    })
+    showToast('저장소 등록 완료', 'success')
+    closeAddRepoDialog()
+    await fetchRepositories()
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '저장소 등록 실패'
+    formError.value = msg
+    showToast(msg, 'error')
+  } finally {
+    formSubmitting.value = false
+  }
+}
+
+// ── Styles ───────────────────────────────────────────────
+
+const inputBase =
+  'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded py-2 px-3 font-sans focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all shadow-inner'
+
+const labelBase = 'block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5'
+
+// ── Component ────────────────────────────────────────────
+
+export function AddRepoDialog() {
+  const open = showAddRepoDialog.value
+  if (!open) return null
+
+  const credentials = credentialsResource.value
+  const hasCredentials = credentials.length > 0
+
+  return html`
+    <div
+      class="fixed inset-0 z-[var(--z-overlay-modal,3060)] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="add-repo-title"
+      onClick=${(e: Event) => {
+        if (e.target === e.currentTarget) closeAddRepoDialog()
+      }}
+    >
+      <div class="w-full max-w-lg rounded-xl border border-[var(--white-10)] bg-[var(--color-bg-surface)] shadow-[0_20px_50px_rgba(0,0,0,0.4)] mx-4">
+        <div class="flex items-center justify-between px-4 py-3 border-b border-[var(--white-10)]">
+          <h2 id="add-repo-title" class="text-sm font-semibold text-[var(--color-fg-secondary)]">
+            저장소 추가
+          </h2>
+          <button
+            type="button"
+            class="p-1 rounded text-[var(--color-fg-muted)] hover:text-[var(--color-fg-secondary)] hover:bg-[var(--white-10)] cursor-pointer transition-colors"
+            aria-label="닫기"
+            onClick=${closeAddRepoDialog}
+          >
+            <${X} size=${16} />
+          </button>
+        </div>
+
+        <div class="px-4 py-4 space-y-4 max-h-[70vh] overflow-y-auto">
+          ${formError.value
+            ? html`
+              <div class="rounded border border-[var(--bad-30)] bg-[var(--bad-12)] px-3 py-2 text-xs text-[var(--bad-light)]" role="alert">
+                ${formError.value}
+              </div>
+            `
+            : null}
+
+          <div>
+            <label class="${labelBase}">이름 <span class="text-[var(--color-status-err)]">*</span></label>
+            <input
+              type="text"
+              class="${inputBase}"
+              placeholder="my-project"
+              value=${formName.value}
+              onInput=${(e: Event) => { formName.value = (e.target as HTMLInputElement).value }}
+              disabled=${formSubmitting.value}
+            />
+          </div>
+
+          <div>
+            <label class="${labelBase}">URL <span class="text-[var(--color-status-err)]">*</span></label>
+            <input
+              type="text"
+              class="${inputBase}"
+              placeholder="https://github.com/owner/repo.git"
+              value=${formUrl.value}
+              onInput=${(e: Event) => { formUrl.value = (e.target as HTMLInputElement).value }}
+              disabled=${formSubmitting.value}
+            />
+          </div>
+
+          <div>
+            <label class="${labelBase}">로컬 경로 <span class="text-[var(--color-status-err)]">*</span></label>
+            <input
+              type="text"
+              class="${inputBase}"
+              placeholder="/path/to/local/clone"
+              value=${formLocalPath.value}
+              onInput=${(e: Event) => { formLocalPath.value = (e.target as HTMLInputElement).value }}
+              disabled=${formSubmitting.value}
+            />
+          </div>
+
+          <div>
+            <label class="${labelBase}">기본 브랜치</label>
+            <input
+              type="text"
+              class="${inputBase}"
+              placeholder="main"
+              value=${formDefaultBranch.value}
+              onInput=${(e: Event) => { formDefaultBranch.value = (e.target as HTMLInputElement).value }}
+              disabled=${formSubmitting.value}
+            />
+          </div>
+
+          <div>
+            <label class="${labelBase}">인증 정보</label>
+            <select
+              class="${inputBase}"
+              value=${formCredentialId.value}
+              onChange=${(e: Event) => { formCredentialId.value = (e.target as HTMLSelectElement).value }}
+              disabled=${formSubmitting.value || credentialsLoading.value}
+            >
+              <option value="">선택 안 함</option>
+              ${hasCredentials
+                ? credentials.map(c => html`<option value=${c.id}>${c.name}</option>`)
+                : null}
+            </select>
+            ${credentialsLoading.value
+              ? html`<span class="text-2xs text-[var(--color-fg-muted)] mt-1 block">인증 정보 로딩 중...</span>`
+              : !hasCredentials
+                ? html`<span class="text-2xs text-[var(--color-fg-muted)] mt-1 block">등록된 인증 정보가 없습니다.</span>`
+                : null}
+          </div>
+
+          <div class="flex items-center gap-3">
+            <label class="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked=${formAutoSync.value}
+                onChange=${(e: Event) => { formAutoSync.value = (e.target as HTMLInputElement).checked }}
+                disabled=${formSubmitting.value}
+              />
+              <span class="text-xs text-[var(--color-fg-secondary)]">자동 동기화</span>
+            </label>
+          </div>
+
+          ${formAutoSync.value
+            ? html`
+              <div>
+                <label class="${labelBase}">동기화 간격 (초)</label>
+                <input
+                  type="number"
+                  class="${inputBase}"
+                  min=${60}
+                  step=${60}
+                  value=${formSyncInterval.value}
+                  onInput=${(e: Event) => {
+                    const v = parseInt((e.target as HTMLInputElement).value, 10)
+                    formSyncInterval.value = isNaN(v) ? 300 : v
+                  }}
+                  disabled=${formSubmitting.value}
+                />
+              </div>
+            `
+            : null}
+        </div>
+
+        <div class="flex items-center justify-end gap-2 px-4 py-3 border-t border-[var(--white-10)]">
+          <button
+            type="button"
+            class="px-4 py-1.5 rounded text-xs font-semibold cursor-pointer border-none bg-[var(--white-10)] text-[var(--text-body)] hover:bg-[var(--white-15)] transition-colors"
+            onClick=${closeAddRepoDialog}
+            disabled=${formSubmitting.value}
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            class="px-4 py-1.5 rounded text-xs font-semibold cursor-pointer border-none bg-[var(--color-status-ok)] text-[#000] hover:opacity-90 transition-opacity disabled:opacity-50"
+            onClick=${() => void submitAddRepo()}
+            disabled=${formSubmitting.value}
+          >
+            ${formSubmitting.value ? '등록 중...' : '저장소 등록'}
+          </button>
+        </div>
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/branch-tree.ts
+++ b/dashboard/src/components/branch-tree.ts
@@ -1,0 +1,72 @@
+// Branch tree -- visual tree/list of branches for a repository.
+// Used inside repo-detail-panel.
+
+import { html } from 'htm/preact'
+
+export interface BranchTreeProps {
+  repository_id: string
+  branches: readonly string[]
+  default_branch?: string
+}
+
+function BranchIcon({ isDefault }: { isDefault: boolean }) {
+  if (isDefault) {
+    return html`
+      <svg class="w-3.5 h-3.5 text-ok shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+        <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0zm3.5 6.5L7 11l-2.5-2.5 1-1L7 9l3.5-3.5 1 1z"/>
+      </svg>
+    `
+  }
+  return html`
+    <svg class="w-3.5 h-3.5 text-text-muted shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d="M11 5.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5zm0 1a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7zM5 5.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5zm0 1a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7zM5 9a1 1 0 0 1 1-1h.5a1 1 0 0 1 .9.6l.5 1.2.5-1.2a1 1 0 0 1 .9-.6h.5a1 1 0 0 1 1 1v4.5a.5.5 0 0 1-1 0V10h-.3l-.7 1.7a.5.5 0 0 1-.9 0L7.3 10H7v3.5a.5.5 0 0 1-1 0V9z"/>
+    </svg>
+  `
+}
+
+export function BranchTree({ repository_id, branches, default_branch }: BranchTreeProps) {
+  if (branches.length === 0) {
+    return html`
+      <div class="py-4 text-center text-2xs text-text-muted" role="status">
+        브랜치가 없습니다.
+      </div>
+    `
+  }
+
+  const sorted = [...branches].sort((a, b) => {
+    // Default branch first, then alphabetical
+    if (a === default_branch) return -1
+    if (b === default_branch) return 1
+    return a.localeCompare(b)
+  })
+
+  return html`
+    <div class="rounded border border-card-border/50 bg-card/20 backdrop-blur-sm overflow-hidden" data-repo-id="${repository_id}">
+      <div class="px-3 py-2 border-b border-card-border/30 bg-card/40">
+        <div class="flex items-center justify-between">
+          <span class="text-2xs font-semibold uppercase tracking-wider text-text-muted">브랜치</span>
+          <span class="text-3xs text-text-dim">${branches.length}개</span>
+        </div>
+      </div>
+      <ul class="divide-y divide-card-border/20" role="list">
+        ${sorted.map(branch => {
+          const isDefault = branch === default_branch
+          return html`
+            <li
+              class="flex items-center gap-2.5 py-2 px-3 hover:bg-card/40 transition-colors"
+              role="listitem"
+            >
+              <${BranchIcon} isDefault=${isDefault} />
+              <span class="text-xs font-medium ${isDefault ? 'text-ok' : 'text-text-body'} truncate">
+                ${branch}
+              </span>
+              ${isDefault
+                ? html`<span class="text-3xs font-bold px-1.5 py-0.5 rounded bg-ok/10 text-ok border border-ok/20 shrink-0">기본</span>`
+                : null}
+            </li>
+          `
+        })}
+      </ul>
+    </div>
+  `
+}

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -1,0 +1,359 @@
+// Credential settings -- page/component for managing credentials.
+// Fetches from GET /api/v1/credentials and supports add/delete.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { get, post } from '../api/core'
+import { createAsyncResource } from '../lib/async-state'
+import { showToast } from './common/toast'
+import { ErrorState, LoadingState } from './common/feedback-state'
+
+// ── Types ────────────────────────────────────────────────
+
+export type CredentialType = 'github' | 'gitlab' | 'local'
+
+export interface Credential {
+  id: string
+  name: string
+  type: CredentialType
+  description?: string
+  config?: Record<string, unknown>
+  created_at?: string
+}
+
+export interface CredentialCreatePayload {
+  id: string
+  name: string
+  type: CredentialType
+  description?: string
+  config?: Record<string, unknown>
+}
+
+// ── State ────────────────────────────────────────────────
+
+const credentialsResource = createAsyncResource<Credential[]>()
+const credentialsState = credentialsResource.state
+const saving = signal(false)
+const saveError = signal<string | null>(null)
+const showAddForm = signal(false)
+const deletingId = signal<string | null>(null)
+
+// Add form draft
+const addDraft = signal<CredentialCreatePayload>({
+  id: '',
+  name: '',
+  type: 'github',
+  description: '',
+})
+
+// ── API ──────────────────────────────────────────────────
+
+async function fetchCredentials(): Promise<Credential[]> {
+  const data = await get('/api/v1/credentials')
+  if (Array.isArray(data)) {
+    return data.map((row: unknown): Credential => {
+      const r = row as Record<string, unknown>
+      return {
+        id: String(r.id ?? ''),
+        name: String(r.name ?? ''),
+        type: coerceCredentialType(r.type),
+        description: r.description ? String(r.description) : undefined,
+        config: isRecord(r.config) ? r.config : undefined,
+        created_at: r.created_at ? String(r.created_at) : undefined,
+      }
+    })
+  }
+  return []
+}
+
+async function createCredential(payload: CredentialCreatePayload): Promise<void> {
+  await post('/api/v1/credentials', payload)
+}
+
+async function deleteCredential(id: string): Promise<void> {
+  const res = await fetch(`/api/v1/credentials/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '삭제 요청 실패')
+    throw new Error(text)
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────
+
+function coerceCredentialType(raw: unknown): CredentialType {
+  if (raw === 'gitlab') return 'gitlab'
+  if (raw === 'local') return 'local'
+  return 'github'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function credentialTypeLabel(type: CredentialType): string {
+  switch (type) {
+    case 'github': return 'GitHub'
+    case 'gitlab': return 'GitLab'
+    case 'local': return 'Local'
+  }
+}
+
+function credentialTypeBadgeClass(type: CredentialType): string {
+  switch (type) {
+    case 'github':
+      return 'bg-[var(--accent-10)] text-accent border-accent/20'
+    case 'gitlab':
+      return 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]'
+    case 'local':
+      return 'bg-[var(--white-5)] text-text-dim border-[var(--white-10)]'
+  }
+}
+
+function resetAddDraft() {
+  addDraft.value = { id: '', name: '', type: 'github', description: '' }
+  saveError.value = null
+}
+
+// ── Load / Refresh ───────────────────────────────────────
+
+export async function loadCredentials(options?: { force?: boolean }): Promise<void> {
+  const force = options?.force === true
+  if (!force && credentialsState.value.status === 'loaded') return
+  if (force) credentialsResource.reset()
+  await credentialsResource.load(() => fetchCredentials())
+}
+
+export function resetCredentials(): void {
+  credentialsResource.reset()
+  showAddForm.value = false
+  resetAddDraft()
+  saving.value = false
+  deletingId.value = null
+}
+
+// ── Sub-components ───────────────────────────────────────
+
+function SectionHeader({ title }: { title: string }) {
+  return html`
+    <div class="text-2xs font-bold uppercase tracking-widest text-accent mt-6 mb-3 pb-1.5 border-b border-accent/20 flex items-center gap-2">
+      <span class="w-1.5 h-1.5 rounded-full bg-accent/50 shadow-[0_0_8px_rgba(71,184,255,0.6)]" aria-hidden="true"></span>
+      ${title}
+    </div>
+  `
+}
+
+function CredentialTypeBadge({ type }: { type: CredentialType }) {
+  return html`
+    <span class="text-2xs font-bold px-2 py-0.5 rounded border ${credentialTypeBadgeClass(type)} shadow-sm">
+      ${credentialTypeLabel(type)}
+    </span>
+  `
+}
+
+// ── Main component ───────────────────────────────────────
+
+export function CredentialSettings() {
+  const state = credentialsState.value
+
+  if (state.status === 'idle' || state.status === 'loading') {
+    return html`<${LoadingState}>크리덴셜 목록 불러오는 중...<//>`
+  }
+
+  if (state.status === 'error') {
+    return html`
+      <div class="flex flex-col gap-3">
+        <${ErrorState} message=${state.message} />
+        <button
+          type="button"
+          class="py-1.5 px-4 rounded text-xs font-semibold cursor-pointer border-none bg-[var(--white-10)] text-text-body self-start"
+          onClick=${() => loadCredentials({ force: true })}
+        >
+          다시 시도
+        </button>
+      </div>
+    `
+  }
+
+  const list = state.data
+  const isAdding = showAddForm.value
+  const isSaving = saving.value
+  const draft = addDraft.value
+
+  async function handleSave() {
+    if (!draft.id.trim() || !draft.name.trim()) {
+      saveError.value = 'ID와 이름은 필수입니다.'
+      return
+    }
+    saving.value = true
+    saveError.value = null
+    try {
+      await createCredential({
+        id: draft.id.trim(),
+        name: draft.name.trim(),
+        type: draft.type,
+        description: draft.description?.trim() || undefined,
+      })
+      showToast('크리덴셜 추가 완료', 'success')
+      resetAddDraft()
+      showAddForm.value = false
+      await loadCredentials({ force: true })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '추가 실패'
+      saveError.value = msg
+      showToast(msg, 'error')
+    } finally {
+      saving.value = false
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm(`크리덴셜 "${id}"을(를) 삭제하시겠습니까?`)) return
+    deletingId.value = id
+    try {
+      await deleteCredential(id)
+      showToast('크리덴셜 삭제 완료', 'success')
+      await loadCredentials({ force: true })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '삭제 실패'
+      showToast(msg, 'error')
+    } finally {
+      deletingId.value = null
+    }
+  }
+
+  const btnBase = 'py-1.5 px-4 rounded text-xs font-semibold cursor-pointer border-none'
+  const fieldStyle = 'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded py-2 px-3 font-sans focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-[var(--t-med)] shadow-inner'
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-sm font-bold text-text-strong">크리덴셜 관리</h2>
+        <button
+          type="button"
+          class="${btnBase} bg-[var(--purple)] text-[#1e1b4b]"
+          onClick=${() => {
+            showAddForm.value = !isAdding
+            if (!isAdding) resetAddDraft()
+          }}
+        >
+          ${isAdding ? '취소' : '크리덴셜 추가'}
+        </button>
+      </div>
+
+      ${isAdding ? html`
+        <div class="rounded border border-card-border/50 bg-card/20 backdrop-blur-sm p-4 shadow-sm">
+          <${SectionHeader} title="새 크리덴셜" />
+          <div class="flex flex-col gap-3">
+            <div>
+              <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">ID</label>
+              <input
+                type="text"
+                class="${fieldStyle}"
+                placeholder="my-credential"
+                value=${draft.id}
+                onInput=${(e: Event) => { addDraft.value = { ...draft, id: (e.target as HTMLInputElement).value } }}
+              />
+            </div>
+            <div>
+              <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">이름</label>
+              <input
+                type="text"
+                class="${fieldStyle}"
+                placeholder="표시 이름"
+                value=${draft.name}
+                onInput=${(e: Event) => { addDraft.value = { ...draft, name: (e.target as HTMLInputElement).value } }}
+              />
+            </div>
+            <div>
+              <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">타입</label>
+              <select
+                class="${fieldStyle}"
+                value=${draft.type}
+                onChange=${(e: Event) => { addDraft.value = { ...draft, type: coerceCredentialType((e.target as HTMLSelectElement).value) } }}
+              >
+                <option value="github">GitHub</option>
+                <option value="gitlab">GitLab</option>
+                <option value="local">Local</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">설명</label>
+              <input
+                type="text"
+                class="${fieldStyle}"
+                placeholder="선택 사항"
+                value=${draft.description ?? ''}
+                onInput=${(e: Event) => { addDraft.value = { ...draft, description: (e.target as HTMLInputElement).value } }}
+              />
+            </div>
+            ${saveError.value ? html`<span class="text-xs text-[var(--color-status-err)]" role="alert">${saveError.value}</span>` : null}
+            <div class="flex gap-2 mt-1">
+              <button
+                type="button"
+                class="${btnBase} bg-[var(--color-status-ok)] text-[#000]"
+                onClick=${handleSave}
+                disabled=${isSaving}
+              >
+                ${isSaving ? '저장 중...' : '저장'}
+              </button>
+              <button
+                type="button"
+                class="${btnBase} bg-[var(--white-10)] text-text-body"
+                onClick=${() => { showAddForm.value = false; resetAddDraft() }}
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        </div>
+      ` : null}
+
+      ${list.length === 0 ? html`
+        <div class="py-8 text-center text-2xs text-text-muted rounded border border-card-border/30 bg-card/10">
+          등록된 크리덴셜이 없습니다.
+        </div>
+      ` : html`
+        <div class="rounded border border-card-border/50 bg-card/20 backdrop-blur-sm overflow-hidden shadow-sm">
+          <table class="w-full text-left">
+            <thead>
+              <tr class="border-b border-card-border/30 bg-card/40">
+                <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">ID</th>
+                <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">이름</th>
+                <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">타입</th>
+                <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">설명</th>
+                <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted text-right">동작</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-card-border/20">
+              ${list.map(cred => html`
+                <tr class="hover:bg-card/40 transition-colors">
+                  <td class="py-2 px-3 text-xs font-mono text-text-body truncate max-w-[12rem]">${cred.id}</td>
+                  <td class="py-2 px-3 text-xs font-medium text-text-strong">${cred.name}</td>
+                  <td class="py-2 px-3">
+                    <${CredentialTypeBadge} type=${cred.type} />
+                  </td>
+                  <td class="py-2 px-3 text-xs text-text-muted truncate max-w-[16rem]">
+                    ${cred.description || '--'}
+                  </td>
+                  <td class="py-2 px-3 text-right">
+                    <button
+                      type="button"
+                      class="text-2xs font-semibold px-2 py-1 rounded bg-[var(--color-status-err)]/10 text-[var(--color-status-err)] border border-[var(--color-status-err)]/20 hover:bg-[var(--color-status-err)]/20 transition-colors cursor-pointer"
+                      onClick=${() => handleDelete(cred.id)}
+                      disabled=${deletingId.value === cred.id}
+                    >
+                      ${deletingId.value === cred.id ? '삭제 중...' : '삭제'}
+                    </button>
+                  </td>
+                </tr>
+              `)}
+            </tbody>
+          </table>
+        </div>
+      `}
+    </div>
+  `
+}

--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -1,0 +1,406 @@
+// Keeper-repo mapping -- page/component for mapping keepers to repositories.
+// Fetches keepers list and allows multi-select assignment per keeper.
+// Save sends POST /api/v1/keepers/:id/repos
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { get, post } from '../api/core'
+import { createAsyncResource } from '../lib/async-state'
+import { showToast } from './common/toast'
+import { ErrorState, LoadingState } from './common/feedback-state'
+import type { Keeper } from '../types'
+
+// ── Types ────────────────────────────────────────────────
+
+export interface RepositoryOption {
+  id: string
+  name: string
+  url?: string
+}
+
+export interface KeeperRepoMapping {
+  keeper_id: string
+  keeper_name: string
+  allowed_repos: string[]
+  allow_all: boolean
+}
+
+// ── State ────────────────────────────────────────────────
+
+const keepersResource = createAsyncResource<Keeper[]>()
+const keepersState = keepersResource.state
+
+const reposResource = createAsyncResource<RepositoryOption[]>()
+const reposState = reposResource.state
+
+const mappingsResource = createAsyncResource<KeeperRepoMapping[]>()
+const mappingsState = mappingsResource.state
+
+const savingKeeperId = signal<string | null>(null)
+const saveError = signal<string | null>(null)
+
+// Local draft: keeper_id -> Set of repo ids or '*' for all
+const draftMappings = signal<Map<string, Set<string> | '*'>>(new Map())
+
+// ── API ──────────────────────────────────────────────────
+
+async function fetchKeepers(): Promise<Keeper[]> {
+  const { fetchDashboardExecution } = await import('../api/dashboard')
+  const data = await fetchDashboardExecution()
+  const raw = Array.isArray(data.keepers) ? data.keepers : []
+  return raw.filter((k): k is Keeper =>
+    k !== null && typeof k === 'object' &&
+    (typeof (k as Keeper).keeper_id === 'string' || typeof (k as Keeper).name === 'string')
+  )
+}
+
+async function fetchRepositories(): Promise<RepositoryOption[]> {
+  const data = await get<unknown>('/api/v1/repositories')
+  if (Array.isArray(data)) {
+    return data.map((row: unknown): RepositoryOption => {
+      const r = row as Record<string, unknown>
+      return {
+        id: String(r.id ?? ''),
+        name: String(r.name ?? r.id ?? ''),
+        url: r.url ? String(r.url) : undefined,
+      }
+    })
+  }
+  return []
+}
+
+async function fetchKeeperRepoMappings(): Promise<KeeperRepoMapping[]> {
+  const data = await get<unknown>('/api/v1/keepers/repos')
+  if (Array.isArray(data)) {
+    return data.map((row: unknown): KeeperRepoMapping => {
+      const r = row as Record<string, unknown>
+      return {
+        keeper_id: String(r.keeper_id ?? ''),
+        keeper_name: String(r.keeper_name ?? ''),
+        allowed_repos: Array.isArray(r.allowed_repos)
+          ? r.allowed_repos.filter((v): v is string => typeof v === 'string')
+          : [],
+        allow_all: r.allow_all === true,
+      }
+    })
+  }
+  return []
+}
+
+async function saveKeeperRepos(keeperId: string, repos: string[]): Promise<void> {
+  await post(`/api/v1/keepers/${encodeURIComponent(keeperId)}/repos`, { repos })
+}
+
+// ── Helpers ──────────────────────────────────────────────
+
+function getDraftForKeeper(keeperId: string, fallback: Set<string> | '*'): Set<string> | '*' {
+  const draft = draftMappings.value.get(keeperId)
+  return draft !== undefined ? draft : fallback
+}
+
+function isRepoSelected(_keeperId: string, repoId: string, current: Set<string> | '*'): boolean {
+  if (current === '*') return true
+  return current.has(repoId)
+}
+
+function isAllowAll(_keeperId: string, current: Set<string> | '*'): boolean {
+  return current === '*'
+}
+
+function toggleRepo(_keeperId: string, repoId: string, current: Set<string> | '*'): Set<string> | '*' {
+  if (current === '*') {
+    // Switch from '*' to explicit set with this repo removed
+    const next = new Set<string>()
+    const repos = reposState.value.status === 'loaded' ? reposState.value.data : []
+    for (const r of repos) {
+      if (r.id !== repoId) next.add(r.id)
+    }
+    return next
+  }
+  const next = new Set(current)
+  if (next.has(repoId)) {
+    next.delete(repoId)
+  } else {
+    next.add(repoId)
+  }
+  return next
+}
+
+function toggleAllowAll(_keeperId: string, current: Set<string> | '*'): Set<string> | '*' {
+  return current === '*' ? new Set<string>() : '*'
+}
+
+function hasChanges(_keeperId: string, original: Set<string> | '*', draft: Set<string> | '*'): boolean {
+  if (original === '*' && draft === '*') return false
+  if (original === '*' || draft === '*') return true
+  if (original.size !== draft.size) return true
+  for (const id of original) {
+    if (!draft.has(id)) return true
+  }
+  return false
+}
+
+function buildRepoSetFromMapping(mapping: KeeperRepoMapping): Set<string> | '*' {
+  if (mapping.allow_all) return '*'
+  return new Set(mapping.allowed_repos)
+}
+
+// ── Load / Refresh ───────────────────────────────────────
+
+export async function loadKeeperRepoMappings(options?: { force?: boolean }): Promise<void> {
+  const force = options?.force === true
+
+  const loadKeepers = async () => {
+    if (!force && keepersState.value.status === 'loaded') return
+    if (force) keepersResource.reset()
+    await keepersResource.load(() => fetchKeepers())
+  }
+
+  const loadRepos = async () => {
+    if (!force && reposState.value.status === 'loaded') return
+    if (force) reposResource.reset()
+    await reposResource.load(() => fetchRepositories())
+  }
+
+  const loadMappings = async () => {
+    if (!force && mappingsState.value.status === 'loaded') return
+    if (force) mappingsResource.reset()
+    await mappingsResource.load(() => fetchKeeperRepoMappings())
+  }
+
+  await Promise.all([loadKeepers(), loadRepos(), loadMappings()])
+
+  // Initialize drafts from loaded mappings
+  if (mappingsState.value.status === 'loaded' && draftMappings.value.size === 0) {
+    const next = new Map<string, Set<string> | '*'>()
+    for (const m of mappingsState.value.data) {
+      next.set(m.keeper_id, buildRepoSetFromMapping(m))
+    }
+    // Also initialize empty drafts for keepers without mappings
+    if (keepersState.value.status === 'loaded') {
+      for (const k of keepersState.value.data) {
+        const id = k.keeper_id ?? k.name
+        if (!next.has(id)) {
+          next.set(id, new Set<string>())
+        }
+      }
+    }
+    draftMappings.value = next
+  }
+}
+
+export function resetKeeperRepoMappings(): void {
+  keepersResource.reset()
+  reposResource.reset()
+  mappingsResource.reset()
+  draftMappings.value = new Map()
+  savingKeeperId.value = null
+  saveError.value = null
+}
+
+// ── Sub-components ───────────────────────────────────────
+
+function RepoBadge({ name }: { name: string }) {
+  return html`
+    <span class="inline-flex items-center py-1 px-2.5 rounded text-2xs font-semibold bg-[var(--accent-10)] text-accent border border-accent/20 shadow-sm">
+      ${name}
+    </span>
+  `
+}
+
+// ── Main component ───────────────────────────────────────
+
+export function KeeperRepoMapping() {
+  const kState = keepersState.value
+  const rState = reposState.value
+  const mState = mappingsState.value
+
+  // Trigger load on first render
+  if (kState.status === 'idle') {
+    void loadKeeperRepoMappings()
+  }
+
+  if (kState.status === 'loading' || rState.status === 'loading' || mState.status === 'loading') {
+    return html`<${LoadingState}>키퍼와 저장소 정보 불러오는 중...</${LoadingState}>`
+  }
+
+  if (kState.status === 'error') {
+    return html`<${ErrorState} message=${kState.message} />`
+  }
+  if (rState.status === 'error') {
+    return html`<${ErrorState} message=${rState.message} />`
+  }
+  if (mState.status === 'error') {
+    return html`<${ErrorState} message=${mState.message} />`
+  }
+
+  if (kState.status !== 'loaded' || rState.status !== 'loaded') {
+    return null
+  }
+
+  const keepers = kState.data
+  const repos = rState.data
+  const mappings = mState.status === 'loaded' ? mState.data : []
+  const mappingByKeeper = new Map(mappings.map(m => [m.keeper_id, m]))
+
+  const btnBase = 'py-1.5 px-4 rounded text-xs font-semibold cursor-pointer border-none'
+
+  async function handleSave(keeperId: string) {
+    const draft = draftMappings.value.get(keeperId)
+    if (draft === undefined) return
+
+    const payload = draft === '*' ? ['*'] : Array.from(draft)
+    savingKeeperId.value = keeperId
+    saveError.value = null
+    try {
+      await saveKeeperRepos(keeperId, payload)
+      showToast('저장소 매핑 저장 완료', 'success')
+      // Update the "original" mapping state so hasChanges resets
+      await loadKeeperRepoMappings({ force: true })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '저장 실패'
+      saveError.value = msg
+      showToast(msg, 'error')
+    } finally {
+      savingKeeperId.value = null
+    }
+  }
+
+  function handleToggleRepo(keeperId: string, repoId: string) {
+    const mapping = mappingByKeeper.get(keeperId)
+    const original = mapping ? buildRepoSetFromMapping(mapping) : new Set<string>()
+    const current = getDraftForKeeper(keeperId, original)
+    const next = toggleRepo(keeperId, repoId, current)
+    const nextMap = new Map(draftMappings.value)
+    nextMap.set(keeperId, next)
+    draftMappings.value = nextMap
+  }
+
+  function handleToggleAllowAll(keeperId: string) {
+    const mapping = mappingByKeeper.get(keeperId)
+    const original = mapping ? buildRepoSetFromMapping(mapping) : new Set<string>()
+    const current = getDraftForKeeper(keeperId, original)
+    const next = toggleAllowAll(keeperId, current)
+    const nextMap = new Map(draftMappings.value)
+    nextMap.set(keeperId, next)
+    draftMappings.value = nextMap
+  }
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-sm font-bold text-text-strong">키퍼 저장소 매핑</h2>
+        <button
+          type="button"
+          class="${btnBase} bg-[var(--white-10)] text-text-body"
+          onClick=${() => loadKeeperRepoMappings({ force: true })}
+        >
+          새로고침
+        </button>
+      </div>
+
+      ${saveError.value ? html`
+        <div class="rounded border border-[var(--color-status-err)]/30 bg-[var(--color-status-err)]/10 px-3 py-2 text-xs text-[var(--color-status-err)]" role="alert">
+          ${saveError.value}
+        </div>
+      ` : null}
+
+      ${keepers.length === 0 ? html`
+        <div class="py-8 text-center text-2xs text-text-muted rounded border border-card-border/30 bg-card/10">
+          등록된 키퍼가 없습니다.
+        </div>
+      ` : html`
+        <div class="flex flex-col gap-3">
+          ${keepers.map(keeper => {
+            const keeperId = keeper.keeper_id ?? keeper.name
+            const keeperName = keeper.name
+            const mapping = mappingByKeeper.get(keeperId)
+            const original = mapping ? buildRepoSetFromMapping(mapping) : new Set<string>()
+            const draft = getDraftForKeeper(keeperId, original)
+            const allowAll = isAllowAll(keeperId, draft)
+            const changed = hasChanges(keeperId, original, draft)
+            const isSaving = savingKeeperId.value === keeperId
+
+            return html`
+              <div
+                key=${keeperId}
+                class="rounded border border-card-border/50 bg-card/20 backdrop-blur-sm overflow-hidden shadow-sm"
+              >
+                <div class="px-3 py-2.5 border-b border-card-border/30 bg-card/40 flex items-center justify-between gap-3">
+                  <div class="flex items-center gap-2 min-w-0">
+                    <span class="text-xs font-semibold text-text-strong truncate">${keeperName}</span>
+                    ${keeper.agent_name ? html`
+                      <span class="text-3xs text-text-dim font-mono truncate">${keeper.agent_name}</span>
+                    ` : null}
+                  </div>
+                  <div class="flex items-center gap-2 shrink-0">
+                    ${changed ? html`
+                      <span class="text-3xs text-accent font-semibold">변경됨</span>
+                    ` : null}
+                    <button
+                      type="button"
+                      class="${btnBase} bg-[var(--color-status-ok)] text-[#000] py-1 px-3 text-2xs"
+                      onClick=${() => handleSave(keeperId)}
+                      disabled=${isSaving || !changed}
+                    >
+                      ${isSaving ? '저장 중...' : '저장'}
+                    </button>
+                  </div>
+                </div>
+
+                <div class="p-3">
+                  <label class="flex items-center gap-2 mb-3 cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      checked=${allowAll}
+                      onChange=${() => handleToggleAllowAll(keeperId)}
+                      class="accent-accent"
+                    />
+                    <span class="text-xs font-medium text-text-body">모든 저장소 허용 (*)</span>
+                  </label>
+
+                  ${repos.length === 0 ? html`
+                    <div class="text-2xs text-text-muted py-2">사용 가능한 저장소가 없습니다.</div>
+                  ` : html`
+                    <div class="grid gap-1.5 ${repos.length > 6 ? 'grid-cols-2' : 'grid-cols-1'}">
+                      ${repos.map(repo => {
+                        const selected = isRepoSelected(keeperId, repo.id, draft)
+                        return html`
+                          <label
+                            key="${keeperId}-${repo.id}"
+                            class="flex items-center gap-2 rounded bg-[var(--white-3)] px-2 py-1.5 text-xs text-text-body cursor-pointer select-none hover:bg-[var(--white-5)] transition-colors"
+                          >
+                            <input
+                              type="checkbox"
+                              checked=${selected}
+                              disabled=${allowAll}
+                              onChange=${() => handleToggleRepo(keeperId, repo.id)}
+                              class="accent-accent"
+                            />
+                            <span class="truncate ${allowAll ? 'opacity-50' : ''}">${repo.name}</span>
+                            ${repo.url ? html`
+                              <span class="text-3xs text-text-dim truncate ml-auto">${repo.url}</span>
+                            ` : null}
+                          </label>
+                        `
+                      })}
+                    </div>
+                  `}
+
+                  ${!allowAll && draft !== '*' && (draft as Set<string>).size > 0 ? html`
+                    <div class="mt-2 flex flex-wrap gap-1">
+                      ${Array.from(draft as Set<string>).map(repoId => {
+                        const repo = repos.find(r => r.id === repoId)
+                        return html`<${RepoBadge} name=${repo?.name ?? repoId} />`
+                      })}
+                    </div>
+                  ` : null}
+                </div>
+              </div>
+            `
+          })}
+        </div>
+      `}
+    </div>
+  `
+}

--- a/dashboard/src/components/repo-detail-panel.ts
+++ b/dashboard/src/components/repo-detail-panel.ts
@@ -1,0 +1,335 @@
+// Repository Detail Panel — shows details of the selected repository.
+// Displays info, sync action, delete with confirmation, and branches list.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { get } from '../api/core'
+import { createAsyncResource } from '../lib/async-state'
+import { LoadingState, ErrorState, EmptyState } from './common/feedback-state'
+import { selectedRepoId, syncRepository, deleteRepository, type Repository, type RepoStatus } from './repo-sidebar'
+import { requestConfirm } from './common/confirm-dialog'
+import { Trash2, GitBranch, Clock, Calendar, Folder, Link, Shield, RefreshCw } from 'lucide-preact'
+
+// ── Branch type ──────────────────────────────────────────
+
+export interface BranchInfo {
+  name: string
+  is_default: boolean
+  is_remote: boolean
+  last_commit_at: string | null
+}
+
+// ── State ────────────────────────────────────────────────
+
+const repoDetailResource = createAsyncResource<Repository>()
+const repoDetailState = repoDetailResource.state
+const branchesResource = createAsyncResource<BranchInfo[]>()
+const branchesState = branchesResource.state
+const syncing = signal(false)
+
+// ── API ──────────────────────────────────────────────────
+
+function normalizeBranch(raw: unknown): BranchInfo | null {
+  if (!raw || typeof raw !== 'object') return null
+  const b = raw as Record<string, unknown>
+  const name = typeof b.name === 'string' ? b.name : ''
+  if (!name) return null
+  return {
+    name,
+    is_default: b.is_default === true,
+    is_remote: b.is_remote === true,
+    last_commit_at: typeof b.last_commit_at === 'string' ? b.last_commit_at : null,
+  }
+}
+
+export async function loadRepoDetail(id: string): Promise<void> {
+  if (repoDetailState.value.status === 'loading') return
+  await repoDetailResource.load(async () => {
+    const raw = await get<unknown>(`/api/v1/repositories/${encodeURIComponent(id)}`)
+    if (!raw || typeof raw !== 'object') throw new Error('Invalid repository response')
+    const r = raw as Record<string, unknown>
+    return {
+      id: typeof r.id === 'string' ? r.id : id,
+      name: typeof r.name === 'string' ? r.name : '',
+      url: typeof r.url === 'string' ? r.url : '',
+      local_path: typeof r.local_path === 'string' ? r.local_path : '',
+      default_branch: typeof r.default_branch === 'string' ? r.default_branch : 'main',
+      status: normalizeRepoStatus(typeof r.status === 'string' ? r.status : undefined),
+      auto_sync: r.auto_sync === true,
+      sync_interval: typeof r.sync_interval === 'number' ? r.sync_interval : 300,
+      credential_id: typeof r.credential_id === 'string' ? r.credential_id : null,
+      created_at: typeof r.created_at === 'string' ? r.created_at : '',
+      updated_at: typeof r.updated_at === 'string' ? r.updated_at : '',
+    } as Repository
+  })
+}
+
+export async function loadRepoBranches(id: string): Promise<void> {
+  await branchesResource.load(async () => {
+    try {
+      const raw = await get<unknown[]>(`/api/v1/repositories/${encodeURIComponent(id)}/branches`)
+      return raw.map(normalizeBranch).filter((b): b is BranchInfo => b !== null)
+    } catch {
+      // Branch endpoint may not exist yet; return empty list
+      return []
+    }
+  })
+}
+
+function normalizeRepoStatus(raw: string | undefined): RepoStatus {
+  switch (raw) {
+    case 'active': return 'active'
+    case 'paused': return 'paused'
+    case 'error': return 'error'
+    default: return 'active'
+  }
+}
+
+export function resetRepoDetail(): void {
+  repoDetailResource.reset()
+  branchesResource.reset()
+  syncing.value = false
+}
+
+// ── Helpers ──────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: RepoStatus }) {
+  const config = {
+    active: { label: '활성', bg: 'bg-[var(--ok-10)]', text: 'text-[var(--color-status-ok)]', border: 'border-[var(--ok-20)]' },
+    paused: { label: '일시정지', bg: 'bg-[var(--warn-10)]', text: 'text-[var(--color-status-warn)]', border: 'border-[var(--warn-20)]' },
+    error: { label: '오류', bg: 'bg-[var(--bad-12)]', text: 'text-[var(--color-status-err)]', border: 'border-[var(--bad-30)]' },
+  }
+  const c = config[status]
+  return html`
+    <span class="inline-flex items-center gap-1 text-2xs font-bold px-2.5 py-0.5 rounded border ${c.bg} ${c.text} ${c.border}">
+      ${c.label}
+    </span>
+  `
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return '--'
+  try {
+    const d = new Date(iso)
+    return d.toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function InfoRow({
+  icon,
+  label,
+  value,
+}: {
+  icon?: unknown
+  label: string
+  value: string | number | boolean | null
+}) {
+  const displayValue =
+    value === null || value === undefined || value === ''
+      ? '--'
+      : typeof value === 'boolean'
+        ? (value ? 'ON' : 'OFF')
+        : String(value)
+  return html`
+    <div class="flex items-center justify-between py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
+      <div class="flex items-center gap-2">
+        ${icon ? html`<span class="text-[var(--color-fg-muted)]">${icon}</span>` : null}
+        <span class="text-xs font-medium text-text-muted">${label}</span>
+      </div>
+      <span class="text-xs font-semibold text-text-strong">${displayValue}</span>
+    </div>
+  `
+}
+
+// ── Component ────────────────────────────────────────────
+
+export function RepoDetailPanel() {
+  const selectedId = selectedRepoId.value
+
+  if (!selectedId) {
+    return html`
+      <div class="flex flex-col h-full items-center justify-center">
+        <${EmptyState} message="저장소를 선택하면 상세 정보가 표시됩니다." />
+      </div>
+    `
+  }
+
+  const detailState = repoDetailState.value
+  const branchState = branchesState.value
+
+  // Load on selection change
+  if (detailState.status === 'idle' || (detailState.status === 'loaded' && detailState.data.id !== selectedId)) {
+    void loadRepoDetail(selectedId)
+    void loadRepoBranches(selectedId)
+  }
+
+  if (detailState.status === 'loading') {
+    return html`<${LoadingState}>저장소 정보 불러오는 중...<//>`
+  }
+
+  if (detailState.status === 'error') {
+    return html`
+      <div class="space-y-3">
+        <${ErrorState} message=${detailState.message} />
+        <button
+          type="button"
+          class="text-2xs px-3 py-1.5 rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-muted)] hover:bg-[var(--white-10)] cursor-pointer transition-colors"
+          onClick=${() => void loadRepoDetail(selectedId)}
+        >
+          다시 시도
+        </button>
+      </div>
+    `
+  }
+
+  if (detailState.status !== 'loaded') return null
+
+  const repo = detailState.data
+
+  async function handleSync() {
+    if (syncing.value) return
+    syncing.value = true
+    try {
+      await syncRepository(repo.id)
+      await loadRepoDetail(repo.id)
+    } finally {
+      syncing.value = false
+    }
+  }
+
+  async function handleDelete() {
+    const confirmed = await requestConfirm({
+      title: '저장소 삭제',
+      message: `${repo.name} 저장소를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.`,
+      confirmText: '삭제',
+      cancelText: '취소',
+      tone: 'danger',
+    })
+    if (!confirmed) return
+    try {
+      await deleteRepository(repo.id)
+    } catch {
+      // error already toasted by deleteRepository
+    }
+  }
+
+  const branches = branchState.status === 'loaded' ? branchState.data : []
+  const branchesLoading = branchState.status === 'loading'
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <h2 class="text-lg font-semibold text-[var(--color-fg-secondary)]">${repo.name}</h2>
+          <${StatusBadge} status=${repo.status} />
+        </div>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-semibold cursor-pointer border-none bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50"
+            onClick=${() => void handleSync()}
+            disabled=${syncing.value}
+          >
+            ${syncing.value
+              ? html`<${RefreshCw} size=${13} class="animate-spin" aria-hidden="true" />`
+              : html`<${RefreshCw} size=${13} aria-hidden="true" />`}
+            ${syncing.value ? '동기화 중...' : '지금 동기화'}
+          </button>
+          <button
+            type="button"
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-semibold cursor-pointer border-none bg-[var(--bad-12)] text-[var(--color-status-err)] hover:bg-[var(--bad-20)] transition-colors"
+            onClick=${() => void handleDelete()}
+          >
+            <${Trash2} size=${13} aria-hidden="true" />
+            삭제
+          </button>
+        </div>
+      </div>
+
+      <div class="space-y-1">
+        <${InfoRow}
+          icon=${html`<${Link} size=${14} />`}
+          label="URL"
+          value=${repo.url}
+        />
+        <${InfoRow}
+          icon=${html`<${Folder} size=${14} />`}
+          label="로컬 경로"
+          value=${repo.local_path}
+        />
+        <${InfoRow}
+          icon=${html`<${GitBranch} size=${14} />`}
+          label="기본 브랜치"
+          value=${repo.default_branch}
+        />
+        <${InfoRow}
+          icon=${html`<${Shield} size=${14} />`}
+          label="자동 동기화"
+          value=${repo.auto_sync}
+        />
+        ${repo.auto_sync
+          ? html`<${InfoRow} icon=${html`<${Clock} size=${14} />`} label="동기화 간격" value="${repo.sync_interval}s" />`
+          : null}
+        <${InfoRow}
+          icon=${html`<${Calendar} size=${14} />`}
+          label="등록일"
+          value=${formatDate(repo.created_at)}
+        />
+        <${InfoRow}
+          icon=${html`<${Calendar} size=${14} />`}
+          label="수정일"
+          value=${formatDate(repo.updated_at)}
+        />
+      </div>
+
+      <div>
+        <div class="text-2xs font-bold uppercase tracking-widest text-accent mt-4 mb-3 pb-1.5 border-b border-accent/20 flex items-center gap-2">
+          <span class="w-1.5 h-1.5 rounded-full bg-accent/50 shadow-[0_0_8px_rgba(71,184,255,0.6)]" aria-hidden="true"></span>
+          브랜치 목록
+        </div>
+
+        ${branchesLoading
+          ? html`<${LoadingState} class="py-4">브랜치 목록 불러오는 중...<//>`
+          : branches.length === 0
+            ? html`
+              <div class="py-4 text-center text-2xs text-[var(--color-fg-muted)]">
+                브랜치 정보가 없습니다.
+              </div>
+            `
+            : html`
+              <div class="space-y-1">
+                ${branches.map(branch => html`
+                  <div
+                    key=${branch.name}
+                    class="flex items-center justify-between py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm"
+                  >
+                    <div class="flex items-center gap-2">
+                      <${GitBranch} size=${12} class="text-[var(--color-fg-muted)]" aria-hidden="true" />
+                      <span class="text-xs font-medium text-text-strong">${branch.name}</span>
+                      ${branch.is_default
+                        ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--accent-10)] text-accent border border-accent/20">기본</span>`
+                        : null}
+                      ${branch.is_remote
+                        ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-text-dim border border-[var(--white-10)]">원격</span>`
+                        : null}
+                    </div>
+                    ${branch.last_commit_at
+                      ? html`<span class="text-2xs text-[var(--color-fg-muted)]">${formatDate(branch.last_commit_at)}</span>`
+                      : null}
+                  </div>
+                `)}
+              </div>
+            `
+        }
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/repo-sidebar.ts
+++ b/dashboard/src/components/repo-sidebar.ts
@@ -1,0 +1,239 @@
+// Repository sidebar — list of repositories with selection and add button.
+// Fetches GET /api/v1/repositories and renders a selectable list.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { get, post } from '../api/core'
+import { createAsyncResource } from '../lib/async-state'
+import { LoadingState, ErrorState } from './common/feedback-state'
+import { showToast } from './common/toast'
+import { Plus, GitBranch, AlertCircle, PauseCircle, CheckCircle2 } from 'lucide-preact'
+
+// ── Types ────────────────────────────────────────────────
+
+export type RepoStatus = 'active' | 'paused' | 'error'
+
+export interface Repository {
+  id: string
+  name: string
+  url: string
+  local_path: string
+  default_branch: string
+  status: RepoStatus
+  auto_sync: boolean
+  sync_interval: number
+  credential_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+// ── State ────────────────────────────────────────────────
+
+const reposResource = createAsyncResource<Repository[]>()
+const reposState = reposResource.state
+export const selectedRepoId = signal<string | null>(null)
+export const showAddRepoDialog = signal(false)
+
+// ── API ──────────────────────────────────────────────────
+
+function normalizeRepoStatus(raw: string | undefined): RepoStatus {
+  switch (raw) {
+    case 'active': return 'active'
+    case 'paused': return 'paused'
+    case 'error': return 'error'
+    default: return 'active'
+  }
+}
+
+function normalizeRepository(raw: unknown): Repository | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const id = typeof r.id === 'string' ? r.id : ''
+  const name = typeof r.name === 'string' ? r.name : ''
+  if (!id || !name) return null
+  return {
+    id,
+    name,
+    url: typeof r.url === 'string' ? r.url : '',
+    local_path: typeof r.local_path === 'string' ? r.local_path : '',
+    default_branch: typeof r.default_branch === 'string' ? r.default_branch : 'main',
+    status: normalizeRepoStatus(typeof r.status === 'string' ? r.status : undefined),
+    auto_sync: r.auto_sync === true,
+    sync_interval: typeof r.sync_interval === 'number' ? r.sync_interval : 300,
+    credential_id: typeof r.credential_id === 'string' ? r.credential_id : null,
+    created_at: typeof r.created_at === 'string' ? r.created_at : '',
+    updated_at: typeof r.updated_at === 'string' ? r.updated_at : '',
+  }
+}
+
+export async function fetchRepositories(): Promise<void> {
+  await reposResource.load(async () => {
+    const raw = await get<unknown[]>('/api/v1/repositories')
+    return raw.map(normalizeRepository).filter((r): r is Repository => r !== null)
+  })
+}
+
+export async function syncRepository(id: string): Promise<void> {
+  try {
+    await post(`/api/v1/repositories/${encodeURIComponent(id)}/sync`, {})
+    showToast('동기화 요청 완료', 'success')
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '동기화 실패'
+    showToast(msg, 'error')
+    throw err
+  }
+}
+
+export async function deleteRepository(id: string): Promise<void> {
+  try {
+    await post(`/api/v1/repositories/${encodeURIComponent(id)}/delete`, {})
+    showToast('저장소 삭제 완료', 'success')
+    await fetchRepositories()
+    if (selectedRepoId.value === id) {
+      selectedRepoId.value = null
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '삭제 실패'
+    showToast(msg, 'error')
+    throw err
+  }
+}
+
+export function selectRepo(id: string | null): void {
+  selectedRepoId.value = id
+}
+
+export function resetRepoSelection(): void {
+  selectedRepoId.value = null
+  reposResource.reset()
+}
+
+// ── Helpers ──────────────────────────────────────────────
+
+function StatusIcon({ status }: { status: RepoStatus }) {
+  switch (status) {
+    case 'active':
+      return html`<${CheckCircle2} size=${14} class="text-[var(--color-status-ok)]" aria-hidden="true" />`
+    case 'paused':
+      return html`<${PauseCircle} size=${14} class="text-[var(--color-status-warn)]" aria-hidden="true" />`
+    case 'error':
+      return html`<${AlertCircle} size=${14} class="text-[var(--color-status-err)]" aria-hidden="true" />`
+  }
+}
+
+function StatusLabel({ status }: { status: RepoStatus }) {
+  const label = status === 'active' ? '활성' : status === 'paused' ? '일시정지' : '오류'
+  const colorClass =
+    status === 'active'
+      ? 'text-[var(--color-status-ok)]'
+      : status === 'paused'
+        ? 'text-[var(--color-status-warn)]'
+        : 'text-[var(--color-status-err)]'
+  return html`<span class="text-2xs font-medium ${colorClass}">${label}</span>`
+}
+
+// ── Component ────────────────────────────────────────────
+
+export function RepoSidebar() {
+  const state = reposState.value
+
+  if (state.status === 'idle') {
+    void fetchRepositories()
+  }
+
+  if (state.status === 'loading') {
+    return html`
+      <div class="flex flex-col h-full">
+        <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--white-10)]">
+          <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">저장소</span>
+        </div>
+        <${LoadingState} class="flex-1">저장소 목록 불러오는 중...<//>
+      </div>
+    `
+  }
+
+  if (state.status === 'error') {
+    return html`
+      <div class="flex flex-col h-full">
+        <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--white-10)]">
+          <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">저장소</span>
+          <button
+            type="button"
+            class="text-2xs px-2 py-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-muted)] hover:bg-[var(--white-10)] cursor-pointer transition-colors"
+            onClick=${() => void fetchRepositories()}
+          >
+            다시 시도
+          </button>
+        </div>
+        <div class="p-3">
+          <${ErrorState} message=${state.message} />
+        </div>
+      </div>
+    `
+  }
+
+  const repos = state.status === 'loaded' ? state.data : []
+  const selected = selectedRepoId.value
+
+  return html`
+    <div class="flex flex-col h-full">
+      <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--white-10)]">
+        <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">
+          저장소 <span class="text-[var(--color-fg-muted)] font-normal">(${repos.length})</span>
+        </span>
+        <button
+          type="button"
+          class="flex items-center gap-1 text-2xs px-2 py-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--color-fg-muted)] hover:bg-[var(--white-10)] hover:text-[var(--color-accent-fg)] cursor-pointer transition-colors"
+          onClick=${() => { showAddRepoDialog.value = true }}
+        >
+          <${Plus} size=${12} aria-hidden="true" />
+          추가
+        </button>
+      </div>
+
+      <div class="flex-1 overflow-y-auto py-1">
+        ${repos.length === 0
+          ? html`
+            <div class="px-3 py-6 text-center text-2xs text-[var(--color-fg-muted)]">
+              등록된 저장소가 없습니다.
+              <div class="mt-1">
+                <button
+                  type="button"
+                  class="text-accent hover:underline cursor-pointer"
+                  onClick=${() => { showAddRepoDialog.value = true }}
+                >
+                  저장소 추가하기
+                </button>
+              </div>
+            </div>
+          `
+          : repos.map((repo: Repository) => {
+            const isSelected = selected === repo.id
+            return html`
+              <button
+                key=${repo.id}
+                type="button"
+                class="w-full text-left px-3 py-2 cursor-pointer transition-colors border-l-2 ${isSelected ? 'bg-[var(--accent-10)] border-l-accent' : 'border-l-transparent hover:bg-[var(--white-5)]'}"
+                onClick=${() => { selectRepo(repo.id) }}
+                aria-pressed=${isSelected ? 'true' : 'false'}
+              >
+                <div class="flex items-center gap-2">
+                  <${StatusIcon} status=${repo.status} />
+                  <span class="text-xs font-medium text-[var(--color-fg-secondary)] truncate flex-1">
+                    ${repo.name}
+                  </span>
+                </div>
+                <div class="flex items-center gap-2 mt-1 ml-5">
+                  <${StatusLabel} status=${repo.status} />
+                  <span class="text-2xs text-[var(--color-fg-muted)] flex items-center gap-1">
+                    <${GitBranch} size=${10} aria-hidden="true" />
+                    ${repo.default_branch}
+                  </span>
+                </div>
+              </button>
+            `
+          })}
+      </div>
+    </div>
+  `
+}

--- a/lib/dune
+++ b/lib/dune
@@ -140,6 +140,9 @@
    server_routes_http_routes_dashboard
    server_routes_http_routes_provider_runs
    server_routes_http_routes_cascade
+   server_routes_http_routes_repositories
+   server_routes_http_routes_credentials
+   server_routes_http_routes_keeper_repos
    server_routes_http_routes_verification
    server_routes_http_routes_attribution
    server_routes_http_routes_activity
@@ -986,6 +989,8 @@
    masc_mcp.resilience
    ;; Multimodal artifact GADT sub-library (Tier B8) — Code/Image/Audio/Doc + Payload + Provenance
    masc_mcp.multimodal
+   ;; Repository manager sub-library (multi-repository feature)
+   masc_mcp.repo_manager
    )
  (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_let ppx_tla))
  (instrumentation (backend bisect_ppx)))

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -80,6 +80,15 @@ let handle_keeper_fs_read
     (match Keeper_sandbox_containment.check_read_target ~config ~meta ~target with
      | Error e -> error_json ~fields:[ "path", `String target ] e
      | Ok () ->
+    (* Multi-repository Phase 2: repository-level access restriction.
+       If the resolved path is under a registered repository, enforce
+       keeper-to-repo mapping.  Paths outside all registered repos are
+       allowed (playground general files). *)
+    (match Keeper_repo_mapping.validate_path_access ~keeper_id:meta.name
+       ~base_path:(Keeper_alerting_path.project_root_of_config config)
+       ~path:target with
+     | Error msg -> error_json ~fields:[ "path", `String target ] msg
+     | Ok () ->
     (* RFC-0006 Phase B-2: Docker keepers route the actual byte read
        through [docker run --rm <image> cat <container_path>] so the
        container's mount restrictions are the load-bearing isolation.
@@ -223,6 +232,11 @@ let handle_keeper_fs_edit
          (match validate_write_target ~config ~meta ~target with
           | Error json -> json
           | Ok () ->
+         (match Keeper_repo_mapping.validate_path_access ~keeper_id:meta.name
+            ~base_path:(Keeper_alerting_path.project_root_of_config config)
+            ~path:target with
+          | Error msg -> error_json ~fields:[ "path", `String target ] msg
+          | Ok () ->
          (try
             let current =
               try Fs_compat.load_file target
@@ -290,6 +304,11 @@ let handle_keeper_fs_edit
   | Ok target ->
     (match validate_write_target ~config ~meta ~target with
      | Error json -> json
+     | Ok () ->
+    (match Keeper_repo_mapping.validate_path_access ~keeper_id:meta.name
+       ~base_path:(Keeper_alerting_path.project_root_of_config config)
+       ~path:target with
+     | Error msg -> error_json ~fields:[ "path", `String target ] msg
      | Ok () ->
     (try
        let write_result =

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -31,21 +31,31 @@ let handle_keeper_shell
   let containment_check target =
     Keeper_sandbox_containment.check_read_target ~config ~meta ~target
   in
+  let repo_check target =
+    Keeper_repo_mapping.validate_path_access ~keeper_id:meta.name
+      ~base_path:root ~path:target
+  in
   let read_target () =
     match Keeper_shell_shared.resolve_keeper_shell_read_path ~config ~meta ~args with
     | Error _ as e -> e
     | Ok target ->
       (match containment_check target with
-       | Ok () -> Ok target
-       | Error msg -> Error msg)
+       | Error msg -> Error msg
+       | Ok () ->
+         match repo_check target with
+         | Error msg -> Error msg
+         | Ok () -> Ok target)
   in
   let cwd_target () =
     match Keeper_shell_shared.resolve_keeper_shell_read_cwd ~config ~meta ~args with
     | Error _ as e -> e
     | Ok cwd ->
       (match containment_check cwd with
-       | Ok () -> Ok cwd
-       | Error msg -> Error msg)
+       | Error msg -> Error msg
+       | Ok () ->
+         match repo_check cwd with
+         | Error msg -> Error msg
+         | Ok () -> Ok cwd)
   in
   (* Actionable error: Samchon/Claude Code validateInput pattern.
      Returns structured JSON with tried path, playground root, and concrete next action. *)

--- a/lib/repo_manager/credential_store.ml
+++ b/lib/repo_manager/credential_store.ml
@@ -1,0 +1,133 @@
+open Repo_manager_types
+
+let ( let* ) = Result.bind
+
+let creds_toml_path base_path =
+  Filename.concat base_path ".masc/config/credentials.toml"
+
+let credential_type_of_string = function
+  | "Github" -> Ok Github
+  | "Gitlab" -> Ok Gitlab
+  | "Local" -> Ok Local
+  | s -> Error (Printf.sprintf "Unknown credential type: %s" s)
+
+let string_of_credential_type = function
+  | Github -> "Github"
+  | Gitlab -> "Gitlab"
+  | Local -> "Local"
+
+let credential_of_toml toml id =
+  let path field = ["credential"; id; field] in
+  let* cred_type_str = Otoml.find_result toml Otoml.get_string (path "type") in
+  let* cred_type = credential_type_of_string cred_type_str in
+  let* username = Otoml.find_result toml Otoml.get_string (path "username") in
+  let gh_config_dir =
+    match Otoml.find_result toml Otoml.get_string (path "gh_config_dir") with
+    | Ok dir -> Some dir
+    | Error _ -> None
+  in
+  let ssh_key_path =
+    match Otoml.find_result toml Otoml.get_string (path "ssh_key_path") with
+    | Ok path -> Some path
+    | Error _ -> None
+  in
+  let gpg_key_id =
+    match Otoml.find_result toml Otoml.get_string (path "gpg_key_id") with
+    | Ok id -> Some id
+    | Error _ -> None
+  in
+  Ok { id; cred_type; username; gh_config_dir; ssh_key_path; gpg_key_id }
+
+let toml_of_credential cred =
+  let fields =
+    [
+      ("type", Otoml.string (string_of_credential_type cred.cred_type));
+      ("username", Otoml.string cred.username);
+    ]
+  in
+  let fields =
+    match cred.gh_config_dir with
+    | Some dir -> ("gh_config_dir", Otoml.string dir) :: fields
+    | None -> fields
+  in
+  let fields =
+    match cred.ssh_key_path with
+    | Some path -> ("ssh_key_path", Otoml.string path) :: fields
+    | None -> fields
+  in
+  let fields =
+    match cred.gpg_key_id with
+    | Some id -> ("gpg_key_id", Otoml.string id) :: fields
+    | None -> fields
+  in
+  Otoml.TomlTable (List.rev fields)
+
+let load_all ~base_path =
+  let path = creds_toml_path base_path in
+  if not (Sys.file_exists path) then Ok []
+  else
+    match Otoml.Parser.from_file_result path with
+    | Error msg -> Error msg
+    | Ok toml -> (
+        match Otoml.find_result toml Fun.id ["credential"] with
+        | Error _ -> Ok []
+        | Ok (Otoml.TomlTable fields | Otoml.TomlInlineTable fields) ->
+            let rec loop acc = function
+              | [] -> Ok (List.rev acc)
+              | (id, value) :: rest -> (
+                  match value with
+                  | Otoml.TomlTable _ | Otoml.TomlInlineTable _ ->
+                      let cred_toml =
+                        Otoml.TomlTable [("credential", Otoml.TomlTable [(id, value)])]
+                      in
+                      (match credential_of_toml cred_toml id with
+                      | Ok cred -> loop (cred :: acc) rest
+                      | Error msg -> Error msg)
+                  | _ ->
+                      Error (Printf.sprintf "credential.%s must be a table" id))
+            in
+            loop [] fields
+        | Ok _ -> Ok [])
+
+let save_all ~base_path (creds : credential list) =
+  let path = creds_toml_path base_path in
+  let config_dir = Filename.dirname path in
+  (try
+     if not (Sys.file_exists config_dir) then Sys.mkdir config_dir 0o755
+   with Sys_error _ -> ());
+  let cred_entries =
+    List.map (fun (cred : credential) -> (cred.id, toml_of_credential cred)) creds
+  in
+  let toml = Otoml.TomlTable [("credential", Otoml.TomlTable cred_entries)] in
+  let content = Otoml.Printer.to_string toml in
+  try
+    let oc = open_out path in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc content);
+    Ok ()
+  with Sys_error msg -> Error msg
+
+let find ~base_path id =
+  let* creds = load_all ~base_path in
+  match List.find_opt (fun (c : credential) -> String.equal c.id id) creds with
+  | Some cred -> Ok cred
+  | None -> Error (Printf.sprintf "Credential not found: %s" id)
+
+let add ~base_path (cred : credential) =
+  let* creds = load_all ~base_path in
+  if List.exists (fun (c : credential) -> String.equal c.id cred.id) creds then
+    Error (Printf.sprintf "Credential already exists: %s" cred.id)
+  else
+    let* () = save_all ~base_path (cred :: creds) in
+    Ok cred
+
+let remove ~base_path id =
+  let* creds = load_all ~base_path in
+  let filtered =
+    List.filter (fun (c : credential) -> not (String.equal c.id id)) creds
+  in
+  if List.length filtered = List.length creds then
+    Error (Printf.sprintf "Credential not found: %s" id)
+  else
+    save_all ~base_path filtered

--- a/lib/repo_manager/credential_store.mli
+++ b/lib/repo_manager/credential_store.mli
@@ -1,0 +1,19 @@
+open Repo_manager_types
+
+val load_all : base_path:string -> (credential list, string) result
+(** [load_all ~base_path] loads all credentials from
+    [.masc/config/credentials.toml]. *)
+
+val save_all : base_path:string -> credential list -> (unit, string) result
+(** [save_all ~base_path credentials] saves all credentials to
+    [.masc/config/credentials.toml]. *)
+
+val find : base_path:string -> string -> (credential, string) result
+(** [find ~base_path id] finds a credential by [id]. *)
+
+val add : base_path:string -> credential -> (credential, string) result
+(** [add ~base_path credential] adds a new credential. Returns an error if a
+    credential with the same [id] already exists. *)
+
+val remove : base_path:string -> string -> (unit, string) result
+(** [remove ~base_path id] removes a credential by [id]. *)

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -1,0 +1,18 @@
+(include_subdirs no)
+
+(library
+ (name repo_manager)
+ (public_name masc_mcp.repo_manager)
+ (modules
+   repo_manager_types
+   repo_store
+   repo_git
+   credential_store
+   keeper_repo_mapping
+   repo_sync)
+ (wrapped false)
+ (libraries
+   yojson
+   otoml
+   unix)
+ (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -1,0 +1,156 @@
+open Repo_manager_types
+
+let ( let* ) = Result.bind
+
+let mappings_toml_path base_path =
+  Filename.concat base_path ".masc/config/keeper_repo_mappings.toml"
+
+let mapping_of_toml toml keeper_id =
+  let path field = ["mapping"; keeper_id; field] in
+  let* repository_ids =
+    Otoml.Helpers.find_strings_result toml (path "repositories")
+  in
+  Ok { keeper_id; repository_ids }
+
+let toml_of_mapping mapping =
+  Otoml.TomlTable
+    [
+      ( "repositories",
+        Otoml.TomlArray
+          (List.map (fun s -> Otoml.TomlString s) mapping.repository_ids) );
+    ]
+
+let load_all ~base_path =
+  let path = mappings_toml_path base_path in
+  if not (Sys.file_exists path) then Ok []
+  else
+    match Otoml.Parser.from_file_result path with
+    | Error msg -> Error msg
+    | Ok toml -> (
+        match Otoml.find_result toml Fun.id ["mapping"] with
+        | Error _ -> Ok []
+        | Ok (Otoml.TomlTable fields | Otoml.TomlInlineTable fields) ->
+            let rec loop acc = function
+              | [] -> Ok (List.rev acc)
+              | (keeper_id, value) :: rest -> (
+                  match value with
+                  | Otoml.TomlTable _ | Otoml.TomlInlineTable _ ->
+                      let mapping_toml =
+                        Otoml.TomlTable [("mapping", Otoml.TomlTable [(keeper_id, value)])]
+                      in
+                      (match mapping_of_toml mapping_toml keeper_id with
+                      | Ok mapping -> loop (mapping :: acc) rest
+                      | Error msg -> Error msg)
+                  | _ ->
+                      Error
+                        (Printf.sprintf "mapping.%s must be a table" keeper_id))
+            in
+            loop [] fields
+        | Ok _ -> Ok [])
+
+let find_mapping ~base_path keeper_id =
+  let* mappings = load_all ~base_path in
+  match
+    List.find_opt
+      (fun (m : keeper_repo_mapping) -> String.equal m.keeper_id keeper_id)
+      mappings
+  with
+  | Some mapping -> Ok mapping
+  | None -> Error (Printf.sprintf "No mapping found for keeper: %s" keeper_id)
+
+let allowed_repositories ~keeper_id ~base_path =
+  let* mapping = find_mapping ~base_path keeper_id in
+  Ok mapping.repository_ids
+
+let is_allowed ~keeper_id ~repository_id ~base_path =
+  match find_mapping ~base_path keeper_id with
+  | Error _ -> true
+  | Ok mapping ->
+      List.exists
+        (fun id -> String.equal id repository_id || String.equal id "*")
+        mapping.repository_ids
+
+let validate_access ~keeper_id ~repository_id ~base_path =
+  if is_allowed ~keeper_id ~repository_id ~base_path then Ok ()
+  else
+    Error
+      (Printf.sprintf "Keeper %s is not allowed to access repository %s"
+         keeper_id repository_id)
+
+let save_all ~base_path mappings =
+  let path = mappings_toml_path base_path in
+  let table =
+    List.map
+      (fun m -> (m.keeper_id, toml_of_mapping m))
+      mappings
+  in
+  let toml = Otoml.TomlTable [("mapping", Otoml.TomlTable table)] in
+  let dir = Filename.dirname path in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let content = Otoml.Printer.to_string toml in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content);
+  Ok ()
+
+let save_mapping ~base_path mapping =
+  let* mappings = load_all ~base_path in
+  let filtered =
+    List.filter
+      (fun (m : keeper_repo_mapping) ->
+        not (String.equal m.keeper_id mapping.keeper_id))
+      mappings
+  in
+  save_all ~base_path (mapping :: filtered)
+
+let apply_mapping ~keeper_id ~base_path ~repositories =
+  match find_mapping ~base_path keeper_id with
+  | Error _ -> repositories
+  | Ok mapping ->
+      if List.exists (String.equal "*") mapping.repository_ids then
+        repositories
+      else
+        List.filter
+          (fun (r : repository) ->
+            List.exists (String.equal r.id) mapping.repository_ids)
+          repositories
+
+(* Path normalization for prefix comparison. *)
+let normalize_path_for_prefix_check path =
+  let p = String.trim path in
+  if String.length p > 0 && p.[String.length p - 1] = '/' then
+    String.sub p 0 (String.length p - 1)
+  else p
+
+(** [path_under_repo ~base_path repo path] returns [true] when [path]
+    is equal to or strictly under [repo]'s resolved local_path. *)
+let path_under_repo ~base_path repo path =
+  let repo_path = Repo_store.local_path ~base_path repo in
+  let repo_norm = normalize_path_for_prefix_check repo_path in
+  let path_norm = normalize_path_for_prefix_check path in
+  String.equal path_norm repo_norm
+  || String.starts_with ~prefix:(repo_norm ^ "/") path_norm
+
+(** [repository_id_of_path ~base_path ~path] returns the ID of the
+    registered repository whose [local_path] contains [path], or [None]
+    if the path is not under any registered repository. *)
+let repository_id_of_path ~base_path ~path =
+  match Repo_store.load_all ~base_path with
+  | Error _ -> None
+  | Ok repos -> (
+      match
+        List.find_opt (fun repo -> path_under_repo ~base_path repo path) repos
+      with
+      | Some repo -> Some repo.id
+      | None -> None)
+
+(** [validate_path_access ~keeper_id ~base_path ~path] checks whether
+    [keeper_id] is allowed to access the repository that contains [path].
+    If [path] is not under any registered repository, access is allowed.
+    This is the integration point for keeper execution paths that operate
+    on filesystem paths rather than explicit repository IDs. *)
+let validate_path_access ~keeper_id ~base_path ~path =
+  match repository_id_of_path ~base_path ~path with
+  | None -> Ok ()
+  | Some repo_id -> validate_access ~keeper_id ~repository_id:repo_id ~base_path

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -1,0 +1,40 @@
+open Repo_manager_types
+
+val allowed_repositories :
+  keeper_id:string -> base_path:string -> (repository_id list, string) result
+(** [allowed_repositories ~keeper_id ~base_path] returns the list of
+    repository IDs that [keeper_id] is allowed to access. *)
+
+val is_allowed :
+  keeper_id:string -> repository_id:repository_id -> base_path:string -> bool
+(** [is_allowed ~keeper_id ~repository_id ~base_path] returns [true] if
+    [keeper_id] may access [repository_id]. *)
+
+val validate_access :
+  keeper_id:string -> repository_id:repository_id -> base_path:string -> (unit, string) result
+(** [validate_access ~keeper_id ~repository_id ~base_path] returns [Ok ()] if
+    access is permitted, or [Error msg] otherwise. *)
+
+val save_mapping :
+  base_path:string -> keeper_repo_mapping -> (unit, string) result
+(** [save_mapping ~base_path mapping] saves or updates the mapping for the
+    given keeper, overwriting any existing mapping for that keeper. *)
+
+val apply_mapping :
+  keeper_id:string -> base_path:string -> repositories:repository list -> repository list
+(** [apply_mapping ~keeper_id ~base_path ~repositories] filters the given
+    repository list to only those accessible by [keeper_id].
+    When no mapping exists for the keeper, all repositories are returned
+    (backward compatibility). *)
+
+val repository_id_of_path :
+  base_path:string -> path:string -> repository_id option
+(** [repository_id_of_path ~base_path ~path] returns the repository ID whose
+    [local_path] contains [path], or [None] if the path is not under any
+    registered repository. *)
+
+val validate_path_access :
+  keeper_id:string -> base_path:string -> path:string -> (unit, string) result
+(** [validate_path_access ~keeper_id ~base_path ~path] returns [Ok ()] if
+    [keeper_id] may access the repository containing [path], or if [path] is
+    not under any registered repository. Returns [Error msg] otherwise. *)

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -1,0 +1,92 @@
+open Repo_manager_types
+
+let env_of_credential credential =
+  match credential.cred_type with
+  | Github | Gitlab -> (
+      match credential.gh_config_dir with
+      | Some dir -> [Printf.sprintf "GH_CONFIG_DIR=%s" dir]
+      | None -> [])
+  | Local -> (
+      match credential.ssh_key_path with
+      | Some key -> [Printf.sprintf "GIT_SSH_COMMAND=ssh -i %s" key]
+      | None -> [])
+
+let run_git ~cwd ?(env = []) args =
+  let env_prefix =
+    if env = [] then "" else String.concat " " env ^ " "
+  in
+  let cmd =
+    Printf.sprintf "%sgit -C %S %s" env_prefix cwd
+      (String.concat " " (List.map Filename.quote args))
+  in
+  let ic = Unix.open_process_in cmd in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let rec loop acc =
+        match input_line ic with
+        | line -> loop (line :: acc)
+        | exception End_of_file -> List.rev acc
+      in
+      let lines = loop [] in
+      match Unix.close_process_in ic with
+      | Unix.WEXITED 0 -> Ok lines
+      | _ -> Error (Printf.sprintf "git command failed: %s" cmd))
+
+let clone ~repository ~credential =
+  let env = env_of_credential credential in
+  let parent_dir = Filename.dirname repository.local_path in
+  (try
+     if not (Sys.file_exists parent_dir) then
+       Sys.mkdir parent_dir 0o755
+   with Sys_error _ -> ());
+  match
+    run_git ~cwd:parent_dir ~env
+      ["clone"; repository.url; repository.local_path]
+  with
+  | Ok _ -> Ok ()
+  | Error msg -> Error msg
+
+let fetch ~repository ~credential : (string list, string) result =
+  let env = env_of_credential credential in
+  match run_git ~env ~cwd:repository.local_path ["fetch"; "--all"] with
+  | Error msg -> Error msg
+  | Ok _ -> (
+      match
+        run_git ~cwd:repository.local_path
+          ["branch"; "-r"; "--format=%(refname:short)"]
+      with
+      | Ok lines -> Ok lines
+      | Error msg -> Error msg)
+
+let checkout_worktree ~repository ~branch =
+  let worktree_path =
+    Filename.concat repository.local_path (Printf.sprintf "_worktrees/%s" branch)
+  in
+  (try
+     if not (Sys.file_exists worktree_path) then
+       let parent = Filename.dirname worktree_path in
+       if not (Sys.file_exists parent) then Sys.mkdir parent 0o755
+   with Sys_error _ -> ());
+  match
+    run_git ~cwd:repository.local_path
+      ["worktree"; "add"; worktree_path; branch]
+  with
+  | Ok _ -> Ok worktree_path
+  | Error msg -> Error msg
+
+let get_branches ~repository =
+  match
+    run_git ~cwd:repository.local_path
+      ["branch"; "-a"; "--format=%(refname:short)"]
+  with
+  | Ok lines -> Ok lines
+  | Error msg -> Error msg
+
+let get_recent_commits ~repository ~branch ~limit =
+  match
+    run_git ~cwd:repository.local_path
+      ["log"; branch; "-n"; string_of_int limit; "--oneline"]
+  with
+  | Ok lines -> Ok lines
+  | Error msg -> Error msg

--- a/lib/repo_manager/repo_git.mli
+++ b/lib/repo_manager/repo_git.mli
@@ -1,0 +1,25 @@
+open Repo_manager_types
+
+val clone :
+  repository:repository -> credential:credential -> (unit, string) result
+(** [clone ~repository ~credential] clones [repository.url] into
+    [repository.local_path] using the given credential. *)
+
+val fetch :
+  repository:repository -> credential:credential -> (string list, string) result
+(** [fetch ~repository ~credential] fetches all remotes and returns the list of
+    remote branch names. *)
+
+val checkout_worktree :
+  repository:repository -> branch:string -> (string, string) result
+(** [checkout_worktree ~repository ~branch] creates or checks out a git
+    worktree for [branch] under the repository. Returns the worktree path. *)
+
+val get_branches :
+  repository:repository -> (string list, string) result
+(** [get_branches ~repository] returns all local and remote branch names. *)
+
+val get_recent_commits :
+  repository:repository -> branch:string -> limit:int -> (string list, string) result
+(** [get_recent_commits ~repository ~branch ~limit] returns the most recent
+    [limit] commits on [branch] as ["HASH subject"] lines. *)

--- a/lib/repo_manager/repo_manager_types.ml
+++ b/lib/repo_manager/repo_manager_types.ml
@@ -1,0 +1,47 @@
+type repository_id = string
+[@@deriving yojson, show, eq]
+
+type repository_status =
+  | Active
+  | Paused
+  | Cloning
+  | Error of string
+[@@deriving yojson, show, eq]
+
+type repository = {
+  id : repository_id;
+  name : string;
+  url : string;
+  local_path : string;
+  default_branch : string;
+  credential_id : string;
+  keepers : string list;
+  status : repository_status;
+  auto_sync : bool;
+  sync_interval : int;
+  created_at : int64;
+  updated_at : int64;
+}
+[@@deriving yojson, show, eq]
+
+type credential_type =
+  | Github
+  | Gitlab
+  | Local
+[@@deriving yojson, show, eq]
+
+type credential = {
+  id : string;
+  cred_type : credential_type;
+  username : string;
+  gh_config_dir : string option;
+  ssh_key_path : string option;
+  gpg_key_id : string option;
+}
+[@@deriving yojson, show, eq]
+
+type keeper_repo_mapping = {
+  keeper_id : string;
+  repository_ids : string list;
+}
+[@@deriving yojson, show, eq]

--- a/lib/repo_manager/repo_manager_types.mli
+++ b/lib/repo_manager/repo_manager_types.mli
@@ -1,0 +1,47 @@
+type repository_id = string
+[@@deriving yojson, show, eq]
+
+type repository_status =
+  | Active
+  | Paused
+  | Cloning
+  | Error of string
+[@@deriving yojson, show, eq]
+
+type repository = {
+  id : repository_id;
+  name : string;
+  url : string;
+  local_path : string;
+  default_branch : string;
+  credential_id : string;
+  keepers : string list;
+  status : repository_status;
+  auto_sync : bool;
+  sync_interval : int;
+  created_at : int64;
+  updated_at : int64;
+}
+[@@deriving yojson, show, eq]
+
+type credential_type =
+  | Github
+  | Gitlab
+  | Local
+[@@deriving yojson, show, eq]
+
+type credential = {
+  id : string;
+  cred_type : credential_type;
+  username : string;
+  gh_config_dir : string option;
+  ssh_key_path : string option;
+  gpg_key_id : string option;
+}
+[@@deriving yojson, show, eq]
+
+type keeper_repo_mapping = {
+  keeper_id : string;
+  repository_ids : string list;
+}
+[@@deriving yojson, show, eq]

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -1,0 +1,182 @@
+open Repo_manager_types
+
+let ( let* ) = Result.bind
+
+let repos_toml_path base_path =
+  Filename.concat base_path ".masc/config/repositories.toml"
+
+let string_of_status = function
+  | Active -> "Active"
+  | Paused -> "Paused"
+  | Cloning -> "Cloning"
+  | Error _ -> "Error"
+
+let status_of_string = function
+  | "Active" -> Ok Active
+  | "Paused" -> Ok Paused
+  | "Cloning" -> Ok Cloning
+  | "Error" -> Ok (Error "")
+  | s -> Error (Printf.sprintf "Unknown repository status: %s" s)
+
+let repository_of_toml toml id =
+  let ( let* ) = Result.bind in
+  let path field = ["repository"; id; field] in
+  let* name = Otoml.find_result toml Otoml.get_string (path "name") in
+  let* url = Otoml.find_result toml Otoml.get_string (path "url") in
+  let* local_path = Otoml.find_result toml Otoml.get_string (path "local_path") in
+  let* default_branch =
+    Otoml.find_result toml Otoml.get_string (path "default_branch")
+  in
+  let* credential_id =
+    Otoml.find_result toml Otoml.get_string (path "credential_id")
+  in
+  let* keepers =
+    Otoml.Helpers.find_strings_result toml (path "keepers")
+  in
+  let* status_str =
+    Otoml.find_result toml Otoml.get_string (path "status")
+  in
+  let* status = status_of_string status_str in
+  let* auto_sync =
+    Otoml.find_result toml Otoml.get_boolean (path "auto_sync")
+  in
+  let* sync_interval =
+    Otoml.Helpers.find_integer_result toml (path "sync_interval")
+  in
+  let* created_at =
+    Otoml.Helpers.find_integer_result toml (path "created_at")
+  in
+  let* updated_at =
+    Otoml.Helpers.find_integer_result toml (path "updated_at")
+  in
+  Ok
+    {
+      id;
+      name;
+      url;
+      local_path;
+      default_branch;
+      credential_id;
+      keepers;
+      status;
+      auto_sync;
+      sync_interval;
+      created_at = Int64.of_int created_at;
+      updated_at = Int64.of_int updated_at;
+    }
+
+let toml_of_repository repo =
+  Otoml.TomlTable
+    [
+      ("name", Otoml.string repo.name);
+      ("url", Otoml.string repo.url);
+      ("local_path", Otoml.string repo.local_path);
+      ("default_branch", Otoml.string repo.default_branch);
+      ("credential_id", Otoml.string repo.credential_id);
+      ( "keepers",
+        Otoml.TomlArray (List.map (fun s -> Otoml.TomlString s) repo.keepers)
+      );
+      ("status", Otoml.string (string_of_status repo.status));
+      ("auto_sync", Otoml.boolean repo.auto_sync);
+      ("sync_interval", Otoml.integer repo.sync_interval);
+      ("created_at", Otoml.integer (Int64.to_int repo.created_at));
+      ("updated_at", Otoml.integer (Int64.to_int repo.updated_at));
+    ]
+
+let load_all ~base_path =
+  let path = repos_toml_path base_path in
+  if not (Sys.file_exists path) then Ok []
+  else
+    match Otoml.Parser.from_file_result path with
+    | Error msg -> Error msg
+    | Ok toml -> (
+        match Otoml.find_result toml Fun.id ["repository"] with
+        | Error _ -> Ok []
+        | Ok (Otoml.TomlTable fields | Otoml.TomlInlineTable fields) ->
+            let rec loop acc = function
+              | [] -> Ok (List.rev acc)
+              | (id, value) :: rest -> (
+                  match value with
+                  | Otoml.TomlTable _ | Otoml.TomlInlineTable _ ->
+                      let repo_toml =
+                        Otoml.TomlTable
+                          [("repository", Otoml.TomlTable [(id, value)])]
+                      in
+                      (match repository_of_toml repo_toml id with
+                      | Ok repo -> loop (repo :: acc) rest
+                      | Error msg -> Error msg)
+                  | _ ->
+                      Error
+                        (Printf.sprintf "repository.%s must be a table" id))
+            in
+            loop [] fields
+        | Ok _ -> Ok [])
+
+let save_all ~base_path (repos : repository list) =
+  let path = repos_toml_path base_path in
+  let config_dir = Filename.dirname path in
+  (try
+     if not (Sys.file_exists config_dir) then Sys.mkdir config_dir 0o755
+   with Sys_error _ -> ());
+  let repo_entries =
+    List.map (fun (repo : repository) -> (repo.id, toml_of_repository repo)) repos
+  in
+  let toml = Otoml.TomlTable [("repository", Otoml.TomlTable repo_entries)] in
+  let content = Otoml.Printer.to_string toml in
+  try
+    let oc = open_out path in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc content);
+    Ok ()
+  with Sys_error msg -> Error msg
+
+let find ~base_path id =
+  let* repos = load_all ~base_path in
+  match List.find_opt (fun (r : repository) -> String.equal r.id id) repos with
+  | Some repo -> Ok repo
+  | None -> Error (Printf.sprintf "Repository not found: %s" id)
+
+let add ~base_path (repo : repository) =
+  let* repos = load_all ~base_path in
+  if List.exists (fun (r : repository) -> String.equal r.id repo.id) repos then
+    Error (Printf.sprintf "Repository already exists: %s" repo.id)
+  else
+    let* () = save_all ~base_path (repo :: repos) in
+    Ok repo
+
+let remove ~base_path id =
+  let* repos = load_all ~base_path in
+  let filtered =
+    List.filter (fun (r : repository) -> not (String.equal r.id id)) repos
+  in
+  if List.length filtered = List.length repos then
+    Error (Printf.sprintf "Repository not found: %s" id)
+  else
+    save_all ~base_path filtered
+
+let update_status ~base_path id status =
+  let* repos = load_all ~base_path in
+  let found = ref false in
+  let updated =
+    List.map
+      (fun (r : repository) ->
+        if String.equal r.id id then (
+          found := true;
+          { r with status })
+        else r)
+      repos
+  in
+  if not !found then Error (Printf.sprintf "Repository not found: %s" id)
+  else save_all ~base_path updated
+
+let local_path ~base_path repo =
+  if Filename.is_relative repo.local_path then
+    Filename.concat base_path repo.local_path
+  else
+    repo.local_path
+
+let list_branches ~base_path id : (string list, string) result =
+  let* repo = find ~base_path id in
+  let path = local_path ~base_path repo in
+  Repo_git.get_branches ~repository:{ repo with local_path = path }

--- a/lib/repo_manager/repo_store.mli
+++ b/lib/repo_manager/repo_store.mli
@@ -1,0 +1,35 @@
+open Repo_manager_types
+
+val load_all : base_path:string -> (repository list, string) result
+(** [load_all ~base_path] reads [.masc/config/repositories.toml] and returns
+    all registered repositories. Returns [Ok []] if the file does not exist. *)
+
+val save_all : base_path:string -> repository list -> (unit, string) result
+(** [save_all ~base_path repos] writes [repos] to
+    [.masc/config/repositories.toml], replacing any previous content. *)
+
+val find : base_path:string -> repository_id -> (repository, string) result
+(** [find ~base_path id] returns the repository with the given [id]. *)
+
+val add : base_path:string -> repository -> (repository, string) result
+(** [add ~base_path repo] adds [repo] to the store. If a repository with the
+    same [id] already exists, returns an error. *)
+
+val remove : base_path:string -> repository_id -> (unit, string) result
+(** [remove ~base_path id] removes the repository with the given [id]. *)
+
+val update_status :
+  base_path:string -> repository_id -> repository_status -> (unit, string) result
+(** [update_status ~base_path id status] updates the status of the repository
+    with the given [id]. *)
+
+val list_branches :
+  base_path:string -> repository_id -> (string list, string) result
+(** [list_branches ~base_path id] lists branch names for the repository.
+    This delegates to the git layer and will be wired once {!Repo_git} is
+    available. *)
+
+val local_path : base_path:string -> repository -> string
+(** [local_path ~base_path repo] returns the absolute path to the repository's
+    local checkout. If [repo.local_path] is already absolute, it is returned
+    as-is; otherwise it is resolved relative to [base_path]. *)

--- a/lib/repo_manager/repo_sync.ml
+++ b/lib/repo_manager/repo_sync.ml
@@ -1,0 +1,35 @@
+open Repo_manager_types
+
+let ( let* ) = Result.bind
+
+let sync_repository ~base_path repo credential : (unit, string) result =
+  let local_path = Repo_store.local_path ~base_path repo in
+  let repo_with_path = { repo with local_path } in
+  match Repo_git.fetch ~repository:repo_with_path ~credential with
+  | Error msg ->
+      let* () = Repo_store.update_status ~base_path repo.id (Error msg) in
+      Error msg
+  | Ok _branches ->
+      let* () = Repo_store.update_status ~base_path repo.id Active in
+      Ok ()
+
+let should_sync repo ~now =
+  if not repo.auto_sync then false
+  else
+    let elapsed = Int64.sub now repo.updated_at in
+    Int64.to_int elapsed >= repo.sync_interval
+
+let sync_all ~base_path ~now : (repository list, string) result =
+  let* repos = Repo_store.load_all ~base_path in
+  let due = List.filter (fun r -> should_sync r ~now) repos in
+  let rec loop synced = function
+    | [] -> Ok (List.rev synced)
+    | repo :: rest -> (
+        match Credential_store.find ~base_path repo.credential_id with
+        | Error msg -> loop synced rest
+        | Ok credential -> (
+            match sync_repository ~base_path repo credential with
+            | Error _ -> loop synced rest
+            | Ok () -> loop (repo :: synced) rest))
+  in
+  loop [] due

--- a/lib/repo_manager/repo_sync.mli
+++ b/lib/repo_manager/repo_sync.mli
@@ -1,0 +1,16 @@
+open Repo_manager_types
+
+val sync_repository :
+  base_path:string -> repository -> credential -> (unit, string) result
+(** [sync_repository ~base_path repo credential] fetches the repository and
+    updates its status to [Active] on success or [Error msg] on failure. *)
+
+val should_sync : repository -> now:int64 -> bool
+(** [should_sync repo ~now] returns [true] if [repo.auto_sync] is enabled and
+    [now - repo.updated_at] exceeds [repo.sync_interval] seconds. *)
+
+val sync_all :
+  base_path:string -> now:int64 -> (repository list, string) result
+(** [sync_all ~base_path ~now] loads all repositories, filters those that
+    should_sync, fetches each one using its credential, and returns the list
+    of successfully synced repositories. *)

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -33,3 +33,6 @@ let make_routes ~port ~host ~sw ~clock =
   |> Server_routes_http_routes_legendary_bash.add_routes
   |> Server_routes_http_routes_channel_gate.add_routes ~sw ~clock
   |> Server_routes_http_routes_sidecar.add_routes ~sw ~clock
+  |> Server_routes_http_routes_repositories.add_routes
+  |> Server_routes_http_routes_credentials.add_routes
+  |> Server_routes_http_routes_keeper_repos.add_routes

--- a/lib/server/server_routes_http_routes_credentials.ml
+++ b/lib/server/server_routes_http_routes_credentials.ml
@@ -1,0 +1,148 @@
+open Server_auth
+open Server_utils
+
+module Http = Http_server_eio
+
+let credential_json (c : Repo_manager_types.credential) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("id", `String c.id);
+      ( "cred_type",
+        `String
+          (match c.cred_type with
+           | Github -> "github"
+           | Gitlab -> "gitlab"
+           | Local -> "local") );
+      ("username", `String c.username);
+      ( "gh_config_dir",
+        match c.gh_config_dir with Some s -> `String s | None -> `Null );
+      ( "ssh_key_path",
+        match c.ssh_key_path with Some s -> `String s | None -> `Null );
+      ("gpg_key_id", match c.gpg_key_id with Some s -> `String s | None -> `Null);
+    ]
+
+let credential_of_json (json : Yojson.Safe.t) :
+    (Repo_manager_types.credential, string) result =
+  let ( let* ) = Result.bind in
+  match json with
+  | `Assoc fields ->
+      let get_string key =
+        match List.assoc_opt key fields with
+        | Some (`String s) -> Ok s
+        | Some _ -> Error (Printf.sprintf "field %s must be a string" key)
+        | None -> Error (Printf.sprintf "missing field %s" key)
+      in
+      let get_opt_string key =
+        match List.assoc_opt key fields with
+        | Some (`String s) -> Ok (Some s)
+        | Some `Null -> Ok None
+        | Some _ -> Error (Printf.sprintf "field %s must be a string or null" key)
+        | None -> Ok None
+      in
+      let* id = get_string "id" in
+      let* cred_type_str = get_string "cred_type" in
+      let* username = get_string "username" in
+      let* gh_config_dir = get_opt_string "gh_config_dir" in
+      let* ssh_key_path = get_opt_string "ssh_key_path" in
+      let* gpg_key_id = get_opt_string "gpg_key_id" in
+      let* cred_type =
+        match cred_type_str with
+        | "github" -> Ok Repo_manager_types.Github
+        | "gitlab" -> Ok Gitlab
+        | "local" -> Ok Local
+        | _ -> Error (Printf.sprintf "unknown cred_type: %s" cred_type_str)
+      in
+      Ok { Repo_manager_types.id; cred_type; username; gh_config_dir; ssh_key_path; gpg_key_id }
+  | _ -> Error "expected JSON object body"
+
+let add_routes router =
+  router
+  |> Http.Router.get "/api/v1/credentials" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_path = state.Mcp_server.room_config.base_path in
+         match Credential_store.load_all ~base_path with
+         | Error msg ->
+             Http.Response.json ~status:`Internal_server_error ~request:req
+               (Yojson.Safe.to_string
+                  (`Assoc [ ("ok", `Bool false); ("error", `String msg) ]))
+               reqd
+         | Ok credentials ->
+             let json = `Assoc [ ("credentials", `List (List.map credential_json credentials)) ] in
+             Http.Response.json ~compress:true ~request:req
+               (Yojson.Safe.to_string json)
+               reqd
+       ) request reqd)
+  |> Http.Router.prefix_get "/api/v1/credentials/" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_path = state.Mcp_server.room_config.base_path in
+         let path = Http.Request.path request in
+         match extract_path_param ~prefix:"/api/v1/credentials/" path with
+         | None | Some "" ->
+             Http.Response.json ~status:`Bad_request ~request:req
+               (Yojson.Safe.to_string
+                  (`Assoc
+                    [ ("ok", `Bool false); ("error", `String "missing credential id") ]))
+               reqd
+         | Some id -> (
+             match Credential_store.find ~base_path id with
+             | Error msg ->
+                 Http.Response.json ~status:`Not_found ~request:req
+                   (Yojson.Safe.to_string
+                      (`Assoc [ ("ok", `Bool false); ("error", `String msg) ]))
+                   reqd
+             | Ok credential ->
+                 Http.Response.json ~request:req
+                   (Yojson.Safe.to_string (credential_json credential))
+                   reqd)
+       ) request reqd)
+  |> Http.Router.post "/api/v1/credentials" (fun request reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun state _agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             let response status message =
+               Http.Response.json ~status ~request:req
+                 (Yojson.Safe.to_string
+                    (`Assoc [ ("ok", `Bool false); ("error", `String message) ]))
+                 reqd
+             in
+             match Yojson.Safe.from_string body_str with
+             | exception Yojson.Json_error msg ->
+                 response `Bad_request ("invalid JSON body: " ^ msg)
+             | json -> (
+                 match credential_of_json json with
+                 | Error msg -> response `Bad_request msg
+                 | Ok credential ->
+                     let base_path = state.Mcp_server.room_config.base_path in
+                     match Credential_store.add ~base_path credential with
+                     | Error msg -> response `Bad_request msg
+                     | Ok cred ->
+                         Http.Response.json ~request:req
+                           (Yojson.Safe.to_string (credential_json cred))
+                           reqd)))
+         request reqd)
+  |> Http.Router.add ~path:("PREFIX:/api/v1/credentials/")
+       ~methods:[`DELETE]
+       ~handler:(fun request reqd ->
+         with_token_permission_auth ~permission:Types.CanAdmin
+           (fun state _agent_name req reqd ->
+             let base_path = state.Mcp_server.room_config.base_path in
+             let path = Http.Request.path request in
+             match extract_path_param ~prefix:"/api/v1/credentials/" path with
+             | None | Some "" ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   (Yojson.Safe.to_string
+                      (`Assoc
+                        [ ("ok", `Bool false); ("error", `String "missing credential id") ]))
+                   reqd
+             | Some id -> (
+                 match Credential_store.remove ~base_path id with
+                 | Error msg ->
+                     Http.Response.json ~status:`Bad_request ~request:req
+                       (Yojson.Safe.to_string
+                          (`Assoc [ ("ok", `Bool false); ("error", `String msg) ]))
+                       reqd
+                 | Ok () ->
+                     Http.Response.json ~request:req
+                       (Yojson.Safe.to_string (`Assoc [ ("ok", `Bool true) ]))
+                       reqd)
+           ) request reqd)

--- a/lib/server/server_routes_http_routes_credentials.mli
+++ b/lib/server/server_routes_http_routes_credentials.mli
@@ -1,0 +1,12 @@
+(** Server_routes_http_routes_credentials — HTTP routes for credential management.
+
+    Provides CRUD endpoints for repository credentials:
+    - GET /api/v1/credentials — list all credentials
+    - GET /api/v1/credentials/:id — find credential by id
+    - POST /api/v1/credentials — add new credential
+    - DELETE /api/v1/credentials/:id — remove credential
+
+    Only the wired routes are exposed via {!add_routes}. *)
+
+val add_routes :
+  Http_server_eio.Router.t -> Http_server_eio.Router.t

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -1,0 +1,137 @@
+open Server_auth
+open Server_utils
+
+module Http = Http_server_eio
+
+let mapping_json (m : Repo_manager_types.keeper_repo_mapping) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("keeper_id", `String m.keeper_id);
+      ("repositories", `List (List.map (fun s -> `String s) m.repository_ids));
+    ]
+
+let mapping_of_json keeper_id (json : Yojson.Safe.t) :
+    (Repo_manager_types.keeper_repo_mapping, string) result =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "repositories" fields with
+      | Some (`List items) ->
+          let repository_ids =
+            List.filter_map
+              (function `String s -> Some s | _ -> None)
+              items
+          in
+          Ok { Repo_manager_types.keeper_id; repository_ids }
+      | Some _ -> Error "field repositories must be an array of strings"
+      | None -> Error "missing field repositories")
+  | _ -> Error "expected JSON object body"
+
+let add_routes router =
+  router
+  |> Http.Router.prefix_get "/api/v1/keepers/" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_path = state.Mcp_server.room_config.base_path in
+         let path = Http.Request.path request in
+         match extract_path_param ~prefix:"/api/v1/keepers/" path with
+         | None | Some "" ->
+             Http.Response.json ~status:`Bad_request ~request:req
+               (Yojson.Safe.to_string
+                  (`Assoc
+                    [
+                      ("ok", `Bool false);
+                      ("error", `String "missing keeper id");
+                    ]))
+               reqd
+         | Some rest -> (
+             match String.split_on_char '/' rest with
+             | keeper_id :: "repos" :: [] -> (
+                 match
+                   Keeper_repo_mapping.allowed_repositories ~keeper_id ~base_path
+                 with
+                 | Error msg ->
+                     Http.Response.json ~status:`Not_found ~request:req
+                       (Yojson.Safe.to_string
+                          (`Assoc
+                            [
+                              ("ok", `Bool false); ("error", `String msg);
+                            ]))
+                       reqd
+                 | Ok repo_ids ->
+                     let json =
+                       `Assoc
+                         [
+                           ("keeper_id", `String keeper_id);
+                           ( "repositories",
+                             `List (List.map (fun s -> `String s) repo_ids) );
+                         ]
+                     in
+                     Http.Response.json ~compress:true ~request:req
+                       (Yojson.Safe.to_string json)
+                       reqd)
+             | _ ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   (Yojson.Safe.to_string
+                      (`Assoc
+                        [
+                          ("ok", `Bool false);
+                          ( "error",
+                            `String "expected path /api/v1/keepers/:id/repos" );
+                        ]))
+                   reqd)
+       ) request reqd)
+  |> Http.Router.prefix_post "/api/v1/keepers/" (fun request reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun state _agent_name req reqd ->
+           let base_path = state.Mcp_server.room_config.base_path in
+           let path = Http.Request.path request in
+           match extract_path_param ~prefix:"/api/v1/keepers/" path with
+           | None | Some "" ->
+               Http.Response.json ~status:`Bad_request ~request:req
+                 (Yojson.Safe.to_string
+                    (`Assoc
+                      [
+                        ("ok", `Bool false);
+                        ("error", `String "missing keeper id");
+                      ]))
+                 reqd
+           | Some rest -> (
+               match String.split_on_char '/' rest with
+               | keeper_id :: "repos" :: [] ->
+                   Http.Request.read_body_async reqd (fun body_str ->
+                     let response status message =
+                       Http.Response.json ~status ~request:req
+                         (Yojson.Safe.to_string
+                            (`Assoc
+                              [
+                                ("ok", `Bool false);
+                                ("error", `String message);
+                              ]))
+                         reqd
+                     in
+                     match Yojson.Safe.from_string body_str with
+                     | exception Yojson.Json_error msg ->
+                         response `Bad_request ("invalid JSON body: " ^ msg)
+                     | json -> (
+                         match mapping_of_json keeper_id json with
+                         | Error msg -> response `Bad_request msg
+                         | Ok mapping -> (
+                             match
+                               Keeper_repo_mapping.save_mapping ~base_path mapping
+                             with
+                             | Error msg -> response `Bad_request msg
+                             | Ok () ->
+                                 Http.Response.json ~request:req
+                                   (Yojson.Safe.to_string (mapping_json mapping))
+                                   reqd)))
+               | _ ->
+                   Http.Response.json ~status:`Bad_request ~request:req
+                     (Yojson.Safe.to_string
+                        (`Assoc
+                          [
+                            ("ok", `Bool false);
+                            ( "error",
+                              `String
+                                "expected path /api/v1/keepers/:id/repos" );
+                          ]))
+                     reqd)
+         ) request reqd)

--- a/lib/server/server_routes_http_routes_keeper_repos.mli
+++ b/lib/server/server_routes_http_routes_keeper_repos.mli
@@ -1,0 +1,11 @@
+(** Server_routes_http_routes_keeper_repos — HTTP routes for keeper-repository
+    access control mappings.
+
+    Provides endpoints for managing which repositories a keeper may access:
+    - GET /api/v1/keepers/:id/repos — list allowed repositories for keeper
+    - POST /api/v1/keepers/:id/repos — update mapping for keeper
+
+    Only the wired routes are exposed via {!add_routes}. *)
+
+val add_routes :
+  Http_server_eio.Router.t -> Http_server_eio.Router.t

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -1,0 +1,143 @@
+open Server_auth
+open Server_utils
+
+module Http = Http_server_eio
+
+let base_path_of_state state = state.Mcp_server.room_config.base_path
+
+let json_error message =
+  `Assoc [("ok", `Bool false); ("error", `String message)]
+
+let json_response ~status req reqd json =
+  Http.Response.json ~status ~request:req
+    (Yojson.Safe.to_string json) reqd
+
+let ok_json data =
+  `Assoc [("ok", `Bool true); ("data", data)]
+
+let repositories_prefix = "/api/v1/repositories/"
+let sync_suffix = "/sync"
+
+let extract_repo_id path =
+  extract_path_param ~prefix:repositories_prefix path
+
+let extract_repo_id_for_sync path =
+  match extract_path_param ~prefix:repositories_prefix path with
+  | None -> None
+  | Some rest ->
+      let suffix_len = String.length sync_suffix in
+      let rest_len = String.length rest in
+      if rest_len > suffix_len && String.sub rest (rest_len - suffix_len) suffix_len = sync_suffix then
+        Some (String.sub rest 0 (rest_len - suffix_len))
+      else
+        None
+
+let parse_repository_json body_str =
+  match Yojson.Safe.from_string body_str with
+  | json -> (
+      match Repo_manager_types.repository_of_yojson json with
+      | Ok repo -> Ok repo
+      | Error msg -> Error ("invalid repository JSON: " ^ msg))
+  | exception Yojson.Json_error msg ->
+      Error ("invalid JSON body: " ^ msg)
+
+let handle_list_repositories state req reqd =
+  let base_path = base_path_of_state state in
+  match Repo_store.load_all ~base_path with
+  | Error msg ->
+      json_response ~status:`Internal_server_error req reqd (json_error msg)
+  | Ok repos ->
+      let json =
+        ok_json (`List (List.map Repo_manager_types.repository_to_yojson repos))
+      in
+      Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd
+
+let handle_get_repository state req reqd =
+  let base_path = base_path_of_state state in
+  let path = Http.Request.path req in
+  match extract_repo_id path with
+  | None ->
+      json_response ~status:`Bad_request req reqd
+        (json_error "repository id path parameter required")
+  | Some id -> (
+      match Repo_store.find ~base_path id with
+      | Error msg ->
+          json_response ~status:`Not_found req reqd (json_error msg)
+      | Ok repo ->
+          let json = ok_json (Repo_manager_types.repository_to_yojson repo) in
+          Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd)
+
+let handle_add_repository state _agent_name req reqd =
+  let base_path = base_path_of_state state in
+  Http.Request.read_body_async reqd (fun body_str ->
+      match parse_repository_json body_str with
+      | Error msg ->
+          json_response ~status:`Bad_request req reqd (json_error msg)
+      | Ok repo -> (
+          match Repo_store.add ~base_path repo with
+          | Error msg ->
+              json_response ~status:`Bad_request req reqd (json_error msg)
+          | Ok added_repo ->
+              let json =
+                ok_json (Repo_manager_types.repository_to_yojson added_repo)
+              in
+              Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd))
+
+let handle_remove_repository state _agent_name req reqd =
+  let base_path = base_path_of_state state in
+  let path = Http.Request.path req in
+  match extract_repo_id path with
+  | None ->
+      json_response ~status:`Bad_request req reqd
+        (json_error "repository id path parameter required")
+  | Some id -> (
+      match Repo_store.remove ~base_path id with
+      | Error msg ->
+          json_response ~status:`Not_found req reqd (json_error msg)
+      | Ok () ->
+          let json = ok_json (`Assoc [("id", `String id)]) in
+          Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd)
+
+let handle_sync_repository state _agent_name req reqd =
+  let base_path = base_path_of_state state in
+  let path = Http.Request.path req in
+  match extract_repo_id_for_sync path with
+  | None ->
+      json_response ~status:`Bad_request req reqd
+        (json_error "repository id path parameter required")
+  | Some id -> (
+      match Repo_store.find ~base_path id with
+      | Error msg ->
+          json_response ~status:`Not_found req reqd (json_error msg)
+      | Ok repo -> (
+          match Credential_store.find ~base_path repo.credential_id with
+          | Error msg ->
+              json_response ~status:`Bad_request req reqd
+                (json_error ("credential not found: " ^ msg))
+          | Ok credential -> (
+              match Repo_sync.sync_repository ~base_path repo credential with
+              | Error msg ->
+                  json_response ~status:`Internal_server_error req reqd
+                    (json_error msg)
+              | Ok () ->
+                  let json = ok_json (`Assoc [("id", `String id)]) in
+                  Http.Response.json ~request:req (Yojson.Safe.to_string json)
+                    reqd)))
+
+let add_routes router =
+  router
+  |> Http.Router.get "/api/v1/repositories" (fun request reqd ->
+       with_public_read handle_list_repositories request reqd)
+  |> Http.Router.prefix_get repositories_prefix (fun request reqd ->
+       with_public_read handle_get_repository request reqd)
+  |> Http.Router.post "/api/v1/repositories" (fun request reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         handle_add_repository request reqd)
+  |> Http.Router.add ~path:("PREFIX:" ^ repositories_prefix)
+       ~methods:[`DELETE]
+       ~handler:(fun request reqd ->
+         with_token_permission_auth ~permission:Types.CanAdmin
+           handle_remove_repository request reqd)
+  |> Http.Router.prefix_post repositories_prefix (fun request reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         handle_sync_repository request reqd)

--- a/lib/server/server_routes_http_routes_repositories.mli
+++ b/lib/server/server_routes_http_routes_repositories.mli
@@ -1,0 +1,14 @@
+(** Server_routes_http_routes_repositories — HTTP routes for repository
+    CRUD and sync operations.
+
+    Routes:
+    - GET    /api/v1/repositories        — list all repositories
+    - POST   /api/v1/repositories        — add a new repository
+    - GET    /api/v1/repositories/:id    — get a single repository
+    - DELETE /api/v1/repositories/:id    — remove a repository
+    - POST   /api/v1/repositories/:id/sync — trigger sync for a repository
+
+    Only the wired routes are exposed via {!add_routes}. *)
+
+val add_routes :
+  Http_server_eio.Router.t -> Http_server_eio.Router.t

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -40,6 +40,7 @@
    (re_export masc_mcp.multimodal)
    (re_export masc_mcp.prompt_registry)
    (re_export masc_mcp.pulse)
+   (re_export masc_mcp.repo_manager)
    (re_export masc_mcp.response)
    ;; masc_mcp.swarm_status removed (retire swarm read surfaces, #7572)
    ;; masc_mcp.team_session_types removed (Epic #6107)

--- a/test/dune
+++ b/test/dune
@@ -117,6 +117,10 @@
         test_claim_post_provision_hook
         test_keeper_toml_config_validation
         test_keeper_id
+        test_repo_store
+        test_credential_store
+        test_keeper_repo_mapping
+        test_repo_sync
         test_exec_core
         test_exec_dispatch
         test_keeper_bash_safety
@@ -302,6 +306,10 @@
           test_claim_post_provision_hook
           test_keeper_toml_config_validation
           test_keeper_id
+          test_repo_store
+          test_credential_store
+          test_keeper_repo_mapping
+          test_repo_sync
           test_exec_core
           test_exec_dispatch
           test_keeper_bash_safety

--- a/test/test_credential_store.ml
+++ b/test/test_credential_store.ml
@@ -1,0 +1,222 @@
+(** Tests for Credential_store module *)
+
+open Repo_manager_types
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
+
+let with_temp_base_path f =
+  let dir = Filename.temp_file "cred_store_test" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let config_dir = Filename.concat dir ".masc" in
+  Unix.mkdir config_dir 0o755;
+  let config_subdir = Filename.concat config_dir "config" in
+  Unix.mkdir config_subdir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then begin
+            Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+            Unix.rmdir path
+          end else
+            Sys.remove path
+      in
+      rm_rf dir)
+    (fun () -> f dir)
+
+let sample_credential id cred_type =
+  {
+    id;
+    cred_type;
+    username = "user-" ^ id;
+    gh_config_dir = Some ("/home/user/.config/gh-" ^ id);
+    ssh_key_path = Some ("/home/user/.ssh/id_" ^ id);
+    gpg_key_id = None;
+  }
+
+let test_load_all_empty () =
+  with_temp_base_path (fun base_path ->
+      match Credential_store.load_all ~base_path with
+      | Ok creds -> Alcotest.(check int) "empty list" 0 (List.length creds)
+      | Error e -> Alcotest.fail ("unexpected error: " ^ e))
+
+let test_save_and_load_roundtrip () =
+  with_temp_base_path (fun base_path ->
+      let creds =
+        [
+          sample_credential "c1" Github;
+          sample_credential "c2" Gitlab;
+          sample_credential "c3" Local;
+        ]
+      in
+      match Credential_store.save_all ~base_path creds with
+      | Error e -> Alcotest.fail ("save failed: " ^ e)
+      | Ok () -> (
+          match Credential_store.load_all ~base_path with
+          | Error e -> Alcotest.fail ("load failed: " ^ e)
+          | Ok loaded ->
+              Alcotest.(check int) "count" 3 (List.length loaded);
+              let ids = List.map (fun (c : credential) -> c.id) loaded in
+              Alcotest.(check bool) "has c1" true (List.mem "c1" ids);
+              Alcotest.(check bool) "has c2" true (List.mem "c2" ids);
+              Alcotest.(check bool) "has c3" true (List.mem "c3" ids)))
+
+let test_credential_type_roundtrip () =
+  with_temp_base_path (fun base_path ->
+      let creds =
+        [
+          sample_credential "gh" Github;
+          sample_credential "gl" Gitlab;
+          sample_credential "loc" Local;
+        ]
+      in
+      match Credential_store.save_all ~base_path creds with
+      | Error e -> Alcotest.fail ("save failed: " ^ e)
+      | Ok () -> (
+          match Credential_store.load_all ~base_path with
+          | Error e -> Alcotest.fail ("load failed: " ^ e)
+          | Ok loaded ->
+              let find id = List.find (fun (c : credential) -> String.equal c.id id) loaded in
+              Alcotest.(check bool) "github type"
+                true
+                (match (find "gh").cred_type with Github -> true | _ -> false);
+              Alcotest.(check bool) "gitlab type"
+                true
+                (match (find "gl").cred_type with Gitlab -> true | _ -> false);
+              Alcotest.(check bool) "local type"
+                true
+                (match (find "loc").cred_type with Local -> true | _ -> false)))
+
+let test_optional_fields_roundtrip () =
+  with_temp_base_path (fun base_path ->
+      let cred =
+        {
+          id = "minimal";
+          cred_type = Local;
+          username = "min-user";
+          gh_config_dir = None;
+          ssh_key_path = None;
+          gpg_key_id = Some "ABC123";
+        }
+      in
+      match Credential_store.save_all ~base_path [ cred ] with
+      | Error e -> Alcotest.fail ("save failed: " ^ e)
+      | Ok () -> (
+          match Credential_store.load_all ~base_path with
+          | Error e -> Alcotest.fail ("load failed: " ^ e)
+          | Ok loaded ->
+              Alcotest.(check int) "count" 1 (List.length loaded);
+              let found = List.hd loaded in
+              Alcotest.(check (option string)) "gh_config_dir None" None found.gh_config_dir;
+              Alcotest.(check (option string)) "ssh_key_path None" None found.ssh_key_path;
+              Alcotest.(check (option string)) "gpg_key_id Some" (Some "ABC123") found.gpg_key_id))
+
+let test_add_new_credential () =
+  with_temp_base_path (fun base_path ->
+      let cred = sample_credential "new-cred" Github in
+      match Credential_store.add ~base_path cred with
+      | Error e -> Alcotest.fail ("add failed: " ^ e)
+      | Ok added ->
+          Alcotest.(check string) "id" "new-cred" added.id;
+          match Credential_store.load_all ~base_path with
+          | Ok loaded -> Alcotest.(check int) "count after add" 1 (List.length loaded)
+          | Error e -> Alcotest.fail ("load after add failed: " ^ e))
+
+let test_add_duplicate_fails () =
+  with_temp_base_path (fun base_path ->
+      let cred = sample_credential "dup-cred" Github in
+      match Credential_store.add ~base_path cred with
+      | Error e -> Alcotest.fail ("first add failed: " ^ e)
+      | Ok _ -> (
+          match Credential_store.add ~base_path cred with
+          | Ok _ -> Alcotest.fail "expected error for duplicate"
+          | Error msg ->
+              Alcotest.(check bool) "mentions already exists" true
+                (contains_substring msg "already exists")))
+
+let test_find_existing () =
+  with_temp_base_path (fun base_path ->
+      let cred = sample_credential "find-me" Gitlab in
+      match Credential_store.add ~base_path cred with
+      | Error e -> Alcotest.fail ("add failed: " ^ e)
+      | Ok _ -> (
+          match Credential_store.find ~base_path "find-me" with
+          | Error e -> Alcotest.fail ("find failed: " ^ e)
+          | Ok found -> Alcotest.(check string) "username" "user-find-me" found.username))
+
+let test_find_missing () =
+  with_temp_base_path (fun base_path ->
+      match Credential_store.find ~base_path "missing" with
+      | Ok _ -> Alcotest.fail "expected error for missing credential"
+      | Error msg ->
+          Alcotest.(check bool) "mentions not found" true (contains_substring msg "not found"))
+
+let test_remove_existing () =
+  with_temp_base_path (fun base_path ->
+      let cred = sample_credential "to-remove" Local in
+      match Credential_store.add ~base_path cred with
+      | Error e -> Alcotest.fail ("add failed: " ^ e)
+      | Ok _ -> (
+          match Credential_store.remove ~base_path "to-remove" with
+          | Error e -> Alcotest.fail ("remove failed: " ^ e)
+          | Ok () -> (
+              match Credential_store.load_all ~base_path with
+              | Ok loaded -> Alcotest.(check int) "count after remove" 0 (List.length loaded)
+              | Error e -> Alcotest.fail ("load after remove failed: " ^ e))))
+
+let test_remove_missing () =
+  with_temp_base_path (fun base_path ->
+      match Credential_store.remove ~base_path "missing" with
+      | Ok _ -> Alcotest.fail "expected error for missing credential"
+      | Error msg ->
+          Alcotest.(check bool) "mentions not found" true (contains_substring msg "not found"))
+
+let test_credential_type_roundtrip () =
+  let types = [ Github; Gitlab; Local ] in
+  List.iter
+    (fun t ->
+      let json = credential_type_to_yojson t in
+      match credential_type_of_yojson json with
+      | Ok parsed -> Alcotest.(check bool) "roundtrip" true (equal_credential_type t parsed)
+      | Error e -> Alcotest.fail e)
+    types
+
+let () =
+  Alcotest.run "Credential_store"
+    [
+      ( "roundtrip",
+        [
+          Alcotest.test_case "load_all empty" `Quick test_load_all_empty;
+          Alcotest.test_case "save and load roundtrip" `Quick test_save_and_load_roundtrip;
+          Alcotest.test_case "credential type roundtrip" `Quick test_credential_type_roundtrip;
+          Alcotest.test_case "optional fields roundtrip" `Quick test_optional_fields_roundtrip;
+        ] );
+      ( "add",
+        [
+          Alcotest.test_case "add new credential" `Quick test_add_new_credential;
+          Alcotest.test_case "add duplicate fails" `Quick test_add_duplicate_fails;
+        ] );
+      ( "find",
+        [
+          Alcotest.test_case "find existing" `Quick test_find_existing;
+          Alcotest.test_case "find missing" `Quick test_find_missing;
+        ] );
+      ( "remove",
+        [
+          Alcotest.test_case "remove existing" `Quick test_remove_existing;
+          Alcotest.test_case "remove missing" `Quick test_remove_missing;
+        ] );
+      ( "credential_type",
+        [
+          Alcotest.test_case "yojson roundtrip" `Quick test_credential_type_roundtrip;
+        ] );
+    ]

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -1,0 +1,181 @@
+(** Tests for Keeper_repo_mapping module *)
+
+open Repo_manager_types
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
+
+let with_temp_base_path f =
+  let dir = Filename.temp_file "mapping_test" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let config_dir = Filename.concat dir ".masc" in
+  Unix.mkdir config_dir 0o755;
+  let config_subdir = Filename.concat config_dir "config" in
+  Unix.mkdir config_subdir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then begin
+            Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+            Unix.rmdir path
+          end else
+            Sys.remove path
+      in
+      rm_rf dir)
+    (fun () -> f dir)
+
+let write_mapping base_path keeper_id repo_ids =
+  let path = Filename.concat base_path ".masc/config/keeper_repo_mappings.toml" in
+  let entries =
+    String.concat ", " (List.map (fun s -> "\"" ^ s ^ "\"") repo_ids)
+  in
+  let content = Printf.sprintf "[mapping.%s]\nrepositories = [%s]\n" keeper_id entries in
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc content)
+
+let sample_repo id =
+  {
+    id;
+    name = "repo-" ^ id;
+    url = "https://github.com/test/" ^ id;
+    local_path = "repos/" ^ id;
+    default_branch = "main";
+    credential_id = "cred-1";
+    keepers = [];
+    status = Active;
+    auto_sync = false;
+    sync_interval = 0;
+    created_at = Int64.zero;
+    updated_at = Int64.zero;
+  }
+
+let test_is_allowed_explicit () =
+  with_temp_base_path (fun base_path ->
+      write_mapping base_path "keeper-1" [ "repo-a"; "repo-b" ];
+      Alcotest.(check bool)
+        "allowed repo-a" true
+        (Keeper_repo_mapping.is_allowed ~keeper_id:"keeper-1" ~repository_id:"repo-a" ~base_path);
+      Alcotest.(check bool)
+        "allowed repo-b" true
+        (Keeper_repo_mapping.is_allowed ~keeper_id:"keeper-1" ~repository_id:"repo-b" ~base_path);
+      Alcotest.(check bool)
+        "not allowed repo-c" false
+        (Keeper_repo_mapping.is_allowed ~keeper_id:"keeper-1" ~repository_id:"repo-c" ~base_path))
+
+let test_is_allowed_wildcard () =
+  with_temp_base_path (fun base_path ->
+      write_mapping base_path "keeper-wild" [ "*" ];
+      Alcotest.(check bool)
+        "wildcard allows any" true
+        (Keeper_repo_mapping.is_allowed ~keeper_id:"keeper-wild" ~repository_id:"any-repo" ~base_path);
+      Alcotest.(check bool)
+        "wildcard allows another" true
+        (Keeper_repo_mapping.is_allowed ~keeper_id:"keeper-wild" ~repository_id:"another" ~base_path))
+
+let test_is_allowed_no_mapping () =
+  with_temp_base_path (fun base_path ->
+      Alcotest.(check bool)
+        "no mapping means not allowed" false
+        (Keeper_repo_mapping.is_allowed ~keeper_id:"unknown" ~repository_id:"repo-a" ~base_path))
+
+let test_validate_access_allowed () =
+  with_temp_base_path (fun base_path ->
+      write_mapping base_path "keeper-1" [ "repo-a" ];
+      match
+        Keeper_repo_mapping.validate_access ~keeper_id:"keeper-1" ~repository_id:"repo-a" ~base_path
+      with
+      | Ok () -> ()
+      | Error e -> Alcotest.fail ("expected Ok, got: " ^ e))
+
+let test_validate_access_denied () =
+  with_temp_base_path (fun base_path ->
+      write_mapping base_path "keeper-1" [ "repo-a" ];
+      match
+        Keeper_repo_mapping.validate_access ~keeper_id:"keeper-1" ~repository_id:"repo-b" ~base_path
+      with
+      | Ok _ -> Alcotest.fail "expected Error"
+      | Error msg ->
+          Alcotest.(check bool) "mentions not allowed" true (contains_substring msg "not allowed"))
+
+let test_apply_mapping_explicit () =
+  with_temp_base_path (fun base_path ->
+      write_mapping base_path "keeper-1" [ "repo-a"; "repo-c" ];
+      let repos = [ sample_repo "repo-a"; sample_repo "repo-b"; sample_repo "repo-c" ] in
+      let filtered =
+        Keeper_repo_mapping.apply_mapping ~keeper_id:"keeper-1" ~base_path ~repositories:repos
+      in
+      Alcotest.(check int) "filtered count" 2 (List.length filtered);
+      let ids = List.map (fun (r : repository) -> r.id) filtered in
+      Alcotest.(check bool) "has repo-a" true (List.mem "repo-a" ids);
+      Alcotest.(check bool) "has repo-c" true (List.mem "repo-c" ids);
+      Alcotest.(check bool) "no repo-b" false (List.mem "repo-b" ids))
+
+let test_apply_mapping_wildcard () =
+  with_temp_base_path (fun base_path ->
+      write_mapping base_path "keeper-wild" [ "*" ];
+      let repos = [ sample_repo "repo-a"; sample_repo "repo-b" ] in
+      let filtered =
+        Keeper_repo_mapping.apply_mapping ~keeper_id:"keeper-wild" ~base_path ~repositories:repos
+      in
+      Alcotest.(check int) "wildcard returns all" 2 (List.length filtered))
+
+let test_apply_mapping_no_mapping () =
+  with_temp_base_path (fun base_path ->
+      let repos = [ sample_repo "repo-a"; sample_repo "repo-b" ] in
+      let filtered =
+        Keeper_repo_mapping.apply_mapping ~keeper_id:"unknown" ~base_path ~repositories:repos
+      in
+      Alcotest.(check int) "no mapping returns empty" 0 (List.length filtered))
+
+let test_allowed_repositories () =
+  with_temp_base_path (fun base_path ->
+      write_mapping base_path "keeper-1" [ "repo-x"; "repo-y" ];
+      match Keeper_repo_mapping.allowed_repositories ~keeper_id:"keeper-1" ~base_path with
+      | Error e -> Alcotest.fail ("unexpected error: " ^ e)
+      | Ok ids ->
+          Alcotest.(check int) "count" 2 (List.length ids);
+          Alcotest.(check bool) "has repo-x" true (List.mem "repo-x" ids);
+          Alcotest.(check bool) "has repo-y" true (List.mem "repo-y" ids))
+
+let test_allowed_repositories_no_mapping () =
+  with_temp_base_path (fun base_path ->
+      match Keeper_repo_mapping.allowed_repositories ~keeper_id:"unknown" ~base_path with
+      | Ok _ -> Alcotest.fail "expected Error"
+      | Error msg ->
+          Alcotest.(check bool) "mentions no mapping" true (contains_substring msg "No mapping"))
+
+let () =
+  Alcotest.run "Keeper_repo_mapping"
+    [
+      ( "is_allowed",
+        [
+          Alcotest.test_case "explicit list" `Quick test_is_allowed_explicit;
+          Alcotest.test_case "wildcard" `Quick test_is_allowed_wildcard;
+          Alcotest.test_case "no mapping" `Quick test_is_allowed_no_mapping;
+        ] );
+      ( "validate_access",
+        [
+          Alcotest.test_case "allowed" `Quick test_validate_access_allowed;
+          Alcotest.test_case "denied" `Quick test_validate_access_denied;
+        ] );
+      ( "apply_mapping",
+        [
+          Alcotest.test_case "explicit list" `Quick test_apply_mapping_explicit;
+          Alcotest.test_case "wildcard" `Quick test_apply_mapping_wildcard;
+          Alcotest.test_case "no mapping" `Quick test_apply_mapping_no_mapping;
+        ] );
+      ( "allowed_repositories",
+        [
+          Alcotest.test_case "returns list" `Quick test_allowed_repositories;
+          Alcotest.test_case "no mapping" `Quick test_allowed_repositories_no_mapping;
+        ] );
+    ]

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -1,0 +1,221 @@
+(** Tests for Repo_store module *)
+
+open Repo_manager_types
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
+
+let with_temp_base_path f =
+  let dir = Filename.temp_file "repo_store_test" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let config_dir = Filename.concat dir ".masc" in
+  Unix.mkdir config_dir 0o755;
+  let config_subdir = Filename.concat config_dir "config" in
+  Unix.mkdir config_subdir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then begin
+            Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+            Unix.rmdir path
+          end else
+            Sys.remove path
+      in
+      rm_rf dir)
+    (fun () -> f dir)
+
+let sample_repo id =
+  {
+    id;
+    name = "test-repo-" ^ id;
+    url = "https://github.com/test/" ^ id;
+    local_path = "repos/" ^ id;
+    default_branch = "main";
+    credential_id = "cred-1";
+    keepers = [ "keeper-a"; "keeper-b" ];
+    status = Active;
+    auto_sync = true;
+    sync_interval = 300;
+    created_at = Int64.of_int 1700000000;
+    updated_at = Int64.of_int 1700000100;
+  }
+
+let test_load_all_empty () =
+  with_temp_base_path (fun base_path ->
+      match Repo_store.load_all ~base_path with
+      | Ok repos -> Alcotest.(check int) "empty list" 0 (List.length repos)
+      | Error e -> Alcotest.fail ("unexpected error: " ^ e))
+
+let test_save_and_load_roundtrip () =
+  with_temp_base_path (fun base_path ->
+      let repos = [ sample_repo "r1"; sample_repo "r2" ] in
+      match Repo_store.save_all ~base_path repos with
+      | Error e -> Alcotest.fail ("save failed: " ^ e)
+      | Ok () -> (
+          match Repo_store.load_all ~base_path with
+          | Error e -> Alcotest.fail ("load failed: " ^ e)
+          | Ok loaded ->
+              Alcotest.(check int) "count" 2 (List.length loaded);
+              let ids = List.map (fun (r : repository) -> r.id) loaded in
+              Alcotest.(check bool) "has r1" true (List.mem "r1" ids);
+              Alcotest.(check bool) "has r2" true (List.mem "r2" ids)))
+
+let test_add_new_repo () =
+  with_temp_base_path (fun base_path ->
+      let repo = sample_repo "new-repo" in
+      match Repo_store.add ~base_path repo with
+      | Error e -> Alcotest.fail ("add failed: " ^ e)
+      | Ok added ->
+          Alcotest.(check string) "id" "new-repo" added.id;
+          match Repo_store.load_all ~base_path with
+          | Ok loaded -> Alcotest.(check int) "count after add" 1 (List.length loaded)
+          | Error e -> Alcotest.fail ("load after add failed: " ^ e))
+
+let test_add_duplicate_fails () =
+  with_temp_base_path (fun base_path ->
+      let repo = sample_repo "dup-repo" in
+      match Repo_store.add ~base_path repo with
+      | Error e -> Alcotest.fail ("first add failed: " ^ e)
+      | Ok _ -> (
+          match Repo_store.add ~base_path repo with
+          | Ok _ -> Alcotest.fail "expected error for duplicate"
+          | Error msg ->
+              Alcotest.(check bool) "mentions already exists" true
+                (contains_substring msg "already exists")))
+
+let test_find_existing () =
+  with_temp_base_path (fun base_path ->
+      let repo = sample_repo "find-me" in
+      match Repo_store.add ~base_path repo with
+      | Error e -> Alcotest.fail ("add failed: " ^ e)
+      | Ok _ -> (
+          match Repo_store.find ~base_path "find-me" with
+          | Error e -> Alcotest.fail ("find failed: " ^ e)
+          | Ok found -> Alcotest.(check string) "name" "test-repo-find-me" found.name))
+
+let test_find_missing () =
+  with_temp_base_path (fun base_path ->
+      match Repo_store.find ~base_path "missing" with
+      | Ok _ -> Alcotest.fail "expected error for missing repo"
+      | Error msg ->
+          Alcotest.(check bool) "mentions not found" true (contains_substring msg "not found"))
+
+let test_remove_existing () =
+  with_temp_base_path (fun base_path ->
+      let repo = sample_repo "to-remove" in
+      match Repo_store.add ~base_path repo with
+      | Error e -> Alcotest.fail ("add failed: " ^ e)
+      | Ok _ -> (
+          match Repo_store.remove ~base_path "to-remove" with
+          | Error e -> Alcotest.fail ("remove failed: " ^ e)
+          | Ok () -> (
+              match Repo_store.load_all ~base_path with
+              | Ok loaded -> Alcotest.(check int) "count after remove" 0 (List.length loaded)
+              | Error e -> Alcotest.fail ("load after remove failed: " ^ e))))
+
+let test_remove_missing () =
+  with_temp_base_path (fun base_path ->
+      match Repo_store.remove ~base_path "missing" with
+      | Ok _ -> Alcotest.fail "expected error for missing repo"
+      | Error msg ->
+          Alcotest.(check bool) "mentions not found" true (contains_substring msg "not found"))
+
+let test_update_status_existing () =
+  with_temp_base_path (fun base_path ->
+      let repo = sample_repo "status-test" in
+      match Repo_store.add ~base_path repo with
+      | Error e -> Alcotest.fail ("add failed: " ^ e)
+      | Ok _ -> (
+          match Repo_store.update_status ~base_path "status-test" Paused with
+          | Error e -> Alcotest.fail ("update_status failed: " ^ e)
+          | Ok () -> (
+              match Repo_store.find ~base_path "status-test" with
+              | Ok found -> (
+                  match found.status with
+                  | Paused -> ()
+                  | _ -> Alcotest.fail "expected Paused status")
+              | Error e -> Alcotest.fail ("find after update failed: " ^ e))))
+
+let test_update_status_missing () =
+  with_temp_base_path (fun base_path ->
+      match Repo_store.update_status ~base_path "missing" Paused with
+      | Ok _ -> Alcotest.fail "expected error for missing repo"
+      | Error msg ->
+          Alcotest.(check bool) "mentions not found" true (contains_substring msg "not found"))
+
+let test_local_path_absolute_preserved () =
+  let repo = { (sample_repo "abs") with local_path = "/absolute/path" } in
+  let path = Repo_store.local_path ~base_path:"/tmp/base" repo in
+  Alcotest.(check string) "absolute preserved" "/absolute/path" path
+
+let test_local_path_relative_resolved () =
+  let repo = { (sample_repo "rel") with local_path = "repos/rel" } in
+  let path = Repo_store.local_path ~base_path:"/tmp/base" repo in
+  Alcotest.(check string) "relative resolved" "/tmp/base/repos/rel" path
+
+let test_status_roundtrip () =
+  let statuses = [ Active; Paused; Cloning; Error "network failure" ] in
+  List.iter
+    (fun status ->
+      let str =
+        match status with
+        | Active -> "Active"
+        | Paused -> "Paused"
+        | Cloning -> "Cloning"
+        | Error _ -> "Error"
+      in
+      Alcotest.(check string) ("status string for " ^ str) str
+        (match status with
+         | Active -> "Active"
+         | Paused -> "Paused"
+         | Cloning -> "Cloning"
+         | Error _ -> "Error"))
+    statuses
+
+let () =
+  Alcotest.run "Repo_store"
+    [
+      ( "roundtrip",
+        [
+          Alcotest.test_case "load_all empty" `Quick test_load_all_empty;
+          Alcotest.test_case "save and load roundtrip" `Quick test_save_and_load_roundtrip;
+        ] );
+      ( "add",
+        [
+          Alcotest.test_case "add new repo" `Quick test_add_new_repo;
+          Alcotest.test_case "add duplicate fails" `Quick test_add_duplicate_fails;
+        ] );
+      ( "find",
+        [
+          Alcotest.test_case "find existing" `Quick test_find_existing;
+          Alcotest.test_case "find missing" `Quick test_find_missing;
+        ] );
+      ( "remove",
+        [
+          Alcotest.test_case "remove existing" `Quick test_remove_existing;
+          Alcotest.test_case "remove missing" `Quick test_remove_missing;
+        ] );
+      ( "update_status",
+        [
+          Alcotest.test_case "update existing" `Quick test_update_status_existing;
+          Alcotest.test_case "update missing" `Quick test_update_status_missing;
+        ] );
+      ( "local_path",
+        [
+          Alcotest.test_case "absolute preserved" `Quick test_local_path_absolute_preserved;
+          Alcotest.test_case "relative resolved" `Quick test_local_path_relative_resolved;
+        ] );
+      ( "status",
+        [
+          Alcotest.test_case "status string roundtrip" `Quick test_status_roundtrip;
+        ] );
+    ]

--- a/test/test_repo_sync.ml
+++ b/test/test_repo_sync.ml
@@ -1,0 +1,116 @@
+(** Tests for Repo_sync module *)
+
+open Repo_manager_types
+
+let sample_repo ?(auto_sync = true) ?(sync_interval = 300) ?(updated_at = Int64.of_int 1700000000) id =
+  {
+    id;
+    name = "repo-" ^ id;
+    url = "https://github.com/test/" ^ id;
+    local_path = "repos/" ^ id;
+    default_branch = "main";
+    credential_id = "cred-1";
+    keepers = [];
+    status = Active;
+    auto_sync;
+    sync_interval;
+    created_at = Int64.of_int 1700000000;
+    updated_at;
+  }
+
+let test_should_sync_auto_sync_disabled () =
+  let repo = sample_repo ~auto_sync:false "r1" in
+  let now = Int64.of_int 1700001000 in
+  Alcotest.(check bool) "auto_sync=false means no sync" false (Repo_sync.should_sync repo ~now)
+
+let test_should_sync_interval_not_elapsed () =
+  let repo = sample_repo ~auto_sync:true ~sync_interval:300 ~updated_at:(Int64.of_int 1700000000) "r1" in
+  let now = Int64.of_int 1700000100 in
+  Alcotest.(check bool) "only 100s elapsed < 300s interval" false (Repo_sync.should_sync repo ~now)
+
+let test_should_sync_interval_elapsed () =
+  let repo = sample_repo ~auto_sync:true ~sync_interval:300 ~updated_at:(Int64.of_int 1700000000) "r1" in
+  let now = Int64.of_int 1700000400 in
+  Alcotest.(check bool) "400s elapsed >= 300s interval" true (Repo_sync.should_sync repo ~now)
+
+let test_should_sync_exact_boundary () =
+  let repo = sample_repo ~auto_sync:true ~sync_interval:300 ~updated_at:(Int64.of_int 1700000000) "r1" in
+  let now = Int64.of_int 1700000300 in
+  Alcotest.(check bool) "exactly 300s elapsed" true (Repo_sync.should_sync repo ~now)
+
+let test_should_sync_zero_interval () =
+  let repo = sample_repo ~auto_sync:true ~sync_interval:0 ~updated_at:(Int64.of_int 1700000000) "r1" in
+  let now = Int64.of_int 1700000000 in
+  Alcotest.(check bool) "zero interval, any elapsed >= 0" true (Repo_sync.should_sync repo ~now)
+
+let test_should_sync_large_elapsed () =
+  let repo = sample_repo ~auto_sync:true ~sync_interval:60 ~updated_at:(Int64.of_int 1700000000) "r1" in
+  let now = Int64.of_int 1700004000 in
+  Alcotest.(check bool) "far past interval" true (Repo_sync.should_sync repo ~now)
+
+let test_should_sync_negative_elapsed () =
+  let repo = sample_repo ~auto_sync:true ~sync_interval:300 ~updated_at:(Int64.of_int 1700000100) "r1" in
+  let now = Int64.of_int 1700000000 in
+  Alcotest.(check bool) "now < updated_at means elapsed < 0" false (Repo_sync.should_sync repo ~now)
+
+let with_temp_base_path f =
+  let dir = Filename.temp_file "repo_sync_test" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let config_dir = Filename.concat dir ".masc" in
+  Unix.mkdir config_dir 0o755;
+  let config_subdir = Filename.concat config_dir "config" in
+  Unix.mkdir config_subdir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then begin
+            Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+            Unix.rmdir path
+          end else
+            Sys.remove path
+      in
+      rm_rf dir)
+    (fun () -> f dir)
+
+let test_sync_all_empty_repos () =
+  with_temp_base_path (fun base_path ->
+      match Repo_sync.sync_all ~base_path ~now:(Int64.of_int 1700004000) with
+      | Ok synced -> Alcotest.(check int) "no repos means no syncs" 0 (List.length synced)
+      | Error e -> Alcotest.fail ("unexpected error: " ^ e))
+
+let test_sync_all_no_due_repos () =
+  with_temp_base_path (fun base_path ->
+      let repos =
+        [
+          sample_repo ~auto_sync:false "r1";
+          sample_repo ~auto_sync:true ~sync_interval:3600 ~updated_at:(Int64.of_int 1700000000) "r2";
+        ]
+      in
+      match Repo_store.save_all ~base_path repos with
+      | Error e -> Alcotest.fail ("save failed: " ^ e)
+      | Ok () -> (
+          match Repo_sync.sync_all ~base_path ~now:(Int64.of_int 1700000100) with
+          | Ok synced -> Alcotest.(check int) "no due repos" 0 (List.length synced)
+          | Error e -> Alcotest.fail ("sync_all failed: " ^ e)))
+
+let () =
+  Alcotest.run "Repo_sync"
+    [
+      ( "should_sync",
+        [
+          Alcotest.test_case "auto_sync disabled" `Quick test_should_sync_auto_sync_disabled;
+          Alcotest.test_case "interval not elapsed" `Quick test_should_sync_interval_not_elapsed;
+          Alcotest.test_case "interval elapsed" `Quick test_should_sync_interval_elapsed;
+          Alcotest.test_case "exact boundary" `Quick test_should_sync_exact_boundary;
+          Alcotest.test_case "zero interval" `Quick test_should_sync_zero_interval;
+          Alcotest.test_case "large elapsed" `Quick test_should_sync_large_elapsed;
+          Alcotest.test_case "negative elapsed" `Quick test_should_sync_negative_elapsed;
+        ] );
+      ( "sync_all",
+        [
+          Alcotest.test_case "empty repos" `Quick test_sync_all_empty_repos;
+          Alcotest.test_case "no due repos" `Quick test_sync_all_no_due_repos;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Multi-repository architecture for MASC-MCP. Adds repository registration, credential management, and per-keeper access control with backward compatibility for unmapped keepers.

## Changes

- **repo_manager core**: TOML-based repository registry, credential store, keeper-to-repo mapping
- **HTTP routes**: `GET/POST /api/v1/repositories`, `/api/v1/credentials`, `/api/v1/keepers/:id/repos`
- **Keeper execution**: Repository access restrictions integrated into `fs_read`, `fs_edit`, and shell ops paths
- **Dashboard UI**: Repository sidebar, detail panel, branch tree, credential settings, keeper mapping dialog
- **Tests**: Unit tests for `repo_store`, `repo_sync`, `credential_store`, `keeper_repo_mapping`

## Backward Compatibility

Keepers without a repo mapping retain full access. Playground files outside registered repositories are always allowed.

## Verification

- `dune build` passes
- 153 files changed, ~4600 insertions across 5 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)