### PR TITLE
fix(ci): repair main OCaml and lint blockers

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -129,7 +129,7 @@ let handle_keeper_fs_read
              ; "bytes", `Int total
              ; "truncated", `Bool truncated
              ; "content", `String body
-             ])))
+             ]))))
 ;;
 
 (* RFC-0006 Phase A.4: replace [old] with [new] in [text]. When

--- a/lib/repo_manager/repo_manager_types.ml
+++ b/lib/repo_manager/repo_manager_types.ml
@@ -34,9 +34,9 @@ type credential = {
   id : string;
   cred_type : credential_type;
   username : string;
-  gh_config_dir : string option;
-  ssh_key_path : string option;
-  gpg_key_id : string option;
+  gh_config_dir : string option; [@default None]
+  ssh_key_path : string option; [@default None]
+  gpg_key_id : string option; [@default None]
 }
 [@@deriving yojson, show, eq]
 

--- a/lib/repo_manager/repo_manager_types.mli
+++ b/lib/repo_manager/repo_manager_types.mli
@@ -34,9 +34,9 @@ type credential = {
   id : string;
   cred_type : credential_type;
   username : string;
-  gh_config_dir : string option;
-  ssh_key_path : string option;
-  gpg_key_id : string option;
+  gh_config_dir : string option; [@default None]
+  ssh_key_path : string option; [@default None]
+  gpg_key_id : string option; [@default None]
 }
 [@@deriving yojson, show, eq]
 


### PR DESCRIPTION
## Summary
- closes the missing parenthesis in keeper_fs_read after the containment/repo/read nested matches
- adds [@default None] to new repo-manager optional credential fields so the yojson option lint stays at baseline
- unblocks current main failures inherited by ready PRs, including #12302

## Verification
- scripts/dune-local.sh build lib/keeper/keeper_exec_fs.ml
- python3 scripts/lint/yojson-option-default.py
- scripts/dune-local.sh build lib/keeper/keeper_exec_fs.ml lib/repo_manager/repo_manager_types.ml