### PR TITLE
test(dashboard): add batch 24 component coverage

### DIFF
--- a/dashboard/src/components/keeper-bdi-panel.test.ts
+++ b/dashboard/src/components/keeper-bdi-panel.test.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+import { describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { KeeperBDIPanel } from './keeper-bdi-panel'
+
+describe('KeeperBDIPanel', () => {
+  const makeContainer = () => document.createElement('div')
+
+  it('returns null when no data provided', () => {
+    const container = makeContainer()
+    render(html`<${KeeperBDIPanel} />`, container)
+    expect(container.innerHTML).toBe('')
+    render(null, container)
+  })
+
+  it('renders BDI fields when provided', () => {
+    const container = makeContainer()
+    render(html`<${KeeperBDIPanel} will="test will" needs="test needs" desires="test desires" />`, container)
+    expect(container.textContent).toContain('의지')
+    expect(container.textContent).toContain('test will')
+    expect(container.textContent).toContain('필요')
+    expect(container.textContent).toContain('test needs')
+    expect(container.textContent).toContain('염망')
+    expect(container.textContent).toContain('test desires')
+    render(null, container)
+  })
+
+  it('renders goal horizons from short_goal/mid_goal/long_goal', () => {
+    const container = makeContainer()
+    render(html`<${KeeperBDIPanel} short_goal="s" mid_goal="m" long_goal="l" />`, container)
+    expect(container.textContent).toContain('goal horizons')
+    expect(container.textContent).toContain('short')
+    expect(container.textContent).toContain('s')
+    expect(container.textContent).toContain('mid')
+    expect(container.textContent).toContain('m')
+    expect(container.textContent).toContain('long')
+    expect(container.textContent).toContain('l')
+    render(null, container)
+  })
+
+  it('renders goal horizons from goal_horizons object', () => {
+    const container = makeContainer()
+    render(html`<${KeeperBDIPanel} goal_horizons=${{ short: 'gs', mid: 'gm', long: 'gl' }} />`, container)
+    expect(container.textContent).toContain('gs')
+    expect(container.textContent).toContain('gm')
+    expect(container.textContent).toContain('gl')
+    render(null, container)
+  })
+
+  it('prefers direct goals over goal_horizons', () => {
+    const container = makeContainer()
+    render(html`<${KeeperBDIPanel} short_goal="direct" goal_horizons=${{ short: 'indirect' }} />`, container)
+    expect(container.textContent).toContain('direct')
+    expect(container.textContent).not.toContain('indirect')
+    render(null, container)
+  })
+
+  it('renders card title', () => {
+    const container = makeContainer()
+    render(html`<${KeeperBDIPanel} will="w" />`, container)
+    expect(container.textContent).toContain('BDI & Horizons')
+    render(null, container)
+  })
+
+  it('does not render BDI section when only goals provided', () => {
+    const container = makeContainer()
+    render(html`<${KeeperBDIPanel} short_goal="only goal" />`, container)
+    expect(container.textContent).not.toContain('의지')
+    expect(container.textContent).not.toContain('필요')
+    expect(container.textContent).toContain('only goal')
+    render(null, container)
+  })
+
+  it('does not render goals section when only BDI provided', () => {
+    const container = makeContainer()
+    render(html`<${KeeperBDIPanel} will="only will" />`, container)
+    expect(container.textContent).toContain('의지')
+    expect(container.textContent).not.toContain('goal horizons')
+    render(null, container)
+  })
+})

--- a/dashboard/src/components/keeper-detail-layout.test.ts
+++ b/dashboard/src/components/keeper-detail-layout.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+import { describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { KeeperDetailSectionCard } from './keeper-detail-layout'
+
+describe('KeeperDetailSectionCard', () => {
+  const makeContainer = () => document.createElement('div')
+
+  it('renders title', () => {
+    const container = makeContainer()
+    render(html`<${KeeperDetailSectionCard} title="Test Title">content<//>`, container)
+    expect(container.textContent).toContain('Test Title')
+    render(null, container)
+  })
+
+  it('renders children', () => {
+    const container = makeContainer()
+    render(html`<${KeeperDetailSectionCard} title="Title">child content<//>`, container)
+    expect(container.textContent).toContain('child content')
+    render(null, container)
+  })
+
+  it('has decorative dot', () => {
+    const container = makeContainer()
+    render(html`<${KeeperDetailSectionCard} title="T" />`, container)
+    const dot = container.querySelector('[aria-hidden="true"]')
+    expect(dot).not.toBeNull()
+    render(null, container)
+  })
+})

--- a/dashboard/src/components/keeper-detail-layout.test.ts
+++ b/dashboard/src/components/keeper-detail-layout.test.ts
@@ -23,7 +23,7 @@ describe('KeeperDetailSectionCard', () => {
 
   it('has decorative dot', () => {
     const container = makeContainer()
-    render(html`<${KeeperDetailSectionCard} title="T" />`, container)
+    render(html`<${KeeperDetailSectionCard} title="T"> <//>`, container)
     const dot = container.querySelector('[aria-hidden="true"]')
     expect(dot).not.toBeNull()
     render(null, container)

--- a/dashboard/src/components/live.test.ts
+++ b/dashboard/src/components/live.test.ts
@@ -1,0 +1,42 @@
+// @ts-nocheck
+import { describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Live } from './live'
+
+describe('Live', () => {
+  const makeContainer = () => document.createElement('div')
+
+  it('renders full variant by default', () => {
+    const container = makeContainer()
+    render(html`<${Live} />`, container)
+    expect(container.querySelector('[aria-label="라이브 협업 상태"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="이벤트 펄스 현황"]')).not.toBeNull()
+    render(null, container)
+  })
+
+  it('renders observatory variant without pulse strip', () => {
+    const container = makeContainer()
+    render(html`<${Live} variant="observatory" />`, container)
+    expect(container.querySelector('[aria-label="라이브 협업 상태"]')).toBeNull()
+    expect(container.querySelector('[aria-label="이벤트 펄스 현황"]')).toBeNull()
+    render(null, container)
+  })
+
+  it('observatory variant shows activity stream and focus sidebar', () => {
+    const container = makeContainer()
+    render(html`<${Live} variant="observatory" />`, container)
+    expect(container.querySelector('[aria-label="활동 스트림"]')).not.toBeNull()
+    expect(container.textContent).toContain('에이전트 상태 상세')
+    render(null, container)
+  })
+
+  it('full variant shows live-panels grid layout', () => {
+    const container = makeContainer()
+    render(html`<${Live} variant="full" />`, container)
+    expect(container.querySelector('.live-panels')).not.toBeNull()
+    expect(container.querySelector('[aria-label="활동 스트림"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="에이전트 상태 사이드바"]')).not.toBeNull()
+    render(null, container)
+  })
+})


### PR DESCRIPTION
## Summary
- Add focused dashboard coverage for Live variants, KeeperDetailSectionCard, and KeeperBDIPanel BDI/goal horizon rendering.
- Split batch 24 onto a clean branch after #12406 merged.

## Verification
- pnpm run typecheck
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-bdi-panel.test.ts src/components/keeper-detail-layout.test.ts src/components/live.test.ts