### PR TITLE
feat(keeper): add visibility for local execution path (A8)

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -198,6 +198,23 @@ let handle_keeper_bash
         ~config ~meta ~cwd ~timeout_sec ~cmd
         ~network_mode:sandbox_network_mode)
     else
+      let local_reason =
+        if Env_config_keeper.KeeperSandbox.hard_mode () then "hard_mode_local"
+        else if not (Env_config_keeper.DockerPlayground.enabled) then
+          "playground_disabled"
+        else "outside_playground"
+      in
+      Log.Keeper.info
+        "LOCAL_EXEC: keeper=%s cwd=%s reason=%s sandbox_profile=%s \
+         playground=%b hard_mode=%b"
+        meta.name cwd local_reason
+        (sandbox_profile_to_string meta.sandbox_profile)
+        in_playground
+        (Env_config_keeper.KeeperSandbox.hard_mode ());
+      Prometheus.inc_counter
+        "masc_keeper_bash_local_execution_total"
+        ~labels:[ ("keeper", meta.name); ("reason", local_reason) ]
+        ();
       (* Local execution path: full validation applies *)
       let validate =
         if write_enabled then Worker_dev_tools.validate_command_coding


### PR DESCRIPTION
## Summary

A8 from Kimi analysis: `handle_keeper_bash` was silently falling back to Local execution without recording why. This made it impossible to diagnose whether a keeper was running locally due to hard_mode, disabled playground, or cwd outside the playground.

## Changes

- Log `LOCAL_EXEC` with keeper name, cwd, reason, sandbox_profile, playground status, and hard_mode status.
- Increment Prometheus counter `masc_keeper_bash_local_execution_total` with `keeper` and `reason` labels.

### Reason classification

| Reason | Condition |
|--------|-----------|
| `hard_mode_local` | `MASC_KEEPER_SANDBOX_HARD_MODE=true` |
| `playground_disabled` | `DockerPlayground.enabled=false` |
| `outside_playground` | cwd not inside sandbox root |

## Test plan

- [x] `dune build lib/keeper/keeper_shell_bash.ml`
- [x] `dune test test/test_keeper_bash_safety.ml` (29 tests pass)

## Kimi reference

A8: `handle_keeper_bash`에서 Local execution path로 진입할 때, 왜 Local인지 이유를 로그/메트릭에 남김. 현재는 조용히 fallback.