### PR TITLE
[codex] Fix repo manager yojson defaults

### DIFF
--- a/lib/repo_manager/repo_manager_types.ml
+++ b/lib/repo_manager/repo_manager_types.ml
@@ -34,9 +34,9 @@ type credential = {
   id : string;
   cred_type : credential_type;
   username : string;
-  gh_config_dir : string option; [@default None]
-  ssh_key_path : string option; [@default None]
-  gpg_key_id : string option; [@default None]
+  gh_config_dir : string option [@default None];
+  ssh_key_path : string option [@default None];
+  gpg_key_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]
 

--- a/lib/repo_manager/repo_manager_types.mli
+++ b/lib/repo_manager/repo_manager_types.mli
@@ -34,9 +34,9 @@ type credential = {
   id : string;
   cred_type : credential_type;
   username : string;
-  gh_config_dir : string option; [@default None]
-  ssh_key_path : string option; [@default None]
-  gpg_key_id : string option; [@default None]
+  gh_config_dir : string option [@default None];
+  ssh_key_path : string option [@default None];
+  gpg_key_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]
 


### PR DESCRIPTION
## Summary

Moves repo manager credential option-field defaults onto the fields so the yojson default lint recognizes them.

## Why

PR #12311 merged while the yojson option default gate was failing on these pre-existing fields. This follow-up unblocks the lint gate without changing runtime behavior.

## Validation

- `python3 scripts/lint/yojson-option-default.py`
- `scripts/dune-local.sh build @lib/repo_manager/all`
- `git diff --check HEAD~1..HEAD`