### PR TITLE
fix: surface silent failures in bin/ tools (masc-trace, main_eio)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -620,7 +620,9 @@ let run_cmd host port base_path =
             (try close_all_sse_connections ()
             with
             | Eio.Cancel.Cancelled _ as e -> raise e
-            | _ -> ());
+            | exn ->
+                Log.Server.warn "shutdown: SSE close error: %s"
+                  (Printexc.to_string exn));
             Log.Server.info "MASC MCP: Server stopped, waiting for background fibers... [active conn: %d, ws: %d]"
             (Masc_mcp.Server_mcp_transport_http_sse.active_session_count ())
             (Masc_mcp.Server_mcp_transport_ws.session_count ())

--- a/bin/masc_trace.ml
+++ b/bin/masc_trace.ml
@@ -91,7 +91,11 @@ let dump_receipts ~base_path ~keeper ~turn_id =
                    if int_field json "turn_count" = Some turn_id then
                      Some (f, json)
                    else None
-                 with _ -> None))
+                 with exn ->
+                   Printf.eprintf
+                     "[masc-trace] warning: skipping malformed line in %s: %s\n"
+                     f (Printexc.to_string exn);
+                   None))
         files
     in
     if matches = [] then
@@ -166,7 +170,11 @@ let dump_fsm_transitions ~base_path ~keeper ~turn_id =
                    if keeper_match && turn_match && is_fsm then
                      Some json
                    else None
-                 with _ -> None))
+                 with exn ->
+                   Printf.eprintf
+                     "[masc-trace] warning: skipping malformed line in %s: %s\n"
+                     f (Printexc.to_string exn);
+                   None))
         files
     in
     if matches = [] then
@@ -287,7 +295,12 @@ let dump_tool_calls ~base_path ~keeper ~turn_id =
                    in
                    if keeper_match && turn_match then Some json
                    else None
-                 with _ -> None))
+                 with exn ->
+                   Printf.eprintf
+                     "[masc-trace] warning: skipping malformed line in %s: %s\n"
+                     (Filename.basename path)
+                       (Printexc.to_string exn);
+                   None))
         files
     in
     if matches = [] then


### PR DESCRIPTION
## Summary
- `bin/masc_trace.ml`: 3 locations where malformed JSON lines were silently skipped (`with _ -> None`). Added `Printf.eprintf` warnings to stderr so operators see data corruption in the diagnostic tool.
- `bin/main_eio.ml`: shutdown SSE close swallowed non-Cancelled exceptions. Added `Log.Server.warn` for observability during cleanup.

## Silent Failure Audit Progress
- Round 1: `lib/` — 10 fixes (PR #12400, MERGED)
- Round 2-3: `lib/` re-scan — 0 new
- OAS: 27 files, 339 try blocks — 0 new
- **Round 4: `bin/` — 2 fixes (this PR)**

## Test plan
- [x] `dune build --root=.worktrees/fix/silent-failure-bin-p1 @install` passes
- [ ] CI Build + Lint checks green
- [ ] Manual: run `masc-trace` against JSONL with intentionally malformed lines — should see `[masc-trace] warning:` on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)