### PR TITLE
Fix keeper timeout watchdog routing

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -307,6 +307,32 @@ let record_semaphore_wait_observation ~base_path ~keeper_name ~channel ~kind =
     keeper_name
     ~reasons:(semaphore_wait_observation_reasons ~kind ~channel)
 
+let oas_timeout_budget_observation_reasons =
+  [
+    "provider_runtime_error";
+    "oas_timeout_budget";
+    "keeper_turn_retry_backoff";
+  ]
+
+let record_oas_timeout_budget_observation ~base_path ~keeper_name =
+  Keeper_registry.record_skip_reasons
+    ~base_path
+    keeper_name
+    ~reasons:oas_timeout_budget_observation_reasons;
+  Keeper_registry.touch_last_turn_ts ~base_path keeper_name
+
+let clear_oas_timeout_budget_failure_reason ~base_path ~keeper_name =
+  match Keeper_registry.get ~base_path keeper_name with
+  | Some { Keeper_registry.last_failure_reason =
+             Some (Keeper_registry.Oas_timeout_budget_loop _); _ } ->
+      Keeper_registry.set_failure_reason ~base_path keeper_name None
+  | _ -> ()
+
+let is_oas_timeout_budget_error (err : Oas.Error.sdk_error) =
+  match Oas_worker_named.classify_masc_internal_error err with
+  | Some (Oas_worker_named.Oas_timeout_budget _) -> true
+  | _ -> false
+
 let run_keepalive_unified_turn
       ~(ctx : _ context)
       ~(meta_after_triage : keeper_meta)
@@ -540,10 +566,17 @@ let run_keepalive_unified_turn
                  same-fiber retry has the same context budget, so a
                  budget exhaustion is unrecoverable in place and only
                  [sweep_and_recover] can clear it. *)
-              if String_util.contains_substring e_str "oas_timeout_budget"
+              if is_oas_timeout_budget_error err
               then begin
                 let keeper_name = meta_after_observe.name in
                 let strikes = Keeper_turn_slot.bump_budget_exhaustion ~keeper_name in
+                Keeper_registry.set_failure_reason
+                  ~base_path:ctx.config.base_path keeper_name
+                  (Some (Keeper_registry.Oas_timeout_budget_loop
+                           { count = strikes }));
+                record_oas_timeout_budget_observation
+                  ~base_path:ctx.config.base_path
+                  ~keeper_name;
                 if strikes >= Keeper_turn_slot.oas_timeout_budget_strike_limit then begin
                   Log.Keeper.error
                     "%s: %d consecutive oas_timeout_budget strikes \
@@ -557,10 +590,6 @@ let run_keepalive_unified_turn
                       ("outcome", "promote");
                     ] ();
                   Keeper_turn_slot.reset_budget_exhaustion ~keeper_name;
-                  Keeper_registry.set_failure_reason
-                    ~base_path:ctx.config.base_path keeper_name
-                    (Some (Keeper_registry.Oas_timeout_budget_loop
-                             { count = strikes }));
                   raise Keeper_registry.Keeper_fiber_crash
                 end else begin
                   Log.Keeper.warn
@@ -590,6 +619,9 @@ let run_keepalive_unified_turn
                  transient budget exhaustion does not trickle into the
                  next 4h-window's strike limit. *)
               Keeper_turn_slot.reset_budget_exhaustion ~keeper_name:meta_after_observe.name;
+              clear_oas_timeout_budget_failure_reason
+                ~base_path:ctx.config.base_path
+                ~keeper_name:meta_after_observe.name;
               updated)
         with
         | Ok meta -> meta

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -65,6 +65,11 @@ val record_semaphore_wait_observation :
   kind:semaphore_wait_observation_kind ->
   unit
 
+val oas_timeout_budget_observation_reasons : string list
+
+val record_oas_timeout_budget_observation :
+  base_path:string -> keeper_name:string -> unit
+
 val run_keepalive_unified_turn :
   ctx:'a context ->
   meta_after_triage:keeper_meta ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -594,6 +594,17 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
              ~keeper_name:live_meta.name
              ~detail)
       in
+      let record_loop_exit () =
+        match Keeper_registry.get
+                ~base_path:ctx.config.base_path live_meta.name with
+        | Some { Keeper_registry.last_failure_reason =
+                   Some ((Keeper_registry.Stale_turn_timeout _
+                         | Keeper_registry.Stale_termination_storm _
+                         | Keeper_registry.Oas_timeout_budget_loop _) as reason);
+                 _ } ->
+          record_crash reason
+        | _ -> record_stopped "normal exit"
+      in
       (* Cancel-safe finally (#9747 iter 2): [cleanup_tracking] touches
          registry state that can raise transiently during shutdown.
          Stdlib [Fun.protect] would wrap that as [Fun.Finally_raised],
@@ -620,7 +631,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         (fun () ->
           try
             run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup;
-            record_stopped "normal exit"
+            record_loop_exit ()
           with
           | Keeper_registry.Keeper_fiber_crash ->
             if Atomic.get stop then

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -124,10 +124,15 @@ let has_recent_skip_observation ~now ~threshold
 
 let pending_oas_timeout_budget_count
     (entry : Keeper_registry.registry_entry) : int option =
+  let is_timeout_budget_observation_reason reason =
+    List.exists
+      (String.equal reason)
+      Keeper_heartbeat_loop.oas_timeout_budget_observation_reasons
+  in
   let has_timeout_observation =
     match entry.last_skip_observation with
     | Some (_, reasons) ->
-        List.exists (String.equal "oas_timeout_budget") reasons
+        List.exists is_timeout_budget_observation_reason reasons
     | None -> false
   in
   match entry.last_failure_reason, has_timeout_observation with

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -122,6 +122,18 @@ let has_recent_skip_observation ~now ~threshold
       reasons <> [] && now -. ts <= threshold
   | None -> false
 
+let pending_oas_timeout_budget_count
+    (entry : Keeper_registry.registry_entry) : int option =
+  let has_timeout_observation =
+    match entry.last_skip_observation with
+    | Some (_, reasons) ->
+        List.exists (String.equal "oas_timeout_budget") reasons
+    | None -> false
+  in
+  match entry.last_failure_reason, has_timeout_observation with
+  | Some (Keeper_registry.Oas_timeout_budget_loop { count }), true -> Some count
+  | _ -> None
+
 let () =
   Prometheus.register_counter
     ~name:"masc_keeper_stale_termination_by_class_total"
@@ -132,6 +144,15 @@ let () =
        only the keeper label — this counter adds the class dimension \
        so dashboards can attribute kills to root cause without \
        re-parsing the reason_desc string.  Labels: keeper, class."
+    ()
+
+let () =
+  Prometheus.register_counter
+    ~name:"masc_keeper_oas_timeout_budget_watchdog_termination_total"
+    ~help:
+      "Total watchdog terminations that preserved an unresolved \
+       oas_timeout_budget failure reason instead of reclassifying the \
+       keeper as an idle stale stall. Labels: keeper."
     ()
 
 (* #10765 phase 2: fleet-wide batch termination detection.
@@ -261,6 +282,23 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                || now -. !last_broadcast_ts > threshold
              in
              if stale && cooldown_ok then begin
+               match pending_oas_timeout_budget_count entry with
+               | Some count when idle_stale ->
+                 let stall_seconds = now -. last_turn in
+                 Keeper_registry.set_failure_reason ~base_path meta.name
+                   (Some (Keeper_registry.Oas_timeout_budget_loop { count }));
+                 (* tla-lint: allow-mutation: fiber signal — stop the keeper
+                    through the provider-timeout path, preserving the typed
+                    root cause for supervisor auto-pause. *)
+                 Atomic.set reg.fiber_stop true;
+                 Prometheus.inc_counter
+                   "masc_keeper_oas_timeout_budget_watchdog_termination_total"
+                   ~labels:[ ("keeper", meta.name) ]
+                   ();
+                 Log.Keeper.error
+                   "%s: watchdog terminating fiber (oas_timeout_budget unresolved after idle %.0fs; count=%d; preserving provider timeout root cause) [cascade=%s]"
+                   meta.name stall_seconds count meta.cascade_name
+               | _ ->
                (* #10940 follow-up: surface the most recent skip reasons
                   alongside [idle %.0fs] so operators can tell whether
                   the kill targeted a *stuck* fiber or a *deliberately

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -603,8 +603,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
            event_bus_drain_cancel := None;
            (try Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed") with
             | Eio.Cancel.Cancelled _ -> ()
-            | Invalid_argument msg
-              when String.equal msg "Cancellation context finished!" -> ())
+            | Invalid_argument msg ->
+                Log.Keeper.debug
+                  "%s: event bus drain cancel ignored after context finish: %s"
+                  meta.name msg)
          | None -> ());
         ignore (drain_turn_event_bus ~site:"unsubscribe_final" ());
         match event_bus_sub, Keeper_event_bus.get () with

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -599,7 +599,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       in
       let unsubscribe_event_bus () =
         (match !event_bus_drain_cancel with
-         | Some cc -> Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed")
+         | Some cc ->
+           event_bus_drain_cancel := None;
+           (try Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed") with
+            | Eio.Cancel.Cancelled _ -> ()
+            | Invalid_argument msg
+              when String.equal msg "Cancellation context finished!" -> ())
          | None -> ());
         ignore (drain_turn_event_bus ~site:"unsubscribe_final" ());
         match event_bus_sub, Keeper_event_bus.get () with

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -166,6 +166,51 @@ let test_wait_observation_updates_registry_skip_stamp () =
       | Some _ -> Alcotest.fail "last_skip_observation was not stamped"
       | None -> Alcotest.fail "registered keeper missing")
 
+let test_oas_timeout_budget_observation_reason_labels () =
+  Alcotest.(check (list string))
+    "timeout budget watchdog reasons"
+    [
+      "provider_runtime_error";
+      "oas_timeout_budget";
+      "keeper_turn_retry_backoff";
+    ]
+    Masc_mcp.Keeper_heartbeat_loop.oas_timeout_budget_observation_reasons
+
+let test_oas_timeout_budget_observation_updates_registry () =
+  let base_path =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-oas-timeout-observation-%d" (Unix.getpid ()))
+  in
+  let keeper = "oas-timeout-observation-12431" in
+  Masc_mcp.Keeper_registry.unregister ~base_path keeper;
+  let meta = make_meta keeper in
+  ignore (Masc_mcp.Keeper_registry.register ~base_path keeper meta);
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_registry.unregister ~base_path keeper)
+    (fun () ->
+      let before =
+        match Masc_mcp.Keeper_registry.get ~base_path keeper with
+        | Some entry -> entry.meta.runtime.usage.last_turn_ts
+        | None -> Alcotest.fail "registered keeper missing before observation"
+      in
+      Masc_mcp.Keeper_heartbeat_loop.record_oas_timeout_budget_observation
+        ~base_path
+        ~keeper_name:keeper;
+      match Masc_mcp.Keeper_registry.get ~base_path keeper with
+      | Some { Masc_mcp.Keeper_registry.last_skip_observation = Some (_, reasons);
+               meta = updated_meta; _ } ->
+        Alcotest.(check (list string))
+          "timeout budget stamped for watchdog routing"
+          Masc_mcp.Keeper_heartbeat_loop.oas_timeout_budget_observation_reasons
+          reasons;
+        Alcotest.(check bool)
+          "last_turn_ts touched"
+          true
+          (updated_meta.runtime.usage.last_turn_ts >= before)
+      | Some _ -> Alcotest.fail "last_skip_observation was not stamped"
+      | None -> Alcotest.fail "registered keeper missing")
+
 let () =
   Alcotest.run "keeper_semaphore_wait_counter_9771" [
     "metric_name", [
@@ -189,5 +234,9 @@ let () =
         test_wait_observation_reason_labels;
       Alcotest.test_case "registry skip stamp is updated" `Quick
         test_wait_observation_updates_registry_skip_stamp;
+      Alcotest.test_case "oas timeout labels are stable" `Quick
+        test_oas_timeout_budget_observation_reason_labels;
+      Alcotest.test_case "oas timeout registry stamp is updated" `Quick
+        test_oas_timeout_budget_observation_updates_registry;
     ];
   ]


### PR DESCRIPTION
## Summary
- Classify `oas_timeout_budget` through the structured MASC OAS error variant instead of string-matching the rendered error text.
- Stamp timeout-budget failures as a typed watchdog observation and preserve `Oas_timeout_budget_loop` when the watchdog later stops the keeper, so the root cause is not reclassified as a generic stale idle kill.
- Make turn event-bus cleanup tolerate the finished cancellation-context race without emitting a misleading cleanup warning.
- Unblock the current main build for the sandbox auto-provisioning slice by closing the missing match paren and exposing `?repo_name` in `Task_sandbox.mli`.

## Why this matters
The observed `issue_king` sequence had a typed OAS timeout at 09:58:14 KST, then a second stale-watchdog termination about five minutes later. That made the terminal boundary look like a stale keeper when the actionable root cause was already `oas_timeout_budget`. This keeps the provider/runtime timeout as the typed failure reason all the way into supervisor handling.

## Verification
- `scripts/dune-local.sh build test/test_keeper_semaphore_wait_counter.exe`
- `_build/default/test/test_keeper_semaphore_wait_counter.exe`
- `scripts/dune-local.sh build test/test_stale_kill_class.exe test/test_oas_timeout_budget_strike.exe test/test_heartbeat_integration.exe`
- `_build/default/test/test_stale_kill_class.exe`
- `_build/default/test/test_oas_timeout_budget_strike.exe`
- `_build/default/test/test_heartbeat_integration.exe`

Note: an additional `test/test_task_sandbox.exe` build was queued, but I stopped my queued process because another worktree held the shared Dune lock for the same target. The sandbox interface/syntax fixes were still compiled by the focused keeper builds above.
