### PR TITLE
refactor(dashboard): merge 4 connector sub-tabs into connector-status

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -42,21 +42,14 @@ import { createManagedAsyncResource } from '../lib/async-state'
 import { route } from '../router'
 import { Tk } from './tk'
 
-// Sub-section -> connector_id filter. `connector-status` (default) shows
-// all connectors; the per-connector sub-sections show just that one. Source
-// of truth: dashboard/src/config/navigation.ts DASHBOARD_SECTION_ITEMS.connectors.
-const SECTION_TO_CONNECTOR_ID: Record<string, string | null> = {
-  'connector-status': null,
-  'connector-discord': 'discord',
-  'connector-imessage': 'imessage',
-  'connector-slack': 'slack',
-  'connector-telegram': 'telegram',
-}
-
+// As of 2026-04-30 the per-connector sub-tabs were merged into
+// connector-status; selection now happens inside the page via
+// ConnectorOverviewStrip rather than top-level navigation.
+// `?connector=<id>` query parameter still narrows the view for deep links.
 function activeConnectorFilter(): string | null {
-  const section = route.value.params.section
-  if (!section) return null
-  return SECTION_TO_CONNECTOR_ID[section] ?? null
+  const connector = route.value.params.connector
+  if (!connector) return null
+  return KNOWN_CONNECTOR_IDS.includes(connector as KnownConnectorId) ? connector : null
 }
 
 // Per-connector lifecycle hints. All four sidecars now ship a run.sh wrapper

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -38,25 +38,13 @@ describe('command navigation', () => {
   })
 })
 
-describe('connectors navigation (Phase 7)', () => {
-  it('exposes connectors as a top-level surface with all + per-bridge sub-sections', () => {
+describe('connectors navigation (Phase 7, post-2026-04-30 merge)', () => {
+  it('exposes connectors as a top-level surface with a single all-connectors section', () => {
     expect(defaultParamsForTab('connectors')).toEqual({ section: 'connector-status' })
 
     const sections = visibleSectionItemsForTab('connectors')
-    expect(sections.map(item => item.id)).toEqual([
-      'connector-status',
-      'connector-discord',
-      'connector-imessage',
-      'connector-slack',
-      'connector-telegram',
-    ])
-    expect(sections.map(item => item.label)).toEqual([
-      '전체',
-      'Discord',
-      'iMessage',
-      'Slack',
-      'Telegram',
-    ])
+    expect(sections.map(item => item.id)).toEqual(['connector-status'])
+    expect(sections.map(item => item.label)).toEqual(['전체'])
   })
 
   it('normalizes unknown connectors section to default', () => {
@@ -64,9 +52,12 @@ describe('connectors navigation (Phase 7)', () => {
     expect(result.section).toBe('connector-status')
   })
 
-  it('preserves a valid per-bridge section through normalize', () => {
+  it('redirects legacy per-bridge section deep links to connector-status', () => {
+    // The four per-sidecar sub-tabs were merged into the single
+    // all-connectors view on 2026-04-30; deep links to the old
+    // section ids fall back to the default.
     const result = normalizeRouteParams('connectors', { section: 'connector-slack' })
-    expect(result.section).toBe('connector-slack')
+    expect(result.section).toBe('connector-status')
   })
 })
 

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -18,11 +18,10 @@ type SurfaceSectionId =
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + inspector (Phase 7: connectors split out)
   // connectors (Phase 7: top-level surface — sidecar-driven channel bridges)
-  | 'connector-status'      // all connectors (default)
-  | 'connector-discord'
-  | 'connector-imessage'
-  | 'connector-slack'
-  | 'connector-telegram'
+  // Per-connector sub-tabs (discord/imessage/slack/telegram) were merged into
+  // connector-status on 2026-04-30; selection happens inside the page via
+  // ConnectorOverviewStrip rather than top-level navigation.
+  | 'connector-status'      // all connectors with internal connector picker
   // workspace
   | 'board'
   | 'planning'       // Phase 1: absorbs goals
@@ -221,32 +220,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'connector-status',
       label: '전체',
-      description: '4개 sidecar(Discord/iMessage/Slack/Telegram)를 한 화면에서.',
+      description: '4개 sidecar(Discord/iMessage/Slack/Telegram)를 한 화면에서. 페이지 내부에서 connector를 선택해 자세히 봅니다.',
       params: { section: 'connector-status' },
-    },
-    {
-      id: 'connector-discord',
-      label: 'Discord',
-      description: 'Discord sidecar — 라이브 상태, keeper 바인딩, 채널, 최근 이벤트.',
-      params: { section: 'connector-discord' },
-    },
-    {
-      id: 'connector-imessage',
-      label: 'iMessage',
-      description: 'iMessage sidecar — chat.db 폴링, self-chat 모드, 라이브 상태.',
-      params: { section: 'connector-imessage' },
-    },
-    {
-      id: 'connector-slack',
-      label: 'Slack',
-      description: 'Slack sidecar — Socket Mode, bot/app 토큰, 라이브 상태.',
-      params: { section: 'connector-slack' },
-    },
-    {
-      id: 'connector-telegram',
-      label: 'Telegram',
-      description: 'Telegram sidecar — BotFather 토큰, admin user IDs, 라이브 상태.',
-      params: { section: 'connector-telegram' },
     },
   ],
   workspace: [


### PR DESCRIPTION
## Summary

Connectors surface 의 5 sub-tab 중 per-sidecar 4개 (Discord/iMessage/Slack/Telegram) 를 제거하고 connector-status 하나로 통합했습니다. 페이지 내부 `ConnectorOverviewStrip` picker가 이미 동일 기능을 가지고 있어 sidebar 의 4 sub-tab 은 redundant 였습니다.

사용자 의도 (\"느낌이 같은 거 합치든가\") 직접 대응. plan `planning/claude-plans/zany-yawning-nebula.md` 의 autonomous cleanup track.

## Changes

- `navigation.ts`: `DASHBOARD_SECTION_ITEMS.connectors` 5 → 1 entry, `SurfaceSectionId` union 4 entry 제거
- `connector-status.ts`: dead `SECTION_TO_CONNECTOR_ID` map 제거, `?connector=<id>` query param 으로 대체. 페이지 내부 picker 가 single source

## Backward compatibility

- legacy deep link `?section=connector-discord` 는 normalizeRouteParams 가 default `connector-status` 로 redirect (validSectionIds 가 4 entry 인식 안 함). 4 sidecar 의 deep link 가 연결된 외부 자료 (북마크 등) 가 있으면 한 단계 redirect 후 도달.
- 새 deep link 형식: `?section=connector-status&connector=discord` (?connector= 가 KnownConnectorId 일 때만 필터링)

## Test plan

- [x] `pnpm typecheck` pass
- [x] `pnpm test src/config/navigation.test.ts` pass (exit 0)
- [ ] CI green (Dashboard / Lint / Build)
- [ ] manual: `#connectors/connector-status` 진입 시 ConnectorOverviewStrip picker 동작 확인

## Future enhancement (out of scope)

- ConnectorOverviewStrip picker 가 클릭 시 `?connector=` URL 을 set 하도록 wire (deep linkability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)