### PR TITLE
fix(keeper): expose turn queue depth metric

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -71,10 +71,19 @@ let autonomous_queue_poll_sec =
 let with_autonomous_wait_queue f =
   Eio.Mutex.use_rw ~protect:true autonomous_wait_queue_mutex f
 
+let autonomous_queue_depth_labels = [ ("channel", "autonomous_queue") ]
+
+let record_autonomous_queue_depth depth =
+  Prometheus.set_gauge
+    Prometheus.metric_keeper_turn_queue_depth
+    ~labels:autonomous_queue_depth_labels
+    (float_of_int depth)
+
 let reset_autonomous_turn_queue_for_test () =
   with_autonomous_wait_queue (fun () ->
     autonomous_wait_queue := [];
-    autonomous_wait_queue_next_ticket := 0)
+    autonomous_wait_queue_next_ticket := 0;
+    record_autonomous_queue_depth 0)
 
 let enqueue_autonomous_waiter ~(keeper_name : string) : int =
   with_autonomous_wait_queue (fun () ->
@@ -82,12 +91,14 @@ let enqueue_autonomous_waiter ~(keeper_name : string) : int =
     incr autonomous_wait_queue_next_ticket;
     autonomous_wait_queue :=
       !autonomous_wait_queue @ [{ ticket; keeper_name }];
+    record_autonomous_queue_depth (List.length !autonomous_wait_queue);
     ticket)
 
 let drop_autonomous_waiter ~(ticket : int) : unit =
   with_autonomous_wait_queue (fun () ->
     autonomous_wait_queue :=
-      List.filter (fun waiter -> waiter.ticket <> ticket) !autonomous_wait_queue)
+      List.filter (fun waiter -> waiter.ticket <> ticket) !autonomous_wait_queue;
+    record_autonomous_queue_depth (List.length !autonomous_wait_queue))
 
 let autonomous_waiter_snapshot_for_test () : string list =
   with_autonomous_wait_queue (fun () ->

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -762,25 +762,37 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
                        (String.concat ", " reserved_cascade_names)
                        fallback_error))
   in
+  let tool_access_defaults = tool_access_defaults_result in
   let result =
     Result.bind result (fun () ->
+        let has_proactive_enabled = has "proactive_enabled" in
         let has_proactive_idle = has "proactive_idle_sec" in
         let has_proactive_cooldown = has "proactive_cooldown_sec" in
-        match (has_proactive_idle, has_proactive_cooldown) with
-        | false, true ->
+        match
+          (has_proactive_enabled, has_proactive_idle, has_proactive_cooldown)
+        with
+        | true, false, false ->
             Error
-              "proactive_cooldown_sec is set but proactive_idle_sec is missing"
-        | true, false ->
+              "proactive_enabled is set but proactive_idle_sec and \
+               proactive_cooldown_sec are missing"
+        | true, false, _ ->
             Error
-              "proactive_idle_sec is set but proactive_cooldown_sec is missing"
+              "proactive_enabled is set but proactive_idle_sec is missing"
+        | true, _, false ->
+            Error
+              "proactive_enabled is set but proactive_cooldown_sec is \
+               missing"
+        | false, true, _ | false, _, true ->
+            Error
+              "proactive_idle_sec or proactive_cooldown_sec is set but \
+               proactive_enabled is missing"
         | _ -> Ok ())
   in
-  let result =
-    Result.bind result (fun () -> tool_access_defaults_result)
-  in
-  Result.map
-    (fun (tool_preset, tool_also_allow, tool_preset_source) ->
-      {
+  Result.bind result (fun () ->
+      match tool_access_defaults with
+      | Error e -> Error e
+      | Ok (tool_preset, tool_also_allow, tool_preset_source) ->
+          Ok {
         id = None;
         manifest_path = None;
         persona_name = str "persona_name";
@@ -852,7 +864,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         oas_env = extract_oas_env_from_doc doc;
         unknown_toml_keys = [];
       })
-    result
 
 (** Fields actually read by [profile_defaults_of_toml] from the [[keeper]]
     TOML table.  Keep this in sync with the record construction above — the

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -342,6 +342,9 @@ let metric_tool_join_required_guard =
 let metric_keeper_semaphore_wait_timeout =
   "masc_keeper_semaphore_wait_timeout_total"
 
+let metric_keeper_turn_queue_depth =
+  "masc_keeper_turn_queue_depth"
+
 let metric_timeout_policy_overshoot =
   "masc_timeout_policy_overshoot_total"
 
@@ -917,6 +920,9 @@ let init () =
     "Total join-required guard rejections before tool execution \
      (labels: tool, agent_name, reason=room_uninitialized|agent_not_joined)"
     Counter;
+  add metric_keeper_turn_queue_depth
+    "Current keeper turn wait queue depth (labels: channel=autonomous_queue)"
+    Gauge;
   add metric_timeout_policy_overshoot
     "Total cooperative-cancel timeout overshoots \
      (labels: layer, origin)"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -122,6 +122,12 @@ val metric_keeper_semaphore_wait_timeout : string
     Labels: [keeper, channel] with channel in
     [autonomous_queue_head | autonomous | turn]. *)
 
+val metric_keeper_turn_queue_depth : string
+(** P-DASH-02: gauge for keeper turn wait queue depth.
+    Labels: [channel] with [autonomous_queue] for the explicit autonomous
+    FIFO wait queue. Reactive turn depth is intentionally not inferred from
+    semaphore availability. *)
+
 val metric_timeout_policy_overshoot : string
 (** #9662: cooperative-cancel timeout overshoot counter emitted by
     [Timeout_policy].  Labels: [layer, origin]. *)

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -18,6 +18,12 @@ let counter_for ~keeper ~channel =
     ]
     ()
 
+let queue_depth_for ~channel =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_keeper_turn_queue_depth
+    ~labels:[ ("channel", channel) ]
+    ()
+
 let make_meta name =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -34,7 +40,40 @@ let test_metric_name_stable () =
   Alcotest.(check string)
     "semaphore wait timeout canonical metric name"
     "masc_keeper_semaphore_wait_timeout_total"
-    Masc_mcp.Prometheus.metric_keeper_semaphore_wait_timeout
+    Masc_mcp.Prometheus.metric_keeper_semaphore_wait_timeout;
+  Alcotest.(check string)
+    "turn queue depth canonical metric name"
+    "masc_keeper_turn_queue_depth"
+    Masc_mcp.Prometheus.metric_keeper_turn_queue_depth
+
+let test_autonomous_queue_depth_gauge_tracks_fifo () =
+  Eio_main.run @@ fun _env ->
+  let module KK = Masc_mcp.Keeper_keepalive in
+  KK.reset_autonomous_turn_queue_for_test ();
+  Alcotest.(check (float 0.0001))
+    "reset records zero depth"
+    0.0
+    (queue_depth_for ~channel:"autonomous_queue");
+  let first = KK.enqueue_autonomous_waiter_for_test "alpha-depth" in
+  Alcotest.(check (float 0.0001))
+    "first enqueue records depth"
+    1.0
+    (queue_depth_for ~channel:"autonomous_queue");
+  let second = KK.enqueue_autonomous_waiter_for_test "beta-depth" in
+  Alcotest.(check (float 0.0001))
+    "second enqueue records depth"
+    2.0
+    (queue_depth_for ~channel:"autonomous_queue");
+  KK.drop_autonomous_waiter_for_test first;
+  Alcotest.(check (float 0.0001))
+    "drop records reduced depth"
+    1.0
+    (queue_depth_for ~channel:"autonomous_queue");
+  KK.drop_autonomous_waiter_for_test second;
+  Alcotest.(check (float 0.0001))
+    "final drop records zero depth"
+    0.0
+    (queue_depth_for ~channel:"autonomous_queue")
 
 let test_increments_per_channel () =
   let keeper = "sangsu-test-9771" in
@@ -132,6 +171,10 @@ let () =
     "metric_name", [
       Alcotest.test_case "canonical name stable" `Quick
         test_metric_name_stable;
+    ];
+    "queue_depth", [
+      Alcotest.test_case "autonomous FIFO depth gauge tracks queue" `Quick
+        test_autonomous_queue_depth_gauge_tracks_fifo;
     ];
     "counter", [
       Alcotest.test_case "all 3 channels increment" `Quick


### PR DESCRIPTION
## Summary
- add masc_keeper_turn_queue_depth gauge with channel=autonomous_queue
- update autonomous FIFO enqueue/drop/reset paths to maintain the gauge
- add focused regression coverage for FIFO depth tracking
- carry the current main compile fix in keeper_types_profile so focused checks can run; this duplicates #12375 until it lands

## Verification
- scripts/dune-local.sh build test/test_keeper_semaphore_wait_counter.exe test/test_keeper_semaphore_fairness.exe
- ./_build/default/test/test_keeper_semaphore_wait_counter.exe
- ./_build/default/test/test_keeper_semaphore_fairness.exe
- git diff --check

## Notes
- From artifact P-DASH-02: queue depth existed only as routine logs; this exposes backend Prometheus truth first.
- Reactive turn depth is intentionally not inferred from semaphore availability.
