### PR TITLE
feat(keeper): wakeup_keeper learns ?stimulus → enqueue_event (PR-C1)

### DIFF
--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -17,8 +17,14 @@ val set_grpc_client : ?env:Eio_unix.Stdenv.base -> Masc_grpc_client.t -> unit
 val process_directive : agent_name:string -> string -> unit
 
 (** Wake up a specific keeper immediately. Used by broadcast notification
-    when a @mention targets a running keeper. *)
-val wakeup_keeper : ?base_path:string -> string -> unit
+    when a @mention targets a running keeper.
+
+    [?stimulus] appends the payload to the keeper's Event Layer queue
+    before flipping the wakeup flag. See RFC-0020 §3. *)
+val wakeup_keeper :
+  ?base_path:string ->
+  ?stimulus:Keeper_event_queue.stimulus ->
+  string -> unit
 
 (** Wake up all running keepers. Used for @@all broadcast mentions
     or system-wide events. *)

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -120,12 +120,24 @@ let interruptible_sleep ~clock ~stop ~wakeup duration : sleep_outcome =
 
 (** Wake up a specific keeper immediately, causing it to skip the rest of
     its sleep and run the next heartbeat cycle. Used by broadcast notification
-    when a @mention targets a running keeper. *)
-let wakeup_keeper ?base_path name =
+    when a @mention targets a running keeper.
+
+    When [?stimulus] is provided, the stimulus is appended to the keeper's
+    Event Layer queue ([Keeper_registry.enqueue_event]) before the wakeup
+    flag flips. This is RFC-0020 Rule 1 (enqueue is independent of policy)
+    + the data-channel half of the layer split — [fiber_wakeup] remains the
+    hint signal, the queue is the authoritative payload. *)
+let wakeup_keeper ?base_path ?stimulus name =
   Keeper_registry.all ?base_path ()
   |> List.iter (fun (entry : Keeper_registry.registry_entry) ->
     if String.equal entry.name name && entry.phase = Keeper_state_machine.Running
-    then Keeper_registry.wakeup ~base_path:entry.base_path name)
+    then begin
+      Option.iter
+        (fun s ->
+          Keeper_registry.enqueue_event ~base_path:entry.base_path name s)
+        stimulus;
+      Keeper_registry.wakeup ~base_path:entry.base_path name
+    end)
 ;;
 
 (** Wake up all running keepers — used when a broadcast mentions @@all

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -37,8 +37,18 @@ val interruptible_sleep :
   clock:'a Eio.Time.clock -> stop:bool Atomic.t -> wakeup:bool Atomic.t ->
   float -> sleep_outcome
 
-(** Wake up a specific keeper immediately. *)
-val wakeup_keeper : ?base_path:string -> string -> unit
+(** Wake up a specific keeper immediately.
+
+    When [?stimulus] is given, the stimulus is appended to the keeper's
+    Event Layer queue ([Keeper_registry.enqueue_event]) before the wakeup
+    flag flips. Callers that have a real payload (board post, mention,
+    operator directive) should pass it; callers that only need to break
+    the keeper out of [interruptible_sleep] may omit it and the call
+    behaves as before. See RFC-0020 §3 (data channel vs hint signal). *)
+val wakeup_keeper :
+  ?base_path:string ->
+  ?stimulus:Keeper_event_queue.stimulus ->
+  string -> unit
 
 (** Wake up all running keepers. [None] preserves legacy global wakeup. *)
 val wakeup_all_keepers : ?base_path:string -> unit -> unit


### PR DESCRIPTION
## Summary

**PR-C1** of the Event Layer / Policy Layer separation (RFC-0020).

Adds an optional `?stimulus : Keeper_event_queue.stimulus` argument to `Keeper_keepalive_signal.wakeup_keeper`. When provided, the stimulus is appended to the keeper's Event Layer queue (via `Keeper_registry.enqueue_event`, landed in #12403) before `fiber_wakeup` flips. When omitted, the call behaves exactly as before — a hint signal with no payload.

This is the **data-write half** of RFC-0020 §3.

## Diff

```ocaml
(* before *)
val wakeup_keeper : ?base_path:string -> string -> unit

(* after *)
val wakeup_keeper :
  ?base_path:string ->
  ?stimulus:Keeper_event_queue.stimulus ->
  string -> unit
```

Body change is also small — `Option.iter` over the new arg before the existing `Keeper_registry.wakeup` call. Backwards-compatible because `?stimulus` is optional and existing callers omit it.

## Files changed

| File | Change |
|---|---|
| `lib/keeper/keeper_keepalive_signal.ml` | `wakeup_keeper` body: `Option.iter (Keeper_registry.enqueue_event) stimulus` before `Keeper_registry.wakeup` |
| `lib/keeper/keeper_keepalive_signal.mli` | New optional arg `?stimulus` |
| `lib/keeper/keeper_keepalive.mli` | mli cascade — `keeper_keepalive.mli` re-exports `wakeup_keeper`, so its signature is updated to match |

3 files, +35 / -7.

## What this PR is *not*

- **Not** rewiring `Heartbeat_smart.should_emit` (PR-C2).
- **Not** the per-turn `dequeue` at the unified turn entry (PR-C3).
- **Not** a behaviour change for any existing caller.

The corresponding Policy Layer changes (caller consults queue first per RFC-0020 *Rule 2*, turn dequeues stimulus per *Rule 4*) land as separate PRs so the data and policy halves can fail or land independently — RFC-0020 §6 PR plan.

## Verification

- [x] `dune build --root . lib/` — exit 0 with new optional argument.
- [x] mli cascade discovered by build (`keeper_keepalive.mli` re-export) and synced.
- [ ] CI Build/Test full pipeline.
- [ ] Smoke: existing wakeup paths (broadcast notification, board-reactive wakeup) compile + behave unchanged.

## Layer plan (RFC-0020 §6)

| PR | Scope | Status |
|---|---|---|
| #12386 | TLA+ spec | ✅ Merged |
| #12396 | Library + property tests | ✅ Merged |
| #12403 | Registry data field + API | ✅ Merged |
| #12409 | RFC-0020 architecture document | ✅ Merged |
| **this PR (PR-C1)** | **`wakeup_keeper` enqueue path** | **Draft** |
| PR-C2 (planned) | `run_smart_heartbeat_gate` queue-non-empty override | — |
| PR-C3 (planned) | per-turn `dequeue` at unified turn entry | — |

## Test plan

- [x] Local lib build green.
- [ ] CI green.
- [ ] Smoke: keeper register → wakeup w/ stimulus → `event_queue_snapshot` shows the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)