### PR TITLE
fix(keeper): close-paren regression in keeper_exec_fs after #12304

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -129,7 +129,7 @@ let handle_keeper_fs_read
              ; "bytes", `Int total
              ; "truncated", `Bool truncated
              ; "content", `String body
-             ])))
+             ]))))
 ;;
 
 (* RFC-0006 Phase A.4: replace [old] with [new] in [text]. When
@@ -293,7 +293,7 @@ let handle_keeper_fs_edit
           | Sys_error e -> error_json ~fields:[ "path", `String target ] e
           | Unix.Unix_error (err, _, _) ->
             error_json ~fields:[ "path", `String target ]
-              (Unix.error_message err))))
+              (Unix.error_message err)))))
   | Some ((Overwrite | Append) as mode) ->
   let mode_label = fs_write_mode_to_string mode in
   if String.trim content = "" then
@@ -356,5 +356,5 @@ let handle_keeper_fs_edit
     | Invalid_argument e -> error_json ~fields:[ "path", `String target ] e
      | Sys_error e -> error_json ~fields:[ "path", `String target ] e
      | Unix.Unix_error (err, _, _) ->
-       error_json ~fields:[ "path", `String target ] (Unix.error_message err)))
+       error_json ~fields:[ "path", `String target ] (Unix.error_message err))))
 ;;


### PR DESCRIPTION
## Summary

🚨 **Main blocker** — PR #12304 (multi-repository architecture) added \`Keeper_repo_mapping.validate_path_access\` checks to three keeper_fs_* handlers but didn't add the matching closing parens. **Main has been unbuildable since the merge.**

## Symptom

\`\`\`
Error: Syntax error: ) expected
File "lib/keeper/keeper_exec_fs.ml", line 80, characters 4-5:
  This ( might be unmatched
\`\`\`

## Fix

Add one closing \`)\` at each of three closing blocks:

| Handler | Line | Before | After |
|---------|------|--------|-------|
| keeper_fs_read | 132 | \`])))\` | \`]))))\` |
| keeper_fs_edit (Patch) | 296 | \`))))\` | \`)))))\` |
| keeper_fs_edit (Overwrite/Append) | 359 | \`)))\` | \`))))\` |

Each handler opened a new \`(match Keeper_repo_mapping ... with\` block; this PR closes it.

## Why this slipped through

The OCaml build CI either ran on a different code state or was bypassed by admin merge (memory: \`feedback_admin_merge_can_bypass_build_ci\`). All open PRs are blocked on this. **Not a Draft** — should merge ASAP to unblock the queue.

## Test plan

- [x] \`dune build --root .\` GREEN