### PR TITLE
feat(dashboard): add Toolbar, Tabs, RadioGroup, Combobox, Tree ARIA primitives

### DIFF
--- a/dashboard/src/components/common/combobox.a11y.test.ts
+++ b/dashboard/src/components/common/combobox.a11y.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { Combobox } from './combobox'
+
+const OPTIONS = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'cherry', label: 'Cherry' },
+]
+
+describe('Combobox a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly', async () => {
+    render(
+      html`<${Combobox}
+        options=${OPTIONS}
+        value=""
+        placeholder="Search"
+        aria-label="Fruit"
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has role combobox', () => {
+    render(
+      html`<${Combobox} options=${OPTIONS} aria-label="Fruit" />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]')
+    expect(input).not.toBeNull()
+  })
+
+  it('aria-expanded is false initially', () => {
+    render(
+      html`<${Combobox} options=${OPTIONS} aria-label="Fruit" />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]') as HTMLInputElement
+    expect(input.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('opens listbox on ArrowDown', async () => {
+    render(
+      html`<${Combobox} options=${OPTIONS} aria-label="Fruit" />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]') as HTMLInputElement
+    input.focus()
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(input.getAttribute('aria-expanded')).toBe('true')
+    expect(container.querySelector('[role="listbox"]')).not.toBeNull()
+  })
+
+  it('sets aria-activedescendant on navigate', async () => {
+    render(
+      html`<${Combobox} options=${OPTIONS} aria-label="Fruit" />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]') as HTMLInputElement
+    input.focus()
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    const ad = input.getAttribute('aria-activedescendant')
+    expect(ad).toBeTruthy()
+    expect(container.querySelector(`#${ad}`)).not.toBeNull()
+  })
+
+  it('options have role option', async () => {
+    render(
+      html`<${Combobox} options=${OPTIONS} aria-label="Fruit" />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]') as HTMLInputElement
+    input.focus()
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    const options = container.querySelectorAll('[role="option"]')
+    expect(options.length).toBe(OPTIONS.length)
+  })
+
+  it('selects option on Enter', async () => {
+    const onChange = vi.fn()
+    render(
+      html`<${Combobox}
+        options=${OPTIONS}
+        aria-label="Fruit"
+        onChange=${onChange}
+      />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]') as HTMLInputElement
+    input.focus()
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onChange).toHaveBeenCalledWith('apple')
+  })
+
+  it('closes on Escape', async () => {
+    render(
+      html`<${Combobox} options=${OPTIONS} aria-label="Fruit" />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]') as HTMLInputElement
+    input.focus()
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(container.querySelector('[role="listbox"]')).not.toBeNull()
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 50))
+    expect(container.querySelector('[role="listbox"]')).toBeNull()
+  })
+
+  it('filters options on type', async () => {
+    render(
+      html`<${Combobox} options=${OPTIONS} aria-label="Fruit" />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]') as HTMLInputElement
+    input.focus()
+    input.value = 'ap'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await new Promise((r) => setTimeout(r, 0))
+    const options = container.querySelectorAll('[role="option"]')
+    expect(options.length).toBe(1)
+    expect(options[0].textContent).toBe('Apple')
+  })
+
+  it('calls onChange with typed value', async () => {
+    const onChange = vi.fn()
+    render(
+      html`<${Combobox}
+        options=${OPTIONS}
+        aria-label="Fruit"
+        onChange=${onChange}
+      />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]') as HTMLInputElement
+    input.focus()
+    input.value = 'ban'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onChange).toHaveBeenCalledWith('ban')
+  })
+
+  it('sets aria-label on listbox', async () => {
+    render(
+      html`<${Combobox} options=${OPTIONS} aria-label="Fruit" />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]') as HTMLInputElement
+    input.focus()
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    const listbox = container.querySelector('[role="listbox"]')
+    expect(listbox?.getAttribute('aria-label')).toBe('Fruit options')
+  })
+
+  it('click selects option', async () => {
+    const onChange = vi.fn()
+    render(
+      html`<${Combobox}
+        options=${OPTIONS}
+        aria-label="Fruit"
+        onChange=${onChange}
+      />`,
+      container,
+    )
+    const input = container.querySelector('[role="combobox"]') as HTMLInputElement
+    input.focus()
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    const option = container.querySelectorAll('[role="option"]')[1] as HTMLElement
+    option.click()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onChange).toHaveBeenCalledWith('banana')
+  })
+})

--- a/dashboard/src/components/common/combobox.a11y.test.ts
+++ b/dashboard/src/components/common/combobox.a11y.test.ts
@@ -153,7 +153,7 @@ describe('Combobox a11y', () => {
     await new Promise((r) => setTimeout(r, 0))
     const options = container.querySelectorAll('[role="option"]')
     expect(options.length).toBe(1)
-    expect(options[0].textContent).toBe('Apple')
+    expect(options[0]!.textContent).toBe('Apple')
   })
 
   it('calls onChange with typed value', async () => {

--- a/dashboard/src/components/common/combobox.ts
+++ b/dashboard/src/components/common/combobox.ts
@@ -1,0 +1,175 @@
+// Combobox — ARIA 1.3 editable combobox with filtering
+//
+// Keyboard: ArrowDown/Up navigates options, Enter selects, Escape closes.
+// Typeahead is implicit via the input field: typing filters the list.
+
+import { html } from 'htm/preact'
+import { useEffect, useId, useRef, useState } from 'preact/hooks'
+
+export interface ComboboxOption {
+  value: string
+  label: string
+}
+
+interface ComboboxProps {
+  options: ComboboxOption[]
+  value?: string
+  onChange?: (value: string) => void
+  placeholder?: string
+  testId?: string
+  /** Accessible name for the combobox input. */
+  'aria-label'?: string
+}
+
+const INPUT_CLS =
+  'w-full rounded bg-[var(--white-4)] border border-[var(--color-border-default)] ' +
+  'text-[var(--color-fg-primary)] px-3 py-2 text-sm transition-colors ' +
+  'hover:bg-[var(--white-6)] focus-visible:bg-[var(--color-bg-page)] ' +
+  'focus-visible:border-[rgba(71,184,255,0.6)] outline-none'
+
+const LISTBOX_CLS =
+  'absolute z-50 top-full mt-1 left-0 w-full max-h-60 overflow-auto ' +
+  'bg-[var(--dialog-panel-bg)] rounded-md border border-[var(--dialog-panel-border)] ' +
+  'shadow-[0_8px_24px_rgba(0,0,0,0.4)] py-1'
+
+const OPTION_BASE = 'px-3 py-2 text-sm cursor-pointer '
+
+function optionCls(active: boolean): string {
+  return active
+    ? OPTION_BASE + 'bg-[var(--color-accent-fg)] text-[var(--color-bg-page)]'
+    : OPTION_BASE + 'text-[var(--color-fg-primary)] hover:bg-[var(--white-6)]'
+}
+
+export function Combobox({
+  options,
+  value,
+  onChange,
+  placeholder,
+  testId,
+  'aria-label': ariaLabel,
+}: ComboboxProps) {
+  const id = useId()
+  const listboxId = `${id}-listbox`
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listboxRef = useRef<HTMLDivElement>(null)
+
+  const [open, setOpen] = useState(false)
+  const [inputValue, setInputValue] = useState(value ?? '')
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const filtered = options.filter((opt) =>
+    opt.label.toLowerCase().includes(inputValue.toLowerCase()),
+  )
+
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [inputValue])
+
+  useEffect(() => {
+    if (!open) return
+    const onDocClick = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (
+        inputRef.current?.contains(target) ||
+        listboxRef.current?.contains(target)
+      ) {
+        return
+      }
+      setOpen(false)
+    }
+    document.addEventListener('click', onDocClick, true)
+    return () => document.removeEventListener('click', onDocClick, true)
+  }, [open])
+
+  const selectOption = (opt: ComboboxOption) => {
+    setInputValue(opt.label)
+    setOpen(false)
+    onChange?.(opt.value)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      if (!open) {
+        setOpen(true)
+        setActiveIndex(0)
+      } else {
+        setActiveIndex((i) => Math.min(filtered.length - 1, i + 1))
+      }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      if (open) {
+        setActiveIndex((i) => Math.max(0, i - 1))
+      }
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (open && filtered[activeIndex]) {
+        selectOption(filtered[activeIndex])
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      setOpen(false)
+    } else if (e.key === 'Home' && open) {
+      e.preventDefault()
+      setActiveIndex(0)
+    } else if (e.key === 'End' && open) {
+      e.preventDefault()
+      setActiveIndex(filtered.length - 1)
+    }
+  }
+
+  const activeDescendant =
+    open && filtered[activeIndex]
+      ? `${id}-option-${activeIndex}`
+      : undefined
+
+  const listboxLabel = ariaLabel ? `${ariaLabel} options` : 'Options'
+
+  return html`
+    <div class="relative inline-block w-full">
+      <input
+        ref=${inputRef}
+        type="text"
+        role="combobox"
+        aria-expanded=${open}
+        aria-controls=${listboxId}
+        aria-activedescendant=${activeDescendant}
+        aria-label=${ariaLabel}
+        data-testid=${testId}
+        value=${inputValue}
+        placeholder=${placeholder}
+        class=${INPUT_CLS}
+        onInput=${(e: Event) => {
+          const val = (e.target as HTMLInputElement).value
+          setInputValue(val)
+          setOpen(true)
+          onChange?.(val)
+        }}
+        onKeyDown=${handleKeyDown}
+      />
+      ${open && filtered.length > 0
+        ? html`<div
+            ref=${listboxRef}
+            id=${listboxId}
+            role="listbox"
+            aria-label=${listboxLabel}
+            class=${LISTBOX_CLS}
+          >
+            ${filtered.map(
+              (opt, idx) => html`
+                <div
+                  id=${`${id}-option-${idx}`}
+                  role="option"
+                  aria-selected=${idx === activeIndex}
+                  class=${optionCls(idx === activeIndex)}
+                  onClick=${() => selectOption(opt)}
+                >
+                  ${opt.label}
+                </div>
+              `,
+            )}
+          </div>`
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/common/radio-group.a11y.test.ts
+++ b/dashboard/src/components/common/radio-group.a11y.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { RadioGroup, Radio } from './radio-group'
+
+describe('RadioGroup a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly', async () => {
+    render(
+      html`<${RadioGroup} name="theme" defaultValue="dark">
+        <${Radio} value="light">Light<//>
+        <${Radio} value="dark">Dark<//>
+      <//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has radiogroup role with aria-label', () => {
+    render(
+      html`<${RadioGroup} name="theme" defaultValue="dark">
+        <${Radio} value="light">Light<//>
+      <//>`,
+      container,
+    )
+    const group = container.querySelector('[role="radiogroup"]') as HTMLElement
+    expect(group).not.toBeNull()
+    expect(group.getAttribute('aria-label')).toBe('theme')
+  })
+
+  it('radio has aria-checked reflecting selection', () => {
+    render(
+      html`<${RadioGroup} name="theme" defaultValue="dark">
+        <${Radio} value="light">Light<//>
+        <${Radio} value="dark">Dark<//>
+      <//>`,
+      container,
+    )
+    const radios = container.querySelectorAll('[role="radio"]')
+    expect(radios[0].getAttribute('aria-checked')).toBe('false')
+    expect(radios[1].getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('selects on click', async () => {
+    const onChange = vi.fn()
+    render(
+      html`<${RadioGroup} name="theme" defaultValue="dark" onValueChange=${onChange}>
+        <${Radio} value="light">Light<//>
+        <${Radio} value="dark">Dark<//>
+      <//>`,
+      container,
+    )
+    const radios = container.querySelectorAll('[role="radio"]')
+    ;(radios[0] as HTMLDivElement).click()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onChange).toHaveBeenCalledWith('light')
+    expect(radios[0].getAttribute('aria-checked')).toBe('true')
+    expect(radios[1].getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('ArrowDown moves focus and selects next', async () => {
+    render(
+      html`<${RadioGroup} name="theme" defaultValue="light">
+        <${Radio} value="light">Light<//>
+        <${Radio} value="dark">Dark<//>
+      <//>`,
+      container,
+    )
+    const radios = container.querySelectorAll('[role="radio"]')
+    ;(radios[0] as HTMLDivElement).focus()
+    radios[0].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(document.activeElement).toBe(radios[1])
+    expect(radios[1].getAttribute('aria-checked')).toBe('true')
+  })
+})

--- a/dashboard/src/components/common/radio-group.a11y.test.ts
+++ b/dashboard/src/components/common/radio-group.a11y.test.ts
@@ -48,8 +48,8 @@ describe('RadioGroup a11y', () => {
       container,
     )
     const radios = container.querySelectorAll('[role="radio"]')
-    expect(radios[0].getAttribute('aria-checked')).toBe('false')
-    expect(radios[1].getAttribute('aria-checked')).toBe('true')
+    expect(radios[0]!.getAttribute('aria-checked')).toBe('false')
+    expect(radios[1]!.getAttribute('aria-checked')).toBe('true')
   })
 
   it('selects on click', async () => {
@@ -62,11 +62,11 @@ describe('RadioGroup a11y', () => {
       container,
     )
     const radios = container.querySelectorAll('[role="radio"]')
-    ;(radios[0] as HTMLDivElement).click()
+    ;(radios[0]! as HTMLDivElement).click()
     await new Promise((r) => setTimeout(r, 0))
     expect(onChange).toHaveBeenCalledWith('light')
-    expect(radios[0].getAttribute('aria-checked')).toBe('true')
-    expect(radios[1].getAttribute('aria-checked')).toBe('false')
+    expect(radios[0]!.getAttribute('aria-checked')).toBe('true')
+    expect(radios[1]!.getAttribute('aria-checked')).toBe('false')
   })
 
   it('ArrowDown moves focus and selects next', async () => {
@@ -78,12 +78,12 @@ describe('RadioGroup a11y', () => {
       container,
     )
     const radios = container.querySelectorAll('[role="radio"]')
-    ;(radios[0] as HTMLDivElement).focus()
-    radios[0].dispatchEvent(
+    ;(radios[0]! as HTMLDivElement).focus()
+    radios[0]!.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
     )
     await new Promise((r) => setTimeout(r, 0))
     expect(document.activeElement).toBe(radios[1])
-    expect(radios[1].getAttribute('aria-checked')).toBe('true')
+    expect(radios[1]!.getAttribute('aria-checked')).toBe('true')
   })
 })

--- a/dashboard/src/components/common/radio-group.ts
+++ b/dashboard/src/components/common/radio-group.ts
@@ -86,6 +86,7 @@ export function Radio({ value, children, class: cx }: RadioProps) {
     if (nextIdx !== -1) {
       e.preventDefault()
       const next = radios[nextIdx]
+      if (!next) return
       next.focus()
       next.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     } else if (e.key === ' ' || e.key === 'Spacebar') {

--- a/dashboard/src/components/common/radio-group.ts
+++ b/dashboard/src/components/common/radio-group.ts
@@ -1,0 +1,110 @@
+// RadioGroup — radiogroup/radio primitive
+// Kimi sec06 ARIA pattern: radiogroup. Arrow keys move focus/selection;
+// Space selects focused item.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+import { createContext } from 'preact'
+import { useCallback, useContext, useRef, useState } from 'preact/hooks'
+
+interface RadioCtx {
+  name: string
+  value: string
+  onChange: (v: string) => void
+}
+
+const Ctx = createContext<RadioCtx | null>(null)
+
+function useCtx() {
+  const c = useContext(Ctx)
+  if (!c) throw new Error('Radio compound components must be inside <RadioGroup>')
+  return c
+}
+
+/* ─── RadioGroup root ─── */
+interface RadioGroupProps {
+  name: string
+  value?: string
+  defaultValue?: string
+  onValueChange?: (value: string) => void
+  children: ComponentChildren
+  class?: string
+}
+
+export function RadioGroup({
+  name,
+  value: controlled,
+  defaultValue,
+  onValueChange,
+  children,
+  class: cx,
+}: RadioGroupProps) {
+  const [uncontrolled, setUncontrolled] = useState(defaultValue ?? '')
+  const isControlled = controlled !== undefined
+  const value = isControlled ? controlled! : uncontrolled
+  const onChange = useCallback(
+    (v: string) => {
+      if (!isControlled) setUncontrolled(v)
+      onValueChange?.(v)
+    },
+    [isControlled, onValueChange],
+  )
+
+  const Provider = Ctx.Provider
+  return html`
+    <div role="radiogroup" aria-label=${name} class=${cx ?? ''}>
+      <${Provider} value=${{ name, value, onChange }}>${children}<//>
+    </div>
+  `
+}
+
+/* ─── Radio item ─── */
+interface RadioProps {
+  value: string
+  children: ComponentChildren
+  class?: string
+}
+
+export function Radio({ value, children, class: cx }: RadioProps) {
+  const { value: selected, onChange } = useCtx()
+  const checked = selected === value
+  const ref = useRef<HTMLDivElement>(null)
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    const group = ref.current?.closest('[role="radiogroup"]') as HTMLElement | null
+    if (!group) return
+    const radios = Array.from(group.querySelectorAll<HTMLElement>('[role="radio"]'))
+    const idx = radios.findIndex((r) => r === ref.current)
+    if (idx === -1) return
+
+    let nextIdx = -1
+    if (e.key === 'ArrowDown' || e.key === 'ArrowRight')
+      nextIdx = (idx + 1) % radios.length
+    else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft')
+      nextIdx = (idx - 1 + radios.length) % radios.length
+
+    if (nextIdx !== -1) {
+      e.preventDefault()
+      const next = radios[nextIdx]
+      next.focus()
+      next.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    } else if (e.key === ' ' || e.key === 'Spacebar') {
+      e.preventDefault()
+      onChange(value)
+    }
+  }
+
+  return html`
+    <div
+      ref=${ref}
+      role="radio"
+      aria-checked=${checked}
+      tabindex=${checked ? 0 : -1}
+      class=${cx ?? ''}
+      onClick=${() => onChange(value)}
+      onKeyDown=${onKeyDown}
+    >
+      ${children}
+    </div>
+  `
+}

--- a/dashboard/src/components/common/tabs.a11y.test.ts
+++ b/dashboard/src/components/common/tabs.a11y.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { Tabs, TabList, Tab, TabPanel } from './tabs'
+
+describe('Tabs a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly', async () => {
+    render(
+      html`<${Tabs} defaultValue="a">
+        <${TabList}>
+          <${Tab} value="a">Tab A<//>
+          <${Tab} value="b">Tab B<//>
+        <//>
+        <${TabPanel} value="a">Panel A<//>
+        <${TabPanel} value="b">Panel B<//>
+      <//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('tablist contains tabs with roles', () => {
+    render(
+      html`<${Tabs} defaultValue="a">
+        <${TabList}>
+          <${Tab} value="a">A<//>
+          <${Tab} value="b">B<//>
+        <//>
+        <${TabPanel} value="a">PA<//>
+      <//>`,
+      container,
+    )
+    const tablist = container.querySelector('[role="tablist"]')
+    expect(tablist).not.toBeNull()
+    const tabs = container.querySelectorAll('[role="tab"]')
+    expect(tabs.length).toBe(2)
+  })
+
+  it('active tab has aria-selected true and inactive false', () => {
+    render(
+      html`<${Tabs} defaultValue="a">
+        <${TabList}>
+          <${Tab} value="a">A<//>
+          <${Tab} value="b">B<//>
+        <//>
+        <${TabPanel} value="a">PA<//>
+        <${TabPanel} value="b">PB<//>
+      <//>`,
+      container,
+    )
+    const tabs = container.querySelectorAll('[role="tab"]')
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true')
+    expect(tabs[1].getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('tab controls panel via aria-controls', () => {
+    render(
+      html`<${Tabs} defaultValue="a">
+        <${TabList}>
+          <${Tab} value="a">A<//>
+        <//>
+        <${TabPanel} value="a">PA<//>
+      <//>`,
+      container,
+    )
+    const tab = container.querySelector('[role="tab"]') as HTMLElement
+    const panel = container.querySelector('[role="tabpanel"]') as HTMLElement
+    expect(tab.getAttribute('aria-controls')).toBe(panel.id)
+    expect(panel.getAttribute('aria-labelledby')).toBe(tab.id)
+  })
+
+  it('switches tab on click', async () => {
+    render(
+      html`<${Tabs} defaultValue="a">
+        <${TabList}>
+          <${Tab} value="a">A<//>
+          <${Tab} value="b">B<//>
+        <//>
+        <${TabPanel} value="a">PA<//>
+        <${TabPanel} value="b">PB<//>
+      <//>`,
+      container,
+    )
+    const tabs = container.querySelectorAll('[role="tab"]')
+    ;(tabs[1] as HTMLButtonElement).click()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(tabs[0].getAttribute('aria-selected')).toBe('false')
+    expect(tabs[1].getAttribute('aria-selected')).toBe('true')
+  })
+
+  it(' ArrowRight cycles tabs and moves focus', async () => {
+    render(
+      html`<${Tabs} defaultValue="a">
+        <${TabList}>
+          <${Tab} value="a">A<//>
+          <${Tab} value="b">B<//>
+        <//>
+        <${TabPanel} value="a">PA<//>
+      <//>`,
+      container,
+    )
+    const tabs = container.querySelectorAll('[role="tab"]')
+    ;(tabs[0] as HTMLButtonElement).focus()
+    tabs[0].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(document.activeElement).toBe(tabs[1])
+    expect(tabs[1].getAttribute('aria-selected')).toBe('true')
+  })
+})

--- a/dashboard/src/components/common/tabs.a11y.test.ts
+++ b/dashboard/src/components/common/tabs.a11y.test.ts
@@ -61,8 +61,8 @@ describe('Tabs a11y', () => {
       container,
     )
     const tabs = container.querySelectorAll('[role="tab"]')
-    expect(tabs[0].getAttribute('aria-selected')).toBe('true')
-    expect(tabs[1].getAttribute('aria-selected')).toBe('false')
+    expect(tabs[0]!.getAttribute('aria-selected')).toBe('true')
+    expect(tabs[1]!.getAttribute('aria-selected')).toBe('false')
   })
 
   it('tab controls panel via aria-controls', () => {
@@ -94,10 +94,10 @@ describe('Tabs a11y', () => {
       container,
     )
     const tabs = container.querySelectorAll('[role="tab"]')
-    ;(tabs[1] as HTMLButtonElement).click()
+    ;(tabs[1]! as HTMLButtonElement).click()
     await new Promise((r) => setTimeout(r, 0))
-    expect(tabs[0].getAttribute('aria-selected')).toBe('false')
-    expect(tabs[1].getAttribute('aria-selected')).toBe('true')
+    expect(tabs[0]!.getAttribute('aria-selected')).toBe('false')
+    expect(tabs[1]!.getAttribute('aria-selected')).toBe('true')
   })
 
   it(' ArrowRight cycles tabs and moves focus', async () => {
@@ -112,12 +112,12 @@ describe('Tabs a11y', () => {
       container,
     )
     const tabs = container.querySelectorAll('[role="tab"]')
-    ;(tabs[0] as HTMLButtonElement).focus()
-    tabs[0].dispatchEvent(
+    ;(tabs[0]! as HTMLButtonElement).focus()
+    tabs[0]!.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
     )
     await new Promise((r) => setTimeout(r, 0))
     expect(document.activeElement).toBe(tabs[1])
-    expect(tabs[1].getAttribute('aria-selected')).toBe('true')
+    expect(tabs[1]!.getAttribute('aria-selected')).toBe('true')
   })
 })

--- a/dashboard/src/components/common/tabs.ts
+++ b/dashboard/src/components/common/tabs.ts
@@ -1,0 +1,144 @@
+// Tabs — tablist/tab/tabpanel primitive
+// Kimi sec06 ARIA pattern: tablist. Keyboard arrows cycle tabs;
+// Home/End jump to first/last.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren, VNode } from 'preact'
+import { createContext } from 'preact'
+import { useCallback, useContext, useId, useRef, useState } from 'preact/hooks'
+
+interface TabsCtx {
+  value: string
+  onChange: (v: string) => void
+  baseId: string
+}
+
+const Ctx = createContext<TabsCtx | null>(null)
+
+function useCtx() {
+  const c = useContext(Ctx)
+  if (!c) throw new Error('Tabs compound components must be inside <Tabs>')
+  return c
+}
+
+/* ─── Tabs root ─── */
+interface TabsProps {
+  defaultValue?: string
+  value?: string
+  onValueChange?: (value: string) => void
+  children: ComponentChildren
+  class?: string
+}
+
+export function Tabs({
+  defaultValue,
+  value: controlled,
+  onValueChange,
+  children,
+  class: cx,
+}: TabsProps) {
+  const [uncontrolled, setUncontrolled] = useState(defaultValue ?? '')
+  const isControlled = controlled !== undefined
+  const value = isControlled ? controlled! : uncontrolled
+  const onChange = useCallback(
+    (v: string) => {
+      if (!isControlled) setUncontrolled(v)
+      onValueChange?.(v)
+    },
+    [isControlled, onValueChange],
+  )
+  const baseId = useId()
+
+  const Provider = Ctx.Provider
+  return html`
+    <div class=${cx ?? ''}><${Provider} value=${{ value, onChange, baseId }}>${children}<//></div>
+  `
+}
+
+/* ─── TabList ─── */
+interface TabListProps {
+  children: ComponentChildren
+  class?: string
+}
+
+export function TabList({ children, class: cx }: TabListProps) {
+  return html`<div role="tablist" class=${cx ?? ''}>${children}</div>`
+}
+
+/* ─── Tab ─── */
+interface TabProps {
+  value: string
+  children: ComponentChildren
+  class?: string
+}
+
+export function Tab({ value, children, class: cx }: TabProps) {
+  const { value: selected, onChange, baseId } = useCtx()
+  const active = selected === value
+  const tabId = `${baseId}-tab-${value}`
+  const panelId = `${baseId}-panel-${value}`
+  const ref = useRef<HTMLButtonElement>(null)
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    const list = ref.current?.closest('[role="tablist"]') as HTMLElement | null
+    if (!list) return
+    const tabs = Array.from(list.querySelectorAll<HTMLElement>('[role="tab"]'))
+    const idx = tabs.findIndex((t) => t === ref.current)
+    if (idx === -1) return
+
+    let nextIdx = -1
+    if (e.key === 'ArrowRight') nextIdx = (idx + 1) % tabs.length
+    else if (e.key === 'ArrowLeft') nextIdx = (idx - 1 + tabs.length) % tabs.length
+    else if (e.key === 'Home') nextIdx = 0
+    else if (e.key === 'End') nextIdx = tabs.length - 1
+
+    if (nextIdx !== -1) {
+      e.preventDefault()
+      const next = tabs[nextIdx] as HTMLButtonElement
+      next.focus()
+      next.click()
+    }
+  }
+
+  return html`
+    <button
+      ref=${ref}
+      role="tab"
+      id=${tabId}
+      aria-selected=${active}
+      aria-controls=${panelId}
+      tabindex=${active ? 0 : -1}
+      class=${cx ?? ''}
+      onClick=${() => onChange(value)}
+      onKeyDown=${onKeyDown}
+    >
+      ${children}
+    </button>
+  `
+}
+
+/* ─── TabPanel ─── */
+interface TabPanelProps {
+  value: string
+  children: ComponentChildren
+  class?: string
+}
+
+export function TabPanel({ value, children, class: cx }: TabPanelProps) {
+  const { value: selected, baseId } = useCtx()
+  const active = selected === value
+  const tabId = `${baseId}-tab-${value}`
+  const panelId = `${baseId}-panel-${value}`
+
+  return html`
+    <div
+      role="tabpanel"
+      id=${panelId}
+      aria-labelledby=${tabId}
+      hidden=${!active}
+      class=${cx ?? ''}
+    >
+      ${active ? children : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/common/tabs.ts
+++ b/dashboard/src/components/common/tabs.ts
@@ -3,7 +3,7 @@
 // Home/End jump to first/last.
 
 import { html } from 'htm/preact'
-import type { ComponentChildren, VNode } from 'preact'
+import type { ComponentChildren } from 'preact'
 import { createContext } from 'preact'
 import { useCallback, useContext, useId, useRef, useState } from 'preact/hooks'
 
@@ -94,7 +94,8 @@ export function Tab({ value, children, class: cx }: TabProps) {
 
     if (nextIdx !== -1) {
       e.preventDefault()
-      const next = tabs[nextIdx] as HTMLButtonElement
+      const next = tabs[nextIdx] as HTMLButtonElement | undefined
+      if (!next) return
       next.focus()
       next.click()
     }

--- a/dashboard/src/components/common/toolbar.a11y.test.ts
+++ b/dashboard/src/components/common/toolbar.a11y.test.ts
@@ -51,9 +51,9 @@ describe('Toolbar a11y', () => {
       container,
     )
     const buttons = container.querySelectorAll('button')
-    expect(buttons[0].getAttribute('tabindex')).toBe('0')
-    expect(buttons[1].getAttribute('tabindex')).toBe('-1')
-    expect(buttons[2].getAttribute('tabindex')).toBe('-1')
+    expect(buttons[0]!.getAttribute('tabindex')).toBe('0')
+    expect(buttons[1]!.getAttribute('tabindex')).toBe('-1')
+    expect(buttons[2]!.getAttribute('tabindex')).toBe('-1')
   })
 
   it('moves focus with ArrowRight in horizontal mode', async () => {
@@ -67,14 +67,14 @@ describe('Toolbar a11y', () => {
     )
     await new Promise((r) => setTimeout(r, 0))
     const buttons = container.querySelectorAll('button')
-    ;(buttons[0] as HTMLButtonElement).focus()
+    ;(buttons[0]! as HTMLButtonElement).focus()
 
-    buttons[0].dispatchEvent(
+    buttons[0]!.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
     )
     await new Promise((r) => setTimeout(r, 0))
-    expect(buttons[0].getAttribute('tabindex')).toBe('-1')
-    expect(buttons[1].getAttribute('tabindex')).toBe('0')
+    expect(buttons[0]!.getAttribute('tabindex')).toBe('-1')
+    expect(buttons[1]!.getAttribute('tabindex')).toBe('0')
   })
 
   it('moves focus with ArrowLeft in horizontal mode', async () => {
@@ -88,17 +88,17 @@ describe('Toolbar a11y', () => {
     )
     await new Promise((r) => setTimeout(r, 0))
     const buttons = container.querySelectorAll('button')
-    ;(buttons[0] as HTMLButtonElement).focus()
+    ;(buttons[0]! as HTMLButtonElement).focus()
 
-    buttons[0].dispatchEvent(
+    buttons[0]!.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
     )
     await new Promise((r) => setTimeout(r, 0))
-    buttons[1].dispatchEvent(
+    buttons[1]!.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
     )
     await new Promise((r) => setTimeout(r, 0))
-    expect(buttons[0].getAttribute('tabindex')).toBe('0')
+    expect(buttons[0]!.getAttribute('tabindex')).toBe('0')
   })
 
   it('jumps to first and last with Home and End', async () => {
@@ -112,24 +112,24 @@ describe('Toolbar a11y', () => {
     )
     await new Promise((r) => setTimeout(r, 0))
     const buttons = container.querySelectorAll('button')
-    ;(buttons[0] as HTMLButtonElement).focus()
+    ;(buttons[0]! as HTMLButtonElement).focus()
 
-    buttons[0].dispatchEvent(
+    buttons[0]!.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
     )
     await new Promise((r) => setTimeout(r, 0))
 
-    buttons[1].dispatchEvent(
+    buttons[1]!.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'Home', bubbles: true }),
     )
     await new Promise((r) => setTimeout(r, 0))
-    expect(buttons[0].getAttribute('tabindex')).toBe('0')
+    expect(buttons[0]!.getAttribute('tabindex')).toBe('0')
 
-    buttons[0].dispatchEvent(
+    buttons[0]!.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'End', bubbles: true }),
     )
     await new Promise((r) => setTimeout(r, 0))
-    expect(buttons[2].getAttribute('tabindex')).toBe('0')
+    expect(buttons[2]!.getAttribute('tabindex')).toBe('0')
   })
 
   it('separator has role separator and aria-orientation', () => {

--- a/dashboard/src/components/common/toolbar.a11y.test.ts
+++ b/dashboard/src/components/common/toolbar.a11y.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { Toolbar, ToolbarButton, ToolbarSeparator } from './toolbar'
+
+describe('Toolbar a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly', async () => {
+    render(
+      html`<${Toolbar} aria-label="Actions">${[
+        html`<${ToolbarButton}>Cut<//>`,
+        html`<${ToolbarButton}>Copy<//>`,
+        html`<${ToolbarButton}>Paste<//>`,
+      ]}<//>`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has toolbar role and aria-orientation', () => {
+    render(
+      html`<${Toolbar} aria-label="Actions" orientation="vertical">${[
+        html`<${ToolbarButton}>A<//>`,
+      ]}<//>`,
+      container,
+    )
+    const toolbar = container.querySelector('[role="toolbar"]')
+    expect(toolbar).not.toBeNull()
+    expect(toolbar?.getAttribute('aria-label')).toBe('Actions')
+    expect(toolbar?.getAttribute('aria-orientation')).toBe('vertical')
+  })
+
+  it('only the first button has tabindex=0 initially', () => {
+    render(
+      html`<${Toolbar} aria-label="Actions">${[
+        html`<${ToolbarButton}>A<//>`,
+        html`<${ToolbarButton}>B<//>`,
+        html`<${ToolbarButton}>C<//>`,
+      ]}<//>`,
+      container,
+    )
+    const buttons = container.querySelectorAll('button')
+    expect(buttons[0].getAttribute('tabindex')).toBe('0')
+    expect(buttons[1].getAttribute('tabindex')).toBe('-1')
+    expect(buttons[2].getAttribute('tabindex')).toBe('-1')
+  })
+
+  it('moves focus with ArrowRight in horizontal mode', async () => {
+    render(
+      html`<${Toolbar} aria-label="Actions">${[
+        html`<${ToolbarButton}>A<//>`,
+        html`<${ToolbarButton}>B<//>`,
+        html`<${ToolbarButton}>C<//>`,
+      ]}<//>`,
+      container,
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    const buttons = container.querySelectorAll('button')
+    ;(buttons[0] as HTMLButtonElement).focus()
+
+    buttons[0].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(buttons[0].getAttribute('tabindex')).toBe('-1')
+    expect(buttons[1].getAttribute('tabindex')).toBe('0')
+  })
+
+  it('moves focus with ArrowLeft in horizontal mode', async () => {
+    render(
+      html`<${Toolbar} aria-label="Actions">${[
+        html`<${ToolbarButton}>A<//>`,
+        html`<${ToolbarButton}>B<//>`,
+        html`<${ToolbarButton}>C<//>`,
+      ]}<//>`,
+      container,
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    const buttons = container.querySelectorAll('button')
+    ;(buttons[0] as HTMLButtonElement).focus()
+
+    buttons[0].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    buttons[1].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(buttons[0].getAttribute('tabindex')).toBe('0')
+  })
+
+  it('jumps to first and last with Home and End', async () => {
+    render(
+      html`<${Toolbar} aria-label="Actions">${[
+        html`<${ToolbarButton}>A<//>`,
+        html`<${ToolbarButton}>B<//>`,
+        html`<${ToolbarButton}>C<//>`,
+      ]}<//>`,
+      container,
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    const buttons = container.querySelectorAll('button')
+    ;(buttons[0] as HTMLButtonElement).focus()
+
+    buttons[0].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+
+    buttons[1].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Home', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(buttons[0].getAttribute('tabindex')).toBe('0')
+
+    buttons[0].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'End', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(buttons[2].getAttribute('tabindex')).toBe('0')
+  })
+
+  it('separator has role separator and aria-orientation', () => {
+    render(
+      html`<${Toolbar} aria-label="Actions">${[
+        html`<${ToolbarButton}>A<//>`,
+        html`<${ToolbarSeparator} />`,
+        html`<${ToolbarButton}>B<//>`,
+      ]}<//>`,
+      container,
+    )
+    const sep = container.querySelector('[role="separator"]')
+    expect(sep).not.toBeNull()
+    expect(sep?.getAttribute('aria-orientation')).toBe('vertical')
+  })
+
+  it('calls onClick when button is clicked', async () => {
+    const onClick = vi.fn()
+    render(
+      html`<${Toolbar} aria-label="Actions">${[
+        html`<${ToolbarButton} onClick=${onClick}>Action<//>`,
+      ]}<//>`,
+      container,
+    )
+    const btn = container.querySelector('button') as HTMLButtonElement
+    btn.click()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+})

--- a/dashboard/src/components/common/toolbar.ts
+++ b/dashboard/src/components/common/toolbar.ts
@@ -3,7 +3,7 @@
 // Home/End jump to first/last. Only one item is tab-accessible at a time.
 
 import { html } from 'htm/preact'
-import type { ComponentChildren, VNode } from 'preact'
+import type { ComponentChildren } from 'preact'
 import { createContext } from 'preact'
 import { useCallback, useContext, useEffect, useRef, useState } from 'preact/hooks'
 
@@ -77,6 +77,7 @@ export function Toolbar({
     if (nextIdx !== -1) {
       e.preventDefault()
       const nextId = sortedItems[nextIdx]
+      if (nextId === undefined) return
       setFocusedIndex(nextId)
     }
   }

--- a/dashboard/src/components/common/toolbar.ts
+++ b/dashboard/src/components/common/toolbar.ts
@@ -1,0 +1,171 @@
+// Toolbar — toolbar primitive with roving tabindex
+// Kimi sec06 ARIA pattern: toolbar. Arrow keys move focus between items;
+// Home/End jump to first/last. Only one item is tab-accessible at a time.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren, VNode } from 'preact'
+import { createContext } from 'preact'
+import { useCallback, useContext, useEffect, useRef, useState } from 'preact/hooks'
+
+interface ToolbarCtx {
+  focusedIndex: number
+  setFocusedIndex: (i: number) => void
+  register: () => number
+  unregister: (i: number) => void
+}
+
+const Ctx = createContext<ToolbarCtx | null>(null)
+
+function useCtx() {
+  const c = useContext(Ctx)
+  if (!c) throw new Error('Toolbar compound components must be inside <Toolbar>')
+  return c
+}
+
+let _id = 0
+
+/* ─── Toolbar root ─── */
+interface ToolbarProps {
+  'aria-label': string
+  orientation?: 'horizontal' | 'vertical'
+  children: ComponentChildren
+  class?: string
+}
+
+export function Toolbar({
+  'aria-label': ariaLabel,
+  orientation = 'horizontal',
+  children,
+  class: cx,
+}: ToolbarProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [focusedIndex, setFocusedIndex] = useState(() => _id)
+  const [items, setItems] = useState<Set<number>>(new Set())
+
+  const register = useCallback(() => {
+    const id = _id++
+    setItems((prev) => new Set(prev).add(id))
+    return id
+  }, [])
+
+  const unregister = useCallback((id: number) => {
+    setItems((prev) => {
+      const next = new Set(prev)
+      next.delete(id)
+      return next
+    })
+  }, [])
+
+  const sortedItems = Array.from(items).sort((a, b) => a - b)
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (sortedItems.length === 0) return
+    const currentIdx = sortedItems.indexOf(focusedIndex)
+    const idx = currentIdx === -1 ? 0 : currentIdx
+    let nextIdx = -1
+
+    if (orientation === 'horizontal') {
+      if (e.key === 'ArrowRight') nextIdx = (idx + 1) % sortedItems.length
+      else if (e.key === 'ArrowLeft') nextIdx = (idx - 1 + sortedItems.length) % sortedItems.length
+    } else {
+      if (e.key === 'ArrowDown') nextIdx = (idx + 1) % sortedItems.length
+      else if (e.key === 'ArrowUp') nextIdx = (idx - 1 + sortedItems.length) % sortedItems.length
+    }
+    if (e.key === 'Home') nextIdx = 0
+    else if (e.key === 'End') nextIdx = sortedItems.length - 1
+
+    if (nextIdx !== -1) {
+      e.preventDefault()
+      const nextId = sortedItems[nextIdx]
+      setFocusedIndex(nextId)
+    }
+  }
+
+  const Provider = Ctx.Provider
+  return html`
+    <div
+      ref=${ref}
+      role="toolbar"
+      aria-label=${ariaLabel}
+      aria-orientation=${orientation}
+      class=${cx ?? ''}
+      onKeyDown=${handleKeyDown}
+    >
+      <${Provider} value=${{ focusedIndex, setFocusedIndex, register, unregister }}
+        >${children}
+      <//>
+    </div>
+  `
+}
+
+/* ─── ToolbarButton ─── */
+interface ToolbarButtonProps {
+  children: ComponentChildren
+  onClick?: (e: MouseEvent) => void
+  disabled?: boolean
+  class?: string
+  'aria-pressed'?: boolean
+  title?: string
+}
+
+export function ToolbarButton({
+  children,
+  onClick,
+  disabled,
+  class: cx,
+  'aria-pressed': ariaPressed,
+  title,
+}: ToolbarButtonProps) {
+  const { focusedIndex, setFocusedIndex, register, unregister } = useCtx()
+  const [id] = useState(() => register())
+  const ref = useRef<HTMLButtonElement>(null)
+  const active = focusedIndex === id
+
+  useEffect(() => {
+    if (active) ref.current?.focus()
+  }, [active])
+
+  useEffect(() => () => unregister(id), [id, unregister])
+
+  return html`
+    <button
+      ref=${ref}
+      type="button"
+      tabindex=${active ? 0 : -1}
+      disabled=${disabled}
+      aria-pressed=${ariaPressed}
+      title=${title}
+      class=${cx ?? ''}
+      onClick=${(e: MouseEvent) => {
+        onClick?.(e)
+        setFocusedIndex(id)
+      }}
+      onFocus=${() => setFocusedIndex(id)}
+    >
+      ${children}
+    </button>
+  `
+}
+
+/* ─── ToolbarSeparator ─── */
+interface ToolbarSeparatorProps {
+  orientation?: 'horizontal' | 'vertical'
+  class?: string
+}
+
+export function ToolbarSeparator({
+  orientation = 'vertical',
+  class: cx,
+}: ToolbarSeparatorProps) {
+  return html`
+    <div
+      role="separator"
+      aria-orientation=${orientation}
+      class=${
+        'shrink-0 bg-[var(--color-border-default)] ' +
+        (orientation === 'vertical' ? 'w-px h-4 mx-1' : 'h-px w-full my-1') +
+        (cx ? ` ${cx}` : '')
+      }
+    />
+  `
+}

--- a/dashboard/src/components/common/tree.a11y.test.ts
+++ b/dashboard/src/components/common/tree.a11y.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import { axe } from 'jest-axe'
+import { Tree } from './tree'
+
+const NODES = [
+  {
+    id: 'root1',
+    label: 'Root 1',
+    children: [
+      { id: 'child1', label: 'Child 1' },
+      { id: 'child2', label: 'Child 2', children: [{ id: 'grand1', label: 'Grand 1' }] },
+    ],
+  },
+  { id: 'root2', label: 'Root 2' },
+]
+
+function StatefulTree({ nodes, initial }: { nodes: typeof NODES; initial?: string }) {
+  const [selectedId, setSelectedId] = useState(initial)
+  return html`<${Tree} nodes=${nodes} selectedId=${selectedId} onSelect=${setSelectedId} aria-label="Files" />`
+}
+
+describe('Tree a11y', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders accessibly', async () => {
+    render(html`<${Tree} nodes=${NODES} aria-label="Files" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has tree role and aria-label', () => {
+    render(html`<${Tree} nodes=${NODES} aria-label="Files" />`, container)
+    const tree = container.querySelector('[role="tree"]')
+    expect(tree).not.toBeNull()
+    expect(tree?.getAttribute('aria-label')).toBe('Files')
+  })
+
+  it('treeitems have aria-selected and aria-level', () => {
+    render(
+      html`<${Tree} nodes=${NODES} selectedId="root1" aria-label="Files" />`,
+      container,
+    )
+    const items = container.querySelectorAll('[role="treeitem"]')
+    expect(items.length).toBeGreaterThan(0)
+    const selected = container.querySelector('[role="treeitem"][aria-selected="true"]')
+    expect(selected?.getAttribute('aria-level')).toBe('1')
+  })
+
+  it('expands and collapses with ArrowRight and ArrowLeft', async () => {
+    render(html`<${Tree} nodes=${NODES} aria-label="Files" />`, container)
+    const tree = container.querySelector('[role="tree"]') as HTMLElement
+    tree.focus()
+
+    tree.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    let items = container.querySelectorAll('[role="treeitem"]')
+    expect(items.length).toBe(4)
+
+    tree.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    items = container.querySelectorAll('[role="treeitem"]')
+    expect(items.length).toBe(2)
+  })
+
+  it('navigates with ArrowDown and ArrowUp', async () => {
+    render(html`<${StatefulTree} nodes=${NODES} />`, container)
+    const tree = container.querySelector('[role="tree"]') as HTMLElement
+    tree.focus()
+
+    tree.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+
+    tree.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    let selected = container.querySelector('[aria-selected="true"]')
+    expect(selected?.querySelector("span:last-child")?.textContent?.trim()).toBe('Child 1')
+
+    tree.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    selected = container.querySelector('[aria-selected="true"]')
+    expect(selected?.querySelector("span:last-child")?.textContent?.trim()).toBe('Child 2')
+
+    tree.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    selected = container.querySelector('[aria-selected="true"]')
+    expect(selected?.querySelector("span:last-child")?.textContent?.trim()).toBe('Child 1')
+  })
+
+  it('selects on Enter and calls onSelect', async () => {
+    const onSelect = vi.fn()
+    render(
+      html`<${Tree} nodes=${NODES} onSelect=${onSelect} aria-label="Files" />`,
+      container,
+    )
+    const tree = container.querySelector('[role="tree"]') as HTMLElement
+    tree.focus()
+
+    tree.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onSelect).toHaveBeenCalledWith('root1')
+  })
+
+  it('jumps to first and last with Home and End', async () => {
+    render(html`<${StatefulTree} nodes=${NODES} initial="root2" />`, container)
+    const tree = container.querySelector('[role="tree"]') as HTMLElement
+    tree.focus()
+
+    tree.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Home', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    let selected = container.querySelector('[aria-selected="true"]')
+    expect(selected?.querySelector("span:last-child")?.textContent?.trim()).toBe('Root 1')
+
+    tree.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'End', bubbles: true }),
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    selected = container.querySelector('[aria-selected="true"]')
+    expect(selected?.querySelector("span:last-child")?.textContent?.trim()).toBe('Root 2')
+  })
+})

--- a/dashboard/src/components/common/tree.ts
+++ b/dashboard/src/components/common/tree.ts
@@ -1,0 +1,189 @@
+// Tree — ARIA 1.3 tree view with expandable/collapsible nodes
+//
+// Keyboard: ArrowDown/Up navigates visible nodes, ArrowRight expands,
+// ArrowLeft collapses, Enter selects.
+
+import { html } from 'htm/preact'
+import { useCallback, useId, useState } from 'preact/hooks'
+
+export interface TreeNode {
+  id: string
+  label: string
+  children?: TreeNode[]
+}
+
+interface TreeProps {
+  nodes: TreeNode[]
+  selectedId?: string
+  onSelect?: (id: string) => void
+  testId?: string
+  /** Accessible name for the tree. */
+  'aria-label'?: string
+}
+
+interface FlatNode {
+  id: string
+  label: string
+  depth: number
+  hasChildren: boolean
+  parentId: string | null
+}
+
+function flatten(
+  nodes: TreeNode[],
+  expanded: Set<string>,
+  depth = 0,
+  parentId: string | null = null,
+): FlatNode[] {
+  const out: FlatNode[] = []
+  for (const n of nodes) {
+    out.push({
+      id: n.id,
+      label: n.label,
+      depth,
+      hasChildren: !!n.children?.length,
+      parentId,
+    })
+    if (n.children?.length && expanded.has(n.id)) {
+      out.push(...flatten(n.children, expanded, depth + 1, n.id))
+    }
+  }
+  return out
+}
+
+const TREEITEM_BASE =
+  'flex items-center gap-1 px-2 py-1 text-sm rounded cursor-pointer select-none '
+
+function treeItemCls(selected: boolean): string {
+  return selected
+    ? TREEITEM_BASE + 'bg-[var(--color-accent-fg)] text-[var(--color-bg-page)]'
+    : TREEITEM_BASE +
+        'text-[var(--color-fg-primary)] hover:bg-[var(--white-6)]'
+}
+
+const EXPANDER_CLS =
+  'inline-flex items-center justify-center w-4 h-4 text-[var(--color-fg-muted)]'
+
+export function Tree({
+  nodes,
+  selectedId,
+  onSelect,
+  testId,
+  'aria-label': ariaLabel,
+}: TreeProps) {
+  const id = useId()
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  const visible = flatten(nodes, expanded)
+
+  const toggleExpand = useCallback(
+    (nodeId: string) => {
+      setExpanded((prev) => {
+        const next = new Set(prev)
+        if (next.has(nodeId)) next.delete(nodeId)
+        else next.add(nodeId)
+        return next
+      })
+    },
+    [setExpanded],
+  )
+
+  const findIndex = (nodeId: string | undefined) => {
+    if (!nodeId) return -1
+    return visible.findIndex((n) => n.id === nodeId)
+  }
+
+  const activeIndex = Math.max(0, findIndex(selectedId))
+  const activeNode = visible[activeIndex] ?? visible[0]
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (visible.length === 0) return
+    let nextIndex = activeIndex
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      nextIndex = Math.min(visible.length - 1, activeIndex + 1)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      nextIndex = Math.max(0, activeIndex - 1)
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      const node = visible[activeIndex]
+      if (node?.hasChildren && !expanded.has(node.id)) {
+        toggleExpand(node.id)
+        return
+      }
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      const node = visible[activeIndex]
+      if (node?.hasChildren && expanded.has(node.id)) {
+        toggleExpand(node.id)
+        return
+      }
+      // Collapse: jump to parent if any
+      if (node?.parentId) {
+        const parentIdx = visible.findIndex((n) => n.id === node.parentId)
+        if (parentIdx >= 0) {
+          onSelect?.(visible[parentIdx].id)
+        }
+        return
+      }
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      const node = visible[activeIndex]
+      if (node) {
+        if (node.hasChildren) toggleExpand(node.id)
+        onSelect?.(node.id)
+      }
+      return
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      nextIndex = 0
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      nextIndex = visible.length - 1
+    }
+
+    if (nextIndex !== activeIndex && visible[nextIndex]) {
+      onSelect?.(visible[nextIndex].id)
+    }
+  }
+
+  return html`
+    <ul
+      role="tree"
+      aria-label=${ariaLabel}
+      data-testid=${testId}
+      tabindex=${0}
+      class="outline-none"
+      onKeyDown=${handleKeyDown}
+    >
+      ${visible.map(
+        (node, idx) => html`
+          <li
+            key=${node.id}
+            role="treeitem"
+            aria-selected=${node.id === selectedId}
+            aria-expanded=${node.hasChildren
+              ? expanded.has(node.id)
+              : undefined}
+            aria-level=${node.depth + 1}
+            class=${treeItemCls(node.id === selectedId)}
+            style=${`padding-left: ${node.depth * 16 + 8}px`}
+            onClick=${() => {
+              if (node.hasChildren) toggleExpand(node.id)
+              onSelect?.(node.id)
+            }}
+          >
+            ${node.hasChildren
+              ? html`<span class=${EXPANDER_CLS}>
+                  ${expanded.has(node.id) ? '▼' : '▶'}
+                </span>`
+              : html`<span class=${EXPANDER_CLS}> </span>`}
+            <span>${node.label}</span>
+          </li>
+        `,
+      )}
+    </ul>
+  `
+}

--- a/dashboard/src/components/common/tree.ts
+++ b/dashboard/src/components/common/tree.ts
@@ -4,7 +4,7 @@
 // ArrowLeft collapses, Enter selects.
 
 import { html } from 'htm/preact'
-import { useCallback, useId, useState } from 'preact/hooks'
+import { useCallback, useState } from 'preact/hooks'
 
 export interface TreeNode {
   id: string
@@ -71,7 +71,6 @@ export function Tree({
   testId,
   'aria-label': ariaLabel,
 }: TreeProps) {
-  const id = useId()
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
   const visible = flatten(nodes, expanded)
@@ -94,7 +93,6 @@ export function Tree({
   }
 
   const activeIndex = Math.max(0, findIndex(selectedId))
-  const activeNode = visible[activeIndex] ?? visible[0]
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (visible.length === 0) return
@@ -123,9 +121,8 @@ export function Tree({
       // Collapse: jump to parent if any
       if (node?.parentId) {
         const parentIdx = visible.findIndex((n) => n.id === node.parentId)
-        if (parentIdx >= 0) {
-          onSelect?.(visible[parentIdx].id)
-        }
+        const parent = visible[parentIdx]
+        if (parent) onSelect?.(parent.id)
         return
       }
     } else if (e.key === 'Enter') {
@@ -144,8 +141,9 @@ export function Tree({
       nextIndex = visible.length - 1
     }
 
-    if (nextIndex !== activeIndex && visible[nextIndex]) {
-      onSelect?.(visible[nextIndex].id)
+    const next = visible[nextIndex]
+    if (nextIndex !== activeIndex && next) {
+      onSelect?.(next.id)
     }
   }
 
@@ -159,7 +157,7 @@ export function Tree({
       onKeyDown=${handleKeyDown}
     >
       ${visible.map(
-        (node, idx) => html`
+        (node) => html`
           <li
             key=${node.id}
             role="treeitem"


### PR DESCRIPTION
## Summary

Adds the sec06 batch 2 ARIA headless primitives to the dashboard common component set:

- **Tabs** — `tablist` / `tab` / `tabpanel` with roving focus
- **RadioGroup** — `radiogroup` / `radio` with arrow-key selection
- **Toolbar** — `toolbar` with roving tabindex and orientation-aware navigation
- **Combobox** — `combobox` / `listbox` / `option` with filtering and keyboard selection
- **Tree** — `tree` / `treeitem` with expand/collapse and selection semantics

## Readiness Fixes

- Rebased the PR branch onto current `main` after the AlertDialog/Popover and dashboard file-tree merges.
- Added strict TypeScript guards for indexed DOM/node lookups in the new a11y tests and primitive internals.
- Kept the merged scope to the batch 2 primitives listed above; later batch 3 primitives are not part of this merged diff.

## Verification

- PR Dashboard check passed on head `cfb4ba21c74d92ecc37ccf4a8bce15eae07efad2`.
- PR CI Gate passed on head `cfb4ba21c74d92ecc37ccf4a8bce15eae07efad2`.
- PR lighthouse-smoke passed on head `cfb4ba21c74d92ecc37ccf4a8bce15eae07efad2`.