### PR TITLE
fix(cascade): centralize exhausted user messages

### DIFF
--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -49,29 +49,31 @@ let decide ~accept_on_exhaustion ~is_last outcome =
 
 (* ── Error formatting ───────────────────────────── *)
 
-let format_exhausted_error last_err =
-  let msg = match last_err with
-    | Some (Llm_provider.Http_client.HttpError { code; body }) ->
+let to_user_message last_err =
+  match last_err with
+  | Some (Llm_provider.Http_client.HttpError { code; body }) ->
       Printf.sprintf "HTTP %d: %s" code
         (String_util.utf8_safe
            ~max_bytes:(Llm_provider.Constants.Truncation.max_error_body_length + 3)
            ~suffix:"..." body
          |> String_util.to_string)
-    | Some (Llm_provider.Http_client.AcceptRejected { reason }) -> reason
-    | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
+  | Some (Llm_provider.Http_client.AcceptRejected { reason }) -> reason
+  | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
       Printf.sprintf "%s provider requires a CLI transport" kind
-    | Some (Llm_provider.Http_client.NetworkError { message; _ }) -> message
-    | Some
-        ( (Llm_provider.Http_client.ProviderTerminal _
-          | Llm_provider.Http_client.ProviderFailure _) as err ) ->
+  | Some (Llm_provider.Http_client.NetworkError { message; _ }) -> message
+  | Some
+      ( (Llm_provider.Http_client.ProviderTerminal _
+        | Llm_provider.Http_client.ProviderFailure _) as err ) ->
       (* Mirror the rendering shape used elsewhere on main HEAD
          (tool_local_runtime_bench / verify): "provider terminal:
          <kind>: <message>". The boundary adapter
          [Oas_compat.Http_client.error_message] supplies that exact
          format, so future variant additions only break the adapter. *)
       Oas_compat.Http_client.error_message err
-    | None -> "No providers available"
-  in
+  | None -> "No providers available"
+
+let format_exhausted_error last_err =
+  let msg = to_user_message last_err in
   let network_error_kind =
     match last_err with
     | Some (Llm_provider.Http_client.NetworkError { kind; _ }) -> kind

--- a/lib/cascade/cascade_fsm.mli
+++ b/lib/cascade/cascade_fsm.mli
@@ -51,6 +51,13 @@ val decide :
 
 (** {1 Error formatting} *)
 
+val to_user_message :
+  Llm_provider.Http_client.http_error option ->
+  string
+(** Render the terminal cascade detail used in keeper/operator messages.
+    This does not add the transport-level ["All models failed"] wrapper; use
+    [format_exhausted_error] when constructing the final HTTP client error. *)
+
 val format_exhausted_error :
   Llm_provider.Http_client.http_error option ->
   Llm_provider.Http_client.http_error

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -350,31 +350,27 @@ let run_named
             else if message_looks_like_cli_wrapped_max_turns message then
               Keeper_types.Max_turns_exceeded
             else
-              Keeper_types.Other_detail message
-        | Some (Llm_provider.Http_client.HttpError { code; body }) ->
+              Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
+        | Some (Llm_provider.Http_client.HttpError { body; _ }) ->
             if message_looks_like_cli_wrapped_max_turns body then
               Keeper_types.Max_turns_exceeded
             else
-              Keeper_types.Other_detail
-                (Printf.sprintf "HTTP %d: %s" code
-                  (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." body |> String_util.to_string))
+              Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.AcceptRejected { reason = r }) ->
             if message_looks_like_cli_wrapped_max_turns r then
               Keeper_types.Max_turns_exceeded
             else
-              Keeper_types.Other_detail r
-        | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
-            Keeper_types.Other_detail
-              (Printf.sprintf "%s provider requires a CLI transport" kind)
+              Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
+        | Some (Llm_provider.Http_client.CliTransportRequired _) ->
+            Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.ProviderTerminal
             { kind = Llm_provider.Http_client.Max_turns _; _ }) ->
             Keeper_types.Max_turns_exceeded
         | Some (Llm_provider.Http_client.ProviderTerminal
-            { kind = Llm_provider.Http_client.Other subtype; message }) ->
-            Keeper_types.Other_detail
-              (Printf.sprintf "provider terminal %s: %s" subtype message)
+            { kind = Llm_provider.Http_client.Other _; _ }) ->
+            Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.ProviderFailure _ as err) ->
-            let message = Oas_compat.Http_client.error_message err in
+            let message = Cascade_fsm.to_user_message (Some err) in
             if message_looks_like_cli_wrapped_max_turns message then
               Keeper_types.Max_turns_exceeded
             else

--- a/test/dune
+++ b/test/dune
@@ -1193,6 +1193,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_cascade_fsm)
+ (modules test_cascade_fsm)
+ (libraries masc_test_deps))
+
+(test
  (name test_cascade_trust_persist)
  (modules test_cascade_trust_persist)
  (libraries masc_test_deps))

--- a/test/test_cascade_fsm.ml
+++ b/test/test_cascade_fsm.ml
@@ -1,0 +1,77 @@
+(** Focused tests for cascade FSM user-facing error rendering. *)
+
+open Masc_mcp
+
+let check_string = Alcotest.(check string)
+
+let test_to_user_message_preserves_http_detail () =
+  let err =
+    Llm_provider.Http_client.HttpError
+      { code = 502; body = "bad gateway from provider" }
+  in
+  check_string
+    "http detail"
+    "HTTP 502: bad gateway from provider"
+    (Cascade_fsm.to_user_message (Some err))
+
+let test_format_exhausted_error_wraps_user_message () =
+  let err =
+    Llm_provider.Http_client.HttpError
+      { code = 502; body = "bad gateway from provider" }
+  in
+  match Cascade_fsm.format_exhausted_error (Some err) with
+  | Llm_provider.Http_client.NetworkError { message; kind } ->
+      check_string
+        "wrapper"
+        "All models failed: HTTP 502: bad gateway from provider"
+        message;
+      Alcotest.(check bool) "kind defaults unknown" true
+        (kind = Llm_provider.Http_client.Unknown)
+  | _ -> Alcotest.fail "expected NetworkError wrapper"
+
+let test_accept_rejected_preserves_error_variant () =
+  let err =
+    Llm_provider.Http_client.AcceptRejected
+      { reason = "accept predicate rejected empty response" }
+  in
+  check_string
+    "accept detail"
+    "accept predicate rejected empty response"
+    (Cascade_fsm.to_user_message (Some err));
+  match Cascade_fsm.format_exhausted_error (Some err) with
+  | Llm_provider.Http_client.AcceptRejected { reason } ->
+      check_string
+        "accept rejected remains terminal accept detail"
+        "accept predicate rejected empty response"
+        reason
+  | _ -> Alcotest.fail "expected AcceptRejected to stay unwrapped"
+
+let test_none_message_is_explicit () =
+  check_string
+    "none detail"
+    "No providers available"
+    (Cascade_fsm.to_user_message None)
+
+let () =
+  Alcotest.run "Cascade_fsm"
+    [
+      ( "user_message",
+        [
+          Alcotest.test_case
+            "http detail"
+            `Quick
+            test_to_user_message_preserves_http_detail;
+          Alcotest.test_case
+            "exhaustion wrapper"
+            `Quick
+            test_format_exhausted_error_wraps_user_message;
+          Alcotest.test_case
+            "accept rejected preserved"
+            `Quick
+            test_accept_rejected_preserves_error_variant;
+          Alcotest.test_case
+            "none detail"
+            `Quick
+            test_none_message_is_explicit;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add Cascade_fsm.to_user_message for terminal cascade details
- make format_exhausted_error reuse the same renderer
- route OAS worker Cascade_exhausted detail mapping through the FSM renderer
- add focused cascade FSM coverage

## Verification
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_cascade_fsm.exe test/test_oas_worker.exe
- ./_build/default/test/test_cascade_fsm.exe
- ./_build/default/test/test_oas_worker.exe test cascade_config

## Notes
- From artifact P-FSM-10: keep the worker control flow intact, but move user-facing cascade exhaustion rendering to the FSM boundary.
- Rebased on current main and removed the stale keeper_types_profile carry-forward from this PR.
