### PR TITLE
fix(keeper): escape XML entities in persona and goals prompt blocks

### DIFF
--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -185,3 +185,14 @@ let to_string = function
 let was_truncated = function
   | Untouched _ -> false
   | Truncated _ -> true
+
+(* XML 1.0 entity escape.  Order matters: [&] first so that the
+   ampersands introduced by the other replacements are not
+   double-escaped. *)
+let escape_xml s =
+  s
+  |> replace_substring ~needle:"&" ~by:"&amp;"
+  |> replace_substring ~needle:"<" ~by:"&lt;"
+  |> replace_substring ~needle:">" ~by:"&gt;"
+  |> replace_substring ~needle:"\"" ~by:"&quot;"
+  |> replace_substring ~needle:"'" ~by:"&apos;"

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -68,3 +68,8 @@ val to_string : truncation -> string
 
 val was_truncated : truncation -> bool
 (** [true] iff the argument is the [Truncated] constructor. *)
+
+val escape_xml : string -> string
+(** Escape the five XML 1.0 predefined entities: ampersand,
+    less-than, greater-than, double-quote, and apostrophe.
+    Order is safe for round-trip use: ampersand is replaced first. *)

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -114,7 +114,7 @@ let build_keeper_system_prompt
       |> Re.replace_string re_keeper_name_upper ~by:keeper_name
   in
   let persona_block =
-    let s = String.trim persona_extended in
+    let s = String_util.escape_xml (String.trim persona_extended) in
     if s = "" then ""
     else Printf.sprintf "<persona>\n%s\n</persona>\n\n" s
   in
@@ -125,7 +125,10 @@ let build_keeper_system_prompt
         let lines =
           List.map
             (fun (id, title, horizon) ->
-               Printf.sprintf "- %s [%s] %s" id horizon title)
+               Printf.sprintf "- %s [%s] %s"
+                 (String_util.escape_xml id)
+                 (String_util.escape_xml horizon)
+                 (String_util.escape_xml title))
             goals
         in
         Printf.sprintf "\n<available_goals>\n%s\n</available_goals>\n"

--- a/test/test_string_util.ml
+++ b/test/test_string_util.ml
@@ -246,6 +246,31 @@ let test_equals_ci_basic () =
   check bool "empty equals empty" true (SU.equals_ci "" "");
   check bool "empty vs non-empty" false (SU.equals_ci "" "x")
 
+(* ---- escape_xml ---- *)
+
+let test_escape_xml_all_entities () =
+  check string "all five"
+    "a &amp; b &lt; c &gt; d &quot;e&quot; &apos;f&apos;"
+    (SU.escape_xml "a & b < c > d \"e\" 'f'")
+
+let test_escape_xml_no_op () =
+  check string "clean string" "hello world"
+    (SU.escape_xml "hello world")
+
+let test_escape_xml_empty () =
+  check string "empty" "" (SU.escape_xml "")
+
+let test_escape_xml_ampersand_first () =
+  (* [&] must be replaced first so that [&lt;] does not become
+     [&amp;lt;] — wait, actually [&lt;] input should become [&amp;lt;]
+     because the [&] is escaped.  The important thing is that
+     a plain [<] becomes [&lt;], not double-escaped. *)
+  check string "pre-escaped ampersand"
+    "&amp;lt;" (SU.escape_xml "&lt;")
+
+let test_escape_xml_no_double_escape () =
+  (* A string with only [<] should become [&lt;], not [&amp;lt;]. *)
+  check string "plain less-than" "&lt;" (SU.escape_xml "<")
 
 (* ---- Test runner ---- *)
 
@@ -292,4 +317,12 @@ let () =
         [ test_case "basic" `Quick test_starts_with_ci_basic;
           test_case "boundaries" `Quick test_starts_with_ci_boundaries ] );
       ( "equals_ci",
-        [ test_case "basic" `Quick test_equals_ci_basic ] ) ]
+        [ test_case "basic" `Quick test_equals_ci_basic ] );
+      ( "escape_xml",
+        [ test_case "all entities" `Quick test_escape_xml_all_entities;
+          test_case "no-op clean" `Quick test_escape_xml_no_op;
+          test_case "empty" `Quick test_escape_xml_empty;
+          test_case "ampersand first ordering" `Quick
+            test_escape_xml_ampersand_first;
+          test_case "no double escape" `Quick
+            test_escape_xml_no_double_escape ] ) ]


### PR DESCRIPTION
## Summary
- Add `String_util.escape_xml` for the five XML 1.0 predefined entities.
- Apply escaping to `persona_extended` and goal fields (`id`, `title`, `horizon`) before injecting them into `<persona>` and `<available_goals>` tags.

## Why
User-supplied persona text or goal metadata containing `<`, `>`, `&`, or quotes can break the pseudo-XML prompt structure or be misinterpreted by the LLM as markup. This is a concrete fix from the security audit (unescaped injection into XML-like blocks).

## Files changed
- `lib/core/string_util.ml` / `.mli` — new `escape_xml` utility
- `lib/keeper/keeper_prompt.ml` — apply escaping to persona and goal fields

## Test plan
- [x] `dune build --root .` passes in worktree
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)