### PR TITLE
feat(keeper): heartbeat gate honours queue-non-empty override (PR-C2)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -690,6 +690,7 @@ let cycle_continues_after_wake
 ;;
 
 let run_smart_heartbeat_gate
+      ~(base_path : string)
       ~(clock : _ Eio.Time.clock)
       ~(stop : bool Atomic.t)
       ~(wakeup : bool Atomic.t)
@@ -710,6 +711,22 @@ let run_smart_heartbeat_gate
         ~last_activity:!last_successful_heartbeat_ts
         ~last_heartbeat:!last_heartbeat_cycle_ts)
     else Heartbeat_smart.Emit
+  in
+  (* RFC-0020 Rule 2: the Event Layer queue overrides the Smart Heartbeat
+     policy. When the queue holds an unprocessed stimulus, force [Emit]
+     regardless of the busy/idle decision so the next cycle consumes the
+     stimulus on time. Pinned by KeeperEventQueue.tla
+     QueueNeverStarvedBySkip invariant. *)
+  let smart_hb_decision =
+    if Heartbeat_smart.should_emit_now smart_hb_decision
+    then smart_hb_decision
+    else (
+      let queue =
+        Keeper_registry.event_queue_snapshot ~base_path meta_current.name
+      in
+      if Keeper_event_queue.is_empty queue
+      then smart_hb_decision
+      else Heartbeat_smart.Emit)
   in
   (* Run side-effects (idle sleep, cycle-timestamp update) per the
      decision, then delegate the gate answer to [cycle_continues_after_wake]
@@ -946,6 +963,7 @@ let run_heartbeat_loop
           ~base_path:ctx.config.base_path meta_current.name meta_current;
       if
         run_smart_heartbeat_gate
+          ~base_path:ctx.config.base_path
           ~clock:ctx.clock
           ~stop
           ~wakeup

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -117,6 +117,7 @@ val cycle_continues_after_wake :
   Heartbeat_smart.decision -> Keeper_keepalive_signal.sleep_outcome -> bool
 
 val run_smart_heartbeat_gate :
+  base_path:string ->
   clock:'a Eio.Time.clock ->
   stop:bool Atomic.t ->
   wakeup:bool Atomic.t ->


### PR DESCRIPTION
## Summary

**PR-C2** of the Event Layer / Policy Layer separation (RFC-0020).

Adds **RFC-0020 Rule 2** to `run_smart_heartbeat_gate`: when the keeper's Event Layer queue holds an unprocessed stimulus, the gate forces `Heartbeat_smart.Emit` regardless of the busy/idle decision the smart heartbeat returned.

This pins `KeeperEventQueue.tla` `QueueNeverStarvedBySkip` invariant in the runtime — once a stimulus enters the queue, no policy decision can settle on `Skip` until the stimulus is consumed. The buggy spec `TickStarvesQueue` is now provably unreachable.

## Decision flow

```
smart_decision := Heartbeat_smart.should_emit (...)

if Heartbeat_smart.should_emit_now smart_decision   (* Emit *)
  then keep smart_decision

else
  if Keeper_event_queue.is_empty (snapshot ~base_path name)
    then keep smart_decision                         (* honest skip *)

    else override to Heartbeat_smart.Emit            (* Rule 2 *)
```

Two-stage monotone: Smart Heartbeat decides first, the queue overrides only when needed. Behaviour change is *strictly an addition* — every previously-Emit decision still emits.

## Files changed

| File | Change |
|---|---|
| `lib/keeper/keeper_heartbeat_loop.ml` | `run_smart_heartbeat_gate` gains `~base_path:string`, body adds queue-snapshot override (+18 lines). Single caller (`keeper_heartbeat_loop.ml:965`) passes `ctx.config.base_path`. |
| `lib/keeper/keeper_heartbeat_loop.mli` | Signature sync (+1 line) |

2 files, +19/-0.

## Independence from PR-C1

Despite the name, **PR-C2 does not depend on PR-C1**. PR-C2 only *reads* the queue (`event_queue_snapshot`), the API for which is on `main` since #12403 (PR-B1). The *write* half (`wakeup_keeper ?stimulus → enqueue_event`) lives in PR-C1 (#12411).

This is RFC-0020 §6: *"PR-C1, C2, C3 may be reviewed in any order because each compiles independently"* — both PRs build cleanly on `main` without each other.

## Verification

- [x] `dune build --root . lib/` — exit 0
- [x] Sweep: `run_smart_heartbeat_gate` callers — 1 caller, updated. Other matches are docstring references only (no functional callers in `prometheus.ml` / `test/test_smart_heartbeat_keepalive.ml`).
- [ ] CI Build/Test full pipeline.
- [ ] Smoke: existing heartbeat decisions (Emit / Skip_busy / Skip_idle) keep their behaviour when queue is empty.

## TLA+ correspondence

After this PR, the runtime maps to `KeeperEventQueue.tla` action `TickQueueOverride`: when `queue_size > 0`, `smart_decision'` is forced to `"emit"`. The *clean* spec includes this transition; the *buggy* spec's `TickStarvesQueue` (`smart_decision := "skip"` while `queue_size > 0`) cannot fire because the runtime now refuses it.

## Layer plan (RFC-0020 §6)

| PR | Scope | Status |
|---|---|---|
| #12386 | TLA+ spec | ✅ Merged |
| #12396 | Library + property tests | ✅ Merged |
| #12403 | Registry data field + API | ✅ Merged |
| #12409 | RFC-0020 architecture document | ✅ Merged |
| #12411 | PR-C1: `wakeup_keeper ?stimulus` enqueue path | ⏸ Draft |
| **this PR (PR-C2)** | **Heartbeat gate Rule 2 override** | **Draft** |
| PR-C3 (planned) | per-turn `dequeue` at unified turn entry | — |

## Test plan

- [x] Local lib build green.
- [ ] CI green.
- [ ] Smoke: stimulus enqueue → next heartbeat → emit overrides Skip_busy/Skip_idle.
- [ ] Future integration test in PR-C3 once the dequeue path is also wired (full round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)