### PR TITLE
fix: eliminate silent failure patterns across server modules

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -35,8 +35,8 @@ let getenv_with_alias ~primary ?deprecated () =
         | Some _ as some ->
           if not (Hashtbl.mem deprecation_warned dep) then begin
             Hashtbl.add deprecation_warned dep ();
-            Printf.eprintf
-              "[warn] env var %s is deprecated; use %s (same semantics)\n%!"
+            Log.Misc.warn
+              "env var %s is deprecated; use %s (same semantics)"
               dep primary
           end;
           some

--- a/lib/coord/coord_eio.ml
+++ b/lib/coord/coord_eio.ml
@@ -197,7 +197,7 @@ let get_recent_events config ~limit =
     | Ok n -> n
     | Error (Backend.NotFound _) -> 0
     | Error e ->
-        Log.Coord.debug "get_recent_events: event seq read failed: %s"
+        Log.Coord.warn "get_recent_events: event seq read failed: %s"
           (match e with Backend.IOError m -> m
            | _ -> "unexpected backend error");
         0

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -147,7 +147,9 @@ let load_git_clone_policy_result ~base_path =
 let load_git_clone_policy ~base_path =
   match load_git_clone_policy_result ~base_path with
   | Ok policy -> policy
-  | Error _ -> [], []
+  | Error msg ->
+      Log.Coord.routine "git_clone_policy: using defaults (%s)" msg;
+      [], []
 
 let valid_github_org_slug org =
   let valid_org_char c =

--- a/lib/governance_anomaly.ml
+++ b/lib/governance_anomaly.ml
@@ -257,7 +257,9 @@ let load_profile ~base_path ~agent_id =
   if not (Sys.file_exists path) then None
   else
     match Safe_ops.read_file_safe path with
-    | Error _ -> None
+    | Error msg ->
+        Log.Misc.warn "governance_anomaly: failed to read profile %s: %s" path msg;
+        None
     | Ok content -> (
         try
           let json = Yojson.Safe.from_string content in

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -277,7 +277,9 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
     | Some raw -> (
         match Auth.resolve_agent_from_token config.base_path ~token:raw with
         | Ok owner_name -> resolve_owner_keeper_identity owner_name
-        | Error _ -> None)
+        | Error msg ->
+            Log.Auth.routine "owner_keeper_identity: token resolve failed: %s" msg;
+            None)
   in
 
   let mode_gate_error =

--- a/lib/mention_inbox.ml
+++ b/lib/mention_inbox.ml
@@ -85,7 +85,9 @@ let load_all_mentions (config : Coord.config) : mention_record list =
   if not (Sys.file_exists path) then []
   else
     match Safe_ops.read_file_safe path with
-    | Error _ -> []
+    | Error msg ->
+        Log.Misc.warn "mention_inbox: failed to read %s: %s" path msg;
+        []
     | Ok content ->
       String.split_on_char '\n' content
       |> List.filter (fun line -> String.length (String.trim line) > 0)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -394,7 +394,10 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       Agent_tool_surfaces.local_worker_tool_schemas ~names:judge_tool_names ()
     with
     | Ok schemas -> schemas
-    | Error _ -> []
+    | Error e ->
+        Log.Server.warn "judge tool schema resolution failed: %s"
+          (Types.masc_error_to_string e);
+        []
   in
   let make_judge_dispatch ~actor ~(name : string) ~(args : Yojson.Safe.t)
       : bool * string =

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -230,9 +230,11 @@ let add_delete_action_routes router =
              | Ok () ->
                  Http.Response.json ~compress:true ~request:req
                    {|{"ok":true}|} reqd
-             | Error _ ->
+             | Error err ->
                  Http.Response.json ~status:`Not_found ~request:req
-                   {|{"ok":false,"error":"post not found or delete failed"}|} reqd
+                   (Printf.sprintf {|{"ok":false,"error":"%s"}|}
+                      (String.escaped (Board_types.pp_board_error err)))
+                   reqd
            with Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req
                {|{"ok":false,"error":"invalid request: requires {\"post_id\":\"...\"}"}|} reqd
@@ -255,9 +257,11 @@ let add_delete_action_routes router =
              | Ok () ->
                  Http.Response.json ~compress:true ~request:req
                    {|{"ok":true}|} reqd
-             | Error _ ->
+             | Error err ->
                  Http.Response.json ~status:`Not_found ~request:req
-                   {|{"ok":false,"error":"task not found or delete failed"}|} reqd
+                   (Printf.sprintf {|{"ok":false,"error":"task delete failed: %s"}|}
+                      (String.escaped (Types.masc_error_to_string err)))
+                   reqd
            with Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req
                {|{"ok":false,"error":"invalid request: requires {\"task_id\":\"...\"}"}|} reqd

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -82,7 +82,8 @@ let spawn_post_sse_keepalive ~sw ~clock info =
              Eio.Time.sleep clock post_sse_keepalive_interval_s
            with
           | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn -> Printf.eprintf "[server_mcp_transport_http] keepalive sleep failed: %s\n%!" (Printexc.to_string exn));
+          | exn -> Log.Server.warn "SSE keepalive sleep failed for session %s: %s"
+                    info.session_id (Printexc.to_string exn));
           if info.closed then
             close_sse_conn info
           else if not !(info.stop) then

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -214,15 +214,19 @@ let readiness_handler _request reqd =
 
 let board_post_detail_json ~response_format ~post_id =
   match Board_dispatch.get_post ~post_id with
-  | Error _ ->
-      (`Not_found, {|{"error":"Post not found"}|})
+  | Error err ->
+      (`Not_found, Printf.sprintf {|{"error":"%s"}|}
+         (String.escaped (Board_types.pp_board_error err)))
   | Ok post ->
       let author = Board.Agent_id.to_string post.author in
       let author_karma = Board_dispatch.get_agent_karma ~agent_name:author in
       let comments =
         match Board_dispatch.get_comments ~post_id with
         | Ok cs -> cs
-        | Error _ -> []
+        | Error err ->
+            Log.Server.warn "board_post_detail: get_comments failed for %s: %s"
+              post_id (Board_types.pp_board_error err);
+            []
       in
       let post_json = board_post_dashboard_json ~author_karma post in
       let comments_json = `List (List.map board_comment_dashboard_json comments) in

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -560,7 +560,7 @@ let handle_claim ?agent_tool_names ctx args =
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
        ])
-   | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
+   | Error e -> Log.Task.warn "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
   result_to_response result
 
 let handle_claim_next ?agent_tool_names ctx _args =


### PR DESCRIPTION
## Summary
- Replace wildcard `Error _ -> ()` / `Error _ -> []` patterns with error-detail propagation in dashboard delete handlers and bootstrap judge schema resolution
- Escalate debug-level logging to warn for task claim failures and event seq read failures
- Replace `Printf.eprintf` with proper Log module calls in SSE keepalive and cascade health tracker

## Silent failure categories addressed

| Category | Pattern | Files |
|----------|---------|-------|
| B: Wildcard error silencing | `Error _ -> ()` / `Error _ -> []` | `server_dashboard_http_delete_actions.ml`, `server_bootstrap_loops.ml` |
| C: Debug on actual failure | `Log.*.debug` on error paths | `tool_task.ml`, `coord_eio.ml` |
| F: Printf.eprintf stderr dump | `Printf.eprintf` → proper Log | `server_mcp_transport_http.ml`, `cascade_health_tracker.ml` |

## Test plan
- [ ] `dune build lib/` passes (main has pre-existing unrelated build error in `keeper_types_profile.ml`)
- [ ] Dashboard delete endpoints return error detail in JSON response
- [ ] Log output shows `WARN` level for task claim failures and event seq failures
- [ ] Judge tool schema failure logs warning instead of silent empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)