### PR TITLE
fix(test): update expect_error to use Tool_coord.tool_result record pattern

### DIFF
--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -91,9 +91,10 @@ let create_done_task config ~goal_id ~title =
   step Types.Start "test fixture start";
   step Types.Done_action "test fixture done"
 
-let expect_error = function
-  | Some (false, body) -> Yojson.Safe.from_string body
-  | Some (true, _) -> fail "expected tool error"
+let expect_error (result : Tool_coord.tool_result option) =
+  match result with
+  | Some { success = false; message = body } -> Yojson.Safe.from_string body
+  | Some { success = true; message = _ } -> fail "expected tool error"
   | None -> fail "tool not handled"
 
 let test_goal_upsert_and_list () =


### PR DESCRIPTION
## Summary
PR #12490 changed `Tool_coord.tool_result` from tuple to record but missed `expect_error` in `test_goal_tools.ml`. This caused a build break on main.

## Error
```
The value rejected_phase has type tool_result option
but an expression was expected of type (bool * string) option
```

## Fix
- Update `expect_error` to use record pattern matching.
- Add explicit type annotation `(result : Tool_coord.tool_result option)` so OCaml can resolve record fields.

## Test
- `dune build @check` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)