### PR TITLE
fix(keeper): restore unit Result.bind chain in profile validation

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -764,8 +764,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   in
   let tool_access_defaults = tool_access_defaults_result in
   let result =
-    Result.bind result
-      (fun (tool_preset, tool_also_allow, tool_preset_source) ->
+    Result.bind result (fun () ->
         let has_proactive_enabled = has "proactive_enabled" in
         let has_proactive_idle = has "proactive_idle_sec" in
         let has_proactive_cooldown = has "proactive_cooldown_sec" in
@@ -787,7 +786,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             Error
               "proactive_idle_sec or proactive_cooldown_sec is set but \
                proactive_enabled is missing"
-        | _ -> Ok (tool_preset, tool_also_allow, tool_preset_source))
+        | _ -> Ok ())
   in
   Result.bind result (fun () ->
       match tool_access_defaults with


### PR DESCRIPTION
## Summary

After the two parallel post-#12367 fixes — #12376 (broader) and #12378 (narrow) — landed back-to-back, the proactive validation block at `lib/keeper/keeper_types_profile.ml:766-790` was left with a 3-tuple lambda that no longer matches the surrounding unit chain:

```ocaml
let result = Result.bind result (fun () -> ... Ok ())  in     (* unit *)
let tool_access_defaults = tool_access_defaults_result in     (* aside *)
let result = Result.bind result
               (fun (tool_preset, ...) -> ... Ok (..., ..., ...))  (* 3-tuple — mismatched *)
in
Result.bind result (fun () ->                                 (* unit again *)
    match tool_access_defaults with ...)
```

`dune build` on main fails with:

```
File "lib/keeper/keeper_types_profile.ml", line 768, characters 11-61:
Error: This pattern matches values of type 'a * 'b * 'c
       but a pattern was expected which matches values of type unit
```

This is a textbook *opposite-direction admin merge* artefact — the two fixes contradicted each other and the contradictions met in the same function.

## Fix

The data-carrying intent (`tool_preset / tool_also_allow / tool_preset_source`) is already covered by the standalone `let tool_access_defaults = tool_access_defaults_result` binding and the closing `match tool_access_defaults with ...`. The middle bind only needs to gate the proactive validation rules.

Restore that bind to a unit chain (`fun () -> ... | _ -> Ok ()`) so the chain types check end-to-end. No semantic change to the validation rules.

## Diff

```
 lib/keeper/keeper_types_profile.ml | 5 ++---
 1 file changed, 2 insertions(+), 3 deletions(-)
```

## Verification

- [x] `dune build --root . @check` — exit 0 (was failing on main).
- [ ] CI Build/Test/Lint pipeline picks up the fix.
- [ ] Unblocks the keeper-touching PRs that have been building on a broken main, including `chore(release): bump version to 0.18.23` (#12391).

## Test plan

- [x] Local type-check passes.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)