### PR TITLE
[codex] Harden multi-repo management surfaces

### DIFF
--- a/dashboard/src/components/add-repo-dialog.ts
+++ b/dashboard/src/components/add-repo-dialog.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { post } from '../api/core'
+import { get, post } from '../api/core'
 import { showToast } from './common/toast'
 import { fetchRepositories, showAddRepoDialog } from './repo-sidebar'
 import { X } from 'lucide-preact'
@@ -28,6 +28,7 @@ const formSubmitting = signal(false)
 const formError = signal<string | null>(null)
 const credentialsResource = signal<CredentialOption[]>([])
 const credentialsLoading = signal(false)
+const credentialsLoaded = signal(false)
 
 function resetForm(): void {
   formName.value = ''
@@ -56,14 +57,25 @@ export function closeAddRepoDialog(): void {
 async function loadCredentials(): Promise<void> {
   credentialsLoading.value = true
   try {
-    const raw = await post<unknown[]>('/api/v1/credentials/list', {})
-    const options: CredentialOption[] = raw
+    const raw = await get<unknown>('/api/v1/credentials')
+    const rows = Array.isArray(raw)
+      ? raw
+      : raw && typeof raw === 'object' && Array.isArray((raw as Record<string, unknown>).credentials)
+        ? (raw as Record<string, unknown>).credentials as unknown[]
+        : []
+    const options: CredentialOption[] = rows
       .filter((item): item is Record<string, unknown> =>
         item !== null && typeof item === 'object',
       )
       .map(item => ({
         id: typeof item.id === 'string' ? item.id : '',
-        name: typeof item.name === 'string' ? item.name : '',
+        name: typeof item.name === 'string'
+          ? item.name
+          : typeof item.username === 'string'
+            ? item.username
+            : typeof item.id === 'string'
+              ? item.id
+              : '',
       }))
       .filter(opt => opt.id && opt.name)
     credentialsResource.value = options
@@ -72,6 +84,7 @@ async function loadCredentials(): Promise<void> {
     credentialsResource.value = []
   } finally {
     credentialsLoading.value = false
+    credentialsLoaded.value = true
   }
 }
 
@@ -91,24 +104,20 @@ async function submitAddRepo(): Promise<void> {
     formError.value = '저장소 URL을 입력하세요.'
     return
   }
-  if (!localPath) {
-    formError.value = '로컬 경로를 입력하세요.'
-    return
-  }
-
   formSubmitting.value = true
   formError.value = null
 
   try {
-    await post('/api/v1/repositories', {
+    const payload: Record<string, unknown> = {
       name,
       url,
-      local_path: localPath,
       default_branch: defaultBranch,
-      credential_id: formCredentialId.value || null,
+      credential_id: formCredentialId.value || 'default',
       auto_sync: formAutoSync.value,
       sync_interval: Math.max(60, formSyncInterval.value),
-    })
+    }
+    if (localPath) payload.local_path = localPath
+    await post('/api/v1/repositories', payload)
     showToast('저장소 등록 완료', 'success')
     closeAddRepoDialog()
     await fetchRepositories()
@@ -133,6 +142,9 @@ const labelBase = 'block text-2xs font-semibold uppercase tracking-wider text-te
 export function AddRepoDialog() {
   const open = showAddRepoDialog.value
   if (!open) return null
+  if (!credentialsLoaded.value && !credentialsLoading.value) {
+    void loadCredentials()
+  }
 
   const credentials = credentialsResource.value
   const hasCredentials = credentials.length > 0
@@ -196,11 +208,11 @@ export function AddRepoDialog() {
           </div>
 
           <div>
-            <label class="${labelBase}">로컬 경로 <span class="text-[var(--color-status-err)]">*</span></label>
+            <label class="${labelBase}">로컬 경로</label>
             <input
               type="text"
               class="${inputBase}"
-              placeholder="/path/to/local/clone"
+              placeholder=".masc/repos/<저장소-id>"
               value=${formLocalPath.value}
               onInput=${(e: Event) => { formLocalPath.value = (e.target as HTMLInputElement).value }}
               disabled=${formSubmitting.value}

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { get, post } from '../api/core'
+import { authHeaders, get, post } from '../api/core'
 import { createAsyncResource } from '../lib/async-state'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
@@ -16,6 +16,10 @@ export interface Credential {
   id: string
   name: string
   type: CredentialType
+  username: string
+  gh_config_dir?: string | null
+  ssh_key_path?: string | null
+  gpg_key_id?: string | null
   description?: string
   config?: Record<string, unknown>
   created_at?: string
@@ -25,6 +29,10 @@ export interface CredentialCreatePayload {
   id: string
   name: string
   type: CredentialType
+  username: string
+  gh_config_dir?: string | null
+  ssh_key_path?: string | null
+  gpg_key_id?: string | null
   description?: string
   config?: Record<string, unknown>
 }
@@ -42,6 +50,7 @@ const deletingId = signal<string | null>(null)
 const addDraft = signal<CredentialCreatePayload>({
   id: '',
   name: '',
+  username: '',
   type: 'github',
   description: '',
 })
@@ -49,14 +58,24 @@ const addDraft = signal<CredentialCreatePayload>({
 // ── API ──────────────────────────────────────────────────
 
 async function fetchCredentials(): Promise<Credential[]> {
-  const data = await get('/api/v1/credentials')
-  if (Array.isArray(data)) {
-    return data.map((row: unknown): Credential => {
+  const data = await get<unknown>('/api/v1/credentials')
+  const rows = Array.isArray(data)
+    ? data
+    : data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).credentials)
+      ? (data as Record<string, unknown>).credentials as unknown[]
+      : []
+  if (Array.isArray(rows)) {
+    return rows.map((row: unknown): Credential => {
       const r = row as Record<string, unknown>
+      const username = String(r.username ?? r.name ?? '')
       return {
         id: String(r.id ?? ''),
-        name: String(r.name ?? ''),
-        type: coerceCredentialType(r.type),
+        name: String(r.name ?? username ?? r.id ?? ''),
+        type: coerceCredentialType(r.type ?? r.cred_type),
+        username,
+        gh_config_dir: typeof r.gh_config_dir === 'string' ? r.gh_config_dir : null,
+        ssh_key_path: typeof r.ssh_key_path === 'string' ? r.ssh_key_path : null,
+        gpg_key_id: typeof r.gpg_key_id === 'string' ? r.gpg_key_id : null,
         description: r.description ? String(r.description) : undefined,
         config: isRecord(r.config) ? r.config : undefined,
         created_at: r.created_at ? String(r.created_at) : undefined,
@@ -67,13 +86,20 @@ async function fetchCredentials(): Promise<Credential[]> {
 }
 
 async function createCredential(payload: CredentialCreatePayload): Promise<void> {
-  await post('/api/v1/credentials', payload)
+  await post('/api/v1/credentials', {
+    id: payload.id,
+    cred_type: payload.type,
+    username: payload.username || payload.name,
+    gh_config_dir: payload.gh_config_dir ?? null,
+    ssh_key_path: payload.ssh_key_path ?? null,
+    gpg_key_id: payload.gpg_key_id ?? null,
+  })
 }
 
 async function deleteCredential(id: string): Promise<void> {
   const res = await fetch(`/api/v1/credentials/${encodeURIComponent(id)}`, {
     method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
+    headers: authHeaders(),
   })
   if (!res.ok) {
     const text = await res.text().catch(() => '삭제 요청 실패')
@@ -113,7 +139,7 @@ function credentialTypeBadgeClass(type: CredentialType): string {
 }
 
 function resetAddDraft() {
-  addDraft.value = { id: '', name: '', type: 'github', description: '' }
+  addDraft.value = { id: '', name: '', username: '', type: 'github', description: '' }
   saveError.value = null
 }
 
@@ -158,6 +184,10 @@ function CredentialTypeBadge({ type }: { type: CredentialType }) {
 export function CredentialSettings() {
   const state = credentialsState.value
 
+  if (state.status === 'idle') {
+    void loadCredentials()
+  }
+
   if (state.status === 'idle' || state.status === 'loading') {
     return html`<${LoadingState}>크리덴셜 목록 불러오는 중...<//>`
   }
@@ -183,8 +213,8 @@ export function CredentialSettings() {
   const draft = addDraft.value
 
   async function handleSave() {
-    if (!draft.id.trim() || !draft.name.trim()) {
-      saveError.value = 'ID와 이름은 필수입니다.'
+    if (!draft.id.trim() || !draft.name.trim() || !draft.username.trim()) {
+      saveError.value = 'ID, 이름, 사용자명은 필수입니다.'
       return
     }
     saving.value = true
@@ -193,6 +223,7 @@ export function CredentialSettings() {
       await createCredential({
         id: draft.id.trim(),
         name: draft.name.trim(),
+        username: draft.username.trim(),
         type: draft.type,
         description: draft.description?.trim() || undefined,
       })
@@ -268,6 +299,16 @@ export function CredentialSettings() {
               />
             </div>
             <div>
+              <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">사용자명</label>
+              <input
+                type="text"
+                class="${fieldStyle}"
+                placeholder="github-user"
+                value=${draft.username}
+                onInput=${(e: Event) => { addDraft.value = { ...draft, username: (e.target as HTMLInputElement).value } }}
+              />
+            </div>
+            <div>
               <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">타입</label>
               <select
                 class="${fieldStyle}"
@@ -331,7 +372,7 @@ export function CredentialSettings() {
               ${list.map(cred => html`
                 <tr class="hover:bg-card/40 transition-colors">
                   <td class="py-2 px-3 text-xs font-mono text-text-body truncate max-w-[12rem]">${cred.id}</td>
-                  <td class="py-2 px-3 text-xs font-medium text-text-strong">${cred.name}</td>
+                  <td class="py-2 px-3 text-xs font-medium text-text-strong">${cred.name || cred.username}</td>
                   <td class="py-2 px-3">
                     <${CredentialTypeBadge} type=${cred.type} />
                   </td>

--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -1,6 +1,6 @@
 // Keeper-repo mapping -- page/component for mapping keepers to repositories.
 // Fetches keepers list and allows multi-select assignment per keeper.
-// Save sends POST /api/v1/keepers/:id/repos
+// Save sends POST /api/v1/keeper-repos/:id
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
@@ -56,8 +56,13 @@ async function fetchKeepers(): Promise<Keeper[]> {
 
 async function fetchRepositories(): Promise<RepositoryOption[]> {
   const data = await get<unknown>('/api/v1/repositories')
-  if (Array.isArray(data)) {
-    return data.map((row: unknown): RepositoryOption => {
+  const rows = Array.isArray(data)
+    ? data
+    : data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).repositories)
+      ? (data as Record<string, unknown>).repositories as unknown[]
+      : []
+  if (Array.isArray(rows)) {
+    return rows.map((row: unknown): RepositoryOption => {
       const r = row as Record<string, unknown>
       return {
         id: String(r.id ?? ''),
@@ -70,15 +75,22 @@ async function fetchRepositories(): Promise<RepositoryOption[]> {
 }
 
 async function fetchKeeperRepoMappings(): Promise<KeeperRepoMapping[]> {
-  const data = await get<unknown>('/api/v1/keepers/repos')
-  if (Array.isArray(data)) {
-    return data.map((row: unknown): KeeperRepoMapping => {
+  const data = await get<unknown>('/api/v1/keeper-repos')
+  const rows = Array.isArray(data)
+    ? data
+    : data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).mappings)
+      ? (data as Record<string, unknown>).mappings as unknown[]
+      : []
+  if (Array.isArray(rows)) {
+    return rows.map((row: unknown): KeeperRepoMapping => {
       const r = row as Record<string, unknown>
       return {
         keeper_id: String(r.keeper_id ?? ''),
         keeper_name: String(r.keeper_name ?? ''),
         allowed_repos: Array.isArray(r.allowed_repos)
           ? r.allowed_repos.filter((v): v is string => typeof v === 'string')
+          : Array.isArray(r.repositories)
+            ? r.repositories.filter((v): v is string => typeof v === 'string')
           : [],
         allow_all: r.allow_all === true,
       }
@@ -88,7 +100,7 @@ async function fetchKeeperRepoMappings(): Promise<KeeperRepoMapping[]> {
 }
 
 async function saveKeeperRepos(keeperId: string, repos: string[]): Promise<void> {
-  await post(`/api/v1/keepers/${encodeURIComponent(keeperId)}/repos`, { repos })
+  await post(`/api/v1/keeper-repos/${encodeURIComponent(keeperId)}`, { repositories: repos })
 }
 
 // ── Helpers ──────────────────────────────────────────────
@@ -181,7 +193,7 @@ export async function loadKeeperRepoMappings(options?: { force?: boolean }): Pro
       for (const k of keepersState.value.data) {
         const id = k.keeper_id ?? k.name
         if (!next.has(id)) {
-          next.set(id, new Set<string>())
+          next.set(id, '*')
         }
       }
     }
@@ -268,7 +280,7 @@ export function KeeperRepoMapping() {
 
   function handleToggleRepo(keeperId: string, repoId: string) {
     const mapping = mappingByKeeper.get(keeperId)
-    const original = mapping ? buildRepoSetFromMapping(mapping) : new Set<string>()
+    const original = mapping ? buildRepoSetFromMapping(mapping) : '*'
     const current = getDraftForKeeper(keeperId, original)
     const next = toggleRepo(keeperId, repoId, current)
     const nextMap = new Map(draftMappings.value)
@@ -278,7 +290,7 @@ export function KeeperRepoMapping() {
 
   function handleToggleAllowAll(keeperId: string) {
     const mapping = mappingByKeeper.get(keeperId)
-    const original = mapping ? buildRepoSetFromMapping(mapping) : new Set<string>()
+    const original = mapping ? buildRepoSetFromMapping(mapping) : '*'
     const current = getDraftForKeeper(keeperId, original)
     const next = toggleAllowAll(keeperId, current)
     const nextMap = new Map(draftMappings.value)
@@ -315,7 +327,7 @@ export function KeeperRepoMapping() {
             const keeperId = keeper.keeper_id ?? keeper.name
             const keeperName = keeper.name
             const mapping = mappingByKeeper.get(keeperId)
-            const original = mapping ? buildRepoSetFromMapping(mapping) : new Set<string>()
+            const original = mapping ? buildRepoSetFromMapping(mapping) : '*'
             const draft = getDraftForKeeper(keeperId, original)
             const allowAll = isAllowAll(keeperId, draft)
             const changed = hasChanges(keeperId, original, draft)

--- a/dashboard/src/components/repo-detail-panel.ts
+++ b/dashboard/src/components/repo-detail-panel.ts
@@ -42,12 +42,30 @@ function normalizeBranch(raw: unknown): BranchInfo | null {
   }
 }
 
+function unwrapRepository(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object') throw new Error('Invalid repository response')
+  const record = raw as Record<string, unknown>
+  if (record.ok === true && record.data && typeof record.data === 'object') {
+    return record.data as Record<string, unknown>
+  }
+  return record
+}
+
+function branchRows(raw: unknown): unknown[] {
+  if (Array.isArray(raw)) return raw
+  if (raw && typeof raw === 'object') {
+    const record = raw as Record<string, unknown>
+    if (Array.isArray(record.branches)) return record.branches
+    if (record.ok === true && Array.isArray(record.data)) return record.data
+  }
+  return []
+}
+
 export async function loadRepoDetail(id: string): Promise<void> {
   if (repoDetailState.value.status === 'loading') return
   await repoDetailResource.load(async () => {
     const raw = await get<unknown>(`/api/v1/repositories/${encodeURIComponent(id)}`)
-    if (!raw || typeof raw !== 'object') throw new Error('Invalid repository response')
-    const r = raw as Record<string, unknown>
+    const r = unwrapRepository(raw)
     return {
       id: typeof r.id === 'string' ? r.id : id,
       name: typeof r.name === 'string' ? r.name : '',
@@ -58,28 +76,24 @@ export async function loadRepoDetail(id: string): Promise<void> {
       auto_sync: r.auto_sync === true,
       sync_interval: typeof r.sync_interval === 'number' ? r.sync_interval : 300,
       credential_id: typeof r.credential_id === 'string' ? r.credential_id : null,
-      created_at: typeof r.created_at === 'string' ? r.created_at : '',
-      updated_at: typeof r.updated_at === 'string' ? r.updated_at : '',
+      created_at: typeof r.created_at === 'string' || typeof r.created_at === 'number' ? r.created_at : null,
+      updated_at: typeof r.updated_at === 'string' || typeof r.updated_at === 'number' ? r.updated_at : null,
     } as Repository
   })
 }
 
 export async function loadRepoBranches(id: string): Promise<void> {
   await branchesResource.load(async () => {
-    try {
-      const raw = await get<unknown[]>(`/api/v1/repositories/${encodeURIComponent(id)}/branches`)
-      return raw.map(normalizeBranch).filter((b): b is BranchInfo => b !== null)
-    } catch {
-      // Branch endpoint may not exist yet; return empty list
-      return []
-    }
+    const raw = await get<unknown>(`/api/v1/repositories/${encodeURIComponent(id)}/branches`)
+    return branchRows(raw).map(normalizeBranch).filter((b): b is BranchInfo => b !== null)
   })
 }
 
 function normalizeRepoStatus(raw: string | undefined): RepoStatus {
-  switch (raw) {
+  switch (raw?.toLowerCase()) {
     case 'active': return 'active'
     case 'paused': return 'paused'
+    case 'cloning': return 'active'
     case 'error': return 'error'
     default: return 'active'
   }
@@ -107,10 +121,11 @@ function StatusBadge({ status }: { status: RepoStatus }) {
   `
 }
 
-function formatDate(iso: string): string {
-  if (!iso) return '--'
+function formatDate(value: string | number | null): string {
+  if (value === null || value === '') return '--'
   try {
-    const d = new Date(iso)
+    const d = typeof value === 'number' ? new Date(value * 1000) : new Date(value)
+    if (Number.isNaN(d.getTime())) return String(value)
     return d.toLocaleString('ko-KR', {
       year: 'numeric',
       month: '2-digit',
@@ -119,7 +134,7 @@ function formatDate(iso: string): string {
       minute: '2-digit',
     })
   } catch {
-    return iso
+    return String(value)
   }
 }
 
@@ -298,6 +313,8 @@ export function RepoDetailPanel() {
 
         ${branchesLoading
           ? html`<${LoadingState} class="py-4">브랜치 목록 불러오는 중...<//>`
+          : branchState.status === 'error'
+            ? html`<${ErrorState} message=${branchState.message} />`
           : branches.length === 0
             ? html`
               <div class="py-4 text-center text-2xs text-[var(--color-fg-muted)]">

--- a/dashboard/src/components/repo-sidebar.ts
+++ b/dashboard/src/components/repo-sidebar.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { get, post } from '../api/core'
+import { authHeaders, get, post } from '../api/core'
 import { createAsyncResource } from '../lib/async-state'
 import { LoadingState, ErrorState } from './common/feedback-state'
 import { showToast } from './common/toast'
@@ -23,8 +23,8 @@ export interface Repository {
   auto_sync: boolean
   sync_interval: number
   credential_id: string | null
-  created_at: string
-  updated_at: string
+  created_at: string | number | null
+  updated_at: string | number | null
 }
 
 // ── State ────────────────────────────────────────────────
@@ -37,12 +37,23 @@ export const showAddRepoDialog = signal(false)
 // ── API ──────────────────────────────────────────────────
 
 function normalizeRepoStatus(raw: string | undefined): RepoStatus {
-  switch (raw) {
+  switch (raw?.toLowerCase()) {
     case 'active': return 'active'
     case 'paused': return 'paused'
+    case 'cloning': return 'active'
     case 'error': return 'error'
     default: return 'active'
   }
+}
+
+function repositoryRows(raw: unknown): unknown[] {
+  if (Array.isArray(raw)) return raw
+  if (raw && typeof raw === 'object') {
+    const record = raw as Record<string, unknown>
+    if (Array.isArray(record.repositories)) return record.repositories
+    if (record.ok === true && Array.isArray(record.data)) return record.data
+  }
+  return []
 }
 
 function normalizeRepository(raw: unknown): Repository | null {
@@ -61,15 +72,15 @@ function normalizeRepository(raw: unknown): Repository | null {
     auto_sync: r.auto_sync === true,
     sync_interval: typeof r.sync_interval === 'number' ? r.sync_interval : 300,
     credential_id: typeof r.credential_id === 'string' ? r.credential_id : null,
-    created_at: typeof r.created_at === 'string' ? r.created_at : '',
-    updated_at: typeof r.updated_at === 'string' ? r.updated_at : '',
+    created_at: typeof r.created_at === 'string' || typeof r.created_at === 'number' ? r.created_at : null,
+    updated_at: typeof r.updated_at === 'string' || typeof r.updated_at === 'number' ? r.updated_at : null,
   }
 }
 
 export async function fetchRepositories(): Promise<void> {
   await reposResource.load(async () => {
-    const raw = await get<unknown[]>('/api/v1/repositories')
-    return raw.map(normalizeRepository).filter((r): r is Repository => r !== null)
+    const raw = await get<unknown>('/api/v1/repositories')
+    return repositoryRows(raw).map(normalizeRepository).filter((r): r is Repository => r !== null)
   })
 }
 
@@ -86,7 +97,14 @@ export async function syncRepository(id: string): Promise<void> {
 
 export async function deleteRepository(id: string): Promise<void> {
   try {
-    await post(`/api/v1/repositories/${encodeURIComponent(id)}/delete`, {})
+    const res = await fetch(`/api/v1/repositories/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      headers: authHeaders(),
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '삭제 실패')
+      throw new Error(text || '삭제 실패')
+    }
     showToast('저장소 삭제 완료', 'success')
     await fetchRepositories()
     if (selectedRepoId.value === id) {

--- a/dashboard/src/components/repository-management.ts
+++ b/dashboard/src/components/repository-management.ts
@@ -1,0 +1,70 @@
+// Repository management surface -- registered repos, credentials, keeper access.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { RepoSidebar } from './repo-sidebar'
+import { RepoDetailPanel } from './repo-detail-panel'
+import { AddRepoDialog } from './add-repo-dialog'
+import { CredentialSettings } from './credential-settings'
+import { KeeperRepoMapping } from './keeper-repo-mapping'
+import { GitBranch, KeyRound, ShieldCheck } from 'lucide-preact'
+
+type RepositoryView = 'repos' | 'credentials' | 'mappings'
+
+const activeView = signal<RepositoryView>('repos')
+
+function viewButton(view: RepositoryView, label: string, icon: unknown) {
+  const active = activeView.value === view
+  return html`
+    <button
+      type="button"
+      class="inline-flex h-8 items-center gap-2 rounded border px-3 text-xs font-semibold transition-colors cursor-pointer ${active
+        ? 'border-accent/40 bg-accent/15 text-accent'
+        : 'border-[var(--white-10)] bg-[var(--white-4)] text-text-muted hover:bg-[var(--white-8)] hover:text-text-body'}"
+      aria-pressed=${active}
+      onClick=${() => { activeView.value = view }}
+    >
+      ${icon}
+      ${label}
+    </button>
+  `
+}
+
+export function RepositoryManagement() {
+  const view = activeView.value
+
+  return html`
+    <div class="flex min-h-[calc(100vh-12rem)] flex-col gap-4">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 class="m-0 text-sm font-bold text-text-strong">저장소 운영</h2>
+        </div>
+        <div class="flex flex-wrap items-center gap-2" role="tablist" aria-label="저장소 운영 보기">
+          ${viewButton('repos', '저장소', html`<${GitBranch} size=${14} aria-hidden="true" />`)}
+          ${viewButton('credentials', 'Credentials', html`<${KeyRound} size=${14} aria-hidden="true" />`)}
+          ${viewButton('mappings', 'Keeper 접근', html`<${ShieldCheck} size=${14} aria-hidden="true" />`)}
+        </div>
+      </div>
+
+      ${view === 'repos' ? html`
+        <div class="grid min-h-0 flex-1 grid-cols-[18rem_minmax(0,1fr)] overflow-hidden rounded border border-[var(--white-8)] bg-[var(--white-3)] max-[900px]:grid-cols-1">
+          <div class="min-h-0 border-r border-[var(--white-8)] max-[900px]:border-r-0 max-[900px]:border-b">
+            <${RepoSidebar} />
+          </div>
+          <div class="min-h-0 overflow-y-auto p-4">
+            <${RepoDetailPanel} />
+          </div>
+        </div>
+        <${AddRepoDialog} />
+      ` : view === 'credentials' ? html`
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-4">
+          <${CredentialSettings} />
+        </div>
+      ` : html`
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-4">
+          <${KeeperRepoMapping} />
+        </div>
+      `}
+    </div>
+  `
+}

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -10,14 +10,17 @@ import { VerificationRequestsPanel } from './verification-requests-panel'
 import { ErrorBoundary } from './common/error-boundary'
 import { LoadingState } from './common/feedback-state'
 
-type WorkSection = 'board' | 'planning' | 'collab-mvp' | 'verification'
+type WorkSection = 'board' | 'planning' | 'repositories' | 'collab-mvp' | 'verification'
 
 const LazyCollabMvp = lazy(async () => ({
   default: (await import('./collab-mvp')).CollabMvp,
 }))
+const LazyRepositoryManagement = lazy(async () => ({
+  default: (await import('./repository-management')).RepositoryManagement,
+}))
 
 function isWorkSection(v: string | undefined): v is WorkSection {
-  return v === 'board' || v === 'planning' || v === 'collab-mvp' || v === 'verification'
+  return v === 'board' || v === 'planning' || v === 'repositories' || v === 'collab-mvp' || v === 'verification'
 }
 
 export function Work() {
@@ -31,6 +34,11 @@ export function Work() {
         <${ErrorBoundary} label=${current}>
           ${current === 'board' ? html`<${Memory} />`
             : current === 'planning' ? html`<${PlanningPanel} />`
+            : current === 'repositories' ? html`
+              <${Suspense} fallback=${html`<${LoadingState}>저장소 화면 불러오는 중...<//>`}>
+                <${LazyRepositoryManagement} />
+              <//>
+            `
             : current === 'collab-mvp' ? html`
               <${Suspense} fallback=${html`<${LoadingState}>협업 화면 불러오는 중...<//>`}>
                 <${LazyCollabMvp} />

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -26,6 +26,7 @@ type SurfaceSectionId =
   // workspace
   | 'board'
   | 'planning'       // Phase 1: absorbs goals
+  | 'repositories'   // Multi-repository cockpit and keeper access mapping
   | 'collab-mvp'     // Track 1: CRDT/editor/git graph/claim queue contract
   | 'verification'   // CDAL follow-up (#7531): Mission detail verification table
   // lab
@@ -261,6 +262,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '계획 & 목표',
       description: '실행 단위 칸반과 상위 의도 구조(목표 트리)를 함께 봅니다.',
       params: { section: 'planning' },
+    },
+    {
+      id: 'repositories',
+      label: '저장소',
+      description: '등록 저장소, 브랜치, credential, keeper 접근 범위를 저장소별로 봅니다.',
+      params: { section: 'repositories' },
     },
     {
       id: 'collab-mvp',

--- a/lib/repo_manager/credential_store.ml
+++ b/lib/repo_manager/credential_store.ml
@@ -5,10 +5,31 @@ let ( let* ) = Result.bind
 let creds_toml_path base_path =
   Filename.concat base_path ".masc/config/credentials.toml"
 
+let default_credential =
+  {
+    id = "default";
+    cred_type = Local;
+    username = "default";
+    gh_config_dir = None;
+    ssh_key_path = None;
+    gpg_key_id = None;
+  }
+
+let ensure_dir path =
+  let rec loop dir =
+    if dir = "" || dir = "." || Sys.file_exists dir then ()
+    else begin
+      loop (Filename.dirname dir);
+      try Unix.mkdir dir 0o755
+      with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    end
+  in
+  loop path
+
 let credential_type_of_string = function
-  | "Github" -> Ok Github
-  | "Gitlab" -> Ok Gitlab
-  | "Local" -> Ok Local
+  | "Github" | "github" -> Ok Github
+  | "Gitlab" | "gitlab" -> Ok Gitlab
+  | "Local" | "local" -> Ok Local
   | s -> Error (Printf.sprintf "Unknown credential type: %s" s)
 
 let string_of_credential_type = function
@@ -92,9 +113,7 @@ let load_all ~base_path =
 let save_all ~base_path (creds : credential list) =
   let path = creds_toml_path base_path in
   let config_dir = Filename.dirname path in
-  (try
-     if not (Sys.file_exists config_dir) then Sys.mkdir config_dir 0o755
-   with Sys_error _ -> ());
+  ensure_dir config_dir;
   let cred_entries =
     List.map (fun (cred : credential) -> (cred.id, toml_of_credential cred)) creds
   in
@@ -112,6 +131,7 @@ let find ~base_path id =
   let* creds = load_all ~base_path in
   match List.find_opt (fun (c : credential) -> String.equal c.id id) creds with
   | Some cred -> Ok cred
+  | None when String.equal id default_credential.id -> Ok default_credential
   | None -> Error (Printf.sprintf "Credential not found: %s" id)
 
 let add ~base_path (cred : credential) =

--- a/lib/repo_manager/credential_store.mli
+++ b/lib/repo_manager/credential_store.mli
@@ -1,5 +1,10 @@
 open Repo_manager_types
 
+val default_credential : credential
+(** Local unauthenticated credential used for public/local repositories when a
+    repository explicitly references [default] and no configured credential is
+    present. *)
+
 val load_all : base_path:string -> (credential list, string) result
 (** [load_all ~base_path] loads all credentials from
     [.masc/config/credentials.toml]. *)

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -12,6 +12,7 @@
    repo_sync)
  (wrapped false)
  (libraries
+   masc_mcp.masc_exec
    yojson
    otoml
    unix)

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -5,6 +5,17 @@ let ( let* ) = Result.bind
 let mappings_toml_path base_path =
   Filename.concat base_path ".masc/config/keeper_repo_mappings.toml"
 
+let ensure_dir path =
+  let rec loop dir =
+    if dir = "" || dir = "." || Sys.file_exists dir then ()
+    else begin
+      loop (Filename.dirname dir);
+      try Unix.mkdir dir 0o755
+      with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    end
+  in
+  loop path
+
 let mapping_of_toml toml keeper_id =
   let path field = ["mapping"; keeper_id; field] in
   let* repository_ids =
@@ -86,13 +97,15 @@ let save_all ~base_path mappings =
   in
   let toml = Otoml.TomlTable [("mapping", Otoml.TomlTable table)] in
   let dir = Filename.dirname path in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  ensure_dir dir;
   let content = Otoml.Printer.to_string toml in
-  let oc = open_out path in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () -> output_string oc content);
-  Ok ()
+  try
+    let oc = open_out path in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc content);
+    Ok ()
+  with Sys_error msg -> Error msg
 
 let save_mapping ~base_path mapping =
   let* mappings = load_all ~base_path in

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -1,5 +1,9 @@
 open Repo_manager_types
 
+val load_all : base_path:string -> (keeper_repo_mapping list, string) result
+(** [load_all ~base_path] loads all keeper-repository mappings from
+    [.masc/config/keeper_repo_mappings.toml]. *)
+
 val allowed_repositories :
   keeper_id:string -> base_path:string -> (repository_id list, string) result
 (** [allowed_repositories ~keeper_id ~base_path] returns the list of

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -1,45 +1,87 @@
 open Repo_manager_types
 
+let ensure_dir path =
+  let rec loop dir =
+    if dir = "" || dir = "." || Sys.file_exists dir then ()
+    else begin
+      loop (Filename.dirname dir);
+      try Unix.mkdir dir 0o755
+      with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    end
+  in
+  loop path
+
+let merge_env overrides =
+  let keys = List.map fst overrides in
+  let has_key entry =
+    match String.index_opt entry '=' with
+    | None -> false
+    | Some idx ->
+        let key = String.sub entry 0 idx in
+        List.exists (String.equal key) keys
+  in
+  let inherited =
+    Unix.environment ()
+    |> Array.to_list
+    |> List.filter (fun entry -> not (has_key entry))
+  in
+  Array.of_list
+    (List.map (fun (k, v) -> Printf.sprintf "%s=%s" k v) overrides
+     @ inherited)
+
 let env_of_credential credential =
+  let non_interactive =
+    [
+      ("GIT_TERMINAL_PROMPT", "0");
+      ("GIT_ASKPASS", "true");
+      ("SSH_ASKPASS", "true");
+    ]
+  in
   match credential.cred_type with
   | Github | Gitlab -> (
       match credential.gh_config_dir with
-      | Some dir -> [Printf.sprintf "GH_CONFIG_DIR=%s" dir]
-      | None -> [])
+      | Some dir -> ("GH_CONFIG_DIR", dir) :: non_interactive
+      | None -> non_interactive)
   | Local -> (
       match credential.ssh_key_path with
-      | Some key -> [Printf.sprintf "GIT_SSH_COMMAND=ssh -i %s" key]
-      | None -> [])
+      | Some key -> ("GIT_SSH_COMMAND", Printf.sprintf "ssh -i %S" key) :: non_interactive
+      | None -> non_interactive)
 
-let run_git ~cwd ?(env = []) args =
-  let env_prefix =
-    if env = [] then "" else String.concat " " env ^ " "
+let split_lines text =
+  if text = "" then []
+  else String.split_on_char '\n' text |> List.filter (fun line -> line <> "")
+
+let run_git ~cwd ?(env = []) args : (string list, string) result =
+  let argv = "git" :: "-C" :: cwd :: args in
+  let envp = merge_env env in
+  let raw_source = String.concat " " (List.map Filename.quote argv) in
+  let status, stdout, stderr =
+    Masc_exec.Exec_gate.run_argv_with_status_split
+      ~actor:"repo-manager/git" ~raw_source ~summary:"repo manager git"
+      ~timeout_sec:300.0 ~env:envp argv
   in
-  let cmd =
-    Printf.sprintf "%sgit -C %S %s" env_prefix cwd
-      (String.concat " " (List.map Filename.quote args))
-  in
-  let ic = Unix.open_process_in cmd in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () ->
-      let rec loop acc =
-        match input_line ic with
-        | line -> loop (line :: acc)
-        | exception End_of_file -> List.rev acc
+  match status with
+  | Unix.WEXITED 0 -> Ok (split_lines stdout)
+  | _ ->
+      let status_text =
+        match status with
+        | Unix.WEXITED code -> Printf.sprintf "exit %d" code
+        | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
+        | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
       in
-      let lines = loop [] in
-      match Unix.close_process_in ic with
-      | Unix.WEXITED 0 -> Ok lines
-      | _ -> Error (Printf.sprintf "git command failed: %s" cmd))
+      let detail =
+        let stderr = String.trim stderr in
+        let stdout = String.trim stdout in
+        if stderr <> "" then status_text ^ ": " ^ stderr
+        else if stdout <> "" then status_text ^ ": " ^ stdout
+        else status_text
+      in
+      Error (Printf.sprintf "git %s failed: %s" (String.concat " " args) detail)
 
 let clone ~repository ~credential =
   let env = env_of_credential credential in
   let parent_dir = Filename.dirname repository.local_path in
-  (try
-     if not (Sys.file_exists parent_dir) then
-       Sys.mkdir parent_dir 0o755
-   with Sys_error _ -> ());
+  ensure_dir parent_dir;
   match
     run_git ~cwd:parent_dir ~env
       ["clone"; repository.url; repository.local_path]
@@ -60,14 +102,13 @@ let fetch ~repository ~credential : (string list, string) result =
       | Error msg -> Error msg)
 
 let checkout_worktree ~repository ~branch =
-  let worktree_path =
-    Filename.concat repository.local_path (Printf.sprintf "_worktrees/%s" branch)
+  let safe_branch_path =
+    String.map (function '/' | ':' | '\\' -> '-' | c -> c) branch
   in
-  (try
-     if not (Sys.file_exists worktree_path) then
-       let parent = Filename.dirname worktree_path in
-       if not (Sys.file_exists parent) then Sys.mkdir parent 0o755
-   with Sys_error _ -> ());
+  let worktree_path =
+    Filename.concat repository.local_path (Printf.sprintf "_worktrees/%s" safe_branch_path)
+  in
+  ensure_dir (Filename.dirname worktree_path);
   match
     run_git ~cwd:repository.local_path
       ["worktree"; "add"; worktree_path; branch]

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -5,6 +5,21 @@ let ( let* ) = Result.bind
 let repos_toml_path base_path =
   Filename.concat base_path ".masc/config/repositories.toml"
 
+let default_local_path id = Filename.concat ".masc/repos" id
+
+let now_unix_seconds () = Int64.of_float (Unix.time ())
+
+let ensure_dir path =
+  let rec loop dir =
+    if dir = "" || dir = "." || Sys.file_exists dir then ()
+    else begin
+      loop (Filename.dirname dir);
+      try Unix.mkdir dir 0o755
+      with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    end
+  in
+  loop path
+
 let string_of_status = function
   | Active -> "Active"
   | Paused -> "Paused"
@@ -12,43 +27,55 @@ let string_of_status = function
   | Error _ -> "Error"
 
 let status_of_string = function
-  | "Active" -> Ok Active
-  | "Paused" -> Ok Paused
-  | "Cloning" -> Ok Cloning
-  | "Error" -> Ok (Error "")
+  | "Active" | "active" -> Ok Active
+  | "Paused" | "paused" -> Ok Paused
+  | "Cloning" | "cloning" -> Ok Cloning
+  | "Error" | "error" -> Ok (Error "")
   | s -> Error (Printf.sprintf "Unknown repository status: %s" s)
 
 let repository_of_toml toml id =
   let ( let* ) = Result.bind in
   let path field = ["repository"; id; field] in
+  let find_string_default field default =
+    match Otoml.find_result toml Otoml.get_string (path field) with
+    | Ok value -> Ok value
+    | Error _ -> Ok default
+  in
+  let find_bool_default field default =
+    match Otoml.find_result toml Otoml.get_boolean (path field) with
+    | Ok value -> Ok value
+    | Error _ -> Ok default
+  in
+  let find_int64_default field default =
+    match Otoml.Helpers.find_integer_result toml (path field) with
+    | Ok value -> Ok (Int64.of_int value)
+    | Error _ -> Ok default
+  in
+  let find_string_list_default field default =
+    match Otoml.Helpers.find_strings_result toml (path field) with
+    | Ok value -> Ok value
+    | Error _ -> Ok default
+  in
   let* name = Otoml.find_result toml Otoml.get_string (path "name") in
   let* url = Otoml.find_result toml Otoml.get_string (path "url") in
-  let* local_path = Otoml.find_result toml Otoml.get_string (path "local_path") in
-  let* default_branch =
-    Otoml.find_result toml Otoml.get_string (path "default_branch")
-  in
-  let* credential_id =
-    Otoml.find_result toml Otoml.get_string (path "credential_id")
-  in
-  let* keepers =
-    Otoml.Helpers.find_strings_result toml (path "keepers")
-  in
-  let* status_str =
-    Otoml.find_result toml Otoml.get_string (path "status")
-  in
+  let* local_path = find_string_default "local_path" (default_local_path id) in
+  let* default_branch = find_string_default "default_branch" "main" in
+  let* credential_id = find_string_default "credential_id" "default" in
+  let* keepers = find_string_list_default "keepers" [] in
+  let* status_str = find_string_default "status" "Active" in
   let* status = status_of_string status_str in
-  let* auto_sync =
-    Otoml.find_result toml Otoml.get_boolean (path "auto_sync")
+  let status =
+    match status with
+    | Error _ -> (
+        match Otoml.find_result toml Otoml.get_string (path "status_error") with
+        | Ok msg -> Error msg
+        | Error _ -> Error "")
+    | other -> other
   in
-  let* sync_interval =
-    Otoml.Helpers.find_integer_result toml (path "sync_interval")
-  in
-  let* created_at =
-    Otoml.Helpers.find_integer_result toml (path "created_at")
-  in
-  let* updated_at =
-    Otoml.Helpers.find_integer_result toml (path "updated_at")
-  in
+  let* auto_sync = find_bool_default "auto_sync" false in
+  let* sync_interval = find_int64_default "sync_interval" (Int64.of_int 300) in
+  let* created_at = find_int64_default "created_at" Int64.zero in
+  let* updated_at = find_int64_default "updated_at" Int64.zero in
   Ok
     {
       id;
@@ -60,13 +87,13 @@ let repository_of_toml toml id =
       keepers;
       status;
       auto_sync;
-      sync_interval;
-      created_at = Int64.of_int created_at;
-      updated_at = Int64.of_int updated_at;
+      sync_interval = Int64.to_int sync_interval;
+      created_at;
+      updated_at;
     }
 
 let toml_of_repository repo =
-  Otoml.TomlTable
+  let fields =
     [
       ("name", Otoml.string repo.name);
       ("url", Otoml.string repo.url);
@@ -82,6 +109,14 @@ let toml_of_repository repo =
       ("created_at", Otoml.integer (Int64.to_int repo.created_at));
       ("updated_at", Otoml.integer (Int64.to_int repo.updated_at));
     ]
+  in
+  let fields =
+    match repo.status with
+    | Error msg when String.trim msg <> "" ->
+        ("status_error", Otoml.string msg) :: fields
+    | _ -> fields
+  in
+  Otoml.TomlTable fields
 
 let load_all ~base_path =
   let path = repos_toml_path base_path in
@@ -115,9 +150,7 @@ let load_all ~base_path =
 let save_all ~base_path (repos : repository list) =
   let path = repos_toml_path base_path in
   let config_dir = Filename.dirname path in
-  (try
-     if not (Sys.file_exists config_dir) then Sys.mkdir config_dir 0o755
-   with Sys_error _ -> ());
+  ensure_dir config_dir;
   let repo_entries =
     List.map (fun (repo : repository) -> (repo.id, toml_of_repository repo)) repos
   in
@@ -142,6 +175,20 @@ let add ~base_path (repo : repository) =
   if List.exists (fun (r : repository) -> String.equal r.id repo.id) repos then
     Error (Printf.sprintf "Repository already exists: %s" repo.id)
   else
+    let now = now_unix_seconds () in
+    let repo =
+      {
+        repo with
+        local_path =
+          (if String.trim repo.local_path = "" then default_local_path repo.id
+           else repo.local_path);
+        credential_id =
+          (if String.trim repo.credential_id = "" then "default"
+           else repo.credential_id);
+        created_at = (if Int64.equal repo.created_at Int64.zero then now else repo.created_at);
+        updated_at = (if Int64.equal repo.updated_at Int64.zero then now else repo.updated_at);
+      }
+    in
     let* () = save_all ~base_path (repo :: repos) in
     Ok repo
 
@@ -158,12 +205,13 @@ let remove ~base_path id =
 let update_status ~base_path id status =
   let* repos = load_all ~base_path in
   let found = ref false in
+  let now = now_unix_seconds () in
   let updated =
     List.map
       (fun (r : repository) ->
         if String.equal r.id id then (
           found := true;
-          { r with status })
+          { r with status; updated_at = now })
         else r)
       repos
   in

--- a/lib/repo_manager/repo_sync.ml
+++ b/lib/repo_manager/repo_sync.ml
@@ -5,7 +5,16 @@ let ( let* ) = Result.bind
 let sync_repository ~base_path repo credential : (unit, string) result =
   let local_path = Repo_store.local_path ~base_path repo in
   let repo_with_path = { repo with local_path } in
-  match Repo_git.fetch ~repository:repo_with_path ~credential with
+  let* () = Repo_store.update_status ~base_path repo.id Cloning in
+  let sync_result =
+    if Sys.file_exists local_path then
+      Repo_git.fetch ~repository:repo_with_path ~credential
+    else
+      match Repo_git.clone ~repository:repo_with_path ~credential with
+      | Error msg -> Error msg
+      | Ok () -> Repo_git.fetch ~repository:repo_with_path ~credential
+  in
+  match sync_result with
   | Error msg ->
       let* () = Repo_store.update_status ~base_path repo.id (Error msg) in
       Error msg

--- a/lib/server/server_routes_http_routes_credentials.ml
+++ b/lib/server/server_routes_http_routes_credentials.ml
@@ -4,15 +4,18 @@ open Server_utils
 module Http = Http_server_eio
 
 let credential_json (c : Repo_manager_types.credential) : Yojson.Safe.t =
+  let typ =
+    match c.cred_type with
+    | Github -> "github"
+    | Gitlab -> "gitlab"
+    | Local -> "local"
+  in
   `Assoc
     [
       ("id", `String c.id);
-      ( "cred_type",
-        `String
-          (match c.cred_type with
-           | Github -> "github"
-           | Gitlab -> "gitlab"
-           | Local -> "local") );
+      ("name", `String c.username);
+      ("type", `String typ);
+      ("cred_type", `String typ);
       ("username", `String c.username);
       ( "gh_config_dir",
         match c.gh_config_dir with Some s -> `String s | None -> `Null );
@@ -32,6 +35,17 @@ let credential_of_json (json : Yojson.Safe.t) :
         | Some _ -> Error (Printf.sprintf "field %s must be a string" key)
         | None -> Error (Printf.sprintf "missing field %s" key)
       in
+      let get_string_alias keys =
+        let rec loop = function
+          | [] -> Error (Printf.sprintf "missing field %s" (String.concat "/" keys))
+          | key :: rest -> (
+              match List.assoc_opt key fields with
+              | Some (`String s) -> Ok s
+              | Some _ -> Error (Printf.sprintf "field %s must be a string" key)
+              | None -> loop rest)
+        in
+        loop keys
+      in
       let get_opt_string key =
         match List.assoc_opt key fields with
         | Some (`String s) -> Ok (Some s)
@@ -40,8 +54,8 @@ let credential_of_json (json : Yojson.Safe.t) :
         | None -> Ok None
       in
       let* id = get_string "id" in
-      let* cred_type_str = get_string "cred_type" in
-      let* username = get_string "username" in
+      let* cred_type_str = get_string_alias ["cred_type"; "type"] in
+      let* username = get_string_alias ["username"; "name"] in
       let* gh_config_dir = get_opt_string "gh_config_dir" in
       let* ssh_key_path = get_opt_string "ssh_key_path" in
       let* gpg_key_id = get_opt_string "gpg_key_id" in
@@ -67,7 +81,21 @@ let add_routes router =
                   (`Assoc [ ("ok", `Bool false); ("error", `String msg) ]))
                reqd
          | Ok credentials ->
-             let json = `Assoc [ ("credentials", `List (List.map credential_json credentials)) ] in
+             let credentials =
+               if List.exists
+                    (fun (c : Repo_manager_types.credential) ->
+                      String.equal c.id Credential_store.default_credential.id)
+                    credentials
+               then credentials
+               else Credential_store.default_credential :: credentials
+             in
+             let json =
+               `Assoc
+                 [
+                   ("credentials", `List (List.map credential_json credentials));
+                   ("total", `Int (List.length credentials));
+                 ]
+             in
              Http.Response.json ~compress:true ~request:req
                (Yojson.Safe.to_string json)
                reqd

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -3,135 +3,140 @@ open Server_utils
 
 module Http = Http_server_eio
 
+let mappings_path = "/api/v1/keeper-repos"
+let mapping_prefix = "/api/v1/keeper-repos/"
+
+let path_parts rest =
+  rest
+  |> String.split_on_char '/'
+  |> List.filter (fun part -> String.trim part <> "")
+
+let extract_keeper_id path =
+  match extract_path_param ~prefix:mapping_prefix path with
+  | None | Some "" -> Error "missing keeper id"
+  | Some rest -> (
+      match path_parts rest with
+      | [keeper_id] -> Ok keeper_id
+      | [] -> Error "missing keeper id"
+      | _ -> Error "expected path /api/v1/keeper-repos/:id")
+
 let mapping_json (m : Repo_manager_types.keeper_repo_mapping) : Yojson.Safe.t =
+  let allow_all = List.exists (String.equal "*") m.repository_ids in
   `Assoc
     [
       ("keeper_id", `String m.keeper_id);
+      ("keeper_name", `String m.keeper_id);
       ("repositories", `List (List.map (fun s -> `String s) m.repository_ids));
+      ("allowed_repos", `List (List.map (fun s -> `String s) m.repository_ids));
+      ("allow_all", `Bool allow_all);
     ]
 
 let mapping_of_json keeper_id (json : Yojson.Safe.t) :
     (Repo_manager_types.keeper_repo_mapping, string) result =
+  let list_field fields key =
+    match List.assoc_opt key fields with
+    | Some (`List items) ->
+        let rec loop acc = function
+          | [] -> Ok (List.rev acc)
+          | `String s :: rest -> loop (s :: acc) rest
+          | _ -> Error (Printf.sprintf "field %s must be an array of strings" key)
+        in
+        loop [] items
+    | Some _ -> Error (Printf.sprintf "field %s must be an array of strings" key)
+    | None -> Error (Printf.sprintf "missing field %s" key)
+  in
   match json with
   | `Assoc fields -> (
-      match List.assoc_opt "repositories" fields with
-      | Some (`List items) ->
-          let repository_ids =
-            List.filter_map
-              (function `String s -> Some s | _ -> None)
-              items
-          in
-          Ok { Repo_manager_types.keeper_id; repository_ids }
-      | Some _ -> Error "field repositories must be an array of strings"
-      | None -> Error "missing field repositories")
+      let repository_ids =
+        match List.assoc_opt "repositories" fields with
+        | Some _ -> list_field fields "repositories"
+        | None -> list_field fields "repos"
+      in
+      match repository_ids with
+      | Ok repository_ids -> Ok { Repo_manager_types.keeper_id; repository_ids }
+      | Error msg -> Error msg)
   | _ -> Error "expected JSON object body"
+
+let handle_list_mappings state req reqd =
+  let base_path = state.Mcp_server.room_config.base_path in
+  match Keeper_repo_mapping.load_all ~base_path with
+  | Error msg ->
+      Http.Response.json ~status:`Internal_server_error ~request:req
+        (Yojson.Safe.to_string
+           (`Assoc [("ok", `Bool false); ("error", `String msg)]))
+        reqd
+  | Ok mappings ->
+      Http.Response.json ~compress:true ~request:req
+        (Yojson.Safe.to_string
+           (`Assoc
+             [
+               ("mappings", `List (List.map mapping_json mappings));
+               ("total", `Int (List.length mappings));
+             ]))
+        reqd
+
+let handle_get_mapping state keeper_id req reqd =
+  let base_path = state.Mcp_server.room_config.base_path in
+  match Keeper_repo_mapping.allowed_repositories ~keeper_id ~base_path with
+  | Ok repo_ids ->
+      Http.Response.json ~compress:true ~request:req
+        (Yojson.Safe.to_string
+           (mapping_json { Repo_manager_types.keeper_id; repository_ids = repo_ids }))
+        reqd
+  | Error _ ->
+      (* No mapping is intentionally treated as wildcard access for backward
+         compatibility with pre-repository keepers. *)
+      Http.Response.json ~compress:true ~request:req
+        (Yojson.Safe.to_string
+           (mapping_json
+              { Repo_manager_types.keeper_id; repository_ids = ["*"] }))
+        reqd
+
+let handle_save_mapping state keeper_id req reqd =
+  let base_path = state.Mcp_server.room_config.base_path in
+  Http.Request.read_body_async reqd (fun body_str ->
+      let response status message =
+        Http.Response.json ~status ~request:req
+          (Yojson.Safe.to_string
+             (`Assoc [("ok", `Bool false); ("error", `String message)]))
+          reqd
+      in
+      match Yojson.Safe.from_string body_str with
+      | exception Yojson.Json_error msg -> response `Bad_request ("invalid JSON body: " ^ msg)
+      | json -> (
+          match mapping_of_json keeper_id json with
+          | Error msg -> response `Bad_request msg
+          | Ok mapping -> (
+              match Keeper_repo_mapping.save_mapping ~base_path mapping with
+              | Error msg -> response `Bad_request msg
+              | Ok () ->
+                  Http.Response.json ~request:req
+                    (Yojson.Safe.to_string (mapping_json mapping))
+                    reqd)))
 
 let add_routes router =
   router
-  |> Http.Router.prefix_get "/api/v1/keepers/" (fun request reqd ->
-       with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.room_config.base_path in
-         let path = Http.Request.path request in
-         match extract_path_param ~prefix:"/api/v1/keepers/" path with
-         | None | Some "" ->
-             Http.Response.json ~status:`Bad_request ~request:req
-               (Yojson.Safe.to_string
-                  (`Assoc
-                    [
-                      ("ok", `Bool false);
-                      ("error", `String "missing keeper id");
-                    ]))
-               reqd
-         | Some rest -> (
-             match String.split_on_char '/' rest with
-             | keeper_id :: "repos" :: [] -> (
-                 match
-                   Keeper_repo_mapping.allowed_repositories ~keeper_id ~base_path
-                 with
-                 | Error msg ->
-                     Http.Response.json ~status:`Not_found ~request:req
-                       (Yojson.Safe.to_string
-                          (`Assoc
-                            [
-                              ("ok", `Bool false); ("error", `String msg);
-                            ]))
-                       reqd
-                 | Ok repo_ids ->
-                     let json =
-                       `Assoc
-                         [
-                           ("keeper_id", `String keeper_id);
-                           ( "repositories",
-                             `List (List.map (fun s -> `String s) repo_ids) );
-                         ]
-                     in
-                     Http.Response.json ~compress:true ~request:req
-                       (Yojson.Safe.to_string json)
-                       reqd)
-             | _ ->
-                 Http.Response.json ~status:`Bad_request ~request:req
-                   (Yojson.Safe.to_string
-                      (`Assoc
-                        [
-                          ("ok", `Bool false);
-                          ( "error",
-                            `String "expected path /api/v1/keepers/:id/repos" );
-                        ]))
-                   reqd)
-       ) request reqd)
-  |> Http.Router.prefix_post "/api/v1/keepers/" (fun request reqd ->
-       with_token_permission_auth ~permission:Types.CanAdmin
-         (fun state _agent_name req reqd ->
-           let base_path = state.Mcp_server.room_config.base_path in
-           let path = Http.Request.path request in
-           match extract_path_param ~prefix:"/api/v1/keepers/" path with
-           | None | Some "" ->
+  |> Http.Router.get mappings_path (fun request reqd ->
+       with_public_read handle_list_mappings request reqd)
+  |> Http.Router.prefix_get mapping_prefix (fun request reqd ->
+       with_public_read
+         (fun state req reqd ->
+           match extract_keeper_id (Http.Request.path req) with
+           | Error msg ->
                Http.Response.json ~status:`Bad_request ~request:req
                  (Yojson.Safe.to_string
-                    (`Assoc
-                      [
-                        ("ok", `Bool false);
-                        ("error", `String "missing keeper id");
-                      ]))
+                    (`Assoc [("ok", `Bool false); ("error", `String msg)]))
                  reqd
-           | Some rest -> (
-               match String.split_on_char '/' rest with
-               | keeper_id :: "repos" :: [] ->
-                   Http.Request.read_body_async reqd (fun body_str ->
-                     let response status message =
-                       Http.Response.json ~status ~request:req
-                         (Yojson.Safe.to_string
-                            (`Assoc
-                              [
-                                ("ok", `Bool false);
-                                ("error", `String message);
-                              ]))
-                         reqd
-                     in
-                     match Yojson.Safe.from_string body_str with
-                     | exception Yojson.Json_error msg ->
-                         response `Bad_request ("invalid JSON body: " ^ msg)
-                     | json -> (
-                         match mapping_of_json keeper_id json with
-                         | Error msg -> response `Bad_request msg
-                         | Ok mapping -> (
-                             match
-                               Keeper_repo_mapping.save_mapping ~base_path mapping
-                             with
-                             | Error msg -> response `Bad_request msg
-                             | Ok () ->
-                                 Http.Response.json ~request:req
-                                   (Yojson.Safe.to_string (mapping_json mapping))
-                                   reqd)))
-               | _ ->
-                   Http.Response.json ~status:`Bad_request ~request:req
-                     (Yojson.Safe.to_string
-                        (`Assoc
-                          [
-                            ("ok", `Bool false);
-                            ( "error",
-                              `String
-                                "expected path /api/v1/keepers/:id/repos" );
-                          ]))
-                     reqd)
-         ) request reqd)
+           | Ok keeper_id -> handle_get_mapping state keeper_id req reqd)
+         request reqd)
+  |> Http.Router.prefix_post mapping_prefix (fun request reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun state _agent_name req reqd ->
+           match extract_keeper_id (Http.Request.path req) with
+           | Error msg ->
+               Http.Response.json ~status:`Bad_request ~request:req
+                 (Yojson.Safe.to_string
+                    (`Assoc [("ok", `Bool false); ("error", `String msg)]))
+                 reqd
+           | Ok keeper_id -> handle_save_mapping state keeper_id req reqd)
+         request reqd)

--- a/lib/server/server_routes_http_routes_keeper_repos.mli
+++ b/lib/server/server_routes_http_routes_keeper_repos.mli
@@ -2,8 +2,12 @@
     access control mappings.
 
     Provides endpoints for managing which repositories a keeper may access:
-    - GET /api/v1/keepers/:id/repos — list allowed repositories for keeper
-    - POST /api/v1/keepers/:id/repos — update mapping for keeper
+    - GET /api/v1/keeper-repos — list configured mappings
+    - GET /api/v1/keeper-repos/:id — list allowed repositories for keeper
+    - POST /api/v1/keeper-repos/:id — update mapping for keeper
+
+    The endpoint deliberately avoids [/api/v1/keepers/*] so it does not shadow
+    existing dashboard keeper detail/chat routes registered under that prefix.
 
     Only the wired routes are exposed via {!add_routes}. *)
 

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -12,14 +12,16 @@ let json_response ~status req reqd json =
   Http.Response.json ~status ~request:req
     (Yojson.Safe.to_string json) reqd
 
-let ok_json data =
-  `Assoc [("ok", `Bool true); ("data", data)]
-
 let repositories_prefix = "/api/v1/repositories/"
 let sync_suffix = "/sync"
 
 let extract_repo_id path =
   extract_path_param ~prefix:repositories_prefix path
+
+let path_parts rest =
+  rest
+  |> String.split_on_char '/'
+  |> List.filter (fun part -> String.trim part <> "")
 
 let extract_repo_id_for_sync path =
   match extract_path_param ~prefix:repositories_prefix path with
@@ -32,12 +34,170 @@ let extract_repo_id_for_sync path =
       else
         None
 
+let timestamp_json value = `Intlit (Int64.to_string value)
+
+let status_json = function
+  | Repo_manager_types.Active -> ("active", None)
+  | Paused -> ("paused", None)
+  | Cloning -> ("cloning", None)
+  | Error msg -> ("error", Some msg)
+
+let repository_json (repo : Repo_manager_types.repository) =
+  let status, error = status_json repo.status in
+  let fields =
+    [
+      ("id", `String repo.id);
+      ("name", `String repo.name);
+      ("url", `String repo.url);
+      ("local_path", `String repo.local_path);
+      ("default_branch", `String repo.default_branch);
+      ("credential_id", `String repo.credential_id);
+      ("keepers", `List (List.map (fun s -> `String s) repo.keepers));
+      ("status", `String status);
+      ("auto_sync", `Bool repo.auto_sync);
+      ("sync_interval", `Int repo.sync_interval);
+      ("created_at", timestamp_json repo.created_at);
+      ("updated_at", timestamp_json repo.updated_at);
+    ]
+  in
+  let fields =
+    match error with
+    | None -> fields
+    | Some msg -> ("error_message", `String msg) :: fields
+  in
+  `Assoc fields
+
+let branch_json ~default_branch name =
+  let remote_prefix = "remotes/" in
+  let is_remote =
+    String.starts_with ~prefix:remote_prefix name
+    || String.starts_with ~prefix:"origin/" name
+  in
+  let short_name =
+    if String.starts_with ~prefix:remote_prefix name then
+      String.sub name (String.length remote_prefix)
+        (String.length name - String.length remote_prefix)
+    else name
+  in
+  let default_names = [default_branch; "origin/" ^ default_branch] in
+  `Assoc
+    [
+      ("name", `String short_name);
+      ("is_default", `Bool (List.exists (String.equal short_name) default_names));
+      ("is_remote", `Bool is_remote);
+      ("last_commit_at", `Null);
+    ]
+
+let slug_of_repo_name name =
+  let raw = String.lowercase_ascii (String.trim name) in
+  let buf = Buffer.create (String.length raw) in
+  String.iter
+    (fun c ->
+      let keep =
+        (c >= 'a' && c <= 'z')
+        || (c >= '0' && c <= '9')
+        || c = '-'
+        || c = '_'
+      in
+      Buffer.add_char buf (if keep then c else '-'))
+    raw;
+  let slug = Buffer.contents buf |> String.trim in
+  if slug = "" then None else Some slug
+
+let repo_name_from_url url =
+  let trimmed = String.trim url in
+  let last =
+    match List.rev (String.split_on_char '/' trimmed) with
+    | part :: _ -> part
+    | [] -> trimmed
+  in
+  if Filename.check_suffix last ".git" then
+    String.sub last 0 (String.length last - 4)
+  else last
+
+let get_string_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`String s) -> Ok (Some s)
+  | Some `Null | None -> Ok None
+  | Some _ -> Error (Printf.sprintf "field %s must be a string" key)
+
+let get_bool_field fields key default =
+  match List.assoc_opt key fields with
+  | Some (`Bool b) -> Ok b
+  | None -> Ok default
+  | Some _ -> Error (Printf.sprintf "field %s must be a boolean" key)
+
+let get_int_field fields key default =
+  match List.assoc_opt key fields with
+  | Some (`Int i) -> Ok i
+  | Some (`Intlit s) -> (
+      match int_of_string_opt s with
+      | Some i -> Ok i
+      | None -> Error (Printf.sprintf "field %s must be an integer" key))
+  | None -> Ok default
+  | Some _ -> Error (Printf.sprintf "field %s must be an integer" key)
+
+let get_string_list_field fields key default =
+  match List.assoc_opt key fields with
+  | None -> Ok default
+  | Some (`List items) ->
+      let rec loop acc = function
+        | [] -> Ok (List.rev acc)
+        | `String s :: rest -> loop (s :: acc) rest
+        | _ -> Error (Printf.sprintf "field %s must be an array of strings" key)
+      in
+      loop [] items
+  | Some _ -> Error (Printf.sprintf "field %s must be an array of strings" key)
+
 let parse_repository_json body_str =
   match Yojson.Safe.from_string body_str with
-  | json -> (
-      match Repo_manager_types.repository_of_yojson json with
-      | Ok repo -> Ok repo
-      | Error msg -> Error ("invalid repository JSON: " ^ msg))
+  | `Assoc fields ->
+      let ( let* ) = Result.bind in
+      let* raw_name = get_string_field fields "name" in
+      let* raw_url = get_string_field fields "url" in
+      let url = Option.value ~default:"" raw_url |> String.trim in
+      if url = "" then Error "field url is required"
+      else
+        let inferred_name =
+          match raw_name with
+          | Some name when String.trim name <> "" -> String.trim name
+          | _ -> repo_name_from_url url
+        in
+        let* raw_id = get_string_field fields "id" in
+        let id_source =
+          match raw_id with
+          | Some id when String.trim id <> "" -> String.trim id
+          | _ -> inferred_name
+        in
+        (match slug_of_repo_name id_source with
+        | None -> Error "repository id could not be inferred"
+        | Some id ->
+            let* raw_local_path = get_string_field fields "local_path" in
+            let* raw_default_branch =
+              get_string_field fields "default_branch"
+            in
+            let* raw_credential_id = get_string_field fields "credential_id" in
+            let* keepers = get_string_list_field fields "keepers" [] in
+            let* auto_sync = get_bool_field fields "auto_sync" false in
+            let* sync_interval = get_int_field fields "sync_interval" 300 in
+            Ok
+              {
+                Repo_manager_types.id;
+                name = inferred_name;
+                url;
+                local_path =
+                  Option.value ~default:(Filename.concat ".masc/repos" id)
+                    raw_local_path;
+                default_branch = Option.value ~default:"main" raw_default_branch;
+                credential_id = Option.value ~default:"default" raw_credential_id;
+                keepers;
+                status = Active;
+                auto_sync;
+                sync_interval;
+                created_at = Int64.zero;
+                updated_at = Int64.zero;
+              })
+  | _ -> Error "invalid repository JSON: expected object"
   | exception Yojson.Json_error msg ->
       Error ("invalid JSON body: " ^ msg)
 
@@ -48,24 +208,56 @@ let handle_list_repositories state req reqd =
       json_response ~status:`Internal_server_error req reqd (json_error msg)
   | Ok repos ->
       let json =
-        ok_json (`List (List.map Repo_manager_types.repository_to_yojson repos))
+        `Assoc
+          [
+            ("repositories", `List (List.map repository_json repos));
+            ("total", `Int (List.length repos));
+          ]
       in
       Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd
 
-let handle_get_repository state req reqd =
+let handle_get_repository state id req reqd =
   let base_path = base_path_of_state state in
-  let path = Http.Request.path req in
-  match extract_repo_id path with
-  | None ->
+  match Repo_store.find ~base_path id with
+  | Error msg -> json_response ~status:`Not_found req reqd (json_error msg)
+  | Ok repo ->
+      Http.Response.json ~request:req
+        (Yojson.Safe.to_string (repository_json repo))
+        reqd
+
+let handle_list_branches state id req reqd =
+  let base_path = base_path_of_state state in
+  match Repo_store.find ~base_path id with
+  | Error msg -> json_response ~status:`Not_found req reqd (json_error msg)
+  | Ok repo -> (
+      match Repo_store.list_branches ~base_path id with
+      | Error msg ->
+          json_response ~status:`Internal_server_error req reqd (json_error msg)
+      | Ok branches ->
+          let json =
+            `Assoc
+              [
+                ("repository_id", `String id);
+                ( "branches",
+                  `List
+                    (List.map (branch_json ~default_branch:repo.default_branch)
+                       branches) );
+              ]
+          in
+          Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd)
+
+let handle_get_repository_path state req reqd =
+  match extract_repo_id (Http.Request.path req) with
+  | None | Some "" ->
       json_response ~status:`Bad_request req reqd
         (json_error "repository id path parameter required")
-  | Some id -> (
-      match Repo_store.find ~base_path id with
-      | Error msg ->
-          json_response ~status:`Not_found req reqd (json_error msg)
-      | Ok repo ->
-          let json = ok_json (Repo_manager_types.repository_to_yojson repo) in
-          Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd)
+  | Some rest -> (
+      match path_parts rest with
+      | [id] -> handle_get_repository state id req reqd
+      | [id; "branches"] -> handle_list_branches state id req reqd
+      | _ ->
+          json_response ~status:`Not_found req reqd
+            (json_error "unknown repository endpoint"))
 
 let handle_add_repository state _agent_name req reqd =
   let base_path = base_path_of_state state in
@@ -78,25 +270,28 @@ let handle_add_repository state _agent_name req reqd =
           | Error msg ->
               json_response ~status:`Bad_request req reqd (json_error msg)
           | Ok added_repo ->
-              let json =
-                ok_json (Repo_manager_types.repository_to_yojson added_repo)
-              in
+              let json = repository_json added_repo in
               Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd))
 
 let handle_remove_repository state _agent_name req reqd =
   let base_path = base_path_of_state state in
   let path = Http.Request.path req in
   match extract_repo_id path with
-  | None ->
+  | None | Some "" ->
       json_response ~status:`Bad_request req reqd
         (json_error "repository id path parameter required")
-  | Some id -> (
+  | Some rest -> (
+      match path_parts rest with
+      | [id] -> (
       match Repo_store.remove ~base_path id with
       | Error msg ->
           json_response ~status:`Not_found req reqd (json_error msg)
       | Ok () ->
-          let json = ok_json (`Assoc [("id", `String id)]) in
+          let json = `Assoc [("id", `String id); ("removed", `Bool true)] in
           Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd)
+      | _ ->
+          json_response ~status:`Bad_request req reqd
+            (json_error "DELETE expects /api/v1/repositories/:id"))
 
 let handle_sync_repository state _agent_name req reqd =
   let base_path = base_path_of_state state in
@@ -120,7 +315,23 @@ let handle_sync_repository state _agent_name req reqd =
                   json_response ~status:`Internal_server_error req reqd
                     (json_error msg)
               | Ok () ->
-                  let json = ok_json (`Assoc [("id", `String id)]) in
+                  let branches =
+                    match Repo_store.list_branches ~base_path id with
+                    | Ok branches ->
+                        `List
+                          (List.map
+                             (branch_json ~default_branch:repo.default_branch)
+                             branches)
+                    | Error _ -> `List []
+                  in
+                  let json =
+                    `Assoc
+                      [
+                        ("id", `String id);
+                        ("status", `String "active");
+                        ("branches", branches);
+                      ]
+                  in
                   Http.Response.json ~request:req (Yojson.Safe.to_string json)
                     reqd)))
 
@@ -129,7 +340,7 @@ let add_routes router =
   |> Http.Router.get "/api/v1/repositories" (fun request reqd ->
        with_public_read handle_list_repositories request reqd)
   |> Http.Router.prefix_get repositories_prefix (fun request reqd ->
-       with_public_read handle_get_repository request reqd)
+       with_public_read handle_get_repository_path request reqd)
   |> Http.Router.post "/api/v1/repositories" (fun request reqd ->
        with_token_permission_auth ~permission:Types.CanAdmin
          handle_add_repository request reqd)

--- a/test/test_credential_store.ml
+++ b/test/test_credential_store.ml
@@ -160,6 +160,16 @@ let test_find_missing () =
       | Error msg ->
           Alcotest.(check bool) "mentions not found" true (contains_substring msg "not found"))
 
+let test_find_default_without_config () =
+  with_temp_base_path (fun base_path ->
+      match Credential_store.find ~base_path "default" with
+      | Error e -> Alcotest.fail ("default credential missing: " ^ e)
+      | Ok cred ->
+          Alcotest.(check string) "id" "default" cred.id;
+          Alcotest.(check bool) "local credential"
+            true
+            (match cred.cred_type with Local -> true | _ -> false))
+
 let test_remove_existing () =
   with_temp_base_path (fun base_path ->
       let cred = sample_credential "to-remove" Local in
@@ -209,6 +219,8 @@ let () =
         [
           Alcotest.test_case "find existing" `Quick test_find_existing;
           Alcotest.test_case "find missing" `Quick test_find_missing;
+          Alcotest.test_case "default without config" `Quick
+            test_find_default_without_config;
         ] );
       ( "remove",
         [

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -33,6 +33,23 @@ let with_temp_base_path f =
       rm_rf dir)
     (fun () -> f dir)
 
+let with_empty_temp_base_path f =
+  let dir = Filename.temp_file "mapping_test_empty" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then begin
+            Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+            Unix.rmdir path
+          end else
+            Sys.remove path
+      in
+      rm_rf dir)
+    (fun () -> f dir)
+
 let write_mapping base_path keeper_id repo_ids =
   let path = Filename.concat base_path ".masc/config/keeper_repo_mappings.toml" in
   let entries =
@@ -84,7 +101,7 @@ let test_is_allowed_wildcard () =
 let test_is_allowed_no_mapping () =
   with_temp_base_path (fun base_path ->
       Alcotest.(check bool)
-        "no mapping means not allowed" false
+        "no mapping preserves legacy access" true
         (Keeper_repo_mapping.is_allowed ~keeper_id:"unknown" ~repository_id:"repo-a" ~base_path))
 
 let test_validate_access_allowed () =
@@ -134,7 +151,7 @@ let test_apply_mapping_no_mapping () =
       let filtered =
         Keeper_repo_mapping.apply_mapping ~keeper_id:"unknown" ~base_path ~repositories:repos
       in
-      Alcotest.(check int) "no mapping returns empty" 0 (List.length filtered))
+      Alcotest.(check int) "no mapping returns all for compatibility" 2 (List.length filtered))
 
 let test_allowed_repositories () =
   with_temp_base_path (fun base_path ->
@@ -152,6 +169,20 @@ let test_allowed_repositories_no_mapping () =
       | Ok _ -> Alcotest.fail "expected Error"
       | Error msg ->
           Alcotest.(check bool) "mentions no mapping" true (contains_substring msg "No mapping"))
+
+let test_save_mapping_creates_config_dir () =
+  with_empty_temp_base_path (fun base_path ->
+      let mapping =
+        { keeper_id = "keeper-new"; repository_ids = [ "repo-a"; "repo-b" ] }
+      in
+      match Keeper_repo_mapping.save_mapping ~base_path mapping with
+      | Error e -> Alcotest.fail ("save_mapping failed: " ^ e)
+      | Ok () -> (
+          match Keeper_repo_mapping.allowed_repositories ~keeper_id:"keeper-new" ~base_path with
+          | Error e -> Alcotest.fail ("allowed_repositories failed: " ^ e)
+          | Ok ids ->
+              Alcotest.(check int) "saved count" 2 (List.length ids);
+              Alcotest.(check bool) "has repo-a" true (List.mem "repo-a" ids)))
 
 let () =
   Alcotest.run "Keeper_repo_mapping"
@@ -177,5 +208,9 @@ let () =
         [
           Alcotest.test_case "returns list" `Quick test_allowed_repositories;
           Alcotest.test_case "no mapping" `Quick test_allowed_repositories_no_mapping;
+        ] );
+      ( "save_mapping",
+        [
+          Alcotest.test_case "creates config dir" `Quick test_save_mapping_creates_config_dir;
         ] );
     ]

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -49,6 +49,12 @@ let sample_repo id =
     updated_at = Int64.of_int 1700000100;
   }
 
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
 let test_load_all_empty () =
   with_temp_base_path (fun base_path ->
       match Repo_store.load_all ~base_path with
@@ -181,6 +187,25 @@ let test_status_roundtrip () =
          | Error _ -> "Error"))
     statuses
 
+let test_load_minimal_toml_defaults () =
+  with_temp_base_path (fun base_path ->
+      let path = Filename.concat base_path ".masc/config/repositories.toml" in
+      write_file path
+        "[repository.demo]\n\
+         name = \"demo\"\n\
+         url = \"https://github.com/example/demo.git\"\n";
+      match Repo_store.load_all ~base_path with
+      | Error e -> Alcotest.fail ("load failed: " ^ e)
+      | Ok [repo] ->
+          Alcotest.(check string) "id" "demo" repo.id;
+          Alcotest.(check string) "local_path default" ".masc/repos/demo" repo.local_path;
+          Alcotest.(check string) "default branch" "main" repo.default_branch;
+          Alcotest.(check string) "credential" "default" repo.credential_id;
+          Alcotest.(check bool) "auto_sync default" false repo.auto_sync;
+          Alcotest.(check int) "interval default" 300 repo.sync_interval
+      | Ok repos ->
+          Alcotest.failf "expected one repo, got %d" (List.length repos))
+
 let () =
   Alcotest.run "Repo_store"
     [
@@ -217,5 +242,10 @@ let () =
       ( "status",
         [
           Alcotest.test_case "status string roundtrip" `Quick test_status_roundtrip;
+        ] );
+      ( "defaults",
+        [
+          Alcotest.test_case "minimal TOML gets production defaults" `Quick
+            test_load_minimal_toml_defaults;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Align repository, credential, branch, delete, and keeper-repo API contracts with the dashboard clients.
- Mount a real dashboard repository management surface with repository detail, credential settings, and keeper access mapping.
- Harden repo storage defaults, credential defaults, recursive config writes, git subprocess execution, and legacy keeper allow-all behavior.

## Why
The multi-repository architecture skeleton had backend/UI contract drift: missing branch API, mismatched response shapes, conflicting keeper routes under `/api/v1/keepers/*`, shell-string git execution, and tests that disagreed with the legacy no-mapping policy. This makes the remaining slice usable through the dashboard and safer for runtime operation.

## Validation
- `scripts/dune-local.sh build test/test_repo_store.exe test/test_credential_store.exe test/test_keeper_repo_mapping.exe test/test_repo_sync.exe`
- `./_build/default/test/test_repo_store.exe`
- `./_build/default/test/test_credential_store.exe`
- `./_build/default/test/test_keeper_repo_mapping.exe`
- `./_build/default/test/test_repo_sync.exe`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard lint` (passes with three pre-existing unused eslint-disable warnings)
- `pnpm --dir dashboard build`
