### PR TITLE
feat(dashboard): add code IDE plane route and shell skeleton (Phase 1 PR-1)

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -36,6 +36,7 @@ const LazyOperations = lazy(async () => ({ default: (await import('./control')).
 const LazyConnectors = lazy(async () => ({ default: (await import('./connector-status')).ConnectorStatusPanel }))
 const LazyLabSurface = lazy(async () => ({ default: (await import('./lab')).Lab }))
 const LazyLogViewer = lazy(async () => ({ default: (await import('./logs')).LogViewer }))
+const LazyIdeShell = lazy(async () => ({ default: (await import('./ide/ide-shell')).IdeShell }))
 
 function lazyTabFallback(label: string) {
   return html`<${LoadingState}>${label} 불러오는 중...<//>`
@@ -501,6 +502,12 @@ function TabContent() {
       return html`
         <${Suspense} fallback=${lazyTabFallback('실험실 화면')}>
           <${LazyLabSurface} />
+        <//>
+      `
+    case 'code':
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('코드 IDE')}>
+          <${LazyIdeShell} />
         <//>
       `
     case 'logs':

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,0 +1,83 @@
+import { html } from 'htm/preact'
+
+// PR-1 placeholder: route + navigation entry are wired but the actual
+// 4-pane content (EXPLORER · 에디터 · CONVERSATION · ACTIVITY) lands in
+// PR-2. The shell renders the cockpit IdePlane prototype's grid stub
+// (`design-system/ui_kits/cockpit/Planes.jsx:144`) so the production
+// surface picks up where v0.4 SSOT left off.
+//
+// Audit reference:
+//   dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md
+//
+// All visible color and spacing values flow from v0.4 Semantic tier
+// tokens; do not introduce raw hex literals here.
+
+export function IdeShell() {
+  return html`
+    <section
+      class="ide-plane-shell"
+      role="region"
+      aria-label="Code IDE shell (Phase 1 placeholder)"
+      style=${{
+        display: 'grid',
+        gridTemplateRows: 'auto 1fr',
+        gap: 'var(--sp-3)',
+        padding: 'var(--sp-4)',
+        minHeight: 'calc(100vh - var(--h-topbar) - var(--h-kpi))',
+        background: 'var(--color-bg-page)',
+        color: 'var(--color-fg-primary)',
+      }}
+    >
+      <header style=${{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-1)' }}>
+        <h1 style=${{ font: 'var(--type-section-title)', margin: 0 }}>
+          코드 IDE
+        </h1>
+        <p style=${{ color: 'var(--color-fg-muted)', margin: 0, font: 'var(--type-body)' }}>
+          Multi-keeper 협업 코드 review surface — Phase 1 라우트 셋업.
+          EXPLORER · 에디터 · CONVERSATION · ACTIVITY 4-pane 콘텐츠는 후속 PR에서 채워집니다.
+        </p>
+      </header>
+      <div
+        class="ide-plane-grid-placeholder"
+        role="presentation"
+        style=${{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(180px, 240px) minmax(0, 1fr) minmax(280px, 320px)',
+          gridTemplateRows: '1fr',
+          gap: 'var(--sp-3)',
+          minHeight: 0,
+        }}
+      >
+        ${PanePlaceholder({ title: 'EXPLORER', body: '파일 트리 (PR-2 / PR-4)' })}
+        ${PanePlaceholder({ title: '에디터', body: '코드 + blame-by-keeper (PR-2 / PR-5)' })}
+        ${PanePlaceholder({
+          title: 'CONVERSATION · ACTIVITY',
+          body: '라인 anchored thread + activity 스트림 (PR-2 / PR-6)',
+        })}
+      </div>
+    </section>
+  `
+}
+
+function PanePlaceholder({ title, body }: { title: string; body: string }) {
+  return html`
+    <div
+      style=${{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--sp-2)',
+        padding: 'var(--sp-3)',
+        background: 'var(--color-bg-surface)',
+        border: '1px solid var(--color-border-default)',
+        borderRadius: 'var(--r-2)',
+      }}
+    >
+      <span style=${{ color: 'var(--color-fg-muted)', font: 'var(--type-eyebrow)' }}>
+        ${title}
+      </span>
+      <span style=${{ color: 'var(--color-fg-secondary)', font: 'var(--type-body)' }}>
+        ${body}
+      </span>
+    </div>
+  `
+}

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, it } from 'vitest'
 
 import { SECTION_REDIRECTS, defaultParamsForTab, normalizeRouteParams, visibleSectionItemsForTab } from './navigation'
 
+describe('code (IDE plane) navigation', () => {
+  it('exposes a single ide-shell section under the code surface (Phase 1, PR-1)', () => {
+    expect(defaultParamsForTab('code')).toEqual({ section: 'ide-shell' })
+
+    const codeSections = visibleSectionItemsForTab('code')
+
+    expect(codeSections.map(item => item.id)).toEqual(['ide-shell'])
+    expect(codeSections.map(item => item.label)).toEqual(['코드 IDE'])
+  })
+
+  it('normalizes unknown code section to default ide-shell', () => {
+    const result = normalizeRouteParams('code', { section: 'bogus' })
+    expect(result.section).toBe('ide-shell')
+  })
+})
+
 describe('lab navigation', () => {
   it('contains only research surfaces after Phase 1 reorg', () => {
     expect(defaultParamsForTab('lab')).toEqual({ section: 'tools' })

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -32,6 +32,8 @@ type SurfaceSectionId =
   | 'tools'
   | 'autoresearch'
   | 'harness'
+  // code (Stage 5 IDE plane — shell only in PR-1, 4-pane content in PR-2+)
+  | 'ide-shell'
 
 type NonHomeTabId = Exclude<TabId, 'overview' | 'logs'>
 
@@ -115,6 +117,15 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     defaultTab: 'lab',
     defaultParams: { section: 'tools' },
     tabs: ['lab'],
+  },
+  {
+    id: 'code',
+    label: '코드',
+    icon: '💻',
+    description: 'Keeper 협업 코드 review IDE — 파일 트리, blame-by-keeper, 라인 anchored 대화, activity 스트림',
+    defaultTab: 'code',
+    defaultParams: { section: 'ide-shell' },
+    tabs: ['code'],
   },
   {
     id: 'logs',
@@ -293,6 +304,14 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '세이프티 하네스',
       description: '평가 모델, 압축 전 상태, 세대 교체 모니터링 상태.',
       params: { section: 'harness' },
+    },
+  ],
+  code: [
+    {
+      id: 'ide-shell',
+      label: '코드 IDE',
+      description: 'Keeper 협업 코드 review IDE shell. 4-pane (EXPLORER · 에디터 · CONVERSATION · ACTIVITY) 는 후속 PR에서 채워집니다.',
+      params: { section: 'ide-shell' },
     },
   ],
 }

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -61,8 +61,11 @@ function parseSegments(
     }
   }
 
-  if ((segments[0] === 'monitoring' || segments[0] === 'workspace' || segments[0] === 'lab') && segments[1]) {
-    const tab = segments[0] as 'monitoring' | 'workspace' | 'lab'
+  if (
+    (segments[0] === 'monitoring' || segments[0] === 'workspace' || segments[0] === 'lab' || segments[0] === 'code')
+    && segments[1]
+  ) {
+    const tab = segments[0] as 'monitoring' | 'workspace' | 'lab' | 'code'
     const nextParams = { ...params, section: decodeSafe(segments[1]) }
     return {
       tab,

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -259,6 +259,7 @@ export type TabId =
   | 'connectors'
   | 'workspace'
   | 'lab'
+  | 'code'
   | 'logs'
 
 export const VALID_TABS: TabId[] = [
@@ -268,6 +269,7 @@ export const VALID_TABS: TabId[] = [
   'connectors',
   'workspace',
   'lab',
+  'code',
   'logs',
 ]
 


### PR DESCRIPTION
## Summary

Stage 5 IDE plane 의 production wiring 시작 — top-level surface `code` 추가 + 단일 `ide-shell` section + Lazy-loaded placeholder 컴포넌트. 시안 mockup 의 4-pane 콘텐츠는 후속 PR (PR-2~6) 에서 채웁니다.

본 PR 은 plan `planning/claude-plans/zany-yawning-nebula.md` 의 **Phase 1 PR-1** 산출물.

## 왜 의도적으로 작게 시작했는가

- mockup IDE 는 기존 cockpit IdePlane prototype (`design-system/ui_kits/cockpit/Planes.jsx:144`) 의 refinement 라는 사실을 audit (#12317) 이 확정. production migration 의 base 는 prototype 의 grid 이며 mockup raw hex 직접 카피는 audit checklist 가 차단.
- shell 은 Preact + htm/preact (default surface stack) 만 사용. Solid island 는 PR-3+ 에서 N >= 100 영역 (file tree / blame strip / activity stream) 에 도입 — RFC 0017 §7d 정합.
- 시각 토큰은 모두 v0.4 Semantic tier (`--color-bg-page`, `--color-fg-muted`, `--sp-3`, `--r-2` 등). raw hex 0개.

## Changes

- `types/sse.ts`: `TabId` + `VALID_TABS` 에 `'code'` 추가
- `config/navigation.ts`: `SurfaceSectionId` 에 `'ide-shell'`, `DASHBOARD_SURFACES` 에 code surface (label '코드', icon 💻), `DASHBOARD_SECTION_ITEMS.code` 에 single `ide-shell` entry
- `config/navigation.test.ts`: code surface 의 default + unknown-section fallback 커버 (2 testcase 추가)
- `router.ts`: `monitoring/workspace/lab` generic handler 에 `'code'` 추가 → `#code/ide-shell` parse 됨
- `components/ide/ide-shell.ts`: 신규 placeholder 컴포넌트 (3-column grid + audit 참조 주석)
- `components/dashboard-shell.ts`: `LazyIdeShell` 등록 + `case 'code'` wire-up

## Test plan

- [x] `pnpm typecheck` pass
- [x] `pnpm test` 357 files / 5166 tests pass (전체)
- [x] `pnpm test src/config/navigation.test.ts` 128 tests pass
- [ ] CI green (Dashboard / Lint / Build)
- [ ] manual: `#code` hash 진입 시 placeholder grid 렌더 (3 pane). 비-IDE 라우트 영향 0
- [ ] manual: bundle size 확인 — IDE chunk 가 lazy 분리되어 main 영향 ±5KB 이내

## Future PRs (이 PR 머지 후)

- **PR-2** (Phase 1): CODE 모드 4-pane shell — `split-pane` (RFC 0014/0015) 위에 시안 mockup 의 EXPLORER/에디터/CONVERSATION/ACTIVITY 4-pane mock 콘텐츠
- **PR-3** (Phase 1): view tabs (SOURCE/SPLIT DIFF/UNIFIED/BLAME) + LAYERS toggle (Time/Parallel/Tools/Approve/Notes/EXPLODE) — 둘 다 mock
- **PR-4~7** (Phase 2): file-tree store, Shiki editor + blame, conversation rail + activity stream, INTERJECT + lazy chunk

## Refs

- `planning/claude-plans/zany-yawning-nebula.md` (Phase 1 PR-1)
- `dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md` (#12317 audit, dependent)
- `dashboard/design-system/RFC/0017-solidjs-migration.md` §7d (Solid island sync-mount rule)
- `dashboard/design-system/ui_kits/cockpit/Planes.jsx:144` (`IdePlane` prototype, 5 modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)