### PR TITLE
refactor(cascade): type runtime cascade lookups

### DIFF
--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -33,8 +33,12 @@ let is_local_label label =
   | Some pname -> Provider_adapter.is_local_provider pname
   | None -> false
 
+let cascade_name_to_string = Keeper_cascade_profile.runtime_name_to_string
+
 let default_model_strings ~cascade_name =
-  let cascade_name = Keeper_cascade_profile.canonicalize cascade_name in
+  let cascade_name =
+    cascade_name |> cascade_name_to_string |> Keeper_cascade_profile.canonicalize
+  in
   let all_labels =
     match Provider_adapter.explicit_llama_model_label_result () with
     | Ok label -> [ label ]
@@ -259,16 +263,18 @@ let cascade_config_path () : string option =
   Config_dir_resolver.log_warnings ~context:"CascadeRuntime" ();
   Config_dir_resolver.cascade_path_opt ()
 
-let models_of_cascade_name_result (cascade_name : string) :
+let models_of_cascade_name_result cascade_name :
     (string list, string) result =
-  Cascade_catalog_runtime.models_of_cascade_name cascade_name
+  Cascade_catalog_runtime.models_of_cascade_name
+    (cascade_name_to_string cascade_name)
 
-let models_of_cascade_name (cascade_name : string) : string list =
+let models_of_cascade_name cascade_name =
+  let cascade_name_string = cascade_name_to_string cascade_name in
   match models_of_cascade_name_result cascade_name with
   | Ok labels -> labels
   | Error detail ->
       let normalized =
-        Keeper_cascade_profile.normalize_declared_name cascade_name
+        Keeper_cascade_profile.normalize_declared_name cascade_name_string
       in
       Log.warn ~ctx:"CascadeRuntime"
         "cascade config resolve failed for %s, returning []: %s"
@@ -304,10 +310,14 @@ let resolve_named_providers_result ?provider_filter
     ?runtime_mcp_policy
     ~cascade_name ()
     : (Llm_provider.Provider_config.t list, string) result =
-  let label = Keeper_cascade_profile.normalize_declared_name cascade_name in
+  let cascade_name_string = cascade_name_to_string cascade_name in
+  let label =
+    Keeper_cascade_profile.normalize_declared_name cascade_name_string
+  in
   match
     Cascade_catalog_runtime.resolve_named_providers ?provider_filter
-      ?runtime_mcp_policy ~require_tool_choice_support:false ~cascade_name ()
+      ?runtime_mcp_policy ~require_tool_choice_support:false
+      ~cascade_name:cascade_name_string ()
   with
   | Error _ as e -> e
   | Ok providers ->
@@ -329,6 +339,7 @@ let resolve_named_providers ?provider_filter
   | Ok providers -> providers
   | Error detail ->
       Log.Misc.warn "cascade %s: %s"
-        (Keeper_cascade_profile.normalize_declared_name cascade_name)
+        (Keeper_cascade_profile.normalize_declared_name
+           (cascade_name_to_string cascade_name))
         detail;
       []

--- a/lib/cascade/cascade_runtime.mli
+++ b/lib/cascade/cascade_runtime.mli
@@ -30,21 +30,28 @@ val clamp_context_for_pure_local_labels :
 val resolve_primary_model_id : string list -> string
 val default_local_model_label_and_id : unit -> string * string
 val ensure_api_keys_for_labels : string list -> (unit, string) result
-val default_model_strings : cascade_name:string -> string list
-val models_of_cascade_name_result : string -> (string list, string) result
-val models_of_cascade_name : string -> string list
+val default_model_strings :
+  cascade_name:Keeper_cascade_profile.runtime_name -> string list
+val models_of_cascade_name_result :
+  Keeper_cascade_profile.runtime_name -> (string list, string) result
+val models_of_cascade_name :
+  Keeper_cascade_profile.runtime_name -> string list
 val resolve_named_providers_result :
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
   ?require_tool_support:bool ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
-  cascade_name:string -> unit -> (Llm_provider.Provider_config.t list, string) result
+  cascade_name:Keeper_cascade_profile.runtime_name ->
+  unit ->
+  (Llm_provider.Provider_config.t list, string) result
 val resolve_named_providers :
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
   ?require_tool_support:bool ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
-  cascade_name:string -> unit -> Llm_provider.Provider_config.t list
+  cascade_name:Keeper_cascade_profile.runtime_name ->
+  unit ->
+  Llm_provider.Provider_config.t list
 val resolve_providers_from_model_strings :
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -567,7 +567,8 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
           let next_model_hint = Keeper_exec_status.next_model_hint_of_meta m in
           let effective_cascade_name = live_keeper_cascade_name m.cascade_name in
           let cascade_models =
-            Cascade_runtime.models_of_cascade_name effective_cascade_name
+            Cascade_runtime.models_of_cascade_name
+              (Keeper_cascade_profile.Runtime_name effective_cascade_name)
           in
           let primary_model =
             match cascade_models with
@@ -870,7 +871,8 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
             | None ->
                 (let effective_cascade_name = live_keeper_cascade_name m.cascade_name in
                  let effective_models =
-                   Cascade_runtime.models_of_cascade_name effective_cascade_name
+                   Cascade_runtime.models_of_cascade_name
+                     (Keeper_cascade_profile.Runtime_name effective_cascade_name)
                  in
                  let cfgs = Cascade_config.parse_model_strings effective_models in
                  match cfgs with
@@ -1455,7 +1457,8 @@ let keeper_config_json (config : Coord.config) (name : string)
           ( "models",
             `List
               (List.map (fun s -> `String s)
-                 (Cascade_runtime.models_of_cascade_name effective_cascade_name)) );
+                 (Cascade_runtime.models_of_cascade_name
+                    (Keeper_cascade_profile.Runtime_name effective_cascade_name))) );
           ("active_model", `String active_model);
           ("active_model_label", Json_util.string_opt_to_json active_model_label);
           ("last_model_used_label", Json_util.string_opt_to_json last_model_used_label);

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -118,7 +118,10 @@ let profile_json_runtime ~keeper_assignable_names name =
       None
 
 let profile_json_raw ~config_path ~keeper_assignable_names name =
-  let defaults = Cascade_runtime.default_model_strings ~cascade_name:name in
+  let defaults =
+    Cascade_runtime.default_model_strings
+      ~cascade_name:(Keeper_cascade_profile.Runtime_name name)
+  in
   let (_models, trace) =
     CC.resolve_model_strings_with_trace ?config_path ~name ~defaults ()
   in

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -130,7 +130,9 @@ let compact_if_needed_typed
         let model_labels =
           match dedupe_keep_order (List.filter (fun s -> String.trim s <> "") meta.models) with
           | _ :: _ as explicit -> explicit
-          | [] -> Cascade_runtime.models_of_cascade_name meta.cascade_name
+          | [] ->
+              Cascade_runtime.models_of_cascade_name
+                (Keeper_cascade_profile.Runtime_name meta.cascade_name)
         in
         let primary_id = match Cascade_config.parse_model_strings model_labels with
           | c :: _ -> c.Llm_provider.Provider_config.model_id | [] -> "auto" in

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -56,7 +56,8 @@ let write_heartbeat_snapshot
   =
   let metrics_store = keeper_metrics_store ctx.config meta_current.name in
   let cascade_models =
-    Cascade_runtime.models_of_cascade_name meta_current.cascade_name
+    Cascade_runtime.models_of_cascade_name
+      (Keeper_cascade_profile.Runtime_name meta_current.cascade_name)
   in
   let max_cascade_context =
     let resolution =

--- a/lib/keeper/keeper_model_labels.ml
+++ b/lib/keeper/keeper_model_labels.ml
@@ -4,7 +4,10 @@ let configured_model_labels_of_meta (m : keeper_meta) : string list =
   match dedupe_keep_order (List.filter (fun s -> String.trim s <> "") m.models) with
   | _ :: _ as explicit -> explicit
   | [] ->
-      let configured = Cascade_runtime.models_of_cascade_name m.cascade_name in
+      let configured =
+        Cascade_runtime.models_of_cascade_name
+          (Keeper_cascade_profile.Runtime_name m.cascade_name)
+      in
       match Keeper_benchmark_canary.recommended_model_label_for_keeper ~keeper_name:m.name with
       | Some model_label when String.trim model_label <> "" ->
           dedupe_keep_order (model_label :: configured)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -211,7 +211,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       in
       let effective_models =
         if direct_reply then
-          Cascade_runtime.models_of_cascade_name turn_cascade_name
+          Cascade_runtime.models_of_cascade_name
+            (Keeper_cascade_profile.Runtime_name turn_cascade_name)
               else
           effective_model_labels_for_turn meta
       in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -299,7 +299,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
               in
               let cascade_models =
                 Cascade_runtime.models_of_cascade_name
-                  Keeper_config.default_cascade_name
+                  (Keeper_cascade_profile.Runtime_name
+                     Keeper_config.default_cascade_name)
               in
               ignore
                 (Cascade_runtime.refresh_local_discovery_if_possible

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -859,7 +859,8 @@ let fallback_cascade_for_provider_cooldown
 let provider_cooldown_remaining_sec_for_cascade
     ~(cascade_name : string) : int option =
   let model_ids =
-    Cascade_runtime.models_of_cascade_name cascade_name
+    Cascade_runtime.models_of_cascade_name
+      (Keeper_cascade_profile.Runtime_name cascade_name)
     |> Cascade_config.parse_model_strings
     |> List.map (fun (cfg : Llm_provider.Provider_config.t) ->
            String.trim cfg.model_id)

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -98,6 +98,7 @@ let run_named
     else Keeper_cascade_profile.normalize_declared_name cascade_name
   in
   let error_cascade_name = cascade_name_of_string cascade_name in
+  let runtime_cascade_name = Keeper_cascade_profile.Runtime_name cascade_name in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~keeper_name tools in
   let configured_labels_result, candidate_cfgs_result =
     match model_strings with
@@ -109,9 +110,10 @@ let run_named
           (resolve_providers_from_model_strings ?provider_filter
              ~require_tool_choice_support ~require_tool_support ms) )
     | _ ->
-      ( Cascade_runtime.models_of_cascade_name_result cascade_name,
+      ( Cascade_runtime.models_of_cascade_name_result runtime_cascade_name,
         resolve_cascade_providers ?provider_filter
-          ~require_tool_choice_support ~require_tool_support ~cascade_name ()
+          ~require_tool_choice_support ~require_tool_support
+          ~cascade_name:runtime_cascade_name ()
       )
   in
   (match configured_labels_result, candidate_cfgs_result with

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -9,7 +9,9 @@
 (* Cascade profile defaults (moved from Cascade module) *)
 
 let default_config_path = Cascade_runtime.cascade_config_path
-let default_model_strings = Cascade_runtime.default_model_strings
+let default_model_strings ~cascade_name =
+  Cascade_runtime.default_model_strings
+    ~cascade_name:(Keeper_cascade_profile.Runtime_name cascade_name)
 
 (* Named model execution *)
 

--- a/lib/oas_worker_named_cascade.mli
+++ b/lib/oas_worker_named_cascade.mli
@@ -39,7 +39,7 @@ val resolve_cascade_providers :
   ?require_tool_choice_support:bool ->
   ?require_tool_support:bool ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
-  cascade_name:string -> unit ->
+  cascade_name:Keeper_cascade_profile.runtime_name -> unit ->
   (Llm_provider.Provider_config.t list, string) result
 (** Resolve cascade provider configs via MASC Cascade_config. *)
 

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -116,7 +116,10 @@ let keeper_runtime_identity_fields (meta : Keeper_types.keeper_meta) =
     Keeper_cascade_profile.resolve_live meta.cascade_name
   in
   let primary_model =
-    match Cascade_runtime.models_of_cascade_name effective_cascade with
+    match
+      Cascade_runtime.models_of_cascade_name
+        (Keeper_cascade_profile.Runtime_name effective_cascade)
+    with
     | model :: _ -> Some model
     | [] -> None
   in

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1386,8 +1386,9 @@ let handle_keeper_get_subroutes state req request reqd =
             Keeper_cascade_routing.select_cascade
               ~base_cascade:m.cascade_name ~phase:current
           in
-          let models = Cascade_runtime.models_of_cascade_name
-            routing.effective_cascade
+          let models =
+            Cascade_runtime.models_of_cascade_name
+              (Keeper_cascade_profile.Runtime_name routing.effective_cascade)
           in
           let last_model = m.runtime.usage.last_model_used in
           let last_provider_result =
@@ -1430,7 +1431,7 @@ let handle_keeper_get_subroutes state req request reqd =
         match meta with
         | Ok (Some m) ->
           Cascade_runtime.models_of_cascade_name
-            m.cascade_name
+            (Keeper_cascade_profile.Runtime_name m.cascade_name)
         | _ -> ["(unknown)"]
       in
       let last_provider =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -685,7 +685,8 @@ let audit_provider_mcp_config_paths (_state : Mcp_server.server_state) =
       List.concat_map
         (fun name ->
           try
-            Cascade_runtime.models_of_cascade_name name
+            Cascade_runtime.models_of_cascade_name
+              (Keeper_cascade_profile.Runtime_name name)
             |> List.filter_map Cascade_runtime.provider_name_of_label
           with exn ->
             Log.Misc.warn

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -480,7 +480,10 @@ let resolve_keeper_meta ctx args =
 let default_keeper_model_label (meta : keeper_meta) =
   match String.trim meta.runtime.usage.last_model_used with
   | "" -> (
-      match Cascade_runtime.models_of_cascade_name meta.cascade_name with
+      match
+        Cascade_runtime.models_of_cascade_name
+          (Keeper_cascade_profile.Runtime_name meta.cascade_name)
+      with
       | first :: _ when String.trim first <> "" -> first
       | _ -> Env_config.Local_runtime.default_model)
   | model -> model

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -471,10 +471,12 @@ let test_legacy_runtime_wrapper_does_not_fallback_to_defaults () =
   ignore (Cascade_catalog_runtime.inspect_active ());
   check (list string) "legacy wrapper still resolves known profile"
     [ valid_model ]
-    (Cascade_runtime.models_of_cascade_name Keeper_config.default_cascade_name);
+    (Cascade_runtime.models_of_cascade_name
+       (Keeper_cascade_profile.Runtime_name Keeper_config.default_cascade_name));
   check (list string) "unknown profile no longer falls back to defaults"
     []
-    (Cascade_runtime.models_of_cascade_name "missing_profile")
+    (Cascade_runtime.models_of_cascade_name
+       (Keeper_cascade_profile.Runtime_name "missing_profile"))
 
 let test_legacy_runtime_wrapper_preserves_configured_label_order () =
   with_temp_dir "cascade-runtime-order" @@ fun dir ->
@@ -505,7 +507,9 @@ let test_legacy_runtime_wrapper_preserves_configured_label_order () =
   ignore (Cascade_catalog_runtime.inspect_active ~sw ~net ~clock ());
   let observed_orders =
     List.init 8 (fun _ ->
-        Cascade_runtime.models_of_cascade_name Keeper_config.default_cascade_name)
+        Cascade_runtime.models_of_cascade_name
+          (Keeper_cascade_profile.Runtime_name
+             Keeper_config.default_cascade_name))
   in
   check (list string) "legacy wrapper keeps configured order" expected
     (List.hd observed_orders);

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1965,7 +1965,8 @@ proactive_enabled = true
        |> to_string);
       let expected_default_models =
         Masc_mcp.Cascade_runtime.models_of_cascade_name
-          Masc_mcp.Keeper_config.default_cascade_name
+          (Masc_mcp.Keeper_cascade_profile.Runtime_name
+             Masc_mcp.Keeper_config.default_cascade_name)
       in
       Alcotest.(check (list string)) "selected cascade models use default profile"
         expected_default_models


### PR DESCRIPTION
## Summary
- type `Cascade_runtime` named cascade lookup APIs with `Keeper_cascade_profile.runtime_name`
- keep public/OAS string entry points as boundary wrappers that construct runtime cascade names
- render back to strings only at catalog lookup/log/dashboard boundaries

## Why it matters
- continues #11926 C-T7 cascade-name sweep by moving the internal runtime lookup path off raw `cascade_name:string`
- preserves existing wire/API behavior for `Oas_worker` callers while making the next internal consumers type-check against runtime cascade names

## Review focus
- `Cascade_runtime` API shape and string rendering boundary
- public facade compatibility in `Oas_worker_named_cascade.default_model_strings`
- caller wrapping sites that intentionally preserve raw configured names with `Runtime_name`

## Evidence
- `git diff --check HEAD~1 HEAD`
- `scripts/stringly-boundary-ratchet.sh` -> `raw_cascade_name_string_signatures 31 / 81`
- `scripts/ocaml-structure-ratchet.sh`
- plain-main focused build attempt is currently blocked by the current-main type errors tracked in #12399
- verified in a temporary worktree with #12399 merged:
  - `scripts/dune-local.sh build test/test_cascade_catalog_runtime.exe test/test_oas_worker.exe test/test_operator_control.exe test/test_dashboard_keeper_routes.exe test/test_dashboard_execution.exe test/test_keeper_unified.exe`
  - `./_build/default/test/test_cascade_catalog_runtime.exe test runtime 5-6`
  - `./_build/default/test/test_oas_worker.exe test cascade_config 0-5`

## Notes
- A broader `test_cascade_catalog_runtime.exe test runtime 5-13` run still hits existing provider-capability expectation drift at runtime case 11, which calls `Cascade_catalog_runtime.resolve_named_providers` directly and is not part of this slice.

Part of #11926.
