### PR TITLE
fix(keeper): redact resolved host path from non-relative read error

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -409,7 +409,7 @@ let resolve_keeper_read_path ~(config : Coord.config)
           ~labels:[ ("kind", "out_of_roots") ] ();
         Error
           (Printf.sprintf "path_not_found_under_allowed_roots: %s"
-             target_norm)
+             raw)
       end
 
 let process_status_to_json (st : Unix.process_status) : Yojson.Safe.t =


### PR DESCRIPTION
## Summary

The non-relative branch of `resolve_keeper_read_path` in `keeper_alerting_path.ml` echoed `target_norm` (resolved absolute path) in the error message, leaking the host sandbox layout to the LLM caller.

All other branches in this function already follow the Tier A3 / Cycle 6 redaction rule: echo only the caller's `raw` input. This PR aligns the last remaining branch with the same pattern.

## Change

- `lib/keeper/keeper_alerting_path.ml` line 412: `target_norm` → `raw`

## Test Plan

- [x] `test_keeper_path_roots_leak_10349.exe` (4 tests) — passed
- [x] `test_keeper_allowed_paths.exe` (8 tests) — passed
- [x] `dune build lib/keeper/keeper_alerting_path.ml` — clean

## Related

- Feedback: `memory/feedback_b1_host_path_leak_keeper_status_detail.md`