### PR TITLE
feat(keeper): log Event Layer queue depth at turn entry (PR-C3a)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -320,6 +320,23 @@ let run_keepalive_unified_turn
   then meta_after_triage
   else (
     try
+      (* RFC-0020 §3 telemetry — log Event Layer queue depth at turn
+         entry. The queue itself is not consumed here (per-turn
+         [Keeper_event_queue.dequeue] lands once [Keeper_registry.dequeue_event]
+         is on main, see PR-B2). Reading the depth alone is enough to
+         confirm the layer split is observable in production: a non-zero
+         depth here pairs with the [TickQueueOverride] action in
+         [KeeperEventQueue.tla]. *)
+      let event_queue_depth =
+        Keeper_event_queue.length
+          (Keeper_registry.event_queue_snapshot
+             ~base_path:ctx.config.base_path
+             meta_after_triage.name)
+      in
+      if event_queue_depth > 0 then
+        Log.Keeper.debug
+          "turn entry: event_queue depth=%d (keeper=%s)"
+          event_queue_depth meta_after_triage.name;
       let obs =
         let allowed_tool_names =
           Keeper_tool_policy.keeper_allowed_tool_names meta_after_triage


### PR DESCRIPTION
## Summary

**PR-C3a** of the Event Layer / Policy Layer separation (RFC-0020).

Adds zero-noise telemetry at the start of `run_keepalive_unified_turn`:

```ocaml
let event_queue_depth =
  Keeper_event_queue.length
    (Keeper_registry.event_queue_snapshot
       ~base_path:ctx.config.base_path
       meta_after_triage.name)
in
if event_queue_depth > 0 then
  Log.Keeper.debug
    "turn entry: event_queue depth=%d (keeper=%s)"
    event_queue_depth meta_after_triage.name;
```

The queue itself is **not** consumed here — only its depth is observed for telemetry.

## Why telemetry-first, consume-later

RFC-0020 §3 *Rule 4* (per-turn dequeue) ultimately requires `Keeper_event_queue.dequeue` at the turn entry. That implementation has two halves:

1. **observability** — does the queue ever fill at all? does the entry path see non-empty queues? (this PR)
2. **consumption** — drain one stimulus per turn (PR-C3b, depends on `Keeper_registry.dequeue_event` from PR-B2 #12413)

Splitting them lets the observability land before `dequeue_event` API is on `main`. Production gets visibility immediately — a non-zero depth at turn entry pairs with the `TickQueueOverride` action in `KeeperEventQueue.tla` and confirms the layer split is *actually working* (PR-C1 enqueue + PR-C2 heartbeat override interaction).

This is *evidence-first* in the RUTHLESS_JUDGMENT spirit: see the queue fill before claiming the system honours it.

## Files changed

| File | Change |
|---|---|
| `lib/keeper/keeper_heartbeat_loop.ml` | `run_keepalive_unified_turn` reads queue depth at entry, logs only when non-zero (+17 lines, no behaviour change) |

1 file, +17/-0.

## Independence

- Builds on `main` directly. Uses `Keeper_registry.event_queue_snapshot` (PR-B1, already merged in #12403).
- **Does not** depend on PR-B2 #12413 (`dequeue_event`) — that's PR-C3b's prerequisite, not this PR's.
- **Does not** depend on PR-C2 #12412 (heartbeat override) — though the two interact: PR-C2 makes the queue *visible* (forces emit), this PR makes it *audible* (logs the depth). Either order is fine.

## Verification

- [x] `dune build --root . lib/` — exit 0
- [x] Zero-noise: log line only fires when depth > 0, so existing keepers (no enqueue callers yet) emit nothing extra.
- [ ] CI Build/Test full pipeline.
- [ ] Smoke: enqueue a stimulus → next turn entry → log shows depth=1.

## Layer plan (RFC-0020 §6)

| PR | Scope | Status |
|---|---|---|
| #12386 | TLA+ spec | ✅ Merged |
| #12396 | Library + property tests | ✅ Merged |
| #12403 (PR-B1) | event_queue field + enqueue_event + snapshot | ✅ Merged |
| #12409 | RFC-0020 architecture | ✅ Merged |
| #12411 (PR-C1) | wakeup_keeper ?stimulus | ✅ Merged |
| #12412 (PR-C2) | heartbeat gate Rule 2 override | ⏸ Draft (CLEAN, mergeable) |
| #12413 (PR-B2) | dequeue_event API | ⏸ Draft |
| **this PR (PR-C3a)** | **turn entry queue-depth telemetry** | **Draft** |
| PR-C3b (planned) | turn entry calls `dequeue_event` (consume) | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)