### PR TITLE
refactor(cascade): type strategy trace cascade names

### DIFF
--- a/lib/cascade/cascade_strategy_trace.ml
+++ b/lib/cascade/cascade_strategy_trace.ml
@@ -4,7 +4,7 @@ type event_kind = Ordered | Filtered_empty | Exhausted
 
 type event = {
   ts : float;
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
   strategy : string;
   cycle : int;
   candidates_in : int;
@@ -58,7 +58,7 @@ let ensure_initialised_locked () =
 let bump_prometheus_counter (ev : event) =
   Prometheus.inc_counter Prometheus.metric_cascade_strategy_decisions
     ~labels:[
-      "cascade", ev.cascade_name;
+      "cascade", Keeper_cascade_profile.runtime_name_to_string ev.cascade_name;
       "strategy", ev.strategy;
       "kind", kind_to_string ev.kind;
     ] ()
@@ -108,7 +108,11 @@ let snapshot ?(limit = 100) ?cascade () =
   let cascade_match =
     match cascade with
     | None -> fun _ -> true
-    | Some c -> fun (e : event) -> e.cascade_name = c
+    | Some c ->
+        fun (e : event) ->
+          String.equal
+            (Keeper_cascade_profile.runtime_name_to_string e.cascade_name)
+            c
   in
   let limit = max 0 limit in
   let rec take n xs =

--- a/lib/cascade/cascade_strategy_trace.mli
+++ b/lib/cascade/cascade_strategy_trace.mli
@@ -37,7 +37,8 @@ type event_kind = Ordered | Filtered_empty | Exhausted
 (** One decision event.
 
     [ts] is a Unix timestamp (seconds).
-    [cascade_name] is the cascade.json profile name.
+    [cascade_name] is the cascade.json profile name carried as a typed
+    runtime cascade identifier.
     [strategy] is {!Cascade_strategy.kind_to_string} of the active kind.
     [cycle] is 0-based, matching the [n] in [oas_worker_named.cycle_loop].
     [candidates_in] is the input list size (post-[resolve_strategy]).
@@ -47,7 +48,7 @@ type event_kind = Ordered | Filtered_empty | Exhausted
     [0] for [Ordered] and [Exhausted]. *)
 type event = {
   ts : float;
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
   strategy : string;
   cycle : int;
   candidates_in : int;

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -785,6 +785,9 @@ let client_capacity_history_json ?limit ?kind ?since_ts () =
 
 let strategy_trace_event_to_json (ev : Cascade_strategy_trace.event)
   : Yojson.Safe.t =
+  let cascade_name =
+    Keeper_cascade_profile.runtime_name_to_string ev.cascade_name
+  in
   let trace_id_json =
     match ev.trace_id with
     | None -> `Null
@@ -792,7 +795,7 @@ let strategy_trace_event_to_json (ev : Cascade_strategy_trace.event)
   in
   `Assoc [
     ("ts", `Float ev.ts);
-    ("cascade_name", `String ev.cascade_name);
+    ("cascade_name", `String cascade_name);
     ("strategy", `String ev.strategy);
     ("cycle", `Int ev.cycle);
     ("candidates_in", `Int ev.candidates_in);

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -843,7 +843,7 @@ let run_named
   let record_trace ~cycle ~candidates_out ~backoff_ms ~kind =
     Cascade_strategy_trace.record {
       ts = Unix.gettimeofday ();
-      cascade_name;
+      cascade_name = Keeper_cascade_profile.Runtime_name cascade_name;
       strategy = strategy_name;
       cycle;
       candidates_in = List.length candidate_cfgs;

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -14,6 +14,7 @@ module H = Masc_mcp.Cascade_health_tracker
 module C = Masc_mcp.Cascade_client_capacity
 module CH = Masc_mcp.Cascade_client_capacity_history
 module ST = Masc_mcp.Cascade_strategy_trace
+module Kcp = Masc_mcp.Keeper_cascade_profile
 module T = Masc_mcp.Cascade_throttle
 module Cascade_state = Masc_mcp.Cascade_state
 
@@ -964,7 +965,8 @@ let mk_trace_event ?(ts = 0.0) ?(cascade_name = "big_three")
     ?(strategy = "failover") ?(cycle = 0) ?(candidates_in = 3)
     ?(candidates_out = 3) ?(backoff_ms = 0) ?(kind = ST.Ordered)
     ?trace_id () =
-  { ST.ts; cascade_name; strategy; cycle; candidates_in; candidates_out;
+  { ST.ts; cascade_name = Kcp.Runtime_name cascade_name; strategy; cycle;
+    candidates_in; candidates_out;
     backoff_ms; kind; trace_id }
 
 let test_trace_record_snapshot_roundtrip () =
@@ -994,7 +996,9 @@ let test_trace_cascade_filter () =
   let unified = ST.snapshot ~cascade:"big_three" () in
   check int "big_three → 2 events" 2 (List.length unified);
   List.iter
-    (fun e -> check string "cascade filter" "big_three" e.ST.cascade_name)
+    (fun e ->
+      check string "cascade filter" "big_three"
+        (Kcp.runtime_name_to_string e.ST.cascade_name))
     unified;
   let missing = ST.snapshot ~cascade:"does_not_exist" () in
   check int "missing cascade → empty" 0 (List.length missing)

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -639,9 +639,10 @@ let test_declared_provider_schemes_handles_malformed_config () =
 (* ── SLO (LT-11) ─────────────────────────────────────── *)
 
 module ST = Masc_mcp.Cascade_strategy_trace
+module Kcp = Masc_mcp.Keeper_cascade_profile
 
 let mk_trace ?(ts = 0.0) ?(strategy = "failover") ?trace_id ~kind () =
-  { ST.ts; cascade_name = "c1"; strategy; cycle = 0;
+  { ST.ts; cascade_name = Kcp.Runtime_name "c1"; strategy; cycle = 0;
     candidates_in = 1; candidates_out = 1; backoff_ms = 0; kind; trace_id }
 
 let assert_field name fields =


### PR DESCRIPTION
## Summary

- Type `Cascade_strategy_trace.event.cascade_name` as `Keeper_cascade_profile.runtime_name`.
- Keep `snapshot ?cascade:string` compatible while rendering typed names only at filter, Prometheus, and dashboard JSON boundaries.
- Wrap `Oas_worker_named` strategy trace records with typed runtime cascade names and update trace/dashboard tests.

## Product impact

This continues #11926's cascade-name boundary ratchet in the strategy trace ring. Operator-facing labels stay unchanged, while the in-process trace event carries typed cascade identity instead of a raw string.

## Evidence

- `scripts/dune-local.sh build test/test_cascade_strategy.exe test/test_dashboard_cascade.exe test/test_oas_worker.exe`
- `./_build/default/test/test_cascade_strategy.exe test strategy_trace 0-5`
- `./_build/default/test/test_dashboard_cascade.exe test slo_json 0-5`
- `./_build/default/test/test_oas_worker.exe test cascade_config 7`
- `git diff --check HEAD~1 HEAD`
- `scripts/stringly-boundary-ratchet.sh` (`raw_cascade_name_string_signatures: 51 -> 49`)
- `scripts/ocaml-structure-ratchet.sh`

## Review evidence

- Existing dashboard query/filter API remains string-based.
- Prometheus and dashboard JSON labels are rendered from the typed cascade name at the output boundary.

## Linked issue

- Part of #11926
