### PR TITLE
fix(keeper): close fs match expressions

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -129,7 +129,7 @@ let handle_keeper_fs_read
              ; "bytes", `Int total
              ; "truncated", `Bool truncated
              ; "content", `String body
-             ])))
+             ]))))
 ;;
 
 (* RFC-0006 Phase A.4: replace [old] with [new] in [text]. When
@@ -293,7 +293,7 @@ let handle_keeper_fs_edit
           | Sys_error e -> error_json ~fields:[ "path", `String target ] e
           | Unix.Unix_error (err, _, _) ->
             error_json ~fields:[ "path", `String target ]
-              (Unix.error_message err))))
+              (Unix.error_message err)))))
   | Some ((Overwrite | Append) as mode) ->
   let mode_label = fs_write_mode_to_string mode in
   if String.trim content = "" then
@@ -356,5 +356,5 @@ let handle_keeper_fs_edit
     | Invalid_argument e -> error_json ~fields:[ "path", `String target ] e
      | Sys_error e -> error_json ~fields:[ "path", `String target ] e
      | Unix.Unix_error (err, _, _) ->
-       error_json ~fields:[ "path", `String target ] (Unix.error_message err)))
+       error_json ~fields:[ "path", `String target ] (Unix.error_message err))))
 ;;


### PR DESCRIPTION
## Summary
- Close the nested read/write match expressions in `keeper_exec_fs` that were left one parenthesis short.
- Restore compilation for keeper FS read/edit paths before the OAS pin update.

## Validation
- `git diff --check`
- `./scripts/dune-local.sh build ./test/test_ci_hardening_source.exe ./test/test_oas_compat_cascade_fallback.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `./_build/default/test/test_oas_compat_cascade_fallback.exe`