### PR TITLE
refactor(cascade): type inventory cascade names

### DIFF
--- a/lib/cascade/cascade_inventory.ml
+++ b/lib/cascade/cascade_inventory.ml
@@ -19,7 +19,7 @@ let score_provider health ~exclude ~keeper_assignable
       success *. latency
 
 type scored_provider = {
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
   provider : Llm_provider.Provider_config.t;
   score : float;
 }

--- a/lib/cascade/cascade_inventory.mli
+++ b/lib/cascade/cascade_inventory.mli
@@ -49,7 +49,7 @@ val score_provider :
 
 (** A provider scored against a snapshot of fleet state. *)
 type scored_provider = {
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
   provider : Llm_provider.Provider_config.t;
   score : float;
 }

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -325,6 +325,9 @@ let resolve_tool_capable_provider_across_cascades
                  | _ -> Some (cascade_name, filtered))
         |> List.concat_map (fun (cascade_name, providers) ->
              let keeper_assignable = is_keeper_assignable cascade_name in
+             let inventory_cascade_name =
+               Keeper_cascade_profile.Runtime_name cascade_name
+             in
              providers
              |> List.map (fun (provider : Llm_provider.Provider_config.t) ->
                   let score =
@@ -334,7 +337,8 @@ let resolve_tool_capable_provider_across_cascades
                       ~keeper_assignable
                       provider
                   in
-                  Cascade_inventory.{ cascade_name; provider; score }))
+                  Cascade_inventory.
+                    { cascade_name = inventory_cascade_name; provider; score }))
       in
       (* The score_provider helper already collapses cooldown,
          keeper_assignable, and the success × latency composition into a
@@ -349,4 +353,5 @@ let resolve_tool_capable_provider_across_cascades
         ~exclude:[]
         scored_candidates
       |> Option.map (fun (sp : Cascade_inventory.scored_provider) ->
-           (sp.cascade_name, sp.provider))
+           ( Keeper_cascade_profile.runtime_name_to_string sp.cascade_name,
+             sp.provider ))

--- a/test/test_cascade_inventory.ml
+++ b/test/test_cascade_inventory.ml
@@ -9,6 +9,7 @@ open Alcotest
 
 module H = Masc_mcp.Cascade_health_tracker
 module Inv = Masc_mcp.Cascade_inventory
+module Kcp = Masc_mcp.Keeper_cascade_profile
 
 (* Build a Provider_config.t from a cascade label, e.g.
    "codex_cli:gpt-5.3-codex" or "ollama:auto".  Reuses the existing
@@ -20,7 +21,12 @@ let provider_of_label label =
   | None -> fail ("expected model label to parse: " ^ label)
 
 let mk_scored ?(cascade_name = "test") ?(score = 0.0) label =
-  Inv.{ cascade_name; provider = provider_of_label label; score }
+  Inv.
+    {
+      cascade_name = Kcp.Runtime_name cascade_name;
+      provider = provider_of_label label;
+      score;
+    }
 
 (* ── score_provider ─────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

- Type `Cascade_inventory.scored_provider.cascade_name` as `Keeper_cascade_profile.runtime_name`.
- Wrap fleet fallback candidate names at the inventory boundary and render them back to strings only when returning to the existing cross-cascade fallback API.
- Update the inventory test fixture to construct typed cascade names.

## Product impact

This continues #11926's cascade-name boundary ratchet. Cross-cascade fallback inventory now carries a typed runtime cascade name internally, reducing raw string drift in the provider promotion path while preserving existing dashboard/log/metric labels.

## Evidence

- `scripts/dune-local.sh build test/test_cascade_inventory.exe test/test_oas_worker.exe`
- `./_build/default/test/test_cascade_inventory.exe`
- `./_build/default/test/test_oas_worker.exe test cascade_config 7`
- `git diff --check`
- `scripts/stringly-boundary-ratchet.sh` (`raw_cascade_name_string_signatures: 51 / 81`)
- `scripts/ocaml-structure-ratchet.sh`

Note: `./_build/default/test/test_oas_worker.exe test cascade_config 8-10` was attempted for adjacent metrics/audit coverage but produced no result for over 70s and was terminated; it is not counted as passing evidence.

## Review evidence

- Diff is limited to `Cascade_inventory`, its cross-cascade fallback caller, and the unit-test fixture.
- Existing public `resolve_tool_capable_provider_across_cascades` behavior still returns string cascade names to the Prometheus/log call sites.

## Linked issue

- Part of #11926
