### PR TITLE
feat(diag): keeper cycle reproducer (silence/error burst measurement)

### DIFF
--- a/scripts/diag-keeper-cycle.sh
+++ b/scripts/diag-keeper-cycle.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# diag-keeper-cycle.sh — keeper "active → silent → error burst → silent" cycle reproducer
+#
+# Reads existing on-disk evidence (~/.masc/keepers/<name>.decisions.jsonl,
+# <name>.json) and emits per-keeper cycle metrics. Code change zero — this is
+# strictly a measurement tool that surfaces signals already persisted by the
+# server but currently invisible to operators.
+#
+# Usage: diag-keeper-cycle.sh [--base-path PATH] [--keeper NAME]
+#                             [--window-min N] [--top-gaps N]
+# Exit codes: 0 ok, 2 base path missing, 3 jq missing.
+
+set -euo pipefail
+
+BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-$HOME/me}}"
+KEEPER_FILTER=""
+WINDOW_MIN=60
+TOP_GAPS=5
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-path) BASE_PATH="$2"; shift 2 ;;
+    --keeper)    KEEPER_FILTER="$2"; shift 2 ;;
+    --window-min) WINDOW_MIN="$2"; shift 2 ;;
+    --top-gaps)  TOP_GAPS="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 64 ;;
+  esac
+done
+
+command -v jq >/dev/null || { echo "jq required" >&2; exit 3; }
+KEEPERS_DIR="$BASE_PATH/.masc/keepers"
+[[ -d "$KEEPERS_DIR" ]] || { echo "no keepers dir at $KEEPERS_DIR" >&2; exit 2; }
+
+NOW="$(date +%s)"
+WINDOW_AGO=$((NOW - WINDOW_MIN * 60))
+
+if [[ -n "$KEEPER_FILTER" ]]; then
+  files=( "$KEEPERS_DIR/$KEEPER_FILTER.decisions.jsonl" )
+else
+  files=()
+  while IFS= read -r line; do files+=( "$line" ); done < <(
+    find "$KEEPERS_DIR" -maxdepth 1 -name '*.decisions.jsonl' | sort
+  )
+fi
+
+printf '%-14s %6s %6s %6s %6s %6s %8s %8s %8s %8s %s\n' \
+  KEEPER TOTAL OK ERR NULL RECENT P50_S P95_S MAX_S SILENT_MIN TOP_GAPS_MIN
+printf '%s\n' "------------------------------------------------------------------------------------------------------------"
+
+for f in "${files[@]}"; do
+  [[ -f "$f" ]] || continue
+  name="$(basename "$f" .decisions.jsonl)"
+
+  read -r total ok err nul recent p50 p95 mx silent gaps_csv < <(
+    jq -sr --argjson now "$NOW" --argjson cutoff "$WINDOW_AGO" --argjson topn "$TOP_GAPS" '
+      def safe_lat: (.latency_ms // 0) / 1000;
+      def percentile($p):
+        if length == 0 then 0 else
+          sort | .[(length * $p / 100 | floor) | if . >= length then length-1 else . end]
+        end;
+      ( . ) as $all
+      | ([ .[] | .ts_unix // 0 ] | sort) as $ts
+      | (
+          [range(1; $ts | length) | ($ts[.] - $ts[.-1])]
+          | map(select(. > 0))
+        ) as $gaps
+      | ($ts | last // 0) as $last_ts
+      | [
+          ($all | length),
+          ([ .[] | select(.outcome == "success") ] | length),
+          ([ .[] | select(.outcome == "error") ] | length),
+          ([ .[] | select(.outcome == null) ] | length),
+          ([ .[] | select((.ts_unix // 0) >= $cutoff) ] | length),
+          ([ .[] | safe_lat ] | percentile(50)),
+          ([ .[] | safe_lat ] | percentile(95)),
+          ([ .[] | safe_lat ] | max // 0),
+          (if $last_ts > 0 then (($now - $last_ts) / 60) else -1 end),
+          ($gaps | sort | reverse | .[0:$topn] | map(. / 60 | floor) | join(","))
+        ]
+      | @tsv
+    ' "$f"
+  )
+
+  printf '%-14s %6s %6s %6s %6s %6s %8.1f %8.1f %8.1f %8.1f %s\n' \
+    "$name" "$total" "$ok" "$err" "$nul" "$recent" \
+    "$p50" "$p95" "$mx" "$silent" "$gaps_csv"
+done
+
+echo
+echo "Legend:"
+echo "  TOTAL/OK/ERR/NULL  decision count by outcome"
+echo "  RECENT             decisions in last ${WINDOW_MIN}m"
+echo "  P50/P95/MAX_S      latency seconds across all decisions"
+echo "  SILENT_MIN         minutes since last decision (-1 = no data)"
+echo "  TOP_GAPS_MIN       largest gaps between decisions (minutes), top ${TOP_GAPS}"


### PR DESCRIPTION
## Summary

Adds \`scripts/diag-keeper-cycle.sh\` — a read-only reproducer that surfaces what is **already** persisted in \`~/.masc/keepers/<name>.{json,decisions.jsonl}\` but is currently invisible to operators.

No code change to the server. Pure measurement tool.

## Output (live snapshot, dev base path, 14 keepers)

\`\`\`
KEEPER          TOTAL     OK    ERR   NULL RECENT    P50_S    P95_S    MAX_S SILENT_MIN
nick0cave         603     81    393    129      2      2.1   1199.1   3602.1     46.5
qa-king           490    118    244    128      1     18.7   1172.0   3584.8     48.0
sangsu            717    160    231    326      3      0.6    898.2   3585.3     47.1
ollama-local      443     41     91    311      0      0.0   1126.6   3585.2    700.9
velvet-hammer      83     27     25     31      0     58.2    414.4   3584.9    850.6
\`\`\`

## What it surfaces

- per-keeper \`success / error / null\` outcome counts
- p50 / p95 / max latency in seconds across all decisions
- recent activity within configurable window
- minutes since last decision
- top-N gaps between consecutive decisions (silence cycles)

## Why this exists

This script is the prerequisite for cascade and watchdog work to be evidence-driven instead of restart-driven:

- RFC-0022 (cascade attempt liveness) uses this output as its empirical baseline (Phase A pre-vs-post comparison)
- RFC-0012 (mid-turn progress probe) uses it to validate that progress kills land on hung turns

Empirical findings from first run:
- MAX_S clusters within 1s of 3600s for 11/14 keepers — \`MASC_KEEPER_TURN_TIMEOUT_SEC\` cap is the dominant failure mode
- P95 is bimodal at ~1170s / ~3585s — no sub-1000s liveness check exists in cascade
- nick0cave error rate 65%, qa-king 50%, masc-improver 55% null share
- several keepers show 27-46h gaps between decisions

## Test plan

- [x] runs on dev base path against 14 keepers
- [x] bash 3.2 compatible (macOS default)
- [x] requires only \`jq\`
- [ ] reviewer runs against own \`~/.masc\` and sees plausible numbers
- [ ] document the script in \`docs/operations/\` (deferred — keep this PR diff small)

## Related

- RFC-0022 (#12433) — cascade attempt liveness, consumes this output
- RFC-0012 — mid-turn progress probe, consumes this output