### PR TITLE
chore(keeper): remove dead SOUL.md "SYSTEM: SOUL INFUSION" path

### DIFF
--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -242,44 +242,19 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let handoff_cooldown_sec_opt = Safe_ops.json_int_opt "handoff_cooldown_sec" args in
     let instructions_arg = get_string_opt args "instructions" in
     let profile_defaults = load_keeper_profile_defaults name in
-    let soul_path =
-      Filename.concat
-        (Filename.concat
-           (Filename.concat
-              (Filename.concat ctx.config.base_path "memory")
-              "souls")
-           name)
-        "SOUL.md"
-    in
-    let soul_content, soul_fallback =
-      if not (Fs_compat.file_exists soul_path) then (
-        Log.Keeper.info "SOUL.md not found for %s (%s)" name soul_path;
-        "", Printf.sprintf "SOUL.md not found for %s (%s)." name soul_path)
-      else
-        match Safe_ops.read_file_safe soul_path with
-        | Ok c -> c, ""
-        | Error e ->
-            Log.Keeper.warn "SOUL.md read failed for %s (%s): %s" name soul_path e;
-            "",
-            Printf.sprintf "SOUL.md read failed for %s (%s): %s" name soul_path e
-    in
-    let base_instructions_opt =
+    (* The previous implementation read [<base>/memory/souls/<name>/SOUL.md]
+       on every keeper turn-up and wrapped the resulting (or "not found")
+       text into a "[SYSTEM: SOUL INFUSION]" block prepended to the
+       keeper's instructions.  No production keeper ships a SOUL.md
+       and no spec defines one — the directory does not exist on any
+       host — so the path emitted an INFO log every cycle and silently
+       polluted every keeper's instructions with a fallback string.
+       Removed; instructions now reflect only the operator-supplied
+       argument or the keeper profile default. *)
+    let instructions_opt =
       match instructions_arg with
       | Some _ -> instructions_arg
       | None -> profile_defaults.instructions
-    in
-    let instructions_opt =
-      let base = Option.value ~default:"" base_instructions_opt in
-      let soul_section =
-        if soul_content <> "" then soul_content else soul_fallback
-      in
-      let infused =
-        if base = "" then
-          "[SYSTEM: SOUL INFUSION]\n" ^ soul_section
-        else
-          base ^ "\n\n[SYSTEM: SOUL INFUSION]\n" ^ soul_section
-      in
-      Some infused
     in
     let will_opt = parse_self_model_opt args "will" in
     let needs_opt = parse_self_model_opt args "needs" in


### PR DESCRIPTION
## Summary

\`keeper_turn_up_args.ml\` was reading \`<base>/memory/souls/<name>/SOUL.md\` on every keeper turn-up, emitting an INFO log when absent (which is always — no host has \`memory/souls/\` and no production keeper ships a SOUL.md), then wrapping the result into a \`[SYSTEM: SOUL INFUSION]\` block prepended to every keeper's \`instructions\` string.

## Symptom that surfaced this

Operator log contained repeating lines like:

\`\`\`
[2026-04-30 23:51:42] [INFO] [Keeper] SOUL.md not found for ollama-local (/Users/dancer/me/memory/souls/ollama-local/SOUL.md)
\`\`\`

Investigation showed the dead path was not just log noise — every keeper's runtime system prompt silently carried a stanza like:

\`\`\`
[SYSTEM: SOUL INFUSION]
SOUL.md not found for <name> (/Users/dancer/me/memory/souls/<name>/SOUL.md).
\`\`\`

i.e. the missing-file fallback was being **fed to the LLM** as if it were part of the keeper's persona spec.

## Why this is dead code

- \`rg "SOUL.md|soul_content|soul_fallback|soul_path|SOUL INFUSION" lib/ test/ docs/\` → only \`lib/keeper/keeper_turn_up_args.ml\` (the loader itself) and \`archive/trpg/scripts/run_trpg_with_soul.sh\` (already in \`archive/\` = deprecated).
- \`memory/souls/\` directory does not exist on any host running this code.
- No keeper profile / dashboard / RFC / manual references SOUL.md.

The TRPG helper in \`archive/\` was the only producer of SOUL.md files, and that helper is already retired.

## Changes

- \`lib/keeper/keeper_turn_up_args.ml\`: drop \`soul_path\`, \`soul_content\`, \`soul_fallback\` locals + the SOUL INFUSION wrapping. \`instructions_opt\` now reflects only:
  1. operator-supplied \`instructions\` argument, OR
  2. keeper profile default, OR
  3. \`None\` — instead of being coerced to \`Some "[SYSTEM: SOUL INFUSION]\\n<not-found message>"\` when both are absent.

\`archive/trpg/scripts/run_trpg_with_soul.sh\` is deliberately left untouched (already deprecated).

## Test plan

- [x] \`dune build lib/keeper\` clean
- [x] 335 adjacent keeper tests pass (\`test_keeper_unified\`, \`_runtime_config_ssot\`, \`_meta_listing\`, \`_meta_canonical_seed\`)
- [x] Repo-wide \`rg\` for SOUL identifiers returns zero hits in production paths after this change (only \`archive/\` retains the deprecated TRPG helper)
- [ ] Reviewer manually verifies that no keeper profile / dashboard component / external integration depends on the \`[SYSTEM: SOUL INFUSION]\` stanza appearing in instructions.

## Out of scope

- Pre-existing main breakage in \`test_model_inference_metrics.ml\` (\`latency_buckets\` field on \`aggregate\` record): predates this PR, blocks full \`dune build\` but does not affect \`lib/keeper\` or this change. Surfaces as the typical "agent ships .ml without updating .mli" pattern targeted by jeong-sik/me #1078 (RFC-0019 PR-D).

🤖 Co-authored with Claude Opus 4.7 (1M context)