### PR TITLE
refactor(keeper): type world observation cascade cooldown

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -147,7 +147,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let effective_cascade_name =
         match
           Keeper_world_observation.provider_cooldown_remaining_sec_for_cascade
-            ~cascade_name:(KCP.Runtime_name effective_cascade_name)
+            ~cascade_name:(KCP.runtime_name_of_string effective_cascade_name)
         with
         | Some remaining_sec ->
             Prometheus.set_gauge

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -147,7 +147,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let effective_cascade_name =
         match
           Keeper_world_observation.provider_cooldown_remaining_sec_for_cascade
-            ~cascade_name:effective_cascade_name
+            ~cascade_name:(KCP.Runtime_name effective_cascade_name)
         with
         | Some remaining_sec ->
             Prometheus.set_gauge

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1009,7 +1009,7 @@ let keeper_cycle_decision
           if should_run
           then
             provider_cooldown_remaining_sec
-              ~cascade_name:(Keeper_cascade_profile.Runtime_name meta.cascade_name)
+              ~cascade_name:(Keeper_cascade_profile.runtime_name_of_string meta.cascade_name)
           else None
         in
         let provider_cooldown_fail_open =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -857,10 +857,10 @@ let fallback_cascade_for_provider_cooldown
   else Some Keeper_config.default_cascade_name
 
 let provider_cooldown_remaining_sec_for_cascade
-    ~(cascade_name : string) : int option =
+    ~(cascade_name : Keeper_cascade_profile.runtime_name) : int option =
   let model_ids =
     Cascade_runtime.models_of_cascade_name
-      (Keeper_cascade_profile.Runtime_name cascade_name)
+      cascade_name
     |> Cascade_config.parse_model_strings
     |> List.map (fun (cfg : Llm_provider.Provider_config.t) ->
            String.trim cfg.model_id)
@@ -1007,7 +1007,9 @@ let keeper_cycle_decision
         in
         let provider_cooldown_remaining_sec =
           if should_run
-          then provider_cooldown_remaining_sec ~cascade_name:meta.cascade_name
+          then
+            provider_cooldown_remaining_sec
+              ~cascade_name:(Keeper_cascade_profile.Runtime_name meta.cascade_name)
           else None
         in
         let provider_cooldown_fail_open =

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -238,14 +238,16 @@ val effective_proactive_cooldown :
   ?consecutive_noop_count:int -> unit -> int
 
 val provider_cooldown_remaining_sec_for_cascade :
-  cascade_name:string -> int option
+  cascade_name:Keeper_cascade_profile.runtime_name -> int option
 
 val keeper_cycle_decision :
-  ?provider_cooldown_remaining_sec:(cascade_name:string -> int option) ->
+  ?provider_cooldown_remaining_sec:
+    (cascade_name:Keeper_cascade_profile.runtime_name -> int option) ->
   meta:Keeper_types.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val unified_turn_decision :
-  ?provider_cooldown_remaining_sec:(cascade_name:string -> int option) ->
+  ?provider_cooldown_remaining_sec:
+    (cascade_name:Keeper_cascade_profile.runtime_name -> int option) ->
   meta:Keeper_types.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val should_run_keeper_cycle :


### PR DESCRIPTION
## Summary
- Narrow `Keeper_world_observation.provider_cooldown_remaining_sec_for_cascade` to accept `Keeper_cascade_profile.runtime_name`.
- Keep the meta/public string boundary at the caller and wrap once before provider cooldown lookup.
- Continue #11926 stringly-boundary cleanup: raw cascade_name signatures drop from 27 to 23 on current main.

## Evidence
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `scripts/stringly-boundary-ratchet.sh` (`raw_cascade_name_string_signatures 23 / 81`)
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `./_build/default/test/test_keeper_unified.exe test world_observation 14`
- `./_build/default/test/test_keeper_unified.exe test world_observation 15`

Refs #11926
