### PR TITLE
feat(dashboard): add AX collaboration and lifecycle organisms

### DIFF
--- a/dashboard/src/components/common/agent-lifecycle.a11y.test.ts
+++ b/dashboard/src/components/common/agent-lifecycle.a11y.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { html } from 'htm/preact'
+import { render } from '@testing-library/preact'
+import { act } from 'preact/test-utils'
+import { axe } from 'jest-axe'
+
+import { AgentLifecycle } from './agent-lifecycle'
+
+function renderInAct(ui: ReturnType<typeof html>) {
+  let result: ReturnType<typeof render>
+  act(() => {
+    result = render(ui)
+  })
+  return result!
+}
+
+describe('AgentLifecycle a11y', () => {
+  it('has no axe violations (created state)', async () => {
+    const { container } = renderInAct(
+      html`<${AgentLifecycle} currentState="created" />`
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no axe violations (active state)', async () => {
+    const { container } = renderInAct(
+      html`<${AgentLifecycle} currentState="active" />`
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no axe violations (idle state)', async () => {
+    const { container } = renderInAct(
+      html`<${AgentLifecycle} currentState="idle" />`
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no axe violations (terminated state)', async () => {
+    const { container } = renderInAct(
+      html`<${AgentLifecycle} currentState="terminated" />`
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has region role and label', () => {
+    const { container } = renderInAct(
+      html`<${AgentLifecycle} currentState="active" />`
+    )
+    const region = container.querySelector('[role="region"]')
+    expect(region).not.toBeNull()
+    expect(region?.getAttribute('aria-label')).toBe('에이전트 생명주기')
+  })
+
+  it('svg has img role and accessible name', () => {
+    const { container } = renderInAct(
+      html`<${AgentLifecycle} currentState="active" />`
+    )
+    const svg = container.querySelector('[role="img"]')
+    expect(svg).not.toBeNull()
+    const label = svg?.getAttribute('aria-label')
+    expect(label).toContain('생성됨')
+    expect(label).toContain('활성')
+  })
+
+  it('current state badge has accessible name', () => {
+    const { container } = renderInAct(
+      html`<${AgentLifecycle} currentState="active" />`
+    )
+    const badge = container.querySelector('[aria-label="현재 상태: 활성"]')
+    expect(badge).not.toBeNull()
+  })
+
+  it('renders last transition info', () => {
+    const { container } = renderInAct(
+      html`<${AgentLifecycle}
+        currentState="active"
+        lastTransition=${{ from: 'created', to: 'active', timestamp: Date.now() }}
+      />`
+    )
+    const info = container.querySelector('[aria-label="에이전트 생명주기"]')
+    expect(info?.textContent).toContain('마지막 전환')
+    expect(info?.textContent).toContain('생성됨')
+    expect(info?.textContent).toContain('활성')
+  })
+
+  it('unknown state falls back to raw state name', () => {
+    const { container } = renderInAct(
+      html`<${AgentLifecycle} currentState="unknown" />`
+    )
+    const badge = container.querySelector('[aria-label="현재 상태: unknown"]')
+    expect(badge).not.toBeNull()
+  })
+
+  it('has no axe violations with lastTransition', async () => {
+    const { container } = renderInAct(
+      html`<${AgentLifecycle}
+        currentState="idle"
+        lastTransition=${{ from: 'active', to: 'idle', timestamp: Date.now() }}
+      />`
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/agent-lifecycle.ts
+++ b/dashboard/src/components/common/agent-lifecycle.ts
@@ -1,0 +1,232 @@
+// AgentLifecycle — AX organism that visualises agent state-machine lifecycle.
+//
+// Kimi design system sec02 2.2.1 reference: SVG FSM diagram showing current
+// state, transitions, and last transition flash.
+
+import { html } from 'htm/preact'
+import { useEffect, useRef, useState } from 'preact/hooks'
+
+export interface LifecycleTransition {
+  from: string
+  to: string
+  label: string
+}
+
+interface AgentLifecycleProps {
+  currentState: string
+  lastTransition?: { from: string; to: string; timestamp: number }
+  testId?: string
+}
+
+const STATES: Record<string, { x: number; y: number; label: string }> = {
+  created: { x: 50, y: 50, label: '생성됨' },
+  active: { x: 200, y: 50, label: '활성' },
+  idle: { x: 200, y: 150, label: '유휴' },
+  terminated: { x: 350, y: 100, label: '종료' },
+}
+
+const TRANSITIONS: LifecycleTransition[] = [
+  { from: 'created', to: 'active', label: 'activate' },
+  { from: 'active', to: 'idle', label: 'pause' },
+  { from: 'idle', to: 'active', label: 'resume' },
+  { from: 'active', to: 'terminated', label: 'kill' },
+  { from: 'idle', to: 'terminated', label: 'timeout' },
+]
+
+function nodeClass(isCurrent: boolean): string {
+  const base =
+    'transition-all duration-300'
+  if (isCurrent) {
+    return `${base} r-6 stroke-[var(--accent-9)] stroke-2 fill-[var(--accent-3)]`
+  }
+  return `${base} r-4 stroke-[var(--gray-8)] stroke-1 fill-[var(--gray-3)]`
+}
+
+function nodeLabelClass(isCurrent: boolean): string {
+  const base = 'text-xs font-medium select-none'
+  if (isCurrent) {
+    return `${base} fill-[var(--accent-11)]`
+  }
+  return `${base} fill-[var(--gray-11)]`
+}
+
+function edgePath(from: { x: number; y: number }, to: { x: number; y: number }): string {
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  const midX = (from.x + to.x) / 2
+  const midY = (from.y + to.y) / 2
+  const offset = 20
+  const ctrlX = midX - dy * 0.2 + (dx < 0 ? -offset : offset)
+  const ctrlY = midY + dx * 0.2
+  return `M ${from.x} ${from.y} Q ${ctrlX} ${ctrlY} ${to.x} ${to.y}`
+}
+
+export function AgentLifecycle({
+  currentState,
+  lastTransition,
+  testId,
+}: AgentLifecycleProps) {
+  const [flashEdge, setFlashEdge] = useState<string | null>(null)
+  const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (lastTransition) {
+      const key = `${lastTransition.from}→${lastTransition.to}`
+      setFlashEdge(key)
+      if (flashTimeoutRef.current) {
+        clearTimeout(flashTimeoutRef.current)
+      }
+      flashTimeoutRef.current = setTimeout(() => {
+        setFlashEdge((current) => (current === key ? null : current))
+      }, 1000)
+    }
+    return () => {
+      if (flashTimeoutRef.current) {
+        clearTimeout(flashTimeoutRef.current)
+      }
+    }
+  }, [lastTransition?.from, lastTransition?.to, lastTransition?.timestamp])
+
+  const svgWidth = 420
+  const svgHeight = 210
+
+  const stateList = Object.entries(STATES)
+
+  return html`
+    <div
+      class="rounded-lg border border-[var(--gray-6)] bg-[var(--gray-1)] p-4"
+      role="region"
+      aria-label="에이전트 생명주기"
+      data-testid=${testId}
+    >
+      <div class="mb-3 flex items-center gap-2">
+        <span class="text-sm font-medium text-[var(--gray-12)]">생명주기 상태</span>
+        <span
+          class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-[var(--accent-3)] text-[var(--accent-11)]"
+          aria-label="현재 상태: ${STATES[currentState]?.label ?? currentState}"
+        >
+          ${STATES[currentState]?.label ?? currentState}
+        </span>
+      </div>
+
+      <svg
+        role="img"
+        aria-label="에이전트 상태 다이어그램. 상태: ${stateList.map(([,s]) => s.label).join(', ')}"
+        viewBox="0 0 ${svgWidth} ${svgHeight}"
+        class="w-full"
+        style="max-width:420px;"
+      >
+        <defs>
+          <marker
+            id="arrowhead"
+            markerWidth="10"
+            markerHeight="7"
+            refX="9"
+            refY="3.5"
+            orient="auto"
+          >
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--gray-8)" />
+          </marker>
+          <marker
+            id="arrowhead-flash"
+            markerWidth="10"
+            markerHeight="7"
+            refX="9"
+            refY="3.5"
+            orient="auto"
+          >
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--accent-9)" />
+          </marker>
+        </defs>
+
+        ${TRANSITIONS.map((t) => {
+          const from = STATES[t.from]
+          const to = STATES[t.to]
+          if (!from || !to) return null
+          const isFlashing =
+            flashEdge === `${t.from}→${t.to}` ||
+            flashEdge === `${t.to}→${t.from}`
+          const pathD = edgePath(from, to)
+
+          return html`
+            <g key=${t.label}>
+              <path
+                d=${pathD}
+                fill="none"
+                stroke=${isFlashing ? 'var(--accent-9)' : 'var(--gray-8)'}
+                stroke-width=${isFlashing ? '2.5' : '1.5'}
+                marker-end=${isFlashing ? 'url(#arrowhead-flash)' : 'url(#arrowhead)'}
+                class=${isFlashing ? 'transition-colors duration-300' : ''}
+              />
+              <text
+                x=${(from.x + to.x) / 2}
+                y=${(from.y + to.y) / 2 - 8}
+                text-anchor="middle"
+                class="text-2xs fill-[var(--gray-10)] select-none"
+              >
+                ${t.label}
+              </text>
+            </g>
+          `
+        })}
+
+        ${stateList.map(([key, state]) => {
+          const isCurrent = key === currentState
+          return html`
+            <g key=${key}>
+              ${isCurrent
+                ? html`
+                    <circle
+                      cx=${state.x}
+                      cy=${state.y}
+                      r="10"
+                      fill="none"
+                      stroke="var(--accent-7)"
+                      stroke-width="1"
+                      opacity="0.5"
+                    >
+                      <animate
+                        attributeName="r"
+                        values="10;14;10"
+                        dur="2s"
+                        repeatCount="indefinite"
+                      />
+                      <animate
+                        attributeName="opacity"
+                        values="0.5;0.2;0.5"
+                        dur="2s"
+                        repeatCount="indefinite"
+                      />
+                    </circle>
+                  `
+                : null}
+              <circle
+                cx=${state.x}
+                cy=${state.y}
+                class=${nodeClass(isCurrent)}
+              />
+              <text
+                x=${state.x}
+                y=${state.y + 20}
+                text-anchor="middle"
+                class=${nodeLabelClass(isCurrent)}
+              >
+                ${state.label}
+              </text>
+            </g>
+          `
+        })}
+      </svg>
+
+      ${lastTransition
+        ? html`
+            <div class="mt-2 text-xs text-[var(--gray-10)]">
+              마지막 전환: ${STATES[lastTransition.from]?.label ?? lastTransition.from}
+              → ${STATES[lastTransition.to]?.label ?? lastTransition.to}
+              (${new Date(lastTransition.timestamp).toLocaleTimeString()})
+            </div>
+          `
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/common/collaboration-canvas.a11y.test.ts
+++ b/dashboard/src/components/common/collaboration-canvas.a11y.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest'
+import { html } from 'htm/preact'
+import { render } from '@testing-library/preact'
+import { act } from 'preact/test-utils'
+import { axe } from 'jest-axe'
+
+import {
+  CollaborationCanvas,
+  CanvasParticipant,
+} from './collaboration-canvas'
+
+function renderInAct(ui: ReturnType<typeof html>) {
+  let result: ReturnType<typeof render>
+  act(() => {
+    result = render(ui)
+  })
+  return result!
+}
+
+const mockParticipants: CanvasParticipant[] = [
+  {
+    id: 'p1',
+    type: 'human',
+    name: 'Alice',
+    color: '#ff0000',
+    cursor: { x: 10, y: 20 },
+  },
+  {
+    id: 'p2',
+    type: 'agent',
+    name: 'Kimi',
+    color: '#00ff00',
+    selection: { start: 0, end: 5 },
+  },
+]
+
+describe('CollaborationCanvas a11y', () => {
+  it('has no axe violations', async () => {
+    const { container } = renderInAct(
+      html`<${CollaborationCanvas}
+        content="hello world"
+        participants=${mockParticipants}
+        onChange=${vi.fn()}
+      />`
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has region role and label', () => {
+    const { container } = renderInAct(
+      html`<${CollaborationCanvas}
+        content="test"
+        participants=${[]}
+        onChange=${vi.fn()}
+      />`
+    )
+    const region = container.querySelector('[role="region"]')
+    expect(region).not.toBeNull()
+    expect(region?.getAttribute('aria-label')).toBe('협업 편집 영역')
+  })
+
+  it('textarea is labelled by span', () => {
+    const { container } = renderInAct(
+      html`<${CollaborationCanvas}
+        content="test"
+        participants=${[]}
+        onChange=${vi.fn()}
+      />`
+    )
+    const textarea = container.querySelector('textarea')
+    expect(textarea).not.toBeNull()
+    const labelId = textarea?.getAttribute('aria-labelledby')
+    expect(labelId).toBeTruthy()
+    const label = document.getElementById(labelId!)
+    expect(label?.textContent).toContain('협업 편집기')
+  })
+
+  it('participant list has list role', () => {
+    const { container } = renderInAct(
+      html`<${CollaborationCanvas}
+        content="test"
+        participants=${mockParticipants}
+        onChange=${vi.fn()}
+      />`
+    )
+    const list = container.querySelector('[role="list"]')
+    expect(list).not.toBeNull()
+    expect(list?.getAttribute('aria-label')).toBe('참여자 목록')
+  })
+
+  it('each participant is a listitem with accessible name', () => {
+    const { container } = renderInAct(
+      html`<${CollaborationCanvas}
+        content="test"
+        participants=${mockParticipants}
+        onChange=${vi.fn()}
+      />`
+    )
+    const items = container.querySelectorAll('[role="listitem"]')
+    expect(items.length).toBe(2)
+    expect(items[0].getAttribute('aria-label')).toBe('Alice (사람)')
+    expect(items[1].getAttribute('aria-label')).toBe('Kimi (에이전트)')
+  })
+
+  it('cursor indicators have img role and labels', () => {
+    const { container } = renderInAct(
+      html`<${CollaborationCanvas}
+        content="test"
+        participants=${mockParticipants}
+        onChange=${vi.fn()}
+      />`
+    )
+    const cursors = container.querySelectorAll('[role="img"]')
+    expect(cursors.length).toBeGreaterThanOrEqual(1)
+    expect(cursors[0].getAttribute('aria-label')).toBe('Alice 커서')
+  })
+
+  it('presence description is present when participants are active', () => {
+    const { container } = renderInAct(
+      html`<${CollaborationCanvas}
+        content="test"
+        participants=${mockParticipants}
+        onChange=${vi.fn()}
+      />`
+    )
+    const desc = container.querySelector('#presence-desc')
+    expect(desc).not.toBeNull()
+    expect(desc?.textContent).toContain('편집 중입니다')
+  })
+
+  it('onChange fires on input', async () => {
+    const onChange = vi.fn()
+    const { container } = renderInAct(
+      html`<${CollaborationCanvas}
+        content="initial"
+        participants=${[]}
+        onChange=${onChange}
+      />`
+    )
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    await act(async () => {
+      textarea.value = 'changed'
+      textarea.dispatchEvent(new Event('input'))
+    })
+    expect(onChange).toHaveBeenCalledWith('changed')
+  })
+
+  it('empty participants has no axe violations', async () => {
+    const { container } = renderInAct(
+      html`<${CollaborationCanvas}
+        content=""
+        participants=${[]}
+        onChange=${vi.fn()}
+      />`
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/collaboration-canvas.ts
+++ b/dashboard/src/components/common/collaboration-canvas.ts
@@ -1,0 +1,163 @@
+// CollaborationCanvas — AX organism for real-time collaborative editing.
+//
+// Kimi design system sec05 5.2.3 reference: shared canvas with participant
+// presence, cursor indicators, and selection highlights.
+
+import { html } from 'htm/preact'
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+
+export interface CanvasParticipant {
+  id: string
+  type: 'human' | 'agent'
+  name: string
+  color: string
+  cursor?: { x: number; y: number }
+  selection?: { start: number; end: number }
+}
+
+interface CollaborationCanvasProps {
+  content: string
+  participants: CanvasParticipant[]
+  onChange: (value: string) => void
+  testId?: string
+}
+
+const PARTICIPANT_BADGE_CLASS =
+  'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium'
+
+function participantBadgeBg(type: CanvasParticipant['type']): string {
+  return type === 'human'
+    ? 'bg-[var(--accent-3)] text-[var(--accent-11)]'
+    : 'bg-[var(--purple-3)] text-[var(--purple-11)]'
+}
+
+function participantDot(color: string): string {
+  return `width:8px;height:8px;border-radius:50%;background:${color};`
+}
+
+function cursorStyle(
+  cursor: CanvasParticipant['cursor'],
+  color: string
+): string {
+  if (!cursor) return ''
+  return `position:absolute;left:${cursor.x}px;top:${cursor.y}px;` +
+    `width:2px;height:20px;background:${color};pointer-events:none;`
+}
+
+function selectionStyle(
+  selection: CanvasParticipant['selection'],
+  color: string
+): string {
+  if (!selection || selection.start === selection.end) return ''
+  return `background:${color}33;`
+}
+
+export function CollaborationCanvas({
+  content,
+  participants,
+  onChange,
+  testId,
+}: CollaborationCanvasProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [localContent, setLocalContent] = useState(content)
+
+  useEffect(() => {
+    setLocalContent(content)
+  }, [content])
+
+  const handleInput = useCallback(
+    (e: Event) => {
+      const target = e.target as HTMLTextAreaElement
+      setLocalContent(target.value)
+      onChange(target.value)
+    },
+    [onChange]
+  )
+
+  const activeParticipants = participants.filter(
+    (p) => p.cursor != null || p.selection != null
+  )
+  const textareaId = testId ? `${testId}-textarea` : 'collab-textarea'
+  const labelId = testId ? `${testId}-label` : 'collab-label'
+
+  return html`
+    <div
+      class="relative flex flex-col gap-3 rounded-lg border border-[var(--gray-6)] bg-[var(--gray-1)] p-4"
+      role="region"
+      aria-label="협업 편집 영역"
+      data-testid=${testId}
+    >
+      <div class="flex items-center justify-between">
+        <span id=${labelId} class="text-sm font-medium text-[var(--gray-12)]">
+          협업 편집기
+        </span>
+        <div
+          class="flex flex-wrap gap-1.5"
+          role="list"
+          aria-label="참여자 목록"
+        >
+          ${participants.map(
+            (p) => html`
+              <span
+                class=${`${PARTICIPANT_BADGE_CLASS} ${participantBadgeBg(p.type)}`}
+                role="listitem"
+                aria-label="${p.name} (${p.type === 'human' ? '사람' : '에이전트'})"
+              >
+                <span style=${participantDot(p.color)}></span>
+                ${p.name}
+              </span>
+            `
+          )}
+        </div>
+      </div>
+
+      <div class="relative">
+        <textarea
+          ref=${textareaRef}
+          id=${textareaId}
+          class="w-full min-h-[160px] resize-y rounded-md border border-[var(--gray-7)] bg-[var(--gray-1)] px-3 py-2 text-sm text-[var(--gray-12)] focus:border-[var(--accent-8)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-8)]"
+          value=${localContent}
+          onInput=${handleInput}
+          aria-labelledby=${labelId}
+          aria-describedby=${activeParticipants.length > 0
+            ? `${testId ? `${testId}-` : ''}presence-desc`
+            : undefined}
+        />
+
+        ${activeParticipants.map(
+          (p) => html`
+            <div
+              style=${cursorStyle(p.cursor, p.color)}
+              role="img"
+              aria-label="${p.name} 커서"
+            />
+          `
+        )}
+      </div>
+
+      ${activeParticipants.length > 0
+        ? html`
+            <div
+              id=${`${testId ? `${testId}-` : ''}presence-desc`}
+              class="text-xs text-[var(--gray-10)]"
+            >
+              ${activeParticipants.map((p) => p.name).join(', ')}님이
+              편집 중입니다.
+            </div>
+            <div class="flex flex-wrap gap-1" aria-hidden="true">
+              ${activeParticipants
+                .filter((p) => p.selection != null && p.selection.start !== p.selection.end)
+                .map((p) => html`
+                  <span
+                    class="rounded px-2 py-0.5 text-xs text-[var(--gray-12)]"
+                    style=${selectionStyle(p.selection, p.color)}
+                  >
+                    ${p.name} ${p.selection?.start}-${p.selection?.end}
+                  </span>
+                `)}
+            </div>
+          `
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -409,7 +409,7 @@ export function PipelineStep({
           <div class="flex items-center gap-1.5 min-w-0">
             ${isActive ? html`<span class="h-1.5 w-1.5 rounded-full bg-[var(--indigo)] ${activePulse} shrink-0"></span>` : null}
             <span class="text-3xs font-semibold tracking-[0.04em] text-[var(--color-fg-muted)]">${label}</span>
-            ${limited ? html`<span class="text-[7px] font-mono text-[var(--color-fg-disabled)] border border-[var(--white-10)] rounded px-1" title="Event_bus 구독 미구현으로 일부 상태만 관찰 가능">제한</span>` : null}
+            ${limited ? html`<span class="text-3xs font-mono text-[var(--color-fg-disabled)] border border-[var(--white-10)] rounded px-1" title="Event_bus 구독 미구현으로 일부 상태만 관찰 가능">제한</span>` : null}
           </div>
           ${heldFor ? html`
             <span class=${`text-3xs font-mono tabular-nums ${stalenessCls}`} aria-hidden="true">${heldFor}</span>


### PR DESCRIPTION
## Summary
- Add `AgentLifecycle` SVG FSM organism with a11y coverage for current state and transition flash behavior.
- Add `CollaborationCanvas` organism with participant presence, cursor indicators, and selection summaries.
- Replace residual arbitrary text pixel classes with dashboard text tokens to satisfy the drift gate.

## Verification
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run src/components/common/agent-lifecycle.a11y.test.ts src/components/common/collaboration-canvas.a11y.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `scripts/dashboard-drift-check.sh`
- `pnpm --dir dashboard exec vitest run src/components/common --config vitest.config.ts --no-file-parallelism --maxWorkers=1` (126 files / 1095 tests)
- `pnpm --dir dashboard lint` (passes with existing unused eslint-disable warnings)
- `pnpm --dir dashboard build`

## Notes
- This is the residual AX organisms slice that landed on `feature/ds-f5-f6-batch2` after #12364 was already merged, split into a fresh draft PR from current `main`.