### PR TITLE
[P-FSM-01] Add Paused transition from Compacting and HandingOff

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -288,13 +288,15 @@ let can_transition ~from_phase ~to_phase =
      re-enters Overflowed so the retry loop can decide next step — if the
      caller has latched [compact_retry_exhausted], derive_phase immediately
      promotes to Paused instead)
+     | Paused (operator pause during compaction)
      | Failing (hb fail / guardrail during)
      | Crashed (fatal) | Draining (operator stop during). *)
-  | Compacting, (Running | Overflowed | Failing | Crashed | Draining) -> true
+  | Compacting, (Running | Overflowed | Failing | Crashed | Draining | Paused) -> true
   | Compacting, _ -> false
   (* HandingOff -> Running (done) | Failing | Crashed
-     | Draining (operator stop during handoff) *)
-  | HandingOff, (Running | Failing | Crashed | Draining) -> true
+     | Draining (operator stop during handoff)
+     | Paused (operator pause during handoff) *)
+  | HandingOff, (Running | Failing | Crashed | Draining | Paused) -> true
   | HandingOff, _ -> false
   (* Draining -> Stopped (done) | Crashed (fatal during drain) *)
   | Draining, (Stopped | Crashed) -> true

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -459,6 +459,12 @@ let test_can_transition_handingoff_to_failing () =
 let test_can_transition_handingoff_to_crashed () =
   check bool "-> Crashed" true (SM.can_transition ~from_phase:SM.HandingOff ~to_phase:SM.Crashed)
 
+let test_can_transition_compacting_to_paused () =
+  check bool "-> Paused" true (SM.can_transition ~from_phase:SM.Compacting ~to_phase:SM.Paused)
+
+let test_can_transition_handingoff_to_paused () =
+  check bool "-> Paused" true (SM.can_transition ~from_phase:SM.HandingOff ~to_phase:SM.Paused)
+
 let test_can_transition_failing_to_draining () =
   check bool "-> Draining" true (SM.can_transition ~from_phase:SM.Failing ~to_phase:SM.Draining)
 
@@ -2138,8 +2144,10 @@ let () =
       test_case "Crashed -> Restarting|Dead only" `Quick test_can_transition_crashed_only_restart_or_dead;
       test_case "Compacting -> Failing" `Quick test_can_transition_compacting_to_failing;
       test_case "Compacting -> Crashed" `Quick test_can_transition_compacting_to_crashed;
+      test_case "Compacting -> Paused" `Quick test_can_transition_compacting_to_paused;
       test_case "HandingOff -> Failing" `Quick test_can_transition_handingoff_to_failing;
       test_case "HandingOff -> Crashed" `Quick test_can_transition_handingoff_to_crashed;
+      test_case "HandingOff -> Paused" `Quick test_can_transition_handingoff_to_paused;
       test_case "Failing -> Draining" `Quick test_can_transition_failing_to_draining;
       test_case "Restarting -> Crashed" `Quick test_can_transition_restarting_to_crashed;
       test_case "Restarting -> Dead" `Quick test_can_transition_restarting_to_dead;


### PR DESCRIPTION
## Summary

Add missing `Paused` transitions from `Compacting` and `HandingOff` states in the keeper state machine.

- `Compacting -> Paused`: operator pause during compaction
- `HandingOff -> Paused`: operator pause during handoff

Both transitions are already implicitly reachable via `derive_phase` when conditions latch, but were absent from the explicit `can_transition` matrix. This caused `Invalid_transition` attribution instead of the expected `Paused` phase.

## Changes

- `lib/keeper/keeper_state_machine.ml`: Added `Paused` to the `Compacting` and `HandingOff` transition arms
- `test/test_keeper_state_machine.ml`: Regression tests for both transitions

## Test plan

- [x] `dune build --root . lib/keeper/` passes
- [x] `dune exec --root . test/test_keeper_state_machine.exe` passes (112 tests)
- [x] New regression tests included

## References

- artifact_synthesis.md Theme 1 / Quick Win QW-1
- Ref: P-FSM-01

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>