### PR TITLE
fix(keeper): eliminate P0 silent failures in policy gate and lifecycle dispatch

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -85,7 +85,7 @@ let inferred_outcome_of_result ~raw_output ~payload_shape =
   | Plain_text ->
       `Success
   | Structured_error ->
-      if is_policy_gate_error raw_output then `Success else `Failure
+      `Failure
   | Malformed_structured _ ->
       `Failure
 

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -121,8 +121,8 @@ type tool_result_payload =
   | Malformed_structured of string
 
 (** Bridge-facing execution outcome.
-    [tool_not_allowed] remains a non-failure outcome so preset/policy
-    rejections do not trip repeated-failure guardrails. *)
+    Structured tool errors, including [tool_not_allowed], are failures so
+    preset/policy rejections cannot silently end a keeper turn as success. *)
 type execution_outcome = [ `Success | `Failure ]
 
 (** Typed keeper tool execution result.

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -95,9 +95,22 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
   if stale_turn_failures > 0 then begin
     Keeper_registry.reset_turn_failures
       ~base_path:ctx.config.base_path meta.name;
-    ignore (Keeper_registry.dispatch_event
-      ~base_path:ctx.config.base_path meta.name
-      Keeper_state_machine.Heartbeat_ok);
+    (match Keeper_registry.dispatch_event
+       ~base_path:ctx.config.base_path meta.name
+       Keeper_state_machine.Heartbeat_ok
+     with
+     | Ok _ -> ()
+     | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+         Log.Keeper.error "recovery(%s): Heartbeat_ok dispatch failed: %s -> %s (%s)"
+           meta.name
+           (Keeper_state_machine.phase_to_string from_phase)
+           (Keeper_state_machine.phase_to_string to_phase)
+           reason
+     | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+         Log.Keeper.warn "recovery(%s): Heartbeat_ok skipped, already terminal: %s (event: %s)"
+           meta.name
+           (Keeper_state_machine.phase_to_string current)
+           attempted_event);
     Keeper_keepalive_signal.dispatch_keepalive_event ~ctx ~keeper_name:meta.name
       Keeper_state_machine.Turn_succeeded;
     Log.Keeper.info
@@ -145,19 +158,45 @@ let sync_keeper_presence
         (* RFC-0002: dispatch heartbeat failure *)
         Prometheus.inc_counter Prometheus.metric_keeper_heartbeat_failures
           ~labels:[("keeper", meta_current.name)] ();
-        ignore (Keeper_registry.dispatch_event
-          ~base_path:ctx.config.base_path meta_current.name
-          (Keeper_state_machine.Heartbeat_failed {
-            consecutive = !consecutive_failures;
-            max_allowed = Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ();
-          })))
+        (match Keeper_registry.dispatch_event
+           ~base_path:ctx.config.base_path meta_current.name
+           (Keeper_state_machine.Heartbeat_failed {
+             consecutive = !consecutive_failures;
+             max_allowed = Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ();
+           })
+         with
+         | Ok _ -> ()
+         | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+             Log.Keeper.error "heartbeat(%s): Heartbeat_failed dispatch failed: %s -> %s (%s)"
+               meta_current.name
+               (Keeper_state_machine.phase_to_string from_phase)
+               (Keeper_state_machine.phase_to_string to_phase)
+               reason
+         | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+             Log.Keeper.warn "heartbeat(%s): Heartbeat_failed skipped, already terminal: %s (event: %s)"
+               meta_current.name
+               (Keeper_state_machine.phase_to_string current)
+               attempted_event))
       else (
         consecutive_failures := 0;
         last_successful_heartbeat_ts := Time_compat.now ();
         (* RFC-0002: dispatch heartbeat success *)
-        ignore (Keeper_registry.dispatch_event
-          ~base_path:ctx.config.base_path meta_current.name
-          Keeper_state_machine.Heartbeat_ok);
+        (match Keeper_registry.dispatch_event
+           ~base_path:ctx.config.base_path meta_current.name
+           Keeper_state_machine.Heartbeat_ok
+         with
+         | Ok _ -> ()
+         | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+             Log.Keeper.error "heartbeat(%s): Heartbeat_ok dispatch failed: %s -> %s (%s)"
+               meta_current.name
+               (Keeper_state_machine.phase_to_string from_phase)
+               (Keeper_state_machine.phase_to_string to_phase)
+               reason
+         | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+             Log.Keeper.warn "heartbeat(%s): Heartbeat_ok skipped, already terminal: %s (event: %s)"
+               meta_current.name
+               (Keeper_state_machine.phase_to_string current)
+               attempted_event);
         Prometheus.inc_counter Prometheus.metric_keeper_heartbeat_successes
           ~labels:[("keeper", meta_current.name)] ();
         maybe_recover_from_failing ~ctx ~meta:meta_current);
@@ -178,12 +217,25 @@ let sync_keeper_presence
         (Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ())
         (Printexc.to_string exn);
       (* RFC-0002: dispatch heartbeat failure *)
-      ignore (Keeper_registry.dispatch_event
-        ~base_path:ctx.config.base_path meta_current.name
-        (Keeper_state_machine.Heartbeat_failed {
-          consecutive = !consecutive_failures;
-          max_allowed = Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ();
-        }));
+      (match Keeper_registry.dispatch_event
+         ~base_path:ctx.config.base_path meta_current.name
+         (Keeper_state_machine.Heartbeat_failed {
+           consecutive = !consecutive_failures;
+           max_allowed = Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ();
+         })
+       with
+       | Ok _ -> ()
+       | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+           Log.Keeper.error "heartbeat(%s): Heartbeat_failed dispatch failed: %s -> %s (%s)"
+             meta_current.name
+             (Keeper_state_machine.phase_to_string from_phase)
+             (Keeper_state_machine.phase_to_string to_phase)
+             reason
+       | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+           Log.Keeper.warn "heartbeat(%s): Heartbeat_failed skipped, already terminal: %s (event: %s)"
+             meta_current.name
+             (Keeper_state_machine.phase_to_string current)
+             attempted_event);
       meta_current)
 ;;
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -500,7 +500,7 @@ let record_keeper_stopped
            (Keeper_state_machine.phase_to_string to_phase)
            reason
      | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
-         Log.Keeper.warning "record_keeper_stopped(%s): Stop_requested skipped, already terminal: %s (event: %s)"
+         Log.Keeper.warn "record_keeper_stopped(%s): Stop_requested skipped, already terminal: %s (event: %s)"
            keeper_name
            (Keeper_state_machine.phase_to_string current)
            attempted_event);
@@ -515,7 +515,7 @@ let record_keeper_stopped
            (Keeper_state_machine.phase_to_string to_phase)
            reason
      | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
-         Log.Keeper.warning "record_keeper_stopped(%s): Drain_complete skipped, already terminal: %s (event: %s)"
+         Log.Keeper.warn "record_keeper_stopped(%s): Drain_complete skipped, already terminal: %s (event: %s)"
            keeper_name
            (Keeper_state_machine.phase_to_string current)
            attempted_event);
@@ -548,7 +548,7 @@ let record_keeper_crashed
            (Keeper_state_machine.phase_to_string to_phase)
            sm_reason
      | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
-         Log.Keeper.warning "record_keeper_crashed(%s): Fiber_terminated skipped, already terminal: %s (event: %s)"
+         Log.Keeper.warn "record_keeper_crashed(%s): Fiber_terminated skipped, already terminal: %s (event: %s)"
            keeper_name
            (Keeper_state_machine.phase_to_string current)
            attempted_event);

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -489,10 +489,36 @@ let record_keeper_stopped
   =
   if resolve_registry_done entry `Stopped
   then (
-    ignore (Keeper_registry.dispatch_event ~base_path keeper_name
-      Keeper_state_machine.Stop_requested);
-    ignore (Keeper_registry.dispatch_event ~base_path keeper_name
-      Keeper_state_machine.Drain_complete);
+    (match Keeper_registry.dispatch_event ~base_path keeper_name
+            Keeper_state_machine.Stop_requested
+     with
+     | Ok _ -> ()
+     | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+         Log.Keeper.error "record_keeper_stopped(%s): Stop_requested dispatch failed: %s -> %s (%s)"
+           keeper_name
+           (Keeper_state_machine.phase_to_string from_phase)
+           (Keeper_state_machine.phase_to_string to_phase)
+           reason
+     | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+         Log.Keeper.warning "record_keeper_stopped(%s): Stop_requested skipped, already terminal: %s (event: %s)"
+           keeper_name
+           (Keeper_state_machine.phase_to_string current)
+           attempted_event);
+    (match Keeper_registry.dispatch_event ~base_path keeper_name
+            Keeper_state_machine.Drain_complete
+     with
+     | Ok _ -> ()
+     | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+         Log.Keeper.error "record_keeper_stopped(%s): Drain_complete dispatch failed: %s -> %s (%s)"
+           keeper_name
+           (Keeper_state_machine.phase_to_string from_phase)
+           (Keeper_state_machine.phase_to_string to_phase)
+           reason
+     | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+         Log.Keeper.warning "record_keeper_stopped(%s): Drain_complete skipped, already terminal: %s (event: %s)"
+           keeper_name
+           (Keeper_state_machine.phase_to_string current)
+           attempted_event);
     publish_keeper_phase_lifecycle ~phase:Keeper_state_machine.Stopped
       ~keeper_name ~detail ();
     true)
@@ -511,8 +537,21 @@ let record_keeper_crashed
   if resolve_registry_done entry (`Crashed reason)
   then (
     Keeper_registry.set_failure_reason ~base_path keeper_name (Some failure_reason);
-    ignore (Keeper_registry.dispatch_event ~base_path keeper_name
-      (Keeper_state_machine.Fiber_terminated { outcome = reason }));
+    (match Keeper_registry.dispatch_event ~base_path keeper_name
+            (Keeper_state_machine.Fiber_terminated { outcome = reason })
+     with
+     | Ok _ -> ()
+     | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason = sm_reason }) ->
+         Log.Keeper.error "record_keeper_crashed(%s): Fiber_terminated dispatch failed: %s → %s (%s)"
+           keeper_name
+           (Keeper_state_machine.phase_to_string from_phase)
+           (Keeper_state_machine.phase_to_string to_phase)
+           sm_reason
+     | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+         Log.Keeper.warning "record_keeper_crashed(%s): Fiber_terminated skipped, already terminal: %s (event: %s)"
+           keeper_name
+           (Keeper_state_machine.phase_to_string current)
+           attempted_event);
     Keeper_registry.record_crash ~base_path keeper_name (Time_compat.now ()) reason;
     Keeper_registry.record_error ~base_path keeper_name reason;
     publish_keeper_phase_lifecycle ~phase:Keeper_state_machine.Crashed

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -262,8 +262,21 @@ let keepalive_entry_accepts_late_event ~(ctx : _ context) ~(keeper_name : string
 
 let dispatch_keepalive_event ~(ctx : _ context) ~(keeper_name : string) event =
   if keepalive_entry_accepts_late_event ~ctx ~keeper_name then
-    ignore (Keeper_registry.dispatch_event
-      ~base_path:ctx.config.base_path keeper_name event)
+    (match Keeper_registry.dispatch_event
+            ~base_path:ctx.config.base_path keeper_name event
+     with
+     | Ok _ -> ()
+     | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+         Log.Keeper.error "dispatch_keepalive_event(%s): dispatch failed: %s -> %s (%s)"
+           keeper_name
+           (Keeper_state_machine.phase_to_string from_phase)
+           (Keeper_state_machine.phase_to_string to_phase)
+           reason
+     | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+         Log.Keeper.warn "dispatch_keepalive_event(%s): skipped, already terminal: %s (event: %s)"
+           keeper_name
+           (Keeper_state_machine.phase_to_string current)
+           attempted_event)
 
 let dispatch_keepalive_event_with_audit
       ~(ctx : _ context)
@@ -274,10 +287,23 @@ let dispatch_keepalive_event_with_audit
       event
   =
   if keepalive_entry_accepts_late_event ~ctx ~keeper_name then
-    ignore (Keeper_registry.dispatch_event_with_audit
-      ~base_path:ctx.config.base_path
-      ~snapshot
-      ~events_fired
-      ~selected_event
-      keeper_name
-      event)
+    (match Keeper_registry.dispatch_event_with_audit
+            ~base_path:ctx.config.base_path
+            ~snapshot
+            ~events_fired
+            ~selected_event
+            keeper_name
+            event
+     with
+     | Ok _ -> ()
+     | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+         Log.Keeper.error "dispatch_keepalive_event_with_audit(%s): dispatch failed: %s -> %s (%s)"
+           keeper_name
+           (Keeper_state_machine.phase_to_string from_phase)
+           (Keeper_state_machine.phase_to_string to_phase)
+           reason
+     | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+         Log.Keeper.warn "dispatch_keepalive_event_with_audit(%s): skipped, already terminal: %s (event: %s)"
+           keeper_name
+           (Keeper_state_machine.phase_to_string current)
+           attempted_event)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1201,7 +1201,21 @@ let rec dispatch_event_with_audit
          tr.entry_actions;
        List.iter
          (fun followup_event ->
-            ignore (dispatch_event_with_audit ~base_path name followup_event))
+            match dispatch_event_with_audit ~base_path name followup_event with
+            | Ok _ -> ()
+            | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+                Log.Keeper.error
+                  "registry(%s): followup dispatch failed: %s -> %s (%s)"
+                  name
+                  (Keeper_state_machine.phase_to_string from_phase)
+                  (Keeper_state_machine.phase_to_string to_phase)
+                  reason
+            | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+                Log.Keeper.warn
+                  "registry(%s): followup skipped, already terminal: %s (event: %s)"
+                  name
+                  (Keeper_state_machine.phase_to_string current)
+                  attempted_event)
        (List.filter_map
             (followup_event_of_entry_action ~phase:tr.new_phase)
             tr.entry_actions);

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -432,9 +432,21 @@ let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
     resumed_meta.name None;
   Keeper_registry.reset_turn_failures ~base_path:ctx.config.base_path
     resumed_meta.name;
-  ignore
-    (Keeper_registry.dispatch_event ~base_path:ctx.config.base_path
-       resumed_meta.name Keeper_state_machine.Operator_resume);
+  (match Keeper_registry.dispatch_event ~base_path:ctx.config.base_path
+          resumed_meta.name Keeper_state_machine.Operator_resume
+   with
+   | Ok _ -> ()
+   | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+       Log.Keeper.error "%s: Operator_resume dispatch failed: %s -> %s (%s)"
+         resumed_meta.name
+         (Keeper_state_machine.phase_to_string from_phase)
+         (Keeper_state_machine.phase_to_string to_phase)
+         reason
+   | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+       Log.Keeper.warn "%s: Operator_resume skipped, already terminal: %s (event: %s)"
+         resumed_meta.name
+         (Keeper_state_machine.phase_to_string current)
+         attempted_event);
   match Keeper_registry.get ~base_path:ctx.config.base_path resumed_meta.name with
   | Some entry when Option.is_none (Eio.Promise.peek entry.done_p) ->
       (* tla-lint: allow-mutation: fiber signal — wake the keeper after operator resume *)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -269,8 +269,21 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
               Keeper_crash_persistence.enqueue_record ~keepers_dir
                 ~name:meta.name ~ts ~reason ~restart_count:rc;
               Keeper_registry.record_error ~base_path meta.name reason;
-              ignore (Keeper_registry.dispatch_event ~base_path meta.name
-                (Keeper_state_machine.Fiber_terminated { outcome = reason }));
+              (match Keeper_registry.dispatch_event ~base_path meta.name
+                      (Keeper_state_machine.Fiber_terminated { outcome = reason })
+               with
+               | Ok _ -> ()
+               | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason = sm_reason }) ->
+                   Log.Keeper.error "supervisor:%s Fiber_terminated dispatch failed: %s -> %s (%s)"
+                     meta.name
+                     (Keeper_state_machine.phase_to_string from_phase)
+                     (Keeper_state_machine.phase_to_string to_phase)
+                     sm_reason
+               | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+                   Log.Keeper.warn "supervisor:%s Fiber_terminated skipped, already terminal: %s (event: %s)"
+                     meta.name
+                     (Keeper_state_machine.phase_to_string current)
+                     attempted_event);
               if resolve_done (`Crashed reason) then
                 publish_phase_lifecycle ~phase:Keeper_state_machine.Crashed
                   meta.name reason ()
@@ -921,8 +934,21 @@ let sweep_and_recover (ctx : _ context) =
   ) !to_unregister;
   List.iter (fun ((entry : Keeper_registry.registry_entry), msg) ->
     (* RFC-0002: dispatch budget exhaustion before marking dead *)
-    ignore (Keeper_registry.dispatch_event ~base_path entry.name
-      Keeper_state_machine.Restart_budget_exhausted);
+    (match Keeper_registry.dispatch_event ~base_path entry.name
+            Keeper_state_machine.Restart_budget_exhausted
+     with
+     | Ok _ -> ()
+     | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+         Log.Keeper.error "supervisor:%s Restart_budget_exhausted dispatch failed: %s -> %s (%s)"
+           entry.name
+           (Keeper_state_machine.phase_to_string from_phase)
+           (Keeper_state_machine.phase_to_string to_phase)
+           reason
+     | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+         Log.Keeper.warn "supervisor:%s Restart_budget_exhausted skipped, already terminal: %s (event: %s)"
+           entry.name
+           (Keeper_state_machine.phase_to_string current)
+           attempted_event);
     Keeper_registry.mark_dead ~base_path entry.name ~at:now;
     let detail =
       Printf.sprintf "restart budget exhausted (%d), last: %s"
@@ -974,8 +1000,21 @@ let sweep_and_recover (ctx : _ context) =
     match read_meta ctx.config old_entry.name with
     | Ok (Some meta) ->
         (* RFC-0002: dispatch restart attempt event *)
-        ignore (Keeper_registry.dispatch_event ~base_path old_entry.name
-          (Keeper_state_machine.Supervisor_restart_attempt { attempt }));
+        (match Keeper_registry.dispatch_event ~base_path old_entry.name
+                (Keeper_state_machine.Supervisor_restart_attempt { attempt })
+         with
+         | Ok _ -> ()
+         | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+             Log.Keeper.error "supervisor:%s Supervisor_restart_attempt dispatch failed: %s -> %s (%s)"
+               old_entry.name
+               (Keeper_state_machine.phase_to_string from_phase)
+               (Keeper_state_machine.phase_to_string to_phase)
+               reason
+         | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+             Log.Keeper.warn "supervisor:%s Supervisor_restart_attempt skipped, already terminal: %s (event: %s)"
+               old_entry.name
+               (Keeper_state_machine.phase_to_string current)
+               attempted_event);
         let old_crash_log = old_entry.crash_log in
         let reg =
           Keeper_registry.register_restarting ~base_path old_entry.name meta

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -51,8 +51,21 @@ let handle_keeper_down ctx args : tool_result =
            | Error err ->
                Log.Keeper.error "keeper_down write_meta failed: %s" err);
           Keeper_registry.update_meta ~base_path:ctx.config.base_path name retained;
-          ignore (Keeper_registry.dispatch_event ~base_path:ctx.config.base_path name
-            Keeper_state_machine.Operator_pause)));
+          (match Keeper_registry.dispatch_event ~base_path:ctx.config.base_path name
+             Keeper_state_machine.Operator_pause
+           with
+           | Ok _ -> ()
+           | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
+               Log.Keeper.error "keeper_down(%s): Operator_pause dispatch failed: %s -> %s (%s)"
+                 name
+                 (Keeper_state_machine.phase_to_string from_phase)
+                 (Keeper_state_machine.phase_to_string to_phase)
+                 reason
+           | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
+               Log.Keeper.warn "keeper_down(%s): Operator_pause skipped, already terminal: %s (event: %s)"
+                 name
+                 (Keeper_state_machine.phase_to_string current)
+                 attempted_event)));
       if remove_session then (
         let rec rm_rf path =
           if Fs_compat.file_exists path then begin

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -122,7 +122,7 @@ let test_malformed_json_like_payload_detected () =
       (Printf.sprintf "expected malformed_structured, got %s"
          (payload_kind other))
 
-let test_execute_with_outcome_policy_gate_is_non_failure () =
+let test_execute_with_outcome_policy_gate_is_failure () =
   with_exec_fixture
     ~tool_access:(Masc_mcp.Keeper_types.Custom [ "keeper_tools_list" ])
     "keeper_exec_tools_policy_gate"
@@ -134,7 +134,7 @@ let test_execute_with_outcome_policy_gate_is_non_failure () =
           ~input:(`Assoc [ ("path", `String "blocked.txt") ])
           ()
       in
-      check string "policy gate outcome" "success"
+      check string "policy gate outcome" "failure"
         (match result.outcome with `Success -> "success" | `Failure -> "failure");
       check string "policy gate payload shape" "structured_error"
         (payload_kind result.payload_shape);
@@ -357,8 +357,8 @@ let () =
         test_malformed_json_like_payload_detected;
     ]);
     ("execute_keeper_tool_call_with_outcome", [
-      test_case "policy gate stays non-failure" `Quick
-        test_execute_with_outcome_policy_gate_is_non_failure;
+      test_case "policy gate is failure" `Quick
+        test_execute_with_outcome_policy_gate_is_failure;
       test_case "missing file is failure" `Quick
         test_execute_with_outcome_missing_file_is_failure;
       test_case "bad query is failure" `Quick


### PR DESCRIPTION
## Summary

- **C1**: Policy-gated tool failures (`tool_not_allowed`) were misclassified as `Success` in `inferred_outcome_of_result`, causing keepers to silently skip retry/recovery. Now all `Structured_error` results are correctly `Failure`.
- **C2**: `dispatch_event` results in `record_keeper_stopped` and `record_keeper_crashed` were discarded via `ignore()`, swallowing both `Invalid_transition` and `Terminal_state` errors. Both functions now pattern-match exhaustively with appropriate logging.

## Root Cause

Silent failure audit (#silent-failure-p0) identified that:

1. `is_policy_gate_error` check in `inferred_outcome_of_result` was treating policy rejections as successful outcomes — the circuit breaker and telemetry saw no failure, so no recovery was triggered.
2. `ignore()` on `dispatch_event` in lifecycle functions meant invalid state transitions and terminal state attempts were completely invisible — no log, no metric, no recovery path.

## Changes

| File | Change |
|------|--------|
| `lib/keeper/keeper_exec_tools.ml` | Remove `is_policy_gate_error` special case; `Structured_error` → always `Failure` |
| `lib/keeper/keeper_keepalive.ml` | `record_keeper_stopped`: Replace `ignore()` with exhaustive match on both `Stop_requested` and `Drain_complete` dispatches |
| `lib/keeper/keeper_keepalive.ml` | `record_keeper_crashed`: Replace `ignore()` with exhaustive match on `Fiber_terminated` dispatch |

## Verification

- `dune build lib/keeper/` — clean, no warnings
- Exhaustive match on both error variants prevents warning 8 (partial-match)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>