### PR TITLE
refactor(keeper): type run cascade context

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -96,10 +96,12 @@ let run_turn
   in
   Fun.protect ~finally:safe_emit_turn_end
   @@ fun () ->
+  let runtime_cascade_name = Keeper_cascade_profile.Runtime_name cascade_name in
   (* Steps 0–4: inference params, session dir, checkpoint, base prompt,
      working context, checkpoint hygiene — all in Keeper_run_context. *)
   let ctx = Keeper_run_context.prepare_run_context
-      ~config ~meta ~base_dir ~max_context ~cascade_name
+      ~config ~meta ~base_dir ~max_context
+      ~cascade_name:runtime_cascade_name
       ?temperature ?max_tokens ?shared_context ~generation
       ()
   in
@@ -141,7 +143,8 @@ let run_turn
       ~config ~meta ~ctx_work ~session ~base_system_prompt
       ~turn_system_prompt ~user_message ~dynamic_context
       ~history_messages ~prompt_metrics ~shared_context ~context_injector
-      ~start_turn_count ~generation ~max_turns ~cascade_name ~is_retry
+      ~start_turn_count ~generation ~max_turns
+      ~cascade_name:runtime_cascade_name ~is_retry
       ~turn_affordances ~config_root ~cascade_config_path ~gemini_mcp_disabled
       ~approval_mode_effective ~approval_mode_derived
       ?max_cost_usd ~trajectory_acc ~tool_overlay

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -34,7 +34,7 @@ let prepare_run_context
       ~(meta : keeper_meta)
       ~(base_dir : string)
       ~(max_context : int)
-      ~(cascade_name : string)
+      ~(cascade_name : Keeper_cascade_profile.runtime_name)
       ?temperature
       ?max_tokens
       ?shared_context
@@ -44,22 +44,19 @@ let prepare_run_context
   let receipt_started_at = Types.now_iso () in
   let meta = Keeper_agent_tool_surface.sync_current_task_id_from_backlog ~config meta in
   (* 0. Resolve inference parameters via Cascade_inference *)
-  let inference_cascade_name =
-    Keeper_cascade_profile.Runtime_name cascade_name
-  in
   let temperature =
     match temperature with
     | Some t -> t
     | None ->
       Cascade_inference.resolve_temperature
-        ~cascade_name:inference_cascade_name ~fallback:(fun () -> 0.3)
+        ~cascade_name ~fallback:(fun () -> 0.3)
   in
   let max_tokens =
     match max_tokens with
     | Some t -> t
     | None ->
       Cascade_inference.resolve_max_tokens
-        ~cascade_name:inference_cascade_name
+        ~cascade_name
           (* 8192 allows complex multi-tool reasoning per turn.
            Cloudflare tunnel 100s is no longer a constraint with
            streaming responses. *)

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -31,7 +31,7 @@ val prepare_run_context :
   -> meta:keeper_meta
   -> base_dir:string
   -> max_context:int
-  -> cascade_name:string
+  -> cascade_name:Keeper_cascade_profile.runtime_name
   -> ?temperature:float
   -> ?max_tokens:int
   -> ?shared_context:Oas.Context.t

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -98,7 +98,7 @@ let prepare_agent_setup
       ~(start_turn_count : int)
       ~(generation : int)
       ~(max_turns : int)
-      ~(cascade_name : string)
+      ~(cascade_name : Keeper_cascade_profile.runtime_name)
       ~(is_retry : bool)
       ~(turn_affordances : string list)
       ~(config_root : string)
@@ -112,6 +112,9 @@ let prepare_agent_setup
       ()
   : (agent_setup, Oas.Error.sdk_error) result
   =
+  let cascade_name_string =
+    Keeper_cascade_profile.runtime_name_to_string cascade_name
+  in
   let ctx_snapshot = ctx_work in
   let agent_name = meta.agent_name in
   let acc : hook_accumulator =
@@ -1002,7 +1005,9 @@ let prepare_agent_setup
                  else
                    None
                in
-               let cascade_seed = Cascade_inference.for_cascade ~name:cascade_name in
+               let cascade_seed =
+                 Cascade_inference.for_cascade ~name:cascade_name_string
+               in
                let current_budget =
                  match cascade_seed.thinking_budget with
                  | Some _ as v -> v
@@ -1258,7 +1263,7 @@ let prepare_agent_setup
                  ~visible_tool_count:(List.length all_allowed)
                  ~required_tools:computed_surface.required_tool_names
                  ~missing_required_tools:computed_surface.missing_required_tool_names
-                 ~cascade_profile:cascade_name
+                 ~cascade_profile:cascade_name_string
                  ();
                (let now = Time_compat.now () in
                 let hook_elapsed_ms = Keeper_timing.round1 ((now -. hook_t0) *. 1000.0) in

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -87,7 +87,7 @@ val prepare_agent_setup :
   -> start_turn_count:int
   -> generation:int
   -> max_turns:int
-  -> cascade_name:string
+  -> cascade_name:Keeper_cascade_profile.runtime_name
   -> is_retry:bool
   -> turn_affordances:string list
   -> config_root:string


### PR DESCRIPTION
## Summary
- type keeper run-context/setup cascade names as `Keeper_cascade_profile.runtime_name`
- keep `Keeper_agent_run.run_turn` as the public string boundary and wrap once at ingress
- render back to strings only for existing prompt seed / tool telemetry fields

## Why it matters
- continues #11926 by removing raw `cascade_name:string` signatures from the internal keeper run setup path
- prevents already-normalized runtime cascade labels from being reinterpreted as loose strings while preserving external caller compatibility

## Review focus
- `Keeper_agent_run.run_turn` remains the public string boundary
- `Keeper_run_context.prepare_run_context` and `Keeper_run_tools.prepare_agent_setup` now require typed runtime names
- string rendering in `Keeper_run_tools` stays limited to legacy prompt/telemetry boundaries

## Evidence
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_toml.exe test/test_keeper_toml_config_validation.exe`
- `./_build/default/test/test_keeper_unified.exe test transient_network_error`
- `./_build/default/test/test_keeper_unified.exe test phase_gate 20`
- `./_build/default/test/test_keeper_unified.exe test phase_gate 31`
- `./_build/default/test/test_keeper_unified.exe test phase_gate 33`
- `./_build/default/test/test_keeper_unified.exe test phase_gate 40`
- `git diff --check`
- `scripts/stringly-boundary-ratchet.sh` -> `raw_cascade_name_string_signatures 27 / 81`
- `scripts/ocaml-structure-ratchet.sh`

Part of #11926.
