### PR TITLE
feat(metrics): RFC-0020 Rule 2 override counter

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -726,7 +726,12 @@ let run_smart_heartbeat_gate
       in
       if Keeper_event_queue.is_empty queue
       then smart_hb_decision
-      else Heartbeat_smart.Emit)
+      else (
+        Prometheus.inc_counter
+          Prometheus.metric_keeper_event_queue_override
+          ~labels:[ ("keeper", meta_current.name) ]
+          ();
+        Heartbeat_smart.Emit))
   in
   (* Run side-effects (idle sleep, cycle-timestamp update) per the
      decision, then delegate the gate answer to [cycle_continues_after_wake]

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -709,6 +709,8 @@ let metric_keeper_dead_total = "masc_keeper_dead_total"
    positive/negative coverage. Labels: keeper. *)
 let metric_keeper_skip_idle_wake_resumed =
   "masc_keeper_skip_idle_wake_resumed_total"
+let metric_keeper_event_queue_override =
+  "masc_keeper_event_queue_override_total"
 let metric_keeper_near_exhaustion_total = "masc_keeper_near_exhaustion_total"
 let metric_keeper_restart_attempts =
   "masc_keeper_restart_attempts_total"
@@ -1062,6 +1064,14 @@ let init () =
      (cycle_continues_after_wake -> true). Positive signal for the \
      #12271 fix; pairs with masc_keeper_stale_termination_by_class_total \
      {class=idle_turn} which should drop in proportion. Labels: keeper."
+    Counter;
+  add metric_keeper_event_queue_override
+    "RFC-0020 Rule 2 — total times run_smart_heartbeat_gate forced \
+     Heartbeat_smart.Emit because the Event Layer queue \
+     (Keeper_registry.event_queue_snapshot) was non-empty. Pairs with \
+     masc_keeper_skip_idle_wake_resumed: skip-idle-resumed measures the \
+     fiber_wakeup hint path, this measures the queue payload path. \
+     Labels: keeper."
     Counter;
   add metric_keeper_near_exhaustion_total
     "Total keeper restart attempts at restart_count = max_restarts - 1, \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -377,6 +377,16 @@ val metric_keeper_dead_total : string
     restart will be attempted. *)
 
 val metric_keeper_skip_idle_wake_resumed : string
+
+(** RFC-0020 Rule 2 evidence — incremented every time
+    [run_smart_heartbeat_gate] overrides a [Skip_busy] / [Skip_idle]
+    decision because the Event Layer queue
+    ([Keeper_registry.event_queue_snapshot]) was non-empty. A zero
+    rate against ongoing keeper activity means either the queue
+    write path (PR-C1 [wakeup_keeper ?stimulus]) is not firing or
+    the smart heartbeat is already returning [Emit] on its own —
+    either way operators can distinguish. Labels: [keeper]. *)
+val metric_keeper_event_queue_override : string
 (** Positive signal for the #12271 Skip_idle + Woken fix path. Increments
     each time [run_smart_heartbeat_gate] observes an external [wakeup_keeper]
     cut a Skip_idle backoff sleep short and the cycle was resumed


### PR DESCRIPTION
## Summary

Adds `masc_keeper_event_queue_override_total` — incremented every time `run_smart_heartbeat_gate` forces `Heartbeat_smart.Emit` because the Event Layer queue is non-empty. This is the **production evidence layer** for the Rule 2 override that landed in PR-C2 (#12412).

## Why a counter

PR-C2 introduced a behaviour change: smart heartbeat decisions get *overridden* when the queue holds an unprocessed stimulus. Without telemetry, operators have no way to know whether the override is actually firing — and a *zero* override rate against ongoing keeper activity would silently mean either:

- the queue write path (PR-C1 `wakeup_keeper ?stimulus`) is not being exercised, or
- the smart heartbeat is already returning `Emit` on its own.

Either is operator-meaningful. The counter makes the distinction visible.

## Operator pair

| Counter | What it measures |
|---|---|
| `masc_keeper_skip_idle_wake_resumed_total` (existing) | `fiber_wakeup` *hint* path cut a `Skip_idle` sleep short |
| **`masc_keeper_event_queue_override_total`** (new) | Event Layer *queue payload* forced `Emit` at decision time |

Both non-zero ⇒ both halves of the Event/Policy split are doing work. Either at zero is a diagnostic signal that the layer is not actually being exercised.

## Files changed

| File | Change |
|---|---|
| `lib/prometheus.mli` | Public symbol + docstring (+10 lines) |
| `lib/prometheus.ml` | Counter constant + `add` registration (+10 lines) |
| `lib/keeper/keeper_heartbeat_loop.ml` | Single `inc_counter` call inside the existing override branch (+6 lines) |

3 files, +26/-1. **No new branches in the override logic** — the counter sits inside the `else (... Heartbeat_smart.Emit)` branch that PR-C2 already created.

## Layer plan (RFC-0020 §6)

| PR | Scope | Status |
|---|---|---|
| #12386 | TLA+ spec | ✅ Merged |
| #12396 | Library + property tests | ✅ Merged |
| #12403 (PR-B1) | Registry data field + enqueue/snapshot | ✅ Merged |
| #12409 | RFC-0020 architecture | ✅ Merged |
| #12411 (PR-C1) | signal `?stimulus` enqueue | ✅ Merged |
| #12412 (PR-C2) | heartbeat gate Rule 2 override | ✅ Merged |
| #12413 (PR-B2) | dequeue_event API | ⏸ Draft |
| #12415 (PR-C3a) | turn entry queue-depth telemetry | ⏸ Draft |
| **this PR** | **Rule 2 override Prometheus counter** | **Draft** |
| PR-C3b (planned) | turn entry calls `dequeue_event` | — |

Independent of #12413 / #12415 — only depends on PR-C2 (already on `main`). No conflict with sibling Drafts: PR-C3a touches `run_keepalive_unified_turn` (different function in same file).

## Verification

- [x] `dune build --root . lib/` — exit 0
- [x] Counter follows existing `masc_keeper_skip_idle_wake_resumed_total` pattern (definition + `add` + `inc_counter ~labels:[("keeper", name)]`).
- [ ] CI Build/Test full pipeline.
- [ ] Smoke: enqueue stimulus → next idle decision → counter increments by 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)