### PR TITLE
fix(keeper): configure stream idle timeout

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -120,7 +120,7 @@ Parse errors log a warning and fall back to env defaults.
 Legacy compatibility names that are no longer read by the unified turn path
 are intentionally excluded from this TOML surface.
 
-**Sections** (68 knobs total):
+**Sections** (69 knobs total):
 
 | Section | Count | Key examples |
 | --- | --- | --- |
@@ -128,7 +128,7 @@ are intentionally excluded from this TOML surface.
 | `[autonomous]` | 6 | `max_turns_per_call`, `semaphore_wait_timeout_sec`, `concurrency` |
 | `[reactive]` | 2 | `max_turns_per_call`, `max_idle_turns` |
 | `[heartbeat]` | 7 | `interval_sec`, `max_silence_sec`, `smart_heartbeat` |
-| `[turn]` | 16 | `timeout_sec`, `tool_cost_max_usd`, `max_tools_per_turn`, `temperature` |
+| `[turn]` | 17 | `timeout_sec`, `stream_idle_timeout_sec`, `tool_cost_max_usd`, `temperature` |
 | `[watchdog]` | 4 | `stale_sec`, `grace_sec`, `noop_threshold` |
 | `[supervisor]` | 4 | `max_restarts`, `backoff_base_sec`, `backoff_max_sec` |
 | `[lifecycle]` | 4 | `self_preservation_ratio`, `dead_ttl_sec` |
@@ -151,6 +151,7 @@ max_turns_per_call = 15
 max_active_keepers = 12
 
 [turn]
+stream_idle_timeout_sec = 120
 tool_cost_max_usd = 1.25
 max_tools_per_turn = 64
 llm_rerank = true

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -511,6 +511,14 @@ module KeeperKeepalive = struct
   let oas_timeout_sec =
     Option.value ~default:300.0 oas_timeout_sec_override
 
+  (** Idle-gap timeout for streaming OAS provider responses.
+      This bounds time between streamed lines, not total turn duration.
+      Env: [MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC]. Default: 120. Range: [5, 600]. *)
+  let stream_idle_timeout_sec =
+    Float.max 5.0
+      (Float.min 600.0
+         (get_float ~default:120.0 "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"))
+
   (** Consecutive idle tool repetitions before on_idle hook issues Skip.
       Below this: graduated Nudge messages.
       With tool_choice=Any, the model always calls tools, so idle

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -138,6 +138,7 @@ module KeeperKeepalive : sig
     estimated_input_tokens:int -> float
 
   val oas_timeout_sec : float
+  val stream_idle_timeout_sec : float
   val idle_skip_threshold : int
 end
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -32,7 +32,7 @@ include Keeper_agent_checkpoint_hygiene
     @param user_message The user's message to the keeper
     @param cascade_name Cascade profile name for model selection
     @param generation Current generation counter
-    @param max_turns Maximum agent turns (default: 50, generous budget for multi-step)
+    @param max_turns Maximum agent turns (default from keeper runtime config)
     @param guardrails Optional OAS guardrails for tool safety gates
     @param temperature MODEL temperature override; when omitted, resolved
            from [Cascade_inference] with a 0.3 fallback
@@ -228,13 +228,15 @@ let run_turn
        (Anthropic/OpenAI/Gemini/GLM/Ollama). The deadline resets after each
        successful line, so this is gap detection, not total run cap.
        (CLI subprocess transports ignore it; bounded separately by OAS
-       cli_common_subprocess idle.) Previous value [timeout_s -. 5.0] made
-       the gap window almost equal to the outer turn budget (~3595s),
-       which never fires in practice. 120s catches real network/stream
+       cli_common_subprocess idle.) Default 120s catches real network/stream
        hangs while preserving legitimate reasoning pauses + provider
-       keepalives (Anthropic SSE keepalive ~15s, reasoning models pause
-       10-30s mid-thought). #9639 envelope addendum. *)
-    let stream_idle_timeout_s = Some 120.0 in
+       keepalives. If the total OAS timeout is shorter, the idle gap is
+       clamped to that total cap so the nested timeout envelope is explicit. *)
+    let stream_idle_timeout_s =
+      Some
+        (Keeper_runtime_resolved.stream_idle_timeout_for_total_timeout
+           ~total_timeout_s:timeout_s)
+    in
     (* Observability for issue #10049: providers that declare runtime MCP
        HTTP header support need claude_mcp_config to reach the masc-mcp
        HTTP MCP endpoint; otherwise the MCP tool catalog is invisible to

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -783,13 +783,13 @@ let keeper_tool_search_top_k_rp =
 let keeper_tool_search_top_k () : int =
   Runtime_params.get keeper_tool_search_top_k_rp
 
-(* max_turns is set in keeper_agent_run.ml (default: 50).
+(* max_turns is set in keeper_agent_run.ml from keeper runtime config.
    Known constraints (retain for future tuning):
    - 1000 turns caused 787s+ latency per turn
    - 20 turns caused 6.7GB RSS in 2 minutes with 3 concurrent keepers
    - 3 turns left keepers unable to do meaningful work (board_post x3 only)
    - 10 turns was insufficient for multi-step tasks (PR creation, web search)
-   - 50 turns balances completion rate vs resource usage *)
+   - historical 50-turn experiments balanced completion rate vs resource usage *)
 
 (** Force module initialization to guarantee all runtime params are registered
     before [Runtime_params.restore]. Call from server bootstrap. *)

--- a/lib/keeper/keeper_runtime_config.ml
+++ b/lib/keeper/keeper_runtime_config.ml
@@ -34,6 +34,7 @@ let key_to_env =
     (* [turn] *)
     "turn.timeout_sec",                 "MASC_KEEPER_TURN_TIMEOUT_SEC";
     "turn.oas_timeout_sec",             "MASC_KEEPER_OAS_TIMEOUT_SEC";
+    "turn.stream_idle_timeout_sec",     "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC";
     "turn.admission_wait_timeout_sec",  "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC";
     "turn.max_consecutive_hb_failures", "MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES";
     "turn.max_consecutive_turn_failures", "MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES";

--- a/lib/keeper/keeper_runtime_config.mli
+++ b/lib/keeper/keeper_runtime_config.mli
@@ -58,6 +58,7 @@ val resolve_overrides :
       max_turns_per_call          = 15
 
       [turn]
+      stream_idle_timeout_sec   = 120
       tool_cost_max_usd           = 1.25
       max_tools_per_turn          = 64
       llm_rerank                  = true

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -18,6 +18,7 @@ type t = {
   turn_timeout_sec : float field;
   admission_wait_timeout_sec : float field;
   oas_timeout_override_sec : float option field;
+  stream_idle_timeout_sec : float field;
   oas_timeout_per_1k : float field;
   oas_timeout_per_turn : float field;
 }
@@ -82,6 +83,11 @@ let admission_wait_timeout_sec_live () =
   Float.max 5.0
     (Float.min 1200.0
        (get_float ~default:180.0 "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"))
+
+let stream_idle_timeout_sec_live () =
+  Float.max 5.0
+    (Float.min 600.0
+       (get_float ~default:120.0 "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"))
 
 let oas_timeout_override_sec_live ~turn_timeout_sec =
   match Env_config_core.raw_value_opt "MASC_KEEPER_OAS_TIMEOUT_SEC" with
@@ -148,6 +154,11 @@ let freeze_from_current () =
           (source_of_env_name "MASC_KEEPER_OAS_TIMEOUT_SEC");
     }
   in
+  let stream_idle_timeout_sec =
+    source_field
+      "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"
+      (stream_idle_timeout_sec_live ())
+  in
   let oas_timeout_per_1k =
     source_field
       "MASC_KEEPER_OAS_TIMEOUT_PER_1K"
@@ -167,6 +178,7 @@ let freeze_from_current () =
     turn_timeout_sec;
     admission_wait_timeout_sec;
     oas_timeout_override_sec;
+    stream_idle_timeout_sec;
     oas_timeout_per_1k;
     oas_timeout_per_turn;
   }
@@ -208,6 +220,7 @@ let to_yojson (runtime : t) =
       ("turn_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.turn_timeout_sec);
       ("admission_wait_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.admission_wait_timeout_sec);
       ("oas_timeout_override_sec", field_to_yojson option_float_to_yojson runtime.oas_timeout_override_sec);
+      ("stream_idle_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.stream_idle_timeout_sec);
       ("oas_timeout_per_1k", field_to_yojson (fun value -> `Float value) runtime.oas_timeout_per_1k);
       ("oas_timeout_per_turn", field_to_yojson (fun value -> `Float value) runtime.oas_timeout_per_turn);
     ]
@@ -232,6 +245,12 @@ let turn_timeout_sec () =
 
 let admission_wait_timeout_sec () =
   (current ()).admission_wait_timeout_sec.value
+
+let stream_idle_timeout_sec () =
+  (current ()).stream_idle_timeout_sec.value
+
+let stream_idle_timeout_for_total_timeout ~(total_timeout_s : float) =
+  Float.min total_timeout_s (stream_idle_timeout_sec ())
 
 let oas_timeout_for_estimated_input_tokens_with_turn_budget
     ~(estimated_input_tokens : int) ~(max_turns : int) : float =

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -27,6 +27,7 @@ type t = {
   turn_timeout_sec : float field;
   admission_wait_timeout_sec : float field;
   oas_timeout_override_sec : float option field;
+  stream_idle_timeout_sec : float field;
   oas_timeout_per_1k : float field;
   oas_timeout_per_turn : float field;
 }
@@ -48,6 +49,8 @@ val reactive_max_idle_turns : unit -> int
 val autonomous_max_idle_turns : unit -> int
 val turn_timeout_sec : unit -> float
 val admission_wait_timeout_sec : unit -> float
+val stream_idle_timeout_sec : unit -> float
+val stream_idle_timeout_for_total_timeout : total_timeout_s:float -> float
 val oas_timeout_for_estimated_input_tokens_with_turn_budget :
   estimated_input_tokens:int ->
   max_turns:int ->

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -118,12 +118,13 @@ let test_applies_turn_execution_overrides () =
      llm_rerank = true\n\
      llm_rerank_cascade = \"tool_rerank_fast\"\n\
      temperature = 0.65\n\
-     max_output_tokens = 8192\n"
+     max_output_tokens = 8192\n\
+     stream_idle_timeout_sec = 90\n"
   in
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied 6" 6 count;
+  check int "applied 7" 7 count;
   check (option string) "tool cost ceiling"
     (Some "1.25")
     (List.assoc_opt "MASC_KEEPER_TOOL_COST_MAX_USD" overrides);
@@ -141,7 +142,10 @@ let test_applies_turn_execution_overrides () =
     (List.assoc_opt "MASC_KEEPER_UNIFIED_TEMP" overrides);
   check (option string) "max output tokens"
     (Some "8192")
-    (List.assoc_opt "MASC_KEEPER_UNIFIED_MAX_TOKENS" overrides)
+    (List.assoc_opt "MASC_KEEPER_UNIFIED_MAX_TOKENS" overrides);
+  check (option string) "stream idle timeout"
+    (Some "90")
+    (List.assoc_opt "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC" overrides)
 
 let test_applies_watchdog_overrides () =
   let doc = parse_or_fail
@@ -289,7 +293,7 @@ let test_resolved_runtime_freezes_toml_values_after_init () =
   with_base_path @@ fun base_path ->
   write_toml base_path
     "[turn]\n\
-     timeout_sec = 1500\n\
+     timeout_sec = 500\n\
      [reactive]\n\
      max_turns_per_call = 12\n";
   (match Keeper_runtime_config.load_and_apply ~base_path with
@@ -300,7 +304,7 @@ let test_resolved_runtime_freezes_toml_values_after_init () =
   Config_boot_overrides.set "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL" "4";
   let runtime = Keeper_runtime_resolved.current () in
   check (float 0.0001) "turn timeout frozen from toml"
-    1500.0 runtime.turn_timeout_sec.value;
+    500.0 runtime.turn_timeout_sec.value;
   check string "turn timeout source"
     "toml"
     (Keeper_runtime_resolved.source_to_string runtime.turn_timeout_sec.source);
@@ -319,18 +323,51 @@ let test_resolved_runtime_accepts_max_turns_ceiling () =
   check int "autonomous max turns accepts 100"
     100 runtime.autonomous_max_turns_per_call.value
 
+let test_resolved_stream_idle_timeout_defaults_and_clamps_to_total () =
+  with_clean_boot_overrides @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (float 0.0001) "stream idle timeout default"
+    120.0 runtime.stream_idle_timeout_sec.value;
+  check string "stream idle timeout default source"
+    "default"
+    (Keeper_runtime_resolved.source_to_string runtime.stream_idle_timeout_sec.source);
+  check (float 0.0001) "stream idle clamps to shorter total"
+    60.0
+    (Keeper_runtime_resolved.stream_idle_timeout_for_total_timeout
+       ~total_timeout_s:60.0);
+  check (float 0.0001) "stream idle keeps configured default below total"
+    120.0
+    (Keeper_runtime_resolved.stream_idle_timeout_for_total_timeout
+       ~total_timeout_s:600.0)
+
+let test_resolved_stream_idle_timeout_uses_toml () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\nstream_idle_timeout_sec = 75\n";
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" msg
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (float 0.0001) "stream idle timeout from toml"
+    75.0 runtime.stream_idle_timeout_sec.value;
+  check string "stream idle timeout source"
+    "toml"
+    (Keeper_runtime_resolved.source_to_string runtime.stream_idle_timeout_sec.source)
+
 let test_resolved_runtime_prefers_env_over_toml () =
   with_clean_boot_overrides @@ fun () ->
   with_base_path @@ fun base_path ->
-  write_toml base_path "[turn]\ntimeout_sec = 1500\n";
-  with_env "MASC_KEEPER_TURN_TIMEOUT_SEC" (Some "777") @@ fun () ->
+  write_toml base_path "[turn]\ntimeout_sec = 500\n";
+  with_env "MASC_KEEPER_TURN_TIMEOUT_SEC" (Some "555") @@ fun () ->
   (match Keeper_runtime_config.load_and_apply ~base_path with
    | Error msg -> failf "unexpected error: %s" msg
    | Ok _ -> ());
   Keeper_runtime_resolved.init ();
   let runtime = Keeper_runtime_resolved.current () in
   check (float 0.0001) "env timeout wins"
-    777.0 runtime.turn_timeout_sec.value;
+    555.0 runtime.turn_timeout_sec.value;
   check string "env source"
     "env"
     (Keeper_runtime_resolved.source_to_string runtime.turn_timeout_sec.source)
@@ -354,6 +391,8 @@ let () =
         ; test_case "float value round trip" `Quick test_float_value_round_trip
         ; test_case "resolved runtime freezes toml values after init" `Quick test_resolved_runtime_freezes_toml_values_after_init
         ; test_case "resolved runtime accepts max_turns ceiling" `Quick test_resolved_runtime_accepts_max_turns_ceiling
+        ; test_case "resolved stream idle timeout defaults and clamps to total" `Quick test_resolved_stream_idle_timeout_defaults_and_clamps_to_total
+        ; test_case "resolved stream idle timeout uses toml" `Quick test_resolved_stream_idle_timeout_uses_toml
         ; test_case "resolved runtime prefers env over toml" `Quick test_resolved_runtime_prefers_env_over_toml
         ] )
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1732,7 +1732,7 @@ let test_unified_turn_runtime_defaults () =
        This test verifies the runtime default, not cascade-resolved value. *)
     check int "unified max_tokens default" 65536
       (KC.keeper_unified_max_tokens ())
-    (* max_turns is set in keeper_agent_run.ml (default: 50) *)))
+    (* max_turns is set in keeper_agent_run.ml from keeper runtime config. *)))
 
 let test_meta_defaults_social_model () =
   check string "default social model" "bdi_speech_v1"


### PR DESCRIPTION
## Summary

- Add `turn.stream_idle_timeout_sec` / `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC`.
- Resolve and freeze stream idle timeout through keeper runtime config.
- Pass the runtime value into keeper agent turns, clamped to the total OAS timeout when shorter.
- Remove stale comments that claimed `max_turns` defaulted to 50 in `keeper_agent_run`.

## Product impact

The stream idle timeout is now a visible runtime knob instead of a hardcoded keeper run-path constant. Operators can tune streaming gap detection without editing code, while the default stays at 120 seconds.

## Evidence

- `scripts/dune-local.sh build test/test_keeper_runtime_toml.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_runtime_toml.exe --compact --quick-tests`
- `./_build/default/test/test_keeper_unified.exe --compact --quick-tests`
- `git diff --check`

## Review evidence

Focused tests cover TOML/env mapping, default value, source freezing, total-timeout clamp behavior, and the existing keeper unified runtime defaults.

## Linked issue

None.
