### PR TITLE
[codex] Fail closed agent draft approval gate

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -191,11 +191,10 @@ jobs:
             let shouldRestoreDraft = false;
             let shouldDisableAutoMerge = false;
             let ciGatePolicyFailure = false;
-            // When a guarded PR is already in the safe invariant
-            // (draft=true, no auto-merge), treating "missing approval" as a
-            // policy violation is a false positive: the guard has nothing left
-            // to enforce because the PR is already draft-only. This covers the
-            // initial draft open path as well as explicit convert-to-draft.
+            // Keep the required guard fail-closed even while the PR is draft.
+            // A previous success on the same head SHA can otherwise let a
+            // ready_for_review + immediate merge race reuse that success before
+            // the new guard run has time to fail.
             const safeDraftOnlyState = current.isDraft && !hasAutoMergeRequest;
             const approvalRequired =
               looksAgentAuthored ||
@@ -204,8 +203,7 @@ jobs:
               bypassPolicyFailures.length > 0;
             const missingVerifiedApproval =
               approvalRequired &&
-              verifiedBypassLabels.length === 0 &&
-              !safeDraftOnlyState;
+              verifiedBypassLabels.length === 0;
             if (missingVerifiedApproval) {
               const expected =
                 bypassLabels.length > 0 ? bypassLabels.join(", ") : "(no configured bypass labels)";
@@ -213,7 +211,7 @@ jobs:
               shouldRestoreDraft = !current.isDraft;
               shouldDisableAutoMerge = hasAutoMergeRequest;
             }
-            if (bypassPolicyFailures.length > 0 && !safeDraftOnlyState) {
+            if (bypassPolicyFailures.length > 0) {
               shouldRestoreDraft = !current.isDraft;
               shouldDisableAutoMerge = hasAutoMergeRequest;
             }

--- a/scripts/ci/check-agent-draft-policy.sh
+++ b/scripts/ci/check-agent-draft-policy.sh
@@ -71,11 +71,6 @@ if [[ "$looks_agent_authored" -eq 0 ]]; then
   exit 0
 fi
 
-if [[ "$(lower "$pr_is_draft")" == "true" ]]; then
-  echo "agent draft policy: pass, agent PR remains draft"
-  exit 0
-fi
-
 bypass_present=0
 IFS=',' read -r -a bypass_labels <<<"$bypass_labels_csv"
 for label in "${bypass_labels[@]}"; do
@@ -96,5 +91,5 @@ if [[ "$bypass_present" -eq 1 ]]; then
   exit 0
 fi
 
-echo "::error title=Agent draft policy violation::agent-like PR '${pr_head_ref}' is ready without an approved bypass label (${bypass_labels_csv}). Keep it draft or add an approved human bypass label."
+echo "::error title=Agent draft policy violation::agent-like PR '${pr_head_ref}' lacks an approved human bypass label (${bypass_labels_csv}). Keep the required gate red until a human adds an approved bypass label."
 exit 1

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -101,11 +101,12 @@ let test_agent_draft_policy_script () =
   in
   check int "non pull_request events are ignored" 0
     (run_agent_draft_policy [ ("GITHUB_EVENT_NAME", "push") ]);
-  check int "draft agent PR passes" 0
-    (run_agent_draft_policy (("PR_IS_DRAFT", "true") :: base));
-  check int "live draft state overrides stale ready event" 0
+  check bool "draft agent PR without bypass fails closed" true
+    (run_agent_draft_policy (("PR_IS_DRAFT", "true") :: base) <> 0);
+  check bool "live draft state does not bypass approval gate" true
     (run_agent_draft_policy
-       (("PR_LIVE_IS_DRAFT", "true") :: ("PR_IS_DRAFT", "false") :: base));
+       (("PR_LIVE_IS_DRAFT", "true") :: ("PR_IS_DRAFT", "false") :: base)
+    <> 0);
   check bool "live ready state overrides stale draft event" true
     (run_agent_draft_policy
        (("PR_LIVE_IS_DRAFT", "false") :: ("PR_IS_DRAFT", "true") :: base)
@@ -131,6 +132,11 @@ let test_agent_draft_policy_script () =
   check int "ready agent PR with bypass label passes" 0
     (run_agent_draft_policy
        (("PR_IS_DRAFT", "false")
+       :: ("PR_LABELS", "enhancement,human-approved-ready")
+       :: List.remove_assoc "PR_LABELS" base));
+  check int "draft agent PR with bypass label passes" 0
+    (run_agent_draft_policy
+       (("PR_IS_DRAFT", "true")
        :: ("PR_LABELS", "enhancement,human-approved-ready")
        :: List.remove_assoc "PR_LABELS" base));
   check int "ready non-agent PR passes" 0
@@ -184,7 +190,10 @@ let test_pr_automation_draft_guard_contracts () =
   check bool "post-merge skip runs before draft restore mutation" true
     (match live_state_skip, draft_restore with
      | Some skip_pos, Some restore_pos -> skip_pos < restore_pos
-     | _ -> false)
+     | _ -> false);
+  check bool "draft-only state does not suppress missing approval" true
+    (file_not_contains_pattern ".github/workflows/pr-automation.yml"
+       "verifiedBypassLabels.length === 0 &&\n              !safeDraftOnlyState")
 
 let test_health_and_ci_runner_diagnostics () =
   check bool "health snapshot records baseline source" true


### PR DESCRIPTION
## Summary

- Keep the draft/approval guard red for agent-like PRs until a verified human bypass label is present, even while the PR is still draft.
- Align the CI Gate shell policy so draft agent PRs no longer leave a reusable green check on the head SHA.
- Update source-guard tests to cover the fail-closed draft path and prevent `safeDraftOnlyState` from suppressing missing approval.

## Root Cause

PR #12339 showed the remaining race: the draft-open `Draft Auto-Merge Guard` success stayed attached to the same head SHA. A later `ready_for_review` event was merged within seconds, before the new guard run could fail and before `convertPullRequestToDraft` could repair state. Because the repair mutation can fail with `Resource not accessible by integration`, the only reliable repo-local gate is to avoid producing a green required guard before human approval exists.

## Validation

- `scripts/dune-local.sh build test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `git diff --check`

Refs #9738
Refs #12332