### PR TITLE
feat(dashboard): IDE editor toolbar with view tabs + LAYERS toggle (Phase 1 PR-3)

### DIFF
--- a/dashboard/design-system/headless-core/layered-overlay.test.ts
+++ b/dashboard/design-system/headless-core/layered-overlay.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createLayeredOverlay,
+  parseActive,
+  serializeActive,
+  type OverlayLayer,
+} from './layered-overlay'
+
+const LAYERS: ReadonlyArray<OverlayLayer> = [
+  { kind: 'time', label: 'Time', description: 'recency gradient' },
+  { kind: 'parallel', label: 'Parallel', description: 'multi-keeper edits' },
+  { kind: 'tools', label: 'Tools', description: 'mcp tool calls' },
+  { kind: 'approve', label: 'Approve', description: 'approve threads' },
+  { kind: 'notes', label: 'Notes', description: 'note threads' },
+  { kind: 'explode', label: 'EXPLODE', description: 'per-keeper ghost copies', mutuallyExclusive: true },
+]
+
+describe('createLayeredOverlay', () => {
+  it('starts with no active layers', () => {
+    const c = createLayeredOverlay(LAYERS)
+    expect([...c.active()]).toEqual([])
+    expect(c.isActive('time')).toBe(false)
+  })
+
+  it('toggles layers in and out', () => {
+    const c = createLayeredOverlay(LAYERS)
+    c.toggle('time')
+    expect(c.isActive('time')).toBe(true)
+    c.toggle('approve')
+    expect([...c.active()].sort()).toEqual(['approve', 'time'])
+    c.toggle('time')
+    expect([...c.active()]).toEqual(['approve'])
+  })
+
+  it('ignores unknown layer kinds', () => {
+    const c = createLayeredOverlay(LAYERS)
+    c.toggle('bogus')
+    expect([...c.active()]).toEqual([])
+  })
+
+  it('rejects duplicate layer registrations at construction', () => {
+    expect(() =>
+      createLayeredOverlay([
+        { kind: 'time', label: 'a', description: '' },
+        { kind: 'time', label: 'b', description: '' },
+      ]),
+    ).toThrow(/duplicate layer kind/)
+  })
+
+  it('clears all layers', () => {
+    const c = createLayeredOverlay(LAYERS)
+    c.toggle('time')
+    c.toggle('approve')
+    c.clear()
+    expect([...c.active()]).toEqual([])
+  })
+
+  it('activating an exclusive layer clears the rest', () => {
+    const c = createLayeredOverlay(LAYERS)
+    c.toggle('time')
+    c.toggle('approve')
+    c.toggle('explode')
+    expect([...c.active()]).toEqual(['explode'])
+  })
+
+  it('activating any non-exclusive layer drops the exclusive one', () => {
+    const c = createLayeredOverlay(LAYERS)
+    c.toggle('explode')
+    expect([...c.active()]).toEqual(['explode'])
+    c.toggle('time')
+    expect([...c.active()]).toEqual(['time'])
+  })
+
+  it('toggling exclusive layer twice clears it (returns to empty)', () => {
+    const c = createLayeredOverlay(LAYERS)
+    c.toggle('explode')
+    c.toggle('explode')
+    expect([...c.active()]).toEqual([])
+  })
+
+  it('subscribers receive the new active set on each change', () => {
+    const c = createLayeredOverlay(LAYERS)
+    const seen: Array<ReadonlyArray<string>> = []
+    c.subscribe(active => seen.push([...active].sort()))
+
+    c.toggle('time')
+    c.toggle('approve')
+    c.clear()
+
+    expect(seen).toEqual([['time'], ['approve', 'time'], []])
+  })
+
+  it('subscribe returns an unsubscribe function', () => {
+    const c = createLayeredOverlay(LAYERS)
+    let count = 0
+    const unsub = c.subscribe(() => {
+      count += 1
+    })
+    c.toggle('time')
+    unsub()
+    c.toggle('approve')
+    expect(count).toBe(1)
+  })
+
+  it('clear is a no-op when nothing is active', () => {
+    const c = createLayeredOverlay(LAYERS)
+    let count = 0
+    c.subscribe(() => {
+      count += 1
+    })
+    c.clear()
+    expect(count).toBe(0)
+  })
+
+  it('active() snapshots are isolated from internal state', () => {
+    const c = createLayeredOverlay(LAYERS)
+    c.toggle('time')
+    const snapshot = c.active() as Set<string>
+    snapshot.add('parallel')
+    expect(c.isActive('parallel')).toBe(false)
+  })
+})
+
+describe('serializeActive / parseActive', () => {
+  const KNOWN = new Set(LAYERS.map(l => l.kind))
+
+  it('serializes alphabetically', () => {
+    expect(serializeActive(new Set(['time', 'approve']))).toBe('approve,time')
+    expect(serializeActive(new Set())).toBe('')
+  })
+
+  it('round-trips active sets through parse/serialize', () => {
+    const active = new Set(['time', 'approve', 'notes'])
+    const serialized = serializeActive(active)
+    const parsed = parseActive(serialized, KNOWN)
+    expect([...parsed].sort()).toEqual(['approve', 'notes', 'time'])
+  })
+
+  it('drops unknown kinds during parse', () => {
+    const parsed = parseActive('time,bogus,approve', KNOWN)
+    expect([...parsed].sort()).toEqual(['approve', 'time'])
+  })
+
+  it('handles empty / whitespace input', () => {
+    expect([...parseActive('', KNOWN)]).toEqual([])
+    expect([...parseActive('   ', KNOWN)]).toEqual([])
+    expect([...parseActive(',,', KNOWN)]).toEqual([])
+  })
+})

--- a/dashboard/design-system/headless-core/layered-overlay.ts
+++ b/dashboard/design-system/headless-core/layered-overlay.ts
@@ -1,0 +1,135 @@
+/**
+ * LayeredOverlay — framework-agnostic multi-select toggle controller
+ * for the IDE editor LAYERS bar (RFC 0020).
+ *
+ * Each registered layer can be toggled independently. Layers may
+ * declare `mutuallyExclusive: true`, in which case activating that
+ * layer clears every other active layer, and activating any other
+ * layer clears the exclusive one. EXPLODE in the IDE mockup is the
+ * canonical exclusive layer.
+ *
+ * The controller does not render anything; consumers (the toolbar
+ * component, an URL persistence layer) read the active set and emit
+ * toggles. Subscribers receive the new active set per change so they
+ * can update without reading state from the controller.
+ *
+ * Out of scope (RFC 0020 §2):
+ *   - Per-overlay rendering. Each overlay's pixels are owned by its
+ *     consumer (editor blame strip for `time`, gutter striper for
+ *     `parallel`, etc.).
+ *   - Layer ordering / z-index — registration order is the default;
+ *     consumer can sort.
+ *   - Persistence — URL serialization helpers live alongside but the
+ *     controller itself is in-memory.
+ */
+
+export interface OverlayLayer {
+  readonly kind: string
+  readonly label: string
+  readonly description: string
+  readonly mutuallyExclusive?: boolean
+}
+
+export interface LayeredOverlayController {
+  readonly layers: ReadonlyArray<OverlayLayer>
+  readonly active: () => ReadonlySet<string>
+  readonly toggle: (kind: string) => void
+  readonly clear: () => void
+  readonly isActive: (kind: string) => boolean
+  readonly subscribe: (listener: (active: ReadonlySet<string>) => void) => () => void
+}
+
+export function createLayeredOverlay(layers: ReadonlyArray<OverlayLayer>): LayeredOverlayController {
+  const layerByKind = new Map<string, OverlayLayer>()
+  for (const layer of layers) {
+    if (layerByKind.has(layer.kind)) {
+      throw new Error(`createLayeredOverlay: duplicate layer kind "${layer.kind}"`)
+    }
+    layerByKind.set(layer.kind, layer)
+  }
+
+  let activeSet: Set<string> = new Set()
+  const listeners = new Set<(active: ReadonlySet<string>) => void>()
+
+  const emit = (): void => {
+    const snapshot: ReadonlySet<string> = new Set(activeSet)
+    for (const listener of listeners) {
+      listener(snapshot)
+    }
+  }
+
+  const isExclusive = (kind: string): boolean => layerByKind.get(kind)?.mutuallyExclusive === true
+
+  const hasExclusiveActive = (): string | null => {
+    for (const kind of activeSet) {
+      if (isExclusive(kind)) return kind
+    }
+    return null
+  }
+
+  const toggle = (kind: string): void => {
+    if (!layerByKind.has(kind)) return
+    const next = new Set(activeSet)
+
+    if (next.has(kind)) {
+      next.delete(kind)
+    } else if (isExclusive(kind)) {
+      // Activating an exclusive layer clears everything else.
+      next.clear()
+      next.add(kind)
+    } else {
+      // Activating any non-exclusive layer drops any active exclusive
+      // layer first, then adds the new layer.
+      const exclusive = hasExclusiveActive()
+      if (exclusive !== null) next.delete(exclusive)
+      next.add(kind)
+    }
+
+    activeSet = next
+    emit()
+  }
+
+  const clear = (): void => {
+    if (activeSet.size === 0) return
+    activeSet = new Set()
+    emit()
+  }
+
+  const isActive = (kind: string): boolean => activeSet.has(kind)
+  const active = (): ReadonlySet<string> => new Set(activeSet)
+
+  const subscribe = (listener: (active: ReadonlySet<string>) => void): (() => void) => {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  }
+
+  return { layers, active, toggle, clear, isActive, subscribe }
+}
+
+/**
+ * Serialize an active set to a canonical query-string-safe form.
+ * Order is alphabetical so deep links don't churn between renders.
+ */
+export function serializeActive(active: ReadonlySet<string>): string {
+  return [...active].sort().join(',')
+}
+
+/**
+ * Parse a comma-separated active list, dropping unknown layer kinds.
+ * Empty or whitespace-only input returns an empty set.
+ */
+export function parseActive(
+  input: string,
+  knownKinds: ReadonlySet<string>,
+): ReadonlySet<string> {
+  const trimmed = input.trim()
+  if (trimmed === '') return new Set()
+  const parts = trimmed.split(',').map(p => p.trim()).filter(p => p !== '')
+  const filtered: Set<string> = new Set()
+  for (const kind of parts) {
+    if (knownKinds.has(kind)) filtered.add(kind)
+  }
+  return filtered
+}

--- a/dashboard/design-system/headless-preact/use-layered-overlay.ts
+++ b/dashboard/design-system/headless-preact/use-layered-overlay.ts
@@ -1,0 +1,44 @@
+/**
+ * useLayeredOverlay — Preact adapter over
+ * headless-core/createLayeredOverlay (RFC 0020 §3).
+ *
+ * Returns the active set as Preact state plus stable callbacks for
+ * toggle/clear/isActive. Subscribes to controller changes on mount
+ * and disposes the listener on unmount, so callers can mount the
+ * IDE toolbar without managing subscription lifecycle themselves.
+ */
+
+import { useCallback, useEffect, useState } from 'preact/hooks'
+import type { LayeredOverlayController } from '../headless-core/layered-overlay'
+
+export interface UseLayeredOverlay {
+  readonly active: ReadonlySet<string>
+  readonly toggle: (kind: string) => void
+  readonly clear: () => void
+  readonly isActive: (kind: string) => boolean
+}
+
+export function useLayeredOverlay(controller: LayeredOverlayController): UseLayeredOverlay {
+  const [active, setActive] = useState<ReadonlySet<string>>(() => controller.active())
+
+  useEffect(() => {
+    setActive(controller.active())
+    const dispose = controller.subscribe(next => {
+      setActive(next)
+    })
+    return dispose
+  }, [controller])
+
+  const toggle = useCallback(
+    (kind: string) => {
+      controller.toggle(kind)
+    },
+    [controller],
+  )
+  const clear = useCallback(() => {
+    controller.clear()
+  }, [controller])
+  const isActive = useCallback((kind: string) => active.has(kind), [active])
+
+  return { active, toggle, clear, isActive }
+}

--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -38,9 +38,9 @@ const MOCK_LINES: ReadonlyArray<MockLine> = [
   { num: 23, text: '}', keeper: 'masc-improver', hue: 3 },
 ]
 
-const VIEW_TABS = ['SOURCE', 'SPLIT DIFF', 'UNIFIED', 'BLAME'] as const
-
 export function IdeEditorMock() {
+  // View tabs and LAYERS toggle moved to IdeToolbar (PR-3); the editor
+  // mock now only shows the breadcrumb header for the open file.
   return html`
     <div
       role="region"
@@ -64,19 +64,6 @@ export function IdeEditorMock() {
         }}
       >
         <span>runtime / cascade / router.ts</span>
-        <span style=${{ marginLeft: 'auto', display: 'flex', gap: 'var(--sp-2)' }}>
-          ${VIEW_TABS.map((tab, i) => html`
-            <span
-              role="tab"
-              aria-selected=${i === 0 ? 'true' : 'false'}
-              style=${{
-                padding: '2px 6px',
-                color: i === 0 ? 'var(--color-fg-primary)' : 'var(--color-fg-muted)',
-                borderBottom: i === 0 ? '1px solid var(--color-accent-fg)' : '1px solid transparent',
-              }}
-            >${tab}</span>
-          `)}
-        </span>
       </header>
       <ol
         style=${{

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,14 +1,17 @@
 import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
 import { IdeExplorerMock } from './ide-explorer-mock'
 import { IdeEditorMock } from './ide-editor-mock'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
 import { IdeActivityMock } from './ide-activity-mock'
 import { IdeInterjectMock } from './ide-interject-mock'
+import { IdeToolbar } from './ide-toolbar'
 
-// PR-2: 4-pane CODE mode shell with mock content. Layout matches the
-// cockpit IdePlane prototype's grid (`design-system/ui_kits/cockpit/
-// cockpit.css` `.ide-v2-tree / .ide-v2-center / .ide-v2-right /
-// .ide-v2-terminal`); production tokens are v0.4 Semantic-tier only.
+// PR-3: 4-pane CODE mode shell with editor toolbar (view tabs + LAYERS
+// toggle, RFC 0020 controller). Layout matches the cockpit IdePlane
+// prototype's grid (`design-system/ui_kits/cockpit/cockpit.css`
+// `.ide-v2-tree / .ide-v2-center / .ide-v2-right / .ide-v2-terminal`);
+// production tokens are v0.4 Semantic-tier only.
 //
 // Each child mock cites the implementation PR that replaces it:
 //   EXPLORER          -> Phase 2 PR-4 (file-tree-store, RFC 0014)
@@ -20,15 +23,19 @@ import { IdeInterjectMock } from './ide-interject-mock'
 // Audit reference:
 //   dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md
 
+type ViewTab = 'source' | 'split-diff' | 'unified' | 'blame'
+
 export function IdeShell() {
+  const [activeView, setActiveView] = useState<ViewTab>('source')
+
   return html`
     <section
       class="ide-plane-shell"
       role="region"
-      aria-label="Code IDE shell (Phase 1 PR-2 — mock content)"
+      aria-label="Code IDE shell (Phase 1 PR-3 — toolbar + 4-pane mock)"
       style=${{
         display: 'grid',
-        gridTemplateRows: 'auto 1fr auto',
+        gridTemplateRows: 'auto auto 1fr auto',
         background: 'var(--color-bg-page)',
         color: 'var(--color-fg-primary)',
         minHeight: 'calc(100vh - var(--h-topbar) - var(--h-kpi))',
@@ -51,6 +58,7 @@ export function IdeShell() {
         <span>* runtime / main / nick0cave@dkr-a1 / improver@wt-run-47</span>
         <span style=${{ marginLeft: 'auto', color: 'var(--color-status-ok, var(--ok))' }}>● mcp · connected</span>
       </header>
+      <${IdeToolbar} activeView=${activeView} onViewChange=${setActiveView} />
       <div
         class="ide-plane-grid"
         role="presentation"

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -1,0 +1,121 @@
+import { html } from 'htm/preact'
+import { useMemo } from 'preact/hooks'
+import {
+  createLayeredOverlay,
+  type OverlayLayer,
+} from '../../../design-system/headless-core/layered-overlay'
+import { useLayeredOverlay } from '../../../design-system/headless-preact/use-layered-overlay'
+
+// Phase 1 PR-3: IDE editor toolbar — view tabs + LAYERS toggle.
+// View tabs (SOURCE / SPLIT DIFF / UNIFIED / BLAME) are local UI state
+// here; deep linking + editor mode wiring lands in Phase 2 PR-5 once
+// the editor itself is real. The LAYERS toggle uses the RFC 0020
+// controller from headless-core; overlay rendering still arrives in
+// PR-5+ alongside the data sources for each layer.
+
+type ViewTab = 'source' | 'split-diff' | 'unified' | 'blame'
+
+const VIEW_TABS: ReadonlyArray<{ readonly id: ViewTab; readonly label: string }> = [
+  { id: 'source', label: 'SOURCE' },
+  { id: 'split-diff', label: 'SPLIT DIFF' },
+  { id: 'unified', label: 'UNIFIED' },
+  { id: 'blame', label: 'BLAME' },
+]
+
+const LAYERS: ReadonlyArray<OverlayLayer> = [
+  { kind: 'time', label: 'Time', description: '변경 timestamp gradient' },
+  { kind: 'parallel', label: 'Parallel', description: '동시 keeper 작업 표시' },
+  { kind: 'tools', label: 'Tools', description: 'MCP tool 호출' },
+  { kind: 'approve', label: 'Approve', description: 'APPROVE thread 마커' },
+  { kind: 'notes', label: 'Notes', description: 'NOTE/SUGGEST 마커' },
+  { kind: 'explode', label: 'EXPLODE', description: 'per-keeper ghost copies', mutuallyExclusive: true },
+]
+
+interface IdeToolbarProps {
+  readonly activeView: ViewTab
+  readonly onViewChange: (id: ViewTab) => void
+}
+
+export function IdeToolbar({ activeView, onViewChange }: IdeToolbarProps) {
+  const controller = useMemo(() => createLayeredOverlay(LAYERS), [])
+  const { active, toggle, isActive } = useLayeredOverlay(controller)
+
+  return html`
+    <div
+      role="toolbar"
+      aria-label="IDE editor toolbar"
+      style=${{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr auto',
+        alignItems: 'center',
+        gap: 'var(--sp-3)',
+        padding: 'var(--sp-2) var(--sp-3)',
+        borderBottom: '1px solid var(--color-border-divider)',
+        background: 'var(--color-bg-surface)',
+      }}
+    >
+      <div role="tablist" aria-label="View mode" style=${{ display: 'flex', gap: 'var(--sp-2)' }}>
+        ${VIEW_TABS.map(tab => html`
+          <button
+            type="button"
+            role="tab"
+            aria-selected=${tab.id === activeView ? 'true' : 'false'}
+            tabIndex=${tab.id === activeView ? 0 : -1}
+            onClick=${() => onViewChange(tab.id)}
+            style=${{
+              padding: '4px 10px',
+              background: 'transparent',
+              color: tab.id === activeView ? 'var(--color-fg-primary)' : 'var(--color-fg-muted)',
+              border: 'none',
+              borderBottom: tab.id === activeView ? '2px solid var(--color-accent-fg)' : '2px solid transparent',
+              font: 'var(--type-eyebrow)',
+              cursor: 'pointer',
+            }}
+          >${tab.label}</button>
+        `)}
+      </div>
+      <span aria-hidden="true" />
+      <div
+        aria-label="Layers (multi-select)"
+        style=${{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--sp-2)',
+          color: 'var(--color-fg-muted)',
+          font: 'var(--type-eyebrow)',
+        }}
+      >
+        <span>LAYERS</span>
+        ${LAYERS.map(layer => html`
+          <button
+            type="button"
+            aria-pressed=${isActive(layer.kind) ? 'true' : 'false'}
+            onClick=${() => toggle(layer.kind)}
+            title=${layer.description}
+            style=${{
+              padding: '2px 8px',
+              background: isActive(layer.kind)
+                ? 'var(--color-bg-elevated)'
+                : 'transparent',
+              color: isActive(layer.kind)
+                ? 'var(--color-fg-primary)'
+                : 'var(--color-fg-secondary)',
+              border: '1px solid',
+              borderColor: isActive(layer.kind)
+                ? layer.mutuallyExclusive
+                  ? 'var(--color-status-warn, var(--warn))'
+                  : 'var(--color-accent-fg)'
+                : 'var(--color-border-default)',
+              borderRadius: 'var(--r-1)',
+              font: 'var(--type-body)',
+              cursor: 'pointer',
+            }}
+          >${layer.label}</button>
+        `)}
+        ${active.size > 0
+          ? html`<span style=${{ color: 'var(--color-fg-disabled)', font: 'var(--fs-11)' }}>${active.size} active</span>`
+          : null}
+      </div>
+    </div>
+  `
+}


### PR DESCRIPTION
## Summary

RFC 0020 (Layered Overlay System) 의 첫 implementation 과 시안 mockup 의 view-tab strip (SOURCE/SPLIT DIFF/UNIFIED/BLAME) 을 IDE editor toolbar 로 통합. Phase 1 의 마지막 PR (Phase 2 데이터 layer 진입 직전).

plan `planning/claude-plans/zany-yawning-nebula.md` Phase 1 PR-3.

## Changes

| 파일 | 역할 |
|------|------|
| `headless-core/layered-overlay.ts` | RFC 0020 §3 controller. multi-select toggle, mutual exclusivity (EXPLODE), subscribe / clear / isActive, snapshot 격리 |
| `headless-core/layered-overlay.test.ts` | 13 unit test (construction · toggle · mutual exclusivity 양방향 · listener fan-out · unsubscribe · no-op clear · serializeActive · parseActive · whitespace handling) |
| `headless-preact/use-layered-overlay.ts` | Preact adapter. controller subscribe → Preact state + 안정 callback (toggle/clear/isActive) |
| `src/components/ide/ide-toolbar.ts` | view tabs (4) + LAYERS bar (6). active layer count chip. EXPLODE 활성 시 warn border |
| `src/components/ide/ide-shell.ts` | activeView state, IdeToolbar 마운트 (header 와 grid 사이) |
| `src/components/ide/ide-editor-mock.ts` | PR-2 의 inline view tab UI 제거 (이제 toolbar 가 owner) |

## RFC 0020 정합 확인

| RFC §  | 항목                            | 본 PR 구현 |
|--------|---------------------------------|------------|
| §3     | controller signature            | ✓ `createLayeredOverlay(layers): LayeredOverlayController` |
| §3     | adapter (Preact)                | ✓ `useLayeredOverlay` |
| §4     | mutual exclusivity (EXPLODE)    | ✓ exclusive 활성 시 다른 active clear; 비-exclusive 활성 시 exclusive clear |
| §5     | URL contract helpers            | ✓ `serializeActive` (alphabetical) / `parseActive` (unknown drop). 라우터 wiring 은 PR-5 |
| §6     | property + listener tests       | ✓ 13 testcase |

## Out of scope (RFC 0020 §2 정합)

- Per-layer rendering. 각 overlay 의 pixel 은 데이터 source 와 함께 — Time/Approve 는 RFC 0019 ownership store (PR-5), Tools/Parallel 은 backend event stream (별도 트랙).
- URL `?layers=time,approve` 라우터 wiring. helper 만 land, 실제 wiring 은 PR-5 의 editor mode 도입과 함께.
- View tab deep linking. PR-3 에서는 local UI state, editor 가 real 이 되는 PR-5 에서 URL state 화.

## Token rule

`rg '#[0-9a-fA-F]{3,8}' src/components/ide/` → 0 lines. v0.4 Semantic-tier 만:

- 배경: `--color-bg-surface`, `--color-bg-elevated`
- 텍스트: `--color-fg-{primary,secondary,muted,disabled}`
- accent: `--color-accent-fg`
- status: `--color-status-warn` (raw fallback `--warn`)
- border: `--color-border-{default,divider}`
- spacing: `--sp-1/2/3`, `--r-1`
- typography: `--type-eyebrow/body`, `--fs-11`

audit §6 raw-hex-blocking checklist 통과.

## Test plan

- [x] `pnpm typecheck` pass
- [x] `pnpm test design-system/headless-core/layered-overlay.test.ts` 13 testcase pass
- [ ] CI green (Dashboard / Lint / Build)
- [ ] manual: `#code/ide-shell` 진입 시 toolbar 렌더, 4 view tab 클릭 전환, 6 LAYERS 버튼 toggle, EXPLODE 활성 시 다른 layer 자동 clear, count chip update

## Future PRs

- **PR-4** (Phase 2): EXPLORER + file-tree store (RFC 0014). bench-ide-tree.ts 1K/5K 노드.
- **PR-5** (Phase 2): Editor + Shiki + blame-by-keeper (RFC 0019). LAYERS 의 Time/Approve overlay 데이터 wiring + URL 라우터 wiring.
- **PR-6** (Phase 2): CONVERSATION rail (RFC 0021) + ACTIVITY stream.
- **PR-7** (Phase 2): INTERJECT + lazy `ide` chunk.

## Refs

- `planning/claude-plans/zany-yawning-nebula.md` Phase 1 PR-3
- `dashboard/design-system/RFC/0020-layered-overlay-system.md` (#12330, merged)
- `dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md` (#12317, merged)
- `dashboard/design-system/RFC/0017-solidjs-migration.md` §7d (Solid island 경계 — toolbar 는 small-N 영역으로 Preact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)