### PR TITLE
fix(dashboard): stabilize keeper detail route render

### DIFF
--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -150,7 +150,7 @@ function GateCard({
             <span class="text-[var(--bad-light)]">⊘ ${blocked}</span>
           </div>
         </div>
-      </${SurfaceCard}>
+      <//>
     </button>
   `
 }
@@ -196,7 +196,7 @@ function EvidenceDetail({ event }: { event: AttributionEvent | null }) {
     return html`
       <${SurfaceCard} variant="light">
         <${EmptyState} message="이벤트를 선택하면 evidence가 여기 표시됩니다." />
-      </${SurfaceCard}>
+      <//>
     `
   }
   const a = event.attribution
@@ -219,7 +219,7 @@ function EvidenceDetail({ event }: { event: AttributionEvent | null }) {
           : null}
         <pre class="text-2xs font-mono bg-[var(--white-5)]/30 rounded p-3 overflow-x-auto max-h-64 whitespace-pre-wrap">${evidenceJson}</pre>
       </div>
-    </${SurfaceCard}>
+    <//>
   `
 }
 
@@ -365,7 +365,7 @@ export function AttributionPanel() {
                   />
                 `)}
           </div>
-        </${SurfaceCard}>
+        <//>
 
         <${EvidenceDetail} event=${selected} />
       </div>

--- a/dashboard/src/components/common/route-link.a11y.test.ts
+++ b/dashboard/src/components/common/route-link.a11y.test.ts
@@ -23,7 +23,7 @@ describe('RouteLink a11y', () => {
 
   it('default link passes axe', async () => {
     render(
-      html`<${RouteLink} tab="overview">Overview</${RouteLink}>`,
+      html`<${RouteLink} tab="overview">Overview<//>`,
       container,
     )
     expect(await axe(container)).toHaveNoViolations()
@@ -31,7 +31,7 @@ describe('RouteLink a11y', () => {
 
   it('aria-current=page passes axe', async () => {
     render(
-      html`<${RouteLink} tab="monitoring" ariaCurrent="page">Monitoring</${RouteLink}>`,
+      html`<${RouteLink} tab="monitoring" ariaCurrent="page">Monitoring<//>`,
       container,
     )
     expect(await axe(container)).toHaveNoViolations()
@@ -42,7 +42,7 @@ describe('RouteLink a11y', () => {
       html`<${RouteLink}
         tab="logs"
         title="Open the system logs view"
-      >Logs</${RouteLink}>`,
+      >Logs<//>`,
       container,
     )
     expect(await axe(container)).toHaveNoViolations()
@@ -53,7 +53,7 @@ describe('RouteLink a11y', () => {
       html`<${RouteLink}
         tab="command"
         params=${{ keeper: 'sigma' }}
-      >Command sigma</${RouteLink}>`,
+      >Command sigma<//>`,
       container,
     )
     expect(await axe(container)).toHaveNoViolations()

--- a/dashboard/src/components/common/section-cap.a11y.test.ts
+++ b/dashboard/src/components/common/section-cap.a11y.test.ts
@@ -22,13 +22,13 @@ describe('SectionCap a11y', () => {
   })
 
   it('default (muted + normal) passes axe', async () => {
-    render(html`<${SectionCap}>Recent activity</${SectionCap}>`, container)
+    render(html`<${SectionCap}>Recent activity<//>`, container)
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('tone=dim variant passes axe', async () => {
     render(
-      html`<${SectionCap} tone="dim">Telemetry</${SectionCap}>`,
+      html`<${SectionCap} tone="dim">Telemetry<//>`,
       container,
     )
     expect(await axe(container)).toHaveNoViolations()
@@ -36,7 +36,7 @@ describe('SectionCap a11y', () => {
 
   it('weight=semibold variant passes axe', async () => {
     render(
-      html`<${SectionCap} weight="semibold">Allowlist</${SectionCap}>`,
+      html`<${SectionCap} weight="semibold">Allowlist<//>`,
       container,
     )
     expect(await axe(container)).toHaveNoViolations()
@@ -46,7 +46,7 @@ describe('SectionCap a11y', () => {
     render(
       html`<${SectionCap} class="mb-2 border-b border-[var(--white-5)]">
         Diagnostics
-      </${SectionCap}>`,
+      <//>`,
       container,
     )
     expect(await axe(container)).toHaveNoViolations()

--- a/dashboard/src/components/common/status-chip.a11y.test.ts
+++ b/dashboard/src/components/common/status-chip.a11y.test.ts
@@ -28,7 +28,7 @@ describe('StatusChip a11y', () => {
   })
 
   it('children API passes axe', async () => {
-    render(html`<${StatusChip}>Active</${StatusChip}>`, container)
+    render(html`<${StatusChip}>Active<//>`, container)
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -47,7 +47,7 @@ describe('StatusChip a11y', () => {
 
   it('uppercase=false (plain pill) passes axe', async () => {
     render(
-      html`<${StatusChip} uppercase=${false}>file/path.ts</${StatusChip}>`,
+      html`<${StatusChip} uppercase=${false}>file/path.ts<//>`,
       container,
     )
     expect(await axe(container)).toHaveNoViolations()

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -361,7 +361,7 @@ export function DoctorPanel() {
             </div>
           `}
         />
-      </${Card}>
+      <//>
     </div>
   `
 }

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -400,7 +400,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
             hint=${(keeper.handoff_count_total ?? 0) === 0 ? '첫 인계 후 표시' : '누적 lineage 길이'}
           />
         </div>
-      </${KpiSection}>
+      <//>
 
       <${KpiSection} title="메모리 압력" question="지금 위험한가?">
         <div class="flex flex-col gap-3">
@@ -454,7 +454,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
             </div>
           ` : null}
         </div>
-      </${KpiSection}>
+      <//>
 
       <${KpiSection} title="자율성 패턴" question="스스로 돌고 있나?">
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
@@ -481,7 +481,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
             hint="아무 작업 없는 턴"
           />
         </div>
-      </${KpiSection}>
+      <//>
 
       <${KpiSection} title="결과" question="무엇을 해냈고 실패했고 검증을 통과했나?">
         ${outcomes ? html`<${OutcomesLedger} keeper=${keeper} outcomes=${outcomes} />` : html`
@@ -489,7 +489,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
             outcomes 집계를 불러오는 중이거나, 이 키퍼는 아직 관찰된 전이가 없습니다.
           </div>
         `}
-      </${KpiSection}>
+      <//>
     </div>
   `
 }

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -299,12 +299,12 @@ export function KeeperDetailOverviewSidebar({
         </div>
 
         <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
-          <${KeeperDetailQuickFact} label="상태">${effectiveStatus}</${KeeperDetailQuickFact}>
-          <${KeeperDetailQuickFact} label="컨텍스트">${contextRatioPct}</${KeeperDetailQuickFact}>
-          <${KeeperDetailQuickFact} label=${effectiveModelLabel}>${effectiveModel}</${KeeperDetailQuickFact}>
+          <${KeeperDetailQuickFact} label="상태">${effectiveStatus}<//>
+          <${KeeperDetailQuickFact} label="컨텍스트">${contextRatioPct}<//>
+          <${KeeperDetailQuickFact} label=${effectiveModelLabel}>${effectiveModel}<//>
           <${KeeperDetailQuickFact} label="최근 활동">
             <${KeeperActivityValue} activity=${activity} />
-          </${KeeperDetailQuickFact}>
+          <//>
         </div>
 
         <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] p-3.5">

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -1,9 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { html } from 'htm/preact'
 
 import type { Keeper } from '../types'
 import type { RouteState } from '../types'
+import { keepers } from '../store'
 
 const mocks = vi.hoisted(() => ({
+  fetchKeeperTransitions: vi.fn(async () => ({ transitions: [] })),
   loadKeeperConfig: vi.fn(async () => {}),
   resetKeeperConfig: vi.fn(),
   selectKeeper: vi.fn(),
@@ -17,6 +21,20 @@ const mocks = vi.hoisted(() => ({
   },
 }))
 
+vi.mock('../api/keeper', async () => {
+  const actual = await vi.importActual<typeof import('../api/keeper')>('../api/keeper')
+  return {
+    ...actual,
+    bootKeeper: vi.fn(async () => ({ ok: true })),
+    clearKeeper: vi.fn(async () => ({ ok: true })),
+    fetchKeeperTransitions: mocks.fetchKeeperTransitions,
+    pauseKeeper: vi.fn(async () => ({ ok: true })),
+    resumeKeeper: vi.fn(async () => ({ ok: true })),
+    shutdownKeeper: vi.fn(async () => ({ ok: true })),
+    wakeKeeper: vi.fn(async () => ({ ok: true })),
+  }
+})
+
 vi.mock('./keeper-config-panel', async () => {
   const actual = await vi.importActual<typeof import('./keeper-config-panel')>('./keeper-config-panel')
   return {
@@ -27,9 +45,74 @@ vi.mock('./keeper-config-panel', async () => {
   }
 })
 
-vi.mock('../keeper-runtime', () => ({
-  selectKeeper: mocks.selectKeeper,
+vi.mock('./keeper-detail-panels', () => ({
+  ContextChart: () => null,
+  CtxCompositionPanel: () => null,
+  EquipmentList: () => null,
+  InferenceTelemetryPanel: () => null,
+  KpiGrid: () => null,
+  MetricsCharts: () => null,
+  PromptTelemetryPanel: () => null,
+  RawDataDebug: () => null,
+  RelationshipList: () => null,
+  TokenTrendChart: () => null,
+  TraitsList: () => null,
 }))
+
+vi.mock('./keeper-detail-history', async () => {
+  const actual = await vi.importActual<typeof import('./keeper-detail-history')>('./keeper-detail-history')
+  return {
+    ...actual,
+    GenerationLineagePanel: () => null,
+    KeeperCheckpointPanel: () => null,
+  }
+})
+
+vi.mock('./keeper-state-diagram', () => ({
+  KeeperStateDiagramPanel: () => null,
+}))
+
+vi.mock('./keeper-memory-tier-panel', () => ({
+  KeeperMemoryTierPanel: () => null,
+}))
+
+vi.mock('./keeper-tool-telemetry', () => ({
+  KeeperToolTelemetry: () => null,
+}))
+
+vi.mock('./keeper-tool-call-inspector', () => ({
+  KeeperToolCallInspector: () => null,
+}))
+
+vi.mock('./keeper-supervisor-diagnostics', () => ({
+  SupervisorDiagnosticsPanel: () => null,
+}))
+
+vi.mock('./keeper-eval-quality', () => ({
+  KeeperEvalQualityPanel: () => null,
+}))
+
+vi.mock('./session-trace/session-trace-view', () => ({
+  SessionTraceView: () => null,
+}))
+
+vi.mock('./agent-detail-journal', () => ({
+  AgentJournalStream: () => null,
+}))
+
+vi.mock('./keeper-shared', () => ({
+  KeeperConversationPanel: () => null,
+  KeeperDiagnosticSummary: () => null,
+  KeeperRuntimeActions: () => null,
+}))
+
+vi.mock('../keeper-runtime', async () => {
+  const actual = await vi.importActual<typeof import('../keeper-runtime')>('../keeper-runtime')
+  return {
+    ...actual,
+    selectKeeper: mocks.selectKeeper,
+  }
+})
 
 vi.mock('../router', () => ({
   navigate: mocks.navigate,
@@ -37,6 +120,7 @@ vi.mock('../router', () => ({
 }))
 
 import {
+  KeeperDetailPage,
   clearKeeperDetailSelection,
   closeKeeperDetail,
   filterCheckpointHistory,
@@ -47,9 +131,16 @@ import {
 } from './keeper-detail'
 import type { KeeperCheckpointSummary } from '../api/keeper'
 
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
 describe('openKeeperDetail', () => {
   beforeEach(() => {
     selectedKeeper.value = null
+    keepers.value = []
+    mocks.fetchKeeperTransitions.mockClear()
     mocks.loadKeeperConfig.mockClear()
     mocks.resetKeeperConfig.mockClear()
     mocks.selectKeeper.mockClear()
@@ -138,6 +229,89 @@ describe('openKeeperDetail', () => {
     expect(selectedKeeper.value).toBeNull()
     expect(mocks.resetKeeperConfig).toHaveBeenCalledTimes(1)
     expect(mocks.selectKeeper).toHaveBeenCalledWith('')
+  })
+})
+
+describe('KeeperDetailPage', () => {
+  beforeEach(() => {
+    selectedKeeper.value = null
+    keepers.value = []
+    mocks.fetchKeeperTransitions.mockClear()
+    mocks.loadKeeperConfig.mockClear()
+    mocks.selectKeeper.mockClear()
+    mocks.route.value = {
+      tab: 'monitoring',
+      params: { section: 'agents', view: 'keepers', keeper: 'analyst' },
+      postId: null,
+    }
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({}), {
+      headers: { 'content-type': 'application/json' },
+      status: 200,
+    })))
+  })
+
+  it('renders a live keeper detail route without tripping the monitoring error boundary', () => {
+    const analyst = {
+      name: 'analyst',
+      status: 'active',
+      phase: 'Running',
+      pipeline_stage: 'idle',
+      agent_name: 'keeper-analyst-agent',
+      runtime_class: 'keeper',
+      keepalive_running: true,
+      short_goal: '현재 대화의 근거와 핵심 수치를 먼저 정리한다.',
+      mid_goal: '세션 전반의 검증 기준을 유지한다.',
+      long_goal: '사실과 가설을 분리하는 구현 파트너가 된다.',
+      generation: 0,
+      turn_count: 97,
+      last_turn_ago_s: 1108,
+      primary_model: 'codex_cli:gpt-5.3-codex-spark',
+      active_model: 'claude_code:auto',
+      active_model_label: 'claude_code:auto',
+      context_ratio: 0.000008,
+      context_tokens: 8,
+      context_max: 1000000,
+      last_speech_act: 'defer',
+      recent_tool_names: ['keeper_stay_silent', 'keeper_tasks_list', 'keeper_shell'],
+      agent: {
+        exists: true,
+        name: 'keeper-analyst-agent',
+        agent_type: 'agent',
+        status: 'active',
+        capabilities: ['keeper', 'preset:research'],
+        current_task: null,
+        joined_at: '2026-05-01T00:46:51Z',
+        last_seen: '2026-05-01T00:48:26Z',
+        age_s: 1206,
+        last_seen_ago_s: 1111,
+        is_zombie: false,
+      },
+      diagnostic: {
+        summary: 'Keeper runtime is reconciling back into live presence.',
+        continuity_state: 'recovering',
+        continuity_summary: 'Keeper runtime is reconciling back into live presence.',
+        health_state: 'stale',
+        quiet_reason: null,
+        next_action_path: 'recover',
+        recoverable: true,
+        last_reply_status: 'never',
+        last_reply_at: null,
+        last_reply_preview: null,
+        last_error: null,
+        keepalive_running: true,
+        next_eligible_at_s: null,
+      },
+      trust: {
+        disposition: 'Pause',
+        disposition_reason: 'tool_required_unsatisfied',
+        needs_attention: true,
+      },
+    } as unknown as Keeper
+    keepers.value = [analyst]
+
+    render(html`<${KeeperDetailPage} />`)
+    expect(screen.getByText('analyst')).toBeTruthy()
+    expect(mocks.selectKeeper).toHaveBeenCalledWith('analyst')
   })
 })
 
@@ -275,4 +449,3 @@ describe('lineageTransitionLabel', () => {
     expect(lineageTransitionLabel(4, 5)).toBe('gen 4 -> gen 5')
   })
 })
-

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1155,6 +1155,7 @@ export function KeeperDetailPage() {
               long_goal=${keeper.long_goal}
               goal_horizons=${keeper.goal_horizons}
             />
+              <//>
 
           ${keeper.inventory && keeper.inventory.length > 0
             ? html`

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -800,7 +800,7 @@ export function KeeperDetailPage() {
   const keeper = resolveKeeperForDetail(
     keeperName,
     findKeeper(keeperName),
-    selectedKeeper.value,
+    selectedKeeper.peek(),
     keepers.value.length,
   )
   if (!keeper) {
@@ -1064,7 +1064,7 @@ export function KeeperDetailPage() {
 
         ${'' /* ── Inference Telemetry (tok/s, cache, reasoning) ── */}
         <${InferenceTelemetryPanel} keeper=${keeper} />
-          </${KeeperDetailSection}>
+          <//>
 
           <${KeeperDetailSection}
             id="keeper-comms"
@@ -1077,7 +1077,7 @@ export function KeeperDetailPage() {
               <div class="text-2xs text-[var(--color-fg-muted)] mb-3">현재 세션의 도구 호출, 태스크 완료, 메시지 등 이벤트 기록</div>
               <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
             <//>
-          </${KeeperDetailSection}>
+          <//>
 
           <${KeeperDetailSection}
             id="keeper-runtime"
@@ -1118,7 +1118,7 @@ export function KeeperDetailPage() {
               <div class="mt-3 text-2xs text-[var(--color-fg-muted)] mb-3">폴백 비율, 정렬 품질, 자율 행동 비율 등 metrics_window 기반 런타임 품질 지표</div>
               <${RuntimeSignals} keeper=${keeper} />
             </details>
-          </${KeeperDetailSection}>
+          <//>
 
           <${KeeperDetailSection}
             id="keeper-identity"
@@ -1187,7 +1187,7 @@ export function KeeperDetailPage() {
               />
             </div>
           </details>
-          </${KeeperDetailSection}>
+          <//>
 
           <${KeeperDetailSection}
             id="keeper-config"
@@ -1215,7 +1215,7 @@ export function KeeperDetailPage() {
                 <${KeeperConfigPanel} keeperName=${keeper.name} />
               </div>
             </details>
-          </${KeeperDetailSection}>
+          <//>
 
           <${KeeperDetailSection}
             id="keeper-debug"
@@ -1239,7 +1239,7 @@ export function KeeperDetailPage() {
             </div>
           </div>
         </details>
-          </${KeeperDetailSection}>
+          <//>
 
         <${KeeperClearContextDialog}
           keeperName=${keeper.name}

--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -233,7 +233,7 @@ export function KeeperRepoMapping() {
   }
 
   if (kState.status === 'loading' || rState.status === 'loading' || mState.status === 'loading') {
-    return html`<${LoadingState}>키퍼와 저장소 정보 불러오는 중...</${LoadingState}>`
+    return html`<${LoadingState}>키퍼와 저장소 정보 불러오는 중...<//>`
   }
 
   if (kState.status === 'error') {

--- a/dashboard/src/components/oas-health-chip.ts
+++ b/dashboard/src/components/oas-health-chip.ts
@@ -101,7 +101,7 @@ export function OasHealthChip() {
     return html`
       <${Card} title="OAS 런타임">
         <${EmptyState} message="아직 OAS 이벤트가 수신되지 않았습니다." />
-      </${Card}>
+      <//>
     `
   }
 
@@ -196,6 +196,6 @@ export function OasHealthChip() {
           ` : null}
         </div>
       ` : null}
-    </${Card}>
+    <//>
   `
 }


### PR DESCRIPTION
## Summary
- Fix the monitoring agents keeper detail route crash by reading `selectedKeeper` as a non-reactive fallback during render.
- Replace remaining production `htm/preact` dynamic component closing forms with the canonical `<//>` close form.
- Add a regression test for direct keeper-detail URL render when a live keeper exists and `selectedKeeper` starts empty.

## Product impact
Operators can open `/dashboard#monitoring?section=agents&keeper=...` directly without the monitoring error boundary taking down the agents view. This specifically covers the live failure seen on the `analyst` keeper route with `insertBefore` throwing from the Preact DOM diff.

## Evidence
- `pnpm exec vitest run --config vitest.config.ts src/components/keeper-detail.test.ts src/components/keeper-detail-panels.test.ts src/components/common/section-cap.a11y.test.ts src/components/common/status-chip.a11y.test.ts src/components/common/route-link.a11y.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty`
- `pnpm run build`
- Local 8935 static dashboard index now serves the rebuilt bundle after copying ignored dashboard assets for live verification.

## Review evidence
- Review focus: `dashboard/src/components/keeper-detail.ts` signal subscription change and `htm/preact` closing syntax cleanup.
- The new regression test keeps heavy child panels mocked and exercises the route-level render contract that triggered the live crash.
- No OCaml/backend code changed.

## Linked issue
- Not linked. Operator-reported live dashboard crash from `monitoring:agents` route.
