### PR TITLE
[codex] make cascade provider-constraint aware

### DIFF
--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -120,6 +120,21 @@ let rate_limit_decay_base =
            (must be in (0.0, 1.0)), using default 0.5" raw;
         0.5
 
+let rate_limit_skip_after =
+  match Sys.getenv_opt "MASC_CASCADE_RATE_LIMIT_SKIP_AFTER" with
+  | None -> 3
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then 3
+    else
+      match Safe_ops.int_of_string_safe trimmed with
+      | Some n when n >= 0 -> n
+      | _ ->
+        Log.Misc.warn
+          "Invalid int for MASC_CASCADE_RATE_LIMIT_SKIP_AFTER=%S, using default 3"
+          raw;
+        3
+
 let rate_limit_score_for_provider health ~provider_key =
   if rate_limit_recency_window_s <= 0.0 then 1.0
   else
@@ -131,6 +146,7 @@ let rate_limit_score_for_provider health ~provider_key =
         ~window_s:rate_limit_recency_window_s
     in
     if count <= 0 then 1.0
+    else if rate_limit_skip_after > 0 && count >= rate_limit_skip_after then 0.0
     else Float.pow rate_limit_decay_base (float_of_int count)
 
 type cycle_policy = {
@@ -264,11 +280,10 @@ let weighted_shuffle adapter ctx cands =
          {!rate_limit_recency_window_s} window.  Providers with no
          recent 429 hit get 1.0.
 
-     Cooled-down providers stay at 0 (multiplication preserves zero),
-     and the [max 1] guard prevents a slow-or-throttled-but-alive
-     provider from being zeroed out purely by these factors —
-     strategy gives it a chance each cycle, just with less probability
-     than its healthier peers. *)
+     Cooled-down providers stay at 0.  Latency never zeroes a provider,
+     but a sustained rate-limit burst may return [rl = 0.0] and remove
+     the provider for this ordering pass; otherwise the [max 1] guard
+     prevents tiny fractional weights from rounding to zero. *)
   let weighted = List.map
       (fun c ->
          let provider_key = adapter.health_key c in
@@ -281,7 +296,8 @@ let weighted_shuffle adapter ctx cands =
            else
              let lat = latency_score_for_provider ctx.health ~provider_key in
              let rl  = rate_limit_score_for_provider ctx.health ~provider_key in
-             max 1 (int_of_float (float_of_int ew *. lat *. rl))
+             if lat <= 0.0 || rl <= 0.0 then 0
+             else max 1 (int_of_float (float_of_int ew *. lat *. rl))
          in
          (c, final))
       cands

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -103,11 +103,12 @@ val rate_limit_score_for_provider :
     [0.0–1.0] multiplier that decays with the count of recent
     [Soft_rate_limited] events for [provider_key].
 
-    Formula: [score = decay_base ^ count] where [count] is the number
-    of soft rate-limit events recorded in the last 60 seconds (default
-    window — env [MASC_CASCADE_RATE_LIMIT_RECENCY_WINDOW_S]).  Default
-    decay base 0.5 (env [MASC_CASCADE_RATE_LIMIT_DECAY_BASE]) — 1
-    recent 429 halves the weight, 2 quarters it, 3 hits → 0.125.
+    Formula: [score = decay_base ^ count] until [count] reaches the
+    hard-skip threshold, where [count] is the number of soft rate-limit
+    events recorded in the last 60 seconds (default window — env
+    [MASC_CASCADE_RATE_LIMIT_RECENCY_WINDOW_S]).  Default decay base 0.5
+    (env [MASC_CASCADE_RATE_LIMIT_DECAY_BASE]); default hard-skip
+    threshold is 3 (env [MASC_CASCADE_RATE_LIMIT_SKIP_AFTER], 0 disables).
 
     - Unknown provider, no recent events, or window disabled
       ([RECENCY_WINDOW_S <= 0]) → [1.0] (optimistic default).
@@ -116,10 +117,10 @@ val rate_limit_score_for_provider :
       fractional score preserves zero.
 
     Used internally by {!Weighted_random} so a provider that just hit
-    a 429 burst gets de-prioritised even after its short cooldown
-    expires — the 429 leaves a recency footprint that biases selection
-    toward peers for the rest of the window.  Exposed for inspection /
-    testability — strategies do not need to call this directly.
+    a sustained 429 burst gets skipped instead of remaining eligible
+    with a tiny non-zero probability after its short cooldown expires.
+    Exposed for inspection / testability — strategies do not need to
+    call this directly.
 
     @since 0.183.0 (PR3b of cascade resilience track) *)
 

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -187,6 +187,12 @@ let runtime_mcp_policy_of_tool_names =
 let provider_label =
   Oas_worker_exec_transport.provider_label
 
+let claude_code_max_turns_hard_cap =
+  Oas_worker_exec_transport.claude_code_max_turns_hard_cap
+
+let provider_effective_max_turns =
+  Oas_worker_exec_transport.provider_effective_max_turns
+
 let resolve_tool_lane_for_oas_tools =
   Oas_worker_exec_transport.resolve_tool_lane_for_oas_tools
 

--- a/lib/oas_worker_exec.mli
+++ b/lib/oas_worker_exec.mli
@@ -157,6 +157,9 @@ val provider_caps_of_config :
   Llm_provider.Provider_config.t ->
   Llm_provider.Capabilities.capabilities
 val provider_label : Llm_provider.Provider_config.t -> string
+val claude_code_max_turns_hard_cap : int
+val provider_effective_max_turns :
+  Llm_provider.Provider_config.provider_kind -> int -> int
 
 (** {1 Kimi CLI configuration} *)
 

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -13,6 +13,16 @@ type cli_transport_overrides = {
   gemini_yolo : bool option;
 }
 
+let claude_code_max_turns_hard_cap = 30
+
+let provider_effective_max_turns kind requested =
+  match kind with
+  | Llm_provider.Provider_config.Claude_code ->
+      min requested claude_code_max_turns_hard_cap
+  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope
+  | Gemini_cli | Kimi_cli | Codex_cli ->
+      requested
+
 (* #10097: codex_cli omits keeper-bound runtime MCP tools that require
    request-scoped auth headers.  That omission is a structural provider
    limitation, not a per-call incident:
@@ -695,7 +705,10 @@ module Kimi_cli_transport_local = struct
   let prompt_needs_stdin prompt =
     prompt_exceeds_argv_budget prompt || prompt_contains_non_ascii prompt
 
+  let sanitize_for_kimi prompt = Inference_utils.sanitize_text_utf8 prompt
+
   let stdin_for_prompt prompt =
+    let prompt = sanitize_for_kimi prompt in
     if prompt_needs_stdin prompt then Some prompt else None
 
   let cli_model_override ~(config : config)
@@ -708,6 +721,7 @@ module Kimi_cli_transport_local = struct
       ~(req_config : Llm_provider.Provider_config.t)
       ~(mcp_config_json : string list)
       ~prompt =
+    let prompt = sanitize_for_kimi prompt in
     let prompt_via_stdin = prompt_needs_stdin prompt in
     let args =
       ref [ config.kimi_path; "--print"; "--output-format"; "stream-json" ]
@@ -772,10 +786,13 @@ module Kimi_cli_transport_local = struct
              { tool_use_id; content; is_error = false; json = parsed_json })
     | None -> None
 
+  let parse_json_line line =
+    Yojson.Safe.from_string (Inference_utils.sanitize_text_utf8 line)
+
   let blocks_of_output_line line =
     let open Yojson.Safe.Util in
     try
-      let json = Yojson.Safe.from_string line in
+      let json = parse_json_line line in
       match json |> member "role" |> to_string_option with
       | Some "assistant" ->
           let content = blocks_of_message_content (json |> member "content") in
@@ -796,7 +813,7 @@ module Kimi_cli_transport_local = struct
     let open Yojson.Safe.Util in
     let find_id line =
       try
-        let json = Yojson.Safe.from_string line in
+        let json = parse_json_line line in
         match json |> member "id" |> to_string_option with
         | Some id when String.trim id <> "" -> Some id
         | _ -> (
@@ -811,7 +828,7 @@ module Kimi_cli_transport_local = struct
     let open Yojson.Safe.Util in
     let find_model line =
       try
-        let json = Yojson.Safe.from_string line in
+        let json = parse_json_line line in
         match json |> member "model" |> to_string_option with
         | Some model when String.trim model <> "" -> Some model
         | _ -> None
@@ -1086,6 +1103,7 @@ module Kimi_cli_transport_local = struct
             Llm_provider.Cli_common_prompt.prompt_with_system_prompt
               ~prompt ~system_prompt
           in
+          let prompt = sanitize_for_kimi prompt in
           let model_id =
             Option.value ~default:"kimi-for-coding"
               (cli_model_override ~config ~req_config:req.config)
@@ -1132,6 +1150,7 @@ module Kimi_cli_transport_local = struct
             Llm_provider.Cli_common_prompt.prompt_with_system_prompt
               ~prompt ~system_prompt
           in
+          let prompt = sanitize_for_kimi prompt in
           let model_id =
             Option.value ~default:"kimi-for-coding"
               (cli_model_override ~config ~req_config:req.config)
@@ -1252,7 +1271,10 @@ let non_http_transport_of_provider
               allowed_tools =
                 Option.value ~default:[] overrides.claude_allowed_tools;
               permission_mode = overrides.claude_permission_mode;
-              max_turns = overrides.claude_max_turns;
+              max_turns =
+                Option.map
+                  (provider_effective_max_turns provider_cfg.kind)
+                  overrides.claude_max_turns;
             }
           in
           Ok

--- a/lib/oas_worker_exec_transport.mli
+++ b/lib/oas_worker_exec_transport.mli
@@ -16,6 +16,15 @@ type cli_transport_overrides = {
   gemini_yolo : bool option;
 }
 
+(** Hard cap for Claude Code's internal agent loop.  MASC may run a keeper
+    for more turns overall, but a single Claude Code subprocess attempt must
+    not receive that keeper-level budget unchanged. *)
+val claude_code_max_turns_hard_cap : int
+
+(** Clamp provider-internal max_turns to provider hard constraints. *)
+val provider_effective_max_turns :
+  Llm_provider.Provider_config.provider_kind -> int -> int
+
 (** Sorted, comma-joined fingerprint of a tool list.  Used as the dedup key
     by the [#10097] omission machinery — identical sets fingerprint to the
     same string regardless of input order. *)

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -16,6 +16,25 @@ include Oas_worker_named_cascade
 include Oas_worker_named_error
 include Oas_worker_named_fsm
 
+let provider_attempt_timeout_hint_s
+    (provider_cfg : Llm_provider.Provider_config.t) : float option =
+  match provider_cfg.kind with
+  | Llm_provider.Provider_config.Ollama -> Some 300.0
+  | Claude_code -> Some 120.0
+  | Gemini | Gemini_cli -> Some 180.0
+  | Kimi_cli -> Some 60.0
+  | Anthropic | Kimi | OpenAI_compat | Glm | DashScope | Codex_cli -> None
+
+let effective_provider_attempt_timeout_s
+    ~(is_last : bool)
+    ~(configured_timeout_s : float option)
+    (provider_cfg : Llm_provider.Provider_config.t) : float option =
+  match configured_timeout_s, provider_attempt_timeout_hint_s provider_cfg with
+  | Some configured, Some hinted -> Some (Float.max configured hinted)
+  | Some configured, None -> if is_last then None else Some configured
+  | None, Some hinted -> Some hinted
+  | None, None -> None
+
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)
 (* ================================================================ *)
@@ -421,7 +440,12 @@ let run_named
     | (provider_cfg : Llm_provider.Provider_config.t) :: rest ->
       let is_last = rest = [] in
       Log.Misc.debug "cascade %s: trying %s (is_last=%b)" cascade_name provider_cfg.model_id is_last;
-      let pp_timeout = if is_last then None else per_provider_timeout_s in
+      let pp_timeout =
+        effective_provider_attempt_timeout_s
+          ~is_last
+          ~configured_timeout_s:per_provider_timeout_s
+          provider_cfg
+      in
       let attempt_started_at = Unix.gettimeofday () in
       let (result, checkpoint_after) = try_provider ?resume_checkpoint ?per_provider_timeout_s:pp_timeout provider_cfg in
       let attempt_latency_ms =

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -308,6 +308,14 @@ let test_rl_score_two_429_decays_to_quarter () =
   let s = S.rate_limit_score_for_provider h ~provider_key:"p" in
   check (float 0.001) "2 × 429 → 0.25" 0.25 s
 
+let test_rl_score_three_429_skips_provider () =
+  let h = H.create () in
+  H.record_soft_rate_limited h ~provider_key:"p" ();
+  H.record_soft_rate_limited h ~provider_key:"p" ();
+  H.record_soft_rate_limited h ~provider_key:"p" ();
+  let s = S.rate_limit_score_for_provider h ~provider_key:"p" in
+  check (float 0.001) "3 × 429 → hard skip" 0.0 s
+
 (* ── weighted_shuffle composition with recency factor ──────────── *)
 
 let test_weighted_shuffle_429_provider_loses_to_clean_peer () =
@@ -339,29 +347,19 @@ let test_weighted_shuffle_429_provider_loses_to_clean_peer () =
        !clean_wins trials win_rate)
     true (win_rate > 0.65)
 
-let test_weighted_shuffle_429_provider_still_eligible () =
-  (* Even after 3 recent 429s, the rate-limited provider must remain
-     eligible (max-1 floor in weighted_shuffle).  This confirms the
-     factor de-prioritises rather than eliminates — the elimination
-     story is the cooldown mechanic, not the recency factor. *)
+let test_weighted_shuffle_429_provider_does_not_crash () =
+  (* Sustained 429s now zero the recency score.  The strategy should
+     return an empty ordering when that removes the only candidate,
+     rather than reviving it via the max-1 floor. *)
   let h = H.create () in
   for _ = 1 to 5 do
     H.record_soft_rate_limited h ~provider_key:"limited" ()
   done;
-  (* Wait would normally clear cooldown; here we work around it by
-     using a single-provider candidate list and forcing the picker to
-     visit it.  As long as effective_weight stays positive (cooldown
-     not active), weighted_shuffle's max-1 floor keeps it. *)
   let cands = [mk_cand ~w:100 "limited"] in
   let strat = mk_t S.Weighted_random in
   let ctx = mk_ctx ~health:h ~rand:(fun _ -> 0) () in
   let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
-  (* When the provider is cooled down (5 × soft_rl far exceeds the
-     immediate cooldown trigger), the post-cooldown filter drops it —
-     check_at_least we get a deterministic empty-or-singleton outcome
-     rather than a crash from a divide-by-zero in the weighted picker. *)
-  check bool "rate-limited provider does not crash strategy"
-    true (List.length ordered <= 1)
+  check (list string) "rate-limited provider skipped" [] (names ordered)
 
 (* ── S4 Circuit_breaker_cycling ──────────────────────────────── *)
 
@@ -1143,10 +1141,12 @@ let () =
         test_rl_score_one_429_decays_to_half;
       test_case "2 × 429 → 0.25" `Quick
         test_rl_score_two_429_decays_to_quarter;
+      test_case "3 × 429 → hard skip" `Quick
+        test_rl_score_three_429_skips_provider;
       test_case "weighted_shuffle prefers clean peer over 429-hit (200 trials)" `Quick
         test_weighted_shuffle_429_provider_loses_to_clean_peer;
       test_case "weighted_shuffle does not crash on rate-limited provider" `Quick
-        test_weighted_shuffle_429_provider_still_eligible;
+        test_weighted_shuffle_429_provider_does_not_crash;
     ];
     "circuit_breaker_cycling", [
       test_case "excludes cooldown and busy" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1658,6 +1658,22 @@ let test_cascade_provider_labels_keep_glm_and_glm_coding_distinct () =
   Alcotest.(check string) "general GLM label" "glm" glm;
   Alcotest.(check string) "coding GLM label" "glm-coding" glm_coding
 
+let test_provider_effective_max_turns_clamps_claude_code () =
+  Alcotest.(check int)
+    "claude_code max_turns hard cap"
+    Oas_worker_exec.claude_code_max_turns_hard_cap
+    (Oas_worker_exec.provider_effective_max_turns
+       Llm_provider.Provider_config.Claude_code
+       39)
+
+let test_provider_effective_max_turns_keeps_ollama_budget () =
+  Alcotest.(check int)
+    "ollama has no provider max_turns cap"
+    39
+    (Oas_worker_exec.provider_effective_max_turns
+       Llm_provider.Provider_config.Ollama
+       39)
+
 let test_cascade_provider_labels_preserve_registered_openai_compat_family () =
   let provider_name = Masc_mcp.Oas_worker_cascade.provider_name_of_config
       (make_openrouter_provider_cfg ()) in
@@ -2464,6 +2480,19 @@ let test_kimi_cli_build_args_uses_stdin_for_non_ascii_prompt () =
   Alcotest.(check bool) "non-ASCII prompt is omitted from argv" false
     (List.mem prompt argv);
   Alcotest.(check bool) "non-ASCII prompt does not use -p" false
+    (List.mem "-p" argv)
+
+let test_kimi_cli_build_args_sanitizes_broken_utf8_prompt () =
+  let prompt = "prefix\x80suffix" in
+  let argv =
+    Oas_worker_exec.Kimi_cli_transport_local.build_args
+      ~config:Oas_worker_exec.Kimi_cli_transport_local.default_config
+      ~req_config:(make_kimi_cli_provider_cfg ())
+      ~mcp_config_json:[] ~prompt
+  in
+  Alcotest.(check bool) "broken UTF-8 prompt omitted" false
+    (List.mem prompt argv);
+  Alcotest.(check bool) "sanitized non-ASCII replacement stays off argv" false
     (List.mem "-p" argv)
 
 let test_kimi_cli_model_for_provider_keeps_transport_default_on_auto () =
@@ -3854,6 +3883,10 @@ let () =
         test_cascade_audit_persists_observation;
       Alcotest.test_case "cascade provider labels keep glm and glm-coding distinct" `Quick
         test_cascade_provider_labels_keep_glm_and_glm_coding_distinct;
+      Alcotest.test_case "provider max_turns clamps claude_code" `Quick
+        test_provider_effective_max_turns_clamps_claude_code;
+      Alcotest.test_case "provider max_turns leaves ollama uncapped" `Quick
+        test_provider_effective_max_turns_keeps_ollama_budget;
       Alcotest.test_case "cascade provider labels preserve registered openai_compat family" `Quick
         test_cascade_provider_labels_preserve_registered_openai_compat_family;
       Alcotest.test_case "cascade provider labels detect kimi from endpoint metadata" `Quick
@@ -4012,6 +4045,8 @@ let () =
         test_kimi_cli_build_args_uses_stdin_for_large_prompt;
       Alcotest.test_case "kimi non-ASCII prompt uses stdin, not argv" `Quick
         test_kimi_cli_build_args_uses_stdin_for_non_ascii_prompt;
+      Alcotest.test_case "kimi broken UTF-8 prompt is sanitized off argv" `Quick
+        test_kimi_cli_build_args_sanitizes_broken_utf8_prompt;
       Alcotest.test_case "kimi auto model keeps transport default" `Quick
         test_kimi_cli_model_for_provider_keeps_transport_default_on_auto;
       Alcotest.test_case "kimi explicit model is preserved" `Quick


### PR DESCRIPTION
## What changed

- Clamp Claude Code `max_turns` at the MASC OAS exec boundary before CLI args are built.
- Add provider-specific attempt timeout hints so Ollama gets a longer cold-load window and CLI/API providers keep bounded attempts.
- Make sustained recent 429s a hard cascade skip after `MASC_CASCADE_RATE_LIMIT_SKIP_AFTER` hits, defaulting to 3 and allowing `0` to disable.
- Sanitize Kimi CLI prompts and JSONL output before argv/stdin routing or JSON parsing.
- Add focused tests for rate-limit skipping, Claude turn clamping, and Kimi broken UTF-8 handling.

## Why

The audit pointed at a structural failure mode: MASC treated providers as a uniform black box even though Claude, Kimi, Gemini, and Ollama have different hard constraints. This patch moves the first containment layer into routing and transport boundaries so repeated recovery does not keep violating the same provider-specific limits.

## Validation

- `git diff --check HEAD~1`
- `scripts/dune-local.sh build test/test_cascade_strategy.exe test/test_oas_worker.exe`
- `./_build/default/test/test_cascade_strategy.exe`
- `env HOME=/private/tmp/masc-test-home MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH=/private/tmp/masc-test-base GRAPHQL_API_KEY= ZAI_API_KEY= MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false MASC_KEEPER_DOCKER_PLAYGROUND=false ./_build/default/test/test_oas_worker.exe`