### PR TITLE
feat(dashboard): IDE 4-pane shell with mock content (Phase 1 PR-2)

### DIFF
--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -1,0 +1,100 @@
+import { html } from 'htm/preact'
+
+// PR-2 placeholder for the ACTIVITY THIS RUN pane. The real activity
+// stream (sse-store.ts pattern, virtual-list, sustained 16-keeper
+// bench) lands in Phase 2 PR-6 alongside the conversation rail.
+
+interface MockActivity {
+  readonly time: string
+  readonly keeper: string
+  readonly verb: 'flagged' | 'edited' | 'commented on' | 'approved' | 'noted' | 'suggested on' | 'committed' | 'refactored' | 'asked on'
+  readonly target: string
+  readonly hue: number
+  readonly hint?: string
+}
+
+const MOCK_ACTIVITY: ReadonlyArray<MockActivity> = [
+  { time: '01:41:18', keeper: 'nick0cave', hue: 1, verb: 'flagged', target: 'router.ts:34', hint: 'if:moonshot-tool-choice · blocker' },
+  { time: '01:40:02', keeper: 'nick0cave', hue: 1, verb: 'edited', target: 'router.ts:35', hint: '+ next.tool_choice = "auto"' },
+  { time: '01:39:02', keeper: 'operator', hue: 9, verb: 'commented on', target: 'router.ts:26', hint: 'question · resolveCascade' },
+  { time: '01:37:11', keeper: 'masc-improver', hue: 3, verb: 'edited', target: 'registry.ts:10', hint: '+8 -2 · budgetFor' },
+  { time: '01:35:22', keeper: 'masc-improver', hue: 3, verb: 'committed', target: 'improver/wt-47', hint: 'fix: init budget map lazily' },
+  { time: '01:32:08', keeper: 'masc-improver', hue: 3, verb: 'refactored', target: 'registry.ts', hint: 'extracted budgetFor' },
+  { time: '01:28:15', keeper: 'operator', hue: 9, verb: 'commented on', target: 'registry.ts:10', hint: 'note · log.warn naming' },
+  { time: '01:22:41', keeper: 'operator', hue: 9, verb: 'approved', target: 'router.ts:60', hint: 'nextStep · budget guard' },
+  { time: '01:18:04', keeper: 'operator', hue: 9, verb: 'noted', target: 'router.ts:35', hint: 'flag · race on Map init' },
+  { time: '01:14:52', keeper: 'masc-improver', hue: 3, verb: 'suggested on', target: 'router.ts:16', hint: 'suggest · extract helper' },
+  { time: '01:09:11', keeper: 'nick0cave', hue: 1, verb: 'edited', target: 'router.ts:34', hint: '+1 -0 · tool_choice guard' },
+  { time: '01:02:11', keeper: 'operator', hue: 9, verb: 'flagged', target: 'registry.ts:10', hint: 'race condition' },
+  { time: '00:58:32', keeper: 'operator', hue: 9, verb: 'asked on', target: 'router.ts:26', hint: 'question · resolveCascade' },
+]
+
+export function IdeActivityMock() {
+  return html`
+    <div
+      role="region"
+      aria-label="ACTIVITY THIS RUN (mock — PR-6 replaces with sse-store-backed stream)"
+      style=${{
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'var(--color-bg-surface)',
+        borderLeft: '1px solid var(--color-border-default)',
+        borderTop: '1px solid var(--color-border-divider)',
+        minHeight: 0,
+      }}
+    >
+      <header
+        style=${{
+          display: 'flex',
+          justifyContent: 'space-between',
+          padding: 'var(--sp-2) var(--sp-3)',
+          color: 'var(--color-fg-muted)',
+          font: 'var(--type-eyebrow)',
+          borderBottom: '1px solid var(--color-border-divider)',
+        }}
+      >
+        <span>ACTIVITY</span>
+        <span>THIS RUN</span>
+      </header>
+      <ol
+        style=${{
+          listStyle: 'none',
+          padding: 'var(--sp-2)',
+          margin: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--sp-1)',
+          overflow: 'auto',
+        }}
+      >
+        ${MOCK_ACTIVITY.map(item => MockActivityRow(item))}
+      </ol>
+    </div>
+  `
+}
+
+function MockActivityRow(item: MockActivity) {
+  const dot = `var(--color-keeper-${item.hue}-glow, var(--k-${item.hue}))`
+  return html`
+    <li
+      style=${{
+        display: 'grid',
+        gridTemplateColumns: '52px 8px 1fr',
+        gap: 'var(--sp-2)',
+        alignItems: 'baseline',
+        padding: '4px 6px',
+        font: 'var(--type-body)',
+        color: 'var(--color-fg-secondary)',
+      }}
+    >
+      <span style=${{ font: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${item.time}</span>
+      <span aria-hidden="true" style=${{ width: '6px', height: '6px', borderRadius: '50%', background: dot, alignSelf: 'center' }} />
+      <div style=${{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+        <span style=${{ font: 'var(--fs-11)' }}>
+          <strong style=${{ color: dot }}>${item.keeper}</strong> ${' '}${item.verb}${' '}<span style=${{ color: 'var(--color-fg-muted)' }}>${item.target}</span>
+        </span>
+        ${item.hint ? html`<span style=${{ font: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${item.hint}</span>` : null}
+      </div>
+    </li>
+  `
+}

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -1,0 +1,163 @@
+import { html } from 'htm/preact'
+
+// PR-2 placeholder for the CONVERSATION rail. The real rail (anchored
+// to lines, controller-mediated scroll, RFC 0021 contract) lands in
+// Phase 2 PR-6.
+
+type ThreadKind = 'flag' | 'question' | 'approve' | 'note' | 'suggest'
+
+interface MockThread {
+  readonly kind: ThreadKind
+  readonly author: string
+  readonly anchor: string
+  readonly hint: string
+  readonly time: string
+  readonly body: string
+  readonly replies: number | null
+  readonly resolved: boolean
+}
+
+const KIND_LABEL: Record<ThreadKind, string> = {
+  flag: 'FLAG',
+  question: 'QUESTION',
+  approve: 'APPROVE',
+  note: 'NOTE',
+  suggest: 'SUGGEST',
+}
+
+const KIND_TOKEN: Record<ThreadKind, string> = {
+  flag: 'var(--color-status-err, var(--err))',
+  question: 'var(--color-status-info, var(--info))',
+  approve: 'var(--color-status-ok, var(--ok))',
+  note: 'var(--color-fg-muted)',
+  suggest: 'var(--color-status-warn, var(--warn))',
+}
+
+const MOCK_THREADS: ReadonlyArray<MockThread> = [
+  {
+    kind: 'flag',
+    author: 'nick0cave',
+    anchor: 'router.ts:34',
+    hint: 'if:moonshot-tool-choice',
+    time: '01:41:18',
+    body: "This is exactly the schema error we're seeing in prod — confirmed 3× on kimi_cli with non-empty tools[].",
+    replies: 2,
+    resolved: false,
+  },
+  {
+    kind: 'question',
+    author: 'operator',
+    anchor: 'router.ts:26',
+    hint: 'fn:resolveCascade',
+    time: '01:39:02',
+    body: 'Should normalizeTools also handle tool_choice=none? feels like an edge case.',
+    replies: 1,
+    resolved: false,
+  },
+  {
+    kind: 'approve',
+    author: 'operator',
+    anchor: 'router.ts:60',
+    hint: 'fn:nextStep',
+    time: '01:22:41',
+    body: 'Budget guard reads well. Ship it when tests pass.',
+    replies: null,
+    resolved: false,
+  },
+  {
+    kind: 'note',
+    author: 'operator',
+    anchor: 'router.ts:35',
+    hint: 'token:log.warn',
+    time: '01:18:04',
+    body: 'telemetry event name needs to match the lifeline schema — will rename later.',
+    replies: null,
+    resolved: false,
+  },
+  {
+    kind: 'suggest',
+    author: 'masc-improver',
+    anchor: 'router.ts:16',
+    hint: 'fn:normalizeTools',
+    time: '01:14:52',
+    body: 'Could you collapse the rest-spread into a small helper? Same pattern appears in provider.ts.',
+    replies: 3,
+    resolved: false,
+  },
+]
+
+export function IdeConversationRailMock() {
+  return html`
+    <div
+      role="region"
+      aria-label="CONVERSATION (mock — PR-6 replaces with RFC 0021 anchored thread rail)"
+      style=${{
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'var(--color-bg-surface)',
+        borderLeft: '1px solid var(--color-border-default)',
+        minHeight: 0,
+      }}
+    >
+      <header
+        style=${{
+          display: 'flex',
+          justifyContent: 'space-between',
+          padding: 'var(--sp-2) var(--sp-3)',
+          color: 'var(--color-fg-muted)',
+          font: 'var(--type-eyebrow)',
+          borderBottom: '1px solid var(--color-border-divider)',
+        }}
+      >
+        <span>CONVERSATION</span>
+        <span>${MOCK_THREADS.length}</span>
+      </header>
+      <ol
+        style=${{
+          listStyle: 'none',
+          padding: 'var(--sp-2)',
+          margin: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--sp-2)',
+          overflow: 'auto',
+        }}
+      >
+        ${MOCK_THREADS.map(thread => MockThreadCard(thread))}
+      </ol>
+    </div>
+  `
+}
+
+function MockThreadCard(thread: MockThread) {
+  const kindColor = KIND_TOKEN[thread.kind]
+  return html`
+    <li
+      style=${{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--sp-1)',
+        padding: 'var(--sp-2)',
+        background: 'var(--color-bg-elevated)',
+        border: '1px solid var(--color-border-default)',
+        borderLeft: `2px solid ${kindColor}`,
+        borderRadius: 'var(--r-2)',
+      }}
+    >
+      <div style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 'var(--sp-2)' }}>
+        <span style=${{ font: 'var(--fs-11)', color: kindColor, letterSpacing: '0.05em' }}>${KIND_LABEL[thread.kind]}</span>
+        <span style=${{ font: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${thread.author}</span>
+        <span style=${{ font: 'var(--fs-11)', color: 'var(--color-fg-muted)', marginLeft: 'auto' }}>${thread.time}</span>
+      </div>
+      <div style=${{ display: 'flex', gap: 'var(--sp-2)', font: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
+        <span>${thread.anchor}</span>
+        <span>·</span>
+        <span>${thread.hint}</span>
+      </div>
+      <p style=${{ font: 'var(--type-body)', color: 'var(--color-fg-secondary)', margin: 0 }}>${thread.body}</p>
+      <div style=${{ font: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
+        ${thread.replies !== null ? `${thread.replies} replies · ` : ''}${thread.resolved ? 'resolved' : 'open'}
+      </div>
+    </li>
+  `
+}

--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -1,0 +1,124 @@
+import { html } from 'htm/preact'
+
+// PR-2 placeholder for the editor pane. The real Shiki-backed read-
+// only viewer + blame-by-keeper overlay lands in Phase 2 PR-5 (cites
+// RFC 0019). The 'attribution' label echoes the cockpit IdePlane
+// prototype's IxEditAttrib (Planes.jsx:155).
+
+interface MockLine {
+  readonly num: number
+  readonly text: string
+  readonly keeper: 'nick0cave' | 'sangsu' | 'masc-improver' | null
+  readonly hue: number | null
+}
+
+const MOCK_LINES: ReadonlyArray<MockLine> = [
+  { num: 1, text: "import { Provider, ProviderKind } from './provider'", keeper: 'nick0cave', hue: 1 },
+  { num: 2, text: "import { Turn, TurnId } from './turn'", keeper: 'nick0cave', hue: 1 },
+  { num: 3, text: "import { FsmEvent } from '../fsm/state'", keeper: 'nick0cave', hue: 1 },
+  { num: 4, text: "import { log } from '../log'", keeper: 'nick0cave', hue: 1 },
+  { num: 5, text: "import type { ToolSpec } from './tools'", keeper: 'nick0cave', hue: 1 },
+  { num: 6, text: "import { TokenRegistry } from '../tokens/registry'", keeper: 'nick0cave', hue: 1 },
+  { num: 7, text: '', keeper: null, hue: null },
+  { num: 8, text: 'export type CascadeReq = {', keeper: 'sangsu', hue: 5 },
+  { num: 9, text: '  model: string', keeper: 'sangsu', hue: 5 },
+  { num: 10, text: '  messages: Array<{ role: string; content: string }>', keeper: 'sangsu', hue: 5 },
+  { num: 11, text: '  tools?: ToolSpec[]', keeper: 'sangsu', hue: 5 },
+  { num: 12, text: "  tool_choice?: 'auto' | 'none'", keeper: 'sangsu', hue: 5 },
+  { num: 13, text: '  max_tokens?: number', keeper: 'sangsu', hue: 5 },
+  { num: 14, text: '}', keeper: 'sangsu', hue: 5 },
+  { num: 15, text: '', keeper: null, hue: null },
+  { num: 16, text: 'export function normalizeTools(req: CascadeReq): CascadeReq {', keeper: 'masc-improver', hue: 3 },
+  { num: 17, text: '  // strip empty tools array', keeper: 'masc-improver', hue: 3 },
+  { num: 18, text: '  if (req.tools && req.tools.length === 0) {', keeper: 'masc-improver', hue: 3 },
+  { num: 19, text: '    const { tools, tool_choice, ...rest } = req', keeper: 'masc-improver', hue: 3 },
+  { num: 20, text: '    return rest as CascadeReq', keeper: 'masc-improver', hue: 3 },
+  { num: 21, text: '  }', keeper: 'masc-improver', hue: 3 },
+  { num: 22, text: '  return req', keeper: 'masc-improver', hue: 3 },
+  { num: 23, text: '}', keeper: 'masc-improver', hue: 3 },
+]
+
+const VIEW_TABS = ['SOURCE', 'SPLIT DIFF', 'UNIFIED', 'BLAME'] as const
+
+export function IdeEditorMock() {
+  return html`
+    <div
+      role="region"
+      aria-label="에디터 (mock — PR-5 replaces with Shiki + blame-by-keeper)"
+      style=${{
+        display: 'grid',
+        gridTemplateRows: 'auto 1fr',
+        background: 'var(--color-bg-page)',
+        minHeight: 0,
+      }}
+    >
+      <header
+        style=${{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--sp-3)',
+          padding: 'var(--sp-2) var(--sp-3)',
+          borderBottom: '1px solid var(--color-border-divider)',
+          color: 'var(--color-fg-muted)',
+          font: 'var(--type-eyebrow)',
+        }}
+      >
+        <span>runtime / cascade / router.ts</span>
+        <span style=${{ marginLeft: 'auto', display: 'flex', gap: 'var(--sp-2)' }}>
+          ${VIEW_TABS.map((tab, i) => html`
+            <span
+              role="tab"
+              aria-selected=${i === 0 ? 'true' : 'false'}
+              style=${{
+                padding: '2px 6px',
+                color: i === 0 ? 'var(--color-fg-primary)' : 'var(--color-fg-muted)',
+                borderBottom: i === 0 ? '1px solid var(--color-accent-fg)' : '1px solid transparent',
+              }}
+            >${tab}</span>
+          `)}
+        </span>
+      </header>
+      <ol
+        style=${{
+          listStyle: 'none',
+          padding: 'var(--sp-2) 0',
+          margin: 0,
+          overflow: 'auto',
+          fontFamily: 'var(--font-mono)',
+          font: 'var(--fs-13)',
+          lineHeight: 1.6,
+        }}
+      >
+        ${MOCK_LINES.map(line => MockEditorRow(line))}
+      </ol>
+    </div>
+  `
+}
+
+function MockEditorRow(line: MockLine) {
+  const dot = line.hue !== null
+    ? `var(--color-keeper-${line.hue}-glow, var(--k-${line.hue}))`
+    : 'transparent'
+  return html`
+    <li
+      style=${{
+        display: 'grid',
+        gridTemplateColumns: '88px 16px auto 1fr',
+        gap: 'var(--sp-2)',
+        alignItems: 'center',
+        padding: '0 var(--sp-3)',
+      }}
+    >
+      <span
+        style=${{
+          color: line.keeper ? `var(--color-keeper-${line.hue}-glow, var(--k-${line.hue}))` : 'var(--color-fg-disabled)',
+          font: 'var(--fs-11)',
+          textAlign: 'right',
+        }}
+      >${line.keeper ?? '—'}</span>
+      <span aria-hidden="true" style=${{ width: '6px', height: '6px', borderRadius: '50%', background: dot, justifySelf: 'center' }} />
+      <span style=${{ color: 'var(--color-fg-disabled)', font: 'var(--fs-11)', minWidth: '24px', textAlign: 'right' }}>${line.num}</span>
+      <span style=${{ color: 'var(--color-fg-secondary)', whiteSpace: 'pre' }}>${line.text}</span>
+    </li>
+  `
+}

--- a/dashboard/src/components/ide/ide-explorer-mock.ts
+++ b/dashboard/src/components/ide/ide-explorer-mock.ts
@@ -1,0 +1,113 @@
+import { html } from 'htm/preact'
+
+// PR-2 placeholder for the EXPLORER pane. The real file tree (with
+// keeper dots, diff counts, RFC 0014 tree-view + roving-tabindex,
+// virtualization, and the file-tree-store) lands in Phase 2 PR-4.
+//
+// This mock matches the shape of the cockpit IdePlane prototype's
+// IxTreeDiff (Planes.jsx:186) and the audit's mapping to the file
+// explorer (RFC 0014 + file-tree-store).
+//
+// All values here are visual placeholders; do not parse them as a
+// real source of truth — the PR-4 store will replace them wholesale.
+
+interface MockTreeNode {
+  readonly path: string
+  readonly depth: number
+  readonly diff: '+12' | '+3' | '-1' | '+8' | '+14' | '-2' | null
+  readonly keeperHue: number | null
+}
+
+const MOCK_TREE: ReadonlyArray<MockTreeNode> = [
+  { path: 'runtime/', depth: 0, diff: null, keeperHue: null },
+  { path: 'cascade/', depth: 1, diff: null, keeperHue: null },
+  { path: 'router.ts', depth: 2, diff: '+14', keeperHue: 1 },
+  { path: 'provider.ts', depth: 2, diff: '+3', keeperHue: 1 },
+  { path: 'turn.ts', depth: 2, diff: null, keeperHue: null },
+  { path: 'index.ts', depth: 2, diff: null, keeperHue: null },
+  { path: 'fsm/', depth: 1, diff: null, keeperHue: null },
+  { path: 'lifeline.ts', depth: 2, diff: '+8', keeperHue: 5 },
+  { path: 'state.ts', depth: 2, diff: null, keeperHue: null },
+  { path: 'tokens/', depth: 1, diff: null, keeperHue: null },
+  { path: 'registry.ts', depth: 2, diff: '+12', keeperHue: 3 },
+  { path: 'format.ts', depth: 2, diff: '-2', keeperHue: 3 },
+  { path: 'package.json', depth: 0, diff: null, keeperHue: null },
+  { path: 'README.md', depth: 0, diff: null, keeperHue: null },
+]
+
+export function IdeExplorerMock() {
+  return html`
+    <div
+      role="region"
+      aria-label="EXPLORER (mock)"
+      style=${{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--sp-2)',
+        padding: 'var(--sp-3)',
+        background: 'var(--color-bg-surface)',
+        borderRight: '1px solid var(--color-border-default)',
+        minHeight: 0,
+        overflow: 'auto',
+      }}
+    >
+      <header
+        style=${{
+          display: 'flex',
+          justifyContent: 'space-between',
+          color: 'var(--color-fg-muted)',
+          font: 'var(--type-eyebrow)',
+          paddingBottom: 'var(--sp-2)',
+          borderBottom: '1px solid var(--color-border-divider)',
+        }}
+      >
+        <span>EXPLORER</span>
+        <span>${MOCK_TREE.filter(n => n.diff !== null).length} FILES</span>
+      </header>
+      <ul
+        role="tree"
+        aria-label="File tree (mock — PR-4 replaces with RFC 0014 tree-view)"
+        style=${{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '2px' }}
+      >
+        ${MOCK_TREE.map(node => MockTreeRow(node))}
+      </ul>
+    </div>
+  `
+}
+
+function MockTreeRow(node: MockTreeNode) {
+  const indent = node.depth * 12
+  const dotColor = node.keeperHue !== null
+    ? `var(--color-keeper-${node.keeperHue}-glow, var(--k-${node.keeperHue}))`
+    : 'transparent'
+  return html`
+    <li
+      role="treeitem"
+      style=${{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr auto',
+        alignItems: 'center',
+        gap: 'var(--sp-2)',
+        padding: '2px 4px',
+        paddingLeft: `${4 + indent}px`,
+        font: 'var(--type-body)',
+        color: 'var(--color-fg-secondary)',
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style=${{
+          width: '8px',
+          height: '8px',
+          borderRadius: '50%',
+          background: dotColor,
+          opacity: node.keeperHue !== null ? 0.85 : 0,
+        }}
+      />
+      <span>${node.path}</span>
+      ${node.diff !== null
+        ? html`<span style=${{ color: 'var(--color-fg-muted)', font: 'var(--fs-11)' }}>${node.diff}</span>`
+        : null}
+    </li>
+  `
+}

--- a/dashboard/src/components/ide/ide-interject-mock.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.ts
@@ -1,0 +1,72 @@
+import { html } from 'htm/preact'
+
+// PR-2 placeholder for the INTERJECT input. The real wiring (input
+// store + active-keeper resolution + Send/Approve/Pause/Drain action
+// dispatch through keeper-actions.ts) lands in Phase 2 PR-7.
+
+const ACTIONS: ReadonlyArray<{ id: string; label: string; primary: boolean }> = [
+  { id: 'send', label: 'Send', primary: true },
+  { id: 'approve', label: 'Approve', primary: false },
+  { id: 'pause', label: 'Pause', primary: false },
+  { id: 'drain', label: 'Drain', primary: false },
+]
+
+export function IdeInterjectMock() {
+  return html`
+    <div
+      role="region"
+      aria-label="INTERJECT (mock — PR-7 replaces with active-keeper wiring)"
+      style=${{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr auto',
+        gap: 'var(--sp-2)',
+        padding: 'var(--sp-2) var(--sp-3)',
+        background: 'var(--color-bg-elevated)',
+        borderTop: '1px solid var(--color-border-default)',
+        alignItems: 'center',
+      }}
+    >
+      <span
+        style=${{
+          font: 'var(--type-eyebrow)',
+          color: 'var(--color-fg-muted)',
+          padding: '0 var(--sp-2)',
+        }}
+      >INTERJECT</span>
+      <input
+        type="text"
+        placeholder="Send message to active keeper..."
+        aria-label="Interject input (mock)"
+        readOnly
+        style=${{
+          width: '100%',
+          padding: 'var(--sp-2)',
+          background: 'var(--color-bg-page)',
+          color: 'var(--color-fg-secondary)',
+          border: '1px solid var(--color-border-default)',
+          borderRadius: 'var(--r-1)',
+          font: 'var(--type-body)',
+        }}
+      />
+      <div style=${{ display: 'flex', gap: 'var(--sp-1)' }}>
+        ${ACTIONS.map(action => html`
+          <button
+            type="button"
+            disabled
+            aria-label=${`${action.label} (mock — PR-7 wires action)`}
+            style=${{
+              padding: '6px 12px',
+              background: action.primary ? 'var(--color-accent-fg)' : 'var(--color-bg-surface)',
+              color: action.primary ? 'var(--color-bg-page)' : 'var(--color-fg-secondary)',
+              border: action.primary ? 'none' : '1px solid var(--color-border-default)',
+              borderRadius: 'var(--r-1)',
+              font: 'var(--type-body)',
+              cursor: 'not-allowed',
+              opacity: 0.85,
+            }}
+          >${action.label}</button>
+        `)}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,83 +1,80 @@
 import { html } from 'htm/preact'
+import { IdeExplorerMock } from './ide-explorer-mock'
+import { IdeEditorMock } from './ide-editor-mock'
+import { IdeConversationRailMock } from './ide-conversation-rail-mock'
+import { IdeActivityMock } from './ide-activity-mock'
+import { IdeInterjectMock } from './ide-interject-mock'
 
-// PR-1 placeholder: route + navigation entry are wired but the actual
-// 4-pane content (EXPLORER · 에디터 · CONVERSATION · ACTIVITY) lands in
-// PR-2. The shell renders the cockpit IdePlane prototype's grid stub
-// (`design-system/ui_kits/cockpit/Planes.jsx:144`) so the production
-// surface picks up where v0.4 SSOT left off.
+// PR-2: 4-pane CODE mode shell with mock content. Layout matches the
+// cockpit IdePlane prototype's grid (`design-system/ui_kits/cockpit/
+// cockpit.css` `.ide-v2-tree / .ide-v2-center / .ide-v2-right /
+// .ide-v2-terminal`); production tokens are v0.4 Semantic-tier only.
+//
+// Each child mock cites the implementation PR that replaces it:
+//   EXPLORER          -> Phase 2 PR-4 (file-tree-store, RFC 0014)
+//   editor            -> Phase 2 PR-5 (Shiki + RFC 0019 blame)
+//   CONVERSATION rail -> Phase 2 PR-6 (RFC 0021)
+//   ACTIVITY          -> Phase 2 PR-6 (sse-store-backed stream)
+//   INTERJECT         -> Phase 2 PR-7 (keeper-actions wiring)
 //
 // Audit reference:
 //   dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md
-//
-// All visible color and spacing values flow from v0.4 Semantic tier
-// tokens; do not introduce raw hex literals here.
 
 export function IdeShell() {
   return html`
     <section
       class="ide-plane-shell"
       role="region"
-      aria-label="Code IDE shell (Phase 1 placeholder)"
+      aria-label="Code IDE shell (Phase 1 PR-2 — mock content)"
       style=${{
         display: 'grid',
-        gridTemplateRows: 'auto 1fr',
-        gap: 'var(--sp-3)',
-        padding: 'var(--sp-4)',
-        minHeight: 'calc(100vh - var(--h-topbar) - var(--h-kpi))',
+        gridTemplateRows: 'auto 1fr auto',
         background: 'var(--color-bg-page)',
         color: 'var(--color-fg-primary)',
+        minHeight: 'calc(100vh - var(--h-topbar) - var(--h-kpi))',
       }}
     >
-      <header style=${{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-1)' }}>
-        <h1 style=${{ font: 'var(--type-section-title)', margin: 0 }}>
-          코드 IDE
-        </h1>
-        <p style=${{ color: 'var(--color-fg-muted)', margin: 0, font: 'var(--type-body)' }}>
-          Multi-keeper 협업 코드 review surface — Phase 1 라우트 셋업.
-          EXPLORER · 에디터 · CONVERSATION · ACTIVITY 4-pane 콘텐츠는 후속 PR에서 채워집니다.
-        </p>
+      <header
+        style=${{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--sp-3)',
+          padding: 'var(--sp-2) var(--sp-3)',
+          background: 'var(--color-bg-surface)',
+          borderBottom: '1px solid var(--color-border-default)',
+          font: 'var(--type-eyebrow)',
+          color: 'var(--color-fg-muted)',
+        }}
+      >
+        <span style=${{ color: 'var(--color-fg-secondary)' }}>코드 IDE</span>
+        <span>·</span>
+        <span>* runtime / main / nick0cave@dkr-a1 / improver@wt-run-47</span>
+        <span style=${{ marginLeft: 'auto', color: 'var(--color-status-ok, var(--ok))' }}>● mcp · connected</span>
       </header>
       <div
-        class="ide-plane-grid-placeholder"
+        class="ide-plane-grid"
         role="presentation"
         style=${{
           display: 'grid',
-          gridTemplateColumns: 'minmax(180px, 240px) minmax(0, 1fr) minmax(280px, 320px)',
-          gridTemplateRows: '1fr',
-          gap: 'var(--sp-3)',
+          gridTemplateColumns: 'minmax(180px, 220px) minmax(0, 1fr) minmax(280px, 320px)',
+          gridTemplateRows: '1fr auto',
           minHeight: 0,
         }}
       >
-        ${PanePlaceholder({ title: 'EXPLORER', body: '파일 트리 (PR-2 / PR-4)' })}
-        ${PanePlaceholder({ title: '에디터', body: '코드 + blame-by-keeper (PR-2 / PR-5)' })}
-        ${PanePlaceholder({
-          title: 'CONVERSATION · ACTIVITY',
-          body: '라인 anchored thread + activity 스트림 (PR-2 / PR-6)',
-        })}
+        <div style=${{ gridColumn: 1, gridRow: '1 / span 2' }}>
+          <${IdeExplorerMock} />
+        </div>
+        <div style=${{ gridColumn: 2, gridRow: '1 / span 2', minHeight: 0 }}>
+          <${IdeEditorMock} />
+        </div>
+        <div style=${{ gridColumn: 3, gridRow: 1, minHeight: 0 }}>
+          <${IdeConversationRailMock} />
+        </div>
+        <div style=${{ gridColumn: 3, gridRow: 2, minHeight: 0 }}>
+          <${IdeActivityMock} />
+        </div>
       </div>
+      <${IdeInterjectMock} />
     </section>
-  `
-}
-
-function PanePlaceholder({ title, body }: { title: string; body: string }) {
-  return html`
-    <div
-      style=${{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 'var(--sp-2)',
-        padding: 'var(--sp-3)',
-        background: 'var(--color-bg-surface)',
-        border: '1px solid var(--color-border-default)',
-        borderRadius: 'var(--r-2)',
-      }}
-    >
-      <span style=${{ color: 'var(--color-fg-muted)', font: 'var(--type-eyebrow)' }}>
-        ${title}
-      </span>
-      <span style=${{ color: 'var(--color-fg-secondary)', font: 'var(--type-body)' }}>
-        ${body}
-      </span>
-    </div>
   `
 }


### PR DESCRIPTION
## Summary

PR-1 (#12325, merged) 의 placeholder grid를 시안 mockup 의 full 4-pane CODE-mode shell 로 확장. 각 pane 은 mock 컴포넌트로 분리되어 후속 PR (Phase 2 PR-4~7) 에서 실데이터/실 wiring 으로 교체. plan `planning/claude-plans/zany-yawning-nebula.md` 의 **Phase 1 PR-2**.

## Changes

5 신규 mock 컴포넌트 + ide-shell.ts 4-pane grid. 각 mock 은 cockpit IdePlane prototype (`ui_kits/cockpit/cockpit.css` `.ide-v2-*` grid) 와 audit 의 element mapping 에 정합:

| 파일 | 역할 | 후속 교체 PR |
|------|------|--------------|
| `ide-explorer-mock.ts` | EXPLORER tree (14 mock 노드, keeper dot, diff count) | PR-4 (file-tree-store, RFC 0014) |
| `ide-editor-mock.ts` | 에디터 + 좌측 keeper label + 라인 dot (router.ts 23 mock 라인) | PR-5 (Shiki + RFC 0019 blame) |
| `ide-conversation-rail-mock.ts` | CONVERSATION 5-kind cards (FLAG/QUESTION/APPROVE/NOTE/SUGGEST), line anchor | PR-6 (RFC 0021) |
| `ide-activity-mock.ts` | ACTIVITY THIS RUN keeper timeline (13 mock events) | PR-6 (sse-store stream) |
| `ide-interject-mock.ts` | 하단 input + Send/Approve/Pause/Drain 버튼 (disabled) | PR-7 (keeper-actions wire) |
| `ide-shell.ts` | 4-pane grid (tree+editor span 2 rows · rail+activity stack 우측 · interject bottom) | — |

## Token rule

\`rg '#[0-9a-fA-F]{3,8}' src/components/ide/\` 출력 0 lines. 모든 visible color/spacing 이 v0.4 Semantic-tier 토큰:

- 배경: `--color-bg-page`, `--color-bg-surface`, `--color-bg-elevated`
- 텍스트: `--color-fg-primary`, `--color-fg-secondary`, `--color-fg-muted`, `--color-fg-disabled`
- keeper hue: `--color-keeper-N-glow` (raw fallback `--k-N`)
- status: `--color-status-{ok,warn,err,info}` (raw fallback `--ok/--warn/--err/--info`)
- spacing: `--sp-1`/`--sp-2`/`--sp-3`, `--r-1`/`--r-2`
- typography: `--type-eyebrow`/`--type-body`, `--fs-11`/`--fs-13`, `--font-mono`

audit §6 raw-hex-blocking checklist 통과.

## Test plan

- [x] `pnpm typecheck` pass
- [ ] CI green (Dashboard / Lint / Build)
- [ ] manual: `#code/ide-shell` 진입 시 4-pane grid 렌더, mockup 시각 fidelity 확인 (SSIM ≥ 0.92)
- [ ] manual: 비-IDE 라우트 영향 0 (다른 surface 의 lazy chunk 만 load)

## Future PRs (이 PR 머지 후)

- **PR-3** (Phase 1): view tabs (SOURCE/SPLIT DIFF/UNIFIED/BLAME) + LAYERS toggle (mock). RFC 0020 controller 구현 + adapter.
- **PR-4** (Phase 2): EXPLORER + file-tree store. RFC 0014 어댑터.
- **PR-5** (Phase 2): Editor + Shiki + blame-by-keeper. RFC 0019 구현.
- **PR-6** (Phase 2): CONVERSATION rail 실데이터 + ACTIVITY stream (sse-store). RFC 0021 구현.
- **PR-7** (Phase 2): INTERJECT 실배선 + lazy chunk.

## Refs

- `planning/claude-plans/zany-yawning-nebula.md` Phase 1 PR-2
- `dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md` (#12317)
- `dashboard/design-system/RFC/0019/0020/0021` (#12330, Draft)
- `dashboard/design-system/ui_kits/cockpit/Planes.jsx:144` (`IdePlane` prototype)

🤖 Generated with [Claude Code](https://claude.com/claude-code)