### PR TITLE
refactor(cascade): type strategy signal cascade names

### DIFF
--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -6,8 +6,11 @@ type signal_ctx = {
   now : float;
   rand_int : int -> int;
   keeper_name : string;
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
 }
+
+let signal_cascade_name ctx =
+  Keeper_cascade_profile.runtime_name_to_string ctx.cascade_name
 
 (* ── Latency-aware weight scaling (Phase: PR3 of cascade resilience) ──
 
@@ -342,10 +345,11 @@ let priority_tier_order adapter ctx ~tiers ~cycle cands =
 (* ── Sticky ─────────────────────────────────────────────────────── *)
 
 let sticky_order adapter ctx cands =
+  let cascade = signal_cascade_name ctx in
   match
     Cascade_state.lookup_sticky
       ~keeper:ctx.keeper_name
-      ~cascade:ctx.cascade_name
+      ~cascade
       ~now:ctx.now
   with
   | None -> cands
@@ -372,7 +376,7 @@ let round_robin_order ctx cands =
   else
     let cursor =
       Cascade_state.rotate_round_robin
-        ~cascade:ctx.cascade_name
+        ~cascade:(signal_cascade_name ctx)
         ~bound:n
     in
     let head, tail =
@@ -415,9 +419,10 @@ let order_candidates t ~adapter ~ctx ~cycle cands =
 let record_choice t ~ctx ~provider_key =
   match t.kind with
   | Sticky ->
+    let cascade = signal_cascade_name ctx in
     Cascade_state.record_sticky_choice
       ~keeper:ctx.keeper_name
-      ~cascade:ctx.cascade_name
+      ~cascade
       ~provider:provider_key
       ~ttl_ms:t.sticky_ttl_ms
       ~now:ctx.now

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -46,10 +46,11 @@ type signal_ctx = {
 
       @since 0.9.7 *)
 
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
   (** Cascade identifier (the [<name>] in [<name>_models]).  Used by
       [Sticky] and [Round_robin] to scope their state.  Required for
-      stateful kinds; tolerated as ["" ] for stateless kinds.
+      stateful kinds; tolerated as [Runtime_name "" ] for stateless kinds.
+      Rendered to string only at the {!Cascade_state} boundary.
 
       @since 0.9.7 *)
 }

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -807,7 +807,7 @@ let run_named
     now = Unix.gettimeofday ();
     rand_int = Random.int;
     keeper_name;
-    cascade_name;
+    cascade_name = error_cascade_name;
   } in
   let cycle_clock = Eio_context.get_clock_opt () in
   let do_backoff cycle =

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -57,7 +57,7 @@ let mk_ctx ?(health = H.create ())
            ?(cascade_name = "")
            () : S.signal_ctx =
   { health; capacity; now; rand_int = rand;
-    keeper_name; cascade_name }
+    keeper_name; cascade_name = Kcp.Runtime_name cascade_name }
 
 let mk_t ?(cycle = S.default_cycle_policy)
          ?(tiers = [])


### PR DESCRIPTION
## Summary

- Type `Cascade_strategy.signal_ctx.cascade_name` as `Keeper_cascade_profile.runtime_name`.
- Render the typed cascade name only at the `Cascade_state` string boundary.
- Pass the already-typed `error_cascade_name` from `Oas_worker_named` into strategy context and update the strategy test fixture.

## Ratchet

- `raw_cascade_name_string_signatures`: `49 -> 47`

## Validation

- `scripts/dune-local.sh build test/test_cascade_strategy.exe test/test_oas_worker.exe`
- `./_build/default/test/test_cascade_strategy.exe test strategy_trace 0-5`
- `./_build/default/test/test_oas_worker.exe test cascade_config 7`
- `git diff --check`
- `scripts/stringly-boundary-ratchet.sh`
- `scripts/ocaml-structure-ratchet.sh`

## Notes

- While validating, current `main` temporarily failed on dashboard/model metrics compile errors. Those were already resolved upstream by the latest `origin/main`; this branch was rebased onto that fixed main before final validation.

Refs #11926.
