### PR TITLE
refactor(oas): type fsm cascade error labels

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -320,7 +320,7 @@ let run_named
     | Ok result ->
       let result =
         Result.map_error
-          (enrich_sdk_error ~cascade_name ~provider_cfg)
+          (enrich_sdk_error ~cascade_name:error_cascade_name ~provider_cfg)
           result
       in
       (* Extract checkpoint from the agent if it made progress.
@@ -534,7 +534,10 @@ let run_named
            Ok result)
       | Error sdk_err ->
         let sdk_err =
-          match sdk_error_to_resumable_cli_session ~cascade_name sdk_err with
+          match
+            sdk_error_to_resumable_cli_session
+              ~cascade_name:error_cascade_name sdk_err
+          with
           | Some err -> err
           | None -> sdk_err
         in
@@ -547,7 +550,7 @@ let run_named
            state. *)
         let err_str = Oas.Error.to_string sdk_err in
         let (_ : Provider_error.t option) =
-          emit_sdk_provider_error_metric ~cascade_name
+          emit_sdk_provider_error_metric ~cascade_name:error_cascade_name
             ~provider:provider_cfg.model_id sdk_err
         in
         if sdk_error_is_hard_quota sdk_err then

--- a/lib/oas_worker_named_fsm.ml
+++ b/lib/oas_worker_named_fsm.ml
@@ -80,7 +80,10 @@ let is_moonshot_provider (provider_cfg : Llm_provider.Provider_config.t) =
   String_util.contains_substring_ci provider_cfg.base_url "moonshot.ai"
   || String.starts_with ~prefix:"kimi" provider_cfg.model_id
 
+let cascade_name_to_string = Oas_worker_named_error.cascade_name_to_string
+
 let resolve_kimi_api_key_env_name ~cascade_name =
+  let cascade_name = cascade_name_to_string cascade_name in
   let fallback_env = "KIMI_API_KEY_SB" in
   let resolve_from_overrides overrides =
     let find_non_empty key =
@@ -246,7 +249,7 @@ let sdk_error_to_resumable_cli_session ~cascade_name
              (Oas_worker_named_error.Resumable_cli_session
                 {
                   cascade_name =
-                    Oas_worker_named_error.cascade_name_of_string cascade_name;
+                    cascade_name;
                   detail = resumable_cli_session_detail message;
                   exit_code = resumable_cli_session_exit_code message;
                 }))
@@ -356,7 +359,7 @@ let provider_error_capacity_scope_label = function
       "none"
 
 let emit_provider_error_metric ~cascade_name ~provider error =
-  let cascade_name = provider_label cascade_name in
+  let cascade_name = provider_label (cascade_name_to_string cascade_name) in
   let provider = provider_label provider in
   Prometheus.inc_counter provider_error_total_metric
     ~labels:

--- a/lib/oas_worker_named_fsm.mli
+++ b/lib/oas_worker_named_fsm.mli
@@ -19,7 +19,7 @@ val sdk_error_to_cascade_outcome :
 (** {1 Error enrichment} *)
 
 val enrich_sdk_error :
-  cascade_name:string ->
+  cascade_name:Oas_worker_named_error.cascade_name ->
   provider_cfg:Llm_provider.Provider_config.t ->
   Oas.Error.sdk_error -> Oas.Error.sdk_error
 (** Enrich an SDK error with provider-specific diagnostic hints
@@ -57,7 +57,9 @@ val retry_message_looks_like_not_found : string -> bool
 (** {1 SDK error predicates} *)
 
 val sdk_error_to_resumable_cli_session :
-  cascade_name:string -> Oas.Error.sdk_error -> Oas.Error.sdk_error option
+  cascade_name:Oas_worker_named_error.cascade_name ->
+  Oas.Error.sdk_error ->
+  Oas.Error.sdk_error option
 (** If the error looks like a resumable CLI session, convert it into the
     structured [Resumable_cli_session] form. *)
 
@@ -85,7 +87,7 @@ val provider_error_total_metric : string
 (** Prometheus counter for additive provider-error variant emission. *)
 
 val emit_provider_error_metric :
-  cascade_name:string ->
+  cascade_name:Oas_worker_named_error.cascade_name ->
   provider:string ->
   Provider_error.t ->
   unit
@@ -93,7 +95,7 @@ val emit_provider_error_metric :
     string-based health tracker labels. *)
 
 val emit_sdk_provider_error_metric :
-  cascade_name:string ->
+  cascade_name:Oas_worker_named_error.cascade_name ->
   provider:string ->
   Oas.Error.sdk_error ->
   Provider_error.t option
@@ -112,7 +114,8 @@ val sdk_error_is_max_turns_exceeded : Oas.Error.sdk_error -> bool
 
 val is_moonshot_provider : Llm_provider.Provider_config.t -> bool
 
-val resolve_kimi_api_key_env_name : cascade_name:string -> string
+val resolve_kimi_api_key_env_name :
+  cascade_name:Oas_worker_named_error.cascade_name -> string
 
 val moonshot_auth_hint_marker : string
 val openai_compat_not_found_hint_marker : string

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -870,7 +870,7 @@ let test_sdk_error_to_cascade_outcome_cascades_resumable_cli_session () =
   let structured =
     match
       Oas_worker_named.sdk_error_to_resumable_cli_session
-        ~cascade_name:"tool_use_strict" sdk_error
+        ~cascade_name:(internal_cascade_name "tool_use_strict") sdk_error
     with
     | Some structured -> structured
     | None -> Alcotest.fail "expected structured resumable CLI session"
@@ -958,7 +958,7 @@ let test_enrich_sdk_error_for_moonshot_auth_includes_env_hint () =
   in
   let rendered =
     Oas_worker_named.enrich_sdk_error
-      ~cascade_name:"keeper_unified"
+      ~cascade_name:(internal_cascade_name "keeper_unified")
       ~provider_cfg
       err
     |> Oas.Error.to_string
@@ -982,7 +982,7 @@ let test_enrich_sdk_error_for_openai_not_found_includes_endpoint_hint () =
   in
   let rendered =
     Oas_worker_named.enrich_sdk_error
-      ~cascade_name:"keeper_unified"
+      ~cascade_name:(internal_cascade_name "keeper_unified")
       ~provider_cfg
       err
     |> Oas.Error.to_string
@@ -2565,7 +2565,7 @@ let test_kimi_cli_resumable_invalid_request_reclassifies_as_structured () =
   in
   match
     Oas_worker_named.sdk_error_to_resumable_cli_session
-      ~cascade_name:"kimi_cli_keeper" sdk_error
+      ~cascade_name:(internal_cascade_name "kimi_cli_keeper") sdk_error
   with
   | Some structured -> (
       match Oas_worker_named.classify_masc_internal_error structured with

--- a/test/test_provider_error.ml
+++ b/test/test_provider_error.ml
@@ -6,6 +6,8 @@ module Prom = Masc_mcp.Prometheus
 module Retry = Llm_provider.Retry
 module OWN = Masc_mcp.Oas_worker_named
 
+let cascade_name raw = OWN.cascade_name_of_string raw
+
 let check_json name expected error =
   check string name expected (Yojson.Safe.to_string (P.to_yojson error))
 
@@ -243,7 +245,7 @@ let test_emit_sdk_provider_error_metric_rate_limit () =
   let emitted =
     Oas.Error.Api
       (Retry.RateLimited { retry_after = Some 2.0; message = "too many" })
-    |> OWN.emit_sdk_provider_error_metric ~cascade_name:"big_three"
+    |> OWN.emit_sdk_provider_error_metric ~cascade_name:(cascade_name "big_three")
          ~provider:"anthropic"
     |> expect_some
   in
@@ -265,7 +267,7 @@ let test_emit_sdk_provider_error_metric_capacity_scope () =
              "You have reached your specified API usage limits. You will \
               regain access on 2026-05-01 at 00:00 UTC.";
          })
-    |> OWN.emit_sdk_provider_error_metric ~cascade_name:"big_three"
+    |> OWN.emit_sdk_provider_error_metric ~cascade_name:(cascade_name "big_three")
          ~provider:"anthropic"
     |> expect_some
   in
@@ -281,7 +283,7 @@ let test_emit_sdk_provider_error_metric_skips_non_api () =
   in
   let emitted =
     Oas.Error.Internal "structural failure"
-    |> OWN.emit_sdk_provider_error_metric ~cascade_name:"big_three"
+    |> OWN.emit_sdk_provider_error_metric ~cascade_name:(cascade_name "big_three")
          ~provider:"anthropic"
   in
   check bool "no provider error emitted" true (Option.is_none emitted);


### PR DESCRIPTION
## Summary
- Refs #11926.
- Type `Oas_worker_named_fsm` cascade labels for error enrichment, resumable CLI-session conversion, and provider-error metric emission.
- Thread the existing typed structured-error cascade name from `run_named` into FSM helpers.
- Preserve Prometheus labels and Kimi env override lookup by rendering typed cascade names only at those boundaries.

## Product impact
The OAS FSM/error path no longer accepts raw `cascade_name:string` for provider error metrics or resumable-session classification. This continues the C-T7.2 cascade_name string-surface reduction while keeping emitted operator labels stable.

## Validation
- `scripts/dune-local.sh build test/test_provider_error.exe test/test_oas_worker.exe` passed before final rebase on the same patch.
- `./_build/default/test/test_provider_error.exe` passed: 12 tests.
- `./_build/default/test/test_oas_worker.exe test cascade_config 25-30` passed: 6 tests.
- `./_build/default/test/test_oas_worker.exe test resume_config 53` passed: 1 test.
- Post-rebase `git diff --check HEAD~1 HEAD` passed.
- Post-rebase `scripts/stringly-boundary-ratchet.sh` passed: `cascade_name 57 / 81`.

## Notes
A final post-rebase focused Dune rebuild retry was stopped while waiting on the shared `/tmp/me-dune-local.lock`; CI should be the post-rebase build authority for this draft.