### PR TITLE
[codex] Enforce do-not-merge hard stop

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -41,6 +41,7 @@ jobs:
           AGENT_DRAFT_GUARD_TITLE_RE: ${{ vars.AGENT_DRAFT_GUARD_TITLE_RE }}
           AGENT_DRAFT_GUARD_BRANCH_RE: ${{ vars.AGENT_DRAFT_GUARD_BRANCH_RE }}
           AGENT_DRAFT_GUARD_BYPASS_LABELS: ${{ vars.AGENT_DRAFT_GUARD_BYPASS_LABELS }}
+          AGENT_DRAFT_GUARD_HARD_STOP_LABELS: ${{ vars.AGENT_DRAFT_GUARD_HARD_STOP_LABELS }}
           AGENT_DRAFT_GUARD_HUMAN_ACTORS: ${{ vars.AGENT_DRAFT_GUARD_HUMAN_ACTORS }}
         with:
           script: |
@@ -63,6 +64,10 @@ jobs:
               .split(",")
               .map((s) => s.trim().toLowerCase())
               .filter((label) => !automationProneBypassLabels.has(label))
+              .filter(Boolean);
+            const hardStopLabels = (process.env.AGENT_DRAFT_GUARD_HARD_STOP_LABELS || "do-not-merge")
+              .split(",")
+              .map((s) => s.trim().toLowerCase())
               .filter(Boolean);
             const humanActors = (process.env.AGENT_DRAFT_GUARD_HUMAN_ACTORS || owner)
               .split(",")
@@ -100,6 +105,11 @@ jobs:
             );
             if (ignoredBypassLabels.length > 0) {
               core.info(`Ignoring automation-prone bypass labels: ${ignoredBypassLabels.join(", ")}.`);
+            }
+            const hardStopLabelSet = new Set(hardStopLabels);
+            const presentHardStopLabels = labels.filter((label) => hardStopLabelSet.has(label));
+            if (presentHardStopLabels.length > 0) {
+              core.warning(`Hard-stop labels present: ${presentHardStopLabels.join(", ")}.`);
             }
 
             const looksAgentAuthored =
@@ -187,6 +197,7 @@ jobs:
               current.isDraft ||
               hasAutoMergeRequest ||
               draftBoundaryAction ||
+              presentHardStopLabels.length > 0 ||
               looksAgentAuthored;
             if (!guarded) {
               if (humanAuthored) {
@@ -209,6 +220,11 @@ jobs:
             let shouldRestoreDraft = false;
             let shouldDisableAutoMerge = false;
             let ciGatePolicyFailure = false;
+            if (presentHardStopLabels.length > 0) {
+              policyFailures.push(`hard-stop label present: ${presentHardStopLabels.join(", ")}`);
+              shouldRestoreDraft = !current.isDraft;
+              shouldDisableAutoMerge = hasAutoMergeRequest;
+            }
             // Keep the required guard fail-closed even while the PR is draft.
             // A previous success on the same head SHA can otherwise let a
             // ready_for_review + immediate merge race reuse that success before

--- a/scripts/ci/check-agent-draft-policy.sh
+++ b/scripts/ci/check-agent-draft-policy.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 title_re="${AGENT_DRAFT_GUARD_TITLE_RE:-^\[codex\]}"
 branch_re="${AGENT_DRAFT_GUARD_BRANCH_RE:-^(codex[/-]|keeper[/-])}"
 bypass_labels_csv="${AGENT_DRAFT_GUARD_BYPASS_LABELS:-human-approved-ready}"
+hard_stop_labels_csv="${AGENT_DRAFT_GUARD_HARD_STOP_LABELS:-do-not-merge}"
 
 event_name="${GITHUB_EVENT_NAME:-}"
 if [[ "$event_name" != "pull_request" ]]; then
@@ -58,6 +59,16 @@ csv_has_label() {
   done
   return 1
 }
+
+IFS=',' read -r -a hard_stop_labels <<<"$hard_stop_labels_csv"
+for label in "${hard_stop_labels[@]}"; do
+  label="$(printf '%s' "$label" | xargs)"
+  [[ -n "$label" ]] || continue
+  if csv_has_label "$pr_labels_csv" "$label"; then
+    echo "::error title=Do-not-merge policy violation::PR '${pr_head_ref}' has hard-stop label ${label}. Remove the hard-stop label before ready/merge."
+    exit 1
+  fi
+done
 
 looks_agent_authored=0
 if [[ "$pr_title" =~ $title_re || "$pr_head_ref" =~ $branch_re ]]; then

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -134,6 +134,12 @@ let test_agent_draft_policy_script () =
        (("PR_IS_DRAFT", "false")
        :: ("PR_LABELS", "enhancement,human-approved-ready")
        :: List.remove_assoc "PR_LABELS" base));
+  check bool "hard-stop label overrides bypass label" true
+    (run_agent_draft_policy
+       (("PR_IS_DRAFT", "false")
+       :: ("PR_LABELS", "enhancement,human-approved-ready,do-not-merge")
+       :: List.remove_assoc "PR_LABELS" base)
+    <> 0);
   check int "draft agent PR with bypass label passes" 0
     (run_agent_draft_policy
        (("PR_IS_DRAFT", "true")
@@ -148,6 +154,16 @@ let test_agent_draft_policy_script () =
          ("PR_HEAD_REF", "feature/human-branch");
          ("PR_LABELS", "enhancement");
        ]);
+  check bool "hard-stop label fails non-agent PR too" true
+    (run_agent_draft_policy
+       [
+         ("GITHUB_EVENT_NAME", "pull_request");
+         ("PR_IS_DRAFT", "false");
+         ("PR_TITLE", "fix: human authored branch");
+         ("PR_HEAD_REF", "feature/human-branch");
+         ("PR_LABELS", "enhancement,do-not-merge");
+       ]
+    <> 0);
   (* #10192: post-merge gate race.  When the live PR state is
      MERGED or CLOSED, the policy is moot (the merge already
      happened) and a missing bypass label must NOT resurrect a
@@ -193,7 +209,13 @@ let test_pr_automation_draft_guard_contracts () =
      | _ -> false);
   check bool "draft-only state does not suppress missing approval" true
     (file_not_contains_pattern ".github/workflows/pr-automation.yml"
-       "verifiedBypassLabels.length === 0 &&\n              !safeDraftOnlyState")
+       "verifiedBypassLabels.length === 0 &&\n              !safeDraftOnlyState");
+  check bool "pr automation has hard-stop label policy" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "hard-stop label present");
+  check bool "pr automation hard-stop participates in guarded decision" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "presentHardStopLabels.length > 0")
 
 let test_health_and_ci_runner_diagnostics () =
   check bool "health snapshot records baseline source" true


### PR DESCRIPTION
## Summary

- Add `do-not-merge` as a configurable hard-stop label for PR Automation.
- Make CI Gate fail any PR carrying a hard-stop label before agent/bypass checks run.
- Cover the bypass+hard-stop and non-agent hard-stop cases in the CI hardening source guard.

## Root Cause

PR #12343 showed that `human-approved-ready` could coexist with `do-not-merge`, then the PR was marked ready and merged. The existing guard treated bypass labels and draft repair separately, but did not make `do-not-merge` override every bypass path.

## Validation

- `scripts/dune-local.sh build test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `git diff --check HEAD~1..HEAD`

Refs #9738