### PR TITLE
refactor(cascade): type record cascade names

### DIFF
--- a/config/keepers/ramarama.toml
+++ b/config/keepers/ramarama.toml
@@ -2,8 +2,11 @@
 persona_name = "ramarama"
 sandbox_profile = "docker"
 network_mode = "inherit"
-tool_preset = "social"
 work_discovery_enabled = true
 work_discovery_sources = ["board_posts"]
 github_identity = "anyang-keepers"
 git_identity_mode = "github_identity"
+
+[keeper.tool_access]
+kind = "preset"
+preset = "social"

--- a/config/keepers/taskmaster.toml
+++ b/config/keepers/taskmaster.toml
@@ -2,8 +2,11 @@
 persona_name = "taskmaster"
 sandbox_profile = "docker"
 network_mode = "inherit"
-tool_preset = "delivery"
 work_discovery_enabled = true
 work_discovery_sources = ["unclaimed_tasks", "stale_tasks"]
 github_identity = "anyang-keepers"
 git_identity_mode = "github_identity"
+
+[keeper.tool_access]
+kind = "preset"
+preset = "delivery"

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -467,6 +467,9 @@ let keeper_name_to_json keeper_name =
   | _ -> `Null
 
 let cascade_audit_json ~now ~keeper_name ~cascade_name ~observation ~outcome =
+  let cascade_name =
+    Keeper_cascade_profile.runtime_name_to_string cascade_name
+  in
   `Assoc
     [
       ("ts", `Float now);
@@ -482,6 +485,9 @@ let cascade_audit_json ~now ~keeper_name ~cascade_name ~observation ~outcome =
 
 let record_cascade_audit store_opt ~now ~keeper_name ~cascade_name ~observation
     ~outcome =
+  let cascade_name_string =
+    Keeper_cascade_profile.runtime_name_to_string cascade_name
+  in
   match store_opt with
   | None -> ()
   | Some store ->
@@ -493,7 +499,7 @@ let record_cascade_audit store_opt ~now ~keeper_name ~cascade_name ~observation
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
           Log.Misc.warn "cascade audit append failed cascade=%s error=%s"
-            cascade_name (Printexc.to_string exn))
+            cascade_name_string (Printexc.to_string exn))
 
 (* ================================================================ *)
 (* Aggregate metrics recording                                       *)
@@ -526,7 +532,7 @@ let attempt_model_display (attempt : cascade_attempt) =
 type msg =
   | Record_cascade of {
       keeper_name : string option;
-      cascade_name : string;
+      cascade_name : Keeper_cascade_profile.runtime_name;
       observation : cascade_observation option;
       outcome : [ `Success | `Failure | `Rejected ];
       now : float;
@@ -542,9 +548,12 @@ type state = {
 let stream = Eio.Stream.create 1024
 
 let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
+  let cascade_name_string =
+    Keeper_cascade_profile.runtime_name_to_string cascade_name
+  in
   let counters = state.counters in
   let counter, counters, evicted =
-    match StringMap.find_opt cascade_name counters with
+    match StringMap.find_opt cascade_name_string counters with
     | Some c -> (c, counters, None)
     | None ->
         let (counters_after_evict, evicted) =
@@ -555,7 +564,7 @@ let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
           else (counters, None)
         in
         let c = create_cascade_counter ~now () in
-        (c, StringMap.add cascade_name c counters_after_evict, evicted)
+        (c, StringMap.add cascade_name_string c counters_after_evict, evicted)
   in
   let counter = { counter with calls = counter.calls + 1; last_used_at = now } in
   let counter =
@@ -598,13 +607,16 @@ let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
     (fun candidate ->
       Log.Misc.warn
         "cascade metrics evicted key=%s calls=%d last_used_at=%.3f to admit %s (limit=%d)"
-        candidate.name candidate.calls candidate.last_used_at cascade_name
+        candidate.name candidate.calls candidate.last_used_at cascade_name_string
         cascade_max_keys)
     evicted;
   let audit_store_next = get_cascade_audit_store state.audit_store in
   record_cascade_audit audit_store_next ~now ~keeper_name ~cascade_name
     ~observation ~outcome;
-  { counters = StringMap.add cascade_name counter counters; audit_store = audit_store_next }
+  {
+    counters = StringMap.add cascade_name_string counter counters;
+    audit_store = audit_store_next;
+  }
 
 let handle_get_metrics state p =
   let counters = state.counters in

--- a/lib/oas_worker_cascade.mli
+++ b/lib/oas_worker_cascade.mli
@@ -187,7 +187,7 @@ val start_actor_if_needed : sw:Eio.Switch.t -> unit
 val record_cascade :
   ?keeper_name:string ->
   observation:cascade_observation option ->
-  cascade_name:string ->
+  cascade_name:Keeper_cascade_profile.runtime_name ->
   outcome:[ `Success | `Failure | `Rejected ] ->
   unit ->
   unit

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -387,7 +387,8 @@ let run_named
           ?strategy:!cascade_strategy_name_ref ~configured_labels
           ~candidate_cfgs ~selected_model_raw:None ~capture ()
       in
-      Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+      Oas_worker_cascade.record_cascade ~keeper_name
+        ~cascade_name:error_cascade_name
         ~outcome:`Failure ~observation:(Some observation) ();
       let terminal_error =
         match last_err with
@@ -461,7 +462,8 @@ let run_named
             ~capture ()
         in
         let result = { result with cascade_observation = Some observation } in
-        Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+        Oas_worker_cascade.record_cascade ~keeper_name
+          ~cascade_name:error_cascade_name
           ~outcome:`Success ~observation:(Some observation) ();
         on_success ~provider_key:provider_cfg.model_id;
         Ok result
@@ -491,8 +493,9 @@ let run_named
                ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
-           Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
-          ~outcome:`Success ~observation:(Some observation) ();
+           Oas_worker_cascade.record_cascade ~keeper_name
+             ~cascade_name:error_cascade_name
+             ~outcome:`Success ~observation:(Some observation) ();
            on_success ~provider_key:provider_cfg.model_id;
            Ok result
          | Cascade_fsm.Try_next { last_err = new_err } ->
@@ -511,7 +514,8 @@ let run_named
                ~candidate_cfgs ~selected_model_raw:(Some result.response.model)
                ~capture ()
            in
-           Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+           Oas_worker_cascade.record_cascade ~keeper_name
+             ~cascade_name:error_cascade_name
              ~outcome:`Rejected ~observation:(Some observation) ();
            Log.Misc.error "cascade %s exhausted: all tiers rejected by accept predicate (last model=%s, reason=%s)"
              cascade_name result.response.model reason;
@@ -533,8 +537,9 @@ let run_named
                ~candidate_cfgs ~selected_model_raw:(Some resp.model) ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
-           Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
-          ~outcome:`Success ~observation:(Some observation) ();
+           Oas_worker_cascade.record_cascade ~keeper_name
+             ~cascade_name:error_cascade_name
+             ~outcome:`Success ~observation:(Some observation) ();
            on_success ~provider_key:provider_cfg.model_id;
            Ok result)
       | Error sdk_err ->
@@ -700,8 +705,9 @@ let run_named
                   ?strategy:!cascade_strategy_name_ref ~configured_labels
                   ~candidate_cfgs ~selected_model_raw:None ~capture ()
               in
-              Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
-        ~outcome:`Failure ~observation:(Some observation) ();
+              Oas_worker_cascade.record_cascade ~keeper_name
+                ~cascade_name:error_cascade_name
+                ~outcome:`Failure ~observation:(Some observation) ();
               Log.Misc.error "cascade %s exhausted: all tiers failed (last model=%s, error=%s)"
                 cascade_name provider_cfg.model_id (Oas.Error.to_string sdk_err);
               Error sdk_err
@@ -714,8 +720,9 @@ let run_named
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_cfgs ~selected_model_raw:None ~capture ()
            in
-           Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
-        ~outcome:`Failure ~observation:(Some observation) ();
+           Oas_worker_cascade.record_cascade ~keeper_name
+             ~cascade_name:error_cascade_name
+             ~outcome:`Failure ~observation:(Some observation) ();
            Log.Misc.error "cascade %s: non-cascadable error from %s: %s"
              cascade_name provider_cfg.model_id (Oas.Error.to_string sdk_err);
            Error sdk_err))
@@ -838,7 +845,8 @@ let run_named
         ?strategy:!cascade_strategy_name_ref ~configured_labels
         ~candidate_cfgs ~selected_model_raw:None ~capture ()
     in
-    Oas_worker_cascade.record_cascade ~keeper_name ~cascade_name
+    Oas_worker_cascade.record_cascade ~keeper_name
+      ~cascade_name:error_cascade_name
       ~outcome:`Failure ~observation:(Some observation) ();
     Error
       (sdk_error_of_masc_internal_error

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -449,6 +449,8 @@ desires = "low false positives"
 instructions = "You are a log analyzer."
 mention_targets = ["sherlock", "log-analyzer"]
 proactive_enabled = true
+proactive_idle_sec = 300
+proactive_cooldown_sec = 60
 room_signal_prompt_enabled = true
 policy_voice_enabled = false
 autoboot_enabled = false
@@ -1027,6 +1029,8 @@ let test_persona_resolver_renders_durable_keeper_toml () =
         ("autoboot_enabled", `Bool false);
         ("mention_targets", `List [ `String "probe"; `String "@probe" ]);
         ("proactive_enabled", `Bool true);
+        ("proactive_idle_sec", `Int 300);
+        ("proactive_cooldown_sec", `Int 60);
         ("allowed_paths", `List [ `String "/tmp/probe" ]);
         ( "tool_access",
           `Assoc

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -59,7 +59,7 @@ let test_named_keeper_docker_defaults () =
   in
   expect_keeper ~name:"issue_king" ~persona:"issue_king";
   expect_keeper ~name:"masc-improver" ~persona:"analyst";
-  expect_keeper ~name:"sangsu" ~persona:"executor"
+  expect_keeper ~name:"sangsu" ~persona:"sangsu"
 
 (** Write a temporary TOML file, run load_keeper_toml, clean up. *)
 let with_temp_toml content f =

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -528,7 +528,7 @@ let test_cascade_metrics_concurrent_recording () =
              fun () ->
                for _ = 1 to 25 do
                  Masc_mcp.Oas_worker_cascade.record_cascade
-                   ~cascade_name:"concurrent-cascade"
+                   ~cascade_name:(internal_cascade_name "concurrent-cascade")
                    ~observation:None
                    ~outcome:`Success
                    ()
@@ -554,26 +554,26 @@ let test_cascade_metrics_evicts_lowest_call_key () =
       Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ())
     (fun () ->
       Masc_mcp.Oas_worker_cascade.record_cascade
-        ~cascade_name:"victim-key"
+        ~cascade_name:(internal_cascade_name "victim-key")
         ~observation:None
         ~outcome:`Success
         ();
       for i = 1 to 254 do
         let name = Printf.sprintf "stable-%03d" i in
         Masc_mcp.Oas_worker_cascade.record_cascade
-          ~cascade_name:name
+          ~cascade_name:(internal_cascade_name name)
           ~observation:None
           ~outcome:`Success
           ();
         Masc_mcp.Oas_worker_cascade.record_cascade
-          ~cascade_name:name
+          ~cascade_name:(internal_cascade_name name)
           ~observation:None
           ~outcome:`Success
           ()
       done;
       for _ = 1 to 3 do
         Masc_mcp.Oas_worker_cascade.record_cascade
-          ~cascade_name:"hot-key"
+          ~cascade_name:(internal_cascade_name "hot-key")
           ~observation:None
           ~outcome:`Success
           ()
@@ -581,7 +581,7 @@ let test_cascade_metrics_evicts_lowest_call_key () =
       let before = Yojson.Safe.Util.to_list (Oas_worker.cascade_metrics_json ()) in
       Alcotest.(check int) "table capped before admit" 256 (List.length before);
       Masc_mcp.Oas_worker_cascade.record_cascade
-        ~cascade_name:"new-key"
+        ~cascade_name:(internal_cascade_name "new-key")
         ~observation:None
         ~outcome:`Success
         ();
@@ -657,7 +657,7 @@ let test_cascade_audit_persists_observation () =
       in
       Masc_mcp.Oas_worker_cascade.record_cascade
         ~keeper_name:"keeper-glm-agent-test"
-        ~cascade_name:"audit-cascade"
+        ~cascade_name:(internal_cascade_name "audit-cascade")
         ~observation:(Some observation)
         ~outcome:`Failure
         ();


### PR DESCRIPTION
## Summary

- Type `Oas_worker_cascade.record_cascade` and its actor message with `Keeper_cascade_profile.runtime_name`.
- Keep cascade-name rendering at the audit JSON and `StringMap` metric-key boundaries.
- Pass the already-typed OAS cascade name from `Oas_worker_named` record paths and update direct tests.
- Migrate checked-in keeper fixtures from legacy `tool_preset` to `[keeper.tool_access]`, and align `sangsu` config validation with the current keeper SSOT.

## Product impact

This continues #11926's cascade-name type ratchet through the async record/audit path while preserving the operator-facing JSON shape. The keeper fixture cleanup keeps checked-in TOML validation on the canonical tool-access shape after latest-main changes.

## Evidence

- `scripts/dune-local.sh build test/test_oas_worker.exe test/test_keeper_toml.exe test/test_keeper_toml_config_validation.exe`
- `./_build/default/test/test_oas_worker.exe test cascade_config 8`
- `./_build/default/test/test_oas_worker.exe test cascade_config 9`
- `./_build/default/test/test_oas_worker.exe test cascade_config 10`
- `./_build/default/test/test_keeper_toml.exe`
- `scripts/dune-local.sh build test/test_keeper_toml_config_validation.exe`
- `./_build/default/test/test_keeper_toml_config_validation.exe`
- `git diff --check`
- `scripts/stringly-boundary-ratchet.sh`
- `scripts/ocaml-structure-ratchet.sh`

## Review evidence

- `raw_cascade_name_string_signatures`: `41 / 81` against the ratchet baseline.
- `raw_decision_string_signatures`: `0`
- `raw_error_kind_string_signatures`: `0`

## Linked issue

- Part of #11926
