### PR TITLE
feat(keeper): wire Keeper_event_queue into registry entry

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -159,6 +159,7 @@ type registry_entry = {
   conditions : Keeper_state_machine.conditions;
   fiber_stop : bool Atomic.t;
   fiber_wakeup : bool Atomic.t;
+  event_queue : Keeper_event_queue.t Atomic.t;
   started_at : float;
   grpc_close : (unit -> unit) option Atomic.t;
   done_p : [ `Stopped | `Crashed of string ] Eio.Promise.t;
@@ -300,6 +301,7 @@ let register_with_state ~base_path name meta
     conditions;
     fiber_stop = Atomic.make false;
     fiber_wakeup = Atomic.make false;
+    event_queue = Atomic.make Keeper_event_queue.empty;
     started_at = Time_compat.now ();
     grpc_close = Atomic.make None;
     done_p;
@@ -1346,3 +1348,22 @@ let get_conditions ~base_path name =
   match get ~base_path name with
   | Some entry -> Some entry.conditions
   | None -> None
+
+let enqueue_event ~base_path name stimulus =
+  match get ~base_path name with
+  | None ->
+      Log.Keeper.warn
+        "registry: enqueue_event name=%s base_path=%s: keeper not registered"
+        name base_path
+  | Some entry ->
+      let rec loop () =
+        let cur = Atomic.get entry.event_queue in
+        let next = Keeper_event_queue.enqueue cur stimulus in
+        if not (Atomic.compare_and_set entry.event_queue cur next) then loop ()
+      in
+      loop ()
+
+let event_queue_snapshot ~base_path name =
+  match get ~base_path name with
+  | None -> Keeper_event_queue.empty
+  | Some entry -> Atomic.get entry.event_queue

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -128,6 +128,12 @@ type registry_entry = {
       (** Observable conditions that derive [phase]. *)
   fiber_stop : bool Atomic.t;
   fiber_wakeup : bool Atomic.t;
+  event_queue : Keeper_event_queue.t Atomic.t;
+      (** Event Layer queue for incoming stimuli. Independent of
+          [fiber_wakeup] (which remains a hint signal). The Policy
+          Layer turn must consult this queue at the start of every
+          [emit] tick — see [specs/keeper-state-machine/KeeperEventQueue.tla]
+          and the [TurnDequeue] action. *)
   started_at : float;
   grpc_close : (unit -> unit) option Atomic.t;
   done_p : [ `Stopped | `Crashed of string ] Eio.Promise.t;
@@ -496,3 +502,20 @@ val get_phase : base_path:string -> string -> Keeper_state_machine.phase option
 
 (** Get the observable conditions of a keeper. *)
 val get_conditions : base_path:string -> string -> Keeper_state_machine.conditions option
+
+(** Append a stimulus to the keeper's Event Layer queue.
+
+    Always succeeds when the keeper is registered. Lock-free CAS
+    loop on [entry.event_queue]; concurrent [enqueue_event] callers
+    do not block. Stimuli arrive in the order observed by the CAS
+    winner, which the Policy Layer respects via [Keeper_event_queue.dequeue].
+
+    Logs a warning when [name] is not in the registry — calling sites
+    should not depend on enqueue success for missing keepers. *)
+val enqueue_event :
+  base_path:string -> string -> Keeper_event_queue.stimulus -> unit
+
+(** Snapshot the keeper's Event Layer queue. Returns [Keeper_event_queue.empty]
+    when the keeper is missing. Read-only — does not consume stimuli. *)
+val event_queue_snapshot :
+  base_path:string -> string -> Keeper_event_queue.t


### PR DESCRIPTION
## Summary

Adds the Event Layer queue to `Keeper_registry.registry_entry` as an `Atomic.t` so concurrent fibers can `enqueue_event` without locking. Initialises `Keeper_event_queue.empty` at register time alongside `fiber_wakeup` — the queue is the **data channel**, `fiber_wakeup` remains the **hint signal** (unchanged here, will be revisited in PR-C).

This is the data half of the layer split documented in `RUTHLESS_JUDGMENT.md` §3-4 and verified by [`KeeperEventQueue.tla`](specs/keeper-state-machine/KeeperEventQueue.tla) (#12386).

## Public API

```ocaml
val enqueue_event :
  base_path:string -> string -> Keeper_event_queue.stimulus -> unit
(** Lock-free CAS append. No-op + warn if keeper missing. *)

val event_queue_snapshot :
  base_path:string -> string -> Keeper_event_queue.t
(** Read-only snapshot for the Policy Layer dequeue path. *)
```

`enqueue_event` uses a CAS retry loop on the entry's `event_queue` atomic, so concurrent fibers do not block. The Policy Layer (PR-C) will own the `dequeue` side.

## What this PR is *not*

- **Not** wiring `wakeup_keeper` to call `enqueue_event` (PR-C).
- **Not** changing `Heartbeat_smart` decisions (PR-C).
- **Not** touching `fiber_wakeup` semantics (PR-C).

The split is intentional: this PR exposes the data channel without changing any control flow. Existing call sites compile unchanged because `registry_entry` is a transparent record and the new field uses default initialisation at the single construction site (`register/registry.ml:295`).

## Verification

- [x] `dune build --root . lib/` — **exit 0** (rebased onto current `main` `493e00c26a` after #12397 absorbed the type-error repairs from the closed #12399).
- [x] `Keeper_registry.cmi` builds cleanly with the new field + API.
- [x] No new tests in this PR — the queue itself has property tests under `test/keeper_event_queue/` (#12396), and the registry wiring is exercised once `wakeup_keeper` calls it (PR-C).

## Layer plan

| PR | Layer | Status |
|---|---|---|
| #12386 | TLA+ spec (KeeperEventQueue + buggy bug-model) | ✅ MERGED |
| #12396 | Library + isolated property tests | ✅ MERGED |
| **this PR** | **Registry entry field + enqueue/snapshot API** | **Draft, ready for review** |
| PR-C (planned) | `wakeup_keeper` enqueue + `Heartbeat_smart` queue-non-empty override + per-turn dequeue | — |

Each PR responsible for one layer, in line with `RUTHLESS_JUDGMENT.md` §3-4.

## Test plan

- [x] `Keeper_registry.cmi` compiles.
- [x] Full `lib/` build green after rebase onto `493e00c26a`.
- [ ] CI `Build and Test` reruns after force-push.
- [ ] Smoke: existing keeper register/lookup/dispatch flows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)