### PR TITLE
fix(dashboard): resolve cascade-inspector and agents insertBefore render errors

### DIFF
--- a/dashboard/src/components/cascade-inspector.ts
+++ b/dashboard/src/components/cascade-inspector.ts
@@ -111,7 +111,7 @@ function StrategyTraceTable({ events }: { events: CascadeStrategyTraceEvent[] })
           ${events.map(e => html`
             <tr key=${e.ts + e.cascade_name + e.cycle} class="hover:bg-[var(--white-3)] transition-colors">
               <td class="px-3 py-2 text-text-body whitespace-nowrap">
-                <${TimeAgo} iso=${new Date(e.ts).toISOString()} />
+                <${TimeAgo} timestamp=${e.ts} />
               </td>
               <td class="px-3 py-2 font-medium text-text-strong">${e.cascade_name}</td>
               <td class="px-3 py-2 text-text-body">${e.strategy}</td>
@@ -159,7 +159,7 @@ function ProviderHealthTable({ providers }: { providers: CascadeHealthProvider[]
               </td>
               <td class="px-3 py-2">
                 ${p.in_cooldown
-                  ? html`<${StatusBadge} tone="warn">잇데이 출다욘 징햊학<///>`
+                  ? html`<${StatusBadge} tone="warn">쿨다운 진행 중<//>`
                   : html`<span class="text-text-muted">-</span>`}
               </td>
               <td class="px-3 py-2 text-right tabular-nums text-text-muted">${p.events_in_window}</td>

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -709,7 +709,7 @@ function StatusBar({
   const liveBadge = snapshot
     ? snapshot.is_live
       ? html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono text-[var(--color-status-ok)] border-[var(--ok-20)] bg-[var(--ok-10)] animate-pulse">● 실행 중</span>`
-      : html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono ${idleIsLong ? 'text-[var(--color-fg-muted)] border-[var(--warn-20)]' : 'text-[var(--color-fg-disabled)] border-[var(--white-10)]'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-3xs opacity-70"><span aria-hidden="true">· </span>턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
+      : html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono ${idleIsLong ? 'text-[var(--color-fg-muted)] border-[var(--warn-20)]' : 'text-[var(--color-fg-disabled)] border-[var(--white-10)]'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-3xs opacity-70"><span aria-hidden="true">· </span>턴 #${snapshot.last_outcome.turn_id}</span>` : null}</span>`
     : null
   const receiptLabel = snapshot ? executionReceiptLabel(snapshot.execution) : null
 


### PR DESCRIPTION
## Summary
- Fixes `Intl.RelativeTimeFormat` finite number error in cascade-inspector by passing correct `timestamp` prop to `TimeAgo`
- Fixes malformed HTM closing tag `<///` → `<//>` in ProviderHealthTable
- Fixes `insertBefore` DOM error in agents view by replacing empty string `''` with `null` in nested `html` conditional fallback within `fsm-hub.ts`

## Changes
- `dashboard/src/components/cascade-inspector.ts`
  - `iso=${...}` → `timestamp=${e.ts}` (line 114)
  - `<///>` → `<//>` + normalize Korean text (line 162)
- `dashboard/src/components/fsm-hub.ts`
  - `''` → `null` in nested html ternary fallback (line 712)

## Test plan
- [ ] Open monitoring → cascade-inspector section, verify no console error
- [ ] Open monitoring → agents section, verify no `insertBefore` error
- [ ] Verify cooldown badge renders correctly in ProviderHealthTable