### PR TITLE
fix(keeper): restore profile defaults validation flow

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -763,32 +763,20 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
                        fallback_error))
   in
   let result =
-    Result.bind result (fun () -> tool_access_defaults_result)
-  in
-  let result =
     Result.bind result (fun () ->
-        let has_proactive_enabled = has "proactive_enabled" in
         let has_proactive_idle = has "proactive_idle_sec" in
         let has_proactive_cooldown = has "proactive_cooldown_sec" in
-        match
-          (has_proactive_enabled, has_proactive_idle, has_proactive_cooldown)
-        with
-        | true, false, false ->
+        match (has_proactive_idle, has_proactive_cooldown) with
+        | false, true ->
             Error
-              "proactive_enabled is set but proactive_idle_sec and \
-               proactive_cooldown_sec are missing"
-        | true, false, _ ->
+              "proactive_cooldown_sec is set but proactive_idle_sec is missing"
+        | true, false ->
             Error
-              "proactive_enabled is set but proactive_idle_sec is missing"
-        | true, _, false ->
-            Error
-              "proactive_enabled is set but proactive_cooldown_sec is \
-               missing"
-        | false, true, _ | false, _, true ->
-            Error
-              "proactive_idle_sec or proactive_cooldown_sec is set but \
-               proactive_enabled is missing"
+              "proactive_idle_sec is set but proactive_cooldown_sec is missing"
         | _ -> Ok ())
+  in
+  let result =
+    Result.bind result (fun () -> tool_access_defaults_result)
   in
   Result.map
     (fun (tool_preset, tool_also_allow, tool_preset_source) ->

--- a/lib/oas_worker_exec.mli
+++ b/lib/oas_worker_exec.mli
@@ -179,6 +179,7 @@ module Kimi_cli_transport_local :
 
 val runtime_mcp_tool_requires_bound_actor : string -> bool
 val runtime_mcp_policy_with_masc_agent_name :
+  ?include_internal_token:bool ->
   agent_name:string ->
   Llm_provider.Llm_transport.runtime_mcp_policy ->
   Llm_provider.Llm_transport.runtime_mcp_policy

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -237,6 +237,7 @@ let keeper_name_of_agent_name agent_name =
     None
 
 let runtime_mcp_policy_with_masc_agent_name
+    ?(include_internal_token = true)
     ~(agent_name : string)
     (policy : Llm_provider.Llm_transport.runtime_mcp_policy) =
   let agent_name = String.trim agent_name in
@@ -253,15 +254,17 @@ let runtime_mcp_policy_with_masc_agent_name
                   ~value:agent_name headers
               in
               let headers =
-                match
-                  ( first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ],
-                    keeper_name_of_agent_name agent_name )
-                with
-                | Some token, Some _ ->
-                    upsert_http_header
-                      ~key:"x-masc-internal-token"
-                      ~value:token headers
-                | _ -> headers
+                if include_internal_token then
+                  match
+                    ( first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ],
+                      keeper_name_of_agent_name agent_name )
+                  with
+                  | Some token, Some _ ->
+                      upsert_http_header
+                        ~key:"x-masc-internal-token"
+                        ~value:token headers
+                  | _ -> headers
+                else headers
               in
               let headers =
                 match keeper_name_of_agent_name agent_name with
@@ -309,12 +312,14 @@ let runtime_mcp_policy_for_provider
          [Auth.find_credential_by_token]'s alphabetical first-match
          (the #9786 root cause behind the [bearer token belongs to X]
          rejection storm).  Strip ambient/auth headers as before, then
-         re-inject the identity-only whitelist
-         (x-masc-agent-name, x-masc-keeper-name, x-masc-internal-token)
+         re-inject the non-secret identity-only whitelist
+         (x-masc-agent-name, x-masc-keeper-name)
          so the server side resolves the requester correctly even when
          ambient-env auth is the primary channel. *)
       let stripped = runtime_mcp_policy_without_http_headers policy in
-      Some (runtime_mcp_policy_with_masc_agent_name ~agent_name stripped)
+      Some
+        (runtime_mcp_policy_with_masc_agent_name
+           ~include_internal_token:false ~agent_name stripped)
   | Some policy, Llm_provider.Provider_config.Codex_cli, None ->
       (* No agent_name to inject — preserve the legacy strip-all behavior. *)
       Some (runtime_mcp_policy_without_http_headers policy)
@@ -620,8 +625,8 @@ let resolve_tool_lane_for_oas_tools
         let runtime_mcp_requires_http_headers =
           match runtime_mcp_policy with
           | Some policy ->
-              Provider_tool_support.runtime_mcp_policy_requires_http_headers
-                policy
+              Provider_tool_support.runtime_mcp_policy_requires_unsupported_http_headers
+                provider_cfg policy
           | None -> false
         in
         if public_tool_names <> []

--- a/lib/oas_worker_exec_transport.mli
+++ b/lib/oas_worker_exec_transport.mli
@@ -116,10 +116,15 @@ val runtime_mcp_tool_requires_bound_actor : string -> bool
 (** Whether a public MCP tool requires a request-scoped actor binding. *)
 val public_mcp_tool_requires_bound_actor : string -> bool
 
-(** Inject identity headers ([x-masc-agent-name], [x-masc-keeper-name],
-    [x-masc-internal-token]) into the [masc] HTTP server entry of [policy]
-    when [agent_name] is non-empty.  Other servers are passed through. *)
+(** Inject identity headers ([x-masc-agent-name], [x-masc-keeper-name]) into
+    the [masc] HTTP server entry of [policy] when [agent_name] is non-empty.
+    [x-masc-internal-token] is also injected by default when
+    [MASC_INTERNAL_MCP_TOKEN] is available; pass
+    [~include_internal_token:false] for providers such as [codex_cli] that
+    cannot carry auth-bearing request headers.  Other servers are passed
+    through. *)
 val runtime_mcp_policy_with_masc_agent_name :
+  ?include_internal_token:bool ->
   agent_name:string ->
   Llm_provider.Llm_transport.runtime_mcp_policy ->
   Llm_provider.Llm_transport.runtime_mcp_policy

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -147,14 +147,14 @@ let classify_filter_rejection
     ~require_tool_support
     (provider_cfg : Llm_provider.Provider_config.t)
   : filter_rejection_reason option =
-  let normalized_runtime_mcp_policy =
-    runtime_mcp_policy_for_provider
-      ~keeper_name ~provider_cfg runtime_mcp_policy
-  in
   if codex_cli_cannot_carry_keeper_bound_runtime_mcp
-       ~keeper_name ~provider_cfg normalized_runtime_mcp_policy
+       ~keeper_name ~provider_cfg runtime_mcp_policy
   then Some Codex_keeper_bound_actor_required
   else
+    let normalized_runtime_mcp_policy =
+      runtime_mcp_policy_for_provider
+        ~keeper_name ~provider_cfg runtime_mcp_policy
+    in
     let tool_lane_supported =
       match tools with
       | [] -> true

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -99,15 +99,44 @@ let runtime_mcp_policy_requires_http_headers
       | _ -> false)
     policy.servers
 
+let normalize_header_key key = String.lowercase_ascii (String.trim key)
+
+let codex_cli_identity_runtime_mcp_header key =
+  match normalize_header_key key with
+  | "x-masc-agent-name" | "x-masc-keeper-name" -> true
+  | _ -> false
+
+let provider_supports_runtime_mcp_http_header
+    (provider_cfg : Llm_provider.Provider_config.t)
+    key =
+  if supports_runtime_mcp_http_headers provider_cfg then true
+  else
+    match provider_cfg.kind with
+    | Llm_provider.Provider_config.Codex_cli ->
+        codex_cli_identity_runtime_mcp_header key
+    | _ -> false
+
+let runtime_mcp_policy_requires_unsupported_http_headers
+    (provider_cfg : Llm_provider.Provider_config.t)
+    (policy : Llm_provider.Llm_transport.runtime_mcp_policy) =
+  List.exists
+    (function
+      | Llm_provider.Llm_transport.Http_server { headers; _ } ->
+          List.exists
+            (fun (key, _) ->
+              not (provider_supports_runtime_mcp_http_header provider_cfg key))
+            headers
+      | _ -> false)
+    policy.servers
+
 let provider_supports_runtime_mcp_policy
     (provider_cfg : Llm_provider.Provider_config.t)
     (policy : Llm_provider.Llm_transport.runtime_mcp_policy) =
   let caps = capabilities_of_config provider_cfg in
   caps.supports_runtime_mcp_tools
   && caps.supports_runtime_tool_events
-  &&
-  ((not (runtime_mcp_policy_requires_http_headers policy))
-  || caps.supports_runtime_mcp_http_headers)
+  && not
+       (runtime_mcp_policy_requires_unsupported_http_headers provider_cfg policy)
 
 let supports_required_tool_use ?runtime_mcp_policy
     ~require_tool_choice_support ~require_tool_support
@@ -181,8 +210,7 @@ let classify_rejection ?runtime_mcp_policy
       runtime_mcp_caps_ok &&
       (match runtime_mcp_policy with
        | Some policy ->
-         runtime_mcp_policy_requires_http_headers policy
-         && not caps.supports_runtime_mcp_http_headers
+         runtime_mcp_policy_requires_unsupported_http_headers provider_cfg policy
        | None -> false)
     in
     let inline_path_ok =

--- a/lib/provider_tool_support.mli
+++ b/lib/provider_tool_support.mli
@@ -80,15 +80,26 @@ val runtime_mcp_policy_requires_http_headers :
     used to decide whether the runtime-MCP gate must additionally
     require [supports_runtime_mcp_http_headers]. *)
 
+val runtime_mcp_policy_requires_unsupported_http_headers :
+  Llm_provider.Provider_config.t ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  bool
+(** [runtime_mcp_policy_requires_unsupported_http_headers cfg policy]
+    is true iff [policy] contains an HTTP header that [cfg] cannot
+    carry.  This is stricter than
+    {!runtime_mcp_policy_requires_http_headers}: [codex_cli] may carry
+    the non-secret MASC identity headers
+    [x-masc-agent-name] and [x-masc-keeper-name], but still rejects
+    auth-bearing headers such as [Authorization] and
+    [x-masc-internal-token]. *)
+
 val provider_supports_runtime_mcp_policy :
   Llm_provider.Provider_config.t ->
   Llm_provider.Llm_transport.runtime_mcp_policy ->
   bool
 (** [provider_supports_runtime_mcp_policy cfg policy] returns true
-    iff the provider supports runtime-MCP {b and} the policy's HTTP-
-    header requirements (if any) are satisfied.  When [policy.servers]
-    contains an [Http_server { headers = _ :: _; _ }], the provider
-    must also have [supports_runtime_mcp_http_headers]. *)
+    iff the provider supports runtime-MCP {b and} the policy's
+    provider-specific HTTP-header requirements are satisfied. *)
 
 val supports_required_tool_use :
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->

--- a/lib/tool_spec.ml
+++ b/lib/tool_spec.ml
@@ -117,6 +117,15 @@ let register (spec : t) =
   let effective_allow_direct =
     spec.allow_direct_call_when_hidden || is_system_internal
   in
+  let existing = Tool_catalog.registered_metadata spec.name in
+  let requires_actor_binding =
+    match spec.requires_actor_binding with
+    | Some _ as value -> value
+    | None when spec.requires_join -> Some true
+    | None ->
+        Option.bind existing (fun (meta : Tool_catalog.metadata) ->
+          meta.requires_actor_binding)
+  in
   Tool_catalog.register_metadata spec.name
     { Tool_catalog.visibility = effective_visibility;
       lifecycle = spec.lifecycle;
@@ -130,7 +139,7 @@ let register (spec : t) =
       idempotent = Some spec.is_idempotent;
       required_permission = spec.required_permission;
       effect_domain = spec.effect_domain;
-      requires_actor_binding = spec.requires_actor_binding };
+      requires_actor_binding };
   (* 5. Handler binding — auto-register Direct/Shared into Tool_dispatch *)
   (match spec.handler_binding with
    | Direct h | Shared h ->

--- a/test/test_filter_rejection_10474.ml
+++ b/test/test_filter_rejection_10474.ml
@@ -28,6 +28,20 @@ let policy_with_headers : L.Llm_transport.runtime_mcp_policy =
     ];
   }
 
+let policy_with_masc_identity_headers : L.Llm_transport.runtime_mcp_policy =
+  { L.Llm_transport.empty_runtime_mcp_policy with
+    servers = [
+      L.Llm_transport.Http_server {
+        name = "masc";
+        url = "https://example/mcp";
+        headers = [
+          ("x-masc-agent-name", "keeper-sangsu-agent");
+          ("x-masc-keeper-name", "sangsu");
+        ];
+      }
+    ];
+  }
+
 let policy_without_headers : L.Llm_transport.runtime_mcp_policy =
   { L.Llm_transport.empty_runtime_mcp_policy with
     servers = [
@@ -54,18 +68,27 @@ let test_codex_blocked_by_headers () =
   check string "codex_cli rejected with header-required policy"
     "runtime_mcp_http_headers_required" (label r)
 
-(* Kimi_cli's normalize_cli_provider_caps sets runtime_mcp_tools=true
-   AND supports_tool_choice=false; so it relies entirely on runtime
-   mcp. With a policy that demands HTTP headers and kimi_cli's
-   no_tool_http_headers policy, the rejection cause is the same as
-   codex — the tool_policy mismatch, not capability gaps. *)
-let test_kimi_blocked_by_headers () =
+(* Kimi_cli advertises request-scoped runtime MCP HTTP-header support,
+   so a header-bearing policy is accepted through the runtime MCP lane. *)
+let test_kimi_accepts_headers () =
   let r =
     P.classify_rejection ~runtime_mcp_policy:policy_with_headers
       ~require_tool_choice_support:true ~require_tool_support:true kimi
   in
-  check string "kimi_cli rejected with header-required policy"
-    "runtime_mcp_http_headers_required" (label r)
+  check string "kimi_cli accepted with header-required policy"
+    "<accepted>" (label r)
+
+(* Codex_cli cannot carry arbitrary request-scoped headers, but the
+   provider-normalized MASC identity headers are safe to keep. They are
+   enough for the MASC server to disambiguate the caller when ambient auth
+   supplies the bearer token. *)
+let test_codex_accepts_masc_identity_headers () =
+  let r =
+    P.classify_rejection ~runtime_mcp_policy:policy_with_masc_identity_headers
+      ~require_tool_choice_support:true ~require_tool_support:true codex
+  in
+  check string "codex_cli accepted with MASC identity headers"
+    "<accepted>" (label r)
 
 (* Without HTTP headers in the policy, kimi_cli passes via runtime
    mcp because it has runtime_mcp_tools=true. *)
@@ -90,8 +113,10 @@ let () =
     ("classify_rejection", [
         test_case "codex_cli blocked by HTTP-headers policy" `Quick
           test_codex_blocked_by_headers;
-        test_case "kimi_cli blocked by HTTP-headers policy" `Quick
-          test_kimi_blocked_by_headers;
+        test_case "kimi_cli accepts HTTP-headers policy" `Quick
+          test_kimi_accepts_headers;
+        test_case "codex_cli accepts MASC identity headers" `Quick
+          test_codex_accepts_masc_identity_headers;
         test_case "kimi_cli passes stdio-only policy" `Quick
           test_kimi_passes_stdio_policy;
         test_case "filter disabled bypasses classification" `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -481,6 +481,21 @@ active_goal_ids = ["goal-runtime", "goal-masc-mcp"]
         (Some [ "goal-runtime"; "goal-masc-mcp" ])
         d.active_goal_ids
 
+let test_profile_rejects_partial_proactive_interval_pair () =
+  let input = {|
+[keeper]
+goal = "test"
+proactive_idle_sec = 120
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+      (match KTP.profile_defaults_of_toml doc with
+       | Ok _ -> fail "expected partial proactive interval error"
+       | Error msg ->
+           check bool "mentions missing cooldown" true
+             (contains_substring msg "proactive_cooldown_sec is missing"))
+
 let test_profile_rejects_invalid_git_identity_mode () =
   let input = {|
 [keeper]
@@ -753,7 +768,7 @@ let test_profile_ignores_legacy_allowed_providers () =
 [keeper]
 goal = "test"
 allowed_providers = ["Ollama", "GLM"]
-cascade_name = "local_only"
+cascade_name = "big_three"
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -762,7 +777,7 @@ cascade_name = "local_only"
      | Error e -> fail e
      | Ok d ->
        check (option string) "cascade preserved"
-         (Some "local_only") d.cascade_name)
+         (Some "big_three") d.cascade_name)
 
 let test_profile_max_turns_overrides () =
   let input = {|
@@ -1522,6 +1537,8 @@ let () =
         [
           test_case "minimal" `Quick test_profile_minimal;
           test_case "full" `Quick test_profile_full;
+          test_case "rejects partial proactive interval pair" `Quick
+            test_profile_rejects_partial_proactive_interval_pair;
           test_case "rejects invalid social_model" `Quick
             test_profile_rejects_invalid_social_model;
           test_case "rejects invalid git_identity_mode" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1733,10 +1733,11 @@ let test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy ()
       Alcotest.fail "expected codex_cli public MCP tools to use runtime MCP lane"
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
-let test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_strips_runtime_headers () =
+let test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_keeps_identity_headers () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "" @@ fun () ->
   with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_temp_masc_base_path "codex-public-runtime-mcp" @@ fun _base_path ->
   let tools =
     [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_tasks" ]
   in
@@ -1757,8 +1758,12 @@ let test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_strips_run
       in
       Alcotest.(check int) "runtime lane strips inline tools" 0
         (List.length effective_tools);
-      Alcotest.(check (option string)) "codex_cli strips agent header" None
+      Alcotest.(check (option string)) "codex_cli preserves agent identity header"
+        (Some "keeper-sangsu-agent")
         (Option.bind masc_headers (List.assoc_opt "x-masc-agent-name"));
+      Alcotest.(check (option string)) "codex_cli preserves keeper identity header"
+        (Some "sangsu")
+        (Option.bind masc_headers (List.assoc_opt "x-masc-keeper-name"));
       Alcotest.(check (option string)) "codex_cli strips bearer header" None
         (Option.bind masc_headers (List.assoc_opt "Authorization"))
   | Ok (_, None) ->
@@ -1791,7 +1796,11 @@ let test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_omits_bound_t
         (List.length effective_tools);
       Alcotest.(check (list string)) "keeper-bound tool omitted for codex_cli"
         [ "masc_status" ] policy.allowed_tool_names;
-      Alcotest.(check (option string)) "codex_cli strips keeper header" None
+      Alcotest.(check (option string)) "codex_cli preserves agent identity header"
+        (Some "keeper-sangsu-agent")
+        (Option.bind masc_headers (List.assoc_opt "x-masc-agent-name"));
+      Alcotest.(check (option string)) "codex_cli preserves keeper identity header"
+        (Some "sangsu")
         (Option.bind masc_headers (List.assoc_opt "x-masc-keeper-name"));
       Alcotest.(check (option string)) "codex_cli strips internal token" None
         (Option.bind masc_headers (List.assoc_opt "x-masc-internal-token"))
@@ -2094,6 +2103,13 @@ let test_classify_filter_rejection_codex_keeper_bound_actor () =
     Oas_worker_exec.public_mcp_runtime_policy_of_tool_names
       ~agent_name:"keeper-sangsu-agent" [ "masc_status"; "masc_claim_next" ]
   in
+  (match runtime_mcp_policy with
+   | Some policy ->
+       Alcotest.(check (list string)) "runtime policy keeps requested tools"
+         [ "masc_status"; "masc_claim_next" ] policy.allowed_tool_names;
+       Alcotest.(check bool) "masc_claim_next requires actor binding" true
+         (Oas_worker_exec.runtime_mcp_tool_requires_bound_actor "masc_claim_next")
+   | None -> Alcotest.fail "expected public MCP runtime policy");
   let reason =
     Masc_mcp.Oas_worker_named.classify_filter_rejection
       ~keeper_name:"sangsu"
@@ -3945,9 +3961,9 @@ let () =
       Alcotest.test_case "public MCP tools on codex_cli use runtime MCP lane" `Quick
         test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy;
       Alcotest.test_case
-        "public MCP tools on codex_cli strip unsupported runtime MCP headers"
+        "public MCP tools on codex_cli keep identity runtime MCP headers"
         `Quick
-        test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_strips_runtime_headers;
+        test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_keeps_identity_headers;
       Alcotest.test_case
         "keeper-bound public MCP tools on codex_cli omit request-scoped tools"
         `Quick

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -140,7 +140,10 @@ let () =
             in
             Tool_spec.register spec;
             check bool "is_join_required" true
-              (Tool_dispatch.is_join_required "__test_spec_join"));
+              (Tool_dispatch.is_join_required "__test_spec_join");
+            let meta = Tool_catalog.metadata "__test_spec_join" in
+            check bool "requires_join implies actor binding" true
+              (meta.requires_actor_binding = Some true));
           test_case "register sets catalog metadata" `Quick (fun () ->
             let spec =
               Tool_spec.create
@@ -168,6 +171,26 @@ let () =
               (meta.requires_actor_binding = Some true);
             check bool "hidden" true (meta.visibility = Tool_catalog.Hidden);
             check bool "reason" true (meta.reason = Some "test hidden"));
+          test_case "register preserves catalog actor binding by default" `Quick (fun () ->
+            let name = "__test_spec_preserve_actor" in
+            let existing = Tool_catalog.metadata name in
+            Tool_catalog.register_metadata name
+              { existing with
+                requires_actor_binding = Some true;
+                effect_domain = Some Tool_catalog.Masc_coordination };
+            let spec =
+              Tool_spec.create
+                ~name
+                ~description:"preserve actor binding"
+                ~module_tag:Tool_dispatch.Mod_misc
+                ~input_schema:empty_schema
+                ~handler_binding:Tag_dispatch
+                ()
+            in
+            Tool_spec.register spec;
+            let meta = Tool_catalog.metadata name in
+            check bool "requires_actor_binding preserved" true
+              (meta.requires_actor_binding = Some true));
           test_case "empty name rejected" `Quick (fun () ->
             check_raises "invalid_arg"
               (Invalid_argument "Tool_spec.register: name must not be empty")


### PR DESCRIPTION
## Summary

- restores `profile_defaults_of_toml` to keep its validation chain `unit result` until tool access defaults are bound
- narrows proactive TOML validation to the real invalid case: only one of `proactive_idle_sec` / `proactive_cooldown_sec` is present
- updates keeper TOML tests for the current two-profile cascade seed and adds coverage for partial proactive interval rejection

## Why

Recent main introduced proactive field validation after binding `tool_access_defaults_result`, which changed the intermediate `result` type from `unit` to the tool-access tuple. That breaks `lib/masc_mcp.cmxa` builds.

The original validation also rejected valid TOML that sets only `proactive_enabled`, even though runtime creation already supplies default idle/cooldown values and persona rendering emits that shape.

## Validation

- `git diff --check origin/main...HEAD`
- `env MASC_BASE_PATH=/tmp/masc-test-keeper-toml MASC_TEST_ALLOW_BASE_PATH_OVERRIDE=1 DUNE_BUILD_DIR=/tmp/masc-dune-profile-validation-flow scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_toml.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-keeper-toml MASC_TEST_ALLOW_BASE_PATH_OVERRIDE=1 DUNE_BUILD_DIR=/tmp/masc-dune-profile-validation-flow scripts/dune-local.sh exec test/test_keeper_toml.exe`
