### PR TITLE
ci: skip heavy checks for draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Draft PRs are collaboration scratch space. Keep only the lightweight
+# PR-sync/CI-Gate path there, then run the full matrix on ready_for_review.
 jobs:
   pr-sync-check:
     name: PR Sync Check
@@ -45,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [pr-sync-check]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
     outputs:
       build: ${{ steps.scope.outputs.build }}
       lint: ${{ steps.scope.outputs.lint }}
@@ -205,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -304,7 +306,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && needs.changes.outputs.health == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.health == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -365,7 +367,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && needs.changes.outputs.build == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.build == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
     outputs:
       advisory_status: ${{ steps.build_advisory_status.outputs.advisory_status }}
 
@@ -615,7 +617,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && needs.changes.outputs.lint == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.lint == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -697,7 +699,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && needs.changes.outputs.dashboard == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.dashboard == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -743,7 +745,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && (needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -766,7 +768,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     needs: [pr-sync-check]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -780,7 +782,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && needs.changes.outputs.tla == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.tla == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -292,12 +292,21 @@ jobs:
                 const ciGateStatus = latestCiGate
                   ? `${latestCiGate.status}/${latestCiGate.conclusion || "none"} ${latestCiGate.html_url}`
                   : "missing";
-                // CI Gate may not exist yet immediately after auto-merge is enabled
-                // or after a force-push/synchronize event invalidates the old gate
-                // before the new CI workflow starts. Only block when the gate is
-                // known to exist but failed, or on events outside that startup race.
-                if (!latestCiGate && (action === "auto_merge_enabled" || action === "synchronize")) {
-                  core.info(`CI Gate not yet present for head ${pr.head.sha}; skipping block on ${action} event.`);
+                // CI Gate may be missing/pending, or left as cancelled by a
+                // superseded draft run, immediately after auto-merge is
+                // enabled or a synchronize event starts a replacement CI run.
+                // Branch protection still prevents merge until a successful
+                // current-head CI Gate exists, so do not disable auto-merge
+                // for this startup race.
+                const ciGateStartupRaceAction =
+                  action === "auto_merge_enabled" || action === "synchronize";
+                const ciGateStartupRace =
+                  ciGateStartupRaceAction &&
+                  (!latestCiGate ||
+                    latestCiGate.status !== "completed" ||
+                    latestCiGate.conclusion === "cancelled");
+                if (ciGateStartupRace) {
+                  core.info(`CI Gate is ${ciGateStatus} for head ${pr.head.sha}; skipping block on ${action} event.`);
                 } else {
                   policyFailures.push(`CI Gate is not completed successfully for head ${pr.head.sha}: ${ciGateStatus}`);
                   shouldDisableAutoMerge = true;


### PR DESCRIPTION
## Summary
- skip heavy CI fanout for draft pull requests
- keep PR Sync and CI Gate active so draft policy still reports quickly
- rely on ready_for_review to run the full build/lint/health/dashboard/TLA matrix

## Why
The current queue is dominated by WIP/draft PRs. Drafts are collaboration scratch space; they should not spend runner capacity on expensive checks until they are ready for review.

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- actionlint unavailable locally