### PR TITLE
dashboard: add Tooltip ARIA atom (sec06 6.1.1)

### DIFF
--- a/dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md
+++ b/dashboard/design-system/audits/2026-04-29-phase2-implementation-gap.md
@@ -330,3 +330,243 @@ Production:
 - `dashboard/src/api/schemas/autoresearch.ts:48-92` — loop/cycle valibot schemas.
 - `dashboard/src/types/core.ts:294-312` — `Goal` type (no `progress`/`total`).
 - `dashboard/src/config/navigation.ts:165-168, 251-254` — `safe-autonomy` and `autoresearch` route registration.
+
+---
+
+## Appendix — 15-Zone Independent Inventory
+
+These zones have **zero dedicated production surface** or a **misaligned partial implementation**. They were scoped out of the main 6-zone audit because no production component was mounted from `navigation.ts` under the preview's zone identity. This appendix records a rapid inventory so Phase F sizing can be completed.
+
+### Methodology
+
+1. Read `cb-root.jsx` section headers (lines 108–246) to record preview variant count and slot IDs.
+2. `rg`-search production `src/components/` and `src/api/` for matching component names, data shapes, or API endpoints.
+3. Check `navigation.ts` for section registration under the zone's canonical tab.
+4. Classify gap: **Zero** = no production code; **Partial** = production code exists but under a different zone identity or with a different data model; **Misaligned** = production and preview share a name but render different shapes.
+
+### Inventory summary
+
+| Zone | Track | Preview variants | Production files | Gap | Effort |
+|------|-------|------------------|------------------|-----|--------|
+| G3 Accountability | Work | 2 (ledger, matrix) | None | Zero | High |
+| C1 Board Zone | Comms | 3 (feed, thread, hot/auto) | None | Zero | Mid |
+| C2 Messages / Broadcast | Comms | 3 (room, inbox, state block) | None | Zero | High |
+| C3 Composer v2 | Comms | 3 (broadcast, mention, state) | None | Zero | High |
+| O2 Audit Ledger | Observability | 3 (ledger, by actor, summary) | None | Zero | High |
+| O4 Cost & Latency | Observability | 3 (per-agent, heatmap, latency) | `cost-dashboard.ts` (per-**model**, not per-agent) | Misaligned | Mid |
+| O5 Heuristic + Stress | Observability | 3 (log, board, by module) | None | Zero | High |
+| K2 Decisions / Memory | Cognition | 2 (stream, entries) | `memory-subsystems.ts` (memory only; no decisions stream) | Partial | Mid |
+| K3 Institution Episodes | Cognition | 2 (cards, learnings) | None | Zero | High |
+| I0 IDE Backbone | IDE | 3 (branch, keeper, nudge) | None | Zero | High |
+| E1 File Tree Explorer | IDE | 4 (tree, filter, tabs, diff) | None | Zero | High |
+| E2 Editor Surfaces | IDE | 5 (attrib, split, merge, review, blame) | None | Zero | High |
+| E3 PR Inspector | IDE | 4 (header, files, thread, checks) | None | Zero | High |
+| E4 Branch / Git Graph | IDE | 4 (DAG, commits, worktree, stash) | `git-graph-panel.ts` (read-only graph; no keeper attribution) | Partial | Mid |
+| E5 Terminal / Search | IDE | 3 (terminal, search, find/replace) | None | Zero | High |
+
+**Aggregate**: 15 zones, **36 preview variants**, **~1.5 production equivalents** (cost-dashboard + memory-subsystems + git-graph-panel). The IDE track (I0 + E1–E5) is entirely unimplemented.
+
+---
+
+### G3 · Accountability
+
+**Preview** (`cb-root.jsx:167-170`): Daily verdict ledger + keeper × scope responsibility matrix. Mock data: accountability ledger with daily entries.
+
+**Production search**: `rg -i "accountability|responsibility.*matrix|daily.*ledger|verdict.*ledger" src/` returned zero hits. `attribution-panel.ts` is a **different surface** (Layer 4 gate-chain observation, per-gate pass/fail counts).
+
+**Gap**: Zero. No ledger data source, no matrix component.
+
+**Effort**: **High** — needs new backend data model (daily accountability records) + 2 new components.
+
+---
+
+### C1 · Board Zone
+
+**Preview** (`cb-root.jsx:174-178`): Feed (hearth-grouped), single post + thread, direct vs automation toggle. Part of **Comms** track.
+
+**Production search**: Zero hits for a dedicated Comms-track board surface. `workspace?section=board` exists under the **Workspace** tab, which is a different organizational plane.
+
+**Gap**: Zero — no Comms-track board zone.
+
+**Effort**: **Mid** — if product keeps Board under Workspace, effort is config-only. If realigned to Comms, new routing + possible component split.
+
+---
+
+### C2 · Messages / Broadcast
+
+**Preview** (`cb-root.jsx:180-184`): Room timeline, mention inbox (@keeper), [STATE] block focus.
+
+**Production search**: `rg -i "broadcast|message.*room|mention.*inbox|state.*block" src/components/` returned zero hits. The `masc_broadcast` MCP tool exists but no dashboard surface consumes it.
+
+**Gap**: Zero.
+
+**Effort**: **High** — needs SSE or polling endpoint for room messages + 3 new components.
+
+---
+
+### C3 · Composer v2
+
+**Preview** (`cb-root.jsx:186-190`): Broadcast compose, mention autocomplete, structured [STATE] payload.
+
+**Production search**: Zero hits for Composer v2. The existing `Composer` component (lines 82–86 in cb-root.jsx) is a Phase 1 prompt composer, not the v2 broadcast/mention/state composer.
+
+**Gap**: Zero.
+
+**Effort**: **High** — new compose surface with mention autocomplete and structured payload validation.
+
+---
+
+### O2 · Audit Ledger
+
+**Preview** (`cb-root.jsx:200-204`): Streaming ledger, filtered by actor, event-kind summary. Append-only audit log.
+
+**Production search**: Zero hits for `audit ledger`, `streaming ledger`, or `event-kind summary`. No `audit.jsonl` consumer in dashboard.
+
+**Gap**: Zero.
+
+**Effort**: **High** — needs audit log data source + streaming component + filter UI.
+
+---
+
+### O4 · Cost & Latency
+
+**Preview** (`cb-root.jsx:212-216`): Per-agent token spend, provider × model heatmap, latency histogram.
+
+**Production**: `cost-dashboard.ts` exists and is mounted at `monitoring?section=cost`. It renders per-**model** metrics (`fetchRuntimeModelMetrics`), not per-**agent** spend. The preview explicitly asks for per-agent attribution.
+
+**Gap**: Misaligned — same tab, wrong granularity.
+
+**Effort**: **Mid** — either re-label the preview to per-model (Low) or add per-agent aggregation to backend + new table variant (Mid).
+
+---
+
+### O5 · Heuristic + Stress
+
+**Preview** (`cb-root.jsx:218-222`): Heuristic firing log, stress board (per-agent), firing rate by module. Mock data: `keeper_hooks_oas` + `agent_stress.jsonl`.
+
+**Production search**: Zero hits for `heuristic log`, `stress board`, `agent_stress`. No stress/heuristic surface in dashboard.
+
+**Gap**: Zero.
+
+**Effort**: **High** — needs stress data source + 3 new components.
+
+---
+
+### K2 · Decisions / Memory
+
+**Preview** (`cb-root.jsx:232-235`): Decisions stream (all keepers, filterable), memory entries (verified / learned / plan). Mock: `decisions.jsonl` + `memory.jsonl`.
+
+**Production**: `memory-subsystems.ts` exists (mounted at `monitoring?section=memory-subsystems`). It renders Hebbian synapse graph + episode records. **No decisions stream**. No `decisions.jsonl` consumer.
+
+**Gap**: Partial — memory half present; decisions half absent.
+
+**Effort**: **Mid** — decisions stream likely needs new endpoint or reuse of keeper telemetry.
+
+---
+
+### K3 · Institution Episodes
+
+**Preview** (`cb-root.jsx:237-240`): Turn cards (click to expand learnings), learnings extraction grouped. Mock: `institution_episodes.jsonl`.
+
+**Production search**: Zero hits for `institution_episodes`, `episode cards`, `learnings extraction`.
+
+**Gap**: Zero.
+
+**Effort**: **High** — needs episodes data source + 2 new components.
+
+---
+
+### I0 · IDE Backbone
+
+**Preview** (`cb-root.jsx:110-114`): Branch selector, keeper multi-select (chip filter), operator nudge log + compose.
+
+**Production search**: Zero hits for `branch selector`, `keeper multi-select`, `nudge log`. No IDE backbone surface exists.
+
+**Gap**: Zero.
+
+**Effort**: **High** — foundation surface for IDE track. Needs branch API + keeper filter + nudge store.
+
+---
+
+### E1 · File Tree Explorer
+
+**Preview** (`cb-root.jsx:118-123`): Tree + allowed_paths overlay, filter bar, recent/pinned/changed tabs, diff-annotated tree.
+
+**Production search**: Zero hits.
+
+**Gap**: Zero.
+
+**Effort**: **High** — 4 variants, needs file tree API + diff annotations.
+
+---
+
+### E2 · Editor Surfaces
+
+**Preview** (`cb-root.jsx:125-130`): Attribution gutter, split 2-pane, 3-way merge, inline review, blame gutter.
+
+**Production search**: Zero hits for editor surfaces. No code editor component in dashboard.
+
+**Gap**: Zero.
+
+**Effort**: **High** — 5 variants; requires Monaco/CodeMirror integration or custom editor.
+
+---
+
+### E3 · PR Inspector
+
+**Preview** (`cb-root.jsx:133-138`): PR header, files changed, comment thread, CI checks with SafeAuto.
+
+**Production search**: Zero hits for `pr inspector`, `files changed`, `comment thread`.
+
+**Gap**: Zero.
+
+**Effort**: **High** — needs GitHub API integration + 4 new components.
+
+---
+
+### E4 · Branch / Git Graph
+
+**Preview** (`cb-root.jsx:140-145`): Branch DAG (SVG), commit list with keeper attribution, worktree picker, stash list.
+
+**Production**: `git-graph-panel.ts` exists (mounted at `monitoring?section=git-graph`). It renders a read-only Git graph. **No keeper attribution**, no worktree picker, no stash list.
+
+**Gap**: Partial — graph exists but lacks preview variants B/C/D.
+
+**Effort**: **Mid** — enhance existing graph or add new variants.
+
+---
+
+### E5 · Terminal / Search
+
+**Preview** (`cb-root.jsx:147-151`): Cascade-aware terminal pane, project search (rg-style), find/replace in file.
+
+**Production search**: Zero hits for terminal or search surfaces in dashboard.
+
+**Gap**: Zero.
+
+**Effort**: **High** — terminal emulation + search backend integration.
+
+---
+
+### Phase F sizing (updated)
+
+Including the 6 zones from the main audit + these 15 zones:
+
+| Bucket | Zones | Effort |
+|--------|-------|--------|
+| Small fix (≤1 PR) | O3 (trend), O4 (relabel or per-agent table), C1 (routing decision) | Low–Mid |
+| Medium (2–3 PRs) | G2 (stale + wall), K1 (BDI + tool + token), K2 (decisions stream), E4 (git graph enrichment) | Mid |
+| Large / blocked | G1 (schema), G3 (new backend), O1 (new surface), O2 (audit backend), O5 (stress backend), K3 (episodes backend), K4 (product decision), C2/C3 (comms backend), I0 + E1–E5 (IDE track) | High |
+
+**Recommended sequence update**:
+
+1. **F1 (Low)** — O3 trend.
+2. **F2 (Mid)** — K1 BDI extraction.
+3. **F3 (Mid)** — G2 stale + wall.
+4. **F4 (Decision)** — K4 product call.
+5. **F5 (Decision)** — G1 metric source.
+6. **F6 (Large)** — O1 Cascade Inspector surface (Phase 3 territory).
+7. **F7 (Decision)** — O4: per-agent vs per-model scope call.
+8. **F8 (Mid)** — K2 decisions stream or defer.
+9. **F9–F15 (High)** — IDE track (I0 + E1–E5) is a separate epic, not Phase F.
+10. **F16–F19 (High)** — Comms track (C2, C3) + Accountability (G3) + Audit (O2) + Stress (O5) + Episodes (K3) need backend-first scoping.

--- a/dashboard/src/api/dashboard-cascade.ts
+++ b/dashboard/src/api/dashboard-cascade.ts
@@ -152,6 +152,7 @@ export interface CascadeHealthResponse {
   window_sec: number
   cooldown_threshold: number
   cooldown_sec: number
+  hard_quota_cooldown_sec: number
   providers: CascadeHealthProvider[]
   /** Window used by the per-provider perf aggregate.  `null` when the
    *  backend did not compute perf (no `base_path`, matches every

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -988,7 +988,7 @@ function decodeHeuristicEvent(raw: unknown): HeuristicEvent | null {
     site: asString(raw.site) ?? '',
     raw_value: asNumber(raw.raw_value) ?? 0,
     threshold: asNumber(raw.threshold) ?? 0,
-    triggered: asBoolean(raw.triggered),
+    triggered: asBoolean(raw.triggered) ?? false,
     provenance: prov
       ? { type: asString(prov.type) ?? '', detail: asString(prov.detail) ?? '' }
       : { type: '', detail: '' },
@@ -1015,6 +1015,75 @@ export async function fetchHeuristics(
   const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/heuristics?limit=${limit}`, { signal: opts?.signal })
   const decoded = decodeHeuristicsResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 heuristics payload')
+  return decoded
+}
+
+export interface StressKind {
+  type: string
+  count?: number
+  consecutive?: number
+  threshold?: number
+  counted_toward_crash?: boolean
+  recoverable?: boolean
+  error_kind?: string
+}
+
+export interface StressEvent {
+  agent_name: string
+  room_id: string
+  kind: StressKind
+  timestamp: number
+}
+
+export interface StressResponse {
+  limit: number
+  count: number
+  events: StressEvent[]
+}
+
+function decodeStressKind(raw: unknown): StressKind | null {
+  if (!isRecord(raw)) return null
+  return {
+    type: asString(raw.type) ?? '',
+    count: asInt(raw.count) ?? undefined,
+    consecutive: asInt(raw.consecutive) ?? undefined,
+    threshold: asInt(raw.threshold) ?? undefined,
+    counted_toward_crash: raw.counted_toward_crash === undefined ? undefined : (asBoolean(raw.counted_toward_crash) ?? false),
+    recoverable: raw.recoverable === undefined ? undefined : (asBoolean(raw.recoverable) ?? false),
+    error_kind: asNullableString(raw.error_kind) ?? undefined,
+  }
+}
+
+function decodeStressEvent(raw: unknown): StressEvent | null {
+  if (!isRecord(raw)) return null
+  const kind = decodeStressKind(raw.kind)
+  if (!kind) return null
+  return {
+    agent_name: asString(raw.agent_name) ?? '',
+    room_id: asString(raw.room_id) ?? '',
+    kind,
+    timestamp: asNumber(raw.timestamp) ?? 0,
+  }
+}
+
+function decodeStressResponse(raw: unknown): StressResponse | null {
+  if (!isRecord(raw)) return null
+  return {
+    limit: asInt(raw.limit) ?? 0,
+    count: asInt(raw.count) ?? 0,
+    events: asRecordArray(raw.events)
+      .map(decodeStressEvent)
+      .filter((e): e is StressEvent => e !== null),
+  }
+}
+
+export async function fetchStress(
+  limit = 100,
+  opts?: AbortableRequestOptions,
+): Promise<StressResponse> {
+  const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/stress?limit=${limit}`, { signal: opts?.signal })
+  const decoded = decodeStressResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 stress payload')
   return decoded
 }
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -820,6 +820,67 @@ export async function fetchRuntimeModelMetrics(
   return decoded
 }
 
+export interface KeeperCostMetric {
+  keeper_name: string
+  total_cost_usd: number
+  total_input_tokens: number
+  total_output_tokens: number
+  total_tokens: number
+  p50_latency_ms: number | null
+  p95_latency_ms: number | null
+  sample_count: number
+  model_breakdown: Array<{ model: string; cost_usd: number }>
+}
+
+export interface KeeperCostMetricsResponse {
+  window_minutes?: number
+  keepers: KeeperCostMetric[]
+  generated_at?: number | null
+}
+
+function decodeKeeperCostMetric(raw: unknown): KeeperCostMetric | null {
+  if (!isRecord(raw)) return null
+  const keeperName = asString(raw.keeper_name)
+  if (!keeperName) return null
+  return {
+    keeper_name: keeperName,
+    total_cost_usd: asNumber(raw.total_cost_usd) ?? 0,
+    total_input_tokens: asNumber(raw.total_input_tokens) ?? 0,
+    total_output_tokens: asNumber(raw.total_output_tokens) ?? 0,
+    total_tokens: asNumber(raw.total_tokens) ?? 0,
+    p50_latency_ms: asNumber(raw.p50_latency_ms) ?? null,
+    p95_latency_ms: asNumber(raw.p95_latency_ms) ?? null,
+    sample_count: asNumber(raw.sample_count) ?? 0,
+    model_breakdown: Array.isArray(raw.model_breakdown)
+      ? (raw.model_breakdown as unknown[])
+          .filter(isRecord)
+          .map(b => ({ model: asString(b.model) ?? '', cost_usd: asNumber(b.cost_usd) ?? 0 }))
+          .filter(b => b.model.length > 0)
+      : [],
+  }
+}
+
+function decodeKeeperCostMetricsResponse(raw: unknown): KeeperCostMetricsResponse | null {
+  if (!isRecord(raw)) return null
+  return {
+    window_minutes: asNumber(raw.window_minutes),
+    keepers: asRecordArray(raw.keepers)
+      .map(decodeKeeperCostMetric)
+      .filter((metric): metric is KeeperCostMetric => metric !== null),
+    generated_at: asNumber(raw.generated_at) ?? null,
+  }
+}
+
+export async function fetchKeeperCostMetrics(
+  windowMinutes = 1440,
+  opts?: AbortableRequestOptions,
+): Promise<KeeperCostMetricsResponse> {
+  const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/keeper-costs?window=${windowMinutes}`, { signal: opts?.signal })
+  const decoded = decodeKeeperCostMetricsResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 keeper cost metrics payload')
+  return decoded
+}
+
 export function fetchDashboardMissionBriefing(
   force = false,
   opts?: { signal?: AbortSignal },

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -633,11 +633,18 @@ export interface DashboardRuntimeModelMetric {
   buckets?: BucketMetric[] | null
 }
 
+export interface LatencyBucket {
+  lo_ms: number
+  hi_ms: number | null
+  count: number
+}
+
 export interface DashboardRuntimeModelMetricsResponse {
   window_minutes?: number
   bucket_minutes?: number
   total_entries?: number
   total_error_entries?: number
+  latency_buckets?: LatencyBucket[] | null
   models: DashboardRuntimeModelMetric[]
 }
 
@@ -797,6 +804,15 @@ function decodeRuntimeModelMetricsResponse(raw: unknown): DashboardRuntimeModelM
     bucket_minutes: asNumber(raw.bucket_minutes),
     total_entries: asNumber(raw.total_entries),
     total_error_entries: asNumber(raw.total_error_entries),
+    latency_buckets: Array.isArray(raw.latency_buckets)
+      ? (raw.latency_buckets as unknown[])
+          .filter(isRecord)
+          .map(b => ({
+            lo_ms: asNumber(b.lo) ?? 0,
+            hi_ms: b.hi == null ? null : (asNumber(b.hi) ?? null),
+            count: asNumber(b.n) ?? 0,
+          }))
+      : null,
     models: asRecordArray(raw.models)
       .map(decodeRuntimeModelMetric)
       .filter((metric): metric is DashboardRuntimeModelMetric => metric !== null),

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -963,6 +963,61 @@ export async function fetchKeeperDecisions(
   return decoded
 }
 
+export interface HeuristicEvent {
+  module: string
+  site: string
+  raw_value: number
+  threshold: number
+  triggered: boolean
+  provenance: { type: string; detail: string }
+  timestamp: number
+  detail?: string
+}
+
+export interface HeuristicsResponse {
+  limit: number
+  count: number
+  events: HeuristicEvent[]
+}
+
+function decodeHeuristicEvent(raw: unknown): HeuristicEvent | null {
+  if (!isRecord(raw)) return null
+  const prov = isRecord(raw.provenance) ? raw.provenance : null
+  return {
+    module: asString(raw.module) ?? '',
+    site: asString(raw.site) ?? '',
+    raw_value: asNumber(raw.raw_value) ?? 0,
+    threshold: asNumber(raw.threshold) ?? 0,
+    triggered: asBoolean(raw.triggered),
+    provenance: prov
+      ? { type: asString(prov.type) ?? '', detail: asString(prov.detail) ?? '' }
+      : { type: '', detail: '' },
+    timestamp: asNumber(raw.timestamp) ?? 0,
+    detail: asNullableString(raw.detail) ?? undefined,
+  }
+}
+
+function decodeHeuristicsResponse(raw: unknown): HeuristicsResponse | null {
+  if (!isRecord(raw)) return null
+  return {
+    limit: asInt(raw.limit) ?? 0,
+    count: asInt(raw.count) ?? 0,
+    events: asRecordArray(raw.events)
+      .map(decodeHeuristicEvent)
+      .filter((e): e is HeuristicEvent => e !== null),
+  }
+}
+
+export async function fetchHeuristics(
+  limit = 100,
+  opts?: AbortableRequestOptions,
+): Promise<HeuristicsResponse> {
+  const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/heuristics?limit=${limit}`, { signal: opts?.signal })
+  const decoded = decodeHeuristicsResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 heuristics payload')
+  return decoded
+}
+
 export function fetchDashboardMissionBriefing(
   force = false,
   opts?: { signal?: AbortSignal },

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -881,6 +881,70 @@ export async function fetchKeeperCostMetrics(
   return decoded
 }
 
+export interface KeeperDecision {
+  ts_unix: number | null
+  keeper_name: string
+  event_type: string
+  outcome: string | null
+  model_used: string | null
+  latency_ms: number | null
+  cost_usd: number | null
+  input_tokens: number | null
+  output_tokens: number | null
+  stop_reason: string | null
+  error_category: string | null
+  tool: string | null
+  duration_ms: number | null
+  match_count: number | null
+}
+
+export interface KeeperDecisionsResponse {
+  events: KeeperDecision[]
+  limit: number
+  generated_at: number | null
+}
+
+function decodeKeeperDecision(raw: unknown): KeeperDecision | null {
+  if (!isRecord(raw)) return null
+  return {
+    ts_unix: asNumber(raw.ts_unix) ?? null,
+    keeper_name: asString(raw.keeper_name) ?? '',
+    event_type: asString(raw.event_type) ?? 'turn',
+    outcome: asNullableString(raw.outcome),
+    model_used: asNullableString(raw.model_used),
+    latency_ms: asNumber(raw.latency_ms) ?? null,
+    cost_usd: asNumber(raw.cost_usd) ?? null,
+    input_tokens: asNumber(raw.input_tokens) ?? null,
+    output_tokens: asNumber(raw.output_tokens) ?? null,
+    stop_reason: asNullableString(raw.stop_reason),
+    error_category: asNullableString(raw.error_category),
+    tool: asNullableString(raw.tool),
+    duration_ms: asNumber(raw.duration_ms) ?? null,
+    match_count: asNumber(raw.match_count) ?? null,
+  }
+}
+
+function decodeKeeperDecisionsResponse(raw: unknown): KeeperDecisionsResponse | null {
+  if (!isRecord(raw)) return null
+  return {
+    events: asRecordArray(raw.events)
+      .map(decodeKeeperDecision)
+      .filter((d): d is KeeperDecision => d !== null),
+    limit: asInt(raw.limit) ?? 0,
+    generated_at: asNumber(raw.generated_at) ?? null,
+  }
+}
+
+export async function fetchKeeperDecisions(
+  limit = 200,
+  opts?: AbortableRequestOptions,
+): Promise<KeeperDecisionsResponse> {
+  const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/keeper-decisions?limit=${limit}`, { signal: opts?.signal })
+  const decoded = decodeKeeperDecisionsResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 keeper decisions payload')
+  return decoded
+}
+
 export function fetchDashboardMissionBriefing(
   force = false,
   opts?: { signal?: AbortSignal },

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1087,6 +1087,50 @@ export async function fetchStress(
   return decoded
 }
 
+export interface CoverageSite {
+  module: string
+  site: string
+  count: number
+  triggered_count: number
+}
+
+export interface HeuristicCoverage {
+  total_events: number
+  unique_decision_tuples: number
+  sites: CoverageSite[]
+}
+
+function decodeCoverageSite(raw: unknown): CoverageSite | null {
+  if (!isRecord(raw)) return null
+  return {
+    module: asString(raw.module) ?? '',
+    site: asString(raw.site) ?? '',
+    count: asInt(raw.count) ?? 0,
+    triggered_count: asInt(raw.triggered_count) ?? 0,
+  }
+}
+
+function decodeHeuristicCoverage(raw: unknown): HeuristicCoverage | null {
+  if (!isRecord(raw)) return null
+  return {
+    total_events: asInt(raw.total_events) ?? 0,
+    unique_decision_tuples: asInt(raw.unique_decision_tuples) ?? 0,
+    sites: asRecordArray(raw.sites)
+      .map(decodeCoverageSite)
+      .filter((s): s is CoverageSite => s !== null),
+  }
+}
+
+export async function fetchHeuristicCoverage(
+  limit = 100,
+  opts?: AbortableRequestOptions,
+): Promise<HeuristicCoverage> {
+  const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/heuristics/coverage?limit=${limit}`, { signal: opts?.signal })
+  const decoded = decodeHeuristicCoverage(raw)
+  if (!decoded) throw new Error('유효하지 않은 heuristic coverage payload')
+  return decoded
+}
+
 export function fetchDashboardMissionBriefing(
   force = false,
   opts?: { signal?: AbortSignal },

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2851,3 +2851,26 @@ export function fetchTlcResults(
     signal: opts?.signal,
   })
 }
+
+export interface AuditEntry {
+  timestamp: number
+  key: string
+  old_value: unknown
+  new_value: unknown
+  actor: string
+  case_id?: string
+}
+
+export interface AuditLedgerResponse {
+  entries: AuditEntry[]
+  count: number
+}
+
+export function fetchAuditLedger(
+  limit = 50,
+  opts?: { signal?: AbortSignal },
+): Promise<AuditLedgerResponse> {
+  return get<AuditLedgerResponse>(`/api/v1/governance/params/audit?limit=${limit}`, {
+    signal: opts?.signal,
+  })
+}

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -562,6 +562,7 @@ export interface BucketMetric {
 
 export interface DashboardRuntimeModelMetric {
   model_id: string
+  provider?: string | null
   entry_count?: number | null
   avg_tok_per_sec?: number | null
   p50_tok_per_sec?: number | null
@@ -699,6 +700,7 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
   if (!modelId) return null
   return {
     model_id: modelId,
+    provider: asNullableString(raw.provider),
     entry_count: asNumber(raw.entry_count) ?? null,
     avg_tok_per_sec: asNumber(raw.avg_tok_per_sec) ?? null,
     p50_tok_per_sec: asNumber(raw.p50_tok_per_sec) ?? null,

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -25,6 +25,8 @@ import {
   keeperPrimaryName,
 } from './common/keeper-identity'
 import { AgentAvatar } from './overview/agent-avatar'
+import { AgentPresence } from './common/agent-presence'
+import { AgentCapability } from './common/agent-capability'
 import { openAgentDetail } from './agent-detail-state'
 import { openKeeperDetail } from './keeper-detail'
 import { formatDuration, trimText } from './mission-utils'
@@ -687,9 +689,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             keeperRuntime?.recent_tool_names,
             keeperRuntime?.latest_tool_names,
           )
-          const visibleTools = recentTools.slice(0, 2)
-          const primaryTool = visibleTools[0] ?? null
-          const extraToolCount = Math.max(0, recentTools.length - (primaryTool ? 1 : 0))
           const toolCallCount =
             keeperRuntime?.latest_tool_call_count
             ?? null
@@ -753,7 +752,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 </div>
 
                 <div class="flex shrink-0 items-start">
-                  <span class="inline-flex items-center rounded-sm border px-2.5 py-1 text-2xs font-semibold ${runtimeBadgeClass(band.key)}" title=${band.description}>${band.label}</span>
+                  <${AgentPresence} status=${agent.status} size="sm" />
                 </div>
               </div>
 
@@ -821,25 +820,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 ` : null}
               </div>
 
-              ${(primaryTool || toolCallCount != null || toolAuditAt) ? html`
+              ${(recentTools.length > 0 || toolCallCount != null || toolAuditAt) ? html`
                 <div class="flex flex-wrap items-center gap-1.5 text-2xs text-[var(--color-fg-muted)]">
                   <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5">최근 도구</span>
-                  ${primaryTool ? html`
-                    <span class="inline-flex items-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 font-mono text-3xs text-[var(--color-fg-primary)]" translate="no">
-                      ${primaryTool}
-                    </span>
-                  ` : null}
-                  ${extraToolCount > 0 ? html`
-                    <span class="inline-flex items-center rounded-sm border border-dashed border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs">
-                      +${extraToolCount}
-                    </span>
-                  ` : null}
-                  ${!primaryTool && toolCallCount === 0 ? html`
-                    <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs">
-                      최근 도구 없음
-                    </span>
-                  ` : null}
-                  ${!primaryTool && toolCallCount != null && toolCallCount > 0 ? html`
+                  <${AgentCapability} tools=${recentTools} maxVisible=${3} />
+                  ${toolCallCount != null && toolCallCount > 0 ? html`
                     <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs">
                       ${toolCallCount}회 관찰됨
                     </span>

--- a/dashboard/src/components/common/agent-capability.a11y.test.ts
+++ b/dashboard/src/components/common/agent-capability.a11y.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { AgentCapability } from './agent-capability'
+
+describe('AgentCapability a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly with known tools', async () => {
+    render(
+      html`<${AgentCapability}
+        tools=${['file_read', 'shell', 'web_search']}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly with overflow', async () => {
+    render(
+      html`<${AgentCapability}
+        tools=${['file_read', 'file_write', 'shell', 'web_search', 'db_query']}
+        maxVisible=${2}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for empty tools', async () => {
+    render(html`<${AgentCapability} tools=${[]} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for null tools', async () => {
+    render(html`<${AgentCapability} tools=${null} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for unknown tools (fallback)', async () => {
+    render(
+      html`<${AgentCapability} tools=${['custom_tool', null, 'another_one']} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly with deduplication', async () => {
+    render(
+      html`<${AgentCapability}
+        tools=${['shell', 'shell', '  shell  ', 'web_search']}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/agent-capability.ts
+++ b/dashboard/src/components/common/agent-capability.ts
@@ -1,0 +1,115 @@
+// AgentCapability — AX molecule that renders an agent's tool set.
+//
+// Kimi design system sec05 reference: icon + tooltip badges for each tool
+// an agent can use. The compact badge row lets operators quickly scan
+// an agent's capability envelope without opening a detail panel.
+//
+// Icons are text/emoji placeholders (Kimi spec uses emoji). Production
+// code should swap the icon field for an SVG icon map when an icon
+// library is adopted.
+
+import { html } from 'htm/preact'
+
+export interface ToolConfig {
+  icon: string
+  label: string
+  description: string
+}
+
+const TOOL_CONFIG: Record<string, ToolConfig> = {
+  file_read: { icon: '\u{1F4C4}', label: '파일 읽기', description: '로컬 파일 시스템 읽기' },
+  file_write: { icon: '\u{270F}\u{FE0F}', label: '파일 쓰기', description: '로컬 파일 시스템 쓰기' },
+  shell: { icon: '\u{1F4BB}', label: '터미널', description: '셸 명령 실행' },
+  web_search: { icon: '\u{1F50D}', label: '웹 검색', description: '인터넷 검색' },
+  db_query: { icon: '\u{1F5C3}\u{FE0F}', label: 'DB 쿼리', description: '데이터베이스 조회' },
+  api_call: { icon: '\u{1F50C}', label: 'API 호출', description: '외부 API 호출' },
+}
+
+/** Pure: lookup a tool's display config. Falls back to a generic
+    representation for unknown tools so the UI never renders blank. */
+export function toolConfig(tool: string): ToolConfig {
+  return (
+    TOOL_CONFIG[tool] ?? {
+      icon: '\u{2699}\u{FE0F}',
+      label: tool,
+      description: `${tool} 도구`,
+    }
+  )
+}
+
+/** Pure: filter + deduplicate tool names, preserving order. */
+export function normalizeTools(
+  tools: Array<string | null | undefined> | null | undefined,
+): string[] {
+  if (!tools) return []
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const t of tools) {
+    const name = t?.trim()
+    if (!name || seen.has(name)) continue
+    seen.add(name)
+    out.push(name)
+  }
+  return out
+}
+
+interface AgentCapabilityProps {
+  tools: Array<string | null | undefined> | null | undefined
+  maxVisible?: number
+  testId?: string
+}
+
+const BASE_BADGE =
+  'inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--white-4)]'
+
+export function AgentCapability({
+  tools,
+  maxVisible = 4,
+  testId,
+}: AgentCapabilityProps) {
+  const normalized = normalizeTools(tools)
+  const visible = normalized.slice(0, maxVisible)
+  const extra = Math.max(0, normalized.length - maxVisible)
+
+  if (visible.length === 0 && extra === 0) {
+    return html`
+      <span
+        class="inline-flex items-center rounded-sm border border-dashed border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]"
+        data-agent-capability
+        data-testid=${testId}
+      >
+        도구 없음
+      </span>
+    `
+  }
+
+  return html`
+    <div class="flex flex-wrap items-center gap-1.5" data-agent-capability data-testid=${testId}>
+      ${visible.map(
+        tool => {
+          const cfg = toolConfig(tool)
+          return html`
+            <span
+              class=${BASE_BADGE}
+              title=${cfg.description}
+              data-tool=${tool}
+            >
+              <span aria-hidden="true">${cfg.icon}</span>
+              <span class="ml-1">${cfg.label}</span>
+            </span>
+          `
+        },
+      )}
+      ${extra > 0
+        ? html`
+            <span
+              class="inline-flex items-center rounded-sm border border-dashed border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]"
+              title="${normalized.slice(maxVisible).join(', ')}"
+            >
+              +${extra}
+            </span>
+          `
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/common/agent-failure.a11y.test.ts
+++ b/dashboard/src/components/common/agent-failure.a11y.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { AgentFailure } from './agent-failure'
+
+describe('AgentFailure a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly for retryable failure', async () => {
+    render(
+      html`<${AgentFailure}
+        type="retryable"
+        message="Connection timeout"
+        retryCount=${1}
+        maxRetries=${3}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for non_retryable failure', async () => {
+    render(
+      html`<${AgentFailure}
+        type="non_retryable"
+        message="Invalid API key"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for human_required failure', async () => {
+    render(
+      html`<${AgentFailure}
+        type="human_required"
+        message="Approval required for destructive action"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for degraded failure', async () => {
+    render(
+      html`<${AgentFailure}
+        type="degraded"
+        message="High latency detected"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly without retry info', async () => {
+    render(
+      html`<${AgentFailure}
+        type="retryable"
+        message="Will retry automatically"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly with empty message', async () => {
+    render(
+      html`<${AgentFailure} type="degraded" message="" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/agent-failure.ts
+++ b/dashboard/src/components/common/agent-failure.ts
@@ -1,0 +1,113 @@
+// AgentFailure — AX atom that renders an error state with type-aware styling.
+//
+// Kimi design system sec05 reference: icons + color-coded borders for retryable,
+// non-retryable, human-required and degraded failure types. The compact alert
+// card lets operators instantly grasp severity and required action.
+//
+// Icons are text/emoji placeholders (Kimi spec uses emoji). Production code
+// should swap the icon field for an SVG icon map when an icon library is
+// adopted.
+
+import { html } from 'htm/preact'
+
+export type FailureType = 'retryable' | 'non_retryable' | 'human_required' | 'degraded'
+
+interface FailureConfig {
+  icon: string
+  colorVar: string
+  label: string
+  action: string
+}
+
+const FAILURE_CONFIG: Record<FailureType, FailureConfig> = {
+  retryable: {
+    icon: '\u{21BB}',
+    colorVar: 'var(--warn-10)',
+    label: '재시도 가능',
+    action: '자동 재시도 중...',
+  },
+  non_retryable: {
+    icon: '\u{2715}',
+    colorVar: 'var(--bad-light)',
+    label: '재시도 불가',
+    action: '수동 개입 필요',
+  },
+  human_required: {
+    icon: '\u{1F464}',
+    colorVar: 'var(--color-accent)',
+    label: '승인 필요',
+    action: 'Human-in-the-loop 대기 중',
+  },
+  degraded: {
+    icon: '\u{26A0}',
+    colorVar: 'var(--warn-10)',
+    label: '성능 저하',
+    action: '대체 모드 실행 중',
+  },
+}
+
+/** Pure: lookup a failure type's display config. */
+export function failureConfig(type: FailureType): FailureConfig {
+  return FAILURE_CONFIG[type]
+}
+
+/** Pure: map a diagnostic error + recoverable flag to a failure type.
+    Defaults to degraded when no error is present, and non_retryable
+    when recoverable is false or undefined. */
+export function failureTypeFromDiagnostic(
+  lastError: string | null | undefined,
+  recoverable: boolean | undefined,
+): FailureType {
+  if (!lastError) return 'degraded'
+  if (recoverable === true) return 'retryable'
+  return 'non_retryable'
+}
+
+interface AgentFailureProps {
+  type: FailureType
+  message: string
+  retryCount?: number
+  maxRetries?: number
+  testId?: string
+}
+
+export function AgentFailure({
+  type,
+  message,
+  retryCount,
+  maxRetries,
+  testId,
+}: AgentFailureProps) {
+  const cfg = FAILURE_CONFIG[type]
+
+  return html`
+    <div
+      class="flex items-start gap-2 rounded border p-2"
+      style="border-color: ${cfg.colorVar}; background-color: color-mix(in srgb, ${cfg.colorVar} 8%, transparent);"
+      role="alert"
+      data-agent-failure
+      data-failure-type=${type}
+      data-testid=${testId}
+    >
+      <span class="text-lg leading-none" aria-hidden="true">${cfg.icon}</span>
+      <div class="min-w-0 flex-1">
+        <div class="text-sm font-medium" style="color: ${cfg.colorVar};">
+          ${cfg.label}
+        </div>
+        <div class="break-words text-xs text-[var(--color-fg-muted)]">
+          ${message}
+        </div>
+        ${retryCount !== undefined && maxRetries !== undefined && maxRetries > 0
+          ? html`
+              <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
+                재시도: ${retryCount}/${maxRetries}
+              </div>
+            `
+          : null}
+      </div>
+      <span class="shrink-0 text-xs text-[var(--color-fg-muted)]">
+        ${cfg.action}
+      </span>
+    </div>
+  `
+}

--- a/dashboard/src/components/common/agent-presence.a11y.test.ts
+++ b/dashboard/src/components/common/agent-presence.a11y.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { AgentPresence } from './agent-presence'
+
+describe('AgentPresence a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly for online status', async () => {
+    render(html`<${AgentPresence} status="active" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for working status', async () => {
+    render(html`<${AgentPresence} status="busy" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for idle status', async () => {
+    render(html`<${AgentPresence} status="idle" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for offline status', async () => {
+    render(html`<${AgentPresence} status="offline" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly with detail text', async () => {
+    render(html`<${AgentPresence} status="busy" detail="compacting" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for unknown status (fallback)', async () => {
+    render(html`<${AgentPresence} status="unknown" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly for null status', async () => {
+    render(html`<${AgentPresence} status=${null} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('both sizes render accessibly', async () => {
+    render(
+      html`<div>
+        <${AgentPresence} status="active" size="sm" />
+        <${AgentPresence} status="active" size="md" />
+      </div>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/agent-presence.ts
+++ b/dashboard/src/components/common/agent-presence.ts
@@ -1,0 +1,113 @@
+// AgentPresence — AX atom that renders an agent's presence state.
+//
+// Kimi design system sec05 reference: Slack status dot + Discord activity
+// indicator. The dot + pulse animation communicates "this agent is a
+// digital colleague" rather than an abstract process.
+//
+// Maps the internal Agent.status domain (6 values) to 4 visual presence
+// states (online / working / idle / offline). The mapping is intentionally
+// lossy — visual density in a roster card cannot carry 6 states without
+// crowding.
+
+import { html } from 'htm/preact'
+
+type PresenceVisualState = 'online' | 'working' | 'idle' | 'offline'
+
+interface PresenceConfig {
+  colorClass: string
+  pulse: boolean
+  label: string
+}
+
+const PRESENCE_CONFIG: Record<PresenceVisualState, PresenceConfig> = {
+  online: {
+    colorClass: 'bg-[var(--ok-10)]',
+    pulse: false,
+    label: '온라인',
+  },
+  working: {
+    colorClass: 'bg-[var(--color-accent)]',
+    pulse: true,
+    label: '작업 중',
+  },
+  idle: {
+    colorClass: 'bg-[var(--warn-10)]',
+    pulse: false,
+    label: '대기',
+  },
+  offline: {
+    colorClass: 'bg-[var(--white-10)]',
+    pulse: false,
+    label: '오프라인',
+  },
+}
+
+/** Pure: map the backend Agent.status to a visual presence state.
+    The mapping collapses 6 backend states into 4 visual buckets so
+    the roster grid stays scannable. */
+export function agentStatusToPresence(
+  status: string | null | undefined,
+): PresenceVisualState {
+  switch (status) {
+    case 'active':
+      return 'online'
+    case 'busy':
+    case 'listening':
+      return 'working'
+    case 'idle':
+      return 'idle'
+    case 'inactive':
+    case 'offline':
+    default:
+      return 'offline'
+  }
+}
+
+/** Pure: config lookup exposed so callers can pre-build strings. */
+export function presenceConfig(state: PresenceVisualState): PresenceConfig {
+  return PRESENCE_CONFIG[state]
+}
+
+interface AgentPresenceProps {
+  status: string | null | undefined
+  detail?: string | null
+  size?: 'sm' | 'md'
+  testId?: string
+}
+
+const SIZE_CLASSES = {
+  sm: 'h-2 w-2',
+  md: 'h-2.5 w-2.5',
+} as const
+
+export function AgentPresence({
+  status,
+  detail,
+  size = 'sm',
+  testId,
+}: AgentPresenceProps) {
+  const state = agentStatusToPresence(status)
+  const config = PRESENCE_CONFIG[state]
+  const dotSize = SIZE_CLASSES[size]
+  const pulseRing = config.pulse
+    ? html`<span
+        class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60 ${config.colorClass}"
+        aria-hidden="true"
+      ></span>`
+    : null
+
+  return html`
+    <div class="inline-flex items-center gap-2" data-agent-presence data-presence-state=${state} data-testid=${testId}>
+      <span class="relative inline-flex ${dotSize}">
+        ${pulseRing}
+        <span
+          class="relative inline-flex rounded-full ${dotSize} ${config.colorClass}"
+          role="img"
+          aria-label=${config.label}
+        ></span>
+      </span>
+      <span class="text-xs text-[var(--color-fg-secondary)]">${config.label}</span>
+      ${detail ? html`<span class="max-w-[120px] truncate text-xs text-[var(--color-fg-muted)]">${detail}</span>` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/common/inline-edit.a11y.test.ts
+++ b/dashboard/src/components/common/inline-edit.a11y.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { InlineEdit } from './inline-edit'
+
+describe('InlineEdit a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly in display mode', async () => {
+    render(
+      html`<${InlineEdit} value="hello" onSave=${vi.fn()} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly with empty value', async () => {
+    render(
+      html`<${InlineEdit} value="" onSave=${vi.fn()} placeholder="type here" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly with placeholder', async () => {
+    render(
+      html`<${InlineEdit} value="" onSave=${vi.fn()} placeholder="click to edit" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('switches to input and remains accessible', async () => {
+    render(
+      html`<${InlineEdit} value="editable" onSave=${vi.fn()} testId="ie" />`,
+      container,
+    )
+    const span = container.querySelector('[data-testid="ie"]') as HTMLElement
+    span.click()
+    await new Promise(r => requestAnimationFrame(r))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('calls onSave with new value on Enter', async () => {
+    const onSave = vi.fn()
+    render(
+      html`<${InlineEdit} value="old" onSave=${onSave} testId="ie" />`,
+      container,
+    )
+    const span = container.querySelector('[data-testid="ie"]') as HTMLElement
+    span.click()
+    await new Promise(r => requestAnimationFrame(r))
+    const input = container.querySelector('input') as HTMLInputElement
+    input.value = 'new'
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }))
+    await new Promise(r => setTimeout(r, 0))
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(onSave).toHaveBeenCalledWith('new')
+  })
+
+  it('calls onCancel on Escape', async () => {
+    const onCancel = vi.fn()
+    render(
+      html`<${InlineEdit} value="val" onSave=${vi.fn()} onCancel=${onCancel} testId="ie" />`,
+      container,
+    )
+    const span = container.querySelector('[data-testid="ie"]') as HTMLElement
+    span.click()
+    await new Promise(r => requestAnimationFrame(r))
+    const input = container.querySelector('input') as HTMLInputElement
+    input.value = 'changed'
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }))
+    await new Promise(r => setTimeout(r, 0))
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/components/common/inline-edit.ts
+++ b/dashboard/src/components/common/inline-edit.ts
@@ -1,0 +1,93 @@
+// InlineEdit — click-to-edit atom with save/cancel semantics.
+//
+// Kimi design system sec02 2.3.1 reference: Atlassian ADS inline-edit pattern.
+// Translated to Preact + htm/preact + Tailwind v4 dashboard conventions.
+
+import { html } from 'htm/preact'
+import { useRef, useState } from 'preact/hooks'
+
+interface InlineEditProps {
+  value: string
+  onSave: (v: string) => void
+  onCancel?: () => void
+  placeholder?: string
+  testId?: string
+}
+
+export function InlineEdit({
+  value,
+  onSave,
+  onCancel,
+  placeholder = '클릭하여 편집',
+  testId,
+}: InlineEditProps) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const startEdit = () => {
+    setEditing(true)
+    setDraft(value)
+    // focus after render
+    requestAnimationFrame(() => {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    })
+  }
+
+  const commit = () => {
+    onSave(draft)
+    setEditing(false)
+  }
+
+  const revert = () => {
+    onCancel?.()
+    setEditing(false)
+    setDraft(value)
+  }
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      commit()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      revert()
+    }
+  }
+
+  if (!editing) {
+    return html`
+      <span
+        class="inline-block cursor-text rounded px-1 py-0.5 text-sm text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--white-6)]"
+        onClick=${startEdit}
+        data-testid=${testId}
+        role="button"
+        tabindex="0"
+        aria-label="편집: ${value || placeholder}"
+        onKeyDown=${(e: KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            startEdit()
+          }
+        }}
+      >
+        ${value || html`<span class="italic text-[var(--color-fg-muted)]">${placeholder}</span>`}
+      </span>
+    `
+  }
+
+  return html`
+    <input
+      ref=${inputRef}
+      type="text"
+      value=${draft}
+      onInput=${(e: InputEvent) => setDraft((e.currentTarget as HTMLInputElement).value)}
+      onBlur=${commit}
+      onKeyDown=${onKeyDown}
+      class="inline-block w-full rounded border border-[var(--accent-30)] bg-[var(--color-bg-page)] px-2 py-0.5 text-sm text-[var(--color-fg-primary)] outline-none focus:ring-1 focus:ring-[var(--accent-30)]"
+      data-testid=${testId ? `${testId}-input` : undefined}
+      aria-label="편집 중"
+    />
+  `
+}

--- a/dashboard/src/components/common/persistence-status.a11y.test.ts
+++ b/dashboard/src/components/common/persistence-status.a11y.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { PersistenceStatus } from './persistence-status'
+
+describe('PersistenceStatus a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly in saved state', async () => {
+    render(html`<${PersistenceStatus} status="saved" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly in syncing state', async () => {
+    render(html`<${PersistenceStatus} status="syncing" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly in conflict state', async () => {
+    render(html`<${PersistenceStatus} status="conflict" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly in offline state', async () => {
+    render(html`<${PersistenceStatus} status="offline" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly with lastSaved timestamp', async () => {
+    render(
+      html`<${PersistenceStatus} status="saved" lastSaved="2026-04-30T08:00:00Z" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('exposes role="status" for screen readers', () => {
+    render(html`<${PersistenceStatus} status="syncing" testId="ps" />`, container)
+    const el = container.querySelector('[data-testid="ps"]') as HTMLElement
+    expect(el.getAttribute('role')).toBe('status')
+    expect(el.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('contains the correct label text for each state', () => {
+    const states = [
+      { status: 'saved', label: '저장됨' },
+      { status: 'syncing', label: '동기화 중' },
+      { status: 'conflict', label: '충돌' },
+      { status: 'offline', label: '오프라인' },
+    ] as const
+
+    for (const { status, label } of states) {
+      render(null, container)
+      render(html`<${PersistenceStatus} status=${status} />`, container)
+      expect(container.textContent).toContain(label)
+    }
+  })
+})

--- a/dashboard/src/components/common/persistence-status.ts
+++ b/dashboard/src/components/common/persistence-status.ts
@@ -1,0 +1,60 @@
+// PersistenceStatus — persistence-state indicator atom (sec03 3.2.1).
+//
+// Maps CRDT-style sync states to a dot + icon + label row.
+// Composes StatusDot so color semantics stay consistent with the rest
+// of the dashboard.
+
+import { html } from 'htm/preact'
+import { StatusDot } from './status-dot'
+import { relativeTime } from '../../lib/format-time'
+
+export type PersistenceState = 'saved' | 'syncing' | 'conflict' | 'offline'
+
+interface StateConfig {
+  toneClass: string
+  icon: string
+  label: string
+}
+
+const CONFIG: Record<PersistenceState, StateConfig> = {
+  saved:   { toneClass: 'bg-[var(--ok-20)]', icon: '✓', label: '저장됨' },
+  syncing: { toneClass: 'bg-[var(--warn-20)]', icon: '↻', label: '동기화 중' },
+  conflict:{ toneClass: 'bg-[var(--bad-20)]', icon: '!', label: '충돌' },
+  offline: { toneClass: 'bg-[var(--accent-30)]', icon: '○', label: '오프라인' },
+}
+
+interface PersistenceStatusProps {
+  status: PersistenceState
+  lastSaved?: string | null
+  testId?: string
+}
+
+export function PersistenceStatus({
+  status,
+  lastSaved,
+  testId,
+}: PersistenceStatusProps) {
+  const cfg = CONFIG[status]
+  const timeText = lastSaved ? relativeTime(lastSaved) : null
+
+  return html`
+    <div
+      class="inline-flex items-center gap-1.5 text-xs"
+      data-testid=${testId}
+      role="status"
+      aria-live="polite"
+      aria-label="${cfg.label}${timeText ? ' · ' + timeText : ''}"
+    >
+      <${StatusDot}
+        size="sm"
+        class=${cfg.toneClass}
+        ariaLabel=${cfg.label}
+      />
+      <span class="text-[var(--color-fg-muted)]">${cfg.icon}</span>
+      <span class="text-[var(--color-fg-muted)]">${cfg.label}</span>
+      ${timeText
+        ? html`<span class="text-[var(--color-fg-muted)] ml-1">${timeText}</span>`
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/common/switch.a11y.test.ts
+++ b/dashboard/src/components/common/switch.a11y.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { Switch } from './switch'
+
+describe('Switch a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly when checked', async () => {
+    render(
+      html`<${Switch} checked=${true} onChange=${vi.fn()} label="Enable feature" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly when unchecked', async () => {
+    render(
+      html`<${Switch} checked=${false} onChange=${vi.fn()} label="Enable feature" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly with aria-label only', async () => {
+    render(html`<${Switch} checked=${false} onChange=${vi.fn()} label="Toggle" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly when disabled', async () => {
+    render(
+      html`<${Switch} checked=${true} onChange=${vi.fn()} label="Locked" disabled=${true} />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('toggles on click', async () => {
+    const onChange = vi.fn()
+    render(
+      html`<${Switch} checked=${false} onChange=${onChange} testId="sw" />`,
+      container,
+    )
+    const el = container.querySelector('[data-testid="sw"]') as HTMLElement
+    el.click()
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+
+  it('toggles on Space key', async () => {
+    const onChange = vi.fn()
+    render(
+      html`<${Switch} checked=${false} onChange=${onChange} testId="sw" />`,
+      container,
+    )
+    const el = container.querySelector('[data-testid="sw"]') as HTMLElement
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+
+  it('does not toggle when disabled', async () => {
+    const onChange = vi.fn()
+    render(
+      html`<${Switch} checked=${false} onChange=${onChange} disabled=${true} testId="sw" />`,
+      container,
+    )
+    const el = container.querySelector('[data-testid="sw"]') as HTMLElement
+    el.click()
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/components/common/switch.ts
+++ b/dashboard/src/components/common/switch.ts
@@ -1,0 +1,66 @@
+// Switch — accessible toggle switch atom.
+//
+// Kimi design system sec06 reference: ARIA switch pattern with Space activation.
+// Uses role="switch" and aria-checked for screen-reader contract.
+
+import { html } from 'htm/preact'
+
+interface SwitchProps {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  label?: string
+  disabled?: boolean
+  testId?: string
+}
+
+export function Switch({
+  checked,
+  onChange,
+  label,
+  disabled = false,
+  testId,
+}: SwitchProps) {
+  const toggle = () => {
+    if (disabled) return
+    onChange(!checked)
+  }
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (disabled) return
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault()
+      toggle()
+    }
+  }
+
+  const trackClass = checked
+    ? 'bg-[var(--ok-20)] border-[var(--ok-20)]'
+    : 'bg-[var(--white-4)] border-[var(--color-border-default)]'
+
+  const thumbClass = checked
+    ? 'translate-x-[14px] bg-[var(--color-fg-primary)]'
+    : 'translate-x-[2px] bg-[var(--color-fg-muted)]'
+
+  return html`
+    <div class="inline-flex items-center gap-2">
+      <div
+        role="switch"
+        aria-checked=${checked}
+        aria-label=${label}
+        aria-disabled=${disabled}
+        tabindex=${disabled ? -1 : 0}
+        data-testid=${testId}
+        class=${`relative h-5 w-9 cursor-pointer rounded-full border transition-colors duration-200 ${trackClass} ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+        onClick=${toggle}
+        onKeyDown=${onKeyDown}
+      >
+        <span
+          class=${`absolute top-[2px] h-3.5 w-3.5 rounded-full transition-transform duration-200 ${thumbClass}`}
+        />
+      </div>
+      ${label
+        ? html`<span class="text-xs text-[var(--color-fg-muted)] select-none">${label}</span>`
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/common/tooltip.a11y.test.ts
+++ b/dashboard/src/components/common/tooltip.a11y.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { Tooltip } from './tooltip'
+
+describe('Tooltip a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly when hidden', async () => {
+    render(
+      html`<${Tooltip} content="help text"><button>Hover me</button><//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders accessibly when visible', async () => {
+    render(
+      html`<${Tooltip} content="help text" testId="tt"><button>Hover me</button><//>`,
+      container,
+    )
+    const btn = container.querySelector('button') as HTMLButtonElement
+    btn.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+    await new Promise(r => setTimeout(r, 200))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('shows tooltip on mouseenter', async () => {
+    render(
+      html`<${Tooltip} content="help text" testId="tt"><button>Hover me</button><//>`,
+      container,
+    )
+    const btn = container.querySelector('button') as HTMLButtonElement
+    btn.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+    await new Promise(r => setTimeout(r, 200))
+    expect(container.querySelector('[data-testid="tt"]')).not.toBeNull()
+  })
+
+  it('hides tooltip on mouseleave', async () => {
+    render(
+      html`<${Tooltip} content="help text" testId="tt"><button>Hover me</button><//>`,
+      container,
+    )
+    const btn = container.querySelector('button') as HTMLButtonElement
+    btn.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+    await new Promise(r => setTimeout(r, 200))
+    btn.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }))
+    await new Promise(r => setTimeout(r, 100))
+    expect(container.querySelector('[data-testid="tt"]')).toBeNull()
+  })
+
+  it('shows tooltip on focus', async () => {
+    render(
+      html`<${Tooltip} content="help text" testId="tt"><button>Focus me</button><//>`,
+      container,
+    )
+    const btn = container.querySelector('button') as HTMLButtonElement
+    btn.dispatchEvent(new FocusEvent('focus', { bubbles: true }))
+    await new Promise(r => setTimeout(r, 200))
+    expect(container.querySelector('[data-testid="tt"]')).not.toBeNull()
+  })
+
+  it('hides tooltip on Escape', async () => {
+    render(
+      html`<${Tooltip} content="help text" testId="tt"><button>Focus me</button><//>`,
+      container,
+    )
+    const btn = container.querySelector('button') as HTMLButtonElement
+    btn.dispatchEvent(new FocusEvent('focus', { bubbles: true }))
+    await new Promise(r => setTimeout(r, 200))
+    btn.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    )
+    await new Promise(r => setTimeout(r, 100))
+    expect(container.querySelector('[data-testid="tt"]')).toBeNull()
+  })
+
+  it('preserves existing trigger handlers', async () => {
+    const onEnter = vi.fn()
+    const onLeave = vi.fn()
+    render(
+      html`<${Tooltip} content="help text" testId="tt">
+        <button onMouseEnter=${onEnter} onMouseLeave=${onLeave}>Hover me</button>
+      <//>`,
+      container,
+    )
+    const btn = container.querySelector('button') as HTMLButtonElement
+    btn.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+    await new Promise(r => setTimeout(r, 200))
+    expect(onEnter).toHaveBeenCalled()
+    btn.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }))
+    await new Promise(r => setTimeout(r, 100))
+    expect(onLeave).toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/components/common/tooltip.ts
+++ b/dashboard/src/components/common/tooltip.ts
@@ -1,0 +1,83 @@
+// Tooltip — ARIA tooltip atom (sec06 6.1.1).
+// Uses role="tooltip" + aria-describedby linkage.
+// Trigger events are composed so existing handlers are preserved.
+
+import { cloneElement } from 'preact'
+import { html } from 'htm/preact'
+import { useCallback, useEffect, useId, useRef, useState } from 'preact/hooks'
+import type { VNode } from 'preact'
+
+interface TooltipProps {
+  children: VNode
+  content: string
+  testId?: string
+}
+
+function compose<T extends Event>(a?: (e: T) => void, b?: (e: T) => void) {
+  return (e: T) => {
+    a?.(e)
+    b?.(e)
+  }
+}
+
+export function Tooltip({ children, content, testId }: TooltipProps) {
+  const id = useId()
+  const [visible, setVisible] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const show = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setVisible(true), 150)
+  }, [])
+
+  const hide = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setVisible(false), 50)
+  }, [])
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') hide()
+    },
+    [hide],
+  )
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  const childProps = (children.props as Record<string, unknown>) || {}
+  const trigger = cloneElement(children, {
+    'aria-describedby': visible ? id : undefined,
+    onMouseEnter: compose(
+      childProps.onMouseEnter as (e: MouseEvent) => void,
+      show,
+    ),
+    onMouseLeave: compose(
+      childProps.onMouseLeave as (e: MouseEvent) => void,
+      hide,
+    ),
+    onFocus: compose(childProps.onFocus as (e: FocusEvent) => void, show),
+    onBlur: compose(childProps.onBlur as (e: FocusEvent) => void, hide),
+    onKeyDown: compose(
+      childProps.onKeyDown as (e: KeyboardEvent) => void,
+      onKeyDown,
+    ),
+  })
+
+  return html`
+    <span class="relative inline-flex">
+      ${trigger}
+      ${visible
+        ? html`<span
+            id=${id}
+            role="tooltip"
+            data-testid=${testId}
+            class="absolute bottom-full left-1/2 z-50 mb-1 -translate-x-1/2 whitespace-nowrap rounded border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-xs text-[var(--color-fg-primary)] shadow-lg"
+          >${content}</span>`
+        : null}
+    </span>
+  `
+}

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -21,6 +21,7 @@ import {
   fetchStress,
   fetchCascadeHealth,
   fetchCascadeConfig,
+  fetchAuditLedger,
   type DashboardRuntimeModelMetric,
   type KeeperCostMetric,
   type LatencyBucket,
@@ -30,6 +31,8 @@ import {
   type StressEvent,
   type CascadeHealthResponse,
   type CascadeConfigResponse,
+  type AuditEntry,
+  type AuditLedgerResponse,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
 
@@ -77,6 +80,12 @@ type CascadeConfigLoadState =
   | { status: 'loaded'; data: CascadeConfigResponse }
   | { status: 'error'; message: string }
 
+type AuditLedgerLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: AuditLedgerResponse }
+  | { status: 'error'; message: string }
+
 const viewMode = signal<ViewMode>('model')
 const modelState = signal<ModelLoadState>({ status: 'idle' })
 const keeperState = signal<KeeperLoadState>({ status: 'idle' })
@@ -85,6 +94,7 @@ const stressState = signal<StressLoadState>({ status: 'idle' })
 const coverageState = signal<CoverageLoadState>({ status: 'idle' })
 const cascadeHealthState = signal<CascadeHealthLoadState>({ status: 'idle' })
 const cascadeConfigState = signal<CascadeConfigLoadState>({ status: 'idle' })
+const auditLedgerState = signal<AuditLedgerLoadState>({ status: 'idle' })
 
 const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
   { key: 30, label: '30분' },
@@ -181,6 +191,17 @@ async function loadCascadeConfig() {
   }
 }
 
+async function loadAuditLedger(limit = 50) {
+  auditLedgerState.value = { status: 'loading' }
+  try {
+    const resp = await fetchAuditLedger(limit)
+    auditLedgerState.value = { status: 'loaded', data: resp }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'audit ledger 불러오기 실패'
+    auditLedgerState.value = { status: 'error', message }
+  }
+}
+
 function loadActiveView(window: number) {
   if (viewMode.value === 'model') {
     void loadModelMetrics(window)
@@ -192,6 +213,7 @@ function loadActiveView(window: number) {
   void loadHeuristicCoverage()
   void loadCascadeHealth()
   void loadCascadeConfig()
+  void loadAuditLedger()
 }
 
 const modelTotals = computed(() => {
@@ -793,6 +815,55 @@ function CascadeBoard({ health, config }: { health: CascadeHealthResponse; confi
   `
 }
 
+function AuditLedgerBoard({ entries, count }: { entries: AuditEntry[]; count: number }) {
+  const fmtTime = (ts: number): string => {
+    const d = new Date(ts * 1000)
+    return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+  }
+
+  const fmtValue = (v: unknown): string => {
+    if (v === null) return 'null'
+    if (v === undefined) return 'undefined'
+    if (typeof v === 'string') return v
+    return JSON.stringify(v)
+  }
+
+  return html`
+    <section class="flex flex-col gap-4" aria-label="Audit ledger">
+      <div class="flex items-center justify-between rounded border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
+        <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">audit ledger · ${count} entries</span>
+      </div>
+
+      <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
+        <table class="w-full" aria-label="Parameter audit entries">
+          <thead>
+            <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-1 text-text-muted">
+              <th scope="col" class="px-2 py-1.5 text-left">time</th>
+              <th scope="col" class="px-2 py-1.5 text-left">actor</th>
+              <th scope="col" class="px-2 py-1.5 text-left">key</th>
+              <th scope="col" class="px-2 py-1.5 text-left">old</th>
+              <th scope="col" class="px-2 py-1.5 text-left">new</th>
+              <th scope="col" class="px-2 py-1.5 text-left">case</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${entries.map((e, i) => html`
+              <tr key=${i} class="border-b border-[var(--color-border-default)]/50 text-2xs">
+                <td class="px-2 py-1.5 text-left font-mono text-text-muted">${fmtTime(e.timestamp)}</td>
+                <td class="px-2 py-1.5 text-left font-mono text-xs text-[var(--color-accent-fg)]">${e.actor}</td>
+                <td class="px-2 py-1.5 text-left font-mono text-text-strong">${e.key}</td>
+                <td class="px-2 py-1.5 text-left font-mono text-text-muted max-w-[12ch] truncate" title=${fmtValue(e.old_value)}>${fmtValue(e.old_value)}</td>
+                <td class="px-2 py-1.5 text-left font-mono text-text-muted max-w-[12ch] truncate" title=${fmtValue(e.new_value)}>${fmtValue(e.new_value)}</td>
+                <td class="px-2 py-1.5 text-left font-mono text-text-muted">${e.case_id ?? '—'}</td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  `
+}
+
 export function CostDashboard() {
   const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
 
@@ -973,6 +1044,18 @@ export function CostDashboard() {
                 onRetry=${() => void loadCascadeConfig()}
               />`
             : html`<${LoadingState} />`}
+
+      ${auditLedgerState.value.status === 'loaded'
+        ? html`<${AuditLedgerBoard}
+            entries=${auditLedgerState.value.data.entries}
+            count=${auditLedgerState.value.data.count}
+          />`
+        : auditLedgerState.value.status === 'error'
+          ? html`<${ErrorState}
+              message=${auditLedgerState.value.message}
+              onRetry=${() => void loadAuditLedger()}
+            />`
+          : html`<${LoadingState} />`}
     </section>
   `
 }

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -17,11 +17,14 @@ import {
   fetchRuntimeModelMetrics,
   fetchKeeperCostMetrics,
   fetchHeuristics,
+  fetchHeuristicCoverage,
   fetchStress,
   type DashboardRuntimeModelMetric,
   type KeeperCostMetric,
   type LatencyBucket,
   type HeuristicEvent,
+  type HeuristicCoverage,
+  type CoverageSite,
   type StressEvent,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
@@ -52,11 +55,18 @@ type StressLoadState =
   | { status: 'loaded'; data: StressEvent[]; limit: number }
   | { status: 'error'; message: string }
 
+type CoverageLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: HeuristicCoverage }
+  | { status: 'error'; message: string }
+
 const viewMode = signal<ViewMode>('model')
 const modelState = signal<ModelLoadState>({ status: 'idle' })
 const keeperState = signal<KeeperLoadState>({ status: 'idle' })
 const heuristicState = signal<HeuristicLoadState>({ status: 'idle' })
 const stressState = signal<StressLoadState>({ status: 'idle' })
+const coverageState = signal<CoverageLoadState>({ status: 'idle' })
 
 const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
   { key: 30, label: '30분' },
@@ -120,6 +130,17 @@ async function loadStress(limit = 100) {
   }
 }
 
+async function loadHeuristicCoverage(limit = 100) {
+  coverageState.value = { status: 'loading' }
+  try {
+    const resp = await fetchHeuristicCoverage(limit)
+    coverageState.value = { status: 'loaded', data: resp }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'heuristic coverage 불러오기 실패'
+    coverageState.value = { status: 'error', message }
+  }
+}
+
 function loadActiveView(window: number) {
   if (viewMode.value === 'model') {
     void loadModelMetrics(window)
@@ -128,6 +149,7 @@ function loadActiveView(window: number) {
   }
   void loadHeuristics()
   void loadStress()
+  void loadHeuristicCoverage()
 }
 
 const modelTotals = computed(() => {
@@ -569,6 +591,61 @@ function StressBoard({ events, limit }: { events: StressEvent[]; limit: number }
   `
 }
 
+function HeuristicByModule({ coverage }: { coverage: HeuristicCoverage }) {
+  const byModule = coverage.sites.reduce((acc, site) => {
+    const arr = acc.get(site.module) ?? []
+    arr.push(site)
+    acc.set(site.module, arr)
+    return acc
+  }, new Map<string, CoverageSite[]>())
+
+  const sortedModules = Array.from(byModule.entries()).sort((a, b) => b[1].length - a[1].length)
+
+  return html`
+    <section class="flex flex-col gap-2" aria-label="Heuristic by module">
+      <div class="flex items-center justify-between rounded border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
+        <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">heuristic by module · ${coverage.total_events} events · ${coverage.unique_decision_tuples} unique tuples</span>
+      </div>
+      <div class="flex flex-col gap-2">
+        ${sortedModules.map(([moduleName, sites]) => {
+          const totalCount = sites.reduce((s, x) => s + x.count, 0)
+          const totalTriggered = sites.reduce((s, x) => s + x.triggered_count, 0)
+          return html`
+            <div key=${moduleName} class="rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
+              <div class="flex items-center justify-between border-b border-[var(--color-border-default)]/50 px-3 py-1.5">
+                <span class="text-xs font-semibold text-text-strong">${moduleName}</span>
+                <span class="font-mono text-2xs text-text-muted">${sites.length} sites · ${totalCount} obs · ${totalTriggered} triggered</span>
+              </div>
+              <div class="overflow-x-auto">
+                <table class="w-full" aria-label=${`Heuristic sites for ${moduleName}`}>
+                  <thead>
+                    <tr class="border-b border-[var(--color-border-default)]/30 text-2xs uppercase tracking-1 text-text-muted">
+                      <th scope="col" class="px-2 py-1 text-left">site</th>
+                      <th scope="col" class="px-2 py-1 text-right">count</th>
+                      <th scope="col" class="px-2 py-1 text-right">triggered</th>
+                      <th scope="col" class="px-2 py-1 text-right">rate</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${sites.sort((a, b) => b.count - a.count).map((s, i) => html`
+                      <tr key=${i} class="border-b border-[var(--color-border-default)]/20 text-2xs">
+                        <td class="px-2 py-1 text-text-muted">${s.site}</td>
+                        <td class="px-2 py-1 text-right font-mono">${s.count}</td>
+                        <td class="px-2 py-1 text-right font-mono ${s.triggered_count > 0 ? 'text-[var(--color-status-err)]' : ''}">${s.triggered_count}</td>
+                        <td class="px-2 py-1 text-right font-mono text-text-muted">${s.count > 0 ? ((s.triggered_count / s.count) * 100).toFixed(1) : '0.0'}%</td>
+                      </tr>
+                    `)}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          `
+        })}
+      </div>
+    </section>
+  `
+}
+
 export function CostDashboard() {
   const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
 
@@ -725,6 +802,12 @@ export function CostDashboard() {
         ? html`<${StressBoard} events=${stressState.value.data} limit=${stressState.value.limit} />`
         : stressState.value.status === 'error'
           ? html`<${ErrorState} message=${stressState.value.message} onRetry=${() => void loadStress()} />`
+          : html`<${LoadingState} />`}
+
+      ${coverageState.value.status === 'loaded'
+        ? html`<${HeuristicByModule} coverage=${coverageState.value.data} />`
+        : coverageState.value.status === 'error'
+          ? html`<${ErrorState} message=${coverageState.value.message} onRetry=${() => void loadHeuristicCoverage()} />`
           : html`<${LoadingState} />`}
     </section>
   `

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -16,9 +16,11 @@ import { signal, computed } from '@preact/signals'
 import {
   fetchRuntimeModelMetrics,
   fetchKeeperCostMetrics,
+  fetchHeuristics,
   type DashboardRuntimeModelMetric,
   type KeeperCostMetric,
   type LatencyBucket,
+  type HeuristicEvent,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
 
@@ -36,9 +38,16 @@ type KeeperLoadState =
   | { status: 'loaded'; data: KeeperCostMetric[]; windowMinutes: number }
   | { status: 'error'; message: string }
 
+type HeuristicLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: HeuristicEvent[]; limit: number }
+  | { status: 'error'; message: string }
+
 const viewMode = signal<ViewMode>('model')
 const modelState = signal<ModelLoadState>({ status: 'idle' })
 const keeperState = signal<KeeperLoadState>({ status: 'idle' })
+const heuristicState = signal<HeuristicLoadState>({ status: 'idle' })
 
 const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
   { key: 30, label: '30분' },
@@ -80,12 +89,24 @@ async function loadKeeperMetrics(window: number) {
   }
 }
 
+async function loadHeuristics(limit = 100) {
+  heuristicState.value = { status: 'loading' }
+  try {
+    const resp = await fetchHeuristics(limit)
+    heuristicState.value = { status: 'loaded', data: resp.events, limit: resp.limit }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'heuristic metrics 불러오기 실패'
+    heuristicState.value = { status: 'error', message }
+  }
+}
+
 function loadActiveView(window: number) {
   if (viewMode.value === 'model') {
     void loadModelMetrics(window)
   } else {
     void loadKeeperMetrics(window)
   }
+  void loadHeuristics()
 }
 
 const modelTotals = computed(() => {
@@ -410,6 +431,56 @@ function CostLatency({ buckets, p50, p95 }: {
   `
 }
 
+function HeuristicLog({ events, limit }: { events: HeuristicEvent[]; limit: number }) {
+  const fmtTime = (ts: number): string => {
+    const d = new Date(ts * 1000)
+    return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+  }
+
+  const triggeredCount = events.filter(e => e.triggered).length
+
+  return html`
+    <section class="flex flex-col gap-2" aria-label=${`Heuristic log · ${events.length} events`}>
+      <div class="flex items-center justify-between rounded border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
+        <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">heuristic log · ${events.length} events · ${triggeredCount} triggered</span>
+        <span class="font-mono text-2xs text-text-muted">limit ${limit}</span>
+      </div>
+      <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
+        <table class="w-full" aria-label="Heuristic events">
+          <thead>
+            <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-1 text-text-muted">
+              <th scope="col" class="px-2 py-1.5 text-left">time</th>
+              <th scope="col" class="px-2 py-1.5 text-left">module</th>
+              <th scope="col" class="px-2 py-1.5 text-left">site</th>
+              <th scope="col" class="px-2 py-1.5 text-right">value</th>
+              <th scope="col" class="px-2 py-1.5 text-right">threshold</th>
+              <th scope="col" class="px-2 py-1.5 text-center">state</th>
+              <th scope="col" class="px-2 py-1.5 text-left">provenance</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${events.map((e, i) => html`
+              <tr key=${i} class="border-b border-[var(--color-border-default)]/50 text-2xs ${e.triggered ? 'bg-[var(--color-status-err)]/5' : ''}">
+                <td class="px-2 py-1.5 font-mono text-text-muted">${fmtTime(e.timestamp)}</td>
+                <td class="px-2 py-1.5 text-text-strong">${e.module}</td>
+                <td class="px-2 py-1.5 text-text-muted">${e.site}</td>
+                <td class="px-2 py-1.5 text-right font-mono">${e.raw_value.toFixed(3)}</td>
+                <td class="px-2 py-1.5 text-right font-mono text-text-muted">${e.threshold.toFixed(3)}</td>
+                <td class="px-2 py-1.5 text-center">
+                  <span class="inline-block rounded px-1.5 py-0.5 text-2xs font-semibold ${e.triggered ? 'bg-[var(--color-status-err)]/15 text-[var(--color-status-err)]' : 'bg-[var(--color-status-ok)]/15 text-[var(--color-status-ok)]'}">
+                    ${e.triggered ? 'TRIGGERED' : 'ok'}
+                  </span>
+                </td>
+                <td class="px-2 py-1.5 text-text-muted">${e.provenance.type}${e.provenance.detail ? ` · ${e.provenance.detail}` : ''}</td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  `
+}
+
 export function CostDashboard() {
   const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
 
@@ -555,6 +626,12 @@ export function CostDashboard() {
           </table>
         </div>
       `}
+
+      ${heuristicState.value.status === 'loaded'
+        ? html`<${HeuristicLog} events=${heuristicState.value.data} limit=${heuristicState.value.limit} />`
+        : heuristicState.value.status === 'error'
+          ? html`<${ErrorState} message=${heuristicState.value.message} onRetry=${() => void loadHeuristics()} />`
+          : html`<${LoadingState} />`}
     </section>
   `
 }

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -19,6 +19,8 @@ import {
   fetchHeuristics,
   fetchHeuristicCoverage,
   fetchStress,
+  fetchCascadeHealth,
+  fetchCascadeConfig,
   type DashboardRuntimeModelMetric,
   type KeeperCostMetric,
   type LatencyBucket,
@@ -26,6 +28,8 @@ import {
   type HeuristicCoverage,
   type CoverageSite,
   type StressEvent,
+  type CascadeHealthResponse,
+  type CascadeConfigResponse,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
 
@@ -61,12 +65,26 @@ type CoverageLoadState =
   | { status: 'loaded'; data: HeuristicCoverage }
   | { status: 'error'; message: string }
 
+type CascadeHealthLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: CascadeHealthResponse }
+  | { status: 'error'; message: string }
+
+type CascadeConfigLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: CascadeConfigResponse }
+  | { status: 'error'; message: string }
+
 const viewMode = signal<ViewMode>('model')
 const modelState = signal<ModelLoadState>({ status: 'idle' })
 const keeperState = signal<KeeperLoadState>({ status: 'idle' })
 const heuristicState = signal<HeuristicLoadState>({ status: 'idle' })
 const stressState = signal<StressLoadState>({ status: 'idle' })
 const coverageState = signal<CoverageLoadState>({ status: 'idle' })
+const cascadeHealthState = signal<CascadeHealthLoadState>({ status: 'idle' })
+const cascadeConfigState = signal<CascadeConfigLoadState>({ status: 'idle' })
 
 const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
   { key: 30, label: '30분' },
@@ -141,6 +159,28 @@ async function loadHeuristicCoverage(limit = 100) {
   }
 }
 
+async function loadCascadeHealth() {
+  cascadeHealthState.value = { status: 'loading' }
+  try {
+    const resp = await fetchCascadeHealth()
+    cascadeHealthState.value = { status: 'loaded', data: resp }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'cascade health 불러오기 실패'
+    cascadeHealthState.value = { status: 'error', message }
+  }
+}
+
+async function loadCascadeConfig() {
+  cascadeConfigState.value = { status: 'loading' }
+  try {
+    const resp = await fetchCascadeConfig()
+    cascadeConfigState.value = { status: 'loaded', data: resp }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'cascade config 불러오기 실패'
+    cascadeConfigState.value = { status: 'error', message }
+  }
+}
+
 function loadActiveView(window: number) {
   if (viewMode.value === 'model') {
     void loadModelMetrics(window)
@@ -150,6 +190,8 @@ function loadActiveView(window: number) {
   void loadHeuristics()
   void loadStress()
   void loadHeuristicCoverage()
+  void loadCascadeHealth()
+  void loadCascadeConfig()
 }
 
 const modelTotals = computed(() => {
@@ -646,6 +688,111 @@ function HeuristicByModule({ coverage }: { coverage: HeuristicCoverage }) {
   `
 }
 
+function CascadeBoard({ health, config }: { health: CascadeHealthResponse; config: CascadeConfigResponse }) {
+  const fmtTime = (iso: string): string => {
+    const d = new Date(iso)
+    return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+  }
+
+  const sortedProviders = [...health.providers].sort((a, b) => b.success_rate - a.success_rate)
+
+  return html`
+    <section class="flex flex-col gap-4" aria-label="Cascade inspector">
+      <div class="flex items-center justify-between rounded border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
+        <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">cascade inspector · ${health.providers.length} providers · updated ${fmtTime(health.updated_at)}</span>
+        <span class="font-mono text-2xs text-text-muted">window ${health.window_sec}s · cooldown ${health.cooldown_threshold} failures / ${health.cooldown_sec}s</span>
+      </div>
+
+      <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
+        <table class="w-full" aria-label="Provider health">
+          <thead>
+            <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-1 text-text-muted">
+              <th scope="col" class="px-2 py-1.5 text-left">provider</th>
+              <th scope="col" class="px-2 py-1.5 text-right">success</th>
+              <th scope="col" class="px-2 py-1.5 text-right">events</th>
+              <th scope="col" class="px-2 py-1.5 text-right">rejected</th>
+              <th scope="col" class="px-2 py-1.5 text-right">latency</th>
+              <th scope="col" class="px-2 py-1.5 text-center">status</th>
+              <th scope="col" class="px-2 py-1.5 text-center">cooldown</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${sortedProviders.map((p, i) => {
+              const successPct = Math.round(p.success_rate * 100)
+              const status = p.status ?? 'configured'
+              const statusClass =
+                status === 'active' ? 'bg-[var(--color-status-ok)]/15 text-[var(--color-status-ok)]'
+                  : status === 'cooldown' ? 'bg-[var(--color-status-warn)]/15 text-[var(--color-status-warn)]'
+                  : 'bg-[var(--color-text-muted)]/15 text-[var(--color-text-muted)]'
+              const latency = p.p50_latency_ms ?? p.avg_latency_ms ?? null
+              const rejected = p.rejected_in_window ?? 0
+              return html`
+                <tr key=${i} class="border-b border-[var(--color-border-default)]/50 text-2xs">
+                  <td class="px-2 py-1.5 text-left font-mono text-xs text-[var(--color-accent-fg)]">${p.provider_key}</td>
+                  <td class="px-2 py-1.5 text-right font-mono ${successPct >= 95 ? 'text-[var(--color-status-ok)]' : successPct >= 80 ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-status-err)]'}">${successPct}%</td>
+                  <td class="px-2 py-1.5 text-right font-mono text-text-muted">${p.events_in_window}</td>
+                  <td class="px-2 py-1.5 text-right font-mono ${rejected > 0 ? 'text-[var(--color-status-err)]' : 'text-text-muted'}">${rejected}</td>
+                  <td class="px-2 py-1.5 text-right font-mono text-text-muted">${latency == null ? '—' : `${Math.round(latency)}ms`}</td>
+                  <td class="px-2 py-1.5 text-center">
+                    <span class="inline-block rounded px-1.5 py-0.5 text-2xs font-semibold ${statusClass}">${status}</span>
+                  </td>
+                  <td class="px-2 py-1.5 text-center">
+                    <span class="inline-block rounded px-1.5 py-0.5 text-2xs font-semibold ${p.in_cooldown ? 'bg-[var(--color-status-err)]/15 text-[var(--color-status-err)]' : 'bg-[var(--color-status-ok)]/15 text-[var(--color-status-ok)]'}">
+                      ${p.in_cooldown ? 'YES' : 'no'}
+                    </span>
+                  </td>
+                </tr>
+              `
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      ${config.profiles.length > 0 ? html`
+        <div class="flex flex-col gap-2">
+          <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">cascade profiles · ${config.profiles.length} profiles · ${config.keeper_profiles.length} keeper assignments</span>
+          <div class="flex flex-col gap-2">
+            ${config.profiles.map((prof, i) => html`
+              <div key=${i} class="rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
+                <div class="flex items-center justify-between border-b border-[var(--color-border-default)]/50 px-3 py-1.5">
+                  <span class="text-xs font-semibold text-text-strong">${prof.name}</span>
+                  <span class="font-mono text-2xs text-text-muted">${prof.candidates.length} candidates · ${prof.source}</span>
+                </div>
+                <div class="overflow-x-auto">
+                  <table class="w-full" aria-label=${`Candidates for ${prof.name}`}>
+                    <thead>
+                      <tr class="border-b border-[var(--color-border-default)]/30 text-2xs uppercase tracking-1 text-text-muted">
+                        <th scope="col" class="px-2 py-1 text-left">model</th>
+                        <th scope="col" class="px-2 py-1 text-right">weight</th>
+                        <th scope="col" class="px-2 py-1 text-right">success</th>
+                        <th scope="col" class="px-2 py-1 text-center">cooldown</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${prof.candidates.map((c, j) => html`
+                        <tr key=${j} class="border-b border-[var(--color-border-default)]/20 text-2xs">
+                          <td class="px-2 py-1 text-left font-mono text-text-strong">${c.model}</td>
+                          <td class="px-2 py-1 text-right font-mono text-text-muted">${c.effective_weight.toFixed(2)}</td>
+                          <td class="px-2 py-1 text-right font-mono ${Math.round(c.success_rate * 100) >= 95 ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-warn)]'}">${Math.round(c.success_rate * 100)}%</td>
+                          <td class="px-2 py-1 text-center">
+                            <span class="inline-block rounded px-1.5 py-0.5 text-2xs font-semibold ${c.in_cooldown ? 'bg-[var(--color-status-err)]/15 text-[var(--color-status-err)]' : 'bg-[var(--color-status-ok)]/15 text-[var(--color-status-ok)]'}">
+                              ${c.in_cooldown ? 'YES' : 'no'}
+                            </span>
+                          </td>
+                        </tr>
+                      `)}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            `)}
+          </div>
+        </div>
+      ` : null}
+    </section>
+  `
+}
+
 export function CostDashboard() {
   const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
 
@@ -809,6 +956,23 @@ export function CostDashboard() {
         : coverageState.value.status === 'error'
           ? html`<${ErrorState} message=${coverageState.value.message} onRetry=${() => void loadHeuristicCoverage()} />`
           : html`<${LoadingState} />`}
+
+      ${cascadeHealthState.value.status === 'loaded' && cascadeConfigState.value.status === 'loaded'
+        ? html`<${CascadeBoard}
+            health=${cascadeHealthState.value.data}
+            config=${cascadeConfigState.value.data}
+          />`
+        : cascadeHealthState.value.status === 'error'
+          ? html`<${ErrorState}
+              message=${cascadeHealthState.value.message}
+              onRetry=${() => void loadCascadeHealth()}
+            />`
+          : cascadeConfigState.value.status === 'error'
+            ? html`<${ErrorState}
+                message=${cascadeConfigState.value.message}
+                onRetry=${() => void loadCascadeConfig()}
+              />`
+            : html`<${LoadingState} />`}
     </section>
   `
 }

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -13,14 +13,13 @@
 
 import { html } from 'htm/preact'
 import { signal, computed } from '@preact/signals'
+import { route } from '../router'
 import {
   fetchRuntimeModelMetrics,
   fetchKeeperCostMetrics,
   fetchHeuristics,
   fetchHeuristicCoverage,
   fetchStress,
-  fetchCascadeHealth,
-  fetchCascadeConfig,
   fetchAuditLedger,
   fetchKeeperDecisions,
   type DashboardRuntimeModelMetric,
@@ -30,16 +29,44 @@ import {
   type HeuristicCoverage,
   type CoverageSite,
   type StressEvent,
-  type CascadeHealthResponse,
-  type CascadeConfigResponse,
   type AuditEntry,
   type AuditLedgerResponse,
   type KeeperDecision,
   type KeeperDecisionsResponse,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
+import { FilterChips } from './common/filter-chips'
 
 type ViewMode = 'model' | 'keeper'
+
+type CostView = 'cost' | 'heuristics' | 'stress' | 'audit' | 'decisions'
+
+const COST_VIEWS: CostView[] = ['cost', 'heuristics', 'stress', 'audit', 'decisions']
+
+function isCostView(v: string | undefined): v is CostView {
+  return !!v && (COST_VIEWS as string[]).includes(v)
+}
+
+const activeView = computed<CostView>(() => {
+  const v = route.value.params.view
+  return isCostView(v) ? v : 'cost'
+})
+
+const VIEW_CHIPS: Array<{ key: CostView; label: string }> = [
+  { key: 'cost',        label: '비용 / 지연' },
+  { key: 'heuristics',  label: '휴리스틱' },
+  { key: 'stress',      label: '스트레스' },
+  { key: 'audit',       label: '감사 원장' },
+  { key: 'decisions',   label: 'Keeper 결정' },
+]
+
+function updateViewParam(view: CostView) {
+  const hash = view === 'cost'
+    ? '#monitoring?section=cost'
+    : `#monitoring?section=cost&view=${view}`
+  history.replaceState(null, '', hash)
+  window.dispatchEvent(new HashChangeEvent('hashchange'))
+}
 
 type ModelLoadState =
   | { status: 'idle' }
@@ -71,18 +98,6 @@ type CoverageLoadState =
   | { status: 'loaded'; data: HeuristicCoverage }
   | { status: 'error'; message: string }
 
-type CascadeHealthLoadState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'loaded'; data: CascadeHealthResponse }
-  | { status: 'error'; message: string }
-
-type CascadeConfigLoadState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'loaded'; data: CascadeConfigResponse }
-  | { status: 'error'; message: string }
-
 type AuditLedgerLoadState =
   | { status: 'idle' }
   | { status: 'loading' }
@@ -101,8 +116,6 @@ const keeperState = signal<KeeperLoadState>({ status: 'idle' })
 const heuristicState = signal<HeuristicLoadState>({ status: 'idle' })
 const stressState = signal<StressLoadState>({ status: 'idle' })
 const coverageState = signal<CoverageLoadState>({ status: 'idle' })
-const cascadeHealthState = signal<CascadeHealthLoadState>({ status: 'idle' })
-const cascadeConfigState = signal<CascadeConfigLoadState>({ status: 'idle' })
 const auditLedgerState = signal<AuditLedgerLoadState>({ status: 'idle' })
 const keeperDecisionsState = signal<KeeperDecisionsLoadState>({ status: 'idle' })
 
@@ -179,28 +192,6 @@ async function loadHeuristicCoverage(limit = 100) {
   }
 }
 
-async function loadCascadeHealth() {
-  cascadeHealthState.value = { status: 'loading' }
-  try {
-    const resp = await fetchCascadeHealth()
-    cascadeHealthState.value = { status: 'loaded', data: resp }
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'cascade health 불러오기 실패'
-    cascadeHealthState.value = { status: 'error', message }
-  }
-}
-
-async function loadCascadeConfig() {
-  cascadeConfigState.value = { status: 'loading' }
-  try {
-    const resp = await fetchCascadeConfig()
-    cascadeConfigState.value = { status: 'loaded', data: resp }
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'cascade config 불러오기 실패'
-    cascadeConfigState.value = { status: 'error', message }
-  }
-}
-
 async function loadAuditLedger(limit = 50) {
   auditLedgerState.value = { status: 'loading' }
   try {
@@ -224,18 +215,27 @@ async function loadKeeperDecisions(limit = 200) {
 }
 
 function loadActiveView(window: number) {
-  if (viewMode.value === 'model') {
-    void loadModelMetrics(window)
-  } else {
-    void loadKeeperMetrics(window)
+  const view = activeView.value
+  if (view === 'cost') {
+    if (viewMode.value === 'model') {
+      void loadModelMetrics(window)
+    } else {
+      void loadKeeperMetrics(window)
+    }
   }
-  void loadHeuristics()
-  void loadStress()
-  void loadHeuristicCoverage()
-  void loadCascadeHealth()
-  void loadCascadeConfig()
-  void loadAuditLedger()
-  void loadKeeperDecisions()
+  if (view === 'heuristics') {
+    void loadHeuristics()
+    void loadHeuristicCoverage()
+  }
+  if (view === 'stress') {
+    void loadStress()
+  }
+  if (view === 'audit') {
+    void loadAuditLedger()
+  }
+  if (view === 'decisions') {
+    void loadKeeperDecisions()
+  }
 }
 
 const modelTotals = computed(() => {
@@ -732,111 +732,6 @@ function HeuristicByModule({ coverage }: { coverage: HeuristicCoverage }) {
   `
 }
 
-function CascadeBoard({ health, config }: { health: CascadeHealthResponse; config: CascadeConfigResponse }) {
-  const fmtTime = (iso: string): string => {
-    const d = new Date(iso)
-    return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
-  }
-
-  const sortedProviders = [...health.providers].sort((a, b) => b.success_rate - a.success_rate)
-
-  return html`
-    <section class="flex flex-col gap-4" aria-label="Cascade inspector">
-      <div class="flex items-center justify-between rounded border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
-        <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">cascade inspector · ${health.providers.length} providers · updated ${fmtTime(health.updated_at)}</span>
-        <span class="font-mono text-2xs text-text-muted">window ${health.window_sec}s · cooldown ${health.cooldown_threshold} failures / ${health.cooldown_sec}s</span>
-      </div>
-
-      <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
-        <table class="w-full" aria-label="Provider health">
-          <thead>
-            <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-1 text-text-muted">
-              <th scope="col" class="px-2 py-1.5 text-left">provider</th>
-              <th scope="col" class="px-2 py-1.5 text-right">success</th>
-              <th scope="col" class="px-2 py-1.5 text-right">events</th>
-              <th scope="col" class="px-2 py-1.5 text-right">rejected</th>
-              <th scope="col" class="px-2 py-1.5 text-right">latency</th>
-              <th scope="col" class="px-2 py-1.5 text-center">status</th>
-              <th scope="col" class="px-2 py-1.5 text-center">cooldown</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${sortedProviders.map((p, i) => {
-              const successPct = Math.round(p.success_rate * 100)
-              const status = p.status ?? 'configured'
-              const statusClass =
-                status === 'active' ? 'bg-[var(--color-status-ok)]/15 text-[var(--color-status-ok)]'
-                  : status === 'cooldown' ? 'bg-[var(--color-status-warn)]/15 text-[var(--color-status-warn)]'
-                  : 'bg-[var(--color-text-muted)]/15 text-[var(--color-text-muted)]'
-              const latency = p.p50_latency_ms ?? p.avg_latency_ms ?? null
-              const rejected = p.rejected_in_window ?? 0
-              return html`
-                <tr key=${i} class="border-b border-[var(--color-border-default)]/50 text-2xs">
-                  <td class="px-2 py-1.5 text-left font-mono text-xs text-[var(--color-accent-fg)]">${p.provider_key}</td>
-                  <td class="px-2 py-1.5 text-right font-mono ${successPct >= 95 ? 'text-[var(--color-status-ok)]' : successPct >= 80 ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-status-err)]'}">${successPct}%</td>
-                  <td class="px-2 py-1.5 text-right font-mono text-text-muted">${p.events_in_window}</td>
-                  <td class="px-2 py-1.5 text-right font-mono ${rejected > 0 ? 'text-[var(--color-status-err)]' : 'text-text-muted'}">${rejected}</td>
-                  <td class="px-2 py-1.5 text-right font-mono text-text-muted">${latency == null ? '—' : `${Math.round(latency)}ms`}</td>
-                  <td class="px-2 py-1.5 text-center">
-                    <span class="inline-block rounded px-1.5 py-0.5 text-2xs font-semibold ${statusClass}">${status}</span>
-                  </td>
-                  <td class="px-2 py-1.5 text-center">
-                    <span class="inline-block rounded px-1.5 py-0.5 text-2xs font-semibold ${p.in_cooldown ? 'bg-[var(--color-status-err)]/15 text-[var(--color-status-err)]' : 'bg-[var(--color-status-ok)]/15 text-[var(--color-status-ok)]'}">
-                      ${p.in_cooldown ? 'YES' : 'no'}
-                    </span>
-                  </td>
-                </tr>
-              `
-            })}
-          </tbody>
-        </table>
-      </div>
-
-      ${config.profiles.length > 0 ? html`
-        <div class="flex flex-col gap-2">
-          <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">cascade profiles · ${config.profiles.length} profiles · ${config.keeper_profiles.length} keeper assignments</span>
-          <div class="flex flex-col gap-2">
-            ${config.profiles.map((prof, i) => html`
-              <div key=${i} class="rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
-                <div class="flex items-center justify-between border-b border-[var(--color-border-default)]/50 px-3 py-1.5">
-                  <span class="text-xs font-semibold text-text-strong">${prof.name}</span>
-                  <span class="font-mono text-2xs text-text-muted">${prof.candidates.length} candidates · ${prof.source}</span>
-                </div>
-                <div class="overflow-x-auto">
-                  <table class="w-full" aria-label=${`Candidates for ${prof.name}`}>
-                    <thead>
-                      <tr class="border-b border-[var(--color-border-default)]/30 text-2xs uppercase tracking-1 text-text-muted">
-                        <th scope="col" class="px-2 py-1 text-left">model</th>
-                        <th scope="col" class="px-2 py-1 text-right">weight</th>
-                        <th scope="col" class="px-2 py-1 text-right">success</th>
-                        <th scope="col" class="px-2 py-1 text-center">cooldown</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      ${prof.candidates.map((c, j) => html`
-                        <tr key=${j} class="border-b border-[var(--color-border-default)]/20 text-2xs">
-                          <td class="px-2 py-1 text-left font-mono text-text-strong">${c.model}</td>
-                          <td class="px-2 py-1 text-right font-mono text-text-muted">${c.effective_weight.toFixed(2)}</td>
-                          <td class="px-2 py-1 text-right font-mono ${Math.round(c.success_rate * 100) >= 95 ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-warn)]'}">${Math.round(c.success_rate * 100)}%</td>
-                          <td class="px-2 py-1 text-center">
-                            <span class="inline-block rounded px-1.5 py-0.5 text-2xs font-semibold ${c.in_cooldown ? 'bg-[var(--color-status-err)]/15 text-[var(--color-status-err)]' : 'bg-[var(--color-status-ok)]/15 text-[var(--color-status-ok)]'}">
-                              ${c.in_cooldown ? 'YES' : 'no'}
-                            </span>
-                          </td>
-                        </tr>
-                      `)}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            `)}
-          </div>
-        </div>
-      ` : null}
-    </section>
-  `
-}
-
 function AuditLedgerBoard({ entries, count }: { entries: AuditEntry[]; count: number }) {
   const fmtTime = (ts: number): string => {
     const d = new Date(ts * 1000)
@@ -933,210 +828,262 @@ function KeeperDecisionsBoard({ events, limit }: { events: KeeperDecision[]; lim
   `
 }
 
-export function CostDashboard() {
-  const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
+function CostDashboardContent() {
+  const view = activeView.value
 
-  if (activeState.status === 'idle') {
-    void loadActiveView(windowMinutes.value)
-  }
+  if (view === 'cost') {
+    const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
 
-  if (activeState.status === 'loading') {
-    return html`<${LoadingState}>cost / latency metrics 불러오는 중...<//>`
-  }
-  if (activeState.status === 'error') {
-    return html`<${ErrorState} message=${activeState.message} />`
-  }
-  if (activeState.status !== 'loaded') return null
+    if (activeState.status === 'idle') {
+      void loadActiveView(windowMinutes.value)
+    }
+    if (activeState.status === 'loading') {
+      return html`<${LoadingState}>cost / latency metrics 불러오는 중...<//>`
+    }
+    if (activeState.status === 'error') {
+      return html`<${ErrorState} message=${activeState.message} />`
+    }
+    if (activeState.status !== 'loaded') return null
 
-  const t = viewMode.value === 'model' ? modelTotals.value : keeperTotals.value
-  const data = activeState.data
-    .slice()
-    .sort((a, b) => (viewMode.value === 'model'
-      ? (b as DashboardRuntimeModelMetric).total_cost_usd ?? 0 - ((a as DashboardRuntimeModelMetric).total_cost_usd ?? 0)
-      : (b as KeeperCostMetric).total_cost_usd - (a as KeeperCostMetric).total_cost_usd))
-  const maxCost = Math.max(0, ...data.map(m =>
-    viewMode.value === 'model' ? ((m as DashboardRuntimeModelMetric).total_cost_usd ?? 0) : (m as KeeperCostMetric).total_cost_usd))
-  const maxP95 = Math.max(0, ...data.map(m => {
-    const p95 = viewMode.value === 'model' ? (m as DashboardRuntimeModelMetric).p95_latency_ms : (m as KeeperCostMetric).p95_latency_ms
-    return p95 ?? 0
-  }))
+    const t = viewMode.value === 'model' ? modelTotals.value : keeperTotals.value
+    const data = activeState.data
+      .slice()
+      .sort((a, b) => (viewMode.value === 'model'
+        ? (b as DashboardRuntimeModelMetric).total_cost_usd ?? 0 - ((a as DashboardRuntimeModelMetric).total_cost_usd ?? 0)
+        : (b as KeeperCostMetric).total_cost_usd - (a as KeeperCostMetric).total_cost_usd))
+    const maxCost = Math.max(0, ...data.map(m =>
+      viewMode.value === 'model' ? ((m as DashboardRuntimeModelMetric).total_cost_usd ?? 0) : (m as KeeperCostMetric).total_cost_usd))
+    const maxP95 = Math.max(0, ...data.map(m => {
+      const p95 = viewMode.value === 'model' ? (m as DashboardRuntimeModelMetric).p95_latency_ms : (m as KeeperCostMetric).p95_latency_ms
+      return p95 ?? 0
+    }))
 
-  return html`
-    <section class="flex flex-col gap-4" aria-label="비용 / 지연 대시보드">
-      <header class="flex flex-wrap items-baseline justify-between gap-3">
-        <div>
-          <h2 class="text-base font-semibold text-text-strong">비용 / 지연 대시보드</h2>
-          <p class="text-2xs text-text-muted">최근 ${activeState.windowMinutes}분 · ${viewMode.value === 'model' ? '모델별' : 'Keeper별'} 토큰 / 비용 / latency</p>
-        </div>
-        <div class="flex items-center gap-2">
-          <div class="flex rounded border border-card-border/40 p-0.5" role="group" aria-label="보기 모드">
-            <button
-              type="button"
-              role="radio"
-              aria-checked=${viewMode.value === 'model'}
-              class="rounded px-2 py-0.5 text-2xs ${viewMode.value === 'model'
-                ? 'bg-[var(--accent-15)] text-accent'
-                : 'text-text-muted hover:text-text-strong'}"
-              onClick=${() => { viewMode.value = 'model'; void loadModelMetrics(windowMinutes.value) }}
-            >
-              모델
-            </button>
-            <button
-              type="button"
-              role="radio"
-              aria-checked=${viewMode.value === 'keeper'}
-              class="rounded px-2 py-0.5 text-2xs ${viewMode.value === 'keeper'
-                ? 'bg-[var(--accent-15)] text-accent'
-                : 'text-text-muted hover:text-text-strong'}"
-              onClick=${() => { viewMode.value = 'keeper'; void loadKeeperMetrics(windowMinutes.value) }}
-            >
-              Keeper
-            </button>
+    return html`
+      <section class="flex flex-col gap-4" aria-label="비용 / 지연 대시보드">
+        <header class="flex flex-wrap items-baseline justify-between gap-3">
+          <div>
+            <h2 class="text-base font-semibold text-text-strong">비용 / 지연 대시보드</h2>
+            <p class="text-2xs text-text-muted">최근 ${activeState.windowMinutes}분 · ${viewMode.value === 'model' ? '모델별' : 'Keeper별'} 토큰 / 비용 / latency</p>
           </div>
-          <div class="flex gap-1" role="radiogroup" aria-label="시간 창">
-            ${WINDOW_OPTIONS.map(o => html`
+          <div class="flex items-center gap-2">
+            <div class="flex rounded border border-card-border/40 p-0.5" role="group" aria-label="보기 모드">
               <button
-                key=${o.key}
                 type="button"
                 role="radio"
-                aria-checked=${windowMinutes.value === o.key}
-                class="rounded border px-2 py-0.5 text-2xs ${windowMinutes.value === o.key
-                  ? 'border-accent/50 bg-[var(--accent-15)] text-accent'
-                  : 'border-card-border/40 text-text-muted hover:border-card-border/60'}"
-                onClick=${() => { windowMinutes.value = o.key; void loadActiveView(o.key) }}
+                aria-checked=${viewMode.value === 'model'}
+                class="rounded px-2 py-0.5 text-2xs ${viewMode.value === 'model'
+                  ? 'bg-[var(--accent-15)] text-accent'
+                  : 'text-text-muted hover:text-text-strong'}"
+                onClick=${() => { viewMode.value = 'model'; void loadModelMetrics(windowMinutes.value) }}
               >
-                ${o.label}
+                모델
               </button>
-            `)}
+              <button
+                type="button"
+                role="radio"
+                aria-checked=${viewMode.value === 'keeper'}
+                class="rounded px-2 py-0.5 text-2xs ${viewMode.value === 'keeper'
+                  ? 'bg-[var(--accent-15)] text-accent'
+                  : 'text-text-muted hover:text-text-strong'}"
+                onClick=${() => { viewMode.value = 'keeper'; void loadKeeperMetrics(windowMinutes.value) }}
+              >
+                Keeper
+              </button>
+            </div>
+            <div class="flex gap-1" role="radiogroup" aria-label="시간 창">
+              ${WINDOW_OPTIONS.map(o => html`
+                <button
+                  key=${o.key}
+                  type="button"
+                  role="radio"
+                  aria-checked=${windowMinutes.value === o.key}
+                  class="rounded border px-2 py-0.5 text-2xs ${windowMinutes.value === o.key
+                    ? 'border-accent/50 bg-[var(--accent-15)] text-accent'
+                    : 'border-card-border/40 text-text-muted hover:border-card-border/60'}"
+                  onClick=${() => { windowMinutes.value = o.key; void loadActiveView(o.key) }}
+                >
+                  ${o.label}
+                </button>
+              `)}
+            </div>
           </div>
-        </div>
-      </header>
+        </header>
 
-      ${t ? html`
-        <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
-          <${StatCell}
-            label="Total Cost"
-            value=${`$${t.totalCost.toFixed(2)}`}
-            sub=${`${t.count} ${viewMode.value === 'model' ? 'models' : 'keepers'}`}
-            tone="ok"
-          />
-          <${StatCell}
-            label="Tokens In / Out"
-            value=${`${formatTokens(t.totalIn)} / ${formatTokens(t.totalOut)}`}
-            sub="aggregated window"
-          />
-          <${StatCell}
-            label="p50 Latency (avg)"
-            value=${`${t.p50Avg}ms`}
-            sub="across entries"
-          />
-          <${StatCell}
-            label="p95 Latency (max)"
-            value=${`${t.p95Max}ms`}
-            sub=${t.p95Max > 8000 ? 'over 8s budget' : 'within budget'}
-            tone=${t.p95Max > 8000 ? 'err' : 'default'}
-          />
-        </div>
-      ` : null}
+        ${t ? html`
+          <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
+            <${StatCell}
+              label="Total Cost"
+              value=${`$${t.totalCost.toFixed(2)}`}
+              sub=${`${t.count} ${viewMode.value === 'model' ? 'models' : 'keepers'}`}
+              tone="ok"
+            />
+            <${StatCell}
+              label="Tokens In / Out"
+              value=${`${formatTokens(t.totalIn)} / ${formatTokens(t.totalOut)}`}
+              sub="aggregated window"
+            />
+            <${StatCell}
+              label="p50 Latency (avg)"
+              value=${`${t.p50Avg}ms`}
+              sub="across entries"
+            />
+            <${StatCell}
+              label="p95 Latency (max)"
+              value=${`${t.p95Max}ms`}
+              sub=${t.p95Max > 8000 ? 'over 8s budget' : 'within budget'}
+              tone=${t.p95Max > 8000 ? 'err' : 'default'}
+            />
+          </div>
+        ` : null}
 
-      ${viewMode.value === 'model' && activeState.status === 'loaded'
-        ? html`
-          <${CostMatrix} models=${activeState.data as DashboardRuntimeModelMetric[]} />
-          <${CostLatency}
-            buckets=${(activeState as Extract<ModelLoadState, { status: 'loaded' }>).latencyBuckets}
-            p50=${t?.p50Avg ?? null}
-            p95=${t?.p95Max ?? null}
-          />
-        `
-        : null}
+        ${viewMode.value === 'model' && activeState.status === 'loaded'
+          ? html`
+            <${CostMatrix} models=${activeState.data as DashboardRuntimeModelMetric[]} />
+            <${CostLatency}
+              buckets=${(activeState as Extract<ModelLoadState, { status: 'loaded' }>).latencyBuckets}
+              p50=${t?.p50Avg ?? null}
+              p95=${t?.p95Max ?? null}
+            />
+          `
+          : null}
 
-      ${data.length === 0 ? html`
-        <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-6 text-center text-sm text-text-muted">
-          이 시간 창에서 기록된 ${viewMode.value === 'model' ? '모델' : 'Keeper'} 비용이 없습니다.
-        </div>
-      ` : html`
-        <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
-          <table class="w-full" aria-label=${`${data.length}개 ${viewMode.value === 'model' ? '모델' : 'Keeper'}의 비용 / 지연`}>
-            <thead>
-              <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-1 text-text-muted">
-                <th scope="col" class="px-2 py-1.5 text-left">${viewMode.value === 'model' ? 'model' : 'keeper'}</th>
-                <th scope="col" class="px-2 py-1.5 text-right">in tok</th>
-                <th scope="col" class="px-2 py-1.5 text-right">out tok</th>
-                <th scope="col" class="px-2 py-1.5 text-right">$ cost</th>
-                <th scope="col" class="px-2 py-1.5 text-left">cost</th>
-                <th scope="col" class="px-2 py-1.5 text-right">p50</th>
-                <th scope="col" class="px-2 py-1.5 text-right">p95</th>
-                <th scope="col" class="px-2 py-1.5 text-left">p95 trend</th>
-                ${viewMode.value === 'keeper' ? html`<th scope="col" class="px-2 py-1.5 text-left">top model</th>` : null}
-              </tr>
-            </thead>
-            <tbody>
-              ${viewMode.value === 'model'
-                ? data.map(m => html`<${ModelRow} key=${(m as DashboardRuntimeModelMetric).model_id} model=${m as DashboardRuntimeModelMetric} maxCost=${maxCost} maxP95=${maxP95} />`)
-                : data.map(k => html`<${KeeperRow} key=${(k as KeeperCostMetric).keeper_name} keeper=${k as KeeperCostMetric} maxCost=${maxCost} maxP95=${maxP95} />`)}
-            </tbody>
-          </table>
-        </div>
-      `}
+        ${data.length === 0 ? html`
+          <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-6 text-center text-sm text-text-muted">
+            이 시간 창에서 기록된 ${viewMode.value === 'model' ? '모델' : 'Keeper'} 비용이 없습니다.
+          </div>
+        ` : html`
+          <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
+            <table class="w-full" aria-label=${`${data.length}개 ${viewMode.value === 'model' ? '모델' : 'Keeper'}의 비용 / 지연`}>
+              <thead>
+                <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-1 text-text-muted">
+                  <th scope="col" class="px-2 py-1.5 text-left">${viewMode.value === 'model' ? 'model' : 'keeper'}</th>
+                  <th scope="col" class="px-2 py-1.5 text-right">in tok</th>
+                  <th scope="col" class="px-2 py-1.5 text-right">out tok</th>
+                  <th scope="col" class="px-2 py-1.5 text-right">$ cost</th>
+                  <th scope="col" class="px-2 py-1.5 text-left">cost</th>
+                  <th scope="col" class="px-2 py-1.5 text-right">p50</th>
+                  <th scope="col" class="px-2 py-1.5 text-right">p95</th>
+                  <th scope="col" class="px-2 py-1.5 text-left">p95 trend</th>
+                  ${viewMode.value === 'keeper' ? html`<th scope="col" class="px-2 py-1.5 text-left">top model</th>` : null}
+                </tr>
+              </thead>
+              <tbody>
+                ${viewMode.value === 'model'
+                  ? data.map(m => html`<${ModelRow} key=${(m as DashboardRuntimeModelMetric).model_id} model=${m as DashboardRuntimeModelMetric} maxCost=${maxCost} maxP95=${maxP95} />`)
+                  : data.map(k => html`<${KeeperRow} key=${(k as KeeperCostMetric).keeper_name} keeper=${k as KeeperCostMetric} maxCost=${maxCost} maxP95=${maxP95} />`)}
+              </tbody>
+            </table>
+          </div>
+        `}
+      </section>
+    `
+  }
 
-      ${heuristicState.value.status === 'loaded'
-        ? html`<${HeuristicLog} events=${heuristicState.value.data} limit=${heuristicState.value.limit} />`
-        : heuristicState.value.status === 'error'
-          ? html`<${ErrorState} message=${heuristicState.value.message} onRetry=${() => void loadHeuristics()} />`
-          : html`<${LoadingState} />`}
+  if (view === 'heuristics') {
+    if (heuristicState.value.status === 'idle') {
+      void loadHeuristics()
+      void loadHeuristicCoverage()
+    }
+    return html`
+      <section class="flex flex-col gap-4" aria-label="휴리스틱">
+        <header class="flex items-baseline justify-between gap-3">
+          <h2 class="text-base font-semibold text-text-strong">휴리스틱</h2>
+        </header>
+        ${heuristicState.value.status === 'loaded'
+          ? html`<${HeuristicLog} events=${heuristicState.value.data} limit=${heuristicState.value.limit} />`
+          : heuristicState.value.status === 'error'
+            ? html`<${ErrorState} message=${heuristicState.value.message} onRetry=${() => void loadHeuristics()} />`
+            : html`<${LoadingState} />`}
+        ${coverageState.value.status === 'loaded'
+          ? html`<${HeuristicByModule} coverage=${coverageState.value.data} />`
+          : coverageState.value.status === 'error'
+            ? html`<${ErrorState} message=${coverageState.value.message} onRetry=${() => void loadHeuristicCoverage()} />`
+            : html`<${LoadingState} />`}
+      </section>
+    `
+  }
 
-      ${stressState.value.status === 'loaded'
-        ? html`<${StressBoard} events=${stressState.value.data} limit=${stressState.value.limit} />`
-        : stressState.value.status === 'error'
-          ? html`<${ErrorState} message=${stressState.value.message} onRetry=${() => void loadStress()} />`
-          : html`<${LoadingState} />`}
+  if (view === 'stress') {
+    if (stressState.value.status === 'idle') {
+      void loadStress()
+    }
+    return html`
+      <section class="flex flex-col gap-4" aria-label="스트레스">
+        <header class="flex items-baseline justify-between gap-3">
+          <h2 class="text-base font-semibold text-text-strong">스트레스 이벤트</h2>
+        </header>
+        ${stressState.value.status === 'loaded'
+          ? html`<${StressBoard} events=${stressState.value.data} limit=${stressState.value.limit} />`
+          : stressState.value.status === 'error'
+            ? html`<${ErrorState} message=${stressState.value.message} onRetry=${() => void loadStress()} />`
+            : html`<${LoadingState} />`}
+      </section>
+    `
+  }
 
-      ${coverageState.value.status === 'loaded'
-        ? html`<${HeuristicByModule} coverage=${coverageState.value.data} />`
-        : coverageState.value.status === 'error'
-          ? html`<${ErrorState} message=${coverageState.value.message} onRetry=${() => void loadHeuristicCoverage()} />`
-          : html`<${LoadingState} />`}
-
-      ${cascadeHealthState.value.status === 'loaded' && cascadeConfigState.value.status === 'loaded'
-        ? html`<${CascadeBoard}
-            health=${cascadeHealthState.value.data}
-            config=${cascadeConfigState.value.data}
-          />`
-        : cascadeHealthState.value.status === 'error'
-          ? html`<${ErrorState}
-              message=${cascadeHealthState.value.message}
-              onRetry=${() => void loadCascadeHealth()}
+  if (view === 'audit') {
+    if (auditLedgerState.value.status === 'idle') {
+      void loadAuditLedger()
+    }
+    return html`
+      <section class="flex flex-col gap-4" aria-label="감사 원장">
+        <header class="flex items-baseline justify-between gap-3">
+          <h2 class="text-base font-semibold text-text-strong">감사 원장</h2>
+        </header>
+        ${auditLedgerState.value.status === 'loaded'
+          ? html`<${AuditLedgerBoard}
+              entries=${auditLedgerState.value.data.entries}
+              count=${auditLedgerState.value.data.count}
             />`
-          : cascadeConfigState.value.status === 'error'
+          : auditLedgerState.value.status === 'error'
             ? html`<${ErrorState}
-                message=${cascadeConfigState.value.message}
-                onRetry=${() => void loadCascadeConfig()}
+                message=${auditLedgerState.value.message}
+                onRetry=${() => void loadAuditLedger()}
               />`
             : html`<${LoadingState} />`}
+      </section>
+    `
+  }
 
-      ${auditLedgerState.value.status === 'loaded'
-        ? html`<${AuditLedgerBoard}
-            entries=${auditLedgerState.value.data.entries}
-            count=${auditLedgerState.value.data.count}
-          />`
-        : auditLedgerState.value.status === 'error'
-          ? html`<${ErrorState}
-              message=${auditLedgerState.value.message}
-              onRetry=${() => void loadAuditLedger()}
+  if (view === 'decisions') {
+    if (keeperDecisionsState.value.status === 'idle') {
+      void loadKeeperDecisions()
+    }
+    return html`
+      <section class="flex flex-col gap-4" aria-label="Keeper 결정">
+        <header class="flex items-baseline justify-between gap-3">
+          <h2 class="text-base font-semibold text-text-strong">Keeper 결정</h2>
+        </header>
+        ${keeperDecisionsState.value.status === 'loaded'
+          ? html`<${KeeperDecisionsBoard}
+              events=${keeperDecisionsState.value.data.events}
+              limit=${keeperDecisionsState.value.data.limit}
             />`
-          : html`<${LoadingState} />`}
+          : keeperDecisionsState.value.status === 'error'
+            ? html`<${ErrorState}
+                message=${keeperDecisionsState.value.message}
+                onRetry=${() => void loadKeeperDecisions()}
+              />`
+            : html`<${LoadingState} />`}
+      </section>
+    `
+  }
 
-      ${keeperDecisionsState.value.status === 'loaded'
-        ? html`<${KeeperDecisionsBoard}
-            events=${keeperDecisionsState.value.data.events}
-            limit=${keeperDecisionsState.value.data.limit}
-          />`
-        : keeperDecisionsState.value.status === 'error'
-          ? html`<${ErrorState}
-              message=${keeperDecisionsState.value.message}
-              onRetry=${() => void loadKeeperDecisions()}
-            />`
-          : html`<${LoadingState} />`}
-    </section>
+  return null
+}
+
+export function CostDashboard() {
+  const view = activeView.value
+  return html`
+    <div class="contain-content flex flex-col gap-4">
+      <${FilterChips}
+        chips=${VIEW_CHIPS}
+        value=${view}
+        onChange=${updateViewParam}
+        size="sm"
+        tone="accent"
+      />
+      <${CostDashboardContent} />
+    </div>
   `
 }

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -17,10 +17,12 @@ import {
   fetchRuntimeModelMetrics,
   fetchKeeperCostMetrics,
   fetchHeuristics,
+  fetchStress,
   type DashboardRuntimeModelMetric,
   type KeeperCostMetric,
   type LatencyBucket,
   type HeuristicEvent,
+  type StressEvent,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
 
@@ -44,10 +46,17 @@ type HeuristicLoadState =
   | { status: 'loaded'; data: HeuristicEvent[]; limit: number }
   | { status: 'error'; message: string }
 
+type StressLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: StressEvent[]; limit: number }
+  | { status: 'error'; message: string }
+
 const viewMode = signal<ViewMode>('model')
 const modelState = signal<ModelLoadState>({ status: 'idle' })
 const keeperState = signal<KeeperLoadState>({ status: 'idle' })
 const heuristicState = signal<HeuristicLoadState>({ status: 'idle' })
+const stressState = signal<StressLoadState>({ status: 'idle' })
 
 const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
   { key: 30, label: '30분' },
@@ -100,6 +109,17 @@ async function loadHeuristics(limit = 100) {
   }
 }
 
+async function loadStress(limit = 100) {
+  stressState.value = { status: 'loading' }
+  try {
+    const resp = await fetchStress(limit)
+    stressState.value = { status: 'loaded', data: resp.events, limit: resp.limit }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'stress events 불러오기 실패'
+    stressState.value = { status: 'error', message }
+  }
+}
+
 function loadActiveView(window: number) {
   if (viewMode.value === 'model') {
     void loadModelMetrics(window)
@@ -107,6 +127,7 @@ function loadActiveView(window: number) {
     void loadKeeperMetrics(window)
   }
   void loadHeuristics()
+  void loadStress()
 }
 
 const modelTotals = computed(() => {
@@ -481,6 +502,73 @@ function HeuristicLog({ events, limit }: { events: HeuristicEvent[]; limit: numb
   `
 }
 
+function StressBoard({ events, limit }: { events: StressEvent[]; limit: number }) {
+  const fmtTime = (ts: number): string => {
+    const d = new Date(ts * 1000)
+    return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+  }
+
+  const fmtKind = (kind: StressEvent['kind']): string => {
+    switch (kind.type) {
+      case 'failure_streak': return `failure_streak · ${kind.count ?? '?'}`
+      case 'turn_failure': return `turn_failure · c=${kind.consecutive ?? '?'} t=${kind.threshold ?? '?'}`
+      case 'fallback_approval': return 'fallback_approval'
+      case 'timeout': return 'timeout'
+      case 'parse_degraded': return 'parse_degraded'
+      case 'task_released': return 'task_released'
+      default: return kind.type
+    }
+  }
+
+  const severityClass = (kind: StressEvent['kind']): string => {
+    switch (kind.type) {
+      case 'failure_streak':
+      case 'turn_failure':
+        return 'bg-[var(--color-status-err)]/15 text-[var(--color-status-err)]'
+      case 'timeout':
+      case 'parse_degraded':
+        return 'bg-[var(--color-status-warn)]/15 text-[var(--color-status-warn)]'
+      default:
+        return 'bg-[var(--color-status-ok)]/15 text-[var(--color-status-ok)]'
+    }
+  }
+
+  return html`
+    <section class="flex flex-col gap-2" aria-label=${`Stress board · ${events.length} events`}>
+      <div class="flex items-center justify-between rounded border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
+        <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">stress board · ${events.length} events</span>
+        <span class="font-mono text-2xs text-text-muted">limit ${limit}</span>
+      </div>
+      <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
+        <table class="w-full" aria-label="Stress events">
+          <thead>
+            <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-1 text-text-muted">
+              <th scope="col" class="px-2 py-1.5 text-left">time</th>
+              <th scope="col" class="px-2 py-1.5 text-left">agent</th>
+              <th scope="col" class="px-2 py-1.5 text-left">room</th>
+              <th scope="col" class="px-2 py-1.5 text-left">kind</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${events.map((e, i) => html`
+              <tr key=${i} class="border-b border-[var(--color-border-default)]/50 text-2xs">
+                <td class="px-2 py-1.5 font-mono text-text-muted">${fmtTime(e.timestamp)}</td>
+                <td class="px-2 py-1.5 text-text-strong">${e.agent_name}</td>
+                <td class="px-2 py-1.5 font-mono text-text-muted">${e.room_id}</td>
+                <td class="px-2 py-1.5">
+                  <span class="inline-block rounded px-1.5 py-0.5 text-2xs font-semibold ${severityClass(e.kind)}">
+                    ${fmtKind(e.kind)}
+                  </span>
+                </td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  `
+}
+
 export function CostDashboard() {
   const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
 
@@ -631,6 +719,12 @@ export function CostDashboard() {
         ? html`<${HeuristicLog} events=${heuristicState.value.data} limit=${heuristicState.value.limit} />`
         : heuristicState.value.status === 'error'
           ? html`<${ErrorState} message=${heuristicState.value.message} onRetry=${() => void loadHeuristics()} />`
+          : html`<${LoadingState} />`}
+
+      ${stressState.value.status === 'loaded'
+        ? html`<${StressBoard} events=${stressState.value.data} limit=${stressState.value.limit} />`
+        : stressState.value.status === 'error'
+          ? html`<${ErrorState} message=${stressState.value.message} onRetry=${() => void loadStress()} />`
           : html`<${LoadingState} />`}
     </section>
   `

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -264,6 +264,78 @@ function KeeperRow({
   `
 }
 
+function CostMatrix({ models }: { models: DashboardRuntimeModelMetric[] }) {
+  const providers = Array.from(new Set(models.map(m => m.provider ?? 'unknown'))).sort()
+  const modelIds = Array.from(new Set(models.map(m => m.model_id))).sort((a, b) => {
+    const ca = models.find(m => m.model_id === a)?.total_cost_usd ?? 0
+    const cb = models.find(m => m.model_id === b)?.total_cost_usd ?? 0
+    return cb - ca
+  })
+
+  const grid: number[][] = providers.map(p =>
+    modelIds.map(mid => {
+      const match = models.find(m => m.model_id === mid && (m.provider ?? 'unknown') === p)
+      return match?.total_cost_usd ?? 0
+    })
+  )
+
+  const flat = grid.flat().filter(v => v > 0)
+  const max = flat.length > 0 ? Math.max(...flat) : 0
+
+  const zone = (v: number): string => {
+    if (v === 0) return 'z0'
+    const p = v / max
+    if (p < 0.1) return 'z1'
+    if (p < 0.3) return 'z2'
+    if (p < 0.7) return 'z3'
+    return 'z4'
+  }
+
+  const zoneClass = (z: string): string => {
+    switch (z) {
+      case 'z0': return 'bg-[var(--color-bg-surface)] text-text-disabled'
+      case 'z1': return 'bg-[var(--accent-5)]/30 text-text-muted'
+      case 'z2': return 'bg-[var(--accent-10)]/40 text-text-strong'
+      case 'z3': return 'bg-[var(--accent-15)]/50 text-accent'
+      case 'z4': return 'bg-[var(--color-accent-fg)] text-white'
+      default: return ''
+    }
+  }
+
+  return html`
+    <section class="flex flex-col gap-2" aria-label="Provider × Model cost matrix">
+      <div class="flex items-center justify-between rounded border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
+        <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">provider × model · $ spent</span>
+      </div>
+      <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
+        <table class="w-full" aria-label="Provider by model cost matrix">
+          <thead>
+            <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-1 text-text-muted">
+              <th scope="col" class="px-2 py-1.5 text-left"></th>
+              ${modelIds.map(mid => html`<th scope="col" class="px-2 py-1.5 text-left font-mono text-xs">${mid}</th>`)}
+            </tr>
+          </thead>
+          <tbody>
+            ${providers.map((p, i) => html`
+              <tr key=${p} class="border-b border-[var(--color-border-default)]/40">
+                <th scope="row" class="px-2 py-1.5 text-left font-mono text-xs text-[var(--color-accent-fg)]">${p}</th>
+                ${(grid[i] ?? []).map((v, j) => {
+                  const z = zone(v)
+                  return html`
+                    <td key=${j} class="px-2 py-1.5 text-right font-mono text-xs ${zoneClass(z)}">
+                      ${v > 0 ? `$${v.toFixed(2)}` : '—'}
+                    </td>
+                  `
+                })}
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  `
+}
+
 export function CostDashboard() {
   const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
 
@@ -369,6 +441,10 @@ export function CostDashboard() {
           />
         </div>
       ` : null}
+
+      ${viewMode.value === 'model' && activeState.status === 'loaded'
+        ? html`<${CostMatrix} models=${activeState.data as DashboardRuntimeModelMetric[]} />`
+        : null}
 
       ${data.length === 0 ? html`
         <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-6 text-center text-sm text-text-muted">

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -22,6 +22,7 @@ import {
   fetchCascadeHealth,
   fetchCascadeConfig,
   fetchAuditLedger,
+  fetchKeeperDecisions,
   type DashboardRuntimeModelMetric,
   type KeeperCostMetric,
   type LatencyBucket,
@@ -33,6 +34,8 @@ import {
   type CascadeConfigResponse,
   type AuditEntry,
   type AuditLedgerResponse,
+  type KeeperDecision,
+  type KeeperDecisionsResponse,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
 
@@ -86,6 +89,12 @@ type AuditLedgerLoadState =
   | { status: 'loaded'; data: AuditLedgerResponse }
   | { status: 'error'; message: string }
 
+type KeeperDecisionsLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: KeeperDecisionsResponse }
+  | { status: 'error'; message: string }
+
 const viewMode = signal<ViewMode>('model')
 const modelState = signal<ModelLoadState>({ status: 'idle' })
 const keeperState = signal<KeeperLoadState>({ status: 'idle' })
@@ -95,6 +104,7 @@ const coverageState = signal<CoverageLoadState>({ status: 'idle' })
 const cascadeHealthState = signal<CascadeHealthLoadState>({ status: 'idle' })
 const cascadeConfigState = signal<CascadeConfigLoadState>({ status: 'idle' })
 const auditLedgerState = signal<AuditLedgerLoadState>({ status: 'idle' })
+const keeperDecisionsState = signal<KeeperDecisionsLoadState>({ status: 'idle' })
 
 const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
   { key: 30, label: '30분' },
@@ -202,6 +212,17 @@ async function loadAuditLedger(limit = 50) {
   }
 }
 
+async function loadKeeperDecisions(limit = 200) {
+  keeperDecisionsState.value = { status: 'loading' }
+  try {
+    const resp = await fetchKeeperDecisions(limit)
+    keeperDecisionsState.value = { status: 'loaded', data: resp }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'keeper decisions 불러오기 실패'
+    keeperDecisionsState.value = { status: 'error', message }
+  }
+}
+
 function loadActiveView(window: number) {
   if (viewMode.value === 'model') {
     void loadModelMetrics(window)
@@ -214,6 +235,7 @@ function loadActiveView(window: number) {
   void loadCascadeHealth()
   void loadCascadeConfig()
   void loadAuditLedger()
+  void loadKeeperDecisions()
 }
 
 const modelTotals = computed(() => {
@@ -864,6 +886,53 @@ function AuditLedgerBoard({ entries, count }: { entries: AuditEntry[]; count: nu
   `
 }
 
+function KeeperDecisionsBoard({ events, limit }: { events: KeeperDecision[]; limit: number }) {
+  const fmtTime = (ts: number | null): string => {
+    if (ts == null) return '—'
+    const d = new Date(ts * 1000)
+    return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+  }
+
+  return html`
+    <section class="flex flex-col gap-4" aria-label="Keeper decisions">
+      <div class="flex items-center justify-between rounded border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
+        <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">keeper decisions · ${events.length} events · limit ${limit}</span>
+      </div>
+
+      <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
+        <table class="w-full" aria-label="Keeper decision events">
+          <thead>
+            <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-1 text-text-muted">
+              <th scope="col" class="px-2 py-1.5 text-left">time</th>
+              <th scope="col" class="px-2 py-1.5 text-left">keeper</th>
+              <th scope="col" class="px-2 py-1.5 text-left">event</th>
+              <th scope="col" class="px-2 py-1.5 text-left">outcome</th>
+              <th scope="col" class="px-2 py-1.5 text-left">model</th>
+              <th scope="col" class="px-2 py-1.5 text-right">latency</th>
+              <th scope="col" class="px-2 py-1.5 text-right">cost</th>
+              <th scope="col" class="px-2 py-1.5 text-center">tool</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${events.map((e, i) => html`
+              <tr key=${i} class="border-b border-[var(--color-border-default)]/50 text-2xs">
+                <td class="px-2 py-1.5 text-left font-mono text-text-muted">${fmtTime(e.ts_unix)}</td>
+                <td class="px-2 py-1.5 text-left font-mono text-xs text-[var(--color-accent-fg)]">${e.keeper_name}</td>
+                <td class="px-2 py-1.5 text-left font-mono text-text-strong">${e.event_type}</td>
+                <td class="px-2 py-1.5 text-left font-mono ${e.outcome === 'success' ? 'text-[var(--color-status-ok)]' : e.outcome === 'error' ? 'text-[var(--color-status-err)]' : 'text-text-muted'}">${e.outcome ?? '—'}</td>
+                <td class="px-2 py-1.5 text-left font-mono text-text-muted">${e.model_used ?? '—'}</td>
+                <td class="px-2 py-1.5 text-right font-mono text-text-muted">${e.latency_ms == null ? '—' : `${Math.round(e.latency_ms)}ms`}</td>
+                <td class="px-2 py-1.5 text-right font-mono text-text-muted">${e.cost_usd == null ? '—' : `$${e.cost_usd.toFixed(4)}`}</td>
+                <td class="px-2 py-1.5 text-center font-mono text-text-muted">${e.tool ?? '—'}</td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  `
+}
+
 export function CostDashboard() {
   const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
 
@@ -1054,6 +1123,18 @@ export function CostDashboard() {
           ? html`<${ErrorState}
               message=${auditLedgerState.value.message}
               onRetry=${() => void loadAuditLedger()}
+            />`
+          : html`<${LoadingState} />`}
+
+      ${keeperDecisionsState.value.status === 'loaded'
+        ? html`<${KeeperDecisionsBoard}
+            events=${keeperDecisionsState.value.data.events}
+            limit=${keeperDecisionsState.value.data.limit}
+          />`
+        : keeperDecisionsState.value.status === 'error'
+          ? html`<${ErrorState}
+              message=${keeperDecisionsState.value.message}
+              onRetry=${() => void loadKeeperDecisions()}
             />`
           : html`<${LoadingState} />`}
     </section>

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -18,6 +18,7 @@ import {
   fetchKeeperCostMetrics,
   type DashboardRuntimeModelMetric,
   type KeeperCostMetric,
+  type LatencyBucket,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
 
@@ -26,7 +27,7 @@ type ViewMode = 'model' | 'keeper'
 type ModelLoadState =
   | { status: 'idle' }
   | { status: 'loading' }
-  | { status: 'loaded'; data: DashboardRuntimeModelMetric[]; windowMinutes: number }
+  | { status: 'loaded'; data: DashboardRuntimeModelMetric[]; latencyBuckets: LatencyBucket[]; windowMinutes: number }
   | { status: 'error'; message: string }
 
 type KeeperLoadState =
@@ -55,6 +56,7 @@ async function loadModelMetrics(window: number) {
     modelState.value = {
       status: 'loaded',
       data: resp.models,
+      latencyBuckets: resp.latency_buckets ?? [],
       windowMinutes: resp.window_minutes ?? window,
     }
   } catch (err) {
@@ -336,6 +338,78 @@ function CostMatrix({ models }: { models: DashboardRuntimeModelMetric[] }) {
   `
 }
 
+function CostLatency({ buckets, p50, p95 }: {
+  buckets: LatencyBucket[]
+  p50: number | null
+  p95: number | null
+}) {
+  const max = Math.max(1, ...buckets.map(b => b.count))
+  const total = buckets.reduce((s, b) => s + b.count, 0)
+
+  const fmtLo = (lo: number): string => {
+    if (lo < 1000) return `${lo}`
+    if (lo < 60000) return `${(lo / 1000).toFixed(0)}k`
+    return `${Math.floor(lo / 60000)}m`
+  }
+
+  const bands = [
+    {
+      label: '< 1s',
+      count: buckets.filter(b => b.hi_ms != null && b.hi_ms <= 1000).reduce((s, b) => s + b.count, 0),
+      color: 'text-[var(--color-status-ok)]',
+    },
+    {
+      label: '1–4s',
+      count: buckets.filter(b => b.lo_ms >= 1000 && b.hi_ms != null && b.hi_ms <= 4000).reduce((s, b) => s + b.count, 0),
+      color: 'text-[var(--color-accent-fg)]',
+    },
+    {
+      label: '4–16s',
+      count: buckets.filter(b => b.lo_ms >= 4000 && b.hi_ms != null && b.hi_ms <= 16000).reduce((s, b) => s + b.count, 0),
+      color: 'text-[var(--color-status-warn)]',
+    },
+    {
+      label: '> 16s',
+      count: buckets.filter(b => b.lo_ms >= 16000).reduce((s, b) => s + b.count, 0),
+      color: 'text-[var(--color-status-err)]',
+    },
+  ]
+
+  return html`
+    <section class="flex flex-col gap-2" aria-label=${`Latency distribution · ${total} calls`}>
+      <div class="flex items-center justify-between rounded border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
+        <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">latency distribution · ${total} calls</span>
+        <div class="flex gap-3 font-mono text-2xs">
+          <span class="text-text-muted">p50 · <span class="text-[var(--color-accent-fg)]">${p50 == null ? '—' : `${Math.round(p50)}ms`}</span></span>
+          <span class="text-text-muted">p95 · <span class="text-[var(--color-status-err)]">${p95 == null ? '—' : `${Math.round(p95)}ms`}</span></span>
+        </div>
+      </div>
+      <div class="flex items-end gap-1 rounded border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-3" role="img" aria-label=${`Latency histogram · ${buckets.length} buckets`}>
+        ${buckets.map((b, i) => {
+          const pct = (b.count / max) * 100
+          const bad = b.lo_ms >= 8000
+          return html`
+            <div key=${i} class="flex flex-1 flex-col items-center gap-1">
+              <div class="w-full rounded-sm ${bad ? 'bg-[var(--color-status-err)]' : 'bg-[var(--color-accent-fg)]'}" style=${`height: ${Math.max(4, pct * 1.5).toFixed(1)}px`}></div>
+              <span class="font-mono text-2xs text-text-muted">${fmtLo(b.lo_ms)}</span>
+            </div>
+          `
+        })}
+      </div>
+      <div class="grid grid-cols-4 gap-px rounded border border-card-border/60 bg-[var(--color-border-default)]" role="list" aria-label="Latency band totals">
+        ${bands.map(b => html`
+          <div key=${b.label} class="flex flex-col gap-0.5 bg-[var(--backdrop-deep)] p-2" role="listitem" aria-label=${`${b.label}: ${b.count} calls (${total > 0 ? ((b.count / total) * 100).toFixed(0) : 0}%)`}>
+            <span class="font-mono text-2xs uppercase tracking-1 text-text-muted">${b.label}</span>
+            <span class="font-mono text-sm font-semibold ${b.color}">
+              ${b.count}<span class="ml-1 text-2xs font-normal text-text-muted">· ${total > 0 ? ((b.count / total) * 100).toFixed(0) : 0}%</span>
+            </span>
+          </div>
+        `)}
+      </div>
+    </section>
+  `
+}
+
 export function CostDashboard() {
   const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
 
@@ -443,7 +517,14 @@ export function CostDashboard() {
       ` : null}
 
       ${viewMode.value === 'model' && activeState.status === 'loaded'
-        ? html`<${CostMatrix} models=${activeState.data as DashboardRuntimeModelMetric[]} />`
+        ? html`
+          <${CostMatrix} models=${activeState.data as DashboardRuntimeModelMetric[]} />
+          <${CostLatency}
+            buckets=${(activeState as Extract<ModelLoadState, { status: 'loaded' }>).latencyBuckets}
+            p50=${t?.p50Avg ?? null}
+            p95=${t?.p95Max ?? null}
+          />
+        `
         : null}
 
       ${data.length === 0 ? html`

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -7,25 +7,37 @@
 // (`/api/v1/models/metrics`) but no surface that consolidates it
 // into a "where is the money going / where is the latency going" view.
 //
-// Production renders per-model rather than per-agent (cost is naturally
-// tracked by model in OAS pipelines), but the spec's intent — quick
-// scan of cost / latency hotspots — is preserved.
+// This component now supports both per-model and per-keeper views,
+// toggled via a segmented control. The per-keeper view consumes the
+// new `/api/v1/dashboard/keeper-costs` endpoint.
 
 import { html } from 'htm/preact'
 import { signal, computed } from '@preact/signals'
 import {
   fetchRuntimeModelMetrics,
+  fetchKeeperCostMetrics,
   type DashboardRuntimeModelMetric,
+  type KeeperCostMetric,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
 
-type LoadState =
+type ViewMode = 'model' | 'keeper'
+
+type ModelLoadState =
   | { status: 'idle' }
   | { status: 'loading' }
   | { status: 'loaded'; data: DashboardRuntimeModelMetric[]; windowMinutes: number }
   | { status: 'error'; message: string }
 
-const state = signal<LoadState>({ status: 'idle' })
+type KeeperLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: KeeperCostMetric[]; windowMinutes: number }
+  | { status: 'error'; message: string }
+
+const viewMode = signal<ViewMode>('model')
+const modelState = signal<ModelLoadState>({ status: 'idle' })
+const keeperState = signal<KeeperLoadState>({ status: 'idle' })
 
 const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
   { key: 30, label: '30분' },
@@ -36,23 +48,46 @@ const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
 
 const windowMinutes = signal<number>(60)
 
-async function loadMetrics(window: number) {
-  state.value = { status: 'loading' }
+async function loadModelMetrics(window: number) {
+  modelState.value = { status: 'loading' }
   try {
     const resp = await fetchRuntimeModelMetrics(window, 5)
-    state.value = {
+    modelState.value = {
       status: 'loaded',
       data: resp.models,
       windowMinutes: resp.window_minutes ?? window,
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : 'cost metrics 불러오기 실패'
-    state.value = { status: 'error', message }
+    modelState.value = { status: 'error', message }
   }
 }
 
-const totals = computed(() => {
-  const s = state.value
+async function loadKeeperMetrics(window: number) {
+  keeperState.value = { status: 'loading' }
+  try {
+    const resp = await fetchKeeperCostMetrics(window)
+    keeperState.value = {
+      status: 'loaded',
+      data: resp.keepers,
+      windowMinutes: resp.window_minutes ?? window,
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'keeper cost metrics 불러오기 실패'
+    keeperState.value = { status: 'error', message }
+  }
+}
+
+function loadActiveView(window: number) {
+  if (viewMode.value === 'model') {
+    void loadModelMetrics(window)
+  } else {
+    void loadKeeperMetrics(window)
+  }
+}
+
+const modelTotals = computed(() => {
+  const s = modelState.value
   if (s.status !== 'loaded') return null
   const data = s.data
   let totalCost = 0
@@ -70,6 +105,30 @@ const totals = computed(() => {
       p50Count += 1
     }
     if (m.p95_latency_ms != null && m.p95_latency_ms > p95Max) p95Max = m.p95_latency_ms
+  }
+  const p50Avg = p50Count > 0 ? Math.round(p50Sum / p50Count) : 0
+  return { totalCost, totalIn, totalOut, p50Avg, p95Max, count: data.length }
+})
+
+const keeperTotals = computed(() => {
+  const s = keeperState.value
+  if (s.status !== 'loaded') return null
+  const data = s.data
+  let totalCost = 0
+  let totalIn = 0
+  let totalOut = 0
+  let p50Sum = 0
+  let p50Count = 0
+  let p95Max = 0
+  for (const k of data) {
+    totalCost += k.total_cost_usd
+    totalIn += k.total_input_tokens
+    totalOut += k.total_output_tokens
+    if (k.p50_latency_ms != null) {
+      p50Sum += k.p50_latency_ms
+      p50Count += 1
+    }
+    if (k.p95_latency_ms != null && k.p95_latency_ms > p95Max) p95Max = k.p95_latency_ms
   }
   const p50Avg = p50Count > 0 ? Math.round(p50Sum / p50Count) : 0
   return { totalCost, totalIn, totalOut, p50Avg, p95Max, count: data.length }
@@ -152,48 +211,135 @@ function ModelRow({
   `
 }
 
+function KeeperRow({
+  keeper, maxCost, maxP95,
+}: {
+  keeper: KeeperCostMetric
+  maxCost: number
+  maxP95: number
+}) {
+  const cost = keeper.total_cost_usd
+  const inTok = keeper.total_input_tokens
+  const outTok = keeper.total_output_tokens
+  const p50 = keeper.p50_latency_ms
+  const p95 = keeper.p95_latency_ms
+  const costPct = maxCost > 0 ? (cost / maxCost) * 100 : 0
+  const p95Pct = maxP95 > 0 && p95 != null ? (p95 / maxP95) * 100 : 0
+  const overBudget = p95 != null && p95 > 8000
+  const topModel = keeper.model_breakdown[0]
+
+  return html`
+    <tr class="border-b border-[var(--color-border-default)]/40 align-baseline">
+      <th scope="row" class="px-2 py-1.5 text-left font-mono text-xs text-[var(--color-accent-fg)]">
+        ${keeper.keeper_name}
+      </th>
+      <td class="px-2 py-1.5 text-right font-mono text-xs">${formatTokens(inTok)}</td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs">${formatTokens(outTok)}</td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs text-[var(--color-accent-fg)]">
+        $${cost.toFixed(2)}
+      </td>
+      <td class="px-2 py-1.5 min-w-[80px]">
+        <div class="h-1.5 rounded-sm bg-[var(--color-bg-surface)]">
+          <div class="h-full rounded-sm bg-[var(--color-accent-fg)]" style=${`width: ${costPct.toFixed(1)}%`}></div>
+        </div>
+      </td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs ${p50 == null ? 'text-text-disabled' : ''}">
+        ${p50 == null ? '—' : `${Math.round(p50)}ms`}
+      </td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs ${overBudget ? 'text-[var(--color-status-err)]' : ''}">
+        ${p95 == null ? html`<span class="text-text-disabled">—</span>` : `${Math.round(p95)}ms`}
+      </td>
+      <td class="px-2 py-1.5 min-w-[80px]">
+        <div class="h-1.5 rounded-sm bg-[var(--color-bg-surface)]">
+          <div
+            class="h-full rounded-sm ${overBudget ? 'bg-[var(--color-status-err)]' : 'bg-[var(--color-status-warn)]'}"
+            style=${`width: ${p95Pct.toFixed(1)}%`}
+          ></div>
+        </div>
+      </td>
+      <td class="px-2 py-1.5 text-left font-mono text-2xs text-text-muted">
+        ${topModel ? `${topModel.model} ($${topModel.cost_usd.toFixed(2)})` : '—'}
+      </td>
+    </tr>
+  `
+}
+
 export function CostDashboard() {
-  if (state.value.status === 'idle') {
-    void loadMetrics(windowMinutes.value)
+  const activeState = viewMode.value === 'model' ? modelState.value : keeperState.value
+
+  if (activeState.status === 'idle') {
+    void loadActiveView(windowMinutes.value)
   }
 
-  if (state.value.status === 'loading') {
+  if (activeState.status === 'loading') {
     return html`<${LoadingState}>cost / latency metrics 불러오는 중...<//>`
   }
-  if (state.value.status === 'error') {
-    return html`<${ErrorState} message=${state.value.message} />`
+  if (activeState.status === 'error') {
+    return html`<${ErrorState} message=${activeState.message} />`
   }
-  if (state.value.status !== 'loaded') return null
+  if (activeState.status !== 'loaded') return null
 
-  const t = totals.value
-  const data = state.value.data
+  const t = viewMode.value === 'model' ? modelTotals.value : keeperTotals.value
+  const data = activeState.data
     .slice()
-    .sort((a, b) => (b.total_cost_usd ?? 0) - (a.total_cost_usd ?? 0))
-  const maxCost = Math.max(0, ...data.map(m => m.total_cost_usd ?? 0))
-  const maxP95 = Math.max(0, ...data.map(m => m.p95_latency_ms ?? 0))
+    .sort((a, b) => (viewMode.value === 'model'
+      ? (b as DashboardRuntimeModelMetric).total_cost_usd ?? 0 - ((a as DashboardRuntimeModelMetric).total_cost_usd ?? 0)
+      : (b as KeeperCostMetric).total_cost_usd - (a as KeeperCostMetric).total_cost_usd))
+  const maxCost = Math.max(0, ...data.map(m =>
+    viewMode.value === 'model' ? ((m as DashboardRuntimeModelMetric).total_cost_usd ?? 0) : (m as KeeperCostMetric).total_cost_usd))
+  const maxP95 = Math.max(0, ...data.map(m => {
+    const p95 = viewMode.value === 'model' ? (m as DashboardRuntimeModelMetric).p95_latency_ms : (m as KeeperCostMetric).p95_latency_ms
+    return p95 ?? 0
+  }))
 
   return html`
     <section class="flex flex-col gap-4" aria-label="비용 / 지연 대시보드">
       <header class="flex flex-wrap items-baseline justify-between gap-3">
         <div>
           <h2 class="text-base font-semibold text-text-strong">비용 / 지연 대시보드</h2>
-          <p class="text-2xs text-text-muted">최근 ${state.value.windowMinutes}분 · 모델별 토큰 / 비용 / latency</p>
+          <p class="text-2xs text-text-muted">최근 ${activeState.windowMinutes}분 · ${viewMode.value === 'model' ? '모델별' : 'Keeper별'} 토큰 / 비용 / latency</p>
         </div>
-        <div class="flex gap-1" role="radiogroup" aria-label="시간 창">
-          ${WINDOW_OPTIONS.map(o => html`
+        <div class="flex items-center gap-2">
+          <div class="flex rounded border border-card-border/40 p-0.5" role="group" aria-label="보기 모드">
             <button
-              key=${o.key}
               type="button"
               role="radio"
-              aria-checked=${windowMinutes.value === o.key}
-              class="rounded border px-2 py-0.5 text-2xs ${windowMinutes.value === o.key
-                ? 'border-accent/50 bg-[var(--accent-15)] text-accent'
-                : 'border-card-border/40 text-text-muted hover:border-card-border/60'}"
-              onClick=${() => { windowMinutes.value = o.key; void loadMetrics(o.key) }}
+              aria-checked=${viewMode.value === 'model'}
+              class="rounded px-2 py-0.5 text-2xs ${viewMode.value === 'model'
+                ? 'bg-[var(--accent-15)] text-accent'
+                : 'text-text-muted hover:text-text-strong'}"
+              onClick=${() => { viewMode.value = 'model'; void loadModelMetrics(windowMinutes.value) }}
             >
-              ${o.label}
+              모델
             </button>
-          `)}
+            <button
+              type="button"
+              role="radio"
+              aria-checked=${viewMode.value === 'keeper'}
+              class="rounded px-2 py-0.5 text-2xs ${viewMode.value === 'keeper'
+                ? 'bg-[var(--accent-15)] text-accent'
+                : 'text-text-muted hover:text-text-strong'}"
+              onClick=${() => { viewMode.value = 'keeper'; void loadKeeperMetrics(windowMinutes.value) }}
+            >
+              Keeper
+            </button>
+          </div>
+          <div class="flex gap-1" role="radiogroup" aria-label="시간 창">
+            ${WINDOW_OPTIONS.map(o => html`
+              <button
+                key=${o.key}
+                type="button"
+                role="radio"
+                aria-checked=${windowMinutes.value === o.key}
+                class="rounded border px-2 py-0.5 text-2xs ${windowMinutes.value === o.key
+                  ? 'border-accent/50 bg-[var(--accent-15)] text-accent'
+                  : 'border-card-border/40 text-text-muted hover:border-card-border/60'}"
+                onClick=${() => { windowMinutes.value = o.key; void loadActiveView(o.key) }}
+              >
+                ${o.label}
+              </button>
+            `)}
+          </div>
         </div>
       </header>
 
@@ -202,7 +348,7 @@ export function CostDashboard() {
           <${StatCell}
             label="Total Cost"
             value=${`$${t.totalCost.toFixed(2)}`}
-            sub=${`${t.count} models`}
+            sub=${`${t.count} ${viewMode.value === 'model' ? 'models' : 'keepers'}`}
             tone="ok"
           />
           <${StatCell}
@@ -213,7 +359,7 @@ export function CostDashboard() {
           <${StatCell}
             label="p50 Latency (avg)"
             value=${`${t.p50Avg}ms`}
-            sub="across models"
+            sub="across entries"
           />
           <${StatCell}
             label="p95 Latency (max)"
@@ -226,14 +372,14 @@ export function CostDashboard() {
 
       ${data.length === 0 ? html`
         <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-6 text-center text-sm text-text-muted">
-          이 시간 창에서 기록된 모델 비용이 없습니다.
+          이 시간 창에서 기록된 ${viewMode.value === 'model' ? '모델' : 'Keeper'} 비용이 없습니다.
         </div>
       ` : html`
         <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
-          <table class="w-full" aria-label=${`${data.length}개 모델의 비용 / 지연`}>
+          <table class="w-full" aria-label=${`${data.length}개 ${viewMode.value === 'model' ? '모델' : 'Keeper'}의 비용 / 지연`}>
             <thead>
               <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-1 text-text-muted">
-                <th scope="col" class="px-2 py-1.5 text-left">model</th>
+                <th scope="col" class="px-2 py-1.5 text-left">${viewMode.value === 'model' ? 'model' : 'keeper'}</th>
                 <th scope="col" class="px-2 py-1.5 text-right">in tok</th>
                 <th scope="col" class="px-2 py-1.5 text-right">out tok</th>
                 <th scope="col" class="px-2 py-1.5 text-right">$ cost</th>
@@ -241,10 +387,13 @@ export function CostDashboard() {
                 <th scope="col" class="px-2 py-1.5 text-right">p50</th>
                 <th scope="col" class="px-2 py-1.5 text-right">p95</th>
                 <th scope="col" class="px-2 py-1.5 text-left">p95 trend</th>
+                ${viewMode.value === 'keeper' ? html`<th scope="col" class="px-2 py-1.5 text-left">top model</th>` : null}
               </tr>
             </thead>
             <tbody>
-              ${data.map(m => html`<${ModelRow} key=${m.model_id} model=${m} maxCost=${maxCost} maxP95=${maxP95} />`)}
+              ${viewMode.value === 'model'
+                ? data.map(m => html`<${ModelRow} key=${(m as DashboardRuntimeModelMetric).model_id} model=${m as DashboardRuntimeModelMetric} maxCost=${maxCost} maxP95=${maxP95} />`)
+                : data.map(k => html`<${KeeperRow} key=${(k as KeeperCostMetric).keeper_name} keeper=${k as KeeperCostMetric} maxCost=${maxCost} maxP95=${maxP95} />`)}
             </tbody>
           </table>
         </div>

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { AgentFailure, failureTypeFromDiagnostic } from './common/agent-failure'
 import { Markdown } from "./common/markdown"
 import { useState } from 'preact/hooks'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
@@ -219,7 +220,10 @@ export function KeeperDiagnosticSummary({
         ${diagnostic?.next_eligible_at_s ? html` -- 다음 응답 가능 ${formatEligible(diagnostic.next_eligible_at_s)}` : null}
       </div>
       ${diagnostic?.last_error
-        ? html`<div class="text-xs text-[var(--bad-light)] leading-relaxed mt-1">${diagnostic.last_error}</div>`
+        ? html`<${AgentFailure}
+            type=${failureTypeFromDiagnostic(diagnostic.last_error, diagnostic.recoverable)}
+            message=${diagnostic.last_error}
+          />`
         : null}
       ${showRawStatus
         ? html`<div class="mt-3 max-h-60 overflow-auto rounded border border-[var(--color-border-default)] bg-[var(--color-bg-page)] custom-scrollbar"><${Markdown} text=${'```text\n' + (detail?.rawText ?? '키퍼 상태를 아직 불러오지 않았습니다.') + '\n```'} /></div>`

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -7,9 +7,11 @@ import { MermaidGraph } from './common/mermaid-graph'
 import { Select } from './common/select'
 import {
   fetchMemorySubsystems,
+  fetchKeeperDecisions,
   type MemorySubsystemsResponse,
   type MemorySubsystemsSynapse,
   type MemorySubsystemsEpisode,
+  type KeeperDecision,
 } from '../api/dashboard'
 import { formatTimeAgo } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
@@ -752,11 +754,178 @@ export function MemorySubsystems() {
         }
       </section>
 
+      <${DecisionsStream} />
+
       ${
         error
           ? html`<div class="text-xs text-[var(--color-status-warn)] mt-2">refresh error: ${error}</div>`
           : null
       }
     </div>
+  `
+}
+
+const DECISION_REFRESH_MS = 30_000
+
+function DecisionsStream() {
+  const state = useSignal<{
+    loading: boolean
+    error: string | null
+    data: KeeperDecision[] | null
+  }>({ loading: true, error: null, data: null })
+
+  const keeperFilter = useSignal<string>('')
+  const eventFilter = useSignal<string>('')
+  const outcomeFilter = useSignal<string>('')
+  const limit = useSignal<number>(50)
+
+  async function refresh(sig?: AbortSignal) {
+    try {
+      const resp = await fetchKeeperDecisions(limit.value, { signal: sig })
+      state.value = { loading: false, error: null, data: resp.events }
+    } catch (err) {
+      if (isAbortError(err)) return
+      state.value = {
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+        data: state.value.data,
+      }
+    }
+  }
+
+  useEffect(() => {
+    const ac = new AbortController()
+    refresh(ac.signal)
+    const cleanup = setupVisibleAutoRefresh(() => refresh(), DECISION_REFRESH_MS)
+    return () => {
+      ac.abort()
+      cleanup()
+    }
+  }, [limit.value])
+
+  const { loading, error, data } = state.value
+  const events = data ?? []
+
+  const knownKeepers = Array.from(new Set(events.map(e => e.keeper_name))).sort()
+  const knownEvents = Array.from(new Set(events.map(e => e.event_type))).sort()
+  const knownOutcomes = Array.from(new Set(events.map(e => e.outcome).filter((o): o is string => o != null))).sort()
+
+  const visible = events.filter(ev => {
+    if (keeperFilter.value && ev.keeper_name !== keeperFilter.value) return false
+    if (eventFilter.value && ev.event_type !== eventFilter.value) return false
+    if (outcomeFilter.value && ev.outcome !== outcomeFilter.value) return false
+    return true
+  })
+
+  const hasFilter = Boolean(keeperFilter.value || eventFilter.value || outcomeFilter.value)
+
+  return html`
+    <section class="flex flex-col gap-3" aria-label="Keeper decisions stream">
+      <div class="flex flex-wrap items-center gap-2">
+        <h3 class="text-sm font-semibold text-text-strong">Decisions Stream</h3>
+        <span class="text-2xs text-text-muted">${visible.length} / ${events.length} events</span>
+        <div class="ml-auto flex items-center gap-2">
+          <${Select}
+            class="px-2 py-1 text-2xs"
+            ariaLabel="Keeper"
+            value=${keeperFilter.value}
+            options=${[
+              { value: '', label: 'all keepers' },
+              ...knownKeepers.map(k => ({ value: k, label: k })),
+            ]}
+            onInput=${(v: string) => { keeperFilter.value = v }}
+          />
+          <${Select}
+            class="px-2 py-1 text-2xs"
+            ariaLabel="Event"
+            value=${eventFilter.value}
+            options=${[
+              { value: '', label: 'all events' },
+              ...knownEvents.map(e => ({ value: e, label: e })),
+            ]}
+            onInput=${(v: string) => { eventFilter.value = v }}
+          />
+          <${Select}
+            class="px-2 py-1 text-2xs"
+            ariaLabel="Outcome"
+            value=${outcomeFilter.value}
+            options=${[
+              { value: '', label: 'all outcomes' },
+              ...knownOutcomes.map(o => ({ value: o, label: o })),
+            ]}
+            onInput=${(v: string) => { outcomeFilter.value = v }}
+          />
+          ${hasFilter
+            ? html`<button
+                class="text-2xs text-text-muted hover:text-text-strong px-2 py-1 border border-card-border/40 rounded"
+                onClick=${() => {
+                  keeperFilter.value = ''
+                  eventFilter.value = ''
+                  outcomeFilter.value = ''
+                }}
+              >clear</button>`
+            : null}
+        </div>
+      </div>
+
+      ${loading && !data
+        ? html`<${LoadingState} label="decisions 로드 중..." />`
+        : error && !data
+          ? html`<div class="text-sm text-[var(--color-status-err)]">decisions 오류: ${error}</div>`
+          : html`
+              <div class="overflow-x-auto rounded border border-card-border/60 bg-[var(--backdrop-deep)]">
+                <table class="w-full text-2xs" aria-label="decision events">
+                  <thead>
+                    <tr class="border-b border-[var(--color-border-default)] text-text-muted uppercase tracking-1">
+                      <th class="px-2 py-1.5 text-left">time</th>
+                      <th class="px-2 py-1.5 text-left">keeper</th>
+                      <th class="px-2 py-1.5 text-left">event</th>
+                      <th class="px-2 py-1.5 text-left">outcome</th>
+                      <th class="px-2 py-1.5 text-left">model</th>
+                      <th class="px-2 py-1.5 text-right">latency</th>
+                      <th class="px-2 py-1.5 text-right">cost</th>
+                      <th class="px-2 py-1.5 text-right">tokens</th>
+                      <th class="px-2 py-1.5 text-left">stop / error</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${visible.map((ev: KeeperDecision) => {
+                      const ts = ev.ts_unix ? formatTimeAgo(ev.ts_unix * 1000) : '—'
+                      const latency = ev.latency_ms != null ? `${Math.round(ev.latency_ms)}ms` : '—'
+                      const cost = ev.cost_usd != null ? `$${ev.cost_usd.toFixed(4)}` : '—'
+                      const tokens = ev.input_tokens != null || ev.output_tokens != null
+                        ? `${ev.input_tokens ?? 0} / ${ev.output_tokens ?? 0}`
+                        : '—'
+                      const stopErr = ev.error_category ?? ev.stop_reason ?? '—'
+                      const rowTone = ev.outcome === 'failure' || ev.error_category
+                        ? 'text-[var(--color-status-err)]'
+                        : ev.outcome === 'partial'
+                          ? 'text-[var(--color-status-warn)]'
+                          : ''
+                      return html`
+                        <tr key=${`${ev.keeper_name}-${ev.ts_unix ?? 0}-${ev.event_type}`}
+                          class="border-b border-[var(--color-border-default)]/40 align-baseline ${rowTone}">
+                          <td class="px-2 py-1.5 font-mono whitespace-nowrap">${ts}</td>
+                          <td class="px-2 py-1.5 font-mono text-[var(--color-accent-fg)]">${ev.keeper_name}</td>
+                          <td class="px-2 py-1.5">
+                            <span class="rounded px-1 py-0.5 bg-[var(--white-10)] text-text-muted">${ev.event_type}</span>
+                          </td>
+                          <td class="px-2 py-1.5">${ev.outcome ?? '—'}</td>
+                          <td class="px-2 py-1.5 font-mono text-text-muted">${ev.model_used ?? '—'}</td>
+                          <td class="px-2 py-1.5 text-right font-mono">${latency}</td>
+                          <td class="px-2 py-1.5 text-right font-mono">${cost}</td>
+                          <td class="px-2 py-1.5 text-right font-mono">${tokens}</td>
+                          <td class="px-2 py-1.5 font-mono text-text-muted">${stopErr}</td>
+                        </tr>
+                      `
+                    })}
+                  </tbody>
+                </table>
+                ${visible.length === 0
+                  ? html`<div class="p-4 text-center text-text-muted">필터에 맞는 결정이 없습니다.</div>`
+                  : null}
+              </div>
+            `}
+    </section>
   `
 }

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1683,3 +1683,124 @@ let keeper_config_json (config : Coord.config) (name : string)
          ("sources", source_provenance_json config m);
          ("metrics", metrics);
        ])
+
+(** Per-keeper cost/latency aggregates for the O4 cost dashboard.
+
+    Reads each keeper's metrics JSONL, extracts cost_usd / latency_ms /
+    token fields, and returns per-keeper totals plus p50/p95 latency
+    percentiles and a model-level cost breakdown.
+
+    This closes the Phase-2 gap between per-model metrics (already in
+    /api/v1/models/metrics) and per-agent spend (required by preview). *)
+let keeper_cost_aggregates_json
+    ~(config : Coord.config)
+    ~(keepers : Keeper_meta.t list)
+    ~(window_minutes : int)
+  : Yojson.Safe.t =
+  let now_ts = Unix.gettimeofday () in
+  let window_sec = float_of_int window_minutes *. 60.0 in
+  let start_ts = now_ts -. window_sec in
+  let keeper_items =
+    List.map (fun (m : Keeper_meta.t) ->
+      let metrics_store = Keeper_types.keeper_metrics_store config m.name in
+      let all_metrics_lines =
+        let dated = Dated_jsonl.read_recent_lines metrics_store 500 in
+        if dated <> [] then dated
+        else
+          let metrics_path = Keeper_types.keeper_metrics_path config m.name in
+          Keeper_memory.read_file_tail_lines metrics_path
+            ~max_bytes:200000 ~max_lines:500
+      in
+      let costs_rev = ref [] in
+      let latencies_rev = ref [] in
+      let input_tokens = ref 0 in
+      let output_tokens = ref 0 in
+      let total_tokens = ref 0 in
+      let model_costs : (string, float) Hashtbl.t = Hashtbl.create 8 in
+      let sample_count = ref 0 in
+      List.iter (fun line ->
+        try
+          let j = Yojson.Safe.from_string line in
+          let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
+          if ts_unix >= start_ts then begin
+            let cost =
+              Safe_ops.json_float_opt "cost_usd" j
+              |> Option.value ~default:0.0
+            in
+            let latency_ms = Safe_ops.json_int ~default:0 "latency_ms" j in
+            let input_t =
+              Safe_ops.json_int_opt "input_tokens" j
+              |> Option.value ~default:0
+            in
+            let output_t =
+              Safe_ops.json_int_opt "output_tokens" j
+              |> Option.value ~default:0
+            in
+            let total_t =
+              Safe_ops.json_int_opt "total_tokens" j
+              |> Option.value ~default:0
+            in
+            let model_used =
+              Safe_ops.json_string ~default:"" "model_used" j
+            in
+            let model_used_norm = normalize_model_name model_used in
+            if cost > 0.0 || latency_ms > 0 then begin
+              costs_rev := cost :: !costs_rev;
+              latencies_rev := float_of_int latency_ms :: !latencies_rev;
+              input_tokens := !input_tokens + input_t;
+              output_tokens := !output_tokens + output_t;
+              total_tokens := !total_tokens + total_t;
+              let prev =
+                Option.value ~default:0.0
+                  (Hashtbl.find_opt model_costs model_used_norm)
+              in
+              Hashtbl.replace model_costs model_used_norm (prev +. cost);
+              incr sample_count;
+            end
+          end
+        with
+        | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ()
+      ) all_metrics_lines;
+      let total_cost = List.fold_left ( +. ) 0.0 !costs_rev in
+      let latency_arr =
+        let arr = Array.of_list !latencies_rev in
+        Array.sort Float.compare arr;
+        arr
+      in
+      let p50_latency =
+        if Array.length latency_arr = 0 then None
+        else Some (percentile latency_arr 50.0)
+      in
+      let p95_latency =
+        if Array.length latency_arr = 0 then None
+        else Some (percentile latency_arr 95.0)
+      in
+      let model_breakdown_json =
+        model_costs
+        |> Hashtbl.to_seq
+        |> List.of_seq
+        |> List.sort (fun (_, ca) (_, cb) -> Float.compare cb ca)
+        |> List.map (fun (model, cost) ->
+             `Assoc [
+               ("model", `String model);
+               ("cost_usd", `Float cost);
+             ])
+      in
+      `Assoc [
+        ("keeper_name", `String m.name);
+        ("total_cost_usd", `Float total_cost);
+        ("total_input_tokens", `Int !input_tokens);
+        ("total_output_tokens", `Int !output_tokens);
+        ("total_tokens", `Int !total_tokens);
+        ("p50_latency_ms", Json_util.float_opt_to_json p50_latency);
+        ("p95_latency_ms", Json_util.float_opt_to_json p95_latency);
+        ("sample_count", `Int !sample_count);
+        ("model_breakdown", `List model_breakdown_json);
+      ]
+    ) keepers
+  in
+  `Assoc [
+    ("keepers", `List keeper_items);
+    ("window_minutes", `Int window_minutes);
+    ("generated_at", `Float now_ts);
+  ]

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1804,3 +1804,99 @@ let keeper_cost_aggregates_json
     ("window_minutes", `Int window_minutes);
     ("generated_at", `Float now_ts);
   ]
+
+(** Read per-keeper [.decisions.jsonl] files and return a unified,
+    time-sorted stream of recent events (turn telemetry, tool_exec,
+    memory_search, etc.).  Each event is normalized to a flat record so
+    the dashboard can render a single chronology without knowing the
+    original schema variants. *)
+let keeper_decisions_json
+    ~(config : Coord.config)
+    ~(keepers : Keeper_meta.t list)
+    ?(limit = 200)
+  : Yojson.Safe.t =
+  let per_keeper_limit = limit * 2 in
+  let all_events =
+    List.concat_map (fun (m : Keeper_meta.t) ->
+      let path = Keeper_types.keeper_decision_log_path config m.name in
+      if not (Fs_compat.file_exists path) then []
+      else
+        let lines =
+          Keeper_memory.read_file_tail_lines path
+            ~max_bytes:500_000 ~max_lines:per_keeper_limit
+        in
+        List.filter_map (fun line ->
+          try
+            let json = Yojson.Safe.from_string line in
+            let ts =
+              match Yojson.Safe.Util.member "ts_unix" json with
+              | `Float f -> f
+              | `Int i -> float_of_int i
+              | _ -> 0.0
+            in
+            let event_type =
+              match Yojson.Safe.Util.member "event" json with
+              | `String s -> s
+              | _ -> "turn"
+            in
+            let keeper_name =
+              match Yojson.Safe.Util.member "keeper_name" json with
+              | `String s -> s
+              | _ -> m.name
+            in
+            Some (ts, json, event_type, keeper_name)
+          with
+          | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+        ) lines
+    ) keepers
+  in
+  let sorted =
+    List.sort (fun (ta, _, _, _) (tb, _, _, _) -> compare tb ta) all_events
+  in
+  let rec take n = function
+    | [] -> []
+    | _ when n <= 0 -> []
+    | x :: xs -> x :: take (n - 1) xs
+  in
+  let top = take limit sorted in
+  let items =
+    List.map (fun (_ts, json, event_type, keeper_name) ->
+      let m = Yojson.Safe.Util.member in
+      let string_or_null key =
+        match m key json with `String s -> `String s | _ -> `Null
+      in
+      let float_or_null key =
+        match m key json with
+        | `Float f -> `Float f
+        | `Int i -> `Float (float_of_int i)
+        | _ -> `Null
+      in
+      let int_or_null key =
+        match m key json with
+        | `Int i -> `Int i
+        | `Float f -> `Int (int_of_float f)
+        | _ -> `Null
+      in
+      `Assoc [
+        ("ts_unix", float_or_null "ts_unix");
+        ("keeper_name", `String keeper_name);
+        ("event_type", `String event_type);
+        ("outcome", string_or_null "outcome");
+        ("model_used", string_or_null "model_used");
+        ("latency_ms", float_or_null "latency_ms");
+        ("cost_usd", float_or_null "cost_usd");
+        ("input_tokens", int_or_null "input_tokens");
+        ("output_tokens", int_or_null "output_tokens");
+        ("stop_reason", string_or_null "stop_reason");
+        ("error_category", string_or_null "error_category");
+        ("tool", string_or_null "tool");
+        ("duration_ms", float_or_null "duration_ms");
+        ("match_count", int_or_null "match_count");
+      ]
+    ) top
+  in
+  `Assoc [
+    ("events", `List items);
+    ("limit", `Int limit);
+    ("generated_at", `Float (Unix.gettimeofday ()));
+  ]

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -108,12 +108,19 @@ type model_stats = {
   buckets : bucket_metric list;
 }
 
+type latency_bucket = {
+  lo_ms : int;
+  hi_ms : int option;
+  count : int;
+}
+
 type aggregate = {
   window_minutes : int;
   bucket_minutes : int;
   models : model_stats list;
   total_entries : int;
   total_error_entries : int;
+  latency_buckets : latency_bucket list;
 }
 
 (* ── Percentile ───────────────────────���─────────────────── *)
@@ -1104,6 +1111,26 @@ let group_entries_by_model (entries : raw_entry list)
   in
   StringMap.fold (fun model es acc -> (model, es) :: acc) tbl []
 
+let latency_histogram (entries : raw_entry list) : latency_bucket list =
+  let bins = [| 0; 0; 0; 0 |] in
+  List.iter
+    (fun e ->
+      match e.latency_ms with
+      | None -> ()
+      | Some ms ->
+          let ms = int_of_float ms in
+          if ms < 1000 then bins.(0) <- bins.(0) + 1
+          else if ms < 4000 then bins.(1) <- bins.(1) + 1
+          else if ms < 16000 then bins.(2) <- bins.(2) + 1
+          else bins.(3) <- bins.(3) + 1)
+    entries;
+  [
+    { lo_ms = 0; hi_ms = Some 1000; count = bins.(0) };
+    { lo_ms = 1000; hi_ms = Some 4000; count = bins.(1) };
+    { lo_ms = 4000; hi_ms = Some 16000; count = bins.(2) };
+    { lo_ms = 16000; hi_ms = None; count = bins.(3) };
+  ]
+
 (* ── Public API ─────────────────────────────────────────── *)
 
 let compute ~base_path ~window_minutes : aggregate =
@@ -1115,7 +1142,8 @@ let compute ~base_path ~window_minutes : aggregate =
   in
   { window_minutes; bucket_minutes = 0; models;
     total_entries = List.length entries;
-    total_error_entries }
+    total_error_entries;
+    latency_buckets = latency_histogram entries }
 
 let compute_with_buckets ~base_path ~window_minutes ~bucket_minutes : aggregate =
   let bucket_minutes = max 1 bucket_minutes in
@@ -1143,7 +1171,8 @@ let compute_with_buckets ~base_path ~window_minutes ~bucket_minutes : aggregate 
   { window_minutes; bucket_minutes;
     models = models_with_buckets;
     total_entries = List.length entries;
-    total_error_entries }
+    total_error_entries;
+    latency_buckets = latency_histogram entries }
 
 let aggregate_buckets ~base_path ~window_min ~bucket_min : model_bucketed list =
   let since_unix = Time_compat.now () -. (Float.of_int window_min *. 60.0) in
@@ -1252,11 +1281,19 @@ let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
     ]
 
 let to_json (agg : aggregate) : Yojson.Safe.t =
+  let latency_bucket_to_json b =
+    `Assoc
+      [ ("lo", `Int b.lo_ms)
+      ; ("hi", match b.hi_ms with Some n -> `Int n | None -> `Null)
+      ; ("n", `Int b.count)
+      ]
+  in
   `Assoc
     [ ("window_minutes", `Int agg.window_minutes)
     ; ("bucket_minutes", `Int agg.bucket_minutes)
     ; ("total_entries", `Int agg.total_entries)
     ; ("total_error_entries", `Int agg.total_error_entries)
+    ; ("latency_buckets", `List (List.map latency_bucket_to_json agg.latency_buckets))
     ; ("models", `List (List.map model_stats_to_json agg.models))
     ]
 

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -138,6 +138,15 @@ let add_routes ~sw router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/heuristics/coverage" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let limit = int_query_param req "limit" ~default:100 in
+         let report = Heuristic_metrics.recent_coverage limit in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string
+              (Heuristic_metrics.coverage_report_to_json report))
+           reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/stress" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let limit = int_query_param req "limit" ~default:100 in

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -105,3 +105,22 @@ let add_routes ~sw router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/keeper-decisions" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let limit = int_query_param req "limit" ~default:200 in
+         let config = state.Mcp_server.room_config in
+         let keeper_names = Dashboard_http_keeper.keeper_names config in
+         let keepers =
+           List.filter_map (fun name ->
+             match Keeper_types.read_meta config name with
+             | Ok (Some m) -> Some m
+             | _ -> None
+           ) keeper_names
+         in
+         let json =
+           Dashboard_http_keeper.keeper_decisions_json
+             ~config ~keepers ~limit
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -124,3 +124,17 @@ let add_routes ~sw router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/heuristics" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let limit = int_query_param req "limit" ~default:100 in
+         let events = Heuristic_metrics.recent limit in
+         let json =
+           `Assoc [
+             ("limit", `Int limit);
+             ("count", `Int (List.length events));
+             ("events", `List events);
+           ]
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -86,3 +86,22 @@ let add_routes ~sw router =
                    (Yojson.Safe.to_string
                       (`Assoc [ ("error", `String message) ])))
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/keeper-costs" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let window = int_query_param req "window" ~default:1440 in
+         let config = state.Mcp_server.room_config in
+         let keeper_names = Dashboard_http_keeper.keeper_names config in
+         let keepers =
+           List.filter_map (fun name ->
+             match Keeper_types.read_meta config name with
+             | Ok (Some m) -> Some m
+             | _ -> None
+           ) keeper_names
+         in
+         let json =
+           Dashboard_http_keeper.keeper_cost_aggregates_json
+             ~config ~keepers ~window_minutes:window
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -138,3 +138,17 @@ let add_routes ~sw router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/stress" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let limit = int_query_param req "limit" ~default:100 in
+         let events = Agent_stress.recent limit in
+         let json =
+           `Assoc [
+             ("limit", `Int limit);
+             ("count", `Int (List.length events));
+             ("events", `List events);
+           ]
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)


### PR DESCRIPTION
## Summary
- Implements Kimi Agent Design System v2.0 sec06 6.1.1 ARIA tooltip pattern.
- Uses `cloneElement` to inject `aria-describedby` and event handlers without hitting `htm/preact` spread limitations.
- Composes existing trigger handlers so callers are not disrupted.
- 7-test a11y suite covers axe, hover/focus/ESC interactions, and handler preservation.

## Test plan
- [x] `npx vitest run src/components/common/tooltip.a11y.test.ts` — 7 passed
- [x] Full dashboard suite — 5215 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)