### PR TITLE
fix(coord_worktree): remove first-clone alphabetical fallback

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -64,7 +64,7 @@ Sandbox layout (NOT `/workspace` — that path does not exist; see <world> WRONG
 
 Clone-then-worktree (one turn is fine when the task is clear):
 1. If `repos/` is empty AND the task names a repo under ALLOWED (and not DENIED — see <world>): call `keeper_shell op=git_clone url=...` first.
-2. In the SAME turn, call `masc_worktree_create task_id=<id>` (targets first clone alphabetically, or pass `repo_name=<dir>` to pick a specific one). `masc_worktree_create` scans `repos/` at call time, so the clone you just issued is visible.
+2. In the SAME turn, call `masc_worktree_create task_id=<id> repo_name=<dir>` (repo_name is required to select the target clone). `masc_worktree_create` resolves repos/<repo_name>/ at call time, so the clone you just issued is visible.
 3. If the clone tool result is `ok: false`, STOP — do not proceed to worktree_create. Read `detail.hint`, retry once if there's a concrete fix, otherwise report via `keeper_broadcast`.
 4. Do NOT split this into two separate turns just to "wait and see" — turns are budgeted, and the clone result is already in the same turn's tool_result before the next call.
 

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -737,10 +737,9 @@ let link_worktree_to_task config ~task_id ~worktree_info =
 
 (** Create worktree for agent - Result version
     @param link_task If true, links worktree info to the task in backlog (default: true)
-    @param repo_name If set, target the keeper's sandbox repo clone at
-           [.masc/playground/<agent>/repos/<repo_name>/] directly. If
-           unset, scan [repos/] and use the first git clone found
-           (alphabetical). A sandbox repo clone is required. *)
+    @param repo_name Required. Targets the keeper's sandbox repo clone at
+           [.masc/playground/<agent>/repos/<repo_name>/]. A sandbox repo
+           clone is required; omitting [repo_name] is an error. *)
 let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~base_branch : string masc_result =
   if not (is_initialized config) then
     Error NotInitialized
@@ -752,9 +751,8 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
   | Ok _, Ok _ ->
     with_worktree_mutation_lock @@ fun () ->
     (* Prefer a keeper's sandbox repo clone under
-       the keeper's backend-specific sandbox repo lane. If [repo_name]
-       is supplied, target that clone directly; otherwise scan the
-       directory and pick the first git clone (alphabetical). Keepers
+       the keeper's backend-specific sandbox repo lane. [repo_name]
+       is required to disambiguate which clone to use. Keepers
        may work on any repo their [tool_policy.toml] allows, but the
        worktree root must come from a sandbox repo clone. *)
     let resolve_keeper_repo_root () =
@@ -769,26 +767,6 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
           then Some (ensure_sandbox_clone_ready candidate |> Result.map (fun note -> (candidate, note)))
           else None
       in
-      let scan_first_git_repo dir =
-        if not (safe_is_dir dir) then None
-        else
-          let entries =
-            try Sys.readdir dir with Sys_error _ -> [||]
-          in
-          Array.sort compare entries;
-          let rec find i =
-            if i >= Array.length entries then None
-            else
-              let candidate = Filename.concat dir entries.(i) in
-              if is_git_clone candidate
-              then
-                Some
-                  (ensure_sandbox_clone_ready candidate
-                   |> Result.map (fun note -> (candidate, note)))
-              else find (i + 1)
-          in
-          find 0
-      in
       match repo_name with
       | Some name when String.trim name <> "" && safe_repo_name name -> (
           match explicit_repo with
@@ -796,12 +774,13 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
           | None ->
               auto_provision_sandbox_clone ~config ~agent_name ~repos_dir
                 ~repo_name:name)
-      | _ -> (
-          match scan_first_git_repo repos_dir with
-          | Some result -> result
-          | None ->
-              Error
-                (missing_sandbox_clone_error ~agent_name ~repos_dir ~repo_name))
+      | _ ->
+          Error
+            (IoError
+               (Printf.sprintf
+                  "repo_name is required to select a sandbox clone for agent %s \
+                   under %s. Pass repo_name explicitly (e.g. 'masc-mcp')."
+                  agent_name repos_dir))
     in
     match resolve_keeper_repo_root () with
     | Error e -> Error e

--- a/lib/coord/coord_worktree.mli
+++ b/lib/coord/coord_worktree.mli
@@ -254,7 +254,8 @@ val worktree_create_r :
   agent_name:string ->
   task_id:string -> base_branch:string -> string Types.masc_result
 (** Create [<root>/.worktrees/<task_id>] tracking [base_branch] for
-    [agent_name].  Auto-provisions the sandbox clone when missing and
+    [agent_name].  [repo_name] is required to select the sandbox clone.
+    Auto-provisions the sandbox clone when missing and
     [docker_sandbox = true].  Returns the absolute worktree path on
     success. *)
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -29,17 +29,49 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
              (match meta.Keeper_meta_contract.sandbox_profile with
               | Keeper_types.Local -> "skip_local"
               | Keeper_types.Docker ->
-                (match Task_sandbox.create ~config ~task_id ~agent_name () with
-                 | Ok _sandbox ->
-                   Log.Misc.info
-                     "[claim_auto_provision] keeper=%s task=%s worktree provisioned"
-                     keeper_name task_id;
-                   "created"
-                 | Error msg ->
-                   Log.Misc.warn
-                     "[claim_auto_provision] keeper=%s task=%s worktree provisioning failed: %s"
-                     keeper_name task_id msg;
-                   "error")))
+                let repos_dir =
+                  Coord_worktree.repos_dir_of_keeper config agent_name
+                in
+                let repo_names =
+                  try
+                    Sys.readdir repos_dir
+                    |> Array.to_list
+                    |> List.filter (fun name ->
+                         Coord_worktree.is_git_clone
+                           (Filename.concat repos_dir name))
+                  with Sys_error _ -> []
+                in
+                (match repo_names with
+                 | [] ->
+                     Log.Misc.info
+                       "[claim_auto_provision] keeper=%s task=%s no sandbox repos \
+                        found under %s, skipping"
+                       keeper_name task_id repos_dir;
+                     "skip_no_repo"
+                 | [repo_name] ->
+                     (match
+                        Task_sandbox.create ~config ~task_id ~agent_name
+                          ~repo_name ()
+                      with
+                      | Ok _sandbox ->
+                          Log.Misc.info
+                            "[claim_auto_provision] keeper=%s task=%s \
+                             worktree provisioned (repo=%s)"
+                            keeper_name task_id repo_name;
+                          "created"
+                      | Error msg ->
+                          Log.Misc.warn
+                            "[claim_auto_provision] keeper=%s task=%s \
+                             worktree provisioning failed: %s"
+                            keeper_name task_id msg;
+                          "error")
+                 | _ ->
+                     Log.Misc.info
+                       "[claim_auto_provision] keeper=%s task=%s ambiguous \
+                        repos [%s], skipping auto-provision"
+                       keeper_name task_id
+                       (String.concat ", " repo_names);
+                     "skip_ambiguous"))
       in
       Prometheus.inc_counter "masc_keeper_claim_auto_provision_total"
         ~labels:[ ("outcome", outcome); ("agent_name", agent_name) ]

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -80,9 +80,9 @@ let symlink_masc ~repo_root ~worktree_path =
   else
     Ok ()
 
-let create ~config ~task_id ?(base_branch = "main") ~agent_name () =
+let create ~config ~task_id ?(base_branch = "main") ?repo_name ~agent_name () =
   (* Delegate worktree creation to Coord_worktree via the Coord facade *)
-  match Coord_worktree.worktree_create_r ~link_task:true config
+  match Coord_worktree.worktree_create_r ~link_task:true ?repo_name config
           ~agent_name ~task_id ~base_branch with
   | Error e ->
     Error (Printf.sprintf "worktree creation failed: %s"
@@ -176,8 +176,8 @@ let cleanup ~config ~agent_name sandbox =
       Error (Printf.sprintf "cleanup failed for %s: %s"
                sandbox.task_id (Types.masc_error_to_string e))
 
-let with_sandbox ~config ~task_id ?base_branch ~agent_name f =
-  match create ~config ~task_id ?base_branch ~agent_name () with
+let with_sandbox ~config ~task_id ?base_branch ?repo_name ~agent_name f =
+  match create ~config ~task_id ?base_branch ?repo_name ~agent_name () with
   | Error e -> Error e
   | Ok sandbox ->
     let result_ref = ref None in

--- a/lib/tool_schemas/tool_schemas_worktree.ml
+++ b/lib/tool_schemas/tool_schemas_worktree.ml
@@ -32,7 +32,7 @@ masc_worktree_remove.";
         ]);
         ("repo_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional. Disambiguates which sandbox repo clone to use when you have multiple repos under repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-]. Must be a single directory name — no slashes, no path traversal. The special values '.' and '..' match the character class above but are rejected at runtime in tool_worktree.handle_worktree_create and Coord_worktree.worktree_create_r. If the sandbox clone is missing and a matching workspace repo exists under base_path, MASC auto-provisions repos/<repo_name>/ first. Leave empty to auto-pick the first clone alphabetically.");
+          ("description", `String "Required. Selects the sandbox repo clone under repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-]. Must be a single directory name — no slashes, no path traversal. The special values '.' and '..' match the character class above but are rejected at runtime in tool_worktree.handle_worktree_create and Coord_worktree.worktree_create_r. If the sandbox clone is missing and a matching workspace repo exists under base_path, MASC auto-provisions repos/<repo_name>/ first. Omitting repo_name is an error.");
           (* Negative lookahead is not supported by JSON Schema Draft 7
              (used by most MCP clients), so the pattern below only
              enforces the character class. The ".", ".." special cases

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -184,7 +184,7 @@ let test_worktree_create_no_git () =
   let _ = Coord.init config ~agent_name:None in
 
   (* worktree_create_r should fail for non-git dir *)
-  let result = Coord.worktree_create_r config ~agent_name:"claude" ~task_id:"test" ~base_branch:"main" in
+  let result = Coord.worktree_create_r config ~agent_name:"claude" ~task_id:"test" ~base_branch:"main" ~repo_name:"test-repo" in
   Alcotest.(check bool) "returns error" true (match result with Error _ -> true | Ok _ -> false);
 
   (* Cleanup *)

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -228,7 +228,8 @@ let test_full_lifecycle () =
       in
 
       match Task_sandbox.create ~config ~task_id:"task-life"
-              ~agent_name:"lifecycle-agent" () with
+              ~agent_name:"lifecycle-agent"
+              ~repo_name:(Filename.basename dir) () with
       | Error e ->
         fail (Printf.sprintf "sandbox create failed: %s" e)
       | Ok sb ->
@@ -322,6 +323,7 @@ let test_with_sandbox_lifecycle () =
 
       match Task_sandbox.with_sandbox ~config ~task_id:"task-with"
               ~agent_name:"with-agent"
+              ~repo_name:(Filename.basename dir)
               (fun sb ->
                 check bool "inside sandbox" true (Sys.file_exists sb.worktree_path);
                 42) with
@@ -383,6 +385,7 @@ let test_with_sandbox_cleans_up_on_exception () =
       (try
         let _ = Task_sandbox.with_sandbox ~config ~task_id:"task-exc"
           ~agent_name:"exc-agent"
+          ~repo_name:(Filename.basename dir)
           (fun sb ->
             worktree_path_ref := sb.worktree_path;
             failwith "intentional test failure") in

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -278,6 +278,7 @@ let test_dispatch_worktree_create_empty_agent_falls_back () =
   let args = `Assoc [
     ("task_id", `String "task-empty-fallback");
     ("base_branch", `String "main");
+    ("repo_name", `String "test-repo");
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
@@ -294,6 +295,7 @@ let test_dispatch_worktree_create_whitespace_agent_trimmed () =
     ("agent_name", `String "   ");
     ("task_id", `String "task-ws");
     ("base_branch", `String "main");
+    ("repo_name", `String "test-repo");
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"


### PR DESCRIPTION
## Summary
- Remove `scan_first_git_repo` alphabetical fallback from `worktree_create_r`
- `repo_name` is now explicitly required; omission returns clear error
- Auto-provision hook only provisions when exactly one sandbox repo exists
- Update tool schema, keeper prompt, and tests accordingly

## Test plan
- [x] `dune build @install` passes
- [x] `test_task_sandbox.ml` 10/10 pass
- [x] `test_room.ml` 90 tests (1 pre-existing RNG failure)
- [x] `test_tool_worktree_coverage.ml` 26 tests (5 pre-existing policy failures)
- [x] Verified pre-existing failures on `main` branch

## Motivation
The alphabetical first-clone fallback caused task-045 to silently bind to `grpc-direct` instead of the intended repo. This removes the footgun entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)