### PR TITLE
fix: main branch build break from merged PR type mismatches

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -71,7 +71,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
                         repos [%s], skipping auto-provision"
                        keeper_name task_id
                        (String.concat ", " repo_names);
-                     "skip_ambiguous"))
+                     "skip_ambiguous")))
       in
       Prometheus.inc_counter "masc_keeper_claim_auto_provision_total"
         ~labels:[ ("outcome", outcome); ("agent_name", agent_name) ]

--- a/lib/task_sandbox.mli
+++ b/lib/task_sandbox.mli
@@ -20,6 +20,7 @@ val create :
   config:Coord_utils_backend_setup.config ->
   task_id:string ->
   ?base_branch:string ->
+  ?repo_name:string ->
   agent_name:string ->
   unit ->
   (sandbox, string) result
@@ -38,6 +39,7 @@ val with_sandbox :
   config:Coord_utils_backend_setup.config ->
   task_id:string ->
   ?base_branch:string ->
+  ?repo_name:string ->
   agent_name:string ->
   (sandbox -> 'a) ->
   ('a * string list, string) result

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -1,5 +1,6 @@
 open Alcotest
 open Masc_mcp
+open Tool_coord
 open Yojson.Safe.Util
 
 let temp_dir () =
@@ -33,8 +34,8 @@ let coord_ctx config : Tool_coord.context =
   { Tool_coord.config; agent_name = "planner" }
 
 let parse_json_result = function
-  | true, body -> Yojson.Safe.from_string body
-  | false, body -> fail body
+  | { success = true; message = body } -> Yojson.Safe.from_string body
+  | { success = false; message = body } -> fail body
 
 let principal_json ~kind ~id =
   `Assoc [ ("kind", `String kind); ("id", `String id) ]

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -2,6 +2,7 @@
 
 open Alcotest
 open Masc_mcp
+open Tool_coord
 
 let temp_dir () =
   let path = Filename.temp_file "goal_tool_test" "" in
@@ -34,8 +35,8 @@ let coord_ctx config : Tool_coord.context =
   { Tool_coord.config; agent_name = "planner" }
 
 let parse_json_result = function
-  | true, body -> Yojson.Safe.from_string body
-  | false, body -> fail body
+  | { success = true; message = body } -> Yojson.Safe.from_string body
+  | { success = false; message = body } -> fail body
 
 let principal_json ~kind ~id =
   `Assoc [ ("kind", `String kind); ("id", `String id) ]

--- a/test/test_goal_upsert_fsm_bypass_10247.ml
+++ b/test/test_goal_upsert_fsm_bypass_10247.ml
@@ -42,15 +42,15 @@ let dispatch_upsert ctx args =
 
 let dispatch_upsert_must_fail ctx args =
   match dispatch_upsert ctx args with
-  | true, body ->
+  | { success = true; message = body } ->
       fail
         (Printf.sprintf "expected upsert rejection, got success: %s" body)
-  | false, body -> Yojson.Safe.from_string body
+  | { success = false; message = body } -> Yojson.Safe.from_string body
 
 let dispatch_upsert_must_succeed ctx args =
   match dispatch_upsert ctx args with
-  | true, body -> Yojson.Safe.from_string body
-  | false, body ->
+  | { success = true; message = body } -> Yojson.Safe.from_string body
+  | { success = false; message = body } ->
       fail (Printf.sprintf "expected upsert success, got error: %s" body)
 
 let body_contains json needle =
@@ -93,8 +93,8 @@ let dispatch_transition_must_succeed ctx ~goal_id ~action =
             ("actor", principal_json ~kind:"operator" ~id:"planner");
           ])
   with
-  | Some (true, _body) -> ()
-  | Some (false, body) ->
+  | Some { success = true; message = _body } -> ()
+  | Some { success = false; message = body } ->
       fail
         (Printf.sprintf "expected transition %s success, got error: %s"
            action body)

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -81,11 +81,11 @@ let () = test "dispatch_status" (fun () ->
   let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
   let args = `Assoc [] in
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args with
-  | Some (success, result) ->
+  | Some { success; message } ->
       assert success;
-      assert (str_contains result "⚡ Snapshot:");
-      assert (str_contains result "🧭 You:");
-      assert (str_contains result "💡 Suggested next:")
+      assert (str_contains message "⚡ Snapshot:");
+      assert (str_contains message "🧭 You:");
+      assert (str_contains message "💡 Suggested next:")
   | None -> failwith "dispatch returned None"
 )
 
@@ -95,7 +95,7 @@ let () = test "dispatch_coordination_fsm_snapshot" (fun () ->
   let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
   let args = `Assoc [] in
   match Tool_coord.dispatch ctx ~name:"masc_coordination_fsm_snapshot" ~args with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       let json = Yojson.Safe.from_string result in
       let open Yojson.Safe.Util in


### PR DESCRIPTION
## Summary
Fixes main branch compilation errors caused by two admin-bypass merged PRs with incompatible type changes:
- PR #12436 changed `Tool_coord.tool_result` from tuple to record
- PR #12440 added `?repo_name` to `Task_sandbox.create` but did not update `.mli`

## Changes
- `lib/server/server_bootstrap_loops.ml`: fix syntax error (missing closing paren)
- `lib/task_sandbox.mli`: add `?repo_name` parameter to `create` and `with_sandbox`
- 4 test files: update tuple patterns to record patterns for `Tool_coord.tool_result`

## Test plan
- [ ] CI Build check passes
- [ ] CI Lint check passes