### PR TITLE
FSM-01: Migrate receipt outcome JSON boundary to TLA+ spec names

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -22,10 +22,10 @@ let outcome_kind_to_tla_receipt = function
   | `Cancelled -> "receipt_cancelled"
 
 let outcome_kind_of_string = function
-  | "ok" -> Some `Ok
-  | "skipped" -> Some `Skipped
-  | "error" -> Some `Error
-  | "cancelled" -> Some `Cancelled
+  | "ok" | "receipt_done" -> Some `Ok
+  | "skipped" | "receipt_skipped" -> Some `Skipped
+  | "error" | "receipt_failed" -> Some `Error
+  | "cancelled" | "receipt_cancelled" -> Some `Cancelled
   | _ -> None
 
 let outcome_kind_is_terminal_success = function
@@ -425,7 +425,11 @@ let to_json (receipt : t) =
         | Some value -> `String value
         | None -> `Null );
       ("goal_ids", list_json receipt.goal_ids);
-      ("outcome", `String receipt.outcome);
+      ("outcome",
+       `String
+         (match outcome_kind_of_string receipt.outcome with
+          | Some kind -> outcome_kind_to_tla_receipt kind
+          | None -> receipt.outcome));
       ("terminal_reason_code", `String receipt.terminal_reason_code);
       ("operator_disposition", `String operator_disposition);
       ("operator_disposition_reason", `String operator_disposition_reason);
@@ -571,7 +575,11 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
         | None -> `Null )
     ; "disposition", `String disposition
     ; "disposition_reason", `String reason
-    ; "outcome", `String receipt.outcome
+    ; "outcome",
+      `String
+        (match outcome_kind_of_string receipt.outcome with
+         | Some kind -> outcome_kind_to_tla_receipt kind
+         | None -> receipt.outcome)
     ; "terminal_reason_code", `String receipt.terminal_reason_code
     ; ( "current_task_id",
         match receipt.current_task_id with

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -766,7 +766,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     Result.bind result (fun () -> tool_access_defaults_result)
   in
   let result =
-    Result.bind result (fun () ->
+    Result.bind result
+      (fun (tool_preset, tool_also_allow, tool_preset_source) ->
         let has_proactive_enabled = has "proactive_enabled" in
         let has_proactive_idle = has "proactive_idle_sec" in
         let has_proactive_cooldown = has "proactive_cooldown_sec" in
@@ -788,7 +789,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             Error
               "proactive_idle_sec or proactive_cooldown_sec is set but \
                proactive_enabled is missing"
-        | _ -> Ok ())
+        | _ -> Ok (tool_preset, tool_also_allow, tool_preset_source))
   in
   Result.map
     (fun (tool_preset, tool_also_allow, tool_preset_source) ->

--- a/test/test_keeper_receipt_outcome_tla_parity.ml
+++ b/test/test_keeper_receipt_outcome_tla_parity.ml
@@ -25,9 +25,10 @@ let spec_terminal_outcome_set : string list =
   |> List.filter (fun s -> not (String.equal s "receipt_unset"))
 
 (* The four [outcome_kind] terminal variants mapped to their TLA+
-   receipt symbols.  This is not a blind prefix: the JSON boundary keeps
-   legacy ["ok"] / ["error"], while the spec names those terminal
-   receipt outcomes ["receipt_done"] / ["receipt_failed"]. *)
+   receipt symbols.  The JSON boundary now emits spec-aligned names
+   (["receipt_done"] / ["receipt_failed"] / ["receipt_skipped"] /
+   ["receipt_cancelled"]); legacy names (["ok"] / ["error"] / etc.)
+   are still accepted on parse for backward compatibility. *)
 let ocaml_terminal_outcome_set =
   List.map
     Masc_mcp.Keeper_execution_receipt.outcome_kind_to_tla_receipt
@@ -75,6 +76,25 @@ let test_string_roundtrip () =
                "outcome_kind round-trip failed for %s -> %s -> ?" s s))
     [ `Ok; `Skipped; `Error; `Cancelled ]
 
+let test_tla_name_roundtrip () =
+  (* JSON boundary migration (FSM-01): TLA names must parse back to the
+     same variant so that spec-aligned emission is reversible. *)
+  List.iter
+    (fun k ->
+      let s =
+        Masc_mcp.Keeper_execution_receipt.outcome_kind_to_tla_receipt k
+      in
+      match
+        Masc_mcp.Keeper_execution_receipt.outcome_kind_of_string s
+      with
+      | Some k' when k = k' -> ()
+      | Some _ | None ->
+          failwith
+            (Printf.sprintf
+               "outcome_kind TLA name round-trip failed for %s -> %s -> ?"
+               s s))
+    [ `Ok; `Skipped; `Error; `Cancelled ]
+
 let test_skipped_is_terminal_success () =
   (* PhaseGateSkip reaches terminal [Done] without dispatching, so the
      receipt outcome must classify as a successful no-op rather than a
@@ -107,6 +127,7 @@ let test_unset_is_not_a_terminal_outcome () =
 let () =
   test_terminal_set_parity ();
   test_string_roundtrip ();
+  test_tla_name_roundtrip ();
   test_skipped_is_terminal_success ();
   test_unset_is_not_a_terminal_outcome ();
   print_endline "test_keeper_receipt_outcome_tla_parity: OK"


### PR DESCRIPTION
## Summary
- `outcome_kind_of_string` now accepts both legacy names (`"ok"`, `"error"`) and TLA+ spec names (`"receipt_done"`, `"receipt_failed"`, `"receipt_skipped"`, `"receipt_cancelled"`).
- JSON serialization (`to_json`) and broadcast payload (`operator_broadcast_payload`) now emit spec-aligned TLA names for known outcomes.
- Unknown outcome strings pass through unchanged (e.g. `"partial"` from `keeper_unified_turn.ml`).
- Added `test_tla_name_roundtrip` to parity test verifying reversibility.

## Companion
- PR #12376 (independent build fix for `keeper_types_profile.ml`) — included here as well since main currently has this compilation error.

## Test plan
- [x] `dune build test/test_keeper_receipt_outcome_tla_parity.exe` passes
- [x] `_build/default/test/test_keeper_receipt_outcome_tla_parity.exe` passes
- [x] `dune build test/test_keeper_turn_fsm_tla_parity.exe` passes
- [x] `_build/default/test/test_keeper_turn_fsm_tla_parity.exe` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)