### PR TITLE
fix: align tool result tests with record type

### DIFF
--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -33,7 +33,8 @@ let with_room f =
 let coord_ctx config : Tool_coord.context =
   { Tool_coord.config; agent_name = "planner" }
 
-let parse_json_result = function
+let parse_json_result (result : Tool_coord.tool_result) =
+  match result with
   | { success = true; message = body } -> Yojson.Safe.from_string body
   | { success = false; message = body } -> fail body
 

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -34,7 +34,8 @@ let with_room f =
 let coord_ctx config : Tool_coord.context =
   { Tool_coord.config; agent_name = "planner" }
 
-let parse_json_result = function
+let parse_json_result (result : Tool_coord.tool_result) =
+  match result with
   | { success = true; message = body } -> Yojson.Safe.from_string body
   | { success = false; message = body } -> fail body
 
@@ -90,9 +91,10 @@ let create_done_task config ~goal_id ~title =
   step Types.Start "test fixture start";
   step Types.Done_action "test fixture done"
 
-let expect_error = function
-  | Some (false, body) -> Yojson.Safe.from_string body
-  | Some (true, _) -> fail "expected tool error"
+let expect_error (result : Tool_coord.tool_result option) =
+  match result with
+  | Some { success = false; message = body } -> Yojson.Safe.from_string body
+  | Some { success = true; message = _ } -> fail "expected tool error"
   | None -> fail "tool not handled"
 
 let test_goal_upsert_and_list () =

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -114,7 +114,7 @@ let () = test "dispatch_status_summary_and_cap" (fun () ->
   done;
   let args = `Assoc [] in
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       assert (str_contains result "tasks active=35 todo=35 claimed=0 in_progress=0");
       assert (str_contains result "⚠️ Attention:");
@@ -133,12 +133,12 @@ let () = test "dispatch_status_done_summary" (fun () ->
   (match
      Coord.transition_task_r ctx.config ~agent_name:"test-agent"
        ~task_id:"task-001" ~action:Types.Done_action ~notes:"ok" ()
-   with
+  with
   | Ok _ -> ()
   | Error err -> failwith (Types.masc_error_to_string err));
   let args = `Assoc [] in
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       assert (str_contains result "owned=-");
       assert (str_contains result "tasks active=0 todo=0 claimed=0 in_progress=0");
@@ -153,7 +153,8 @@ let () = test "dispatch_reset_no_confirm" (fun () ->
   let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
   let args = `Assoc [] in
   match Tool_coord.dispatch ctx ~name:"masc_reset" ~args with
-  | Some (success, _result) -> assert (not success) (* Should fail without confirm *)
+  | Some { success; message = _ } ->
+      assert (not success) (* Should fail without confirm *)
   | None -> failwith "dispatch returned None"
 )
 
@@ -163,7 +164,7 @@ let () = test "dispatch_reset_with_confirm" (fun () ->
   let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
   let args = `Assoc [("confirm", `Bool true)] in
   match Tool_coord.dispatch ctx ~name:"masc_reset" ~args with
-  | Some (success, _result) -> assert success
+  | Some { success; message = _ } -> assert success
   | None -> failwith "dispatch returned None"
 )
 
@@ -194,7 +195,7 @@ let () = test "dispatch_check_transition_claim_auto_binds_current_task" (fun () 
   in
   match Tool_coord.dispatch ctx ~name:"masc_check"
           ~args:(`Assoc [("assertions", `List [`String "task_claimed"; `String "current_task_set"])]) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       let json = Yojson.Safe.from_string result in
       assert (Yojson.Safe.Util.member "all_passed" json = `Bool true)
@@ -217,7 +218,7 @@ let () = test "dispatch_check_claim_next_marks_current_task_set" (fun () ->
   let (_success, _result) = Tool_task.handle_claim_next task_ctx (`Assoc []) in
   match Tool_coord.dispatch ctx ~name:"masc_check"
           ~args:(`Assoc [("assertions", `List [`String "task_claimed"; `String "current_task_set"])]) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       let json = Yojson.Safe.from_string result in
       assert (Yojson.Safe.Util.member "all_passed" json = `Bool true)
@@ -236,7 +237,7 @@ let () = test "dispatch_status_multi_assignment_current_requires_disambiguation"
   ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-002");
   Planning_eio.set_current_task ctx.config ~task_id:"task-002";
   (match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       assert (str_contains result "owned=task-001 | current=task-002");
       assert (str_contains result "assigned_set=[task-001,task-002]");
@@ -250,7 +251,7 @@ let () = test "dispatch_status_multi_assignment_current_requires_disambiguation"
   | None -> failwith "dispatch returned None");
   match Tool_coord.dispatch ctx ~name:"masc_check"
           ~args:(`Assoc [("assertions", `List [`String "task_claimed"; `String "current_task_set"])]) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       let json = Yojson.Safe.from_string result in
       assert (Yojson.Safe.Util.member "all_passed" json = `Bool false);
@@ -273,7 +274,7 @@ let () = test "dispatch_check_owned_current_drift_fails_current_task_set" (fun (
   Planning_eio.set_current_task ctx.config ~task_id:"task-002";
   match Tool_coord.dispatch ctx ~name:"masc_check"
           ~args:(`Assoc [("assertions", `List [`String "task_claimed"; `String "current_task_set"])]) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       let json = Yojson.Safe.from_string result in
       assert (Yojson.Safe.Util.member "all_passed" json = `Bool false);
@@ -295,7 +296,7 @@ let () = test "dispatch_status_surfaces_owned_current_drift" (fun () ->
   ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
   Planning_eio.set_current_task ctx.config ~task_id:"task-002";
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       assert (str_contains result "owned=task-001");
       assert (str_contains result "current=task-002");
@@ -317,7 +318,7 @@ let () = test "dispatch_status_suppresses_lifecycle_guidance_without_credential"
   ignore (Coord.add_task ctx.config ~title:"Credentialed work" ~priority:3 ~description:"");
   Planning_eio.set_current_task ctx.config ~task_id:"task-001";
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       assert (str_contains result "🔐 Credential: required=yes | available=no | candidates=test-agent");
       assert (str_contains result "Lifecycle actions are credential-blocked for test-agent");
@@ -337,7 +338,7 @@ let () = test "dispatch_status_treats_keeper_internal_auth_as_credential" (fun (
   ignore (Coord.add_task ctx.config ~title:"Keeper work" ~priority:3 ~description:"");
   Planning_eio.set_current_task ctx.config ~task_id:"task-001";
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       assert (
         str_contains result
@@ -359,7 +360,7 @@ let () = test "dispatch_status_no_owned_prefers_claim_next_over_transition" (fun
   ignore (Coord.add_task ctx.config ~title:"Unclaimed task" ~priority:3 ~description:"");
   Planning_eio.set_current_task ctx.config ~task_id:"task-001";
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       assert (str_contains result "owned=- | current=task-001");
       assert (str_contains result "drift_reason=no_owned");
@@ -379,7 +380,7 @@ let () = test "dispatch_status_surfaces_missing_planning_for_owned_task" (fun ()
   ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
   Planning_eio.set_current_task ctx.config ~task_id:"task-001";
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       assert (str_contains result "owned=task-001 | current=task-001");
       assert (str_contains result "📝 Planning: missing=yes | task=task-001");
@@ -407,7 +408,7 @@ let () = test "dispatch_status_surfaces_completed_deliverable_conflict_for_activ
     (Planning_eio.set_deliverable ctx.config ~task_id:"task-001"
        ~content:"Task-001 completed. stale control-plane artifact.");
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       assert (str_contains result "owned=task-001 | current=task-001");
       assert (str_contains result "📝 Planning: deliverable_conflict=yes | task=task-001");
@@ -429,7 +430,7 @@ let () = test "dispatch_status_flags_todo_with_completed_deliverable_as_conflict
     (Planning_eio.set_deliverable ctx.config ~task_id:"task-001"
        ~content:"Task-001 completed. Exercised masc_observe_operations.");
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       assert (str_contains result "⚠️ task-001 P2 [todo_conflict] Conflicted todo (unclaimed)");
       assert (str_contains result "📋 task-002 P2 [todo] Fresh todo (unclaimed)");
@@ -442,7 +443,7 @@ let () = test "dispatch_check_project_ready_alias" (fun () ->
   let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
   match Tool_coord.dispatch ctx ~name:"masc_check"
           ~args:(`Assoc [("assertions", `List [`String "project_ready"])]) with
-  | Some (success, result) ->
+  | Some { success; message = result } ->
       assert success;
       let json = Yojson.Safe.from_string result in
       assert (Yojson.Safe.Util.member "all_passed" json = `Bool true)


### PR DESCRIPTION
## Summary
- Update Tool_coord dispatch test patterns to match the current tool_result record type.
- Add explicit result annotations where OCaml could not infer record fields in focused tests.

## Why
- Current open PR CI is failing shared Health/build snapshots with unbound record field success and tuple-vs-record pattern errors in test_dashboard_goals.ml, test_goal_tools.ml, and test_tool_coord_coverage.ml.
- This is a mainline test compatibility fix, not specific to docs/config PRs.

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_dashboard_goals.exe test/test_goal_tools.exe test/test_tool_coord_coverage.exe