### PR TITLE
fix(runtime): reconcile keeper task state and utf8 persistence

### DIFF
--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -263,14 +263,17 @@ let read_text config path =
   match key_of_path config path with
   | Some key -> begin
       match backend_get config ~key with
-      | Ok (Some content) -> content
+      | Ok (Some content) ->
+        Safe_ops.repair_utf8_text ~surface:"coord_text" ~path content
       | Ok None -> ""
       | Error e ->
         Log.Misc.warn "[read_text] backend_get failed for %s: %s" key (Backend_types.show_error e);
         ""
     end
   | None ->
-      if Fs_compat.file_exists path then Fs_compat.load_file path
+      if Fs_compat.file_exists path then
+        Fs_compat.load_file path
+        |> Safe_ops.repair_utf8_text ~surface:"coord_text" ~path
       else ""
 
 let should_dual_write_local (config : config) =

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -200,6 +200,11 @@ let extract_github_org url =
       | [] -> None)
   | None -> None
 
+let normalize_github_clone_url url =
+  match extract_github_org_repo url with
+  | Some org_repo -> "https://github.com/" ^ org_repo ^ ".git"
+  | None -> url
+
 let validate_clone_origin_url ~base_path url =
   match load_git_clone_policy_result ~base_path with
   | Error msg ->
@@ -623,6 +628,20 @@ let git_origin_url root =
   | Unix.WEXITED 0, output -> first_nonempty_line output
   | _ -> None
 
+let normalize_origin_remote_to_https root =
+  match git_origin_url root with
+  | None -> None
+  | Some origin_url ->
+      let normalized = normalize_github_clone_url origin_url in
+      if String.equal origin_url normalized then None
+      else
+        match
+          run_argv_with_status
+            [ "git"; "-C"; root; "remote"; "set-url"; "origin"; normalized ]
+        with
+        | Unix.WEXITED 0, _ -> Some normalized
+        | _ -> None
+
 let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
   let search_root = project_root config in
   match workspace_repo_matches ~search_root ~repo_name with
@@ -663,6 +682,7 @@ let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
                          "auto_provision_clone_failed: origin %s rejected by clone policy: %s"
                          origin_url err))
              | Ok () ->
+                 let origin_url = normalize_github_clone_url origin_url in
                  let status, output =
                    run_argv_with_status [ "git"; "clone"; origin_url; clone_path ]
                  in
@@ -854,6 +874,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                Use the longer git_fetch_timeout_sec budget — the default
                30s rejected legitimately slow Docker-bridge fetches and
                cold fetches on large remotes (#9587). *)
+            ignore (normalize_origin_remote_to_https root : string option);
             let fetch_exit =
               run_argv_exit
                 ~timeout_sec:(Env_config_core.git_fetch_timeout_sec ())

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -59,8 +59,83 @@ let handle f handler =
     Printexc.raise_with_backtrace e bt
   | exn -> handler exn
 
+type utf8_repair_stats =
+  { repaired_reads : int
+  ; repaired_bytes : int
+  ; path_samples : string list
+  }
+
+let utf8_repair_mu = Stdlib.Mutex.create ()
+let utf8_repaired_reads = ref 0
+let utf8_repaired_bytes = ref 0
+let utf8_repair_path_samples = ref []
+let utf8_repair_path_sample_limit = 8
+
+let record_utf8_repair ~surface ~path ~invalid_bytes =
+  let surface = if String.trim surface = "" then "persistence" else surface in
+  let path = match path with Some p when String.trim p <> "" -> p | _ -> "(unknown)" in
+  Stdlib.Mutex.protect utf8_repair_mu (fun () ->
+      incr utf8_repaired_reads;
+      utf8_repaired_bytes := !utf8_repaired_bytes + invalid_bytes;
+      if not (List.mem path !utf8_repair_path_samples) then
+        utf8_repair_path_samples :=
+          (path :: !utf8_repair_path_samples)
+          |> List.filteri (fun i _ -> i < utf8_repair_path_sample_limit));
+  Log.Misc.warn "[%s] persistence UTF-8 repaired path=%s invalid_bytes=%d"
+    surface path invalid_bytes
+
+let persistence_utf8_repair_stats () =
+  Stdlib.Mutex.protect utf8_repair_mu (fun () ->
+      { repaired_reads = !utf8_repaired_reads
+      ; repaired_bytes = !utf8_repaired_bytes
+      ; path_samples = List.rev !utf8_repair_path_samples
+      })
+
+let reset_persistence_utf8_repair_stats_for_tests () =
+  Stdlib.Mutex.protect utf8_repair_mu (fun () ->
+      utf8_repaired_reads := 0;
+      utf8_repaired_bytes := 0;
+      utf8_repair_path_samples := [])
+
+let count_invalid_utf8_bytes s =
+  let len = String.length s in
+  let rec loop i count =
+    if i >= len then count
+    else
+      let dec = String.get_utf_8_uchar s i in
+      let dlen = Uchar.utf_decode_length dec in
+      if dlen > 0 && Uchar.utf_decode_is_valid dec then
+        loop (i + dlen) count
+      else
+        loop (i + 1) (count + 1)
+  in
+  loop 0 0
+
+let repair_utf8_text ?(surface = "persistence") ?path s =
+  let invalid_bytes = count_invalid_utf8_bytes s in
+  if invalid_bytes = 0 then s
+  else
+    let len = String.length s in
+    let buf = Buffer.create len in
+    let rec loop i =
+      if i >= len then ()
+      else
+        let dec = String.get_utf_8_uchar s i in
+        let dlen = Uchar.utf_decode_length dec in
+        if dlen > 0 && Uchar.utf_decode_is_valid dec then (
+          Buffer.add_substring buf s i dlen;
+          loop (i + dlen))
+        else (
+          Buffer.add_string buf "\xEF\xBF\xBD";
+          loop (i + 1))
+    in
+    loop 0;
+    record_utf8_repair ~surface ~path ~invalid_bytes;
+    Buffer.contents buf
+
 (** Parse JSON with detailed error reporting *)
 let parse_json_safe ~context str : (Yojson.Safe.t, string) result =
+  let str = repair_utf8_text ~surface:"json" ~path:context str in
   try Ok (Yojson.Safe.from_string str)
   with Yojson.Json_error msg ->
     let preview = String_util.utf8_safe ~max_bytes:53 ~suffix:"..." str |> String_util.to_string in
@@ -132,7 +207,7 @@ let result_to_option_logged ~on_drop ~surface ~reason ~path = function
     Drop-in replacement for [Yojson.Safe.from_file] in Eio fiber contexts.
     Falls back to blocking I/O when Eio fs is not set. *)
 let read_json_eio (path : string) : Yojson.Safe.t =
-  let content = Fs_compat.load_file path in
+  let content = Fs_compat.load_file path |> repair_utf8_text ~surface:"json_eio" ~path in
   Yojson.Safe.from_string content
 
 (** List files in directory safely *)

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -26,6 +26,24 @@ val handle : (unit -> 'a) -> (exn -> 'a) -> 'a
 
 (** {1 JSON Parsing} *)
 
+type utf8_repair_stats =
+  { repaired_reads : int
+  ; repaired_bytes : int
+  ; path_samples : string list
+  }
+
+val repair_utf8_text :
+  ?surface:string -> ?path:string -> string -> string
+(** Replace malformed UTF-8 byte sequences with U+FFFD and record an
+    observable persistence repair. Valid UTF-8 is returned unchanged. *)
+
+val persistence_utf8_repair_stats : unit -> utf8_repair_stats
+(** Process-local cumulative count of malformed UTF-8 repairs seen by
+    persistence read helpers. *)
+
+val reset_persistence_utf8_repair_stats_for_tests : unit -> unit
+(** Reset {!persistence_utf8_repair_stats}. Test-only. *)
+
 val parse_json_safe : context:string -> string -> (Yojson.Safe.t, string) result
 (** Parse JSON with detailed error reporting. *)
 

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -339,9 +339,26 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       (* Execution queue: top 10 priority items *)
       let limited_queue = take 10 execution_queue in
       let base_fields =
+        let utf8_repair = Safe_ops.persistence_utf8_repair_stats () in
         [
           ("generated_at", `String (Types.now_iso ()));
           ("status", room_status_json config);
+          ( "projection_diagnostics",
+            `Assoc
+              [
+                ("surface", `String "execution");
+                ("coordination_root", `String config.base_path);
+                ("workspace_path", `String config.workspace_path);
+                ( "persistence_sanitized_count",
+                  `Int utf8_repair.repaired_reads );
+                ( "persistence_sanitized_bytes",
+                  `Int utf8_repair.repaired_bytes );
+                ( "persistence_sanitized_paths_sample",
+                  `List
+                    (List.map
+                       (fun path -> `String path)
+                       utf8_repair.path_samples) );
+              ] );
           ("execution_queue", `List (List.map (fun (row : queue_context) -> row.json) limited_queue));
           ("operation_briefs", `List (List.map (fun (row : operation_context) -> row.json) limited_ops));
           ("worker_support_briefs", `List (List.map (fun (row : worker_context) -> row.json) worker_support_briefs));

--- a/lib/dune
+++ b/lib/dune
@@ -546,7 +546,7 @@
    keeper_runtime_contract
    keeper_runtime_trust_snapshot
    keeper_agent_prompt_metrics
-   keeper_agent_tool_surface
+   keeper_current_task_reconcile keeper_agent_tool_surface
    keeper_agent_result
    keeper_agent_error
    keeper_turn_terminal
@@ -756,7 +756,7 @@
   keeper_model_labels
   keeper_fs
   keeper_identity
-  keeper_checkpoint_store
+  keeper_current_task_reconcile keeper_checkpoint_store
   keeper_text_processing
   keeper_summarizer
   keeper_context_core

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -190,93 +190,17 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
        task_update, task_done, etc.). *)
     Oas.Types.Any
 
-let owned_active_task_id_for_meta ~(config : Coord.config)
-    ~(meta : Keeper_types.keeper_meta) =
-  match meta.current_task_id with
-  | Some task_id -> Some task_id
-  | None ->
-    let actual_name =
-      try Coord.resolve_agent_name config meta.agent_name
-      with
-      | Sys_error _ | Yojson.Json_error _ -> meta.agent_name
-      | exn ->
-        Log.Keeper.warn
-          "keeper:%s resolve_agent_name failed while reconciling current task: %s"
-          meta.name (Printexc.to_string exn);
-        meta.agent_name
-    in
-    let matches assignee =
-      String.equal assignee meta.agent_name || String.equal assignee actual_name
-    in
-    (try
-       Coord.get_tasks_raw config
-       |> List.find_map (fun (task : Types.task) ->
-            match task.task_status with
-            | Types.Claimed { assignee; _ }
-            | Types.InProgress { assignee; _ }
-            | Types.AwaitingVerification { assignee; _ }
-              when matches assignee -> (
-                match Keeper_id.Task_id.of_string task.id with
-                | Ok task_id -> Some task_id
-                | Error msg ->
-                  Log.Keeper.warn
-                    "keeper:%s owned task %s could not be parsed: %s"
-                    meta.name task.id msg;
-                  None)
-            | Types.Claimed _
-            | Types.InProgress _
-            | Types.AwaitingVerification _
-            | Types.Todo
-            | Types.Done _
-            | Types.Cancelled _ -> None)
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Log.Keeper.warn
-         "keeper:%s owned task reconciliation failed: %s"
-         meta.name (Printexc.to_string exn);
-       None)
-;;
+let owned_active_task_id_for_meta =
+  Keeper_current_task_reconcile.owned_active_task_id_for_meta
 
-let merge_current_task_id ~(latest : Keeper_types.keeper_meta)
-    ~(caller : Keeper_types.keeper_meta) =
-  {
-    latest with
-    current_task_id = caller.current_task_id;
-    updated_at = caller.updated_at;
-  }
-;;
+let merge_current_task_id =
+  Keeper_current_task_reconcile.merge_current_task_id
 
-let sync_current_task_id_from_backlog ~(config : Coord.config)
-    (meta : Keeper_types.keeper_meta) =
-  match meta.current_task_id with
-  | Some _ -> meta
-  | None -> (
-    match owned_active_task_id_for_meta ~config ~meta with
-    | None -> meta
-    | Some task_id ->
-      let updated_meta =
-        {
-          meta with
-          current_task_id = Some task_id;
-          updated_at = Types.now_iso ();
-        }
-      in
-      Keeper_registry.update_meta ~base_path:config.base_path meta.name updated_meta;
-      (match
-         Keeper_types.write_meta_with_merge
-           ~merge:merge_current_task_id config updated_meta
-       with
-       | Ok () -> ()
-       | Error msg ->
-         Log.Keeper.warn
-           "keeper:%s failed to persist reconciled current_task_id=%s: %s"
-           meta.name (Keeper_id.Task_id.to_string task_id) msg);
-      Log.Keeper.info
-        "keeper:%s reconciled current_task_id=%s from backlog ownership"
-        meta.name (Keeper_id.Task_id.to_string task_id);
-      updated_meta)
-;;
+let sync_current_task_id_from_backlog =
+  Keeper_current_task_reconcile.sync_current_task_id_from_backlog
+
+let sync_current_task_id_for_agent_name =
+  Keeper_current_task_reconcile.sync_current_task_id_for_agent_name
 
 let tool_names =
   List.map Tool_name.to_string

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -118,6 +118,13 @@ val sync_current_task_id_from_backlog :
   Keeper_types.keeper_meta ->
   Keeper_types.keeper_meta
 
+(** Best-effort reconciliation for callers that only know an agent name.
+    No-ops for non-keeper agents. *)
+val sync_current_task_id_for_agent_name :
+  config:Coord.config ->
+  agent_name:string ->
+  unit
+
 (** Convenience [List.map Tool_name.to_string]. *)
 val tool_names : Tool_name.t list -> string list
 

--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -1,0 +1,147 @@
+(** Keeper current-task reconciliation shared by task transitions and
+    keeper run-context assembly.
+
+    This module intentionally does not depend on Tool_task or
+    Keeper_agent_tool_surface, so lifecycle transitions can update keeper meta
+    without creating a keeper tool-surface dependency cycle. *)
+
+let resolved_agent_names ~(config : Coord.config) ~(agent_name : string) =
+  let actual_name =
+    try Coord.resolve_agent_name config agent_name
+    with
+    | Sys_error _ | Yojson.Json_error _ -> agent_name
+    | exn ->
+      Log.Keeper.warn
+        "resolve_agent_name failed while reconciling current task for %s: %s"
+        agent_name (Printexc.to_string exn);
+      agent_name
+  in
+  [ agent_name; actual_name ] |> List.sort_uniq String.compare
+
+let task_id_of_owned_active_task ~(keeper_name : string) (task : Types.task) =
+  match Keeper_id.Task_id.of_string task.id with
+  | Ok task_id -> Some task_id
+  | Error msg ->
+    Log.Keeper.warn
+      "keeper:%s owned task %s could not be parsed: %s"
+      keeper_name task.id msg;
+    None
+
+let owned_active_task_ids_for_meta ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta) =
+  let names = resolved_agent_names ~config ~agent_name:meta.agent_name in
+  let matches assignee = List.mem assignee names in
+  try
+    Coord.get_tasks_raw config
+    |> List.filter_map (fun (task : Types.task) ->
+         match task.task_status with
+         | Types.Claimed { assignee; _ }
+         | Types.InProgress { assignee; _ }
+           when matches assignee ->
+             task_id_of_owned_active_task ~keeper_name:meta.name task
+         | Types.Claimed _
+         | Types.InProgress _
+         | Types.AwaitingVerification _
+         | Types.Todo
+         | Types.Done _
+         | Types.Cancelled _ -> None)
+    |> List.sort_uniq (fun a b ->
+         String.compare
+           (Keeper_id.Task_id.to_string a)
+           (Keeper_id.Task_id.to_string b))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "keeper:%s owned task reconciliation failed: %s"
+      meta.name (Printexc.to_string exn);
+    []
+
+let owned_active_task_id_for_meta ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta) =
+  match owned_active_task_ids_for_meta ~config ~meta with
+  | [ task_id ] -> Some task_id
+  | [] -> None
+  | task_ids ->
+    Log.Keeper.warn
+      "keeper:%s has %d active owned tasks; leaving current_task_id unset until one task is explicit"
+      meta.name (List.length task_ids);
+    None
+
+let merge_current_task_id ~(latest : Keeper_types.keeper_meta)
+    ~(caller : Keeper_types.keeper_meta) =
+  {
+    latest with
+    current_task_id = caller.current_task_id;
+    updated_at = caller.updated_at;
+  }
+
+let sync_current_task_id_from_backlog ~(config : Coord.config)
+    (meta : Keeper_types.keeper_meta) =
+  let desired = owned_active_task_id_for_meta ~config ~meta in
+  let equal =
+    match meta.current_task_id, desired with
+    | None, None -> true
+    | Some a, Some b -> Keeper_id.Task_id.equal a b
+    | Some _, None | None, Some _ -> false
+  in
+  if equal then meta
+  else
+    let updated_meta =
+      { meta with current_task_id = desired; updated_at = Types.now_iso () }
+    in
+    Keeper_registry.update_meta ~base_path:config.base_path meta.name updated_meta;
+    (match
+       Keeper_types.write_meta_with_merge
+         ~merge:merge_current_task_id config updated_meta
+     with
+     | Ok () -> ()
+     | Error msg ->
+       Log.Keeper.warn
+         "keeper:%s failed to persist reconciled current_task_id=%s: %s"
+         meta.name
+         (match desired with
+          | Some task_id -> Keeper_id.Task_id.to_string task_id
+          | None -> "(cleared)")
+         msg);
+    Log.Keeper.info
+      "keeper:%s reconciled current_task_id=%s from backlog ownership"
+      meta.name
+      (match desired with
+       | Some task_id -> Keeper_id.Task_id.to_string task_id
+       | None -> "(cleared)");
+    updated_meta
+
+let keeper_name_candidates ~(config : Coord.config) ~(agent_name : string) =
+  resolved_agent_names ~config ~agent_name
+  |> List.filter_map Keeper_identity.canonical_keeper_name
+  |> List.sort_uniq String.compare
+
+let sync_current_task_id_for_agent_name ~(config : Coord.config) ~agent_name =
+  let candidates = keeper_name_candidates ~config ~agent_name in
+  let entry_from_candidates =
+    candidates
+    |> List.find_map (fun name ->
+         match Keeper_registry.get ~base_path:config.base_path name with
+         | Some entry -> Some entry
+         | None -> None)
+  in
+  let entry =
+    match entry_from_candidates with
+    | Some _ as entry -> entry
+    | None ->
+      Keeper_registry.all ~base_path:config.base_path ()
+      |> List.find_opt (fun (entry : Keeper_registry.registry_entry) ->
+           String.equal entry.meta.agent_name agent_name)
+  in
+  match entry with
+  | Some entry ->
+    ignore (sync_current_task_id_from_backlog ~config entry.meta : Keeper_types.keeper_meta)
+  | None ->
+    candidates
+    |> List.find_map (fun name ->
+         match Keeper_types.read_meta config name with
+         | Ok (Some meta) -> Some meta
+         | Ok None | Error _ -> None)
+    |> Option.iter (fun meta ->
+         ignore (sync_current_task_id_from_backlog ~config meta : Keeper_types.keeper_meta))

--- a/lib/keeper/keeper_current_task_reconcile.mli
+++ b/lib/keeper/keeper_current_task_reconcile.mli
@@ -1,0 +1,29 @@
+(** Reconcile keeper [current_task_id] with active backlog ownership. *)
+
+(** Find the single active task a keeper owns.
+
+    Only [Claimed] and [InProgress] tasks are active bindings. Tasks awaiting
+    verification have left the keeper's execution lane and clear the binding. *)
+val owned_active_task_id_for_meta :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  Keeper_id.Task_id.t option
+
+(** Field-level merge for [Keeper_types.write_meta_with_merge]. *)
+val merge_current_task_id :
+  latest:Keeper_types.keeper_meta ->
+  caller:Keeper_types.keeper_meta ->
+  Keeper_types.keeper_meta
+
+(** Persist [meta.current_task_id] after comparing it with backlog ownership. *)
+val sync_current_task_id_from_backlog :
+  config:Coord.config ->
+  Keeper_types.keeper_meta ->
+  Keeper_types.keeper_meta
+
+(** Best-effort reconciliation for callers that only know an agent name.
+    No-ops for non-keeper agents. *)
+val sync_current_task_id_for_agent_name :
+  config:Coord.config ->
+  agent_name:string ->
+  unit

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -564,19 +564,6 @@ let gh_simple_command_has_repo_flag cmd =
 let gh_simple_command_with_repo_flag ~repo_slug cmd =
   { argv = inject_repo_flag_args ~repo_slug cmd.argv }
 
-let run_argv_first_line_unix ~(prog : string) ~(argv : string array) : string option =
-  try
-    match
-      With_process.with_process_args_in prog argv (fun ic ->
-        With_process.drain_lines ic
-        |> List.map String.trim
-        |> List.find_opt (fun line -> line <> ""))
-    with
-    | line, Unix.WEXITED 0 -> line
-    | _ -> None
-  with
-  | Unix.Unix_error _ | Sys_error _ -> None
-
 let inject_repo_flag_cmd ~repo_slug cmd =
   let normalized = normalize_gh_command cmd in
   if has_repo_flag normalized
@@ -584,33 +571,14 @@ let inject_repo_flag_cmd ~repo_slug cmd =
   else String.trim (normalized ^ " --repo " ^ repo_slug)
 
 let repo_slug_of_remote_url url =
-  let url = String.trim url in
-  let strip_git s =
-    if String.length s > 4 && String.sub s (String.length s - 4) 4 = ".git"
-    then String.sub s 0 (String.length s - 4)
-    else s
-  in
-  match String.split_on_char ':' url with
-  | [ _; path ] when String.contains url '@' ->
-      validate_repo_slug (strip_git path) |> Result.to_option
-  | _ ->
-      let parts = String.split_on_char '/' url in
-      let n = List.length parts in
-      if n >= 2
-      then
-        match List.nth_opt parts (n - 2), List.nth_opt parts (n - 1) with
-        | Some owner, Some last_part ->
-            let repo = strip_git last_part in
-            validate_repo_slug (owner ^ "/" ^ repo) |> Result.to_option
-        | _ -> None
-      else
-        None
+  match Tool_code_write.extract_github_org_repo url with
+  | Some slug -> validate_repo_slug slug |> Result.to_option
+  | None -> None
 
-(** Cached owner/repo slug from git remote origin. *)
-let _repo_slug_cache : string option option ref = ref None
-
-let repo_slug_of_git_config ~git_root =
-  let config_path = Filename.concat git_root ".git/config" in
+(** Read an origin slug from a concrete git config path without invoking git.
+    This survives host/container worktree divergence where [.git] points at a
+    container-only gitdir but the host-side parent clone config is readable. *)
+let origin_url_of_git_config_path config_path =
   if not (Sys.file_exists config_path)
   then None
   else
@@ -637,24 +605,121 @@ let repo_slug_of_git_config ~git_root =
                 then String.sub trimmed 6 (String.length trimmed - 6)
                 else String.sub trimmed 4 (String.length trimmed - 4)
               in
-              repo_slug_of_remote_url value
+              Some (String.trim value)
             else loop ~in_origin
           | exception End_of_file -> None
         in
         loop ~in_origin:false)
 
+let repo_slug_of_git_config_path config_path =
+  match origin_url_of_git_config_path config_path with
+  | Some url -> repo_slug_of_remote_url url
+  | None -> None
+
+(** Cached owner/repo slug from git remote origin. *)
+let _repo_slug_cache : string option option ref = ref None
+
+let repo_slug_of_git_config ~git_root =
+  Filename.concat git_root ".git/config" |> repo_slug_of_git_config_path
+
+let repo_root_inferred_from_worktree_cwd worktree_cwd =
+  let marker = "/.worktrees/" in
+  match String_util.find_substring worktree_cwd marker with
+  | None -> None
+  | Some idx -> Some (String.sub worktree_cwd 0 idx)
+
+let repo_slug_of_worktree_parent_config ~worktree_cwd =
+  match repo_root_inferred_from_worktree_cwd worktree_cwd with
+  | Some repo_root -> repo_slug_of_git_config ~git_root:repo_root
+  | None -> None
+
+let origin_url_of_worktree_parent_config ~worktree_cwd =
+  match repo_root_inferred_from_worktree_cwd worktree_cwd with
+  | Some repo_root ->
+    origin_url_of_git_config_path
+      (Filename.concat repo_root ".git/config")
+  | None -> None
+
+let origin_url_of_worktree_gitfile ~worktree_cwd =
+  let dotgit = Filename.concat worktree_cwd ".git" in
+  if not (Sys.file_exists dotgit) || Sys.is_directory dotgit then None
+  else
+    try
+      let line =
+        let ic = open_in_bin dotgit in
+        Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+            input_line ic)
+      in
+      let prefix = "gitdir:" in
+      let trimmed = String.trim line in
+      if not (String.starts_with ~prefix trimmed) then None
+      else
+        let raw = String.sub trimmed (String.length prefix)
+            (String.length trimmed - String.length prefix)
+          |> String.trim
+        in
+        let gitdir =
+          if Filename.is_relative raw then Filename.concat worktree_cwd raw
+          else raw
+        in
+        match origin_url_of_git_config_path (Filename.concat gitdir "config") with
+        | Some _ as origin -> origin
+        | None ->
+          let common_git_dir =
+            Filename.dirname (Filename.dirname gitdir)
+          in
+          origin_url_of_git_config_path
+            (Filename.concat common_git_dir "config")
+    with
+    | Sys_error _ | End_of_file -> None
+
+let repo_slug_of_worktree_gitfile ~worktree_cwd =
+  match origin_url_of_worktree_gitfile ~worktree_cwd with
+  | Some url -> repo_slug_of_remote_url url
+  | None -> None
+
+let repo_slug_of_git_command ~cwd =
+  match
+    Process_eio.run_argv_with_status
+      ~cwd
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ())
+      [ "git"; "remote"; "get-url"; "origin" ]
+  with
+  | Unix.WEXITED 0, url -> repo_slug_of_remote_url url
+  | _ -> None
+
+let origin_url_of_git_command ~cwd =
+  match
+    Process_eio.run_argv_with_status
+      ~cwd
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ())
+      [ "git"; "remote"; "get-url"; "origin" ]
+  with
+  | Unix.WEXITED 0, url ->
+    let url = String.trim url in
+    if url = "" then None else Some url
+  | _ -> None
+
+let origin_url_of_task_worktree ~git_root ~worktree_cwd =
+  [ (fun () ->
+      origin_url_of_git_config_path
+        (Filename.concat git_root ".git/config"))
+  ; (fun () -> origin_url_of_worktree_parent_config ~worktree_cwd)
+  ; (fun () -> origin_url_of_worktree_gitfile ~worktree_cwd)
+  ; (fun () -> origin_url_of_git_command ~cwd:git_root)
+  ; (fun () -> origin_url_of_git_command ~cwd:worktree_cwd)
+  ]
+  |> List.find_map (fun f -> f ())
+
+let repo_slug_of_task_worktree ~git_root ~worktree_cwd =
+  match origin_url_of_task_worktree ~git_root ~worktree_cwd with
+  | Some url -> repo_slug_of_remote_url url
+  | None -> None
+
 let repo_slug_of_git_root ~git_root =
   match repo_slug_of_git_config ~git_root with
   | Some slug -> Some slug
-  | None ->
-    (match
-       Process_eio.run_argv_with_status
-         ~cwd:git_root
-         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ())
-         [ "git"; "remote"; "get-url"; "origin" ]
-     with
-     | Unix.WEXITED 0, url -> repo_slug_of_remote_url url
-     | _ -> None)
+  | None -> repo_slug_of_git_command ~cwd:git_root
 
 let project_repo_slug () : string option =
   match !_repo_slug_cache with
@@ -685,23 +750,23 @@ let resolve_task_repo_context
       | None -> Error (Current_task_missing_worktree task_id)
       | Some wt ->
         let git_root = wt.git_root in
-        (match
-           run_argv_first_line_unix
-             ~prog:"git"
-             ~argv:[| "git"; "-C"; git_root; "remote"; "get-url"; "origin" |]
-         with
-         | Some origin_url ->
-           let origin_url = String.trim origin_url in
-           (match Tool_code_write.extract_github_org_repo origin_url with
-            | Some repo_slug -> Ok { task_id; git_root; repo_slug }
-            | None ->
+        let worktree_cwd =
+          if Filename.is_relative wt.path
+          then Filename.concat git_root wt.path
+          else wt.path
+        in
+        (match repo_slug_of_task_worktree ~git_root ~worktree_cwd with
+         | Some repo_slug -> Ok { task_id; git_root; repo_slug }
+         | None ->
+           (match origin_url_of_task_worktree ~git_root ~worktree_cwd with
+            | Some _ ->
               Error
                 (Current_task_origin_not_github
-                   { task_id; git_root }))
-         | None ->
+                   { task_id; git_root })
+            | None ->
            Error
              (Current_task_origin_unavailable
-                { task_id; git_root }))
+                { task_id; git_root })))
 
 (** Replace a wrong --repo/-R slug in cmd with the correct one.
     Returns (corrected_cmd, was_corrected). *)

--- a/lib/keeper/keeper_gh_shared.mli
+++ b/lib/keeper/keeper_gh_shared.mli
@@ -136,6 +136,13 @@ val inject_repo_flag_cmd : repo_slug:string -> string -> string
 
 val project_repo_slug : unit -> string option
 
+val repo_slug_of_remote_url : string -> string option
+
+val repo_slug_of_git_config : git_root:string -> string option
+
+val repo_slug_of_task_worktree :
+  git_root:string -> worktree_cwd:string -> string option
+
 val resolve_task_repo_context :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_shell_gh_context.ml
+++ b/lib/keeper/keeper_shell_gh_context.ml
@@ -134,7 +134,10 @@ let resolve_gh_repo_context ~(config : Coord.config) ~(meta : keeper_meta)
                          ^ " If the task is already claimed, recreate the linked task worktree, then retry the gh command.")
                       ())
                else
-                 match Keeper_gh_shared.repo_slug_of_git_root ~git_root with
+                 match
+                   Keeper_gh_shared.repo_slug_of_task_worktree
+                     ~git_root ~worktree_cwd
+                 with
                  | Some repo_slug ->
                      Ok
                        {

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -906,6 +906,7 @@ let handle_keeper_shell
                ; "url", `String url
                ])
        | Ok () ->
+         let clone_url = Tool_code_write.normalize_github_clone_url url in
          let _bundle_paths = Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta in
          ignore (_bundle_paths : string list);
          let playground = keeper_playground_root ~config ~meta in
@@ -952,6 +953,30 @@ let handle_keeper_shell
            | Ok env ->
                Process_eio.run_argv_with_status ?env ~cwd ~timeout_sec argv
          in
+         let normalize_existing_origin_to_https clone_path =
+           match
+             Process_eio.run_argv_with_status
+               ~timeout_sec:10.0
+               [ "git"; "-C"; clone_path; "remote"; "get-url"; "origin" ]
+           with
+           | Unix.WEXITED 0, origin ->
+             let origin = String.trim origin in
+             let normalized = Tool_code_write.normalize_github_clone_url origin in
+             if String.equal origin normalized then None
+             else
+               (match
+                  Process_eio.run_argv_with_status
+                    ~timeout_sec:10.0
+                    [ "git"; "-C"; clone_path; "remote"; "set-url"; "origin"; normalized ]
+                with
+                | Unix.WEXITED 0, _ -> Some "origin remote normalized to HTTPS"
+                | _, out ->
+                  Some
+                    (Printf.sprintf
+                       "origin remote normalization failed: %s"
+                       (String.trim out)))
+           | _ -> None
+         in
          if Fs_compat.file_exists clone_path then
            (* Existing sandbox clones may have a .git directory but no
               checked-out files. Repair that locally before a pull, otherwise
@@ -973,6 +998,9 @@ let handle_keeper_shell
                        ]
                       @ route_fields))
             | Ok repair_note ->
+                let origin_repair_note =
+                  normalize_existing_origin_to_https clone_path
+                in
                 (* Already cloned — pull latest instead *)
                 let st, out =
                   if docker_hard_mode_brokered then
@@ -997,9 +1025,11 @@ let handle_keeper_shell
                     ~playground_dir:playground ~repo_name ~repo_path:clone_path
                     ~action:"pull" ~shallow:false;
                 let repair_fields =
-                  match repair_note with
-                  | None -> []
-                  | Some note -> [ "repair_note", `String note ]
+                  [ repair_note; origin_repair_note ]
+                  |> List.filter_map (fun note -> note)
+                  |> function
+                  | [] -> []
+                  | notes -> [ "repair_note", `String (String.concat "; " notes) ]
                 in
                 Yojson.Safe.to_string
                   (`Assoc
@@ -1022,12 +1052,12 @@ let handle_keeper_shell
              if docker_hard_mode_brokered then
                run_brokered_git ~cwd:repos_dir
                  ~timeout_sec:(Keeper_tool_policy.clone_timeout_sec ())
-                 ("git" :: "clone" :: depth_args @ [ url; clone_path ])
+                 ("git" :: "clone" :: depth_args @ [ clone_url; clone_path ])
              else if meta.sandbox_profile = Docker then
                let clone_cmd =
                  String.concat " "
                    (List.map Filename.quote
-                      ("git" :: "clone" :: depth_args @ [ url; repo_name ]))
+                      ("git" :: "clone" :: depth_args @ [ clone_url; repo_name ]))
                in
                match
                  Keeper_shell_shared.run_docker_shell_command_with_status ~config ~meta ~cwd:repos_dir
@@ -1040,7 +1070,7 @@ let handle_keeper_shell
              else
                Process_eio.run_argv_with_status
                  ~timeout_sec:(Keeper_tool_policy.clone_timeout_sec ())
-                 ("git" :: "clone" :: depth_args @ [ url; clone_path ])
+                 ("git" :: "clone" :: depth_args @ [ clone_url; clone_path ])
            in
            if st = Unix.WEXITED 0 then
              Keeper_shell_shared.update_playground_repo_cache

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -307,6 +307,16 @@ let extract_github_org_repo url =
       Some (org ^ "/" ^ repo)
     | _ -> None
 
+let canonical_github_https_clone_url url =
+  match extract_github_org_repo url with
+  | Some slug -> Some ("https://github.com/" ^ slug ^ ".git")
+  | None -> None
+
+let normalize_github_clone_url url =
+  match canonical_github_https_clone_url url with
+  | Some normalized -> normalized
+  | None -> url
+
 let load_clone_denied_repos ~base_path =
   match get_policy_config ~base_path with
   | Some cfg -> Keeper_tool_policy_config.git_clone_denied_repos cfg
@@ -657,6 +667,7 @@ let handle_code_git ctx args =
         match validate_clone_cwd ~agent_name:ctx.agent_name ctx.config cwd with
         | Error e -> (false, Types.masc_error_to_string e)
         | Ok abs_cwd ->
+          let clone_url = normalize_github_clone_url url in
           (* Only pass the validated URL — no extra args allowed.
              Depth and timeout are config-driven via [git_clone] in tool_policy.toml. *)
           let depth = match get_policy_config ~base_path:ctx.config.Coord.base_path with
@@ -674,7 +685,7 @@ let handle_code_git ctx args =
                      Printf.sprintf "cd %s && git clone%s %s"
                        (Filename.quote abs_cwd)
                        depth_flag
-                       (Filename.quote url)]
+                       (Filename.quote clone_url)]
           in
           match Process_eio.run_argv_with_status ~timeout_sec:timeout cmd with
           | Unix.WEXITED code, output ->

--- a/lib/tool_code_write.mli
+++ b/lib/tool_code_write.mli
@@ -159,6 +159,15 @@ val extract_github_org_repo : string -> string option
     are rejected so org-level allow + repo-level deny lookups
     cannot be confused by sub-paths. *)
 
+val canonical_github_https_clone_url : string -> string option
+(** Return [Some "https://github.com/org/repo.git"] for supported
+    GitHub SSH/HTTPS clone URLs, using the same parser as
+    {!extract_github_org_repo}. *)
+
+val normalize_github_clone_url : string -> string
+(** Convert supported GitHub SSH clone URLs to HTTPS clone URLs.
+    Non-GitHub or malformed inputs are returned unchanged. *)
+
 val validate_clone_url :
   base_path:string -> string -> (unit, string) result
 (** [validate_clone_url ~base_path url] validates the URL

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -132,14 +132,20 @@ let sync_planning_current_task_with_owned_task (ctx : context) =
     |> List.find_map (fun (task : Types.task) ->
            match task.task_status with
            | Types.Claimed { assignee; _ }
-           | Types.InProgress { assignee; _ }
-           | Types.AwaitingVerification { assignee; _ } ->
+           | Types.InProgress { assignee; _ } ->
                if matches_you assignee then Some task.id else None
-           | Types.Todo | Types.Done _ | Types.Cancelled _ -> None)
+           | Types.Todo
+           | Types.AwaitingVerification _
+           | Types.Done _
+           | Types.Cancelled _ -> None)
   in
   match owned_task with
   | Some task_id -> Planning_eio.set_current_task ctx.config ~task_id
   | None -> Planning_eio.clear_current_task ctx.config
+
+let sync_keeper_current_task_binding (ctx : context) =
+  Keeper_current_task_reconcile.sync_current_task_id_for_agent_name
+    ~config:ctx.config ~agent_name:ctx.agent_name
 
 let keeper_agent_tool_names (ctx : context) =
   let resolved =
@@ -546,6 +552,7 @@ let handle_claim ?agent_tool_names ctx args =
   in
   (match result with
    | Ok _ ->
+       sync_keeper_current_task_binding ctx;
        sync_planning_current_task_with_owned_task ctx;
        Subscriptions.push_event_to_sessions (`Assoc [
          ("type", `String "masc/task_claimed");
@@ -570,6 +577,7 @@ let handle_claim_next ?agent_tool_names ctx _args =
   in
   let message = match result with
     | Coord.Claim_next_claimed { message; task_id; _ } ->
+        sync_keeper_current_task_binding ctx;
         sync_planning_current_task_with_owned_task ctx;
         append_claim_observation message ~now:(Time_compat.now ())
           ~agent_name:ctx.agent_name ~task_id
@@ -601,7 +609,9 @@ let handle_release ctx args =
              ?expected_version ?handoff_context ()
          in
          (match result with
-          | Ok _ -> sync_planning_current_task_with_owned_task ctx
+          | Ok _ ->
+            sync_keeper_current_task_binding ctx;
+            sync_planning_current_task_with_owned_task ctx
           | Error _ -> ());
          result_to_response result)
 
@@ -650,6 +660,7 @@ and handle_cancel_task ctx args =
   (* Record failed metric on cancellation *)
   (match result with
    | Ok _ ->
+       sync_keeper_current_task_binding ctx;
        sync_planning_current_task_with_owned_task ctx;
        let metric : Metrics_store_eio.task_metric = {
          id = Printf.sprintf "metric-%s-%d" task_id (int_of_float (Time_compat.now () *. 1000.));
@@ -973,7 +984,9 @@ and handle_transition ?agent_tool_names ctx args =
   in
   let result = try_transition 0 in
   (match result with
-   | Ok _ -> sync_planning_current_task_with_owned_task ctx
+   | Ok _ ->
+     sync_keeper_current_task_binding ctx;
+     sync_planning_current_task_with_owned_task ctx
    | Error _ -> ());
   (* Notify A2A subscribers on successful transition *)
   (match result with

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -224,6 +224,37 @@ let test_dashboard_execution_live_empty_room () =
           (json |> member "continuity_briefs" |> to_list |> List.length);
       ))
 
+let test_dashboard_execution_surfaces_utf8_repair_diagnostics () =
+  let dir = test_dir () in
+  Safe_ops.reset_persistence_utf8_repair_stats_for_tests ();
+  Fun.protect
+    ~finally:(fun () ->
+      Safe_ops.reset_persistence_utf8_repair_stats_for_tests ();
+      cleanup_dir dir)
+    (fun () ->
+      ignore
+        (Safe_ops.parse_json_safe ~context:"dashboard-corrupt-row"
+           "{\"msg\":\"bad\xffrow\"}");
+      let config = Coord_utils.default_config dir in
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run (fun sw ->
+        let json =
+          Lib.Dashboard_execution.json
+            ~config
+            ~sw
+            ~clock:(Eio.Stdenv.clock env)
+            ~proc_mgr:None
+            ()
+        in
+        let open Yojson.Safe.Util in
+        let diagnostics = json |> member "projection_diagnostics" in
+        check string "execution diagnostics surface" "execution"
+          (diagnostics |> member "surface" |> to_string);
+        check int "utf8 repair count surfaced" 1
+          (diagnostics |> member "persistence_sanitized_count" |> to_int);
+        check int "utf8 repair bytes surfaced" 1
+          (diagnostics |> member "persistence_sanitized_bytes" |> to_int)))
+
 let test_dashboard_execution_namespace_status () =
   let dir = test_dir () in
   Fun.protect
@@ -911,6 +942,8 @@ let () =
         [
           Alcotest.test_case "fixture response" `Quick test_dashboard_execution_fixture;
           Alcotest.test_case "live empty room is safe" `Quick test_dashboard_execution_live_empty_room;
+          Alcotest.test_case "execution surfaces utf8 repair diagnostics"
+            `Quick test_dashboard_execution_surfaces_utf8_repair_diagnostics;
           Alcotest.test_case "current room drives status" `Quick
             test_dashboard_execution_namespace_status;
           Alcotest.test_case "shell follows current room" `Quick

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -497,6 +497,27 @@ let test_resolve_task_repo_context_rejects_non_github_origin () =
   | Ok _ -> Alcotest.fail "expected non-github origin error"
   | Error _ -> Alcotest.fail "unexpected repo context error"
 
+let test_repo_slug_of_task_worktree_infers_parent_config_for_container_gitdir () =
+  with_repo_context_test_env @@ fun ~base:_ ~config:_ ~repo_dir ->
+  run_argv
+    [ "git"; "-C"; repo_dir; "remote"; "add"; "origin"
+    ; "git@github.com:example/project.git"
+    ];
+  let worktree_dir = Filename.concat repo_dir ".worktrees/task-001" in
+  ensure_dir worktree_dir;
+  let oc = open_out_bin (Filename.concat worktree_dir ".git") in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc
+        "gitdir: /home/keeper/repos/project/.git/worktrees/task-001\n");
+  Alcotest.(check (option string))
+    "repo slug recovered from host parent clone config"
+    (Some "example/project")
+    (Keeper_gh_shared.repo_slug_of_task_worktree
+       ~git_root:"/home/keeper/repos/project"
+       ~worktree_cwd:worktree_dir)
+
 let fake_docker_gh_script =
   "#!/bin/sh\n\
 if [ \"$1\" = \"info\" ]; then\n\
@@ -884,6 +905,10 @@ let () =
             test_resolve_task_repo_context_reports_missing_worktree;
           Alcotest.test_case "non-github origin is structured error" `Quick
             test_resolve_task_repo_context_rejects_non_github_origin;
+          Alcotest.test_case
+            "worktree parent config survives container gitdir"
+            `Quick
+            test_repo_slug_of_task_worktree_infers_parent_config_for_container_gitdir;
           Alcotest.test_case
             "keeper_shell gh without current task uses sandbox context"
             `Quick test_keeper_shell_gh_without_current_task_uses_sandbox_context;

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -216,6 +216,66 @@ let test_claim_syncs_keeper_current_task_id () =
       check (option string) "persisted current_task_id" (Some task_id)
         (current_task_id_string persisted_meta)))
 
+let test_release_clears_keeper_current_task_id () =
+  with_room (fun config ->
+    let meta = make_test_meta () in
+    with_registered_keeper config meta (fun () ->
+      let _ =
+        Coord.add_task config ~title:"Release task" ~priority:1
+          ~description:"desc"
+      in
+      let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+      let json = parse_json result in
+      let task_id =
+        Yojson.Safe.Util.(
+          json |> member "claimed_task" |> member "task_id" |> to_string)
+      in
+      let ok, message =
+        Tool_task.handle_transition
+          { Tool_task.config; agent_name = meta.agent_name; sw = None }
+          (`Assoc
+             [
+               ("task_id", `String task_id);
+               ("action", `String "release");
+               ("reason", `String "scope changed");
+             ])
+      in
+      if not ok then fail message;
+      let registry_meta =
+        match Keeper_registry.get ~base_path:config.Coord.base_path meta.name with
+        | Some entry -> entry.meta
+        | None -> fail "expected keeper registry entry"
+      in
+      check (option string) "registry current_task_id cleared" None
+        (current_task_id_string registry_meta);
+      let persisted_meta =
+        match Keeper_types.read_meta config meta.name with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "expected persisted keeper meta"
+        | Error msg -> fail msg
+      in
+      check (option string) "persisted current_task_id cleared" None
+        (current_task_id_string persisted_meta)))
+
+let test_stale_current_task_id_is_cleared_from_backlog () =
+  with_room (fun config ->
+    let task_id =
+      match Keeper_id.Task_id.of_string "task-missing" with
+      | Ok task_id -> task_id
+      | Error msg -> fail msg
+    in
+    let meta = { (make_test_meta ()) with current_task_id = Some task_id } in
+    with_registered_keeper config meta (fun () ->
+      (match Keeper_types.write_meta config meta with
+       | Ok () -> ()
+       | Error msg -> fail msg);
+      let synced =
+        Keeper_agent_tool_surface.sync_current_task_id_from_backlog
+          ~config meta
+      in
+      check (option string) "stale current_task_id cleared" None
+        (current_task_id_string synced)))
+
 let test_claim_empty_room () =
   with_room (fun config ->
     let meta = make_test_meta () in
@@ -616,7 +676,15 @@ let test_submit_for_verification_transitions_task () =
                  fail
                    (Printf.sprintf
                       "expected awaiting_verification, got %s"
-                      (Types.string_of_task_status status)))
+                      (Types.string_of_task_status status)));
+            let persisted_meta =
+              match Keeper_types.read_meta config meta.name with
+              | Ok (Some meta) -> meta
+              | Ok None -> fail "expected persisted keeper meta"
+              | Error msg -> fail msg
+            in
+            check (option string) "awaiting verification clears current_task_id"
+              None (current_task_id_string persisted_meta)
         | _ -> fail "expected keeper_task_submit_for_verification to succeed")))
 
 (* --- keeper_tool_search tests --- *)
@@ -716,6 +784,10 @@ let () =
         test_claim_returns_observation_fragment;
       test_case "claim syncs keeper current_task_id" `Quick
         test_claim_syncs_keeper_current_task_id;
+      test_case "release clears keeper current_task_id" `Quick
+        test_release_clears_keeper_current_task_id;
+      test_case "stale current_task_id clears from backlog" `Quick
+        test_stale_current_task_id_is_cleared_from_backlog;
       test_case "claim empty room" `Quick test_claim_empty_room;
       test_case "claim respects active_goal_ids" `Quick
         test_claim_respects_active_goal_ids;

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -32,6 +32,28 @@ let test_parse_json_safe_invalid () =
   let result = parse_json_safe ~context:"test" "not json" in
   check bool "Error on invalid JSON" true (Result.is_error result)
 
+let test_parse_json_safe_repairs_invalid_utf8_inside_string () =
+  let open Safe_ops in
+  reset_persistence_utf8_repair_stats_for_tests ();
+  let replacement = "\xEF\xBF\xBD" in
+  let result = parse_json_safe ~context:"utf8-fixture" "{\"msg\":\"ok\xffbad\"}" in
+  match result with
+  | Error msg -> fail msg
+  | Ok json ->
+    let msg = Yojson.Safe.Util.(json |> member "msg" |> to_string) in
+    check string "invalid byte replaced" ("ok" ^ replacement ^ "bad") msg;
+    let stats = persistence_utf8_repair_stats () in
+    check int "one repaired read" 1 stats.repaired_reads;
+    check int "one invalid byte" 1 stats.repaired_bytes
+
+let test_parse_json_safe_still_rejects_malformed_json_after_utf8_repair () =
+  let open Safe_ops in
+  reset_persistence_utf8_repair_stats_for_tests ();
+  let result = parse_json_safe ~context:"utf8-malformed" ("{\xff:1}") in
+  check bool "malformed json still rejected" true (Result.is_error result);
+  let stats = persistence_utf8_repair_stats () in
+  check int "repair was observed" 1 stats.repaired_reads
+
 let test_read_file_safe_not_found () =
   let open Safe_ops in
   let result = read_file_safe "/nonexistent/path/file.txt" in
@@ -373,6 +395,10 @@ let () =
     "parse_json_safe", [
       test_case "valid json" `Quick test_parse_json_safe_valid;
       test_case "invalid json" `Quick test_parse_json_safe_invalid;
+      test_case "repairs invalid utf8 inside string" `Quick
+        test_parse_json_safe_repairs_invalid_utf8_inside_string;
+      test_case "malformed json still rejected after utf8 repair" `Quick
+        test_parse_json_safe_still_rejects_malformed_json_after_utf8_repair;
       test_case "long invalid" `Quick test_parse_json_safe_long_invalid;
     ];
     "read_file_safe", [

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -233,6 +233,12 @@ let test_ssh_allowed () =
     (Tool_code_write.validate_clone_url ~base_path:bp
        "git@github.com:jeong-sik/oas.git")
 
+let test_normalize_github_clone_url_converts_ssh_to_https () =
+  check string "ssh remote normalized to https"
+    "https://github.com/jeong-sik/oas.git"
+    (Tool_code_write.normalize_github_clone_url
+       "git@github.com:jeong-sik/oas.git")
+
 let test_missing_base_path_without_config_fails_closed () =
   Tool_code_write.reset_policy_config_cache ();
   Fun.protect ~finally:Tool_code_write.reset_policy_config_cache (fun () ->
@@ -576,6 +582,8 @@ let () =
         test_missing_policy_does_not_reuse_previous_cache;
       test_case "explicit config dir override still validates" `Quick test_explicit_config_dir_override_still_validates;
       test_case "mixed-case org" `Quick test_mixed_case_org;
+      test_case "normalize ssh clone url to https" `Quick
+        test_normalize_github_clone_url_converts_ssh_to_https;
     ]);
     ("masc_code_git", [
       test_case "clone rejects flag args" `Quick

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1039,7 +1039,7 @@ let () = test "transition_release_clears_planning_current_task" (fun () ->
   assert (Planning_eio.get_current_task ctx.config = None)
 )
 
-let () = test "transition_done_redirects_to_verification_and_keeps_planning_current_task" (fun () ->
+let () = test "transition_done_redirects_to_verification_and_clears_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Transition done")]) in
   let (success_claim, _result) =
@@ -1058,7 +1058,7 @@ let () = test "transition_done_redirects_to_verification_and_keeps_planning_curr
   in
   assert success_done;
   assert (not (str_contains result "rejected"));
-  assert (Planning_eio.get_current_task ctx.config = Some "task-001");
+  assert (Planning_eio.get_current_task ctx.config = None);
   match Coord.get_tasks_raw ctx.config with
   | [ task ] -> (
       match task.task_status with


### PR DESCRIPTION
## Summary
- Repair invalid UTF-8 on runtime JSON/text reads and surface aggregate diagnostics in dashboard execution projection.
- Reconcile keeper current_task_id from active backlog ownership after claim/release/cancel/transition, excluding AwaitingVerification as active.
- Preserve GitHub repo context across host/container worktree path drift and normalize GitHub SSH remotes to HTTPS before clone/pull.

## Validation
- scripts/dune-local.sh build test/test_safe_ops.exe test/test_keeper_task_dispatch.exe test/test_keeper_github_read_only.exe test/test_tool_code_write_coverage.exe test/test_dashboard_execution.exe test/test_tool_task_coverage.exe
- ./_build/default/test/test_safe_ops.exe
- ./_build/default/test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_github_read_only.exe
- ./_build/default/test/test_tool_code_write_coverage.exe
- ./_build/default/test/test_tool_task_coverage.exe
- env MASC_TEST_ALLOW_HOME_BASE_PATH=1 ./_build/default/test/test_dashboard_execution.exe

Note: bare dashboard execution suite reaches the existing Fs_compat home-base isolation guard after the new UTF-8 diagnostic test passes, so the full suite was verified with the existing allow-home test env.