### PR TITLE
feat(keeper): export lifecycle restart metrics

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1163,6 +1163,12 @@ let rec dispatch_event_with_audit
         | phase, Running when phase <> Running ->
           Atomic.incr running_count_atomic
         | _ -> ());
+       Prometheus.inc_counter Prometheus.metric_keeper_lifecycle_transitions
+         ~labels:[
+           ("keeper", name);
+           ("from_phase", Keeper_state_machine.phase_to_string tr.prev_phase);
+           ("to_phase", Keeper_state_machine.phase_to_string tr.new_phase);
+         ] ();
        (* Update dead_since_ts: always set to now on Dead transition *)
        let dead_since_ts = match tr.new_phase with
          | Keeper_state_machine.Dead -> Some now

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -968,9 +968,11 @@ let sweep_and_recover (ctx : _ context) =
     apply_self_preservation ~keepers_dir ~total_keepers:active_count !to_restart in
   (* Restart crashed keepers *)
   List.iter (fun ((old_entry : Keeper_registry.registry_entry), crash_msg) ->
+    let attempt = old_entry.restart_count + 1 in
+    Prometheus.inc_counter Prometheus.metric_keeper_restart_attempts
+      ~labels:[("keeper", old_entry.name)] ();
     match read_meta ctx.config old_entry.name with
     | Ok (Some meta) ->
-        let attempt = old_entry.restart_count + 1 in
         (* RFC-0002: dispatch restart attempt event *)
         ignore (Keeper_registry.dispatch_event ~base_path old_entry.name
           (Keeper_state_machine.Supervisor_restart_attempt { attempt }));
@@ -988,6 +990,8 @@ let sweep_and_recover (ctx : _ context) =
                       phase = Some Keeper_state_machine.Running })
           old_entry.name
           (Printf.sprintf "attempt %d" attempt) ();
+        Prometheus.inc_counter Prometheus.metric_keeper_restart_outcomes
+          ~labels:[("keeper", old_entry.name); ("outcome", "started")] ();
         Log.Keeper.info "%s: restarted (attempt %d, backoff %.0fs)"
           old_entry.name attempt (backoff_delay (attempt - 1));
         (* Soft pre-warning when this is the FINAL allowed restart: next
@@ -1001,6 +1005,8 @@ let sweep_and_recover (ctx : _ context) =
             ~labels:[("keeper", old_entry.name)] ()
         end
     | _ ->
+        Prometheus.inc_counter Prometheus.metric_keeper_restart_outcomes
+          ~labels:[("keeper", old_entry.name); ("outcome", "meta_unavailable")] ();
         Log.Keeper.error "%s: cannot read meta for restart, removing"
           old_entry.name;
         Keeper_registry.unregister ~base_path old_entry.name;

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -642,6 +642,8 @@ let metric_keeper_fsm_edge_transitions =
   "masc_keeper_fsm_edge_transitions_total"
 let metric_keeper_turn_fsm_transitions =
   "masc_keeper_turn_fsm_transitions_total"
+let metric_keeper_lifecycle_transitions =
+  "masc_keeper_lifecycle_transitions_total"
 let metric_fsm_guard_violation = "masc_fsm_guard_violation_total"
 let metric_keeper_lifecycle_callback_failures =
   "masc_keeper_lifecycle_callback_failures_total"
@@ -659,6 +661,10 @@ let metric_keeper_dead_total = "masc_keeper_dead_total"
 let metric_keeper_skip_idle_wake_resumed =
   "masc_keeper_skip_idle_wake_resumed_total"
 let metric_keeper_near_exhaustion_total = "masc_keeper_near_exhaustion_total"
+let metric_keeper_restart_attempts =
+  "masc_keeper_restart_attempts_total"
+let metric_keeper_restart_outcomes =
+  "masc_keeper_restart_outcomes_total"
 (* PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
    per keeper. Counter increments on each strike; a strike at
    [outcome=promote] means [Keeper_fiber_crash] was raised so
@@ -990,6 +996,18 @@ let init () =
   add metric_keeper_near_exhaustion_total
     "Total keeper restart attempts at restart_count = max_restarts - 1, \
      i.e. one failure away from Dead. Soft pre-warning; labeled by keeper."
+    Counter;
+  add metric_keeper_lifecycle_transitions
+    "Total keeper lifecycle phase transitions emitted only when the registry \
+     phase changes. Labeled by keeper, from_phase, and to_phase; deliberately \
+     omits event/reason payloads to keep cardinality bounded."
+    Counter;
+  add metric_keeper_restart_attempts
+    "Total supervisor restart attempts for crashed keepers. Labeled by keeper."
+    Counter;
+  add metric_keeper_restart_outcomes
+    "Total supervisor restart outcomes. Labeled by keeper and bounded \
+     outcome=started|meta_unavailable."
     Counter;
   add metric_keeper_tool_alias_canonicalizations
     "Total observed LLM-facing tool names canonicalized to keeper internal \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -289,6 +289,12 @@ val metric_keeper_fsm_edge_transitions : string
     keepers = ≤ 1600 series; reachable subset is much smaller. *)
 val metric_keeper_turn_fsm_transitions : string
 
+(** Keeper lifecycle phase transitions emitted by [Keeper_registry] only
+    when the persisted registry phase changes. Labels:
+    [keeper, from_phase, to_phase].  No event/reason label is included so
+    free-form transition payloads cannot create unbounded series. *)
+val metric_keeper_lifecycle_transitions : string
+
 (** Cycle 43 (Tier I3 follow-up to fsm_guard smoke at
     [keeper_turn_fsm.ml:118]): runtime [@@fsm_guard] assert violations
     that the [Keeper_fsm_guard_runtime.wrap_unit] caught and recovered
@@ -351,6 +357,14 @@ val metric_keeper_near_exhaustion_total : string
 (** Total times a keeper restart attempt landed at
     [restart_count = max_restarts - 1], i.e. one attempt away from Dead.
     Soft pre-warning; labeled by [keeper]. *)
+
+val metric_keeper_restart_attempts : string
+(** Total supervisor restart attempts for crashed keepers. Labels:
+    [keeper]. *)
+
+val metric_keeper_restart_outcomes : string
+(** Total supervisor restart outcomes. Labels:
+    [keeper, outcome]. Outcome is one of [started | meta_unavailable]. *)
 
 val metric_keeper_oas_timeout_budget_strike : string
 (** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes.

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -434,6 +434,43 @@ let test_dispatch_event_emits_phase_sse () =
           check string "event" "operator_pause"
             (Json.member "event" payload |> Json.to_string))
 
+let test_dispatch_event_emits_lifecycle_transition_metric_only_on_phase_change () =
+  R.clear ();
+  let keeper_name = "k4-lifecycle-metric" in
+  let changed_labels =
+    [
+      ("keeper", keeper_name);
+      ("from_phase", "running");
+      ("to_phase", "paused");
+    ]
+  in
+  let unchanged_labels =
+    [
+      ("keeper", keeper_name);
+      ("from_phase", "running");
+      ("to_phase", "running");
+    ]
+  in
+  let changed_before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_lifecycle_transitions
+      ~labels:changed_labels ()
+  in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  ignore (R.dispatch_event ~base_path:bp keeper_name KSM.Fiber_started);
+  check (float 0.001) "no same-phase metric emitted" 0.0
+    (Masc_mcp.Prometheus.metric_value_or_zero
+       Masc_mcp.Prometheus.metric_keeper_lifecycle_transitions
+       ~labels:unchanged_labels ());
+  ignore (R.dispatch_event ~base_path:bp keeper_name KSM.Operator_pause);
+  let changed_after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_lifecycle_transitions
+      ~labels:changed_labels ()
+  in
+  check (float 0.001) "phase-change transition metric incremented"
+    (changed_before +. 1.0) changed_after
+
 let test_extended_states () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k4x" (make_meta "k4x") in
@@ -1198,6 +1235,8 @@ let () =
           eio_test "set state" test_set_state;
           eio_test "dispatch event emits phase SSE"
             test_dispatch_event_emits_phase_sse;
+          eio_test "dispatch event emits lifecycle metric only on phase change"
+            test_dispatch_event_emits_lifecycle_transition_metric_only_on_phase_change;
           eio_test "extended states" test_extended_states;
           eio_test "stopped entry action is observability-only"
             test_stopped_entry_action_is_observability_only;

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -308,6 +308,124 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
       check bool "keeper registered after approval" true
         (Reg.is_registered ~base_path:config.base_path meta.name))
 
+let test_restart_path_emits_attempt_and_started_outcome_metrics () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let name = "restart-metric-keeper" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive ~base_path:base_dir name;
+      Reg.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
+      let meta = make_meta name in
+      (match KT.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register ~base_path:config.base_path name meta in
+      Eio.Promise.resolve reg.done_r (`Crashed "ordinary crash");
+      Reg.restore_supervisor_state ~base_path:config.base_path name
+        ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
+      let attempt_labels = [ ("keeper", name) ] in
+      let outcome_labels = [ ("keeper", name); ("outcome", "started") ] in
+      let attempts_before =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_keeper_restart_attempts
+          ~labels:attempt_labels ()
+      in
+      let outcomes_before =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_keeper_restart_outcomes
+          ~labels:outcome_labels ()
+      in
+      let ctx : _ KT.context =
+        {
+          config;
+          agent_name = "supervisor";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      Sup.sweep_and_recover ctx;
+      check (float 0.001) "restart attempt metric incremented"
+        (attempts_before +. 1.0)
+        (Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Prometheus.metric_keeper_restart_attempts
+           ~labels:attempt_labels ());
+      check (float 0.001) "restart started outcome metric incremented"
+        (outcomes_before +. 1.0)
+        (Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Prometheus.metric_keeper_restart_outcomes
+           ~labels:outcome_labels ());
+      match Reg.get ~base_path:config.base_path name with
+      | None -> fail "expected restarted keeper in registry"
+      | Some entry ->
+          check int "restart count restored to attempt" 1 entry.restart_count)
+
+let test_restart_path_emits_meta_unavailable_outcome_metric () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let name = "restart-missing-meta-metric-keeper" in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
+      let meta = make_meta name in
+      let reg = Reg.register ~base_path:config.base_path name meta in
+      Eio.Promise.resolve reg.done_r (`Crashed "ordinary crash");
+      Reg.restore_supervisor_state ~base_path:config.base_path name
+        ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
+      let attempt_labels = [ ("keeper", name) ] in
+      let outcome_labels =
+        [ ("keeper", name); ("outcome", "meta_unavailable") ]
+      in
+      let attempts_before =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_keeper_restart_attempts
+          ~labels:attempt_labels ()
+      in
+      let outcomes_before =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_keeper_restart_outcomes
+          ~labels:outcome_labels ()
+      in
+      let ctx : _ KT.context =
+        {
+          config;
+          agent_name = "supervisor";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      Sup.sweep_and_recover ctx;
+      check (float 0.001) "restart attempt metric incremented"
+        (attempts_before +. 1.0)
+        (Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Prometheus.metric_keeper_restart_attempts
+           ~labels:attempt_labels ());
+      check (float 0.001) "missing-meta outcome metric incremented"
+        (outcomes_before +. 1.0)
+        (Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Prometheus.metric_keeper_restart_outcomes
+           ~labels:outcome_labels ());
+      check bool "keeper unregistered after missing meta" false
+        (Reg.is_registered ~base_path:config.base_path name))
+
 (* ── Dead-state loud alert (PR-C) ──────────────────────── *)
 
 (* Reproduces the 2026-04-25 incident pattern: 8 keepers crashed silently
@@ -625,6 +743,12 @@ let () =
     "reconcile_gate_recovery", [
       test_case "sweep restores reconcile gate for paused keeper" `Quick
         test_sweep_restores_reconcile_gate_for_paused_keeper;
+    ];
+    "restart_metrics", [
+      test_case "restart path emits attempt and started outcome metrics" `Quick
+        test_restart_path_emits_attempt_and_started_outcome_metrics;
+      test_case "restart path emits missing-meta outcome metrics" `Quick
+        test_restart_path_emits_meta_unavailable_outcome_metric;
     ];
     "dead_state_alert", [
       test_case "max_restarts exhaustion emits Dead alert" `Quick


### PR DESCRIPTION
## Summary

- Add `masc_keeper_lifecycle_transitions_total` for real registry phase changes.
- Add restart attempt and restart outcome counters for supervisor recovery paths.
- Keep metric labels bounded: `keeper`, lifecycle phases, and outcome values `started|meta_unavailable`.

## Product impact

Keeper recovery is easier to audit from Prometheus without scraping logs. Operators can distinguish phase movement, restart attempts, successful restarts, and abandoned restarts caused by missing metadata.

## Evidence

- `scripts/dune-local.sh build test/test_keeper_registry.exe test/test_keeper_supervisor.exe`
- `./_build/default/test/test_keeper_registry.exe --compact --quick-tests`
- `./_build/default/test/test_keeper_supervisor.exe --compact --quick-tests`
- `git diff --check`

## Review evidence

Tests cover lifecycle metrics only on actual phase changes, restart attempt increments, successful restart outcomes, and missing-meta restart outcomes.

## Linked issue

None.
