### PR TITLE
fix(ci): race-condition guard for draft-automerge on merged PRs (#12332)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -69,6 +69,24 @@ jobs:
               .map((s) => s.trim().toLowerCase())
               .filter(Boolean);
 
+            // Race-condition defence: the event payload reflects the PR state at
+            // trigger time. If the PR was merged/closed between trigger and job
+            // execution, bail out gracefully instead of failing on irreversible
+            // mutations (e.g. convert-to-draft on a merged PR).
+            const { data: currentPr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber
+            });
+            if (currentPr.merged) {
+              core.info(`PR #${pullNumber} is already merged. Skipping draft guard.`);
+              return;
+            }
+            if (currentPr.state === "closed") {
+              core.info(`PR #${pullNumber} is already closed. Skipping draft guard.`);
+              return;
+            }
+
             const prAuthorLogin = (pr.user?.login || "").toLowerCase();
             const prAuthorType = pr.user?.type;
             const humanAuthored =


### PR DESCRIPTION
## Summary
Adds a current-state API check at the start of the draft-automerge-guard script to handle the race condition where a PR is merged between workflow trigger and job execution.

## Problem
The guard reads PR state from `github.event.pull_request`, which reflects the state at trigger time. If the PR is merged before the job starts, the script attempts to convert a merged PR back to draft and fails with:
- `Resource not accessible by integration`

## Fix
Query the current PR state via `github.rest.pulls.get` before any guard logic runs. Exit gracefully if already merged or closed.

## Test plan
- [ ] Verify the PR Automation workflow still runs on open PRs
- [ ] Verify no regression in label-and-review job (depends on draft-automerge-guard success)

Fixes #12332