### PR TITLE
P-DASH-13: Add provider_block_duration histogram metric

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -404,8 +404,11 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
          [provider_info] can count Rejected separately for dashboards. *)
       state.consecutive_failures <- state.consecutive_failures + 1;
       bump_failure_fp ();
-      if state.consecutive_failures >= cooldown_threshold then
-        state.cooldown_until <- now +. cooldown_sec
+      if state.consecutive_failures >= cooldown_threshold then begin
+        state.cooldown_until <- now +. cooldown_sec;
+        Prometheus.observe_histogram Prometheus.metric_keeper_provider_block_duration_sec
+          ~labels:[("provider", provider_key)] cooldown_sec
+      end
     | Soft_rate_limited ->
       (* Transient HTTP 429.  Apply an immediate short cooldown so the
          current cascade cycle skips this provider for the next selection
@@ -425,8 +428,11 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
         | _ -> soft_rate_limit_cooldown_sec
       in
       let new_until = now +. cooldown_dur in
-      if new_until > state.cooldown_until then
-        state.cooldown_until <- new_until
+      if new_until > state.cooldown_until then begin
+        state.cooldown_until <- new_until;
+        Prometheus.observe_histogram Prometheus.metric_keeper_provider_block_duration_sec
+          ~labels:[("provider", provider_key)] cooldown_dur
+      end
     | Hard_quota ->
       (* Hard-quota errors (balance depleted, quota exceeded, resource
          exhausted) don't recover on short-window retries — set a long
@@ -437,8 +443,11 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       state.consecutive_failures <- state.consecutive_failures + 1;
       bump_failure_fp ();
       let new_until = now +. hard_quota_cooldown_sec in
-      if new_until > state.cooldown_until then
-        state.cooldown_until <- new_until
+      if new_until > state.cooldown_until then begin
+        state.cooldown_until <- new_until;
+        Prometheus.observe_histogram Prometheus.metric_keeper_provider_block_duration_sec
+          ~labels:[("provider", provider_key)] hard_quota_cooldown_sec
+      end
     | Terminal_failure ->
       (* Terminal structural errors are not quota exhaustion, but they have the
          same retry shape: the next cascade tick will hit the same provider
@@ -450,8 +459,11 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       state.consecutive_failures <- state.consecutive_failures + 1;
       bump_failure_fp ();
       let new_until = now +. terminal_failure_cooldown_sec in
-      if new_until > state.cooldown_until then
-        state.cooldown_until <- new_until)
+      if new_until > state.cooldown_until then begin
+        state.cooldown_until <- new_until;
+        Prometheus.observe_histogram Prometheus.metric_keeper_provider_block_duration_sec
+          ~labels:[("provider", provider_key)] terminal_failure_cooldown_sec
+      end)
 
 let record_success t ~provider_key ?latency_ms () =
   record t ~provider_key ~outcome:Success ?latency_ms

--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -405,9 +405,12 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       state.consecutive_failures <- state.consecutive_failures + 1;
       bump_failure_fp ();
       if state.consecutive_failures >= cooldown_threshold then begin
-        state.cooldown_until <- now +. cooldown_sec;
-        Prometheus.observe_histogram Prometheus.metric_keeper_provider_block_duration_sec
-          ~labels:[("provider", provider_key)] cooldown_sec
+        let new_until = now +. cooldown_sec in
+        if new_until > state.cooldown_until then begin
+          state.cooldown_until <- new_until;
+          Prometheus.observe_histogram Prometheus.metric_keeper_provider_block_duration_sec
+            ~labels:[("provider", provider_key)] cooldown_sec
+        end
       end
     | Soft_rate_limited ->
       (* Transient HTTP 429.  Apply an immediate short cooldown so the

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -953,6 +953,12 @@ let init () =
   add metric_keeper_turn_queue_depth
     "Current keeper turn wait queue depth (labels: channel=autonomous_queue)"
     Gauge;
+  (* P-DASH-13: provider block duration histogram.
+     Records the duration (in seconds) for which a provider is placed in
+     cooldown each time a cooldown is applied or extended.  Labels: provider. *)
+  register_histogram ~name:metric_keeper_provider_block_duration_sec
+    ~help:"Duration in seconds for which a provider is placed into cooldown \
+           (observed each time a cooldown is applied or extended). Labels: provider." ();
   add metric_timeout_policy_overshoot
     "Total cooperative-cancel timeout overshoots \
      (labels: layer, origin)"

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -298,6 +298,13 @@ let metric_keeper_provider_cooldown_skip =
 let metric_keeper_provider_cooldown_remaining_sec =
   "masc_keeper_provider_cooldown_remaining_sec"
 
+(* P-DASH-13: provider block duration histogram.
+   Records the duration (in seconds) for which a provider is placed
+   in cooldown each time a cooldown is applied or extended.
+   Labels: provider. *)
+let metric_keeper_provider_block_duration_sec =
+  "masc_keeper_provider_block_duration_sec"
+
 (* P-DASH-02: turn queue depth gauge.  Semaphore waiters are
    observable via [autonomous_waiter_snapshot_for_test] but were
    only emitted as a debug log line.  Surfacing as a gauge lets

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -115,6 +115,12 @@ val metric_keeper_provider_cooldown_remaining_sec : string
     Exposes the current cooldown duration so operators can see
     which cascade is blocked and for how long.  Labels: [keeper, cascade]. *)
 
+val metric_keeper_provider_block_duration_sec : string
+(** P-DASH-13: provider block duration histogram.
+    Records the duration (in seconds) for which a provider is placed
+    in cooldown each time a cooldown is applied or extended.
+    Labels: [provider]. *)
+
 val metric_keeper_turn_queue_depth : string
 (** P-DASH-02: turn queue depth gauge.  Semaphore waiter count
     surfaced so operators can alert on queue pressure without log

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -6,8 +6,19 @@
 
 open Alcotest
 module H = Masc_mcp.Cascade_health_tracker
+module P = Masc_mcp.Prometheus
 
 let kind value = H.error_kind_of_string value
+
+let provider_block_metric_labels provider_key = [("provider", provider_key)]
+
+let provider_block_duration_sum provider_key =
+  P.metric_value_or_zero P.metric_keeper_provider_block_duration_sec
+    ~labels:(provider_block_metric_labels provider_key) ()
+
+let provider_block_duration_count provider_key =
+  P.metric_value_or_zero (P.metric_keeper_provider_block_duration_sec ^ "_count")
+    ~labels:(provider_block_metric_labels provider_key) ()
 
 let test_record_success_keeps_rate_1 () =
   let t = H.create () in
@@ -142,6 +153,56 @@ let test_evict_idle_returns_zero_when_all_active () =
   H.record_failure t ~provider_key:"b" ();
   check int "no eviction when all providers have recent events"
     0 (H.evict_idle t)
+
+(* ── Provider block duration histogram (P-DASH-13) ──────────── *)
+
+let test_provider_block_duration_observed_after_failure_threshold () =
+  let provider_key = "p-dash-13-failure-threshold" in
+  let t = H.create () in
+  check (float 0.001) "no histogram count before failures" 0.0
+    (provider_block_duration_count provider_key);
+  H.record_failure t ~provider_key ();
+  H.record_failure t ~provider_key ();
+  check (float 0.001) "below threshold does not observe cooldown" 0.0
+    (provider_block_duration_count provider_key);
+  H.record_failure t ~provider_key ();
+  check (float 0.001) "threshold observes exactly once" 1.0
+    (provider_block_duration_count provider_key);
+  check bool "recorded block duration is positive" true
+    (provider_block_duration_sum provider_key > 0.0)
+
+let test_provider_block_duration_observed_for_immediate_cooldowns () =
+  let t = H.create () in
+  let soft_provider = "p-dash-13-soft-rl" in
+  let hard_provider = "p-dash-13-hard-quota" in
+  let terminal_provider = "p-dash-13-terminal" in
+  H.record_soft_rate_limited t ~provider_key:soft_provider ~retry_after_s:30.0 ();
+  check (float 0.001) "soft 429 count" 1.0
+    (provider_block_duration_count soft_provider);
+  check (float 0.001) "soft 429 observes Retry-After seconds" 30.0
+    (provider_block_duration_sum soft_provider);
+  H.record_hard_quota t ~provider_key:hard_provider ();
+  check (float 0.001) "hard quota count" 1.0
+    (provider_block_duration_count hard_provider);
+  check bool "hard quota duration is long" true
+    (provider_block_duration_sum hard_provider > 300.0);
+  H.record_terminal_failure t ~provider_key:terminal_provider ();
+  check (float 0.001) "terminal failure count" 1.0
+    (provider_block_duration_count terminal_provider);
+  check bool "terminal failure duration is long" true
+    (provider_block_duration_sum terminal_provider > 300.0)
+
+let test_provider_block_duration_skips_non_extending_cooldown () =
+  let provider_key = "p-dash-13-no-shortening" in
+  let t = H.create () in
+  H.record_hard_quota t ~provider_key ();
+  let count_after_hard_quota = provider_block_duration_count provider_key in
+  let sum_after_hard_quota = provider_block_duration_sum provider_key in
+  H.record_soft_rate_limited t ~provider_key ();
+  check (float 0.001) "shorter cooldown does not add observation"
+    count_after_hard_quota (provider_block_duration_count provider_key);
+  check (float 0.001) "shorter cooldown does not add duration"
+    sum_after_hard_quota (provider_block_duration_sum provider_key)
 
 (* ── Hard_quota outcome (0.161.0) ──────────────────── *)
 
@@ -682,6 +743,14 @@ let () =
         test_evict_idle_drops_no_event_providers;
       test_case "all-active → no eviction" `Quick
         test_evict_idle_returns_zero_when_all_active;
+    ];
+    "provider_block_duration", [
+      test_case "failure threshold observes one block duration" `Quick
+        test_provider_block_duration_observed_after_failure_threshold;
+      test_case "immediate cooldown outcomes observe block durations" `Quick
+        test_provider_block_duration_observed_for_immediate_cooldowns;
+      test_case "non-extending cooldown does not double-count" `Quick
+        test_provider_block_duration_skips_non_extending_cooldown;
     ];
     "hard_quota", [
       test_case "single event trips immediate cooldown" `Quick


### PR DESCRIPTION
## Summary

Adds `masc_keeper_provider_block_duration_sec` histogram metric to track how long providers are blocked in cooldown.

## Changes

- `lib/prometheus.ml` / `.mli`: New metric constant `metric_keeper_provider_block_duration_sec`
- `lib/cascade/cascade_health_tracker.ml`: Histogram observations at all 4 cooldown-setting paths:
  - `Failure` / `Rejected`: `cooldown_sec`
  - `Soft_rate_limited`: computed `cooldown_dur`
  - `Hard_quota`: `hard_quota_cooldown_sec`
  - `Terminal_failure`: `terminal_failure_cooldown_sec`
- `test/test_cascade_health_tracker.ml`: Regression coverage for histogram count/sum emission, immediate cooldown paths, and non-extending cooldown de-duplication.

Labels: `provider`.

## Test plan

- [x] `scripts/dune-local.sh build test/test_cascade_health_tracker.exe`
- [x] `./_build/default/test/test_cascade_health_tracker.exe` (53 tests)
- [ ] CI checks pass