### PR TITLE
[codex] Fix model metrics fixtures and provider routes

### DIFF
--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -90,7 +90,7 @@ let add_routes ~sw router =
        with_public_read (fun state req reqd ->
          let window = int_query_param req "window" ~default:1440 in
          let config = state.Mcp_server.room_config in
-         let keeper_names = Dashboard_http_keeper.keeper_names config in
+         let keeper_names = Keeper_types.keeper_names config in
          let keepers =
            List.filter_map (fun name ->
              match Keeper_types.read_meta config name with
@@ -109,7 +109,7 @@ let add_routes ~sw router =
        with_public_read (fun state req reqd ->
          let limit = int_query_param req "limit" ~default:200 in
          let config = state.Mcp_server.room_config in
-         let keeper_names = Dashboard_http_keeper.keeper_names config in
+         let keeper_names = Keeper_types.keeper_names config in
          let keepers =
            List.filter_map (fun name ->
              match Keeper_types.read_meta config name with

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -848,6 +848,7 @@ let test_provider_rollup_empty_aggregate () =
     ; models = []
     ; total_entries = 0
     ; total_error_entries = 0
+    ; latency_buckets = []
     }
   in
   check int "empty models gives empty rollup" 0
@@ -859,7 +860,7 @@ let test_provider_rollup_skips_unknown_provider () =
   let m2 = zero_model_stats "bare-model" ~provider:None ~entry_count:3 in
   let agg : M.aggregate =
     { window_minutes = 30; bucket_minutes = 0; models = [m1; m2]
-    ; total_entries = 8; total_error_entries = 0 }
+    ; total_entries = 8; total_error_entries = 0; latency_buckets = [] }
   in
   let rollup = M.provider_rollup agg in
   check int "only provider=Some survives" 1 (List.length rollup);
@@ -883,7 +884,7 @@ let test_provider_rollup_weighted_mean () =
   in
   let agg : M.aggregate =
     { window_minutes = 30; bucket_minutes = 0; models = [m1; m2]
-    ; total_entries = 100; total_error_entries = 0 }
+    ; total_entries = 100; total_error_entries = 0; latency_buckets = [] }
   in
   let rollup = M.provider_rollup agg in
   let stats = List.hd rollup in
@@ -903,7 +904,7 @@ let test_provider_rollup_all_none_yields_none () =
   let m2 = zero_model_stats "x:2" ~provider:(Some "x") ~entry_count:5 in
   let agg : M.aggregate =
     { window_minutes = 30; bucket_minutes = 0; models = [m1; m2]
-    ; total_entries = 10; total_error_entries = 0 }
+    ; total_entries = 10; total_error_entries = 0; latency_buckets = [] }
   in
   let rollup = M.provider_rollup agg in
   let stats = List.hd rollup in
@@ -920,7 +921,7 @@ let test_provider_rollup_sort_by_entry_count_desc () =
   let c = zero_model_stats "c:1" ~provider:(Some "c") ~entry_count:7 in
   let agg : M.aggregate =
     { window_minutes = 30; bucket_minutes = 0; models = [a; b; c]
-    ; total_entries = 20; total_error_entries = 0 }
+    ; total_entries = 20; total_error_entries = 0; latency_buckets = [] }
   in
   let rollup = M.provider_rollup agg in
   let names = List.map (fun s -> s.M.ps_provider) rollup in
@@ -936,7 +937,7 @@ let test_provider_rollup_json_shape () =
   in
   let agg : M.aggregate =
     { window_minutes = 30; bucket_minutes = 0; models = [m]
-    ; total_entries = 42; total_error_entries = 0 }
+    ; total_entries = 42; total_error_entries = 0; latency_buckets = [] }
   in
   let json = M.provider_stats_to_json (List.hd (M.provider_rollup agg)) in
   match json with


### PR DESCRIPTION
## Summary

- Add the new `latency_buckets` aggregate field to provider-rollup test fixtures.
- Route provider-run keeper scans through `Keeper_types.keeper_names` instead of the non-exported dashboard wrapper.

## Root Cause

`Model_inference_metrics.aggregate` now exposes `latency_buckets`, while provider-rollup fixtures still constructed the old record shape. The provider-runs route also referenced `Dashboard_http_keeper.keeper_names`, which is not part of the exposed dashboard keeper interface.

## Validation

- `scripts/dune-local.sh build test/test_model_inference_metrics.exe test/test_credential_provider_bridge.exe test/test_credential_store.exe test/test_credential_materializer.exe bin/main_eio.exe`
