### PR TITLE
fix: replace Printf.eprintf with Log.Server.warn in SSE keepalive

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -35,8 +35,8 @@ let getenv_with_alias ~primary ?deprecated () =
         | Some _ as some ->
           if not (Hashtbl.mem deprecation_warned dep) then begin
             Hashtbl.add deprecation_warned dep ();
-            Printf.eprintf
-              "[warn] env var %s is deprecated; use %s (same semantics)\n%!"
+            Log.Misc.warn
+              "env var %s is deprecated; use %s (same semantics)"
               dep primary
           end;
           some

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -82,7 +82,8 @@ let spawn_post_sse_keepalive ~sw ~clock info =
              Eio.Time.sleep clock post_sse_keepalive_interval_s
            with
           | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn -> Printf.eprintf "[server_mcp_transport_http] keepalive sleep failed: %s\n%!" (Printexc.to_string exn));
+          | exn -> Log.Server.warn "SSE keepalive sleep failed for session %s: %s"
+                    info.session_id (Printexc.to_string exn));
           if info.closed then
             close_sse_conn info
           else if not !(info.stop) then


### PR DESCRIPTION
## Summary
- Replace `Printf.eprintf` in `server_mcp_transport_http.ml` SSE keepalive fiber with structured `Log.Server.warn`
- Printf goes to stderr (may be /dev/null in daemon mode), bypassing structured logging, log rotation, and log level configuration
- Continuation of silent failure sweep from PR #12389 (merged)

## Test plan
- [ ] CI Build + Lint pass
- [ ] Verify Log.Server.warn is used consistently in lib/server/ for error reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)