### PR TITLE
fix(test): align skipped receipt outcome with TLA+ label (#12469)

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3226,7 +3226,7 @@ let test_run_keeper_cycle_skips_non_executable_phase () =
            with
            | None -> fail "expected skipped turn execution receipt"
            | Some receipt ->
-              check string "skipped receipt outcome" "skipped"
+              check string "skipped receipt outcome" "receipt_skipped"
                  Yojson.Safe.Util.(receipt |> member "outcome" |> to_string);
                check string "skipped receipt terminal reason"
                  "non_executable_phase:paused"


### PR DESCRIPTION
## Summary
- Fixes #12469
- `test_keeper_unified.ml` expected the raw outcome string `"skipped"` but the execution receipt JSON serialization normalizes outcomes to TLA+ receipt labels (`receipt_skipped`).
- Single-line test expectation update.

## Test plan
- [x] `dune build @check` passes
- [x] `dune build test/test_keeper_unified.exe` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)