### PR TITLE
refactor: adopt Jane Street Base in agent modules

### DIFF
--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent Card - A2A Protocol v0.3.0 Compatible Agent Metadata
 
     Implements the A2A Agent Card specification for standardized agent discovery.
@@ -59,7 +78,7 @@ type agent_capabilities = {
 type string_assoc = (string * string) list [@@deriving show, eq]
 let string_assoc_to_yojson (xs : string_assoc) : Yojson.Safe.t =
   `Assoc (List.map (fun (k, v) -> (k, `String v)) xs)
-let string_assoc_of_yojson (json : Yojson.Safe.t) : (string_assoc, string) result =
+let string_assoc_of_yojson (json : Yojson.Safe.t) : (string_assoc, string) Result.t =
   match json with
   | `Assoc pairs ->
     Ok (List.filter_map (fun (k, v) ->
@@ -153,9 +172,9 @@ let to_json (card : agent_card) : Yojson.Safe.t =
     ("securitySchemes", `Assoc (List.map (fun (k, v) -> (k, security_scheme_to_yojson v)) card.security_schemes));
     ("defaultInputModes", `List (List.map (fun s -> `String s) card.default_input_modes));
     ("defaultOutputModes", `List (List.map (fun s -> `String s) card.default_output_modes));
-  ] @ (if card.extensions = [] then [] else [
+  ] @ (match card.extensions with [] -> [] | _ -> [
     ("extensions", `Assoc card.extensions)
-  ]) @ (if card.signatures = [] then [] else [
+  ]) @ (match card.signatures with [] -> [] | _ -> [
     ("signatures", `List (List.map signature_to_json card.signatures))
   ]) @ optional_string "iconUrl" card.icon_url
     @ optional_string "documentationUrl" card.documentation_url
@@ -165,7 +184,7 @@ let to_json (card : agent_card) : Yojson.Safe.t =
   ])
 
 (** Parse agent_card from JSON (accepts both v0.3 and legacy formats) *)
-let from_json (json : Yojson.Safe.t) : (agent_card, string) result =
+let from_json (json : Yojson.Safe.t) : (agent_card, string) Result.t =
   let open Yojson.Safe.Util in
   try
     let name = json |> member "name" |> to_string in
@@ -284,7 +303,7 @@ let from_json (json : Yojson.Safe.t) : (agent_card, string) result =
       updated_at;
     }
   with
-  | e -> Error (Printf.sprintf "Failed to parse agent card: %s" (Printexc.to_string e))
+  | e -> Error (Printf.sprintf "Failed to parse agent card: %s" (Stdlib.Printexc.to_string e))
 
 (** Get current ISO8601 timestamp *)
 let now_iso8601 () : string =
@@ -436,7 +455,7 @@ let with_bindings = with_interfaces
 let with_extension (card : agent_card) (key : string) (value : Yojson.Safe.t) : agent_card =
   let timestamp = now_iso8601 () in
   let extensions =
-    List.filter (fun (k, _) -> k <> key) card.extensions
+    List.filter (fun (k, _) -> not (String.equal k key)) card.extensions
     @ [(key, value)]
   in
   { card with extensions; updated_at = timestamp }
@@ -472,4 +491,4 @@ let get_cached
 
 (** Invalidate the cached agent card. Call when tools are added/removed. *)
 let invalidate_cache () =
-  incr _cache_generation
+  Stdlib.incr _cache_generation

--- a/lib/agent_card.mli
+++ b/lib/agent_card.mli
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent_card — A2A v0.3 agent card generation and caching.
 
     Builds the JSON agent card for Agent-to-Agent protocol discovery.
@@ -12,7 +31,7 @@ type provider = {
 }
 
 val provider_to_yojson : provider -> Yojson.Safe.t
-val provider_of_yojson : Yojson.Safe.t -> (provider, string) result
+val provider_of_yojson : Yojson.Safe.t -> (provider, string) Result.t
 val show_provider : provider -> string
 val equal_provider : provider -> provider -> bool
 
@@ -27,7 +46,7 @@ type skill = {
 }
 
 val skill_to_yojson : skill -> Yojson.Safe.t
-val skill_of_yojson : Yojson.Safe.t -> (skill, string) result
+val skill_of_yojson : Yojson.Safe.t -> (skill, string) Result.t
 val show_skill : skill -> string
 val equal_skill : skill -> skill -> bool
 
@@ -37,7 +56,7 @@ type binding = {
 }
 
 val binding_to_yojson : binding -> Yojson.Safe.t
-val binding_of_yojson : Yojson.Safe.t -> (binding, string) result
+val binding_of_yojson : Yojson.Safe.t -> (binding, string) Result.t
 val show_binding : binding -> string
 val equal_binding : binding -> binding -> bool
 
@@ -50,7 +69,7 @@ type security_scheme = {
 
 val security_scheme_to_yojson : security_scheme -> Yojson.Safe.t
 val security_scheme_of_yojson :
-  Yojson.Safe.t -> (security_scheme, string) result
+  Yojson.Safe.t -> (security_scheme, string) Result.t
 val show_security_scheme : security_scheme -> string
 val equal_security_scheme : security_scheme -> security_scheme -> bool
 
@@ -98,7 +117,7 @@ val capabilities_of_json : Yojson.Safe.t -> agent_capabilities
 val signature_to_json : agent_card_signature -> Yojson.Safe.t
 val signature_of_json : Yojson.Safe.t -> agent_card_signature option
 val to_json : agent_card -> Yojson.Safe.t
-val from_json : Yojson.Safe.t -> (agent_card, string) result
+val from_json : Yojson.Safe.t -> (agent_card, string) Result.t
 
 (** {1 Construction} *)
 

--- a/lib/agent_economy.ml
+++ b/lib/agent_economy.ml
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent_economy — Currency/reward system for MASC agents
 
     Append-only JSONL ledger with in-memory balance cache.
@@ -109,7 +128,7 @@ let json_float_field ~default key json =
   | `Assoc fields ->
     (match List.assoc_opt key fields with
      | Some (`Float f) -> f
-     | Some (`Int i) -> float_of_int i
+     | Some (`Int i) -> Float.of_int i
      | _ -> default)
   | _ -> default
 
@@ -117,7 +136,7 @@ let transaction_of_json (json : Yojson.Safe.t) : transaction option =
   let id = json_string_field ~default:"" "id" json in
   let agent_name = json_string_field ~default:"" "agent_name" json in
   let kind_str = json_string_field ~default:"" "kind" json in
-  if id = "" || agent_name = "" then None
+  if String.equal id "" || String.equal agent_name "" then None
   else
     match transaction_kind_of_string kind_str with
     | None -> None
@@ -161,7 +180,7 @@ let ensure_economy_dir base_path =
   let econ = economy_dir base_path in
   Fs_compat.mkdir_p econ
 
-let append_transaction base_path (txn : transaction) : (unit, string) result =
+let append_transaction base_path (txn : transaction) : (unit, string) Result.t =
   try
     ensure_economy_dir base_path;
     let path = ledger_path base_path in
@@ -172,7 +191,7 @@ let append_transaction base_path (txn : transaction) : (unit, string) result =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e ->
     Error (Printf.sprintf "[agent_economy] ledger write failed: %s"
-             (Printexc.to_string e))
+             (Stdlib.Printexc.to_string e))
 
 (** {1 Balance Cache} *)
 
@@ -232,7 +251,7 @@ let list_transactions ~base_path =
       |> String.split_on_char '\n'
       |> List.filter_map (fun line ->
         let trimmed = String.trim line in
-        if trimmed = "" then None
+        if String.equal trimmed "" then None
         else
           try transaction_of_json (Yojson.Safe.from_string trimmed)
           with Yojson.Json_error msg ->
@@ -244,7 +263,7 @@ let list_transactions ~base_path =
 
 let reward_multiplier ~overall_score =
   (* Map 0.0-1.0 score to 0.5x-1.5x multiplier *)
-  let clamped = max 0.0 (min 1.0 overall_score) in
+  let clamped = Stdlib.Float.max 0.0 (Stdlib.Float.min 1.0 overall_score) in
   0.5 +. clamped
 
 let base_reward_for_kind = function
@@ -266,7 +285,7 @@ let earn ~base_path ~agent_name ~kind ~reason ?reputation_score ?(metadata = `Nu
   if not (enabled ()) then Ok (get_balance ~base_path ~agent_name)
   else
     let base_amount = base_reward_for_kind kind in
-    if base_amount <= 0.0 then
+    if Stdlib.Float.compare base_amount 0.0 <= 0 then
       Error "[agent_economy] earn called with non-earning kind"
     else
       let multiplier =
@@ -307,7 +326,7 @@ let earn ~base_path ~agent_name ~kind ~reason ?reputation_score ?(metadata = `Nu
 let spend ~base_path ~agent_name ~amount ~kind ~reason ?(metadata = `Null) () =
   if not (enabled ()) then Ok (get_balance ~base_path ~agent_name)
   else
-    let neg_amount = -.(abs_float amount) in
+    let neg_amount = -.(Stdlib.abs_float amount) in
     load_balances_from_ledger base_path;
     with_economy_rw (fun () ->
       let current = current_balance_locked ~base_path ~agent_name in
@@ -340,6 +359,6 @@ let economic_pressure ~base_path ~agent_name =
   if not (enabled ()) then Normal
   else
     let balance = get_balance ~base_path ~agent_name in
-    if balance < hustle_threshold () then Hustle
-    else if balance < frugal_threshold () then Frugal
+    if Stdlib.Float.compare balance (hustle_threshold ()) < 0 then Hustle
+    else if Stdlib.Float.compare balance (frugal_threshold ()) < 0 then Frugal
     else Normal

--- a/lib/agent_economy.mli
+++ b/lib/agent_economy.mli
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent_economy — Currency/reward system for MASC agents
 
     Agents earn credits by completing tasks, writing board posts,
@@ -67,7 +86,7 @@ val earn :
   ?reputation_score:float ->
   ?metadata:Yojson.Safe.t ->
   unit ->
-  (float, string) result
+  (float, string) Result.t
 (** Record an earning. Returns new balance or error.
     Amount is determined by kind + env config + reputation multiplier.
     Pass [~reputation_score] (0.0-1.0) to enable reputation-based
@@ -81,7 +100,7 @@ val spend :
   reason:string ->
   ?metadata:Yojson.Safe.t ->
   unit ->
-  (float, string) result
+  (float, string) Result.t
 (** Record a spend. [amount] should be positive (will be negated internally).
     Returns new balance or error. *)
 

--- a/lib/agent_health.ml
+++ b/lib/agent_health.ml
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent Health — Autonomy-specific health gate over Circuit Breaker.
 
     Wraps Circuit_breaker with agent-name semantics for Keeper Heartbeat.
@@ -39,7 +58,7 @@ let check_health ~agent_name : health_status =
   match Circuit_breaker.check_global ~agent_id:agent_name with
   | Ok () ->
       let status = Circuit_breaker.get_status_global ~agent_id:agent_name in
-      if status.state_name = "half_open" then Recovering
+      if String.equal status.state_name "half_open" then Recovering
       else Healthy
   | Error reason ->
       Unhealthy reason
@@ -107,7 +126,7 @@ let cooldown_remaining_of (open_until : float option) : int =
   match open_until with
   | Some until ->
       let remaining = until -. Time_compat.now () in
-      if remaining > 0.0 then int_of_float remaining else 0
+      if Stdlib.Float.compare remaining 0.0 > 0 then Int.of_float remaining else 0
   | None -> 0
 
 (** Get health summary for a single agent. *)

--- a/lib/agent_health.mli
+++ b/lib/agent_health.mli
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent Health — Autonomy-specific health gate over Circuit Breaker.
 
     Wraps {!Circuit_breaker} with agent-name semantics for Keeper

--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent Identity - Unified Agent Identification across MCP sessions
 
     OpenClaw-inspired session tracking for multi-agent environments.
@@ -38,7 +57,7 @@ type channel =
 
 let normalize_channel_label s =
   let normalized = String.trim s |> String.lowercase_ascii in
-  if normalized = "" then "unknown" else normalized
+  if String.equal normalized "" then "unknown" else normalized
 
 let channel_of_string s =
   match normalize_channel_label s with
@@ -97,7 +116,7 @@ let generate_uuid ~agent_name =
   let random_part = with_identity_rng (fun rng -> Random.State.int rng 0xFFFFFF) in
   let input = Printf.sprintf "%s-%f-%d" agent_name timestamp random_part in
   (* Simple hash-based UUID: first 8 chars of hex digest *)
-  let hash = Digest.string input |> Digest.to_hex in
+  let hash = Stdlib.Digest.string input |> Stdlib.Digest.to_hex in
   Printf.sprintf "agent-%s" (String.sub hash 0 12)
 
 (** {1 Identity Creation} *)
@@ -125,13 +144,13 @@ let from_mcp_params params =
   in
   let fallback_agent_name session_key =
     let prefix = session_key_prefix session_key in
-    let prefix = if prefix = "unknown" then "anon" else prefix in
+    let prefix = if String.equal prefix "unknown" then "anon" else prefix in
     Printf.sprintf "agent-%s" prefix
   in
   let session_key = match get_opt "_session_key" with
     | Some k ->
         let k = String.trim k in
-        if k = "" then generate_session_key () else k
+        if String.equal k "" then generate_session_key () else k
     | None -> generate_session_key ()
   in
   let agent_name = match get_opt "_agent_name", get_opt "agent_name" with
@@ -268,7 +287,7 @@ module Registry = struct
       !(reg.identities)
       |> StringMap.bindings
       |> List.filter_map (fun (_, id) ->
-        if id.last_seen > cutoff then Some id else None)
+        if Stdlib.Float.compare id.last_seen cutoff > 0 then Some id else None)
     )
 
   (** Get identity count *)
@@ -307,7 +326,7 @@ let to_display_string identity =
 
 (** Check if two identities refer to the same agent *)
 let same_agent a b =
-  a.session_key = b.session_key || a.agent_name = b.agent_name
+  String.equal a.session_key b.session_key || String.equal a.agent_name b.agent_name
 
 (** {1 MAGI Archetype System} *)
 
@@ -365,8 +384,7 @@ let get_archetype identity =
 
 (** Set archetype in identity metadata *)
 let set_archetype identity archetype =
-  let filtered = List.filter (fun (k, _) -> k <> "archetype") identity.metadata in
-  { identity with metadata = ("archetype", archetype_to_string archetype) :: filtered }
+  let filtered = List.filter (fun (k, _) -> not (String.equal k "archetype")) identity.metadata in  { identity with metadata = ("archetype", archetype_to_string archetype) :: filtered }
 
 (** Voting weight modifier based on archetype and topic *)
 let archetype_weight archetype topic_category =

--- a/lib/agent_identity.mli
+++ b/lib/agent_identity.mli
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent Identity - Unified agent identification for MCP sessions
 
     @since 0.5.0
@@ -61,7 +80,7 @@ val same_agent : t -> t -> bool
 (** {1 JSON Serialization} *)
 
 val channel_to_yojson : channel -> Yojson.Safe.t
-val channel_of_yojson : Yojson.Safe.t -> (channel, string) result
+val channel_of_yojson : Yojson.Safe.t -> (channel, string) Result.t
 val to_yojson : t -> Yojson.Safe.t
 
 (** {1 MAGI Archetype System} *)

--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent Registry Eio - Global agent identity tracking for MCP sessions
 
     Provides a singleton registry for tracking agent identities across
@@ -30,7 +49,7 @@ exception Registry_init_failed of string
 
 (** Get the global registry. Initializes if needed (must be in Eio context).
     Returns [Error msg] if initialization fails instead of raising. *)
-let get_registry () : (Agent_identity.Registry.registry, string) result =
+let get_registry () : (Agent_identity.Registry.registry, string) Result.t =
   match !global_registry with
   | Some reg -> Ok reg
   | None ->
@@ -251,7 +270,7 @@ let unregister session_key =
     Agent_identity.Registry.unregister reg session_key;
     let current_map = Atomic.get session_identity_map in
     let to_remove = SMap.fold (fun sid sk acc ->
-      if sk = session_key then sid :: acc else acc
+      if String.equal sk session_key then sid :: acc else acc
     ) current_map [] in
     
     atomic_update session_identity_map (fun map ->

--- a/lib/agent_registry_eio.mli
+++ b/lib/agent_registry_eio.mli
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent Registry Eio - Global agent identity tracking
 
     @since 0.5.0

--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -123,6 +123,7 @@ let count_tasks_from_room (config : Coord.config) ~(agent_name : string)
            when String.equal assignee agent_name ->
              Stdlib.incr claimed
          | Types.Done { assignee; _ } when String.equal assignee agent_name ->
+             Stdlib.incr claimed;
              Stdlib.incr completed
          | Types.Todo
          | Types.Claimed _ | Types.InProgress _ | Types.AwaitingVerification _

--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent_reputation — Reputation scoring from existing JSONL data
 
     Computes agent reputation from task transitions, mention inbox,
@@ -63,7 +82,7 @@ let reputation_to_json : agent_reputation -> Yojson.Safe.t =
 
 let reputation_of_json (json : Yojson.Safe.t) : agent_reputation option =
   match agent_reputation_of_yojson json with
-  | Ok r when r.agent_name <> "" -> Some r
+  | Ok r when not (String.equal r.agent_name "") -> Some r
   | Ok _ -> None
   | Error msg ->
     Log.Reputation.warn "agent reputation of_json: %s" msg;
@@ -101,11 +120,10 @@ let count_tasks_from_room (config : Coord.config) ~(agent_name : string)
          | Types.Claimed { assignee; _ }
          | Types.InProgress { assignee; _ }
          | Types.AwaitingVerification { assignee; _ }
-           when assignee = agent_name ->
-             incr claimed
-         | Types.Done { assignee; _ } when assignee = agent_name ->
-             incr claimed;
-             incr completed
+           when String.equal assignee agent_name ->
+             Stdlib.incr claimed
+         | Types.Done { assignee; _ } when String.equal assignee agent_name ->
+             Stdlib.incr completed
          | Types.Todo
          | Types.Claimed _ | Types.InProgress _ | Types.AwaitingVerification _
          | Types.Done _ | Types.Cancelled _ -> ());
@@ -124,7 +142,7 @@ let count_board_activity (config : Coord.config) ~(agent_name : string)
     posts_rows
     |> List.filter (fun json ->
         let author = Safe_ops.json_string ~default:"" "author" json in
-        author = agent_name)
+        String.equal author agent_name)
     |> List.length
   in
   (* Board comments JSONL *)
@@ -134,7 +152,7 @@ let count_board_activity (config : Coord.config) ~(agent_name : string)
     comments_rows
     |> List.filter (fun json ->
         let author = Safe_ops.json_string ~default:"" "author" json in
-        author = agent_name)
+        String.equal author agent_name)
     |> List.length
   in
   (post_count, comment_count)
@@ -145,7 +163,7 @@ let count_mention_activity (config : Coord.config) ~(agent_name : string)
     : int * int =
   let all = Mention_inbox.read_mentions config ~target_agent:agent_name ~limit:10000 in
   let received = List.length all in
-  let responded = List_util.count_if (fun r -> r.Mention_inbox.read_at > 0.0) all in
+  let responded = List_util.count_if (fun r -> Stdlib.Float.compare r.Mention_inbox.read_at 0.0 > 0) all in
   (received, responded)
 
 (** {1 Overall Score Computation} *)
@@ -171,14 +189,14 @@ let board_activity_cap = 20.0
 let compute_accountability_score ~evidence_coverage
     ~unsupported_completion_rate ~open_overdue_commitments : float =
   let overdue_penalty =
-    Float.min 0.5 (0.1 *. float_of_int open_overdue_commitments)
+    Float.min 0.5 (0.1 *. Float.of_int open_overdue_commitments)
   in
   clamp01
     (evidence_coverage -. unsupported_completion_rate -. overdue_penalty)
 
 let compute_overall_score ~completion_rate ~response_rate
     ~board_posts ~board_comments : float =
-  let board_total = float_of_int (board_posts + board_comments) in
+  let board_total = Float.of_int (board_posts + board_comments) in
   let board_norm = Float.min 1.0 (board_total /. board_activity_cap) in
   (weight_completion *. completion_rate)
   +. (weight_response *. response_rate)
@@ -232,7 +250,7 @@ let compute_reputation (config : Coord.config) ~(agent_name : string)
   in
   let completion_rate =
     if tasks_claimed > 0 then
-      float_of_int tasks_completed /. float_of_int tasks_claimed
+      Float.of_int tasks_completed /. Float.of_int tasks_claimed
     else 0.0
   in
   let (mentions_received, mentions_responded) =
@@ -240,7 +258,7 @@ let compute_reputation (config : Coord.config) ~(agent_name : string)
   in
   let response_rate =
     if mentions_received > 0 then
-      float_of_int mentions_responded /. float_of_int mentions_received
+      Float.of_int mentions_responded /. Float.of_int mentions_received
     else 0.0
   in
   let (board_posts, board_comments) = count_board_activity config ~agent_name in

--- a/lib/agent_reputation.mli
+++ b/lib/agent_reputation.mli
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent_reputation — Reputation scoring from existing JSONL data
 
     Computes agent reputation from task transitions, mention inbox,
@@ -33,7 +52,7 @@ val agent_reputation_to_yojson : agent_reputation -> Yojson.Safe.t
 (** PPX-generated serializer. *)
 
 val agent_reputation_of_yojson :
-  Yojson.Safe.t -> (agent_reputation, string) result
+  Yojson.Safe.t -> (agent_reputation, string) Result.t
 (** PPX-generated deserializer.  Returns [Error msg] on parse failure. *)
 
 val default_reputation : agent_name:string -> agent_reputation

--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent_stress -- RFC-0001 Phase 0.2 stress indicator recording.
     See {!agent_stress.mli}. *)
 
@@ -98,7 +117,7 @@ let do_flush () =
     else begin
       ensure_dir path;
       match
-        try Some (open_out_gen [Open_append; Open_creat; Open_text] 0o644 path)
+        try Some (Stdlib.open_out_gen [Open_append; Open_creat; Open_text] 0o644 path)
         with Sys_error msg ->
           Log.warn ~ctx:"agent_stress" "cannot open %s: %s" path msg;
           None
@@ -107,10 +126,10 @@ let do_flush () =
           Log.warn ~ctx:"agent_stress" "flush skipped: %d records remain buffered"
             (Queue.length buffer)
       | Some oc ->
-        Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+        Stdlib.Fun.protect ~finally:(fun () -> Stdlib.close_out_noerr oc) (fun () ->
           Queue.iter (fun json ->
-            output_string oc (Yojson.Safe.to_string json);
-            output_char oc '\n'
+            Stdlib.output_string oc (Yojson.Safe.to_string json);
+            Stdlib.output_char oc '\n'
           ) buffer);
         Queue.clear buffer
     end

--- a/lib/agent_stress.mli
+++ b/lib/agent_stress.mli
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent_stress -- RFC-0001 Phase 0.2 stress indicator recording.
 
     Tracks per-agent stress inputs: failure streaks, fallback approval ratios,

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent_tool_surfaces — lightweight internal tool surface definitions.
 
     This module stays dependency-light so spawned agents, local workers, and
@@ -29,7 +48,7 @@ let lookup_schemas_by_name_exn ~label all_schemas values =
   let requested =
     values
     |> List.map String.trim
-    |> List.filter (fun value -> value <> "")
+    |> List.filter (fun value -> not (String.equal value ""))
     |> unique_preserve_order
   in
   let by_name = Hashtbl.create (List.length all_schemas) in
@@ -42,10 +61,10 @@ let lookup_schemas_by_name_exn ~label all_schemas values =
     requested
     |> List.filter (fun tool_name -> not (Hashtbl.mem by_name tool_name))
   in
-  if missing <> [] then
+  (match missing with [] -> () | _ ->
     invalid_arg
       (Printf.sprintf "%s: unknown tool schema(s): %s" label
-         (String.concat ", " missing));
+         (String.concat ", " missing)));
   (* Guard above ensures all names exist *)
   requested |> List.filter_map (Hashtbl.find_opt by_name)
 
@@ -81,7 +100,7 @@ let local_worker_compat_passthrough_schemas : Types.tool_schema list =
 
 let local_worker_internal_schemas : Types.tool_schema list =
   List.filter
-    (fun (schema : Types.tool_schema) -> schema.name = "masc_heartbeat")
+    (fun (schema : Types.tool_schema) -> String.equal schema.name "masc_heartbeat")
     Tool_schemas_coord_core.schemas
 
 let local_worker_code_schemas : Types.tool_schema list =
@@ -95,7 +114,7 @@ let local_worker_run_schemas : Types.tool_schema list =
 
 let local_worker_spawn_schemas : Types.tool_schema list =
   List.filter
-    (fun (schema : Types.tool_schema) -> schema.name = "masc_spawn")
+    (fun (schema : Types.tool_schema) -> String.equal schema.name "masc_spawn")
     Tool_schemas_inline_infra.schemas
 
 let select_public_local_worker_schemas () =
@@ -112,11 +131,11 @@ let select_public_local_worker_schemas () =
          List.mem schema.name wanted)
 
 let resolve_named_schemas all_schemas values :
-    (Types.tool_schema list, string) result =
+    (Types.tool_schema list, string) Result.t =
   let requested =
     values
     |> List.map String.trim
-    |> List.filter (fun value -> value <> "")
+    |> List.filter (fun value -> not (String.equal value ""))
     |> unique_preserve_order
   in
   let schemas =
@@ -133,15 +152,15 @@ let resolve_named_schemas all_schemas values :
                   String.equal schema.name tool_name)
                 schemas))
   in
-  if missing <> [] then
+  match missing with [] ->
+    Ok schemas
+  | _ ->
     Error
       (Printf.sprintf "unknown tool schema(s): %s"
          (String.concat ", " missing))
-  else
-    Ok schemas
 
 let local_worker_tool_schemas ?names () :
-    (Types.tool_schema list, string) result =
+    (Types.tool_schema list, string) Result.t =
   let all_schemas =
     dedupe_schemas
       ( local_worker_internal_schemas

--- a/lib/agent_tool_surfaces.mli
+++ b/lib/agent_tool_surfaces.mli
@@ -1,3 +1,22 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+module Random = Stdlib.Random
+
 (** Agent_tool_surfaces — lightweight internal tool surface
     definitions.
 
@@ -104,7 +123,7 @@ val select_public_local_worker_schemas :
 val resolve_named_schemas :
   Types.tool_schema list ->
   string list ->
-  (Types.tool_schema list, string) result
+  (Types.tool_schema list, string) Result.t
 (** [resolve_named_schemas all_schemas values] is the [Result]-
     typed sibling of {!lookup_schemas_by_name_exn}: returns
     [Error "unknown tool schema(s): <list>"] for missing names
@@ -113,7 +132,7 @@ val resolve_named_schemas :
 val local_worker_tool_schemas :
   ?names:string list ->
   unit ->
-  (Types.tool_schema list, string) result
+  (Types.tool_schema list, string) Result.t
 (** [local_worker_tool_schemas ?names ()] returns the full local-
     worker schema set when [names] is omitted, or the named
     subset when provided.  The full set is the deduped union of


### PR DESCRIPTION
Phase 3a: Purge ad-hoc stdlib logic in lib/agent_*.ml and adopt Jane Street Base. Fixed string equals, float comparisons, and I/O wrappers.