### PR TITLE
fix(keeper): add Log.Keeper.warning alias and guard late event dispatch

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -590,6 +590,9 @@ module type LOGGER = sig
   val warn :
     ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
 
+  val warning :
+    ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
+
   val error :
     ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
 end

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -646,6 +646,7 @@ module Make (M : sig val name : string end) = struct
   let debug ?keeper_name ?turn_id fmt = log_module Debug ?keeper_name ?turn_id fmt
   let info ?keeper_name ?turn_id fmt = log_module Info ?keeper_name ?turn_id fmt
   let warn ?keeper_name ?turn_id fmt = log_module Warn ?keeper_name ?turn_id fmt
+  let warning = warn
   let error ?keeper_name ?turn_id fmt = log_module Error ?keeper_name ?turn_id fmt
 end
 

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -130,6 +130,7 @@ module type LOGGER = sig
   val debug : ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
   val info : ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
   val warn : ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
+  val warning : ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
   val error : ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
 end
 


### PR DESCRIPTION
## Summary
- Adds `let warning = warn` alias to `Log.Make` functor to resolve `Unbound value Log.Keeper.warning` compile error.
- Guards late event dispatch across keeper heartbeat loop, keepalive signal, registry, supervisor, and turn lifecycle to prevent invalid state machine transitions from crashing the keeper.

## Test plan
- [ ] `dune build` passes
- [ ] Keeper integration smoke test

## Related
Fixes build break on main where `Log.Keeper.warning` was used without definition.