### PR TITLE
fix(dashboard): surface goal FSM freshness explicitly

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -956,6 +956,27 @@ function decodeGoalTreeTask(raw: unknown): GoalTreeTask | null {
   }
 }
 
+function decodeGoalFsmProjection(raw: unknown, phase: string) {
+  if (!isRecord(raw)) {
+    return {
+      state: phase,
+      source: 'goal.phase',
+      state_kind: phase,
+      next_actions: [],
+      activity_observation: 'goal_metadata',
+      stagnation_status: 'recent',
+    }
+  }
+  return {
+    state: asString(raw.state, phase),
+    source: asString(raw.source, 'goal.phase'),
+    state_kind: asString(raw.state_kind, phase),
+    next_actions: asStringArray(raw.next_actions),
+    activity_observation: asString(raw.activity_observation, 'goal_metadata'),
+    stagnation_status: asString(raw.stagnation_status, 'recent'),
+  }
+}
+
 function decodeGoalKeeperTrustLatestEvent(raw: unknown): GoalKeeperTrustLatestEvent | null {
   if (!isRecord(raw)) return null
   const kind = asString(raw.kind)
@@ -1034,6 +1055,7 @@ function decodeGoalTreeNode(raw: unknown): GoalTreeNode | null {
     status_color: asString(raw.status_color, ''),
     phase: asString(raw.phase, 'unknown'),
     phase_color: asString(raw.phase_color, ''),
+    goal_fsm: decodeGoalFsmProjection(raw.goal_fsm, asString(raw.phase, 'unknown')),
     health: asString(raw.health, 'at_risk'),
     health_color: asString(raw.health_color, ''),
     badges: asStringArray(raw.badges),
@@ -1057,6 +1079,8 @@ function decodeGoalTreeNode(raw: unknown): GoalTreeNode | null {
     child_count: asInt(raw.child_count) ?? children.length,
     last_activity_at: asString(raw.last_activity_at, ''),
     stagnation_seconds: asInt(raw.stagnation_seconds) ?? 0,
+    activity_observation: asString(raw.activity_observation, 'goal_metadata'),
+    stagnation_status: asString(raw.stagnation_status, 'recent'),
     linked_keeper_names: asStringArray(raw.linked_keeper_names),
     pending_approval_count: asInt(raw.pending_approval_count) ?? 0,
     infra_risk_count: asInt(raw.infra_risk_count) ?? 0,

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { GoalTreeNode, GoalTreeTask } from '../../types'
-import { filterGoalTree, filterGoalTreeByPhase } from './goal-tree'
+import {
+  filterGoalTree,
+  filterGoalTreeByPhase,
+  goalFsmObservationLabel,
+  goalFsmStateKindLabel,
+  goalFsmStagnationLabel,
+} from './goal-tree'
 
 function makeTask(overrides: Partial<GoalTreeTask> = {}): GoalTreeTask {
   return {
@@ -28,6 +34,14 @@ function makeNode(overrides: Partial<GoalTreeNode> = {}): GoalTreeNode {
     status_color: '#fff',
     phase: 'executing',
     phase_color: '#0ea5e9',
+    goal_fsm: {
+      state: 'executing',
+      source: 'goal.phase',
+      state_kind: 'executing',
+      next_actions: ['request_complete', 'pause', 'operator_block', 'drop'],
+      activity_observation: 'goal_metadata',
+      stagnation_status: 'recent',
+    },
     health: 'on_track',
     health_color: '#4ade80',
     badges: [],
@@ -58,6 +72,8 @@ function makeNode(overrides: Partial<GoalTreeNode> = {}): GoalTreeNode {
     child_count: 0,
     last_activity_at: '2026-04-17T00:00:00Z',
     stagnation_seconds: 0,
+    activity_observation: 'goal_metadata',
+    stagnation_status: 'recent',
     linked_keeper_names: [],
     pending_approval_count: 0,
     infra_risk_count: 0,
@@ -196,6 +212,20 @@ describe('filterGoalTree', () => {
     })
     const result = filterGoalTree([root], 'anything')
     expect(result).toHaveLength(0)
+  })
+})
+
+describe('goal FSM labels', () => {
+  it('labels FSM state kinds separately from coarse health', () => {
+    expect(goalFsmStateKindLabel('verification_gate')).toBe('검증 게이트')
+    expect(goalFsmStateKindLabel('approval_gate')).toBe('승인 게이트')
+    expect(goalFsmStateKindLabel('executing')).toBe('실행')
+  })
+
+  it('labels metadata-only freshness as unobserved instead of stalled', () => {
+    expect(goalFsmObservationLabel('goal_metadata')).toBe('goal metadata only')
+    expect(goalFsmStagnationLabel('unobserved')).toBe('unobserved')
+    expect(goalFsmStagnationLabel('stalled')).toBe('stalled')
   })
 })
 

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -24,6 +24,7 @@ import type {
   DashboardCoordinationFsmViolation,
   GoalDetailKeeper,
   GoalDetailTimelineEvent,
+  GoalFsmProjection,
   GoalTreeNode,
   GoalTreeTask,
   GoalTreeSummary,
@@ -147,6 +148,7 @@ function badgeLabel(badge: string): string {
     case 'cascade': return 'Cascade'
     case 'task_verification_pending': return 'Task 검증 대기'
     case 'stalled': return '정체'
+    case 'activity_unobserved': return '활동 관측 부족'
     case 'linkage_warning': return '연결 경고'
     default: return badge
   }
@@ -159,6 +161,8 @@ function badgeClass(badge: string): string {
     case 'task_verification_pending':
     case 'stalled':
       return 'border-warn/30 bg-warn/10 text-warn'
+    case 'activity_unobserved':
+      return 'border-card-border/60 bg-[var(--white-4)] text-text-muted'
     case 'sandbox':
       return 'border-accent/30 bg-[var(--accent-10)] text-accent'
     case 'linkage_warning':
@@ -224,6 +228,62 @@ function blockerSourceClass(source: GoalTreeNode['blocking_source']): string {
     default:
       return 'border-card-border/60 bg-[var(--white-4)] text-text-body'
   }
+}
+
+export function goalFsmStateKindLabel(kind: GoalFsmProjection['state_kind']): string {
+  switch (kind) {
+    case 'executing': return '실행'
+    case 'verification_gate': return '검증 게이트'
+    case 'approval_gate': return '승인 게이트'
+    case 'blocked': return '차단'
+    case 'paused': return '일시정지'
+    case 'completed': return '완료'
+    case 'dropped': return '중단'
+    default: return kind
+  }
+}
+
+export function goalFsmObservationLabel(
+  observation: GoalFsmProjection['activity_observation'],
+): string {
+  switch (observation) {
+    case 'runtime': return 'runtime evidence'
+    case 'approval': return 'approval event'
+    case 'task': return 'task update'
+    case 'child': return 'child goal'
+    case 'goal_metadata': return 'goal metadata only'
+    default: return observation
+  }
+}
+
+export function goalFsmStagnationLabel(
+  status: GoalFsmProjection['stagnation_status'],
+): string {
+  switch (status) {
+    case 'recent': return 'recent'
+    case 'stalled': return 'stalled'
+    case 'unobserved': return 'unobserved'
+    default: return status
+  }
+}
+
+function GoalFsmBadge({ fsm }: { fsm: GoalFsmProjection }) {
+  const toneClass =
+    fsm.stagnation_status === 'stalled'
+      ? 'border-warn/30 bg-warn/10 text-warn'
+      : fsm.state_kind === 'blocked'
+        ? 'border-bad/35 bg-bad/10 text-bad'
+        : fsm.state_kind === 'verification_gate' || fsm.state_kind === 'approval_gate'
+          ? 'border-amber-400/30 bg-amber-400/10 text-amber-200'
+          : 'border-card-border/60 bg-[var(--white-4)] text-text-body'
+  return html`
+    <span
+      class="inline-flex items-center rounded border px-2 py-0.5 text-3xs font-semibold uppercase ${toneClass}"
+      title=${`source=${fsm.source}; activity=${goalFsmObservationLabel(fsm.activity_observation)}; stagnation=${goalFsmStagnationLabel(fsm.stagnation_status)}`}
+    >
+      Goal FSM · ${goalFsmStateKindLabel(fsm.state_kind)}
+    </span>
+  `
 }
 
 function keeperTrustDispositionClass(
@@ -593,6 +653,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
               ${horizonLabel(node.horizon)}
             </span>
             <${StatusBadge} status=${goalPhaseStatus(node.phase)} label=${goalPhaseLabel(node.phase)} />
+            <${GoalFsmBadge} fsm=${node.goal_fsm} />
             <span class="break-words text-base font-semibold text-text-strong line-clamp-2">${node.title}</span>
             <span class="text-2xs text-text-dim">${priorityStars(node.priority)}</span>
           </div>
@@ -896,6 +957,7 @@ function GoalDetailPanel({
             <${HealthBadge} health=${selectedNode.health} />
             <${StatusBadge} status=${selectedNode.status} />
             <${StatusBadge} status=${goalPhaseStatus(selectedNode.phase)} label=${goalPhaseLabel(selectedNode.phase)} />
+            <${GoalFsmBadge} fsm=${selectedNode.goal_fsm} />
             <span class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-widest" style="color:${horizonColor(selectedNode.horizon)}">
               ${horizonLabel(selectedNode.horizon)}
             </span>
@@ -936,6 +998,40 @@ function GoalDetailPanel({
       ${loading && !detail ? html`<${LoadingState}>goal detail 로드 중...<//>` : null}
 
       ${activeTab === 'summary' ? html`
+        <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
+          <div class="mb-2 flex flex-wrap items-center gap-2">
+            <span class="text-2xs font-semibold uppercase text-text-muted">Goal FSM</span>
+            <span class="rounded border border-card-border/60 bg-[var(--white-4)] px-2 py-0.5 text-3xs font-semibold text-text-body">
+              ${selectedNode.goal_fsm.source}
+            </span>
+          </div>
+          <div class="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-2 text-xs text-text-body">
+            <div class="rounded border border-card-border/50 bg-[var(--white-3)] p-2">
+              <div class="text-3xs uppercase text-text-muted">state</div>
+              <div class="mt-1 font-semibold text-text-strong">${goalPhaseLabel(selectedNode.goal_fsm.state)}</div>
+            </div>
+            <div class="rounded border border-card-border/50 bg-[var(--white-3)] p-2">
+              <div class="text-3xs uppercase text-text-muted">kind</div>
+              <div class="mt-1 font-semibold text-text-strong">${goalFsmStateKindLabel(selectedNode.goal_fsm.state_kind)}</div>
+            </div>
+            <div class="rounded border border-card-border/50 bg-[var(--white-3)] p-2">
+              <div class="text-3xs uppercase text-text-muted">activity</div>
+              <div class="mt-1 font-semibold text-text-strong">${goalFsmObservationLabel(selectedNode.goal_fsm.activity_observation)}</div>
+            </div>
+            <div class="rounded border border-card-border/50 bg-[var(--white-3)] p-2">
+              <div class="text-3xs uppercase text-text-muted">stagnation</div>
+              <div class="mt-1 font-semibold text-text-strong">${goalFsmStagnationLabel(selectedNode.goal_fsm.stagnation_status)}</div>
+            </div>
+          </div>
+          ${selectedNode.goal_fsm.next_actions.length > 0 ? html`
+            <div class="mt-3 flex flex-wrap gap-1.5">
+              ${selectedNode.goal_fsm.next_actions.map(action => html`
+                <code key=${action} class="rounded border border-card-border/60 bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-text-secondary">${action}</code>
+              `)}
+            </div>
+          ` : null}
+        </div>
+
         ${selectedNode.blocking_source !== 'none' ? html`
           <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
             <div class="mb-2 flex flex-wrap items-center gap-2">

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -569,6 +569,15 @@ export interface GoalVerificationSummary {
   remaining_possible: number
 }
 
+export interface GoalFsmProjection {
+  state: string
+  source: 'goal.phase' | string
+  state_kind: string
+  next_actions: string[]
+  activity_observation: 'runtime' | 'approval' | 'task' | 'child' | 'goal_metadata' | string
+  stagnation_status: 'recent' | 'stalled' | 'unobserved' | string
+}
+
 export interface GoalKeeperTrustLatestEvent {
   kind: string
   ts: string
@@ -614,6 +623,7 @@ export interface GoalTreeNode {
   status_color: string
   phase: string
   phase_color: string
+  goal_fsm: GoalFsmProjection
   health: 'done' | 'paused' | 'blocked' | 'at_risk' | 'on_track' | string
   health_color: string
   badges: string[]
@@ -637,6 +647,8 @@ export interface GoalTreeNode {
   child_count: number
   last_activity_at: string
   stagnation_seconds: number
+  activity_observation: GoalFsmProjection['activity_observation']
+  stagnation_status: GoalFsmProjection['stagnation_status']
   linked_keeper_names: string[]
   pending_approval_count: number
   infra_risk_count: number

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -23,6 +23,8 @@ type tree_node = {
   latest_keeper_ref : string option;
   latest_turn_ref : int option;
   stalled_since : string option;
+  activity_observation : string;
+  stagnation_status : string;
 }
 
 type goal_detail_keeper = {
@@ -117,6 +119,9 @@ let receipt_started_at json =
 let receipt_ended_at json =
   json |> member "ended_at" |> to_string_option
 
+let receipt_turn_count json =
+  json |> member "turn_count" |> to_int_option
+
 let trust_disposition json =
   json |> member "disposition" |> to_string_option
 
@@ -129,6 +134,12 @@ let trust_attention_reason json =
 let trust_needs_attention json =
   json |> member "needs_attention" |> to_bool_option
   |> Option.value ~default:false
+
+let trust_snapshot_unavailable json =
+  String.equal
+    (json |> member "disposition_reason" |> to_string_option
+     |> Option.value ~default:"")
+    "runtime_trust_snapshot_unavailable"
 
 let trust_turn_id json =
   json |> member "turn_id" |> to_int_option
@@ -270,7 +281,8 @@ let goal_phase_to_health = function
 
 let goal_health_reason ~goal_phase ~blocked_by_receipt ~child_blocked
     ~pending_approvals ~sandbox_risk ~cascade_risk ~fsm_risk ~stalled
-    ~stagnation_seconds ~child_at_risk ~linkage_warning_reason =
+    ~stagnation_seconds ~child_at_risk ~linkage_warning_reason
+    ~activity_observation ~stagnation_status =
   match goal_phase_to_health goal_phase with
   | Some "done" -> "Goal phase is completed."
   | Some "paused" -> "Goal phase is paused."
@@ -306,6 +318,10 @@ let goal_health_reason ~goal_phase ~blocked_by_receipt ~child_blocked
       else if stalled then
         Printf.sprintf "No linked activity for %s."
           (human_duration stagnation_seconds)
+      else if String.equal stagnation_status "unobserved" then
+        Printf.sprintf
+          "Goal FSM is %s; activity freshness is based only on %s, so stalled is not asserted."
+          (Goal_phase.to_string goal_phase) activity_observation
       else if child_at_risk then
         "A linked sub-goal is at risk."
       else
@@ -319,14 +335,64 @@ let tree_health ~goal_phase ~blocked_by_receipt ~child_blocked ~at_risk =
       else if at_risk then "at_risk"
       else "on_track"
 
-let tree_badges ~pending_approvals ~sandbox_risk ~cascade_risk ~fsm_risk ~stalled =
+let tree_badges ~pending_approvals ~sandbox_risk ~cascade_risk ~fsm_risk ~stalled
+    ~activity_unobserved =
   let badges = ref [] in
   if pending_approvals > 0 then badges := "awaiting_approval" :: !badges;
   if sandbox_risk then badges := "sandbox" :: !badges;
   if cascade_risk then badges := "cascade" :: !badges;
   if fsm_risk then badges := "task_verification_pending" :: !badges;
   if stalled then badges := "stalled" :: !badges;
+  if activity_unobserved then badges := "activity_unobserved" :: !badges;
   List.rev !badges
+
+let goal_fsm_state_kind = function
+  | Goal_phase.Executing -> "executing"
+  | Goal_phase.Awaiting_verification -> "verification_gate"
+  | Goal_phase.Awaiting_approval -> "approval_gate"
+  | Goal_phase.Blocked -> "blocked"
+  | Goal_phase.Paused -> "paused"
+  | Goal_phase.Completed -> "completed"
+  | Goal_phase.Dropped -> "dropped"
+
+let goal_fsm_next_actions ~goal_phase ~has_effective_verifier_policy
+    ~require_completion_approval =
+  [
+    Goal_phase.Request_complete;
+    Goal_phase.Approve_completion;
+    Goal_phase.Reject_completion;
+    Goal_phase.Pause;
+    Goal_phase.Resume;
+    Goal_phase.Operator_block;
+    Goal_phase.Operator_unblock;
+    Goal_phase.Drop;
+    Goal_phase.Reopen;
+  ]
+  |> List.filter (fun action ->
+         match
+           Goal_phase.decide_transition ~phase:goal_phase ~action
+             ~has_effective_verifier_policy ~require_completion_approval
+         with
+         | Ok _ -> true
+         | Error _ -> false)
+  |> List.map Goal_phase.action_to_string
+
+let goal_fsm_to_json ~effective_policy (goal : Goal_store.goal)
+    (node : tree_node) =
+  `Assoc
+    [
+      ("state", Goal_phase.to_yojson goal.phase);
+      ("source", `String "goal.phase");
+      ("state_kind", `String (goal_fsm_state_kind goal.phase));
+      ( "next_actions",
+        `List
+          (goal_fsm_next_actions ~goal_phase:goal.phase
+             ~has_effective_verifier_policy:(Option.is_some effective_policy)
+             ~require_completion_approval:goal.require_completion_approval
+          |> List.map (fun action -> `String action)) );
+      ("activity_observation", `String node.activity_observation);
+      ("stagnation_status", `String node.stagnation_status);
+    ]
 
 type build_context = {
   now_ts : float;
@@ -336,6 +402,188 @@ type build_context = {
   latest_receipts : (string * Yojson.Safe.t) list;
   latest_runtime_trusts : (string * Yojson.Safe.t) list;
 }
+
+let keeper_runtime_trust_snapshot_json ~config ~(meta : Keeper_types.keeper_meta) =
+  try Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta with
+  | exn ->
+      let error = Printexc.to_string exn in
+      `Assoc
+        [
+          ("disposition", `String "Pause");
+          ("disposition_reason", `String "runtime_trust_snapshot_unavailable");
+          ("needs_attention", `Bool true);
+          ("attention_reason", `String "runtime_trust_snapshot_unavailable");
+          ("next_human_action", `String "inspect_keeper_runtime_trust");
+          ("snapshot_error", `String error);
+          ("latest_causal_event", `Null);
+          ("causal_timeline", `List []);
+        ]
+
+let display_disposition_of_receipt_json receipt =
+  let operator_disposition =
+    receipt |> member "operator_disposition" |> to_string_option
+    |> Option.value ~default:"unknown"
+  in
+  let operator_disposition_reason =
+    receipt |> member "operator_disposition_reason" |> to_string_option
+    |> Option.value ~default:""
+  in
+  let reason fallback =
+    match String.trim operator_disposition_reason with
+    | "" -> fallback
+    | value -> value
+  in
+  match String.lowercase_ascii operator_disposition with
+  | "pass" -> ("Pass", "healthy", operator_disposition, operator_disposition_reason)
+  | "skipped" ->
+      ("Pass", "phase_skipped", operator_disposition, operator_disposition_reason)
+  | "pass_next_model" ->
+      ("Pass", "cascade_fallback", operator_disposition, operator_disposition_reason)
+  | "pause_human" ->
+      ( "Pause",
+        reason "needs_human_attention",
+        operator_disposition,
+        operator_disposition_reason )
+  | "fail_open_next_cascade" ->
+      ("Pause", reason "degraded_retry", operator_disposition, operator_disposition_reason)
+  | "user_cancelled" ->
+      ("Pause", reason "cancelled", operator_disposition, operator_disposition_reason)
+  | "alert_exhausted" ->
+      ("Alert", reason "cascade_exhausted", operator_disposition, operator_disposition_reason)
+  | "unknown" ->
+      ( "Alert",
+        reason "unmapped_cascade_state",
+        operator_disposition,
+        operator_disposition_reason )
+  | _ ->
+      ( "Alert",
+        reason "unmapped_operator_disposition",
+        operator_disposition,
+        operator_disposition_reason )
+
+let runtime_blocker_event_from_meta ~config ~(meta : Keeper_types.keeper_meta) =
+  let runtime_blocker_fields =
+    Keeper_status_bridge.runtime_blocker_fields_json config meta
+  in
+  let assoc_string_opt name =
+    match List.assoc_opt name runtime_blocker_fields with
+    | Some json -> to_string_option json
+    | None -> None
+  in
+  let blocker_class = assoc_string_opt "runtime_blocker_class" in
+  let blocker_summary = assoc_string_opt "runtime_blocker_summary" in
+  let summary =
+    match blocker_summary, blocker_class with
+    | Some value, _ when String.trim value <> "" -> Some value
+    | _, Some value when String.trim value <> "" -> Some value
+    | _ -> None
+  in
+  match summary with
+  | None -> None
+  | Some summary ->
+      let now_ts = Time_compat.now () in
+      let now_iso = Types.now_iso () in
+      Some
+        (`Assoc
+          [
+            ("kind", `String "runtime_blocker");
+            ("ts", `String now_iso);
+            ("ts_unix", `Float now_ts);
+            ("observed_at", `String now_iso);
+            ("observed_at_unix", `Float now_ts);
+            ("observation_only", `Bool true);
+            ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
+            ("keeper_turn_id", `Null);
+            ("task_id", `Null);
+            ( "goal_ids",
+              `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids)
+            );
+            ("title", `String "Runtime Blocker");
+            ("summary", `String summary);
+            ( "severity",
+              `String
+                (match blocker_class with
+                 | Some "cascade_exhausted"
+                 | Some "completion_contract_violation" ->
+                     "bad"
+                 | _ -> "warn") );
+            ("next_human_action", `String "inspect_runtime_blocker");
+          ])
+
+let runtime_trust_from_receipt_fallback ~config ~(meta : Keeper_types.keeper_meta)
+    receipt =
+  let disposition, disposition_reason, operator_disposition,
+      operator_disposition_reason =
+    display_disposition_of_receipt_json receipt
+  in
+  let ts =
+    receipt_ended_at receipt
+    |> Option.value ~default:meta.updated_at
+  in
+  let turn_id = receipt_turn_count receipt in
+  let severity =
+    match disposition with
+    | "Pass" -> "ok"
+    | "Pause" -> "warn"
+    | _ -> "bad"
+  in
+  let latest_event =
+    `Assoc
+      [
+        ("kind", `String "execution_receipt");
+        ("ts", `String ts);
+        ("keeper_turn_id", Json_util.int_opt_to_json turn_id);
+        ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
+        ("title", `String "Keeper Execution Receipt");
+        ("summary", `String disposition_reason);
+        ("severity", `String severity);
+      ]
+  in
+  let runtime_blocker_fields =
+    Keeper_status_bridge.runtime_blocker_fields_json config meta
+  in
+  let causal_timeline =
+    let blocker_events =
+      runtime_blocker_event_from_meta ~config ~meta
+      |> Option.map (fun event -> [ event ])
+      |> Option.value ~default:[]
+    in
+    `List (latest_event :: blocker_events)
+  in
+  `Assoc
+    [
+      ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
+      ("generation", `Int meta.runtime.generation);
+      ("turn_id", Json_util.int_opt_to_json turn_id);
+      ("phase", `Null);
+      ("raw_phase", `Null);
+      ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
+      ("disposition", `String disposition);
+      ("disposition_reason", `String disposition_reason);
+      ("operator_disposition", `String operator_disposition);
+      ("operator_disposition_reason", `String operator_disposition_reason);
+      ("needs_attention", `Bool (not (String.equal disposition "Pass")));
+      ("attention_reason", `Null);
+      ("next_human_action", `Null);
+      ( "approval",
+        `Assoc
+          [
+            ("state", `String "idle");
+            ("summary", `String "idle");
+            ("pending_count", `Int 0);
+          ] );
+      ( "execution_summary",
+        `Assoc
+          [
+            ( "tool_contract_result",
+              receipt |> member "tool_contract_result" );
+            ("latest_receipt_at", `String ts);
+          ] );
+      ("runtime_blockers", `Assoc runtime_blocker_fields);
+      ("latest_causal_event", latest_event);
+      ("causal_timeline", causal_timeline);
+      ("latest_receipt", receipt);
+    ]
 
 let rec build_tree context goals goal =
   let child_goals =
@@ -375,10 +623,14 @@ let rec build_tree context goals goal =
   let direct_linked_keeper_names =
     dedupe_sort (direct_task_keeper_names @ direct_goal_keeper_names)
   in
-  let direct_receipts =
+  let direct_receipt_refs =
     direct_linked_keeper_names
     |> List.filter_map (fun keeper_name ->
-           List.assoc_opt keeper_name context.latest_receipts)
+           List.assoc_opt keeper_name context.latest_receipts
+           |> Option.map (fun receipt -> (keeper_name, receipt)))
+  in
+  let direct_receipts =
+    direct_receipt_refs |> List.map snd
   in
   let direct_runtime_trusts =
     direct_linked_keeper_names
@@ -397,16 +649,34 @@ let rec build_tree context goals goal =
         || String.equal child.health "blocked")
       children
   in
+  let task_activity_values =
+    linked_tasks
+    |> List.map (fun ((task, _) : Types.task * string) -> task_updated_at task)
+  in
+  let approval_activity_values =
+    direct_pending_approvals
+    |> List.filter_map (fun json ->
+           json |> member "requested_at_iso" |> to_string_option)
+  in
+  let receipt_activity_values =
+    direct_receipts |> List.filter_map receipt_ended_at
+  in
+  let runtime_activity_values =
+    direct_runtime_trusts
+    |> List.filter_map (fun (_, trust) -> trust_latest_event_ts trust)
+  in
+  let direct_observed_activity_values =
+    task_activity_values @ approval_activity_values @ receipt_activity_values
+    @ runtime_activity_values
+  in
   let direct_last_activity_values =
-    goal.Goal_store.updated_at
-    :: (linked_tasks
-        |> List.map (fun ((task, _) : Types.task * string) -> task_updated_at task))
-    @ (direct_pending_approvals
-       |> List.filter_map (fun json ->
-              json |> member "requested_at_iso" |> to_string_option))
-    @ (direct_receipts |> List.filter_map receipt_ended_at)
-    @ (direct_runtime_trusts
-       |> List.filter_map (fun (_, trust) -> trust_latest_event_ts trust))
+    goal.Goal_store.updated_at :: direct_observed_activity_values
+  in
+  let child_observed_activity_values =
+    children
+    |> List.filter_map (fun child ->
+           if String.equal child.activity_observation "goal_metadata" then None
+           else Some child.last_activity_at)
   in
   let child_last_activity_values =
     children |> List.map (fun child -> child.last_activity_at)
@@ -437,16 +707,19 @@ let rec build_tree context goals goal =
   let direct_runtime_blocking_reason =
     direct_runtime_trusts
     |> List.find_map (fun (_keeper_name, trust) ->
-           match trust_disposition trust with
-           | Some "Alert" ->
-               (match trust_attention_reason trust with
-                | Some _ as reason -> reason
-                | None -> trust_disposition_reason trust)
-           | Some "Pause" when trust_needs_attention trust ->
-               (match trust_attention_reason trust with
-                | Some _ as reason -> reason
-                | None -> trust_disposition_reason trust)
-           | _ -> None)
+           if trust_snapshot_unavailable trust && direct_receipts <> [] then
+             None
+           else
+             match trust_disposition trust with
+             | Some "Alert" ->
+                 (match trust_attention_reason trust with
+                  | Some _ as reason -> reason
+                  | None -> trust_disposition_reason trust)
+             | Some "Pause" when trust_needs_attention trust ->
+                 (match trust_attention_reason trust with
+                  | Some _ as reason -> reason
+                  | None -> trust_disposition_reason trust)
+             | _ -> None)
   in
   let direct_fsm_risk =
     List.exists
@@ -487,13 +760,35 @@ let rec build_tree context goals goal =
     | Goal_phase.Dropped ->
         None
   in
-  let stalled =
+  let activity_observation =
+    if runtime_activity_values <> [] || receipt_activity_values <> [] then
+      "runtime"
+    else if approval_activity_values <> [] then
+      "approval"
+    else if task_activity_values <> [] then
+      "task"
+    else if child_observed_activity_values <> [] then
+      "child"
+    else
+      "goal_metadata"
+  in
+  let stale_by_threshold =
     stagnation_seconds >= stagnation_threshold_seconds goal.Goal_store.horizon
+  in
+  let observed_for_stagnation =
+    not (String.equal activity_observation "goal_metadata")
+  in
+  let stalled = stale_by_threshold && observed_for_stagnation in
+  let stagnation_status =
+    if stalled then "stalled"
+    else if stale_by_threshold then "unobserved"
+    else "recent"
   in
   let direct_badges =
     tree_badges ~pending_approvals:(List.length direct_pending_approvals)
       ~sandbox_risk:direct_sandbox_risk ~cascade_risk:direct_cascade_risk
       ~fsm_risk:direct_fsm_risk ~stalled
+      ~activity_unobserved:(String.equal stagnation_status "unobserved")
   in
   let direct_badges =
     match linkage_warning_reason with
@@ -521,10 +816,13 @@ let rec build_tree context goals goal =
     + List.length
         (List.filter
            (fun (_, trust) ->
-             match trust_disposition trust with
-             | Some "Alert" -> true
-             | Some "Pause" -> trust_needs_attention trust
-             | _ -> false)
+             if trust_snapshot_unavailable trust && direct_receipts <> [] then
+               false
+             else
+               match trust_disposition trust with
+               | Some "Alert" -> true
+               | Some "Pause" -> trust_needs_attention trust
+               | _ -> false)
            direct_runtime_trusts)
   in
   let infra_risk_count =
@@ -570,6 +868,7 @@ let rec build_tree context goals goal =
       ~sandbox_risk:direct_sandbox_risk ~cascade_risk:direct_cascade_risk
       ~fsm_risk:direct_fsm_risk ~stalled
       ~stagnation_seconds ~child_at_risk ~linkage_warning_reason
+      ~activity_observation ~stagnation_status
   in
   let blocking_source, blocking_reason =
     match goal.Goal_store.phase with
@@ -593,15 +892,40 @@ let rec build_tree context goals goal =
         else
           ("none", status_reason)
   in
-  let latest_keeper_ref, latest_turn_ref =
+  let latest_receipt_ref =
+    direct_receipt_refs
+    |> List.sort (fun (_, left) (_, right) ->
+           String.compare
+             (Option.value ~default:"" (receipt_ended_at right))
+             (Option.value ~default:"" (receipt_ended_at left)))
+    |> function
+    | (keeper_name, receipt) :: _ -> (Some keeper_name, receipt_turn_count receipt)
+    | [] -> (None, None)
+  in
+  let latest_runtime_ref =
     direct_runtime_trusts
+    |> List.filter (fun (_, trust) ->
+           Option.is_some (trust_latest_event_ts_unix trust))
     |> List.sort (fun (_, left) (_, right) ->
            Float.compare
              (Option.value ~default:0.0 (trust_latest_event_ts_unix right))
              (Option.value ~default:0.0 (trust_latest_event_ts_unix left)))
     |> function
-    | (keeper_name, trust) :: _ -> (Some keeper_name, trust_turn_id trust)
+    | (keeper_name, trust) :: _ -> Some (Some keeper_name, trust_turn_id trust)
+    | [] -> None
+  in
+  let latest_linked_keeper_ref =
+    match direct_linked_keeper_names with
+    | keeper_name :: _ -> (Some keeper_name, None)
     | [] -> (None, None)
+  in
+  let latest_keeper_ref, latest_turn_ref =
+    match latest_runtime_ref with
+    | Some latest -> latest
+    | None -> (
+        match latest_receipt_ref with
+        | Some _, _ -> latest_receipt_ref
+        | None, _ -> latest_linked_keeper_ref)
   in
   let stalled_since =
     if stalled then Some last_activity_at else None
@@ -627,6 +951,8 @@ let rec build_tree context goals goal =
     latest_keeper_ref;
     latest_turn_ref;
     stalled_since;
+    activity_observation;
+    stagnation_status;
   }
 
 let build_forest ~(config : Coord.config) ~goals ~tasks =
@@ -664,8 +990,7 @@ let build_forest ~(config : Coord.config) ~goals ~tasks =
         keeper_metas
         |> List.map (fun (meta : Keeper_types.keeper_meta) ->
                ( meta.name,
-                 Keeper_runtime_trust_snapshot.snapshot_json
-                   ~config ~meta ));
+                 keeper_runtime_trust_snapshot_json ~config ~meta ));
     }
   in
   goals
@@ -829,6 +1154,7 @@ let rec tree_node_to_json ?(effective_policy_for_goal = fun _ -> None)
       ("status_color", `String (goal_status_color goal.status));
       ("phase", Goal_phase.to_yojson goal.phase);
       ("phase_color", `String (goal_phase_color goal.phase));
+      ("goal_fsm", goal_fsm_to_json ~effective_policy goal node);
       ("health", `String node.health);
       ("health_color", `String (goal_health_color node.health));
       ("badges", `List (List.map (fun badge -> `String badge) node.badges));
@@ -894,6 +1220,8 @@ let rec tree_node_to_json ?(effective_policy_for_goal = fun _ -> None)
       ("child_count", `Int (List.length node.children));
       ("last_activity_at", `String node.last_activity_at);
       ("stagnation_seconds", `Int node.stagnation_seconds);
+      ("activity_observation", `String node.activity_observation);
+      ("stagnation_status", `String node.stagnation_status);
       ( "linked_keeper_names",
         `List
           (List.map (fun keeper_name -> `String keeper_name) node.linked_keeper_names)
@@ -1198,16 +1526,28 @@ let goal_detail_json ~(config : Coord.config) ~goal_id :
         |> List.filter_map (fun keeper_name ->
                match Keeper_types.read_meta config keeper_name with
                | Ok (Some meta) when List.mem meta.name node.linked_keeper_names ->
+                   let latest_receipt =
+                     List.assoc_opt meta.name
+                       (Keeper_execution_receipt.latest_json_by_keeper
+                          config node.linked_keeper_names)
+                   in
+                   let runtime_trust =
+                     let snapshot =
+                       keeper_runtime_trust_snapshot_json ~config ~meta
+                     in
+                     if trust_snapshot_unavailable snapshot then
+                       match latest_receipt with
+                       | Some receipt ->
+                           runtime_trust_from_receipt_fallback ~config ~meta receipt
+                       | None -> snapshot
+                     else
+                       snapshot
+                   in
                    Some
                      {
                        meta;
-                       latest_receipt =
-                         List.assoc_opt meta.name
-                           (Keeper_execution_receipt.latest_json_by_keeper
-                              config node.linked_keeper_names);
-                       runtime_trust =
-                         Keeper_runtime_trust_snapshot.snapshot_json
-                           ~config ~meta;
+                       latest_receipt;
+                       runtime_trust;
                      }
                | Ok None | Error _ | Ok (Some _) -> None)
       in

--- a/lib/dashboard/dashboard_goals.mli
+++ b/lib/dashboard/dashboard_goals.mli
@@ -56,6 +56,8 @@ type tree_node = {
   latest_keeper_ref : string option;
   latest_turn_ref : int option;
   stalled_since : string option;
+  activity_observation : string;
+  stagnation_status : string;
 }
 (** Per-goal projection node returned by
     {!build_forest}.  Concrete record because

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -66,6 +66,18 @@ let create_done_task config ~goal_id ~title =
 let string_list_field json field =
   json |> member field |> to_list |> List.map to_string
 
+let rewrite_goal_updated_at config ~goal_id ~updated_at =
+  let state = Goal_store.read_state config in
+  let goals =
+    state.goals
+    |> List.map (fun (goal : Goal_store.goal) ->
+           if String.equal goal.id goal_id then
+             { goal with created_at = updated_at; updated_at }
+           else
+             goal)
+  in
+  Goal_store.write_state config { state with updated_at; goals }
+
 let make_keeper_meta ~name ~goal_id =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -130,8 +142,7 @@ let append_keeper_receipt ?(outcome = "ok")
       network_mode = Keeper_types.network_mode_to_string meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
-      cascade_name =
-        Keeper_execution_receipt.cascade_name_of_string meta.cascade_name;
+      cascade_name = Keeper_cascade_profile.Runtime_name meta.cascade_name;
       cascade_selected_model = Some "openai:gpt-5.4";
       cascade_attempt_count = 1;
       cascade_fallback_applied = false;
@@ -373,10 +384,61 @@ let test_blocked_phase_projects_blocked_health () =
     (node |> member "phase" |> to_string);
   check string "health follows blocked phase" "blocked"
     (node |> member "health" |> to_string);
+  let fsm = node |> member "goal_fsm" in
+  check string "goal fsm source is explicit phase" "goal.phase"
+    (fsm |> member "source" |> to_string);
+  check string "goal fsm state follows phase" "blocked"
+    (fsm |> member "state" |> to_string);
+  check string "goal fsm kind is blocked" "blocked"
+    (fsm |> member "state_kind" |> to_string);
+  check (list string) "blocked goal next actions"
+    [ "operator_unblock"; "drop" ]
+    (string_list_field fsm "next_actions");
   check int "blocked summary count" 1
     (json |> member "summary" |> member "blocked_goals" |> to_int);
   check int "paused summary count" 0
     (json |> member "summary" |> member "paused_goals" |> to_int)
+
+let test_goal_fsm_withholds_stalled_when_activity_is_metadata_only () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Metadata-only active goal" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  rewrite_goal_updated_at config ~goal_id:goal.id
+    ~updated_at:"2026-04-01T00:00:00Z";
+  let meta = make_keeper_meta ~name:"metadata-only-keeper" ~goal_id:goal.id in
+  (match Keeper_types.write_meta ~force:true config meta with
+   | Ok () -> ()
+   | Error err -> fail ("write_meta failed: " ^ err));
+  let node = Dashboard_goals.dashboard_goals_tree_json ~config |> root_node in
+  check string "phase remains the lifecycle source" "executing"
+    (node |> member "phase" |> to_string);
+  check string "snapshot failure is surfaced as keeper runtime risk"
+    "keeper_runtime"
+    (node |> member "blocking_source" |> to_string);
+  check string "health is demoted by runtime-trust failure" "at_risk"
+    (node |> member "health" |> to_string);
+  check bool "stalled badge withheld" false
+    (List.mem "stalled" (string_list_field node "badges"));
+  check bool "unobserved badge explains weak freshness" true
+    (List.mem "activity_unobserved" (string_list_field node "badges"));
+  check string "activity observation is metadata only" "goal_metadata"
+    (node |> member "activity_observation" |> to_string);
+  check string "stagnation status is unobserved" "unobserved"
+    (node |> member "stagnation_status" |> to_string);
+  let fsm = node |> member "goal_fsm" in
+  check string "goal fsm source is explicit phase" "goal.phase"
+    (fsm |> member "source" |> to_string);
+  check string "goal fsm state remains executing" "executing"
+    (fsm |> member "state" |> to_string);
+  check string "goal fsm carries observation confidence" "goal_metadata"
+    (fsm |> member "activity_observation" |> to_string);
+  check string "goal fsm carries unobserved freshness" "unobserved"
+    (fsm |> member "stagnation_status" |> to_string);
+  check bool "operator can still pause executing goal" true
+    (List.mem "pause" (string_list_field fsm "next_actions"))
 
 let test_goal_detail_surfaces_keeper_runtime_trust_and_blockers () =
   with_room @@ fun config ->
@@ -556,6 +618,10 @@ let () =
             test_title_marker_links_legacy_task;
           test_case "blocked phase maps to blocked health" `Quick
             test_blocked_phase_projects_blocked_health;
+          test_case
+            "metadata-only freshness does not assert stalled FSM state"
+            `Quick
+            test_goal_fsm_withholds_stalled_when_activity_is_metadata_only;
           test_case "goal detail surfaces keeper runtime trust and blockers"
             `Quick
             test_goal_detail_surfaces_keeper_runtime_trust_and_blockers;


### PR DESCRIPTION
## Summary
- Add explicit `goal_fsm` projection to goal tree payloads and dashboard UI, sourced from `goal.phase` with available lifecycle actions.
- Split activity freshness into observed runtime/task/approval/child evidence versus metadata-only freshness, so stale metadata-only goals show `activity_unobserved` instead of incorrectly asserting `stalled`.
- Harden goal runtime-trust rendering so snapshot failures are surfaced instead of crashing, while durable receipts remain authoritative and runtime blockers stay observation-only.

## Bugs found while testing
- Linked keepers with null decision telemetry could lose the visible keeper ref in the goal tree.
- Receipt fallback initially dropped runtime blocker observations from the causal timeline.

## Verification
- `scripts/dune-local.sh build test/test_dashboard_goals.exe`
- `./_build/default/test/test_dashboard_goals.exe --compact --quick-tests`
- `./node_modules/.bin/vitest run src/components/goals/goal-tree.test.ts src/components/goals/goal-helpers.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty`
- `git diff --check`