### PR TITLE
fix: repair main type errors after error API changes

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -278,7 +278,8 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
         match Auth.resolve_agent_from_token config.base_path ~token:raw with
         | Ok owner_name -> resolve_owner_keeper_identity owner_name
         | Error msg ->
-            Log.Auth.routine "owner_keeper_identity: token resolve failed: %s" msg;
+            Log.Auth.routine "owner_keeper_identity: token resolve failed: %s"
+              (Types.masc_error_to_string msg);
             None)
   in
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -395,8 +395,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     with
     | Ok schemas -> schemas
     | Error e ->
-        Log.Server.warn "judge tool schema resolution failed: %s"
-          (Types.masc_error_to_string e);
+        Log.Server.warn "judge tool schema resolution failed: %s" e;
         []
   in
   let make_judge_dispatch ~actor ~(name : string) ~(args : Yojson.Safe.t)

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -233,7 +233,7 @@ let add_delete_action_routes router =
              | Error err ->
                  Http.Response.json ~status:`Not_found ~request:req
                    (Printf.sprintf {|{"ok":false,"error":"%s"}|}
-                      (String.escaped (Board_types.pp_board_error err)))
+                      (String.escaped (Board_types.show_board_error err)))
                    reqd
            with Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -216,7 +216,7 @@ let board_post_detail_json ~response_format ~post_id =
   match Board_dispatch.get_post ~post_id with
   | Error err ->
       (`Not_found, Printf.sprintf {|{"error":"%s"}|}
-         (String.escaped (Board_types.pp_board_error err)))
+         (String.escaped (Board_types.show_board_error err)))
   | Ok post ->
       let author = Board.Agent_id.to_string post.author in
       let author_karma = Board_dispatch.get_agent_karma ~agent_name:author in
@@ -225,7 +225,7 @@ let board_post_detail_json ~response_format ~post_id =
         | Ok cs -> cs
         | Error err ->
             Log.Server.warn "board_post_detail: get_comments failed for %s: %s"
-              post_id (Board_types.pp_board_error err);
+              post_id (Board_types.show_board_error err);
             []
       in
       let post_json = board_post_dashboard_json ~author_karma post in


### PR DESCRIPTION
## Summary
- use string renderers for board errors in dashboard/runtime routes
- stringify auth Masc_error values before routine logging
- keep local worker schema errors as strings in bootstrap logging

## Verification
- scripts/dune-local.sh build test/test_oas_worker.exe

## Queue impact
- Current main fails this target with four type errors outside the remaining draft PRs. This PR is a narrow unblocker so #12383/#12384 can be rebased and validated on a buildable base.