### PR TITLE
fix: promote invisible diagnostics to operator-visible logging (silent failure sweep)

### DIFF
--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -76,7 +76,9 @@ let load_jsonl_safe (path : string) : Yojson.Safe.t list =
   if not (Sys.file_exists path) then []
   else
     match Safe_ops.read_file_safe path with
-    | Error _ -> []
+    | Error msg ->
+        Log.Misc.warn "agent_reputation: failed to read %s: %s" path msg;
+        []
     | Ok content ->
       String.split_on_char '\n' content
       |> List.filter (fun line -> String.length (String.trim line) > 0)

--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -143,7 +143,7 @@ let recent n =
     else
       match Safe_ops.read_file_safe path with
       | Error msg ->
-          Eio.traceln "[AgentStress] recent read_file_safe failed: %s" msg;
+          Log.Misc.warn "[AgentStress] recent read_file_safe failed: %s" msg;
           []
       | Ok content ->
         let lines =

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -211,7 +211,5 @@ let local_worker_resolvable_tool_names () : string list =
   | Ok schemas ->
       List.map (fun (s : Types.tool_schema) -> s.name) schemas
   | Error msg ->
-      Eio.traceln
-        "[AgentToolSurfaces] local_worker_tool_schemas failed: %s"
-        msg;
+      Log.Misc.warn "[AgentToolSurfaces] local_worker_tool_schemas failed: %s" msg;
       []

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -1046,8 +1046,9 @@ let apply_provider_filter ~provider_filter ~label providers =
     in
     let filtered = List.filter matches providers in
     if filtered = [] then (
-      Eio.traceln "[CascadeConfig] provider_filter matched no providers (%s); \
-        falling back to unfiltered (filter=[%s] providers=[%s])"
+      Log.warn ~ctx:"CascadeConfig"
+        "provider_filter matched no providers (%s); \
+         falling back to unfiltered (filter=[%s] providers=[%s])"
         label (String.concat "," filters)
         (String.concat "," (List.map (fun (p : Llm_provider.Provider_config.t) ->
           Llm_provider.Provider_config.string_of_provider_kind p.kind) providers));

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -326,8 +326,7 @@ let read_bool_field json key =
 let resolve_inference_params ~config_path ~name =
   match load_json config_path with
   | Error msg ->
-      Eio.traceln
-        "[CascadeConfig] resolve_inference_params: %s (name=%s, path=%s)"
+      Log.Misc.warn "[CascadeConfig] resolve_inference_params: %s (name=%s, path=%s)"
         msg name config_path;
       { temperature = None; max_tokens = None;
         keep_alive = None; num_ctx = None;
@@ -400,8 +399,7 @@ let read_api_key_env_field json key =
 let resolve_api_key_env ~config_path ~name =
   match load_json config_path with
   | Error msg ->
-      Eio.traceln
-        "[CascadeConfig] resolve_api_key_env: %s (name=%s, path=%s)"
+      Log.Misc.warn "[CascadeConfig] resolve_api_key_env: %s (name=%s, path=%s)"
         msg name config_path;
       []
   | Ok json ->
@@ -466,8 +464,7 @@ let empty_strategy_config = {
 let resolve_strategy_config ~config_path ~name =
   match load_json config_path with
   | Error msg ->
-      Eio.traceln
-        "[CascadeConfig] resolve_strategy_config: %s (name=%s, path=%s)"
+      Log.Misc.warn "[CascadeConfig] resolve_strategy_config: %s (name=%s, path=%s)"
         msg name config_path;
       empty_strategy_config
   | Ok json ->

--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -222,8 +222,8 @@ let warn_invalid_route_target_once ~route_key ~target ~fallback =
   let key = (route_key, target) in
   if not (Hashtbl.mem logged_invalid_route_targets key) then begin
     Hashtbl.add logged_invalid_route_targets key ();
-    Eio.traceln
-      "[CascadeRoutes] WARN routes.%s targets missing profile %s; using %s"
+    Log.Misc.warn
+      "[CascadeRoutes] routes.%s targets missing profile %s; using %s"
       route_key target fallback
   end
 

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -258,7 +258,7 @@ let recent n =
     else
       match Safe_ops.read_file_safe path with
       | Error msg ->
-          Eio.traceln "[HeuristicMetrics] recent read_file_safe failed: %s" msg;
+          Log.warn ~ctx:"heuristic_metrics" "recent_entries read failed: %s" msg;
           []
       | Ok content ->
         let lines =

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -240,8 +240,8 @@ let fallback_cascade_for ?config_path name =
                     let key = (trimmed_name, target) in
                     if not (Hashtbl.mem logged_invalid_fallback key) then begin
                       Hashtbl.add logged_invalid_fallback key ();
-                      Eio.traceln
-                        "[CascadeConfig] WARN profile %s declares \
+                      Log.Misc.warn
+                        "[CascadeConfig] profile %s declares \
                          fallback_cascade=%s which is not in the live \
                          catalog; ignoring hint"
                         trimmed_name target

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1060,8 +1060,8 @@ module Kimi_cli_transport_local = struct
     if !warned || tools = [] then ()
     else (
       warned := true;
-      Eio.traceln
-        "[warn] kimi_cli print mode ignores OAS req.tools. \
+      Log.Misc.warn
+        "kimi_cli print mode ignores OAS req.tools. \
          Provider-native built-in tools and configured MCP servers remain \
          available; external OAS tool callbacks require a future wire-mode \
          transport.")

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1211,7 +1211,7 @@ let auto_label_for_adapter (adapter : adapter) =
     match default_model_label_for_adapter adapter with
     | Ok label -> Some label
     | Error msg ->
-        Eio.traceln "[ProviderAdapter] default_model_label_for_adapter failed: %s" msg;
+        Log.Misc.warn "[ProviderAdapter] default_model_label_for_adapter failed: %s" msg;
         None
 
 (** Cloud adapters that participate in auto-detection (excludes llama

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -14,6 +14,7 @@
  (wrapped false)
  (libraries
    masc_mcp.masc_exec
+   masc_mcp.masc_log
    digestif
    yojson
    otoml

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -2,6 +2,8 @@ open Repo_manager_types
 
 let ( let* ) = Result.bind
 
+let logged_mapping_errors : (string, unit) Hashtbl.t = Hashtbl.create 4
+
 let mappings_toml_path base_path =
   Filename.concat base_path ".masc/config/keeper_repo_mappings.toml"
 
@@ -88,7 +90,13 @@ let allowed_repositories ~keeper_id ~base_path =
     mapping is not an error. *)
 let credentials_for_keeper ~base_path ~keeper_id =
   match find_mapping ~base_path keeper_id with
-  | Error _ -> Ok []
+  | Error msg ->
+      if not (String.starts_with ~prefix:"No mapping found" msg) then
+        Log.Misc.warn
+          "[KeeperRepoMapping] credentials_for_keeper: mapping store error \
+           for keeper %s (error: %s)"
+          keeper_id msg;
+      Ok []
   | Ok mapping ->
       let* repos = Repo_store.load_all ~base_path in
       let mapped_repos =
@@ -128,7 +136,17 @@ let credentials_for_keeper ~base_path ~keeper_id =
 
 let is_allowed ~keeper_id ~repository_id ~base_path =
   match find_mapping ~base_path keeper_id with
-  | Error _ -> true
+  | Error msg ->
+      if not (String.starts_with ~prefix:"No mapping found" msg)
+         && not (Hashtbl.mem logged_mapping_errors keeper_id)
+      then begin
+        Hashtbl.add logged_mapping_errors keeper_id ();
+        Log.Misc.warn
+          "[KeeperRepoMapping] is_allowed: mapping store error for keeper %s \
+           — access control bypassed (error: %s)"
+          keeper_id msg
+      end;
+      true
   | Ok mapping ->
       List.exists
         (fun id -> String.equal id repository_id || String.equal id "*")
@@ -172,7 +190,13 @@ let save_mapping ~base_path mapping =
 
 let apply_mapping ~keeper_id ~base_path ~repositories =
   match find_mapping ~base_path keeper_id with
-  | Error _ -> repositories
+  | Error msg ->
+      if not (String.starts_with ~prefix:"No mapping found" msg) then
+        Log.Misc.warn
+          "[KeeperRepoMapping] apply_mapping: mapping store error for \
+           keeper %s — returning unfiltered repositories (error: %s)"
+          keeper_id msg;
+      repositories
   | Ok mapping ->
       if List.exists (String.equal "*") mapping.repository_ids then
         repositories
@@ -203,7 +227,12 @@ let path_under_repo ~base_path repo path =
     if the path is not under any registered repository. *)
 let repository_id_of_path ~base_path ~path =
   match Repo_store.load_all ~base_path with
-  | Error _ -> None
+  | Error msg ->
+      Log.Misc.warn
+        "[KeeperRepoMapping] repository_id_of_path: repo store load failed \
+         for path %s (error: %s)"
+        path msg;
+      None
   | Ok repos -> (
       match
         List.find_opt (fun repo -> path_under_repo ~base_path repo path) repos

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -1185,7 +1185,12 @@ let handle_start state request reqd =
                     ?previous_attempt
                     ~observed_state
                     ~write_attempt:(write_attempt_record ~base_path ~id)
-                    ~start_shell:(fun () -> ignore (Sys.command cmd))
+                    ~start_shell:(fun () ->
+                        let exit_code = Sys.command cmd in
+                        if exit_code <> 0 then
+                          Log.Misc.warn
+                            "[Sidecar] shell start failed with exit=%d (cmd=%s)"
+                            exit_code cmd)
                     desired
                 in
                 respond_json request reqd ~status:`Accepted

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -663,7 +663,7 @@ let handle_vote args =
                     author dimension (if is_positive then "+0.01" else "-0.01")
                 end else ""
             | Error e ->
-                Eio.traceln "[ToolBoard] get_reputation_evolution failed: %s" (board_error_to_string e);
+                Log.Misc.warn "[ToolBoard] get_reputation_evolution failed: %s" (board_error_to_string e);
                 ""
       in
       (true, Printf.sprintf "%s Vote recorded. New score: %+d%s" arrow new_score evolution_msg)

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -175,7 +175,7 @@ let request_of_yojson = function
                    match criterion_of_yojson j with
                    | Ok c -> Some c
                    | Error msg ->
-                     Eio.traceln "[Verification] dropping invalid criterion: %s" msg;
+                     Log.Misc.warn "[Verification] dropping invalid criterion: %s" msg;
                      None
                  ) l
              | _ -> []
@@ -192,7 +192,7 @@ let request_of_yojson = function
              | Some json -> (match request_status_of_yojson json with
                  | Ok s -> s
                  | Error msg ->
-                   Eio.traceln "[Verification] unparseable status, falling back to Pending: %s" msg;
+                   Log.Misc.warn "[Verification] unparseable status, falling back to Pending: %s" msg;
                    Pending)
              | None -> Pending
            in


### PR DESCRIPTION
## Summary
- promote remaining `Eio.traceln` dev-only diagnostics to structured `Log.*.warn` calls across agent, cascade, provider, tool, and verification paths
- make fail-open repo-manager mapping/store errors operator-visible while preserving existing permissive fallback behavior
- surface sidecar shell start non-zero exits instead of ignoring `Sys.command` failures

## Files changed
- `lib/agent_reputation.ml`
- `lib/agent_stress.ml`
- `lib/agent_tool_surfaces.ml`
- `lib/cascade/cascade_config.ml`
- `lib/cascade/cascade_config_loader.ml`
- `lib/cascade/cascade_routes.ml`
- `lib/heuristic_metrics.ml`
- `lib/keeper/keeper_cascade_profile.ml`
- `lib/oas_worker_exec_transport.ml`
- `lib/provider_adapter.ml`
- `lib/repo_manager/dune`
- `lib/repo_manager/keeper_repo_mapping.ml`
- `lib/server/server_routes_http_routes_sidecar.ml`
- `lib/tool_board.ml`
- `lib/verification.ml`

## Verification
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_keeper_repo_mapping.exe test/test_oas_worker.exe test/test_verification.exe test/test_backend.exe test/test_keeper_accountability.exe
- ./_build/default/test/test_keeper_repo_mapping.exe
- ./_build/default/test/test_verification.exe
- ./_build/default/test/test_oas_worker.exe test cascade_config

## Notes
- Control flow is preserved: fail-open/default branches still return the same fallback values, but no longer disappear silently.
