### PR TITLE
feat(keeper): add Keeper_registry.dequeue_event API (PR-B2)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1367,3 +1367,18 @@ let event_queue_snapshot ~base_path name =
   match get ~base_path name with
   | None -> Keeper_event_queue.empty
   | Some entry -> Atomic.get entry.event_queue
+
+let dequeue_event ~base_path name =
+  match get ~base_path name with
+  | None -> None
+  | Some entry ->
+      let rec loop () =
+        let cur = Atomic.get entry.event_queue in
+        match Keeper_event_queue.dequeue cur with
+        | None -> None
+        | Some (stim, rest) ->
+            if Atomic.compare_and_set entry.event_queue cur rest
+            then Some stim
+            else loop ()
+      in
+      loop ()

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -519,3 +519,17 @@ val enqueue_event :
     when the keeper is missing. Read-only — does not consume stimuli. *)
 val event_queue_snapshot :
   base_path:string -> string -> Keeper_event_queue.t
+
+(** Consume at most one stimulus from the keeper's Event Layer queue.
+
+    Returns [Some stim] when the queue had work (and the stimulus is
+    removed from the queue), [None] when the queue is empty or the
+    keeper is not registered. Lock-free CAS retry on
+    [entry.event_queue]; concurrent callers do not block.
+
+    The Policy Layer (turn entry) calls this once per [Emit] tick to
+    drain one stimulus per turn. See RFC-0020 §3 (Rule 4: per-turn
+    dequeue) and KeeperEventQueue.tla Conservation invariant
+    ([dequeued_total <= enqueued_total]). *)
+val dequeue_event :
+  base_path:string -> string -> Keeper_event_queue.stimulus option

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -47,6 +47,10 @@ let make_meta name =
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
 
+let make_stimulus ?(urgency = Masc_mcp.Keeper_event_queue.Normal)
+    ?(arrived_at = 0.0) post_id payload =
+  Masc_mcp.Keeper_event_queue.{ post_id; urgency; arrived_at; payload }
+
 let test_bonsai_keepers_summary_uses_scoped_registry () =
   let base_path = temp_base_path "bonsai-summary" in
   let other_base_path = temp_base_path "bonsai-summary-other" in
@@ -633,6 +637,54 @@ let test_register_replaces () =
   | None -> fail "expected dup"
   | Some e ->
     check int "restart count reset" 0 e.restart_count
+
+let test_dequeue_event_consumes_fifo () =
+  R.clear ();
+  let keeper_name = "dequeue-fifo" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  let s1 = make_stimulus "post-1" "first" in
+  let s2 =
+    make_stimulus ~urgency:Masc_mcp.Keeper_event_queue.Immediate "post-2"
+      "second"
+  in
+  R.enqueue_event ~base_path:bp keeper_name s1;
+  R.enqueue_event ~base_path:bp keeper_name s2;
+  check int "queued before dequeue" 2
+    (Masc_mcp.Keeper_event_queue.length
+       (R.event_queue_snapshot ~base_path:bp keeper_name));
+  (match R.dequeue_event ~base_path:bp keeper_name with
+   | Some stim ->
+       check string "first post id" "post-1" stim.post_id;
+       check string "first payload" "first" stim.payload
+   | None -> fail "expected first stimulus");
+  check int "one queued after first dequeue" 1
+    (Masc_mcp.Keeper_event_queue.length
+       (R.event_queue_snapshot ~base_path:bp keeper_name));
+  (match R.dequeue_event ~base_path:bp keeper_name with
+   | Some stim ->
+       check string "second post id" "post-2" stim.post_id;
+       check string "second payload" "second" stim.payload
+   | None -> fail "expected second stimulus");
+  check bool "empty after drain" true
+    (Masc_mcp.Keeper_event_queue.is_empty
+       (R.event_queue_snapshot ~base_path:bp keeper_name));
+  check bool "dequeue empty returns None" true
+    (Option.is_none (R.dequeue_event ~base_path:bp keeper_name))
+
+let test_dequeue_event_respects_base_path_and_missing_keeper () =
+  R.clear ();
+  let name = "dequeue-scope" in
+  let other_bp = "/tmp/test-dequeue-scope-other" in
+  ignore (R.register ~base_path:bp name (make_meta name));
+  ignore (R.register ~base_path:other_bp name (make_meta name));
+  R.enqueue_event ~base_path:bp name (make_stimulus "scoped" "payload");
+  check bool "missing keeper returns None" true
+    (Option.is_none (R.dequeue_event ~base_path:bp "missing-dequeue"));
+  check bool "other base path stays empty" true
+    (Option.is_none (R.dequeue_event ~base_path:other_bp name));
+  match R.dequeue_event ~base_path:bp name with
+  | Some stim -> check string "scoped payload" "payload" stim.payload
+  | None -> fail "expected scoped stimulus"
 
 (* ── New fields: grpc_close, crash_log, wakeup, fiber_health ── *)
 
@@ -1251,6 +1303,10 @@ let () =
           eio_test "get returns None for missing" test_get_returns_none_for_missing;
           eio_test "noop on missing keys" test_noop_on_missing;
           eio_test "register replaces existing" test_register_replaces;
+          eio_test "dequeue event consumes FIFO"
+            test_dequeue_event_consumes_fifo;
+          eio_test "dequeue event respects base path and missing keeper"
+            test_dequeue_event_respects_base_path_and_missing_keeper;
         ] );
       ( "extended",
         [


### PR DESCRIPTION
## Summary

**PR-B2** of the Event Layer / Policy Layer separation (RFC-0020).

Adds the consumer-side counterpart to `enqueue_event` (#12403):

```ocaml
val dequeue_event :
  base_path:string -> string -> Keeper_event_queue.stimulus option
```

Lock-free CAS retry on `entry.event_queue`, mirroring the existing `enqueue_event` pattern. Returns `Some stim` when work was consumed, `None` when the queue is empty or the keeper is not registered.

This PR also covers the registry-level behavior with focused tests: FIFO consumption, snapshot depth after dequeue, empty/missing keeper `None`, and base-path isolation.

## Why a separate PR

The dequeue API is required by RFC-0020 §3 *Rule 4* (per-turn dequeue at the unified turn entry). The Policy Layer (heartbeat / unified turn) will call it once per `Emit` tick to drain at most one stimulus per turn.

We split this off from PR-C3 (which uses the API) so the registry data layer change stays alone, in line with RFC-0020 §6 *"each PR responsible for one layer transition"*.

## Files changed

| File | Change |
|---|---|
| `lib/keeper/keeper_registry.ml` | `dequeue_event` body — CAS retry that mirrors `enqueue_event` |
| `lib/keeper/keeper_registry.mli` | Public signature + docstring |
| `test/test_keeper_registry.ml` | Registry-level dequeue coverage |

## Layer plan (RFC-0020 §6)

| PR | Scope | Status |
|---|---|---|
| #12386 | TLA+ spec | ✅ Merged |
| #12396 | Library + property tests | ✅ Merged |
| #12403 (PR-B1) | `event_queue` field + `enqueue_event` + `snapshot` | ✅ Merged |
| #12409 | RFC-0020 architecture | ✅ Merged |
| #12411 (PR-C1) | `wakeup_keeper ?stimulus` enqueue path | ⏸ Draft |
| #12412 (PR-C2) | Heartbeat gate Rule 2 override | ⏸ Draft |
| **this PR (PR-B2)** | **`dequeue_event` API** | **Draft** |
| PR-C3 (planned) | Turn entry calls `dequeue_event` + telemetry | — |

PR-B2 is independent of PR-C1/C2 — it only adds the API and registry-level tests. PR-C3 will be the first runtime consumer.

## Verification

- [x] `git diff --check`
- [x] `scripts/dune-local.sh build test/test_keeper_registry.exe`
- [x] `./_build/default/test/test_keeper_registry.exe`
- [ ] CI green.
- [ ] Future integration test in PR-C3 once `run_keepalive_unified_turn` calls `dequeue_event`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)