### PR TITLE
Reduce routine keeper runtime log noise

### DIFF
--- a/lib/auth_resolve.ml
+++ b/lib/auth_resolve.ml
@@ -104,7 +104,7 @@ let emit_resolution_trace ~cascade ~keeper_id ~provider_label ~outcome =
   let keeper_label = Option.value keeper_id ~default:"-" in
   match outcome with
   | Ok { source; _ } ->
-      Log.Auth.info
+      Log.Auth.debug
         ?keeper_name:keeper_id
         "auth_resolve: cascade=%s provider=%s keeper=%s outcome=ok source=%s"
         cascade provider_label keeper_label

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -654,9 +654,14 @@ let refresh_once ~sw ~net
         st.degraded_reason <- None);
     match compute_judgments ~masc_tools ~dispatch ~build_facts with
     | Ok (model_used, generated_at, expires_at, judgments) ->
-        Log.Governance.info
-          "refresh_once: ok model=%s judgments=%d"
-          model_used (List.length judgments);
+        if judgments = [] then
+          Log.Governance.debug
+            "refresh_once: ok model=%s judgments=%d"
+            model_used 0
+        else
+          Log.Governance.info
+            "refresh_once: ok model=%s judgments=%d"
+            model_used (List.length judgments);
         append_judgments base_path judgments;
         with_lock st (fun () ->
             st.refreshing <- false;

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1692,16 +1692,26 @@ let keeper_config_json (config : Coord.config) (name : string)
 
     This closes the Phase-2 gap between per-model metrics (already in
     /api/v1/models/metrics) and per-agent spend (required by preview). *)
+let percentile_sorted_float (sorted : float array) (p : float) : float =
+  let n = Array.length sorted in
+  if n = 0 then 0.0
+  else
+    let rank = p /. 100.0 *. Float.of_int (n - 1) in
+    let lo = int_of_float (floor rank) in
+    let hi = min (lo + 1) (n - 1) in
+    let frac = rank -. Float.of_int lo in
+    sorted.(lo) *. (1.0 -. frac) +. sorted.(hi) *. frac
+
 let keeper_cost_aggregates_json
     ~(config : Coord.config)
-    ~(keepers : Keeper_meta.t list)
+    ~(keepers : Keeper_types.keeper_meta list)
     ~(window_minutes : int)
   : Yojson.Safe.t =
   let now_ts = Unix.gettimeofday () in
   let window_sec = float_of_int window_minutes *. 60.0 in
   let start_ts = now_ts -. window_sec in
   let keeper_items =
-    List.map (fun (m : Keeper_meta.t) ->
+    List.map (fun (m : Keeper_types.keeper_meta) ->
       let metrics_store = Keeper_types.keeper_metrics_store config m.name in
       let all_metrics_lines =
         let dated = Dated_jsonl.read_recent_lines metrics_store 500 in
@@ -1769,11 +1779,11 @@ let keeper_cost_aggregates_json
       in
       let p50_latency =
         if Array.length latency_arr = 0 then None
-        else Some (percentile latency_arr 50.0)
+        else Some (percentile_sorted_float latency_arr 50.0)
       in
       let p95_latency =
         if Array.length latency_arr = 0 then None
-        else Some (percentile latency_arr 95.0)
+        else Some (percentile_sorted_float latency_arr 95.0)
       in
       let model_breakdown_json =
         model_costs
@@ -1812,12 +1822,13 @@ let keeper_cost_aggregates_json
     original schema variants. *)
 let keeper_decisions_json
     ~(config : Coord.config)
-    ~(keepers : Keeper_meta.t list)
+    ~(keepers : Keeper_types.keeper_meta list)
     ?(limit = 200)
+    ()
   : Yojson.Safe.t =
   let per_keeper_limit = limit * 2 in
   let all_events =
-    List.concat_map (fun (m : Keeper_meta.t) ->
+    List.concat_map (fun (m : Keeper_types.keeper_meta) ->
       let path = Keeper_types.keeper_decision_log_path config m.name in
       if not (Fs_compat.file_exists path) then []
       else

--- a/lib/dashboard/dashboard_http_keeper.mli
+++ b/lib/dashboard/dashboard_http_keeper.mli
@@ -36,6 +36,9 @@
 val keeper_count : Coord.config -> int
 (** Total keepers visible in [config.base_path] meta. *)
 
+val keeper_names : Coord.config -> string list
+(** Keeper names visible in [config.base_path] meta. *)
+
 val running_keeper_count : Coord.config -> int
 (** Counts keepers whose meta indicates an active
     keep-alive runtime.  Used by the dashboard fleet
@@ -71,6 +74,21 @@ val execution_trust_dashboard_json : Coord.config -> Yojson.Safe.t
     every keeper's recent turns + capability metadata
     into a single JSON envelope used by the
     [Server_dashboard_http_execution_surfaces] cache. *)
+
+val keeper_cost_aggregates_json :
+  config:Coord.config ->
+  keepers:Keeper_types.keeper_meta list ->
+  window_minutes:int ->
+  Yojson.Safe.t
+(** Renders per-keeper cost and latency aggregates for the provider dashboard. *)
+
+val keeper_decisions_json :
+  config:Coord.config ->
+  keepers:Keeper_types.keeper_meta list ->
+  ?limit:int ->
+  unit ->
+  Yojson.Safe.t
+(** Renders a recent unified keeper decision/event stream. *)
 
 (** {1 Per-keeper config snapshot} *)
 

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -202,7 +202,7 @@ let prepare_run_context
        decision checkpoint_hygiene.before_tokens checkpoint_hygiene.after_tokens
        max_context before_ratio loaded_checkpoint_present
    else
-     Log.Keeper.info
+     Log.Keeper.debug
        "%s: pre-dispatch compaction skipped decision=%s tokens=%d \
         max_context=%d ratio=%.4f checkpoint=%b"
        meta.name decision checkpoint_hygiene.before_tokens max_context before_ratio

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -73,7 +73,7 @@ let build_turn_context
      | Some hex -> hex
      | None -> "empty"
    in
-   Log.Keeper.info
+   Log.Keeper.debug
      "[substrate:system_prompt] agent=%s turn=%d length=%d hash=%s"
      meta.agent_name (start_turn_count + 1) segment.Keeper_agent_prompt_metrics.bytes hash16);
   (* [substrate:task_assignment] observability *)
@@ -85,7 +85,7 @@ let build_turn_context
      | Some hex -> hex
      | None -> "empty"
    in
-   Log.Keeper.info
+   Log.Keeper.debug
      "[substrate:task_assignment] agent=%s turn=%d user_length=%d \
       user_hash=%s dyn_length=%d dyn_hash=%s"
      meta.agent_name (start_turn_count + 1) user_seg.Keeper_agent_prompt_metrics.bytes

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -174,7 +174,7 @@ let prepare_agent_setup
     in
     if entries <> []
     then
-      Log.Keeper.info
+      Log.Keeper.debug
         "keeper:%s affinity pre-populated %d tools: [%s]"
         meta.name
         (List.length entries)

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -245,16 +245,9 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
              in
              let failure_loop = noop_count >= noop_threshold () in
              let stale = idle_stale || in_turn_stale || failure_loop in
-             (* #10908: 92% of ticks are
-               [noop=0 idle_stale=false failure_loop=false stale=false]
-                — every health bool at default.  Logging at INFO drowns
-                actionable ticks (and competing real signals) under
-                ~800 lines/day of identical heartbeat noise.  Same fix
-                pattern as #10881 (WS lifecycle log): keep INFO for
-                anything an operator should see (any flag set or any
-                noop accumulated), demote the all-default heartbeat to
-                DEBUG. *)
-             let actionable = stale || noop_count > 0 || idle_skip_suppressed in
+             (* The tick line is a sampled state snapshot. Stale termination
+                and broadcasts below remain ERROR, so INFO does not need every
+                intermediate heartbeat/noop snapshot. *)
              let log_line =
                Printf.sprintf
                  "%s: watchdog tick noop=%d idle_stale=%b idle_skip_suppressed=%b in_turn_stale=%b in_turn_age=%.0f failure_loop=%b stale=%b last_turn=%.0f fiber_age=%.0f grace_rem=%.0f"
@@ -262,9 +255,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  in_turn_stale in_turn_age failure_loop stale last_turn
                  fiber_age grace_remaining
              in
-             if actionable
-             then Log.Keeper.info "%s" log_line
-             else Log.Keeper.debug "%s" log_line;
+             Log.Keeper.debug "%s" log_line;
              let cooldown_ok =
                !last_broadcast_ts = 0.0
                || now -. !last_broadcast_ts > threshold

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -56,6 +56,12 @@ type model_bucketed = {
     (** Ordered oldest-first; only non-empty buckets are emitted. *)
 }
 
+type latency_bucket = {
+  lo_ms : int;
+  hi_ms : int option;
+  count : int;
+}
+
 type model_stats = {
   model_id : string;
   provider : string option;
@@ -108,6 +114,7 @@ type aggregate = {
   models : model_stats list;
   total_entries : int;
   total_error_entries : int;
+  latency_buckets : latency_bucket list;
 }
 
 val compute : base_path:string -> window_minutes:int -> aggregate

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -57,8 +57,11 @@ let payload_agent_name payload =
      | None -> payload_string_opt "keeper_name" payload)
 
 let emit_native_event_log (evt : Oas.Event_bus.event) (json : Yojson.Safe.t) =
+  let log_at level message =
+    Log.emit level ~module_name:"oas:event" ~details:json message
+  in
   let log message =
-    Log.emit Log.Info ~module_name:"oas:event" ~details:json message
+    log_at Log.Info message
   in
   match evt.payload with
   | Oas.Event_bus.AgentStarted { agent_name; task_id } ->
@@ -91,7 +94,7 @@ let emit_native_event_log (evt : Oas.Event_bus.event) (json : Yojson.Safe.t) =
       let names_hash =
         Digest.to_hex (Digest.string (String.concat "\n" tool_names))
       in
-      log
+      log_at Log.Debug
         (Printf.sprintf
            "[substrate:tool_surface] agent=%s turn=%d count=%d names_hash=%s"
            agent_name turn (List.length tool_names)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -750,20 +750,10 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
             Log.Server.info "Reaped %d stale connections (active: %d)"
               (List.length stale_sids) (Sse.client_count ());
           let evicted_events = Sse.cleanup_expired_events () in
-          if evicted_events > 0 then begin
-            (* Same rationale as the namespace-truth broadcast log below:
-               when zero SSE clients are attached, the eviction loop is
-               garbage-collecting events that nobody would ever replay,
-               which is routine housekeeping rather than an
-               operator-actionable signal. Emit at INFO only when at
-               least one client is on the wire — otherwise DEBUG. *)
-            let log_fn =
-              if Sse.client_count () > 0
-              then Log.Server.info
-              else Log.Server.debug
-            in
-            log_fn "Evicted %d expired SSE buffer events" evicted_events
-          end;
+          if evicted_events > 0 then
+            (* SSE replay-buffer eviction is periodic housekeeping; failed
+               sends and stale connection reaping remain visible elsewhere. *)
+            Log.Server.debug "Evicted %d expired SSE buffer events" evicted_events;
           let evicted = Cache_eio.evict_expired state.room_config in
           if evicted > 0 then
             Log.Server.info "Cache: evicted %d expired entries" evicted;

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -232,19 +232,9 @@ let broadcast_namespace_truth_snapshot (state : Mcp_server.server_state) : unit 
       Sse.broadcast_to Observers namespace_sse_json;
       Sse.broadcast_to Observers namespace_alias_sse_json;
       Sse.broadcast_to Observers legacy_sse_json;
-      (* Demote the "pushed via SSE" log to DEBUG when no SSE client is
-         connected. With zero observers, the broadcast still runs (for
-         the replay buffer and external subscribers) but the log line
-         is pure housekeeping noise — once per minute for 96 minutes
-         straight in a fresh masc-server.log when nothing is tailing
-         /project-snapshot. Operators only care about this signal when
-         there is an actual client on the wire. *)
-      let log_fn =
-        if Sse.client_count () > 0
-        then Log.Dashboard.info
-        else Log.Dashboard.debug
-      in
-      log_fn "project-snapshot pushed via SSE"
+      (* Snapshot broadcasts are normal dashboard fanout. The cache/update
+         failures around this path are logged separately. *)
+      Log.Dashboard.debug "project-snapshot pushed via SSE"
   | Some _ ->
       Log.Dashboard.debug "project-snapshot unchanged, skipping SSE broadcast"
 

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -119,7 +119,7 @@ let add_routes ~sw router =
          in
          let json =
            Dashboard_http_keeper.keeper_decisions_json
-             ~config ~keepers ~limit
+             ~config ~keepers ~limit ()
          in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd


### PR DESCRIPTION
## Summary

- Demote routine keeper/dashboard runtime logs from INFO to DEBUG:
  watchdog tick snapshots, SSE project snapshot fanout, SSE replay-buffer eviction,
  auth_resolve success traces, prompt substrate hashes, tool-surface hashes,
  affinity pre-population, compaction-skipped traces, and empty governance refreshes.
- Keep error/action signals visible: stale watchdog termination/broadcast, auth errors,
  compaction applied/attempted, tool truncation, failed sends, and provider failures.
- Repair current provider metrics dashboard interface drift found during focused Dune
  validation: expose new helper functions in the mli, expose latency buckets, and replace
  a stale Keeper_meta alias.

## Product impact

Operator logs stay focused on failures and state transitions instead of repeating routine
heartbeats and dashboard housekeeping while keepers are busy.

## Evidence

- `git diff --check`
- `scripts/dune-local.sh build bin/main_eio.exe`

## Review evidence

- Focus on log-level changes in keeper/dashboard hot paths.
- The dashboard/provider metrics edits are compile repairs required by the focused build;
  they do not change route behavior beyond making the existing implementation reachable
  through its interface.

## Linked issue

- Follow-up to live log-noise triage from the keeper runtime session.
