### PR TITLE
fix(policy): fail closed on unavailable clone policy

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -83,18 +83,44 @@ let policy_string_array_of_line ~key line =
       in
       Some items
 
-(* SSOT path resolution: canonical config root is [<base_path>/.masc/config/]
-   (same primitive Config_dir_resolver.path_from_local_masc uses via
-   Common.masc_dir_from_base_path). The legacy [<base_path>/config/] form is
-   retained as a secondary lookup for older deployments. Reading order:
-   canonical first, legacy fallback only when canonical is absent. *)
-let load_git_clone_policy ~base_path =
+let git_clone_policy_paths ~base_path =
   let canonical =
     Filename.concat
       (Common.masc_dir_from_base_path ~base_path |> fun d -> Filename.concat d "config")
       "tool_policy.toml"
   in
   let legacy = Filename.concat (Filename.concat base_path "config") "tool_policy.toml" in
+  canonical, legacy
+
+let parse_git_clone_policy_content content =
+  let rec loop in_git_clone allowed denied = function
+    | [] -> allowed, denied
+    | raw_line :: rest ->
+        let line = String.trim raw_line in
+        if line = "" || String.starts_with ~prefix:"#" line then
+          loop in_git_clone allowed denied rest
+        else if String.length line >= 2 && line.[0] = '[' && line.[String.length line - 1] = ']'
+        then
+          loop (String.equal line "[git_clone]") allowed denied rest
+        else if not in_git_clone then
+          loop in_git_clone allowed denied rest
+        else
+          let allowed =
+            match policy_string_array_of_line ~key:"allowed_orgs" line with
+            | Some items -> items
+            | None -> allowed
+          in
+          let denied =
+            match policy_string_array_of_line ~key:"denied_repos" line with
+            | Some items -> items
+            | None -> denied
+          in
+          loop in_git_clone allowed denied rest
+  in
+  loop false [] [] (String.split_on_char '\n' content)
+
+let load_git_clone_policy_result ~base_path =
+  let canonical, legacy = git_clone_policy_paths ~base_path in
   let read_or_empty p =
     match Safe_ops.read_file_safe p with
     | Error _ -> None
@@ -106,33 +132,28 @@ let load_git_clone_policy ~base_path =
     | None -> read_or_empty legacy
   in
   match content_opt with
-  | None -> [], []
-  | Some content ->
-      let rec loop in_git_clone allowed denied = function
-        | [] -> allowed, denied
-        | raw_line :: rest ->
-            let line = String.trim raw_line in
-            if line = "" || String.starts_with ~prefix:"#" line then
-              loop in_git_clone allowed denied rest
-            else if String.length line >= 2 && line.[0] = '[' && line.[String.length line - 1] = ']'
-            then
-              loop (String.equal line "[git_clone]") allowed denied rest
-            else if not in_git_clone then
-              loop in_git_clone allowed denied rest
-            else
-              let allowed =
-                match policy_string_array_of_line ~key:"allowed_orgs" line with
-                | Some items -> items
-                | None -> allowed
-              in
-              let denied =
-                match policy_string_array_of_line ~key:"denied_repos" line with
-                | Some items -> items
-                | None -> denied
-              in
-              loop in_git_clone allowed denied rest
-      in
-      loop false [] [] (String.split_on_char '\n' content)
+  | None ->
+      Error
+        (Printf.sprintf
+           "tool policy config not found at %s or %s"
+           canonical legacy)
+  | Some content -> Ok (parse_git_clone_policy_content content)
+
+(* SSOT path resolution: canonical config root is [<base_path>/.masc/config/]
+   (same primitive Config_dir_resolver.path_from_local_masc uses via
+   Common.masc_dir_from_base_path). The legacy [<base_path>/config/] form is
+   retained as a secondary lookup for older deployments. Reading order:
+   canonical first, legacy fallback only when canonical is absent. *)
+let load_git_clone_policy ~base_path =
+  match load_git_clone_policy_result ~base_path with
+  | Ok policy -> policy
+  | Error _ -> [], []
+
+let valid_github_org_slug org =
+  let valid_org_char c =
+    (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '-'
+  in
+  org <> "" && Seq.for_all valid_org_char (String.to_seq org)
 
 let extract_github_org_repo url =
   let lc = String.lowercase_ascii (String.trim url) in
@@ -167,7 +188,8 @@ let extract_github_org_repo url =
         else rest
       in
       match String.split_on_char '/' stripped with
-      | [ org; repo ] when org <> "" && repo <> "" -> Some (org ^ "/" ^ repo)
+      | [ org; repo ] when valid_github_org_slug org && repo <> "" ->
+          Some (org ^ "/" ^ repo)
       | _ -> None
 
 let extract_github_org url =
@@ -179,32 +201,32 @@ let extract_github_org url =
   | None -> None
 
 let validate_clone_origin_url ~base_path url =
-  let allowed_orgs, denied_repos = load_git_clone_policy ~base_path in
-  let denied_check () =
-    match extract_github_org_repo url with
-    | Some org_repo when List.mem org_repo denied_repos ->
-        Error (Printf.sprintf "Repository '%s' is in the denied list" org_repo)
-    | _ -> Ok ()
-  in
-  if allowed_orgs = [] then
-    (* Empty allowed_orgs = skip org check. Per config/tool_policy.toml,
-       this matches operator intent: the keeper may clone any repo
-       reachable through the operator's gh credential, subject to
-       denied_repos. SSOT alignment with [Tool_code_write.validate_clone_url]
-       (#11951) and [Gh_command_validation.validate_gh_command] which
-       both treat [allowed_orgs = []] as "policy not configured / skip".
-       Follow-up to #11830 — second site that PR #11951 missed. *)
-    denied_check ()
-  else
-    match extract_github_org url with
-    | None ->
-        Error (Printf.sprintf "Cannot parse GitHub org from URL: %s" url)
-    | Some org when not (List.mem org allowed_orgs) ->
-        Error
-          (Printf.sprintf
-             "GitHub org '%s' not in allowed list: %s. Use the actual GitHub owner from the clone URL; do not infer an org from local workspace path segments."
-             org (String.concat ", " allowed_orgs))
-    | Some _ -> denied_check ()
+  match load_git_clone_policy_result ~base_path with
+  | Error msg ->
+      Error (Printf.sprintf "Git clone policy unavailable: %s" msg)
+  | Ok (allowed_orgs, denied_repos) ->
+      let allowed_lc = List.map String.lowercase_ascii allowed_orgs in
+      let denied_lc = List.map String.lowercase_ascii denied_repos in
+      match extract_github_org_repo url with
+      | None ->
+          Error (Printf.sprintf "Cannot parse GitHub org/repo from URL: %s" url)
+      | Some org_repo ->
+          if List.mem org_repo denied_lc then
+            Error (Printf.sprintf "Repository '%s' is in the denied list" org_repo)
+          else
+            match String.split_on_char '/' org_repo with
+            | _org :: _ when allowed_lc = [] ->
+                (* Explicit empty allowed_orgs means "any supported GitHub org",
+                   still bounded by URL parsing and denied_repos. *)
+                Ok ()
+            | org :: _ when List.mem org allowed_lc -> Ok ()
+            | org :: _ ->
+                Error
+                  (Printf.sprintf
+                     "GitHub org '%s' not in allowed list: %s. Use the actual GitHub owner from the clone URL; do not infer an org from local workspace path segments."
+                     org (String.concat ", " allowed_orgs))
+            | [] ->
+                Error (Printf.sprintf "Cannot parse GitHub org/repo from URL: %s" url)
 
 (** Check if directory is a git repository - delegates to Coord_git *)
 let is_git_repo config =

--- a/lib/coord/coord_worktree.mli
+++ b/lib/coord/coord_worktree.mli
@@ -43,10 +43,11 @@ val policy_string_array_of_line :
 
 val load_git_clone_policy :
   base_path:string -> string list * string list
-(** Load [(allow_orgs, allow_orgrepos)] from
-    [<base_path>/git_clone_policy.toml]; returns empty lists when the file
-    is missing or unparseable.  Used to gate auto-provisioning of sandbox
-    clones from arbitrary GitHub URLs. *)
+(** Load [(allowed_orgs, denied_repos)] from [tool_policy.toml].  Canonical
+    [<base_path>/.masc/config/tool_policy.toml] takes priority over legacy
+    [<base_path>/config/tool_policy.toml].  Returns empty lists when the file
+    is missing for compatibility; enforcement uses a fail-closed result loader
+    internally. *)
 
 (** {1 GitHub URL parsing} *)
 
@@ -60,7 +61,9 @@ val extract_github_org : string -> string option
 val validate_clone_origin_url :
   base_path:string -> string -> (unit, string) result
 (** Validate [origin_url] against the policy at [base_path].  Used before
-    auto-provisioning a sandbox clone from a workspace repo. *)
+    auto-provisioning a sandbox clone from a workspace repo.  Missing policy
+    fails closed; an explicitly empty [allowed_orgs] list allows any supported
+    GitHub ["org/repo"] URL subject to [denied_repos]. *)
 
 (** {1 Repository discovery / shape checks} *)
 

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -194,24 +194,46 @@ let truncate_output s =
 
 (* Loads tool_policy.toml config directly via Keeper_tool_policy_config
    to avoid circular dependency with Keeper_tool_policy (which imports
-   Tool_code_write.schemas for schema assembly). *)
-let _policy_config_cache : Keeper_tool_policy_config.t option ref = ref None
+   Tool_code_write.schemas for schema assembly).  Enforcement paths must
+   distinguish "loaded with an empty allowlist" from "policy unavailable". *)
+type policy_config_cache_entry = {
+  base_path : string;
+  env_config_dir : string option;
+  result : (Keeper_tool_policy_config.t, string) result;
+}
+
+let _policy_config_cache : policy_config_cache_entry option ref = ref None
 
 (** Reset internal config cache — for test isolation only. *)
 let reset_policy_config_cache () = _policy_config_cache := None
 
-let get_policy_config ~base_path =
+let get_policy_config_result ~base_path =
+  let env_config_dir = Env_config.config_dir_opt () in
   match !_policy_config_cache with
-  | Some cfg -> Some cfg
-  | None ->
-    match Keeper_tool_policy_config.load ~base_path with
-    | Ok cfg -> _policy_config_cache := Some cfg; Some cfg
-    | Error _ -> None
+  | Some { base_path = cached_base_path; env_config_dir = cached_env; result }
+    when String.equal cached_base_path base_path && cached_env = env_config_dir ->
+    result
+  | _ ->
+    let result = Keeper_tool_policy_config.load ~base_path in
+    _policy_config_cache := Some { base_path; env_config_dir; result };
+    result
+
+let get_policy_config ~base_path =
+  match get_policy_config_result ~base_path with
+  | Ok cfg -> Some cfg
+  | Error _ -> None
 
 let load_clone_allowed_orgs ~base_path =
   match get_policy_config ~base_path with
   | Some cfg -> Keeper_tool_policy_config.git_clone_allowed_orgs cfg
-  | None -> []
+  | None ->
+    []
+
+let valid_github_org_slug org =
+  let valid_org_char c =
+    (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '-'
+  in
+  org <> "" && Seq.for_all valid_org_char (String.to_seq org)
 
 (** Extract GitHub org from clone URL (case-normalized to lowercase).
     Strict matching: URL must start with an exact known prefix to prevent
@@ -221,7 +243,7 @@ let load_clone_allowed_orgs ~base_path =
     - [git@github.com:ORG/repo\[.git\]]
     - [ssh://git@github.com/ORG/repo\[.git\]] *)
 let extract_github_org url =
-  let lc = String.lowercase_ascii url in
+  let lc = String.lowercase_ascii (String.trim url) in
   let prefixes = [
     "https://github.com/";
     "git@github.com:";
@@ -243,11 +265,7 @@ let extract_github_org url =
     | None -> None
     | Some idx ->
       let org = String.sub rest 0 idx in
-      (* GitHub org names: alphanumeric + hyphens only *)
-      let valid_org_char c =
-        (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '-'
-      in
-      if org = "" || not (String.to_seq org |> Seq.for_all valid_org_char) then
+      if not (valid_github_org_slug org) then
         None
       else
         Some org
@@ -255,7 +273,7 @@ let extract_github_org url =
 (** Extract "org/repo" from a GitHub clone URL (lowercase, .git and trailing
     slash stripped). Returns exactly two path segments or None. *)
 let extract_github_org_repo url =
-  let lc = String.lowercase_ascii url in
+  let lc = String.lowercase_ascii (String.trim url) in
   let prefixes = [
     "https://github.com/";
     "git@github.com:";
@@ -285,7 +303,7 @@ let extract_github_org_repo url =
     in
     (* Validate exactly "org/repo" — two segments, no deeper paths *)
     match String.split_on_char '/' stripped with
-    | [org; repo] when org <> "" && repo <> "" ->
+    | [org; repo] when valid_github_org_slug org && repo <> "" ->
       Some (org ^ "/" ^ repo)
     | _ -> None
 
@@ -295,35 +313,35 @@ let load_clone_denied_repos ~base_path =
   | None -> []
 
 let validate_clone_url ~base_path url =
-  let allowed = load_clone_allowed_orgs ~base_path in
-  let denied = load_clone_denied_repos ~base_path in
-  let denied_lc = List.map String.lowercase_ascii denied in
-  let denied_check () =
+  match get_policy_config_result ~base_path with
+  | Error msg ->
+    Error (Printf.sprintf "Git clone policy unavailable: %s" msg)
+  | Ok cfg ->
+    let allowed = Keeper_tool_policy_config.git_clone_allowed_orgs cfg in
+    let denied = Keeper_tool_policy_config.git_clone_denied_repos cfg in
+    let allowed_lc = List.map String.lowercase_ascii allowed in
+    let denied_lc = List.map String.lowercase_ascii denied in
     match extract_github_org_repo url with
-    | Some org_repo when List.mem org_repo denied_lc ->
-      Error (Printf.sprintf "Repository '%s' is in the denied list" org_repo)
-    | _ -> Ok ()
-  in
-  if allowed = [] then
-    (* Empty allowed_orgs = skip org check. Per config/tool_policy.toml,
-       this matches operator intent: the keeper may clone any repo reachable
-       through the operator's gh credential, subject to denied_repos. SSOT
-       alignment with [Gh_command_validation.validate_gh_command], which
-       treats [allowed_orgs = []] as "policy not configured / skip". #11830. *)
-    denied_check ()
-  else
-    match extract_github_org url with
     | None ->
-      Error (Printf.sprintf "Cannot parse GitHub org from URL: %s" url)
-    | Some org ->
-      let allowed_lc = List.map String.lowercase_ascii allowed in
-      if not (List.mem org allowed_lc) then
-        Error
-          (Printf.sprintf
-             "GitHub org '%s' not in allowed list: %s. Use the actual GitHub owner from the clone URL; do not infer an org from local workspace path segments."
-             org (String.concat ", " allowed))
+      Error (Printf.sprintf "Cannot parse GitHub org/repo from URL: %s" url)
+    | Some org_repo ->
+      if List.mem org_repo denied_lc then
+        Error (Printf.sprintf "Repository '%s' is in the denied list" org_repo)
       else
-        denied_check ()
+        match String.split_on_char '/' org_repo with
+        | _org :: _ when allowed_lc = [] ->
+          (* Explicit empty allowed_orgs means "any supported GitHub org",
+             still bounded by URL parsing and denied_repos. *)
+          Ok ()
+        | org :: _ when List.mem org allowed_lc ->
+          Ok ()
+        | org :: _ ->
+          Error
+            (Printf.sprintf
+               "GitHub org '%s' not in allowed list: %s. Use the actual GitHub owner from the clone URL; do not infer an org from local workspace path segments."
+               org (String.concat ", " allowed))
+        | [] ->
+          Error (Printf.sprintf "Cannot parse GitHub org/repo from URL: %s" url)
 
 (** Validate cwd for clone: allows .worktrees/ itself (not just subdirs)
     and THIS agent's own .masc/playground/<agent_name>/repos/ directory.

--- a/lib/tool_code_write.mli
+++ b/lib/tool_code_write.mli
@@ -162,11 +162,14 @@ val extract_github_org_repo : string -> string option
 val validate_clone_url :
   base_path:string -> string -> (unit, string) result
 (** [validate_clone_url ~base_path url] validates the URL
-    against the policy at
-    [{base_path}/config/tool_policy.toml]:
+    against the resolved [tool_policy.toml] for [base_path]:
 
-    + Empty allowed-orgs list -> [Error] (no clones permitted
-      until configured).
+    + Missing/unreadable policy -> [Error] (clone policy fails
+      closed).
+    + URL must parse as a supported GitHub ["org/repo"] clone URL,
+      even when the allowlist is explicitly empty.
+    + Empty allowed-orgs list in a loaded policy -> skip org allowlist
+      matching, still subject to URL parsing and repo denylist.
     + Org from {!extract_github_org} not in
       [git_clone.allowed_orgs] -> [Error].
     + ["org/repo"] from {!extract_github_org_repo} present in

--- a/test/test_coord_worktree_policy_path.ml
+++ b/test/test_coord_worktree_policy_path.ml
@@ -14,6 +14,16 @@ open Alcotest
 
 module CW = Coord_worktree
 
+let contains ~needle haystack =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop i =
+    if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else loop (i + 1)
+  in
+  nlen = 0 || loop 0
+
 let with_temp_dir prefix f =
   let dir = Filename.temp_file prefix "" in
   Sys.remove dir;
@@ -38,9 +48,19 @@ let rec mkdir_p dir =
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
-let policy_with_orgs orgs =
+let policy_with_orgs ?(denied_repos = []) orgs =
   let arr = orgs |> List.map (Printf.sprintf "%S") |> String.concat ", " in
-  Printf.sprintf "[git_clone]\nallowed_orgs = [%s]\n" arr
+  let denied =
+    denied_repos |> List.map (Printf.sprintf "%S") |> String.concat ", "
+  in
+  Printf.sprintf
+    "[git_clone]\nallowed_orgs = [%s]\ndenied_repos = [%s]\n"
+    arr denied
+
+let write_canonical_policy base content =
+  let dir = Filename.concat (Filename.concat base ".masc") "config" in
+  mkdir_p dir;
+  write_file (Filename.concat dir "tool_policy.toml") content
 
 let test_canonical_masc_config () =
   with_temp_dir "coord-worktree-policy-canon" @@ fun base ->
@@ -82,6 +102,52 @@ let test_neither_present () =
   check (list string) "no policy file → empty allowed" [] allowed;
   check (list string) "no policy file → empty denied" [] denied
 
+let test_validate_missing_policy_fails_closed () =
+  with_temp_dir "coord-worktree-policy-validate-none" @@ fun base ->
+  match CW.validate_clone_origin_url ~base_path:base
+    "https://github.com/jeong-sik/masc-mcp.git" with
+  | Error reason ->
+      check bool "mentions unavailable policy" true
+        (contains ~needle:"Git clone policy unavailable" reason)
+  | Ok () -> fail "missing policy must fail closed"
+
+let test_validate_empty_allowed_allows_supported_github () =
+  with_temp_dir "coord-worktree-policy-validate-open" @@ fun base ->
+  write_canonical_policy base (policy_with_orgs []);
+  (check (result unit string)) "explicit empty allowed_orgs allows GitHub"
+    (Ok ())
+    (CW.validate_clone_origin_url ~base_path:base
+       "https://github.com/other-org/repo.git")
+
+let test_validate_empty_allowed_rejects_non_github () =
+  with_temp_dir "coord-worktree-policy-validate-nongh" @@ fun base ->
+  write_canonical_policy base (policy_with_orgs []);
+  match CW.validate_clone_origin_url ~base_path:base
+    "https://gitlab.com/other-org/repo.git" with
+  | Error _ -> ()
+  | Ok () -> fail "non-GitHub URL must be rejected even with empty allowed_orgs"
+
+let test_validate_empty_allowed_applies_denied_repos () =
+  with_temp_dir "coord-worktree-policy-validate-denied" @@ fun base ->
+  write_canonical_policy base
+    (policy_with_orgs ~denied_repos:[ "jeong-sik/me" ] []);
+  match CW.validate_clone_origin_url ~base_path:base
+    "https://github.com/jeong-sik/me.git" with
+  | Error reason ->
+      check bool "mentions denied list" true
+        (contains ~needle:"denied list" reason)
+  | Ok () -> fail "denied repo must be rejected"
+
+let test_validate_allowed_org_rejects_other_org () =
+  with_temp_dir "coord-worktree-policy-validate-allowed" @@ fun base ->
+  write_canonical_policy base (policy_with_orgs [ "jeong-sik" ]);
+  match CW.validate_clone_origin_url ~base_path:base
+    "https://github.com/other-org/repo.git" with
+  | Error reason ->
+      check bool "mentions allowed list" true
+        (contains ~needle:"not in allowed list" reason)
+  | Ok () -> fail "org outside non-empty allowed_orgs must be rejected"
+
 let () =
   Alcotest.run "coord_worktree policy path"
     [
@@ -91,5 +157,18 @@ let () =
           test_case "legacy <base>/config/" `Quick test_legacy_config_dir;
           test_case "canonical takes priority" `Quick test_canonical_takes_priority;
           test_case "neither path present" `Quick test_neither_present;
+        ] );
+      ( "validate_clone_origin_url",
+        [
+          test_case "missing policy fails closed" `Quick
+            test_validate_missing_policy_fails_closed;
+          test_case "empty allowed_orgs allows supported GitHub" `Quick
+            test_validate_empty_allowed_allows_supported_github;
+          test_case "empty allowed_orgs rejects non-GitHub" `Quick
+            test_validate_empty_allowed_rejects_non_github;
+          test_case "empty allowed_orgs applies denied repos" `Quick
+            test_validate_empty_allowed_applies_denied_repos;
+          test_case "non-empty allowed_orgs rejects other org" `Quick
+            test_validate_allowed_org_rejects_other_org;
         ] );
     ]

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -30,6 +30,52 @@ let with_trimmed_env name value f =
       | None -> Unix.putenv name "")
     f
 
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let rec rm_rf path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let policy_toml ?(denied_repos = []) allowed_orgs =
+  let array items =
+    items |> List.map (Printf.sprintf "%S") |> String.concat ", "
+  in
+  Printf.sprintf
+    "[git_clone]\nallowed_orgs = [%s]\ndenied_repos = [%s]\n"
+    (array allowed_orgs)
+    (array denied_repos)
+
+let with_temp_policy ?denied_repos allowed_orgs f =
+  with_temp_dir "tool-code-write-policy" @@ fun base_path ->
+  let config_dir = Filename.concat base_path "config" in
+  mkdir_p config_dir;
+  write_file
+    (Filename.concat config_dir "tool_policy.toml")
+    (policy_toml ?denied_repos allowed_orgs);
+  Tool_code_write.reset_policy_config_cache ();
+  Fun.protect ~finally:Tool_code_write.reset_policy_config_cache (fun () ->
+    f base_path)
+
 (* ── extract_github_org ──────────────────────────────────────────── *)
 
 let test_https_url () =
@@ -133,21 +179,21 @@ let dispatch_exn ctx ~name ~args =
   | None -> fail ("dispatch returned None for " ^ name)
 
 let test_allowed_org () =
-  let bp = project_base_path () in
+  with_temp_policy [ "jeong-sik" ] @@ fun bp ->
   (check (result unit string)) "allowed org passes"
     (Ok ())
     (Tool_code_write.validate_clone_url ~base_path:bp
        "https://github.com/jeong-sik/masc-mcp.git")
 
 let test_disallowed_org () =
-  let bp = project_base_path () in
+  with_temp_policy [ "jeong-sik" ] @@ fun bp ->
   match Tool_code_write.validate_clone_url ~base_path:bp
     "https://github.com/other-org/repo.git" with
   | Error _ -> ()
   | Ok () -> fail "expected error for disallowed org"
 
 let test_disallowed_org_mentions_workspace_path_hint () =
-  let bp = project_base_path () in
+  with_temp_policy [ "jeong-sik" ] @@ fun bp ->
   match Tool_code_write.validate_clone_url ~base_path:bp
     "https://github.com/yousleepwhen/masc-mcp.git" with
   | Error reason ->
@@ -158,14 +204,30 @@ let test_disallowed_org_mentions_workspace_path_hint () =
   | Ok () -> fail "expected error for disallowed org"
 
 let test_non_github_rejected () =
-  let bp = project_base_path () in
+  with_temp_policy [] @@ fun bp ->
   match Tool_code_write.validate_clone_url ~base_path:bp
     "https://gitlab.com/jeong-sik/repo.git" with
   | Error _ -> ()
   | Ok () -> fail "expected error for non-github URL"
 
+let test_empty_allowed_orgs_allows_supported_github () =
+  with_temp_policy [] @@ fun bp ->
+  (check (result unit string)) "explicit empty allowed_orgs allows GitHub"
+    (Ok ())
+    (Tool_code_write.validate_clone_url ~base_path:bp
+       "https://github.com/other-org/repo.git")
+
+let test_empty_allowed_orgs_still_applies_denied_repos () =
+  with_temp_policy ~denied_repos:[ "jeong-sik/me" ] [] @@ fun bp ->
+  match Tool_code_write.validate_clone_url ~base_path:bp
+    "https://github.com/jeong-sik/me.git" with
+  | Error reason ->
+      check bool "mentions denied list" true
+        (msg_contains ~needle:"denied list" reason)
+  | Ok () -> fail "expected denied repo to fail even with empty allowed_orgs"
+
 let test_ssh_allowed () =
-  let bp = project_base_path () in
+  with_temp_policy [ "jeong-sik" ] @@ fun bp ->
   (check (result unit string)) "ssh allowed org passes"
     (Ok ())
     (Tool_code_write.validate_clone_url ~base_path:bp
@@ -182,12 +244,30 @@ let test_missing_base_path_without_config_fails_closed () =
       (Env_config.config_dir_opt ());
     match Tool_code_write.validate_clone_url ~base_path:"/nonexistent"
       "https://github.com/evil-corp/repo.git" with
-    | Error _ -> ()
-    | Ok () -> fail "validation should fail closed when config root is missing")
+  | Error _ -> ()
+  | Ok () -> fail "validation should fail closed when config root is missing")
+
+let test_missing_policy_does_not_reuse_previous_cache () =
+  with_temp_policy [ "jeong-sik" ] @@ fun configured_bp ->
+  (check (result unit string)) "configured policy passes"
+    (Ok ())
+    (Tool_code_write.validate_clone_url ~base_path:configured_bp
+       "https://github.com/jeong-sik/repo.git");
+  with_temp_dir "tool-code-write-missing-policy" @@ fun missing_bp ->
+  match Tool_code_write.validate_clone_url ~base_path:missing_bp
+    "https://github.com/jeong-sik/repo.git" with
+  | Error reason ->
+      check bool "mentions unavailable policy" true
+        (msg_contains ~needle:"Git clone policy unavailable" reason)
+  | Ok () -> fail "missing policy should not reuse prior cached config"
 
 let test_explicit_config_dir_override_still_validates () =
-  let project_root = project_base_path () in
-  let config_dir = Filename.concat project_root "config" in
+  with_temp_dir "tool-code-write-env-policy" @@ fun root ->
+  let config_dir = Filename.concat root "config" in
+  mkdir_p config_dir;
+  write_file
+    (Filename.concat config_dir "tool_policy.toml")
+    (policy_toml [ "jeong-sik" ]);
   Tool_code_write.reset_policy_config_cache ();
   Fun.protect ~finally:Tool_code_write.reset_policy_config_cache (fun () ->
     with_trimmed_env "MASC_CONFIG_DIR" (Some config_dir) @@ fun () ->
@@ -203,7 +283,7 @@ let test_explicit_config_dir_override_still_validates () =
         fail "disallowed org should still be rejected with explicit config override")
 
 let test_mixed_case_org () =
-  let bp = project_base_path () in
+  with_temp_policy [ "jeong-sik" ] @@ fun bp ->
   (check (result unit string)) "mixed-case org passes"
     (Ok ())
     (Tool_code_write.validate_clone_url ~base_path:bp
@@ -486,8 +566,14 @@ let () =
       test_case "disallowed org hints against workspace path inference" `Quick
         test_disallowed_org_mentions_workspace_path_hint;
       test_case "non-github rejected" `Quick test_non_github_rejected;
+      test_case "empty allowed_orgs allows supported GitHub" `Quick
+        test_empty_allowed_orgs_allows_supported_github;
+      test_case "empty allowed_orgs still applies denied repos" `Quick
+        test_empty_allowed_orgs_still_applies_denied_repos;
       test_case "ssh allowed" `Quick test_ssh_allowed;
       test_case "missing config fails closed" `Quick test_missing_base_path_without_config_fails_closed;
+      test_case "missing policy does not reuse previous cache" `Quick
+        test_missing_policy_does_not_reuse_previous_cache;
       test_case "explicit config dir override still validates" `Quick test_explicit_config_dir_override_still_validates;
       test_case "mixed-case org" `Quick test_mixed_case_org;
     ]);


### PR DESCRIPTION
## Summary

- Fail closed when git clone policy cannot be loaded for `masc_code_git` and coord worktree clone validation.
- Keep explicit `allowed_orgs = []` as an open policy only after the URL parses as a supported GitHub `org/repo`.
- Preserve `denied_repos` enforcement for both non-empty and explicit-empty allowlists.

## Product impact

Operators no longer get an accidental open clone surface when `tool_policy.toml` is missing, unreadable, or resolved from the wrong config root. Explicit open policy remains available, but only for supported GitHub URLs and still bounded by repo denylist.

## Evidence

- `scripts/dune-local.sh build test/test_tool_code_write_coverage.exe test/test_coord_worktree_policy_path.exe test/test_worker_dev_tools.exe`
- `./_build/default/test/test_tool_code_write_coverage.exe --compact --quick-tests`
- `./_build/default/test/test_coord_worktree_policy_path.exe --compact --quick-tests`
- `./_build/default/test/test_worker_dev_tools.exe --compact --quick-tests`
- `git diff --check`

## Review evidence

Focused tests cover missing policy fail-closed, explicit empty allowlist behavior, non-GitHub URL rejection, denylist enforcement, and cache isolation across base paths.

## Linked issue

None.
