### PR TITLE
feat(q1): Quadrant 1 Quick Wins bundle

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -194,6 +194,26 @@ export function fetchDashboardConfig(): Promise<DashboardConfigResponse> {
   return get('/api/v1/dashboard/config')
 }
 
+/** Parse runtime context-ratio thresholds from the dashboard config response.
+    Falls back to the compiled defaults when keys are missing or malformed. */
+export function parseContextThresholds(
+  data: DashboardConfigResponse,
+  defaults: { critical: number; warn: number; compacting: number },
+): { critical: number; warn: number; compacting: number } {
+  const cat = data.categories.dashboard ?? []
+  const find = (env: string): number | null => {
+    const entry = cat.find(e => e.env === env)
+    if (!entry || entry.value == null) return null
+    const n = parseFloat(entry.value)
+    return Number.isFinite(n) ? n : null
+  }
+  return {
+    critical: find('MASC_DASHBOARD_CTX_HANDOFF_IMMINENT') ?? defaults.critical,
+    warn: find('MASC_DASHBOARD_CTX_PREPARING') ?? defaults.warn,
+    compacting: find('MASC_DASHBOARD_CTX_COMPACTING') ?? defaults.compacting,
+  }
+}
+
 export function fetchDashboardNamespaceTruth(opts?: AbortableRequestOptions): Promise<DashboardNamespaceTruthResponse> {
   return get('/api/v1/dashboard/project-snapshot', {
     timeoutMs: NAMESPACE_TRUTH_GET_TIMEOUT_MS,

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -20,6 +20,9 @@ import { refreshShell } from './store'
 import { connectDashboardWS, disconnectDashboardWS, subscribeDashboardRoute } from './dashboard-ws'
 import { dashboardWsOnlyEnabled } from './dashboard-ws-cutover'
 import { ensureDevToken } from './api/dev-token'
+import { fetchDashboardConfig, parseContextThresholds } from './api/dashboard'
+import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
+import { setContextThresholds } from './config/context-thresholds'
 import {
   BuildIdentityBadge,
   ConnectionStatus,
@@ -100,6 +103,21 @@ export function App() {
     // while the project snapshot warms heavier execution/command projections.
     void refreshShell({ light: true })
     requestNamespaceTruthNow()
+
+    // Fetch runtime thresholds so health-strip and lifecycle state use
+    // server-side config instead of compiled fallback defaults (P-DASH-07).
+    void fetchDashboardConfig()
+      .then(data => {
+        const thresholds = parseContextThresholds(data, {
+          critical: CONTEXT_RATIO_CRITICAL,
+          warn: CONTEXT_RATIO_WARN,
+          compacting: CONTEXT_RATIO_COMPACTING,
+        })
+        setContextThresholds(thresholds)
+      })
+      .catch(err => {
+        console.warn('[app] dashboard config fetch failed', err instanceof Error ? err.message : err)
+      })
 
     // Replay durable OAS state before opening the live SSE tail.
     pauseQueuedOasRuntimeIngress()

--- a/dashboard/src/components/live/keeper-health-strip.ts
+++ b/dashboard/src/components/live/keeper-health-strip.ts
@@ -2,12 +2,13 @@
 
 import { html } from 'htm/preact'
 import { keeperHealthSummary, type KeeperPressure } from '../../live-store'
-import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from '../../config/constants'
+import { contextThresholds } from '../../config/context-thresholds'
 
 function pressureColor(ratio: number): string {
-  if (ratio > CONTEXT_RATIO_CRITICAL) return 'bg-[var(--color-status-err)]'
-  if (ratio > CONTEXT_RATIO_WARN) return 'bg-[var(--color-status-warn)]'
-  if (ratio > CONTEXT_RATIO_COMPACTING) return 'bg-[var(--color-status-warn)]'
+  const t = contextThresholds.value
+  if (ratio > t.critical) return 'bg-[var(--color-status-err)]'
+  if (ratio > t.warn) return 'bg-[var(--color-status-warn)]'
+  if (ratio > t.compacting) return 'bg-[var(--color-status-warn)]'
   return 'bg-[var(--color-status-ok)]'
 }
 

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -32,9 +32,10 @@ export const PERIODIC_REFRESH_DEV_MS = 180_000
 export const PERIODIC_REFRESH_PROD_MS = 120_000
 export const TELEMETRY_AUTO_REFRESH_MS = 30_000
 
-// --- Context ratio thresholds ---
-// Lifecycle state thresholds (SSOT: lib/config/env_config_runtime.ml Dashboard module)
-// Env vars: MASC_DASHBOARD_CTX_HANDOFF_IMMINENT, MASC_DASHBOARD_CTX_PREPARING, MASC_DASHBOARD_CTX_COMPACTING
+// --- Context ratio thresholds (fallback defaults) ---
+// Runtime values come from /api/v1/dashboard/config (SSOT: lib/config/env_config_runtime.ml).
+// These constants are compiled fallbacks used before the config response arrives.
+// Consumers should read from config/context-thresholds.ts, not import these directly.
 export const CONTEXT_RATIO_CRITICAL = 0.85  // handoff-imminent
 export const CONTEXT_RATIO_WARN = 0.70      // preparing
 export const CONTEXT_RATIO_COMPACTING = 0.50 // compacting

--- a/dashboard/src/config/context-thresholds.ts
+++ b/dashboard/src/config/context-thresholds.ts
@@ -1,0 +1,25 @@
+// Runtime context-ratio thresholds — populated from /api/v1/dashboard/config.
+// Consumers should import from here; constants.ts values are fallback defaults only.
+
+import { signal, computed, type ReadonlySignal } from '@preact/signals'
+import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './constants'
+
+export interface ContextThresholds {
+  critical: number
+  warn: number
+  compacting: number
+}
+
+const _thresholds = signal<ContextThresholds>({
+  critical: CONTEXT_RATIO_CRITICAL,
+  warn: CONTEXT_RATIO_WARN,
+  compacting: CONTEXT_RATIO_COMPACTING,
+})
+
+/** Mutable ref for the writer (app.ts init).  Consumers read via `contextThresholds`. */
+export function setContextThresholds(next: ContextThresholds): void {
+  _thresholds.value = next
+}
+
+/** Readonly signal of the current runtime thresholds. */
+export const contextThresholds: ReadonlySignal<ContextThresholds> = computed(() => _thresholds.value)

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -11,7 +11,7 @@ import type {
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
 import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
-import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
+import { contextThresholds } from './config/context-thresholds'
 import { normalizeKeeperDiagnostic } from './keeper-state'
 
 /** Maps lowercase backend phase strings to PascalCase KeeperPhase values.
@@ -85,9 +85,10 @@ export function deriveLifecycleState(keeper: Keeper): KeeperLifecycleState {
   if (latest.is_handoff) return 'handoff-imminent'
   if (latest.is_compaction) return 'compacting'
   const ratio = latest.context_ratio
-  if (ratio > CONTEXT_RATIO_CRITICAL) return 'handoff-imminent'
-  if (ratio > CONTEXT_RATIO_WARN) return 'preparing'
-  if (ratio > CONTEXT_RATIO_COMPACTING) return 'compacting'
+  const thresholds = contextThresholds.value
+  if (ratio > thresholds.critical) return 'handoff-imminent'
+  if (ratio > thresholds.warn) return 'preparing'
+  if (ratio > thresholds.compacting) return 'compacting'
   return 'active'
 }
 

--- a/dashboard/src/live-store.ts
+++ b/dashboard/src/live-store.ts
@@ -6,7 +6,7 @@ import type { JournalEntry } from './types'
 import type { PipelineStage } from './types/core'
 import { journal } from './sse'
 import { agents, agentMotionMap, keepers, staleKeepers } from './store'
-import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN } from './config/constants'
+import { contextThresholds } from './config/context-thresholds'
 import type { AgentMotionSnapshot } from './components/common/agent-motion'
 
 // --- Filter toggles ---
@@ -168,10 +168,11 @@ export const keeperHealthSummary: ReadonlySignal<KeeperHealthSummary> = computed
   let warningCount = 0
   let criticalCount = 0
 
+  const thresholds = contextThresholds.value
   const pressures: KeeperPressure[] = active.map(k => {
     const ratio = k.context_ratio ?? 0
-    if (ratio > CONTEXT_RATIO_CRITICAL) criticalCount++
-    else if (ratio > CONTEXT_RATIO_WARN || stale.has(k.name)) warningCount++
+    if (ratio > thresholds.critical) criticalCount++
+    else if (ratio > thresholds.warn || stale.has(k.name)) warningCount++
     return { name: k.name, ratio, stage: (k.pipeline_stage ?? 'idle') as PipelineStage }
   }).sort((a, b) => b.ratio - a.ratio)
 

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -283,7 +283,8 @@ let make_registry_config ~temperature ~max_tokens ?system_prompt
     | _ -> None
   in
   let model_resolution =
-    resolve_auto_model ?discover provider_name model_id
+    resolve_auto_model ?discover provider_name
+      (Cascade_model_resolve.model_selector_of_string model_id)
   in
   let resolved_model_id = model_resolution.resolved_model_id in
   let base_url =

--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -88,4 +88,16 @@ let format_exhausted_error last_err =
         kind = network_error_kind;
       }
 
+(* ── Human-readable description ─────────────────── *)
+
+let provider_outcome_to_string = function
+  | Call_ok _ -> "call-ok"
+  | Call_err _ -> "call-err"
+  | Accept_rejected _ -> "accept-rejected"
+  | Slot_full -> "slot-full"
+
+let provider_outcome_option_to_string = function
+  | Some outcome -> "some-" ^ provider_outcome_to_string outcome
+  | None -> "none"
+
 (* ── Inline tests ───────────────────────────────── *)

--- a/lib/cascade/cascade_fsm.mli
+++ b/lib/cascade/cascade_fsm.mli
@@ -62,3 +62,13 @@ val format_exhausted_error :
   Llm_provider.Http_client.http_error option ->
   Llm_provider.Http_client.http_error
 (** Format the final error when all providers are exhausted. *)
+
+(** {1 Human-readable description} *)
+
+val provider_outcome_to_string : provider_outcome -> string
+(** Short label for a provider outcome: ["call-ok"], ["call-err"],
+    ["accept-rejected"], ["slot-full"]. *)
+
+val provider_outcome_option_to_string : provider_outcome option -> string
+(** Same as [provider_outcome_to_string] wrapped with ["some-"] or ["none"].
+    Useful for test failure messages. *)

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -21,6 +21,12 @@
 
     All text/vision models support function calling.
     glm-5.1 supports reasoning (reasoning_content field). *)
+type model_selector = Concrete of string | Auto
+
+let model_selector_of_string s =
+  if String.equal (String.lowercase_ascii (String.trim s)) "auto" then Auto
+  else Concrete s
+
 type model_resolution_provenance =
   | Explicit_input
   | Alias of string
@@ -101,21 +107,24 @@ let kimi_cli_auto_models () =
   Provider_adapter.auto_models_for_cascade_prefix "kimi_cli"
   |> Option.value ~default:[]
 
-let resolve_glm_model ?getenv model_id =
+let resolve_glm_model ?getenv selector =
+  let model_id = match selector with Concrete s -> s | Auto -> "auto" in
   let default_model = default_resolution ?getenv "glm" ~requested_model_id:model_id in
   let resolved_model_id =
     Llm_provider.Zai_catalog.resolve_glm_alias
       ~default_model:default_model.resolved_model_id
       model_id
   in
-  if String.equal model_id "auto" then
-    { default_model with resolved_model_id }
-  else if String.equal resolved_model_id model_id then
-    explicit_resolution model_id resolved_model_id
-  else
-    { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
+  match selector with
+  | Auto -> { default_model with resolved_model_id }
+  | Concrete _ ->
+      if String.equal resolved_model_id model_id then
+        explicit_resolution model_id resolved_model_id
+      else
+        { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
 
-let resolve_glm_coding_model ?getenv model_id =
+let resolve_glm_coding_model ?getenv selector =
+  let model_id = match selector with Concrete s -> s | Auto -> "auto" in
   let default_model =
     default_resolution ?getenv "glm-coding" ~requested_model_id:model_id
   in
@@ -124,14 +133,16 @@ let resolve_glm_coding_model ?getenv model_id =
       ~default_model:default_model.resolved_model_id
       model_id
   in
-  if String.equal model_id "auto" then
-    { default_model with resolved_model_id }
-  else if String.equal resolved_model_id model_id then
-    explicit_resolution model_id resolved_model_id
-  else
-    { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
+  match selector with
+  | Auto -> { default_model with resolved_model_id }
+  | Concrete _ ->
+      if String.equal resolved_model_id model_id then
+        explicit_resolution model_id resolved_model_id
+      else
+        { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
 
-let resolve_kimi_model ?getenv model_id =
+let resolve_kimi_model ?getenv selector =
+  let model_id = match selector with Concrete s -> s | Auto -> "auto" in
   let trimmed = String.trim model_id in
   match String.lowercase_ascii trimmed with
   | "auto" ->
@@ -146,10 +157,10 @@ let resolve_kimi_model ?getenv model_id =
   | _ -> explicit_resolution model_id trimmed
 
 let resolve_glm_model_id model_id =
-  (resolve_glm_model model_id).resolved_model_id
+  (resolve_glm_model (model_selector_of_string model_id)).resolved_model_id
 
 let resolve_glm_coding_model_id model_id =
-  (resolve_glm_coding_model model_id).resolved_model_id
+  (resolve_glm_coding_model (model_selector_of_string model_id)).resolved_model_id
 
 (** Resolve "auto" and aliases to concrete model IDs.
     Cloud APIs generally require concrete model names, and local
@@ -162,32 +173,34 @@ let resolve_glm_coding_model_id model_id =
 let resolve_auto_model
     ?getenv
     ?(discover = Llm_provider.Discovery.first_discovered_model_id)
-    provider_name model_id =
+    provider_name selector =
+  let model_id = match selector with Concrete s -> s | Auto -> "auto" in
   match Provider_adapter.resolve_adapter_by_cascade_prefix provider_name with
   | Some { runtime_kind = Provider_adapter.Local; _ } ->
-      if String.equal model_id "auto" then
-        match discover () with
-        | Some resolved_model_id ->
-            { requested_model_id = model_id; resolved_model_id; provenance = Discovery }
-        | None -> default_resolution ?getenv provider_name ~requested_model_id:model_id
-      else explicit_resolution model_id model_id
+      (match selector with
+       | Auto ->
+           (match discover () with
+            | Some resolved_model_id ->
+                { requested_model_id = model_id; resolved_model_id; provenance = Discovery }
+            | None -> default_resolution ?getenv provider_name ~requested_model_id:model_id)
+       | Concrete _ -> explicit_resolution model_id model_id)
   | Some { model_policy = { family = Provider_adapter.Glm_general; _ }; _ } ->
-      resolve_glm_model ?getenv model_id
+      resolve_glm_model ?getenv selector
   | Some { model_policy = { family = Provider_adapter.Glm_coding; _ }; _ } ->
-      resolve_glm_coding_model ?getenv model_id
+      resolve_glm_coding_model ?getenv selector
   | Some { model_policy = { family = Provider_adapter.Kimi_api_family; _ }; _ } ->
-      resolve_kimi_model ?getenv model_id
+      resolve_kimi_model ?getenv selector
   | Some _ ->
-      if String.equal model_id "auto" then
-        default_resolution ?getenv provider_name ~requested_model_id:model_id
-      else
-        explicit_resolution model_id model_id
+      (match selector with
+       | Auto -> default_resolution ?getenv provider_name ~requested_model_id:model_id
+       | Concrete _ -> explicit_resolution model_id model_id)
   | None ->
-      if String.equal model_id "auto" then unresolved_auto model_id
-      else explicit_resolution model_id model_id
+      (match selector with
+       | Auto -> unresolved_auto model_id
+       | Concrete _ -> explicit_resolution model_id model_id)
 
 let resolve_auto_model_id provider_name model_id =
-  (resolve_auto_model provider_name model_id).resolved_model_id
+  (resolve_auto_model provider_name (model_selector_of_string model_id)).resolved_model_id
 
 let parse_custom_model model_id =
   match String.index_opt model_id '@' with

--- a/lib/cascade/cascade_model_resolve.mli
+++ b/lib/cascade/cascade_model_resolve.mli
@@ -37,6 +37,10 @@ val claude_code_auto_models : unit -> string list
     Defaults to [["kimi-for-coding"]]. *)
 val kimi_cli_auto_models : unit -> string list
 
+type model_selector = Concrete of string | Auto
+
+val model_selector_of_string : string -> model_selector
+
 type model_resolution_provenance =
   | Explicit_input
   | Alias of string
@@ -52,9 +56,9 @@ type model_resolution = {
 }
 
 val resolve_glm_model :
-  ?getenv:(string -> string option) -> string -> model_resolution
+  ?getenv:(string -> string option) -> model_selector -> model_resolution
 val resolve_glm_coding_model :
-  ?getenv:(string -> string option) -> string -> model_resolution
+  ?getenv:(string -> string option) -> model_selector -> model_resolution
 
 (** Resolve a GLM model alias to the concrete API model ID.
     - ["auto"] -> env var [ZAI_DEFAULT_MODEL] or ["glm-5.1"]
@@ -72,7 +76,7 @@ val resolve_auto_model :
   ?getenv:(string -> string option) ->
   ?discover:(unit -> string option) ->
   string ->
-  string ->
+  model_selector ->
   model_resolution
 val resolve_auto_model_id : string -> string -> string
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -570,6 +570,26 @@ module KeeperWatchdog = struct
       up to 255 s plus one heartbeat cycle). *)
   let grace_period_sec =
     Float.max 0.0 (get_float ~default:360.0 "MASC_KEEPER_WATCHDOG_GRACE_SEC")
+
+  (** Sliding window for stale-termination escalation tracking.
+      Default: 21600 (6 hours). *)
+  let termination_window_sec =
+    Float.max 3600.0 (get_float ~default:21600.0 "MASC_KEEPER_TERMINATION_WINDOW_SEC")
+
+  (** Number of stale terminations within [termination_window_sec] before
+      escalating to [Stale_termination_storm]. Default: 5. *)
+  let escalation_threshold =
+    max 1 (get_int ~default:5 "MASC_KEEPER_ESCALATION_THRESHOLD")
+
+  (** Fleet batch-termination detection window in seconds.
+      Default: 30. *)
+  let batch_window_sec =
+    Float.max 1.0 (get_float ~default:30.0 "MASC_KEEPER_BATCH_WINDOW_SEC")
+
+  (** Number of distinct keepers terminating within [batch_window_sec] before
+      emitting a fleet batch alert. Default: 3. *)
+  let batch_threshold =
+    max 1 (get_int ~default:3 "MASC_KEEPER_BATCH_THRESHOLD")
 end
 
 (** {1 gRPC Heartbeat Reconnect} *)

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -811,4 +811,35 @@ module KeeperCascade = struct
        | _ -> Some parts)
 end
 
+(** {1 Transient Retry Backoff}
+
+    Outer-loop retry parameters for transient network errors and
+    recoverable cascade failures.  These govern the keeper's exponential
+    backoff between re-attempts when all OAS providers fail transiently
+    (e.g. TCP keepalive expiry).  They do NOT affect OAS internal
+    per-provider retry (3 attempts with its own backoff). *)
+module KeeperRetryBackoff = struct
+  (** Maximum outer-loop retries after the initial attempt.
+      Total attempts = 1 initial + max_transient_retries.
+      Env: [MASC_KEEPER_MAX_TRANSIENT_RETRIES].  Default: 2. *)
+  let max_transient_retries () = get_int ~default:2 "MASC_KEEPER_MAX_TRANSIENT_RETRIES"
+
+  (** Base delay (seconds) for exponential backoff.
+      Delay at attempt [n] is [base * 2^(n-1)].
+      Env: [MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC].  Default: 1.0. *)
+  let transient_backoff_base_sec () = get_float ~default:1.0 "MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC"
+
+  (** Hard cap on backoff delay (seconds).
+      Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. *)
+  let transient_backoff_cap_sec () = get_float ~default:4.0 "MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC"
+
+  (** Exponential backoff delay for transient retry [attempt] (1-indexed).
+      Env: [MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC] and
+      [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC]. *)
+  let transient_backoff_sec (attempt : int) : float =
+    let base = transient_backoff_base_sec () in
+    let cap = transient_backoff_cap_sec () in
+    Float.min cap (base *. Float.of_int (1 lsl (attempt - 1)))
+end
+
 (** Print configuration summary for debugging *)

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -246,3 +246,12 @@ end
 module KeeperCascade : sig
   val provider_allowlist : unit -> string list option
 end
+
+(** {1 Transient retry backoff} *)
+
+module KeeperRetryBackoff : sig
+  val max_transient_retries : unit -> int
+  val transient_backoff_base_sec : unit -> float
+  val transient_backoff_cap_sec : unit -> float
+  val transient_backoff_sec : int -> float
+end

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -70,6 +70,10 @@ module KeeperWatchdog : sig
   val poll_sec : float
   val noop_threshold : int
   val grace_period_sec : float
+  val termination_window_sec : float
+  val escalation_threshold : int
+  val batch_window_sec : float
+  val batch_threshold : int
 end
 
 (** {1 Keeper poll intervals} *)

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -449,13 +449,16 @@ let classify_post_commit_failure
 (** Max transient retries (excluding the initial attempt).  Total attempts
     = 1 initial + max_transient_retries.  OAS internal retry is 3 per
     provider; this outer retry covers cases where all providers fail
-    transiently (e.g. TCP keepalive expiry across all backends). *)
-let max_transient_retries = 2
+    transiently (e.g. TCP keepalive expiry across all backends).
+
+    Runtime-configurable via [Env_config_keeper.KeeperRetryBackoff]. *)
+let max_transient_retries () =
+  Env_config_keeper.KeeperRetryBackoff.max_transient_retries ()
 
 (** Exponential backoff delay for transient retry [attempt] (1-indexed).
-    Delays: 1s, 2s — total wait 3s before giving up. *)
+    Delegates to [Env_config_keeper.KeeperRetryBackoff]. *)
 let transient_backoff_sec (attempt : int) : float =
-  Float.min 4.0 (1.0 *. Float.of_int (1 lsl (attempt - 1)))
+  Env_config_keeper.KeeperRetryBackoff.transient_backoff_sec attempt
 
 (** [true] when a structured error indicates context overflow. *)
 let is_context_overflow (err : Oas.Error.sdk_error) : bool =

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -104,7 +104,7 @@ val degraded_rotation_after_recoverable_error :
   Oas.Error.sdk_error ->
   degraded_retry option
 
-val max_transient_retries : int
+val max_transient_retries : unit -> int
 
 val transient_backoff_sec : int -> float
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -263,6 +263,10 @@ let log_grpc_heartbeat_stream_failure ~agent_name ~attempts = function
       (attempts + 1)
       Env_config.KeeperGrpc.max_reconnect_attempts
   | `Error exn ->
+    Prometheus.inc_counter
+      "masc_keeper_grpc_stream_failures"
+      ~labels:[("keeper", agent_name)]
+      ();
     Log.Keeper.warn
       "gRPC heartbeat stream error for %s: %s (attempt %d/%d)"
       agent_name
@@ -424,6 +428,8 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
+    Prometheus.inc_counter Prometheus.metric_keeper_write_meta_failures
+      ~labels:[("keeper", m.name); ("phase", "bootstrap-catch")] ();
     Log.Keeper.error "room presence bootstrap failed: %s" (Printexc.to_string exn);
     m
 ;;
@@ -602,6 +608,10 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         with
         | Eio.Cancel.Cancelled _ -> ()
         | e ->
+          Prometheus.inc_counter
+            "masc_keeper_cleanup_tracking_failures"
+            ~labels:[("keeper", live_meta.name)]
+            ();
           Log.Keeper.warn
             "%s: cleanup_tracking in heartbeat finally raised: %s"
             live_meta.name (Printexc.to_string e)
@@ -663,7 +673,11 @@ let stop_keepalive ?base_path name =
        | Some close_fn ->
           (try close_fn () with
            | Eio.Cancel.Cancelled _ as e -> raise e
-           | _exn -> ())
+           | _exn ->
+              Prometheus.inc_counter
+                "masc_keeper_grpc_close_failures"
+                ~labels:[("keeper", entry.meta.name)]
+                ())
         | None -> ());
        (match entry.phase with
         | Keeper_state_machine.Crashed | Keeper_state_machine.Dead -> ()

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -75,8 +75,8 @@ open Keeper_types
    This is observability only — we still let the supervisor restart
    the keeper.  Phase 2 (deciding whether to auto-pause) is left
    for a follow-up PR with measurement evidence in hand. *)
-let termination_window_sec = 21600.0  (* 6h *)
-let escalation_threshold = 5
+let termination_window_sec = Env_config_keeper.KeeperWatchdog.termination_window_sec
+let escalation_threshold = Env_config_keeper.KeeperWatchdog.escalation_threshold
 let termination_history : (string, float list) Hashtbl.t = Hashtbl.create 16
 let termination_history_mu = Eio.Mutex.create ()
 
@@ -152,8 +152,8 @@ let () =
    systemic root-cause issue list, plus a Prometheus counter.  No
    state-machine change: the per-keeper restart still proceeds.  The
    point is to make the batch event visible at all. *)
-let batch_window_sec = 30.0
-let batch_threshold = 3
+let batch_window_sec = Env_config_keeper.KeeperWatchdog.batch_window_sec
+let batch_threshold = Env_config_keeper.KeeperWatchdog.batch_threshold
 let batch_terminations : (string * float) list Atomic.t = Atomic.make []
 
 let record_batch_termination keeper_name now : string list =

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -396,6 +396,10 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                 with
                 | Eio.Cancel.Cancelled _ as e -> raise e
                 | exn ->
+                  Prometheus.inc_counter
+                    "masc_keeper_stale_broadcast_emit_failures"
+                    ~labels:[("keeper", meta.name)]
+                    ();
                   Log.Keeper.warn
                     "%s: stale broadcast emit failed (restart still triggered): %s"
                     meta.name (Printexc.to_string exn))

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -373,6 +373,9 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
     (Eio.Semaphore.get_value autonomous_turn_semaphore)
     (Eio.Semaphore.get_value turn_semaphore)
     queue_depth;
+  Prometheus.set_gauge Prometheus.metric_keeper_turn_queue_depth
+    ~labels:[("keeper", keeper_name); ("channel", channel_label)]
+    (float_of_int queue_depth);
   (* Track acquisitions in mutable flags so the outer Fun.protect can
      release exactly the slots we hold — regardless of which result or
      exception path fires (Eio.Cancel.Cancelled or any other). This

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1068,7 +1068,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                       mark_terminal_error err;
                       Error err
                   | No_degraded_retry when EC.is_transient_network_error err
-                              && attempt <= EC.max_transient_retries ->
+                              && attempt <= EC.max_transient_retries () ->
                       let delay = EC.transient_backoff_sec attempt in
                       Log.Keeper.warn
                         "%s: transient network error cascade=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s retry=%d/%d backoff=%.0fs: %s"
@@ -1079,7 +1079,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                         (match execution.max_context_resolution.requested_override with
                          | Some requested -> string_of_int requested
                          | None -> "none")
-                        attempt EC.max_transient_retries delay
+                        attempt (EC.max_transient_retries ()) delay
                         (short_preview (Oas.Error.to_string err));
                       Eio.Time.sleep clock delay;
                       retry_loop ~run_meta ~execution ~run_generation

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -430,7 +430,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let post_commit_failure_reason = ref None in
       let paused_meta_override = ref None in
       let current_turn_overflow_blocker = ref None in
-      let event_bus_drain_active = Atomic.make true in
+      let event_bus_drain_cancel = ref None in
       let turn_event_bus_mu = Eio.Mutex.create () in
       let mark_paused_after_overflow ~run_meta ~reason =
         let paused_meta =
@@ -551,16 +551,17 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         match event_bus_sub, Eio_context.get_switch_opt () with
         | Some _, Some sw ->
             Eio.Fiber.fork ~sw (fun () ->
-              let rec loop () =
-                if Atomic.get event_bus_drain_active then begin
-                  (try
-                     ignore (drain_turn_event_bus ~site:"background_poll" ())
-                   with
-                   | Eio.Cancel.Cancelled _ as e -> raise e
-                   | exn ->
-                       Log.Keeper.warn
-                         "%s: keeper_turn event-bus drain failed: %s"
-                         meta.name (Printexc.to_string exn));
+              Eio.Cancel.sub (fun cc ->
+                event_bus_drain_cancel := Some cc;
+                let rec loop () =
+                  try
+                    ignore (drain_turn_event_bus ~site:"background_poll" ())
+                  with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn ->
+                    Log.Keeper.warn
+                      "%s: keeper_turn event-bus drain failed: %s"
+                      meta.name (Printexc.to_string exn);
                   (* 2026-04-20: 0.25s → 0.05s.  OAS publishes a burst
                      of events per tool cycle (ToolCalled / ToolResult /
                      ToolCompleted + assistant / usage).  With 0.25s
@@ -577,13 +578,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                      via [MASC_KEEPER_TURN_DRAIN_INTERVAL_SEC]. *)
                   Eio.Time.sleep clock (turn_event_bus_drain_interval_sec ());
                   loop ()
-                end
-              in
-              loop ())
+                in
+                loop ()))
         | _ -> ()
       in
       let unsubscribe_event_bus () =
-        Atomic.set event_bus_drain_active false;
+        (match !event_bus_drain_cancel with
+         | Some cc -> Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed")
+         | None -> ());
         ignore (drain_turn_event_bus ~site:"unsubscribe_final" ());
         match event_bus_sub, Keeper_event_bus.get () with
         | Some sub, Some bus -> Oas_bus_instrument.unsubscribe bus sub

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -160,6 +160,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                  Log.Keeper.warn
                    "%s: cascade %s provider cooldown pending (%ds); fail-opening to %s"
                    meta.name effective_cascade_name remaining_sec fallback_cascade;
+                 Prometheus.inc_counter
+                   Prometheus.metric_keeper_provider_cooldown_skip
+                   ~labels:[
+                     ("keeper", meta.name);
+                     ("from_cascade", effective_cascade_name);
+                     ("to_cascade", fallback_cascade);
+                   ]
+                   ();
                  fallback_cascade
              | _ -> effective_cascade_name)
         | None -> effective_cascade_name

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -150,6 +150,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~cascade_name:effective_cascade_name
         with
         | Some remaining_sec ->
+            Prometheus.set_gauge
+              Prometheus.metric_keeper_provider_cooldown_remaining_sec
+              ~labels:[
+                ("keeper", meta.name);
+                ("cascade", effective_cascade_name);
+              ]
+              (float_of_int remaining_sec);
             (match
                EC.fallback_cascade_for_unavailable_profile
                  ~base_cascade:meta.cascade_name
@@ -170,7 +177,15 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                    ();
                  fallback_cascade
              | _ -> effective_cascade_name)
-        | None -> effective_cascade_name
+        | None ->
+            Prometheus.set_gauge
+              Prometheus.metric_keeper_provider_cooldown_remaining_sec
+              ~labels:[
+                ("keeper", meta.name);
+                ("cascade", effective_cascade_name);
+              ]
+              0.0;
+            effective_cascade_name
       in
       (* PR-B: ollama saturation pre-skip.  If the resolved cascade
          is ollama-only and the [/api/ps] cache reports zero

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -291,6 +291,14 @@ let metric_keeper_turn_latency_by_model_bucket =
 let metric_keeper_provider_cooldown_skip =
   "masc_keeper_provider_cooldown_skip_total"
 
+(* P-DASH-02: turn queue depth gauge.  Semaphore waiters are
+   observable via [autonomous_waiter_snapshot_for_test] but were
+   only emitted as a debug log line.  Surfacing as a gauge lets
+   operators alert on queue pressure without log parsing.
+   Labels: keeper, channel. *)
+let metric_keeper_turn_queue_depth =
+  "masc_keeper_turn_queue_depth"
+
 (* #10125: keeper supervisor sweep observability.
 
    The supervisor sweep is a Pulse loop that recovers crashed

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -291,6 +291,13 @@ let metric_keeper_turn_latency_by_model_bucket =
 let metric_keeper_provider_cooldown_skip =
   "masc_keeper_provider_cooldown_skip_total"
 
+(* P-DASH-01: provider cooldown remaining seconds gauge.
+   Exposes the current cooldown duration so operators can see
+   which cascade is blocked and for how long without log parsing.
+   Labels: keeper, cascade. *)
+let metric_keeper_provider_cooldown_remaining_sec =
+  "masc_keeper_provider_cooldown_remaining_sec"
+
 (* P-DASH-02: turn queue depth gauge.  Semaphore waiters are
    observable via [autonomous_waiter_snapshot_for_test] but were
    only emitted as a debug log line.  Surfacing as a gauge lets

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -283,6 +283,14 @@ let metric_keeper_turn_latency_bucket =
 let metric_keeper_turn_latency_by_model_bucket =
   "masc_keeper_turn_latency_by_model_bucket_total"
 
+(* P-DASH-01: provider cooldown skip counter.
+   When a cascade's provider is in cooldown and the keeper
+   fail-opens to a fallback cascade, increment this counter
+   so operators can see how often cooldown is triggering
+   cascade switches.  Labels: keeper, from_cascade, to_cascade. *)
+let metric_keeper_provider_cooldown_skip =
+  "masc_keeper_provider_cooldown_skip_total"
+
 (* #10125: keeper supervisor sweep observability.
 
    The supervisor sweep is a Pulse loop that recovers crashed

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -105,6 +105,11 @@ val metric_keeper_turn_latency_by_model_bucket : string
     [keeper, channel, provider_kind, model_used, resolved_model_id,
     cascade_profile, bucket]. *)
 
+val metric_keeper_provider_cooldown_skip : string
+(** P-DASH-01: provider cooldown skip counter.  Incremented when a
+    cascade is in provider cooldown and the keeper fail-opens to a
+    fallback cascade.  Labels: [keeper, from_cascade, to_cascade]. *)
+
 (** #10125: supervisor sweep liveness counters.  See {!Prometheus.ml}
     for the rationale.  Counter increments on each Pulse start;
     gauge advances on every successful beat. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -110,6 +110,11 @@ val metric_keeper_provider_cooldown_skip : string
     cascade is in provider cooldown and the keeper fail-opens to a
     fallback cascade.  Labels: [keeper, from_cascade, to_cascade]. *)
 
+val metric_keeper_turn_queue_depth : string
+(** P-DASH-02: turn queue depth gauge.  Semaphore waiter count
+    surfaced so operators can alert on queue pressure without log
+    parsing.  Labels: [keeper, channel]. *)
+
 (** #10125: supervisor sweep liveness counters.  See {!Prometheus.ml}
     for the rationale.  Counter increments on each Pulse start;
     gauge advances on every successful beat. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -110,6 +110,11 @@ val metric_keeper_provider_cooldown_skip : string
     cascade is in provider cooldown and the keeper fail-opens to a
     fallback cascade.  Labels: [keeper, from_cascade, to_cascade]. *)
 
+val metric_keeper_provider_cooldown_remaining_sec : string
+(** P-DASH-01: provider cooldown remaining seconds gauge.
+    Exposes the current cooldown duration so operators can see
+    which cascade is blocked and for how long.  Labels: [keeper, cascade]. *)
+
 val metric_keeper_turn_queue_depth : string
 (** P-DASH-02: turn queue depth gauge.  Semaphore waiter count
     surfaced so operators can alert on queue pressure without log

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -825,12 +825,7 @@ let test_sdk_error_to_cascade_outcome_maps_not_found_to_404 () =
   | outcome ->
       Alcotest.failf
         "expected Some (Call_err (HttpError 404)) for 404-like InvalidRequest, got %s"
-         (match outcome with
-          | Some (Cascade_fsm.Call_err _) -> "some-call-err"
-           | Some (Cascade_fsm.Accept_rejected _) -> "some-accept-rejected"
-          | Some (Cascade_fsm.Call_ok _) -> "some-call-ok"
-          | Some Cascade_fsm.Slot_full -> "some-slot-full"
-          | None -> "none")
+        (Cascade_fsm.provider_outcome_option_to_string outcome)
 
 let test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400 () =
   let err =
@@ -846,12 +841,7 @@ let test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400 () =
   | outcome ->
       Alcotest.failf
         "expected Some (Call_err (HttpError 400)) for ordinary InvalidRequest, got %s"
-        (match outcome with
-         | Some (Cascade_fsm.Call_err _) -> "some-call-err"
-         | Some (Cascade_fsm.Accept_rejected _) -> "some-accept-rejected"
-         | Some (Cascade_fsm.Call_ok _) -> "some-call-ok"
-         | Some Cascade_fsm.Slot_full -> "some-slot-full"
-         | None -> "none")
+        (Cascade_fsm.provider_outcome_option_to_string outcome)
 
 let test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config () =
   let detail = "codex_cli runtime MCP cannot carry keeper-bound auth headers" in
@@ -867,12 +857,7 @@ let test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config () =
   | outcome ->
       Alcotest.failf
         "expected runtime_mcp_auth InvalidConfig to cascade as AcceptRejected, got %s"
-        (match outcome with
-         | Some (Cascade_fsm.Call_err _) -> "some-call-err"
-         | Some (Cascade_fsm.Accept_rejected _) -> "some-accept-rejected"
-         | Some (Cascade_fsm.Call_ok _) -> "some-call-ok"
-         | Some Cascade_fsm.Slot_full -> "some-slot-full"
-         | None -> "none")
+        (Cascade_fsm.provider_outcome_option_to_string outcome)
 
 let test_sdk_error_to_cascade_outcome_cascades_resumable_cli_session () =
   let raw_message =
@@ -904,12 +889,7 @@ let test_sdk_error_to_cascade_outcome_cascades_resumable_cli_session () =
   | outcome ->
       Alcotest.failf
         "expected resumable CLI session to cascade as NetworkError, got %s"
-        (match outcome with
-         | Some (Cascade_fsm.Call_err _) -> "some-call-err"
-         | Some (Cascade_fsm.Accept_rejected _) -> "some-accept-rejected"
-         | Some (Cascade_fsm.Call_ok _) -> "some-call-ok"
-         | Some Cascade_fsm.Slot_full -> "some-slot-full"
-         | None -> "none")
+        (Cascade_fsm.provider_outcome_option_to_string outcome)
 
 let test_sdk_error_is_resumable_cli_session_detects_structured_error () =
   let err =

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -187,7 +187,8 @@ let test_labels_require_local_discovery () =
 
 let test_cascade_model_resolve_alias_provenance () =
   let resolved =
-    Model_resolve.resolve_glm_model ~getenv:(fun _ -> None) "flash"
+    Model_resolve.resolve_glm_model ~getenv:(fun _ -> None)
+      (Model_resolve.model_selector_of_string "flash")
   in
   check string "glm flash alias" "glm-4.7-flashx" resolved.resolved_model_id;
   check resolution_provenance "alias provenance"
@@ -195,7 +196,8 @@ let test_cascade_model_resolve_alias_provenance () =
 
 let test_cascade_model_resolve_hardcoded_default_provenance () =
   let resolved =
-    Model_resolve.resolve_auto_model ~getenv:(fun _ -> None) "openai" "auto"
+    Model_resolve.resolve_auto_model ~getenv:(fun _ -> None) "openai"
+      (Model_resolve.model_selector_of_string "auto")
   in
   check string "openai hardcoded default" "gpt-4.1" resolved.resolved_model_id;
   check resolution_provenance "hardcoded provenance"
@@ -207,7 +209,8 @@ let test_cascade_model_resolve_env_default_provenance () =
     | _ -> None
   in
   let resolved =
-    Model_resolve.resolve_auto_model ~getenv "gemini" "auto"
+    Model_resolve.resolve_auto_model ~getenv "gemini"
+      (Model_resolve.model_selector_of_string "auto")
   in
   check string "gemini env default" "gemini-2.5-flash"
     resolved.resolved_model_id;
@@ -220,7 +223,7 @@ let test_cascade_model_resolve_discovery_provenance () =
     Model_resolve.resolve_auto_model
       ~getenv:(fun _ -> None)
       ~discover:(fun () -> Some "qwen3:8b")
-      "ollama" "auto"
+      "ollama" (Model_resolve.model_selector_of_string "auto")
   in
   check string "ollama discovery" "qwen3:8b" resolved.resolved_model_id;
   check resolution_provenance "discovery provenance"
@@ -228,7 +231,8 @@ let test_cascade_model_resolve_discovery_provenance () =
 
 let test_cascade_model_resolve_unresolved_auto_provenance () =
   let resolved =
-    Model_resolve.resolve_auto_model ~getenv:(fun _ -> None) "openrouter" "auto"
+    Model_resolve.resolve_auto_model ~getenv:(fun _ -> None) "openrouter"
+      (Model_resolve.model_selector_of_string "auto")
   in
   check string "openrouter unresolved auto stays auto" "auto"
     resolved.resolved_model_id;


### PR DESCRIPTION
## Summary
Artifact synthesis Quadrant 1 Quick Wins batch. 8 commits across metrics, config, dashboard, and cascade.

## Changes
- P-DASH-07: dashboard consumes runtime context-ratio thresholds from /config
- P-DASH-01: add provider cooldown skip metric
- P-EIO-06: externalize stale watchdog constants
- P-FSM-09: externalize transient retry backoff constants
- P-FSM-10: add provider_outcome_to_string delegation
- P-STR-02: replace \"auto\" magic string with model_selector ADT
- Prometheus: cooldown remaining gauge, silent failure counter, turn queue depth gauge

## Test plan
- [x] dune build @install
- [ ] dune runtest
- [ ] CI checks green

## Stats
- 24 files changed, +353/-111 lines