### PR TITLE
[codex] Fix draft guard post-merge races

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -134,6 +134,8 @@ jobs:
                   pullRequest(number: $number) {
                     id
                     isDraft
+                    state
+                    merged
                     autoMergeRequest {
                       enabledAt
                     }
@@ -147,6 +149,17 @@ jobs:
               number: pullNumber
             });
             const current = result.repository.pullRequest;
+            if (!current) {
+              core.info(`PR #${pullNumber} no longer resolves; skip draft auto-merge guard.`);
+              return;
+            }
+            if (current.state === "MERGED" || current.state === "CLOSED" || current.merged === true) {
+              core.info(
+                `PR #${pullNumber} live state is ${current.state} (merged=${current.merged}); ` +
+                  "skip draft auto-merge guard for post-close/post-merge event."
+              );
+              return;
+            }
             const draftBoundaryAction =
               action === "ready_for_review" ||
               action === "auto_merge_enabled" ||

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -160,6 +160,32 @@ let test_agent_draft_policy_script () =
        (("PR_IS_DRAFT", "false") :: ("PR_LIVE_STATE", "OPEN") :: base)
      <> 0)
 
+let test_pr_automation_draft_guard_contracts () =
+  check bool "pr automation live query includes PR state" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "state\n                    merged");
+  check bool "pr automation skips live merged PRs" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       {|current.state === "MERGED"|});
+  check bool "pr automation skips live closed PRs" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       {|current.state === "CLOSED"|});
+  check bool "pr automation skips when live merged flag is true" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "current.merged === true");
+  let live_state_skip =
+    file_pattern_position ".github/workflows/pr-automation.yml"
+      {|current.state === "MERGED"|}
+  in
+  let draft_restore =
+    file_pattern_position ".github/workflows/pr-automation.yml"
+      "convertPullRequestToDraft"
+  in
+  check bool "post-merge skip runs before draft restore mutation" true
+    (match live_state_skip, draft_restore with
+     | Some skip_pos, Some restore_pos -> skip_pos < restore_pos
+     | _ -> false)
+
 let test_health_and_ci_runner_diagnostics () =
   check bool "health snapshot records baseline source" true
     (file_contains_pattern "scripts/health_snapshot.sh" "\"baseline\": {");
@@ -1033,6 +1059,8 @@ let () =
            test_case "sync and asset contracts" `Quick test_ci_sync_and_asset_contracts;
            test_case "agent draft policy script" `Quick
              test_agent_draft_policy_script;
+           test_case "pr automation draft guard contracts" `Quick
+             test_pr_automation_draft_guard_contracts;
            test_case "contract harness contracts" `Quick
              test_contract_harness_contracts;
            test_case "health and ci diagnostics" `Quick test_health_and_ci_runner_diagnostics;


### PR DESCRIPTION
## Summary

- Re-check the live GraphQL PR state inside Draft Auto-Merge Guard before applying policy repairs.
- Skip guard mutation/comment/failure paths when the live PR is already merged or closed.
- Add a CI hardening source guard so the live-state skip remains before `convertPullRequestToDraft`.

## Root Cause

The workflow already skipped events whose payload said the PR was closed or merged, but a `ready_for_review` event can be queued while the PR payload is still open and then execute after the PR has merged. In that case the guard used stale payload state, tried to convert an already-merged PR back to draft, and produced a red post-merge guard failure.

## Validation

- `scripts/dune-local.sh build test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ci_hardening_source.exe`

Fixes #12332.
