### PR TITLE
refactor(keeper): type agent run cascade name

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -30,7 +30,7 @@ include Keeper_agent_checkpoint_hygiene
     @param build_turn_prompt Callback: receives the base keeper system prompt
            and checkpoint message history, returns the final turn system prompt
     @param user_message The user's message to the keeper
-    @param cascade_name Cascade profile name for model selection
+    @param cascade_name Runtime cascade profile name for model selection
     @param generation Current generation counter
     @param max_turns Maximum agent turns (default from keeper runtime config)
     @param guardrails Optional OAS guardrails for tool safety gates
@@ -49,7 +49,7 @@ let run_turn
       ~(build_turn_prompt :
          base_system_prompt:string -> messages:Oas.Types.message list -> turn_prompt)
       ~(user_message : string)
-      ~(cascade_name : string)
+      ~(cascade_name : Keeper_cascade_profile.runtime_name)
       ?world_observation
       ?(turn_affordances = [])
       ?provider_filter
@@ -96,7 +96,10 @@ let run_turn
   in
   Fun.protect ~finally:safe_emit_turn_end
   @@ fun () ->
-  let runtime_cascade_name = Keeper_cascade_profile.Runtime_name cascade_name in
+  let runtime_cascade_name = cascade_name in
+  let cascade_name_string =
+    Keeper_cascade_profile.runtime_name_to_string runtime_cascade_name
+  in
   (* Steps 0–4: inference params, session dir, checkpoint, base prompt,
      working context, checkpoint hygiene — all in Keeper_run_context. *)
   let ctx = Keeper_run_context.prepare_run_context
@@ -256,7 +259,7 @@ let run_turn
            "keeper %s (cascade=%s): cli-backed providers selected but \
             claude_mcp_config is None; MCP tool catalog will not be \
             visible to the subprocess (see issue #10049 for fix plan)"
-           meta.name cascade_name);
+           meta.name cascade_name_string);
     let cli_transport_overrides =
       let claude_mcp_config =
         match keeper_oas_context.claude_mcp_config with
@@ -340,7 +343,7 @@ let run_turn
       match
        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
          Oas_worker.run_named
-           ~cascade_name
+           ~cascade_name:cascade_name_string
            ~keeper_name:meta.name
            ~model_strings:meta.models
            ?provider_filter
@@ -1173,8 +1176,7 @@ let run_turn
         network_mode = Keeper_types.network_mode_to_string meta.network_mode;
         approval_profile = acc.tool_surface.approval_mode_effective;
         approval_profile_derived = acc.tool_surface.approval_mode_derived;
-        cascade_name =
-          Keeper_execution_receipt.cascade_name_of_string cascade_name;
+        cascade_name = runtime_cascade_name;
         cascade_selected_model =
           Option.bind cascade_observation (fun obs -> obs.selected_model);
         cascade_attempt_count =

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -208,7 +208,7 @@ val adaptive_thinking_budget :
     @param build_turn_prompt Callback: receives the base keeper system prompt
            and checkpoint message history, returns the final turn system prompt
     @param user_message The user's message to the keeper
-    @param cascade_name Cascade profile name for model selection
+    @param cascade_name Runtime cascade profile name for model selection
     @param world_observation Structured keeper world snapshot used by
            required-tool contract checks. When omitted, the contract gate
            does not infer world state from prompt text.
@@ -239,7 +239,7 @@ val run_turn :
         -> messages:Oas.Types.message list
         -> turn_prompt)
   -> user_message:string
-  -> cascade_name:string
+  -> cascade_name:Keeper_cascade_profile.runtime_name
   -> ?world_observation:Keeper_world_observation.world_observation
   -> ?turn_affordances:string list
   -> ?provider_filter:string list

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -413,8 +413,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     ~build_turn_prompt
                     ~user_message:message
                     ~cascade_name:
-                      (Keeper_cascade_profile.runtime_name_of_string
-                         turn_cascade_name)
+                      (Keeper_cascade_profile.Runtime_name turn_cascade_name)
                     ~world_observation:(direct_turn_observation meta)
                     ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
                     ~generation:meta.runtime.generation

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -412,7 +412,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     ~max_context:max_cascade_context
                     ~build_turn_prompt
                     ~user_message:message
-                    ~cascade_name:turn_cascade_name
+                    ~cascade_name:
+                      (Keeper_cascade_profile.runtime_name_of_string
+                         turn_cascade_name)
                     ~world_observation:(direct_turn_observation meta)
                     ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
                     ~generation:meta.runtime.generation

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -719,9 +719,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let do_run ~(execution : cascade_execution) ~run_meta ~run_generation ~is_retry
               ~oas_timeout_s =
             last_execution := execution;
-            let execution_cascade_name =
-              KCP.runtime_name_to_string execution.cascade_name
-            in
             Otel_genai.with_keeper_turn_span
               ~keeper_name:run_meta.name
               ~agent_name:run_meta.agent_name
@@ -744,7 +741,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 try
                   Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
                     ~max_context:execution.max_context ~build_turn_prompt
-                    ~user_message ~cascade_name:execution_cascade_name
+                    ~user_message ~cascade_name:execution.cascade_name
                     ~world_observation:observation
                     ~turn_affordances
                     ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -63,6 +63,7 @@ let record_handoff_metric ?(timestamp = Time_compat.now ()) ?(keeper_name = "kee
     ?prev_trace_id ?new_trace_id ?to_model config =
   let meta = make_keeper_meta ~name:keeper_name ~trace_id () in
   write_keeper_meta config meta;
+  let keeper_name = meta.name in
   let handoff_fields =
     [ ("performed", `Bool true) ]
     @ (match next_generation with


### PR DESCRIPTION
## Summary
- Narrow `Keeper_agent_run.run_turn` to accept `Keeper_cascade_profile.runtime_name` for the keeper execution cascade.
- Keep the OAS worker boundary string-based by converting with `runtime_name_to_string` at the call site.
- Continue #11926 stringly-boundary cleanup: raw cascade_name signatures drop from 23 to 21 on current main.

## Evidence
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `scripts/stringly-boundary-ratchet.sh` (`raw_cascade_name_string_signatures 21 / 81`)
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD`

Refs #11926
