### PR TITLE
[codex] Fix dashboard IO contention and world memory prompts

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -307,6 +307,57 @@ module FileSystem = struct
           acc
     | _ -> acc
 
+  let validate_prefix prefix =
+    if prefix = "" then
+      Ok ()
+    else
+      let len = String.length prefix in
+      let key =
+        if prefix.[len - 1] = ':' then
+          String.sub prefix 0 (len - 1)
+        else
+          prefix
+      in
+      match validate_key key with
+      | Ok _ -> Ok ()
+      | Error e -> Error e
+
+  let prefix_scan_root t ~prefix =
+    match validate_prefix prefix with
+    | Error e -> Error e
+    | Ok () ->
+        let segments = String.split_on_char ':' prefix in
+        let complete_segments =
+          if prefix <> "" && prefix.[String.length prefix - 1] = ':' then
+            List.filter (fun segment -> segment <> "") segments
+          else
+            match List.rev segments with
+            | [] | [ _ ] -> []
+            | _partial :: parents_rev -> List.rev parents_rev
+        in
+        let path =
+          List.fold_left (fun path segment -> Eio.Path.(path / segment)) t.fs
+            complete_segments
+        in
+        let logical_prefix = String.concat ":" complete_segments in
+        Ok (path, logical_prefix)
+
+  let list_keys_by_prefix_scan t ~prefix =
+    match prefix_scan_root t ~prefix with
+    | Error e -> Error e
+    | Ok (scan_root, logical_prefix) -> (
+        try
+          let keys =
+            collect_keys_under ~requested_prefix:prefix ~logical_prefix
+              scan_root []
+          in
+          ki_replace_bulk t (List.map (fun key -> (key, ())) keys);
+          Ok (List.sort_uniq String.compare keys)
+        with
+        | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) -> Ok []
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn -> Error (IOError (Printexc.to_string exn)))
+
   let ensure_key_index t =
     (* Domain-safe check-and-populate.  Stdlib.Mutex serializes the
        check of key_index length + key_index_promise so that two
@@ -361,7 +412,6 @@ module FileSystem = struct
     match validate_key key with
     | Error _ -> false
     | Ok _ ->
-      ensure_key_index t;
       (* Verify the real filesystem even on index hits so raw rm_rf/reset
          cannot leave stale positives in the in-memory key index. *)
       match key_to_path t key with
@@ -381,13 +431,13 @@ module FileSystem = struct
              false)
 
   let list_keys t ~prefix =
-    ensure_key_index t;
-    let result = ref [] in
-    ki_iter t (fun k () ->
-      if prefix = "" || starts_with ~prefix k then
-        result := k :: !result
-    );
-    Ok (List.sort_uniq String.compare !result)
+    if prefix = "" then begin
+      ensure_key_index t;
+      let result = ref [] in
+      ki_iter t (fun k () -> result := k :: !result);
+      Ok (List.sort_uniq String.compare !result)
+    end else
+      list_keys_by_prefix_scan t ~prefix
 
   (** Set if not exists (atomic, auto-compresses) *)
   let set_if_not_exists t key value =

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -31,6 +31,8 @@ let create_store () = {
   comments_by_post = Hashtbl.create 1024;
   dirty_posts = false;
   dirty_comments = false;
+  dirty_post_ids = Hashtbl.create 256;
+  dirty_comment_ids = Hashtbl.create 512;
   last_flush = Time_compat.now ();
   flusher_inbox = Eio.Stream.create 1000;
 }
@@ -53,6 +55,14 @@ let invalidate_post_caches store =
 (** Invalidate caches that depend on comment data *)
 let invalidate_comment_caches store =
   store.karma_cache <- None
+
+let mark_dirty_post store post_id =
+  store.dirty_posts <- true;
+  Hashtbl.replace store.dirty_post_ids post_id ()
+
+let mark_dirty_comment store comment_id =
+  store.dirty_comments <- true;
+  Hashtbl.replace store.dirty_comment_ids comment_id ()
 
 (** {1 Eio-style Locking with Switch.on_release} *)
 
@@ -511,6 +521,7 @@ let reclassify_posts store ?(limit = 5200) ?(dry_run = true) () =
       invalidate_post_caches store;
       rewrite_posts store;
       store.dirty_posts <- false;
+      Hashtbl.clear store.dirty_post_ids;
       store.last_flush <- Time_compat.now ()
     end;
     {

--- a/lib/board_core.mli
+++ b/lib/board_core.mli
@@ -120,6 +120,14 @@ val rotate_if_needed : string -> unit
     routed through the persist-error counter so the runtime
     keeps appending to the live file rather than aborting. *)
 
+(** {1 Append-only persistence} *)
+
+val append_post : post -> unit
+(** Appends one post snapshot to {!persist_path}. *)
+
+val append_comment : comment -> unit
+(** Appends one comment snapshot to {!comments_path}. *)
+
 (** {1 Whole-state JSONL rewrite} *)
 
 val rewrite_posts : store -> unit
@@ -131,6 +139,14 @@ val rewrite_comments : store -> unit
 (** Atomically rewrites {!comments_path} from
     [store.comments].  Same usage pattern as
     {!rewrite_posts}. *)
+
+val mark_dirty_post : store -> string -> unit
+(** Marks one post for append-only deferred persistence.  Call with
+    [store.mutex] already held. *)
+
+val mark_dirty_comment : store -> string -> unit
+(** Marks one comment for append-only deferred persistence.  Call with
+    [store.mutex] already held. *)
 
 (** {1 Wire encoders} *)
 

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -200,7 +200,8 @@ type store = {
   comments_by_post: (string, string list) Hashtbl.t;      (** post_id -> comment_id list *)
   mutable dirty_posts: bool;                               (** Deferred flush flag *)
   mutable dirty_comments: bool;                            (** Deferred flush flag *)
+  dirty_post_ids: (string, unit) Hashtbl.t;                 (** Deferred post snapshots *)
+  dirty_comment_ids: (string, unit) Hashtbl.t;              (** Deferred comment snapshots *)
   mutable last_flush: float;
   flusher_inbox: flusher_msg Eio.Stream.t;                               (** Last deferred flush time *)
 }
-

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -148,6 +148,8 @@ type store = {
   (** post_id -> comment_id list. *)
   mutable dirty_posts : bool;
   mutable dirty_comments : bool;
+  dirty_post_ids : (string, unit) Hashtbl.t;
+  dirty_comment_ids : (string, unit) Hashtbl.t;
   mutable last_flush : float;
   flusher_inbox : flusher_msg Eio.Stream.t;
 }

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -120,7 +120,7 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
                   in
                   Hashtbl.replace store.posts (Post_id.to_string pid) flipped;
                   Hashtbl.replace store.vote_log vote_key (direction, now);
-                  store.dirty_posts <- true;  (* Deferred flush *)
+                  mark_dirty_post store (Post_id.to_string pid);
                   invalidate_post_caches store;
                   append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
                   (* Record vote for Thompson Sampling feedback *)
@@ -137,7 +137,7 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
                   in
                   Hashtbl.replace store.posts (Post_id.to_string pid) updated;
                   Hashtbl.replace store.vote_log vote_key (direction, now);
-                  store.dirty_posts <- true;  (* Deferred flush *)
+                  mark_dirty_post store (Post_id.to_string pid);
                   invalidate_post_caches store;
                   append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
                   (* Record vote for Thompson Sampling feedback *)
@@ -194,7 +194,7 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) result
                 in
                 Hashtbl.replace store.comments (Comment_id.to_string cid) flipped;
                 Hashtbl.replace store.vote_log vote_key (direction, now);
-                store.dirty_comments <- true;  (* Deferred flush *)
+                mark_dirty_comment store (Comment_id.to_string cid);
                 invalidate_comment_caches store;
                 append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
                 (* Record vote for Thompson Sampling feedback *)
@@ -209,7 +209,7 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) result
                 in
                 Hashtbl.replace store.comments (Comment_id.to_string cid) updated;
                 Hashtbl.replace store.vote_log vote_key (direction, now);
-                store.dirty_comments <- true;  (* Deferred flush *)
+                mark_dirty_comment store (Comment_id.to_string cid);
                 invalidate_comment_caches store;
                 append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
                 (* Record vote for Thompson Sampling feedback *)
@@ -378,7 +378,11 @@ let load_persisted_comments store =
             (* Build comments_by_post index *)
             let post_key = Post_id.to_string c.post_id in
             let existing = Hashtbl.find_opt store.comments_by_post post_key |> Option.value ~default:[] in
-            Hashtbl.replace store.comments_by_post post_key (cid :: existing);
+            let indexed =
+              if List.exists (String.equal cid) existing then existing
+              else cid :: existing
+            in
+            Hashtbl.replace store.comments_by_post post_key indexed;
             incr loaded
         | _ -> ()
       ) lines;
@@ -586,6 +590,8 @@ let delete_post store ~post_id : (unit, board_error) result =
             rewrite_vote_log store;
             store.dirty_posts <- false;
             store.dirty_comments <- false;
+            Hashtbl.clear store.dirty_post_ids;
+            Hashtbl.clear store.dirty_comment_ids;
             store.last_flush <- Time_compat.now ();
             Ok ())
 
@@ -619,18 +625,39 @@ let reset_global_for_test () =
 
 (** Flush any dirty state to disk. Call on shutdown to prevent data loss. *)
 let flush_dirty store =
-  with_lock store (fun () ->
-    if store.dirty_posts then begin
-      rewrite_posts store;
-      store.dirty_posts <- false
-    end;
-    if store.dirty_comments then begin
-      rewrite_comments store;
-      store.dirty_comments <- false
-    end;
-    rewrite_vote_log store;
-    store.last_flush <- Time_compat.now ()
-  )
+  let posts, comments =
+    with_lock store (fun () ->
+      let posts =
+        if store.dirty_posts then
+          Hashtbl.fold
+            (fun post_id () acc ->
+              match Hashtbl.find_opt store.posts post_id with
+              | Some post -> post :: acc
+              | None -> acc)
+            store.dirty_post_ids []
+        else
+          []
+      in
+      let comments =
+        if store.dirty_comments then
+          Hashtbl.fold
+            (fun comment_id () acc ->
+              match Hashtbl.find_opt store.comments comment_id with
+              | Some comment -> comment :: acc
+              | None -> acc)
+            store.dirty_comment_ids []
+        else
+          []
+      in
+      Hashtbl.clear store.dirty_post_ids;
+      Hashtbl.clear store.dirty_comment_ids;
+      store.dirty_posts <- false;
+      store.dirty_comments <- false;
+      store.last_flush <- Time_compat.now ();
+      (posts, comments))
+  in
+  List.iter append_post posts;
+  List.iter append_comment comments
 
 
 (** {1 Karma & Flair - Reddit-style} *)

--- a/lib/board_votes.mli
+++ b/lib/board_votes.mli
@@ -169,11 +169,10 @@ val reset_global_for_test : unit -> unit
     from test setup before concurrent fibers exist. *)
 
 val flush_dirty : store -> unit
-(** Flushes [dirty_posts] / [dirty_comments] back to the
-    JSONL files via {!rewrite_posts} / {!rewrite_comments},
-    then atomically rewrites the vote-log.  Stamps
-    [last_flush] with the wall clock.  Call on shutdown to
-    prevent data loss from the deferred-flush write path. *)
+(** Flushes dirty post/comment snapshots to the JSONL files
+    with a short in-memory snapshot lock and append-only disk
+    writes.  Vote changes are already appended on the vote
+    path.  Stamps [last_flush] with the wall clock. *)
 
 (** {1 Karma} *)
 

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -274,7 +274,8 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
          Eio's cooperative scheduler needs explicit yields in CPU-bound paths
          so other fibers (SSE, health checks) can progress. *)
       Eio.Fiber.yield ();
-      let operation_contexts = build_operation_contexts () in
+      let tasks = tasks_safe config in
+      let operation_contexts = build_operation_contexts ~tasks in
       let session_contexts = [] in
       let execution_queue =
         build_execution_queue session_contexts operation_contexts
@@ -313,7 +314,6 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
          In light mode, tasks and messages are NOT serialized in the
          response payload (saves ~143KB) but are still loaded for
          worker_support_briefs computation. *)
-      let tasks = tasks_safe config in
       let agents = agents_safe config in
       let messages = messages_safe config in
       let t_after_data_load = Time_compat.now () in

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -385,8 +385,90 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
    future code needs status-based severity, re-introduce with a Variant
    input + exhaustive match instead of a string. *)
 
-let build_operation_contexts () =
-  []
+let task_operation_status (task : Types.task) =
+  match task.task_status with
+  | Types.Todo | Types.Claimed _ | Types.InProgress _ -> Some "active"
+  | Types.AwaitingVerification _ -> Some "paused"
+  | Types.Done _ | Types.Cancelled _ -> None
+
+let task_operation_severity (task : Types.task) =
+  match task.task_status with
+  | Types.AwaitingVerification _ -> Tone_warn
+  | Types.Todo | Types.Claimed _ | Types.InProgress _ -> Tone_ok
+  | Types.Done _ | Types.Cancelled _ -> Tone_ok
+
+let task_operation_updated_at (task : Types.task) =
+  match task.task_status with
+  | Types.Done { completed_at; _ } -> completed_at
+  | Types.Cancelled { cancelled_at; _ } -> cancelled_at
+  | Types.InProgress { started_at; _ } -> started_at
+  | Types.AwaitingVerification { submitted_at; _ } -> submitted_at
+  | Types.Claimed { claimed_at; _ } -> claimed_at
+  | Types.Todo -> task.created_at
+
+let task_operation_links (task : Types.task) =
+  match task.contract with
+  | Some contract -> contract.links
+  | None -> { Types.operation_id = None; session_id = None; autoresearch_loop_id = None }
+
+let task_operation_id (task : Types.task) =
+  let links = task_operation_links task in
+  match trim_to_option (Option.value ~default:"" links.operation_id) with
+  | Some operation_id -> operation_id
+  | None -> task.id
+
+let build_operation_contexts ~(tasks : Types.task list) =
+  tasks
+  |> List.filter_map (fun (task : Types.task) ->
+         match task_operation_status task with
+         | None -> None
+         | Some status ->
+           let links = task_operation_links task in
+           let operation_id = task_operation_id task in
+           let updated_at = task_operation_updated_at task in
+           let severity = task_operation_severity task in
+           let stage = Option.map Task_stage.to_string task.stage in
+           let linked_session_id =
+             Option.bind links.session_id (fun value -> trim_to_option value)
+           in
+           let last_seen_ts =
+             parse_iso_opt (Some updated_at) |> Option.value ~default:0.0
+           in
+           Some
+             {
+               operation_id;
+               severity;
+               last_seen_ts;
+               linked_session_id;
+               linked_detachment_id = None;
+               json =
+                 `Assoc
+                   [
+                     ("operation_id", `String operation_id);
+                     ("status", `String status);
+                     ("task_status", `String (Types.task_status_to_string task.task_status));
+                     ("stage", json_string_option stage);
+                     ("objective", `String task.title);
+                     ("updated_at", `String updated_at);
+                     ("source", `String "task_contract");
+                     ("task_id", `String task.id);
+                     ("severity", `String (string_of_tone severity));
+                     ("linked_session_id", json_string_option linked_session_id);
+                     ("linked_detachment_id", `Null);
+                     ( "handoff",
+                       handoff_json ~surface:"dashboard_execution"
+                         ?operation_id:(Some operation_id)
+                         ~label:"Open task"
+                         ~target_type:"task"
+                         ~target_id:task.id
+                         ~focus_kind:"task"
+                         () );
+                   ];
+             })
+  |> List.sort (fun left right ->
+         let by_tone = Int.compare (tone_rank right.severity) (tone_rank left.severity) in
+         if by_tone <> 0 then by_tone
+         else Float.compare right.last_seen_ts left.last_seen_ts)
 
 let build_worker_support_briefs ~(now_ts : float) ~(tasks : Types.task list)
     ~(agents : Types.agent list) ~(messages : Types.message list) session_contexts :

--- a/lib/dashboard/dashboard_execution_builders.mli
+++ b/lib/dashboard/dashboard_execution_builders.mli
@@ -29,11 +29,10 @@ val task_assignee : Types.task -> string option
     contract seam — adding a new task status that should also
     carry an assignee requires extending this match. *)
 
-val build_operation_contexts : unit -> operation_context list
-(** [build_operation_contexts ()] currently returns [\[\]].
-    Reserved for future operation-context aggregation; kept as a
-    function (not constant) so callers don't need to change call
-    sites when the implementation lands. *)
+val build_operation_contexts : tasks:Types.task list -> operation_context list
+(** [build_operation_contexts ~tasks] projects non-terminal tasks into
+    operation rows.  Task contracts provide operation/session links when
+    present; otherwise the task id is used as a stable operation id. *)
 
 val build_worker_support_briefs :
   now_ts:float ->

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -704,8 +704,16 @@ let session_json ?actor ~session_id ~config ~sw
     build_projection ?actor ~config ~sw
       ~clock ~proc_mgr ()
   in
+  let tasks =
+    if Coord.is_initialized config then Coord.get_tasks_safe config else []
+  in
+  let operation_contexts =
+    Dashboard_mission_assembly.build_operation_contexts ~tasks
+  in
   let session_row_json =
-    Dashboard_mission_assembly.build_sessions projection.sessions projection.attention_queue projection.agent_briefs
+    Dashboard_mission_assembly.build_sessions
+      ~operation_contexts
+      projection.sessions projection.attention_queue projection.agent_briefs
       projection.keeper_briefs
     |> List.find_opt (fun json ->
            String.equal (string_field "session_id" json) session_id)
@@ -729,7 +737,6 @@ let session_json ?actor ~session_id ~config ~sw
     ignore (config, session_id);
     `Null
   in
-  let operation_contexts = Dashboard_mission_assembly.build_operation_contexts () in
   let operations_json =
     match session_context with
     | None -> []

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -335,8 +335,50 @@ let build_internal_signals incidents actions =
   |> List.sort (fun left right -> Int.compare right.pressure_rank left.pressure_rank)
   |> List.map (fun (row : keeper_context) -> row.json)
 
-let build_operation_contexts () =
-  []
+let task_operation_status (task : Types.task) =
+  match task.task_status with
+  | Types.Todo | Types.Claimed _ | Types.InProgress _ -> Some "active"
+  | Types.AwaitingVerification _ -> Some "paused"
+  | Types.Done _ | Types.Cancelled _ -> None
+
+let task_operation_updated_at (task : Types.task) =
+  match task.task_status with
+  | Types.Done { completed_at; _ } -> completed_at
+  | Types.Cancelled { cancelled_at; _ } -> cancelled_at
+  | Types.InProgress { started_at; _ } -> started_at
+  | Types.AwaitingVerification { submitted_at; _ } -> submitted_at
+  | Types.Claimed { claimed_at; _ } -> claimed_at
+  | Types.Todo -> task.created_at
+
+let task_operation_links (task : Types.task) =
+  match task.contract with
+  | Some contract -> contract.links
+  | None -> { Types.operation_id = None; session_id = None; autoresearch_loop_id = None }
+
+let task_operation_id (task : Types.task) =
+  let links = task_operation_links task in
+  match trim_to_option (Option.value ~default:"" links.operation_id) with
+  | Some operation_id -> operation_id
+  | None -> task.id
+
+let build_operation_contexts ~(tasks : Types.task list) =
+  tasks
+  |> List.filter_map (fun (task : Types.task) ->
+         match task_operation_status task with
+         | None -> None
+         | Some status ->
+           let links = task_operation_links task in
+           Some
+             {
+               operation_id = task_operation_id task;
+               linked_session_id =
+                 Option.bind links.session_id (fun value -> trim_to_option value);
+               status = Some status;
+               stage = Option.map Task_stage.to_string task.stage;
+               detachment_status = None;
+               objective = trim_to_option task.title;
+               updated_at = Some (task_operation_updated_at task);
+             })
 
 let operation_badge_json (operation : operation_context) =
   let status_str =
@@ -439,7 +481,7 @@ let keeper_refs_for_session member_names keeper_briefs =
                  ("current_work", member_assoc "current_work" row);
                ]))
 
-let build_sessions sessions attention_queue agent_briefs keeper_briefs =
+let build_sessions ?(operation_contexts = []) sessions attention_queue agent_briefs keeper_briefs =
   let related_attention_count session_id =
     attention_queue
     |> List.fold_left
@@ -447,7 +489,6 @@ let build_sessions sessions attention_queue agent_briefs keeper_briefs =
            if List.mem session_id attention.related_session_ids then acc + 1 else acc)
          0
   in
-  let operation_contexts = build_operation_contexts () in
   sessions
   |> List.map (fun (session : session_context) ->
          let attention_count = related_attention_count session.session_id in

--- a/lib/dashboard/dashboard_mission_assembly.mli
+++ b/lib/dashboard/dashboard_mission_assembly.mli
@@ -57,20 +57,22 @@ val build_internal_signals :
     one internal-signal list, sorted by descending
     pressure rank. *)
 
-val build_operation_contexts : unit -> operation_context list
-(** Currently returns [\[\]] — placeholder for upcoming
-    operation-context aggregation. *)
+val build_operation_contexts : tasks:Types.task list -> operation_context list
+(** Projects non-terminal tasks into operation contexts for mission
+    badges.  Task contract links provide operation/session ids when
+    available; otherwise the task id remains visible as the operation id. *)
 
 (** {1 Session assembly} *)
 
 val build_sessions :
+  ?operation_contexts:operation_context list ->
   session_context list ->
   attention_context list ->
   Yojson.Safe.t list ->
   Yojson.Safe.t list ->
   Yojson.Safe.t list
-(** [build_sessions sessions attention_queue agent_briefs
-      keeper_briefs] renders the session row JSON list,
+(** [build_sessions ?operation_contexts sessions attention_queue
+      agent_briefs keeper_briefs] renders the session row JSON list,
     sorted by attention count → severity rank → recency.
     Each row carries the embedded [member_previews] /
     [operation_badges] / [keeper_refs] envelopes built

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -614,9 +614,10 @@ type history_line_action =
 
 let classify_history_entry ~(source : string) ~(content : string) :
     history_line_action =
-  if Keeper_types.is_prompt_history_source source
-     || has_world_state_signature content
-  then Drop_line
+  (* World-state headings can appear in user-authored long-term memory.
+     Only explicit prompt/internal sources control history routing. *)
+  ignore content;
+  if Keeper_types.is_prompt_history_source source then Drop_line
   else if Keeper_types.is_internal_history_source source then
     Move_internal
   else Keep_main

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -108,9 +108,8 @@ let write_heartbeat_snapshot
                let content =
                  Safe_ops.json_string ~default:"" "content" json |> String.trim
                in
-               if Keeper_types.is_prompt_history_source source
-                  || Keeper_context_core.has_world_state_signature content
-               then None
+               ignore content;
+               if Keeper_types.is_prompt_history_source source then None
                else Some (Keeper_context_core.message_of_json json)
              with
              | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -632,7 +632,6 @@ let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
            in
            if content = ""
               || Keeper_types.is_internal_history_source source
-              || Keeper_context_core.has_world_state_signature content
            then None
            else Some content
          else None

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1314,17 +1314,22 @@ let prepare_agent_setup
   in
   let hooks = Oas.Hooks.compose ~outer:before_turn_hook ~inner:base_hooks in
   let base_dir = Coord.masc_root_dir config in
-  let memory =
-    Memory_oas_bridge.create_memory
+  let memory_session_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  let memory_backend =
+    Memory_oas_bridge.make_backend
       ~agent_name
       ~base_dir
-      ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+      ~session_id:memory_session_id
       ()
+  in
+  let memory =
+    Oas.Memory.create ~long_term:memory_backend ()
   in
   let hooks =
     let mem_hooks =
       Memory_hooks.make
         ~agent_name ~config ~memory
+        ~world_backend:memory_backend
         ~episode_limit:30
         ~procedure_limit:10 ()
     in

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -756,8 +756,8 @@ let handle_keeper_status ctx args : tool_result =
                      in
                      let role_lc = String.lowercase_ascii role in
                      let is_internal =
+                       ignore content;
                        Keeper_types.is_internal_history_source source
-                       || Keeper_context_core.has_world_state_signature content
                      in
                      let entry_kind =
                        match source, role_lc with

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -251,16 +251,17 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
            name)
         "SOUL.md"
     in
-    let soul_content =
+    let soul_content, soul_fallback =
       if not (Fs_compat.file_exists soul_path) then (
         Log.Keeper.info "SOUL.md not found for %s (%s)" name soul_path;
-        "")
+        "", Printf.sprintf "SOUL.md not found for %s (%s)." name soul_path)
       else
         match Safe_ops.read_file_safe soul_path with
-        | Ok c -> c
+        | Ok c -> c, ""
         | Error e ->
             Log.Keeper.warn "SOUL.md read failed for %s (%s): %s" name soul_path e;
-            ""
+            "",
+            Printf.sprintf "SOUL.md read failed for %s (%s): %s" name soul_path e
     in
     let base_instructions_opt =
       match instructions_arg with
@@ -268,11 +269,17 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       | None -> profile_defaults.instructions
     in
     let instructions_opt =
-      if soul_content <> "" then
-        let base = Option.value ~default:"" base_instructions_opt in
-        Some (base ^ "\n\n[SYSTEM: SOUL INFUSION]\n" ^ soul_content)
-      else
-        base_instructions_opt
+      let base = Option.value ~default:"" base_instructions_opt in
+      let soul_section =
+        if soul_content <> "" then soul_content else soul_fallback
+      in
+      let infused =
+        if base = "" then
+          "[SYSTEM: SOUL INFUSION]\n" ^ soul_section
+        else
+          base ^ "\n\n[SYSTEM: SOUL INFUSION]\n" ^ soul_section
+      in
+      Some infused
     in
     let will_opt = parse_self_model_opt args "will" in
     let needs_opt = parse_self_model_opt args "needs" in

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -28,13 +28,19 @@
 
     Pure: no side effects, no OAS state mutation. *)
 let render_memory_context
+    ?memory
+    ?world_backend
     ~(agent_name : string)
     ~(config : Coord_utils.config)
     ~(episode_limit : int)
     ~(procedure_limit : int)
+    ?(world_limit = 8)
     () : string option =
   let sections =
     [ Memory_oas_bridge.load_institution_text ~config
+    ; Option.bind memory (fun memory ->
+        Memory_oas_bridge.load_world_text ~backend:world_backend
+          ~memory ~limit:world_limit)
     ; Memory_oas_bridge.load_episodes_text ~limit:episode_limit
     ; Memory_oas_bridge.load_procedures_text ~agent_name ~limit:procedure_limit
     ]
@@ -65,6 +71,7 @@ let make
     ~(agent_name : string)
     ~(config : Coord_utils.config)
     ~(memory : Oas.Memory.t)
+    ?world_backend
     ?(episode_limit = 30)
     ?(procedure_limit = 10)
     () : Oas.Hooks.hooks =
@@ -74,7 +81,7 @@ let make
       match event with
       | Oas.Hooks.BeforeTurnParams { current_params; _ } ->
         let memory_ctx =
-          render_memory_context ~agent_name ~config
+          render_memory_context ~memory ?world_backend ~agent_name ~config
             ~episode_limit ~procedure_limit ()
         in
         (match memory_ctx with

--- a/lib/memory_hooks.mli
+++ b/lib/memory_hooks.mli
@@ -20,10 +20,13 @@
     - [before_turn_params]: injects memory text via [extra_system_context]
     - [after_turn]: incrementally flushes episodes/procedures *)
 val render_memory_context :
+  ?memory:Agent_sdk.Memory.t ->
+  ?world_backend:Agent_sdk.Memory.long_term_backend ->
   agent_name:string ->
   config:Coord_utils.config ->
   episode_limit:int ->
   procedure_limit:int ->
+  ?world_limit:int ->
   unit ->
   string option
 
@@ -31,6 +34,7 @@ val make :
   agent_name:string ->
   config:Coord_utils.config ->
   memory:Agent_sdk.Memory.t ->
+  ?world_backend:Agent_sdk.Memory.long_term_backend ->
   ?episode_limit:int ->
   ?procedure_limit:int ->
   unit ->

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -809,6 +809,68 @@ let load_procedures_text ~(agent_name : string) ~(limit : int) : string option =
     Some (Printf.sprintf "[procedural memory: %d procedures]\n%s"
       (List.length ps) (String.concat "\n" lines))
 
+let compact_world_text raw =
+  raw
+  |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)
+  |> String_util.utf8_safe ~max_bytes:603 ~suffix:"..."
+  |> String_util.to_string
+
+let take_unique_entries limit entries =
+  if limit <= 0 then
+    []
+  else
+    let seen = Hashtbl.create (limit + 1) in
+    let rec loop remaining acc = function
+      | [] -> List.rev acc
+      | _ when remaining <= 0 -> List.rev acc
+      | (key, value) :: rest ->
+          if Hashtbl.mem seen key then
+            loop remaining acc rest
+          else begin
+            Hashtbl.replace seen key ();
+            loop (remaining - 1) ((key, value) :: acc) rest
+          end
+    in
+    loop limit [] entries
+
+let memory_context_query ~(memory : Oas.Memory.t) ~prefix ~limit =
+  let ctx = Oas.Memory.context memory in
+  Oas.Context.keys_in_scope ctx (Oas.Context.Custom "lt")
+  |> List.filter (fun key -> String.starts_with ~prefix key)
+  |> List.filter_map (fun key ->
+         match Oas.Context.get_scoped ctx (Oas.Context.Custom "lt") key with
+         | Some value -> Some (key, value)
+         | None -> None)
+  |> take_unique_entries limit
+
+let load_world_text
+    ~backend
+    ~(memory : Oas.Memory.t)
+    ~(limit : int) : string option =
+  let entries =
+    let backend_entries =
+      match backend with
+      | Some backend -> backend.Oas.Memory.query ~prefix:"world" ~limit
+      | None -> []
+    in
+    take_unique_entries limit
+      (backend_entries @ memory_context_query ~memory ~prefix:"world" ~limit)
+  in
+  match entries with
+  | [] -> None
+  | rows ->
+    let lines =
+      List.map
+        (fun (key, json) ->
+          Printf.sprintf "- %s: %s" key
+            (json |> content_of_json |> compact_world_text))
+        rows
+    in
+    Some
+      (Printf.sprintf "[world memory: %d entries]\n%s"
+         (List.length rows)
+         (String.concat "\n" lines))
+
 (** Load institutional memory as a text block for system context injection.
 
     Returns [None] when no institution config is available.

--- a/lib/memory_oas_bridge.mli
+++ b/lib/memory_oas_bridge.mli
@@ -168,6 +168,17 @@ val load_procedures_text :
     renders them for prompt injection.  Same fail-soft
     contract as {!load_episodes_text}. *)
 
+val load_world_text :
+  backend:Oas.Memory.long_term_backend option ->
+  memory:Oas.Memory.t ->
+  limit:int ->
+  string option
+(** Reads long-term OAS memory entries whose keys start with
+    ["world"] and renders them for prompt injection.  This is
+    intentionally sourced from [Oas.Memory.t] rather than keeper
+    runtime state so user-authored world memory can reach the
+    deliberation/prompt path. *)
+
 val load_institution_text :
   config:Coord_utils.config -> string option
 (** Reads the structured [institution.json] under [config]

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -354,16 +354,19 @@ let test_load_history_user_messages_ignores_internal_prompt_entries () =
     let lines = [
       {|{"role":"user","source":"world_state_prompt","content":"## Current World State\n\n### Namespace State\n- Unclaimed tasks: 1\n\n### Available Tools\n- keeper_board_list\n\n### Continuity\nGoal: keep going"}|};
       {|{"role":"user","content":"real user question"}|};
-      {|{"role":"user","content":"[Summary]\n[User] ## Current World State\n\n### Namespace State\n- Unclaimed tasks: 1\n\n### Available Tools\n- keeper_board_list\n\n### Continuity\nGoal: keep going"}|};
+      {|{"role":"user","source":"memory_jsonl","content":"## Current World State\n\n### Namespace State\n- User-authored world memory should survive history filtering"}|};
       {|{"role":"user","content":"second real question"}|};
     ] in
     let oc = open_out path in
     List.iter (fun l -> output_string oc (l ^ "\n")) lines;
     close_out oc;
     let result = Keeper_memory_recall.load_history_user_messages ~path ~max_n:10 in
-    check int "only real user messages kept" 2 (List.length result);
+    check int "prompt source dropped, user-authored world kept" 3 (List.length result);
     check string "first real" "real user question" (List.hd result);
-    check string "second real" "second real question" (List.nth result 1))
+    check string "world memory kept"
+      "## Current World State\n\n### Namespace State\n- User-authored world memory should survive history filtering"
+      (List.nth result 1);
+    check string "second real" "second real question" (List.nth result 2))
 
 let test_recall_candidates_with_history_dedup () =
   let dir = test_tmpdir () in

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -13,7 +13,19 @@ open Alcotest
 module Memory_oas_bridge = Masc_mcp.Memory_oas_bridge
 module Memory_hooks = Masc_mcp.Memory_hooks
 
+let test_base_path = Filename.temp_dir "masc_memory_hooks_base" ""
+let () = Unix.putenv "MASC_BASE_PATH" test_base_path
+
 (* ── Test helpers ──────────────────────────────────────────── *)
+
+let contains_text ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    idx + needle_len <= haystack_len
+    && (String.sub haystack idx needle_len = needle || loop (idx + 1))
+  in
+  needle_len = 0 || loop 0
 
 let make_test_config ~base_path : Coord_utils.config =
   let backend_config : Backend_types.config = {
@@ -122,6 +134,42 @@ let test_hook_preserves_existing_context () =
    | _ -> fail "unexpected hook decision");
   (try Sys.rmdir tmp_dir with _ -> ())
 
+let test_hook_injects_world_memory () =
+  let tmp_dir = Filename.temp_dir "masc_test_mh" "" in
+  let config = make_test_config ~base_path:tmp_dir in
+  let memory = Agent_sdk.Memory.create () in
+  ignore
+    (Agent_sdk.Memory.store
+       memory
+       ~tier:Agent_sdk.Memory.Long_term
+       "world:mission"
+       (`Assoc [ "content", `String "Bridge the world memory into prompt context." ]));
+  let hooks =
+    Memory_hooks.make
+      ~agent_name:"test_world"
+      ~config
+      ~memory
+      ()
+  in
+  let event = make_before_turn_params_event ~turn:1 () in
+  let decision =
+    match hooks.before_turn_params with
+    | Some f -> f event
+    | None -> fail "before_turn_params hook should be Some"
+  in
+  (match decision with
+   | Agent_sdk.Hooks.AdjustParams params ->
+     (match params.extra_system_context with
+      | Some ctx ->
+        check bool "world section present" true
+          (contains_text ~needle:"[world memory:" ctx);
+        check bool "world key present" true
+          (contains_text ~needle:"world:mission" ctx)
+      | None -> fail "world memory should inject extra_system_context")
+   | Agent_sdk.Hooks.Continue -> fail "world memory should adjust params"
+   | _ -> fail "unexpected hook decision");
+  (try Sys.rmdir tmp_dir with _ -> ())
+
 let test_after_turn_hook_returns_continue () =
   let tmp_dir = Filename.temp_dir "masc_test_mh" "" in
   let config = make_test_config ~base_path:tmp_dir in
@@ -195,6 +243,7 @@ let () =
     "hook_decisions", [
       test_case "returns Continue when no memory" `Quick test_hook_returns_continue_when_no_memory;
       test_case "preserves existing context" `Quick test_hook_preserves_existing_context;
+      test_case "injects world memory" `Quick test_hook_injects_world_memory;
       test_case "after_turn returns Continue" `Quick test_after_turn_hook_returns_continue;
     ];
     "hook_structure", [


### PR DESCRIPTION
## Summary

Fixes the dashboard/keeper bottleneck slice across filesystem indexing, board persistence, world-memory prompt injection, and operation projection.

Companion OAS PR: https://github.com/jeong-sik/oas/pull/1276

## Root Cause

- Dashboard refresh could trigger `FileSystem.exists`, which forced `ensure_key_index` and recursively scanned the backend while boot was already populating the key index.
- Board vote flush rewrote full post/comment/vote JSONL state under the exclusive board lock, blocking writes during periodic flush.
- User-authored `world*` long-term memory was not connected to prompt injection, and world-state-looking content was filtered from history by content signature rather than source.
- Operation contexts were hardcoded to `[]`, so dashboard operation surfaces could not show task-linked work.

## Changes

- Make filesystem `exists` use direct stat only, and make non-empty `list_keys ~prefix` scan only the relevant prefix subtree.
- Track dirty board post/comment IDs and flush append-only snapshots outside the board lock; keep delete/reclassify rewrites explicit.
- Add world-memory prompt rendering from OAS long-term memory/context and wire keeper run setup to pass the memory backend into hooks.
- Route history filtering by explicit source instead of dropping every world-state signature.
- Always include a `[SYSTEM: SOUL INFUSION]` section, including a clear missing/read-failed SOUL fallback.
- Project non-terminal tasks into dashboard operation contexts for execution and mission surfaces.

## Operator Impact

- Cold boot key-index population should no longer stall dashboard refresh through an incidental `exists` call.
- Board writes should not freeze behind the 30-second full rewrite flush path.
- User-authored world memory can appear in prompt context instead of silently disappearing.
- Operations are visible from task contracts rather than being permanently empty.

## Validation

- `scripts/dune-local.sh build test/test_backend.exe test/test_memory_hooks.exe test/test_keeper_memory.exe test/test_dashboard_execution.exe test/test_dashboard_mission.exe`
- `./_build/default/test/test_backend.exe`
- `./_build/default/test/test_memory_hooks.exe`
- `./_build/default/test/test_keeper_memory.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 ./_build/default/test/test_dashboard_execution.exe`
- `./_build/default/test/test_dashboard_mission.exe`
- `scripts/dune-local.sh build test/test_board_vote_quarantine.exe test/test_board_ttl.exe test/test_board_dispatch.exe test/test_board_core_payload.exe`
- `./_build/default/test/test_board_vote_quarantine.exe`
- `env MASC_BASE_PATH=/tmp/masc_board_ttl_test ./_build/default/test/test_board_ttl.exe`
- `./_build/default/test/test_board_dispatch.exe`
- `./_build/default/test/test_board_core_payload.exe`
- `git diff --check`