### PR TITLE
refactor(cascade): type inference cascade lookup names

### DIFF
--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -137,15 +137,18 @@ let generate_code_change ~goal ~baseline ~lower_is_better ~history ~insights
   end else
   let prompt = build_code_change_prompt ~goal ~baseline ~lower_is_better ~history ~insights
     ~file_content ~target_file in
+  let inference_cascade_name =
+    Keeper_cascade_profile.Runtime_name "autoresearch"
+  in
   match
     Masc_oas_bridge.run_with_caller
       ~caller:Env_config_oas_bridge.Autoresearch_codegen (fun () ->
       Oas_worker.run_named ~cascade_name:"autoresearch"
         ~goal:prompt ~max_turns:1
         ~temperature:(Cascade_inference.resolve_temperature
-          ~cascade_name:"autoresearch" ~fallback:(fun () -> 0.7))
+          ~cascade_name:inference_cascade_name ~fallback:(fun () -> 0.7))
         ~max_tokens:(Cascade_inference.resolve_max_tokens
-          ~cascade_name:"autoresearch" ~fallback:(fun () -> 4096))
+          ~cascade_name:inference_cascade_name ~fallback:(fun () -> 4096))
         ~approval:Approval_callbacks.auto_approve
         ()
     )

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -68,13 +68,19 @@ let for_cascade ~(name : string) : t =
       empty
 
 (** Resolve a temperature value: cascade config -> fallback. *)
-let resolve_temperature ~(cascade_name : string) ~(fallback : unit -> float) : float =
+let resolve_temperature
+    ~(cascade_name : Keeper_cascade_profile.runtime_name)
+    ~(fallback : unit -> float) : float =
+  let cascade_name = Keeper_cascade_profile.runtime_name_to_string cascade_name in
   match (for_cascade ~name:cascade_name).temperature with
   | Some t -> t
   | None -> fallback ()
 
 (** Resolve a max_tokens value: cascade config -> fallback. *)
-let resolve_max_tokens ~(cascade_name : string) ~(fallback : unit -> int) : int =
+let resolve_max_tokens
+    ~(cascade_name : Keeper_cascade_profile.runtime_name)
+    ~(fallback : unit -> int) : int =
+  let cascade_name = Keeper_cascade_profile.runtime_name_to_string cascade_name in
   match (for_cascade ~name:cascade_name).max_tokens with
   | Some t -> t
   | None -> fallback ()

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -33,11 +33,17 @@ val for_json : name:string -> Yojson.Safe.t -> t
 
 (** Resolve a temperature value with cascade config priority.
     Returns cascade config value if present, otherwise calls [fallback]. *)
-val resolve_temperature : cascade_name:string -> fallback:(unit -> float) -> float
+val resolve_temperature :
+  cascade_name:Keeper_cascade_profile.runtime_name ->
+  fallback:(unit -> float) ->
+  float
 
 (** Resolve a max_tokens value with cascade config priority.
     Returns cascade config value if present, otherwise calls [fallback]. *)
-val resolve_max_tokens : cascade_name:string -> fallback:(unit -> int) -> int
+val resolve_max_tokens :
+  cascade_name:Keeper_cascade_profile.runtime_name ->
+  fallback:(unit -> int) ->
+  int
 
 (** Clamp max_tokens to provider ceiling.
 

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -426,9 +426,13 @@ let execute_single_agent_run ~sw ~net ~run_id ~provider ~model ~prompt =
                 ~system_prompt:(run_system_prompt provider)
                 ~max_turns:4
                 ~max_tokens:(Cascade_inference.resolve_max_tokens
-                  ~cascade_name:"provider_benchmark" ~fallback:(fun () -> 2048))
+                  ~cascade_name:
+                    (Keeper_cascade_profile.Runtime_name "provider_benchmark")
+                  ~fallback:(fun () -> 2048))
                 ~temperature:(Cascade_inference.resolve_temperature
-                  ~cascade_name:"provider_benchmark" ~fallback:(fun () -> 0.2))
+                  ~cascade_name:
+                    (Keeper_cascade_profile.Runtime_name "provider_benchmark")
+                  ~fallback:(fun () -> 0.2))
                 ~sw ?net
                 ()
             )

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -44,18 +44,22 @@ let prepare_run_context
   let receipt_started_at = Types.now_iso () in
   let meta = Keeper_agent_tool_surface.sync_current_task_id_from_backlog ~config meta in
   (* 0. Resolve inference parameters via Cascade_inference *)
+  let inference_cascade_name =
+    Keeper_cascade_profile.Runtime_name cascade_name
+  in
   let temperature =
     match temperature with
     | Some t -> t
     | None ->
-      Cascade_inference.resolve_temperature ~cascade_name ~fallback:(fun () -> 0.3)
+      Cascade_inference.resolve_temperature
+        ~cascade_name:inference_cascade_name ~fallback:(fun () -> 0.3)
   in
   let max_tokens =
     match max_tokens with
     | Some t -> t
     | None ->
       Cascade_inference.resolve_max_tokens
-        ~cascade_name
+        ~cascade_name:inference_cascade_name
           (* 8192 allows complex multi-tool reasoning per turn.
            Cloudflare tunnel 100s is no longer a constraint with
            streaming responses. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -258,12 +258,18 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   resolved_max_context_for_turn ~meta model_labels
                 in
                 let temperature =
+                  let cascade_name =
+                    Keeper_cascade_profile.Runtime_name cascade_name
+                  in
                   Cascade_inference.resolve_temperature
                     ~cascade_name
                     ~fallback:Keeper_config.keeper_unified_temperature
                 in
                 let max_tokens =
                   let raw =
+                    let cascade_name =
+                      Keeper_cascade_profile.Runtime_name cascade_name
+                    in
                     Cascade_inference.resolve_max_tokens
                       ~cascade_name
                       ~fallback:Keeper_config.keeper_unified_max_tokens


### PR DESCRIPTION
## Summary
- Refs #11926.
- Type `Cascade_inference.resolve_temperature` and `resolve_max_tokens` cascade lookup names as `Keeper_cascade_profile.runtime_name`.
- Wrap caller-provided runtime cascade labels at the call sites and render only inside `Cascade_inference` before catalog lookup.
- Preserve existing named-cascade lookup behavior and operator-facing labels.

## Product impact
Inference parameter resolution no longer accepts raw `cascade_name:string` at its public lookup boundary. This continues the C-T7.2 cascade_name string-surface reduction while keeping catalog resolution semantics unchanged.

## Validation
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_oas_worker.exe`
- `./_build/default/test/test_oas_worker.exe test cascade_config 6`
- `./_build/default/test/test_keeper_unified.exe test phase_gate 20-22`
- Post-rebase `git diff --check HEAD~1 HEAD`
- Post-rebase `scripts/ocaml-structure-ratchet.sh && scripts/stringly-boundary-ratchet.sh` -> `cascade_name 53 / 81`

## Notes
An earlier build attempt failed on the then-current main `keeper_exec_fs.ml` syntax regression; #12313/#12314 fixed that and this branch was rebased before final validation.