### PR TITLE
feat(keeper): RFC-0019 PR-A — bridge Host_config_provider to Credential_store

### DIFF
--- a/lib/keeper/host_config_provider.ml
+++ b/lib/keeper/host_config_provider.ml
@@ -152,41 +152,160 @@ let metadata_of_binding (kb : Keeper_gh_env.keeper_binding) =
   | Some id -> base @ [ "github_identity", id ]
   | None -> base
 
-let resolve ~config ~identity:keeper_name =
+(* RFC-0019 PR-A — bridge to the multi-repo credential store
+   (#12304).  When a keeper has a [Keeper_repo_mapping] entry that
+   resolves to exactly one [Credential_store] credential we synthesise
+   a [Keeper_gh_env.keeper_binding] from that credential and reuse the
+   existing [compose_env]/[compose_ro_mounts] flow verbatim, preserving
+   every fail-closed semantics and warning the legacy path already
+   carries.  Keepers with no mapping fall through to [legacy_resolve]
+   exactly as before.
+
+   See [docs/rfc/RFC-0019-keeper-credential-unification.md] §4.2 and §5
+   (PR-A) for the rationale.  Per-repo dispatch for keepers with
+   multiple mapped credentials is delivered in PR-B; PR-A reports
+   such keepers as [Missing_bundle] with an actionable [path] field. *)
+let count_resolve_outcome ~keeper_name ~source ~reason =
+  Prometheus.inc_counter
+    "keeper_credential_provider_resolve_total"
+    ~labels:
+      [ ("keeper", keeper_name); ("source", source); ("reason", reason) ]
+    ()
+
+let bind_from_keeper_binding ~keeper_name (kb : Keeper_gh_env.keeper_binding)
+    ~extra_metadata =
+  let git_author_name, git_author_email =
+    resolve_git_identity kb ~keeper_name
+  in
+  let env = compose_env ~git_author_name ~git_author_email in
+  let ro_mounts = compose_ro_mounts ~keeper_name kb in
+  (* β7 fail-closed: resolve is called only when git_creds_enabled
+     (caller at keeper_shell_docker.ml:398-400).  If ALL credential
+     host paths are empty or missing, ro_mounts will be [].  Returning
+     Ok with empty mounts lets the keeper start in Docker with no
+     credential files — gh/git commands then fail with confusing 401
+     or "permission denied" errors.  Return Error so the caller
+     reports the real cause at sandbox creation time. *)
+  if ro_mounts = [] then
+    Error
+      (Credential_provider.Missing_bundle
+         { identity = keeper_name
+         ; path = "all credential host paths empty or missing"
+         })
+  else
+    let metadata = metadata_of_binding kb @ extra_metadata in
+    Ok
+      Credential_provider.
+        {
+          identity = kb.effective_github_identity;
+          env;
+          ro_mounts;
+          bootstrap = None;
+          metadata;
+        }
+
+let legacy_resolve ~config ~keeper_name =
   match Keeper_gh_env.keeper_binding config ~keeper_name with
   | Error reason ->
       Error
         (Credential_provider.Missing_bundle
-          { identity = keeper_name; path = reason })
-  | Ok kb ->
-      let git_author_name, git_author_email =
-        resolve_git_identity kb ~keeper_name
-      in
-      let env = compose_env ~git_author_name ~git_author_email in
-      let ro_mounts = compose_ro_mounts ~keeper_name kb in
-      (* β7 fail-closed: resolve is called only when git_creds_enabled
-         (caller at keeper_shell_docker.ml:398-400).  If ALL credential
-         host paths are empty or missing, ro_mounts will be [].  Returning
-         Ok with empty mounts lets the keeper start in Docker with no
-         credential files — gh/git commands then fail with confusing 401
-         or "permission denied" errors.  Return Error so the caller
-         reports the real cause at sandbox creation time. *)
-      if ro_mounts = [] then
-        Error
-          (Credential_provider.Missing_bundle
-            { identity = keeper_name
-            ; path = "all credential host paths empty or missing"
-            })
-      else
-        let metadata = metadata_of_binding kb in
-        Ok
-          Credential_provider.{
-            identity = kb.effective_github_identity;
-            env;
-            ro_mounts;
-            bootstrap = None;
-            metadata;
+           { identity = keeper_name; path = reason })
+  | Ok kb -> bind_from_keeper_binding ~keeper_name kb ~extra_metadata:[]
+
+(* Synthesise a [Keeper_gh_env.keeper_binding] from a credential store
+   record.  PR-A convention: [bundle_root = dirname gh_config_dir].  This
+   matches the existing host bundle layout
+   (<base>/.masc/github-identities/<id>/gh) but tolerates operator-set
+   custom paths — sibling files (gitconfig, ssh) that happen to live next
+   to [gh_config_dir] are picked up by [compose_ro_mounts] via
+   [mount_if_present]; absent siblings are silently skipped, just as in
+   the legacy path. *)
+let binding_of_credential (cred : Repo_manager_types.credential)
+    : (Keeper_gh_env.keeper_binding, string) result =
+  match cred.gh_config_dir with
+  | None ->
+      Error
+        (Printf.sprintf
+           "credential %s has no gh_config_dir; the PR-A bridge cannot \
+            materialise an unmaterialised credential. Resolution: \
+            populate gh_config_dir via dashboard or `gh auth login` \
+            into the bundle path, then retry."
+           cred.id)
+  | Some "" ->
+      Error
+        (Printf.sprintf
+           "credential %s has empty gh_config_dir" cred.id)
+  | Some gh_config_dir ->
+      (* Local name [synth_bundle_root] avoids field punning collision
+         with the [Keeper_gh_env.bundle_root] function that the
+         [Keeper_gh_env.{ ... }] qualified record syntax brings into
+         scope. *)
+      let synth_bundle_root = Filename.dirname gh_config_dir in
+      Ok
+        Keeper_gh_env.
+          {
+            github_identity = Some cred.username;
+            effective_github_identity = cred.username;
+            credential_scope = Keeper_identity;
+            git_identity_mode = "github_identity";
+            bundle_root = synth_bundle_root;
+            gh_config_dir;
           }
+
+let bind_from_credential ~keeper_name (cred : Repo_manager_types.credential) =
+  match binding_of_credential cred with
+  | Error reason ->
+      Error
+        (Credential_provider.Missing_bundle
+           { identity = keeper_name; path = reason })
+  | Ok kb ->
+      bind_from_keeper_binding ~keeper_name kb
+        ~extra_metadata:
+          [ ("credential_source", "credential_store");
+            ("credential_id", cred.id) ]
+
+let resolve ~config ~identity:keeper_name =
+  match
+    Keeper_repo_mapping.credentials_for_keeper
+      ~base_path:config.Coord.base_path ~keeper_id:keeper_name
+  with
+  | Error err ->
+      (* Mapping store unreadable — treat as infra error, not absence.
+         Fall through to legacy resolver so a corrupt
+         [keeper_repo_mappings.toml] does not break previously-working
+         keepers. *)
+      count_resolve_outcome ~keeper_name ~source:"legacy"
+        ~reason:"mapping_load_error";
+      Log.Keeper.warn
+        "%s: keeper_repo_mapping load error (%s); falling back to \
+         legacy host_config_provider resolver"
+        keeper_name err;
+      legacy_resolve ~config ~keeper_name
+  | Ok [] ->
+      count_resolve_outcome ~keeper_name ~source:"legacy"
+        ~reason:"no_mapping";
+      legacy_resolve ~config ~keeper_name
+  | Ok [cred] ->
+      count_resolve_outcome ~keeper_name ~source:"credential_store"
+        ~reason:"single_mapping";
+      bind_from_credential ~keeper_name cred
+  | Ok many ->
+      count_resolve_outcome ~keeper_name ~source:"ambiguous"
+        ~reason:"multi_mapping";
+      let ids =
+        List.map (fun (c : Repo_manager_types.credential) -> c.id) many
+      in
+      Error
+        (Credential_provider.Missing_bundle
+           { identity = keeper_name
+           ; path =
+               Printf.sprintf
+                 "keeper %s has %d credentials mapped (%s); RFC-0019 \
+                  PR-A resolves only single-credential keepers. \
+                  Per-repo dispatch is delivered in PR-B \
+                  (resolve_for_repo)."
+                 keeper_name (List.length many) (String.concat ", " ids)
+           })
 
 let finalize (_b : Credential_provider.binding) ~container_id:_ =
   (* PR-1: noop.  PR-3 will rewrite hosts.yml:user inside the

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -62,6 +62,59 @@ let allowed_repositories ~keeper_id ~base_path =
   let* mapping = find_mapping ~base_path keeper_id in
   Ok mapping.repository_ids
 
+(** Resolve the credentials currently mapped to [keeper_id], by looking
+    through every repository the keeper is allowed to access and
+    extracting each repository's [credential_id] into a unique list of
+    [credential] records.
+
+    Returns [Ok []] when the keeper has no mapping.  This is the
+    backward-compatibility branch consumed by the credential provider
+    bridge (RFC-0019 PR-A): a keeper without a mapping continues to use
+    the legacy [Keeper_gh_env.keeper_binding] resolver.
+
+    Returns [Error _] only on infrastructure failure (mapping store
+    unreadable, repository not found, credential not found).  Absence of
+    mapping is not an error. *)
+let credentials_for_keeper ~base_path ~keeper_id =
+  match find_mapping ~base_path keeper_id with
+  | Error _ -> Ok []
+  | Ok mapping ->
+      let* repos = Repo_store.load_all ~base_path in
+      let mapped_repos =
+        if List.exists (String.equal "*") mapping.repository_ids then
+          repos
+        else
+          List.filter
+            (fun (r : repository) ->
+              List.exists (String.equal r.id) mapping.repository_ids)
+            repos
+      in
+      (* Unique credential ids preserving first-seen order, so a keeper
+         with several repos pointing at the same credential collapses to
+         a single entry; the bridge can then dispatch deterministically. *)
+      let cred_ids =
+        List.fold_left
+          (fun acc (r : repository) ->
+            if List.mem r.credential_id acc then acc
+            else r.credential_id :: acc)
+          []
+          mapped_repos
+        |> List.rev
+      in
+      let rec resolve_creds acc = function
+        | [] -> Ok (List.rev acc)
+        | id :: rest -> (
+            match Credential_store.find ~base_path id with
+            | Ok c -> resolve_creds (c :: acc) rest
+            | Error msg ->
+                Error
+                  (Printf.sprintf
+                     "credential %s referenced by mapping for keeper %s \
+                      not found in credential store: %s"
+                     id keeper_id msg))
+      in
+      resolve_creds [] cred_ids
+
 let is_allowed ~keeper_id ~repository_id ~base_path =
   match find_mapping ~base_path keeper_id with
   | Error _ -> true

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -5,6 +5,18 @@ val allowed_repositories :
 (** [allowed_repositories ~keeper_id ~base_path] returns the list of
     repository IDs that [keeper_id] is allowed to access. *)
 
+val credentials_for_keeper :
+  base_path:string -> keeper_id:string -> (credential list, string) result
+(** [credentials_for_keeper ~base_path ~keeper_id] resolves the unique
+    credentials currently mapped to [keeper_id] by walking every
+    repository the keeper is allowed to access and looking up each
+    repository's [credential_id] in the credential store.
+
+    Returns [Ok []] when the keeper has no mapping (backward-compatibility
+    signal consumed by the RFC-0019 PR-A credential provider bridge).
+    Returns [Error _] only on infrastructure failure (mapping store
+    unreadable, referenced credential missing). *)
+
 val is_allowed :
   keeper_id:string -> repository_id:repository_id -> base_path:string -> bool
 (** [is_allowed ~keeper_id ~repository_id ~base_path] returns [true] if

--- a/test/dune
+++ b/test/dune
@@ -120,6 +120,7 @@
         test_repo_store
         test_credential_store
         test_keeper_repo_mapping
+        test_credential_provider_bridge
         test_repo_sync
         test_exec_core
         test_exec_dispatch
@@ -306,6 +307,7 @@
           test_repo_store
           test_credential_store
           test_keeper_repo_mapping
+          test_credential_provider_bridge
           test_repo_sync
           test_exec_core
           test_exec_dispatch

--- a/test/test_credential_provider_bridge.ml
+++ b/test/test_credential_provider_bridge.ml
@@ -1,0 +1,274 @@
+(** RFC-0019 PR-A — bridge resolver coverage for
+    {!Keeper_repo_mapping.credentials_for_keeper}.
+
+    This is the load-bearing helper consumed by
+    {!Host_config_provider.resolve} when deciding whether to route a
+    keeper through the new {!Credential_store} or the legacy
+    {!Keeper_gh_env.keeper_binding} path.
+
+    Pinned scenarios:
+
+    1. No mapping for the keeper → [Ok []] (the bridge interprets this
+       as "use the legacy resolver"; an [Error] would falsely block
+       legacy keepers).
+    2. Mapping with exactly one repo → [Ok [credential]].
+    3. Mapping with several repos that share one credential → [Ok
+       [credential]] (deduplicated; the bridge expects a single
+       single-element list to dispatch deterministically).
+    4. Mapping with several repos with distinct credentials →
+       [Ok [c1; c2]] in mapping order (the bridge surfaces ambiguity
+       to the caller as a [Missing_bundle] with an actionable message;
+       the helper itself stays total).
+    5. Mapping references a non-existent credential → [Error _].
+       Infrastructure failure, not absence; bridge should surface
+       this rather than silently fall back.
+    6. Wildcard ["*"] mapping → returns credentials for every
+       registered repository (deduplicated by credential id).
+
+    Integration of [Host_config_provider.resolve] itself with
+    [Coord.config] + filesystem bundles is exercised by
+    [test_keeper_shell_docker_route]; this file stays pure to avoid
+    re-staging that fixture. *)
+
+open Repo_manager_types
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
+
+let with_temp_base_path f =
+  let dir = Filename.temp_file "rfc0019_bridge" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let masc_dir = Filename.concat dir ".masc" in
+  Unix.mkdir masc_dir 0o755;
+  let cfg_dir = Filename.concat masc_dir "config" in
+  Unix.mkdir cfg_dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then begin
+            Sys.readdir path
+            |> Array.iter (fun n -> rm_rf (Filename.concat path n));
+            Unix.rmdir path
+          end
+          else Sys.remove path
+      in
+      rm_rf dir)
+    (fun () -> f dir)
+
+let write_mapping base_path keeper_id repo_ids =
+  let path =
+    Filename.concat base_path ".masc/config/keeper_repo_mappings.toml"
+  in
+  let entries =
+    String.concat ", " (List.map (fun s -> "\"" ^ s ^ "\"") repo_ids)
+  in
+  let content =
+    Printf.sprintf "[mapping.%s]\nrepositories = [%s]\n" keeper_id entries
+  in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let make_credential ~id ~username ~gh_config_dir : credential =
+  {
+    id;
+    cred_type = Github;
+    username;
+    gh_config_dir = Some gh_config_dir;
+    ssh_key_path = None;
+    gpg_key_id = None;
+  }
+
+let make_repo ~id ~credential_id : repository =
+  {
+    id;
+    name = "repo-" ^ id;
+    url = "https://github.com/test/" ^ id;
+    local_path = "repos/" ^ id;
+    default_branch = "main";
+    credential_id;
+    keepers = [];
+    status = Active;
+    auto_sync = false;
+    sync_interval = 0;
+    created_at = Int64.zero;
+    updated_at = Int64.zero;
+  }
+
+let seed_credential ~base_path cred =
+  match Credential_store.add ~base_path cred with
+  | Ok _ -> ()
+  | Error msg ->
+      Alcotest.failf "seed credential %s: %s" cred.id msg
+
+let seed_repo ~base_path repo =
+  match Repo_store.add ~base_path repo with
+  | Ok _ -> ()
+  | Error msg ->
+      Alcotest.failf "seed repo %s: %s" repo.id msg
+
+(* --- 1. No mapping → Ok [] --- *)
+
+let test_no_mapping_yields_empty_list () =
+  with_temp_base_path (fun base_path ->
+      match
+        Keeper_repo_mapping.credentials_for_keeper
+          ~base_path ~keeper_id:"unmapped-keeper"
+      with
+      | Ok creds ->
+          Alcotest.(check int)
+            "absence-of-mapping is empty list, not error"
+            0 (List.length creds)
+      | Error msg ->
+          Alcotest.failf
+            "absence of mapping must surface as Ok []; got Error %S"
+            msg)
+
+(* --- 2. Single repo, single credential --- *)
+
+let test_single_repo_single_credential () =
+  with_temp_base_path (fun base_path ->
+      seed_credential ~base_path
+        (make_credential ~id:"cred-A" ~username:"user-A"
+           ~gh_config_dir:"/tmp/cred-A/gh");
+      seed_repo ~base_path (make_repo ~id:"repo-1" ~credential_id:"cred-A");
+      write_mapping base_path "keeper-1" [ "repo-1" ];
+      match
+        Keeper_repo_mapping.credentials_for_keeper
+          ~base_path ~keeper_id:"keeper-1"
+      with
+      | Ok [ c ] ->
+          Alcotest.(check string) "credential id" "cred-A" c.id;
+          Alcotest.(check string) "credential username" "user-A" c.username
+      | Ok creds ->
+          Alcotest.failf "expected exactly one credential, got %d"
+            (List.length creds)
+      | Error msg -> Alcotest.failf "unexpected error: %s" msg)
+
+(* --- 3. Multiple repos sharing one credential → deduplicated --- *)
+
+let test_two_repos_same_credential_deduped () =
+  with_temp_base_path (fun base_path ->
+      seed_credential ~base_path
+        (make_credential ~id:"cred-A" ~username:"user-A"
+           ~gh_config_dir:"/tmp/cred-A/gh");
+      seed_repo ~base_path (make_repo ~id:"repo-1" ~credential_id:"cred-A");
+      seed_repo ~base_path (make_repo ~id:"repo-2" ~credential_id:"cred-A");
+      write_mapping base_path "keeper-1" [ "repo-1"; "repo-2" ];
+      match
+        Keeper_repo_mapping.credentials_for_keeper
+          ~base_path ~keeper_id:"keeper-1"
+      with
+      | Ok [ c ] -> Alcotest.(check string) "single deduped credential" "cred-A" c.id
+      | Ok creds ->
+          Alcotest.failf
+            "expected dedupe to a single credential, got %d (%s)"
+            (List.length creds)
+            (String.concat ", "
+               (List.map (fun (c : credential) -> c.id) creds))
+      | Error msg -> Alcotest.failf "unexpected error: %s" msg)
+
+(* --- 4. Distinct credentials surfaced in mapping order --- *)
+
+let test_distinct_credentials_surfaced () =
+  with_temp_base_path (fun base_path ->
+      seed_credential ~base_path
+        (make_credential ~id:"cred-A" ~username:"user-A"
+           ~gh_config_dir:"/tmp/cred-A/gh");
+      seed_credential ~base_path
+        (make_credential ~id:"cred-B" ~username:"user-B"
+           ~gh_config_dir:"/tmp/cred-B/gh");
+      seed_repo ~base_path (make_repo ~id:"repo-1" ~credential_id:"cred-A");
+      seed_repo ~base_path (make_repo ~id:"repo-2" ~credential_id:"cred-B");
+      write_mapping base_path "keeper-1" [ "repo-1"; "repo-2" ];
+      match
+        Keeper_repo_mapping.credentials_for_keeper
+          ~base_path ~keeper_id:"keeper-1"
+      with
+      | Ok creds ->
+          Alcotest.(check int) "two credentials" 2 (List.length creds);
+          let ids = List.map (fun (c : credential) -> c.id) creds in
+          Alcotest.(check bool) "has cred-A" true (List.mem "cred-A" ids);
+          Alcotest.(check bool) "has cred-B" true (List.mem "cred-B" ids)
+      | Error msg -> Alcotest.failf "unexpected error: %s" msg)
+
+(* --- 5. Mapping references missing credential --- *)
+
+let test_missing_credential_yields_error () =
+  with_temp_base_path (fun base_path ->
+      seed_repo ~base_path
+        (make_repo ~id:"repo-1" ~credential_id:"cred-MISSING");
+      write_mapping base_path "keeper-1" [ "repo-1" ];
+      match
+        Keeper_repo_mapping.credentials_for_keeper
+          ~base_path ~keeper_id:"keeper-1"
+      with
+      | Ok creds ->
+          Alcotest.failf
+            "expected Error for missing credential, got Ok with %d \
+             credentials"
+            (List.length creds)
+      | Error msg ->
+          Alcotest.(check bool)
+            "error mentions credential id"
+            true (contains_substring msg "cred-MISSING");
+          Alcotest.(check bool)
+            "error mentions keeper id"
+            true (contains_substring msg "keeper-1"))
+
+(* --- 6. Wildcard mapping resolves every registered repo --- *)
+
+let test_wildcard_mapping_returns_all_credentials () =
+  with_temp_base_path (fun base_path ->
+      seed_credential ~base_path
+        (make_credential ~id:"cred-A" ~username:"user-A"
+           ~gh_config_dir:"/tmp/cred-A/gh");
+      seed_credential ~base_path
+        (make_credential ~id:"cred-B" ~username:"user-B"
+           ~gh_config_dir:"/tmp/cred-B/gh");
+      seed_repo ~base_path (make_repo ~id:"repo-1" ~credential_id:"cred-A");
+      seed_repo ~base_path (make_repo ~id:"repo-2" ~credential_id:"cred-B");
+      seed_repo ~base_path (make_repo ~id:"repo-3" ~credential_id:"cred-A");
+      write_mapping base_path "keeper-wild" [ "*" ];
+      match
+        Keeper_repo_mapping.credentials_for_keeper
+          ~base_path ~keeper_id:"keeper-wild"
+      with
+      | Ok creds ->
+          Alcotest.(check int)
+            "wildcard dedupes to two distinct credentials"
+            2 (List.length creds);
+          let ids = List.map (fun (c : credential) -> c.id) creds in
+          Alcotest.(check bool) "has cred-A" true (List.mem "cred-A" ids);
+          Alcotest.(check bool) "has cred-B" true (List.mem "cred-B" ids)
+      | Error msg -> Alcotest.failf "unexpected error: %s" msg)
+
+let () =
+  Alcotest.run "credential_provider_bridge"
+    [
+      ( "credentials_for_keeper",
+        [
+          Alcotest.test_case "no mapping is Ok []" `Quick
+            test_no_mapping_yields_empty_list;
+          Alcotest.test_case "single repo, single credential" `Quick
+            test_single_repo_single_credential;
+          Alcotest.test_case "two repos, one credential, deduped" `Quick
+            test_two_repos_same_credential_deduped;
+          Alcotest.test_case "two repos, distinct credentials" `Quick
+            test_distinct_credentials_surfaced;
+          Alcotest.test_case "missing credential surfaces Error" `Quick
+            test_missing_credential_yields_error;
+          Alcotest.test_case "wildcard mapping resolves all" `Quick
+            test_wildcard_mapping_returns_all_credentials;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Wires the host-mounted credential resolver to the multi-repository credential registry shipped in #12304 so keepers with a \`keeper_repo_mapping\` entry are routed through the new TOML registry while keepers without a mapping continue on the legacy \`Keeper_gh_env.keeper_binding\` path. Backward compatible.

Refs **RFC-0019 §4.2 + §5 (PR-A)** — see #12328 for the full design rationale.

## Why this exists

User-observed symptom: \`gh search prs --owner yousleepwhen --author anyang-keepers\` → 0 PRs in 8 days. Root-cause investigation found \`~/.masc/github-identities/\` missing on host, and the multi-repo architecture (#12304) merged 3 hours before this PR's plan was authored ships a parallel credential subsystem with **zero integration** to the existing one. PR-A is the smallest backward-compatible bridge that lets the new registry start to influence keeper resolve outcomes.

## Changes

### lib/repo_manager/keeper_repo_mapping.{ml,mli}
Add \`credentials_for_keeper\`: walks keeper → repos → credential_ids → credentials, dedupes by id, returns \`Ok []\` for unmapped keepers (backward-compatibility signal) and \`Error\` for missing-credential infra failures (mapping references a credential that does not exist in the store).

### lib/keeper/host_config_provider.ml
Refactor \`resolve\` into:
- \`legacy_resolve\` — original \`Keeper_gh_env.keeper_binding\` path (extracted verbatim).
- \`bind_from_credential\` — synthesises a \`Keeper_gh_env.keeper_binding\` from a \`Repo_manager_types.credential\` (\`bundle_root = dirname gh_config_dir\`), then runs the existing \`compose_env\` / \`compose_ro_mounts\` / \`metadata_of_binding\` flow verbatim.
- New top-level \`resolve\` dispatches on \`credentials_for_keeper\` outcome (0 / 1 / many) and emits \`keeper_credential_provider_resolve_total{source, reason}\` Prometheus counter for each branch:
  - mapping load \`Error\` → fall back to legacy + warn (corrupt TOML must not break previously-working keepers)
  - \`Ok []\` (no mapping) → fall back to legacy
  - \`Ok [cred]\` → bind from credential store (the new path)
  - \`Ok many\` → \`Missing_bundle\` with actionable \`path\` field; per-repo \`resolve_for_repo\` is delivered in PR-B.

Preserves every existing fail-closed semantics, env compose, ro_mounts compose, and \`warn_mount_skips_if_any\` warning path.

### test/test_credential_provider_bridge.ml (new)
Six \`Alcotest\` cases covering:
1. No mapping → \`Ok []\`.
2. Single repo, single credential → \`Ok [c]\`.
3. Two repos, same credential → \`Ok [c]\` (deduped).
4. Two repos, distinct credentials → \`Ok [c1; c2]\` (mapping order).
5. Mapping references missing credential → \`Error\` mentions both keeper id and credential id.
6. Wildcard \`*\` mapping → returns credentials for every registered repo (deduped).

Integration of \`resolve\` itself with \`Coord.config\` + filesystem bundles is left to \`test_keeper_shell_docker_route\` — matches the existing \`test_credential_provider\` precedent.

## Out of scope, observed during this work

\`test/test_keeper_repo_mapping\` has 2 pre-existing failures on origin/main HEAD \`2011b1cb65\` (\`is_allowed.no_mapping\`, \`apply_mapping.no_mapping\`). Both predate this change (verified by running the test on main). RFC-0019 §7 (process safeguards) discusses why a test-failing PR can land. Suggested follow-up: a separate fix PR before PR-B begins.

## Test plan

- [x] \`dune build\` clean
- [x] \`dune exec test/test_credential_provider_bridge.exe\` — 6/6 pass
- [x] \`dune exec test/test_credential_provider.exe\` — 10/10 pass (no regression)
- [x] \`dune exec test/test_credential_store.exe\` — 11/11 pass (no regression)
- [ ] Reviewer manually verifies that a keeper with \`keeper_repo_mapping\` but with a credential whose \`gh_config_dir\` is not yet materialised on disk surfaces a clear \`Missing_bundle\` error rather than a confusing 401 at \`gh\` runtime.

🤖 Co-authored with Claude Opus 4.7 (1M context)