### PR TITLE
refactor(cascade): type oas observation cascade names

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -502,7 +502,8 @@ let provider_context_json ~(meta : keeper_meta)
       let cascade_name, selected_model, candidate_models =
         match r.cascade_observation with
         | Some observation ->
-            ( observation.cascade_name,
+            ( Keeper_cascade_profile.runtime_name_to_string
+                observation.cascade_name,
               observation.selected_model,
               observation.candidate_models )
         | None ->
@@ -812,8 +813,12 @@ let append_decision_record
               let cascade_fields =
                 match r.cascade_observation with
                 | Some co ->
+                    let cascade_name =
+                      Keeper_cascade_profile.runtime_name_to_string
+                        co.cascade_name
+                    in
                     [
-                      ("cascade_name", `String co.cascade_name);
+                      ("cascade_name", `String cascade_name);
                       ("strategy", Json_util.string_opt_to_json co.strategy);
                       ("primary_model", match co.primary_model with Some m -> `String m | None -> `Null);
                       ("selected_model", match co.selected_model with Some m -> `String m | None -> `Null);
@@ -1309,7 +1314,9 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
   record_turn_latency_bucket ~keeper:meta.name ~latency_ms;
   let cascade_profile =
     match result.cascade_observation with
-    | Some observation -> observation.Oas_worker.cascade_name
+    | Some observation ->
+      Keeper_cascade_profile.runtime_name_to_string
+        observation.Oas_worker.cascade_name
     | None -> meta.cascade_name
   in
   (* #9933: same latency bucket, split by provider/model/cascade.

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -33,7 +33,7 @@ type cascade_fallback_event = {
 }
 
 type cascade_observation = {
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
   strategy : string option;
   configured_labels : string list;
   candidate_models : string list;

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -39,7 +39,7 @@ let worker_max_tool_calls_per_turn = 12
 (* ================================================================ *)
 
 type cascade_observation = {
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
   strategy : string option;
   configured_labels : string list;
   candidate_models : string list;
@@ -399,9 +399,12 @@ let cascade_observation_with_metrics ~cascade_name ?strategy ~configured_labels
 (* ================================================================ *)
 
 let cascade_observation_to_json (obs : cascade_observation) : Yojson.Safe.t =
+  let cascade_name =
+    Keeper_cascade_profile.runtime_name_to_string obs.cascade_name
+  in
   `Assoc
     [
-      ("cascade_name", `String obs.cascade_name);
+      ("cascade_name", `String cascade_name);
       ("strategy", Json_util.string_opt_to_json obs.strategy);
       ( "configured_labels",
         `List (List.map (fun label -> `String label) obs.configured_labels) );

--- a/lib/oas_worker_cascade.mli
+++ b/lib/oas_worker_cascade.mli
@@ -82,7 +82,7 @@ type cascade_fallback_event = {
 }
 
 type cascade_observation = {
-  cascade_name : string;
+  cascade_name : Keeper_cascade_profile.runtime_name;
   strategy : string option;
   configured_labels : string list;
   candidate_models : string list;
@@ -146,7 +146,7 @@ val cascade_metrics_for_candidates :
     global [Llm_metric_bridge] when both are wired). *)
 
 val cascade_observation_with_metrics :
-  cascade_name:string ->
+  cascade_name:Keeper_cascade_profile.runtime_name ->
   ?strategy:string ->
   configured_labels:string list ->
   candidate_cfgs:Llm_provider.Provider_config.t list ->

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -382,7 +382,8 @@ let run_named
         | None -> Keeper_types.No_providers_available
       in
       let observation =
-        Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+        Oas_worker_cascade.cascade_observation_with_metrics
+          ~cascade_name:error_cascade_name
           ?strategy:!cascade_strategy_name_ref ~configured_labels
           ~candidate_cfgs ~selected_model_raw:None ~capture ()
       in
@@ -453,7 +454,8 @@ let run_named
           ~latency_ms:attempt_latency_ms ());
         (* FSM: Call_ok → Accept *)
         let observation =
-          Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+          Oas_worker_cascade.cascade_observation_with_metrics
+            ~cascade_name:error_cascade_name
             ?strategy:!cascade_strategy_name_ref ~configured_labels
             ~candidate_cfgs ~selected_model_raw:(Some result.response.model)
             ~capture ()
@@ -482,7 +484,8 @@ let run_named
         (match Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
          | Cascade_fsm.Accept_on_exhaustion { response; _ } ->
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+             Oas_worker_cascade.cascade_observation_with_metrics
+               ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_cfgs ~selected_model_raw:(Some response.model)
                ~capture ()
@@ -502,7 +505,8 @@ let run_named
            try_cascade ?resume_checkpoint:next_resume rest new_err
          | Cascade_fsm.Exhausted _ ->
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+             Oas_worker_cascade.cascade_observation_with_metrics
+               ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_cfgs ~selected_model_raw:(Some result.response.model)
                ~capture ()
@@ -523,7 +527,8 @@ let run_named
            (* Should be unreachable with accept_on_exhaustion:false, but handle gracefully *)
            Log.Misc.warn "cascade %s: unexpected Accept in Accept_rejected branch (model=%s)" cascade_name resp.model;
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+             Oas_worker_cascade.cascade_observation_with_metrics
+               ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_cfgs ~selected_model_raw:(Some resp.model) ~capture ()
            in
@@ -690,7 +695,8 @@ let run_named
               try_cascade ?resume_checkpoint:next_resume rest new_err
             | Cascade_fsm.Exhausted _ ->
               let observation =
-                Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+                Oas_worker_cascade.cascade_observation_with_metrics
+                  ~cascade_name:error_cascade_name
                   ?strategy:!cascade_strategy_name_ref ~configured_labels
                   ~candidate_cfgs ~selected_model_raw:None ~capture ()
               in
@@ -703,7 +709,8 @@ let run_named
          | None ->
            (* Non-API error (agent, config, etc.) — not cascadeable *)
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+             Oas_worker_cascade.cascade_observation_with_metrics
+               ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_cfgs ~selected_model_raw:None ~capture ()
            in
@@ -826,7 +833,8 @@ let run_named
   in
   let cascade_exhausted_after_filter ~cycle =
     let observation =
-      Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+      Oas_worker_cascade.cascade_observation_with_metrics
+        ~cascade_name:error_cascade_name
         ?strategy:!cascade_strategy_name_ref ~configured_labels
         ~candidate_cfgs ~selected_model_raw:None ~capture ()
     in

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1921,7 +1921,9 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
       ~model:"qwen3.5:27b-nvfp4" ~input_tok:100 ~output_tok:50
       ~cascade_observation:
         {
-          Masc_mcp.Oas_worker.cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+          Masc_mcp.Oas_worker.cascade_name =
+            Masc_mcp.Keeper_cascade_profile.Runtime_name
+              Masc_mcp.Keeper_config.default_cascade_name;
           strategy = Some "round_robin";
           configured_labels = [ "llama:auto" ];
           candidate_models =
@@ -1984,7 +1986,8 @@ let test_metrics_resolved_model_id_prefers_last_attempt_id () =
       ~cascade_observation:
         {
           Masc_mcp.Oas_worker.cascade_name =
-            Masc_mcp.Keeper_config.default_cascade_name;
+            Masc_mcp.Keeper_cascade_profile.Runtime_name
+              Masc_mcp.Keeper_config.default_cascade_name;
           strategy = Some "round_robin";
           configured_labels = [ "claude_code:auto" ];
           candidate_models =
@@ -2392,7 +2395,9 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
           cascade_observation =
             Some
               {
-                Masc_mcp.Oas_worker.cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+                Masc_mcp.Oas_worker.cascade_name =
+                  Masc_mcp.Keeper_cascade_profile.Runtime_name
+                    Masc_mcp.Keeper_config.default_cascade_name;
                 strategy = Some "round_robin";
                 configured_labels = [ "llama:auto" ];
                 candidate_models =

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -106,6 +106,18 @@ let with_env name value f =
       | None -> Unix.putenv name "")
     f
 
+let with_temp_masc_base_path prefix f =
+  let base = temp_dir prefix in
+  let previous = Sys.getenv_opt "MASC_BASE_PATH" in
+  Unix.putenv "MASC_BASE_PATH" base;
+  Fun.protect
+    ~finally:(fun () ->
+      (match previous with
+       | Some value -> Unix.putenv "MASC_BASE_PATH" value
+       | None -> Unix.putenv "MASC_BASE_PATH" "");
+      cleanup_dir base)
+    f
+
 let with_temp_masc_config cascade_json f =
   let base = temp_dir "test_masc_config" in
   let config_dir = Filename.concat base ".masc/config" in
@@ -435,7 +447,9 @@ let test_cascade_inference_normalizes_keeper_aliases () =
 let test_cascade_observation_json_includes_fallback_fields () =
   let observation : Oas_worker.cascade_observation =
     {
-      cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+      cascade_name =
+        Masc_mcp.Keeper_cascade_profile.Runtime_name
+          Masc_mcp.Keeper_config.default_cascade_name;
       strategy = Some "round_robin";
       configured_labels = [ "glm:auto"; "llama:auto" ];
       candidate_models = [ "glm:glm-5.1"; "openai:qwen3.5-35b" ];
@@ -503,6 +517,7 @@ let find_cascade_metric_entry name (json : Yojson.Safe.t) =
            name)
 
 let test_cascade_metrics_concurrent_recording () =
+  with_temp_masc_base_path "test_cascade_metrics_concurrent" @@ fun () ->
   Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ();
   Fun.protect
     ~finally:(fun () ->
@@ -532,6 +547,7 @@ let test_cascade_metrics_concurrent_recording () =
             Yojson.Safe.Util.(entry |> member "failures" |> to_int))
 
 let test_cascade_metrics_evicts_lowest_call_key () =
+  with_temp_masc_base_path "test_cascade_metrics_evicts" @@ fun () ->
   Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ();
   Fun.protect
     ~finally:(fun () ->
@@ -597,7 +613,8 @@ let test_cascade_audit_persists_observation () =
       Unix.putenv "MASC_BASE_PATH" base;
       let observation : Masc_mcp.Oas_worker_cascade.cascade_observation =
         {
-          cascade_name = "audit-cascade";
+          cascade_name =
+            Masc_mcp.Keeper_cascade_profile.Runtime_name "audit-cascade";
           strategy = Some "round_robin";
           configured_labels = [ "glm:auto"; "openai:auto" ];
           candidate_models = [ "glm:glm-5.1"; "openai:qwen3.5-35b" ];
@@ -644,6 +661,7 @@ let test_cascade_audit_persists_observation () =
         ~observation:(Some observation)
         ~outcome:`Failure
         ();
+      ignore (Oas_worker.cascade_metrics_json ());
       let store =
         Dated_jsonl.create
           ~base_dir:(Filename.concat base ".masc/cascade_audit")
@@ -3787,6 +3805,8 @@ let () =
     ~proc_mgr:(Eio.Stdenv.process_mgr env)
     ~clock:(Eio.Stdenv.clock env);
   Eio_guard.enable ();
+  Eio.Switch.run @@ fun sw ->
+  Masc_mcp.Oas_worker_cascade.start_actor_if_needed ~sw;
   Alcotest.run "OAS Worker" [
     "sse_event_bridge", [
       Alcotest.test_case "text delta extraction" `Quick


### PR DESCRIPTION
## Summary

- Type `Oas_worker_cascade.cascade_observation.cascade_name` as `Keeper_cascade_profile.runtime_name`.
- Keep string rendering at JSON, decision-record, and latency-bucket boundaries.
- Pass the typed runtime cascade name from `Oas_worker_named` observation materialization and update tests.
- Start the cascade audit actor in `test_oas_worker` and isolate metrics/audit tests under temp `MASC_BASE_PATH`.

## Product impact

This continues #11926's cascade-name type ratchet by moving OAS observation snapshots off raw string cascade names while preserving operator-facing JSON and metrics labels. The test actor wiring also makes cascade audit persistence tests exercise the real mailbox drain path instead of relying on an unstarted actor.

## Evidence

- `scripts/dune-local.sh build test/test_oas_worker.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_oas_worker.exe test cascade_config`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 2`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 3`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 17`
- `git diff --check`
- `scripts/stringly-boundary-ratchet.sh`
- `scripts/ocaml-structure-ratchet.sh`

## Review evidence

- `raw_cascade_name_string_signatures`: `47 -> 43`
- `raw_decision_string_signatures`: `0`
- `raw_error_kind_string_signatures`: `0`

## Linked issue

- Part of #11926
