### PR TITLE
[codex] Make keeper cascade routing config-driven

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,56 +1,36 @@
 {
-  "_comment": "Checked-in seed for cascade authoring. Keep repo defaults boring: bootstrap keeper profile big_three, local keeper profile ollama_only, system-only fallback/judge/phase-routing profiles (default, governance_judge, operator_judge, local_only, local_recovery, tool_rerank), and move personal/live experiments to $MASC_BASE_PATH/.masc/config/cascade.toml.",
-  "_comment_default": "System-only fallback profile for unknown/missing cascade names. Mirrors big_three without Claude CLI so automatic recovery does not pull Claude by default.",
-  "default_models": [
-    { "model": "codex_cli:auto", "weight": 1 },
-    { "model": "gemini_cli:auto", "weight": 1 },
-    { "model": "codex_cli:gpt-5.3-codex-spark", "weight": 1 }
-  ],
-  "default_temperature": 0.2,
-  "default_max_tokens": 16384,
-  "default_keeper_assignable": false,
-  "_comment_big_three": "Canonical keeper bootstrap profile exposed by the checked-in seed. Automatic keepers stay off Claude CLI unless an operator opts in via live config.",
+  "_comment": "Checked-in seed for cascade authoring. Repo defaults expose exactly two profiles: big_three for keeper/workflow calls and tool_rerank for short rerank calls. Logical usage names are configured under [routes] instead of being profile names.",
+  "routes": {
+    "keeper_turn": "big_three",
+    "phase_recovery": "big_three",
+    "phase_buffer": "big_three",
+    "tool_required": "big_three",
+    "governance_judge": "big_three",
+    "operator_judge": "big_three",
+    "cross_verifier": "big_three",
+    "verifier": "big_three",
+    "autoresearch": "big_three",
+    "adversarial_reviewer": "big_three",
+    "auto_responder": "big_three",
+    "routing": "big_three",
+    "openai_compat": "big_three",
+    "persona_generation": "big_three",
+    "provider_benchmark": "big_three",
+    "llm_rerank": "tool_rerank"
+  },
+  "_comment_big_three": "Canonical keeper/workflow profile. Keep operator-chosen providers here; code must route logical usages through [routes] instead of hardcoding extra profile names.",
   "big_three_models": [
-    { "model": "codex_cli:auto", "weight": 1 },
-    { "model": "gemini_cli:auto", "weight": 1 },
-    { "model": "codex_cli:gpt-5.3-codex-spark", "weight": 1 }
+    "codex_cli:gpt-5.3-codex-spark", "gemini_cli:auto",
+    "kimi_cli:kimi-for-coding", "glm-coding:auto", "claude_code:auto"
   ],
   "big_three_temperature": 0.2,
   "big_three_max_tokens": 16384,
-  "_comment_governance_judge": "System-only dashboard governance judge profile. Explicitly defined so background judge loops do not inherit fallback providers such as Claude CLI. Gemini listed first because [codex_cli:auto] internally rotates 5 models (30s timeout each = 150s wasted wall-clock when codex auth is broken); Gemini-first attempts the cheap success path first while codex remains a fallback that auto-rejoins on recovery (#10554 disabled codex_cli for 4 seed cascades; this profile keeps codex as fallback rather than removing it).",
-  "governance_judge_models": [
-    { "model": "gemini_cli:auto", "weight": 1 },
-    { "model": "codex_cli:auto", "weight": 1 }
+  "big_three_keeper_assignable": true,
+  "_comment_tool_rerank": "System-only short-output profile for rerank/scoring calls.",
+  "tool_rerank_models": [
+    "codex_cli:gpt-5.3-codex-spark", "gemini_cli:auto",
+    "kimi_cli:kimi-for-coding", "glm-coding:auto", "claude_code:auto"
   ],
-  "governance_judge_temperature": 0.2,
-  "governance_judge_max_tokens": 16384,
-  "governance_judge_keeper_assignable": false,
-  "_comment_operator_judge": "System-only dashboard operator judge profile. Mirrors governance_judge so background control loops stay off Claude CLI by default. Gemini-first ordering: see governance_judge for rationale.",
-  "operator_judge_models": [
-    { "model": "gemini_cli:auto", "weight": 1 },
-    { "model": "codex_cli:auto", "weight": 1 }
-  ],
-  "operator_judge_temperature": 0.2,
-  "operator_judge_max_tokens": 16384,
-  "operator_judge_keeper_assignable": false,
-  "_comment_local_only": "System-only local phase-routing profile for compacting/handoff paths.",
-  "local_only_models": [ "ollama:auto" ],
-  "local_only_temperature": 0.2,
-  "local_only_max_tokens": 32768,
-  "local_only_keeper_assignable": false,
-  "_comment_local_recovery": "System-only local recovery profile used after cloud/provider failures.",
-  "local_recovery_models": [ "ollama:auto" ],
-  "local_recovery_temperature": 0.1,
-  "local_recovery_max_tokens": 8192,
-  "local_recovery_keeper_assignable": false,
-  "_comment_ollama_only": "Keeper-assignable ollama-only profile for local-only agents. qwen3.6 27B supports 256k context locally; default to a 128k Ollama context while keeping output capped.",
-  "ollama_only_models": [ "ollama:auto" ],
-  "ollama_only_temperature": 0.7,
-  "ollama_only_max_tokens": 8192,
-  "ollama_only_keep_alive": "-1",
-  "ollama_only_num_ctx": 131072,
-  "ollama_only_keeper_assignable": true,
-  "_comment_tool_rerank": "inference-only override: tool_rerank has no _models of its own; callers reuse the default cascade's models and apply the short max_tokens here.",
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
   "tool_rerank_keeper_assignable": false

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -1,85 +1,45 @@
-comment = "Checked-in seed for cascade authoring. Keep repo defaults boring: bootstrap keeper profile big_three, local keeper profile ollama_only, system-only fallback/judge/phase-routing profiles (default, governance_judge, operator_judge, local_only, local_recovery, tool_rerank), and move personal/live experiments to $MASC_BASE_PATH/.masc/config/cascade.toml."
+comment = "Checked-in seed for cascade authoring. Repo defaults expose exactly two profiles: big_three for keeper/workflow calls and tool_rerank for short rerank calls. Logical usage names are configured under [routes] instead of being profile names."
 
-[default]
-comment = "System-only fallback profile for unknown/missing cascade names. Mirrors big_three without Claude CLI so automatic recovery does not pull Claude by default. glm:auto + gemini:auto are Direct API fallbacks that pass the tool-use gate via inline tools (Path B) — CLI providers (codex_cli, gemini_cli) cannot carry keeper-bound runtime MCP HTTP headers."
-models = [
-  { model = "codex_cli:auto", weight = 1 },
-  { model = "gemini_cli:auto", weight = 1 },
-  { model = "codex_cli:gpt-5.3-codex-spark", weight = 1 },
-  { model = "glm:auto", weight = 1 },
-  { model = "gemini:auto", weight = 1 },
-]
-temperature = 0.2
-max_tokens = 16384
-keeper_assignable = false
+[routes]
+keeper_turn = "big_three"
+phase_recovery = "big_three"
+phase_buffer = "big_three"
+tool_required = "big_three"
+governance_judge = "big_three"
+operator_judge = "big_three"
+cross_verifier = "big_three"
+verifier = "big_three"
+autoresearch = "big_three"
+adversarial_reviewer = "big_three"
+auto_responder = "big_three"
+routing = "big_three"
+openai_compat = "big_three"
+persona_generation = "big_three"
+provider_benchmark = "big_three"
+llm_rerank = "tool_rerank"
 
 [big_three]
-comment = "Canonical keeper bootstrap profile exposed by the checked-in seed. Automatic keepers stay off Claude CLI unless an operator opts in via live config. glm:auto + gemini:auto are Direct API fallbacks that pass the tool-use gate via inline tools (Path B)."
+comment = "Canonical keeper/workflow profile. Keep operator-chosen providers here; code must route logical usages through [routes] instead of hardcoding extra profile names."
 models = [
-  { model = "codex_cli:auto", weight = 1 },
-  { model = "gemini_cli:auto", weight = 1 },
-  { model = "codex_cli:gpt-5.3-codex-spark", weight = 1 },
-  { model = "glm:auto", weight = 1 },
-  { model = "gemini:auto", weight = 1 },
+  "codex_cli:gpt-5.3-codex-spark",
+  "gemini_cli:auto",
+  "kimi_cli:kimi-for-coding",
+  "glm-coding:auto",
+  "claude_code:auto",
 ]
 temperature = 0.2
 max_tokens = 16384
-
-[governance_judge]
-comment = "System-only dashboard governance judge profile. Explicitly defined so background judge loops do not inherit fallback providers such as Claude CLI. Gemini listed first because [codex_cli:auto] internally rotates 5 models (30s timeout each = 150s wasted wall-clock when codex auth is broken); Gemini-first attempts the cheap success path first while codex remains a fallback that auto-rejoins on recovery (#10554 disabled codex_cli for 4 seed cascades; this profile keeps codex as fallback rather than removing it). glm:auto + gemini:auto are Direct API fallbacks that pass the tool-use gate via inline tools (Path B)."
-models = [
-  { model = "gemini_cli:auto", weight = 1 },
-  { model = "codex_cli:auto", weight = 1 },
-  { model = "glm:auto", weight = 1 },
-  { model = "gemini:auto", weight = 1 },
-]
-temperature = 0.2
-max_tokens = 16384
-keeper_assignable = false
-
-[operator_judge]
-comment = "System-only dashboard operator judge profile. Mirrors governance_judge so background control loops stay off Claude CLI by default. Gemini-first ordering: see governance_judge for rationale. glm:auto + gemini:auto are Direct API fallbacks that pass the tool-use gate via inline tools (Path B)."
-models = [
-  { model = "gemini_cli:auto", weight = 1 },
-  { model = "codex_cli:auto", weight = 1 },
-  { model = "glm:auto", weight = 1 },
-  { model = "gemini:auto", weight = 1 },
-]
-temperature = 0.2
-max_tokens = 16384
-keeper_assignable = false
-
-[local_only]
-comment = "System-only local phase-routing profile for compacting/handoff paths."
-models = [
-  "ollama:auto",
-]
-temperature = 0.2
-max_tokens = 32768
-keeper_assignable = false
-
-[local_recovery]
-comment = "System-only local recovery profile used after cloud/provider failures."
-models = [
-  "ollama:auto",
-]
-temperature = 0.1
-max_tokens = 8192
-keeper_assignable = false
-
-[ollama_only]
-comment = "Keeper-assignable ollama-only profile for local-only agents. qwen3.6 27B supports 256k context locally; default to a 128k Ollama context while keeping output capped."
-models = [
-  "ollama:auto",
-]
-temperature = 0.7
-max_tokens = 8192
-keep_alive = "-1"
-num_ctx = 131072
 keeper_assignable = true
 
 [tool_rerank]
-comment = "inference-only override: tool_rerank has no _models of its own; callers reuse the default cascade's models and apply the short max_tokens here."
+comment = "System-only short-output profile for rerank/scoring calls."
+models = [
+  "codex_cli:gpt-5.3-codex-spark",
+  "gemini_cli:auto",
+  "kimi_cli:kimi-for-coding",
+  "glm-coding:auto",
+  "claude_code:auto",
+]
 temperature = 0.0
 max_tokens = 200
 keeper_assignable = false

--- a/docs/CASCADE-TOML.md
+++ b/docs/CASCADE-TOML.md
@@ -16,9 +16,12 @@ runtime materializes sibling `cascade.json` before loading.
 The repo seed should stay intentionally small.
 
 - Keep the checked-in keeper-assignable set explicit and boring:
-  `big_three` for normal bootstrap and `ollama_only` for local-only keepers.
-- Keep system-only plumbing profiles checked in only when runtime routing needs
-  them: `default`, `governance_judge`, `operator_judge`, `local_only`, `local_recovery`, `tool_rerank`
+  `big_three` for keeper/general turns.
+- Keep system-only lanes explicit and minimal: `tool_rerank` for short
+  rerank/scoring calls.
+- Put logical usages such as `governance_judge`, `operator_judge`,
+  `local_recovery`, `tool_use_strict`, `cross_verifier`, and `autoresearch`
+  under `[routes]`. They are route keys, not profile names.
 - Put personal experiments, vendor mixes, and machine-specific profiles in
   live config under `$MASC_BASE_PATH/.masc/config/cascade.toml`, not in the
   repo seed
@@ -28,19 +31,28 @@ graveyard of personal cascade variants.
 
 ## Seed Profiles
 
-- `default`: fallback for unknown/missing cascade names. Keep it boring and
-  close to `big_three`.
-- `big_three`: canonical keeper bootstrap profile for checked-in keepers.
-- `governance_judge`: system-only dashboard governance judge profile.
-- `operator_judge`: system-only dashboard operator judge profile.
-- `local_only`: system-only local lane used by phase routing during compacting
-  and handoff paths.
-- `local_recovery`: system-only local recovery lane used after provider/cloud
-  failures.
-- `ollama_only`: keeper-assignable local-only profile for keepers that should
-  not enter cloud/provider rotation.
-- `tool_rerank`: system-only short-output override. It has no own model list
-  and reuses the default cascade models.
+- `big_three`: canonical keeper/workflow profile.
+- `tool_rerank`: system-only short-output profile.
+
+## Routes
+
+`[routes]` maps logical call-site names to concrete profiles:
+
+```toml
+[routes]
+governance_judge = "big_three"
+operator_judge = "big_three"
+cross_verifier = "big_three"
+llm_rerank = "tool_rerank"
+```
+
+Runtime code must use the logical route key and let config choose the concrete
+profile. Do not add a new checked-in profile just because one call site needs a
+name.
+
+The runtime validates `[routes]` against the code route registry. Unknown route
+keys are rejected as config/code drift, and route targets must name an active
+profile in the same catalog.
 
 Use `keeper_assignable = false` for profiles that must exist in the catalog but
 must not appear as normal keeper choices.
@@ -69,8 +81,8 @@ dune exec --root . ./test/test_keeper_cascade_profile.exe
 Add a checked-in profile only when at least one of these is true:
 
 - a checked-in keeper depends on it
-- phase-routing/runtime recovery depends on it
-- operators need the same boring default everywhere
+- the profile has materially different model/parameter behavior from the two
+  defaults
 
 Otherwise, put it in live config or a private/local cookbook-derived setup.
 

--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -397,13 +397,15 @@ let parse_verdict (text : string) : (verdict, string) result =
 (* ================================================================ *)
 
 (** Default evaluator cascade name. Override via [~evaluator_cascade]
-    to force cross-model evaluation (e.g. "cross_verifier" configured
-    to use a different provider than the generator's cascade).
+    to force a specific evaluator profile. Without an override, the
+    concrete profile comes from [routes.cross_verifier].
 
     Cross-model evaluation is more effective than same-model different-role
     because different model architectures have different blindspots.
     See: Anthropic "Harness Design" blog analysis. *)
-let default_evaluator_cascade = "cross_verifier"
+let default_evaluator_cascade =
+  Keeper_cascade_profile.cascade_name_for_use
+    Keeper_cascade_profile.Cross_verifier
 
 (* ================================================================ *)
 (* Core: review                                                     *)
@@ -412,8 +414,9 @@ let default_evaluator_cascade = "cross_verifier"
 (** Review completion notes for avoidance patterns and substance.
 
     @param evaluator_cascade Override the cascade used for LLM verification.
-      Default: ["verifier"]. Set to a cascade that uses a different model
-      family than the generator for genuine cross-model evaluation.
+      Default: the profile selected by [routes.cross_verifier]. Set to a
+      cascade that uses a different model family than the generator for genuine
+      cross-model evaluation.
     @param generator_cascade Optional name of the cascade the generator used.
       Logged for auditing model separation. Not used in verification logic. *)
 (* ================================================================ *)

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -62,8 +62,8 @@ type review_result = {
 (** Review a task completion claim with optional cross-model separation.
 
     @param evaluator_cascade Override cascade for LLM verification.
-      Default: ["cross_verifier"]. Use a different cascade name to ensure
-      cross-model evaluation (e.g. ["cross_verifier"]).
+      Default: the profile selected by [routes.cross_verifier]. Use a
+      different cascade name to force a specific evaluator profile.
     @param generator_cascade Optional name of the generator's cascade.
       Logged for auditing; not used in verification logic. *)
 val review :

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -155,8 +155,9 @@ let run_cli_agent ~agent_type ~prompt =
 
 (* --- MODEL mode: shared cascade + in-process MASC HTTP tools/call --- *)
 
-let cascade_name_for_agent_type agent_type =
-  Printf.sprintf "auto_responder_%s" agent_type
+let cascade_name_for_agent_type _agent_type =
+  Keeper_cascade_profile.cascade_name_for_use
+    Keeper_cascade_profile.Auto_responder
 
 (** Validate model response using structural fields, not text heuristics.
     Guardrail principle: accept unless there is a clear structural reason to reject.

--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -110,12 +110,16 @@ let parse_model_code_response response =
       Result.error "MODEL response must be a JSON object"
 
 let has_background_capacity () =
+  let cascade_name =
+    Keeper_cascade_profile.cascade_name_for_use
+      Keeper_cascade_profile.Autoresearch
+  in
   match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
   | Some sw, Some net -> (
       try
         let capacity =
           Cascade_config.local_capacity_for_selections ~sw ~net
-            [ "autoresearch" ]
+            [ cascade_name ]
         in
         not
           (capacity.all_discovered && capacity.endpoints_found > 0
@@ -127,7 +131,7 @@ let has_background_capacity () =
         false)
   | _ -> false
 
-(** Generate code change via Cascade "autoresearch" profile.
+(** Generate code change via the profile selected by [routes.autoresearch].
     Returns Ok (hypothesis, new_code) or Error reason. *)
 let generate_code_change ~goal ~baseline ~lower_is_better ~history ~insights
     ~target_file ~file_content =
@@ -137,13 +141,15 @@ let generate_code_change ~goal ~baseline ~lower_is_better ~history ~insights
   end else
   let prompt = build_code_change_prompt ~goal ~baseline ~lower_is_better ~history ~insights
     ~file_content ~target_file in
-  let inference_cascade_name =
-    Keeper_cascade_profile.Runtime_name "autoresearch"
+  let cascade_name =
+    Keeper_cascade_profile.cascade_name_for_use
+      Keeper_cascade_profile.Autoresearch
   in
+  let inference_cascade_name = Keeper_cascade_profile.Runtime_name cascade_name in
   match
     Masc_oas_bridge.run_with_caller
       ~caller:Env_config_oas_bridge.Autoresearch_codegen (fun () ->
-      Oas_worker.run_named ~cascade_name:"autoresearch"
+      Oas_worker.run_named ~cascade_name
         ~goal:prompt ~max_turns:1
         ~temperature:(Cascade_inference.resolve_temperature
           ~cascade_name:inference_cascade_name ~fallback:(fun () -> 0.7))

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -476,9 +476,8 @@ let runtime_required_profiles ~config_path =
     | Error _ -> []
   in
   List.sort_uniq String.compare
-    (Keeper_cascade_profile.known_cascades
-    @ keepers_from_catalog
-    @ [ "governance_judge"; "operator_judge" ])
+    (keepers_from_catalog
+     @ Cascade_routes.configured_route_targets ~config_path ())
 
 let runtime_required_profile_names ?config_path () =
   let config_path =
@@ -490,9 +489,7 @@ let runtime_required_profile_names ?config_path () =
         | None -> "")
   in
   if String.equal config_path "" then
-    Keeper_cascade_profile.known_cascades
-    @ [ "governance_judge"; "operator_judge" ]
-    |> List.sort_uniq String.compare
+    Keeper_cascade_profile.known_cascades |> List.sort_uniq String.compare
   else
     runtime_required_profiles ~config_path
 
@@ -520,6 +517,26 @@ let validate_path_result ~config_path =
              ~profiles:[])
     | Ok json ->
         let profiles = discover_profiles json in
+        let required_default_profile =
+          Cascade_routes.cascade_name_for_use
+            ~config_path
+            Cascade_routes.Keeper_turn
+        in
+        let route_target_errors =
+          Cascade_routes.configured_route_targets ~config_path ()
+          |> List.filter_map (fun target ->
+                 if List.mem target profiles then None
+                 else
+                   Some
+                     (Printf.sprintf
+                        "cascade route targets missing profile %S"
+                        target))
+        in
+        let route_key_errors =
+          Cascade_routes.configured_unknown_route_keys ~config_path ()
+          |> List.map (fun key ->
+                 Printf.sprintf "unknown cascade route key %S" key)
+        in
         let top_errors =
           let base =
             if profiles = [] then
@@ -527,15 +544,15 @@ let validate_path_result ~config_path =
             else
               []
           in
-          if List.mem Keeper_config.default_cascade_name profiles then
-            base
+          let base = base @ route_key_errors @ route_target_errors in
+          if List.mem required_default_profile profiles then base
           else
             base
             @
             [
               Printf.sprintf
                 "required default profile %S is missing"
-                Keeper_config.default_cascade_name;
+                required_default_profile;
             ]
         in
         let built_profiles, statically_rejected_profiles =
@@ -579,7 +596,7 @@ let validate_path_result ~config_path =
           let default_profile_validated =
             List.exists
               (fun (profile : profile_snapshot) ->
-                String.equal profile.name Keeper_config.default_cascade_name)
+                String.equal profile.name required_default_profile)
               profile_snapshots
           in
           let snapshot =
@@ -603,7 +620,7 @@ let validate_path_result ~config_path =
                       [
                         Printf.sprintf
                           "required default profile %S failed validation"
-                          Keeper_config.default_cascade_name;
+                          required_default_profile;
                       ])
                    @
                    [
@@ -746,10 +763,16 @@ let normalize_declared_name raw =
   Keeper_cascade_profile.normalize_declared_name raw
 
 let lookup_active_profile ?sw ?net ?clock raw_name =
-  let normalized = normalize_declared_name raw_name in
   match require_snapshot ?sw ?net ?clock () with
   | Error _ as e -> e
   | Ok snapshot -> (
+      let trimmed = String.trim raw_name in
+      let normalized =
+        if (not (String.equal trimmed ""))
+           && Option.is_some (profile_lookup snapshot.profiles trimmed)
+        then trimmed
+        else normalize_declared_name raw_name
+      in
       match profile_lookup snapshot.profiles normalized with
       | Some profile -> Ok (snapshot, normalized, profile)
       | None ->

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -687,7 +687,7 @@ let text_of_response (resp : Llm_provider.Types.api_response) : string =
     | _ -> None)
   |> fun lst -> List.fold_left (fun acc s -> acc ^ s) "" lst
 
-(* ── Model resolution: named -> "default" -> hardcoded ─── *)
+(* ── Model resolution: named -> routes.keeper_turn -> built-in defaults ─── *)
 
 type cascade_source =
   | Named
@@ -823,9 +823,14 @@ let resolve_model_strings_traced_with
           (fun (e : Cascade_config_loader.weighted_entry) -> e.model) ordered in
       (models, Named)
     else
+      let fallback_profile =
+        Cascade_routes.cascade_name_for_use
+          ~config_path:path
+          Cascade_routes.Keeper_turn
+      in
       let fallback_weighted =
         Cascade_config_loader.load_profile_weighted
-          ~config_path:path ~name:"default" in
+          ~config_path:path ~name:fallback_profile in
       if fallback_weighted <> [] then
         let ordered = order_weighted_entries ~rand_int fallback_weighted in
         let models = List.map
@@ -982,9 +987,14 @@ let resolve_model_strings_with_trace ?config_path ~name ~defaults () =
       let candidates = List.map candidate_info_of_weighted ordered in
       (models, { candidates; source = Named })
     else
+      let fallback_profile =
+        Cascade_routes.cascade_name_for_use
+          ~config_path:path
+          Cascade_routes.Keeper_turn
+      in
       let fallback_weighted =
         Cascade_config_loader.load_profile_weighted
-          ~config_path:path ~name:"default" in
+          ~config_path:path ~name:fallback_profile in
       if fallback_weighted <> [] then
         let ordered = order_weighted_entries fallback_weighted in
         let models = List.map

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -192,7 +192,7 @@ val load_profile :
 (** How a cascade name was resolved. *)
 type cascade_source =
   | Named              (** Found as "{name}_models" in config *)
-  | Default_fallback   (** Name not found; used "default_models" *)
+  | Default_fallback   (** Name not found; used the [routes.keeper_turn] profile *)
   | Hardcoded_defaults (** Neither found; used hardcoded [defaults] *)
   | Load_failed of string
     (** Config file load failed (parse / IO / missing).  Returned in
@@ -204,7 +204,7 @@ type cascade_source =
 
     Resolution order:
     1. Named profile "{name}_models" from [config_path]
-    2. "default_models" profile from [config_path] (fallback)
+    2. [routes.keeper_turn] profile from [config_path] (fallback)
     3. Hardcoded [defaults]
 
     When [config_path] is [None], returns [defaults] directly. *)

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -257,9 +257,9 @@ let load_profile_weighted ~config_path ~name =
   match load_json config_path with
   | Error msg ->
       (* Surface the load failure on the standard logging channel so
-         operators see it without tailing stderr.  Returning the empty
-         list still lets callers fall back to "default" / hardcoded
-         defaults (see [Cascade_config.resolve_model_strings_traced_with]),
+         operators see it without tailing stderr. Returning the empty
+         list still lets callers fall back through the configured
+         keeper route (see [Cascade_config.resolve_model_strings_traced_with]),
          but the elevated WARN gives observability into what would
          otherwise be a silent permissive-default cascade. *)
       Log.warn ~ctx:"CascadeConfig"

--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -1,0 +1,248 @@
+(** See {!Cascade_routes} interface. *)
+
+type logical_use =
+  | Keeper_turn
+  | Phase_recovery
+  | Phase_buffer
+  | Tool_required
+  | Governance_judge
+  | Operator_judge
+  | Cross_verifier
+  | Verifier
+  | Autoresearch
+  | Adversarial_reviewer
+  | Auto_responder
+  | Routing
+  | Openai_compat
+  | Persona_generation
+  | Provider_benchmark
+  | Tool_rerank_use
+
+type fallback_policy =
+  | Prefer_keeper_assignable of { last_resort_profile : string }
+  | Prefer_system_only of {
+      preferred_profiles : string list;
+      last_resort_profile : string;
+    }
+
+type route_spec = {
+  use : logical_use;
+  key : string;
+  aliases : string list;
+  fallback_policy : fallback_policy;
+}
+
+let keeper_route use key aliases =
+  {
+    use;
+    key;
+    aliases;
+    fallback_policy =
+      Prefer_keeper_assignable { last_resort_profile = "big_three" };
+  }
+
+let system_route use key aliases ~preferred_profiles ~last_resort_profile =
+  {
+    use;
+    key;
+    aliases;
+    fallback_policy =
+      Prefer_system_only { preferred_profiles; last_resort_profile };
+  }
+
+let route_specs =
+  [
+    keeper_route Keeper_turn "keeper_turn"
+      [
+        "default";
+        "default_models";
+        "oas-keeper_unified";
+        "coding_first";
+        "oas-coding_first";
+        "keeper_reply";
+        "keeper_unified";
+      ];
+    keeper_route Phase_recovery "phase_recovery" [ "local_recovery" ];
+    keeper_route Phase_buffer "phase_buffer" [ "local_only" ];
+    keeper_route Tool_required "tool_required"
+      [ "tool_use_strict"; "resilient_breaker" ];
+    keeper_route Governance_judge "governance_judge" [];
+    keeper_route Operator_judge "operator_judge" [];
+    keeper_route Cross_verifier "cross_verifier" [];
+    keeper_route Verifier "verifier" [];
+    keeper_route Autoresearch "autoresearch" [];
+    keeper_route Adversarial_reviewer "adversarial_reviewer" [];
+    keeper_route Auto_responder "auto_responder" [];
+    keeper_route Routing "routing" [ "routing_judge" ];
+    keeper_route Openai_compat "openai_compat" [];
+    keeper_route Persona_generation "persona_generation" [];
+    keeper_route Provider_benchmark "provider_benchmark" [];
+    system_route Tool_rerank_use "llm_rerank" []
+      ~preferred_profiles:[ "tool_rerank" ]
+      ~last_resort_profile:"tool_rerank";
+  ]
+
+let spec_for_use use =
+  match List.find_opt (fun spec -> spec.use = use) route_specs with
+  | Some spec -> spec
+  | None -> assert false
+
+let all_logical_uses = List.map (fun spec -> spec.use) route_specs
+
+let known_route_keys =
+  route_specs
+  |> List.map (fun spec -> spec.key)
+  |> List.sort_uniq String.compare
+
+let logical_use_key use = (spec_for_use use).key
+
+let logical_use_of_string_opt raw =
+  match String.trim raw |> String.lowercase_ascii with
+  | "" -> Some Keeper_turn
+  | normalized ->
+      route_specs
+      |> List.find_map (fun spec ->
+             if String.equal normalized spec.key
+                || List.mem normalized spec.aliases
+             then Some spec.use
+             else None)
+
+let route_bindings_from_json = function
+  | `Assoc fields -> (
+      match List.assoc_opt "routes" fields with
+      | Some (`Assoc routes) ->
+          routes
+          |> List.filter_map (fun (key, value) ->
+                 match value with
+                 | `String raw_target ->
+                     let target = String.trim raw_target in
+                     if String.equal key "" || String.equal target "" then None
+                     else Some (key, target)
+                 | _ -> None)
+      | _ -> [])
+  | _ -> []
+
+let configured_route_bindings ?config_path () =
+  let path_opt =
+    match config_path with
+    | Some path -> Some path
+    | None -> Config_dir_resolver.cascade_path_opt ()
+  in
+  match path_opt with
+  | None -> []
+  | Some path -> (
+      match Cascade_config_loader.load_json path with
+      | Ok json -> route_bindings_from_json json
+      | Error _ -> [])
+
+let configured_route_targets ?config_path () =
+  configured_route_bindings ?config_path ()
+  |> List.map snd
+  |> List.sort_uniq String.compare
+
+let configured_route_keys ?config_path () =
+  configured_route_bindings ?config_path ()
+  |> List.map fst
+  |> List.sort_uniq String.compare
+
+let configured_unknown_route_keys ?config_path () =
+  configured_route_keys ?config_path ()
+  |> List.filter (fun key -> not (List.mem key known_route_keys))
+
+let catalog_entries ?config_path () =
+  let path_opt =
+    match config_path with
+    | Some path -> Some path
+    | None -> Config_dir_resolver.cascade_path_opt ()
+  in
+  match path_opt with
+  | None -> None
+  | Some path -> (
+      match Cascade_config_loader.load_catalog ~config_path:path with
+      | Ok entries -> Some entries
+      | Error _ -> None)
+
+let first_keeper_assignable entries =
+  entries
+  |> List.find_map (fun (entry : Cascade_config_loader.catalog_entry) ->
+         if entry.keeper_assignable then Some entry.name else None)
+
+let first_system_only entries =
+  entries
+  |> List.find_map (fun (entry : Cascade_config_loader.catalog_entry) ->
+         if entry.keeper_assignable then None else Some entry.name)
+
+let first_catalog_name entries =
+  match entries with
+  | (entry : Cascade_config_loader.catalog_entry) :: _ -> Some entry.name
+  | [] -> None
+
+let first_available_name ~catalog names =
+  names |> List.find_opt (fun name -> List.mem name catalog)
+
+let fallback_from_entries use entries =
+  let spec = spec_for_use use in
+  let catalog_names =
+    List.map (fun (entry : Cascade_config_loader.catalog_entry) -> entry.name) entries
+  in
+  match spec.fallback_policy with
+  | Prefer_keeper_assignable { last_resort_profile } ->
+      (match first_keeper_assignable entries with
+       | Some name -> name
+       | None ->
+           Option.value (first_catalog_name entries) ~default:last_resort_profile)
+  | Prefer_system_only { preferred_profiles; last_resort_profile } ->
+      (match first_available_name ~catalog:catalog_names preferred_profiles with
+       | Some name -> name
+       | None -> (
+           match first_system_only entries with
+           | Some name -> name
+           | None -> (
+               match first_keeper_assignable entries with
+               | Some name -> name
+               | None ->
+                   Option.value (first_catalog_name entries)
+                     ~default:last_resort_profile)))
+
+let fallback_name_for_catalog use ~catalog =
+  let first_catalog = match catalog with name :: _ -> Some name | [] -> None in
+  let spec = spec_for_use use in
+  match spec.fallback_policy with
+  | Prefer_keeper_assignable { last_resort_profile } ->
+      Option.value first_catalog ~default:last_resort_profile
+  | Prefer_system_only { preferred_profiles; last_resort_profile } -> (
+      match first_available_name ~catalog preferred_profiles with
+      | Some name -> name
+      | None -> Option.value first_catalog ~default:last_resort_profile)
+
+let logged_invalid_route_targets : (string * string, unit) Hashtbl.t =
+  Hashtbl.create 8
+
+let warn_invalid_route_target_once ~route_key ~target ~fallback =
+  let key = (route_key, target) in
+  if not (Hashtbl.mem logged_invalid_route_targets key) then begin
+    Hashtbl.add logged_invalid_route_targets key ();
+    Eio.traceln
+      "[CascadeRoutes] WARN routes.%s targets missing profile %s; using %s"
+      route_key target fallback
+  end
+
+let cascade_name_for_use ?config_path use =
+  let route_key = logical_use_key use in
+  let route_target =
+    configured_route_bindings ?config_path ()
+    |> List.find_map (fun (key, target) ->
+           if String.equal key route_key then Some target else None)
+  in
+  let entries = Option.value (catalog_entries ?config_path ()) ~default:[] in
+  let catalog_names =
+    List.map (fun (entry : Cascade_config_loader.catalog_entry) -> entry.name) entries
+  in
+  let fallback = fallback_from_entries use entries in
+  match route_target with
+  | Some target when catalog_names = [] -> target
+  | Some target when List.mem target catalog_names -> target
+  | Some target ->
+      warn_invalid_route_target_once ~route_key ~target ~fallback;
+      fallback
+  | None -> fallback

--- a/lib/cascade/cascade_routes.mli
+++ b/lib/cascade/cascade_routes.mli
@@ -1,0 +1,51 @@
+(** Config-driven mapping from logical cascade usages to live profile names.
+
+    Code should name the usage it needs (for example [Governance_judge]) and
+    let [cascade.toml]/[cascade.json] decide which concrete profile handles it.
+    This keeps profiles as configuration data instead of scattering profile
+    literals through runtime call sites. *)
+
+type logical_use =
+  | Keeper_turn
+  | Phase_recovery
+  | Phase_buffer
+  | Tool_required
+  | Governance_judge
+  | Operator_judge
+  | Cross_verifier
+  | Verifier
+  | Autoresearch
+  | Adversarial_reviewer
+  | Auto_responder
+  | Routing
+  | Openai_compat
+  | Persona_generation
+  | Provider_benchmark
+  | Tool_rerank_use
+
+val logical_use_key : logical_use -> string
+val logical_use_of_string_opt : string -> logical_use option
+
+val all_logical_uses : logical_use list
+(** Logical call-site uses known by the route registry. *)
+
+val known_route_keys : string list
+(** Stable keys accepted under [routes]. *)
+
+val cascade_name_for_use : ?config_path:string -> logical_use -> string
+(** Resolve a logical use through [routes.<logical_use_key>]. Falls back to the
+    live catalog when the route is missing, and to the built-in bootstrap name
+    only when no catalog is available. *)
+
+val configured_route_targets : ?config_path:string -> unit -> string list
+(** Unique non-empty profile names referenced by [routes]. *)
+
+val configured_route_keys : ?config_path:string -> unit -> string list
+(** Unique keys declared by [routes]. *)
+
+val configured_unknown_route_keys : ?config_path:string -> unit -> string list
+(** Declared route keys that are not part of {!known_route_keys}. *)
+
+val fallback_name_for_catalog : logical_use -> catalog:string list -> string
+(** Catalog-only fallback used by string normalizers that already have an
+    explicit active profile list. *)

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -247,6 +247,19 @@ let api_key_env_json ~path value =
       in
       loop [] fields
 
+let routes_json ~path value =
+  match table_fields ~path value with
+  | Error _ as err -> err
+  | Ok fields ->
+      let rec loop acc = function
+        | [] -> Ok (`Assoc (List.rev acc))
+        | (key, field_value) :: rest -> (
+            match trimmed_nonempty_string ~path:(Printf.sprintf "%s.%s" path key) field_value with
+            | Ok target -> loop ((key, `String target) :: acc) rest
+            | Error _ as err -> err)
+      in
+      loop [] fields
+
 let profile_field_json ~profile_name ~field_name field_value =
   let profile_path = profile_name ^ "." ^ field_name in
   match field_name with
@@ -339,6 +352,10 @@ let render_toml_to_yojson toml =
               match string_value ~path:"comment" value with
               | Ok text -> loop ([ ("_comment", `String text) ] :: acc) rest
               | Error _ as err -> err
+            else if String.equal key "routes" then
+              match routes_json ~path:"routes" value with
+              | Ok routes -> loop ([ ("routes", routes) ] :: acc) rest
+              | Error _ as err -> err
             else (
               match profile_table_json_fields ~profile_name:key value with
               | Ok rendered -> loop (rendered :: acc) rest
@@ -398,10 +415,11 @@ let toml_section_names_result ~config_path =
                 let is_meta_key key =
                   String.length key > 0 && key.[0] = '_'
                 in
+                let is_reserved_table key = String.equal key "routes" in
                 let names =
                   fields
                   |> List.filter_map (fun (key, value) ->
-                         if is_meta_key key then None
+                         if is_meta_key key || is_reserved_table key then None
                          else
                            match value with
                            | Otoml.TomlTable _ | Otoml.TomlInlineTable _ ->

--- a/lib/config/env_config_governance.ml
+++ b/lib/config/env_config_governance.ml
@@ -182,11 +182,13 @@ module Model_defaults = struct
   let default_model_opt () =
     Sys.getenv_opt "MASC_DEFAULT_MODEL" |> trim_opt
 
-  (** Routing cascade for team session routing. Default: "routing_judge". *)
+  (** Routing cascade for team session routing. Defaults to the logical
+      [routes.routing] key; runtime callers normalize it through the cascade
+      route table. *)
   let routing_cascade () =
     match Sys.getenv_opt "MASC_ROUTING_CASCADE" |> trim_opt with
     | Some s -> s
-    | None -> "routing_judge"
+    | None -> "routing"
 
   (** Goal models (comma-separated). *)
   let goal_models_opt () =

--- a/lib/config/env_config_governance.mli
+++ b/lib/config/env_config_governance.mli
@@ -161,7 +161,7 @@ module Model_defaults : sig
   val default_provider_opt : unit -> string option
   val default_model_opt : unit -> string option
   val routing_cascade : unit -> string
-  (** [MASC_ROUTING_CASCADE] (default ["routing_judge"]). *)
+  (** [MASC_ROUTING_CASCADE] override, otherwise logical key ["routing"]. *)
 
   val goal_models_opt : unit -> string option
   val goal_dispatch_runtime : unit -> string

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -482,6 +482,10 @@ let compute_judgments
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ~build_facts =
+  let cascade_name =
+    Keeper_cascade_profile.cascade_name_for_use
+      Keeper_cascade_profile.Governance_judge
+  in
   match
     (* build_facts() is moved inside the bridge so a deadlock in
        get_agents_status is bounded by the resolved timeout rather
@@ -493,7 +497,7 @@ let compute_judgments
       ~caller:Env_config_oas_bridge.Governance_judge (fun () ->
       let factual_json = build_facts () in
       let prompt = prompt_for_facts factual_json in
-      Oas_worker.run_named_with_masc_tools ~cascade_name:"governance_judge"
+      Oas_worker.run_named_with_masc_tools ~cascade_name
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
         ~approval:Approval_callbacks.auto_approve
         ()
@@ -597,10 +601,14 @@ let append_judgments base_path judgments =
   List.iter (fun json -> Dated_jsonl.append store json) judgments
 
 let should_backoff ~sw ~net =
+  let cascade_name =
+    Keeper_cascade_profile.cascade_name_for_use
+      Keeper_cascade_profile.Governance_judge
+  in
   try
     let capacity =
       Cascade_config.local_capacity_for_selections ~sw ~net
-        [ "governance_judge" ]
+        [ cascade_name ]
     in
     capacity.all_discovered && capacity.endpoints_found > 0
     && capacity.process_available <= 0

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -194,6 +194,10 @@ let compute_judgments
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ~facts_json =
   let prompt = prompt_for_facts facts_json in
+  let cascade_name =
+    Keeper_cascade_profile.cascade_name_for_use
+      Keeper_cascade_profile.Operator_judge
+  in
   match
     (* #9629: caller migrated from legacy run_safe (which fell back to
        the global 30s inference timeout) to run_with_caller so this
@@ -201,7 +205,7 @@ let compute_judgments
        per-caller Prometheus counter. *)
     Masc_oas_bridge.run_with_caller
       ~caller:Env_config_oas_bridge.Operator_judge (fun () ->
-      Oas_worker.run_named_with_masc_tools ~cascade_name:"operator_judge"
+      Oas_worker.run_named_with_masc_tools ~cascade_name
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
         ~approval:Approval_callbacks.auto_approve
         ()
@@ -230,10 +234,14 @@ let compute_judgments
           Error (Printf.sprintf "Operator judge parse error: %s" (Printexc.to_string exn)))
 
 let should_backoff ~sw ~net =
+  let cascade_name =
+    Keeper_cascade_profile.cascade_name_for_use
+      Keeper_cascade_profile.Operator_judge
+  in
   try
     let capacity =
       Cascade_config.local_capacity_for_selections ~sw ~net
-        [ "operator_judge" ]
+        [ cascade_name ]
     in
     capacity.all_discovered && capacity.endpoints_found > 0
     && capacity.process_available <= 0

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -419,6 +419,11 @@ let execute_single_agent_run ~sw ~net ~run_id ~provider ~model ~prompt =
                "Provider '%s' is not runnable in dashboard single-agent mode"
                provider)
         else (
+          let inference_cascade_name =
+            Keeper_cascade_profile.Runtime_name
+              (Keeper_cascade_profile.cascade_name_for_use
+                 Keeper_cascade_profile.Provider_benchmark)
+          in
           match
             Masc_oas_bridge.run_with_caller
               ~caller:Env_config_oas_bridge.Dashboard_provider_runs (fun () ->
@@ -426,12 +431,10 @@ let execute_single_agent_run ~sw ~net ~run_id ~provider ~model ~prompt =
                 ~system_prompt:(run_system_prompt provider)
                 ~max_turns:4
                 ~max_tokens:(Cascade_inference.resolve_max_tokens
-                  ~cascade_name:
-                    (Keeper_cascade_profile.Runtime_name "provider_benchmark")
+                  ~cascade_name:inference_cascade_name
                   ~fallback:(fun () -> 2048))
                 ~temperature:(Cascade_inference.resolve_temperature
-                  ~cascade_name:
-                    (Keeper_cascade_profile.Runtime_name "provider_benchmark")
+                  ~cascade_name:inference_cascade_name
                   ~fallback:(fun () -> 0.2))
                 ~sw ?net
                 ()

--- a/lib/dune
+++ b/lib/dune
@@ -42,7 +42,7 @@
    cascade_client_capacity_history
    cascade_catalog_validator
    cascade_config
-   cascade_config_loader
+   cascade_config_loader cascade_routes
    cascade_toml_materializer
    cascade_fsm
    cascade_health_filter

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -3,10 +3,8 @@
 (** SSOT variant for the 1+1 cascade model.
 
     One keeper-assignable bootstrap profile ({!Big_three}) and one system-only
-    profile ({!Tool_rerank}).  Phase-routing names ("local_only",
-    "local_recovery") are NOT variants — they pass through
-    [canonicalize_with_catalog] as catalog names, so keeper phase-routing
-    code that references them by string continues to work without changes.
+    profile ({!Tool_rerank}). Historical phase-routing, judge, evaluator, and
+    local names are logical route keys, not live catalog profiles.
 
     Adding a new profile is a compile-time event: add a variant here, then
     exhaustive [match] sites flag every consumer that needs to handle it.
@@ -30,6 +28,29 @@ let known_cascades = List.map to_string all
 let default = Big_three
 let default_name = to_string default
 
+type logical_use = Cascade_routes.logical_use =
+  | Keeper_turn
+  | Phase_recovery
+  | Phase_buffer
+  | Tool_required
+  | Governance_judge
+  | Operator_judge
+  | Cross_verifier
+  | Verifier
+  | Autoresearch
+  | Adversarial_reviewer
+  | Auto_responder
+  | Routing
+  | Openai_compat
+  | Persona_generation
+  | Provider_benchmark
+  | Tool_rerank_use
+
+let logical_use_key = Cascade_routes.logical_use_key
+let logical_use_of_string_opt = Cascade_routes.logical_use_of_string_opt
+let configured_route_targets = Cascade_routes.configured_route_targets
+let cascade_name_for_use = Cascade_routes.cascade_name_for_use
+
 type runtime_name = Runtime_name of string
 
 let runtime_name_to_string (Runtime_name value) = value
@@ -39,23 +60,6 @@ let of_string_opt (raw : string) : t option =
   | "" -> Some default
   | "big_three" -> Some Big_three
   | "tool_rerank" -> Some Tool_rerank
-  (* Legacy aliases → Big_three *)
-  | "default"
-  | "oas-keeper_unified"
-  | "coding_first"
-  | "oas-coding_first"
-  | "keeper_turn" | "keeper_reply"
-  | "sangsu" | "local_mlx_vlm_qwen36"
-  | "nick0cave" | "capacity_queue_trio" | "vendor_mix_balanced"
-  | "cost_tier_ladder" | "oauth_cli_rotate" | "quality_sticky_glm51"
-  | "underdog" | "local"
-    -> Some Big_three
-  (* Catalog-routed names: NOT variants.  Returning None lets
-     [canonicalize_with_catalog] preserve them as catalog names so
-     keeper phase-routing and tool-routing code continues to resolve
-     cascade.json keys correctly. *)
-  | "keeper_unified" | "tool_use_strict" | "resilient_breaker"
-  | "local_only" | "local_recovery" -> None
   | _ -> None
 
 let canonical (raw : string) : t =
@@ -247,23 +251,48 @@ let fallback_cascade_for ?config_path name =
 
 let canonicalize_with_catalog ~catalog raw =
   match String.trim raw with
-  | "" -> default_name
+  | "" -> Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
   | trimmed -> (
-      match of_string_opt trimmed with
-      | Some profile -> to_string profile
+      if List.mem trimmed catalog then trimmed
+      else match of_string_opt trimmed with
+      | Some profile ->
+          let name = to_string profile in
+          if catalog = [] || List.mem name catalog then name
+          else Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
       | None ->
-          if List.mem trimmed catalog then trimmed else default_name)
+          match logical_use_of_string_opt trimmed with
+          | Some use -> Cascade_routes.fallback_name_for_catalog use ~catalog
+          | None -> Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog)
 
 let normalize_declared_name (raw : string) : string =
   let trimmed = String.trim raw in
-  match of_string_opt trimmed with
-  | Some t -> to_string t
-  | None when trimmed = "" -> default_name
-  | None -> trimmed
+  if String.equal trimmed "" then
+    cascade_name_for_use Keeper_turn
+  else
+    match of_string_opt trimmed with
+    | Some t -> to_string t
+    | None -> (
+        match logical_use_of_string_opt trimmed with
+        | Some use -> cascade_name_for_use use
+        | None -> trimmed)
 
 let resolve_live_with_catalog ~catalog raw =
-  let normalized = normalize_declared_name raw in
-  if List.mem normalized catalog then normalized else default_name
+  let trimmed = String.trim raw in
+  let normalized =
+    if List.mem trimmed catalog then trimmed
+    else
+      match of_string_opt trimmed with
+      | Some t ->
+          let name = to_string t in
+          if catalog = [] || List.mem name catalog then name
+          else Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
+      | None -> (
+          match logical_use_of_string_opt trimmed with
+          | Some use -> Cascade_routes.fallback_name_for_catalog use ~catalog
+          | None -> trimmed)
+  in
+  if List.mem normalized catalog then normalized
+  else Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
 
 let resolve_live ?config_path raw =
   resolve_live_with_catalog ~catalog:(catalog_names ?config_path ()) raw

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -1,15 +1,13 @@
-(** Canonical keeper cascade profile names and legacy alias normalization.
+(** Canonical keeper cascade profile names and config-driven route lookup.
 
     Keepers historically used stringly-typed cascade names in TOML, runtime
     metadata, telemetry labels, and cascade.json lookups. This module is the
-    SSOT for the active keeper cascade profile and the legacy aliases that must
-    continue to resolve to it.
+    SSOT for the small built-in profile vocabulary and the logical route keys
+    that resolve through [cascade.json]/[cascade.toml].
 
     One keeper-assignable bootstrap profile (Big_three) and one system-only
-    profile (Tool_rerank).
-    Catalog-routed names ("keeper_unified", "tool_use_strict",
-    "resilient_breaker", "local_only", "local_recovery") are NOT variants —
-    they pass through [canonicalize_with_catalog] as catalog names.
+    profile (Tool_rerank). Historical routing, judge, evaluator, and local names
+    are logical uses, not live catalog profiles.
 
     @since 0.9.5 *)
 
@@ -34,10 +32,9 @@ val to_string : t -> string
 (** Canonical lowercase-snake-case name. *)
 
 val of_string_opt : string -> t option
-(** Parse a raw cascade name into the variant. Handles legacy aliases
-    by collapsing them to [Big_three]. Returns [None] for unknown names
-    and catalog-routed names ("keeper_unified", "tool_use_strict",
-    "resilient_breaker", "local_only", "local_recovery"). *)
+(** Parse a raw cascade profile name into the built-in variant. Logical route
+    names and legacy aliases return [None]; use {!cascade_name_for_use} for
+    call sites that mean "governance judge", "operator judge", etc. *)
 
 val canonical : string -> t
 (** [canonical raw] = [of_string_opt raw |> Option.value ~default]. *)
@@ -45,6 +42,48 @@ val canonical : string -> t
 val default : t
 val default_name : string
 (** [default_name = to_string default = "big_three"]. *)
+
+type logical_use =
+  | Keeper_turn
+  | Phase_recovery
+  | Phase_buffer
+  | Tool_required
+  | Governance_judge
+  | Operator_judge
+  | Cross_verifier
+  | Verifier
+  | Autoresearch
+  | Adversarial_reviewer
+  | Auto_responder
+  | Routing
+  | Openai_compat
+  | Persona_generation
+  | Provider_benchmark
+  | Tool_rerank_use
+
+val logical_use_key : logical_use -> string
+(** Stable config key under [routes]. *)
+
+val logical_use_of_string_opt : string -> logical_use option
+(** Parse a logical route key or historical alias. Concrete profile names such
+    as [big_three] and [tool_rerank] are not logical route keys. *)
+
+val cascade_name_for_use : ?config_path:string -> logical_use -> string
+(** Runtime cascade profile for a logical call site.
+
+    Resolution order:
+    1. [routes.<logical_use_key>] from the active cascade config, when it points
+       at a live catalog profile.
+    2. A catalog-derived fallback based on route policy: keeper work prefers a
+       keeper-assignable profile; system work prefers a system-only profile.
+    3. The two-profile seed names only when no catalog is available.
+
+    This is the boundary for code that used to hardcode profile names such as
+    ["governance_judge"], ["operator_judge"], ["local_recovery"], or
+    ["cross_verifier"]. *)
+
+val configured_route_targets : ?config_path:string -> unit -> string list
+(** Unique non-empty profile names referenced from [routes]. *)
 
 val known_cascades : string list
 (** [known_cascades = List.map to_string all]. Provided for consumers

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -2,25 +2,34 @@
 
 open Tool_args
 
-(** Default cascade name for keeper turns. SSOT — all keeper code must
-    reference this constant instead of using the string literal. *)
-let default_cascade_name = Keeper_cascade_profile.default_name
+(** Default cascade name for keeper turns. Resolved through [routes.keeper_turn]
+    so the concrete profile remains configuration-owned. *)
+let default_cascade_name =
+  Keeper_cascade_profile.cascade_name_for_use
+    Keeper_cascade_profile.Keeper_turn
 
 
 (** Cascade name for recovery turns when keeper is in Failing phase.
-    Maps to local_recovery_* entries in cascade.json. *)
-let local_recovery_cascade_name = "local_recovery"
+    Two-profile deployments no longer maintain a separate local recovery lane;
+    recovery reuses the canonical keeper cascade. *)
+let local_recovery_cascade_name =
+  Keeper_cascade_profile.cascade_name_for_use
+    Keeper_cascade_profile.Phase_recovery
 
-(** Cascade name for buffer operations (compacting, handing off).
-    Maps to local_only_* entries in cascade.json. *)
-let local_only_cascade_name = "local_only"
+(** Cascade name for buffer operations (compacting, handing off). *)
+let local_only_cascade_name =
+  Keeper_cascade_profile.cascade_name_for_use
+    Keeper_cascade_profile.Phase_buffer
 
 let phase_routing_cascade_names =
   [ local_only_cascade_name; local_recovery_cascade_name ]
+  |> List.sort_uniq String.compare
 ;;
 
 (** Cascade name for turns that must use a tool-capable provider lane. *)
-let tool_use_strict_cascade_name = "tool_use_strict"
+let tool_use_strict_cascade_name =
+  Keeper_cascade_profile.cascade_name_for_use
+    Keeper_cascade_profile.Tool_required
 
 (** Minimum context window (tokens) for any keeper turn.
     64k-class local models are valid keeper backends; do not clamp them upward
@@ -676,11 +685,17 @@ let keeper_llm_rerank_enabled () : bool =
   Runtime_params.get keeper_llm_rerank_enabled_rp
 
 (** Named cascade profile for the LLM reranker.
-    Env: [MASC_KEEPER_LLM_RERANK_CASCADE]. Default: "tool_rerank". *)
+    Env: [MASC_KEEPER_LLM_RERANK_CASCADE]. Default: [routes.llm_rerank]. *)
 let keeper_llm_rerank_cascade () : string =
   match Env_config_core.raw_value_opt "MASC_KEEPER_LLM_RERANK_CASCADE" with
-  | Some v when String.trim v <> "" -> String.trim v
-  | _ -> "tool_rerank"
+  | Some v when String.trim v <> "" -> (
+      let trimmed = String.trim v in
+      match Keeper_cascade_profile.logical_use_of_string_opt trimmed with
+      | Some use -> Keeper_cascade_profile.cascade_name_for_use use
+      | None -> trimmed)
+  | _ ->
+      Keeper_cascade_profile.cascade_name_for_use
+        Keeper_cascade_profile.Tool_rerank_use
 
 (* ================================================================ *)
 (* Rule engine thresholds                                           *)

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -7,16 +7,19 @@
 
 (** {1 Core Constants} *)
 
-(** Default cascade name for keeper turns.  All keeper code must reference
-    this constant instead of using the string literal.
+(** Default cascade name for keeper turns. Resolved from [routes.keeper_turn];
+    all keeper code must reference this constant instead of using a profile
+    string literal.
     @since v2.128.0 *)
 val default_cascade_name : string
 
-(** Cascade name for recovery turns (Failing phase).
+(** Cascade name for recovery turns (Failing phase). In the two-profile
+    catalog this resolves to the canonical keeper cascade.
     @since Core Triad *)
 val local_recovery_cascade_name : string
 
-(** Cascade name for buffer operations (Compacting, HandingOff).
+(** Cascade name for buffer operations (Compacting, HandingOff). In the
+    two-profile catalog this resolves to the canonical keeper cascade.
     @since Core Triad *)
 val local_only_cascade_name : string
 
@@ -203,6 +206,8 @@ val keeper_retry_max_tools_per_turn : unit -> int
 val keeper_board_event_limit : unit -> int
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_cascade : unit -> string
+(** Reranker cascade profile. Defaults through [routes.llm_rerank]; env
+    overrides may be either a concrete profile name or a logical route key. *)
 
 val keeper_rule_reflect_repetition_threshold : unit -> float
 val keeper_rule_plan_goal_alignment_threshold : unit -> float

--- a/lib/keeper/keeper_persona_authoring_contract.ml
+++ b/lib/keeper/keeper_persona_authoring_contract.ml
@@ -20,7 +20,9 @@ type archetype_axis =
   }
 
 let default_generation_language = "ko"
-let default_generation_cascade_name = "operator_judge"
+let default_generation_cascade_name =
+  Keeper_cascade_profile.cascade_name_for_use
+    Keeper_cascade_profile.Persona_generation
 let default_temperature = 0.7
 let default_max_tokens = 2500
 let default_proactive_enabled = false

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -664,9 +664,9 @@ module Kimi_cli_transport_local = struct
     }
 
   (* Kimi CLI imports [setproctitle] on macOS before processing the
-     request.  Long UTF-8 prompts in argv can make setproctitle's
-     import-time [getproctitle()] decode fail before Kimi reads the
-     prompt, so keep argv small and stream keeper prompts via stdin. *)
+     request. UTF-8 prompts in argv can make setproctitle's import-time
+     [getproctitle()] decode fail before Kimi reads the prompt, so keep
+     non-ASCII or large prompts out of argv and stream them via stdin. *)
   let default_prompt_argv_threshold = 16 * 1024
 
   let prompt_argv_threshold () =
@@ -680,8 +680,18 @@ module Kimi_cli_transport_local = struct
   let prompt_exceeds_argv_budget prompt =
     String.length prompt >= prompt_argv_threshold ()
 
+  let prompt_contains_non_ascii prompt =
+    let rec loop idx =
+      idx < String.length prompt
+      && (Char.code prompt.[idx] > 0x7f || loop (idx + 1))
+    in
+    loop 0
+
+  let prompt_needs_stdin prompt =
+    prompt_exceeds_argv_budget prompt || prompt_contains_non_ascii prompt
+
   let stdin_for_prompt prompt =
-    if prompt_exceeds_argv_budget prompt then Some prompt else None
+    if prompt_needs_stdin prompt then Some prompt else None
 
   let cli_model_override ~(config : config)
       ~(req_config : Llm_provider.Provider_config.t) =
@@ -693,7 +703,7 @@ module Kimi_cli_transport_local = struct
       ~(req_config : Llm_provider.Provider_config.t)
       ~(mcp_config_json : string list)
       ~prompt =
-    let prompt_via_stdin = prompt_exceeds_argv_budget prompt in
+    let prompt_via_stdin = prompt_needs_stdin prompt in
     let args =
       ref [ config.kimi_path; "--print"; "--output-format"; "stream-json" ]
     in

--- a/lib/oas_worker_exec_transport.mli
+++ b/lib/oas_worker_exec_transport.mli
@@ -218,8 +218,8 @@ module Kimi_cli_transport_local : sig
   val default_config : config
 
   (** Build the kimi_cli argv from a config + per-call request, deciding
-      whether the prompt goes via [-p] or stdin (see
-      {!prompt_exceeds_argv_budget}). *)
+      whether the prompt goes via [-p] or stdin. Non-ASCII or large prompts
+      use stdin to avoid Kimi CLI macOS setproctitle UTF-8 decode crashes. *)
   val build_args :
     config:config ->
     req_config:Llm_provider.Provider_config.t ->

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -101,11 +101,15 @@ let route_keeper ~config ~sw ~clock ~keeper_name ~message : (string, string) res
 (** Route to direct MASC named-cascade execution via [Oas_worker.run_named]. *)
 let route_cascade ~message ~system_prompt ~max_tokens ~temperature
   : (string, string) result =
+  let cascade_name =
+    Keeper_cascade_profile.cascade_name_for_use
+      Keeper_cascade_profile.Openai_compat
+  in
   match
     Masc_oas_bridge.run_with_caller
       ~caller:Env_config_oas_bridge.Server_openai_compat (fun () ->
       Oas_worker.run_named
-        ~cascade_name:"default_models"
+        ~cascade_name
         ~goal:message
         ~system_prompt
         ~max_turns:1

--- a/lib/server/server_openai_compat.mli
+++ b/lib/server/server_openai_compat.mli
@@ -51,7 +51,7 @@ val handle_chat_completions :
     | Condition | Route |
     |---|---|
     | [model] starts with [keeper:] (length > 7) | {!Keeper_turn.handle_keeper_msg} |
-    | otherwise | {!Oas_worker.run_named} with cascade [default_models] |
+    | otherwise | {!Oas_worker.run_named} with [routes.openai_compat] |
 
     The [keeper:] prefix length check (`> 7`) is intentional: an
     empty keeper name (`model = "keeper:"`) falls through to the

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -103,11 +103,15 @@ let handle_deep_review (config : Coord.config) args : bool * string =
           ("error", `String msg)
         ]))
     | Ok prompt ->
+        let cascade_name =
+          Keeper_cascade_profile.cascade_name_for_use
+            Keeper_cascade_profile.Adversarial_reviewer
+        in
         match
           Masc_oas_bridge.run_with_caller
             ~caller:Env_config_oas_bridge.Tool_deep_review (fun () ->
             Oas_worker.run_named
-              ~cascade_name:"adversarial_reviewer"
+              ~cascade_name
               ~goal:prompt
               ~max_turns:1
               ~temperature:0.5

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -236,7 +236,7 @@ Tasks created through masc_add_task normally route action='done' into awaiting_v
         ]);
         ("evaluator_cascade", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional evaluator cascade override for anti-rationalization review. Default: cross_verifier");
+          ("description", `String "Optional evaluator cascade override for anti-rationalization review. Default comes from routes.cross_verifier");
         ]);
         ("reason", `Assoc [
           ("type", `String "string");

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -85,9 +85,13 @@ let verify (req : verification_request) : (verdict, string) result =
         Log.Verifier.warn "Structured verdict parse failed: %s" msg;
         (false, sprintf "Invalid verdict format: %s" msg)
     in
+    let cascade_name =
+      Keeper_cascade_profile.cascade_name_for_use
+        Keeper_cascade_profile.Verifier
+    in
     match
       Oas_worker_named.run_named_with_masc_tools
-        ~cascade_name:"verifier"
+        ~cascade_name
         ~goal:prompt
         ~masc_tools:[report_verdict_schema]
         ~dispatch

--- a/test/test_anti_rationalization_coverage.ml
+++ b/test/test_anti_rationalization_coverage.ml
@@ -164,7 +164,10 @@ let () = test "review_result_gate_field_excuse" (fun () ->
 
 let () = test "review_result_evaluator_cascade_default" (fun () ->
   let r = Anti_rationalization.review (make_request "") in
-  assert (r.evaluator_cascade = "cross_verifier"))
+  assert
+    (r.evaluator_cascade
+     = Keeper_cascade_profile.cascade_name_for_use
+         Keeper_cascade_profile.Cross_verifier))
 
 let () = test "review_result_custom_evaluator_cascade" (fun () ->
   let r = Anti_rationalization.review ~evaluator_cascade:"cross_verifier" (make_request "") in

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -229,6 +229,99 @@ let runtime_mcp_policy_with_headers =
     disable_builtin_tools = true;
   }
 
+let test_route_validation_rejects_unknown_route_key () =
+  with_temp_dir "cascade-routes-unknown-key" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  let model = Printf.sprintf "custom:stable@%s/v1" dummy_base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "routes": {
+    "keeper_turn": "big_three",
+    "governance_jduge": "big_three"
+  },
+  "big_three_models": ["%s"]
+}|}
+          model));
+  match Cascade_catalog_runtime.inspect_active () with
+  | Error rejection ->
+      let detail =
+        Cascade_catalog_runtime.rejection_to_yojson rejection
+        |> Yojson.Safe.to_string
+      in
+      check bool "unknown route key is surfaced" true
+        (contains_substring detail "unknown cascade route key")
+  | Ok state ->
+      failf "expected route key rejection, got %s"
+        (Yojson.Safe.to_string (Cascade_catalog_runtime.state_to_yojson state))
+
+let test_route_validation_rejects_missing_route_target () =
+  with_temp_dir "cascade-routes-missing-target" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  let model = Printf.sprintf "custom:stable@%s/v1" dummy_base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "routes": {
+    "keeper_turn": "big_three",
+    "governance_judge": "missing_profile"
+  },
+  "big_three_models": ["%s"]
+}|}
+          model));
+  match Cascade_catalog_runtime.inspect_active () with
+  | Error rejection ->
+      let detail =
+        Cascade_catalog_runtime.rejection_to_yojson rejection
+        |> Yojson.Safe.to_string
+      in
+      check bool "missing route target is surfaced" true
+        (contains_substring detail
+           "cascade route targets missing profile")
+  | Ok state ->
+      failf "expected route target rejection, got %s"
+        (Yojson.Safe.to_string (Cascade_catalog_runtime.state_to_yojson state))
+
+let test_keeper_turn_route_is_required_default_profile () =
+  with_temp_dir "cascade-routes-default-profile" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  let model = Printf.sprintf "custom:stable@%s/v1" dummy_base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "routes": {
+    "keeper_turn": "custom_default"
+  },
+  "custom_default_models": ["%s"]
+}|}
+          model));
+  let snapshot =
+    match Cascade_catalog_runtime.inspect_active () with
+    | Ok (Cascade_catalog_runtime.Validated snapshot) -> snapshot
+    | Ok state ->
+        failf "expected fully validated custom default, got %s"
+          (Yojson.Safe.to_string (Cascade_catalog_runtime.state_to_yojson state))
+    | Error rejection ->
+        failf "unexpected route-default rejection: %s"
+          (Yojson.Safe.to_string
+             (Cascade_catalog_runtime.rejection_to_yojson rejection))
+  in
+  let snapshot_json = Cascade_catalog_runtime.snapshot_to_yojson snapshot in
+  check int "profile_count" 1 (json_int_field "profile_count" snapshot_json);
+  check string "blank name follows routes.keeper_turn"
+    "custom_default"
+    (require_ok
+       (Cascade_catalog_runtime.resolve_declared_name ~raw_name:"" ()))
+
 let test_valid_catalog_skips_live_probes_at_bootstrap () =
   with_temp_dir "cascade-catalog-runtime" @@ fun dir ->
   let config_dir = Filename.concat dir "config" in
@@ -817,6 +910,18 @@ let () =
             "valid catalog skips live probes at bootstrap"
             `Quick
             test_valid_catalog_skips_live_probes_at_bootstrap;
+          test_case
+            "route validation rejects unknown route key"
+            `Quick
+            test_route_validation_rejects_unknown_route_key;
+          test_case
+            "route validation rejects missing route target"
+            `Quick
+            test_route_validation_rejects_missing_route_target;
+          test_case
+            "routes.keeper_turn is the required default profile"
+            `Quick
+            test_keeper_turn_route_is_required_default_profile;
           test_case
             "invalid hot reload preserves last-known-good"
             `Quick

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -104,23 +104,104 @@ let model_names_for_profile json profile_name =
        | `String model -> model
        | value -> value |> member "model" |> to_string)
 
-let test_repo_seed_excludes_claude_from_automatic_profiles () =
+let test_repo_seed_uses_two_profiles_plus_routes () =
   let rendered = render_or_fail (repo_toml_path ()) |> Yojson.Safe.from_string in
   let expect_profile_models profile_name expected =
     check (list string) (profile_name ^ " models")
       expected
       (model_names_for_profile rendered profile_name)
   in
-  expect_profile_models "default"
-    [ "codex_cli:auto"; "gemini_cli:auto"; "codex_cli:gpt-5.3-codex-spark" ];
   expect_profile_models "big_three"
-    [ "codex_cli:auto"; "gemini_cli:auto"; "codex_cli:gpt-5.3-codex-spark" ];
-  expect_profile_models "governance_judge" [ "gemini_cli:auto"; "codex_cli:auto" ];
-  expect_profile_models "operator_judge" [ "gemini_cli:auto"; "codex_cli:auto" ];
-  check bool "governance_judge is system-only" false
-    (rendered |> member "governance_judge_keeper_assignable" |> to_bool);
-  check bool "operator_judge is system-only" false
-    (rendered |> member "operator_judge_keeper_assignable" |> to_bool)
+    [
+      "codex_cli:gpt-5.3-codex-spark";
+      "gemini_cli:auto";
+      "kimi_cli:kimi-for-coding";
+      "glm-coding:auto";
+      "claude_code:auto";
+    ];
+  expect_profile_models "tool_rerank"
+    [
+      "codex_cli:gpt-5.3-codex-spark";
+      "gemini_cli:auto";
+      "kimi_cli:kimi-for-coding";
+      "glm-coding:auto";
+      "claude_code:auto";
+    ];
+  check bool "default profile removed" true
+    (match rendered |> member "default_models" with `Null -> true | _ -> false);
+  check bool "governance profile removed" true
+    (match rendered |> member "governance_judge_models" with `Null -> true | _ -> false);
+  check bool "operator profile removed" true
+    (match rendered |> member "operator_judge_models" with `Null -> true | _ -> false);
+  let routes = rendered |> member "routes" in
+  let route_keys =
+    match routes with
+    | `Assoc fields -> fields |> List.map fst |> List.sort String.compare
+    | _ -> []
+  in
+  check (list string) "repo seed routes cover known logical uses"
+    (Masc_mcp.Cascade_routes.known_route_keys |> List.sort String.compare)
+    route_keys;
+  check string "governance route" "big_three"
+    (routes |> member "governance_judge" |> to_string);
+  check string "operator route" "big_three"
+    (routes |> member "operator_judge" |> to_string);
+  check string "rerank route" "tool_rerank"
+    (routes |> member "llm_rerank" |> to_string);
+  check bool "tool_rerank is system-only" false
+    (rendered |> member "tool_rerank_keeper_assignable" |> to_bool)
+
+let test_routes_table_is_parsed () =
+  match
+    Masc_mcp.Cascade_toml_materializer.render_toml_string_to_json_string
+      {|
+[routes]
+governance_judge = "big_three"
+llm_rerank = "tool_rerank"
+
+[big_three]
+models = ["codex_cli:auto"]
+
+[tool_rerank]
+models = ["gemini_cli:auto"]
+keeper_assignable = false
+|}
+  with
+  | Error msg -> failf "expected routes table to parse, got: %s" msg
+  | Ok json_str ->
+      let json = Yojson.Safe.from_string json_str in
+      let routes = json |> member "routes" in
+      check string "governance_judge route rendered" "big_three"
+        (routes |> member "governance_judge" |> to_string);
+      check string "llm_rerank route rendered" "tool_rerank"
+        (routes |> member "llm_rerank" |> to_string);
+      check (list string) "routes is not a profile section fallback"
+        [ "big_three"; "tool_rerank" ]
+        (let dir = Filename.temp_file "cascade-routes-section-" "" in
+         Sys.remove dir;
+         Unix.mkdir dir 0o755;
+         let toml_path = Filename.concat dir "cascade.toml" in
+         let json_path = Filename.concat dir "cascade.json" in
+         write_file toml_path
+           {|
+[routes]
+governance_judge = "big_three"
+
+[big_three]
+models = ["codex_cli:auto"]
+
+[tool_rerank]
+models = ["gemini_cli:auto"]
+|};
+         Fun.protect
+           ~finally:(fun () -> rm_rf dir)
+           (fun () ->
+             match
+               Masc_mcp.Cascade_toml_materializer.toml_section_names_result
+                 ~config_path:json_path
+             with
+             | Ok names -> names
+             | Error msg -> failf "section fallback failed: %s" msg))
 
 let test_repo_toml_renders_to_committed_json () =
   let rendered = render_or_fail (repo_toml_path ()) in
@@ -493,8 +574,8 @@ let () =
         [
           test_case "repo toml renders to committed json" `Quick
             test_repo_toml_renders_to_committed_json;
-          test_case "repo seed excludes claude from automatic profiles" `Quick
-            test_repo_seed_excludes_claude_from_automatic_profiles;
+          test_case "repo seed uses two profiles plus routes" `Quick
+            test_repo_seed_uses_two_profiles_plus_routes;
         ] );
       ( "validation",
         [
@@ -510,6 +591,8 @@ let () =
             test_keep_alive_duration_string_is_parsed;
           test_case "num_ctx field is parsed" `Quick
             test_num_ctx_field_is_parsed;
+          test_case "routes table is parsed" `Quick
+            test_routes_table_is_parsed;
           test_case "keep_alive absent is backward compatible" `Quick
             test_keep_alive_absent_is_backward_compatible;
           test_case "loader catalog exposes fallback_cascade" `Quick

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -918,15 +918,15 @@ let test_oas_capacity_restore_contracts () =
   check bool "operator judge backoff uses OAS local capacity" true
     (file_contains_pattern "lib/dashboard/dashboard_operator_judge.ml"
        "local_capacity_for_selections ~sw ~net");
-  check bool "operator judge selection is explicit" true
+  check bool "operator judge selection is routed through cascade config" true
     (file_contains_pattern "lib/dashboard/dashboard_operator_judge.ml"
-       {|[ "operator_judge" ]|});
+       "Keeper_cascade_profile.Operator_judge");
   check bool "governance judge backoff uses OAS local capacity" true
     (file_contains_pattern "lib/dashboard/dashboard_governance_judge.ml"
        "local_capacity_for_selections ~sw ~net");
-  check bool "governance judge selection is explicit" true
+  check bool "governance judge selection is routed through cascade config" true
     (file_contains_pattern "lib/dashboard/dashboard_governance_judge.ml"
-       {|[ "governance_judge" ]|});
+       "Keeper_cascade_profile.Governance_judge");
   check bool "autoresearch background gating restores OAS capacity query" true
     (file_contains_pattern "lib/autoresearch_codegen.ml"
        "local_capacity_for_selections ~sw ~net");

--- a/test/test_keeper_cascade_profile.ml
+++ b/test/test_keeper_cascade_profile.ml
@@ -2,8 +2,8 @@ open Alcotest
 
 module Profile = Masc_mcp.Keeper_cascade_profile
 
-(* Only the SSOT variants round-trip through [of_string_opt] -> [to_string].
-   Legacy aliases collapse to Big_three; phase-routing names return None. *)
+(* Only concrete profile variants round-trip through [of_string_opt] ->
+   [to_string]. Legacy aliases are logical route names, not profile names. *)
 let variant_names = [ "big_three"; "tool_rerank" ]
 
 let write_file path contents =
@@ -38,7 +38,7 @@ let test_known_cascades_covers_variants () =
       check bool ("known_cascades contains " ^ name) true listed)
     variant_names
 
-let test_legacy_aliases_collapse_to_big_three () =
+let test_legacy_aliases_follow_keeper_fallback_without_catalog () =
   let aliases = [ "oas-keeper_unified"; "coding_first"; "oas-coding_first";
                   "keeper_turn"; "keeper_reply"; "default"; "keeper_unified";
                   "sangsu"; "local_mlx_vlm_qwen36";
@@ -48,28 +48,28 @@ let test_legacy_aliases_collapse_to_big_three () =
   List.iter
     (fun raw ->
       let canon = Profile.canonicalize_with_catalog ~catalog:[] raw in
-      check string ("alias " ^ raw ^ " -> big_three") "big_three" canon)
+      check string ("alias " ^ raw ^ " -> fallback") "big_three" canon)
     aliases
 
-let test_catalog_routed_names_return_none () =
+let test_logical_route_names_are_not_profile_variants () =
   check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "keeper_unified returns None"
+    "keeper_unified is not a built-in profile"
     None
     (Profile.of_string_opt "keeper_unified");
   check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "tool_use_strict returns None"
+    "tool_use_strict is not a built-in profile"
     None
     (Profile.of_string_opt "tool_use_strict");
   check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "resilient_breaker returns None"
+    "resilient_breaker is not a built-in profile"
     None
     (Profile.of_string_opt "resilient_breaker");
   check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "local_only returns None"
+    "local_only is not a built-in profile"
     None
     (Profile.of_string_opt "local_only");
   check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "local_recovery returns None"
+    "local_recovery is not a built-in profile"
     None
     (Profile.of_string_opt "local_recovery")
 
@@ -125,10 +125,10 @@ let test_catalog_names_follow_live_config () =
         "tool_use_strict"
         (Profile.canonicalize_with_catalog ~catalog "tool_use_strict");
       check string "dynamic live profile requires exact match"
-        "big_three"
+        "custom_live"
         (Profile.canonicalize_with_catalog ~catalog "Custom_Live");
       check string "unknown live profile still falls back"
-        "big_three"
+        "custom_live"
         (Profile.canonicalize_with_catalog ~catalog "missing_profile"))
 
 let test_resolve_live_with_catalog_requires_active_membership () =
@@ -152,15 +152,75 @@ let test_resolve_live_with_catalog_requires_active_membership () =
       check string "tool_use_strict catalog profile survives live resolution"
         "tool_use_strict"
         (Profile.resolve_live_with_catalog ~catalog "tool_use_strict");
-      check string "legacy alias resolves through active default"
-        "big_three"
+      check string "legacy alias resolves through active catalog fallback"
+        "custom_live"
         (Profile.resolve_live_with_catalog ~catalog "oas-keeper_unified");
       check string "inactive built-in profile falls back to default"
-        "big_three"
+        "custom_live"
         (Profile.resolve_live_with_catalog ~catalog "vendor_mix_balanced");
       check string "unknown profile falls back to default"
-        "big_three"
+        "custom_live"
         (Profile.resolve_live_with_catalog ~catalog "missing_profile"))
+
+let test_routes_resolve_logical_uses_to_configured_profiles () =
+  with_temp_config
+    {|
+      {
+        "big_three_models": ["codex_cli:auto"],
+        "custom_live_models": ["gemini_cli:auto"],
+        "tool_rerank_models": ["codex_cli:auto"],
+        "tool_rerank_keeper_assignable": false,
+        "routes": {
+          "governance_judge": "custom_live",
+          "operator_judge": "big_three",
+          "llm_rerank": "tool_rerank"
+        }
+      }
+    |}
+    (fun path ->
+      check string "governance route target"
+        "custom_live"
+        (Profile.cascade_name_for_use ~config_path:path Profile.Governance_judge);
+      check string "operator route target"
+        "big_three"
+        (Profile.cascade_name_for_use ~config_path:path Profile.Operator_judge);
+      check string "tool rerank route target"
+        "tool_rerank"
+        (Profile.cascade_name_for_use ~config_path:path Profile.Tool_rerank_use);
+      check (list string) "route targets are discovered"
+        [ "big_three"; "custom_live"; "tool_rerank" ]
+        (Profile.configured_route_targets ~config_path:path ()))
+
+let test_missing_route_uses_catalog_fallback_not_logical_name () =
+  with_temp_config
+    {|
+      {
+        "alpha_models": ["gemini_cli:auto"],
+        "tool_rerank_models": ["codex_cli:auto"],
+        "tool_rerank_keeper_assignable": false
+      }
+    |}
+    (fun path ->
+      check string "missing governance route uses keeper-assignable profile"
+        "alpha"
+        (Profile.cascade_name_for_use ~config_path:path Profile.Governance_judge);
+      check string "missing rerank route still prefers tool_rerank when present"
+        "tool_rerank"
+        (Profile.cascade_name_for_use ~config_path:path Profile.Tool_rerank_use))
+
+let test_missing_system_route_prefers_system_only_catalog_profile () =
+  with_temp_config
+    {|
+      {
+        "alpha_models": ["gemini_cli:auto"],
+        "short_scoring_models": ["codex_cli:auto"],
+        "short_scoring_keeper_assignable": false
+      }
+    |}
+    (fun path ->
+      check string "system route uses system-only catalog profile"
+        "short_scoring"
+        (Profile.cascade_name_for_use ~config_path:path Profile.Tool_rerank_use))
 
 let test_catalog_read_failures_do_not_fallback_to_hardcoded_names () =
   let missing = Filename.concat (Filename.get_temp_dir_name ()) "missing-cascade.json" in
@@ -179,13 +239,20 @@ let () =
     [ ( "ssot",
         [ test_case "active names round-trip" `Quick test_round_trip;
           test_case "known_cascades covers active" `Quick test_known_cascades_covers_variants;
-          test_case "legacy aliases collapse" `Quick test_legacy_aliases_collapse_to_big_three;
-          test_case "catalog-routed names return None" `Quick
-            test_catalog_routed_names_return_none;
+          test_case "legacy aliases follow fallback" `Quick
+            test_legacy_aliases_follow_keeper_fallback_without_catalog;
+          test_case "logical route names are not profile variants" `Quick
+            test_logical_route_names_are_not_profile_variants;
           test_case "unknown falls back to default" `Quick test_unknown_falls_back_to_default;
           test_case "catalog_names follow live config" `Quick test_catalog_names_follow_live_config;
           test_case "resolve_live_with_catalog requires active membership" `Quick
             test_resolve_live_with_catalog_requires_active_membership;
+          test_case "routes resolve logical uses" `Quick
+            test_routes_resolve_logical_uses_to_configured_profiles;
+          test_case "missing route uses catalog fallback" `Quick
+            test_missing_route_uses_catalog_fallback_not_logical_name;
+          test_case "missing system route uses system-only fallback" `Quick
+            test_missing_system_route_prefers_system_only_catalog_profile;
           test_case "catalog read failures stay empty" `Quick
             test_catalog_read_failures_do_not_fallback_to_hardcoded_names ] )
     ]

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2439,6 +2439,19 @@ let test_kimi_cli_build_args_uses_stdin_for_large_prompt () =
   Alcotest.(check bool) "large prompt does not use -p" false
     (List.mem "-p" argv)
 
+let test_kimi_cli_build_args_uses_stdin_for_non_ascii_prompt () =
+  let prompt = "한글 prompt" in
+  let argv =
+    Oas_worker_exec.Kimi_cli_transport_local.build_args
+      ~config:Oas_worker_exec.Kimi_cli_transport_local.default_config
+      ~req_config:(make_kimi_cli_provider_cfg ())
+      ~mcp_config_json:[] ~prompt
+  in
+  Alcotest.(check bool) "non-ASCII prompt is omitted from argv" false
+    (List.mem prompt argv);
+  Alcotest.(check bool) "non-ASCII prompt does not use -p" false
+    (List.mem "-p" argv)
+
 let test_kimi_cli_model_for_provider_keeps_transport_default_on_auto () =
   let provider_cfg = make_kimi_cli_provider_cfg () in
   Alcotest.(check (option string)) "auto uses transport default"
@@ -3981,6 +3994,8 @@ let () =
         test_kimi_cli_build_args_include_runtime_mcp_config;
       Alcotest.test_case "kimi large prompt uses stdin, not argv" `Quick
         test_kimi_cli_build_args_uses_stdin_for_large_prompt;
+      Alcotest.test_case "kimi non-ASCII prompt uses stdin, not argv" `Quick
+        test_kimi_cli_build_args_uses_stdin_for_non_ascii_prompt;
       Alcotest.test_case "kimi auto model keeps transport default" `Quick
         test_kimi_cli_model_for_provider_keeps_transport_default_on_auto;
       Alcotest.test_case "kimi explicit model is preserved" `Quick


### PR DESCRIPTION
## Summary

- Collapse the checked-in cascade seed to two concrete profiles: `big_three` and `tool_rerank`.
- Add a config-owned `[routes]` mapping so logical uses such as governance/operator judges, phase recovery, verifier, autoresearch, OpenAI compat, and rerank resolve to active profile names instead of requiring profile-name aliases.
- Move cascade fallback and route validation into a single route registry, including fail-loud checks for unknown route keys and missing route targets.
- Route keeper defaults, rerank defaults, dashboard judges, verifier/autoresearch/deep-review/server callers, and related docs/tests through the route registry.
- Keep Kimi CLI prompts with non-ASCII bytes out of argv and route them through stdin to avoid local `setproctitle` UTF-8 decode crashes.

## Why

The previous implementation mixed cascade definition and usage across separate hardcoded strings. Runtime code could still force names such as `governance_judge` or `operator_judge` to exist as concrete profiles, which broke the intended two-profile setup and made config drift hard to reason about.

This PR makes the catalog shape simple: concrete profiles are config data, logical call sites are route keys, and validation checks the route table rather than silently reconstructing old profile names.

## Operator Impact

- Operators can keep only `big_three` and `tool_rerank` in live config while routing every logical lane through `[routes]`.
- A typo such as `governance_jduge` now rejects the catalog with an actionable route-key error.
- A route target that names a missing profile now rejects the catalog instead of falling back silently.
- `routes.keeper_turn` is the required default profile; `big_three` is no longer the validation gate when config declares a different keeper default.

## Validation

- `scripts/dune-local.sh build ./test/test_oas_worker.exe ./test/test_cascade_catalog_runtime.exe ./test/test_keeper_cascade_profile.exe ./test/test_cascade_toml_materialization.exe ./test/test_keeper_topk_llm.exe ./test/test_ci_hardening_source.exe ./test/test_anti_rationalization_coverage.exe`
- `./_build/default/test/test_cascade_catalog_runtime.exe`
- `./_build/default/test/test_keeper_cascade_profile.exe`
- `env MASC_CASCADE_TOML_PATH=config/cascade.toml MASC_CASCADE_JSON_PATH=config/cascade.json ./_build/default/test/test_cascade_toml_materialization.exe`
- `./_build/default/test/test_keeper_topk_llm.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `./_build/default/test/test_anti_rationalization_coverage.exe`
- `./_build/default/test/test_oas_worker.exe test resume_config 46,47`
- `git diff --check`

Note: full `test_oas_worker.exe` was started but hung after initial cases with no output for several minutes, so it was stopped; the Kimi-specific regression cases were run directly.