### PR TITLE
fix(keeper): prevent stale watchdog from killing proactive keepers on skip

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -387,6 +387,14 @@ let run_keepalive_unified_turn
           ~base_path:ctx.config.base_path
           meta_after_triage.name
           ~reasons:verdict_strs;
+        (* #10940 follow-up — proactive keepers with no actionable work skip
+           turns legitimately.  Without updating [last_turn_ts] the stale
+           watchdog sees an idle > 300 s fiber and kills the keeper.
+           Touching the timestamp keeps the watchdog aligned with the
+           heartbeat loop's actual liveness. *)
+        Keeper_registry.touch_last_turn_ts
+          ~base_path:ctx.config.base_path
+          meta_after_triage.name;
         let log_not_scheduled =
           match turn_decision.verdict with
           | Keeper_world_observation.Skip { reasons = (Keeper_world_observation.Scheduled_autonomous_disabled, []) } ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -696,6 +696,21 @@ let record_skip_reasons ~base_path name ~reasons =
       { e with last_skip_observation = Some (now, reasons) })
   end
 
+let touch_last_turn_ts ~base_path name =
+  let now = Time_compat.now () in
+  update_entry ~base_path name (fun e ->
+    let runtime = e.meta.runtime in
+    let usage = runtime.usage in
+    { e with
+      meta =
+        { e.meta with
+          runtime =
+            { runtime with
+              usage = { usage with last_turn_ts = now }
+            }
+        }
+    })
+
 let increment_turn_failures ~base_path name =
   update_entry ~base_path name (fun e ->
     { e with turn_consecutive_failures = e.turn_consecutive_failures + 1 })

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -328,6 +328,12 @@ val mark_turn_finished : base_path:string -> string -> unit
 val record_skip_reasons :
   base_path:string -> string -> reasons:string list -> unit
 
+(** Touch [last_turn_ts] in the registry entry so the stale watchdog
+    sees the keeper as recently active.  Called from the heartbeat
+    skip branch when a proactive keeper legitimately has no work to do.
+    No-op if no entry is registered for [name]. *)
+val touch_last_turn_ts : base_path:string -> string -> unit
+
 (** Increment turn consecutive failure counter. *)
 val increment_turn_failures : base_path:string -> string -> unit
 

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -765,6 +765,31 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   let result =
     Result.bind result (fun () -> tool_access_defaults_result)
   in
+  let result =
+    Result.bind result (fun () ->
+        let has_proactive_enabled = has "proactive_enabled" in
+        let has_proactive_idle = has "proactive_idle_sec" in
+        let has_proactive_cooldown = has "proactive_cooldown_sec" in
+        match
+          (has_proactive_enabled, has_proactive_idle, has_proactive_cooldown)
+        with
+        | true, false, false ->
+            Error
+              "proactive_enabled is set but proactive_idle_sec and \
+               proactive_cooldown_sec are missing"
+        | true, false, _ ->
+            Error
+              "proactive_enabled is set but proactive_idle_sec is missing"
+        | true, _, false ->
+            Error
+              "proactive_enabled is set but proactive_cooldown_sec is \
+               missing"
+        | false, true, _ | false, _, true ->
+            Error
+              "proactive_idle_sec or proactive_cooldown_sec is set but \
+               proactive_enabled is missing"
+        | _ -> Ok ())
+  in
   Result.map
     (fun (tool_preset, tool_also_allow, tool_preset_source) ->
       {


### PR DESCRIPTION
## Summary

- Add Keeper_registry.touch_last_turn_ts to update last_turn_ts when a proactive keeper legitimately skips a turn.
- Call touch_last_turn_ts from the heartbeat skip branch right after record_skip_reasons.
- Validate proactive field consistency in keeper TOML loader: if any of proactive_enabled / proactive_idle_sec / proactive_cooldown_sec is present, the group must be complete.

## Root cause

Proactive keepers with no actionable work skip turns. The skip path updated last_skip_observation but not last_turn_ts. After 300s the stale watchdog saw last_turn_ts > 300s and killed the keeper, even though the heartbeat loop was running normally.

## Test plan

- [ ] dune build @check passes
- [ ] Verify qa-king and scholar TOML configs load without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
