### PR TITLE
keeper: add masc_keeper_docker_runtime_discarded_total metric

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -646,6 +646,13 @@ let run_docker_hardened_bash
                 ("output", `String out);
               ] @ gh_exit_class_field ~cmd ~status:st ~output:out)))
     | _ ->
+      (match turn_sandbox_runtime with
+       | Some _ ->
+         Prometheus.inc_counter
+           "masc_keeper_docker_runtime_discarded_total"
+           ~labels:[ ("keeper", meta.name); ("reason", "network_mode_mismatch") ]
+           ()
+       | None -> ());
       (* P12: check egress policy before running networked container *)
       (match check_egress ~config ~meta ~cmd with
        | Some blocked_json -> blocked_json


### PR DESCRIPTION
## Summary
Add a Prometheus counter `masc_keeper_docker_runtime_discarded_total` to track when a cached `turn_sandbox_runtime` is discarded because `network_mode` is not `Network_none`.

## Context
When a keeper turn completes, the Docker container runtime may be cached in `turn_sandbox_runtime` for reuse on the next turn. However, if `network_mode` is not `Network_none`, the runtime is silently discarded and a cold-start container is spun up instead. This metric makes that cold-start path visible for observability.

## Changes
- `lib/keeper/keeper_shell_docker.ml`: increment counter in the discard path

## Test Plan
- [x] `dune build lib/keeper/` compiles
- [ ] CI checks pass