### PR TITLE
docs(design-system): add RFCs 0019/0020/0021 for IDE plane primitives

### DIFF
--- a/dashboard/design-system/RFC/0019-keeper-line-ownership.md
+++ b/dashboard/design-system/RFC/0019-keeper-line-ownership.md
@@ -1,0 +1,99 @@
+# RFC 0019 — Keeper Line Ownership
+
+- **Status**: Draft
+- **Author**: design-system stewardship
+- **Created**: 2026-04-30
+- **Depends on**:
+  - RFC 0010 (Collaboration Cursor — keeper identity primitive)
+  - RFC 0001 (Headless Foundation — `IdGenerator`)
+- **Consumes**: `--color-keeper-N-glow` (semantic), `--k-N` (raw fallback) for blame strip color encoding.
+- **Blocks**: editor `blame-by-keeper` overlay (Stage 5 IDE plane PR-5), audit-aware diff strip, refactor attribution surfaces.
+
+---
+
+## 1. Motivation
+
+The IDE mockup (`design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md` §2) shows each editor line carrying a left-rail keeper ownership label (`nick0cave`, `sangsu`, `masc-improver`) and a colored dot for change. The cockpit `IdePlane` prototype (`ui_kits/cockpit/Planes.jsx:155`) names the same surface `IxEditAttrib` ("attribution") but does not yet specify a data model.
+
+Today the dashboard knows about keeper events through `keeper-state.ts` and `sse-store.ts`, but no store is line-indexed. Computing ownership at the editor surface (file path + line) requires:
+
+1. A canonical event shape so multiple producers (server, future webhook ingest, replay) can populate the same store.
+2. An accumulator that derives `Map<lineNum, KeeperId[]>` from a stream without re-reading the whole event history per render.
+3. A stable mapping `KeeperId → keeper hue (1–12)` that survives keeper additions and removals.
+
+Without RFC 0019 every consumer (editor blame strip, refactor attribution, audit ledger) reinvents this accumulator with subtle drift.
+
+## 2. Non-Goals
+
+- Wire format definition. The server-side event source (Git blame replay, runtime keeper edit stream, MCP tool action) is owned by the backend RFC track (Kimi Phase 1–3, gap_analysis Gap-001). This RFC defines only the in-dashboard contract.
+- Authorship resolution conflicts (two keepers claiming the same line). Resolved by `last-event-wins` in v1; multi-author overlay is a follow-up.
+- Persistence across page reloads. v1 rebuilds ownership from the live event stream at mount.
+- Editor rendering. Headless — the consumer owns the gutter / strip DOM.
+
+## 3. Public API (sketch)
+
+```ts
+// src/components/ide/keeper-line-ownership-store.ts
+
+import type { Accessor } from 'solid-js'
+
+export interface KeeperEdit {
+  readonly file_path: string
+  readonly line_start: number       // 1-indexed, inclusive
+  readonly line_end: number         // 1-indexed, inclusive
+  readonly keeper_id: string
+  readonly timestamp_ms: number
+  readonly kind: 'edit' | 'create' | 'refactor' | 'revert'
+}
+
+export interface LineOwnership {
+  readonly keeper_id: string
+  readonly hue_index: number        // 1..12, stable per keeper_id
+  readonly last_edit_kind: KeeperEdit['kind']
+  readonly last_edit_ms: number
+}
+
+export interface KeeperLineOwnershipStore {
+  readonly ownership: Accessor<ReadonlyMap<number, LineOwnership>>
+  readonly eventsForLine: (line: number) => ReadonlyArray<KeeperEdit>
+  readonly knownKeepers: Accessor<ReadonlyArray<string>>
+  readonly ingest: (event: KeeperEdit) => void
+  readonly reset: (filePath: string) => void
+  readonly dispose: () => void
+}
+
+export function createKeeperLineOwnership(
+  filePath: Accessor<string>,
+): KeeperLineOwnershipStore
+```
+
+The store is signal-based (`@preact/signals` for the Preact half; `solid-js` `createSignal` for the Solid half — both are surface adapters over the same accumulator). The accumulator itself is framework-agnostic and lives in `headless-core/keeper-line-ownership.ts`.
+
+## 4. Hue assignment
+
+`hue_index` maps `keeper_id → 1..12` deterministically:
+
+```
+hue_index(keeper_id) = (hash(keeper_id) % 12) + 1
+```
+
+The hash is FNV-1a (32-bit) so that two dashboards mounting the same keeper see the same hue. The mapping is also re-exposed through `knownKeepers()` so the blame strip can render a legend without duplicating the hash.
+
+The 12-slot palette is `--color-keeper-1-glow` … `--color-keeper-12-glow` (semantic). Raw fallback is `--k-1` … `--k-12`. Components must consume the semantic tier per SPEC §3 / audit §3.
+
+## 5. Test plan
+
+- Property test: feeding N events from M keepers produces a `Map` whose size equals `count(unique line)` and whose values reflect the latest event per line.
+- Determinism test: `hue_index('nick0cave')` is stable across runs; collisions in 12-slot space are surfaced via `knownKeepers()` (consumer can warn).
+- Reset test: `reset(filePath)` empties the accumulator without disposing the signal so subscribers continue receiving updates.
+
+## 6. Migration & rollout
+
+- Phase A (this RFC): land the headless accumulator + Solid adapter + 1 unit test.
+- Phase B (PR-5): wire the editor blame strip to the store.
+- Phase C: extend the store with an audit-export selector for the audit ledger (separate RFC).
+
+## 7. Open questions
+
+- Should the hue assignment be configurable per project (e.g., a pinned mapping for long-lived keepers)? Defer to a follow-up if real keeper rotation reveals collisions.
+- Multi-line ranges with overlapping keepers — current model picks last-event-wins per individual line. A "co-owned" representation is possible but adds rendering complexity; defer.

--- a/dashboard/design-system/RFC/0020-layered-overlay-system.md
+++ b/dashboard/design-system/RFC/0020-layered-overlay-system.md
@@ -1,0 +1,104 @@
+# RFC 0020 — Layered Overlay System (LAYERS toggle)
+
+- **Status**: Draft
+- **Author**: design-system stewardship
+- **Created**: 2026-04-30
+- **Depends on**:
+  - RFC 0015 (Tabs — multi-select activation variant)
+  - RFC 0019 (Keeper Line Ownership — overlay data source)
+  - RFC 0010 (Collaboration Cursor — keeper presence)
+- **Consumes**: `--color-bg-elevated`, `--color-fg-secondary`, `--color-keeper-N-glow`, `--color-status-{ok,warn,err,info,stalled}`.
+- **Blocks**: editor LAYERS toggle bar (Stage 5 IDE plane PR-3, mock; PR-5+ real overlays).
+
+---
+
+## 1. Motivation
+
+The IDE mockup top of the editor pane carries a `LAYERS` toggle:
+
+```
+LAYERS  [Time] [Parallel] [Tools] [Approve] [Notes]   [EXPLODE]
+```
+
+Each toggle reveals a different overlay on top of the source view, scoped to the visible viewport:
+
+| Layer    | Encodes                                           |
+|----------|----------------------------------------------------|
+| Time     | Recency gradient — how long ago each line was last touched, mapped to opacity. |
+| Parallel | Lines currently being edited by ≥2 keepers in this run, highlighted with a striped gutter. |
+| Tools    | Lines that triggered or were produced by an MCP tool call (refactor, search-replace, generator). |
+| Approve  | Lines where any keeper logged an `APPROVE` thread (RFC 0021). |
+| Notes    | Lines where any keeper logged a `NOTE` or `SUGGEST` thread. |
+| EXPLODE  | Modal overlay that fans the file out into per-keeper "ghost copies" stacked vertically — read-only diff per keeper, useful for refactor review. |
+
+The cockpit `IdePlane` prototype does not have this toggle; it is a mockup-introduced refinement (`design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md` §2). Without an RFC each overlay is a one-off feature with its own state shape and toggle component, and the mockup's "compose 2–3 overlays at once" affordance is impossible.
+
+This RFC defines the headless overlay system: a multi-select toggle primitive plus an overlay registration model so the editor can render any subset of registered layers without knowing which are active at compile time.
+
+## 2. Non-Goals
+
+- Per-overlay rendering. Each overlay's pixels are owned by its consumer (editor blame strip for `Time`, gutter striper for `Parallel`, etc.). This RFC defines registration and toggle plumbing only.
+- Full-screen `EXPLODE` mode layout. Treated as one registered layer that the overlay host happens to render in a different DOM region; mode-specific layout is a follow-up RFC.
+- Layer ordering / z-index. Default is registration order; consumer can sort.
+- Persistence. v1 keeps active layers in URL query (`?layers=time,approve`) so deep links work; reload behavior is consumer-decided.
+
+## 3. Public API (sketch)
+
+```ts
+// headless-core/layered-overlay.ts
+
+export type LayerKind = 'time' | 'parallel' | 'tools' | 'approve' | 'notes' | 'explode'
+
+export interface OverlayLayer {
+  readonly kind: LayerKind
+  readonly label: string
+  readonly description: string
+  readonly mutuallyExclusive?: boolean   // EXPLODE clears the rest when active
+}
+
+export interface LayeredOverlayController {
+  readonly active: ReadonlySet<LayerKind>
+  readonly toggle: (kind: LayerKind) => void
+  readonly clear: () => void
+  readonly isActive: (kind: LayerKind) => boolean
+  readonly subscribe: (listener: (active: ReadonlySet<LayerKind>) => void) => () => void
+}
+
+export function createLayeredOverlay(layers: ReadonlyArray<OverlayLayer>): LayeredOverlayController
+```
+
+Adapters:
+- `headless-preact/use-layered-overlay.ts` — `signal<Set<LayerKind>>`-backed, returns the `active` signal directly.
+- `headless-solid/use-layered-overlay.ts` — `createSignal` wrapper returning an `Accessor<Set<LayerKind>>`.
+
+## 4. Mutual exclusivity
+
+`EXPLODE` is declared with `mutuallyExclusive: true`. When activated, all other layers are cleared. Activating any other layer while `EXPLODE` is active first clears `EXPLODE`. This keeps the `EXPLODE` modal from composing with the per-line overlays (which would visually conflict).
+
+## 5. URL contract
+
+The active set is persisted as a comma-separated query parameter:
+
+```
+#code/ide-shell?file=src/router.ts&layers=time,approve
+```
+
+Order in the query is canonicalized (alphabetical) so deep links don't churn. Unknown layer kinds are dropped.
+
+## 6. Test plan
+
+- Toggle test: `toggle('time')` flips presence of `'time'` in `active`; calling twice returns to the empty set.
+- Mutual exclusivity test: activating `EXPLODE` after `time + approve` clears `time` and `approve`; activating `time` after `EXPLODE` clears `EXPLODE`.
+- URL roundtrip test: `parse('time,bogus,approve') → Set('time','approve')`, `format(Set('approve','time')) === 'approve,time'`.
+- Subscribe test: subscriber fires once per change with the *new* set, not the old one.
+
+## 7. Migration & rollout
+
+- Phase A (this RFC): land headless controller + 2 adapters + tests. No editor wiring.
+- Phase B (PR-3 of Phase 1): mount the toggle bar in the editor mock with all 6 layer kinds; overlays are no-ops.
+- Phase C (PR-5+): wire each layer to its data source — `time`/`approve` to RFC 0019 ownership store, `tools` to keeper tool-event stream, etc.
+
+## 8. Open questions
+
+- Should the controller emit per-layer activation events (e.g., for analytics)? Defer until needed.
+- Naming: "EXPLODE" reads dramatic — consider "Per-keeper view" if the metaphor doesn't survive contact with users.

--- a/dashboard/design-system/RFC/0021-anchored-thread-rail.md
+++ b/dashboard/design-system/RFC/0021-anchored-thread-rail.md
@@ -1,0 +1,129 @@
+# RFC 0021 — Anchored Thread Rail
+
+- **Status**: Draft
+- **Author**: design-system stewardship
+- **Created**: 2026-04-30
+- **Depends on**:
+  - RFC 0010 (Collaboration Cursor — keeper presence + line-anchor base)
+  - RFC 0014 (TreeView — for grouping threads by file in cross-file views)
+- **Consumes**: `--color-status-{ok,warn,err,info,stalled}` (per thread kind), `--color-bg-elevated`, `--color-fg-secondary`, `--color-keeper-N-glow`.
+- **Blocks**: editor CONVERSATION rail (Stage 5 IDE plane PR-6), cross-file review feed (follow-up RFC).
+
+---
+
+## 1. Motivation
+
+The IDE mockup right rail carries five kinds of conversation cards anchored to specific lines:
+
+```
+[FLAG]     nick0cave   router.ts:34   if:moonshot-tool-choice         01:41:18
+           "This is exactly the schema error we're seeing in prod —"
+           2 replies · open
+
+[QUESTION] operator    router.ts:26   fn:resolveCascade               01:39:02
+           "Should normalizeTools also handle tool_choice=none?"
+           1 reply · open
+
+[APPROVE]  operator    router.ts:60   fn:nextStep                     01:22:41
+           "Budget guard reads well. Ship it when tests pass." · open
+
+[NOTE]     operator    router.ts:35   token:log.warn                  01:18:04
+           "telemetry event name needs to match the lifeline schema"
+
+[SUGGEST]  masc-improver router.ts:16 fn:normalizeTools               01:14:52
+           "Could you collapse the rest-spread into a small helper?"
+           3 replies · open
+```
+
+Each card carries: (a) a **kind** (FLAG / QUESTION / APPROVE / NOTE / SUGGEST), (b) an **anchor** (file path + line range or symbol), (c) **author** (keeper id), (d) **timestamp**, (e) **body**, (f) optional **reply count and resolution state**.
+
+RFC 0010 defines the keeper-presence anchor primitive but does not cover thread aggregation, kind taxonomy, or the editor↔rail click-to-scroll coordination. This RFC fills that gap so all three consumers (CONVERSATION rail in the IDE, audit ledger, cross-file review feed) share one model.
+
+## 2. Non-Goals
+
+- Conversation persistence and event sourcing. Backend RFC track owns it (Kimi gap_analysis Gap-001 / Gap-006).
+- Inline rendering inside the editor (e.g., per-line balloon). The rail is the v1 surface; per-line balloons are a follow-up.
+- Threading depth beyond reply count. Replies render as a flat list in v1.
+- Editing threads. Read + create + resolve only; in-place edits are a follow-up.
+
+## 3. Public API (sketch)
+
+```ts
+// headless-core/anchored-thread-rail.ts
+
+export type ThreadKind = 'flag' | 'question' | 'approve' | 'note' | 'suggest'
+
+export interface ThreadAnchor {
+  readonly file_path: string
+  readonly line_start: number | null      // null = file-level
+  readonly line_end: number | null
+  readonly symbol_hint?: string           // optional 'fn:resolveCascade' / 'token:log.warn'
+}
+
+export interface Thread {
+  readonly id: string
+  readonly kind: ThreadKind
+  readonly author_keeper_id: string
+  readonly anchor: ThreadAnchor
+  readonly body: string
+  readonly created_ms: number
+  readonly resolved: boolean
+  readonly reply_count: number
+}
+
+export interface AnchoredThreadRailController {
+  readonly visibleThreads: ReadonlyArray<Thread>      // current-file scope
+  readonly threadsForLine: (line: number) => ReadonlyArray<Thread>
+  readonly focusedThreadId: string | null
+  readonly focusThread: (id: string) => void
+  readonly clearFocus: () => void
+  readonly subscribe: (listener: () => void) => () => void
+}
+
+export function createAnchoredThreadRail(opts: {
+  filePath: () => string
+  threads: () => ReadonlyArray<Thread>
+}): AnchoredThreadRailController
+```
+
+Adapters: `headless-preact/use-anchored-thread-rail.ts`, `headless-solid/use-anchored-thread-rail.ts`.
+
+## 4. Editor ↔ rail coordination
+
+Two flows must work without coupling consumers:
+
+1. **Click thread → scroll editor**. The rail emits a `focusThread(id)` event. The editor host subscribes to focus changes and scrolls the visible viewport so `anchor.line_start` is in view; if anchor is `null` it scrolls to the top of the file. The scroll behavior (smooth / instant / centered) is the editor's choice.
+2. **Click line → highlight related threads**. The editor exposes `currentLine: Accessor<number | null>` (from cursor position). The rail uses `threadsForLine(currentLine)` to render the related-threads strip at the rail head. When `currentLine` is `null`, the strip is empty.
+
+Both flows are mediated by the controller — no direct DOM coupling between editor and rail.
+
+## 5. Kind taxonomy and color encoding
+
+| Kind     | Status semantics       | Token                       |
+|----------|------------------------|-----------------------------|
+| FLAG     | blocking, requires action | `--color-status-err`        |
+| QUESTION | open clarification      | `--color-status-info`       |
+| APPROVE  | passed review           | `--color-status-ok`         |
+| NOTE     | observational           | `--color-fg-muted`          |
+| SUGGEST  | optional improvement    | `--color-status-warn`       |
+
+The author keeper hue (RFC 0019 `hue_index`) is rendered as a left border on each card so an operator scanning the rail sees both kind (chip color) and author (border color) without reading text.
+
+## 6. Test plan
+
+- Filter test: feeding 30 threads across 3 files, scoping to one file path returns only that file's threads in `visibleThreads`.
+- Line lookup test: `threadsForLine(L)` returns threads whose `[anchor.line_start, anchor.line_end]` range includes `L`.
+- Focus test: `focusThread(id)` sets `focusedThreadId`; `clearFocus()` resets to `null`; subscribers fire on each change.
+- Resolved filter test: a `resolved=true` thread is still in `visibleThreads` (consumer decides hiding); `reply_count` is exposed for filter chips.
+
+## 7. Migration & rollout
+
+- Phase A (this RFC): land headless controller + 2 adapters + tests. No surface wiring.
+- Phase B (PR-6 of Phase 2): mount the rail in the IDE shell, fed by mock threads.
+- Phase C: wire to the live thread store (backend RFC dependent — see Kimi Phase 1–3, gap_analysis Gap-001).
+
+## 8. Open questions
+
+- Cross-file rail mode (a global review feed) — same controller with `filePath: () => null`? Or a separate controller? Defer until cross-file review feed has a concrete consumer.
+- Reply rendering — flat in v1, but does threading depth ever matter? Probably no for code review; the SUGGEST/FLAG flow reads naturally as flat replies.
+- Resolution: should resolved threads auto-collapse after T seconds? Defer to operator preference.


### PR DESCRIPTION
## Summary

Three Draft RFCs that fill the contract gap the audit (#12317) identified — the data and behavior shapes that PR-5 / PR-6 of the IDE plane production migration depend on. Headless first; surface adapters and consumer wiring land in their respective implementation PRs.

본 PR 은 plan `planning/claude-plans/zany-yawning-nebula.md` 의 future tracks §1-3 에 해당하는 contract layer.

## RFC summary

| RFC | 정체 | 의존 PR |
|-----|------|---------|
| **0019 Keeper Line Ownership** | Blame-by-keeper accumulator (line → keeper id), 12-slot stable hue mapping (FNV-1a). 시안 mockup 의 editor 좌측 keeper label + line dot 데이터 모델. | Phase 2 PR-5 (editor blame strip) |
| **0020 Layered Overlay System** | 6-kind multi-select toggle (Time/Parallel/Tools/Approve/Notes/EXPLODE), mutual exclusivity for EXPLODE, URL `?layers=` 영속화. 시안 mockup 의 LAYERS bar contract. | Phase 1 PR-3 (mock toggle), Phase 2 PR-5+ (overlay wiring) |
| **0021 Anchored Thread Rail** | 5-kind thread taxonomy (FLAG/QUESTION/APPROVE/NOTE/SUGGEST), file+line+symbol anchor, editor↔rail click-to-scroll via controller (no DOM coupling). 시안 mockup 의 CONVERSATION rail contract. | Phase 2 PR-6 (rail in IDE) |

## Why three at once

Three RFC, separately, would have entered Drafts asynchronously over 6+ weeks and forced PR-5/6 to either block or reinvent the contracts. Bundling them lets the implementation PRs cite stable signatures from day one. None of the three implements behavior in this PR — they're contracts only.

## Namespace clarification

`dashboard/design-system/RFC/` 는 자체 시퀀스 (0001~0017 까지 사용됨, 0018 은 plan 단계에서 superseded 되어 미사용, 0019~0021 신규). `lib/keeper/RFC-0019-credential-unification` (#12328) 와 별개의 namespace. 혼동 방지 위해 commit message + 본문에 design-system 명시.

## Changes

- `dashboard/design-system/RFC/0019-keeper-line-ownership.md` (~110 lines)
- `dashboard/design-system/RFC/0020-layered-overlay-system.md` (~115 lines)
- `dashboard/design-system/RFC/0021-anchored-thread-rail.md` (~110 lines)

## Test plan

- [x] RFC 본문이 Status/Author/Created/Depends on/Blocks 헤더 형식 준수 (RFC 0014/0015 참고)
- [x] 각 RFC 의 §3 Public API sketch 가 TypeScript signature 로 작성 (header type only)
- [x] 각 RFC 의 §6 또는 §5 Test plan 이 property test / unit test 단위로 명시
- [ ] Reviewer: 3 RFC 가 audit §4 (#12317) 의 \"신규 RFC 필요\" 항목과 1:1 대응
- [ ] Reviewer: kind taxonomy / hue mapping / URL contract 가 시안 mockup 과 정합

## Future implementation PRs

- **PR-5** (Phase 2) — editor + Shiki + blame-by-keeper. RFC 0019 의 `createKeeperLineOwnership` 구현 + adapter.
- **PR-3** (Phase 1) — LAYERS toggle (mock). RFC 0020 의 controller 구현 + adapter.
- **PR-6** (Phase 2) — CONVERSATION rail. RFC 0021 의 controller 구현 + adapter.

## Refs

- `planning/claude-plans/zany-yawning-nebula.md`
- `dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md` §4
- `dashboard/design-system/RFC/0014-tree-view.md` / `0015-tabs.md` (RFC 형식 reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)