### PR TITLE
test(dashboard): add batch 25 component coverage

### DIFF
--- a/dashboard/src/components/goals/planning.test.ts
+++ b/dashboard/src/components/goals/planning.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { PlanningStat } from './planning'
+
+describe('PlanningStat', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders label and value', () => {
+    render(
+      html`<${PlanningStat} label="전체 태스크" value=${42} />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('전체 태스크')
+    expect(container.textContent).toContain('42')
+  })
+
+  it('applies default tone class', () => {
+    render(
+      html`<${PlanningStat} label="Done" value=${5} />`,
+      container,
+    )
+
+    const valueDiv = container.querySelector('.text-3xl')
+    expect(valueDiv?.classList.contains('text-text-strong')).toBe(true)
+  })
+
+  it('applies bad tone class', () => {
+    render(
+      html`<${PlanningStat} label="Errors" value=${3} tone="bad" />`,
+      container,
+    )
+
+    const valueDiv = container.querySelector('.text-3xl')
+    expect(valueDiv?.classList.contains('text-bad')).toBe(true)
+  })
+
+  it('applies warn tone class', () => {
+    render(
+      html`<${PlanningStat} label="Warnings" value=${7} tone="warn" />`,
+      container,
+    )
+
+    const valueDiv = container.querySelector('.text-3xl')
+    expect(valueDiv?.classList.contains('text-warn')).toBe(true)
+  })
+
+  it('applies ok tone class', () => {
+    render(
+      html`<${PlanningStat} label="OK" value=${100} tone="ok" />`,
+      container,
+    )
+
+    const valueDiv = container.querySelector('.text-3xl')
+    expect(valueDiv?.classList.contains('text-ok')).toBe(true)
+  })
+
+  it('accepts string value', () => {
+    render(
+      html`<${PlanningStat} label="Status" value="active" />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('active')
+  })
+})

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -29,7 +29,7 @@ import { TaskCreateForm } from '../task-manage/task-create-form'
 
 const QUICK_START_DOC_URL = 'https://github.com/jeong-sik/masc-mcp/blob/main/docs/QUICK-START.md'
 
-function PlanningStat({
+export function PlanningStat({
   label,
   value,
   tone = 'default',

--- a/dashboard/src/components/keeper-detail-shell.test.ts
+++ b/dashboard/src/components/keeper-detail-shell.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { KeeperDetailSection } from './keeper-detail-shell'
+
+describe('KeeperDetailSection', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders eyebrow, title, description, and children', () => {
+    render(
+      html`<${KeeperDetailSection}
+        id="keeper-summary"
+        eyebrow="OVERVIEW"
+        title="Status Overview"
+        description="Summary of keeper state."
+      >
+        <div data-testid="child">Child</div>
+      <//>`,
+      container,
+    )
+
+    expect(container.textContent).toContain('OVERVIEW')
+    expect(container.textContent).toContain('Status Overview')
+    expect(container.textContent).toContain('Summary of keeper state.')
+    expect(container.querySelector('[data-testid="child"]')).not.toBeNull()
+  })
+
+  it('sets section id and aria-label', () => {
+    render(
+      html`<${KeeperDetailSection}
+        id="keeper-debug"
+        eyebrow="DEBUG"
+        title="Debug"
+        description="Debug info."
+      >
+        <span>content</span>
+      <//>`,
+      container,
+    )
+
+    const section = container.querySelector('section')
+    expect(section?.getAttribute('id')).toBe('keeper-debug')
+    expect(section?.getAttribute('aria-label')).toBe('Debug')
+  })
+
+  it('applies scroll margin and rounded styling', () => {
+    render(
+      html`<${KeeperDetailSection}
+        id="keeper-config"
+        eyebrow="CONFIG"
+        title="Configuration"
+        description="Config details."
+      >
+        <div>inner</div>
+      <//>`,
+      container,
+    )
+
+    const section = container.querySelector('section')
+    expect(section?.classList.contains('scroll-mt-24')).toBe(true)
+    expect(section?.classList.contains('rounded-[28px]')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Add focused dashboard coverage for PlanningStat and KeeperDetailSection.
- Export PlanningStat so the small stat leaf can be tested directly.

## Verification
- pnpm run typecheck
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/goals/planning.test.ts src/components/keeper-detail-shell.test.ts